### PR TITLE
fix: optimize llama-cpp GPU utilization and context window

### DIFF
--- a/charts/llama-cpp/templates/_helpers.tpl
+++ b/charts/llama-cpp/templates/_helpers.tpl
@@ -53,9 +53,6 @@ llama-server CLI arguments (shared between direct args and auto-discovery shell 
 */}}
 {{- define "llama-cpp.serverArgs" -}}
 --n-gpu-layers {{ .Values.server.nGpuLayers | quote }} \
-{{- if .Values.server.noKvOffload }}
---no-kv-offload \
-{{- end }}
 --ctx-size {{ .Values.server.ctxSize | quote }} \
 {{- if .Values.server.flashAttn }}
 --flash-attn {{ .Values.server.flashAttn | quote }} \

--- a/charts/llama-cpp/values.yaml
+++ b/charts/llama-cpp/values.yaml
@@ -23,8 +23,6 @@ server:
   modelPath: ""
   ## Number of layers to offload to GPU (-1 = all)
   nGpuLayers: 99
-  ## Keep KV cache in system RAM instead of VRAM
-  noKvOffload: true
   ## Context window size (tokens)
   ctxSize: 32768
   ## Flash attention: "on", "off", or "auto" (empty string to disable)

--- a/overlays/prod/llama-cpp/values.yaml
+++ b/overlays/prod/llama-cpp/values.yaml
@@ -12,9 +12,8 @@ modelVolume:
   mountPath: "/model-image"
 
 server:
-  nGpuLayers: 99
-  noKvOffload: true
-  ctxSize: 32768
+  nGpuLayers: 999
+  ctxSize: 40960
   flashAttn: "on"
   cacheTypeK: "q8_0"
   cacheTypeV: "q4_0"


### PR DESCRIPTION
## Summary
- **nGpuLayers 99→999**: Future-proof for larger models (99 already covers all 40 layers of 14B, but 999 is safer convention)
- **noKvOffload false**: Keep KV cache on GPU VRAM instead of forcing PCIe roundtrips to system RAM. Fixes 0% GPU utilization observed on the monitor
- **ctxSize 32768→40960**: Use the full trained context window of Hermes-4-14B. VRAM budget: ~8GB model (IQ4_XS) + ~2.4GB KV cache = ~10.4GB, well within RTX 4090's 24GB

## Test plan
- [ ] Pod restarts successfully with new settings
- [ ] `kubectl logs` shows all layers offloaded to GPU and KV cache on CUDA
- [ ] GPU monitor shows higher VRAM usage (~10-11GB) and active utilization during inference
- [ ] Chat completion test responds at expected speed (~80+ tok/s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)