### PR TITLE
fix(cloudflare-operator): add missing status fields to CRD schema

### DIFF
--- a/operators/cloudflare/helm/cloudflare-operator/crds/tunnels.cloudflare.io_cloudflaretunnels.yaml
+++ b/operators/cloudflare/helm/cloudflare-operator/crds/tunnels.cloudflare.io_cloudflaretunnels.yaml
@@ -14,7 +14,20 @@ spec:
     singular: cloudflaretunnel
   scope: Namespaced
   versions:
-  - name: v1
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .status.tunnelId
+      name: TunnelID
+      type: string
+    - jsonPath: .status.active
+      name: Active
+      type: boolean
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
     schema:
       openAPIV3Schema:
         description: CloudflareTunnel is the Schema for the cloudflaretunnels API.
@@ -132,14 +145,42 @@ spec:
                   - type
                   type: object
                 type: array
+              errorMessage:
+                description: ErrorMessage contains the error that caused the Failed state
+                type: string
+              lastState:
+                description: LastState stores the state before transitioning to Failed
+                type: string
               observedGeneration:
                 description: ObservedGeneration reflects the generation of the most
                   recently observed spec
                 format: int64
                 type: integer
+              observedPhase:
+                description: ObservedPhase stores the phase value when it was unrecognized (for Unknown state)
+                type: string
+              phase:
+                description: Phase is the current state machine phase
+                enum:
+                - Pending
+                - CreatingTunnel
+                - CreatingSecret
+                - ConfiguringIngress
+                - Ready
+                - Failed
+                - DeletingTunnel
+                - Deleted
+                - Unknown
+                type: string
               ready:
                 description: Ready indicates if the tunnel is ready for use
                 type: boolean
+              retryCount:
+                description: RetryCount tracks retry attempts from Failed state
+                type: integer
+              secretName:
+                description: SecretName is the name of the Secret containing the tunnel credentials
+                type: string
               tunnelId:
                 description: TunnelID is the Cloudflare tunnel ID
                 type: string


### PR DESCRIPTION
## Summary
- Adds missing status fields to CloudflareTunnel CRD that were added by the sextant state machine integration
- Fields added: `phase`, `secretName`, `errorMessage`, `lastState`, `retryCount`, `observedPhase`
- Adds `additionalPrinterColumns` for better `kubectl get cloudflaretunnels` output

## Context
The SSA patch was failing with error:
```
.status.phase: field not declared in schema
```

The Go types in `cloudflaretunnel_types.go` have these fields but the CRD was never regenerated after the sextant integration.

## Test plan
- [ ] ArgoCD syncs the CRD update to the cluster
- [ ] CloudflareTunnel status updates succeed (no schema validation errors)
- [ ] `kubectl get cloudflaretunnels` shows Phase, TunnelID, Active, Age columns

🤖 Generated with [Claude Code](https://claude.com/claude-code)