### PR TITLE
fix(openclaw): add explicit --config flag

### DIFF
--- a/charts/openclaw/Chart.yaml
+++ b/charts/openclaw/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: openclaw
 description: OpenClaw AI coding assistant with web interface
 type: application
-version: 1.0.2
+version: 1.0.3
 appVersion: "2026.1.30"
 keywords:
   - ai

--- a/charts/openclaw/templates/deployment.yaml
+++ b/charts/openclaw/templates/deployment.yaml
@@ -96,6 +96,8 @@ spec:
             - dist/index.js
           args:
             - gateway
+            - --config
+            - /etc/openclaw/openclaw.json
             - --bind
             - lan
             - --port


### PR DESCRIPTION
## Summary
OpenClaw wasn't reading from `OPENCLAW_CONFIG` env var. Explicitly pass `--config /etc/openclaw/openclaw.json` to gateway command.

## Test plan
- [ ] Personal pod starts and stays running
- [ ] Friends pod starts and stays running

🤖 Generated with [Claude Code](https://claude.com/claude-code)