### PR TITLE
fix(ci): improve branch detection for BuildBuddy CI environment

### DIFF
--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -25,9 +25,11 @@ actions:
             exit 0
           fi
           # Only push images on main branch (not PRs)
-          # GITHUB_REF_NAME is set by BuildBuddy for GitHub webhook events
-          if [ "${GITHUB_REF_NAME:-}" != "main" ]; then
-            echo "Skipping image push for non-main branch: ${GITHUB_REF_NAME:-unknown}"
+          # BuildBuddy provides GIT_BRANCH or GITHUB_REF for branch detection
+          # workspace_status.sh will check multiple environment variables
+          branch="${GIT_BRANCH:-${GITHUB_REF_NAME:-}}"
+          if [ "${branch}" != "main" ] && [ "${branch}" != "refs/heads/main" ]; then
+            echo "Skipping image push for non-main branch: ${branch:-unknown}"
             exit 0
           fi
           # GHCR_TOKEN set in BuildBuddy Settings → Secrets

--- a/tools/workspace_status.sh
+++ b/tools/workspace_status.sh
@@ -17,11 +17,44 @@ auto_version=$(
 base_image_tag=$(date -u +"%Y.%m.%d.%H.%M.%S")-${git_short_sha}
 
 # Get branch name (sanitized for Docker tags)
-# In CI: use GITHUB_REF_NAME, otherwise use git
+# Check multiple CI environment variables for branch name
 if [ -n "${GITHUB_REF_NAME:-}" ]; then
+	# GitHub Actions provides this directly
 	branch="${GITHUB_REF_NAME}"
+elif [ -n "${GIT_BRANCH:-}" ]; then
+	# BuildBuddy and Jenkins provide this
+	branch="${GIT_BRANCH}"
+elif [ -n "${GITHUB_REF:-}" ]; then
+	# GitHub webhook events provide refs/heads/branch-name
+	# Extract branch name from refs/heads/ or refs/pull/
+	if [[ "${GITHUB_REF}" == refs/heads/* ]]; then
+		branch="${GITHUB_REF#refs/heads/}"
+	elif [[ "${GITHUB_REF}" == refs/pull/* ]]; then
+		# For pull requests, use PR branch name if available
+		branch="${GITHUB_HEAD_REF:-pr-${GITHUB_REF#refs/pull/}}"
+	else
+		branch="${GITHUB_REF}"
+	fi
+elif [ -n "${BUILDKITE_BRANCH:-}" ]; then
+	# Buildkite CI
+	branch="${BUILDKITE_BRANCH}"
+elif [ -n "${CIRCLE_BRANCH:-}" ]; then
+	# CircleCI
+	branch="${CIRCLE_BRANCH}"
+elif [ -n "${CI_COMMIT_BRANCH:-}" ]; then
+	# GitLab CI
+	branch="${CI_COMMIT_BRANCH}"
 else
-	branch=$(git rev-parse --abbrev-ref HEAD)
+	# Fallback to git command (may fail in detached HEAD state)
+	branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
+fi
+
+# Debug output when CI is set (only visible in build logs)
+if [ "${CI:-}" = "true" ] || [ "${CI:-}" = "1" ]; then
+	>&2 echo "workspace_status.sh: Detected branch '${branch}' from environment"
+	>&2 echo "  GITHUB_REF_NAME=${GITHUB_REF_NAME:-<not set>}"
+	>&2 echo "  GIT_BRANCH=${GIT_BRANCH:-<not set>}"
+	>&2 echo "  GITHUB_REF=${GITHUB_REF:-<not set>}"
 fi
 # Sanitize: replace / with - and convert to lowercase
 branch_tag=$(echo "${branch}" | tr '/' '-' | tr '[:upper:]' '[:lower:]')


### PR DESCRIPTION
## Summary
- Make workspace_status.sh more robust by checking multiple CI environment variables
- Ensure 'main' branch tag is pushed alongside timestamp tags in BuildBuddy CI

## Problem
BuildBuddy doesn't provide `GITHUB_REF_NAME` like GitHub Actions does. Our workspace_status.sh script was falling back to `git rev-parse --abbrev-ref HEAD`, which might not work correctly in BuildBuddy's environment, preventing the 'main' tag from being pushed to GHCR.

## Solution
Updated `tools/workspace_status.sh` to check multiple environment variables in priority order:
1. `GITHUB_REF_NAME` (GitHub Actions)
2. `GIT_BRANCH` (BuildBuddy, Jenkins)  
3. `GITHUB_REF` (GitHub webhooks - extracts from refs/heads/main)
4. Other CI systems (Buildkite, CircleCI, GitLab)
5. Fallback to git command

Also added debug output when `CI=true` to help verify which environment variable is being used.

## Testing
- Tested locally with various environment variable combinations
- Verified correct branch detection with `GIT_BRANCH=main` (BuildBuddy style)
- Verified extraction from `GITHUB_REF=refs/heads/main` format
- Debug output confirms the correct source is being used

## Impact
Once merged, BuildBuddy CI will correctly:
1. Detect it's on the 'main' branch
2. Push both tags: `main` (for ArgoCD digest tracking) and timestamp tags
3. Enable ArgoCD Image Updater to properly track and update images

🤖 Generated with [Claude Code](https://claude.com/claude-code)