### PR TITLE
fix: disable OCI tools bootstrap on macOS

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -2,21 +2,6 @@
 # Note: for direnv, $PWD is always the directory of the .envrc
 export ORION_EXTENSIONS_DIR=$PWD/.aspect/gazelle/
 
-# Developer tools from OCI image (see bootstrap.sh)
-# Stored in user cache — shared across worktrees, no sudo needed
-TOOLS_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/homelab-tools"
-if [[ ! -d "$TOOLS_DIR/usr/bin" ]]; then
-  log_error "Run './bootstrap.sh' to install dev tools"
-else
-  PATH_add "$TOOLS_DIR/usr/bin"
-  # Check for updates in the background (non-blocking)
-  if command -v crane &>/dev/null && [[ -f "$TOOLS_DIR/.digest" ]]; then
-    (
-      remote=$(crane digest ghcr.io/jomcgi/homelab-tools:main 2>/dev/null || true)
-      local_digest=$(cat "$TOOLS_DIR/.digest")
-      if [[ -n "$remote" ]] && [[ "$remote" != "$local_digest" ]]; then
-        log_status "Dev tools update available — run './bootstrap.sh'"
-      fi
-    ) &
-  fi
-fi
+# Developer tools from OCI image — disabled on macOS.
+# The OCI tools image contains Linux (ELF) binaries that cannot run on macOS.
+# Local dev uses Homebrew-installed tools; CI uses the image directly via BuildBuddy.

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,45 +1,18 @@
 #!/usr/bin/env bash
 # Bootstrap developer tools for the homelab repo.
-# macOS only — installs crane via Homebrew, then pulls the OCI tools image.
-set -euo pipefail
-
-if [[ "$(uname -s)" != "Darwin" ]]; then
-	echo "ERROR: bootstrap.sh is only supported on macOS."
-	echo "For Linux/CI environments, tools are provided via the OCI tools image directly."
-	exit 1
-fi
-
-# Install crane if missing
-if ! command -v crane &>/dev/null; then
-	if ! command -v brew &>/dev/null; then
-		echo "ERROR: Homebrew is required. Install from https://brew.sh"
-		exit 1
-	fi
-	echo "Installing crane via Homebrew..."
-	brew install crane
-fi
-
-# Pull tools from OCI image
-TOOLS_IMAGE="ghcr.io/jomcgi/homelab-tools:main"
-TOOLS_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/homelab-tools"
-
-# Check remote digest
-REMOTE_DIGEST=$(crane digest "$TOOLS_IMAGE" 2>/dev/null) || {
-	echo "ERROR: Failed to fetch digest for $TOOLS_IMAGE"
-	echo "Check that the image exists and you have access to ghcr.io"
-	exit 1
-}
-
-# Skip if already up to date
-if [[ -f "$TOOLS_DIR/.digest" ]] && [[ "$(cat "$TOOLS_DIR/.digest")" == "$REMOTE_DIGEST" ]]; then
-	echo "Tools already up to date ($REMOTE_DIGEST)"
-	exit 0
-fi
-
-echo "Pulling developer tools from $TOOLS_IMAGE..."
-rm -rf "$TOOLS_DIR"
-mkdir -p "$TOOLS_DIR"
-crane export "$TOOLS_IMAGE" - | tar --no-same-owner -xf - -C "$TOOLS_DIR"
-echo "$REMOTE_DIGEST" >"$TOOLS_DIR/.digest"
-
-echo "Done. Run 'direnv allow' to add tools to your PATH."
+#
+# The OCI tools image (ghcr.io/jomcgi/homelab-tools) contains Linux binaries
+# for CI use (BuildBuddy remote execution). These cannot run on macOS.
+#
+# For local macOS development, install tools via Homebrew:
+#   brew install crane go node pnpm python gh
+#   go install mvdan.cc/gofumpt@latest
+#   pnpm install -g prettier
+#   pip install ruff
+echo "bootstrap.sh is no longer needed for local development."
+echo ""
+echo "The OCI tools image contains Linux binaries for CI — not macOS."
+echo "Install dev tools via Homebrew instead:"
+echo "  brew install crane go node pnpm python gh"
+echo ""
+echo "See CLAUDE.md for the full list of vendored tools."


### PR DESCRIPTION
## Summary
- The OCI tools image (`ghcr.io/jomcgi/homelab-tools`) contains Linux ELF binaries that can't run on macOS — they were shadowing native `git`, `node`, `go` etc. with non-functional binaries
- Removed the `PATH_add` from `.envrc` and replaced `bootstrap.sh` with Homebrew guidance
- CI is unaffected — it uses the OCI image directly via BuildBuddy

## Test plan
- [ ] Verify `direnv allow` no longer errors about missing tools dir
- [ ] Verify native `git`, `node` etc. work without shadowing
- [ ] Verify CI format + test jobs still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)