### PR TITLE
fix(mcp-servers): surface HTTP errors in registration jobs

### DIFF
--- a/charts/mcp-servers/templates/registration-job.yaml
+++ b/charts/mcp-servers/templates/registration-job.yaml
@@ -70,23 +70,40 @@ spec:
               ")
 
               # Idempotent: skip registration if the gateway already exists.
-              EXISTING_ID=$(curl -sf "{{ $.Values.gateway.url }}/gateways" \
-                -H "Authorization: Bearer ${TOKEN}" \
-                | python3 -c "import sys,json; gws=json.load(sys.stdin); print(next((g['id'] for g in gws if g['name']=='{{ .name }}'),''))")
+              RESPONSE=$(curl -s -w "\n%{http_code}" "{{ $.Values.gateway.url }}/gateways" \
+                -H "Authorization: Bearer ${TOKEN}")
+              HTTP_CODE=$(echo "$RESPONSE" | tail -1)
+              BODY=$(echo "$RESPONSE" | sed '$d')
+
+              if [ "$HTTP_CODE" != "200" ]; then
+                echo "ERROR: GET /gateways returned HTTP ${HTTP_CODE}"
+                echo "$BODY"
+                exit 1
+              fi
+
+              EXISTING_ID=$(echo "$BODY" | python3 -c "import sys,json; gws=json.load(sys.stdin); print(next((g['id'] for g in gws if g['name']=='{{ .name }}'),''))")
 
               if [ -n "${EXISTING_ID}" ]; then
                 echo "{{ .name }} already registered (${EXISTING_ID}), skipping."
               else
                 echo "Registering {{ .name }}..."
-                curl -sf -X POST "{{ $.Values.gateway.url }}/gateways" \
+                REG_RESPONSE=$(curl -s -w "\n%{http_code}" -X POST "{{ $.Values.gateway.url }}/gateways" \
                   -H "Authorization: Bearer ${TOKEN}" \
                   -H "Content-Type: application/json" \
                   -d '{
                     "name": "{{ .name }}",
                     "url": "http://{{ .name }}.{{ $.Release.Namespace }}.svc.cluster.local:{{ include "mcp-servers.port" . }}/mcp",
                     "transport": "{{ .registration.transport | default "STREAMABLEHTTP" }}"
-                  }'
-                echo ""
+                  }')
+                REG_CODE=$(echo "$REG_RESPONSE" | tail -1)
+                REG_BODY=$(echo "$REG_RESPONSE" | sed '$d')
+
+                if [ "$REG_CODE" != "200" ] && [ "$REG_CODE" != "201" ]; then
+                  echo "ERROR: POST /gateways returned HTTP ${REG_CODE}"
+                  echo "$REG_BODY"
+                  exit 1
+                fi
+                echo "$REG_BODY"
               fi
 
               echo "Registration complete."


### PR DESCRIPTION
## Summary
- Registration jobs silently swallowed HTTP errors, producing empty output that crashes json.load with JSONDecodeError
- Now captures HTTP status code separately and fails with a clear error message showing the status code and response body
- Affects all MCP server registration jobs (signoz-mcp, buildbuddy-mcp, kubernetes-mcp, argocd-mcp, todo-mcp)

## Root cause
The -f flag on HTTP requests outputs nothing on errors. In a pipe to python3, only python3's exit code is checked by set -e. So the HTTP request fails silently, python3 gets empty stdin, and crashes.

## Test plan
- [x] helm template renders correctly
- [ ] CI passes
- [ ] After merge: registration jobs either succeed or show the actual HTTP error (status code + body)

🤖 Generated with [Claude Code](https://claude.com/claude-code)