### PR TITLE
revert(mcp-oauth-proxy): remove path from MCP_SERVER_URL

### DIFF
--- a/charts/mcp-oauth-proxy/values.yaml
+++ b/charts/mcp-oauth-proxy/values.yaml
@@ -14,7 +14,7 @@ config:
   # OAuth scopes to request from Google
   SCOPES_SUPPORTED: "openid,email,profile"
   # Upstream MCP server URL (Context Forge ClusterIP)
-  MCP_SERVER_URL: "http://context-forge-mcp-stack-mcpgateway.mcp-gateway.svc.cluster.local:80/mcp/"
+  MCP_SERVER_URL: "http://context-forge-mcp-stack-mcpgateway.mcp-gateway.svc.cluster.local:80"
 
 # 1Password secret — provides OAUTH_CLIENT_ID, OAUTH_CLIENT_SECRET, ENCRYPTION_KEY
 secret:


### PR DESCRIPTION
## Summary
- Revert `MCP_SERVER_URL` to bare origin — the proxy rejects URLs with paths
- The proxy is currently crashlooping with: `MCP server URL must not contain a path, query, or fragment`

## Context
Context Forge requires both `/mcp/` (trailing slash) and `Accept: application/json` headers. Clients must use `https://mcp.jomcgi.dev/mcp/` — the proxy passes the path through to the upstream.

## Test plan
- [ ] Proxy starts successfully
- [ ] Claude.ai connector works with `https://mcp.jomcgi.dev/mcp/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)