### PR TITLE
fix(oci-model-cache): read termination message from Job pod

### DIFF
--- a/operators/oci-model-cache/internal/controller/BUILD
+++ b/operators/oci-model-cache/internal/controller/BUILD
@@ -1,4 +1,4 @@
-load("@rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "controller",
@@ -27,5 +27,20 @@ go_library(
         "@io_k8s_sigs_controller_runtime//pkg/handler",
         "@io_k8s_sigs_controller_runtime//pkg/log",
         "@io_k8s_utils//ptr",
+    ],
+)
+
+go_test(
+    name = "controller_test",
+    srcs = ["job_result_test.go"],
+    embed = [":controller"],
+    deps = [
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+        "@io_k8s_api//batch/v1:batch",
+        "@io_k8s_api//core/v1:core",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:meta",
+        "@io_k8s_apimachinery//pkg/runtime",
+        "@io_k8s_sigs_controller_runtime//pkg/client/fake",
     ],
 )

--- a/operators/oci-model-cache/internal/controller/job_result.go
+++ b/operators/oci-model-cache/internal/controller/job_result.go
@@ -1,10 +1,13 @@
 package controller
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 
 	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // terminationResult is the JSON structure written by hf2oci as a termination message.
@@ -19,19 +22,25 @@ type terminationResult struct {
 }
 
 // parseTerminationMessage reads the JSON termination message from a completed Job's pod.
-// hf2oci writes its result to the container's termination message when --termination-message is set.
-func parseTerminationMessage(job *batchv1.Job) (*ResolveResult, error) {
-	// The termination message is in the Job status's pod template status,
-	// but we need to check the pods. For simplicity, we look at the Job's
-	// completionTime and the first container's termination state.
-	// In practice, the controller should read the pod's termination message.
+// hf2oci writes its result to /dev/termination-log, which Kubernetes exposes on the
+// pod's container status as state.terminated.message.
+func parseTerminationMessage(ctx context.Context, c client.Client, job *batchv1.Job) (*ResolveResult, error) {
+	// List pods belonging to this Job.
+	var pods corev1.PodList
+	if err := c.List(ctx, &pods,
+		client.InNamespace(job.Namespace),
+		client.MatchingLabels{"job-name": job.Name},
+	); err != nil {
+		return nil, fmt.Errorf("listing pods for job %s: %w", job.Name, err)
+	}
 
-	// Check if the job has the message annotation (set by the Job controller)
-	// For now, fall back to using Job annotations if the pod isn't directly accessible.
-
-	// Try to get termination message from job annotations (workaround)
-	if msg, ok := job.Annotations["oci-model-cache.jomcgi.dev/result"]; ok {
-		return parseResultJSON(msg)
+	// Find a terminated container with a termination message.
+	for i := range pods.Items {
+		for _, cs := range pods.Items[i].Status.ContainerStatuses {
+			if cs.State.Terminated != nil && cs.State.Terminated.Message != "" {
+				return parseResultJSON(cs.State.Terminated.Message)
+			}
+		}
 	}
 
 	return nil, fmt.Errorf("no termination message found on job %s", job.Name)

--- a/operators/oci-model-cache/internal/controller/job_result_test.go
+++ b/operators/oci-model-cache/internal/controller/job_result_test.go
@@ -1,0 +1,94 @@
+package controller
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestParseTerminationMessage(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "mc-sync-test",
+			Namespace: "default",
+		},
+	}
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "mc-sync-test-abc12",
+			Namespace: "default",
+			Labels:    map[string]string{"job-name": "mc-sync-test"},
+		},
+		Status: corev1.PodStatus{
+			ContainerStatuses: []corev1.ContainerStatus{
+				{
+					Name: "hf2oci",
+					State: corev1.ContainerState{
+						Terminated: &corev1.ContainerStateTerminated{
+							ExitCode: 0,
+							Message:  `{"ref":"ghcr.io/test/model:v1","digest":"sha256:abc123","revision":"main","format":"safetensors","fileCount":3,"totalSize":1024}`,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(pod).Build()
+
+	result, err := parseTerminationMessage(context.Background(), c, job)
+	require.NoError(t, err)
+
+	assert.Equal(t, "ghcr.io/test/model:v1", result.Ref)
+	assert.Equal(t, "sha256:abc123", result.Digest)
+	assert.Equal(t, "main", result.Revision)
+	assert.Equal(t, "safetensors", result.Format)
+	assert.Equal(t, 3, result.FileCount)
+	assert.Equal(t, int64(1024), result.TotalSize)
+}
+
+func TestParseTerminationMessageNoPod(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "mc-sync-test",
+			Namespace: "default",
+		},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	_, err := parseTerminationMessage(context.Background(), c, job)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no termination message found")
+}
+
+func TestParseResultJSON(t *testing.T) {
+	result, err := parseResultJSON(`{"ref":"ghcr.io/r/m:t","digest":"sha256:def","revision":"v2","format":"gguf","fileCount":1,"totalSize":500}`)
+	require.NoError(t, err)
+	assert.Equal(t, "ghcr.io/r/m:t", result.Ref)
+	assert.Equal(t, "sha256:def", result.Digest)
+	assert.Equal(t, "v2", result.Revision)
+	assert.Equal(t, "gguf", result.Format)
+	assert.Equal(t, 1, result.FileCount)
+	assert.Equal(t, int64(500), result.TotalSize)
+}
+
+func TestParseResultJSONInvalid(t *testing.T) {
+	_, err := parseResultJSON("not-json")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "parsing termination message")
+}

--- a/operators/oci-model-cache/internal/controller/modelcache_controller.go
+++ b/operators/oci-model-cache/internal/controller/modelcache_controller.go
@@ -157,7 +157,7 @@ func (v *modelCacheVisitor) VisitSyncing(s sm.ModelCacheSyncing) VisitResult {
 	// Check Job status
 	if isJobComplete(&job) {
 		log.Info("Sync Job completed successfully", "job", s.SyncJobName)
-		result, err := parseTerminationMessage(&job)
+		result, err := parseTerminationMessage(v.ctx, v.reconciler.Client, &job)
 		if err != nil {
 			log.Error(err, "Failed to parse Job termination message, using status fields")
 			// Fall back to existing status fields


### PR DESCRIPTION
## Summary
- Fixes `parseTerminationMessage` to actually read the pod's termination message instead of looking for a non-existent Job annotation
- The hf2oci container writes its result JSON to `/dev/termination-log`, which Kubernetes exposes at `pod.status.containerStatuses[].state.terminated.message` — the operator was never reading it
- This caused successful sync Jobs to lose their digest, sending the ModelCache into an infinite `Syncing → Unknown → Pending → Syncing` loop

## Root cause
`parseTerminationMessage` only checked `job.Annotations["oci-model-cache.jomcgi.dev/result"]`, which nothing ever sets. The fallback path used `mc.Status.Digest` (empty, since it was never populated), causing the calculator to reject the `Ready` state with "digest is required" and reset to `Unknown`.

## Fix
Lists the Job's child pods via `job-name` label selector and reads `containerStatuses[].state.terminated.message` from the first terminated container with a message.

## Test plan
- [x] `TestParseTerminationMessage` — verifies reading termination message from a fake pod
- [x] `TestParseTerminationMessageNoPod` — verifies error when no pod found
- [x] `TestParseResultJSON` / `TestParseResultJSONInvalid` — unit tests for JSON parsing
- [x] `bazel test //operators/oci-model-cache/...` — all 3 test targets pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)