### PR TITLE
fix(agent-orchestrator): reconcile orphaned RUNNING jobs on startup

### DIFF
--- a/services/agent-orchestrator/BUILD
+++ b/services/agent-orchestrator/BUILD
@@ -8,6 +8,7 @@ go_library(
         "consumer.go",
         "main.go",
         "model.go",
+        "reconcile.go",
         "sandbox.go",
         "store.go",
         "watchdog.go",
@@ -19,6 +20,7 @@ go_library(
         "@com_github_nats_io_nats_go//jetstream",
         "@com_github_oklog_ulid_v2//:ulid",
         "@io_k8s_api//core/v1:core",
+        "@io_k8s_apimachinery//pkg/api/errors",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:meta",
         "@io_k8s_apimachinery//pkg/apis/meta/v1/unstructured",
         "@io_k8s_apimachinery//pkg/runtime/schema",
@@ -41,6 +43,7 @@ go_test(
     name = "agent-orchestrator_unit_test",
     srcs = [
         "api_test.go",
+        "reconcile_test.go",
         "sandbox_test.go",
         "watchdog_test.go",
     ],
@@ -51,6 +54,7 @@ go_test(
     name = "agent-orchestrator_test",
     srcs = [
         "api_test.go",
+        "reconcile_test.go",
         "sandbox_test.go",
         "store_test.go",
         "watchdog_test.go",

--- a/services/agent-orchestrator/main.go
+++ b/services/agent-orchestrator/main.go
@@ -136,6 +136,13 @@ func main() {
 		ReadHeaderTimeout: 10 * time.Second,
 	}
 
+	// Reconcile orphaned jobs before starting the consumer.
+	// After a restart, jobs left in RUNNING state have lost their SPDY exec
+	// connection and sandbox claims are stale. Reset them for retry.
+	if sandbox != nil {
+		reconcileOrphanedJobs(ctx, store, publish, sandbox.dynClient, sandboxNamespace, logger)
+	}
+
 	// Start consumer if sandbox is available.
 	if sandbox != nil {
 		consumer := NewConsumer(cons, store, sandbox, maxDuration, logger)

--- a/services/agent-orchestrator/reconcile.go
+++ b/services/agent-orchestrator/reconcile.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/dynamic"
+)
+
+// reconcileOrphanedJobs scans the KV store for jobs stuck in RUNNING state
+// and resets them for retry. This handles the case where the orchestrator
+// restarts while jobs are in-flight: the SPDY exec connection is lost,
+// the sandbox claim is orphaned, and the NATS message sits unACKed until
+// AckWait expires (168h by default).
+//
+// For each orphaned job, this function:
+//  1. Cleans up the stale SandboxClaim (if it still exists)
+//  2. Resets the job to PENDING
+//  3. Re-publishes the job ID to the NATS stream for redelivery
+func reconcileOrphanedJobs(ctx context.Context, store Store, publish func(string) error, dynClient dynamic.Interface, namespace string, logger *slog.Logger) {
+	jobs, _, err := store.List(ctx, []string{string(JobRunning)}, 100, 0)
+	if err != nil {
+		logger.Error("reconcile: failed to list running jobs", "error", err)
+		return
+	}
+
+	if len(jobs) == 0 {
+		logger.Info("reconcile: no orphaned jobs found")
+		return
+	}
+
+	logger.Info("reconcile: found orphaned running jobs", "count", len(jobs))
+
+	for _, job := range jobs {
+		jlog := logger.With("jobID", job.ID)
+
+		// Clean up stale sandbox claim from the last attempt.
+		if len(job.Attempts) > 0 {
+			lastAttempt := job.Attempts[len(job.Attempts)-1]
+			if lastAttempt.SandboxClaimName != "" {
+				cleanupSandboxClaim(ctx, dynClient, namespace, lastAttempt.SandboxClaimName, jlog)
+			}
+		}
+
+		// Mark the interrupted attempt as failed.
+		if len(job.Attempts) > 0 {
+			now := time.Now().UTC()
+			last := &job.Attempts[len(job.Attempts)-1]
+			if last.FinishedAt == nil {
+				last.FinishedAt = &now
+				exitCode := -1
+				last.ExitCode = &exitCode
+				last.Output = appendOutput(last.Output, "[orchestrator restarted - execution interrupted]")
+			}
+		}
+
+		retriesRemaining := job.MaxRetries - len(job.Attempts)
+		if retriesRemaining <= 0 {
+			jlog.Info("reconcile: no retries remaining, marking failed")
+			job.Status = JobFailed
+			if err := store.Put(ctx, &job); err != nil {
+				jlog.Error("reconcile: failed to update job to failed", "error", err)
+			}
+			continue
+		}
+
+		jlog.Info("reconcile: resetting to pending for retry", "retriesRemaining", retriesRemaining)
+		job.Status = JobPending
+		if err := store.Put(ctx, &job); err != nil {
+			jlog.Error("reconcile: failed to reset job", "error", err)
+			continue
+		}
+
+		if err := publish(job.ID); err != nil {
+			jlog.Error("reconcile: failed to re-publish job", "error", err)
+		}
+	}
+}
+
+func cleanupSandboxClaim(ctx context.Context, dynClient dynamic.Interface, namespace, claimName string, logger *slog.Logger) {
+	if dynClient == nil {
+		return
+	}
+	err := dynClient.Resource(sandboxClaimGVR).Namespace(namespace).Delete(
+		ctx, claimName, metav1.DeleteOptions{})
+	if err != nil {
+		if !apierrors.IsNotFound(err) {
+			logger.Warn("reconcile: failed to delete sandbox claim", "claim", claimName, "error", err)
+		}
+		return
+	}
+	logger.Info("reconcile: deleted orphaned sandbox claim", "claim", claimName)
+}
+
+func appendOutput(existing, suffix string) string {
+	if existing == "" {
+		return suffix
+	}
+	return fmt.Sprintf("%s\n%s", existing, suffix)
+}

--- a/services/agent-orchestrator/reconcile_test.go
+++ b/services/agent-orchestrator/reconcile_test.go
@@ -1,0 +1,144 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+	"time"
+)
+
+func TestReconcileOrphanedJobs_ResetsRunningJobs(t *testing.T) {
+	store := newMemStore()
+	ctx := context.Background()
+
+	// Seed two orphaned RUNNING jobs (simulating an orchestrator crash mid-execution).
+	store.Put(ctx, &JobRecord{
+		ID:         "job-orphan-1",
+		Task:       "deploy envoy gateway",
+		Status:     JobRunning,
+		CreatedAt:  time.Now().Add(-2 * time.Hour),
+		MaxRetries: 2,
+		Attempts: []Attempt{{
+			Number:           1,
+			SandboxClaimName: "orch-job-orphan-1-1",
+			StartedAt:        time.Now().Add(-2 * time.Hour),
+		}},
+	})
+	store.Put(ctx, &JobRecord{
+		ID:         "job-orphan-2",
+		Task:       "fix CI",
+		Status:     JobRunning,
+		CreatedAt:  time.Now().Add(-1 * time.Hour),
+		MaxRetries: 3,
+		Attempts: []Attempt{{
+			Number:           1,
+			SandboxClaimName: "orch-job-orphan-2-1",
+			StartedAt:        time.Now().Add(-1 * time.Hour),
+		}},
+	})
+
+	// A PENDING job that should not be touched.
+	store.Put(ctx, &JobRecord{
+		ID:        "job-pending",
+		Task:      "pending task",
+		Status:    JobPending,
+		CreatedAt: time.Now(),
+	})
+
+	var republished []string
+	publish := func(jobID string) error {
+		republished = append(republished, jobID)
+		return nil
+	}
+
+	reconcileOrphanedJobs(ctx, store, publish, nil, "goose-sandboxes", slog.Default())
+
+	// Both orphaned jobs should be reset to PENDING.
+	for _, id := range []string{"job-orphan-1", "job-orphan-2"} {
+		job, err := store.Get(ctx, id)
+		if err != nil {
+			t.Fatalf("Get(%s): %v", id, err)
+		}
+		if job.Status != JobPending {
+			t.Errorf("%s: status = %s, want PENDING", id, job.Status)
+		}
+		// The interrupted attempt should be marked with exit code -1.
+		last := job.Attempts[len(job.Attempts)-1]
+		if last.ExitCode == nil || *last.ExitCode != -1 {
+			t.Errorf("%s: last attempt exit code = %v, want -1", id, last.ExitCode)
+		}
+		if last.FinishedAt == nil {
+			t.Errorf("%s: last attempt FinishedAt should be set", id)
+		}
+	}
+
+	// Both should be re-published to NATS.
+	if len(republished) != 2 {
+		t.Fatalf("republished count = %d, want 2", len(republished))
+	}
+
+	// PENDING job should be untouched.
+	pending, _ := store.Get(ctx, "job-pending")
+	if pending.Status != JobPending {
+		t.Errorf("pending job status = %s, want PENDING", pending.Status)
+	}
+}
+
+func TestReconcileOrphanedJobs_ExhaustedRetriesMarksFailed(t *testing.T) {
+	store := newMemStore()
+	ctx := context.Background()
+
+	// Job that has used all its retries.
+	store.Put(ctx, &JobRecord{
+		ID:         "job-exhausted",
+		Task:       "flaky task",
+		Status:     JobRunning,
+		CreatedAt:  time.Now().Add(-3 * time.Hour),
+		MaxRetries: 1,
+		Attempts: []Attempt{
+			{Number: 1, SandboxClaimName: "orch-job-exhausted-1", StartedAt: time.Now().Add(-3 * time.Hour)},
+		},
+	})
+
+	var republished []string
+	publish := func(jobID string) error {
+		republished = append(republished, jobID)
+		return nil
+	}
+
+	reconcileOrphanedJobs(ctx, store, publish, nil, "goose-sandboxes", slog.Default())
+
+	job, _ := store.Get(ctx, "job-exhausted")
+	if job.Status != JobFailed {
+		t.Errorf("status = %s, want FAILED", job.Status)
+	}
+
+	// Should NOT be re-published since retries are exhausted.
+	if len(republished) != 0 {
+		t.Errorf("republished count = %d, want 0", len(republished))
+	}
+}
+
+func TestReconcileOrphanedJobs_NoRunningJobs(t *testing.T) {
+	store := newMemStore()
+	ctx := context.Background()
+
+	store.Put(ctx, &JobRecord{
+		ID:     "job-done",
+		Task:   "completed task",
+		Status: JobSucceeded,
+	})
+
+	published := false
+	publish := func(string) error {
+		published = true
+		return nil
+	}
+
+	// Should be a no-op.
+	reconcileOrphanedJobs(ctx, store, publish, nil, "goose-sandboxes", slog.Default())
+
+	if published {
+		t.Error("should not have published anything")
+	}
+}


### PR DESCRIPTION
## Summary

- Adds a startup reconciliation loop that scans KV for jobs stuck in RUNNING state after an orchestrator restart
- Cleans up stale SandboxClaim resources left behind when the SPDY exec connection is severed
- Marks interrupted attempts as failed (exit code -1) and resets jobs to PENDING for retry
- Re-publishes job IDs to the NATS stream so the consumer picks them up immediately

**Root cause:** When the orchestrator pod restarts mid-execution, the NATS messages sit unACKed but AckWait is 168h — so redelivery takes a week. Meanwhile jobs appear RUNNING in the API but nothing is actually executing them.

## Test plan

- [x] Unit tests for reconciliation: resets RUNNING jobs, handles exhausted retries, no-ops on clean state
- [ ] CI passes (format + bazel test)
- [ ] Verify on cluster: restart orchestrator pod, confirm orphaned jobs get retried

🤖 Generated with [Claude Code](https://claude.com/claude-code)