### PR TITLE
fix(format): make pre-commit format identical to CI

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,15 +10,14 @@ repos:
         always_run: true
         pass_filenames: false
 
-      # Fast format - builds all tools once, runs in parallel
-      # Only triggered when code files change
+      # Fast format - identical to CI's format check
+      # Runs all formatters, script generators, and gazelle
       - id: format-code
         name: Format code
-        entry: tools/format/fast-format.sh staged
+        entry: tools/format/fast-format.sh
         language: script
+        always_run: true
         pass_filenames: false
-        types_or: [python, go, shell, javascript, json, markdown, yaml]
-        files: '\.(py|go|sh|js|jsx|ts|tsx|json|md|yaml|yml|bzl)$|BUILD'
 
       # Lock file updates - only when source files change
       - id: update-python-requirements

--- a/tools/format/BUILD
+++ b/tools/format/BUILD
@@ -72,13 +72,8 @@ sh_binary(
 )
 
 # Fast format script - builds once, runs in parallel
-# Use this instead of multirun for better performance
+# Used by both pre-commit and CI for identical formatting
 sh_binary(
     name = "fast_format",
     srcs = ["fast-format.sh"],
-    data = [
-        ":update_apko_locks",
-        ":update_python_requirements",
-        ":validate_apko_configs",
-    ],
 )

--- a/tools/format/fast-format.sh
+++ b/tools/format/fast-format.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Fast format script - builds tools once, runs in parallel
-# Much faster than multirun which has bazel overhead per tool
+# Used by both pre-commit and CI for identical formatting
 set -euo pipefail
 
 cd "${BUILD_WORKSPACE_DIRECTORY:-$(git rev-parse --show-toplevel)}"
@@ -11,37 +11,18 @@ NC='\033[0m'
 
 log() { echo -e "${GREEN}▶${NC} $1"; }
 
-# Check if any staged files match a pattern
-staged_matches() {
-	git diff --cached --name-only 2>/dev/null | grep -qE "$1" || return 1
-}
-
-# Determine mode: "staged" for pre-commit, "all" for full format
-MODE="${1:-all}"
-if [[ "$MODE" == "staged" ]]; then
-	log "Pre-commit mode (staged files only)"
-else
-	log "Full format"
-fi
-
 # Build all format tools + script generators in one shot
 log "Building tools..."
