### PR TITLE
fix(cloudflare-tunnel): disable envoy sidecar to fix QUIC instability

### DIFF
--- a/overlays/prod/cloudflare-tunnel/values.yaml
+++ b/overlays/prod/cloudflare-tunnel/values.yaml
@@ -72,12 +72,9 @@ resources:
     cpu: 250m
     memory: 256Mi
 
-# Enable Envoy proxy sidecar with tracing to SigNoz
+# Envoy proxy sidecar disabled - QUIC tunnel connections were cycling every
+# ~60s with "timeout: no recent network activity", causing intermittent 503s.
+# The iptables rules from the transparent proxy init container likely interfere
+# with UDP conntrack for QUIC flows. Re-enable after investigating root cause.
 envoy:
-  enabled: true
-  # Enable transparent proxy to intercept all outbound traffic
-  transparentProxy:
-    enabled: true
-  tracing:
-    enabled: true
-    serviceName: "cloudflare-tunnel-ingress"
+  enabled: false


### PR DESCRIPTION
## Summary

- Disables the Envoy transparent proxy sidecar on cloudflare-tunnel pods
- Both cloudflared pods were experiencing chronic QUIC connection cycling (~60s intervals) with `timeout: no recent network activity` errors
- During reconnection windows, Cloudflare's edge returned 503 for in-flight requests, breaking services like claude-desktop's Xpra HTML5 client

## Root Cause Analysis

The Envoy transparent proxy's init container adds iptables rules to the `OUTPUT` chain in the `nat` table. While these rules explicitly target `-p tcp`, they likely interfere with UDP conntrack state for QUIC flows. Evidence:

- All files serve 200 via `kubectl port-forward` (bypassing tunnel)
- All files serve 200 from inside the pod
- Both cloudflared pods on different nodes show identical QUIC cycling
- 12+ warnings/errors per pod per minute

## Test plan

- [ ] Verify cloudflared pods restart without Envoy sidecar (1/1 containers)
- [ ] Verify QUIC connections stabilize (no more `timeout: no recent network activity`)
- [ ] Verify `claude.jomcgi.dev` loads all JS files without 503s
- [ ] Verify other tunneled services (argocd, signoz, etc.) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)