### PR TITLE
fix(tools): extract full OCI image instead of symlink layer

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -11,10 +11,10 @@ if [[ ! -d "$TOOLS_DIR" ]]; then
     ln -s "$MAIN_WORKTREE/.tools" "$TOOLS_DIR"
   fi
 fi
-if [[ ! -d "$TOOLS_DIR/bin" ]]; then
+if [[ ! -d "$TOOLS_DIR/usr/bin" ]]; then
   log_error "Run './bootstrap.sh' to install dev tools"
 else
-  PATH_add "$TOOLS_DIR/bin"
+  PATH_add "$TOOLS_DIR/usr/bin"
   # Check for updates in the background (non-blocking)
   if command -v crane &>/dev/null && [[ -f "$TOOLS_DIR/.digest" ]]; then
     (

--- a/architecture/decisions/tooling/001-oci-tool-distribution.md
+++ b/architecture/decisions/tooling/001-oci-tool-distribution.md
@@ -41,12 +41,12 @@ Eliminate local Bazel entirely. Distribute developer tools as a multi-arch OCI i
 
 ### OCI Tools Image
 
-A single multi-arch (x86_64 + aarch64) OCI image containing all developer tools:
+A single multi-arch (x86_64 + aarch64) OCI image containing all developer tools. Wolfi packages install to standard paths (`/usr/bin/`, `/usr/lib/`), and the full image filesystem is extracted locally — no symlink indirection layer.
 
 ```
 ghcr.io/jomcgi/homelab-tools:latest
 
-/tools/bin/
+/usr/bin/
 ├── helm              # Helm CLI (from multitool)
 ├── crane             # OCI image tool (from multitool)
 ├── kind              # Local K8s clusters (from multitool)
@@ -57,7 +57,8 @@ ghcr.io/jomcgi/homelab-tools:latest
 ├── go                # Go toolchain
 ├── node              # Node.js runtime
 ├── pnpm              # Node package manager
-├── python            # Python runtime
+├── python3           # Python runtime (+ stdlib in /usr/lib/python3.x/)
+├── prettier          # Code formatter (symlink → /usr/local/lib/node_modules/prettier/)
 ├── bb                # BuildBuddy CLI (for remote query/execution)
 ├── scaffold          # Scaffold code generator
 ├── copier            # Project templating
@@ -65,6 +66,8 @@ ghcr.io/jomcgi/homelab-tools:latest
 ```
 
 Built via apko (consistent with all other images in the repo), pushed to GHCR on every merge to main.
+
+**Why full extraction instead of a symlink layer:** Earlier designs created a `/tools/bin/` directory with symlinks to `/usr/bin/` and extracted only that subtree. This broke on macOS — the symlinks resolved to the host's `/usr/bin/` (e.g., Xcode shims) instead of the image's binaries. Extracting the full filesystem avoids this entirely. Tools like Python also depend on their stdlib (`/usr/lib/python3.x/`), which only works when the full image is present.
 
 Claude Code is included as a first-class tool — it's installed via `pnpm add -g @anthropic-ai/claude-code` during the image build. This gives:
 - **Pinned versions** across local dev, CI, and in-cluster agents
@@ -78,20 +81,21 @@ Local development is macOS-only, so the bootstrap assumes `crane` is available (
 Local `.envrc` replaces the `bazel_env` integration:
 
 ```bash
-TOOLS_IMAGE="ghcr.io/jomcgi/homelab-tools:latest"
 TOOLS_DIR="$PWD/.tools"
-
-# Pull tools if missing or stale (>24h)
-if [[ ! -d "$TOOLS_DIR/bin" || ! -f "$TOOLS_DIR/.pulled" || $(find "$TOOLS_DIR/.pulled" -mtime +1 -print -quit 2>/dev/null) ]]; then
-  echo "Pulling developer tools from $TOOLS_IMAGE..."
-  mkdir -p "$TOOLS_DIR"
-  crane export "$TOOLS_IMAGE" - | tar -xf - -C "$TOOLS_DIR" tools/
-  mv "$TOOLS_DIR/tools/"* "$TOOLS_DIR/bin/" 2>/dev/null || true
-  touch "$TOOLS_DIR/.pulled"
+if [[ ! -d "$TOOLS_DIR/usr/bin" ]]; then
+  log_error "Run './bootstrap.sh' to install dev tools"
+else
+  PATH_add "$TOOLS_DIR/usr/bin"
 fi
-
-PATH_add "$TOOLS_DIR/bin"
 ```
+
+`bootstrap.sh` extracts the full image filesystem into `.tools/`:
+
+```bash
+crane export "$TOOLS_IMAGE" - | tar -xf - -C "$TOOLS_DIR"
+```
+
+No `--strip-components`, no path filtering. The image's `/usr/bin/go` becomes `.tools/usr/bin/go`, and the full dependency tree (stdlib, shared libs) is preserved at relative paths.
 
 The `.tools/` directory is gitignored. Tools are refreshed daily or on demand.
 
@@ -180,18 +184,18 @@ The OCI tools image is an opportunity to close gaps in the current `bazel_env` s
 
 ### Phase 1: OCI Tools Image
 
-- [ ] Create `tools/image/apko.yaml` with all tools currently in `bazel_env` plus missing tools (`gh`, `ruff`, `shellcheck`, `eslint`)
+- [x] Create `tools/image/apko.yaml` with all tools currently in `bazel_env` plus missing tools (`gh`, `ruff`, `shellcheck`, `eslint`)
 - [ ] Include custom Go binaries (`agent-run`, `hf2oci`) — built in CI, copied into image
-- [ ] Create `tools/image/BUILD` with apko build + push rules
+- [x] Create `tools/image/BUILD` with apko build + push rules (no symlink layer — full image extraction)
 - [ ] Add `homelab-tools` image push to `buildbuddy.yaml` CI pipeline (push on main)
 - [ ] Add ArgoCD Image Updater config for automatic digest updates
 - [ ] Verify multi-arch (x86_64 + aarch64) build works
 
 ### Phase 2: Local Bootstrap
 
-- [ ] Update `.envrc` to pull tools via `crane export` instead of `bazel_env`
+- [x] Update `.envrc` to PATH_add `.tools/usr/bin` (full image extraction, no symlink indirection)
 - [ ] Add `.tools/` to `.gitignore`
-- [ ] Create `bootstrap.sh` — macOS-only script that installs `crane` via Homebrew and pulls tools image
+- [x] Create `bootstrap.sh` — extracts full image filesystem via `crane export` (no path filtering)
 - [ ] Update `README.bazel.md` to reflect new workflow
 - [ ] Remove `bazel_env` rule from `tools/BUILD` (or deprecate)
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -38,8 +38,8 @@ fi
 
 echo "Pulling developer tools from $TOOLS_IMAGE..."
 rm -rf "$TOOLS_DIR"
-mkdir -p "$TOOLS_DIR/bin"
-crane export "$TOOLS_IMAGE" - | tar -xf - -C "$TOOLS_DIR" --strip-components=1 tools/
+mkdir -p "$TOOLS_DIR"
+crane export "$TOOLS_IMAGE" - | tar -xf - -C "$TOOLS_DIR"
 echo "$REMOTE_DIGEST" >"$TOOLS_DIR/.digest"
 
 echo "Done. Run 'direnv allow' to add tools to your PATH."

--- a/charts/goose-agent/image/apko.lock.json
+++ b/charts/goose-agent/image/apko.lock.json
@@ -256,22 +256,22 @@
       },
       {
         "name": "libacl1",
-        "url": "https://packages.wolfi.dev/os/x86_64/libacl1-2.3.2-r54.apk",
-        "version": "2.3.2-r54",
+        "url": "https://packages.wolfi.dev/os/x86_64/libacl1-2.3.2-r55.apk",
+        "version": "2.3.2-r55",
         "architecture": "x86_64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-6706",
-          "checksum": "sha1-/JQZFaXMysggjQNmeOUav7xEqg4="
+          "range": "bytes=0-7702",
+          "checksum": "sha1-yPga0Q7H2gxy18ZuQTovdIHWQvY="
         },
         "data": {
-          "range": "bytes=6707-27429",
-          "checksum": "sha256-rOp5f+h5E6s7DdUX6BeqG0YfawO1QKF2UTSWeAAmyHw="
+          "range": "bytes=7703-28751",
+          "checksum": "sha256-0/eSvAC2Htvs+FehVF8Wx4+mwO3cLJM3nJly2lJgEPg="
         },
-        "checksum": "Q1/JQZFaXMysggjQNmeOUav7xEqg4="
+        "checksum": "Q1yPga0Q7H2gxy18ZuQTovdIHWQvY="
       },
       {
         "name": "libattr1",
@@ -1700,22 +1700,22 @@
       },
       {
         "name": "libacl1",
-        "url": "https://packages.wolfi.dev/os/aarch64/libacl1-2.3.2-r54.apk",
-        "version": "2.3.2-r54",
+        "url": "https://packages.wolfi.dev/os/aarch64/libacl1-2.3.2-r55.apk",
+        "version": "2.3.2-r55",
         "architecture": "aarch64",
         "signature": {
           "range": "",
           "checksum": ""
         },
         "control": {
-          "range": "bytes=0-6757",
-          "checksum": "sha1-qmnLb5wi6lZi+6bgdN4YLtZD41w="
+          "range": "bytes=0-7755",
+          "checksum": "sha1-QuETN12TZyAYavvqfsBmZl9q4Bc="
         },
         "data": {
-          "range": "bytes=6758-28022",
-          "checksum": "sha256-l2VOV2JuxzxSMiV2ap5AHLMMzyTE4NT16gNF8W8UY1I="
+          "range": "bytes=7756-29382",
+          "checksum": "sha256-M4NWjimRiTyV0ZRBtBu7mgAQ6US97kwJjfeRVCFo27A="
         },
-        "checksum": "Q1qmnLb5wi6lZi+6bgdN4YLtZD41w="
+        "checksum": "Q1QuETN12TZyAYavvqfsBmZl9q4Bc="
       },
       {
         "name": "libattr1",

--- a/tools/image/BUILD
+++ b/tools/image/BUILD
@@ -1,28 +1,8 @@
-load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 load("//tools/oci:apko_image.bzl", "apko_image")
-
-# Symlinks from /tools/bin/ to actual binary locations.
-# bootstrap.sh extracts /tools/bin/* from the image into .tools/bin/
-pkg_tar(
-    name = "tools_bin_symlinks",
-    symlinks = {
-        # Formatters (Wolfi packages install to /usr/bin/)
-        "/tools/bin/ruff": "/usr/bin/ruff",
-        "/tools/bin/shfmt": "/usr/bin/shfmt",
-        "/tools/bin/gofumpt": "/usr/bin/gofumpt",
-        # Developer tools
-        "/tools/bin/go": "/usr/bin/go",
-        "/tools/bin/node": "/usr/bin/node",
-        "/tools/bin/pnpm": "/usr/bin/pnpm",
-        "/tools/bin/python": "/usr/bin/python3",
-        "/tools/bin/git": "/usr/bin/git",
-        "/tools/bin/gh": "/usr/bin/gh",
-    },
-)
 
 # Package prettier from the pnpm lockfile-managed npm package.
 # Places the package at /usr/local/lib/node_modules/prettier/
-# with a symlink at /tools/bin/prettier for PATH discovery.
+# with a symlink at /usr/bin/prettier for PATH discovery.
 genrule(
     name = "prettier_tar",
     srcs = ["//:node_modules/prettier"],
@@ -35,8 +15,8 @@ genrule(
         SRC_DIR=$$(echo '$(locations //:node_modules/prettier)' | tr ' ' '\\n' | grep 'prettier$$' | head -1)
         cp -rL "$$SRC_DIR/." "$$DEST/"
         chmod 755 "$$DEST/bin/prettier.cjs"
-        mkdir -p "$$WORK/tools/bin"
-        ln -s "../../usr/local/lib/node_modules/prettier/bin/prettier.cjs" "$$WORK/tools/bin/prettier"
+        mkdir -p "$$WORK/usr/bin"
+        ln -s "../local/lib/node_modules/prettier/bin/prettier.cjs" "$$WORK/usr/bin/prettier"
         tar -cf $@ -C "$$WORK" .
         rm -rf "$$WORK"
     """,
@@ -48,7 +28,6 @@ apko_image(
     contents = "@homelab_tools_lock//:contents",
     repository = "ghcr.io/jomcgi/homelab-tools",
     tars = [
-        ":tools_bin_symlinks",
         ":prettier_tar",
     ],
 )

--- a/tools/image/apko.lock.json
+++ b/tools/image/apko.lock.json
@@ -1,8 +1,8 @@
 {
   "version": "v1",
   "config": {
-    "name": "tools/image/apko.yaml",
-    "checksum": "sha256-XUu5DZlTLT2Qlh9i9xpbHrqO1mJKjaJO7K9Yp27t37c="
+    "name": "./tools/image/apko.yaml",
+    "checksum": "sha256-3xjzBtnCBsLTQwBNTP+SQeswWxyCtqfS/2orSU+X6qs="
   },
   "contents": {
     "keyring": [

--- a/tools/image/apko.yaml
+++ b/tools/image/apko.yaml
@@ -31,10 +31,3 @@ accounts:
       uid: 65532
       gid: 65532
   run-as: 65532
-
-paths:
-  - path: /tools/bin
-    type: directory
-    uid: 0
-    gid: 0
-    permissions: 0o755


### PR DESCRIPTION
## Summary

- Remove the `tools_bin_symlinks` pkg_tar that created broken symlinks from `/tools/bin/` → `/usr/bin/` (resolved to macOS host paths when extracted)
- Extract full image filesystem via `crane export` instead of just the `/tools/` subtree — gives working binaries with their full dependency trees (Python stdlib, shared libs)
- PATH to `.tools/usr/bin/` directly, eliminating the symlink indirection layer
- Move prettier symlink from `/tools/bin/prettier` to `/usr/bin/prettier`

## Context

`.tools/bin/python` was a symlink to `/usr/bin/python3`, which on macOS resolves to the Xcode shim rather than the image's Python. The same issue affected all tools — go, node, ruff, etc. were all broken symlinks pointing into the host filesystem.

## Test plan

- [ ] CI passes (BuildBuddy builds the image successfully)
- [ ] Run `./bootstrap.sh` after image is published — verify `.tools/usr/bin/python3` works
- [ ] Verify `direnv allow` picks up tools via `.tools/usr/bin/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)