### PR TITLE
feat: migrate 22 alert ConfigMaps to SigNoz v0.113 v5 format

### DIFF
--- a/overlays/cluster-critical/argocd/argocd-httpcheck-alert.yaml
+++ b/overlays/cluster-critical/argocd/argocd-httpcheck-alert.yaml
@@ -15,6 +15,7 @@ data:
       "alert": "ArgoCD Unreachable",
       "alertType": "METRICS_BASED_ALERT",
       "ruleType": "threshold_rule",
+      "version": "v5",
       "broadcastToAll": false,
       "disabled": false,
       "evalWindow": "10m0s",
@@ -30,32 +31,58 @@ data:
       },
       "condition": {
         "compositeQuery": {
-          "builderQueries": {
-            "A": {
-              "queryName": "A",
-              "dataSource": "metrics",
-              "aggregateOperator": "avg",
-              "aggregateAttribute": {
-                "key": "httpcheck.status",
-                "dataType": "float64",
-                "type": "Gauge"
-              },
-              "filters": {
-                "items": [
+          "queries": [
+            {
+              "type": "builder_query",
+              "spec": {
+                "name": "A",
+                "signal": "metrics",
+                "stepInterval": 60,
+                "aggregations": [
                   {
-                    "key": {"key": "http.url"},
-                    "op": "=",
-                    "value": "https://argocd.jomcgi.dev"
+                    "timeAggregation": "avg",
+                    "spaceAggregation": "avg",
+                    "metricName": "httpcheck.status"
                   }
-                ]
+                ],
+                "filters": {
+                  "items": [
+                    {
+                      "key": {
+                        "key": "http.url",
+                        "dataType": "string",
+                        "type": "tag",
+                        "isColumn": false
+                      },
+                      "op": "=",
+                      "value": "https://argocd.jomcgi.dev"
+                    }
+                  ],
+                  "op": "AND"
+                },
+                "groupBy": [],
+                "order": [],
+                "disabled": false
               }
             }
-          },
+          ],
+          "panelType": "graph",
           "queryType": "builder"
         },
-        "op": "<",
-        "target": 1,
-        "matchType": "5"
+        "selectedQueryName": "A",
+        "thresholds": {
+          "kind": "basic",
+          "spec": [
+            {
+              "name": "critical",
+              "target": 1,
+              "targetUnit": "",
+              "matchType": "5",
+              "op": "<",
+              "channels": ["pagerduty-homelab"]
+            }
+          ]
+        }
       },
       "preferredChannels": ["pagerduty-homelab"]
     }

--- a/overlays/cluster-critical/longhorn/longhorn-httpcheck-alert.yaml
+++ b/overlays/cluster-critical/longhorn/longhorn-httpcheck-alert.yaml
@@ -15,6 +15,7 @@ data:
       "alert": "Longhorn Unreachable",
       "alertType": "METRICS_BASED_ALERT",
       "ruleType": "threshold_rule",
+      "version": "v5",
       "broadcastToAll": false,
       "disabled": false,
       "evalWindow": "10m0s",
@@ -30,32 +31,58 @@ data:
       },
       "condition": {
         "compositeQuery": {
-          "builderQueries": {
-            "A": {
-              "queryName": "A",
-              "dataSource": "metrics",
-              "aggregateOperator": "avg",
-              "aggregateAttribute": {
-                "key": "httpcheck.status",
-                "dataType": "float64",
-                "type": "Gauge"
-              },
-              "filters": {
-                "items": [
+          "queries": [
+            {
+              "type": "builder_query",
+              "spec": {
+                "name": "A",
+                "signal": "metrics",
+                "stepInterval": 60,
+                "aggregations": [
                   {
-                    "key": {"key": "http.url"},
-                    "op": "=",
-                    "value": "https://longhorn.jomcgi.dev"
+                    "timeAggregation": "avg",
+                    "spaceAggregation": "avg",
+                    "metricName": "httpcheck.status"
                   }
-                ]
+                ],
+                "filters": {
+                  "items": [
+                    {
+                      "key": {
+                        "key": "http.url",
+                        "dataType": "string",
+                        "type": "tag",
+                        "isColumn": false
+                      },
+                      "op": "=",
+                      "value": "https://longhorn.jomcgi.dev"
+                    }
+                  ],
+                  "op": "AND"
+                },
+                "groupBy": [],
+                "order": [],
+                "disabled": false
               }
             }
-          },
+          ],
+          "panelType": "graph",
           "queryType": "builder"
         },
-        "op": "<",
-        "target": 1,
-        "matchType": "5"
+        "selectedQueryName": "A",
+        "thresholds": {
+          "kind": "basic",
+          "spec": [
+            {
+              "name": "critical",
+              "target": 1,
+              "targetUnit": "",
+              "matchType": "5",
+              "op": "<",
+              "channels": ["pagerduty-homelab"]
+            }
+          ]
+        }
       },
       "preferredChannels": ["pagerduty-homelab"]
     }

--- a/overlays/cluster-critical/signoz/alerts/argocd-app-degraded.yaml
+++ b/overlays/cluster-critical/signoz/alerts/argocd-app-degraded.yaml
@@ -15,6 +15,7 @@ data:
       "alert": "ArgoCD App Degraded",
       "alertType": "METRICS_BASED_ALERT",
       "ruleType": "threshold_rule",
+      "version": "v5",
       "broadcastToAll": false,
       "disabled": false,
       "evalWindow": "5m0s",
@@ -30,36 +31,71 @@ data:
       },
       "condition": {
         "compositeQuery": {
-          "builderQueries": {
-            "A": {
-              "queryName": "A",
-              "dataSource": "metrics",
-              "aggregateOperator": "count",
-              "aggregateAttribute": {
-                "key": "argocd_app_info",
-                "dataType": "float64",
-                "type": "Gauge"
-              },
-              "filters": {
-                "items": [
+          "queries": [
+            {
+              "type": "builder_query",
+              "spec": {
+                "name": "A",
+                "signal": "metrics",
+                "stepInterval": 60,
+                "aggregations": [
                   {
-                    "key": {"key": "health_status"},
-                    "op": "=",
-                    "value": "Degraded"
+                    "timeAggregation": "count",
+                    "spaceAggregation": "sum",
+                    "metricName": "argocd_app_info"
                   }
-                ]
-              },
-              "groupBy": [
-                {"key": "name"},
-                {"key": "namespace"}
-              ]
+                ],
+                "filters": {
+                  "items": [
+                    {
+                      "key": {
+                        "key": "health_status",
+                        "dataType": "string",
+                        "type": "tag",
+                        "isColumn": false
+                      },
+                      "op": "=",
+                      "value": "Degraded"
+                    }
+                  ],
+                  "op": "AND"
+                },
+                "groupBy": [
+                  {
+                    "name": "name",
+                    "dataType": "string",
+                    "type": "tag",
+                    "isColumn": false
+                  },
+                  {
+                    "name": "namespace",
+                    "dataType": "string",
+                    "type": "tag",
+                    "isColumn": false
+                  }
+                ],
+                "order": [],
+                "disabled": false
+              }
             }
-          },
+          ],
+          "panelType": "graph",
           "queryType": "builder"
         },
-        "op": ">",
-        "target": 0,
-        "matchType": "1"
+        "selectedQueryName": "A",
+        "thresholds": {
+          "kind": "basic",
+          "spec": [
+            {
+              "name": "warning",
+              "target": 0,
+              "targetUnit": "",
+              "matchType": "1",
+              "op": ">",
+              "channels": ["pagerduty-homelab"]
+            }
+          ]
+        }
       },
       "preferredChannels": ["pagerduty-homelab"]
     }

