### PR TITLE
fix(agent-run): exec-based task execution with repo prewarming

### DIFF
--- a/charts/goose-sandboxes/templates/sandboxtemplate.yaml
+++ b/charts/goose-sandboxes/templates/sandboxtemplate.yaml
@@ -11,22 +11,43 @@ spec:
         runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
-      containers:
-        - name: goose
+      initContainers:
+        - name: clone-repo
           image: "{{ .Values.sandboxTemplate.image.repository }}:{{ .Values.sandboxTemplate.image.tag }}"
           command: ["/bin/sh", "-c"]
-          args: ['goose run --text "$AGENT_TASK"']
+          args:
+            - |
+              git clone --depth 1 https://x-access-token:${GITHUB_TOKEN}@github.com/{{ .Values.sandboxTemplate.env.repoOwner }}/{{ .Values.sandboxTemplate.env.repoName }}.git /workspace/{{ .Values.sandboxTemplate.env.repoName }}
           securityContext:
             runAsUser: 65532
             runAsGroup: 65532
             allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: false # Agent needs writable fs for git, npm, build tools
             capabilities:
               drop:
                 - ALL
           env:
-            - name: AGENT_TASK
-              value: ""
+            - name: GITHUB_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: agent-secrets
+                  key: GITHUB_TOKEN
+          volumeMounts:
+            - name: workspace
+              mountPath: /workspace
+      containers:
+        - name: goose
+          image: "{{ .Values.sandboxTemplate.image.repository }}:{{ .Values.sandboxTemplate.image.tag }}"
+          command: ["sleep", "infinity"]
+          workingDir: /workspace/{{ .Values.sandboxTemplate.env.repoName }}
+          securityContext:
+            runAsUser: 65532
+            runAsGroup: 65532
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: false
+            capabilities:
+              drop:
+                - ALL
+          env:
             - name: GOOSE_PROVIDER
               value: {{ .Values.sandboxTemplate.env.gooseProvider }}
             - name: OPENAI_BASE_URL

--- a/charts/goose-sandboxes/values.yaml
+++ b/charts/goose-sandboxes/values.yaml
@@ -15,12 +15,14 @@ sandboxTemplate:
   name: goose-agent
   image:
     repository: ghcr.io/jomcgi/homelab/goose-agent
-    tag: latest
+    tag: main
   env:
     gooseProvider: openai
     gooseModel: claude-opus-4-6
     litellmBaseUrl: http://litellm-claude-sdk.litellm.svc.cluster.local:4000/v1
     contextForgeUrl: http://context-forge.mcp-gateway.svc.cluster.local:8000/mcp
+    repoOwner: jomcgi
+    repoName: homelab
   resources:
     requests:
       cpu: "1"

--- a/go.mod
+++ b/go.mod
@@ -48,6 +48,8 @@ require (
 	github.com/googleapis/gax-go/v2 v2.17.0 // indirect
 	github.com/klauspost/compress v1.18.0 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
+	github.com/moby/spdystream v0.5.0 // indirect
+	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.1 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -304,6 +304,8 @@ github.com/mitchellh/hashstructure/v2 v2.0.2 h1:vGKWl0YJqUNxE8d+h8f6NJLcCJrgbhC4
 github.com/mitchellh/hashstructure/v2 v2.0.2/go.mod h1:MG3aRVU/N29oo/V/IhBX8GR/zz4kQkprJgF2EVszyDE=
 github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zxSIeXaQ=
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
+github.com/moby/spdystream v0.5.0 h1:7r0J1Si3QO/kjRitvSLVVFUjxMEb/YLj6S9FF62JBCU=
+github.com/moby/spdystream v0.5.0/go.mod h1:xBAYlnt/ay+11ShkdFKNAG7LsyK/tmNBVvVOwrfMgdI=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -320,6 +322,8 @@ github.com/muesli/termenv v0.16.0 h1:S5AlUN9dENB57rsbnkPyfdGuWIlkmzJjbFf0Tf5FWUc
 github.com/muesli/termenv v0.16.0/go.mod h1:ZRfOIKPFDYQoDFF4Olj7/QJbW60Ol/kL1pU3VfY/Cnk=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
+github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f h1:y5//uYreIhSUg3J1GEMiLbxo1LJaP8RfCpH6pymGZus=
+github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
 github.com/onsi/ginkgo/v2 v2.22.0 h1:Yed107/8DjTr0lKCNt7Dn8yQ6ybuDRQoMGrNFKzMfHg=
 github.com/onsi/ginkgo/v2 v2.22.0/go.mod h1:7Du3c42kxCUegi0IImZ1wUQzMBVecgIHjR1C+NkhLQo=
 github.com/onsi/gomega v1.36.1 h1:bJDPBO7ibjxcbHMgSCoo4Yj18UWbKDlLwX1x9sybDcw=

--- a/tools/agent-run/BUILD
+++ b/tools/agent-run/BUILD
@@ -11,11 +11,13 @@ go_library(
         "@io_k8s_apimachinery//pkg/apis/meta/v1:meta",
         "@io_k8s_apimachinery//pkg/apis/meta/v1/unstructured",
         "@io_k8s_apimachinery//pkg/runtime/schema",
-        "@io_k8s_apimachinery//pkg/types",
-        "@io_k8s_apimachinery//pkg/watch",
         "@io_k8s_client_go//dynamic",
         "@io_k8s_client_go//kubernetes",
+        "@io_k8s_client_go//kubernetes/scheme",
+        "@io_k8s_client_go//rest",
         "@io_k8s_client_go//tools/clientcmd",
+        "@io_k8s_client_go//tools/remotecommand",
+        "@io_k8s_client_go//util/exec",
     ],
 )
 

