### PR TITLE
fix: disable linkerd sidecar injection on Jobs

### DIFF
--- a/charts/context-forge/templates/registration-job.yaml
+++ b/charts/context-forge/templates/registration-job.yaml
@@ -17,6 +17,8 @@ spec:
   backoffLimit: 3
   template:
     metadata:
+      annotations:
+        linkerd.io/inject: disabled
       labels:
         {{- include "context-forge.selectorLabels" . | nindent 8 }}
     spec:

--- a/charts/kyverno/templates/linkerd-disable-jobs-policy.yaml
+++ b/charts/kyverno/templates/linkerd-disable-jobs-policy.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.linkerdInjection.enabled }}
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: disable-linkerd-on-jobs
+  annotations:
+    policies.kyverno.io/title: Disable Linkerd Injection on Jobs
+    policies.kyverno.io/category: Service Mesh
+    policies.kyverno.io/severity: low
+    policies.kyverno.io/description: |
+      Disables Linkerd sidecar injection on Job pods. The sidecar proxy
+      never terminates on its own, which prevents Job pods from completing.
+spec:
+  background: false
+  rules:
+  - name: disable-linkerd-on-job-pods
+    match:
+      any:
+      - resources:
+          kinds:
+          - Job
+    mutate:
+      patchStrategicMerge:
+        spec:
+          template:
+            metadata:
+              annotations:
+                linkerd.io/inject: disabled
+{{- end }}


### PR DESCRIPTION
## Summary
- Linkerd sidecar proxy never self-terminates, preventing Job pods from completing
- This blocked ArgoCD syncs waiting for Helm hooks (migration job was stuck at `1/2 NotReady`)
- Adds `linkerd.io/inject: disabled` to our registration job pod template
- Adds a Kyverno ClusterPolicy to automatically disable linkerd on **all** Jobs cluster-wide

## Context
This will also fix any other Jobs in the cluster that get stuck due to the linkerd sidecar (e.g. knowledge-graph cronjobs already opt out manually — this policy makes it automatic).

Sixth fix in the Context Forge deployment chain:
1. #645 — `SIGNOZ_BACKEND_URL` → `SIGNOZ_URL`
2. #646 — `TRANSPORT_MODE=http` for signoz-mcp
3. #648 — Cloudflare tunnel service name
4. #650 — Registration job gateway URL
5. #651 — JWT_SECRET_KEY empty string override
6. This PR — Linkerd sidecar blocking Job completion

## Test plan
- [ ] Merge and confirm ArgoCD syncs kyverno chart
- [ ] Trigger a context-forge sync — migration job should complete without getting stuck
- [ ] Registration job should also complete cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)