### PR TITLE
fix(claude): persist worktrees, fix resume, refactor auth

### DIFF
--- a/charts/claude/src/dist/auth.d.ts
+++ b/charts/claude/src/dist/auth.d.ts
@@ -1,0 +1,6 @@
+import { Express } from "express";
+import { IncomingMessage } from "http";
+import { Socket } from "net";
+export declare const ttydWss: import("ws").Server<typeof import("ws"), typeof IncomingMessage>;
+export declare function handleTtydUpgrade(req: IncomingMessage, socket: Socket, head: Buffer): void;
+export declare function setupAuthRoutes(app: Express): void;

--- a/charts/claude/src/dist/auth.js
+++ b/charts/claude/src/dist/auth.js
@@ -1,0 +1,191 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.ttydWss = void 0;
+exports.handleTtydUpgrade = handleTtydUpgrade;
+exports.setupAuthRoutes = setupAuthRoutes;
+const ws_1 = require("ws");
+const http_1 = require("http");
+const http_proxy_middleware_1 = require("http-proxy-middleware");
+const child_process_1 = require("child_process");
+const path_1 = __importDefault(require("path"));
+const fs_1 = __importDefault(require("fs"));
+const HOME = process.env.HOME || "/home/user";
+const CLAUDE_BIN = path_1.default.join(HOME, ".npm-global", "bin", "claude");
+const TTYD_PORT = 7681;
+// Authentication state
+let authTtydProcess = null;
+// WebSocket server for ttyd terminal proxy
+// Uses proper WebSocket-to-WebSocket proxying
+// IMPORTANT: Must accept "tty" subprotocol or ttyd client will reject the connection
+// IMPORTANT: Disable compression on server - browser may negotiate it but ttyd doesn't use it
+exports.ttydWss = new ws_1.WebSocketServer({
+    noServer: true,
+    perMessageDeflate: false,
+    handleProtocols: (protocols) => {
+        // Accept "tty" subprotocol if client requests it (ttyd always does)
+        if (protocols.has("tty")) {
+            return "tty";
+        }
+        return false;
+    },
+});
+exports.ttydWss.on("connection", (clientWs) => {
+    console.log("Client WebSocket connected, connecting to ttyd...");
+    // Connect to ttyd using WebSocket protocol with "tty" subprotocol
+    // IMPORTANT: Disable perMessageDeflate to avoid compression mismatch with ttyd
+    const ttydWs = new ws_1.WebSocket(`ws://localhost:${TTYD_PORT}/ws`, ["tty"], {
+        perMessageDeflate: false,
+    });
+    // Set binary type to match ttyd expectations
+    ttydWs.binaryType = "arraybuffer";
+    // Track connection state
+    let ttydConnected = false;
+    ttydWs.on("open", () => {
+        console.log("Connected to ttyd WebSocket");
+        ttydConnected = true;
+    });
+    ttydWs.on("message", (data, isBinary) => {
+        // Forward ttyd messages to client, preserving binary/text type
+        if (clientWs.readyState === ws_1.WebSocket.OPEN) {
+            clientWs.send(data, { binary: isBinary });
+        }
+    });
+    ttydWs.on("close", (code, reason) => {
+        console.log(`ttyd WebSocket closed: ${code} ${reason}`);
+        ttydConnected = false;
+        if (clientWs.readyState === ws_1.WebSocket.OPEN) {
+            clientWs.close(code, reason.toString());
+        }
+    });
+    ttydWs.on("error", (err) => {
+        console.error("ttyd WebSocket error:", err);
+        ttydConnected = false;
+        if (clientWs.readyState === ws_1.WebSocket.OPEN) {
+            clientWs.close(1011, "ttyd connection error");
+        }
+    });
+    clientWs.on("message", (data, isBinary) => {
+        // Forward client messages to ttyd, preserving binary/text type
+        if (ttydWs.readyState === ws_1.WebSocket.OPEN) {
+            ttydWs.send(data, { binary: isBinary });
+        }
+    });
+    clientWs.on("close", (code, reason) => {
+        console.log(`Client WebSocket closed: ${code} ${reason}`);
+        // Only close ttyd connection if it's open or connecting
+        if (ttydConnected || ttydWs.readyState === ws_1.WebSocket.CONNECTING) {
+            ttydWs.close();
+        }
+    });
+    clientWs.on("error", (err) => {
+        console.error("Client WebSocket error:", err);
+        if (ttydConnected || ttydWs.readyState === ws_1.WebSocket.CONNECTING) {
+            ttydWs.close();
+        }
+    });
+});
+// Handle WebSocket upgrade for ttyd
+function handleTtydUpgrade(req, socket, head) {
+    console.log(`WebSocket upgrade request for ttyd: ${req.url}`);
+    exports.ttydWss.handleUpgrade(req, socket, head, (ws) => {
+        exports.ttydWss.emit("connection", ws, req);
+    });
+}
+// Setup auth routes on express app
+function setupAuthRoutes(app) {
+    // Auth status - check if Claude is authenticated
+    app.get("/api/auth/status", (_req, res) => {
+        const authFile = path_1.default.join(HOME, ".claude", "auth.json");
+        const authenticated = fs_1.default.existsSync(authFile);
+        res.json({
+            authenticated,
+            terminalActive: authTtydProcess !== null,
+        });
+    });
+    // Start auth terminal (spawn ttyd)
+    app.post("/api/auth/start", (_req, res) => {
+        // Clean up any existing auth process
+        if (authTtydProcess) {
+            console.log("Killing existing ttyd process...");
+            authTtydProcess.kill();
+            authTtydProcess = null;
+        }
+        try {
+            // Spawn ttyd with claude
+            // -W: Don't wait for initial connection (start immediately)
+            // -p: Port to listen on
+            // -t: Set terminal type
+            console.log(`Starting ttyd on port ${TTYD_PORT}...`);
+            // Run claude interactively - user types /login inside the session
+            const ttyd = (0, child_process_1.spawn)("ttyd", [
+                "-p",
+                TTYD_PORT.toString(),
+                "-W", // Start immediately
+                "-t",
+                "titleFixed=Claude Authentication",
+                CLAUDE_BIN,
+            ], {
+                cwd: HOME,
+                env: { ...process.env, HOME },
+                stdio: ["ignore", "pipe", "pipe"],
+            });
+            authTtydProcess = ttyd;
+            ttyd.stdout.on("data", (data) => {
+                console.log(`[ttyd stdout] ${data.toString().trim()}`);
+            });
+            ttyd.stderr.on("data", (data) => {
+                console.log(`[ttyd stderr] ${data.toString().trim()}`);
+            });
+            ttyd.on("close", (code) => {
+                console.log(`ttyd process exited with code ${code}`);
+                authTtydProcess = null;
+            });
+            ttyd.on("error", (err) => {
+                console.error(`ttyd process error: ${err}`);
+                authTtydProcess = null;
+            });
+            // Give ttyd a moment to start
+            setTimeout(() => {
+                res.json({
+                    success: true,
+                    message: "Terminal started. Connect to /api/auth/terminal",
+                    terminalUrl: "/api/auth/terminal",
+                });
+            }, 500);
+        }
+        catch (err) {
+            console.error("Failed to start ttyd:", err);
+            res.status(500).json({ error: "Failed to start terminal" });
+        }
+    });
+    // Stop auth terminal
+    app.post("/api/auth/stop", (_req, res) => {
+        if (authTtydProcess) {
+            console.log("Stopping ttyd process...");
+            authTtydProcess.kill();
+            authTtydProcess = null;
+        }
+        res.json({ success: true });
+    });
+    // Proxy to ttyd terminal (HTTP only - WebSocket handled separately)
+    const ttydProxy = (0, http_proxy_middleware_1.createProxyMiddleware)({
+        target: `http://localhost:${TTYD_PORT}`,
+        changeOrigin: true,
+        pathRewrite: {
+            "^/api/auth/terminal": "", // Remove prefix
+        },
+        on: {
+            error: (err, _req, res) => {
+                console.error("Proxy error:", err);
+                if (res instanceof http_1.ServerResponse) {
+                    res.writeHead(502);
+                    res.end("Terminal not available");
+                }
+            },
+        },
+    });
+    app.use("/api/auth/terminal", ttydProxy);
+}