--- a/overlays/cluster-critical/signoz/alerts/argocd-app-missing.yaml
+++ b/overlays/cluster-critical/signoz/alerts/argocd-app-missing.yaml
@@ -15,6 +15,7 @@ data:
       "alert": "ArgoCD App Missing",
       "alertType": "METRICS_BASED_ALERT",
       "ruleType": "threshold_rule",
+      "version": "v5",
       "broadcastToAll": false,
       "disabled": false,
       "evalWindow": "5m0s",
@@ -30,36 +31,71 @@ data:
       },
       "condition": {
         "compositeQuery": {
-          "builderQueries": {
-            "A": {
-              "queryName": "A",
-              "dataSource": "metrics",
-              "aggregateOperator": "count",
-              "aggregateAttribute": {
-                "key": "argocd_app_info",
-                "dataType": "float64",
-                "type": "Gauge"
-              },
-              "filters": {
-                "items": [
+          "queries": [
+            {
+              "type": "builder_query",
+              "spec": {
+                "name": "A",
+                "signal": "metrics",
+                "stepInterval": 60,
+                "aggregations": [
                   {
-                    "key": {"key": "health_status"},
-                    "op": "=",
-                    "value": "Missing"
+                    "timeAggregation": "count",
+                    "spaceAggregation": "sum",
+                    "metricName": "argocd_app_info"
                   }
-                ]
-              },
-              "groupBy": [
-                {"key": "name"},
-                {"key": "namespace"}
-              ]
+                ],
+                "filters": {
+                  "items": [
+                    {
+                      "key": {
+                        "key": "health_status",
+                        "dataType": "string",
+                        "type": "tag",
+                        "isColumn": false
+                      },
+                      "op": "=",
+                      "value": "Missing"
+                    }
+                  ],
+                  "op": "AND"
+                },
+                "groupBy": [
+                  {
+                    "name": "name",
+                    "dataType": "string",
+                    "type": "tag",
+                    "isColumn": false
+                  },
+                  {
+                    "name": "namespace",
+                    "dataType": "string",
+                    "type": "tag",
+                    "isColumn": false
+                  }
+                ],
+                "order": [],
+                "disabled": false
+              }
             }
-          },
+          ],
+          "panelType": "graph",
           "queryType": "builder"
         },
-        "op": ">",
-        "target": 0,
-        "matchType": "1"
+        "selectedQueryName": "A",
+        "thresholds": {
+          "kind": "basic",
+          "spec": [
+            {
+              "name": "critical",
+              "target": 0,
+              "targetUnit": "",
+              "matchType": "1",
+              "op": ">",
+              "channels": ["pagerduty-homelab"]
+            }
+          ]
+        }
       },
       "preferredChannels": ["pagerduty-homelab"]
     }

--- a/overlays/cluster-critical/signoz/alerts/argocd-app-outofsync.yaml
+++ b/overlays/cluster-critical/signoz/alerts/argocd-app-outofsync.yaml
@@ -15,6 +15,7 @@ data:
       "alert": "ArgoCD App OutOfSync",
       "alertType": "METRICS_BASED_ALERT",
       "ruleType": "threshold_rule",
+      "version": "v5",
       "broadcastToAll": false,
       "disabled": false,
       "evalWindow": "5m0s",
@@ -30,36 +31,71 @@ data:
       },
       "condition": {
         "compositeQuery": {
-          "builderQueries": {
-            "A": {
-              "queryName": "A",
-              "dataSource": "metrics",
-              "aggregateOperator": "count",
-              "aggregateAttribute": {
-                "key": "argocd_app_info",
-                "dataType": "float64",
-                "type": "Gauge"
-              },
-              "filters": {
-                "items": [
+          "queries": [
+            {
+              "type": "builder_query",
+              "spec": {
+                "name": "A",
+                "signal": "metrics",
+                "stepInterval": 60,
+                "aggregations": [
                   {
-                    "key": {"key": "sync_status"},
-                    "op": "=",
-                    "value": "OutOfSync"
+                    "timeAggregation": "count",
+                    "spaceAggregation": "sum",
+                    "metricName": "argocd_app_info"
                   }
-                ]
-              },
-              "groupBy": [
-                {"key": "name"},
-                {"key": "namespace"}
-              ]
+                ],
+                "filters": {
+                  "items": [
+                    {
+                      "key": {
+                        "key": "sync_status",
+                        "dataType": "string",
+                        "type": "tag",
+                        "isColumn": false
+                      },
+                      "op": "=",
+                      "value": "OutOfSync"
+                    }
+                  ],
+                  "op": "AND"
+                },
+                "groupBy": [
+                  {
+                    "name": "name",
+                    "dataType": "string",
+                    "type": "tag",
+                    "isColumn": false
+                  },
+                  {
+                    "name": "namespace",
+                    "dataType": "string",
+                    "type": "tag",
+                    "isColumn": false
+                  }
+                ],
+                "order": [],
+                "disabled": false
+              }
             }
-          },
+          ],
+          "panelType": "graph",
           "queryType": "builder"
         },
-        "op": ">",
-        "target": 0,
-        "matchType": "1"
+        "selectedQueryName": "A",
+        "thresholds": {
+          "kind": "basic",
+          "spec": [
+            {
+              "name": "warning",
+              "target": 0,
+              "targetUnit": "",
+              "matchType": "1",
+              "op": ">",
+              "channels": ["pagerduty-homelab"]
+            }
+          ]
+        }
       },
       "preferredChannels": ["pagerduty-homelab"]
     }

--- a/overlays/cluster-critical/signoz/alerts/argocd-app-suspended.yaml
+++ b/overlays/cluster-critical/signoz/alerts/argocd-app-suspended.yaml
@@ -15,6 +15,7 @@ data:
       "alert": "ArgoCD App Suspended",
       "alertType": "METRICS_BASED_ALERT",
       "ruleType": "threshold_rule",
+      "version": "v5",
       "broadcastToAll": false,
       "disabled": false,
       "evalWindow": "10m0s",
