### PR TITLE
claude/session-011CUa7Q5Ks3CCvtKJurKotL

### DIFF
--- a/services/hikes/update_forecast/update.py
+++ b/services/hikes/update_forecast/update.py
@@ -325,9 +325,11 @@ def main():
         # Upload ONLY the Brotli-compressed version
         # NOTE: Do NOT set ContentEncoding="br" - that would cause R2 to auto-decompress.
         # Frontend manually decompresses, so we want R2 to serve the compressed file as-is.
+        # Use .brotli extension instead of .br to prevent Cloudflare from auto-detecting
+        # and adding content-encoding header (which causes double decompression).
         uploader.s3_client.put_object(
             Bucket=uploader.bucket_name,
-            Key="bundle.json.br",
+            Key="bundle.brotli",
             Body=brotli_data,
             ContentType="application/octet-stream",  # Raw binary data
         )

--- a/websites/hikes.jomcgi.dev/public/app.js
+++ b/websites/hikes.jomcgi.dev/public/app.js
@@ -181,11 +181,10 @@ function parseBundleData(bundle) {
 // Data loading
 async function loadIndexData() {
   try {
-    const brotliPath = `${CONFIG.dataPath}bundle.json.br`;
+    const brotliPath = `${CONFIG.dataPath}bundle.brotli`;
     const response = await fetch(brotliPath, {
       headers: {
-        Accept: "application/json",
-        "Accept-Encoding": "br, gzip, deflate",
+        Accept: "application/octet-stream",
       },
     });
 

--- a/websites/hikes.jomcgi.dev/tests/app-functionality.spec.js
+++ b/websites/hikes.jomcgi.dev/tests/app-functionality.spec.js
@@ -3,7 +3,7 @@ import { test, expect } from "@playwright/test";
 test.describe("App Core Functionality", () => {
   test.beforeEach(async ({ page }) => {
     // Mock the fetch request for bundle data
-    await page.route("**/bundle.json.br", async (route) => {
+    await page.route("**/bundle.brotli", async (route) => {
       const mockBundle = {
         v: 2,
         g: Math.floor(Date.now() / 1000),

--- a/websites/hikes.jomcgi.dev/tests/coordinates.spec.js
+++ b/websites/hikes.jomcgi.dev/tests/coordinates.spec.js
@@ -3,7 +3,7 @@ import { test, expect } from "@playwright/test";
 test.describe("Coordinates Functionality", () => {
   test.beforeEach(async ({ page }) => {
     // Mock the fetch request for bundle data
-    await page.route("**/bundle.json.br", async (route) => {
+    await page.route("**/bundle.brotli", async (route) => {
       const mockBundle = {
         v: 2,
         g: Math.floor(Date.now() / 1000),

--- a/websites/hikes.jomcgi.dev/tests/deployment-health.spec.js
+++ b/websites/hikes.jomcgi.dev/tests/deployment-health.spec.js
@@ -3,7 +3,7 @@ import { test, expect } from "@playwright/test";
 test.describe("Deployment Health Checks", () => {
   test.beforeEach(async ({ page }) => {
     // Mock the fetch request for bundle data
-    await page.route("**/bundle.json.br", async (route) => {
+    await page.route("**/bundle.brotli", async (route) => {
       const mockBundle = {
         v: 2,
         g: Math.floor(Date.now() / 1000),

--- a/websites/hikes.jomcgi.dev/tests/mock-data.spec.js
+++ b/websites/hikes.jomcgi.dev/tests/mock-data.spec.js
@@ -3,7 +3,7 @@ import { test, expect } from "@playwright/test";
 test.describe("Mock Data Tests", () => {
   test.beforeEach(async ({ page }) => {
     // Mock the fetch request for bundle data
-    await page.route("**/bundle.json.br", async (route) => {
+    await page.route("**/bundle.brotli", async (route) => {
       const mockBundle = {
         v: 2,
         g: Math.floor(Date.now() / 1000),


### PR DESCRIPTION
…e.json.br to bundle.brotli

Cloudflare was auto-detecting the .br extension and adding 'content-encoding: br' header, causing the browser to auto-decompress. The client-side WASM then tried to decompress again, resulting in "Brotli decompression failed" errors.

Changes:
- Rename bundle.json.br to bundle.brotli to avoid Cloudflare auto-detection
- Update fetch to request application/octet-stream instead of application/json
- Update all test mocks to use new filename

This preserves the efficient client-side decompression design (293KB transfer vs 1.8MB), while preventing the double-decompression issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)