### PR TITLE
fix(openhands): set RUNTIME=process to prevent Docker sandbox crash

### DIFF
--- a/charts/openhands/templates/deployment.yaml
+++ b/charts/openhands/templates/deployment.yaml
@@ -57,6 +57,8 @@ spec:
               containerPort: 3000
               protocol: TCP
           env:
+            - name: RUNTIME
+              value: "process"
             - name: LLM_BASE_URL
               value: {{ .Values.llm.baseUrl | default (printf "http://%s-litellm:4000/v1" (include "openhands.fullname" .)) | quote }}
             - name: LLM_API_KEY


### PR DESCRIPTION
## Summary
- Adds `RUNTIME=process` env var to the OpenHands deployment
- Fixes 500 errors on `/api/conversations` and `/api/v1/app-conversations` endpoints

## Root Cause
OpenHands 1.4.0 mounts V1 `app_server` routes alongside the V0 server. The V1 sandbox service selection reads the `RUNTIME` env var (not `config.toml`), and defaults to `DockerSandboxServiceInjector` when unset. This crashes immediately with `DockerException` because our cluster uses containerd, not Docker.

Setting `RUNTIME=process` makes the V1 endpoints use `ProcessSandboxService` instead, while the V0 `KubernetesRuntime` (configured via `config.toml`) continues handling actual sandbox pod creation.

## Test plan
- [ ] OpenHands pod restarts without DockerException in logs
- [ ] `/api/conversations` returns 200 instead of 500
- [ ] Creating a new conversation works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)