### PR TITLE
fix(openclaw): add --token flag for gateway auth

### DIFF
--- a/charts/openclaw/templates/deployment.yaml
+++ b/charts/openclaw/templates/deployment.yaml
@@ -100,6 +100,8 @@ spec:
             - lan
             - --port
             - {{ .Values.server.port | quote }}
+            - --token
+            - {{ .Values.gateway.token | default "openclaw" | quote }}
           ports:
             - name: http
               containerPort: {{ .Values.server.port }}


### PR DESCRIPTION
## Summary
Gateway requires a token even with `--allow-unconfigured`. Add `--token openclaw` flag.

## Test plan
- [ ] Pod starts successfully
- [ ] Gateway responds

🤖 Generated with [Claude Code](https://claude.com/claude-code)