### PR TITLE
fix(grimoire): add /var/lib/nginx emptyDir and fix UID mismatch

### DIFF
--- a/charts/grimoire/templates/frontend-deployment.yaml
+++ b/charts/grimoire/templates/frontend-deployment.yaml
@@ -26,8 +26,8 @@ spec:
       serviceAccountName: {{ include "grimoire.serviceAccountName" . }}
       securityContext:
         runAsNonRoot: true
-        runAsUser: 1000
-        runAsGroup: 1000
+        runAsUser: 65532
+        runAsGroup: 65532
         seccompProfile:
           type: RuntimeDefault
       containers:
@@ -54,6 +54,8 @@ spec:
               mountPath: /var/run
             - name: nginx-tmp
               mountPath: /tmp
+            - name: nginx-lib
+              mountPath: /var/lib/nginx
           livenessProbe:
             httpGet:
               path: /
@@ -75,4 +77,6 @@ spec:
         - name: nginx-run
           emptyDir: {}
         - name: nginx-tmp
+          emptyDir: {}
+        - name: nginx-lib
           emptyDir: {}


### PR DESCRIPTION
## Summary

- **Add `/var/lib/nginx` emptyDir volume mount** — Wolfi's nginx writes error logs to `/var/lib/nginx/logs/` and temp files to `/var/lib/nginx/tmp/`. With `readOnlyRootFilesystem: true`, nginx crashed on startup because this path had no writable mount.
- **Fix UID/GID mismatch** (1000 → 65532) — The pod `securityContext` was running as UID 1000, but the container image (apko.yaml) defines `nonroot` user as UID 65532. Aligning these prevents potential permission issues with image-owned files.

## Test plan

- [ ] Verify grimoire-frontend pod starts successfully after ArgoCD sync
- [ ] Confirm nginx serves the SPA at `/`
- [ ] Confirm WebSocket proxy works at `/ws`

🤖 Generated with [Claude Code](https://claude.com/claude-code)