### PR TITLE
fix(image-updater): split knowledge-graph into per-image updaters

### DIFF
--- a/overlays/prod/knowledge-graph/imageupdater.yaml
+++ b/overlays/prod/knowledge-graph/imageupdater.yaml
@@ -1,7 +1,7 @@
 apiVersion: argocd-image-updater.argoproj.io/v1alpha1
 kind: ImageUpdater
 metadata:
-  name: knowledge-graph
+  name: knowledge-graph-scraper
   namespace: argocd
 spec:
   applicationRefs:
@@ -15,6 +15,23 @@ spec:
             helm:
               name: scraper.image.repository
               tag: scraper.image.tag
+      namePattern: prod-knowledge-graph
+  namespace: argocd
+  writeBackConfig:
+    method: git:secret:argocd/argocd-image-updater-token
+    gitConfig:
+      repository: https://github.com/jomcgi/homelab.git
+      branch: main
+      writeBackTarget: helmvalues:../../overlays/prod/knowledge-graph/values.yaml
+---
+apiVersion: argocd-image-updater.argoproj.io/v1alpha1
+kind: ImageUpdater
+metadata:
+  name: knowledge-graph-embedder
+  namespace: argocd
+spec:
+  applicationRefs:
+    - images:
         - alias: embedder
           commonUpdateSettings:
             updateStrategy: digest
@@ -24,6 +41,23 @@ spec:
             helm:
               name: embedder.image.repository
               tag: embedder.image.tag
+      namePattern: prod-knowledge-graph
+  namespace: argocd
+  writeBackConfig:
+    method: git:secret:argocd/argocd-image-updater-token
+    gitConfig:
+      repository: https://github.com/jomcgi/homelab.git
+      branch: main
+      writeBackTarget: helmvalues:../../overlays/prod/knowledge-graph/values.yaml
+---
+apiVersion: argocd-image-updater.argoproj.io/v1alpha1
+kind: ImageUpdater
+metadata:
+  name: knowledge-graph-mcp
+  namespace: argocd
+spec:
+  applicationRefs:
+    - images:
         - alias: mcp
           commonUpdateSettings:
             updateStrategy: digest


### PR DESCRIPTION
## Summary
- Split the knowledge-graph `ImageUpdater` from a single 3-image resource into 3 separate single-image resources (scraper, embedder, mcp)
- Fixes a tag flip-flop bug where the multi-image updater rewrote unchanged images' tag prefixes from `main` to `latest` on each cycle, creating noisy no-op commits

## Context
The ArgoCD Image Updater's digest strategy has a bug when handling multiple images in a single `ImageUpdater` resource: when only one image gets a new digest, unchanged images have their tag prefix incorrectly rewritten to `latest`. This matches the single-image pattern used by all other services (todo, agent-orchestrator, litellm, etc.).

## Test plan
- [x] `bazel test //overlays/prod/knowledge-graph/...` passes (template + semgrep)
- [ ] CI passes
- [ ] After merge, verify no more `main` ↔ `latest` flip-flop commits from image updater

🤖 Generated with [Claude Code](https://claude.com/claude-code)