### PR TITLE
feat: add repository cache GC for Bazel 9

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -23,6 +23,11 @@ common --@aspect_rules_ts//ts:default_to_tsc_transpiler
 # Repository cache location
 common --repository_cache=~/.cache/bazel/repository_cache
 common --experimental_repository_cache_hardlinks
+# Garbage-collect repo contents cache entries older than 14 days (Bazel 9+)
+# This covers the extracted repository rule outputs (repository_cache/contents/)
+# but NOT the raw download blobs (content_addressable/). Use tools/bazel-cache-gc.sh
+# to prune stale download blobs periodically.
+common --repo_contents_cache_gc_max_age=14d
 
 # =============================================================================
 # Disk Cache - Share build artifacts across all workspaces (local only)

--- a/tools/bazel-cache-gc.sh
+++ b/tools/bazel-cache-gc.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Garbage-collects stale entries from the Bazel repository cache.
+#
+# Bazel 9 has built-in GC for disk_cache and repo_contents_cache, but the
+# content-addressable download cache (content_addressable/sha256/) has no
+# automatic cleanup. This script prunes entries not accessed in MAX_AGE_DAYS.
+#
+# Usage:
+#   tools/bazel-cache-gc.sh              # dry-run (default)
+#   tools/bazel-cache-gc.sh --delete     # actually delete stale entries
+#
+# Recommended: run monthly or when disk usage gets high.
+set -o errexit -o nounset -o pipefail
+
+CACHE_DIR="${BAZEL_REPO_CACHE:-${HOME}/.cache/bazel/repository_cache}"
+MAX_AGE_DAYS="${BAZEL_CACHE_MAX_AGE_DAYS:-30}"
+DRY_RUN=true
+
+for arg in "$@"; do
+	case "$arg" in
+	--delete) DRY_RUN=false ;;
+	--help | -h)
+		echo "Usage: $0 [--delete]"
+		echo "  --delete  Actually remove stale cache entries (default: dry-run)"
+		exit 0
+		;;
+	*)
+		echo "Unknown argument: $arg" >&2
+		exit 1
+		;;
+	esac
+done
+
+if [ ! -d "$CACHE_DIR" ]; then
+	echo "Cache directory not found: $CACHE_DIR"
+	exit 0
+fi
+
+# Report current usage
+echo "Repository cache: $CACHE_DIR"
+du -sh "$CACHE_DIR" 2>/dev/null | awk '{print "Current size: " $1}'
+echo "Max age: ${MAX_AGE_DAYS} days"
+echo ""
+
+# Find stale entries in content_addressable (the unbounded part)
+ca_dir="$CACHE_DIR/content_addressable"
+if [ ! -d "$ca_dir" ]; then
+	echo "No content_addressable directory found, nothing to clean."
+	exit 0
+fi
+
+# Use -atime on macOS (last access time) to avoid evicting files still being
+# referenced by hardlinks in active output bases.
+stale_files=$(find "$ca_dir" -type f -atime "+${MAX_AGE_DAYS}" 2>/dev/null)
+stale_count=$(echo "$stale_files" | grep -c . 2>/dev/null || echo 0)
+
+if [ "$stale_count" -eq 0 ]; then
+	echo "No stale entries older than ${MAX_AGE_DAYS} days."
+	exit 0
+fi
+
+# Calculate reclaimable space
+stale_size=$(echo "$stale_files" | xargs du -ch 2>/dev/null | tail -1 | awk '{print $1}')
+echo "Stale entries: $stale_count files ($stale_size)"
+
+if [ "$DRY_RUN" = true ]; then
+	echo ""
+	echo "Dry-run mode. Run with --delete to remove these entries."
+else
+	echo "Deleting stale entries..."
+	echo "$stale_files" | xargs rm -f
+	# Clean up empty directories
+	find "$ca_dir" -type d -empty -delete 2>/dev/null || true
+	echo "Done. Reclaimed $stale_size."
+fi


### PR DESCRIPTION
## Summary
- Bazel's `repository_cache/content_addressable/` directory grew to **100GB** over ~4 months with no automatic cleanup
- Added `--repo_contents_cache_gc_max_age=14d` to `.bazelrc` — enables Bazel 9's built-in GC for the `contents/` subdirectory (was 14GB)
- Added `tools/bazel-cache-gc.sh` — prunes stale download blobs from `content_addressable/` (was 86GB) based on access time

## Details

Bazel 9 introduced GC for `repo_contents_cache` (extracted repo rule outputs) but still has **no built-in GC** for the raw download cache (`content_addressable/sha256/`). The script fills this gap:

```bash
tools/bazel-cache-gc.sh              # dry-run, shows reclaimable space
tools/bazel-cache-gc.sh --delete     # actually prune entries >30 days old
```

Configurable via env vars: `BAZEL_REPO_CACHE`, `BAZEL_CACHE_MAX_AGE_DAYS`.

## Test plan
- [x] Verified 100GB cache was present before cleanup
- [ ] Run `tools/bazel-cache-gc.sh` in dry-run mode
- [ ] Run `bazelisk build //tools/...` to confirm fresh cache works
- [ ] CI passes (BuildBuddy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)