### PR TITLE
fix(stargazer): show day name to disambiguate duplicate times

### DIFF
--- a/websites/jomcgi.dev/src/pages/stargazer.astro
+++ b/websites/jomcgi.dev/src/pages/stargazer.astro
@@ -277,12 +277,28 @@
         }
 
         // Format time for display (in UK timezone since locations are in Scotland)
+        // Shows "HH:MM" for today, "Thu HH:MM" for other days
         function formatTimeShort(date) {
-            return date.toLocaleTimeString('en-GB', {
+            const timeStr = date.toLocaleTimeString('en-GB', {
                 hour: '2-digit',
                 minute: '2-digit',
                 timeZone: 'Europe/London'
             });
+
+            // Get today's date in UK timezone
+            const ukNow = new Date().toLocaleDateString('en-GB', { timeZone: 'Europe/London' });
+            const ukDate = date.toLocaleDateString('en-GB', { timeZone: 'Europe/London' });
+
+            if (ukDate === ukNow) {
+                return timeStr;
+            }
+
+            // Show day name for other days
+            const dayName = date.toLocaleDateString('en-GB', {
+                weekday: 'short',
+                timeZone: 'Europe/London'
+            });
+            return `${dayName} ${timeStr}`;
         }
 
         // Map setup


### PR DESCRIPTION
## Summary
- Times on different days were showing as duplicates (e.g., two "00:00" entries with different scores)
- Now shows day name for future dates: "Thu 00:00" instead of just "00:00"
- Today's times remain concise: "18:00"

## Test plan
- [ ] Verify today's windows show just time (e.g., "20:00")
- [ ] Verify tomorrow's windows show day + time (e.g., "Mon 00:00")
- [ ] Verify no more ambiguous duplicate times

🤖 Generated with [Claude Code](https://claude.ai/code)