### PR TITLE
fix(vllm): add --enforce-eager to workaround AWQ Marlin OOM bug

### DIFF
--- a/overlays/prod/vllm/values.yaml
+++ b/overlays/prod/vllm/values.yaml
@@ -76,6 +76,7 @@ vllm-stack:
 
           # Additional performance flags
           extraArgs:
+            - "--enforce-eager" # Disable CUDA graphs - workaround for AWQ Marlin + cpu_offload OOM bug
             - "--enable-chunked-prefill"
             - "--enable-prefix-caching"
             - "--gpu-memory-utilization"


### PR DESCRIPTION
## Summary
- Add `--enforce-eager` flag to disable CUDA graphs

## Problem
Still hitting OOM during `gptq_marlin_repack` - this is a [known vLLM bug (#21864)](https://github.com/vllm-project/vllm/issues/21864) where AWQ weight repacking with `cpu_offload` creates tensors on GPU that don't get moved back to CPU.

The `gpu-memory-utilization` and `cpu-offload-gb` settings don't help because the OOM happens during weight repacking, not KV cache allocation.

## Solution
Add `--enforce-eager` which disables CUDA graphs. This may help by:
- Changing memory allocation patterns during model loading
- Avoiding pre-allocation of graph memory
- More predictable memory usage

## Trade-offs
- ~10-20% slower inference (no CUDA graph optimization)
- Faster startup (skips graph capture warmup)

## Test plan
- [ ] Pod starts without OOM during weight repacking
- [ ] Model loads and serves requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)