### PR TITLE
fix: correct v5 query builder field names in alert ConfigMaps

### DIFF
--- a/overlays/cluster-critical/argocd/argocd-httpcheck-alert.yaml
+++ b/overlays/cluster-critical/argocd/argocd-httpcheck-alert.yaml
@@ -45,20 +45,8 @@ data:
                     "metricName": "httpcheck.status"
                   }
                 ],
-                "filters": {
-                  "items": [
-                    {
-                      "key": {
-                        "key": "http.url",
-                        "dataType": "string",
-                        "type": "tag",
-                        "isColumn": false
-                      },
-                      "op": "=",
-                      "value": "https://argocd.jomcgi.dev"
-                    }
-                  ],
-                  "op": "AND"
+                "filter": {
+                  "expression": "http.url = 'https://argocd.jomcgi.dev'"
                 },
                 "groupBy": [],
                 "order": [],

--- a/overlays/cluster-critical/longhorn/longhorn-httpcheck-alert.yaml
+++ b/overlays/cluster-critical/longhorn/longhorn-httpcheck-alert.yaml
@@ -45,20 +45,8 @@ data:
                     "metricName": "httpcheck.status"
                   }
                 ],
-                "filters": {
-                  "items": [
-                    {
-                      "key": {
-                        "key": "http.url",
-                        "dataType": "string",
-                        "type": "tag",
-                        "isColumn": false
-                      },
-                      "op": "=",
-                      "value": "https://longhorn.jomcgi.dev"
-                    }
-                  ],
-                  "op": "AND"
+                "filter": {
+                  "expression": "http.url = 'https://longhorn.jomcgi.dev'"
                 },
                 "groupBy": [],
                 "order": [],

--- a/overlays/cluster-critical/signoz/alerts/argocd-app-degraded.yaml
+++ b/overlays/cluster-critical/signoz/alerts/argocd-app-degraded.yaml
@@ -45,33 +45,19 @@ data:
                     "metricName": "argocd_app_info"
                   }
                 ],
-                "filters": {
-                  "items": [
-                    {
-                      "key": {
-                        "key": "health_status",
-                        "dataType": "string",
-                        "type": "tag",
-                        "isColumn": false
-                      },
-                      "op": "=",
-                      "value": "Degraded"
-                    }
-                  ],
-                  "op": "AND"
+                "filter": {
+                  "expression": "health_status = 'Degraded'"
                 },
                 "groupBy": [
                   {
                     "name": "name",
-                    "dataType": "string",
-                    "type": "tag",
-                    "isColumn": false
+                    "fieldDataType": "string",
+                    "fieldContext": "tag"
                   },
                   {
                     "name": "namespace",
-                    "dataType": "string",
-                    "type": "tag",
-                    "isColumn": false
+                    "fieldDataType": "string",
+                    "fieldContext": "tag"
                   }
                 ],
                 "order": [],

--- a/overlays/cluster-critical/signoz/alerts/argocd-app-missing.yaml
+++ b/overlays/cluster-critical/signoz/alerts/argocd-app-missing.yaml
@@ -45,33 +45,19 @@ data:
                     "metricName": "argocd_app_info"
                   }
                 ],
-                "filters": {
-                  "items": [
-                    {
-                      "key": {
-                        "key": "health_status",
-                        "dataType": "string",
-                        "type": "tag",
-                        "isColumn": false
-                      },
-                      "op": "=",
-                      "value": "Missing"
-                    }
-                  ],
-                  "op": "AND"
+                "filter": {
+                  "expression": "health_status = 'Missing'"
                 },
                 "groupBy": [
                   {
                     "name": "name",
-                    "dataType": "string",
-                    "type": "tag",
-                    "isColumn": false
+                    "fieldDataType": "string",
+                    "fieldContext": "tag"
                   },
                   {
                     "name": "namespace",
-                    "dataType": "string",
-                    "type": "tag",
-                    "isColumn": false
+                    "fieldDataType": "string",
+                    "fieldContext": "tag"
                   }
                 ],
                 "order": [],

--- a/overlays/cluster-critical/signoz/alerts/argocd-app-outofsync.yaml
+++ b/overlays/cluster-critical/signoz/alerts/argocd-app-outofsync.yaml
@@ -45,33 +45,19 @@ data:
                     "metricName": "argocd_app_info"
                   }
                 ],
