### PR TITLE
fix(mcp-oauth-proxy): replace SQLite with PostgreSQL sidecar

### DIFF
--- a/charts/mcp-oauth-proxy/templates/deployment.yaml
+++ b/charts/mcp-oauth-proxy/templates/deployment.yaml
@@ -32,6 +32,8 @@ spec:
             - name: {{ $key }}
               value: {{ $value | quote }}
             {{- end }}
+            - name: DATABASE_DSN
+              value: {{ .Values.postgres.dsn | quote }}
           envFrom:
             - secretRef:
                 name: {{ .Values.secret.name }}
@@ -39,19 +41,48 @@ spec:
             httpGet:
               path: /healthz
               port: http
-            initialDelaySeconds: 5
+            initialDelaySeconds: 10
             periodSeconds: 10
           readinessProbe:
             httpGet:
               path: /healthz
               port: http
-            initialDelaySeconds: 5
+            initialDelaySeconds: 10
             periodSeconds: 10
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+        - name: postgres
+          image: "{{ .Values.postgres.image.repository }}:{{ .Values.postgres.image.tag }}"
+          securityContext:
+            runAsUser: 70
+            runAsGroup: 70
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          env:
+            - name: POSTGRES_USER
+              value: {{ .Values.postgres.user | quote }}
+            - name: POSTGRES_DB
+              value: {{ .Values.postgres.database | quote }}
+            - name: POSTGRES_HOST_AUTH_METHOD
+              value: "trust"
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+          ports:
+            - name: postgres
+              containerPort: 5432
+              protocol: TCP
+          readinessProbe:
+            exec:
+              command: ["pg_isready", "-U", {{ .Values.postgres.user | quote }}]
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          resources:
+            {{- toYaml .Values.postgres.resources | nindent 12 }}
           volumeMounts:
-            - name: data
-              mountPath: /app/data
+            - name: pgdata
+              mountPath: /var/lib/postgresql/data
       volumes:
-        - name: data
+        - name: pgdata
           emptyDir: {}

--- a/charts/mcp-oauth-proxy/values.yaml
+++ b/charts/mcp-oauth-proxy/values.yaml
@@ -21,6 +21,22 @@ secret:
   name: mcp-oauth-proxy
   itemPath: "vaults/k8s-homelab/items/mcp-oauth-proxy"
 
+# PostgreSQL sidecar — replaces SQLite (upstream binary lacks CGO)
+postgres:
+  image:
+    repository: postgres
+    tag: "17-alpine"
+  user: "mcp"
+  database: "mcp_oauth"
+  dsn: "postgres://mcp@localhost:5432/mcp_oauth?sslmode=disable"
+  resources:
+    requests:
+      cpu: 10m
+      memory: 64Mi
+    limits:
+      cpu: 200m
+      memory: 256Mi
+
 resources:
   requests:
     cpu: 10m
@@ -31,15 +47,14 @@ resources:
 
 podSecurityContext:
   runAsNonRoot: true
-  runAsUser: 65532
-  runAsGroup: 65532
-  fsGroup: 65532
   seccompProfile:
     type: RuntimeDefault
 
 securityContext:
+  runAsUser: 65532
+  runAsGroup: 65532
   allowPrivilegeEscalation: false
-  readOnlyRootFilesystem: false  # SQLite needs writable filesystem
+  readOnlyRootFilesystem: true
   capabilities:
     drop:
       - ALL


### PR DESCRIPTION
## Summary
- Upstream `mcp-oauth-proxy` is compiled with `CGO_ENABLED=0`, making `go-sqlite3` a non-functional stub
- Replace the emptyDir SQLite approach with a lightweight `postgres:17-alpine` sidecar
- Proxy connects via `DATABASE_DSN=postgres://mcp@localhost:5432/mcp_oauth?sslmode=disable`

## Changes
- Add PostgreSQL sidecar container with trust auth (localhost only)
- Set `DATABASE_DSN` env var on the proxy container
- Move `runAsUser`/`runAsGroup` to container-level security contexts (proxy=65532, postgres=70)
- Enable `readOnlyRootFilesystem: true` on proxy (no longer needs SQLite writes)
- Bump probe `initialDelaySeconds` to 10s to allow postgres startup

## Root cause
```
Binary was compiled with 'CGO_ENABLED=0', go-sqlite3 requires cgo to work. This is a stub
```
All published image tags (`latest`, `main-*`) are statically linked — SQLite will never work.

## Test plan
- [ ] CI passes
- [ ] Both containers start (proxy + postgres sidecar)
- [ ] `pg_isready` readiness probe passes
- [ ] `/healthz` returns 200
- [ ] OAuth flow completes end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)