### PR TITLE
fix(mcp-oauth-proxy): remove path from MCP_SERVER_URL

### DIFF
--- a/charts/mcp-oauth-proxy/values.yaml
+++ b/charts/mcp-oauth-proxy/values.yaml
@@ -14,7 +14,7 @@ config:
   # OAuth scopes to request from Google
   SCOPES_SUPPORTED: "openid,email,profile"
   # Upstream MCP server URL (Context Forge ClusterIP)
-  MCP_SERVER_URL: "http://context-forge-mcp-stack-mcpgateway.mcp-gateway.svc.cluster.local:80/mcp/"
+  MCP_SERVER_URL: "http://context-forge-mcp-stack-mcpgateway.mcp-gateway.svc.cluster.local:80"
 
 # 1Password secret — provides OAUTH_CLIENT_ID, OAUTH_CLIENT_SECRET, ENCRYPTION_KEY
 secret:


### PR DESCRIPTION
## Summary

- Remove `/mcp/` path from `MCP_SERVER_URL` — the proxy rejects URLs with paths, queries, or fragments
- Fixes startup crash: `MCP server URL must not contain a path, query, or fragment`

## Test plan

- [ ] Proxy pod starts without configuration error
- [ ] OAuth flow completes and requests are proxied to Context Forge

🤖 Generated with [Claude Code](https://claude.com/claude-code)