### PR TITLE
fix(bazel): add disk cache GC to prevent unbounded growth

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -30,6 +30,9 @@ common --experimental_repository_cache_hardlinks
 # All worktrees and main repo share the same disk cache, reducing rebuild time
 # and disk usage. Each workspace still has its own output_base for tracking.
 build --disk_cache=~/.cache/bazel/disk_cache
+# Garbage-collect disk cache entries older than 30 days or when total exceeds 10 GB
+build --experimental_disk_cache_gc_max_size=10G
+build --experimental_disk_cache_gc_max_age=30d
 
 # CI: Disable disk cache (BuildBuddy has limited disk, uses remote cache instead)
 build:ci --disk_cache=


### PR DESCRIPTION
## Summary
- Adds `--experimental_disk_cache_gc_max_size=10G` and `--experimental_disk_cache_gc_max_age=30d` to cap the shared disk cache
- Disk was at 99% (6.3 GB free) with ~356 GB of Bazel caches across multiple locations
- GC runs automatically during idle periods after builds

## Test plan
- [x] Verify Bazel accepts the new flags (`bazel build` doesn't error)
- [ ] Monitor disk usage over time to confirm cache stays bounded

🤖 Generated with [Claude Code](https://claude.com/claude-code)