### PR TITLE
fix(openhands): increase litellm memory limit and probe timeouts

### DIFF
--- a/charts/openhands/templates/litellm-deployment.yaml
+++ b/charts/openhands/templates/litellm-deployment.yaml
@@ -49,8 +49,9 @@ spec:
               httpHeaders:
                 - name: Authorization
                   value: Bearer {{ .Values.llm.apiKey }}
-            initialDelaySeconds: 10
+            initialDelaySeconds: 30
             periodSeconds: 15
+            timeoutSeconds: 5
             failureThreshold: 3
           readinessProbe:
             httpGet:
@@ -59,8 +60,9 @@ spec:
               httpHeaders:
                 - name: Authorization
                   value: Bearer {{ .Values.llm.apiKey }}
-            initialDelaySeconds: 5
+            initialDelaySeconds: 15
             periodSeconds: 10
+            timeoutSeconds: 5
             failureThreshold: 3
           volumeMounts:
             - name: claude-home

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -56,10 +56,10 @@ litellm:
   resources:
     requests:
       cpu: 100m
-      memory: 256Mi
-    limits:
-      cpu: 500m
       memory: 512Mi
+    limits:
+      cpu: "1"
+      memory: 1Gi
 
 # =============================================================================
 # LLM Settings


### PR DESCRIPTION
## Summary
- Raise litellm memory limit from 512Mi to 1Gi (was OOMKilled)
- Raise memory request from 256Mi to 512Mi
- Raise CPU limit from 500m to 1 core
- Increase liveness `initialDelaySeconds` from 10s to 30s
- Increase readiness `initialDelaySeconds` from 5s to 15s
- Add `timeoutSeconds: 5` to both probes (was default 1s)

## Root cause
```
Last State: Terminated, Reason: OOMKilled
Liveness probe failed: context deadline exceeded
```

## Test plan
- [ ] LiteLLM pod stays running (no OOMKill)
- [ ] Health probes pass after startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)