### PR TITLE
fix(openhands): downgrade to 0.59 (last pre-V1 on new org)

### DIFF
--- a/charts/openhands/Chart.yaml
+++ b/charts/openhands/Chart.yaml
@@ -3,7 +3,7 @@ name: openhands
 description: OpenHands autonomous coding agents with KubernetesRuntime
 type: application
 version: 0.1.0
-appVersion: "0.62.0"
+appVersion: "0.59"
 maintainers:
   - name: homelab
 keywords:

--- a/charts/openhands/templates/deployment.yaml
+++ b/charts/openhands/templates/deployment.yaml
@@ -57,8 +57,6 @@ spec:
               containerPort: 3000
               protocol: TCP
           env:
-            - name: RUNTIME
-              value: "kubernetes"
             - name: LLM_BASE_URL
               value: {{ .Values.llm.baseUrl | default (printf "http://%s-litellm:4000/v1" (include "openhands.fullname" .)) | quote }}
             - name: LLM_API_KEY

--- a/charts/openhands/values.yaml
+++ b/charts/openhands/values.yaml
@@ -19,7 +19,7 @@ imagePullSecret:
 app:
   image:
     repository: ghcr.io/openhands/openhands
-    tag: "0.62"
+    tag: "0.59"
     pullPolicy: IfNotPresent
   replicas: 1
   resources:
@@ -92,7 +92,7 @@ serviceAccount:
 # =============================================================================
 kubernetes:
   sandboxNamespace: openhands-sandboxes
-  runtimeImage: "ghcr.io/openhands/runtime:0.62-nikolaik"
+  runtimeImage: "ghcr.io/openhands/runtime:0.59-nikolaik"
   pvcStorageClass: "longhorn"
   pvcStorageSize: "2Gi"
   resourceCpuRequest: "1"


### PR DESCRIPTION
## Summary
- Downgrades OpenHands from 0.62 to 0.59
- 0.59 is the newest version on `ghcr.io/openhands` that doesn't include the V1 app_server
- Removes `RUNTIME` env var (0.59 reads `runtime = "kubernetes"` from config.toml only)

## Why 0.59?
| Version | V1 app_server | Docker dependency | K8s runtime |
|---------|--------------|-------------------|-------------|
| 0.59    | No (0 files) | None              | Native via config.toml |
| 0.60    | Yes (75 files) | DockerSandboxServiceInjector | V0 works, V1 crashes |
| 0.61    | Yes (75 files) | DockerSandboxServiceInjector | V0 works, V1 crashes |
| 0.62    | Yes (77 files) | DockerSandboxServiceInjector | V0 works, V1 crashes |

## Test plan
- [ ] Pod starts without crashes
- [ ] `/api/conversations?limit=10` returns 200
- [ ] Frontend loads and is functional
- [ ] Sandbox creation works via K8s runtime

🤖 Generated with [Claude Code](https://claude.com/claude-code)