### PR TITLE
fix(oci-model-cache): move copyImage to fix Image Updater path resolution

### DIFF
--- a/operators/oci-model-cache/helm/oci-model-cache-operator/templates/deployment.yaml
+++ b/operators/oci-model-cache/helm/oci-model-cache-operator/templates/deployment.yaml
@@ -63,7 +63,7 @@ spec:
         - name: OCI_REGISTRY
           value: {{ .Values.controllerManager.env.ociRegistry | quote }}
         - name: COPY_IMAGE
-          value: "{{ .Values.controllerManager.env.copyImage.repository }}:{{ .Values.controllerManager.env.copyImage.tag }}"
+          value: "{{ .Values.controllerManager.copyImage.repository }}:{{ .Values.controllerManager.copyImage.tag }}"
         - name: SYNC_SERVICE_ACCOUNT
           value: {{ include "oci-model-cache-operator.syncServiceAccountName" . | quote }}
         - name: POD_NAMESPACE

--- a/operators/oci-model-cache/helm/oci-model-cache-operator/values.yaml
+++ b/operators/oci-model-cache/helm/oci-model-cache-operator/values.yaml
@@ -38,11 +38,12 @@ controllerManager:
   tolerations: []
   affinity: {}
 
+  copyImage:
+    repository: ghcr.io/jomcgi/homelab/tools/hf2oci
+    tag: main
+
   env:
     ociRegistry: "ghcr.io/jomcgi/models"
-    copyImage:
-      repository: ghcr.io/jomcgi/homelab/tools/hf2oci
-      tag: main
     syncServiceAccount: ""
 
   healthProbeBindAddress: ":8081"

--- a/overlays/dev/oci-model-cache/values.yaml
+++ b/overlays/dev/oci-model-cache/values.yaml
@@ -10,11 +10,11 @@ controllerManager:
     serviceVersion: "dev"
     sampler: "parentbased_traceidratio"
     samplerArg: "1.0"
+  copyImage:
+    repository: ghcr.io/jomcgi/homelab/tools/hf2oci
+    tag: main
   env:
     ociRegistry: "ghcr.io/jomcgi/models"
-    copyImage:
-      repository: ghcr.io/jomcgi/homelab/tools/hf2oci
-      tag: main
 hfToken:
   create: true
   type: "onepassword"
@@ -31,8 +31,8 @@ imageUpdater:
   - alias: hf2oci
     imageName: ghcr.io/jomcgi/homelab/tools/hf2oci:main
     helm:
-      name: controllerManager.env.copyImage.repository
-      tag: controllerManager.env.copyImage.tag
+      name: controllerManager.copyImage.repository
+      tag: controllerManager.copyImage.tag
   writeBack:
     method: git:secret:argocd/argocd-image-updater-token
     repository: https://github.com/jomcgi/homelab.git


### PR DESCRIPTION
## Summary
- Move `copyImage` from `controllerManager.env.copyImage` up to `controllerManager.copyImage` to fix ArgoCD Image Updater "parameter not found" error
- The 4-level deep path `controllerManager.env.copyImage.tag` was not resolvable by the `helmvalues` write-back; the 3-level path `controllerManager.copyImage.tag` matches the pattern used by all other working services (Marine, Stargazer, etc.)

## Test plan
- [x] `helm template` renders correct `COPY_IMAGE` env var
- [x] `helm template` renders correct ImageUpdater CR with new paths
- [x] `bazel test //operators/oci-model-cache/...` passes
- [ ] After merge: verify Image Updater reconciles without errors in ArgoCD logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)