### PR TITLE
fix(image-updater): correct namePattern to match prefixed ArgoCD app names

### DIFF
--- a/charts/mcp-servers/templates/imageupdater.yaml
+++ b/charts/mcp-servers/templates/imageupdater.yaml
@@ -20,7 +20,7 @@ spec:
             helm:
               name: servers[{{ $index }}].image.repository
               tag: servers[{{ $index }}].image.tag
-      namePattern: {{ $.Release.Name }}
+      namePattern: {{ $.Values.imageUpdater.applicationName | default $.Release.Name }}
   namespace: argocd
   writeBackConfig:
     method: git:secret:{{ $.Values.imageUpdater.gitSecret }}

--- a/charts/mcp-servers/values.yaml
+++ b/charts/mcp-servers/values.yaml
@@ -26,6 +26,7 @@ imageUpdater:
   gitRepository: "https://github.com/jomcgi/homelab.git"
   gitBranch: "main"
   gitSecret: "argocd/argocd-image-updater-token"
+  applicationName: "" # ArgoCD Application name (defaults to release name)
   writeBackTarget: "" # required if any server has imageUpdater.enabled
 
 # MCP servers to deploy

--- a/overlays/prod/knowledge-graph/imageupdater.yaml
+++ b/overlays/prod/knowledge-graph/imageupdater.yaml
@@ -33,7 +33,7 @@ spec:
             helm:
               name: mcp.image.repository
               tag: mcp.image.tag
-      namePattern: knowledge-graph
+      namePattern: prod-knowledge-graph
   namespace: argocd
   writeBackConfig:
     method: git:secret:argocd/argocd-image-updater-token

--- a/overlays/prod/mcp-servers/values.yaml
+++ b/overlays/prod/mcp-servers/values.yaml
@@ -1,4 +1,5 @@
 imageUpdater:
+  applicationName: "prod-mcp-servers"
   writeBackTarget: "helmvalues:../../overlays/prod/mcp-servers/values.yaml"
 
 servers:


### PR DESCRIPTION
## Summary
- Kustomize `namePrefix: prod-` transforms `Application` `metadata.name` but not the `namePattern` field inside `ImageUpdater` CRD specs
- This caused the image updater to match **0 applications** for `mcp-servers-buildbuddy-mcp` and `prod-knowledge-graph`, silently skipping digest updates every 2-minute reconcile cycle
- Adds `applicationName` override to the mcp-servers chart template (defaults to release name for backwards compatibility)
- Sets `applicationName: prod-mcp-servers` in the prod overlay
- Fixes knowledge-graph `namePattern` from `knowledge-graph` to `prod-knowledge-graph`

## Evidence
Image updater logs showed the issue clearly:
```
considering 0 application(s) for update  imageUpdater_name=mcp-servers-buildbuddy-mcp
considering 0 application(s) for update  imageUpdater_name=prod-knowledge-graph
```

## Test plan
- [ ] CI passes (format check + tests)
- [ ] After merge, verify image updater logs show `considering 1 application(s)` for both `mcp-servers-buildbuddy-mcp` and `prod-knowledge-graph`
- [ ] Confirm automatic update commits appear for buildbuddy-mcp within ~5 minutes

🤖 Generated with [Claude Code](https://claude.com/claude-code)