### PR TITLE
fix(claude): use xterm.js for auth terminal instead of ttyd iframe

### DIFF
--- a/charts/claude/frontend/package.json
+++ b/charts/claude/frontend/package.json
@@ -10,7 +10,11 @@
   },
   "dependencies": {
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "@xterm/xterm": "^5.5.0",
+    "@xterm/addon-fit": "^0.10.0",
+    "@xterm/addon-web-links": "^0.11.0",
+    "@xterm/addon-webgl": "^0.18.0"
   },
   "devDependencies": {
     "@types/react": "^18.3.0",

--- a/charts/claude/frontend/src/App.tsx
+++ b/charts/claude/frontend/src/App.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef, useCallback } from "react";
+import { AuthTerminal } from "./AuthTerminal";
 
 interface Message {
   id: string;
@@ -78,7 +79,8 @@ function App() {
       const res = await fetch(`${API_BASE}/auth/start`, { method: "POST" });
       const data = await res.json();
       if (data.success) {
-        setTerminalUrl(`${API_BASE}/auth/terminal`);
+        // Use WebSocket URL for xterm.js direct connection
+        setTerminalUrl(`${WS_BASE}/api/auth/terminal/ws`);
         await fetchAuthStatus();
       }
     } catch (err) {
@@ -459,14 +461,8 @@ function App() {
                     </p>
                   </div>
 
-                  {/* Terminal iframe */}
-                  <div className="bg-black rounded overflow-hidden">
-                    <iframe
-                      src={terminalUrl}
-                      className="w-full h-[500px] border-0"
-                      title="Authentication Terminal"
-                    />
-                  </div>
+                  {/* Terminal with xterm.js */}
+                  <AuthTerminal wsUrl={terminalUrl} />
 
                   <button
                     onClick={() => {

--- a/charts/claude/frontend/src/AuthTerminal.tsx
+++ b/charts/claude/frontend/src/AuthTerminal.tsx
@@ -1,0 +1,195 @@
+import { useEffect, useRef } from "react";
+import { Terminal } from "@xterm/xterm";
+import { FitAddon } from "@xterm/addon-fit";
+import { WebLinksAddon } from "@xterm/addon-web-links";
+import { WebglAddon } from "@xterm/addon-webgl";
+import "@xterm/xterm/css/xterm.css";
+
+interface AuthTerminalProps {
+  wsUrl: string;
+}
+
+/**
+ * AuthTerminal - xterm.js terminal component that implements the ttyd protocol
+ *
+ * ttyd protocol:
+ * - On connect: Send JSON auth message with terminal dimensions
+ * - Server messages: Prefixed with type ('0' = output, '1' = title)
+ * - Client messages: Prefixed with type ('0' = input, '1' = resize)
+ */
+export function AuthTerminal({ wsUrl }: AuthTerminalProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const terminalRef = useRef<Terminal | null>(null);
+  const wsRef = useRef<WebSocket | null>(null);
+  const fitAddonRef = useRef<FitAddon | null>(null);
+  const webglAddonRef = useRef<WebglAddon | null>(null);
+
+  useEffect(() => {
+    if (!containerRef.current) return;
+
+    // Create terminal with performance optimizations
+    const term = new Terminal({
+      cursorBlink: true,
+      fontSize: 14,
+      fontFamily: 'Menlo, Monaco, "Courier New", monospace',
+      theme: {
+        background: "#000000",
+        foreground: "#ffffff",
+        cursor: "#10b981",
+        selection: "rgba(255, 255, 255, 0.3)",
+      },
+      scrollback: 10000,
+    });
+
+    const fitAddon = new FitAddon();
+    const webLinksAddon = new WebLinksAddon();
+
+    term.loadAddon(fitAddon);
+    term.loadAddon(webLinksAddon);
+    term.open(containerRef.current);
+
+    // Try WebGL renderer for better performance
+    try {
+      const webglAddon = new WebglAddon();
+      webglAddon.onContextLoss(() => {
+        try {
+          webglAddon.dispose();
+        } catch (err) {
+          console.warn("Error disposing WebGL addon on context loss:", err);
+        }
+        webglAddonRef.current = null;
+      });
+      term.loadAddon(webglAddon);
+      webglAddonRef.current = webglAddon;
+    } catch (e) {
+      console.warn("WebGL renderer not available, falling back to canvas:", e);
+    }
+
+    fitAddon.fit();
+    terminalRef.current = term;
+    fitAddonRef.current = fitAddon;
+
+    term.write("\x1b[33mConnecting to terminal...\x1b[0m\r\n");
+
+    // Connect to WebSocket with ttyd protocol
+    const ws = new WebSocket(wsUrl, ["tty"]);
+    ws.binaryType = "arraybuffer";
+
+    ws.onopen = () => {
+      term.write("\x1b[32mConnected!\x1b[0m\r\n");
+
+      // ttyd protocol: First message is JSON auth with terminal dimensions
+      const authMessage = JSON.stringify({
+        AuthToken: "",
+        columns: term.cols,
+        rows: term.rows,
+      });
+      ws.send(authMessage);
+    };
+
+    ws.onmessage = (event) => {
+      // Handle both ArrayBuffer and string data
+      let data = event.data;
+      if (data instanceof ArrayBuffer) {
+        const decoder = new TextDecoder();
+        data = decoder.decode(data);
+      }
+
+      if (typeof data === "string" && data.length > 0) {
+        const messageType = data[0];
+        const payload = data.substring(1);
+
+        if (messageType === "0") {
+          // OUTPUT: write terminal data
+          term.write(payload);
+        } else if (messageType === "1") {
+          // SET_WINDOW_TITLE: ignore for auth terminal
+        }
+      }
+    };
+
+    ws.onerror = (error) => {
+      console.error("WebSocket error:", error);
+      term.write("\r\n\x1b[31mConnection error\x1b[0m\r\n");
+    };
+
+    ws.onclose = () => {
+      term.write("\r\n\x1b[33mConnection closed\x1b[0m\r\n");
+    };
+
+    wsRef.current = ws;
+
+    // Send terminal input to WebSocket
+    // ttyd protocol: prefix input with '0' (INPUT message type)
+    const encoder = new TextEncoder();
+    const dataHandler = term.onData((data) => {
+      if (ws.readyState === WebSocket.OPEN) {
+        const encoded = encoder.encode(data);
+        const message = new Uint8Array(encoded.length + 1);
+        message[0] = 48; // ASCII '0' for ttyd INPUT message type
+        message.set(encoded, 1);
+        ws.send(message.buffer);
+      }
+    });
+
+    // Handle window resize
+    const resizeHandler = () => {
+      fitAddon.fit();
+
+      // Notify ttyd of terminal size change with RESIZE message (type '1')
+      if (ws.readyState === WebSocket.OPEN) {
+        const resizeJson = JSON.stringify({
+          columns: term.cols,
+          rows: term.rows,
+        });
+        const encoded = encoder.encode(resizeJson);
+        const resizeMessage = new Uint8Array(encoded.length + 1);
+        resizeMessage[0] = 49; // ASCII '1' for ttyd RESIZE message type
+        resizeMessage.set(encoded, 1);
+        ws.send(resizeMessage.buffer);
+      }
+    };
+    window.addEventListener("resize", resizeHandler);
+
+    // Focus terminal
+    term.focus();
+
+    // Cleanup
+    return () => {
+      window.removeEventListener("resize", resizeHandler);
+      dataHandler.dispose();
+
+      if (wsRef.current) {
+        wsRef.current.close();
+        wsRef.current = null;
+      }
+
+      if (webglAddonRef.current) {
+        try {
+          webglAddonRef.current.dispose();
+        } catch (err) {
+          console.warn("Error disposing WebGL addon:", err);
+        }
+        webglAddonRef.current = null;
+      }
+
+      if (terminalRef.current) {
+        try {
+          terminalRef.current.dispose();
+        } catch (err) {
+          console.warn("Error disposing terminal:", err);
+        }
+        terminalRef.current = null;
+      }
+
+      fitAddonRef.current = null;
+    };
+  }, [wsUrl]);
+
+  return (
+    <div
+      ref={containerRef}
+      className="w-full h-[500px] bg-black rounded overflow-hidden"
+    />
+  );
+}


### PR DESCRIPTION
## Summary

Replace the iframe-based ttyd terminal with xterm.js that implements the ttyd protocol directly. This is the same approach used by the old ttyd-session-manager that worked reliably.

## Why

The iframe approach embedded ttyd's built-in web UI which makes WebSocket connections through our proxy. Multiple issues with WebSocket compression, subprotocols, and frame handling made this unreliable.

## Changes

- Add xterm.js and addons (`@xterm/xterm`, `@xterm/addon-fit`, `@xterm/addon-web-links`, `@xterm/addon-webgl`)
- Create `AuthTerminal` component that implements ttyd protocol:
  - On connect: Send JSON auth message with terminal dimensions
  - Handle server messages (prefixed with `'0'` for output, `'1'` for title)
  - Send client messages (prefixed with `'0'` for input, `'1'` for resize)
- Replace iframe in auth modal with AuthTerminal component

## Test plan

- [ ] Open https://claude.jomcgi.dev
- [ ] Click Auth → Open Terminal
- [ ] Verify xterm.js terminal renders and connects
- [ ] Type `/login` and verify interactive OAuth flow works
- [ ] Complete authentication and verify status updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)