### PR TITLE
fix(knowledge-graph): allow root for aspect_rules_py venv compatibility

### DIFF
--- a/charts/knowledge-graph/templates/cronjob-embedder.yaml
+++ b/charts/knowledge-graph/templates/cronjob-embedder.yaml
@@ -29,9 +29,8 @@ spec:
           {{- end }}
           restartPolicy: OnFailure
           securityContext:
-            runAsNonRoot: true
-            runAsUser: 65534
-            runAsGroup: 65534
+            # Note: Running as root because aspect_rules_py venv needs to write
+            # to the installation directory. TODO: Fix image to run as non-root
             seccompProfile:
               type: RuntimeDefault
           containers:

--- a/charts/knowledge-graph/templates/cronjob-scrape.yaml
+++ b/charts/knowledge-graph/templates/cronjob-scrape.yaml
@@ -29,9 +29,8 @@ spec:
           {{- end }}
           restartPolicy: OnFailure
           securityContext:
-            runAsNonRoot: true
-            runAsUser: 65534
-            runAsGroup: 65534
+            # Note: Running as root because aspect_rules_py venv needs to write
+            # to the installation directory. TODO: Fix image to run as non-root
             seccompProfile:
               type: RuntimeDefault
           containers:

--- a/charts/knowledge-graph/templates/deployment-mcp.yaml
+++ b/charts/knowledge-graph/templates/deployment-mcp.yaml
@@ -23,9 +23,8 @@ spec:
         - name: ghcr-imagepull-secret
       {{- end }}
       securityContext:
-        runAsNonRoot: true
-        runAsUser: 65534
-        runAsGroup: 65534
+        # Note: Running as root because aspect_rules_py venv needs to write
+        # to the installation directory. TODO: Fix image to run as non-root
         seccompProfile:
           type: RuntimeDefault
       containers:

--- a/charts/knowledge-graph/templates/deployment-scraper.yaml
+++ b/charts/knowledge-graph/templates/deployment-scraper.yaml
@@ -25,9 +25,8 @@ spec:
         - name: ghcr-imagepull-secret
       {{- end }}
       securityContext:
-        runAsNonRoot: true
-        runAsUser: 65534
-        runAsGroup: 65534
+        # Note: Running as root because aspect_rules_py venv needs to write
+        # to the installation directory. TODO: Fix image to run as non-root
         seccompProfile:
           type: RuntimeDefault
       containers:


### PR DESCRIPTION
## Summary
- The previous fix (#373) resolved `CreateContainerConfigError` by adding `runAsUser: 65534`, but pods now crash with `CrashLoopBackOff`: _"Unable to create base venv directory - Permission denied"_
- `aspect_rules_py` creates a virtualenv at runtime in the binary's installation directory, which is root-owned in the image layers — a non-root user cannot write there
- This is the same issue hit by marine, trips, and ais-ingest services
- Removes `runAsNonRoot`, `runAsUser`, and `runAsGroup` constraints, matching the established pattern across other `py3_image`-based services
- Retains all other security constraints: `seccompProfile: RuntimeDefault`, `allowPrivilegeEscalation: false`, `capabilities.drop: ALL`

## Test plan
- [ ] Verify mcp and scraper pods transition to `Running` after ArgoCD sync
- [ ] Confirm health checks pass on `/health` endpoints
- [ ] Verify cronjobs can execute on next scheduled run

🤖 Generated with [Claude Code](https://claude.com/claude-code)