### PR TITLE
fix: set --parallel 1 to prevent GPU slot contention

### DIFF
--- a/overlays/prod/llama-cpp/values.yaml
+++ b/overlays/prod/llama-cpp/values.yaml
@@ -21,6 +21,8 @@ server:
   threads: 8
   jinja: true
   extraArgs:
+    - "--parallel"
+    - "1"
     - "--metrics"
     - "--alias"
     - "hermes-4-14b"


### PR DESCRIPTION
## Summary
- llama-server defaults to 4 parallel slots with 32K context each
- When OpenClaw sends its ~8.7K token system prompt, multiple slots compete for the GPU
- This causes a **1,800x slowdown**: 311 tok/s → 0.17 tok/s prompt processing
- Requests time out, retry, and cascade — the GPU never catches up

## Evidence
Single slot (idle):
```
prompt eval: 41ms / 13 tokens = 311 tok/s
generation:  195ms / 14 tokens = 71 tok/s
```
4 concurrent slots:
```
prompt eval: 177,287ms / 30 tokens = 0.17 tok/s
generation:  325,264ms / 12 tokens = 0.04 tok/s
```

## Change
- Add `--parallel 1` to llama-cpp server args in prod overlay

## Test plan
- [ ] CI passes
- [ ] ArgoCD syncs, pod restarts with single slot
- [ ] Send Discord message to OpenClaw, verify response within seconds

🤖 Generated with [Claude Code](https://claude.com/claude-code)