### PR TITLE
fix(oci-model-cache): pass file selector to resolver

### DIFF
--- a/operators/oci-model-cache/cmd/main.go
+++ b/operators/oci-model-cache/cmd/main.go
@@ -64,11 +64,12 @@ type hf2ociResolver struct {
 	client *hf.Client
 }
 
-func (r *hf2ociResolver) Resolve(ctx context.Context, repo, registry, revision string) (*controller.ResolveResult, error) {
+func (r *hf2ociResolver) Resolve(ctx context.Context, repo, registry, revision, file string) (*controller.ResolveResult, error) {
 	result, err := copy.Resolve(ctx, copy.ResolveOptions{
 		Repo:     repo,
 		Registry: registry,
 		Revision: revision,
+		File:     file,
 		HFClient: r.client,
 	})
 	if err != nil {

--- a/operators/oci-model-cache/internal/controller/modelcache_controller.go
+++ b/operators/oci-model-cache/internal/controller/modelcache_controller.go
@@ -92,7 +92,7 @@ func (v *modelCacheVisitor) VisitPending(s sm.ModelCachePending) VisitResult {
 
 	log.Info("Resolving model", "repo", mc.Spec.Repo, "revision", mc.Spec.Revision)
 
-	result, err := v.reconciler.Resolver.Resolve(v.ctx, mc.Spec.Repo, mc.Spec.Registry, mc.Spec.Revision)
+	result, err := v.reconciler.Resolver.Resolve(v.ctx, mc.Spec.Repo, mc.Spec.Registry, mc.Spec.Revision, mc.Spec.File)
 	if err != nil {
 		return v.handleError(s, err, "Pending")
 	}

--- a/operators/oci-model-cache/internal/controller/resolver.go
+++ b/operators/oci-model-cache/internal/controller/resolver.go
@@ -6,7 +6,7 @@ import "context"
 // The controller depends on this interface, not hf2oci directly.
 // The concrete adapter lives in cmd/main.go — the only file that imports hf2oci.
 type Resolver interface {
-	Resolve(ctx context.Context, repo, registry, revision string) (*ResolveResult, error)
+	Resolve(ctx context.Context, repo, registry, revision, file string) (*ResolveResult, error)
 }
 
 // ResolveResult contains the outcome of a resolve operation.


### PR DESCRIPTION
## Summary

- Threads `mc.Spec.File` through the `Resolver.Resolve()` call in `VisitPending`, fixing GGUF repos with multiple quantization variants failing with "specify one with :filename" despite the file field being set on the ModelCache CR

## Root cause

The `Resolver` interface accepted `(repo, registry, revision)` but not `file`. The webhook correctly set `spec.file` on the CR, and `buildCopyJob` correctly passed `--file` to the hf2oci CLI — but the resolve step in the Pending phase never forwarded it, causing the HF file listing to see 18 variants and bail.

## Changes

| File | Change |
|------|--------|
| `internal/controller/resolver.go` | Add `file` param to `Resolver` interface |
| `internal/controller/modelcache_controller.go` | Pass `mc.Spec.File` in `VisitPending` |
| `cmd/main.go` | Forward `file` to `copy.ResolveOptions.File` |

## Test plan

- [x] `bazel test //operators/oci-model-cache/...` — 4/4 pass
- [x] `bazel build //operators/oci-model-cache/...` — compiles clean
- [ ] Deploy and verify ModelCache CR with file selector resolves through Pending → Resolving

🤖 Generated with [Claude Code](https://claude.com/claude-code)