### PR TITLE
fix(ais-ingest): enable non-root execution with RULES_PYTHON_EXTRACT_ROOT

### DIFF
--- a/charts/ais-ingest/templates/deployment.yaml
+++ b/charts/ais-ingest/templates/deployment.yaml
@@ -46,6 +46,9 @@ spec:
               value: /tmp
             - name: UV_CACHE_DIR
               value: /tmp/.uv-cache
+            # rules_python bootstrap files need writable location for non-root
+            - name: RULES_PYTHON_EXTRACT_ROOT
+              value: /tmp
             - name: NATS_URL
               value: {{ .Values.nats.url | quote }}
             - name: AISSTREAM_URL

--- a/overlays/dev/ais-ingest/manifests/all.yaml
+++ b/overlays/dev/ais-ingest/manifests/all.yaml
@@ -70,7 +70,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: ais-ingest
-          image: "ghcr.io/jomcgi/homelab/services/ais-ingest:2026.01.17.07.23.08-c801724"
+          image: "ghcr.io/jomcgi/homelab/services/ais-ingest:2026.01.17.07.34.03-01c5a42"
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false
@@ -88,6 +88,9 @@ spec:
               value: /tmp
             - name: UV_CACHE_DIR
               value: /tmp/.uv-cache
+            # rules_python bootstrap files need writable location for non-root
+            - name: RULES_PYTHON_EXTRACT_ROOT
+              value: /tmp
             - name: NATS_URL
               value: "nats://nats.nats.svc.cluster.local:4222"
             - name: AISSTREAM_URL


### PR DESCRIPTION
## Summary
- Adds `RULES_PYTHON_EXTRACT_ROOT=/tmp` environment variable to ais-ingest deployment
- Fixes "Unable to create base venv directory" permission error when running as non-root user
- Allows `aspect_rules_py` to create its bootstrap files in the writable `/tmp` directory

## Root Cause
The `aspect_rules_py` runtime creates a virtual environment at the binary's installation location during startup. When running as non-root (user 1000), this fails because the installation directory is owned by root.

## Fix
Setting `RULES_PYTHON_EXTRACT_ROOT=/tmp` tells rules_python to create its bootstrap files in `/tmp` instead, which is already mounted as a writable emptyDir volume.

## Test plan
- [ ] Deploy to dev namespace and verify pod starts successfully
- [ ] Verify `/health` endpoint responds
- [ ] Confirm pod runs as non-root (uid 1000)

🤖 Generated with [Claude Code](https://claude.com/claude-code)