### PR TITLE
fix(signoz): correct httpcheck headers config and add GPU metrics

### DIFF
--- a/overlays/cluster-critical/signoz/values.yaml
+++ b/overlays/cluster-critical/signoz/values.yaml
@@ -44,6 +44,18 @@ k8s-infra:
                     labels:
                       service: nats
 
+        # Prometheus scraper for NVIDIA GPU metrics (DCGM exporter)
+        prometheus/dcgm:
+          config:
+            scrape_configs:
+              - job_name: "nvidia-dcgm"
+                scrape_interval: 30s
+                static_configs:
+                  - targets:
+                      - "nvidia-dcgm-exporter.gpu-operator.svc.cluster.local:9400"
+                    labels:
+                      service: nvidia-gpu
+
         # =============================================================================
         # Synthetic HTTP Health Checks
         # Monitors all public domains for availability and response time
@@ -51,47 +63,73 @@ k8s-infra:
         # =============================================================================
 
         # Kubernetes-hosted services (via Cloudflare Tunnel)
-        # These may require Cloudflare Zero Trust authentication bypass
+        # These require Cloudflare Zero Trust authentication bypass via service token headers
         httpcheck/k8s-services:
+          collection_interval: 60s
           targets:
             # GitOps - ArgoCD
             - endpoint: https://argocd.jomcgi.dev
               method: GET
+              headers:
+                CF-Access-Client-Id: "${env:CF_ACCESS_CLIENT_ID}"
+                CF-Access-Client-Secret: "${env:CF_ACCESS_CLIENT_SECRET}"
             # Storage management - Longhorn
             - endpoint: https://longhorn.jomcgi.dev
               method: GET
+              headers:
+                CF-Access-Client-Id: "${env:CF_ACCESS_CLIENT_ID}"
+                CF-Access-Client-Secret: "${env:CF_ACCESS_CLIENT_SECRET}"
             # Workflow automation - n8n
             - endpoint: https://n8n.jomcgi.dev
               method: GET
+              headers:
+                CF-Access-Client-Id: "${env:CF_ACCESS_CLIENT_ID}"
+                CF-Access-Client-Secret: "${env:CF_ACCESS_CLIENT_SECRET}"
             # RSS feed reader - FreshRSS
             - endpoint: https://feeds.jomcgi.dev
               method: GET
+              headers:
+                CF-Access-Client-Id: "${env:CF_ACCESS_CLIENT_ID}"
+                CF-Access-Client-Secret: "${env:CF_ACCESS_CLIENT_SECRET}"
             # Observability - SigNoz
             - endpoint: https://signoz.jomcgi.dev
               method: GET
+              headers:
+                CF-Access-Client-Id: "${env:CF_ACCESS_CLIENT_ID}"
+                CF-Access-Client-Secret: "${env:CF_ACCESS_CLIENT_SECRET}"
             # Claude Code interface
             - endpoint: https://claude.jomcgi.dev
               method: GET
+              headers:
+                CF-Access-Client-Id: "${env:CF_ACCESS_CLIENT_ID}"
+                CF-Access-Client-Secret: "${env:CF_ACCESS_CLIENT_SECRET}"
             # Image hosting
             - endpoint: https://img.jomcgi.dev
               method: GET
+              headers:
+                CF-Access-Client-Id: "${env:CF_ACCESS_CLIENT_ID}"
+                CF-Access-Client-Secret: "${env:CF_ACCESS_CLIENT_SECRET}"
             # API gateway
             - endpoint: https://api.jomcgi.dev/status.json
               method: GET
-            # Todo app (public)
+              headers:
+                CF-Access-Client-Id: "${env:CF_ACCESS_CLIENT_ID}"
+                CF-Access-Client-Secret: "${env:CF_ACCESS_CLIENT_SECRET}"
+            # Todo app (public - no auth needed but include for consistency)
             - endpoint: https://todo.jomcgi.dev
               method: GET
             # Todo admin (requires auth)
             - endpoint: https://todo-admin.jomcgi.dev
               method: GET
+              headers:
+                CF-Access-Client-Id: "${env:CF_ACCESS_CLIENT_ID}"
+                CF-Access-Client-Secret: "${env:CF_ACCESS_CLIENT_SECRET}"
             # Ships/Marine frontend
             - endpoint: https://ships.jomcgi.dev
               method: GET
-          collection_interval: 60s
-          # Cloudflare Access service token headers for Zero Trust bypass
-          headers:
-            CF-Access-Client-Id: "${env:CF_ACCESS_CLIENT_ID}"
-            CF-Access-Client-Secret: "${env:CF_ACCESS_CLIENT_SECRET}"
+              headers:
+                CF-Access-Client-Id: "${env:CF_ACCESS_CLIENT_ID}"
+                CF-Access-Client-Secret: "${env:CF_ACCESS_CLIENT_SECRET}"
 
         # Cloudflare Pages (static sites) - no auth required
         httpcheck/cloudflare-pages:
@@ -113,6 +151,7 @@ k8s-infra:
           metrics/scraper:
             receivers:
               - prometheus/nats
+              - prometheus/dcgm
               - httpcheck/k8s-services
               - httpcheck/cloudflare-pages
             processors:


### PR DESCRIPTION
## Summary
- Move `headers` from receiver level to target level per [OpenTelemetry httpcheck receiver spec](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/httpcheckreceiver/README.md)
- Add `prometheus/dcgm` receiver to scrape NVIDIA GPU metrics from the existing dcgm-exporter

## Problem
The previous config had:
```yaml
httpcheck/k8s-services:
  targets: [...]
  headers:  # ERROR: invalid key at receiver level
    CF-Access-Client-Id: ...
```

Which caused:
```
error decoding 'receivers': error reading configuration for "httpcheck/k8s-services":
decoding failed due to the following error(s): '' has invalid keys: headers
```

## Fix
Headers must be per-target:
```yaml
httpcheck/k8s-services:
  targets:
    - endpoint: https://argocd.jomcgi.dev
      headers:  # Correct: at target level
        CF-Access-Client-Id: ...
```

## Additional Changes
- Added `prometheus/dcgm` scraper for NVIDIA GPU metrics from `nvidia-dcgm-exporter.gpu-operator.svc.cluster.local:9400`
- The DCGM exporter was already running but not being scraped

## Test plan
- [ ] ArgoCD syncs successfully
- [ ] `signoz-k8s-infra-otel-deployment` pod starts without config errors
- [ ] After ~60s, httpcheck metrics appear in SigNoz (httpcheck.status, httpcheck.duration)
- [ ] After ~30s, DCGM/GPU metrics appear (DCGM_FI_DEV_GPU_TEMP, DCGM_FI_DEV_POWER_USAGE, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)