### PR TITLE
fix: add GHCR image pull secret to signoz-dashboard-sidecar

### DIFF
--- a/charts/signoz-dashboard-sidecar/templates/deployment.yaml
+++ b/charts/signoz-dashboard-sidecar/templates/deployment.yaml
@@ -20,6 +20,12 @@ spec:
         {{- include "signoz-dashboard-sidecar.labels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ include "signoz-dashboard-sidecar.serviceAccountName" . }}
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- range .Values.imagePullSecrets }}
+        - name: {{ .name }}
+        {{- end }}
+      {{- end }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/charts/signoz-dashboard-sidecar/templates/image-pull-secret.yaml
+++ b/charts/signoz-dashboard-sidecar/templates/image-pull-secret.yaml
@@ -1,0 +1,16 @@
+{{- if and .Values.imagePullSecret.enabled .Values.imagePullSecret.create }}
+---
+# GHCR Pull Secret (for Kubernetes image pulls)
+# Allows signoz-dashboard-sidecar to pull private images from GitHub Container Registry
+# Type: kubernetes.io/dockerconfigjson (used for imagePullSecrets)
+apiVersion: onepassword.com/v1
+kind: OnePasswordItem
+type: kubernetes.io/dockerconfigjson
+metadata:
+  name: ghcr-imagepull-secret
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "signoz-dashboard-sidecar.labels" . | nindent 4 }}
+spec:
+  itemPath: {{ .Values.imagePullSecret.onepassword.itemPath | quote }}
+{{- end }}

--- a/charts/signoz-dashboard-sidecar/values.yaml
+++ b/charts/signoz-dashboard-sidecar/values.yaml
@@ -5,6 +5,16 @@ image:
   tag: "" # Defaults to appVersion
   pullPolicy: IfNotPresent
 
+# Image pull secrets for private registries
+imagePullSecrets: []
+
+# Image pull secret configuration (OnePassword)
+imagePullSecret:
+  enabled: false
+  create: true
+  onepassword:
+    itemPath: "vaults/k8s-homelab/items/ghcr-read-permissions"
+
 # SigNoz API configuration
 signoz:
   # URL to SigNoz query-service (internal cluster DNS)

--- a/overlays/cluster-critical/signoz-dashboard-sidecar/values.yaml
+++ b/overlays/cluster-critical/signoz-dashboard-sidecar/values.yaml
@@ -5,6 +5,13 @@ image:
   repository: ghcr.io/jomcgi/homelab/signoz-dashboard-sidecar
   # tag will be updated by argocd-image-updater
 
+# GHCR image pull authentication
+imagePullSecrets:
+  - name: ghcr-imagepull-secret
+
+imagePullSecret:
+  enabled: true
+
 # SigNoz configuration - use cluster-internal DNS
 signoz:
   url: "http://signoz-query-service.signoz.svc.cluster.local:8080"


### PR DESCRIPTION
## Summary
- Fixes ErrImagePull on signoz-dashboard-sidecar deployment by adding GHCR authentication
- Adds OnePassword-backed image pull secret using the same pattern as other charts (stargazer, marine, etc.)
- Enables the secret in the cluster-critical overlay

## Test plan
- [ ] Verify ArgoCD syncs the changes
- [ ] Confirm the pod starts without ErrImagePull
- [ ] Check the OnePassword secret is created in the namespace

🤖 Generated with [Claude Code](https://claude.com/claude-code)