### PR TITLE
fix(longhorn): reduce default replica count from 3 to 1

### DIFF
--- a/overlays/cluster-critical/longhorn/values.yaml
+++ b/overlays/cluster-critical/longhorn/values.yaml
@@ -15,3 +15,6 @@ longhorn:
     # Options: "disabled", "least-effort", "best-effort"
     # "best-effort" = Active rebalancing to distribute replicas evenly
     replicaAutoBalance: "best-effort"
+
+    # Default to single replica for homelab workloads
+    defaultReplicaCount: 1


### PR DESCRIPTION
## Summary
- Sets `defaultReplicaCount: 1` in Longhorn settings to reduce disk usage across nodes
- 3-way replication is excessive for homelab workloads where data is largely reconstructable via GitOps
- node-2 was at 79% disk usage due to ~1.1 TiB of replicated storage from ~365 Gi of actual data

## Note
This only affects **new volumes**. Existing volumes will retain their current replica count. To reduce replicas on existing volumes, update them individually in the Longhorn UI or API.

## Test plan
- [ ] Verify ArgoCD syncs the Longhorn settings change
- [ ] Confirm new PVCs are created with 1 replica
- [ ] Monitor disk usage on nodes over the next few days

🤖 Generated with [Claude Code](https://claude.com/claude-code)