### PR TITLE
fix(oci-model-cache): resolve OCI refs at admission time

### DIFF
--- a/operators/oci-model-cache/cmd/main.go
+++ b/operators/oci-model-cache/cmd/main.go
@@ -276,6 +276,7 @@ func main() {
 				Client:   mgr.GetClient(),
 				Decoder:  admission.NewDecoder(mgr.GetScheme()),
 				Registry: cfg.Registry,
+				HFClient: hfClient,
 			},
 		})
 	}

--- a/operators/oci-model-cache/internal/webhook/BUILD
+++ b/operators/oci-model-cache/internal/webhook/BUILD
@@ -1,4 +1,4 @@
-load("@rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "webhook",
@@ -11,11 +11,33 @@ go_library(
         "//operators/oci-model-cache/internal/hfref",
         "//operators/oci-model-cache/internal/naming",
         "//operators/oci-model-cache/internal/statemachine",
+        "//tools/hf2oci/pkg/hf",
+        "//tools/hf2oci/pkg/ociref",
         "@io_k8s_api//core/v1:core",
         "@io_k8s_apimachinery//pkg/api/errors",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:meta",
         "@io_k8s_sigs_controller_runtime//pkg/client",
         "@io_k8s_sigs_controller_runtime//pkg/log",
+        "@io_k8s_sigs_controller_runtime//pkg/webhook/admission",
+    ],
+)
+
+go_test(
+    name = "webhook_test",
+    srcs = ["pod_mutator_test.go"],
+    embed = [":webhook"],
+    deps = [
+        "//operators/oci-model-cache/api/v1alpha1:api",
+        "//operators/oci-model-cache/internal/statemachine",
+        "//tools/hf2oci/pkg/hf",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+        "@io_k8s_api//admission/v1:admission",
+        "@io_k8s_api//core/v1:core",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:meta",
+        "@io_k8s_apimachinery//pkg/runtime",
+        "@io_k8s_sigs_controller_runtime//pkg/client",
+        "@io_k8s_sigs_controller_runtime//pkg/client/fake",
         "@io_k8s_sigs_controller_runtime//pkg/webhook/admission",
     ],
 )

--- a/operators/oci-model-cache/internal/webhook/pod_mutator.go
+++ b/operators/oci-model-cache/internal/webhook/pod_mutator.go
@@ -18,16 +18,20 @@ import (
 	"github.com/jomcgi/homelab/operators/oci-model-cache/internal/hfref"
 	"github.com/jomcgi/homelab/operators/oci-model-cache/internal/naming"
 	sm "github.com/jomcgi/homelab/operators/oci-model-cache/internal/statemachine"
+	"github.com/jomcgi/homelab/tools/hf2oci/pkg/hf"
+	"github.com/jomcgi/homelab/tools/hf2oci/pkg/ociref"
 )
 
 // PodMutator handles mutating admission requests for Pods.
 // It scans pod volumes for hf.co/ image volume references, creates
-// ModelCache CRs if needed, and either rewrites the volume source
-// (if Ready) or adds a scheduling gate (if not Ready).
+// ModelCache CRs if needed, and always rewrites the volume ref to a
+// valid OCI reference. If the model is not yet Ready, a scheduling gate
+// is added to block scheduling until the cache is populated.
 type PodMutator struct {
 	Client   client.Client
 	Decoder  admission.Decoder
 	Registry string // Default OCI registry
+	HFClient *hf.Client
 }
 
 // Handle implements admission.Handler.
@@ -65,16 +69,23 @@ func (m *PodMutator) Handle(ctx context.Context, req admission.Request) admissio
 			continue
 		}
 
-		if mc.Status.Phase == sm.PhaseReady && mc.Status.ResolvedRef != "" {
-			// Model is ready — rewrite the volume source
-			log.Info("Model ready, rewriting volume", "volume", vol.Name, "ref", mc.Status.ResolvedRef)
+		// Always rewrite the volume ref — pod spec is immutable after admission.
+		if mc.Status.ResolvedRef != "" {
+			// Use the ref already computed by the controller (any phase).
+			log.Info("Rewriting volume from status", "volume", vol.Name, "ref", mc.Status.ResolvedRef)
 			pod.Spec.Volumes[i].Image.Reference = mc.Status.ResolvedRef
-			mutated = true
 		} else {
-			// Model not ready — gate the pod
+			// ModelCache is brand new (no resolvedRef yet) — compute via HF API.
+			resolved := ociref.ResolveRef(ctx, m.HFClient, repo, m.Registry, revision)
+			log.Info("Rewriting volume via HF API", "volume", vol.Name, "ref", resolved)
+			pod.Spec.Volumes[i].Image.Reference = resolved
+		}
+		mutated = true
+
+		// Gate if model is not yet Ready.
+		if mc.Status.Phase != sm.PhaseReady {
 			log.Info("Model not ready, gating pod", "volume", vol.Name, "modelCache", mcName, "phase", mc.Status.Phase)
 			waitingFor = append(waitingFor, mcName)
-			mutated = true
 		}
 	}
 

