### PR TITLE
fix: add image repository fields for image updater write-back

### DIFF
--- a/overlays/dev/bosun/values.yaml
+++ b/overlays/dev/bosun/values.yaml
@@ -1,8 +1,10 @@
 backend:
   image:
+    repository: ghcr.io/jomcgi/homelab/charts/bosun/backend
     tag: "main"
 frontend:
   image:
+    repository: ghcr.io/jomcgi/homelab/charts/bosun/frontend
     tag: "main"
 gitSync:
   enabled: true


### PR DESCRIPTION
## Summary

- Adds `repository` fields to both `backend.image` and `frontend.image` in the bosun overlay values
- Fixes `Could not update application spec: frontend.image.tag parameter not found` error in ArgoCD Image Updater

The image updater's `manifestTargets.helm` config references both `name` (repository) and `tag` fields. Both must be present in the target values file for the git write-back to succeed.

## Test plan

- [ ] Image updater logs show successful digest write-back for both images
- [ ] Pod rolls with the new RUNFILES_DIR fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)