### PR TITLE
fix: set PLATFORM_ADMIN_EMAIL to match registration JWT subject

### DIFF
--- a/charts/context-forge/values.yaml
+++ b/charts/context-forge/values.yaml
@@ -14,6 +14,7 @@ mcp-stack:
       enabled: false
     config:
       GUNICORN_WORKERS: "2"
+      PLATFORM_ADMIN_EMAIL: "admin@jomcgi.dev"
       MCPGATEWAY_UI_ENABLED: "false"
       MCPGATEWAY_A2A_ENABLED: "false"
       LLMCHAT_ENABLED: "false"


### PR DESCRIPTION
## Summary
- Sets `PLATFORM_ADMIN_EMAIL=admin@jomcgi.dev` in the Context Forge gateway config
- The migration bootstrap creates the admin user with whatever email `PLATFORM_ADMIN_EMAIL` is set to (default: `admin@example.com`), but the registration job mints a JWT with `sub=admin@jomcgi.dev` — the mismatch caused RBAC to deny the gateway registration request
- On next sync, the migration will create a new admin user with the correct email, and the registration job's JWT will resolve to that user

## Test plan
- [ ] ArgoCD syncs successfully (migration + registration jobs both complete)
- [ ] `POST /gateways` succeeds with the registration JWT
- [ ] `tools/list` on `/mcp/` returns signoz-mcp tools
- [ ] `npx mcp-remote https://mcp.jomcgi.dev/mcp/` connects and lists tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)