### PR TITLE
fix(knowledge-graph): add runAsUser/runAsGroup to resolve CreateContainerConfigError

### DIFF
--- a/charts/knowledge-graph/templates/cronjob-embedder.yaml
+++ b/charts/knowledge-graph/templates/cronjob-embedder.yaml
@@ -30,6 +30,8 @@ spec:
           restartPolicy: OnFailure
           securityContext:
             runAsNonRoot: true
+            runAsUser: 65534
+            runAsGroup: 65534
             seccompProfile:
               type: RuntimeDefault
           containers:

--- a/charts/knowledge-graph/templates/cronjob-scrape.yaml
+++ b/charts/knowledge-graph/templates/cronjob-scrape.yaml
@@ -30,6 +30,8 @@ spec:
           restartPolicy: OnFailure
           securityContext:
             runAsNonRoot: true
+            runAsUser: 65534
+            runAsGroup: 65534
             seccompProfile:
               type: RuntimeDefault
           containers:

--- a/charts/knowledge-graph/templates/deployment-mcp.yaml
+++ b/charts/knowledge-graph/templates/deployment-mcp.yaml
@@ -24,6 +24,8 @@ spec:
       {{- end }}
       securityContext:
         runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
         seccompProfile:
           type: RuntimeDefault
       containers:

--- a/charts/knowledge-graph/templates/deployment-scraper.yaml
+++ b/charts/knowledge-graph/templates/deployment-scraper.yaml
@@ -26,6 +26,8 @@ spec:
       {{- end }}
       securityContext:
         runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
         seccompProfile:
           type: RuntimeDefault
       containers:


### PR DESCRIPTION
## Summary
- Both `knowledge-graph-mcp` and `knowledge-graph-scraper` pods are stuck in `CreateContainerConfigError` with: _"container has runAsNonRoot and image will run as root"_
- The Ubuntu-based Python images default to UID 0 (root), conflicting with `runAsNonRoot: true` in the pod security context
- Adds `runAsUser: 65534` and `runAsGroup: 65534` (nobody) to all 4 knowledge-graph templates (deployment-mcp, deployment-scraper, cronjob-scrape, cronjob-embedder), matching the pattern used by `signoz-dashboard-sidecar`

## Test plan
- [ ] Verify pods transition from `CreateContainerConfigError` to `Running` after ArgoCD sync
- [ ] Confirm health checks pass on both mcp and scraper deployments
- [ ] Verify cronjobs can execute successfully on next scheduled run

🤖 Generated with [Claude Code](https://claude.com/claude-code)