### PR TITLE
fix(grimoire): use k8s-homelab vault for 1Password secret

### DIFF
--- a/charts/grimoire/values.yaml
+++ b/charts/grimoire/values.yaml
@@ -72,7 +72,7 @@ grimoireSecret:
   enabled: true
   name: grimoire
   onepassword:
-    itemPath: "vaults/Homelab/items/grimoire"
+    itemPath: "vaults/k8s-homelab/items/grimoire"
 
 # Cloudflare Tunnel (disabled — routing handled by shared cloudflare-tunnel chart)
 tunnel:


### PR DESCRIPTION
## Summary
- Fixes grimoire's `OnePasswordItem` to reference `vaults/k8s-homelab/items/grimoire` instead of `vaults/Homelab/items/grimoire`
- Aligns with the vault naming convention used by every other service in the repo

## Test plan
- [ ] Verify ArgoCD syncs the updated `OnePasswordItem` CR
- [ ] Confirm the grimoire secret resolves correctly from the `k8s-homelab` vault

🤖 Generated with [Claude Code](https://claude.com/claude-code)