### PR TITLE
Fix One Password Secret Reference Path

### DIFF
--- a/overlays/cluster-critical/argocd-image-updater/onepassword-secrets.yaml
+++ b/overlays/cluster-critical/argocd-image-updater/onepassword-secrets.yaml
@@ -34,4 +34,4 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "0"
 spec:
-  itemPath: "vaults/k8s-homelab/items/argocd-image-updater/docker-config-json"
+  itemPath: "vaults/k8s-homelab/items/argocd-image-updater"


### PR DESCRIPTION
Remove field name from itemPath - the 1Password operator expects path format: vaults/{vault}/items/{item}

Field mapping happens automatically based on secret type.

Fixes: "vaults/k8s-homelab/items/argocd-image-updater/docker-config-json" is not an acceptable path

🤖 Generated with [Claude Code](https://claude.com/claude-code)