### PR TITLE
fix(goose-recipes): use block scalar for prompt template variable

### DIFF
--- a/charts/goose-agent/image/BUILD
+++ b/charts/goose-agent/image/BUILD
@@ -1,6 +1,7 @@
 load("@aspect_bazel_lib//lib:tar.bzl", "tar")
 load("@aspect_bazel_lib//lib:transitions.bzl", "platform_transition_filegroup")
 load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
 load("//tools/oci:apko_image.bzl", "apko_image")
 
 # Package the Goose config into the image at ~/.config/goose/config.yaml
@@ -19,6 +20,19 @@ pkg_tar(
     mode = "0644",
     owner = "65532.65532",
     package_dir = "/home/goose-agent/recipes",
+)
+
+# Validate recipe YAML files on every PR.
+# Checks required fields and guards against the double-quoted template-variable
+# anti-pattern that produces invalid YAML after MiniJinja rendering.
+sh_test(
+    name = "recipe_yaml_test",
+    srcs = ["validate-recipes.sh"],
+    args = [
+        "$(rootpath recipes/ci-debug.yaml)",
+        "$(rootpath recipes/code-fix.yaml)",
+    ],
+    data = glob(["recipes/*.yaml"]),
 )
 
 # Package Claude Code CLI from the pnpm lockfile-managed npm package.

--- a/charts/goose-agent/image/recipes/ci-debug.yaml
+++ b/charts/goose-agent/image/recipes/ci-debug.yaml
@@ -7,7 +7,8 @@ instructions: |
   Fix the issue, verify with bazel test, commit using conventional commits
   format, and create a PR.
   DO NOT use kubectl or argocd CLI commands.
-prompt: "{{ task_description }}"
+prompt: |-
+  {{ task_description }}
 parameters:
   - key: task_description
     description: "The task to perform"

--- a/charts/goose-agent/image/recipes/code-fix.yaml
+++ b/charts/goose-agent/image/recipes/code-fix.yaml
@@ -6,7 +6,8 @@ instructions: |
   Run bazel test //... to verify your changes.
   Commit using conventional commits format and create a PR.
   You do NOT have access to cluster tools.
-prompt: "{{ task_description }}"
+prompt: |-
+  {{ task_description }}
 parameters:
   - key: task_description
     description: "The task to perform"

--- a/charts/goose-agent/image/validate-recipes.sh
+++ b/charts/goose-agent/image/validate-recipes.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# validate-recipes.sh — Validates Goose recipe YAML files.
+#
+# Usage: validate-recipes.sh <recipe.yaml> [<recipe.yaml> ...]
+#
+# Checks each recipe file for:
+#   1. Required top-level fields: title, description
+#   2. At least one of: instructions, prompt
+#   3. No double-quoted template variables in the prompt field.
+#      Using prompt: "{{ var }}" breaks YAML parsing when the task description
+#      contains " characters. Use a block scalar (prompt: |-) instead.
+
+set -euo pipefail
+
+FAILED=0
+
+check_recipe() {
+	local file="$1"
+	local ok=1
+
+	echo "Checking: $file"
+
+	# 1. Required fields
+	for field in title description; do
+		if ! grep -qE "^${field}:" "$file"; then
+			echo "  ERROR: missing required field '${field}'"
+			ok=0
+		fi
+	done
+
+	# 2. Must have at least instructions or prompt
+	if ! grep -qE "^(instructions|prompt):" "$file"; then
+		echo "  ERROR: missing 'instructions' or 'prompt'"
+		ok=0
+	fi
+
+	# 3. Detect double-quoted template variable in prompt.
+	#    Pattern: a line starting with "prompt:" that contains "{{ anywhere in quotes.
+	#    e.g.  prompt: "{{ task_description }}"   <- BROKEN
+	#    Fix:  prompt: |-                          <- safe block scalar
+	#            {{ task_description }}
+	if grep -qE '^prompt:[[:space:]]+"[^"]*\{\{' "$file"; then
+		echo "  ERROR: prompt field uses a double-quoted template variable."
+		echo "         This produces invalid YAML when the substituted value"
+		echo "         contains \" characters (common in task descriptions)."
+		echo "         Use a YAML block scalar instead:"
+		echo "           prompt: |-"
+		echo "             {{ task_description }}"
+		ok=0
+	fi
+
+	if [ "$ok" -eq 1 ]; then
+		echo "  OK"
+	else
+		FAILED=1
+	fi
+}
+
+if [ "$#" -eq 0 ]; then
+	echo "Usage: $0 <recipe.yaml> [<recipe.yaml> ...]"
+	exit 1
+fi
+
+for recipe in "$@"; do
+	check_recipe "$recipe"
+done
+
+if [ "$FAILED" -ne 0 ]; then
+	echo ""
+	echo "FAIL: one or more recipe files failed validation"
+	exit 1
+fi
+
+echo ""
+echo "PASS: all recipe files valid"


### PR DESCRIPTION
## Summary

- **Root cause**: Both Goose recipe files (`code-fix.yaml`, `ci-debug.yaml`) used a YAML double-quoted scalar for the `prompt` field containing a MiniJinja template variable: `prompt: "{{ task_description }}"`. When the template is rendered, any `"` in the task description produces invalid YAML (e.g. `prompt: "Fix the "auth" bug"`), causing jobs to fail with `Error: Invalid recipe: did not find expected key` or `Error: Invalid recipe: found unexpected document indicator`.
- **Fix**: Switched `prompt:` to a YAML literal block scalar with strip chomping (`|-`). Block scalars treat the rendered value as literal text, so `"`, `\`, and other special characters no longer break YAML parsing.
- **Regression guard**: Added `validate-recipes.sh` + a Bazel `sh_test` (`recipe_yaml_test`) to `charts/goose-agent/image/BUILD`. This test runs on every PR and fails if any recipe uses the broken double-quoted template variable pattern.

## What changed

| File | Change |
|---|---|
| `charts/goose-agent/image/recipes/code-fix.yaml` | `prompt: "{{ task_description }}"` → `prompt: |-` block scalar |
| `charts/goose-agent/image/recipes/ci-debug.yaml` | Same fix |
| `charts/goose-agent/image/validate-recipes.sh` | New validation script (checks required fields + anti-pattern) |
| `charts/goose-agent/image/BUILD` | Adds `sh_test` target `recipe_yaml_test` for CI |

## Test plan

- [ ] CI passes (format + `bazel test //...`)
- [ ] `recipe_yaml_test` target exists and passes under `//charts/goose-agent/image:recipe_yaml_test`
- [ ] Confirm: submitting a job with `profile: "code-fix"` and a task description containing `"` no longer fails with `Invalid recipe`

🤖 Generated with [Claude Code](https://claude.com/claude-code)