### PR TITLE
feat(goose-agent): add container image for autonomous coding agents

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -247,10 +247,24 @@ apko.translate_lock(
     name = "todo_lock",
     lock = "//charts/todo/image:apko.lock.json",
 )
-use_repo(apko, "grimoire_frontend_lock", "ships_frontend_lock", "todo_lock")
+apko.translate_lock(
+    name = "goose_agent_lock",
+    lock = "//charts/goose-agent/image:apko.lock.json",
+)
+use_repo(apko, "goose_agent_lock", "grimoire_frontend_lock", "ships_frontend_lock", "todo_lock")
 
 # Download multiarch archives (binaries from zip files)
 multiarch_http_archive = use_repo_rule("//tools/http:multiarch_http_archive.bzl", "multiarch_http_archive")
+
+multiarch_http_archive(
+    name = "goose",
+    amd64_sha256 = "cfd81f9e17a02d3b87917de7411e43daa7bb72fb3b79fc26c3329010a0471f1e",
+    amd64_url = "https://github.com/block/goose/releases/download/v1.27.1/goose-x86_64-unknown-linux-gnu.tar.bz2",
+    arm64_sha256 = "fae890273700778a73891c51afe992aee254657fb0882702596eb7a6aeb1b894",
+    arm64_url = "https://github.com/block/goose/releases/download/v1.27.1/goose-aarch64-unknown-linux-gnu.tar.bz2",
+    binary_name = "goose",
+    package_dir = "/usr/local/bin",
+)
 
 multiarch_http_archive(
     name = "opencode",
@@ -264,6 +278,16 @@ multiarch_http_archive(
 
 # Download multiarch binaries (raw binary files)
 multiarch_http_file = use_repo_rule("//tools/http:multiarch_http_file.bzl", "multiarch_http_file")
+
+multiarch_http_file(
+    name = "bb",
+    amd64_sha256 = "54282799c6c2e4ca4e2589d8c9c23b7e7caa3a6faa87a53a06cbe990a353550e",
+    amd64_url = "https://github.com/buildbuddy-io/bazel/releases/download/5.0.321/bazel-5.0.321-linux-x86_64",
+    arm64_sha256 = "0d81fe62e060d6b8a862f1ea553afc571bba2aa2cbbff97c59ada3ea20b7d2bb",
+    arm64_url = "https://github.com/buildbuddy-io/bazel/releases/download/5.0.321/bazel-5.0.321-linux-arm64",
+    binary_name = "bb",
+    package_dir = "/usr/local/bin",
+)
 
 multiarch_http_file(
     name = "ttyd",

--- a/charts/goose-agent/image/BUILD
+++ b/charts/goose-agent/image/BUILD
@@ -1,0 +1,27 @@
+load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
+load("//tools/oci:apko_image.bzl", "apko_image")
+
+# Package the Goose config into the image at ~/.config/goose/config.yaml
+pkg_tar(
+    name = "config_tar",
+    srcs = ["config.yaml"],
+    mode = "0644",
+    owner = "65532.65532",
+    package_dir = "/home/goose-agent/.config/goose",
+)
+
+# Build the goose-agent image:
+#   apko base: bash, git, gh, go, node, pnpm (from Wolfi)
+#   multiarch tars: goose binary, bb (BuildBuddy CLI)
+#   regular tars: Goose config
+apko_image(
+    name = "image",
+    config = "apko.yaml",
+    contents = "@goose_agent_lock//:contents",
+    multiarch_tars = [
+        "@goose//:tar",
+        "@bb//:tar",
+    ],
+    repository = "ghcr.io/jomcgi/homelab/goose-agent",
+    tars = [":config_tar"],
+)

--- a/charts/goose-agent/image/apko.lock.json
+++ b/charts/goose-agent/image/apko.lock.json
@@ -1,0 +1,2919 @@
+{
+  "version": "v1",
+  "config": {
+    "name": "./charts/goose-agent/image/apko.yaml",
+    "checksum": "sha256-PCZiWR9hdt8JOHho4zX+abzdU+wCclvrSznR64MMwOQ="
+  },
+  "contents": {
+    "keyring": [
+      {
+        "name": "packages.wolfi.dev/os/wolfi-signing.rsa.pub",
+        "url": "https://packages.wolfi.dev/os/wolfi-signing.rsa.pub"
+      }
+    ],
+    "build_repositories": [],
+    "runtime_repositories": [],
+    "repositories": [
+      {
+        "name": "packages.wolfi.dev/os/x86_64",
+        "url": "https://packages.wolfi.dev/os/x86_64/APKINDEX.tar.gz",
+        "architecture": "x86_64"
+      },
+      {
+        "name": "packages.wolfi.dev/os/aarch64",
+        "url": "https://packages.wolfi.dev/os/aarch64/APKINDEX.tar.gz",
+        "architecture": "aarch64"
+      }
+    ],
+    "packages": [
+      {
+        "name": "wolfi-baselayout",
+        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r28.apk",
+        "version": "20230201-r28",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-1874",
+          "checksum": "sha1-mwFbm0URZnDYSuI8Q2COPu6RIKM="
+        },
+        "data": {
+          "range": "bytes=1875-13893",
+          "checksum": "sha256-urnBTxcmLJV8GooxYvZ0bCpR5iTdeQJNWfELGes9HTg="
+        },
+        "checksum": "Q1mwFbm0URZnDYSuI8Q2COPu6RIKM="
+      },
+      {
+        "name": "ca-certificates-bundle",
+        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20251003-r3.apk",
+        "version": "20251003-r3",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-7276",
+          "checksum": "sha1-uPsF66i1LFuOOuRIyW7EIY4rxEc="
+        },
+        "data": {
+          "range": "bytes=7277-139287",
+          "checksum": "sha256-OetqqaiETG2RtAPDyb2mQv4HBSYd/0y8mbsukojGfKI="
+        },
+        "checksum": "Q1uPsF66i1LFuOOuRIyW7EIY4rxEc="
+      },
+      {
+        "name": "ncurses-terminfo-base",
+        "url": "https://packages.wolfi.dev/os/x86_64/ncurses-terminfo-base-6.6_p20251230-r5.apk",
+        "version": "6.6_p20251230-r5",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-4812",
+          "checksum": "sha1-M/wXFHgujdz/HD+KJOL3IhZ3FTU="
+        },
+        "data": {
+          "range": "bytes=4813-106542",
+          "checksum": "sha256-COqiheUAQ7h1C49egdKCSb0fjr8FkCJ3gVKeHnAk9zM="
+        },
+        "checksum": "Q1M/wXFHgujdz/HD+KJOL3IhZ3FTU="
+      },
+      {
+        "name": "libgcc",
+        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-15.2.0-r10.apk",
+        "version": "15.2.0-r10",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-9584",
+          "checksum": "sha1-bdhf+eoIwvIRKWqbYi//U6x+j+A="
+        },
+        "data": {
+          "range": "bytes=9585-104119",
+          "checksum": "sha256-Xe7d1g4pQ13knP335sMnB0Hz9Y/sM72VrlyuIqf1VaE="
+        },
+        "checksum": "Q1bdhf+eoIwvIRKWqbYi//U6x+j+A="
+      },
+      {
+        "name": "glibc-locale-posix",
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.43-r2.apk",
+        "version": "2.43-r2",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-11042",
+          "checksum": "sha1-wYnSIuUpuocbJdgbW7XIPbU6JKw="
+        },
+        "data": {
+          "range": "bytes=11043-87728",
+          "checksum": "sha256-7mSLJt5b1XzRn5rp2fXgRORfFxWV68XE5fAVbpEpLtA="
+        },
+        "checksum": "Q1wYnSIuUpuocbJdgbW7XIPbU6JKw="
+      },
+      {
+        "name": "glibc",
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.43-r2.apk",
+        "version": "2.43-r2",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-11274",
+          "checksum": "sha1-Cob3kOxaTTRBo4g2BOSmkDrD0VU="
+        },
+        "data": {
+          "range": "bytes=11275-3017730",
+          "checksum": "sha256-YlUG8PTkqdtDlreIWXmR4MMA58ujAk9firY56W65WAM="
+        },
+        "checksum": "Q1Cob3kOxaTTRBo4g2BOSmkDrD0VU="
+      },
+      {
+        "name": "ld-linux",
+        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.43-r2.apk",
+        "version": "2.43-r2",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-11079",
+          "checksum": "sha1-EYCNqiW+Mi47U0/kVLGE1FUxaMY="
+        },
+        "data": {
+          "range": "bytes=11080-143081",
+          "checksum": "sha256-zTMt0gHSjxhn5qp/IlhuuCX/0o21Ahk/Utp+JHZ09y4="
+        },
+        "checksum": "Q1EYCNqiW+Mi47U0/kVLGE1FUxaMY="
+      },
+      {
+        "name": "ncurses",
+        "url": "https://packages.wolfi.dev/os/x86_64/ncurses-6.6_p20251230-r5.apk",
+        "version": "6.6_p20251230-r5",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-4931",
+          "checksum": "sha1-ORn0KiuFBQnzlIkNHgTf5Puq84I="
+        },
+        "data": {
+          "range": "bytes=4932-449192",
+          "checksum": "sha256-sv+Yor0xLkPXUZYpMhKUd9luti4I/BuLnCW92tHO65c="
+        },
+        "checksum": "Q1ORn0KiuFBQnzlIkNHgTf5Puq84I="
+      },
+      {
+        "name": "bash",
+        "url": "https://packages.wolfi.dev/os/x86_64/bash-5.3-r5.apk",
+        "version": "5.3-r5",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-4777",
+          "checksum": "sha1-ndANzXZUFH0pmPWxEhOttSyuWtI="
+        },
+        "data": {
+          "range": "bytes=4778-758590",
+          "checksum": "sha256-eflqITpoU10CJMJFoZqG8jSm4HydvFanOlNXRcbjAkw="
+        },
+        "checksum": "Q1ndANzXZUFH0pmPWxEhOttSyuWtI="
+      },
+      {
+        "name": "libxcrypt",
+        "url": "https://packages.wolfi.dev/os/x86_64/libxcrypt-4.5.2-r2.apk",
+        "version": "4.5.2-r2",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-7351",
+          "checksum": "sha1-Hd4hmmuoHyn1GTmAZseSSpDjRZg="
+        },
+        "data": {
+          "range": "bytes=7352-102849",
+          "checksum": "sha256-K67qe8YxV8RpTxkq9quau99j8AB4VuUtWo0MwOIRdtk="
+        },
+        "checksum": "Q1Hd4hmmuoHyn1GTmAZseSSpDjRZg="
+      },
+      {
+        "name": "libcrypt1",
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.43-r2.apk",
+        "version": "2.43-r2",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-11088",
+          "checksum": "sha1-rcSIkJh/Wv5+684R2lzLow8h/rE="
+        },
+        "data": {
+          "range": "bytes=11089-12610",
+          "checksum": "sha256-RNw3gLTLokd4bATPhmMax8Qlt45ZKK3YBcVAK3sGUKQ="
+        },
+        "checksum": "Q1rcSIkJh/Wv5+684R2lzLow8h/rE="
+      },
+      {
+        "name": "busybox",
+        "url": "https://packages.wolfi.dev/os/x86_64/busybox-1.37.0-r54.apk",
+        "version": "1.37.0-r54",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-8351",
+          "checksum": "sha1-37/dSBWyzocM5aQo8Q9q0hofVJo="
+        },
+        "data": {
+          "range": "bytes=8352-425144",
+          "checksum": "sha256-w71t3rYaSgRCxui2ba/H63B7Wlm0bTsBOOHWU4eDEzs="
+        },
+        "checksum": "Q137/dSBWyzocM5aQo8Q9q0hofVJo="
+      },
+      {
+        "name": "libacl1",
+        "url": "https://packages.wolfi.dev/os/x86_64/libacl1-2.3.2-r54.apk",
+        "version": "2.3.2-r54",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-6706",
+          "checksum": "sha1-/JQZFaXMysggjQNmeOUav7xEqg4="
+        },
+        "data": {
+          "range": "bytes=6707-27429",
+          "checksum": "sha256-rOp5f+h5E6s7DdUX6BeqG0YfawO1QKF2UTSWeAAmyHw="
+        },
+        "checksum": "Q1/JQZFaXMysggjQNmeOUav7xEqg4="
+      },
+      {
+        "name": "libattr1",
+        "url": "https://packages.wolfi.dev/os/x86_64/libattr1-2.5.2-r55.apk",
+        "version": "2.5.2-r55",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-7406",
+          "checksum": "sha1-+lu6T7Q5sBrSvcgVJvdlNZ5cpl0="
+        },
+        "data": {
+          "range": "bytes=7407-18770",
+          "checksum": "sha256-oiNa2kfrL7ZefHWRZn6BV8HlbPcZs4FQH8BjfVBJIxs="
+        },
+        "checksum": "Q1+lu6T7Q5sBrSvcgVJvdlNZ5cpl0="
+      },
+      {
+        "name": "libpcre2-8-0",
+        "url": "https://packages.wolfi.dev/os/x86_64/libpcre2-8-0-10.47-r0.apk",
+        "version": "10.47-r0",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-6848",
+          "checksum": "sha1-5bkXL31L9lMVsxJdyleMiTb2Esg="
+        },
+        "data": {
+          "range": "bytes=6849-307246",
+          "checksum": "sha256-LBagnNrkJtEnWnNJIYKGEllGZqRH6y5+9I9lQ05+NIs="
+        },
+        "checksum": "Q15bkXL31L9lMVsxJdyleMiTb2Esg="
+      },
+      {
+        "name": "libsepol",
+        "url": "https://packages.wolfi.dev/os/x86_64/libsepol-3.10-r0.apk",
+        "version": "3.10-r0",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-5853",
+          "checksum": "sha1-sIOnZX6zzzKgVaVITGQ1TsEBt8g="
+        },
+        "data": {
+          "range": "bytes=5854-441377",
+          "checksum": "sha256-7URt5I4D9uuOdvvM49599i1ECgBHX6/JTg2MPQMirWM="
+        },
+        "checksum": "Q1sIOnZX6zzzKgVaVITGQ1TsEBt8g="
+      },
+      {
+        "name": "libselinux",
+        "url": "https://packages.wolfi.dev/os/x86_64/libselinux-3.10-r0.apk",
+        "version": "3.10-r0",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-7251",
+          "checksum": "sha1-CM7/ih5kzO/43c2A1NI9lWvFHQQ="
+        },
+        "data": {
+          "range": "bytes=7252-318547",
+          "checksum": "sha256-JyOZS2AgOp7yzXMvmXgG+G71DBctZeyuEY15XddGXUU="
+        },
+        "checksum": "Q1CM7/ih5kzO/43c2A1NI9lWvFHQQ="
+      },
+      {
+        "name": "libcrypto3",
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.6.1-r2.apk",
+        "version": "3.6.1-r2",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-10404",
+          "checksum": "sha1-+ufDLFQFStzetM4sT3t2fdZipcM="
+        },
+        "data": {
+          "range": "bytes=10405-2360900",
+          "checksum": "sha256-Zi41ixjwKajifY8sMCBHZoC071e2MxiLo9Js//8FWy4="
+        },
+        "checksum": "Q1+ufDLFQFStzetM4sT3t2fdZipcM="
+      },
+      {
+        "name": "coreutils",
+        "url": "https://packages.wolfi.dev/os/x86_64/coreutils-9.10-r1.apk",
+        "version": "9.10-r1",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-8133",
+          "checksum": "sha1-2HK7aaZVS9wq1NLT4UeCxIYQWZE="
+        },
+        "data": {
+          "range": "bytes=8134-797857",
+          "checksum": "sha256-h9u5sECryPHkHXlNgH9e0Kew9M7HptWugmCbbD5+p9Y="
+        },
+        "checksum": "Q12HK7aaZVS9wq1NLT4UeCxIYQWZE="
+      },
+      {
+        "name": "gh",
+        "url": "https://packages.wolfi.dev/os/x86_64/gh-2.87.3-r0.apk",
+        "version": "2.87.3-r0",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-5133",
+          "checksum": "sha1-Dziy1Ycd/IyBTXLtWjGpFQILixY="
+        },
+        "data": {
+          "range": "bytes=5134-14900156",
+          "checksum": "sha256-4OiobJ/9i17Q44d+I65tjG+/rJCUymyLv9kRZzVU47Q="
+        },
+        "checksum": "Q1Dziy1Ycd/IyBTXLtWjGpFQILixY="
+      },
+      {
+        "name": "zlib",
+        "url": "https://packages.wolfi.dev/os/x86_64/zlib-1.3.2-r1.apk",
+        "version": "1.3.2-r1",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-8189",
+          "checksum": "sha1-ZeYFok2h2i7pZXa/UbB8AJUbMOg="
+        },
+        "data": {
+          "range": "bytes=8190-70388",
+          "checksum": "sha256-GT2jfwUKEwZkhvwSxuhL9Stpe4RLVGn+ja4T8pjvaIc="
+        },
+        "checksum": "Q1ZeYFok2h2i7pZXa/UbB8AJUbMOg="
+      },
+      {
+        "name": "libexpat1",
+        "url": "https://packages.wolfi.dev/os/x86_64/libexpat1-2.7.4-r3.apk",
+        "version": "2.7.4-r3",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-5055",
+          "checksum": "sha1-J6sRMj6a89BEeEHph4cIzVApUwg="
+        },
+        "data": {
+          "range": "bytes=5056-88470",
+          "checksum": "sha256-isweyIeZ6MmM4TEHVqAXzb/bVStdBgsKiHyNc5a5Gww="
+        },
+        "checksum": "Q1J6sRMj6a89BEeEHph4cIzVApUwg="
+      },
+      {
+        "name": "libunistring",
+        "url": "https://packages.wolfi.dev/os/x86_64/libunistring-1.4.2-r0.apk",
+        "version": "1.4.2-r0",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-3950",
+          "checksum": "sha1-wdGfu4KepYDBrKoGOi3wqrOHoZY="
+        },
+        "data": {
+          "range": "bytes=3951-971941",
+          "checksum": "sha256-QUhWKyYpMMSSItaUFmykM/9ZHeUI+jjalp4DirUnwCA="
+        },
+        "checksum": "Q1wdGfu4KepYDBrKoGOi3wqrOHoZY="
+      },
+      {
+        "name": "libidn2",
+        "url": "https://packages.wolfi.dev/os/x86_64/libidn2-2.3.8-r4.apk",
+        "version": "2.3.8-r4",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-4283",
+          "checksum": "sha1-H5NE3PC0vcmbE5hKamLobdfzFYg="
+        },
+        "data": {
+          "range": "bytes=4284-130773",
+          "checksum": "sha256-EfJ3avs5XbxB6bhskEg62V9H5XF4YqDrgnhTATfz1Qw="
+        },
+        "checksum": "Q1H5NE3PC0vcmbE5hKamLobdfzFYg="
+      },
+      {
+        "name": "libpsl",
+        "url": "https://packages.wolfi.dev/os/x86_64/libpsl-0.21.5-r7.apk",
+        "version": "0.21.5-r7",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-6966",
+          "checksum": "sha1-ignuNkbN+Ujaq8T4jxaq42FLBZo="
+        },
+        "data": {
+          "range": "bytes=6967-68230",
+          "checksum": "sha256-idZrHv4I7/ff2Tkw9cwOYL3RqjYFGA8GT2rZAoebTkc="
+        },
+        "checksum": "Q1ignuNkbN+Ujaq8T4jxaq42FLBZo="
+      },
+      {
+        "name": "libbrotlicommon1",
+        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlicommon1-1.2.0-r1.apk",
+        "version": "1.2.0-r1",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-5720",
+          "checksum": "sha1-8W75xZPekcxpRQc7Rjau7aDICg4="
+        },
+        "data": {
+          "range": "bytes=5721-75591",
+          "checksum": "sha256-T5oQD72nCSQc5+LNzfcvOsecQJ0fgHsET7slU/eYJv0="
+        },
+        "checksum": "Q18W75xZPekcxpRQc7Rjau7aDICg4="
+      },
+      {
+        "name": "libbrotlidec1",
+        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlidec1-1.2.0-r1.apk",
+        "version": "1.2.0-r1",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-5731",
+          "checksum": "sha1-uYGCtevwN4il39gIr24tPutP8Tw="
+        },
+        "data": {
+          "range": "bytes=5732-37023",
+          "checksum": "sha256-L6JfADow/ORXenVYb+N5nTXw0JoC/onPJqpuuCylhsM="
+        },
+        "checksum": "Q1uYGCtevwN4il39gIr24tPutP8Tw="
+      },
+      {
+        "name": "nghttp3",
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp3-1.15.0-r1.apk",
+        "version": "1.15.0-r1",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-6086",
+          "checksum": "sha1-Q0D9aYr/iDaT+ziBmBjONJvTICQ="
+        },
+        "data": {
+          "range": "bytes=6087-103181",
+          "checksum": "sha256-wGd7ryn9K9OSDkBhu8GItA/kqxR5VXMqxSJDgZon+Rk="
+        },
+        "checksum": "Q1Q0D9aYr/iDaT+ziBmBjONJvTICQ="
+      },
+      {
+        "name": "libnghttp2-14",
+        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.68.0-r1.apk",
+        "version": "1.68.0-r1",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-6774",
+          "checksum": "sha1-UdtVYFgumPM6x9hczhJVGRySo/M="
+        },
+        "data": {
+          "range": "bytes=6775-105426",
+          "checksum": "sha256-Ev3bIWlpkxQyq3+0jubSD3U0IZ4zR7/ZL4DZfjAktIk="
+        },
+        "checksum": "Q1UdtVYFgumPM6x9hczhJVGRySo/M="
+      },
+      {
+        "name": "libverto",
+        "url": "https://packages.wolfi.dev/os/x86_64/libverto-0.3.2-r6.apk",
+        "version": "0.3.2-r6",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-5926",
+          "checksum": "sha1-gnPEX/D3QZLHFoD3MdL0XzWk11Q="
+        },
+        "data": {
+          "range": "bytes=5927-18863",
+          "checksum": "sha256-7G7tkgmU/XoawtlJNCR49y6bITsfAzQ0AVg8fHn8F6Y="
+        },
+        "checksum": "Q1gnPEX/D3QZLHFoD3MdL0XzWk11Q="
+      },
+      {
+        "name": "krb5-conf",
+        "url": "https://packages.wolfi.dev/os/x86_64/krb5-conf-1.0-r8.apk",
+        "version": "1.0-r8",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-1055",
+          "checksum": "sha1-7DdnzLKUNkstFNxYRBcvNG3SImg="
+        },
+        "data": {
+          "range": "bytes=1056-2776",
+          "checksum": "sha256-gVk1p5pWK5QeMHk1CPB1nHCMcSTBf8Qft8E0XxdzOaM="
+        },
+        "checksum": "Q17DdnzLKUNkstFNxYRBcvNG3SImg="
+      },
+      {
+        "name": "libcom_err",
+        "url": "https://packages.wolfi.dev/os/x86_64/libcom_err-1.47.3-r3.apk",
+        "version": "1.47.3-r3",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-8102",
+          "checksum": "sha1-OTGFrHfTsMZedDaw4TG0dvo5GSg="
+        },
+        "data": {
+          "range": "bytes=8103-16561",
+          "checksum": "sha256-sD8FhW+QEgkICvztFwRwim9Bc6v3PFvTuNI8kWOlkXY="
+        },
+        "checksum": "Q1OTGFrHfTsMZedDaw4TG0dvo5GSg="
+      },
+      {
+        "name": "keyutils-libs",
+        "url": "https://packages.wolfi.dev/os/x86_64/keyutils-libs-1.6.3-r38.apk",
+        "version": "1.6.3-r38",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-7279",
+          "checksum": "sha1-n6vDDtjepPx8dX6+DNE1ZryKl+A="
+        },
+        "data": {
+          "range": "bytes=7280-17714",
+          "checksum": "sha256-LObgKe6wZKNDXK5PALdGfj3iSGZlvsQvBjy0z7fOaIA="
+        },
+        "checksum": "Q1n6vDDtjepPx8dX6+DNE1ZryKl+A="
+      },
+      {
+        "name": "libssl3",
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.6.1-r2.apk",
+        "version": "3.6.1-r2",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-10409",
+          "checksum": "sha1-E8SlIgq/Ux+j/EAvCfXqs4r3nxc="
+        },
+        "data": {
+          "range": "bytes=10410-499068",
+          "checksum": "sha256-7UQX6GkXo210dZgD7UUpZ/2kblgytQ1i3Wil5JGOGl4="
+        },
+        "checksum": "Q1E8SlIgq/Ux+j/EAvCfXqs4r3nxc="
+      },
+      {
+        "name": "krb5-libs",
+        "url": "https://packages.wolfi.dev/os/x86_64/krb5-libs-1.22.2-r1.apk",
+        "version": "1.22.2-r1",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-8594",
+          "checksum": "sha1-AVlyFZhO++5jrY3Nga/bqISGUts="
+        },
+        "data": {
+          "range": "bytes=8595-1047609",
+          "checksum": "sha256-U2kVAsrI3+4h/iiy1mNc2rMeFqO5qFxNMOiPb+r6tqA="
+        },
+        "checksum": "Q1AVlyFZhO++5jrY3Nga/bqISGUts="
+      },
+      {
+        "name": "readline",
+        "url": "https://packages.wolfi.dev/os/x86_64/readline-8.3-r1.apk",
+        "version": "8.3-r1",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-3887",
+          "checksum": "sha1-vL4XjVse3ZTOexy4Rl4c2olko9s="
+        },
+        "data": {
+          "range": "bytes=3888-339634",
+          "checksum": "sha256-MO7S4LbvC4dyv4Lzk8eq1BPdU/CveFeJVR11vqHZQ+Q="
+        },
+        "checksum": "Q1vL4XjVse3ZTOexy4Rl4c2olko9s="
+      },
+      {
+        "name": "sqlite-libs",
+        "url": "https://packages.wolfi.dev/os/x86_64/sqlite-libs-3.51.1-r0.apk",
+        "version": "3.51.1-r0",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-4684",
+          "checksum": "sha1-0DYaC8Zxf5Ji2/ceNQ2iTNGYd1U="
+        },
+        "data": {
+          "range": "bytes=4685-888468",
+          "checksum": "sha256-pwucqxbYhCAmO+OMEgHhmqx0fJZv8KXzLRmlhdGP9as="
+        },
+        "checksum": "Q10DYaC8Zxf5Ji2/ceNQ2iTNGYd1U="
+      },
+      {
+        "name": "heimdal-libs",
+        "url": "https://packages.wolfi.dev/os/x86_64/heimdal-libs-7.8.0-r43.apk",
+        "version": "7.8.0-r43",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-5683",
+          "checksum": "sha1-OBFnM03+D/9elqMi4Jy5tN2WU0M="
+        },
+        "data": {
+          "range": "bytes=5684-1422420",
+          "checksum": "sha256-5m//SMqQcN9TxwxEFbC9V7nlI0K2+hkVOeFGjiFN/UA="
+        },
+        "checksum": "Q1OBFnM03+D/9elqMi4Jy5tN2WU0M="
+      },
+      {
+        "name": "gdbm",
+        "url": "https://packages.wolfi.dev/os/x86_64/gdbm-1.26-r2.apk",
+        "version": "1.26-r2",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-4366",
+          "checksum": "sha1-N10i5WoMAyuSuPO9nrQRLnhk+yU="
+        },
+        "data": {
+          "range": "bytes=4367-256649",
+          "checksum": "sha256-oiWVbSFrlfJ3dMhn0VwLofRflZlVyfS/L1cVSKgxCkk="
+        },
+        "checksum": "Q1N10i5WoMAyuSuPO9nrQRLnhk+yU="
+      },
+      {
+        "name": "cyrus-sasl",
+        "url": "https://packages.wolfi.dev/os/x86_64/cyrus-sasl-2.1.28-r46.apk",
+        "version": "2.1.28-r46",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-7979",
+          "checksum": "sha1-MkAbhUkGTvbD9NsQ2fushy+u8W8="
+        },
+        "data": {
+          "range": "bytes=7980-276512",
+          "checksum": "sha256-lljb1vDIZ234PEObohWr0p+vQiQ51P/Mbey9QeI59OQ="
+        },
+        "checksum": "Q1MkAbhUkGTvbD9NsQ2fushy+u8W8="
+      },
+      {
+        "name": "libldap-2.6",
+        "url": "https://packages.wolfi.dev/os/x86_64/libldap-2.6-2.6.12-r3.apk",
+        "version": "2.6.12-r3",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-11330",
+          "checksum": "sha1-mYxBrNCSLT8gBOydaU+mIcB7cqQ="
+        },
+        "data": {
+          "range": "bytes=11331-252576",
+          "checksum": "sha256-nTOGHHReM2TspYXQn8pE4TZm16FniisS/DMVyiZ947w="
+        },
+        "checksum": "Q1mYxBrNCSLT8gBOydaU+mIcB7cqQ="
+      },
+      {
+        "name": "libcurl-openssl4",
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.18.0-r3.apk",
+        "version": "8.18.0-r3",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-11865",
+          "checksum": "sha1-iCoLW5PeALqfhpmr+V4D7sSOtPc="
+        },
+        "data": {
+          "range": "bytes=11866-514545",
+          "checksum": "sha256-dQ3Dw95sjJTEB2ml6593JqQ4kiD81bnf1+bULqaTYsQ="
+        },
+        "checksum": "Q1iCoLW5PeALqfhpmr+V4D7sSOtPc="
+      },
+      {
+        "name": "git",
+        "url": "https://packages.wolfi.dev/os/x86_64/git-2.53.0-r0.apk",
+        "version": "2.53.0-r0",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-11609",
+          "checksum": "sha1-EIDuzQKRhfIPn/bwSDbemXaYLyE="
+        },
+        "data": {
+          "range": "bytes=11610-9222038",
+          "checksum": "sha256-+LMU2wVP0vRYRidbukap0a2kqFcUQU0+GiFocIa9Fow="
+        },
+        "checksum": "Q1EIDuzQKRhfIPn/bwSDbemXaYLyE="
+      },
+      {
+        "name": "make",
+        "url": "https://packages.wolfi.dev/os/x86_64/make-4.4.1-r9.apk",
+        "version": "4.4.1-r9",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-3085",
+          "checksum": "sha1-igtxNLv+6qe04K4MrLUdpUjeFCY="
+        },
+        "data": {
+          "range": "bytes=3086-623373",
+          "checksum": "sha256-aYxCES7LRB97qbR/X5xQtjvNYQsWM5tTCqW7BZcrRRo="
+        },
+        "checksum": "Q1igtxNLv+6qe04K4MrLUdpUjeFCY="
+      },
+      {
+        "name": "pkgconf",
+        "url": "https://packages.wolfi.dev/os/x86_64/pkgconf-2.5.1-r1.apk",
+        "version": "2.5.1-r1",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-6334",
+          "checksum": "sha1-jfHR2LwPIB4Tw1OyfIuN/dsUtKA="
+        },
+        "data": {
+          "range": "bytes=6335-82003",
+          "checksum": "sha256-Zm1wu3tfHF4rNyjfdpaM0RrihHdHDZ4Cx4/8DdUkyWA="
+        },
+        "checksum": "Q1jfHR2LwPIB4Tw1OyfIuN/dsUtKA="
+      },
+      {
+        "name": "libzstd1",
+        "url": "https://packages.wolfi.dev/os/x86_64/libzstd1-1.5.7-r7.apk",
+        "version": "1.5.7-r7",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-6956",
+          "checksum": "sha1-cTRXxDInIFx3GcTLSFkQjw/z+j0="
+        },
+        "data": {
+          "range": "bytes=6957-585257",
+          "checksum": "sha256-tRC0QBdYQbVFn29Y8yeoyZKVw18mpafC9XeKgEIzYnc="
+        },
+        "checksum": "Q1cTRXxDInIFx3GcTLSFkQjw/z+j0="
+      },
+      {
+        "name": "libstdc++",
+        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-15.2.0-r10.apk",
+        "version": "15.2.0-r10",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-9592",
+          "checksum": "sha1-BTRjwfufQkPEUyLe83d5IzpcxaM="
+        },
+        "data": {
+          "range": "bytes=9593-1135865",
+          "checksum": "sha256-CgtoswglIYtuWzIR9iv9w7F/Mjd1aqgZ4UW/96s7VuQ="
+        },
+        "checksum": "Q1BTRjwfufQkPEUyLe83d5IzpcxaM="
+      },
+      {
+        "name": "binutils",
+        "url": "https://packages.wolfi.dev/os/x86_64/binutils-2.46-r1.apk",
+        "version": "2.46-r1",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-7130",
+          "checksum": "sha1-TOCRj7XW/xyuV03yCgGkLWn9xhA="
+        },
+        "data": {
+          "range": "bytes=7131-23997511",
+          "checksum": "sha256-1NqQ7siA8lSEPz9QP2Yl3QxSFf4AYQZkCpSphrPxNzs="
+        },
+        "checksum": "Q1TOCRj7XW/xyuV03yCgGkLWn9xhA="
+      },
+      {
+        "name": "libxcrypt-dev",
+        "url": "https://packages.wolfi.dev/os/x86_64/libxcrypt-dev-4.5.2-r2.apk",
+        "version": "4.5.2-r2",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-7377",
+          "checksum": "sha1-u5Opo06J5zJko1RTSVdZA50Ljgg="
+        },
+        "data": {
+          "range": "bytes=7378-422245",
+          "checksum": "sha256-q+g2z+0msgzQud9f0hmMX3G8hkKtrByXR/J7qR8UCt4="
+        },
+        "checksum": "Q1u5Opo06J5zJko1RTSVdZA50Ljgg="
+      },
+      {
+        "name": "nss-db",
+        "url": "https://packages.wolfi.dev/os/x86_64/nss-db-2.43-r2.apk",
+        "version": "2.43-r2",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-11114",
+          "checksum": "sha1-LXFR1U6PPskW56usowvdlAUdh+o="
+        },
+        "data": {
+          "range": "bytes=11115-36927",
+          "checksum": "sha256-K8yHcVsXEZ3PS9SW18+t9Q2KMqoRvD+f581/nrFV3Zw="
+        },
+        "checksum": "Q1LXFR1U6PPskW56usowvdlAUdh+o="
+      },
+      {
+        "name": "nss-hesiod",
+        "url": "https://packages.wolfi.dev/os/x86_64/nss-hesiod-2.43-r2.apk",
+        "version": "2.43-r2",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-11100",
+          "checksum": "sha1-cXG5VGb/F//YP1nrnINRaFVz/iA="
+        },
+        "data": {
+          "range": "bytes=11101-22772",
+          "checksum": "sha256-bUZcUALG6Nbt9qVULPPojh1eMkJuLhmff98MPvyDQVw="
+        },
+        "checksum": "Q1cXG5VGb/F//YP1nrnINRaFVz/iA="
+      },
+      {
+        "name": "linux-headers",
+        "url": "https://packages.wolfi.dev/os/x86_64/linux-headers-6.19.6-r0.apk",
+        "version": "6.19.6-r0",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-4682",
+          "checksum": "sha1-nH/NRTpfs5xr8eXuO1+GmjYoxv8="
+        },
+        "data": {
+          "range": "bytes=4683-2086660",
+          "checksum": "sha256-cGZGIiPui/d6sKeUWZi5Y9eexj/8AowqvbfrmhWw6+k="
+        },
+        "checksum": "Q1nH/NRTpfs5xr8eXuO1+GmjYoxv8="
+      },
+      {
+        "name": "glibc-dev",
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-dev-2.43-r2.apk",
+        "version": "2.43-r2",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-11130",
+          "checksum": "sha1-ddzsUs8zxX7NTP02nacltP/qJv4="
+        },
+        "data": {
+          "range": "bytes=11131-14919091",
+          "checksum": "sha256-GYFFVguVj4gm1/jobZ0Lyu9K+iLzuYPSQfhHEo1EXH8="
+        },
+        "checksum": "Q1ddzsUs8zxX7NTP02nacltP/qJv4="
+      },
+      {
+        "name": "gmp",
+        "url": "https://packages.wolfi.dev/os/x86_64/gmp-6.3.0-r8.apk",
+        "version": "6.3.0-r8",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-3146",
+          "checksum": "sha1-EmPqkatD3RZaAekI7H2++FuHDEU="
+        },
+        "data": {
+          "range": "bytes=3147-312348",
+          "checksum": "sha256-wA6I5IvLGyLMG9gUHXskQXXvqmjL2lN10jiFYeP+WVk="
+        },
+        "checksum": "Q1EmPqkatD3RZaAekI7H2++FuHDEU="
+      },
+      {
+        "name": "mpfr",
+        "url": "https://packages.wolfi.dev/os/x86_64/mpfr-4.2.2-r2.apk",
+        "version": "4.2.2-r2",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-5046",
+          "checksum": "sha1-/LLzx2/nYW2VqxniABVTyQTkW2U="
+        },
+        "data": {
+          "range": "bytes=5047-719833",
+          "checksum": "sha256-Y0fLqKxVKcfeq2x2nJcRxgwBpEn1wz+uNpkc1fAsOzg="
+        },
+        "checksum": "Q1/LLzx2/nYW2VqxniABVTyQTkW2U="
+      },
+      {
+        "name": "mpc",
+        "url": "https://packages.wolfi.dev/os/x86_64/mpc-1.3.1-r7.apk",
+        "version": "1.3.1-r7",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-5544",
+          "checksum": "sha1-1Y6FRNd0nJLrzzxbD2xmrGiIPnw="
+        },
+        "data": {
+          "range": "bytes=5545-73393",
+          "checksum": "sha256-DDjyG2Gj0Ygr2jm1R2N5DP3U0T0Pxhj9jfDONbCwAzo="
+        },
+        "checksum": "Q11Y6FRNd0nJLrzzxbD2xmrGiIPnw="
+      },
+      {
+        "name": "posix-cc-wrappers",
+        "url": "https://packages.wolfi.dev/os/x86_64/posix-cc-wrappers-2-r8.apk",
+        "version": "2-r8",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-1363",
+          "checksum": "sha1-Y7aZ3LPD1tgJuXyh783Tr3oqiMU="
+        },
+        "data": {
+          "range": "bytes=1364-3191",
+          "checksum": "sha256-nUo5O5LRkFKprvI5g6W7LqDWA/+6UaV0hvEoUbD+03w="
+        },
+        "checksum": "Q1Y7aZ3LPD1tgJuXyh783Tr3oqiMU="
+      },
+      {
+        "name": "isl",
+        "url": "https://packages.wolfi.dev/os/x86_64/isl-0.27-r5.apk",
+        "version": "0.27-r5",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-5837",
+          "checksum": "sha1-9Jv0nJ0ZiNdW70NsaboIzlNFFas="
+        },
+        "data": {
+          "range": "bytes=5838-1075712",
+          "checksum": "sha256-5n1pjwxJkLeLcX9/H+bK958VGN1kZ5XY1CI8ULyQlfo="
+        },
+        "checksum": "Q19Jv0nJ0ZiNdW70NsaboIzlNFFas="
+      },
+      {
+        "name": "libquadmath",
+        "url": "https://packages.wolfi.dev/os/x86_64/libquadmath-15.2.0-r10.apk",
+        "version": "15.2.0-r10",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-9587",
+          "checksum": "sha1-2sLil2/KjkwwvRr11gf9BOh9gQ8="
+        },
+        "data": {
+          "range": "bytes=9588-182213",
+          "checksum": "sha256-BWLK/RcKlCzURMCFUfw2RPpaaRHKCvuYuLAKBFV9Xd4="
+        },
+        "checksum": "Q12sLil2/KjkwwvRr11gf9BOh9gQ8="
+      },
+      {
+        "name": "libstdc++-dev",
+        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-dev-15.2.0-r10.apk",
+        "version": "15.2.0-r10",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-9561",
+          "checksum": "sha1-9v7alv0M70qs/3XwNkR/Won/Cy0="
+        },
+        "data": {
+          "range": "bytes=9562-14345082",
+          "checksum": "sha256-SiIgYSj1l7qSRXA45UK7w9D1fnhMWEc5hH7/QV5itms="
+        },
+        "checksum": "Q19v7alv0M70qs/3XwNkR/Won/Cy0="
+      },
+      {
+        "name": "libatomic",
+        "url": "https://packages.wolfi.dev/os/x86_64/libatomic-15.2.0-r10.apk",
+        "version": "15.2.0-r10",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-9574",
+          "checksum": "sha1-ha5w2lk0dVH7cCpqB0G91BS/bJA="
+        },
+        "data": {
+          "range": "bytes=9575-25157",
+          "checksum": "sha256-uIf8O+/DEBNSxCzWuJ3oIc+WUgJ7u/CHNPvQry6KGcM="
+        },
+        "checksum": "Q1ha5w2lk0dVH7cCpqB0G91BS/bJA="
+      },
+      {
+        "name": "libgomp",
+        "url": "https://packages.wolfi.dev/os/x86_64/libgomp-15.2.0-r10.apk",
+        "version": "15.2.0-r10",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-9576",
+          "checksum": "sha1-xdCaT1WzJi04LNUeFRtJIKwx8DA="
+        },
+        "data": {
+          "range": "bytes=9577-193562",
+          "checksum": "sha256-L2aQ+9fY8XyfEIoVectUQv6Aeq0cji0aTdtkPloIPBY="
+        },
+        "checksum": "Q1xdCaT1WzJi04LNUeFRtJIKwx8DA="
+      },
+      {
+        "name": "openssf-compiler-options",
+        "url": "https://packages.wolfi.dev/os/x86_64/openssf-compiler-options-20250904-r4.apk",
+        "version": "20250904-r4",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-3063",
+          "checksum": "sha1-k2SOrWqbGefldaGDLGZ7lNi6A70="
+        },
+        "data": {
+          "range": "bytes=3064-10238",
+          "checksum": "sha256-Z11E+t/WjSNQf8VlDqJro4NgjCZwS0bqycBn5b0iV34="
+        },
+        "checksum": "Q1k2SOrWqbGefldaGDLGZ7lNi6A70="
+      },
+      {
+        "name": "gcc",
+        "url": "https://packages.wolfi.dev/os/x86_64/gcc-15.2.0-r10.apk",
+        "version": "15.2.0-r10",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-9863",
+          "checksum": "sha1-yQQZD4e669DchtmEh+bGzO5Y6RE="
+        },
+        "data": {
+          "range": "bytes=9864-125543423",
+          "checksum": "sha256-0qOxHSw5g/PW4e1mgVNRyrp2jq6Yzne+y7HSE/R/HQw="
+        },
+        "checksum": "Q1yQQZD4e669DchtmEh+bGzO5Y6RE="
+      },
+      {
+        "name": "build-base",
+        "url": "https://packages.wolfi.dev/os/x86_64/build-base-1-r9.apk",
+        "version": "1-r9",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-1227",
+          "checksum": "sha1-G0NI46h68hOHKdcZuxbqUZDNs+c="
+        },
+        "data": {
+          "range": "bytes=1228-2288",
+          "checksum": "sha256-jlNGrgo58mBV689VMd6bNndFK3dM8NWcU4w3TiSOKbE="
+        },
+        "checksum": "Q1G0NI46h68hOHKdcZuxbqUZDNs+c="
+      },
+      {
+        "name": "go-1.25",
+        "url": "https://packages.wolfi.dev/os/x86_64/go-1.25-1.25.8-r0.apk",
+        "version": "1.25.8-r0",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-7359",
+          "checksum": "sha1-56UCxw7FalIZpqVkvcbtBDnzi1A="
+        },
+        "data": {
+          "range": "bytes=7360-50405502",
+          "checksum": "sha256-ThJDuUsNtkcvPwKFb3oIylLLyYenlSI7Jse/ATvbk7s="
+        },
+        "checksum": "Q156UCxw7FalIZpqVkvcbtBDnzi1A="
+      },
+      {
+        "name": "icu78-data-full",
+        "url": "https://packages.wolfi.dev/os/x86_64/icu78-data-full-78.2-r0.apk",
+        "version": "78.2-r0",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-5588",
+          "checksum": "sha1-5hXurelz0z5tMLyhvLCDg97CxQU="
+        },
+        "data": {
+          "range": "bytes=5589-13975201",
+          "checksum": "sha256-snqGr9oGKnNJJ2HeUC1wXoR3qgp8wTLTLEhNh/zGSTk="
+        },
+        "checksum": "Q15hXurelz0z5tMLyhvLCDg97CxQU="
+      },
+      {
+        "name": "libicu78",
+        "url": "https://packages.wolfi.dev/os/x86_64/libicu78-78.2-r0.apk",
+        "version": "78.2-r0",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-5683",
+          "checksum": "sha1-evtOYNphwXT6883kspGcZ2U8hjA="
+        },
+        "data": {
+          "range": "bytes=5684-3044652",
+          "checksum": "sha256-ZFE6Eez5jLJNTy1Cid9cskUjjeJG7cWBj5zq6NTcbfU="
+        },
+        "checksum": "Q1evtOYNphwXT6883kspGcZ2U8hjA="
+      },
+      {
+        "name": "libbrotlienc1",
+        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlienc1-1.2.0-r1.apk",
+        "version": "1.2.0-r1",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-5733",
+          "checksum": "sha1-2hoGLMkBWJQouNj8PaqDoj+MuSk="
+        },
+        "data": {
+          "range": "bytes=5734-445593",
+          "checksum": "sha256-V5brLuBMoiBGU++W6TRo3XVgzdWmQHGdcnfZJY8RvrM="
+        },
+        "checksum": "Q12hoGLMkBWJQouNj8PaqDoj+MuSk="
+      },
+      {
+        "name": "libuv",
+        "url": "https://packages.wolfi.dev/os/x86_64/libuv-1.52.0-r0.apk",
+        "version": "1.52.0-r0",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-6179",
+          "checksum": "sha1-xrBd8ZSFVJs8ClTpe3oHncku6Qk="
+        },
+        "data": {
+          "range": "bytes=6180-127602",
+          "checksum": "sha256-tx7zTX6MSsr+kUxMdZ3OZzbsuyJFmBzeCzpqJvrNMsI="
+        },
+        "checksum": "Q1xrBd8ZSFVJs8ClTpe3oHncku6Qk="
+      },
+      {
+        "name": "c-ares",
+        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.34.6-r0.apk",
+        "version": "1.34.6-r0",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-6504",
+          "checksum": "sha1-csguXCW/1pGYLPUIv9qYi61c7RI="
+        },
+        "data": {
+          "range": "bytes=6505-150282",
+          "checksum": "sha256-NcEFNufEOPOnxczt9rps+TJeXLzJTtyqqWg5eP4dJjs="
+        },
+        "checksum": "Q1csguXCW/1pGYLPUIv9qYi61c7RI="
+      },
+      {
+        "name": "nodejs-25",
+        "url": "https://packages.wolfi.dev/os/x86_64/nodejs-25-25.8.0-r0.apk",
+        "version": "25.8.0-r0",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-6588",
+          "checksum": "sha1-wXx/+K64RV/2PMLmKGW91e94U5w="
+        },
+        "data": {
+          "range": "bytes=6589-31715983",
+          "checksum": "sha256-Xt/4X9/xitqpJHmiRQOej4FyFPS7QB1lMZGxYJDwNCE="
+        },
+        "checksum": "Q1wXx/+K64RV/2PMLmKGW91e94U5w="
+      },
+      {
+        "name": "libedit",
+        "url": "https://packages.wolfi.dev/os/x86_64/libedit-3.1-r15.apk",
+        "version": "3.1-r15",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-4754",
+          "checksum": "sha1-cghakUVqoeCIaCqCgWTnK20PWAY="
+        },
+        "data": {
+          "range": "bytes=4755-115967",
+          "checksum": "sha256-0gcTiWICdmamcq+6SfbhuqkYqbz7aR3WezaC8RZQCdw="
+        },
+        "checksum": "Q1cghakUVqoeCIaCqCgWTnK20PWAY="
+      },
+      {
+        "name": "openssh-client",
+        "url": "https://packages.wolfi.dev/os/x86_64/openssh-client-10.2_p1-r3.apk",
+        "version": "10.2_p1-r3",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-7351",
+          "checksum": "sha1-gHTs2P7PUiRkhBo4wqJzM7ydbw0="
+        },
+        "data": {
+          "range": "bytes=7352-1147734",
+          "checksum": "sha256-c5kAJTNKWe5LgOmMwCh97O21zg1Q2lstw1voVkt6+pA="
+        },
+        "checksum": "Q1gHTs2P7PUiRkhBo4wqJzM7ydbw0="
+      },
+      {
+        "name": "pnpm",
+        "url": "https://packages.wolfi.dev/os/x86_64/pnpm-10.30.3-r0.apk",
+        "version": "10.30.3-r0",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-4981",
+          "checksum": "sha1-eeH60W/H5qXFawH9luh+RLhwfzk="
+        },
+        "data": {
+          "range": "bytes=4982-1968639",
+          "checksum": "sha256-7ZMkGDT4q4bPY2JitbTcmIrp62ptXR61Tu3F9nA3eNA="
+        },
+        "checksum": "Q1eeH60W/H5qXFawH9luh+RLhwfzk="
+      },
+      {
+        "name": "tzdata",
+        "url": "https://packages.wolfi.dev/os/x86_64/tzdata-2026a-r0.apk",
+        "version": "2026a-r0",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-4808",
+          "checksum": "sha1-5W7T9ZMwEnJZzs4q5cETY3RFkr4="
+        },
+        "data": {
+          "range": "bytes=4809-569024",
+          "checksum": "sha256-naAT+v7J4uZVUeFtN3cosAIAl3f1RrLDfNh3pcz8O7k="
+        },
+        "checksum": "Q15W7T9ZMwEnJZzs4q5cETY3RFkr4="
+      },
+      {
+        "name": "wolfi-baselayout",
+        "url": "https://packages.wolfi.dev/os/aarch64/wolfi-baselayout-20230201-r28.apk",
+        "version": "20230201-r28",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-1904",
+          "checksum": "sha1-n4xA1Jg9t8XhPROt45YLbfKhU8g="
+        },
+        "data": {
+          "range": "bytes=1905-13920",
+          "checksum": "sha256-8EwAL2GPWjrGJyh8gj5hq3QTP6K1BliyryTLsatXI0A="
+        },
+        "checksum": "Q1n4xA1Jg9t8XhPROt45YLbfKhU8g="
+      },
+      {
+        "name": "ca-certificates-bundle",
+        "url": "https://packages.wolfi.dev/os/aarch64/ca-certificates-bundle-20251003-r3.apk",
+        "version": "20251003-r3",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-7313",
+          "checksum": "sha1-vy8pnQXAheVK8I4eNp+cgeJWzx0="
+        },
+        "data": {
+          "range": "bytes=7314-139324",
+          "checksum": "sha256-Usxt3c5CrsfHpkAf4uPnQgsNWo56z/X7sNIRS5OSoxA="
+        },
+        "checksum": "Q1vy8pnQXAheVK8I4eNp+cgeJWzx0="
+      },
+      {
+        "name": "ncurses-terminfo-base",
+        "url": "https://packages.wolfi.dev/os/aarch64/ncurses-terminfo-base-6.6_p20251230-r5.apk",
+        "version": "6.6_p20251230-r5",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-4847",
+          "checksum": "sha1-sKMhTpww0nw2pyGCorWmpWNcVu0="
+        },
+        "data": {
+          "range": "bytes=4848-106568",
+          "checksum": "sha256-cP8kzumZCzgh3vJTYzoXPBMsgaL4G8ZdnlYt2+ShZAo="
+        },
+        "checksum": "Q1sKMhTpww0nw2pyGCorWmpWNcVu0="
+      },
+      {
+        "name": "libgcc",
+        "url": "https://packages.wolfi.dev/os/aarch64/libgcc-15.2.0-r10.apk",
+        "version": "15.2.0-r10",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-9607",
+          "checksum": "sha1-/UODyhZSJE4TgWBkeQWziUgECo4="
+        },
+        "data": {
+          "range": "bytes=9608-86311",
+          "checksum": "sha256-dWPDgsB5A7B8pJpDzDBNhefc3z/aoghRUFAgr+n3vTc="
+        },
+        "checksum": "Q1/UODyhZSJE4TgWBkeQWziUgECo4="
+      },
+      {
+        "name": "glibc-locale-posix",
+        "url": "https://packages.wolfi.dev/os/aarch64/glibc-locale-posix-2.43-r2.apk",
+        "version": "2.43-r2",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-11084",
+          "checksum": "sha1-5f5FIudipdKRbKE+iKt6p0VJxNM="
+        },
+        "data": {
+          "range": "bytes=11085-87773",
+          "checksum": "sha256-gh0VE4HZWBoJVc7R2LlF0k0ffcsYtgcAejZifkRvH6M="
+        },
+        "checksum": "Q15f5FIudipdKRbKE+iKt6p0VJxNM="
+      },
+      {
+        "name": "glibc",
+        "url": "https://packages.wolfi.dev/os/aarch64/glibc-2.43-r2.apk",
+        "version": "2.43-r2",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-11310",
+          "checksum": "sha1-A8ub4Bccl0LhLOfdON713q5s7OM="
+        },
+        "data": {
+          "range": "bytes=11311-2248164",
+          "checksum": "sha256-7movgAszgMBiaKE1qVfwtROPkXCw9gkH/WrwA1sG76Y="
+        },
+        "checksum": "Q1A8ub4Bccl0LhLOfdON713q5s7OM="
+      },
+      {
+        "name": "ld-linux",
+        "url": "https://packages.wolfi.dev/os/aarch64/ld-linux-2.43-r2.apk",
+        "version": "2.43-r2",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-11116",
+          "checksum": "sha1-ImhUYsWpeTblMHFkDe+oyRmsEc0="
+        },
+        "data": {
+          "range": "bytes=11117-122598",
+          "checksum": "sha256-eQGYw1wcdc5cZ2hkdGrA8fToDD/uJF+Ox0VFDEZwdMI="
+        },
+        "checksum": "Q1ImhUYsWpeTblMHFkDe+oyRmsEc0="
+      },
+      {
+        "name": "ncurses",
+        "url": "https://packages.wolfi.dev/os/aarch64/ncurses-6.6_p20251230-r5.apk",
+        "version": "6.6_p20251230-r5",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-4962",
+          "checksum": "sha1-o518k6gI/yU/XXbK91oQfMk6+80="
+        },
+        "data": {
+          "range": "bytes=4963-452272",
+          "checksum": "sha256-43kdpw51X6elm5v3RWTgnAxuP+U90stLPYjKJtOZ7/c="
+        },
+        "checksum": "Q1o518k6gI/yU/XXbK91oQfMk6+80="
+      },
+      {
+        "name": "bash",
+        "url": "https://packages.wolfi.dev/os/aarch64/bash-5.3-r5.apk",
+        "version": "5.3-r5",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-4805",
+          "checksum": "sha1-WDX4xAg8squxIfSsHt7oJB5YCA0="
+        },
+        "data": {
+          "range": "bytes=4806-748314",
+          "checksum": "sha256-AZO26di4oybD4x9s3JSSgRyqwEQZYGKoWfZKIjLnqs8="
+        },
+        "checksum": "Q1WDX4xAg8squxIfSsHt7oJB5YCA0="
+      },
+      {
+        "name": "libxcrypt",
+        "url": "https://packages.wolfi.dev/os/aarch64/libxcrypt-4.5.2-r2.apk",
+        "version": "4.5.2-r2",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-7395",
+          "checksum": "sha1-McB8vGRCy1ZHRghUBm9SZPIfTbk="
+        },
+        "data": {
+          "range": "bytes=7396-104689",
+          "checksum": "sha256-QLE9M55RoGXYiY9e9OvdfHbk3gv0QUTsipcIMQ2ZRgQ="
+        },
+        "checksum": "Q1McB8vGRCy1ZHRghUBm9SZPIfTbk="
+      },
+      {
+        "name": "libcrypt1",
+        "url": "https://packages.wolfi.dev/os/aarch64/libcrypt1-2.43-r2.apk",
+        "version": "2.43-r2",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-11128",
+          "checksum": "sha1-pNqWld3rYEKy9kayyy5gXgVrt94="
+        },
+        "data": {
+          "range": "bytes=11129-12645",
+          "checksum": "sha256-re9jk5KFJTgv32SleU6iBPrfCHg0HwlfkQq1MOvNoKU="
+        },
+        "checksum": "Q1pNqWld3rYEKy9kayyy5gXgVrt94="
+      },
+      {
+        "name": "busybox",
+        "url": "https://packages.wolfi.dev/os/aarch64/busybox-1.37.0-r54.apk",
+        "version": "1.37.0-r54",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-8379",
+          "checksum": "sha1-mhffPatl/xHV9OrtgaT5I8sHgsM="
+        },
+        "data": {
+          "range": "bytes=8380-428369",
+          "checksum": "sha256-ixkH9FriJc8T3lGf3oSey8hQofjnyR/5EPwzJE2o0+U="
+        },
+        "checksum": "Q1mhffPatl/xHV9OrtgaT5I8sHgsM="
+      },
+      {
+        "name": "libacl1",
+        "url": "https://packages.wolfi.dev/os/aarch64/libacl1-2.3.2-r54.apk",
+        "version": "2.3.2-r54",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-6757",
+          "checksum": "sha1-qmnLb5wi6lZi+6bgdN4YLtZD41w="
+        },
+        "data": {
+          "range": "bytes=6758-28022",
+          "checksum": "sha256-l2VOV2JuxzxSMiV2ap5AHLMMzyTE4NT16gNF8W8UY1I="
+        },
+        "checksum": "Q1qmnLb5wi6lZi+6bgdN4YLtZD41w="
+      },
+      {
+        "name": "libattr1",
+        "url": "https://packages.wolfi.dev/os/aarch64/libattr1-2.5.2-r55.apk",
+        "version": "2.5.2-r55",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-7454",
+          "checksum": "sha1-QAbW0OBsuaUYBnUA74geaDySRwY="
+        },
+        "data": {
+          "range": "bytes=7455-19050",
+          "checksum": "sha256-CRgi5wY+SRVBfqmZyIqXCxiYHWE8pXo1mkGzYCXrGBw="
+        },
+        "checksum": "Q1QAbW0OBsuaUYBnUA74geaDySRwY="
+      },
+      {
+        "name": "libpcre2-8-0",
+        "url": "https://packages.wolfi.dev/os/aarch64/libpcre2-8-0-10.47-r0.apk",
+        "version": "10.47-r0",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-6891",
+          "checksum": "sha1-lNf7ODNAkpMSoBvdKCbPrNH+78w="
+        },
+        "data": {
+          "range": "bytes=6892-284052",
+          "checksum": "sha256-c1gHKQBjlH7hmsX+z8z4f6UT3dWMoMQg5aqWNhDOzfs="
+        },
+        "checksum": "Q1lNf7ODNAkpMSoBvdKCbPrNH+78w="
+      },
+      {
+        "name": "libsepol",
+        "url": "https://packages.wolfi.dev/os/aarch64/libsepol-3.10-r0.apk",
+        "version": "3.10-r0",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-5883",
+          "checksum": "sha1-GC2uLSK4Z/DyIDHAEf7rjyszEms="
+        },
+        "data": {
+          "range": "bytes=5884-447064",
+          "checksum": "sha256-iWFHatGO41vM2vASNJC2JkbQ6AlmOk+w5xLj0plNHsw="
+        },
+        "checksum": "Q1GC2uLSK4Z/DyIDHAEf7rjyszEms="
+      },
+      {
+        "name": "libselinux",
+        "url": "https://packages.wolfi.dev/os/aarch64/libselinux-3.10-r0.apk",
+        "version": "3.10-r0",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-7281",
+          "checksum": "sha1-QskYFn49nq7LobnjH7MC5SrXJ9c="
+        },
+        "data": {
+          "range": "bytes=7282-430625",
+          "checksum": "sha256-H3xcq7N/69/PG3qdcp5sNPbegnICwVAIOK9XTZhjqhw="
+        },
+        "checksum": "Q1QskYFn49nq7LobnjH7MC5SrXJ9c="
+      },
+      {
+        "name": "libcrypto3",
+        "url": "https://packages.wolfi.dev/os/aarch64/libcrypto3-3.6.1-r2.apk",
+        "version": "3.6.1-r2",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-10435",
+          "checksum": "sha1-FdY4cG7TKJMqxgdj/KK8WDcJBe4="
+        },
+        "data": {
+          "range": "bytes=10436-2203720",
+          "checksum": "sha256-C3X2DpgiXcFCVNKghOHZNwN/O/3jUBsMju9t8dcPZxE="
+        },
+        "checksum": "Q1FdY4cG7TKJMqxgdj/KK8WDcJBe4="
+      },
+      {
+        "name": "coreutils",
+        "url": "https://packages.wolfi.dev/os/aarch64/coreutils-9.10-r1.apk",
+        "version": "9.10-r1",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-8160",
+          "checksum": "sha1-3jDh1nw2aIEmejnrpVki0eUi9HY="
+        },
+        "data": {
+          "range": "bytes=8161-779810",
+          "checksum": "sha256-8wnv7Nlur5enSJjUHdetoO4oX78/OHn3dX/pE4xGRHA="
+        },
+        "checksum": "Q13jDh1nw2aIEmejnrpVki0eUi9HY="
+      },
+      {
+        "name": "gh",
+        "url": "https://packages.wolfi.dev/os/aarch64/gh-2.87.3-r0.apk",
+        "version": "2.87.3-r0",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-5163",
+          "checksum": "sha1-75L1Ljx3KtlZpCLsWv//uwLSyZo="
+        },
+        "data": {
+          "range": "bytes=5164-13555465",
+          "checksum": "sha256-VFZQwjwpvr0n0FwAIYH9N85RsBut/L66awytLYMNFGM="
+        },
+        "checksum": "Q175L1Ljx3KtlZpCLsWv//uwLSyZo="
+      },
+      {
+        "name": "zlib",
+        "url": "https://packages.wolfi.dev/os/aarch64/zlib-1.3.2-r1.apk",
+        "version": "1.3.2-r1",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-8229",
+          "checksum": "sha1-jSj/o9zfJygjjNQohJ5Y5IuALyY="
+        },
+        "data": {
+          "range": "bytes=8230-60069",
+          "checksum": "sha256-Q99FhRAcC3RlbLyAjIWNoPTa2GCxgFfwRj6dtRVLP9E="
+        },
+        "checksum": "Q1jSj/o9zfJygjjNQohJ5Y5IuALyY="
+      },
+      {
+        "name": "libexpat1",
+        "url": "https://packages.wolfi.dev/os/aarch64/libexpat1-2.7.4-r3.apk",
+        "version": "2.7.4-r3",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-5108",
+          "checksum": "sha1-uqtN5J3mVySc9aEASDogvhRpFqE="
+        },
+        "data": {
+          "range": "bytes=5109-85726",
+          "checksum": "sha256-oUfLc94p+ZOWhT09lBluxhkB1uQoDdsmhRS8Z2NLTCY="
+        },
+        "checksum": "Q1uqtN5J3mVySc9aEASDogvhRpFqE="
+      },
+      {
+        "name": "libunistring",
+        "url": "https://packages.wolfi.dev/os/aarch64/libunistring-1.4.2-r0.apk",
+        "version": "1.4.2-r0",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-4004",
+          "checksum": "sha1-52vovoN8d3W/k/oxbBylirv98N0="
+        },
+        "data": {
+          "range": "bytes=4005-963839",
+          "checksum": "sha256-DOmaVA+ZBe4zLybVwj9CgcTe3NxuzhjMlJKf4AKSvnM="
+        },
+        "checksum": "Q152vovoN8d3W/k/oxbBylirv98N0="
+      },
+      {
+        "name": "libidn2",
+        "url": "https://packages.wolfi.dev/os/aarch64/libidn2-2.3.8-r4.apk",
+        "version": "2.3.8-r4",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-4333",
+          "checksum": "sha1-GPtr9SWkOub2hc9GIUYWsGJwBfo="
+        },
+        "data": {
+          "range": "bytes=4334-130794",
+          "checksum": "sha256-i+Z3ieTt6l+5SU/wcArIZMx3g84euGImIQhIkDxuiaQ="
+        },
+        "checksum": "Q1GPtr9SWkOub2hc9GIUYWsGJwBfo="
+      },
+      {
+        "name": "libpsl",
+        "url": "https://packages.wolfi.dev/os/aarch64/libpsl-0.21.5-r7.apk",
+        "version": "0.21.5-r7",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-7023",
+          "checksum": "sha1-gRDMWo3+FGiCdTxnRKWEB6RzBco="
+        },
+        "data": {
+          "range": "bytes=7024-68733",
+          "checksum": "sha256-EvK/44MLkGYRpknwdO4T8NUwldb/Nccuut9YiuIY2u4="
+        },
+        "checksum": "Q1gRDMWo3+FGiCdTxnRKWEB6RzBco="
+      },
+      {
+        "name": "libbrotlicommon1",
+        "url": "https://packages.wolfi.dev/os/aarch64/libbrotlicommon1-1.2.0-r1.apk",
+        "version": "1.2.0-r1",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-5750",
+          "checksum": "sha1-ccaMmf9zyxkFIC+jOgPd8ikKGq8="
+        },
+        "data": {
+          "range": "bytes=5751-75990",
+          "checksum": "sha256-e+s+ztL322ROtLa5sPnoBRdeXer5uA90SyRrcnfDkoE="
+        },
+        "checksum": "Q1ccaMmf9zyxkFIC+jOgPd8ikKGq8="
+      },
+      {
+        "name": "libbrotlidec1",
+        "url": "https://packages.wolfi.dev/os/aarch64/libbrotlidec1-1.2.0-r1.apk",
+        "version": "1.2.0-r1",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-5773",
+          "checksum": "sha1-Xu/XrSM38djnnP9e/qkMVeplcFM="
+        },
+        "data": {
+          "range": "bytes=5774-36516",
+          "checksum": "sha256-jGhvX683KgtXh7W8a6duqgwQJYZ5nwZ5gwQhvzuE8YI="
+        },
+        "checksum": "Q1Xu/XrSM38djnnP9e/qkMVeplcFM="
+      },
+      {
+        "name": "nghttp3",
+        "url": "https://packages.wolfi.dev/os/aarch64/nghttp3-1.15.0-r1.apk",
+        "version": "1.15.0-r1",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-6129",
+          "checksum": "sha1-AWIdYAn7uby13dWbalf8dbj253M="
+        },
+        "data": {
+          "range": "bytes=6130-100670",
+          "checksum": "sha256-OwrjElXwKKIpqNzNZTl4sz59VPlvx84VsVSwr5uURAE="
+        },
+        "checksum": "Q1AWIdYAn7uby13dWbalf8dbj253M="
+      },
+      {
+        "name": "libnghttp2-14",
+        "url": "https://packages.wolfi.dev/os/aarch64/libnghttp2-14-1.68.0-r1.apk",
+        "version": "1.68.0-r1",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-6816",
+          "checksum": "sha1-fgoYoE3FPiOtGykA63uzeXsvKU4="
+        },
+        "data": {
+          "range": "bytes=6817-104226",
+          "checksum": "sha256-mR4RYhazjP2/qrpKv0oDnYVZ3DSpvoY4jfXzKTvzMtY="
+        },
+        "checksum": "Q1fgoYoE3FPiOtGykA63uzeXsvKU4="
+      },
+      {
+        "name": "libverto",
+        "url": "https://packages.wolfi.dev/os/aarch64/libverto-0.3.2-r6.apk",
+        "version": "0.3.2-r6",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-5971",
+          "checksum": "sha1-eN0T+PDmeRULUDXDAj08AHHMIbU="
+        },
+        "data": {
+          "range": "bytes=5972-19148",
+          "checksum": "sha256-eysA8zipY/mRoyGsRKtyaK1cTdJlbwEC+y0zkRQOsHA="
+        },
+        "checksum": "Q1eN0T+PDmeRULUDXDAj08AHHMIbU="
+      },
+      {
+        "name": "krb5-conf",
+        "url": "https://packages.wolfi.dev/os/aarch64/krb5-conf-1.0-r8.apk",
+        "version": "1.0-r8",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-1083",
+          "checksum": "sha1-TxxoI5qiU+911GP+odnAXbvqzdc="
+        },
+        "data": {
+          "range": "bytes=1084-2806",
+          "checksum": "sha256-ydvoUZvJfvrdw0/C/XTjJJhYJcPlewHDeqa0nLHfHIU="
+        },
+        "checksum": "Q1TxxoI5qiU+911GP+odnAXbvqzdc="
+      },
+      {
+        "name": "libcom_err",
+        "url": "https://packages.wolfi.dev/os/aarch64/libcom_err-1.47.3-r3.apk",
+        "version": "1.47.3-r3",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-8145",
+          "checksum": "sha1-jfz1NP/xvZ/xdmUBmDr4RTV94K0="
+        },
+        "data": {
+          "range": "bytes=8146-17173",
+          "checksum": "sha256-MG1twW5IYHnmSHW2sPzolfDWJbePkyRrMgGmMk5phr8="
+        },
+        "checksum": "Q1jfz1NP/xvZ/xdmUBmDr4RTV94K0="
+      },
+      {
+        "name": "keyutils-libs",
+        "url": "https://packages.wolfi.dev/os/aarch64/keyutils-libs-1.6.3-r38.apk",
+        "version": "1.6.3-r38",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-7321",
+          "checksum": "sha1-LIaKjRS0ih4BVQNOfkjd8QrL9gM="
+        },
+        "data": {
+          "range": "bytes=7322-18674",
+          "checksum": "sha256-gD7Qb5AloO3XuzBgXQsGt4UdpyU+ywOxM8ccsshKPic="
+        },
+        "checksum": "Q1LIaKjRS0ih4BVQNOfkjd8QrL9gM="
+      },
+      {
+        "name": "libssl3",
+        "url": "https://packages.wolfi.dev/os/aarch64/libssl3-3.6.1-r2.apk",
+        "version": "3.6.1-r2",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-10440",
+          "checksum": "sha1-d6nwPKYa01t6JABfD9dmcMV/4Rc="
+        },
+        "data": {
+          "range": "bytes=10441-485362",
+          "checksum": "sha256-ukGA10v5TeT9L4HvlJzZGZMu5SbS4px7SrpJC9+HFM8="
+        },
+        "checksum": "Q1d6nwPKYa01t6JABfD9dmcMV/4Rc="
+      },
+      {
+        "name": "krb5-libs",
+        "url": "https://packages.wolfi.dev/os/aarch64/krb5-libs-1.22.2-r1.apk",
+        "version": "1.22.2-r1",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-8639",
+          "checksum": "sha1-a/opKHYYr8cRG5b+uqr/eTYDcgY="
+        },
+        "data": {
+          "range": "bytes=8640-1056064",
+          "checksum": "sha256-mZLoUgLmhzON9tnIfTLeeM7m2q4OZ8ze7HfEVTXeHTM="
+        },
+        "checksum": "Q1a/opKHYYr8cRG5b+uqr/eTYDcgY="
+      },
+      {
+        "name": "readline",
+        "url": "https://packages.wolfi.dev/os/aarch64/readline-8.3-r1.apk",
+        "version": "8.3-r1",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-3933",
+          "checksum": "sha1-U8GDjvDj9eHCB+1NdgXp4NKzmPE="
+        },
+        "data": {
+          "range": "bytes=3934-335034",
+          "checksum": "sha256-PU16uzdKxlk7V28YHwwE6EgxQfcPeQdbqV4nrD0wyC0="
+        },
+        "checksum": "Q1U8GDjvDj9eHCB+1NdgXp4NKzmPE="
+      },
+      {
+        "name": "sqlite-libs",
+        "url": "https://packages.wolfi.dev/os/aarch64/sqlite-libs-3.51.1-r0.apk",
+        "version": "3.51.1-r0",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-4728",
+          "checksum": "sha1-HbRYEc6Dcdi3QTdAGCthLEmtzas="
+        },
+        "data": {
+          "range": "bytes=4729-878253",
+          "checksum": "sha256-bRRZnJ5sCntvejf+n4NBfpf7DQwRO4W30pHA5bpt4Hk="
+        },
+        "checksum": "Q1HbRYEc6Dcdi3QTdAGCthLEmtzas="
+      },
+      {
+        "name": "heimdal-libs",
+        "url": "https://packages.wolfi.dev/os/aarch64/heimdal-libs-7.8.0-r43.apk",
+        "version": "7.8.0-r43",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-5725",
+          "checksum": "sha1-7n4oVFCZkY9FQkIcivUEhj9D+eA="
+        },
+        "data": {
+          "range": "bytes=5726-1429187",
+          "checksum": "sha256-cnEgWPNT/CEngAsEdD25hpYBDEKbJ4tCUUhjDqt46rY="
+        },
+        "checksum": "Q17n4oVFCZkY9FQkIcivUEhj9D+eA="
+      },
+      {
+        "name": "gdbm",
+        "url": "https://packages.wolfi.dev/os/aarch64/gdbm-1.26-r2.apk",
+        "version": "1.26-r2",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-4396",
+          "checksum": "sha1-wB5byTNDWRM2zL8qGg8/xUIe7is="
+        },
+        "data": {
+          "range": "bytes=4397-258713",
+          "checksum": "sha256-7lkX2QRKwLw9oh2jX3y45QJqdBirRGL8/z1e/SmEqmQ="
+        },
+        "checksum": "Q1wB5byTNDWRM2zL8qGg8/xUIe7is="
+      },
+      {
+        "name": "cyrus-sasl",
+        "url": "https://packages.wolfi.dev/os/aarch64/cyrus-sasl-2.1.28-r46.apk",
+        "version": "2.1.28-r46",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-8004",
+          "checksum": "sha1-GEB79u1zK7n3fhxbjjn0pzpZg3o="
+        },
+        "data": {
+          "range": "bytes=8005-308564",
+          "checksum": "sha256-JqzlK3KQ4Kq+ZELT3/mdSV7R/dwe7BU8UgL8KoXHddY="
+        },
+        "checksum": "Q1GEB79u1zK7n3fhxbjjn0pzpZg3o="
+      },
+      {
+        "name": "libldap-2.6",
+        "url": "https://packages.wolfi.dev/os/aarch64/libldap-2.6-2.6.12-r3.apk",
+        "version": "2.6.12-r3",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-11372",
+          "checksum": "sha1-A8dvwMww5Nf8TDWMglc9yXb/3Zc="
+        },
+        "data": {
+          "range": "bytes=11373-243347",
+          "checksum": "sha256-24WYkgH5d56Ouq/xjcubkSLF2VpssBJhGT+IYR2AiPg="
+        },
+        "checksum": "Q1A8dvwMww5Nf8TDWMglc9yXb/3Zc="
+      },
+      {
+        "name": "libcurl-openssl4",
+        "url": "https://packages.wolfi.dev/os/aarch64/libcurl-openssl4-8.18.0-r3.apk",
+        "version": "8.18.0-r3",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-11909",
+          "checksum": "sha1-5DMLoC368eGxvUHQ7G7SlETJeww="
+        },
+        "data": {
+          "range": "bytes=11910-509786",
+          "checksum": "sha256-CfztaAvMeGU4wdlK+q1bh328i6cUmXOxS8Pz78ST8dU="
+        },
+        "checksum": "Q15DMLoC368eGxvUHQ7G7SlETJeww="
+      },
+      {
+        "name": "git",
+        "url": "https://packages.wolfi.dev/os/aarch64/git-2.53.0-r0.apk",
+        "version": "2.53.0-r0",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-11631",
+          "checksum": "sha1-+Hkj1ivT954d4lAcCtQ34KG9bsA="
+        },
+        "data": {
+          "range": "bytes=11632-9053550",
+          "checksum": "sha256-udd5UTkzYl+bU33aECx8q8DF10SNujitxwFSFDq+GSw="
+        },
+        "checksum": "Q1+Hkj1ivT954d4lAcCtQ34KG9bsA="
+      },
+      {
+        "name": "make",
+        "url": "https://packages.wolfi.dev/os/aarch64/make-4.4.1-r9.apk",
+        "version": "4.4.1-r9",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-3113",
+          "checksum": "sha1-Ic/6GbUG8Wtp2+GVZd06SiFuQ80="
+        },
+        "data": {
+          "range": "bytes=3114-622024",
+          "checksum": "sha256-70rpHwU6tzMhXCaZBZ9fYfz1/w9Ur6XRopYjlFr20hQ="
+        },
+        "checksum": "Q1Ic/6GbUG8Wtp2+GVZd06SiFuQ80="
+      },
+      {
+        "name": "pkgconf",
+        "url": "https://packages.wolfi.dev/os/aarch64/pkgconf-2.5.1-r1.apk",
+        "version": "2.5.1-r1",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-6364",
+          "checksum": "sha1-BiG01uplvoS1tflhFy3KgO5pw/E="
+        },
+        "data": {
+          "range": "bytes=6365-83393",
+          "checksum": "sha256-gOiOWy405Ob8n3DACVDmz4En9BMCLumHsjzy6s4APq0="
+        },
+        "checksum": "Q1BiG01uplvoS1tflhFy3KgO5pw/E="
+      },
+      {
+        "name": "libzstd1",
+        "url": "https://packages.wolfi.dev/os/aarch64/libzstd1-1.5.7-r7.apk",
+        "version": "1.5.7-r7",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-6991",
+          "checksum": "sha1-wZpSMZyQJxXAI1trGnHEAQ6fWTo="
+        },
+        "data": {
+          "range": "bytes=6992-566800",
+          "checksum": "sha256-IBz8XUaBkMNDmV7dIO1fvdsBAk1pc+VGECskx1Uf1do="
+        },
+        "checksum": "Q1wZpSMZyQJxXAI1trGnHEAQ6fWTo="
+      },
+      {
+        "name": "libstdc++",
+        "url": "https://packages.wolfi.dev/os/aarch64/libstdc++-15.2.0-r10.apk",
+        "version": "15.2.0-r10",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-9623",
+          "checksum": "sha1-B4tpw1UwBX2SBkjI2yNdF87KmMk="
+        },
+        "data": {
+          "range": "bytes=9624-1081134",
+          "checksum": "sha256-PzmIAiAoAWf1IOxDWy3HdL3YcaokVq6rO48+19YBy24="
+        },
+        "checksum": "Q1B4tpw1UwBX2SBkjI2yNdF87KmMk="
+      },
+      {
+        "name": "binutils",
+        "url": "https://packages.wolfi.dev/os/aarch64/binutils-2.46-r1.apk",
+        "version": "2.46-r1",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-7161",
+          "checksum": "sha1-Q78X1pXkS0js6xI2HioxbwYT+VY="
+        },
+        "data": {
+          "range": "bytes=7162-25286256",
+          "checksum": "sha256-mWOxMkyN0jD4pyVJAbIU1PEt/xy887+qoYgVRoi5HsU="
+        },
+        "checksum": "Q1Q78X1pXkS0js6xI2HioxbwYT+VY="
+      },
+      {
+        "name": "libxcrypt-dev",
+        "url": "https://packages.wolfi.dev/os/aarch64/libxcrypt-dev-4.5.2-r2.apk",
+        "version": "4.5.2-r2",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-7416",
+          "checksum": "sha1-N1EMDrjdv2mbQcFsVq6/jiERDOo="
+        },
+        "data": {
+          "range": "bytes=7417-374693",
+          "checksum": "sha256-jLlNDliJOGM7+BdnbLW40gXSXYlHgOr/DgmfGKGePFc="
+        },
+        "checksum": "Q1N1EMDrjdv2mbQcFsVq6/jiERDOo="
+      },
+      {
+        "name": "nss-db",
+        "url": "https://packages.wolfi.dev/os/aarch64/nss-db-2.43-r2.apk",
+        "version": "2.43-r2",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-11153",
+          "checksum": "sha1-FE2NKq7AuN54DaVqevSpgbc2T44="
+        },
+        "data": {
+          "range": "bytes=11154-38517",
+          "checksum": "sha256-3zNLjF7fwhQSa8OeA8d5w4OtCISNZM25Q2z56DvRzEc="
+        },
+        "checksum": "Q1FE2NKq7AuN54DaVqevSpgbc2T44="
+      },
+      {
+        "name": "nss-hesiod",
+        "url": "https://packages.wolfi.dev/os/aarch64/nss-hesiod-2.43-r2.apk",
+        "version": "2.43-r2",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-11147",
+          "checksum": "sha1-emDWnGTS7XKBB3JBNCjiNrSoBbU="
+        },
+        "data": {
+          "range": "bytes=11148-23452",
+          "checksum": "sha256-6j8VETZzj5H55aZ95SKdC+IuVTQSjUJ18h4QYjTdfBc="
+        },
+        "checksum": "Q1emDWnGTS7XKBB3JBNCjiNrSoBbU="
+      },
+      {
+        "name": "linux-headers",
+        "url": "https://packages.wolfi.dev/os/aarch64/linux-headers-6.19.6-r0.apk",
+        "version": "6.19.6-r0",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-4712",
+          "checksum": "sha1-roX6G1N5nqvAAt+U3oikyX5RHrY="
+        },
+        "data": {
+          "range": "bytes=4713-2048925",
+          "checksum": "sha256-zTPXJQyzMNZZTAGHOvSxi4pHUL+aGjf6Q0jRXYOeqGQ="
+        },
+        "checksum": "Q1roX6G1N5nqvAAt+U3oikyX5RHrY="
+      },
+      {
+        "name": "glibc-dev",
+        "url": "https://packages.wolfi.dev/os/aarch64/glibc-dev-2.43-r2.apk",
+        "version": "2.43-r2",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-11168",
+          "checksum": "sha1-BbZ8/Kk55oc4ToEwhnMMMSPxlz8="
+        },
+        "data": {
+          "range": "bytes=11169-11381544",
+          "checksum": "sha256-aOwokvgSe+9XZy45guMfrz4X5PEmSz6dCUl7x0mdK5M="
+        },
+        "checksum": "Q1BbZ8/Kk55oc4ToEwhnMMMSPxlz8="
+      },
+      {
+        "name": "gmp",
+        "url": "https://packages.wolfi.dev/os/aarch64/gmp-6.3.0-r8.apk",
+        "version": "6.3.0-r8",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-3185",
+          "checksum": "sha1-0E0Cbwo947xIppsMc/IcDYfTYb8="
+        },
+        "data": {
+          "range": "bytes=3186-304773",
+          "checksum": "sha256-65yd7i1r3U/j4fHjQ7AaVeNICTzelQ13eu4t9VZC+xQ="
+        },
+        "checksum": "Q10E0Cbwo947xIppsMc/IcDYfTYb8="
+      },
+      {
+        "name": "mpfr",
+        "url": "https://packages.wolfi.dev/os/aarch64/mpfr-4.2.2-r2.apk",
+        "version": "4.2.2-r2",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-5073",
+          "checksum": "sha1-u6rxizuEgj8RkyZMUPQZ5RJ3G7Q="
+        },
+        "data": {
+          "range": "bytes=5074-640885",
+          "checksum": "sha256-oNrJKUk/y4F25NAA4bV/zYsfoS1iolfwlA86YCRVdbs="
+        },
+        "checksum": "Q1u6rxizuEgj8RkyZMUPQZ5RJ3G7Q="
+      },
+      {
+        "name": "mpc",
+        "url": "https://packages.wolfi.dev/os/aarch64/mpc-1.3.1-r7.apk",
+        "version": "1.3.1-r7",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-5594",
+          "checksum": "sha1-vO9Rlk8NESYpsuAJbzx5ivhCES4="
+        },
+        "data": {
+          "range": "bytes=5595-75365",
+          "checksum": "sha256-BAe4P7mFhpMA6UzvQAuh9d6Cz+6kuhVSDbiVC/W0G4s="
+        },
+        "checksum": "Q1vO9Rlk8NESYpsuAJbzx5ivhCES4="
+      },
+      {
+        "name": "posix-cc-wrappers",
+        "url": "https://packages.wolfi.dev/os/aarch64/posix-cc-wrappers-2-r8.apk",
+        "version": "2-r8",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-1388",
+          "checksum": "sha1-1VWaCNgBDB3hwp08UV4VC9h4LSI="
+        },
+        "data": {
+          "range": "bytes=1389-3215",
+          "checksum": "sha256-5gLwgkGLdnWprxw6fDHTbB5puWHKbBKrrbN7CPCItP4="
+        },
+        "checksum": "Q11VWaCNgBDB3hwp08UV4VC9h4LSI="
+      },
+      {
+        "name": "isl",
+        "url": "https://packages.wolfi.dev/os/aarch64/isl-0.27-r5.apk",
+        "version": "0.27-r5",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-5878",
+          "checksum": "sha1-5k10WzjVVoBjJFZRb70alz6fgPM="
+        },
+        "data": {
+          "range": "bytes=5879-1032199",
+          "checksum": "sha256-xihcfCYYExlWWfaSY4f3fysy/i+ZDQFZmSvZBwWU+T8="
+        },
+        "checksum": "Q15k10WzjVVoBjJFZRb70alz6fgPM="
+      },
+      {
+        "name": "libquadmath",
+        "url": "https://packages.wolfi.dev/os/aarch64/libquadmath-15.2.0-r10.apk",
+        "version": "15.2.0-r10",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-9583",
+          "checksum": "sha1-C4bXjNKZXUW1ox12GnN/51gBSSw="
+        },
+        "data": {
+          "range": "bytes=9584-11130",
+          "checksum": "sha256-7qcW7MAPQREUt5C183POZ6RTWLc9fZ3GcoJPxKj1vvM="
+        },
+        "checksum": "Q1C4bXjNKZXUW1ox12GnN/51gBSSw="
+      },
+      {
+        "name": "libstdc++-dev",
+        "url": "https://packages.wolfi.dev/os/aarch64/libstdc++-dev-15.2.0-r10.apk",
+        "version": "15.2.0-r10",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-9599",
+          "checksum": "sha1-5DtwckdyizQDtyL8h9KUGJOBSEQ="
+        },
+        "data": {
+          "range": "bytes=9600-14136212",
+          "checksum": "sha256-37wsULgp90VsQK11L7e9sZ9KJQqZdJ13qD/vdZJEIHU="
+        },
+        "checksum": "Q15DtwckdyizQDtyL8h9KUGJOBSEQ="
+      },
+      {
+        "name": "libatomic",
+        "url": "https://packages.wolfi.dev/os/aarch64/libatomic-15.2.0-r10.apk",
+        "version": "15.2.0-r10",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-9626",
+          "checksum": "sha1-e0MnRVSX+zaPqiZm/y2qIn/qwgs="
+        },
+        "data": {
+          "range": "bytes=9627-29672",
+          "checksum": "sha256-uBkNPx/tC2yiZSsV6TZT1gKPC9lnFLVCp4Ibhssy9og="
+        },
+        "checksum": "Q1e0MnRVSX+zaPqiZm/y2qIn/qwgs="
+      },
+      {
+        "name": "libgomp",
+        "url": "https://packages.wolfi.dev/os/aarch64/libgomp-15.2.0-r10.apk",
+        "version": "15.2.0-r10",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-9626",
+          "checksum": "sha1-Cb7bVMo8r0H/8IjBPNKqg7gWfQk="
+        },
+        "data": {
+          "range": "bytes=9627-190528",
+          "checksum": "sha256-7fz83gaWQXjAT3o11U5VRMaN6YBUicmzEN+uZLpJ36g="
+        },
+        "checksum": "Q1Cb7bVMo8r0H/8IjBPNKqg7gWfQk="
+      },
+      {
+        "name": "openssf-compiler-options",
+        "url": "https://packages.wolfi.dev/os/aarch64/openssf-compiler-options-20250904-r4.apk",
+        "version": "20250904-r4",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-3094",
+          "checksum": "sha1-h/JTufakR0+cZLIV0ZF4H/AwICo="
+        },
+        "data": {
+          "range": "bytes=3095-10215",
+          "checksum": "sha256-zROIcjRSDOKssTV6wxYiqSG4CvP4YvST/JHoLZLa5iI="
+        },
+        "checksum": "Q1h/JTufakR0+cZLIV0ZF4H/AwICo="
+      },
+      {
+        "name": "gcc",
+        "url": "https://packages.wolfi.dev/os/aarch64/gcc-15.2.0-r10.apk",
+        "version": "15.2.0-r10",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-9891",
+          "checksum": "sha1-JxCRlC5qjuTYTXfY0xLydYMTRJo="
+        },
+        "data": {
+          "range": "bytes=9892-118980022",
+          "checksum": "sha256-MDOAcoEhCyzbAX8ncNXBChdkwrqK4lQTT5cEhlaGqzQ="
+        },
+        "checksum": "Q1JxCRlC5qjuTYTXfY0xLydYMTRJo="
+      },
+      {
+        "name": "build-base",
+        "url": "https://packages.wolfi.dev/os/aarch64/build-base-1-r9.apk",
+        "version": "1-r9",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-1255",
+          "checksum": "sha1-BhxkGA1/DUcuyUoFoYl1+V2v/mQ="
+        },
+        "data": {
+          "range": "bytes=1256-2314",
+          "checksum": "sha256-WZlh7IjA1IqeH+xPSqudtijMQsjblW43yuUlBJfieWM="
+        },
+        "checksum": "Q1BhxkGA1/DUcuyUoFoYl1+V2v/mQ="
+      },
+      {
+        "name": "go-1.25",
+        "url": "https://packages.wolfi.dev/os/aarch64/go-1.25-1.25.8-r0.apk",
+        "version": "1.25.8-r0",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-7391",
+          "checksum": "sha1-YhFvD/EoUAf1V1uWVYLtDu9yfD8="
+        },
+        "data": {
+          "range": "bytes=7392-47697996",
+          "checksum": "sha256-44GZp8pSn9FGrHYzOSkozkunQrczu2fSYx9pIDTT8YM="
+        },
+        "checksum": "Q1YhFvD/EoUAf1V1uWVYLtDu9yfD8="
+      },
+      {
+        "name": "icu78-data-full",
+        "url": "https://packages.wolfi.dev/os/aarch64/icu78-data-full-78.2-r0.apk",
+        "version": "78.2-r0",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-5622",
+          "checksum": "sha1-sVSbb9aRjiJMMPVnn1ypcGxEZqo="
+        },
+        "data": {
+          "range": "bytes=5623-13975237",
+          "checksum": "sha256-SDRlr+jE3IJb/sbiUe4LXBX6sSbMoronafza+JNw8Xg="
+        },
+        "checksum": "Q1sVSbb9aRjiJMMPVnn1ypcGxEZqo="
+      },
+      {
+        "name": "libicu78",
+        "url": "https://packages.wolfi.dev/os/aarch64/libicu78-78.2-r0.apk",
+        "version": "78.2-r0",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-5717",
+          "checksum": "sha1-yVIpndO/naYqzGzG4KQwrEHt0qY="
+        },
+        "data": {
+          "range": "bytes=5718-2941066",
+          "checksum": "sha256-4WHVrLg3Rl+CGq8SIUE/8MaiMo6DPlSf02gDi5PcPVE="
+        },
+        "checksum": "Q1yVIpndO/naYqzGzG4KQwrEHt0qY="
+      },
+      {
+        "name": "libbrotlienc1",
+        "url": "https://packages.wolfi.dev/os/aarch64/libbrotlienc1-1.2.0-r1.apk",
+        "version": "1.2.0-r1",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-5775",
+          "checksum": "sha1-Z+Bdm6myMPYGCRvYtidd0sC7uG8="
+        },
+        "data": {
+          "range": "bytes=5776-421362",
+          "checksum": "sha256-/F25qM+Ic9WUqxOs2ZVzwt2JgFJmmqv6Uu+tDzYOeN4="
+        },
+        "checksum": "Q1Z+Bdm6myMPYGCRvYtidd0sC7uG8="
+      },
+      {
+        "name": "libuv",
+        "url": "https://packages.wolfi.dev/os/aarch64/libuv-1.52.0-r0.apk",
+        "version": "1.52.0-r0",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-6223",
+          "checksum": "sha1-BRdP0RBSxPDf2y4gSocI++5Hvmg="
+        },
+        "data": {
+          "range": "bytes=6224-122836",
+          "checksum": "sha256-E0so2vzyOagmfr450kwWjY49XyYWSH4qetS2JMPBIlQ="
+        },
+        "checksum": "Q1BRdP0RBSxPDf2y4gSocI++5Hvmg="
+      },
+      {
+        "name": "c-ares",
+        "url": "https://packages.wolfi.dev/os/aarch64/c-ares-1.34.6-r0.apk",
+        "version": "1.34.6-r0",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-6542",
+          "checksum": "sha1-ZNcuIZKNSS10YM3/KWc+GHaHUIY="
+        },
+        "data": {
+          "range": "bytes=6543-149992",
+          "checksum": "sha256-SpugSZhRUoadg8/22PH5LqVz77HdUuirHTG9SNDoHL0="
+        },
+        "checksum": "Q1ZNcuIZKNSS10YM3/KWc+GHaHUIY="
+      },
+      {
+        "name": "nodejs-25",
+        "url": "https://packages.wolfi.dev/os/aarch64/nodejs-25-25.8.0-r0.apk",
+        "version": "25.8.0-r0",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-6615",
+          "checksum": "sha1-iJ+US4G+E8+Ey29iv4BGQK652qA="
+        },
+        "data": {
+          "range": "bytes=6616-30875850",
+          "checksum": "sha256-7YwXVP3Oupl4RrH7suFt9IK0APPviJ6Q5iQQu+8vWnA="
+        },
+        "checksum": "Q1iJ+US4G+E8+Ey29iv4BGQK652qA="
+      },
+      {
+        "name": "libedit",
+        "url": "https://packages.wolfi.dev/os/aarch64/libedit-3.1-r15.apk",
+        "version": "3.1-r15",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-4797",
+          "checksum": "sha1-J6SDLOLfaOarRCbG5115Vt37VGk="
+        },
+        "data": {
+          "range": "bytes=4798-116982",
+          "checksum": "sha256-JZsgpHgsavaXx0HvUgmdQWqp4a7B3d1GdK8APJUAUC8="
+        },
+        "checksum": "Q1J6SDLOLfaOarRCbG5115Vt37VGk="
+      },
+      {
+        "name": "openssh-client",
+        "url": "https://packages.wolfi.dev/os/aarch64/openssh-client-10.2_p1-r3.apk",
+        "version": "10.2_p1-r3",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-7382",
+          "checksum": "sha1-acmq8RduvbsykV72/JVRUU4xXwc="
+        },
+        "data": {
+          "range": "bytes=7383-1145019",
+          "checksum": "sha256-rQot8Tu45H+ML5GmbocoJJojaDqglF4iXaxTVkxU9Sw="
+        },
+        "checksum": "Q1acmq8RduvbsykV72/JVRUU4xXwc="
+      },
+      {
+        "name": "pnpm",
+        "url": "https://packages.wolfi.dev/os/aarch64/pnpm-10.30.3-r0.apk",
+        "version": "10.30.3-r0",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-5015",
+          "checksum": "sha1-8/ggWomXUgXPqUa1vL14PTLaRLo="
+        },
+        "data": {
+          "range": "bytes=5016-1986468",
+          "checksum": "sha256-pLBCHcy5Wjj3mkrv/1nNpyKglzXJSZmImRwS0oe53is="
+        },
+        "checksum": "Q18/ggWomXUgXPqUa1vL14PTLaRLo="
+      },
+      {
+        "name": "tzdata",
+        "url": "https://packages.wolfi.dev/os/aarch64/tzdata-2026a-r0.apk",
+        "version": "2026a-r0",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-4834",
+          "checksum": "sha1-KrgovzPvPynHVgzVkjK1Vw4i1So="
+        },
+        "data": {
+          "range": "bytes=4835-569047",
+          "checksum": "sha256-UA+yz0sMrEFRbe5Zx8vunvlXc7AdvVb77n4OanorxAc="
+        },
+        "checksum": "Q1KrgovzPvPynHVgzVkjK1Vw4i1So="
+      }
+    ]
+  }
+}

