### PR TITLE
Enable ArgoCD image updater for Claude deployment

### DIFF
--- a/charts/claude/values.yaml
+++ b/charts/claude/values.yaml
@@ -4,8 +4,8 @@
 ## Container image
 image:
   repository: ghcr.io/jomcgi/homelab/charts/claude
-  pullPolicy: Always  # Always pull since we use mutable 'main' tag
-  tag: "main"
+  pullPolicy: IfNotPresent  # Use IfNotPresent since image updater uses immutable tags
+  tag: "main"  # Default tag, overridden by ArgoCD Image Updater
 
 imagePullSecrets:
   - name: ghcr-pull-secret

--- a/overlays/dev/claude/application.yaml
+++ b/overlays/dev/claude/application.yaml
@@ -3,6 +3,15 @@ kind: Application
 metadata:
   name: claude
   namespace: argocd
+  annotations:
+    # ArgoCD Image Updater configuration
+    # Track the Claude image and update on new builds from main
+    argocd-image-updater.argoproj.io/image-list: claude=ghcr.io/jomcgi/homelab/charts/claude
+    argocd-image-updater.argoproj.io/claude.update-strategy: newest-build
+    argocd-image-updater.argoproj.io/claude.allow-tags: regexp:^\d{4}\.\d{2}\.\d{2}\.\d{2}\.\d{2}\.\d{2}-[0-9a-f]{7}$
+    argocd-image-updater.argoproj.io/claude.helm.image-name: image.repository
+    argocd-image-updater.argoproj.io/claude.helm.image-tag: image.tag
+    argocd-image-updater.argoproj.io/write-back-method: argocd
 spec:
   project: default
   source:


### PR DESCRIPTION
Add image updater annotations to track the Claude container image and automatically update when new builds are pushed from main. Uses the same date-based tag pattern as other services in the cluster.

Also updates pullPolicy to IfNotPresent since image tags will now be immutable version tags instead of the mutable 'main' tag.