### PR TITLE
fix(openhands): widen litellm home mount, exclude sandboxes from Linkerd

### DIFF
--- a/charts/kyverno/values.yaml
+++ b/charts/kyverno/values.yaml
@@ -34,6 +34,8 @@ linkerdInjection:
     - longhorn-system # Storage system
     # Observability (optional - can mesh these if desired)
     - signoz # SigNoz collector (avoid circular tracing)
+    # Sandbox namespaces (ephemeral pods, no sidecar needed)
+    - openhands-sandboxes
 
 kyverno:
   # Admission controller configuration

--- a/charts/openhands/templates/litellm-deployment.yaml
+++ b/charts/openhands/templates/litellm-deployment.yaml
@@ -56,7 +56,7 @@ spec:
             failureThreshold: 3
           volumeMounts:
             - name: claude-home
-              mountPath: /home/claude/.claude
+              mountPath: /home/claude
             - name: tmp
               mountPath: /tmp
       {{- with .Values.nodeSelector }}


### PR DESCRIPTION
## Summary
- **LiteLLM**: Widen emptyDir mount from `/home/claude/.claude` to `/home/claude` — the entrypoint writes to both `.claude/.credentials.json` (line 17) and `.claude.json` (line 32)
- **Kyverno**: Add `openhands-sandboxes` to `linkerdInjection.excludeNamespaces` — the Kyverno background policy was overriding the chart's `linkerd.io/inject: disabled` annotation with `enabled`

## Root causes
```
/usr/local/bin/docker-entrypoint.sh: line 32: /home/claude/.claude.json: Read-only file system
```
The previous fix (PR #599) mounted `/home/claude/.claude` but the entrypoint also writes to `/home/claude/.claude.json` (parent directory).

```
linkerd.io/inject: enabled  (on openhands-sandboxes namespace)
```
Kyverno's `inject-linkerd-namespace-annotation` policy excludes namespaces by **label**, but the chart sets `linkerd.io/inject: disabled` as an **annotation**. Adding to the exclude list bypasses this.

## Test plan
- [ ] LiteLLM pod starts successfully (no read-only filesystem errors)
- [ ] `openhands-sandboxes` namespace has `linkerd.io/inject: disabled`

🤖 Generated with [Claude Code](https://claude.com/claude-code)