### PR TITLE
fix(stargazer): add parent namespace imports for py_venv_binary runfiles

### DIFF
--- a/services/stargazer/BUILD
+++ b/services/stargazer/BUILD
@@ -6,6 +6,7 @@ py_library(
     name = "stargazer",
     srcs = ["__init__.py"],
     visibility = ["//:__subpackages__"],
+    deps = ["//services"],
 )
 
 # Container image for stargazer with GDAL tools

--- a/services/stargazer/__init__.py
+++ b/services/stargazer/__init__.py
@@ -1,1 +1,3 @@
 """Stargazer - Dark Sky Location Finder for Scotland."""
+
+import services  # noqa: F401

--- a/services/stargazer/app/BUILD
+++ b/services/stargazer/app/BUILD
@@ -31,6 +31,7 @@ py_library(
     ],
     visibility = ["//:__subpackages__"],
     deps = [
+        "//services/stargazer",
         "@pip//astral",
         "@pip//geopandas",
         "@pip//httpx",

--- a/services/stargazer/app/__init__.py
+++ b/services/stargazer/app/__init__.py
@@ -1,1 +1,3 @@
 """Stargazer application module."""
+
+import services.stargazer  # noqa: F401


### PR DESCRIPTION
## Summary
- Adds explicit parent package imports in `__init__.py` files so gazelle wires the namespace dep chain
- Fixes `ModuleNotFoundError: No module named 'services'` in stargazer CronJob container
- `services/stargazer/app/__init__.py` → `import services.stargazer` → gazelle adds `//services/stargazer` dep
- `services/stargazer/__init__.py` → `import services` → gazelle adds `//services` dep

## Root cause
`py_venv_binary` only includes files from its transitive dep closure in the runfiles tree. The parent `__init__.py` files (`services/__init__.py`, `services/stargazer/__init__.py`) were in separate `py_library` targets that nothing depended on, so they were missing from the container. Python needs these to resolve `from services.stargazer.app import X`.

## Test plan
- [x] `bazel test //services/stargazer/...` — 19/19 pass
- [x] `bazel build //services/stargazer:image` — builds successfully
- [x] `format` passes (gazelle doesn't strip the deps)
- [ ] CI passes
- [ ] Stargazer CronJob runs successfully after image rebuild

🤖 Generated with [Claude Code](https://claude.com/claude-code)