### PR TITLE
fix(docs): remove dead ADRs link from nav and homepage

### DIFF
--- a/websites/docs.jomcgi.dev/.vitepress/config.js
+++ b/websites/docs.jomcgi.dev/.vitepress/config.js
@@ -11,7 +11,6 @@ export default defineConfig({
   themeConfig: {
     nav: [
       { text: 'Architecture', link: '/architecture/services' },
-      { text: 'ADRs', link: '/architecture/decisions/' },
       { text: 'GitHub', link: 'https://github.com/jomcgi/homelab' },
     ],
 

--- a/websites/docs.jomcgi.dev/index.md
+++ b/websites/docs.jomcgi.dev/index.md
@@ -10,9 +10,6 @@ hero:
       text: Architecture
       link: /architecture/services
     - theme: alt
-      text: ADRs
-      link: /architecture/decisions/
-    - theme: alt
       text: GitHub
       link: https://github.com/jomcgi/homelab
 


### PR DESCRIPTION
## Summary
- Remove broken "ADRs" link from top nav and homepage hero
- ADRs are already accessible via the sidebar under Architecture — no index page exists at `/architecture/decisions/`

## Test plan
- [x] `bazel build //websites/docs.jomcgi.dev:build` passes with no dead links
- [ ] Verify nav and homepage render correctly after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)