### PR TITLE
fix(oci-model-cache): make digest optional in pre-push state validation

### DIFF
--- a/operators/oci-model-cache/internal/statemachine/model_cache_types.go
+++ b/operators/oci-model-cache/internal/statemachine/model_cache_types.go
@@ -57,12 +57,11 @@ type ResolveResult struct {
 }
 
 // Validate checks that all required fields in ResolveResult are present.
+// Digest is NOT validated here — it's only known after push and is checked
+// separately by states that require it (Ready).
 func (g ResolveResult) Validate() error {
 	if g.ResolvedRef == "" {
 		return fmt.Errorf("resolvedRef is required")
-	}
-	if g.Digest == "" {
-		return fmt.Errorf("digest is required")
 	}
 	if g.ResolvedRevision == "" {
 		return fmt.Errorf("resolvedRevision is required")
@@ -229,6 +228,9 @@ func (s ModelCacheReady) Resource() *v1alpha1.ModelCache {
 func (s ModelCacheReady) Validate() error {
 	if err := s.ResolveResult.Validate(); err != nil {
 		return err
+	}
+	if s.Digest == "" {
+		return fmt.Errorf("digest is required for Ready state")
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary
- `ResolveResult.Validate()` required `digest` to be non-empty, but digest is only known after OCI push completes
- This caused Resolving and Syncing states to fail validation, loop through Unknown→Pending, and never progress
- Moved digest validation to `ModelCacheReady.Validate()` — the only state where a digest is guaranteed

## Test plan
- [x] `bazel test //operators/oci-model-cache/...` — all tests pass
- [ ] After merge: verify ModelCache CR progresses past Resolving to Syncing/Ready

🤖 Generated with [Claude Code](https://claude.com/claude-code)