### PR TITLE
Resolve Cloudflare Operator Image Pull Failure

### DIFF
--- a/charts/kyverno/templates/policies.yaml
+++ b/charts/kyverno/templates/policies.yaml
@@ -41,10 +41,9 @@ spec:
         name: ghcr-pull-secret
         namespace: "{{`{{request.object.metadata.name}}`}}"
         synchronize: true
-        data:
-          type: kubernetes.io/dockerconfigjson
-          data:
-            .dockerconfigjson: "{{`{{ $secret := lookup(\"v1\", \"Secret\", \"argocd\", \"ghcr-pull-secret\") }} {{ $token := $secret.data.github_token | base64_decode }} {{ $auth := printf(\"jomcgi:%s\", $token) | base64_encode }} { \"auths\": { \"ghcr.io\": { \"username\": \"jomcgi\", \"password\": \"{{ $token }}\", \"auth\": \"{{ $auth }}\" } } }`}}"
+        clone:
+          namespace: argocd
+          name: ghcr-pull-secret
 {{- end }}
 {{- if .Values.policies.ghcrImagePullSecretInjection.enabled }}
 ---


### PR DESCRIPTION
… secret sync

Replaces the complex inline JMESPath/template expression with Kyverno's native clone functionality for syncing the ghcr-pull-secret across namespaces.

The previous approach used complex variable assignments and lookups that are not properly supported by Kyverno's template engine, causing the policy to fail and preventing the secret from being synced to application namespaces.

The new clone-based approach:
- Uses Kyverno's native clone.namespace and clone.name fields
- Directly clones the secret from argocd namespace to all namespaces
- Maintains synchronize: true for automatic updates
- Is simpler, more reliable, and follows Kyverno best practices

This fixes the ImagePullBackOff errors for cloudflare-operator and any other pods trying to pull private images from ghcr.io/jomcgi/*.

Fixes: 401 Unauthorized when pulling ghcr.io/jomcgi/cloudflare-operator:latest
Resolves: Unable to retrieve image pull secret (ghcr-pull-secret)

🤖 Generated with [Claude Code](https://claude.com/claude-code)