### PR TITLE
fix(openhands): migrate images to openhands org, bump to 0.62

### DIFF
--- a/charts/openhands/Chart.yaml
+++ b/charts/openhands/Chart.yaml
@@ -3,7 +3,7 @@ name: openhands
 description: OpenHands autonomous coding agents with KubernetesRuntime
 type: application
 version: 0.1.0
-appVersion: "0.48.0"
+appVersion: "0.62.0"
 maintainers:
   - name: homelab
 keywords:

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -18,8 +18,8 @@ imagePullSecret:
 # =============================================================================
 app:
   image:
-    repository: ghcr.io/all-hands-ai/openhands
-    tag: "0.48"
+    repository: ghcr.io/openhands/openhands
+    tag: "0.62"
     pullPolicy: IfNotPresent
   replicas: 1
   resources:
@@ -92,7 +92,7 @@ serviceAccount:
 # =============================================================================
 kubernetes:
   sandboxNamespace: openhands-sandboxes
-  runtimeImage: "ghcr.io/all-hands-ai/runtime:0.48-nikolaik"
+  runtimeImage: "ghcr.io/openhands/runtime:0.62-nikolaik"
   pvcStorageClass: "longhorn"
   pvcStorageSize: "2Gi"
   resourceCpuRequest: "1"


### PR DESCRIPTION
## Summary
- Migrates OpenHands container images from deprecated `ghcr.io/all-hands-ai/` org to new `ghcr.io/openhands/` org
- Bumps app and runtime images from `0.48` to `0.62` (old org stopped publishing after `0.59`)
- Fixes `ImagePullBackOff` / `ErrImagePull` errors on sandbox runtime pods

## Changes
| Image | Before | After |
|-------|--------|-------|
| App | `ghcr.io/all-hands-ai/openhands:0.48` | `ghcr.io/openhands/openhands:0.62` |
| Runtime | `ghcr.io/all-hands-ai/runtime:0.48-nikolaik` | `ghcr.io/openhands/runtime:0.62-nikolaik` |
| LiteLLM | unchanged | unchanged |

## Test plan
- [ ] CI passes (format check + helm template render)
- [ ] ArgoCD syncs the updated deployment
- [ ] OpenHands pod starts with new `0.62` image
- [ ] Sandbox runtime pods can pull `ghcr.io/openhands/runtime:0.62-nikolaik`
- [ ] New conversation in OpenHands UI successfully spawns a sandbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)