### PR TITLE
fix: disable ServiceMonitor, fix stale-PR hook on chained commands

### DIFF
--- a/charts/context-forge/values.yaml
+++ b/charts/context-forge/values.yaml
@@ -27,6 +27,9 @@ mcp-stack:
     extraEnvFrom:
       - secretRef:
           name: context-forge
+    metrics:
+      serviceMonitor:
+        enabled: false  # Requires prometheus-operator CRDs
     resources:
       requests:
         cpu: 50m


### PR DESCRIPTION
## Summary
- Disable the `ServiceMonitor` rendered by the upstream mcp-stack chart — the cluster doesn't have the `monitoring.coreos.com/ServiceMonitor` CRD installed
- Fix `check-stale-pr.sh` hook failing to detect merged PRs when the Bash command is chained (e.g., `cd /tmp/wt && git add && git commit && git push`)

## Root cause (hook bug)
The hook parses `git push` args by stripping a `^git ... push` prefix with sed, but chained commands start with `cd`, not `git`. The entire command string became "push args", producing a garbage branch name that never matched any PR — silently allowing pushes to merged branches.

## Fix
Extract just the `git push ...` segment from chained commands before parsing args. Also extract `cd <path>` for `-C` fallback using sed (BASH_REMATCH unreliable on macOS bash 5.3+).

## Test plan
- [x] `helm template` no longer renders ServiceMonitor
- [x] Hook correctly blocks chained `cd && git push` to merged branches
- [x] All 7 push command patterns tested: bare push, with remote, with `-u`, with `-C`, chained `cd &&`, etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)