### PR TITLE
fix(goose-sandboxes): remove /v1 from LiteLLM base URL

### DIFF
--- a/charts/goose-sandboxes/values.yaml
+++ b/charts/goose-sandboxes/values.yaml
@@ -19,7 +19,7 @@ sandboxTemplate:
   env:
     gooseProvider: openai
     gooseModel: claude-opus-4-6
-    litellmBaseUrl: http://litellm-claude-sdk.litellm.svc.cluster.local:4000/v1
+    litellmBaseUrl: http://litellm-claude-sdk.litellm.svc.cluster.local:4000
     contextForgeUrl: http://context-forge.mcp-gateway.svc.cluster.local:8000/mcp
     repoOwner: jomcgi
     repoName: homelab


### PR DESCRIPTION
## Summary
- Remove `/v1` suffix from `litellmBaseUrl` — goose appends `/v1/chat/completions` to `OPENAI_HOST` automatically, causing double-pathing (`/v1/v1/chat/completions` → 404)

## Test plan
- [ ] Verify LiteLLM logs show `/v1/chat/completions` (not `/v1/v1/...`)
- [ ] Run `bazel run //tools/agent-run -- "list files"` end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)