### PR TITLE
fix: correct Cloudflare tunnel service name for Context Forge

### DIFF
--- a/overlays/prod/cloudflare-tunnel/values.yaml
+++ b/overlays/prod/cloudflare-tunnel/values.yaml
@@ -13,7 +13,7 @@ ingress:
     - hostname: longhorn.jomcgi.dev
       service: http://longhorn-frontend.longhorn.svc.cluster.local:80
     - hostname: mcp.jomcgi.dev
-      service: http://context-forge.mcp-gateway.svc.cluster.local:4444
+      service: http://context-forge-mcp-stack-mcpgateway.mcp-gateway.svc.cluster.local:80
     - hostname: n8n.jomcgi.dev
       service: http://n8n.n8n.svc.cluster.local:80
     - hostname: feeds.jomcgi.dev


### PR DESCRIPTION
## Summary
- The Cloudflare tunnel route for `mcp.jomcgi.dev` pointed to `context-forge:4444`
- The actual K8s service is named `context-forge-mcp-stack-mcpgateway` (due to subchart naming) and exposes port `80` (targetPort `4444`)
- This DNS mismatch caused all external requests to return 502

## Test plan
- [ ] Merge and wait for ArgoCD to sync the tunnel config
- [ ] `curl -H "CF-Access-Client-Id: ..." https://mcp.jomcgi.dev/health` returns 200
- [ ] Verify MCP endpoint responds at `https://mcp.jomcgi.dev/mcp`

🤖 Generated with [Claude Code](https://claude.com/claude-code)