### PR TITLE
fix(claude): use ttyd binary instead of Wolfi package

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -203,4 +203,17 @@ multiarch_http_archive(
     package_dir = "/usr/local/bin",
 )
 
+# Download multiarch binaries (raw binary files)
+multiarch_http_file = use_repo_rule("//tools/http:multiarch_http_file.bzl", "multiarch_http_file")
+
+multiarch_http_file(
+    name = "ttyd",
+    amd64_sha256 = "8a217c968aba172e0dbf3f34447218dc015bc4d5e59bf51db2f2cd12b7be4f55",
+    amd64_url = "https://github.com/tsl0922/ttyd/releases/download/1.7.7/ttyd.x86_64",
+    arm64_sha256 = "b38acadd89d1d396a0f5649aa52c539edbad07f4bc7348b27b4f4b7219dd4165",
+    arm64_url = "https://github.com/tsl0922/ttyd/releases/download/1.7.7/ttyd.aarch64",
+    binary_name = "ttyd",
+    package_dir = "/usr/local/bin",
+)
+
 bazel_dep(name = "rules_pkg", version = "1.1.0")

--- a/charts/claude/image/BUILD
+++ b/charts/claude/image/BUILD
@@ -42,4 +42,7 @@ apko_image(
         ":app_dist_tar",
         ":frontend_tar",
     ],
+    multiarch_tars = [
+        "@ttyd//:tar",
+    ],
 )

--- a/charts/claude/image/apko.lock.json
+++ b/charts/claude/image/apko.lock.json
@@ -7,12 +7,12 @@
   "contents": {
     "keyring": [
       {
-        "name": "packages.wolfi.dev/os/wolfi-signing.rsa.pub",
-        "url": "https://packages.wolfi.dev/os/wolfi-signing.rsa.pub"
-      },
-      {
         "name": "packages.cgr.dev/extras/chainguard-extras.rsa.pub",
         "url": "https://packages.cgr.dev/extras/chainguard-extras.rsa.pub"
+      },
+      {
+        "name": "packages.wolfi.dev/os/wolfi-signing.rsa.pub",
+        "url": "https://packages.wolfi.dev/os/wolfi-signing.rsa.pub"
       }
     ],
     "build_repositories": [],

--- a/charts/claude/image/apko.yaml
+++ b/charts/claude/image/apko.yaml
@@ -11,7 +11,6 @@ contents:
     - bash
     - busybox  # Provides /bin/sh for npm scripts
     - curl
-    - ttyd     # Terminal over WebSocket for interactive auth
     # Node.js for API server and Claude Code
     - nodejs-22
     - npm


### PR DESCRIPTION
The ttyd package doesn't exist in Wolfi repositories, causing the
apko lockfile to be out of sync and CI builds to fail.

**Changes:**
1. Remove ttyd from apko.yaml packages list
2. Download ttyd v1.7.7 binaries via multiarch_http_file
3. Add ttyd as multiarch tar layer to claude image
4. Regenerate apko lockfile with correct checksum

**How it works:**
- ttyd binaries (x86_64 and aarch64) are downloaded from GitHub releases
- Binaries are packaged into platform-specific tars
- Tars are layered onto the apko base image at /usr/local/bin/ttyd
- Same functionality as before, but using downloaded binary instead of package

Fixes CI build error:
```
Error: locking config: checksum in the lock file does not match
the original config (maybe regenerate the lock file)
```

This approach mirrors how other binaries (like opencode) are handled
in the repository.