### PR TITLE
Review and verify all README files

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -36,9 +36,9 @@ External Ingress        Applications             Observability
 ```
 charts/                     # Helm charts
 ├── cloudflare-tunnel/      # Cloudflare tunnel chart
-└── n8n/                    # N8N workflow automation
-    ├── WORKFLOWS.md        # Workflow GitOps documentation
-    └── templates/          # Helm templates
+├── n8n/                    # N8N wrapper chart (wraps upstream n8n chart)
+├── n8n-obsidian-api/       # N8N Obsidian API service chart
+└── freshrss/               # FreshRSS RSS aggregator chart
 
 clusters/                   # Cluster entry points
 └── homelab/                # Production cluster
@@ -46,7 +46,8 @@ clusters/                   # Cluster entry points
 
 operators/                  # Custom Kubernetes operators
 └── cloudflare/             # Cloudflare operator
-    └── helm/               # Operator Helm chart
+    ├── helm/               # Operator Helm chart
+    └── README.md           # Operator documentation
 
 overlays/                   # Environment-based deployments
 ├── cluster-critical/       # Critical infrastructure (argocd, longhorn, signoz)
@@ -73,8 +74,8 @@ overlays/                   # Environment-based deployments
 │       ├── application.yaml
 │       ├── kustomization.yaml
 │       ├── values.yaml
-│       └── workflows/       # Environment-specific workflow ConfigMaps
-│           └── *.yaml       # Workflow definitions
+│       └── manifests/       # Helm-rendered n8n manifests (for review)
+│           └── all.yaml
 └── dev/                    # Development services
     ├── kustomization.yaml
     └── obsidian-automation/
@@ -82,9 +83,17 @@ overlays/                   # Environment-based deployments
         ├── kustomization.yaml
         └── values.yaml
 
+pkg/                        # Shared Go libraries
+└── n8n/                    # N8N Go client (auto-generated from OpenAPI)
+
+services/                   # Backend services
+├── n8n_obsidian_api/       # N8N Obsidian API service
+└── hikes/                  # Hikes data scraping and processing
+    ├── scrape_walkhighlands/
+    └── update_forecast/
+
 websites/                   # Static websites
 └── hikes.jomcgi.dev/       # Hiking route finder (static)
-└── jomcgi.dev/frank        # Frank x Vancouver trip site
 
 ```
 
@@ -171,9 +180,9 @@ We test **actual behavior**, not implementation details:
 
 #### N8N Workflow Automation
 - **Workflow automation platform** for integrations and automations
-- **GitOps-managed workflows** via ConfigMaps and initContainer sync
+- **Workflows managed via UI** with persistence in Longhorn storage
 - **Persistent storage** via Longhorn (15Gi)
-- **API-based deployment** with name-based matching and tagging
+- **API enabled** for programmatic access
 - **Ingress**: `n8n.jomcgi.dev` via Cloudflare Tunnel
 - **Deployed via**: ArgoCD Application with Helm chart
 
@@ -252,79 +261,6 @@ Use the Claude Code spec workflow tool for structured development:
    - `helm template <service> charts/<service>/ --namespace <namespace>` to verify rendering
    - Commit and push to Git
    - ArgoCD automatically discovers and syncs the new application to the cluster
