### PR TITLE
fix(observability): tune alert queries to reduce false positives

### DIFF
--- a/architecture/observability-alerting.md
+++ b/architecture/observability-alerting.md
@@ -135,7 +135,7 @@ The `thresholds` block is still needed for the SigNoz UI to render threshold con
 
 ### HTTPCheck Alerts
 
-Monitor service availability via the OTel httpcheck receiver. Pattern: `avg(httpcheck.status)` where `http.url = '<url>'`, alert when `< 1` for 5 consecutive checks.
+Monitor service availability via the OTel httpcheck receiver. Pattern: `max(httpcheck.status)` (space aggregation) where `http.url = '<url>'`, alert when `< 1` for 5 consecutive checks. Uses `max` space aggregation to avoid false positives from stale metric series left by previous collector pod incarnations.
 
 | Service          | URL                                       | Location                              |
 | ---------------- | ----------------------------------------- | ------------------------------------- |
@@ -172,9 +172,9 @@ Located in `overlays/cluster-critical/signoz/alerts/`:
 - `node-memory-pressure.yaml` — `k8s.node.condition_memory_pressure` > 0 always (warning)
 - `node-pid-pressure.yaml` — `k8s.node.condition_pid_pressure` > 0 always (warning)
 - `node-not-ready.yaml` — `k8s.node.condition_ready` < 1 for 5 consecutive (critical)
-- `pod-oomkilled.yaml` — `k8s.container.restarts` where `last_terminated_reason = OOMKilled` > 0 once (critical)
+- `pod-oomkilled.yaml` — `increase(k8s.container.restarts)` where `last_terminated_reason = OOMKilled` > 0 once (critical). Uses `increase` time aggregation to detect new OOM events, not cumulative lifetime count.
 - `pod-pending.yaml` — `k8s.pod.phase` == 1 (Pending) for 5 consecutive over 15min (warning)
-- `pod-restart-rate.yaml` — `k8s.container.restarts` > 3 once in 15min (warning)
+- `pod-restart-rate.yaml` — `increase(k8s.container.restarts)` > 3 once in 15min (warning). Uses `increase` time aggregation to detect restarts within the eval window, not cumulative lifetime count.
 
 ## Sidecar Architecture
 

--- a/charts/mcp-servers/templates/alert.yaml
+++ b/charts/mcp-servers/templates/alert.yaml
@@ -44,7 +44,7 @@ data:
                 "aggregations": [
                   {
                     "timeAggregation": "avg",
-                    "spaceAggregation": "avg",
+                    "spaceAggregation": "max",
                     "metricName": "httpcheck.status"
                   }
                 ],

--- a/overlays/cluster-critical/argocd/argocd-httpcheck-alert.yaml
+++ b/overlays/cluster-critical/argocd/argocd-httpcheck-alert.yaml
@@ -41,7 +41,7 @@ data:
                 "aggregations": [
                   {
                     "timeAggregation": "avg",
-                    "spaceAggregation": "avg",
+                    "spaceAggregation": "max",
                     "metricName": "httpcheck.status"
                   }
                 ],

--- a/overlays/cluster-critical/longhorn/longhorn-httpcheck-alert.yaml
+++ b/overlays/cluster-critical/longhorn/longhorn-httpcheck-alert.yaml
@@ -41,7 +41,7 @@ data:
                 "aggregations": [
                   {
                     "timeAggregation": "avg",
-                    "spaceAggregation": "avg",
+                    "spaceAggregation": "max",
                     "metricName": "httpcheck.status"
                   }
                 ],

--- a/overlays/cluster-critical/signoz/alerts/pod-oomkilled.yaml
+++ b/overlays/cluster-critical/signoz/alerts/pod-oomkilled.yaml
@@ -40,8 +40,8 @@ data:
                 "stepInterval": 60,
                 "aggregations": [
                   {
-                    "timeAggregation": "max",
-                    "spaceAggregation": "max",
+                    "timeAggregation": "increase",
+                    "spaceAggregation": "sum",
                     "metricName": "k8s.container.restarts"
                   }
                 ],

