### PR TITLE
fix(llama-cpp): pass value to --flash-attn argument

### DIFF
--- a/charts/llama-cpp/templates/deployment.yaml
+++ b/charts/llama-cpp/templates/deployment.yaml
@@ -47,6 +47,7 @@ spec:
             - {{ .Values.server.ctxSize | quote }}
             {{- if .Values.server.flashAttn }}
             - "--flash-attn"
+            - {{ .Values.server.flashAttn | quote }}
             {{- end }}
             - "--cache-type-k"
             - {{ .Values.server.cacheTypeK | quote }}

--- a/charts/llama-cpp/values.yaml
+++ b/charts/llama-cpp/values.yaml
@@ -25,8 +25,9 @@ server:
   noKvOffload: true
   ## Context window size (tokens)
   ctxSize: 32768
-  ## Enable flash attention
-  flashAttn: true
+  ## Flash attention: "on", "off", or "auto" (empty string to disable)
+  ## See: https://github.com/ggml-org/llama.cpp/blob/master/tools/server/README.md
+  flashAttn: "on"
   ## KV cache quantization types
   cacheTypeK: "q8_0"
   cacheTypeV: "q4_0"

--- a/overlays/prod/llama-cpp/values.yaml
+++ b/overlays/prod/llama-cpp/values.yaml
@@ -13,7 +13,7 @@ server:
   nGpuLayers: 99
   noKvOffload: true
   ctxSize: 32768
-  flashAttn: true
+  flashAttn: "on"
   cacheTypeK: "q8_0"
   cacheTypeV: "q4_0"
   threads: 8


### PR DESCRIPTION
## Summary
- Fix startup failure caused by `--flash-attn` argument parsing error
- Recent llama.cpp changed `--flash-attn` from a boolean flag to requiring a value (`on`, `off`, or `auto`)
- Updated Helm chart to pass the `flashAttn` value as a string argument

## Root Cause
The error:
```
error while handling argument "--flash-attn": error: unknown value for --flash-attn: '--cache-type-k'
```

Was caused by llama.cpp's argument parser trying to use `--cache-type-k` (the next argument) as the value for `--flash-attn`, since the flag now requires an explicit value.

## Changes
- `charts/llama-cpp/templates/deployment.yaml`: Add value argument after `--flash-attn` flag
- `charts/llama-cpp/values.yaml`: Change `flashAttn` from boolean `true` to string `"on"`
- `overlays/prod/llama-cpp/values.yaml`: Change `flashAttn` from boolean `true` to string `"on"`

## Documentation References
- [llama.cpp server README](https://github.com/ggml-org/llama.cpp/blob/master/tools/server/README.md) - Documents `-fa, --flash-attn [on|off|auto]` syntax
- [arg.cpp source](https://github.com/ggml-org/llama.cpp/blob/master/common/arg.cpp) - Shows the argument parser requires a value

## Test Plan
- [ ] Verify Helm template renders correctly with `helm template`
- [ ] Deploy to cluster and confirm llama-server starts without argument parsing errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)