### PR TITLE
fix(kyverno): add skipBackgroundRequests to disable-linkerd-on-jobs policy

### DIFF
--- a/charts/kyverno/templates/linkerd-disable-jobs-policy.yaml
+++ b/charts/kyverno/templates/linkerd-disable-jobs-policy.yaml
@@ -14,6 +14,7 @@ spec:
   background: false
   rules:
   - name: disable-linkerd-on-job-pods
+    skipBackgroundRequests: true
     match:
       any:
       - resources:


### PR DESCRIPTION
## Summary
- Adds `skipBackgroundRequests: true` to the `disable-linkerd-on-jobs` ClusterPolicy template
- The Kyverno admission webhook defaults this field on all policy rules, causing perpetual OutOfSync drift in ArgoCD
- The other two ClusterPolicies (`inject-linkerd-namespace-annotation`, `inject-otel-env-vars`) already set this explicitly — this aligns the remaining policy

## Context
Follow-up to #721. That PR's `ignoreDifferences` for `.spec.rules[].mutate` was correct but insufficient — the actual drifting field was `skipBackgroundRequests`, not `mutate`.

## Test plan
- [ ] ArgoCD kyverno app shows Synced after merge
- [ ] `disable-linkerd-on-jobs` ClusterPolicy no longer shows OutOfSync
- [ ] `autoHealAttemptsCount` stops incrementing

🤖 Generated with [Claude Code](https://claude.com/claude-code)