### PR TITLE
feat(claude): improve error surfacing in frontend

### DIFF
--- a/charts/claude/frontend/src/cui-server.ts
+++ b/charts/claude/frontend/src/cui-server.ts
@@ -675,8 +675,21 @@ export class CUIServer {
         });
       }
 
-      if (code === 0) {
-        // Session completion notification removed
+      // If process exited with non-zero code, broadcast error to clients before closing
+      if (code !== 0) {
+        const errorEvent: StreamEvent = {
+          type: "error" as const,
+          error: `Claude process exited unexpectedly (exit code: ${code}). Check server logs for details.`,
+          streamingId: streamingId,
+          timestamp: new Date().toISOString(),
+        };
+
+        this.logger.debug("Broadcasting process exit error to clients", {
+          streamingId,
+          exitCode: code,
+        });
+
+        this.streamManager.broadcast(streamingId, errorEvent);
       }
 
       this.streamManager.closeSession(streamingId);

--- a/charts/claude/frontend/src/web/chat/components/ConversationView/ConversationView.tsx
+++ b/charts/claude/frontend/src/web/chat/components/ConversationView/ConversationView.tsx
@@ -3,7 +3,7 @@ import { useParams, useLocation, useNavigate } from "react-router-dom";
 import { MessageList } from "../MessageList/MessageList";
 import { Composer, ComposerRef } from "@/web/chat/components/Composer";
 import { ConversationHeader } from "../ConversationHeader/ConversationHeader";
-import { api } from "../../services/api";
+import { api, ApiServiceError } from "../../services/api";
 import { useStreaming, useConversationMessages } from "../../hooks";
 import type {
   ChatMessage,
@@ -11,6 +11,17 @@ import type {
   ConversationMessage,
   ConversationSummary,
 } from "../../types";
+
+// Helper to format errors with full details
+function formatError(err: unknown): string {
+  if (err instanceof ApiServiceError) {
+    return err.toDisplayString();
+  }
+  if (err instanceof Error) {
+    return err.message;
+  }
+  return String(err);
+}
 
 export function ConversationView() {
   const { sessionId } = useParams<{ sessionId: string }>();
@@ -158,8 +169,8 @@ export function ConversationView() {
             }
           }
         }
-      } catch (err: any) {
-        setError(err.message || "Failed to load conversation");
+      } catch (err: unknown) {
+        setError(formatError(err) || "Failed to load conversation");
       } finally {
         setIsLoading(false);
 
@@ -208,8 +219,8 @@ export function ConversationView() {
 
       // Navigate to the session (may be same URL for resume, but ensures URL is correct)
       navigate(`/c/${response.sessionId}`);
-    } catch (err: any) {
-      setError(err.message || "Failed to send message");
+    } catch (err: unknown) {
+      setError(formatError(err) || "Failed to send message");
     }
   };
 
@@ -227,9 +238,9 @@ export function ConversationView() {
       setStreamingId(null);
 
       // Streaming has stopped
-    } catch (err: any) {
+    } catch (err: unknown) {
       console.error("Failed to stop conversation:", err);
-      setError(err.message || "Failed to stop conversation");
+      setError(formatError(err) || "Failed to stop conversation");
     }
   };
 
@@ -245,9 +256,9 @@ export function ConversationView() {
       await api.sendPermissionDecision(requestId, { action, denyReason });
       // Clear the permission request after successful decision
       clearPermissionRequest();
-    } catch (err: any) {
+    } catch (err: unknown) {
       console.error("Failed to send permission decision:", err);
-      setError(err.message || "Failed to send permission decision");
+      setError(formatError(err) || "Failed to send permission decision");
     } finally {
       setIsPermissionDecisionLoading(false);
     }
@@ -341,11 +352,38 @@ export function ConversationView() {
 
       {error && (
         <div
-          className="bg-red-500/10 border-b border-red-500 text-red-600 dark:text-red-400 px-4 py-2 text-sm text-center animate-in slide-in-from-top duration-300"
+          className="bg-red-500/10 border-b border-red-500 text-red-600 dark:text-red-400 px-4 py-3 animate-in slide-in-from-top duration-300"
           role="alert"
           aria-label="Error message"
         >
-          {error}
+          <div className="max-w-3xl mx-auto flex items-start justify-between gap-3">
+            <div className="flex-1 min-w-0">
+              <div className="font-medium text-sm mb-1">Error</div>
+              <div className="text-sm whitespace-pre-wrap break-words font-mono">
+                {error}
+              </div>
+            </div>
+            <button
+              onClick={() => setError(null)}
+              className="shrink-0 p-1 hover:bg-red-500/20 rounded transition-colors"
+              aria-label="Dismiss error"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <line x1="18" y1="6" x2="6" y2="18" />
+                <line x1="6" y1="6" x2="18" y2="18" />
+              </svg>
+            </button>
+          </div>
         </div>
       )}
 

--- a/charts/claude/frontend/src/web/chat/components/Home/Home.tsx
+++ b/charts/claude/frontend/src/web/chat/components/Home/Home.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useRef } from "react";
 import { useNavigate } from "react-router-dom";
 import { useConversations } from "../../contexts/ConversationsContext";
