### PR TITLE
fix(openclaw): copy config to expected location

### DIFF
--- a/charts/openclaw/Chart.yaml
+++ b/charts/openclaw/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: openclaw
 description: OpenClaw AI coding assistant with web interface
 type: application
-version: 1.0.3
+version: 1.0.4
 appVersion: "2026.1.30"
 keywords:
   - ai

--- a/charts/openclaw/templates/deployment.yaml
+++ b/charts/openclaw/templates/deployment.yaml
@@ -35,8 +35,8 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       initContainers:
         {{- if .Values.initContainers.initConfig.enabled }}
-        # init-config: Set up config directory with correct permissions
-        # Runs as root briefly to chown the directory to user 1000:1000
+        # init-config: Copy config and set up directory permissions
+        # OpenClaw expects config at $HOME/.openclaw/openclaw.json
         - name: init-config
           image: {{ .Values.initContainers.initConfig.image }}
           command:
@@ -44,6 +44,7 @@ spec:
             - -c
             - |
               mkdir -p /home/openclaw/.openclaw
+              cp /config/openclaw.json /home/openclaw/.openclaw/openclaw.json
               chown -R 1000:1000 /home/openclaw
           securityContext:
             runAsUser: 0
@@ -51,6 +52,9 @@ spec:
           volumeMounts:
             - name: data
               mountPath: /home/openclaw
+            - name: config
+              mountPath: /config
+              readOnly: true
           resources:
             {{- toYaml .Values.initContainers.initConfig.resources | nindent 12 }}
         {{- end }}
@@ -96,8 +100,6 @@ spec:
             - dist/index.js
           args:
             - gateway
-            - --config
-            - /etc/openclaw/openclaw.json
             - --bind
             - lan
             - --port
@@ -109,8 +111,6 @@ spec:
           env:
             - name: HOME
               value: /home/openclaw
-            - name: OPENCLAW_CONFIG
-              value: /etc/openclaw/openclaw.json
             - name: OPENCLAW_PORT
               value: {{ .Values.server.port | quote }}
             {{- if .Values.chromium.enabled }}


### PR DESCRIPTION
## Summary
OpenClaw expects config at `$HOME/.openclaw/openclaw.json`. The `--config` flag doesn't exist.

Changes:
- Remove invalid `--config` flag from gateway args
- Update init-config to copy config from ConfigMap to `$HOME/.openclaw/openclaw.json`
- Remove `OPENCLAW_CONFIG` env var (not needed)

## Test plan
- [ ] Personal pod starts and reads config
- [ ] Friends pod starts and reads config

🤖 Generated with [Claude Code](https://claude.com/claude-code)