### PR TITLE
feat: add syncNodeSelector to pin sync jobs to worker nodes

### DIFF
--- a/operators/oci-model-cache/helm/oci-model-cache-operator/templates/deployment.yaml
+++ b/operators/oci-model-cache/helm/oci-model-cache-operator/templates/deployment.yaml
@@ -70,6 +70,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        {{- with .Values.controllerManager.syncNodeSelector }}
+        - name: SYNC_NODE_SELECTOR
+          value: {{ . | toJson | quote }}
+        {{- end }}
         {{- if .Values.controllerManager.tracing.endpoint }}
         - name: OTEL_EXPORTER_OTLP_ENDPOINT
           value: {{ .Values.controllerManager.tracing.endpoint | quote }}

--- a/operators/oci-model-cache/helm/oci-model-cache-operator/values.yaml
+++ b/operators/oci-model-cache/helm/oci-model-cache-operator/values.yaml
@@ -42,6 +42,10 @@ controllerManager:
     repository: ghcr.io/jomcgi/homelab/tools/hf2oci
     tag: main
 
+  # -- nodeSelector applied to sync Job pods (model download/push).
+  # Use this to pin heavy sync workloads to worker nodes and keep control plane healthy.
+  syncNodeSelector: {}
+
   env:
     ociRegistry: "ghcr.io/jomcgi/models"
     syncServiceAccount: ""

--- a/operators/oci-model-cache/internal/config/config.go
+++ b/operators/oci-model-cache/internal/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"encoding/json"
 	"flag"
 	"os"
 	"time"
@@ -31,6 +32,9 @@ type Config struct {
 
 	// RegistryPushSecret is the name of a Secret containing .dockerconfigjson for pushing to the OCI registry.
 	RegistryPushSecret string
+
+	// SyncNodeSelector is applied to sync Job pods to control which nodes run model downloads.
+	SyncNodeSelector map[string]string
 }
 
 // BindFlags registers config flags on the given FlagSet.
@@ -47,6 +51,9 @@ func (c *Config) BindFlags(fs *flag.FlagSet) {
 	c.HFTokenSecret = envOrDefault("HF_TOKEN_SECRET", "")
 	c.HFTokenSecretKey = envOrDefault("HF_TOKEN_SECRET_KEY", "")
 	c.RegistryPushSecret = envOrDefault("REGISTRY_PUSH_SECRET", "")
+	if v := os.Getenv("SYNC_NODE_SELECTOR"); v != "" {
+		_ = json.Unmarshal([]byte(v), &c.SyncNodeSelector)
+	}
 }
 
 func envOrDefault(key, fallback string) string {

--- a/operators/oci-model-cache/internal/controller/job_builder.go
+++ b/operators/oci-model-cache/internal/controller/job_builder.go
@@ -85,6 +85,10 @@ func buildCopyJob(mc *v1alpha1.ModelCache, cfg config.Config) *batchv1.Job {
 		},
 	}
 
+	if len(cfg.SyncNodeSelector) > 0 {
+		job.Spec.Template.Spec.NodeSelector = cfg.SyncNodeSelector
+	}
+
 	if cfg.SyncServiceAccount != "" {
 		job.Spec.Template.Spec.ServiceAccountName = cfg.SyncServiceAccount
 	}

--- a/overlays/dev/oci-model-cache/values.yaml
+++ b/overlays/dev/oci-model-cache/values.yaml
@@ -13,6 +13,8 @@ controllerManager:
   copyImage:
     repository: ghcr.io/jomcgi/homelab/tools/hf2oci
     tag: main
+  syncNodeSelector:
+    kubernetes.io/hostname: node-4
   env:
     ociRegistry: "ghcr.io/jomcgi/models"
 registryPushSecret: "oci-model-cache-operator-hf-token"


### PR DESCRIPTION
## Summary

- Adds `controllerManager.syncNodeSelector` Helm value, passed as `SYNC_NODE_SELECTOR` JSON env var to the operator
- Operator parses the JSON into `config.SyncNodeSelector` and applies it to sync Job pod specs
- Dev overlay pins sync jobs to `node-4` (64GB RAM worker) to keep control plane nodes healthy

## Context

PR #489 added parallel range downloads for GGUF shards (10 shards x 8 workers = 80 concurrent connections). Testing revealed this saturates memory on the 15GB control plane nodes, causing API server timeouts and Cloudflare Tunnel 1033 errors. Node-4 has 64GB RAM and is the natural home for these workloads.

## Test plan

- [x] `bazel test //operators/oci-model-cache/...` — all 5 targets pass (including Helm lint)
- [x] `helm template` renders `SYNC_NODE_SELECTOR` as `{"kubernetes.io/hostname":"node-4"}`
- [ ] After merge, verify sync jobs land on node-4: `kubectl get pods -n oci-model-cache -o wide`

🤖 Generated with [Claude Code](https://claude.com/claude-code)