### PR TITLE
fix(hf2oci): treat HTTP 429 as transient error

### DIFF
--- a/tools/hf2oci/pkg/copy/copy_test.go
+++ b/tools/hf2oci/pkg/copy/copy_test.go
@@ -259,6 +259,26 @@ func TestCopy404IsPermanent(t *testing.T) {
 	assert.Contains(t, err.Error(), "not found (HTTP 404)")
 }
 
+func TestCopyHF429IsTransient(t *testing.T) {
+	hfSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+		w.Write([]byte(`{"error":"Rate limit exceeded"}`))
+	}))
+	defer hfSrv.Close()
+
+	client := hf.NewClient(hf.WithBaseURL(hfSrv.URL))
+	_, err := Copy(context.Background(), Options{
+		Repo:       "Org/Model",
+		Registry:   "ghcr.io/test",
+		Revision:   "main",
+		HFClient:   client,
+		RemoteOpts: []remote.Option{},
+	})
+	require.Error(t, err)
+	assert.False(t, IsPermanent(err), "HF 429 should be transient (retryable)")
+	assert.Contains(t, err.Error(), "listing repo")
+}
+
 func TestCopyMultipleWeightShards(t *testing.T) {
 	const shardCount = 8
 	const shardSize = 512

--- a/tools/hf2oci/pkg/copy/resolve.go
+++ b/tools/hf2oci/pkg/copy/resolve.go
@@ -48,7 +48,7 @@ func resolveModel(ctx context.Context, client *hf.Client, repo, registry, revisi
 	if err != nil {
 		wrapped := fmt.Errorf("listing repo: %w", err)
 		var apiErr *hf.APIError
-		if errors.As(err, &apiErr) && apiErr.IsClientError() {
+		if errors.As(err, &apiErr) && apiErr.IsClientError() && !apiErr.IsRetryable() {
 			return nil, Permanent(wrapped)
 		}
 		return nil, wrapped
@@ -136,7 +136,9 @@ func Resolve(ctx context.Context, opts ResolveOptions) (*Result, error) {
 func wrapRegistryError(err error) error {
 	wrapped := fmt.Errorf("checking registry: %w", err)
 	var te *transport.Error
-	if errors.As(err, &te) && te.StatusCode >= http.StatusBadRequest && te.StatusCode < http.StatusInternalServerError {
+	if errors.As(err, &te) && te.StatusCode >= http.StatusBadRequest &&
+		te.StatusCode < http.StatusInternalServerError &&
+		te.StatusCode != http.StatusTooManyRequests {
 		return Permanent(wrapped)
 	}
 	return wrapped

--- a/tools/hf2oci/pkg/hf/client.go
+++ b/tools/hf2oci/pkg/hf/client.go
@@ -148,6 +148,11 @@ func (e *APIError) IsClientError() bool {
 	return e.StatusCode >= 400 && e.StatusCode < 500
 }
 
+// IsRetryable reports whether the error is a retryable status (429, 408).
+func (e *APIError) IsRetryable() bool {
+	return e.StatusCode == http.StatusTooManyRequests || e.StatusCode == http.StatusRequestTimeout
+}
+
 func checkResponse(resp *http.Response) error {
 	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
 		return nil

--- a/tools/hf2oci/pkg/hf/client_test.go
+++ b/tools/hf2oci/pkg/hf/client_test.go
@@ -77,6 +77,24 @@ func TestTreeUnauthorized(t *testing.T) {
 	assert.True(t, apiErr.IsClientError())
 }
 
+func TestTree429IsRetryable(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+		w.Write([]byte(`{"error":"Rate limit exceeded"}`))
+	}))
+	defer srv.Close()
+
+	c := NewClient(WithBaseURL(srv.URL))
+	_, err := c.Tree(context.Background(), "some/repo", "main")
+	require.Error(t, err)
+
+	var apiErr *APIError
+	require.ErrorAs(t, err, &apiErr)
+	assert.Equal(t, 429, apiErr.StatusCode)
+	assert.True(t, apiErr.IsClientError(), "429 is in the 4xx range")
+	assert.True(t, apiErr.IsRetryable(), "429 should be retryable")
+}
+
 func TestDownload(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "/MyOrg/MyModel/resolve/main/config.json", r.URL.Path)


### PR DESCRIPTION
## Summary
- Add `IsRetryable()` method to `APIError` for HTTP 429 (Too Many Requests) and 408 (Request Timeout)
- Exclude retryable errors from permanent classification in `resolveModel()` and `wrapRegistryError()`
- Previously, HuggingFace rate limits caused ModelCache to fail permanently with no retries

## Test plan
- [x] `TestTree429IsRetryable` — verifies `APIError.IsRetryable()` returns true for 429
- [x] `TestCopyHF429IsTransient` — verifies 429 from HF API is NOT wrapped as `PermanentError`
- [x] `TestCopy404IsPermanent` — existing test still passes (404 remains permanent)
- [x] `TestCopyHF500IsTransient` — existing test still passes (500 remains transient)
- [x] All operator tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)