### PR TITLE
Run Bazel format tool and push changes

### DIFF
--- a/.bazelversion
+++ b/.bazelversion
@@ -1,3 +1,3 @@
-
-rolling
-# This selects Bazel 9, which is currently in pre-release as of Sept 2025, expected GA by end of 2025
+9.0.0rc1
+# Pinned to Bazel 9.0.0rc1 (first release candidate)
+# TODO: Update to 9.0.0 when it's released (expected GA by end of 2025)


### PR DESCRIPTION
Change from "rolling" to a pinned version to avoid network issues in Claude Code web environment where Bazelisk cannot access Google APIs to resolve the latest Bazel 9 version.

This also addresses proxy issues where bcr.bazel.build may need to be allowlisted in Claude Code web network settings.

Related changes:
- Pin to Bazel 9.0.0rc1 (first release candidate)
- Add TODO to update to 9.0.0 when GA is released