### PR TITLE
fix(claude): add ImageUpdater CRD for automatic image updates

### DIFF
--- a/overlays/dev/claude/imageupdater.yaml
+++ b/overlays/dev/claude/imageupdater.yaml
@@ -1,0 +1,26 @@
+apiVersion: argocd-image-updater.argoproj.io/v1alpha1
+kind: ImageUpdater
+metadata:
+  name: claude
+  namespace: argocd
+spec:
+  applicationRefs:
+  - images:
+    - alias: claude
+      commonUpdateSettings:
+        allowTags: regexp:^\d{4}\.\d{2}\.\d{2}\.\d{2}\.\d{2}\.\d{2}-[0-9a-f]{7}$
+        updateStrategy: newest-build
+        forceUpdate: false
+      imageName: ghcr.io/jomcgi/homelab/charts/claude
+      manifestTargets:
+        helm:
+          name: image.repository
+          tag: image.tag
+    namePattern: claude
+  namespace: argocd
+  writeBackConfig:
+    method: git:secret:argocd/argocd-image-updater-token
+    gitConfig:
+      repository: https://github.com/jomcgi/homelab.git
+      branch: main
+      writeBackTarget: helmvalues:overlays/dev/claude/values.yaml

--- a/overlays/dev/claude/kustomization.yaml
+++ b/overlays/dev/claude/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 
 resources:
   - ./application.yaml
+  - ./imageupdater.yaml


### PR DESCRIPTION
ArgoCD Image Updater only processes ImageUpdater CRDs, not just
annotations. Claude was using annotation-based config but missing
the CRD resource, so it was never being processed by the updater.

This adds the ImageUpdater CRD that:
- Watches ghcr.io/jomcgi/homelab/charts/claude for new images
- Matches timestamp tags (YYYY.MM.DD.HH.MM.SS-shortsha)
- Uses newest-build strategy to select latest
- Writes back to overlays/dev/claude/values.yaml via Git