### PR TITLE
fix(openhands): use lightweight litellm health endpoints for probes

### DIFF
--- a/charts/openhands/templates/litellm-deployment.yaml
+++ b/charts/openhands/templates/litellm-deployment.yaml
@@ -46,25 +46,19 @@ spec:
             {{- toYaml .Values.litellm.resources | nindent 12 }}
           livenessProbe:
             httpGet:
-              path: /health
+              path: /health/liveliness
               port: http
-              httpHeaders:
-                - name: Authorization
-                  value: Bearer {{ .Values.llm.apiKey }}
-            initialDelaySeconds: 30
+            initialDelaySeconds: 15
             periodSeconds: 15
-            timeoutSeconds: 5
+            timeoutSeconds: 3
             failureThreshold: 3
           readinessProbe:
             httpGet:
-              path: /health
+              path: /health/readiness
               port: http
-              httpHeaders:
-                - name: Authorization
-                  value: Bearer {{ .Values.llm.apiKey }}
-            initialDelaySeconds: 15
+            initialDelaySeconds: 5
             periodSeconds: 10
-            timeoutSeconds: 5
+            timeoutSeconds: 3
             failureThreshold: 3
           volumeMounts:
             - name: claude-home


### PR DESCRIPTION
## Summary
- Switch litellm liveness probe from `/health` to `/health/liveliness` (process-level check, ~28ms)
- Switch litellm readiness probe from `/health` to `/health/readiness` (local deps check, ~30ms)
- Remove unnecessary `Authorization` header from probes (lightweight endpoints don't require auth)

## Problem
The `/health` endpoint makes live API calls to all 3 configured model providers (sonnet, opus, haiku), consistently taking ~4.7s. With a `timeoutSeconds: 5`, any network jitter causes the kubelet to mark the probe as failed — even though the container logs show `200 OK` (the response arrives after the kubelet has already timed out).

## Test plan
- [x] Verified `/health/liveliness` returns `200` in ~28ms via port-forward
- [x] Verified `/health/readiness` returns `200` in ~30ms via port-forward
- [x] Helm template renders correctly
- [ ] Monitor pod readiness after merge — should see zero probe failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)