### PR TITLE
fix: bump Context Forge to RC1, use STREAMABLEHTTP transport

### DIFF
--- a/charts/context-forge/templates/configmap.yaml
+++ b/charts/context-forge/templates/configmap.yaml
@@ -27,5 +27,5 @@ data:
     # Register SigNoz MCP server
     curl -sf -X POST "$GATEWAY/gateways" \
       -H "Content-Type: application/json" \
-      -d '{"name":"signoz","url":"http://localhost:{{ .Values.signoz.port }}/mcp","description":"SigNoz observability — logs, traces, metrics, alerts, dashboards"}'
+      -d '{"name":"signoz","url":"http://localhost:{{ .Values.signoz.port }}/mcp","transport":"STREAMABLEHTTP","description":"SigNoz observability — logs, traces, metrics, alerts, dashboards"}'
     {{- end }}

--- a/charts/context-forge/values.yaml
+++ b/charts/context-forge/values.yaml
@@ -5,7 +5,7 @@
 gateway:
   image:
     repository: ghcr.io/ibm/mcp-context-forge
-    tag: "1.0.0-BETA-1"
+    tag: "v1.0.0-RC1"
     pullPolicy: IfNotPresent
   port: 4444
   resources:


### PR DESCRIPTION
## Summary
- Bump Context Forge from `1.0.0-BETA-1` to `v1.0.0-RC1` (BETA-1 only has SSE client)
- Add `"transport":"STREAMABLEHTTP"` to gateway registration payload
- SigNoz MCP server uses Streamable HTTP — Context Forge needs to be told explicitly (no auto-detection)

## Test plan
- [ ] Gateway pod starts and stays healthy
- [ ] Registration script succeeds (`POST /gateways` returns 200)
- [ ] SigNoz tools appear in Context Forge tool catalog

🤖 Generated with [Claude Code](https://claude.com/claude-code)