### PR TITLE
docs(adr): add ADR for static documentation site with rules_vitepress

### DIFF
--- a/architecture/decisions/docs/001-static-docs-site.md
+++ b/architecture/decisions/docs/001-static-docs-site.md
@@ -22,14 +22,15 @@ searchable, navigable format without requiring readers to clone the repo.
 ## Proposal
 
 Use **VitePress** to generate the documentation site, deployed to Cloudflare Pages
-via the existing `rules_wrangler` + Bazel pipeline.
+via the existing `rules_wrangler` + Bazel pipeline. A new **`rules_vitepress`**
+module provides the content assembly and link rewriting layer.
 
 | Aspect | Today | Proposed |
 |--------|-------|----------|
 | Discovery | `grep` / browse GitHub | Search at docs.jomcgi.dev |
 | Navigation | Repository tree | Sidebar + cross-links |
 | Access | Requires repo access | Public static site |
-| Build system | N/A | Bazel (`vite_build` macro) |
+| Build system | N/A | Bazel (`rules_vitepress` + `vite_build` macro) |
 
 ### Why VitePress
 
@@ -64,151 +65,216 @@ result.
 
 ## Architecture
 
-### Content Assembly via Bazel Filegroups
+### `rules_vitepress` Module
 
-The key design question is how to assemble documentation from scattered locations
-into the VitePress source tree at build time. VitePress assumes all content lives
-under one directory — but ours is spread across the repo.
+A custom Bazel rule module that handles content declaration, assembly, link
+rewriting, and site building. It provides two rules:
 
-The approach: use Bazel `filegroup` targets to declare which markdown files
-participate in the docs site, then assemble them into a predictable directory
-structure via a `genrule`. This is the same pattern used by
-`hikes.jomcgi.dev/BUILD` (static filegroup → `wrangler_pages`), extended with an
-assembly step.
+```
+rules_vitepress/
+├── BUILD
+├── defs.bzl            # vitepress_filegroup rule + VitePressContentInfo provider
+├── site.bzl            # vitepress_site macro (assemble → rewrite → build → deploy)
+└── rewriter/
+    ├── BUILD
+    └── rewrite.py      # Link resolution, remapping, and dead link stripping
+```
+
+### `vitepress_filegroup` — Content Declaration
+
+Each content source declares a `vitepress_filegroup` target in its BUILD file.
+This is a custom Bazel rule (not a macro wrapping `filegroup`) that carries a
+`VitePressContentInfo` provider with metadata about where the content should
+appear in the docs site.
+
+```python
+# rules_vitepress/defs.bzl
+
+VitePressContentInfo = provider(
+    fields = {
+        "repo_path": "Source package path in the repo (auto-derived from ctx.label.package)",
+        "vitepress_path": "Output path in the docs site",
+        "files": "Depset of source markdown files",
+    },
+)
+
+def _vitepress_filegroup_impl(ctx):
+    return [
+        DefaultInfo(files = depset(ctx.files.srcs)),
+        VitePressContentInfo(
+            repo_path = ctx.label.package,
+            vitepress_path = ctx.attr.vitepress_path,
+            files = depset(ctx.files.srcs),
+        ),
+    ]
+
+vitepress_filegroup = rule(
+    implementation = _vitepress_filegroup_impl,
+    attrs = {
+        "srcs": attr.label_list(allow_files = [".md"]),
+        "vitepress_path": attr.string(
+            mandatory = True,
+            doc = "Directory path in the docs site where these files are mounted.",
+        ),
+    },
+)
+```
+
+**`repo_path` is derived automatically** from `ctx.label.package` — no user input
+needed. This gives the link rewriter the source-side path for resolving relative
+links. `vitepress_path` is the user-specified destination in the docs site.
+
+Usage across the repo:
+
+```python
+# architecture/BUILD
+load("//rules_vitepress:defs.bzl", "vitepress_filegroup")
+
+vitepress_filegroup(
+    name = "docs",
+    srcs = glob(["*.md"]) + glob(["decisions/**/*.md"]),
+    vitepress_path = "architecture",
+    visibility = ["//websites/docs.jomcgi.dev:__pkg__"],
+)
+# architecture/security.md              → architecture/security.md
+# architecture/decisions/docs/001-*.md  → architecture/decisions/docs/001-*.md
+```
+
+```python
+# services/ships_api/BUILD
+vitepress_filegroup(
+    name = "docs",
+    srcs = ["README.md"],
+    vitepress_path = "services/ships-api",
+)
+# services/ships_api/README.md → services/ships-api/README.md
+```
+
+```python
+# operators/BUILD
+vitepress_filegroup(
+    name = "docs",
+    srcs = glob(["*.md"]),
+    vitepress_path = "operators",
+)
+```
+
+**Why a custom rule, not a tagged `filegroup`**: A plain `filegroup` with
+`tags = ["docs"]` cannot carry structured metadata like `vitepress_path`.
+A custom rule with a provider gives the aggregation rule type-safe access
+to the path mapping, which the link rewriter needs. This also means Bazel's
+dependency graph naturally tracks which content sources are included — adding
+a `vitepress_filegroup` is an explicit opt-in act.
+
+### `vitepress_site` — Aggregation and Build
+
+The `vitepress_site` macro in `websites/docs.jomcgi.dev/BUILD` lists all
+content sources, assembles them, rewrites links, builds with VitePress, and
+wires up deployment.
+
+```python
+# websites/docs.jomcgi.dev/BUILD
+load("//rules_vitepress:site.bzl", "vitepress_site")
+
+vitepress_site(
+    name = "docs",
+    content = [
+        "//architecture:docs",
+        "//services/ships_api:docs",
+        "//operators:docs",
+    ],
+    wrangler_project = "docs-jomcgi-dev",
+)
+```
+
+This macro expands to the following pipeline:
 
 ```mermaid
 graph LR
     subgraph Sources
-        A[architecture/*.md]
-        B[services/*/README.md]
-        C[charts/*/README.md]
-        D[operators/*.md]
+        A["//architecture:docs"]
+        B["//services/ships_api:docs"]
+        C["//operators:docs"]
     end
 
-    subgraph Bazel
-        F[filegroup targets]
-        G[genrule: assemble]
-        H[vite_build: VitePress]
+    subgraph rules_vitepress
+        D[assemble]
+        E[generate path map]
+        F[rewrite links]
+    end
+
+    subgraph Build
+        G[vite_build: VitePress]
     end
 
     subgraph Deploy
-        I[wrangler_pages]
-        J[docs.jomcgi.dev]
+        H[wrangler_pages]
+        I[docs.jomcgi.dev]
     end
 
-    A & B & C & D --> F
-    F --> G --> H --> I --> J
+    A & B & C --> D
+    A & B & C --> E
+    D & E --> F --> G --> H --> I
 ```
 
