### PR TITLE
feat(hf2oci): smart OCI naming from HF baseModels API

### DIFF
--- a/tools/hf2oci/pkg/copy/copy.go
+++ b/tools/hf2oci/pkg/copy/copy.go
@@ -212,8 +212,16 @@ func DeriveTag(tag, revision string) string {
 	return "rev-" + rev
 }
 
-// deriveRepoName converts a HuggingFace repo name to a valid OCI repo path component.
-// e.g. "NousResearch/Hermes-4.3-Llama-3-36B-AWQ" → "nousresearch-hermes-4.3-llama-3-36b-awq"
+// deriveRepoName converts a HuggingFace repo name to an OCI repo path,
+// preserving the org/model structure for cleaner registry organization.
+// e.g. "NousResearch/Hermes-4.3-Llama-3-36B-AWQ" → "nousresearch/hermes-4.3-llama-3-36b-awq"
 func deriveRepoName(repo string) string {
+	return strings.ToLower(repo)
+}
+
+// deriveVariantTag flattens a HuggingFace repo name into a valid OCI tag.
+// Used for derivative models to encode the variant identity in the tag.
+// e.g. "Emilio407/nllb-200-distilled-1.3B-4bit" → "emilio407-nllb-200-distilled-1.3b-4bit"
+func deriveVariantTag(repo string) string {
 	return strings.ToLower(strings.ReplaceAll(repo, "/", "-"))
 }

--- a/tools/hf2oci/pkg/copy/copy_test.go
+++ b/tools/hf2oci/pkg/copy/copy_test.go
@@ -29,6 +29,8 @@ func TestCopySafetensors(t *testing.T) {
 				{Type: "file", Path: "model.safetensors", Size: 1024},
 				{Type: "file", Path: "README.md", Size: 50},
 			})
+		case r.URL.Path == "/api/models/TestOrg/TestModel":
+			json.NewEncoder(w).Encode(hf.ModelInfo{ID: "TestOrg/TestModel"})
 		case r.URL.Path == "/TestOrg/TestModel/resolve/abc123def456/config.json":
 			w.Write([]byte(`{"model_type":"test"}`))
 		case r.URL.Path == "/TestOrg/TestModel/resolve/abc123def456/tokenizer.json":
@@ -60,7 +62,7 @@ func TestCopySafetensors(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	assert.Equal(t, regHost+"/models/testorg-testmodel:rev-abc123def456", result.Ref)
+	assert.Equal(t, regHost+"/models/testorg/testmodel:rev-abc123def456", result.Ref)
 	assert.Contains(t, result.Digest, "sha256:")
 	assert.False(t, result.Cached)
 	assert.Equal(t, "TestOrg/TestModel", result.Repo)
@@ -88,6 +90,8 @@ func TestCopyGGUF(t *testing.T) {
 				{Type: "file", Path: "model-q4.gguf", Size: 512},
 				{Type: "file", Path: "README.md", Size: 50},
 			})
+		case r.URL.Path == "/api/models/Qwen/Qwen2.5-GGUF":
+			json.NewEncoder(w).Encode(hf.ModelInfo{ID: "Qwen/Qwen2.5-GGUF"})
 		case r.URL.Path == "/Qwen/Qwen2.5-GGUF/resolve/main/model-q4.gguf":
 			w.Header().Set("Content-Length", "512")
 			w.Write(make([]byte, 512))
@@ -113,7 +117,7 @@ func TestCopyGGUF(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	assert.Equal(t, regHost+"/models/qwen-qwen2.5-gguf:rev-main", result.Ref)
+	assert.Equal(t, regHost+"/models/qwen/qwen2.5-gguf:rev-main", result.Ref)
 	assert.False(t, result.Cached)
 }
 
