### PR TITLE
fix(cloudflare-operator): clear ManagedFields in SSA patch

### DIFF
--- a/operators/cloudflare/internal/statemachine/cloudflare_tunnel_status.go
+++ b/operators/cloudflare/internal/statemachine/cloudflare_tunnel_status.go
@@ -47,6 +47,9 @@ func SSAPatch(state CloudflareTunnelState) (client.Patch, error) {
 	// Clear everything except metadata identifiers and status
 	obj.Spec = v1.CloudflareTunnelSpec{}
 
+	// Clear ManagedFields - SSA patches must not include managedFields
+	obj.ManagedFields = nil
+
 	// Apply the state to status
 	applyStateToStatus(state, &obj.Status)
 


### PR DESCRIPTION
## Summary
- Clear `managedFields` from the object before marshaling SSA patch

## Problem
The CloudflareTunnel controller was failing with:
```
error": "metadata.managedFields must be nil"
```

This happened because `DeepCopy()` copies all metadata including `managedFields`, but SSA patches must not include `managedFields`. The Kubernetes API server rejects patches that include this field.

This was blocking the entire reconciliation flow:
1. CloudflareTunnel controller fails to update status
2. Gateway controller waits for CloudflareTunnel `secretName` to be set
3. HTTPRoute controller can't proceed without Gateway annotations
4. Routes never get programmed

## Test plan
- [ ] Merge PR and wait for new image to deploy
- [ ] Verify CloudflareTunnel status shows `phase` and `secretName`
- [ ] Verify HTTPRoutes get programmed

🤖 Generated with [Claude Code](https://claude.com/claude-code)