### PR TITLE
feat(oci-model-cache): add HuggingFace token support

### DIFF
--- a/operators/oci-model-cache/cmd/main.go
+++ b/operators/oci-model-cache/cmd/main.go
@@ -237,7 +237,12 @@ func main() {
 	}
 
 	// Initialize HuggingFace client
-	hfClient := hf.NewClient(nil)
+	var hfOpts []hf.Option
+	if token := os.Getenv("HF_TOKEN"); token != "" {
+		hfOpts = append(hfOpts, hf.WithToken(token))
+		setupLog.Info("HuggingFace token configured")
+	}
+	hfClient := hf.NewClient(hfOpts...)
 
 	// Initialize state machine calculator and observer
 	calculator := sm.NewModelCacheCalculator(ctrl.Log.WithName("calculator"))

--- a/operators/oci-model-cache/helm/oci-model-cache-operator/templates/_helpers.tpl
+++ b/operators/oci-model-cache/helm/oci-model-cache-operator/templates/_helpers.tpl
@@ -41,6 +41,14 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 {{- end }}
 
+{{- define "oci-model-cache-operator.hfTokenSecretName" -}}
+{{- if .Values.hfToken.existingSecret }}
+{{- .Values.hfToken.existingSecret }}
+{{- else }}
+{{- printf "%s-hf-token" (include "oci-model-cache-operator.fullname" .) }}
+{{- end }}
+{{- end }}
+
 {{- define "oci-model-cache-operator.syncServiceAccountName" -}}
 {{- if .Values.syncServiceAccount.create }}
 {{- default (printf "%s-sync" (include "oci-model-cache-operator.fullname" .)) .Values.syncServiceAccount.name }}

--- a/operators/oci-model-cache/helm/oci-model-cache-operator/templates/deployment.yaml
+++ b/operators/oci-model-cache/helm/oci-model-cache-operator/templates/deployment.yaml
@@ -94,6 +94,17 @@ spec:
         - name: OTEL_SDK_DISABLED
           value: "true"
         {{- end }}
+        {{- if or .Values.hfToken.create .Values.hfToken.existingSecret }}
+        - name: HF_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "oci-model-cache-operator.hfTokenSecretName" . }}
+              key: {{ .Values.hfToken.secretKey }}
+        - name: HF_TOKEN_SECRET
+          value: {{ include "oci-model-cache-operator.hfTokenSecretName" . | quote }}
+        - name: HF_TOKEN_SECRET_KEY
+          value: {{ .Values.hfToken.secretKey | quote }}
+        {{- end }}
         lifecycle:
           preStop:
             exec:

