### PR TITLE
fix(litellm): add custom_provider_map for claude-agent-sdk provider

### DIFF
--- a/charts/litellm/values.yaml
+++ b/charts/litellm/values.yaml
@@ -30,6 +30,13 @@ litellmConfig:
     - model_name: claude-sonnet-4-6
       litellm_params:
         model: claude-agent-sdk/claude-sonnet-4-6
+  general_settings:
+    master_key: os.environ/LITELLM_MASTER_KEY
+  litellm_settings:
+    drop_params: true
+    custom_provider_map:
+      - provider: claude-agent-sdk
+        custom_handler: providers.claude_agent_provider.claude_agent_provider
 
 resources:
   requests:


### PR DESCRIPTION
## Summary
- Adds `custom_provider_map` to `litellm_settings` so LiteLLM recognizes `claude-agent-sdk/` as a valid provider prefix
- Adds `drop_params: true` to handle unsupported OpenAI params gracefully
- Adds `general_settings.master_key` referencing the env var

## Context
After #806 fixed the config mount path, our models showed as registered but with "no healthy deployments". The cabinlab image bundles the custom provider handler at `providers.claude_agent_provider.claude_agent_provider`, but LiteLLM's router needs the `custom_provider_map` config entry to wire it up.

## Test plan
- [ ] LiteLLM startup logs show no "LLM Provider NOT provided" errors
- [ ] `agent-run` can make successful API calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)