### PR TITLE
refactor(bosun): replace SDK async iterator with CLI subprocess

### DIFF
--- a/charts/bosun/README.md
+++ b/charts/bosun/README.md
@@ -22,7 +22,7 @@ npm install
 # Backend
 python -m venv .venv
 source .venv/bin/activate
-pip install fastapi "uvicorn[standard]" claude-agent-sdk google-genai
+pip install fastapi "uvicorn[standard]" google-genai
 ```
 
 ### Run

--- a/charts/bosun/backend/BUILD
+++ b/charts/bosun/backend/BUILD
@@ -6,7 +6,6 @@ py_binary(
     srcs = ["server.py"],
     visibility = ["//:__subpackages__"],
     deps = [
-        "@pip//claude_agent_sdk",
         "@pip//fastapi",
         "@pip//google_genai",
         "@pip//uvicorn",
@@ -18,7 +17,6 @@ py_library(
     srcs = ["server.py"],
     visibility = ["//:__subpackages__"],
     deps = [
-        "@pip//claude_agent_sdk",
         "@pip//fastapi",
         "@pip//google_genai",
         "@pip//uvicorn",
@@ -31,7 +29,7 @@ py_test(
     imports = ["."],
     deps = [
         "//charts/bosun",
-        "@pip//claude_agent_sdk",
+        "//charts/bosun/backend/tests:conftest",
         "@pip//pytest",
         "@pip//starlette",
     ],

--- a/charts/bosun/backend/server.py
+++ b/charts/bosun/backend/server.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python3
 """
-Bosun — FastAPI backend bridging the web UI to Claude Code via Agent SDK.
+Bosun — FastAPI backend bridging the web UI to Claude Code CLI.
 
-Uses the Claude Agent SDK (`claude-agent-sdk`) for typed async streaming,
-session management, and tool handling. Forwards events to the browser over WebSocket.
+Runs Claude Code as a subprocess with ``--output-format stream-json``,
+parses the JSONL output, and forwards events to the browser over WebSocket.
 
 Usage:
-    pip install fastapi "uvicorn[standard]" claude-agent-sdk
+    pip install fastapi "uvicorn[standard]"
     python server.py [--port 8420] [--workdir /path/to/project]
 
 Or with Vite dev server (for hot reload):
@@ -36,23 +36,7 @@ try:
 except ImportError:
     sys.exit("Install dependencies: pip install fastapi 'uvicorn[standard]'")
 
-try:
-    from claude_agent_sdk import (
-        query,
-        ClaudeAgentOptions,
-        SystemMessage,
-        AssistantMessage,
-        UserMessage,
-        ResultMessage,
-        TextBlock,
-        ToolUseBlock,
-        ToolResultBlock,
-    )
-    from claude_agent_sdk.types import StreamEvent
-
-    HAS_SDK = True
-except ImportError:
-    HAS_SDK = False
+import uuid
 
 # Optional Gemini TTS
 try:
@@ -68,13 +52,13 @@ log = logging.getLogger("bosun")
 
 # ── Config ──────────────────────────────────────────────────────────────────
 
-# Unset CLAUDECODE to allow nested Claude sessions via the SDK.
+# Unset CLAUDECODE to allow nested Claude sessions.
 # When this server runs inside a Claude Code session, the CLI sets CLAUDECODE
 # which prevents launching child sessions. Clearing it here is safe because
 # the server is an independent process that intentionally spawns Claude sessions.
 os.environ.pop("CLAUDECODE", None)
 
-# Resolve the system Claude CLI path (not the SDK's bundled version, which lacks auth).
+# Resolve the Claude CLI path.
 # Check common locations since npm/sh may not have the full PATH from fish/zsh.
 CLAUDE_BIN = os.environ.get("CLAUDE_BIN", "")
 if not CLAUDE_BIN:
@@ -83,14 +67,14 @@ if not CLAUDE_BIN:
             CLAUDE_BIN = candidate
             break
 if not CLAUDE_BIN:
-    import shutil
-
     CLAUDE_BIN = shutil.which("claude") or ""
 CLAUDE_CLI_PATH = CLAUDE_BIN or None
 if CLAUDE_CLI_PATH:
-    log.info("Using system Claude CLI: %s", CLAUDE_CLI_PATH)
+    log.info("Using Claude CLI: %s", CLAUDE_CLI_PATH)
 else:
-    log.warning("System claude not found — SDK will use bundled CLI (may lack auth)")
+    log.warning(
+        "Claude CLI not found — install via: npm install -g @anthropic-ai/claude-code"
+    )
 GOLDEN_PATH = os.environ.get("BOSUN_GOLDEN_PATH", "")
 SESSIONS_PATH = os.environ.get("BOSUN_SESSIONS_PATH", "")
 if GOLDEN_PATH and os.path.isdir(os.path.join(GOLDEN_PATH, ".git")):
@@ -390,9 +374,6 @@ async def _poll_prs(ws: WebSocket, session_id: str):
             db.close()
 
 
-if not HAS_SDK:
-    log.warning("claude-agent-sdk not installed — run: pip install claude-agent-sdk")
-
 # ── Per-session clone isolation ─────────────────────────────────────────────
 
 
@@ -470,7 +451,7 @@ def _prune_stale_sessions():
     """Remove session clones with no activity in SESSION_TTL_DAYS.
 
     Called on startup and periodically. Uses directory mtime to determine
-    last activity — each SDK query touches the session dir.
+    last activity — each query touches the session dir.
     """
     if not SESSIONS_PATH or not os.path.isdir(SESSIONS_PATH):
         return
@@ -498,72 +479,77 @@ def _prune_stale_sessions():
 # ── Fixture recording (for integration tests) ──────────────────────────────
 
 
-def _sdk_event_to_dict(msg) -> dict:
-    """Convert an SDK message object to a JSON-serialisable dict for fixture recording."""
-    if isinstance(msg, SystemMessage):
-        return {"kind": "system_init", "data": msg.data}
+def _jsonl_event_to_dict(event: dict) -> dict:
+    """Convert a JSONL event dict to a fixture-compatible dict for recording.
 
-    if isinstance(msg, StreamEvent):
+    Maps CLI stream-json output types to the fixture ``kind`` format used
+    by the test harness.
+    """
+    etype = event.get("type", "")
+
+    if etype == "system":
+        return {"kind": "system_init", "data": event}
+
+    if etype == "stream_event":
         return {
             "kind": "stream_event",
-            "uuid": msg.uuid,
-            "session_id": msg.session_id,
-            "event": msg.event,
-            "parent_tool_use_id": msg.parent_tool_use_id,
+            "uuid": event.get("uuid", ""),
+            "session_id": event.get("session_id", ""),
+            "event": event.get("event", {}),
+            "parent_tool_use_id": event.get("parent_tool_use_id"),
         }
 
-    if isinstance(msg, AssistantMessage):
+    if etype == "assistant":
+        msg = event.get("message", {})
         blocks = []
-        for block in msg.content:
-            if isinstance(block, TextBlock):
-                blocks.append({"type": "text", "text": block.text})
-            elif isinstance(block, ToolUseBlock):
+        for block in msg.get("content", []):
+            btype = block.get("type", "")
+            if btype == "text":
+                blocks.append({"type": "text", "text": block.get("text", "")})
+            elif btype == "tool_use":
                 blocks.append(
                     {
                         "type": "tool_use",
-                        "id": block.id,
-                        "name": block.name,
-                        "input": block.input,
+                        "id": block.get("id", ""),
+                        "name": block.get("name", ""),
+                        "input": block.get("input", {}),
                     }
                 )
-            elif isinstance(block, ToolResultBlock):
+            elif btype == "tool_result":
                 blocks.append(
                     {
                         "type": "tool_result",
-                        "tool_use_id": block.tool_use_id,
-                        "content": block.content,
-                        "is_error": getattr(block, "is_error", False),
+                        "tool_use_id": block.get("tool_use_id", ""),
+                        "content": block.get("content", ""),
+                        "is_error": block.get("is_error", False),
                     }
                 )
             else:
-                blocks.append({"type": type(block).__name__})
+                blocks.append({"type": btype})
         return {
             "kind": "assistant",
             "content": blocks,
-            "model": getattr(msg, "model", None),
-            "parent_tool_use_id": msg.parent_tool_use_id,
+            "model": msg.get("model"),
+            "parent_tool_use_id": event.get("parent_tool_use_id"),
         }
 
-    if isinstance(msg, ResultMessage):
+    if etype == "result":
         return {
             "kind": "result",
-            "subtype": msg.subtype,
-            "session_id": msg.session_id,
-            "duration_ms": msg.duration_ms,
-            "total_cost_usd": msg.total_cost_usd,
-            "num_turns": msg.num_turns,
-            "result": msg.result,
-            "is_error": msg.is_error,
+            "subtype": event.get("subtype", "success"),
+            "session_id": event.get("session_id", ""),
+            "duration_ms": event.get("duration_ms", 0),
+            "total_cost_usd": event.get("total_cost_usd", 0.0),
+            "num_turns": event.get("num_turns", 0),
+            "result": event.get("result", ""),
+            "is_error": event.get("is_error", False),
         }
 
-    if isinstance(msg, UserMessage):
-        return {"kind": "user", "tool_use_result": msg.tool_use_result}
-
-    return {"kind": "unknown", "type": type(msg).__name__}
+    return {"kind": "unknown", "type": etype}
 
 
-def _record_event(msg, session_name: str) -> None:
-    """Append an SDK event to the fixture file for the given session.
+def _record_event(event: dict, session_name: str) -> None:
+    """Append a JSONL event dict to the fixture file for the given session.
 
     Only active when RECORD_FIXTURES_DIR is set (checked once at module load).
     Uses a simple read-modify-write on a JSON array file per session.
@@ -583,7 +569,7 @@ def _record_event(msg, session_name: str) -> None:
             except (json.JSONDecodeError, OSError):
                 events = []
 
-        events.append(_sdk_event_to_dict(msg))
+        events.append(_jsonl_event_to_dict(event))
         filepath.write_text(json.dumps(events, indent=2, default=str))
         log.debug(
             "Recorded fixture event #%d for session %s", len(events), session_name
@@ -592,456 +578,263 @@ def _record_event(msg, session_name: str) -> None:
         log.debug("Fixture recording failed: %s", e)
 
 
-# ── Claude Agent SDK session manager ────────────────────────────────────────
+# ── Claude CLI subprocess session manager ──────────────────────────────────
 
 
 class ClaudeSession:
-    """Manages a Claude Agent SDK session and streams results to a WebSocket."""
+    """Manages a Claude CLI subprocess and streams JSONL results to a WebSocket."""
 
     def __init__(self, workdir: str):
-        import uuid
-
         self._session_name = str(uuid.uuid4())[:8]
         self.workdir = _create_session_workdir(workdir, session_name=self._session_name)
         self.session_id: str | None = None
-        self._cancel_event = asyncio.Event()
-        # Preserved across retry attempts for fallback result
+        self._proc: asyncio.subprocess.Process | None = None
         self._last_run_text: str = ""
         self._last_tool_summaries: list[str] = []
-        # Cross-reconnect dedup: prevent replaying events the frontend
-        # already has when include_partial_messages=True replays history.
-        self._emitted_tool_ids: set[str] = set()
-        self._emitted_text: set[str] = set()
 
     async def run(self, prompt: str, ws: WebSocket):
-        """Run a query via the Agent SDK and stream events to the WebSocket.
-
-        The SDK's async iterator can terminate mid-run when it encounters
-        unknown message types (e.g. rate_limit_event).  The subprocess
-        keeps running, so we reconnect via ``resume`` until we receive a
-        proper ``ResultMessage``.
-
-        We track two streak counters to detect session completion:
-
-        - **silent_streak**: consecutive reconnects with zero messages
-          (subprocess has exited or is unreachable).
-        - **stale_streak**: consecutive reconnects that yield messages but
-          no *new* content after dedup filtering.  This catches the case
-          where the session finished but ``resume`` replays the full
-          history every time — ``msg_count`` stays high, but all events
-          are duplicates the frontend already has.
-
-        As long as each reconnect produces *new* content, both counters
-        stay at zero.  A 30-minute swarm task with periodic
-        rate_limit_event disconnects will reconnect hundreds of times
-        and that's fine.
-        """
-        MAX_SILENT_RECONNECTS = 5  # give up after N reconnects with zero events
-        MAX_STALE_RECONNECTS = 3  # give up after N reconnects with only replayed events
-        RECONNECT_DELAY = 2  # seconds between reconnects
-        start = time.monotonic()
-        attempt = 0
-        silent_streak = 0  # consecutive reconnects that yielded nothing
-        stale_streak = 0  # consecutive reconnects with msgs but no new content
-
-        while (
-            silent_streak < MAX_SILENT_RECONNECTS
-            and stale_streak < MAX_STALE_RECONNECTS
-        ):
-            attempt += 1
-            got_result, had_output, msg_count, had_new_content = await self._run_once(
-                prompt, ws, attempt
-            )
-            if got_result:
-                return  # Got a proper ResultMessage — truly done
-            if self._cancel_event.is_set():
-                return  # User cancelled — don't reconnect
-
-            # Track consecutive silent and stale reconnects.
-            if msg_count > 0:
-                silent_streak = 0
-                if had_new_content:
-                    stale_streak = 0
-                else:
-                    stale_streak += 1
-            else:
-                silent_streak += 1
-
-            if (
-                silent_streak >= MAX_SILENT_RECONNECTS
-                or stale_streak >= MAX_STALE_RECONNECTS
-            ):
-                break
-
-            log.info(
-                "Reconnecting to session (attempt %d, elapsed %.0fs, "
-                "msgs=%d, silent=%d, stale=%d)",
-                attempt,
-                time.monotonic() - start,
-                msg_count,
-                silent_streak,
-                stale_streak,
-            )
-            await asyncio.sleep(RECONNECT_DELAY)
-
-        # Session appears dead or stale — send fallback from accumulated state
-        elapsed = time.monotonic() - start
-        if self._last_run_text.strip() or self._last_tool_summaries:
-            log.warning(
-                "Session ended after %.0fs (%d reconnects, silent=%d, stale=%d)"
-                " — sending fallback (text_len=%d)",
-                elapsed,
-                attempt,
-                silent_streak,
-                stale_streak,
-                len(self._last_run_text.strip()),
-            )
-            fallback_payload = {
-                "type": "result",
-                "session_id": self.session_id,
-                "full_text": self._last_run_text.strip(),
-            }
-            if self._last_tool_summaries:
-                fallback_payload["tool_summaries"] = self._last_tool_summaries
-            await ws.send_json(fallback_payload)
-        else:
-            log.warning(
-                "Session produced no output after %.0fs (%d attempts)",
-                elapsed,
-                attempt,
-            )
-            await ws.send_json(
-                {
-                    "type": "error",
-                    "message": "Claude produced no response."
-                    " This may be due to rate limiting — try again shortly.",
-                }
-            )
-
-    async def _run_once(self, prompt: str, ws: WebSocket, attempt: int = 1):
-        """Execute a single SDK query attempt.
-
-        Returns (got_result, had_output, msg_count, had_new_content):
-        - got_result: True if a ResultMessage was received (session done)
-        - had_output: True if text or tool summaries were accumulated
-        - msg_count: total messages yielded by the iterator (liveness signal)
-        - had_new_content: True if any content passed the dedup filters
-        """
-        self._cancel_event.clear()
-
-        options = ClaudeAgentOptions(
-            cwd=self.workdir,
-            # Use the built-in Claude Code system prompt (preset avoids the SDK
-            # passing --system-prompt "" which clears it).
-            system_prompt={"type": "preset", "preset": "claude_code"},
-            allowed_tools=AUTO_APPROVED_TOOLS,
-            permission_mode="acceptEdits",
-            include_partial_messages=True,
-            setting_sources=["project"],
-            cli_path=CLAUDE_CLI_PATH or None,
-            stderr=lambda line: log.info("claude stderr: %s", line.rstrip()),
-        )
+        """Run a query via Claude CLI subprocess, streaming JSONL to WebSocket."""
+        _touch_session_workdir(self.workdir)
+        cmd = [
+            CLAUDE_CLI_PATH or "claude",
+            "--print",
+            "--output-format",
+            "stream-json",
+            "--verbose",
+            "--include-partial-messages",
+            "--permission-mode",
+            "acceptEdits",
+            "--allowedTools",
+            ",".join(AUTO_APPROVED_TOOLS),
+            "--setting-sources",
+            "project",
+        ]
         if self.session_id:
-            options.resume = self.session_id
+            cmd.extend(["--resume", self.session_id])
+        cmd.append(prompt)  # positional arg at end
 
         log.info(
-            "SDK query (attempt %d): %s... (session=%s)",
-            attempt,
+            "Subprocess start: %s... (session=%s)",
             prompt[:60],
             self.session_id or "new",
         )
-        _touch_session_workdir(self.workdir)
 
+        try:
+            self._proc = await asyncio.create_subprocess_exec(
+                *cmd,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                cwd=self.workdir,
+            )
+        except Exception as e:
+            log.error("Failed to start claude: %s", e)
+            await ws.send_json(
+                {"type": "error", "message": f"Failed to start Claude: {e}"}
+            )
+            return
+
+        stderr_task = asyncio.create_task(self._drain_stderr())
+        await self._process_stdout(ws)
+
+        try:
+            await asyncio.wait_for(self._proc.wait(), timeout=5.0)
+        except asyncio.TimeoutError:
+            log.warning("Process did not exit, terminating")
+            self._proc.terminate()
+
+        stderr_task.cancel()
+        try:
+            await stderr_task
+        except asyncio.CancelledError:
+            pass
+
+        rc = self._proc.returncode
+        if rc and rc != 0:
+            log.warning("Claude exited with code %d", rc)
+        self._proc = None
+
+    async def _drain_stderr(self):
+        """Log stderr from claude subprocess."""
+        try:
+            while True:
+                line = await self._proc.stderr.readline()
+                if not line:
+                    break
+                log.info(
+                    "claude stderr: %s", line.decode("utf-8", errors="replace").rstrip()
+                )
+        except (asyncio.CancelledError, Exception):
+            pass
+
+    async def _process_stdout(self, ws: WebSocket):
+        """Parse JSONL stdout from Claude CLI and emit WebSocket events."""
         text_buf = ""
         full_run_text = ""
         streaming_text = False
-        streaming_captured: set[str] = (
-            set()
-        )  # Text already captured from streaming path
-        artifact_counter = 0  # Counter for generating unique msg_ids for artifacts
-        tool_summaries = []  # Human-readable tool call summaries for TTS context
-        speculative_summary_task: asyncio.Task | None = None  # Background summarization
-
+        artifact_counter = 0
+        tool_summaries: list[str] = []
+        speculative_summary_task: asyncio.Task | None = None
         got_result = False
-        msg_count = 0  # total messages from iterator (liveness signal)
-        new_content = False  # True if any content passed dedup filters
 
-        try:
-            msg_iter = query(prompt=prompt, options=options).__aiter__()
-            while True:
-                try:
-                    msg = await msg_iter.__anext__()
-                except StopAsyncIteration:
-                    log.info(
-                        "SDK iteration ended (StopAsyncIteration, msgs=%d)", msg_count
+        while True:
+            line = await self._proc.stdout.readline()
+            if not line:
+                break  # EOF — process exited
+
+            line_str = line.decode("utf-8", errors="replace").rstrip()
+            if not line_str:
+                continue
+
+            try:
+                event = json.loads(line_str)
+            except json.JSONDecodeError:
+                log.debug("Non-JSON line from claude: %s", line_str[:200])
+                continue
+
+            _record_event(event, self._session_name)
+            etype = event.get("type", "")
+
+            # ── System messages (session init) ────────────────
+            if etype == "system":
+                if event.get("subtype") == "init":
+                    self.session_id = event.get("session_id")
+                    log.info("Session initialized: %s", self.session_id)
+                    await ws.send_json(
+                        {
+                            "type": "session_init",
+                            "session_id": self.session_id,
+                        }
                     )
-                    break
-                except Exception as iter_err:
-                    if "Unknown message type" in str(iter_err):
-                        log.info(
-                            "SDK: skipping %s: %s", type(iter_err).__name__, iter_err
-                        )
-                        continue
-                    raise
+                continue
 
-                msg_count += 1
-                _record_event(msg, self._session_name)
-                log.debug("SDK msg: %s", type(msg).__name__)
+            # ── Streaming deltas ──────────────────────────────
+            if etype == "stream_event":
+                ev = event.get("event", {})
+                ev_type = ev.get("type", "")
 
-                # Check for cancellation
-                if self._cancel_event.is_set():
-                    log.info("Query cancelled by user")
-                    break
+                if ev_type == "content_block_start":
+                    cb = ev.get("content_block", {})
+                    if cb.get("type") == "text" and not streaming_text:
+                        await ws.send_json({"type": "assistant_start"})
+                        streaming_text = True
+                        text_buf = ""
 
-                # ── System messages (session init, etc.) ──────────
-                if isinstance(msg, SystemMessage):
-                    if msg.subtype == "init":
-                        self.session_id = msg.data.get("session_id")
+                elif ev_type == "content_block_delta":
+                    delta = ev.get("delta", {})
+                    if delta.get("type") == "text_delta":
+                        chunk = delta.get("text", "")
+                        text_buf += chunk
                         await ws.send_json(
                             {
-                                "type": "session_init",
-                                "session_id": self.session_id,
+                                "type": "assistant_text",
+                                "content": chunk,
                             }
                         )
-                    else:
-                        log.info(
-                            "SDK SystemMessage subtype=%s data=%s",
-                            msg.subtype,
-                            msg.data,
-                        )
-                    continue
 
-                # ── Streaming deltas (partial text from API) ──────
-                if isinstance(msg, StreamEvent):
-                    ev = msg.event
-                    ev_type = ev.get("type", "")
-
-                    if ev_type == "content_block_start":
-                        cb = ev.get("content_block", {})
-                        if cb.get("type") == "text" and not streaming_text:
-                            await ws.send_json({"type": "assistant_start"})
-                            streaming_text = True
-                            text_buf = ""
-                        elif cb.get("type") == "tool_use":
-                            tool_id = cb.get("id", "")
-                            # Skip Task tools — AssistantMessage handler
-                            # sends them with full input/description.
-                            # Also skip already-emitted IDs (reconnect replay).
-                            if (
-                                cb.get("name") != "Task"
-                                and tool_id
-                                and tool_id not in self._emitted_tool_ids
-                            ):
-                                self._emitted_tool_ids.add(tool_id)
-                                new_content = True
-                                await ws.send_json(
-                                    {
-                                        "type": "tool_use",
-                                        "name": cb.get("name", ""),
-                                        "tool_use_id": tool_id,
-                                        "summary": f"Using {cb.get('name', '')}",
-                                        "parent_tool_use_id": msg.parent_tool_use_id,
-                                    }
-                                )
-
-                    elif ev_type == "content_block_delta":
-                        delta = ev.get("delta", {})
-                        if delta.get("type") == "text_delta":
-                            chunk = delta.get("text", "")
-                            text_buf += chunk
-                            await ws.send_json(
-                                {
-                                    "type": "assistant_text",
-                                    "content": chunk,
-                                }
-                            )
-
-                    elif ev_type == "message_delta":
-                        usage = ev.get("usage", {})
-                        if usage:
-                            await ws.send_json(
-                                {
-                                    "type": "usage_update",
-                                    "input_tokens": usage.get("input_tokens", 0),
-                                    "output_tokens": usage.get("output_tokens", 0),
-                                }
-                            )
-
-                    elif ev_type == "message_stop":
-                        if streaming_text:
-                            # Deduplicate text across reconnects — the SDK
-                            # replays in-flight messages on resume.
-                            if text_buf in self._emitted_text:
-                                streaming_text = False
-                                text_buf = ""
-                            else:
-                                self._emitted_text.add(text_buf)
-                                new_content = True
-                                full_run_text += text_buf + "\n"
-                                streaming_captured.add(text_buf)
-                                await ws.send_json(
-                                    {
-                                        "type": "assistant_done",
-                                        "full_text": text_buf,
-                                    }
-                                )
-                                # Scan for mermaid blocks in the completed text
-                                for mi, mblock in enumerate(
-                                    _extract_mermaid_blocks(text_buf)
-                                ):
-                                    await ws.send_json(
-                                        {
-                                            "type": "mermaid_artifact",
-                                            "code": mblock["code"],
-                                            "label": mblock["label"],
-                                        }
-                                    )
-                                    # Auto-save mermaid artifact
-                                    if self.session_id:
-                                        artifact_counter += 1
-                                        _save_artifact(
-                                            self.session_id,
-                                            f"mermaid-{artifact_counter}",
-                                            str(mi + 1),
-                                            {
-                                                "type": "mermaid",
-                                                "label": mblock["label"],
-                                                "data": mblock["code"],
-                                            },
-                                        )
-                                streaming_text = False
-                                text_buf = ""
-
-                            # Speculative summarization: kick off Gemini summary
-                            # in the background while Claude may still be doing
-                            # tool calls. By the time ResultMessage arrives the
-                            # summary is often already ready, saving ~300ms.
-                            if (
-                                len(full_run_text) >= 200
-                                and speculative_summary_task is None
-                            ):
-                                client = _get_gemini()
-                                if client:
-                                    truncated = _truncate_for_tts(full_run_text.strip())
-                                    speculative_summary_task = asyncio.create_task(
-                                        _summarize(client, truncated, True)
-                                    )
-
-                    continue
-
-                # ── Complete assistant messages ────────────────────
-                if isinstance(msg, AssistantMessage):
-                    for block in msg.content:
-                        if isinstance(block, ToolUseBlock):
-                            # Deduplicate across reconnects and streaming/complete
-                            if block.id in self._emitted_tool_ids:
-                                continue
-                            self._emitted_tool_ids.add(block.id)
-                            new_content = True
-                            summary = _tool_summary_sdk(block)
-                            tool_summaries.append(summary)
-                            await ws.send_json(
-                                {
-                                    "type": "tool_use",
-                                    "name": block.name,
-                                    "tool_use_id": block.id,
-                                    "input": block.input,
-                                    "summary": summary,
-                                    "parent_tool_use_id": msg.parent_tool_use_id,
-                                }
-                            )
-                            # Emit structured events for specific tool types
-                            if block.name == "TodoWrite":
-                                await ws.send_json(
-                                    {
-                                        "type": "todo_update",
-                                        "todos": block.input.get("todos", []),
-                                        "parent_tool_use_id": msg.parent_tool_use_id,
-                                    }
-                                )
-                            elif block.name == "Task":
-                                await ws.send_json(
-                                    {
-                                        "type": "subagent_start",
-                                        "tool_use_id": block.id,
-                                        "name": block.input.get(
-                                            "name", block.input.get("description", "")
-                                        ),
-                                        "description": block.input.get(
-                                            "description", ""
-                                        ),
-                                        "subagent_type": block.input.get(
-                                            "subagent_type", ""
-                                        ),
-                                        "parent_tool_use_id": msg.parent_tool_use_id,
-                                    }
-                                )
-                        elif isinstance(block, TextBlock) and block.text:
-                            # Skip if already captured via streaming path
-                            # (include_partial_messages=True causes both to fire)
-                            if block.text not in streaming_captured:
-                                full_run_text += block.text + "\n"
-                        elif isinstance(block, ToolResultBlock):
-                            content = block.content
-                            images = (
-                                _extract_images(content)
-                                if isinstance(content, list)
-                                else []
-                            )
-                            if isinstance(content, list):
-                                content = "\n".join(
-                                    b.get("text", "")
-                                    for b in content
-                                    if isinstance(b, dict) and b.get("type") == "text"
-                                )
-                            result_msg = {
-                                "type": "tool_result",
-                                "tool_use_id": block.tool_use_id,
-                                "name": getattr(block, "name", None) or "",
-                                "output": str(content or "")[:5000],
+                elif ev_type == "message_delta":
+                    usage = ev.get("usage", {})
+                    if usage:
+                        await ws.send_json(
+                            {
+                                "type": "usage_update",
+                                "input_tokens": usage.get("input_tokens", 0),
+                                "output_tokens": usage.get("output_tokens", 0),
                             }
-                            if getattr(block, "is_error", False):
-                                result_msg["is_error"] = True
-                            if images:
-                                result_msg["image"] = images[0]
-                                # Auto-save image artifact
-                                if self.session_id:
-                                    artifact_counter += 1
-                                    _save_artifact(
-                                        self.session_id,
-                                        f"tool-{artifact_counter}",
-                                        "1",
-                                        {
-                                            "type": "image",
-                                            "label": block.name or "screenshot",
-                                            "data": images[0].get("data", ""),
-                                            "mimeType": images[0].get(
-                                                "mimeType", "image/png"
-                                            ),
-                                        },
-                                    )
-                            await ws.send_json(result_msg)
-                            # Detect PR URLs in tool output
-                            await _detect_prs_in_output(
-                                str(content or ""), self.session_id, ws
-                            )
-                    continue
+                        )
 
-                # ── User messages (tool results flowing back) ─────
-                if isinstance(msg, UserMessage):
-                    if msg.tool_use_result:
-                        tur = msg.tool_use_result
-                        # MCP tool results may be a list of content blocks
-                        # instead of a dict with "content" key
-                        if isinstance(tur, list):
-                            content = tur
-                            tool_use_id = ""
-                        elif isinstance(tur, dict):
-                            content = tur.get("content", "")
-                            tool_use_id = tur.get("tool_use_id", "")
-                        else:
-                            content = str(tur)
-                            tool_use_id = ""
+                elif ev_type == "message_stop":
+                    if streaming_text:
+                        full_run_text += text_buf + "\n"
+                        await ws.send_json(
+                            {
+                                "type": "assistant_done",
+                                "full_text": text_buf,
+                            }
+                        )
+                        # Scan for mermaid blocks in the completed text
+                        for mi, mblock in enumerate(_extract_mermaid_blocks(text_buf)):
+                            await ws.send_json(
+                                {
+                                    "type": "mermaid_artifact",
+                                    "code": mblock["code"],
+                                    "label": mblock["label"],
+                                }
+                            )
+                            if self.session_id:
+                                artifact_counter += 1
+                                _save_artifact(
+                                    self.session_id,
+                                    f"mermaid-{artifact_counter}",
+                                    str(mi + 1),
+                                    {
+                                        "type": "mermaid",
+                                        "label": mblock["label"],
+                                        "data": mblock["code"],
+                                    },
+                                )
+                        streaming_text = False
+                        text_buf = ""
+
+                    # Speculative summarization
+                    if len(full_run_text) >= 200 and speculative_summary_task is None:
+                        client = _get_gemini()
+                        if client:
+                            truncated = _truncate_for_tts(full_run_text.strip())
+                            speculative_summary_task = asyncio.create_task(
+                                _summarize(client, truncated, True)
+                            )
+
+                continue
+
+            # ── Complete assistant messages (tool_use / tool_result) ──
+            if etype == "assistant":
+                msg = event.get("message", {})
+                parent_tool_use_id = event.get("parent_tool_use_id")
+                for block in msg.get("content", []):
+                    btype = block.get("type", "")
+
+                    if btype == "tool_use":
+                        summary = _tool_summary(block)
+                        tool_summaries.append(summary)
+                        await ws.send_json(
+                            {
+                                "type": "tool_use",
+                                "name": block.get("name", ""),
+                                "tool_use_id": block.get("id", ""),
+                                "input": block.get("input", {}),
+                                "summary": summary,
+                                "parent_tool_use_id": parent_tool_use_id,
+                            }
+                        )
+                        # Emit structured events for specific tool types
+                        tool_name = block.get("name", "")
+                        tool_input = block.get("input", {})
+                        if tool_name == "TodoWrite":
+                            await ws.send_json(
+                                {
+                                    "type": "todo_update",
+                                    "todos": tool_input.get("todos", []),
+                                    "parent_tool_use_id": parent_tool_use_id,
+                                }
+                            )
+                        elif tool_name == "Task":
+                            await ws.send_json(
+                                {
+                                    "type": "subagent_start",
+                                    "tool_use_id": block.get("id", ""),
+                                    "name": tool_input.get(
+                                        "name", tool_input.get("description", "")
+                                    ),
+                                    "description": tool_input.get("description", ""),
+                                    "subagent_type": tool_input.get(
+                                        "subagent_type", ""
+                                    ),
+                                    "parent_tool_use_id": parent_tool_use_id,
+                                }
+                            )
+
+                    elif btype == "tool_result":
+                        content = block.get("content", "")
                         images = (
                             _extract_images(content)
                             if isinstance(content, list)
@@ -1055,21 +848,23 @@ class ClaudeSession:
                             )
                         result_msg = {
                             "type": "tool_result",
-                            "tool_use_id": tool_use_id,
+                            "tool_use_id": block.get("tool_use_id", ""),
+                            "name": block.get("name", ""),
                             "output": str(content or "")[:5000],
                         }
+                        if block.get("is_error"):
+                            result_msg["is_error"] = True
                         if images:
                             result_msg["image"] = images[0]
-                            # Auto-save image artifact
                             if self.session_id:
                                 artifact_counter += 1
                                 _save_artifact(
                                     self.session_id,
-                                    f"user-tool-{artifact_counter}",
+                                    f"tool-{artifact_counter}",
                                     "1",
                                     {
                                         "type": "image",
-                                        "label": "screenshot",
+                                        "label": block.get("name", "screenshot"),
                                         "data": images[0].get("data", ""),
                                         "mimeType": images[0].get(
                                             "mimeType", "image/png"
@@ -1081,110 +876,113 @@ class ClaudeSession:
                         await _detect_prs_in_output(
                             str(content or ""), self.session_id, ws
                         )
-                    continue
 
-                # ── Final result ──────────────────────────────────
-                if isinstance(msg, ResultMessage):
-                    self.session_id = msg.session_id
+                continue
 
-                    # Send any remaining streaming text
-                    if streaming_text:
-                        full_run_text += text_buf + "\n"
-                        await ws.send_json(
-                            {
-                                "type": "assistant_done",
-                                "full_text": text_buf,
-                            }
-                        )
-                        streaming_text = False
+            # ── Final result ──────────────────────────────────
+            if etype == "result":
+                self.session_id = event.get("session_id", self.session_id)
 
-                    final_text = full_run_text.strip() or (msg.result or "")
-                    log.info(
-                        "SDK result: session=%s, turns=%d, text_len=%d, is_error=%s, tools=%d",
-                        msg.session_id,
-                        msg.num_turns,
-                        len(final_text),
-                        msg.is_error,
-                        len(tool_summaries),
+                # Send any remaining streaming text
+                if streaming_text:
+                    full_run_text += text_buf + "\n"
+                    await ws.send_json(
+                        {
+                            "type": "assistant_done",
+                            "full_text": text_buf,
+                        }
                     )
-                    if not final_text and tool_summaries:
-                        log.warning(
-                            "SDK returned tools but no text (turns=%d, is_error=%s) — "
-                            "Claude may have terminated early",
-                            msg.num_turns,
-                            msg.is_error,
+                    streaming_text = False
+
+                final_text = full_run_text.strip() or event.get("result", "")
+                num_turns = event.get("num_turns", 0)
+                is_error = event.get("is_error", False)
+                log.info(
+                    "Result: session=%s, turns=%d, text_len=%d, is_error=%s, tools=%d",
+                    self.session_id,
+                    num_turns,
+                    len(final_text),
+                    is_error,
+                    len(tool_summaries),
+                )
+                got_result = True
+                result_payload = {
+                    "type": "result",
+                    "session_id": self.session_id,
+                    "cost_usd": event.get("total_cost_usd", 0.0),
+                    "duration_ms": event.get("duration_ms", 0),
+                    "num_turns": num_turns,
+                    "is_error": is_error,
+                    "full_text": final_text,
+                }
+                if tool_summaries:
+                    result_payload["tool_summaries"] = tool_summaries
+
+                # Attach speculative summary if ready (or wait briefly)
+                if speculative_summary_task is not None:
+                    try:
+                        spoken, summary, actions = await asyncio.wait_for(
+                            speculative_summary_task, timeout=2.0
                         )
-                    got_result = True
-                    result_payload = {
-                        "type": "result",
-                        "session_id": msg.session_id,
-                        "cost_usd": msg.total_cost_usd,
-                        "duration_ms": msg.duration_ms,
-                        "num_turns": msg.num_turns,
-                        "is_error": msg.is_error,
-                        "full_text": final_text,
-                    }
-                    if tool_summaries:
-                        result_payload["tool_summaries"] = tool_summaries
-
-                    # Attach speculative summary if ready (or wait briefly)
-                    if speculative_summary_task is not None:
-                        try:
-                            spoken, summary, actions = await asyncio.wait_for(
-                                speculative_summary_task, timeout=2.0
+                        if summary:
+                            result_payload["speculative_summary"] = {
+                                "summary": summary,
+                                "actions": actions or [],
+                            }
+                            log.info(
+                                "Speculative summary attached (%d chars)",
+                                len(summary),
                             )
-                            if summary:
-                                result_payload["speculative_summary"] = {
-                                    "summary": summary,
-                                    "actions": actions or [],
-                                }
-                                log.info(
-                                    "Speculative summary attached (%d chars)",
-                                    len(summary),
-                                )
-                        except (asyncio.TimeoutError, Exception) as e:
-                            log.info("Speculative summary not ready: %s", e)
+                    except (asyncio.TimeoutError, Exception) as e:
+                        log.info("Speculative summary not ready: %s", e)
 
-                    await ws.send_json(result_payload)
-                    continue
+                await ws.send_json(result_payload)
+                continue
 
-        except asyncio.CancelledError:
-            log.info("SDK query task cancelled")
-            raise
-        except Exception as e:
-            log.error("SDK query error: %s", e)
-            try:
-                await ws.send_json({"type": "error", "message": str(e)})
-            except Exception:
-                pass
-            return True, True, msg_count, new_content  # Don't retry on exceptions
-
-        # Preserve accumulated state for run() to use after retries exhaust.
-        had_output = bool(full_run_text.strip() or tool_summaries)
-        if not got_result and had_output:
-            log.warning(
-                "SDK ended without ResultMessage (text_len=%d, tools=%d, msgs=%d)",
-                len(full_run_text.strip()),
-                len(tool_summaries),
-                msg_count,
-            )
+        # Process exited without a result event — send fallback
+        if not got_result:
             if streaming_text:
                 full_run_text += text_buf + "\n"
                 await ws.send_json({"type": "assistant_done", "full_text": text_buf})
-            self._last_run_text = full_run_text.strip()
-            self._last_tool_summaries = tool_summaries
 
-        return got_result, had_output, msg_count, new_content
+            if full_run_text.strip() or tool_summaries:
+                log.warning(
+                    "Process exited without result event (text_len=%d, tools=%d)",
+                    len(full_run_text.strip()),
+                    len(tool_summaries),
+                )
+                fallback = {
+                    "type": "result",
+                    "session_id": self.session_id,
+                    "full_text": full_run_text.strip(),
+                }
+                if tool_summaries:
+                    fallback["tool_summaries"] = tool_summaries
+                await ws.send_json(fallback)
+            else:
+                log.warning("Process exited with no output")
+                await ws.send_json(
+                    {
+                        "type": "error",
+                        "message": "Claude produced no response."
+                        " This may be due to rate limiting — try again shortly.",
+                    }
+                )
+
+        self._last_run_text = full_run_text.strip()
+        self._last_tool_summaries = tool_summaries
 
     def cancel(self):
-        """Signal the running query to stop."""
-        self._cancel_event.set()
+        """Kill the running subprocess."""
+        if self._proc and self._proc.returncode is None:
+            log.info("Cancelling claude subprocess (pid=%d)", self._proc.pid)
+            self._proc.terminate()
 
 
-def _tool_summary_sdk(block: ToolUseBlock) -> str:
-    """Generate a human-readable summary for a SDK ToolUseBlock."""
-    name = block.name
-    inp = block.input
+def _tool_summary(block: dict) -> str:
+    """Generate a human-readable summary for a tool use dict."""
+    name = block.get("name", "")
+    inp = block.get("input", {})
 
     if name == "Edit":
         return f"Edit: {inp.get('file_path', 'file')}"
@@ -1211,29 +1009,6 @@ def _tool_summary_sdk(block: ToolUseBlock) -> str:
     return name
 
 
-# Keep old helper for session history parsing (uses dicts, not SDK types)
-def _tool_summary(block: dict) -> str:
-    """Generate a human-readable summary for a tool use dict (JSONL parsing)."""
-    name = block.get("name", "")
-    inp = block.get("input", {})
-
-    if name == "Edit":
-        return f"Edit: {inp.get('file_path', 'file')}"
-    if name == "Write":
-        return f"Write: {inp.get('file_path', 'file')}"
-    if name == "Read":
-        return f"Read: {inp.get('file_path', 'file')}"
-    if name == "Bash":
-        cmd = inp.get("command", "")
-        return f"Run: {cmd[:80]}"
-    if name == "Glob":
-        return f"Search: {inp.get('pattern', '')}"
-    if name == "Grep":
-        return f"Grep: {inp.get('pattern', '')}"
-
-    return name
-
-
 _MERMAID_RE = re.compile(r"```mermaid\s*\n(.*?)\n```", re.DOTALL)
 
 
@@ -1248,7 +1023,7 @@ def _extract_mermaid_blocks(text: str) -> list[dict]:
 
 
 def _extract_images(content) -> list[dict]:
-    """Extract image data from SDK content blocks."""
+    """Extract image data from content blocks."""
     images = []
     if isinstance(content, list):
         for block in content:

--- a/charts/bosun/backend/tests/BUILD
+++ b/charts/bosun/backend/tests/BUILD
@@ -11,7 +11,6 @@ py_library(
     visibility = ["//:__subpackages__"],
     deps = [
         "//charts/bosun/backend:server_lib",
-        "@pip//claude_agent_sdk",
         "@pip//pytest",
     ],
 )
@@ -41,7 +40,6 @@ py_test(
     srcs = ["ws_lifecycle_test.py"],
     deps = [
         ":conftest",
-        "@pip//claude_agent_sdk",
         "@pip//pytest",
         "@pip//starlette",
     ],

--- a/charts/bosun/backend/tests/conftest.py
+++ b/charts/bosun/backend/tests/conftest.py
@@ -1,119 +1,146 @@
 """
 Shared fixtures and helpers for Bosun integration tests.
 
-Converts fixture JSON files into SDK types, mocks `server.query`,
-and provides WebSocket message collection utilities.
+Converts fixture JSON files into JSONL lines, mocks
+``asyncio.create_subprocess_exec`` with a ``MockProcess``, and provides
+WebSocket message collection utilities.
 
 This is a pytest conftest — fixtures are auto-discovered by tests
 in this directory without explicit imports.
 """
 
+import asyncio
 import json
 import sqlite3
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import patch, AsyncMock
 
 import pytest
 
 import charts.bosun.backend.server as server
-from claude_agent_sdk import (
-    SystemMessage,
-    AssistantMessage,
-    UserMessage,
-    ResultMessage,
-    TextBlock,
-    ToolUseBlock,
-    ToolResultBlock,
-)
-from claude_agent_sdk.types import StreamEvent
 
 FIXTURES_DIR = Path(__file__).parent / "fixtures"
 
 
-# ── SDK event builders ──────────────────────────────────────────────────────
+# ── Fixture → JSONL conversion ────────────────────────────────────────────
 
 
-def _build_sdk_event(desc: dict):
-    """Convert a fixture JSON dict into the corresponding SDK type."""
+def _fixture_to_jsonl(desc: dict) -> str:
+    """Convert a fixture JSON dict (with ``kind``) into a CLI JSONL line."""
     kind = desc["kind"]
 
     if kind == "system_init":
-        return SystemMessage(subtype="init", data=desc["data"])
+        return json.dumps(
+            {
+                "type": "system",
+                "subtype": "init",
+                "session_id": desc["data"].get("session_id", ""),
+            }
+        )
 
     if kind == "stream_event":
-        return StreamEvent(
-            uuid=desc["uuid"],
-            session_id=desc["session_id"],
-            event=desc["event"],
-            parent_tool_use_id=desc.get("parent_tool_use_id"),
+        return json.dumps(
+            {
+                "type": "stream_event",
+                "event": desc["event"],
+                "parent_tool_use_id": desc.get("parent_tool_use_id"),
+            }
         )
 
     if kind == "assistant":
-        blocks = []
-        for block_desc in desc["content"]:
-            btype = block_desc["type"]
-            if btype == "text":
-                blocks.append(TextBlock(text=block_desc["text"]))
-            elif btype == "tool_use":
-                blocks.append(
-                    ToolUseBlock(
-                        id=block_desc["id"],
-                        name=block_desc["name"],
-                        input=block_desc.get("input", {}),
-                    )
-                )
-            elif btype == "tool_result":
-                blocks.append(
-                    ToolResultBlock(
-                        tool_use_id=block_desc["tool_use_id"],
-                        content=block_desc.get("content", ""),
-                        is_error=block_desc.get("is_error", False),
-                    )
-                )
-        return AssistantMessage(
-            content=blocks,
-            model=desc.get("model", "claude-sonnet-4-5-20250929"),
-            parent_tool_use_id=desc.get("parent_tool_use_id"),
+        return json.dumps(
+            {
+                "type": "assistant",
+                "message": {
+                    "content": desc["content"],
+                    "model": desc.get("model", "claude-sonnet-4-5-20250929"),
+                },
+                "parent_tool_use_id": desc.get("parent_tool_use_id"),
+            }
         )
 
     if kind == "result":
-        return ResultMessage(
-            subtype=desc.get("subtype", "success"),
-            session_id=desc["session_id"],
-            duration_ms=desc.get("duration_ms", 0),
-            duration_api_ms=desc.get("duration_api_ms", 0),
-            total_cost_usd=desc.get("total_cost_usd", 0.0),
-            num_turns=desc.get("num_turns", 0),
-            result=desc.get("result", ""),
-            is_error=desc.get("is_error", False),
-            usage=desc.get("usage", {}),
-            structured_output=None,
+        return json.dumps(
+            {
+                "type": "result",
+                "subtype": desc.get("subtype", "success"),
+                "session_id": desc.get("session_id", ""),
+                "duration_ms": desc.get("duration_ms", 0),
+                "total_cost_usd": desc.get("total_cost_usd", 0.0),
+                "num_turns": desc.get("num_turns", 0),
+                "result": desc.get("result", ""),
+                "is_error": desc.get("is_error", False),
+            }
         )
 
     if kind == "user":
-        return UserMessage(
-            tool_use_result=desc.get("tool_use_result"),
+        return json.dumps(
+            {
+                "type": "user",
+                "tool_use_result": desc.get("tool_use_result"),
+            }
         )
 
     raise ValueError(f"Unknown fixture kind: {kind}")
 
 
-def build_sdk_events(fixture_name: str) -> list:
-    """Load a fixture JSON file and return a list of SDK event objects."""
+def build_jsonl_lines(fixture_name: str) -> list[bytes]:
+    """Load a fixture JSON file and return JSONL lines as bytes (with newline)."""
     fixture_path = FIXTURES_DIR / fixture_name
     with open(fixture_path) as f:
         descs = json.load(f)
-    return [_build_sdk_event(d) for d in descs]
+    return [(_fixture_to_jsonl(d) + "\n").encode() for d in descs]
 
 
-def make_mock_query(events: list):
-    """Return an async generator function that yields the given SDK events."""
+# ── Mock subprocess ───────────────────────────────────────────────────────
 
-    async def _mock_query(**kwargs):
-        for event in events:
-            yield event
 
-    return _mock_query
+class MockStdout:
+    """Async readline()-compatible stdout that yields pre-built JSONL lines."""
+
+    def __init__(self, lines: list[bytes]):
+        self._lines = list(lines)
+        self._index = 0
+
+    async def readline(self) -> bytes:
+        if self._index < len(self._lines):
+            line = self._lines[self._index]
+            self._index += 1
+            return line
+        return b""  # EOF
+
+
+class MockStderr:
+    """Async readline()-compatible stderr that is always empty."""
+
+    async def readline(self) -> bytes:
+        return b""
+
+
+class MockProcess:
+    """Mock of asyncio.subprocess.Process for testing."""
+
+    def __init__(self, stdout_lines: list[bytes]):
+        self.stdout = MockStdout(stdout_lines)
+        self.stderr = MockStderr()
+        self.returncode = 0
+        self.pid = 99999
+
+    async def wait(self):
+        return 0
+
+    def terminate(self):
+        pass
+
+
+def make_mock_subprocess(fixture_name: str):
+    """Return an async function that creates a MockProcess from a fixture file."""
+    lines = build_jsonl_lines(fixture_name)
+
+    async def _mock_create_subprocess_exec(*args, **kwargs):
+        return MockProcess(lines)
+
+    return _mock_create_subprocess_exec
 
 
 # ── WebSocket helpers ───────────────────────────────────────────────────────
@@ -143,7 +170,7 @@ def patched_server(tmp_path):
     Yields the server module with:
     - DB_PATH pointing to tmp_path/bosun.db
     - app.state.workdir set to tmp_path
-    - Caller patches server.query via: patch.object(server, "query", ...)
+    - Caller patches asyncio.create_subprocess_exec for the mock subprocess
     """
     db_path = tmp_path / "bosun.db"
 

--- a/charts/bosun/backend/tests/ws_artifacts_test.py
+++ b/charts/bosun/backend/tests/ws_artifacts_test.py
@@ -11,18 +11,17 @@ import pytest
 from starlette.testclient import TestClient
 
 from charts.bosun.backend.tests.conftest import (
-    build_sdk_events,
-    make_mock_query,
+    make_mock_subprocess,
     collect_ws_messages,
 )
 
 
 def test_mermaid_block_extracted(patched_server):
     """Mermaid code blocks in text produce mermaid_artifact WS messages."""
-    events = build_sdk_events("mermaid_response.json")
-    mock_query = make_mock_query(events)
-
-    with patch.object(patched_server, "query", side_effect=mock_query):
+    with patch(
+        "asyncio.create_subprocess_exec",
+        side_effect=make_mock_subprocess("mermaid_response.json"),
+    ):
         client = TestClient(patched_server.app)
         with client.websocket_connect("/ws") as ws:
             ws.send_json({"type": "message", "text": "Show me a diagram"})
@@ -41,10 +40,10 @@ def test_mermaid_block_extracted(patched_server):
 
 def test_no_mermaid_when_absent(patched_server):
     """No mermaid_artifact messages when text has no mermaid blocks."""
-    events = build_sdk_events("simple_text.json")
-    mock_query = make_mock_query(events)
-
-    with patch.object(patched_server, "query", side_effect=mock_query):
+    with patch(
+        "asyncio.create_subprocess_exec",
+        side_effect=make_mock_subprocess("simple_text.json"),
+    ):
         client = TestClient(patched_server.app)
         with client.websocket_connect("/ws") as ws:
             ws.send_json({"type": "message", "text": "Hello"})

--- a/charts/bosun/backend/tests/ws_lifecycle_test.py
+++ b/charts/bosun/backend/tests/ws_lifecycle_test.py
@@ -5,26 +5,26 @@ Validates session_init, cancel, and new_session behavior.
 """
 
 import asyncio
+import json
 from unittest.mock import patch
 
 import pytest
 from starlette.testclient import TestClient
 
-from claude_agent_sdk import SystemMessage, ResultMessage
-
 from charts.bosun.backend.tests.conftest import (
-    build_sdk_events,
-    make_mock_query,
+    build_jsonl_lines,
+    make_mock_subprocess,
+    MockProcess,
     collect_ws_messages,
 )
 
 
 def test_session_init_on_first_message(patched_server):
     """session_init must be the first WS message received after sending a prompt."""
-    events = build_sdk_events("simple_text.json")
-    mock_query = make_mock_query(events)
-
-    with patch.object(patched_server, "query", side_effect=mock_query):
+    with patch(
+        "asyncio.create_subprocess_exec",
+        side_effect=make_mock_subprocess("simple_text.json"),
+    ):
         client = TestClient(patched_server.app)
         with client.websocket_connect("/ws") as ws:
             ws.send_json({"type": "message", "text": "Hello"})
@@ -38,23 +38,54 @@ def test_session_init_on_first_message(patched_server):
 def test_cancel_sends_cancelled(patched_server):
     """Sending 'cancel' type produces a 'cancelled' WS message."""
 
-    async def _slow_query(**kwargs):
-        yield SystemMessage(subtype="init", data={"session_id": "test-cancel-001"})
-        await asyncio.sleep(5)
-        yield ResultMessage(
-            subtype="success",
-            session_id="test-cancel-001",
-            duration_ms=100,
-            duration_api_ms=0,
-            total_cost_usd=0.0,
-            num_turns=0,
-            result="",
-            is_error=False,
-            usage={},
-            structured_output=None,
-        )
+    class SlowMockStdout:
+        """Stdout that yields init then blocks until cancelled."""
 
-    with patch.object(patched_server, "query", side_effect=_slow_query):
+        def __init__(self):
+            self._init_sent = False
+            self._event = asyncio.Event()
+
+        async def readline(self) -> bytes:
+            if not self._init_sent:
+                self._init_sent = True
+                return (
+                    json.dumps(
+                        {
+                            "type": "system",
+                            "subtype": "init",
+                            "session_id": "test-cancel-001",
+                        }
+                    )
+                    + "\n"
+                ).encode()
+            # Block until the process is terminated
+            try:
+                await asyncio.wait_for(self._event.wait(), timeout=10)
+            except asyncio.TimeoutError:
+                pass
+            return b""
+
+    class SlowMockProcess:
+        def __init__(self):
+            self.stdout = SlowMockStdout()
+            from charts.bosun.backend.tests.conftest import MockStderr
+
+            self.stderr = MockStderr()
+            self.returncode = None
+            self.pid = 99998
+
+        async def wait(self):
+            self.returncode = -15  # SIGTERM
+            return self.returncode
+
+        def terminate(self):
+            self.returncode = -15
+            self.stdout._event.set()
+
+    async def _slow_subprocess(*args, **kwargs):
+        return SlowMockProcess()
+
+    with patch("asyncio.create_subprocess_exec", side_effect=_slow_subprocess):
         client = TestClient(patched_server.app)
         with client.websocket_connect("/ws") as ws:
             ws.send_json({"type": "message", "text": "Do something slow"})
@@ -82,18 +113,15 @@ def test_cancel_sends_cancelled(patched_server):
 
 def test_new_session_resets(patched_server):
     """Sending 'new_session' allows a fresh session on next message."""
-    events1 = build_sdk_events("simple_text.json")
-    events2 = build_sdk_events("simple_text.json")
     call_count = 0
 
-    async def _multi_query(**kwargs):
+    async def _multi_subprocess(*args, **kwargs):
         nonlocal call_count
         call_count += 1
-        src = events1 if call_count == 1 else events2
-        for event in src:
-            yield event
+        lines = build_jsonl_lines("simple_text.json")
+        return MockProcess(lines)
 
-    with patch.object(patched_server, "query", side_effect=_multi_query):
+    with patch("asyncio.create_subprocess_exec", side_effect=_multi_subprocess):
         client = TestClient(patched_server.app)
         with client.websocket_connect("/ws") as ws:
             # First message

--- a/charts/bosun/backend/tests/ws_streaming_test.py
+++ b/charts/bosun/backend/tests/ws_streaming_test.py
@@ -12,18 +12,17 @@ import pytest
 from starlette.testclient import TestClient
 
 from charts.bosun.backend.tests.conftest import (
-    build_sdk_events,
-    make_mock_query,
+    make_mock_subprocess,
     collect_ws_messages,
 )
 
 
 def test_simple_text_streaming(patched_server):
     """Simple text response produces correct message sequence."""
-    events = build_sdk_events("simple_text.json")
-    mock_query = make_mock_query(events)
-
-    with patch.object(patched_server, "query", side_effect=mock_query):
+    with patch(
+        "asyncio.create_subprocess_exec",
+        side_effect=make_mock_subprocess("simple_text.json"),
+    ):
         client = TestClient(patched_server.app)
         with client.websocket_connect("/ws") as ws:
             ws.send_json({"type": "message", "text": "Say hello"})
@@ -45,10 +44,10 @@ def test_simple_text_streaming(patched_server):
 
 def test_assistant_text_has_content_not_full_text(patched_server):
     """assistant_text carries streaming 'content' but never 'full_text'."""
-    events = build_sdk_events("simple_text.json")
-    mock_query = make_mock_query(events)
-
-    with patch.object(patched_server, "query", side_effect=mock_query):
+    with patch(
+        "asyncio.create_subprocess_exec",
+        side_effect=make_mock_subprocess("simple_text.json"),
+    ):
         client = TestClient(patched_server.app)
         with client.websocket_connect("/ws") as ws:
             ws.send_json({"type": "message", "text": "Say hello"})
@@ -67,10 +66,10 @@ def test_assistant_text_has_content_not_full_text(patched_server):
 
 def test_result_has_full_text(patched_server):
     """The result message carries full_text for TTS."""
-    events = build_sdk_events("simple_text.json")
-    mock_query = make_mock_query(events)
-
-    with patch.object(patched_server, "query", side_effect=mock_query):
+    with patch(
+        "asyncio.create_subprocess_exec",
+        side_effect=make_mock_subprocess("simple_text.json"),
+    ):
         client = TestClient(patched_server.app)
         with client.websocket_connect("/ws") as ws:
             ws.send_json({"type": "message", "text": "Say hello"})
@@ -88,10 +87,10 @@ def test_result_has_full_text(patched_server):
 
 def test_tool_then_text_streaming(patched_server):
     """Text + tool + text sequence produces all expected message types in order."""
-    events = build_sdk_events("tool_use_flow.json")
-    mock_query = make_mock_query(events)
-
-    with patch.object(patched_server, "query", side_effect=mock_query):
+    with patch(
+        "asyncio.create_subprocess_exec",
+        side_effect=make_mock_subprocess("tool_use_flow.json"),
+    ):
         client = TestClient(patched_server.app)
         with client.websocket_connect("/ws") as ws:
             ws.send_json({"type": "message", "text": "Check the file"})
@@ -117,10 +116,10 @@ def test_result_has_full_text_after_tool_turn(patched_server):
     When a turn includes tool calls, the result message must contain the accumulated
     full_text from all streaming blocks, not just the tool results.
     """
-    events = build_sdk_events("tool_use_flow.json")
-    mock_query = make_mock_query(events)
-
-    with patch.object(patched_server, "query", side_effect=mock_query):
+    with patch(
+        "asyncio.create_subprocess_exec",
+        side_effect=make_mock_subprocess("tool_use_flow.json"),
+    ):
         client = TestClient(patched_server.app)
         with client.websocket_connect("/ws") as ws:
             ws.send_json({"type": "message", "text": "Check the file"})

--- a/charts/bosun/backend/tests/ws_tools_test.py
+++ b/charts/bosun/backend/tests/ws_tools_test.py
@@ -11,18 +11,17 @@ import pytest
 from starlette.testclient import TestClient
 
 from charts.bosun.backend.tests.conftest import (
-    build_sdk_events,
-    make_mock_query,
+    make_mock_subprocess,
     collect_ws_messages,
 )
 
 
 def test_tool_use_has_name_and_id(patched_server):
     """tool_use WS messages must have name, tool_use_id, and summary."""
-    events = build_sdk_events("tool_use_flow.json")
-    mock_query = make_mock_query(events)
-
-    with patch.object(patched_server, "query", side_effect=mock_query):
+    with patch(
+        "asyncio.create_subprocess_exec",
+        side_effect=make_mock_subprocess("tool_use_flow.json"),
+    ):
         client = TestClient(patched_server.app)
         with client.websocket_connect("/ws") as ws:
             ws.send_json({"type": "message", "text": "Read the file"})
@@ -39,10 +38,10 @@ def test_tool_use_has_name_and_id(patched_server):
 
 def test_tool_result_has_output(patched_server):
     """tool_result WS messages must have output field."""
-    events = build_sdk_events("tool_use_flow.json")
-    mock_query = make_mock_query(events)
-
-    with patch.object(patched_server, "query", side_effect=mock_query):
+    with patch(
+        "asyncio.create_subprocess_exec",
+        side_effect=make_mock_subprocess("tool_use_flow.json"),
+    ):
         client = TestClient(patched_server.app)
         with client.websocket_connect("/ws") as ws:
             ws.send_json({"type": "message", "text": "Read the file"})
@@ -57,10 +56,10 @@ def test_tool_result_has_output(patched_server):
 
 def test_tool_error_has_is_error(patched_server):
     """Tool results with is_error=true must propagate is_error in the WS message."""
-    events = build_sdk_events("tool_error.json")
-    mock_query = make_mock_query(events)
-
-    with patch.object(patched_server, "query", side_effect=mock_query):
+    with patch(
+        "asyncio.create_subprocess_exec",
+        side_effect=make_mock_subprocess("tool_error.json"),
+    ):
         client = TestClient(patched_server.app)
         with client.websocket_connect("/ws") as ws:
             ws.send_json({"type": "message", "text": "Run the command"})
@@ -77,10 +76,10 @@ def test_tool_error_has_is_error(patched_server):
 
 def test_tool_use_no_full_text(patched_server):
     """tool_use messages must never carry full_text (TTS field)."""
-    events = build_sdk_events("tool_use_flow.json")
-    mock_query = make_mock_query(events)
-
-    with patch.object(patched_server, "query", side_effect=mock_query):
+    with patch(
+        "asyncio.create_subprocess_exec",
+        side_effect=make_mock_subprocess("tool_use_flow.json"),
+    ):
         client = TestClient(patched_server.app)
         with client.websocket_connect("/ws") as ws:
             ws.send_json({"type": "message", "text": "Read the file"})
@@ -89,8 +88,3 @@ def test_tool_use_no_full_text(patched_server):
     tool_uses = [m for m in received if m["type"] == "tool_use"]
     for tu in tool_uses:
         assert "full_text" not in tu, f"tool_use should not have full_text: {tu}"
-
-
-# NOTE: test_tool_result_image removed — server.py line 730 has a bug
-# accessing block.name on ToolResultBlock (should use getattr).
-# Re-enable after fixing: https://github.com/jomcgi/homelab/issues/XXX

--- a/charts/bosun/backend/tts_on_result_test.py
+++ b/charts/bosun/backend/tts_on_result_test.py
@@ -14,114 +14,86 @@ from unittest.mock import patch, AsyncMock
 
 import pytest
 
-# We need to mock the SDK before importing server.py, since server.py
-# imports from claude_agent_sdk at module level.
-
-from claude_agent_sdk import (
-    SystemMessage,
-    AssistantMessage,
-    ResultMessage,
-    ToolUseBlock,
-    ToolResultBlock,
+from charts.bosun.backend.tests.conftest import (
+    MockProcess,
+    MockStderr,
 )
-from claude_agent_sdk.types import StreamEvent
 
 
-def _make_stream_events():
-    """Create a realistic sequence of SDK messages for a simple query.
-
-    Simulates: system init -> streaming text -> tool use -> tool result
-    -> more text -> result.
-    """
-    return [
-        # 1. Session init
-        SystemMessage(subtype="init", data={"session_id": "test-session-123"}),
-        # 2. Streaming text start
-        StreamEvent(
-            uuid="e1",
-            session_id="test-session-123",
-            event={"type": "content_block_start", "content_block": {"type": "text"}},
-            parent_tool_use_id=None,
-        ),
-        # 3. Text delta
-        StreamEvent(
-            uuid="e2",
-            session_id="test-session-123",
-            event={
+def _make_jsonl_lines():
+    """Create JSONL lines simulating: init -> text -> tool -> text -> result."""
+    events = [
+        {"type": "system", "subtype": "init", "session_id": "test-session-123"},
+        {
+            "type": "stream_event",
+            "event": {"type": "content_block_start", "content_block": {"type": "text"}},
+        },
+        {
+            "type": "stream_event",
+            "event": {
                 "type": "content_block_delta",
                 "delta": {"type": "text_delta", "text": "Let me check that file."},
             },
-            parent_tool_use_id=None,
-        ),
-        # 4. Message stop (finalize first text block)
-        StreamEvent(
-            uuid="e3",
-            session_id="test-session-123",
-            event={"type": "message_stop"},
-            parent_tool_use_id=None,
-        ),
-        # 5. Tool use (Read)
-        AssistantMessage(
-            content=[
-                ToolUseBlock(
-                    id="tu-1", name="Read", input={"file_path": "/tmp/test.py"}
-                ),
-            ],
-            model="claude-sonnet-4-5-20250929",
-            parent_tool_use_id=None,
-        ),
-        # 6. Tool result
-        AssistantMessage(
-            content=[
-                ToolResultBlock(
-                    tool_use_id="tu-1", content="print('hello')", is_error=False
-                ),
-            ],
-            model="claude-sonnet-4-5-20250929",
-            parent_tool_use_id=None,
-        ),
-        # 7. More streaming text
-        StreamEvent(
-            uuid="e4",
-            session_id="test-session-123",
-            event={"type": "content_block_start", "content_block": {"type": "text"}},
-            parent_tool_use_id=None,
-        ),
-        StreamEvent(
-            uuid="e5",
-            session_id="test-session-123",
-            event={
+        },
+        {"type": "stream_event", "event": {"type": "message_stop"}},
+        {
+            "type": "assistant",
+            "message": {
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": "tu-1",
+                        "name": "Read",
+                        "input": {"file_path": "/tmp/test.py"},
+                    }
+                ],
+                "model": "claude-sonnet-4-5-20250929",
+            },
+            "parent_tool_use_id": None,
+        },
+        {
+            "type": "assistant",
+            "message": {
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "tu-1",
+                        "content": "print('hello')",
+                        "is_error": False,
+                    }
+                ],
+                "model": "claude-sonnet-4-5-20250929",
+            },
+            "parent_tool_use_id": None,
+        },
+        {
+            "type": "stream_event",
+            "event": {"type": "content_block_start", "content_block": {"type": "text"}},
+        },
+        {
+            "type": "stream_event",
+            "event": {
                 "type": "content_block_delta",
                 "delta": {"type": "text_delta", "text": "The file looks good."},
             },
-            parent_tool_use_id=None,
-        ),
-        StreamEvent(
-            uuid="e6",
-            session_id="test-session-123",
-            event={"type": "message_stop"},
-            parent_tool_use_id=None,
-        ),
-        # 8. Final result
-        ResultMessage(
-            subtype="success",
-            duration_ms=1500,
-            duration_api_ms=1200,
-            is_error=False,
-            num_turns=2,
-            session_id="test-session-123",
-            total_cost_usd=0.005,
-            usage={"input_tokens": 100, "output_tokens": 50},
-            result="The file looks good.",
-            structured_output=None,
-        ),
+        },
+        {"type": "stream_event", "event": {"type": "message_stop"}},
+        {
+            "type": "result",
+            "subtype": "success",
+            "session_id": "test-session-123",
+            "duration_ms": 1500,
+            "total_cost_usd": 0.005,
+            "num_turns": 2,
+            "result": "The file looks good.",
+            "is_error": False,
+        },
     ]
+    return [(json.dumps(e) + "\n").encode() for e in events]
 
 
-async def _mock_query(**kwargs):
-    """Async generator that yields the mock SDK messages."""
-    for msg in _make_stream_events():
-        yield msg
+async def _mock_subprocess(*args, **kwargs):
+    return MockProcess(_make_jsonl_lines())
 
 
 @pytest.mark.asyncio
@@ -132,7 +104,7 @@ async def test_tts_fires_only_on_result():
     only when msg.type === 'result'. If full_text leaked into other message
     types, TTS would fire prematurely (e.g., on each streaming chunk).
     """
-    with patch("server.query", side_effect=_mock_query):
+    with patch("asyncio.create_subprocess_exec", side_effect=_mock_subprocess):
         import charts.bosun.backend.server as server
 
         from starlette.testclient import TestClient
@@ -148,7 +120,6 @@ async def test_tts_fires_only_on_result():
             ws.send_json({"type": "message", "text": "Check the file /tmp/test.py"})
 
             # Collect all messages until we get a "result"
-            deadline = asyncio.get_event_loop().time() + 10
             while True:
                 try:
                     data = ws.receive_json(mode="text")
@@ -165,7 +136,6 @@ async def test_tts_fires_only_on_result():
 
     # Extract message types
     types_seen = [m["type"] for m in received]
-    print(f"Message types received: {types_seen}")
 
     # Must have these event types (proves the full pipeline ran)
     assert "session_init" in types_seen, "Missing session_init"
@@ -188,7 +158,6 @@ async def test_tts_fires_only_on_result():
         elif msg["type"] == "assistant_done":
             # assistant_done carries full_text too, but this is the per-block text,
             # not the TTS trigger. The frontend doesn't call tts.speak on this.
-            # This is fine — it's the "result" type that matters.
             pass
         else:
             # No other message type should contain full_text
@@ -199,24 +168,17 @@ async def test_tts_fires_only_on_result():
                 )
 
     # ── Verify intermediate messages DON'T trigger TTS ──────────────
-    # assistant_text should only carry 'content' (streaming chunk), not full_text
     text_msgs = [m for m in received if m["type"] == "assistant_text"]
     for m in text_msgs:
         assert "content" in m, "assistant_text missing content field"
         assert "full_text" not in m, "assistant_text should not have full_text"
 
-    # tool_use should carry name/summary, not full_text
     tool_msgs = [m for m in received if m["type"] == "tool_use"]
     for m in tool_msgs:
         assert "name" in m, "tool_use missing name"
         assert "full_text" not in m, "tool_use should not have full_text"
 
-    # tool_result should carry output, not full_text
     result_msgs = [m for m in received if m["type"] == "tool_result"]
     for m in result_msgs:
         assert "output" in m, "tool_result missing output"
         assert "full_text" not in m, "tool_result should not have full_text"
-
-    print("\nAll assertions passed: TTS fires only on 'result' message.")
-    print(f"Total messages: {len(received)}")
-    print(f"Result full_text: {received[-1].get('full_text', '')[:80]}...")

--- a/charts/bosun/frontend/e2e/mock-server.py
+++ b/charts/bosun/frontend/e2e/mock-server.py
@@ -2,109 +2,22 @@
 """
 Mock server for Playwright e2e tests.
 
-Patches server.query with a mock that yields a deterministic fixture sequence,
-then serves the Bosun frontend on port 8420.
+Patches asyncio.create_subprocess_exec with a mock that yields a deterministic
+JSONL fixture sequence, then serves the Bosun frontend on port 8420.
 """
 
 import asyncio
+import json
 import sys
 import types
 from pathlib import Path
-from unittest.mock import AsyncMock
+from unittest.mock import patch
 
 # Add backend to path so we can import the server module
 backend_dir = Path(__file__).resolve().parent.parent.parent / "backend"
 sys.path.insert(0, str(backend_dir))
 
-# -- Mock the claude_agent_sdk before importing server -----------------------
-
-mock_sdk = types.ModuleType("claude_agent_sdk")
-mock_sdk_types = types.ModuleType("claude_agent_sdk.types")
-
-
-class SystemMessage:
-    def __init__(self, **kwargs):
-        self.type = "system"
-        self.__dict__.update(kwargs)
-
-
-class ResultMessage:
-    def __init__(self, **kwargs):
-        self.type = "result"
-        self.__dict__.update(kwargs)
-
-
-class StreamEvent:
-    def __init__(self, **kwargs):
-        self.type = "stream_event"
-        self.__dict__.update(kwargs)
-
-    class ContentBlockStart:
-        def __init__(self, content_block=None):
-            self.type = "content_block_start"
-            self.content_block = content_block
-
-    class ContentBlockDelta:
-        def __init__(self, delta=None):
-            self.type = "content_block_delta"
-            self.delta = delta
-
-    class MessageStop:
-        def __init__(self):
-            self.type = "message_stop"
-
-
-class TextBlock:
-    def __init__(self, text=""):
-        self.type = "text"
-        self.text = text
-
-
-class ToolUseBlock:
-    def __init__(self, **kwargs):
-        self.type = "tool_use"
-        self.__dict__.update(kwargs)
-
-
-class ToolResultBlock:
-    def __init__(self, **kwargs):
-        self.type = "tool_result"
-        self.__dict__.update(kwargs)
-
-
-class AssistantMessage:
-    def __init__(self, **kwargs):
-        self.type = "assistant"
-        self.__dict__.update(kwargs)
-
-
-class UserMessage:
-    def __init__(self, **kwargs):
-        self.type = "user"
-        self.__dict__.update(kwargs)
-
-
-class ClaudeAgentOptions:
-    def __init__(self, **kwargs):
-        self.__dict__.update(kwargs)
-
-
-# Install mock SDK types
-mock_sdk.query = None  # will be patched below
-mock_sdk.ClaudeAgentOptions = ClaudeAgentOptions
-mock_sdk.SystemMessage = SystemMessage
-mock_sdk.AssistantMessage = AssistantMessage
-mock_sdk.UserMessage = UserMessage
-mock_sdk.ResultMessage = ResultMessage
-mock_sdk.TextBlock = TextBlock
-mock_sdk.ToolUseBlock = ToolUseBlock
-mock_sdk.ToolResultBlock = ToolResultBlock
-mock_sdk_types.StreamEvent = StreamEvent
-
-sys.modules["claude_agent_sdk"] = mock_sdk
-sys.modules["claude_agent_sdk.types"] = mock_sdk_types
-
-# Also mock google genai so server doesn't need it
+# Mock google genai so server doesn't need it
 mock_google = types.ModuleType("google")
 mock_genai = types.ModuleType("google.genai")
 mock_genai_types = types.ModuleType("google.genai.types")
@@ -115,44 +28,94 @@ sys.modules["google.genai"] = mock_genai
 sys.modules["google.genai.types"] = mock_genai_types
 
 
-# -- Mock query function ----------------------------------------------------
+# -- Mock subprocess --------------------------------------------------------
 
 
-async def mock_query(**kwargs):
-    """Yield a deterministic fixture: init -> text stream -> message_stop -> result."""
+class MockStdout:
+    def __init__(self):
+        self._lines = [
+            json.dumps(
+                {"type": "system", "subtype": "init", "session_id": "mock-session-id"}
+            )
+            + "\n",
+            json.dumps(
+                {
+                    "type": "stream_event",
+                    "event": {
+                        "type": "content_block_start",
+                        "content_block": {"type": "text"},
+                    },
+                }
+            )
+            + "\n",
+            json.dumps(
+                {
+                    "type": "stream_event",
+                    "event": {
+                        "type": "content_block_delta",
+                        "delta": {"type": "text_delta", "text": "Hello from mock"},
+                    },
+                }
+            )
+            + "\n",
+            json.dumps({"type": "stream_event", "event": {"type": "message_stop"}})
+            + "\n",
+            json.dumps(
+                {
+                    "type": "result",
+                    "subtype": "success",
+                    "session_id": "mock-session-id",
+                    "duration_ms": 100,
+                    "total_cost_usd": 0.001,
+                    "num_turns": 1,
+                    "result": "Hello from mock",
+                    "is_error": False,
+                }
+            )
+            + "\n",
+        ]
+        self._index = 0
 
-    # 1. SystemMessage (init)
-    yield SystemMessage(message="session_init")
-
-    # 2. StreamEvent: text content "Hello from mock"
-    yield StreamEvent(
-        event=StreamEvent.ContentBlockStart(content_block=TextBlock(text=""))
-    )
-    yield StreamEvent(
-        event=StreamEvent.ContentBlockDelta(
-            delta=types.SimpleNamespace(type="text_delta", text="Hello from mock")
-        )
-    )
-    yield StreamEvent(event=StreamEvent.MessageStop())
-
-    # 3. ResultMessage
-    yield ResultMessage(
-        text="Hello from mock",
-        session_id=kwargs.get("options", ClaudeAgentOptions()).session_id
-        if hasattr(kwargs.get("options", ClaudeAgentOptions()), "session_id")
-        else "mock-session-id",
-    )
+    async def readline(self):
+        if self._index < len(self._lines):
+            line = self._lines[self._index].encode()
+            self._index += 1
+            return line
+        return b""
 
 
-mock_sdk.query = mock_query
+class MockStderr:
+    async def readline(self):
+        return b""
+
+
+class MockProcess:
+    def __init__(self):
+        self.stdout = MockStdout()
+        self.stderr = MockStderr()
+        self.returncode = 0
+        self.pid = 99999
+
+    async def wait(self):
+        return 0
+
+    def terminate(self):
+        pass
+
+
+async def mock_create_subprocess(*args, **kwargs):
+    return MockProcess()
+
 
 # -- Import and configure the server ----------------------------------------
 
+# Patch create_subprocess_exec before importing server so the first call works
+_orig_create = asyncio.create_subprocess_exec
+asyncio.create_subprocess_exec = mock_create_subprocess
+
 import server  # noqa: E402
 
-server.HAS_SDK = True
 server.HAS_GEMINI = False
-server.query = mock_query
 server.app.state.workdir = "/tmp"
 
 # Serve static files from dist/ if it exists

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,6 @@ dependencies = [
     "lxml-html-clean",  # Required by trafilatura; added explicitly because lxml[html-clean] creates a Bazel cycle
     # Bosun (Claude Code web interface) dependencies
     "google-genai~=1.56",
-    "claude-agent-sdk~=0.1.39",
 ]
 
 # See https://docs.astral.sh/ruff/configuration/

--- a/requirements/all.txt
+++ b/requirements/all.txt
@@ -167,11 +167,8 @@ anyio==4.11.0 \
     # via
     #   -c requirements/runtime.txt
     #   -r requirements/runtime.txt
-    #   claude-agent-sdk
     #   google-genai
     #   httpx
-    #   mcp
-    #   sse-starlette
     #   starlette
     #   watchfiles
 apscheduler==3.11.0 \
@@ -210,9 +207,7 @@ attrs==25.4.0 \
     #   cattrs
     #   fiona
     #   jsii
-    #   jsonschema
     #   rasterio
-    #   referencing
     #   requests-cache
 babel==2.18.0 \
     --hash=sha256:b80b99a14bd085fcacfa15c9165f651fbb3406e66cc603abf11c5750937c992d \
@@ -618,15 +613,6 @@ charset-normalizer==3.4.4 \
     #   htmldate
     #   requests
     #   trafilatura
-claude-agent-sdk==0.1.39 \
-    --hash=sha256:0c03b5a3772eaec42e29ea39240c7d24b760358082f2e36336db9e71dde3dda4 \
-    --hash=sha256:6ed6a79781f545b761b9fe467bc5ae213a103c9d3f0fe7a9dad3c01790ed58fa \
-    --hash=sha256:d03324daf7076be79d2dd05944559aabf4cc11c98d3a574b992a442a7c7a26d6 \
-    --hash=sha256:d2665c9e87b6ffece590bcdd6eb9def47cde4809b0d2f66e0a61a719189be7c9 \
-    --hash=sha256:dcf0ebd5a638c9a7d9f3af7640932a9212b2705b7056e4f08bd3968a865b4268
-    # via
-    #   -c requirements/runtime.txt
-    #   -r requirements/runtime.txt
 click==8.3.0 \
     --hash=sha256:9b9f285302c6e3064f4330c05f05b81945b2a39544279343e6e7c5f27a9baddc \
     --hash=sha256:e7b8232224eba16f4ebe410c25ced9f7875cb5f3263ffc93cc3e8da705e229c4
@@ -1177,14 +1163,6 @@ httpx==0.28.1 \
     #   -c requirements/runtime.txt
     #   -r requirements/runtime.txt
     #   google-genai
-    #   mcp
-httpx-sse==0.4.3 \
-    --hash=sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc \
-    --hash=sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d
-    # via
-    #   -c requirements/runtime.txt
-    #   -r requirements/runtime.txt
-    #   mcp
 idna==3.11 \
     --hash=sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea \
     --hash=sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902
@@ -1252,20 +1230,6 @@ jsii==1.125.0 \
     #   -r requirements/runtime.txt
     #   cdk8s
     #   constructs
-jsonschema==4.26.0 \
-    --hash=sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326 \
-    --hash=sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce
-    # via
-    #   -c requirements/runtime.txt
-    #   -r requirements/runtime.txt
-    #   mcp
-jsonschema-specifications==2025.9.1 \
-    --hash=sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe \
-    --hash=sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d
-    # via
-    #   -c requirements/runtime.txt
-    #   -r requirements/runtime.txt
-    #   jsonschema
 justext==3.0.2 \
     --hash=sha256:13496a450c44c4cd5b5a75a5efcd9996066d2a189794ea99a49949685a0beb05 \
     --hash=sha256:62b1c562b15c3c6265e121cc070874243a443bfd53060e869393f09d6b6cc9a7
@@ -1537,13 +1501,6 @@ markupsafe==3.0.3 \
     #   -r requirements/runtime.txt
     #   jinja2
     #   mako
-mcp==1.12.4 \
-    --hash=sha256:0765585e9a3a5916a3c3ab8659330e493adc7bd8b2ca6120c2d7a0c43e034ca5 \
-    --hash=sha256:7aa884648969fab8e78b89399d59a683202972e12e6bc9a1c88ce7eda7743789
-    # via
-    #   -c requirements/runtime.txt
-    #   -r requirements/runtime.txt
-    #   claude-agent-sdk
 mdurl==0.1.2 \
     --hash=sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8 \
     --hash=sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba
@@ -2441,7 +2398,6 @@ pydantic==2.12.3 \
     #   copier
     #   fastapi
     #   google-genai
-    #   mcp
     #   open-gopro
     #   pydantic-extra-types
     #   pydantic-settings
@@ -2580,7 +2536,6 @@ pydantic-settings==2.11.0 \
     # via
     #   -c requirements/runtime.txt
     #   -r requirements/runtime.txt
-    #   mcp
 pydantic-sqlite==0.3.0 \
     --hash=sha256:62efe8437c279e6b47e09ddc5a718ebfb0d91cbbdc28b2f8b80f0f7b07590799 \
     --hash=sha256:cc9d3c1b01582f8f26b988fc58fdbd2f5dea4d1a7d76b80e1394f8c11d7831e8
@@ -2766,7 +2721,6 @@ python-multipart==0.0.20 \
     # via
     #   -c requirements/runtime.txt
     #   -r requirements/runtime.txt
-    #   mcp
 pytz==2024.2 \
     --hash=sha256:2aa355083c50a0f93fa581709deac0c9ad65cca8a9e9beac660adcbd493c798a \
     --hash=sha256:31c7c1817eb7fae7ca4b8c7ee50c72f93aa2dd863de768e1ef4245d426aa0725
@@ -2776,7 +2730,7 @@ pytz==2024.2 \
     #   dateparser
     #   open-gopro
     #   pandas
-pywin32==311 ; sys_platform == 'win32' \
+pywin32==311 ; platform_python_implementation != 'PyPy' and sys_platform == 'win32' \
     --hash=sha256:0502d1facf1fed4839a9a51ccbcc63d952cf318f78ffc00a7e78528ac27d7a2b \
     --hash=sha256:184eb5e436dea364dcd3d2316d577d625c0351bf237c4e9a5fabbcfa5a58b151 \
     --hash=sha256:3aca44c046bd2ed8c90de9cb8427f581c479e594e99b5c0bb19b29c10fd6cb87 \
@@ -2797,11 +2751,7 @@ pywin32==311 ; sys_platform == 'win32' \
     --hash=sha256:e0c4cfb0621281fe40387df582097fd796e80430597cb9944f0ae70447bacd91 \
     --hash=sha256:e286f46a9a39c4a18b319c28f59b61de793654af2f395c102b4f819e584b5852 \
     --hash=sha256:f95ba5a847cba10dd8c4d8fefa9f2a6cf283b8b88ed6178fa8a6c1ab16054d0d
-    # via
-    #   -c requirements/runtime.txt
-    #   -r requirements/runtime.txt
-    #   mcp
-    #   plumbum
+    # via plumbum
 pyyaml==6.0.3 \
     --hash=sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c \
     --hash=sha256:0150219816b6a1fa26fb4699fb7daa9caf09eb1999f3b70fb6e786805e80375a \
@@ -2911,14 +2861,6 @@ rasterio==1.4.3 \
     # via
     #   -c requirements/runtime.txt
     #   -r requirements/runtime.txt
-referencing==0.37.0 \
-    --hash=sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231 \
-    --hash=sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8
-    # via
-    #   -c requirements/runtime.txt
-    #   -r requirements/runtime.txt
-    #   jsonschema
-    #   jsonschema-specifications
 regex==2026.1.15 \
     --hash=sha256:0057de9eaef45783ff69fa94ae9f0fd906d629d0bd4c3217048f46d1daa32e9b \
     --hash=sha256:008b185f235acd1e53787333e5690082e4f156c44c87d894f880056089e9bc7c \
@@ -3088,127 +3030,6 @@ rich==14.2.0 \
     #   -r requirements/runtime.txt
     #   open-gopro
     #   typer
-rpds-py==0.30.0 \
-    --hash=sha256:07ae8a593e1c3c6b82ca3292efbe73c30b61332fd612e05abee07c79359f292f \
-    --hash=sha256:0a59119fc6e3f460315fe9d08149f8102aa322299deaa5cab5b40092345c2136 \
-    --hash=sha256:0c0e95f6819a19965ff420f65578bacb0b00f251fefe2c8b23347c37174271f3 \
-    --hash=sha256:0d08f00679177226c4cb8c5265012eea897c8ca3b93f429e546600c971bcbae7 \
-    --hash=sha256:0ed177ed9bded28f8deb6ab40c183cd1192aa0de40c12f38be4d59cd33cb5c65 \
-    --hash=sha256:12f90dd7557b6bd57f40abe7747e81e0c0b119bef015ea7726e69fe550e394a4 \
-    --hash=sha256:1726859cd0de969f88dc8673bdd954185b9104e05806be64bcd87badbe313169 \
-    --hash=sha256:1ab5b83dbcf55acc8b08fc62b796ef672c457b17dbd7820a11d6c52c06839bdf \
-    --hash=sha256:1b151685b23929ab7beec71080a8889d4d6d9fa9a983d213f07121205d48e2c4 \
-    --hash=sha256:1f3587eb9b17f3789ad50824084fa6f81921bbf9a795826570bda82cb3ed91f2 \
-    --hash=sha256:250fa00e9543ac9b97ac258bd37367ff5256666122c2d0f2bc97577c60a1818c \
-    --hash=sha256:2771c6c15973347f50fece41fc447c054b7ac2ae0502388ce3b6738cd366e3d4 \
-    --hash=sha256:27f4b0e92de5bfbc6f86e43959e6edd1425c33b5e69aab0984a72047f2bcf1e3 \
-    --hash=sha256:2e6ecb5a5bcacf59c3f912155044479af1d0b6681280048b338b28e364aca1f6 \
-    --hash=sha256:32c8528634e1bf7121f3de08fa85b138f4e0dc47657866630611b03967f041d7 \
-    --hash=sha256:33f559f3104504506a44bb666b93a33f5d33133765b0c216a5bf2f1e1503af89 \
-    --hash=sha256:3896fa1be39912cf0757753826bc8bdc8ca331a28a7c4ae46b7a21280b06bb85 \
-    --hash=sha256:389a2d49eded1896c3d48b0136ead37c48e221b391c052fba3f4055c367f60a6 \
-    --hash=sha256:39c02563fc592411c2c61d26b6c5fe1e51eaa44a75aa2c8735ca88b0d9599daa \
-    --hash=sha256:3adbb8179ce342d235c31ab8ec511e66c73faa27a47e076ccc92421add53e2bb \
-    --hash=sha256:3d4a69de7a3e50ffc214ae16d79d8fbb0922972da0356dcf4d0fdca2878559c6 \
-    --hash=sha256:3e62880792319dbeb7eb866547f2e35973289e7d5696c6e295476448f5b63c87 \
-    --hash=sha256:3e8eeb0544f2eb0d2581774be4c3410356eba189529a6b3e36bbbf9696175856 \
-    --hash=sha256:422c3cb9856d80b09d30d2eb255d0754b23e090034e1deb4083f8004bd0761e4 \
-    --hash=sha256:4559c972db3a360808309e06a74628b95eaccbf961c335c8fe0d590cf587456f \
-    --hash=sha256:46e83c697b1f1c72b50e5ee5adb4353eef7406fb3f2043d64c33f20ad1c2fc53 \
-    --hash=sha256:47b0ef6231c58f506ef0b74d44e330405caa8428e770fec25329ed2cb971a229 \
-    --hash=sha256:47e77dc9822d3ad616c3d5759ea5631a75e5809d5a28707744ef79d7a1bcfcad \
-    --hash=sha256:47f236970bccb2233267d89173d3ad2703cd36a0e2a6e92d0560d333871a3d23 \
-    --hash=sha256:47f9a91efc418b54fb8190a6b4aa7813a23fb79c51f4bb84e418f5476c38b8db \
-    --hash=sha256:495aeca4b93d465efde585977365187149e75383ad2684f81519f504f5c13038 \
-    --hash=sha256:4c5f36a861bc4b7da6516dbdf302c55313afa09b81931e8280361a4f6c9a2d27 \
-    --hash=sha256:4cc2206b76b4f576934f0ed374b10d7ca5f457858b157ca52064bdfc26b9fc00 \
-    --hash=sha256:4e7fc54e0900ab35d041b0601431b0a0eb495f0851a0639b6ef90f7741b39a18 \
-    --hash=sha256:51a1234d8febafdfd33a42d97da7a43f5dcb120c1060e352a3fbc0c6d36e2083 \
-    --hash=sha256:55f66022632205940f1827effeff17c4fa7ae1953d2b74a8581baaefb7d16f8c \
-    --hash=sha256:58edca431fb9b29950807e301826586e5bbf24163677732429770a697ffe6738 \
-    --hash=sha256:5965af57d5848192c13534f90f9dd16464f3c37aaf166cc1da1cae1fd5a34898 \
-    --hash=sha256:5ba103fb455be00f3b1c2076c9d4264bfcb037c976167a6047ed82f23153f02e \
-    --hash=sha256:5d4c2aa7c50ad4728a094ebd5eb46c452e9cb7edbfdb18f9e1221f597a73e1e7 \
-    --hash=sha256:61046904275472a76c8c90c9ccee9013d70a6d0f73eecefd38c1ae7c39045a08 \
-    --hash=sha256:613aa4771c99f03346e54c3f038e4cc574ac09a3ddfb0e8878487335e96dead6 \
-    --hash=sha256:626a7433c34566535b6e56a1b39a7b17ba961e97ce3b80ec62e6f1312c025551 \
-    --hash=sha256:669b1805bd639dd2989b281be2cfd951c6121b65e729d9b843e9639ef1fd555e \
-    --hash=sha256:679ae98e00c0e8d68a7fda324e16b90fd5260945b45d3b824c892cec9eea3288 \
-    --hash=sha256:67b02ec25ba7a9e8fa74c63b6ca44cf5707f2fbfadae3ee8e7494297d56aa9df \
-    --hash=sha256:68f19c879420aa08f61203801423f6cd5ac5f0ac4ac82a2368a9fcd6a9a075e0 \
-    --hash=sha256:692bef75a5525db97318e8cd061542b5a79812d711ea03dbc1f6f8dbb0c5f0d2 \
-    --hash=sha256:6abc8880d9d036ecaafe709079969f56e876fcf107f7a8e9920ba6d5a3878d05 \
-    --hash=sha256:6bdfdb946967d816e6adf9a3d8201bfad269c67efe6cefd7093ef959683c8de0 \
-    --hash=sha256:6de2a32a1665b93233cde140ff8b3467bdb9e2af2b91079f0333a0974d12d464 \
-    --hash=sha256:73c67f2db7bc334e518d097c6d1e6fed021bbc9b7d678d6cc433478365d1d5f5 \
-    --hash=sha256:74a3243a411126362712ee1524dfc90c650a503502f135d54d1b352bd01f2404 \
-    --hash=sha256:76fec018282b4ead0364022e3c54b60bf368b9d926877957a8624b58419169b7 \
-    --hash=sha256:7c64d38fb49b6cdeda16ab49e35fe0da2e1e9b34bc38bd78386530f218b37139 \
-    --hash=sha256:7cee9c752c0364588353e627da8a7e808a66873672bcb5f52890c33fd965b394 \
-    --hash=sha256:7e6ecfcb62edfd632e56983964e6884851786443739dbfe3582947e87274f7cb \
-    --hash=sha256:806f36b1b605e2d6a72716f321f20036b9489d29c51c91f4dd29a3e3afb73b15 \
-    --hash=sha256:858738e9c32147f78b3ac24dc0edb6610000e56dc0f700fd5f651d0a0f0eb9ff \
-    --hash=sha256:8d6d1cc13664ec13c1b84241204ff3b12f9bb82464b8ad6e7a5d3486975c2eed \
-    --hash=sha256:9027da1ce107104c50c81383cae773ef5c24d296dd11c99e2629dbd7967a20c6 \
-    --hash=sha256:922e10f31f303c7c920da8981051ff6d8c1a56207dbdf330d9047f6d30b70e5e \
-    --hash=sha256:945dccface01af02675628334f7cf49c2af4c1c904748efc5cf7bbdf0b579f95 \
-    --hash=sha256:946fe926af6e44f3697abbc305ea168c2c31d3e3ef1058cf68f379bf0335a78d \
-    --hash=sha256:95f0802447ac2d10bcc69f6dc28fe95fdf17940367b21d34e34c737870758950 \
-    --hash=sha256:9854cf4f488b3d57b9aaeb105f06d78e5529d3145b1e4a41750167e8c213c6d3 \
-    --hash=sha256:993914b8e560023bc0a8bf742c5f303551992dcb85e247b1e5c7f4a7d145bda5 \
-    --hash=sha256:99b47d6ad9a6da00bec6aabe5a6279ecd3c06a329d4aa4771034a21e335c3a97 \
-    --hash=sha256:9a4e86e34e9ab6b667c27f3211ca48f73dba7cd3d90f8d5b11be56e5dbc3fb4e \
-    --hash=sha256:9cf69cdda1f5968a30a359aba2f7f9aa648a9ce4b580d6826437f2b291cfc86e \
-    --hash=sha256:a090322ca841abd453d43456ac34db46e8b05fd9b3b4ac0c78bcde8b089f959b \
-    --hash=sha256:a1010ed9524c73b94d15919ca4d41d8780980e1765babf85f9a2f90d247153dd \
-    --hash=sha256:a161f20d9a43006833cd7068375a94d035714d73a172b681d8881820600abfad \
-    --hash=sha256:a1d0bc22a7cdc173fedebb73ef81e07faef93692b8c1ad3733b67e31e1b6e1b8 \
-    --hash=sha256:a2bffea6a4ca9f01b3f8e548302470306689684e61602aa3d141e34da06cf425 \
-    --hash=sha256:a452763cc5198f2f98898eb98f7569649fe5da666c2dc6b5ddb10fde5a574221 \
-    --hash=sha256:a4796a717bf12b9da9d3ad002519a86063dcac8988b030e405704ef7d74d2d9d \
-    --hash=sha256:a51033ff701fca756439d641c0ad09a41d9242fa69121c7d8769604a0a629825 \
-    --hash=sha256:a8fa71a2e078c527c3e9dc9fc5a98c9db40bcc8a92b4e8858e36d329f8684b51 \
-    --hash=sha256:ac37f9f516c51e5753f27dfdef11a88330f04de2d564be3991384b2f3535d02e \
-    --hash=sha256:ac98b175585ecf4c0348fd7b29c3864bda53b805c773cbf7bfdaffc8070c976f \
-    --hash=sha256:acd7eb3f4471577b9b5a41baf02a978e8bdeb08b4b355273994f8b87032000a8 \
-    --hash=sha256:ad1fa8db769b76ea911cb4e10f049d80bf518c104f15b3edb2371cc65375c46f \
-    --hash=sha256:b40fb160a2db369a194cb27943582b38f79fc4887291417685f3ad693c5a1d5d \
-    --hash=sha256:b4dc1a6ff022ff85ecafef7979a2c6eb423430e05f1165d6688234e62ba99a07 \
-    --hash=sha256:ba3af48635eb83d03f6c9735dfb21785303e73d22ad03d489e88adae6eab8877 \
-    --hash=sha256:ba81a9203d07805435eb06f536d95a266c21e5b2dfbf6517748ca40c98d19e31 \
-    --hash=sha256:c2262bdba0ad4fc6fb5545660673925c2d2a5d9e2e0fb603aad545427be0fc58 \
-    --hash=sha256:c77afbd5f5250bf27bf516c7c4a016813eb2d3e116139aed0096940c5982da94 \
-    --hash=sha256:ca28829ae5f5d569bb62a79512c842a03a12576375d5ece7d2cadf8abe96ec28 \
-    --hash=sha256:cdc62c8286ba9bf7f47befdcea13ea0e26bf294bda99758fd90535cbaf408000 \
-    --hash=sha256:d948b135c4693daff7bc2dcfc4ec57237a29bd37e60c2fabf5aff2bbacf3e2f1 \
-    --hash=sha256:d96c2086587c7c30d44f31f42eae4eac89b60dabbac18c7669be3700f13c3ce1 \
-    --hash=sha256:d9a0ca5da0386dee0655b4ccdf46119df60e0f10da268d04fe7cc87886872ba7 \
-    --hash=sha256:da279aa314f00acbb803da1e76fa18666778e8a8f83484fba94526da5de2cba7 \
-    --hash=sha256:dbd936cde57abfee19ab3213cf9c26be06d60750e60a8e4dd85d1ab12c8b1f40 \
-    --hash=sha256:dc4f992dfe1e2bc3ebc7444f6c7051b4bc13cd8e33e43511e8ffd13bf407010d \
-    --hash=sha256:dc824125c72246d924f7f796b4f63c1e9dc810c7d9e2355864b3c3a73d59ade0 \
-    --hash=sha256:dd8ff7cf90014af0c0f787eea34794ebf6415242ee1d6fa91eaba725cc441e84 \
-    --hash=sha256:dea5b552272a944763b34394d04577cf0f9bd013207bc32323b5a89a53cf9c2f \
-    --hash=sha256:dff13836529b921e22f15cb099751209a60009731a68519630a24d61f0b1b30a \
-    --hash=sha256:e0b65193a413ccc930671c55153a03ee57cecb49e6227204b04fae512eb657a7 \
-    --hash=sha256:e5d3e6b26f2c785d65cc25ef1e5267ccbe1b069c5c21b8cc724efee290554419 \
-    --hash=sha256:e7536cd91353c5273434b4e003cbda89034d67e7710eab8761fd918ec6c69cf8 \
-    --hash=sha256:eb0b93f2e5c2189ee831ee43f156ed34e2a89a78a66b98cadad955972548be5a \
-    --hash=sha256:eb2c4071ab598733724c08221091e8d80e89064cd472819285a9ab0f24bcedb9 \
-    --hash=sha256:ec7c4490c672c1a0389d319b3a9cfcd098dcdc4783991553c332a15acf7249be \
-    --hash=sha256:ee454b2a007d57363c2dfd5b6ca4a5d7e2c518938f8ed3b706e37e5d470801ed \
-    --hash=sha256:ee6af14263f25eedc3bb918a3c04245106a42dfd4f5c2285ea6f997b1fc3f89a \
-    --hash=sha256:f14fc5df50a716f7ece6a80b6c78bb35ea2ca47c499e422aa4463455dd96d56d \
-    --hash=sha256:f207f69853edd6f6700b86efb84999651baf3789e78a466431df1331608e5324 \
-    --hash=sha256:f251c812357a3fed308d684a5079ddfb9d933860fc6de89f2b7ab00da481e65f \
-    --hash=sha256:f83424d738204d9770830d35290ff3273fbb02b41f919870479fab14b9d303b2 \
-    --hash=sha256:f8d1736cfb49381ba528cd5baa46f82fdc65c06e843dab24dd70b63d09121b3f \
-    --hash=sha256:fe5fa731a1fa8a0a56b0977413f8cacac1768dad38d16b3a296712709476fbd5
-    # via
-    #   -c requirements/runtime.txt
-    #   -r requirements/runtime.txt
-    #   jsonschema
-    #   referencing
 rsa==4.9.1 \
     --hash=sha256:68635866661c6836b8d39430f97a996acbd61bfa49406748ea243539fe239762 \
     --hash=sha256:e7bdbfdb5497da4c07dfd35530e1a902659db6ff241e39d9953cad06ebd0ae75
@@ -3335,13 +3156,6 @@ sqlite-utils==3.38 \
     #   -c requirements/runtime.txt
     #   -r requirements/runtime.txt
     #   pydantic-sqlite
-sse-starlette==3.0.3 \
-    --hash=sha256:88cfb08747e16200ea990c8ca876b03910a23b547ab3bd764c0d8eb81019b971 \
-    --hash=sha256:af5bf5a6f3933df1d9c7f8539633dc8444ca6a97ab2e2a7cd3b6e431ac03a431
-    # via
-    #   -c requirements/runtime.txt
-    #   -r requirements/runtime.txt
-    #   mcp
 starlette==0.46.2 \
     --hash=sha256:595633ce89f8ffa71a015caed34a5b2dc1c0cdb3f0f1fbd1e69339cf2abeec35 \
     --hash=sha256:7f7361f34eed179294600af672f565727419830b54b7b084efe44bb82d2fccd5
@@ -3349,7 +3163,6 @@ starlette==0.46.2 \
     #   -c requirements/runtime.txt
     #   -r requirements/runtime.txt
     #   fastapi
-    #   mcp
 sunrisesunset==1.0.2 \
     --hash=sha256:14c3dd6acec8368236419117081c2e17edc15b8892455fe7009aace6cf092505 \
     --hash=sha256:533f12c04169c45eaa7e2e020c56b8f39a51936caa42c345bddf02331c61b16e
@@ -3486,7 +3299,6 @@ uvicorn[standard]==0.34.3 \
     # via
     #   -c requirements/runtime.txt
     #   -r requirements/runtime.txt
-    #   mcp
 uvloop==0.22.1 ; platform_python_implementation != 'PyPy' and sys_platform != 'cygwin' and sys_platform != 'win32' \
     --hash=sha256:017bd46f9e7b78e81606329d07141d3da446f8798c6baeec124260e22c262772 \
     --hash=sha256:0530a5fbad9c9e4ee3f2b33b148c6a64d47bbad8000ea63704fa8260f4cf728e \

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -150,11 +150,8 @@ anyio==4.11.0 \
     --hash=sha256:0287e96f4d26d4149305414d4e3bc32f0dcd0862365a4bddea19d7a1ec38c4fc \
     --hash=sha256:82a8d0b81e318cc5ce71a5f1f8b5c4e63619620b63141ef8c995fa0db95a57c4
     # via
-    #   claude-agent-sdk
     #   google-genai
     #   httpx
-    #   mcp
-    #   sse-starlette
     #   starlette
     #   watchfiles
 apscheduler==3.11.0 \
@@ -181,9 +178,7 @@ attrs==25.4.0 \
     #   cattrs
     #   fiona
     #   jsii
-    #   jsonschema
     #   rasterio
-    #   referencing
     #   requests-cache
 babel==2.18.0 \
     --hash=sha256:b80b99a14bd085fcacfa15c9165f651fbb3406e66cc603abf11c5750937c992d \
@@ -563,13 +558,6 @@ charset-normalizer==3.4.4 \
     #   htmldate
     #   requests
     #   trafilatura
-claude-agent-sdk==0.1.39 \
-    --hash=sha256:0c03b5a3772eaec42e29ea39240c7d24b760358082f2e36336db9e71dde3dda4 \
-    --hash=sha256:6ed6a79781f545b761b9fe467bc5ae213a103c9d3f0fe7a9dad3c01790ed58fa \
-    --hash=sha256:d03324daf7076be79d2dd05944559aabf4cc11c98d3a574b992a442a7c7a26d6 \
-    --hash=sha256:d2665c9e87b6ffece590bcdd6eb9def47cde4809b0d2f66e0a61a719189be7c9 \
-    --hash=sha256:dcf0ebd5a638c9a7d9f3af7640932a9212b2705b7056e4f08bd3968a865b4268
-    # via homelab (pyproject.toml)
 click==8.3.0 \
     --hash=sha256:9b9f285302c6e3064f4330c05f05b81945b2a39544279343e6e7c5f27a9baddc \
     --hash=sha256:e7b8232224eba16f4ebe410c25ced9f7875cb5f3263ffc93cc3e8da705e229c4
@@ -1042,11 +1030,6 @@ httpx==0.28.1 \
     # via
     #   homelab (pyproject.toml)
     #   google-genai
-    #   mcp
-httpx-sse==0.4.3 \
-    --hash=sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc \
-    --hash=sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d
-    # via mcp
 idna==3.11 \
     --hash=sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea \
     --hash=sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902
@@ -1088,14 +1071,6 @@ jsii==1.125.0 \
     # via
     #   cdk8s
     #   constructs
-jsonschema==4.26.0 \
-    --hash=sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326 \
-    --hash=sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce
-    # via mcp
-jsonschema-specifications==2025.9.1 \
-    --hash=sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe \
-    --hash=sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d
-    # via jsonschema
 justext==3.0.2 \
     --hash=sha256:13496a450c44c4cd5b5a75a5efcd9996066d2a189794ea99a49949685a0beb05 \
     --hash=sha256:62b1c562b15c3c6265e121cc070874243a443bfd53060e869393f09d6b6cc9a7
@@ -1352,10 +1327,6 @@ markupsafe==3.0.3 \
     # via
     #   jinja2
     #   mako
-mcp==1.12.4 \
-    --hash=sha256:0765585e9a3a5916a3c3ab8659330e493adc7bd8b2ca6120c2d7a0c43e034ca5 \
-    --hash=sha256:7aa884648969fab8e78b89399d59a683202972e12e6bc9a1c88ce7eda7743789
-    # via claude-agent-sdk
 mdurl==0.1.2 \
     --hash=sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8 \
     --hash=sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba
@@ -2149,7 +2120,6 @@ pydantic==2.12.3 \
     #   homelab (pyproject.toml)
     #   fastapi
     #   google-genai
-    #   mcp
     #   open-gopro
     #   pydantic-extra-types
     #   pydantic-settings
@@ -2280,9 +2250,7 @@ pydantic-extra-types==2.10.6 \
 pydantic-settings==2.11.0 \
     --hash=sha256:d0e87a1c7d33593beb7194adb8470fc426e95ba02af83a0f23474a04c9a08180 \
     --hash=sha256:fe2cea3413b9530d10f3a5875adffb17ada5c1e1bab0b2885546d7310415207c
-    # via
-    #   homelab (pyproject.toml)
-    #   mcp
+    # via homelab (pyproject.toml)
 pydantic-sqlite==0.3.0 \
     --hash=sha256:62efe8437c279e6b47e09ddc5a718ebfb0d91cbbdc28b2f8b80f0f7b07590799 \
     --hash=sha256:cc9d3c1b01582f8f26b988fc58fdbd2f5dea4d1a7d76b80e1394f8c11d7831e8
@@ -2434,9 +2402,7 @@ python-dotenv==1.2.1 \
 python-multipart==0.0.20 \
     --hash=sha256:8a62d3a8335e06589fe01f2a3e178cdcc632f3fbe0d492ad9ee0ec35aab1f104 \
     --hash=sha256:8dd0cab45b8e23064ae09147625994d090fa46f5b0d1e13af944c331a7fa9d13
-    # via
-    #   homelab (pyproject.toml)
-    #   mcp
+    # via homelab (pyproject.toml)
 pytz==2024.2 \
     --hash=sha256:2aa355083c50a0f93fa581709deac0c9ad65cca8a9e9beac660adcbd493c798a \
     --hash=sha256:31c7c1817eb7fae7ca4b8c7ee50c72f93aa2dd863de768e1ef4245d426aa0725
@@ -2445,28 +2411,6 @@ pytz==2024.2 \
     #   dateparser
     #   open-gopro
     #   pandas
-pywin32==311 ; sys_platform == 'win32' \
-    --hash=sha256:0502d1facf1fed4839a9a51ccbcc63d952cf318f78ffc00a7e78528ac27d7a2b \
-    --hash=sha256:184eb5e436dea364dcd3d2316d577d625c0351bf237c4e9a5fabbcfa5a58b151 \
-    --hash=sha256:3aca44c046bd2ed8c90de9cb8427f581c479e594e99b5c0bb19b29c10fd6cb87 \
-    --hash=sha256:3ce80b34b22b17ccbd937a6e78e7225d80c52f5ab9940fe0506a1a16f3dab503 \
-    --hash=sha256:62ea666235135fee79bb154e695f3ff67370afefd71bd7fea7512fc70ef31e3d \
-    --hash=sha256:6c6f2969607b5023b0d9ce2541f8d2cbb01c4f46bc87456017cf63b73f1e2d8c \
-    --hash=sha256:718a38f7e5b058e76aee1c56ddd06908116d35147e133427e59a3983f703a20d \
-    --hash=sha256:750ec6e621af2b948540032557b10a2d43b0cee2ae9758c54154d711cc852d31 \
-    --hash=sha256:797c2772017851984b97180b0bebe4b620bb86328e8a884bb626156295a63b3b \
-    --hash=sha256:7b4075d959648406202d92a2310cb990fea19b535c7f4a78d3f5e10b926eeb8a \
-    --hash=sha256:a508e2d9025764a8270f93111a970e1d0fbfc33f4153b388bb649b7eec4f9b42 \
-    --hash=sha256:a733f1388e1a842abb67ffa8e7aad0e70ac519e09b0f6a784e65a136ec7cefd2 \
-    --hash=sha256:aba8f82d551a942cb20d4a83413ccbac30790b50efb89a75e4f586ac0bb8056b \
-    --hash=sha256:b7a2c10b93f8986666d0c803ee19b5990885872a7de910fc460f9b0c2fbf92ee \
-    --hash=sha256:b8c095edad5c211ff31c05223658e71bf7116daa0ecf3ad85f3201ea3190d067 \
-    --hash=sha256:c8015b09fb9a5e188f83b7b04de91ddca4658cee2ae6f3bc483f0b21a77ef6cd \
-    --hash=sha256:d03ff496d2a0cd4a5893504789d4a15399133fe82517455e78bad62efbb7f0a3 \
-    --hash=sha256:e0c4cfb0621281fe40387df582097fd796e80430597cb9944f0ae70447bacd91 \
-    --hash=sha256:e286f46a9a39c4a18b319c28f59b61de793654af2f395c102b4f819e584b5852 \
-    --hash=sha256:f95ba5a847cba10dd8c4d8fefa9f2a6cf283b8b88ed6178fa8a6c1ab16054d0d
-    # via mcp
 pyyaml==6.0.3 \
     --hash=sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c \
     --hash=sha256:0150219816b6a1fa26fb4699fb7daa9caf09eb1999f3b70fb6e786805e80375a \
@@ -2567,12 +2511,6 @@ rasterio==1.4.3 \
     --hash=sha256:e703e4b2c74c678786d5d110a3f30e26f3acfd65f09ccf35f69683a532f7a772 \
     --hash=sha256:e79847a5a0e01399457a1e02d8c92040cb56729d054fe7796f0c17b246b18bf0
     # via homelab (pyproject.toml)
-referencing==0.37.0 \
-    --hash=sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231 \
-    --hash=sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8
-    # via
-    #   jsonschema
-    #   jsonschema-specifications
 regex==2026.1.15 \
     --hash=sha256:0057de9eaef45783ff69fa94ae9f0fd906d629d0bd4c3217048f46d1daa32e9b \
     --hash=sha256:008b185f235acd1e53787333e5690082e4f156c44c87d894f880056089e9bc7c \
@@ -2731,125 +2669,6 @@ rich==14.2.0 \
     # via
     #   open-gopro
     #   typer
-rpds-py==0.30.0 \
-    --hash=sha256:07ae8a593e1c3c6b82ca3292efbe73c30b61332fd612e05abee07c79359f292f \
-    --hash=sha256:0a59119fc6e3f460315fe9d08149f8102aa322299deaa5cab5b40092345c2136 \
-    --hash=sha256:0c0e95f6819a19965ff420f65578bacb0b00f251fefe2c8b23347c37174271f3 \
-    --hash=sha256:0d08f00679177226c4cb8c5265012eea897c8ca3b93f429e546600c971bcbae7 \
-    --hash=sha256:0ed177ed9bded28f8deb6ab40c183cd1192aa0de40c12f38be4d59cd33cb5c65 \
-    --hash=sha256:12f90dd7557b6bd57f40abe7747e81e0c0b119bef015ea7726e69fe550e394a4 \
-    --hash=sha256:1726859cd0de969f88dc8673bdd954185b9104e05806be64bcd87badbe313169 \
-    --hash=sha256:1ab5b83dbcf55acc8b08fc62b796ef672c457b17dbd7820a11d6c52c06839bdf \
-    --hash=sha256:1b151685b23929ab7beec71080a8889d4d6d9fa9a983d213f07121205d48e2c4 \
-    --hash=sha256:1f3587eb9b17f3789ad50824084fa6f81921bbf9a795826570bda82cb3ed91f2 \
-    --hash=sha256:250fa00e9543ac9b97ac258bd37367ff5256666122c2d0f2bc97577c60a1818c \
-    --hash=sha256:2771c6c15973347f50fece41fc447c054b7ac2ae0502388ce3b6738cd366e3d4 \
-    --hash=sha256:27f4b0e92de5bfbc6f86e43959e6edd1425c33b5e69aab0984a72047f2bcf1e3 \
-    --hash=sha256:2e6ecb5a5bcacf59c3f912155044479af1d0b6681280048b338b28e364aca1f6 \
-    --hash=sha256:32c8528634e1bf7121f3de08fa85b138f4e0dc47657866630611b03967f041d7 \
-    --hash=sha256:33f559f3104504506a44bb666b93a33f5d33133765b0c216a5bf2f1e1503af89 \
-    --hash=sha256:3896fa1be39912cf0757753826bc8bdc8ca331a28a7c4ae46b7a21280b06bb85 \
-    --hash=sha256:389a2d49eded1896c3d48b0136ead37c48e221b391c052fba3f4055c367f60a6 \
-    --hash=sha256:39c02563fc592411c2c61d26b6c5fe1e51eaa44a75aa2c8735ca88b0d9599daa \
-    --hash=sha256:3adbb8179ce342d235c31ab8ec511e66c73faa27a47e076ccc92421add53e2bb \
-    --hash=sha256:3d4a69de7a3e50ffc214ae16d79d8fbb0922972da0356dcf4d0fdca2878559c6 \
-    --hash=sha256:3e62880792319dbeb7eb866547f2e35973289e7d5696c6e295476448f5b63c87 \
-    --hash=sha256:3e8eeb0544f2eb0d2581774be4c3410356eba189529a6b3e36bbbf9696175856 \
-    --hash=sha256:422c3cb9856d80b09d30d2eb255d0754b23e090034e1deb4083f8004bd0761e4 \
-    --hash=sha256:4559c972db3a360808309e06a74628b95eaccbf961c335c8fe0d590cf587456f \
-    --hash=sha256:46e83c697b1f1c72b50e5ee5adb4353eef7406fb3f2043d64c33f20ad1c2fc53 \
-    --hash=sha256:47b0ef6231c58f506ef0b74d44e330405caa8428e770fec25329ed2cb971a229 \
-    --hash=sha256:47e77dc9822d3ad616c3d5759ea5631a75e5809d5a28707744ef79d7a1bcfcad \
-    --hash=sha256:47f236970bccb2233267d89173d3ad2703cd36a0e2a6e92d0560d333871a3d23 \
-    --hash=sha256:47f9a91efc418b54fb8190a6b4aa7813a23fb79c51f4bb84e418f5476c38b8db \
-    --hash=sha256:495aeca4b93d465efde585977365187149e75383ad2684f81519f504f5c13038 \
-    --hash=sha256:4c5f36a861bc4b7da6516dbdf302c55313afa09b81931e8280361a4f6c9a2d27 \
-    --hash=sha256:4cc2206b76b4f576934f0ed374b10d7ca5f457858b157ca52064bdfc26b9fc00 \
-    --hash=sha256:4e7fc54e0900ab35d041b0601431b0a0eb495f0851a0639b6ef90f7741b39a18 \
-    --hash=sha256:51a1234d8febafdfd33a42d97da7a43f5dcb120c1060e352a3fbc0c6d36e2083 \
-    --hash=sha256:55f66022632205940f1827effeff17c4fa7ae1953d2b74a8581baaefb7d16f8c \
-    --hash=sha256:58edca431fb9b29950807e301826586e5bbf24163677732429770a697ffe6738 \
-    --hash=sha256:5965af57d5848192c13534f90f9dd16464f3c37aaf166cc1da1cae1fd5a34898 \
-    --hash=sha256:5ba103fb455be00f3b1c2076c9d4264bfcb037c976167a6047ed82f23153f02e \
-    --hash=sha256:5d4c2aa7c50ad4728a094ebd5eb46c452e9cb7edbfdb18f9e1221f597a73e1e7 \
-    --hash=sha256:61046904275472a76c8c90c9ccee9013d70a6d0f73eecefd38c1ae7c39045a08 \
-    --hash=sha256:613aa4771c99f03346e54c3f038e4cc574ac09a3ddfb0e8878487335e96dead6 \
-    --hash=sha256:626a7433c34566535b6e56a1b39a7b17ba961e97ce3b80ec62e6f1312c025551 \
-    --hash=sha256:669b1805bd639dd2989b281be2cfd951c6121b65e729d9b843e9639ef1fd555e \
-    --hash=sha256:679ae98e00c0e8d68a7fda324e16b90fd5260945b45d3b824c892cec9eea3288 \
-    --hash=sha256:67b02ec25ba7a9e8fa74c63b6ca44cf5707f2fbfadae3ee8e7494297d56aa9df \
-    --hash=sha256:68f19c879420aa08f61203801423f6cd5ac5f0ac4ac82a2368a9fcd6a9a075e0 \
-    --hash=sha256:692bef75a5525db97318e8cd061542b5a79812d711ea03dbc1f6f8dbb0c5f0d2 \
-    --hash=sha256:6abc8880d9d036ecaafe709079969f56e876fcf107f7a8e9920ba6d5a3878d05 \
-    --hash=sha256:6bdfdb946967d816e6adf9a3d8201bfad269c67efe6cefd7093ef959683c8de0 \
-    --hash=sha256:6de2a32a1665b93233cde140ff8b3467bdb9e2af2b91079f0333a0974d12d464 \
-    --hash=sha256:73c67f2db7bc334e518d097c6d1e6fed021bbc9b7d678d6cc433478365d1d5f5 \
-    --hash=sha256:74a3243a411126362712ee1524dfc90c650a503502f135d54d1b352bd01f2404 \
-    --hash=sha256:76fec018282b4ead0364022e3c54b60bf368b9d926877957a8624b58419169b7 \
-    --hash=sha256:7c64d38fb49b6cdeda16ab49e35fe0da2e1e9b34bc38bd78386530f218b37139 \
-    --hash=sha256:7cee9c752c0364588353e627da8a7e808a66873672bcb5f52890c33fd965b394 \
-    --hash=sha256:7e6ecfcb62edfd632e56983964e6884851786443739dbfe3582947e87274f7cb \
-    --hash=sha256:806f36b1b605e2d6a72716f321f20036b9489d29c51c91f4dd29a3e3afb73b15 \
-    --hash=sha256:858738e9c32147f78b3ac24dc0edb6610000e56dc0f700fd5f651d0a0f0eb9ff \
-    --hash=sha256:8d6d1cc13664ec13c1b84241204ff3b12f9bb82464b8ad6e7a5d3486975c2eed \
-    --hash=sha256:9027da1ce107104c50c81383cae773ef5c24d296dd11c99e2629dbd7967a20c6 \
-    --hash=sha256:922e10f31f303c7c920da8981051ff6d8c1a56207dbdf330d9047f6d30b70e5e \
-    --hash=sha256:945dccface01af02675628334f7cf49c2af4c1c904748efc5cf7bbdf0b579f95 \
-    --hash=sha256:946fe926af6e44f3697abbc305ea168c2c31d3e3ef1058cf68f379bf0335a78d \
-    --hash=sha256:95f0802447ac2d10bcc69f6dc28fe95fdf17940367b21d34e34c737870758950 \
-    --hash=sha256:9854cf4f488b3d57b9aaeb105f06d78e5529d3145b1e4a41750167e8c213c6d3 \
-    --hash=sha256:993914b8e560023bc0a8bf742c5f303551992dcb85e247b1e5c7f4a7d145bda5 \
-    --hash=sha256:99b47d6ad9a6da00bec6aabe5a6279ecd3c06a329d4aa4771034a21e335c3a97 \
-    --hash=sha256:9a4e86e34e9ab6b667c27f3211ca48f73dba7cd3d90f8d5b11be56e5dbc3fb4e \
-    --hash=sha256:9cf69cdda1f5968a30a359aba2f7f9aa648a9ce4b580d6826437f2b291cfc86e \
-    --hash=sha256:a090322ca841abd453d43456ac34db46e8b05fd9b3b4ac0c78bcde8b089f959b \
-    --hash=sha256:a1010ed9524c73b94d15919ca4d41d8780980e1765babf85f9a2f90d247153dd \
-    --hash=sha256:a161f20d9a43006833cd7068375a94d035714d73a172b681d8881820600abfad \
-    --hash=sha256:a1d0bc22a7cdc173fedebb73ef81e07faef93692b8c1ad3733b67e31e1b6e1b8 \
-    --hash=sha256:a2bffea6a4ca9f01b3f8e548302470306689684e61602aa3d141e34da06cf425 \
-    --hash=sha256:a452763cc5198f2f98898eb98f7569649fe5da666c2dc6b5ddb10fde5a574221 \
-    --hash=sha256:a4796a717bf12b9da9d3ad002519a86063dcac8988b030e405704ef7d74d2d9d \
-    --hash=sha256:a51033ff701fca756439d641c0ad09a41d9242fa69121c7d8769604a0a629825 \
-    --hash=sha256:a8fa71a2e078c527c3e9dc9fc5a98c9db40bcc8a92b4e8858e36d329f8684b51 \
-    --hash=sha256:ac37f9f516c51e5753f27dfdef11a88330f04de2d564be3991384b2f3535d02e \
-    --hash=sha256:ac98b175585ecf4c0348fd7b29c3864bda53b805c773cbf7bfdaffc8070c976f \
-    --hash=sha256:acd7eb3f4471577b9b5a41baf02a978e8bdeb08b4b355273994f8b87032000a8 \
-    --hash=sha256:ad1fa8db769b76ea911cb4e10f049d80bf518c104f15b3edb2371cc65375c46f \
-    --hash=sha256:b40fb160a2db369a194cb27943582b38f79fc4887291417685f3ad693c5a1d5d \
-    --hash=sha256:b4dc1a6ff022ff85ecafef7979a2c6eb423430e05f1165d6688234e62ba99a07 \
-    --hash=sha256:ba3af48635eb83d03f6c9735dfb21785303e73d22ad03d489e88adae6eab8877 \
-    --hash=sha256:ba81a9203d07805435eb06f536d95a266c21e5b2dfbf6517748ca40c98d19e31 \
-    --hash=sha256:c2262bdba0ad4fc6fb5545660673925c2d2a5d9e2e0fb603aad545427be0fc58 \
-    --hash=sha256:c77afbd5f5250bf27bf516c7c4a016813eb2d3e116139aed0096940c5982da94 \
-    --hash=sha256:ca28829ae5f5d569bb62a79512c842a03a12576375d5ece7d2cadf8abe96ec28 \
-    --hash=sha256:cdc62c8286ba9bf7f47befdcea13ea0e26bf294bda99758fd90535cbaf408000 \
-    --hash=sha256:d948b135c4693daff7bc2dcfc4ec57237a29bd37e60c2fabf5aff2bbacf3e2f1 \
-    --hash=sha256:d96c2086587c7c30d44f31f42eae4eac89b60dabbac18c7669be3700f13c3ce1 \
-    --hash=sha256:d9a0ca5da0386dee0655b4ccdf46119df60e0f10da268d04fe7cc87886872ba7 \
-    --hash=sha256:da279aa314f00acbb803da1e76fa18666778e8a8f83484fba94526da5de2cba7 \
-    --hash=sha256:dbd936cde57abfee19ab3213cf9c26be06d60750e60a8e4dd85d1ab12c8b1f40 \
-    --hash=sha256:dc4f992dfe1e2bc3ebc7444f6c7051b4bc13cd8e33e43511e8ffd13bf407010d \
-    --hash=sha256:dc824125c72246d924f7f796b4f63c1e9dc810c7d9e2355864b3c3a73d59ade0 \
-    --hash=sha256:dd8ff7cf90014af0c0f787eea34794ebf6415242ee1d6fa91eaba725cc441e84 \
-    --hash=sha256:dea5b552272a944763b34394d04577cf0f9bd013207bc32323b5a89a53cf9c2f \
-    --hash=sha256:dff13836529b921e22f15cb099751209a60009731a68519630a24d61f0b1b30a \
-    --hash=sha256:e0b65193a413ccc930671c55153a03ee57cecb49e6227204b04fae512eb657a7 \
-    --hash=sha256:e5d3e6b26f2c785d65cc25ef1e5267ccbe1b069c5c21b8cc724efee290554419 \
-    --hash=sha256:e7536cd91353c5273434b4e003cbda89034d67e7710eab8761fd918ec6c69cf8 \
-    --hash=sha256:eb0b93f2e5c2189ee831ee43f156ed34e2a89a78a66b98cadad955972548be5a \
-    --hash=sha256:eb2c4071ab598733724c08221091e8d80e89064cd472819285a9ab0f24bcedb9 \
-    --hash=sha256:ec7c4490c672c1a0389d319b3a9cfcd098dcdc4783991553c332a15acf7249be \
-    --hash=sha256:ee454b2a007d57363c2dfd5b6ca4a5d7e2c518938f8ed3b706e37e5d470801ed \
-    --hash=sha256:ee6af14263f25eedc3bb918a3c04245106a42dfd4f5c2285ea6f997b1fc3f89a \
-    --hash=sha256:f14fc5df50a716f7ece6a80b6c78bb35ea2ca47c499e422aa4463455dd96d56d \
-    --hash=sha256:f207f69853edd6f6700b86efb84999651baf3789e78a466431df1331608e5324 \
-    --hash=sha256:f251c812357a3fed308d684a5079ddfb9d933860fc6de89f2b7ab00da481e65f \
-    --hash=sha256:f83424d738204d9770830d35290ff3273fbb02b41f919870479fab14b9d303b2 \
-    --hash=sha256:f8d1736cfb49381ba528cd5baa46f82fdc65c06e843dab24dd70b63d09121b3f \
-    --hash=sha256:fe5fa731a1fa8a0a56b0977413f8cacac1768dad38d16b3a296712709476fbd5
-    # via
-    #   jsonschema
-    #   referencing
 rsa==4.9.1 \
     --hash=sha256:68635866661c6836b8d39430f97a996acbd61bfa49406748ea243539fe239762 \
     --hash=sha256:e7bdbfdb5497da4c07dfd35530e1a902659db6ff241e39d9953cad06ebd0ae75
@@ -2950,16 +2769,10 @@ sqlite-utils==3.38 \
     --hash=sha256:1ae77b931384052205a15478d429464f6c67a3ac3b4eafd3c674ac900f623aab \
     --hash=sha256:8a27441015c3b2ef475f555861f7a2592f73bc60d247af9803a11b65fc605bf9
     # via pydantic-sqlite
-sse-starlette==3.0.3 \
-    --hash=sha256:88cfb08747e16200ea990c8ca876b03910a23b547ab3bd764c0d8eb81019b971 \
-    --hash=sha256:af5bf5a6f3933df1d9c7f8539633dc8444ca6a97ab2e2a7cd3b6e431ac03a431
-    # via mcp
 starlette==0.46.2 \
     --hash=sha256:595633ce89f8ffa71a015caed34a5b2dc1c0cdb3f0f1fbd1e69339cf2abeec35 \
     --hash=sha256:7f7361f34eed179294600af672f565727419830b54b7b084efe44bb82d2fccd5
-    # via
-    #   fastapi
-    #   mcp
+    # via fastapi
 sunrisesunset==1.0.2 \
     --hash=sha256:14c3dd6acec8368236419117081c2e17edc15b8892455fe7009aace6cf092505 \
     --hash=sha256:533f12c04169c45eaa7e2e020c56b8f39a51936caa42c345bddf02331c61b16e
@@ -3058,9 +2871,7 @@ urllib3==2.5.0 \
 uvicorn[standard]==0.34.3 \
     --hash=sha256:16246631db62bdfbf069b0645177d6e8a77ba950cfedbfd093acef9444e4d885 \
     --hash=sha256:35919a9a979d7a59334b6b10e05d77c1d0d574c50e0fc98b8b1a0f165708b55a
-    # via
-    #   homelab (pyproject.toml)
-    #   mcp
+    # via homelab (pyproject.toml)
 uvloop==0.22.1 ; platform_python_implementation != 'PyPy' and sys_platform != 'cygwin' and sys_platform != 'win32' \
     --hash=sha256:017bd46f9e7b78e81606329d07141d3da446f8798c6baeec124260e22c262772 \
     --hash=sha256:0530a5fbad9c9e4ee3f2b33b148c6a64d47bbad8000ea63704fa8260f4cf728e \

--- a/tools/python/gazelle_python.yaml
+++ b/tools/python/gazelle_python.yaml
@@ -46,7 +46,6 @@ manifest:
     certifi: certifi
     cffi: cffi
     charset_normalizer: charset_normalizer
-    claude_agent_sdk: claude_agent_sdk
     click: click
     click_default_group: click_default_group
     click_plugins: click_plugins


### PR DESCRIPTION
## Summary

- **Replace `claude_agent_sdk.query()` async iterator** with `asyncio.create_subprocess_exec("claude", "--print", "--output-format", "stream-json", ...)` — the CLI handles rate limiting internally, and process exit = done
- **Remove `claude-agent-sdk` dependency entirely** from code, BUILD files, pyproject.toml, and regenerated lock files
- **Delete ~636 net lines** including the reconnect/dedup loop (`_run_once` ~450 lines), `_tool_summary_sdk`, `_sdk_event_to_dict`, and all SDK-typed handling

## Context

The Agent SDK's `query()` async iterator breaks on `rate_limit_event` → `MessageParseError` → `StopAsyncIteration`. The reconnect logic built around it (#542, #543) never reliably detects session completion because `resume` replays full message history, rate limits kill replays mid-stream, and partial text causes infinite "new content" detection.

The CLI subprocess approach eliminates all of this: no reconnect loop, no dedup sets, no stale-streak counters. JSONL lines from stdout are parsed and mapped to the same WebSocket events the frontend already expects.

## Changes

| Area | What changed |
|------|-------------|
| `server.py` | Removed SDK imports, rewrote `ClaudeSession` (subprocess-based `run()`, new `_process_stdout()` JSONL parser, new `_drain_stderr()`), deleted `_run_once()`, merged `_tool_summary_sdk` into `_tool_summary` |
| `tests/conftest.py` | New `MockProcess`/`MockStdout`/`MockStderr` with fixture→JSONL conversion |
| `tests/ws_*.py` | Patch `asyncio.create_subprocess_exec` instead of SDK `query()` |
| `tts_on_result_test.py` | Same mock pattern update |
| `e2e/mock-server.py` | Subprocess mock instead of SDK mock |
| `BUILD`, `pyproject.toml`, `gazelle_python.yaml` | Removed `claude_agent_sdk` dependency |
| `requirements/*.txt` | Regenerated without SDK transitive deps |

## Test plan

- [x] All 6 backend tests pass (`bazel test //charts/bosun/backend/tests/... //charts/bosun/backend:tts_on_result_test`)
- [x] Format check passes
- [ ] Deploy to cluster, send a message via Bosun voice UI — verify streaming text appears live
- [ ] Ask Claude to read a file — verify `tool_use` + `tool_result` events render correctly
- [ ] Say "cancel" mid-response — verify subprocess terminates and "Cancelled." appears
- [ ] Send two messages in sequence — verify second uses `--resume` and continues the conversation

🤖 Generated with [Claude Code](https://claude.com/claude-code)