### PR TITLE
feat(otel): enable Go eBPF auto-instrumentation

### DIFF
--- a/charts/grimoire/templates/ws-gateway-deployment.yaml
+++ b/charts/grimoire/templates/ws-gateway-deployment.yaml
@@ -28,9 +28,6 @@ spec:
       {{- end }}
       serviceAccountName: {{ include "grimoire.serviceAccountName" . }}
       securityContext:
-        runAsNonRoot: true
-        runAsUser: 65532
-        runAsGroup: 65532
         seccompProfile:
           type: RuntimeDefault
       containers:
@@ -58,6 +55,9 @@ spec:
                   key: redis_password
           securityContext:
             allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            runAsUser: 65532
+            runAsGroup: 65532
             capabilities:
               drop:
                 - ALL

--- a/overlays/dev/grimoire/values.yaml
+++ b/overlays/dev/grimoire/values.yaml
@@ -33,6 +33,7 @@ wsGateway:
   cfAccessTeam: jomcgi.cloudflareaccess.com
   podAnnotations:
     instrumentation.opentelemetry.io/inject-go: "go"
+    instrumentation.opentelemetry.io/otel-go-auto-target-exe: "/opt/app"
   image:
     repository: ghcr.io/jomcgi/homelab/services/grimoire-ws-gateway
     tag: main@sha256:97807a194e6e619e6215cdd092e793724dc598dfc8d3079eb475600c2162bd23

--- a/overlays/prod/todo/values.yaml
+++ b/overlays/prod/todo/values.yaml
@@ -15,6 +15,7 @@ image:
   repository: ghcr.io/jomcgi/homelab/charts/todo
 podAnnotations:
   instrumentation.opentelemetry.io/inject-go: "go"
+  instrumentation.opentelemetry.io/otel-go-auto-target-exe: "/opt/app"
 # Prefer to schedule on the same node to avoid volume reattachment delays
 affinity:
   podAffinity:


### PR DESCRIPTION
## Summary
- Adds `instrumentation.opentelemetry.io/otel-go-auto-target-exe: "/opt/app"` annotation to grimoire-ws-gateway and todo deployments
- Moves `runAsNonRoot`/`runAsUser`/`runAsGroup` from pod-level to container-level on grimoire ws-gateway so the eBPF sidecar (needs `privileged: true` + `runAsUser: 0`) can coexist with the non-root app container
- Todo already has no pod-level security context, so only the annotation is needed

## Context
Go auto-instrumentation uses eBPF to attach to compiled binaries at runtime. Unlike Python/Node.js which hook into the language interpreter, the Go agent needs:
1. The target executable path (`otel-go-auto-target-exe` annotation)
2. A privileged sidecar running as root (injected by the OTEL operator)

## Test plan
- [x] `bazel test //overlays/dev/grimoire:template_test //overlays/prod/todo:template_test` — pass
- [x] Verified rendered template shows correct security context placement
- [ ] Verify Go eBPF sidecar is injected after ArgoCD sync
- [ ] Verify traces appear in SigNoz from ws-gateway and todo


🤖 Generated with [Claude Code](https://claude.com/claude-code)