### PR TITLE
fix: lowercase hf.co repo name for valid OCI reference

### DIFF
--- a/overlays/prod/llama-cpp/values.yaml
+++ b/overlays/prod/llama-cpp/values.yaml
@@ -5,7 +5,7 @@ imagePullSecret:
 
 modelVolume:
   enabled: true
-  reference: "hf.co/bartowski/NousResearch_Hermes-4.3-36B-GGUF:NousResearch_Hermes-4.3-36B-IQ4_XS"
+  reference: "hf.co/bartowski/nousresearch_hermes-4.3-36b-gguf:NousResearch_Hermes-4.3-36B-IQ4_XS"
   mountPath: "/model-image"
 
 server:


### PR DESCRIPTION
## Summary

- Fixes invalid OCI reference in #463 — repo name must be lowercase per OCI distribution spec
- `NousResearch_Hermes-4.3-36B-GGUF` → `nousresearch_hermes-4.3-36b-gguf`
- Tag (file selector) keeps original case since OCI tags allow `[a-zA-Z0-9_.-]`
- HuggingFace API resolves repos case-insensitively, GGUF file matching uses `strings.EqualFold`

```
hf.co/bartowski/nousresearch_hermes-4.3-36b-gguf:NousResearch_Hermes-4.3-36B-IQ4_XS
```

## Test plan

- [ ] ArgoCD syncs without "invalid reference format" error
- [ ] Webhook creates ModelCache and rewrites volume reference
- [ ] llama-cpp pod starts and serves inference

🤖 Generated with [Claude Code](https://claude.com/claude-code)