### PR TITLE
feat(litellm): add gpt-4o-mini model alias for Goose

### DIFF
--- a/charts/litellm/values.yaml
+++ b/charts/litellm/values.yaml
@@ -30,6 +30,10 @@ litellmConfig:
     - model_name: claude-sonnet-4-6
       litellm_params:
         model: claude-agent-sdk/claude-sonnet-4-6
+    # Goose uses gpt-4o-mini internally for tool planning — route to Sonnet
+    - model_name: gpt-4o-mini
+      litellm_params:
+        model: claude-agent-sdk/claude-sonnet-4-6
   general_settings:
     master_key: os.environ/LITELLM_MASTER_KEY
   litellm_settings:


### PR DESCRIPTION
## Summary
- Adds `gpt-4o-mini` as a model alias in LiteLLM config, routing requests to `claude-sonnet-4-6` via the Claude Agent SDK provider
- Goose internally uses `gpt-4o-mini` for tool planning/summarization — without this alias, those requests return 400 errors

## Test plan
- [ ] Verify LiteLLM pod starts successfully with the updated config
- [ ] Run `agent-run` and confirm Goose tool planning requests (gpt-4o-mini) succeed
- [ ] Confirm Claude model requests (opus/sonnet) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)