### PR TITLE
fix(openclaw): correct vLLM network policy pod selector

### DIFF
--- a/charts/openclaw/values.yaml
+++ b/charts/openclaw/values.yaml
@@ -332,8 +332,10 @@ networkPolicy:
     ## Port for vLLM service
     port: 8000
     ## Pod selector labels for vLLM pods
+    ## Default matches common vLLM router deployments (release: router)
+    ## Override if your vLLM pods use different labels
     podSelector:
-      app.kubernetes.io/name: vllm
+      release: router
 
   ## Additional egress rules
   ## Use this for custom destinations not covered by the provider defaults

--- a/overlays/prod/openclaw-friends/values.yaml
+++ b/overlays/prod/openclaw-friends/values.yaml
@@ -76,12 +76,10 @@ resources:
 ## Network policy - allow external internet, restrict internal cluster
 networkPolicy:
   enabled: true
-  ## vLLM egress (internal service - explicit allow)
+  ## vLLM egress - uses chart default podSelector (release: router)
+  ## Only override port since router uses port 80 (not default 8000)
   vllm:
-    namespace: "vllm"
     port: 80
-    podSelector:
-      release: router
   ## Allow all external internet (web search, APIs, etc.)
   ## Block internal cluster traffic except explicit vLLM rule above
   egress:


### PR DESCRIPTION
## Summary
- Fix NetworkPolicy pod selector for vLLM egress - was using `app.kubernetes.io/name: vllm` but the vLLM router pod only has `release: router`
- This was blocking openclaw-friends from reaching the vLLM endpoint, causing crashes when users tried to chat

## Test plan
- [ ] Merge PR and wait for ArgoCD sync
- [ ] Verify NetworkPolicy has correct selector: `kubectl get networkpolicy openclaw-friends -n openclaw -o yaml | grep -A5 "podSelector:"`
- [ ] Test connectivity: `kubectl exec -n openclaw <pod> -- curl http://vllm-router-service.vllm.svc.cluster.local:80/v1/models`
- [ ] Send a test message via Discord or web UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)