### PR TITLE
fix(kyverno): add RBAC permissions for secret cloning across namespaces

### DIFF
--- a/charts/kyverno/Chart.yaml
+++ b/charts/kyverno/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kyverno
 description: Kyverno policy engine with ClusterPolicies for GHCR secret management
 type: application
-version: 1.0.2
+version: 1.0.3
 appVersion: "3.5.2"
 
 dependencies:

--- a/charts/kyverno/templates/rbac.yaml
+++ b/charts/kyverno/templates/rbac.yaml
@@ -8,26 +8,28 @@ metadata:
   name: kyverno-secret-cloner
   labels:
     app.kubernetes.io/name: kyverno
-    app.kubernetes.io/component: admission-controller
+    app.kubernetes.io/component: policy-engine
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 rules:
-  # Read secrets from source namespaces (specifically argocd for ghcr-pull-secret)
+  # Full secret management permissions for cloning across namespaces
+  # - get/list: Read source secret from argocd namespace
+  # - create/update/patch: Write cloned secrets to target namespaces
+  # - delete: Clean up generated secrets when source is deleted
   - apiGroups: [""]
     resources: ["secrets"]
-    verbs: ["get", "list"]
-  # Create/update secrets in target namespaces
-  - apiGroups: [""]
-    resources: ["secrets"]
-    verbs: ["create", "update", "patch"]
+    verbs: ["get", "list", "create", "update", "patch", "delete"]
 ---
-# ClusterRoleBinding: Bind the secret-cloner role to Kyverno's service account
+# ClusterRoleBinding: Bind the secret-cloner role to Kyverno's service accounts
+# Both admission-controller and background-controller need these permissions:
+# - admission-controller: Validates and generates secrets on resource creation
+# - background-controller: Processes existing resources (generateExisting: true)
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: kyverno-secret-cloner
   labels:
     app.kubernetes.io/name: kyverno
-    app.kubernetes.io/component: admission-controller
+    app.kubernetes.io/component: policy-engine
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -36,5 +38,8 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: kyverno-admission-controller
+    namespace: kyverno
+  - kind: ServiceAccount
+    name: kyverno-background-controller
     namespace: kyverno
 {{- end }}


### PR DESCRIPTION
Grant Kyverno admission and background controllers the necessary RBAC permissions to clone secrets across namespaces. This fixes the validation webhook errors preventing the sync-ghcr-pull-secret policy from functioning.

The policy clones the 1Password-managed ghcr-pull-secret from the argocd namespace to all application namespaces, enabling automatic image pulls from GHCR without per-namespace configuration.

Changes:
- Add ClusterRole with full secret management permissions:
  - get, list: Read source secret from argocd namespace
  - create, update, patch: Write cloned secrets to target namespaces
  - delete: Clean up generated secrets when source is deleted

- Add ClusterRoleBinding for both service accounts:
  - kyverno-admission-controller: Handles new namespace creation
  - kyverno-background-controller: Processes existing namespaces (generateExisting: true)

- Bump chart version to 1.0.3

Resolves:
- admission webhook "validate-policy.kyverno.svc" denied the request
- system:serviceaccount:kyverno:kyverno-admission-controller requires permissions
- system:serviceaccount:kyverno:kyverno-background-controller requires permissions

🤖 Generated with [Claude Code](https://claude.com/claude-code)