### PR TITLE
fix(semgrep): add JS/Go support, dynamic version detection, and ADR refs

### DIFF
--- a/architecture/decisions/security/001-bazel-semgrep.md
+++ b/architecture/decisions/security/001-bazel-semgrep.md
@@ -68,3 +68,11 @@ graph TD
 | Cold cache (all tests + images + semgrep) | N/A | **4m** |
 | Determinism | Non-deterministic (registry fetches) | **Hermetic** (digest-pinned) |
 | Cache invalidation | Time-based / none | **Content-addressed** (source + rule hash) |
+
+## References
+
+- [semgrep-core CLI](https://semgrep.dev/docs/contributing/semgrep-core-overview/) — OCaml engine invoked directly, bypassing the Python `pysemgrep` wrapper
+- [semgrep-core ATD target format](https://github.com/semgrep/semgrep/blob/develop/libs/ojsonnet/) — JSON `["Targets",[["CodeTarget",{...}]]]` schema used for `-targets` flag; see `semgrep-test.sh` for generation
+- [Semgrep Pro Engine](https://semgrep.dev/docs/semgrep-code/semgrep-pro-engine-intro/) — `semgrep-core-proprietary` binary enabling cross-file analysis via `--pro` flag
+- [Semgrep App API (scan upload)](https://semgrep.dev/docs/semgrep-ci/running-semgrep-ci-without-semgrep-cloud-platform/) — 3-step REST flow: register scan → upload findings → mark complete (used by `upload.py`)
+- [GHCR OCI artifact layout](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry) — engine binaries stored as content-addressed OCI artifacts at `ghcr.io/<org>/semgrep-*`, pulled via `oci_archive` Bazel repository rules with SHA-256 digest pinning

--- a/rules_semgrep/gazelle/config.go
+++ b/rules_semgrep/gazelle/config.go
@@ -11,12 +11,18 @@ import (
 var langRules = map[string]string{
 	"py": "//semgrep_rules:python_rules",
 	"go": "//semgrep_rules:golang_rules",
+	"js": "//semgrep_rules:javascript_rules",
 }
 
 // langExtensions maps language keys to their file extensions.
+// For languages with multiple extensions (e.g., .js/.jsx/.ts/.tsx), only the
+// primary extension is listed here. The Gazelle extension matches files by
+// this extension; other extensions can be covered via semgrep_target_test which
+// uses an aspect to collect transitive sources regardless of extension.
 var langExtensions = map[string]string{
 	"py": ".py",
 	"go": ".go",
+	"js": ".js",
 }
 
 // defaultTargetKinds is the default set of rule kinds that trigger
@@ -24,6 +30,7 @@ var langExtensions = map[string]string{
 // ("" means the target itself).
 var defaultTargetKinds = map[string]string{
 	"py_venv_binary": "",
+	"go_binary":      "",
 }
 
 // defaultLanguages is the default set of languages to scan.

--- a/rules_semgrep/gazelle/config_test.go
+++ b/rules_semgrep/gazelle/config_test.go
@@ -21,12 +21,15 @@ func TestGetSemgrepConfig_Defaults(t *testing.T) {
 		t.Errorf("expected excludeRules to be empty by default, got %v", cfg.excludeRules)
 	}
 
-	// Default targetKinds: py_venv_binary → ""
-	if len(cfg.targetKinds) != 1 {
-		t.Fatalf("expected 1 default targetKind, got %d: %v", len(cfg.targetKinds), cfg.targetKinds)
+	// Default targetKinds: py_venv_binary → "", go_binary → ""
+	if len(cfg.targetKinds) != 2 {
+		t.Fatalf("expected 2 default targetKinds, got %d: %v", len(cfg.targetKinds), cfg.targetKinds)
 	}
 	if attr, ok := cfg.targetKinds["py_venv_binary"]; !ok || attr != "" {
 		t.Errorf("expected targetKinds[py_venv_binary]=\"\", got ok=%v attr=%q", ok, attr)
+	}
+	if attr, ok := cfg.targetKinds["go_binary"]; !ok || attr != "" {
+		t.Errorf("expected targetKinds[go_binary]=\"\", got ok=%v attr=%q", ok, attr)
 	}
 
 	// Default languages: ["py"]

--- a/rules_semgrep/semgrep-manifest-test.sh
+++ b/rules_semgrep/semgrep-manifest-test.sh
@@ -53,6 +53,10 @@ if ! "$SEMGREP_CORE" -version >/dev/null 2>&1; then
 	exit 0
 fi
 
+# Export the engine version for downstream tools (e.g., upload.py).
+SEMGREP_ENGINE_VERSION=$("$SEMGREP_CORE" -version 2>/dev/null | head -1 || echo "")
+export SEMGREP_ENGINE_VERSION
+
 # Stage both binaries in the same directory (Pro requires co-located OSS binary)
 PRO_DIR="${TEST_TMPDIR}/pro_bin"
 mkdir -p "$PRO_DIR"

--- a/rules_semgrep/semgrep-test.sh
+++ b/rules_semgrep/semgrep-test.sh
@@ -47,6 +47,10 @@ if ! "$SEMGREP_CORE" -version >/dev/null 2>&1; then
 	exit 0
 fi
 
+# Export the engine version for downstream tools (e.g., upload.py).
+SEMGREP_ENGINE_VERSION=$("$SEMGREP_CORE" -version 2>/dev/null | head -1 || echo "")
+export SEMGREP_ENGINE_VERSION
+
 # Stage both binaries in the same directory (Pro requires co-located OSS binary)
 PRO_DIR="${TEST_TMPDIR}/pro_bin"
 mkdir -p "$PRO_DIR"

--- a/tools/semgrep/upload.py
+++ b/tools/semgrep/upload.py
@@ -83,8 +83,15 @@ def _detect_branch() -> str:
 
 
 def _detect_semgrep_version() -> str:
-    """Return the pinned semgrep version matching requirements/all.txt."""
-    return "1.153.1"
+    """Return the semgrep engine version from the environment or a fallback.
+
+    The SEMGREP_ENGINE_VERSION env var is set by the test runner from the actual
+    semgrep-core binary's -version output. Falls back to a static version if
+    the env var is not set (e.g., when invoked outside the test runner).
+    """
+    import os
+
+    return os.environ.get("SEMGREP_ENGINE_VERSION", "1.153.1")
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary

- Add JavaScript (`js`) to Gazelle `langRules`/`langExtensions` for auto-generated semgrep_test targets on `.js` files
- Add `go_binary` to `defaultTargetKinds` so Go binaries get `semgrep_target_test` without manual directives
- Export `SEMGREP_ENGINE_VERSION` from test runners so `upload.py` reports the actual engine version instead of a hardcoded fallback
- Add References section to the semgrep ADR

## Test plan

- [ ] CI passes (format check + test and push)
- [ ] Gazelle config test updated to expect 2 default targetKinds

🤖 Generated with [Claude Code](https://claude.com/claude-code)