### PR TITLE
fix(stargazer): set HOME=/tmp for aspect_rules_py venv cache

### DIFF
--- a/charts/stargazer/templates/cronjob.yaml
+++ b/charts/stargazer/templates/cronjob.yaml
@@ -42,6 +42,9 @@ spec:
             # Use image entrypoint (Bazel binary with deps in runfiles)
             # NOT "python3 -m" which uses system Python without dependencies
             env:
+            # aspect_rules_py needs writable cache dir for venv bootstrap
+            - name: HOME
+              value: /tmp
             - name: DATA_DIR
               valueFrom:
                 configMapKeyRef:

--- a/overlays/dev/stargazer/manifests/all.yaml
+++ b/overlays/dev/stargazer/manifests/all.yaml
@@ -371,6 +371,9 @@ spec:
             # Use image entrypoint (Bazel binary with deps in runfiles)
             # NOT "python3 -m" which uses system Python without dependencies
             env:
+            # aspect_rules_py needs writable cache dir for venv bootstrap
+            - name: HOME
+              value: /tmp
             - name: DATA_DIR
               valueFrom:
                 configMapKeyRef:


### PR DESCRIPTION
## Summary
- Set `HOME=/tmp` for CronJob container so `aspect_rules_py` can create its venv cache directory
- Running as non-root user 65532 has no writable home by default, causing "Permission denied" errors

## Test plan
- [ ] Trigger manual job: `kubectl create job --from=cronjob/stargazer stargazer-test -n stargazer`
- [ ] Verify job completes successfully
- [ ] Verify data files created in `/data/output/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)