### PR TITLE
fix(openhands): set RUNTIME=process for V1 app server

### DIFF
--- a/charts/openhands/templates/deployment.yaml
+++ b/charts/openhands/templates/deployment.yaml
@@ -57,6 +57,8 @@ spec:
               containerPort: 3000
               protocol: TCP
           env:
+            - name: RUNTIME
+              value: "process"
             - name: LLM_BASE_URL
               value: {{ .Values.llm.baseUrl | default (printf "http://%s-litellm:4000/v1" (include "openhands.fullname" .)) | quote }}
             - name: LLM_API_KEY


### PR DESCRIPTION
## Summary
- Adds `RUNTIME=process` env var to the OpenHands deployment
- Fixes 500 errors on `/api/conversations` caused by V1 app server trying to connect to Docker daemon
- V0 server still uses `runtime = "kubernetes"` from config.toml for actual K8s sandbox creation

## Root Cause
OpenHands 0.62 runs dual V0/V1 servers in parallel. The V1 `app_server` reads the `RUNTIME` env var independently from V0's `config.toml`. When `RUNTIME` is unset, V1 defaults to `DockerSandboxServiceInjector`, which calls `docker.from_env()` and crashes with `DockerException` since there's no Docker socket in K8s pods.

## Test plan
- [ ] Verify pod starts without DockerException errors in logs
- [ ] Verify `/api/conversations?limit=10` returns 200 instead of 500
- [ ] Verify frontend loads correctly
- [ ] Verify sandbox creation still works via K8s runtime

🤖 Generated with [Claude Code](https://claude.com/claude-code)