### PR TITLE
fix(litellm): use subPath mount to preserve providers directory

### DIFF
--- a/charts/litellm/templates/deployment.yaml
+++ b/charts/litellm/templates/deployment.yaml
@@ -58,7 +58,8 @@ spec:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
             - name: config
-              mountPath: /app/config
+              mountPath: /app/config/litellm_config.yaml
+              subPath: litellm_config.yaml
               readOnly: true
             - name: claude-home
               mountPath: /home/claude


### PR DESCRIPTION
## Summary
- Uses `subPath` to mount only `litellm_config.yaml` instead of replacing the entire `/app/config/` directory
- The cabinlab image stores its custom provider at `/app/config/providers/claude_agent_provider.py` — a directory mount was clobbering it

## Context
The cabinlab image has this layout:
```
/app/config/
├── litellm_config.yaml    ← we want to override this
└── providers/             ← must be preserved
    ├── __init__.py
    └── claude_agent_provider.py
```

Mounting the ConfigMap as a directory replaced everything, causing `ImportError: Could not import claude_agent_provider`.

## Test plan
- [ ] LiteLLM starts without ImportError
- [ ] Provider initializes: "ClaudeAgentSDKProvider initialized"
- [ ] Models register as healthy deployments
- [ ] `agent-run` end-to-end works

🤖 Generated with [Claude Code](https://claude.com/claude-code)