### PR TITLE
fix(perplexica): disable linkerd injection

### DIFF
--- a/overlays/prod/perplexica/values.yaml
+++ b/overlays/prod/perplexica/values.yaml
@@ -3,6 +3,10 @@
 
 fullnameOverride: "perplexica"
 
+## Disable linkerd injection (causes PostStartHook timeouts)
+podAnnotations:
+  linkerd.io/inject: disabled
+
 ## LLM: Use existing vLLM deployment with Qwen3-Coder
 llm:
   baseUrl: "http://vllm-router-service.vllm.svc.cluster.local:80/v1"


### PR DESCRIPTION
## Summary

- Disable linkerd sidecar injection with `linkerd.io/inject: disabled` annotation
- Linkerd proxy causes PostStartHook timeouts with the multi-container pod setup

## Test plan

- [ ] Verify pod starts without linkerd sidecar
- [ ] Verify Perplexica and SearXNG containers are healthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)