### PR TITLE
fix(claude-desktop): correct .deb download URL and improve CI workflow

### DIFF
--- a/.github/workflows/claude-desktop-image.yaml
+++ b/.github/workflows/claude-desktop-image.yaml
@@ -3,6 +3,8 @@ on:
   push:
     branches: [main]
     paths: ['charts/claude-desktop/image/**']
+  pull_request:
+    paths: ['charts/claude-desktop/image/**']
   workflow_dispatch:
 concurrency:
   group: claude-desktop-image-${{ github.ref }}
@@ -21,11 +23,18 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - uses: docker/setup-buildx-action@v3
+      - uses: docker/metadata-action@v5
+        id: meta
+        with:
+          images: ghcr.io/jomcgi/homelab/charts/claude-desktop
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=sha
       - uses: docker/build-push-action@v6
         with:
           context: charts/claude-desktop/image
           platforms: linux/amd64,linux/arm64
-          push: true
-          tags: |
-            ghcr.io/jomcgi/homelab/charts/claude-desktop:main
-            ghcr.io/jomcgi/homelab/charts/claude-desktop:${{ github.sha }}
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/charts/claude-desktop/image/Dockerfile
+++ b/charts/claude-desktop/image/Dockerfile
@@ -1,10 +1,13 @@
 FROM debian:bookworm-slim
 ARG TARGETARCH
-ARG CLAUDE_DESKTOP_VERSION=1.1.3830-1.3.12
+# Release tag: v${PKG_VERSION}+claude${CLAUDE_VERSION}
+# Asset name:  claude-desktop_${CLAUDE_VERSION}-${PKG_VERSION}_${arch}.deb
+ARG CLAUDE_VERSION=1.1.3830
+ARG PKG_VERSION=1.3.12
 
+# Install system deps + xpra
 RUN apt-get update && apt-get install -y --no-install-recommends \
       ca-certificates wget gnupg && \
-    # xpra official repo
     wget -qO /usr/share/keyrings/xpra.asc https://xpra.org/xpra.asc && \
     echo "deb [signed-by=/usr/share/keyrings/xpra.asc] https://xpra.org/ bookworm main" \
       > /etc/apt/sources.list.d/xpra.list && \
@@ -13,11 +16,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       libgtk-3-0 libnotify4 libnss3 libxss1 libxtst6 \
       libatspi2.0-0 libdrm2 libgbm1 libasound2 \
       fonts-liberation fonts-noto-color-emoji && \
-    # claude-desktop .deb
-    DEB_ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "arm64" || echo "amd64") && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Install claude-desktop .deb (separate layer for version bump caching)
+RUN DEB_ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "arm64" || echo "amd64") && \
     wget -qO /tmp/claude-desktop.deb \
-      "https://github.com/aaddrick/claude-desktop-debian/releases/download/v${CLAUDE_DESKTOP_VERSION}/claude-desktop_${CLAUDE_DESKTOP_VERSION}_${DEB_ARCH}.deb" && \
-    apt-get install -y /tmp/claude-desktop.deb && \
+      "https://github.com/aaddrick/claude-desktop-debian/releases/download/v${PKG_VERSION}%2Bclaude${CLAUDE_VERSION}/claude-desktop_${CLAUDE_VERSION}-${PKG_VERSION}_${DEB_ARCH}.deb" && \
+    apt-get update && apt-get install -y /tmp/claude-desktop.deb && \
     rm /tmp/claude-desktop.deb && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Summary
- Fix wget 404: release tag is `v{pkg}+claude{ver}` (URL-encoded `%2B`), not `v{ver}-{pkg}`. Split `CLAUDE_DESKTOP_VERSION` into `CLAUDE_VERSION` + `PKG_VERSION` ARGs
- Add `pull_request` trigger so image builds are validated on PRs (build-only, no push)
- Replace hardcoded tags with `docker/metadata-action` for dynamic tagging (`main`, `pr-N`, `sha-abc1234`)
- Split Dockerfile into separate xpra + claude-desktop layers for better caching

## Test plan
- [x] `podman build --platform linux/amd64` succeeds locally
- [ ] CI builds on this PR (validates the PR trigger works)
- [ ] After merge, CI pushes to GHCR with `main` and `sha-*` tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)