### PR TITLE
feat: parallel range downloads for GGUF shard layers

### DIFF
--- a/tools/hf2oci/pkg/copy/copy.go
+++ b/tools/hf2oci/pkg/copy/copy.go
@@ -343,15 +343,10 @@ func buildSplitGGUFLayers(ctx context.Context, client *hf.Client, opts Options, 
 				return fmt.Errorf("building shard %d header: %w", i+1, err)
 			}
 
-			// Range-request this shard's tensor data.
-			bodySize := int64(shard.DataEnd - shard.DataStart + 1)
-			body, dlSize, _, err := client.DownloadRange(ctx, opts.Repo, opts.Revision, w.Path, int64(shard.DataStart), int64(shard.DataEnd))
+			// Range-request this shard's tensor data using parallel connections.
+			body, bodySize, err := client.ParallelDownloadRange(ctx, opts.Repo, opts.Revision, w.Path, int64(shard.DataStart), int64(shard.DataEnd))
 			if err != nil {
 				return fmt.Errorf("downloading shard %d data: %w", i+1, err)
-			}
-			// Prefer server-reported size, fall back to computed size.
-			if dlSize > 0 {
-				bodySize = dlSize
 			}
 
 			// Wrap with shard-aware progress (aggregate + per-shard),

--- a/tools/hf2oci/pkg/hf/parallel.go
+++ b/tools/hf2oci/pkg/hf/parallel.go
@@ -61,13 +61,39 @@ func (c *Client) ParallelDownload(ctx context.Context, repo, revision, path stri
 	numChunks := int((totalSize + chunkSize - 1) / chunkSize)
 
 	pr, pw := io.Pipe()
-	go c.downloadChunks(ctx, pw, repo, revision, path, totalSize, numChunks, chunkSize, workers)
+	go c.downloadChunks(ctx, pw, repo, revision, path, 0, totalSize, numChunks, chunkSize, workers)
 	return pr, totalSize, nil
 }
 
+// ParallelDownloadRange fetches a byte range [start, end] of a file using
+// multiple parallel HTTP Range requests, the same strategy as ParallelDownload
+// but scoped to a sub-range. Falls back to single-connection DownloadRange for
+// ranges below the minimum threshold. The caller must close the returned
+// ReadCloser.
+func (c *Client) ParallelDownloadRange(ctx context.Context, repo, revision, path string, start, end int64) (io.ReadCloser, int64, error) {
+	rangeSize := end - start + 1
+	if rangeSize <= c.getParallelMinFileSize() {
+		body, size, _, err := c.DownloadRange(ctx, repo, revision, path, start, end)
+		if err != nil {
+			return nil, 0, err
+		}
+		return body, size, nil
+	}
+
+	chunkSize := c.getParallelChunkSize()
+	workers := c.getParallelWorkers()
+	numChunks := int((rangeSize + chunkSize - 1) / chunkSize)
+
+	pr, pw := io.Pipe()
+	go c.downloadChunks(ctx, pw, repo, revision, path, start, rangeSize, numChunks, chunkSize, workers)
+	return pr, rangeSize, nil
+}
+
 // downloadChunks dispatches parallel range-request downloads and reassembles
