### PR TITLE
build: switch from bazelisk to buildbuddy CLI

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -9,8 +9,6 @@ common --noexperimental_merged_skyframe_analysis_execution
 
 # also see: https://blog.aspect.build/configuring-bazels-downloader
 common --downloader_config=tools/downloader.cfg
-# Scale HTTP timeouts for better reliability with slow connections
-common --http_timeout_scaling=2.0
 # for speed, passes an argument `--skipLibCheck` to *every* spawn of tsc
 common --@aspect_rules_ts//ts:skipLibCheck=always
 # Transpiler is set per-target (transpiler = "tsc") instead of globally.
@@ -104,7 +102,8 @@ build:ci --bes_backend=grpcs://remote.buildbuddy.io
 # =============================================================================
 # Import remote execution config when using --config=remote
 # This allows easy toggling of RBE without modifying this file
-# Note: API key is set in user.bazelrc via --remote_header flag
+# Note: Authenticate locally with `bb login`. CI uses BuildBuddy runner auth.
+# For manual auth, set API key via --remote_header in user.bazelrc
 try-import %workspace%/.bazelrc.remote
 
 # Load any settings & overrides specific to the current user from `.aspect/bazelrc/user.bazelrc`.

--- a/.bazelrc.remote
+++ b/.bazelrc.remote
@@ -10,14 +10,14 @@
 # - Build Event Service (BES) for observability (configured in main .bazelrc)
 # - Managed toolchains (compilers, runtimes)
 #
-# Note: API key must be set via --remote_header in user.bazelrc
+# Auth: Run `bb login` locally. CI uses BuildBuddy runner auth.
+# For manual auth, set API key via --remote_header in user.bazelrc
 
 # =============================================================================
 # Remote Execution - Applied to CI builds
 # =============================================================================
 build:ci --remote_executor=grpcs://remote.buildbuddy.io
 build:ci --remote_cache=grpcs://remote.buildbuddy.io
-build:ci --remote_timeout=3600
 build:ci --jobs=80  # Use all 80 available cores for remote execution
 build:ci --remote_cache_compression  # Faster transfers
 build:ci --remote_download_minimal  # Don't download unnecessary outputs

--- a/.bazelversion
+++ b/.bazelversion
@@ -1,3 +1,2 @@
-
-rolling
-# This selects Bazel 9, which is currently in pre-release as of Sept 2025, expected GA by end of 2025
+buildbuddy-io/5.0.321
+9.0.0


### PR DESCRIPTION
## Summary

- Replace raw Bazelisk with the [BuildBuddy CLI](https://www.buildbuddy.io/cli/) (`bb`), which wraps Bazelisk and adds a local network proxy, `bb login` auth, and plugin support
- Pin Bazel from `rolling` to `9.0.0` (GA since Jan 2026)
- Remove network resilience workarounds that the `bb` proxy makes redundant (`--http_timeout_scaling`, `--remote_timeout`)

## How it works

The `.bazelversion` file now has `buildbuddy-io/5.0.321` as the first line. When Bazelisk sees this, it downloads the `bb` binary from [buildbuddy-io/bazel](https://github.com/buildbuddy-io/bazel/releases) instead of stock Bazel. `bb` then manages the actual Bazel 9.0.0 download from line 2.

For local dev, `bb login` replaces the manual `--remote_header` setup in `user.bazelrc`. CI is unaffected (BuildBuddy runners handle auth natively).

## Test plan

- [ ] Verify `bazel version` shows BuildBuddy CLI wrapper + Bazel 9.0.0
- [ ] Verify `bb login` works for local remote cache auth
- [ ] CI passes (format check + test suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)