### PR TITLE
fix(knowledge-graph): increase memory and remove CPU limits for mcp/scraper

### DIFF
--- a/charts/knowledge-graph/values.yaml
+++ b/charts/knowledge-graph/values.yaml
@@ -13,10 +13,9 @@ scraper:
   resources:
     requests:
       cpu: 10m
-      memory: 128Mi
+      memory: 256Mi
     limits:
-      cpu: 10m
-      memory: 128Mi
+      memory: 256Mi
 
 # --- CronJob (batch scrape) ---
 cronjob:
@@ -64,10 +63,9 @@ mcp:
   resources:
     requests:
       cpu: 10m
-      memory: 128Mi
+      memory: 256Mi
     limits:
-      cpu: 10m
-      memory: 128Mi
+      memory: 256Mi
 
 # --- Shared ---
 imagePullSecret:


### PR DESCRIPTION
## Summary
- Both `knowledge-graph-mcp` and `knowledge-graph-scraper` deployments have been in CrashLoopBackOff since Feb 26 (585 and 1,840 restarts respectively)
- Root cause: 10m CPU limit (request == limit, Guaranteed QoS) left no burst headroom — containers can't initialize before the liveness probe kills them (exit code 137)
- Removes CPU limits to allow burst during startup, increases memory requests/limits from 128Mi to 256Mi

## Test plan
- [ ] CI passes (helm template renders correctly without `limits.cpu`)
- [ ] After merge, verify ArgoCD syncs and new pods start successfully
- [ ] Confirm both deployments reach Healthy status and old Rev:4 ReplicaSets scale down

🤖 Generated with [Claude Code](https://claude.com/claude-code)