### PR TITLE
feat: add sync time hover tooltip for GitOps status on jomcgi.dev

### DIFF
--- a/charts/api-gateway/templates/collector-configmap.yaml
+++ b/charts/api-gateway/templates/collector-configmap.yaml
@@ -81,6 +81,7 @@ data:
     # Get ArgoCD app-of-apps status (canada)
     ARGO_STATUS=$(kubectl get application -n argocd canada -o jsonpath='{.status.sync.status}' 2>/dev/null || echo "Unknown")
     ARGO_REVISION=$(kubectl get application -n argocd canada -o jsonpath='{.status.sync.revision}' 2>/dev/null | cut -c1-7 || echo "")
+    ARGO_SYNCED_AT=$(kubectl get application -n argocd canada -o jsonpath='{.status.operationState.finishedAt}' 2>/dev/null || echo "")
 
     # Generate timestamp
     TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
@@ -94,8 +95,15 @@ data:
       GPU_FIELDS=$GPU_FIELDS',"vram":{"used":'$VRAM_USED',"total":'$VRAM_TOTAL'}'
     fi
 
-    printf '{"updated_at":"%s","nodes":{"cp":{"total":%s,"ready":%s},"gpu":{"total":%s,"ready":%s}},"cpu":%s,"mem":{"used":%s,"total":%s},"pods":%s,"gitops":{"status":"%s","revision":"%s"}%s}\n' \
-      "$TIMESTAMP" "$CP_TOTAL" "$CP_READY" "$GPU_TOTAL" "$GPU_READY" "$CPU_AVG" "$MEM_USED_GB" "$MEM_TOTAL_GB" "$POD_JSON" "$ARGO_STATUS" "$ARGO_REVISION" "$GPU_FIELDS" > "$TEMP_FILE"
+    # Build gitops JSON with optional syncedAt
+    GITOPS_JSON='{"status":"'"$ARGO_STATUS"'","revision":"'"$ARGO_REVISION"'"'
+    if [ -n "$ARGO_SYNCED_AT" ]; then
+      GITOPS_JSON=$GITOPS_JSON',"syncedAt":"'"$ARGO_SYNCED_AT"'"'
+    fi
+    GITOPS_JSON=$GITOPS_JSON'}'
+
+    printf '{"updated_at":"%s","nodes":{"cp":{"total":%s,"ready":%s},"gpu":{"total":%s,"ready":%s}},"cpu":%s,"mem":{"used":%s,"total":%s},"pods":%s,"gitops":%s%s}\n' \
+      "$TIMESTAMP" "$CP_TOTAL" "$CP_READY" "$GPU_TOTAL" "$GPU_READY" "$CPU_AVG" "$MEM_USED_GB" "$MEM_TOTAL_GB" "$POD_JSON" "$GITOPS_JSON" "$GPU_FIELDS" > "$TEMP_FILE"
 
     # Atomic move
     mv "$TEMP_FILE" "$OUTPUT_FILE"

--- a/websites/jomcgi.dev/src/pages/index.astro
+++ b/websites/jomcgi.dev/src/pages/index.astro
@@ -353,6 +353,21 @@
             vertical-align: middle;
         }
 
+        /* GitOps hover tooltip - shows sync time */
+        .gitops-status {
+            cursor: default;
+            position: relative;
+        }
+
+        .gitops-status.has-sync-time {
+            cursor: pointer;
+        }
+
+        .gitops-status.has-sync-time:hover {
+            background: var(--fg);
+            color: var(--bg);
+        }
+
         /* === STATUS + POD MATRIX CELL === */
         /* Status on left, Pod Matrix (Scantron sheet) on right */
         .stat-cell.status-pod-cell {
@@ -524,7 +539,7 @@
                     </div>
                     <div class="stat-cell">
                         <div class="stat-label">GitOps</div>
-                        <div class="stat-value" id="sys-gitops"><span class="st-dim">...</span></div>
+                        <div class="stat-value"><span class="gitops-status" id="sys-gitops"><span class="st-dim">...</span></span></div>
                     </div>
                     <div class="stat-cell">
                         <div class="stat-label">Ver</div>
@@ -652,6 +667,28 @@
             });
         }
 
+        // Format a timestamp as relative time (e.g., "2m ago", "1h 30m ago")
+        function formatTimeAgo(date) {
+            const now = new Date();
+            const diffMs = now - date;
+            const diffSec = Math.floor(diffMs / 1000);
+            const diffMin = Math.floor(diffSec / 60);
+            const diffHr = Math.floor(diffMin / 60);
+            const diffDays = Math.floor(diffHr / 24);
+
+            if (diffDays > 0) {
+                return diffDays === 1 ? '1d ago' : `${diffDays}d ago`;
+            }
+            if (diffHr > 0) {
+                const mins = diffMin % 60;
+                return mins > 0 ? `${diffHr}h ${mins}m ago` : `${diffHr}h ago`;
+            }
+            if (diffMin > 0) {
+                return `${diffMin}m ago`;
+            }
+            return 'just now';
+        }
+
         // Fetch with exponential backoff retry
         // Retries help survive brief network hiccups without immediately showing UNREACHABLE
         async function fetchWithRetry(url, maxRetries = 3) {
@@ -771,14 +808,38 @@
                 // Render Pod Matrix
                 renderPodMatrix(els, data.pods);
 
-                // Render GitOps status
+                // Render GitOps status with hover tooltip
                 if (data.gitops) {
                     const status = data.gitops.status || 'Unknown';
+                    const syncedAt = data.gitops.syncedAt;
+
                     els.gitops.innerText = `[${status}]`;
-                    els.gitops.className = '';
-                    if (status === 'Synced') els.gitops.className = 'st-ok';
-                    else if (status === 'OutOfSync') els.gitops.className = 'st-warn';
-                    else if (status === 'Unknown') els.gitops.className = 'st-err';
+                    els.gitops.className = 'gitops-status';
+                    if (status === 'Synced') els.gitops.classList.add('st-ok');
+                    else if (status === 'OutOfSync') els.gitops.classList.add('st-warn');
+                    else if (status === 'Unknown') els.gitops.classList.add('st-err');
+
+                    // Add hover behavior if we have sync time
+                    if (syncedAt) {
+                        els.gitops.classList.add('has-sync-time');
+                        els.gitops.dataset.status = status;
+                        els.gitops.dataset.syncedAt = syncedAt;
+
+                        // Remove old listeners by cloning
+                        const newGitops = els.gitops.cloneNode(true);
+                        els.gitops.parentNode.replaceChild(newGitops, els.gitops);
+                        els.gitops = newGitops;
+
+                        els.gitops.addEventListener('mouseenter', () => {
+                            const syncTime = new Date(els.gitops.dataset.syncedAt);
+                            const ago = formatTimeAgo(syncTime);
+                            els.gitops.innerText = `[${ago}]`;
+                        });
+
+                        els.gitops.addEventListener('mouseleave', () => {
+                            els.gitops.innerText = `[${els.gitops.dataset.status}]`;
+                        });
+                    }
 
                     // Render version (git revision)
                     const rev = data.gitops.revision || '';


### PR DESCRIPTION
- Collector now fetches ArgoCD operationState.finishedAt timestamp
- GitOps [Synced] status inverts on hover and shows relative time (e.g., "2m ago", "1h 30m ago")
- Provides quick visibility into when the cluster last synced