### PR TITLE
fix(ships): use getClusterExpansionZoom for reliable cluster clicks

### DIFF
--- a/websites/ships.jomcgi.dev/src/App.jsx
+++ b/websites/ships.jomcgi.dev/src/App.jsx
@@ -329,23 +329,22 @@ export default function App() {
       map.current.on("click", "vessels-anchored", handleVesselClick);
       map.current.on("click", "vessels-moving", handleVesselClick);
 
-      // Click handler for clusters - zoom to bounding box of all points
+      // Click handler for clusters - zoom to expansion level
       map.current.on("click", "vessel-clusters", (e) => {
-        const features = map.current.queryRenderedFeatures(e.point, {
-          layers: ["vessel-clusters"],
-        });
-        const clusterId = features[0].properties.cluster_id;
-        const pointCount = features[0].properties.point_count;
-        map.current
-          .getSource("vessels")
-          .getClusterLeaves(clusterId, pointCount, 0, (err, leaves) => {
-            if (err || !leaves.length) return;
-            const bounds = new maplibregl.LngLatBounds();
-            leaves.forEach((leaf) => {
-              bounds.extend(leaf.geometry.coordinates);
-            });
-            map.current.fitBounds(bounds, { padding: 50 });
+        const feature = e.features[0];
+        if (!feature) return;
+
+        const clusterId = feature.properties.cluster_id;
+        const coordinates = feature.geometry.coordinates;
+        const source = map.current.getSource("vessels");
+
+        source.getClusterExpansionZoom(clusterId, (err, zoom) => {
+          if (err) return;
+          map.current.easeTo({
+            center: coordinates,
+            zoom: zoom,
           });
+        });
       });
 
       const setCursor = () => {


### PR DESCRIPTION
## Summary

- Fixes cluster click not zooming on desktop or mobile
- Uses `getClusterExpansionZoom` instead of `getClusterLeaves` for reliable behavior
- Adds null check for clicked feature

## Problem

The previous implementation using `getClusterLeaves(clusterId, pointCount, 0, callback)` could fail silently - the callback would return empty results without an error, causing no zoom action to occur.

## Solution

Switch to `getClusterExpansionZoom` which is the standard pattern for cluster interactions. This reliably returns the zoom level at which the clicked cluster will expand into smaller clusters or individual points.

## Test plan

- [ ] Click on cluster markers - should zoom in smoothly
- [ ] Verify works on desktop and mobile
- [ ] Verify individual vessel clicks still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)