### PR TITLE
fix: enforce plan files are written to worktrees

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -71,6 +71,8 @@ Examples:
 
 Breaking changes: add `!` after type/scope — `feat!: redesign auth token format`
 
+**Plan & design files:** The brainstorming and writing-plans skills save to `docs/plans/`. Create a worktree **before** saving any plan or design documents — they must land on the feature branch, not main. A PreToolUse hook enforces this.
+
 ## Context Loading Rules
 
 - **Security changes**: Read `architecture/security.md` FIRST

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -10,6 +10,16 @@
             "timeout": 10
           }
         ]
+      },
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "tools/git/check-plan-worktree.sh",
+            "timeout": 5
+          }
+        ]
       }
     ]
   },

--- a/tools/git/check-plan-worktree.sh
+++ b/tools/git/check-plan-worktree.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+# PreToolUse hook: blocks plan/design file writes to the main worktree.
+# Plans should be written in a linked worktree so they land on the feature branch.
+#
+# Input: JSON on stdin from Claude Code hook system
+# Exit 0: allow the write
+# Exit 2: block the write (reason shown to Claude)
+
+set -euo pipefail
+
+INPUT=$(cat)
+TOOL=$(echo "$INPUT" | jq -r '.tool_name // empty')
+
+# Only check Write and Edit tools
+if [[ "$TOOL" != "Write" && "$TOOL" != "Edit" ]]; then
+	exit 0
+fi
+
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
+
+# Only check docs/plans/ files
+if [[ "$FILE_PATH" != *"/docs/plans/"* ]]; then
+	exit 0
+fi
+
+# Determine the git repo root for this file
+DIR=$(dirname "$FILE_PATH")
+if [ ! -d "$DIR" ]; then
+	# Directory doesn't exist yet — check parent
+	DIR=$(dirname "$DIR")
+	[ -d "$DIR" ] || exit 0
+fi
+
+REPO_ROOT=$(git -C "$DIR" rev-parse --show-toplevel 2>/dev/null) || exit 0
+
+# Check if we're in a linked worktree by comparing --git-dir to --git-common-dir.
+# In the main worktree these resolve to the same path; in a linked worktree they differ.
+GIT_DIR=$(cd "$REPO_ROOT" && git rev-parse --absolute-git-dir 2>/dev/null) || exit 0
+GIT_COMMON_DIR=$(cd "$REPO_ROOT" && git rev-parse --git-common-dir 2>/dev/null) || exit 0
+
+# Normalize --git-common-dir (may be relative)
+if [[ "$GIT_COMMON_DIR" != /* ]]; then
+	GIT_COMMON_DIR=$(cd "$REPO_ROOT" && cd "$GIT_COMMON_DIR" && pwd)
+fi
+
+if [[ "$GIT_DIR" != "$GIT_COMMON_DIR" ]]; then
+	# Linked worktree — allow the write
+	exit 0
+fi
+
+# Main worktree — block the write
+cat >&2 <<-EOF
+	BLOCKED: Plan/design files must be written to a worktree, not the main repo.
+	File: $FILE_PATH
+
+	Create a worktree first, then save plans there:
+	  git worktree add -b docs/<topic> /tmp/claude-worktrees/<topic> origin/main
+
+	Then write to the worktree's docs/plans/ directory instead.
+EOF
+exit 2


### PR DESCRIPTION
## Summary

- Add `check-plan-worktree.sh` PreToolUse hook that blocks Write/Edit to `docs/plans/` in the main worktree
- Uses git's own worktree detection (`--git-dir` vs `--git-common-dir`) — no hardcoded paths
- Register hook in `.claude/settings.json` with `Write|Edit` matcher
- Add guidance in `.claude/CLAUDE.md` under Development Workflow

## Context

The superpowers brainstorming and writing-plans skills save to `docs/plans/` but don't create a worktree first. This caused plan files to land in the main repo instead of on the feature branch, requiring manual cleanup (see #662).

## Test plan

- [x] Hook blocks Write to `~/repos/homelab/docs/plans/*.md` (exit 2 with guidance)
- [x] Hook allows Write to `/tmp/claude-worktrees/*/docs/plans/*.md` (exit 0)
- [x] Hook allows Write to non-plans paths in main repo (exit 0)
- [x] Hook blocks Edit tool to main repo plans (exit 2)
- [x] Hook ignores non-Write/Edit tools like Bash (exit 0)
- [x] Hook handles non-existent nested directories gracefully (exit 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)