### PR TITLE
feat(stargazer): add real data API with Cloudflare CDN caching

### DIFF
--- a/charts/stargazer/templates/configmap-nginx.yaml
+++ b/charts/stargazer/templates/configmap-nginx.yaml
@@ -32,11 +32,19 @@ data:
             return 200 '{"status":"healthy"}';
         }
 
-        # API endpoints
+        # API endpoints with caching headers for Cloudflare CDN
         location /api/best {
             alias /data/output/best_locations.json;
             add_header Content-Type application/json;
             add_header Access-Control-Allow-Origin *;
+            # Cache for 1 hour (data updates every 6 hours)
+            add_header Cache-Control "public, max-age=3600, s-maxage=3600";
+            add_header CDN-Cache-Control "max-age=3600";
+            add_header X-Content-Type-Options "nosniff";
+
+            # Add last-modified header based on file modification time
+            add_header Last-Modified $date_gmt;
+            etag on;
 
             # Fallback if file doesn't exist
             try_files $uri /api/empty.json;
@@ -46,6 +54,14 @@ data:
             alias /data/output/forecasts_scored.json;
             add_header Content-Type application/json;
             add_header Access-Control-Allow-Origin *;
+            # Cache for 1 hour
+            add_header Cache-Control "public, max-age=3600, s-maxage=3600";
+            add_header CDN-Cache-Control "max-age=3600";
+            add_header X-Content-Type-Options "nosniff";
+
+            # Add last-modified header based on file modification time
+            add_header Last-Modified $date_gmt;
+            etag on;
 
             # Fallback if file doesn't exist
             try_files $uri /api/empty.json;

--- a/charts/stargazer/templates/httproute.yaml
+++ b/charts/stargazer/templates/httproute.yaml
@@ -13,7 +13,23 @@ spec:
   hostnames:
     - {{ .Values.api.httproute.hostname }}
   rules:
+    {{- if .Values.api.httproute.pathPrefix }}
+    - matches:
+      - path:
+          type: PathPrefix
+          value: {{ .Values.api.httproute.pathPrefix }}
+      filters:
+      - type: URLRewrite
+        urlRewrite:
+          path:
+            type: ReplacePrefixMatch
+            replacePrefixMatch: /
+      backendRefs:
+      - name: {{ include "stargazer.fullname" . }}-api
+        port: {{ .Values.api.service.port }}
+    {{- else }}
     - backendRefs:
       - name: {{ include "stargazer.fullname" . }}-api
         port: {{ .Values.api.service.port }}
+    {{- end }}
 {{- end }}

--- a/overlays/dev/stargazer/values.yaml
+++ b/overlays/dev/stargazer/values.yaml
@@ -40,6 +40,8 @@ api:
   httproute:
     enabled: true
     hostname: api.jomcgi.dev
+    # Path prefix for stargazer API
+    pathPrefix: /stargazer
 
 # Enable web server for dev
 webServer:

--- a/websites/jomcgi.dev/src/pages/stargazer.astro
+++ b/websites/jomcgi.dev/src/pages/stargazer.astro
@@ -602,7 +602,26 @@ import { ViewTransitions } from 'astro:transitions';
             try {
                 const response = await fetch(API_URL);
                 if (response.ok) {
-                    locations = await response.json();
+                    const apiData = await response.json();
+                    // Transform API data to frontend format
+                    locations = apiData.map((loc, index) => {
+                        const bestHour = loc.best_hours && loc.best_hours[0] || {};
+                        return {
+                            id: loc.id || `location-${index}`,
+                            name: `Location ${loc.id}`,
+                            lat: loc.coordinates[1],
+                            lon: loc.coordinates[0],
+                            altitude_m: loc.altitude_m,
+                            lp_zone: loc.lp_zone || 'Unknown',
+                            score: Math.round(loc.best_score || 0),
+                            cloud_cover: Math.round(bestHour.cloud_cover || 0),
+                            humidity: Math.round(bestHour.humidity || 0),
+                            wind_speed: bestHour.wind_speed ? bestHour.wind_speed.toFixed(1) : '0',
+                            next_clear: bestHour.hour || 'Unknown',
+                            moon_phase: bestHour.moon_illumination ?
+                                `Moon: ${Math.round(bestHour.moon_illumination * 100)}%` : 'Moon: Unknown'
+                        };
+                    });
                     console.log(`Loaded ${locations.length} locations from API`);
                 } else {
                     console.warn('API unavailable, using demo data');


### PR DESCRIPTION
## Summary
- Configure nginx to serve actual stargazer astronomical observation data
- Add proper CDN caching headers for optimal Cloudflare performance
- Update frontend to parse and display real API data

## Changes
- **Nginx Configuration**: Added caching headers (Cache-Control, ETags, Last-Modified) for 1-hour CDN cache
- **HTTPRoute**: Enabled with `/stargazer` path prefix and URL rewriting for proper API routing
- **Frontend**: Updated to transform backend data format to display format with proper field mapping
- **API Endpoints**:
  - `/api/best` - Returns top 20 stargazing locations with scores
  - `/api/locations` - Returns all scored forecast data

## Test Plan
- [ ] Verify stargazer cronjob runs successfully
- [ ] Check that `/data/output/best_locations.json` is generated
- [ ] Test API endpoint at `https://api.jomcgi.dev/stargazer/api/best`
- [ ] Confirm frontend at `jomcgi.dev/stargazer` displays real data
- [ ] Verify Cloudflare is caching responses (check Cache-Control headers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)