### PR TITLE
fix(mcp-servers): always render pod template annotations to prevent ArgoCD diff

### DIFF
--- a/charts/mcp-servers/templates/deployment.yaml
+++ b/charts/mcp-servers/templates/deployment.yaml
@@ -13,9 +13,11 @@ spec:
       {{- include "mcp-servers.selectorLabels" (dict "server" . "Release" $.Release) | nindent 6 }}
   template:
     metadata:
-      {{- with .podAnnotations }}
+      {{- if .podAnnotations }}
       annotations:
-        {{- toYaml . | nindent 8 }}
+        {{- toYaml .podAnnotations | nindent 8 }}
+      {{- else }}
+      annotations: {}
       {{- end }}
       labels:
         {{- include "mcp-servers.selectorLabels" (dict "server" . "Release" $.Release) | nindent 8 }}


### PR DESCRIPTION
## Summary
- Fixes persistent OutOfSync diff on `kubernetes-mcp` (and `argocd-mcp`) Deployments
- The Helm template conditionally omitted `annotations` when `podAnnotations` was unset, but Kubernetes normalizes pod templates to `annotations: {}` — causing ArgoCD to always see a diff
- Now always renders `annotations: {}` for servers without `podAnnotations`

## Test plan
- [x] `helm template` renders `annotations: {}` for servers without podAnnotations
- [x] `helm template` still renders annotations correctly for servers with podAnnotations
- [x] `bazel test //charts/mcp-servers/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)