### PR TITLE
feat(mcp-gateway): add OAuth 2.1 proxy for Claude.ai web MCP auth

### DIFF
--- a/architecture/decisions/agents/006-oidc-auth-mcp-gateway.md
+++ b/architecture/decisions/agents/006-oidc-auth-mcp-gateway.md
@@ -1,8 +1,9 @@
 # ADR 006: OIDC Authentication for MCP Gateway
 
 **Author:** Joe McGinley
-**Status:** Draft
+**Status:** Accepted
 **Created:** 2026-03-01
+**Updated:** 2026-03-06
 **Relates to:** [003-context-forge](003-context-forge.md), [005-role-based-mcp-access](005-role-based-mcp-access.md)
 
 ---
@@ -21,19 +22,29 @@ The MCP gateway (Context Forge) is currently protected by Cloudflare Access serv
 
 ## Proposal
 
-Replace the Cloudflare Access service token gatekeeper with Context Forge's built-in OAuth 2.0 authorization server, backed by Cloudflare Access for SaaS as the OIDC identity provider. All MCP clients — CLI and web — authenticate through the same OAuth flow.
+Deploy [`obot-platform/mcp-oauth-proxy`](https://github.com/obot-platform/mcp-oauth-proxy) as an OAuth 2.1 proxy in front of Context Forge. The proxy:
 
-| Aspect                 | Today                                       | Proposed                                                                         |
-| ---------------------- | ------------------------------------------- | -------------------------------------------------------------------------------- |
-| **Edge auth**          | CF Access service token (static headers)    | None — CF Tunnel still routes traffic (DDoS, TLS) but Access application removed |
-| **MCP endpoint auth**  | `MCP_REQUIRE_AUTH=false` (trusts CF Access) | `MCP_REQUIRE_AUTH=true` (Context Forge validates OAuth tokens)                   |
-| **Identity provider**  | N/A (service token has no user identity)    | Cloudflare Access for SaaS (OIDC) — reuses existing CF Zero Trust IdP            |
-| **Claude Code CLI**    | `mcp-remote` + CF service token headers     | `mcp-remote` (OAuth flow — opens browser, caches token)                          |
-| **Claude.ai web**      | Not possible                                | Works via standard MCP connector dialog                                          |
-| **In-cluster agents**  | ClusterIP, no auth                          | Unchanged — ClusterIP access stays unauthenticated                               |
-| **Token type**         | CF Access JWT (edge-validated)              | Context Forge OAuth token (application-validated)                                |
-| **Per-user identity**  | No                                          | Yes — SSO login identifies the user                                              |
-| **Session revocation** | Rotate shared service token                 | Revoke individual user session                                                   |
+1. Acts as the Authorization Server (serves RFC 9728 + RFC 8414 metadata, accepts DCR)
+2. Delegates user authentication to Google OIDC
+3. Issues its own JWTs to MCP clients
+4. Validates those tokens and proxies requests to Context Forge with `X-Forwarded-User` header
+5. Context Forge trusts the proxy via `TRUST_PROXY_AUTH=true`
+
+### Why an OAuth Proxy Instead of Context Forge's Built-in SSO
+
+The original plan (draft version of this ADR) used Context Forge's built-in SSO with Cloudflare Access for SaaS as the OIDC provider. This was abandoned because Claude.ai's MCP connector requires a full RFC 9728 → DCR → Authorization Code + PKCE flow that Context Forge's SSO integration doesn't fully implement — Context Forge can only validate its own JWTs signed with `JWT_SECRET_KEY`, not tokens from external Authorization Servers.
+
+| Aspect                 | Today                                       | Proposed                                                                          |
+| ---------------------- | ------------------------------------------- | --------------------------------------------------------------------------------- |
+| **Edge auth**          | CF Access service token (static headers)    | None — CF Tunnel still routes traffic (DDoS, TLS) but Access application removed  |
+| **MCP endpoint auth**  | `MCP_REQUIRE_AUTH=false` (trusts CF Access)  | mcp-oauth-proxy validates its own JWTs; Context Forge trusts proxy headers         |
+| **Identity provider**  | N/A (service token has no user identity)    | Google OIDC via mcp-oauth-proxy                                                   |
+| **Claude Code CLI**    | `mcp-remote` + CF service token headers     | `mcp-remote` (OAuth flow — opens browser, caches token)                           |
+| **Claude.ai web**      | Not possible                                | Works via standard MCP connector dialog (RFC 9728 discovery + DCR)                |
+| **In-cluster agents**  | ClusterIP, no auth                          | Unchanged — ClusterIP access stays unauthenticated                                |
+| **Token type**         | CF Access JWT (edge-validated)              | mcp-oauth-proxy JWT (proxy-validated)                                             |
+| **Per-user identity**  | No                                          | Yes — Google OIDC login identifies the user                                       |
+| **Session revocation** | Rotate shared service token                 | Pod restart clears SQLite state (acceptable for single user)                      |
 
 ---
 
@@ -42,133 +53,78 @@ Replace the Cloudflare Access service token gatekeeper with Context Forge's buil
 ### Auth Flow
 
 ```
-┌─────────────────────────────────────────────────────────────────────┐
-│  MCP Client (Claude Code CLI or Claude.ai web)                      │
-│                                                                     │
-│  1. GET /.well-known/oauth-authorization-server                     │
-│  2. POST /oauth/register  (DCR — auto-registers client)            │
-│  3. Redirect user → /oauth/authorize                                │
-│        └──► CF Access SSO login (OTP / GitHub / Google)             │
-│  4. Callback with auth code                                         │
-│  5. POST /oauth/token  (exchange for access token)                  │
-│  6. POST /mcp/  with Authorization: Bearer <token>                  │
-└─────────────────────────────────────────────────────────────────────┘
-
-         │                                    ▲
-         │ HTTPS (Cloudflare Tunnel)          │ OIDC (authorization code flow)
-         ▼                                    │
-
-┌─ mcp.jomcgi.dev ───────────────────────────────────────────────────┐
-│                                                                     │
-│  Cloudflare Tunnel (DDoS protection, TLS termination)               │
-│  NO Cloudflare Access application — tunnel route only               │
-│                                                                     │
-└────────────────────────────────┬────────────────────────────────────┘
-                                 │
-                                 ▼
-┌─ Namespace: mcp-gateway ───────────────────────────────────────────┐
-│                                                                     │
-│  Context Forge (OAuth Authorization Server + MCP Gateway)           │
-│  ├─ OAuth discovery: /.well-known/oauth-authorization-server        │
-│  ├─ DCR endpoint:    /oauth/register                                │
-│  ├─ Authorization:   /oauth/authorize → CF Access OIDC login        │
-│  ├─ Token exchange:  /oauth/token                                   │
-│  ├─ MCP endpoint:    /mcp/ (Bearer token required)                  │
-│  └─ SSO provider:    Cloudflare Access for SaaS (generic OIDC)      │
-│                                                                     │
-│  Backends (unchanged):                                              │
-│  ┌──────────┐ ┌──────────┐ ┌──────────┐                            │
-│  │ SigNoz   │ │ ArgoCD   │ │ Longhorn │                            │
-│  │ :8080    │ │ :80      │ │ :80      │                            │
-│  └──────────┘ └──────────┘ └──────────┘                            │
-│                                                                     │
-└─────────────────────────────────────────────────────────────────────┘
+Claude.ai web ("Add custom connector")
+    │
+    │ 1. GET /.well-known/oauth-protected-resource  → proxy returns metadata
+    │ 2. POST /register                             → proxy auto-registers client (DCR)
+    │ 3. GET /authorize                             → proxy redirects to Google
+    │ 4. User authenticates with Google Workspace
+    │ 5. POST /token                                → proxy issues its own JWT
+    │ 6. POST /mcp with Bearer <proxy-jwt>
+    ▼
+┌─ mcp.jomcgi.dev ─────────────────────────────────────┐
+│  Cloudflare Tunnel (DDoS, TLS) — no CF Access app     │
+└───────────────────────┬───────────────────────────────┘
+                        ▼
+┌─ Namespace: mcp-gateway ──────────────────────────────┐
+│                                                        │
+│  mcp-oauth-proxy (Deployment)                          │
+│  ├─ Validates Bearer token (its own JWT)               │
+│  ├─ Injects: X-Forwarded-User, X-Forwarded-Email       │
+│  └─ Proxies to Context Forge ClusterIP                 │
+│         ▼                                              │
+│  Context Forge (existing)                              │
+│  ├─ TRUST_PROXY_AUTH=true                              │
+│  ├─ PROXY_USER_HEADER=X-Forwarded-User                │
+│  ├─ MCP_CLIENT_AUTH_ENABLED=false (proxy handles auth) │
+│  └─ MCP tools served to authenticated user             │
+│                                                        │
+│  In-cluster agents (ClusterIP) → Context Forge direct  │
+│  (unchanged, no auth)                                  │
+└────────────────────────────────────────────────────────┘
 ```
 
 ### In-Cluster Access (Unchanged)
 
 In-cluster agents (OpenHands sandboxes, Goose pods) continue to access Context Forge via ClusterIP at `http://context-forge-mcp-stack-mcpgateway.mcp-gateway.svc.cluster.local:80/mcp`. No OAuth required — ClusterIP is not externally reachable, and sandbox pods are already scoped to isolated namespaces.
 
-### Cloudflare Access for SaaS as OIDC Provider
-
-Cloudflare Access for SaaS acts as a standards-compliant OIDC provider, exposing:
-
-| Endpoint      | URL                                                                                                        |
-| ------------- | ---------------------------------------------------------------------------------------------------------- |
-| Authorization | `https://<team>.cloudflareaccess.com/cdn-cgi/access/sso/oidc/<client-id>/authorization`                    |
-| Token         | `https://<team>.cloudflareaccess.com/cdn-cgi/access/sso/oidc/<client-id>/token`                            |
-| Userinfo      | `https://<team>.cloudflareaccess.com/cdn-cgi/access/sso/oidc/<client-id>/userinfo`                         |
-| JWKS          | `https://<team>.cloudflareaccess.com/cdn-cgi/access/sso/oidc/<client-id>/jwks`                             |
-| Discovery     | `https://<team>.cloudflareaccess.com/cdn-cgi/access/sso/oidc/<client-id>/.well-known/openid-configuration` |
-
-This reuses whatever identity provider is already configured in CF Zero Trust (one-time PIN at minimum, optionally GitHub/Google). No new identity provider accounts needed.
-
 ---
 
 ## Implementation
 
-### Phase 1: Cloudflare Configuration
+### Phase 0: Google Cloud Console (Manual)
 
-- [ ] Create a SaaS OIDC application in Cloudflare Zero Trust (Access → Applications → SaaS)
-  - Application name: `Context Forge MCP`
-  - Auth protocol: OIDC
-  - Redirect URL: `https://mcp.jomcgi.dev/auth/sso/callback/cloudflare`
+- [x] Create OAuth Client ID in GCP Console (Web application type)
+  - Authorized redirect URI: `https://mcp.jomcgi.dev/callback`
   - Scopes: `openid`, `email`, `profile`
-- [ ] Add Allow policy scoped to authorized email(s)
-- [ ] Copy Client ID, Client Secret, and OIDC endpoint URLs
-- [ ] Store CF OIDC Client ID and Client Secret in 1Password (`context-forge` item)
-- [ ] Remove (or disable) the existing self-hosted CF Access application for `mcp.jomcgi.dev`
-  - Tunnel route stays — only the Access gatekeeper is removed
+- [x] Store Client ID, Client Secret, and ENCRYPTION_KEY in 1Password (`mcp-oauth-proxy` item)
 
-### Phase 2: Context Forge Configuration
+### Phase 1: Deploy mcp-oauth-proxy
 
-- [ ] Add SSO + OAuth environment variables to 1Password secret or values.yaml:
-  - `SSO_ENABLED=true`
-  - `SSO_GENERIC_ENABLED=true`
-  - `SSO_GENERIC_PROVIDER_ID=cloudflare`
-  - `SSO_GENERIC_DISPLAY_NAME=Cloudflare Access`
-  - `SSO_GENERIC_CLIENT_ID=<from CF Zero Trust>`
-  - `SSO_GENERIC_CLIENT_SECRET=<from CF Zero Trust>`
-  - `SSO_GENERIC_AUTHORIZATION_URL=<CF authorization endpoint>`
-  - `SSO_GENERIC_TOKEN_URL=<CF token endpoint>`
-  - `SSO_GENERIC_USERINFO_URL=<CF userinfo endpoint>`
-  - `SSO_GENERIC_ISSUER=<CF issuer URL>`
-  - `SSO_GENERIC_SCOPE=openid profile email`
-  - `SSO_AUTO_CREATE_USERS=true`
-  - `SSO_TRUSTED_DOMAINS=jomcgi.dev` (controls who can _log in_ — authorization is handled by ADR 005's team/RBAC layer)
-  - `SSO_PRESERVE_ADMIN_AUTH=true`
-- [ ] Enable Context Forge OAuth authorization server:
-  - `MCP_REQUIRE_AUTH=true`
-  - `OAUTH_DISCOVERY_ENABLED=true`
-- [ ] Deploy updated configuration via GitOps (values.yaml change → ArgoCD auto-sync)
-- [ ] Verify OAuth discovery endpoint returns metadata: `GET https://mcp.jomcgi.dev/.well-known/oauth-authorization-server`
+- [x] Create Helm chart at `charts/mcp-oauth-proxy/` (deployment, service, onepassworditem)
+- [x] Create ArgoCD overlay at `overlays/prod/mcp-oauth-proxy/`
+- [x] Add to `overlays/prod/kustomization.yaml`
 
-### Phase 3: Client Configuration
+### Phase 2: Update Cloudflare Tunnel Route
 
-- [ ] Update `.mcp.json` — remove CF service token headers:
-  ```json
-  {
-    "mcpServers": {
-      "context-forge": {
-        "type": "stdio",
-        "command": "npx",
-        "args": ["mcp-remote", "https://mcp.jomcgi.dev/mcp/"]
-      }
-    }
-  }
-  ```
-- [ ] Test Claude Code CLI: `mcp-remote` should open browser for OAuth login, cache token
-- [ ] Add connector in Claude.ai web (Settings → Integrations → Add custom connector):
-  - Name: `homelab-context-forge`
-  - Remote MCP server URL: `https://mcp.jomcgi.dev/mcp/`
-  - OAuth Client ID / Secret: leave empty (DCR auto-registers)
-- [ ] Test Claude.ai web: verify SigNoz tools are available after SSO login
+- [x] Route `mcp.jomcgi.dev` to `http://mcp-oauth-proxy.mcp-gateway.svc.cluster.local:8080`
 
-### Phase 4: Cleanup
+### Phase 3: Update Context Forge Configuration
 
-- [ ] Remove `CF_ACCESS_CLIENT_ID` / `CF_ACCESS_CLIENT_SECRET` from local `direnv` config
-- [ ] Revoke the CF Access service token for `mcp.jomcgi.dev` in Zero Trust dashboard
-- [ ] Update ADR 003 status to note OIDC auth replaces the service token model
+- [x] Remove SSO config (SSO_ENABLED, SSO_GENERIC_*, OAUTH_DISCOVERY_ENABLED, MCPGATEWAY_DCR_ENABLED)
+- [x] Set `TRUST_PROXY_AUTH=true`, `PROXY_USER_HEADER=X-Forwarded-User`
+- [x] Set `MCP_CLIENT_AUTH_ENABLED=false`, `MCP_REQUIRE_AUTH=false`
+- [ ] Remove SSO fields from 1Password `context-forge` item (manual)
+
+### Phase 4: Client Configuration
+
+- [ ] Configure Claude.ai web connector: URL `https://mcp.jomcgi.dev/mcp/`
+- [ ] Update Claude Code `.mcp.json` to use `mcp-remote` without CF Access headers
+
+### Phase 5: Cleanup
+
+- [ ] Remove `CF_ACCESS_CLIENT_ID` / `CF_ACCESS_CLIENT_SECRET` from local `direnv`
+- [ ] Revoke CF Access service token in Zero Trust dashboard
 
 ---
 
@@ -176,64 +132,55 @@ This reuses whatever identity provider is already configured in CF Zero Trust (o
 
 ### What Changes
 
-- **Authentication moves from edge to application.** Cloudflare Tunnel still provides DDoS protection and TLS termination. The authentication decision moves from CF Access (edge) to Context Forge (application). This is the standard model for OAuth-protected APIs — the reverse proxy handles transport security, the application handles identity.
+- **Authentication moves from edge to proxy.** Cloudflare Tunnel still provides DDoS protection and TLS termination. The mcp-oauth-proxy validates its own JWTs before proxying to Context Forge. Context Forge trusts proxy headers (`TRUST_PROXY_AUTH=true`).
 
-- **Per-user identity replaces shared secrets.** Each session is tied to an authenticated user via SSO. Sessions can be revoked individually. Audit logs show which user made which MCP tool call.
+- **Per-user identity replaces shared secrets.** Each session is tied to an authenticated Google user. The proxy injects `X-Forwarded-User` and `X-Forwarded-Email` headers.
 
-- **OAuth tokens are short-lived.** Context Forge issues tokens with configurable expiry (default: minutes, not days). Refresh tokens extend sessions without re-authentication. CF service tokens had static TTLs set at creation.
+- **SQLite state is ephemeral.** DCR registrations are stored in SQLite on an emptyDir volume. Pod restart loses state — Claude.ai re-registers on next connection. Acceptable for single user.
 
 ### What Stays the Same
 
-- Non-root, read-only filesystem, drop all capabilities (standard security context)
-- Secrets via 1Password (CF OIDC credentials added to existing `context-forge` item)
+- Non-root (uid 65532), drop all capabilities
+- Secrets via 1Password (Google OAuth credentials in new `mcp-oauth-proxy` item)
 - Ingress via Cloudflare Tunnel only (no direct internet exposure)
 - In-cluster access via ClusterIP (unchanged, no auth required)
 - Backend credentials (SigNoz API key, ArgoCD token) remain server-side — agents never see them
 
 ### Deviations from Security Model
 
-**One deviation:** The self-hosted CF Access application for `mcp.jomcgi.dev` is removed. Traffic from the internet to Context Forge's OAuth endpoints (discovery, authorize, token, register) is no longer gated by Cloudflare Access. This is intentional — these endpoints must be publicly reachable for the OAuth flow to work. The `/mcp` endpoint itself requires a valid Bearer token, enforced by Context Forge.
-
-This is the same pattern used by any public OAuth-protected API (GitHub API, Slack API, etc.) — discovery and token endpoints are public, resource endpoints require authentication.
+**One deviation:** The OAuth proxy's discovery, registration, and authorization endpoints are publicly reachable (no CF Access gatekeeper). This is intentional — these endpoints must be public for the OAuth flow to work. The `/mcp` endpoint requires a valid Bearer token validated by the proxy. Same pattern as any public OAuth-protected API (GitHub API, Slack API).
 
 ---
 
 ## Risks
 
-| Risk                                                                | Likelihood | Impact | Mitigation                                                                                                                                                                    |
-| ------------------------------------------------------------------- | ---------- | ------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **OAuth endpoint abuse** — discovery/token endpoints are now public | Medium     | Low    | Rate limiting via CF Tunnel + Context Forge built-in rate limits. DCR registration is the main vector — monitor for unusual client registrations.                             |
-| **DCR spam** — automated client registrations                       | Low        | Low    | Context Forge supports `DCR_ALLOWED_ISSUERS` to restrict which authorization servers can register. Monitor registered clients via admin API.                                  |
-| **Token theft** — stolen OAuth token grants MCP access              | Low        | Medium | Short token expiry (minutes). Refresh tokens tied to session. Same risk profile as any OAuth API — no worse than the current shared service token.                            |
-| **SSO outage** — CF Access OIDC endpoints go down                   | Low        | Medium | Existing cached tokens continue to work until expiry. `SSO_PRESERVE_ADMIN_AUTH=true` keeps local admin access for emergency. CLI can fall back to direct admin JWT if needed. |
-| **Browser popup on CLI** — `mcp-remote` OAuth opens a browser tab   | Certain    | Low    | One-time action per session. Token is cached locally. Headless environments (CI, remote SSH) may need a pre-authenticated token — address if needed.                          |
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| `mcp-oauth-proxy` doesn't implement RFC 9728/DCR | Low | High | Fall back to `sigbit/mcp-auth-proxy` (73 stars, Claude.ai verified, MIT) |
+| Pod restart loses SQLite state (DCR registrations) | Certain | Low | Claude.ai re-registers on next connection — acceptable for single user |
+| `TRUST_PROXY_AUTH` bypasses all MCP auth | Low | Medium | Proxy only reachable via Tunnel (external) or ClusterIP (internal) — same security boundary |
+| Container image `latest` tag is unstable | Medium | Low | Pin to specific release tag once verified |
+| Google OAuth callback URL mismatch | Low | Low | Verify exact callback path from proxy docs before creating GCP OAuth client |
+| Browser popup on CLI | Certain | Low | One-time per session. Token cached locally. Headless envs may need pre-auth token. |
 
 ---
 
 ## Open Questions
 
-1. ~~**DCR vs static client credentials for Claude.ai**~~ — **Resolved: static credentials, DCR disabled.** Single-user homelab doesn't benefit from DCR, and disabling it eliminates the public registration endpoint as an attack surface. `MCPGATEWAY_DCR_ENABLED=false` is set in values.yaml. Claude.ai and Claude Code CLI both use pre-registered static client credentials.
+1. **Pin container image tag** — `ghcr.io/obot-platform/mcp-oauth-proxy:latest` should be pinned to a specific release once the deployment is verified working. Check releases at https://github.com/obot-platform/mcp-oauth-proxy/releases.
 
-2. **Team assignment for SSO-created users** — `SSO_AUTO_CREATE_USERS=true` creates a Context Forge user on first login, but does not assign them to a team. ADR 005's RBAC model depends on users being in specific teams (`infra-agents`, `web-chat`) with a `developer` role. The bridge between authentication (this ADR) and authorization (ADR 005) needs a team assignment mechanism. Options:
-   - **SSO group claim mapping** (recommended) — CF Access for SaaS supports the `groups` scope. Map CF Access groups to Context Forge teams. This is automatic and doesn't require manual intervention after first login.
-   - **Admin manual assignment** — admin assigns team after first login. Simple but doesn't scale and breaks the Claude.ai flow (user would authenticate but have no tool access until manually promoted).
-   - **Default team assignment** — new SSO users auto-join a default team (e.g., `web-chat` with read-only SigNoz). CLI users are manually promoted to `infra-agents`. Safe default, but requires investigating whether Context Forge supports default team assignment on user creation.
+2. **Team assignment for proxy-identified users** — The proxy injects `X-Forwarded-User` with the Google email, but Context Forge's RBAC model (ADR 005) depends on users being in specific teams. With `TRUST_PROXY_AUTH=true`, Context Forge auto-creates users from the header. Investigate whether default team assignment works, or if admin manual assignment is needed.
 
-3. **In-cluster agents and OAuth** — Currently in-cluster agents bypass auth entirely via ClusterIP. If per-agent identity becomes important (audit logs per sandbox), in-cluster agents could use Context Forge's JWT auth with service accounts. More broadly, _all_ user-to-team mapping — not just in-cluster — needs to be defined before ADR 005's role-based access works. This ADR provides the authentication layer; ADR 005 consumes it for authorization. The two should share a combined phasing plan.
-
-4. **Token caching in `mcp-remote`** — Verify that `mcp-remote` persists OAuth tokens across Claude Code sessions to avoid repeated browser login prompts. If not, consider a local token cache wrapper.
+3. **Token caching in `mcp-remote`** — Verify that `mcp-remote` persists OAuth tokens across Claude Code sessions to avoid repeated browser login prompts.
 
 ---
 
 ## References
 
-| Resource                                                                                                                                                          | Relevance                                                                              |
-| ----------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
-| [Claude.ai remote MCP connectors](https://support.claude.com/en/articles/11503834-building-custom-connectors-via-remote-mcp-servers)                              | Claude.ai OAuth requirements (DCR, PKCE, callback URL)                                 |
-| [Cloudflare Access for SaaS — Generic OIDC](https://developers.cloudflare.com/cloudflare-one/access-controls/applications/http-apps/saas-apps/generic-oidc-saas/) | CF Access as OIDC provider configuration                                               |
-| [Context Forge — Generic OIDC SSO Setup](https://ibm.github.io/mcp-context-forge/manage/sso-generic-oidc-tutorial/)                                               | SSO environment variables and callback URL pattern                                     |
-| [Context Forge — Dynamic Client Registration](https://ibm.github.io/mcp-context-forge/manage/dcr/)                                                                | DCR configuration for MCP clients                                                      |
-| [Context Forge — OAuth 2.0 Integration](https://ibm.github.io/mcp-context-forge/manage/oauth/)                                                                    | OAuth authorization server configuration                                               |
-| [ADR 003 — Context Forge](003-context-forge.md)                                                                                                                   | Current service-token auth model (being replaced)                                      |
-| [ADR 005 — Role-Based MCP Access](005-role-based-mcp-access.md)                                                                                                   | Authorization layer that consumes this ADR's authentication model (team scoping, RBAC) |
-| [architecture/security.md](../../security.md)                                                                                                                     | Cluster security model — one deviation documented above                                |
+| Resource | Relevance |
+|----------|-----------|
+| [obot-platform/mcp-oauth-proxy](https://github.com/obot-platform/mcp-oauth-proxy) | OAuth 2.1 proxy used for this implementation |
+| [Claude.ai remote MCP connectors](https://support.claude.com/en/articles/11503834-building-custom-connectors-via-remote-mcp-servers) | Claude.ai OAuth requirements (DCR, PKCE, callback URL) |
+| [ADR 003 — Context Forge](003-context-forge.md) | Current service-token auth model (being replaced) |
+| [ADR 005 — Role-Based MCP Access](005-role-based-mcp-access.md) | Authorization layer that consumes this ADR's authentication |
+| [architecture/security.md](../../security.md) | Cluster security model — one deviation documented above |

--- a/charts/context-forge/values.yaml
+++ b/charts/context-forge/values.yaml
@@ -21,25 +21,13 @@ mcp-stack:
       MCPGATEWAY_CATALOG_ENABLED: "false"
       MCPGATEWAY_DIRECT_PROXY_ENABLED: "false"
       MCPGATEWAY_BULK_IMPORT_ENABLED: "false"
-      # SSO via Cloudflare Access for SaaS (OIDC) — see ADR 006
-      # Sensitive values (client ID/secret, OIDC URLs, encryption key)
-      # are sourced from 1Password via extraEnvFrom below.
-      SSO_ENABLED: "true"
-      SSO_GENERIC_ENABLED: "true"
-      SSO_GENERIC_PROVIDER_ID: "cloudflare"
-      SSO_GENERIC_DISPLAY_NAME: "Cloudflare Access"
-      SSO_GENERIC_SCOPE: "openid profile email"
-      SSO_AUTO_CREATE_USERS: "true"
-      SSO_TRUSTED_DOMAINS: "jomcgi.dev"
-      SSO_PRESERVE_ADMIN_AUTH: "true"
-      # OAuth authorization server
-      OAUTH_DISCOVERY_ENABLED: "true"
-      # Static client credentials only — no public registration endpoint
-      MCPGATEWAY_DCR_ENABLED: "false"
     secret:
       AUTH_REQUIRED: "true"
-      MCP_CLIENT_AUTH_ENABLED: "true"
-      MCP_REQUIRE_AUTH: "true"
+      MCP_CLIENT_AUTH_ENABLED: "false"
+      MCP_REQUIRE_AUTH: "false"
+      # mcp-oauth-proxy handles auth and injects X-Forwarded-User — see ADR 006
+      TRUST_PROXY_AUTH: "true"
+      PROXY_USER_HEADER: "X-Forwarded-User"
     extraEnvFrom:
       - secretRef:
           name: context-forge
@@ -94,10 +82,7 @@ mcp-stack:
   mcpFastTimeServer:
     enabled: false
 
-# 1Password secret — provides JWT_SECRET_KEY, SSO credentials, and
-# OIDC endpoint URLs (SSO_GENERIC_CLIENT_ID, SSO_GENERIC_CLIENT_SECRET,
-# SSO_GENERIC_AUTHORIZATION_URL, SSO_GENERIC_TOKEN_URL,
-# SSO_GENERIC_USERINFO_URL, SSO_GENERIC_ISSUER, AUTH_ENCRYPTION_SECRET)
+# 1Password secret — provides JWT_SECRET_KEY, AUTH_ENCRYPTION_SECRET
 secret:
   name: context-forge
   itemPath: "vaults/k8s-homelab/items/context-forge"

--- a/charts/mcp-oauth-proxy/Chart.yaml
+++ b/charts/mcp-oauth-proxy/Chart.yaml
@@ -1,0 +1,17 @@
+apiVersion: v2
+name: mcp-oauth-proxy
+description: OAuth 2.1 proxy for MCP gateway authentication via Google OIDC
+type: application
+version: 0.1.0
+appVersion: "latest"
+keywords:
+  - mcp
+  - oauth
+  - proxy
+  - oidc
+maintainers:
+  - name: jomcgi
+annotations:
+  org.opencontainers.image.source: "https://github.com/jomcgi/homelab"
+  org.opencontainers.image.url: "https://github.com/jomcgi/homelab"
+  org.opencontainers.image.licenses: "MPL-2.0"

--- a/charts/mcp-oauth-proxy/templates/_helpers.tpl
+++ b/charts/mcp-oauth-proxy/templates/_helpers.tpl
@@ -1,0 +1,49 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "mcp-oauth-proxy.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "mcp-oauth-proxy.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "mcp-oauth-proxy.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "mcp-oauth-proxy.labels" -}}
+helm.sh/chart: {{ include "mcp-oauth-proxy.chart" . }}
+{{ include "mcp-oauth-proxy.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "mcp-oauth-proxy.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "mcp-oauth-proxy.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/mcp-oauth-proxy/templates/deployment.yaml
+++ b/charts/mcp-oauth-proxy/templates/deployment.yaml
@@ -1,0 +1,57 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "mcp-oauth-proxy.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "mcp-oauth-proxy.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "mcp-oauth-proxy.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "mcp-oauth-proxy.labels" . | nindent 8 }}
+    spec:
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          env:
+            {{- range $key, $value := .Values.config }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
+          envFrom:
+            - secretRef:
+                name: {{ .Values.secret.name }}
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: data
+              mountPath: /data
+      volumes:
+        - name: data
+          emptyDir: {}

--- a/charts/mcp-oauth-proxy/templates/onepassworditem.yaml
+++ b/charts/mcp-oauth-proxy/templates/onepassworditem.yaml
@@ -1,0 +1,8 @@
+apiVersion: onepassword.com/v1
+kind: OnePasswordItem
+metadata:
+  name: {{ .Values.secret.name }}
+  labels:
+    {{- include "mcp-oauth-proxy.labels" . | nindent 4 }}
+spec:
+  itemPath: {{ .Values.secret.itemPath | quote }}

--- a/charts/mcp-oauth-proxy/templates/service.yaml
+++ b/charts/mcp-oauth-proxy/templates/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "mcp-oauth-proxy.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "mcp-oauth-proxy.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "mcp-oauth-proxy.selectorLabels" . | nindent 4 }}

--- a/charts/mcp-oauth-proxy/values.yaml
+++ b/charts/mcp-oauth-proxy/values.yaml
@@ -1,0 +1,45 @@
+# mcp-oauth-proxy configuration
+# OAuth 2.1 proxy that authenticates MCP clients via Google OIDC
+# and proxies requests to Context Forge with X-Forwarded-User headers.
+
+image:
+  repository: ghcr.io/obot-platform/mcp-oauth-proxy
+  tag: "latest"
+  pullPolicy: IfNotPresent
+
+# Non-secret environment variables
+config:
+  # Google OIDC authorize endpoint
+  OAUTH_AUTHORIZE_URL: "https://accounts.google.com"
+  # OAuth scopes to request from Google
+  SCOPES_SUPPORTED: "openid,email,profile"
+  # Upstream MCP server URL (Context Forge ClusterIP)
+  MCP_SERVER_URL: "http://context-forge-mcp-stack-mcpgateway.mcp-gateway.svc.cluster.local:80/mcp/"
+
+# 1Password secret — provides OAUTH_CLIENT_ID, OAUTH_CLIENT_SECRET, ENCRYPTION_KEY
+secret:
+  name: mcp-oauth-proxy
+  itemPath: "vaults/k8s-homelab/items/mcp-oauth-proxy"
+
+resources:
+  requests:
+    cpu: 10m
+    memory: 32Mi
+  limits:
+    cpu: 100m
+    memory: 128Mi
+
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 65532
+  runAsGroup: 65532
+  fsGroup: 65532
+  seccompProfile:
+    type: RuntimeDefault
+
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: false  # SQLite needs writable filesystem
+  capabilities:
+    drop:
+      - ALL

--- a/overlays/prod/cloudflare-tunnel/values.yaml
+++ b/overlays/prod/cloudflare-tunnel/values.yaml
@@ -13,7 +13,7 @@ ingress:
     - hostname: longhorn.jomcgi.dev
       service: http://longhorn-frontend.longhorn.svc.cluster.local:80
     - hostname: mcp.jomcgi.dev
-      service: http://context-forge-mcp-stack-mcpgateway.mcp-gateway.svc.cluster.local:80
+      service: http://mcp-oauth-proxy.mcp-gateway.svc.cluster.local:8080
     - hostname: n8n.jomcgi.dev
       service: http://n8n.n8n.svc.cluster.local:80
     - hostname: feeds.jomcgi.dev

--- a/overlays/prod/kustomization.yaml
+++ b/overlays/prod/kustomization.yaml
@@ -13,6 +13,7 @@ resources:
   - ./knowledge-graph
   - ./nats
   - ./seaweedfs
+  - ./mcp-oauth-proxy
   - ./mcp-servers
   - ./todo
   - ./trips

--- a/overlays/prod/mcp-oauth-proxy/application.yaml
+++ b/overlays/prod/mcp-oauth-proxy/application.yaml
@@ -1,0 +1,26 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: mcp-oauth-proxy
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/jomcgi/homelab.git
+    path: charts/mcp-oauth-proxy
+    targetRevision: HEAD
+    helm:
+      releaseName: mcp-oauth-proxy
+      valueFiles:
+        - values.yaml
+        - ../../overlays/prod/mcp-oauth-proxy/values.yaml
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: mcp-gateway
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/overlays/prod/mcp-oauth-proxy/kustomization.yaml
+++ b/overlays/prod/mcp-oauth-proxy/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - application.yaml

--- a/overlays/prod/mcp-oauth-proxy/values.yaml
+++ b/overlays/prod/mcp-oauth-proxy/values.yaml
@@ -1,0 +1,2 @@
+# Production overrides for mcp-oauth-proxy
+# Base values in charts/mcp-oauth-proxy/values.yaml


### PR DESCRIPTION
## Summary

- Deploy `obot-platform/mcp-oauth-proxy` as an OAuth 2.1 proxy in front of Context Forge, enabling Claude.ai web's MCP connector flow (RFC 9728 discovery → DCR → Authorization Code + PKCE → Google OIDC login)
- Route `mcp.jomcgi.dev` through the proxy instead of directly to Context Forge — proxy validates JWTs and injects `X-Forwarded-User` headers
- Context Forge switches from built-in SSO to `TRUST_PROXY_AUTH=true` mode, trusting the proxy for user identity
- ADR 006 updated from Draft → Accepted, reflecting the OAuth proxy approach

## Architecture

```
Claude.ai / mcp-remote → mcp.jomcgi.dev (CF Tunnel)
  → mcp-oauth-proxy (OAuth 2.1 + Google OIDC)
    → Context Forge (TRUST_PROXY_AUTH=true)
```

In-cluster agents continue accessing Context Forge directly via ClusterIP (unchanged).

## Prerequisites (manual)

Before merging, complete Phase 0:
1. Create Google OAuth Client ID in GCP Console (redirect URI: `https://mcp.jomcgi.dev/callback`)
2. Create 1Password item `mcp-oauth-proxy` in `k8s-homelab` vault with `OAUTH_CLIENT_ID`, `OAUTH_CLIENT_SECRET`, `ENCRYPTION_KEY`
3. Remove SSO fields from 1Password `context-forge` item (`SSO_GENERIC_*` fields)

## Post-merge (manual)

- Configure Claude.ai web connector: `https://mcp.jomcgi.dev/mcp/`
- Update Claude Code `.mcp.json` to remove CF Access headers
- Remove `CF_ACCESS_CLIENT_ID`/`CF_ACCESS_CLIENT_SECRET` from direnv
- Revoke CF Access service token

## Test plan

- [ ] `helm template mcp-oauth-proxy charts/mcp-oauth-proxy/` renders correctly (verified locally)
- [ ] CI passes (format check + tests)
- [ ] After merge: ArgoCD syncs proxy pod, verify it starts and becomes Ready
- [ ] `curl https://mcp.jomcgi.dev/.well-known/oauth-protected-resource` returns OAuth metadata
- [ ] Claude.ai web: Add connector → Google login → tools available
- [ ] Claude Code CLI: `mcp-remote` OAuth flow works
- [ ] In-cluster agents still work via ClusterIP (no auth change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)