### PR TITLE
fix: enable model cache webhook for llama-cpp namespace

### DIFF
--- a/overlays/prod/llama-cpp/application.yaml
+++ b/overlays/prod/llama-cpp/application.yaml
@@ -18,6 +18,9 @@ spec:
     server: https://kubernetes.default.svc
     namespace: llama-cpp
   syncPolicy:
+    managedNamespaceMetadata:
+      labels:
+        oci-model-cache.jomcgi.dev/enabled: "true"
     automated:
       prune: true
       selfHeal: true


### PR DESCRIPTION
## Summary

- The `llama-cpp` namespace is missing the `oci-model-cache.jomcgi.dev/enabled: "true"` label required by the webhook's namespace selector
- Without this label, the webhook doesn't intercept pods, so the kubelet tries to pull `hf.co/` directly as an OCI registry (400 Bad Request from HuggingFace)
- Uses ArgoCD `managedNamespaceMetadata` to declaratively add the label

## Test plan

- [ ] ArgoCD syncs and adds label to `llama-cpp` namespace
- [ ] Webhook intercepts pod, creates ModelCache, rewrites volume to `ghcr.io/...`
- [ ] llama-cpp pod starts and serves inference

🤖 Generated with [Claude Code](https://claude.com/claude-code)