### PR TITLE
feat(tools): add agent-run to bazel_env and revert TTY exec

### DIFF
--- a/tools/BUILD
+++ b/tools/BUILD
@@ -69,6 +69,8 @@ bazel_env(
         "advent": "//advent_of_code/cmd/aoc",
         # HuggingFace model tools
         "hf_lock": ":hf_lock",
+        # Agent tools
+        "agent-run": "//tools/agent-run",
     },
 )
 

--- a/tools/agent-run/main.go
+++ b/tools/agent-run/main.go
@@ -259,10 +259,8 @@ func execGoose(ctx context.Context, config *rest.Config, clientset kubernetes.In
 		VersionedParams(&corev1.PodExecOptions{
 			Container: "goose",
 			Command:   []string{"goose", "run", "--text", task},
-			Stdin:     true,
 			Stdout:    true,
 			Stderr:    true,
-			TTY:       true,
 		}, scheme.ParameterCodec)
 
 	exec, err := remotecommand.NewSPDYExecutor(config, "POST", req.URL())
@@ -271,10 +269,8 @@ func execGoose(ctx context.Context, config *rest.Config, clientset kubernetes.In
 	}
 
 	err = exec.StreamWithContext(ctx, remotecommand.StreamOptions{
-		Stdin:  os.Stdin,
 		Stdout: os.Stdout,
 		Stderr: os.Stderr,
-		Tty:    true,
 	})
 	if err != nil {
 		// Extract exit code from exec error if possible.


### PR DESCRIPTION
## Summary
- Register `agent-run` in the `bazel_env` tools map so it's available on `$PATH` via direnv — invoke as `agent-run "task"` instead of `bazel run //tools/agent-run -- "task"`
- Revert the TTY exec mode from #819 which suppresses output when invoked outside a real terminal (e.g. through `bazel run`)

## Test plan
- [ ] Run `direnv allow` then `agent-run "say hello"` to verify it's on PATH
- [ ] Verify output streams properly without TTY

🤖 Generated with [Claude Code](https://claude.com/claude-code)