--- a/tools/agent-run/main.go
+++ b/tools/agent-run/main.go
@@ -1,11 +1,9 @@
 // Package main provides the agent-run CLI for triggering Goose agent tasks
-// by creating SandboxClaim resources and streaming pod logs.
+// by creating SandboxClaim resources and exec-ing into sandbox pods.
 package main
 
 import (
-	"bufio"
 	"context"
-	"encoding/json"
 	"fmt"
 	"os"
 	"os/signal"
@@ -16,11 +14,13 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/tools/remotecommand"
+	executil "k8s.io/client-go/util/exec"
 
 	"github.com/spf13/cobra"
 )
@@ -49,8 +49,8 @@ var rootCmd = &cobra.Command{
 	Short: "Trigger a Goose agent task in a sandbox pod",
 	Long: `agent-run creates a SandboxClaim referencing the goose-agent SandboxTemplate,
 waits for the controller to allocate a Sandbox (from the warm pool if available),
-patches the pod's AGENT_TASK environment variable, streams pod logs until Goose
-exits, and reports the exit code.`,
+exec's into the pod to run goose with the task, and streams output until Goose exits.
+The SandboxClaim is cleaned up on exit, recycling the pod.`,
 	Args:         cobra.MinimumNArgs(0),
 	SilenceUsage: true,
 	RunE:         run,
@@ -133,20 +133,16 @@ func run(cmd *cobra.Command, args []string) error {
 	}
 	fmt.Printf("Sandbox pod: %s\n", podName)
 
-	// Patch the pod's AGENT_TASK env var with the task description.
-	if err := patchAgentTask(ctx, clientset, podName, task); err != nil {
-		return fmt.Errorf("patching AGENT_TASK: %w", err)
-	}
-
-	// Wait for pod to be running.
+	// Wait for pod to be running (init containers finished).
 	if err := waitPodRunning(ctx, clientset, podName); err != nil {
 		return fmt.Errorf("waiting for pod running: %w", err)
 	}
 
-	// Stream logs until completion.
-	exitCode, err := streamLogs(ctx, clientset, podName)
+	// Exec goose in the sandbox pod and stream output.
+	fmt.Printf("Running goose task in %s...\n", podName)
+	exitCode, err := execGoose(ctx, config, clientset, podName, task)
 	if err != nil {
-		return fmt.Errorf("streaming logs: %w", err)
+		return fmt.Errorf("exec goose: %w", err)
 	}
 
 	fmt.Printf("\nGoose exited with code %d\n", exitCode)
@@ -219,90 +215,69 @@ func resolvePodName(ctx context.Context, client dynamic.Interface, sandboxName s
 	return sandboxName, nil
 }
 
-// patchAgentTask sets the AGENT_TASK env var on the goose container via a strategic merge patch.
-func patchAgentTask(ctx context.Context, clientset kubernetes.Interface, podName, task string) error {
-	patch := map[string]interface{}{
-		"spec": map[string]interface{}{
-			"containers": []map[string]interface{}{
-				{
-					"name": "goose",
-					"env": []map[string]interface{}{
-						{
-							"name":  "AGENT_TASK",
-							"value": task,
-						},
-					},
-				},
-			},
-		},
-	}
-	patchBytes, err := json.Marshal(patch)
-	if err != nil {
-		return fmt.Errorf("marshaling patch: %w", err)
-	}
-	_, err = clientset.CoreV1().Pods(namespace).Patch(ctx, podName, types.StrategicMergePatchType, patchBytes, metav1.PatchOptions{})
-	return err
-}
-
 func waitPodRunning(ctx context.Context, clientset kubernetes.Interface, podName string) error {
-	w, err := clientset.CoreV1().Pods(namespace).Watch(ctx, metav1.ListOptions{
-		FieldSelector: "metadata.name=" + podName,
-	})
-	if err != nil {
-		return err
-	}
-	defer w.Stop()
+	fmt.Printf("Waiting for pod %s to be ready...\n", podName)
 
-	fmt.Printf("Waiting for pod %s to be running...\n", podName)
-	for event := range w.ResultChan() {
-		if event.Type == watch.Error {
-			return fmt.Errorf("watch error")
+	timeout := 5 * time.Minute
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	for {
+		pod, err := clientset.CoreV1().Pods(namespace).Get(ctx, podName, metav1.GetOptions{})
+		if err != nil {
+			return err
 		}
-		pod, ok := event.Object.(*corev1.Pod)
-		if !ok {
-			continue
-		}
+
 		switch pod.Status.Phase {
 		case corev1.PodRunning:
-			fmt.Println("Pod is running")
-			return nil
-		case corev1.PodSucceeded:
-			fmt.Println("Pod completed")
-			return nil
+			// Verify the goose container is ready (init containers finished).
+			for _, cs := range pod.Status.ContainerStatuses {
+				if cs.Name == "goose" && cs.Ready {
+					fmt.Println("Pod is ready")
+					return nil
+				}
+			}
 		case corev1.PodFailed:
 			return fmt.Errorf("pod failed: %s", pod.Status.Message)
 		}
+
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("timed out waiting for pod to be ready")
+		case <-time.After(2 * time.Second):
+		}
 	}
-	return fmt.Errorf("watch closed")
 }
 
-func streamLogs(ctx context.Context, clientset kubernetes.Interface, podName string) (int, error) {
-	req := clientset.CoreV1().Pods(namespace).GetLogs(podName, &corev1.PodLogOptions{
-		Container: "goose",
-		Follow:    true,
+// execGoose runs goose inside the sandbox pod via K8s exec and streams output.
+func execGoose(ctx context.Context, config *rest.Config, clientset kubernetes.Interface, podName, task string) (int, error) {
+	req := clientset.CoreV1().RESTClient().Post().
+		Resource("pods").
+		Name(podName).
+		Namespace(namespace).
+		SubResource("exec").
+		VersionedParams(&corev1.PodExecOptions{
+			Container: "goose",
+			Command:   []string{"goose", "run", "--text", task},
+			Stdout:    true,
+			Stderr:    true,
+		}, scheme.ParameterCodec)
+
+	exec, err := remotecommand.NewSPDYExecutor(config, "POST", req.URL())
+	if err != nil {
+		return -1, fmt.Errorf("creating executor: %w", err)
+	}
+
+	err = exec.StreamWithContext(ctx, remotecommand.StreamOptions{
+		Stdout: os.Stdout,
+		Stderr: os.Stderr,
 	})
-
-	stream, err := req.Stream(ctx)
 	if err != nil {
-		return -1, fmt.Errorf("opening log stream: %w", err)
-	}
-	defer stream.Close()
-
-	scanner := bufio.NewScanner(stream)
-	for scanner.Scan() {
-		fmt.Println(scanner.Text())
-	}
-
-	// Check final pod status for exit code.
-	pod, err := clientset.CoreV1().Pods(namespace).Get(context.Background(), podName, metav1.GetOptions{})
-	if err != nil {
-		return -1, fmt.Errorf("getting final pod status: %w", err)
-	}
-
-	for _, cs := range pod.Status.ContainerStatuses {
-		if cs.Name == "goose" && cs.State.Terminated != nil {
-			return int(cs.State.Terminated.ExitCode), nil
+		// Extract exit code from exec error if possible.
+		if exitErr, ok := err.(executil.ExitError); ok {
+			return exitErr.ExitStatus(), nil
 		}
+		return -1, err
 	}
 
 	return 0, nil


### PR DESCRIPTION
## Summary
- **Resolve pod name from warm pool**: SandboxClaim returns the Sandbox resource name, not the pod name. When adopted from the warm pool, the actual pod name is in the `agents.x-k8s.io/pod-name` annotation on the Sandbox resource. Also fixes the Sandbox GVR to use the correct `agents.x-k8s.io` API group.
- **Exec instead of env patching**: K8s doesn't allow patching env vars on running pods. Replace `AGENT_TASK` env var approach with `kubectl exec` equivalent — uses `remotecommand` SPDY executor to run `goose run --text "..."` and stream stdout/stderr.
- **Repo prewarming**: Add init container to clone the homelab repo into `/workspace` during pod startup. Main container now runs `sleep infinity` so warm pool pods stay alive and ready for exec.

## Test plan
- [ ] Verify warm pool pod starts, init container clones repo, main container sleeps
- [ ] Run `bazel run //tools/agent-run -- "echo hello from goose"` end-to-end
- [ ] Verify SandboxClaim cleanup recycles the pod
- [ ] Verify warm pool replenishes a new pod after cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)