### PR TITLE
fix: run bosun frontend as root + add backend /health endpoint

### DIFF
--- a/charts/bosun/backend/server.py
+++ b/charts/bosun/backend/server.py
@@ -122,6 +122,12 @@ AUTO_APPROVED_TOOLS = [
 
 app = FastAPI()
 
+
+@app.get("/health")
+async def health():
+    return {"status": "ok"}
+
+
 # ── SQLite persistence ─────────────────────────────────────────────────────
 
 DB_PATH = Path.home() / ".claude" / "bosun.db"

--- a/charts/bosun/templates/frontend-deployment.yaml
+++ b/charts/bosun/templates/frontend-deployment.yaml
@@ -41,10 +41,10 @@ spec:
               protocol: TCP
           securityContext:
             allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            runAsNonRoot: true
-            runAsUser: 101
-            runAsGroup: 101
+            readOnlyRootFilesystem: false
+            runAsNonRoot: false
+            runAsUser: 0
+            runAsGroup: 0
             capabilities:
               drop:
                 - ALL


### PR DESCRIPTION
## Summary
- **Frontend 403 fix**: Changed frontend nginx container to run as root (uid 0) so it can read the root-owned static files built into the image by `pkg_tar`
- **Backend health endpoint**: Added `GET /health` to FastAPI server — without this, K8s readiness probes fail and the Service won't route traffic to the backend pod

## Test plan
- [ ] Frontend: `curl bosun.jomcgi.dev/` returns React HTML (not 403)
- [ ] Backend: `curl bosun.jomcgi.dev/api/status` proxied successfully through nginx
- [ ] Backend health: `kubectl logs` shows `GET /health` returning 200
- [ ] WebSocket: Bosun UI connects and streams Claude responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)