### PR TITLE
fix(grimoire): provide custom nginx.conf for rootless container

### DIFF
--- a/charts/grimoire/templates/frontend-deployment.yaml
+++ b/charts/grimoire/templates/frontend-deployment.yaml
@@ -45,7 +45,11 @@ spec:
                 - ALL
             readOnlyRootFilesystem: true
           volumeMounts:
-            - name: nginx-config
+            - name: nginx-main-config
+              mountPath: /etc/nginx/nginx.conf
+              subPath: nginx.conf
+              readOnly: true
+            - name: nginx-site-config
               mountPath: /etc/nginx/conf.d
               readOnly: true
             - name: nginx-cache
@@ -54,8 +58,6 @@ spec:
               mountPath: /var/run
             - name: nginx-tmp
               mountPath: /tmp
-            - name: nginx-lib
-              mountPath: /var/lib/nginx
           livenessProbe:
             httpGet:
               path: /
@@ -69,14 +71,21 @@ spec:
           resources:
             {{- toYaml .Values.frontend.resources | nindent 12 }}
       volumes:
-        - name: nginx-config
+        - name: nginx-main-config
           configMap:
             name: {{ include "grimoire.fullname" . }}-nginx
+            items:
+              - key: nginx.conf
+                path: nginx.conf
+        - name: nginx-site-config
+          configMap:
+            name: {{ include "grimoire.fullname" . }}-nginx
+            items:
+              - key: default.conf
+                path: default.conf
         - name: nginx-cache
           emptyDir: {}
         - name: nginx-run
           emptyDir: {}
         - name: nginx-tmp
-          emptyDir: {}
-        - name: nginx-lib
           emptyDir: {}

--- a/charts/grimoire/templates/nginx-configmap.yaml
+++ b/charts/grimoire/templates/nginx-configmap.yaml
@@ -6,6 +6,30 @@ metadata:
     {{- include "grimoire.labels" . | nindent 4 }}
     app.kubernetes.io/component: frontend
 data:
+  nginx.conf: |
+    worker_processes auto;
+    error_log stderr warn;
+    pid /var/run/nginx.pid;
+
+    events {
+        worker_connections 1024;
+    }
+
+    http {
+        include /etc/nginx/mime.types;
+        default_type application/octet-stream;
+
+        client_body_temp_path /tmp/client_body;
+        proxy_temp_path /tmp/proxy;
+        fastcgi_temp_path /tmp/fastcgi;
+        uwsgi_temp_path /tmp/uwsgi;
+        scgi_temp_path /tmp/scgi;
+
+        sendfile on;
+        keepalive_timeout 65;
+
+        include /etc/nginx/conf.d/*.conf;
+    }
   default.conf: |
     upstream ws_gateway {
         server {{ include "grimoire.fullname" . }}-ws-gateway:{{ .Values.wsGateway.service.port }};


### PR DESCRIPTION
## Summary
- Adds a custom `nginx.conf` to the grimoire-nginx ConfigMap that redirects all writable paths (`error_log`, `*_temp_path`) to existing emptyDir mounts (`/tmp`, `/var/run`) instead of `/var/lib/nginx/` subdirectories
- Splits the ConfigMap volume into two filtered mounts (`nginx-main-config` for `nginx.conf`, `nginx-site-config` for `default.conf`) to prevent `nginx.conf` from being loaded as a conf.d server block
- Removes the now-unnecessary `nginx-lib` emptyDir volume for `/var/lib/nginx`

## Context
The frontend nginx container was CrashLoopBackOff because the Wolfi nginx package's default `nginx.conf` expects `/var/lib/nginx/logs/` and `/var/lib/nginx/tmp/` to exist. While an emptyDir was mounted at `/var/lib/nginx`, it was empty — and nginx doesn't create intermediate directories, only leaf ones.

## Test plan
- [ ] Verify Helm template renders correctly (validated locally)
- [ ] Confirm frontend pod starts without CrashLoopBackOff after ArgoCD sync
- [ ] Verify nginx serves the SPA and WebSocket proxy still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)