@@ -124,6 +128,8 @@ func TestCopyCacheHit(t *testing.T) {
 			json.NewEncoder(w).Encode([]hf.TreeEntry{
 				{Type: "file", Path: "model.safetensors", Size: 256},
 			})
+		case r.URL.Path == "/api/models/Org/Model":
+			json.NewEncoder(w).Encode(hf.ModelInfo{ID: "Org/Model"})
 		case r.URL.Path == "/Org/Model/resolve/rev1/model.safetensors":
 			w.Header().Set("Content-Length", "256")
 			w.Write(make([]byte, 256))
@@ -162,9 +168,16 @@ func TestCopyCacheHit(t *testing.T) {
 
 func TestCopyDryRun(t *testing.T) {
 	hfSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		json.NewEncoder(w).Encode([]hf.TreeEntry{
-			{Type: "file", Path: "model.safetensors", Size: 1024},
-		})
+		switch {
+		case r.URL.Path == "/api/models/Org/Model/tree/abc123":
+			json.NewEncoder(w).Encode([]hf.TreeEntry{
+				{Type: "file", Path: "model.safetensors", Size: 1024},
+			})
+		case r.URL.Path == "/api/models/Org/Model":
+			json.NewEncoder(w).Encode(hf.ModelInfo{ID: "Org/Model"})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
 	}))
 	defer hfSrv.Close()
 
@@ -178,7 +191,7 @@ func TestCopyDryRun(t *testing.T) {
 		HFClient: client,
 	})
 	require.NoError(t, err)
-	assert.Equal(t, "ghcr.io/test/org-model:rev-abc123", result.Ref)
+	assert.Equal(t, "ghcr.io/test/org/model:rev-abc123", result.Ref)
 	assert.Empty(t, result.Digest)
 }
 
@@ -189,6 +202,8 @@ func TestCopyRegistryDeniedPassesCheckAndFailsOnPush(t *testing.T) {
 			json.NewEncoder(w).Encode([]hf.TreeEntry{
 				{Type: "file", Path: "model.safetensors", Size: 256},
 			})
+		case r.URL.Path == "/api/models/Org/Model":
+			json.NewEncoder(w).Encode(hf.ModelInfo{ID: "Org/Model"})
 		case r.URL.Path == "/Org/Model/resolve/main/model.safetensors":
 			w.Header().Set("Content-Length", "256")
 			w.Write(make([]byte, 256))
@@ -297,6 +312,8 @@ func TestCopyMultipleWeightShards(t *testing.T) {
 				})
 			}
 			json.NewEncoder(w).Encode(entries)
+		case r.URL.Path == "/api/models/Org/ShardedModel":
+			json.NewEncoder(w).Encode(hf.ModelInfo{ID: "Org/ShardedModel"})
 		case r.URL.Path == "/Org/ShardedModel/resolve/main/config.json":
 			w.Write([]byte(`{"model_type":"test"}`))
 		default:
@@ -361,16 +378,78 @@ func TestCopyMultipleWeightShards(t *testing.T) {
 	}
 }
 
+func TestCopyWithBaseModel(t *testing.T) {
+	hfSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/api/models/Emilio407/nllb-200-distilled-1.3B-4bit/tree/main":
+			json.NewEncoder(w).Encode([]hf.TreeEntry{
+				{Type: "file", Path: "config.json", Size: 100},
+				{Type: "file", Path: "model.safetensors", Size: 512},
+			})
+		case r.URL.Path == "/api/models/Emilio407/nllb-200-distilled-1.3B-4bit":
+			json.NewEncoder(w).Encode(hf.ModelInfo{
+				ID: "Emilio407/nllb-200-distilled-1.3B-4bit",
+				BaseModels: &hf.BaseModels{
+					Relation: "quantized",
+					Models:   []hf.BaseModel{{ID: "facebook/nllb-200-distilled-1.3B"}},
+				},
+			})
+		case r.URL.Path == "/Emilio407/nllb-200-distilled-1.3B-4bit/resolve/main/config.json":
+			w.Write([]byte(`{"model_type":"test"}`))
+		case r.URL.Path == "/Emilio407/nllb-200-distilled-1.3B-4bit/resolve/main/model.safetensors":
+			w.Header().Set("Content-Length", "512")
+			w.Write(make([]byte, 512))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer hfSrv.Close()
+
+	reg := registry.New()
+	regSrv := httptest.NewServer(reg)
+	defer regSrv.Close()
+
+	client := hf.NewClient(hf.WithBaseURL(hfSrv.URL))
+	regHost := regSrv.Listener.Addr().String()
+
+	result, err := Copy(context.Background(), Options{
+		Repo:       "Emilio407/nllb-200-distilled-1.3B-4bit",
+		Registry:   regHost + "/models",
+		Revision:   "main",
+		HFClient:   client,
+		RemoteOpts: []remote.Option{},
+	})
+	require.NoError(t, err)
+
+	// Derivative model: repo path uses base model, tag uses variant name.
+	assert.Equal(t, regHost+"/models/facebook/nllb-200-distilled-1.3b:emilio407-nllb-200-distilled-1.3b-4bit", result.Ref)
+	assert.Contains(t, result.Digest, "sha256:")
+	assert.False(t, result.Cached)
+}
+
 func TestDeriveRepoName(t *testing.T) {
 	tests := []struct {
 		input string
 		want  string
 	}{
-		{"NousResearch/Hermes-4.3-Llama-3-36B-AWQ", "nousresearch-hermes-4.3-llama-3-36b-awq"},
-		{"Qwen/Qwen2.5-0.5B-Instruct-GGUF", "qwen-qwen2.5-0.5b-instruct-gguf"},
-		{"org/model", "org-model"},
+		{"NousResearch/Hermes-4.3-Llama-3-36B-AWQ", "nousresearch/hermes-4.3-llama-3-36b-awq"},
+		{"Qwen/Qwen2.5-0.5B-Instruct-GGUF", "qwen/qwen2.5-0.5b-instruct-gguf"},
+		{"org/model", "org/model"},
 	}
 	for _, tt := range tests {
 		assert.Equal(t, tt.want, deriveRepoName(tt.input))
+	}
+}
+
+func TestDeriveVariantTag(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"Emilio407/nllb-200-distilled-1.3B-4bit", "emilio407-nllb-200-distilled-1.3b-4bit"},
+		{"Org/Model", "org-model"},
+	}
+	for _, tt := range tests {
+		assert.Equal(t, tt.want, deriveVariantTag(tt.input))
 	}
 }

