### PR TITLE
Review GitHub Actions workflow

### DIFF
--- a/charts/linkerd/charts/linkerd-control-plane/BUILD
+++ b/charts/linkerd/charts/linkerd-control-plane/BUILD
@@ -2,5 +2,5 @@ load("//tools/argocd:defs.bzl", "chart_files")
 
 chart_files(
     name = "all_files",
-    visibility = ["//overlays/...:__subpackages__"],
+    visibility = ["//overlays:__subpackages__"],
 )

--- a/charts/linkerd/charts/linkerd-control-plane/charts/partials/BUILD
+++ b/charts/linkerd/charts/linkerd-control-plane/charts/partials/BUILD
@@ -2,5 +2,5 @@ load("//tools/argocd:defs.bzl", "chart_files")
 
 chart_files(
     name = "all_files",
-    visibility = ["//overlays/...:__subpackages__"],
+    visibility = ["//overlays:__subpackages__"],
 )

--- a/tools/argocd/generate.go
+++ b/tools/argocd/generate.go
@@ -113,7 +113,7 @@ func generateRules(args language.GenerateArgs) language.GenerateResult {
 			chartFilesRule.SetAttr("visibility", overlays)
 		} else {
 			// Fallback to overlays if no specific overlays found (shouldn't happen normally)
-			chartFilesRule.SetAttr("visibility", []string{"//overlays/..."})
+			chartFilesRule.SetAttr("visibility", []string{"//overlays:__subpackages__"})
 		}
 
 		result.Gen = append(result.Gen, chartFilesRule)


### PR DESCRIPTION
The visibility pattern `//overlays/...` is invalid Bazel syntax. Changed to `//overlays/...:__subpackages__` which correctly allows all subpackages under //overlays to access these targets.

This fixes the build error:
  invalid label '//overlays/...': package name cannot contain '...'

Fixes the Bazel CI failure from commit 6bf60db.