### PR TITLE
fix(mcp-oauth-proxy): set workingDir to writable emptyDir mount

### DIFF
--- a/charts/mcp-oauth-proxy/templates/deployment.yaml
+++ b/charts/mcp-oauth-proxy/templates/deployment.yaml
@@ -49,6 +49,7 @@ spec:
             periodSeconds: 10
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          workingDir: /data
           volumeMounts:
             - name: data
               mountPath: /data


### PR DESCRIPTION
## Summary
- Fix `permission denied` error when mcp-oauth-proxy tries to create its `data/` SQLite directory
- Set `workingDir: /data` on the container so the relative `mkdir data` resolves to the writable emptyDir volume mount

## Root cause
The proxy creates a relative `data/` directory for SQLite storage. Running as uid 65532 (non-root), it cannot write to the container's default working directory. The emptyDir is mounted at `/data` but without `workingDir`, the relative path fails.

## Test plan
- [ ] CI passes (Helm template renders correctly)
- [ ] ArgoCD syncs the updated deployment
- [ ] Pod starts without `permission denied` and `/healthz` returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)