### PR TITLE
chore(signoz): remove defunct n8n and feeds health checks

### DIFF
--- a/overlays/cluster-critical/signoz/values.yaml
+++ b/overlays/cluster-critical/signoz/values.yaml
@@ -91,8 +91,8 @@ k8s-infra:
               headers:
                 CF-Access-Client-Id: "${env:CF_ACCESS_CLIENT_ID}"
                 CF-Access-Client-Secret: "${env:CF_ACCESS_CLIENT_SECRET}"
-            # Image hosting
-            - endpoint: https://img.jomcgi.dev
+            # Image hosting (trips-nginx serves /health)
+            - endpoint: https://img.jomcgi.dev/health
               method: GET
               headers:
                 CF-Access-Client-Id: "${env:CF_ACCESS_CLIENT_ID}"


### PR DESCRIPTION
## Summary
- Remove n8n.jomcgi.dev from synthetic health checks (service no longer exists)
- Remove feeds.jomcgi.dev from synthetic health checks (service no longer exists)

## Test plan
- [ ] Verify ArgoCD syncs successfully
- [ ] Confirm no errors in SigNoz OTel collector logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)