### PR TITLE
fix(argocd-image-updater): add :main tag to imageName for digest strategy

### DIFF
--- a/overlays/dev/cloudflare-operator/imageupdater.yaml
+++ b/overlays/dev/cloudflare-operator/imageupdater.yaml
@@ -11,7 +11,7 @@ spec:
         allowTags: regexp:^\d{4}\.\d{2}\.\d{2}\.\d{2}\.\d{2}\.\d{2}-[0-9a-f]{7}$
         updateStrategy: digest
         forceUpdate: false
-      imageName: ghcr.io/jomcgi/homelab/operators/cloudflare
+      imageName: ghcr.io/jomcgi/homelab/operators/cloudflare:main
       manifestTargets:
         helm:
           name: controllerManager.image.repository

--- a/overlays/dev/marine/imageupdater.yaml
+++ b/overlays/dev/marine/imageupdater.yaml
@@ -11,7 +11,7 @@ spec:
         allowTags: regexp:^\d{4}\.\d{2}\.\d{2}\.\d{2}\.\d{2}\.\d{2}-[0-9a-f]{7}$
         updateStrategy: digest
         forceUpdate: false
-      imageName: ghcr.io/jomcgi/homelab/services/ais-ingest
+      imageName: ghcr.io/jomcgi/homelab/services/ais-ingest:main
       manifestTargets:
         helm:
           name: ingest.image.repository
@@ -21,7 +21,7 @@ spec:
         allowTags: regexp:^\d{4}\.\d{2}\.\d{2}\.\d{2}\.\d{2}\.\d{2}-[0-9a-f]{7}$
         updateStrategy: digest
         forceUpdate: false
-      imageName: ghcr.io/jomcgi/homelab/services/ships-api
+      imageName: ghcr.io/jomcgi/homelab/services/ships-api:main
       manifestTargets:
         helm:
           name: api.image.repository
@@ -31,7 +31,7 @@ spec:
         allowTags: regexp:^\d{4}\.\d{2}\.\d{2}\.\d{2}\.\d{2}\.\d{2}-[0-9a-f]{7}$
         updateStrategy: digest
         forceUpdate: false
-      imageName: ghcr.io/jomcgi/homelab/services/ships-frontend
+      imageName: ghcr.io/jomcgi/homelab/services/ships-frontend:main
       manifestTargets:
         helm:
           name: frontend.image.repository

--- a/overlays/dev/stargazer/imageupdater.yaml
+++ b/overlays/dev/stargazer/imageupdater.yaml
@@ -11,7 +11,7 @@ spec:
         allowTags: regexp:^\d{4}\.\d{2}\.\d{2}\.\d{2}\.\d{2}\.\d{2}-[0-9a-f]{7}$
         updateStrategy: digest
         forceUpdate: false
-      imageName: ghcr.io/jomcgi/homelab/services/stargazer
+      imageName: ghcr.io/jomcgi/homelab/services/stargazer:main
       manifestTargets:
         helm:
           name: image.repository


### PR DESCRIPTION
## Summary
- Add `:main` tag to `imageName` fields in ImageUpdater configs for cloudflare-operator, stargazer, and marine services
- Fixes error: `cannot use update strategy 'digest' without a version constraint`
- Matches the pattern used by the working claude ImageUpdater config

## Context
The digest update strategy requires a version constraint (a tag) to know which tag's digest to watch. The affected configs only had the image name without a tag, causing the image updater to fail.

## Test plan
- [ ] Verify ArgoCD Image Updater logs no longer show the "version constraint" error
- [ ] Confirm image updates work correctly when new images are pushed

🤖 Generated with [Claude Code](https://claude.com/claude-code)