### PR TITLE
fix(marine): correct image tag prefix from 'latest' to 'main'

### DIFF
--- a/overlays/dev/marine/values.yaml
+++ b/overlays/dev/marine/values.yaml
@@ -10,7 +10,7 @@ imagePullSecrets:
 ingest:
   image:
     repository: ghcr.io/jomcgi/homelab/services/ais_ingest
-    tag: "latest@sha256:6c6a6bc57e6807f2c52a530dc2c1895679ae2511dcce819d70cc5da8102a5e13"
+    tag: "main@sha256:6c6a6bc57e6807f2c52a530dc2c1895679ae2511dcce819d70cc5da8102a5e13"
     pullPolicy: Always
   # Pre-populate OTEL annotation to match Kyverno injection (prevents ArgoCD drift)
   podAnnotations:
@@ -33,7 +33,7 @@ api:
     otel.injected-by: kyverno/inject-otel-env-vars
 frontend:
   image:
-    tag: latest@sha256:9934e2cda9cbc92c63eefa155454fc5eb9ac56e139c6fe9d3305c8d2b3d77756
+    tag: main@sha256:9934e2cda9cbc92c63eefa155454fc5eb9ac56e139c6fe9d3305c8d2b3d77756
     repository: ghcr.io/jomcgi/homelab/services/ships_frontend
   # Zero Trust access policy - disabled, manually configured in Cloudflare
   zeroTrust:


### PR DESCRIPTION
## Summary

- Fixes image tag prefix mismatch in marine namespace
- Changes `latest@sha256:...` to `main@sha256:...` for ingest and frontend components
- Aligns values.yaml with imageupdater configuration which tracks `:main` tag

## Problem

The `marine-api-0` pod was stuck in `ImagePullBackOff` because:
1. The pod spec had `latest@sha256:3ca2d8a6...` (an old digest)
2. This old digest was garbage collected from GHCR
3. The imageupdater was configured to track `:main`, not `:latest`
4. The mismatch prevented automatic updates from correcting the digest

## Root Cause

The `ingest.image.tag` and `frontend.image.tag` values had `latest@sha256:...` prefix instead of `main@sha256:...`. This likely happened during a manual edit or a bug in an earlier image updater write-back.

## Changes

| Component | Before | After |
|-----------|--------|-------|
| ingest | `latest@sha256:6c6a6bc5...` | `main@sha256:6c6a6bc5...` |
| frontend | `latest@sha256:9934e2cd...` | `main@sha256:9934e2cd...` |

## Test plan

- [ ] Verify ArgoCD syncs the changes to the cluster
- [ ] Confirm `marine-api-0` pod starts successfully after sync
- [ ] Confirm frontend pods recover from CrashLoopBackOff

🤖 Generated with [Claude Code](https://claude.com/claude-code)