### PR TITLE
Fix pod view alignment for failed pods

### DIFF
--- a/websites/jomcgi.dev/src/pages/index.astro
+++ b/websites/jomcgi.dev/src/pages/index.astro
@@ -412,7 +412,7 @@
 
         :global(.pod-dot.pod-pending) {
             background: transparent;
-            border: 1px solid var(--fg);
+            box-shadow: inset 0 0 0 1px var(--fg);
             animation: pod-pulse 1.5s ease-in-out infinite;
         }
 


### PR DESCRIPTION
Border on small 6px elements causes subpixel rendering issues that break grid alignment. box-shadow: inset creates the same hollow effect without affecting layout dimensions.