### PR TITLE
fix: add ChatML chat template with tool role support for Dolphin

### DIFF
--- a/overlays/prod/llama-cpp/values.yaml
+++ b/overlays/prod/llama-cpp/values.yaml
@@ -19,6 +19,35 @@ server:
   cacheTypeV: "f16"
   threads: 8
   jinja: true
+  ## Override Dolphin's built-in chat template to add tool role support.
+  ## Without this, tool call results from openclaw cause a Jinja exception
+  ## because the GGUF template only accepts user/system/assistant roles.
+  chatTemplate: |
+    {%- for message in messages %}
+    {%- if message.role == 'tool' %}
+    <|im_start|>tool
+    {{ message.content }}
+    <|im_end|>
+    {%- elif message.role == 'tool_calls' or message.tool_calls is defined %}
+    <|im_start|>assistant
+    {%- if message.content %}
+    {{ message.content }}
+    {%- endif %}
+    {%- for tool_call in (message.tool_calls or []) %}
+    <tool_call>
+    {"name": "{{ tool_call.function.name }}", "arguments": {{ tool_call.function.arguments }}}
+    </tool_call>
+    {%- endfor %}
+    <|im_end|>
+    {%- else %}
+    <|im_start|>{{ message.role }}
+    {{ message.content }}
+    <|im_end|>
+    {%- endif %}
+    {%- endfor %}
+    {%- if add_generation_prompt %}
+    <|im_start|>assistant
+    {%- endif %}
   extraArgs:
     - "--parallel"
     - "1"


### PR DESCRIPTION
## Summary
- Add custom ChatML Jinja chat template that handles `tool` and `tool_calls` message roles
- Fixes `500 Jinja Exception: Only user, system and assistant roles are supported!` when openclaw uses web search via Discord

## Context
The Dolphin Mistral 24B GGUF's built-in chat template explicitly rejects any role that isn't `user`, `system`, or `assistant`. When openclaw sends tool call results (e.g. web search) back to the model, they use the `tool` role per the OpenAI API format, which triggers the exception.

The llama-cpp chart already supports `server.chatTemplate` — this creates a ConfigMap mounted as `--chat-template-file`, which overrides the GGUF's built-in template.

## Test plan
- [ ] Verify llama-cpp pod starts with the new ConfigMap mounted
- [ ] Send a Discord message to claw-friends that triggers web search
- [ ] Confirm no more Jinja 500 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)