### PR TITLE
fix(grimoire): fix remaining pod failures

### DIFF
--- a/charts/grimoire/templates/frontend-deployment.yaml
+++ b/charts/grimoire/templates/frontend-deployment.yaml
@@ -34,6 +34,7 @@ spec:
         - name: nginx
           image: "{{ .Values.frontend.image.repository }}:{{ .Values.frontend.image.tag }}"
           imagePullPolicy: {{ .Values.frontend.image.pullPolicy }}
+          env: []
           ports:
             - name: http
               containerPort: 8080
@@ -58,6 +59,8 @@ spec:
               mountPath: /var/run
             - name: nginx-tmp
               mountPath: /tmp
+            - name: nginx-lib
+              mountPath: /var/lib/nginx
           livenessProbe:
             httpGet:
               path: /
@@ -88,4 +91,6 @@ spec:
         - name: nginx-run
           emptyDir: {}
         - name: nginx-tmp
+          emptyDir: {}
+        - name: nginx-lib
           emptyDir: {}

--- a/charts/grimoire/templates/ws-gateway-deployment.yaml
+++ b/charts/grimoire/templates/ws-gateway-deployment.yaml
@@ -24,8 +24,8 @@ spec:
       serviceAccountName: {{ include "grimoire.serviceAccountName" . }}
       securityContext:
         runAsNonRoot: true
-        runAsUser: 1000
-        runAsGroup: 1000
+        runAsUser: 65532
+        runAsGroup: 65532
         seccompProfile:
           type: RuntimeDefault
       containers:
@@ -41,7 +41,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.grimoireSecret.name }}
-                  key: GOOGLE_API_KEY
+                  key: google_api_key
             - name: REDIS_ADDR
               value: "{{ include "grimoire.fullname" . }}-redis:{{ .Values.redis.service.port }}"
             {{- if .Values.redis.auth.enabled }}


### PR DESCRIPTION
## Summary

- Add `/var/lib/nginx` emptyDir volume so nginx can write its compiled-in default error log during binary bootstrap (before `nginx.conf` is parsed)
- Add explicit `env: []` to frontend container to prevent persistent ArgoCD diff caused by Kyverno OTEL injection + `ignoreDifferences` stripping
- Fix secret key from `GOOGLE_API_KEY` (uppercase) to `google_api_key` (lowercase) matching 1Password Operator field naming
- Fix ws-gateway UID/GID from 1000 to 65532 to match the apko-built container image

## Test plan

- [x] `bazel test //charts/grimoire:lint_test` passes
- [x] `helm template` renders all four fixes correctly
- [ ] After ArgoCD sync: `kubectl get pods -n grimoire` shows all pods Running
- [ ] `kubectl logs <frontend-pod> -n grimoire -c nginx` — no filesystem errors
- [ ] `kubectl logs <ws-gateway-pod> -n grimoire -c ws-gateway` — starts without secret error
- [ ] ArgoCD shows `Synced / Healthy` with no persistent diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)