### PR TITLE
fix(goose-sandboxes): use OPENAI_HOST for LiteLLM endpoint

### DIFF
--- a/charts/goose-sandboxes/templates/sandboxtemplate.yaml
+++ b/charts/goose-sandboxes/templates/sandboxtemplate.yaml
@@ -51,7 +51,7 @@ spec:
           env:
             - name: GOOSE_PROVIDER
               value: {{ .Values.sandboxTemplate.env.gooseProvider }}
-            - name: OPENAI_BASE_URL
+            - name: OPENAI_HOST
               value: {{ .Values.sandboxTemplate.env.litellmBaseUrl }}
             - name: OPENAI_API_KEY
               valueFrom:


### PR DESCRIPTION
## Summary
- Goose uses `OPENAI_HOST` (not `OPENAI_BASE_URL`) for custom OpenAI-compatible endpoints. The wrong env var name caused goose to hit the real OpenAI API instead of our LiteLLM proxy, resulting in 401 errors.

## Test plan
- [ ] Verify goose routes requests through LiteLLM (check LiteLLM logs for incoming requests)
- [ ] Run `bazel run //tools/agent-run -- "list files"` end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)