### PR TITLE
fix(mcp-servers): skip registration when gateway already exists

### DIFF
--- a/charts/mcp-servers/templates/registration-job.yaml
+++ b/charts/mcp-servers/templates/registration-job.yaml
@@ -69,29 +69,26 @@ spec:
               print(jwt.encode(payload, os.environ.get('JWT_SECRET_KEY', ''), algorithm='HS256'))
               ")
 
-              # Idempotent: look up existing gateway by name, delete by ID, then re-register.
-              # The gateway API requires the UUID for deletion, not the name.
+              # Idempotent: skip registration if the gateway already exists.
               EXISTING_ID=$(curl -sf "{{ $.Values.gateway.url }}/gateways" \
                 -H "Authorization: Bearer ${TOKEN}" \
                 | python3 -c "import sys,json; gws=json.load(sys.stdin); print(next((g['id'] for g in gws if g['name']=='{{ .name }}'),''))")
 
               if [ -n "${EXISTING_ID}" ]; then
-                echo "Deleting existing registration ${EXISTING_ID}..."
-                curl -sf -X DELETE "{{ $.Values.gateway.url }}/gateways/${EXISTING_ID}" \
-                  -H "Authorization: Bearer ${TOKEN}"
+                echo "{{ .name }} already registered (${EXISTING_ID}), skipping."
+              else
+                echo "Registering {{ .name }}..."
+                curl -sf -X POST "{{ $.Values.gateway.url }}/gateways" \
+                  -H "Authorization: Bearer ${TOKEN}" \
+                  -H "Content-Type: application/json" \
+                  -d '{
+                    "name": "{{ .name }}",
+                    "url": "http://{{ .name }}.{{ $.Release.Namespace }}.svc.cluster.local:{{ include "mcp-servers.port" . }}/mcp",
+                    "transport": "{{ .registration.transport | default "STREAMABLEHTTP" }}"
+                  }'
+                echo ""
               fi
 
-              echo "Registering {{ .name }}..."
-              curl -sf -X POST "{{ $.Values.gateway.url }}/gateways" \
-                -H "Authorization: Bearer ${TOKEN}" \
-                -H "Content-Type: application/json" \
-                -d '{
-                  "name": "{{ .name }}",
-                  "url": "http://{{ .name }}.{{ $.Release.Namespace }}.svc.cluster.local:{{ include "mcp-servers.port" . }}/mcp",
-                  "transport": "{{ .registration.transport | default "STREAMABLEHTTP" }}"
-                }'
-
-              echo ""
               echo "Registration complete."
           envFrom:
             - secretRef:


### PR DESCRIPTION
## Summary
- Follow-up to #675 — the previous fix deleted and re-created the gateway registration on every ArgoCD sync
- Now checks if the registration already exists and skips if so
- Only POSTs a new registration when the gateway name is absent

## Test plan
- [ ] ArgoCD syncs the hook — job should log "already registered, skipping" and exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)