### PR TITLE
fix: add -L to find_bin to follow bazel-bin symlink

### DIFF
--- a/tools/format/fast-format.sh
+++ b/tools/format/fast-format.sh
@@ -44,7 +44,8 @@ fi
 bazel build "${TARGETS[@]}" 2>&1 | grep -v "^INFO:" || true
 
 # Find binaries in bazel-bin (faster than cquery)
-find_bin() { find bazel-bin -name "$1" -type f -perm +111 2>/dev/null | head -1; }
+# -L follows symlinks (bazel-bin itself is a symlink)
+find_bin() { find -L bazel-bin -name "$1" -type f -perm +111 2>/dev/null | head -1; }
 
 RUFF=$(find_bin ruff)
 SHFMT=$(find_bin shfmt)


### PR DESCRIPTION
## Summary
- `bazel-bin` is a symlink, and `find` doesn't follow symlinks by default
- This caused `find_bin` to return empty paths, silently breaking all formatters
- Fixes pre-commit not catching Python formatting errors (ruff never ran)

## Test plan
- [x] Pre-commit hook passes
- [ ] Test with intentionally malformatted Python file - should now fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)