### PR TITLE
fix(models): exclude large models from CI push_all to prevent cache eviction

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -27,6 +27,18 @@ common --experimental_repository_cache_hardlinks
 # CI: Use default repository cache location (ephemeral per-runner)
 # Longhorn RWX volumes have I/O errors, BuildBuddy handles remote caching
 
+# =============================================================================
+# Remote Cache Control - Handle large artifacts
+# =============================================================================
+# Disable remote caching for ALL Tar operations in CI builds (--config=ci)
+# This prevents BuildBuddy cache eviction failures caused by large ML model
+# tarballs (5GB+ weight files) that exceed cache retention limits.
+#
+# Trade-off: ALL pkg_tar operations skip remote cache in CI, not just large
+# models. However, small tarballs build quickly enough that the performance
+# impact is negligible. Local (non-CI) builds still benefit from Tar caching.
+build:ci --modify_execution_info=Tar=+no-remote-cache
+
 # rules_python is working to enable this default to avoid dependency on a system interpreter
 # See https://github.com/bazel-contrib/rules_python/issues/3187
 # NB: some tools run py_binary targets even if the user didn't select to add Python to their project

--- a/CACHE_EVICTION_FIX.md
+++ b/CACHE_EVICTION_FIX.md
@@ -1,0 +1,111 @@
+# Fix: BuildBuddy Remote Cache Eviction for Large Models
+
+## Problem
+
+CI builds were failing with:
+```
+ERROR: remote cache evicted: Lost inputs no longer available remotely:
+models/qwen3_30b_a3b_awq_amd64/blobs/sha256/181ab3a... (5GB+)
+```
+
+### Root Cause
+
+The Qwen3-30B-A3B-AWQ model has 4 safetensors weight files (~5GB each, ~16GB total).
+When packaged as an OCI image:
+- Each weight file creates a separate layer (for efficient caching)
+- Layers are built for both amd64 and arm64 platforms
+- This creates ~8 large OCI layer blobs in BuildBuddy's remote cache
+- BuildBuddy evicts large blobs due to LRU cache policies
+- CI fails when trying to build/push the model and cached layers are missing
+
+## Solution
+
+**Exclude large models from `//images:push_all` in CI.**
+
+### Changes Made
+
+1. **Tagged qwen3 model as "manual"** (`models/BUILD`)
+   - Prevents accidental inclusion in bulk operations
+   - Model can still be pushed manually: `bazel run //models:qwen3_30b_a3b_awq.push`
+
+2. **Added tag support to model packaging rules** (`models/internal/*.bzl`)
+   - `safetensors_image()` and `gguf_image()` now accept `tags` parameter
+   - Tags propagate to all generated targets (oci_image, oci_push, pkg_tar, etc.)
+
+3. **Disabled remote cache for Tar actions in CI** (`.bazelrc`)
+   - Added `build:ci --modify_execution_info=Tar=+no-remote-cache`
+   - Prevents remote cache eviction for ALL Tar operations during CI builds
+   - Local builds still benefit from Tar caching
+
+4. **Excluded large models from push_all** (`scripts/generate-push-all.sh`)
+   - Added grep filter to exclude qwen3_30b_a3b_awq.push
+   - Small models (<1GB) continue to push in CI without issues
+
+5. **Regenerated images/BUILD**
+   - push_all now contains 12 targets instead of 13
+   - qwen3 model excluded
+
+### Trade-offs
+
+**Before:** All models pushed in CI, but large model failures blocked entire pipeline
+
+**After:**
+- Small models (<1GB): Push in CI automatically ✅
+- Large models (>1GB): Push manually when needed ✅
+- CI unblocked from cache eviction issues ✅
+
+### Manual Push Workflow for Large Models
+
+When you need to push the qwen3 model:
+
+```bash
+# Build and push manually
+bazel run //models:qwen3_30b_a3b_awq.push
+
+# Or via local development (uses local Bazel cache, no remote cache issues)
+```
+
+## Long-term Solutions (Future Work)
+
+1. **Hybrid storage approach** (recommended by cache-researcher agent):
+   - Store model configs/metadata in OCI images (Bazel-built)
+   - Store large weight files in GHCR or object storage
+   - Download weights at container runtime via init container
+
+2. **Increase BuildBuddy cache retention**:
+   - Configure larger cache size (100GB+ instead of default)
+   - Longer TTL for large artifacts
+   - Enable compression for network efficiency
+
+3. **Use --distdir for CI**:
+   - Pre-populate large model files in shared storage
+   - BuildBuddy runners mount this directory
+   - Avoids re-downloads and cache eviction
+
+## Testing
+
+Verify the fix:
+
+```bash
+# Check that push_all excludes qwen3 by inspecting generated BUILD file
+grep qwen images/BUILD
+
+# Should see:
+#   "//models:qwen2_5_0_5b_gguf.push",
+#   "//models:qwen2_5_0_5b_st.push",
+# But NOT:
+#   "//models:qwen3_30b_a3b_awq.push",
+
+# Verify qwen3 can still be pushed manually
+bazel run //models:qwen3_30b_a3b_awq.push --config=ci
+
+# Verify Tar operations skip remote cache in CI
+bazel build //models:qwen3_30b_a3b_awq --config=ci --explain=explain.log
+grep "no-remote-cache" explain.log
+```
+
+## References
+
+- BuildBuddy invocation: https://app.buildbuddy.io/invocation/872ceb0e-5151-46ff-9e0e-830b5b306c7c
+- Original error: Remote cache evicted 5GB+ OCI layer blobs
+- Related PR: #357 (added qwen3 model originally)

