### PR TITLE
chore: remove redundant context from claude config

### DIFF
--- a/.claude/AGENTS.md
+++ b/.claude/AGENTS.md
@@ -1,21 +1,8 @@
 # AGENTS.md - Specialized Agent Definitions
 
 This file defines specialized agents for common tasks in this repository.
-Agents duplicated by on-demand skills (`bazelisk`, `helm`, `kubectl`, `signoz`, `gh-pr`, `buildbuddy`) have been removed — use those skills instead.
 
----
-
-## CRITICAL: All Tests Must Use Bazel
-
-**NEVER run tests directly with `pytest`, `go test`, `vitest`, or `npm test`.** All tests in this repository MUST be run via Bazel:
-
-```bash
-bazel test //...                                    # Run all tests
-bazel test //services/ships_api:ships_api_test      # Run specific target
-bazel test //... --config=ci                        # CI mode (remote caching)
-```
-
-**When adding new tests:** create test files, add BUILD.bazel with test targets, use patterns from language-specific sections below.
+Repo-wide rules (test commands, anti-patterns, key patterns) live in CLAUDE.md — not repeated here.
 
 ---
 
@@ -179,9 +166,7 @@ use_repo(apko, "myservice_lock")
 1. **Not updating lock file** — run `bazel run @rules_apko//apko -- lock <path>` after changing apko.yaml
 2. **Missing architectures** — always include both `x86_64` and `aarch64`
 3. **Missing CA certificates** — HTTPS calls fail without `ca-certificates-bundle`
-4. **Running as root** — always set `run-as` to non-root uid
-5. **Forgetting MODULE.bazel** — new locks must be registered with `apko.translate_lock`
-6. **Using Dockerfiles** — this repo uses apko exclusively
+4. **Forgetting MODULE.bazel** — new locks must be registered with `apko.translate_lock`
 
 ### Debugging Image Issues
 
@@ -284,7 +269,7 @@ helm template kyverno charts/kyverno/ -s templates/otel-injection-policy.yaml
 ```yaml
 securityContext:
   runAsNonRoot: true
-  runAsUser: 65534
+  runAsUser: 65532
   allowPrivilegeEscalation: false
   readOnlyRootFilesystem: true
   capabilities:
@@ -320,11 +305,9 @@ spec:
 
 ### Common Mistakes to Avoid
 
-1. **Running containers as root** — always use `runAsNonRoot: true`
-2. **Using `:latest` image tags** — pin to digest or immutable tags
-3. **Storing secrets in Git** — use 1Password Operator (OnePasswordItem CRD)
-4. **Wildcard RBAC permissions** — specify exact resources and verbs
-5. **No NetworkPolicies** — apply default-deny in every namespace
+1. **Using `:latest` image tags** — pin to digest or immutable tags
+2. **Wildcard RBAC permissions** — specify exact resources and verbs
+3. **No NetworkPolicies** — apply default-deny in every namespace
 
 ---
 
@@ -338,44 +321,9 @@ ArgoCD GitOps specialist. Use the `kubectl` skill for general cluster debugging.
 - Understanding Application.yaml patterns
 - Debugging sync failures specific to ArgoCD configuration
 
-### Application.yaml Pattern (This Repo)
+### Application.yaml Pattern
 
-```yaml
-apiVersion: argoproj.io/v1alpha1
-kind: Application
-metadata:
-  name: <env>-<service> # e.g., prod-trips
-  namespace: argocd
-  annotations:
-    argocd.argoproj.io/sync-wave: "2"
-spec:
-  project: default
-  source:
-    repoURL: https://github.com/jomcgi/homelab.git
-    path: charts/<chart>
-    targetRevision: HEAD
-    helm:
-      releaseName: <service>
-      valueFiles:
-        - values.yaml
-        - ../../overlays/<env>/<service>/values.yaml
-  destination:
-    server: https://kubernetes.default.svc
-    namespace: <namespace>
-  syncPolicy:
-    automated:
-      prune: true
-      selfHeal: true
-    syncOptions:
-      - CreateNamespace=true
-      - ServerSideApply=true
-    retry:
-      limit: 5
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 3m
-```
+Use the `/add-service` skill to scaffold new applications. For the full template, see `overlays/<env>/<service>/application.yaml` in any existing service.
 
 ### Sync Strategies
 
@@ -453,11 +401,7 @@ Vite build tool specialist for the frontend apps in this repo.
 
 Code review specialist for PR validation. Use with the `code-review` or `coderabbit` skills.
 
-### Pre-requisite Reading (Context-dependent)
-
-- **Security changes:** `architecture/security.md`
-- **New services:** `architecture/contributing.md` + `architecture/services.md`
-- **Observability changes:** `architecture/observability.md`
+Pre-requisite reading is context-dependent — see "Context Loading Rules" in CLAUDE.md.
 
 ### Checklist by Change Type
 
@@ -491,7 +435,7 @@ Code review specialist for PR validation. Use with the `code-review` or `coderab
 
 ## observability
 
