### PR TITLE
fix(ais-ingest): use certifi for SSL certificate verification

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ dependencies = [
     "nats-py~=2.9",
     # AIS ingest dependencies
     "websockets~=12.0",
+    "certifi",  # CA certificates for SSL in minimal containers
     # Stargazer geospatial dependencies
     "rasterio~=1.3",
     "geopandas~=0.14",

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -328,6 +328,7 @@ certifi==2025.10.5 \
     --hash=sha256:0f212c2744a9bb6de0c56639a6f68afe01ecd92d91f14ae897c4fe7bbeeef0de \
     --hash=sha256:47c09d31ccf2acf0be3f701ea53595ee7e0b8fa08801c6624be771df09ae7b43
     # via
+    #   homelab (pyproject.toml)
     #   fiona
     #   httpcore
     #   httpx

--- a/services/ais-ingest/BUILD
+++ b/services/ais-ingest/BUILD
@@ -6,6 +6,7 @@ py_binary(
     srcs = ["main.py"],
     visibility = ["//:__subpackages__"],
     deps = [
+        "@pip//certifi",
         "@pip//fastapi",
         "@pip//nats_py",
         "@pip//uvicorn",
@@ -15,9 +16,13 @@ py_binary(
 
 py_library(
     name = "ais-ingest",
-    srcs = ["main.py"],
+    srcs = [
+        "__init__.py",
+        "main.py",
+    ],
     visibility = ["//:__subpackages__"],
     deps = [
+        "@pip//certifi",
         "@pip//fastapi",
         "@pip//nats_py",
         "@pip//uvicorn",

--- a/services/ais-ingest/main.py
+++ b/services/ais-ingest/main.py
@@ -11,9 +11,11 @@ import json
 import logging
 import os
 import signal
+import ssl
 from contextlib import asynccontextmanager
 from datetime import timedelta
 
+import certifi
 import nats
 from nats.js.api import DiscardPolicy, StorageType, StreamConfig
 import websockets
@@ -147,10 +149,13 @@ class AISIngestService:
         """Connect to AISStream and process messages with reconnection logic."""
         reconnect_delay = INITIAL_RECONNECT_DELAY
 
+        # Create SSL context with certifi CA bundle (needed for minimal container images)
+        ssl_context = ssl.create_default_context(cafile=certifi.where())
+
         while self.running:
             try:
                 logger.info(f"Connecting to AISStream at {AISSTREAM_URL}")
-                async with websockets.connect(AISSTREAM_URL) as ws:
+                async with websockets.connect(AISSTREAM_URL, ssl=ssl_context) as ws:
                     # Send subscription message within 3 seconds
                     subscription = {
                         "APIKey": AISSTREAM_API_KEY,


### PR DESCRIPTION
## Summary
- Fixed SSL certificate verification failure when connecting to AISStream.io
- Root cause: minimal Ubuntu base image lacks ca-certificates package
- Solution: use `certifi` package with explicit SSL context configuration

## Changes
- Added `certifi` as a direct dependency in `pyproject.toml`
- Updated `main.py` to create SSL context with certifi's CA bundle
- Regenerated lock files and BUILD via gazelle

## Test plan
- [ ] CI passes (image builds successfully)
- [ ] Verify pod connects to AISStream.io without SSL errors
- [ ] Confirm AIS position reports are published to NATS

🤖 Generated with [Claude Code](https://claude.com/claude-code)