### PR TITLE
fix(hikes): use github-hosted runner instead of self-hosted

### DIFF
--- a/.github/workflows/cf-pages-deploy-hikes.yaml
+++ b/.github/workflows/cf-pages-deploy-hikes.yaml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   update-data:
-    runs-on: homelab-runners # Needs Docker-in-Docker to pull and run images
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     name: Update Hike Data
 


### PR DESCRIPTION
## Summary

- Updates the `runs-on` field in `.github/workflows/cf-pages-deploy-hikes.yaml` from `homelab-runners` (self-hosted) to `ubuntu-latest` (GitHub-hosted)
- Self-hosted runners have been removed, causing the workflow to fail
- `ubuntu-latest` runners include Docker pre-installed, so `docker pull` and `docker run` steps work without modification

## Test plan
- [ ] Verify CI checks pass on this PR
- [ ] Confirm the hikes workflow no longer errors with a missing runner