### PR TITLE
fix(openclaw): minimal deployment - configure via UI

### DIFF
--- a/charts/openclaw/Chart.yaml
+++ b/charts/openclaw/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: openclaw
 description: OpenClaw AI coding assistant with web interface
 type: application
-version: 1.0.5
+version: 1.0.6
 appVersion: "2026.1.30"
 keywords:
   - ai

--- a/charts/openclaw/templates/configmap.yaml
+++ b/charts/openclaw/templates/configmap.yaml
@@ -1,3 +1,6 @@
+{{- if false }}
+# ConfigMap disabled - configure OpenClaw via UI after deployment
+# This file kept for reference of proper config structure
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -6,87 +9,5 @@ metadata:
     {{- include "openclaw.labels" . | nindent 4 }}
 data:
   openclaw.json: |
-    {
-      "gateway": {
-        "mode": "local",
-        "port": {{ .Values.server.port }},
-        "auth": {
-          "mode": "token",
-          "token": "openclaw-gateway-token"
-        }
-      },
-      "agents": {
-        "defaults": {
-          "workspace": "/home/openclaw/.openclaw/workspace",
-          "model": {
-            {{- if eq .Values.llm.provider "anthropic" }}
-            "primary": {{ printf "anthropic/%s" .Values.llm.model | quote }}
-            {{- else if eq .Values.llm.provider "openai-compatible" }}
-            "primary": {{ printf "custom/%s" .Values.llm.model | quote }}
-            {{- end }}
-          },
-          "timeoutSeconds": 600,
-          "maxConcurrent": 1
-        },
-        "list": [
-          {
-            "id": "main",
-            "default": true,
-            "identity": {
-              "name": "OpenClaw",
-              "emoji": "🦞"
-            }
-          }
-        ]
-      }
-      {{- if eq .Values.llm.provider "openai-compatible" }}
-      ,"models": {
-        "providers": {
-          "custom": {
-            "baseUrl": {{ .Values.llm.baseUrl | quote }},
-            "api": "openai-completions"
-            {{- if .Values.llm.apiKey }}
-            ,"apiKey": {{ .Values.llm.apiKey | quote }}
-            {{- end }}
-          }
-        }
-      }
-      {{- end }}
-      {{- if or .Values.discord.enabled .Values.whatsapp.enabled }}
-      ,"channels": {
-        {{- $channelList := list }}
-        {{- if .Values.discord.enabled }}
-        {{- $discordConfig := dict "enabled" true }}
-        {{- if .Values.discord.settings.guilds }}
-        {{- $discordConfig = merge $discordConfig (dict "guilds" .Values.discord.settings.guilds) }}
-        {{- end }}
-        {{- if .Values.discord.settings.historyLimit }}
-        {{- $discordConfig = merge $discordConfig (dict "historyLimit" .Values.discord.settings.historyLimit) }}
-        {{- end }}
-        {{- if .Values.discord.settings.dm }}
-        {{- $discordConfig = merge $discordConfig (dict "dm" .Values.discord.settings.dm) }}
-        {{- end }}
-        {{- $channelList = append $channelList (printf "\"discord\": %s" ($discordConfig | toJson)) }}
-        {{- end }}
-        {{- if .Values.whatsapp.enabled }}
-        {{- $whatsappConfig := dict "enabled" true }}
-        {{- if .Values.whatsapp.settings.dmPolicy }}
-        {{- $whatsappConfig = merge $whatsappConfig (dict "dmPolicy" .Values.whatsapp.settings.dmPolicy) }}
-        {{- end }}
-        {{- if .Values.whatsapp.settings.groups }}
-        {{- $whatsappConfig = merge $whatsappConfig (dict "groups" .Values.whatsapp.settings.groups) }}
-        {{- end }}
-        {{- $channelList = append $channelList (printf "\"whatsapp\": %s" ($whatsappConfig | toJson)) }}
-        {{- end }}
-        {{ join "," $channelList }}
-      }
-      {{- end }}
-      ,"tools": {
-        "profile": "full"
-      }
-      ,"logging": {
-        "level": "info",
-        "consoleLevel": "info",
-        "consoleStyle": "compact"
-      }
-    }
+    {}
+{{- end }}

--- a/charts/openclaw/templates/deployment.yaml
+++ b/charts/openclaw/templates/deployment.yaml
@@ -35,8 +35,7 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       initContainers:
         {{- if .Values.initContainers.initConfig.enabled }}
-        # init-config: Set up directory and seed config if not exists
-        # Only creates config if missing - preserves manual changes across restarts
+        # init-config: Set up directories with correct permissions
         - name: init-config
           image: {{ .Values.initContainers.initConfig.image }}
           command:
@@ -44,13 +43,6 @@ spec:
             - -c
             - |
               mkdir -p /home/openclaw/.openclaw/workspace
-              # Only copy seed config if no config exists (preserve manual changes)
-              if [ ! -f /home/openclaw/.openclaw/openclaw.json ]; then
-                echo "Creating initial config..."
-                cp /config/openclaw.json /home/openclaw/.openclaw/openclaw.json
-              else
-                echo "Config exists, preserving..."
-              fi
               chown -R 1000:1000 /home/openclaw
           securityContext:
             runAsUser: 0
@@ -58,9 +50,6 @@ spec:
           volumeMounts:
             - name: data
               mountPath: /home/openclaw
-            - name: config
-              mountPath: /config
-              readOnly: true
           resources:
             {{- toYaml .Values.initContainers.initConfig.resources | nindent 12 }}
         {{- end }}
@@ -194,9 +183,6 @@ spec:
           volumeMounts:
             - name: data
               mountPath: /home/openclaw
-            - name: config
-              mountPath: /etc/openclaw
-              readOnly: true
             # Writable directories for readOnlyRootFilesystem
             - name: tmp
               mountPath: /tmp
@@ -243,9 +229,6 @@ spec:
           {{- else }}
           emptyDir: {}
           {{- end }}
-        - name: config
-          configMap:
-            name: {{ include "openclaw.fullname" . }}-config
         # Writable directories for readOnlyRootFilesystem
         - name: tmp
           emptyDir: {}


### PR DESCRIPTION
## Summary
Strip down to bare minimum to get gateway running:
- Remove configmap (no model/channel config)
- Keep gateway flags (`--allow-unconfigured --bind lan --port`)
- Init container only creates directories

Configure models, channels, etc. via OpenClaw UI/CLI after pod starts.

## Test plan
- [ ] Pod starts with `--allow-unconfigured`
- [ ] Gateway responds on port 18789
- [ ] Can access UI via Cloudflare

🤖 Generated with [Claude Code](https://claude.com/claude-code)