### PR TITLE
fix(argocd): use digest strategy for image updater

### DIFF
--- a/overlays/dev/cloudflare-operator/application.yaml
+++ b/overlays/dev/cloudflare-operator/application.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     # ArgoCD Image Updater configuration
     argocd-image-updater.argoproj.io/image-list: operator=ghcr.io/jomcgi/homelab/operators/cloudflare
-    argocd-image-updater.argoproj.io/operator.update-strategy: newest-build
+    argocd-image-updater.argoproj.io/operator.update-strategy: digest
     argocd-image-updater.argoproj.io/operator.allow-tags: regexp:^\d{4}\.\d{2}\.\d{2}\.\d{2}\.\d{2}\.\d{2}-[0-9a-f]{7}$
     argocd-image-updater.argoproj.io/operator.helm.image-name: controllerManager.image.repository
     argocd-image-updater.argoproj.io/operator.helm.image-tag: controllerManager.image.tag

--- a/overlays/dev/cloudflare-operator/imageupdater.yaml
+++ b/overlays/dev/cloudflare-operator/imageupdater.yaml
@@ -9,7 +9,7 @@ spec:
     - alias: operator
       commonUpdateSettings:
         allowTags: regexp:^\d{4}\.\d{2}\.\d{2}\.\d{2}\.\d{2}\.\d{2}-[0-9a-f]{7}$
-        updateStrategy: newest-build
+        updateStrategy: digest
         forceUpdate: false
       imageName: ghcr.io/jomcgi/homelab/operators/cloudflare
       manifestTargets:

--- a/overlays/dev/marine/imageupdater.yaml
+++ b/overlays/dev/marine/imageupdater.yaml
@@ -9,7 +9,7 @@ spec:
     - alias: ingest
       commonUpdateSettings:
         allowTags: regexp:^\d{4}\.\d{2}\.\d{2}\.\d{2}\.\d{2}\.\d{2}-[0-9a-f]{7}$
-        updateStrategy: newest-build
+        updateStrategy: digest
         forceUpdate: false
       imageName: ghcr.io/jomcgi/homelab/services/ais-ingest
       manifestTargets:
@@ -19,7 +19,7 @@ spec:
     - alias: api
       commonUpdateSettings:
         allowTags: regexp:^\d{4}\.\d{2}\.\d{2}\.\d{2}\.\d{2}\.\d{2}-[0-9a-f]{7}$
-        updateStrategy: newest-build
+        updateStrategy: digest
         forceUpdate: false
       imageName: ghcr.io/jomcgi/homelab/services/ships-api
       manifestTargets:
@@ -29,7 +29,7 @@ spec:
     - alias: frontend
       commonUpdateSettings:
         allowTags: regexp:^\d{4}\.\d{2}\.\d{2}\.\d{2}\.\d{2}\.\d{2}-[0-9a-f]{7}$
-        updateStrategy: newest-build
+        updateStrategy: digest
         forceUpdate: false
       imageName: ghcr.io/jomcgi/homelab/services/ships-frontend
       manifestTargets:

--- a/overlays/dev/stargazer/imageupdater.yaml
+++ b/overlays/dev/stargazer/imageupdater.yaml
@@ -9,7 +9,7 @@ spec:
     - alias: stargazer
       commonUpdateSettings:
         allowTags: regexp:^\d{4}\.\d{2}\.\d{2}\.\d{2}\.\d{2}\.\d{2}-[0-9a-f]{7}$
-        updateStrategy: newest-build
+        updateStrategy: digest
         forceUpdate: false
       imageName: ghcr.io/jomcgi/homelab/services/stargazer
       manifestTargets:


### PR DESCRIPTION
## Summary
- Change all ArgoCD Image Updater configurations from `newest-build` to `digest` strategy
- Prevents spurious redeployments when tags are updated but image content hasn't changed
- Updates marine (3 images), stargazer, and cloudflare-operator configurations

## Test plan
- [ ] Verify ArgoCD Image Updater picks up the new configuration
- [ ] Confirm deployments only trigger when actual image digests change
- [ ] Check that existing deployments are not affected by the config change

🤖 Generated with [Claude Code](https://claude.com/claude-code)