-                "filters": {
-                  "items": [
-                    {
-                      "key": {
-                        "key": "sync_status",
-                        "dataType": "string",
-                        "type": "tag",
-                        "isColumn": false
-                      },
-                      "op": "=",
-                      "value": "OutOfSync"
-                    }
-                  ],
-                  "op": "AND"
+                "filter": {
+                  "expression": "sync_status = 'OutOfSync'"
                 },
                 "groupBy": [
                   {
                     "name": "name",
-                    "dataType": "string",
-                    "type": "tag",
-                    "isColumn": false
+                    "fieldDataType": "string",
+                    "fieldContext": "tag"
                   },
                   {
                     "name": "namespace",
-                    "dataType": "string",
-                    "type": "tag",
-                    "isColumn": false
+                    "fieldDataType": "string",
+                    "fieldContext": "tag"
                   }
                 ],
                 "order": [],

--- a/overlays/cluster-critical/signoz/alerts/argocd-app-suspended.yaml
+++ b/overlays/cluster-critical/signoz/alerts/argocd-app-suspended.yaml
@@ -45,33 +45,19 @@ data:
                     "metricName": "argocd_app_info"
                   }
                 ],
-                "filters": {
-                  "items": [
-                    {
-                      "key": {
-                        "key": "health_status",
-                        "dataType": "string",
-                        "type": "tag",
-                        "isColumn": false
-                      },
-                      "op": "=",
-                      "value": "Suspended"
-                    }
-                  ],
-                  "op": "AND"
+                "filter": {
+                  "expression": "health_status = 'Suspended'"
                 },
                 "groupBy": [
                   {
                     "name": "name",
-                    "dataType": "string",
-                    "type": "tag",
-                    "isColumn": false
+                    "fieldDataType": "string",
+                    "fieldContext": "tag"
                   },
                   {
                     "name": "namespace",
-                    "dataType": "string",
-                    "type": "tag",
-                    "isColumn": false
+                    "fieldDataType": "string",
+                    "fieldContext": "tag"
                   }
                 ],
                 "order": [],

--- a/overlays/cluster-critical/signoz/alerts/node-disk-pressure.yaml
+++ b/overlays/cluster-critical/signoz/alerts/node-disk-pressure.yaml
@@ -45,16 +45,11 @@ data:
                     "metricName": "k8s.node.condition_disk_pressure"
                   }
                 ],
-                "filters": {
-                  "items": [],
-                  "op": "AND"
-                },
                 "groupBy": [
                   {
                     "name": "k8s.node.name",
-                    "dataType": "string",
-                    "type": "resource",
-                    "isColumn": false
+                    "fieldDataType": "string",
+                    "fieldContext": "resource"
                   }
                 ],
                 "order": [],

--- a/overlays/cluster-critical/signoz/alerts/node-memory-pressure.yaml
+++ b/overlays/cluster-critical/signoz/alerts/node-memory-pressure.yaml
@@ -45,16 +45,11 @@ data:
                     "metricName": "k8s.node.condition_memory_pressure"
                   }
                 ],
-                "filters": {
-                  "items": [],
-                  "op": "AND"
-                },
                 "groupBy": [
                   {
                     "name": "k8s.node.name",
-                    "dataType": "string",
-                    "type": "resource",
-                    "isColumn": false
+                    "fieldDataType": "string",
+                    "fieldContext": "resource"
                   }
                 ],
                 "order": [],

--- a/overlays/cluster-critical/signoz/alerts/node-not-ready.yaml
+++ b/overlays/cluster-critical/signoz/alerts/node-not-ready.yaml
@@ -45,16 +45,11 @@ data:
                     "metricName": "k8s.node.condition_ready"
                   }
                 ],
-                "filters": {
-                  "items": [],
-                  "op": "AND"
-                },
                 "groupBy": [
                   {
                     "name": "k8s.node.name",
-                    "dataType": "string",
-                    "type": "resource",
-                    "isColumn": false
+                    "fieldDataType": "string",
+                    "fieldContext": "resource"
                   }
                 ],
                 "order": [],

