### PR TITLE
fix(mcp-servers): add writableTmp for buildbuddy-mcp startup

### DIFF
--- a/charts/mcp-servers/templates/deployment.yaml
+++ b/charts/mcp-servers/templates/deployment.yaml
@@ -44,10 +44,16 @@ spec:
             - name: mcp
               containerPort: {{ .translate.port | default 8080 }}
               protocol: TCP
-          {{- with .env }}
           env:
+            {{- if .writableTmp }}
+            - name: HOME
+              value: /tmp
+            - name: UV_CACHE_DIR
+              value: /tmp/.uv-cache
+            {{- end }}
+            {{- with .env }}
             {{- toYaml . | nindent 12 }}
-          {{- end }}
+            {{- end }}
           {{- if .secret }}
           envFrom:
             - secretRef:
@@ -55,9 +61,14 @@ spec:
           {{- end }}
           securityContext:
             allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
+            readOnlyRootFilesystem: {{ not .writableTmp }}
             capabilities:
               drop: ["ALL"]
+          {{- if .writableTmp }}
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+          {{- end }}
           {{- with .translate.resources | default (dict "requests" (dict "cpu" "10m" "memory" "64Mi") "limits" (dict "cpu" "100m" "memory" "128Mi")) }}
           resources:
             {{- toYaml . | nindent 12 }}
@@ -80,10 +91,16 @@ spec:
             - name: mcp
               containerPort: {{ required "port is required when translate is disabled" .port }}
               protocol: TCP
-          {{- with .env }}
           env:
+            {{- if .writableTmp }}
+            - name: HOME
+              value: /tmp
+            - name: UV_CACHE_DIR
+              value: /tmp/.uv-cache
+            {{- end }}
+            {{- with .env }}
             {{- toYaml . | nindent 12 }}
-          {{- end }}
+            {{- end }}
           {{- if .secret }}
           envFrom:
             - secretRef:
@@ -91,9 +108,14 @@ spec:
           {{- end }}
           securityContext:
             allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
+            readOnlyRootFilesystem: {{ not .writableTmp }}
             capabilities:
               drop: ["ALL"]
+          {{- if .writableTmp }}
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+          {{- end }}
           {{- if .resources }}
           resources:
             {{- toYaml .resources | nindent 12 }}
@@ -109,4 +131,9 @@ spec:
             initialDelaySeconds: 5
             periodSeconds: 10
         {{- end }}
+      {{- if .writableTmp }}
+      volumes:
+        - name: tmp
+          emptyDir: {}
+      {{- end }}
 {{- end }}

--- a/overlays/prod/mcp-servers/values.yaml
+++ b/overlays/prod/mcp-servers/values.yaml
@@ -38,6 +38,7 @@ servers:
       repository: ghcr.io/jomcgi/homelab/services/buildbuddy-mcp
       tag: "main"
     port: 8000
+    writableTmp: true
     env:
       - name: BUILDBUDDY_URL
         value: "https://app.buildbuddy.io"


### PR DESCRIPTION
## Summary
- Add per-server `writableTmp` option to the mcp-servers chart deployment template
- When enabled: mounts `emptyDir` at `/tmp`, sets `HOME=/tmp` + `UV_CACHE_DIR=/tmp/.uv-cache`, disables `readOnlyRootFilesystem`
- Enable it for `buildbuddy-mcp` which uses `aspect_rules_py` (creates venvs at runtime)

## Context
BuildBuddy MCP server fails on startup with:
```
Unable to create base venv directory: Read-only file system (os error 30)
```
This is a known limitation of `aspect_rules_py` — the Python binary bootstraps a venv at runtime. The same pattern (`writableTmp` + emptyDir) is used by `trips`, `knowledge-graph`, and `marine` charts.

## Test plan
- [ ] `helm template mcp-servers charts/mcp-servers/ -f overlays/prod/mcp-servers/values.yaml` renders correctly
- [ ] signoz-mcp retains `readOnlyRootFilesystem: true` (no `writableTmp`)
- [ ] buildbuddy-mcp gets emptyDir volume, HOME/UV_CACHE_DIR env vars, `readOnlyRootFilesystem: false`
- [ ] After merge, verify buildbuddy-mcp pod starts successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)