### PR TITLE
fix: use v5 numeric enum values for alert threshold ops

### DIFF
--- a/overlays/cluster-critical/argocd/argocd-httpcheck-alert.yaml
+++ b/overlays/cluster-critical/argocd/argocd-httpcheck-alert.yaml
@@ -66,7 +66,7 @@ data:
               "target": 1,
               "targetUnit": "",
               "matchType": "5",
-              "op": "<",
+              "op": "2",
               "channels": ["pagerduty-homelab"]
             }
           ]

--- a/overlays/cluster-critical/longhorn/longhorn-httpcheck-alert.yaml
+++ b/overlays/cluster-critical/longhorn/longhorn-httpcheck-alert.yaml
@@ -66,7 +66,7 @@ data:
               "target": 1,
               "targetUnit": "",
               "matchType": "5",
-              "op": "<",
+              "op": "2",
               "channels": ["pagerduty-homelab"]
             }
           ]

--- a/overlays/cluster-critical/signoz/alerts/argocd-app-degraded.yaml
+++ b/overlays/cluster-critical/signoz/alerts/argocd-app-degraded.yaml
@@ -77,7 +77,7 @@ data:
               "target": 0,
               "targetUnit": "",
               "matchType": "1",
-              "op": ">",
+              "op": "1",
               "channels": ["pagerduty-homelab"]
             }
           ]

--- a/overlays/cluster-critical/signoz/alerts/argocd-app-missing.yaml
+++ b/overlays/cluster-critical/signoz/alerts/argocd-app-missing.yaml
@@ -77,7 +77,7 @@ data:
               "target": 0,
               "targetUnit": "",
               "matchType": "1",
-              "op": ">",
+              "op": "1",
               "channels": ["pagerduty-homelab"]
             }
           ]

--- a/overlays/cluster-critical/signoz/alerts/argocd-app-outofsync.yaml
+++ b/overlays/cluster-critical/signoz/alerts/argocd-app-outofsync.yaml
@@ -77,7 +77,7 @@ data:
               "target": 0,
               "targetUnit": "",
               "matchType": "1",
-              "op": ">",
+              "op": "1",
               "channels": ["pagerduty-homelab"]
             }
           ]

--- a/overlays/cluster-critical/signoz/alerts/argocd-app-suspended.yaml
+++ b/overlays/cluster-critical/signoz/alerts/argocd-app-suspended.yaml
@@ -77,7 +77,7 @@ data:
               "target": 0,
               "targetUnit": "",
               "matchType": "1",
-              "op": ">",
+              "op": "1",
               "channels": ["pagerduty-homelab"]
             }
           ]

--- a/overlays/cluster-critical/signoz/alerts/node-disk-pressure.yaml
+++ b/overlays/cluster-critical/signoz/alerts/node-disk-pressure.yaml
@@ -69,7 +69,7 @@ data:
               "target": 0,
               "targetUnit": "",
               "matchType": "3",
-              "op": ">",
+              "op": "1",
               "channels": ["pagerduty-homelab"]
             }
           ]

--- a/overlays/cluster-critical/signoz/alerts/node-memory-pressure.yaml
+++ b/overlays/cluster-critical/signoz/alerts/node-memory-pressure.yaml
@@ -69,7 +69,7 @@ data:
               "target": 0,
               "targetUnit": "",
               "matchType": "3",
-              "op": ">",
+              "op": "1",
               "channels": ["pagerduty-homelab"]
             }
           ]

--- a/overlays/cluster-critical/signoz/alerts/node-not-ready.yaml
+++ b/overlays/cluster-critical/signoz/alerts/node-not-ready.yaml
@@ -69,7 +69,7 @@ data:
               "target": 1,
               "targetUnit": "",
               "matchType": "5",
-              "op": "<",
+              "op": "2",
               "channels": ["pagerduty-homelab"]
             }
           ]

--- a/overlays/cluster-critical/signoz/alerts/node-pid-pressure.yaml
+++ b/overlays/cluster-critical/signoz/alerts/node-pid-pressure.yaml
@@ -69,7 +69,7 @@ data:
               "target": 0,
               "targetUnit": "",
               "matchType": "3",
-              "op": ">",
+              "op": "1",
               "channels": ["pagerduty-homelab"]
             }
           ]

--- a/overlays/cluster-critical/signoz/alerts/pod-oomkilled.yaml
+++ b/overlays/cluster-critical/signoz/alerts/pod-oomkilled.yaml
@@ -82,7 +82,7 @@ data:
               "target": 0,
               "targetUnit": "",
               "matchType": "1",
-              "op": ">",
+              "op": "1",
               "channels": ["pagerduty-homelab"]
             }
           ]

--- a/overlays/cluster-critical/signoz/alerts/pod-pending.yaml
+++ b/overlays/cluster-critical/signoz/alerts/pod-pending.yaml
@@ -73,8 +73,8 @@ data:
               "name": "warning",
               "target": 1,
               "targetUnit": "",
-              "matchType": "15",
-              "op": "=",
+              "matchType": "5",
+              "op": "3",
               "channels": ["pagerduty-homelab"]
             }
           ]

--- a/overlays/cluster-critical/signoz/alerts/pod-restart-rate.yaml
+++ b/overlays/cluster-critical/signoz/alerts/pod-restart-rate.yaml
@@ -74,7 +74,7 @@ data:
               "target": 3,
               "targetUnit": "",
               "matchType": "1",
