### PR TITLE
fix(otel): use HTTP OTLP port for Go eBPF instrumentation

### DIFF
--- a/charts/opentelemetry-operator/templates/instrumentation-go.yaml
+++ b/charts/opentelemetry-operator/templates/instrumentation-go.yaml
@@ -8,7 +8,7 @@ metadata:
   namespace: {{ . }}
 spec:
   exporter:
-    endpoint: {{ $.Values.instrumentation.endpoint }}
+    endpoint: {{ $.Values.instrumentation.go.endpoint | default $.Values.instrumentation.endpoint }}
   propagators:
   {{- range $.Values.instrumentation.propagators }}
     - {{ . }}

--- a/charts/opentelemetry-operator/values.yaml
+++ b/charts/opentelemetry-operator/values.yaml
@@ -28,3 +28,5 @@ instrumentation:
     enabled: false
   go:
     enabled: false
+    # Go eBPF agent uses HTTP OTLP (not gRPC), so it needs port 4318
+    endpoint: ""

--- a/overlays/cluster-critical/opentelemetry-operator/values.yaml
+++ b/overlays/cluster-critical/opentelemetry-operator/values.yaml
@@ -8,6 +8,7 @@ instrumentation:
     enabled: true
   go:
     enabled: true
+    endpoint: http://signoz-k8s-infra-otel-agent.signoz.svc.cluster.local:4318
   # Namespaces to deploy Instrumentation CRs into
   namespaces:
     # Production


### PR DESCRIPTION
## Summary
- Go eBPF auto-instrumentation agent uses HTTP OTLP (not gRPC), so it needs port 4318 instead of 4317
- Adds per-language endpoint override to the Go Instrumentation CR template (`go.endpoint` falls back to the shared `endpoint`)
- Sets Go endpoint to port 4318 in the cluster overlay while Python/Node.js continue using gRPC on port 4317

## Context
After merging #697, the Go eBPF sidecars are running but failing to export traces:
```
traces export: failed to send to .../v1/traces: 500 Internal Server Error
```
The agent sends HTTP OTLP to port 4317 (gRPC), which rejects the HTTP request.

## Test plan
- [x] `bazel test //overlays/cluster-critical/opentelemetry-operator:template_test` — pass
- [x] Verified Go CRs render with port 4318, Python/Node.js with 4317
- [ ] Verify Go eBPF traces appear in SigNoz after sync


🤖 Generated with [Claude Code](https://claude.com/claude-code)