### PR TITLE
docs(claude): update skills and agents for BuildBuddy CLI

### DIFF
--- a/.claude/AGENTS.md
+++ b/.claude/AGENTS.md
@@ -10,13 +10,13 @@ This file defines specialized agents for common tasks in this repository. Each a
 
 ```bash
 # Run all tests
-bazelisk test //...
+bazel test //...
 
 # Run specific test target
-bazelisk test //services/ships_api:ships_api_test
+bazel test //services/ships_api:ships_api_test
 
 # Run tests in CI mode (remote caching)
-bazelisk test //... --config=ci
+bazel test //... --config=ci
 ```
 
 **When adding new tests:**
@@ -29,7 +29,7 @@ bazelisk test //... --config=ci
 
 ## bazel
 
-Bazel build system specialist using bzlmod (MODULE.bazel). This repo uses Bazel 8 via bazelisk with aspect_rules_py, rules_js, rules_oci, and rules_apko.
+Bazel build system specialist using bzlmod (MODULE.bazel). This repo uses Bazel 9 via BuildBuddy CLI (`bb`) with aspect_rules_py, rules_js, rules_oci, and rules_apko. Shell aliases route `bazel` and `bazelisk` to `bb`.
 
 ### Vendored Tools
 
@@ -63,35 +63,35 @@ The following tools are vendored via `bazel_env` and available in PATH (after `d
 ### Key Commands
 
 ```bash
-# ALWAYS use bazelisk, not bazel directly
+# bazel, bazelisk, and bb are all equivalent (shell aliases route to bb)
 # Format code + update lock files (most common command)
 format
 
 # Build and test
-bazelisk build //...
-bazelisk test //...
-bazelisk run //:target
+bazel build //...
+bazel test //...
+bazel run //:target
 
 # Update BUILD files after adding Go imports
-bazelisk run gazelle
+bazel run gazelle
 
 # Update MODULE.bazel after go mod tidy
 bazel mod tidy
 
 # Push container images
-bazelisk run //charts/<service>/image:push
+bazel run //charts/<service>/image:push
 
 # Query and analysis
-bazelisk query "deps(//:target)"
-bazelisk cquery "deps(//:target)"    # With config
-bazelisk aquery "deps(//:target)"    # Action query
+bazel query "deps(//:target)"
+bazel cquery "deps(//:target)"    # With config
+bazel aquery "deps(//:target)"    # Action query
 
 # Run with CI config (remote caching + BuildBuddy)
-bazelisk test //... --config=ci
+bazel test //... --config=ci
 
 # Debugging
-bazelisk build --explain=log.txt
-bazelisk build --profile=profile.json
+bazel build --explain=log.txt
+bazel build --profile=profile.json
 ```
 
 ### bzlmod Patterns (MODULE.bazel)
@@ -132,7 +132,7 @@ Images are defined in `apko.yaml` files, not Dockerfiles:
 
 ```bash
 # Update apko lock after modifying apko.yaml
-bazelisk run @rules_apko//apko -- lock charts/<service>/image/apko.yaml
+bazel run @rules_apko//apko -- lock charts/<service>/image/apko.yaml
 
 # Or run format to update all locks
 format
@@ -140,12 +140,11 @@ format
 
 ### Common Mistakes to Avoid
 
-- **Using `bazel` instead of `bazelisk`** - bazelisk manages Bazel versions via .bazelversion
 - **Running tests in CI without --config=ci** - Misses remote caching and BuildBuddy
 - **Not pinning toolchains** - Use hermetic toolchains
 - **Using recursive globs** - `glob(["**/*.py"])` breaks caching
 - **Non-hermetic genrules** - Avoid timestamps, uname, or PATH-dependent tools
-- **Forgetting to run gazelle** - After adding Go imports, run `bazelisk run gazelle`
+- **Forgetting to run gazelle** - After adding Go imports, run `bazel run gazelle`
 
 ### Example Prompts
 
@@ -361,17 +360,17 @@ Go development specialist, especially for Kubernetes operators and controllers.
 
 ```bash
 # Build and test via Bazel (no Makefile in this repo)
-bazelisk build //operators/...
-bazelisk test //operators/...
+bazel build //operators/...
+bazel test //operators/...
 
 # Update BUILD files after adding imports
-bazelisk run //:gazelle
+bazel run //:gazelle
 
 # Linting via nogo (built into Bazel, not golangci-lint)
 # Linting runs automatically during build
 
 # Run a specific operator
-bazelisk run //operators/<name>/cmd:cmd
+bazel run //operators/<name>/cmd:cmd
 ```
 
 ### Reconcile Return Values
@@ -812,19 +811,19 @@ environment:
 
 ```bash
 # Update lock file after modifying apko.yaml
-bazelisk run @rules_apko//apko -- lock charts/<service>/image/apko.yaml
+bazel run @rules_apko//apko -- lock charts/<service>/image/apko.yaml
 
 # Or run format to update ALL apko locks
 format
 
 # Build the image
-bazelisk build //charts/<service>/image:image
+bazel build //charts/<service>/image:image
 
 # Push image to registry
-bazelisk run //charts/<service>/image:image.push
+bazel run //charts/<service>/image:image.push
 
 # Run image locally (for debugging)
-bazelisk run //charts/<service>/image:image.run
+bazel run //charts/<service>/image:image.run
 
 # Scan image for vulnerabilities (requires global trivy install)
 trivy image ghcr.io/jomcgi/homelab/charts/<service>:latest
@@ -938,7 +937,7 @@ use_repo(apko, "myservice_lock")
 
 ### Common Mistakes to Avoid
 
-1. **Not updating lock file** - Always run `bazelisk run @rules_apko//apko -- lock <path>` after changing apko.yaml
+1. **Not updating lock file** - Always run `bazel run @rules_apko//apko -- lock <path>` after changing apko.yaml
 2. **Missing architectures** - Always include both `x86_64` and `aarch64`
 3. **Missing CA certificates** - HTTPS calls fail without `ca-certificates-bundle`
 4. **Running as root** - Always set `run-as` to non-root uid
@@ -1095,7 +1094,7 @@ Overview with purpose.
 ## Running Locally
 
 ```bash
-bazelisk run //services/myservice:myservice
+bazel run //services/myservice:myservice
 ```
 
 ````
@@ -1311,7 +1310,7 @@ gh pr review <number> --request-changes --body "See comments for required fixes"
 
 **CI/Build Changes:**
 
-- [ ] Tests pass locally with `bazelisk test //...`
+- [ ] Tests pass locally with `bazel test //...`
 - [ ] No new non-hermetic dependencies
 - [ ] Cache-friendly (no timestamps, no random values)
 
@@ -1512,16 +1511,16 @@ gh pr checks | grep buildbuddy
 
 ```bash
 # Run with CI config
-bazelisk test //... --config=ci
+bazel test //... --config=ci
 
 # Run specific failing target
-bazelisk test //path:failing_target --config=ci
+bazel test //path:failing_target --config=ci
 
 # Force no-cache to match fresh CI run
-bazelisk test //path:target --cache_test_results=no
+bazel test //path:target --cache_test_results=no
 
 # Full clean rebuild
-bazelisk clean --expunge && bazelisk test //...
+bazel clean --expunge && bazel test //...
 ```
 
 ### Common CI Failures
@@ -1546,7 +1545,7 @@ bazelisk clean --expunge && bazelisk test //...
 1. **Declaring done before CI passes** - Always wait for green
 2. **Ignoring flaky tests** - Fix them, don't re-run until green
 3. **Not checking BuildBuddy logs** - Contains detailed failure info
-4. **Pushing without local test** - Run `bazelisk test //...` first
+4. **Pushing without local test** - Run `bazel test //...` first
 5. **Large PRs** - Smaller PRs are easier to review and debug
 
 ### Example Prompts

--- a/.claude/skills/bazelisk/SKILL.md
+++ b/.claude/skills/bazelisk/SKILL.md
@@ -1,13 +1,18 @@
 ---
 name: bazelisk
-description: Use when building code, formatting files, rendering manifests, pushing container images, or running tests. Handles all Bazel operations with automatic version management via .bazelversion.
+description: Use when building code, formatting files, rendering manifests, pushing container images, or running tests. Handles all Bazel operations via BuildBuddy CLI (bb) with automatic version management via .bazelversion.
 ---
 
-# Bazel Build System (bazelisk)
+# Bazel Build System (BuildBuddy CLI)
 
 ## Overview
 
-Use `bazelisk` for all Bazel commands. It automatically uses the version specified in `.bazelversion` (currently `rolling` = Bazel 9).
+This repo uses the **BuildBuddy CLI (`bb`)** as its Bazel launcher. Shell aliases route `bazel` and `bazelisk` to `bb`, so all three commands are interchangeable. The `.bazelversion` file pins BuildBuddy CLI 5.0.321 + Bazel 9.0.0.
+
+The `bb` CLI wraps Bazelisk and adds:
+- **Local gRPC proxy** for remote cache/BES — handles retries and buffering transparently
+- **`bb login`** for easy BuildBuddy authentication (no manual `--remote_header` needed)
+- **Plugin support** for extending the build system
 
 ## Common Commands
 
@@ -29,46 +34,46 @@ This runs multiple tasks in parallel:
 
 ```bash
 # Build everything
-bazelisk build //...
+bazel build //...
 
 # Build specific image
-bazelisk build //charts/todo/image:image
+bazel build //charts/todo/image:image
 
 # Build with verbose output
-bazelisk build //charts/todo/image:image --verbose_failures
+bazel build //charts/todo/image:image --verbose_failures
 ```
 
 ### Pushing Images
 
 ```bash
 # Push Todo image to registry
-bazelisk run //charts/todo/image:push
+bazel run //charts/todo/image:push
 ```
 
 ### Running Tests
 
 ```bash
 # Run all tests
-bazelisk test //...
+bazel test //...
 
 # Run specific test
-bazelisk test //pkg/mypackage:mypackage_test
+bazel test //pkg/mypackage:mypackage_test
 
 # Run with verbose output
-bazelisk test //... --test_output=all
+bazel test //... --test_output=all
 ```
 
 ### Querying Build Graph
 
 ```bash
 # List all targets in a package
-bazelisk query //charts/todo/...
+bazel query //charts/todo/...
 
 # Find what depends on a target
-bazelisk query "rdeps(//..., //charts/todo/image:image)"
+bazel query "rdeps(//..., //charts/todo/image:image)"
 
 # Show target dependencies
-bazelisk query "deps(//charts/todo/image:image)"
+bazel query "deps(//charts/todo/image:image)"
 ```
 
 ## Key Targets
@@ -148,7 +153,7 @@ paths:
 When you modify `apko.yaml`, update the lock:
 
 ```bash
-bazelisk run @rules_apko//apko -- lock charts/<service>/image/apko.yaml
+bazel run @rules_apko//apko -- lock charts/<service>/image/apko.yaml
 ```
 
 Or run `format` which updates all locks automatically.
@@ -205,20 +210,20 @@ Bazel caches build artifacts aggressively:
 To force rebuild:
 
 ```bash
-bazelisk build //target --noremote_cache
+bazel build //target --noremote_cache
 ```
 
 ## Troubleshooting
 
 ```bash
 # Clean build artifacts
-bazelisk clean
+bazel clean
 
 # Clean everything including external deps
-bazelisk clean --expunge
+bazel clean --expunge
 
 # Show why a target was rebuilt
-bazelisk build //target --explain=explain.log --verbose_explanations
+bazel build //target --explain=explain.log --verbose_explanations
 ```
 
 ## Workflow Integration


### PR DESCRIPTION
## Summary
- Follow-up to #569 (switch from bazelisk to BuildBuddy CLI)
- Updates `.claude/skills/bazelisk/SKILL.md` overview to describe `bb` CLI features (local gRPC proxy, `bb login`, plugin support) and pin versions (bb 5.0.321 + Bazel 9.0.0)
- Updates `.claude/AGENTS.md` bazel agent section from "Bazel 8 via bazelisk" to "Bazel 9 via BuildBuddy CLI"
- Replaces all `bazelisk <cmd>` examples with `bazel <cmd>` across both files (since shell aliases make them equivalent)
- Removes obsolete anti-pattern "Using `bazel` instead of `bazelisk`"

## Test plan
- [ ] Verify `/bazelisk` skill still loads correctly (skill name unchanged)
- [ ] Spot-check command examples render correctly in markdown preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)