### PR TITLE
fix(perplexica): set static SearXNG secret key and pin image tags

### DIFF
--- a/overlays/prod/perplexica/values.yaml
+++ b/overlays/prod/perplexica/values.yaml
@@ -3,6 +3,10 @@
 
 fullnameOverride: "perplexica"
 
+## Pin images to specific versions to prevent rollout churn from :latest
+image:
+  tag: "v1.12.0"
+
 ## Disable linkerd injection (causes PostStartHook timeouts)
 podAnnotations:
   linkerd.io/inject: disabled
@@ -21,8 +25,12 @@ embedding:
 ## SearXNG configuration
 searxng:
   enabled: true
+  image:
+    tag: "2026.2.13-a2db6f650"
   settings:
     instanceName: "Homelab Search"
+    ## Static secret key to prevent ConfigMap churn (randAlphaNum changes every sync)
+    secretKey: "475795e9c97144931a97e7f8ab7f2ecb"
     ## Enable additional academic engines
     engines:
       google:


### PR DESCRIPTION
## Summary

- **Root cause**: SearXNG ConfigMap used `randAlphaNum 32` for `secret_key`, generating a new random value on every ArgoCD sync. The deployment's `checksum/config` annotation detected the change and triggered a rollout — creating **32+ ReplicaSets in 24 hours**
- **Cascading failure**: Rapid pod cycling prevented the Longhorn RWO volume from cleanly unmounting, causing persistent `MountVolume.MountDevice failed: already mounted or mount point busy` errors
- **Fix**: Set a static `secretKey` in prod values, pin both `perplexica` (v1.12.0) and `searxng` (2026.2.13-a2db6f650) images away from `:latest`

## Test plan

- [ ] Verify Helm template renders deterministically (`helm template` produces same `checksum/config` on repeated runs)
- [ ] After merge, confirm ArgoCD syncs without creating new ReplicaSets
- [ ] Confirm Perplexica pod starts successfully with volume mounted
- [ ] Verify SearXNG sidecar responds on port 8080

🤖 Generated with [Claude Code](https://claude.com/claude-code)