### PR TITLE
perf(gh-arc-runners): add per-runner PVC for Bazel cache

### DIFF
--- a/overlays/prod/gh-arc-runners/values.yaml
+++ b/overlays/prod/gh-arc-runners/values.yaml
@@ -1,12 +1,6 @@
 # Self-hosted GitHub Actions runners
 # Supports Docker-in-Docker for container builds
 
-# Bazel cache configured via volumeClaimTemplates in gha-runner-scale-set.template
-# Each runner gets its own RWO PVC (avoids Longhorn RWX I/O errors)
-# Shared PVC approach disabled - see volumeClaimTemplates below
-bazelCache:
-  enabled: false
-
 secret:
   # Create the secret via OnePasswordItem
   create: true


### PR DESCRIPTION
Use volumeClaimTemplates to give each runner its own RWO PVC, avoiding the Longhorn RWX I/O errors from the shared PVC approach.

- Add 50Gi bazel-cache PVC per runner via volumeClaimTemplates
- Mount cache at /home/runner/.cache/bazel
- Reduce maxRunners from 10 to 2 for controlled scaling
- Each runner maintains its own warm cache for faster builds