### PR TITLE
fix(ci): enable digest-based image updates with main tag

### DIFF
--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -23,7 +23,7 @@ actions:
           fi
           # GHCR_TOKEN set in BuildBuddy Settings → Secrets
           echo "$GHCR_TOKEN" | docker login ghcr.io -u jomcgi --password-stdin
-          bazel run //images:push_all
+          bazel run //images:push_all --config=ci
 
   - name: "Test"
     container_image: "ubuntu-24.04"

--- a/overlays/dev/ais-ingest/imageupdater.yaml
+++ b/overlays/dev/ais-ingest/imageupdater.yaml
@@ -8,10 +8,9 @@ spec:
   - images:
     - alias: ais-ingest
       commonUpdateSettings:
-        allowTags: regexp:^\d{4}\.\d{2}\.\d{2}\.\d{2}\.\d{2}\.\d{2}-[0-9a-f]{7}$
-        updateStrategy: newest-build
+        updateStrategy: digest
         forceUpdate: false
-      imageName: ghcr.io/jomcgi/homelab/services/ais-ingest
+      imageName: ghcr.io/jomcgi/homelab/services/ais-ingest:main
       manifestTargets:
         helm:
           name: image.repository


### PR DESCRIPTION
## Summary
- Add `--config=ci` flag to BuildBuddy to push both main and timestamp tags
- Simplify ArgoCD Image Updater to use digest-based tracking of main tag
- Remove complex regex pattern for cleaner configuration

## Problem
BuildBuddy CI wasn't pushing the 'main' tag alongside timestamp tags, causing ArgoCD Image Updater to miss updates.

## Solution
1. **BuildBuddy**: Added `--config=ci` flag to `bazel run //images:push_all` to enable dual tagging
2. **ArgoCD Image Updater**: Switched from regex-based tag matching to digest-based tracking of the 'main' tag

## Impact
- CI builds now push both tags: `main` (mutable) and `YYYY.MM.DD.HH.MM.SS-<sha>` (immutable)
- ArgoCD tracks the main tag's digest for reliable updates
- Cleaner, more maintainable configuration

🤖 Generated with [Claude Code](https://claude.com/claude-code)