### PR TITLE
fix(stargazer): add explicit env to prevent ArgoCD drift

### DIFF
--- a/charts/stargazer/templates/deployment-api.yaml
+++ b/charts/stargazer/templates/deployment-api.yaml
@@ -37,6 +37,7 @@ spec:
           {{- toYaml .Values.api.securityContext | nindent 10 }}
         image: "{{ .Values.api.nginx.image.repository }}:{{ .Values.api.nginx.image.tag }}"
         imagePullPolicy: {{ .Values.api.nginx.image.pullPolicy }}
+        env: []
         ports:
         - name: http
           containerPort: 8080


### PR DESCRIPTION
## Summary
- Adds explicit `env: []` to the stargazer API deployment template to match what Kubernetes normalizes at runtime
- Fixes permanent ArgoCD drift where the live manifest always shows `env: []` but the desired manifest omits the field entirely

## Test plan
- [x] `helm template` renders `env: []` in the container spec
- [x] Chart lint tests pass (`bazel test //charts/stargazer/...`)
- [ ] Verify ArgoCD drift resolves after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)