### PR TITLE
feat(agent-orchestrator): add profile parameter to job API

### DIFF
--- a/services/agent-orchestrator/BUILD
+++ b/services/agent-orchestrator/BUILD
@@ -41,6 +41,7 @@ go_test(
     name = "agent-orchestrator_unit_test",
     srcs = [
         "api_test.go",
+        "sandbox_test.go",
         "watchdog_test.go",
     ],
     embed = [":agent-orchestrator_lib"],
@@ -50,6 +51,7 @@ go_test(
     name = "agent-orchestrator_test",
     srcs = [
         "api_test.go",
+        "sandbox_test.go",
         "store_test.go",
         "watchdog_test.go",
     ],

--- a/services/agent-orchestrator/api.go
+++ b/services/agent-orchestrator/api.go
@@ -51,6 +51,12 @@ func (a *API) handleSubmit(w http.ResponseWriter, r *http.Request) {
 		a.writeError(w, http.StatusBadRequest, "task is required")
 		return
 	}
+	if req.Profile != "" {
+		if _, ok := ValidProfiles[req.Profile]; !ok {
+			a.writeError(w, http.StatusBadRequest, "unknown profile: "+req.Profile)
+			return
+		}
+	}
 
 	maxRetries := a.defaultMaxRetries
 	if req.MaxRetries != nil {
@@ -79,6 +85,7 @@ func (a *API) handleSubmit(w http.ResponseWriter, r *http.Request) {
 	job := &JobRecord{
 		ID:         id.String(),
 		Task:       req.Task,
+		Profile:    req.Profile,
 		Status:     JobPending,
 		CreatedAt:  now,
 		UpdatedAt:  now,

--- a/services/agent-orchestrator/api_test.go
+++ b/services/agent-orchestrator/api_test.go
@@ -111,6 +111,75 @@ func TestHandleSubmit(t *testing.T) {
 	}
 }
 
+func TestHandleSubmit_WithProfile(t *testing.T) {
+	store := newMemStore()
+	_, mux := newTestAPI(store)
+
+	body := `{"task":"fix the build","profile":"ci-debug"}`
+	req := httptest.NewRequest(http.MethodPost, "/jobs", bytes.NewBufferString(body))
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("expected 202, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp SubmitResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	// Verify profile was stored on the job record.
+	job, err := store.Get(context.Background(), resp.ID)
+	if err != nil {
+		t.Fatalf("get job: %v", err)
+	}
+	if job.Profile != "ci-debug" {
+		t.Fatalf("expected profile ci-debug, got %q", job.Profile)
+	}
+}
+
+func TestHandleSubmit_NoProfile(t *testing.T) {
+	store := newMemStore()
+	_, mux := newTestAPI(store)
+
+	body := `{"task":"run tests"}`
+	req := httptest.NewRequest(http.MethodPost, "/jobs", bytes.NewBufferString(body))
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("expected 202, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp SubmitResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	// Verify empty profile preserves default behavior.
+	job, err := store.Get(context.Background(), resp.ID)
+	if err != nil {
+		t.Fatalf("get job: %v", err)
+	}
+	if job.Profile != "" {
+		t.Fatalf("expected empty profile, got %q", job.Profile)
+	}
+}
+
+func TestHandleSubmit_InvalidProfile(t *testing.T) {
+	_, mux := newTestAPI(newMemStore())
+
+	body := `{"task":"run tests","profile":"nonexistent"}`
+	req := httptest.NewRequest(http.MethodPost, "/jobs", bytes.NewBufferString(body))
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
 func TestHandleSubmit_MissingTask(t *testing.T) {
 	_, mux := newTestAPI(newMemStore())
 

--- a/services/agent-orchestrator/consumer.go
+++ b/services/agent-orchestrator/consumer.go
@@ -126,7 +126,7 @@ func (c *Consumer) processJob(ctx context.Context, msg jetstream.Msg) {
 	}
 	resultCh := make(chan sandboxResult, 1)
 	go func() {
-		r, err := c.sandbox.Run(jobCtx, claimName, task, cancelFn, outputBuf)
+		r, err := c.sandbox.Run(jobCtx, claimName, task, job.Profile, cancelFn, outputBuf)
 		resultCh <- sandboxResult{r, err}
 	}()
 

--- a/services/agent-orchestrator/model.go
+++ b/services/agent-orchestrator/model.go
@@ -13,10 +13,18 @@ const (
 	JobCancelled JobStatus = "CANCELLED"
 )
 
+// ValidProfiles maps profile names to their recipe paths inside the container.
+// An empty profile means default behavior (no recipe, all tools).
+var ValidProfiles = map[string]string{
+	"ci-debug": "/home/goose-agent/recipes/ci-debug.yaml",
+	"code-fix": "/home/goose-agent/recipes/code-fix.yaml",
+}
+
 // JobRecord is the primary data model persisted in the NATS KV store.
 type JobRecord struct {
 	ID         string    `json:"id"`
 	Task       string    `json:"task"`
+	Profile    string    `json:"profile,omitempty"`
 	Status     JobStatus `json:"status"`
 	CreatedAt  time.Time `json:"created_at"`
 	UpdatedAt  time.Time `json:"updated_at"`
@@ -45,6 +53,7 @@ type Attempt struct {
 // SubmitRequest is the JSON body for POST /jobs.
 type SubmitRequest struct {
 	Task       string `json:"task"`
+	Profile    string `json:"profile,omitempty"`
 	MaxRetries *int   `json:"max_retries,omitempty"`
 	Source     string `json:"source,omitempty"`
 }

--- a/services/agent-orchestrator/sandbox.go
+++ b/services/agent-orchestrator/sandbox.go
@@ -73,7 +73,7 @@ func NewSandboxExecutor(config *rest.Config, namespace, template string, inactiv
 // Run creates a SandboxClaim, waits for the pod, refreshes the workspace,
 // executes goose with the task, captures output, and cleans up.
 // The cancelFn is checked before each phase to support cooperative cancellation.
-func (s *SandboxExecutor) Run(ctx context.Context, claimName, task string, cancelFn func() bool, outputBuf *syncBuffer) (*ExecResult, error) {
+func (s *SandboxExecutor) Run(ctx context.Context, claimName, task, profile string, cancelFn func() bool, outputBuf *syncBuffer) (*ExecResult, error) {
 	s.logger.Info("creating sandbox claim", "claim", claimName, "namespace", s.namespace)
 
 	if err := s.createClaim(ctx, claimName); err != nil {
@@ -109,8 +109,9 @@ func (s *SandboxExecutor) Run(ctx context.Context, claimName, task string, cance
 		return nil, fmt.Errorf("cancelled before exec")
 	}
 
-	s.logger.Info("running goose task", "pod", podName)
-	exitCode, err := s.execGoose(ctx, podName, task, outputBuf)
+	s.logger.Info("running goose task", "pod", podName, "profile", profile)
+	cmd := buildGooseCommand(task, profile)
+	exitCode, err := s.execGoose(ctx, podName, cmd, outputBuf)
 	if err != nil {
 		return nil, fmt.Errorf("exec goose: %w", err)
 	}
@@ -278,8 +279,25 @@ func (w *logWriter) Write(p []byte) (int, error) {
 	return len(p), nil
 }
 
+// buildGooseCommand constructs the goose CLI arguments for the given task and profile.
+// When profile is empty, it uses the default behavior (all tools via config.yaml).
+// When profile is set, it uses the corresponding recipe with --no-profile to avoid
+// loading default extensions.
+func buildGooseCommand(task, profile string) []string {
+	if profile == "" {
+		return []string{"goose", "run", "--text", task}
+	}
+	recipePath := ValidProfiles[profile]
+	return []string{
+		"goose", "run",
+		"--recipe", recipePath,
+		"--no-profile",
+		"--params", fmt.Sprintf("task_description=%s", task),
+	}
+}
+
 // execGoose runs goose inside the sandbox pod and captures stdout+stderr.
-func (s *SandboxExecutor) execGoose(ctx context.Context, podName, task string, outputBuf *syncBuffer) (int, error) {
+func (s *SandboxExecutor) execGoose(ctx context.Context, podName string, cmd []string, outputBuf *syncBuffer) (int, error) {
 	req := s.clientset.CoreV1().RESTClient().Post().
 		Resource("pods").
 		Name(podName).
@@ -287,7 +305,7 @@ func (s *SandboxExecutor) execGoose(ctx context.Context, podName, task string, o
 		SubResource("exec").
 		VersionedParams(&corev1.PodExecOptions{
 			Container: "goose",
-			Command:   []string{"goose", "run", "--text", task},
+			Command:   cmd,
 			Stdout:    true,
 			Stderr:    true,
 		}, scheme.ParameterCodec)

--- a/services/agent-orchestrator/sandbox_test.go
+++ b/services/agent-orchestrator/sandbox_test.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestBuildGooseCommand_NoProfile(t *testing.T) {
+	cmd := buildGooseCommand("fix the tests", "")
+	expected := []string{"goose", "run", "--text", "fix the tests"}
+	if !reflect.DeepEqual(cmd, expected) {
+		t.Fatalf("expected %v, got %v", expected, cmd)
+	}
+}
+
+func TestBuildGooseCommand_WithProfile(t *testing.T) {
+	cmd := buildGooseCommand("fix the build", "ci-debug")
+	expected := []string{
+		"goose", "run",
+		"--recipe", "/home/goose-agent/recipes/ci-debug.yaml",
+		"--no-profile",
+		"--params", "task_description=fix the build",
+	}
+	if !reflect.DeepEqual(cmd, expected) {
+		t.Fatalf("expected %v, got %v", expected, cmd)
+	}
+}
+
+func TestBuildGooseCommand_CodeFixProfile(t *testing.T) {
+	cmd := buildGooseCommand("refactor auth", "code-fix")
+	expected := []string{
+		"goose", "run",
+		"--recipe", "/home/goose-agent/recipes/code-fix.yaml",
+		"--no-profile",
+		"--params", "task_description=refactor auth",
+	}
+	if !reflect.DeepEqual(cmd, expected) {
+		t.Fatalf("expected %v, got %v", expected, cmd)
+	}
+}


### PR DESCRIPTION
## Summary
- Add optional `profile` field to `POST /jobs` request body for selecting Goose recipes (ci-debug, code-fix)
- Profile validation rejects unknown profiles with 400 Bad Request
- Empty/omitted profile preserves current default behavior (all MCP tools)
- `buildGooseCommand()` helper constructs recipe-based or default goose CLI args
- Follows up on #844 which added MCP profiles with scoped JWT tokens and Goose recipes

## Test plan
- [x] `TestHandleSubmit_WithProfile` — valid profile stored on job record
- [x] `TestHandleSubmit_NoProfile` — empty profile preserves default
- [x] `TestHandleSubmit_InvalidProfile` — unknown profile returns 400
- [x] `TestBuildGooseCommand_NoProfile` — default `goose run --text` command
- [x] `TestBuildGooseCommand_WithProfile` — recipe-based command with `--no-profile`
- [x] `TestBuildGooseCommand_CodeFixProfile` — code-fix recipe path
- [x] All existing tests continue to pass (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)