### PR TITLE
fix(ci): document CLOUDFLARE_ACCOUNT_ID in Deploy Pages

### DIFF
--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -175,5 +175,5 @@ actions:
             echo "Skipping argocd-image-updater commit"
             exit 0
           fi
-          # CLOUDFLARE_API_TOKEN set in BuildBuddy Settings → Secrets
+          # CLOUDFLARE_API_TOKEN and CLOUDFLARE_ACCOUNT_ID set in BuildBuddy Settings → Secrets
           bazel run //websites:push_all_pages --config=ci


### PR DESCRIPTION
## Summary
- Updated the comment in the Deploy Pages BuildBuddy action to document that both `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` secrets are required
- The wrangler CLI needs both values but only the API token was documented

## Test plan
- [ ] Verify Deploy Pages action succeeds after `CLOUDFLARE_ACCOUNT_ID` secret was added to BuildBuddy

🤖 Generated with [Claude Code](https://claude.com/claude-code)