### PR TITLE
chore(goose-sandboxes): remove ci-watcher agent

### DIFF
--- a/charts/goose-sandboxes/values.yaml
+++ b/charts/goose-sandboxes/values.yaml
@@ -52,26 +52,4 @@ secrets:
 
 # Long-lived agents — each entry generates a ConfigMap + Deployment.
 # Prompt changes trigger pod restart via checksum annotation.
-agents:
-  ci-watcher:
-    enabled: false
-    pollInterval: 300
-    prompt: |
-      You are a CI watcher agent for the jomcgi/homelab GitHub repository.
-      Check all open pull requests for CI failures and fix any you find.
-
-      Steps:
-      1. List open PRs: gh pr list --state open --json number,title,statusCheckRollup
-      2. For each PR with failing checks:
-         a. Check out the PR branch
-         b. Read the CI failure logs (use BuildBuddy MCP tools)
-         c. Diagnose and fix the issue
-         d. Commit and push the fix
-         e. Wait for CI to re-run and verify it passes
-      3. Report results and exit. You will be re-invoked automatically.
-
-      Important:
-      - Never force-push or rewrite history
-      - Create fixup commits, not amends
-      - If you can't fix a failure after 2 attempts, skip it and move on
-      - Use conventional commit messages: fix(scope): description
+agents: {}

--- a/overlays/prod/goose-sandboxes/values.yaml
+++ b/overlays/prod/goose-sandboxes/values.yaml
@@ -7,6 +7,3 @@ sandboxTemplate:
   image:
     repository: ghcr.io/jomcgi/homelab/goose-agent
     tag: main@sha256:158164f90b66d08bacdb26c58ca06e83f8f75cc1cc171eb9a14e93aecea8816f
-agents:
-  ci-watcher:
-    enabled: true


### PR DESCRIPTION
## Summary
- Remove the `ci-watcher` long-lived agent definition from goose-sandboxes chart defaults and prod overlay
- CI watching functionality will be replaced by ephemeral agents triggered through the orchestrator with Goose profiles, providing better visibility and lower resource usage
- Agent templates (`deployment-agents.yaml`, `configmap-agents.yaml`) are kept for future use

## Test plan
- [ ] CI passes (helm template renders cleanly with `agents: {}`)
- [ ] ArgoCD syncs goose-sandboxes — `agent-ci-watcher` Deployment and `agent-prompt-ci-watcher` ConfigMap are removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)