### PR TITLE
Debug Kyverno Webhook Admission Policy Error

### DIFF
--- a/charts/kyverno/templates/policies.yaml
+++ b/charts/kyverno/templates/policies.yaml
@@ -86,7 +86,7 @@ spec:
       # Only inject if imagePullSecrets is not already set
       preconditions:
         all:
-        - key: "{{`{{ request.object.spec.imagePullSecrets || `}}[]{{` | length(@) }}`}}"
+        - key: "{{`{{ request.object.spec.imagePullSecrets || `}}`[]`{{` | length(@) }}`}}"
           operator: Equals
           value: 0
       mutate:


### PR DESCRIPTION
The JMESPath expression was using `|| []` but the empty array literal wasn't backtick-quoted, causing JMESPath to fail when the field is null. Changed to `|| \`[]\`` so JMESPath recognizes it as an array literal.

This fixes the error:
"JMESPath query failed: Invalid type for: <nil>, expected: []jmespath.JpType"

🤖 Generated with [Claude Code](https://claude.com/claude-code)