### PR TITLE
feat: smaller OCI shards and higher parallelism

### DIFF
--- a/tools/hf2oci/cmd/hf2oci/cmd/copy.go
+++ b/tools/hf2oci/cmd/hf2oci/cmd/copy.go
@@ -19,6 +19,7 @@ var (
 	copyModelDir     string
 	copyFile         string
 	copyMaxShardSize string
+	copyMaxParallel  int
 	copyDryRun       bool
 )
 
@@ -45,8 +46,8 @@ Examples:
   # Dry run to see what would be uploaded
   hf2oci copy NousResearch/Hermes-4.3-Llama-3-36B-AWQ -r ghcr.io/jomcgi/models --dry-run
 
-  # Split a large GGUF into 4GB shard layers
-  hf2oci copy bartowski/Hermes-4.3-36B-GGUF:Hermes-4.3-36B-IQ4_XS -r ghcr.io/jomcgi/models --max-shard-size 4G`,
+  # Split a large GGUF into 500MB shard layers (default)
+  hf2oci copy bartowski/Hermes-4.3-36B-GGUF:Hermes-4.3-36B-IQ4_XS -r ghcr.io/jomcgi/models`,
 	Args: cobra.ExactArgs(1),
 	RunE: runCopy,
 }
@@ -59,7 +60,8 @@ func init() {
 	copyCmd.Flags().StringVarP(&copyTag, "tag", "t", "", "Override OCI tag (default: rev-{revision[:12]})")
 	copyCmd.Flags().StringVar(&copyModelDir, "model-dir", "", "In-image model path (default: /)")
 	copyCmd.Flags().StringVar(&copyFile, "file", "", "GGUF filename prefix selector (e.g. ModelName-Q4_K_M)")
-	copyCmd.Flags().StringVar(&copyMaxShardSize, "max-shard-size", "4G", "Max size per GGUF shard layer (e.g. 4G, 500M). 0 disables splitting.")
+	copyCmd.Flags().StringVar(&copyMaxShardSize, "max-shard-size", "500M", "Max size per GGUF shard layer (e.g. 4G, 500M). 0 disables splitting.")
+	copyCmd.Flags().IntVar(&copyMaxParallel, "max-parallel", 100, "Max concurrent layer uploads/downloads")
 	copyCmd.Flags().BoolVar(&copyDryRun, "dry-run", false, "List files without downloading or pushing")
 
 	copyCmd.MarkFlagRequired("registry")
@@ -91,12 +93,19 @@ func runCopy(cmd *cobra.Command, args []string) error {
 		ModelDir:     copyModelDir,
 		File:         copyFile,
 		MaxShardSize: maxShard,
+		MaxParallel:  copyMaxParallel,
 		DryRun:       copyDryRun,
 		HFClient:     client,
 	}
 
 	// Transfer progress is always logged to stderr (visible in container logs
 	// even when -o json directs structured output to the termination log).
+	opts.OnShardProgress = func(index, total int, bytesRead, shardSize, overallRead, overallSize int64) {
+		fmt.Fprintf(os.Stderr, "Shard %d/%d: %d/%d MB | Overall: %d/%d MB (%.0f%%)\n",
+			index, total, bytesRead>>20, shardSize>>20,
+			overallRead>>20, overallSize>>20, float64(overallRead)/float64(overallSize)*100)
+	}
+	// Legacy per-layer progress for non-split paths.
 	opts.OnProgress = func(bytesRead, totalSize int64) {
 		if totalSize > 0 {
 			fmt.Fprintf(os.Stderr, "Transfer: %d/%d MB (%.0f%%)\n",

--- a/tools/hf2oci/pkg/copy/copy.go
+++ b/tools/hf2oci/pkg/copy/copy.go
@@ -27,6 +27,7 @@ type Options struct {
 	ModelDir     string // In-image model path (default "/")
 	File         string // GGUF filename prefix selector (e.g. "ModelName-Q4_K_M")
 	MaxShardSize int64  // Max bytes per GGUF shard layer (0 = no splitting)
+	MaxParallel  int    // Max concurrent layer uploads/downloads (0 = default 100)
 	DryRun       bool
 
 	// Callbacks for progress reporting.
@@ -37,7 +38,11 @@ type Options struct {
 	OnUploadConfig func(count int)
 	OnUploadWeight func(index, total int, filename string)
 	OnGGUFSplit    func(shards int, originalFile string)
-	OnProgress     func(bytesRead, totalSize int64) // periodic transfer progress
+	OnProgress     func(bytesRead, totalSize int64) // periodic per-layer transfer progress (deprecated, use OnShardProgress)
+
+	// OnShardProgress reports per-shard transfer progress with shard context.
+	// index is 1-based, total is the number of shards.
+	OnShardProgress func(index, total int, bytesRead, shardSize, overallRead, overallSize int64)
 
 	// Injected dependencies (for testing).
 	HFClient   *hf.Client
@@ -156,9 +161,14 @@ func Copy(ctx context.Context, opts Options) (*Result, error) {
 	// the in-flight reads from the response bodies.
 	var weightLayers []v1.Layer
 
+	parallel := opts.MaxParallel
+	if parallel <= 0 {
+		parallel = 100
+	}
+
 	if rm.format == FormatGGUF && len(rm.weights) == 1 && opts.MaxShardSize > 0 && rm.weights[0].Size > opts.MaxShardSize {
 		// GGUF split path: single large file → multiple shard layers.
-		weightLayers, err = buildSplitGGUFLayers(ctx, client, opts, rm, modelDir)
+		weightLayers, err = buildSplitGGUFLayers(ctx, client, opts, rm, modelDir, parallel)
 		if err != nil {
 			return nil, err
 		}
@@ -166,7 +176,7 @@ func Copy(ctx context.Context, opts Options) (*Result, error) {
 		// Existing path: 1 layer per weight file.
 		weightLayers = make([]v1.Layer, len(rm.weights))
 		g, _ := errgroup.WithContext(ctx)
-		g.SetLimit(5) // max 5 concurrent HuggingFace connections
+		g.SetLimit(parallel)
 		var progressMu sync.Mutex
 		for i, w := range rm.weights {
 			i, w := i, w // capture for closure
@@ -239,7 +249,7 @@ func deriveVariantTag(repo string) string {
 // buildSplitGGUFLayers handles the GGUF split path: probes the file header
 // via a range request, plans tensor-boundary splits, and creates one streaming
 // OCI layer per shard.
-func buildSplitGGUFLayers(ctx context.Context, client *hf.Client, opts Options, rm *resolvedModel, modelDir string) ([]v1.Layer, error) {
+func buildSplitGGUFLayers(ctx context.Context, client *hf.Client, opts Options, rm *resolvedModel, modelDir string, parallel int) ([]v1.Layer, error) {
 	w := rm.weights[0]
 
 	// 1. Probe: range-request first 10MB to parse GGUF header.
@@ -304,8 +314,14 @@ func buildSplitGGUFLayers(ctx context.Context, client *hf.Client, opts Options, 
 	basename := strings.TrimSuffix(w.Path, ".gguf")
 	layers := make([]v1.Layer, len(shards))
 	g, _ := errgroup.WithContext(ctx)
-	g.SetLimit(5)
+	g.SetLimit(parallel)
 	var progressMu sync.Mutex
+
+	agg := &aggregateProgress{
+		totalSize:  w.Size,
+		shardCount: len(shards),
+		onProgress: opts.OnShardProgress,
+	}
 
 	for i, shard := range shards {
 		i, shard := i, shard
@@ -335,10 +351,16 @@ func buildSplitGGUFLayers(ctx context.Context, client *hf.Client, opts Options, 
 				bodySize = dlSize
 			}
 
-			// StreamingSplitGGUFLayer takes ownership of body and closes it.
-			// No early returns possible between DownloadRange and here, but
-			// guard defensively in case future code changes add logic.
-			layers[i] = oci.StreamingSplitGGUFLayer(headerBuf.Bytes(), wrapProgress(body, bodySize, opts.OnProgress), bodySize, modelDir, shardFilename)
+			// Wrap with shard-aware progress (aggregate + per-shard),
+			// falling back to the legacy per-layer callback.
+			var wrappedBody io.ReadCloser
+			if opts.OnShardProgress != nil {
+				wrappedBody = agg.wrapShardProgress(body, int64(i+1), bodySize)
+			} else {
+				wrappedBody = wrapProgress(body, bodySize, opts.OnProgress)
+			}
+
+			layers[i] = oci.StreamingSplitGGUFLayer(headerBuf.Bytes(), wrappedBody, bodySize, modelDir, shardFilename)
 			return nil
 		})
 	}
@@ -398,5 +420,61 @@ func (r *progressReader) Read(p []byte) (int, error) {
 }
 
 func (r *progressReader) Close() error {
+	return r.inner.Close()
+}
+
+// aggregateProgress tracks overall transfer progress across all concurrent shards.
+type aggregateProgress struct {
+	mu         sync.Mutex
+	totalSize  int64
+	totalRead  int64
+	shardCount int
+	onProgress func(index, total int, bytesRead, shardSize, overallRead, overallSize int64)
+}
+
+// wrapShardProgress wraps a body with per-shard + aggregate progress reporting.
+func (a *aggregateProgress) wrapShardProgress(body io.ReadCloser, shardIndex, shardSize int64) io.ReadCloser {
+	if a.onProgress == nil {
+		return body
+	}
+	return &shardProgressReader{
+		inner:      body,
+		shardIndex: int(shardIndex),
+		shardSize:  shardSize,
+		shardCount: a.shardCount,
+		agg:        a,
+		interval:   100 << 20, // 100MB
+	}
+}
+
+type shardProgressReader struct {
+	inner      io.ReadCloser
+	shardIndex int
+	shardSize  int64
+	shardCount int
+	shardRead  int64
+	lastReport int64
+	agg        *aggregateProgress
+	interval   int64
+}
+
+func (r *shardProgressReader) Read(p []byte) (int, error) {
+	n, err := r.inner.Read(p)
+	r.shardRead += int64(n)
+
+	r.agg.mu.Lock()
+	r.agg.totalRead += int64(n)
+	overallRead := r.agg.totalRead
+	overallSize := r.agg.totalSize
+	r.agg.mu.Unlock()
+
+	if r.shardRead-r.lastReport >= r.interval || err == io.EOF {
+		r.agg.onProgress(r.shardIndex, r.shardCount, r.shardRead, r.shardSize, overallRead, overallSize)
+		r.lastReport = r.shardRead
+	}
+	return n, err
+}
+
+func (r *shardProgressReader) Close() error {
 	return r.inner.Close()
 }


### PR DESCRIPTION
## Summary
- **`--max-shard-size` 4G→500M**: Splits large GGUFs into ~500MB OCI layers instead of ~4GB. For a 13.5GB model this means ~27 layers vs ~4, giving containerd much more parallelism when pulling on k8s nodes
- **`--max-parallel` flag** (default 100): Replaces hardcoded limit of 5 concurrent layer downloads. Configurable via CLI so the operator can tune it per workload
- **Per-shard progress logging**: Each progress line now identifies the shard and shows aggregate overall progress:
  ```
  Shard 3/27: 100/500 MB | Overall: 1200/13500 MB (9%)
  ```

### Why smaller shards?
containerd pulls OCI layers in parallel (`max-concurrent-downloads`, default 3). With 4GB shards, only 3-4 layers run concurrently. With 500MB shards, the download pipeline stays full — as each finishes, the next starts immediately. Failed layers also only lose 500MB vs 4GB of progress.

## Test plan
- [x] `bazel test //tools/hf2oci/...` — all 6 tests pass
- [ ] CI passes
- [ ] Next model sync job creates ~27 layers and logs per-shard progress

🤖 Generated with [Claude Code](https://claude.com/claude-code)