### PR TITLE
fix(litellm): raise memory to 8Gi, set LITELLM_LOG=ERROR

### DIFF
--- a/charts/openhands/templates/litellm-deployment.yaml
+++ b/charts/openhands/templates/litellm-deployment.yaml
@@ -33,6 +33,8 @@ spec:
               containerPort: 4000
               protocol: TCP
           env:
+            - name: LITELLM_LOG
+              value: "ERROR"
             - name: LITELLM_MASTER_KEY
               value: {{ .Values.llm.apiKey | quote }}
             - name: CLAUDE_CODE_OAUTH_TOKEN

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -55,11 +55,11 @@ litellm:
     pullPolicy: Always
   resources:
     requests:
-      cpu: 100m
-      memory: 1.5Gi
+      cpu: "4"
+      memory: 8Gi
     limits:
-      cpu: "1"
-      memory: 1.5Gi
+      cpu: "4"
+      memory: 8Gi
 
 # =============================================================================
 # LLM Settings


### PR DESCRIPTION
## Summary

- Bump litellm resource requests/limits from 1.5Gi → 8Gi RAM and 100m → 4 CPU
- Add `LITELLM_LOG=ERROR` env var to reduce memory overhead from verbose logging

## Context

LiteLLM was OOMKilling consistently within ~29 seconds of startup. After iterating
from 512Mi → 1Gi → 1.5Gi limits with no success, checked the [official production
docs](https://docs.litellm.ai/docs/proxy/prod) which recommend **8 GB RAM minimum**.

The `cabinlab/litellm-claude-code` image runs both Python litellm (imports all
provider SDKs at load time) and the Node.js Claude Code SDK — together these easily
exceed 1.5Gi at startup before handling a single request.

## After merging

Once litellm stabilises, run `kubectl top pod -n openhands` to see actual peak usage
and scale back to a tighter limit.

## Test plan

- [ ] ArgoCD syncs and litellm pod starts without OOMKill
- [ ] `kubectl top pod -n openhands` shows litellm memory usage
- [ ] OpenHands can route a request through the proxy successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)