### PR TITLE
fix(agent-orchestrator): lowercase sandbox claim names

### DIFF
--- a/services/agent-orchestrator/consumer.go
+++ b/services/agent-orchestrator/consumer.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"strings"
 	"sync"
 	"time"
 
@@ -90,7 +91,7 @@ func (c *Consumer) processJob(ctx context.Context, msg jetstream.Msg) {
 
 	// Create new attempt.
 	attemptNum := len(job.Attempts) + 1
-	claimName := fmt.Sprintf("orch-%s-%d", truncateID(job.ID, 8), attemptNum)
+	claimName := fmt.Sprintf("orch-%s-%d", strings.ToLower(truncateID(job.ID, 8)), attemptNum)
 
 	attempt := Attempt{
 		Number:           attemptNum,


### PR DESCRIPTION
## Summary
- Lowercase the ULID substring in sandbox claim names for RFC 1123 compliance
- ULIDs are uppercase by default (`01KK59DS`), producing claim names like `orch-01KK59DS-1` which Kubernetes rejects
- Root cause of all jobs failing instantly since initial deployment

## Test plan
- [x] Unit tests pass
- [ ] Deploy, submit job, verify claim is created successfully and job progresses past `createClaim`

🤖 Generated with [Claude Code](https://claude.com/claude-code)