-TARGETS=(
-	@aspect_rules_lint//format:ruff
-	@aspect_rules_lint//format:shfmt
-	@buildifier_prebuilt//:buildifier
-	//tools/format:prettier
-)
-
-if [[ "$MODE" == "all" ]] || staged_matches '\.go$'; then
-	TARGETS+=(@aspect_rules_lint//format:gofumpt)
-fi
-
-if [[ "$MODE" == "all" ]]; then
-	TARGETS+=(//scripts:generate-push-all //scripts:generate-push-all-pages //scripts:generate-render-all)
-fi
-
-bazel build "${TARGETS[@]}" 2>&1 | grep -v "^INFO:" || true
+bazel build \
+	@aspect_rules_lint//format:ruff \
+	@aspect_rules_lint//format:shfmt \
+	@aspect_rules_lint//format:gofumpt \
+	@buildifier_prebuilt//:buildifier \
+	//tools/format:prettier \
+	//scripts:generate-push-all \
+	//scripts:generate-push-all-pages \
+	//scripts:generate-render-all \
+	2>&1 | grep -v "^INFO:" || true
 
 # Find binaries in bazel-bin (faster than cquery)
 # -L follows symlinks (bazel-bin itself is a symlink)
@@ -58,62 +39,48 @@ RUFF=$(find_bin ruff)
 SHFMT=$(find_bin shfmt)
 BUILDIFIER=$(find_bin buildifier)
 PRETTIER=$(find_bin prettier)
+GOFUMPT=$(find_bin gofumpt)
 
-# Run formatters AND script generators in parallel
+# Run formatters and script generators in parallel
 log "Formatting..."
 PIDS=()
 
 # Python
-if [[ "$MODE" == "all" ]] || staged_matches '\.py$'; then
-	"$RUFF" format . 2>/dev/null &
-	PIDS+=($!)
-fi
+"$RUFF" format . 2>/dev/null &
+PIDS+=($!)
 
 # Shell
-if [[ "$MODE" == "all" ]] || staged_matches '\.(sh|bash)$'; then
-	(find . -name '*.sh' -not -path './bazel-*' -not -path './.git/*' -print0 |
-		xargs -0 "$SHFMT" -w 2>/dev/null || true) &
-	PIDS+=($!)
-fi
+(find . -name '*.sh' -not -path './bazel-*' -not -path './.git/*' -print0 |
+	xargs -0 "$SHFMT" -w 2>/dev/null || true) &
+PIDS+=($!)
 
 # Starlark
-if [[ "$MODE" == "all" ]] || staged_matches '\.(bzl|BUILD|bazel)$'; then
-	"$BUILDIFIER" -r . 2>/dev/null &
-	PIDS+=($!)
-fi
+"$BUILDIFIER" -r . 2>/dev/null &
+PIDS+=($!)
 
 # Go
-if [[ "$MODE" == "all" ]] || staged_matches '\.go$'; then
-	GOFUMPT=$(find_bin gofumpt)
-	(find . -name '*.go' -not -path './bazel-*' -not -path './.git/*' -print0 |
-		xargs -0 "$GOFUMPT" -w 2>/dev/null || true) &
-	PIDS+=($!)
-fi
+(find . -name '*.go' -not -path './bazel-*' -not -path './.git/*' -print0 |
+	xargs -0 "$GOFUMPT" -w 2>/dev/null || true) &
+PIDS+=($!)
 
 # Prettier (JS/TS/JSON/YAML/MD)
-if [[ "$MODE" == "all" ]] || staged_matches '\.(js|jsx|ts|tsx|json|md|yaml|yml)$'; then
-	"$PRETTIER" --write . 2>/dev/null &
-	PIDS+=($!)
-fi
+"$PRETTIER" --write . 2>/dev/null &
+PIDS+=($!)
 
 # Script generators (run in parallel with formatters)
-if [[ "$MODE" == "all" ]]; then
-	$(find_bin generate-push-all) 2>/dev/null &
-	PIDS+=($!)
-	$(find_bin generate-push-all-pages) 2>/dev/null &
-	PIDS+=($!)
-	$(find_bin generate-render-all) &
-	PIDS+=($!)
-fi
+$(find_bin generate-push-all) 2>/dev/null &
+PIDS+=($!)
+$(find_bin generate-push-all-pages) 2>/dev/null &
+PIDS+=($!)
+$(find_bin generate-render-all) &
+PIDS+=($!)
 
 # Wait for all parallel tasks
 for pid in "${PIDS[@]}"; do wait "$pid" 2>/dev/null || true; done
 
 # Gazelle (generates BUILD files for Go/Python)
 # Run after formatters complete since it needs formatted files
-if [[ "$MODE" == "all" ]] || staged_matches '\.(go|py)$'; then
-	log "Running gazelle..."
-	bazel run //:gazelle 2>&1 | grep -v "^INFO:" || true
-fi
+log "Running gazelle..."
+bazel run //:gazelle 2>&1 | grep -v "^INFO:" || true
 
 log "Done!"


### PR DESCRIPTION
## Summary
- Removed the `staged`/`all` mode split from `fast-format.sh` so pre-commit runs the exact same steps as CI
- Pre-commit now always runs all formatters, script generators, and gazelle (previously skipped in `staged` mode)
- Removed dead `data` deps from the `fast_format` Bazel target (the script never invoked them)

### What was wrong

Pre-commit ran `fast-format.sh staged` which:
1. Only ran formatters for file types matching staged files
2. Skipped script generators (`generate-push-all`, etc.)
3. Only ran gazelle when `.go`/`.py` files were staged

CI ran `bazel run //tools/format:fast_format` which defaults to `all` mode — running everything unconditionally. This meant code could pass pre-commit locally but fail CI's format check.

### What changed

`fast-format.sh` no longer accepts a mode argument. It always runs the full format (same as CI). The pre-commit hook calls it with `always_run: true` instead of filtering by file type.

Lock file update hooks (`update-python-requirements`, `update-apko-locks`) are kept as separate pre-commit hooks since they're triggered by specific file changes.

## Test plan
- [x] Pre-commit passes on this commit
- [ ] CI format check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)