-Observability specialist. Use the `signoz` skill for querying logs, traces, and metrics via MCP.
+Observability specialist.
 
 ### Pre-requisite Reading
 

--- a/.claude/skills/add-httpcheck-alert/SKILL.md
+++ b/.claude/skills/add-httpcheck-alert/SKILL.md
@@ -187,74 +187,6 @@ Creates: `overlays/cluster-critical/signoz/signoz-httpcheck-alert.yaml`
 
 Creates: `overlays/prod/api-gateway/api-gateway-httpcheck-alert.yaml`
 
-## Complete Example
-
-For a service named `myapp` with URL `https://myapp.jomcgi.dev`:
-
-```yaml
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: myapp-httpcheck-alert
-  namespace: myapp
-  labels:
-    signoz.io/alert: "true"
-  annotations:
-    signoz.io/alert-name: "myapp Unreachable"
-    signoz.io/severity: "critical"
-    signoz.io/notification-channels: "pagerduty-homelab"
-data:
-  alert.json: |
-    {
-      "alert": "myapp Unreachable",
-      "alertType": "METRICS_BASED_ALERT",
-      "ruleType": "threshold_rule",
-      "broadcastToAll": false,
-      "disabled": false,
-      "evalWindow": "10m0s",
-      "frequency": "2m0s",
-      "severity": "critical",
-      "labels": {
-        "service": "myapp",
-        "environment": "production"
-      },
-      "annotations": {
-        "summary": "myapp at https://myapp.jomcgi.dev is unreachable",
-        "description": "HTTP health check has failed 5 consecutive times over 10 minutes. This could indicate the service is down or Cloudflare auth is failing (3xx redirect)."
-      },
-      "condition": {
-        "compositeQuery": {
-          "builderQueries": {
-            "A": {
-              "queryName": "A",
-              "dataSource": "metrics",
-              "aggregateOperator": "avg",
-              "aggregateAttribute": {
-                "key": "httpcheck.status",
-                "dataType": "float64",
-                "type": "Gauge"
-              },
-              "filters": {
-                "items": [
-                  {
-                    "key": {"key": "http.url"},
-                    "op": "=",
-                    "value": "https://myapp.jomcgi.dev"
-                  }
-                ]
-              }
-            }
-          },
-          "queryType": "builder"
-        },
-        "op": "<",
-        "target": 1,
-        "matchType": "5"
-      },
-      "preferredChannels": ["pagerduty-homelab"]
-    }
-```
-
 ## Post-Creation Steps
 
 1. Add the alert file to the service's `kustomization.yaml` if not using `resources: ["*.yaml"]`
@@ -267,15 +199,5 @@ data:
 After ArgoCD syncs, verify the alert was created:
 
 ```bash
-# Check ConfigMap exists
 kubectl get configmap <service>-httpcheck-alert -n <namespace>
-
-# Verify in SigNoz (via MCP)
-mcp__signoz__list_alerts
 ```
-
-## Related Skills
-
-- `/signoz` - Query SigNoz for logs, traces, and alert status
-- `/worktree` - Create worktree for making changes
-- `/gh-pr` - Create PR after adding the alert

