### PR TITLE
fix(stargazer): add explicit env field to prevent ArgoCD drift

### DIFF
--- a/charts/stargazer/templates/deployment-api.yaml
+++ b/charts/stargazer/templates/deployment-api.yaml
@@ -37,6 +37,7 @@ spec:
           {{- toYaml .Values.api.securityContext | nindent 10 }}
         image: "nginxinc/nginx-unprivileged:alpine"
         imagePullPolicy: IfNotPresent
+        env: []
         ports:
         - name: http
           containerPort: 8080


### PR DESCRIPTION
## Summary
- Adds explicit `env: []` to stargazer-api deployment container spec
- Prevents persistent ArgoCD drift caused by Kubernetes normalizing missing env fields

## Test plan
- [ ] Verify ArgoCD shows stargazer as synced (no diff) after deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)