### PR TITLE
fix(models): use correct GHCR repository path

### DIFF
--- a/models/BUILD
+++ b/models/BUILD
@@ -62,16 +62,17 @@ bzl_library(
 # =============================================================================
 
 # GGUF variant - Qwen 2.5 0.5B Instruct quantized model
+# Repository auto-generated as ghcr.io/jomcgi/homelab/models/qwen2_5_0_5b_gguf
 model_oci_image(
     name = "qwen2_5_0_5b_gguf",
     srcs = ["@qwen2_5_0_5b_gguf//:model_files"],
     format = "gguf",
     model_dir = "/models/qwen2.5-0.5b",
-    repository = "ghcr.io/joemcginley/models/qwen2.5-0.5b-gguf",
     visibility = ["//visibility:public"],
 )
 
 # Safetensors variant - Qwen 2.5 0.5B Instruct full precision
+# Repository auto-generated as ghcr.io/jomcgi/homelab/models/qwen2_5_0_5b_st
 model_oci_image(
     name = "qwen2_5_0_5b_st",
     config_srcs = [
@@ -81,7 +82,6 @@ model_oci_image(
     ],
     format = "safetensors",
     model_dir = "/models/qwen2.5-0.5b",
-    repository = "ghcr.io/joemcginley/models/qwen2.5-0.5b-st",
     visibility = ["//visibility:public"],
     weight_srcs = ["@qwen2_5_0_5b_st//:model_safetensors"],
 )

--- a/models/internal/gguf.bzl
+++ b/models/internal/gguf.bzl
@@ -97,46 +97,48 @@ def gguf_image(
         visibility = visibility,
     )
 
-    # Create push target if repository is specified
-    if repository:
-        # Create stamped tags file for CI builds
-        expand_template(
-            name = name + "_stamped_tags_ci",
-            out = name + "_stamped_ci.tags.txt",
-            template = [
-                "{STABLE_BRANCH_TAG}",
-                "{STABLE_IMAGE_TAG}",
-            ],
-            stamp_substitutions = {
-                "{STABLE_BRANCH_TAG}": "{{STABLE_BRANCH_TAG}}",
-                "{STABLE_IMAGE_TAG}": "{{STABLE_IMAGE_TAG}}",
-            },
-            visibility = ["//visibility:private"],
-        )
+    # Auto-generate repository if not specified
+    if not repository:
+        repository = "ghcr.io/jomcgi/homelab/" + native.package_name() + "/" + name
 
-        # Create stamped tags file for local builds
-        expand_template(
-            name = name + "_stamped_tags_local",
-            out = name + "_stamped_local.tags.txt",
-            template = [
-                "{STABLE_IMAGE_TAG}",
-            ],
-            stamp_substitutions = {
-                "{STABLE_IMAGE_TAG}": "{{STABLE_IMAGE_TAG}}",
-            },
-            visibility = ["//visibility:private"],
-        )
+    # Create stamped tags file for CI builds
+    expand_template(
+        name = name + "_stamped_tags_ci",
+        out = name + "_stamped_ci.tags.txt",
+        template = [
+            "{STABLE_BRANCH_TAG}",
+            "{STABLE_IMAGE_TAG}",
+        ],
+        stamp_substitutions = {
+            "{STABLE_BRANCH_TAG}": "{{STABLE_BRANCH_TAG}}",
+            "{STABLE_IMAGE_TAG}": "{{STABLE_IMAGE_TAG}}",
+        },
+        visibility = ["//visibility:private"],
+    )
 
-        oci_push(
-            name = name + ".push",
-            image = name,
-            repository = repository,
-            remote_tags = select({
-                "//tools/oci:ci_build": name + "_stamped_tags_ci",
-                "//conditions:default": name + "_stamped_tags_local",
-            }),
-            visibility = visibility,
-        )
+    # Create stamped tags file for local builds
+    expand_template(
+        name = name + "_stamped_tags_local",
+        out = name + "_stamped_local.tags.txt",
+        template = [
+            "{STABLE_IMAGE_TAG}",
+        ],
+        stamp_substitutions = {
+            "{STABLE_IMAGE_TAG}": "{{STABLE_IMAGE_TAG}}",
+        },
+        visibility = ["//visibility:private"],
+    )
+
+    oci_push(
+        name = name + ".push",
+        image = name,
+        repository = repository,
+        remote_tags = select({
+            "//tools/oci:ci_build": name + "_stamped_tags_ci",
+            "//conditions:default": name + "_stamped_tags_local",
+        }),
+        visibility = visibility,
+    )
 
 def gguf_image_split(
         name,
@@ -226,41 +228,43 @@ def gguf_image_split(
         visibility = visibility,
     )
 
-    # Create push target if repository is specified
-    if repository:
-        expand_template(
-            name = name + "_stamped_tags_ci",
-            out = name + "_stamped_ci.tags.txt",
-            template = [
-                "{STABLE_BRANCH_TAG}",
-                "{STABLE_IMAGE_TAG}",
-            ],
-            stamp_substitutions = {
-                "{STABLE_BRANCH_TAG}": "{{STABLE_BRANCH_TAG}}",
-                "{STABLE_IMAGE_TAG}": "{{STABLE_IMAGE_TAG}}",
-            },
-            visibility = ["//visibility:private"],
-        )
+    # Auto-generate repository if not specified
+    if not repository:
+        repository = "ghcr.io/jomcgi/homelab/" + native.package_name() + "/" + name
 
-        expand_template(
-            name = name + "_stamped_tags_local",
-            out = name + "_stamped_local.tags.txt",
-            template = [
-                "{STABLE_IMAGE_TAG}",
-            ],
-            stamp_substitutions = {
-                "{STABLE_IMAGE_TAG}": "{{STABLE_IMAGE_TAG}}",
-            },
-            visibility = ["//visibility:private"],
-        )
+    expand_template(
+        name = name + "_stamped_tags_ci",
+        out = name + "_stamped_ci.tags.txt",
+        template = [
+            "{STABLE_BRANCH_TAG}",
+            "{STABLE_IMAGE_TAG}",
+        ],
+        stamp_substitutions = {
+            "{STABLE_BRANCH_TAG}": "{{STABLE_BRANCH_TAG}}",
+            "{STABLE_IMAGE_TAG}": "{{STABLE_IMAGE_TAG}}",
+        },
+        visibility = ["//visibility:private"],
+    )
 
-        oci_push(
-            name = name + ".push",
-            image = name,
-            repository = repository,
-            remote_tags = select({
-                "//tools/oci:ci_build": name + "_stamped_tags_ci",
-                "//conditions:default": name + "_stamped_tags_local",
-            }),
-            visibility = visibility,
-        )
+    expand_template(
+        name = name + "_stamped_tags_local",
+        out = name + "_stamped_local.tags.txt",
+        template = [
+            "{STABLE_IMAGE_TAG}",
+        ],
+        stamp_substitutions = {
+            "{STABLE_IMAGE_TAG}": "{{STABLE_IMAGE_TAG}}",
+        },
+        visibility = ["//visibility:private"],
+    )
+
+    oci_push(
+        name = name + ".push",
+        image = name,
+        repository = repository,
+        remote_tags = select({
+            "//tools/oci:ci_build": name + "_stamped_tags_ci",
+            "//conditions:default": name + "_stamped_tags_local",
+        }),
+        visibility = visibility,
+    )

--- a/models/internal/safetensors.bzl
+++ b/models/internal/safetensors.bzl
@@ -148,43 +148,45 @@ def safetensors_image(
         visibility = visibility,
     )
 
-    # Create push target if repository is specified
-    if repository:
-        # Create stamped tags file for CI builds
-        expand_template(
-            name = name + "_stamped_tags_ci",
-            out = name + "_stamped_ci.tags.txt",
-            template = [
-                "{STABLE_BRANCH_TAG}",
-                "{STABLE_IMAGE_TAG}",
-            ],
-            stamp_substitutions = {
-                "{STABLE_BRANCH_TAG}": "{{STABLE_BRANCH_TAG}}",
-                "{STABLE_IMAGE_TAG}": "{{STABLE_IMAGE_TAG}}",
-            },
-            visibility = ["//visibility:private"],
-        )
+    # Auto-generate repository if not specified
+    if not repository:
+        repository = "ghcr.io/jomcgi/homelab/" + native.package_name() + "/" + name
 
-        # Create stamped tags file for local builds
-        expand_template(
-            name = name + "_stamped_tags_local",
-            out = name + "_stamped_local.tags.txt",
-            template = [
-                "{STABLE_IMAGE_TAG}",
-            ],
-            stamp_substitutions = {
-                "{STABLE_IMAGE_TAG}": "{{STABLE_IMAGE_TAG}}",
-            },
-            visibility = ["//visibility:private"],
-        )
+    # Create stamped tags file for CI builds
+    expand_template(
+        name = name + "_stamped_tags_ci",
+        out = name + "_stamped_ci.tags.txt",
+        template = [
+            "{STABLE_BRANCH_TAG}",
+            "{STABLE_IMAGE_TAG}",
+        ],
+        stamp_substitutions = {
+            "{STABLE_BRANCH_TAG}": "{{STABLE_BRANCH_TAG}}",
+            "{STABLE_IMAGE_TAG}": "{{STABLE_IMAGE_TAG}}",
+        },
+        visibility = ["//visibility:private"],
+    )
 
-        oci_push(
-            name = name + ".push",
-            image = name,
-            repository = repository,
-            remote_tags = select({
-                "//tools/oci:ci_build": name + "_stamped_tags_ci",
-                "//conditions:default": name + "_stamped_tags_local",
-            }),
-            visibility = visibility,
-        )
+    # Create stamped tags file for local builds
+    expand_template(
+        name = name + "_stamped_tags_local",
+        out = name + "_stamped_local.tags.txt",
+        template = [
+            "{STABLE_IMAGE_TAG}",
+        ],
+        stamp_substitutions = {
+            "{STABLE_IMAGE_TAG}": "{{STABLE_IMAGE_TAG}}",
+        },
+        visibility = ["//visibility:private"],
+    )
+
+    oci_push(
+        name = name + ".push",
+        image = name,
+        repository = repository,
+        remote_tags = select({
+            "//tools/oci:ci_build": name + "_stamped_tags_ci",
+            "//conditions:default": name + "_stamped_tags_local",
+        }),
+        visibility = visibility,
+    )


### PR DESCRIPTION
## Summary

- Fix GHCR repository paths for model OCI images to use the homelab convention
- Changes `ghcr.io/joemcginley/models/...` → `ghcr.io/jomcgi/homelab/models/...`

## Problem

Push was failing with:
```
Error: POST https://ghcr.io/v2/joemcginley/models/qwen2.5-0.5b-gguf/blobs/uploads/: DENIED: permission_denied: create_package
```

GitHub packages require the repository path to match the GitHub repo structure for proper authentication.

## Test plan

- [ ] `bazel run //models:qwen2_5_0_5b_gguf.push` succeeds
- [ ] `bazel run //models:qwen2_5_0_5b_st.push` succeeds

🤖 Generated with [Claude Code](https://claude.ai/code)