### PR TITLE
fix(stargazer,knowledge-graph): add namespace package deps for py_venv_binary

### DIFF
--- a/services/knowledge_graph/app/BUILD
+++ b/services/knowledge_graph/app/BUILD
@@ -121,6 +121,11 @@ py_venv_binary(
     name = "scraper",
     main = "scraper_main.py",
     visibility = ["//:__subpackages__"],
+    deps = [
+        ":scraper_main",
+        "//services:services",
+        "//services/knowledge_graph",
+    ],
 )
 
 py_library(
@@ -141,6 +146,11 @@ py_venv_binary(
     name = "embedder",
     main = "embedder_main.py",
     visibility = ["//:__subpackages__"],
+    deps = [
+        ":embedder_main",
+        "//services:services",
+        "//services/knowledge_graph",
+    ],
 )
 
 py_library(
@@ -162,6 +172,11 @@ py_venv_binary(
     name = "mcp",
     main = "mcp_main.py",
     visibility = ["//:__subpackages__"],
+    deps = [
+        ":mcp_main",
+        "//services:services",
+        "//services/knowledge_graph",
+    ],
 )
 
 semgrep_test(

--- a/services/stargazer/app/BUILD
+++ b/services/stargazer/app/BUILD
@@ -9,6 +9,8 @@ py_venv_binary(
     visibility = ["//:__subpackages__"],
     deps = [
         ":app",
+        "//services:services",
+        "//services/stargazer",
         "@pip//httpx",
         "@pip//opentelemetry_api",
         "@pip//opentelemetry_exporter_otlp_proto_grpc",


### PR DESCRIPTION
## Summary
- Adds `//services:services` and `//services/{service}` namespace package deps to `py_venv_binary` targets
- Fixes `ModuleNotFoundError: No module named 'services'` at runtime in stargazer CronJob
- Also fixes the same latent bug in knowledge-graph scraper, embedder, and mcp binaries

## Root cause
`py_venv_binary` only includes files from its transitive dep closure in the runfiles tree. The parent namespace `__init__.py` files (`services/__init__.py`, `services/stargazer/__init__.py`) were not declared as deps, so they were missing from the container at runtime. The old `py_binary` rule handled this implicitly via Bazel-generated stubs.

## Test plan
- [x] `bazel build //services/stargazer/app:main //services/knowledge_graph/app:scraper //services/knowledge_graph/app:embedder //services/knowledge_graph/app:mcp` — all pass
- [ ] CI passes
- [ ] Stargazer CronJob runs successfully after image rebuild

🤖 Generated with [Claude Code](https://claude.com/claude-code)