### PR TITLE
fix(openclaw-friends): fix NetworkPolicy blocking llama-cpp egress

### DIFF
--- a/overlays/prod/openclaw-friends/values.yaml
+++ b/overlays/prod/openclaw-friends/values.yaml
@@ -1,5 +1,5 @@
 ## OpenClaw Friends Instance - Production Values
-## Group chat AI assistant with local Qwen + Discord
+## Group chat AI assistant with local Hermes via llama.cpp + Discord
 
 fullnameOverride: "openclaw-friends"
 
@@ -12,12 +12,6 @@ llm:
   provider: "openai-compatible"
   model: "hermes-4.3-36b"
   baseUrl: "http://llama-cpp.llama-cpp.svc.cluster.local:8080/v1"
-  vllm:
-    enabled: true
-    namespace: "llama-cpp"
-    port: 8080
-    podSelector:
-      app.kubernetes.io/name: llama-cpp
 
 ## No Anthropic auth needed
 auth:
@@ -73,14 +67,16 @@ resources:
 ## Network policy - allow external internet, restrict internal cluster
 networkPolicy:
   enabled: true
-  ## llama-cpp egress
+  ## llama-cpp egress (uses chart's "vllm" key for openai-compatible provider)
+  ## "release: null" removes the chart default (release: router) via Helm deep-merge
   vllm:
     namespace: "llama-cpp"
     port: 8080
     podSelector:
       app.kubernetes.io/name: llama-cpp
+      release: null
   ## Allow all external internet (web search, APIs, etc.)
-  ## Block internal cluster traffic except explicit vLLM rule above
+  ## Block internal cluster traffic except explicit llama-cpp rule above
   egress:
     - ipBlock:
         cidr: 0.0.0.0/0


### PR DESCRIPTION
## Summary

- **Root cause**: Helm deep-merges chart default `podSelector: {release: router}` with the overlay's `{app.kubernetes.io/name: llama-cpp}`, resulting in the NetworkPolicy requiring **both** labels. The llama-cpp pod doesn't have `release: router`, so egress was silently blocked.
- Adds `release: null` to the overlay to remove the stale chart default via Helm deep-merge
- Removes unused `llm.vllm` config block (leftover from vLLM migration)
- Updates comments to reflect llama-cpp backend

## Test plan

- [x] `helm template` renders NetworkPolicy with only `app.kubernetes.io/name: llama-cpp` in podSelector (no `release: router`)
- [ ] After merge, verify ArgoCD syncs the updated NetworkPolicy
- [ ] Send a Discord message to @OpenClaw and confirm it responds (no "Connection error")

🤖 Generated with [Claude Code](https://claude.com/claude-code)