### PR TITLE
fix(claude): add ghcr-pull-secret OnePasswordItem

### DIFF
--- a/charts/claude/templates/secret.yaml
+++ b/charts/claude/templates/secret.yaml
@@ -1,4 +1,5 @@
 {{- if eq .Values.secret.type "onepassword" }}
+---
 apiVersion: onepassword.com/v1
 kind: OnePasswordItem
 metadata:
@@ -7,4 +8,13 @@ metadata:
     {{- include "claude-api.labels" . | nindent 4 }}
 spec:
   itemPath: {{ .Values.secret.onepassword.itemPath | quote }}
+---
+apiVersion: onepassword.com/v1
+kind: OnePasswordItem
+metadata:
+  name: ghcr-pull-secret
+  labels:
+    {{- include "claude-api.labels" . | nindent 4 }}
+spec:
+  itemPath: "vaults/k8s-homelab/items/ghcr-read-permissions"
 {{- end }}


### PR DESCRIPTION
## Summary
- Adds a separate OnePasswordItem for `ghcr-pull-secret` using the shared `ghcr-read-permissions` 1Password item
- This creates a secret with the correct `kubernetes.io/dockerconfigjson` type for image pulling

## Test plan
- [ ] Verify ghcr-pull-secret is created with correct type
- [ ] Verify claude pod can pull the image from GHCR

🤖 Generated with [Claude Code](https://claude.com/claude-code)