### PR TITLE
fix(oci-model-cache): set observedGeneration on status updates

### DIFF
--- a/operators/oci-model-cache/internal/controller/modelcache_controller.go
+++ b/operators/oci-model-cache/internal/controller/modelcache_controller.go
@@ -250,6 +250,10 @@ func (v *modelCacheVisitor) VisitUnknown(s sm.ModelCacheUnknown) VisitResult {
 
 // updateStatus updates the resource status with the new state using Server-Side Apply.
 func (v *modelCacheVisitor) updateStatus(newState sm.ModelCacheState) VisitResult {
+	// Mark the current generation as observed so HasSpecChanged() returns false
+	// until the user modifies the spec again.
+	newState.Resource().Status.ObservedGeneration = newState.Resource().Generation
+
 	patch, err := sm.SSAPatch(newState)
 	if err != nil {
 		return VisitResult{Error: fmt.Errorf("failed to create SSA patch: %w", err)}


### PR DESCRIPTION
## Summary
- Fixes infinite `Ready → Pending` loop caused by `HasSpecChanged()` always returning `true`
- `updateStatus` now sets `observedGeneration = generation` before creating the SSA patch

## Root cause
`applyStateToStatus()` (generated by controlflow) sets phase and state-specific fields but never sets `observedGeneration`. Since `HasSpecChanged()` compares `generation != observedGeneration`, and `observedGeneration` stays at zero, `VisitReady` always triggers "Spec changed, resyncing" and resets to Pending.

## Test plan
- [x] `bazel test //operators/oci-model-cache/...` — all 3 test targets pass
- [ ] Deploy and verify ModelCache reaches and stays in `Ready` state

🤖 Generated with [Claude Code](https://claude.com/claude-code)