@@ -30,36 +31,71 @@ data:
       },
       "condition": {
         "compositeQuery": {
-          "builderQueries": {
-            "A": {
-              "queryName": "A",
-              "dataSource": "metrics",
-              "aggregateOperator": "count",
-              "aggregateAttribute": {
-                "key": "argocd_app_info",
-                "dataType": "float64",
-                "type": "Gauge"
-              },
-              "filters": {
-                "items": [
+          "queries": [
+            {
+              "type": "builder_query",
+              "spec": {
+                "name": "A",
+                "signal": "metrics",
+                "stepInterval": 60,
+                "aggregations": [
                   {
-                    "key": {"key": "health_status"},
-                    "op": "=",
-                    "value": "Suspended"
+                    "timeAggregation": "count",
+                    "spaceAggregation": "sum",
+                    "metricName": "argocd_app_info"
                   }
-                ]
-              },
-              "groupBy": [
-                {"key": "name"},
-                {"key": "namespace"}
-              ]
+                ],
+                "filters": {
+                  "items": [
+                    {
+                      "key": {
+                        "key": "health_status",
+                        "dataType": "string",
+                        "type": "tag",
+                        "isColumn": false
+                      },
+                      "op": "=",
+                      "value": "Suspended"
+                    }
+                  ],
+                  "op": "AND"
+                },
+                "groupBy": [
+                  {
+                    "name": "name",
+                    "dataType": "string",
+                    "type": "tag",
+                    "isColumn": false
+                  },
+                  {
+                    "name": "namespace",
+                    "dataType": "string",
+                    "type": "tag",
+                    "isColumn": false
+                  }
+                ],
+                "order": [],
+                "disabled": false
+              }
             }
-          },
+          ],
+          "panelType": "graph",
           "queryType": "builder"
         },
-        "op": ">",
-        "target": 0,
-        "matchType": "1"
+        "selectedQueryName": "A",
+        "thresholds": {
+          "kind": "basic",
+          "spec": [
+            {
+              "name": "info",
+              "target": 0,
+              "targetUnit": "",
+              "matchType": "1",
+              "op": ">",
+              "channels": ["pagerduty-homelab"]
+            }
+          ]
+        }
       },
       "preferredChannels": ["pagerduty-homelab"]
     }

--- a/overlays/cluster-critical/signoz/alerts/node-disk-pressure.yaml
+++ b/overlays/cluster-critical/signoz/alerts/node-disk-pressure.yaml
@@ -15,6 +15,7 @@ data:
       "alert": "Node Disk Pressure",
       "alertType": "METRICS_BASED_ALERT",
       "ruleType": "threshold_rule",
+      "version": "v5",
       "broadcastToAll": false,
       "disabled": false,
       "evalWindow": "5m0s",
@@ -30,29 +31,54 @@ data:
       },
       "condition": {
         "compositeQuery": {
-          "builderQueries": {
-            "A": {
-              "queryName": "A",
-              "dataSource": "metrics",
-              "aggregateOperator": "max",
-              "aggregateAttribute": {
-                "key": "k8s.node.condition_disk_pressure",
-                "dataType": "float64",
-                "type": "Gauge"
-              },
-              "filters": {
-                "items": []
-              },
-              "groupBy": [
-                {"key": "k8s.node.name"}
-              ]
+          "queries": [
+            {
+              "type": "builder_query",
+              "spec": {
+                "name": "A",
+                "signal": "metrics",
+                "stepInterval": 60,
+                "aggregations": [
+                  {
+                    "timeAggregation": "max",
+                    "spaceAggregation": "max",
+                    "metricName": "k8s.node.condition_disk_pressure"
+                  }
+                ],
+                "filters": {
+                  "items": [],
+                  "op": "AND"
+                },
+                "groupBy": [
+                  {
+                    "name": "k8s.node.name",
+                    "dataType": "string",
+                    "type": "resource",
+                    "isColumn": false
+                  }
+                ],
+                "order": [],
+                "disabled": false
+              }
             }
-          },
+          ],
+          "panelType": "graph",
           "queryType": "builder"
         },
-        "op": ">",
-        "target": 0,
-        "matchType": "3"
+        "selectedQueryName": "A",
+        "thresholds": {
+          "kind": "basic",
+          "spec": [
+            {
+              "name": "warning",
+              "target": 0,
+              "targetUnit": "",
+              "matchType": "3",
+              "op": ">",
+              "channels": ["pagerduty-homelab"]
+            }
+          ]
+        }
       },
       "preferredChannels": ["pagerduty-homelab"]
     }

--- a/overlays/cluster-critical/signoz/alerts/node-memory-pressure.yaml
+++ b/overlays/cluster-critical/signoz/alerts/node-memory-pressure.yaml
@@ -15,6 +15,7 @@ data:
       "alert": "Node Memory Pressure",
       "alertType": "METRICS_BASED_ALERT",
       "ruleType": "threshold_rule",
+      "version": "v5",
       "broadcastToAll": false,
       "disabled": false,
       "evalWindow": "5m0s",
@@ -30,29 +31,54 @@ data:
       },
       "condition": {
         "compositeQuery": {
-          "builderQueries": {
-            "A": {
-              "queryName": "A",
-              "dataSource": "metrics",
-              "aggregateOperator": "max",
-              "aggregateAttribute": {
-                "key": "k8s.node.condition_memory_pressure",
-                "dataType": "float64",
-                "type": "Gauge"
-              },
-              "filters": {
-                "items": []
-              },
-              "groupBy": [
-                {"key": "k8s.node.name"}
-              ]
+          "queries": [
+            {
+              "type": "builder_query",
+              "spec": {
+                "name": "A",
+                "signal": "metrics",
+                "stepInterval": 60,
+                "aggregations": [
+                  {
+                    "timeAggregation": "max",
+                    "spaceAggregation": "max",
+                    "metricName": "k8s.node.condition_memory_pressure"
+                  }
+                ],
+                "filters": {
+                  "items": [],
+                  "op": "AND"
+                },
+                "groupBy": [
+                  {
+                    "name": "k8s.node.name",
+                    "dataType": "string",
+                    "type": "resource",
+                    "isColumn": false
+                  }
+                ],
+                "order": [],
+                "disabled": false
+              }
             }
-          },
+          ],
+          "panelType": "graph",
           "queryType": "builder"
         },
-        "op": ">",
-        "target": 0,
-        "matchType": "3"
+        "selectedQueryName": "A",
+        "thresholds": {
+          "kind": "basic",
+          "spec": [
+            {
+              "name": "warning",
+              "target": 0,
+              "targetUnit": "",
+              "matchType": "3",
+              "op": ">",
+              "channels": ["pagerduty-homelab"]
+            }
+          ]
+        }
       },
       "preferredChannels": ["pagerduty-homelab"]
     }

--- a/overlays/cluster-critical/signoz/alerts/node-not-ready.yaml
+++ b/overlays/cluster-critical/signoz/alerts/node-not-ready.yaml
@@ -15,6 +15,7 @@ data:
       "alert": "Node Not Ready",
       "alertType": "METRICS_BASED_ALERT",
       "ruleType": "threshold_rule",
+      "version": "v5",
       "broadcastToAll": false,
       "disabled": false,
       "evalWindow": "5m0s",
