### PR TITLE
fix(gh-arc-runners): update to official GitHub Actions runner image

### DIFF
--- a/overlays/prod/gh-arc-runners/values.yaml
+++ b/overlays/prod/gh-arc-runners/values.yaml
@@ -55,7 +55,7 @@ gha-runner-scale-set:
             runAsGroup: 1001 # runner user GID
             runAsNonRoot: true
             allowPrivilegeEscalation: false
-          image: ghcr.io/jomcgi/homelab/gh-arc-runner:latest@sha256:8e37d498033ed7a868fcc00dca13f1c6613895c7f9f94a78195200b165f8375f
+          image: ghcr.io/actions/actions-runner:latest
           command: ["/home/runner/run.sh"]
 
           resources:


### PR DESCRIPTION
## Summary
- Switch from custom `ghcr.io/jomcgi/homelab/gh-arc-runner` image to official `ghcr.io/actions/actions-runner:latest`
- Fixes runner deprecation error: "Runner version v2.329.0 is deprecated and cannot receive messages"
- The official image is maintained by GitHub and stays current with required runner versions

## Root Cause
The custom runner image had runner version v2.329.0 baked in, which GitHub deprecated. This caused all runner pods to fail immediately after starting, leaving GitHub Actions jobs stuck in "queued" state.

## Test plan
- [ ] Verify ArgoCD syncs the change
- [ ] Confirm new runner pods start successfully
- [ ] Check that queued CF Pages workflows execute

🤖 Generated with [Claude Code](https://claude.ai/code)