### PR TITLE
feat(observability): OpenTelemetry for Goose agent runs

### DIFF
--- a/charts/goose-sandboxes/templates/deployment-agents.yaml
+++ b/charts/goose-sandboxes/templates/deployment-agents.yaml
@@ -101,6 +101,9 @@ spec:
                 secretKeyRef:
                   name: agent-secrets
                   key: BUILDBUDDY_API_KEY
+            {{- if $.Values.sandboxTemplate.extraEnv }}
+            {{- toYaml $.Values.sandboxTemplate.extraEnv | nindent 12 }}
+            {{- end }}
           resources:
             {{- toYaml ($agent.resources | default $.Values.sandboxTemplate.resources) | nindent 12 }}
           volumeMounts:

--- a/charts/goose-sandboxes/templates/sandboxtemplate.yaml
+++ b/charts/goose-sandboxes/templates/sandboxtemplate.yaml
@@ -76,6 +76,9 @@ spec:
                   name: goose-mcp-tokens
                   key: CI_DEBUG_MCP_TOKEN
                   optional: true
+            {{- if .Values.sandboxTemplate.extraEnv }}
+            {{- toYaml .Values.sandboxTemplate.extraEnv | nindent 12 }}
+            {{- end }}
           resources:
             {{- toYaml .Values.sandboxTemplate.resources | nindent 12 }}
           volumeMounts:

--- a/charts/goose-sandboxes/values.yaml
+++ b/charts/goose-sandboxes/values.yaml
@@ -31,6 +31,14 @@ sandboxTemplate:
     limits:
       cpu: "4"
       memory: 8Gi
+  # Extra env vars injected into all goose containers (SandboxTemplate pods and long-lived agent Deployments).
+  # Use this to pass additional configuration without modifying the chart templates.
+  extraEnv: []
+  # Example:
+  # extraEnv:
+  #   - name: MY_VAR
+  #     value: my-value
+
   workspace:
     storageClassName: longhorn
     size: 20Gi

--- a/overlays/prod/goose-sandboxes/values.yaml
+++ b/overlays/prod/goose-sandboxes/values.yaml
@@ -7,3 +7,41 @@ sandboxTemplate:
   image:
     repository: ghcr.io/jomcgi/homelab/goose-agent
     tag: main@sha256:0870c284d94286c94b358c2da63b956542367d36e15ca2bbbf06b9efdeef33f0
+
+  # OpenTelemetry configuration for Goose agent observability.
+  #
+  # Goose (block/goose) has native OTEL support using the Rust opentelemetry SDK.
+  # It exports traces, metrics, and logs — but uses HTTP OTLP exclusively (port 4318),
+  # not gRPC. The Kyverno policy injects OTEL_EXPORTER_OTLP_ENDPOINT pointing to the
+  # gRPC port (4317), which Goose cannot use. We set signal-specific endpoints here
+  # (OTEL_EXPORTER_OTLP_{SIGNAL}_ENDPOINT) which take precedence over the generic
+  # Kyverno-injected endpoint per the OpenTelemetry specification.
+  #
+  # What this gives us in SigNoz:
+  #   - Traces: agent reply spans, tool dispatch spans, session spans
+  #   - Metrics: infrastructure metrics from the Goose runtime
+  #   - Logs: structured log output from Goose
+  #
+  # For LLM token metrics (gen_ai.usage.input_tokens, gen_ai.usage.output_tokens),
+  # see the LiteLLM overlay — LiteLLM emits these via its OTEL callback when
+  # requests are routed through it.
+  extraEnv:
+    # Signal-specific HTTP endpoints override Kyverno's generic gRPC endpoint.
+    - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
+      value: "http://signoz-otel-collector.signoz.svc.cluster.local:4318"
+    - name: OTEL_EXPORTER_OTLP_METRICS_ENDPOINT
+      value: "http://signoz-otel-collector.signoz.svc.cluster.local:4318"
+    - name: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT
+      value: "http://signoz-otel-collector.signoz.svc.cluster.local:4318"
+    # Explicitly enable OTLP export for all three signals.
+    - name: OTEL_TRACES_EXPORTER
+      value: "otlp"
+    - name: OTEL_METRICS_EXPORTER
+      value: "otlp"
+    - name: OTEL_LOGS_EXPORTER
+      value: "otlp"
+    # Service identity in SigNoz.
+    - name: OTEL_SERVICE_NAME
+      value: "goose-agent"
+    - name: OTEL_RESOURCE_ATTRIBUTES
+      value: "service.namespace=goose-sandboxes,deployment.environment=prod"


### PR DESCRIPTION
## Summary

- **Goose native OTEL**: Enables traces, metrics, and logs from Goose AI agent runs (block/goose v1.27.1) into SigNoz via its built-in OpenTelemetry SDK
- **Chart improvement**: Adds a generic `extraEnv` escape-hatch to the `goose-sandboxes` Helm chart so overlay values can inject arbitrary env vars into both `SandboxTemplate` pods and long-lived agent `Deployment`s without touching the chart templates

## Technical decisions

### Why signal-specific OTLP endpoints for Goose?

Goose uses **HTTP OTLP exclusively** (built with `SpanExporter::builder().with_http()`). The Kyverno cluster-wide injection sets `OTEL_EXPORTER_OTLP_ENDPOINT=signoz-otel-collector.signoz.svc.cluster.local:4317` (gRPC, no scheme), which Goose cannot connect to.

Per the OpenTelemetry spec, signal-specific env vars (`OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`, etc.) take priority over the generic one. We set these to `http://signoz-otel-collector.signoz.svc.cluster.local:4318` (HTTP port) so Goose uses the right protocol while leaving Kyverno's generic injection intact for other services.

### What lands in SigNoz from Goose?

Goose instruments these spans via `#[instrument]` macros and `tracing_opentelemetry`:
- `reply` -- top-level per-agent-turn span
- `reply_stream` -- LLM completion stream span (records `input` / `output`)
- `dispatch_tool_call` -- per-tool invocation span

These give full visibility into agent sessions without any code changes to Goose.

## Test plan

- [ ] Verify ArgoCD syncs `goose-sandboxes` app cleanly after merge
- [ ] Confirm `goose-agent` service appears in SigNoz -> Services within a few minutes of an agent run
- [ ] Check no regression in agent task completion (OTEL is additive, not behavioural)

🤖 Generated with [Claude Code](https://claude.com/claude-code)