### PR TITLE
fix(otel): use Instrumentation CR names in annotations

### DIFF
--- a/overlays/dev/grimoire/values.yaml
+++ b/overlays/dev/grimoire/values.yaml
@@ -32,7 +32,7 @@ frontend:
 wsGateway:
   cfAccessTeam: jomcgi.cloudflareaccess.com
   podAnnotations:
-    instrumentation.opentelemetry.io/inject-go: "true"
+    instrumentation.opentelemetry.io/inject-go: "go"
   image:
     repository: ghcr.io/jomcgi/homelab/services/grimoire-ws-gateway
     tag: main@sha256:97807a194e6e619e6215cdd092e793724dc598dfc8d3079eb475600c2162bd23

--- a/overlays/dev/marine/values.yaml
+++ b/overlays/dev/marine/values.yaml
@@ -40,7 +40,7 @@ ingest:
   # Pre-populate OTEL annotation to match Kyverno injection (prevents ArgoCD drift)
   podAnnotations:
     otel.injected-by: kyverno/inject-otel-env-vars
-    instrumentation.opentelemetry.io/inject-python: "true"
+    instrumentation.opentelemetry.io/inject-python: "python"
 # Ships API component
 api:
   image:
@@ -70,7 +70,7 @@ api:
   # Pre-populate OTEL annotation to match Kyverno injection (prevents ArgoCD drift)
   podAnnotations:
     otel.injected-by: kyverno/inject-otel-env-vars
-    instrumentation.opentelemetry.io/inject-python: "true"
+    instrumentation.opentelemetry.io/inject-python: "python"
 frontend:
   image:
     repository: ghcr.io/jomcgi/homelab/services/ships_frontend
@@ -86,4 +86,4 @@ frontend:
   # Pre-populate OTEL annotation to match Kyverno injection (prevents ArgoCD drift)
   podAnnotations:
     otel.injected-by: kyverno/inject-otel-env-vars
-    instrumentation.opentelemetry.io/inject-nodejs: "true"
+    instrumentation.opentelemetry.io/inject-nodejs: "nodejs"

--- a/overlays/dev/stargazer/values.yaml
+++ b/overlays/dev/stargazer/values.yaml
@@ -68,4 +68,4 @@ imagePullSecrets:
 # Pre-populate OTEL annotation to match Kyverno injection (prevents ArgoCD drift)
 podAnnotations:
   otel.injected-by: kyverno/inject-otel-env-vars
-  instrumentation.opentelemetry.io/inject-python: "true"
+  instrumentation.opentelemetry.io/inject-python: "python"

--- a/overlays/prod/knowledge-graph/values.yaml
+++ b/overlays/prod/knowledge-graph/values.yaml
@@ -5,7 +5,7 @@ scraper:
   image:
     tag: main
   podAnnotations:
-    instrumentation.opentelemetry.io/inject-python: "true"
+    instrumentation.opentelemetry.io/inject-python: "python"
 
 embedder:
   image:
@@ -15,7 +15,7 @@ mcp:
   image:
     tag: main
   podAnnotations:
-    instrumentation.opentelemetry.io/inject-python: "true"
+    instrumentation.opentelemetry.io/inject-python: "python"
 
 seaweedfs:
   endpoint: http://seaweedfs-s3.seaweedfs.svc.cluster.local:8333

--- a/overlays/prod/mcp-servers/values.yaml
+++ b/overlays/prod/mcp-servers/values.yaml
@@ -8,7 +8,7 @@ servers:
     tag: "v0.0.5"
   port: 8000
   podAnnotations:
-    instrumentation.opentelemetry.io/inject-python: "true"
+    instrumentation.opentelemetry.io/inject-python: "python"
   env:
   - name: SIGNOZ_URL
     value: "http://signoz.signoz.svc.cluster.local:8080"
@@ -40,7 +40,7 @@ servers:
     tag: "main@sha256:bdbfff85ced097cf2d51973328c805d8252be19ccca4410231613e100ec3c883"
   port: 8000
   podAnnotations:
-    instrumentation.opentelemetry.io/inject-python: "true"
+    instrumentation.opentelemetry.io/inject-python: "python"
   writableTmp: true
   env:
   - name: BUILDBUDDY_URL

--- a/overlays/prod/todo/values.yaml
+++ b/overlays/prod/todo/values.yaml
@@ -14,7 +14,7 @@ image:
   tag: main@sha256:2c899988b5bf38120be654213f422b76883f9a63a0a5df36766619fa0081e492
   repository: ghcr.io/jomcgi/homelab/charts/todo
 podAnnotations:
-  instrumentation.opentelemetry.io/inject-go: "true"
+  instrumentation.opentelemetry.io/inject-go: "go"
 # Prefer to schedule on the same node to avoid volume reattachment delays
 affinity:
   podAffinity:

--- a/overlays/prod/trips/values.yaml
+++ b/overlays/prod/trips/values.yaml
@@ -12,4 +12,4 @@ api:
     repository: ghcr.io/jomcgi/homelab/services/trips_api
     tag: main # Use branch tag from CI
   podAnnotations:
-    instrumentation.opentelemetry.io/inject-python: "true"
+    instrumentation.opentelemetry.io/inject-python: "python"


### PR DESCRIPTION
## Summary
- Changes all `instrumentation.opentelemetry.io/inject-<lang>` annotation values from `"true"` to the specific Instrumentation CR name (`"python"`, `"go"`, `"nodejs"`)
- Fixes OTEL operator error: `"multiple OpenTelemetry Instrumentation instances available, cannot determine which one to select"`
- When multiple Instrumentation CRs exist per namespace (one per language), the operator requires the CR name to disambiguate

## Test plan
- [x] `bazel test //overlays/...` — all 54 tests pass
- [ ] Verify operator logs no longer show "multiple instances" error after ArgoCD syncs
- [ ] Verify OTEL init containers are injected into restarted pods


🤖 Generated with [Claude Code](https://claude.com/claude-code)