### PR TITLE
fix(ais-ingest): remove non-existent StreamNameAlreadyInUseError

### DIFF
--- a/services/ais-ingest/main.py
+++ b/services/ais-ingest/main.py
@@ -59,19 +59,16 @@ class AISIngestService:
         self.js = self.nc.jetstream()
         logger.info("Connected to NATS")
 
-        # Create or update the AIS stream
-        try:
-            await self.js.add_stream(
-                name="ais",
-                subjects=["ais.>"],
-                max_age=int(timedelta(hours=24).total_seconds() * 1e9),  # nanoseconds
-                storage=nats.js.api.StorageType.FILE,
-                discard=nats.js.api.DiscardPolicy.OLD,
-                description="AIS position reports from AISStream.io",
-            )
-            logger.info("Created/updated 'ais' stream with 24h retention")
-        except nats.js.errors.StreamNameAlreadyInUseError:
-            logger.info("Stream 'ais' already exists")
+        # Create or update the AIS stream (add_stream is idempotent if config matches)
+        await self.js.add_stream(
+            name="ais",
+            subjects=["ais.>"],
+            max_age=int(timedelta(hours=24).total_seconds() * 1e9),  # nanoseconds
+            storage=nats.js.api.StorageType.FILE,
+            discard=nats.js.api.DiscardPolicy.OLD,
+            description="AIS position reports from AISStream.io",
+        )
+        logger.info("Created/updated 'ais' stream with 24h retention")
 
     async def publish_position(self, mmsi: str, data: dict) -> None:
         """Publish a position report to NATS."""


### PR DESCRIPTION
## Summary

- Fixes startup error: `module 'nats.js.errors' has no attribute 'StreamNameAlreadyInUseError'`
- The nats-py library doesn't have this exception class
- `add_stream()` is idempotent - it succeeds if the stream exists with matching configuration

## Test plan

- [ ] Verify ais-ingest pod starts without the error
- [ ] Confirm NATS stream is created/updated correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)