-Each source directory exports a `filegroup`:
+Internally, `vitepress_site` creates these targets:
 
-```python
-# architecture/BUILD
-filegroup(
-    name = "docs",
-    srcs = glob(["*.md"]) + glob(["decisions/**/*.md"]),
-    visibility = ["//websites/docs.jomcgi.dev:__pkg__"],
-)
+1. **`:assemble`** — Collects files from each `vitepress_filegroup` dep, copies
+   them into a directory tree using each target's `vitepress_path` as the
+   destination prefix. Preserves internal directory structure beneath the prefix.
+2. **`:path_map`** — Generates a JSON mapping from all `VitePressContentInfo`
+   providers: `{ "repo_path": "vitepress_path", ... }`.
+3. **`:rewrite`** — Runs `rewrite.py` against the assembled tree using the path
+   map. Outputs the rewritten content directory.
+4. **`:build`** — `vite_build` with VitePress against the rewritten content.
+5. **`:docs.push`** — `wrangler_pages` deployment to Cloudflare Pages.
+
+### Link Rewriter
+
+Authors write standard relative markdown links that work on GitHub. The build-time
+rewriter translates them for the docs site. This means the same markdown renders
+correctly in both GitHub and the docs site.
+
+The rewriter (`rules_vitepress/rewriter/rewrite.py`) processes every `.md` file
+in the assembled tree through a three-step pipeline:
+
+| Step | Operation | On failure |
+|------|-----------|------------|
+| **Resolve** | Relative path → full repo path | Warn (malformed link) |
+| **Remap** | Full repo path → vitepress path via path map | No mapping → strip link |
+| **Validate** | Check file exists in assembled tree | Missing → strip link |
+
+**Resolve**: Uses the file's `repo_path` (from `VitePressContentInfo`) to resolve
+relative links. A link `../services/ships_api/README.md` in a file at repo path
+`architecture/services.md` resolves to `services/ships_api/README.md`.
+
+**Remap**: Looks up the resolved repo path in the path map. If
+`services/ships_api` maps to `services/ships-api`, the link becomes
+`/services/ships-api/README.md`.
+
+**Validate**: Confirms the target file exists in the assembled tree. If the link
+points to a file not included in any `vitepress_filegroup` (e.g., `.claude/AGENTS.md`),
+the link is stripped — the display text is preserved but the link markup is removed.
+
+Example transformations:
+
+```markdown
+# In architecture/services.md (repo source)
+
+See the [Ships API](../services/ships_api/README.md) for details.
+# → See the [Ships API](/services/ships-api/README.md) for details.
+
+Read about [agent capabilities](../.claude/AGENTS.md) for context.
+# → Read about agent capabilities for context.
+#    (link stripped — .claude/AGENTS.md not in any vitepress_filegroup)
 ```
 
-A `genrule` in `websites/docs.jomcgi.dev/BUILD` copies these into VitePress's
-expected structure:
+Stripped links produce build warnings (not errors) so the build does not block
+on references to unpublished content:
 
-```python
-genrule(
-    name = "assemble_docs",
-    srcs = [
-        "//architecture:docs",
-        "//services/ships_api:docs",
-        "//charts/longhorn:docs",
-        # ...
-    ],
-    outs = ["assembled"],
-    cmd = """
-        mkdir -p $@/architecture $@/services $@/charts
-        cp $(locations //architecture:docs) $@/architecture/
-        cp $(locations //services/ships_api:docs) $@/services/ships-api/
-        # ...
-    """,
-)
 ```
-
-**Why filegroups, not glob-all**: This gives full control over what lands on the
-public site. Only files explicitly named in a `filegroup`'s `srcs` are included —
-an allowlist model. Files like `.claude/AGENTS.md` (internal agent capabilities),
-`.claude/skills/` (prompt engineering), and `docs/plans/` (ephemeral design
-documents) stay excluded by default. When a new content source should be published,
-it requires adding a `filegroup` export and an assembly line — a deliberate act, not
-an accidental inclusion.
-
-**Why genrule over a custom Starlark rule**: A `genrule` with shell `cp` is
-sufficient for Phase 1 where the assembly is a flat copy per content area. The
-trade-off is that nested directory structures (e.g., `decisions/agents/001-*.md`)
-require explicit `mkdir -p` per subdirectory. If the assembly grows beyond ~10
-sources or needs path rewriting (e.g., renaming directories during copy), a custom
-Starlark rule would give better control. Start with genrule, migrate if it gets
-unwieldy.
-
-### Build Target Structure
-
-The BUILD file follows the same pattern as `trips.jomcgi.dev/BUILD` and
-`jomcgi.dev/BUILD` — both use `vite_build` + `wrangler_pages`:
-
-```python
-# websites/docs.jomcgi.dev/BUILD
-load("@npm//websites/docs.jomcgi.dev:vitepress/package_json.bzl", vitepress_bin = "bin")
-load("@npm//websites/docs.jomcgi.dev:wrangler/package_json.bzl", wrangler_bin = "bin")
-load("//rules_wrangler:defs.bzl", "wrangler_pages")
-load("//tools/js:vite_build.bzl", "vite_build")
-
-# VitePress binary
-vitepress_bin.vitepress_binary(name = "vitepress")
-
-# Wrangler binary for Cloudflare Pages deployment
-wrangler_bin.wrangler_binary(name = "wrangler")
-
-# Assemble markdown from across the repo into VitePress source tree
-genrule(
-    name = "assemble_docs",
-    srcs = [
-        "//architecture:docs",
-        # Phase 2: add services, charts, operators filegroups
-    ],
-    outs = ["assembled"],
-    cmd = """
-        mkdir -p $@/architecture $@/architecture/decisions/agents $@/architecture/decisions/docs
-        cp $(locations //architecture:docs) $@/architecture/
-    """,
-)
-
-# Build docs site — VitePress wraps Vite, so vite_build macro works directly.
-# --outDir dist normalises output from .vitepress/dist to dist/ for the macro.
-vite_build(
-    name = "build",
-    srcs = [":assemble_docs"] + glob([".vitepress/**/*"]),
-    build_args = ["build", "--outDir", "dist"],
-    config = None,  # VitePress auto-discovers .vitepress/config.js
-    tool = ":vitepress",
-    visibility = ["//visibility:public"],
-    deps = ["vitepress"],
-)
-
-# Cloudflare Pages deployment
-wrangler_pages(
-    name = "docs",
-    dist = ":build_dist",
-    project_name = "docs-jomcgi-dev",
-    visibility = ["//websites:__pkg__"],
-    wrangler = ":wrangler",
-)
+WARNING: architecture/services.md:42 — link to .claude/AGENTS.md stripped (not in docs site)
 ```
-
-**`vite_build` macro compatibility**: The macro (`tools/js/vite_build.bzl`) creates
-three targets: `:node_modules`, `:src` (js_library), and `:build` (js_run_binary).
-It accepts any tool binary — `jomcgi.dev` passes `:astro`, `trips.jomcgi.dev` passes
-`:vite`, and this site passes `:vitepress`. The `build_args` parameter overrides the
-default `["build"]` to add `--outDir dist`, which makes VitePress write output to
-the standard `dist/` directory instead of `.vitepress/dist`. No macro changes needed.
 
 ### Deployment
 
@@ -222,13 +288,17 @@ Same pattern as all other websites in this repo:
 
 ## Implementation
 
-### Phase 1: MVP — VitePress scaffold + architecture docs
+### Phase 1: `rules_vitepress` + architecture docs
 
+- [ ] Create `rules_vitepress/defs.bzl` with `vitepress_filegroup` rule and
+      `VitePressContentInfo` provider
+- [ ] Create `rules_vitepress/site.bzl` with `vitepress_site` macro
+      (assemble + path map + rewrite + vite_build + wrangler_pages)
+- [ ] Create `rules_vitepress/rewriter/rewrite.py` — link rewriting script
+- [ ] Add `vitepress_filegroup` target in `architecture/BUILD`
 - [ ] Add `vitepress` to pnpm workspace (`websites/docs.jomcgi.dev/package.json`)
 - [ ] Create VitePress config (`.vitepress/config.js`) with basic theme and nav
-- [ ] Add `filegroup` targets in `architecture/BUILD` for markdown exports
-- [ ] Create `websites/docs.jomcgi.dev/BUILD` with `vite_build` + `wrangler_pages`
-- [ ] Write assembly `genrule` for architecture docs
+- [ ] Create `websites/docs.jomcgi.dev/BUILD` using `vitepress_site`
 - [ ] Add static index page (`websites/docs.jomcgi.dev/index.md`)
 - [ ] Verify `bazel build //websites/docs.jomcgi.dev:build` produces working output
 - [ ] Create Cloudflare Pages project `docs-jomcgi-dev`
