### PR TITLE
chore(marine): reduce bounding box to Americas coverage

### DIFF
--- a/charts/marine/values.yaml
+++ b/charts/marine/values.yaml
@@ -36,9 +36,9 @@ nats:
 # AISStream configuration (for ingest)
 aisstream:
   url: wss://stream.aisstream.io/v0/stream
-  # Global coverage - all vessels worldwide
-  # ~300 messages/second, ~10GB/day storage
-  boundingBox: "[[[-90, -180], [90, 180]]]"
+  # Americas coverage - Pacific to Atlantic, equator to Arctic
+  # West: -173, South: -2.5, East: -32, North: 71.4
+  boundingBox: "[[[-173.009262, -2.455379], [-32.0327, -2.455379], [-32.0327, 71.414709], [-173.009262, 71.414709], [-173.009262, -2.455379]]]"
 
 # Pod security context (shared)
 # Note: Running as root because aspect_rules_py venv needs to write


### PR DESCRIPTION
## Summary
Reduce AIS coverage from global to Americas only to reduce message volume.

**New bounding box:**
- West: -173° (mid-Pacific)
- East: -32° (mid-Atlantic)  
- South: -2.5° (equator)
- North: 71.4° (Arctic)

## Why
Global coverage was ~300 msg/sec, causing catchup issues. Americas coverage should be significantly lower.

## Manual steps after merge
```bash
# Purge NATS stream
kubectl exec -n nats deploy/nats -- nats consumer delete AIS ships-api --force
kubectl exec -n nats deploy/nats -- nats stream purge AIS --force

# Delete SQLite to start fresh
kubectl scale -n marine deploy/marine-api --replicas=0
kubectl delete pvc -n marine marine-api-data
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)