### PR TITLE
fix(marine): increase probe timeouts to prevent crashloop during catchup

### DIFF
--- a/charts/marine/templates/api-deployment.yaml
+++ b/charts/marine/templates/api-deployment.yaml
@@ -59,17 +59,19 @@ spec:
             httpGet:
               path: /health
               port: http
-            initialDelaySeconds: 5
-            periodSeconds: 10
+            initialDelaySeconds: 10
+            periodSeconds: 15
+            timeoutSeconds: 10
             failureThreshold: 6
           readinessProbe:
             httpGet:
               path: /ready
               port: http
-            initialDelaySeconds: 5
-            periodSeconds: 5
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 10
             # Allow longer startup for large replay
-            failureThreshold: 120
+            failureThreshold: 360
           resources:
             {{- toYaml .Values.api.resources | nindent 12 }}
           volumeMounts:


### PR DESCRIPTION
## Summary

The ships-api pod was entering CrashLoopBackOff because the liveness probe was timing out when the service is busy processing large batches:

```
Liveness probe failed: context deadline exceeded (Client.Timeout exceeded while awaiting headers)
```

## Changes

| Probe | Setting | Before | After |
|-------|---------|--------|-------|
| liveness | timeoutSeconds | 1s | 10s |
| liveness | periodSeconds | 10s | 15s |
| readiness | timeoutSeconds | 1s | 10s |
| readiness | periodSeconds | 5s | 10s |
| readiness | failureThreshold | 120 | 360 |

The readiness failureThreshold of 360 × 10s = 1 hour allows for extended catchup time.

## Test plan

- [ ] Deploy and verify pod stays running
- [ ] Confirm catchup proceeds without restarts

🤖 Generated with [Claude Code](https://claude.com/claude-code)