### PR TITLE
fix(claude): add missing leader election ConfigMap and RBAC permissions

### DIFF
--- a/charts/claude/templates/clusterrole.yaml
+++ b/charts/claude/templates/clusterrole.yaml
@@ -26,4 +26,10 @@ rules:
   - apiGroups: ["batch"]
     resources: ["jobs"]
     verbs: ["create"]
+  {{- if .Values.leaderElection.enabled }}
+  # Leader election requires lease management
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "create", "update", "patch"]
+  {{- end }}
 {{- end }}

--- a/charts/claude/templates/leader-election-configmap.yaml
+++ b/charts/claude/templates/leader-election-configmap.yaml
@@ -1,0 +1,119 @@
+{{- if .Values.leaderElection.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "claude-api.fullname" . }}-leader-election
+  labels:
+    {{- include "claude-api.labels" . | nindent 4 }}
+data:
+  leader-election.sh: |
+    #!/bin/sh
+    set -euo pipefail
+
+    # Leader election using Kubernetes leases
+    # This script continuously tries to acquire or renew a lease
+    # Only the leader pod will hold the lease at any time
+
+    LEASE_NAME="{{ include "claude-api.fullname" . }}-leader"
+    LEASE_NAMESPACE="${POD_NAMESPACE}"
+    LEASE_DURATION="15"  # seconds
+    RENEW_DEADLINE="10"  # seconds
+    RETRY_PERIOD="2"     # seconds
+
+    echo "Starting leader election for pod: ${POD_NAME}"
+
+    while true; do
+      # Try to acquire or renew the lease
+      CURRENT_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+      # Check if lease exists
+      if kubectl get lease "${LEASE_NAME}" -n "${LEASE_NAMESPACE}" >/dev/null 2>&1; then
+        # Lease exists, check if we own it or if it's expired
+        HOLDER=$(kubectl get lease "${LEASE_NAME}" -n "${LEASE_NAMESPACE}" -o jsonpath='{.spec.holderIdentity}' 2>/dev/null || echo "")
+        ACQUIRE_TIME=$(kubectl get lease "${LEASE_NAME}" -n "${LEASE_NAMESPACE}" -o jsonpath='{.spec.acquireTime}' 2>/dev/null || echo "")
+        RENEW_TIME=$(kubectl get lease "${LEASE_NAME}" -n "${LEASE_NAMESPACE}" -o jsonpath='{.spec.renewTime}' 2>/dev/null || echo "")
+
+        if [ "${HOLDER}" = "${POD_NAME}" ]; then
+          # We are the leader, renew the lease
+          echo "Renewing lease as leader: ${POD_NAME}"
+          kubectl patch lease "${LEASE_NAME}" -n "${LEASE_NAMESPACE}" --type=json -p='[
+            {"op": "replace", "path": "/spec/renewTime", "value": "'${CURRENT_TIME}'"},
+            {"op": "replace", "path": "/spec/leaseDurationSeconds", "value": '${LEASE_DURATION}'}
+          ]' >/dev/null 2>&1 || {
+            echo "Failed to renew lease, will retry"
+            echo "false" > /tmp/leader
+            sleep "${RETRY_PERIOD}"
+            continue
+          }
+          echo "true" > /tmp/leader
+        else
+          # Check if lease is expired (no renew in last LEASE_DURATION seconds)
+          if [ -n "${RENEW_TIME}" ]; then
+            RENEW_EPOCH=$(date -d "${RENEW_TIME}" +%s 2>/dev/null || echo "0")
+            CURRENT_EPOCH=$(date +%s)
+            AGE=$((CURRENT_EPOCH - RENEW_EPOCH))
+
+            if [ ${AGE} -gt ${LEASE_DURATION} ]; then
+              # Lease is expired, try to take it
+              echo "Lease expired (age: ${AGE}s), attempting to acquire: ${POD_NAME}"
+              kubectl patch lease "${LEASE_NAME}" -n "${LEASE_NAMESPACE}" --type=json -p='[
+                {"op": "replace", "path": "/spec/holderIdentity", "value": "'${POD_NAME}'"},
+                {"op": "replace", "path": "/spec/acquireTime", "value": "'${CURRENT_TIME}'"},
+                {"op": "replace", "path": "/spec/renewTime", "value": "'${CURRENT_TIME}'"},
+                {"op": "replace", "path": "/spec/leaseDurationSeconds", "value": '${LEASE_DURATION}'}
+              ]' >/dev/null 2>&1 && {
+                echo "Successfully acquired lease: ${POD_NAME}"
+                echo "true" > /tmp/leader
+              } || {
+                echo "Failed to acquire expired lease, will retry"
+                echo "false" > /tmp/leader
+              }
+            else
+              # Lease is held by another pod and not expired
+              echo "Leader is ${HOLDER}, waiting..."
+              echo "false" > /tmp/leader
+            fi
+          else
+            echo "false" > /tmp/leader
+          fi
+        fi
+      else
+        # Lease doesn't exist, create it
+        echo "Creating lease for pod: ${POD_NAME}"
+        kubectl create -f - >/dev/null 2>&1 <<EOF && {
+          echo "Successfully created lease: ${POD_NAME}"
+          echo "true" > /tmp/leader
+        } || {
+          echo "Failed to create lease (may have been created by another pod), will retry"
+          echo "false" > /tmp/leader
+        }
+    apiVersion: coordination.k8s.io/v1
+    kind: Lease
+    metadata:
+      name: ${LEASE_NAME}
+      namespace: ${LEASE_NAMESPACE}
+    spec:
+      holderIdentity: ${POD_NAME}
+      leaseDurationSeconds: ${LEASE_DURATION}
+      acquireTime: ${CURRENT_TIME}
+      renewTime: ${CURRENT_TIME}
+    EOF
+      fi
+
+      sleep "${RETRY_PERIOD}"
+    done
+
+  health-check.sh: |
+    #!/bin/sh
+    # Health check script for leader election
+    # Returns 0 if this pod is the leader, 1 otherwise
+
+    if [ -f /tmp/leader ]; then
+      LEADER_STATUS=$(cat /tmp/leader)
+      if [ "${LEADER_STATUS}" = "true" ]; then
+        exit 0
+      fi
+    fi
+
+    exit 1
+{{- end }}

--- a/overlays/dev/claude/values.yaml
+++ b/overlays/dev/claude/values.yaml
@@ -25,6 +25,9 @@ defaultPermissionMode: "bypassPermissions"
 statefulset:
   enabled: false
 replicas: 1
+# Leader election not needed with single replica
+leaderElection:
+  enabled: false
 # Session affinity not needed with single replica
 service:
   sessionAffinity: false


### PR DESCRIPTION
Resolves the "configmap 'claude-leader-election' not found" error by:

1. Created leader-election-configmap.yaml template with:
   - leader-election.sh: Manages Kubernetes lease-based leader election
   - health-check.sh: Readiness probe to check if pod is the leader

2. Updated ClusterRole to add lease management permissions:
   - coordination.k8s.io/leases: get, create, update, patch
   - Only added when leaderElection.enabled is true

3. Disabled leader election in dev overlay:
   - Not needed with replicas: 1
   - Reduces unnecessary overhead

The leader election implementation uses Kubernetes coordination.k8s.io/v1
Lease resources for HA deployments with multiple replicas.