--- a/operators/oci-model-cache/helm/oci-model-cache-operator/templates/hf-token-secret.yaml
+++ b/operators/oci-model-cache/helm/oci-model-cache-operator/templates/hf-token-secret.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.hfToken.create }}
+{{- if eq .Values.hfToken.type "onepassword" }}
+apiVersion: onepassword.com/v1
+kind: OnePasswordItem
+metadata:
+  name: {{ include "oci-model-cache-operator.hfTokenSecretName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "oci-model-cache-operator.labels" . | nindent 4 }}
+spec:
+  itemPath: {{ .Values.hfToken.onepassword.itemPath | quote }}
+{{- else if eq .Values.hfToken.type "manual" }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "oci-model-cache-operator.hfTokenSecretName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "oci-model-cache-operator.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  {{ .Values.hfToken.secretKey }}: {{ required "hfToken.manual.token is required when type=manual" .Values.hfToken.manual.token | quote }}
+{{- end }}
+{{- end }}

--- a/operators/oci-model-cache/helm/oci-model-cache-operator/values.yaml
+++ b/operators/oci-model-cache/helm/oci-model-cache-operator/values.yaml
@@ -81,6 +81,20 @@ createNamespace: false
 
 imagePullSecrets: []
 
+hfToken:
+  # -- Create a Secret (OnePasswordItem or manual). If false, use existingSecret.
+  create: false
+  # -- Name of a pre-existing Secret containing the HF token
+  existingSecret: ""
+  # -- Key within the Secret
+  secretKey: "hf_token"
+  # -- Secret type when create=true: "onepassword" or "manual"
+  type: "onepassword"
+  onepassword:
+    itemPath: ""
+  manual:
+    token: ""
+
 webhook:
   enabled: true
 

--- a/operators/oci-model-cache/internal/config/config.go
+++ b/operators/oci-model-cache/internal/config/config.go
@@ -22,6 +22,12 @@ type Config struct {
 
 	// Namespace is the operator's namespace (from POD_NAMESPACE).
 	Namespace string
+
+	// HFTokenSecret is the name of the Kubernetes Secret containing the HF token for copy Jobs.
+	HFTokenSecret string
+
+	// HFTokenSecretKey is the key within the Secret that holds the HF token.
+	HFTokenSecretKey string
 }
 
 // BindFlags registers config flags on the given FlagSet.
@@ -35,6 +41,8 @@ func (c *Config) BindFlags(fs *flag.FlagSet) {
 	fs.StringVar(&c.SyncServiceAccount, "sync-service-account", envOrDefault("SYNC_SERVICE_ACCOUNT", ""),
 		"Service account for sync Jobs")
 	c.Namespace = envOrDefault("POD_NAMESPACE", "oci-model-cache")
+	c.HFTokenSecret = envOrDefault("HF_TOKEN_SECRET", "")
+	c.HFTokenSecretKey = envOrDefault("HF_TOKEN_SECRET_KEY", "")
 }
 
 func envOrDefault(key, fallback string) string {

--- a/operators/oci-model-cache/internal/controller/job_builder.go
+++ b/operators/oci-model-cache/internal/controller/job_builder.go
@@ -82,6 +82,21 @@ func buildCopyJob(mc *v1alpha1.ModelCache, cfg config.Config) *batchv1.Job {
 		job.Spec.Template.Spec.ServiceAccountName = cfg.SyncServiceAccount
 	}
 
+	if cfg.HFTokenSecret != "" {
+		job.Spec.Template.Spec.Containers[0].Env = append(
+			job.Spec.Template.Spec.Containers[0].Env,
+			corev1.EnvVar{
+				Name: "HF_TOKEN",
+				ValueFrom: &corev1.EnvVarSource{
+					SecretKeyRef: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{Name: cfg.HFTokenSecret},
+						Key:                  cfg.HFTokenSecretKey,
+					},
+				},
+			},
+		)
+	}
+
 	return job
 }
 

--- a/overlays/dev/oci-model-cache/values.yaml
+++ b/overlays/dev/oci-model-cache/values.yaml
@@ -13,6 +13,11 @@ controllerManager:
   env:
     ociRegistry: "ghcr.io/jomcgi/models"
     copyImage: "ghcr.io/jomcgi/homelab/tools/hf2oci:main"
+hfToken:
+  create: true
+  type: "onepassword"
+  onepassword:
+    itemPath: "vaults/k8s-homelab/items/oci-model-cache"
 extraResources:
   - apiVersion: onepassword.com/v1
     kind: OnePasswordItem


### PR DESCRIPTION
## Summary

- Wire `HF_TOKEN` through the full stack: Helm chart → operator deployment → resolver + copy Jobs
- Add `hfToken` values block with support for 1Password (`OnePasswordItem`) and manual Secret creation
- Operator resolver now authenticates with HuggingFace API for gated/private model repos
- Copy Jobs receive `HF_TOKEN` via `secretKeyRef` so `hf2oci copy` can download gated models
- Fully backwards compatible — no token injected when `hfToken` is unconfigured

## Test plan

- [x] `bazel test //operators/oci-model-cache/...` — all tests pass
- [x] `helm template` with dev overlay — HF_TOKEN env vars present, OnePasswordItem created
- [x] `helm template` with defaults — no HF_TOKEN env vars (backwards compatible)
- [ ] Deploy to dev and verify operator logs show "HuggingFace token configured"
- [ ] Verify copy Job for a gated model succeeds with the token

🤖 Generated with [Claude Code](https://claude.com/claude-code)