### PR TITLE
fix(stargazer): disable Linkerd sidecar injection for CronJob

### DIFF
--- a/charts/stargazer/templates/cronjob.yaml
+++ b/charts/stargazer/templates/cronjob.yaml
@@ -17,6 +17,9 @@ spec:
         metadata:
           annotations:
             checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+            # Disable Linkerd sidecar injection - sidecars prevent Job completion
+            # because they don't know when the main container finishes
+            linkerd.io/inject: disabled
             {{- with .Values.podAnnotations }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/overlays/dev/stargazer/manifests/all.yaml
+++ b/overlays/dev/stargazer/manifests/all.yaml
@@ -336,6 +336,9 @@ spec:
         metadata:
           annotations:
             checksum/config: 0c8163bd14b94dfe2b65737ab85a1cfdd7a2f4ef71cf06c9dd9a1d1bebe45750
+            # Disable Linkerd sidecar injection - sidecars prevent Job completion
+            # because they don't know when the main container finishes
+            linkerd.io/inject: disabled
           labels:
             app.kubernetes.io/name: stargazer
             app.kubernetes.io/instance: stargazer
@@ -354,7 +357,7 @@ spec:
                 drop:
                 - ALL
               readOnlyRootFilesystem: false
-            image: "ghcr.io/jomcgi/homelab/services/stargazer:2026.01.15.19.20.05-442085c"
+            image: "ghcr.io/jomcgi/homelab/services/stargazer:2026.01.15.20.19.54-bd931c8"
             imagePullPolicy: IfNotPresent
             # Use image entrypoint (Bazel binary with deps in runfiles)
             # NOT "python3 -m" which uses system Python without dependencies


### PR DESCRIPTION
## Summary
- Disables Linkerd sidecar injection for stargazer CronJob pods
- Fixes issue where Jobs stay in "Running" state indefinitely after application completes
- Linkerd sidecars don't know when the main container finishes, preventing Job completion

## Test plan
- [ ] Trigger a manual stargazer job: `kubectl create job stargazer-test-$(date +%s) --from=cronjob/stargazer -n stargazer`
- [ ] Verify job completes successfully (no Linkerd sidecar keeping it running)
- [ ] Check ArgoCD shows application as healthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)