### PR TITLE
fix(claude): disable Linkerd injection to debug WebSocket timeout

### DIFF
--- a/charts/claude/values.yaml
+++ b/charts/claude/values.yaml
@@ -104,6 +104,8 @@ affinity: {}
 
 ## Pod annotations
 podAnnotations:
+  # Disable Linkerd injection to debug WebSocket timeout issues
+  linkerd.io/inject: disabled
   # Mark ports as opaque to bypass Linkerd's HTTP detection
   # This prevents the default 10-second response timeout from killing WebSocket connections
   # Port 8080 (nginx) receives external traffic, port 3000 is the backend


### PR DESCRIPTION
## Summary
- Disable Linkerd sidecar injection for the claude pod
- This isolates whether Linkerd is causing the 10-second WebSocket timeout despite opaque-ports config

## Test plan
- [ ] Verify pod has 2/2 containers (nginx + claude) instead of 3/3
- [ ] Test WebSocket connection stays open beyond 10 seconds
- [ ] If timeout persists, issue is in Cloudflare Tunnel or Node.js proxy

🤖 Generated with [Claude Code](https://claude.com/claude-code)