### PR TITLE
fix(claude): buffer close event when no clients connected

### DIFF
--- a/charts/claude/frontend/src/services/stream-manager.ts
+++ b/charts/claude/frontend/src/services/stream-manager.ts
@@ -275,10 +275,27 @@ export class StreamManager extends EventEmitter {
    * Close all connections for a session
    */
   closeSession(streamingId: string): void {
-    // Clean up message buffer for this session
-    this.messageBuffer.delete(streamingId);
-
     const clients = this.clients.get(streamingId);
+
+    // If there are clients connected, they'll receive the close event
+    // and we can clear the buffer since messages were delivered
+    if (clients && clients.size > 0) {
+      this.messageBuffer.delete(streamingId);
+    } else {
+      // No clients connected - buffer the close event so late-connecting
+      // clients can receive all messages including the close
+      this.bufferMessage(streamingId, {
+        type: "closed",
+        streamingId: streamingId,
+        timestamp: new Date().toISOString(),
+      });
+      this.logger.info("Session closed with no clients - buffered close event", {
+        streamingId,
+        bufferSize: this.messageBuffer.get(streamingId)?.length || 0,
+      });
+      return; // Don't proceed with client cleanup since there are none
+    }
+
     if (!clients) return;
 
     const closeEvent: StreamEvent = {


### PR DESCRIPTION
## Summary

This PR fixes two related issues preventing the frontend from receiving streamed responses:

### Backend: Buffer close event when no clients connected
- Fixes race condition where `closeSession()` cleared the message buffer before late-connecting clients could receive messages
- Now only clears buffer if clients are connected (they received the messages)
- If no clients connected, buffers the close event so late-connecting clients receive all messages

### Frontend: Pass streamingId through navigation state  
- When navigating to a new/resumed conversation, the old component was setting `streamingId` in state, but navigation would unmount it
- The new component instance started with `streamingId=null` and never connected to the stream
- Now passes `streamingId` through React Router navigation state
- ConversationView initializes from navigation state on mount
- Home component also updated to pass streamingId when starting new conversations

## Problem

After sending a message (new or resumed), the frontend never connected to receive the response because:

1. **Backend**: `closeSession()` was clearing the buffer before clients connected
2. **Frontend**: Navigation to a new session unmounted the component, losing the streamingId state

Server logs showed:
```
Buffered message eventType="assistant" bufferSize=1
Buffered message eventType="result" bufferSize=2
Active session unregistered  <- No client ever connected
Session closed with no clients - buffered close event
```

## Solution

1. **Backend** (`stream-manager.ts`): Check if clients exist before deciding what to do with the buffer
2. **Frontend** (`ConversationView.tsx`, `Home.tsx`): Pass streamingId through navigation state so new component instances can connect immediately

## Test plan
- [ ] Send a message and verify response appears in UI
- [ ] Resume a conversation and verify response appears
- [ ] Check logs show "Flushing buffered messages" when client connects
- [ ] Check logs show client connection after navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)