@@ -30,29 +31,54 @@ data:
       },
       "condition": {
         "compositeQuery": {
-          "builderQueries": {
-            "A": {
-              "queryName": "A",
-              "dataSource": "metrics",
-              "aggregateOperator": "min",
-              "aggregateAttribute": {
-                "key": "k8s.node.condition_ready",
-                "dataType": "float64",
-                "type": "Gauge"
-              },
-              "filters": {
-                "items": []
-              },
-              "groupBy": [
-                {"key": "k8s.node.name"}
-              ]
+          "queries": [
+            {
+              "type": "builder_query",
+              "spec": {
+                "name": "A",
+                "signal": "metrics",
+                "stepInterval": 60,
+                "aggregations": [
+                  {
+                    "timeAggregation": "min",
+                    "spaceAggregation": "min",
+                    "metricName": "k8s.node.condition_ready"
+                  }
+                ],
+                "filters": {
+                  "items": [],
+                  "op": "AND"
+                },
+                "groupBy": [
+                  {
+                    "name": "k8s.node.name",
+                    "dataType": "string",
+                    "type": "resource",
+                    "isColumn": false
+                  }
+                ],
+                "order": [],
+                "disabled": false
+              }
             }
-          },
+          ],
+          "panelType": "graph",
           "queryType": "builder"
         },
-        "op": "<",
-        "target": 1,
-        "matchType": "5"
+        "selectedQueryName": "A",
+        "thresholds": {
+          "kind": "basic",
+          "spec": [
+            {
+              "name": "critical",
+              "target": 1,
+              "targetUnit": "",
+              "matchType": "5",
+              "op": "<",
+              "channels": ["pagerduty-homelab"]
+            }
+          ]
+        }
       },
       "preferredChannels": ["pagerduty-homelab"]
     }

--- a/overlays/cluster-critical/signoz/alerts/node-pid-pressure.yaml
+++ b/overlays/cluster-critical/signoz/alerts/node-pid-pressure.yaml
@@ -15,6 +15,7 @@ data:
       "alert": "Node PID Pressure",
       "alertType": "METRICS_BASED_ALERT",
       "ruleType": "threshold_rule",
+      "version": "v5",
       "broadcastToAll": false,
       "disabled": false,
       "evalWindow": "5m0s",
@@ -30,29 +31,54 @@ data:
       },
       "condition": {
         "compositeQuery": {
-          "builderQueries": {
-            "A": {
-              "queryName": "A",
-              "dataSource": "metrics",
-              "aggregateOperator": "max",
-              "aggregateAttribute": {
-                "key": "k8s.node.condition_pid_pressure",
-                "dataType": "float64",
-                "type": "Gauge"
-              },
-              "filters": {
-                "items": []
-              },
-              "groupBy": [
-                {"key": "k8s.node.name"}
-              ]
+          "queries": [
+            {
+              "type": "builder_query",
+              "spec": {
+                "name": "A",
+                "signal": "metrics",
+                "stepInterval": 60,
+                "aggregations": [
+                  {
+                    "timeAggregation": "max",
+                    "spaceAggregation": "max",
+                    "metricName": "k8s.node.condition_pid_pressure"
+                  }
+                ],
+                "filters": {
+                  "items": [],
+                  "op": "AND"
+                },
+                "groupBy": [
+                  {
+                    "name": "k8s.node.name",
+                    "dataType": "string",
+                    "type": "resource",
+                    "isColumn": false
+                  }
+                ],
+                "order": [],
+                "disabled": false
+              }
             }
-          },
+          ],
+          "panelType": "graph",
           "queryType": "builder"
         },
-        "op": ">",
-        "target": 0,
-        "matchType": "3"
+        "selectedQueryName": "A",
+        "thresholds": {
+          "kind": "basic",
+          "spec": [
+            {
+              "name": "warning",
+              "target": 0,
+              "targetUnit": "",
+              "matchType": "3",
+              "op": ">",
+              "channels": ["pagerduty-homelab"]
+            }
+          ]
+        }
       },
       "preferredChannels": ["pagerduty-homelab"]
     }

--- a/overlays/cluster-critical/signoz/alerts/pod-oomkilled.yaml
+++ b/overlays/cluster-critical/signoz/alerts/pod-oomkilled.yaml
@@ -15,6 +15,7 @@ data:
       "alert": "Pod OOMKilled",
       "alertType": "METRICS_BASED_ALERT",
       "ruleType": "threshold_rule",
+      "version": "v5",
       "broadcastToAll": false,
       "disabled": false,
       "evalWindow": "5m0s",
@@ -30,37 +31,77 @@ data:
       },
       "condition": {
         "compositeQuery": {
-          "builderQueries": {
-            "A": {
-              "queryName": "A",
-              "dataSource": "metrics",
-              "aggregateOperator": "max",
-              "aggregateAttribute": {
-                "key": "k8s.container.restarts",
-                "dataType": "float64",
-                "type": "Gauge"
-              },
-              "filters": {
-                "items": [
+          "queries": [
+            {
+              "type": "builder_query",
+              "spec": {
+                "name": "A",
+                "signal": "metrics",
+                "stepInterval": 60,
+                "aggregations": [
                   {
-                    "key": {"key": "k8s.container.status.last_terminated_reason"},
-                    "op": "=",
-                    "value": "OOMKilled"
+                    "timeAggregation": "max",
+                    "spaceAggregation": "max",
+                    "metricName": "k8s.container.restarts"
                   }
-                ]
-              },
-              "groupBy": [
-                {"key": "k8s.namespace.name"},
-                {"key": "k8s.pod.name"},
-                {"key": "k8s.container.name"}
-              ]
+                ],
+                "filters": {
+                  "items": [
+                    {
+                      "key": {
+                        "key": "k8s.container.status.last_terminated_reason",
+                        "dataType": "string",
+                        "type": "resource",
+                        "isColumn": false
+                      },
+                      "op": "=",
+                      "value": "OOMKilled"
+                    }
+                  ],
+                  "op": "AND"
+                },
+                "groupBy": [
+                  {
+                    "name": "k8s.namespace.name",
+                    "dataType": "string",
+                    "type": "resource",
+                    "isColumn": false
+                  },
+                  {
+                    "name": "k8s.pod.name",
+                    "dataType": "string",
+                    "type": "resource",
+                    "isColumn": false
+                  },
+                  {
+                    "name": "k8s.container.name",
+                    "dataType": "string",
+                    "type": "resource",
+                    "isColumn": false
+                  }
+                ],
+                "order": [],
+                "disabled": false
+              }
             }
-          },
+          ],
+          "panelType": "graph",
           "queryType": "builder"
         },
-        "op": ">",
-        "target": 0,
-        "matchType": "1"
+        "selectedQueryName": "A",
+        "thresholds": {
+          "kind": "basic",
+          "spec": [
+            {
+              "name": "critical",
+              "target": 0,
+              "targetUnit": "",
+              "matchType": "1",
+              "op": ">",
+              "channels": ["pagerduty-homelab"]
+            }
+          ]
+        }
       },
       "preferredChannels": ["pagerduty-homelab"]
     }

--- a/overlays/cluster-critical/signoz/alerts/pod-pending.yaml
+++ b/overlays/cluster-critical/signoz/alerts/pod-pending.yaml
@@ -15,6 +15,7 @@ data:
       "alert": "Pod Stuck Pending",
       "alertType": "METRICS_BASED_ALERT",
       "ruleType": "threshold_rule",
+      "version": "v5",
       "broadcastToAll": false,
       "disabled": false,
       "evalWindow": "15m0s",
