### PR TITLE
fix: correct gateway service name in registration job

### DIFF
--- a/charts/context-forge/templates/registration-job.yaml
+++ b/charts/context-forge/templates/registration-job.yaml
@@ -32,7 +32,7 @@ spec:
             - |
               set -e
 
-              GATEWAY_URL="http://{{ .Release.Name }}-mcp-stack:80"
+              GATEWAY_URL="http://{{ .Release.Name }}-mcp-stack-mcpgateway:80"
 
               echo "Waiting for gateway at ${GATEWAY_URL}/health..."
               until curl -sf "${GATEWAY_URL}/health" > /dev/null 2>&1; do


### PR DESCRIPTION
## Summary
- The MCP server registration job used `context-forge-mcp-stack:80` as the gateway URL
- The actual K8s service is `context-forge-mcp-stack-mcpgateway` (subchart naming convention)
- This prevented signoz-mcp from being registered with the gateway, resulting in `tools/list` returning empty

## Context
Fourth fix in the Context Forge deployment chain:
1. #645 — `SIGNOZ_BACKEND_URL` → `SIGNOZ_URL` 
2. #646 — Added `TRANSPORT_MODE=http` for signoz-mcp
3. #648 — Fixed Cloudflare tunnel service name
4. This PR — Fixed registration job gateway URL

## Test plan
- [ ] Merge and confirm ArgoCD runs the registration hook
- [ ] `curl https://mcp.jomcgi.dev/mcp/` with `tools/list` returns signoz tools
- [ ] Verify end-to-end MCP tool call works

🤖 Generated with [Claude Code](https://claude.com/claude-code)