### PR TITLE
fix(marine-api): batch TTL cleanup to prevent liveness probe timeouts

### DIFF
--- a/services/ships-api/main.py
+++ b/services/ships-api/main.py
@@ -445,27 +445,41 @@ class Database:
         await self.db.commit()
 
     async def cleanup_old_positions(self) -> int:
-        """Delete positions older than retention period. Returns count deleted."""
+        """Delete positions older than retention period in batches.
+
+        Deletes in batches of 10k rows to avoid long DB locks that could
+        cause liveness probe timeouts and pod restarts.
+        """
         cutoff = (
             datetime.now(timezone.utc) - timedelta(days=POSITION_RETENTION_DAYS)
         ).isoformat()
+        total_deleted = 0
+        batch_size = 10000
 
-        cursor = await self.db.execute(
-            "SELECT COUNT(*) FROM positions WHERE timestamp < ?", (cutoff,)
-        )
-        row = await cursor.fetchone()
-        count = row[0] if row else 0
-
-        if count > 0:
-            await self.db.execute(
-                "DELETE FROM positions WHERE timestamp < ?", (cutoff,)
+        while True:
+            # Delete in small batches to avoid long locks
+            cursor = await self.db.execute(
+                "DELETE FROM positions WHERE rowid IN "
+                "(SELECT rowid FROM positions WHERE timestamp < ? LIMIT ?)",
+                (cutoff, batch_size),
             )
+            deleted = cursor.rowcount
             await self.db.commit()
+            total_deleted += deleted
+
+            if deleted < batch_size:
+                break
+
+            # Yield to allow other operations (health checks, message processing)
+            await asyncio.sleep(0.1)
+
+        if total_deleted > 0:
             logger.info(
-                f"Cleaned up {count} positions older than {POSITION_RETENTION_DAYS} days"
+                f"Cleaned up {total_deleted} positions older than "
+                f"{POSITION_RETENTION_DAYS} days"
             )
 
-        return count
+        return total_deleted
 
     async def get_latest_positions(self) -> list[dict]:
         """Get latest position for each vessel using cache table."""


### PR DESCRIPTION
## Summary
- Changed `cleanup_old_positions()` to delete in batches of 10k rows instead of one massive DELETE
- Added `asyncio.sleep(0.1)` between batches to yield to event loop for health checks
- Prevents SQLite DB locks from causing liveness probe timeouts and pod restarts

## Problem
The TTL cleanup job was performing a single `DELETE FROM positions WHERE timestamp < ?` that could lock the SQLite database for extended periods when deleting millions of old positions. This caused:
- Liveness probe timeouts (`context deadline exceeded`)
- Kubernetes killing the pod
- NATS message backlog during subsequent catchup (~1.6M messages)

## Test plan
- [ ] Deploy to cluster and monitor during next hourly cleanup cycle
- [ ] Verify liveness probes continue to succeed during cleanup
- [ ] Check logs for batch cleanup progress messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)