--- a/tools/hf2oci/pkg/copy/resolve.go
+++ b/tools/hf2oci/pkg/copy/resolve.go
@@ -60,10 +60,19 @@ func resolveModel(ctx context.Context, client *hf.Client, repo, registry, revisi
 		return nil, Permanent(fmt.Errorf("classifying files: %w", err))
 	}
 
-	// 3. Derive tag and ref.
-	t := DeriveTag(tag, revision)
-	repoName := deriveRepoName(repo)
-	refStr := fmt.Sprintf("%s/%s:%s", registry, repoName, t)
+	// 3. Fetch model info for smart naming (non-fatal on failure).
+	var repoPath, ociTag string
+	info, infoErr := client.ModelInfo(ctx, repo)
+	if infoErr == nil && info.BaseModels != nil && len(info.BaseModels.Models) > 0 {
+		// Derivative model: group under base model's repo path for layer dedup.
+		repoPath = deriveRepoName(info.BaseModels.Models[0].ID)
+		ociTag = deriveVariantTag(repo)
+	} else {
+		// Base model or ModelInfo unavailable: use repo directly.
+		repoPath = deriveRepoName(repo)
+		ociTag = DeriveTag(tag, revision)
+	}
+	refStr := fmt.Sprintf("%s/%s:%s", registry, repoPath, ociTag)
 
 	ref, err := name.ParseReference(refStr)
 	if err != nil {

--- a/tools/hf2oci/pkg/copy/resolve_test.go
+++ b/tools/hf2oci/pkg/copy/resolve_test.go
@@ -17,10 +17,17 @@ import (
 
 func TestResolveSuccess(t *testing.T) {
 	hfSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		json.NewEncoder(w).Encode([]hf.TreeEntry{
-			{Type: "file", Path: "config.json", Size: 100},
-			{Type: "file", Path: "model.safetensors", Size: 4096},
-		})
+		switch {
+		case r.URL.Path == "/api/models/Org/Model/tree/abc123":
+			json.NewEncoder(w).Encode([]hf.TreeEntry{
+				{Type: "file", Path: "config.json", Size: 100},
+				{Type: "file", Path: "model.safetensors", Size: 4096},
+			})
+		case r.URL.Path == "/api/models/Org/Model":
+			json.NewEncoder(w).Encode(hf.ModelInfo{ID: "Org/Model"})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
 	}))
 	defer hfSrv.Close()
 
@@ -39,7 +46,7 @@ func TestResolveSuccess(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	assert.Equal(t, regHost+"/models/org-model:rev-abc123", result.Ref)
+	assert.Equal(t, regHost+"/models/org/model:rev-abc123", result.Ref)
 	assert.False(t, result.Cached)
 	assert.Empty(t, result.Digest)
 	assert.Equal(t, "Org/Model", result.Repo)
@@ -56,6 +63,8 @@ func TestResolveCacheHit(t *testing.T) {
 			json.NewEncoder(w).Encode([]hf.TreeEntry{
 				{Type: "file", Path: "model.safetensors", Size: 256},
 			})
+		case r.URL.Path == "/api/models/Org/Model":
+			json.NewEncoder(w).Encode(hf.ModelInfo{ID: "Org/Model"})
 		case r.URL.Path == "/Org/Model/resolve/rev1/model.safetensors":
 			w.Header().Set("Content-Length", "256")
 			w.Write(make([]byte, 256))
@@ -99,9 +108,16 @@ func TestResolveCacheHit(t *testing.T) {
 
 func TestResolveRegistryAuthTreatedAsNotFound(t *testing.T) {
 	hfSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		json.NewEncoder(w).Encode([]hf.TreeEntry{
-			{Type: "file", Path: "model.safetensors", Size: 256},
-		})
+		switch {
+		case r.URL.Path == "/api/models/Org/Model/tree/main":
+			json.NewEncoder(w).Encode([]hf.TreeEntry{
+				{Type: "file", Path: "model.safetensors", Size: 256},
+			})
+		case r.URL.Path == "/api/models/Org/Model":
+			json.NewEncoder(w).Encode(hf.ModelInfo{ID: "Org/Model"})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
 	}))
 	defer hfSrv.Close()
 
@@ -166,4 +182,45 @@ func TestResolveNoWeightsIsPermanent(t *testing.T) {
 	require.Error(t, err)
 	assert.True(t, IsPermanent(err), "no weights should be a permanent error")
 	assert.Contains(t, err.Error(), "no weight files found")
+}
+
+func TestResolveWithBaseModel(t *testing.T) {
+	hfSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/api/models/Variant/Quantized-Model/tree/main":
+			json.NewEncoder(w).Encode([]hf.TreeEntry{
+				{Type: "file", Path: "model.safetensors", Size: 512},
+			})
+		case r.URL.Path == "/api/models/Variant/Quantized-Model":
+			json.NewEncoder(w).Encode(hf.ModelInfo{
+				ID: "Variant/Quantized-Model",
+				BaseModels: &hf.BaseModels{
+					Relation: "quantized",
+					Models:   []hf.BaseModel{{ID: "Base/Original-Model"}},
+				},
+			})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer hfSrv.Close()
+
+	reg := registry.New()
+	regSrv := httptest.NewServer(reg)
+	defer regSrv.Close()
+	regHost := regSrv.Listener.Addr().String()
+
+	client := hf.NewClient(hf.WithBaseURL(hfSrv.URL))
+	result, err := Resolve(context.Background(), ResolveOptions{
+		Repo:       "Variant/Quantized-Model",
+		Registry:   regHost + "/models",
+		Revision:   "main",
+		HFClient:   client,
+		RemoteOpts: []remote.Option{},
+	})
+	require.NoError(t, err)
+
+	// Derivative: repo path from base model, tag from variant name.
+	assert.Equal(t, regHost+"/models/base/original-model:variant-quantized-model", result.Ref)
+	assert.False(t, result.Cached)
 }

--- a/tools/hf2oci/pkg/hf/client.go
+++ b/tools/hf2oci/pkg/hf/client.go
@@ -93,6 +93,34 @@ func (c *Client) Tree(ctx context.Context, repo, revision string) ([]TreeEntry, 
 	return entries, nil
 }
 
+// ModelInfo fetches model metadata including base model relationships.
+// Use expand[]=baseModels to get lineage information for smart OCI naming.
+func (c *Client) ModelInfo(ctx context.Context, repo string) (*ModelInfo, error) {
+	u := fmt.Sprintf("%s/api/models/%s?expand[]=baseModels", c.baseURL, repo)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+	c.setAuth(req)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetching model info: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if err := checkResponse(resp); err != nil {
+		return nil, err
+	}
+
+	var info ModelInfo
+	if err := json.NewDecoder(resp.Body).Decode(&info); err != nil {
+		return nil, fmt.Errorf("decoding model info: %w", err)
+	}
+	return &info, nil
+}
+
 // Download fetches a file from a HuggingFace model repository.
 // The caller must close the returned ReadCloser.
 func (c *Client) Download(ctx context.Context, repo, revision, path string) (io.ReadCloser, int64, error) {

--- a/tools/hf2oci/pkg/hf/client_test.go
+++ b/tools/hf2oci/pkg/hf/client_test.go
@@ -95,6 +95,47 @@ func TestTree429IsRetryable(t *testing.T) {
 	assert.True(t, apiErr.IsRetryable(), "429 should be retryable")
 }
 
+func TestModelInfo(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/models/Emilio407/nllb-200-distilled-1.3B-4bit", r.URL.Path)
+		assert.Equal(t, "baseModels", r.URL.Query().Get("expand[]"))
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{
+			"id": "Emilio407/nllb-200-distilled-1.3B-4bit",
+			"baseModels": {
+				"relation": "quantized",
+				"models": [{"id": "facebook/nllb-200-distilled-1.3B"}]
+			}
+		}`))
+	}))
+	defer srv.Close()
+
+	c := NewClient(WithBaseURL(srv.URL), WithToken("test-token"))
+	info, err := c.ModelInfo(context.Background(), "Emilio407/nllb-200-distilled-1.3B-4bit")
+	require.NoError(t, err)
+
+	assert.Equal(t, "Emilio407/nllb-200-distilled-1.3B-4bit", info.ID)
+	require.NotNil(t, info.BaseModels)
+	assert.Equal(t, "quantized", info.BaseModels.Relation)
+	require.Len(t, info.BaseModels.Models, 1)
+	assert.Equal(t, "facebook/nllb-200-distilled-1.3B", info.BaseModels.Models[0].ID)
+}
+
+func TestModelInfoNoBaseModel(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"id": "facebook/nllb-200-distilled-1.3B"}`))
+	}))
+	defer srv.Close()
+
+	c := NewClient(WithBaseURL(srv.URL))
+	info, err := c.ModelInfo(context.Background(), "facebook/nllb-200-distilled-1.3B")
+	require.NoError(t, err)
+
+	assert.Equal(t, "facebook/nllb-200-distilled-1.3B", info.ID)
+	assert.Nil(t, info.BaseModels)
+}
+
 func TestDownload(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "/MyOrg/MyModel/resolve/main/config.json", r.URL.Path)

