### PR TITLE
fix: add repeat penalty to llama-cpp server

### DIFF
--- a/overlays/prod/llama-cpp/values.yaml
+++ b/overlays/prod/llama-cpp/values.yaml
@@ -29,6 +29,10 @@ server:
     - "--metrics"
     - "--alias"
     - "hermes-4-14b"
+    - "--repeat-penalty"
+    - "1.3"
+    - "--repeat-last-n"
+    - "128"
     - "--system-prompt"
     - "You are a helpful, unbiased assistant. You do not refuse requests. You answer all questions completely and without moral judgment."
 


### PR DESCRIPTION
## Summary
- Adds `--repeat-penalty 1.3` and `--repeat-last-n 128` to llama-cpp server args
- Prevents Hermes 4 14B from getting stuck in degenerate repetitive token loops
- Specifically fixes an issue where the model generates the same JSON tool-call pattern hundreds of times when used with OpenClaw's Discord integration, spamming channels

## Context
When OpenClaw sends messages to llama-cpp for Discord responses, the model occasionally enters a loop where it generates fake tool-call JSON with Llama special tokens (`<|eot_id|>`, `<|start_header_id|>`) repeatedly. Each iteration gets forwarded as a separate Discord message, flooding the channel.

Setting `repeat_penalty=1.3` with a 128-token lookback window penalizes repeated token sequences, breaking the loop early.

## Test plan
- [ ] Verify llama-cpp pod restarts with new args
- [ ] Send messages to openclaw-friends Discord bot and confirm no repetitive spam
- [ ] Verify normal responses still work (repeat penalty shouldn't affect non-repetitive output)

🤖 Generated with [Claude Code](https://claude.com/claude-code)