### PR TITLE
feat(trips): add demo data notification badge

### DIFF
--- a/websites/trips.jomcgi.dev/src/App.jsx
+++ b/websites/trips.jomcgi.dev/src/App.jsx
@@ -613,6 +613,14 @@ export default function App() {
         }
       `}</style>
 
+      {/* Demo Data Banner */}
+      <div className="absolute top-14 left-1/2 -translate-x-1/2 z-50">
+        <div className="bg-amber-500/90 text-zinc-900 px-4 py-1.5 rounded-full text-sm font-medium shadow-lg flex items-center gap-2">
+          <span className="w-2 h-2 bg-zinc-900 rounded-full animate-pulse" />
+          Demo Data
+        </div>
+      </div>
+
       {/* Status Bar */}
       <div className="flex-none border-b border-zinc-800 bg-zinc-900/80 px-4 py-2.5">
         <div className="flex items-center justify-between">


### PR DESCRIPTION
Add floating amber pill badge to indicate demo data is being shown. Easy to remove once real data is available.