### PR TITLE
fix(openhands): pre-configure LLM settings for web UI

### DIFF
--- a/charts/openhands/templates/configmap.yaml
+++ b/charts/openhands/templates/configmap.yaml
@@ -9,6 +9,12 @@ data:
     [core]
     runtime = "kubernetes"
 
+    [llm]
+    model = "openai/{{ .Values.llm.model }}"
+    api_key = "{{ .Values.llm.apiKey }}"
+    base_url = {{ .Values.llm.baseUrl | default (printf "http://%s-litellm:4000/v1" (include "openhands.fullname" .)) | quote }}
+    custom_llm_provider = "openai"
+
     [sandbox]
     runtime_container_image = "{{ .Values.kubernetes.runtimeImage }}"
 
@@ -19,3 +25,15 @@ data:
     resource_cpu_request = "{{ .Values.kubernetes.resourceCpuRequest }}"
     resource_memory_request = "{{ .Values.kubernetes.resourceMemoryRequest }}"
     resource_memory_limit = "{{ .Values.kubernetes.resourceMemoryLimit }}"
+
+  settings.json: |
+    {
+      "llm_model": "openai/{{ .Values.llm.model }}",
+      "llm_api_key": {{ .Values.llm.apiKey | quote }},
+      "llm_base_url": {{ .Values.llm.baseUrl | default (printf "http://%s-litellm:4000/v1" (include "openhands.fullname" .)) | quote }},
+      "agent": "CodeActAgent",
+      "language": "en",
+      "confirmation_mode": false,
+      "security_analyzer": "llm",
+      "enable_default_condenser": true
+    }

--- a/charts/openhands/templates/deployment.yaml
+++ b/charts/openhands/templates/deployment.yaml
@@ -25,6 +25,27 @@ spec:
       serviceAccountName: {{ include "openhands.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.app.podSecurityContext | nindent 8 }}
+      initContainers:
+        - name: seed-settings
+          image: busybox:1.37
+          command:
+            - sh
+            - -c
+            - |
+              STORE={{ .Values.app.persistence.mountPath }}/.openhands/file_store
+              if [ ! -f "$STORE/settings.json" ]; then
+                mkdir -p "$STORE"
+                cp /defaults/settings.json "$STORE/settings.json"
+                echo "Seeded default settings.json"
+              else
+                echo "settings.json already exists, skipping"
+              fi
+          volumeMounts:
+            - name: defaults
+              mountPath: /defaults
+              readOnly: true
+            - name: workspace
+              mountPath: {{ .Values.app.persistence.mountPath }}
       containers:
         - name: openhands
           image: "{{ .Values.app.image.repository }}:{{ .Values.app.image.tag }}"
@@ -41,9 +62,13 @@ spec:
             - name: LLM_API_KEY
               value: {{ .Values.llm.apiKey | quote }}
             - name: LLM_MODEL
-              value: {{ .Values.llm.model | quote }}
+              value: "openai/{{ .Values.llm.model }}"
             - name: OH_PERSISTENCE_DIR
               value: {{ .Values.app.persistence.mountPath | quote }}
+            - name: FILE_STORE_PATH
+              value: "{{ .Values.app.persistence.mountPath }}/.openhands/file_store"
+            - name: HIDE_LLM_SETTINGS
+              value: "true"
             - name: SANDBOX_ENV_GITHUB_TOKEN
               valueFrom:
                 secretKeyRef:
@@ -95,6 +120,12 @@ spec:
         - name: config
           configMap:
             name: {{ include "openhands.fullname" . }}-config
+        - name: defaults
+          configMap:
+            name: {{ include "openhands.fullname" . }}-config
+            items:
+              - key: settings.json
+                path: settings.json
         - name: workspace
           {{- if .Values.app.persistence.enabled }}
           persistentVolumeClaim:


### PR DESCRIPTION
## Summary
- Pre-seeds `settings.json` on the PVC via busybox initContainer so the web UI skips the "AI Provider Configuration" setup modal
- Sets `HIDE_LLM_SETTINGS=true` to hide the LLM settings tab (managed proxy — nothing for users to configure)
- Sets `FILE_STORE_PATH` on the workspace PVC for persistent settings across restarts
- Adds `[llm]` section to config.toml for headless/CLI compatibility
- Uses `openai/` model prefix so litellm client uses the OpenAI-compatible protocol through our LiteLLM proxy

## How it works
The OpenHands web UI checks `GET /api/settings` on load — if it returns 404 (no `settings.json`), the setup modal appears. The config.toml `[llm]` section is headless/CLI only and doesn't affect the web UI.

The initContainer copies `settings.json` from a ConfigMap to the PVC **only on first boot** (skips if already exists), so user changes persist.

## Test plan
- [ ] Verify initContainer seeds settings.json (check logs: "Seeded default settings.json")
- [ ] Verify web UI loads directly without showing AI Provider Configuration screen
- [ ] Verify starting a conversation uses the LiteLLM proxy (check litellm pod logs for requests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)