--- a/operators/oci-model-cache/internal/webhook/pod_mutator_test.go
+++ b/operators/oci-model-cache/internal/webhook/pod_mutator_test.go
@@ -1,0 +1,361 @@
+package webhook
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	admissionv1 "k8s.io/api/admission/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	v1alpha1 "github.com/jomcgi/homelab/operators/oci-model-cache/api/v1alpha1"
+	sm "github.com/jomcgi/homelab/operators/oci-model-cache/internal/statemachine"
+	"github.com/jomcgi/homelab/tools/hf2oci/pkg/hf"
+)
+
+func newScheme() *runtime.Scheme {
+	s := runtime.NewScheme()
+	_ = corev1.AddToScheme(s)
+	_ = v1alpha1.AddToScheme(s)
+	return s
+}
+
+func makeAdmissionRequest(t *testing.T, pod *corev1.Pod) admission.Request {
+	t.Helper()
+	raw, err := json.Marshal(pod)
+	require.NoError(t, err)
+	return admission.Request{
+		AdmissionRequest: admissionv1.AdmissionRequest{
+			Object: runtime.RawExtension{Raw: raw},
+		},
+	}
+}
+
+// findPatchStringValue finds the patch for a given path and returns its string value.
+// PatchResponseFromRaw stores patches in resp.Patches (Go structs), not resp.Patch
+// (raw bytes) — the latter is only populated after resp.Complete() is called by the
+// webhook server. In unit tests we call Handle directly, so we use resp.Patches.
+func findPatchStringValue(resp admission.Response, path string) (string, bool) {
+	for _, p := range resp.Patches {
+		if p.Path == path {
+			if s, ok := p.Value.(string); ok {
+				return s, true
+			}
+		}
+	}
+	return "", false
+}
+
+// hasPatchPath returns true if any patch operation targets the given path prefix.
+func hasPatchPath(resp admission.Response, prefix string) bool {
+	for _, p := range resp.Patches {
+		if strings.HasPrefix(p.Path, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func podWithHFVolume(repo string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default"},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{Name: "main", Image: "busybox"}},
+			Volumes: []corev1.Volume{{
+				Name: "model",
+				VolumeSource: corev1.VolumeSource{
+					Image: &corev1.ImageVolumeSource{
+						Reference: "hf.co/" + repo,
+					},
+				},
+			}},
+		},
+	}
+}
+
+func podWithNoHFVolumes() *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default"},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{Name: "main", Image: "busybox"}},
+			Volumes: []corev1.Volume{{
+				Name: "data",
+				VolumeSource: corev1.VolumeSource{
+					EmptyDir: &corev1.EmptyDirVolumeSource{},
+				},
+			}},
+		},
+	}
+}
+
+func TestHandle_ModelReady_RewritesFromStatus(t *testing.T) {
+	s := newScheme()
+	mc := &v1alpha1.ModelCache{
+		ObjectMeta: metav1.ObjectMeta{Name: "nousresearch-hermes-3-8b-rev-main"},
+		Spec: v1alpha1.ModelCacheSpec{
+			Repo:     "NousResearch/Hermes-3-8B",
+			Registry: "ghcr.io/jomcgi/models",
+			Revision: "main",
+		},
+		Status: v1alpha1.ModelCacheStatus{
+			Phase:       sm.PhaseReady,
+			ResolvedRef: "ghcr.io/jomcgi/models/nousresearch/hermes-3-8b:rev-main",
+		},
+	}
+
+	k8sClient := fake.NewClientBuilder().WithScheme(s).WithStatusSubresource(&v1alpha1.ModelCache{}).WithObjects(mc).Build()
+	hfSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("HF API should not be called when resolvedRef exists")
+	}))
+	defer hfSrv.Close()
+
+	mutator := &PodMutator{
+		Client:   k8sClient,
+		Decoder:  admission.NewDecoder(s),
+		Registry: "ghcr.io/jomcgi/models",
+		HFClient: hf.NewClient(hf.WithBaseURL(hfSrv.URL)),
+	}
+
+	pod := podWithHFVolume("NousResearch/Hermes-3-8B")
+	resp := mutator.Handle(context.Background(), makeAdmissionRequest(t, pod))
+	require.True(t, resp.Allowed)
+	require.NotEmpty(t, resp.Patches)
+
+	ref, found := findPatchStringValue(resp, "/spec/volumes/0/image/reference")
+	assert.True(t, found, "expected ref rewrite patch")
+	assert.Equal(t, "ghcr.io/jomcgi/models/nousresearch/hermes-3-8b:rev-main", ref)
+
+	// No scheduling gate should be added (model is Ready)
+	assert.False(t, hasPatchPath(resp, "/spec/schedulingGates"), "should not gate when Ready")
+}
+
+func TestHandle_ModelNotReady_RewritesAndGates(t *testing.T) {
+	s := newScheme()
+	mc := &v1alpha1.ModelCache{
+		ObjectMeta: metav1.ObjectMeta{Name: "nousresearch-hermes-3-8b-rev-main"},
+		Spec: v1alpha1.ModelCacheSpec{
+			Repo:     "NousResearch/Hermes-3-8B",
+			Registry: "ghcr.io/jomcgi/models",
+			Revision: "main",
+		},
+		Status: v1alpha1.ModelCacheStatus{
+			Phase: sm.PhasePending,
+		},
+	}
+
+	k8sClient := fake.NewClientBuilder().WithScheme(s).WithStatusSubresource(&v1alpha1.ModelCache{}).WithObjects(mc).Build()
+	hfSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/models/NousResearch/Hermes-3-8B" {
+			json.NewEncoder(w).Encode(hf.ModelInfo{ID: "NousResearch/Hermes-3-8B"})
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer hfSrv.Close()
+
+	mutator := &PodMutator{
+		Client:   k8sClient,
+		Decoder:  admission.NewDecoder(s),
+		Registry: "ghcr.io/jomcgi/models",
+		HFClient: hf.NewClient(hf.WithBaseURL(hfSrv.URL)),
+	}
+
+	pod := podWithHFVolume("NousResearch/Hermes-3-8B")
+	resp := mutator.Handle(context.Background(), makeAdmissionRequest(t, pod))
+	require.True(t, resp.Allowed)
+	require.NotEmpty(t, resp.Patches)
+
+	ref, found := findPatchStringValue(resp, "/spec/volumes/0/image/reference")
+	assert.True(t, found, "expected ref rewrite patch")
+	assert.Equal(t, "ghcr.io/jomcgi/models/nousresearch/hermes-3-8b:rev-main", ref)
+	assert.True(t, hasPatchPath(resp, "/spec/schedulingGates"), "should gate when Pending")
+}
+
+func TestHandle_ModelNotReady_HasResolvedRef(t *testing.T) {
+	s := newScheme()
+	mc := &v1alpha1.ModelCache{
+		ObjectMeta: metav1.ObjectMeta{Name: "nousresearch-hermes-3-8b-rev-main"},
+		Spec: v1alpha1.ModelCacheSpec{
+			Repo:     "NousResearch/Hermes-3-8B",
+			Registry: "ghcr.io/jomcgi/models",
+			Revision: "main",
+		},
+		Status: v1alpha1.ModelCacheStatus{
+			Phase:       "Syncing",
+			ResolvedRef: "ghcr.io/jomcgi/models/nousresearch/hermes-3-8b:rev-main",
+		},
+	}
+
+	k8sClient := fake.NewClientBuilder().WithScheme(s).WithStatusSubresource(&v1alpha1.ModelCache{}).WithObjects(mc).Build()
+	hfSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("HF API should not be called when resolvedRef exists")
+	}))
+	defer hfSrv.Close()
+
+	mutator := &PodMutator{
+		Client:   k8sClient,
+		Decoder:  admission.NewDecoder(s),
+		Registry: "ghcr.io/jomcgi/models",
+		HFClient: hf.NewClient(hf.WithBaseURL(hfSrv.URL)),
+	}
+
+	pod := podWithHFVolume("NousResearch/Hermes-3-8B")
+	resp := mutator.Handle(context.Background(), makeAdmissionRequest(t, pod))
+	require.True(t, resp.Allowed)
+
+	ref, found := findPatchStringValue(resp, "/spec/volumes/0/image/reference")
+	assert.True(t, found, "expected ref rewrite from status")
+	assert.Equal(t, "ghcr.io/jomcgi/models/nousresearch/hermes-3-8b:rev-main", ref)
+	assert.True(t, hasPatchPath(resp, "/spec/schedulingGates"), "should gate — model is Syncing, not Ready")
+}
+
+func TestHandle_DerivativeModel_SmartNaming(t *testing.T) {
+	s := newScheme()
+	mc := &v1alpha1.ModelCache{
+		ObjectMeta: metav1.ObjectMeta{Name: "emilio407-nllb-200-distilled-1.3b-4bit-rev-main"},
+		Spec: v1alpha1.ModelCacheSpec{
+			Repo:     "Emilio407/nllb-200-distilled-1.3B-4bit",
+			Registry: "ghcr.io/jomcgi/models",
+			Revision: "main",
+		},
+		Status: v1alpha1.ModelCacheStatus{
+			Phase: sm.PhasePending,
+		},
+	}
+
+	k8sClient := fake.NewClientBuilder().WithScheme(s).WithStatusSubresource(&v1alpha1.ModelCache{}).WithObjects(mc).Build()
+	hfSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/models/Emilio407/nllb-200-distilled-1.3B-4bit" {
+			json.NewEncoder(w).Encode(hf.ModelInfo{
+				ID: "Emilio407/nllb-200-distilled-1.3B-4bit",
+				BaseModels: &hf.BaseModels{
+					Relation: "quantized",
+					Models:   []hf.BaseModel{{ID: "facebook/nllb-200-distilled-1.3B"}},
+				},
+			})
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer hfSrv.Close()
+
+	mutator := &PodMutator{
+		Client:   k8sClient,
+		Decoder:  admission.NewDecoder(s),
+		Registry: "ghcr.io/jomcgi/models",
+		HFClient: hf.NewClient(hf.WithBaseURL(hfSrv.URL)),
+	}
+
+	pod := podWithHFVolume("Emilio407/nllb-200-distilled-1.3B-4bit")
+	resp := mutator.Handle(context.Background(), makeAdmissionRequest(t, pod))
+	require.True(t, resp.Allowed)
+	require.NotEmpty(t, resp.Patches)
+
+	ref, found := findPatchStringValue(resp, "/spec/volumes/0/image/reference")
+	require.True(t, found, "expected ref rewrite patch")
+	assert.Equal(t, "ghcr.io/jomcgi/models/facebook/nllb-200-distilled-1.3b:emilio407-nllb-200-distilled-1.3b-4bit", ref)
+}
+
+func TestHandle_HFUnavailable_FallbackNaming(t *testing.T) {
+	s := newScheme()
+	mc := &v1alpha1.ModelCache{
+		ObjectMeta: metav1.ObjectMeta{Name: "org-model-rev-main"},
+		Spec: v1alpha1.ModelCacheSpec{
+			Repo:     "Org/Model",
+			Registry: "ghcr.io/test",
+			Revision: "main",
+		},
+		Status: v1alpha1.ModelCacheStatus{
+			Phase: sm.PhasePending,
+		},
+	}
+
+	k8sClient := fake.NewClientBuilder().WithScheme(s).WithStatusSubresource(&v1alpha1.ModelCache{}).WithObjects(mc).Build()
+	hfSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer hfSrv.Close()
+
+	mutator := &PodMutator{
+		Client:   k8sClient,
+		Decoder:  admission.NewDecoder(s),
+		Registry: "ghcr.io/test",
+		HFClient: hf.NewClient(hf.WithBaseURL(hfSrv.URL)),
+	}
+
+	pod := podWithHFVolume("Org/Model")
+	resp := mutator.Handle(context.Background(), makeAdmissionRequest(t, pod))
+	require.True(t, resp.Allowed)
+	require.NotEmpty(t, resp.Patches)
+
+	ref, found := findPatchStringValue(resp, "/spec/volumes/0/image/reference")
+	require.True(t, found, "expected ref rewrite patch")
+	assert.Equal(t, "ghcr.io/test/org/model:rev-main", ref)
+}
+
+func TestHandle_NoHFVolumes(t *testing.T) {
+	s := newScheme()
+	k8sClient := fake.NewClientBuilder().WithScheme(s).Build()
+
+	mutator := &PodMutator{
+		Client:   k8sClient,
+		Decoder:  admission.NewDecoder(s),
+		Registry: "ghcr.io/test",
+		HFClient: hf.NewClient(),
+	}
+
+	pod := podWithNoHFVolumes()
+	resp := mutator.Handle(context.Background(), makeAdmissionRequest(t, pod))
+
+	require.True(t, resp.Allowed)
+	assert.Empty(t, resp.Patches, "no patches expected for non-HF volumes")
+	assert.Contains(t, resp.Result.Message, "no hf.co volumes")
+}
+
+func TestHandle_NewModelCache_CreatedAndGated(t *testing.T) {
+	s := newScheme()
+	k8sClient := fake.NewClientBuilder().WithScheme(s).Build()
+
+	hfSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/models/Org/NewModel" {
+			json.NewEncoder(w).Encode(hf.ModelInfo{ID: "Org/NewModel"})
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer hfSrv.Close()
+
+	mutator := &PodMutator{
+		Client:   k8sClient,
+		Decoder:  admission.NewDecoder(s),
+		Registry: "ghcr.io/test",
+		HFClient: hf.NewClient(hf.WithBaseURL(hfSrv.URL)),
+	}
+
+	pod := podWithHFVolume("Org/NewModel")
+	resp := mutator.Handle(context.Background(), makeAdmissionRequest(t, pod))
+	require.True(t, resp.Allowed)
+	require.NotEmpty(t, resp.Patches)
+
+	ref, found := findPatchStringValue(resp, "/spec/volumes/0/image/reference")
+	assert.True(t, found, "expected ref rewrite")
+	assert.Equal(t, "ghcr.io/test/org/newmodel:rev-main", ref)
+	assert.True(t, hasPatchPath(resp, "/spec/schedulingGates"), "should gate — newly created MC not Ready")
+
+	// Verify the ModelCache CR was created
+	mc := &v1alpha1.ModelCache{}
+	err := k8sClient.Get(context.Background(), client.ObjectKey{Name: "org-newmodel-rev-main"}, mc)
+	require.NoError(t, err, "ModelCache CR should have been created")
+	assert.Equal(t, "Org/NewModel", mc.Spec.Repo)
+	assert.Equal(t, "ghcr.io/test", mc.Spec.Registry)
+}

