### PR TITLE
feat: switch llama-cpp to Hermes-4-14B

### DIFF
--- a/overlays/prod/llama-cpp/values.yaml
+++ b/overlays/prod/llama-cpp/values.yaml
@@ -5,7 +5,7 @@ imagePullSecret:
 
 modelVolume:
   enabled: true
-  reference: "hf.co/bartowski/nousresearch_hermes-4.3-36b-gguf:NousResearch_Hermes-4.3-36B-IQ4_XS"
+  reference: "hf.co/bartowski/nousresearch_hermes-4-14b-gguf:NousResearch_Hermes-4-14B-IQ4_XS"
   mountPath: "/model-image"
 
 server:
@@ -20,7 +20,7 @@ server:
   extraArgs:
     - "--metrics"
     - "--alias"
-    - "hermes-4.3-36b"
+    - "hermes-4-14b"
 
 nodeSelector:
   kubernetes.io/hostname: node-4


### PR DESCRIPTION
## Summary

- Switches from Hermes-4.3-36B to Hermes-4-14B (IQ4_XS quantization)
- Smaller model that fits more comfortably in 24GB VRAM on node-4
- Updates `--alias` from `hermes-4.3-36b` to `hermes-4-14b`

## Test plan

- [ ] ModelCache resolves and syncs the 14B model
- [ ] Scheduling gate removed, pod starts
- [ ] llama-server loads model and serves `/v1/chat/completions`

🤖 Generated with [Claude Code](https://claude.com/claude-code)