-
-### Managing N8N Workflows
-
-N8N workflows are managed as Kubernetes ConfigMaps and automatically synced to n8n via an initContainer.
-
-#### Adding a New Workflow
-
-1. **Export from n8n UI**: Download workflow as JSON from n8n
-2. **Clean instance data**:
-   ```bash
-   cat workflow.json | jq 'del(.id) |
-     walk(if type == "object" then del(.webhookId) else . end) |
-     del(.meta.instanceId)' > cleaned-workflow.json
-   ```
-3. **Create ConfigMap** in `overlays/prod/n8n/workflows/<name>.yaml`:
-   ```yaml
-   apiVersion: v1
-   kind: ConfigMap
-   metadata:
-     name: n8n-workflow-<name>
-     namespace: n8n
-     labels:
-       app.kubernetes.io/name: n8n
-       app.kubernetes.io/component: workflow
-       workflow-sync: "enabled"
-   data:
-     <name>.json: |
-       # Paste cleaned workflow JSON here (indented 4 spaces)
-   ```
-4. **Add to kustomization**: Update `overlays/prod/n8n/kustomization.yaml`:
-   ```yaml
-   resources:
-     - ./workflows/<name>.yaml
-   ```
-5. **Add to Helm values**: Update `overlays/prod/n8n/values.yaml` projected volume:
-   ```yaml
-   extraVolumes:
-     - name: workflows
-       projected:
-         sources:
-           - configMap:
-               name: n8n-workflow-<name>
-   ```
-6. **Commit and push**: ArgoCD syncs, restart n8n pod to import workflow
-
-#### Workflow Naming Convention
-
-- **In Git**: `"name": "My Workflow"`
-- **In n8n**: `My Workflow [git-managed]`
-- **Tag**: Automatically tagged with `gitops-managed`
-
-This makes it clear which workflows are managed by Git vs created in the UI.
-
-#### Updating a Workflow
-
-1. Edit the workflow JSON in the ConfigMap
-2. Commit and push changes
-3. Restart n8n pod: `kubectl rollout restart deployment/n8n -n n8n`
-
-The initContainer will update the workflow on startup (matched by name).
-
-#### First-Time Setup
-
-Generate n8n API key and create secret:
-```bash
-# 1. Open n8n UI: Settings > n8n API > Create API key
-# 2. Create secret
-kubectl create secret generic n8n-api-key \
-  --from-literal=api-key=YOUR_KEY \
-  --namespace=n8n
-```
-
-See `charts/n8n/WORKFLOWS.md` for complete documentation.
 
 ### Security Review Checklist
 - [ ] Service runs as non-root user

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Homelab - Secure Kubernetes Infrastructure 
+# Homelab - Secure Kubernetes Infrastructure
 
 A security-first Kubernetes homelab running on Talos Linux with GitOps deployment via ArgoCD.
 
@@ -8,66 +8,68 @@ See [CLAUDE.md](.claude/CLAUDE.md) for detailed architecture documentation.
 
 ## Quick Start
 
