### PR TITLE
fix(claude): accept tty subprotocol for ttyd WebSocket proxy

### DIFF
--- a/charts/claude/src/src/index.ts
+++ b/charts/claude/src/src/index.ts
@@ -266,7 +266,17 @@ const server = createServer(app);
 
 // WebSocket server for ttyd terminal proxy
 // Uses proper WebSocket-to-WebSocket proxying (like ttyd-session-manager did with gorilla/websocket)
-const ttydWss = new WebSocketServer({ noServer: true });
+// IMPORTANT: Must accept "tty" subprotocol or ttyd client will reject the connection
+const ttydWss = new WebSocketServer({
+  noServer: true,
+  handleProtocols: (protocols) => {
+    // Accept "tty" subprotocol if client requests it (ttyd always does)
+    if (protocols.has("tty")) {
+      return "tty";
+    }
+    return false;
+  },
+});
 
 ttydWss.on("connection", (clientWs: WebSocket) => {
   console.log("Client WebSocket connected, connecting to ttyd...");


### PR DESCRIPTION
## Summary

- Accept "tty" WebSocket subprotocol that ttyd's client requires
- Without this, the client rejects the connection (1006 close code)

## Root Cause

ttyd's JavaScript client requests the "tty" subprotocol when establishing a WebSocket connection. If the server doesn't respond with that subprotocol in the handshake, the client considers the connection invalid and closes it immediately with code 1006 (abnormal closure).

## Test plan

- [ ] Open https://claude.jomcgi.dev
- [ ] Click Auth → Open Terminal
- [ ] Verify terminal loads and is interactive
- [ ] Type `/login` and verify OAuth flow works

🤖 Generated with [Claude Code](https://claude.com/claude-code)