### PR TITLE
fix(context-forge): re-enable JWT auth for registration jobs

### DIFF
--- a/charts/context-forge/values.yaml
+++ b/charts/context-forge/values.yaml
@@ -23,7 +23,8 @@ mcp-stack:
       MCPGATEWAY_BULK_IMPORT_ENABLED: "false"
     secret:
       AUTH_REQUIRED: "true"
-      MCP_CLIENT_AUTH_ENABLED: "false"
+      # JWT auth required for in-cluster registration jobs (charts/mcp-servers registration-job.yaml)
+      MCP_CLIENT_AUTH_ENABLED: "true"
       MCP_REQUIRE_AUTH: "false"
       # mcp-oauth-proxy handles auth and injects X-Forwarded-User — see ADR 006
       TRUST_PROXY_AUTH: "true"


### PR DESCRIPTION
## Summary
- The OAuth proxy migration (23506394) set `MCP_CLIENT_AUTH_ENABLED: "false"`, disabling JWT bearer token auth on the Context Forge admin API
- This broke all MCP server registration jobs, which authenticate via JWT signed with `JWT_SECRET_KEY`
- Re-enables `MCP_CLIENT_AUTH_ENABLED: "true"` so the gateway accepts both JWT tokens (in-cluster jobs) and proxy auth headers (external via mcp-oauth-proxy)

## Test plan
- [ ] CI passes
- [ ] After merge: registration jobs for all 5 MCP servers complete successfully
- [ ] External access via mcp-oauth-proxy still works (OAuth flow unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)