### PR TITLE
fix(mcp-servers): use minimal stable selectorLabels to fix sync

### DIFF
--- a/charts/mcp-servers/templates/_helpers.tpl
+++ b/charts/mcp-servers/templates/_helpers.tpl
@@ -11,11 +11,11 @@ helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | 
 
 {{/*
 Selector labels for a server.
-Usage: {{- include "mcp-servers.selectorLabels" (dict "server" . "Release" $.Release) }}
+Minimal and stable — selectors are immutable after Deployment creation.
+Usage: {{- include "mcp-servers.selectorLabels" .server }}
 */}}
 {{- define "mcp-servers.selectorLabels" -}}
-app.kubernetes.io/name: {{ .server.name }}
-app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/name: {{ .name }}
 {{- end }}
 
 {{/*

--- a/charts/mcp-servers/templates/deployment.yaml
+++ b/charts/mcp-servers/templates/deployment.yaml
@@ -10,11 +10,11 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      {{- include "mcp-servers.selectorLabels" (dict "server" . "Release" $.Release) | nindent 6 }}
+      {{- include "mcp-servers.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       labels:
-        {{- include "mcp-servers.selectorLabels" (dict "server" . "Release" $.Release) | nindent 8 }}
+        {{- include "mcp-servers.selectorLabels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ .name }}
       securityContext:

--- a/charts/mcp-servers/templates/registration-job.yaml
+++ b/charts/mcp-servers/templates/registration-job.yaml
@@ -19,7 +19,7 @@ spec:
       annotations:
         linkerd.io/inject: disabled
       labels:
-        {{- include "mcp-servers.selectorLabels" (dict "server" . "Release" $.Release) | nindent 8 }}
+        {{- include "mcp-servers.selectorLabels" . | nindent 8 }}
     spec:
       restartPolicy: OnFailure
       securityContext:

--- a/charts/mcp-servers/templates/service.yaml
+++ b/charts/mcp-servers/templates/service.yaml
@@ -14,5 +14,5 @@ spec:
       protocol: TCP
       name: mcp
   selector:
-    {{- include "mcp-servers.selectorLabels" (dict "server" . "Release" $.Release) | nindent 4 }}
+    {{- include "mcp-servers.selectorLabels" . | nindent 4 }}
 {{- end }}


### PR DESCRIPTION
## Summary

- Removes `app.kubernetes.io/instance` from `selectorLabels` to fix ArgoCD sync failure
- Kubernetes `spec.selector.matchLabels` is immutable — the old signoz-mcp Deployment has `{name: signoz-mcp, instance: signoz-mcp}` and the new chart was trying to set `{name: signoz-mcp, instance: mcp-servers}`
- Keeps `instance` in common metadata labels (for tooling) but not in the immutable selector

## Post-merge steps

After this PR merges, run these commands to clean up the old resources:

```bash
# 1. Delete the orphaned ArgoCD Application (doesn't cascade-delete resources)
argocd app delete prod-signoz-mcp --cascade=false

# 2. Delete the existing Deployment so ArgoCD recreates it with new selectors
kubectl delete deploy signoz-mcp -n mcp-servers
```

ArgoCD auto-sync will recreate the Deployment with the correct single-label selector.

## Test plan

- [x] `bazel test //charts/mcp-servers:lint_test` passes
- [x] `bazel test //overlays/prod/mcp-servers:template_test` passes
- [ ] ArgoCD sync succeeds after post-merge cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)