### PR TITLE
feat(signoz): add prometheus scraping for NATS metrics

### DIFF
--- a/overlays/cluster-critical/signoz/manifests/all.yaml
+++ b/overlays/cluster-critical/signoz/manifests/all.yaml
@@ -470,6 +470,16 @@ data:
             enabled: true
       k8s_events:
         auth_type: serviceAccount
+      prometheus/nats:
+        config:
+          scrape_configs:
+          - job_name: nats
+            scrape_interval: 30s
+            static_configs:
+            - labels:
+                service: nats
+              targets:
+              - nats.nats.svc.cluster.local:7777
     service:
       extensions:
       - health_check
@@ -494,6 +504,15 @@ data:
           - batch
           receivers:
           - k8s_cluster
+        metrics/scraper:
+          exporters:
+          - otlp
+          processors:
+          - resourcedetection
+          - k8sattributes
+          - batch
+          receivers:
+          - prometheus/nats
       telemetry:
         logs:
           encoding: json
@@ -2286,7 +2305,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 0016ce3956d9ea4b46a0516b1acccbe7d2de4d3971c62b594f1ac22b1fd8db96
+        checksum/config: 1b4e0b907467effd8f97c9be5d4cdb6b101222c12a4a8d72a6c3c928d149396e
       labels:
         app.kubernetes.io/name: k8s-infra
         app.kubernetes.io/instance: signoz

--- a/overlays/cluster-critical/signoz/values.yaml
+++ b/overlays/cluster-critical/signoz/values.yaml
@@ -16,10 +16,16 @@ k8s-infra:
                       service: nats
       service:
         pipelines:
-          metrics:
+          # Add NATS metrics to the scraper pipeline
+          metrics/scraper:
             receivers:
-              - otlp
               - prometheus/nats
+            processors:
+              - k8sattributes
+              - resourcedetection
+              - batch
+            exporters:
+              - otlp
 
 signoz:
   clickhouse:


### PR DESCRIPTION
## Summary

Configure SigNoz k8s-infra to scrape NATS JetStream prometheus metrics, enabling observability of the message queue.

## Metrics enabled

| Metric | Description |
|--------|-------------|
| `nats_consumer_num_pending` | Backlog size per consumer |
| `nats_consumer_ack_floor_*` | Processing progress |
| `nats_consumer_delivered_*` | Messages delivered |
| `nats_connz_*` | Connection statistics |
| `nats_stream_*` | Stream statistics |

## Configuration

- **Target:** `nats.nats.svc.cluster.local:7777`
- **Scrape interval:** 30s
- **Receiver:** `prometheus/nats` added to otelDeployment

## Test plan

- [ ] Deploy and verify signoz-k8s-infra-otel-deployment restarts
- [ ] Check SigNoz Metrics Explorer for `nats_*` metrics
- [ ] Verify `nats_consumer_num_pending{consumer_name="ships-api"}` shows backlog

🤖 Generated with [Claude Code](https://claude.com/claude-code)