### PR TITLE
Investigate jomcgi.dev unreachability and CDN caching

### DIFF
--- a/charts/api-gateway/templates/configmap.yaml
+++ b/charts/api-gateway/templates/configmap.yaml
@@ -55,21 +55,25 @@ data:
             }
 
             # Cluster info endpoint - serve static JSON
+            # CDN caching: fresh for 30s, serve stale up to 5min while revalidating
+            # This ensures brief origin outages don't show UNREACHABLE to users
             location = /cluster-info {
                 alias /data/status.json;
                 default_type application/json;
-                add_header Cache-Control "no-cache, no-store, must-revalidate";
+                add_header Cache-Control "public, s-maxage={{ .Values.clusterInfo.cache.maxAge }}, stale-while-revalidate={{ .Values.clusterInfo.cache.staleWhileRevalidate }}" always;
                 add_header Access-Control-Allow-Origin $cors_origin always;
                 add_header Access-Control-Allow-Methods "GET, OPTIONS" always;
+                add_header Access-Control-Max-Age "86400" always;
             }
 
             # Legacy endpoint for backwards compatibility
             location = /status.json {
                 alias /data/status.json;
                 default_type application/json;
-                add_header Cache-Control "no-cache, no-store, must-revalidate";
+                add_header Cache-Control "public, s-maxage={{ .Values.clusterInfo.cache.maxAge }}, stale-while-revalidate={{ .Values.clusterInfo.cache.staleWhileRevalidate }}" always;
                 add_header Access-Control-Allow-Origin $cors_origin always;
                 add_header Access-Control-Allow-Methods "GET, OPTIONS" always;
+                add_header Access-Control-Max-Age "86400" always;
             }
 
             # Trips API - proxy to trips-nginx (keep /trips/ prefix)

--- a/charts/api-gateway/values.yaml
+++ b/charts/api-gateway/values.yaml
@@ -20,7 +20,16 @@ clusterInfo:
     tag: "latest"
     pullPolicy: IfNotPresent
   # How often to update status.json (seconds)
-  interval: 5
+  interval: 30
+  # CDN cache settings for Cloudflare
+  # These enable "stale-while-revalidate" so brief origin outages don't
+  # immediately show UNREACHABLE to users
+  cache:
+    # Fresh cache duration (seconds) - CDN serves without checking origin
+    maxAge: 30
+    # Stale-while-revalidate duration (seconds) - CDN serves stale content
+    # while fetching fresh in background. Total survivable downtime = maxAge + staleWhileRevalidate
+    staleWhileRevalidate: 300
   resources:
     requests:
       cpu: 50m

--- a/websites/jomcgi.dev/src/pages/index.astro
+++ b/websites/jomcgi.dev/src/pages/index.astro
@@ -652,6 +652,26 @@
             });
         }
 
+        // Fetch with exponential backoff retry
+        // Retries help survive brief network hiccups without immediately showing UNREACHABLE
+        async function fetchWithRetry(url, maxRetries = 3) {
+            let lastError;
+            for (let attempt = 0; attempt < maxRetries; attempt++) {
+                try {
+                    const res = await fetch(url);
+                    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+                    return await res.json();
+                } catch (e) {
+                    lastError = e;
+                    if (attempt < maxRetries - 1) {
+                        // Exponential backoff: 1s, 2s, 4s
+                        await new Promise(r => setTimeout(r, 1000 * Math.pow(2, attempt)));
+                    }
+                }
+            }
+            throw lastError;
+        }
+
         async function fetchStats() {
             const els = {
                 dot: document.getElementById('sys-dot'),
@@ -667,22 +687,23 @@
             };
 
             try {
-                const res = await fetch('https://api.jomcgi.dev/cluster-info?t=' + Date.now());
-                if (!res.ok) throw new Error('Fetch failed');
-
-                const data = await res.json();
+                // Fetch with retry logic - CDN caching means we don't need cache busting
+                // Retry up to 3 times with exponential backoff before showing UNREACHABLE
+                const data = await fetchWithRetry('https://api.jomcgi.dev/cluster-info', 3);
                 const now = new Date();
                 const lastUpdate = new Date(data.updated_at);
                 const diffMs = now - lastUpdate;
 
-                // Deadman Switch: If data > 1 hour old, show OFFLINE
-                if (diffMs > 3600000) {
+                // Deadman Switch: If data > 5 minutes old, show OFFLINE
+                // (With CDN caching, data can be legitimately up to ~5.5min old)
+                if (diffMs > 300000) {
                     setOfflineState(els, 'OFFLINE');
                     return;
                 }
 
-                // Stale Data Check: If data > 60s old, warn but show data
-                if (diffMs > 60000) {
+                // Stale Data Check: If data > 2 minutes old, warn but show data
+                // (Accounts for collector interval + CDN cache age)
+                if (diffMs > 120000) {
                     els.dot.className = 'status-dot st-warn';
                     els.text.innerText = 'STALE';
                 } else {
@@ -783,7 +804,9 @@
         }
 
         fetchStats();
-        setInterval(fetchStats, 5000);
+        // Poll every 30s - matches CDN cache duration
+        // No need to poll faster since CDN serves cached response anyway
+        setInterval(fetchStats, 30000);
     </script>
 </body>
 </html>


### PR DESCRIPTION
Problem: The cluster status dashboard showed UNREACHABLE during any brief network hiccup or pod restart because every request went directly to the origin with no caching.

Solution: Enable Cloudflare CDN caching with stale-while-revalidate:
- Backend: Cache-Control with s-maxage=30, stale-while-revalidate=300
- Frontend: Remove cache-busting query param, poll every 30s instead of 5s
- Frontend: Add retry logic with exponential backoff before UNREACHABLE
- Frontend: Adjust staleness thresholds (2min STALE, 5min OFFLINE)

This allows the CDN to serve cached responses during brief outages, giving the cluster time to recover without impacting user experience.