### PR TITLE
fix(seaweedfs): regenerate missing idx files to resolve CrashLoopBackOff

### DIFF
--- a/charts/seaweedfs/values.yaml
+++ b/charts/seaweedfs/values.yaml
@@ -51,6 +51,43 @@ seaweedfs:
         maxVolumes: 0
     idx:
       type: "emptyDir"
+    # Regenerate missing .idx files from .dat files on startup.
+    # The built-in move-idx init container moves .idx from /data to /idx (emptyDir),
+    # but if the pod is rescheduled the emptyDir is lost and the .idx files are gone.
+    # This init container runs weed fix to rebuild them.
+    initContainers: |
+      - name: seaweedfs-vol-fix-idx
+        image: '{{ include "volume.image" . }}'
+        imagePullPolicy: IfNotPresent
+        command: ['/bin/sh', '-c']
+        args:
+          - |
+            echo "Checking for missing idx files..."
+            for dat in /data/*.dat; do
+              [ -f "$dat" ] || continue
+              base=$(basename "$dat" .dat)
+              if [ ! -f "/idx/${base}.idx" ]; then
+                if echo "$base" | grep -q '_'; then
+                  collection=$(echo "$base" | sed 's/_[0-9]*$//')
+                  volid=$(echo "$base" | grep -o '[0-9]*$')
+                  echo "Regenerating idx: collection=$collection volumeId=$volid"
+                  /usr/bin/weed fix -dir=/data -collection="$collection" -volumeId="$volid"
+                else
+                  echo "Regenerating idx: volumeId=$base"
+                  /usr/bin/weed fix -dir=/data -volumeId="$base"
+                fi
+                if [ -f "/data/${base}.idx" ]; then
+                  mv "/data/${base}.idx" /idx/
+                  echo "Moved ${base}.idx to /idx/"
+                fi
+              fi
+            done
+            echo "idx check complete"
+        volumeMounts:
+          - name: data
+            mountPath: /data
+          - name: idx
+            mountPath: /idx
     logs:
       type: "emptyDir"
     resources:


### PR DESCRIPTION
## Summary

- seaweedfs-volume-0 has been in CrashLoopBackOff for 8 days (2,215 restarts) because `.idx` files are missing
- Root cause: idx volume uses `emptyDir` which is destroyed on pod rescheduling, and the `.idx` files had already been moved out of the persistent `/data` PVC by the built-in init container on a previous startup
- Adds a `weed fix` init container that regenerates missing `.idx` files from `.dat` files before the volume server starts
- Handles both plain volumes (`5.dat` → `weed fix -volumeId=5`) and collection volumes (`trips_12.dat` → `weed fix -collection=trips -volumeId=12`)

## Test plan

- [ ] CI passes (helm template renders correctly)
- [ ] After merge, verify seaweedfs-volume-0 pod restarts successfully
- [ ] Check init container logs: `kubectl logs seaweedfs-volume-0 -n seaweedfs -c seaweedfs-vol-fix-idx`
- [ ] Verify volume server is healthy: `kubectl get pods -n seaweedfs`
- [ ] Consider follow-up to change `idx` from `emptyDir` to `persistentVolumeClaim` to avoid rebuilding on every pod reschedule

🤖 Generated with [Claude Code](https://claude.com/claude-code)