### PR TITLE
fix(api-gateway): get newest history entry, not oldest

### DIFF
--- a/charts/api-gateway/templates/collector-configmap.yaml
+++ b/charts/api-gateway/templates/collector-configmap.yaml
@@ -82,9 +82,9 @@ data:
     ARGO_STATUS=$(kubectl get application -n argocd canada -o jsonpath='{.status.sync.status}' 2>/dev/null || echo "Unknown")
     ARGO_REVISION=$(kubectl get application -n argocd canada -o jsonpath='{.status.sync.revision}' 2>/dev/null | cut -c1-7 || echo "")
     # Get the most recent deployment time from ALL ArgoCD applications
-    # Uses history[0].deployedAt which only updates when a new revision is deployed,
-    # not on periodic reconciliation or refresh operations
-    ARGO_SYNCED_AT=$(kubectl get applications -n argocd -o jsonpath='{range .items[*]}{.status.history[0].deployedAt}{"\n"}{end}' 2>/dev/null | sort -r | head -1 || echo "")
+    # Iterates through all history entries (not just history[0] which is oldest)
+    # and finds the most recent deployedAt timestamp
+    ARGO_SYNCED_AT=$(kubectl get applications -n argocd -o jsonpath='{range .items[*]}{range .status.history[*]}{.deployedAt}{"\n"}{end}{end}' 2>/dev/null | sort -r | head -1 || echo "")
 
     # Generate timestamp
     TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")


### PR DESCRIPTION
## Summary
- ArgoCD history array is ordered oldest→newest, so `history[0]` was returning the oldest deployment
- Changed JSONPath to iterate ALL history entries from all applications and sort to find the most recent `deployedAt` timestamp
- Fixes #223 which still showed stale timestamps

## Test plan
- [ ] Verify GitOps timestamp on jomcgi.dev shows recent deployment time after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)