### PR TITLE
fix(todo): set correct permissions on data directory

### DIFF
--- a/charts/todo/templates/deployment.yaml
+++ b/charts/todo/templates/deployment.yaml
@@ -37,8 +37,9 @@ spec:
                 rm -rf /repo/* /repo/.[!.]* 2>/dev/null || true
                 git clone --branch {{ .Values.git.branch }} {{ .Values.git.repo }} /repo
               fi
-              # Ensure data directory exists
+              # Ensure data directory exists and is writable by API (uid 65532)
               mkdir -p /repo/{{ .Values.git.dataPath }}
+              chown -R 65532:65532 /repo/{{ .Values.git.dataPath }}
           env:
             - name: GIT_TOKEN
               valueFrom:


### PR DESCRIPTION
## Summary
- Fix permission denied error when API tries to write to `/repo/data/todo/public/`
- The git-clone init container runs as root, creating directories with root ownership
- The API container runs as uid 65532 and needs write access
- Add `chown -R 65532:65532` after creating the data directory

## Test plan
- [x] Identified permission denied error in API logs
- [ ] Deploy and verify todo.jomcgi.dev serves content

🤖 Generated with [Claude Code](https://claude.com/claude-code)