### PR TITLE
fix(ships-api): add ASC index for vessel track queries

### DIFF
--- a/services/ships-api/main.py
+++ b/services/ships-api/main.py
@@ -108,6 +108,10 @@ ON positions(mmsi, timestamp DESC);
 CREATE INDEX IF NOT EXISTS idx_positions_timestamp
 ON positions(timestamp DESC);
 
+-- Index for track queries (ASC order matches query pattern)
+CREATE INDEX IF NOT EXISTS idx_positions_mmsi_timestamp_asc
+ON positions(mmsi, timestamp ASC);
+
 -- Index for retention cleanup
 CREATE INDEX IF NOT EXISTS idx_positions_received_at
 ON positions(received_at);


### PR DESCRIPTION
## Summary
- Add `idx_positions_mmsi_timestamp_asc` index on `(mmsi, timestamp ASC)` to match the track query pattern
- The existing index was `(mmsi, timestamp DESC)` but track queries use `ORDER BY timestamp ASC`
- SQLite can't efficiently use a DESC index for ASC queries

## Test plan
- [ ] Deploy and verify track queries are faster
- [ ] Check `EXPLAIN QUERY PLAN` shows the new index being used

🤖 Generated with [Claude Code](https://claude.com/claude-code)