--- a/overlays/cluster-critical/signoz/alerts/pod-restart-rate.yaml
+++ b/overlays/cluster-critical/signoz/alerts/pod-restart-rate.yaml
@@ -40,8 +40,8 @@ data:
                 "stepInterval": 60,
                 "aggregations": [
                   {
-                    "timeAggregation": "max",
-                    "spaceAggregation": "max",
+                    "timeAggregation": "increase",
+                    "spaceAggregation": "sum",
                     "metricName": "k8s.container.restarts"
                   }
                 ],

--- a/overlays/cluster-critical/signoz/hikes-httpcheck-alert.yaml
+++ b/overlays/cluster-critical/signoz/hikes-httpcheck-alert.yaml
@@ -42,7 +42,7 @@ data:
                 "aggregations": [
                   {
                     "timeAggregation": "avg",
-                    "spaceAggregation": "avg",
+                    "spaceAggregation": "max",
                     "metricName": "httpcheck.status"
                   }
                 ],

--- a/overlays/cluster-critical/signoz/jomcgi-dev-httpcheck-alert.yaml
+++ b/overlays/cluster-critical/signoz/jomcgi-dev-httpcheck-alert.yaml
@@ -42,7 +42,7 @@ data:
                 "aggregations": [
                   {
                     "timeAggregation": "avg",
-                    "spaceAggregation": "avg",
+                    "spaceAggregation": "max",
                     "metricName": "httpcheck.status"
                   }
                 ],

--- a/overlays/cluster-critical/signoz/signoz-httpcheck-alert.yaml
+++ b/overlays/cluster-critical/signoz/signoz-httpcheck-alert.yaml
@@ -41,7 +41,7 @@ data:
                 "aggregations": [
                   {
                     "timeAggregation": "avg",
-                    "spaceAggregation": "avg",
+                    "spaceAggregation": "max",
                     "metricName": "httpcheck.status"
                   }
                 ],

--- a/overlays/cluster-critical/signoz/trips-pages-httpcheck-alert.yaml
+++ b/overlays/cluster-critical/signoz/trips-pages-httpcheck-alert.yaml
@@ -42,7 +42,7 @@ data:
                 "aggregations": [
                   {
                     "timeAggregation": "avg",
-                    "spaceAggregation": "avg",
+                    "spaceAggregation": "max",
                     "metricName": "httpcheck.status"
                   }
                 ],

--- a/overlays/dev/marine/marine-httpcheck-alert.yaml
+++ b/overlays/dev/marine/marine-httpcheck-alert.yaml
@@ -41,7 +41,7 @@ data:
                 "aggregations": [
                   {
                     "timeAggregation": "avg",
-                    "spaceAggregation": "avg",
+                    "spaceAggregation": "max",
                     "metricName": "httpcheck.status"
                   }
                 ],

--- a/overlays/prod/api-gateway/api-gateway-httpcheck-alert.yaml
+++ b/overlays/prod/api-gateway/api-gateway-httpcheck-alert.yaml
@@ -41,7 +41,7 @@ data:
                 "aggregations": [
                   {
                     "timeAggregation": "avg",
-                    "spaceAggregation": "avg",
+                    "spaceAggregation": "max",
                     "metricName": "httpcheck.status"
                   }
                 ],

--- a/overlays/prod/knowledge-graph/values.yaml
+++ b/overlays/prod/knowledge-graph/values.yaml
@@ -4,8 +4,6 @@ scraper:
   image:
     tag: main@sha256:ce9d18b355bccd73bd212caeedd5cec8b20e252ca7122c9b1b0b756c8d65c17a
     repository: ghcr.io/jomcgi/homelab/services/knowledge-graph-scraper
-  podAnnotations:
-    instrumentation.opentelemetry.io/inject-python: "python"
 embedder:
   image:
     tag: latest@sha256:4c6f5c8d8ca551a1d6a15042ea38ef60cba6cc1f3c9b89f33a5fa66cd00bce2f
