### PR TITLE
fix: handle unknown SDK message types without aborting query

### DIFF
--- a/charts/bosun/backend/server.py
+++ b/charts/bosun/backend/server.py
@@ -261,7 +261,18 @@ class ClaudeSession:
         artifact_counter = 0  # Counter for generating unique msg_ids for artifacts
 
         try:
-            async for msg in query(prompt=prompt, options=options):
+            msg_iter = query(prompt=prompt, options=options).__aiter__()
+            while True:
+                try:
+                    msg = await msg_iter.__anext__()
+                except StopAsyncIteration:
+                    break
+                except Exception as iter_err:
+                    if "Unknown message type" in str(iter_err):
+                        log.debug("SDK: skipping unknown message type: %s", iter_err)
+                        continue
+                    raise
+
                 # Check for cancellation
                 if self._cancel_event.is_set():
                     log.info("Query cancelled by user")


### PR DESCRIPTION
## Summary
- The Claude Agent SDK (v0.1.38) throws on unrecognized message types like `rate_limit_event`, which kills the entire query
- Switch from `async for` to manual `__anext__()` iteration so we can catch and skip unknown message types while the query continues
- Makes the server resilient to any future unrecognized event types from the SDK

## Test plan
- [ ] Trigger a query and confirm no `SDK query error: Unknown message type` in logs
- [ ] Verify queries complete successfully end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)