### PR TITLE
fix(oci-model-cache): clear managedFields in SSA status patches

### DIFF
--- a/operators/oci-model-cache/internal/statemachine/model_cache_status.go
+++ b/operators/oci-model-cache/internal/statemachine/model_cache_status.go
@@ -44,8 +44,11 @@ func SSAPatch(state ModelCacheState) (client.Patch, error) {
 	// Create a minimal object with just the status fields we want to set
 	obj := state.Resource().DeepCopy()
 
-	// Clear everything except metadata identifiers and status
+	// Clear everything except metadata identifiers and status.
+	// managedFields must be nil — the API server owns those and rejects
+	// SSA patches that include them.
 	obj.Spec = v1alpha1.ModelCacheSpec{}
+	obj.ManagedFields = nil
 
 	// Apply the state to status
 	applyStateToStatus(state, &obj.Status)


### PR DESCRIPTION
## Summary
- `SSAPatch` deep-copies the full ModelCache resource including `metadata.managedFields`, which Kubernetes rejects in Server-Side Apply patches
- Added `obj.ManagedFields = nil` to clear the field before marshaling
- This was blocking all status transitions (Pending → Resolving → Syncing) with `metadata.managedFields must be nil`

## Test plan
- [x] `bazel test //operators/oci-model-cache/...` — all tests pass
- [ ] After merge: delete and recreate `nllb-200-distilled-4bit` ModelCache CR to verify status transitions work

🤖 Generated with [Claude Code](https://claude.com/claude-code)