### PR TITLE
docs: add repository URL and gh CLI reference to CLAUDE.md

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,5 +1,16 @@
 # CLAUDE.md - Secure Kubernetes Homelab
 
+## Repository
+
+This repo is hosted at **https://github.com/jomcgi/homelab**. The `gh` CLI is authenticated and available — use it for issues, PRs, and code review:
+
+```bash
+gh issue list
+gh issue view <number>
+gh pr create --title "..." --body "..."
+gh pr view <number>
+```
+
 ## Development Workflow Requirements
 
 **NEVER make changes directly on the main branch.** All modifications MUST:


### PR DESCRIPTION
## Summary
- Adds a **Repository** section near the top of `.claude/CLAUDE.md` with the GitHub URL and `gh` CLI examples
- Fixes an issue where new Claude Code sessions couldn't discover the repo was GitHub-hosted without running `git remote -v`

## Test plan
- [ ] Start a new Claude Code session and verify CLAUDE.md context includes the Repository section
- [ ] Confirm `gh issue list` and `gh pr list` work as documented

🤖 Generated with [Claude Code](https://claude.com/claude-code)