--- a/.claude/skills/add-image-updater/SKILL.md
+++ b/.claude/skills/add-image-updater/SKILL.md
@@ -281,51 +281,6 @@ After creating the ImageUpdater:
    kubectl get imageupdater -n argocd
    ```
 
-## Complete Example
-
-For a new service `myapp` in `overlays/prod/myapp/`:
-
-**overlays/prod/myapp/imageupdater.yaml:**
-
-```yaml
-apiVersion: argocd-image-updater.argoproj.io/v1alpha1
-kind: ImageUpdater
-metadata:
-  name: myapp
-  namespace: argocd
-spec:
-  applicationRefs:
-    - images:
-        - alias: myapp
-          commonUpdateSettings:
-            updateStrategy: digest
-            forceUpdate: false
-          imageName: ghcr.io/jomcgi/homelab/charts/myapp:main
-          manifestTargets:
-            helm:
-              name: image.repository
-              tag: image.tag
-      namePattern: myapp
-  namespace: argocd
-  writeBackConfig:
-    method: git:secret:argocd/argocd-image-updater-token
-    gitConfig:
-      repository: https://github.com/jomcgi/homelab.git
-      branch: main
-      writeBackTarget: helmvalues:../../overlays/prod/myapp/values.yaml
-```
-
-**overlays/prod/myapp/kustomization.yaml:**
-
-```yaml
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-
-resources:
-  - application.yaml
-  - imageupdater.yaml
-```
-
 ## Troubleshooting
 
 | Issue                     | Solution                                                              |

--- a/.claude/skills/add-service/SKILL.md
+++ b/.claude/skills/add-service/SKILL.md
@@ -205,50 +205,10 @@ imagePullSecret:
 
 ## Common Add-ons
 
-After creating the base service, you may want to add:
+After creating the base service, use these skills to add supporting resources:
 
-### Image Updater (for auto-updating container images)
-
-Create `overlays/{env}/{service}/imageupdater.yaml`:
-
-```yaml
-apiVersion: argocd-image-updater.argoproj.io/v1alpha1
-kind: ImageUpdater
-metadata:
-  name: { service }
-  namespace: argocd
-spec:
-  applicationRefs:
-    - images:
-        - alias: { service }
-          commonUpdateSettings:
-            updateStrategy: digest
-            forceUpdate: false
-          imageName: ghcr.io/jomcgi/homelab/charts/{service}:main
-          manifestTargets:
-            helm:
-              name: image.repository
-              tag: image.tag
-      namePattern: { service }
-  writeBackConfig:
-    method: git:secret:argocd/argocd-image-updater-token
-    gitConfig:
-      repository: https://github.com/jomcgi/homelab.git
-      branch: main
-      writeBackTarget: helmvalues:../../overlays/{env}/{service}/values.yaml
-```
-
-Then update `kustomization.yaml`:
-
-```yaml
-resources:
-  - application.yaml
-  - imageupdater.yaml
-```
-
-### HTTP Check Alert (for monitoring)
-
-Create `overlays/{env}/{service}/{service}-httpcheck-alert.yaml` with SigNoz alert rules.
+- `/add-image-updater` — automatic container image updates via ArgoCD Image Updater
+- `/add-httpcheck-alert` — SigNoz HTTP health check monitoring
 
 ## Workflow Summary
 

--- a/.claude/skills/bazel/SKILL.md
+++ b/.claude/skills/bazel/SKILL.md
@@ -112,93 +112,17 @@ bazel run //tools:help
 
 ## Container Images with apko
 
-apko is Chainguard's declarative container image builder. Images are defined in `apko.yaml` files.
-
-### apko.yaml Structure
-
-```yaml
-contents:
-  repositories:
-    - https://packages.wolfi.dev/os # Wolfi packages
-    - https://packages.cgr.dev/extras # Chainguard extras
-  keyring:
-    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
-  packages:
-    - nodejs-22
-    - npm
-    - kubectl
-    - bazelisk # NOT bazel-9 (use bazelisk for version management)
-
-archs:
-  - x86_64
-  - aarch64
-
-cmd: /app/start.sh
-
-accounts:
-  users:
-    - username: user
-      uid: 1000
-  run-as: 1000
-
-paths:
-  - path: /app
-    type: directory
-    uid: 1000
-    permissions: 0o755
-```
+For apko.yaml structure, BUILD.bazel patterns, and package reference, see the `container` agent in AGENTS.md.
 
 ### Updating Lock Files
 
-When you modify `apko.yaml`, update the lock:
-
 ```bash
+# Update a single lock
 bazel run @rules_apko//apko -- lock charts/<service>/image/apko.yaml
