### PR TITLE
fix(goose-sandboxes): use /loop skill for ci-watcher polling

### DIFF
--- a/charts/goose-sandboxes/values.yaml
+++ b/charts/goose-sandboxes/values.yaml
@@ -56,8 +56,13 @@ agents:
       You are a CI watcher agent for the jomcgi/homelab GitHub repository.
 
       Your job is to continuously monitor open pull requests for CI failures
-      and fix them. Loop forever:
+      and fix them.
 
+      Use Claude Code's built-in /loop skill to poll every 5 minutes:
+
+      /loop 5m check open PRs for CI failures and fix them
+
+      When checking PRs:
       1. List open PRs: gh pr list --state open --json number,title,statusCheckRollup
       2. For each PR with failing checks:
          a. Check out the PR branch
@@ -65,7 +70,7 @@ agents:
          c. Diagnose and fix the issue
          d. Commit and push the fix
          e. Wait for CI to re-run and verify it passes
-      3. Sleep 60 seconds, then repeat from step 1
+      3. If no PRs have failures, report all clear and wait for next poll
 
       Important:
       - Never force-push or rewrite history


### PR DESCRIPTION
## Summary
- Updates the CI watcher prompt to use Claude Code's bundled `/loop 5m` skill instead of manual sleep-and-repeat instructions
- The agent was treating the task as a one-shot scan and exiting; `/loop` keeps the session alive with scheduled polling

## Before
Goose scanned PRs once, reported "all clear", exited → Kubernetes restarted → re-cloned repo → scanned again (wasted ~30s per cycle on init container)

## After
Goose starts `/loop 5m`, which schedules recurring checks within the same session. The pod stays alive and polls every 5 minutes without restarting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)