### PR TITLE
feat: auto-tune hf2oci parallelism from GOMEMLIMIT

### DIFF
--- a/overlays/dev/oci-model-cache/values.yaml
+++ b/overlays/dev/oci-model-cache/values.yaml
@@ -15,8 +15,8 @@ controllerManager:
     tag: main
   syncNodeSelector:
     kubernetes.io/hostname: node-4
-  syncMemoryRequest: "1Gi"
-  syncMemoryLimit: "2Gi"
+  syncMemoryRequest: "2Gi"
+  syncMemoryLimit: "4Gi"
   env:
     ociRegistry: "ghcr.io/jomcgi/models"
 registryPushSecret: "oci-model-cache-operator-hf-token"

--- a/tools/hf2oci/cmd/hf2oci/cmd/copy.go
+++ b/tools/hf2oci/cmd/hf2oci/cmd/copy.go
@@ -61,7 +61,7 @@ func init() {
 	copyCmd.Flags().StringVar(&copyModelDir, "model-dir", "", "In-image model path (default: /)")
 	copyCmd.Flags().StringVar(&copyFile, "file", "", "GGUF filename prefix selector (e.g. ModelName-Q4_K_M)")
 	copyCmd.Flags().StringVar(&copyMaxShardSize, "max-shard-size", "500M", "Max size per GGUF shard layer (e.g. 4G, 500M). 0 disables splitting.")
-	copyCmd.Flags().IntVar(&copyMaxParallel, "max-parallel", 100, "Max concurrent layer uploads/downloads")
+	copyCmd.Flags().IntVar(&copyMaxParallel, "max-parallel", 0, "Max concurrent layer uploads/downloads (0 = auto from GOMEMLIMIT, fallback 100)")
 	copyCmd.Flags().BoolVar(&copyDryRun, "dry-run", false, "List files without downloading or pushing")
 
 	copyCmd.MarkFlagRequired("registry")
@@ -85,6 +85,16 @@ func runCopy(cmd *cobra.Command, args []string) error {
 	}
 	client := hf.NewClient(clientOpts...)
 
+	parallel := copyMaxParallel
+	if parallel <= 0 {
+		if n := copy.AutoParallel(); n > 0 {
+			parallel = n
+			fmt.Fprintf(os.Stderr, "Auto-tuned parallelism: %d (from GOMEMLIMIT)\n", parallel)
+		} else {
+			parallel = 100
+		}
+	}
+
 	opts := copy.Options{
 		Repo:         repo,
 		Registry:     copyRegistry,
@@ -93,7 +103,7 @@ func runCopy(cmd *cobra.Command, args []string) error {
 		ModelDir:     copyModelDir,
 		File:         copyFile,
 		MaxShardSize: maxShard,
-		MaxParallel:  copyMaxParallel,
+		MaxParallel:  parallel,
 		DryRun:       copyDryRun,
 		HFClient:     client,
 	}

--- a/tools/hf2oci/pkg/copy/copy.go
+++ b/tools/hf2oci/pkg/copy/copy.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"math"
+	"runtime/debug"
 	"strings"
 	"sync"
 
@@ -17,6 +19,33 @@ import (
 	"github.com/jomcgi/homelab/tools/hf2oci/pkg/oci"
 	"github.com/jomcgi/homelab/tools/hf2oci/pkg/ociref"
 )
+
+const (
+	// estimatedMemPerStream is a conservative estimate of peak memory per
+	// concurrent shard stream: parallel download workers (8 × 10 MB chunks
+	// buffered in the pending map) + 4 MB tar I/O buffer + GGUF shard header.
+	estimatedMemPerStream = 100 << 20 // 100 MB
+)
+
+// AutoParallel calculates a safe concurrency limit from the process's
+// GOMEMLIMIT. Returns 0 when no memory limit is configured, signalling
+// the caller to fall back to a static default.
+func AutoParallel() int {
+	// SetMemoryLimit(-1) returns the current soft limit without changing it.
+	// When GOMEMLIMIT is unset the runtime returns math.MaxInt64.
+	limit := debug.SetMemoryLimit(-1)
+	if limit == math.MaxInt64 || limit <= 0 {
+		return 0
+	}
+	// Reserve 20% of the budget for GC overhead, runtime stacks, and
+	// non-streaming allocations (config downloads, OCI manifest building, …).
+	budget := limit * 4 / 5
+	n := int(budget / estimatedMemPerStream)
+	if n < 1 {
+		return 1
+	}
+	return n
+}
 
 // Options configures the copy operation.
 type Options struct {
@@ -163,7 +192,11 @@ func Copy(ctx context.Context, opts Options) (*Result, error) {
 
 	parallel := opts.MaxParallel
 	if parallel <= 0 {
-		parallel = 100
+		if n := AutoParallel(); n > 0 {
+			parallel = n
+		} else {
+			parallel = 100
+		}
 	}
 
 	if rm.format == FormatGGUF && len(rm.weights) == 1 && opts.MaxShardSize > 0 && rm.weights[0].Size > opts.MaxShardSize {

--- a/tools/hf2oci/pkg/copy/copy_test.go
+++ b/tools/hf2oci/pkg/copy/copy_test.go
@@ -6,8 +6,10 @@ import (
 	"encoding/binary"
 	"encoding/json"
 	"fmt"
+	"math"
 	"net/http"
 	"net/http/httptest"
+	"runtime/debug"
 	"strconv"
 	"strings"
 	"sync"
@@ -749,4 +751,45 @@ func TestCopyGGUFNoSplitWhenSmall(t *testing.T) {
 	layers, err := img.Layers()
 	require.NoError(t, err)
 	assert.Len(t, layers, 1, "expected 1 layer for small model")
+}
+
+func TestAutoParallel(t *testing.T) {
+	// Save and restore the original GOMEMLIMIT.
+	original := debug.SetMemoryLimit(-1)
+	t.Cleanup(func() { debug.SetMemoryLimit(original) })
+
+	tests := []struct {
+		name  string
+		limit int64
+		want  int
+	}{
+		{
+			name:  "no limit returns 0",
+			limit: math.MaxInt64,
+			want:  0,
+		},
+		{
+			name:  "4Gi memory limit",
+			limit: 4 * (1 << 30) * 4 / 5, // GOMEMLIMIT = 80% of 4Gi ≈ 3.4Gi
+			want:  26,                    // 3.4Gi * 80% / 100MB ≈ 26
+		},
+		{
+			name:  "2Gi memory limit",
+			limit: 2 * (1 << 30) * 4 / 5, // GOMEMLIMIT = 80% of 2Gi ≈ 1.7Gi
+			want:  13,                    // 1.7Gi * 80% / 100MB ≈ 13
+		},
+		{
+			name:  "very small limit clamps to 1",
+			limit: 10 << 20, // 10MB
+			want:  1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			debug.SetMemoryLimit(tt.limit)
+			got := AutoParallel()
+			assert.Equal(t, tt.want, got)
+		})
+	}
 }


### PR DESCRIPTION
## Summary

- **hf2oci now auto-calculates `--max-parallel` from `GOMEMLIMIT`**, preventing OOMKills on sync jobs without new config fields
- Formula: `(GOMEMLIMIT × 80%) / 100MB` — reserves headroom for GC and runtime overhead
- Bumps dev overlay `syncMemoryLimit` from 2Gi → 4Gi for Hermes 4 14B model sync
- Falls back to previous default (100) when GOMEMLIMIT is unset (e.g. local runs)

## Context

Sync jobs for `NousResearch_Hermes-4-14B-Q6_K` were OOMKilled at 2Gi. The ~11GB GGUF splits into 26 shards, and with the default parallelism of 100 all 26 streamed concurrently. Each stream holds ~100MB of live buffers (HTTP download chunks + tar I/O + GGUF headers), totalling ~2.6GB — exceeding the container limit. GOMEMLIMIT couldn't help because the memory was live (reachable from goroutines), not garbage.

The fix makes hf2oci memory-aware: it reads the GOMEMLIMIT already set by the operator (80% of container limit) and derives safe concurrency from it. With 4Gi limit → GOMEMLIMIT ~3.4Gi → 26 parallel streams with comfortable headroom.

## Test plan

- [x] `TestAutoParallel` covers: no limit (fallback), 4Gi, 2Gi, and very small (clamp to 1)
- [x] All existing hf2oci tests pass with new `--max-parallel 0` default
- [ ] Deploy and verify Hermes 4 14B sync completes without OOMKill

🤖 Generated with [Claude Code](https://claude.com/claude-code)