### PR TITLE
fix(litellm): use cabinlab/litellm-claude-code image with custom provider

### DIFF
--- a/charts/litellm/templates/deployment.yaml
+++ b/charts/litellm/templates/deployment.yaml
@@ -37,11 +37,16 @@ spec:
             - name: {{ $key }}
               value: {{ $value | quote }}
             {{- end }}
-          envFrom:
-            {{- range $key, $secret := .Values.secrets }}
-            - secretRef:
-                name: {{ $secret.name }}
-            {{- end }}
+            - name: CLAUDE_CODE_OAUTH_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.secrets.claudeAuth.name }}
+                  key: CLAUDE_AUTH_TOKEN
+            - name: LITELLM_MASTER_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.secrets.apiKey.name }}
+                  key: LITELLM_MASTER_KEY
           livenessProbe:
             httpGet:
               path: /health/liveliness
@@ -60,12 +65,16 @@ spec:
             - name: config
               mountPath: /etc/litellm
               readOnly: true
+            - name: claude-home
+              mountPath: /home/claude
             - name: tmp
               mountPath: /tmp
       volumes:
         - name: config
           configMap:
             name: {{ include "litellm.fullname" . }}-config
+        - name: claude-home
+          emptyDir: {}
         - name: tmp
           emptyDir:
             medium: Memory

--- a/charts/litellm/values.yaml
+++ b/charts/litellm/values.yaml
@@ -3,13 +3,11 @@
 # via the Claude Agent SDK.
 
 image:
-  repository: ghcr.io/berriai/litellm
-  tag: "main-latest"
+  repository: ghcr.io/cabinlab/litellm-claude-code
+  tag: "latest"
   pullPolicy: IfNotPresent
 
 config:
-  # litellm-claude-code custom provider module
-  LITELLM_CUSTOM_PROVIDER: "litellm_claude_code"
   LITELLM_LOG: "INFO"
 
 # 1Password secrets
@@ -28,18 +26,18 @@ litellmConfig:
   model_list:
     - model_name: claude-opus-4-6
       litellm_params:
-        model: claude_code/claude-opus-4-6
+        model: claude-agent-sdk/claude-opus-4-6
     - model_name: claude-sonnet-4-6
       litellm_params:
-        model: claude_code/claude-sonnet-4-6
+        model: claude-agent-sdk/claude-sonnet-4-6
 
 resources:
   requests:
-    cpu: 100m
-    memory: 512Mi
+    cpu: "2"
+    memory: 4Gi
   limits:
     cpu: "2"
-    memory: 3Gi
+    memory: 4Gi
 
 podSecurityContext:
   runAsNonRoot: true
@@ -47,8 +45,8 @@ podSecurityContext:
     type: RuntimeDefault
 
 securityContext:
-  runAsUser: 65532
-  runAsGroup: 65532
+  runAsUser: 1001
+  runAsGroup: 1001
   allowPrivilegeEscalation: false
   readOnlyRootFilesystem: true
   capabilities:

--- a/overlays/prod/litellm/imageupdater.yaml
+++ b/overlays/prod/litellm/imageupdater.yaml
@@ -10,7 +10,7 @@ spec:
           commonUpdateSettings:
             updateStrategy: digest
             forceUpdate: false
-          imageName: ghcr.io/berriai/litellm:main-latest
+          imageName: ghcr.io/cabinlab/litellm-claude-code:latest
           manifestTargets:
             helm:
               name: image.repository

--- a/overlays/prod/litellm/values.yaml
+++ b/overlays/prod/litellm/values.yaml
@@ -4,5 +4,5 @@
 # Override fullname to match the service DNS name expected by goose-sandboxes
 fullnameOverride: litellm-claude-sdk
 image:
-  tag: main-latest@sha256:59a2736ac84800821fa0e1656487366089f2d29d10f8ae05c918df9c6e4940af
-  repository: ghcr.io/berriai/litellm
+  repository: ghcr.io/cabinlab/litellm-claude-code
+  tag: latest


### PR DESCRIPTION
## Summary
- Switches from upstream `ghcr.io/berriai/litellm` to `ghcr.io/cabinlab/litellm-claude-code` which bundles the Claude Agent SDK custom provider
- Matches the original working OpenHands deployment configuration
- Updates model prefix from `claude_code/` to `claude-agent-sdk/`
- Adds explicit `CLAUDE_CODE_OAUTH_TOKEN` env var mapping and `/home/claude` volume for SDK state
- Updates security context to uid 1001 (cabinlab image's `claude` user)
- Bumps resources to 4Gi/2CPU (proven working config)

## Context
The upstream LiteLLM image doesn't include the `litellm_claude_code` provider module, causing "LLM Provider NOT provided" errors at startup and "no healthy deployments" when agents try to use models.

## Test plan
- [ ] LiteLLM pod starts without provider errors
- [ ] Models show as healthy in LiteLLM router
- [ ] `agent-run` can successfully make API calls through LiteLLM

🤖 Generated with [Claude Code](https://claude.com/claude-code)