### PR TITLE
fix: update golangci-lint-action to v8 for golangci-lint v2 compatibi…

### DIFF
--- a/.github/workflows/cloudflare-operator.yaml
+++ b/.github/workflows/cloudflare-operator.yaml
@@ -38,9 +38,9 @@ jobs:
             ${{ runner.os }}-go-${{ hashFiles('operators/cloudflare/go.sum') }}
       
       - name: Run linter
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v8
         with:
-          version: latest
+          version: v2.1.0
           working-directory: operators/cloudflare
 
   build:


### PR DESCRIPTION
…lity

Updated the GitHub Actions workflow to use golangci-lint-action@v8 with golangci-lint v2.1.0 to match the v2 config format in operators/cloudflare/.golangci.yml.

Previous setup used action v3 which installed golangci-lint v1.64.8, causing version mismatch errors with the v2 configuration format.

This aligns the root workflow with the operator's own lint.yml workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)