-import { api } from "../../services/api";
+import { api, ApiServiceError } from "../../services/api";
 import { Header } from "./Header";
 import { Composer, ComposerRef } from "@/web/chat/components/Composer";
 import { TaskTabs } from "./TaskTabs";
@@ -131,10 +131,14 @@ export function Home() {
       navigate(`/c/${response.sessionId}`);
     } catch (error) {
       console.error("Failed to start conversation:", error);
-      // You might want to show an error message to the user here
-      alert(
-        `Failed to start conversation: ${error instanceof Error ? error.message : "Unknown error"}`,
-      );
+      // Show detailed error message to user
+      const errorMessage =
+        error instanceof ApiServiceError
+          ? error.toDisplayString()
+          : error instanceof Error
+            ? error.message
+            : "Unknown error";
+      alert(`Failed to start conversation: ${errorMessage}`);
       setIsSubmitting(false);
     }
   };

--- a/charts/claude/frontend/src/web/chat/services/api.ts
+++ b/charts/claude/frontend/src/web/chat/services/api.ts
@@ -19,6 +19,32 @@ type GeminiHealthResponse = {
   apiKeyValid: boolean;
 };
 
+// Custom error class that includes the error code from the API
+export class ApiServiceError extends Error {
+  code?: string;
+  statusCode?: number;
+
+  constructor(message: string, code?: string, statusCode?: number) {
+    super(message);
+    this.name = "ApiServiceError";
+    this.code = code;
+    this.statusCode = statusCode;
+  }
+
+  // Format error for display with all available details
+  toDisplayString(): string {
+    const parts: string[] = [];
+    if (this.code) {
+      parts.push(`[${this.code}]`);
+    }
+    parts.push(this.message);
+    if (this.statusCode && this.statusCode !== 500) {
+      parts.push(`(HTTP ${this.statusCode})`);
+    }
+    return parts.join(" ");
+  }
+}
+
 class ApiService {
   private baseUrl = "";
 
@@ -55,15 +81,26 @@ class ApiService {
 
       if (!response.ok) {
         if (response.status === 401) {
-          throw new Error("Unauthorized");
+          throw new ApiServiceError("Unauthorized", "UNAUTHORIZED", 401);
         }
-        throw new Error((data as ApiError).error || `HTTP ${response.status}`);
+        // Extract error details from response
+        const apiError = data as ApiError & { code?: string };
+        const errorMessage = apiError.error || `HTTP ${response.status}`;
+        const errorCode = apiError.code;
+        throw new ApiServiceError(errorMessage, errorCode, response.status);
       }
 
       return data;
     } catch (error) {
-      // console.error(`[API Error] ${fullUrl}:`, error);
-      throw error;
+      // Re-throw ApiServiceError as-is
+      if (error instanceof ApiServiceError) {
+        throw error;
+      }
+      // Wrap other errors
+      throw new ApiServiceError(
+        error instanceof Error ? error.message : String(error),
+        "UNKNOWN_ERROR",
+      );
     }
   }
 


### PR DESCRIPTION
## Summary
- Broadcast error events to streaming clients when Claude process exits with non-zero code
- Add ApiServiceError class with error code support for better error formatting
- Improve error display in ConversationView with prominent banner and dismiss button
- Show detailed error codes like `[CLAUDE_PROCESS_EXITED_EARLY]` to help debugging

## Problem
When sending a message, if the Claude process crashes or exits early, users see either:
- Generic "Failed to send message" error
- Nothing at all (the stream just closes silently)

This made it difficult to debug issues because the actual error (like exit code, error code) was hidden from the user.

## Solution
1. **Backend**: When Claude process exits with non-zero code, broadcast an explicit error event to streaming clients before closing the session
2. **Frontend**: 
   - New `ApiServiceError` class that captures error codes and HTTP status from API responses
   - `toDisplayString()` method formats errors as `[ERROR_CODE] message`
   - Improved error banner with header, monospace text, and dismiss button
   - Changed error handlers from `any` to `unknown` for type safety

## Test plan
- [ ] Send a message and verify normal flow still works
- [ ] Trigger an error (e.g., by having Claude process crash) and verify error banner shows with details
- [ ] Click dismiss button to clear error
- [ ] Verify Home page shows detailed errors on conversation start failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)