### PR TITLE
feat: add priority classes, resources & HA for critical infrastructure

### DIFF
--- a/charts/cloudflare-tunnel/templates/deployment.yaml
+++ b/charts/cloudflare-tunnel/templates/deployment.yaml
@@ -20,6 +20,9 @@ spec:
       labels:
         {{- include "cloudflare-tunnel.selectorLabels" . | nindent 8 }}
     spec:
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
       {{- with .Values.podSecurityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}
@@ -181,6 +184,10 @@ spec:
         emptyDir:
           medium: Memory
           sizeLimit: 64Mi
+      {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/charts/cloudflare-tunnel/values.yaml
+++ b/charts/cloudflare-tunnel/values.yaml
@@ -44,6 +44,10 @@ service:
 
 resources: {}
 
+priorityClassName: ""
+
+topologySpreadConstraints: []
+
 nodeSelector: {}
 
 tolerations: []

--- a/clusters/homelab/argocd/values.yaml
+++ b/clusters/homelab/argocd/values.yaml
@@ -3,6 +3,8 @@ argo-cd:
     # Enable Prometheus scrape annotations on all ArgoCD metrics services
     # This allows the SigNoz OTel collector to discover and scrape ArgoCD metrics
     addPrometheusAnnotations: true
+    # Ensure ArgoCD pods survive resource pressure from workload evictions
+    priorityClassName: system-cluster-critical
   configs:
     params:
       # Run server in insecure mode (behind Cloudflare Tunnel HTTPS termination)
@@ -12,32 +14,99 @@ argo-cd:
   # These expose Prometheus metrics including argocd_app_info for health/sync status
   # Pod annotations enable SigNoz autodiscovery (scraper uses role: pod)
   controller:
+    resources:
+      requests:
+        cpu: 50m
+        memory: 256Mi
+      limits:
+        cpu: 250m
+        memory: 512Mi
     metrics:
       enabled: true
     podAnnotations:
       prometheus.io/scrape: "true"
       prometheus.io/port: "8082"
   server:
+    replicas: 2
+    resources:
+      requests:
+        cpu: 25m
+        memory: 64Mi
+      limits:
+        cpu: 125m
+        memory: 256Mi
+    topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/component: server
     metrics:
       enabled: true
     podAnnotations:
       prometheus.io/scrape: "true"
       prometheus.io/port: "8083"
   repoServer:
+    replicas: 2
+    resources:
+      requests:
+        cpu: 25m
+        memory: 128Mi
+      limits:
+        cpu: 125m
+        memory: 512Mi
+    topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/component: repo-server
     metrics:
       enabled: true
     podAnnotations:
       prometheus.io/scrape: "true"
       prometheus.io/port: "8084"
+  redis:
+    resources:
+      requests:
+        cpu: 15m
+        memory: 32Mi
+      limits:
+        cpu: 100m
+        memory: 128Mi
   applicationSet:
+    resources:
+      requests:
+        cpu: 15m
+        memory: 64Mi
+      limits:
+        cpu: 100m
+        memory: 256Mi
     metrics:
       enabled: true
     podAnnotations:
       prometheus.io/scrape: "true"
       prometheus.io/port: "8080"
   notifications:
+    resources:
+      requests:
+        cpu: 10m
+        memory: 32Mi
+      limits:
+        cpu: 50m
+        memory: 128Mi
     metrics:
       enabled: true
     podAnnotations:
       prometheus.io/scrape: "true"
       prometheus.io/port: "9001"
+  dex:
+    resources:
+      requests:
+        cpu: 10m
+        memory: 32Mi
+      limits:
+        cpu: 50m
+        memory: 128Mi

--- a/overlays/cluster-critical/cert-manager/values.yaml
+++ b/overlays/cluster-critical/cert-manager/values.yaml
@@ -1,8 +1,42 @@
 # Cluster-specific cert-manager overrides for homelab
 
 cert-manager:
-  # Lower resource requests for homelab
+  global:
+    priorityClassName: system-cluster-critical
+
+  # Controller (main cert-manager pod)
   resources:
     requests:
-      cpu: 5m
-      memory: 24Mi
+      cpu: 10m
+      memory: 32Mi
+    limits:
+      cpu: 100m
+      memory: 128Mi
+
+  # Webhook — scales to 2 for HA (on the API server critical path)
+  webhook:
+    replicaCount: 2
+    resources:
+      requests:
+        cpu: 10m
+        memory: 24Mi
+      limits:
+        cpu: 50m
+        memory: 64Mi
+    topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/component: webhook
+
+  # CA injector
+  cainjector:
+    resources:
+      requests:
+        cpu: 10m
+        memory: 32Mi
+      limits:
+        cpu: 100m
+        memory: 128Mi

--- a/overlays/cluster-critical/kyverno/values.yaml
+++ b/overlays/cluster-critical/kyverno/values.yaml
@@ -3,7 +3,8 @@
 
 # Admission controller configuration
 admissionController:
-  replicas: 1
+  replicas: 2
+  priorityClassName: system-cluster-critical
 
   # Resource limits
   resources:
@@ -13,6 +14,15 @@ admissionController:
     requests:
       cpu: 100m
       memory: 256Mi
+
+  # Spread admission webhook pods across nodes for HA
+  topologySpreadConstraints:
+    - maxSkew: 1
+      topologyKey: kubernetes.io/hostname
+      whenUnsatisfiable: ScheduleAnyway
+      labelSelector:
+        matchLabels:
+          app.kubernetes.io/component: admission-controller
 
   # Security context
   securityContext:
@@ -29,6 +39,7 @@ admissionController:
 backgroundController:
   enabled: true
   replicas: 1
+  priorityClassName: system-cluster-critical
 
   resources:
     limits:
@@ -42,6 +53,7 @@ backgroundController:
 cleanupController:
   enabled: true
   replicas: 1
+  priorityClassName: system-cluster-critical
 
   resources:
     limits:
@@ -55,6 +67,7 @@ cleanupController:
 reportsController:
   enabled: true
   replicas: 1
+  priorityClassName: system-cluster-critical
 
   resources:
     limits:

--- a/overlays/cluster-critical/linkerd/values.yaml
+++ b/overlays/cluster-critical/linkerd/values.yaml
@@ -2,6 +2,11 @@
 # This file contains environment-specific values for the homelab cluster
 
 linkerd-control-plane:
+  # Ensure Linkerd control plane survives resource pressure
+  priorityClassName: system-cluster-critical
+  # Spread control plane pods across nodes for HA
+  enablePodAntiAffinity: true
+
   proxy:
     # Reduce log noise from connection-closed INFO messages
     # Default is "warn,linkerd=info,hickory=error" which logs benign

--- a/overlays/prod/cloudflare-tunnel/values.yaml
+++ b/overlays/prod/cloudflare-tunnel/values.yaml
@@ -45,6 +45,27 @@ ingress:
         keepAliveTimeout: 90s
         tcpKeepAlive: 30s
 
+# Ensure tunnel pods survive resource pressure from workload evictions
+priorityClassName: system-cluster-critical
+
+# Spread tunnel replicas across nodes for HA
+topologySpreadConstraints:
+  - maxSkew: 1
+    topologyKey: kubernetes.io/hostname
+    whenUnsatisfiable: ScheduleAnyway
+    labelSelector:
+      matchLabels:
+        app.kubernetes.io/name: cloudflare-tunnel
+
+# Cloudflared container resources
+resources:
+  requests:
+    cpu: 25m
+    memory: 64Mi
+  limits:
+    cpu: 250m
+    memory: 256Mi
+
 # Enable Envoy proxy sidecar with tracing to SigNoz
 envoy:
   enabled: true


### PR DESCRIPTION
## Summary

- Add `system-cluster-critical` priority class to **ArgoCD, Kyverno, cert-manager, Linkerd, and Cloudflare Tunnel** so infrastructure pods survive resource pressure (e.g., model sync downloads causing evictions)
- Scale HA-critical webhooks/servers to **2 replicas** with topology spread constraints: ArgoCD server + repoServer, Kyverno admissionController, cert-manager webhook
- Add **resource requests/limits** to all ArgoCD components, cert-manager controller/webhook/cainjector, and Cloudflare Tunnel cloudflared container
- Enable **pod anti-affinity** for Linkerd control plane and add **topology spread** template support to the Cloudflare Tunnel Helm chart

### Services hardened

| Service | Priority Class | Replicas Scaled | Topology Spread | Resources Added |
|---|---|---|---|---|
| ArgoCD (all components) | global | server: 2, repoServer: 2 | server, repoServer | All 7 components |
| Kyverno (4 controllers) | per-controller | admissionController: 1→2 | admissionController | Already set |
| cert-manager | global | webhook: 1→2 | webhook | controller, webhook, cainjector |
| Linkerd | control-plane | Already 2 | enablePodAntiAffinity | Already set |
| Cloudflare Tunnel | prod overlay | Already 2 | hostname spread | cloudflared |

### Out of scope
- **CoreDNS & metrics-server** — K3s static manifests, already have priority classes + resources
- **Traefik** — unused (all traffic via Cloudflare Tunnel), future cleanup candidate

### Resource budget
Total new memory requests: ~700Mi (< 5% of 15GB node capacity)

## Test plan

- [ ] Helm lint passes for cloudflare-tunnel chart (verified locally)
- [ ] BuildBuddy CI passes (format check + bazel test)
- [ ] After merge + ArgoCD sync, verify `priorityClassName` applied: `kubectl get pods -A -o jsonpath='{range .items[?(@.spec.priorityClassName=="system-cluster-critical")]}{.metadata.namespace}/{.metadata.name}{"\n"}{end}'`
- [ ] Verify replica counts: `kubectl get deploy -n argocd`, `kubectl get deploy -n kyverno`, `kubectl get deploy -n cert-manager`
- [ ] `kubectl top nodes` — confirm no significant memory pressure increase

🤖 Generated with [Claude Code](https://claude.com/claude-code)