### PR TITLE
fix(claude): use Always imagePullPolicy for mutable main tag

### DIFF
--- a/charts/claude/values.yaml
+++ b/charts/claude/values.yaml
@@ -4,7 +4,7 @@
 ## Container image
 image:
   repository: ghcr.io/jomcgi/homelab/charts/claude
-  pullPolicy: IfNotPresent
+  pullPolicy: Always  # Always pull since we use mutable 'main' tag
   tag: "main"
 
 imagePullSecrets:


### PR DESCRIPTION
## Summary
- Change `imagePullPolicy` from `IfNotPresent` to `Always`

## Problem
The deployment uses the mutable `main` tag, but `imagePullPolicy: IfNotPresent` means nodes cache the old image and don't pull updates.

## Solution
Use `imagePullPolicy: Always` so each pod creation pulls the latest `main` image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)