### PR TITLE
perf(ci): increase CPU and memory for test workflow

### DIFF
--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -34,6 +34,8 @@ actions:
   - name: "Test and push"
     container_image: "ubuntu-24.04"
     resource_requests:
+      cpu: "8"
+      memory: "12GB"
       disk: "75GB"
     triggers:
       push:


### PR DESCRIPTION
## Summary
- Bumps the "Test and push" workflow runner from defaults (3 CPU / 8GB RAM) to **8 CPU / 12GB RAM**
- Should improve Bazel client performance and local action throughput during CI
- Format check action left at defaults since it's lighter weight

## Test plan
- [ ] Verify CI runs successfully on this PR
- [ ] Compare build times against recent main branch runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)