### PR TITLE
fix: stop overriding JWT_SECRET_KEY to empty string

### DIFF
--- a/charts/context-forge/values.yaml
+++ b/charts/context-forge/values.yaml
@@ -23,7 +23,6 @@ mcp-stack:
     secret:
       AUTH_REQUIRED: "false"
       MCP_CLIENT_AUTH_ENABLED: "false"
-      JWT_SECRET_KEY: ""  # Injected from 1Password via extraEnvFrom
     extraEnvFrom:
       - secretRef:
           name: context-forge
@@ -70,7 +69,7 @@ mcp-stack:
   mcpFastTimeServer:
     enabled: false
 
-# 1Password secret for JWT_SECRET_KEY
+# 1Password secret — provides JWT_SECRET_KEY for admin API auth
 secret:
   name: context-forge
   itemPath: "vaults/k8s-homelab/items/context-forge"


### PR DESCRIPTION
## Summary
- The chart set `JWT_SECRET_KEY: ""` in the mcp-stack secret block, which explicitly overrode the 1Password-injected value to empty
- This broke: admin API auth (403 on `/gateways`), login endpoint (`/auth/login` → "Authentication service error"), token generation utility, and the registration job
- Fix: remove the explicit empty value so the 1Password `extraEnvFrom` secret takes effect

## Prerequisites
- Add a `JWT_SECRET_KEY` field to the `context-forge` 1Password item with a strong random secret (32+ chars)

## Context
Fifth fix in the Context Forge deployment chain:
1. #645 — `SIGNOZ_BACKEND_URL` → `SIGNOZ_URL`
2. #646 — Added `TRANSPORT_MODE=http` for signoz-mcp  
3. #648 — Fixed Cloudflare tunnel service name
4. #650 — Fixed registration job gateway URL
5. This PR — Fixed JWT_SECRET_KEY being overridden to empty

## Test plan
- [ ] Add `JWT_SECRET_KEY` to 1Password item
- [ ] Merge and confirm ArgoCD syncs
- [ ] `POST /auth/login` with admin credentials returns an `access_token`
- [ ] Registration job succeeds and `tools/list` returns signoz tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)