### PR TITLE
Add Skaffold deployment workflows for Uptime Kuma and Nginx Public St…

### DIFF
--- a/.github/workflows/deploy-public-status-nginx.yaml
+++ b/.github/workflows/deploy-public-status-nginx.yaml
@@ -1,0 +1,28 @@
+name: Deploy Public Status Nginx
+
+on:
+  schedule:
+    - cron: '0 0 * * 0'  # Weekly on Sunday
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/deploy-public-status-nginx.yaml'
+      - 'cluster/services/nginx-public-status/**'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  deploy-public-status-nginx:
+    runs-on: self-hosted
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v3
+      - name: Deploy Public Status Nginx
+        run: |
+          skaffold run -f cluster/services/nginx-public-status/skaffold.yaml
+        env:
+          KUBECONFIG: /home/jomcgi/.kube/talos

--- a/.github/workflows/deploy-uptime-kuma.yaml
+++ b/.github/workflows/deploy-uptime-kuma.yaml
@@ -1,0 +1,28 @@
+name: Deploy Uptime Kuma
+
+on:
+  schedule:
+    - cron: '0 0 * * 0'  # Weekly on Sunday
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/deploy-uptime-kuma.yaml'
+      - 'cluster/services/uptime-kuma/**'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  deploy-uptime-kuma:
+    runs-on: self-hosted
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v3
+      - name: Deploy Uptime Kuma
+        run: |
+          skaffold run -f cluster/services/uptime-kuma/skaffold.yaml
+        env:
+          KUBECONFIG: /home/jomcgi/.kube/talos


### PR DESCRIPTION
…atus

This commit introduces two new GitHub Actions workflows:

1.  `deploy-uptime-kuma.yaml`: Deploys the Uptime Kuma service using its Skaffold configuration. It triggers on a weekly schedule, on pushes to main affecting relevant paths, or manually.

2.  `deploy-public-status-nginx.yaml`: Deploys the Nginx public status page service using its Skaffold configuration. It triggers on a weekly schedule, on pushes to main affecting relevant paths, or manually.

Both workflows follow the established pattern in the repository, utilizing self-hosted runners and Skaffold for deployment. The `KUBECONFIG` environment variable is set as required. Concurrency is configured to prevent multiple simultaneous runs for the same workflow and branch, matching existing workflows.