--- a/tools/hf2oci/README.md
+++ b/tools/hf2oci/README.md
@@ -105,6 +105,19 @@ hf2oci copy Qwen/Qwen2.5-0.5B-Instruct-GGUF -r ghcr.io/jomcgi/models
 hf2oci copy Qwen/Qwen2.5-0.5B-Instruct-GGUF -r ghcr.io/jomcgi/models --tag latest
 ```
 
+## Smart naming (derivative models)
+
+When a model has a `baseModels` relationship on HuggingFace (quantization, finetune,
+adapter, merge), hf2oci groups it under the base model's OCI repository:
+
+| Model | Base model | OCI ref |
+|-------|-----------|---------|
+| `facebook/nllb-200-distilled-1.3B` | (none) | `registry/facebook/nllb-200-distilled-1.3b:rev-main` |
+| `Emilio407/nllb-200-distilled-1.3B-4bit` | `facebook/nllb-200-distilled-1.3B` | `registry/facebook/nllb-200-distilled-1.3b:emilio407-nllb-200-distilled-1.3b-4bit` |
+
+This enables OCI blob deduplication — config files and tokenizers shared between
+base and derivative models are stored once.
+
 ## Exit codes
 
 | Code | Meaning                                                              |
@@ -130,6 +143,7 @@ tools/hf2oci/
 │   └── cmd/             Cobra commands (copy, resolve, output formatting)
 └── pkg/
     ├── copy/            Orchestration: list → classify → build → push
-    ├── hf/              HuggingFace API client (Tree, Download)
-    └── oci/             OCI image building and registry push
+    ├── hf/              HuggingFace API client (Tree, Download, ModelInfo)
+    ├── oci/             OCI image building and registry push
+    └── ociref/          Shared OCI ref naming (DeriveTag, ResolveRef)
 ```

