### PR TITLE
fix: correct ingest digest and force api StatefulSet rollout

### DIFF
--- a/overlays/dev/marine/values.yaml
+++ b/overlays/dev/marine/values.yaml
@@ -11,7 +11,7 @@ ingest:
   image:
     repository: ghcr.io/jomcgi/homelab/services/ais_ingest
     tag: main
-    digest: latest@sha256:6c6a6bc57e6807f2c52a530dc2c1895679ae2511dcce819d70cc5da8102a5e13
+    digest: main@sha256:6c6a6bc57e6807f2c52a530dc2c1895679ae2511dcce819d70cc5da8102a5e13
     pullPolicy: Always
   # Pre-populate OTEL annotation to match Kyverno injection (prevents ArgoCD drift)
   podAnnotations:
@@ -45,6 +45,7 @@ api:
   # Pre-populate OTEL annotation to match Kyverno injection (prevents ArgoCD drift)
   podAnnotations:
     otel.injected-by: kyverno/inject-otel-env-vars
+    kubectl.kubernetes.io/restartedAt: "2026-02-06T04:30:00Z"
 frontend:
   image:
     repository: ghcr.io/jomcgi/homelab/services/ships_frontend


### PR DESCRIPTION
## Summary

- Fix ingest digest tag from `latest@sha256:...` to `main@sha256:...` (corrupted by Image Updater between fix attempts)
- Add `restartedAt` annotation to api pod template to force StatefulSet rollout — pod stuck 47h on old corrupted image (`main@latest@sha256:...`) because controller revision already matches current spec

## Current cluster state

| Component | Status | Issue |
|-----------|--------|-------|
| ingest | Running | Has `latest` tag prefix instead of `main` |
| api | InvalidImageName (47h) | StatefulSet won't roll — `currentRevision == updateRevision` |
| frontend | Failing readiness | New RS correct but `/ready` returns 503 because api is down |

## Expected cascade after merge

1. ArgoCD syncs → ingest gets `main` tag prefix
2. `restartedAt` annotation creates new StatefulSet revision → old pod deleted → new pod with correct image
3. API comes up → frontend readiness probes pass → old ReplicaSet scales down

## Test plan

- [ ] All three marine pods reach Running/Ready state
- [ ] No `InvalidImageName` errors remain
- [ ] Images use clean `main@sha256:...` format

🤖 Generated with [Claude Code](https://claude.com/claude-code)