-This monorepo uses [`mise`](https://mise.jdx.dev/) for tool management and task automation.
+This monorepo uses [Bazel](https://bazel.build/) for build automation and dependency management.
 
 ### Setup
 
 ```bash
-# Install mise (if not already installed)
-curl https://mise.run | sh
+# Install bazelisk (Bazel launcher)
+curl -LO "https://github.com/bazelbuild/bazelisk/releases/latest/download/bazelisk-linux-amd64"
+chmod +x bazelisk-linux-amd64
+sudo mv bazelisk-linux-amd64 /usr/local/bin/bazel
 
-# Install tools and dependencies
-mise install
-mise run install
+# Build all targets
+bazel build //...
 
-# Activate mise in your shell (optional, for auto-activation)
-echo 'eval "$(mise activate zsh)"' >> ~/.zshrc  # or bash/fish
+# Run tests
+bazel test //...
 ```
 
 ### Development Tasks
 
 ```bash
-mise run lint       # Lint all Python code (with auto-fix)
-mise run format     # Format all Python code
-mise run typecheck  # Type check all Python code
-mise run check      # Run lint + typecheck
-mise run test       # Run all tests
+# Format code
+bazel run //:format
+
+# Lint code
+aspect lint //...
+
+# Run specific tests
+bazel test //services/n8n_obsidian_api:test
+bazel test //websites/hikes.jomcgi.dev:test
 ```
 
-### Tool Versions
-
-Tools are automatically installed at the versions specified in `mise.toml`:
-- **Python 3.11** - For services
-- **Node 20** - For websites
-- **uv** - Fast Python package management
-
-Run `mise list` to see installed tools.
+See [README.bazel.md](README.bazel.md) for detailed Bazel workflows.
 
 ## Monorepo Structure
 
 ```
 ├── services/          # Backend services (Python/Go)
-│   └── n8n-obsidian-api/
+│   ├── n8n_obsidian_api/
+│   └── hikes/
 ├── operators/         # Custom Kubernetes operators
 │   └── cloudflare/
 ├── charts/            # Helm charts
 │   ├── n8n/
-│   └── cloudflare-tunnel/
+│   ├── cloudflare-tunnel/
+│   └── n8n-obsidian-api/
 ├── clusters/          # Cluster entry points for ArgoCD
 │   └── homelab/
 ├── overlays/          # Environment-specific configs
 │   ├── cluster-critical/
 │   ├── prod/
 │   └── dev/
+├── pkg/               # Shared Go libraries
+│   └── n8n/
 └── websites/          # Static websites
     └── hikes.jomcgi.dev/
 ```
 
 ## Configuration Files
 
-- **`mise.toml`** - Tool versions and monorepo tasks
+- **`MODULE.bazel`** - Bazel module dependencies
 - **`pyproject.toml`** - Shared Python configuration (ruff, pyright, pytest)
-- **`.github/workflows/`** - CI/CD pipelines using mise
+- **`.github/workflows/`** - CI/CD pipelines using Bazel
 
 ## CI/CD
 

--- a/websites/hikes.jomcgi.dev/README.md
+++ b/websites/hikes.jomcgi.dev/README.md
@@ -14,12 +14,12 @@ A purely static website that helps hikers find routes with good weather conditio
 ## How It Works
 
 1. **Initial Setup** (One-time data collection):
-   - `scrape_walkhighlands/scrape.py` scrapes walk data from WalkHighlands.co.uk
+   - `../../services/hikes/scrape_walkhighlands/scrape.py` scrapes walk data from WalkHighlands.co.uk
    - Creates SQLite database (`walks.db`) with routes, distances, and coordinates
    - Includes robust error handling and retry logic for reliability
 
 2. **Regular Updates** (Weather data refresh):
-   - `update_forecast/generate_bundle_direct.py` runs periodically
+   - `../../services/hikes/update_forecast/generate_bundle_direct.py` runs periodically
    - Fetches 7-day weather forecasts from met.no API for each walk location
    - Filters out extreme weather (>2mm rain, >80km/h wind)
    - Creates optimized Brotli-compressed bundle and uploads to R2
@@ -33,9 +33,13 @@ A purely static website that helps hikers find routes with good weather conditio
 ## Project Structure
 
 ```
-scrape_walkhighlands/           # One-time data collection for walks.db
-update_forecast/                # Regular weather data updates
-public/                         # Static website files
+../../services/hikes/
+├── scrape_walkhighlands/       # One-time data collection for walks.db
+└── update_forecast/            # Regular weather data updates
+
+./
+├── public/                     # Static website files
+└── tests/                      # Playwright tests
 ```
 
 


### PR DESCRIPTION
Update three README files that contained outdated or incorrect references:

1. README.md (root):
   - Remove mise references (project uses Bazel, not mise)
   - Update to reference Bazel build system and workflows
   - Fix service directory name: n8n-obsidian-api → n8n_obsidian_api
   - Remove non-existent websites/jomcgi.dev/frank reference
   - Update configuration files section (MODULE.bazel instead of mise.toml)
   - Add pkg/ directory to monorepo structure

2. websites/hikes.jomcgi.dev/README.md:
   - Fix directory references for scrape_walkhighlands/ and update_forecast/
   - Actual location: services/hikes/ (not in website directory)
   - Update project structure documentation

3. .claude/CLAUDE.md:
   - Fix n8n chart structure (wrapper chart, not custom templates)
   - Remove entire "Managing N8N Workflows" section (ConfigMap-based workflow sync was removed - workflows are now managed via n8n UI with Longhorn persistence)
   - Update n8n description: workflows managed via UI, not GitOps ConfigMaps
   - Fix manifests/ directory description (Helm-rendered output, not workflow definitions)
   - Remove non-existent websites/jomcgi.dev/frank reference
   - Add freshrss, n8n-obsidian-api charts to directory structure
   - Add pkg/ and services/ directories with proper subdirectories

All changes verified against actual file structure in the repository.