@@ -30,30 +31,60 @@ data:
       },
       "condition": {
         "compositeQuery": {
-          "builderQueries": {
-            "A": {
-              "queryName": "A",
-              "dataSource": "metrics",
-              "aggregateOperator": "max",
-              "aggregateAttribute": {
-                "key": "k8s.pod.phase",
-                "dataType": "float64",
-                "type": "Gauge"
-              },
-              "filters": {
-                "items": []
-              },
-              "groupBy": [
-                {"key": "k8s.namespace.name"},
-                {"key": "k8s.pod.name"}
-              ]
+          "queries": [
+            {
+              "type": "builder_query",
+              "spec": {
+                "name": "A",
+                "signal": "metrics",
+                "stepInterval": 60,
+                "aggregations": [
+                  {
+                    "timeAggregation": "max",
+                    "spaceAggregation": "max",
+                    "metricName": "k8s.pod.phase"
+                  }
+                ],
+                "filters": {
+                  "items": [],
+                  "op": "AND"
+                },
+                "groupBy": [
+                  {
+                    "name": "k8s.namespace.name",
+                    "dataType": "string",
+                    "type": "resource",
+                    "isColumn": false
+                  },
+                  {
+                    "name": "k8s.pod.name",
+                    "dataType": "string",
+                    "type": "resource",
+                    "isColumn": false
+                  }
+                ],
+                "order": [],
+                "disabled": false
+              }
             }
-          },
+          ],
+          "panelType": "graph",
           "queryType": "builder"
         },
-        "op": "=",
-        "target": 1,
-        "matchType": "15"
+        "selectedQueryName": "A",
+        "thresholds": {
+          "kind": "basic",
+          "spec": [
+            {
+              "name": "warning",
+              "target": 1,
+              "targetUnit": "",
+              "matchType": "15",
+              "op": "=",
+              "channels": ["pagerduty-homelab"]
+            }
+          ]
+        }
       },
       "preferredChannels": ["pagerduty-homelab"]
     }

--- a/overlays/cluster-critical/signoz/alerts/pod-restart-rate.yaml
+++ b/overlays/cluster-critical/signoz/alerts/pod-restart-rate.yaml
@@ -15,6 +15,7 @@ data:
       "alert": "Pod High Restart Rate",
       "alertType": "METRICS_BASED_ALERT",
       "ruleType": "threshold_rule",
+      "version": "v5",
       "broadcastToAll": false,
       "disabled": false,
       "evalWindow": "15m0s",
@@ -30,30 +31,60 @@ data:
       },
       "condition": {
         "compositeQuery": {
-          "builderQueries": {
-            "A": {
-              "queryName": "A",
-              "dataSource": "metrics",
-              "aggregateOperator": "max",
-              "aggregateAttribute": {
-                "key": "k8s.container.restarts",
-                "dataType": "float64",
-                "type": "Gauge"
-              },
-              "filters": {
-                "items": []
-              },
-              "groupBy": [
-                {"key": "k8s.namespace.name"},
-                {"key": "k8s.pod.name"}
-              ]
+          "queries": [
+            {
+              "type": "builder_query",
+              "spec": {
+                "name": "A",
+                "signal": "metrics",
+                "stepInterval": 60,
+                "aggregations": [
+                  {
+                    "timeAggregation": "max",
+                    "spaceAggregation": "max",
+                    "metricName": "k8s.container.restarts"
+                  }
+                ],
+                "filters": {
+                  "items": [],
+                  "op": "AND"
+                },
+                "groupBy": [
+                  {
+                    "name": "k8s.namespace.name",
+                    "dataType": "string",
+                    "type": "resource",
+                    "isColumn": false
+                  },
+                  {
+                    "name": "k8s.pod.name",
+                    "dataType": "string",
+                    "type": "resource",
+                    "isColumn": false
+                  }
+                ],
+                "order": [],
+                "disabled": false
+              }
             }
-          },
+          ],
+          "panelType": "graph",
           "queryType": "builder"
         },
-        "op": ">",
-        "target": 3,
-        "matchType": "1"
+        "selectedQueryName": "A",
+        "thresholds": {
+          "kind": "basic",
+          "spec": [
+            {
+              "name": "warning",
+              "target": 3,
+              "targetUnit": "",
+              "matchType": "1",
+              "op": ">",
+              "channels": ["pagerduty-homelab"]
+            }
+          ]
+        }
       },
       "preferredChannels": ["pagerduty-homelab"]
     }

--- a/overlays/cluster-critical/signoz/hikes-httpcheck-alert.yaml
+++ b/overlays/cluster-critical/signoz/hikes-httpcheck-alert.yaml
@@ -15,6 +15,7 @@ data:
       "alert": "hikes.jomcgi.dev Unreachable",
       "alertType": "METRICS_BASED_ALERT",
       "ruleType": "threshold_rule",
+      "version": "v5",
       "broadcastToAll": false,
       "disabled": false,
       "evalWindow": "10m0s",
