### PR TITLE
fix(marine): use digest directly instead of appending to tag

### DIFF
--- a/charts/marine/templates/api-deployment.yaml
+++ b/charts/marine/templates/api-deployment.yaml
@@ -35,7 +35,7 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: api
-          image: "{{ .Values.api.image.repository }}:{{ .Values.api.image.tag }}{{ with .Values.api.image.digest }}@{{ . }}{{ end }}"
+          image: "{{ .Values.api.image.repository }}:{{ .Values.api.image.digest | default .Values.api.image.tag }}"
           imagePullPolicy: {{ .Values.api.image.pullPolicy }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
@@ -141,7 +141,7 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: api
-          image: "{{ .Values.api.image.repository }}:{{ .Values.api.image.tag }}{{ with .Values.api.image.digest }}@{{ . }}{{ end }}"
+          image: "{{ .Values.api.image.repository }}:{{ .Values.api.image.digest | default .Values.api.image.tag }}"
           imagePullPolicy: {{ .Values.api.image.pullPolicy }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}

--- a/charts/marine/templates/frontend-deployment.yaml
+++ b/charts/marine/templates/frontend-deployment.yaml
@@ -35,7 +35,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: frontend
-          image: "{{ .Values.frontend.image.repository }}:{{ .Values.frontend.image.tag }}{{ with .Values.frontend.image.digest }}@{{ . }}{{ end }}"
+          image: "{{ .Values.frontend.image.repository }}:{{ .Values.frontend.image.digest | default .Values.frontend.image.tag }}"
           imagePullPolicy: {{ .Values.frontend.image.pullPolicy }}
           securityContext:
             readOnlyRootFilesystem: false

--- a/charts/marine/templates/ingest-deployment.yaml
+++ b/charts/marine/templates/ingest-deployment.yaml
@@ -33,7 +33,7 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: ingest
-          image: "{{ .Values.ingest.image.repository }}:{{ .Values.ingest.image.tag }}{{ with .Values.ingest.image.digest }}@{{ . }}{{ end }}"
+          image: "{{ .Values.ingest.image.repository }}:{{ .Values.ingest.image.digest | default .Values.ingest.image.tag }}"
           imagePullPolicy: {{ .Values.ingest.image.pullPolicy }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}


### PR DESCRIPTION
## Summary

- Fix Helm image templates that produced invalid image references like `repo:main@main@sha256:abc...`
- The ArgoCD Image Updater writes `tag@sha256:digest` to the `digest` field, but the old template also prepended `:tag@`, duplicating the tag
- Changed all 4 image lines (api x2, ingest, frontend) from `repo:tag@digest` to `repo:(digest | default tag)`
- All three marine pods currently have `InvalidImageName` errors — this fix will resolve them on sync

## What was happening

```
# Old template
image: "{{ repo }}:{{ tag }}{{ with digest }}@{{ digest }}{{ end }}"
# Rendered: repo:main@main@sha256:abc...  ← BROKEN (tag duplicated)

# New template  
image: "{{ repo }}:{{ digest | default tag }}"
# Rendered: repo:main@sha256:abc...  ← CORRECT
```

## Test plan

- [x] `helm template` with dev overlay values — images render as `repo:tag@sha256:digest`
- [x] `helm template` with base values only (no digest) — images fall back to `repo:tag`
- [ ] ArgoCD syncs and pods start with valid image references

🤖 Generated with [Claude Code](https://claude.com/claude-code)