### PR TITLE
fix(mcp): switch Context Forge auth from CF Access to OAuth

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,16 +1,9 @@
 {
   "mcpServers": {
     "context-forge": {
-      "type": "stdio",
-      "command": "npx",
-      "args": [
-        "mcp-remote",
-        "https://mcp.jomcgi.dev/mcp/",
-        "--header",
-        "CF-Access-Client-Id: ${CF_ACCESS_CLIENT_ID}",
-        "--header",
-        "CF-Access-Client-Secret: ${CF_ACCESS_CLIENT_SECRET}"
-      ]
+      "type": "http",
+      "url": "https://mcp.jomcgi.dev/mcp/",
+      "clientId": "${MCP_OAUTH_CLIENT_ID}"
     }
   }
 }


### PR DESCRIPTION
## Summary
- Replace `mcp-remote` stdio proxy + CF Access headers with native streamable HTTP
- Use `MCP_OAUTH_CLIENT_ID` env var for OAuth client identification
- Gateway now uses JWT-based auth instead of Cloudflare Zero Trust

## Test plan
- [ ] Restart Claude Code and verify Context Forge MCP connects successfully
- [ ] Confirm MCP tools (kubernetes, argocd, buildbuddy, signoz) are functional

🤖 Generated with [Claude Code](https://claude.com/claude-code)