### PR TITLE
fix: use 1Password item name 'bosun' for secret

### DIFF
--- a/charts/bosun/values.yaml
+++ b/charts/bosun/values.yaml
@@ -95,7 +95,7 @@ securityContext:
 secret:
   type: onepassword
   onepassword:
-    itemPath: "vaults/k8s-homelab/items/bosun.jomcgi.dev"
+    itemPath: "vaults/k8s-homelab/items/bosun"
 
 ## Service Account configuration
 serviceAccount:


### PR DESCRIPTION
## Summary

- Updates the 1Password item path from `bosun.jomcgi.dev` to `bosun` to match the actual item name in the vault

## Test plan

- [ ] Backend pod starts without `CreateContainerConfigError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)