### PR TITLE
feat(observability): add Prometheus pod annotations for SigNoz autodiscovery

### DIFF
--- a/charts/kyverno/values.yaml
+++ b/charts/kyverno/values.yaml
@@ -39,6 +39,10 @@ kyverno:
   # Admission controller configuration
   admissionController:
     replicas: 1
+    # Prometheus annotations enable SigNoz autodiscovery
+    podAnnotations:
+      prometheus.io/scrape: "true"
+      prometheus.io/port: "8000"
     resources:
       limits:
         cpu: 500m
@@ -60,6 +64,10 @@ kyverno:
   backgroundController:
     enabled: true
     replicas: 1
+    # Prometheus annotations enable SigNoz autodiscovery
+    podAnnotations:
+      prometheus.io/scrape: "true"
+      prometheus.io/port: "8000"
     resources:
       limits:
         cpu: 200m
@@ -72,6 +80,10 @@ kyverno:
   cleanupController:
     enabled: true
     replicas: 1
+    # Prometheus annotations enable SigNoz autodiscovery
+    podAnnotations:
+      prometheus.io/scrape: "true"
+      prometheus.io/port: "8000"
     resources:
       limits:
         cpu: 100m
@@ -84,6 +96,10 @@ kyverno:
   reportsController:
     enabled: true
     replicas: 1
+    # Prometheus annotations enable SigNoz autodiscovery
+    podAnnotations:
+      prometheus.io/scrape: "true"
+      prometheus.io/port: "8000"
     resources:
       limits:
         cpu: 200m

--- a/charts/seaweedfs/values.yaml
+++ b/charts/seaweedfs/values.yaml
@@ -13,8 +13,11 @@ seaweedfs:
     # Disable anti-affinity for single-node homelab
     affinity: ""
     # Pre-populate OTEL annotation to match Kyverno injection (prevents ArgoCD drift)
+    # Prometheus annotations enable SigNoz autodiscovery
     podAnnotations:
       otel.injected-by: kyverno/inject-otel-env-vars
+      prometheus.io/scrape: "true"
+      prometheus.io/port: "9327"
     data:
       type: "persistentVolumeClaim"
       size: "1Gi"
@@ -35,8 +38,11 @@ seaweedfs:
     # Disable anti-affinity for single-node homelab
     affinity: ""
     # Pre-populate OTEL annotation to match Kyverno injection (prevents ArgoCD drift)
+    # Prometheus annotations enable SigNoz autodiscovery
     podAnnotations:
       otel.injected-by: kyverno/inject-otel-env-vars
+      prometheus.io/scrape: "true"
+      prometheus.io/port: "9327"
     dataDirs:
       - name: data
         type: "persistentVolumeClaim"
@@ -61,8 +67,11 @@ seaweedfs:
     # Disable anti-affinity for single-node homelab
     affinity: ""
     # Pre-populate OTEL annotation to match Kyverno injection (prevents ArgoCD drift)
+    # Prometheus annotations enable SigNoz autodiscovery
     podAnnotations:
       otel.injected-by: kyverno/inject-otel-env-vars
+      prometheus.io/scrape: "true"
+      prometheus.io/port: "9327"
     data:
       type: "persistentVolumeClaim"
       size: "5Gi"
@@ -83,8 +92,11 @@ seaweedfs:
     port: 8333
     enableAuth: false
     # Pre-populate OTEL annotation to match Kyverno injection (prevents ArgoCD drift)
+    # Prometheus annotations enable SigNoz autodiscovery
     podAnnotations:
       otel.injected-by: kyverno/inject-otel-env-vars
+      prometheus.io/scrape: "true"
+      prometheus.io/port: "9327"
     resources:
       requests:
         cpu: 50m

--- a/clusters/homelab/argocd/values.yaml
+++ b/clusters/homelab/argocd/values.yaml
@@ -10,18 +10,34 @@ argo-cd:
       otlp.address: "signoz-otel-collector.signoz.svc.cluster.local:4317"
   # Enable metrics endpoints for all ArgoCD components
   # These expose Prometheus metrics including argocd_app_info for health/sync status
+  # Pod annotations enable SigNoz autodiscovery (scraper uses role: pod)
   controller:
     metrics:
       enabled: true
+    podAnnotations:
+      prometheus.io/scrape: "true"
+      prometheus.io/port: "8082"
   server:
     metrics:
       enabled: true
+    podAnnotations:
+      prometheus.io/scrape: "true"
+      prometheus.io/port: "8083"
   repoServer:
     metrics:
       enabled: true
+    podAnnotations:
+      prometheus.io/scrape: "true"
+      prometheus.io/port: "8084"
   applicationSet:
     metrics:
       enabled: true
+    podAnnotations:
+      prometheus.io/scrape: "true"
+      prometheus.io/port: "8080"
   notifications:
     metrics:
       enabled: true
+    podAnnotations:
+      prometheus.io/scrape: "true"
+      prometheus.io/port: "9001"


### PR DESCRIPTION
## Summary

- Add `prometheus.io/scrape` and `prometheus.io/port` pod annotations to enable SigNoz metrics autodiscovery
- Fixes broken ArgoCD alerts that reference `argocd_app_info` metrics with `health_status` label

## Services Updated

| Service | Components | Port |
|---------|-----------|------|
| ArgoCD | controller, server, repo-server, applicationset, notifications | 8082, 8083, 8084, 8080, 9001 |
| Kyverno | admission, background, cleanup, reports | 8000 |
| SeaweedFS | master, volume, filer, s3 | 9327 |

## Root Cause

The SigNoz OTEL collector uses `kubernetes_sd_configs` with `role: pod`, which looks for annotations on **pods**. ArgoCD's `addPrometheusAnnotations: true` only adds annotations to **services**, causing a mismatch.

## Test plan

- [ ] After ArgoCD sync, verify pods have prometheus annotations: `kubectl get pod -n argocd argocd-application-controller-0 -o jsonpath='{.metadata.annotations}'`
- [ ] Check SigNoz metrics explorer for `argocd_app_info` metric with `health_status` label
- [ ] Verify ArgoCD App Degraded alert no longer shows "key health_status not found" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)