### PR TITLE
fix(perplexica): use pod port 8000 for vLLM network policy

### DIFF
--- a/overlays/prod/perplexica/values.yaml
+++ b/overlays/prod/perplexica/values.yaml
@@ -78,6 +78,7 @@ networkPolicy:
   vllm:
     enabled: true
     namespace: "vllm"
-    port: 80
+    ## Use pod port 8000, not service port 80 (NetworkPolicy operates on pod-to-pod traffic)
+    port: 8000
     podSelector:
       release: router


### PR DESCRIPTION
## Summary
- Fix NetworkPolicy egress rule to use pod port 8000 instead of service port 80
- NetworkPolicy operates on pod-to-pod traffic after DNAT, so the container port is required

## Problem
Perplexica couldn't connect to vLLM for LLM inference because the egress rule specified port 80 (the Service port), but traffic is evaluated at the pod level where the actual port is 8000.

## Test plan
- [ ] ArgoCD syncs the updated NetworkPolicy
- [ ] Verify Perplexica pod can reach vLLM: `kubectl exec -n search <pod> -- wget -q -O- http://vllm-router-service.vllm.svc.cluster.local:80/v1/models`
- [ ] Test a Perplexica search query that uses LLM

🤖 Generated with [Claude Code](https://claude.com/claude-code)