### PR TITLE
Resolve Image Pull Failure for Cloudflare Operator

### DIFF
--- a/charts/kyverno/templates/policies.yaml
+++ b/charts/kyverno/templates/policies.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.policies.ghcrSecretSync.enabled }}
 ---
 # ClusterPolicy: Generate GHCR pull secret in all namespaces
-# Clones the read-only GHCR token from argocd namespace to all application namespaces
+# Clones the dockerconfigjson secret from argocd namespace to all application namespaces
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
@@ -13,7 +13,7 @@ metadata:
     policies.kyverno.io/subject: Secret
     policies.kyverno.io/description: >-
       This policy generates a docker-registry secret for GHCR in each namespace
-      by reading the GitHub token from the 1Password-synced secret in argocd namespace.
+      by cloning the ghcr-docker-config secret from the argocd namespace.
       This allows all pods to pull private images from ghcr.io without per-namespace configuration.
 spec:
   generateExisting: true
@@ -43,7 +43,7 @@ spec:
         synchronize: true
         clone:
           namespace: argocd
-          name: ghcr-pull-secret
+          name: ghcr-docker-config
 {{- end }}
 {{- if .Values.policies.ghcrImagePullSecretInjection.enabled }}
 ---

--- a/overlays/cluster-critical/argocd-image-updater/onepassword-secrets.yaml
+++ b/overlays/cluster-critical/argocd-image-updater/onepassword-secrets.yaml
@@ -11,6 +11,7 @@ spec:
 ---
 # GHCR Pull Secret (for Kubernetes image pulls)
 # Permissions: read:packages only (least privilege)
+# NOTE: This creates an Opaque secret with github_token field (used by ArgoCD Image Updater)
 apiVersion: onepassword.com/v1
 kind: OnePasswordItem
 metadata:
@@ -20,3 +21,17 @@ metadata:
     argocd.argoproj.io/sync-wave: "0"
 spec:
   itemPath: "vaults/k8s-homelab/items/ghcr-read-permissions"
+---
+# GHCR Docker Config Secret (for imagePullSecrets)
+# Contains .dockerconfigjson field with full Docker registry auth config
+# This secret is cloned to all namespaces by Kyverno policy
+apiVersion: onepassword.com/v1
+kind: OnePasswordItem
+type: kubernetes.io/dockerconfigjson
+metadata:
+  name: ghcr-docker-config
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+spec:
+  itemPath: "vaults/k8s-homelab/items/argocd-image-updater/docker-config-json"


### PR DESCRIPTION
Fixes ImagePullBackOff errors by creating a proper kubernetes.io/dockerconfigjson secret that can be used as an imagePullSecret.

Changes:
- Add new OnePasswordItem (ghcr-docker-config) with type kubernetes.io/dockerconfigjson
- Points to 1Password vault item containing .dockerconfigjson field
- Update Kyverno clone policy to sync ghcr-docker-config instead of ghcr-pull-secret
- Keep original ghcr-pull-secret for ArgoCD Image Updater (needs Opaque with github_token)

The 1Password vault item at k8s-homelab/argocd-image-updater/docker-config-json contains the .dockerconfigjson field with the full Docker registry auth config in the format: {"auths":{"ghcr.io":{"username":"...","password":"...","auth":"..."}}}

Once ArgoCD syncs this change:
1. 1Password operator creates ghcr-docker-config secret in argocd namespace
2. Kyverno clones it as ghcr-pull-secret to all other namespaces
3. Kyverno injects imagePullSecrets into pods automatically
4. Pods can pull private images from ghcr.io/jomcgi/*

Fixes: 401 Unauthorized when pulling ghcr.io/jomcgi/cloudflare-operator:latest
Resolves: Unable to retrieve image pull secret (ghcr-pull-secret)

🤖 Generated with [Claude Code](https://claude.com/claude-code)