### PR TITLE
feat(ci): add cacheable Helm template tests for all overlays

### DIFF
--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -1,10 +1,10 @@
 actions:
-  # Gazelle check - lightweight, no pip dependencies needed
+  # Format check - runs formatters and gazelle, verifies no changes needed
   # Runs in parallel with Test action
-  - name: "Gazelle lint"
+  - name: "Format check"
     container_image: "ubuntu-24.04"
     resource_requests:
-      disk: "20GB"  # Smaller disk, gazelle doesn't need much
+      disk: "30GB"  # Slightly larger for format tools
     triggers:
       push:
         branches:
@@ -19,11 +19,12 @@ actions:
             echo "Skipping argocd-image-updater commit"
             exit 0
           fi
-          # Verify BUILD files are up-to-date (catches missing test targets)
-          # Run without --config=ci to avoid triggering RBE analysis and pip fetches
-          bazel run //:gazelle
+          # Run full format (includes formatters + gazelle)
+          bazel run //tools/format:fast_format
           if ! git diff --exit-code; then
-            echo "ERROR: BUILD files out of sync. Run 'bazelisk run //:gazelle' locally."
+            echo "ERROR: Code not formatted or BUILD files out of sync."
+            echo "Run 'format' locally to fix."
+            echo ""
             echo "Changes detected:"
             git diff
             exit 1

