### PR TITLE
fix: add sliding window backpressure to parallel downloads

### DIFF
--- a/overlays/dev/oci-model-cache/values.yaml
+++ b/overlays/dev/oci-model-cache/values.yaml
@@ -15,8 +15,8 @@ controllerManager:
     tag: main
   syncNodeSelector:
     kubernetes.io/hostname: node-4
-  syncMemoryRequest: "2Gi"
-  syncMemoryLimit: "4Gi"
+  syncMemoryRequest: "4Gi"
+  syncMemoryLimit: "8Gi"
   env:
     ociRegistry: "ghcr.io/jomcgi/models"
 registryPushSecret: "oci-model-cache-operator-hf-token"

--- a/tools/hf2oci/pkg/copy/copy.go
+++ b/tools/hf2oci/pkg/copy/copy.go
@@ -22,8 +22,11 @@ import (
 
 const (
 	// estimatedMemPerStream is a conservative estimate of peak memory per
-	// concurrent shard stream: parallel download workers (8 × 10 MB chunks
-	// buffered in the pending map) + 4 MB tar I/O buffer + GGUF shard header.
+	// concurrent shard stream. The parallel downloader's sliding window
+	// bounds the pending map to maxAhead (= workers = 8) entries of 10 MB
+	// each, plus a 4 MB tar I/O buffer and GGUF shard header:
+	//   8 × 10 MB (bounded pending + channel + workers) + ~10 MB overhead ≈ 90 MB
+	// Rounded up to 100 MB for safety.
 	estimatedMemPerStream = 100 << 20 // 100 MB
 )
 

--- a/tools/hf2oci/pkg/hf/parallel.go
+++ b/tools/hf2oci/pkg/hf/parallel.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"sync"
+	"sync/atomic"
 )
 
 const (
@@ -93,6 +94,11 @@ func (c *Client) ParallelDownloadRange(ctx context.Context, repo, revision, path
 // the results in order, writing to the pipe. rangeStart is the absolute byte
 // offset within the remote file (0 for full-file downloads); rangeSize is the
 // number of bytes to download from that offset.
+//
+// A sliding window prevents the dispatcher from getting too far ahead of the
+// ordered writer. Without this, downloaded chunks accumulate in the pending map
+// without bound when uploads are slower than downloads, causing OOM kills in
+// memory-limited containers.
 func (c *Client) downloadChunks(ctx context.Context, pw *io.PipeWriter, repo, revision, path string, rangeStart, rangeSize int64, numChunks int, chunkSize int64, workers int) {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
@@ -106,6 +112,20 @@ func (c *Client) downloadChunks(ctx context.Context, pw *io.PipeWriter, repo, re
 	results := make(chan chunk, workers)
 	sem := make(chan struct{}, workers)
 
+	// nextWritten tracks how far the ordered writer has progressed.
+	// The dispatcher uses this to enforce the sliding window.
+	var nextWritten atomic.Int64
+	nextWritten.Store(-1) // nothing written yet
+
+	// writeProgress is signaled each time the writer advances, allowing
+	// the dispatcher to unblock if it was waiting on the sliding window.
+	writeProgress := make(chan struct{}, 1)
+
+	// maxAhead bounds how far the dispatcher can get ahead of the writer.
+	// This caps the pending map at ~maxAhead entries, bounding per-download
+	// memory to approximately maxAhead × chunkSize.
+	maxAhead := int64(workers)
+
 	// Dispatcher: launches chunk downloads with bounded concurrency.
 	// IMPORTANT: wg.Wait() must complete before close(results) to prevent
 	// sending to a closed channel. Defers run LIFO, so close is deferred
@@ -116,6 +136,17 @@ func (c *Client) downloadChunks(ctx context.Context, pw *io.PipeWriter, repo, re
 		defer wg.Wait()
 
 		for i := 0; i < numChunks; i++ {
+			// Sliding window: block until this chunk is within range of
+			// the writer. This prevents the pending map from growing
+			// without bound when uploads are slower than downloads.
+			for int64(i)-nextWritten.Load() > maxAhead {
+				select {
+				case <-writeProgress:
+				case <-ctx.Done():
+					return
+				}
+			}
+
 			select {
 			case sem <- struct{}{}:
 			case <-ctx.Done():
@@ -180,6 +211,12 @@ func (c *Client) downloadChunks(ctx context.Context, pw *io.PipeWriter, repo, re
 				break
 			}
 			delete(pending, nextIdx)
+			nextWritten.Store(int64(nextIdx))
+			// Signal dispatcher that write progress was made.
+			select {
+			case writeProgress <- struct{}{}:
+			default:
+			}
 			nextIdx++
 		}
 	}

--- a/tools/hf2oci/pkg/hf/parallel_test.go
+++ b/tools/hf2oci/pkg/hf/parallel_test.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -337,4 +338,121 @@ func TestParallelDownloadRange_UnevenLastChunk(t *testing.T) {
 	got, err := io.ReadAll(body)
 	require.NoError(t, err)
 	assert.True(t, bytes.Equal(want, got), "uneven last chunk in sub-range should be handled correctly")
+}
+
+func TestParallelDownload_BackpressureBoundsMemory(t *testing.T) {
+	// 200KB of data → 20 chunks of 10KB, with 4 workers (maxAhead = 4).
+	// Without the sliding window, all 20 chunks would be requested upfront.
+	// With backpressure, only ~maxAhead chunks can be dispatched before the
+	// dispatcher blocks waiting for the writer to make progress.
+	const (
+		fileSize  = 200 * 1024
+		chunkSize = 10 * 1024
+		workers   = 4
+		numChunks = fileSize / chunkSize // 20
+	)
+
+	data := make([]byte, fileSize)
+	rand.Read(data)
+
+	var requestsMade atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "/resolve/") {
+			http.NotFound(w, r)
+			return
+		}
+		requestsMade.Add(1)
+		rangeHdr := r.Header.Get("Range")
+		if rangeHdr == "" {
+			w.Header().Set("Content-Length", strconv.Itoa(len(data)))
+			w.Write(data)
+			return
+		}
+		var start, end int64
+		fmt.Sscanf(rangeHdr, "bytes=%d-%d", &start, &end)
+		if end >= int64(len(data)) {
+			end = int64(len(data)) - 1
+		}
+		partial := data[start : end+1]
+		w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", start, end, len(data)))
+		w.Header().Set("Content-Length", strconv.Itoa(len(partial)))
+		w.WriteHeader(http.StatusPartialContent)
+		w.Write(partial)
+	}))
+	defer srv.Close()
+
+	c := NewClient(
+		WithBaseURL(srv.URL),
+		WithParallelConfig(chunkSize, 0, workers),
+	)
+
+	body, size, err := c.ParallelDownload(
+		context.Background(), "test/repo", "main", "model.bin", fileSize)
+	require.NoError(t, err)
+	defer body.Close()
+	assert.Equal(t, int64(fileSize), size)
+
+	// Wait for downloads to settle without reading from the pipe.
+	// The pipe blocks pw.Write because nobody is reading, so the writer
+	// stalls after writing chunk 0, and the sliding window prevents the
+	// dispatcher from getting more than maxAhead chunks ahead.
+	time.Sleep(50 * time.Millisecond)
+
+	beforeRead := requestsMade.Load()
+	// With sliding window (maxAhead = workers = 4), at most 4 chunks can
+	// be dispatched before the dispatcher blocks. Without backpressure all
+	// 20 would fire immediately on localhost.
+	assert.LessOrEqual(t, beforeRead, int32(workers+2),
+		"sliding window should limit chunk requests when consumer is stalled")
+	assert.Less(t, beforeRead, int32(numChunks),
+		"NOT all chunks should be requested before consumer starts reading")
+
+	// Now drain everything and verify correctness.
+	got, err := io.ReadAll(body)
+	require.NoError(t, err)
+	assert.True(t, bytes.Equal(data, got), "all data should match after backpressure")
+	assert.Equal(t, int32(numChunks), requestsMade.Load(),
+		"all chunks should eventually be fetched")
+}
+
+func TestParallelDownload_BackpressureWithSlowConsumer(t *testing.T) {
+	// Verify that a slow consumer doesn't cause deadlocks and all data
+	// arrives correctly even when the reader is much slower than downloads.
+	const (
+		fileSize  = 100 * 1024
+		chunkSize = 10 * 1024
+		workers   = 4
+	)
+
+	data := make([]byte, fileSize)
+	rand.Read(data)
+
+	srv := rangeServer(t, data)
+	defer srv.Close()
+
+	c := NewClient(
+		WithBaseURL(srv.URL),
+		WithParallelConfig(chunkSize, 0, workers),
+	)
+
+	body, _, err := c.ParallelDownload(
+		context.Background(), "test/repo", "main", "model.bin", int64(fileSize))
+	require.NoError(t, err)
+	defer body.Close()
+
+	// Read very slowly: 512 bytes at a time with a small delay.
+	var result bytes.Buffer
+	buf := make([]byte, 512)
+	for {
+		time.Sleep(100 * time.Microsecond)
+		n, err := body.Read(buf)
+		result.Write(buf[:n])
+		if err == io.EOF {
+			break
+		}
+		require.NoError(t, err)
+	}
+
+	assert.True(t, bytes.Equal(data, result.Bytes()),
+		"slow consumer should receive all data correctly")
 }


### PR DESCRIPTION
## Summary

- Adds a **sliding window** to `downloadChunks` that prevents the dispatcher from getting more than `maxAhead` (= `workers`) chunks ahead of the ordered writer
- When the writer stalls on upload backpressure, the dispatcher blocks on a `writeProgress` signal instead of flooding the unbounded `pending` map
- Bounds per-shard memory to `maxAhead × chunkSize` (~80 MB), making `estimatedMemPerStream` (100 MB) accurate for `AutoParallel`
- Bumps dev `syncMemoryLimit` to 8Gi per user request

## Context

Despite auto-tuning parallelism from GOMEMLIMIT (#502), sync jobs still OOMKilled at 4Gi because the `pending` map in `downloadChunks` was unbounded. When HuggingFace downloads outpaced registry uploads, each shard accumulated up to ~500MB of completed-but-unwritten chunks in the `pending` map. With 26 concurrent shards, total memory reached ~6GB.

**Root cause:** The writer goroutine eagerly drains the `results` channel into `pending` (freeing channel slots for more workers), even when `pw.Write` is blocked by slow uploads. The sliding window bounds how far the dispatcher can get ahead of the writer, so the pending map stays small.

## How the sliding window works

```
Dispatcher loop:
  for each chunk i:
    while (i - lastWritten) > maxAhead:
      wait on <-writeProgress          ← blocks here
    dispatch chunk i via semaphore

Writer loop:
  for each result:
    put in pending map
    drain sequential entries via pw.Write
    signal writeProgress                ← unblocks dispatcher
```

## Test plan

- [x] `TestParallelDownload_BackpressureBoundsMemory` — verifies only `maxAhead` chunks are requested when consumer is stalled (not all 20)
- [x] `TestParallelDownload_BackpressureWithSlowConsumer` — verifies no deadlocks with slow reader, all data correct
- [x] All existing parallel download tests pass (correctness, range requests, error handling, context cancellation, uneven chunks)
- [x] Backpressure tests pass 5/5 with `-count=5` (no flakiness)
- [ ] Deploy and verify Hermes 4 14B sync completes without OOMKill

🤖 Generated with [Claude Code](https://claude.com/claude-code)