--- a/images/BUILD
+++ b/images/BUILD
@@ -12,7 +12,6 @@ multirun(
         "//charts/todo/image:image.push",
         "//models:qwen2_5_0_5b_gguf.push",
         "//models:qwen2_5_0_5b_st.push",
-        "//models:qwen3_30b_a3b_awq.push",
         "//operators/cloudflare:image.push",
         "//services/ais_ingest:image.push",
         "//services/hikes/update_forecast:update_image.push",

--- a/models/BUILD
+++ b/models/BUILD
@@ -86,8 +86,21 @@ model_oci_image(
     weight_srcs = ["@qwen2_5_0_5b_st//:model_safetensors"],
 )
 
-# Qwen3 30B A3B AWQ - Production vLLM model
+# Qwen3 30B A3B AWQ - Production vLLM model (~16GB total)
 # Repository auto-generated as ghcr.io/jomcgi/homelab/models/qwen3_30b_a3b_awq
+#
+# IMPORTANT: Large models (4 × ~5GB weight files) exceed BuildBuddy's cache limits.
+# Remote caching is disabled for ALL Tar operations in CI via .bazelrc setting:
+#   build:ci --modify_execution_info=Tar=+no-remote-cache
+# The no-remote-cache tag below is for documentation only; see .bazelrc for the
+# actual mechanism that prevents cache eviction. Local builds still use Tar caching.
+#
+# NOTE: Also tagged "manual" to exclude from //images:push_all (via grep filter
+# in scripts/generate-push-all.sh) to prevent BuildBuddy cache eviction failures
+# that would block the entire CI pipeline.
+#
+# The model can be built and pushed manually via:
+#   bazel run //models:qwen3_30b_a3b_awq.push
 model_oci_image(
     name = "qwen3_30b_a3b_awq",
     config_srcs = [
@@ -99,6 +112,10 @@ model_oci_image(
     ],
     format = "safetensors",
     model_dir = "/models/qwen3-30b-a3b-awq",
+    tags = [
+        "manual",  # Exclude from //images:push_all (via grep filter) to prevent cache eviction
+        "no-remote-cache",  # Documentary: documents large files (actual caching control via .bazelrc)
+    ],
     visibility = ["//visibility:public"],
     weight_srcs = [
         "@qwen3_30b_a3b_awq//:model_00001_of_00004_safetensors",

--- a/models/internal/gguf.bzl
+++ b/models/internal/gguf.bzl
@@ -14,7 +14,8 @@ def gguf_image(
         model_dir = "/models",
         base = "@empty_base",
         repository = None,
-        visibility = None):
+        visibility = None,
+        tags = None):
     """Package GGUF model files as an OCI image.
 
     Creates a multi-platform OCI image containing GGUF model files, suitable for
@@ -32,6 +33,12 @@ def gguf_image(
                     (e.g., "ghcr.io/org/models/my-model").
                     Required for push target.
         visibility: Visibility for the generated targets.
+        tags: Optional list of tags to apply to all generated targets.
+              NOTE: The "no-remote-cache" tag is for documentation only and does
+              NOT directly control caching. Actual remote cache exclusion is
+              enforced via .bazelrc (--modify_execution_info=Tar=+no-remote-cache)
+              which applies to ALL Tar actions in CI builds regardless of tags.
+              Use this tag to document models with large files (>1GB).
 
     Creates:
         :{name} - The multi-platform oci_image_index target
@@ -57,6 +64,9 @@ def gguf_image(
         model_dir = "/" + model_dir
     model_dir = model_dir.rstrip("/")
 
+    # Propagate tags to all generated targets
+    tags = tags or []
+
     # Create tar layers for model files
     # Using pkg_tar to place files at the correct mount path
     tar_layers = []
@@ -67,6 +77,7 @@ def gguf_image(
         srcs = srcs,
         package_dir = model_dir,
         mode = "0644",
+        tags = tags,  # Propagate tags to child targets
         visibility = ["//visibility:private"],
     )
     tar_layers.append(name + "_model_layer")
@@ -77,6 +88,7 @@ def gguf_image(
         name = name + "_amd64",
         base = base + "_linux_amd64",
         tars = tar_layers,
+        tags = tags,
         visibility = ["//visibility:private"],
     )
 
@@ -84,6 +96,7 @@ def gguf_image(
         name = name + "_arm64",
         base = base + "_linux_arm64_v8",
         tars = tar_layers,
+        tags = tags,
         visibility = ["//visibility:private"],
     )
 
@@ -94,6 +107,7 @@ def gguf_image(
             name + "_amd64",
             name + "_arm64",
         ],
+        tags = tags,
         visibility = visibility,
     )
 
@@ -137,6 +151,7 @@ def gguf_image(
             "//tools/oci:ci_build": name + "_stamped_tags_ci",
             "//conditions:default": name + "_stamped_tags_local",
         }),
+        tags = tags,
         visibility = visibility,
     )
 
@@ -146,7 +161,8 @@ def gguf_image_split(
         model_dir = "/models",
         base = "@empty_base",
         repository = None,
-        visibility = None):
+        visibility = None,
+        tags = None):
     """Package GGUF model files as an OCI image with one layer per file.
 
     Similar to gguf_image but creates a separate layer for each source file.
@@ -190,6 +206,9 @@ def gguf_image_split(
         model_dir = "/" + model_dir
     model_dir = model_dir.rstrip("/")
 
+    # Propagate tags to all generated targets
+    tags = tags or []
+
     # Create individual tar layers for each source file
     tar_layers = []
     for i, src in enumerate(srcs):
@@ -199,6 +218,7 @@ def gguf_image_split(
             srcs = [src],
             package_dir = model_dir,
             mode = "0644",
+            tags = tags,  # Propagate tags to child targets
             visibility = ["//visibility:private"],
         )
         tar_layers.append(layer_name)
@@ -208,6 +228,7 @@ def gguf_image_split(
         name = name + "_amd64",
         base = base + "_linux_amd64",
         tars = tar_layers,
+        tags = tags,
         visibility = ["//visibility:private"],
     )
 
@@ -215,6 +236,7 @@ def gguf_image_split(
         name = name + "_arm64",
         base = base + "_linux_arm64_v8",
         tars = tar_layers,
+        tags = tags,
         visibility = ["//visibility:private"],
     )
 
@@ -225,6 +247,7 @@ def gguf_image_split(
             name + "_amd64",
             name + "_arm64",
         ],
+        tags = tags,
         visibility = visibility,
     )
 
@@ -266,5 +289,6 @@ def gguf_image_split(
             "//tools/oci:ci_build": name + "_stamped_tags_ci",
             "//conditions:default": name + "_stamped_tags_local",
         }),
+        tags = tags,
         visibility = visibility,
     )

--- a/models/internal/safetensors.bzl
+++ b/models/internal/safetensors.bzl
@@ -22,7 +22,8 @@ def safetensors_image(
         model_dir = "/models",
         base = "@empty_base",
         repository = None,
-        visibility = None):
+        visibility = None,
+        tags = None):
     """Package Safetensors model files as an OCI image.
 
     Creates a multi-platform OCI image containing Safetensors model files with
@@ -46,6 +47,12 @@ def safetensors_image(
                     (e.g., "ghcr.io/org/models/my-model").
                     Required for push target.
         visibility: Visibility for the generated targets.
+        tags: Optional list of tags to apply to all generated targets.
+              NOTE: The "no-remote-cache" tag is for documentation only and does
+              NOT directly control caching. Actual remote cache exclusion is
+              enforced via .bazelrc (--modify_execution_info=Tar=+no-remote-cache)
+              which applies to ALL Tar actions in CI builds regardless of tags.
+              Use this tag to document models with large files (>1GB).
 
     Creates:
         :{name} - The multi-platform oci_image_index target
@@ -98,6 +105,9 @@ def safetensors_image(
     # Build tar layers in order: config layer first (bottom), then weight layers (top)
     tar_layers = []
 
+    # Propagate tags to all generated targets
+    tags = tags or []
+
     # Create config layer if config_srcs provided
     if config_srcs:
         pkg_tar(
@@ -105,6 +115,7 @@ def safetensors_image(
             srcs = config_srcs,
             package_dir = model_dir,
             mode = "0644",
+            tags = tags,  # Propagate tags to child targets
             visibility = ["//visibility:private"],
         )
         tar_layers.append(name + "_config_layer")
@@ -118,6 +129,7 @@ def safetensors_image(
             srcs = [src],
             package_dir = model_dir,
             mode = "0644",
+            tags = tags,  # Propagate tags to child targets
             visibility = ["//visibility:private"],
         )
         tar_layers.append(layer_name)
@@ -128,6 +140,7 @@ def safetensors_image(
         name = name + "_amd64",
         base = base + "_linux_amd64",
         tars = tar_layers,
+        tags = tags,
         visibility = ["//visibility:private"],
     )
 
@@ -135,6 +148,7 @@ def safetensors_image(
         name = name + "_arm64",
         base = base + "_linux_arm64_v8",
         tars = tar_layers,
+        tags = tags,
         visibility = ["//visibility:private"],
     )
 
@@ -145,6 +159,7 @@ def safetensors_image(
             name + "_amd64",
             name + "_arm64",
         ],
+        tags = tags,
         visibility = visibility,
     )
 
@@ -188,5 +203,6 @@ def safetensors_image(
             "//tools/oci:ci_build": name + "_stamped_tags_ci",
             "//conditions:default": name + "_stamped_tags_local",
         }),
+        tags = tags,
         visibility = visibility,
     )

--- a/scripts/generate-push-all.sh
+++ b/scripts/generate-push-all.sh
@@ -9,7 +9,15 @@ fi
 
 BUILD_FILE="images/BUILD"
 
+# Query all oci_push targets
 PUSH_TARGETS=$(bazel query 'kind("oci_push", //...)' --output label 2>/dev/null | sort)
+
+# Exclude large models tagged "manual" (e.g., qwen3_30b_a3b_awq)
+# These can be pushed individually but won't be included in push_all to prevent
+# CI failures from BuildBuddy remote cache eviction of large model layers.
+# Note: Using grep instead of Bazel query's attr("tags", "manual", ...) because
+# tags don't propagate reliably through macro-generated targets in queries.
+PUSH_TARGETS=$(echo "$PUSH_TARGETS" | grep -v "qwen3_30b_a3b_awq")
 
 if [ -z "$PUSH_TARGETS" ]; then
 	echo "⚠️  No oci_push targets found"


### PR DESCRIPTION
## Fix: BuildBuddy Remote Cache Eviction for Large Models

### Problem

BuildBuddy CI builds were failing with remote cache eviction errors:

```
ERROR: remote cache evicted: Lost inputs no longer available remotely:
models/qwen3_30b_a3b_awq_amd64/blobs/sha256/181ab3a... (~5GB blobs)
```

**Root cause:** The Qwen3-30B-A3B-AWQ model contains 4 safetensors weight files (~5GB each, ~16GB total). When packaged as an OCI image:
- Each weight file creates a separate layer (for efficient caching)
- Layers are built for both amd64 and arm64 platforms (~8 large blobs total)
- BuildBuddy's LRU cache policy evicts these 5GB+ blobs to stay within retention limits
- Subsequent CI builds fail when trying to reuse cached tar operations that reference evicted blobs

### Solution

Use a multi-layered approach to prevent cache eviction failures while maintaining flexibility:

1. **Tag qwen3 model as "no-remote-cache"** - Documents intent to exclude from remote cache
2. **Configure .bazelrc with --modify_execution_info** - Enforces local-only caching for tar operations
3. **Exclude large models from CI push_all** - Prevents CI from building/pushing large models automatically

#### How --modify_execution_info Works

In `.bazelrc:29-38`:
```bazel
# Disable remote caching for ALL Tar operations in CI builds (--config=ci)
# This prevents BuildBuddy cache eviction failures caused by large ML model
# tarballs (5GB+ weight files) that exceed cache retention limits.
#
# Trade-off: ALL pkg_tar operations skip remote cache in CI, not just large
# models. However, small tarballs build quickly enough that the performance
# impact is negligible. Local (non-CI) builds still benefit from Tar caching.
build:ci --modify_execution_info=Tar=+no-remote-cache
```

The `--modify_execution_info` flag modifies the execution requirements for actions:
- `Tar=+no-remote-cache` adds the "no-remote-cache" requirement to all actions with mnemonic "Tar"
- The `+` prefix means "add this requirement" (vs `=` which replaces all requirements)
- This flag only applies when using `--config=ci`, so local builds are unaffected
- pkg_tar rules (used by OCI image packaging) generate "Tar" mnemonic actions

**Note:** The "no-remote-cache" tag on the model target documents the intent but doesn't control behavior. The actual enforcement happens via .bazelrc configuration.

### Changed Files

| File | Purpose |
|------|---------|
| `.bazelrc` | Added `--modify_execution_info=Tar=+no-remote-cache` for CI builds to prevent remote caching of tar operations |
| `CACHE_EVICTION_FIX.md` | Detailed documentation of problem, solution, trade-offs, and future work |
| `models/BUILD` | Tagged qwen3_30b_a3b_awq with "no-remote-cache" (documents intent) and "manual" (excludes from push_all) |
| `models/internal/safetensors.bzl` | Added `tags` parameter support to safetensors_image() macro with propagation to all child targets |
| `models/internal/gguf.bzl` | Added `tags` parameter support to gguf_image() macro with propagation to all child targets |
| `scripts/generate-push-all.sh` | Added filter to exclude qwen3_30b_a3b_awq from generated push_all target |
| `images/BUILD` | Regenerated push_all target (12 targets instead of 13, qwen3 excluded) |

### Trade-offs

✅ **Small models (<1GB):** Push automatically in CI
✅ **Large models (>1GB):** Push manually when needed
✅ **CI pipeline:** Unblocked from cache eviction failures
✅ **Local builds:** Still benefit from local tar caching
⚠️ **CI builds:** ALL Tar operations are local-only (no remote cache reuse for any pkg_tar)

The last trade-off is acceptable because:
- Small model tarballs build quickly (seconds)
- The performance impact is negligible compared to build failures
- Local development still benefits from full remote caching

### Testing & Verification

```bash
# Verify qwen3 excluded from push_all
grep qwen images/BUILD
# Should show: qwen2_5_0_5b_gguf.push, qwen2_5_0_5b_st.push
# Should NOT show: qwen3_30b_a3b_awq.push

# Verify manual push still works
bazel run //models:qwen3_30b_a3b_awq.push --config=ci

# Verify .bazelrc configuration is active
bazel build //models:qwen3_30b_a3b_awq --config=ci --announce_rc 2>&1 | grep modify_execution_info
# Should show: --modify_execution_info=Tar=+no-remote-cache

# Verify Tar operations skip remote cache
bazel build //models:qwen3_30b_a3b_awq --config=ci --explain=explain.log
grep "no-remote-cache" explain.log
```

### Manual Push Workflow for Large Models

When you need to push the qwen3 model:

```bash
# Build and push manually (uses local Bazel cache, no remote cache issues)
bazel run //models:qwen3_30b_a3b_awq.push
```

### Long-term Solutions (Future Work)

See `CACHE_EVICTION_FIX.md` for detailed discussion of:
1. **Hybrid storage approach** - Store metadata in OCI, weights in object storage
2. **Increase BuildBuddy cache retention** - Configure larger cache size/TTL
3. **Use --distdir for CI** - Pre-populate large files in shared storage

### References

- BuildBuddy failure: https://app.buildbuddy.io/invocation/872ceb0e-5151-46ff-9e0e-830b5b306c7c
- Original model PR: #357
