### PR TITLE
feat(jomcgi.dev): add Claude Code preview support

### DIFF
--- a/websites/jomcgi.dev/astro.config.mjs
+++ b/websites/jomcgi.dev/astro.config.mjs
@@ -6,4 +6,17 @@ import tailwind from "@astrojs/tailwind";
 // https://astro.build/config
 export default defineConfig({
   integrations: [react(), tailwind()],
+  vite: {
+    server: {
+      host: true,
+      hmr: {
+        clientPort: 443,
+        protocol: 'wss',
+      },
+    },
+  },
+  server: {
+    host: true,
+    allowedHosts: ['claude.jomcgi.dev'],
+  },
 });


### PR DESCRIPTION
## Summary
- Configure Astro dev server to work with Claude Code's preview proxy
- Enable hot module reload (HMR) over WebSocket through HTTPS
- Allow claude.jomcgi.dev host for development previews

## Changes
- Added Vite server configuration to allow claude.jomcgi.dev host
- Configured WebSocket settings for HMR to work through the nginx proxy
- Set server to bind to all interfaces for proxy accessibility

## Test plan
✅ Tested locally:
- [x] Run `npm run dev` in websites/jomcgi.dev
- [x] Access site through https://claude.jomcgi.dev/preview/4321/
- [x] Verify site loads without host blocking errors
- [x] Confirm HMR works for live updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)