### PR TITLE
fix(ais-ingest): reduce stream max_bytes to 10GB and fix max_age unit

### DIFF
--- a/services/ais-ingest/main.py
+++ b/services/ais-ingest/main.py
@@ -103,12 +103,13 @@ class AISIngestService:
         logger.info("Connected to NATS")
 
         # Create or update the AIS stream (add_stream is idempotent if config matches)
-        # Storage limits: 40GB max, 24h retention, whichever is hit first
+        # Storage limits: 10GB max, 24h retention, whichever is hit first
+        # Note: Reduced from 40GB to fit NATS JetStream storage quota
         stream_config = StreamConfig(
             name="ais",
             subjects=["ais.>"],
-            max_age=timedelta(hours=24).total_seconds(),  # seconds, not nanoseconds
-            max_bytes=40 * 1024 * 1024 * 1024,  # 40GB hard limit
+            max_age=86400_000_000_000,  # 24h in nanoseconds (NATS native unit)
+            max_bytes=10 * 1024 * 1024 * 1024,  # 10GB hard limit
             storage=StorageType.FILE,
             discard=DiscardPolicy.OLD,
             description="AIS position reports from AISStream.io (global coverage)",
@@ -116,12 +117,12 @@ class AISIngestService:
 
         try:
             await self.js.add_stream(stream_config)
-            logger.info("Created 'ais' stream with 24h retention, 40GB max")
+            logger.info("Created 'ais' stream with 24h retention, 10GB max")
         except nats.js.errors.BadRequestError as e:
             if "already in use" in str(e):
                 # Stream exists with different config, update it
                 await self.js.update_stream(stream_config)
-                logger.info("Updated 'ais' stream with 24h retention, 40GB max")
+                logger.info("Updated 'ais' stream with 24h retention, 10GB max")
             else:
                 raise
 


### PR DESCRIPTION
## Summary
- Reduce max_bytes from 40GB to 10GB to fit NATS JetStream storage quota
- Fix max_age to use nanoseconds (NATS native unit) instead of seconds

## Why
NATS was returning "insufficient storage resources available" (error 10047) when trying to create/update the stream with 40GB. The JetStream quota is 50GB and with reservations it couldn't allocate 40GB more.

🤖 Generated with [Claude Code](https://claude.com/claude-code)