### PR TITLE
fix: use full OCI tag for Hermes 4 14B GGUF

### DIFF
--- a/overlays/prod/llama-cpp/values.yaml
+++ b/overlays/prod/llama-cpp/values.yaml
@@ -8,7 +8,7 @@ imagePullSecret:
 
 modelVolume:
   enabled: true
-  reference: "hf.co/bartowski/NousResearch_Hermes-4-14B-GGUF:Q6_K"
+  reference: "hf.co/bartowski/NousResearch_Hermes-4-14B-GGUF:NousResearch_Hermes-4-14B-Q6_K"
   mountPath: "/model-image"
 
 server:


### PR DESCRIPTION
## Summary
- Fix OCI image tag from `:Q6_K` to `:NousResearch_Hermes-4-14B-Q6_K`

## Context
HuggingFace GGUF OCI tags use the full filename (minus `.gguf`), not just the quantization suffix. The short tag caused `GGUF file selector matched no files in repo`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)