### PR TITLE
fix: correct GGUF magic constant (swapped middle bytes)

### DIFF
--- a/tools/hf2oci/pkg/gguf/parse_test.go
+++ b/tools/hf2oci/pkg/gguf/parse_test.go
@@ -156,12 +156,38 @@ func TestParse_EmptyFile(t *testing.T) {
 	}
 }
 
+func TestMagic_MatchesGGUFSpec(t *testing.T) {
+	// GGUF spec: first 4 bytes are ASCII 'G','G','U','F'.
+	// Validate the constant matches, not just round-trip consistency.
+	specBytes := []byte{'G', 'G', 'U', 'F'}
+	specMagic := binary.LittleEndian.Uint32(specBytes)
+	if Magic != specMagic {
+		t.Errorf("Magic constant 0x%08X doesn't match GGUF spec bytes %q (expected 0x%08X)", Magic, specBytes, specMagic)
+	}
+}
+
 func TestParse_InvalidMagic(t *testing.T) {
 	var buf bytes.Buffer
 	binary.Write(&buf, binary.LittleEndian, uint32(0xDEADBEEF))
 	_, err := Parse(&buf)
 	if err == nil {
 		t.Fatal("expected error for invalid magic, got nil")
+	}
+}
+
+func TestParse_RealGGUFMagicBytes(t *testing.T) {
+	// Verify the parser accepts the raw GGUF spec magic bytes (not our constant).
+	var buf bytes.Buffer
+	buf.Write([]byte{'G', 'G', 'U', 'F'}) // raw spec bytes
+	binary.Write(&buf, binary.LittleEndian, uint32(3))
+	binary.Write(&buf, binary.LittleEndian, uint64(0))
+	binary.Write(&buf, binary.LittleEndian, uint64(0))
+	f, err := Parse(bytes.NewReader(buf.Bytes()))
+	if err != nil {
+		t.Fatalf("Parse rejected valid GGUF magic bytes: %v", err)
+	}
+	if f.Header.Magic != Magic {
+		t.Errorf("parsed magic 0x%08X != Magic constant 0x%08X", f.Header.Magic, Magic)
 	}
 }
 

--- a/tools/hf2oci/pkg/gguf/types.go
+++ b/tools/hf2oci/pkg/gguf/types.go
@@ -2,8 +2,8 @@
 // used by llama.cpp and compatible inference engines.
 package gguf
 
-// Magic is the GGUF magic number: "GGUF" in little-endian.
-const Magic uint32 = 0x46475547
+// Magic is the GGUF magic number: ASCII "GGUF" (0x47,0x47,0x55,0x46) as little-endian uint32.
+const Magic uint32 = 0x46554747
 
 // GGMLType identifies a tensor element quantization type.
 type GGMLType uint32


### PR DESCRIPTION
## Summary

- GGUF magic constant was `0x46475547` (`GUFG`) instead of `0x46554747` (`GGUF` as LE uint32)
- Middle bytes `0x47,0x55` were swapped to `0x55,0x47`, causing every real GGUF file to be rejected
- This is why the llama-cpp sync jobs fail with `invalid GGUF magic: 0x46554747`
- Tests passed because both writer and parser used the same wrong constant — round-trip consistent but not spec-compliant

## Changes

- Fix `Magic` constant in `types.go`
- Add `TestMagic_MatchesGGUFSpec` — derives expected value from raw ASCII `'G','G','U','F'` bytes
- Add `TestParse_RealGGUFMagicBytes` — verifies parser accepts spec-compliant magic

## Test plan

- [x] All GGUF tests pass
- [ ] After operator rebuild, sync job successfully parses and pushes Hermes-4-14B

🤖 Generated with [Claude Code](https://claude.com/claude-code)