### PR TITLE
fix(stargazer): use Bazel binary entrypoint and add api-gateway routing

### DIFF
--- a/charts/api-gateway/templates/configmap.yaml
+++ b/charts/api-gateway/templates/configmap.yaml
@@ -92,10 +92,23 @@ data:
                 proxy_read_timeout 86400;
             }
 
+            # Stargazer API - proxy to stargazer-api (strip /stargazer prefix)
+            # Backend expects /best, /locations, /health - not /stargazer/best
+            location /stargazer/ {
+                proxy_pass http://{{ .Values.backends.stargazer.host }}:{{ .Values.backends.stargazer.port }}/;
+                proxy_http_version 1.1;
+                proxy_set_header Host $host;
+                proxy_set_header X-Real-IP $remote_addr;
+                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                proxy_set_header X-Forwarded-Proto $scheme;
+
+                # Cache headers are set by stargazer-api
+            }
+
             # Root - return API info
             location = / {
                 default_type application/json;
-                return 200 '{"service":"api-gateway","endpoints":["/cluster-info","/trips/"]}';
+                return 200 '{"service":"api-gateway","endpoints":["/cluster-info","/trips/","/stargazer/"]}';
             }
 
             # Catch-all 404

--- a/charts/api-gateway/values.yaml
+++ b/charts/api-gateway/values.yaml
@@ -42,6 +42,9 @@ backends:
   trips:
     host: trips-nginx.trips.svc.cluster.local
     port: 80
+  stargazer:
+    host: stargazer-api.stargazer.svc.cluster.local
+    port: 80
 
 service:
   type: ClusterIP

--- a/charts/stargazer/templates/cronjob.yaml
+++ b/charts/stargazer/templates/cronjob.yaml
@@ -39,7 +39,8 @@ spec:
               {{- toYaml .Values.securityContext | nindent 14 }}
             image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
             imagePullPolicy: {{ .Values.image.pullPolicy }}
-            command: ["python3", "-m", "services.stargazer.app.main"]
+            # Use image entrypoint (Bazel binary with deps in runfiles)
+            # NOT "python3 -m" which uses system Python without dependencies
             env:
             - name: DATA_DIR
               valueFrom:

--- a/overlays/dev/stargazer/application.yaml
+++ b/overlays/dev/stargazer/application.yaml
@@ -26,9 +26,17 @@ spec:
   destination:
     server: https://kubernetes.default.svc
     namespace: stargazer
+  # Ignore fields injected by Kyverno policies (OTEL env vars)
+  ignoreDifferences:
+    - group: apps
+      kind: Deployment
+      jqPathExpressions:
+        - .spec.template.metadata.annotations."otel.injected-by"
+        - .spec.template.spec.containers[].env[] | select(.name | startswith("OTEL_"))
   syncPolicy:
     automated:
       prune: true
       selfHeal: true
     syncOptions:
       - CreateNamespace=true
+      - RespectIgnoreDifferences=true

--- a/overlays/dev/stargazer/manifests/all.yaml
+++ b/overlays/dev/stargazer/manifests/all.yaml
@@ -368,7 +368,8 @@ spec:
                 type: RuntimeDefault
             image: "ghcr.io/jomcgi/homelab/services/stargazer:2026.01.15.19.20.05-442085c"
             imagePullPolicy: IfNotPresent
-            command: ["python3", "-m", "services.stargazer.app.main"]
+            # Use image entrypoint (Bazel binary with deps in runfiles)
+            # NOT "python3 -m" which uses system Python without dependencies
             env:
             - name: DATA_DIR
               valueFrom:

--- a/overlays/prod/api-gateway/manifests/all.yaml
+++ b/overlays/prod/api-gateway/manifests/all.yaml
@@ -227,10 +227,23 @@ data:
                 proxy_read_timeout 86400;
             }
 
+            # Stargazer API - proxy to stargazer-api (strip /stargazer prefix)
+            # Backend expects /best, /locations, /health - not /stargazer/best
+            location /stargazer/ {
+                proxy_pass http://stargazer-api.stargazer.svc.cluster.local:80/;
+                proxy_http_version 1.1;
+                proxy_set_header Host $host;
+                proxy_set_header X-Real-IP $remote_addr;
+                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                proxy_set_header X-Forwarded-Proto $scheme;
+
+                # Cache headers are set by stargazer-api
+            }
+
             # Root - return API info
             location = / {
                 default_type application/json;
-                return 200 '{"service":"api-gateway","endpoints":["/cluster-info","/trips/"]}';
+                return 200 '{"service":"api-gateway","endpoints":["/cluster-info","/trips/","/stargazer/"]}';
             }
 
             # Catch-all 404
@@ -332,7 +345,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/nginx-config: 4b5f9d467c388502fb5f99e7e90683cad0b995b3e20becbf26c71f012d75a514
+        checksum/nginx-config: e792c375cd719b870324034e5745cd1cfa503fa5cda24cf290e670f7858705db
         checksum/collector-config: d3187019a8acac2b2460628f02686505f2d28c10950d9363a90659af9cc06ad8
       labels:
         app.kubernetes.io/name: api-gateway


### PR DESCRIPTION
## Summary
- Fix CronJob to use Bazel-built binary entrypoint instead of `python3 -m` which was using system Python without dependencies (caused `ModuleNotFoundError: No module named 'httpx'`)
- Add `/stargazer/` route to api-gateway nginx config with prefix stripping so `https://api.jomcgi.dev/stargazer/best` routes correctly
- Add `ignoreDifferences` to ArgoCD application to handle Kyverno OTEL injection drift

## Test plan
- [ ] Trigger a manual CronJob run and verify it completes successfully: `kubectl create job --from=cronjob/stargazer stargazer-test -n stargazer`
- [ ] Verify data files are created in `/data/output/`
- [ ] Test API endpoint: `curl https://api.jomcgi.dev/stargazer/best`
- [ ] Verify ArgoCD shows application as Healthy (not Progressing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)