-// the results in order, writing to the pipe.
-func (c *Client) downloadChunks(ctx context.Context, pw *io.PipeWriter, repo, revision, path string, totalSize int64, numChunks int, chunkSize int64, workers int) {
+// the results in order, writing to the pipe. rangeStart is the absolute byte
+// offset within the remote file (0 for full-file downloads); rangeSize is the
+// number of bytes to download from that offset.
+func (c *Client) downloadChunks(ctx context.Context, pw *io.PipeWriter, repo, revision, path string, rangeStart, rangeSize int64, numChunks int, chunkSize int64, workers int) {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
@@ -100,10 +126,10 @@ func (c *Client) downloadChunks(ctx context.Context, pw *io.PipeWriter, repo, re
 				defer wg.Done()
 				defer func() { <-sem }()
 
-				start := int64(idx) * chunkSize
+				start := rangeStart + int64(idx)*chunkSize
 				end := start + chunkSize - 1
-				if end >= totalSize {
-					end = totalSize - 1
+				if end >= rangeStart+rangeSize {
+					end = rangeStart + rangeSize - 1
 				}
 
 				body, _, fallback, err := c.DownloadRange(ctx, repo, revision, path, start, end)

--- a/tools/hf2oci/pkg/hf/parallel_test.go
+++ b/tools/hf2oci/pkg/hf/parallel_test.go
@@ -235,3 +235,106 @@ func TestParallelDownload_UnevenLastChunk(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, bytes.Equal(data, got), "should handle uneven last chunk")
 }
+
+func TestParallelDownloadRange_ReassemblesSubRange(t *testing.T) {
+	// 200KB file, request range [50KB, 150KB).
+	data := make([]byte, 200*1024)
+	rand.Read(data)
+
+	srv := rangeServer(t, data)
+	defer srv.Close()
+
+	c := NewClient(
+		WithBaseURL(srv.URL),
+		WithParallelConfig(10*1024, 0, 4), // 10KB chunks, no min threshold
+	)
+
+	rangeStart := int64(50 * 1024)
+	rangeEnd := int64(150*1024 - 1) // inclusive
+	want := data[rangeStart : rangeEnd+1]
+
+	body, size, err := c.ParallelDownloadRange(context.Background(), "test/repo", "main", "model.bin", rangeStart, rangeEnd)
+	require.NoError(t, err)
+	defer body.Close()
+
+	assert.Equal(t, int64(len(want)), size)
+	got, err := io.ReadAll(body)
+	require.NoError(t, err)
+	assert.True(t, bytes.Equal(want, got), "sub-range data should match original byte-for-byte")
+}
+
+func TestParallelDownloadRange_SmallRangeFallback(t *testing.T) {
+	// Range smaller than minFileSize should fall back to single DownloadRange.
+	data := make([]byte, 100*1024)
+	rand.Read(data)
+
+	var rangeRequests atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "/resolve/") {
+			http.NotFound(w, r)
+			return
+		}
+		rangeHdr := r.Header.Get("Range")
+		if rangeHdr != "" {
+			rangeRequests.Add(1)
+		}
+		var start, end int64
+		fmt.Sscanf(rangeHdr, "bytes=%d-%d", &start, &end)
+		if end >= int64(len(data)) {
+			end = int64(len(data)) - 1
+		}
+		partial := data[start : end+1]
+		w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", start, end, len(data)))
+		w.Header().Set("Content-Length", strconv.Itoa(len(partial)))
+		w.WriteHeader(http.StatusPartialContent)
+		w.Write(partial)
+	}))
+	defer srv.Close()
+
+	// minFileSize=20KB, request a 10KB range → single DownloadRange call.
+	c := NewClient(
+		WithBaseURL(srv.URL),
+		WithParallelConfig(5*1024, 20*1024, 4),
+	)
+
+	rangeStart := int64(10 * 1024)
+	rangeEnd := int64(20*1024 - 1)
+	want := data[rangeStart : rangeEnd+1]
+
+	body, size, err := c.ParallelDownloadRange(context.Background(), "test/repo", "main", "model.bin", rangeStart, rangeEnd)
+	require.NoError(t, err)
+	defer body.Close()
+
+	assert.Equal(t, int64(len(want)), size)
+	got, err := io.ReadAll(body)
+	require.NoError(t, err)
+	assert.True(t, bytes.Equal(want, got))
+	assert.Equal(t, int32(1), rangeRequests.Load(), "small range should use single DownloadRange")
+}
+
+func TestParallelDownloadRange_UnevenLastChunk(t *testing.T) {
+	// 100KB file, range [5KB, 30KB] with 10KB chunks → 10KB, 10KB, 6KB+1.
+	data := make([]byte, 100*1024)
+	rand.Read(data)
+
+	srv := rangeServer(t, data)
+	defer srv.Close()
+
+	c := NewClient(
+		WithBaseURL(srv.URL),
+		WithParallelConfig(10*1024, 0, 4),
+	)
+
+	rangeStart := int64(5 * 1024)
+	rangeEnd := int64(30*1024 + 500) // not aligned to chunk boundary
+	want := data[rangeStart : rangeEnd+1]
+
+	body, size, err := c.ParallelDownloadRange(context.Background(), "test/repo", "main", "model.bin", rangeStart, rangeEnd)
+	require.NoError(t, err)
+	defer body.Close()
+
+	assert.Equal(t, int64(len(want)), size)
+	got, err := io.ReadAll(body)
+	require.NoError(t, err)
+	assert.True(t, bytes.Equal(want, got), "uneven last chunk in sub-range should be handled correctly")
+}


### PR DESCRIPTION
## Summary

- Adds `ParallelDownloadRange` to the HF client — same chunked parallel download strategy as `ParallelDownload` but operating on a byte sub-range of a file
- Refactors `downloadChunks` to accept a `rangeStart` offset parameter so chunks are calculated within an arbitrary range
- Replaces single-connection `DownloadRange` with `ParallelDownloadRange` in `buildSplitGGUFLayers`, giving each GGUF shard 8 concurrent HTTP connections instead of 1

Each shard was bottlenecked by a single TCP connection's bandwidth-delay product (~11 Mbps effective on a 46 Mbps link). With 8 parallel range-request workers per shard, throughput should approach link capacity.

## Test plan

- [x] `bazel test //tools/hf2oci/...` — all 6 targets pass
- [x] New tests: `TestParallelDownloadRange_ReassemblesSubRange`, `SmallRangeFallback`, `UnevenLastChunk`
- [x] Existing `ParallelDownload` tests still pass (verifies `rangeStart=0` backward compatibility)
- [ ] Deploy and monitor sync job for throughput improvement

🤖 Generated with [Claude Code](https://claude.com/claude-code)