### PR TITLE
Resolve GitHub Container Registry Authentication Error

### DIFF
--- a/charts/n8n/templates/workflow-sync-cronjob.yaml
+++ b/charts/n8n/templates/workflow-sync-cronjob.yaml
@@ -26,6 +26,10 @@ spec:
         spec:
           restartPolicy: OnFailure
           serviceAccountName: {{ include "n8n.fullname" . }}
+          {{- with .Values.workflowSync.imagePullSecrets }}
+          imagePullSecrets:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           containers:
             - name: workflow-sync
               image: {{ .Values.workflowSync.image.repository }}:{{ .Values.workflowSync.image.tag | default "latest" }}

--- a/charts/n8n/templates/workflow-sync-job.yaml
+++ b/charts/n8n/templates/workflow-sync-job.yaml
@@ -20,6 +20,10 @@ spec:
     spec:
       restartPolicy: OnFailure
       serviceAccountName: {{ include "n8n.fullname" . }}
+      {{- with .Values.workflowSync.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: workflow-sync
           image: {{ .Values.workflowSync.image.repository }}:{{ .Values.workflowSync.image.tag | default "latest" }}

--- a/charts/n8n/values.yaml
+++ b/charts/n8n/values.yaml
@@ -19,6 +19,12 @@ workflowSync:
     tag: "latest"  # Override with specific version in production
     pullPolicy: IfNotPresent
 
+  # Image pull secrets for private container registry
+  imagePullSecrets: []
+  # Example:
+  # imagePullSecrets:
+  #   - name: ghcr-pull-secret
+
   # API key secret reference
   apiKeySecret:
     name: "n8n-api-key"

--- a/overlays/prod/n8n/kustomization.yaml
+++ b/overlays/prod/n8n/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 
 resources:
   - ./application.yaml
+  - ./onepassword-secrets.yaml

--- a/overlays/prod/n8n/onepassword-secrets.yaml
+++ b/overlays/prod/n8n/onepassword-secrets.yaml
@@ -1,0 +1,14 @@
+---
+# GHCR Pull Secret (for Kubernetes image pulls)
+# Allows n8n workflow sync job to pull private images from GitHub Container Registry
+# Type: kubernetes.io/dockerconfigjson (used for imagePullSecrets)
+apiVersion: onepassword.com/v1
+kind: OnePasswordItem
+type: kubernetes.io/dockerconfigjson
+metadata:
+  name: ghcr-pull-secret
+  namespace: n8n
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+spec:
+  itemPath: "vaults/k8s-homelab/items/argocd-image-updater"

--- a/overlays/prod/n8n/values.yaml
+++ b/overlays/prod/n8n/values.yaml
@@ -11,6 +11,10 @@ workflowSync:
     tag: "latest"  # TODO: Pin to specific version after first build
     pullPolicy: IfNotPresent
 
+  # Image pull secrets for private GHCR images
+  imagePullSecrets:
+    - name: ghcr-pull-secret
+
   # API key secret (create via: kubectl create secret generic n8n-api-key --from-literal=api-key=YOUR_KEY -n n8n)
   apiKeySecret:
     name: "n8n-api-key"


### PR DESCRIPTION
Fixes image pull error for ghcr.io/jomcgi/homelab/n8n-workflow-syncer by mirroring the pattern used in cloudflare-operator deployment:

- Add imagePullSecrets support to workflow-sync-job.yaml template
- Add imagePullSecrets support to workflow-sync-cronjob.yaml template
- Add imagePullSecrets configuration to chart values.yaml (default: [])
- Create ghcr-pull-secret OnePasswordItem in n8n namespace
- Configure prod overlay to use ghcr-pull-secret for image authentication

The OnePasswordItem creates a kubernetes.io/dockerconfigjson secret that allows the workflow sync job and cronjob to authenticate with GitHub Container Registry for private image pulls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)