### PR TITLE
fix(bosun): deduplicate events across reconnects and clean up agent UI

### DIFF
--- a/charts/bosun/backend/server.py
+++ b/charts/bosun/backend/server.py
@@ -599,6 +599,10 @@ class ClaudeSession:
         # Preserved across retry attempts for fallback result
         self._last_run_text: str = ""
         self._last_tool_summaries: list[str] = []
+        # Cross-reconnect dedup: prevent replaying events the frontend
+        # already has when include_partial_messages=True replays history.
+        self._emitted_tool_ids: set[str] = set()
+        self._emitted_text: set[str] = set()
 
     async def run(self, prompt: str, ws: WebSocket):
         """Run a query via the Agent SDK and stream events to the WebSocket.
@@ -788,24 +792,22 @@ class ClaudeSession:
                             streaming_text = True
                             text_buf = ""
                         elif cb.get("type") == "tool_use":
-                            await ws.send_json(
-                                {
-                                    "type": "tool_use",
-                                    "name": cb.get("name", ""),
-                                    "tool_use_id": cb.get("id", ""),
-                                    "summary": f"Using {cb.get('name', '')}",
-                                    "parent_tool_use_id": msg.parent_tool_use_id,
-                                }
-                            )
-                            # Emit early subagent_start for Task tools during streaming
-                            if cb.get("name") == "Task":
+                            tool_id = cb.get("id", "")
+                            # Skip Task tools — AssistantMessage handler
+                            # sends them with full input/description.
+                            # Also skip already-emitted IDs (reconnect replay).
+                            if (
+                                cb.get("name") != "Task"
+                                and tool_id
+                                and tool_id not in self._emitted_tool_ids
+                            ):
+                                self._emitted_tool_ids.add(tool_id)
                                 await ws.send_json(
                                     {
-                                        "type": "subagent_start",
-                                        "tool_use_id": cb.get("id", ""),
-                                        "name": "",
-                                        "description": "",
-                                        "subagent_type": "",
+                                        "type": "tool_use",
+                                        "name": cb.get("name", ""),
+                                        "tool_use_id": tool_id,
+                                        "summary": f"Using {cb.get('name', '')}",
                                         "parent_tool_use_id": msg.parent_tool_use_id,
                                     }
                                 )
@@ -835,40 +837,47 @@ class ClaudeSession:
 
                     elif ev_type == "message_stop":
                         if streaming_text:
-                            full_run_text += text_buf + "\n"
-                            streaming_captured.add(text_buf)
-                            await ws.send_json(
-                                {
-                                    "type": "assistant_done",
-                                    "full_text": text_buf,
-                                }
-                            )
-                            # Scan for mermaid blocks in the completed text
-                            for mi, mblock in enumerate(
-                                _extract_mermaid_blocks(text_buf)
-                            ):
+                            # Deduplicate text across reconnects — the SDK
+                            # replays in-flight messages on resume.
+                            if text_buf in self._emitted_text:
+                                streaming_text = False
+                                text_buf = ""
+                            else:
+                                self._emitted_text.add(text_buf)
+                                full_run_text += text_buf + "\n"
+                                streaming_captured.add(text_buf)
                                 await ws.send_json(
                                     {
-                                        "type": "mermaid_artifact",
-                                        "code": mblock["code"],
-                                        "label": mblock["label"],
+                                        "type": "assistant_done",
+                                        "full_text": text_buf,
                                     }
                                 )
-                                # Auto-save mermaid artifact
-                                if self.session_id:
-                                    artifact_counter += 1
-                                    _save_artifact(
-                                        self.session_id,
-                                        f"mermaid-{artifact_counter}",
-                                        str(mi + 1),
+                                # Scan for mermaid blocks in the completed text
+                                for mi, mblock in enumerate(
+                                    _extract_mermaid_blocks(text_buf)
+                                ):
+                                    await ws.send_json(
                                         {
-                                            "type": "mermaid",
+                                            "type": "mermaid_artifact",
+                                            "code": mblock["code"],
                                             "label": mblock["label"],
-                                            "data": mblock["code"],
-                                        },
+                                        }
                                     )
-                            streaming_text = False
-                            text_buf = ""
+                                    # Auto-save mermaid artifact
+                                    if self.session_id:
+                                        artifact_counter += 1
+                                        _save_artifact(
+                                            self.session_id,
+                                            f"mermaid-{artifact_counter}",
+                                            str(mi + 1),
+                                            {
+                                                "type": "mermaid",
+                                                "label": mblock["label"],
+                                                "data": mblock["code"],
+                                            },
+                                        )
+                                streaming_text = False
+                                text_buf = ""
 
                             # Speculative summarization: kick off Gemini summary
                             # in the background while Claude may still be doing
@@ -891,6 +900,10 @@ class ClaudeSession:
                 if isinstance(msg, AssistantMessage):
                     for block in msg.content:
                         if isinstance(block, ToolUseBlock):
+                            # Deduplicate across reconnects and streaming/complete
+                            if block.id in self._emitted_tool_ids:
+                                continue
+                            self._emitted_tool_ids.add(block.id)
                             summary = _tool_summary_sdk(block)
                             tool_summaries.append(summary)
                             await ws.send_json(

--- a/charts/bosun/frontend/src/components/SubagentProgress.jsx
+++ b/charts/bosun/frontend/src/components/SubagentProgress.jsx
@@ -27,10 +27,10 @@ export function SubagentProgress({ subagents }) {
             }}
           >
             <span style={{ color: C.accentBlue }}>&#x23FA; </span>
-            {agent.type || "agent"}
-            {agent.desc && (
+            {agent.name || agent.type || "agent"}
+            {!agent.name && agent.desc && (
               <span style={{ fontWeight: 400, color: C.textTer }}>
-                ({agent.desc.length > 40 ? agent.desc.slice(0, 37) + "..." : agent.desc})
+                {" "}({agent.desc.length > 40 ? agent.desc.slice(0, 37) + "..." : agent.desc})
               </span>
             )}
           </div>

--- a/charts/bosun/frontend/src/hooks/useClaudeSocket.js
+++ b/charts/bosun/frontend/src/hooks/useClaudeSocket.js
@@ -163,7 +163,7 @@ export function useClaudeSocket({ onResult: onResultCb } = {}) {
           if (msg.tool_use_id) {
             toolInfoRef.current.set(msg.tool_use_id, { name: msg.name, input: msg.input });
           }
-          // Track tool calls within subagents
+          // Child tool calls within subagents — track in SubagentProgress only
           if (msg.parent_tool_use_id) {
             setSubagents((prev) => {
               const agent = prev[msg.parent_tool_use_id];
@@ -173,7 +173,10 @@ export function useClaudeSocket({ onResult: onResultCb } = {}) {
               }
               return prev;
             });
+            break; // Don't add to transcript — SubagentProgress handles it
           }
+          // Task tool calls — SubagentProgress handles the display
+          if (msg.name === "Task") break;
           setMessages((prev) => [
             ...prev,
             { id: nextId(), role: "claude", time: now(), status: "tool", text: `${msg.name}: ${msg.summary || ""}` },
@@ -201,6 +204,14 @@ export function useClaudeSocket({ onResult: onResultCb } = {}) {
           const isErr = looksLikeError(msg.output, msg.is_error);
           // Clean up the tracking map
           if (msg.tool_use_id) toolInfoRef.current.delete(msg.tool_use_id);
+          // Clean up completed subagents from the live progress panel
+          setSubagents((prev) => {
+            if (prev[msg.tool_use_id]) {
+              const { [msg.tool_use_id]: _, ...rest } = prev;
+              return rest;
+            }
+            return prev;
+          });
           let toolArtifact = null;
           if (isErr) {
             // Error results: no artifact, store error detail for inline display


### PR DESCRIPTION
## Summary

- **Cross-reconnect dedup**: `include_partial_messages=True` replays the in-flight message on every `resume`, causing duplicate tool calls and text blocks. Track emitted tool IDs and text blocks on the session instance to skip re-sending.
- **Remove early empty `subagent_start`**: The streaming `content_block_start` handler sent `subagent_start` before tool input was available, creating bare "agent" entries with no name/description. Removed — the `AssistantMessage` handler sends the full version shortly after.
- **Skip streaming `tool_use` for Task tools**: "Using Task" with no description is useless. Wait for the `AssistantMessage` version which has the full input/name.
- **Don't add Task/child tool_use to transcript**: `SubagentProgress` handles agent display — adding them to the transcript too caused duplicate entries piling up.
- **Remove completed subagents**: Clean up from `subagents` state when `tool_result` arrives, so the live panel only shows active agents.
- **Better labels**: Use `agent.name` (e.g. "Explore(Analyze charts group 1 smells)") as primary label instead of bare "agent".

## Test plan

- [ ] Run a swarm task — verify SubagentProgress shows named agents that disappear when they complete
- [ ] Verify no duplicate "agent" or tool entries in the transcript steps
- [ ] Check that text doesn't repeat in the result after reconnects
- [ ] Verify non-Task tool calls (Bash, Edit, etc.) still appear in transcript steps normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)