### PR TITLE
fix(coredns): increase DNS cache TTL for cluster stability

### DIFF
--- a/charts/coredns/values.yaml
+++ b/charts/coredns/values.yaml
@@ -29,7 +29,7 @@ corefile: |
         prefer_udp
         max_concurrent 1000
       }
-      cache 30
+      cache 300
       loop
       reload
       loadbalance
@@ -43,7 +43,7 @@ forwarders:
   - 8.8.8.8 # Google
 
 # Cache TTL in seconds
-cacheTTL: 30
+cacheTTL: 300
 
 # Max concurrent forwards
 maxConcurrent: 1000


### PR DESCRIPTION
## Summary
- Increases CoreDNS cache TTL from 30s to 300s to reduce upstream query pressure
- Complements the CoreDNS replica scaling (1→3) that resolved transient DNS failures

## Context
The cluster was experiencing transient access loss caused by DNS resolution failures cascading into:
- Image pull errors (`lookup ghcr.io: Try again`)
- Cloudflared tunnel 503s and restarts
- ArgoCD repo-server liveness probe timeouts
- ArgoCD Image Updater CrashLoopBackOff

**Root cause:** Single CoreDNS replica (now scaled to 3). This cache TTL increase further reduces the blast radius of any future upstream DNS hiccups.

## Note: UDP buffer sysctl (manual, not in this PR)
The cloudflared QUIC tunnel also reports undersized UDP buffers (`wanted: 7168 kiB, got: 416 kiB`). This requires a node-level sysctl change that can't be done via GitOps:
```bash
# Run on each node:
sudo sysctl -w net.core.rmem_max=7500000 net.core.wmem_max=7500000
echo -e "net.core.rmem_max=7500000\nnet.core.wmem_max=7500000" | sudo tee /etc/sysctl.d/99-udp-buffers.conf
```

## Test plan
- [ ] Verify CoreDNS ConfigMap updates after ArgoCD sync (`kubectl get cm coredns -n kube-system -o yaml | grep cache`)
- [ ] Confirm no DNS resolution regressions (`kubectl run dns-test --image=busybox --rm -it -- nslookup ghcr.io`)
- [ ] Monitor SigNoz HTTP health checks for continued stability

🤖 Generated with [Claude Code](https://claude.com/claude-code)