### PR TITLE
fix: set signoz-mcp transport mode to http

### DIFF
--- a/charts/signoz-mcp/templates/deployment.yaml
+++ b/charts/signoz-mcp/templates/deployment.yaml
@@ -30,6 +30,10 @@ spec:
           env:
             - name: SIGNOZ_URL
               value: {{ .Values.signozUrl | quote }}
+            - name: TRANSPORT_MODE
+              value: "http"
+            - name: MCP_SERVER_PORT
+              value: {{ .Values.port | quote }}
           envFrom:
             - secretRef:
                 name: {{ .Values.secret.name }}


### PR DESCRIPTION
## Summary
- The signoz-mcp-server defaults to `stdio` transport mode, which communicates over stdin/stdout and never opens a TCP socket
- This causes the Kubernetes TCP liveness/readiness probes on port 8000 to fail, resulting in CrashLoopBackOff
- Adds `TRANSPORT_MODE=http` and `MCP_SERVER_PORT=8000` env vars so the server listens on the expected port

## Context
Follow-up to #645 which fixed the `SIGNOZ_URL` env var name. The server now starts successfully but in the wrong transport mode.

## Test plan
- [ ] Merge and confirm ArgoCD syncs the updated deployment
- [ ] Verify signoz-mcp pod becomes Ready (no more CrashLoopBackOff)
- [ ] Verify the MCP endpoint responds at `http://signoz-mcp.mcp-servers.svc.cluster.local:8000/mcp`

🤖 Generated with [Claude Code](https://claude.com/claude-code)