### PR TITLE
fix(stargazer): right-size CronJob resources from 1Gi to 256Mi

### DIFF
--- a/charts/stargazer/values.yaml
+++ b/charts/stargazer/values.yaml
@@ -38,11 +38,11 @@ securityContext:
 # Resource limits for processing geospatial data
 resources:
   limits:
-    cpu: 500m
-    memory: 1Gi
+    cpu: 100m
+    memory: 256Mi
   requests:
-    cpu: 500m
-    memory: 1Gi
+    cpu: 100m
+    memory: 256Mi
 
 # Persistent storage for data
 persistence:

--- a/overlays/dev/stargazer/values.yaml
+++ b/overlays/dev/stargazer/values.yaml
@@ -30,11 +30,11 @@ persistence:
 # Resource limits
 resources:
   limits:
-    cpu: 500m
-    memory: 1Gi
+    cpu: 100m
+    memory: 256Mi
   requests:
-    cpu: 500m
-    memory: 1Gi
+    cpu: 100m
+    memory: 256Mi
 # OpenTelemetry configuration
 config:
   opentelemetry:


### PR DESCRIPTION
## Summary
- Reduced stargazer CronJob memory from 1Gi to 256Mi (~19% headroom over observed 215 MiB peak)
- Reduced CPU from 500m to 100m (job is I/O-bound, completes in ~4 seconds)
- Updated both base chart and dev overlay to maintain requests = limits (Guaranteed QoS)

## Evidence
SigNoz `k8s.pod.memory.usage` over 4 days shows CronJob pods peak at ~215 MiB. The job fetches ~210 weather forecasts from Met.no and scores them with fiona/GDAL — almost entirely I/O-bound.

## Test plan
- [ ] CronJob runs successfully on next scheduled execution (every 30 min in dev)
- [ ] Pod stays within 256Mi limit (monitor via SigNoz)

🤖 Generated with [Claude Code](https://claude.com/claude-code)