### PR TITLE
Resolve Missing N8N API Key Secret

### DIFF
--- a/overlays/prod/n8n/onepassword-secrets.yaml
+++ b/overlays/prod/n8n/onepassword-secrets.yaml
@@ -11,4 +11,17 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "0"
 spec:
-  itemPath: "vaults/k8s-homelab/items/argocd-image-updater"
+  itemPath: "vaults/k8s-homelab/items/n8n-workflow-sync"
+---
+# N8N API Key Secret
+# Used by workflow sync job to interact with n8n API for GitOps workflow management
+# Type: Opaque (contains api-key field)
+apiVersion: onepassword.com/v1
+kind: OnePasswordItem
+metadata:
+  name: n8n-api-key
+  namespace: n8n
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+spec:
+  itemPath: "vaults/k8s-homelab/items/n8n-workflow-sync"


### PR DESCRIPTION
Add OnePasswordItem CRD for n8n API key secret to fix workflow sync job authentication. Both secrets reference the 1Password item at vaults/k8s-homelab/items/n8n-workflow-sync which contains:
- .dockerconfigjson field (for image pull secrets)
- n8n-api-key field (for n8n API authentication)

The secrets will be automatically synced by the 1Password operator.

Resolves: Error: secret "n8n-api-key" not found

🤖 Generated with [Claude Code](https://claude.com/claude-code)