--- a/tools/hf2oci/pkg/hf/types.go
+++ b/tools/hf2oci/pkg/hf/types.go
@@ -13,3 +13,20 @@ type LFSInfo struct {
 	OID  string `json:"oid"` // "sha256:abc..."
 	Size int64  `json:"size"`
 }
+
+// ModelInfo holds metadata from the /api/models/{repo} endpoint.
+type ModelInfo struct {
+	ID         string      `json:"id"`
+	BaseModels *BaseModels `json:"baseModels,omitempty"`
+}
+
+// BaseModels describes the lineage relationship to a parent model.
+type BaseModels struct {
+	Relation string      `json:"relation"` // "quantized", "finetune", "adapter", "merge"
+	Models   []BaseModel `json:"models"`
+}
+
+// BaseModel identifies a parent model.
+type BaseModel struct {
+	ID string `json:"id"` // HF repo identifier (e.g. "facebook/nllb-200-distilled-1.3B")
+}


### PR DESCRIPTION
## Summary
- Call HuggingFace `/api/models/{repo}?expand[]=baseModels` to detect derivative model relationships
- Derivative models (quantized, finetune, adapter, merge) are grouped under the base model's OCI repo path, with the variant name as the tag — enabling blob deduplication for shared config/tokenizer layers
- Base models now preserve the `org/model` structure in the OCI repo path instead of flattening to `org-model`
- `ModelInfo()` failures are non-fatal — falls back to standard naming

### Example OCI refs

| HF Repo | Base Model | OCI Reference |
|---------|-----------|--------------|
| `facebook/nllb-200-distilled-1.3B` | (none) | `ghcr.io/.../facebook/nllb-200-distilled-1.3b:rev-main` |
| `Emilio407/nllb-200-distilled-1.3B-4bit` | `facebook/nllb-200-distilled-1.3B` | `ghcr.io/.../facebook/nllb-200-distilled-1.3b:emilio407-nllb-200-distilled-1.3b-4bit` |

## Test plan
- [x] `TestModelInfo` — verifies ModelInfo response with baseModels
- [x] `TestModelInfoNoBaseModel` — verifies ModelInfo without baseModels
- [x] `TestCopyWithBaseModel` — end-to-end: derivative model uses base model repo path
- [x] `TestResolveWithBaseModel` — resolve produces correct ref for derivative
- [x] `TestDeriveVariantTag` — variant tag flattening
- [x] `TestDeriveRepoName` — updated for preserved `/` behavior
- [x] All existing tests updated and passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)