@@ -14,8 +12,6 @@ mcp:
   image:
     tag: main@sha256:e711fedbe73ce35d7966238e36abe5e89c7652b290bcee6ac0ba683e70b20a7d
     repository: ghcr.io/jomcgi/homelab/services/knowledge-graph-mcp
-  podAnnotations:
-    instrumentation.opentelemetry.io/inject-python: "python"
 seaweedfs:
   endpoint: http://seaweedfs-s3.seaweedfs.svc.cluster.local:8333
 sources:

--- a/overlays/prod/todo/todo-admin-httpcheck-alert.yaml
+++ b/overlays/prod/todo/todo-admin-httpcheck-alert.yaml
@@ -41,7 +41,7 @@ data:
                 "aggregations": [
                   {
                     "timeAggregation": "avg",
-                    "spaceAggregation": "avg",
+                    "spaceAggregation": "max",
                     "metricName": "httpcheck.status"
                   }
                 ],

--- a/overlays/prod/todo/todo-httpcheck-alert.yaml
+++ b/overlays/prod/todo/todo-httpcheck-alert.yaml
@@ -41,7 +41,7 @@ data:
                 "aggregations": [
                   {
                     "timeAggregation": "avg",
-                    "spaceAggregation": "avg",
+                    "spaceAggregation": "max",
                     "metricName": "httpcheck.status"
                   }
                 ],

--- a/overlays/prod/trips/img-httpcheck-alert.yaml
+++ b/overlays/prod/trips/img-httpcheck-alert.yaml
@@ -41,7 +41,7 @@ data:
                 "aggregations": [
                   {
                     "timeAggregation": "avg",
-                    "spaceAggregation": "avg",
+                    "spaceAggregation": "max",
                     "metricName": "httpcheck.status"
                   }
                 ],


### PR DESCRIPTION
## Summary
- **HTTPCheck alerts (11 files + 1 template)**: Change `spaceAggregation` from `avg` to `max` — stale metric series from previous collector pod incarnations were dragging the average to `0.2` (1 healthy series out of 5 total including stale ones), causing all HTTP unreachable alerts to fire permanently
- **Pod OOMKilled + Restart Rate alerts**: Change `timeAggregation` from `max` to `increase` on `k8s.container.restarts` — this is a cumulative counter that never resets, so `max > 0` fires forever after any restart. `increase` detects new restarts within the eval window only
- **knowledge-graph**: Remove OTel Python auto-instrumentation annotations causing CrashLoopBackOff — `autoinstrumentation-python:0.60b1` is incompatible with Bazel-built runfiles (`otlp_proto_grpc` not found)

## Alerts addressed
| Alert | Root cause | Fix |
|---|---|---|
| 8x HTTP Unreachable | Stale metric series → avg=0.2 | spaceAggregation: max |
| Pod OOMKilled (multiple) | Cumulative counter, never resets | timeAggregation: increase |
| Pod High Restart Rate (multiple) | Cumulative counter, never resets | timeAggregation: increase |
| ArgoCD App Degraded | knowledge-graph CrashLoopBackOff | Remove broken OTel annotation |

## Not addressed (separate issues)
- **Node Disk Pressure**: Alert design is correct (gauge, not counter). Intermittent real disk pressure on a node — needs investigation
- **ArgoCD App OutOfSync (prod-mcp-servers)**: Synced via ArgoCD MCP
- **OTel + Bazel Python compatibility**: Root cause of knowledge-graph crash needs deeper investigation to re-enable auto-instrumentation

## Test plan
- [ ] Verify CI passes (format check + bazel test)
- [ ] After merge, confirm httpcheck alerts resolve within ~10 minutes (eval window)
- [ ] Confirm OOMKilled/restart rate alerts clear for pods that haven't restarted recently
- [ ] Confirm knowledge-graph pods start successfully without OTel injection

🤖 Generated with [Claude Code](https://claude.com/claude-code)