### PR TITLE
fix(claude): use /bin/bash for shell spawn

### DIFF
--- a/charts/claude/src/dist/index.js
+++ b/charts/claude/src/dist/index.js
@@ -406,7 +406,7 @@ function runClaudeMessage(session, userMessage) {
             HOME,
         },
         stdio: ["inherit", "pipe", "pipe"], // stdin inherit, stdout/stderr piped
-        shell: true,
+        shell: "/bin/bash", // wolfi container doesn't have /bin/sh
     });
     session.process = claude;
     claude.on("spawn", () => {

--- a/charts/claude/src/src/index.ts
+++ b/charts/claude/src/src/index.ts
@@ -501,7 +501,7 @@ function runClaudeMessage(session: Session, userMessage: string) {
       HOME,
     },
     stdio: ["inherit", "pipe", "pipe"], // stdin inherit, stdout/stderr piped
-    shell: true,
+    shell: "/bin/bash", // wolfi container doesn't have /bin/sh
   });
 
   session.process = claude;


### PR DESCRIPTION
## Summary
Fixes shell spawn error by using `/bin/bash` explicitly instead of the default `/bin/sh`.

## Problem
The wolfi-based container doesn't have `/bin/sh`, causing `spawn /bin/sh ENOENT` errors when using `shell: true`.

## Solution
Change `shell: true` to `shell: "/bin/bash"` since bash is available in the container.

## Test plan
- [ ] Deploy and verify Claude sessions work
- [ ] Send a message and verify response streams back

🤖 Generated with [Claude Code](https://claude.com/claude-code)