### PR TITLE
fix(semgrep): use authenticated API for SCA rules download

### DIFF
--- a/.github/workflows/update-semgrep-pro.yaml
+++ b/.github/workflows/update-semgrep-pro.yaml
@@ -167,6 +167,8 @@ jobs:
           done
 
       - name: Download SCA advisory rules
+        env:
+          SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
         run: |
           set -euo pipefail
           dir="artifacts/rules-sca"
@@ -174,7 +176,8 @@ jobs:
 
           echo "Downloading SCA supply-chain advisory rules..."
           curl -sSfL \
-            "https://semgrep.dev/c/supply-chain" \
+            -H "Authorization: Bearer ${SEMGREP_APP_TOKEN}" \
+            "https://semgrep.dev/api/agent/deployments/scans/config?sca=true" \
             -o "${dir}/supply-chain.yaml"
 
           echo "Downloaded SCA rules ($(stat --format=%s "${dir}/supply-chain.yaml") bytes)"


### PR DESCRIPTION
## Summary

- Fix 404 error when downloading SCA advisory rules in the update workflow
- SCA supply chain rules require `SEMGREP_APP_TOKEN` authentication — they are not available from the public registry
- Changed from `https://semgrep.dev/c/supply-chain` (404) to `https://semgrep.dev/api/agent/deployments/scans/config?sca=true` with Bearer auth

## Context

The original SCA feature PR assumed supply chain rules were publicly downloadable like SAST rule packs (`semgrep.dev/c/p/<lang>`). They are not — Semgrep's SCA advisory database is only available through the authenticated scan config API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)