--- a/charts/signoz-dashboard-sidecar/cmd/main.go
+++ b/charts/signoz-dashboard-sidecar/cmd/main.go
@@ -51,11 +51,11 @@ const (
 	alertPath        = "api/v1/rules"
 
 	// Notification channel constants
-	channelLabel    = "signoz.io/channel"
-	channelNameKey  = "signoz.io/channel-name"
-	channelTypeKey  = "signoz.io/channel-type"
-	channelPath     = "api/v1/channels"
-	secretRefKey    = "signoz.io/secret-ref" // Format: "namespace/secretName" or just "secretName" (same namespace)
+	channelLabel   = "signoz.io/channel"
+	channelNameKey = "signoz.io/channel-name"
+	channelTypeKey = "signoz.io/channel-type"
+	channelPath    = "api/v1/channels"
+	secretRefKey   = "signoz.io/secret-ref" // Format: "namespace/secretName" or just "secretName" (same namespace)
 
 	// Default tag applied to all sidecar-managed dashboards
 	defaultManagedTag = "iac-managed"

--- a/overlays/cluster-critical/argocd-image-updater/BUILD
+++ b/overlays/cluster-critical/argocd-image-updater/BUILD
@@ -1,3 +1,5 @@
+load("//tools/argocd:defs.bzl", "helm_template_test")
+
 genrule(
     name = "render_manifests",
     srcs = [
@@ -17,4 +19,20 @@ genrule(
         "@multitool//tools/helm",
     ],
     visibility = ["//visibility:public"],
+)
+
+helm_template_test(
+    name = "template_test",
+    chart = "charts/argocd-image-updater",
+    chart_files = "//charts/argocd-image-updater:all_files",
+    namespace = "argocd",
+    release_name = "argocd-image-updater",
+    tags = [
+        "helm",
+        "template",
+    ],
+    values_files = [
+        "//charts/argocd-image-updater:values.yaml",
+        "values.yaml",
+    ],
 )

--- a/overlays/cluster-critical/argocd/BUILD
+++ b/overlays/cluster-critical/argocd/BUILD
@@ -1,3 +1,5 @@
+load("//tools/argocd:defs.bzl", "helm_template_test")
+
 genrule(
     name = "render_manifests",
     srcs = [
@@ -17,4 +19,20 @@ genrule(
         "@multitool//tools/helm",
     ],
     visibility = ["//visibility:public"],
+)
+
+helm_template_test(
+    name = "template_test",
+    chart = "charts/argocd",
+    chart_files = "//charts/argocd:all_files",
+    namespace = "argocd",
+    release_name = "argocd",
+    tags = [
+        "helm",
+        "template",
+    ],
+    values_files = [
+        "//charts/argocd:values.yaml",
+        "//clusters/homelab/argocd:values.yaml",
+    ],
 )

--- a/overlays/cluster-critical/cert-manager/BUILD
+++ b/overlays/cluster-critical/cert-manager/BUILD
@@ -1,3 +1,5 @@
+load("//tools/argocd:defs.bzl", "helm_template_test")
+
 genrule(
     name = "render_manifests",
     srcs = [
@@ -17,4 +19,20 @@ genrule(
         "@multitool//tools/helm",
     ],
     visibility = ["//visibility:public"],
+)
+
+helm_template_test(
+    name = "template_test",
+    chart = "charts/cert-manager",
+    chart_files = "//charts/cert-manager:all_files",
+    namespace = "cert-manager",
+    release_name = "cert-manager",
+    tags = [
+        "helm",
+        "template",
+    ],
+    values_files = [
+        "//charts/cert-manager:values.yaml",
+        "values.yaml",
+    ],
 )

--- a/overlays/cluster-critical/coredns/BUILD
+++ b/overlays/cluster-critical/coredns/BUILD
@@ -1,3 +1,5 @@
+load("//tools/argocd:defs.bzl", "helm_template_test")
+
 genrule(
     name = "render_manifests",
     srcs = [
@@ -17,4 +19,20 @@ genrule(
         "@multitool//tools/helm",
     ],
     visibility = ["//visibility:public"],
+)
+
+helm_template_test(
+    name = "template_test",
+    chart = "charts/coredns",
+    chart_files = "//charts/coredns:all_files",
+    namespace = "kube-system",
+    release_name = "coredns",
+    tags = [
+        "helm",
+        "template",
+    ],
+    values_files = [
+        "//charts/coredns:values.yaml",
+        "values.yaml",
+    ],
 )

--- a/overlays/cluster-critical/kyverno/BUILD
+++ b/overlays/cluster-critical/kyverno/BUILD
@@ -1,3 +1,5 @@
+load("//tools/argocd:defs.bzl", "helm_template_test")
+
 genrule(
     name = "render_manifests",
     srcs = [
@@ -17,4 +19,20 @@ genrule(
         "@multitool//tools/helm",
     ],
     visibility = ["//visibility:public"],
+)
+
+helm_template_test(
+    name = "template_test",
+    chart = "charts/kyverno",
+    chart_files = "//charts/kyverno:all_files",
+    namespace = "kyverno",
+    release_name = "kyverno",
+    tags = [
+        "helm",
+        "template",
+    ],
+    values_files = [
+        "//charts/kyverno:values.yaml",
+        "values.yaml",
+    ],
 )

--- a/overlays/cluster-critical/linkerd/BUILD
+++ b/overlays/cluster-critical/linkerd/BUILD
@@ -1,3 +1,5 @@
+load("//tools/argocd:defs.bzl", "helm_template_test")
+
 genrule(
     name = "render_manifests",
     srcs = [
@@ -17,4 +19,20 @@ genrule(
         "@multitool//tools/helm",
     ],
     visibility = ["//visibility:public"],
+)
+
+helm_template_test(
+    name = "template_test",
+    chart = "charts/linkerd",
+    chart_files = "//charts/linkerd:all_files",
+    namespace = "linkerd",
+    release_name = "linkerd",
+    tags = [
+        "helm",
+        "template",
+    ],
+    values_files = [
+        "//charts/linkerd:values.yaml",
+        "values.yaml",
+    ],
 )

--- a/overlays/cluster-critical/longhorn/BUILD
+++ b/overlays/cluster-critical/longhorn/BUILD
@@ -1,3 +1,5 @@
+load("//tools/argocd:defs.bzl", "helm_template_test")
+
 genrule(
     name = "render_manifests",
     srcs = [
@@ -17,4 +19,20 @@ genrule(
         "@multitool//tools/helm",
     ],
     visibility = ["//visibility:public"],
+)
+
+helm_template_test(
+    name = "template_test",
+    chart = "charts/longhorn",
+    chart_files = "//charts/longhorn:all_files",
+    namespace = "longhorn",
+    release_name = "longhorn",
+    tags = [
+        "helm",
+        "template",
+    ],
+    values_files = [
+        "//charts/longhorn:values.yaml",
+        "values.yaml",
+    ],
 )

--- a/overlays/cluster-critical/nvidia-gpu-operator/BUILD
+++ b/overlays/cluster-critical/nvidia-gpu-operator/BUILD
@@ -1,3 +1,5 @@
+load("//tools/argocd:defs.bzl", "helm_template_test")
+
 genrule(
     name = "render_manifests",
     srcs = [
@@ -16,4 +18,17 @@ genrule(
         "@multitool//tools/helm",
     ],
     visibility = ["//visibility:public"],
+)
+
+helm_template_test(
+    name = "template_test",
+    chart = "charts/nvidia-gpu-operator",
+    chart_files = "//charts/nvidia-gpu-operator:all_files",
+    namespace = "gpu-operator",
+    release_name = "nvidia-gpu-operator",
+    tags = [
+        "helm",
+        "template",
+    ],
+    values_files = ["//charts/nvidia-gpu-operator:values.yaml"],
 )

--- a/overlays/cluster-critical/signoz-dashboard-sidecar/BUILD
+++ b/overlays/cluster-critical/signoz-dashboard-sidecar/BUILD
@@ -1,3 +1,5 @@
+load("//tools/argocd:defs.bzl", "helm_template_test")
+
 genrule(
     name = "render_manifests",
     srcs = [
@@ -17,4 +19,20 @@ genrule(
         "@multitool//tools/helm",
     ],
     visibility = ["//visibility:public"],
+)
+
+helm_template_test(
+    name = "template_test",
+    chart = "charts/signoz-dashboard-sidecar",
+    chart_files = "//charts/signoz-dashboard-sidecar:all_files",
+    namespace = "signoz",
+    release_name = "signoz-dashboard-sidecar",
+    tags = [
+        "helm",
+        "template",
+    ],
+    values_files = [
+        "//charts/signoz-dashboard-sidecar:values.yaml",
+        "values.yaml",
+    ],
 )

--- a/overlays/cluster-critical/signoz/BUILD
+++ b/overlays/cluster-critical/signoz/BUILD
@@ -1,3 +1,5 @@
+load("//tools/argocd:defs.bzl", "helm_template_test")
+
 genrule(
     name = "render_manifests",
     srcs = [
@@ -17,4 +19,20 @@ genrule(
         "@multitool//tools/helm",
     ],
     visibility = ["//visibility:public"],
+)
+
+helm_template_test(
+    name = "template_test",
+    chart = "charts/signoz",
+    chart_files = "//charts/signoz:all_files",
+    namespace = "signoz",
+    release_name = "signoz",
+    tags = [
+        "helm",
+        "template",
+    ],
+    values_files = [
+        "//charts/signoz:values.yaml",
+        "values.yaml",
+    ],
 )

--- a/overlays/dev/claude/BUILD
+++ b/overlays/dev/claude/BUILD
@@ -1,3 +1,5 @@
+load("//tools/argocd:defs.bzl", "helm_template_test")
+
 genrule(
     name = "render_manifests",
     srcs = [
@@ -17,4 +19,20 @@ genrule(
         "@multitool//tools/helm",
     ],
     visibility = ["//visibility:public"],
+)
+
+helm_template_test(
+    name = "template_test",
+    chart = "charts/claude",
+    chart_files = "//charts/claude:all_files",
+    namespace = "claude",
+    release_name = "claude",
+    tags = [
+        "helm",
+        "template",
+    ],
+    values_files = [
+        "//charts/claude:values.yaml",
+        "values.yaml",
+    ],
 )

--- a/overlays/dev/cloudflare-operator-test/BUILD
+++ b/overlays/dev/cloudflare-operator-test/BUILD
@@ -1,3 +1,5 @@
+load("//tools/argocd:defs.bzl", "helm_template_test")
+
 genrule(
     name = "render_manifests",
     srcs = [
@@ -17,4 +19,20 @@ genrule(
         "@multitool//tools/helm",
     ],
     visibility = ["//visibility:public"],
+)
+
+helm_template_test(
+    name = "template_test",
+    chart = "charts/cloudflare-operator-test",
+    chart_files = "//charts/cloudflare-operator-test:all_files",
+    namespace = "cloudflare-operator-test",
+    release_name = "cloudflare-operator-test",
+    tags = [
+        "helm",
+        "template",
+    ],
+    values_files = [
+        "//charts/cloudflare-operator-test:values.yaml",
+        "values.yaml",
+    ],
 )

--- a/overlays/dev/cloudflare-operator/BUILD
+++ b/overlays/dev/cloudflare-operator/BUILD
@@ -1,3 +1,5 @@
+load("//tools/argocd:defs.bzl", "helm_template_test")
+
 genrule(
     name = "render_manifests",
     srcs = [
@@ -17,4 +19,20 @@ genrule(
         "@multitool//tools/helm",
     ],
     visibility = ["//visibility:public"],
+)
+
+helm_template_test(
+    name = "template_test",
+    chart = "operators/cloudflare/helm/cloudflare-operator",
+    chart_files = "//operators/cloudflare/helm/cloudflare-operator:all_files",
+    namespace = "cloudflare",
+    release_name = "cloudflare-operator",
+    tags = [
+        "helm",
+        "template",
+    ],
+    values_files = [
+        "//operators/cloudflare/helm/cloudflare-operator:values.yaml",
+        "values.yaml",
+    ],
 )

--- a/overlays/dev/marine/BUILD
+++ b/overlays/dev/marine/BUILD
@@ -1,3 +1,5 @@
+load("//tools/argocd:defs.bzl", "helm_template_test")
+
 genrule(
     name = "render_manifests",
     srcs = [
@@ -17,4 +19,20 @@ genrule(
         "@multitool//tools/helm",
     ],
     visibility = ["//visibility:public"],
+)
+
+helm_template_test(
+    name = "template_test",
+    chart = "charts/marine",
+    chart_files = "//charts/marine:all_files",
+    namespace = "marine",
+    release_name = "marine",
+    tags = [
+        "helm",
+        "template",
+    ],
+    values_files = [
+        "//charts/marine:values.yaml",
+        "values.yaml",
+    ],
 )

--- a/overlays/dev/stargazer/BUILD
+++ b/overlays/dev/stargazer/BUILD
@@ -1,3 +1,5 @@
+load("//tools/argocd:defs.bzl", "helm_template_test")
+
 genrule(
     name = "render_manifests",
     srcs = [
@@ -17,4 +19,20 @@ genrule(
         "@multitool//tools/helm",
     ],
     visibility = ["//visibility:public"],
+)
+
+helm_template_test(
+    name = "template_test",
+    chart = "charts/stargazer",
+    chart_files = "//charts/stargazer:all_files",
+    namespace = "stargazer",
+    release_name = "stargazer",
+    tags = [
+        "helm",
+        "template",
+    ],
+    values_files = [
+        "//charts/stargazer:values.yaml",
+        "values.yaml",
+    ],
 )

--- a/overlays/prod/api-gateway/BUILD
+++ b/overlays/prod/api-gateway/BUILD
@@ -1,3 +1,5 @@
+load("//tools/argocd:defs.bzl", "helm_template_test")
+
 genrule(
     name = "render_manifests",
     srcs = [
@@ -17,4 +19,20 @@ genrule(
         "@multitool//tools/helm",
     ],
     visibility = ["//visibility:public"],
+)
+
+helm_template_test(
+    name = "template_test",
+    chart = "charts/api-gateway",
+    chart_files = "//charts/api-gateway:all_files",
+    namespace = "api-gateway",
+    release_name = "api-gateway",
+    tags = [
+        "helm",
+        "template",
+    ],
+    values_files = [
+        "//charts/api-gateway:values.yaml",
+        "values.yaml",
+    ],
 )

--- a/overlays/prod/cloudflare-tunnel/BUILD
+++ b/overlays/prod/cloudflare-tunnel/BUILD
@@ -1,3 +1,5 @@
+load("//tools/argocd:defs.bzl", "helm_template_test")
+
 genrule(
     name = "render_manifests",
     srcs = [
@@ -17,4 +19,20 @@ genrule(
         "@multitool//tools/helm",
     ],
     visibility = ["//visibility:public"],
+)
+
+helm_template_test(
+    name = "template_test",
+    chart = "charts/cloudflare-tunnel",
+    chart_files = "//charts/cloudflare-tunnel:all_files",
+    namespace = "ingress",
+    release_name = "cluster-ingress",
+    tags = [
+        "helm",
+        "template",
+    ],
+    values_files = [
+        "//charts/cloudflare-tunnel:values.yaml",
+        "values.yaml",
+    ],
 )

--- a/overlays/prod/gh-arc-controller/BUILD
+++ b/overlays/prod/gh-arc-controller/BUILD
@@ -1,3 +1,5 @@
+load("//tools/argocd:defs.bzl", "helm_template_test")
+
 genrule(
     name = "render_manifests",
     srcs = [
@@ -17,4 +19,20 @@ genrule(
         "@multitool//tools/helm",
     ],
     visibility = ["//visibility:public"],
+)
+
+helm_template_test(
+    name = "template_test",
+    chart = "charts/gh-arc-controller",
+    chart_files = "//charts/gh-arc-controller:all_files",
+    namespace = "gh-arc-controller",
+    release_name = "gh-arc-controller",
+    tags = [
+        "helm",
+        "template",
+    ],
+    values_files = [
+        "//charts/gh-arc-controller:values.yaml",
+        "values.yaml",
+    ],
 )

--- a/overlays/prod/gh-arc-runners/BUILD
+++ b/overlays/prod/gh-arc-runners/BUILD
@@ -1,3 +1,5 @@
+load("//tools/argocd:defs.bzl", "helm_template_test")
+
 genrule(
     name = "render_manifests",
     srcs = [
@@ -17,4 +19,20 @@ genrule(
         "@multitool//tools/helm",
     ],
     visibility = ["//visibility:public"],
+)
+
+helm_template_test(
+    name = "template_test",
+    chart = "charts/gh-arc-runners",
+    chart_files = "//charts/gh-arc-runners:all_files",
+    namespace = "gh-arc-runners",
+    release_name = "gh-arc-runners",
+    tags = [
+        "helm",
+        "template",
+    ],
+    values_files = [
+        "//charts/gh-arc-runners:values.yaml",
+        "values.yaml",
+    ],
 )

--- a/overlays/prod/nats/BUILD
+++ b/overlays/prod/nats/BUILD
@@ -1,3 +1,5 @@
+load("//tools/argocd:defs.bzl", "helm_template_test")
+
 genrule(
     name = "render_manifests",
     srcs = [
@@ -17,4 +19,20 @@ genrule(
         "@multitool//tools/helm",
     ],
     visibility = ["//visibility:public"],
+)
+
+helm_template_test(
+    name = "template_test",
+    chart = "charts/nats",
+    chart_files = "//charts/nats:all_files",
+    namespace = "nats",
+    release_name = "nats",
+    tags = [
+        "helm",
+        "template",
+    ],
+    values_files = [
+        "//charts/nats:values.yaml",
+        "values.yaml",
+    ],
 )

--- a/overlays/prod/seaweedfs/BUILD
+++ b/overlays/prod/seaweedfs/BUILD
@@ -1,3 +1,5 @@
+load("//tools/argocd:defs.bzl", "helm_template_test")
+
 genrule(
     name = "render_manifests",
     srcs = [
@@ -17,4 +19,20 @@ genrule(
         "@multitool//tools/helm",
     ],
     visibility = ["//visibility:public"],
+)
+
+helm_template_test(
+    name = "template_test",
+    chart = "charts/seaweedfs",
+    chart_files = "//charts/seaweedfs:all_files",
+    namespace = "seaweedfs",
+    release_name = "seaweedfs",
+    tags = [
+        "helm",
+        "template",
+    ],
+    values_files = [
+        "//charts/seaweedfs:values.yaml",
+        "values.yaml",
+    ],
 )

--- a/overlays/prod/todo/BUILD
+++ b/overlays/prod/todo/BUILD
@@ -1,3 +1,5 @@
+load("//tools/argocd:defs.bzl", "helm_template_test")
+
 genrule(
     name = "render_manifests",
     srcs = [
@@ -17,4 +19,20 @@ genrule(
         "@multitool//tools/helm",
     ],
     visibility = ["//visibility:public"],
+)
+
+helm_template_test(
+    name = "template_test",
+    chart = "charts/todo",
+    chart_files = "//charts/todo:all_files",
+    namespace = "todo",
+    release_name = "todo",
+    tags = [
+        "helm",
+        "template",
+    ],
+    values_files = [
+        "//charts/todo:values.yaml",
+        "values.yaml",
+    ],
 )

--- a/overlays/prod/trips/BUILD
+++ b/overlays/prod/trips/BUILD
@@ -1,3 +1,5 @@
+load("//tools/argocd:defs.bzl", "helm_template_test")
+
 genrule(
     name = "render_manifests",
     srcs = [
@@ -17,4 +19,20 @@ genrule(
         "@multitool//tools/helm",
     ],
     visibility = ["//visibility:public"],
+)
+
+helm_template_test(
+    name = "template_test",
+    chart = "charts/trips",
+    chart_files = "//charts/trips:all_files",
+    namespace = "trips",
+    release_name = "trips",
+    tags = [
+        "helm",
+        "template",
+    ],
+    values_files = [
+        "//charts/trips:values.yaml",
+        "values.yaml",
+    ],
 )

--- a/overlays/prod/vllm/BUILD
+++ b/overlays/prod/vllm/BUILD
@@ -1,3 +1,5 @@
+load("//tools/argocd:defs.bzl", "helm_template_test")
+
 genrule(
     name = "render_manifests",
     srcs = [
@@ -17,4 +19,20 @@ genrule(
         "@multitool//tools/helm",
     ],
     visibility = ["//visibility:public"],
+)
+
+helm_template_test(
+    name = "template_test",
+    chart = "charts/vllm",
+    chart_files = "//charts/vllm:all_files",
+    namespace = "vllm",
+    release_name = "vllm",
+    tags = [
+        "helm",
+        "template",
+    ],
+    values_files = [
+        "//charts/vllm:values.yaml",
+        "values.yaml",
+    ],
 )

--- a/scripts/test-charts.sh
+++ b/scripts/test-charts.sh
@@ -11,29 +11,29 @@ set -euo pipefail
 
 # Support both direct invocation and Bazel execution
 if [[ -n "${BUILD_WORKSPACE_DIRECTORY:-}" ]]; then
-    # Running via Bazel
-    REPO_ROOT="$BUILD_WORKSPACE_DIRECTORY"
-    CHARTS_DIR="$REPO_ROOT/charts"
-    # Use helm from multitool if HELM is set
-    if [[ -n "${HELM:-}" ]]; then
-        # Export function so it's available in subshells
-        HELM_BIN="$HELM"
-        export HELM_BIN
-    fi
+	# Running via Bazel
+	REPO_ROOT="$BUILD_WORKSPACE_DIRECTORY"
+	CHARTS_DIR="$REPO_ROOT/charts"
+	# Use helm from multitool if HELM is set
+	if [[ -n "${HELM:-}" ]]; then
+		# Export function so it's available in subshells
+		HELM_BIN="$HELM"
+		export HELM_BIN
+	fi
 else
-    # Direct invocation
-    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-    REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-    CHARTS_DIR="$REPO_ROOT/charts"
+	# Direct invocation
+	SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+	REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+	CHARTS_DIR="$REPO_ROOT/charts"
 fi
 
 # Wrapper for helm command - uses HELM_BIN if set
 run_helm() {
-    if [[ -n "${HELM_BIN:-}" ]]; then
-        "$HELM_BIN" "$@"
-    else
-        helm "$@"
-    fi
+	if [[ -n "${HELM_BIN:-}" ]]; then
+		"$HELM_BIN" "$@"
+	else
+		helm "$@"
+	fi
 }
 
 # Colors for output
@@ -48,155 +48,155 @@ FAILED=0
 SKIPPED=0
 
 log_info() {
-    echo -e "${GREEN}[INFO]${NC} $1"
+	echo -e "${GREEN}[INFO]${NC} $1"
 }
 
 log_warn() {
-    echo -e "${YELLOW}[WARN]${NC} $1"
+	echo -e "${YELLOW}[WARN]${NC} $1"
 }
 
 log_error() {
-    echo -e "${RED}[ERROR]${NC} $1"
+	echo -e "${RED}[ERROR]${NC} $1"
 }
 
 lint_chart() {
-    local chart_path="$1"
-    local chart_name
-    chart_name=$(basename "$chart_path")
+	local chart_path="$1"
+	local chart_name
+	chart_name=$(basename "$chart_path")
 
-    # Check if Chart.yaml exists
-    if [[ ! -f "$chart_path/Chart.yaml" ]]; then
-        log_warn "Skipping $chart_name: no Chart.yaml found"
-        ((SKIPPED++))
-        return 0
-    fi
+	# Check if Chart.yaml exists
+	if [[ ! -f "$chart_path/Chart.yaml" ]]; then
+		log_warn "Skipping $chart_name: no Chart.yaml found"
+		((SKIPPED++))
+		return 0
+	fi
 
-    echo -n "Linting $chart_name... "
+	echo -n "Linting $chart_name... "
 
-    # Run helm lint with strict mode
-    local output
-    if output=$(run_helm lint "$chart_path" --strict 2>&1); then
-        echo -e "${GREEN}PASSED${NC}"
-        ((PASSED++))
-        return 0
-    else
-        echo -e "${RED}FAILED${NC}"
-        echo "$output" | sed 's/^/  /'
-        ((FAILED++))
-        return 1
-    fi
+	# Run helm lint with strict mode
+	local output
+	if output=$(run_helm lint "$chart_path" --strict 2>&1); then
+		echo -e "${GREEN}PASSED${NC}"
+		((PASSED++))
+		return 0
+	else
+		echo -e "${RED}FAILED${NC}"
+		echo "$output" | sed 's/^/  /'
+		((FAILED++))
+		return 1
+	fi
 }
 
 run_unittest() {
-    local chart_path="$1"
-    local chart_name
-    chart_name=$(basename "$chart_path")
-    local tests_dir="$chart_path/tests"
+	local chart_path="$1"
+	local chart_name
+	chart_name=$(basename "$chart_path")
+	local tests_dir="$chart_path/tests"
 
-    # Check if tests directory exists
-    if [[ ! -d "$tests_dir" ]]; then
-        return 0
-    fi
+	# Check if tests directory exists
+	if [[ ! -d "$tests_dir" ]]; then
+		return 0
+	fi
 
-    # Check if helm-unittest plugin is installed
-    if ! run_helm plugin list 2>/dev/null | grep -q unittest; then
-        log_warn "helm-unittest plugin not installed, skipping unit tests for $chart_name"
-        log_warn "Install with: helm plugin install https://github.com/helm-unittest/helm-unittest"
-        return 0
-    fi
+	# Check if helm-unittest plugin is installed
+	if ! run_helm plugin list 2>/dev/null | grep -q unittest; then
+		log_warn "helm-unittest plugin not installed, skipping unit tests for $chart_name"
+		log_warn "Install with: helm plugin install https://github.com/helm-unittest/helm-unittest"
+		return 0
+	fi
 
-    echo -n "Running unit tests for $chart_name... "
+	echo -n "Running unit tests for $chart_name... "
 
-    local output
-    if output=$(run_helm unittest "$chart_path" 2>&1); then
-        echo -e "${GREEN}PASSED${NC}"
-        return 0
-    else
-        echo -e "${RED}FAILED${NC}"
-        echo "$output" | sed 's/^/  /'
-        return 1
-    fi
+	local output
+	if output=$(run_helm unittest "$chart_path" 2>&1); then
+		echo -e "${GREEN}PASSED${NC}"
+		return 0
+	else
+		echo -e "${RED}FAILED${NC}"
+		echo "$output" | sed 's/^/  /'
+		return 1
+	fi
 }
 
 main() {
-    log_info "Helm Chart Validation"
-    echo ""
+	log_info "Helm Chart Validation"
+	echo ""
 
-    # Check if helm is available
-    if ! command -v run_helm &>/dev/null && [[ -z "${HELM_BIN:-}" ]] && ! command -v helm &>/dev/null; then
-        log_error "helm is not installed or not in PATH"
-        exit 1
-    fi
+	# Check if helm is available
+	if ! command -v run_helm &>/dev/null && [[ -z "${HELM_BIN:-}" ]] && ! command -v helm &>/dev/null; then
+		log_error "helm is not installed or not in PATH"
+		exit 1
+	fi
 
-    log_info "Using helm version: $(run_helm version --short)"
-    echo ""
+	log_info "Using helm version: $(run_helm version --short)"
+	echo ""
 
-    # Determine which charts to test
-    local charts_to_test=()
+	# Determine which charts to test
+	local charts_to_test=()
 
-    if [[ $# -gt 0 ]]; then
-        # Test specific chart
-        local chart_path="$CHARTS_DIR/$1"
-        if [[ -d "$chart_path" ]]; then
-            charts_to_test+=("$chart_path")
-        else
-            log_error "Chart not found: $1"
-            exit 1
-        fi
-    else
-        # Test all charts
-        for chart_path in "$CHARTS_DIR"/*/; do
-            if [[ -d "$chart_path" ]]; then
-                charts_to_test+=("$chart_path")
-            fi
-        done
-    fi
+	if [[ $# -gt 0 ]]; then
+		# Test specific chart
+		local chart_path="$CHARTS_DIR/$1"
+		if [[ -d "$chart_path" ]]; then
+			charts_to_test+=("$chart_path")
+		else
+			log_error "Chart not found: $1"
+			exit 1
+		fi
+	else
+		# Test all charts
+		for chart_path in "$CHARTS_DIR"/*/; do
+			if [[ -d "$chart_path" ]]; then
+				charts_to_test+=("$chart_path")
+			fi
+		done
+	fi
 
-    if [[ ${#charts_to_test[@]} -eq 0 ]]; then
-        log_warn "No charts found in $CHARTS_DIR"
-        exit 0
-    fi
+	if [[ ${#charts_to_test[@]} -eq 0 ]]; then
+		log_warn "No charts found in $CHARTS_DIR"
+		exit 0
+	fi
 
-    log_info "Found ${#charts_to_test[@]} chart(s) to validate"
-    echo ""
+	log_info "Found ${#charts_to_test[@]} chart(s) to validate"
+	echo ""
 
-    # Phase 1: Lint all charts
-    echo "=== Phase 1: Helm Lint ==="
-    echo ""
+	# Phase 1: Lint all charts
+	echo "=== Phase 1: Helm Lint ==="
+	echo ""
 
-    local lint_failed=0
-    for chart_path in "${charts_to_test[@]}"; do
-        if ! lint_chart "$chart_path"; then
-            lint_failed=1
-        fi
-    done
-    echo ""
+	local lint_failed=0
+	for chart_path in "${charts_to_test[@]}"; do
+		if ! lint_chart "$chart_path"; then
+			lint_failed=1
+		fi
+	done
+	echo ""
 
-    # Phase 2: Run unit tests (if available)
-    echo "=== Phase 2: Unit Tests ==="
-    echo ""
+	# Phase 2: Run unit tests (if available)
+	echo "=== Phase 2: Unit Tests ==="
+	echo ""
 
-    local unittest_failed=0
-    for chart_path in "${charts_to_test[@]}"; do
-        if ! run_unittest "$chart_path"; then
-            unittest_failed=1
-        fi
-    done
-    echo ""
+	local unittest_failed=0
+	for chart_path in "${charts_to_test[@]}"; do
+		if ! run_unittest "$chart_path"; then
+			unittest_failed=1
+		fi
+	done
+	echo ""
 
-    # Summary
-    echo "=== Summary ==="
-    echo "  Passed:  $PASSED"
-    echo "  Failed:  $FAILED"
-    echo "  Skipped: $SKIPPED"
-    echo ""
+	# Summary
+	echo "=== Summary ==="
+	echo "  Passed:  $PASSED"
+	echo "  Failed:  $FAILED"
+	echo "  Skipped: $SKIPPED"
+	echo ""
 
-    if [[ $FAILED -gt 0 ]] || [[ $lint_failed -eq 1 ]] || [[ $unittest_failed -eq 1 ]]; then
-        log_error "Some charts failed validation"
-        exit 1
-    fi
+	if [[ $FAILED -gt 0 ]] || [[ $lint_failed -eq 1 ]] || [[ $unittest_failed -eq 1 ]]; then
+		log_error "Some charts failed validation"
+		exit 1
+	fi
 
-    log_info "All charts passed validation"
+	log_info "All charts passed validation"
 }
 
 main "$@"

--- a/services/ais_ingest/ais_ingest_test.py
+++ b/services/ais_ingest/ais_ingest_test.py
@@ -299,6 +299,7 @@ class TestAISIngestService:
         service.running = True
         service.ready = True
         service.nc = AsyncMock()
+
         # Create a proper task mock that can be cancelled and awaited
         async def dummy_task():
             await asyncio.sleep(10)

--- a/services/hikes/scrape_walkhighlands/scrape_test.py
+++ b/services/hikes/scrape_walkhighlands/scrape_test.py
@@ -407,11 +407,14 @@ class TestScrapeWalkhighlands:
 
     def test_scrape_walkhighlands_empty_sub_areas(self):
         """Returns empty list when no sub-area links found."""
-        with patch(
-            "services.hikes.scrape_walkhighlands.scrape.scrape_area_links_from_homepage"
-        ) as mock_areas, patch(
-            "services.hikes.scrape_walkhighlands.scrape.scrape_sub_area_links_from_area"
-        ) as mock_sub_areas:
+        with (
+            patch(
+                "services.hikes.scrape_walkhighlands.scrape.scrape_area_links_from_homepage"
+            ) as mock_areas,
+            patch(
+                "services.hikes.scrape_walkhighlands.scrape.scrape_sub_area_links_from_area"
+            ) as mock_sub_areas,
+        ):
             mock_areas.return_value = ["https://example.com/area1"]
             mock_sub_areas.return_value = []
 
@@ -433,15 +436,20 @@ class TestScrapeWalkhighlands:
             longitude=-5.0,
         )
 
-        with patch(
-            "services.hikes.scrape_walkhighlands.scrape.scrape_area_links_from_homepage"
-        ) as mock_areas, patch(
-            "services.hikes.scrape_walkhighlands.scrape.scrape_sub_area_links_from_area"
-        ) as mock_sub_areas, patch(
-            "services.hikes.scrape_walkhighlands.scrape.scrape_walks_from_sub_area"
-        ) as mock_walks, patch(
-            "services.hikes.scrape_walkhighlands.scrape.scrape_walk_data_from_file"
-        ) as mock_walk_data:
+        with (
+            patch(
+                "services.hikes.scrape_walkhighlands.scrape.scrape_area_links_from_homepage"
+            ) as mock_areas,
+            patch(
+                "services.hikes.scrape_walkhighlands.scrape.scrape_sub_area_links_from_area"
+            ) as mock_sub_areas,
+            patch(
+                "services.hikes.scrape_walkhighlands.scrape.scrape_walks_from_sub_area"
+            ) as mock_walks,
+            patch(
+                "services.hikes.scrape_walkhighlands.scrape.scrape_walk_data_from_file"
+            ) as mock_walk_data,
+        ):
             mock_areas.return_value = ["https://example.com/area1"]
             mock_sub_areas.return_value = ["https://example.com/subarea1"]
             mock_walks.return_value = ["https://example.com/walk1"]

--- a/services/hikes/update_forecast/update_test.py
+++ b/services/hikes/update_forecast/update_test.py
@@ -108,9 +108,7 @@ class TestParseWeatherData:
                                     "cloud_area_fraction": 25.0,
                                 }
                             },
-                            "next_1_hours": {
-                                "details": {"precipitation_amount": 0.5}
-                            },
+                            "next_1_hours": {"details": {"precipitation_amount": 0.5}},
                         },
                     }
                 ]
@@ -337,9 +335,7 @@ class TestLoadWalksFromDb:
     def test_load_walks_missing_db(self, tmp_path, monkeypatch):
         """Missing database causes system exit."""
         # Patch the db_path to point to non-existent file
-        with patch(
-            "services.hikes.update_forecast.update.Path"
-        ) as mock_path:
+        with patch("services.hikes.update_forecast.update.Path") as mock_path:
             mock_path.return_value.parent.__truediv__.return_value.__truediv__.return_value = (
                 tmp_path / "nonexistent.db"
             )

--- a/services/ships_api/tests/api_test.py
+++ b/services/ships_api/tests/api_test.py
@@ -138,7 +138,9 @@ class TestTrackEndpoint:
         assert data["track"] == []
 
     @pytest.mark.asyncio
-    async def test_track_with_data(self, test_client: AsyncClient, track_data: list[dict]):
+    async def test_track_with_data(
+        self, test_client: AsyncClient, track_data: list[dict]
+    ):
         """Track returns position history."""
         from services.ships_api.main import service
 
@@ -157,7 +159,9 @@ class TestTrackEndpoint:
         assert len(data["track"]) == len(track_data)
 
     @pytest.mark.asyncio
-    async def test_track_with_limit(self, test_client: AsyncClient, track_data: list[dict]):
+    async def test_track_with_limit(
+        self, test_client: AsyncClient, track_data: list[dict]
+    ):
         """Track respects limit parameter."""
         from services.ships_api.main import service
 

--- a/services/ships_api/tests/database_test.py
+++ b/services/ships_api/tests/database_test.py
@@ -331,7 +331,9 @@ class TestVesselUpsert:
         assert row["imo"] == sample_vessel_data["imo"]
 
     @pytest.mark.asyncio
-    async def test_upsert_vessel_update(self, test_db: Database, sample_vessel_data: dict):
+    async def test_upsert_vessel_update(
+        self, test_db: Database, sample_vessel_data: dict
+    ):
         """Update existing vessel metadata."""
         await test_db.upsert_vessels_batch([sample_vessel_data])
         await test_db.commit()

--- a/services/stargazer/tests/acquisition_test.py
+++ b/services/stargazer/tests/acquisition_test.py
@@ -17,7 +17,9 @@ from services.stargazer.app.acquisition import (
 from services.stargazer.app.config import Settings
 
 
-def create_mock_stream_response(content: bytes, raise_on_status: Exception | None = None):
+def create_mock_stream_response(
+    content: bytes, raise_on_status: Exception | None = None
+):
     """Create a properly mocked async stream response."""
     mock_response = MagicMock()
     if raise_on_status:

--- a/services/stargazer/tests/api_test.py
+++ b/services/stargazer/tests/api_test.py
@@ -407,7 +407,7 @@ class TestDataTransformation:
                 "id": "test1",
                 "coordinates": {"lat": 55.0, "lon": -4.5},
                 "best_hours": [
-                    {"time": f"2024-01-15T{20+i}:00:00Z", "score": 90 - i}
+                    {"time": f"2024-01-15T{20 + i}:00:00Z", "score": 90 - i}
                     for i in range(10)
                 ],
             }

--- a/services/stargazer/tests/conftest.py
+++ b/services/stargazer/tests/conftest.py
@@ -105,9 +105,7 @@ def sample_forecast_response() -> dict:
                                 "air_pressure_at_sea_level": 1018.0,
                             }
                         },
-                        "next_1_hours": {
-                            "summary": {"symbol_code": "clearsky_night"}
-                        },
+                        "next_1_hours": {"summary": {"symbol_code": "clearsky_night"}},
                     },
                 },
                 {
@@ -124,9 +122,7 @@ def sample_forecast_response() -> dict:
                                 "air_pressure_at_sea_level": 1010.0,
                             }
                         },
-                        "next_1_hours": {
-                            "summary": {"symbol_code": "cloudy"}
-                        },
+                        "next_1_hours": {"summary": {"symbol_code": "cloudy"}},
                     },
                 },
             ],
@@ -255,20 +251,22 @@ def mock_httpx_client():
 @pytest.fixture
 def sample_polygon() -> Polygon:
     """Sample polygon for spatial tests (area around Galloway)."""
-    return Polygon([
-        (-4.8, 54.9),
-        (-4.2, 54.9),
-        (-4.2, 55.2),
-        (-4.8, 55.2),
-        (-4.8, 54.9),
-    ])
+    return Polygon(
+        [
+            (-4.8, 54.9),
+            (-4.2, 54.9),
+            (-4.2, 55.2),
+            (-4.8, 55.2),
+            (-4.8, 54.9),
+        ]
+    )
 
 
 @pytest.fixture
 def sample_points() -> list[Point]:
     """Sample points for spatial tests."""
     return [
-        Point(-4.5, 55.0),   # Inside sample polygon
-        Point(-4.5, 55.1),   # Inside sample polygon
-        Point(-3.0, 55.0),   # Outside sample polygon
+        Point(-4.5, 55.0),  # Inside sample polygon
+        Point(-4.5, 55.1),  # Inside sample polygon
+        Point(-3.0, 55.0),  # Outside sample polygon
     ]

--- a/services/stargazer/tests/spatial_test.py
+++ b/services/stargazer/tests/spatial_test.py
@@ -42,11 +42,13 @@ class TestExtractDarkRegions:
 
         # Mock rasterio operations
         mock_raster = MagicMock()
-        mock_raster.read.return_value = np.array([
-            [[50, 50], [100, 100]],  # R
-            [[50, 50], [100, 100]],  # G
-            [[50, 50], [100, 100]],  # B
-        ])
+        mock_raster.read.return_value = np.array(
+            [
+                [[50, 50], [100, 100]],  # R
+                [[50, 50], [100, 100]],  # G
+                [[50, 50], [100, 100]],  # B
+            ]
+        )
         mock_raster.transform = MagicMock()
         mock_raster.__enter__ = MagicMock(return_value=mock_raster)
         mock_raster.__exit__ = MagicMock(return_value=False)
@@ -54,7 +56,9 @@ class TestExtractDarkRegions:
         # Create a sample polygon geometry for the mock shapes
         sample_geom = {
             "type": "Polygon",
-            "coordinates": [[[-4.5, 55.0], [-4.4, 55.0], [-4.4, 55.1], [-4.5, 55.1], [-4.5, 55.0]]]
+            "coordinates": [
+                [[-4.5, 55.0], [-4.4, 55.0], [-4.4, 55.1], [-4.5, 55.1], [-4.5, 55.0]]
+            ],
         }
 
         with patch("rasterio.open", return_value=mock_raster):
@@ -154,13 +158,15 @@ class TestIntersectDarkAccessible:
     def test_creates_intersection(self, settings: Settings):
         """Test that intersection of dark and accessible areas is created."""
         # Create dark regions (a square)
-        dark_polygon = Polygon([
-            (-5.0, 54.5),
-            (-4.0, 54.5),
-            (-4.0, 55.5),
-            (-5.0, 55.5),
-            (-5.0, 54.5),
-        ])
+        dark_polygon = Polygon(
+            [
+                (-5.0, 54.5),
+                (-4.0, 54.5),
+                (-4.0, 55.5),
+                (-5.0, 55.5),
+                (-5.0, 54.5),
+            ]
+        )
         dark_gdf = gpd.GeoDataFrame(
             {"dark": [True]},
             geometry=[dark_polygon],
@@ -170,13 +176,15 @@ class TestIntersectDarkAccessible:
         dark_gdf.to_file(dark_path, driver="GeoJSON")
 
         # Create road buffer (overlapping square)
-        buffer_polygon = Polygon([
-            (-4.8, 54.8),
-            (-4.2, 54.8),
-            (-4.2, 55.2),
-            (-4.8, 55.2),
-            (-4.8, 54.8),
-        ])
+        buffer_polygon = Polygon(
+            [
+                (-4.8, 54.8),
+                (-4.2, 54.8),
+                (-4.2, 55.2),
+                (-4.8, 55.2),
+                (-4.8, 54.8),
+            ]
+        )
         buffer_gdf = gpd.GeoDataFrame(
             geometry=[buffer_polygon],
             crs=WGS84_CRS,
@@ -195,13 +203,15 @@ class TestIntersectDarkAccessible:
     def test_empty_intersection(self, settings: Settings):
         """Test handling of non-overlapping regions."""
         # Create non-overlapping regions
-        dark_polygon = Polygon([
-            (-8.0, 58.0),
-            (-7.0, 58.0),
-            (-7.0, 59.0),
-            (-8.0, 59.0),
-            (-8.0, 58.0),
-        ])
+        dark_polygon = Polygon(
+            [
+                (-8.0, 58.0),
+                (-7.0, 58.0),
+                (-7.0, 59.0),
+                (-8.0, 59.0),
+                (-8.0, 58.0),
+            ]
+        )
         dark_gdf = gpd.GeoDataFrame(
             {"dark": [True]},
             geometry=[dark_polygon],
@@ -212,13 +222,15 @@ class TestIntersectDarkAccessible:
             driver="GeoJSON",
         )
 
-        buffer_polygon = Polygon([
-            (-4.0, 54.0),
-            (-3.0, 54.0),
-            (-3.0, 55.0),
-            (-4.0, 55.0),
-            (-4.0, 54.0),
-        ])
+        buffer_polygon = Polygon(
+            [
+                (-4.0, 54.0),
+                (-3.0, 54.0),
+                (-3.0, 55.0),
+                (-4.0, 55.0),
+                (-4.0, 54.0),
+            ]
+        )
         buffer_gdf = gpd.GeoDataFrame(
             geometry=[buffer_polygon],
             crs=WGS84_CRS,
@@ -251,13 +263,15 @@ class TestGenerateSampleGrid:
     def test_generates_points_within_area(self, settings: Settings):
         """Test that sample points are generated within accessible area."""
         # Create a larger accessible area to ensure points are generated
-        accessible_polygon = Polygon([
-            (-6.0, 54.0),
-            (-3.0, 54.0),
-            (-3.0, 57.0),
-            (-6.0, 57.0),
-            (-6.0, 54.0),
-        ])
+        accessible_polygon = Polygon(
+            [
+                (-6.0, 54.0),
+                (-3.0, 54.0),
+                (-3.0, 57.0),
+                (-6.0, 57.0),
+                (-6.0, 54.0),
+            ]
+        )
         accessible_gdf = gpd.GeoDataFrame(
             geometry=[accessible_polygon],
             crs=WGS84_CRS,
@@ -284,13 +298,15 @@ class TestGenerateSampleGrid:
 
     def test_points_have_required_columns(self, settings: Settings):
         """Test that generated points have id, lat, lon columns."""
-        accessible_polygon = Polygon([
-            (-6.0, 54.0),
-            (-3.0, 54.0),
-            (-3.0, 57.0),
-            (-6.0, 57.0),
-            (-6.0, 54.0),
-        ])
+        accessible_polygon = Polygon(
+            [
+                (-6.0, 54.0),
+                (-3.0, 54.0),
+                (-3.0, 57.0),
+                (-6.0, 57.0),
+                (-6.0, 54.0),
+            ]
+        )
         accessible_gdf = gpd.GeoDataFrame(
             geometry=[accessible_polygon],
             crs=WGS84_CRS,
@@ -318,13 +334,15 @@ class TestGenerateSampleGrid:
         # Just test that the function can handle different spacing values
         # without errors - actual point count comparison is complex due to
         # projection and boundary effects
-        accessible_polygon = Polygon([
-            (-6.0, 54.0),
-            (-3.0, 54.0),
-            (-3.0, 57.0),
-            (-6.0, 57.0),
-            (-6.0, 54.0),
-        ])
+        accessible_polygon = Polygon(
+            [
+                (-6.0, 54.0),
+                (-3.0, 54.0),
+                (-3.0, 57.0),
+                (-6.0, 57.0),
+                (-6.0, 54.0),
+            ]
+        )
         accessible_gdf = gpd.GeoDataFrame(
             geometry=[accessible_polygon],
             crs=WGS84_CRS,

--- a/services/stargazer/tests/weather_test.py
+++ b/services/stargazer/tests/weather_test.py
@@ -239,7 +239,9 @@ class TestScoreLocations:
                                     "air_pressure_at_sea_level": 1020.0,
                                 }
                             },
-                            "next_1_hours": {"summary": {"symbol_code": "clearsky_day"}},
+                            "next_1_hours": {
+                                "summary": {"symbol_code": "clearsky_day"}
+                            },
                         },
                     }
                 ]
@@ -425,7 +427,7 @@ class TestOutputBestLocations:
                 "altitude_m": 100,
                 "lp_zone": "1a",
                 "scored_hours": [
-                    {"time": f"2024-01-15T{20+i}:00:00Z", "score": 90.0 - i}
+                    {"time": f"2024-01-15T{20 + i}:00:00Z", "score": 90.0 - i}
                     for i in range(10)
                 ],
             },

--- a/services/trips_api/trips_api_test.py
+++ b/services/trips_api/trips_api_test.py
@@ -181,7 +181,7 @@ class TestTripsState:
                 id=f"p{i}",
                 lat=45.0 + i,
                 lng=-122.0,
-                timestamp=f"2024-01-15T{10+i:02d}:00:00Z",
+                timestamp=f"2024-01-15T{10 + i:02d}:00:00Z",
             )
 
         points = state.get_points(limit=3)
@@ -193,7 +193,7 @@ class TestTripsState:
                 id=f"p{i}",
                 lat=45.0 + i,
                 lng=-122.0,
-                timestamp=f"2024-01-15T{10+i:02d}:00:00Z",
+                timestamp=f"2024-01-15T{10 + i:02d}:00:00Z",
             )
 
         points = state.get_points(offset=2)

--- a/tools/argocd-parallel/BUILD
+++ b/tools/argocd-parallel/BUILD
@@ -33,6 +33,7 @@ filegroup(
         "//overlays/prod/gh-arc-runners:render_manifests",
         "//overlays/prod/nats:render_manifests",
         "//overlays/prod/seaweedfs:render_manifests",
+        "//overlays/prod/todo:render_manifests",
         "//overlays/prod/trips:render_manifests",
         "//overlays/prod/vllm:render_manifests",
     ],

--- a/tools/argocd/BUILD
+++ b/tools/argocd/BUILD
@@ -3,7 +3,10 @@ load("@multitool//:tools.bzl", MULTITOOL_TOOLS = "TOOLS")
 load("@rules_go//go:def.bzl", "go_library", "go_test")
 load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
 
-exports_files(["render-manifests.sh"])
+exports_files([
+    "helm-template-test.sh",
+    "render-manifests.sh",
+])
 
 sh_binary(
     name = "validate_manifests",

--- a/tools/argocd/defs.bzl
+++ b/tools/argocd/defs.bzl
@@ -115,6 +115,38 @@ helm_render = rule(
     """,
 )
 
+def helm_template_test(name, chart, release_name, namespace, values_files, chart_files, **kwargs):
+    """Creates a cacheable test that validates Helm chart renders with given values.
+
+    This test runs helm template with the full values hierarchy from an ArgoCD
+    Application and fails if rendering produces errors. Results are cached by
+    Bazel based on input file hashes.
+
+    Args:
+        name: Name of the test target
+        chart: Path to chart directory (e.g., "charts/todo")
+        release_name: Helm release name
+        namespace: Kubernetes namespace for rendering
+        values_files: List of values file labels in order (e.g., ["//charts/todo:values.yaml", "values.yaml"])
+        chart_files: Label for chart's all_files filegroup (e.g., "//charts/todo:all_files")
+        **kwargs: Additional arguments passed to sh_test
+    """
+    sh_test(
+        name = name,
+        srcs = ["//tools/argocd:helm-template-test.sh"],
+        args = [
+            "$(rootpath @multitool//tools/helm)",
+            release_name,
+            chart,
+            namespace,
+        ] + ["$(rootpath {})".format(vf) for vf in values_files],
+        data = [
+            "@multitool//tools/helm",
+            chart_files,
+        ] + values_files,
+        **kwargs
+    )
+
 def helm_lint_test(name, chart_path = None, **kwargs):
     """Creates a test that runs helm lint on a chart.
 
@@ -170,4 +202,3 @@ EOF
         ] + native.glob(["templates/**"]),
         **kwargs
     )
-

--- a/tools/argocd/generate.go
+++ b/tools/argocd/generate.go
@@ -159,6 +159,13 @@ func generateRules(args language.GenerateArgs) language.GenerateResult {
 			result.Gen = append(result.Gen, manifestRule)
 			result.Imports = append(result.Imports, nil)
 		}
+
+		// Also generate a cacheable template test
+		templateTestRule := generateTemplateTestRule(app, args.Rel, args.Dir)
+		if templateTestRule != nil {
+			result.Gen = append(result.Gen, templateTestRule)
+			result.Imports = append(result.Imports, nil)
+		}
 	}
 
 	return result
@@ -411,6 +418,85 @@ func generateManifestRule(app *ArgoCDApplication, currentPackage string, current
 
 	// Tag as manual so it doesn't run on bazel build //...
 	r.SetAttr("tags", []string{"manual"})
+
+	return r
+}
+
+// generateTemplateTestRule creates a helm_template_test that validates the chart renders
+// successfully with the full values hierarchy. This is a cacheable Bazel test.
+func generateTemplateTestRule(app *ArgoCDApplication, currentPackage string, currentDir string) *rule.Rule {
+	r := rule.NewRule("helm_template_test", "template_test")
+
+	chartPath := app.Spec.Source.Path
+	if chartPath == "" {
+		return nil
+	}
+
+	// Set chart path
+	r.SetAttr("chart", chartPath)
+
+	// Set chart_files label for dependencies
+	r.SetAttr("chart_files", "//"+filepath.ToSlash(chartPath)+":all_files")
+
+	// releaseName defaults to app name if not specified (ArgoCD behavior)
+	releaseName := app.Spec.Source.Helm.ReleaseName
+	if releaseName == "" {
+		releaseName = app.Metadata.Name
+	}
+	r.SetAttr("release_name", releaseName)
+
+	// Set namespace
+	r.SetAttr("namespace", app.Spec.Destination.Namespace)
+
+	// Build the values_files list (as Bazel labels)
+	var valuesFiles []string
+
+	// Add chart's default values.yaml first
+	valuesFiles = append(valuesFiles, "//"+filepath.ToSlash(chartPath)+":values.yaml")
+
+	// Add all valueFiles referenced in the Application spec
+	for _, vf := range app.Spec.Source.Helm.ValueFiles {
+		if strings.HasPrefix(vf, "../") {
+			// Relative path - resolve it relative to chart path
+			resolvedPath := filepath.Join(chartPath, vf)
+			cleanPath := filepath.Clean(resolvedPath)
+
+			// Skip paths that escape workspace root
+			if strings.HasPrefix(cleanPath, "..") {
+				continue
+			}
+
+			// Check if this file is in the current package
+			fileDir := filepath.Dir(cleanPath)
+			fileName := filepath.Base(cleanPath)
+
+			if filepath.ToSlash(fileDir) == currentPackage {
+				// File is in current package, use relative reference
+				valuesFiles = append(valuesFiles, fileName)
+			} else {
+				// File is in different package, use absolute label
+				valuesFiles = append(valuesFiles, "//"+filepath.ToSlash(fileDir)+":"+fileName)
+			}
+		} else if !strings.Contains(vf, "/") {
+			// Simple filename in chart directory
+			valuesFiles = append(valuesFiles, "//"+filepath.ToSlash(chartPath)+":"+vf)
+		}
+	}
+
+	// Deduplicate values files
+	seen := make(map[string]bool)
+	var uniqueValuesFiles []string
+	for _, vf := range valuesFiles {
+		if !seen[vf] {
+			seen[vf] = true
+			uniqueValuesFiles = append(uniqueValuesFiles, vf)
+		}
+	}
+
+	r.SetAttr("values_files", uniqueValuesFiles)
+
+	// Tag for filtering
+	r.SetAttr("tags", []string{"helm", "template"})
 
 	return r
 }

--- a/tools/argocd/generate_test.go
+++ b/tools/argocd/generate_test.go
@@ -133,7 +133,7 @@ spec:
 			// Create a temp file with the YAML content
 			tmpDir := t.TempDir()
 			tmpFile := filepath.Join(tmpDir, "application.yaml")
-			if err := os.WriteFile(tmpFile, []byte(tc.yamlContent), 0644); err != nil {
+			if err := os.WriteFile(tmpFile, []byte(tc.yamlContent), 0o644); err != nil {
 				t.Fatalf("Failed to write temp file: %v", err)
 			}
 
@@ -170,7 +170,7 @@ func TestDiscoverOverlaysUsingChart(t *testing.T) {
 
 	// Create overlays directory structure
 	overlaysDir := filepath.Join(tmpDir, "overlays", "prod", "myapp")
-	if err := os.MkdirAll(overlaysDir, 0755); err != nil {
+	if err := os.MkdirAll(overlaysDir, 0o755); err != nil {
 		t.Fatalf("Failed to create overlays dir: %v", err)
 	}
 
@@ -189,7 +189,7 @@ spec:
     server: https://kubernetes.default.svc
     namespace: myapp
 `
-	if err := os.WriteFile(filepath.Join(overlaysDir, "application.yaml"), []byte(appYaml), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(overlaysDir, "application.yaml"), []byte(appYaml), 0o644); err != nil {
 		t.Fatalf("Failed to write application.yaml: %v", err)
 	}
 
@@ -213,7 +213,7 @@ func TestDiscoverOverlaysUsingChart_MultipleOverlays(t *testing.T) {
 	envs := []string{"dev", "staging", "prod"}
 	for _, env := range envs {
 		overlaysDir := filepath.Join(tmpDir, "overlays", env, "myapp")
-		if err := os.MkdirAll(overlaysDir, 0755); err != nil {
+		if err := os.MkdirAll(overlaysDir, 0o755); err != nil {
 			t.Fatalf("Failed to create overlays dir: %v", err)
 		}
 
@@ -227,7 +227,7 @@ spec:
   destination:
     server: https://kubernetes.default.svc
 `
-		if err := os.WriteFile(filepath.Join(overlaysDir, "application.yaml"), []byte(appYaml), 0644); err != nil {
+		if err := os.WriteFile(filepath.Join(overlaysDir, "application.yaml"), []byte(appYaml), 0o644); err != nil {
 			t.Fatalf("Failed to write application.yaml: %v", err)
 		}
 	}
@@ -244,7 +244,7 @@ func TestDiscoverOverlaysUsingChart_NoMatches(t *testing.T) {
 
 	// Create an overlay that references a different chart
 	overlaysDir := filepath.Join(tmpDir, "overlays", "prod", "other")
-	if err := os.MkdirAll(overlaysDir, 0755); err != nil {
+	if err := os.MkdirAll(overlaysDir, 0o755); err != nil {
 		t.Fatalf("Failed to create overlays dir: %v", err)
 	}
 
@@ -258,7 +258,7 @@ spec:
   destination:
     server: https://kubernetes.default.svc
 `
-	if err := os.WriteFile(filepath.Join(overlaysDir, "application.yaml"), []byte(appYaml), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(overlaysDir, "application.yaml"), []byte(appYaml), 0o644); err != nil {
 		t.Fatalf("Failed to write application.yaml: %v", err)
 	}
 
@@ -283,12 +283,12 @@ func TestDiscoverOverlaysUsingChart_InvalidYaml(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	overlaysDir := filepath.Join(tmpDir, "overlays", "prod", "broken")
-	if err := os.MkdirAll(overlaysDir, 0755); err != nil {
+	if err := os.MkdirAll(overlaysDir, 0o755); err != nil {
 		t.Fatalf("Failed to create overlays dir: %v", err)
 	}
 
 	// Write invalid YAML
-	if err := os.WriteFile(filepath.Join(overlaysDir, "application.yaml"), []byte("invalid: yaml: ["), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(overlaysDir, "application.yaml"), []byte("invalid: yaml: ["), 0o644); err != nil {
 		t.Fatalf("Failed to write application.yaml: %v", err)
 	}
 
@@ -333,7 +333,7 @@ func TestGenerateLiveDiffRule(t *testing.T) {
 	// Create temp dir with values.yaml
 	tmpDir := t.TempDir()
 	valuesFile := filepath.Join(tmpDir, "values.yaml")
-	if err := os.WriteFile(valuesFile, []byte("key: value"), 0644); err != nil {
+	if err := os.WriteFile(valuesFile, []byte("key: value"), 0o644); err != nil {
 		t.Fatalf("Failed to write values.yaml: %v", err)
 	}
 
@@ -497,6 +497,172 @@ func containsSubstringHelper(s, substr string) bool {
 		}
 	}
 	return false
+}
+
+func TestGenerateTemplateTestRule(t *testing.T) {
+	app := &ArgoCDApplication{
+		Metadata: struct {
+			Name      string `yaml:"name"`
+			Namespace string `yaml:"namespace"`
+		}{
+			Name:      "test-app",
+			Namespace: "argocd",
+		},
+		Spec: struct {
+			Source struct {
+				RepoURL        string `yaml:"repoURL"`
+				Path           string `yaml:"path"`
+				Chart          string `yaml:"chart"`
+				TargetRevision string `yaml:"targetRevision"`
+				Helm           struct {
+					ReleaseName string   `yaml:"releaseName"`
+					ValueFiles  []string `yaml:"valueFiles"`
+				} `yaml:"helm"`
+			} `yaml:"source"`
+			Destination struct {
+				Server    string `yaml:"server"`
+				Namespace string `yaml:"namespace"`
+			} `yaml:"destination"`
+		}{},
+	}
+	app.Spec.Source.Path = "charts/test"
+	app.Spec.Source.Helm.ReleaseName = "test-release"
+	app.Spec.Source.Helm.ValueFiles = []string{"../overlays/prod/test/values.yaml"}
+	app.Spec.Destination.Namespace = "test-ns"
+
+	tmpDir := t.TempDir()
+
+	rule := generateTemplateTestRule(app, "overlays/prod/test", tmpDir)
+
+	if rule == nil {
+		t.Fatal("generateTemplateTestRule returned nil")
+	}
+
+	if rule.Kind() != "helm_template_test" {
+		t.Errorf("rule kind = %q, want %q", rule.Kind(), "helm_template_test")
+	}
+
+	if rule.Name() != "template_test" {
+		t.Errorf("rule name = %q, want %q", rule.Name(), "template_test")
+	}
+
+	// Check chart attribute
+	chart := rule.AttrString("chart")
+	if chart != "charts/test" {
+		t.Errorf("chart = %q, want %q", chart, "charts/test")
+	}
+
+	// Check release_name attribute
+	releaseName := rule.AttrString("release_name")
+	if releaseName != "test-release" {
+		t.Errorf("release_name = %q, want %q", releaseName, "test-release")
+	}
+
+	// Check namespace attribute
+	namespace := rule.AttrString("namespace")
+	if namespace != "test-ns" {
+		t.Errorf("namespace = %q, want %q", namespace, "test-ns")
+	}
+
+	// Check chart_files attribute
+	chartFiles := rule.AttrString("chart_files")
+	if chartFiles != "//charts/test:all_files" {
+		t.Errorf("chart_files = %q, want %q", chartFiles, "//charts/test:all_files")
+	}
+
+	// Check values_files attribute exists
+	valuesFiles := rule.Attr("values_files")
+	if valuesFiles == nil {
+		t.Error("values_files attribute is nil")
+	}
+
+	// Check tags attribute
+	tags := rule.Attr("tags")
+	if tags == nil {
+		t.Error("tags attribute is nil")
+	}
+}
+
+func TestGenerateTemplateTestRule_DefaultReleaseName(t *testing.T) {
+	app := &ArgoCDApplication{
+		Metadata: struct {
+			Name      string `yaml:"name"`
+			Namespace string `yaml:"namespace"`
+		}{
+			Name: "my-app-name",
+		},
+		Spec: struct {
+			Source struct {
+				RepoURL        string `yaml:"repoURL"`
+				Path           string `yaml:"path"`
+				Chart          string `yaml:"chart"`
+				TargetRevision string `yaml:"targetRevision"`
+				Helm           struct {
+					ReleaseName string   `yaml:"releaseName"`
+					ValueFiles  []string `yaml:"valueFiles"`
+				} `yaml:"helm"`
+			} `yaml:"source"`
+			Destination struct {
+				Server    string `yaml:"server"`
+				Namespace string `yaml:"namespace"`
+			} `yaml:"destination"`
+		}{},
+	}
+	app.Spec.Source.Path = "charts/test"
+	// ReleaseName is empty - should default to app name
+	app.Spec.Destination.Namespace = "test-ns"
+
+	tmpDir := t.TempDir()
+
+	rule := generateTemplateTestRule(app, "overlays/prod/test", tmpDir)
+
+	if rule == nil {
+		t.Fatal("generateTemplateTestRule returned nil")
+	}
+
+	// Check release_name defaults to app name
+	releaseName := rule.AttrString("release_name")
+	if releaseName != "my-app-name" {
+		t.Errorf("release_name = %q, want %q (defaulted from app name)", releaseName, "my-app-name")
+	}
+}
+
+func TestGenerateTemplateTestRule_NoChartPath(t *testing.T) {
+	app := &ArgoCDApplication{
+		Metadata: struct {
+			Name      string `yaml:"name"`
+			Namespace string `yaml:"namespace"`
+		}{
+			Name: "test-app",
+		},
+		Spec: struct {
+			Source struct {
+				RepoURL        string `yaml:"repoURL"`
+				Path           string `yaml:"path"`
+				Chart          string `yaml:"chart"`
+				TargetRevision string `yaml:"targetRevision"`
+				Helm           struct {
+					ReleaseName string   `yaml:"releaseName"`
+					ValueFiles  []string `yaml:"valueFiles"`
+				} `yaml:"helm"`
+			} `yaml:"source"`
+			Destination struct {
+				Server    string `yaml:"server"`
+				Namespace string `yaml:"namespace"`
+			} `yaml:"destination"`
+		}{},
+	}
+	// No chart path set
+	app.Spec.Destination.Namespace = "test-ns"
+
+	tmpDir := t.TempDir()
+
+	rule := generateTemplateTestRule(app, "overlays/prod/test", tmpDir)
+
+	// Should return nil when no chart path
+	if rule != nil {
+		t.Error("expected nil rule when chart path is empty")
+	}
 }
 
 func TestArgoCDApplication_Structure(t *testing.T) {

--- a/tools/argocd/helm-template-test.sh
+++ b/tools/argocd/helm-template-test.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# helm-template-test.sh - Validates that a Helm chart renders successfully with given values
+#
+# Usage: helm-template-test.sh <helm-binary> <release-name> <chart-path> <namespace> [values-files...]
+#
+# This script is used by Bazel's helm_template_test rule to validate that
+# Helm charts render without errors when combined with their values files.
+# Exit code 0 = success, non-zero = rendering failed.
+
+set -euo pipefail
+
+if [[ $# -lt 4 ]]; then
+	echo "Usage: $0 <helm-binary> <release-name> <chart-path> <namespace> [values-files...]"
+	exit 1
+fi
+
+HELM="$1"
+RELEASE_NAME="$2"
+CHART_PATH="$3"
+NAMESPACE="$4"
+shift 4
+
+# Build values arguments
+VALUES_ARGS=()
+for values_file in "$@"; do
+	VALUES_ARGS+=("--values" "$values_file")
+done
+
+echo "Testing Helm template rendering:"
+echo "  Release: $RELEASE_NAME"
+echo "  Chart:   $CHART_PATH"
+echo "  Namespace: $NAMESPACE"
+echo "  Values:  $*"
+echo ""
+
+# Run helm template and discard output - we only care about exit code
+# Errors will be printed to stderr
+if "$HELM" template "$RELEASE_NAME" "$CHART_PATH" \
+	--namespace "$NAMESPACE" \
+	"${VALUES_ARGS[@]}" \
+	>/dev/null; then
+	echo "PASSED: Chart renders successfully"
+	exit 0
+else
+	echo ""
+	echo "FAILED: Chart rendering produced errors"
+	exit 1
+fi

--- a/tools/argocd/language.go
+++ b/tools/argocd/language.go
@@ -91,6 +91,20 @@ func (l *argoCDLang) Kinds() map[string]rule.KindInfo {
 				"visibility": true,
 			},
 		},
+		"helm_template_test": {
+			MatchAny: false,
+			NonEmptyAttrs: map[string]bool{
+				"chart":        true,
+				"release_name": true,
+				"namespace":    true,
+				"values_files": true,
+				"chart_files":  true,
+			},
+			MergeableAttrs: map[string]bool{
+				"values_files": true,
+				"tags":         true,
+			},
+		},
 	}
 }
 
@@ -103,7 +117,7 @@ func (l *argoCDLang) Loads() []rule.LoadInfo {
 		},
 		{
 			Name:    "//tools/argocd:defs.bzl",
-			Symbols: []string{"chart_files"},
+			Symbols: []string{"chart_files", "helm_template_test"},
 		},
 	}
 }

--- a/tools/argocd/language_test.go
+++ b/tools/argocd/language_test.go
@@ -198,7 +198,6 @@ func TestArgoCDLang_Loads(t *testing.T) {
 func TestArgoCDLang_CheckFlags(t *testing.T) {
 	lang := NewLanguage()
 	err := lang.CheckFlags(nil, nil)
-
 	if err != nil {
 		t.Errorf("CheckFlags() returned error: %v", err)
 	}

--- a/tools/format/fast-format.sh
+++ b/tools/format/fast-format.sh
@@ -45,7 +45,14 @@ bazel build "${TARGETS[@]}" 2>&1 | grep -v "^INFO:" || true
 
 # Find binaries in bazel-bin (faster than cquery)
 # -L follows symlinks (bazel-bin itself is a symlink)
-find_bin() { find -L bazel-bin -name "$1" -type f -perm +111 2>/dev/null | head -1; }
+# Use -perm /111 for GNU find (Linux) or -perm +111 for BSD find (macOS)
+find_bin() {
+	if find --version 2>/dev/null | grep -q GNU; then
+		find -L bazel-bin -name "$1" -type f -perm /111 2>/dev/null | head -1
+	else
+		find -L bazel-bin -name "$1" -type f -perm +111 2>/dev/null | head -1
+	fi
+}
 
 RUFF=$(find_bin ruff)
 SHFMT=$(find_bin shfmt)


### PR DESCRIPTION
## Summary

- Adds `helm_template_test` Bazel rule that validates Helm charts render successfully with the full values hierarchy from ArgoCD Applications
- Tests are auto-generated by Gazelle for every overlay with `application.yaml`
- Tests are cacheable by Bazel - only re-run when chart or values files change
- Updates BuildBuddy CI to run format check (which includes gazelle) instead of just gazelle

## What this catches

| Issue | Before | After |
|-------|--------|-------|
| Typo in overlay values.yaml | ❌ Merges, fails at deploy | ✅ Fails CI |
| Missing required value | ❌ Merges, fails at deploy | ✅ Fails CI |
| Template syntax error | ❌ Merges, fails at deploy | ✅ Fails CI |
| Undefined template variable | ❌ Merges, fails at deploy | ✅ Fails CI |

## Changes

- `tools/argocd/defs.bzl` - Add `helm_template_test()` macro
- `tools/argocd/generate.go` - Add `generateTemplateTestRule()` function
- `tools/argocd/language.go` - Register new rule kind
- `tools/argocd/helm-template-test.sh` - Test runner script
- `tools/argocd/generate_test.go` - Add unit tests
- `overlays/**/BUILD` - Auto-generated `template_test` targets (24 overlays)
- `buildbuddy.yaml` - Replace "Gazelle lint" with "Format check"

## Test plan

- [x] All 24 template tests pass locally
- [x] Go unit tests pass (`//tools/argocd:argocd_test`)
- [x] Tests are properly cached on re-run
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)