### PR TITLE
feat: add memory resources and GOMEMLIMIT to sync Job pods

### DIFF
--- a/operators/oci-model-cache/helm/oci-model-cache-operator/templates/deployment.yaml
+++ b/operators/oci-model-cache/helm/oci-model-cache-operator/templates/deployment.yaml
@@ -74,6 +74,14 @@ spec:
         - name: SYNC_NODE_SELECTOR
           value: {{ . | toJson | quote }}
         {{- end }}
+        {{- with .Values.controllerManager.syncMemoryRequest }}
+        - name: SYNC_MEMORY_REQUEST
+          value: {{ . | quote }}
+        {{- end }}
+        {{- with .Values.controllerManager.syncMemoryLimit }}
+        - name: SYNC_MEMORY_LIMIT
+          value: {{ . | quote }}
+        {{- end }}
         {{- if .Values.controllerManager.tracing.endpoint }}
         - name: OTEL_EXPORTER_OTLP_ENDPOINT
           value: {{ .Values.controllerManager.tracing.endpoint | quote }}

--- a/operators/oci-model-cache/helm/oci-model-cache-operator/values.yaml
+++ b/operators/oci-model-cache/helm/oci-model-cache-operator/values.yaml
@@ -46,6 +46,12 @@ controllerManager:
   # Use this to pin heavy sync workloads to worker nodes and keep control plane healthy.
   syncNodeSelector: {}
 
+  # -- Memory request/limit for sync Job containers.
+  # When syncMemoryLimit is set, GOMEMLIMIT is automatically configured to 80% of the
+  # limit so the Go GC applies back-pressure before the kubelet OOMKills.
+  syncMemoryRequest: ""
+  syncMemoryLimit: ""
+
   env:
     ociRegistry: "ghcr.io/jomcgi/models"
     syncServiceAccount: ""

--- a/operators/oci-model-cache/internal/config/config.go
+++ b/operators/oci-model-cache/internal/config/config.go
@@ -35,6 +35,12 @@ type Config struct {
 
 	// SyncNodeSelector is applied to sync Job pods to control which nodes run model downloads.
 	SyncNodeSelector map[string]string
+
+	// SyncMemoryRequest is the Kubernetes memory request for sync Job containers (e.g. "1Gi").
+	SyncMemoryRequest string
+
+	// SyncMemoryLimit is the Kubernetes memory limit for sync Job containers (e.g. "2Gi").
+	SyncMemoryLimit string
 }
 
 // BindFlags registers config flags on the given FlagSet.
@@ -54,6 +60,8 @@ func (c *Config) BindFlags(fs *flag.FlagSet) {
 	if v := os.Getenv("SYNC_NODE_SELECTOR"); v != "" {
 		_ = json.Unmarshal([]byte(v), &c.SyncNodeSelector)
 	}
+	c.SyncMemoryRequest = envOrDefault("SYNC_MEMORY_REQUEST", "")
+	c.SyncMemoryLimit = envOrDefault("SYNC_MEMORY_LIMIT", "")
 }
 
 func envOrDefault(key, fallback string) string {

--- a/operators/oci-model-cache/internal/controller/BUILD
+++ b/operators/oci-model-cache/internal/controller/BUILD
@@ -20,6 +20,7 @@ go_library(
         "@io_k8s_api//batch/v1:batch",
         "@io_k8s_api//core/v1:core",
         "@io_k8s_apimachinery//pkg/api/errors",
+        "@io_k8s_apimachinery//pkg/api/resource",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:meta",
         "@io_k8s_apimachinery//pkg/runtime",
         "@io_k8s_sigs_controller_runtime//:controller-runtime",

--- a/operators/oci-model-cache/internal/controller/job_builder.go
+++ b/operators/oci-model-cache/internal/controller/job_builder.go
@@ -1,8 +1,11 @@
 package controller
 
 import (
+	"fmt"
+
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 
@@ -87,6 +90,29 @@ func buildCopyJob(mc *v1alpha1.ModelCache, cfg config.Config) *batchv1.Job {
 
 	if len(cfg.SyncNodeSelector) > 0 {
 		job.Spec.Template.Spec.NodeSelector = cfg.SyncNodeSelector
+	}
+
+	if cfg.SyncMemoryRequest != "" || cfg.SyncMemoryLimit != "" {
+		resources := corev1.ResourceRequirements{}
+		if cfg.SyncMemoryRequest != "" {
+			resources.Requests = corev1.ResourceList{
+				corev1.ResourceMemory: resource.MustParse(cfg.SyncMemoryRequest),
+			}
+		}
+		if cfg.SyncMemoryLimit != "" {
+			memLimit := resource.MustParse(cfg.SyncMemoryLimit)
+			resources.Limits = corev1.ResourceList{
+				corev1.ResourceMemory: memLimit,
+			}
+			// Set GOMEMLIMIT to 80% of the memory limit so the Go GC applies
+			// back-pressure before the kubelet OOMKills the container.
+			goMemLimit := memLimit.Value() * 4 / 5
+			job.Spec.Template.Spec.Containers[0].Env = append(
+				job.Spec.Template.Spec.Containers[0].Env,
+				corev1.EnvVar{Name: "GOMEMLIMIT", Value: fmt.Sprintf("%dB", goMemLimit)},
+			)
+		}
+		job.Spec.Template.Spec.Containers[0].Resources = resources
 	}
 
 	if cfg.SyncServiceAccount != "" {

--- a/overlays/dev/oci-model-cache/values.yaml
+++ b/overlays/dev/oci-model-cache/values.yaml
@@ -15,6 +15,8 @@ controllerManager:
     tag: main
   syncNodeSelector:
     kubernetes.io/hostname: node-4
+  syncMemoryRequest: "1Gi"
+  syncMemoryLimit: "2Gi"
   env:
     ociRegistry: "ghcr.io/jomcgi/models"
 registryPushSecret: "oci-model-cache-operator-hf-token"


### PR DESCRIPTION
## Summary
- Adds `syncMemoryRequest` and `syncMemoryLimit` Helm values to configure Kubernetes resource requests/limits on sync Job containers
- When a memory limit is set, automatically injects `GOMEMLIMIT` env var at 80% of the limit — this makes Go's GC more aggressive as the heap approaches the cap, providing graceful back-pressure instead of abrupt OOMKill
- Dev overlay sets 1Gi request / 2Gi limit (→ ~1.7GB GOMEMLIMIT)

## Context
Sync Jobs running parallel range downloads consumed unbounded memory, starving the API server on the 15GB control plane node. Combined with the nodeSelector from #492 (which pins sync Jobs to the 64GB worker node-4), this ensures sync workloads are both isolated and resource-bounded.

## Changes
| File | Change |
|------|--------|
| `config.go` | New `SyncMemoryRequest` / `SyncMemoryLimit` fields from env vars |
| `job_builder.go` | Apply resources to Job containers + compute GOMEMLIMIT at 80% of limit |
| `values.yaml` | New Helm values with documentation |
| `deployment.yaml` | Pass env vars to operator pod |
| `overlays/dev/values.yaml` | Set 1Gi request, 2Gi limit |
| `BUILD` | Gazelle-added `@io_k8s_apimachinery//pkg/api/resource` dep |

## Test plan
- [x] `bazel test //operators/oci-model-cache/...` — 5/5 pass
- [ ] Deploy and verify sync Job pod spec has correct resources and GOMEMLIMIT
- [ ] Confirm sync Job stays within memory limit during parallel downloads

🤖 Generated with [Claude Code](https://claude.com/claude-code)