### PR TITLE
fix(gh-arc-runners): remove unsupported volumeClaimTemplates

### DIFF
--- a/overlays/prod/gh-arc-runners/values.yaml
+++ b/overlays/prod/gh-arc-runners/values.yaml
@@ -67,22 +67,6 @@ gha-runner-scale-set:
             memory: 8Gi
             ephemeral-storage: 100Gi
 
-        volumeMounts:
-        - name: bazel-cache
-          mountPath: /home/runner/.cache/bazel
-
-      # Per-runner persistent cache (like StatefulSet volumeClaimTemplates)
-      # Each runner pod gets its own RWO PVC for Bazel cache
-      volumeClaimTemplates:
-      - metadata:
-          name: bazel-cache
-        spec:
-          accessModes: ["ReadWriteOnce"]
-          storageClassName: longhorn
-          resources:
-            requests:
-              storage: 50Gi
-
   listenerTemplate:
     spec:
       securityContext:


### PR DESCRIPTION
The gha-runner-scale-set chart v0.9.3 does not support volumeClaimTemplates.
Attempting to use them causes the chart to ignore the configuration, resulting
in pod failures when volumeMounts references a non-existent volume.

This was causing CI jobs to queue indefinitely because runner pods could not
start. Remove the unsupported configuration to unblock CI.

Bazel will use BuildBuddy remote cache instead of local persistent cache.