### PR TITLE
fix(claude): reference ghcr-pull-secret for imagePullSecrets

### DIFF
--- a/charts/claude/values.yaml
+++ b/charts/claude/values.yaml
@@ -8,7 +8,7 @@ image:
   tag: "main"
 
 imagePullSecrets:
-  - name: claude-secret
+  - name: ghcr-pull-secret
 
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
## Summary
- Update imagePullSecrets to reference `ghcr-pull-secret` instead of `claude-secret`
- `claude-secret` is type `Opaque`, but imagePullSecrets requires `kubernetes.io/dockerconfigjson`

## Test plan
- [ ] Verify deployment uses ghcr-pull-secret
- [ ] Verify claude pod can pull the image from GHCR

🤖 Generated with [Claude Code](https://claude.com/claude-code)