### PR TITLE
fix(todo-mcp): correct todo-admin service URL

### DIFF
--- a/overlays/prod/mcp-servers/values.yaml
+++ b/overlays/prod/mcp-servers/values.yaml
@@ -136,7 +136,7 @@ servers:
     instrumentation.opentelemetry.io/inject-python: "python"
   env:
   - name: TODO_URL
-    value: "http://todo.todo.svc.cluster.local:8080"
+    value: "http://todo-admin.todo.svc.cluster.local:8080"
   resources:
     requests:
       cpu: 10m


### PR DESCRIPTION
## Summary
- Fix `TODO_URL` from `http://todo.todo.svc.cluster.local:8080` to `http://todo-admin.todo.svc.cluster.local:8080`
- The Kubernetes service is named `todo-admin`, not `todo`

## Test plan
- [ ] CI passes
- [ ] After merge: `get_tasks` returns current tasks via MCP

🤖 Generated with [Claude Code](https://claude.com/claude-code)