### PR TITLE
fix(seaweedfs): correct weed fix command syntax

### DIFF
--- a/charts/seaweedfs/values.yaml
+++ b/charts/seaweedfs/values.yaml
@@ -71,10 +71,10 @@ seaweedfs:
                   collection=$(echo "$base" | sed 's/_[0-9]*$//')
                   volid=$(echo "$base" | grep -o '[0-9]*$')
                   echo "Regenerating idx: collection=$collection volumeId=$volid"
-                  /usr/bin/weed fix -dir=/data -collection="$collection" -volumeId="$volid"
+                  /usr/bin/weed fix -collection="$collection" -volumeId="$volid" /data
                 else
                   echo "Regenerating idx: volumeId=$base"
-                  /usr/bin/weed fix -dir=/data -volumeId="$base"
+                  /usr/bin/weed fix -volumeId="$base" /data
                 fi
                 if [ -f "/data/${base}.idx" ]; then
                   mv "/data/${base}.idx" /idx/


### PR DESCRIPTION
## Summary
- The `weed fix` directory argument is **positional** (trailing), not a `-dir` flag
- PR #390 used `-dir=/data` which fails with `flag provided but not defined: -dir`
- Fix: changed to `weed fix -volumeId=N /data` (directory as positional arg)

## Context
After merging #390, the init container ran but every `weed fix` invocation failed silently (no `set -e`), leaving all .idx files ungenerated. The volume server continues to crash with `idx file does not exists`.

## Test plan
- [ ] ArgoCD syncs the updated StatefulSet
- [ ] Delete seaweedfs-volume-0 pod to trigger new init container
- [ ] Verify `seaweedfs-vol-fix-idx` logs show successful idx regeneration
- [ ] Verify seaweedfs-volume-0 reaches Running/Ready state

🤖 Generated with [Claude Code](https://claude.com/claude-code)