### PR TITLE
feat: add transfer progress logging to hf2oci

### DIFF
--- a/tools/hf2oci/cmd/hf2oci/cmd/copy.go
+++ b/tools/hf2oci/cmd/hf2oci/cmd/copy.go
@@ -95,7 +95,18 @@ func runCopy(cmd *cobra.Command, args []string) error {
 		HFClient:     client,
 	}
 
-	// Suppress progress callbacks in JSON mode for clean machine output.
+	// Transfer progress is always logged to stderr (visible in container logs
+	// even when -o json directs structured output to the termination log).
+	opts.OnProgress = func(bytesRead, totalSize int64) {
+		if totalSize > 0 {
+			fmt.Fprintf(os.Stderr, "Transfer: %d/%d MB (%.0f%%)\n",
+				bytesRead>>20, totalSize>>20, float64(bytesRead)/float64(totalSize)*100)
+		} else {
+			fmt.Fprintf(os.Stderr, "Transfer: %d MB\n", bytesRead>>20)
+		}
+	}
+
+	// Suppress verbose callbacks in JSON mode for clean machine output.
 	if outputFormat != "json" {
 		opts.OnResolve = func(repo, revision string) {
 			fmt.Fprintf(os.Stderr, "Resolving %s@%s...\n", repo, revision)

--- a/tools/hf2oci/pkg/copy/copy.go
+++ b/tools/hf2oci/pkg/copy/copy.go
@@ -37,6 +37,7 @@ type Options struct {
 	OnUploadConfig func(count int)
 	OnUploadWeight func(index, total int, filename string)
 	OnGGUFSplit    func(shards int, originalFile string)
+	OnProgress     func(bytesRead, totalSize int64) // periodic transfer progress
 
 	// Injected dependencies (for testing).
 	HFClient   *hf.Client
@@ -179,7 +180,7 @@ func Copy(ctx context.Context, opts Options) (*Result, error) {
 				if err != nil {
 					return fmt.Errorf("downloading weight %s: %w", w.Path, err)
 				}
-				weightLayers[i] = oci.StreamingWeightLayer(body, size, modelDir, w.Path)
+				weightLayers[i] = oci.StreamingWeightLayer(wrapProgress(body, size, opts.OnProgress), size, modelDir, w.Path)
 				return nil
 			})
 		}
@@ -337,7 +338,7 @@ func buildSplitGGUFLayers(ctx context.Context, client *hf.Client, opts Options, 
 			// StreamingSplitGGUFLayer takes ownership of body and closes it.
 			// No early returns possible between DownloadRange and here, but
 			// guard defensively in case future code changes add logic.
-			layers[i] = oci.StreamingSplitGGUFLayer(headerBuf.Bytes(), body, bodySize, modelDir, shardFilename)
+			layers[i] = oci.StreamingSplitGGUFLayer(headerBuf.Bytes(), wrapProgress(body, bodySize, opts.OnProgress), bodySize, modelDir, shardFilename)
 			return nil
 		})
 	}
@@ -358,5 +359,44 @@ func buildSingleWeightLayer(ctx context.Context, client *hf.Client, opts Options
 	if opts.OnUploadWeight != nil {
 		opts.OnUploadWeight(1, 1, w.Path)
 	}
+	body = wrapProgress(body, size, opts.OnProgress)
 	return []v1.Layer{oci.StreamingWeightLayer(body, size, modelDir, w.Path)}, nil
+}
+
+// wrapProgress wraps an io.ReadCloser with periodic progress reporting.
+// Reports every 100MB of data read. Returns the original body if onProgress is nil.
+func wrapProgress(body io.ReadCloser, total int64, onProgress func(int64, int64)) io.ReadCloser {
+	if onProgress == nil {
+		return body
+	}
+	return &progressReader{
+		inner:      body,
+		total:      total,
+		onProgress: onProgress,
+		interval:   100 << 20, // 100MB
+	}
+}
+
+// progressReader wraps an io.ReadCloser and reports bytes transferred periodically.
+type progressReader struct {
+	inner      io.ReadCloser
+	total      int64
+	read       int64
+	onProgress func(bytesRead, totalSize int64)
+	interval   int64
+	lastReport int64
+}
+
+func (r *progressReader) Read(p []byte) (int, error) {
+	n, err := r.inner.Read(p)
+	r.read += int64(n)
+	if r.read-r.lastReport >= r.interval || err == io.EOF {
+		r.onProgress(r.read, r.total)
+		r.lastReport = r.read
+	}
+	return n, err
+}
+
+func (r *progressReader) Close() error {
+	return r.inner.Close()
 }


### PR DESCRIPTION
## Summary
- Adds periodic transfer progress logging (every 100MB) to stderr during model syncing
- Covers all download paths: normal multi-file, single-file fallback, and split GGUF shards
- Progress always logs to stderr (even in JSON mode) so it's visible in container logs without polluting structured output

## Context
Sync jobs for multi-GB models (like Hermes-4-14B at 8.1GB) currently run completely silent — no output until success or failure. This makes it impossible to tell if a job is making progress or stuck.

## Test plan
- [x] `bazel test //tools/hf2oci/...` — all 6 test targets pass
- [ ] Deploy updated hf2oci image → trigger sync job → verify stderr shows `Transfer: X/Y MB (Z%)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)