### PR TITLE
fix(observability): add OTEL auto-instrumentation for agent-orchestrator

### DIFF
--- a/overlays/cluster-critical/opentelemetry-operator/values.yaml
+++ b/overlays/cluster-critical/opentelemetry-operator/values.yaml
@@ -17,6 +17,7 @@ instrumentation:
     - api-gateway
     - mcp-servers
     - todo
+    - agent-orchestrator
     # Development
     - grimoire
     - marine

--- a/overlays/prod/agent-orchestrator/values.yaml
+++ b/overlays/prod/agent-orchestrator/values.yaml
@@ -3,3 +3,6 @@ imagePullSecret:
 image:
   tag: main@sha256:5ea29fd9b8a944c7516faf2020d47aba24d92776c8c7006283cc9ac676f7b930
   repository: ghcr.io/jomcgi/homelab/services/agent-orchestrator
+podAnnotations:
+  instrumentation.opentelemetry.io/inject-go: "go"
+  instrumentation.opentelemetry.io/otel-go-auto-target-exe: "/opt/app"


### PR DESCRIPTION
## Summary
- Add Go eBPF auto-instrumentation annotations (`inject-go`, `otel-go-auto-target-exe: /opt/app`) to agent-orchestrator pod
- Add `agent-orchestrator` namespace to OpenTelemetry Operator's instrumentation scope

## Context
The agent-orchestrator Go service was missing OpenTelemetry auto-instrumentation while sibling services (todo, trips, knowledge-graph) already had it. This adds the same eBPF-based Go instrumentation pattern used by `todo` and `grimoire`.

## Test plan
- [ ] Verify ArgoCD syncs both opentelemetry-operator and agent-orchestrator apps
- [ ] Confirm Go Instrumentation CR is created in `agent-orchestrator` namespace
- [ ] Verify agent-orchestrator pods restart with eBPF sidecar
- [ ] Check SigNoz for traces from agent-orchestrator service

🤖 Generated with [Claude Code](https://claude.com/claude-code)