### PR TITLE
test(oci): add automatic config validation for py3_image

### DIFF
--- a/tools/oci/BUILD
+++ b/tools/oci/BUILD
@@ -13,6 +13,7 @@ exports_files(
     [
         "apko_push.sh.tpl",
         "verify-apko-lock.sh",
+        "verify-py3-image.sh",
     ],
     visibility = ["//visibility:public"],
 )
@@ -36,6 +37,7 @@ bzl_library(
         "@aspect_bazel_lib//lib:transitions",
         "@aspect_rules_py//py:defs",
         "@rules_oci//oci:defs",
+        "@rules_shell//shell:rules_bzl",
     ],
 )
 

--- a/tools/oci/py3_image.bzl
+++ b/tools/oci/py3_image.bzl
@@ -4,6 +4,7 @@ load("@aspect_bazel_lib//lib:expand_template.bzl", "expand_template")
 load("@aspect_bazel_lib//lib:transitions.bzl", "platform_transition_filegroup")
 load("@aspect_rules_py//py:defs.bzl", "py_image_layer")
 load("@rules_oci//oci:defs.bzl", "oci_image", "oci_image_index", "oci_load", "oci_push")
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
 
 def py3_image(name, binary, root = "/", layer_groups = {}, env = {}, workdir = None, base = "@python_base", repository = None, visibility = ["//images:__pkg__"], multi_platform = True):
     """Create a multi-platform Python 3 image from a Python binary.
@@ -150,6 +151,17 @@ def py3_image(name, binary, root = "/", layer_groups = {}, env = {}, workdir = N
         stamp_substitutions = {
             "{STABLE_IMAGE_TAG}": "{{STABLE_IMAGE_TAG}}",
         },
+    )
+
+    # Verify image config has correct Python runtime environment.
+    # Tests one platform (amd64) since the config is identical across architectures.
+    sh_test(
+        name = name + "_config_test",
+        srcs = ["//tools/oci:verify-py3-image.sh"],
+        args = ["$(rootpath {})".format(
+            name + "_base_amd64" if multi_platform else name + "_image",
+        )],
+        data = [name + "_base_amd64" if multi_platform else name + "_image"],
     )
 
     # Push uses the index for multi-platform, or platform-specific for single platform

--- a/tools/oci/verify-py3-image.sh
+++ b/tools/oci/verify-py3-image.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# verify-py3-image.sh — Verify Python OCI image has correct runtime configuration.
+#
+# Inspects the OCI image config blob to ensure PYTHONPATH, RUNFILES_DIR, and
+# entrypoint are set. This catches packaging regressions where py_venv_binary
+# images ship without the environment needed to locate Python modules.
+#
+# Usage: verify-py3-image.sh <image_dir>
+set -euo pipefail
+
+IMAGE_DIR="$1"
+
+if [ ! -d "$IMAGE_DIR" ]; then
+	echo "FAIL: Image directory not found: $IMAGE_DIR" >&2
+	exit 1
+fi
+
+exec python3 -c '
+import json, os, sys
+
+image_dir = sys.argv[1]
+
+# Walk the OCI layout: index.json -> manifest -> config
+with open(os.path.join(image_dir, "index.json")) as f:
+    index = json.load(f)
+
+manifest_ref = index["manifests"][0]["digest"]
+algo, digest = manifest_ref.split(":", 1)
+with open(os.path.join(image_dir, "blobs", algo, digest)) as f:
+    manifest = json.load(f)
+
+config_ref = manifest["config"]["digest"]
+algo, digest = config_ref.split(":", 1)
+with open(os.path.join(image_dir, "blobs", algo, digest)) as f:
+    config = json.load(f)
+
+container = config.get("config", {})
+env_list = container.get("Env", [])
+entrypoint = container.get("Entrypoint", [])
+env = dict(e.split("=", 1) for e in env_list)
+
+errors = []
+
+if "PYTHONPATH" not in env:
+    errors.append("PYTHONPATH not set in image environment")
+elif not env["PYTHONPATH"]:
+    errors.append("PYTHONPATH is empty")
+
+if "RUNFILES_DIR" not in env:
+    errors.append("RUNFILES_DIR not set in image environment")
+
+if not entrypoint:
+    errors.append("No entrypoint configured")
+
+if errors:
+    for e in errors:
+        print(f"FAIL: {e}", file=sys.stderr)
+    sys.exit(1)
+
+print("PASS: entrypoint=" + str(entrypoint))
+print("PASS: PYTHONPATH=" + env["PYTHONPATH"])
+print("PASS: RUNFILES_DIR=" + env["RUNFILES_DIR"])
+' "$IMAGE_DIR"


### PR DESCRIPTION
## Summary
- Adds a `_config_test` target auto-generated by the `py3_image` macro that inspects the OCI image config blob
- Verifies `PYTHONPATH`, `RUNFILES_DIR`, and `Entrypoint` are correctly set in every Python container image
- Runs as part of `bazel test //...` — no per-service configuration needed

## Context
After migrating to `py_venv_binary`, the trips-api entered CrashLoopBackOff because the container image was missing `PYTHONPATH` in its environment. The fix (setting `PYTHONPATH` in `py3_image.bzl`) was already committed, but there was no test to catch this class of regression.

This test would have caught the issue before the broken image was pushed.

## Test plan
- [x] All 9 existing Python image config tests pass locally
- [ ] CI passes on BuildBuddy

🤖 Generated with [Claude Code](https://claude.com/claude-code)