### PR TITLE
fix(claude): add skip waiting handler to fix notification refresh

### DIFF
--- a/charts/claude/frontend/src/web/main.tsx
+++ b/charts/claude/frontend/src/web/main.tsx
@@ -61,9 +61,5 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
   </React.StrictMode>,
 );
 
-// Register Service Worker for PWA & Push
-if ("serviceWorker" in navigator) {
-  window.addEventListener("load", () => {
-    navigator.serviceWorker.register("/sw.js").catch(() => {});
-  });
-}
+// Service Worker registration is handled by vite-plugin-pwa via useRegisterSW in App.tsx
+// Do not manually register here - it causes duplicate registrations and interferes with update flow

--- a/charts/claude/frontend/src/web/sw.ts
+++ b/charts/claude/frontend/src/web/sw.ts
@@ -15,8 +15,12 @@ declare const self: ServiceWorkerGlobalScope & {
   __WB_MANIFEST: ManifestEntry[];
 };
 
-// Removed forced skipWaiting on install - let vite-plugin-pwa control update strategy
-// with registerType: "prompt" to avoid mid-session cache issues
+// Handle SKIP_WAITING message from vite-plugin-pwa when user clicks "Refresh Now"
+self.addEventListener("message", (event: MessageEvent) => {
+  if (event.data && event.data.type === "SKIP_WAITING") {
+    self.skipWaiting();
+  }
+});
 
 self.addEventListener("activate", (event: ExtendableEvent) => {
   event.waitUntil(self.clients.claim());


### PR DESCRIPTION
The "Refresh Now" button wasn't clearing the cache because the service
worker was missing the SKIP_WAITING message handler. When vite-plugin-pwa
sends this message, the service worker now properly calls skipWaiting()
to activate the new version.

Also removed duplicate service worker registration from main.tsx which
was interfering with vite-plugin-pwa's update flow.