### PR TITLE
fix(mcp-servers): delete gateway registration by ID, not name

### DIFF
--- a/charts/mcp-servers/templates/registration-job.yaml
+++ b/charts/mcp-servers/templates/registration-job.yaml
@@ -69,9 +69,17 @@ spec:
               print(jwt.encode(payload, os.environ.get('JWT_SECRET_KEY', ''), algorithm='HS256'))
               ")
 
-              # Idempotent: delete existing, then re-register
-              curl -sf -X DELETE "{{ $.Values.gateway.url }}/gateways/{{ .name }}" \
-                -H "Authorization: Bearer ${TOKEN}" || true
+              # Idempotent: look up existing gateway by name, delete by ID, then re-register.
+              # The gateway API requires the UUID for deletion, not the name.
+              EXISTING_ID=$(curl -sf "{{ $.Values.gateway.url }}/gateways" \
+                -H "Authorization: Bearer ${TOKEN}" \
+                | python3 -c "import sys,json; gws=json.load(sys.stdin); print(next((g['id'] for g in gws if g['name']=='{{ .name }}'),''))")
+
+              if [ -n "${EXISTING_ID}" ]; then
+                echo "Deleting existing registration ${EXISTING_ID}..."
+                curl -sf -X DELETE "{{ $.Values.gateway.url }}/gateways/${EXISTING_ID}" \
+                  -H "Authorization: Bearer ${TOKEN}"
+              fi
 
               echo "Registering {{ .name }}..."
               curl -sf -X POST "{{ $.Values.gateway.url }}/gateways" \


### PR DESCRIPTION
## Summary
- The Context Forge gateway API requires a UUID for `DELETE /gateways/{id}`, not the gateway name
- The registration job was calling `DELETE /gateways/signoz-mcp` which returned 404 (silently swallowed by `|| true`)
- The subsequent `POST /gateways` then failed with **409 Conflict** (`"Gateway name already exists"`) because the old registration was never removed
- Fix: list all gateways, find the matching ID by name, then delete by ID before re-registering

## Test plan
- [x] Manually reproduced the 404 DELETE + 409 POST failure from a debug pod
- [x] Confirmed the gateway API returns UUIDs as IDs (e.g. `f887b059c9a5452395b10c19f82a3b2e`)
- [ ] ArgoCD will sync and re-run the registration hook — verify the job succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)