### PR TITLE
fix(bosun): refresh sidebar session list reactively

### DIFF
--- a/charts/bosun/frontend/src/App.jsx
+++ b/charts/bosun/frontend/src/App.jsx
@@ -219,6 +219,20 @@ export default function App() {
     }
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
+  // Refresh sidebar when session changes (new session created or session resumed)
+  useEffect(() => {
+    if (sessionId) history.refresh();
+  }, [sessionId]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Refresh sidebar when a turn completes (session preview/timestamp changed on disk)
+  const prevStreamingRef = useRef(false);
+  useEffect(() => {
+    if (prevStreamingRef.current && !streaming) {
+      history.refresh();
+    }
+    prevStreamingRef.current = streaming;
+  }, [streaming]); // eslint-disable-line react-hooks/exhaustive-deps
+
   // Auto-scroll on new messages
   useEffect(() => {
     if (scrollAnchorRef.current) {


### PR DESCRIPTION
## Summary
- The sidebar session list only loaded on page mount and never updated, requiring a manual refresh to see new or updated sessions
- Added two `useEffect` hooks that call `history.refresh()` when:
  - **`sessionId` changes** — fires when a new session is created (backend sends `session_init`) or when the user resumes a different session
  - **`streaming` transitions from `true` → `false`** — fires when Claude finishes a turn, meaning the session file on disk has updated preview text and timestamp

## Test plan
- [ ] Open Bosun, verify sidebar loads existing sessions
- [ ] Click "New session", send a message — new session should appear in the sidebar without refresh
- [ ] Send follow-up messages — session preview text and timestamp should update in sidebar
- [ ] Click on an older session to resume it — sidebar ordering should reflect the resumed session

🤖 Generated with [Claude Code](https://claude.com/claude-code)