### PR TITLE
fix(bosun): system prompt for session workdir + Write-tool mermaid detection

### DIFF
--- a/charts/bosun/backend/server.py
+++ b/charts/bosun/backend/server.py
@@ -115,6 +115,50 @@ AUTO_APPROVED_TOOLS = [
     "Teammate",  # Enable swarm/team tools
 ]
 
+# System prompt appended to every CLI subprocess invocation.
+# Constrains Claude to the session workdir and instructs it about rendering
+# so that rich content appears correctly in the Bosun voice UI.
+_BOSUN_SYSTEM_PROMPT = """\
+You are running inside Bosun, a voice-controlled coding assistant UI.
+Your responses are rendered in a chat panel and often read aloud via TTS.
+
+## Working directory
+Your working directory is your project root. Always use RELATIVE paths for \
+file operations (Read, Write, Edit, Glob, Grep, Bash). Never use absolute \
+paths to other directories — all files you need are in your cwd.
+
+## Response formatting
+The UI renders GitHub Flavored Markdown. Use it freely:
+- **Headings, bold, italic, links, blockquotes, horizontal rules** all work.
+- **Markdown tables** render with borders and striped headers — prefer them \
+for structured data.
+- **Fenced code blocks** render in monospace with a copy button. Include the \
+language identifier (e.g. ```python) for readability, but note there is no \
+syntax highlighting.
+- **Ordered and unordered lists** render with proper indentation.
+- Do NOT use raw HTML — it will be escaped, not rendered.
+- Do NOT use LaTeX math notation — it renders as plain text. Describe math \
+in words or use code blocks instead.
+
+## Diagrams
+The UI renders Mermaid diagrams inline with zoom, pan, and download controls. \
+To display a diagram, include it directly in your response text as a fenced \
+mermaid code block:
+
+```mermaid
+graph TD
+    A --> B
+```
+
+Do NOT write mermaid to a separate .mmd file — always include diagrams inline \
+in your response text so the UI can detect and render them.
+
+## Voice / TTS awareness
+When the user is using voice input, keep responses concise and conversational. \
+Avoid excessive markdown formatting in short answers — plain text reads better \
+aloud. Save rich formatting for longer explanations or when explicitly asked.\
+"""
+
 app = FastAPI()
 
 
@@ -608,6 +652,8 @@ class ClaudeSession:
             ",".join(AUTO_APPROVED_TOOLS),
             "--setting-sources",
             "project",
+            "--append-system-prompt",
+            _BOSUN_SYSTEM_PROMPT,
         ]
         if self.session_id:
             cmd.extend(["--resume", self.session_id])
@@ -833,6 +879,86 @@ class ClaudeSession:
                                 }
                             )
 
+                        # Emit diff artifact for Edit tool
+                        if tool_name == "Edit":
+                            old_str = tool_input.get("old_string", "")
+                            new_str = tool_input.get("new_string", "")
+                            fpath = tool_input.get("file_path", "")
+                            if old_str and new_str and fpath:
+                                diff_text = _make_edit_diff(fpath, old_str, new_str)
+                                if diff_text:
+                                    fname = os.path.basename(fpath)
+                                    await ws.send_json(
+                                        {
+                                            "type": "diff",
+                                            "content": diff_text,
+                                            "file": fname,
+                                        }
+                                    )
+                                    if self.session_id:
+                                        artifact_counter += 1
+                                        _save_artifact(
+                                            self.session_id,
+                                            f"diff-{artifact_counter}",
+                                            "1",
+                                            {
+                                                "type": "diff",
+                                                "label": fname,
+                                                "data": diff_text,
+                                            },
+                                        )
+
+                        # Detect mermaid content written to files
+                        if tool_name == "Write":
+                            file_path = tool_input.get("file_path", "")
+                            file_content = tool_input.get("content", "")
+                            if file_path.endswith(".mmd") and file_content:
+                                # Treat entire file as a mermaid diagram
+                                label = os.path.basename(file_path)
+                                await ws.send_json(
+                                    {
+                                        "type": "mermaid_artifact",
+                                        "code": file_content.strip(),
+                                        "label": label,
+                                    }
+                                )
+                                if self.session_id:
+                                    artifact_counter += 1
+                                    _save_artifact(
+                                        self.session_id,
+                                        f"mermaid-{artifact_counter}",
+                                        "1",
+                                        {
+                                            "type": "mermaid",
+                                            "label": label,
+                                            "data": file_content.strip(),
+                                        },
+                                    )
+                            elif file_content:
+                                # Also scan for inline mermaid blocks in any written file
+                                for mi, mblock in enumerate(
+                                    _extract_mermaid_blocks(file_content)
+                                ):
+                                    await ws.send_json(
+                                        {
+                                            "type": "mermaid_artifact",
+                                            "code": mblock["code"],
+                                            "label": mblock["label"],
+                                        }
+                                    )
+                                    if self.session_id:
+                                        artifact_counter += 1
+                                        _save_artifact(
+                                            self.session_id,
+                                            f"mermaid-{artifact_counter}",
+                                            str(mi + 1),
+                                            {
+                                                "type": "mermaid",
+                                                "label": mblock["label"],
+                                                "data": mblock["code"],
+                                            },
+                                        )
+
                     elif btype == "tool_result":
                         content = block.get("content", "")
                         images = (
@@ -872,10 +998,32 @@ class ClaudeSession:
                                     },
                                 )
                         await ws.send_json(result_msg)
