### PR TITLE
fix(claude): convert 'default' permissionMode to undefined in ConversationView

### DIFF
--- a/charts/claude/frontend/src/web/chat/components/ConversationView/ConversationView.tsx
+++ b/charts/claude/frontend/src/web/chat/components/ConversationView/ConversationView.tsx
@@ -196,8 +196,10 @@ export function ConversationView() {
         resumedSessionId: sessionId,
         initialPrompt: message,
         workingDirectory: workingDirectory || currentWorkingDirectory,
-        model,
-        permissionMode,
+        model: model === "default" ? undefined : model,
+        // Convert "default" to undefined to let server use DEFAULT_PERMISSION_MODE env var
+        permissionMode:
+          permissionMode === "default" ? undefined : permissionMode,
       });
 
       // Navigate immediately to the new session


### PR DESCRIPTION
## Summary
ConversationView.tsx was passing `permissionMode: "default"` directly to the API, which overrode the server's `DEFAULT_PERMISSION_MODE` env var.

Now converts `"default"` to `undefined` (matching Home.tsx behavior), allowing the server default (`bypassPermissions`) to take effect.

## Test plan
- [ ] Resume a conversation
- [ ] Verify no permission prompts appear (since server default is `bypassPermissions`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)