### PR TITLE
fix: resolve ArgoCD app health and sync issues

### DIFF
--- a/charts/todo/templates/deployment.yaml
+++ b/charts/todo/templates/deployment.yaml
@@ -99,12 +99,12 @@ spec:
           resources:
             {{- toYaml .Values.resources.api | nindent 12 }}
         - name: static
-          image: nginx:alpine
+          image: nginxinc/nginx-unprivileged:alpine
           securityContext:
             {{- toYaml .Values.staticSecurityContext | nindent 12 }}
           ports:
             - name: http
-              containerPort: 80
+              containerPort: 8080
           volumeMounts:
             - name: repo
               mountPath: /usr/share/nginx/html

--- a/charts/todo/templates/nginx-config.yaml
+++ b/charts/todo/templates/nginx-config.yaml
@@ -7,7 +7,7 @@ metadata:
 data:
   default.conf: |
     server {
-        listen 80;
+        listen 8080;
         server_name _;
 
         root /usr/share/nginx/html;

--- a/charts/todo/values.yaml
+++ b/charts/todo/values.yaml
@@ -75,10 +75,12 @@ apiSecurityContext:
     drop:
       - ALL
 
-## Static (nginx) container security context
+## Static (nginx-unprivileged) container security context
 staticSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 65532
   allowPrivilegeEscalation: false
-  readOnlyRootFilesystem: false # nginx needs writable /var/cache/nginx and /var/run
+  readOnlyRootFilesystem: false # nginx needs writable /tmp and /var/cache/nginx
   capabilities:
     drop:
       - ALL

--- a/overlays/cluster-critical/kyverno/application.yaml
+++ b/overlays/cluster-critical/kyverno/application.yaml
@@ -21,6 +21,12 @@ spec:
   destination:
     server: https://kubernetes.default.svc
     namespace: kyverno
+  # Ignore fields defaulted by Kyverno webhook on ClusterPolicy resources
+  ignoreDifferences:
+    - group: kyverno.io
+      kind: ClusterPolicy
+      jqPathExpressions:
+        - .spec.rules[].mutate
   syncPolicy:
     automated:
       prune: true
@@ -28,6 +34,7 @@ spec:
     syncOptions:
       - CreateNamespace=true
       - ServerSideApply=true
+      - RespectIgnoreDifferences=true
     retry:
       limit: 5
       backoff:

--- a/overlays/dev/grimoire/application.yaml
+++ b/overlays/dev/grimoire/application.yaml
@@ -17,13 +17,13 @@ spec:
   destination:
     server: https://kubernetes.default.svc
     namespace: grimoire
-  # Ignore fields injected by Kyverno policies (OTEL env vars)
+  # Ignore fields injected by OTel operator and Kyverno policies
   ignoreDifferences:
     - group: apps
       kind: Deployment
       jqPathExpressions:
         - .spec.template.metadata.annotations."otel.injected-by"
-        - .spec.template.spec.containers[].env[] | select(.name | startswith("OTEL_"))
+        - .spec.template.spec.containers[].env
   syncPolicy:
     automated:
       prune: true

--- a/overlays/dev/marine/application.yaml
+++ b/overlays/dev/marine/application.yaml
@@ -17,13 +17,13 @@ spec:
   destination:
     server: https://kubernetes.default.svc
     namespace: marine
-  # Ignore fields injected by Kyverno policies (OTEL env vars)
+  # Ignore fields injected by OTel operator and Kyverno policies
   ignoreDifferences:
     - group: apps
       kind: Deployment
       jqPathExpressions:
         - .spec.template.metadata.annotations."otel.injected-by"
-        - .spec.template.spec.containers[].env[] | select(.name | startswith("OTEL_"))
+        - .spec.template.spec.containers[].env
   syncPolicy:
     automated:
       prune: true

--- a/overlays/prod/mcp-servers/application.yaml
+++ b/overlays/prod/mcp-servers/application.yaml
@@ -17,9 +17,17 @@ spec:
   destination:
     server: https://kubernetes.default.svc
     namespace: mcp-servers
+  # Ignore fields injected by OTel operator and Kyverno policies
+  ignoreDifferences:
+    - group: apps
+      kind: Deployment
+      jqPathExpressions:
+        - .spec.template.metadata.annotations."otel.injected-by"
+        - .spec.template.spec.containers[].env
   syncPolicy:
     automated:
       prune: true
       selfHeal: true
     syncOptions:
       - CreateNamespace=true
+      - RespectIgnoreDifferences=true


### PR DESCRIPTION
## Summary
- **prod-todo CrashLoopBackOff**: Switch `nginx:alpine` to `nginxinc/nginx-unprivileged:alpine` with port 8080 and `runAsNonRoot: true` — fixes `chown` failure under non-root security context
- **grimoire/marine/mcp-servers OutOfSync**: Broaden `ignoreDifferences` to ignore all container env vars (matching stargazer's working pattern) instead of only `OTEL_*` prefixed ones, and add `RespectIgnoreDifferences=true` where missing
- **kyverno OutOfSync**: Add `ignoreDifferences` for ClusterPolicy `.spec.rules[].mutate` fields defaulted by the Kyverno webhook, plus `RespectIgnoreDifferences=true`

## Test plan
- [ ] Verify prod-todo pod starts successfully (no CrashLoopBackOff)
- [ ] Verify todo static site serves on port 8080 via the `http` named port
- [ ] Confirm grimoire, kyverno, and prod-mcp-servers show as Synced in ArgoCD
- [ ] Confirm marine stays Synced with updated ignoreDifferences
- [ ] Verify no self-heal loops (autoHealAttemptsCount stops incrementing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)