### PR TITLE
feat(hf2oci): add TTL cache for HF API responses

### DIFF
--- a/operators/oci-model-cache/cmd/main.go
+++ b/operators/oci-model-cache/cmd/main.go
@@ -236,8 +236,9 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Initialize HuggingFace client
-	var hfOpts []hf.Option
+	// Initialize HuggingFace client with 1-hour response cache — Tree and ModelInfo
+	// responses are effectively immutable for a given repo+revision.
+	hfOpts := []hf.Option{hf.WithCacheTTL(1 * time.Hour)}
 	if token := os.Getenv("HF_TOKEN"); token != "" {
 		hfOpts = append(hfOpts, hf.WithToken(token))
 		setupLog.Info("HuggingFace token configured")

--- a/tools/hf2oci/pkg/hf/client.go
+++ b/tools/hf2oci/pkg/hf/client.go
@@ -7,6 +7,8 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"sync"
+	"time"
 )
 
 const defaultBaseURL = "https://huggingface.co"
@@ -16,6 +18,13 @@ type Client struct {
 	baseURL    string
 	token      string
 	httpClient *http.Client
+	cacheTTL   time.Duration
+	cache      sync.Map // key → cacheEntry
+}
+
+type cacheEntry struct {
+	data      any
+	expiresAt time.Time
 }
 
 // Option configures a Client.
