### PR TITLE
fix(signoz-sidecar): correct image updater writeBackTarget path

### DIFF
--- a/overlays/cluster-critical/signoz-dashboard-sidecar/imageupdater.yaml
+++ b/overlays/cluster-critical/signoz-dashboard-sidecar/imageupdater.yaml
@@ -22,4 +22,4 @@ spec:
     gitConfig:
       repository: https://github.com/jomcgi/homelab.git
       branch: main
-      writeBackTarget: helmvalues:../../../../overlays/cluster-critical/signoz-dashboard-sidecar/values.yaml
+      writeBackTarget: helmvalues:../../overlays/cluster-critical/signoz-dashboard-sidecar/values.yaml


### PR DESCRIPTION
## Summary

Fixes the ArgoCD Image Updater writeBackTarget path for signoz-dashboard-sidecar.

The path was `../../../../overlays/...` (4 levels up) instead of `../../overlays/...` (2 levels up), causing the image updater to resolve to `/overlays` at the filesystem root instead of within the git repo.

**Error from image updater logs:**
```
level=error msg="Could not update application spec: mkdir /overlays: read-only file system"
```

## Test plan

- [ ] Merge and wait for ImageUpdater to reconcile
- [ ] Verify it commits digest update to values.yaml
- [ ] Verify sidecar pod restarts with new image containing alert/channel support

🤖 Generated with [Claude Code](https://claude.ai/code)