### PR TITLE
fix(todo): correct ImageUpdater application name pattern

### DIFF
--- a/overlays/prod/todo/imageupdater.yaml
+++ b/overlays/prod/todo/imageupdater.yaml
@@ -15,7 +15,7 @@ spec:
             helm:
               name: image.repository
               tag: image.tag
-      namePattern: todo
+      namePattern: prod-todo
   namespace: argocd
   writeBackConfig:
     method: git:secret:argocd/argocd-image-updater-token


### PR DESCRIPTION
## Summary
Fix ImageUpdater not finding the todo application.

## Issue
```
Starting image update cycle, considering 0 application(s) for update
```

The `namePattern: todo` doesn't match the actual ArgoCD application name `prod-todo`.

## Fix
Change `namePattern: todo` → `namePattern: prod-todo`

🤖 Generated with [Claude Code](https://claude.com/claude-code)