### PR TITLE
fix(overlays): remove redundant prod- prefix from application names

### DIFF
--- a/overlays/prod/llama-cpp/BUILD
+++ b/overlays/prod/llama-cpp/BUILD
@@ -1,7 +1,7 @@
 load("//rules_helm:defs.bzl", "argocd_app")
 
 argocd_app(
-    name = "prod-llama-cpp",
+    name = "llama-cpp",
     chart = "charts/llama-cpp",
     chart_files = "//charts/llama-cpp:chart",
     namespace = "llama-cpp",

--- a/overlays/prod/llama-cpp/application.yaml
+++ b/overlays/prod/llama-cpp/application.yaml
@@ -1,7 +1,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: prod-llama-cpp
+  name: llama-cpp
   namespace: argocd
 spec:
   project: default

--- a/overlays/prod/nats/BUILD
+++ b/overlays/prod/nats/BUILD
@@ -1,7 +1,7 @@
 load("//rules_helm:defs.bzl", "argocd_app")
 
 argocd_app(
-    name = "prod-nats",
+    name = "nats",
     chart = "charts/nats",
     chart_files = "//charts/nats:chart",
     namespace = "nats",

--- a/overlays/prod/nats/application.yaml
+++ b/overlays/prod/nats/application.yaml
@@ -1,7 +1,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: prod-nats
+  name: nats
   namespace: argocd
   labels:
     app.kubernetes.io/part-of: shared-infrastructure

--- a/overlays/prod/seaweedfs/BUILD
+++ b/overlays/prod/seaweedfs/BUILD
@@ -1,7 +1,7 @@
 load("//rules_helm:defs.bzl", "argocd_app")
 
 argocd_app(
-    name = "prod-seaweedfs",
+    name = "seaweedfs",
     chart = "charts/seaweedfs",
     chart_files = "//charts/seaweedfs:chart",
     namespace = "seaweedfs",

--- a/overlays/prod/seaweedfs/application.yaml
+++ b/overlays/prod/seaweedfs/application.yaml
@@ -1,7 +1,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: prod-seaweedfs
+  name: seaweedfs
   namespace: argocd
   labels:
     app.kubernetes.io/part-of: shared-infrastructure

--- a/overlays/prod/trips/BUILD
+++ b/overlays/prod/trips/BUILD
@@ -1,7 +1,7 @@
 load("//rules_helm:defs.bzl", "argocd_app")
 
 argocd_app(
-    name = "prod-trips",
+    name = "trips",
     chart = "charts/trips",
     chart_files = "//charts/trips:chart",
     namespace = "trips",

--- a/overlays/prod/trips/application.yaml
+++ b/overlays/prod/trips/application.yaml
@@ -1,7 +1,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: prod-trips
+  name: trips
   namespace: argocd
   labels:
     app.kubernetes.io/part-of: yukon-tracker


### PR DESCRIPTION
## Summary
- Removed hardcoded `prod-` prefix from 4 ArgoCD Application names (`trips`, `nats`, `seaweedfs`, `llama-cpp`) and their BUILD files
- The `overlays/prod/kustomization.yaml` already applies `namePrefix: prod-`, so these apps were ending up as `prod-prod-*` in the cluster
- Aligns with the other 6 prod services (`api-gateway`, `todo`, `knowledge-graph`, etc.) that correctly let Kustomize handle the prefix

## Test plan
- [ ] Verify Bazel `helm` template targets still render correctly (`bazelisk test //overlays/prod/...`)
- [ ] After merge, confirm ArgoCD shows `prod-trips` (not `prod-prod-trips`) for affected apps
- [ ] Old `prod-prod-*` Applications should be pruned automatically by ArgoCD since `prune: true` is enabled

> **Note:** ArgoCD will see these as *new* Applications (`prod-trips`) alongside the old ones (`prod-prod-trips`). The old ones will be pruned by ArgoCD's automated sync since all affected apps have `prune: true`. The Helm release names are unchanged, so no actual workload disruption occurs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)