### PR TITLE
feat: add SigNoz API key authentication for dashboard sidecar

### DIFF
--- a/charts/signoz-dashboard-sidecar/templates/api-key-secret.yaml
+++ b/charts/signoz-dashboard-sidecar/templates/api-key-secret.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.signoz.apiKeySecret.create }}
+---
+# SigNoz API Key Secret
+# Allows signoz-dashboard-sidecar to authenticate with SigNoz API
+apiVersion: onepassword.com/v1
+kind: OnePasswordItem
+metadata:
+  name: {{ .Values.signoz.apiKeySecret.name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "signoz-dashboard-sidecar.labels" . | nindent 4 }}
+spec:
+  itemPath: {{ .Values.signoz.apiKeySecret.onepassword.itemPath | quote }}
+{{- end }}

--- a/charts/signoz-dashboard-sidecar/templates/deployment.yaml
+++ b/charts/signoz-dashboard-sidecar/templates/deployment.yaml
@@ -40,7 +40,7 @@ spec:
             {{- if .Values.signoz.apiKey }}
             - name: SIGNOZ_API_KEY
               value: {{ .Values.signoz.apiKey | quote }}
-            {{- else if .Values.signoz.apiKeySecret }}
+            {{- else if .Values.signoz.apiKeySecret.enabled }}
             - name: SIGNOZ_API_KEY
               valueFrom:
                 secretKeyRef:

--- a/charts/signoz-dashboard-sidecar/values.yaml
+++ b/charts/signoz-dashboard-sidecar/values.yaml
@@ -22,9 +22,18 @@ signoz:
   # API key for authentication (optional, leave empty if not required)
   apiKey: ""
   # Secret containing API key (alternative to apiKey)
-  # apiKeySecret:
-  #   name: signoz-api-key
-  #   key: api-key
+  apiKeySecret:
+    # Set to true to use a secret for the API key
+    enabled: false
+    # Set to true to create the OnePasswordItem for the API key
+    create: false
+    # Name of the Kubernetes secret
+    name: "signoz-api-key"
+    # Key within the secret containing the API key
+    key: "api-key"
+    # OnePassword configuration (used when create: true)
+    onepassword:
+      itemPath: "vaults/k8s-homelab/items/signoz"
 
 # Watch configuration
 watch:

--- a/overlays/cluster-critical/signoz-dashboard-sidecar/values.yaml
+++ b/overlays/cluster-critical/signoz-dashboard-sidecar/values.yaml
@@ -16,6 +16,10 @@ imagePullSecret:
 # SigNoz configuration - use cluster-internal DNS
 signoz:
   url: "http://signoz.signoz.svc.cluster.local:8080"
+  # API key for SigNoz authentication (from 1Password)
+  apiKeySecret:
+    enabled: true
+    create: true
 
 # Watch all namespaces for dashboard ConfigMaps
 watch:


### PR DESCRIPTION
## Summary
- Adds OnePassword-based API key secret support to authenticate the dashboard sidecar with SigNoz
- Fixes 401 unauthenticated errors when syncing dashboards
- Creates `OnePasswordItem` from `vaults/k8s-homelab/items/signoz` with field `api-key`

## Changes
- New template `api-key-secret.yaml` for creating the secret via 1Password operator
- Updated `values.yaml` with `apiKeySecret.enabled` and `apiKeySecret.create` flags
- Enabled API key secret in cluster-critical overlay

## Test plan
- [ ] Verify 1Password item `signoz` exists in `k8s-homelab` vault with `api-key` field
- [ ] Deploy and confirm sidecar pod starts without 401 errors
- [ ] Verify dashboards are syncing successfully to SigNoz

🤖 Generated with [Claude Code](https://claude.com/claude-code)