### PR TITLE
fix(stargazer): make dark mode much darker

### DIFF
--- a/websites/jomcgi.dev/src/pages/stargazer.astro
+++ b/websites/jomcgi.dev/src/pages/stargazer.astro
@@ -383,9 +383,9 @@
                         mapInstance.setPaintProperty('osm', 'raster-brightness-max', 0.7);
                         mapInstance.setPaintProperty('osm', 'raster-contrast', 0.6);
                     } else {
-                        mapInstance.setPaintProperty('osm', 'raster-brightness-min', 0.1);
-                        mapInstance.setPaintProperty('osm', 'raster-brightness-max', 0.35);
-                        mapInstance.setPaintProperty('osm', 'raster-contrast', 0.8);
+                        mapInstance.setPaintProperty('osm', 'raster-brightness-min', 0);
+                        mapInstance.setPaintProperty('osm', 'raster-brightness-max', 0.15);
+                        mapInstance.setPaintProperty('osm', 'raster-contrast', 1);
                     }
                 }
 
@@ -470,9 +470,9 @@
                     type: 'raster',
                     source: 'osm',
                     paint: {
-                        'raster-brightness-min': startInverted ? 0.4 : 0.1,
-                        'raster-brightness-max': startInverted ? 0.7 : 0.35,
-                        'raster-contrast': startInverted ? 0.6 : 0.8,
+                        'raster-brightness-min': startInverted ? 0.4 : 0,
+                        'raster-brightness-max': startInverted ? 0.7 : 0.15,
+                        'raster-contrast': startInverted ? 0.6 : 1,
                         'raster-saturation': -1
                     }
                 }]


### PR DESCRIPTION
## Summary
- Adjusts raster map styling for dark mode to be nearly black with whitish lines
- Sets brightness-min to 0 (was 0.1), brightness-max to 0.15 (was 0.35), contrast to 1 (was 0.8)
- Better contrast and visibility for night-time stargazing

## Test plan
- [ ] Open stargazer page in dark mode
- [ ] Verify map appears much darker (almost black background with light lines)
- [ ] Toggle between light/dark mode to confirm both work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)