### PR TITLE
fix(claude): add ghcr-pull-secret type and PR merge check skill

### DIFF
--- a/.claude/skills/homelab-repo/SKILL.md
+++ b/.claude/skills/homelab-repo/SKILL.md
@@ -66,6 +66,26 @@ git push -u origin feat/my-feature
    ```
 6. Merge PR - the sync loop pulls changes to `~/repos/homelab` automatically
 
+## Before Pushing Changes
+
+**Always check if your PR has been merged before pushing additional commits:**
+
+```bash
+# Check PR status before pushing
+gh pr view <branch-name> --json state -q .state
+```
+
+- If state is `MERGED`: Your branch was already merged. **Create a new branch and PR** for additional changes.
+- If state is `OPEN`: Safe to push additional commits to the existing PR.
+
+**Why?** Pushing to a merged branch creates orphaned commits that won't reach main. You'll need to rebase onto main and create a new PR anyway.
+
+```bash
+# If PR was merged, start fresh:
+git -C ~/repos/homelab fetch origin
+git -C ~/repos/homelab worktree add -b fix/new-issue /tmp/claude-worktrees/new-issue origin/main
+```
+
 ## Listing and Cleaning Worktrees
 
 ```bash

--- a/charts/claude/templates/secret.yaml
+++ b/charts/claude/templates/secret.yaml
@@ -11,6 +11,7 @@ spec:
 ---
 apiVersion: onepassword.com/v1
 kind: OnePasswordItem
+type: kubernetes.io/dockerconfigjson
 metadata:
   name: ghcr-pull-secret
   labels:


### PR DESCRIPTION
## Summary
- Add `type: kubernetes.io/dockerconfigjson` to ghcr-pull-secret OnePasswordItem so the 1Password operator creates a secret with the correct type for imagePullSecrets
- Add skill guidance to check PR merge status before pushing additional commits

## Test plan
- [ ] Verify ghcr-pull-secret is recreated with type `kubernetes.io/dockerconfigjson`
- [ ] Verify claude pod can pull the image from GHCR

🤖 Generated with [Claude Code](https://claude.com/claude-code)