### PR TITLE
fix(claude): correct argument order for --resume flag

### DIFF
--- a/charts/claude/frontend/src/services/claude-process-manager.ts
+++ b/charts/claude/frontend/src/services/claude-process-manager.ts
@@ -741,11 +741,14 @@ export class ClaudeProcessManager extends EventEmitter {
         config.message.substring(0, 50) +
         (config.message.length > 50 ? "..." : ""),
     });
-    const args = this.buildBaseArgs();
+    // For resume, --resume must come BEFORE -p
+    // Correct order: claude --resume <sessionId> -p "<message>" ...
+    const args: string[] = [];
 
     args.push(
       "--resume",
       config.sessionId, // Resume existing session
+      "-p", // Print mode flag
       config.message, // Message to continue with
       "--output-format",
       "stream-json", // JSONL output format


### PR DESCRIPTION
## Summary
Fix incorrect CLI argument order when resuming conversations.

## Problem
When resuming a conversation, the spawn args were:
```
claude -p --resume <sessionId> <message>
```

The `-p` flag expects a prompt immediately after it, so `--resume` was being interpreted as the prompt text, not as a flag. This caused resumed conversations to fail silently.

## Solution
Correct the argument order:
```
claude --resume <sessionId> -p <message>
```

## Root cause
`buildResumeArgs()` was calling `buildBaseArgs()` which adds `-p` first, then pushing `--resume` after. Fixed by not using `buildBaseArgs()` for resume and manually constructing the correct order.

## Test plan
- [ ] Start a new conversation and verify it works
- [ ] Send a follow-up message to resume the conversation
- [ ] Verify the response appears correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)