### PR TITLE
feat(context-forge): enable OIDC authentication via Cloudflare Access

### DIFF
--- a/architecture/decisions/agents/006-oidc-auth-mcp-gateway.md
+++ b/architecture/decisions/agents/006-oidc-auth-mcp-gateway.md
@@ -212,7 +212,7 @@ This is the same pattern used by any public OAuth-protected API (GitHub API, Sla
 
 ## Open Questions
 
-1. **DCR vs static client credentials for Claude.ai** — Claude.ai supports both Dynamic Client Registration (auto-registers) and static credentials (entered in advanced settings). DCR is cleaner but adds a public registration endpoint. If DCR proves noisy, fall back to static client credentials.
+1. ~~**DCR vs static client credentials for Claude.ai**~~ — **Resolved: static credentials, DCR disabled.** Single-user homelab doesn't benefit from DCR, and disabling it eliminates the public registration endpoint as an attack surface. `MCPGATEWAY_DCR_ENABLED=false` is set in values.yaml. Claude.ai and Claude Code CLI both use pre-registered static client credentials.
 
 2. **Team assignment for SSO-created users** — `SSO_AUTO_CREATE_USERS=true` creates a Context Forge user on first login, but does not assign them to a team. ADR 005's RBAC model depends on users being in specific teams (`infra-agents`, `web-chat`) with a `developer` role. The bridge between authentication (this ADR) and authorization (ADR 005) needs a team assignment mechanism. Options:
    - **SSO group claim mapping** (recommended) — CF Access for SaaS supports the `groups` scope. Map CF Access groups to Context Forge teams. This is automatic and doesn't require manual intervention after first login.

--- a/charts/context-forge/values.yaml
+++ b/charts/context-forge/values.yaml
@@ -21,10 +21,25 @@ mcp-stack:
       MCPGATEWAY_CATALOG_ENABLED: "false"
       MCPGATEWAY_DIRECT_PROXY_ENABLED: "false"
       MCPGATEWAY_BULK_IMPORT_ENABLED: "false"
+      # SSO via Cloudflare Access for SaaS (OIDC) — see ADR 006
+      # Sensitive values (client ID/secret, OIDC URLs, encryption key)
+      # are sourced from 1Password via extraEnvFrom below.
+      SSO_ENABLED: "true"
+      SSO_GENERIC_ENABLED: "true"
+      SSO_GENERIC_PROVIDER_ID: "cloudflare"
+      SSO_GENERIC_DISPLAY_NAME: "Cloudflare Access"
+      SSO_GENERIC_SCOPE: "openid profile email"
+      SSO_AUTO_CREATE_USERS: "true"
+      SSO_TRUSTED_DOMAINS: "jomcgi.dev"
+      SSO_PRESERVE_ADMIN_AUTH: "true"
+      # OAuth authorization server
+      OAUTH_DISCOVERY_ENABLED: "true"
+      # Static client credentials only — no public registration endpoint
+      MCPGATEWAY_DCR_ENABLED: "false"
     secret:
       AUTH_REQUIRED: "true"
       MCP_CLIENT_AUTH_ENABLED: "true"
-      MCP_REQUIRE_AUTH: "false"
+      MCP_REQUIRE_AUTH: "true"
     extraEnvFrom:
       - secretRef:
           name: context-forge
@@ -79,7 +94,10 @@ mcp-stack:
   mcpFastTimeServer:
     enabled: false
 
-# 1Password secret — provides JWT_SECRET_KEY for admin API auth
+# 1Password secret — provides JWT_SECRET_KEY, SSO credentials, and
+# OIDC endpoint URLs (SSO_GENERIC_CLIENT_ID, SSO_GENERIC_CLIENT_SECRET,
+# SSO_GENERIC_AUTHORIZATION_URL, SSO_GENERIC_TOKEN_URL,
+# SSO_GENERIC_USERINFO_URL, SSO_GENERIC_ISSUER, AUTH_ENCRYPTION_SECRET)
 secret:
   name: context-forge
   itemPath: "vaults/k8s-homelab/items/context-forge"


### PR DESCRIPTION
## Summary

- Enable SSO via Cloudflare Access for SaaS as OIDC identity provider (ADR 006)
- Set `MCP_REQUIRE_AUTH=true` — auth enforcement moves from CF Access edge to Context Forge application layer
- Enable OAuth discovery endpoint for MCP clients
- Disable DCR (`MCPGATEWAY_DCR_ENABLED=false`) — static client credentials only, resolves ADR 006 open question #1
- Sensitive OIDC values (client ID/secret, endpoints, encryption key) sourced from 1Password `extraEnvFrom`

## Pre-merge checklist

Before merging this PR, complete these manual steps:

### 1. Cloudflare Zero Trust — Create SaaS OIDC Application
- [ ] Access → Applications → Add application → SaaS
- [ ] Application name: `Context Forge MCP`, Auth protocol: OIDC
- [ ] Redirect URL: `https://mcp.jomcgi.dev/auth/sso/callback/cloudflare`
- [ ] Scopes: `openid`, `email`, `profile`
- [ ] Add Allow policy scoped to your email
- [ ] Copy Client ID, Client Secret, and OIDC endpoint URLs

### 2. 1Password — Add secrets to `context-forge` item
- [x] `SSO_GENERIC_CLIENT_ID` — from CF Zero Trust
- [x] `SSO_GENERIC_CLIENT_SECRET` — from CF Zero Trust
- [x] `SSO_GENERIC_AUTHORIZATION_URL` — `https://<team>.cloudflareaccess.com/cdn-cgi/access/sso/oidc/<client-id>/authorization`
- [x] `SSO_GENERIC_TOKEN_URL` — `https://<team>.cloudflareaccess.com/cdn-cgi/access/sso/oidc/<client-id>/token`
- [x] `SSO_GENERIC_USERINFO_URL` — `https://<team>.cloudflareaccess.com/cdn-cgi/access/sso/oidc/<client-id>/userinfo`
- [x] `SSO_GENERIC_ISSUER` — `https://<team>.cloudflareaccess.com/cdn-cgi/access/sso/oidc/<client-id>`
- [x] `AUTH_ENCRYPTION_SECRET` — `openssl rand -hex 32`

## Post-merge steps

1. Verify ArgoCD syncs and pods are healthy
2. Verify OAuth discovery: `GET https://mcp.jomcgi.dev/.well-known/oauth-authorization-server`
3. Test OAuth flow via `mcp-remote`
4. Remove old CF Access self-hosted application for `mcp.jomcgi.dev`
5. Update `.mcp.json` to remove CF service token headers
6. Remove `CF_ACCESS_CLIENT_ID` / `CF_ACCESS_CLIENT_SECRET` from direnv

## Test plan

- [ ] 1Password secret syncs to cluster (check pod logs for missing env vars)
- [ ] OAuth discovery endpoint returns metadata
- [ ] SSO login flow redirects to Cloudflare, authenticates, returns token
- [ ] MCP tools accessible with Bearer token via `mcp-remote`
- [ ] Existing CF Access service token flow still works until gatekeeper removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)