### PR TITLE
chore: add dist/ to root .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ MODULE.bazel.lock
 
 
 node_modules/
+dist/
 
 
 *.venv/


### PR DESCRIPTION
## Summary
- Adds `dist/` to the repo-level `.gitignore` next to `node_modules/`
- Prevents accidental commits of Vite build output from local dev

## Test plan
- [ ] Verify `dist/` directories no longer show in `git status` after local builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)