### PR TITLE
fix: auto-symlink .tools in worktrees

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -3,7 +3,14 @@
 export ORION_EXTENSIONS_DIR=$PWD/.aspect/gazelle/
 
 # Developer tools from OCI image (see bootstrap.sh)
+# In worktrees, symlink .tools from the main worktree
 TOOLS_DIR="$PWD/.tools"
+if [[ ! -d "$TOOLS_DIR" ]]; then
+  MAIN_WORKTREE=$(git worktree list --porcelain 2>/dev/null | head -1 | sed 's/^worktree //')
+  if [[ -n "$MAIN_WORKTREE" ]] && [[ -d "$MAIN_WORKTREE/.tools" ]]; then
+    ln -s "$MAIN_WORKTREE/.tools" "$TOOLS_DIR"
+  fi
+fi
 if [[ ! -d "$TOOLS_DIR/bin" ]]; then
   log_error "Run './bootstrap.sh' to install dev tools"
 else

--- a/tools/format/fast-format.sh
+++ b/tools/format/fast-format.sh
@@ -5,6 +5,11 @@ set -euo pipefail
 
 cd "${BUILD_WORKSPACE_DIRECTORY:-$(git rev-parse --show-toplevel)}"
 
+# Ensure .tools/bin is on PATH (pre-commit doesn't run through direnv)
+if [[ -d "$PWD/.tools/bin" ]]; then
+	export PATH="$PWD/.tools/bin:$PATH"
+fi
+
 # Colors for output
 GREEN='\033[0;32m'
 RED='\033[0;31m'
@@ -24,6 +29,7 @@ done
 if [ ${#MISSING[@]} -gt 0 ]; then
 	err "Missing tools: ${MISSING[*]}"
 	err "Run './bootstrap.sh' to install dev tools"
+	err "In a worktree? Run 'direnv allow' to symlink tools from the main repo"
 	exit 1
 fi
 


### PR DESCRIPTION
## Summary
- `.envrc` now auto-creates a `.tools` symlink pointing to the main worktree when running in a git worktree, so `direnv allow` is all that's needed to get vendored tools working
- `fast-format.sh` adds `.tools/bin` to PATH directly so pre-commit hooks work without direnv
- Improved error message when tools are missing — directs worktree users to run `direnv allow`

## Test plan
- [ ] Create a new worktree, run `direnv allow`, verify `.tools` symlink is created
- [ ] Commit in the worktree — pre-commit format hook should find tools via PATH
- [ ] Verify main repo `.envrc` is unaffected (`.tools/` already exists, symlink logic skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)