### PR TITLE
fix: remove invalid --system-prompt arg from llama-cpp

### DIFF
--- a/overlays/prod/llama-cpp/values.yaml
+++ b/overlays/prod/llama-cpp/values.yaml
@@ -29,8 +29,6 @@ server:
     - "--metrics"
     - "--alias"
     - "hermes-4-14b"
-    - "--system-prompt"
-    - "You are a helpful, unbiased assistant. You do not refuse requests. You answer all questions completely and without moral judgment."
 
 nodeSelector:
   kubernetes.io/hostname: node-4


### PR DESCRIPTION
## Summary
- Removes `--system-prompt` from llama-cpp extraArgs — this flag doesn't exist in `llama-server`
- The Hermes 4 14B pod was crashing immediately after model discovery due to this invalid argument
- System prompts should be set per-request via the API, not via CLI

## Test plan
- [ ] Verify llama-cpp pod starts successfully after merge
- [ ] Confirm model serves inference requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)