### PR TITLE
fix(openclaw): preserve config across restarts

### DIFF
--- a/charts/openclaw/Chart.yaml
+++ b/charts/openclaw/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: openclaw
 description: OpenClaw AI coding assistant with web interface
 type: application
-version: 1.0.4
+version: 1.0.5
 appVersion: "2026.1.30"
 keywords:
   - ai

--- a/charts/openclaw/templates/configmap.yaml
+++ b/charts/openclaw/templates/configmap.yaml
@@ -7,38 +7,86 @@ metadata:
 data:
   openclaw.json: |
     {
-      {{- if eq .Values.llm.provider "anthropic" }}
-      "provider": "anthropic",
-      "model": {{ .Values.llm.model | quote }}
-      {{- else if eq .Values.llm.provider "openai-compatible" }}
-      "provider": "openai-compatible",
-      "model": {{ .Values.llm.model | quote }},
-      "baseUrl": {{ .Values.llm.baseUrl | quote }}
-      {{- if .Values.llm.apiKey }}
-      ,"apiKey": {{ .Values.llm.apiKey | quote }}
-      {{- end }}
-      {{- end }}
-      ,"permissionMode": {{ .Values.config.permissionMode | quote }}
-      {{- if .Values.config.trustedProxies }}
-      ,"trustedProxies": {{ .Values.config.trustedProxies | toJson }}
+      "gateway": {
+        "mode": "local",
+        "port": {{ .Values.server.port }},
+        "auth": {
+          "mode": "token",
+          "token": "openclaw-gateway-token"
+        }
+      },
+      "agents": {
+        "defaults": {
+          "workspace": "/home/openclaw/.openclaw/workspace",
+          "model": {
+            {{- if eq .Values.llm.provider "anthropic" }}
+            "primary": {{ printf "anthropic/%s" .Values.llm.model | quote }}
+            {{- else if eq .Values.llm.provider "openai-compatible" }}
+            "primary": {{ printf "custom/%s" .Values.llm.model | quote }}
+            {{- end }}
+          },
+          "timeoutSeconds": 600,
+          "maxConcurrent": 1
+        },
+        "list": [
+          {
+            "id": "main",
+            "default": true,
+            "identity": {
+              "name": "OpenClaw",
+              "emoji": "🦞"
+            }
+          }
+        ]
+      }
+      {{- if eq .Values.llm.provider "openai-compatible" }}
+      ,"models": {
+        "providers": {
+          "custom": {
+            "baseUrl": {{ .Values.llm.baseUrl | quote }},
+            "api": "openai-completions"
+            {{- if .Values.llm.apiKey }}
+            ,"apiKey": {{ .Values.llm.apiKey | quote }}
+            {{- end }}
+          }
+        }
+      }
       {{- end }}
       {{- if or .Values.discord.enabled .Values.whatsapp.enabled }}
       ,"channels": {
         {{- $channelList := list }}
         {{- if .Values.discord.enabled }}
-        {{- $discordConfig := merge (dict "enabled" true) .Values.discord.settings }}
+        {{- $discordConfig := dict "enabled" true }}
+        {{- if .Values.discord.settings.guilds }}
+        {{- $discordConfig = merge $discordConfig (dict "guilds" .Values.discord.settings.guilds) }}
+        {{- end }}
+        {{- if .Values.discord.settings.historyLimit }}
+        {{- $discordConfig = merge $discordConfig (dict "historyLimit" .Values.discord.settings.historyLimit) }}
+        {{- end }}
+        {{- if .Values.discord.settings.dm }}
+        {{- $discordConfig = merge $discordConfig (dict "dm" .Values.discord.settings.dm) }}
+        {{- end }}
         {{- $channelList = append $channelList (printf "\"discord\": %s" ($discordConfig | toJson)) }}
         {{- end }}
         {{- if .Values.whatsapp.enabled }}
-        {{- $whatsappConfig := merge (dict "enabled" true) .Values.whatsapp.settings }}
+        {{- $whatsappConfig := dict "enabled" true }}
+        {{- if .Values.whatsapp.settings.dmPolicy }}
+        {{- $whatsappConfig = merge $whatsappConfig (dict "dmPolicy" .Values.whatsapp.settings.dmPolicy) }}
+        {{- end }}
+        {{- if .Values.whatsapp.settings.groups }}
+        {{- $whatsappConfig = merge $whatsappConfig (dict "groups" .Values.whatsapp.settings.groups) }}
+        {{- end }}
         {{- $channelList = append $channelList (printf "\"whatsapp\": %s" ($whatsappConfig | toJson)) }}
         {{- end }}
         {{ join "," $channelList }}
       }
       {{- end }}
-      {{- if .Values.config.extra }}
-      {{- range $key, $value := .Values.config.extra }}
-      ,{{ $key | quote }}: {{ $value | toJson }}
-      {{- end }}
-      {{- end }}
+      ,"tools": {
+        "profile": "full"
+      }
+      ,"logging": {
+        "level": "info",
+        "consoleLevel": "info",
+        "consoleStyle": "compact"
+      }
     }