--- a/charts/goose-agent/image/apko.yaml
+++ b/charts/goose-agent/image/apko.yaml
@@ -1,0 +1,61 @@
+contents:
+  repositories:
+    - https://packages.wolfi.dev/os
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+  packages:
+    - bash
+    - busybox
+    - ca-certificates-bundle
+    - coreutils
+    - git
+    - gh
+    - go
+    - nodejs
+    - openssh-client
+    - pnpm
+    - tzdata
+
+archs:
+  - x86_64
+  - aarch64
+
+accounts:
+  groups:
+    - groupname: goose-agent
+      gid: 65532
+  users:
+    - username: goose-agent
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+environment:
+  TZ: Europe/Dublin
+  HOME: /home/goose-agent
+  GIT_SSH_COMMAND: ssh -o StrictHostKeyChecking=no
+
+paths:
+  - path: /home/goose-agent
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+  - path: /home/goose-agent/.ssh
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o700
+  - path: /home/goose-agent/.config/goose
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+  - path: /workspace
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+
+entrypoint:
+  command: /usr/local/bin/goose

--- a/charts/goose-agent/image/config.yaml
+++ b/charts/goose-agent/image/config.yaml
@@ -1,0 +1,20 @@
+# Goose configuration baked into the goose-agent container image.
+# Provider and model are set via environment variables (GOOSE_PROVIDER, GOOSE_MODEL)
+# injected by the SandboxTemplate, not hardcoded here.
+#
+# Extensions configured:
+#   - developer (builtin): filesystem, shell, editor scoped to /workspace
+#   - context-forge (remote): SigNoz observability, ArgoCD, Kubernetes via MCP gateway
+extensions:
+  developer:
+    bundled: true
+    enabled: true
+    name: developer
+    timeout: 300
+    type: builtin
+  context-forge:
+    enabled: true
+    name: context-forge
+    timeout: 300
+    type: streamablehttp
+    uri: http://context-forge.mcp-gateway.svc.cluster.local:8000/mcp