@@ -237,29 +307,35 @@ Same pattern as all other websites in this repo:
 
 ### Phase 2: Expand content sources
 
-- [ ] Add `filegroup` exports for `services/*/` READMEs
-- [ ] Add `filegroup` exports for `charts/*/` READMEs
-- [ ] Add `filegroup` exports for `operators/` docs
-- [ ] Expand assembly genrule to include all sources
+- [ ] Add `vitepress_filegroup` targets for `services/*/` READMEs
+- [ ] Add `vitepress_filegroup` targets for `charts/*/` READMEs
+- [ ] Add `vitepress_filegroup` targets for `operators/` docs
+- [ ] Add new content targets to `vitepress_site` content list
 - [ ] Configure VitePress sidebar to reflect full content tree
 - [ ] Add search (VitePress built-in local search)
 
 ### Phase 3: Polish
 
 - [ ] Custom theme / branding alignment with jomcgi.dev
-- [ ] Cross-reference links between docs (architecture -> service -> chart)
 - [ ] ADR index page (auto-generated from `architecture/decisions/`)
 - [ ] Add to CLAUDE.md as documentation reference
+- [ ] Gazelle extension for auto-discovering `vitepress_filegroup` targets
+      (replaces manual `content` list in `vitepress_site`)
 
 ---
 
 ## Security
 
