### PR TITLE
fix(mcp-servers): drop runAsNonRoot for aspect_rules_py servers

### DIFF
--- a/charts/mcp-servers/templates/deployment.yaml
+++ b/charts/mcp-servers/templates/deployment.yaml
@@ -18,8 +18,10 @@ spec:
     spec:
       serviceAccountName: {{ .name }}
       securityContext:
+        {{- if not .writableTmp }}
         runAsNonRoot: true
         runAsUser: 65532
+        {{- end }}
         seccompProfile:
           type: RuntimeDefault
       containers:


### PR DESCRIPTION
## Summary
- Make pod-level `runAsNonRoot`/`runAsUser: 65532` conditional on `writableTmp`
- When `writableTmp: true`, the pod runs as root (matching trips-api, knowledge-graph pattern)

## Root cause
`aspect_rules_py` creates Python venvs in the **binary's installation directory** at runtime — a root-owned path baked into the image. Running as uid 65532 causes "Permission denied" even with `readOnlyRootFilesystem: false`.

The previous fix (PR #679) only addressed the read-only filesystem error. This fixes the permission error that remained.

## Security posture for writableTmp servers
Still hardened via container-level securityContext:
- `allowPrivilegeEscalation: false`
- `capabilities.drop: ["ALL"]`
- `seccompProfile: RuntimeDefault`

Servers without `writableTmp` (e.g., signoz-mcp) retain full non-root enforcement.

## Test plan
- [ ] `helm template` shows `runAsNonRoot`/`runAsUser` only for signoz-mcp, not buildbuddy-mcp
- [ ] After merge, buildbuddy-mcp pod starts successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)