+
+                        # Detect unified diff in tool output (e.g. git diff)
+                        content_str = str(content or "")
+                        if _DIFF_RE.search(content_str):
+                            await ws.send_json(
+                                {
+                                    "type": "diff",
+                                    "content": content_str[:10000],
+                                    "file": "changes",
+                                }
+                            )
+                            if self.session_id:
+                                artifact_counter += 1
+                                _save_artifact(
+                                    self.session_id,
+                                    f"diff-{artifact_counter}",
+                                    "1",
+                                    {
+                                        "type": "diff",
+                                        "label": "changes",
+                                        "data": content_str[:10000],
+                                    },
+                                )
+
                         # Detect PR URLs in tool output
-                        await _detect_prs_in_output(
-                            str(content or ""), self.session_id, ws
-                        )
+                        await _detect_prs_in_output(content_str, self.session_id, ws)
 
                 continue
 
@@ -1007,6 +1155,29 @@ def _tool_summary(block: dict) -> str:
         return f"Message → {inp.get('recipient', inp.get('type', ''))}"
 
     return name
+
+
+def _make_edit_diff(file_path: str, old_string: str, new_string: str) -> str:
+    """Build a unified diff string from Edit tool input fields."""
+    import difflib
+
+    old_lines = old_string.splitlines(keepends=True)
+    new_lines = new_string.splitlines(keepends=True)
+    diff = difflib.unified_diff(
+        old_lines,
+        new_lines,
+        fromfile=f"a/{file_path}",
+        tofile=f"b/{file_path}",
+        lineterm="",
+    )
+    return "\n".join(diff)
+
+
+# Matches unified diff output (git diff, diff -u, etc.)
+_DIFF_RE = re.compile(
+    r"^---\s+\S.*\n\+\+\+\s+\S.*\n@@\s",
+    re.MULTILINE,
+)
 
 
 _MERMAID_RE = re.compile(r"```mermaid\s*\n(.*?)\n```", re.DOTALL)
@@ -1847,18 +2018,20 @@ def _truncate_for_tts(text: str) -> str:
 
 
 _SUMMARY_PROMPT = (
-    "You are briefing a developer who is listening, not reading.\n"
-    "Summarize the coding agent's output for spoken delivery.\n\n"
+    "You are briefing a developer who is listening via voice, not reading a screen.\n"
+    "Your job is to move progress forward — surface what matters so they can respond.\n\n"
     "Rules:\n"
-    "- Be concise. Use as few words as possible to convey the key point.\n"
-    "- For short or simple outputs, just relay the answer directly.\n"
-    "- For longer outputs, summarize what was done and any next step. Max 150 words.\n"
-    '- Lead with the conclusion, not "The agent investigated..."\n'
-    "- Include specific details (file names, values) only when the listener\n"
-    "  needs them to respond without seeing the screen\n"
-    "- If the agent asks the user a question, end with that question\n"
-    "- Be natural and conversational — this will be spoken aloud\n"
-    "- Do NOT use markdown, bullet points, or formatting\n\n"
+    "- Lead with the outcome or decision needed. Never start with 'The agent...'\n"
+    "- If the agent is BLOCKED or asking a question, end with that question clearly.\n"
+    "  The user needs to speak back to unblock it.\n"
+    "- If the agent completed work, state what's done in one sentence.\n"
+    '  "PR is ready" beats a paragraph about what the PR contains.\n'
+    "- Only include file names, values, or details the user needs to make a decision\n"
+    "  or take action. Skip implementation details they can see on screen.\n"
+    "- Keep it under 2-3 sentences for simple completions.\n"
+    "  Use more words only when there's a real decision or ambiguity to resolve.\n"
+    "- Be conversational — this is spoken aloud, not a status report.\n"
+    "- Do NOT use markdown, bullet points, or formatting.\n\n"
 )
 
 
