### PR TITLE
fix: move dev tools to user cache dir

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -3,14 +3,8 @@
 export ORION_EXTENSIONS_DIR=$PWD/.aspect/gazelle/
 
 # Developer tools from OCI image (see bootstrap.sh)
-# In worktrees, symlink .tools from the main worktree
-TOOLS_DIR="$PWD/.tools"
-if [[ ! -d "$TOOLS_DIR" ]]; then
-  MAIN_WORKTREE=$(git worktree list --porcelain 2>/dev/null | head -1 | sed 's/^worktree //')
-  if [[ -n "$MAIN_WORKTREE" ]] && [[ -d "$MAIN_WORKTREE/.tools" ]]; then
-    ln -s "$MAIN_WORKTREE/.tools" "$TOOLS_DIR"
-  fi
-fi
+# Stored in user cache — shared across worktrees, no sudo needed
+TOOLS_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/homelab-tools"
 if [[ ! -d "$TOOLS_DIR/usr/bin" ]]; then
   log_error "Run './bootstrap.sh' to install dev tools"
 else

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -21,7 +21,7 @@ fi
 
 # Pull tools from OCI image
 TOOLS_IMAGE="ghcr.io/jomcgi/homelab-tools:main"
-TOOLS_DIR="$PWD/.tools"
+TOOLS_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/homelab-tools"
 
 # Check remote digest
 REMOTE_DIGEST=$(crane digest "$TOOLS_IMAGE" 2>/dev/null) || {
@@ -39,7 +39,7 @@ fi
 echo "Pulling developer tools from $TOOLS_IMAGE..."
 rm -rf "$TOOLS_DIR"
 mkdir -p "$TOOLS_DIR"
-crane export "$TOOLS_IMAGE" - | tar -xf - -C "$TOOLS_DIR"
+crane export "$TOOLS_IMAGE" - | tar --no-same-owner -xf - -C "$TOOLS_DIR"
 echo "$REMOTE_DIGEST" >"$TOOLS_DIR/.digest"
 
 echo "Done. Run 'direnv allow' to add tools to your PATH."


### PR DESCRIPTION
## Summary
- Moves bootstrapped tools from `$PWD/.tools` to `~/.cache/homelab-tools` (XDG-compliant user cache)
- Eliminates the sudo escalation cycle where root-owned `.tools/` forced `sudo ./bootstrap.sh` forever
- Adds `--no-same-owner` to tar extraction to prevent container uid/gid leaking into local files
- Removes worktree symlink hack — all worktrees now share the same cache path automatically

## Test plan
- [ ] `sudo rm -rf .tools` to clean up old root-owned dir
- [ ] Run `./bootstrap.sh` — tools should land in `~/.cache/homelab-tools/`
- [ ] `direnv allow` — tools should appear on PATH
- [ ] Verify in a worktree: `git worktree add /tmp/test origin/main && cd /tmp/test && direnv allow && which format`

🤖 Generated with [Claude Code](https://claude.com/claude-code)