### PR TITLE
fix(todo): resolve port conflict between api and static containers

### DIFF
--- a/charts/todo/templates/deployment.yaml
+++ b/charts/todo/templates/deployment.yaml
@@ -104,7 +104,7 @@ spec:
             {{- toYaml .Values.staticSecurityContext | nindent 12 }}
           ports:
             - name: http
-              containerPort: 8080
+              containerPort: 8081
           volumeMounts:
             - name: repo
               mountPath: /usr/share/nginx/html

--- a/charts/todo/templates/nginx-config.yaml
+++ b/charts/todo/templates/nginx-config.yaml
@@ -7,7 +7,7 @@ metadata:
 data:
   default.conf: |
     server {
-        listen 8080;
+        listen 8081;
         server_name _;
 
         root /usr/share/nginx/html;


### PR DESCRIPTION
## Summary
- Both `api` and `static` (nginx) containers in the todo pod were binding port 8080, causing nginx to CrashLoopBackOff with `Address in use`
- Changed nginx to listen on port 8081, while `proxy_pass` correctly continues to reach the api container on 8080
- Service routing is unaffected since it uses named `targetPort: http` which resolves dynamically

## Test plan
- [ ] Verify ArgoCD syncs the change successfully
- [ ] Confirm todo pod reaches `Running` with 4/4 containers ready
- [ ] Check public endpoint serves static files and API proxy works

🤖 Generated with [Claude Code](https://claude.com/claude-code)