### PR TITLE
fix(stargazer): use GDAL ubuntu-full base image with Python support

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -178,6 +178,20 @@ oci.pull(
 )
 use_repo(oci, "gdal_base", "gdal_base_linux_amd64", "gdal_base_linux_arm64")
 
+# GDAL Python base - includes GDAL with Python 3.10 and pip installed
+# Using ubuntu-full variant which has Python bindings properly configured
+oci.pull(
+    name = "gdal_python_base",
+    # Note: not specifying digest to allow using latest manifest
+    image = "docker.io/osgeo/gdal",
+    platforms = [
+        "linux/amd64",
+        "linux/arm64",
+    ],
+    tag = "ubuntu-full-3.6.3",
+)
+use_repo(oci, "gdal_python_base", "gdal_python_base_linux_amd64", "gdal_python_base_linux_arm64")
+
 # Configure apko for container images
 apko = use_extension("@rules_apko//apko:extensions.bzl", "apko")
 apko.translate_lock(

--- a/services/stargazer/BUILD
+++ b/services/stargazer/BUILD
@@ -8,11 +8,12 @@ py_library(
 )
 
 # Container image for stargazer with GDAL tools
-# Base includes: gdal_translate, gdalwarp, ogr2ogr
+# Using ubuntu-full variant which includes Python 3.10 with GDAL bindings
+# Base includes: gdal_translate, gdalwarp, ogr2ogr, Python GDAL bindings
 # Note: osmium-tool not included - need to install via apt or use alternative
 py3_image(
     name = "image",
-    base = "@gdal_base",
+    base = "@gdal_python_base",
     binary = "//services/stargazer/app:main",
     env = {
         "GDAL_DATA": "/usr/share/gdal",


### PR DESCRIPTION
## Summary
- Fixed stargazer job failing with `ModuleNotFoundError: No module named 'httpx'`
- Changed base image from `osgeo/gdal:ubuntu-small-3.6.3` to `osgeo/gdal:ubuntu-full-3.6.3`
- The ubuntu-full variant includes Python 3.10 with GDAL bindings properly configured

## Problem
The stargazer CronJob was failing with `BackoffLimitExceeded` because the container couldn't import the `httpx` Python module. Investigation revealed that the `ubuntu-small` GDAL base image doesn't have Python properly installed, preventing `py_image_layer` from correctly packaging Python dependencies.

## Solution
Switch to the `ubuntu-full` GDAL image variant which includes:
- Python 3.10 with pip
- GDAL Python bindings properly configured  
- All GDAL tools (gdal_translate, gdalwarp, ogr2ogr)

## Test plan
- [ ] Build the new stargazer image
- [ ] Deploy to dev environment
- [ ] Verify the CronJob runs successfully
- [ ] Check that all Python dependencies are available

🤖 Generated with [Claude Code](https://claude.com/claude-code)