### PR TITLE
fix(bosun): resolve React hooks violation causing error #300

### DIFF
--- a/charts/bosun/frontend/src/App.jsx
+++ b/charts/bosun/frontend/src/App.jsx
@@ -264,6 +264,12 @@ export default function App() {
     else { setDetailArtifact(artifact); setDetailId(id); setShowDetail(true); }
   }, [detailId]);
 
+  const openGallery = useCallback(() => {
+    setDetailArtifact(null);
+    setDetailId(null);
+    setShowDetail(true);
+  }, []);
+
   // ── Mobile layout ──────────────────────────────────────────────
   if (bp === "mobile") {
     return (
@@ -326,12 +332,6 @@ export default function App() {
       </div>
     );
   }
-
-  const openGallery = useCallback(() => {
-    setDetailArtifact(null);
-    setDetailId(null);
-    setShowDetail(true);
-  }, []);
 
   // ── Desktop layout ─────────────────────────────────────────────
   const hasDetail = showDetail && (detailArtifact || allArtifacts.length > 0);

--- a/charts/bosun/frontend/src/components/DetailPanel.jsx
+++ b/charts/bosun/frontend/src/components/DetailPanel.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useRef } from "react";
-import { X, ClipboardCopy, Download, Code, ZoomIn, ZoomOut, Grid, Maximize, Expand, FileCode } from "lucide-react";
+import { X, ClipboardCopy, Download, Code, ZoomIn, ZoomOut, Grid, Maximize, Expand, FileCode, Terminal, GitBranch, Image } from "lucide-react";
 import { C, sans, mono } from "../tokens.js";
 import { MarkdownContent } from "./MarkdownContent.jsx";
 import { MermaidDiagram } from "./MermaidDiagram.jsx";


### PR DESCRIPTION
## Summary

- **Move `openGallery` `useCallback`** in `App.jsx` before the `if (bp === "mobile") return` conditional early return. The hook was placed *after* the conditional, meaning mobile renders called 21 hooks while desktop renders called 22 — a Rules of Hooks violation that causes React error #300 ("Rendered fewer hooks than expected")
- **Add missing lucide-react imports** (`Terminal`, `GitBranch`, `Image`) in `DetailPanel.jsx` that are used in the fullscreen overlay but were never imported — would crash when entering fullscreen on output/mermaid/image artifacts

## Root Cause

The `openGallery` `useCallback` was positioned at line 330, after the mobile conditional return at line 268. React requires the same number of hooks to be called on every render. When `useBreakpoint()` returns "mobile" (e.g. due to a scrollbar appearance shrinking `innerWidth` below 768px during a long query), the component returns early and skips the final `useCallback`, triggering error #300 and crashing the entire component tree — preventing both the response text and TTS audio from appearing.

## Test plan

- [ ] Send a voice query and verify the response text appears in the UI
- [ ] Verify the audio summary plays after the response
- [ ] Resize browser window across the 768px breakpoint during a query — should not crash
- [ ] Click fullscreen on an image/mermaid/output artifact in the detail panel — should render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)