### PR TITLE
fix: handle stale alert state after SigNoz reinstall

### DIFF
--- a/charts/signoz-dashboard-sidecar/cmd/main.go
+++ b/charts/signoz-dashboard-sidecar/cmd/main.go
@@ -1090,10 +1090,20 @@ func (s *Sidecar) syncAlert(ctx context.Context, cm *corev1.ConfigMap, forceUpda
 
 	if exists {
 		if err := s.updateAlert(ctx, existing.ID, alert); err != nil {
-			alertSyncTotal.WithLabelValues("sync", "update_error").Inc()
-			return err
+			// If rule was deleted from SigNoz (e.g. after fresh install),
+			// clear stale state and fall through to create below.
+			if strings.Contains(err.Error(), "status 404") {
+				s.logger.Info("Alert not found in SigNoz, recreating",
+					"id", existing.ID, "namespace", cm.Namespace, "name", cm.Name)
+				exists = false
+			} else {
+				alertSyncTotal.WithLabelValues("sync", "update_error").Inc()
+				return err
+			}
 		}
+	}
 
+	if exists {
 		s.stateMu.Lock()
 		s.alertState[uid] = AlertState{
 			ID:          existing.ID,


### PR DESCRIPTION
## Summary
- After a fresh SigNoz install, the sidecar's persisted state ConfigMap (`signoz-dashboard-sidecar-state`) still references old alert rule IDs that no longer exist
- The sidecar tries to PUT (update) these stale IDs, gets 404 "rule not found", and fails
- This fix detects the 404 and falls back to POST (create), allowing the sidecar to self-heal

## Context

After upgrading SigNoz from v0.92 to v0.113 (fresh install via PR #658), the alert sync pipeline hit three successive format issues:
1. **PR #664**: `unknown field "filters"` → fixed field names (`filters` → `filter`, groupBy field names)
2. **PR #667**: `invalid compare operation: <` → fixed threshold enum values (`"<"` → `"2"`, etc.)
3. **This PR**: `rule not found` (404) → handle stale state by falling back to create

## Change

In `syncAlert()`, when `updateAlert()` returns a 404, instead of returning the error:
1. Log that the alert was not found and will be recreated
2. Set `exists = false` to fall through to the create path
3. The create path POSTs a new alert and updates the state with the new ID

## Test plan
- [ ] CI passes (go vet, bazel build)
- [ ] After merge + deploy, verify `list-alerts` returns 22 alerts
- [ ] Verify sidecar logs show "Alert not found in SigNoz, recreating" followed by "Created alert" for each rule

🤖 Generated with [Claude Code](https://claude.com/claude-code)