### PR TITLE
fix(goose-sandboxes): seed overlay values for image updater write-back

### DIFF
--- a/overlays/prod/goose-sandboxes/values.yaml
+++ b/overlays/prod/goose-sandboxes/values.yaml
@@ -1,2 +1,9 @@
 # goose-sandboxes — production overrides
 # Base values in charts/goose-sandboxes/values.yaml
+
+# Image config — managed by ArgoCD Image Updater (digest strategy).
+# Do not remove: the updater needs this structure to write back digest updates.
+sandboxTemplate:
+  image:
+    repository: ghcr.io/jomcgi/homelab/goose-agent
+    tag: main


### PR DESCRIPTION
## Summary
- The ArgoCD Image Updater detects the new `goose-agent:main` digest but fails to write it back because the overlay `values.yaml` was empty (comments only)
- Error: `failed to set image parameter version value: unexpected type for root`
- Seeds the file with `sandboxTemplate.image` structure so the updater can merge digest updates

## Test plan
- [ ] PR merges, ArgoCD syncs
- [ ] Image updater successfully writes digest to values.yaml on next cycle (~2 min)
- [ ] Warm pool pods roll with the new image containing Claude Code CLI

🤖 Generated with [Claude Code](https://claude.com/claude-code)