### PR TITLE
fix(alerts): use correct OpenTelemetry metric names for k8s alerts

### DIFF
--- a/overlays/cluster-critical/signoz/alerts/node-disk-pressure.yaml
+++ b/overlays/cluster-critical/signoz/alerts/node-disk-pressure.yaml
@@ -25,8 +25,8 @@ data:
         "environment": "production"
       },
       "annotations": {
-        "summary": "Node {{ $labels.node }} has disk pressure",
-        "description": "Kubernetes node {{ $labels.node }} is under disk pressure condition"
+        "summary": "Node {{ $labels.k8s_node_name }} has disk pressure",
+        "description": "Kubernetes node {{ $labels.k8s_node_name }} is under disk pressure condition"
       },
       "condition": {
         "compositeQuery": {
@@ -36,26 +36,15 @@ data:
               "dataSource": "metrics",
               "aggregateOperator": "max",
               "aggregateAttribute": {
-                "key": "kube_node_status_condition",
+                "key": "k8s.node.condition_disk_pressure",
                 "dataType": "float64",
                 "type": "Gauge"
               },
               "filters": {
-                "items": [
-                  {
-                    "key": {"key": "condition"},
-                    "op": "=",
-                    "value": "DiskPressure"
-                  },
-                  {
-                    "key": {"key": "status"},
-                    "op": "=",
-                    "value": "true"
-                  }
-                ]
+                "items": []
               },
               "groupBy": [
-                {"key": "node"}
+                {"key": "k8s.node.name"}
               ]
             }
           },

--- a/overlays/cluster-critical/signoz/alerts/node-memory-pressure.yaml
+++ b/overlays/cluster-critical/signoz/alerts/node-memory-pressure.yaml
@@ -25,8 +25,8 @@ data:
         "environment": "production"
       },
       "annotations": {
-        "summary": "Node {{ $labels.node }} has memory pressure",
-        "description": "Kubernetes node {{ $labels.node }} is under memory pressure condition"
+        "summary": "Node {{ $labels.k8s_node_name }} has memory pressure",
+        "description": "Kubernetes node {{ $labels.k8s_node_name }} is under memory pressure condition"
       },
       "condition": {
         "compositeQuery": {
@@ -36,26 +36,15 @@ data:
               "dataSource": "metrics",
               "aggregateOperator": "max",
               "aggregateAttribute": {
-                "key": "kube_node_status_condition",
+                "key": "k8s.node.condition_memory_pressure",
                 "dataType": "float64",
                 "type": "Gauge"
               },
               "filters": {
-                "items": [
-                  {
-                    "key": {"key": "condition"},
-                    "op": "=",
-                    "value": "MemoryPressure"
-                  },
-                  {
-                    "key": {"key": "status"},
-                    "op": "=",
-                    "value": "true"
-                  }
-                ]
+                "items": []
               },
               "groupBy": [
-                {"key": "node"}
+                {"key": "k8s.node.name"}
               ]
             }
           },

--- a/overlays/cluster-critical/signoz/alerts/node-not-ready.yaml
+++ b/overlays/cluster-critical/signoz/alerts/node-not-ready.yaml
@@ -25,8 +25,8 @@ data:
         "environment": "production"
       },
       "annotations": {
-        "summary": "Node {{ $labels.node }} is not Ready",
-        "description": "Kubernetes node {{ $labels.node }} is not in Ready condition for 5 consecutive checks"
+        "summary": "Node {{ $labels.k8s_node_name }} is not Ready",
+        "description": "Kubernetes node {{ $labels.k8s_node_name }} is not in Ready condition for 5 consecutive checks"
       },
       "condition": {
         "compositeQuery": {
@@ -34,35 +34,24 @@ data:
             "A": {
               "queryName": "A",
               "dataSource": "metrics",
-              "aggregateOperator": "max",
+              "aggregateOperator": "min",
               "aggregateAttribute": {
-                "key": "kube_node_status_condition",
+                "key": "k8s.node.condition_ready",
                 "dataType": "float64",
                 "type": "Gauge"
               },
               "filters": {
-                "items": [
-                  {
-                    "key": {"key": "condition"},
-                    "op": "=",
-                    "value": "Ready"
-                  },
-                  {
-                    "key": {"key": "status"},
-                    "op": "!=",
-                    "value": "true"
-                  }
-                ]
+                "items": []
               },
               "groupBy": [
-                {"key": "node"}
+                {"key": "k8s.node.name"}
               ]
             }
           },
           "queryType": "builder"
         },
-        "op": ">",
-        "target": 0,
+        "op": "<",
+        "target": 1,
         "matchType": "5"
       },
       "preferredChannels": ["pagerduty-homelab"]

--- a/overlays/cluster-critical/signoz/alerts/node-pid-pressure.yaml
+++ b/overlays/cluster-critical/signoz/alerts/node-pid-pressure.yaml
@@ -25,8 +25,8 @@ data:
         "environment": "production"
       },
       "annotations": {
-        "summary": "Node {{ $labels.node }} has PID pressure",
-        "description": "Kubernetes node {{ $labels.node }} is under PID pressure condition"
+        "summary": "Node {{ $labels.k8s_node_name }} has PID pressure",
+        "description": "Kubernetes node {{ $labels.k8s_node_name }} is under PID pressure condition"
       },
       "condition": {
         "compositeQuery": {
@@ -36,26 +36,15 @@ data:
               "dataSource": "metrics",
               "aggregateOperator": "max",
               "aggregateAttribute": {
-                "key": "kube_node_status_condition",
+                "key": "k8s.node.condition_pid_pressure",
                 "dataType": "float64",
                 "type": "Gauge"
               },
               "filters": {
-                "items": [
-                  {
-                    "key": {"key": "condition"},
-                    "op": "=",
-                    "value": "PIDPressure"
-                  },
-                  {
-                    "key": {"key": "status"},
-                    "op": "=",
-                    "value": "true"
-                  }
-                ]
+                "items": []
               },
               "groupBy": [
-                {"key": "node"}
+                {"key": "k8s.node.name"}
               ]
             }
           },

