### PR TITLE
Troubleshoot Kyverno Webhook Permission Denied Error

### DIFF
--- a/charts/kyverno/Chart.yaml
+++ b/charts/kyverno/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kyverno
 description: Kyverno policy engine with ClusterPolicies for GHCR secret management
 type: application
-version: 1.0.1
+version: 1.0.2
 appVersion: "3.5.2"
 
 dependencies:

--- a/charts/kyverno/templates/rbac.yaml
+++ b/charts/kyverno/templates/rbac.yaml
@@ -1,0 +1,40 @@
+{{- if .Values.policies.ghcrSecretSync.enabled }}
+---
+# ClusterRole: Grant Kyverno permission to clone secrets across namespaces
+# Required for the sync-ghcr-pull-secret policy to function
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kyverno-secret-cloner
+  labels:
+    app.kubernetes.io/name: kyverno
+    app.kubernetes.io/component: admission-controller
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+rules:
+  # Read secrets from source namespaces (specifically argocd for ghcr-pull-secret)
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list"]
+  # Create/update secrets in target namespaces
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["create", "update", "patch"]
+---
+# ClusterRoleBinding: Bind the secret-cloner role to Kyverno's service account
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kyverno-secret-cloner
+  labels:
+    app.kubernetes.io/name: kyverno
+    app.kubernetes.io/component: admission-controller
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kyverno-secret-cloner
+subjects:
+  - kind: ServiceAccount
+    name: kyverno-admission-controller
+    namespace: kyverno
+{{- end }}


### PR DESCRIPTION
…cloning

Add ClusterRole and ClusterRoleBinding to grant Kyverno's admission controller the necessary permissions to clone secrets across namespaces. This fixes the validation webhook error preventing the sync-ghcr-pull-secret policy from functioning.

The policy clones the 1Password-managed ghcr-pull-secret from the argocd namespace to all application namespaces, enabling automatic image pulls from GHCR without per-namespace configuration.

Permissions granted:
- get, list: Read secrets from source namespace (argocd)
- create, update, patch: Write secrets to target namespaces

Resolves: admission webhook "validate-policy.kyverno.svc" denied the request due to missing permissions for resource v1/Secret

🤖 Generated with [Claude Code](https://claude.com/claude-code)