### PR TITLE
fix: lowercase hf.co repo name for valid OCI reference

### DIFF
--- a/overlays/prod/llama-cpp/values.yaml
+++ b/overlays/prod/llama-cpp/values.yaml
@@ -5,7 +5,7 @@ imagePullSecret:
 
 modelVolume:
   enabled: true
-  reference: "hf.co/bartowski/NousResearch_Hermes-4.3-36B-GGUF:NousResearch_Hermes-4.3-36B-IQ4_XS"
+  reference: "hf.co/bartowski/nousresearch_hermes-4.3-36b-gguf:NousResearch_Hermes-4.3-36B-IQ4_XS"
   mountPath: "/model-image"
 
 server:


### PR DESCRIPTION
## Summary

- Fixes #463 — repo name must be lowercase per OCI distribution spec
- Kubernetes validates the image volume reference *before* the mutating webhook runs, so the ref must be valid OCI even though the webhook rewrites it
- HuggingFace API resolves repos case-insensitively, so `bartowski/nousresearch_hermes-4.3-36b-gguf` works correctly

```diff
- hf.co/bartowski/NousResearch_Hermes-4.3-36B-GGUF:NousResearch_Hermes-4.3-36B-IQ4_XS
+ hf.co/bartowski/nousresearch_hermes-4.3-36b-gguf:NousResearch_Hermes-4.3-36B-IQ4_XS
```

Tag (file selector) keeps original case — OCI tags allow `[a-zA-Z0-9_.-]` and GGUF file matching uses `strings.EqualFold`.

## Test plan

- [ ] ArgoCD syncs without "invalid reference format" error
- [ ] Webhook creates ModelCache and rewrites volume reference
- [ ] llama-cpp pod starts and serves inference

🤖 Generated with [Claude Code](https://claude.com/claude-code)