### PR TITLE
fix(cloudflare-operator): use pinned cloudflared image version

### DIFF
--- a/operators/cloudflare/cmd/main.go
+++ b/operators/cloudflare/cmd/main.go
@@ -289,9 +289,16 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Get cloudflared image from environment variable if set
+	cloudflaredImage := os.Getenv("CLOUDFLARED_IMAGE")
+	if cloudflaredImage != "" {
+		setupLog.Info("using custom cloudflared image", "image", cloudflaredImage)
+	}
+
 	if err := (&controller.GatewayReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
+		Client:           mgr.GetClient(),
+		Scheme:           mgr.GetScheme(),
+		CloudflaredImage: cloudflaredImage,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Gateway")
 		os.Exit(1)

--- a/operators/cloudflare/helm/cloudflare-operator/templates/deployment.yaml
+++ b/operators/cloudflare/helm/cloudflare-operator/templates/deployment.yaml
@@ -74,6 +74,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        {{- if .Values.controllerManager.cloudflaredImage }}
+        - name: CLOUDFLARED_IMAGE
+          value: {{ .Values.controllerManager.cloudflaredImage | quote }}
+        {{- end }}
         {{- if .Values.controllerManager.tracing.endpoint }}
         # OpenTelemetry standard environment variables
         - name: OTEL_EXPORTER_OTLP_ENDPOINT

--- a/operators/cloudflare/helm/cloudflare-operator/values.yaml
+++ b/operators/cloudflare/helm/cloudflare-operator/values.yaml
@@ -80,6 +80,11 @@ controllerManager:
   # Enable daemon mode to auto-create default tunnel
   enableDaemon: true
 
+  # Cloudflared image configuration
+  # This image is used for the cloudflared daemon pods created by the operator
+  # If not set, defaults to cloudflare/cloudflared:2025.11.1
+  cloudflaredImage: ""
+
   # OpenTelemetry tracing configuration using standard OTEL environment variables
   # See: https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/
   tracing:

--- a/operators/cloudflare/internal/controller/gateway_controller.go
+++ b/operators/cloudflare/internal/controller/gateway_controller.go
@@ -58,8 +58,9 @@ const (
 	// GatewayAnnotationAccountID stores the Cloudflare account ID
 	GatewayAnnotationAccountID = "gateway.cloudflare.io/account-id"
 
-	// DefaultCloudflaredImage is the default cloudflared image
-	DefaultCloudflaredImage = "cloudflare/cloudflared:latest"
+	// DefaultCloudflaredImage is the default cloudflared image with a pinned version
+	// Using a specific version ensures reliability and prevents Docker Hub rate limiting issues
+	DefaultCloudflaredImage = "cloudflare/cloudflared:2025.11.1"
 
 	// DefaultCloudflaredReplicas is the default number of cloudflared replicas
 	DefaultCloudflaredReplicas = 2
@@ -68,8 +69,9 @@ const (
 // GatewayReconciler reconciles a Gateway object
 type GatewayReconciler struct {
 	client.Client
-	Scheme *runtime.Scheme
-	tracer trace.Tracer
+	Scheme           *runtime.Scheme
+	tracer           trace.Tracer
+	CloudflaredImage string // Configurable cloudflared image
 }
 
 // +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=gateways,verbs=get;list;watch;update;patch
@@ -587,6 +589,14 @@ func (r *GatewayReconciler) ensureTunnelSecret(ctx context.Context, gateway *gat
 	return secretName, nil
 }
 
+// getCloudflaredImage returns the cloudflared image to use, either from configuration or default
+func (r *GatewayReconciler) getCloudflaredImage() string {
+	if r.CloudflaredImage != "" {
+		return r.CloudflaredImage
+	}
+	return DefaultCloudflaredImage
+}
+
 // ensureCloudflaredDeployment creates or updates the cloudflared daemon deployment
 func (r *GatewayReconciler) ensureCloudflaredDeployment(ctx context.Context, gateway *gatewayv1.Gateway, secretName string) (string, error) {
 	log := log.FromContext(ctx)
@@ -624,7 +634,7 @@ func (r *GatewayReconciler) ensureCloudflaredDeployment(ctx context.Context, gat
 					Containers: []corev1.Container{
 						{
 							Name:  "cloudflared",
-							Image: DefaultCloudflaredImage,
+							Image: r.getCloudflaredImage(),
 							Args: []string{
 								"tunnel",
 								"--no-autoupdate",


### PR DESCRIPTION
## Summary
- Fixes cloudflared pods failing with `ImagePullBackOff` in marine namespace
- Replaces unreliable `:latest` tag with specific version `2025.11.1`
- Adds configuration option for custom image versions

## Problem
The Cloudflare operator was using `cloudflare/cloudflared:latest` which was causing:
- Docker Hub pull failures due to missing/unstable `:latest` tag
- Pods stuck in `ImagePullBackOff` state
- Ships.jomcgi.dev being inaccessible due to tunnel failures

## Solution
1. Updated the default image from `cloudflare/cloudflared:latest` to `cloudflare/cloudflared:2025.11.1`
2. Added support for configuring the image via:
   - Environment variable: `CLOUDFLARED_IMAGE`
   - Helm value: `controllerManager.cloudflaredImage`
3. Made the configuration optional with sensible defaults

## Test Plan
- [x] Helm template renders correctly with custom image
- [x] Helm template works without custom image (uses default)
- [ ] Deploy updated operator to cluster
- [ ] Verify marine namespace cloudflared pods start successfully
- [ ] Confirm ships.jomcgi.dev becomes accessible

🤖 Generated with [Claude Code](https://claude.com/claude-code)