### PR TITLE
feat(vllm): switch to Qwen3 instruct model for chat assistant

### DIFF
--- a/overlays/prod/openclaw-friends/values.yaml
+++ b/overlays/prod/openclaw-friends/values.yaml
@@ -10,7 +10,7 @@ podAnnotations:
 ## LLM: Local Qwen via vLLM
 llm:
   provider: "openai-compatible"
-  model: "Qwen/Qwen2.5-Coder-32B-Instruct"
+  model: "Qwen/Qwen3-30B-A3B-Instruct-2507-AWQ"
   ## Use the vLLM router service (port 80, not 8000)
   baseUrl: "http://vllm-router-service.vllm.svc.cluster.local:80/v1"
   vllm:

--- a/overlays/prod/vllm/values.yaml
+++ b/overlays/prod/vllm/values.yaml
@@ -33,13 +33,13 @@ vllm-stack:
       failureThreshold: 3
 
     modelSpec:
-      - name: "qwen3-coder-30b"
+      - name: "qwen3-30b-instruct"
         # Standard vLLM image (no LMCache)
         repository: "vllm/vllm-openai"
         tag: "latest@sha256:014a95f21c9edf6abe0aea6b07353f96baa4ec291c427bb1176dc7c93a85845c"
         imagePullPolicy: IfNotPresent
-        # Qwen3-Coder 30B with AWQ 4-bit quantization
-        modelURL: "cpatonn/Qwen3-Coder-30B-A3B-Instruct-AWQ-4bit"
+        # Qwen3 30B Instruct with AWQ quantization (general-purpose, better for chat)
+        modelURL: "Qwen/Qwen3-30B-A3B-Instruct-2507-AWQ"
         replicaCount: 1
 
         # HuggingFace token from 1Password secret
@@ -91,7 +91,7 @@ vllm-stack:
             - "15"  # Increased from 10GB to offload more to CPU RAM (we have 32Gi available)
             - "--enable-auto-tool-choice"   # Enable function/tool calling
             - "--tool-call-parser"
-            - "qwen3_coder"  # Use qwen3_coder parser for Qwen3-Coder models (not hermes)
+            - "hermes"  # Use hermes parser for general Qwen3 instruct models
             # Note: quantization auto-detected from model config (compressed-tensors)
 
         # Node affinity: schedule only on node-4 (GPU node with storage)


### PR DESCRIPTION
## Summary

- Switch vLLM from Qwen3-Coder to Qwen3 general instruct model
- Update tool-call parser from `qwen3_coder` to `hermes`
- Update openclaw-friends model reference

## Rationale

The Qwen3-Coder model is optimized for code generation tasks. Since openclaw-friends is a Discord chat assistant (not a coding assistant), the general-purpose Qwen3 instruct model should provide more natural conversational responses.

## Changes

| Component | Before | After |
|-----------|--------|-------|
| vLLM model | `cpatonn/Qwen3-Coder-30B-A3B-Instruct-AWQ-4bit` | `Qwen/Qwen3-30B-A3B-Instruct-2507-AWQ` |
| Tool parser | `qwen3_coder` | `hermes` |
| OpenClaw model | `Qwen/Qwen2.5-Coder-32B-Instruct` | `Qwen/Qwen3-30B-A3B-Instruct-2507-AWQ` |

## Test plan

- [ ] vLLM pod starts successfully with new model
- [ ] openclaw-friends can connect to vLLM
- [ ] Chat responses are more conversational/natural

🤖 Generated with [Claude Code](https://claude.com/claude-code)