-No sensitive content should be published. The `filegroup` approach provides an
-explicit allowlist — only files named in `srcs` are included. This is safer than
-a glob-everything approach where secrets or internal notes could leak.
+No sensitive content should be published. The `vitepress_filegroup` approach
+provides an explicit allowlist — only packages that declare a `vitepress_filegroup`
+target and are listed in the `vitepress_site` content list are included. This is
+safer than a glob-everything approach where secrets or internal notes could leak.
 
-Content to exclude:
+The link rewriter provides a second safety layer: even if a markdown file references
+excluded content via relative links, those links are stripped during build rather
+than producing broken links on the public site.
+
+Content that must remain excluded:
 
 | Path | Reason |
 |------|--------|
@@ -270,8 +346,6 @@ Content to exclude:
 | `advent_of_code/` | Puzzle solutions, not homelab docs |
 | `websites/jomcgi.dev/src/assets/cv.md` | Personal CV, not homelab docs |
 
-Review the content of each exported filegroup before adding it to the assembly.
-
 ---
 
 ## Risks
@@ -279,9 +353,10 @@ Review the content of each exported filegroup before adding it to the assembly.
 | Risk | Likelihood | Impact | Mitigation |
 |------|-----------|--------|------------|
 | VitePress breaking changes | Low | Low | Pin version in package.json, Bazel ensures hermetic builds |
