### PR TITLE
fix(openclaw): add gateway.mode=local config

### DIFF
--- a/overlays/prod/openclaw-friends/values.yaml
+++ b/overlays/prod/openclaw-friends/values.yaml
@@ -22,6 +22,13 @@ llm:
 auth:
   enabled: false
 
+## Gateway config - required for startup
+config:
+  extra:
+    gateway:
+      mode: "local"
+      port: 18789
+
 ## Discord channel
 discord:
   enabled: true

--- a/overlays/prod/openclaw-personal/values.yaml
+++ b/overlays/prod/openclaw-personal/values.yaml
@@ -8,6 +8,13 @@ llm:
   provider: "anthropic"
   model: "claude-sonnet-4-20250514"
 
+## Gateway config - required for startup
+config:
+  extra:
+    gateway:
+      mode: "local"
+      port: 18789
+
 ## Claude auth via manual login
 ## After pod starts: kubectl exec -it -n openclaw deployment/openclaw-personal -- openclaw auth login
 ## Credentials persist to PVC


### PR DESCRIPTION
## Summary
OpenClaw requires `gateway.mode=local` in config to start. Without it, the container fails with:
```
Missing config. Run `openclaw setup` or set gateway.mode=local
```

This was causing the cascading linkerd PostStartHook failures (linkerd-proxy times out waiting for the main container to become ready).

## Test plan
- [ ] Personal pod starts successfully
- [ ] Friends pod starts successfully
- [ ] Linkerd proxy becomes ready

🤖 Generated with [Claude Code](https://claude.com/claude-code)