-              "op": ">",
+              "op": "1",
               "channels": ["pagerduty-homelab"]
             }
           ]

--- a/overlays/cluster-critical/signoz/hikes-httpcheck-alert.yaml
+++ b/overlays/cluster-critical/signoz/hikes-httpcheck-alert.yaml
@@ -67,7 +67,7 @@ data:
               "target": 1,
               "targetUnit": "",
               "matchType": "5",
-              "op": "<",
+              "op": "2",
               "channels": ["pagerduty-homelab"]
             }
           ]

--- a/overlays/cluster-critical/signoz/jomcgi-dev-httpcheck-alert.yaml
+++ b/overlays/cluster-critical/signoz/jomcgi-dev-httpcheck-alert.yaml
@@ -67,7 +67,7 @@ data:
               "target": 1,
               "targetUnit": "",
               "matchType": "5",
-              "op": "<",
+              "op": "2",
               "channels": ["pagerduty-homelab"]
             }
           ]

--- a/overlays/cluster-critical/signoz/signoz-httpcheck-alert.yaml
+++ b/overlays/cluster-critical/signoz/signoz-httpcheck-alert.yaml
@@ -66,7 +66,7 @@ data:
               "target": 1,
               "targetUnit": "",
               "matchType": "5",
-              "op": "<",
+              "op": "2",
               "channels": ["pagerduty-homelab"]
             }
           ]

--- a/overlays/cluster-critical/signoz/trips-pages-httpcheck-alert.yaml
+++ b/overlays/cluster-critical/signoz/trips-pages-httpcheck-alert.yaml
@@ -67,7 +67,7 @@ data:
               "target": 1,
               "targetUnit": "",
               "matchType": "5",
-              "op": "<",
+              "op": "2",
               "channels": ["pagerduty-homelab"]
             }
           ]

--- a/overlays/dev/marine/marine-httpcheck-alert.yaml
+++ b/overlays/dev/marine/marine-httpcheck-alert.yaml
@@ -66,7 +66,7 @@ data:
               "target": 1,
               "targetUnit": "",
               "matchType": "5",
-              "op": "<",
+              "op": "2",
               "channels": ["pagerduty-homelab"]
             }
           ]

--- a/overlays/prod/api-gateway/api-gateway-httpcheck-alert.yaml
+++ b/overlays/prod/api-gateway/api-gateway-httpcheck-alert.yaml
@@ -66,7 +66,7 @@ data:
               "target": 1,
               "targetUnit": "",
               "matchType": "5",
-              "op": "<",
+              "op": "2",
               "channels": ["pagerduty-homelab"]
             }
           ]

--- a/overlays/prod/todo/todo-admin-httpcheck-alert.yaml
+++ b/overlays/prod/todo/todo-admin-httpcheck-alert.yaml
@@ -66,7 +66,7 @@ data:
               "target": 1,
               "targetUnit": "",
               "matchType": "5",
-              "op": "<",
+              "op": "2",
               "channels": ["pagerduty-homelab"]
             }
           ]

--- a/overlays/prod/todo/todo-httpcheck-alert.yaml
+++ b/overlays/prod/todo/todo-httpcheck-alert.yaml
@@ -66,7 +66,7 @@ data:
               "target": 1,
               "targetUnit": "",
               "matchType": "5",
-              "op": "<",
+              "op": "2",
               "channels": ["pagerduty-homelab"]
             }
           ]

--- a/overlays/prod/trips/img-httpcheck-alert.yaml
+++ b/overlays/prod/trips/img-httpcheck-alert.yaml
@@ -66,7 +66,7 @@ data:
               "target": 1,
               "targetUnit": "",
               "matchType": "5",
-              "op": "<",
+              "op": "2",
               "channels": ["pagerduty-homelab"]
             }
           ]


### PR DESCRIPTION
## Summary
- SigNoz v0.113 threshold spec validates `CompareOp` and `MatchType` as numeric string enums, not operator symbols
- Replace `"op": "<"` → `"op": "2"` (ValueIsBelow), `"op": ">"` → `"op": "1"` (ValueIsAbove), `"op": "="` → `"op": "3"` (ValueIsEq)
- Fix `"matchType": "15"` → `"matchType": "5"` (Last) in pod-pending alert

## Context

After merging #664 (field name fixes), the sidecar successfully passed JSON parsing but hit a second validation layer: `invalid rule threshold spec: invalid compare operation: <`. The v5 API uses Go string-typed enums where `CompareOp` values are `"1"`-`"7"` and `MatchType` values are `"1"`-`"5"`, defined in `pkg/types/ruletypes/alerting.go`.

## Enum mapping

| Symbol | v5 Value | Constant |
|--------|----------|----------|
| `>` | `"1"` | ValueIsAbove |
| `<` | `"2"` | ValueIsBelow |
| `=` | `"3"` | ValueIsEq |

| MatchType | Constant |
|-----------|----------|
| `"1"` | AtleastOnce |
| `"3"` | OnAverage |
| `"5"` | Last |

## Test plan
- [ ] Merge and wait for ArgoCD sync + sidecar reconciliation (~5 min)
- [ ] Verify `list-alerts` returns 22 alerts via SigNoz MCP
- [ ] Spot-check alert details via `get-alert` MCP

🤖 Generated with [Claude Code](https://claude.com/claude-code)