### PR TITLE
fix(claude): add nginx port to Linkerd opaque-ports

### DIFF
--- a/charts/claude/values.yaml
+++ b/charts/claude/values.yaml
@@ -104,9 +104,10 @@ affinity: {}
 
 ## Pod annotations
 podAnnotations:
-  # Mark port 3000 as opaque to bypass Linkerd's HTTP detection
+  # Mark ports as opaque to bypass Linkerd's HTTP detection
   # This prevents the default 10-second response timeout from killing WebSocket connections
-  config.linkerd.io/opaque-ports: "3000"
+  # Port 8080 (nginx) receives external traffic, port 3000 is the backend
+  config.linkerd.io/opaque-ports: "8080,3000"
 
 ## Pod labels
 podLabels: {}


### PR DESCRIPTION
## Summary
- Add port 8080 (nginx) to Linkerd opaque-ports annotation
- Traffic enters through nginx on port 8080, so Linkerd sees it on 8080, not 3000
- Without marking 8080 as opaque, Linkerd's HTTP detection times out WebSocket connections after exactly 10 seconds

This is the root cause of the ttyd terminal disconnection issue. The ttyd-session-manager doesn't have this issue because its namespace doesn't have Linkerd injection enabled.

## Test plan
- [ ] Deploy the changes via ArgoCD sync
- [ ] Navigate to claude.jomcgi.dev and start an auth session
- [ ] Verify the terminal stays connected beyond 10 seconds
- [ ] Type `/login` in the interactive Claude session and complete authentication

🤖 Generated with [Claude Code](https://claude.com/claude-code)