### PR TITLE
fix: correct signoz URL in overlay values

### DIFF
--- a/overlays/cluster-critical/signoz-dashboard-sidecar/values.yaml
+++ b/overlays/cluster-critical/signoz-dashboard-sidecar/values.yaml
@@ -15,7 +15,7 @@ imagePullSecret:
 
 # SigNoz configuration - use cluster-internal DNS
 signoz:
-  url: "http://signoz-query-service.signoz.svc.cluster.local:8080"
+  url: "http://signoz.signoz.svc.cluster.local:8080"
 
 # Watch all namespaces for dashboard ConfigMaps
 watch:


### PR DESCRIPTION
## Summary
- Fixes DNS resolution error in signoz-dashboard-sidecar
- The overlay was overriding the chart default with `signoz-query-service` but the actual service is named `signoz`

## Test plan
- [ ] Verify sidecar pod restarts without DNS errors
- [ ] Confirm dashboards sync successfully to SigNoz

🤖 Generated with [Claude Code](https://claude.com/claude-code)