### PR TITLE
fix: add imagePullSecrets to frontend + mkdir for sqlite db

### DIFF
--- a/charts/bosun/backend/server.py
+++ b/charts/bosun/backend/server.py
@@ -128,6 +128,7 @@ DB_PATH = Path.home() / ".claude" / "bosun.db"
 
 
 def _init_db():
+    DB_PATH.parent.mkdir(parents=True, exist_ok=True)
     db = sqlite3.connect(str(DB_PATH))
     db.execute("PRAGMA journal_mode=WAL")
     db.execute("""

--- a/charts/bosun/templates/frontend-deployment.yaml
+++ b/charts/bosun/templates/frontend-deployment.yaml
@@ -27,6 +27,10 @@ spec:
         {{- include "bosun.selectorLabels" . | nindent 8 }}
         component: frontend
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: nginx
           image: "{{ .Values.frontend.image.repository }}:{{ .Values.frontend.image.tag }}"


### PR DESCRIPTION
## Summary
- Frontend pod needs `imagePullSecrets` to pull from private GHCR (401 Unauthorized)
- Backend sqlite init needs to `mkdir -p ~/.claude/` before creating `bosun.db`

## Test plan
- [ ] Frontend pod pulls image successfully
- [ ] Backend starts without sqlite `unable to open database file` error

🤖 Generated with [Claude Code](https://claude.com/claude-code)