### PR TITLE
fix(stargazer): ignore entire env field to resolve Kyverno drift

### DIFF
--- a/charts/stargazer/templates/deployment-api.yaml
+++ b/charts/stargazer/templates/deployment-api.yaml
@@ -37,7 +37,6 @@ spec:
           {{- toYaml .Values.api.securityContext | nindent 10 }}
         image: "{{ .Values.api.nginx.image.repository }}:{{ .Values.api.nginx.image.tag }}"
         imagePullPolicy: {{ .Values.api.nginx.image.pullPolicy }}
-        env: []
         ports:
         - name: http
           containerPort: 8080

--- a/overlays/dev/stargazer/application.yaml
+++ b/overlays/dev/stargazer/application.yaml
@@ -24,7 +24,7 @@ spec:
       kind: Deployment
       jqPathExpressions:
         - .spec.template.metadata.annotations."otel.injected-by"
-        - .spec.template.spec.containers[].env[] | select(.name | startswith("OTEL_"))
+        - .spec.template.spec.containers[].env
   syncPolicy:
     automated:
       prune: true


### PR DESCRIPTION
## Summary
- Changes the `ignoreDifferences` jqPathExpression from filtering individual `OTEL_*` env entries to ignoring the entire `env` field on the Deployment
- Reverts the `env: []` template change from #416 (no longer needed)

## Root cause
The previous jqPathExpression (`containers[].env[] | select(.name | startswith("OTEL_"))`) doesn't fully resolve drift when the container has **zero** application env vars. Kyverno's MutatingAdmissionWebhook injects OTEL vars during admission, which get persisted into `last-applied-configuration`. ArgoCD then perpetually sees a diff between the desired state (no env / `env: []`) and the live state (`env: [OTEL_...]`).

The `marine` chart doesn't have this problem because its containers already define their own env vars (HOME, PORT, etc.), so after filtering out OTEL entries the remaining list matches.

## Test plan
- [ ] Verify ArgoCD shows stargazer as `Synced` after merge
- [x] Chart lint tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)