### PR TITLE
feat(argocd): add mcp-agent account for MCP server

### DIFF
--- a/charts/argocd/values.yaml
+++ b/charts/argocd/values.yaml
@@ -1,3 +1,13 @@
 globals:
   logging:
     format: json
+
+argo-cd:
+  configs:
+    cm:
+      accounts.mcp-agent: apiKey
+    rbac:
+      policy.csv: |
+        p, mcp-agent, applications, *, */*, allow
+        p, mcp-agent, projects, get, *, allow
+        p, mcp-agent, clusters, get, *, allow


### PR DESCRIPTION
## Summary
- Add `mcp-agent` local account to ArgoCD with `apiKey` capability
- Configure RBAC policy granting full application management and read access to projects/clusters
- Used by the `argocd-mcp` server deployed in PR #690

## Context
The `argocd-mcp` MCP server needs an API token to interact with ArgoCD. The `admin` account doesn't allow API key generation, so this creates a dedicated service account.

These values were previously applied via `kubectl patch` but got reverted by ArgoCD's `selfHeal`. This PR makes them persistent via GitOps.

## Test plan
- [ ] CI passes
- [ ] After merge: verify `argocd-rbac-cm` contains the policy
- [ ] After merge: generate API token for `mcp-agent` via ArgoCD UI
- [ ] Store token in 1Password at `vaults/k8s-homelab/items/argocd-mcp`

🤖 Generated with [Claude Code](https://claude.com/claude-code)