### PR TITLE
fix(signoz): increase otel-collector memory limit to 4Gi

### DIFF
--- a/overlays/cluster-critical/signoz/manifests/all.yaml
+++ b/overlays/cluster-critical/signoz/manifests/all.yaml
@@ -2762,7 +2762,7 @@ spec:
           resources:
             limits:
               cpu: 2
-              memory: 2Gi
+              memory: 4Gi
             requests:
               cpu: 200m
               memory: 2Gi

--- a/overlays/cluster-critical/signoz/values.yaml
+++ b/overlays/cluster-critical/signoz/values.yaml
@@ -73,7 +73,7 @@ signoz:
         memory: 2Gi
       limits:
         cpu: 2
-        memory: 2Gi
+        memory: 4Gi
   k8sInfra:
     otelAgent:
       resources:


### PR DESCRIPTION
## Summary
- Increase otel-collector memory limit from 2Gi to 4Gi

## Problem
The signoz-otel-collector pod has been OOMKilled 677 times with the current 2Gi limit. Memory spikes during high traffic exceed the limit.

## Test plan
- [ ] Verify collector pod doesn't OOM after deployment
- [ ] Monitor memory usage under load

🤖 Generated with [Claude Code](https://claude.com/claude-code)