### PR TITLE
fix(ci): enable branch tagging for image pushes

### DIFF
--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -18,12 +18,19 @@ actions:
             echo "Skipping argocd-image-updater commit"
             exit 0
           fi
-          bazel test //... --deleted_packages=tools/python
+          bazel test //... --config=ci --deleted_packages=tools/python
 
       - run: |
           if [ "$(git log -1 --format='%an')" = "argocd-image-updater" ]; then
             exit 0
           fi
+          # Only push images on main branch (not PRs)
+          # GITHUB_REF_NAME is set by BuildBuddy for GitHub webhook events
+          if [ "${GITHUB_REF_NAME:-}" != "main" ]; then
+            echo "Skipping image push for non-main branch: ${GITHUB_REF_NAME:-unknown}"
+            exit 0
+          fi
           # GHCR_TOKEN set in BuildBuddy Settings → Secrets
           echo "$GHCR_TOKEN" | docker login ghcr.io -u jomcgi --password-stdin
-          bazel run //images:push_all
+          # --config=ci enables branch tag (e.g., "main") in addition to timestamp tag
+          bazel run //images:push_all --config=ci


### PR DESCRIPTION
## Summary
- Add `--define CI=true` to BuildBuddy CI to enable branch tagging
- Skip image push on PRs (only push on main branch)

## Problem
Images were being pushed with only timestamp tags (e.g., `2026.01.18.19.48.26-55ad3ef`) but no `:main` tag. The digest-based image updater needs the `:main` tag to track.

## Fix
Add `--define CI=true` which triggers the `ci_build` config setting in Bazel, causing images to be pushed with both:
- `main` - branch tag for digest tracking
- `2026.01.18.20.50.31-abc1234` - timestamp tag

## How It Works
1. CI pushes image with tags: `main` + timestamp
2. Image updater watches `:main` tag's digest
3. When digest changes, writes `main@sha256:...` to values.yaml
4. Kubernetes pulls by digest = immutable deployments

## Test plan
- [ ] Verify next CI build pushes images with `:main` tag
- [ ] Verify image updater writes `main@sha256:...` format

🤖 Generated with [Claude Code](https://claude.com/claude-code)