### PR TITLE
fix(litellm): mount config at /app/config for cabinlab entrypoint

### DIFF
--- a/charts/litellm/templates/configmap.yaml
+++ b/charts/litellm/templates/configmap.yaml
@@ -6,5 +6,5 @@ metadata:
   labels:
     {{- include "litellm.labels" . | nindent 4 }}
 data:
-  config.yaml: |
+  litellm_config.yaml: |
     {{- toYaml .Values.litellmConfig | nindent 4 }}

--- a/charts/litellm/templates/deployment.yaml
+++ b/charts/litellm/templates/deployment.yaml
@@ -23,11 +23,6 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          args:
-            - "--config"
-            - "/etc/litellm/config.yaml"
-            - "--port"
-            - "4000"
           ports:
             - name: http
               containerPort: 4000
@@ -63,7 +58,7 @@ spec:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
             - name: config
-              mountPath: /etc/litellm
+              mountPath: /app/config
               readOnly: true
             - name: claude-home
               mountPath: /home/claude


### PR DESCRIPTION
## Summary
- The cabinlab entrypoint hardcodes `--config /app/config/litellm_config.yaml`, ignoring container args
- Mounts our ConfigMap at `/app/config` instead of `/etc/litellm` with the expected filename `litellm_config.yaml`
- Removes unused `args` from the deployment since the entrypoint handles startup

## Context
After switching to the cabinlab image in #803, LiteLLM loaded its built-in default models (`opus`, `sonnet`, `haiku`) instead of our configured `claude-opus-4-6` / `claude-sonnet-4-6`.

## Test plan
- [ ] LiteLLM startup logs show `claude-opus-4-6` and `claude-sonnet-4-6` as registered models
- [ ] `agent-run` can successfully call `claude-opus-4-6` through LiteLLM

🤖 Generated with [Claude Code](https://claude.com/claude-code)