### PR TITLE
fix(signoz): fix Incident.io webhook channel and migrate remaining alerts

### DIFF
--- a/architecture/observability-alerting.md
+++ b/architecture/observability-alerting.md
@@ -1,10 +1,10 @@
 # Observability & Alerting
 
-The homelab has a complete observability stack (SigNoz v0.113, OTel, Linkerd) with a fully operational alerting pipeline. 22 alert rules monitor infrastructure health, application availability, and GitOps state. Alerts are synced to SigNoz via the signoz-dashboard-sidecar and notify through PagerDuty.
+The homelab has a complete observability stack (SigNoz v0.113, OTel, Linkerd) with a fully operational alerting pipeline. 22 alert rules monitor infrastructure health, application availability, and GitOps state. Alerts are synced to SigNoz via the signoz-dashboard-sidecar and notify through Incident.io.
 
 ## Current State
 
-**What works:** 22 alert rules are synced, evaluating, and generating alert history in SigNoz v0.113. The signoz-dashboard-sidecar reconciles alert ConfigMaps every 5 minutes, creating or updating rules via the SigNoz API. PagerDuty notification channel (`pagerduty-homelab`) is configured and active.
+**What works:** 22 alert rules are synced, evaluating, and generating alert history in SigNoz v0.113. The signoz-dashboard-sidecar reconciles alert ConfigMaps every 5 minutes, creating or updating rules via the SigNoz API. Incident.io notification channel (`incidentio`) is configured via webhook, with Bearer token auth sourced from 1Password.
 
 **Alert inventory:**
 
@@ -38,7 +38,7 @@ All alerts are Kubernetes ConfigMaps with the `signoz.io/alert: "true"` label, d
   "labels": { ... },
   "annotations": { "summary": "...", "description": "..." },
   "condition": { ... },
