### PR TITLE
perf: remove ARM64 platform from Cloudflare Operator build to reduce …

### DIFF
--- a/.github/workflows/cloudflare-operator.yaml
+++ b/.github/workflows/cloudflare-operator.yaml
@@ -77,7 +77,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: operators/cloudflare
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
…build time

Building ARM64 images via QEMU emulation on ubuntu-latest runners takes ~42 minutes compared to ~5.5 minutes for native AMD64 builds. Since ARM64 images are not currently needed, removing this platform reduces total build time from 50 minutes to ~6 minutes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)