### PR TITLE
fix(grimoire): use :main image tag and enable image updater

### DIFF
--- a/overlays/dev/grimoire/values.yaml
+++ b/overlays/dev/grimoire/values.yaml
@@ -26,11 +26,11 @@ imagePullSecret:
 frontend:
   image:
     repository: ghcr.io/jomcgi/homelab/services/grimoire-frontend
-    tag: latest
-    pullPolicy: IfNotPresent
+    tag: main
+    pullPolicy: Always
 # WebSocket Gateway image
 wsGateway:
   image:
     repository: ghcr.io/jomcgi/homelab/services/grimoire-ws-gateway
-    tag: latest
-    pullPolicy: IfNotPresent
+    tag: main
+    pullPolicy: Always


### PR DESCRIPTION
## Summary

- Fix `ImagePullBackOff` on `grimoire-frontend` and `grimoire-ws-gateway` pods
- The overlay `values.yaml` was setting image tags to `latest`, but CI pushes images as `:main`
- Also switched `pullPolicy` from `IfNotPresent` to `Always` — required for mutable tags so kubelet re-pulls when the digest changes
- The `imageUpdater` config was already in place (`enabled: true`), so once the tags match, ArgoCD Image Updater will start pinning digests automatically

## What was broken

```
Failed to pull image "ghcr.io/jomcgi/homelab/services/grimoire-frontend:latest": not found
Failed to pull image "ghcr.io/jomcgi/homelab/services/grimoire-ws-gateway:latest": not found
```

## Changes

| Field | Before | After |
|-------|--------|-------|
| `frontend.image.tag` | `latest` | `main` |
| `wsGateway.image.tag` | `latest` | `main` |
| `frontend.image.pullPolicy` | `IfNotPresent` | `Always` |
| `wsGateway.image.pullPolicy` | `IfNotPresent` | `Always` |

## Test plan

- [ ] ArgoCD syncs grimoire app successfully
- [ ] Frontend and ws-gateway pods start without ImagePullBackOff
- [ ] ImageUpdater resource is created in argocd namespace
- [ ] ImageUpdater detects and writes back digests on next CI push

🤖 Generated with [Claude Code](https://claude.com/claude-code)