--- a/overlays/cluster-critical/signoz/alerts/pod-oomkilled.yaml
+++ b/overlays/cluster-critical/signoz/alerts/pod-oomkilled.yaml
@@ -25,8 +25,8 @@ data:
         "environment": "production"
       },
       "annotations": {
-        "summary": "Container {{ $labels.container }} was OOMKilled",
-        "description": "Container {{ $labels.container }} in pod {{ $labels.k8s_pod_name }} namespace {{ $labels.k8s_namespace_name }} was terminated due to OOM"
+        "summary": "Container {{ $labels.k8s_container_name }} was OOMKilled",
+        "description": "Container {{ $labels.k8s_container_name }} in pod {{ $labels.k8s_pod_name }} namespace {{ $labels.k8s_namespace_name }} was terminated due to OOM"
       },
       "condition": {
         "compositeQuery": {
@@ -36,23 +36,23 @@ data:
               "dataSource": "metrics",
               "aggregateOperator": "max",
               "aggregateAttribute": {
-                "key": "kube_pod_container_status_last_terminated_reason",
+                "key": "k8s.container.restarts",
                 "dataType": "float64",
                 "type": "Gauge"
               },
               "filters": {
                 "items": [
                   {
-                    "key": {"key": "reason"},
+                    "key": {"key": "k8s.container.status.last_terminated_reason"},
                     "op": "=",
                     "value": "OOMKilled"
                   }
                 ]
               },
               "groupBy": [
-                {"key": "k8s_namespace_name"},
-                {"key": "k8s_pod_name"},
-                {"key": "container"}
+                {"key": "k8s.namespace.name"},
+                {"key": "k8s.pod.name"},
+                {"key": "k8s.container.name"}
               ]
             }
           },

--- a/overlays/cluster-critical/signoz/alerts/pod-pending.yaml
+++ b/overlays/cluster-critical/signoz/alerts/pod-pending.yaml
@@ -36,29 +36,23 @@ data:
               "dataSource": "metrics",
               "aggregateOperator": "max",
               "aggregateAttribute": {
-                "key": "kube_pod_status_phase",
+                "key": "k8s.pod.phase",
                 "dataType": "float64",
                 "type": "Gauge"
               },
               "filters": {
-                "items": [
-                  {
-                    "key": {"key": "phase"},
-                    "op": "=",
-                    "value": "Pending"
-                  }
-                ]
+                "items": []
               },
               "groupBy": [
-                {"key": "k8s_namespace_name"},
-                {"key": "k8s_pod_name"}
+                {"key": "k8s.namespace.name"},
+                {"key": "k8s.pod.name"}
               ]
             }
           },
           "queryType": "builder"
         },
-        "op": ">",
-        "target": 0,
+        "op": "=",
+        "target": 1,
         "matchType": "15"
       },
       "preferredChannels": ["pagerduty-homelab"]

--- a/overlays/cluster-critical/signoz/alerts/pod-restart-rate.yaml
+++ b/overlays/cluster-critical/signoz/alerts/pod-restart-rate.yaml
@@ -34,18 +34,18 @@ data:
             "A": {
               "queryName": "A",
               "dataSource": "metrics",
-              "aggregateOperator": "sum",
+              "aggregateOperator": "max",
               "aggregateAttribute": {
-                "key": "kube_pod_container_status_restarts_total",
+                "key": "k8s.container.restarts",
                 "dataType": "float64",
-                "type": "Sum"
+                "type": "Gauge"
               },
               "filters": {
                 "items": []
               },
               "groupBy": [
-                {"key": "k8s_namespace_name"},
-                {"key": "k8s_pod_name"}
+                {"key": "k8s.namespace.name"},
+                {"key": "k8s.pod.name"}
               ]
             }
           },


### PR DESCRIPTION
## Summary

- Fixed 7 Kubernetes health alerts that were using non-existent metric names
- The alerts were using kube-state-metrics naming convention but SigNoz uses OpenTelemetry k8sclusterreceiver naming convention
- These alerts were **never firing** because the metrics didn't exist

## Changes

| Alert | Old Metric (Invalid) | New Metric (Valid) |
|-------|---------------------|-------------------|
| Node Disk Pressure | `kube_node_status_condition` | `k8s.node.condition_disk_pressure` |
| Node Memory Pressure | `kube_node_status_condition` | `k8s.node.condition_memory_pressure` |
| Node PID Pressure | `kube_node_status_condition` | `k8s.node.condition_pid_pressure` |
| Node Not Ready | `kube_node_status_condition` | `k8s.node.condition_ready` |
| Pod OOMKilled | `kube_pod_container_status_last_terminated_reason` | `k8s.container.restarts` |
| Pod Stuck Pending | `kube_pod_status_phase` | `k8s.pod.phase` |
| Pod High Restart Rate | `kube_pod_container_status_restarts_total` | `k8s.container.restarts` |

Also updated label references:
- `node` → `k8s.node.name`
- `k8s_namespace_name` → `k8s.namespace.name`
- `k8s_pod_name` → `k8s.pod.name`
- `container` → `k8s.container.name`

## Test plan

- [ ] Verify alerts sync to SigNoz via ArgoCD
- [ ] Check SigNoz Alerts UI to confirm rules are valid
- [ ] Optionally trigger a test condition (e.g., pending pod) to verify alert fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)