### PR TITLE
fix(openhands): upgrade from 0.62 to 1.4.0

### DIFF
--- a/charts/openhands/Chart.yaml
+++ b/charts/openhands/Chart.yaml
@@ -3,7 +3,7 @@ name: openhands
 description: OpenHands autonomous coding agents with KubernetesRuntime
 type: application
 version: 0.1.0
-appVersion: "0.62.0"
+appVersion: "1.4.0"
 maintainers:
   - name: homelab
 keywords:

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -19,7 +19,7 @@ imagePullSecret:
 app:
   image:
     repository: ghcr.io/openhands/openhands
-    tag: "0.62"
+    tag: "1.4.0"
     pullPolicy: IfNotPresent
   replicas: 1
   resources:
@@ -92,7 +92,7 @@ serviceAccount:
 # =============================================================================
 kubernetes:
   sandboxNamespace: openhands-sandboxes
-  runtimeImage: "ghcr.io/openhands/runtime:0.62-nikolaik"
+  runtimeImage: "ghcr.io/openhands/runtime:1.4.0-nikolaik"
   pvcStorageClass: "longhorn"
   pvcStorageSize: "2Gi"
   resourceCpuRequest: "1"


### PR DESCRIPTION
## Summary
- Upgrades OpenHands app image from 0.62 to 1.4.0
- Upgrades runtime sandbox image from 0.62-nikolaik to 1.4.0-nikolaik
- Fixes immediate 500 error ("This conversation does not exist") caused by `docker_sandbox_spec_service` trying to connect to a Docker socket in a containerd-based cluster

## Root Cause
OpenHands 0.62 has a bug where `docker_sandbox_spec_service.py` runs `docker.from_env()` as a mandatory FastAPI dependency injection on every conversation endpoint — even when `runtime = "kubernetes"` is configured. Since our cluster uses containerd (not Docker), this crashes immediately with `DockerException: Error while fetching server API version`.

## Test plan
- [ ] ArgoCD syncs the new deployment successfully
- [ ] OpenHands pod starts without DockerException in logs
- [ ] Creating a new conversation no longer returns 500
- [ ] Sandbox runtime pod starts and becomes ready

🤖 Generated with [Claude Code](https://claude.com/claude-code)