### PR TITLE
fix(cluster-agents): align alert struct with raw SigNoz API

### DIFF
--- a/services/cluster-agents/collector_alerts.go
+++ b/services/cluster-agents/collector_alerts.go
@@ -9,16 +9,19 @@ import (
 )
 
 type alertRulesResponse struct {
-	Status string      `json:"status"`
-	Data   []alertRule `json:"data"`
+	Status string         `json:"status"`
+	Data   alertRulesData `json:"data"`
+}
+
+type alertRulesData struct {
+	Rules []alertRule `json:"rules"`
 }
 
 type alertRule struct {
-	ID       string            `json:"ruleId"`
-	Name     string            `json:"alertname"`
-	State    string            `json:"state"`
-	Severity string            `json:"severity,omitempty"`
-	Labels   map[string]string `json:"labels,omitempty"`
+	ID     string            `json:"id"`
+	Name   string            `json:"alert"`
+	State  string            `json:"state"`
+	Labels map[string]string `json:"labels,omitempty"`
 }
 
 type AlertCollector struct {
@@ -62,12 +65,12 @@ func (c *AlertCollector) Collect(ctx context.Context) ([]Finding, error) {
 	var findings []Finding
 	now := time.Now()
 
-	for _, rule := range result.Data {
-		if rule.State != "active" {
+	for _, rule := range result.Data.Rules {
+		if rule.State != "firing" {
 			continue
 		}
 
-		severity := mapSeverity(rule.Severity)
+		severity := mapSeverity(rule.Labels["severity"])
 
 		findings = append(findings, Finding{
 			Fingerprint: fmt.Sprintf("patrol.alert.%s", rule.ID),
@@ -78,7 +81,7 @@ func (c *AlertCollector) Collect(ctx context.Context) ([]Finding, error) {
 			Data: map[string]any{
 				"rule_id":  rule.ID,
 				"labels":   rule.Labels,
-				"severity": rule.Severity,
+				"severity": rule.Labels["severity"],
 			},
 			Timestamp: now,
 		})

--- a/services/cluster-agents/collector_alerts_test.go
+++ b/services/cluster-agents/collector_alerts_test.go
@@ -15,26 +15,35 @@ func TestAlertCollector_FiringAlerts(t *testing.T) {
 		}
 		resp := alertRulesResponse{
 			Status: "success",
-			Data: []alertRule{
-				{
-					ID:       "rule-42",
-					Name:     "Pod OOMKilled",
-					State:    "active",
-					Severity: "warning",
-					Labels:   map[string]string{"namespace": "trips", "service": "imgproxy"},
-				},
-				{
-					ID:       "rule-43",
-					Name:     "Node NotReady",
-					State:    "inactive",
-					Severity: "critical",
-				},
-				{
-					ID:       "rule-44",
-					Name:     "High Error Rate",
-					State:    "active",
-					Severity: "critical",
-					Labels:   map[string]string{"service": "api-gateway"},
+			Data: alertRulesData{
+				Rules: []alertRule{
+					{
+						ID:    "rule-42",
+						Name:  "Pod OOMKilled",
+						State: "firing",
+						Labels: map[string]string{
+							"namespace": "trips",
+							"service":   "imgproxy",
+							"severity":  "warning",
+						},
+					},
+					{
+						ID:    "rule-43",
+						Name:  "Node NotReady",
+						State: "inactive",
+						Labels: map[string]string{
+							"severity": "critical",
+						},
+					},
+					{
+						ID:    "rule-44",
+						Name:  "High Error Rate",
+						State: "firing",
+						Labels: map[string]string{
+							"service":  "api-gateway",
+							"severity": "critical",
+						},
+					},
 				},
 			},
 		}
@@ -49,7 +58,7 @@ func TestAlertCollector_FiringAlerts(t *testing.T) {
 	}
 
 	if len(findings) != 2 {
-		t.Fatalf("expected 2 findings (only active), got %d", len(findings))
+		t.Fatalf("expected 2 findings (only firing), got %d", len(findings))
 	}
 
 	if findings[0].Fingerprint != "patrol.alert.rule-42" {
@@ -70,8 +79,17 @@ func TestAlertCollector_NoFiringAlerts(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := alertRulesResponse{
 			Status: "success",
-			Data: []alertRule{
-				{ID: "rule-1", Name: "Healthy", State: "inactive", Severity: "warning"},
+			Data: alertRulesData{
+				Rules: []alertRule{
+					{
+						ID:    "rule-1",
+						Name:  "Healthy",
+						State: "inactive",
+						Labels: map[string]string{
+							"severity": "warning",
+						},
+					},
+				},
 			},
 		}
 		json.NewEncoder(w).Encode(resp)

--- a/services/cluster-agents/patrol_test.go
+++ b/services/cluster-agents/patrol_test.go
@@ -58,8 +58,17 @@ func TestPatrolAgent_CollectAggregatesFromCollector(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := alertRulesResponse{
 			Status: "success",
-			Data: []alertRule{
-				{ID: "rule-10", Name: "Test Alert", State: "active", Severity: "critical"},
+			Data: alertRulesData{
+				Rules: []alertRule{
+					{
+						ID:    "rule-10",
+						Name:  "Test Alert",
+						State: "firing",
+						Labels: map[string]string{
+							"severity": "critical",
+						},
+					},
+				},
 			},
 		}
 		json.NewEncoder(w).Encode(resp)


### PR DESCRIPTION
## Summary
- Fixes alert rules struct to match raw SigNoz `/api/v1/rules` response (validated via port-forward)
- `data` is a nested object `{"rules": [...]}`, not a flat array
- Rule ID field is `id` (not `ruleId`), alert name is `alert` (not `alertname`)
- State is `firing` (not `active`) — the MCP tool was translating these values
- Severity lives inside `labels` map, not as a top-level field

## Context
Follow-up to PR #903. The MCP `list-alerts` tool returns a processed/transformed view of the SigNoz API, so the struct fields didn't match the raw HTTP response that cluster-agents actually consumes.

## Test plan
- [ ] CI passes (Bazel test)
- [ ] cluster-agents pod starts without decode errors
- [ ] Patrol loop successfully collects firing alerts from SigNoz

🤖 Generated with [Claude Code](https://claude.com/claude-code)