### PR TITLE
fix(claude): check for binary at exact path instead of using command -v

### DIFF
--- a/charts/claude/image/start.sh
+++ b/charts/claude/image/start.sh
@@ -6,12 +6,13 @@ export NPM_CONFIG_PREFIX="$HOME/.npm-global"
 export PATH="$NPM_CONFIG_PREFIX/bin:$PATH"
 mkdir -p "$NPM_CONFIG_PREFIX"
 
-# Install Claude Code if not already present
-if ! command -v claude &>/dev/null; then
+# Install Claude Code if not already present at expected location
+CLAUDE_BIN="$NPM_CONFIG_PREFIX/bin/claude"
+if [ ! -f "$CLAUDE_BIN" ]; then
 	echo "Installing Claude Code..."
 	npm install -g @anthropic-ai/claude-code
 else
-	echo "Claude Code already installed"
+	echo "Claude Code already installed at $CLAUDE_BIN"
 fi
 
 # Git configuration


### PR DESCRIPTION
The PVC mount at /home/user shadows the container image's directory
structure. The previous check used 'command -v claude' which searches
the entire PATH and may find stale installations. This caused the
install to be skipped, leaving no binary at the expected location.

Now we explicitly check if the binary exists at the exact path we'll
use: /bin/claude

Fixes ENOENT error when spawning claude binary.