### PR TITLE
chore: migrate kubectl image from bitnami to alpine/kubectl

### DIFF
--- a/charts/api-gateway/values.yaml
+++ b/charts/api-gateway/values.yaml
@@ -16,8 +16,8 @@ nginx:
 clusterInfo:
   enabled: true
   image:
-    repository: bitnami/kubectl
-    tag: "1.35"
+    repository: alpine/kubectl
+    tag: "1.35.0"
     pullPolicy: IfNotPresent
   # How often to update status.json (seconds)
   interval: 30

--- a/charts/claude/values.yaml
+++ b/charts/claude/values.yaml
@@ -192,8 +192,8 @@ leaderElection:
   enabled: true
   # kubectl image used for leader election sidecar
   image:
-    repository: bitnami/kubectl
-    tag: "1.35"
+    repository: alpine/kubectl
+    tag: "1.35.0"
     pullPolicy: IfNotPresent
 
 ## Nginx reverse proxy sidecar for WebSocket support

--- a/charts/vllm/values.yaml
+++ b/charts/vllm/values.yaml
@@ -35,8 +35,8 @@ initContainer:
 # kubectl image used by patcher jobs (init-container, image-volume)
 patcher:
   image:
-    repository: bitnami/kubectl
-    tag: "1.35"
+    repository: alpine/kubectl
+    tag: "1.35.0"
 
 vllm-stack:
   # Minimal defaults - see overlay values for production configuration

--- a/overlays/cluster-critical/longhorn/configure-node-4-disks.yaml
+++ b/overlays/cluster-critical/longhorn/configure-node-4-disks.yaml
@@ -17,9 +17,9 @@ spec:
         - securityContext:
             allowPrivilegeEscalation: false
           name: configure-disks
-          image: bitnami/kubectl:1.35
+          image: alpine/kubectl:1.35.0
           command:
-            - /bin/bash
+            - /bin/sh
             - -c
             - |
               set -e
@@ -59,4 +59,4 @@ spec:
               ]'
 
               echo "Disk configuration complete!"
-              kubectl get nodes.longhorn.io -n longhorn node-4 -o jsonpath='{.spec.disks}' | jq '.'
+              kubectl get nodes.longhorn.io -n longhorn node-4 -o jsonpath='{.spec.disks}'


### PR DESCRIPTION
## Summary
- Replaces `bitnami/kubectl:1.35` with `alpine/kubectl:1.35.0` across all 4 usages
- Bitnami dropped community image support — version tags no longer published to Docker Hub
- `alpine/kubectl` is actively maintained, multi-arch, and 3.6x smaller (21MB vs 76MB)

## Changes
| File | Change |
|------|--------|
| `charts/vllm/values.yaml` | patcher image → `alpine/kubectl:1.35.0` |
| `charts/api-gateway/values.yaml` | clusterInfo image → `alpine/kubectl:1.35.0` |
| `charts/claude/values.yaml` | leaderElection image → `alpine/kubectl:1.35.0` |
| `overlays/cluster-critical/longhorn/configure-node-4-disks.yaml` | image + `/bin/bash` → `/bin/sh`, drop `jq` pipe |

## Test plan
- [ ] Verify api-gateway clusterInfo sidecar starts and writes `status.json`
- [ ] Verify claude leader election sidecar functions correctly
- [ ] Verify Longhorn disk config job runs on next sync (PostSync hook)
- [ ] Confirm vllm patcher init-containers work with new image

🤖 Generated with [Claude Code](https://claude.com/claude-code)