### PR TITLE
feat(claude): add mobile-friendly web-based authentication

### DIFF
--- a/charts/claude/frontend/src/App.tsx
+++ b/charts/claude/frontend/src/App.tsx
@@ -17,9 +17,7 @@ interface Session {
 
 interface AuthStatus {
   authenticated: boolean;
-  cliInstalled: boolean;
-  authInProgress: boolean;
-  authUrl?: string;
+  terminalActive: boolean;
 }
 
 // Same-origin API - no CORS needed
@@ -38,8 +36,7 @@ function App() {
   // Auth state
   const [showAuthModal, setShowAuthModal] = useState(false);
   const [authStatus, setAuthStatus] = useState<AuthStatus | null>(null);
-  const [authCode, setAuthCode] = useState("");
-  const [authMessage, setAuthMessage] = useState("");
+  const [terminalUrl, setTerminalUrl] = useState<string | null>(null);
 
   const wsRef = useRef<WebSocket | null>(null);
   const messagesEndRef = useRef<HTMLDivElement>(null);
@@ -76,73 +73,32 @@ function App() {
     }
   };
 
-  const startAuth = async () => {
+  const startAuthTerminal = async () => {
     try {
-      setAuthMessage("Starting authentication flow...");
       const res = await fetch(`${API_BASE}/auth/start`, { method: "POST" });
       const data = await res.json();
-      setAuthMessage(data.message);
-
-      // Poll for auth URL if not immediately available
-      if (!data.authUrl) {
-        const pollInterval = setInterval(async () => {
-          const statusRes = await fetch(`${API_BASE}/auth/status`);
-          const status = await statusRes.json();
-          setAuthStatus(status);
-          if (status.authUrl) {
-            clearInterval(pollInterval);
-          }
-        }, 1000);
-
-        // Stop polling after 10 seconds
-        setTimeout(() => clearInterval(pollInterval), 10000);
-      } else {
+      if (data.success) {
+        setTerminalUrl(`${API_BASE}/auth/terminal`);
         await fetchAuthStatus();
       }
     } catch (err) {
-      console.error("Failed to start auth:", err);
-      setAuthMessage("Failed to start authentication flow");
+      console.error("Failed to start auth terminal:", err);
     }
   };
 
-  const completeAuth = async () => {
-    if (!authCode.trim()) {
-      setAuthMessage("Please enter the authorization code");
-      return;
-    }
-
+  const stopAuthTerminal = async () => {
     try {
-      setAuthMessage("Completing authentication...");
-      const res = await fetch(`${API_BASE}/auth/complete`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ code: authCode }),
-      });
-      const data = await res.json();
-      setAuthMessage(data.message);
-
-      if (data.success) {
-        setAuthCode("");
-        setTimeout(() => {
-          fetchAuthStatus();
-          setShowAuthModal(false);
-        }, 2000);
-      }
-    } catch (err) {
-      console.error("Failed to complete auth:", err);
-      setAuthMessage("Failed to complete authentication");
-    }
-  };
-
-  const cancelAuth = async () => {
-    try {
-      await fetch(`${API_BASE}/auth/cancel`, { method: "POST" });
+      await fetch(`${API_BASE}/auth/stop`, { method: "POST" });
+      setTerminalUrl(null);
       await fetchAuthStatus();
-      setAuthCode("");
-      setAuthMessage("");
     } catch (err) {
-      console.error("Failed to cancel auth:", err);
+      console.error("Failed to stop auth terminal:", err);
     }
+  };
+
+  const closeAuthModal = () => {
+    setShowAuthModal(false);
+    stopAuthTerminal();
   };
 
   const createSession = async () => {
@@ -435,10 +391,7 @@ function App() {
               <div className="flex justify-between items-center mb-4">
                 <h2 className="text-2xl font-bold">Authentication</h2>
                 <button
-                  onClick={() => {
-                    setShowAuthModal(false);
-                    cancelAuth();
-                  }}
+                  onClick={closeAuthModal}
                   className="text-gray-400 hover:text-white"
                 >
                   <svg
@@ -460,7 +413,7 @@ function App() {
 
               {/* Auth Status */}
               <div className="mb-6 p-4 bg-[#1a1a2e] rounded">
-                <div className="flex items-center gap-2 mb-2">
+                <div className="flex items-center gap-2">
                   <span className="font-semibold">Status:</span>
                   {authStatus?.authenticated ? (
                     <span className="text-green-400 flex items-center gap-1">
@@ -474,15 +427,10 @@ function App() {
                     </span>
                   )}
                 </div>
-                {authStatus?.cliInstalled && (
-                  <div className="text-sm text-gray-400">
-                    Claude CLI is installed
-                  </div>
-                )}
               </div>
 
-              {/* Instructions */}
-              {!authStatus?.authInProgress && (
+              {/* Terminal or Start Button */}
+              {!terminalUrl ? (
                 <div className="mb-6">
                   <h3 className="font-semibold mb-2">
                     {authStatus?.authenticated
@@ -490,102 +438,46 @@ function App() {
                       : "Authenticate Claude CLI"}
                   </h3>
                   <p className="text-sm text-gray-400 mb-4">
-                    Click the button below to start the authentication flow.
-                    You'll be able to scan a QR code or click a link to
-                    authorize on any device.
+                    Click below to open an interactive terminal. Type commands
+                    directly, follow the prompts, and authenticate with Claude.
                   </p>
                   <button
-                    onClick={startAuth}
+                    onClick={startAuthTerminal}
                     className="w-full py-3 px-4 bg-[#e94560] text-white rounded hover:bg-[#d63d56] transition"
                   >
-                    Start Authentication
+                    Open Terminal
                   </button>
                 </div>
-              )}
-
-              {/* Auth Flow */}
-              {authStatus?.authInProgress && (
+              ) : (
                 <div className="space-y-4">
-                  <div>
-                    <h3 className="font-semibold mb-2">Step 1: Authorize</h3>
-                    {authStatus.authUrl ? (
-                      <div className="space-y-4">
-                        {/* QR Code */}
-                        <div className="bg-white p-4 rounded flex justify-center">
-                          <img
-                            src={`https://api.qrserver.com/v1/create-qr-code/?size=200x200&data=${encodeURIComponent(authStatus.authUrl)}`}
-                            alt="Auth QR Code"
-                            className="w-48 h-48"
-                          />
-                        </div>
-
-                        {/* URL Link */}
-                        <div className="p-3 bg-[#1a1a2e] rounded">
-                          <div className="text-sm text-gray-400 mb-1">
-                            Or click the link:
-                          </div>
-                          <a
-                            href={authStatus.authUrl}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="text-[#e94560] hover:underline break-all text-sm"
-                          >
-                            {authStatus.authUrl}
-                          </a>
-                        </div>
-                      </div>
-                    ) : (
-                      <div className="text-gray-400">
-                        Waiting for authentication URL...
-                      </div>
-                    )}
-                  </div>
-
-                  <div>
-                    <h3 className="font-semibold mb-2">
-                      Step 2: Enter Authorization Code
-                    </h3>
-                    <p className="text-sm text-gray-400 mb-3">
-                      After authorizing, paste the code here:
+                  <div className="text-sm text-gray-400">
+                    <p className="mb-2">
+                      Interactive terminal running <code>claude /login</code>
                     </p>
-                    <div className="flex gap-2">
-                      <input
-                        type="text"
-                        value={authCode}
-                        onChange={(e) => setAuthCode(e.target.value)}
-                        placeholder="Paste authorization code"
-                        className="flex-1 bg-[#1a1a2e] rounded px-4 py-2 focus:outline-none focus:ring-2 focus:ring-[#e94560]"
-                        onKeyDown={(e) => {
-                          if (e.key === "Enter") {
-                            completeAuth();
-                          }
-                        }}
-                      />
-                      <button
-                        onClick={completeAuth}
-                        disabled={!authCode.trim()}
-                        className="px-6 py-2 bg-[#e94560] rounded hover:bg-[#d63d56] transition disabled:opacity-50 disabled:cursor-not-allowed"
-                      >
-                        Submit
-                      </button>
-                    </div>
+                    <p>
+                      Follow the prompts in the terminal below. When done,
+                      close this modal and refresh the page.
+                    </p>
                   </div>
 
-                  <div className="flex gap-2">
-                    <button
-                      onClick={cancelAuth}
-                      className="w-full py-2 px-4 bg-gray-700 text-white rounded hover:bg-gray-600 transition"
-                    >
-                      Cancel
-                    </button>
+                  {/* Terminal iframe */}
+                  <div className="bg-black rounded overflow-hidden">
+                    <iframe
+                      src={terminalUrl}
+                      className="w-full h-[500px] border-0"
+                      title="Authentication Terminal"
+                    />
                   </div>
-                </div>
-              )}
 
-              {/* Status Message */}
-              {authMessage && (
-                <div className="mt-4 p-3 bg-[#1a1a2e] rounded text-sm">
-                  {authMessage}
+                  <button
+                    onClick={() => {
+                      stopAuthTerminal();
+                      fetchAuthStatus();
+                    }}
+                    className="w-full py-2 px-4 bg-green-600 text-white rounded hover:bg-green-700 transition"
+                  >
+                    Done - Close Terminal
+                  </button>
                 </div>
               )}
             </div>

--- a/charts/claude/image/apko.yaml
+++ b/charts/claude/image/apko.yaml
@@ -11,6 +11,7 @@ contents:
     - bash
     - busybox  # Provides /bin/sh for npm scripts
     - curl
+    - ttyd     # Terminal over WebSocket for interactive auth
     # Node.js for API server and Claude Code
     - nodejs-22
     - npm

--- a/charts/claude/src/package.json
+++ b/charts/claude/src/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@anthropic-ai/claude-code": "^1.0.0",
     "express": "^4.21.0",
+    "http-proxy-middleware": "^3.0.3",
     "ws": "^8.18.0",
     "uuid": "^10.0.0"
   },

--- a/charts/claude/src/src/index.ts
+++ b/charts/claude/src/src/index.ts
@@ -1,6 +1,7 @@
 import express from "express";
 import { WebSocketServer, WebSocket } from "ws";
-import { createServer } from "http";
+import { createServer, ServerResponse } from "http";
+import { createProxyMiddleware } from "http-proxy-middleware";
 import { v4 as uuidv4 } from "uuid";
 import { spawn, ChildProcess } from "child_process";
 import path from "path";
@@ -15,15 +16,14 @@ const WORKTREES_DIR = "/tmp/claude-worktrees";
 const SESSIONS_DIR = path.join(HOME, ".claude-api", "sessions");
 const STATIC_DIR = process.env.STATIC_DIR || "/app/public";
 const CLAUDE_BIN = path.join(HOME, ".npm-global", "bin", "claude");
+const TTYD_PORT = 7681;
 
 // Ensure directories exist
 fs.mkdirSync(SESSIONS_DIR, { recursive: true });
 fs.mkdirSync(WORKTREES_DIR, { recursive: true });
 
 // Authentication state
-let authProcess: ChildProcess | null = null;
-let authUrl: string | null = null;
-let authOutput: string = "";
+let authTtydProcess: ChildProcess | null = null;
 
 interface Session {
   id: string;
@@ -42,193 +42,111 @@ app.get("/api/health", (_req, res) => {
 });
 
 // Auth status - check if Claude is authenticated
-app.get("/api/auth/status", async (_req, res) => {
-  try {
-    // Try to run a simple command to check auth status
-    const testProcess = spawn(CLAUDE_BIN, ["--help"], {
-      env: { ...process.env, HOME },
-      stdio: ["ignore", "pipe", "pipe"],
-    });
+app.get("/api/auth/status", (_req, res) => {
+  const authFile = path.join(HOME, ".claude", "auth.json");
+  const authenticated = fs.existsSync(authFile);
 
-    let output = "";
-    let error = "";
-
-    testProcess.stdout.on("data", (data) => {
-      output += data.toString();
-    });
-
-    testProcess.stderr.on("data", (data) => {
-      error += data.toString();
-    });
-
-    testProcess.on("close", (code) => {
-      // If help runs successfully, CLI is installed
-      // Check if auth file exists
-      const authFile = path.join(HOME, ".claude", "auth.json");
-      const authenticated = fs.existsSync(authFile);
-
-      res.json({
-        authenticated,
-        cliInstalled: code === 0,
-        authInProgress: authProcess !== null,
-        authUrl: authUrl,
-      });
-    });
-  } catch (err) {
-    res.status(500).json({ error: "Failed to check auth status" });
-  }
-});
-
-// Get auth output (for debugging)
-app.get("/api/auth/output", (_req, res) => {
   res.json({
-    output: authOutput,
-    authUrl: authUrl,
-    authInProgress: authProcess !== null,
+    authenticated,
+    terminalActive: authTtydProcess !== null,
   });
 });
 
-// Start auth flow
-app.post("/api/auth/start", (req, res) => {
+// Start auth terminal (spawn ttyd)
+app.post("/api/auth/start", (_req, res) => {
   // Clean up any existing auth process
-  if (authProcess) {
-    authProcess.kill();
-    authProcess = null;
+  if (authTtydProcess) {
+    console.log("Killing existing ttyd process...");
+    authTtydProcess.kill();
+    authTtydProcess = null;
   }
 
-  authUrl = null;
-  authOutput = "";
-
   try {
-    // Spawn claude in interactive mode, then send /login command
-    // This mimics the interactive terminal behavior more closely
-    const process = spawn(CLAUDE_BIN, [], {
-      cwd: HOME,
-      env: { ...process.env, HOME },
-      stdio: ["pipe", "pipe", "pipe"],
-    });
+    // Spawn ttyd with claude /login
+    // -W: Don't wait for initial connection (start immediately)
+    // -p: Port to listen on
+    // -t: Set terminal type
+    console.log(`Starting ttyd on port ${TTYD_PORT}...`);
 
-    authProcess = process;
-
-    // Send /login command via stdin once process starts
-    process.on("spawn", () => {
-      console.log("Claude process spawned, sending /login command...");
-      process.stdin?.write("/login\n");
-    });
-
-    // Capture output to extract auth URL
-    process.stdout.on("data", (data) => {
-      const output = data.toString();
-      authOutput += output;
-      console.log(`Auth stdout: ${output}`);
-
-      // Look for the auth URL pattern
-      // Claude CLI outputs URLs in format: https://...
-      // Try to match any https URL in the output
-      const urlMatch = output.match(/https:\/\/[^\s\)]+/);
-      if (urlMatch && !authUrl) {
-        // Only set if not already set
-        authUrl = urlMatch[0];
-        console.log(`✓ Found auth URL: ${authUrl}`);
+    const ttyd = spawn(
+      "ttyd",
+      [
+        "-p", TTYD_PORT.toString(),
+        "-W", // Start immediately
+        "-t", "titleFixed=Claude Authentication",
+        "bash", "-c",
+        `echo "Starting Claude authentication..." && ${CLAUDE_BIN} /login`
+      ],
+      {
+        cwd: HOME,
+        env: { ...process.env, HOME },
+        stdio: ["ignore", "pipe", "pipe"],
       }
+    );
+
+    authTtydProcess = ttyd;
+
+    ttyd.stdout.on("data", (data) => {
+      console.log(`[ttyd stdout] ${data.toString().trim()}`);
     });
 
-    process.stderr.on("data", (data) => {
-      const output = data.toString();
-      authOutput += output;
-      console.log(`Auth stderr: ${output}`);
-
-      // Also check stderr for URL (in case CLI outputs there)
-      const urlMatch = output.match(/https:\/\/[^\s\)]+/);
-      if (urlMatch && !authUrl) {
-        authUrl = urlMatch[0];
-        console.log(`✓ Found auth URL in stderr: ${authUrl}`);
-      }
+    ttyd.stderr.on("data", (data) => {
+      console.log(`[ttyd stderr] ${data.toString().trim()}`);
     });
 
-    process.on("close", (code) => {
-      console.log(`Auth process exited with code ${code}`);
-      console.log(`Full auth output:\n${authOutput}`);
-      authProcess = null;
+    ttyd.on("close", (code) => {
+      console.log(`ttyd process exited with code ${code}`);
+      authTtydProcess = null;
     });
 
-    process.on("error", (err) => {
-      console.error(`Auth process error: ${err}`);
-      authProcess = null;
+    ttyd.on("error", (err) => {
+      console.error(`ttyd process error: ${err}`);
+      authTtydProcess = null;
     });
 
-    // Give it a moment to output the URL (increased to 3s for reliability)
+    // Give ttyd a moment to start
     setTimeout(() => {
       res.json({
         success: true,
-        authUrl: authUrl,
-        message: authUrl
-          ? "Auth flow started. Please visit the URL to authorize."
-          : "Auth flow started. Waiting for URL... (check logs if this persists)",
-        debug: authOutput.substring(0, 500), // Include first 500 chars for debugging
+        message: "Terminal started. Connect to /api/auth/terminal",
+        terminalUrl: "/api/auth/terminal",
       });
-    }, 3000);
+    }, 500);
   } catch (err) {
-    console.error("Failed to start auth:", err);
-    res.status(500).json({ error: "Failed to start auth flow" });
+    console.error("Failed to start ttyd:", err);
+    res.status(500).json({ error: "Failed to start terminal" });
   }
 });
 
-// Complete auth flow with code
-app.post("/api/auth/complete", (req, res) => {
-  const { code } = req.body;
-
-  if (!authProcess) {
-    return res.status(400).json({ error: "No auth process in progress" });
-  }
-
-  if (!code) {
-    return res.status(400).json({ error: "Auth code is required" });
-  }
-
-  try {
-    // Send the code to the waiting process
-    authProcess.stdin?.write(code + "\n");
-
-    // Wait a bit for the process to complete
-    setTimeout(() => {
-      // Check if auth file was created
-      const authFile = path.join(HOME, ".claude", "auth.json");
-      const success = fs.existsSync(authFile);
-
-      if (success) {
-        res.json({
-          success: true,
-          message: "Authentication successful!",
-        });
-      } else {
-        res.json({
-          success: false,
-          message: "Authentication may have failed. Please check the code and try again.",
-        });
-      }
-
-      // Clean up
-      authProcess = null;
-      authUrl = null;
-      authOutput = "";
-    }, 3000);
-  } catch (err) {
-    console.error("Failed to complete auth:", err);
-    res.status(500).json({ error: "Failed to complete auth" });
-  }
-});
-
-// Cancel auth flow
-app.post("/api/auth/cancel", (_req, res) => {
-  if (authProcess) {
-    authProcess.kill();
-    authProcess = null;
-    authUrl = null;
-    authOutput = "";
+// Stop auth terminal
+app.post("/api/auth/stop", (_req, res) => {
+  if (authTtydProcess) {
+    console.log("Stopping ttyd process...");
+    authTtydProcess.kill();
+    authTtydProcess = null;
   }
   res.json({ success: true });
 });
+
+// Proxy to ttyd terminal (HTTP and WebSocket)
+app.use(
+  "/api/auth/terminal",
+  createProxyMiddleware({
+    target: `http://localhost:${TTYD_PORT}`,
+    changeOrigin: true,
+    ws: true, // Enable WebSocket proxying
+    pathRewrite: {
+      "^/api/auth/terminal": "", // Remove prefix
+    },
+    onError: (err, req, res) => {
+      console.error("Proxy error:", err);
+      if (res instanceof ServerResponse) {
+        res.writeHead(502);
+        res.end("Terminal not available");
+      }
+    },
+  })
+);
 
 // List sessions
 app.get("/api/sessions", (_req, res) => {


### PR DESCRIPTION
Add web-based authentication flow for Claude CLI that works seamlessly
on mobile devices and browsers, eliminating the need for kubectl exec.

**Backend changes (index.ts):**
- Add /api/auth/status endpoint to check authentication state
- Add /api/auth/start endpoint to initiate login flow
- Add /api/auth/complete endpoint to finish auth with code
- Add /api/auth/cancel endpoint to abort authentication
- Spawn claude /login process and capture auth URL from output
- Pipe authorization code back to waiting process

**Frontend changes (App.tsx):**
- Add Auth button to sidebar with status indicator
- Add authentication modal with two-step flow:
  1. Display auth URL as QR code (for mobile scanning)
  2. Accept authorization code via web form
- Poll for auth status updates
- Show clear success/failure messages

**User experience:**
- Click "Auth" button in sidebar
- Scan QR code with mobile device OR click link
- Authorize in browser
- Paste code back into web form
- Done! No kubectl access needed

This replaces the cumbersome kubectl exec + claude /login workflow
with a streamlined web-based flow that works from any device.