### PR TITLE
fix: use :main tag for tools image and add update check

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -3,8 +3,19 @@
 export ORION_EXTENSIONS_DIR=$PWD/.aspect/gazelle/
 
 # Developer tools from OCI image (see bootstrap.sh)
-TOOLS_DIR="$PWD/.tools/bin"
-if [[ ! -d "$TOOLS_DIR" ]]; then
-  log_error "ERROR: Run './bootstrap.sh' to install dev tools"
+TOOLS_DIR="$PWD/.tools"
+if [[ ! -d "$TOOLS_DIR/bin" ]]; then
+  log_error "Run './bootstrap.sh' to install dev tools"
+else
+  PATH_add "$TOOLS_DIR/bin"
+  # Check for updates in the background (non-blocking)
+  if command -v crane &>/dev/null && [[ -f "$TOOLS_DIR/.digest" ]]; then
+    (
+      remote=$(crane digest ghcr.io/jomcgi/homelab-tools:main 2>/dev/null || true)
+      local_digest=$(cat "$TOOLS_DIR/.digest")
+      if [[ -n "$remote" ]] && [[ "$remote" != "$local_digest" ]]; then
+        log_status "Dev tools update available — run './bootstrap.sh'"
+      fi
+    ) &
+  fi
 fi
-PATH_add "$TOOLS_DIR"

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -20,12 +20,26 @@ if ! command -v crane &>/dev/null; then
 fi
 
 # Pull tools from OCI image
-TOOLS_IMAGE="ghcr.io/jomcgi/homelab-tools:latest"
+TOOLS_IMAGE="ghcr.io/jomcgi/homelab-tools:main"
 TOOLS_DIR="$PWD/.tools"
 
+# Check remote digest
+REMOTE_DIGEST=$(crane digest "$TOOLS_IMAGE" 2>/dev/null) || {
+	echo "ERROR: Failed to fetch digest for $TOOLS_IMAGE"
+	echo "Check that the image exists and you have access to ghcr.io"
+	exit 1
+}
+
+# Skip if already up to date
+if [[ -f "$TOOLS_DIR/.digest" ]] && [[ "$(cat "$TOOLS_DIR/.digest")" == "$REMOTE_DIGEST" ]]; then
+	echo "Tools already up to date ($REMOTE_DIGEST)"
+	exit 0
+fi
+
 echo "Pulling developer tools from $TOOLS_IMAGE..."
+rm -rf "$TOOLS_DIR"
 mkdir -p "$TOOLS_DIR/bin"
 crane export "$TOOLS_IMAGE" - | tar -xf - -C "$TOOLS_DIR" --strip-components=1 tools/
-touch "$TOOLS_DIR/.pulled"
+echo "$REMOTE_DIGEST" >"$TOOLS_DIR/.digest"
 
 echo "Done. Run 'direnv allow' to add tools to your PATH."


### PR DESCRIPTION
## Summary
- Fix `bootstrap.sh` to use `:main` tag instead of `:latest` (which doesn't exist — images are tagged with branch names via workspace stamping)
- Add digest-based version tracking so `bootstrap.sh` skips re-pulling when already up to date
- Add background update check in `.envrc` that notifies when a newer image is available

## Test plan
- [ ] Run `./bootstrap.sh` — should pull the tools image successfully
- [ ] Run `./bootstrap.sh` again — should print "Tools already up to date"
- [ ] Open a new shell — direnv should add tools to PATH and check for updates in background

🤖 Generated with [Claude Code](https://claude.com/claude-code)