### PR TITLE
fix(todo): use Recreate deployment strategy for RWO PVC

### DIFF
--- a/charts/todo/templates/deployment.yaml
+++ b/charts/todo/templates/deployment.yaml
@@ -6,6 +6,8 @@ metadata:
     {{- include "todo.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  strategy:
+    type: Recreate  # Required for RWO PVC - can't attach to multiple pods
   selector:
     matchLabels:
       {{- include "todo.selectorLabels" . | nindent 6 }}


### PR DESCRIPTION
## Summary
Fix Multi-Attach error during deployments:
```
Multi-Attach error for volume "pvc-..." Volume is already used by pod(s) todo-...
```

## Root Cause
- PVC is ReadWriteOnce (can only attach to one pod)
- Default RollingUpdate starts new pod before old terminates
- Both pods try to attach the same volume → conflict

## Fix
Use `strategy.type: Recreate` which terminates the old pod before starting the new one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)