### PR TITLE
fix(argocd-image-updater): increase memory to fix fork() exhaustion

### DIFF
--- a/charts/argocd-image-updater/values.yaml
+++ b/charts/argocd-image-updater/values.yaml
@@ -46,9 +46,10 @@ argocd-image-updater:
       enabled: false
 
   # Resource limits
+  # 512Mi caused fork() exhaustion with 6+ ImageUpdaters at 10s interval
   resources:
     limits:
-      memory: 512Mi
+      memory: 1Gi
     requests:
       cpu: 500m
-      memory: 512Mi
+      memory: 1Gi


### PR DESCRIPTION
## Summary

- Bump image updater memory from 512Mi to 1Gi (limits and requests)
- Fixes `cannot fork() for remote-https: Resource temporarily unavailable` errors affecting **all 6 ImageUpdaters** (338 failures/hour)
- The image updater successfully resolves new digests but fails at the git write-back step because `fork()` can't allocate memory for `git-remote-https` subprocesses

## Root cause

With 6 ImageUpdater resources polling at 10s intervals, the pod spawns concurrent `git fetch` + `git push` processes. At 311Mi/512Mi usage, `fork()` fails because the kernel can't account for the new child process within the cgroup memory limit.

## Test plan

- [ ] After merge, verify `kubectl logs` no longer shows `cannot fork()` errors
- [ ] Verify `tag: main` values get updated to `tag: main@sha256:...` in overlay values files
- [ ] If fork errors persist, investigate PID cgroup limits as next suspect

🤖 Generated with [Claude Code](https://claude.com/claude-code)