### PR TITLE
fix(marine): align Image Updater write target with other services

### DIFF
--- a/overlays/dev/marine/imageupdater.yaml
+++ b/overlays/dev/marine/imageupdater.yaml
@@ -14,7 +14,7 @@ spec:
           manifestTargets:
             helm:
               name: ingest.image.repository
-              tag: ingest.image.digest
+              tag: ingest.image.tag
         - alias: api
           commonUpdateSettings:
             updateStrategy: digest
@@ -23,7 +23,7 @@ spec:
           manifestTargets:
             helm:
               name: api.image.repository
-              tag: api.image.digest
+              tag: api.image.tag
         - alias: frontend
           commonUpdateSettings:
             updateStrategy: digest
@@ -32,7 +32,7 @@ spec:
           manifestTargets:
             helm:
               name: frontend.image.repository
-              tag: frontend.image.digest
+              tag: frontend.image.tag
       namePattern: marine
   namespace: argocd
   writeBackConfig:

--- a/overlays/dev/marine/values.yaml
+++ b/overlays/dev/marine/values.yaml
@@ -10,8 +10,7 @@ imagePullSecrets:
 ingest:
   image:
     repository: ghcr.io/jomcgi/homelab/services/ais_ingest
-    tag: main
-    digest: latest@sha256:6c6a6bc57e6807f2c52a530dc2c1895679ae2511dcce819d70cc5da8102a5e13
+    tag: main@sha256:6c6a6bc57e6807f2c52a530dc2c1895679ae2511dcce819d70cc5da8102a5e13
     pullPolicy: Always
   # Pre-populate OTEL annotation to match Kyverno injection (prevents ArgoCD drift)
   podAnnotations:
@@ -20,8 +19,7 @@ ingest:
 api:
   image:
     repository: ghcr.io/jomcgi/homelab/services/ships_api
-    tag: main
-    digest: main@sha256:af41b804e33ba2cf962bd3c2e169faed71e80f2f5ef73ea91ef99198dcb1d632
+    tag: main@sha256:af41b804e33ba2cf962bd3c2e169faed71e80f2f5ef73ea91ef99198dcb1d632
     pullPolicy: Always
   # Overprovisioned for catchup - reduce after caught up
   resources:
@@ -45,12 +43,10 @@ api:
   # Pre-populate OTEL annotation to match Kyverno injection (prevents ArgoCD drift)
   podAnnotations:
     otel.injected-by: kyverno/inject-otel-env-vars
-    kubectl.kubernetes.io/restartedAt: "2026-02-06T04:30:00Z"
 frontend:
   image:
     repository: ghcr.io/jomcgi/homelab/services/ships_frontend
-    tag: main
-    digest: main@sha256:18d74880ab5c094f2fbcf4963076c43be208bdc6e9298096c10596c78452f5f1
+    tag: main@sha256:18d74880ab5c094f2fbcf4963076c43be208bdc6e9298096c10596c78452f5f1
   # Zero Trust access policy - disabled, manually configured in Cloudflare
   zeroTrust:
     policyId: ""


### PR DESCRIPTION
## Summary

- **Image Updater** was writing to `*.image.digest` fields instead of `*.image.tag`, causing corrupted image references that accumulated extra tag prefixes on each update cycle
- **marine-api**: `InvalidImageName` — rendered as `ships_api:main@latest@sha256:...`
- **marine-frontend**: `InvalidImageName` — rendered as `ships_frontend:main@main@main@main@main@main@sha256:...`
- **marine-frontend (cascade)**: `CrashLoopBackOff` — valid image but API dependency is dead, so `/ready` returns 503

### Changes
- Point Image Updater `tag` target to `*.image.tag` (matching claude, stargazer, todo, cloudflare-operator)
- Consolidate separate `tag` + `digest` values into single `tag: main@sha256:...` format
- Remove stale `restartedAt` annotation from api pod

## Test plan

- [ ] PR merges and ArgoCD syncs the new Image Updater config
- [ ] marine-api pod starts with valid image reference
- [ ] marine-frontend pod recovers once API is healthy
- [ ] Image Updater's next write-back cycle produces clean `tag: main@sha256:...` values (no corruption)

🤖 Generated with [Claude Code](https://claude.com/claude-code)