### PR TITLE
Debug n8n Workflow Sync API Error

### DIFF
--- a/charts/n8n/syncer/internal/sync/syncer.go
+++ b/charts/n8n/syncer/internal/sync/syncer.go
@@ -329,11 +329,30 @@ func (s *Syncer) syncWorkflow(ctx context.Context, wf *n8n.Workflow, existingMap
 	slog.InfoContext(ctx, "creating new workflow")
 	span.SetAttributes(attribute.String("operation", "create"))
 
+	// n8n API doesn't allow tags to be set during workflow creation (tags field is read-only on POST)
+	// Save tags and remove them before creating
+	tags := wf.Tags
+	wf.Tags = nil
+
 	created, err := s.config.N8NClient.CreateWorkflow(ctx, wf)
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, "failed to create workflow")
 		return fmt.Errorf("create workflow: %w", err)
+	}
+
+	// After creation, update the workflow with tags using PUT endpoint
+	if len(tags) > 0 {
+		created.Tags = tags
+		_, err := s.config.N8NClient.UpdateWorkflow(ctx, created.ID, created)
+		if err != nil {
+			slog.WarnContext(ctx, "failed to add tags to newly created workflow",
+				"workflow_id", created.ID,
+				"error", err)
+			// Don't fail the sync if tags can't be added - the workflow is created successfully
+		} else {
+			slog.InfoContext(ctx, "added tags to newly created workflow", "workflow_id", created.ID)
+		}
 	}
 
 	span.SetAttributes(attribute.String("workflow.id", created.ID))


### PR DESCRIPTION
The n8n API doesn't allow tags to be set during workflow creation (POST /api/v1/workflows) - the tags field is read-only on creation.

This commit changes the workflow sync logic to:
1. Create the workflow WITHOUT tags
2. Immediately update it WITH tags via PUT endpoint

This fixes the error:
"create workflow returned status 400: {\"message\":\"request/body/tags is read-only\"}"

The fix gracefully handles tag update failures by logging a warning instead of failing the entire sync, since the workflow is already created successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)