### PR TITLE
feat(todo): add pod affinity to reduce volume reattachment delays

### DIFF
--- a/charts/todo/templates/deployment.yaml
+++ b/charts/todo/templates/deployment.yaml
@@ -20,6 +20,10 @@ spec:
       imagePullSecrets:
         - name: ghcr-imagepull-secret
       {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       # TODO: Add pod security context (runAsNonRoot, seccompProfile)
       # Blocked by: init container needs root to chown git repo for API user
       initContainers:

--- a/charts/todo/values.yaml
+++ b/charts/todo/values.yaml
@@ -57,4 +57,8 @@ resources:
       memory: "32Mi"
       cpu: "50m"
 
+# Pod affinity/anti-affinity rules
+# Useful for RWO volumes to keep pod on same node and avoid volume reattachment delays
+affinity: {}
+
 adminUrl: https://todo-admin.jomcgi.dev

--- a/overlays/prod/todo/values.yaml
+++ b/overlays/prod/todo/values.yaml
@@ -18,3 +18,14 @@ persistence:
 image:
   tag: main@sha256:0139d48406f2f313386eb6b34fb5fa080cbc61e6b9d22e9fc6d7fe4faa692261
   repository: ghcr.io/jomcgi/homelab/charts/todo
+# Prefer to schedule on the same node to avoid volume reattachment delays
+affinity:
+  podAffinity:
+    preferredDuringSchedulingIgnoredDuringExecution:
+    - weight: 100
+      podAffinityTerm:
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/name: todo
+            app.kubernetes.io/instance: todo
+        topologyKey: kubernetes.io/hostname


### PR DESCRIPTION
## Summary
- Add pod affinity to the todo app deployment to prefer scheduling on the same node
- Reduces Multi-Attach errors and volume reattachment delays for RWO volumes

## Changes
- ✅ Add affinity field support to deployment template
- ✅ Document affinity configuration in chart default values
- ✅ Configure pod affinity in prod overlay

## Why
When a pod with an RWO (ReadWriteOnce) volume is rescheduled to a different node, Longhorn needs to detach the volume from the old node and reattach it to the new node. This causes:
- Transient Multi-Attach errors
- 20-30 second delays during pod restarts
- Unnecessary volume migrations

With pod affinity, the scheduler will **prefer** (soft constraint) to place the pod on the same node where it was previously running, avoiding these delays in most cases.

## Test plan
- [x] Helm template renders correctly with affinity configuration
- [ ] Deploy to prod and verify pod affinity is applied
- [ ] Trigger pod restart and confirm it stays on the same node (when possible)
- [ ] Verify ArgoCD syncs successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)