### PR TITLE
fix: remove duplicate :latest tag from operator image repository

### DIFF
--- a/operators/cloudflare/helm/cloudflare-operator/values.yaml
+++ b/operators/cloudflare/helm/cloudflare-operator/values.yaml
@@ -7,7 +7,7 @@ fullnameOverride: ""
 controllerManager:
   # Container image configuration
   image:
-    repository: jomcgi/cloudflare-operator:latest
+    repository: jomcgi/cloudflare-operator
     tag: latest
     pullPolicy: IfNotPresent
   


### PR DESCRIPTION
The repository field incorrectly included the :latest tag, which was then appended again by the deployment template, resulting in an invalid image reference: jomcgi/cloudflare-operator:latest:latest

Fixed by removing the tag from the repository field, allowing the template to correctly construct: jomcgi/cloudflare-operator:latest

Resolves InvalidImageName error in operator deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)