### PR TITLE
feat(nats): enable Prometheus metrics exporter

### DIFF
--- a/charts/nats/values.yaml
+++ b/charts/nats/values.yaml
@@ -35,6 +35,27 @@ nats:
           annotations:
             numberOfReplicas: "1"
 
+    # Enable monitoring endpoint for Prometheus exporter
+    monitor:
+      enabled: true
+      port: 8222
+
+  # Prometheus metrics exporter sidecar
+  promExporter:
+    enabled: true
+    image:
+      repository: natsio/prometheus-nats-exporter
+      tag: 0.18.0
+    port: 7777
+    merge:
+      resources:
+        requests:
+          cpu: 10m
+          memory: 32Mi
+        limits:
+          cpu: 100m
+          memory: 64Mi
+
   # Container configuration
   container:
     image:
@@ -61,3 +82,10 @@ nats:
       nats:
         enabled: true
         port: 4222
+    # Prometheus scrape annotations for SigNoz
+    merge:
+      metadata:
+        annotations:
+          prometheus.io/scrape: "true"
+          prometheus.io/port: "7777"
+          prometheus.io/path: "/metrics"

--- a/overlays/prod/nats/manifests/all.yaml
+++ b/overlays/prod/nats/manifests/all.yaml
@@ -99,6 +99,10 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    prometheus.io/path: /metrics
+    prometheus.io/port: "7777"
+    prometheus.io/scrape: "true"
   labels:
     app.kubernetes.io/component: nats
     app.kubernetes.io/instance: nats
@@ -292,6 +296,28 @@ spec:
           name: pid
         - mountPath: /etc/nats-config
           name: config
+      - args:
+        - -port=7777
+        - -connz
+        - -routez
+        - -subz
+        - -varz
+        - -prefix=nats
+        - -use_internal_server_id
+        - -jsz=all
+        - http://localhost:8222/
+        image: natsio/prometheus-nats-exporter:0.18.0
+        name: prom-exporter
+        ports:
+        - containerPort: 7777
+          name: prom-metrics
+        resources:
+          limits:
+            cpu: 100m
+            memory: 64Mi
+          requests:
+            cpu: 10m
+            memory: 32Mi
       enableServiceLinks: false
       nodeSelector:
         kubernetes.io/hostname: node-4


### PR DESCRIPTION
## Summary
- Enable prometheus-nats-exporter sidecar on NATS StatefulSet
- Add prometheus.io annotations to Service for SigNoz auto-discovery
- Expose JetStream metrics (jsz=all) for stream/consumer visibility

## Metrics Available
After deployment, NATS will expose metrics on port 7777:
- `nats_varz_*` - Server stats (connections, memory, CPU)
- `nats_connz_*` - Connection details
- `nats_jsz_*` - JetStream streams/consumers (messages, bytes, pending)

## Test plan
- [ ] Verify pod starts with prom-exporter sidecar
- [ ] Verify metrics endpoint: `kubectl exec -n nats nats-0 -c prom-exporter -- wget -qO- http://localhost:7777/metrics | head`
- [ ] Verify SigNoz discovers and scrapes NATS metrics

🤖 Generated with [Claude Code](https://claude.com/claude-code)