### PR TITLE
fix(ais-ingest): correct NATS JetStream max_age configuration

### DIFF
--- a/services/ais-ingest/main.py
+++ b/services/ais-ingest/main.py
@@ -63,13 +63,24 @@ class AISIngestService:
         stream_config = StreamConfig(
             name="ais",
             subjects=["ais.>"],
-            max_age=int(timedelta(hours=24).total_seconds() * 1e9),  # nanoseconds
+            max_age=timedelta(hours=24).total_seconds(),  # seconds, not nanoseconds
             storage=StorageType.FILE,
             discard=DiscardPolicy.OLD,
             description="AIS position reports from AISStream.io",
         )
-        await self.js.add_stream(stream_config)
-        logger.info("Created/updated 'ais' stream with 24h retention")
+
+        try:
+            await self.js.add_stream(stream_config)
+            logger.info("Created/updated 'ais' stream with 24h retention")
+        except Exception as e:
+            logger.error(f"Failed to create/update stream: {e}")
+            # Try to get existing stream info for debugging
+            try:
+                stream_info = await self.js.stream_info("ais")
+                logger.info(f"Existing stream config: {stream_info}")
+            except:
+                logger.info("No existing stream found")
+            raise
 
     async def publish_position(self, mmsi: str, data: dict) -> None:
         """Publish a position report to NATS."""


### PR DESCRIPTION
## Summary
- Fixed NATS JetStream stream creation error that was preventing ais-ingest from starting
- The max_age parameter was incorrectly specified in nanoseconds but the API expects seconds
- Added better error handling for stream creation to aid debugging

## Problem
The ais-ingest service was failing to start with the error:
```
ERROR - Failed to start service: nats: BadRequestError: code=400 err_code=10025 description='invalid JSON'
```

This was due to the max_age parameter being calculated as nanoseconds (86400000000000) instead of seconds (86400).

## Solution
- Changed `max_age=int(timedelta(hours=24).total_seconds() * 1e9)` to `max_age=timedelta(hours=24).total_seconds()`
- Added try/catch block with detailed error logging for stream creation
- Will log existing stream configuration if creation fails to help with debugging

## Test plan
- [ ] Verify the ais-ingest pod starts successfully
- [ ] Check that NATS JetStream stream is created with 24h retention
- [ ] Confirm no "invalid JSON" errors in pod logs
- [ ] Verify AIS messages are being published to NATS

🤖 Generated with [Claude Code](https://claude.com/claude-code)