@@ -1868,7 +2041,10 @@ async def _summarize(client, text: str, suggest_actions: bool):
         if suggest_actions:
             sa_prompt = (
                 _SUMMARY_PROMPT
-                + "Then suggest 1-3 follow-up actions the user might want.\n\n"
+                + "Then suggest 1-3 concrete next actions the user can say aloud to continue.\n"
+                "Actions should be specific to what just happened, not generic.\n"
+                'Good: "Merge the PR", "Run the failing test again"\n'
+                'Bad: "Review the changes", "Continue working"\n\n'
                 "Output format (JSON only, no markdown):\n"
                 '{"summary": "...", "actions": [{"label": "Run tests", "prompt": "run the test suite"}]}\n\n'
                 f"Agent output:\n{text}"

--- a/charts/bosun/backend/tests/BUILD
+++ b/charts/bosun/backend/tests/BUILD
@@ -64,3 +64,13 @@ py_test(
         "@pip//starlette",
     ],
 )
+
+py_test(
+    name = "ws_diff_test",
+    srcs = ["ws_diff_test.py"],
+    deps = [
+        ":conftest",
+        "@pip//pytest",
+        "@pip//starlette",
+    ],
+)

--- a/charts/bosun/backend/tests/fixtures/bash_diff.json
+++ b/charts/bosun/backend/tests/fixtures/bash_diff.json
@@ -1,0 +1,87 @@
+[
+  { "kind": "system_init", "data": { "session_id": "test-bashdiff-001" } },
+  {
+    "kind": "stream_event",
+    "uuid": "e1",
+    "session_id": "test-bashdiff-001",
+    "event": {
+      "type": "content_block_start",
+      "content_block": { "type": "text" }
+    }
+  },
+  {
+    "kind": "stream_event",
+    "uuid": "e2",
+    "session_id": "test-bashdiff-001",
+    "event": {
+      "type": "content_block_delta",
+      "delta": { "type": "text_delta", "text": "Let me check the changes." }
+    }
+  },
+  {
+    "kind": "stream_event",
+    "uuid": "e3",
+    "session_id": "test-bashdiff-001",
+    "event": { "type": "message_stop" }
+  },
+  {
+    "kind": "assistant",
+    "content": [
+      {
+        "type": "tool_use",
+        "id": "tu-bash-1",
+        "name": "Bash",
+        "input": { "command": "git diff src/handler.py" }
+      }
+    ],
+    "model": "claude-sonnet-4-5-20250929",
+    "parent_tool_use_id": null
+  },
+  {
+    "kind": "assistant",
+    "content": [
+      {
+        "type": "tool_result",
+        "tool_use_id": "tu-bash-1",
+        "content": "--- a/src/handler.py\n+++ b/src/handler.py\n@@ -1,2 +1,4 @@\n def handle(req):\n+    if not req:\n+        return 400\n     return 200",
+        "is_error": false
+      }
+    ],
+    "model": "claude-sonnet-4-5-20250929",
+    "parent_tool_use_id": null
+  },
+  {
+    "kind": "stream_event",
+    "uuid": "e4",
+    "session_id": "test-bashdiff-001",
+    "event": {
+      "type": "content_block_start",
+      "content_block": { "type": "text" }
+    }
+  },
+  {
+    "kind": "stream_event",
+    "uuid": "e5",
+    "session_id": "test-bashdiff-001",
+    "event": {
+      "type": "content_block_delta",
+      "delta": { "type": "text_delta", "text": "Here are the changes." }
+    }
+  },
+  {
+    "kind": "stream_event",
+    "uuid": "e6",
+    "session_id": "test-bashdiff-001",
+    "event": { "type": "message_stop" }
+  },
+  {
+    "kind": "result",
+    "subtype": "success",
+    "session_id": "test-bashdiff-001",
+    "duration_ms": 300,
+    "total_cost_usd": 0.001,
+    "num_turns": 1,
+    "result": "Here are the changes.",
+    "is_error": false
+  }
+]

