### PR TITLE
fix: use /mcp endpoint for SigNoz MCP server

### DIFF
--- a/charts/context-forge/templates/configmap.yaml
+++ b/charts/context-forge/templates/configmap.yaml
@@ -27,5 +27,5 @@ data:
     # Register SigNoz MCP server
     curl -sf -X POST "$GATEWAY/gateways" \
       -H "Content-Type: application/json" \
-      -d '{"name":"signoz","url":"http://localhost:{{ .Values.signoz.port }}/sse","description":"SigNoz observability — logs, traces, metrics, alerts, dashboards"}'
+      -d '{"name":"signoz","url":"http://localhost:{{ .Values.signoz.port }}/mcp","description":"SigNoz observability — logs, traces, metrics, alerts, dashboards"}'
     {{- end }}


### PR DESCRIPTION
## Summary
- SigNoz MCP server uses Streamable HTTP transport at `/mcp`, not SSE at `/sse`
- Context Forge gateway was failing with `404 Not Found` when trying to register the upstream server
- One-line fix: `/sse` → `/mcp` in the registration script

## Test plan
- [ ] ArgoCD syncs the updated ConfigMap
- [ ] Gateway pod restarts and successfully registers SigNoz MCP at `/mcp`
- [ ] `POST /gateways` returns 200 (not 503)

🤖 Generated with [Claude Code](https://claude.com/claude-code)