### PR TITLE
fix(vllm): increase cpu-offload-gb to 17 for GPU headroom

### DIFF
--- a/overlays/prod/vllm/values.yaml
+++ b/overlays/prod/vllm/values.yaml
@@ -79,9 +79,9 @@ vllm-stack:
             - "--enable-chunked-prefill"
             - "--enable-prefix-caching"
             - "--gpu-memory-utilization"
-            - "0.95" # Increased from 0.90 - use more VRAM since we reduced CPU offload
+            - "0.95"
             - "--cpu-offload-gb"
-            - "15" # Reduced from 30GB - keep more on 24GB VRAM, free CPU RAM for loading
+            - "17" # Offload 17GB to CPU - model uses 22.7GB VRAM, need headroom for KV cache
             - "--kv-cache-dtype"
             - "fp8_e4m3" # FP8 KV cache halves memory usage (RTX 4090 supports this)
             - "--enable-auto-tool-choice"


### PR DESCRIPTION
## Summary
- Increase `cpu-offload-gb`: 15 → 17

## Problem
After PR #384, the model still hit CUDA OOM:
```
torch.OutOfMemoryError: CUDA out of memory. Tried to allocate 270.00 MiB. 
GPU has 23.53 GiB total, 266.56 MiB free. 22.71 GiB allocated by PyTorch.
```

The model weights loaded successfully but used 22.7GB of VRAM, leaving only 266MB for KV cache allocation.

## Solution
Increase CPU offload from 15GB to 17GB, freeing ~2GB more VRAM for KV cache and runtime allocations.

## Test plan
- [ ] Pod starts without CUDA OOM
- [ ] Model loads and serves requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)