### PR TITLE
fix(openclaw): use Recreate strategy and disable skills

### DIFF
--- a/charts/openclaw/Chart.yaml
+++ b/charts/openclaw/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: openclaw
 description: OpenClaw AI coding assistant with web interface
 type: application
-version: 1.0.0
+version: 1.0.1
 appVersion: "2026.1.30"
 keywords:
   - ai

--- a/charts/openclaw/templates/deployment.yaml
+++ b/charts/openclaw/templates/deployment.yaml
@@ -7,6 +7,9 @@ metadata:
 spec:
   # OpenClaw does not support horizontal scaling - single replica only
   replicas: 1
+  # Recreate strategy to avoid PVC multi-attach issues with single replica
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       {{- include "openclaw.selectorLabels" . | nindent 6 }}

--- a/overlays/prod/openclaw-friends/values.yaml
+++ b/overlays/prod/openclaw-friends/values.yaml
@@ -40,9 +40,11 @@ discord:
         requireMention: true
 
 ## ClawHub skills
+## TODO: Re-enable after debugging init-skills permission issue
+## Skills can be installed manually: kubectl exec -it <pod> -n openclaw -- clawhub install steipete/discord
 clawhub:
-  skills:
-    - "steipete/discord"
+  skills: []
+  # - "steipete/discord"
 
 ## Cloudflare Zero Trust
 cloudflare:


### PR DESCRIPTION
## Summary
- Add Recreate deployment strategy to avoid PVC multi-attach errors when pods are replaced
- Temporarily disable clawhub skills for friends instance (permission issue needs debugging)
- Skills can be installed manually after pod is running: `kubectl exec -it <pod> -n openclaw -- clawhub install steipete/discord`

## Test plan
- [ ] Verify personal pod starts without Multi-Attach errors
- [ ] Verify friends pod starts without init-skills crash
- [ ] Verify both services are accessible via Cloudflare

🤖 Generated with [Claude Code](https://claude.com/claude-code)