-| Stale docs on site | Medium | Medium | CI rebuilds on every push to main; genrule deps track source files |
-| Accidental secret publication | Low | High | Explicit filegroup allowlist, no glob-all patterns |
-| Bazel genrule complexity for assembly | Medium | Low | Start simple (Phase 1 = architecture only), expand incrementally |
+| Stale docs on site | Medium | Medium | CI rebuilds on every push to main; Bazel deps track source files |
+| Accidental secret publication | Low | High | Explicit `vitepress_filegroup` allowlist, link stripping for excluded content |
+| Link rewriter misses edge cases | Medium | Low | Warnings on stripped links surface issues; relative links still work on GitHub as fallback |
+| `rules_vitepress` maintenance overhead | Low | Low | Small surface area (~3 files), follows existing `rules_wrangler` patterns |
 
 ---
 
@@ -289,6 +364,9 @@ Review the content of each exported filegroup before adding it to the assembly.
 
 1. Should ADRs render with their full implementation checklists, or should those
    be stripped for the public-facing version?
+2. Should `vitepress_site` support a `strict` mode that fails the build on
+   stripped links instead of warning? Useful for enforcing complete cross-references
+   once all content sources are added.
 
 ---
 
@@ -298,7 +376,8 @@ Review the content of each exported filegroup before adding it to the assembly.
 |----------|-----------|
 | [VitePress docs](https://vitepress.dev) | Framework documentation |
 | `tools/js/vite_build.bzl` | Existing Vite build macro — framework-agnostic, supports VitePress directly |
-| `rules_wrangler/defs.bzl` | CF Pages deployment rule |
+| `rules_wrangler/defs.bzl` | CF Pages deployment rule — `rules_vitepress` follows same patterns |
+| `rules_wrangler/gazelle/` | Reference for future gazelle extension (Phase 3) |
 | `websites/trips.jomcgi.dev/BUILD` | Reference: Vite + `vite_build` macro + `wrangler_pages` |
 | `websites/jomcgi.dev/BUILD` | Reference: Astro (wraps Vite) + `vite_build` macro + `wrangler_pages` |
-| `websites/hikes.jomcgi.dev/BUILD` | Reference: static `filegroup` -> `wrangler_pages` (no build step) |
+| `websites/hikes.jomcgi.dev/BUILD` | Reference: static `filegroup` → `wrangler_pages` (no build step) |


### PR DESCRIPTION
## Summary

- Adds ADR-001 to the `docs` decision category proposing VitePress for a static documentation site at `docs.jomcgi.dev`
- Designs a `rules_vitepress` Bazel module with two rules:
  - **`vitepress_filegroup`** — declares content sources with a `vitepress_path` for docs site placement and auto-derived `repo_path` for link resolution
  - **`vitepress_site`** — aggregates content, rewrites relative markdown links, builds with VitePress, and deploys via `wrangler_pages`
- Build-time link rewriter resolves relative links (preserving GitHub compatibility), remaps paths, validates targets exist, and strips links to excluded content with warnings

## Key design decisions

- **Custom rule over tagged filegroups**: `vitepress_filegroup` carries a `VitePressContentInfo` provider with structured metadata — plain `filegroup` tags can't do this
- **Link rewriting over lint enforcement**: Authors write natural relative links that work on GitHub; the build translates them for the docs site. Links to excluded content are stripped (not broken)
- **Warn-not-fail for stripped links**: Build warns on dead links rather than failing, since not all referenced content will be published (especially in early phases)

## Test plan

- [ ] Verify ADR renders correctly on GitHub
- [ ] Confirm `vitepress_filegroup` rule design is compatible with Bazel rule semantics
- [ ] Validate `vitepress_site` macro can compose `vite_build` + `wrangler_pages`
- [ ] Review link rewriter edge cases (anchors, external URLs, image links)

🤖 Generated with [Claude Code](https://claude.com/claude-code)