### PR TITLE
fix(argocd-image-updater): remove unsupported --max-concurrency flag

### DIFF
--- a/charts/argocd-image-updater/values.yaml
+++ b/charts/argocd-image-updater/values.yaml
@@ -7,8 +7,6 @@ argocd-image-updater:
   extraArgs:
     - --interval
     - 2m
-    - --max-concurrency
-    - "2"
 
   # Image updater configuration
   config:


### PR DESCRIPTION
## Summary
- Removes the `--max-concurrency` flag from argocd-image-updater extraArgs, which is no longer recognized and causes startup failure: `Error: unknown flag: --max-concurrency`
- The `--interval 2m` polling config is retained unchanged

## Test plan
- [ ] CI passes (format check + build)
- [ ] ArgoCD Image Updater pod starts without errors after ArgoCD syncs
- [ ] Image update polling continues to work at 2m intervals

🤖 Generated with [Claude Code](https://claude.com/claude-code)