### PR TITLE
fix: bosun frontend nginx root path and writable log volume

### DIFF
--- a/charts/bosun/image/frontend/BUILD
+++ b/charts/bosun/image/frontend/BUILD
@@ -9,7 +9,7 @@ load("//tools/oci:apko_image.bzl", "apko_image")
 pkg_tar(
     name = "dist_tar",
     srcs = ["//charts/bosun/frontend:dist"],
-    mode = "0755",
+    mode = "0644",
     owner = "101.101",
     package_dir = "usr/share/nginx/html",
     strip_prefix = "charts/bosun/frontend/dist",

--- a/charts/bosun/templates/frontend-deployment.yaml
+++ b/charts/bosun/templates/frontend-deployment.yaml
@@ -86,6 +86,8 @@ spec:
               mountPath: /var/cache/nginx
             - name: nginx-log
               mountPath: /var/log/nginx
+            - name: nginx-lib-log
+              mountPath: /var/lib/nginx/logs
           resources:
             {{- toYaml .Values.frontend.resources | nindent 12 }}
       volumes:
@@ -99,4 +101,6 @@ spec:
           emptyDir:
             medium: Memory
         - name: nginx-log
+          emptyDir: {}
+        - name: nginx-lib-log
           emptyDir: {}

--- a/charts/bosun/templates/frontend-nginx-configmap.yaml
+++ b/charts/bosun/templates/frontend-nginx-configmap.yaml
@@ -64,7 +64,7 @@ data:
 
             # Static React frontend
             location / {
-                root /usr/share/nginx/html;
+                root /usr/share/nginx/html/charts/bosun/frontend/dist;
                 try_files $uri $uri/ /index.html;
                 expires 1h;
                 add_header Cache-Control "public";


### PR DESCRIPTION
## Summary
- Point nginx `root` at `/usr/share/nginx/html/charts/bosun/frontend/dist` where the Vite dist files actually land (Bazel `pkg_tar` `strip_prefix` is a no-op on tree artifacts)
- Add emptyDir volume at `/var/lib/nginx/logs` so the wolfi nginx binary can write its compiled-in default error log before our ConfigMap config loads
- Revert BUILD `mode` back to `0644` (the 403 was from missing `index.html` at the root, not directory permissions)

## Context
Follows #520 which switched the frontend to non-root (UID 101). Two remaining issues:
1. `403 Forbidden` — nginx couldn't find `index.html` because files are nested under `charts/bosun/frontend/dist/` due to `strip_prefix` not working on Bazel tree artifacts
2. `Read-only file system` — wolfi nginx opens `/var/lib/nginx/logs/error.log` at startup before processing our config

## Test plan
- [ ] Frontend pod starts without errors
- [ ] `GET /` serves the React SPA (no 403)
- [ ] No read-only filesystem errors in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)