### PR TITLE
fix(agent-orchestrator): log sandbox execution errors

### DIFF
--- a/services/agent-orchestrator/consumer.go
+++ b/services/agent-orchestrator/consumer.go
@@ -168,6 +168,8 @@ loop:
 			job.Attempts[idx].Truncated = true
 		}
 		job.Attempts[idx].Output = output
+	} else if execErr != nil {
+		job.Attempts[idx].Output = execErr.Error()
 	}
 
 	// Check for cancellation after exec.
@@ -184,7 +186,7 @@ loop:
 	retriesRemaining := job.MaxRetries - len(job.Attempts)
 
 	if failed && retriesRemaining > 0 {
-		logger.Info("task failed, will retry", "attempt", attemptNum, "retriesRemaining", retriesRemaining)
+		logger.Info("task failed, will retry", "attempt", attemptNum, "retriesRemaining", retriesRemaining, "error", execErr)
 		// Set status back to PENDING for next attempt; store and Nak to redeliver.
 		job.Status = JobPending
 		if err := c.store.Put(jobCtx, job); err != nil {
@@ -195,7 +197,7 @@ loop:
 	}
 
 	if failed {
-		logger.Info("task failed, retries exhausted", "attempt", attemptNum)
+		logger.Info("task failed, retries exhausted", "attempt", attemptNum, "error", execErr)
 		job.Status = JobFailed
 		if err := c.store.Put(jobCtx, job); err != nil {
 			logger.Error("failed to store failed state", "error", err)


### PR DESCRIPTION
## Summary
- Include `execErr` in "task failed" log lines so sandbox failures are diagnosable
- Store the error message in `attempt.Output` when sandbox execution returns an error (no `ExecResult`)
- Discovered while testing: all jobs fail instantly because `createClaim` errors, but the error was silently swallowed

## Test plan
- [x] Unit tests pass (`bazel test //services/agent-orchestrator:agent-orchestrator_unit_test`)
- [ ] Deploy, submit a job, verify error message appears in logs and `/jobs/{id}/output`

🤖 Generated with [Claude Code](https://claude.com/claude-code)