+
+# Or update all locks
+format
 ```
-
-Or run `format` which updates all locks automatically.
-
-### Checking Package Availability
-
-Packages come from Wolfi. Check if a package exists:
-
-```bash
-# Search for packages
-curl -s https://packages.wolfi.dev/os/x86_64/APKINDEX.tar.gz | \
-  tar -xzO APKINDEX 2>/dev/null | grep "^P:" | grep -i "<search-term>"
-
-# Example: find bazel packages
-curl -s https://packages.wolfi.dev/os/x86_64/APKINDEX.tar.gz | \
-  tar -xzO APKINDEX 2>/dev/null | grep "^P:bazel"
-# Returns: bazel-5, bazel-6, bazel-7, bazel-8, bazelisk
-```
-
-### Common Package Names
-
-| Want       | Package Name  | Notes                                   |
-| ---------- | ------------- | --------------------------------------- |
-| Bazel      | `bazelisk`    | Auto-selects version from .bazelversion |
-| Node.js    | `nodejs-22`   | Version-specific                        |
-| Python     | `python-3.12` | Version-specific                        |
-| kubectl    | `kubectl`     | Latest stable                           |
-| Helm       | `helm`        | Resolves to helm-4                      |
-| GitHub CLI | `gh`          |                                         |
-| ripgrep    | `ripgrep`     |                                         |
-
-### Troubleshooting "nothing provides" Errors
-
-If `apko lock` fails with "nothing provides X":
-
-1. **Check package name** - Search Wolfi (see above)
-2. **Check spelling** - Package names are exact (e.g., `nodejs-22` not `node`)
-3. **Version suffix** - Some packages need version (e.g., `python-3.12` not `python`)
-4. **Use meta-packages** - `bazelisk` instead of `bazel-9`
-
-### Image Locations
-
-| Service | apko.yaml Location              |
-| ------- | ------------------------------- |
-| Todo    | `charts/todo/image/apko.yaml` |
 
 ## Caching
 

--- a/.claude/skills/buildbuddy/SKILL.md
+++ b/.claude/skills/buildbuddy/SKILL.md
@@ -95,139 +95,38 @@ curl -s -X POST \
   https://jomcgi.buildbuddy.io/api/v1/GetLog
 ```
 
-## Common Use Cases
+## API Request Pattern
 
-### 1. Analyze Failed Bazel Builds
+All endpoints use the same request format:
 
 ```bash
-# Get invocation summary (success status, duration, command, patterns)
 curl -s -X POST \
   -H "x-buildbuddy-api-key: $BUILDBUDDY_API_KEY" \
   -H "Content-Type: application/json" \
-  -d '{"selector":{"invocation_id":"<id>"}}' \
-  https://jomcgi.buildbuddy.io/api/v1/GetInvocation \
-  | jq '{success: .invocation.success, duration_ms: .invocation.duration_millis, command: .invocation.command}'
-
-# Get build logs (includes stdout/stderr)
-curl -s -X POST \
-  -H "x-buildbuddy-api-key: $BUILDBUDDY_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"selector":{"invocation_id":"<id>"}}' \
-  https://jomcgi.buildbuddy.io/api/v1/GetLog \
-  | jq -r '.log'
+  -d '{"selector":{"invocation_id":"<INVOCATION_ID>"}}' \
+  https://jomcgi.buildbuddy.io/api/v1/<ENDPOINT>
 ```
 
-### 2. Check Build Performance
+### Useful jq Filters by Endpoint
+
+| Endpoint | jq Filter | Returns |
+| --- | --- | --- |
+| `GetInvocation` | `'{success: .invocation.success, command: .invocation.command, duration_ms: .invocation.duration_millis}'` | Build summary |
+| `GetInvocation` | `'{repo: .invocation.repo_url, commit: .invocation.commit_sha, branch: .invocation.branch_name}'` | Repo context |
+| `GetLog` | `-r '.log'` | Full build log |
+| `GetLog` | `-r '.log' \| grep -iE "(error\|fail\|fatal)" \| head -20` | Errors only |
+
+## GitHub PR Integration
 
 ```bash
-# Get timing and action count
-curl -s -X POST \
-  -H "x-buildbuddy-api-key: $BUILDBUDDY_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"selector":{"invocation_id":"<id>"}}' \
-  https://jomcgi.buildbuddy.io/api/v1/GetInvocation \
-  | jq '{duration_ms: .invocation.duration_millis, action_count: .invocation.action_count}'
-```
-
-### 3. Get Repository Context
-
-```bash
-# Get repo URL, commit, and branch info
-curl -s -X POST \
-  -H "x-buildbuddy-api-key: $BUILDBUDDY_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"selector":{"invocation_id":"<id>"}}' \
-  https://jomcgi.buildbuddy.io/api/v1/GetInvocation \
-  | jq '{repo: .invocation.repo_url, commit: .invocation.commit_sha, branch: .invocation.branch_name}'
-```
-
-## Integration with GitHub PR Debugging
-
-### Full Workflow
-
-```bash
-# 1. Check PR status
-gh pr checks --json name,state,link
-
-# 2. Extract BuildBuddy invocation IDs from failed checks
+# Extract invocation IDs from failed PR checks
 gh pr checks --json link,state | \
   jq -r '.[] | select(.state == "FAILURE") | .link' | \
   grep buildbuddy | \
   sed 's|.*/invocation/||'
-
-# 3. For each failed invocation, get details
-for INVOCATION_ID in $(gh pr checks --json link,state | jq -r '.[] | select(.state == "FAILURE") | .link' | grep buildbuddy | sed 's|.*/invocation/||'); do
-  echo "=== Invocation: $INVOCATION_ID ==="
-
-  # Get summary
-  curl -s -X POST \
-    -H "x-buildbuddy-api-key: $BUILDBUDDY_API_KEY" \
-    -H "Content-Type: application/json" \
-    -d "{\"selector\":{\"invocation_id\":\"$INVOCATION_ID\"}}" \
-    https://jomcgi.buildbuddy.io/api/v1/GetInvocation \
-    | jq -r '{success: .invocation.success, command: .invocation.command, duration_ms: .invocation.duration_millis}'
-
-  # Get logs (first 50 lines)
-  curl -s -X POST \
-    -H "x-buildbuddy-api-key: $BUILDBUDDY_API_KEY" \
-    -H "Content-Type: application/json" \
-    -d "{\"selector\":{\"invocation_id\":\"$INVOCATION_ID\"}}" \
-    https://jomcgi.buildbuddy.io/api/v1/GetLog \
-    | jq -r '.log' | head -50
-
-  echo ""
-done
 ```
 
