### PR TITLE
fix: use absolute path for llama-server and pin image digest

### DIFF
--- a/charts/llama-cpp/templates/deployment.yaml
+++ b/charts/llama-cpp/templates/deployment.yaml
@@ -39,7 +39,7 @@ spec:
           command: ["/bin/sh", "-c"]
           args:
             - |
-              exec llama-server \
+              exec /app/llama-server \
                 --model {{ .Values.server.modelPath | quote }} \
                 {{ include "llama-cpp.serverArgs" . | indent 16 | trim }}
           {{- else }}
@@ -55,7 +55,7 @@ spec:
                 exit 1
               fi
               echo "Auto-discovered model: $MODEL"
-              exec llama-server \
+              exec /app/llama-server \
                 --model "$MODEL" \
                 {{ include "llama-cpp.serverArgs" . | indent 16 | trim }}
           {{- end }}

--- a/overlays/prod/llama-cpp/values.yaml
+++ b/overlays/prod/llama-cpp/values.yaml
@@ -1,5 +1,8 @@
 fullnameOverride: "llama-cpp"
 
+image:
+  tag: "server-cuda@sha256:a8ad9d1fd95640cec092d2ac27cb16d71183114c776f2a342e65a1196195c873"
+
 imagePullSecret:
   enabled: true
 


### PR DESCRIPTION
## Summary
- The upstream `ghcr.io/ggml-org/llama.cpp:server-cuda` image restructured its filesystem, moving `llama-server` from a standard PATH directory to `/app/`
- Our deployment template used `exec llama-server` (PATH lookup), which broke when the image updated silently via the floating tag
- Pod has been in CrashLoopBackOff with `exec: llama-server: not found` for ~4 hours

## Changes
- Use absolute path `/app/llama-server` in the Helm deployment template (both auto-discover and explicit model path branches)
- Pin the image to its current digest (`sha256:a8ad9d1f...`) in the prod overlay to prevent future silent breakage from upstream tag mutations

## Test plan
- [ ] CI passes (Helm template renders correctly)
- [ ] ArgoCD syncs, pod starts and passes health checks
- [ ] llama-server responds on the `/health` endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)