### PR TITLE
fix(mcp-oauth-proxy): use TCP probes instead of HTTP /healthz

### DIFF
--- a/charts/mcp-oauth-proxy/templates/deployment.yaml
+++ b/charts/mcp-oauth-proxy/templates/deployment.yaml
@@ -73,14 +73,12 @@ spec:
             - secretRef:
                 name: {{ .Values.secret.name }}
           livenessProbe:
-            httpGet:
-              path: /healthz
+            tcpSocket:
               port: http
             initialDelaySeconds: 5
             periodSeconds: 10
           readinessProbe:
-            httpGet:
-              path: /healthz
+            tcpSocket:
               port: http
             initialDelaySeconds: 5
             periodSeconds: 10


### PR DESCRIPTION
## Summary
- Fix probe failures causing crash loop: `/healthz` returns 401 (proxy requires auth on all endpoints)
- Switch liveness and readiness probes from `httpGet /healthz` to `tcpSocket` on port 8080

## Root cause
The mcp-oauth-proxy authenticates all endpoints — there's no unauthenticated health route. Kubernetes HTTP probes send unauthenticated GET requests, resulting in 401 responses which count as probe failures.

## Test plan
- [ ] CI passes
- [ ] Pod becomes Ready (no more 401 probe failures)
- [ ] Proxy serves OAuth flow correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)