### PR TITLE
Debug Workflow Sync Failure with Missing Settings

### DIFF
--- a/overlays/prod/n8n/values.yaml
+++ b/overlays/prod/n8n/values.yaml
@@ -32,6 +32,9 @@ workflowSync:
       definition: |
         {
           "name": "Joe Phone Tracker",
+          "settings": {
+            "executionOrder": "v1"
+          },
           "nodes": [
             {
               "parameters": {


### PR DESCRIPTION
The n8n API requires all workflows to have a 'settings' property. The workflow sync was failing with: "request/body must have required property 'settings'"

Added minimal settings object with executionOrder field to fix the validation error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)