### PR TITLE
fix(bosun): clear action chips on session switch

### DIFF
--- a/charts/bosun/frontend/src/App.jsx
+++ b/charts/bosun/frontend/src/App.jsx
@@ -304,8 +304,9 @@ export default function App() {
     }
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
-  // Refresh sidebar when session changes (new session created or session resumed)
+  // Refresh sidebar and clear stale UI when session changes
   useEffect(() => {
+    voiceCommands.clearActions();
     if (sessionId) history.refresh();
   }, [sessionId]); // eslint-disable-line react-hooks/exhaustive-deps
 


### PR DESCRIPTION
## Summary
- Action buttons (e.g. "Explain the architecture", "Edit the diagram") from a previous session's TTS response persisted when switching to a new/different session
- Root cause: `voiceCommands.actions` state lives in `useVoiceCommands` independently from session state in `useClaudeSocket`, so it was never reset on navigation
- Fix: call `voiceCommands.clearActions()` in the existing `sessionId` effect, which fires for all transition paths (sidebar clicks, new session button, URL params, voice commands)

## Test plan
- [ ] Open a session that has action buttons visible
- [ ] Click "+ New session" — buttons should disappear
- [ ] Go back to the session with actions, then click a different session in the sidebar — buttons should disappear
- [ ] Verify action buttons still appear correctly after a new TTS response completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)