### PR TITLE
feat: publish oci-model-cache-operator Helm chart to GHCR

### DIFF
--- a/images/BUILD
+++ b/images/BUILD
@@ -11,6 +11,7 @@ multirun(
         "//charts/signoz-dashboard-sidecar/cmd:image.push",
         "//charts/todo/image:image.push",
         "//operators/cloudflare:image.push",
+        "//operators/oci-model-cache/helm/oci-model-cache-operator:chart.push",
         "//operators/oci-model-cache:image.push",
         "//services/ais_ingest:image.push",
         "//services/hikes/update_forecast:update_image.push",

--- a/operators/oci-model-cache/helm/oci-model-cache-operator/BUILD
+++ b/operators/oci-model-cache/helm/oci-model-cache-operator/BUILD
@@ -2,5 +2,6 @@ load("//rules_helm:defs.bzl", "helm_chart")
 
 helm_chart(
     name = "chart",
+    publish = True,
     visibility = ["//overlays/dev/oci-model-cache:__pkg__"],
 )

--- a/rules_helm/push.bzl
+++ b/rules_helm/push.bzl
@@ -33,6 +33,13 @@ def _helm_package_impl(ctx):
         tools = [ctx.executable._helm],
         command = """\
 set -euo pipefail
+# Exclude Bazel build files from the chart package
+cat > "{chart_dir}/.helmignore" << 'HELMIGNORE'
+BUILD
+BUILD.bazel
+*.bzl
+.git/
+HELMIGNORE
 "{helm}" package "{chart_dir}" --destination "{out_dir}"
 # helm package outputs <name>-<version>.tgz, find and move it
 TGZ=$(ls "{out_dir}"/*.tgz)


### PR DESCRIPTION
## Summary

- Enable OCI chart publishing for `oci-model-cache-operator` by setting `publish = True` on its `helm_chart` macro
- Add `.helmignore` to exclude `BUILD` files from the packaged chart `.tgz`
- Regenerate `images/BUILD` to include `chart.push` in the `push_all` multirun target

After merge, CI will push to: `oci://ghcr.io/jomcgi/homelab/charts/oci-model-cache-operator:0.1.0`

## Test plan

- [x] `helm_package` builds valid `.tgz` (BUILD files excluded via `.helmignore`)
- [x] `helm_push` target discovered by `generate-push-all.sh`
- [x] All operator tests pass (lint, controller, webhook, template)
- [ ] CI pushes chart to GHCR on merge to main
- [ ] `helm pull oci://ghcr.io/jomcgi/homelab/charts/oci-model-cache-operator --version 0.1.0`


🤖 Generated with [Claude Code](https://claude.com/claude-code)