--- a/charts/bosun/backend/tests/fixtures/edit_file.json
+++ b/charts/bosun/backend/tests/fixtures/edit_file.json
@@ -1,0 +1,91 @@
+[
+  { "kind": "system_init", "data": { "session_id": "test-edit-001" } },
+  {
+    "kind": "stream_event",
+    "uuid": "e1",
+    "session_id": "test-edit-001",
+    "event": {
+      "type": "content_block_start",
+      "content_block": { "type": "text" }
+    }
+  },
+  {
+    "kind": "stream_event",
+    "uuid": "e2",
+    "session_id": "test-edit-001",
+    "event": {
+      "type": "content_block_delta",
+      "delta": { "type": "text_delta", "text": "I'll fix that function." }
+    }
+  },
+  {
+    "kind": "stream_event",
+    "uuid": "e3",
+    "session_id": "test-edit-001",
+    "event": { "type": "message_stop" }
+  },
+  {
+    "kind": "assistant",
+    "content": [
+      {
+        "type": "tool_use",
+        "id": "tu-edit-1",
+        "name": "Edit",
+        "input": {
+          "file_path": "src/handler.py",
+          "old_string": "def handle(req):\n    return 200",
+          "new_string": "def handle(req):\n    if not req:\n        return 400\n    return 200"
+        }
+      }
+    ],
+    "model": "claude-sonnet-4-5-20250929",
+    "parent_tool_use_id": null
+  },
+  {
+    "kind": "assistant",
+    "content": [
+      {
+        "type": "tool_result",
+        "tool_use_id": "tu-edit-1",
+        "content": "File edited successfully.",
+        "is_error": false
+      }
+    ],
+    "model": "claude-sonnet-4-5-20250929",
+    "parent_tool_use_id": null
+  },
+  {
+    "kind": "stream_event",
+    "uuid": "e4",
+    "session_id": "test-edit-001",
+    "event": {
+      "type": "content_block_start",
+      "content_block": { "type": "text" }
+    }
+  },
+  {
+    "kind": "stream_event",
+    "uuid": "e5",
+    "session_id": "test-edit-001",
+    "event": {
+      "type": "content_block_delta",
+      "delta": { "type": "text_delta", "text": "Added input validation." }
+    }
+  },
+  {
+    "kind": "stream_event",
+    "uuid": "e6",
+    "session_id": "test-edit-001",
+    "event": { "type": "message_stop" }
+  },
+  {
+    "kind": "result",
+    "subtype": "success",
+    "session_id": "test-edit-001",
+    "duration_ms": 600,
+    "total_cost_usd": 0.002,
+    "num_turns": 1,
+    "result": "Added input validation.",
+    "is_error": false
+  }
+]

--- a/charts/bosun/backend/tests/fixtures/write_mermaid.json
+++ b/charts/bosun/backend/tests/fixtures/write_mermaid.json
@@ -1,0 +1,90 @@
+[
+  { "kind": "system_init", "data": { "session_id": "test-mermaid-write-001" } },
+  {
+    "kind": "stream_event",
+    "uuid": "e1",
+    "session_id": "test-mermaid-write-001",
+    "event": {
+      "type": "content_block_start",
+      "content_block": { "type": "text" }
+    }
+  },
+  {
+    "kind": "stream_event",
+    "uuid": "e2",
+    "session_id": "test-mermaid-write-001",
+    "event": {
+      "type": "content_block_delta",
+      "delta": { "type": "text_delta", "text": "I'll create an architecture diagram for you." }
+    }
+  },
+  {
+    "kind": "stream_event",
+    "uuid": "e3",
+    "session_id": "test-mermaid-write-001",
+    "event": { "type": "message_stop" }
+  },
+  {
+    "kind": "assistant",
+    "content": [
+      {
+        "type": "tool_use",
+        "id": "tu-write-1",
+        "name": "Write",
+        "input": {
+          "file_path": "architecture.mmd",
+          "content": "graph TD\n    A[Frontend] --> B[API Gateway]\n    B --> C[Backend]\n    C --> D[Database]"
+        }
+      }
+    ],
+    "model": "claude-sonnet-4-5-20250929",
+    "parent_tool_use_id": null
+  },
+  {
+    "kind": "assistant",
+    "content": [
+      {
+        "type": "tool_result",
+        "tool_use_id": "tu-write-1",
+        "content": "File written successfully.",
+        "is_error": false
+      }
+    ],
+    "model": "claude-sonnet-4-5-20250929",
+    "parent_tool_use_id": null
+  },
+  {
+    "kind": "stream_event",
+    "uuid": "e4",
+    "session_id": "test-mermaid-write-001",
+    "event": {
+      "type": "content_block_start",
+      "content_block": { "type": "text" }
+    }
+  },
+  {
+    "kind": "stream_event",
+    "uuid": "e5",
+    "session_id": "test-mermaid-write-001",
+    "event": {
+      "type": "content_block_delta",
+      "delta": { "type": "text_delta", "text": "Created the architecture diagram." }
+    }
+  },
+  {
+    "kind": "stream_event",
+    "uuid": "e6",
+    "session_id": "test-mermaid-write-001",
+    "event": { "type": "message_stop" }
+  },
+  {
+    "kind": "result",
+    "subtype": "success",
+    "session_id": "test-mermaid-write-001",
+    "duration_ms": 800,
+    "total_cost_usd": 0.003,
+    "num_turns": 1,
+    "result": "Created the architecture diagram.",
+    "is_error": false
+  }
+]

