### PR TITLE
fix: prevent image tag duplication in marine chart templates

### DIFF
--- a/charts/marine/templates/api-deployment.yaml
+++ b/charts/marine/templates/api-deployment.yaml
@@ -35,7 +35,7 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: api
-          image: "{{ .Values.api.image.repository }}:{{ .Values.api.image.tag }}{{ with .Values.api.image.digest }}@{{ . }}{{ end }}"
+          image: "{{ .Values.api.image.repository }}:{{ .Values.api.image.digest | default .Values.api.image.tag }}"
           imagePullPolicy: {{ .Values.api.image.pullPolicy }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
@@ -141,7 +141,7 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: api
-          image: "{{ .Values.api.image.repository }}:{{ .Values.api.image.tag }}{{ with .Values.api.image.digest }}@{{ . }}{{ end }}"
+          image: "{{ .Values.api.image.repository }}:{{ .Values.api.image.digest | default .Values.api.image.tag }}"
           imagePullPolicy: {{ .Values.api.image.pullPolicy }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}

--- a/charts/marine/templates/frontend-deployment.yaml
+++ b/charts/marine/templates/frontend-deployment.yaml
@@ -35,7 +35,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: frontend
-          image: "{{ .Values.frontend.image.repository }}:{{ .Values.frontend.image.tag }}{{ with .Values.frontend.image.digest }}@{{ . }}{{ end }}"
+          image: "{{ .Values.frontend.image.repository }}:{{ .Values.frontend.image.digest | default .Values.frontend.image.tag }}"
           imagePullPolicy: {{ .Values.frontend.image.pullPolicy }}
           securityContext:
             readOnlyRootFilesystem: false

--- a/charts/marine/templates/ingest-deployment.yaml
+++ b/charts/marine/templates/ingest-deployment.yaml
@@ -33,7 +33,7 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: ingest
-          image: "{{ .Values.ingest.image.repository }}:{{ .Values.ingest.image.tag }}{{ with .Values.ingest.image.digest }}@{{ . }}{{ end }}"
+          image: "{{ .Values.ingest.image.repository }}:{{ .Values.ingest.image.digest | default .Values.ingest.image.tag }}"
           imagePullPolicy: {{ .Values.ingest.image.pullPolicy }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}


### PR DESCRIPTION
## Summary

- Fixes compounding `@main@main@main...` image tag duplication in marine deployments
- ArgoCD Image Updater writes `main@sha256:hash` to the `digest` field (includes tag), but the old template concatenated `:tag@digest`, producing `:main@main@sha256:...`
- Each Image Updater cycle read the mangled image back and compounded it further
- Changed template to `{{ .digest | default .tag }}` — uses digest directly when set, falls back to tag when empty

## Affected templates

- `charts/marine/templates/api-deployment.yaml` (2 occurrences — StatefulSet + Deployment)
- `charts/marine/templates/frontend-deployment.yaml`
- `charts/marine/templates/ingest-deployment.yaml`

## Rendered output (verified)

```
ghcr.io/jomcgi/homelab/services/ais_ingest:main@sha256:6c6a6bc...
ghcr.io/jomcgi/homelab/services/ships_api:main@sha256:af41b80...
ghcr.io/jomcgi/homelab/services/ships_frontend:main@sha256:18d7488...
```

## Test plan

- [x] `helm template` renders correct image references with dev values
- [ ] Verify pods pick up correct images after ArgoCD sync
- [ ] Confirm next Image Updater cycle does not re-corrupt digest values

🤖 Generated with [Claude Code](https://claude.com/claude-code)