--- a/overlays/cluster-critical/signoz/alerts/node-pid-pressure.yaml
+++ b/overlays/cluster-critical/signoz/alerts/node-pid-pressure.yaml
@@ -45,16 +45,11 @@ data:
                     "metricName": "k8s.node.condition_pid_pressure"
                   }
                 ],
-                "filters": {
-                  "items": [],
-                  "op": "AND"
-                },
                 "groupBy": [
                   {
                     "name": "k8s.node.name",
-                    "dataType": "string",
-                    "type": "resource",
-                    "isColumn": false
+                    "fieldDataType": "string",
+                    "fieldContext": "resource"
                   }
                 ],
                 "order": [],

--- a/overlays/cluster-critical/signoz/alerts/pod-oomkilled.yaml
+++ b/overlays/cluster-critical/signoz/alerts/pod-oomkilled.yaml
@@ -45,39 +45,24 @@ data:
                     "metricName": "k8s.container.restarts"
                   }
                 ],
-                "filters": {
-                  "items": [
-                    {
-                      "key": {
-                        "key": "k8s.container.status.last_terminated_reason",
-                        "dataType": "string",
-                        "type": "resource",
-                        "isColumn": false
-                      },
-                      "op": "=",
-                      "value": "OOMKilled"
-                    }
-                  ],
-                  "op": "AND"
+                "filter": {
+                  "expression": "k8s.container.status.last_terminated_reason = 'OOMKilled'"
                 },
                 "groupBy": [
                   {
                     "name": "k8s.namespace.name",
-                    "dataType": "string",
-                    "type": "resource",
-                    "isColumn": false
+                    "fieldDataType": "string",
+                    "fieldContext": "resource"
                   },
                   {
                     "name": "k8s.pod.name",
-                    "dataType": "string",
-                    "type": "resource",
-                    "isColumn": false
+                    "fieldDataType": "string",
+                    "fieldContext": "resource"
                   },
                   {
                     "name": "k8s.container.name",
-                    "dataType": "string",
-                    "type": "resource",
-                    "isColumn": false
+                    "fieldDataType": "string",
+                    "fieldContext": "resource"
                   }
                 ],
                 "order": [],

--- a/overlays/cluster-critical/signoz/alerts/pod-pending.yaml
+++ b/overlays/cluster-critical/signoz/alerts/pod-pending.yaml
@@ -45,22 +45,16 @@ data:
                     "metricName": "k8s.pod.phase"
                   }
                 ],
-                "filters": {
-                  "items": [],
-                  "op": "AND"
-                },
                 "groupBy": [
                   {
                     "name": "k8s.namespace.name",
-                    "dataType": "string",
-                    "type": "resource",
-                    "isColumn": false
+                    "fieldDataType": "string",
+                    "fieldContext": "resource"
                   },
                   {
                     "name": "k8s.pod.name",
-                    "dataType": "string",
-                    "type": "resource",
-                    "isColumn": false
+                    "fieldDataType": "string",
+                    "fieldContext": "resource"
                   }
                 ],
                 "order": [],

--- a/overlays/cluster-critical/signoz/alerts/pod-restart-rate.yaml
+++ b/overlays/cluster-critical/signoz/alerts/pod-restart-rate.yaml
@@ -45,22 +45,16 @@ data:
                     "metricName": "k8s.container.restarts"
                   }
                 ],
-                "filters": {
-                  "items": [],
-                  "op": "AND"
-                },
                 "groupBy": [
                   {
                     "name": "k8s.namespace.name",
-                    "dataType": "string",
-                    "type": "resource",
-                    "isColumn": false
+                    "fieldDataType": "string",
+                    "fieldContext": "resource"
                   },
                   {
                     "name": "k8s.pod.name",
-                    "dataType": "string",
-                    "type": "resource",
-                    "isColumn": false
+                    "fieldDataType": "string",
+                    "fieldContext": "resource"
                   }
                 ],
                 "order": [],

--- a/overlays/cluster-critical/signoz/hikes-httpcheck-alert.yaml
+++ b/overlays/cluster-critical/signoz/hikes-httpcheck-alert.yaml
@@ -46,20 +46,8 @@ data:
                     "metricName": "httpcheck.status"
                   }
                 ],
