### PR TITLE
chore: remove stale enumerations from CLAUDE.md

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -2,31 +2,22 @@
 
 ## Repository
 
-Hosted at **https://github.com/jomcgi/homelab**. The `gh` CLI is authenticated:
-
-```bash
-gh issue list
-gh issue view <number>
-gh pr create --title "..." --body "..."
-gh pr view <number>
-```
+Hosted at **https://github.com/jomcgi/homelab**. The `gh` CLI is authenticated.
 
 ## Repository Structure
 
 ```
 homelab/
-├── charts/              # Helm charts (27 charts: argocd, signoz, trips, grimoire, ...)
-├── overlays/            # Environment-specific overrides
-│   ├── cluster-critical/  # Core infra (argocd, cert-manager, linkerd, longhorn, signoz)
-│   ├── dev/               # Development services (grimoire, marine, stargazer)
-│   └── prod/              # Production services (trips, knowledge-graph, nats, ...)
+├── charts/              # Helm charts — ls to discover available charts
+├── overlays/            # Environment-specific overrides — ls overlays/<env>/ for services
+│   ├── cluster-critical/  # Core infra (networking, storage, observability, policy)
+│   ├── dev/               # Development services
+│   └── prod/              # Production services
 ├── operators/           # Custom Kubernetes operators (Go, controller-runtime)
-│   ├── cloudflare/        # Cloudflare DNS/tunnel operator
-│   └── oci-model-cache/   # ML model caching operator
 ├── services/            # Application source code (Go, Python)
 ├── websites/            # Frontend apps (Vite + React, Astro) — JS, not TypeScript
 ├── tools/               # Build tooling (Bazel macros, OCI helpers, scripts)
-├── architecture/        # Design docs (security, observability, services, contributing)
+├── architecture/        # Design docs and RFCs — ls to discover available docs
 ├── clusters/            # Kustomization entry point for ArgoCD
 ├── MODULE.bazel         # Bazel dependency management (bzlmod, not WORKSPACE)
 └── buildbuddy.yaml      # CI pipeline definition
@@ -66,7 +57,9 @@ bazelisk run //charts/<service>/image:push
 - **Security changes**: Read `architecture/security.md` FIRST
 - **New services**: Read `architecture/contributing.md` + `architecture/services.md`
 - **Observability work**: Read `architecture/observability.md`
+- **Alerting work**: Read `architecture/observability-alerting.md`
 - **Operator changes**: Read `operators/best-practices.md`
+- **Design proposals**: Check `architecture/rfcs/` for existing RFCs
 
 ## Key Patterns
 


### PR DESCRIPTION
## Summary
- Replaced hardcoded chart counts, service names, and operator examples with structural descriptions that encourage `ls` exploration instead of going stale
- Added missing context loading rules for `architecture/observability-alerting.md` and `architecture/rfcs/`
- Trimmed `gh` CLI section from 7 lines of example commands to a one-liner (Claude already knows how to use `gh`)

## Motivation
The CLAUDE.md had **27 charts** hardcoded when there are actually 28. Dev overlay listed 3 services but there are 4. Cluster-critical listed 5 but there are 11. These drift every time a service is added. The fix: describe *what kind of things* live in each directory, and tell Claude to `ls` when it needs specifics.

## Test plan
- [ ] Verify CLAUDE.md renders correctly on GitHub
- [ ] Confirm no useful information was lost (structural patterns and rules preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)