--- a/charts/claude/src/dist/index.js
+++ b/charts/claude/src/dist/index.js
@@ -6,11 +6,11 @@ Object.defineProperty(exports, "__esModule", { value: true });
 const express_1 = __importDefault(require("express"));
 const ws_1 = require("ws");
 const http_1 = require("http");
-const http_proxy_middleware_1 = require("http-proxy-middleware");
 const uuid_1 = require("uuid");
 const child_process_1 = require("child_process");
 const path_1 = __importDefault(require("path"));
 const fs_1 = __importDefault(require("fs"));
+const auth_1 = require("./auth");
 const app = (0, express_1.default)();
 app.use(express_1.default.json());
 const PORT = parseInt(process.env.PORT || "3000", 10);
@@ -19,109 +19,16 @@ const WORKTREES_DIR = path_1.default.join(HOME, ".claude-api", "worktrees"); // 
 const SESSIONS_DIR = path_1.default.join(HOME, ".claude-api", "sessions");
 const STATIC_DIR = process.env.STATIC_DIR || "/app/public";
 const CLAUDE_BIN = path_1.default.join(HOME, ".npm-global", "bin", "claude");
-const TTYD_PORT = 7681;
 // Ensure directories exist
 fs_1.default.mkdirSync(SESSIONS_DIR, { recursive: true });
 fs_1.default.mkdirSync(WORKTREES_DIR, { recursive: true });
-// Authentication state
-let authTtydProcess = null;
 const sessions = new Map();
 // Health check
 app.get("/api/health", (_req, res) => {
     res.json({ status: "ok", sessions: sessions.size });
 });
