### PR TITLE
fix(openhands): mount emptyDir for litellm credentials path

### DIFF
--- a/charts/openhands/templates/litellm-deployment.yaml
+++ b/charts/openhands/templates/litellm-deployment.yaml
@@ -55,6 +55,8 @@ spec:
             periodSeconds: 10
             failureThreshold: 3
           volumeMounts:
+            - name: claude-home
+              mountPath: /home/claude/.claude
             - name: tmp
               mountPath: /tmp
       {{- with .Values.nodeSelector }}
@@ -70,5 +72,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       volumes:
+        - name: claude-home
+          emptyDir: {}
         - name: tmp
           emptyDir: {}


### PR DESCRIPTION
## Summary
- Add emptyDir volume mount at `/home/claude/.claude` for the litellm container
- The `litellm-claude-code` entrypoint writes OAuth credentials to `/home/claude/.claude/.credentials.json`, which fails with `readOnlyRootFilesystem: true`
- Keeps `readOnlyRootFilesystem: true` intact — only the credentials directory is writable

## Root cause
```
/usr/local/bin/docker-entrypoint.sh: line 17: /home/claude/.claude/.credentials.json: Read-only file system
```

## Test plan
- [ ] LiteLLM pod starts without CrashLoopBackOff
- [ ] `/health` endpoint responds (readiness probe passes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)