### PR TITLE
fix: correct ingest image digest tag from latest to main

### DIFF
--- a/overlays/dev/marine/values.yaml
+++ b/overlays/dev/marine/values.yaml
@@ -11,7 +11,7 @@ ingest:
   image:
     repository: ghcr.io/jomcgi/homelab/services/ais_ingest
     tag: main
-    digest: latest@sha256:6c6a6bc57e6807f2c52a530dc2c1895679ae2511dcce819d70cc5da8102a5e13
+    digest: main@sha256:6c6a6bc57e6807f2c52a530dc2c1895679ae2511dcce819d70cc5da8102a5e13
     pullPolicy: Always
   # Pre-populate OTEL annotation to match Kyverno injection (prevents ArgoCD drift)
   podAnnotations:


### PR DESCRIPTION
## Summary

- Fixes corrupted ingest digest value written by Image Updater between template fix attempts
- Changes `latest@sha256:6c6a6bc...` → `main@sha256:6c6a6bc...` in `overlays/dev/marine/values.yaml`
- This is the data fix companion to #370 (template fix)

## Current cluster state

| Component | Status | Issue |
|-----------|--------|-------|
| ingest | Running | Image has `latest` tag prefix instead of `main` |
| api | InvalidImageName | StatefulSet pod stuck on old corrupted image spec |
| frontend | InvalidImageName / CrashLoopBackOff | Old ReplicaSet has corrupted image, new RS deploying |

Once merged, ArgoCD sync should fix ingest and trigger a StatefulSet rollout for api.

## Test plan

- [ ] Verify all three marine pods reach Running state after ArgoCD sync
- [ ] Confirm images use `main@sha256:...` format

🤖 Generated with [Claude Code](https://claude.com/claude-code)