@@ -34,6 +43,12 @@ func WithBaseURL(u string) Option {
 // WithHTTPClient sets a custom HTTP client.
 func WithHTTPClient(hc *http.Client) Option {
 	return func(c *Client) { c.httpClient = hc }
+}
+
+// WithCacheTTL enables in-memory caching of Tree and ModelInfo responses.
+// Cached entries expire after the given duration. Zero disables caching.
+func WithCacheTTL(ttl time.Duration) Option {
+	return func(c *Client) { c.cacheTTL = ttl }
 }
 
 // NewClient creates a new HuggingFace API client.
@@ -68,6 +83,11 @@ func (c *Client) checkRedirect(req *http.Request, via []*http.Request) error {
 
 // Tree lists all files in a HuggingFace model repository.
 func (c *Client) Tree(ctx context.Context, repo, revision string) ([]TreeEntry, error) {
+	cacheKey := "tree\x00" + repo + "\x00" + revision
+	if cached, ok := c.loadCache(cacheKey); ok {
+		return cached.([]TreeEntry), nil
+	}
+
 	u := fmt.Sprintf("%s/api/models/%s/tree/%s", c.baseURL, repo, url.PathEscape(revision))
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
@@ -90,12 +110,19 @@ func (c *Client) Tree(ctx context.Context, repo, revision string) ([]TreeEntry, 
 	if err := json.NewDecoder(resp.Body).Decode(&entries); err != nil {
 		return nil, fmt.Errorf("decoding tree response: %w", err)
 	}
+
+	c.storeCache(cacheKey, entries)
 	return entries, nil
 }
 
 // ModelInfo fetches model metadata including base model relationships.
 // Use expand[]=baseModels to get lineage information for smart OCI naming.
 func (c *Client) ModelInfo(ctx context.Context, repo string) (*ModelInfo, error) {
+	cacheKey := "info\x00" + repo
+	if cached, ok := c.loadCache(cacheKey); ok {
+		return cached.(*ModelInfo), nil
+	}
+
 	u := fmt.Sprintf("%s/api/models/%s?expand[]=baseModels", c.baseURL, repo)
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
@@ -118,6 +145,8 @@ func (c *Client) ModelInfo(ctx context.Context, repo string) (*ModelInfo, error)
 	if err := json.NewDecoder(resp.Body).Decode(&info); err != nil {
 		return nil, fmt.Errorf("decoding model info: %w", err)
 	}
+
+	c.storeCache(cacheKey, &info)
 	return &info, nil
 }
 
@@ -143,6 +172,29 @@ func (c *Client) Download(ctx context.Context, repo, revision, path string) (io.
 	}
 
 	return resp.Body, resp.ContentLength, nil
+}
+
+func (c *Client) loadCache(key string) (any, bool) {
+	if c.cacheTTL <= 0 {
+		return nil, false
+	}
+	v, ok := c.cache.Load(key)
+	if !ok {
+		return nil, false
+	}
+	e := v.(cacheEntry)
+	if time.Now().After(e.expiresAt) {
+		c.cache.Delete(key)
+		return nil, false
+	}
+	return e.data, true
+}
+
+func (c *Client) storeCache(key string, data any) {
+	if c.cacheTTL <= 0 {
+		return
+	}
+	c.cache.Store(key, cacheEntry{data: data, expiresAt: time.Now().Add(c.cacheTTL)})
 }
 
 func (c *Client) setAuth(req *http.Request) {

--- a/tools/hf2oci/pkg/hf/client_test.go
+++ b/tools/hf2oci/pkg/hf/client_test.go
@@ -5,7 +5,9 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -178,4 +180,55 @@ func TestDownloadAuthStrippedOnRedirect(t *testing.T) {
 	data, err := io.ReadAll(body)
 	require.NoError(t, err)
 	assert.Equal(t, "file-content", string(data))
+}
+
+func TestTreeCacheTTL(t *testing.T) {
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		w.Write([]byte(`[{"type":"file","path":"model.safetensors","size":1024}]`))
+	}))
+	defer srv.Close()
+
+	c := NewClient(WithBaseURL(srv.URL), WithCacheTTL(1*time.Hour))
+
+	// First call hits the server.
+	entries1, err := c.Tree(context.Background(), "org/model", "main")
+	require.NoError(t, err)
+	assert.Len(t, entries1, 1)
+	assert.Equal(t, int32(1), calls.Load())
+
+	// Second call should be served from cache.
+	entries2, err := c.Tree(context.Background(), "org/model", "main")
+	require.NoError(t, err)
+	assert.Equal(t, entries1, entries2)
+	assert.Equal(t, int32(1), calls.Load(), "second call should not hit the server")
+
+	// Different revision should miss cache.
+	_, err = c.Tree(context.Background(), "org/model", "v2")
+	require.NoError(t, err)
+	assert.Equal(t, int32(2), calls.Load(), "different revision should hit the server")
+}
+
+func TestModelInfoCacheTTL(t *testing.T) {
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		w.Write([]byte(`{"id":"org/model"}`))
+	}))
+	defer srv.Close()
+
+	c := NewClient(WithBaseURL(srv.URL), WithCacheTTL(1*time.Hour))
+
+	// First call hits the server.
+	info1, err := c.ModelInfo(context.Background(), "org/model")
+	require.NoError(t, err)
+	assert.Equal(t, "org/model", info1.ID)
+	assert.Equal(t, int32(1), calls.Load())
+
+	// Second call should be served from cache.
+	info2, err := c.ModelInfo(context.Background(), "org/model")
+	require.NoError(t, err)
+	assert.Equal(t, info1, info2)
+	assert.Equal(t, int32(1), calls.Load(), "second call should not hit the server")
 }


### PR DESCRIPTION
## Summary
- Adds an in-memory TTL cache to the HuggingFace API client for `Tree()` and `ModelInfo()` responses
- Cache uses `sync.Map` for goroutine safety (operator runs 3 concurrent reconcile workers)
- Wires up 1-hour cache TTL in the operator's `main.go` — HF tree listings and model metadata are effectively immutable for a given repo+revision, so caching avoids redundant API calls during reconcile loops
- Cache keys include repo and revision so different revisions are cached independently

## Motivation
The operator calls `Resolver.Resolve()` on every reconcile, which hits `Tree()` and `ModelInfo()` endpoints. With the default 3 concurrent workers and 10-second requeue intervals, this can accumulate significant API calls. A 1-hour TTL eliminates nearly all redundant calls since this data rarely changes.

## Test plan
- [x] `TestTreeCacheTTL` — verifies second Tree() call for same repo/revision is served from cache, different revision misses
- [x] `TestModelInfoCacheTTL` — verifies second ModelInfo() call is served from cache
- [x] `bazel test //tools/hf2oci/... //operators/oci-model-cache/...` — all 6 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)