### PR TITLE
fix(mcp-oauth-proxy): add /mcp/ path to upstream MCP_SERVER_URL

### DIFF
--- a/charts/mcp-oauth-proxy/values.yaml
+++ b/charts/mcp-oauth-proxy/values.yaml
@@ -14,7 +14,7 @@ config:
   # OAuth scopes to request from Google
   SCOPES_SUPPORTED: "openid,email,profile"
   # Upstream MCP server URL (Context Forge ClusterIP)
-  MCP_SERVER_URL: "http://context-forge-mcp-stack-mcpgateway.mcp-gateway.svc.cluster.local:80"
+  MCP_SERVER_URL: "http://context-forge-mcp-stack-mcpgateway.mcp-gateway.svc.cluster.local:80/mcp/"
 
 # 1Password secret — provides OAUTH_CLIENT_ID, OAUTH_CLIENT_SECRET, ENCRYPTION_KEY
 secret:


### PR DESCRIPTION
## Summary
- Fix 307 redirect from Context Forge when proxy forwards to `/mcp` (no trailing slash)
- Set `MCP_SERVER_URL` to include the full `/mcp/` path

## Root cause
The proxy forwards requests to `MCP_SERVER_URL` + incoming path. Context Forge's Gunicorn backend returns 307 Temporary Redirect on `/mcp` → `/mcp/`. The redirect breaks the proxied MCP request chain.

## Test plan
- [ ] CI passes
- [ ] Proxy logs show successful proxied requests (non-307)
- [ ] Claude.ai connector completes the full flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)