### PR TITLE
fix(claude): remove shell option from spawn

### DIFF
--- a/charts/claude/src/dist/index.js
+++ b/charts/claude/src/dist/index.js
@@ -406,7 +406,6 @@ function runClaudeMessage(session, userMessage) {
             HOME,
         },
         stdio: ["inherit", "pipe", "pipe"], // stdin inherit, stdout/stderr piped
-        shell: "/bin/bash", // wolfi container doesn't have /bin/sh
     });
     session.process = claude;
     claude.on("spawn", () => {

--- a/charts/claude/src/src/index.ts
+++ b/charts/claude/src/src/index.ts
@@ -501,7 +501,6 @@ function runClaudeMessage(session: Session, userMessage: string) {
       HOME,
     },
     stdio: ["inherit", "pipe", "pipe"], // stdin inherit, stdout/stderr piped
-    shell: "/bin/bash", // wolfi container doesn't have /bin/sh
   });
 
   session.process = claude;


### PR DESCRIPTION
## Summary
Removes the `shell` option from Claude process spawn - it's not needed and was causing ENOENT errors.

## Problem
Using `shell: true` or `shell: "/bin/bash"` caused spawn errors because Node.js couldn't find the shell binary in the expected location.

## Solution
Remove the shell option entirely. Tested via kubectl exec that Claude binary can be spawned directly:
```
kubectl exec -n claude deploy/claude -c claude -- /home/user/.npm-global/bin/claude -p --output-format stream-json --verbose --dangerously-skip-permissions "hello"
```
Works perfectly and returns proper JSONL output.

## Test plan
- [ ] Deploy and verify Claude sessions work
- [ ] Send a message and verify JSONL response streams back

🤖 Generated with [Claude Code](https://claude.com/claude-code)