### PR TITLE
fix: override Hermes-4 chat template for native tool support

### DIFF
--- a/charts/llama-cpp/templates/_helpers.tpl
+++ b/charts/llama-cpp/templates/_helpers.tpl
@@ -63,6 +63,9 @@ llama-server CLI arguments (shared between direct args and auto-discovery shell 
 {{- if .Values.server.jinja }}
 --jinja \
 {{- end }}
+{{- if .Values.server.chatTemplate }}
+--chat-template-file "/etc/llama-cpp/chat-template.jinja" \
+{{- end }}
 --host {{ .Values.server.host | quote }} \
 --port {{ .Values.server.port | quote }}{{ range .Values.server.extraArgs }} \
 {{ . | quote }}{{ end }}

--- a/charts/llama-cpp/templates/configmap-chat-template.yaml
+++ b/charts/llama-cpp/templates/configmap-chat-template.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.server.chatTemplate }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "llama-cpp.fullname" . }}-chat-template
+  labels:
+    {{- include "llama-cpp.labels" . | nindent 4 }}
+data:
+  chat-template.jinja: |
+    {{- .Values.server.chatTemplate | nindent 4 }}
+{{- end }}

--- a/charts/llama-cpp/templates/deployment.yaml
+++ b/charts/llama-cpp/templates/deployment.yaml
@@ -83,6 +83,11 @@ spec:
               mountPath: {{ .Values.modelVolume.mountPath }}
               readOnly: true
             {{- end }}
+            {{- if .Values.server.chatTemplate }}
+            - name: chat-template
+              mountPath: /etc/llama-cpp
+              readOnly: true
+            {{- end }}
             - name: dshm
               mountPath: /dev/shm
       volumes:
@@ -91,6 +96,11 @@ spec:
           image:
             reference: {{ .Values.modelVolume.reference }}
             pullPolicy: IfNotPresent
+        {{- end }}
+        {{- if .Values.server.chatTemplate }}
+        - name: chat-template
+          configMap:
+            name: {{ include "llama-cpp.fullname" . }}-chat-template
         {{- end }}
         - name: dshm
           emptyDir:

--- a/charts/llama-cpp/values.yaml
+++ b/charts/llama-cpp/values.yaml
@@ -38,6 +38,9 @@ server:
   ## Host and port
   host: "0.0.0.0"
   port: 8080
+  ## Override the model's built-in chat template (Jinja format).
+  ## When set, creates a ConfigMap and passes --chat-template-file.
+  chatTemplate: ""
   ## Additional CLI arguments
   extraArgs: []
 

--- a/overlays/prod/llama-cpp/values.yaml
+++ b/overlays/prod/llama-cpp/values.yaml
@@ -13,15 +13,99 @@ modelVolume:
 
 server:
   nGpuLayers: 999
-  ctxSize: 40960
+  ctxSize: 16384
   flashAttn: "on"
   cacheTypeK: "q8_0"
   cacheTypeV: "q4_0"
   threads: 8
   jinja: true
