### PR TITLE
fix(grimoire): route /ws through nginx proxy instead of Tunnel CRD

### DIFF
--- a/charts/grimoire/templates/frontend-deployment.yaml
+++ b/charts/grimoire/templates/frontend-deployment.yaml
@@ -13,6 +13,8 @@ spec:
       app.kubernetes.io/component: frontend
   template:
     metadata:
+      annotations:
+        checksum/nginx-config: {{ include (print $.Template.BasePath "/nginx-configmap.yaml") . | sha256sum }}
       labels:
         {{- include "grimoire.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: frontend
@@ -43,6 +45,9 @@ spec:
                 - ALL
             readOnlyRootFilesystem: true
           volumeMounts:
+            - name: nginx-config
+              mountPath: /etc/nginx/conf.d
+              readOnly: true
             - name: nginx-cache
               mountPath: /var/cache/nginx
             - name: nginx-run
@@ -62,6 +67,9 @@ spec:
           resources:
             {{- toYaml .Values.frontend.resources | nindent 12 }}
       volumes:
+        - name: nginx-config
+          configMap:
+            name: {{ include "grimoire.fullname" . }}-nginx
         - name: nginx-cache
           emptyDir: {}
         - name: nginx-run

--- a/charts/grimoire/templates/nginx-configmap.yaml
+++ b/charts/grimoire/templates/nginx-configmap.yaml
@@ -1,0 +1,39 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "grimoire.fullname" . }}-nginx
+  labels:
+    {{- include "grimoire.labels" . | nindent 4 }}
+    app.kubernetes.io/component: frontend
+data:
+  default.conf: |
+    upstream ws_gateway {
+        server {{ include "grimoire.fullname" . }}-ws-gateway:{{ .Values.wsGateway.service.port }};
+    }
+
+    server {
+        listen 8080;
+        server_name _;
+
+        root /usr/share/nginx/html;
+        index index.html;
+
+        # WebSocket proxy to ws-gateway service
+        location /ws {
+            proxy_pass http://ws_gateway;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_read_timeout 86400s;
+            proxy_send_timeout 86400s;
+        }
+
+        # SPA fallback — serve index.html for client-side routes
+        location / {
+            try_files $uri $uri/ /index.html;
+        }
+    }

--- a/charts/grimoire/values.yaml
+++ b/charts/grimoire/values.yaml
@@ -74,9 +74,9 @@ geminiSecret:
   onepassword:
     itemPath: "vaults/Homelab/items/grimoire-gemini-api-key"
 
-# Cloudflare Tunnel
+# Cloudflare Tunnel (disabled — routing handled by shared cloudflare-tunnel chart)
 tunnel:
-  enabled: true
+  enabled: false
   hostname: grimoire.jomcgi.dev
 
 # Image pull secret for private GHCR registry

--- a/overlays/prod/cloudflare-tunnel/values.yaml
+++ b/overlays/prod/cloudflare-tunnel/values.yaml
@@ -21,6 +21,9 @@ ingress:
     # Shared image hosting (projects use /project-name/ prefix)
     - hostname: img.jomcgi.dev
       service: http://trips-nginx.trips.svc.cluster.local:80
+    # D&D campaign manager (nginx proxies /ws to ws-gateway internally)
+    - hostname: grimoire.jomcgi.dev
+      service: http://grimoire-frontend.grimoire.svc.cluster.local:8080
     # Shared API hosting (route-based: /trips, /cluster-info, etc.)
     - hostname: api.jomcgi.dev
       service: http://api-gateway.api-gateway.svc.cluster.local:80


### PR DESCRIPTION
## Summary
- Grimoire's ArgoCD Application was stuck in `SyncFailed` because the chart's `tunnel.yaml` template references a `cloudflare.jomcgi.dev/Tunnel` CRD that doesn't exist on the cluster
- Instead of installing a new CRD/operator, this routes `grimoire.jomcgi.dev` through the existing shared `cloudflare-tunnel` chart and adds an nginx reverse proxy in the frontend pod to split `/ws` traffic to the ws-gateway service

## Changes
- **New:** `charts/grimoire/templates/nginx-configmap.yaml` — nginx config with `proxy_pass` for `/ws` → `grimoire-ws-gateway:8080` and SPA fallback for React Router
- **Modified:** `charts/grimoire/templates/frontend-deployment.yaml` — mounts the ConfigMap at `/etc/nginx/conf.d`, adds checksum annotation for rollout on config change
- **Modified:** `charts/grimoire/values.yaml` — sets `tunnel.enabled: false`
- **Modified:** `overlays/prod/cloudflare-tunnel/values.yaml` — adds `grimoire.jomcgi.dev` route pointing to the frontend service

## Architecture

```
Browser → grimoire.jomcgi.dev
  → Cloudflare Tunnel → grimoire-frontend:8080 (nginx)
    → /ws  → proxy_pass → grimoire-ws-gateway:8080 (Go)
    → /*   → static React build (try_files with SPA fallback)
```

## Test plan
- [ ] Verify chart renders cleanly: `helm template grimoire charts/grimoire -f overlays/dev/grimoire/values.yaml`
- [ ] Confirm ArgoCD Application syncs successfully after merge
- [ ] Verify `grimoire.jomcgi.dev` serves the frontend
- [ ] Verify WebSocket connections to `wss://grimoire.jomcgi.dev/ws` reach the ws-gateway

🤖 Generated with [Claude Code](https://claude.com/claude-code)