### PR TITLE
fix(engineering): resolve Mermaid diagram naming collision in Ships section

### DIFF
--- a/websites/jomcgi.dev/src/pages/engineering.astro
+++ b/websites/jomcgi.dev/src/pages/engineering.astro
@@ -206,7 +206,7 @@ const bazelDiagram = `flowchart LR
 const shipsDiagram = `flowchart LR
     subgraph Ingest
         AIS[AISStream.io]
-        Ingest[ais-ingest]
+        Svc[ais-ingest]
     end
 
     subgraph Store
@@ -223,15 +223,15 @@ const shipsDiagram = `flowchart LR
         Map[MapLibre]
     end
 
-    AIS -->|WebSocket| Ingest
-    Ingest -->|Publish| NATS
+    AIS -->|WebSocket| Svc
+    Svc -->|Publish| NATS
     NATS -->|Subscribe| API
     API --> WS
     WS --> UI
     UI --> Map
 
     style AIS fill:#ff6b6b,stroke:#ff6b6b,color:#fff
-    style Ingest fill:#ffa502,stroke:#ffa502,color:#fff
+    style Svc fill:#ffa502,stroke:#ffa502,color:#fff
     style NATS fill:#ffd93d,stroke:#ffd93d,color:#000
     style API fill:#6bcb77,stroke:#6bcb77,color:#fff
     style WS fill:#4d96ff,stroke:#4d96ff,color:#fff


### PR DESCRIPTION
## Summary
Fix the Ships diagram on the engineering page that was showing raw Mermaid text instead of rendering.

## Root Cause
Mermaid node ID "Ingest" conflicted with subgraph ID "Ingest":

```mermaid
subgraph Ingest        <!-- subgraph has ID "Ingest" -->
    Ingest[ais-ingest] <!-- node ALSO has ID "Ingest" - collision! -->
end
```

Mermaid fails silently when there's a naming collision, displaying the raw text.

## Fix
Renamed the node from `Ingest[ais-ingest]` to `Svc[ais-ingest]` to avoid the collision.

## Test plan
- [ ] Verify Ships diagram renders correctly on engineering page

🤖 Generated with [Claude Code](https://claude.com/claude-code)