### PR TITLE
fix(alerts): change longhorn alert namespace to signoz

### DIFF
--- a/overlays/cluster-critical/longhorn/longhorn-httpcheck-alert.yaml
+++ b/overlays/cluster-critical/longhorn/longhorn-httpcheck-alert.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: longhorn-httpcheck-alert
-  namespace: longhorn-system
+  namespace: signoz
   labels:
     signoz.io/alert: "true"
   annotations:


### PR DESCRIPTION
## Summary

Fix ArgoCD sync failure caused by longhorn-httpcheck-alert trying to create ConfigMap in non-existent `longhorn-system` namespace.

## Changes

- Change `namespace: longhorn-system` → `namespace: signoz`

The signoz-dashboard-sidecar watches all namespaces for ConfigMaps with `signoz.io/alert` label, so moving to `signoz` namespace works correctly.

## Test plan

- [ ] Verify ArgoCD sync succeeds
- [ ] Confirm alert appears in SigNoz

🤖 Generated with [Claude Code](https://claude.com/claude-code)