### PR TITLE
fix(ais-ingest): use seconds for max_age

### DIFF
--- a/services/ais-ingest/main.py
+++ b/services/ais-ingest/main.py
@@ -108,7 +108,7 @@ class AISIngestService:
         stream_config = StreamConfig(
             name="ais",
             subjects=["ais.>"],
-            max_age=86400_000_000_000,  # 24h in nanoseconds (NATS native unit)
+            max_age=86400,  # 24h in seconds (nats-py converts to nanoseconds)
             max_bytes=10 * 1024 * 1024 * 1024,  # 10GB hard limit
             storage=StorageType.FILE,
             discard=DiscardPolicy.OLD,


### PR DESCRIPTION
## Summary
Fix max_age format - nats-py expects seconds, not nanoseconds. The library converts internally.

Previous commit used nanoseconds which caused "invalid JSON" error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)