### PR TITLE
fix(semgrep): use wildcard for wheel data path in semgrep-core extraction

### DIFF
--- a/.github/workflows/update-semgrep-pro.yaml
+++ b/.github/workflows/update-semgrep-pro.yaml
@@ -95,7 +95,8 @@ jobs:
             curl -sSfL -o /tmp/semgrep-${arch}.whl "${WHEEL_URL}"
 
             echo "Extracting semgrep-core from wheel..."
-            unzip -p "/tmp/semgrep-${arch}.whl" "semgrep/bin/semgrep-core" > "${dir}/semgrep-core"
+            # Wheel layout: {name}-{version}.data/purelib/semgrep/bin/semgrep-core
+            unzip -p "/tmp/semgrep-${arch}.whl" "*/semgrep/bin/semgrep-core" > "${dir}/semgrep-core"
             chmod 755 "${dir}/semgrep-core"
 
             SIZE=$(stat --format=%s "${dir}/semgrep-core")


### PR DESCRIPTION
## Summary

- Fixes semgrep-core extraction from PyPI wheels in the update workflow
- The binary is at `{name}-{version}.data/purelib/semgrep/bin/semgrep-core` inside the wheel, not `semgrep/bin/semgrep-core`
- Uses `*/semgrep/bin/semgrep-core` glob to match the version-prefixed `.data` directory

## Test plan

- [ ] Re-run the Update Semgrep Artifacts workflow — extraction should succeed


🤖 Generated with [Claude Code](https://claude.com/claude-code)