### PR TITLE
fix(ais-ingest): add dockerconfigjson type to image pull secret

### DIFF
--- a/charts/ais-ingest/templates/image-pull-secret.yaml
+++ b/charts/ais-ingest/templates/image-pull-secret.yaml
@@ -1,6 +1,11 @@
 {{- if and .Values.imagePullSecret.enabled .Values.imagePullSecret.create }}
+---
+# GHCR Pull Secret (for Kubernetes image pulls)
+# Allows ais-ingest to pull private images from GitHub Container Registry
+# Type: kubernetes.io/dockerconfigjson (used for imagePullSecrets)
 apiVersion: onepassword.com/v1
 kind: OnePasswordItem
+type: kubernetes.io/dockerconfigjson
 metadata:
   name: ghcr-imagepull-secret
   namespace: {{ .Release.Namespace }}

--- a/overlays/dev/ais-ingest/manifests/all.yaml
+++ b/overlays/dev/ais-ingest/manifests/all.yaml
@@ -70,7 +70,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: ais-ingest
-          image: "ghcr.io/jomcgi/homelab/services/ais-ingest:latest"
+          image: "ghcr.io/jomcgi/homelab/services/ais-ingest:2026.01.17.07.23.08-c801724"
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false
@@ -127,8 +127,12 @@ spec:
           emptyDir: {}
 ---
 # Source: ais-ingest/templates/image-pull-secret.yaml
+# GHCR Pull Secret (for Kubernetes image pulls)
+# Allows ais-ingest to pull private images from GitHub Container Registry
+# Type: kubernetes.io/dockerconfigjson (used for imagePullSecrets)
 apiVersion: onepassword.com/v1
 kind: OnePasswordItem
+type: kubernetes.io/dockerconfigjson
 metadata:
   name: ghcr-imagepull-secret
   namespace: ais-ingest


### PR DESCRIPTION
## Summary

Fixes image pull failure for ais-ingest by adding the required `type: kubernetes.io/dockerconfigjson` to the OnePasswordItem that creates the GHCR pull secret.

## Problem

```
failed to pull and unpack image "ghcr.io/jomcgi/homelab/services/ais-ingest:latest": 
failed to authorize: failed to fetch anonymous token: unexpected status from GET request: 403 Forbidden
```

The secret was being created but Kubernetes couldn't use it as a Docker registry credential because it lacked the proper type annotation.

## Fix

Add `type: kubernetes.io/dockerconfigjson` to the OnePasswordItem spec, matching the pattern used by other services (e.g., stargazer).

## Test plan

- [ ] ArgoCD syncs the change
- [ ] Pod starts pulling successfully
- [ ] Verify with: `kubectl get pods -n ais-ingest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)