--- a/charts/openclaw/templates/deployment.yaml
+++ b/charts/openclaw/templates/deployment.yaml
@@ -35,16 +35,22 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       initContainers:
         {{- if .Values.initContainers.initConfig.enabled }}
-        # init-config: Copy config and set up directory permissions
-        # OpenClaw expects config at $HOME/.openclaw/openclaw.json
+        # init-config: Set up directory and seed config if not exists
+        # Only creates config if missing - preserves manual changes across restarts
         - name: init-config
           image: {{ .Values.initContainers.initConfig.image }}
           command:
             - /bin/sh
             - -c
             - |
-              mkdir -p /home/openclaw/.openclaw
-              cp /config/openclaw.json /home/openclaw/.openclaw/openclaw.json
+              mkdir -p /home/openclaw/.openclaw/workspace
+              # Only copy seed config if no config exists (preserve manual changes)
+              if [ ! -f /home/openclaw/.openclaw/openclaw.json ]; then
+                echo "Creating initial config..."
+                cp /config/openclaw.json /home/openclaw/.openclaw/openclaw.json
+              else
+                echo "Config exists, preserving..."
+              fi
               chown -R 1000:1000 /home/openclaw
           securityContext:
             runAsUser: 0
@@ -100,6 +106,7 @@ spec:
             - dist/index.js
           args:
             - gateway
+            - --allow-unconfigured
             - --bind
             - lan
             - --port
@@ -111,6 +118,11 @@ spec:
           env:
             - name: HOME
               value: /home/openclaw
+            {{- if .Values.gateway.token }}
+            # Gateway WebSocket auth token (optional - Cloudflare Zero Trust handles external auth)
+            - name: OPENCLAW_GATEWAY_TOKEN
+              value: {{ .Values.gateway.token | quote }}
+            {{- end }}
             - name: OPENCLAW_PORT
               value: {{ .Values.server.port | quote }}
             {{- if .Values.chromium.enabled }}

--- a/charts/openclaw/values.yaml
+++ b/charts/openclaw/values.yaml
@@ -16,6 +16,12 @@ fullnameOverride: ""
 server:
   port: 18789
 
+## Gateway configuration
+gateway:
+  ## WebSocket auth token - clients need this to connect
+  ## Override with a secret value in your overlay
+  token: ""
+
 ## LLM provider configuration
 ## Supports multiple backends for different use cases
 llm:

--- a/overlays/prod/openclaw-friends/values.yaml
+++ b/overlays/prod/openclaw-friends/values.yaml
@@ -26,13 +26,6 @@ llm:
 auth:
   enabled: false
 
-## Gateway config - required for startup
-config:
-  extra:
-    gateway:
-      mode: "local"
-      port: 18789
-
 ## Discord channel
 discord:
   enabled: true

--- a/overlays/prod/openclaw-personal/values.yaml
+++ b/overlays/prod/openclaw-personal/values.yaml
@@ -12,13 +12,6 @@ llm:
   provider: "anthropic"
   model: "claude-sonnet-4-20250514"
 
-## Gateway config - required for startup
-config:
-  extra:
-    gateway:
-      mode: "local"
-      port: 18789
-
 ## Claude auth via manual login
 ## After pod starts: kubectl exec -it -n openclaw deployment/openclaw-personal -- openclaw auth login
 ## Credentials persist to PVC


### PR DESCRIPTION
## Summary
- Only seed config if it doesn't exist (preserves manual changes)
- Use `--allow-unconfigured` flag so gateway starts without full config
- Use `OPENCLAW_GATEWAY_TOKEN` env var for WebSocket auth
- Fix configmap to use correct OpenClaw config schema
- Remove hardcoded gateway config from overlays

Users can now manually configure OpenClaw via dashboard/CLI and changes persist across restarts.

## Test plan
- [ ] Pod starts with --allow-unconfigured
- [ ] Config is only created on first run
- [ ] Manual config changes persist after pod restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)