### PR TITLE
feat: switch to Dolphin 3.0 Llama 3.1 8B, drop custom chat template

### DIFF
--- a/overlays/prod/llama-cpp/values.yaml
+++ b/overlays/prod/llama-cpp/values.yaml
@@ -8,7 +8,7 @@ imagePullSecret:
 
 modelVolume:
   enabled: true
-  reference: "ghcr.io/jomcgi/models/dphn/dolphin-mistral-24b-venice-edition:bartowski-gguf-cognitivecomputations-dolphin-mistral-24b-venice-edition-q4-0"
+  reference: "hf.co/bartowski/Dolphin3.0-Llama3.1-8B-GGUF:Dolphin3.0-Llama3.1-8B-Q8_0"
   mountPath: "/model-image"
 
 server:
@@ -19,35 +19,6 @@ server:
   cacheTypeV: "f16"
   threads: 8
   jinja: true
-  ## Override Dolphin's built-in chat template to add tool role support.
-  ## Without this, tool call results from openclaw cause a Jinja exception
-  ## because the GGUF template only accepts user/system/assistant roles.
-  chatTemplate: |
-    {%- for message in messages %}
-    {%- if message.role == 'tool' %}
-    <|im_start|>tool
-    {{ message.content }}
-    <|im_end|>
-    {%- elif message.role == 'tool_calls' or message.tool_calls is defined %}
-    <|im_start|>assistant
-    {%- if message.content %}
-    {{ message.content }}
-    {%- endif %}
-    {%- for tool_call in (message.tool_calls or []) %}
-    <tool_call>
-    {"name": "{{ tool_call.function.name }}", "arguments": {{ tool_call.function.arguments }}}
-    </tool_call>
-    {%- endfor %}
-    <|im_end|>
-    {%- else %}
-    <|im_start|>{{ message.role }}
-    {{ message.content }}
-    <|im_end|>
-    {%- endif %}
-    {%- endfor %}
-    {%- if add_generation_prompt %}
-    <|im_start|>assistant
-    {%- endif %}
   extraArgs:
     - "--parallel"
     - "1"
@@ -57,7 +28,7 @@ server:
     - "256"
     - "--metrics"
     - "--alias"
-    - "dolphin-mistral-24b"
+    - "dolphin3-llama3.1-8b"
 
 nodeSelector:
   kubernetes.io/hostname: node-4

--- a/overlays/prod/openclaw-friends/values.yaml
+++ b/overlays/prod/openclaw-friends/values.yaml
@@ -1,5 +1,5 @@
 ## OpenClaw Friends Instance - Production Values
-## Group chat AI assistant with local Dolphin Mistral via llama.cpp + Discord
+## Group chat AI assistant with local Dolphin 3.0 via llama.cpp + Discord
 
 fullnameOverride: "openclaw-friends"
 
@@ -7,10 +7,10 @@ fullnameOverride: "openclaw-friends"
 podAnnotations:
   linkerd.io/inject: disabled
 
-## LLM: Local Dolphin Mistral via llama.cpp
+## LLM: Local Dolphin 3.0 (Llama 3.1 8B) via llama.cpp
 llm:
   provider: "openai-compatible"
-  model: "dolphin-mistral-24b"
+  model: "dolphin3-llama3.1-8b"
   baseUrl: "http://llama-cpp.llama-cpp.svc.cluster.local:8080/v1"
 
 ## No Anthropic auth needed


### PR DESCRIPTION
## Summary
- Switch model from Dolphin Mistral 24B (Q4_0, 14GB) to Dolphin 3.0 Llama 3.1 8B (Q8_0, 8.5GB)
- Remove custom ChatML chat template — Dolphin 3.0's built-in template handles all roles
- Update openclaw-friends model reference to match new alias

## Context
Dolphin 3.0's chat template uses a generic ChatML passthrough (`message['role']` directly in the output) instead of an explicit allowlist, so `tool` role messages from openclaw render correctly without a custom override.

## Test plan
- [ ] Verify llama-cpp loads the new model from `hf.co/bartowski/Dolphin3.0-Llama3.1-8B-GGUF`
- [ ] Test openclaw-friends Discord messages including web search

🤖 Generated with [Claude Code](https://claude.com/claude-code)