-                "filters": {
-                  "items": [
-                    {
-                      "key": {
-                        "key": "http.url",
-                        "dataType": "string",
-                        "type": "tag",
-                        "isColumn": false
-                      },
-                      "op": "=",
-                      "value": "https://hikes.jomcgi.dev"
-                    }
-                  ],
-                  "op": "AND"
+                "filter": {
+                  "expression": "http.url = 'https://hikes.jomcgi.dev'"
                 },
                 "groupBy": [],
                 "order": [],

--- a/overlays/cluster-critical/signoz/jomcgi-dev-httpcheck-alert.yaml
+++ b/overlays/cluster-critical/signoz/jomcgi-dev-httpcheck-alert.yaml
@@ -46,20 +46,8 @@ data:
                     "metricName": "httpcheck.status"
                   }
                 ],
-                "filters": {
-                  "items": [
-                    {
-                      "key": {
-                        "key": "http.url",
-                        "dataType": "string",
-                        "type": "tag",
-                        "isColumn": false
-                      },
-                      "op": "=",
-                      "value": "https://jomcgi.dev"
-                    }
-                  ],
-                  "op": "AND"
+                "filter": {
+                  "expression": "http.url = 'https://jomcgi.dev'"
                 },
                 "groupBy": [],
                 "order": [],

--- a/overlays/cluster-critical/signoz/signoz-httpcheck-alert.yaml
+++ b/overlays/cluster-critical/signoz/signoz-httpcheck-alert.yaml
@@ -45,20 +45,8 @@ data:
                     "metricName": "httpcheck.status"
                   }
                 ],
-                "filters": {
-                  "items": [
-                    {
-                      "key": {
-                        "key": "http.url",
-                        "dataType": "string",
-                        "type": "tag",
-                        "isColumn": false
-                      },
-                      "op": "=",
-                      "value": "https://signoz.jomcgi.dev"
-                    }
-                  ],
-                  "op": "AND"
+                "filter": {
+                  "expression": "http.url = 'https://signoz.jomcgi.dev'"
                 },
                 "groupBy": [],
                 "order": [],

--- a/overlays/cluster-critical/signoz/trips-pages-httpcheck-alert.yaml
+++ b/overlays/cluster-critical/signoz/trips-pages-httpcheck-alert.yaml
@@ -46,20 +46,8 @@ data:
                     "metricName": "httpcheck.status"
                   }
                 ],
-                "filters": {
-                  "items": [
-                    {
-                      "key": {
-                        "key": "http.url",
-                        "dataType": "string",
-                        "type": "tag",
-                        "isColumn": false
-                      },
-                      "op": "=",
-                      "value": "https://trips.jomcgi.dev"
-                    }
-                  ],
-                  "op": "AND"
+                "filter": {
+                  "expression": "http.url = 'https://trips.jomcgi.dev'"
                 },
                 "groupBy": [],
                 "order": [],

--- a/overlays/dev/marine/marine-httpcheck-alert.yaml
+++ b/overlays/dev/marine/marine-httpcheck-alert.yaml
@@ -45,20 +45,8 @@ data:
                     "metricName": "httpcheck.status"
                   }
                 ],
-                "filters": {
-                  "items": [
-                    {
-                      "key": {
-                        "key": "http.url",
-                        "dataType": "string",
-                        "type": "tag",
-                        "isColumn": false
-                      },
-                      "op": "=",
-                      "value": "https://ships.jomcgi.dev"
-                    }
-                  ],
-                  "op": "AND"
+                "filter": {
+                  "expression": "http.url = 'https://ships.jomcgi.dev'"
                 },
                 "groupBy": [],
                 "order": [],

--- a/overlays/prod/api-gateway/api-gateway-httpcheck-alert.yaml
+++ b/overlays/prod/api-gateway/api-gateway-httpcheck-alert.yaml
@@ -45,20 +45,8 @@ data:
                     "metricName": "httpcheck.status"
                   }
                 ],
