### PR TITLE
fix(vllm): reduce gpu-memory-utilization to 0.85

### DIFF
--- a/overlays/prod/vllm/values.yaml
+++ b/overlays/prod/vllm/values.yaml
@@ -79,7 +79,7 @@ vllm-stack:
             - "--enable-chunked-prefill"
             - "--enable-prefix-caching"
             - "--gpu-memory-utilization"
-            - "0.95"
+            - "0.85"
             - "--cpu-offload-gb"
             - "17" # Offload 17GB to CPU - model uses 22.7GB VRAM, need headroom for KV cache
             - "--kv-cache-dtype"


### PR DESCRIPTION
## Summary
- Reduce `gpu-memory-utilization`: 0.95 → 0.85

## Problem
Still hitting CUDA OOM after PR #385. At 0.95 utilization, vLLM only reserves ~1.2GB for KV cache and runtime, which isn't enough.

## Solution
Reduce GPU memory utilization to 0.85, reserving ~3.5GB VRAM for KV cache and other allocations.

| Setting | Reserved VRAM |
|---------|---------------|
| 0.95 | ~1.2 GB |
| 0.90 | ~2.4 GB |
| 0.85 | ~3.5 GB |

## Test plan
- [ ] Pod starts without CUDA OOM
- [ ] Model loads and serves requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)