### PR TITLE
fix(oci-model-cache): remove hf2oci from ImageUpdater tracking

### DIFF
--- a/overlays/dev/oci-model-cache/values.yaml
+++ b/overlays/dev/oci-model-cache/values.yaml
@@ -28,11 +28,6 @@ imageUpdater:
     helm:
       name: controllerManager.image.repository
       tag: controllerManager.image.tag
-  - alias: hf2oci
-    imageName: ghcr.io/jomcgi/homelab/tools/hf2oci:main
-    helm:
-      name: controllerManager.copyImage.repository
-      tag: controllerManager.copyImage.tag
   writeBack:
     method: git:secret:argocd/argocd-image-updater-token
     repository: https://github.com/jomcgi/homelab.git


### PR DESCRIPTION
## Summary
- Remove hf2oci copy image from ArgoCD Image Updater tracking
- The Image Updater matches tracked images against `status.summary.images` (container images in pod specs). Since hf2oci is referenced as an env var (`COPY_IMAGE`), not as a container image, it never appears in status images and causes "parameter not found" during write-back
- This was blocking the operator image from being updated too (the entire commit fails)

## Root cause
The ArgoCD Image Updater can only track images that appear as actual container images in Kubernetes pod specs. The hf2oci image is used as a configuration value (env var) that tells the operator what image to use when creating copy Jobs — it's not a container the Application itself runs.

## Test plan
- [x] `helm template` renders ImageUpdater CR with only the operator image
- [ ] After merge: verify Image Updater reconciles without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)