### PR TITLE
test(oci): auto-generate apko lock staleness tests

### DIFF
--- a/tools/oci/BUILD
+++ b/tools/oci/BUILD
@@ -9,7 +9,10 @@ config_setting(
 
 # Export push template for apko_push rule
 exports_files(
-    ["apko_push.sh.tpl"],
+    [
+        "apko_push.sh.tpl",
+        "verify-apko-lock.sh",
+    ],
     visibility = ["//visibility:public"],
 )
 
@@ -46,6 +49,7 @@ bzl_library(
         "@aspect_bazel_lib//lib:transitions",
         "@rules_apko//apko:defs",
         "@rules_oci//oci:defs",
+        "@rules_shell//shell:rules_bzl",
     ],
 )
 

--- a/tools/oci/apko_image.bzl
+++ b/tools/oci/apko_image.bzl
@@ -4,6 +4,7 @@ load("@aspect_bazel_lib//lib:expand_template.bzl", "expand_template")
 load("@aspect_bazel_lib//lib:transitions.bzl", "platform_transition_filegroup")
 load("@rules_apko//apko:defs.bzl", _apko_image = "apko_image")
 load("@rules_oci//oci:defs.bzl", "oci_image", "oci_image_index", "oci_push")
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
 load("//tools/oci:apko_push.bzl", "apko_push")
 load("//tools/oci:oci_run.bzl", "oci_run")
 
@@ -39,6 +40,7 @@ def apko_image(
         :{name} - The apko image target (or oci_image_index if tars are provided)
         :{name}.push - Target to push image to registry
         :{name}.run - Target to run image locally (without pushing)
+        :{name}_lock_test - Test that verifies lock file is in sync with config
 
     Examples:
         # Using new API
@@ -215,4 +217,17 @@ def apko_image(
     oci_run(
         name = name + ".run",
         image = ":" + name,
+    )
+
+    # Verify lock file checksum matches config
+    # Catches stale lock files in CI via `bazel test //...`
+    lock = config.replace(".yaml", ".lock.json")
+    sh_test(
+        name = name + "_lock_test",
+        srcs = ["//tools/oci:verify-apko-lock.sh"],
+        args = [
+            "$(location " + config + ")",
+            "$(location " + lock + ")",
+        ],
+        data = [config, lock],
     )

--- a/tools/oci/verify-apko-lock.sh
+++ b/tools/oci/verify-apko-lock.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Verify an apko lock file is in sync with its config.
+# Compares the SHA-256 checksum embedded in the lock file against the actual config.
+# Usage: verify-apko-lock.sh <config.yaml> <config.lock.json>
+set -euo pipefail
+
+CONFIG="$1"
+LOCK="$2"
+
+# Compute SHA-256 of config in SRI format
+COMPUTED="sha256-$(openssl dgst -sha256 -binary "$CONFIG" | openssl base64 -A)"
+
+# Extract checksum from lock file
+EXPECTED=$(python3 -c "import json,sys; print(json.load(open(sys.argv[1]))['config']['checksum'])" "$LOCK")
+
+if [ "$COMPUTED" != "$EXPECTED" ]; then
+	echo "ERROR: apko lock file is stale!"
+	echo "  Config:   $CONFIG"
+	echo "  Lock:     $LOCK"
+	echo "  Expected: $EXPECTED"
+	echo "  Got:      $COMPUTED"
+	echo ""
+	echo "Run 'format' to update lock files."
+	exit 1
+fi
+
+echo "OK: apko lock file is in sync with config"


### PR DESCRIPTION
## Summary
- The `apko_image` macro now auto-generates a `:{name}_lock_test` target for every apko image
- The test verifies the SHA-256 checksum embedded in `apko.lock.json` matches the actual `apko.yaml` contents
- Catches stale lock files in CI via `bazel test //...`, closing the gap where `rules_apko` (unlike `pip_compile`) has no built-in staleness check

### How it works

The `apko lock` command embeds an SRI checksum of the config file into the lock file:
```json
"config": {
    "checksum": "sha256-aUXGE5aQFZ2DpshVmynNh7/wOsY3woFK9d9vX6VnrZQ="
}
```

The test computes `sha256(apko.yaml)` and compares it to this embedded value. Fast (~0.2s), offline, no apko binary needed.

### Auto-generated targets

Every `apko_image()` call now produces a test target automatically:
- `//services/grimoire/frontend:image_lock_test`
- `//services/ships_frontend:image_lock_test`
- `//charts/todo/image:image_lock_test`

New apko images get the test for free — no manual wiring required.

## Test plan
- [x] All 3 lock tests pass locally via `bazel test`
- [x] Failure case verified (modified config correctly detected as stale)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)