### PR TITLE
fix(stargazer): add UV_CACHE_DIR and XDG_CACHE_HOME for venv bootstrap

### DIFF
--- a/charts/stargazer/templates/cronjob.yaml
+++ b/charts/stargazer/templates/cronjob.yaml
@@ -42,9 +42,13 @@ spec:
             # Use image entrypoint (Bazel binary with deps in runfiles)
             # NOT "python3 -m" which uses system Python without dependencies
             env:
-            # aspect_rules_py needs writable cache dir for venv bootstrap
+            # rules_uv/aspect_rules_py need writable cache dirs for venv bootstrap
             - name: HOME
               value: /tmp
+            - name: UV_CACHE_DIR
+              value: /tmp/.cache/uv
+            - name: XDG_CACHE_HOME
+              value: /tmp/.cache
             - name: DATA_DIR
               valueFrom:
                 configMapKeyRef:


### PR DESCRIPTION
## Summary
- Add `UV_CACHE_DIR=/tmp/.cache/uv` and `XDG_CACHE_HOME=/tmp/.cache` for CronJob
- `rules_uv` (used by `aspect_rules_py`) needs writable cache directories
- Running as non-root user 65532, the default cache locations are not writable

Fixes the "Unable to create base venv directory - Permission denied" error.

## Test plan
- [ ] Trigger manual job: `kubectl create job --from=cronjob/stargazer stargazer-test -n stargazer`
- [ ] Verify job completes successfully
- [ ] Verify data files created in `/data/output/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)