### PR TITLE
fix(oci-model-cache): add cert-manager integration for webhook TLS

### DIFF
--- a/operators/oci-model-cache/helm/oci-model-cache-operator/templates/deployment.yaml
+++ b/operators/oci-model-cache/helm/oci-model-cache-operator/templates/deployment.yaml
@@ -105,10 +105,26 @@ spec:
         - name: HF_TOKEN_SECRET_KEY
           value: {{ .Values.hfToken.secretKey | quote }}
         {{- end }}
+        {{- if .Values.webhook.enabled }}
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        volumeMounts:
+        - name: webhook-certs
+          mountPath: /tmp/k8s-webhook-server/serving-certs
+          readOnly: true
+        {{- end }}
         lifecycle:
           preStop:
             exec:
               command: ["/bin/sh", "-c", "sleep 5"]
+      {{- if .Values.webhook.enabled }}
+      volumes:
+      - name: webhook-certs
+        secret:
+          secretName: {{ include "oci-model-cache-operator.fullname" . }}-webhook-cert
+      {{- end }}
       terminationGracePeriodSeconds: 60
       {{- with .Values.controllerManager.nodeSelector }}
       nodeSelector:

--- a/operators/oci-model-cache/helm/oci-model-cache-operator/templates/mutatingwebhookconfiguration.yaml
+++ b/operators/oci-model-cache/helm/oci-model-cache-operator/templates/mutatingwebhookconfiguration.yaml
@@ -5,6 +5,8 @@ metadata:
   name: {{ include "oci-model-cache-operator.fullname" . }}-mutating
   labels:
     {{- include "oci-model-cache-operator.labels" . | nindent 4 }}
+  annotations:
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "oci-model-cache-operator.fullname" . }}-webhook-cert
 webhooks:
 - admissionReviewVersions:
   - v1

--- a/operators/oci-model-cache/helm/oci-model-cache-operator/templates/webhook-certificate.yaml
+++ b/operators/oci-model-cache/helm/oci-model-cache-operator/templates/webhook-certificate.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.webhook.enabled }}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "oci-model-cache-operator.fullname" . }}-webhook-cert
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "oci-model-cache-operator.labels" . | nindent 4 }}
+spec:
+  secretName: {{ include "oci-model-cache-operator.fullname" . }}-webhook-cert
+  dnsNames:
+    - {{ include "oci-model-cache-operator.fullname" . }}-webhook.{{ .Release.Namespace }}.svc
+    - {{ include "oci-model-cache-operator.fullname" . }}-webhook.{{ .Release.Namespace }}.svc.cluster.local
+  issuerRef:
+    name: {{ .Values.webhook.certIssuer | default (printf "%s-selfsigned" (include "oci-model-cache-operator.fullname" .)) }}
+    kind: {{ .Values.webhook.certIssuerKind | default "Issuer" }}
+{{- end }}

--- a/operators/oci-model-cache/helm/oci-model-cache-operator/templates/webhook-selfsigned-issuer.yaml
+++ b/operators/oci-model-cache/helm/oci-model-cache-operator/templates/webhook-selfsigned-issuer.yaml
@@ -1,0 +1,11 @@
+{{- if and .Values.webhook.enabled .Values.webhook.createSelfSignedIssuer }}
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ include "oci-model-cache-operator.fullname" . }}-selfsigned
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "oci-model-cache-operator.labels" . | nindent 4 }}
+spec:
+  selfSigned: {}
+{{- end }}

--- a/operators/oci-model-cache/helm/oci-model-cache-operator/values.yaml
+++ b/operators/oci-model-cache/helm/oci-model-cache-operator/values.yaml
@@ -97,6 +97,12 @@ hfToken:
 
 webhook:
   enabled: true
+  # -- Create a namespace-scoped self-signed Issuer for the webhook cert
+  createSelfSignedIssuer: true
+  # -- Override the cert-manager Issuer name (defaults to fullname-selfsigned)
+  certIssuer: ""
+  # -- Issuer kind: "Issuer" (namespace) or "ClusterIssuer"
+  certIssuerKind: ""
 
 imageUpdater:
   enabled: false


### PR DESCRIPTION
## Summary

- Add cert-manager `Issuer` (self-signed, namespace-scoped) and `Certificate` for the webhook server TLS
- Mount the generated cert Secret into the operator Deployment at `/tmp/k8s-webhook-server/serving-certs/`
- Add `cert-manager.io/inject-ca-from` annotation to `MutatingWebhookConfiguration` so the API server trusts the webhook
- Add `webhook.createSelfSignedIssuer`, `webhook.certIssuer`, and `webhook.certIssuerKind` values for configurability

Fixes the operator crash-loop:
```
ERROR  setup  problem running manager  {"error": "open /tmp/k8s-webhook-server/serving-certs/tls.crt: no such file or directory"}
```

## Test plan

- [x] `bazel test //operators/oci-model-cache/...` — all tests pass
- [x] `helm template` renders correct Issuer → Certificate → Secret → Volume chain
- [ ] After merge, verify operator pod starts successfully and webhook endpoint responds

🤖 Generated with [Claude Code](https://claude.com/claude-code)