### PR TITLE
fix(mcp-oauth-proxy): specify database in pg_isready startup probe

### DIFF
--- a/charts/mcp-oauth-proxy/templates/deployment.yaml
+++ b/charts/mcp-oauth-proxy/templates/deployment.yaml
@@ -43,7 +43,7 @@ spec:
               protocol: TCP
           startupProbe:
             exec:
-              command: ["pg_isready", "-U", {{ .Values.postgres.user | quote }}]
+              command: ["pg_isready", "-U", {{ .Values.postgres.user | quote }}, "-d", {{ .Values.postgres.database | quote }}]
             initialDelaySeconds: 3
             periodSeconds: 3
             failureThreshold: 10


### PR DESCRIPTION
## Summary
- Fix spurious `FATAL: database "mcp" does not exist` errors in postgres logs
- Add `-d mcp_oauth` to `pg_isready` command so it checks the correct database

## Root cause
`pg_isready -U mcp` defaults to connecting to a database named after the user (`mcp`), but only `mcp_oauth` exists. This causes FATAL log entries and may delay the startup probe passing.

## Test plan
- [ ] CI passes
- [ ] No spurious FATAL entries in postgres logs
- [ ] Startup probe correctly validates `mcp_oauth` database is ready

🤖 Generated with [Claude Code](https://claude.com/claude-code)