### PR TITLE
fix: remove redundant local MCP server config

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,8 +1,0 @@
-{
-  "mcpServers": {
-    "context-forge": {
-      "command": "sh",
-      "args": ["-c", "npx mcp-remote https://mcp.jomcgi.dev/mcp/ $MCP_OAUTH_CALLBACK_PORT --static-oauth-client-info '{\"client_id\":\"'\"$MCP_OAUTH_CLIENT_ID\"'\"}'"]
-    }
-  }
-}


### PR DESCRIPTION
## Summary
- Removes `.mcp.json` which configured a local `context-forge` MCP server via `mcp-remote`
- This server was redundant with the Claude.ai remote MCP connection (`claude_ai_Homelab`) and was failing due to environment variable inheritance issues in the spawned `sh` subprocess
- The remote MCP connection is more reliable as it handles OAuth at the platform level

## Test plan
- [x] Verified MCP tools still work via Claude.ai remote connection
- [x] Verified tool discovery via `ToolSearch` returns correct tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)