### PR TITLE
fix(claude): set streamingId on follow-up messages

### DIFF
--- a/charts/claude/frontend/src/web/chat/components/ConversationView/ConversationView.tsx
+++ b/charts/claude/frontend/src/web/chat/components/ConversationView/ConversationView.tsx
@@ -202,7 +202,11 @@ export function ConversationView() {
           permissionMode === "default" ? undefined : permissionMode,
       });
 
-      // Navigate immediately to the new session
+      // Set the new streamingId to connect to the response stream
+      // This is critical for receiving Claude's response after resume
+      setStreamingId(response.streamingId);
+
+      // Navigate to the session (may be same URL for resume, but ensures URL is correct)
       navigate(`/c/${response.sessionId}`);
     } catch (err: any) {
       setError(err.message || "Failed to send message");


### PR DESCRIPTION
## Summary
Follow-up messages in conversations weren't receiving Claude's response.

**Root cause:** When sending a follow-up message, the component was only navigating to the session URL without setting the new `streamingId`. Since the `sessionId` is the same for resumed conversations, the navigation didn't trigger a reconnection, and Claude's response was never received.

**Fix:** Explicitly set `streamingId` from the API response before navigating, ensuring the `useStreaming` hook connects to the new response stream.

## Test plan
- [ ] Open an existing conversation
- [ ] Send a follow-up message
- [ ] Verify Claude's response appears in the chat

🤖 Generated with [Claude Code](https://claude.com/claude-code)