### PR TITLE
docs(buildbuddy-mcp): note full SHA requirement in get_invocation

### DIFF
--- a/services/buildbuddy_mcp/app/main.py
+++ b/services/buildbuddy_mcp/app/main.py
@@ -69,6 +69,10 @@ async def get_invocation(
     Returns build metadata including success status, duration, command,
     repo URL, branch, and bazel exit code.
 
+    IMPORTANT: commit_sha must be a full 40-character hex SHA. Short SHAs
+    (e.g. "88a97bd0") will return no results. Use `git rev-parse <short>`
+    to resolve before calling.
+
     Set include_child_invocations=True to get inner bazel invocation IDs
     from workflow runs (needed to navigate to test results).
     """


### PR DESCRIPTION
## Summary
- Document that `commit_sha` in `get_invocation` must be a full 40-character hex SHA
- Short SHAs silently return empty results from the BuildBuddy API, causing output schema validation errors in MCP callers

## Test plan
- [ ] Verify CI passes
- [ ] Confirm tool description change is reflected when MCP server restarts

🤖 Generated with [Claude Code](https://claude.com/claude-code)