### PR TITLE
fix: single-manifest OCI index for streaming layer push

### DIFF
--- a/tools/hf2oci/pkg/copy/copy.go
+++ b/tools/hf2oci/pkg/copy/copy.go
@@ -446,7 +446,7 @@ func (a *aggregateProgress) wrapShardProgress(body io.ReadCloser, shardIndex, sh
 		shardSize:  shardSize,
 		shardCount: a.shardCount,
 		agg:        a,
-		interval:   100 << 20, // 100MB
+		interval:   25 << 20, // 25MB — frequent enough for many concurrent shards sharing upload bandwidth
 	}
 }
 

--- a/tools/hf2oci/pkg/copy/copy_test.go
+++ b/tools/hf2oci/pkg/copy/copy_test.go
@@ -83,7 +83,7 @@ func TestCopySafetensors(t *testing.T) {
 	require.NoError(t, err)
 	mf, err := idx.IndexManifest()
 	require.NoError(t, err)
-	assert.Len(t, mf.Manifests, 2, "should have 2 platforms")
+	assert.Len(t, mf.Manifests, 1, "single-manifest index for arch-independent model weights")
 	assert.Equal(t, "TestOrg/TestModel", mf.Annotations["org.huggingface.repo"])
 }
 
@@ -365,22 +365,20 @@ func TestCopyMultipleWeightShards(t *testing.T) {
 		assert.Contains(t, reportedWeights, expected)
 	}
 
-	// Verify pushed index has both platforms with correct layer count.
+	// Verify pushed index has correct layer count.
 	ref, err := name.ParseReference(result.Ref)
 	require.NoError(t, err)
 	idx, err := remote.Index(ref)
 	require.NoError(t, err)
 	mf, err := idx.IndexManifest()
 	require.NoError(t, err)
-	assert.Len(t, mf.Manifests, 2)
+	require.Len(t, mf.Manifests, 1)
 
