### PR TITLE
perf(ships-api): increase catchup batch size to 10k and parallelize acks

### DIFF
--- a/services/ships-api/main.py
+++ b/services/ships-api/main.py
@@ -667,8 +667,9 @@ class ShipsAPIService:
 
             while self.running:
                 try:
-                    # Use smaller batches to reduce DB lock duration
-                    batch_size = 1000 if not self.replay_complete else 100
+                    # Large batches during catchup (not serving reads yet)
+                    # Smaller batches when live to reduce DB lock duration
+                    batch_size = 10000 if not self.replay_complete else 100
                     timeout = 5 if not self.replay_complete else 1
 
                     msgs = await psub.fetch(batch=batch_size, timeout=timeout)
@@ -706,12 +707,8 @@ class ShipsAPIService:
                     # Commit after batch
                     await self.db.commit()
 
-                    # Batch ack all messages at once (after successful DB commit)
-                    for i, msg in enumerate(msgs):
-                        await msg.ack()
-                        # Yield periodically during acks
-                        if i % 500 == 0:
-                            await asyncio.sleep(0)
+                    # Batch ack all messages in parallel (after successful DB commit)
+                    await asyncio.gather(*[msg.ack() for msg in msgs])
 
                     # Broadcast to WebSocket clients (after catchup)
                     # Send as batch with only latest position per vessel
@@ -726,18 +723,16 @@ class ShipsAPIService:
                             "positions": list(latest_by_mmsi.values())
                         })
 
-                    # Log progress during catchup (every 10k messages)
+                    # Log progress and check catchup every 10k messages
                     if not self.replay_complete and self.messages_received % 10000 == 0:
                         info = await psub.consumer_info()
                         logger.info(
                             f"Catchup progress: {self.messages_received} processed, "
                             f"{info.num_pending} pending"
                         )
-
-                    # Check for catchup completion after each batch
-                    # Use threshold to avoid waiting for exactly 0 pending
-                    if not self.replay_complete and len(msgs) < batch_size:
-                        info = await psub.consumer_info()
+                        # Check if we've caught up enough to serve traffic
+                        # Don't require len(msgs) < batch_size - messages may arrive
+                        # faster than we process, but we can still serve data
                         if info.num_pending <= CATCHUP_PENDING_THRESHOLD:
                             vessel_count = await self.db.get_vessel_count()
                             position_count = await self.db.get_position_count()


### PR DESCRIPTION
## Summary
- Increase batch size from 1000 to 10000 during catchup (not serving reads anyway)
- Parallelize message acks using `asyncio.gather` instead of sequential awaits
- Fix catchup detection to check threshold every 10k messages regardless of batch fullness

## Context
Messages were arriving faster (~14k/min) than we could process (~7k/min). These changes should roughly 10x throughput during catchup.

## Test plan
- [ ] Watch pod logs during catchup - should process 10k messages per batch
- [ ] Verify catchup completes and service becomes ready

🤖 Generated with [Claude Code](https://claude.com/claude-code)