### PR TITLE
fix(openclaw): allow egress to SigNoz OTEL collector

### DIFF
--- a/overlays/prod/openclaw-friends/values.yaml
+++ b/overlays/prod/openclaw-friends/values.yaml
@@ -100,3 +100,15 @@ networkPolicy:
           port: 3000   # Perplexica API
         - protocol: TCP
           port: 8080   # SearXNG API
+    ## SigNoz OTEL collector (telemetry)
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: signoz
+      podSelector:
+        matchLabels:
+          app.kubernetes.io/component: otel-collector
+      ports:
+        - protocol: TCP
+          port: 4317   # OTLP gRPC
+        - protocol: TCP
+          port: 4318   # OTLP HTTP


### PR DESCRIPTION
## Summary
- Add network policy egress rule to allow openclaw-friends to send OpenTelemetry data to SigNoz
- Allows ports 4317 (OTLP gRPC) and 4318 (OTLP HTTP) to the signoz-otel-collector pod

## Test plan
- [ ] Verify ArgoCD syncs the network policy change
- [ ] Confirm openclaw-friends can send telemetry to SigNoz
- [ ] Check SigNoz UI for incoming traces/metrics from OpenClaw

🤖 Generated with [Claude Code](https://claude.com/claude-code)