### PR TITLE
fix(hf2oci): treat GHCR 401/403 as not-found in CheckExists

### DIFF
--- a/tools/hf2oci/pkg/copy/copy_test.go
+++ b/tools/hf2oci/pkg/copy/copy_test.go
@@ -182,15 +182,23 @@ func TestCopyDryRun(t *testing.T) {
 	assert.Empty(t, result.Digest)
 }
 
-func TestCopyRegistryAuthIsPermanent(t *testing.T) {
+func TestCopyRegistryDeniedPassesCheckAndFailsOnPush(t *testing.T) {
 	hfSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		json.NewEncoder(w).Encode([]hf.TreeEntry{
-			{Type: "file", Path: "model.safetensors", Size: 256},
-		})
+		switch {
+		case r.URL.Path == "/api/models/Org/Model/tree/main":
+			json.NewEncoder(w).Encode([]hf.TreeEntry{
+				{Type: "file", Path: "model.safetensors", Size: 256},
+			})
+		case r.URL.Path == "/Org/Model/resolve/main/model.safetensors":
+			w.Header().Set("Content-Length", "256")
+			w.Write(make([]byte, 256))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
 	}))
 	defer hfSrv.Close()
 
-	// Registry that rejects all requests with 401.
+	// Registry that rejects all requests with 401 (GHCR behavior for nonexistent packages).
 	regSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusUnauthorized)
 	}))
@@ -207,8 +215,8 @@ func TestCopyRegistryAuthIsPermanent(t *testing.T) {
 		RemoteOpts: []remote.Option{},
 	})
 	require.Error(t, err)
-	assert.True(t, IsPermanent(err), "registry 401 should be a permanent error")
-	assert.Contains(t, err.Error(), "checking registry")
+	assert.False(t, IsPermanent(err), "push failure to 401 registry should be transient")
+	assert.Contains(t, err.Error(), "pushing", "should fail at push, not at registry check")
 }
 
 func TestCopyHF500IsTransient(t *testing.T) {

--- a/tools/hf2oci/pkg/copy/resolve_test.go
+++ b/tools/hf2oci/pkg/copy/resolve_test.go
@@ -97,7 +97,7 @@ func TestResolveCacheHit(t *testing.T) {
 	assert.Contains(t, result.Digest, "sha256:")
 }
 
-func TestResolveRegistryAuthIsPermanent(t *testing.T) {
+func TestResolveRegistryAuthTreatedAsNotFound(t *testing.T) {
 	hfSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		json.NewEncoder(w).Encode([]hf.TreeEntry{
 			{Type: "file", Path: "model.safetensors", Size: 256},
@@ -105,7 +105,7 @@ func TestResolveRegistryAuthIsPermanent(t *testing.T) {
 	}))
 	defer hfSrv.Close()
 
-	// Registry that rejects all requests with 401.
+	// Registry that rejects all requests with 401 (GHCR behavior for nonexistent packages).
 	regSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusUnauthorized)
 	}))
@@ -114,16 +114,16 @@ func TestResolveRegistryAuthIsPermanent(t *testing.T) {
 	client := hf.NewClient(hf.WithBaseURL(hfSrv.URL))
 	regHost := regSrv.Listener.Addr().String()
 
-	_, err := Resolve(context.Background(), ResolveOptions{
+	result, err := Resolve(context.Background(), ResolveOptions{
 		Repo:       "Org/Model",
 		Registry:   regHost + "/models",
 		Revision:   "main",
 		HFClient:   client,
 		RemoteOpts: []remote.Option{},
 	})
-	require.Error(t, err)
-	assert.True(t, IsPermanent(err), "registry 401 should be a permanent error")
-	assert.Contains(t, err.Error(), "checking registry")
+	require.NoError(t, err, "401 from registry should be treated as not-found, not an error")
+	assert.False(t, result.Cached)
+	assert.Empty(t, result.Digest)
 }
 
 func TestResolve404IsPermanent(t *testing.T) {

--- a/tools/hf2oci/pkg/oci/push.go
+++ b/tools/hf2oci/pkg/oci/push.go
@@ -14,15 +14,19 @@ import (
 
 // CheckExists checks if a tag already exists in the registry.
 // Returns the digest and true if found, empty string and false if not.
-// Only 404 is treated as "not found"; auth errors and 5xx are propagated.
+// 404, 401, and 403 are treated as "not found" because registries like GHCR
+// return DENIED/UNAUTHORIZED for packages that have never been pushed.
 func CheckExists(_ context.Context, ref name.Reference, opts ...remote.Option) (string, bool, error) {
 	desc, err := remote.Head(ref, opts...)
 	if err != nil {
 		var te *transport.Error
-		if errors.As(err, &te) && te.StatusCode == http.StatusNotFound {
-			return "", false, nil
+		if errors.As(err, &te) {
+			switch te.StatusCode {
+			case http.StatusNotFound, http.StatusUnauthorized, http.StatusForbidden:
+				return "", false, nil
+			}
 		}
-		// Propagate auth errors, 5xx, network errors so callers can react.
+		// Propagate 5xx, network errors so callers can react.
 		return "", false, fmt.Errorf("checking %s: %w", ref, err)
 	}
 	return desc.Digest.String(), true, nil

--- a/tools/hf2oci/pkg/oci/push_test.go
+++ b/tools/hf2oci/pkg/oci/push_test.go
@@ -31,7 +31,7 @@ func TestCheckExistsReturnsErrorOn500(t *testing.T) {
 	assert.Contains(t, err.Error(), "checking")
 }
 
-func TestCheckExistsReturnsErrorOn401(t *testing.T) {
+func TestCheckExists401IsNotFound(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusUnauthorized)
 	}))
@@ -41,7 +41,21 @@ func TestCheckExistsReturnsErrorOn401(t *testing.T) {
 	require.NoError(t, err)
 
 	_, exists, err := CheckExists(context.Background(), ref)
-	require.Error(t, err, "401 should be propagated, not swallowed")
+	require.NoError(t, err, "401 should be treated as not-found (GHCR returns DENIED for nonexistent packages)")
+	assert.False(t, exists)
+}
+
+func TestCheckExists403IsNotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer srv.Close()
+
+	ref, err := name.ParseReference(srv.Listener.Addr().String() + "/test/model:v1")
+	require.NoError(t, err)
+
+	_, exists, err := CheckExists(context.Background(), ref)
+	require.NoError(t, err, "403 should be treated as not-found (GHCR returns DENIED for nonexistent packages)")
 	assert.False(t, exists)
 }
 


### PR DESCRIPTION
## Summary
- GHCR returns `DENIED`/`UNAUTHORIZED` (401/403) for OCI packages that have never been pushed, rather than 404
- `CheckExists` now treats 401 and 403 the same as 404 — as "not found" — so first-time model pushes proceed instead of being marked as permanent failures
- Added explicit 403 test coverage alongside existing 401 and 404 tests

## Test plan
- [x] `bazel test //tools/hf2oci/...` — all 4 test targets pass
- [x] `TestCheckExists401IsNotFound` — verifies 401 → not-found
- [x] `TestCheckExists403IsNotFound` — verifies 403 → not-found
- [x] `TestResolveRegistryAuthTreatedAsNotFound` — verifies Resolve succeeds with Cached=false
- [x] `TestCopyRegistryDeniedPassesCheckAndFailsOnPush` — verifies Copy proceeds past check, fails at push (transient)
- [ ] After merge: delete and recreate `nllb-200-distilled-4bit` ModelCache CR to verify end-to-end flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)