### PR TITLE
fix(format): exclude .claude/worktrees from gazelle and formatters

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,5 @@
 # Helm templates contain Go template syntax that Prettier doesn't understand
 charts/*/templates/
+
+# Git worktrees have their own formatting
+.claude/worktrees/

--- a/BUILD
+++ b/BUILD
@@ -48,6 +48,7 @@ exports_files(
 
 # gazelle:prefix github.com/jomcgi/homelab
 # gazelle:exclude cdk8s
+# gazelle:exclude .claude
 
 # Custom gazelle binary with ArgoCD and wrangler extensions
 gazelle_binary(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,3 +75,4 @@ dependencies = [
 
 # See https://docs.astral.sh/ruff/configuration/
 [tool.ruff]
+extend-exclude = [".claude/worktrees"]

--- a/scripts/generate-dev-deploy-registry.sh
+++ b/scripts/generate-dev-deploy-registry.sh
@@ -33,7 +33,7 @@ while IFS= read -r build_file; do
 			echo "${repo}|//${pkg}:${name}.push" >>"$REPO_MAP"
 		fi
 	done < <(grep -o 'ghcr.io/jomcgi/homelab/[^"]*' "$build_file" | sort -u)
-done < <(grep -rl 'repository.*=.*"ghcr.io/jomcgi/homelab/' --include='BUILD' . 2>/dev/null | grep -v './bazel-' | LC_ALL=C sort)
+done < <(grep -rl 'repository.*=.*"ghcr.io/jomcgi/homelab/' --include='BUILD' . 2>/dev/null | grep -v './bazel-' | grep -v './\.claude/' | LC_ALL=C sort)
 
 # --- Step 2: Find dev-deploy enabled charts and generate registry ---
 mkdir -p "$(dirname "$OUTPUT")"

--- a/tools/format/fast-format.sh
+++ b/tools/format/fast-format.sh
@@ -51,16 +51,18 @@ PIDS=()
 PIDS+=($!)
 
 # Shell
-(find . -name '*.sh' -not -path './bazel-*' -not -path './.git/*' -print0 |
+(find . -name '*.sh' -not -path './bazel-*' -not -path './.git/*' -not -path './.claude/worktrees/*' -print0 |
 	xargs -0 "$SHFMT" -w 2>/dev/null || true) &
 PIDS+=($!)
 
-# Starlark
-"$BUILDIFIER" -r . 2>/dev/null &
+# Starlark (exclude worktrees — they have their own formatting)
+(find . \( -name BUILD -o -name BUILD.bazel -o -name '*.bzl' -o -name WORKSPACE -o -name WORKSPACE.bazel \) \
+	-not -path './bazel-*' -not -path './.claude/worktrees/*' -print0 |
+	xargs -0 "$BUILDIFIER" 2>/dev/null || true) &
 PIDS+=($!)
 
 # Go
-(find . -name '*.go' -not -path './bazel-*' -not -path './.git/*' -print0 |
+(find . -name '*.go' -not -path './bazel-*' -not -path './.git/*' -not -path './.claude/worktrees/*' -print0 |
 	xargs -0 "$GOFUMPT" -w 2>/dev/null || true) &
 PIDS+=($!)
 


### PR DESCRIPTION
## Summary

- `.claude/worktrees/` contains git worktrees with full repo copies, causing Gazelle to find **duplicate Go packages** for every import (e.g., `//operators/...` vs `//.claude/worktrees/agitated-nobel/operators/...`)
- When Gazelle can't disambiguate, it **silently drops all internal deps** from BUILD files — producing 100+ line diffs on every `format` run
- The `generate-dev-deploy-registry` script had the same issue: `grep` found BUILD files in worktrees first (lexicographic sort of `.claude/` < `services/`), resolving push targets to worktree paths

### Changes
- Add `# gazelle:exclude .claude` to root BUILD file
- Filter `.claude/` from `generate-dev-deploy-registry.sh` BUILD file search
- Exclude `.claude/worktrees/` from all formatters in `fast-format.sh` (buildifier, shfmt, gofumpt, ruff, prettier)

## Test plan

- [ ] CI format check passes (no diff after running format)
- [ ] `bazel run //:gazelle` produces no ambiguity warnings
- [ ] `bazel run //scripts:generate-dev-deploy-registry` generates canonical `//services/...` paths (not `//.claude/worktrees/...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)