### PR TITLE
perf(ships-api): aggressive SQLite tuning for faster catchup

### DIFF
--- a/services/ships-api/main.py
+++ b/services/ships-api/main.py
@@ -170,11 +170,13 @@ class Database:
         self.db = await aiosqlite.connect(self.db_path)
         self.db.row_factory = aiosqlite.Row
 
-        # Enable WAL mode for better concurrent performance
+        # Aggressive SQLite tuning for high-throughput ingestion
         await self.db.execute("PRAGMA journal_mode=WAL")
-        await self.db.execute("PRAGMA synchronous=NORMAL")
-        # Increase cache for better performance with large datasets
-        await self.db.execute("PRAGMA cache_size=-384000")  # 384MB cache
+        await self.db.execute("PRAGMA synchronous=OFF")  # Skip fsync (WAL provides crash safety)
+        await self.db.execute("PRAGMA temp_store=MEMORY")  # Temp tables in RAM
+        await self.db.execute("PRAGMA mmap_size=268435456")  # 256MB memory-mapped I/O
+        await self.db.execute("PRAGMA cache_size=-512000")  # 512MB cache
+        await self.db.execute("PRAGMA wal_autocheckpoint=10000")  # Checkpoint every 10k pages
 
         # Create schema
         await self.db.executescript(SCHEMA)
@@ -661,8 +663,8 @@ class ShipsAPIService:
             while self.running:
                 try:
                     # Use larger batches when catching up, smaller for live
-                    batch_size = 2000 if not self.replay_complete else 200
-                    timeout = 2 if not self.replay_complete else 1
+                    batch_size = 5000 if not self.replay_complete else 500
+                    timeout = 5 if not self.replay_complete else 1
 
                     msgs = await psub.fetch(batch=batch_size, timeout=timeout)
 


### PR DESCRIPTION
## Summary

The ships-api pod is using only 2-3% CPU during catchup, indicating it's I/O bound waiting on SQLite fsync calls. This PR adds aggressive SQLite tuning to maximize write throughput.

## Changes

| Setting | Before | After | Impact |
|---------|--------|-------|--------|
| `synchronous` | NORMAL | OFF | Skip fsync calls |
| `temp_store` | default | MEMORY | Temp tables in RAM |
| `mmap_size` | 0 | 256MB | Memory-mapped I/O |
| `cache_size` | 384MB | 512MB | Larger page cache |
| `wal_autocheckpoint` | 1000 | 10000 | Less frequent checkpoints |
| Batch size | 2000 | 5000 | Larger DB batches |

### Safety of synchronous=OFF

With WAL mode enabled, `synchronous=OFF` is relatively safe:
- Committed transactions are still durable in the WAL
- Worst case on crash: lose the last uncommitted batch
- For AIS data this is acceptable - we can replay from NATS

## Test plan

- [ ] Deploy and monitor catchup rate
- [ ] Verify CPU usage increases (should be doing actual work now)
- [ ] Check if backlog is shrinking instead of growing

🤖 Generated with [Claude Code](https://claude.com/claude-code)