### PR TITLE
refactor(grimoire): rename Gemini secret to follow repo conventions

### DIFF
--- a/charts/grimoire/templates/externalsecret.yaml
+++ b/charts/grimoire/templates/externalsecret.yaml
@@ -1,14 +1,14 @@
-{{- if .Values.geminiSecret.enabled }}
+{{- if .Values.grimoireSecret.enabled }}
 ---
-# Gemini API key (synced from 1Password via 1Password Operator)
-# Used by the WebSocket gateway for Gemini Live sessions — never exposed to browsers
+# Grimoire secrets (synced from 1Password via 1Password Operator)
+# Contains GOOGLE_API_KEY for Gemini Live sessions — never exposed to browsers
 apiVersion: onepassword.com/v1
 kind: OnePasswordItem
 metadata:
-  name: {{ .Values.geminiSecret.name }}
+  name: {{ .Values.grimoireSecret.name }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "grimoire.labels" . | nindent 4 }}
 spec:
-  itemPath: {{ .Values.geminiSecret.onepassword.itemPath | quote }}
+  itemPath: {{ .Values.grimoireSecret.onepassword.itemPath | quote }}
 {{- end }}

--- a/charts/grimoire/templates/ws-gateway-deployment.yaml
+++ b/charts/grimoire/templates/ws-gateway-deployment.yaml
@@ -37,11 +37,11 @@ spec:
               containerPort: 8080
               protocol: TCP
           env:
-            - name: GEMINI_API_KEY
+            - name: GOOGLE_API_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.geminiSecret.name }}
-                  key: key
+                  name: {{ .Values.grimoireSecret.name }}
+                  key: GOOGLE_API_KEY
             - name: REDIS_ADDR
               value: "{{ include "grimoire.fullname" . }}-redis:{{ .Values.redis.service.port }}"
             {{- if .Values.redis.auth.enabled }}

--- a/charts/grimoire/values.yaml
+++ b/charts/grimoire/values.yaml
@@ -67,12 +67,12 @@ serviceAccount:
 networkPolicy:
   enabled: true
 
-# Gemini API key secret (synced from 1Password via OnePasswordItem)
-geminiSecret:
+# Grimoire secrets (synced from 1Password via OnePasswordItem)
+grimoireSecret:
   enabled: true
-  name: gemini-api-key
+  name: grimoire
   onepassword:
-    itemPath: "vaults/Homelab/items/grimoire-gemini-api-key"
+    itemPath: "vaults/Homelab/items/grimoire"
 
 # Cloudflare Tunnel (disabled — routing handled by shared cloudflare-tunnel chart)
 tunnel:

--- a/services/grimoire/architecture.md
+++ b/services/grimoire/architecture.md
@@ -663,7 +663,7 @@ Central real-time hub running in the homelab cluster. Serves two roles: (1) game
 - Memory: 256MB (increased for Gemini session buffers)
 - CPU: 200m
 - Replicas: 1 (sufficient for 5-6 concurrent connections)
-- Environment: `GEMINI_API_KEY` from ExternalSecret (1Password)
+- Environment: `GOOGLE_API_KEY` from OnePasswordItem (1Password `grimoire` item)
 
 **Event types (browser ↔ gateway):**
 
@@ -1174,14 +1174,14 @@ deploy-api: build-api
 		--platform=managed \
 		--allow-unauthenticated \
 		--set-env-vars="GCP_PROJECT_ID=$(PROJECT_ID),FIRESTORE_DATABASE=$(FIRESTORE_DB),CF_ACCESS_TEAM=your-team.cloudflareaccess.com" \
-		--set-secrets="GEMINI_API_KEY=gemini-api-key:latest" \
+		--set-secrets="GOOGLE_API_KEY=google-api-key:latest" \
 		--min-instances=0 \
 		--max-instances=2 \
 		--memory=256Mi \
 		--cpu=1 \
 		--concurrency=80
 	@echo "🚀 API deployed to Cloud Run"
-	@echo "   Note: Cloud Run uses GEMINI_API_KEY for Gemini Flash (RAG) + embeddings"
+	@echo "   Note: Cloud Run uses GOOGLE_API_KEY for Gemini Flash (RAG) + embeddings"
 	@echo "   The homelab WS Gateway uses a separate secret synced from 1Password"
 
 # ──────────────────────────────────────────────

--- a/services/grimoire/gcp/Makefile
+++ b/services/grimoire/gcp/Makefile
@@ -75,14 +75,14 @@ deploy-api: build-api
 		--platform=managed \
 		--allow-unauthenticated \
 		--set-env-vars="GCP_PROJECT_ID=$(PROJECT_ID),FIRESTORE_DATABASE=$(FIRESTORE_DB),CF_ACCESS_TEAM=your-team.cloudflareaccess.com" \
-		--set-secrets="GEMINI_API_KEY=gemini-api-key:latest" \
+		--set-secrets="GOOGLE_API_KEY=google-api-key:latest" \
 		--min-instances=0 \
 		--max-instances=2 \
 		--memory=256Mi \
 		--cpu=1 \
 		--concurrency=80
 	@echo "API deployed to Cloud Run"
-	@echo "   Note: Cloud Run uses GEMINI_API_KEY for Gemini Flash (RAG) + embeddings"
+	@echo "   Note: Cloud Run uses GOOGLE_API_KEY for Gemini Flash (RAG) + embeddings"
 	@echo "   The homelab WS Gateway uses a separate secret synced from 1Password"
 
 # ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Rename 1Password item from `grimoire-gemini-api-key` to `grimoire` (matching `marine`, `signoz` convention of one item per service)
- Change secret key from `key` to `GOOGLE_API_KEY` (standard env var that Google client libraries auto-discover)
- Rename Helm values block from `geminiSecret` to `grimoireSecret`
- Update architecture docs and GCP Makefile references

## Manual step required
In the **Homelab** 1Password vault, rename the item `grimoire-gemini-api-key` to `grimoire` and rename the field from `key` to `GOOGLE_API_KEY`.

## Test plan
- [x] `helm template` renders correctly with dev overlay values
- [x] Pre-commit hooks pass (format, secrets detection)
- [ ] Verify 1Password item is updated before ArgoCD syncs

🤖 Generated with [Claude Code](https://claude.com/claude-code)