--- a/images/BUILD
+++ b/images/BUILD
@@ -7,6 +7,7 @@ load("@rules_multirun//:defs.bzl", "multirun")
 multirun(
     name = "push_all",
     commands = [
+        "//charts/goose-agent/image:image.push",
         "//charts/signoz-dashboard-sidecar/cmd:image.push",
         "//charts/todo/image:image.push",
         "//operators/cloudflare:image.push",


### PR DESCRIPTION
## Summary
- Adds a multi-platform (x86_64 + aarch64) apko-based container image for Goose agents
- Includes Goose v1.27.1, BuildBuddy CLI v5.0.321, Go, Node.js, pnpm, git, and gh from Wolfi
- Bakes in Goose config with `developer` (builtin) and `context-forge` (streaming HTTP MCP gateway) extensions
- Adds `multiarch_http_file` entry for `bb` and `multiarch_http_archive` entry for `goose` in MODULE.bazel

## Design decisions
- **Minimal base image** — only essential build tools included; additional tooling (helm, buildifier, etc.) will be composed via OCI artifact volumes per-agent in future
- **Goose config baked in** — versioned with the image at `~/.config/goose/config.yaml`, provider/model injected via env vars by the SandboxTemplate
- **Binary tar layers** — Goose and bb added as multiarch tar layers on top of the Wolfi apko base, following existing patterns (opencode, ttyd)

## What this enables
This is the critical-path blocker for Phase 1 of the autonomous agents platform (ADR 004). With this image, the already-deployed `SandboxTemplate` and `SandboxWarmPool` in `goose-sandboxes` namespace can start running actual agent pods.

## Remaining Phase 1 work
- [ ] `agent-run` trigger CLI (creates SandboxClaim, streams logs)
- [ ] End-to-end validation (`agent-run "Fix issue #N"` → sandbox → Goose → PR)
- [ ] Update SandboxTemplate command if `--profile sandbox` needs adjustment for Goose v1.27+

## Test plan
- [x] `bazel query //charts/goose-agent/image:all` — all targets generated correctly
- [x] `format` — passes, auto-added image to `images/BUILD` push_all
- [ ] CI build (BuildBuddy remote execution) — verifies full image assembly
- [ ] Manual: `bazel run //charts/goose-agent/image:image.run` — verify container starts

🤖 Generated with [Claude Code](https://claude.com/claude-code)