@@ -31,32 +32,58 @@ data:
       },
       "condition": {
         "compositeQuery": {
-          "builderQueries": {
-            "A": {
-              "queryName": "A",
-              "dataSource": "metrics",
-              "aggregateOperator": "avg",
-              "aggregateAttribute": {
-                "key": "httpcheck.status",
-                "dataType": "float64",
-                "type": "Gauge"
-              },
-              "filters": {
-                "items": [
+          "queries": [
+            {
+              "type": "builder_query",
+              "spec": {
+                "name": "A",
+                "signal": "metrics",
+                "stepInterval": 60,
+                "aggregations": [
                   {
-                    "key": {"key": "http.url"},
-                    "op": "=",
-                    "value": "https://hikes.jomcgi.dev"
+                    "timeAggregation": "avg",
+                    "spaceAggregation": "avg",
+                    "metricName": "httpcheck.status"
                   }
-                ]
+                ],
+                "filters": {
+                  "items": [
+                    {
+                      "key": {
+                        "key": "http.url",
+                        "dataType": "string",
+                        "type": "tag",
+                        "isColumn": false
+                      },
+                      "op": "=",
+                      "value": "https://hikes.jomcgi.dev"
+                    }
+                  ],
+                  "op": "AND"
+                },
+                "groupBy": [],
+                "order": [],
+                "disabled": false
               }
             }
-          },
+          ],
+          "panelType": "graph",
           "queryType": "builder"
         },
-        "op": "<",
-        "target": 1,
-        "matchType": "5"
+        "selectedQueryName": "A",
+        "thresholds": {
+          "kind": "basic",
+          "spec": [
+            {
+              "name": "warning",
+              "target": 1,
+              "targetUnit": "",
+              "matchType": "5",
+              "op": "<",
+              "channels": ["pagerduty-homelab"]
+            }
+          ]
+        }
       },
       "preferredChannels": ["pagerduty-homelab"]
     }

--- a/overlays/cluster-critical/signoz/jomcgi-dev-httpcheck-alert.yaml
+++ b/overlays/cluster-critical/signoz/jomcgi-dev-httpcheck-alert.yaml
@@ -15,6 +15,7 @@ data:
       "alert": "jomcgi.dev Unreachable",
       "alertType": "METRICS_BASED_ALERT",
       "ruleType": "threshold_rule",
+      "version": "v5",
       "broadcastToAll": false,
       "disabled": false,
       "evalWindow": "10m0s",
@@ -31,32 +32,58 @@ data:
       },
       "condition": {
         "compositeQuery": {
-          "builderQueries": {
-            "A": {
-              "queryName": "A",
-              "dataSource": "metrics",
-              "aggregateOperator": "avg",
-              "aggregateAttribute": {
-                "key": "httpcheck.status",
-                "dataType": "float64",
-                "type": "Gauge"
-              },
-              "filters": {
-                "items": [
+          "queries": [
+            {
+              "type": "builder_query",
+              "spec": {
+                "name": "A",
+                "signal": "metrics",
+                "stepInterval": 60,
+                "aggregations": [
                   {
-                    "key": {"key": "http.url"},
-                    "op": "=",
-                    "value": "https://jomcgi.dev"
+                    "timeAggregation": "avg",
+                    "spaceAggregation": "avg",
+                    "metricName": "httpcheck.status"
                   }
-                ]
+                ],
+                "filters": {
+                  "items": [
+                    {
+                      "key": {
+                        "key": "http.url",
+                        "dataType": "string",
+                        "type": "tag",
+                        "isColumn": false
+                      },
+                      "op": "=",
+                      "value": "https://jomcgi.dev"
+                    }
+                  ],
+                  "op": "AND"
+                },
+                "groupBy": [],
+                "order": [],
+                "disabled": false
               }
             }
-          },
+          ],
+          "panelType": "graph",
           "queryType": "builder"
         },
-        "op": "<",
-        "target": 1,
-        "matchType": "5"
+        "selectedQueryName": "A",
+        "thresholds": {
+          "kind": "basic",
+          "spec": [
+            {
+              "name": "warning",
+              "target": 1,
+              "targetUnit": "",
+              "matchType": "5",
+              "op": "<",
+              "channels": ["pagerduty-homelab"]
+            }
+          ]
+        }
       },
       "preferredChannels": ["pagerduty-homelab"]
     }

--- a/overlays/cluster-critical/signoz/signoz-httpcheck-alert.yaml
+++ b/overlays/cluster-critical/signoz/signoz-httpcheck-alert.yaml
@@ -15,6 +15,7 @@ data:
       "alert": "SigNoz Unreachable",
       "alertType": "METRICS_BASED_ALERT",
       "ruleType": "threshold_rule",
+      "version": "v5",
       "broadcastToAll": false,
       "disabled": false,
       "evalWindow": "10m0s",
@@ -30,32 +31,58 @@ data:
       },
       "condition": {
         "compositeQuery": {
-          "builderQueries": {
-            "A": {
-              "queryName": "A",
-              "dataSource": "metrics",
-              "aggregateOperator": "avg",
-              "aggregateAttribute": {
-                "key": "httpcheck.status",
-                "dataType": "float64",
-                "type": "Gauge"
-              },
-              "filters": {
-                "items": [
+          "queries": [
+            {
+              "type": "builder_query",
+              "spec": {
+                "name": "A",
+                "signal": "metrics",
+                "stepInterval": 60,
+                "aggregations": [
                   {
-                    "key": {"key": "http.url"},
-                    "op": "=",
-                    "value": "https://signoz.jomcgi.dev"
+                    "timeAggregation": "avg",
+                    "spaceAggregation": "avg",
+                    "metricName": "httpcheck.status"
                   }
-                ]
+                ],
+                "filters": {
+                  "items": [
+                    {
+                      "key": {
+                        "key": "http.url",
+                        "dataType": "string",
+                        "type": "tag",
+                        "isColumn": false
+                      },
+                      "op": "=",
+                      "value": "https://signoz.jomcgi.dev"
+                    }
+                  ],
+                  "op": "AND"
+                },
+                "groupBy": [],
+                "order": [],
+                "disabled": false
               }
             }
-          },
+          ],
+          "panelType": "graph",
           "queryType": "builder"
         },
-        "op": "<",
-        "target": 1,
-        "matchType": "5"
+        "selectedQueryName": "A",
+        "thresholds": {
+          "kind": "basic",
+          "spec": [
+            {
+              "name": "critical",
+              "target": 1,
+              "targetUnit": "",
+              "matchType": "5",
+              "op": "<",
+              "channels": ["pagerduty-homelab"]
+            }
+          ]
+        }
       },
       "preferredChannels": ["pagerduty-homelab"]
     }

--- a/overlays/cluster-critical/signoz/trips-pages-httpcheck-alert.yaml
+++ b/overlays/cluster-critical/signoz/trips-pages-httpcheck-alert.yaml
@@ -15,6 +15,7 @@ data:
       "alert": "trips.jomcgi.dev Unreachable",
       "alertType": "METRICS_BASED_ALERT",
       "ruleType": "threshold_rule",
+      "version": "v5",
       "broadcastToAll": false,
       "disabled": false,
       "evalWindow": "10m0s",
@@ -31,32 +32,58 @@ data:
       },
       "condition": {
         "compositeQuery": {
-          "builderQueries": {
-            "A": {
-              "queryName": "A",
-              "dataSource": "metrics",
-              "aggregateOperator": "avg",
-              "aggregateAttribute": {
-                "key": "httpcheck.status",
-                "dataType": "float64",
-                "type": "Gauge"
-              },
-              "filters": {
-                "items": [
+          "queries": [
+            {
+              "type": "builder_query",
+              "spec": {
+                "name": "A",
+                "signal": "metrics",
+                "stepInterval": 60,
+                "aggregations": [
                   {
-                    "key": {"key": "http.url"},
-                    "op": "=",
-                    "value": "https://trips.jomcgi.dev"
+                    "timeAggregation": "avg",
+                    "spaceAggregation": "avg",
+                    "metricName": "httpcheck.status"
                   }
-                ]
+                ],
+                "filters": {
+                  "items": [
+                    {
+                      "key": {
+                        "key": "http.url",
+                        "dataType": "string",
+                        "type": "tag",
+                        "isColumn": false
+                      },
+                      "op": "=",
+                      "value": "https://trips.jomcgi.dev"
+                    }
+                  ],
+                  "op": "AND"
+                },
+                "groupBy": [],
+                "order": [],
+                "disabled": false
               }
             }
-          },
+          ],
+          "panelType": "graph",
           "queryType": "builder"
         },
-        "op": "<",
-        "target": 1,
-        "matchType": "5"
+        "selectedQueryName": "A",
+        "thresholds": {
+          "kind": "basic",
+          "spec": [
+            {
+              "name": "warning",
+              "target": 1,
+              "targetUnit": "",
+              "matchType": "5",
+              "op": "<",
+              "channels": ["pagerduty-homelab"]
+            }
+          ]
+        }
       },
       "preferredChannels": ["pagerduty-homelab"]
     }

--- a/overlays/dev/marine/marine-httpcheck-alert.yaml
+++ b/overlays/dev/marine/marine-httpcheck-alert.yaml
@@ -15,6 +15,7 @@ data:
       "alert": "marine Unreachable",
       "alertType": "METRICS_BASED_ALERT",
       "ruleType": "threshold_rule",
+      "version": "v5",
       "broadcastToAll": false,
       "disabled": false,
       "evalWindow": "10m0s",
@@ -30,32 +31,58 @@ data:
       },
       "condition": {
         "compositeQuery": {
-          "builderQueries": {
-            "A": {
-              "queryName": "A",
-              "dataSource": "metrics",
-              "aggregateOperator": "avg",
-              "aggregateAttribute": {
-                "key": "httpcheck.status",
-                "dataType": "float64",
-                "type": "Gauge"
-              },
-              "filters": {
-                "items": [
+          "queries": [
+            {
+              "type": "builder_query",
+              "spec": {
+                "name": "A",
+                "signal": "metrics",
+                "stepInterval": 60,
+                "aggregations": [
                   {
-                    "key": {"key": "http.url"},
-                    "op": "=",
-                    "value": "https://ships.jomcgi.dev"
+                    "timeAggregation": "avg",
+                    "spaceAggregation": "avg",
+                    "metricName": "httpcheck.status"
                   }
-                ]
+                ],
+                "filters": {
+                  "items": [
+                    {
+                      "key": {
+                        "key": "http.url",
+                        "dataType": "string",
+                        "type": "tag",
+                        "isColumn": false
+                      },
+                      "op": "=",
+                      "value": "https://ships.jomcgi.dev"
+                    }
+                  ],
+                  "op": "AND"
+                },
+                "groupBy": [],
+                "order": [],
+                "disabled": false
               }
             }
-          },
+          ],
+          "panelType": "graph",
           "queryType": "builder"
         },
-        "op": "<",
-        "target": 1,
-        "matchType": "5"
+        "selectedQueryName": "A",
+        "thresholds": {
+          "kind": "basic",
+          "spec": [
+            {
+              "name": "warning",
+              "target": 1,
+              "targetUnit": "",
+              "matchType": "5",
+              "op": "<",
+              "channels": ["pagerduty-homelab"]
+            }
+          ]
+        }
       },
       "preferredChannels": ["pagerduty-homelab"]
     }

--- a/overlays/prod/api-gateway/api-gateway-httpcheck-alert.yaml
+++ b/overlays/prod/api-gateway/api-gateway-httpcheck-alert.yaml
@@ -15,6 +15,7 @@ data:
       "alert": "api-gateway Unreachable",
       "alertType": "METRICS_BASED_ALERT",
       "ruleType": "threshold_rule",
+      "version": "v5",
       "broadcastToAll": false,
       "disabled": false,
       "evalWindow": "10m0s",
@@ -30,32 +31,58 @@ data:
       },
       "condition": {
         "compositeQuery": {
-          "builderQueries": {
-            "A": {
-              "queryName": "A",
-              "dataSource": "metrics",
-              "aggregateOperator": "avg",
-              "aggregateAttribute": {
-                "key": "httpcheck.status",
-                "dataType": "float64",
-                "type": "Gauge"
-              },
-              "filters": {
-                "items": [
+          "queries": [
+            {
+              "type": "builder_query",
+              "spec": {
+                "name": "A",
+                "signal": "metrics",
+                "stepInterval": 60,
+                "aggregations": [
                   {
-                    "key": {"key": "http.url"},
-                    "op": "=",
-                    "value": "https://api.jomcgi.dev/status.json"
+                    "timeAggregation": "avg",
+                    "spaceAggregation": "avg",
+                    "metricName": "httpcheck.status"
                   }
-                ]
+                ],
+                "filters": {
+                  "items": [
+                    {
+                      "key": {
+                        "key": "http.url",
+                        "dataType": "string",
+                        "type": "tag",
+                        "isColumn": false
+                      },
+                      "op": "=",
+                      "value": "https://api.jomcgi.dev/status.json"
+                    }
+                  ],
+                  "op": "AND"
+                },
+                "groupBy": [],
+                "order": [],
+                "disabled": false
               }
             }
-          },
+          ],
+          "panelType": "graph",
           "queryType": "builder"
         },
-        "op": "<",
-        "target": 1,
-        "matchType": "5"
+        "selectedQueryName": "A",
+        "thresholds": {
+          "kind": "basic",
+          "spec": [
+            {
+              "name": "critical",
+              "target": 1,
+              "targetUnit": "",
+              "matchType": "5",
+              "op": "<",
+              "channels": ["pagerduty-homelab"]
+            }
+          ]
+        }
       },
       "preferredChannels": ["pagerduty-homelab"]
     }

--- a/overlays/prod/todo/todo-admin-httpcheck-alert.yaml
+++ b/overlays/prod/todo/todo-admin-httpcheck-alert.yaml
@@ -15,6 +15,7 @@ data:
       "alert": "todo-admin Unreachable",
       "alertType": "METRICS_BASED_ALERT",
       "ruleType": "threshold_rule",
+      "version": "v5",
       "broadcastToAll": false,
       "disabled": false,
       "evalWindow": "10m0s",
@@ -30,32 +31,58 @@ data:
       },
       "condition": {
         "compositeQuery": {
-          "builderQueries": {
-            "A": {
-              "queryName": "A",
-              "dataSource": "metrics",
-              "aggregateOperator": "avg",
-              "aggregateAttribute": {
-                "key": "httpcheck.status",
-                "dataType": "float64",
-                "type": "Gauge"
-              },
-              "filters": {
-                "items": [
+          "queries": [
+            {
+              "type": "builder_query",
+              "spec": {
+                "name": "A",
+                "signal": "metrics",
+                "stepInterval": 60,
+                "aggregations": [
                   {
-                    "key": {"key": "http.url"},
-                    "op": "=",
-                    "value": "https://todo-admin.jomcgi.dev"
+                    "timeAggregation": "avg",
+                    "spaceAggregation": "avg",
+                    "metricName": "httpcheck.status"
                   }
-                ]
+                ],
+                "filters": {
+                  "items": [
+                    {
+                      "key": {
+                        "key": "http.url",
+                        "dataType": "string",
+                        "type": "tag",
+                        "isColumn": false
+                      },
+                      "op": "=",
+                      "value": "https://todo-admin.jomcgi.dev"
+                    }
+                  ],
+                  "op": "AND"
+                },
+                "groupBy": [],
+                "order": [],
+                "disabled": false
               }
             }
-          },
+          ],
+          "panelType": "graph",
           "queryType": "builder"
         },
-        "op": "<",
-        "target": 1,
-        "matchType": "5"
+        "selectedQueryName": "A",
+        "thresholds": {
+          "kind": "basic",
+          "spec": [
+            {
+              "name": "critical",
+              "target": 1,
+              "targetUnit": "",
+              "matchType": "5",
+              "op": "<",
+              "channels": ["pagerduty-homelab"]
+            }
+          ]
+        }
       },
       "preferredChannels": ["pagerduty-homelab"]
     }

--- a/overlays/prod/todo/todo-httpcheck-alert.yaml
+++ b/overlays/prod/todo/todo-httpcheck-alert.yaml
@@ -15,6 +15,7 @@ data:
       "alert": "todo Unreachable",
       "alertType": "METRICS_BASED_ALERT",
       "ruleType": "threshold_rule",
+      "version": "v5",
       "broadcastToAll": false,
       "disabled": false,
       "evalWindow": "10m0s",
@@ -30,32 +31,58 @@ data:
       },
       "condition": {
         "compositeQuery": {
-          "builderQueries": {
-            "A": {
-              "queryName": "A",
-              "dataSource": "metrics",
-              "aggregateOperator": "avg",
-              "aggregateAttribute": {
-                "key": "httpcheck.status",
-                "dataType": "float64",
-                "type": "Gauge"
-              },
-              "filters": {
-                "items": [
+          "queries": [
+            {
+              "type": "builder_query",
+              "spec": {
+                "name": "A",
+                "signal": "metrics",
+                "stepInterval": 60,
+                "aggregations": [
                   {
-                    "key": {"key": "http.url"},
-                    "op": "=",
-                    "value": "https://todo.jomcgi.dev"
+                    "timeAggregation": "avg",
+                    "spaceAggregation": "avg",
+                    "metricName": "httpcheck.status"
                   }
-                ]
+                ],
+                "filters": {
+                  "items": [
+                    {
+                      "key": {
+                        "key": "http.url",
+                        "dataType": "string",
+                        "type": "tag",
+                        "isColumn": false
+                      },
+                      "op": "=",
+                      "value": "https://todo.jomcgi.dev"
+                    }
+                  ],
+                  "op": "AND"
+                },
+                "groupBy": [],
+                "order": [],
+                "disabled": false
               }
             }
-          },
+          ],
+          "panelType": "graph",
           "queryType": "builder"
         },
-        "op": "<",
-        "target": 1,
-        "matchType": "5"
+        "selectedQueryName": "A",
+        "thresholds": {
+          "kind": "basic",
+          "spec": [
+            {
+              "name": "critical",
+              "target": 1,
+              "targetUnit": "",
+              "matchType": "5",
+              "op": "<",
+              "channels": ["pagerduty-homelab"]
+            }
+          ]
+        }
       },
       "preferredChannels": ["pagerduty-homelab"]
     }

--- a/overlays/prod/trips/img-httpcheck-alert.yaml
+++ b/overlays/prod/trips/img-httpcheck-alert.yaml
@@ -15,6 +15,7 @@ data:
       "alert": "img Unreachable",
       "alertType": "METRICS_BASED_ALERT",
       "ruleType": "threshold_rule",
+      "version": "v5",
       "broadcastToAll": false,
       "disabled": false,
       "evalWindow": "10m0s",
@@ -30,32 +31,58 @@ data:
       },
       "condition": {
         "compositeQuery": {
-          "builderQueries": {
-            "A": {
-              "queryName": "A",
-              "dataSource": "metrics",
-              "aggregateOperator": "avg",
-              "aggregateAttribute": {
-                "key": "httpcheck.status",
-                "dataType": "float64",
-                "type": "Gauge"
-              },
-              "filters": {
-                "items": [
+          "queries": [
+            {
+              "type": "builder_query",
+              "spec": {
+                "name": "A",
+                "signal": "metrics",
+                "stepInterval": 60,
+                "aggregations": [
                   {
-                    "key": {"key": "http.url"},
-                    "op": "=",
-                    "value": "https://img.jomcgi.dev/health"
+                    "timeAggregation": "avg",
+                    "spaceAggregation": "avg",
+                    "metricName": "httpcheck.status"
                   }
-                ]
+                ],
+                "filters": {
+                  "items": [
+                    {
+                      "key": {
+                        "key": "http.url",
+                        "dataType": "string",
+                        "type": "tag",
+                        "isColumn": false
+                      },
+                      "op": "=",
+                      "value": "https://img.jomcgi.dev/health"
+                    }
+                  ],
+                  "op": "AND"
+                },
+                "groupBy": [],
+                "order": [],
+                "disabled": false
               }
             }
-          },
+          ],
+          "panelType": "graph",
           "queryType": "builder"
         },
-        "op": "<",
-        "target": 1,
-        "matchType": "5"
+        "selectedQueryName": "A",
+        "thresholds": {
+          "kind": "basic",
+          "spec": [
+            {
+              "name": "critical",
+              "target": 1,
+              "targetUnit": "",
+              "matchType": "5",
+              "op": "<",
+              "channels": ["pagerduty-homelab"]
+            }
+          ]
+        }
       },
       "preferredChannels": ["pagerduty-homelab"]
     }


### PR DESCRIPTION
## Summary

- Migrate all 22 alert ConfigMaps from legacy `builderQueries` map format to the v5 `queries` array format required by SigNoz v0.113
- All 8 unique metric queries validated against live SigNoz instance via `execute-builder-query`
- Format changes enable the dashboard sidecar to successfully sync alerts after the SigNoz upgrade (PR #658)

## Format Changes (old → new)

| Field | Old Format | v5 Format |
|-------|-----------|-----------|
| Query structure | `builderQueries: { "A": {...} }` (map) | `queries: [{ type: "builder_query", spec: {...} }]` (array) |
| Aggregation | `aggregateOperator` + `aggregateAttribute` | `aggregations: [{ timeAggregation, spaceAggregation, metricName }]` |
| Data source | `dataSource: "metrics"` | `signal: "metrics"` |
| Filter keys | `{ "key": "http.url" }` | `{ "key": "http.url", "dataType": "string", "type": "tag", "isColumn": false }` |
| Filter combiner | (implicit) | `filters.op: "AND"` |
| GroupBy keys | `{ "key": "k8s.node.name" }` | `{ "name": "k8s.node.name", "dataType": "string", "type": "resource", "isColumn": false }` |
| Threshold | `condition.op`/`target`/`matchType` | `condition.thresholds: { kind: "basic", spec: [...] }` |
| New fields | — | `version: "v5"`, `panelType`, `selectedQueryName`, `stepInterval`, `order`, `disabled` |

## Metric Query Validation Results

All queries executed against live SigNoz v0.113 with 30-minute lookback:

| Metric | Aggregation | Result | Notes |
|--------|-------------|--------|-------|
| `httpcheck.status` | avg | ✅ Data flowing | avg=0.2 for signoz.jomcgi.dev |
| `argocd_app_info` | count | ✅ Data flowing | Shows degraded apps (linkerd, kyverno) |
| `k8s.node.condition_ready` | min | ✅ All nodes = 1 | All 4 nodes healthy |
| `k8s.node.condition_disk_pressure` | max | ✅ All nodes = 0 | No pressure |
| `k8s.node.condition_memory_pressure` | max | ✅ All nodes = 0 | No pressure |
| `k8s.node.condition_pid_pressure` | max | ✅ All nodes = 0 | No pressure |
| `k8s.container.restarts` | max | ✅ Data flowing | Active restart data (OOMKilled filter validated) |
| `k8s.pod.phase` | max | ✅ Data flowing | All pod phases reporting |

> **Note:** Alerts for rare events (OOMKilled, node pressure) may show empty data in normal operation — this is expected. The queries are confirmed valid.

## Files Changed (22)

**HTTP check alerts (11):** argocd, longhorn, signoz, hikes, jomcgi-dev, trips-pages, marine, api-gateway, todo, todo-admin, img

**ArgoCD app state alerts (4):** degraded, missing, out-of-sync, suspended

**K8s health alerts (7):** node-not-ready, node-disk-pressure, node-memory-pressure, node-pid-pressure, pod-oomkilled, pod-pending, pod-restart-rate

## Test plan

- [ ] CI passes (format check + build)
- [ ] After merge, ArgoCD syncs alert ConfigMaps (~5-10s)
- [ ] Dashboard sidecar reconciles and POSTs alerts to SigNoz API
- [ ] `list-alerts` returns 22 alerts
- [ ] Spot-check `get-alert` on a few alerts for correct v5 structure
- [ ] `get-alert-history` shows evaluation activity on httpcheck alerts

🤖 Generated with [Claude Code](https://claude.com/claude-code)