### PR TITLE
fix(bosun): ensure result message creates done entry in message array

### DIFF
--- a/charts/bosun/frontend/src/hooks/useClaudeSocket.js
+++ b/charts/bosun/frontend/src/hooks/useClaudeSocket.js
@@ -244,15 +244,42 @@ export function useClaudeSocket({ onResult: onResultCb } = {}) {
           });
           break;
 
-        case "result":
-          // The agent is done — fire the onResult callback with full turn text + tool context
-          console.log("[bosun] result received:", { hasText: !!msg.full_text, len: msg.full_text?.length, tools: msg.tool_summaries?.length || 0, speculative: !!msg.speculative_summary, hasCallback: !!onResultRef.current });
-          if (onResultRef.current && (msg.full_text || msg.tool_summaries?.length)) {
-            onResultRef.current(msg.full_text || "", msg.tool_summaries, msg.speculative_summary || null);
-          } else if (!msg.full_text && !msg.tool_summaries?.length) {
+        case "result": {
+          // The agent turn is complete — ensure the messages array has a "done"
+          // message with the full result text so exports/grouping work correctly.
+          const fullText = (msg.full_text || "").trim();
+          console.log("[bosun] result received:", { hasText: !!fullText, len: fullText.length, tools: msg.tool_summaries?.length || 0, speculative: !!msg.speculative_summary, hasCallback: !!onResultRef.current });
+
+          if (fullText) {
+            setMessages((prev) => {
+              // Find the last voice message to scope our search to the current turn
+              const lastVoiceIdx = prev.findLastIndex((m) => m.role === "voice");
+              // Look for an existing "done" message from assistant_done in this turn
+              const existingIdx = prev.findLastIndex(
+                (m, i) => i > lastVoiceIdx && m.role === "claude" && m.status === "done",
+              );
+              if (existingIdx >= 0) {
+                // Update the existing done message with the authoritative full text
+                const updated = [...prev];
+                updated[existingIdx] = { ...updated[existingIdx], text: fullText };
+                return updated;
+              }
+              // No done message yet (tool-only turn) — create one
+              return [
+                ...prev,
+                { id: nextId(), role: "claude", time: now(), status: "done", text: fullText },
+              ];
+            });
+          }
+
+          // Fire the onResult callback for TTS/summary generation
+          if (onResultRef.current && (fullText || msg.tool_summaries?.length)) {
+            onResultRef.current(fullText, msg.tool_summaries, msg.speculative_summary || null);
+          } else if (!fullText && !msg.tool_summaries?.length) {
             console.warn("[bosun] result message had no content:", msg);
           }
           break;
+        }
 
         case "queued":
           // Message was queued because agent is busy — mark the existing voice message


### PR DESCRIPTION
## Summary
- The `result` WebSocket handler in `useClaudeSocket.js` only fired the `onResult` callback (for TTS) but never created/updated a `status: "done"` message in the React messages array
- This caused **tool-only turns** to show "No response generated" in exports, and **mixed turns** (streaming text + tool calls) to have stale/partial result text
- The fix makes `result` the authoritative turn-completion signal: it updates an existing "done" message with full text, or creates one if none exists

## What was broken (from a real export)
- **Turn 6**: Claude wrote a file (tool-only), fallback result fired TTS, but export showed "No response generated"
- **Turns 1 & 3**: Claude streamed "Let me check..." then ran tools — the export captured the premature streaming text instead of the full result
- **5/6 turns had no Gemini spoken summary** because `onResult` wasn't reaching TTS for turns without clean `ResultMessage` delivery

## Test plan
- [ ] Open a Bosun chat session and run a tool-heavy prompt (e.g. "write a hello world file")
- [ ] Verify the transcript shows Claude's full response, not "No response generated"
- [ ] Export the transcript and confirm all turns have a "Claude Response" section
- [ ] Verify TTS/spoken summary fires for tool-only turns

🤖 Generated with [Claude Code](https://claude.com/claude-code)