### PR TITLE
fix: use ubuntu-latest runner for build job to fix Docker daemon conn…

### DIFF
--- a/.github/workflows/cloudflare-operator.yaml
+++ b/.github/workflows/cloudflare-operator.yaml
@@ -45,7 +45,7 @@ jobs:
 
   build:
     needs: test
-    runs-on: homelab-runners
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
…ection

The build job requires Docker for building container images, but homelab-runners don't have Docker daemon running. Switching the build job back to GitHub-hosted ubuntu-latest runners resolves the "Cannot connect to the Docker daemon" error.

The test job remains on homelab-runners since it only needs Go tooling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)