### PR TITLE
fix(ships-api): increase max_ack_pending to prevent NATS throttling

### DIFF
--- a/services/ships-api/main.py
+++ b/services/ships-api/main.py
@@ -634,10 +634,12 @@ class ShipsAPIService:
 
         try:
             # Durable consumer - NATS tracks position across restarts
+            # max_ack_pending allows larger batches without NATS throttling
             consumer_config = ConsumerConfig(
                 durable_name="ships-api",
                 deliver_policy=DeliverPolicy.ALL,
                 ack_wait=120,  # Longer ack wait for batch processing
+                max_ack_pending=10000,  # Allow 10k unacked msgs (default 1000 throttles us)
             )
 
             psub = await self.js.pull_subscribe(


### PR DESCRIPTION
## Summary

The previous performance optimization PR (#230) didn't help because NATS was throttling us at the consumer level.

**Root cause:** The NATS consumer was created with the default `max_ack_pending=1000`. When we fetch batches of 2000 messages, we immediately hit the limit and NATS stops delivering until acks are processed.

Evidence from `nats consumer info ais ships-api`:
```
Outstanding Acks: 1,000 out of maximum 1,000
Unprocessed Messages: 888,091
```

**Fix:** Increase `max_ack_pending` to 10,000 to allow larger batches without throttling.

## Important: Manual step required

The existing consumer must be deleted for the new config to take effect. NATS doesn't allow changing consumer config after creation.

```bash
kubectl exec -n nats nats-box-798dc8f484-dkvnc -- nats consumer delete ais ships-api
```

Then restart the ships-api pod to recreate the consumer with the new config.

## Test plan

- [ ] Delete existing consumer (command above)
- [ ] Restart ships-api pod: `kubectl delete pod -n marine marine-api-0`
- [ ] Verify new consumer has `max_ack_pending=10000`: `nats consumer info ais ships-api`
- [ ] Monitor catchup progress - should see >10x improvement in processing rate

🤖 Generated with [Claude Code](https://claude.com/claude-code)