### PR TITLE
fix(openclaw): use pod port 8000 for vLLM network policy

### DIFF
--- a/overlays/prod/openclaw-friends/values.yaml
+++ b/overlays/prod/openclaw-friends/values.yaml
@@ -76,10 +76,9 @@ resources:
 ## Network policy - allow external internet, restrict internal cluster
 networkPolicy:
   enabled: true
-  ## vLLM egress - uses chart default podSelector (release: router)
-  ## Only override port since router uses port 80 (not default 8000)
-  vllm:
-    port: 80
+  ## vLLM egress - uses chart defaults (release: router, port 8000)
+  ## Note: NetworkPolicy uses pod port (8000), not service port (80)
+  vllm: {}
   ## Allow all external internet (web search, APIs, etc.)
   ## Block internal cluster traffic except explicit vLLM rule above
   egress:


### PR DESCRIPTION
## Summary
- Fix NetworkPolicy port to use pod port (8000) instead of service port (80)

## Problem
NetworkPolicy with `podSelector` targets pods directly, so it needs the pod's listening port (8000), not the Kubernetes service port (80). The service maps `80 -> 8000`, but the policy bypasses the service.

This is a follow-up to #334 which fixed the pod selector labels.

## Test plan
- [ ] Verify `curl http://vllm-router-service.vllm.svc.cluster.local:80/v1/models` works from openclaw-friends pod
- [ ] Test chat in web UI

🤖 Generated with [Claude Code](https://claude.ai/code)