### PR TITLE
fix(oci): add PYTHONPATH to py3_image for py_venv_binary compatibility

### DIFF
--- a/tools/oci/py3_image.bzl
+++ b/tools/oci/py3_image.bzl
@@ -26,9 +26,11 @@ def py3_image(name, binary, root = "/", layer_groups = {}, env = {}, workdir = N
     binary_path = "{}{}/{}".format(root, binary.package, binary.name)
     runfiles_dir = "{}.runfiles".format(binary_path)
     repo_name = binary.repo_name or "_main"
+    workspace_root = "{}/{}".format(runfiles_dir, repo_name)
     env = dict({
         "BAZEL_WORKSPACE": repo_name,
         "RUNFILES_DIR": runfiles_dir,
+        "PYTHONPATH": workspace_root,
     }, **env)
 
     if multi_platform:
@@ -44,7 +46,7 @@ def py3_image(name, binary, root = "/", layer_groups = {}, env = {}, workdir = N
             ),
             entrypoint = [binary_path],
             env = env,
-            workdir = workdir or "{}/{}".format(runfiles_dir, repo_name),
+            workdir = workdir or workspace_root,
         )
         platform_transition_filegroup(
             name = name + "_amd64",
@@ -64,7 +66,7 @@ def py3_image(name, binary, root = "/", layer_groups = {}, env = {}, workdir = N
             ),
             entrypoint = [binary_path],
             env = env,
-            workdir = workdir or "{}/{}".format(runfiles_dir, repo_name),
+            workdir = workdir or workspace_root,
         )
         platform_transition_filegroup(
             name = name + "_arm64",
@@ -108,7 +110,7 @@ def py3_image(name, binary, root = "/", layer_groups = {}, env = {}, workdir = N
             ),
             entrypoint = [binary_path],
             env = env,
-            workdir = workdir or "{}/{}".format(runfiles_dir, repo_name),
+            workdir = workdir or workspace_root,
         )
         platform_transition_filegroup(
             name = name,


### PR DESCRIPTION
## Summary
- `py_venv_binary` entrypoint runs `venv/bin/python -B script.py`, which only adds the script's directory to `sys.path` — not the runfiles workspace root
- This breaks all workspace-rooted imports (`services.X.Y`) in containers, causing `ModuleNotFoundError: No module named 'services'`
- Adds `PYTHONPATH` env var pointing to the runfiles workspace root in `py3_image.bzl`
- Fixes buildbuddy-mcp CrashLoopBackOff (and any other py_venv_binary service with cross-package imports)

## Root cause
```
# py_binary (old) — Bazel stub adds workspace root to sys.path ✓
# py_venv_binary (new) — venv Python only gets script dir + site-packages ✗

$ python -B /app/main.runfiles/_main/services/buildbuddy_mcp/app/main.py
# sys.path[0] = /app/main.runfiles/_main/services/buildbuddy_mcp/app/
# Missing: /app/main.runfiles/_main/  ← workspace root needed for "import services.X"
```

## Test plan
- [x] `bazel test //services/buildbuddy_mcp/...` — all 3 tests pass
- [ ] CI passes
- [ ] After merge, buildbuddy-mcp pod exits CrashLoopBackOff and starts serving

🤖 Generated with [Claude Code](https://claude.com/claude-code)