### PR TITLE
fix(bosun): cache invalidation, TTS debugging, voice input delay

### DIFF
--- a/charts/bosun/backend/server.py
+++ b/charts/bosun/backend/server.py
@@ -488,6 +488,12 @@ class ClaudeSession:
                         streaming_text = False
 
                     final_text = full_run_text.strip() or (msg.result or "")
+                    log.info(
+                        "SDK result: session=%s, turns=%s, text_len=%d",
+                        msg.session_id,
+                        msg.num_turns,
+                        len(final_text),
+                    )
                     await ws.send_json(
                         {
                             "type": "result",

--- a/charts/bosun/frontend/src/App.jsx
+++ b/charts/bosun/frontend/src/App.jsx
@@ -90,8 +90,9 @@ export default function App() {
   const tts = useTTS();
   const { connected, sessionId, messages, streaming, pendingApproval, send, approve, reject, newSession, resumeSession, wsRef, addGeminiMessage } = useClaudeSocket({
     onResult: (text) => {
+      console.log("[bosun] onResult fired, text length:", text?.length);
       // Dedup: skip if this is the same result text as last time (echo/replay)
-      if (text === lastTtsRef.current) return;
+      if (text === lastTtsRef.current) { console.log("[bosun] onResult dedup — skipping"); return; }
       lastTtsRef.current = text;
 
       // Voice already suppressed via streaming effect, but ensure it's off
@@ -238,6 +239,7 @@ export default function App() {
         // onResult — route through voice command classifier instead of direct send
         async (text) => {
           const result = await voiceCommands.classify(text);
+          voice.clearPending(); // Clear pending text now that classification is done
           // Handle switch_session command result
           if (result?.switchTo) {
             resumeSession(result.switchTo);
@@ -588,7 +590,7 @@ export default function App() {
                     {voice.pending && <span style={{ color: C.textSec }}>{voice.pending} </span>}
                     {voice.interim}
                     {voice.pending && !voice.interim && (
-                      <span style={{ fontSize: 11, color: C.textTer, marginLeft: 8 }}>sending in 2s...</span>
+                      <span style={{ fontSize: 11, color: C.textTer, marginLeft: 8 }}>sending...</span>
                     )}
                   </div>
                 )}

--- a/charts/bosun/frontend/src/hooks/useClaudeSocket.js
+++ b/charts/bosun/frontend/src/hooks/useClaudeSocket.js
@@ -246,8 +246,11 @@ export function useClaudeSocket({ onResult: onResultCb } = {}) {
 
         case "result":
           // The agent is done — fire the onResult callback with full turn text
+          console.log("[bosun] result received:", { hasText: !!msg.full_text, len: msg.full_text?.length, hasCallback: !!onResultRef.current });
           if (msg.full_text && onResultRef.current) {
             onResultRef.current(msg.full_text);
+          } else if (!msg.full_text) {
+            console.warn("[bosun] result message had no full_text:", msg);
           }
           break;
 

--- a/charts/bosun/frontend/src/hooks/useVoiceInput.js
+++ b/charts/bosun/frontend/src/hooks/useVoiceInput.js
@@ -29,9 +29,13 @@ export function useVoiceInput() {
       onResultRef.current(text);
     }
     bufRef.current = "";
-    setPending("");
+    // Keep pending text visible during async classification — consumer calls clearPending()
     // Reset to default debounce after each send
     debounceMsRef.current = DEBOUNCE_DEFAULT;
+  }, []);
+
+  const clearPending = useCallback(() => {
+    setPending("");
   }, []);
 
   const micStreamRef = useRef(null);
@@ -212,5 +216,5 @@ export function useVoiceInput() {
     debounceMsRef.current = fast ? DEBOUNCE_FAST : DEBOUNCE_DEFAULT;
   }, []);
 
-  return { listening, interim, pending, supported, start, stop, wakeWordFlash, suppress, unsuppress, setFastDebounce };
+  return { listening, interim, pending, supported, start, stop, wakeWordFlash, suppress, unsuppress, setFastDebounce, clearPending };
 }

--- a/charts/bosun/image/frontend/nginx.conf
+++ b/charts/bosun/image/frontend/nginx.conf
@@ -91,15 +91,16 @@ http {
             proxy_buffering off;
         }
 
-        # Static files with caching
+        # Hashed assets — cache forever (content hash guarantees freshness)
         location /assets/ {
             expires 1y;
             add_header Cache-Control "public, immutable";
         }
 
-        # SPA fallback - serve index.html for all other routes
+        # SPA fallback — always revalidate so deploys are picked up immediately
         location / {
             try_files $uri $uri/ /index.html;
+            add_header Cache-Control "no-cache";
         }
     }
 }

--- a/charts/bosun/templates/frontend-nginx-configmap.yaml
+++ b/charts/bosun/templates/frontend-nginx-configmap.yaml
@@ -62,12 +62,18 @@ data:
                 return 200 'ok\n';
             }
 
-            # Static React frontend
+            # Hashed assets — cache forever (content hash guarantees freshness)
+            location /assets/ {
+                root /usr/share/nginx/html/charts/bosun/frontend/dist;
+                expires 1y;
+                add_header Cache-Control "public, immutable";
+            }
+
+            # SPA fallback — always revalidate so deploys are picked up immediately
             location / {
                 root /usr/share/nginx/html/charts/bosun/frontend/dist;
                 try_files $uri $uri/ /index.html;
-                expires 1h;
-                add_header Cache-Control "public";
+                add_header Cache-Control "no-cache";
             }
 
             # WebSocket -> backend


### PR DESCRIPTION
## Summary
- **Cache invalidation**: Split nginx location blocks — `no-cache` on `index.html` (always revalidate), `immutable` on `/assets/` (hashed files). Eliminates the need to hard-refresh after deploys.
- **TTS pipeline logging**: Added `console.log` tracing at `result` message receipt, `onResult` callback, and backend `log.info` when sending the result. Will pinpoint exactly where the TTS signal drops.
- **Voice input delay**: Keep the pending voice text visible during async Gemini intent classification instead of clearing it prematurely in `flush()`. Consumer calls `clearPending()` after classification completes. Eliminates the 1s gap between pending text disappearing and permanent message appearing.

## Test plan
- [ ] After deploy, regular page refresh loads new bundle (no hard refresh needed)
- [ ] Browser console shows `[bosun] result received:` and `[bosun] onResult fired` after a query
- [ ] Voice pending text stays visible during classification, transitions smoothly to permanent message

🤖 Generated with [Claude Code](https://claude.com/claude-code)