### PR TITLE
feat: inject chart-specific URL annotation at build time

### DIFF
--- a/rules_helm/chart.bzl
+++ b/rules_helm/chart.bzl
@@ -3,7 +3,7 @@
 load("//rules_helm:push.bzl", "helm_package", "helm_push")
 load("//rules_helm:test.bzl", "helm_lint_test")
 
-def helm_chart(name, publish = False, repository = "oci://ghcr.io/jomcgi/homelab/charts", visibility = None, lint = True):
+def helm_chart(name, publish = False, repository = "oci://ghcr.io/jomcgi/homelab/charts", source_url = "https://github.com/jomcgi/homelab", visibility = None, lint = True):
     """Declares a Helm chart directory with optional lint testing and OCI publishing.
 
     This macro replaces chart_files() and adds support for packaging charts as
@@ -13,6 +13,7 @@ def helm_chart(name, publish = False, repository = "oci://ghcr.io/jomcgi/homelab
         name: Name of the filegroup target (typically "chart")
         publish: If True, create package and push targets for OCI registry
         repository: OCI repository URL for pushing (default: ghcr.io/jomcgi/homelab/charts)
+        source_url: Base GitHub repository URL for chart deep linking (default: github.com/jomcgi/homelab)
         visibility: Visibility for the filegroup target
         lint: If True, create a helm lint test (default: True)
     """
@@ -37,6 +38,7 @@ def helm_chart(name, publish = False, repository = "oci://ghcr.io/jomcgi/homelab
         helm_package(
             name = name + ".package",
             srcs = native.glob(["**/*"]),
+            url = source_url + "/tree/main/" + native.package_name(),
         )
 
         helm_push(

--- a/rules_helm/push.bzl
+++ b/rules_helm/push.bzl
@@ -27,28 +27,45 @@ def _helm_package_impl(ctx):
             chart_dir = src.dirname
             break
 
+    # Build URL annotation patch command if url is specified.
+    # This replaces org.opencontainers.image.url in Chart.yaml so GHCR
+    # links to the chart's directory rather than the monorepo root.
+    url_patch = ""
+    if ctx.attr.url:
+        url_patch = (
+            "sed 's|org.opencontainers.image.url:.*|org.opencontainers.image.url: \"{url}\"|' " +
+            "\"$WORK_DIR/Chart.yaml\" > \"$WORK_DIR/Chart.yaml.tmp\"\n" +
+            "mv \"$WORK_DIR/Chart.yaml.tmp\" \"$WORK_DIR/Chart.yaml\""
+        ).format(url = ctx.attr.url)
+
     ctx.actions.run_shell(
         outputs = [output],
         inputs = ctx.files.srcs,
         tools = [ctx.executable._helm],
         command = """\
 set -euo pipefail
+# Copy chart to writable directory for patching (sandbox inputs are read-only)
+WORK_DIR=$(mktemp -d)
+cp -rL "{chart_dir}/." "$WORK_DIR/"
 # Exclude Bazel build files from the chart package
-cat > "{chart_dir}/.helmignore" << 'HELMIGNORE'
+cat > "$WORK_DIR/.helmignore" << 'HELMIGNORE'
 BUILD
 BUILD.bazel
 *.bzl
 .git/
 HELMIGNORE
-"{helm}" package "{chart_dir}" --destination "{out_dir}"
+{url_patch}
+"{helm}" package "$WORK_DIR" --destination "{out_dir}"
 # helm package outputs <name>-<version>.tgz, find and move it
 TGZ=$(ls "{out_dir}"/*.tgz)
 mv "$TGZ" "{output}"
+rm -rf "$WORK_DIR"
 """.format(
             helm = ctx.executable._helm.path,
             chart_dir = chart_dir,
             out_dir = output.dirname,
             output = output.path,
+            url_patch = url_patch,
         ),
         mnemonic = "HelmPackage",
         progress_message = "Packaging Helm chart %s" % ctx.label.name,
@@ -63,6 +80,10 @@ helm_package = rule(
             mandatory = True,
             allow_files = True,
             doc = "Chart source files (typically from glob([\"**/*\"]))",
+        ),
+        "url": attr.string(
+            doc = "URL to inject into Chart.yaml org.opencontainers.image.url annotation. " +
+                  "Used by GHCR to deep-link to the chart's source directory.",
         ),
         "_helm": attr.label(
             default = "@multitool//tools/helm",


### PR DESCRIPTION
## Summary
- `helm_package` now copies the chart to a writable temp dir before packaging, enabling Chart.yaml patching
- Injects `org.opencontainers.image.url` with the chart's GitHub directory path (e.g. `.../tree/main/operators/.../oci-model-cache-operator`)
- `org.opencontainers.image.source` stays at repo root (required for GHCR repo linking)
- New `source_url` parameter on `helm_chart` macro for customization

## How it works
At `helm package` time, the build action:
1. Copies chart files to a writable temp directory (sandbox inputs are read-only symlinks)
2. Writes `.helmignore` to exclude Bazel files
3. Patches `Chart.yaml` URL annotation via `sed`
4. Runs `helm package` on the patched copy

## Test plan
- [x] `bazel build //operators/oci-model-cache/helm/oci-model-cache-operator:chart.package` succeeds
- [x] Extracted `Chart.yaml` from `.tgz` shows patched URL
- [x] No `BUILD`/`.bzl` files in packaged chart
- [x] Lint test passes
- [ ] CI format check passes
- [ ] CI test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)