### PR TITLE
fix(claude): preserve frontend assets directory structure

### DIFF
--- a/charts/claude/image/BUILD
+++ b/charts/claude/image/BUILD
@@ -29,6 +29,7 @@ pkg_tar(
     mode = "0644",
     owner = "1000.1000",
     package_dir = "app/public",
+    strip_prefix = "charts/claude/frontend/dist",
 )
 
 apko_image(


### PR DESCRIPTION
## Summary
- Add `strip_prefix` to `frontend_tar` to preserve the `assets/` subdirectory structure
- Without this, `pkg_tar` flattens all files into `/app/public/` directly
- The `index.html` references `/assets/*.js` and `/assets/*.css` which 404'd

## Test plan
- [ ] CI passes
- [ ] Frontend JS/CSS loads correctly at claude.jomcgi.dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)