### PR TITLE
fix: enable MCP_CLIENT_AUTH to allow JWT auth on admin API

### DIFF
--- a/charts/context-forge/values.yaml
+++ b/charts/context-forge/values.yaml
@@ -23,7 +23,8 @@ mcp-stack:
       MCPGATEWAY_BULK_IMPORT_ENABLED: "false"
     secret:
       AUTH_REQUIRED: "true"
-      MCP_CLIENT_AUTH_ENABLED: "false"
+      MCP_CLIENT_AUTH_ENABLED: "true"
+      MCP_REQUIRE_AUTH: "false"
     extraEnvFrom:
       - secretRef:
           name: context-forge


### PR DESCRIPTION
## Summary
- Changes `MCP_CLIENT_AUTH_ENABLED` from `false` to `true` so the admin API (`/gateways`) validates JWT Bearer tokens through the standard auth path
- Adds `MCP_REQUIRE_AUTH=false` explicitly to keep the `/mcp/` endpoint accessible without authentication
- The previous `MCP_CLIENT_AUTH_ENABLED=false` caused `get_current_user_with_permissions` to skip JWT validation entirely, falling through to proxy auth (which isn't configured), resulting in all admin API requests failing with 401 "no auth method configured"

## Context
The registration job mints a JWT with `sub=admin@jomcgi.dev` to authenticate against the admin API. With `MCP_CLIENT_AUTH_ENABLED=false`, the RBAC dependency never evaluates the Bearer token — it goes straight to proxy auth mode, which fails because `TRUST_PROXY_AUTH=false`.

## Test plan
- [ ] ArgoCD syncs successfully (migration + registration jobs complete)
- [ ] `POST /gateways` with Bearer JWT returns 200 (not 401/403)
- [ ] `tools/list` on `/mcp/` returns signoz-mcp tools
- [ ] `/mcp/` endpoint still works without authentication
- [ ] `npx mcp-remote https://mcp.jomcgi.dev/mcp/` connects and lists tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)