### PR TITLE
fix(vllm): resolve OOMKilled crashes for Hermes 4.3 36B

### DIFF
--- a/overlays/prod/vllm/values.yaml
+++ b/overlays/prod/vllm/values.yaml
@@ -62,14 +62,14 @@ vllm-stack:
           - name: VLLM_LOGGING_LEVEL
             value: "INFO"
 
-        # Resource allocation (40GB model with 30GB CPU offload)
+        # Resource allocation - reduced memory request for 64GB node
         requestCPU: 4
-        requestMemory: "48Gi"
+        requestMemory: "40Gi"
         requestGPU: 1
 
         # vLLM engine configuration
         vllmConfig:
-          maxModelLen: 32768 # 32k tokens - more KV cache headroom with 30GB offload
+          maxModelLen: 16384 # 16k tokens - reduced from 32k for memory constraints
 
           # AWQ quantization works with bfloat16
           dtype: "bfloat16"
@@ -79,9 +79,11 @@ vllm-stack:
             - "--enable-chunked-prefill"
             - "--enable-prefix-caching"
             - "--gpu-memory-utilization"
-            - "0.90"
+            - "0.95" # Increased from 0.90 - use more VRAM since we reduced CPU offload
             - "--cpu-offload-gb"
-            - "30" # Offload 30GB to CPU RAM, maximize VRAM for KV cache
+            - "15" # Reduced from 30GB - keep more on 24GB VRAM, free CPU RAM for loading
+            - "--kv-cache-dtype"
+            - "fp8_e4m3" # FP8 KV cache halves memory usage (RTX 4090 supports this)
             - "--enable-auto-tool-choice"
             - "--tool-call-parser"
             - "hermes" # Hermes tool calling format (NousResearch Hermes models)
@@ -94,14 +96,14 @@ vllm-stack:
                 values:
                   - node-4
 
-        # Resource limits (high memory for CPU offloading)
+        # Resource limits - tuned for 64GB node with reduced CPU offload
         resources:
           requests:
             cpu: 4
-            memory: "48Gi"
+            memory: "40Gi"
             nvidia.com/gpu: 1
           limits:
-            memory: "56Gi"
+            memory: "48Gi"
             nvidia.com/gpu: 1
 
   # Router configuration (for request routing)


### PR DESCRIPTION
## Summary
- Reduce `maxModelLen`: 32k → 16k (halves KV cache memory)
- Add FP8 KV cache (`fp8_e4m3`) - halves KV cache memory again (RTX 4090 supports this)
- Reduce `cpu_offload_gb`: 30 → 15 (keep more on 24GB VRAM, free CPU RAM for loading)
- Increase `gpu-memory-utilization`: 0.90 → 0.95
- Reduce memory request: 48Gi → 40Gi (leaves headroom for OS/kubelet on 64GB node)

## Problem
The Hermes 4.3 36B AWQ pod was OOMKilled (exit code 137) during model loading. With 30GB CPU offload and 32k context, the peak memory during loading exceeded 48GB.

## Solution
Rebalance memory usage:
- More model weights on GPU (reduced offload)
- Smaller KV cache via FP8 quantization and reduced context
- Lower CPU memory request to leave room for loading overhead

## Test plan
- [ ] Pod starts without OOMKilled
- [ ] Model loads successfully (check logs for "Model loaded")
- [ ] Inference works at 16k context

🤖 Generated with [Claude Code](https://claude.com/claude-code)