### PR TITLE
fix(claude-desktop): add ghcr-pull-secret via 1Password

### DIFF
--- a/charts/claude-desktop/templates/image-pull-secret.yaml
+++ b/charts/claude-desktop/templates/image-pull-secret.yaml
@@ -1,0 +1,9 @@
+apiVersion: onepassword.com/v1
+kind: OnePasswordItem
+type: kubernetes.io/dockerconfigjson
+metadata:
+  name: ghcr-pull-secret
+  labels:
+    {{- include "claude-desktop.labels" . | nindent 4 }}
+spec:
+  itemPath: "vaults/k8s-homelab/items/ghcr-read-permissions"


### PR DESCRIPTION
## Summary
- Pod stuck in `ImagePullBackOff` — the `ghcr-pull-secret` doesn't exist in the `claude-desktop` namespace
- Add `OnePasswordItem` template that syncs docker credentials from `vaults/k8s-homelab/items/ghcr-read-permissions` (same pattern as bosun/claude charts)

## Test plan
- [ ] ArgoCD syncs the new template
- [ ] 1Password operator creates `ghcr-pull-secret` in `claude-desktop` namespace
- [ ] Pod pulls image and starts successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)