### PR TITLE
fix(marine): correct image digest reference format

### DIFF
--- a/charts/marine/templates/api-deployment.yaml
+++ b/charts/marine/templates/api-deployment.yaml
@@ -35,7 +35,7 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: api
-          image: "{{ .Values.api.image.repository }}:{{ .Values.api.image.digest | default .Values.api.image.tag }}"
+          image: "{{ .Values.api.image.repository }}{{ if .Values.api.image.digest }}@{{ .Values.api.image.digest }}{{ else }}:{{ .Values.api.image.tag }}{{ end }}"
           imagePullPolicy: {{ .Values.api.image.pullPolicy }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
@@ -141,7 +141,7 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: api
-          image: "{{ .Values.api.image.repository }}:{{ .Values.api.image.digest | default .Values.api.image.tag }}"
+          image: "{{ .Values.api.image.repository }}{{ if .Values.api.image.digest }}@{{ .Values.api.image.digest }}{{ else }}:{{ .Values.api.image.tag }}{{ end }}"
           imagePullPolicy: {{ .Values.api.image.pullPolicy }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}

--- a/charts/marine/templates/frontend-deployment.yaml
+++ b/charts/marine/templates/frontend-deployment.yaml
@@ -35,7 +35,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: frontend
-          image: "{{ .Values.frontend.image.repository }}:{{ .Values.frontend.image.digest | default .Values.frontend.image.tag }}"
+          image: "{{ .Values.frontend.image.repository }}{{ if .Values.frontend.image.digest }}@{{ .Values.frontend.image.digest }}{{ else }}:{{ .Values.frontend.image.tag }}{{ end }}"
           imagePullPolicy: {{ .Values.frontend.image.pullPolicy }}
           securityContext:
             readOnlyRootFilesystem: false

--- a/charts/marine/templates/ingest-deployment.yaml
+++ b/charts/marine/templates/ingest-deployment.yaml
@@ -33,7 +33,7 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: ingest
-          image: "{{ .Values.ingest.image.repository }}:{{ .Values.ingest.image.digest | default .Values.ingest.image.tag }}"
+          image: "{{ .Values.ingest.image.repository }}{{ if .Values.ingest.image.digest }}@{{ .Values.ingest.image.digest }}{{ else }}:{{ .Values.ingest.image.tag }}{{ end }}"
           imagePullPolicy: {{ .Values.ingest.image.pullPolicy }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}

--- a/overlays/dev/marine/imageupdater.yaml
+++ b/overlays/dev/marine/imageupdater.yaml
@@ -15,6 +15,7 @@ spec:
             helm:
               name: ingest.image.repository
               tag: ingest.image.tag
+              digest: ingest.image.digest
         - alias: api
           commonUpdateSettings:
             updateStrategy: digest
@@ -24,6 +25,7 @@ spec:
             helm:
               name: api.image.repository
               tag: api.image.tag
+              digest: api.image.digest
         - alias: frontend
           commonUpdateSettings:
             updateStrategy: digest
@@ -33,6 +35,7 @@ spec:
             helm:
               name: frontend.image.repository
               tag: frontend.image.tag
+              digest: frontend.image.digest
       namePattern: marine
   namespace: argocd
   writeBackConfig:

--- a/overlays/dev/marine/values.yaml
+++ b/overlays/dev/marine/values.yaml
@@ -10,9 +10,9 @@ imagePullSecrets:
 ingest:
   image:
     repository: ghcr.io/jomcgi/homelab/services/ais_ingest
-    tag: latest@sha256:6c6a6bc57e6807f2c52a530dc2c1895679ae2511dcce819d70cc5da8102a5e13
+    tag: main
     pullPolicy: Always
-    digest: latest@sha256:6c6a6bc57e6807f2c52a530dc2c1895679ae2511dcce819d70cc5da8102a5e13
+    digest: sha256:6c6a6bc57e6807f2c52a530dc2c1895679ae2511dcce819d70cc5da8102a5e13
   # Pre-populate OTEL annotation to match Kyverno injection (prevents ArgoCD drift)
   podAnnotations:
     otel.injected-by: kyverno/inject-otel-env-vars
@@ -20,9 +20,9 @@ ingest:
 api:
   image:
     repository: ghcr.io/jomcgi/homelab/services/ships_api
-    tag: main@sha256:af41b804e33ba2cf962bd3c2e169faed71e80f2f5ef73ea91ef99198dcb1d632
+    tag: main
     pullPolicy: Always
-    digest: main@sha256:af41b804e33ba2cf962bd3c2e169faed71e80f2f5ef73ea91ef99198dcb1d632
+    digest: sha256:af41b804e33ba2cf962bd3c2e169faed71e80f2f5ef73ea91ef99198dcb1d632
   # Overprovisioned for catchup - reduce after caught up
   resources:
     requests:
@@ -48,8 +48,8 @@ api:
 frontend:
   image:
     repository: ghcr.io/jomcgi/homelab/services/ships_frontend
-    tag: main@sha256:18d74880ab5c094f2fbcf4963076c43be208bdc6e9298096c10596c78452f5f1
-    digest: main@sha256:18d74880ab5c094f2fbcf4963076c43be208bdc6e9298096c10596c78452f5f1
+    tag: main
+    digest: sha256:18d74880ab5c094f2fbcf4963076c43be208bdc6e9298096c10596c78452f5f1
   # Zero Trust access policy - disabled, manually configured in Cloudflare
   zeroTrust:
     policyId: ""


### PR DESCRIPTION
## Summary
- **Helm templates** used `:` separator for all image references (`repo:digest`), producing invalid refs like `repo:main@sha256:...`. Fixed to use `@` when digest is set, `:` when falling back to tag
- **ImageUpdater config** lacked separate `digest` helm targets, so tag and digest were written as a combined value. Added `digest` field to all three image entries
- **Overlay values** cleaned up — separated the mangled `tag@sha256:...` values back into proper `tag: main` and `digest: sha256:...`

## What was broken
Pods failed with `InvalidImageName` because the rendered image ref was `ghcr.io/.../ships_api:main@latest@sha256:...` — an invalid Docker reference.

## Test plan
- [x] `helm template` with overlay values renders `repo@sha256:digest` (valid)
- [x] `helm template` with chart defaults renders `repo:main` (valid fallback)
- [ ] Verify pods start successfully after ArgoCD sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)