### PR TITLE
fix(vllm): use correct HuggingFace model identifier

### DIFF
--- a/overlays/prod/openclaw-friends/values.yaml
+++ b/overlays/prod/openclaw-friends/values.yaml
@@ -10,7 +10,7 @@ podAnnotations:
 ## LLM: Local Qwen via vLLM
 llm:
   provider: "openai-compatible"
-  model: "Qwen/Qwen3-30B-A3B-Instruct-2507-AWQ"
+  model: "QuixiAI/Qwen3-30B-A3B-AWQ"
   ## Use the vLLM router service (port 80, not 8000)
   baseUrl: "http://vllm-router-service.vllm.svc.cluster.local:80/v1"
   vllm:

--- a/overlays/prod/vllm/values.yaml
+++ b/overlays/prod/vllm/values.yaml
@@ -39,7 +39,7 @@ vllm-stack:
         tag: "latest@sha256:014a95f21c9edf6abe0aea6b07353f96baa4ec291c427bb1176dc7c93a85845c"
         imagePullPolicy: IfNotPresent
         # Qwen3 30B Instruct with AWQ quantization (general-purpose, better for chat)
-        modelURL: "Qwen/Qwen3-30B-A3B-Instruct-2507-AWQ"
+        modelURL: "QuixiAI/Qwen3-30B-A3B-AWQ"
         replicaCount: 1
 
         # HuggingFace token from 1Password secret


### PR DESCRIPTION
## Summary

Fix the HuggingFace model identifier that was merged in #343. The model `Qwen/Qwen3-30B-A3B-Instruct-2507-AWQ` doesn't exist.

## Changes

| File | Before | After |
|------|--------|-------|
| vLLM | `Qwen/Qwen3-30B-A3B-Instruct-2507-AWQ` | `QuixiAI/Qwen3-30B-A3B-AWQ` |
| OpenClaw | `Qwen/Qwen3-30B-A3B-Instruct-2507-AWQ` | `QuixiAI/Qwen3-30B-A3B-AWQ` |

## Test plan

- [ ] vLLM pod starts successfully and downloads the model

🤖 Generated with [Claude Code](https://claude.com/claude-code)