### PR TITLE
fix(ci): use docker login for GHCR auth in image push

### DIFF
--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -66,7 +66,7 @@ actions:
           fi
 
           # GHCR_TOKEN set in BuildBuddy Settings → Secrets
-          echo "$GHCR_TOKEN" | bazel run @crane//:crane -- auth login ghcr.io -u jomcgi --password-stdin
+          echo "$GHCR_TOKEN" | docker login ghcr.io -u jomcgi --password-stdin
           bazel run //images:push_services --config=ci --stamp
 
   # GHCR Validation - validates pushed images without downloading blobs


### PR DESCRIPTION
## Summary

- Fixes the broken CI image push step from #369
- Replaces `bazel run @crane//:crane -- auth login` (which fails with "No repository visible as '@crane'") with `docker login` which was the original working approach
- `oci_push` reads credentials from `~/.docker/config.json` natively

## Context

The previous working version (before commit `26f756da`) used `docker login ghcr.io`. The `@crane` reference was incorrect — crane is registered as a toolchain (`@custom_crane_crane_toolchains`), not a runnable Bazel target.

## Test plan

- [ ] CI passes on this PR
- [ ] After merge, "Test and push" job successfully pushes service images on main
- [ ] Knowledge-graph pods exit ImagePullBackOff once images are available

🤖 Generated with [Claude Code](https://claude.com/claude-code)