### PR TITLE
fix(vllm): add GHCR pull secret for image volume auth

### DIFF
--- a/charts/vllm/templates/image-pull-secret.yaml
+++ b/charts/vllm/templates/image-pull-secret.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.imagePullSecret.enabled }}
+---
+apiVersion: onepassword.com/v1
+kind: OnePasswordItem
+type: kubernetes.io/dockerconfigjson
+metadata:
+  name: ghcr-imagepull-secret
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  itemPath: {{ .Values.imagePullSecret.onepassword.itemPath | quote }}
+{{- end }}

--- a/charts/vllm/values.yaml
+++ b/charts/vllm/values.yaml
@@ -14,6 +14,12 @@ secret:
     # Manually provided HuggingFace token (only used if type is "manual")
     hfToken: ""
 
+# Image pull secret for private GHCR registry (used by image volumes)
+imagePullSecret:
+  enabled: false
+  onepassword:
+    itemPath: "vaults/k8s-homelab/items/ghcr-read-permissions"
+
 # Init container for fast model downloads using hf_transfer
 initContainer:
   enabled: false

--- a/overlays/prod/vllm/values.yaml
+++ b/overlays/prod/vllm/values.yaml
@@ -5,6 +5,10 @@ secret:
   onepassword:
     itemPath: "vaults/k8s-homelab/items/vllm"
 
+# GHCR image pull secret (for private image volumes)
+imagePullSecret:
+  enabled: true
+
 # Enable fast model downloads via init container
 initContainer:
   enabled: true
@@ -38,6 +42,8 @@ vllm-stack:
         repository: "vllm/vllm-openai"
         tag: "latest@sha256:014a95f21c9edf6abe0aea6b07353f96baa4ec291c427bb1176dc7c93a85845c"
         imagePullPolicy: IfNotPresent
+        # GHCR pull secret for private image volume
+        imagePullSecret: ghcr-imagepull-secret
         # Local path - model loaded from image volume (not HuggingFace)
         # Image mounts at /model-image, files inside at /models/hermes-4.3-36b-awq/
         modelURL: "/model-image/models/hermes-4.3-36b-awq"


### PR DESCRIPTION
## Summary
- Adds `ghcr-imagepull-secret` OnePasswordItem to the vllm chart (1Password-backed, same pattern as trips/marine/todo)
- Sets `imagePullSecret: ghcr-imagepull-secret` on the Hermes modelSpec, using the upstream vllm-stack chart's native support
- Fixes `ErrImagePull` / 401 Unauthorized when pulling `ghcr.io/jomcgi/homelab/models/hermes_4_3_36b_awq:main` as an image volume

## Test plan
- [ ] Verify OnePasswordItem creates the `ghcr-imagepull-secret` in the vllm namespace
- [ ] Verify the vLLM deployment pod spec includes `imagePullSecrets`
- [ ] Verify the image volume pulls successfully from GHCR

🤖 Generated with [Claude Code](https://claude.com/claude-code)