### PR TITLE
docs: streamline homepage and add ships to engineering

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -119,6 +119,7 @@ charts/                     # Helm charts
 ├── kyverno/                # Policy engine for Kubernetes
 ├── linkerd/                # Linkerd service mesh for automatic tracing
 ├── longhorn/               # Distributed persistent storage
+├── marine/                 # AIS vessel tracking and API
 ├── nats/                   # NATS messaging system
 ├── nvidia-gpu-operator/    # NVIDIA GPU operator for GPU workloads
 ├── seaweedfs/              # SeaweedFS distributed storage
@@ -174,6 +175,7 @@ overlays/                   # Environment-based deployments
     ├── kustomization.yaml
     ├── claude/             # Claude Code deployment
     ├── cloudflare-operator/# Cloudflare operator deployment
+    ├── marine/             # AIS vessel tracking service
     └── stargazer/          # Stargazer service
 
 pkg/                        # Shared Go libraries
@@ -185,7 +187,8 @@ services/                   # Backend services
 
 websites/                   # Static websites
 ├── hikes.jomcgi.dev/       # Hiking route finder (static)
-└── jomcgi.dev/             # Personal website (Astro-based)
+├── jomcgi.dev/             # Personal website (Astro-based)
+└── ships.jomcgi.dev/       # Real-time vessel tracking UI
 
 ```
 
@@ -370,6 +373,13 @@ We test **actual behavior**, not implementation details:
 - **Custom Kubernetes operator** for Cloudflare resource management
 - **Automated tunnel provisioning** and **DNS management**
 - **Deployed via**: ArgoCD Application referencing operators/cloudflare/helm/
+
+#### Marine (ships.jomcgi.dev)
+- **Real-time AIS vessel tracking** for Pacific Northwest waters
+- **AIS ingest service** streams from AISStream.io to NATS JetStream
+- **Ships API** with REST endpoints and WebSocket for live updates
+- **React/MapLibre frontend** for vessel visualization
+- **Deployed via**: ArgoCD Application
 
 #### Stargazer
 - **Experimental service** for testing new features

--- a/websites/jomcgi.dev/src/pages/engineering.astro
+++ b/websites/jomcgi.dev/src/pages/engineering.astro
@@ -202,6 +202,41 @@ const bazelDiagram = `flowchart LR
     style Cache fill:#9b59b6,stroke:#9b59b6,color:#fff
     style Git fill:#e056fd,stroke:#e056fd,color:#fff
     style Reg fill:#e056fd,stroke:#e056fd,color:#fff`;
+
+const shipsDiagram = `flowchart LR
+    subgraph Ingest
+        AIS[AISStream.io]
+        Ingest[ais-ingest]
+    end
+
+    subgraph Store
+        NATS[(NATS JetStream)]
+    end
+
+    subgraph Serve
+        API[ships-api]
+        WS[WebSocket]
+    end
+
+    subgraph Display
+        UI[ships.jomcgi.dev]
+        Map[MapLibre]
+    end
+
+    AIS -->|WebSocket| Ingest
+    Ingest -->|Publish| NATS
+    NATS -->|Subscribe| API
+    API --> WS
+    WS --> UI
+    UI --> Map
+
+    style AIS fill:#ff6b6b,stroke:#ff6b6b,color:#fff
+    style Ingest fill:#ffa502,stroke:#ffa502,color:#fff
+    style NATS fill:#ffd93d,stroke:#ffd93d,color:#000
+    style API fill:#6bcb77,stroke:#6bcb77,color:#fff
+    style WS fill:#4d96ff,stroke:#4d96ff,color:#fff
+    style UI fill:#9b59b6,stroke:#9b59b6,color:#fff
+    style Map fill:#e056fd,stroke:#e056fd,color:#fff`;
 ---
 
 <!DOCTYPE html>