--- a/charts/bosun/backend/tests/ws_artifacts_test.py
+++ b/charts/bosun/backend/tests/ws_artifacts_test.py
@@ -2,7 +2,8 @@
 Tests for artifact extraction (mermaid blocks).
 
 Validates that mermaid code blocks in assistant text are extracted
-and sent as separate mermaid_artifact WS messages.
+and sent as separate mermaid_artifact WS messages, including when
+mermaid content is written to files via the Write tool.
 """
 
 from unittest.mock import patch
@@ -51,3 +52,26 @@ def test_no_mermaid_when_absent(patched_server):
 
     mermaid_msgs = [m for m in received if m["type"] == "mermaid_artifact"]
     assert len(mermaid_msgs) == 0, "Should not produce mermaid_artifact for plain text"
+
+
+def test_mermaid_from_write_tool(patched_server):
+    """Mermaid content written to .mmd file via Write tool produces mermaid_artifact."""
+    with patch(
+        "asyncio.create_subprocess_exec",
+        side_effect=make_mock_subprocess("write_mermaid.json"),
+    ):
+        client = TestClient(patched_server.app)
+        with client.websocket_connect("/ws") as ws:
+            ws.send_json({"type": "message", "text": "Create a diagram"})
+            received = collect_ws_messages(ws, until_type="result")
+
+    types = [m["type"] for m in received]
+    assert "mermaid_artifact" in types, (
+        f"Expected mermaid_artifact from Write, got: {types}"
+    )
+
+    mermaid_msgs = [m for m in received if m["type"] == "mermaid_artifact"]
+    assert len(mermaid_msgs) == 1
+    assert "graph TD" in mermaid_msgs[0]["code"]
+    assert "A[Frontend]" in mermaid_msgs[0]["code"]
+    assert mermaid_msgs[0]["label"] == "architecture.mmd"

--- a/charts/bosun/backend/tests/ws_diff_test.py
+++ b/charts/bosun/backend/tests/ws_diff_test.py
@@ -1,0 +1,77 @@
+"""
+Tests for diff artifact detection.
+
+Validates that code diffs are extracted from Edit tool inputs and from
+tool results containing unified diff output (e.g. git diff), and sent
+as 'diff' WS events that the frontend can render.
+"""
+
+from unittest.mock import patch
+
+import pytest
+from starlette.testclient import TestClient
+
+from charts.bosun.backend.tests.conftest import (
+    make_mock_subprocess,
+    collect_ws_messages,
+)
+
+
+def test_edit_tool_produces_diff(patched_server):
+    """Edit tool_use with old_string/new_string emits a diff event."""
+    with patch(
+        "asyncio.create_subprocess_exec",
+        side_effect=make_mock_subprocess("edit_file.json"),
+    ):
+        client = TestClient(patched_server.app)
+        with client.websocket_connect("/ws") as ws:
+            ws.send_json({"type": "message", "text": "Fix the function"})
+            received = collect_ws_messages(ws, until_type="result")
+
+    types = [m["type"] for m in received]
+    assert "diff" in types, f"Expected 'diff' event from Edit tool, got: {types}"
+
+    diff_msgs = [m for m in received if m["type"] == "diff"]
+    assert len(diff_msgs) == 1
+    diff = diff_msgs[0]
+    assert diff["file"] == "handler.py"
+    assert "--- a/src/handler.py" in diff["content"]
+    assert "+++ b/src/handler.py" in diff["content"]
+    assert "+    if not req:" in diff["content"]
+    assert "+        return 400" in diff["content"]
+
+
+def test_bash_diff_output_produces_diff(patched_server):
+    """Bash tool result containing unified diff emits a diff event."""
+    with patch(
+        "asyncio.create_subprocess_exec",
+        side_effect=make_mock_subprocess("bash_diff.json"),
+    ):
+        client = TestClient(patched_server.app)
+        with client.websocket_connect("/ws") as ws:
+            ws.send_json({"type": "message", "text": "Show me the changes"})
+            received = collect_ws_messages(ws, until_type="result")
+
+    types = [m["type"] for m in received]
+    assert "diff" in types, f"Expected 'diff' event from Bash output, got: {types}"
+
+    diff_msgs = [m for m in received if m["type"] == "diff"]
+    assert len(diff_msgs) == 1
+    diff = diff_msgs[0]
+    assert "--- a/src/handler.py" in diff["content"]
+    assert "+    if not req:" in diff["content"]
+
+
+def test_no_diff_for_plain_tool_result(patched_server):
+    """Tool results without diff content should not produce diff events."""
+    with patch(
+        "asyncio.create_subprocess_exec",
+        side_effect=make_mock_subprocess("simple_text.json"),
+    ):
+        client = TestClient(patched_server.app)
+        with client.websocket_connect("/ws") as ws:
+            ws.send_json({"type": "message", "text": "Hello"})
+            received = collect_ws_messages(ws, until_type="result")
+
+    diff_msgs = [m for m in received if m["type"] == "diff"]
+    assert len(diff_msgs) == 0, "Should not produce diff for plain text response"


### PR DESCRIPTION
## Summary

- **System prompt** via `--append-system-prompt` — instructs Claude to use relative paths, render mermaid inline, use GFM markdown (not HTML/LaTeX), and adapt formatting for TTS
- **Diff artifact detection** from Edit tool inputs (constructs unified diff from old/new strings) and tool results containing `git diff` output — the frontend already renders these with colored add/remove lines
- **Rewritten TTS summary prompt** — actionable briefings instead of verbose summaries; surfaces blockers/questions for voice response; suggests concrete follow-up actions
- **Write-tool mermaid fallback** — detects mermaid content in `.mmd` files or files with ` ```mermaid ` blocks written via the Write tool

## Context

After merging #546 (CLI subprocess), three issues surfaced:
1. Claude explores `/repos/golden` via absolute paths instead of staying in the session clone
2. Mermaid diagrams and code diffs aren't rendered as artifacts when Claude writes them to files or uses Edit/Bash tools
3. TTS summaries are too descriptive ("The agent investigated the file and found...") instead of actionable ("PR is ready" or "Which auth method do you want?")

## Changes

| File | What changed |
|------|-------------|
| `server.py` | `_BOSUN_SYSTEM_PROMPT` (GFM rules, relative paths, mermaid inline, TTS awareness); `_make_edit_diff()` + `_DIFF_RE` for diff detection; diff emission in Edit tool_use and tool_result handlers; rewritten `_SUMMARY_PROMPT` |
| `tests/ws_diff_test.py` | New: 3 tests for Edit diff, Bash diff output, and no-diff-for-plain-text |
| `tests/ws_artifacts_test.py` | New: `test_mermaid_from_write_tool` |
| `tests/BUILD` | Added `ws_diff_test` target |
| `fixtures/` | New: `edit_file.json`, `bash_diff.json`, `write_mermaid.json` |

## Test plan

- [x] All 7 backend tests pass (6 existing + new `ws_diff_test`)
- [x] Format check passes
- [ ] Deploy and verify Claude uses relative paths
- [ ] Edit a file — verify diff artifact renders inline with colored lines
- [ ] Run `git diff` — verify diff output renders as artifact
- [ ] Ask for a diagram — verify mermaid renders inline
- [ ] Complete a task — verify TTS summary is concise and actionable

🤖 Generated with [Claude Code](https://claude.com/claude-code)