### PR TITLE
Fix website title display issue

### DIFF
--- a/websites/jomcgi.dev/src/pages/index.astro
+++ b/websites/jomcgi.dev/src/pages/index.astro
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <title>jomci</title>
+    <title>jomcgi</title>
     <style>
         * {
             margin: 0;


### PR DESCRIPTION
The page title was showing "jomci" instead of "jomcgi".