### PR TITLE
feat(openclaw): add 1Password support for Anthropic API key

### DIFF
--- a/charts/openclaw/Chart.yaml
+++ b/charts/openclaw/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: openclaw
 description: OpenClaw AI coding assistant with web interface
 type: application
-version: 1.0.6
+version: 1.0.7
 appVersion: "2026.1.30"
 keywords:
   - ai

--- a/charts/openclaw/templates/onepassworditem.yaml
+++ b/charts/openclaw/templates/onepassworditem.yaml
@@ -26,3 +26,17 @@ spec:
   itemPath: {{ .Values.whatsapp.secret.onepassword.itemPath | quote }}
 {{- end }}
 {{- end }}
+{{- if and .Values.auth.enabled (eq .Values.auth.method "api-key") }}
+{{- if eq (default "manual" .Values.auth.secret.type) "onepassword" }}
+---
+apiVersion: onepassword.com/v1
+kind: OnePasswordItem
+metadata:
+  name: {{ include "openclaw.fullname" . }}-auth
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "openclaw.labels" . | nindent 4 }}
+spec:
+  itemPath: {{ .Values.auth.secret.onepassword.itemPath | quote }}
+{{- end }}
+{{- end }}

--- a/charts/openclaw/values.yaml
+++ b/charts/openclaw/values.yaml
@@ -399,6 +399,18 @@ auth:
   # WARNING: This value will be stored in Helm release secrets
   apiKey: ""
 
+  ## Secret configuration for API key (when method is "api-key")
+  ## Supports 1Password Kubernetes Operator for secure secret management
+  secret:
+    ## Type: "onepassword" or "manual"
+    ## onepassword: Create a OnePasswordItem that syncs to K8s secret
+    ## manual: Use existingSecret or apiKey above
+    type: "manual"
+    onepassword:
+      ## 1Password item path (e.g., "vaults/k8s-homelab/items/anthropic")
+      ## The item must have a field named "ANTHROPIC_API_KEY" (or match apiKeySecretKey)
+      itemPath: ""
+
 ## Cloudflare Zero Trust configuration
 ## Exposes the OpenClaw dashboard via Cloudflare Tunnel with access policies
 cloudflare:

--- a/overlays/prod/openclaw-personal/values.yaml
+++ b/overlays/prod/openclaw-personal/values.yaml
@@ -12,12 +12,15 @@ llm:
   provider: "anthropic"
   model: "claude-sonnet-4-20250514"
 
-## Claude auth via manual login
-## After pod starts: kubectl exec -it -n openclaw deployment/openclaw-personal -- openclaw auth login
-## Credentials persist to PVC
+## Claude auth via 1Password-managed API key
 auth:
   enabled: true
-  method: "manual"
+  method: "api-key"
+  secret:
+    type: "onepassword"
+    onepassword:
+      ## 1Password item must have field named "ANTHROPIC_API_KEY"
+      itemPath: "vaults/k8s-homelab/items/anthropic"
 
 ## WhatsApp channel (QR code auth - run `openclaw channels login` after deploy)
 whatsapp:


### PR DESCRIPTION
## Summary
- Add `auth.secret.onepassword` configuration to manage ANTHROPIC_API_KEY via 1Password Kubernetes Operator
- Configure personal overlay to use 1Password item at `vaults/k8s-homelab/items/anthropic`

## Prerequisites
Create a 1Password item with a field named `ANTHROPIC_API_KEY` containing your Anthropic API key.

## Test plan
- [ ] Verify OnePasswordItem is created in openclaw namespace
- [ ] Verify secret syncs from 1Password
- [ ] Verify personal pod can authenticate to Anthropic API

🤖 Generated with [Claude Code](https://claude.com/claude-code)