### PR TITLE
fix(openclaw): disable linkerd injection temporarily

### DIFF
--- a/overlays/prod/openclaw-friends/values.yaml
+++ b/overlays/prod/openclaw-friends/values.yaml
@@ -3,6 +3,10 @@
 
 fullnameOverride: "openclaw-friends"
 
+## Disable linkerd injection (debugging PostStartHook timeouts)
+podAnnotations:
+  linkerd.io/inject: disabled
+
 ## LLM: Local Qwen via vLLM
 llm:
   provider: "openai-compatible"

--- a/overlays/prod/openclaw-personal/values.yaml
+++ b/overlays/prod/openclaw-personal/values.yaml
@@ -3,6 +3,10 @@
 
 fullnameOverride: "openclaw-personal"
 
+## Disable linkerd injection (debugging PostStartHook timeouts)
+podAnnotations:
+  linkerd.io/inject: disabled
+
 ## LLM: Anthropic Claude
 llm:
   provider: "anthropic"


### PR DESCRIPTION
## Summary
Linkerd PostStartHook times out (2min) waiting for linkerd-proxy to become ready. This causes endless restart loops.

Disabling linkerd injection to get pods running. Can investigate linkerd issue separately.

## Test plan
- [ ] Personal pod starts without linkerd
- [ ] Friends pod starts without linkerd

🤖 Generated with [Claude Code](https://claude.com/claude-code)