### PR TITLE
fix(mcp-oauth-proxy): mount emptyDir at /app/data instead of overriding workingDir

### DIFF
--- a/charts/mcp-oauth-proxy/templates/deployment.yaml
+++ b/charts/mcp-oauth-proxy/templates/deployment.yaml
@@ -49,10 +49,9 @@ spec:
             periodSeconds: 10
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-          workingDir: /data
           volumeMounts:
             - name: data
-              mountPath: /data
+              mountPath: /app/data
       volumes:
         - name: data
           emptyDir: {}


### PR DESCRIPTION
## Summary
- Fixes container crash: `exec: "./oauth-proxy": stat ./oauth-proxy: no such file or directory`
- The previous fix (#777) set `workingDir: /data`, which moved CWD away from the binary at `/app/oauth-proxy`
- Instead, mount the emptyDir at `/app/data` so the relative `mkdir data` from the image's default `/app` working directory lands on the writable volume

## Root cause
The image sets `WorkingDir: /app` and `Cmd: ["./oauth-proxy"]`. Overriding `workingDir` to `/data` broke the relative entrypoint. The app also creates `data/` relative to CWD for SQLite, so the volume must be at `/app/data`.

## Test plan
- [ ] CI passes (Helm template renders correctly)
- [ ] Pod starts without `permission denied` or `no such file` errors
- [ ] `/healthz` returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)