### PR TITLE
fix(goose-agent): correct streamable_http extension type for Context Forge

### DIFF
--- a/charts/goose-agent/image/config.yaml
+++ b/charts/goose-agent/image/config.yaml
@@ -17,7 +17,7 @@ extensions:
     enabled: true
     name: context-forge
     timeout: 300
-    type: streamablehttp
+    type: streamable_http
     uri: http://context-forge.mcp-gateway.svc.cluster.local:8000/mcp
   github:
     enabled: true


### PR DESCRIPTION
## Summary

- Fix typo in goose `config.yaml`: `streamablehttp` → `streamable_http` (with underscore)
- Goose silently ignores unrecognized extension types, so the Context Forge extension never initialized
- This is why sandbox agents could use `stdio` extensions (github, developer) but not the HTTP-based Context Forge extension

## Context

The correct type name is `streamable_http` per [goose docs](https://block.github.io/goose/) and consistent with PR #844's recipe files which already use the correct type.

## Test plan

- [ ] Rebuild goose-agent image: `bazel run //charts/goose-agent/image:push`
- [ ] Run `agent-run "what mcp tools are available? search for kubernetes, argocd, signoz, buildbuddy"` and verify context-forge tools are discovered

🤖 Generated with [Claude Code](https://claude.com/claude-code)