### PR TITLE
fix(image-updater): strip digest from imageName to prevent update loop

### DIFF
--- a/charts/mcp-servers/templates/imageupdater.yaml
+++ b/charts/mcp-servers/templates/imageupdater.yaml
@@ -15,7 +15,7 @@ spec:
           commonUpdateSettings:
             updateStrategy: {{ $server.imageUpdater.strategy | default "digest" }}
             forceUpdate: {{ $server.imageUpdater.forceUpdate | default false }}
-          imageName: {{ $server.image.repository }}:{{ $server.image.tag }}
+          imageName: {{ $server.image.repository }}:{{ regexReplaceAll "@sha256:.*" $server.image.tag "" }}
           manifestTargets:
             helm:
               name: servers[{{ $index }}].image.repository


### PR DESCRIPTION
## Summary
- After the first image updater writeback, the resolved digest (e.g. `main@sha256:abc...`) gets baked into the `tag` field in values.yaml
- On the next ArgoCD sync, the chart template interpolates this full string into the ImageUpdater CRD's `imageName`, creating a pinned reference that can never have a "newer" digest — permanently halting future updates
- Fix: strip `@sha256:...` suffix with `regexReplaceAll` so `imageName` always references the mutable tag

## Test plan
- [ ] Verify `helm template` renders `imageName` with just the base tag (no digest suffix)
- [ ] Confirm image updater picks up the new buildbuddy-mcp digest after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)