+  chatTemplate: |
+    {%- set thinking_prompt = 'You are a deep thinking AI, you may use extremely long chains of thought to deeply consider the problem and deliberate with yourself via systematic reasoning processes to help come to a correct solution prior to answering. You should enclose your thoughts and internal monologue inside <think> </think> tags, and then provide your solution or response to the problem.' %}
+    {%- set standard_prompt = 'You are Hermes, created by Nous Research.' %}
+    {%- if not thinking is defined %}{% set thinking = false %}{% endif %}
+    {%- if not keep_cots is defined %}{% set keep_cots = false %}{% endif %}
+    {%- if thinking %}{%- set system_prompt = thinking_prompt %}{%- else %}{%- set system_prompt = standard_prompt %}{%- endif %}
+    {%- if tools %}
+        {{- '<|im_start|>system\n' }}
+        {%- if messages[0]['role'] == 'system' %}
+            {{- messages[0]['content'] }}
+        {%- else %}
+            {{- system_prompt }}
+        {%- endif %}
+        {{- "\n\n# Tools\n\nYou are a function calling AI model. You may call one or more functions to assist with the user query.\n\nYou are provided with function signatures within <tools></tools> XML tags:\n<tools>" }}
+        {%- for tool in tools %}
+            {%- if tool.function is defined %}
+                {%- set _name = tool.function.name %}
+            {%- endif %}
+            {{- "\n" }}
+            {{- tool | tojson }}
+        {%- endfor %}
+        {{- "\n</tools>\n\nFor each function call, return a json object with function name and arguments within <tool_call></tool_call> XML tags:\n<tool_call>\n{\"name\": \"<function-name>\", \"arguments\": <args-json-object>}\n</tool_call><|im_end|>\n" }}
+    {%- else %}
+        {%- if messages[0]['role'] == 'system' %}
+            {{- '<|im_start|>system\n' + messages[0]['content'] + '<|im_end|>\n' }}
+        {%- else %}
+            {{- '<|im_start|>system\n' + system_prompt + '<|im_end|>\n' }}
+        {%- endif %}
+    {%- endif %}
+    {%- for message in messages %}
+        {%- if (message.role == "user") or (message.role == "system" and not loop.first) %}
+            {{- '<|im_start|>' + message.role + '\n' + message.content + '<|im_end|>' + '\n' }}
+        {%- elif (message.role == "assistant" and not message.tool_calls) %}
+            {{- '<|im_start|>' + message.role }}
+            {%- if message.content %}
+                {%- set content = message['content'] -%}
+                {%- if thinking %}
+                    {%- if not keep_cots %}
+                        {%- set content = '<think> </think>' + content.split('</think>', 1)[1] -%}
+                    {%- endif %}
+                {%- endif %}
+                {{- '\n' + content + '<|im_end|>' + '\n' }}
+            {%- endif %}
+        {%- elif message.role == "assistant" %}
+            {{- '<|im_start|>' + message.role }}
+            {%- if message.content %}
+                {%- set content = message['content'] -%}
+                {%- if thinking %}
+                    {%- if not keep_cots %}
+                        {%- set content = '<think> </think>' + content.split('</think>', 1)[1] -%}
+                    {%- endif %}
+                {%- endif %}
+                {{- '\n' + content }}
+            {%- endif %}
+            {%- for tool_call in message.tool_calls %}
+                {%- if tool_call.function is defined %}
+                    {%- set tool_call = tool_call.function %}
+                {%- endif %}
+                {{- '\n<tool_call>\n{"name": "' }}
+                {{- tool_call.name }}
+                {{- '", "arguments": ' }}
+                {{- tool_call.arguments | tojson }}
+                {{- '}\n</tool_call>' }}
+            {%- endfor %}
+            {{- '<|im_end|>\n' }}
+        {%- elif message.role == "tool" %}
+            {%- if (loop.index0 == 0) or (messages[loop.index0 - 1].role != "tool") %}
+                {{- '<|im_start|>user' }}
+            {%- endif %}
+            {{- '\n<tool_response>\n' }}
+            {{- message.content }}
+            {{- '\n</tool_response>' }}
+            {%- if loop.last or (messages[loop.index0 + 1].role != "tool") %}
+                {{- '<|im_end|>\n' }}
+            {%- endif %}
+        {%- endif %}
+    {%- endfor %}
+    {%- if add_generation_prompt %}
+        {{- '<|im_start|>assistant\n' }}
+    {%- endif %}
   extraArgs:
     - "--parallel"
     - "1"
+    - "--ubatch-size"
+    - "2048"
+    - "--cache-reuse"
+    - "256"
     - "--metrics"
     - "--alias"
     - "hermes-4-14b"


### PR DESCRIPTION
## Summary
- **Chat template override**: Adds `server.chatTemplate` value to the llama-cpp chart. When set, creates a ConfigMap mounted at `/etc/llama-cpp/chat-template.jinja` and passes `--chat-template-file`
- **Hermes-4 template fix**: The upstream template uses `tool | tojson` which triggers a false positive in llama.cpp's capability detection (`caps.cpp` checks for explicit `tool.function.name` access). This causes the server to fall back to a generic tool handler instead of the native Hermes one. Fix: add `{%- set _name = tool.function.name %}` in the tools loop — satisfies the heuristic without changing output
- **ctxSize 40960→16384**: Right-size for single-user Discord bot use case
- **`--ubatch-size 2048`**: Process full prompt batch in single GPU call (default 512 splits into 4 sub-batches)
- **`--cache-reuse 256`**: Reuse system prompt KV cache prefix across requests (~1.5s saved per request)

## Test plan
- [ ] Pod starts without the "does not natively describe tools" warning
- [ ] `helm template` with empty `chatTemplate` produces no ConfigMap or mount (verified locally)
- [ ] Tool calls from OpenClaw use native `<tool_call>` format, not generic JSON fallback
- [ ] Verify system prompt caching via `/slots` endpoint (cached tokens > 0 on second request)

🤖 Generated with [Claude Code](https://claude.com/claude-code)