### PR TITLE
feat(signoz): add alerting support with PagerDuty integration

### DIFF
--- a/charts/signoz-dashboard-sidecar/cmd/main.go
+++ b/charts/signoz-dashboard-sidecar/cmd/main.go
@@ -1,5 +1,9 @@
-// Package main implements a GitOps sidecar for syncing SigNoz dashboards from ConfigMaps.
-// It watches ConfigMaps with a specific label and syncs their JSON content to SigNoz.
+// Package main implements a GitOps sidecar for syncing SigNoz resources from ConfigMaps.
+// It watches ConfigMaps with specific labels and syncs their JSON content to SigNoz:
+//   - signoz.io/dashboard=true -> Dashboards (api/v1/dashboards)
+//   - signoz.io/alert=true -> Alerts (api/v1/rules)
+//   - signoz.io/channel=true -> Notification channels (api/v1/channels)
+//
 // Periodic reconciliation enforces desired state by always pushing ConfigMap content,
 // ensuring manual changes in the SigNoz UI are reverted (drift correction).
 package main
@@ -38,6 +42,20 @@ const (
 	dashboardNameKey = "signoz.io/dashboard-name"
 	dashboardTagsKey = "signoz.io/dashboard-tags"
 	dashboardPath    = "api/v1/dashboards"
+
+	// Alert constants
+	alertLabel       = "signoz.io/alert"
+	alertNameKey     = "signoz.io/alert-name"
+	alertSeverityKey = "signoz.io/severity"
+	alertChannelsKey = "signoz.io/notification-channels"
+	alertPath        = "api/v1/rules"
+
+	// Notification channel constants
+	channelLabel    = "signoz.io/channel"
+	channelNameKey  = "signoz.io/channel-name"
+	channelTypeKey  = "signoz.io/channel-type"
+	channelPath     = "api/v1/channels"
+	secretRefKey    = "signoz.io/secret-ref" // Format: "namespace/secretName" or just "secretName" (same namespace)
 
 	// Default tag applied to all sidecar-managed dashboards
 	defaultManagedTag = "iac-managed"
@@ -83,6 +101,60 @@ var (
 		Name: "signoz_dashboard_sidecar_drift_corrections_total",
 		Help: "Total number of drift corrections (forced updates during reconciliation)",
 	})
+
+	// Alert metrics
+	alertSyncTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "signoz_dashboard_sidecar_alert_sync_total",
+		Help: "Total number of alert sync operations",
+	}, []string{"operation", "status"})
+
+	alertSyncDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "signoz_dashboard_sidecar_alert_sync_duration_seconds",
+		Help:    "Duration of alert sync operations",
+		Buckets: prometheus.DefBuckets,
+	}, []string{"operation"})
+
+	alertsManaged = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "signoz_dashboard_sidecar_alerts_managed",
+		Help: "Current number of alerts managed by the sidecar",
+	})
+
+	alertConfigMapsWatched = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "signoz_dashboard_sidecar_alert_configmaps_watched",
+		Help: "Current number of alert ConfigMaps being watched",
+	})
+
+	alertDriftCorrections = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "signoz_dashboard_sidecar_alert_drift_corrections_total",
+		Help: "Total number of alert drift corrections (forced updates during reconciliation)",
+	})
+
+	// Channel metrics
+	channelSyncTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "signoz_dashboard_sidecar_channel_sync_total",
+		Help: "Total number of notification channel sync operations",
+	}, []string{"operation", "status"})
+
+	channelSyncDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "signoz_dashboard_sidecar_channel_sync_duration_seconds",
+		Help:    "Duration of notification channel sync operations",
+		Buckets: prometheus.DefBuckets,
+	}, []string{"operation"})
+
+	channelsManaged = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "signoz_dashboard_sidecar_channels_managed",
+		Help: "Current number of notification channels managed by the sidecar",
+	})
+
+	channelConfigMapsWatched = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "signoz_dashboard_sidecar_channel_configmaps_watched",
+		Help: "Current number of channel ConfigMaps being watched",
+	})
+
+	channelDriftCorrections = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "signoz_dashboard_sidecar_channel_drift_corrections_total",
+		Help: "Total number of channel drift corrections (forced updates during reconciliation)",
+	})
 )
 
 // Config holds the sidecar configuration.
@@ -104,18 +176,44 @@ type DashboardState struct {
 	SyncedAt    string `json:"syncedAt"`
 }
 
+// AlertState tracks a synced alert.
+type AlertState struct {
+	ID          string `json:"id"` // SigNoz returns "id" not "uuid" for alerts
+	ContentHash string `json:"contentHash"`
+	Name        string `json:"name"`
+	Namespace   string `json:"namespace"`
+	SyncedAt    string `json:"syncedAt"`
+}
+
 // StateStore maps ConfigMap UID -> DashboardState.
 type StateStore map[string]DashboardState
 
