### PR TITLE
fix(claude): correct start.sh path in image BUILD remap

### DIFF
--- a/charts/claude/image/BUILD
+++ b/charts/claude/image/BUILD
@@ -14,7 +14,7 @@ pkg_tar(
     remap_paths = {
         "src/dist": "/app/dist",
         "src/package.json": "/app/package.json",
-        "start.sh": "/app/start.sh",
+        "image/start.sh": "/app/start.sh",
     },
     strip_prefix = "charts/claude",
 )


### PR DESCRIPTION
## Summary
- Fixed incorrect `remap_paths` entry in `charts/claude/image/BUILD`
- Changed `"start.sh"` to `"image/start.sh"` to account for the file's location after `strip_prefix = "charts/claude"` is applied

## Problem
The container was failing to start with:
```
OCI runtime create failed: unable to start container process: exec: "/app/start.sh": stat /app/start.sh: no such file or directory
```

## Root Cause
The `start.sh` file lives at `charts/claude/image/start.sh`. After `strip_prefix = "charts/claude"` is applied by `pkg_tar`, the path becomes `image/start.sh`. The remap entry was looking for `start.sh` which didn't match, so the file wasn't being placed at `/app/start.sh` in the container.

## Test plan
- [ ] Merge and wait for image rebuild
- [ ] Verify pod starts successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)