-// Auth status - check if Claude is authenticated
-app.get("/api/auth/status", (_req, res) => {
-    const authFile = path_1.default.join(HOME, ".claude", "auth.json");
-    const authenticated = fs_1.default.existsSync(authFile);
-    res.json({
-        authenticated,
-        terminalActive: authTtydProcess !== null,
-    });
-});
-// Start auth terminal (spawn ttyd)
-app.post("/api/auth/start", (_req, res) => {
-    // Clean up any existing auth process
-    if (authTtydProcess) {
-        console.log("Killing existing ttyd process...");
-        authTtydProcess.kill();
-        authTtydProcess = null;
-    }
-    try {
-        // Spawn ttyd with claude /login
-        // -W: Don't wait for initial connection (start immediately)
-        // -p: Port to listen on
-        // -t: Set terminal type
-        console.log(`Starting ttyd on port ${TTYD_PORT}...`);
-        // Run claude interactively - user types /login inside the session
-        const ttyd = (0, child_process_1.spawn)("ttyd", [
-            "-p",
-            TTYD_PORT.toString(),
-            "-W", // Start immediately
-            "-t",
-            "titleFixed=Claude Authentication",
-            CLAUDE_BIN,
-        ], {
-            cwd: HOME,
-            env: { ...process.env, HOME },
-            stdio: ["ignore", "pipe", "pipe"],
-        });
-        authTtydProcess = ttyd;
-        ttyd.stdout.on("data", (data) => {
-            console.log(`[ttyd stdout] ${data.toString().trim()}`);
-        });
-        ttyd.stderr.on("data", (data) => {
-            console.log(`[ttyd stderr] ${data.toString().trim()}`);
-        });
-        ttyd.on("close", (code) => {
-            console.log(`ttyd process exited with code ${code}`);
-            authTtydProcess = null;
-        });
-        ttyd.on("error", (err) => {
-            console.error(`ttyd process error: ${err}`);
-            authTtydProcess = null;
-        });
-        // Give ttyd a moment to start
-        setTimeout(() => {
-            res.json({
-                success: true,
-                message: "Terminal started. Connect to /api/auth/terminal",
-                terminalUrl: "/api/auth/terminal",
-            });
-        }, 500);
-    }
-    catch (err) {
-        console.error("Failed to start ttyd:", err);
-        res.status(500).json({ error: "Failed to start terminal" });
-    }
-});
-// Stop auth terminal
-app.post("/api/auth/stop", (_req, res) => {
-    if (authTtydProcess) {
-        console.log("Stopping ttyd process...");
-        authTtydProcess.kill();
-        authTtydProcess = null;
-    }
-    res.json({ success: true });
-});
-// Proxy to ttyd terminal (HTTP only - WebSocket handled separately)
-const ttydProxy = (0, http_proxy_middleware_1.createProxyMiddleware)({
-    target: `http://localhost:${TTYD_PORT}`,
-    changeOrigin: true,
-    pathRewrite: {
-        "^/api/auth/terminal": "", // Remove prefix
-    },
-    on: {
-        error: (err, req, res) => {
-            console.error("Proxy error:", err);
-            if (res instanceof http_1.ServerResponse) {
-                res.writeHead(502);
-                res.end("Terminal not available");
-            }
-        },
-    },
-});
-app.use("/api/auth/terminal", ttydProxy);
+// Setup auth routes (ttyd terminal for /login)
+(0, auth_1.setupAuthRoutes)(app);
 // List sessions
 app.get("/api/sessions", (_req, res) => {
     const sessionList = Array.from(sessions.values()).map((s) => ({
@@ -215,89 +122,14 @@ app.get("*", (req, res) => {
 });
 // Create HTTP server
 const server = (0, http_1.createServer)(app);
-// WebSocket server for ttyd terminal proxy
-// Uses proper WebSocket-to-WebSocket proxying (like ttyd-session-manager did with gorilla/websocket)
-// IMPORTANT: Must accept "tty" subprotocol or ttyd client will reject the connection
-// IMPORTANT: Disable compression on server - browser may negotiate it but ttyd doesn't use it
-const ttydWss = new ws_1.WebSocketServer({
-    noServer: true,
-    perMessageDeflate: false,
-    handleProtocols: (protocols) => {
-        // Accept "tty" subprotocol if client requests it (ttyd always does)
-        if (protocols.has("tty")) {
-            return "tty";
-        }
-        return false;
-    },
-});
-ttydWss.on("connection", (clientWs) => {
-    console.log("Client WebSocket connected, connecting to ttyd...");
-    // Connect to ttyd using WebSocket protocol with "tty" subprotocol
-    // IMPORTANT: Disable perMessageDeflate to avoid compression mismatch with ttyd
-    const ttydWs = new ws_1.WebSocket(`ws://localhost:${TTYD_PORT}/ws`, ["tty"], {
-        perMessageDeflate: false,
-    });
-    // Set binary type to match ttyd expectations
-    ttydWs.binaryType = "arraybuffer";
-    // Track connection state
-    let ttydConnected = false;
-    ttydWs.on("open", () => {
-        console.log("Connected to ttyd WebSocket");
-        ttydConnected = true;
-    });
-    ttydWs.on("message", (data, isBinary) => {
-        // Forward ttyd messages to client, preserving binary/text type
-        if (clientWs.readyState === ws_1.WebSocket.OPEN) {
-            clientWs.send(data, { binary: isBinary });
-        }
-    });
-    ttydWs.on("close", (code, reason) => {
-        console.log(`ttyd WebSocket closed: ${code} ${reason}`);
-        ttydConnected = false;
-        if (clientWs.readyState === ws_1.WebSocket.OPEN) {
-            clientWs.close(code, reason.toString());
-        }
-    });
-    ttydWs.on("error", (err) => {
-        console.error("ttyd WebSocket error:", err);
-        ttydConnected = false;
-        if (clientWs.readyState === ws_1.WebSocket.OPEN) {
-            clientWs.close(1011, "ttyd connection error");
-        }
-    });
-    clientWs.on("message", (data, isBinary) => {
-        // Forward client messages to ttyd, preserving binary/text type
-        if (ttydWs.readyState === ws_1.WebSocket.OPEN) {
-            ttydWs.send(data, { binary: isBinary });
-        }
-    });
-    clientWs.on("close", (code, reason) => {
-        console.log(`Client WebSocket closed: ${code} ${reason}`);
-        // Only close ttyd connection if it's open or connecting
-        if (ttydConnected || ttydWs.readyState === ws_1.WebSocket.CONNECTING) {
-            ttydWs.close();
-        }
-    });
-    clientWs.on("error", (err) => {
-        console.error("Client WebSocket error:", err);
-        if (ttydConnected || ttydWs.readyState === ws_1.WebSocket.CONNECTING) {
-            ttydWs.close();
-        }
-    });
-});
-// WebSocket server for streaming (also noServer to avoid duplicate upgrade handlers)
+// WebSocket server for session streaming
 const wss = new ws_1.WebSocketServer({ noServer: true });
 // Handle ALL WebSocket upgrades in one place to avoid conflicts
-// When using { server, path } option, ws library registers its own upgrade handler
-// which can conflict with manual handlers and send duplicate responses
 server.on("upgrade", (req, socket, head) => {
     const url = req.url || "";
-    console.log(`[UPGRADE] Request received: ${url}, headers: ${JSON.stringify(req.headers)}`);
+    console.log(`[UPGRADE] Request received: ${url}`);
     if (url.startsWith("/api/auth/terminal/ws")) {
-        console.log(`WebSocket upgrade request for ttyd: ${url}`);
-        ttydWss.handleUpgrade(req, socket, head, (ws) => {
-            ttydWss.emit("connection", ws, req);
-        });
+        (0, auth_1.handleTtydUpgrade)(req, socket, head);
     }
     else if (url.startsWith("/ws")) {
         console.log(`WebSocket upgrade request for session: ${url}`);
@@ -386,23 +218,25 @@ function runClaudeMessage(session, userMessage) {
         fs_1.default.mkdirSync(session.workdir, { recursive: true });
     }
     session.isProcessing = true;
-    // Build args for print mode
-    // -p: print mode (non-interactive)
-    // --output-format stream-json: structured JSONL output
-    // --verbose: required with stream-json
-    // --dangerously-skip-permissions: skip permission prompts
-    const args = [
-        "-p", // Print mode
-        "--output-format", "stream-json",
-        "--verbose",
-        "--dangerously-skip-permissions",
-    ];
-    // If we have a previous Claude session, resume it
+    // Build args based on whether this is a new conversation or resume
+    // cui pattern:
+    //   new: -p <message> --output-format stream-json --verbose
+    //   resume: --resume <sessionId> <message> --output-format stream-json --verbose
+    const args = [];
     if (session.claudeSessionId) {
+        // Resume existing conversation (no -p flag)
         args.push("--resume", session.claudeSessionId);
+        args.push(userMessage);
     }
-    // Add the user message as the last argument
-    args.push(userMessage);
+    else {
+        // New conversation with print mode
+        args.push("-p");
+        args.push(userMessage);
+    }
+    // Common flags
+    args.push("--output-format", "stream-json");
+    args.push("--verbose");
+    args.push("--dangerously-skip-permissions");
     console.log(`Claude args: ${args.join(" ")}`);
     const claude = (0, child_process_1.spawn)(CLAUDE_BIN, args, {
         cwd: session.workdir,
@@ -420,7 +254,10 @@ function runClaudeMessage(session, userMessage) {
         console.error(`Claude process error: ${err.message}`);
         session.isProcessing = false;
         session.process = undefined;
-        broadcast(session, { type: "error", content: `Process error: ${err.message}` });
+        broadcast(session, {
+            type: "error",
+            content: `Process error: ${err.message}`,
+        });
     });
     // Buffer for incomplete JSON lines
     let buffer = "";
@@ -437,7 +274,7 @@ function runClaudeMessage(session, userMessage) {
                 const event = JSON.parse(line);
                 handleClaudeEvent(session, event);
             }
-            catch (err) {
+            catch {
                 // Not valid JSON, might be regular output
                 console.log(`Claude non-JSON output: ${line.substring(0, 100)}`);
             }
@@ -500,7 +337,10 @@ function handleClaudeEvent(session, event) {
     // Handle errors
     if (event.type === "error") {
         const err = event;
-        broadcast(session, { type: "error", content: err.error?.message || "Unknown error" });
+        broadcast(session, {
+            type: "error",
+            content: err.error?.message || "Unknown error",
+        });
     }
 }
 // Broadcast message to all session clients

--- a/charts/claude/src/src/auth.ts
+++ b/charts/claude/src/src/auth.ts
@@ -1,0 +1,224 @@
+import { Express, Request, Response } from "express";
+import { WebSocketServer, WebSocket } from "ws";
+import { ServerResponse, IncomingMessage } from "http";
+import { Socket } from "net";
+import { createProxyMiddleware } from "http-proxy-middleware";
+import { spawn, ChildProcess } from "child_process";
+import path from "path";
+import fs from "fs";
+
+const HOME = process.env.HOME || "/home/user";
+const CLAUDE_BIN = path.join(HOME, ".npm-global", "bin", "claude");
+const TTYD_PORT = 7681;
+
+// Authentication state
+let authTtydProcess: ChildProcess | null = null;
+
+// WebSocket server for ttyd terminal proxy
+// Uses proper WebSocket-to-WebSocket proxying
+// IMPORTANT: Must accept "tty" subprotocol or ttyd client will reject the connection
+// IMPORTANT: Disable compression on server - browser may negotiate it but ttyd doesn't use it
+export const ttydWss = new WebSocketServer({
+  noServer: true,
+  perMessageDeflate: false,
+  handleProtocols: (protocols) => {
+    // Accept "tty" subprotocol if client requests it (ttyd always does)
+    if (protocols.has("tty")) {
+      return "tty";
+    }
+    return false;
+  },
+});
+
+ttydWss.on("connection", (clientWs: WebSocket) => {
+  console.log("Client WebSocket connected, connecting to ttyd...");
+
+  // Connect to ttyd using WebSocket protocol with "tty" subprotocol
+  // IMPORTANT: Disable perMessageDeflate to avoid compression mismatch with ttyd
+  const ttydWs = new WebSocket(`ws://localhost:${TTYD_PORT}/ws`, ["tty"], {
+    perMessageDeflate: false,
+  });
+
+  // Set binary type to match ttyd expectations
+  ttydWs.binaryType = "arraybuffer";
+
+  // Track connection state
+  let ttydConnected = false;
+
+  ttydWs.on("open", () => {
+    console.log("Connected to ttyd WebSocket");
+    ttydConnected = true;
+  });
+
+  ttydWs.on("message", (data: Buffer, isBinary: boolean) => {
+    // Forward ttyd messages to client, preserving binary/text type
+    if (clientWs.readyState === WebSocket.OPEN) {
+      clientWs.send(data, { binary: isBinary });
+    }
+  });
+
+  ttydWs.on("close", (code, reason) => {
+    console.log(`ttyd WebSocket closed: ${code} ${reason}`);
+    ttydConnected = false;
+    if (clientWs.readyState === WebSocket.OPEN) {
+      clientWs.close(code, reason.toString());
+    }
+  });
+
+  ttydWs.on("error", (err) => {
+    console.error("ttyd WebSocket error:", err);
+    ttydConnected = false;
+    if (clientWs.readyState === WebSocket.OPEN) {
+      clientWs.close(1011, "ttyd connection error");
+    }
+  });
+
+  clientWs.on("message", (data: Buffer, isBinary: boolean) => {
+    // Forward client messages to ttyd, preserving binary/text type
+    if (ttydWs.readyState === WebSocket.OPEN) {
+      ttydWs.send(data, { binary: isBinary });
+    }
+  });
+
+  clientWs.on("close", (code, reason) => {
+    console.log(`Client WebSocket closed: ${code} ${reason}`);
+    // Only close ttyd connection if it's open or connecting
+    if (ttydConnected || ttydWs.readyState === WebSocket.CONNECTING) {
+      ttydWs.close();
+    }
+  });
+
+  clientWs.on("error", (err) => {
+    console.error("Client WebSocket error:", err);
+    if (ttydConnected || ttydWs.readyState === WebSocket.CONNECTING) {
+      ttydWs.close();
+    }
+  });
+});
+
+// Handle WebSocket upgrade for ttyd
+export function handleTtydUpgrade(
+  req: IncomingMessage,
+  socket: Socket,
+  head: Buffer
+) {
+  console.log(`WebSocket upgrade request for ttyd: ${req.url}`);
+  ttydWss.handleUpgrade(req, socket, head, (ws) => {
+    ttydWss.emit("connection", ws, req);
+  });
+}
+
+// Setup auth routes on express app
+export function setupAuthRoutes(app: Express) {
+  // Auth status - check if Claude is authenticated
+  app.get("/api/auth/status", (_req, res) => {
+    const authFile = path.join(HOME, ".claude", "auth.json");
+    const authenticated = fs.existsSync(authFile);
+
+    res.json({
+      authenticated,
+      terminalActive: authTtydProcess !== null,
+    });
+  });
+
+  // Start auth terminal (spawn ttyd)
+  app.post("/api/auth/start", (_req, res) => {
+    // Clean up any existing auth process
+    if (authTtydProcess) {
+      console.log("Killing existing ttyd process...");
+      authTtydProcess.kill();
+      authTtydProcess = null;
+    }
+
+    try {
+      // Spawn ttyd with claude
+      // -W: Don't wait for initial connection (start immediately)
+      // -p: Port to listen on
+      // -t: Set terminal type
+      console.log(`Starting ttyd on port ${TTYD_PORT}...`);
+
+      // Run claude interactively - user types /login inside the session
+      const ttyd = spawn(
+        "ttyd",
+        [
+          "-p",
+          TTYD_PORT.toString(),
+          "-W", // Start immediately
+          "-t",
+          "titleFixed=Claude Authentication",
+          CLAUDE_BIN,
+        ],
+        {
+          cwd: HOME,
+          env: { ...process.env, HOME },
+          stdio: ["ignore", "pipe", "pipe"],
+        }
+      );
+
+      authTtydProcess = ttyd;
+
+      ttyd.stdout.on("data", (data) => {
+        console.log(`[ttyd stdout] ${data.toString().trim()}`);
+      });
+
+      ttyd.stderr.on("data", (data) => {
+        console.log(`[ttyd stderr] ${data.toString().trim()}`);
+      });
+
+      ttyd.on("close", (code) => {
+        console.log(`ttyd process exited with code ${code}`);
+        authTtydProcess = null;
+      });
+
+      ttyd.on("error", (err) => {
+        console.error(`ttyd process error: ${err}`);
+        authTtydProcess = null;
+      });
+
+      // Give ttyd a moment to start
+      setTimeout(() => {
+        res.json({
+          success: true,
+          message: "Terminal started. Connect to /api/auth/terminal",
+          terminalUrl: "/api/auth/terminal",
+        });
+      }, 500);
+    } catch (err) {
+      console.error("Failed to start ttyd:", err);
+      res.status(500).json({ error: "Failed to start terminal" });
+    }
+  });
+
+  // Stop auth terminal
+  app.post("/api/auth/stop", (_req, res) => {
+    if (authTtydProcess) {
+      console.log("Stopping ttyd process...");
+      authTtydProcess.kill();
+      authTtydProcess = null;
+    }
+    res.json({ success: true });
+  });
+
+  // Proxy to ttyd terminal (HTTP only - WebSocket handled separately)
+  const ttydProxy = createProxyMiddleware({
+    target: `http://localhost:${TTYD_PORT}`,
+    changeOrigin: true,
+    pathRewrite: {
+      "^/api/auth/terminal": "", // Remove prefix
+    },
+    on: {
+      error: (
+        err: Error,
+        _req: Request,
+        res: Response | ServerResponse | Socket
+      ) => {
+        console.error("Proxy error:", err);
+        if (res instanceof ServerResponse) {
+          res.writeHead(502);
+          res.end("Terminal not available");
+        }
+      },
+    },
+  });
+  app.use("/api/auth/terminal", ttydProxy);
+}

--- a/charts/claude/src/src/index.ts
+++ b/charts/claude/src/src/index.ts
@@ -1,12 +1,13 @@
-import express, { Request, Response } from "express";
+import express from "express";
 import { WebSocketServer, WebSocket } from "ws";
-import { createServer, ServerResponse, IncomingMessage } from "http";
+import { createServer, IncomingMessage } from "http";
 import { Socket } from "net";
-import { createProxyMiddleware } from "http-proxy-middleware";
 import { v4 as uuidv4 } from "uuid";
 import { spawn, ChildProcess } from "child_process";
 import path from "path";
 import fs from "fs";
+
+import { setupAuthRoutes, handleTtydUpgrade } from "./auth";
 
 const app = express();
 app.use(express.json());
@@ -17,14 +18,10 @@ const WORKTREES_DIR = path.join(HOME, ".claude-api", "worktrees"); // Persistent
 const SESSIONS_DIR = path.join(HOME, ".claude-api", "sessions");
 const STATIC_DIR = process.env.STATIC_DIR || "/app/public";
 const CLAUDE_BIN = path.join(HOME, ".npm-global", "bin", "claude");
-const TTYD_PORT = 7681;
 
 // Ensure directories exist
 fs.mkdirSync(SESSIONS_DIR, { recursive: true });
 fs.mkdirSync(WORKTREES_DIR, { recursive: true });
-
-// Authentication state
-let authTtydProcess: ChildProcess | null = null;
 
 interface Session {
   id: string;
@@ -44,117 +41,8 @@ app.get("/api/health", (_req, res) => {
   res.json({ status: "ok", sessions: sessions.size });
 });
 
-// Auth status - check if Claude is authenticated
-app.get("/api/auth/status", (_req, res) => {
-  const authFile = path.join(HOME, ".claude", "auth.json");
-  const authenticated = fs.existsSync(authFile);
-
-  res.json({
-    authenticated,
-    terminalActive: authTtydProcess !== null,
-  });
-});
-
-// Start auth terminal (spawn ttyd)
-app.post("/api/auth/start", (_req, res) => {
-  // Clean up any existing auth process
-  if (authTtydProcess) {
-    console.log("Killing existing ttyd process...");
-    authTtydProcess.kill();
-    authTtydProcess = null;
-  }
-
-  try {
-    // Spawn ttyd with claude /login
-    // -W: Don't wait for initial connection (start immediately)
-    // -p: Port to listen on
-    // -t: Set terminal type
-    console.log(`Starting ttyd on port ${TTYD_PORT}...`);
-
-    // Run claude interactively - user types /login inside the session
-    const ttyd = spawn(
-      "ttyd",
-      [
-        "-p",
-        TTYD_PORT.toString(),
-        "-W", // Start immediately
-        "-t",
-        "titleFixed=Claude Authentication",
-        CLAUDE_BIN,
-      ],
-      {
-        cwd: HOME,
-        env: { ...process.env, HOME },
-        stdio: ["ignore", "pipe", "pipe"],
-      },
-    );
-
-    authTtydProcess = ttyd;
-
-    ttyd.stdout.on("data", (data) => {
-      console.log(`[ttyd stdout] ${data.toString().trim()}`);
-    });
-
-    ttyd.stderr.on("data", (data) => {
-      console.log(`[ttyd stderr] ${data.toString().trim()}`);
-    });
-
-    ttyd.on("close", (code) => {
-      console.log(`ttyd process exited with code ${code}`);
-      authTtydProcess = null;
-    });
-
-    ttyd.on("error", (err) => {
-      console.error(`ttyd process error: ${err}`);
-      authTtydProcess = null;
-    });
-
-    // Give ttyd a moment to start
-    setTimeout(() => {
-      res.json({
-        success: true,
-        message: "Terminal started. Connect to /api/auth/terminal",
-        terminalUrl: "/api/auth/terminal",
-      });
-    }, 500);
-  } catch (err) {
-    console.error("Failed to start ttyd:", err);
-    res.status(500).json({ error: "Failed to start terminal" });
-  }
-});
-
-// Stop auth terminal
-app.post("/api/auth/stop", (_req, res) => {
-  if (authTtydProcess) {
-    console.log("Stopping ttyd process...");
-    authTtydProcess.kill();
-    authTtydProcess = null;
-  }
-  res.json({ success: true });
-});
-
-// Proxy to ttyd terminal (HTTP only - WebSocket handled separately)
-const ttydProxy = createProxyMiddleware({
-  target: `http://localhost:${TTYD_PORT}`,
-  changeOrigin: true,
-  pathRewrite: {
-    "^/api/auth/terminal": "", // Remove prefix
-  },
-  on: {
-    error: (
-      err: Error,
-      req: Request,
-      res: Response | ServerResponse | Socket,
-    ) => {
-      console.error("Proxy error:", err);
-      if (res instanceof ServerResponse) {
-        res.writeHead(502);
-        res.end("Terminal not available");
-      }
-    },
-  },
-});
-app.use("/api/auth/terminal", ttydProxy);
+// Setup auth routes (ttyd terminal for /login)
+setupAuthRoutes(app);
 
 // List sessions
 app.get("/api/sessions", (_req, res) => {
@@ -190,7 +78,7 @@ app.post("/api/sessions", (req, res) => {
 
   sessions.set(id, session);
   console.log(
-    `Session created: ${id}, Total sessions in memory: ${sessions.size}`,
+    `Session created: ${id}, Total sessions in memory: ${sessions.size}`
   );
 
   // Save session metadata
@@ -202,7 +90,7 @@ app.post("/api/sessions", (req, res) => {
       name: session.name,
       workdir: session.workdir,
       createdAt: session.createdAt,
-    }),
+    })
   );
 
   res.status(201).json({
@@ -270,103 +158,16 @@ app.get("*", (req, res) => {
 // Create HTTP server
 const server = createServer(app);
 
-// WebSocket server for ttyd terminal proxy
-// Uses proper WebSocket-to-WebSocket proxying (like ttyd-session-manager did with gorilla/websocket)
-// IMPORTANT: Must accept "tty" subprotocol or ttyd client will reject the connection
-// IMPORTANT: Disable compression on server - browser may negotiate it but ttyd doesn't use it
-const ttydWss = new WebSocketServer({
-  noServer: true,
-  perMessageDeflate: false,
-  handleProtocols: (protocols) => {
-    // Accept "tty" subprotocol if client requests it (ttyd always does)
-    if (protocols.has("tty")) {
-      return "tty";
-    }
-    return false;
-  },
-});
-
-ttydWss.on("connection", (clientWs: WebSocket) => {
-  console.log("Client WebSocket connected, connecting to ttyd...");
-
-  // Connect to ttyd using WebSocket protocol with "tty" subprotocol
-  // IMPORTANT: Disable perMessageDeflate to avoid compression mismatch with ttyd
-  const ttydWs = new WebSocket(`ws://localhost:${TTYD_PORT}/ws`, ["tty"], {
-    perMessageDeflate: false,
-  });
-
-  // Set binary type to match ttyd expectations
-  ttydWs.binaryType = "arraybuffer";
-
-  // Track connection state
-  let ttydConnected = false;
-
-  ttydWs.on("open", () => {
-    console.log("Connected to ttyd WebSocket");
-    ttydConnected = true;
-  });
-
-  ttydWs.on("message", (data: Buffer, isBinary: boolean) => {
-    // Forward ttyd messages to client, preserving binary/text type
-    if (clientWs.readyState === WebSocket.OPEN) {
-      clientWs.send(data, { binary: isBinary });
-    }
-  });
-
-  ttydWs.on("close", (code, reason) => {
-    console.log(`ttyd WebSocket closed: ${code} ${reason}`);
-    ttydConnected = false;
-    if (clientWs.readyState === WebSocket.OPEN) {
-      clientWs.close(code, reason.toString());
-    }
-  });
-
-  ttydWs.on("error", (err) => {
-    console.error("ttyd WebSocket error:", err);
-    ttydConnected = false;
-    if (clientWs.readyState === WebSocket.OPEN) {
-      clientWs.close(1011, "ttyd connection error");
-    }
-  });
-
-  clientWs.on("message", (data: Buffer, isBinary: boolean) => {
-    // Forward client messages to ttyd, preserving binary/text type
-    if (ttydWs.readyState === WebSocket.OPEN) {
-      ttydWs.send(data, { binary: isBinary });
-    }
-  });
-
-  clientWs.on("close", (code, reason) => {
-    console.log(`Client WebSocket closed: ${code} ${reason}`);
-    // Only close ttyd connection if it's open or connecting
-    if (ttydConnected || ttydWs.readyState === WebSocket.CONNECTING) {
-      ttydWs.close();
-    }
-  });
-
-  clientWs.on("error", (err) => {
-    console.error("Client WebSocket error:", err);
-    if (ttydConnected || ttydWs.readyState === WebSocket.CONNECTING) {
-      ttydWs.close();
-    }
-  });
-});
-
-// WebSocket server for streaming (also noServer to avoid duplicate upgrade handlers)
+// WebSocket server for session streaming
 const wss = new WebSocketServer({ noServer: true });
 
 // Handle ALL WebSocket upgrades in one place to avoid conflicts
-// When using { server, path } option, ws library registers its own upgrade handler
-// which can conflict with manual handlers and send duplicate responses
 server.on("upgrade", (req: IncomingMessage, socket: Socket, head: Buffer) => {
   const url = req.url || "";
-  console.log(`[UPGRADE] Request received: ${url}, headers: ${JSON.stringify(req.headers)}`);
+  console.log(`[UPGRADE] Request received: ${url}`);
 
   if (url.startsWith("/api/auth/terminal/ws")) {
-    console.log(`WebSocket upgrade request for ttyd: ${url}`);
-    ttydWss.handleUpgrade(req, socket, head, (ws) => {
-      ttydWss.emit("connection", ws, req);
-    });
+    handleTtydUpgrade(req, socket, head);
   } else if (url.startsWith("/ws")) {
     console.log(`WebSocket upgrade request for session: ${url}`);
     wss.handleUpgrade(req, socket, head, (ws) => {
@@ -402,7 +203,7 @@ wss.on("connection", (ws, req) => {
   const session = sessions.get(sessionId);
   if (!session) {
     console.log(
-      `Session ${sessionId} not found. Available sessions: ${Array.from(sessions.keys()).join(", ")}`,
+      `Session ${sessionId} not found. Available sessions: ${Array.from(sessions.keys()).join(", ")}`
     );
     ws.close(4004, "Session not found");
     return;
@@ -416,28 +217,34 @@ wss.on("connection", (ws, req) => {
   ws.on("message", (data) => {
     const message = JSON.parse(data.toString());
     console.log(
-      `Received message for session ${session.id}: ${JSON.stringify(message).substring(0, 100)}`,
+      `Received message for session ${session.id}: ${JSON.stringify(message).substring(0, 100)}`
     );
 
     if (message.type === "input") {
       if (session.isProcessing) {
-        console.log(`Session ${session.id} is already processing, queuing not implemented`);
-        ws.send(JSON.stringify({
-          type: "error",
-          content: "Please wait for the current response to complete",
-        }));
+        console.log(
+          `Session ${session.id} is already processing, queuing not implemented`
+        );
+        ws.send(
+          JSON.stringify({
+            type: "error",
+            content: "Please wait for the current response to complete",
+          })
+        );
         return;
       }
 
       // Run Claude in print mode with the user's message
-      console.log(`Running Claude for session ${session.id} with message: ${message.content.substring(0, 50)}...`);
+      console.log(
+        `Running Claude for session ${session.id} with message: ${message.content.substring(0, 50)}...`
+      );
       runClaudeMessage(session, message.content);
     }
   });
 
   ws.on("close", (code, reason) => {
     console.log(
-      `Session ${session.id} WebSocket closed: ${code} ${reason.toString()}`,
+      `Session ${session.id} WebSocket closed: ${code} ${reason.toString()}`
     );
     session.wsClients.delete(ws);
   });
@@ -455,18 +262,21 @@ wss.on("connection", (ws, req) => {
         sessionId: session.id,
         name: session.name,
         workdir: session.workdir,
-      }),
+      })
     );
     console.log(`Welcome message sent successfully to session ${session.id}`);
   } catch (err) {
-    console.error(`Failed to send welcome message to session ${session.id}:`, err);
+    console.error(
+      `Failed to send welcome message to session ${session.id}:`,
+      err
+    );
   }
 });
 
 // Run Claude in print mode with a single message (like cui does)
 function runClaudeMessage(session: Session, userMessage: string) {
   console.log(
-    `Running Claude for session ${session.id} in ${session.workdir}`,
+    `Running Claude for session ${session.id} in ${session.workdir}`
   );
   console.log(`Using Claude binary: ${CLAUDE_BIN}`);
 
@@ -478,25 +288,26 @@ function runClaudeMessage(session: Session, userMessage: string) {
 
   session.isProcessing = true;
 
-  // Build args for print mode
-  // -p: print mode (non-interactive)
-  // --output-format stream-json: structured JSONL output
-  // --verbose: required with stream-json
-  // --dangerously-skip-permissions: skip permission prompts
-  const args = [
-    "-p", // Print mode
-    "--output-format", "stream-json",
-    "--verbose",
-    "--dangerously-skip-permissions",
-  ];
+  // Build args based on whether this is a new conversation or resume
+  // cui pattern:
+  //   new: -p <message> --output-format stream-json --verbose
+  //   resume: --resume <sessionId> <message> --output-format stream-json --verbose
+  const args: string[] = [];
 
-  // If we have a previous Claude session, resume it
   if (session.claudeSessionId) {
+    // Resume existing conversation (no -p flag)
     args.push("--resume", session.claudeSessionId);
+    args.push(userMessage);
+  } else {
+    // New conversation with print mode
+    args.push("-p");
+    args.push(userMessage);
   }
 
-  // Add the user message as the last argument
-  args.push(userMessage);
+  // Common flags
+  args.push("--output-format", "stream-json");
+  args.push("--verbose");
+  args.push("--dangerously-skip-permissions");
 
   console.log(`Claude args: ${args.join(" ")}`);
 
@@ -519,7 +330,10 @@ function runClaudeMessage(session: Session, userMessage: string) {
     console.error(`Claude process error: ${err.message}`);
     session.isProcessing = false;
     session.process = undefined;
-    broadcast(session, { type: "error", content: `Process error: ${err.message}` });
+    broadcast(session, {
+      type: "error",
+      content: `Process error: ${err.message}`,
+    });
   });
 
   // Buffer for incomplete JSON lines
@@ -539,7 +353,7 @@ function runClaudeMessage(session: Session, userMessage: string) {
       try {
         const event = JSON.parse(line);
         handleClaudeEvent(session, event);
-      } catch (err) {
+      } catch {
         // Not valid JSON, might be regular output
         console.log(`Claude non-JSON output: ${line.substring(0, 100)}`);
       }
@@ -589,7 +403,9 @@ function handleClaudeEvent(session: Session, event: Record<string, unknown>) {
 
   // Forward assistant messages to clients
   if (event.type === "assistant") {
-    const msg = event as { message?: { content?: Array<{ type: string; text?: string }> } };
+    const msg = event as {
+      message?: { content?: Array<{ type: string; text?: string }> };
+    };
     if (msg.message?.content) {
       for (const block of msg.message.content) {
         if (block.type === "text" && block.text) {
@@ -610,7 +426,10 @@ function handleClaudeEvent(session: Session, event: Record<string, unknown>) {
   // Handle errors
   if (event.type === "error") {
     const err = event as { error?: { message?: string } };
-    broadcast(session, { type: "error", content: err.error?.message || "Unknown error" });
+    broadcast(session, {
+      type: "error",
+      content: err.error?.message || "Unknown error",
+    });
   }
 }
 
@@ -635,7 +454,7 @@ function saveSession(session: Session) {
       workdir: session.workdir,
       createdAt: session.createdAt,
       claudeSessionId: session.claudeSessionId,
-    }),
+    })
   );
 }
 
@@ -649,7 +468,7 @@ function loadSessions() {
 
     try {
       const data = JSON.parse(
-        fs.readFileSync(path.join(SESSIONS_DIR, file), "utf-8"),
+        fs.readFileSync(path.join(SESSIONS_DIR, file), "utf-8")
       );
       sessions.set(data.id, {
         id: data.id,


### PR DESCRIPTION
## Summary
Multiple fixes for Claude session management:

1. **Persist worktrees on PVC** - Move from `/tmp` to `~/.claude-api/worktrees`
2. **Fix conversation resume** - Use `--resume` without `-p` flag (matches cui pattern)
3. **Refactor auth module** - Extract ttyd auth logic into separate `auth.ts`

## Changes

### Worktree persistence
- Worktrees now stored at `~/.claude-api/worktrees` (on PVC)
- Session context, files, and git state persist across pod restarts

### Resume fix (cui pattern)
- **New conversation**: `-p <message> --output-format stream-json --verbose`
- **Resume**: `--resume <sessionId> <message> --output-format stream-json --verbose`
- No `-p` flag when resuming existing conversations

### Code refactor
```
src/
├── auth.ts    # ttyd authentication (routes + WebSocket proxy)
└── index.ts   # Sessions + Claude spawning (cleaner)
```

## Test plan
- [ ] Deploy and verify new sessions work
- [ ] Send message, verify response
- [ ] Send follow-up, verify conversation context maintained
- [ ] Restart pod, verify sessions persist

🤖 Generated with [Claude Code](https://claude.com/claude-code)