### PR TITLE
fix: add legacy threshold fields for SigNoz v0.113 alert evaluation

### DIFF
--- a/overlays/cluster-critical/argocd/argocd-httpcheck-alert.yaml
+++ b/overlays/cluster-critical/argocd/argocd-httpcheck-alert.yaml
@@ -58,6 +58,10 @@ data:
           "queryType": "builder"
         },
         "selectedQueryName": "A",
+        "op": "2",
+        "target": 1,
+        "matchType": "5",
+        "targetUnit": "",
         "thresholds": {
           "kind": "basic",
           "spec": [

--- a/overlays/cluster-critical/longhorn/longhorn-httpcheck-alert.yaml
+++ b/overlays/cluster-critical/longhorn/longhorn-httpcheck-alert.yaml
@@ -58,6 +58,10 @@ data:
           "queryType": "builder"
         },
         "selectedQueryName": "A",
+        "op": "2",
+        "target": 1,
+        "matchType": "5",
+        "targetUnit": "",
         "thresholds": {
           "kind": "basic",
           "spec": [

--- a/overlays/cluster-critical/signoz/alerts/argocd-app-degraded.yaml
+++ b/overlays/cluster-critical/signoz/alerts/argocd-app-degraded.yaml
@@ -69,6 +69,10 @@ data:
           "queryType": "builder"
         },
         "selectedQueryName": "A",
+        "op": "1",
+        "target": 0,
+        "matchType": "1",
+        "targetUnit": "",
         "thresholds": {
           "kind": "basic",
           "spec": [

--- a/overlays/cluster-critical/signoz/alerts/argocd-app-missing.yaml
+++ b/overlays/cluster-critical/signoz/alerts/argocd-app-missing.yaml
@@ -69,6 +69,10 @@ data:
           "queryType": "builder"
         },
         "selectedQueryName": "A",
+        "op": "1",
+        "target": 0,
+        "matchType": "1",
+        "targetUnit": "",
         "thresholds": {
           "kind": "basic",
           "spec": [

--- a/overlays/cluster-critical/signoz/alerts/argocd-app-outofsync.yaml
+++ b/overlays/cluster-critical/signoz/alerts/argocd-app-outofsync.yaml
@@ -69,6 +69,10 @@ data:
           "queryType": "builder"
         },
         "selectedQueryName": "A",
+        "op": "1",
+        "target": 0,
+        "matchType": "1",
+        "targetUnit": "",
         "thresholds": {
           "kind": "basic",
           "spec": [

--- a/overlays/cluster-critical/signoz/alerts/argocd-app-suspended.yaml
+++ b/overlays/cluster-critical/signoz/alerts/argocd-app-suspended.yaml
@@ -69,6 +69,10 @@ data:
           "queryType": "builder"
         },
         "selectedQueryName": "A",
+        "op": "1",
+        "target": 0,
+        "matchType": "1",
+        "targetUnit": "",
         "thresholds": {
           "kind": "basic",
           "spec": [

--- a/overlays/cluster-critical/signoz/alerts/node-disk-pressure.yaml
+++ b/overlays/cluster-critical/signoz/alerts/node-disk-pressure.yaml
@@ -61,6 +61,10 @@ data:
           "queryType": "builder"
         },
         "selectedQueryName": "A",
+        "op": "1",
+        "target": 0,
+        "matchType": "3",
+        "targetUnit": "",
         "thresholds": {
           "kind": "basic",
           "spec": [

--- a/overlays/cluster-critical/signoz/alerts/node-memory-pressure.yaml
+++ b/overlays/cluster-critical/signoz/alerts/node-memory-pressure.yaml
@@ -61,6 +61,10 @@ data:
           "queryType": "builder"
         },
         "selectedQueryName": "A",
+        "op": "1",
+        "target": 0,
+        "matchType": "3",
+        "targetUnit": "",
         "thresholds": {
           "kind": "basic",
           "spec": [

--- a/overlays/cluster-critical/signoz/alerts/node-not-ready.yaml
+++ b/overlays/cluster-critical/signoz/alerts/node-not-ready.yaml
@@ -61,6 +61,10 @@ data:
           "queryType": "builder"
         },
         "selectedQueryName": "A",
+        "op": "2",
+        "target": 1,
+        "matchType": "5",
+        "targetUnit": "",
         "thresholds": {
           "kind": "basic",
           "spec": [

--- a/overlays/cluster-critical/signoz/alerts/node-pid-pressure.yaml
+++ b/overlays/cluster-critical/signoz/alerts/node-pid-pressure.yaml
@@ -61,6 +61,10 @@ data:
           "queryType": "builder"
         },
         "selectedQueryName": "A",
+        "op": "1",
+        "target": 0,
+        "matchType": "3",
+        "targetUnit": "",
         "thresholds": {
           "kind": "basic",
           "spec": [

--- a/overlays/cluster-critical/signoz/alerts/pod-oomkilled.yaml
+++ b/overlays/cluster-critical/signoz/alerts/pod-oomkilled.yaml
@@ -74,6 +74,10 @@ data:
           "queryType": "builder"
         },
         "selectedQueryName": "A",
+        "op": "1",
+        "target": 0,
+        "matchType": "1",
+        "targetUnit": "",
         "thresholds": {
           "kind": "basic",
           "spec": [

--- a/overlays/cluster-critical/signoz/alerts/pod-pending.yaml
+++ b/overlays/cluster-critical/signoz/alerts/pod-pending.yaml
@@ -66,6 +66,10 @@ data:
           "queryType": "builder"
         },
         "selectedQueryName": "A",
+        "op": "3",
+        "target": 1,
+        "matchType": "5",
+        "targetUnit": "",
         "thresholds": {
           "kind": "basic",
           "spec": [

--- a/overlays/cluster-critical/signoz/alerts/pod-restart-rate.yaml
+++ b/overlays/cluster-critical/signoz/alerts/pod-restart-rate.yaml
@@ -66,6 +66,10 @@ data:
           "queryType": "builder"
         },
         "selectedQueryName": "A",
+        "op": "1",
+        "target": 3,
+        "matchType": "1",
+        "targetUnit": "",
         "thresholds": {
           "kind": "basic",
           "spec": [

--- a/overlays/cluster-critical/signoz/hikes-httpcheck-alert.yaml
+++ b/overlays/cluster-critical/signoz/hikes-httpcheck-alert.yaml
@@ -59,6 +59,10 @@ data:
           "queryType": "builder"
         },
         "selectedQueryName": "A",
+        "op": "2",
+        "target": 1,
+        "matchType": "5",
+        "targetUnit": "",
         "thresholds": {
           "kind": "basic",
           "spec": [

--- a/overlays/cluster-critical/signoz/jomcgi-dev-httpcheck-alert.yaml
+++ b/overlays/cluster-critical/signoz/jomcgi-dev-httpcheck-alert.yaml
@@ -59,6 +59,10 @@ data:
           "queryType": "builder"
         },
         "selectedQueryName": "A",
+        "op": "2",
+        "target": 1,
+        "matchType": "5",
+        "targetUnit": "",
         "thresholds": {
           "kind": "basic",
           "spec": [

--- a/overlays/cluster-critical/signoz/signoz-httpcheck-alert.yaml
+++ b/overlays/cluster-critical/signoz/signoz-httpcheck-alert.yaml
@@ -58,6 +58,10 @@ data:
           "queryType": "builder"
         },
         "selectedQueryName": "A",
+        "op": "2",
+        "target": 1,
+        "matchType": "5",
+        "targetUnit": "",
         "thresholds": {
           "kind": "basic",
           "spec": [

--- a/overlays/cluster-critical/signoz/trips-pages-httpcheck-alert.yaml
+++ b/overlays/cluster-critical/signoz/trips-pages-httpcheck-alert.yaml
@@ -59,6 +59,10 @@ data:
           "queryType": "builder"
         },
         "selectedQueryName": "A",
+        "op": "2",
+        "target": 1,
+        "matchType": "5",
+        "targetUnit": "",
         "thresholds": {
           "kind": "basic",
           "spec": [

--- a/overlays/dev/marine/marine-httpcheck-alert.yaml
+++ b/overlays/dev/marine/marine-httpcheck-alert.yaml
@@ -58,6 +58,10 @@ data:
           "queryType": "builder"
         },
         "selectedQueryName": "A",
+        "op": "2",
+        "target": 1,
+        "matchType": "5",
+        "targetUnit": "",
         "thresholds": {
           "kind": "basic",
           "spec": [

--- a/overlays/prod/api-gateway/api-gateway-httpcheck-alert.yaml
+++ b/overlays/prod/api-gateway/api-gateway-httpcheck-alert.yaml
@@ -58,6 +58,10 @@ data:
           "queryType": "builder"
         },
         "selectedQueryName": "A",
+        "op": "2",
+        "target": 1,
+        "matchType": "5",
+        "targetUnit": "",
         "thresholds": {
           "kind": "basic",
           "spec": [

--- a/overlays/prod/todo/todo-admin-httpcheck-alert.yaml
+++ b/overlays/prod/todo/todo-admin-httpcheck-alert.yaml
@@ -58,6 +58,10 @@ data:
           "queryType": "builder"
         },
         "selectedQueryName": "A",
+        "op": "2",
+        "target": 1,
+        "matchType": "5",
+        "targetUnit": "",
         "thresholds": {
           "kind": "basic",
           "spec": [

--- a/overlays/prod/todo/todo-httpcheck-alert.yaml
+++ b/overlays/prod/todo/todo-httpcheck-alert.yaml
@@ -58,6 +58,10 @@ data:
           "queryType": "builder"
         },
         "selectedQueryName": "A",
+        "op": "2",
+        "target": 1,
+        "matchType": "5",
+        "targetUnit": "",
         "thresholds": {
           "kind": "basic",
           "spec": [

--- a/overlays/prod/trips/img-httpcheck-alert.yaml
+++ b/overlays/prod/trips/img-httpcheck-alert.yaml
@@ -58,6 +58,10 @@ data:
           "queryType": "builder"
         },
         "selectedQueryName": "A",
+        "op": "2",
+        "target": 1,
+        "matchType": "5",
+        "targetUnit": "",
         "thresholds": {
           "kind": "basic",
           "spec": [


### PR DESCRIPTION
## Summary

- Adds legacy threshold fields (`op`, `target`, `matchType`, `targetUnit`) at the condition level in all 22 alert ConfigMaps
- Fixes nil pointer panics during SigNoz alert evaluation caused by missing threshold data

## Root cause

SigNoz v0.113's `PostableRule.UnmarshalJSON()` calls `processRuleDefaults()` which:
1. Defaults `schemaVersion` to `"v1"` (our alerts set `"version": "v5"` but not `"schemaVersion"`)
2. For v1 schema: **overwrites** `condition.Thresholds` with values derived from legacy fields (`condition.op`, `condition.target`, `condition.matchType`)
3. Our alerts only had threshold values inside `condition.thresholds.spec[]` (v5 format), NOT at the condition level
4. Result: `BasicRuleThreshold.TargetValue` is nil → panic during `threshold.target()` evaluation

```
panic during threshold rule evaluation
panic: runtime error: invalid memory address or nil pointer dereference
  BasicRuleThreshold.target (threshold.go:215)
  → BasicRuleThreshold.shouldAlert (threshold.go:262)
    → BasicRuleThresholds.Eval (threshold.go:130)
```

## Fix

Add legacy fields directly on the condition object, mirroring the values from `thresholds.spec[0]`:

```json
"condition": {
  "compositeQuery": { ... },
  "selectedQueryName": "A",
  "op": "2",
  "target": 1,
  "matchType": "5",
  "targetUnit": "",
  "thresholds": {
    "kind": "basic",
    "spec": [{ "op": "2", "target": 1, "matchType": "5", ... }]
  }
}
```

## Threshold values by alert category

| Category | Count | op | target | matchType | Meaning |
|----------|-------|----|--------|-----------|---------|
| httpcheck | 11 | 2 (below) | 1 | 5 (last) | Status below 1 = down |
| argocd | 4 | 1 (above) | 0 | 1 (at least once) | Count > 0 = issue |
| node conditions | 3 | 1 (above) | 0 | 3 (on average) | Pressure > 0 |
| node-not-ready | 1 | 2 (below) | 1 | 5 (last) | Ready < 1 = not ready |
| pod-oomkilled | 1 | 1 (above) | 0 | 1 (at least once) | Restarts > 0 |
| pod-pending | 1 | 3 (equals) | 1 | 5 (last) | Phase = 1 (Pending) |
| pod-restart-rate | 1 | 1 (above) | 3 | 1 (at least once) | Restarts > 3 |

## Test plan

- [ ] Merge PR, wait for ArgoCD sync (~1 min)
- [ ] Wait for sidecar reconciliation (~5 min) to push updated alerts to SigNoz
- [ ] Verify panics stop in SigNoz query service logs
- [ ] Check `list-alerts` returns alerts (may need MCP tool fix separately)
- [ ] Check `get-alert-history` shows evaluation entries for httpcheck alerts

🤖 Generated with [Claude Code](https://claude.com/claude-code)