### PR TITLE
fix: allow compound cd+git commands in worktree directories

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -19,6 +19,8 @@
   },
   "permissions": {
     "allow": [
+      "Bash(cd /tmp/claude-worktrees:*)",
+      "Bash(cd /private/tmp/claude-worktrees:*)",
       "Bash(git status:*)",
       "Bash(git add:*)",
       "Bash(git commit:*)",


### PR DESCRIPTION
## Summary
- Adds `Bash(cd /tmp/claude-worktrees:*)` and `Bash(cd /private/tmp/claude-worktrees:*)` to Claude Code project permissions
- Fixes unnecessary approval prompts when running compound commands like `cd /tmp/claude-worktrees/foo && git log`
- Covers both `/tmp` and `/private/tmp` (macOS symlink resolution)

## Test plan
- [ ] Start a new Claude Code session in the homelab repo
- [ ] Run a compound command like `cd /tmp/claude-worktrees/<branch> && git log --oneline -10`
- [ ] Verify it auto-approves without prompting

🤖 Generated with [Claude Code](https://claude.com/claude-code)