### PR TITLE
fix: right-size all service resources for Guaranteed QoS

### DIFF
--- a/charts/api-gateway/values.yaml
+++ b/charts/api-gateway/values.yaml
@@ -7,11 +7,11 @@ nginx:
     pullPolicy: IfNotPresent
   resources:
     requests:
-      cpu: 10m
-      memory: 32Mi
+      cpu: 100m
+      memory: 48Mi
     limits:
       cpu: 100m
-      memory: 64Mi
+      memory: 48Mi
 
 clusterInfo:
   enabled: true
@@ -35,6 +35,7 @@ clusterInfo:
       cpu: 50m
       memory: 256Mi
     limits:
+      cpu: 50m
       memory: 256Mi
 
 # Backend services to route to

--- a/charts/grimoire/values.yaml
+++ b/charts/grimoire/values.yaml
@@ -10,11 +10,11 @@ frontend:
     port: 8080
   resources:
     requests:
-      cpu: 50m
-      memory: 64Mi
+      cpu: 5m
+      memory: 32Mi
     limits:
-      cpu: 100m
-      memory: 64Mi
+      cpu: 5m
+      memory: 32Mi
 
 # WebSocket Gateway — Go binary proxying Gemini Live + game relay
 wsGateway:
@@ -29,11 +29,11 @@ wsGateway:
     port: 8080
   resources:
     requests:
-      cpu: 200m
-      memory: 256Mi
+      cpu: 5m
+      memory: 16Mi
     limits:
-      cpu: 500m
-      memory: 256Mi
+      cpu: 5m
+      memory: 16Mi
 
 # Redis — ephemeral pub/sub + session state
 redis:
@@ -47,11 +47,11 @@ redis:
     port: 6379
   resources:
     requests:
-      cpu: 100m
-      memory: 128Mi
+      cpu: 10m
+      memory: 16Mi
     limits:
-      cpu: 200m
-      memory: 128Mi
+      cpu: 10m
+      memory: 16Mi
 
 # ServiceAccount
 serviceAccount:

--- a/charts/knowledge-graph/values.yaml
+++ b/charts/knowledge-graph/values.yaml
@@ -12,11 +12,11 @@ scraper:
     targetPort: 8080
   resources:
     requests:
-      cpu: 100m
-      memory: 256Mi
+      cpu: 10m
+      memory: 128Mi
     limits:
-      cpu: 500m
-      memory: 512Mi
+      cpu: 10m
+      memory: 128Mi
 
 # --- CronJob (batch scrape) ---
 cronjob:
@@ -46,8 +46,8 @@ embedder:
       cpu: 500m
       memory: 512Mi
     limits:
-      cpu: 2000m
-      memory: 1Gi
+      cpu: 500m
+      memory: 512Mi
 
 # --- MCP Server ---
 mcp:
@@ -63,11 +63,11 @@ mcp:
     targetPort: 8080
   resources:
     requests:
-      cpu: 50m
+      cpu: 10m
       memory: 128Mi
     limits:
-      cpu: 500m
-      memory: 256Mi
+      cpu: 10m
+      memory: 128Mi
 
 # --- Shared ---
 imagePullSecret:

--- a/charts/marine/values.yaml
+++ b/charts/marine/values.yaml
@@ -97,11 +97,11 @@ ingest:
   # Increased for global AIS coverage (~300 msg/sec)
   resources:
     requests:
-      cpu: 100m
-      memory: 128Mi
+      cpu: 20m
+      memory: 100Mi
     limits:
-      cpu: 500m
-      memory: 256Mi
+      cpu: 20m
+      memory: 100Mi
 
   # Pod annotations
   podAnnotations: {}
@@ -140,13 +140,13 @@ api:
     origins: "http://localhost:3000"
 
   # Resource limits
-  # Increased memory for larger SQLite operations
   resources:
     requests:
       cpu: 100m
-      memory: 256Mi
+      memory: 900Mi
     limits:
-      memory: 1Gi
+      cpu: 100m
+      memory: 900Mi
 
   # Liveness probe - checks if container should be restarted
   # During catchup, the API may be unresponsive; increase tolerance
@@ -204,10 +204,10 @@ frontend:
   resources:
     requests:
       cpu: 10m
-      memory: 64Mi
+      memory: 100Mi
     limits:
-      cpu: 200m
-      memory: 256Mi
+      cpu: 10m
+      memory: 100Mi
 
   # Pod annotations
   podAnnotations: {}

--- a/charts/stargazer/values.yaml
+++ b/charts/stargazer/values.yaml
@@ -38,8 +38,8 @@ securityContext:
 # Resource limits for processing geospatial data
 resources:
   limits:
-    cpu: 2000m
-    memory: 4Gi
+    cpu: 500m
+    memory: 1Gi
   requests:
     cpu: 500m
     memory: 1Gi
@@ -118,11 +118,11 @@ api:
     runAsUser: 101 # nginx user in nginx-unprivileged image
   resources:
     limits:
-      cpu: 200m
-      memory: 256Mi
+      cpu: 5m
+      memory: 32Mi
     requests:
-      cpu: 50m
-      memory: 128Mi
+      cpu: 5m
+      memory: 32Mi
   httproute:
     enabled: false
     hostname: api.jomcgi.dev

--- a/charts/todo/values.yaml
+++ b/charts/todo/values.yaml
@@ -44,18 +44,18 @@ persistence:
 resources:
   api:
     requests:
