### PR TITLE
fix(knowledge-graph): add image updater and use unsigned S3

### DIFF
--- a/charts/knowledge-graph/values.yaml
+++ b/charts/knowledge-graph/values.yaml
@@ -5,7 +5,7 @@ scraper:
   image:
     repository: ghcr.io/jomcgi/homelab/services/knowledge-graph-scraper
     tag: "latest"
-    pullPolicy: IfNotPresent
+    pullPolicy: Always
   service:
     type: ClusterIP
     port: 80
@@ -35,7 +35,7 @@ embedder:
   image:
     repository: ghcr.io/jomcgi/homelab/services/knowledge-graph-embedder
     tag: "latest"
-    pullPolicy: IfNotPresent
+    pullPolicy: Always
   backoffLimit: 2
   activeDeadlineSeconds: 3600
   concurrencyPolicy: Forbid
@@ -56,7 +56,7 @@ mcp:
   image:
     repository: ghcr.io/jomcgi/homelab/services/knowledge-graph-mcp
     tag: "latest"
-    pullPolicy: IfNotPresent
+    pullPolicy: Always
   service:
     type: ClusterIP
     port: 80

--- a/overlays/prod/knowledge-graph/imageupdater.yaml
+++ b/overlays/prod/knowledge-graph/imageupdater.yaml
@@ -1,0 +1,43 @@
+apiVersion: argocd-image-updater.argoproj.io/v1alpha1
+kind: ImageUpdater
+metadata:
+  name: knowledge-graph
+  namespace: argocd
+spec:
+  applicationRefs:
+    - images:
+        - alias: scraper
+          commonUpdateSettings:
+            updateStrategy: digest
+            forceUpdate: false
+          imageName: ghcr.io/jomcgi/homelab/services/knowledge-graph-scraper:main
+          manifestTargets:
+            helm:
+              name: scraper.image.repository
+              tag: scraper.image.tag
+        - alias: embedder
+          commonUpdateSettings:
+            updateStrategy: digest
+            forceUpdate: false
+          imageName: ghcr.io/jomcgi/homelab/services/knowledge-graph-embedder:main
+          manifestTargets:
+            helm:
+              name: embedder.image.repository
+              tag: embedder.image.tag
+        - alias: mcp
+          commonUpdateSettings:
+            updateStrategy: digest
+            forceUpdate: false
+          imageName: ghcr.io/jomcgi/homelab/services/knowledge-graph-mcp:main
+          manifestTargets:
+            helm:
+              name: mcp.image.repository
+              tag: mcp.image.tag
+      namePattern: knowledge-graph
+  namespace: argocd
+  writeBackConfig:
+    method: git:secret:argocd/argocd-image-updater-token
+    gitConfig:
+      repository: https://github.com/jomcgi/homelab.git
+      branch: main
+      writeBackTarget: helmvalues:../../overlays/prod/knowledge-graph/values.yaml

--- a/overlays/prod/knowledge-graph/kustomization.yaml
+++ b/overlays/prod/knowledge-graph/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 
 resources:
   - application.yaml
+  - ./imageupdater.yaml


### PR DESCRIPTION
## Summary
- Fix `NoCredentialsError` by using `botocore.UNSIGNED` for anonymous SeaweedFS access (no AWS credentials needed)
- Add ArgoCD Image Updater for all 3 images (scraper, embedder, mcp) with digest-based updates
- Change `pullPolicy` from `IfNotPresent` to `Always` so new digests get pulled

## Context
The knowledge-graph pods were in CrashLoopBackOff because:
1. botocore requires credentials by default, even when SeaweedFS has `enableAuth: false`
2. No image updater was configured, so code changes weren't being deployed

## Test plan
- [ ] CI passes (format, GHCR validation, test and push)
- [ ] Pods start without CrashLoopBackOff after merge
- [ ] Image updater picks up new digests going forward

🤖 Generated with [Claude Code](https://claude.com/claude-code)