### PR TITLE
fix(openhands): use ghcr.io for OpenHands images

### DIFF
--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -18,7 +18,7 @@ imagePullSecret:
 # =============================================================================
 app:
   image:
-    repository: docker.all-hands.dev/all-hands-ai/openhands
+    repository: ghcr.io/all-hands-ai/openhands
     tag: "0.48"
     pullPolicy: IfNotPresent
   replicas: 1
@@ -96,7 +96,7 @@ serviceAccount:
 # =============================================================================
 kubernetes:
   sandboxNamespace: openhands-sandboxes
-  runtimeImage: "docker.all-hands.dev/all-hands-ai/runtime:0.48-nikolaik"
+  runtimeImage: "ghcr.io/all-hands-ai/runtime:0.48-nikolaik"
   pvcStorageClass: "longhorn"
   pvcStorageSize: "2Gi"
   resourceCpuRequest: "1"


### PR DESCRIPTION
## Summary
- Switch app and runtime image repositories from `docker.all-hands.dev` to `ghcr.io/all-hands-ai`
- `docker.all-hands.dev` doesn't resolve from in-cluster DNS, causing `ImagePullBackOff`

(This commit was part of PR #600 but was dropped during squash-merge because it was pushed after the merge started.)

## Test plan
- [ ] OpenHands app pod pulls image successfully
- [ ] No more `ImagePullBackOff`

🤖 Generated with [Claude Code](https://claude.com/claude-code)