### PR TITLE
Troubleshoot Cloudflare Operator Image Pull Error

### DIFF
--- a/charts/kyverno/values.yaml
+++ b/charts/kyverno/values.yaml
@@ -98,7 +98,7 @@ kyverno:
 policies:
   # Enable GHCR secret sync policy
   ghcrSecretSync:
-    enabled: false
+    enabled: true
 
   # Enable GHCR imagePullSecrets injection policy
   ghcrImagePullSecretInjection:


### PR DESCRIPTION
Enables the Kyverno ClusterPolicy that syncs ghcr-pull-secret from the argocd namespace to all application namespaces. This fixes ImagePullBackOff errors for the cloudflare-operator and any other private GHCR images.

The policy works by:
1. Reading ghcr-pull-secret from argocd namespace (synced from 1Password)
2. Cloning it to all application namespaces
3. Automatically injecting it into pods via the existing inject-ghcr-pull-secret policy

Fixes: cloudflare-operator pod ImagePullBackOff (401 Unauthorized)
Resolves: #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)