### PR TITLE
fix(vllm): use qwen3_coder tool-call-parser for Qwen3-Coder models

### DIFF
--- a/overlays/prod/vllm/values.yaml
+++ b/overlays/prod/vllm/values.yaml
@@ -89,9 +89,9 @@ vllm-stack:
             - "0.85"  # Reduced from 0.95 to leave headroom for CUDA graph compilation
             - "--cpu-offload-gb"
             - "15"  # Increased from 10GB to offload more to CPU RAM (we have 32Gi available)
-            - "--enable-auto-tool-choice"   # Enable function/tool calling for OpenCode
+            - "--enable-auto-tool-choice"   # Enable function/tool calling
             - "--tool-call-parser"
-            - "hermes"  # Use Hermes parser for tool calling (compatible with Qwen models)
+            - "qwen3_coder"  # Use qwen3_coder parser for Qwen3-Coder models (not hermes)
             # Note: quantization auto-detected from model config (compressed-tensors)
 
         # Node affinity: schedule only on node-4 (GPU node with storage)


### PR DESCRIPTION
## Summary
- Changed `--tool-call-parser` from `hermes` to `qwen3_coder`

## Problem
OpenClaw's Discord bot wasn't completing tool calls (e.g., weather queries). The model would respond "Let me check the weather..." but never actually execute the tool.

The issue is that Qwen3-Coder models use a different tool-call format than Hermes models. vLLM has a dedicated `qwen3_coder` parser for this.

## References
- [vLLM Qwen3-Coder Usage Guide](https://docs.vllm.ai/projects/recipes/en/latest/Qwen/Qwen3-Coder-480B-A35B.html)
- [vLLM Tool Calling Docs](https://docs.vllm.ai/en/latest/features/tool_calling/)

## Test plan
- [ ] Wait for vLLM pod to restart with new args
- [ ] Test tool calling via OpenClaw Discord (e.g., "@bot what's the weather in Vancouver?")

⚠️ **Note**: This will cause a vLLM pod restart

🤖 Generated with [Claude Code](https://claude.ai/code)