### PR TITLE
docs(skills): document image updater seeded values requirement

### DIFF
--- a/.claude/skills/add-image-updater/SKILL.md
+++ b/.claude/skills/add-image-updater/SKILL.md
@@ -281,11 +281,37 @@ After creating the ImageUpdater:
    kubectl get imageupdater -n argocd
    ```
 
+## Critical: Seed the Write-Back Target
+
+The overlay `values.yaml` **must contain a valid YAML mapping** with the image keys before the image updater can write to it. If the file is empty or contains only comments, the updater will fail with:
+
+```
+failed to set image parameter version value: unexpected type  for root
+```
+
+When creating an image updater, always ensure the overlay `values.yaml` includes the image structure that matches the `manifestTargets.helm` paths:
+
+```yaml
+# Example: for helm.name=image.repository and helm.tag=image.tag
+image:
+  repository: ghcr.io/jomcgi/homelab/charts/myapp
+  tag: main
+
+# Example: for helm.name=sandboxTemplate.image.repository
+sandboxTemplate:
+  image:
+    repository: ghcr.io/jomcgi/homelab/goose-agent
+    tag: main
+```
+
+The updater will then overwrite the `tag` value with the digest-pinned version on each update cycle.
+
 ## Troubleshooting
 
 | Issue                     | Solution                                                              |
 | ------------------------- | --------------------------------------------------------------------- |
 | Image not updating        | Check `namePattern` matches ArgoCD Application name exactly           |
 | Git write-back fails      | Verify `argocd-image-updater-token` secret exists in argocd namespace |
+| `unexpected type for root`| Overlay `values.yaml` is empty — seed it with the image key structure |
 | Wrong values file updated | Check `writeBackTarget` relative path is correct                      |
 | Digest not changing       | Ensure CI is pushing to the correct image tag (`:main`)               |

--- a/.claude/skills/add-service/SKILL.md
+++ b/.claude/skills/add-service/SKILL.md
@@ -99,11 +99,13 @@ resources:
 
 ### values.yaml Template
 
+**Important:** If you plan to add an image updater (via `/add-image-updater`), the `image` keys must be **uncommented** — not just present as comments. The image updater's git write-back fails on empty YAML files. Always seed the values with the actual image config.
+
 ```yaml
 # {Environment} values for {service}
 # Override chart defaults here
 
-# Example: Image configuration
+# Image configuration — uncomment if using /add-image-updater
 # image:
 #   repository: ghcr.io/jomcgi/homelab/services/{service}
 #   tag: main


### PR DESCRIPTION
## Summary
- Adds "Critical: Seed the Write-Back Target" section to `add-image-updater` skill with examples
- Adds `unexpected type for root` to troubleshooting table
- Adds warning to `add-service` skill's values.yaml template about uncommenting image keys when using image updater

Discovered while debugging why the goose-sandboxes image updater wasn't writing back digests — the overlay values.yaml was empty (comments only).

## Test plan
- [ ] Skills render correctly when invoked via `/add-image-updater` and `/add-service`

🤖 Generated with [Claude Code](https://claude.com/claude-code)