### PR TITLE
fix(stargazer): remove restrictive securityContext to match trips pattern

### DIFF
--- a/charts/stargazer/templates/cronjob.yaml
+++ b/charts/stargazer/templates/cronjob.yaml
@@ -42,13 +42,6 @@ spec:
             # Use image entrypoint (Bazel binary with deps in runfiles)
             # NOT "python3 -m" which uses system Python without dependencies
             env:
-            # rules_uv/aspect_rules_py need writable cache dirs for venv bootstrap
-            - name: HOME
-              value: /tmp
-            - name: UV_CACHE_DIR
-              value: /tmp/.cache/uv
-            - name: XDG_CACHE_HOME
-              value: /tmp/.cache
             - name: DATA_DIR
               valueFrom:
                 configMapKeyRef:

--- a/charts/stargazer/values.yaml
+++ b/charts/stargazer/values.yaml
@@ -25,11 +25,7 @@ serviceAccount:
 
 podAnnotations: {}
 
-podSecurityContext:
-  runAsNonRoot: true
-  runAsUser: 65532
-  runAsGroup: 65532
-  fsGroup: 65532
+podSecurityContext: {}
 
 securityContext:
   allowPrivilegeEscalation: false
@@ -37,10 +33,6 @@ securityContext:
     drop:
       - ALL
   readOnlyRootFilesystem: false  # Needs write for /data
-  runAsNonRoot: true
-  runAsUser: 65532
-  seccompProfile:
-    type: RuntimeDefault
 
 # Resource limits for processing geospatial data
 resources:


### PR DESCRIPTION
## Summary
- Remove `runAsUser: 65532`, `runAsGroup`, `fsGroup` from podSecurityContext
- Remove `runAsNonRoot`, `runAsUser`, `seccompProfile` from container securityContext  
- Remove cache env vars (HOME, UV_CACHE_DIR, XDG_CACHE_HOME) no longer needed
- Aligns with trips-api deployment which uses image defaults and works

The restrictive security context prevented the Bazel Python binary from creating its venv cache directory.

## Test plan
- [ ] Merge and wait for ArgoCD sync
- [ ] Trigger manual job: `kubectl create job --from=cronjob/stargazer stargazer-test -n stargazer`
- [ ] Verify job completes successfully
- [ ] Verify data files created: `kubectl exec -n stargazer deploy/stargazer-api -c api -- ls -la /data/output/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)