### PR TITLE
fix(goose-sandboxes): use shell loop for agent polling

### DIFF
--- a/charts/goose-sandboxes/templates/deployment-agents.yaml
+++ b/charts/goose-sandboxes/templates/deployment-agents.yaml
@@ -55,7 +55,14 @@ spec:
       containers:
         - name: goose
           image: "{{ $.Values.sandboxTemplate.image.repository }}:{{ $.Values.sandboxTemplate.image.tag }}"
-          command: ["goose", "run", "--text", "$(AGENT_PROMPT)"]
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              while true; do
+                goose run --text "$AGENT_PROMPT"
+                echo "Agent exited, sleeping before restart..."
+                sleep ${AGENT_POLL_INTERVAL:-300}
+              done
           workingDir: /workspace/{{ $.Values.sandboxTemplate.env.repoName }}
           securityContext:
             runAsUser: 65532
@@ -71,6 +78,8 @@ spec:
                 configMapKeyRef:
                   name: agent-prompt-{{ $name }}
                   key: prompt
+            - name: AGENT_POLL_INTERVAL
+              value: {{ $agent.pollInterval | default 300 | quote }}
             - name: GOOSE_PROVIDER
               value: {{ $.Values.sandboxTemplate.env.gooseProvider }}
             - name: GOOSE_MODEL

--- a/charts/goose-sandboxes/values.yaml
+++ b/charts/goose-sandboxes/values.yaml
@@ -52,17 +52,12 @@ secrets:
 agents:
   ci-watcher:
     enabled: false
+    pollInterval: 300
     prompt: |
       You are a CI watcher agent for the jomcgi/homelab GitHub repository.
+      Check all open pull requests for CI failures and fix any you find.
 
-      Your job is to continuously monitor open pull requests for CI failures
-      and fix them.
-
-      Use Claude Code's built-in /loop skill to poll every 5 minutes:
-
-      /loop 5m check open PRs for CI failures and fix them
-
-      When checking PRs:
+      Steps:
       1. List open PRs: gh pr list --state open --json number,title,statusCheckRollup
       2. For each PR with failing checks:
          a. Check out the PR branch
@@ -70,7 +65,7 @@ agents:
          c. Diagnose and fix the issue
          d. Commit and push the fix
          e. Wait for CI to re-run and verify it passes
-      3. If no PRs have failures, report all clear and wait for next poll
+      3. Report results and exit. You will be re-invoked automatically.
 
       Important:
       - Never force-push or rewrite history


### PR DESCRIPTION
## Summary
- Wraps `goose run --text` in a shell `while true` loop so the container stays alive between invocations
- Adds configurable `pollInterval` (default 300s) to control sleep between agent runs
- Reverts prompt to one-shot instructions ("report results and exit") since the shell loop handles re-invocation

## Context
`goose run --text` is one-shot — Goose exits after completing the task. Previous approaches failed:
1. Telling the agent to "loop forever" — Goose treated it as a single task and exited
2. Using Claude Code's `/loop` skill — session dies when Goose exits, killing the cron

The shell-level loop is the simplest reliable solution.

## Test plan
- [ ] `helm lint charts/goose-sandboxes/ -f overlays/prod/goose-sandboxes/values.yaml` passes
- [ ] Rendered template shows `while true` loop with `sleep $AGENT_POLL_INTERVAL`
- [ ] Pod stays alive after Goose completes a scan (no restarts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)