### PR TITLE
fix(oci-model-cache): add ForceOwnership to SSA status patches

### DIFF
--- a/operators/oci-model-cache/internal/controller/modelcache_controller.go
+++ b/operators/oci-model-cache/internal/controller/modelcache_controller.go
@@ -256,7 +256,7 @@ func (v *modelCacheVisitor) updateStatus(newState sm.ModelCacheState) VisitResul
 	}
 
 	resource := newState.Resource()
-	if err := v.reconciler.Status().Patch(v.ctx, resource, patch, client.FieldOwner(sm.FieldManager)); err != nil {
+	if err := v.reconciler.Status().Patch(v.ctx, resource, patch, client.FieldOwner(sm.FieldManager), client.ForceOwnership); err != nil {
 		return VisitResult{Error: err}
 	}
 


### PR DESCRIPTION
## Summary
- Add `client.ForceOwnership` to the SSA status patch call
- When a ModelCache CR is created via `kubectl apply`, the `"app"` field manager claims `.status.phase`. Without force, the operator's SSA patch fails with a persistent conflict error on every reconcile

## Test plan
- [x] `bazel test //operators/oci-model-cache/...` passes
- [ ] After merge: verify the operator can update status on the existing `nllb-200-distilled-4bit` ModelCache CR

🤖 Generated with [Claude Code](https://claude.com/claude-code)