### PR TITLE
fix(openhands): fix security context for litellm and app containers

### DIFF
--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -35,22 +35,18 @@ app:
     size: 5Gi
     mountPath: /opt/workspace_base
   podSecurityContext:
-    fsGroup: 1000
     seccompProfile:
       type: RuntimeDefault
   securityContext:
     allowPrivilegeEscalation: false
-    runAsNonRoot: true
-    # runAsUser intentionally omitted — upstream OpenHands image defines its own
-    # non-root user. runAsNonRoot: true asserts the image doesn't run as root.
+    # runAsNonRoot omitted — upstream OpenHands image runs as root.
+    # readOnlyRootFilesystem omitted — OpenHands writes to internal caches,
+    # session state, and __pycache__. See architecture/rfcs/background-agents.md.
     capabilities:
       drop:
         - ALL
     seccompProfile:
       type: RuntimeDefault
-    # readOnlyRootFilesystem intentionally omitted — OpenHands writes to
-    # internal caches, session state, and __pycache__ beyond /tmp and the
-    # workspace mount. See architecture/rfcs/background-agents.md Security Deviations.
 
 # =============================================================================
 # LiteLLM Claude Proxy Component
@@ -131,13 +127,12 @@ podSecurityContext:
   seccompProfile:
     type: RuntimeDefault
 
-# Container security context (shared)
+# Container security context (used by litellm)
 securityContext:
   readOnlyRootFilesystem: true
   allowPrivilegeEscalation: false
   runAsNonRoot: true
-  # runAsUser intentionally omitted — upstream litellm-claude-code image defines
-  # its own non-root user. runAsNonRoot: true asserts the image doesn't run as root.
+  runAsUser: 1001  # litellm-claude-code image uses USER claude (uid 1001)
   capabilities:
     drop:
       - ALL


### PR DESCRIPTION
## Summary
- **LiteLLM**: Add `runAsUser: 1001` — the image sets `USER claude` (string name), and Kubernetes can't verify `runAsNonRoot` with non-numeric users. UID 1001 is the `claude` user from `/etc/passwd` in the image.
- **OpenHands app**: Remove `runAsNonRoot: true` — upstream `all-hands-ai/openhands:0.48` image runs as **root** (verified via `crane config`). Also removed `fsGroup: 1000` since root doesn't need it.
- The Longhorn PVC "device in use" error should resolve when the new deployment revision triggers a pod cycle (detach/reattach).

## Root causes
```
Error: container has runAsNonRoot and image has non-numeric user (claude)
```
K8s requires a numeric UID to verify non-root. The `litellm-claude-code` image sets `USER claude` (not `USER 1001`).

```
MountVolume.MountDevice failed ... is apparently in use by the system
```
Transient Longhorn race condition during initial format — new pod cycle should clear it.

## Test plan
- [ ] LiteLLM pod starts without `CreateContainerConfigError`
- [ ] OpenHands app pod starts (no `runAsNonRoot` violation)
- [ ] Longhorn PVC mounts successfully after pod recreation

🤖 Generated with [Claude Code](https://claude.com/claude-code)