### PR TITLE
fix(ais-ingest): add SSL_CERT_FILE env var for certificate verification

### DIFF
--- a/charts/ais-ingest/templates/deployment.yaml
+++ b/charts/ais-ingest/templates/deployment.yaml
@@ -46,6 +46,9 @@ spec:
               value: /tmp
             - name: UV_CACHE_DIR
               value: /tmp/.uv-cache
+            # Point Python SSL to system CA certificates
+            - name: SSL_CERT_FILE
+              value: /etc/ssl/certs/ca-certificates.crt
             - name: NATS_URL
               value: {{ .Values.nats.url | quote }}
             - name: AISSTREAM_URL


### PR DESCRIPTION
## Summary
- Add `SSL_CERT_FILE` environment variable pointing to `/etc/ssl/certs/ca-certificates.crt`
- Fixes SSL certificate verification error when connecting to AISStream.io WebSocket

## Problem
The ais-ingest service was failing with:
```
[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate
```

Python's SSL module couldn't find the CA certificates bundle in the Ubuntu-based container. The certificates exist at `/etc/ssl/certs/ca-certificates.crt`, but Python didn't know where to look.

## Test plan
- [ ] Deploy and verify ais-ingest connects to AISStream.io without SSL errors
- [ ] Check logs for successful WebSocket connection

🤖 Generated with [Claude Code](https://claude.com/claude-code)