### PR TITLE
fix: resolve Context Forge crashloop from postStart hook failure

### DIFF
--- a/charts/context-forge/templates/configmap.yaml
+++ b/charts/context-forge/templates/configmap.yaml
@@ -8,24 +8,42 @@ data:
   register-gateways.sh: |
     #!/bin/sh
     # Register upstream MCP servers with Context Forge gateway.
-    # Runs as a postStart lifecycle hook — gateway starts concurrently,
-    # so we poll /health until it's ready before registering.
+    # Runs as a postStart lifecycle hook — must exit 0 or Kubernetes
+    # kills the container. Registration failures are logged but non-fatal.
     GATEWAY="http://localhost:{{ .Values.gateway.port }}"
 
-    # Wait for gateway to be healthy (up to 60s)
-    attempts=0
-    until curl -sf "$GATEWAY/health" > /dev/null 2>&1; do
-      attempts=$((attempts + 1))
-      if [ "$attempts" -ge 60 ]; then
-        echo "ERROR: gateway not healthy after 60s" >&2
-        exit 1
-      fi
-      sleep 1
-    done
+    wait_for() {
+      url="$1"; label="$2"; max="$3"
+      attempts=0
+      until curl -sf "$url" > /dev/null 2>&1; do
+        attempts=$((attempts + 1))
+        if [ "$attempts" -ge "$max" ]; then
+          echo "WARNING: $label not ready after ${max}s" >&2
+          return 1
+        fi
+        sleep 1
+      done
+    }
+
+    # Wait for gateway to be healthy (up to 90s)
+    if ! wait_for "$GATEWAY/health" "gateway" 90; then
+      exit 0
+    fi
 
     {{ if .Values.signoz.enabled }}
+    # Wait for SigNoz sidecar to be healthy (up to 30s)
+    if ! wait_for "http://localhost:{{ .Values.signoz.port }}/mcp" "signoz-mcp" 30; then
+      exit 0
+    fi
+
     # Register SigNoz MCP server
-    curl -sf -X POST "$GATEWAY/gateways" \
+    if curl -sf -X POST "$GATEWAY/gateways" \
       -H "Content-Type: application/json" \
-      -d '{"name":"signoz","url":"http://localhost:{{ .Values.signoz.port }}/mcp","transport":"STREAMABLEHTTP","description":"SigNoz observability — logs, traces, metrics, alerts, dashboards"}'
+      -d '{"name":"signoz","url":"http://localhost:{{ .Values.signoz.port }}/mcp","transport":"STREAMABLEHTTP","description":"SigNoz observability — logs, traces, metrics, alerts, dashboards"}'; then
+      echo "Registered signoz MCP server"
+    else
+      echo "WARNING: failed to register signoz MCP server" >&2
+    fi
     {{- end }}
+
+    exit 0

--- a/charts/context-forge/templates/deployment.yaml
+++ b/charts/context-forge/templates/deployment.yaml
@@ -38,6 +38,8 @@ spec:
               value: "0.0.0.0"
             - name: PORT
               value: {{ .Values.gateway.port | quote }}
+            - name: GUNICORN_WORKERS
+              value: "2"
             - name: DATABASE_URL
               value: "sqlite:////data/context-forge.db"
             - name: AUTH_REQUIRED
@@ -62,13 +64,13 @@ spec:
             httpGet:
               path: /health
               port: http
-            initialDelaySeconds: 10
+            initialDelaySeconds: 30
             periodSeconds: 30
           readinessProbe:
             httpGet:
               path: /health
               port: http
-            initialDelaySeconds: 5
+            initialDelaySeconds: 10
             periodSeconds: 10
           resources:
             {{- toYaml .Values.gateway.resources | nindent 12 }}


### PR DESCRIPTION
## Summary

- Set `GUNICORN_WORKERS=2` — the gateway auto-detected 12 node CPUs and spawned 16 workers, overwhelming the 200m CPU / 512Mi memory limits
- Make registration script always exit 0 — postStart hook failures kill the container, so registration errors are now logged as warnings instead of fatal exits
- Wait for SigNoz sidecar before registration — the hook previously only waited for the gateway, causing race conditions with the sidecar

Also bumped probe `initialDelaySeconds` (liveness: 10→30, readiness: 5→10) to match the reduced worker startup time.

## Test plan

- [ ] Pod starts without `PostStartHookError` or `CrashLoopBackOff`
- [ ] Gateway logs show 2 workers spawning (not 16)
- [ ] Registration script logs show successful SigNoz registration
- [ ] `kubectl logs -c gateway` shows no ERROR lines
- [ ] MCP endpoint responds at `mcp.jomcgi.dev`

🤖 Generated with [Claude Code](https://claude.com/claude-code)