### PR TITLE
fix(goose-agent): add auth header to default MCP config

### DIFF
--- a/charts/goose-agent/image/config.yaml
+++ b/charts/goose-agent/image/config.yaml
@@ -19,6 +19,8 @@ extensions:
     timeout: 300
     type: streamable_http
     uri: http://context-forge.mcp-gateway.svc.cluster.local:8000/mcp
+    headers:
+      Authorization: "Bearer ${CI_DEBUG_MCP_TOKEN}"
   github:
     enabled: true
     name: github


### PR DESCRIPTION
## Summary
- Sandbox agents running without a recipe profile had no MCP tools because the default `config.yaml` was missing the `Authorization` header for the Context Forge gateway
- Adds `Bearer ${CI_DEBUG_MCP_TOKEN}` header to the default context-forge extension config
- This gives all sandbox jobs access to cluster tools (SigNoz, ArgoCD, Kubernetes) plus BuildBuddy

## Context
After PR #906 removed recipe profiles from patrol-triggered jobs, agents fell back to the default goose config which lacked authentication. The gateway rejected requests silently and agents had no cluster investigation tools.

## Test plan
- [ ] CI passes (image rebuild with updated config)
- [ ] New patrol-triggered jobs can access MCP tools in sandbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)