### PR TITLE
fix(stargazer): remove empty env array to prevent ArgoCD drift

### DIFF
--- a/charts/stargazer/templates/deployment-api.yaml
+++ b/charts/stargazer/templates/deployment-api.yaml
@@ -37,7 +37,6 @@ spec:
           {{- toYaml .Values.api.securityContext | nindent 10 }}
         image: "nginxinc/nginx-unprivileged:alpine"
         imagePullPolicy: IfNotPresent
-        env: []
         ports:
         - name: http
           containerPort: 8080


### PR DESCRIPTION
## Summary
- Removes the explicit `env: []` declaration from the stargazer API deployment template
- Fixes persistent ArgoCD drift caused by Kyverno OTEL injection

## Problem
The stargazer API deployment had an explicit `env: []` in the pod template. When Kyverno's `inject-otel-env-vars` policy mutates the pod at runtime to add OTEL environment variables, ArgoCD detects a diff between:
- **Git manifest**: `env: []` (empty array)
- **Live state**: `env: [OTEL_EXPORTER_OTLP_ENDPOINT, OTEL_EXPORTER_OTLP_PROTOCOL]`

This causes a persistent "OutOfSync" status in ArgoCD.

## Solution
Remove the `env: []` line entirely. When the env field is undefined in the template:
- Kyverno can still inject the environment variables
- ArgoCD doesn't see a diff because the field wasn't explicitly defined in Git
- The rendered manifest matches the mutated live state

## Test Plan
- [ ] ArgoCD sync shows the deployment as in-sync after this change
- [ ] Stargazer API pod still receives OTEL env vars from Kyverno
- [ ] No functional changes to the application

🤖 Generated with [Claude Code](https://claude.com/claude-code)