### PR TITLE
fix(openclaw): increase friends memory for Discord

### DIFF
--- a/overlays/prod/openclaw-friends/values.yaml
+++ b/overlays/prod/openclaw-friends/values.yaml
@@ -65,13 +65,13 @@ persistence:
   storageClass: "longhorn"
   size: 5Gi
 
-## Resources (lower - inference is on vLLM)
+## Resources - Discord integration needs more memory
 resources:
   requests:
     cpu: 250m
-    memory: 512Mi
-  limits:
     memory: 1Gi
+  limits:
+    memory: 2Gi
 
 ## Network policy - allow external internet, restrict internal cluster
 networkPolicy:


### PR DESCRIPTION
## Summary
Friends pod hitting JS heap out of memory at ~507MB. Discord integration needs more memory.

- Memory limit: 1Gi → 2Gi
- Memory request: 512Mi → 1Gi

## Test plan
- [ ] Friends pod starts without OOM
- [ ] Discord bot connects

🤖 Generated with [Claude Code](https://claude.com/claude-code)