### PR TITLE
fix(claude): persist worktrees and fix spawn issues

### DIFF
--- a/charts/claude/src/dist/index.js
+++ b/charts/claude/src/dist/index.js
@@ -15,7 +15,7 @@ const app = (0, express_1.default)();
 app.use(express_1.default.json());
 const PORT = parseInt(process.env.PORT || "3000", 10);
 const HOME = process.env.HOME || "/home/user";
-const WORKTREES_DIR = "/tmp/claude-worktrees";
+const WORKTREES_DIR = path_1.default.join(HOME, ".claude-api", "worktrees"); // Persistent on PVC
 const SESSIONS_DIR = path_1.default.join(HOME, ".claude-api", "sessions");
 const STATIC_DIR = process.env.STATIC_DIR || "/app/public";
 const CLAUDE_BIN = path_1.default.join(HOME, ".npm-global", "bin", "claude");
@@ -380,6 +380,11 @@ wss.on("connection", (ws, req) => {
 function runClaudeMessage(session, userMessage) {
     console.log(`Running Claude for session ${session.id} in ${session.workdir}`);
     console.log(`Using Claude binary: ${CLAUDE_BIN}`);
+    // Ensure workdir exists (may have been cleared if in /tmp after pod restart)
+    if (!fs_1.default.existsSync(session.workdir)) {
+        console.log(`Creating workdir: ${session.workdir}`);
+        fs_1.default.mkdirSync(session.workdir, { recursive: true });
+    }
     session.isProcessing = true;
     // Build args for print mode
     // -p: print mode (non-interactive)

--- a/charts/claude/src/src/index.ts
+++ b/charts/claude/src/src/index.ts
@@ -13,7 +13,7 @@ app.use(express.json());
 
 const PORT = parseInt(process.env.PORT || "3000", 10);
 const HOME = process.env.HOME || "/home/user";
-const WORKTREES_DIR = "/tmp/claude-worktrees";
+const WORKTREES_DIR = path.join(HOME, ".claude-api", "worktrees"); // Persistent on PVC
 const SESSIONS_DIR = path.join(HOME, ".claude-api", "sessions");
 const STATIC_DIR = process.env.STATIC_DIR || "/app/public";
 const CLAUDE_BIN = path.join(HOME, ".npm-global", "bin", "claude");
@@ -469,6 +469,12 @@ function runClaudeMessage(session: Session, userMessage: string) {
     `Running Claude for session ${session.id} in ${session.workdir}`,
   );
   console.log(`Using Claude binary: ${CLAUDE_BIN}`);
+
+  // Ensure workdir exists (may have been cleared if in /tmp after pod restart)
+  if (!fs.existsSync(session.workdir)) {
+    console.log(`Creating workdir: ${session.workdir}`);
+    fs.mkdirSync(session.workdir, { recursive: true });
+  }
 
   session.isProcessing = true;
 


### PR DESCRIPTION
## Summary
Fixes Claude session spawning issues with multiple improvements:

1. **Move worktrees to PVC** - From `/tmp/claude-worktrees` to `~/.claude-api/worktrees`
   - Persists Claude's working context across pod restarts
   - Keeps session files, git state, etc.

2. **Remove shell option** - Claude binary can be spawned directly
   - `shell: true` caused ENOENT errors due to missing `/bin/sh`
   - Tested via kubectl exec that direct spawn works perfectly

3. **Ensure workdir exists** - Safety check before spawning
   - Prevents confusing ENOENT errors when cwd doesn't exist

## Testing done
```bash
# Verified Claude works directly in container
kubectl exec -n claude deploy/claude -c claude -- \
  /home/user/.npm-global/bin/claude -p --output-format stream-json \
  --verbose --dangerously-skip-permissions "hello"
# Returns proper JSONL output
```

## Test plan
- [ ] Deploy and verify session connections work
- [ ] Send a message and verify response streams back
- [ ] Restart pod and verify sessions + worktrees persist

🤖 Generated with [Claude Code](https://claude.com/claude-code)