-	for _, d := range mf.Manifests {
-		img, err := idx.Image(d.Digest)
-		require.NoError(t, err)
-		layers, err := img.Layers()
-		require.NoError(t, err)
-		assert.Len(t, layers, shardCount+1, "expected %d layers (1 config + %d weights)", shardCount+1, shardCount)
-	}
+	img, err := idx.Image(mf.Manifests[0].Digest)
+	require.NoError(t, err)
+	layers, err := img.Layers()
+	require.NoError(t, err)
+	assert.Len(t, layers, shardCount+1, "expected %d layers (1 config + %d weights)", shardCount+1, shardCount)
 }
 
 func TestCopyWithBaseModel(t *testing.T) {
@@ -679,22 +677,20 @@ func TestCopyGGUFSplit(t *testing.T) {
 	assert.Contains(t, reportedWeights, "BigModel-00001-of-00002.gguf")
 	assert.Contains(t, reportedWeights, "BigModel-00002-of-00002.gguf")
 
-	// Verify the pushed index has both platforms with correct layer count.
+	// Verify the pushed index has correct layer count.
 	ref, err := name.ParseReference(result.Ref)
 	require.NoError(t, err)
 	idx, err := remote.Index(ref)
 	require.NoError(t, err)
 	mf, err := idx.IndexManifest()
 	require.NoError(t, err)
-	assert.Len(t, mf.Manifests, 2, "should have 2 platforms")
+	require.Len(t, mf.Manifests, 1)
 
-	for _, d := range mf.Manifests {
-		img, err := idx.Image(d.Digest)
-		require.NoError(t, err)
-		layers, err := img.Layers()
-		require.NoError(t, err)
-		assert.Len(t, layers, 2, "expected 2 layers (2 shard layers, no config)")
-	}
+	img, err := idx.Image(mf.Manifests[0].Digest)
+	require.NoError(t, err)
+	layers, err := img.Layers()
+	require.NoError(t, err)
+	assert.Len(t, layers, 2, "expected 2 layers (2 shard layers, no config)")
 }
 
 func TestCopyGGUFNoSplitWhenSmall(t *testing.T) {
@@ -747,11 +743,10 @@ func TestCopyGGUFNoSplitWhenSmall(t *testing.T) {
 	require.NoError(t, err)
 	mf, err := idx.IndexManifest()
 	require.NoError(t, err)
-	for _, d := range mf.Manifests {
-		img, err := idx.Image(d.Digest)
-		require.NoError(t, err)
-		layers, err := img.Layers()
-		require.NoError(t, err)
-		assert.Len(t, layers, 1, "expected 1 layer for small model")
-	}
+	require.Len(t, mf.Manifests, 1)
+	img, err := idx.Image(mf.Manifests[0].Digest)
+	require.NoError(t, err)
+	layers, err := img.Layers()
+	require.NoError(t, err)
+	assert.Len(t, layers, 1, "expected 1 layer for small model")
 }

--- a/tools/hf2oci/pkg/oci/image.go
+++ b/tools/hf2oci/pkg/oci/image.go
@@ -19,27 +19,22 @@ import (
 // The config layer should contain small metadata files, weight layers contain
 // model weight shards. Annotations are added to the image index manifest.
 func BuildIndex(configLayer v1.Layer, weightLayers []v1.Layer, annotations map[string]string) (v1.ImageIndex, error) {
-	platforms := []v1.Platform{
-		{OS: "linux", Architecture: "amd64"},
-		{OS: "linux", Architecture: "arm64"},
+	img, err := buildImage(configLayer, weightLayers)
+	if err != nil {
+		return nil, fmt.Errorf("building image: %w", err)
 	}
 
-	var adds []mutate.IndexAddendum
-	for _, p := range platforms {
-		img, err := buildImage(configLayer, weightLayers)
-		if err != nil {
-			return nil, fmt.Errorf("building image for %s/%s: %w", p.OS, p.Architecture, err)
-		}
-		plat := p // copy for pointer
-		adds = append(adds, mutate.IndexAddendum{
-			Add: img,
-			Descriptor: v1.Descriptor{
-				Platform: &plat,
-			},
-		})
-	}
-
-	idx := mutate.AppendManifests(empty.Index, adds...)
+	// Single manifest in the index: model weights are architecture-independent
+	// data files, so we don't need per-platform child images. Using a single
+	// child also avoids a go-containerregistry bug where streaming layers
+	// (stream.NewLayer) shared across multiple child images cause
+	// "stream was already consumed" errors during push.
+	idx := mutate.AppendManifests(empty.Index, mutate.IndexAddendum{
+		Add: img,
+		Descriptor: v1.Descriptor{
+			Platform: &v1.Platform{OS: "linux", Architecture: "amd64"},
+		},
+	})
 	idx = mutate.IndexMediaType(idx, types.OCIImageIndex)
 
 	if len(annotations) > 0 {

--- a/tools/hf2oci/pkg/oci/image_test.go
+++ b/tools/hf2oci/pkg/oci/image_test.go
@@ -105,27 +105,21 @@ func TestBuildIndex(t *testing.T) {
 	mf, err := pulledIdx.IndexManifest()
 	require.NoError(t, err)
 
-	// Verify dual-platform index.
-	assert.Len(t, mf.Manifests, 2)
-	platforms := make([]string, len(mf.Manifests))
-	for i, d := range mf.Manifests {
-		platforms[i] = d.Platform.OS + "/" + d.Platform.Architecture
-	}
-	assert.Contains(t, platforms, "linux/amd64")
-	assert.Contains(t, platforms, "linux/arm64")
+	// Single-manifest index (model weights are architecture-independent).
+	require.Len(t, mf.Manifests, 1)
+	assert.Equal(t, "linux", mf.Manifests[0].Platform.OS)
+	assert.Equal(t, "amd64", mf.Manifests[0].Platform.Architecture)
 
 	// Verify annotations.
 	assert.Equal(t, "TestOrg/TestModel", mf.Annotations["org.huggingface.repo"])
 	assert.Equal(t, "abc123", mf.Annotations["org.huggingface.revision"])
 
-	// Verify each platform image has 2 layers (config + weight).
-	for _, d := range mf.Manifests {
-		img, err := pulledIdx.Image(d.Digest)
-		require.NoError(t, err)
-		layers, err := img.Layers()
-		require.NoError(t, err)
-		assert.Len(t, layers, 2, "expected 2 layers for %s", d.Platform)
-	}
+	// Verify image has 2 layers (config + weight).
+	img, err := pulledIdx.Image(mf.Manifests[0].Digest)
+	require.NoError(t, err)
+	layers, err := img.Layers()
+	require.NoError(t, err)
+	assert.Len(t, layers, 2)
 }
 
 func TestBuildIndexNoConfig(t *testing.T) {
@@ -151,14 +145,13 @@ func TestBuildIndexNoConfig(t *testing.T) {
 	mf, err := pulledIdx.IndexManifest()
 	require.NoError(t, err)
 
-	// Each platform image should have 1 layer (weight only).
-	for _, d := range mf.Manifests {
-		img, err := pulledIdx.Image(d.Digest)
-		require.NoError(t, err)
-		layers, err := img.Layers()
-		require.NoError(t, err)
-		assert.Len(t, layers, 1)
-	}
+	// Single image should have 1 layer (weight only).
+	require.Len(t, mf.Manifests, 1)
+	img, err := pulledIdx.Image(mf.Manifests[0].Digest)
+	require.NoError(t, err)
+	layers, err := img.Layers()
+	require.NoError(t, err)
+	assert.Len(t, layers, 1)
 }
 
 // extractTar reads a layer and returns a map of path -> content.

--- a/tools/hf2oci/pkg/oci/push_test.go
+++ b/tools/hf2oci/pkg/oci/push_test.go
@@ -119,5 +119,5 @@ func TestPushAndCheckExists(t *testing.T) {
 	require.NoError(t, err)
 	mf, err := pulledIdx.IndexManifest()
 	require.NoError(t, err)
-	assert.Len(t, mf.Manifests, 2, "should have 2 platform manifests")
+	assert.Len(t, mf.Manifests, 1, "single-manifest index for arch-independent model weights")
 }


### PR DESCRIPTION
## Summary
- Fix `stream was already consumed` error when pushing multi-shard GGUF models to GHCR
- `BuildIndex` previously created two child images (amd64 + arm64) sharing the same `stream.NewLayer` objects — `remote.WriteIndex` consumed the streams for the first image and failed on the second
- Model weights are architecture-independent data files, so a single manifest in the index is correct
- Reduce shard progress reporting interval from 100MB to 25MB for better visibility with many concurrent small shards

## Test plan
- [x] All 6 hf2oci tests pass with updated assertions (single-manifest)
- [ ] Deploy and verify sync job completes without "stream was already consumed" error
- [ ] Verify shard progress logs appear at 25MB intervals

🤖 Generated with [Claude Code](https://claude.com/claude-code)