--- a/tools/hf2oci/pkg/copy/BUILD
+++ b/tools/hf2oci/pkg/copy/BUILD
@@ -13,6 +13,7 @@ go_library(
     deps = [
         "//tools/hf2oci/pkg/hf",
         "//tools/hf2oci/pkg/oci",
+        "//tools/hf2oci/pkg/ociref",
         "@com_github_google_go_containerregistry//pkg/authn",
         "@com_github_google_go_containerregistry//pkg/name",
         "@com_github_google_go_containerregistry//pkg/v1:pkg",

--- a/tools/hf2oci/pkg/copy/copy.go
+++ b/tools/hf2oci/pkg/copy/copy.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"strings"
 	"sync"
 
 	v1 "github.com/google/go-containerregistry/pkg/v1"
@@ -13,6 +12,7 @@ import (
 
 	"github.com/jomcgi/homelab/tools/hf2oci/pkg/hf"
 	"github.com/jomcgi/homelab/tools/hf2oci/pkg/oci"
+	"github.com/jomcgi/homelab/tools/hf2oci/pkg/ociref"
 )
 
 // Options configures the copy operation.
@@ -202,26 +202,19 @@ func Copy(ctx context.Context, opts Options) (*Result, error) {
 // DeriveTag returns the OCI tag to use. If tag is non-empty it is returned as-is;
 // otherwise it is derived from revision as "rev-{revision[:12]}".
 func DeriveTag(tag, revision string) string {
-	if tag != "" {
-		return tag
-	}
-	rev := revision
-	if len(rev) > 12 {
-		rev = rev[:12]
-	}
-	return "rev-" + rev
+	return ociref.DeriveTag(tag, revision)
 }
 
 // deriveRepoName converts a HuggingFace repo name to an OCI repo path,
 // preserving the org/model structure for cleaner registry organization.
 // e.g. "NousResearch/Hermes-4.3-Llama-3-36B-AWQ" → "nousresearch/hermes-4.3-llama-3-36b-awq"
 func deriveRepoName(repo string) string {
-	return strings.ToLower(repo)
+	return ociref.DeriveRepoName(repo)
 }
 
 // deriveVariantTag flattens a HuggingFace repo name into a valid OCI tag.
 // Used for derivative models to encode the variant identity in the tag.
 // e.g. "Emilio407/nllb-200-distilled-1.3B-4bit" → "emilio407-nllb-200-distilled-1.3b-4bit"
 func deriveVariantTag(repo string) string {
-	return strings.ToLower(strings.ReplaceAll(repo, "/", "-"))
+	return ociref.DeriveVariantTag(repo)
 }

--- a/tools/hf2oci/pkg/copy/resolve.go
+++ b/tools/hf2oci/pkg/copy/resolve.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/jomcgi/homelab/tools/hf2oci/pkg/hf"
 	"github.com/jomcgi/homelab/tools/hf2oci/pkg/oci"
+	"github.com/jomcgi/homelab/tools/hf2oci/pkg/ociref"
 )
 
 // ResolveOptions configures the resolve operation.
@@ -65,12 +66,12 @@ func resolveModel(ctx context.Context, client *hf.Client, repo, registry, revisi
 	info, infoErr := client.ModelInfo(ctx, repo)
 	if infoErr == nil && info.BaseModels != nil && len(info.BaseModels.Models) > 0 {
 		// Derivative model: group under base model's repo path for layer dedup.
-		repoPath = deriveRepoName(info.BaseModels.Models[0].ID)
-		ociTag = deriveVariantTag(repo)
+		repoPath = ociref.DeriveRepoName(info.BaseModels.Models[0].ID)
+		ociTag = ociref.DeriveVariantTag(repo)
 	} else {
 		// Base model or ModelInfo unavailable: use repo directly.
-		repoPath = deriveRepoName(repo)
-		ociTag = DeriveTag(tag, revision)
+		repoPath = ociref.DeriveRepoName(repo)
+		ociTag = ociref.DeriveTag(tag, revision)
 	}
 	refStr := fmt.Sprintf("%s/%s:%s", registry, repoPath, ociTag)
 

--- a/tools/hf2oci/pkg/ociref/BUILD
+++ b/tools/hf2oci/pkg/ociref/BUILD
@@ -1,0 +1,19 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "ociref",
+    srcs = ["ociref.go"],
+    importpath = "github.com/jomcgi/homelab/tools/hf2oci/pkg/ociref",
+    visibility = ["//visibility:public"],
+    deps = ["//tools/hf2oci/pkg/hf"],
+)
+
+go_test(
+    name = "ociref_test",
+    srcs = ["ociref_test.go"],
+    embed = [":ociref"],
+    deps = [
+        "//tools/hf2oci/pkg/hf",
+        "@com_github_stretchr_testify//assert",
+    ],
+)

--- a/tools/hf2oci/pkg/ociref/ociref.go
+++ b/tools/hf2oci/pkg/ociref/ociref.go
@@ -1,0 +1,62 @@
+// Package ociref provides pure naming functions for deriving OCI references
+// from HuggingFace model repositories. It also provides a lightweight ref
+// resolver that calls ModelInfo for smart naming without requiring Tree/Classify.
+package ociref
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/jomcgi/homelab/tools/hf2oci/pkg/hf"
+)
+
+// DeriveTag returns the OCI tag to use. If tag is non-empty it is returned as-is;
+// otherwise it is derived from revision as "rev-{revision[:12]}".
+func DeriveTag(tag, revision string) string {
+	if tag != "" {
+		return tag
+	}
+	rev := revision
+	if len(rev) > 12 {
+		rev = rev[:12]
+	}
+	return "rev-" + rev
+}
+
+// DeriveRepoName converts a HuggingFace repo name to an OCI repo path,
+// preserving the org/model structure for cleaner registry organization.
+// e.g. "NousResearch/Hermes-4.3-Llama-3-36B-AWQ" -> "nousresearch/hermes-4.3-llama-3-36b-awq"
+func DeriveRepoName(repo string) string {
+	return strings.ToLower(repo)
+}
+
+// DeriveVariantTag flattens a HuggingFace repo name into a valid OCI tag.
+// Used for derivative models to encode the variant identity in the tag.
+// e.g. "Emilio407/nllb-200-distilled-1.3B-4bit" -> "emilio407-nllb-200-distilled-1.3b-4bit"
+func DeriveVariantTag(repo string) string {
+	return strings.ToLower(strings.ReplaceAll(repo, "/", "-"))
+}
+
+// ResolveRef computes the full OCI reference for a HuggingFace model by calling
+// ModelInfo to determine base model relationships. On failure, falls back to
+// simple naming (repo path + rev tag).
+func ResolveRef(ctx context.Context, client *hf.Client, repo, registry, revision string) string {
+	if revision == "" {
+		revision = "main"
+	}
+
+	var repoPath, ociTag string
+	info, err := client.ModelInfo(ctx, repo)
+	if err == nil && info.BaseModels != nil && len(info.BaseModels.Models) > 0 {
+		// Derivative model: group under base model's repo path for layer dedup.
+		repoPath = DeriveRepoName(info.BaseModels.Models[0].ID)
+		ociTag = DeriveVariantTag(repo)
+	} else {
+		// Base model or ModelInfo unavailable: use repo directly.
+		repoPath = DeriveRepoName(repo)
+		ociTag = DeriveTag("", revision)
+	}
+
+	return fmt.Sprintf("%s/%s:%s", registry, repoPath, ociTag)
+}

--- a/tools/hf2oci/pkg/ociref/ociref_test.go
+++ b/tools/hf2oci/pkg/ociref/ociref_test.go
@@ -1,0 +1,127 @@
+package ociref
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/jomcgi/homelab/tools/hf2oci/pkg/hf"
+)
+
+func TestDeriveTag(t *testing.T) {
+	tests := []struct {
+		name     string
+		tag      string
+		revision string
+		want     string
+	}{
+		{name: "explicit tag", tag: "latest", revision: "main", want: "latest"},
+		{name: "short revision", tag: "", revision: "main", want: "rev-main"},
+		{name: "long revision truncated", tag: "", revision: "abc123def456789", want: "rev-abc123def456"},
+		{name: "exact 12 chars", tag: "", revision: "abc123def456", want: "rev-abc123def456"},
+		{name: "empty tag empty rev", tag: "", revision: "", want: "rev-"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, DeriveTag(tt.tag, tt.revision))
+		})
+	}
+}
+
+func TestDeriveRepoName(t *testing.T) {
+	tests := []struct {
+		name string
+		repo string
+		want string
+	}{
+		{name: "mixed case", repo: "NousResearch/Hermes-3-8B", want: "nousresearch/hermes-3-8b"},
+		{name: "already lowercase", repo: "org/model", want: "org/model"},
+		{name: "all uppercase", repo: "ORG/MODEL", want: "org/model"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, DeriveRepoName(tt.repo))
+		})
+	}
+}
+
+func TestDeriveVariantTag(t *testing.T) {
+	tests := []struct {
+		name string
+		repo string
+		want string
+	}{
+		{name: "with slash", repo: "Emilio407/nllb-200-distilled-1.3B-4bit", want: "emilio407-nllb-200-distilled-1.3b-4bit"},
+		{name: "already flat", repo: "model-name", want: "model-name"},
+		{name: "uppercase", repo: "ORG/MODEL", want: "org-model"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, DeriveVariantTag(tt.repo))
+		})
+	}
+}
+
+func TestResolveRef_BaseModel(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/models/NousResearch/Hermes-3-8B" {
+			json.NewEncoder(w).Encode(hf.ModelInfo{ID: "NousResearch/Hermes-3-8B"})
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	client := hf.NewClient(hf.WithBaseURL(srv.URL))
+	ref := ResolveRef(context.Background(), client, "NousResearch/Hermes-3-8B", "ghcr.io/jomcgi/models", "main")
+	assert.Equal(t, "ghcr.io/jomcgi/models/nousresearch/hermes-3-8b:rev-main", ref)
+}
+
+func TestResolveRef_DerivativeModel(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/models/Emilio407/nllb-200-distilled-1.3B-4bit" {
+			json.NewEncoder(w).Encode(hf.ModelInfo{
+				ID: "Emilio407/nllb-200-distilled-1.3B-4bit",
+				BaseModels: &hf.BaseModels{
+					Relation: "quantized",
+					Models:   []hf.BaseModel{{ID: "facebook/nllb-200-distilled-1.3B"}},
+				},
+			})
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	client := hf.NewClient(hf.WithBaseURL(srv.URL))
+	ref := ResolveRef(context.Background(), client, "Emilio407/nllb-200-distilled-1.3B-4bit", "ghcr.io/jomcgi/models", "main")
+	assert.Equal(t, "ghcr.io/jomcgi/models/facebook/nllb-200-distilled-1.3b:emilio407-nllb-200-distilled-1.3b-4bit", ref)
+}
+
+func TestResolveRef_HFFailure(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	client := hf.NewClient(hf.WithBaseURL(srv.URL))
+	ref := ResolveRef(context.Background(), client, "Org/Model", "ghcr.io/test", "abc123def456")
+	// Falls back to simple naming
+	assert.Equal(t, "ghcr.io/test/org/model:rev-abc123def456", ref)
+}
+
+func TestResolveRef_EmptyRevision(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(hf.ModelInfo{ID: "Org/Model"})
+	}))
+	defer srv.Close()
+
+	client := hf.NewClient(hf.WithBaseURL(srv.URL))
+	ref := ResolveRef(context.Background(), client, "Org/Model", "ghcr.io/test", "")
+	// Empty revision defaults to "main"
+	assert.Equal(t, "ghcr.io/test/org/model:rev-main", ref)
+}

