### PR TITLE
fix: rename SIGNOZ_BACKEND_URL to SIGNOZ_URL for signoz-mcp-server

### DIFF
--- a/charts/signoz-mcp/templates/deployment.yaml
+++ b/charts/signoz-mcp/templates/deployment.yaml
@@ -28,8 +28,8 @@ spec:
               containerPort: {{ .Values.port }}
               protocol: TCP
           env:
-            - name: SIGNOZ_BACKEND_URL
-              value: {{ .Values.signozBackendUrl | quote }}
+            - name: SIGNOZ_URL
+              value: {{ .Values.signozUrl | quote }}
           envFrom:
             - secretRef:
                 name: {{ .Values.secret.name }}

--- a/charts/signoz-mcp/values.yaml
+++ b/charts/signoz-mcp/values.yaml
@@ -8,7 +8,7 @@ image:
 
 port: 8000
 
-signozBackendUrl: "http://signoz.signoz.svc.cluster.local:8080"
+signozUrl: "http://signoz.signoz.svc.cluster.local:8080"
 
 resources:
   requests:


### PR DESCRIPTION
## Summary
- The `signoz-mcp-server:v0.0.5` image expects `SIGNOZ_URL`, not `SIGNOZ_BACKEND_URL`
- The env var mismatch caused CrashLoopBackOff with validation error: "SIGNOZ_URL is required"
- Renames the env var in the Helm deployment template and corresponding values key

## Test plan
- [ ] Verify `helm template` renders `SIGNOZ_URL` (confirmed locally)
- [ ] Merge and confirm ArgoCD syncs the updated deployment
- [ ] Verify signoz-mcp pod exits CrashLoopBackOff and becomes Ready

🤖 Generated with [Claude Code](https://claude.com/claude-code)