### PR TITLE
fix(mcp): use mcp-remote for OAuth with env var expansion

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,9 +1,8 @@
 {
   "mcpServers": {
     "context-forge": {
-      "type": "http",
-      "url": "https://mcp.jomcgi.dev/mcp/",
-      "clientId": "${MCP_OAUTH_CLIENT_ID}"
+      "command": "sh",
+      "args": ["-c", "npx mcp-remote https://mcp.jomcgi.dev/mcp/ $MCP_OAUTH_CALLBACK_PORT --static-oauth-client-info '{\"client_id\":\"'\"$MCP_OAUTH_CLIENT_ID\"'\"}'"]
     }
   }
 }


### PR DESCRIPTION
## Summary
- Switch Context Forge MCP config from built-in HTTP transport to `mcp-remote` stdio bridge
- Claude Code's HTTP transport doesn't expand `${ENV_VAR}` in `oauth.clientId`, so using `sh -c` with `mcp-remote` enables shell expansion of `$MCP_OAUTH_CLIENT_ID` and `$MCP_OAUTH_CALLBACK_PORT`
- Callback port is pinned via env var because `mcp-oauth-proxy` does exact redirect URI matching (doesn't follow RFC 8252 §7.3 loopback port flexibility)

## Setup
Requires two env vars (e.g. in fish config):
```fish
set -x MCP_OAUTH_CLIENT_ID <registered-client-id>
set -x MCP_OAUTH_CALLBACK_PORT 19876
```

## Test plan
- [x] Verified OAuth flow completes with `mcp-remote` and env var expansion
- [x] Confirmed pre-registered client ID bypasses dynamic registration (avoids empty `client_uri`/`jwks_uri` bug)
- [x] Pinned callback port matches registered redirect URI

🤖 Generated with [Claude Code](https://claude.com/claude-code)