-  "preferredChannels": ["pagerduty-homelab"]
+  "preferredChannels": ["incidentio"]
 }
 ```
 
@@ -103,7 +103,7 @@ Thresholds must be defined in **two places** on the `condition` object — both 
         "targetUnit": "",
         "matchType": "5",
         "op": "2",
-        "channels": ["pagerduty-homelab"]
+        "channels": ["incidentio"]
       }
     ]
   }

--- a/overlays/cluster-critical/argocd/argocd-httpcheck-alert.yaml
+++ b/overlays/cluster-critical/argocd/argocd-httpcheck-alert.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     signoz.io/alert-name: "ArgoCD Unreachable"
     signoz.io/severity: "critical"
-    signoz.io/notification-channels: "pagerduty-homelab"
+    signoz.io/notification-channels: "incidentio"
 data:
   alert.json: |
     {
@@ -71,10 +71,10 @@ data:
               "targetUnit": "",
               "matchType": "5",
               "op": "2",
-              "channels": ["pagerduty-homelab"]
+              "channels": ["incidentio"]
             }
           ]
         }
       },
-      "preferredChannels": ["pagerduty-homelab"]
+      "preferredChannels": ["incidentio"]
     }

--- a/overlays/cluster-critical/longhorn/longhorn-httpcheck-alert.yaml
+++ b/overlays/cluster-critical/longhorn/longhorn-httpcheck-alert.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     signoz.io/alert-name: "Longhorn Unreachable"
     signoz.io/severity: "critical"
-    signoz.io/notification-channels: "pagerduty-homelab"
+    signoz.io/notification-channels: "incidentio"
 data:
   alert.json: |
     {
@@ -71,10 +71,10 @@ data:
               "targetUnit": "",
               "matchType": "5",
               "op": "2",
-              "channels": ["pagerduty-homelab"]
+              "channels": ["incidentio"]
             }
           ]
         }
       },
-      "preferredChannels": ["pagerduty-homelab"]
+      "preferredChannels": ["incidentio"]
     }

--- a/overlays/cluster-critical/signoz/incidentio-channel.yaml
+++ b/overlays/cluster-critical/signoz/incidentio-channel.yaml
@@ -16,7 +16,7 @@ data:
       "webhook_configs": [
         {
           "send_resolved": true,
-          "api_url": "https://api.incident.io/v2/alert_events/alertmanager/01KJZQPDWP2HY5E3HDC2TXKS6K",
+          "url": "https://api.incident.io/v2/alert_events/alertmanager/01KJZQPDWP2HY5E3HDC2TXKS6K",
           "http_config": {
             "authorization": {
               "type": "Bearer",

--- a/overlays/dev/marine/marine-httpcheck-alert.yaml
+++ b/overlays/dev/marine/marine-httpcheck-alert.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     signoz.io/alert-name: "marine Unreachable"
     signoz.io/severity: "warning"
-    signoz.io/notification-channels: "pagerduty-homelab"
+    signoz.io/notification-channels: "incidentio"
 data:
   alert.json: |
     {
@@ -71,10 +71,10 @@ data:
               "targetUnit": "",
               "matchType": "5",
               "op": "2",
-              "channels": ["pagerduty-homelab"]
+              "channels": ["incidentio"]
             }
           ]
         }
       },
-      "preferredChannels": ["pagerduty-homelab"]
+      "preferredChannels": ["incidentio"]
     }

--- a/overlays/prod/api-gateway/api-gateway-httpcheck-alert.yaml
+++ b/overlays/prod/api-gateway/api-gateway-httpcheck-alert.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     signoz.io/alert-name: "api-gateway Unreachable"
     signoz.io/severity: "critical"
-    signoz.io/notification-channels: "pagerduty-homelab"
+    signoz.io/notification-channels: "incidentio"
 data:
   alert.json: |
     {
@@ -71,10 +71,10 @@ data:
               "targetUnit": "",
               "matchType": "5",
               "op": "2",
-              "channels": ["pagerduty-homelab"]
+              "channels": ["incidentio"]
             }
           ]
         }
       },
-      "preferredChannels": ["pagerduty-homelab"]
+      "preferredChannels": ["incidentio"]
     }

--- a/overlays/prod/todo/todo-admin-httpcheck-alert.yaml
+++ b/overlays/prod/todo/todo-admin-httpcheck-alert.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     signoz.io/alert-name: "todo-admin Unreachable"
     signoz.io/severity: "critical"
-    signoz.io/notification-channels: "pagerduty-homelab"
+    signoz.io/notification-channels: "incidentio"
 data:
   alert.json: |
     {
@@ -71,10 +71,10 @@ data:
               "targetUnit": "",
               "matchType": "5",
               "op": "2",
-              "channels": ["pagerduty-homelab"]
+              "channels": ["incidentio"]
             }
           ]
         }
       },
-      "preferredChannels": ["pagerduty-homelab"]
+      "preferredChannels": ["incidentio"]
     }

--- a/overlays/prod/todo/todo-httpcheck-alert.yaml
+++ b/overlays/prod/todo/todo-httpcheck-alert.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     signoz.io/alert-name: "todo Unreachable"
     signoz.io/severity: "critical"
-    signoz.io/notification-channels: "pagerduty-homelab"
+    signoz.io/notification-channels: "incidentio"
 data:
   alert.json: |
     {
@@ -71,10 +71,10 @@ data:
               "targetUnit": "",
               "matchType": "5",
               "op": "2",
-              "channels": ["pagerduty-homelab"]
+              "channels": ["incidentio"]
             }
           ]
         }
       },
-      "preferredChannels": ["pagerduty-homelab"]
+      "preferredChannels": ["incidentio"]
     }

--- a/overlays/prod/trips/img-httpcheck-alert.yaml
+++ b/overlays/prod/trips/img-httpcheck-alert.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     signoz.io/alert-name: "img Unreachable"
     signoz.io/severity: "critical"
-    signoz.io/notification-channels: "pagerduty-homelab"
+    signoz.io/notification-channels: "incidentio"
 data:
   alert.json: |
     {
@@ -71,10 +71,10 @@ data:
               "targetUnit": "",
               "matchType": "5",
               "op": "2",
-              "channels": ["pagerduty-homelab"]
+              "channels": ["incidentio"]
             }
           ]
         }
       },
-      "preferredChannels": ["pagerduty-homelab"]
+      "preferredChannels": ["incidentio"]
     }


### PR DESCRIPTION
## Summary
- Fix `incidentio-channel.yaml` webhook config field name (`api_url` → `url`) — this was causing the sidecar to fail every 5 minutes with `"one of url or url_file must be configured"`
- Migrate 7 remaining HTTPCheck alerts from `pagerduty-homelab` to `incidentio` (argocd, longhorn, marine, api-gateway, todo, todo-admin, img)
- Update `architecture/observability-alerting.md` to reflect the Incident.io migration

## Test plan
- [ ] After merge, verify sidecar logs no longer show channel sync errors
- [ ] Confirm `incidentio` channel appears in SigNoz UI under Settings → Alert Channels
- [ ] Verify a firing alert (e.g. ArgoCD Unreachable) creates an incident in Incident.io
- [ ] Confirm all 22 alerts show `preferredChannels: ["incidentio"]` in SigNoz

🤖 Generated with [Claude Code](https://claude.com/claude-code)