### PR TITLE
fix(claude): skip npm scripts during CUI install

### DIFF
--- a/charts/claude/image/start.sh
+++ b/charts/claude/image/start.sh
@@ -33,10 +33,10 @@ fi
 # Build and start CUI server (new frontend with built-in API)
 cd /app/frontend/charts/claude/frontend
 
-# Install dependencies if needed
+# Install dependencies if needed (--ignore-scripts skips husky/prepare hooks)
 if [ ! -d "node_modules" ]; then
 	echo "Installing CUI server dependencies..."
-	npm install
+	npm install --ignore-scripts
 else
 	echo "CUI server dependencies already installed"
 fi


### PR DESCRIPTION
## Summary
Fixes 503 error caused by npm install failing due to husky prepare script.

## Problem
```
> cui-server@0.6.3 prepare
> husky

sh: husky: not found
npm error code 127
```

Husky is a git hooks tool (dev dependency) that isn't available in the production container.

## Solution
Use `npm install --ignore-scripts` to skip prepare/postinstall hooks.

## Test plan
- [ ] Deploy and verify CUI server starts
- [ ] Verify frontend loads at https://claude.jomcgi.dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)