-      memory: "32Mi"
-      cpu: "10m"
+      memory: "24Mi"
+      cpu: "5m"
     limits:
-      memory: "64Mi"
-      cpu: "100m"
+      memory: "24Mi"
+      cpu: "5m"
   static:
     requests:
       memory: "16Mi"
       cpu: "5m"
     limits:
-      memory: "32Mi"
-      cpu: "50m"
+      memory: "16Mi"
+      cpu: "5m"
 
 # Pod affinity/anti-affinity rules
 # Useful for RWO volumes to keep pod on same node and avoid volume reattachment delays

--- a/charts/trips/values.yaml
+++ b/charts/trips/values.yaml
@@ -26,10 +26,11 @@ imgproxy:
 
   resources:
     requests:
-      cpu: 500m
-      memory: 1Gi
+      cpu: 10m
+      memory: 75Mi
     limits:
-      memory: 1Gi
+      cpu: 10m
+      memory: 75Mi
 
   config:
     quality: "90"
@@ -48,11 +49,11 @@ nginx:
 
   resources:
     requests:
-      cpu: 20m
-      memory: 32Mi
+      cpu: 5m
+      memory: 16Mi
     limits:
-      cpu: 200m
-      memory: 128Mi
+      cpu: 5m
+      memory: 16Mi
 
 # API server configuration
 api:
@@ -68,11 +69,11 @@ api:
 
   resources:
     requests:
-      cpu: 50m
-      memory: 64Mi
+      cpu: 10m
+      memory: 75Mi
     limits:
-      cpu: 500m
-      memory: 256Mi
+      cpu: 10m
+      memory: 75Mi
 
   # Upload API authentication (from 1Password secret)
   auth:

--- a/overlays/dev/marine/values.yaml
+++ b/overlays/dev/marine/values.yaml
@@ -47,13 +47,13 @@ api:
     tag: main@sha256:41fe89f61cf4747304cc2c8cee32774829708e1445fb56505fc184e7177e9e1e
     pullPolicy: Always
     digest: sha256:af41b804e33ba2cf962bd3c2e169faed71e80f2f5ef73ea91ef99198dcb1d632
-  # Overprovisioned for catchup - reduce after caught up
   resources:
     requests:
-      cpu: 1
-      memory: 1Gi
+      cpu: 100m
+      memory: 900Mi
     limits:
-      memory: 10Gi
+      cpu: 100m
+      memory: 900Mi
   # Increased tolerance for liveness probe during NATS message catchup
   # The API may be unresponsive while processing large backlogs
   livenessProbe:
@@ -77,10 +77,10 @@ frontend:
   resources:
     requests:
       cpu: 10m
-      memory: 128Mi
+      memory: 100Mi
     limits:
-      cpu: 200m
-      memory: 512Mi
+      cpu: 10m
+      memory: 100Mi
   # Zero Trust access policy - disabled, manually configured in Cloudflare
   zeroTrust:
     policyId: ""

--- a/overlays/dev/stargazer/values.yaml
+++ b/overlays/dev/stargazer/values.yaml
@@ -30,8 +30,8 @@ persistence:
 # Resource limits
 resources:
   limits:
-    cpu: 2000m
-    memory: 4Gi
+    cpu: 500m
+    memory: 1Gi
   requests:
     cpu: 500m
     memory: 1Gi


### PR DESCRIPTION
## Summary
Sets requests = limits (Guaranteed QoS) across all homelab services, targeting ~80% memory utilization based on `kubectl top` measurements.

## Changes (9 files)

| Service | Component | Before Req/Limit | After Req=Limit | Actual Usage |
|---------|-----------|-----------------|-----------------|-------------|
| marine | api | 1Gi / 10Gi | 900Mi / 900Mi | 725Mi |
| marine | frontend | 128Mi / 512Mi | 100Mi / 100Mi | 80Mi |
| marine | ingest | 128Mi / 256Mi | 100Mi / 100Mi | 79Mi |
| grimoire | frontend | 64Mi / 64Mi | 32Mi / 32Mi | 13Mi |
| grimoire | ws-gateway | 256Mi / 256Mi | 16Mi / 16Mi | 7Mi |
| grimoire | redis | 128Mi / 128Mi | 16Mi / 16Mi | 3Mi |
| stargazer | CronJob | 1Gi / 4Gi | 1Gi / 1Gi | (batch) |
| stargazer | api (nginx) | 128Mi / 256Mi | 32Mi / 32Mi | 14Mi |
| trips | api | 64Mi / 256Mi | 75Mi / 75Mi | 58Mi |
| trips | imgproxy | 1Gi / 1Gi | 75Mi / 75Mi | 59Mi |
| trips | nginx | 32Mi / 128Mi | 16Mi / 16Mi | 10Mi |
| knowledge-graph | scraper | 256Mi / 512Mi | 128Mi / 128Mi | 103Mi |
| knowledge-graph | mcp | 128Mi / 256Mi | 128Mi / 128Mi | 93Mi |
| knowledge-graph | embedder | 512Mi / 1Gi | 512Mi / 512Mi | (batch) |
| api-gateway | nginx | 32Mi / 64Mi | 48Mi / 48Mi | 37Mi |
| todo | api+static | 48Mi / 96Mi | 40Mi / 40Mi | 17Mi |

## Total memory limit reduction
~17Gi freed across the cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)