### PR TITLE
fix(ci): only skip test-and-push for image-updater commits

### DIFF
--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -97,9 +97,9 @@ actions:
         merge_with_base: false
     steps:
       - run: |
-          # Skip automated commits
+          # Skip image-updater commits (digest-only bumps, no code to test)
           AUTHOR="$(git log -1 --format='%an')"
-          if [ "$AUTHOR" = "argocd-image-updater" ] || [ "$AUTHOR" = "ci-format-bot" ]; then
+          if [ "$AUTHOR" = "argocd-image-updater" ]; then
             echo "Skipping automated commit from $AUTHOR"
             exit 0
           fi
@@ -108,7 +108,7 @@ actions:
       # Push images on main branch only
       - run: |
           AUTHOR="$(git log -1 --format='%an')"
-          if [ "$AUTHOR" = "argocd-image-updater" ] || [ "$AUTHOR" = "ci-format-bot" ]; then
+          if [ "$AUTHOR" = "argocd-image-updater" ]; then
             exit 0
           fi
 
@@ -126,7 +126,7 @@ actions:
       # CLOUDFLARE_API_TOKEN and CLOUDFLARE_ACCOUNT_ID set in BuildBuddy Settings → Secrets
       - run: |
           AUTHOR="$(git log -1 --format='%an')"
-          if [ "$AUTHOR" = "argocd-image-updater" ] || [ "$AUTHOR" = "ci-format-bot" ]; then
+          if [ "$AUTHOR" = "argocd-image-updater" ]; then
             exit 0
           fi
 


### PR DESCRIPTION
## Summary
- Remove `ci-format-bot` from the skip list in all three "Test and push" steps
- Only `argocd-image-updater` commits are skipped (digest-only bumps with nothing to test/push)
- Format bot commits contain real code changes that need testing and image pushing

## Root cause
The agent-orchestrator-mcp image was never pushed to GHCR because the last commit on the PR was a `style: auto-format` from ci-format-bot. When that landed on main via rebase merge, CI skipped the entire "Test and push" action — including the image push step.

## Test plan
- [ ] CI passes on this PR (format check + tests)
- [ ] After merge, verify the next ci-format-bot commit on main triggers image push
- [ ] Verify agent-orchestrator-mcp image appears on GHCR after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)