-### Quick Error Check
-
-```bash
-# Get logs and filter for ERROR/FAILURE patterns
-INVOCATION_ID="<id>"
-
-curl -s -X POST \
-  -H "x-buildbuddy-api-key: $BUILDBUDDY_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d "{\"selector\":{\"invocation_id\":\"$INVOCATION_ID\"}}" \
-  https://jomcgi.buildbuddy.io/api/v1/GetLog \
-  | jq -r '.log' \
-  | grep -i -E "(error|fail|fatal)" \
-  | head -20
-```
-
-## Helper Functions
-
-Add to your shell profile for easier debugging:
-
-```bash
-# Get BuildBuddy invocation summary
-bb_summary() {
-  local id="$1"
-  curl -s -X POST \
-    -H "x-buildbuddy-api-key: $BUILDBUDDY_API_KEY" \
-    -H "Content-Type: application/json" \
-    -d "{\"selector\":{\"invocation_id\":\"$id\"}}" \
-    https://jomcgi.buildbuddy.io/api/v1/GetInvocation \
-    | jq '{success: .invocation.success, command: .invocation.command, duration_ms: .invocation.duration_millis, action_count: .invocation.action_count}'
-}
-
-# Get BuildBuddy logs
-bb_logs() {
-  local id="$1"
-  curl -s -X POST \
-    -H "x-buildbuddy-api-key: $BUILDBUDDY_API_KEY" \
-    -H "Content-Type: application/json" \
-    -d "{\"selector\":{\"invocation_id\":\"$id\"}}" \
-    https://jomcgi.buildbuddy.io/api/v1/GetLog \
-    | jq -r '.log'
-}
-
-# Get BuildBuddy errors
-bb_errors() {
-  local id="$1"
-  bb_logs "$id" | grep -i -E "(error|fail|fatal)" | head -30
-}
-```
+Then use the invocation ID with the API request pattern above.
 
 ## Tips
 


### PR DESCRIPTION
## Summary

- **Fix UID contradiction**: security agent example used `65534` instead of repo-standard `65532`
- **Remove ~427 lines** of duplicated context across AGENTS.md and 5 skills
- **Establish clear ownership**: each concept documented once, other files reference it

## What changed

| File | Change | Lines saved |
|------|--------|-------------|
| AGENTS.md | Remove critical section (duplicates CLAUDE.md), fix UID, remove duplicated common mistakes, replace ArgoCD template with skill reference, remove reviewer prereqs duplication, fix stale signoz reference | ~76 |
| bazel skill | Remove apko.yaml section (owned by container agent) | ~84 |
| buildbuddy skill | Single API pattern + jq filter table replaces 10 repeated curl blocks, remove shell helper functions | ~129 |
| add-httpcheck-alert skill | Remove duplicate complete example, remove stale related skills | ~78 |
| add-image-updater skill | Remove duplicate complete example | ~45 |
| add-service skill | Replace inline image updater template with skill references | ~46 |

## Ownership model

| Concept | Canonical location |
|---------|-------------------|
| Repo-wide rules (anti-patterns, key patterns) | CLAUDE.md |
| apko.yaml structure, BUILD.bazel patterns | container agent (AGENTS.md) |
| ArgoCD application.yaml template | add-service skill |
| Image updater config | add-image-updater skill |
| HTTP check alerts | add-httpcheck-alert skill |
| BuildBuddy API | buildbuddy skill |

## Test plan

- [ ] Verify AGENTS.md reads coherently end-to-end
- [ ] Verify each skill still contains enough context to execute independently
- [ ] Confirm no contradictions remain between CLAUDE.md and AGENTS.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)