### PR TITLE
fix(claude): use claude-secret for imagePullSecrets

### DIFF
--- a/charts/claude/values.yaml
+++ b/charts/claude/values.yaml
@@ -8,7 +8,7 @@ image:
   tag: "main"
 
 imagePullSecrets:
-  - name: ghcr-pull-secret
+  - name: claude-secret
 
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
## Summary

Fix image pull by referencing `claude-secret` instead of non-existent `ghcr-pull-secret`.

The `.dockerconfigjson` is stored in the main 1Password item alongside other secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)