### PR TITLE
fix(todo): add nginx proxy for read-only API endpoints

### DIFF
--- a/charts/todo/templates/deployment.yaml
+++ b/charts/todo/templates/deployment.yaml
@@ -92,9 +92,15 @@ spec:
               mountPath: /usr/share/nginx/html
               subPath: {{ .Values.git.dataPath }}/public
               readOnly: true
+            - name: nginx-config
+              mountPath: /etc/nginx/conf.d
+              readOnly: true
           resources:
             {{- toYaml .Values.resources.static | nindent 12 }}
       volumes:
         - name: repo
           persistentVolumeClaim:
             claimName: {{ include "todo.fullname" . }}
+        - name: nginx-config
+          configMap:
+            name: {{ include "todo.fullname" . }}-nginx-config

--- a/charts/todo/templates/nginx-config.yaml
+++ b/charts/todo/templates/nginx-config.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "todo.fullname" . }}-nginx-config
+  labels:
+    {{- include "todo.labels" . | nindent 4 }}
+data:
+  default.conf: |
+    server {
+        listen 80;
+        server_name _;
+
+        root /usr/share/nginx/html;
+        index index.html;
+
+        # Proxy read-only API endpoints to the API container
+        # Only GET requests to specific endpoints used by the public frontend
+        location = /api/weekly {
+            limit_except GET { deny all; }
+            proxy_pass http://127.0.0.1:8080;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+        }
+
+        location = /api/daily {
+            limit_except GET { deny all; }
+            proxy_pass http://127.0.0.1:8080;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+        }
+
+        location = /api/dates {
+            limit_except GET { deny all; }
+            proxy_pass http://127.0.0.1:8080;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+        }
+
+        # Serve static files
+        location / {
+            try_files $uri $uri/ =404;
+        }
+    }


### PR DESCRIPTION
## Summary
The public frontend at `todo.jomcgi.dev` makes API calls to `/api/*` on the same origin, but nginx only serves static files, causing 404 errors.

Add nginx ConfigMap to proxy read-only endpoints to the API container (same pod, `127.0.0.1:8080`):
- `GET /api/weekly`
- `GET /api/daily`
- `GET /api/dates`

## Security
Write endpoints are explicitly blocked by nginx:
- `PUT /api/todo` → 404
- `POST /api/reset/daily` → 404
- `POST /api/reset/weekly` → 404

These are only accessible via `todo-admin.jomcgi.dev`.

## Test plan
- [ ] Verify todo.jomcgi.dev displays current tasks
- [ ] Verify todo-admin.jomcgi.dev can still edit tasks

🤖 Generated with [Claude Code](https://claude.com/claude-code)