### PR TITLE
fix: set RUNFILES_DIR for bosun backend venv bootstrap

### DIFF
--- a/charts/bosun/image/backend/BUILD
+++ b/charts/bosun/image/backend/BUILD
@@ -53,6 +53,10 @@ oci_image(
     name = "image_base_amd64",
     base = ":base_amd64_transitioned",
     entrypoint = ["/app/start.sh"],
+    env = {
+        "BAZEL_WORKSPACE": "_main",
+        "RUNFILES_DIR": "/charts/bosun/backend/server.runfiles",
+    },
     tars = py_image_layer(
         name = "py_layers_amd64",
         binary = "//charts/bosun/backend:server",
@@ -74,6 +78,10 @@ oci_image(
     name = "image_base_arm64",
     base = ":base_arm64_transitioned",
     entrypoint = ["/app/start.sh"],
+    env = {
+        "BAZEL_WORKSPACE": "_main",
+        "RUNFILES_DIR": "/charts/bosun/backend/server.runfiles",
+    },
     tars = py_image_layer(
         name = "py_layers_arm64",
         binary = "//charts/bosun/backend:server",


### PR DESCRIPTION
## Summary

- Adds `BAZEL_WORKSPACE` and `RUNFILES_DIR` env vars to the backend OCI image, matching the `py3_image.bzl` pattern
- Fixes `Unable to create base venv directory - Permission denied` error at container startup

The `aspect_rules_py` binary creates a lightweight venv at `${RUNFILES_DIR}/.server.venv` on startup. Without `RUNFILES_DIR` set as an image env var, the launcher script resolves it to `$0.runfiles` inside a read-only image layer.

## Test plan

- [x] `bazel build //charts/bosun/image/backend:image` passes
- [ ] Backend pod starts without venv permission error

🤖 Generated with [Claude Code](https://claude.com/claude-code)