-// Sidecar manages dashboard synchronization.
+// AlertStateStore maps ConfigMap UID -> AlertState.
+type AlertStateStore map[string]AlertState
+
+// ChannelState tracks a synced notification channel.
+type ChannelState struct {
+	ID          string `json:"id"`
+	ContentHash string `json:"contentHash"`
+	Name        string `json:"name"`
+	Namespace   string `json:"namespace"`
+	SyncedAt    string `json:"syncedAt"`
+}
+
+// ChannelStateStore maps ConfigMap UID -> ChannelState.
+type ChannelStateStore map[string]ChannelState
+
+// Sidecar manages dashboard, alert, and channel synchronization.
 type Sidecar struct {
 	config     Config
 	clientset  *kubernetes.Clientset
 	httpClient *http.Client
 	logger     *slog.Logger
 
-	stateMu sync.RWMutex
-	state   StateStore
+	stateMu      sync.RWMutex
+	state        StateStore
+	alertState   AlertStateStore
+	channelState ChannelStateStore
 }
 
 type dashboardResponse struct {
@@ -128,6 +226,16 @@ type dashboardResponse struct {
 type dashboardData struct {
 	UUID string          `json:"uuid"`
 	Data json.RawMessage `json:"data"`
+}
+
+type alertResponse struct {
+	Status string    `json:"status"`
+	Data   alertData `json:"data"`
+	Error  string    `json:"error,omitempty"`
+}
+
+type alertData struct {
+	ID string `json:"id"`
 }
 
 // NewSidecar creates a new dashboard sidecar.
@@ -143,11 +251,13 @@ func NewSidecar(config Config, logger *slog.Logger) (*Sidecar, error) {
 	}
 
 	return &Sidecar{
-		config:     config,
-		clientset:  clientset,
-		httpClient: &http.Client{Timeout: 30 * time.Second},
-		logger:     logger,
-		state:      make(StateStore),
+		config:       config,
+		clientset:    clientset,
+		httpClient:   &http.Client{Timeout: 30 * time.Second},
+		logger:       logger,
+		state:        make(StateStore),
+		alertState:   make(AlertStateStore),
+		channelState: make(ChannelStateStore),
 	}, nil
 }
 
@@ -168,6 +278,8 @@ func (s *Sidecar) Run(ctx context.Context) error {
 
 	// Start watching for changes
 	go s.watchConfigMaps(ctx)
+	go s.watchAlertConfigMaps(ctx)
+	go s.watchChannelConfigMaps(ctx)
 
 	// Periodic reconciliation with drift correction
 	ticker := time.NewTicker(s.config.ReconcileInterval)
@@ -217,20 +329,34 @@ func (s *Sidecar) loadState(ctx context.Context) error {
 		return fmt.Errorf("failed to get state ConfigMap: %w", err)
 	}
 
-	stateJSON, ok := cm.Data["state"]
-	if !ok {
-		return nil
-	}
-
 	s.stateMu.Lock()
 	defer s.stateMu.Unlock()
 
-	if err := json.Unmarshal([]byte(stateJSON), &s.state); err != nil {
-		return fmt.Errorf("failed to unmarshal state: %w", err)
+	// Load dashboard state
+	if stateJSON, ok := cm.Data["state"]; ok {
+		if err := json.Unmarshal([]byte(stateJSON), &s.state); err != nil {
+			return fmt.Errorf("failed to unmarshal dashboard state: %w", err)
+		}
+	}
+
+	// Load alert state
+	if alertStateJSON, ok := cm.Data["alertState"]; ok {
+		if err := json.Unmarshal([]byte(alertStateJSON), &s.alertState); err != nil {
+			return fmt.Errorf("failed to unmarshal alert state: %w", err)
+		}
+	}
+
+	// Load channel state
+	if channelStateJSON, ok := cm.Data["channelState"]; ok {
+		if err := json.Unmarshal([]byte(channelStateJSON), &s.channelState); err != nil {
+			return fmt.Errorf("failed to unmarshal channel state: %w", err)
+		}
 	}
 
 	dashboardsManaged.Set(float64(len(s.state)))
-	s.logger.Info("Loaded state", "dashboards", len(s.state))
+	alertsManaged.Set(float64(len(s.alertState)))
+	channelsManaged.Set(float64(len(s.channelState)))
+	s.logger.Info("Loaded state", "dashboards", len(s.state), "alerts", len(s.alertState), "channels", len(s.channelState))
 
 	return nil
 }
@@ -238,23 +364,35 @@ func (s *Sidecar) loadState(ctx context.Context) error {
 func (s *Sidecar) saveState(ctx context.Context) error {
 	s.stateMu.RLock()
 	stateJSON, err := json.Marshal(s.state)
-	s.stateMu.RUnlock()
-
 	if err != nil {
-		return fmt.Errorf("failed to marshal state: %w", err)
+		s.stateMu.RUnlock()
+		return fmt.Errorf("failed to marshal dashboard state: %w", err)
 	}
+	alertStateJSON, err := json.Marshal(s.alertState)
+	if err != nil {
+		s.stateMu.RUnlock()
+		return fmt.Errorf("failed to marshal alert state: %w", err)
+	}
+	channelStateJSON, err := json.Marshal(s.channelState)
+	if err != nil {
+		s.stateMu.RUnlock()
+		return fmt.Errorf("failed to marshal channel state: %w", err)
+	}
+	s.stateMu.RUnlock()
 
 	cm := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      stateConfigMapName,
 			Namespace: s.config.StateNamespace,
 			Labels: map[string]string{
-				"app.kubernetes.io/name":      "signoz-dashboard-sidecar",
+				"app.kubernetes.io/name":      "signoz-sidecar",
 				"app.kubernetes.io/component": "state",
 			},
 		},
 		Data: map[string]string{
-			"state": string(stateJSON),
+			"state":        string(stateJSON),
+			"alertState":   string(alertStateJSON),
+			"channelState": string(channelStateJSON),
 		},
 	}
 
@@ -275,6 +413,8 @@ func (s *Sidecar) saveState(ctx context.Context) error {
 
 	s.stateMu.RLock()
 	dashboardsManaged.Set(float64(len(s.state)))
+	alertsManaged.Set(float64(len(s.alertState)))
+	channelsManaged.Set(float64(len(s.channelState)))
 	s.stateMu.RUnlock()
 
 	return nil
@@ -476,6 +616,16 @@ func (s *Sidecar) reconcileAll(ctx context.Context) error {
 		s.stateMu.Lock()
 		delete(s.state, od.uid)
 		s.stateMu.Unlock()
+	}
+
+	// Reconcile alerts
+	if err := s.reconcileAlerts(ctx); err != nil {
+		s.logger.Error("Alert reconciliation failed", "error", err)
+	}
+
+	// Reconcile channels
+	if err := s.reconcileChannels(ctx); err != nil {
+		s.logger.Error("Channel reconciliation failed", "error", err)
 	}
 
 	if err := s.saveState(ctx); err != nil {
@@ -762,6 +912,801 @@ func (s *Sidecar) setHeaders(req *http.Request) {
 	if s.config.SignozAPIKey != "" {
 		req.Header.Set("SIGNOZ-API-KEY", s.config.SignozAPIKey)
 	}
+}
+
+// ============================================================================
+// Alert sync methods
+// ============================================================================
+
+func (s *Sidecar) watchAlertConfigMaps(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+
+		listOpts := metav1.ListOptions{
+			LabelSelector: fmt.Sprintf("%s=true", alertLabel),
+		}
+
+		var watcher watch.Interface
+		var err error
+
+		if s.config.Namespace == "" {
+			watcher, err = s.clientset.CoreV1().ConfigMaps("").Watch(ctx, listOpts)
+		} else {
+			watcher, err = s.clientset.CoreV1().ConfigMaps(s.config.Namespace).Watch(ctx, listOpts)
+		}
+
+		if err != nil {
+			s.logger.Error("Failed to start alert watch", "error", err)
+			time.Sleep(5 * time.Second)
+			continue
+		}
+
+		s.handleAlertWatchEvents(ctx, watcher)
+		watcher.Stop()
+	}
+}
+
+func (s *Sidecar) handleAlertWatchEvents(ctx context.Context, watcher watch.Interface) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case event, ok := <-watcher.ResultChan():
+			if !ok {
+				s.logger.Info("Alert watch channel closed, restarting...")
+				return
+			}
+
+			cm, ok := event.Object.(*corev1.ConfigMap)
+			if !ok {
+				continue
+			}
+
+			switch event.Type {
+			case watch.Added, watch.Modified:
+				if err := s.syncAlert(ctx, cm, false); err != nil {
+					s.logger.Error("Failed to sync alert", "namespace", cm.Namespace, "name", cm.Name, "error", err)
+				}
+			case watch.Deleted:
+				if err := s.deleteAlert(ctx, cm); err != nil {
+					s.logger.Error("Failed to delete alert", "namespace", cm.Namespace, "name", cm.Name, "error", err)
+				}
+			}
+		}
+	}
+}
+
+func (s *Sidecar) reconcileAlerts(ctx context.Context) error {
+	timer := prometheus.NewTimer(alertSyncDuration.WithLabelValues("reconcile_all"))
+	defer timer.ObserveDuration()
+
+	listOpts := metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("%s=true", alertLabel),
+	}
+
+	var configMaps *corev1.ConfigMapList
+	var err error
+
+	if s.config.Namespace == "" {
+		configMaps, err = s.clientset.CoreV1().ConfigMaps("").List(ctx, listOpts)
+	} else {
+		configMaps, err = s.clientset.CoreV1().ConfigMaps(s.config.Namespace).List(ctx, listOpts)
+	}
+
+	if err != nil {
+		alertSyncTotal.WithLabelValues("reconcile_all", "error").Inc()
+		return fmt.Errorf("failed to list alert configmaps: %w", err)
+	}
+
+	alertConfigMapsWatched.Set(float64(len(configMaps.Items)))
+	s.logger.Info("Reconciling alert ConfigMaps", "count", len(configMaps.Items))
+
+	seenUIDs := make(map[string]bool)
+
+	for i := range configMaps.Items {
+		cm := &configMaps.Items[i]
+		seenUIDs[string(cm.UID)] = true
+
+		if err := s.syncAlert(ctx, cm, true); err != nil {
+			s.logger.Error("Failed to sync alert", "namespace", cm.Namespace, "name", cm.Name, "error", err)
+		}
+	}
+
+	// Clean up orphaned alerts
+	var orphaned []struct {
+		uid, id, namespace, name string
+	}
+
+	s.stateMu.Lock()
+	for uid, state := range s.alertState {
+		if !seenUIDs[uid] {
+			orphaned = append(orphaned, struct{ uid, id, namespace, name string }{uid, state.ID, state.Namespace, state.Name})
+		}
+	}
+	s.stateMu.Unlock()
+
+	for _, od := range orphaned {
+		s.logger.Info("Cleaning up orphaned alert", "id", od.id, "namespace", od.namespace, "name", od.name)
+		if err := s.deleteAlertByID(ctx, od.id); err != nil {
+			s.logger.Error("Failed to delete orphaned alert", "id", od.id, "error", err)
+			continue
+		}
+		s.stateMu.Lock()
+		delete(s.alertState, od.uid)
+		s.stateMu.Unlock()
+	}
+
+	alertSyncTotal.WithLabelValues("reconcile_all", "success").Inc()
+	return nil
+}
+
+func (s *Sidecar) syncAlert(ctx context.Context, cm *corev1.ConfigMap, forceUpdate bool) error {
+	timer := prometheus.NewTimer(alertSyncDuration.WithLabelValues("sync"))
+	defer timer.ObserveDuration()
+
+	alertJSON, err := s.extractAlertJSON(cm)
+	if err != nil {
+		alertSyncTotal.WithLabelValues("sync", "invalid_config").Inc()
+		return err
+	}
+
+	contentHash := hashContent(alertJSON)
+	uid := string(cm.UID)
+
+	s.stateMu.RLock()
+	existing, exists := s.alertState[uid]
+	s.stateMu.RUnlock()
+
+	if !forceUpdate && exists && existing.ContentHash == contentHash {
+		s.logger.Debug("Alert unchanged, skipping", "namespace", cm.Namespace, "name", cm.Name)
+		alertSyncTotal.WithLabelValues("sync", "skipped").Inc()
+		return nil
+	}
+
+	var alert map[string]interface{}
+	if err := json.Unmarshal(alertJSON, &alert); err != nil {
+		alertSyncTotal.WithLabelValues("sync", "invalid_json").Inc()
+		return fmt.Errorf("invalid alert JSON: %w", err)
+	}
+
+	// Override from annotations if provided
+	if name, ok := cm.Annotations[alertNameKey]; ok {
+		alert["alert"] = name
+	}
+	if severity, ok := cm.Annotations[alertSeverityKey]; ok {
+		alert["severity"] = severity
+	}
+	if channels, ok := cm.Annotations[alertChannelsKey]; ok {
+		channelList := strings.Split(channels, ",")
+		for i := range channelList {
+			channelList[i] = strings.TrimSpace(channelList[i])
+		}
+		alert["preferredChannels"] = channelList
+	}
+
+	if exists {
+		if err := s.updateAlert(ctx, existing.ID, alert); err != nil {
+			alertSyncTotal.WithLabelValues("sync", "update_error").Inc()
+			return err
+		}
+
+		s.stateMu.Lock()
+		s.alertState[uid] = AlertState{
+			ID:          existing.ID,
+			ContentHash: contentHash,
+			Name:        cm.Name,
+			Namespace:   cm.Namespace,
+			SyncedAt:    time.Now().UTC().Format(time.RFC3339),
+		}
+		s.stateMu.Unlock()
+
+		if forceUpdate && existing.ContentHash == contentHash {
+			alertDriftCorrections.Inc()
+			alertSyncTotal.WithLabelValues("sync", "drift_corrected").Inc()
+		} else {
+			alertSyncTotal.WithLabelValues("sync", "updated").Inc()
+			s.logger.Info("Updated alert", "id", existing.ID, "namespace", cm.Namespace, "name", cm.Name)
+		}
+	} else {
+		alertID, err := s.createAlert(ctx, alert)
+		if err != nil {
+			alertSyncTotal.WithLabelValues("sync", "create_error").Inc()
+			return err
+		}
+
+		s.stateMu.Lock()
+		s.alertState[uid] = AlertState{
+			ID:          alertID,
+			ContentHash: contentHash,
+			Name:        cm.Name,
+			Namespace:   cm.Namespace,
+			SyncedAt:    time.Now().UTC().Format(time.RFC3339),
+		}
+		s.stateMu.Unlock()
+
+		alertSyncTotal.WithLabelValues("sync", "created").Inc()
+		s.logger.Info("Created alert", "id", alertID, "namespace", cm.Namespace, "name", cm.Name)
+	}
+
+	return nil
+}
+
+func (s *Sidecar) extractAlertJSON(cm *corev1.ConfigMap) ([]byte, error) {
+	if data, ok := cm.Data["alert.json"]; ok {
+		return []byte(data), nil
+	}
+	for key, value := range cm.Data {
+		if strings.HasSuffix(key, ".json") {
+			return []byte(value), nil
+		}
+	}
+	if len(cm.Data) == 1 {
+		for _, value := range cm.Data {
+			return []byte(value), nil
+		}
+	}
+	return nil, fmt.Errorf("no alert JSON found in ConfigMap (expected 'alert.json' key)")
+}
+
+func (s *Sidecar) deleteAlert(ctx context.Context, cm *corev1.ConfigMap) error {
+	timer := prometheus.NewTimer(alertSyncDuration.WithLabelValues("delete"))
+	defer timer.ObserveDuration()
+
+	uid := string(cm.UID)
+
+	s.stateMu.RLock()
+	state, exists := s.alertState[uid]
+	s.stateMu.RUnlock()
+
+	if !exists {
+		return nil
+	}
+
+	if err := s.deleteAlertByID(ctx, state.ID); err != nil {
+		alertSyncTotal.WithLabelValues("delete", "error").Inc()
+		return err
+	}
+
+	s.stateMu.Lock()
+	delete(s.alertState, uid)
+	s.stateMu.Unlock()
+
+	alertSyncTotal.WithLabelValues("delete", "success").Inc()
+	s.logger.Info("Deleted alert", "id", state.ID, "namespace", cm.Namespace, "name", cm.Name)
+
+	return nil
+}
+
+// Alert API calls
+
+func (s *Sidecar) createAlert(ctx context.Context, alert map[string]interface{}) (string, error) {
+	payload, err := json.Marshal(alert)
+	if err != nil {
+		return "", err
+	}
+
+	reqURL, err := url.JoinPath(s.config.SignozURL, alertPath)
+	if err != nil {
+		return "", err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, reqURL, bytes.NewReader(payload))
+	if err != nil {
+		return "", err
+	}
+
+	s.setHeaders(req)
+
+	resp, err := s.httpClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	if resp.StatusCode >= 400 {
+		apiErrors.WithLabelValues("alert_create", fmt.Sprintf("%d", resp.StatusCode)).Inc()
+		return "", fmt.Errorf("API error (status %d): %s", resp.StatusCode, string(body))
+	}
+
+	var result alertResponse
+	if err := json.Unmarshal(body, &result); err != nil {
+		return "", err
+	}
+
+	if result.Status != "success" {
+		apiErrors.WithLabelValues("alert_create", "api_error").Inc()
+		return "", fmt.Errorf("API error: %s", result.Error)
+	}
+
+	return result.Data.ID, nil
+}
+
+func (s *Sidecar) updateAlert(ctx context.Context, id string, alert map[string]interface{}) error {
+	payload, err := json.Marshal(alert)
+	if err != nil {
+		return err
+	}
+
+	reqURL, err := url.JoinPath(s.config.SignozURL, alertPath, id)
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, reqURL, bytes.NewReader(payload))
+	if err != nil {
+		return err
+	}
+
+	s.setHeaders(req)
+
+	resp, err := s.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		body, _ := io.ReadAll(resp.Body)
+		apiErrors.WithLabelValues("alert_update", fmt.Sprintf("%d", resp.StatusCode)).Inc()
+		return fmt.Errorf("API error (status %d): %s", resp.StatusCode, string(body))
+	}
+
+	return nil
+}
+
+func (s *Sidecar) deleteAlertByID(ctx context.Context, id string) error {
+	reqURL, err := url.JoinPath(s.config.SignozURL, alertPath, id)
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, reqURL, nil)
+	if err != nil {
+		return err
+	}
+
+	s.setHeaders(req)
+
+	resp, err := s.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 && resp.StatusCode != 404 {
+		body, _ := io.ReadAll(resp.Body)
+		apiErrors.WithLabelValues("alert_delete", fmt.Sprintf("%d", resp.StatusCode)).Inc()
+		return fmt.Errorf("API error (status %d): %s", resp.StatusCode, string(body))
+	}
+
+	return nil
+}
+
+// ============================================================================
+// Channel sync methods
+// ============================================================================
+
+type channelResponse struct {
+	Status string      `json:"status"`
+	Data   channelData `json:"data"`
+	Error  string      `json:"error,omitempty"`
+}
+
+type channelData struct {
+	ID string `json:"id"`
+}
+
+func (s *Sidecar) watchChannelConfigMaps(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+
+		listOpts := metav1.ListOptions{
+			LabelSelector: fmt.Sprintf("%s=true", channelLabel),
+		}
+
+		var watcher watch.Interface
+		var err error
+
+		if s.config.Namespace == "" {
+			watcher, err = s.clientset.CoreV1().ConfigMaps("").Watch(ctx, listOpts)
+		} else {
+			watcher, err = s.clientset.CoreV1().ConfigMaps(s.config.Namespace).Watch(ctx, listOpts)
+		}
+
+		if err != nil {
+			s.logger.Error("Failed to start channel watch", "error", err)
+			time.Sleep(5 * time.Second)
+			continue
+		}
+
+		s.handleChannelWatchEvents(ctx, watcher)
+		watcher.Stop()
+	}
+}
+
+func (s *Sidecar) handleChannelWatchEvents(ctx context.Context, watcher watch.Interface) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case event, ok := <-watcher.ResultChan():
+			if !ok {
+				s.logger.Info("Channel watch channel closed, restarting...")
+				return
+			}
+
+			cm, ok := event.Object.(*corev1.ConfigMap)
+			if !ok {
+				continue
+			}
+
+			switch event.Type {
+			case watch.Added, watch.Modified:
+				if err := s.syncChannel(ctx, cm, false); err != nil {
+					s.logger.Error("Failed to sync channel", "namespace", cm.Namespace, "name", cm.Name, "error", err)
+				}
+			case watch.Deleted:
+				if err := s.deleteChannel(ctx, cm); err != nil {
+					s.logger.Error("Failed to delete channel", "namespace", cm.Namespace, "name", cm.Name, "error", err)
+				}
+			}
+		}
+	}
+}
+
+func (s *Sidecar) reconcileChannels(ctx context.Context) error {
+	timer := prometheus.NewTimer(channelSyncDuration.WithLabelValues("reconcile_all"))
+	defer timer.ObserveDuration()
+
+	listOpts := metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("%s=true", channelLabel),
+	}
+
+	var configMaps *corev1.ConfigMapList
+	var err error
+
+	if s.config.Namespace == "" {
+		configMaps, err = s.clientset.CoreV1().ConfigMaps("").List(ctx, listOpts)
+	} else {
+		configMaps, err = s.clientset.CoreV1().ConfigMaps(s.config.Namespace).List(ctx, listOpts)
+	}
+
+	if err != nil {
+		channelSyncTotal.WithLabelValues("reconcile_all", "error").Inc()
+		return fmt.Errorf("failed to list channel configmaps: %w", err)
+	}
+
+	channelConfigMapsWatched.Set(float64(len(configMaps.Items)))
+	s.logger.Info("Reconciling channel ConfigMaps", "count", len(configMaps.Items))
+
+	seenUIDs := make(map[string]bool)
+
+	for i := range configMaps.Items {
+		cm := &configMaps.Items[i]
+		seenUIDs[string(cm.UID)] = true
+
+		if err := s.syncChannel(ctx, cm, true); err != nil {
+			s.logger.Error("Failed to sync channel", "namespace", cm.Namespace, "name", cm.Name, "error", err)
+		}
+	}
+
+	// Clean up orphaned channels
+	var orphaned []struct {
+		uid, id, namespace, name string
+	}
+
+	s.stateMu.Lock()
+	for uid, state := range s.channelState {
+		if !seenUIDs[uid] {
+			orphaned = append(orphaned, struct{ uid, id, namespace, name string }{uid, state.ID, state.Namespace, state.Name})
+		}
+	}
+	s.stateMu.Unlock()
+
+	for _, od := range orphaned {
+		s.logger.Info("Cleaning up orphaned channel", "id", od.id, "namespace", od.namespace, "name", od.name)
+		if err := s.deleteChannelByID(ctx, od.id); err != nil {
+			s.logger.Error("Failed to delete orphaned channel", "id", od.id, "error", err)
+			continue
+		}
+		s.stateMu.Lock()
+		delete(s.channelState, od.uid)
+		s.stateMu.Unlock()
+	}
+
+	channelSyncTotal.WithLabelValues("reconcile_all", "success").Inc()
+	return nil
+}
+
+func (s *Sidecar) syncChannel(ctx context.Context, cm *corev1.ConfigMap, forceUpdate bool) error {
+	timer := prometheus.NewTimer(channelSyncDuration.WithLabelValues("sync"))
+	defer timer.ObserveDuration()
+
+	channelJSON, err := s.extractChannelJSON(cm)
+	if err != nil {
+		channelSyncTotal.WithLabelValues("sync", "invalid_config").Inc()
+		return err
+	}
+
+	// Substitute secret values if secretRef annotation is present
+	if secretRef, ok := cm.Annotations[secretRefKey]; ok {
+		channelJSON, err = s.substituteSecrets(ctx, channelJSON, secretRef, cm.Namespace)
+		if err != nil {
+			channelSyncTotal.WithLabelValues("sync", "secret_error").Inc()
+			return fmt.Errorf("failed to substitute secrets: %w", err)
+		}
+	}
+
+	contentHash := hashContent(channelJSON)
+	uid := string(cm.UID)
+
+	s.stateMu.RLock()
+	existing, exists := s.channelState[uid]
+	s.stateMu.RUnlock()
+
+	if !forceUpdate && exists && existing.ContentHash == contentHash {
+		s.logger.Debug("Channel unchanged, skipping", "namespace", cm.Namespace, "name", cm.Name)
+		channelSyncTotal.WithLabelValues("sync", "skipped").Inc()
+		return nil
+	}
+
+	var channel map[string]interface{}
+	if err := json.Unmarshal(channelJSON, &channel); err != nil {
+		channelSyncTotal.WithLabelValues("sync", "invalid_json").Inc()
+		return fmt.Errorf("invalid channel JSON: %w", err)
+	}
+
+	// Override name from annotation if provided
+	if name, ok := cm.Annotations[channelNameKey]; ok {
+		channel["name"] = name
+	}
+
+	if exists {
+		if err := s.updateChannel(ctx, existing.ID, channel); err != nil {
+			channelSyncTotal.WithLabelValues("sync", "update_error").Inc()
+			return err
+		}
+
+		s.stateMu.Lock()
+		s.channelState[uid] = ChannelState{
+			ID:          existing.ID,
+			ContentHash: contentHash,
+			Name:        cm.Name,
+			Namespace:   cm.Namespace,
+			SyncedAt:    time.Now().UTC().Format(time.RFC3339),
+		}
+		s.stateMu.Unlock()
+
+		if forceUpdate && existing.ContentHash == contentHash {
+			channelDriftCorrections.Inc()
+			channelSyncTotal.WithLabelValues("sync", "drift_corrected").Inc()
+		} else {
+			channelSyncTotal.WithLabelValues("sync", "updated").Inc()
+			s.logger.Info("Updated channel", "id", existing.ID, "namespace", cm.Namespace, "name", cm.Name)
+		}
+	} else {
+		channelID, err := s.createChannel(ctx, channel)
+		if err != nil {
+			channelSyncTotal.WithLabelValues("sync", "create_error").Inc()
+			return err
+		}
+
+		s.stateMu.Lock()
+		s.channelState[uid] = ChannelState{
+			ID:          channelID,
+			ContentHash: contentHash,
+			Name:        cm.Name,
+			Namespace:   cm.Namespace,
+			SyncedAt:    time.Now().UTC().Format(time.RFC3339),
+		}
+		s.stateMu.Unlock()
+
+		channelSyncTotal.WithLabelValues("sync", "created").Inc()
+		s.logger.Info("Created channel", "id", channelID, "namespace", cm.Namespace, "name", cm.Name)
+	}
+
+	return nil
+}
+
+func (s *Sidecar) extractChannelJSON(cm *corev1.ConfigMap) ([]byte, error) {
+	if data, ok := cm.Data["channel.json"]; ok {
+		return []byte(data), nil
+	}
+	for key, value := range cm.Data {
+		if strings.HasSuffix(key, ".json") {
+			return []byte(value), nil
+		}
+	}
+	if len(cm.Data) == 1 {
+		for _, value := range cm.Data {
+			return []byte(value), nil
+		}
+	}
+	return nil, fmt.Errorf("no channel JSON found in ConfigMap (expected 'channel.json' key)")
+}
+
+func (s *Sidecar) deleteChannel(ctx context.Context, cm *corev1.ConfigMap) error {
+	timer := prometheus.NewTimer(channelSyncDuration.WithLabelValues("delete"))
+	defer timer.ObserveDuration()
+
+	uid := string(cm.UID)
+
+	s.stateMu.RLock()
+	state, exists := s.channelState[uid]
+	s.stateMu.RUnlock()
+
+	if !exists {
+		return nil
+	}
+
+	if err := s.deleteChannelByID(ctx, state.ID); err != nil {
+		channelSyncTotal.WithLabelValues("delete", "error").Inc()
+		return err
+	}
+
+	s.stateMu.Lock()
+	delete(s.channelState, uid)
+	s.stateMu.Unlock()
+
+	channelSyncTotal.WithLabelValues("delete", "success").Inc()
+	s.logger.Info("Deleted channel", "id", state.ID, "namespace", cm.Namespace, "name", cm.Name)
+
+	return nil
+}
+
+// Channel API calls
+
+func (s *Sidecar) createChannel(ctx context.Context, channel map[string]interface{}) (string, error) {
+	payload, err := json.Marshal(channel)
+	if err != nil {
+		return "", err
+	}
+
+	reqURL, err := url.JoinPath(s.config.SignozURL, channelPath)
+	if err != nil {
+		return "", err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, reqURL, bytes.NewReader(payload))
+	if err != nil {
+		return "", err
+	}
+
+	s.setHeaders(req)
+
+	resp, err := s.httpClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	if resp.StatusCode >= 400 {
+		apiErrors.WithLabelValues("channel_create", fmt.Sprintf("%d", resp.StatusCode)).Inc()
+		return "", fmt.Errorf("API error (status %d): %s", resp.StatusCode, string(body))
+	}
+
+	var result channelResponse
+	if err := json.Unmarshal(body, &result); err != nil {
+		return "", err
+	}
+
+	if result.Status != "success" {
+		apiErrors.WithLabelValues("channel_create", "api_error").Inc()
+		return "", fmt.Errorf("API error: %s", result.Error)
+	}
+
+	return result.Data.ID, nil
+}
+
+func (s *Sidecar) updateChannel(ctx context.Context, id string, channel map[string]interface{}) error {
+	payload, err := json.Marshal(channel)
+	if err != nil {
+		return err
+	}
+
+	reqURL, err := url.JoinPath(s.config.SignozURL, channelPath, id)
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, reqURL, bytes.NewReader(payload))
+	if err != nil {
+		return err
+	}
+
+	s.setHeaders(req)
+
+	resp, err := s.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		body, _ := io.ReadAll(resp.Body)
+		apiErrors.WithLabelValues("channel_update", fmt.Sprintf("%d", resp.StatusCode)).Inc()
+		return fmt.Errorf("API error (status %d): %s", resp.StatusCode, string(body))
+	}
+
+	return nil
+}
+
+func (s *Sidecar) deleteChannelByID(ctx context.Context, id string) error {
+	reqURL, err := url.JoinPath(s.config.SignozURL, channelPath, id)
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, reqURL, nil)
+	if err != nil {
+		return err
+	}
+
+	s.setHeaders(req)
+
+	resp, err := s.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 && resp.StatusCode != 404 {
+		body, _ := io.ReadAll(resp.Body)
+		apiErrors.WithLabelValues("channel_delete", fmt.Sprintf("%d", resp.StatusCode)).Inc()
+		return fmt.Errorf("API error (status %d): %s", resp.StatusCode, string(body))
+	}
+
+	return nil
+}
+
+// ============================================================================
+// Helper functions
+// ============================================================================
+
+// substituteSecrets reads a Kubernetes secret and replaces ${KEY} placeholders in the JSON.
+// secretRef format: "secretName" (same namespace as ConfigMap) or "namespace/secretName"
+func (s *Sidecar) substituteSecrets(ctx context.Context, jsonData []byte, secretRef, defaultNamespace string) ([]byte, error) {
+	// Parse secretRef
+	namespace := defaultNamespace
+	secretName := secretRef
+	if parts := strings.SplitN(secretRef, "/", 2); len(parts) == 2 {
+		namespace = parts[0]
+		secretName = parts[1]
+	}
+
+	// Fetch the secret
+	secret, err := s.clientset.CoreV1().Secrets(namespace).Get(ctx, secretName, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get secret %s/%s: %w", namespace, secretName, err)
+	}
+
+	// Replace ${KEY} patterns with secret values
+	result := string(jsonData)
+	for key, value := range secret.Data {
+		placeholder := fmt.Sprintf("${%s}", key)
+		result = strings.ReplaceAll(result, placeholder, string(value))
+	}
+
+	s.logger.Debug("Substituted secrets", "secret", secretRef, "keys", len(secret.Data))
+	return []byte(result), nil
 }
 
 func getEnv(key, fallback string) string {

--- a/charts/signoz-operator/crds/README.md
+++ b/charts/signoz-operator/crds/README.md
@@ -1,0 +1,339 @@
+# SigNoz Operator CRDs
+
+This directory contains Custom Resource Definitions (CRDs) for the SigNoz Operator, enabling Kubernetes-native management of SigNoz monitoring resources.
+
+## Overview
+
+The SigNoz Operator provides three CRDs:
+
+| CRD                   | Scope      | Purpose                                      |
+| --------------------- | ---------- | -------------------------------------------- |
+| `HTTPCheck`           | Namespaced | Synthetic HTTP health checks                 |
+| `Alert`               | Namespaced | Alerting rules based on metrics              |
+| `NotificationChannel` | Cluster    | Notification targets (PagerDuty, Slack, etc) |
+
+All CRDs use `apiVersion: monitoring.jomcgi.dev/v1alpha1`.
+
+## HTTPCheck
+
+Defines synthetic HTTP health checks that SigNoz will execute at regular intervals.
+
+### Spec Fields
+
+| Field                | Type              | Required | Default | Description                              |
+| -------------------- | ----------------- | -------- | ------- | ---------------------------------------- |
+| `endpoint`           | string            | Yes      | -       | URL to check (must start with http(s)://) |
+| `method`             | enum              | No       | GET     | HTTP method (GET, POST, HEAD)            |
+| `expectedStatusCode` | integer           | No       | 200     | Expected response status code            |
+| `interval`           | string            | No       | 2m      | Check frequency (e.g., "30s", "2m")      |
+| `timeout`            | string            | No       | 10s     | Request timeout                          |
+| `headers`            | map[string]string | No       | -       | Custom HTTP headers                      |
+| `body`               | string            | No       | -       | Request body for POST requests           |
+| `authSecretRef`      | object            | No       | -       | Reference to Secret with auth credentials|
+| `insecureSkipVerify` | boolean           | No       | false   | Skip TLS verification                    |
+| `labels`             | map[string]string | No       | -       | Labels for grouping/filtering            |
+| `disabled`           | boolean           | No       | false   | Temporarily disable the check            |
+
+### Example
+
+```yaml
+apiVersion: monitoring.jomcgi.dev/v1alpha1
+kind: HTTPCheck
+metadata:
+  name: grafana-health
+  namespace: monitoring
+spec:
+  endpoint: https://grafana.example.com/api/health
+  method: GET
+  expectedStatusCode: 200
+  interval: 2m
+  timeout: 10s
+  labels:
+    service: grafana
+    environment: production
+  # For Cloudflare Access protected endpoints
+  authSecretRef:
+    name: cf-access-credentials
+    keys:
+      - secretKey: CF_ACCESS_CLIENT_ID
+        headerName: CF-Access-Client-Id
+      - secretKey: CF_ACCESS_CLIENT_SECRET
+        headerName: CF-Access-Client-Secret
+```
+
+### Status
+
+```yaml
+status:
+  phase: Synced              # Pending, Syncing, Synced, Error, Disabled
+  signozId: "abc123"         # ID in SigNoz
+  lastSyncTime: "2024-01-15T10:30:00Z"
+  lastCheckTime: "2024-01-15T10:32:00Z"
+  lastCheckResult: Success   # Success, Failure, Unknown
+  lastResponseTime: 45       # Response time in ms
+```
+
+## Alert
+
+Defines alerting rules that evaluate metrics and trigger notifications.
+
+### Spec Fields
+
+| Field                  | Type     | Required | Default | Description                              |
+| ---------------------- | -------- | -------- | ------- | ---------------------------------------- |
+| `alertName`            | string   | Yes      | -       | Display name for the alert               |
+| `description`          | string   | No       | -       | Detailed description                     |
+| `summary`              | string   | No       | -       | Short summary for notifications          |
+| `httpCheckRef`         | object   | No*      | -       | Reference to HTTPCheck to alert on       |
+| `customQuery`          | object   | No*      | -       | Custom PromQL/ClickHouse query           |
+| `condition`            | object   | Yes      | -       | Alert trigger condition                  |
+| `evalWindow`           | string   | No       | 5m      | Evaluation time window                   |
+| `frequency`            | string   | No       | 1m      | Evaluation frequency                     |
+| `consecutiveFailures`  | integer  | No       | 1       | Required consecutive failures            |
+| `severity`             | enum     | No       | warning | critical, warning, info                  |
+| `notificationChannels` | []string | No       | -       | NotificationChannel names to notify      |
+| `labels`               | map      | No       | -       | Labels for grouping/routing              |
+| `annotations`          | map      | No       | -       | Additional metadata                      |
+| `disabled`             | boolean  | No       | false   | Temporarily disable                      |
+| `runbookUrl`           | string   | No       | -       | Link to response documentation           |
+
+*Either `httpCheckRef` or `customQuery` should be specified.
+
+### Condition Object
+
+| Field       | Type   | Required | Default | Description                          |
+| ----------- | ------ | -------- | ------- | ------------------------------------ |
+| `operator`  | enum   | Yes      | -       | >, >=, <, <=, ==, !=                 |
+| `threshold` | number | Yes      | -       | Value to compare against             |
+| `matchType` | enum   | No       | once    | once, always, onAverage, inTotal     |
+
+### Example: HTTPCheck Alert
+
+```yaml
+apiVersion: monitoring.jomcgi.dev/v1alpha1
+kind: Alert
+metadata:
+  name: grafana-down
+  namespace: monitoring
+spec:
+  alertName: Grafana Unreachable
+  description: Grafana health check has been failing
+  httpCheckRef:
+    name: grafana-health
+  condition:
+    operator: "<"
+    threshold: 1
+    matchType: always
+  evalWindow: 10m
+  frequency: 2m
+  consecutiveFailures: 5
+  severity: critical
+  notificationChannels:
+    - pagerduty-oncall
+    - slack-alerts
+  labels:
+    service: grafana
+    team: platform
+  runbookUrl: https://wiki.example.com/runbooks/grafana-down
+```
+
+### Example: Custom Query Alert
+
+```yaml
+apiVersion: monitoring.jomcgi.dev/v1alpha1
+kind: Alert
+metadata:
+  name: high-error-rate
+  namespace: my-app
+spec:
+  alertName: High Error Rate
+  description: Application error rate exceeds 5%
+  customQuery:
+    query: |
+      sum(rate(http_requests_total{status=~"5.."}[5m])) /
+      sum(rate(http_requests_total[5m])) * 100
+    queryType: promql
+  condition:
+    operator: ">"
+    threshold: 5
+  evalWindow: 5m
+  severity: warning
+  notificationChannels:
+    - slack-alerts
+```
+
+### Status
+
+```yaml
+status:
+  phase: Synced
+  signozId: "def456"
+  lastSyncTime: "2024-01-15T10:30:00Z"
+  alertState: inactive    # inactive, pending, firing
+  lastFiredTime: "2024-01-14T15:45:00Z"
+```
+
+## NotificationChannel
+
+Defines notification targets for alerts. This is a cluster-scoped resource.
+
+### Spec Fields
+
+| Field          | Type    | Required | Default | Description                              |
+| -------------- | ------- | -------- | ------- | ---------------------------------------- |
+| `type`         | enum    | Yes      | -       | pagerduty, webhook, slack, email, opsgenie, msteams |
+| `sendResolved` | boolean | No       | true    | Send notification when alert resolves    |
+| `pagerduty`    | object  | No*      | -       | PagerDuty configuration                  |
+| `webhook`      | object  | No*      | -       | Webhook configuration                    |
+| `slack`        | object  | No*      | -       | Slack configuration                      |
+| `email`        | object  | No*      | -       | Email configuration                      |
+| `opsgenie`     | object  | No*      | -       | OpsGenie configuration                   |
+| `msteams`      | object  | No*      | -       | Microsoft Teams configuration            |
+
+*The corresponding configuration object is required based on `type`.
+
+### Example: PagerDuty
+
+```yaml
+apiVersion: monitoring.jomcgi.dev/v1alpha1
+kind: NotificationChannel
+metadata:
+  name: pagerduty-oncall
+spec:
+  type: pagerduty
+  sendResolved: true
+  pagerduty:
+    routingKeySecretRef:
+      name: pagerduty-credentials
+      namespace: monitoring
+      key: routing-key
+    severity: error
+```
+
+### Example: Slack
+
+```yaml
+apiVersion: monitoring.jomcgi.dev/v1alpha1
+kind: NotificationChannel
+metadata:
+  name: slack-alerts
+spec:
+  type: slack
+  sendResolved: true
+  slack:
+    webhookUrlSecretRef:
+      name: slack-webhook
+      namespace: monitoring
+      key: webhook-url
+    channel: "#alerts"
+    username: SigNoz Alerts
+    iconEmoji: ":warning:"
+```
+
+### Example: Webhook
+
+```yaml
+apiVersion: monitoring.jomcgi.dev/v1alpha1
+kind: NotificationChannel
+metadata:
+  name: custom-webhook
+spec:
+  type: webhook
+  sendResolved: true
+  webhook:
+    url: https://api.example.com/alerts
+    httpMethod: POST
+    authSecretRef:
+      name: webhook-auth
+      namespace: monitoring
+      key: token
+      headerName: Authorization
+    headers:
+      Content-Type: application/json
+```
+
+### Status
+
+```yaml
+status:
+  phase: Synced
+  signozId: "ghi789"
+  lastSyncTime: "2024-01-15T10:30:00Z"
+  lastTestTime: "2024-01-15T10:30:05Z"
+  lastTestResult: Success
+```
+
+## Secret References
+
+All sensitive data (API keys, tokens, webhooks) are stored in Kubernetes Secrets and referenced by the CRDs.
+
+### Cloudflare Access Credentials
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cf-access-credentials
+  namespace: monitoring
+type: Opaque
+stringData:
+  CF_ACCESS_CLIENT_ID: "<service-token-id>"
+  CF_ACCESS_CLIENT_SECRET: "<service-token-secret>"
+```
+
+### PagerDuty Routing Key
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: pagerduty-credentials
+  namespace: monitoring
+type: Opaque
+stringData:
+  routing-key: "<pagerduty-routing-key>"
+```
+
+## kubectl Usage
+
+Short names are available for convenience:
+
+```bash
+# HTTPChecks
+kubectl get httpchecks           # or: kubectl get hc
+kubectl get hc -n monitoring
+
+# Alerts
+kubectl get alerts               # or: kubectl get al
+kubectl get al -n monitoring
+
+# NotificationChannels (cluster-scoped)
+kubectl get notificationchannels # or: kubectl get nc
+kubectl get notifchan
+```
+
+## Status Phases
+
+All resources follow the same phase lifecycle:
+
+| Phase      | Description                                          |
+| ---------- | ---------------------------------------------------- |
+| `Pending`  | Resource created, waiting for initial sync           |
+| `Syncing`  | Actively syncing to SigNoz                           |
+| `Synced`   | Successfully synced, SigNoz ID assigned              |
+| `Error`    | Sync failed, see `errorMessage` for details          |
+| `Disabled` | Resource disabled via `spec.disabled: true`          |
+
+## Design Decisions
+
+1. **Namespaced HTTPCheck and Alert**: Services can define their own monitoring alongside their deployments, following the principle of co-location.
+
+2. **Cluster-scoped NotificationChannel**: Notification targets (PagerDuty, Slack) are typically shared infrastructure, avoiding duplication across namespaces.
+
+3. **Secret references**: Sensitive credentials are stored in Kubernetes Secrets, following security best practices.
+
+4. **HTTPCheck reference in Alerts**: Alerts can reference HTTPChecks directly, automatically using the check's status metric without requiring manual query construction.
+
+5. **Short names**: `hc`, `al`, and `nc` provide quick kubectl access.
+
+6. **Printer columns**: Key status information visible in `kubectl get` output.

--- a/charts/signoz-operator/crds/alert-crd.yaml
+++ b/charts/signoz-operator/crds/alert-crd.yaml
@@ -1,0 +1,271 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: alerts.monitoring.jomcgi.dev
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+spec:
+  group: monitoring.jomcgi.dev
+  names:
+    kind: Alert
+    listKind: AlertList
+    plural: alerts
+    singular: alert
+    shortNames:
+      - al
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      additionalPrinterColumns:
+        - name: Alert Name
+          type: string
+          jsonPath: .spec.alertName
+          priority: 0
+        - name: Severity
+          type: string
+          jsonPath: .spec.severity
+          priority: 0
+        - name: Status
+          type: string
+          jsonPath: .status.phase
+          priority: 0
+        - name: State
+          type: string
+          jsonPath: .status.alertState
+          priority: 1
+        - name: Age
+          type: date
+          jsonPath: .metadata.creationTimestamp
+          priority: 0
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
+          description: Alert defines an alerting rule to be managed in SigNoz.
+          type: object
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated. In CamelCase.
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: AlertSpec defines the desired state of Alert.
+              type: object
+              required:
+                - alertName
+                - condition
+              properties:
+                alertName:
+                  description: AlertName is the display name for the alert in SigNoz.
+                  type: string
+                  minLength: 1
+                  maxLength: 255
+                description:
+                  description: Description provides details about what this alert monitors.
+                  type: string
+                  maxLength: 4096
+                summary:
+                  description: Summary is a short summary template for alert notifications.
+                  type: string
+                  maxLength: 1024
+                httpCheckRef:
+                  description: |-
+                    HTTPCheckRef references an HTTPCheck resource to alert on.
+                    When set, the alert will automatically use the HTTPCheck's status metric.
+                  type: object
+                  required:
+                    - name
+                  properties:
+                    name:
+                      description: Name of the HTTPCheck in the same namespace.
+                      type: string
+                customQuery:
+                  description: |-
+                    CustomQuery allows defining a custom PromQL/SigNoz query.
+                    Either httpCheckRef or customQuery must be specified, but not both.
+                  type: object
+                  required:
+                    - query
+                  properties:
+                    query:
+                      description: Query is the PromQL or SigNoz query expression.
+                      type: string
+                    queryType:
+                      description: QueryType specifies the query language (promql or clickhouse).
+                      type: string
+                      enum:
+                        - promql
+                        - clickhouse
+                      default: promql
+                condition:
+                  description: Condition defines when the alert should fire.
+                  type: object
+                  required:
+                    - operator
+                    - threshold
+                  properties:
+                    operator:
+                      description: Operator is the comparison operator.
+                      type: string
+                      enum:
+                        - ">"
+                        - ">="
+                        - "<"
+                        - "<="
+                        - "=="
+                        - "!="
+                    threshold:
+                      description: Threshold is the value to compare against.
+                      type: number
+                    matchType:
+                      description: MatchType defines how the condition should match.
+                      type: string
+                      enum:
+                        - once
+                        - always
+                        - onAverage
+                        - inTotal
+                      default: once
+                evalWindow:
+                  description: EvalWindow is the time window for evaluating the condition (e.g., "5m", "10m").
+                  type: string
+                  pattern: ^[0-9]+(s|m|h)$
+                  default: "5m"
+                frequency:
+                  description: Frequency is how often the alert rule is evaluated (e.g., "1m", "2m").
+                  type: string
+                  pattern: ^[0-9]+(s|m|h)$
+                  default: "1m"
+                consecutiveFailures:
+                  description: |-
+                    ConsecutiveFailures is the number of consecutive evaluation failures
+                    required before firing the alert. Useful to avoid flapping.
+                  type: integer
+                  minimum: 1
+                  default: 1
+                severity:
+                  description: Severity indicates the priority of the alert.
+                  type: string
+                  enum:
+                    - critical
+                    - warning
+                    - info
+                  default: warning
+                notificationChannels:
+                  description: |-
+                    NotificationChannels is a list of NotificationChannel names to notify.
+                    These should reference cluster-scoped NotificationChannel resources.
+                  type: array
+                  items:
+                    type: string
+                labels:
+                  description: Labels are key-value pairs attached to the alert for grouping and routing.
+                  type: object
+                  additionalProperties:
+                    type: string
+                annotations:
+                  description: Annotations are key-value pairs for additional alert metadata.
+                  type: object
+                  additionalProperties:
+                    type: string
+                disabled:
+                  description: Disabled temporarily disables the alert without deleting it.
+                  type: boolean
+                  default: false
+                runbookUrl:
+                  description: RunbookUrl is a link to documentation for responding to this alert.
+                  type: string
+            status:
+              description: AlertStatus defines the observed state of Alert.
+              type: object
+              properties:
+                phase:
+                  description: Phase indicates the current state of the Alert.
+                  type: string
+                  enum:
+                    - Pending
+                    - Syncing
+                    - Synced
+                    - Error
+                    - Disabled
+                signozId:
+                  description: SignozId is the ID of this alert rule in SigNoz.
+                  type: string
+                lastSyncTime:
+                  description: LastSyncTime is when the alert was last synced to SigNoz.
+                  type: string
+                  format: date-time
+                alertState:
+                  description: AlertState is the current firing state from SigNoz.
+                  type: string
+                  enum:
+                    - inactive
+                    - pending
+                    - firing
+                lastFiredTime:
+                  description: LastFiredTime is when the alert last fired.
+                  type: string
+                  format: date-time
+                errorMessage:
+                  description: ErrorMessage contains details if the phase is Error.
+                  type: string
+                observedGeneration:
+                  description: ObservedGeneration reflects the generation of the most recently observed spec.
+                  type: integer
+                  format: int64
+                conditions:
+                  description: Conditions represent the latest available observations.
+                  type: array
+                  items:
+                    type: object
+                    required:
+                      - type
+                      - status
+                      - lastTransitionTime
+                      - reason
+                      - message
+                    properties:
+                      type:
+                        description: Type of condition.
+                        type: string
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      status:
+                        description: Status of the condition, one of True, False, Unknown.
+                        type: string
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                      lastTransitionTime:
+                        description: LastTransitionTime is when the condition last transitioned.
+                        type: string
+                        format: date-time
+                      reason:
+                        description: Reason is a programmatic identifier for the condition's last transition.
+                        type: string
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      message:
+                        description: Message is a human readable message indicating details.
+                        type: string
+                        maxLength: 32768
+                      observedGeneration:
+                        description: ObservedGeneration for this condition.
+                        type: integer
+                        format: int64
+                        minimum: 0

--- a/charts/signoz-operator/crds/httpcheck-crd.yaml
+++ b/charts/signoz-operator/crds/httpcheck-crd.yaml
@@ -1,0 +1,235 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: httpchecks.monitoring.jomcgi.dev
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+spec:
+  group: monitoring.jomcgi.dev
+  names:
+    kind: HTTPCheck
+    listKind: HTTPCheckList
+    plural: httpchecks
+    singular: httpcheck
+    shortNames:
+      - hc
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      additionalPrinterColumns:
+        - name: Endpoint
+          type: string
+          jsonPath: .spec.endpoint
+          priority: 0
+        - name: Method
+          type: string
+          jsonPath: .spec.method
+          priority: 0
+        - name: Interval
+          type: string
+          jsonPath: .spec.interval
+          priority: 0
+        - name: Status
+          type: string
+          jsonPath: .status.phase
+          priority: 0
+        - name: Last Check
+          type: date
+          jsonPath: .status.lastCheckTime
+          priority: 1
+        - name: Age
+          type: date
+          jsonPath: .metadata.creationTimestamp
+          priority: 0
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
+          description: HTTPCheck defines a synthetic HTTP health check to be monitored by SigNoz.
+          type: object
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated. In CamelCase.
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: HTTPCheckSpec defines the desired state of HTTPCheck.
+              type: object
+              required:
+                - endpoint
+              properties:
+                endpoint:
+                  description: Endpoint is the URL to check (e.g., https://example.com/health).
+                  type: string
+                  pattern: ^https?://
+                method:
+                  description: Method is the HTTP method to use for the check.
+                  type: string
+                  enum:
+                    - GET
+                    - POST
+                    - HEAD
+                  default: GET
+                expectedStatusCode:
+                  description: ExpectedStatusCode is the HTTP status code expected for a successful check.
+                  type: integer
+                  minimum: 100
+                  maximum: 599
+                  default: 200
+                interval:
+                  description: Interval is how often the check should run (e.g., "2m", "30s").
+                  type: string
+                  pattern: ^[0-9]+(s|m|h)$
+                  default: "2m"
+                timeout:
+                  description: Timeout is the maximum time to wait for a response (e.g., "10s").
+                  type: string
+                  pattern: ^[0-9]+(s|m)$
+                  default: "10s"
+                headers:
+                  description: Headers are custom HTTP headers to include in the request.
+                  type: object
+                  additionalProperties:
+                    type: string
+                body:
+                  description: Body is the request body for POST requests.
+                  type: string
+                authSecretRef:
+                  description: |-
+                    AuthSecretRef references a Secret containing authentication credentials.
+                    The Secret should contain keys like 'CF_ACCESS_CLIENT_ID' and 'CF_ACCESS_CLIENT_SECRET'
+                    for Cloudflare Access, or 'Authorization' for bearer tokens.
+                  type: object
+                  required:
+                    - name
+                  properties:
+                    name:
+                      description: Name is the name of the Secret in the same namespace.
+                      type: string
+                    keys:
+                      description: |-
+                        Keys specifies which keys from the Secret to use as headers.
+                        If not specified, defaults to CF_ACCESS_CLIENT_ID and CF_ACCESS_CLIENT_SECRET.
+                      type: array
+                      items:
+                        type: object
+                        required:
+                          - secretKey
+                          - headerName
+                        properties:
+                          secretKey:
+                            description: SecretKey is the key in the Secret.
+                            type: string
+                          headerName:
+                            description: HeaderName is the HTTP header name to set.
+                            type: string
+                insecureSkipVerify:
+                  description: InsecureSkipVerify skips TLS certificate verification. Use with caution.
+                  type: boolean
+                  default: false
+                labels:
+                  description: Labels are key-value pairs for grouping and filtering checks.
+                  type: object
+                  additionalProperties:
+                    type: string
+                disabled:
+                  description: Disabled temporarily disables the check without deleting it.
+                  type: boolean
+                  default: false
+            status:
+              description: HTTPCheckStatus defines the observed state of HTTPCheck.
+              type: object
+              properties:
+                phase:
+                  description: Phase indicates the current state of the HTTPCheck.
+                  type: string
+                  enum:
+                    - Pending
+                    - Syncing
+                    - Synced
+                    - Error
+                    - Disabled
+                signozId:
+                  description: SignozId is the ID of this check in SigNoz.
+                  type: string
+                lastSyncTime:
+                  description: LastSyncTime is when the check was last synced to SigNoz.
+                  type: string
+                  format: date-time
+                lastCheckTime:
+                  description: LastCheckTime is when the health check last executed.
+                  type: string
+                  format: date-time
+                lastCheckResult:
+                  description: LastCheckResult indicates the result of the last check.
+                  type: string
+                  enum:
+                    - Success
+                    - Failure
+                    - Unknown
+                lastResponseTime:
+                  description: LastResponseTime is the response time in milliseconds of the last check.
+                  type: integer
+                errorMessage:
+                  description: ErrorMessage contains details if the phase is Error.
+                  type: string
+                observedGeneration:
+                  description: ObservedGeneration reflects the generation of the most recently observed spec.
+                  type: integer
+                  format: int64
+                conditions:
+                  description: Conditions represent the latest available observations.
+                  type: array
+                  items:
+                    type: object
+                    required:
+                      - type
+                      - status
+                      - lastTransitionTime
+                      - reason
+                      - message
+                    properties:
+                      type:
+                        description: Type of condition.
+                        type: string
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      status:
+                        description: Status of the condition, one of True, False, Unknown.
+                        type: string
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                      lastTransitionTime:
+                        description: LastTransitionTime is when the condition last transitioned.
+                        type: string
+                        format: date-time
+                      reason:
+                        description: Reason is a programmatic identifier for the condition's last transition.
+                        type: string
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      message:
+                        description: Message is a human readable message indicating details.
+                        type: string
+                        maxLength: 32768
+                      observedGeneration:
+                        description: ObservedGeneration for this condition.
+                        type: integer
+                        format: int64
+                        minimum: 0

--- a/charts/signoz-operator/crds/notificationchannel-crd.yaml
+++ b/charts/signoz-operator/crds/notificationchannel-crd.yaml
@@ -1,0 +1,379 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: notificationchannels.monitoring.jomcgi.dev
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+spec:
+  group: monitoring.jomcgi.dev
+  names:
+    kind: NotificationChannel
+    listKind: NotificationChannelList
+    plural: notificationchannels
+    singular: notificationchannel
+    shortNames:
+      - nc
+      - notifchan
+  scope: Cluster
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      additionalPrinterColumns:
+        - name: Type
+          type: string
+          jsonPath: .spec.type
+          priority: 0
+        - name: Status
+          type: string
+          jsonPath: .status.phase
+          priority: 0
+        - name: Send Resolved
+          type: boolean
+          jsonPath: .spec.sendResolved
+          priority: 1
+        - name: Age
+          type: date
+          jsonPath: .metadata.creationTimestamp
+          priority: 0
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
+          description: NotificationChannel defines a notification target for alerts in SigNoz.
+          type: object
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated. In CamelCase.
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: NotificationChannelSpec defines the desired state of NotificationChannel.
+              type: object
+              required:
+                - type
+              properties:
+                type:
+                  description: Type is the notification channel type.
+                  type: string
+                  enum:
+                    - pagerduty
+                    - webhook
+                    - slack
+                    - email
+                    - opsgenie
+                    - msteams
+                sendResolved:
+                  description: SendResolved indicates whether to send notifications when alerts resolve.
+                  type: boolean
+                  default: true
+                pagerduty:
+                  description: PagerDuty configuration (required when type is pagerduty).
+                  type: object
+                  required:
+                    - routingKeySecretRef
+                  properties:
+                    routingKeySecretRef:
+                      description: RoutingKeySecretRef references a Secret containing the PagerDuty routing key.
+                      type: object
+                      required:
+                        - name
+                        - namespace
+                      properties:
+                        name:
+                          description: Name of the Secret.
+                          type: string
+                        namespace:
+                          description: Namespace of the Secret.
+                          type: string
+                        key:
+                          description: Key in the Secret containing the routing key.
+                          type: string
+                          default: routing-key
+                    severity:
+                      description: Severity to use for PagerDuty events.
+                      type: string
+                      enum:
+                        - critical
+                        - error
+                        - warning
+                        - info
+                      default: error
+                    description:
+                      description: Description template for PagerDuty events.
+                      type: string
+                    detailsTemplate:
+                      description: DetailsTemplate is a Go template for custom PagerDuty details.
+                      type: string
+                webhook:
+                  description: Webhook configuration (required when type is webhook).
+                  type: object
+                  required:
+                    - url
+                  properties:
+                    url:
+                      description: URL is the webhook endpoint.
+                      type: string
+                      pattern: ^https?://
+                    authSecretRef:
+                      description: AuthSecretRef references a Secret for webhook authentication.
+                      type: object
+                      required:
+                        - name
+                        - namespace
+                      properties:
+                        name:
+                          description: Name of the Secret.
+                          type: string
+                        namespace:
+                          description: Namespace of the Secret.
+                          type: string
+                        key:
+                          description: Key in the Secret containing the auth token.
+                          type: string
+                          default: token
+                        headerName:
+                          description: HeaderName is the HTTP header to set with the auth token.
+                          type: string
+                          default: Authorization
+                    headers:
+                      description: Headers are additional HTTP headers to include.
+                      type: object
+                      additionalProperties:
+                        type: string
+                    httpMethod:
+                      description: HTTPMethod is the HTTP method to use (POST or PUT).
+                      type: string
+                      enum:
+                        - POST
+                        - PUT
+                      default: POST
+                slack:
+                  description: Slack configuration (required when type is slack).
+                  type: object
+                  required:
+                    - webhookUrlSecretRef
+                  properties:
+                    webhookUrlSecretRef:
+                      description: WebhookUrlSecretRef references a Secret containing the Slack webhook URL.
+                      type: object
+                      required:
+                        - name
+                        - namespace
+                      properties:
+                        name:
+                          description: Name of the Secret.
+                          type: string
+                        namespace:
+                          description: Namespace of the Secret.
+                          type: string
+                        key:
+                          description: Key in the Secret containing the webhook URL.
+                          type: string
+                          default: webhook-url
+                    channel:
+                      description: Channel to post to (overrides webhook default).
+                      type: string
+                    username:
+                      description: Username to post as.
+                      type: string
+                      default: SigNoz Alerts
+                    iconEmoji:
+                      description: IconEmoji is the emoji to use as the icon (e.g., ":warning:").
+                      type: string
+                    titleTemplate:
+                      description: TitleTemplate is a Go template for the message title.
+                      type: string
+                    textTemplate:
+                      description: TextTemplate is a Go template for the message body.
+                      type: string
+                email:
+                  description: Email configuration (required when type is email).
+                  type: object
+                  required:
+                    - to
+                  properties:
+                    to:
+                      description: To is the list of recipient email addresses.
+                      type: array
+                      items:
+                        type: string
+                      minItems: 1
+                    subjectTemplate:
+                      description: SubjectTemplate is a Go template for the email subject.
+                      type: string
+                    bodyTemplate:
+                      description: BodyTemplate is a Go template for the email body.
+                      type: string
+                opsgenie:
+                  description: OpsGenie configuration (required when type is opsgenie).
+                  type: object
+                  required:
+                    - apiKeySecretRef
+                  properties:
+                    apiKeySecretRef:
+                      description: ApiKeySecretRef references a Secret containing the OpsGenie API key.
+                      type: object
+                      required:
+                        - name
+                        - namespace
+                      properties:
+                        name:
+                          description: Name of the Secret.
+                          type: string
+                        namespace:
+                          description: Namespace of the Secret.
+                          type: string
+                        key:
+                          description: Key in the Secret containing the API key.
+                          type: string
+                          default: api-key
+                    priority:
+                      description: Priority for OpsGenie alerts.
+                      type: string
+                      enum:
+                        - P1
+                        - P2
+                        - P3
+                        - P4
+                        - P5
+                      default: P3
+                    responders:
+                      description: Responders to notify in OpsGenie.
+                      type: array
+                      items:
+                        type: object
+                        required:
+                          - type
+                          - id
+                        properties:
+                          type:
+                            description: Type of responder.
+                            type: string
+                            enum:
+                              - team
+                              - user
+                              - escalation
+                              - schedule
+                          id:
+                            description: ID of the responder.
+                            type: string
+                msteams:
+                  description: Microsoft Teams configuration (required when type is msteams).
+                  type: object
+                  required:
+                    - webhookUrlSecretRef
+                  properties:
+                    webhookUrlSecretRef:
+                      description: WebhookUrlSecretRef references a Secret containing the Teams webhook URL.
+                      type: object
+                      required:
+                        - name
+                        - namespace
+                      properties:
+                        name:
+                          description: Name of the Secret.
+                          type: string
+                        namespace:
+                          description: Namespace of the Secret.
+                          type: string
+                        key:
+                          description: Key in the Secret containing the webhook URL.
+                          type: string
+                          default: webhook-url
+                    titleTemplate:
+                      description: TitleTemplate is a Go template for the message title.
+                      type: string
+                    textTemplate:
+                      description: TextTemplate is a Go template for the message body.
+                      type: string
+            status:
+              description: NotificationChannelStatus defines the observed state of NotificationChannel.
+              type: object
+              properties:
+                phase:
+                  description: Phase indicates the current state of the NotificationChannel.
+                  type: string
+                  enum:
+                    - Pending
+                    - Syncing
+                    - Synced
+                    - Error
+                signozId:
+                  description: SignozId is the ID of this channel in SigNoz.
+                  type: string
+                lastSyncTime:
+                  description: LastSyncTime is when the channel was last synced to SigNoz.
+                  type: string
+                  format: date-time
+                lastTestTime:
+                  description: LastTestTime is when the channel was last tested.
+                  type: string
+                  format: date-time
+                lastTestResult:
+                  description: LastTestResult indicates whether the last test was successful.
+                  type: string
+                  enum:
+                    - Success
+                    - Failure
+                errorMessage:
+                  description: ErrorMessage contains details if the phase is Error.
+                  type: string
+                observedGeneration:
+                  description: ObservedGeneration reflects the generation of the most recently observed spec.
+                  type: integer
+                  format: int64
+                conditions:
+                  description: Conditions represent the latest available observations.
+                  type: array
+                  items:
+                    type: object
+                    required:
+                      - type
+                      - status
+                      - lastTransitionTime
+                      - reason
+                      - message
+                    properties:
+                      type:
+                        description: Type of condition.
+                        type: string
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      status:
+                        description: Status of the condition, one of True, False, Unknown.
+                        type: string
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                      lastTransitionTime:
+                        description: LastTransitionTime is when the condition last transitioned.
+                        type: string
+                        format: date-time
+                      reason:
+                        description: Reason is a programmatic identifier for the condition's last transition.
+                        type: string
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      message:
+                        description: Message is a human readable message indicating details.
+                        type: string
+                        maxLength: 32768
+                      observedGeneration:
+                        description: ObservedGeneration for this condition.
+                        type: integer
+                        format: int64
+                        minimum: 0

--- a/overlays/cluster-critical/argocd/argocd-httpcheck-alert.yaml
+++ b/overlays/cluster-critical/argocd/argocd-httpcheck-alert.yaml
@@ -1,0 +1,61 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: argocd-httpcheck-alert
+  namespace: argocd
+  labels:
+    signoz.io/alert: "true"
+  annotations:
+    signoz.io/alert-name: "ArgoCD Unreachable"
+    signoz.io/severity: "critical"
+    signoz.io/notification-channels: "pagerduty-homelab"
+data:
+  alert.json: |
+    {
+      "alert": "ArgoCD Unreachable",
+      "alertType": "METRICS_BASED_ALERT",
+      "ruleType": "threshold_rule",
+      "broadcastToAll": false,
+      "disabled": false,
+      "evalWindow": "10m0s",
+      "frequency": "2m0s",
+      "severity": "critical",
+      "labels": {
+        "service": "argocd",
+        "environment": "production"
+      },
+      "annotations": {
+        "summary": "ArgoCD at argocd.jomcgi.dev is unreachable",
+        "description": "HTTP health check has failed 5 consecutive times over 10 minutes"
+      },
+      "condition": {
+        "compositeQuery": {
+          "builderQueries": {
+            "A": {
+              "queryName": "A",
+              "dataSource": "metrics",
+              "aggregateOperator": "avg",
+              "aggregateAttribute": {
+                "key": "httpcheck_status",
+                "dataType": "float64",
+                "type": "Gauge"
+              },
+              "filters": {
+                "items": [
+                  {
+                    "key": {"key": "http_url"},
+                    "op": "=",
+                    "value": "https://argocd.jomcgi.dev"
+                  }
+                ]
+              }
+            }
+          },
+          "queryType": "builder"
+        },
+        "op": "<",
+        "target": 1,
+        "matchType": "5"
+      },
+      "preferredChannels": ["pagerduty-homelab"]
+    }

--- a/overlays/cluster-critical/argocd/kustomization.yaml
+++ b/overlays/cluster-critical/argocd/kustomization.yaml
@@ -5,3 +5,4 @@ namespace: argocd
 
 resources:
   - application.yaml
+  - argocd-httpcheck-alert.yaml

--- a/overlays/cluster-critical/signoz/kustomization.yaml
+++ b/overlays/cluster-critical/signoz/kustomization.yaml
@@ -4,3 +4,4 @@ kind: Kustomization
 resources:
   - application.yaml
   - synthetic-monitor-secret.yaml
+  - pagerduty-channel.yaml

--- a/overlays/cluster-critical/signoz/pagerduty-channel.yaml
+++ b/overlays/cluster-critical/signoz/pagerduty-channel.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: pagerduty-channel
+  namespace: signoz
+  labels:
+    signoz.io/channel: "true"
+  annotations:
+    signoz.io/channel-name: "pagerduty-homelab"
+    signoz.io/channel-type: "pagerduty"
+    # Reference the synthetic-tests secret for value substitution
+    # Keys from the secret will replace ${key-name} placeholders in channel.json
+    signoz.io/secret-ref: "synthetic-tests"
+data:
+  channel.json: |
+    {
+      "name": "pagerduty-homelab",
+      "pagerduty_configs": [
+        {
+          "send_resolved": true,
+          "routing_key": "${signoz-pagerduty-integration-key}",
+          "severity": "critical",
+          "description": "{{ .Labels.alertname }}: {{ .Annotations.summary }}",
+          "client": "SigNoz Homelab",
+          "client_url": "https://signoz.jomcgi.dev"
+        }
+      ]
+    }

--- a/overlays/cluster-critical/signoz/synthetic-monitor-secret.yaml
+++ b/overlays/cluster-critical/signoz/synthetic-monitor-secret.yaml
@@ -1,5 +1,5 @@
 # Synthetic Tests Secret
-# Contains credentials for synthetic monitoring (extensible for future use)
+# Contains credentials for synthetic monitoring and alerting
 #
 # Setup:
 # 1. Go to Cloudflare Zero Trust Dashboard > Access > Service Auth
@@ -9,6 +9,7 @@
 #    with fields:
 #    - cloudflare-client-id: <your-client-id>
 #    - cloudflare-client-secret: <your-client-secret>
+#    - signoz-pagerduty-integration-key: <PagerDuty Events API v2 routing key>
 # 5. Add the service token to your Access applications' policies:
 #    - Add a "Service Auth" rule that includes the service token
 #

--- a/overlays/cluster-critical/signoz/values.yaml
+++ b/overlays/cluster-critical/signoz/values.yaml
@@ -65,7 +65,7 @@ k8s-infra:
         # Kubernetes-hosted services (via Cloudflare Tunnel)
         # These require Cloudflare Zero Trust authentication bypass via service token headers
         httpcheck/k8s-services:
-          collection_interval: 60s
+          collection_interval: 120s
           targets:
             # GitOps - ArgoCD
             - endpoint: https://argocd.jomcgi.dev
@@ -131,7 +131,7 @@ k8s-infra:
             # Trip management UI
             - endpoint: https://trips.jomcgi.dev
               method: GET
-          collection_interval: 60s
+          collection_interval: 120s
 
       service:
         pipelines:


### PR DESCRIPTION
## Summary

Extends the signoz-dashboard-sidecar to also sync **alerts** and **notification channels** from ConfigMaps to SigNoz, enabling GitOps-managed alerting.

- Add alert sync via `signoz.io/alert=true` ConfigMaps → `/api/v1/rules`
- Add channel sync via `signoz.io/channel=true` ConfigMaps → `/api/v1/channels`
- Add secret substitution for sensitive values (PagerDuty routing keys)
- Update httpcheck interval: 60s → 120s (5 consecutive failures = 10min outage)
- Include example ArgoCD alert co-located with the service
- Include CRD designs for future operator implementation

## New ConfigMap Labels

| Label | API Endpoint | Purpose |
|-------|--------------|---------|
| `signoz.io/dashboard=true` | `/api/v1/dashboards` | Dashboards (existing) |
| `signoz.io/alert=true` | `/api/v1/rules` | Alert rules (new) |
| `signoz.io/channel=true` | `/api/v1/channels` | Notification channels (new) |

## Secret Substitution

Use `signoz.io/secret-ref: "secret-name"` annotation to substitute `${key}` placeholders:

```yaml
metadata:
  annotations:
    signoz.io/secret-ref: "synthetic-tests"
data:
  channel.json: |
    { "routing_key": "${signoz-pagerduty-integration-key}" }
```

## Test plan

- [ ] Add `signoz-pagerduty-integration-key` to 1Password `synthetic-tests` item
- [ ] Deploy and verify sidecar starts watching alert/channel ConfigMaps
- [ ] Verify PagerDuty channel appears in SigNoz Settings > Alert Channels
- [ ] Verify ArgoCD alert appears in SigNoz Alerts
- [ ] Test alert fires when ArgoCD is unreachable for 10+ minutes

🤖 Generated with [Claude Code](https://claude.ai/code)