### PR TITLE
fix: correct signoz-dashboard-sidecar service URL

### DIFF
--- a/charts/signoz-dashboard-sidecar/values.yaml
+++ b/charts/signoz-dashboard-sidecar/values.yaml
@@ -18,7 +18,7 @@ imagePullSecret:
 # SigNoz API configuration
 signoz:
   # URL to SigNoz query-service (internal cluster DNS)
-  url: "http://signoz-query-service.signoz.svc.cluster.local:8080"
+  url: "http://signoz.signoz.svc.cluster.local:8080"
   # API key for authentication (optional, leave empty if not required)
   apiKey: ""
   # Secret containing API key (alternative to apiKey)


### PR DESCRIPTION
## Summary
- Fixes DNS resolution error in signoz-dashboard-sidecar
- The default URL was set to `signoz-query-service` but the actual service is named `signoz`

## Test plan
- [ ] Verify sidecar pod restarts without DNS errors
- [ ] Confirm dashboards sync successfully to SigNoz

🤖 Generated with [Claude Code](https://claude.com/claude-code)