### PR TITLE
fix(stargazer): filter past hours and sort windows chronologically

### DIFF
--- a/websites/jomcgi.dev/src/pages/stargazer.astro
+++ b/websites/jomcgi.dev/src/pages/stargazer.astro
@@ -481,17 +481,25 @@
                     }
 
                     const data = await res.json();
+                    const now = new Date();
+
                     locations = data
                         .map(loc => {
                             const lat = loc.coordinates?.lat;
                             const lon = loc.coordinates?.lon;
                             if (typeof lat !== 'number' || typeof lon !== 'number') return null;
 
-                            // API returns only dark hours (sun below -12°), sorted by score
-                            const hours = (loc.best_hours || []).slice(0, 5);
-                            if (hours.length === 0) return null;
+                            // Filter to future hours only and sort chronologically
+                            const futureHours = (loc.best_hours || [])
+                                .filter(h => new Date(h.time) > now)
+                                .sort((a, b) => new Date(a.time) - new Date(b.time))
+                                .slice(0, 5);
 
-                            const best = hours[0];
+                            if (futureHours.length === 0) return null;
+
+                            // Best score is the highest among remaining future hours
+                            const best = futureHours.reduce((max, h) =>
+                                h.score > max.score ? h : max, futureHours[0]);
 
                             return {
                                 id: loc.id,
@@ -500,7 +508,7 @@
                                 score: Math.round(best.score || 0),
                                 cloud: Math.round(best.cloud_area_fraction || 0),
                                 wind: best.wind_speed?.toFixed(1) || '?',
-                                windows: hours.map(h => ({
+                                windows: futureHours.map(h => ({
                                     time: formatTimeShort(new Date(h.time)),
                                     score: Math.round(h.score)
                                 }))


### PR DESCRIPTION
## Summary
- Filters out clear window hours that have already passed (time < now)
- Sorts remaining hours chronologically by time instead of by score
- Uses highest score from remaining future hours for marker display

This keeps the API response cacheable (one cached response per 30min regardless of users) while ensuring users see only upcoming viewing windows in correct time order.

## Test plan
- [ ] Load stargazer page after midnight
- [ ] Verify past hours (e.g., 00:00) no longer appear in tooltip
- [ ] Verify windows are sorted chronologically (e.g., 20:00, 21:00, 22:00)
- [ ] Verify marker score reflects best score among remaining future hours

🤖 Generated with [Claude Code](https://claude.ai/code)