### PR TITLE
fix(goose-sandboxes): add fsGroup for workspace volume ownership

### DIFF
--- a/charts/goose-sandboxes/templates/sandboxtemplate.yaml
+++ b/charts/goose-sandboxes/templates/sandboxtemplate.yaml
@@ -9,6 +9,7 @@ spec:
       serviceAccountName: goose-agent
       securityContext:
         runAsNonRoot: true
+        fsGroup: 65532
         seccompProfile:
           type: RuntimeDefault
       initContainers:


### PR DESCRIPTION
## Summary
- Add `fsGroup: 65532` to pod security context so the ephemeral PVC workspace volume is owned by the goose-agent user, allowing the init container to clone into `/workspace`

## Test plan
- [ ] Verify warm pool pod init container clones repo successfully
- [ ] Verify goose container starts and stays running with `sleep infinity`

🤖 Generated with [Claude Code](https://claude.com/claude-code)