### PR TITLE
feat(todo): add favicons for todo and todo-admin sites

### DIFF
--- a/charts/todo/static/edit.html
+++ b/charts/todo/static/edit.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>TODO - Edit</title>
+  <link rel="icon" type="image/svg+xml" href="/favicon-admin.svg" />
   <style>
     :root {
       --base: #eff1f5;

--- a/charts/todo/static/favicon-admin.svg
+++ b/charts/todo/static/favicon-admin.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <!-- Clean bold checkbox with red background -->
+  <rect x="48" y="48" width="416" height="416" fill="#d20f39" stroke="black" stroke-width="48"/>
+
+  <!-- Bold checkmark -->
+  <polyline points="128,272 208,352 384,160"
+            fill="none"
+            stroke="black"
+            stroke-width="72"
+            stroke-linecap="square"
+            stroke-linejoin="miter"/>
+</svg>

--- a/charts/todo/static/favicon.svg
+++ b/charts/todo/static/favicon.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <!-- Clean bold checkbox -->
+  <rect x="48" y="48" width="416" height="416" fill="white" stroke="black" stroke-width="48"/>
+
+  <!-- Bold checkmark -->
+  <polyline points="128,272 208,352 384,160"
+            fill="none"
+            stroke="black"
+            stroke-width="72"
+            stroke-linecap="square"
+            stroke-linejoin="miter"/>
+</svg>

--- a/charts/todo/static/index.html
+++ b/charts/todo/static/index.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>TODO</title>
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   <style>
     :root {
       --base: #eff1f5;


### PR DESCRIPTION
## Summary
- Add checkbox SVG favicon for todo.jomcgi.dev (white background)
- Add checkbox SVG favicon for todo-admin.jomcgi.dev (red background)
- Update HTML files to reference the favicons

## Test plan
- [ ] Verify favicon appears on todo.jomcgi.dev (white checkbox)
- [ ] Verify favicon appears on todo-admin.jomcgi.dev (red checkbox)

🤖 Generated with [Claude Code](https://claude.com/claude-code)