### PR TITLE
feat: switch llama-cpp to Dolphin Mistral 24B Venice Edition

### DIFF
--- a/overlays/prod/llama-cpp/values.yaml
+++ b/overlays/prod/llama-cpp/values.yaml
@@ -8,7 +8,7 @@ imagePullSecret:
 
 modelVolume:
   enabled: true
-  reference: "hf.co/bartowski/Qwen_Qwen3-VL-8B-Instruct-GGUF:Qwen_Qwen3-VL-8B-Instruct-Q8_0"
+  reference: "ghcr.io/jomcgi/models/dphn/dolphin-mistral-24b-venice-edition:bartowski-gguf-cognitivecomputations-dolphin-mistral-24b-venice-edition-q4-0"
   mountPath: "/model-image"
 
 server:
@@ -28,7 +28,7 @@ server:
     - "256"
     - "--metrics"
     - "--alias"
-    - "qwen3-vl-8b"
+    - "dolphin-mistral-24b"
 
 nodeSelector:
   kubernetes.io/hostname: node-4

--- a/overlays/prod/openclaw-friends/values.yaml
+++ b/overlays/prod/openclaw-friends/values.yaml
@@ -1,5 +1,5 @@
 ## OpenClaw Friends Instance - Production Values
-## Group chat AI assistant with local Hermes via llama.cpp + Discord
+## Group chat AI assistant with local Dolphin Mistral via llama.cpp + Discord
 
 fullnameOverride: "openclaw-friends"
 
@@ -7,10 +7,10 @@ fullnameOverride: "openclaw-friends"
 podAnnotations:
   linkerd.io/inject: disabled
 
-## LLM: Local Hermes via llama.cpp
+## LLM: Local Dolphin Mistral via llama.cpp
 llm:
   provider: "openai-compatible"
-  model: "hermes-4.3-36b"
+  model: "dolphin-mistral-24b"
   baseUrl: "http://llama-cpp.llama-cpp.svc.cluster.local:8080/v1"
 
 ## No Anthropic auth needed


### PR DESCRIPTION
## Summary
- Swap llama-cpp model from Qwen3-VL-8B (hf.co) to Dolphin Mistral 24B Venice Edition Q4_0 (GHCR mirror)
- Update openclaw-friends model reference and comments to match new model alias

## Details
- **Model**: `ghcr.io/jomcgi/models/dphn/dolphin-mistral-24b-venice-edition:bartowski-gguf-cognitivecomputations-dolphin-mistral-24b-venice-edition-q4-0`
- **Size**: ~14GB Q4_0 quantization, fits within RTX 4090 24GB VRAM
- **Alias**: `dolphin-mistral-24b`

## Post-merge follow-up
After ArgoCD syncs, the openclaw-friends runtime config (`openclaw.json` and `models.json` on the PVC) will need updating to reference `dolphin-mistral-24b` instead of `hermes-4-14b`. This can be done via the OpenClaw UI or `kubectl exec`.

## Test plan
- [ ] Verify llama-cpp pod starts and loads the Dolphin GGUF from the OCI image volume
- [ ] Verify openclaw-friends can reach the new model via `/v1/chat/completions`
- [ ] Test a Discord message to confirm end-to-end flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)