### PR TITLE
fix(ais-ingest): run as root for aspect_rules_py venv compatibility

### DIFF
--- a/charts/ais-ingest/templates/deployment.yaml
+++ b/charts/ais-ingest/templates/deployment.yaml
@@ -46,9 +46,6 @@ spec:
               value: /tmp
             - name: UV_CACHE_DIR
               value: /tmp/.uv-cache
-            # rules_python bootstrap files need writable location for non-root
-            - name: RULES_PYTHON_EXTRACT_ROOT
-              value: /tmp
             - name: NATS_URL
               value: {{ .Values.nats.url | quote }}
             - name: AISSTREAM_URL

--- a/charts/ais-ingest/values.yaml
+++ b/charts/ais-ingest/values.yaml
@@ -44,16 +44,17 @@ serviceAccount:
 podAnnotations: {}
 
 # Pod security context
+# Note: Running as root because aspect_rules_py venv needs to write
+# to the installation directory. TODO: Fix image to run as non-root
 podSecurityContext:
-  runAsNonRoot: true
-  runAsUser: 1000
-  fsGroup: 1000
   seccompProfile:
     type: RuntimeDefault
 
 # Container security context
 securityContext:
-  readOnlyRootFilesystem: false  # aspect_rules_py needs write access
+  # Note: readOnlyRootFilesystem disabled because aspect_rules_py
+  # creates a virtualenv at runtime (by design)
+  readOnlyRootFilesystem: false
   allowPrivilegeEscalation: false
   capabilities:
     drop:

--- a/overlays/dev/ais-ingest/manifests/all.yaml
+++ b/overlays/dev/ais-ingest/manifests/all.yaml
@@ -63,14 +63,11 @@ spec:
         - name: ghcr-imagepull-secret
       serviceAccountName: ais-ingest
       securityContext:
-        fsGroup: 1000
-        runAsNonRoot: true
-        runAsUser: 1000
         seccompProfile:
           type: RuntimeDefault
       containers:
         - name: ais-ingest
-          image: "ghcr.io/jomcgi/homelab/services/ais-ingest:2026.01.17.07.34.03-01c5a42"
+          image: "ghcr.io/jomcgi/homelab/services/ais-ingest:2026.01.17.07.47.58-0972d56"
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false
@@ -88,9 +85,6 @@ spec:
               value: /tmp
             - name: UV_CACHE_DIR
               value: /tmp/.uv-cache
-            # rules_python bootstrap files need writable location for non-root
-            - name: RULES_PYTHON_EXTRACT_ROOT
-              value: /tmp
             - name: NATS_URL
               value: "nats://nats.nats.svc.cluster.local:4222"
             - name: AISSTREAM_URL


### PR DESCRIPTION
## Summary
- Remove non-root constraints (`runAsNonRoot`, `runAsUser`, `fsGroup`) from ais-ingest
- Remove ineffective `RULES_PYTHON_EXTRACT_ROOT` env var from previous PR
- Match trips-api configuration for aspect_rules_py compatibility

## Root Cause
`aspect_rules_py` creates a virtualenv at runtime in the binary's installation directory. Running as non-root fails with "Unable to create base venv directory" permission error. The `RULES_PYTHON_EXTRACT_ROOT` env var didn't help.

## Fix
Run as root (like trips-api) until a proper non-root solution is found for aspect_rules_py images.

## Test plan
- [ ] Verify pod starts successfully after merge
- [ ] Verify `/health` endpoint responds

🤖 Generated with [Claude Code](https://claude.com/claude-code)