### PR TITLE
fix(llama-cpp): use ghcr-read-permissions for image pull secret

### DIFF
--- a/charts/llama-cpp/values.yaml
+++ b/charts/llama-cpp/values.yaml
@@ -13,7 +13,7 @@ fullnameOverride: ""
 imagePullSecret:
   enabled: false
   onepassword:
-    itemPath: "vaults/k8s-homelab/items/vllm"
+    itemPath: "vaults/k8s-homelab/items/ghcr-read-permissions"
 
 ## llama-server configuration
 server:


### PR DESCRIPTION
## Summary

- Fix 1Password item path for the GHCR image pull secret from `vaults/k8s-homelab/items/vllm` (HF token) to `vaults/k8s-homelab/items/ghcr-read-permissions` (dockerconfigjson)
- The vllm item contains a HuggingFace token, not GHCR docker credentials, causing `Secret is invalid: data[.dockerconfigjson]: Required value`

## Test plan

- [x] `bazel test //overlays/prod/llama-cpp:template_test` passes
- [ ] After merge: 1Password Operator creates valid dockerconfigjson secret
- [ ] After merge: model OCI image pulls successfully from GHCR

🤖 Generated with [Claude Code](https://claude.com/claude-code)