### PR TITLE
fix(cloudflare-operator): correct ImageUpdater config for automatic updates

### DIFF
--- a/overlays/dev/cloudflare-operator/imageupdater.yaml
+++ b/overlays/dev/cloudflare-operator/imageupdater.yaml
@@ -9,7 +9,7 @@ spec:
     - alias: operator
       commonUpdateSettings:
         allowTags: regexp:^\d{4}\.\d{2}\.\d{2}\.\d{2}\.\d{2}\.\d{2}-[0-9a-f]{7}$
-        updateStrategy: alphabetical
+        updateStrategy: newest-build
         forceUpdate: false
       imageName: ghcr.io/jomcgi/homelab/operators/cloudflare
       manifestTargets:
@@ -23,4 +23,4 @@ spec:
     gitConfig:
       repository: https://github.com/jomcgi/homelab.git
       branch: main
-      writeBackTarget: helmvalues:overlays/dev/cloudflare-operator/values.yaml
+      writeBackTarget: helmvalues:../../../../overlays/dev/cloudflare-operator/values.yaml


### PR DESCRIPTION
## Summary
- Change `updateStrategy` from `alphabetical` to `newest-build` to properly sort timestamp-based image tags
- Fix `writeBackTarget` path to use correct relative path from chart location

## Problem
The ImageUpdater was configured incorrectly, preventing automatic image tag commits to Git. This caused the cloudflare-operator to stay on version `4e3a488` (from Nov 20) instead of updating to the latest `a5e8fa6` (with sextant state machine integration).

The issues:
1. `updateStrategy: alphabetical` doesn't correctly sort `YYYY.MM.DD.HH.MM.SS-hash` tags
2. `writeBackTarget` path was missing the `../../../../` prefix needed to navigate from `operators/cloudflare/helm/cloudflare-operator/` to the overlay values file

## Test plan
- [ ] Merge PR
- [ ] Verify ImageUpdater commits new image tag to `overlays/dev/cloudflare-operator/values.yaml`
- [ ] Confirm cloudflare-operator pod restarts with new image

🤖 Generated with [Claude Code](https://claude.com/claude-code)