### PR TITLE
fix: only strip known file extensions in compact tag derivation

### DIFF
--- a/tools/hf2oci/pkg/ociref/ociref.go
+++ b/tools/hf2oci/pkg/ociref/ociref.go
@@ -56,9 +56,14 @@ func DeriveCompactVariantTag(author, format, file, baseModelName string) string 
 		remainder = strings.TrimLeft(remainder, "-_")
 	}
 
-	// Strip file extension (.gguf, etc.).
-	if idx := strings.LastIndex(remainder, "."); idx >= 0 {
-		remainder = remainder[:idx]
+	// Strip known model file extensions. Only strip recognized extensions
+	// to avoid eating version numbers that contain dots (e.g. "4.3" in
+	// "NousResearch_Hermes-4.3-36B-IQ4_XS").
+	for _, ext := range []string{".gguf", ".safetensors", ".bin", ".pt"} {
+		if strings.HasSuffix(strings.ToLower(remainder), ext) {
+			remainder = remainder[:len(remainder)-len(ext)]
+			break
+		}
 	}
 
 	// Build tag: author-format-remainder, normalize.

--- a/tools/hf2oci/pkg/ociref/ociref_test.go
+++ b/tools/hf2oci/pkg/ociref/ociref_test.go
@@ -116,6 +116,22 @@ func TestDeriveCompactVariantTag(t *testing.T) {
 			baseModelName: "Hermes-3-8B",
 			want:          "thebloke-gguf-q5-k-s",
 		},
+		{
+			name:          "file selector without extension containing version dots",
+			author:        "bartowski",
+			format:        "gguf",
+			file:          "NousResearch_Hermes-4.3-36B-IQ4_XS",
+			baseModelName: "Hermes-4.3-36B",
+			want:          "bartowski-gguf-nousresearch-hermes-4.3-36b-iq4-xs",
+		},
+		{
+			name:          "file selector without extension no dots",
+			author:        "bartowski",
+			format:        "gguf",
+			file:          "Llama-3-8B-Q4_K_M",
+			baseModelName: "Llama-3-8B",
+			want:          "bartowski-gguf-q4-k-m",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

- Fixes a bug where `DeriveCompactVariantTag` used `strings.LastIndex(".")` to strip file extensions, which also ate version numbers containing dots
- Example: `NousResearch_Hermes-4.3-36B-IQ4_XS` → tag was `bartowski-gguf-nousresearch-hermes-4` (wrong), now `bartowski-gguf-nousresearch-hermes-4.3-36b-iq4-xs` (correct)
- Replaces generic dot-strip with explicit known extensions: `.gguf`, `.safetensors`, `.bin`, `.pt`

## Root cause

File selectors from `hf.co/` references don't include the `.gguf` extension, but the extension stripping logic assumed any last-dot suffix was an extension. Version numbers like `4.3` matched the dot pattern.

## Test plan

- [x] Added test case for file selector with version dots and no extension
- [x] Added test case for file selector without extension and no dots
- [x] All 6 hf2oci tests pass
- [ ] After merge + operator rebuild, llama-cpp ModelCache resolves correct tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)