### PR TITLE
feat(todo): setup ArgoCD Image Updater

### DIFF
--- a/overlays/prod/todo/imageupdater.yaml
+++ b/overlays/prod/todo/imageupdater.yaml
@@ -1,0 +1,25 @@
+apiVersion: argocd-image-updater.argoproj.io/v1alpha1
+kind: ImageUpdater
+metadata:
+  name: todo
+  namespace: argocd
+spec:
+  applicationRefs:
+    - images:
+        - alias: todo
+          commonUpdateSettings:
+            updateStrategy: digest
+            forceUpdate: false
+          imageName: ghcr.io/jomcgi/homelab/charts/todo:main
+          manifestTargets:
+            helm:
+              name: image.repository
+              tag: image.tag
+      namePattern: todo
+  namespace: argocd
+  writeBackConfig:
+    method: git:secret:argocd/argocd-image-updater-token
+    gitConfig:
+      repository: https://github.com/jomcgi/homelab.git
+      branch: main
+      writeBackTarget: helmvalues:../../overlays/prod/todo/values.yaml

--- a/overlays/prod/todo/kustomization.yaml
+++ b/overlays/prod/todo/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 
 resources:
   - application.yaml
+  - imageupdater.yaml


### PR DESCRIPTION
## Summary
Setup ArgoCD Image Updater for the todo deployment to automatically roll out new images.

## Configuration
- **Image:** `ghcr.io/jomcgi/homelab/charts/todo:main`
- **Strategy:** digest (updates when image SHA changes)
- **Write-back:** `overlays/prod/todo/values.yaml`

When CI pushes a new image, the updater will:
1. Detect the new digest
2. Update values.yaml with the new image reference
3. ArgoCD syncs the change automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)