### PR TITLE
fix(api-gateway): use deployedAt for GitOps sync timestamp

### DIFF
--- a/charts/api-gateway/templates/collector-configmap.yaml
+++ b/charts/api-gateway/templates/collector-configmap.yaml
@@ -81,8 +81,10 @@ data:
     # Get ArgoCD app-of-apps status (canada) for overall sync status
     ARGO_STATUS=$(kubectl get application -n argocd canada -o jsonpath='{.status.sync.status}' 2>/dev/null || echo "Unknown")
     ARGO_REVISION=$(kubectl get application -n argocd canada -o jsonpath='{.status.sync.revision}' 2>/dev/null | cut -c1-7 || echo "")
-    # Get the most recent sync time from ALL ArgoCD applications (not just app-of-apps)
-    ARGO_SYNCED_AT=$(kubectl get applications -n argocd -o jsonpath='{range .items[*]}{.status.operationState.finishedAt}{"\n"}{end}' 2>/dev/null | sort -r | head -1 || echo "")
+    # Get the most recent deployment time from ALL ArgoCD applications
+    # Uses history[0].deployedAt which only updates when a new revision is deployed,
+    # not on periodic reconciliation or refresh operations
+    ARGO_SYNCED_AT=$(kubectl get applications -n argocd -o jsonpath='{range .items[*]}{.status.history[0].deployedAt}{"\n"}{end}' 2>/dev/null | sort -r | head -1 || echo "")
 
     # Generate timestamp
     TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")


### PR DESCRIPTION
## Summary
- Changed cluster-info collector to use `status.history[0].deployedAt` instead of `status.operationState.finishedAt`
- The timestamp now only updates when a new revision is actually deployed, not on periodic ArgoCD reconciliation or refresh operations
- Fixes misleading "3m ago" timestamps on jomcgi.dev when no commits were recently merged

## Test plan
- [ ] Verify api-gateway collector pod restarts after ArgoCD sync
- [ ] Check that GitOps timestamp on jomcgi.dev reflects actual deployment times

🤖 Generated with [Claude Code](https://claude.com/claude-code)