### PR TITLE
feat: switch to Qwen3-VL-8B-Instruct vision-language model

### DIFF
--- a/overlays/prod/llama-cpp/values.yaml
+++ b/overlays/prod/llama-cpp/values.yaml
@@ -8,7 +8,7 @@ imagePullSecret:
 
 modelVolume:
   enabled: true
-  reference: "hf.co/bartowski/cognitivecomputations_Dolphin-Mistral-24B-Venice-Edition-GGUF:cognitivecomputations_Dolphin-Mistral-24B-Venice-Edition-Q4_0"
+  reference: "hf.co/bartowski/Qwen_Qwen3-VL-8B-Instruct-GGUF:Qwen_Qwen3-VL-8B-Instruct-Q8_0"
   mountPath: "/model-image"
 
 server:
@@ -28,7 +28,7 @@ server:
     - "256"
     - "--metrics"
     - "--alias"
-    - "dolphin-mistral-24b"
+    - "qwen3-vl-8b"
 
 nodeSelector:
   kubernetes.io/hostname: node-4


### PR DESCRIPTION
## Summary
- Switch from Dolphin-Mistral-24B (Q4_0, 13.5GB) to Qwen3-VL-8B-Instruct (Q8_0, 8.7GB)
- Smaller model at higher quantization quality with multimodal vision+text capabilities
- Tests the single-manifest OCI index fix from #484 with a fresh model sync (8.7GB / 500MB shards = ~18 layers)

## Test plan
- [ ] ModelCache sync job completes without errors (validates #484 fix)
- [ ] Shard progress logs show concurrent uploads with 25MB reporting interval
- [ ] llama-server starts and loads model successfully
- [ ] API responds to text completion requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)