### PR TITLE
fix(claude): disable WebSocket compression on proxy server

### DIFF
--- a/charts/claude/src/src/index.ts
+++ b/charts/claude/src/src/index.ts
@@ -267,8 +267,10 @@ const server = createServer(app);
 // WebSocket server for ttyd terminal proxy
 // Uses proper WebSocket-to-WebSocket proxying (like ttyd-session-manager did with gorilla/websocket)
 // IMPORTANT: Must accept "tty" subprotocol or ttyd client will reject the connection
+// IMPORTANT: Disable compression on server - browser may negotiate it but ttyd doesn't use it
 const ttydWss = new WebSocketServer({
   noServer: true,
+  perMessageDeflate: false,
   handleProtocols: (protocols) => {
     // Accept "tty" subprotocol if client requests it (ttyd always does)
     if (protocols.has("tty")) {


### PR DESCRIPTION
## Summary

- Disable `perMessageDeflate` on the WebSocketServer that accepts browser connections

## Root Cause

The browser may negotiate permessage-deflate compression with our WebSocket proxy server. When relaying frames to ttyd (which doesn't use compression), this causes "RSV1 must be clear" errors because compressed frames are being sent over an uncompressed connection.

Previous PRs disabled compression on the connection TO ttyd, but not on the server accepting FROM the browser.

## Test plan

- [ ] Open https://claude.jomcgi.dev
- [ ] Click Auth → Open Terminal  
- [ ] Verify terminal loads and is interactive

🤖 Generated with [Claude Code](https://claude.com/claude-code)