-                "filters": {
-                  "items": [
-                    {
-                      "key": {
-                        "key": "http.url",
-                        "dataType": "string",
-                        "type": "tag",
-                        "isColumn": false
-                      },
-                      "op": "=",
-                      "value": "https://api.jomcgi.dev/status.json"
-                    }
-                  ],
-                  "op": "AND"
+                "filter": {
+                  "expression": "http.url = 'https://api.jomcgi.dev/status.json'"
                 },
                 "groupBy": [],
                 "order": [],

--- a/overlays/prod/todo/todo-admin-httpcheck-alert.yaml
+++ b/overlays/prod/todo/todo-admin-httpcheck-alert.yaml
@@ -45,20 +45,8 @@ data:
                     "metricName": "httpcheck.status"
                   }
                 ],
-                "filters": {
-                  "items": [
-                    {
-                      "key": {
-                        "key": "http.url",
-                        "dataType": "string",
-                        "type": "tag",
-                        "isColumn": false
-                      },
-                      "op": "=",
-                      "value": "https://todo-admin.jomcgi.dev"
-                    }
-                  ],
-                  "op": "AND"
+                "filter": {
+                  "expression": "http.url = 'https://todo-admin.jomcgi.dev'"
                 },
                 "groupBy": [],
                 "order": [],

--- a/overlays/prod/todo/todo-httpcheck-alert.yaml
+++ b/overlays/prod/todo/todo-httpcheck-alert.yaml
@@ -45,20 +45,8 @@ data:
                     "metricName": "httpcheck.status"
                   }
                 ],
-                "filters": {
-                  "items": [
-                    {
-                      "key": {
-                        "key": "http.url",
-                        "dataType": "string",
-                        "type": "tag",
-                        "isColumn": false
-                      },
-                      "op": "=",
-                      "value": "https://todo.jomcgi.dev"
-                    }
-                  ],
-                  "op": "AND"
+                "filter": {
+                  "expression": "http.url = 'https://todo.jomcgi.dev'"
                 },
                 "groupBy": [],
                 "order": [],

--- a/overlays/prod/trips/img-httpcheck-alert.yaml
+++ b/overlays/prod/trips/img-httpcheck-alert.yaml
@@ -45,20 +45,8 @@ data:
                     "metricName": "httpcheck.status"
                   }
                 ],
-                "filters": {
-                  "items": [
-                    {
-                      "key": {
-                        "key": "http.url",
-                        "dataType": "string",
-                        "type": "tag",
-                        "isColumn": false
-                      },
-                      "op": "=",
-                      "value": "https://img.jomcgi.dev/health"
-                    }
-                  ],
-                  "op": "AND"
+                "filter": {
+                  "expression": "http.url = 'https://img.jomcgi.dev/health'"
                 },
                 "groupBy": [],
                 "order": [],


### PR DESCRIPTION
## Summary
- Fixes 3 incorrect field names in v5 `QueryBuilderQuery[MetricAggregation]` struct that caused `unknown field` 500 errors from the SigNoz alert API
- `"filters"` → `"filter"` with expression syntax (`{"expression": "http.url = '...'}`)
- `"dataType"` → `"fieldDataType"` and `"type"` → `"fieldContext"` in groupBy keys
- Removes `"isColumn"` (not in v5 `TelemetryFieldKey`)
- Empty filters (node/pod alerts with no criteria) omitted entirely (field is `omitempty`)

## Context
PR #661 migrated alerts to v5 format but used incorrect field names derived from docs. The live SigNoz v0.113 API uses `DisallowUnknownFields()` during JSON deserialization, rejecting unknown fields with 500 errors. Correct field names were determined from the [SigNoz source](https://github.com/SigNoz/signoz/blob/main/pkg/types/querybuildertypes/querybuildertypesv5/builder_query.go) and validated via `execute-builder-query` MCP tool.

## Test plan
- [x] All 22 alert JSON payloads validated
- [x] Filter expression syntax verified via `execute-builder-query` MCP (returns data)
- [x] No remaining `"filters"`, `"dataType"`, `"isColumn"` fields in alert files
- [ ] Sidecar creates all 22 alerts (check `list-alerts` after ArgoCD sync)
- [ ] `get-alert-history` shows evaluation for httpcheck alerts

🤖 Generated with [Claude Code](https://claude.com/claude-code)