--- a/websites/jomcgi.dev/src/pages/engineering.astro
+++ b/websites/jomcgi.dev/src/pages/engineering.astro
@@ -282,6 +282,7 @@ const ociCacheDiagram = `flowchart LR
     subgraph Webhook
         Pod[Pod Create]
         Mutator[PodMutator]
+        Rewrite[Rewrite Ref]
         Gate[Scheduling Gate]
     end
 
@@ -297,7 +298,8 @@ const ociCacheDiagram = `flowchart LR
     end
 
     Pod --> Mutator
-    Mutator --> Gate
+    Mutator -->|HF API| Rewrite
+    Rewrite --> Gate
     Mutator --> CR
     CR --> Resolve
     Resolve -->|hf2oci| Sync
@@ -307,6 +309,7 @@ const ociCacheDiagram = `flowchart LR
 
     style Pod fill:#ff6b6b,stroke:#ff6b6b,color:#fff
     style Mutator fill:#ffa502,stroke:#ffa502,color:#fff
+    style Rewrite fill:#ffa502,stroke:#ffa502,color:#fff
     style Gate fill:#ffd93d,stroke:#ffd93d,color:#000
     style CR fill:#6bcb77,stroke:#6bcb77,color:#fff
     style Resolve fill:#4d96ff,stroke:#4d96ff,color:#fff
@@ -1181,7 +1184,7 @@ transitions:
                 <div class="execution-grid">
                     <div class="execution-row">
                         <div class="execution-key">PodMutator</div>
-                        <div class="execution-value">Webhook intercepts pods with hf.co/ volume references. Creates a ModelCache CR for the model, adds a scheduling gate to block the pod until the model is ready.</div>
+                        <div class="execution-value">Webhook intercepts pods with hf.co/ volume references. Calls cached HF API to resolve the OCI ref at admission time (pod spec is immutable after this point). Creates ModelCache CR and adds scheduling gate if model not yet synced.</div>
                     </div>
                     <div class="execution-row">
                         <div class="execution-key">State Machine</div>
@@ -1196,8 +1199,12 @@ transitions:
                         <div class="execution-value">HuggingFace baseModels API resolves derivative models to their base. Derivatives share the base repo path for OCI layer deduplication. TTL cache for API responses.</div>
                     </div>
                     <div class="execution-row">
+                        <div class="execution-key">Admission-Time Resolution</div>
+                        <div class="execution-value">Pod spec is immutable after admission. Webhook calls the cached HF API to compute the GHCR ref synchronously, ensuring the correct OCI path is baked into the pod before it's created.</div>
+                    </div>
+                    <div class="execution-row">
                         <div class="execution-key">Pod Ungating</div>
-                        <div class="execution-value">Ready state triggers scheduling gate removal and volume rewrite to the resolved OCI digest. Pod schedules normally with the cached model available.</div>
+                        <div class="execution-value">Ready state triggers scheduling gate removal. Volume ref was already rewritten at admission time — pod schedules normally with the cached model available.</div>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary

- **Fix InvalidImageName bug**: Pod spec is immutable after admission, but the webhook previously only rewrote `hf.co/` volume refs when the ModelCache was Ready — leaving unresolvable refs that caused `InvalidImageName` errors
- **Always rewrite refs at admission time**: Uses the controller's `resolvedRef` if available, or computes it via the cached HF API (`ociref.ResolveRef`) for new models. Scheduling gates still block until the model is synced
- **Extract shared `ociref` package**: Moves OCI ref naming functions (`DeriveTag`, `DeriveRepoName`, `DeriveVariantTag`, `ResolveRef`) from `copy` into `tools/hf2oci/pkg/ociref` for reuse by the webhook
- **Add 7 webhook tests**: ModelReady, ModelNotReady (with/without resolvedRef), derivative model smart naming, HF unavailable fallback, no HF volumes, new ModelCache creation
- **Fix website deep dive inaccuracies**: Update Mermaid diagram, PodMutator description, and Pod Ungating description to reflect admission-time resolution

## Test plan

- [x] `bazel test //tools/hf2oci/...` — all existing + new ociref tests pass (4 tests)
- [x] `bazel test //operators/oci-model-cache/...` — all existing + new webhook tests pass (7 tests)
- [ ] Deploy and create test pod with `hf.co/` volume — verify webhook rewrites ref and gates correctly
- [ ] Verify pod runs successfully after ModelCache reaches Ready


🤖 Generated with [Claude Code](https://claude.com/claude-code)