@@ -723,10 +758,55 @@ const bazelDiagram = `flowchart LR
             </div>
         </section>
 
-        <!-- Deep Dive 3: Sextant -->
-        <section class="deep-dive" id="sextant">
+        <!-- Deep Dive 3: Ships - Real-Time Vessel Tracking -->
+        <section class="deep-dive" id="ships">
             <div class="deep-dive-header">
                 <span class="deep-dive-number">03</span>
+                <h2>Ships: Real-Time AIS Vessel Tracking</h2>
+            </div>
+
+            <div class="motivation">
+                <div class="motivation-label">Motivation</div>
+                <div class="motivation-text">
+                    Living near the coast, I wanted to see what ships are passing by in real-time. AIS (Automatic
+                    Identification System) data is publicly broadcast by vessels, but there's no simple way to
+                    visualize it locally. I built a pipeline that streams AIS data through my cluster to a live map.
+                </div>
+            </div>
+
+            <div class="diagram-container">
+                <MermaidDiagram diagram={shipsDiagram} id="ships" />
+            </div>
+
+            <a href="https://ships.jomcgi.dev" target="_blank" class="live-link">View Live at ships.jomcgi.dev →</a>
+
+            <div class="execution">
+                <div class="execution-label">Execution</div>
+                <div class="execution-grid">
+                    <div class="execution-row">
+                        <div class="execution-key">AIS Ingest</div>
+                        <div class="execution-value">Python service connects to AISStream.io WebSocket. Filters for Pacific Northwest bounding box. Publishes position reports to NATS JetStream.</div>
+                    </div>
+                    <div class="execution-row">
+                        <div class="execution-key">Event Sourcing</div>
+                        <div class="execution-value">Same pattern as Trips: NATS JetStream as the source of truth. API replays stream on startup to rebuild vessel state. No database needed.</div>
+                    </div>
+                    <div class="execution-row">
+                        <div class="execution-key">Ships API</div>
+                        <div class="execution-value">Go service with REST endpoints and WebSocket streaming. Clients subscribe to real-time position updates. 3 replicas for availability.</div>
+                    </div>
+                    <div class="execution-row">
+                        <div class="execution-key">MapLibre UI</div>
+                        <div class="execution-value">React frontend with MapLibre GL. Vessels rendered as directional arrows based on heading. Click for details: ship type, speed, course, destination.</div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Deep Dive 4: Sextant -->
+        <section class="deep-dive" id="sextant">
+            <div class="deep-dive-header">
+                <span class="deep-dive-number">04</span>
                 <h2>Sextant: Type-Safe Operator State Machines</h2>
             </div>
 
@@ -782,10 +862,10 @@ transitions:
       - requestID: string</code></pre>
         </section>
 
-        <!-- Deep Dive 4: Cloudflare Operator -->
+        <!-- Deep Dive 5: Cloudflare Operator -->
         <section class="deep-dive" id="cloudflare-operator">
             <div class="deep-dive-header">
-                <span class="deep-dive-number">04</span>
+                <span class="deep-dive-number">05</span>
                 <h2>Cloudflare Operator</h2>
             </div>
 
@@ -830,10 +910,10 @@ transitions:
     cloudflare.zero-trust.policy: joe-only</code></pre>
         </section>
 
-        <!-- Deep Dive 5: Stargazer -->
+        <!-- Deep Dive 6: Stargazer -->
         <section class="deep-dive" id="stargazer">
             <div class="deep-dive-header">
-                <span class="deep-dive-number">05</span>
+                <span class="deep-dive-number">06</span>
                 <h2>Stargazer: Dark Sky Location Finder</h2>
             </div>
 
@@ -873,10 +953,10 @@ transitions:
             </div>
         </section>
 
-        <!-- Deep Dive 6: Bazel Build System -->
+        <!-- Deep Dive 7: Bazel Build System -->
         <section class="deep-dive" id="bazel">
             <div class="deep-dive-header">
-                <span class="deep-dive-number">06</span>
+                <span class="deep-dive-number">07</span>
                 <h2>Bazel: One Way to Build Everything</h2>
             </div>
 

--- a/websites/jomcgi.dev/src/pages/index.astro
+++ b/websites/jomcgi.dev/src/pages/index.astro
@@ -521,17 +521,21 @@
                     <div class="project-name">trips.jomcgi.dev</div>
                     <div class="project-desc">Road trip tracker for our Yukon drive. On-the-road inference to detect wildlife from a car-mounted GoPro.</div>
                 </a>
-                <a href="/frank" class="project">
-                    <div class="project-name">Frank x Vancouver</div>
-                    <div class="project-desc">Trip website for my sister's visit.</div>
+                <a href="https://ships.jomcgi.dev" class="project">
+                    <div class="project-name">ships.jomcgi.dev</div>
+                    <div class="project-desc">Real-time vessel tracking for the Pacific Northwest. AIS data streamed via WebSocket to a MapLibre interface.</div>
+                </a>
+                <a href="/stargazer" class="project">
+                    <div class="project-name">Stargazer</div>
+                    <div class="project-desc">Dark sky locations in Scotland with clear weather forecasts. Find the best spots for astronomy tonight.</div>
                 </a>
                 <a href="https://hikes.jomcgi.dev" class="project">
                     <div class="project-name">hikes.jomcgi.dev</div>
                     <div class="project-desc">Find hikes in Scotland with good weather right now. Forecast updates every 30 minutes.</div>
                 </a>
-                <a href="/stargazer" class="project">
-                    <div class="project-name">Stargazer</div>
-                    <div class="project-desc">Dark sky locations in Scotland with clear weather forecasts. Find the best spots for astronomy tonight.</div>
+                <a href="/frank" class="project">
+                    <div class="project-name">Frank x Vancouver</div>
+                    <div class="project-desc">Trip website for my sister's visit.</div>
                 </a>
             </div>
         </section>
@@ -539,10 +543,6 @@
         <section>
             <div class="section-header">Building</div>
             <div class="section-content">
-                <a href="/engineering#claude-code" class="project wip">
-                    <div class="project-name">claude.jomcgi.dev</div>
-                    <div class="project-desc">In-cluster coding assistant with SigNoz access, local vLLM for code tasks, and full cluster visibility.</div>
-                </a>
                 <a href="/engineering#sextant" class="project wip">
                     <div class="project-name">Sextant</div>
                     <div class="project-desc">Generates typed Go for Kubernetes operators from declarative state machines.</div>
@@ -551,13 +551,9 @@
                     <div class="project-name">Cloudflare Operator</div>
                     <div class="project-desc">Annotate a service with a domain → operator creates tunnels, DNS records, zero trust rules.</div>
                 </a>
-                <a href="/engineering#stargazer" class="project wip">
-                    <div class="project-name">Stargazer</div>
-                    <div class="project-desc">Map of good stargazing spots. Filters for road access, low light pollution, clear forecasts.</div>
-                </a>
-                <a href="/engineering#bazel" class="project">
-                    <div class="project-name">Bazel Build System</div>
-                    <div class="project-desc">One command for everything. Same build on laptop, CI, and Claude Code in the cluster.</div>
+                <a href="/engineering#claude-code" class="project wip">
+                    <div class="project-name">claude.jomcgi.dev</div>
+                    <div class="project-desc">In-cluster coding assistant with SigNoz access, local vLLM for code tasks, and full cluster visibility.</div>
                 </a>
             </div>
         </section>


### PR DESCRIPTION
## Summary
- Reorder Side Quests by technical interest for recruiters/colleagues (trips → ships → stargazer → hikes → frank)
- Add ships.jomcgi.dev to Side Quests section
- Remove duplicates: Stargazer from Building (already in Side Quests), Bazel from Building (already in Homelab)
- Add Ships deep dive (#03) to engineering page documenting the AIS → NATS → WebSocket → MapLibre pipeline
- Update CLAUDE.md with marine chart, overlay, website, and service documentation

## Changes

**index.astro (homepage):**
- Side Quests reordered by technical impressiveness
- Added ships.jomcgi.dev with AIS streaming description
- Removed Stargazer duplicate from Building section  
- Removed Bazel from Building section (redundant with Homelab arch-grid)
- Building section now: Sextant, Cloudflare Operator, Claude Code

**engineering.astro:**
- Added Deep Dive 03: Ships - Real-Time AIS Vessel Tracking
- Includes Mermaid diagram showing AISStream.io → Ingest → NATS → API → WebSocket → MapLibre
- Renumbered sections 03-06 to 04-07

**CLAUDE.md:**
- Added `marine/` to charts directory listing
- Added `marine/` to overlays/dev directory listing
- Added `ships.jomcgi.dev/` to websites directory listing
- Added Marine service description to Development Services section

## Test plan
- [ ] Verify homepage renders correctly with new Side Quests order
- [ ] Verify ships.jomcgi.dev link works
- [ ] Verify engineering page Ships section renders with Mermaid diagram
- [ ] Verify all engineering section anchor links still work (#sextant, #cloudflare-operator, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)