### PR TITLE
fix: pin migration job image to match gateway version

### DIFF
--- a/charts/context-forge/values.yaml
+++ b/charts/context-forge/values.yaml
@@ -49,6 +49,14 @@ mcp-stack:
         cpu: 500m
         memory: 512Mi
 
+  # Pin migration image to match the gateway — upstream defaults to :latest
+  # which can apply migrations the pinned gateway version doesn't understand.
+  migration:
+    image:
+      repository: ghcr.io/ibm/mcp-context-forge
+      tag: "v1.0.0-RC1"
+      pullPolicy: IfNotPresent
+
   redis:
     enabled: true
     resources:


### PR DESCRIPTION
## Summary
- The upstream mcp-stack chart defaults the migration image to `:latest`
- This applied DB revision `d9e0f1a2b3c4` which `v1.0.0-RC1` doesn't recognize
- The gateway crashed on startup with `Can't locate revision identified by 'd9e0f1a2b3c4'`
- Fix: pin the migration image to `v1.0.0-RC1` to match the gateway
- DB was manually stamped back to the correct revision `x7h8i9j0k1l2`

## Test plan
- [ ] Merge and confirm ArgoCD sync doesn't break the gateway
- [ ] Verify gateway starts cleanly without alembic errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)