### PR TITLE
fix: update operator image registry to ghcr.io

### DIFF
--- a/operators/cloudflare/helm/cloudflare-operator/values.yaml
+++ b/operators/cloudflare/helm/cloudflare-operator/values.yaml
@@ -7,7 +7,7 @@ fullnameOverride: ""
 controllerManager:
   # Container image configuration
   image:
-    repository: jomcgi/cloudflare-operator
+    repository: ghcr.io/jomcgi/cloudflare-operator
     tag: latest
     pullPolicy: IfNotPresent
   


### PR DESCRIPTION
The GitHub Actions workflow builds and pushes images to GitHub Container Registry (ghcr.io), but the Helm chart was referencing Docker Hub.

Updated repository from:
  jomcgi/cloudflare-operator
To:
  ghcr.io/jomcgi/cloudflare-operator

This matches the registry configured in .github/workflows/cloudflare-operator.yaml

🤖 Generated with [Claude Code](https://claude.com/claude-code)