### PR TITLE
docs: RFC — wiring app images into Helm chart definitions via Bazel (revised)

### DIFF
--- a/docs/rfcs/helm-image-wiring.md
+++ b/docs/rfcs/helm-image-wiring.md
@@ -19,61 +19,72 @@ When someone adds a new service or renames a chart, these have to be kept in syn
 
 ---
 
-## Solution: `helm_image_values` rule
+## Solution: `images` dict on `helm_chart`
 
-A new `helm_image_values` rule reads the image's stamp tag (already produced by `rules_oci`) and the repository string, then emits a Helm values YAML fragment:
+The fix is a first-class `images` attribute on `helm_chart`. Each entry maps a dot-notation Helm values path to a Bazel image label:
+
+```starlark
+helm_chart(
+    name = "chart",
+    publish = True,
+    images = {
+        "image":         "//charts/todo/image:image",
+        "sidecar.image": "//services/trips/sidecar:image",
+    },
+)
+```
+
+Dict keys are dot-notation Helm values paths. Dict values are Bazel image labels. `helm_chart` resolves each label to a repository URL + stamp tag via the standard `OciImageInfo` provider, then generates a merged values fragment at build time. No separate targets, no repository string duplication, no boilerplate.
+
+### Generated values fragment
+
+Dot-notation keys expand to nested YAML. For a two-image chart:
 
 ```yaml
 image:
-  repository: ghcr.io/jomcgi/homelab/myapp
+  repository: ghcr.io/jomcgi/homelab/charts/todo
   tag: main-abc1234
+sidecar:
+  image:
+    repository: ghcr.io/jomcgi/homelab/services/trips/sidecar
+    tag: main-abc1234
 ```
 
-This is the only change needed. No digest threading, no `.repository` genrules, no jq pipelines.
+Fragments are merged using `python3 -c` (always available in the Bazel sandbox).
 
 ### Why stamp tags — not digests
 
-Images in this repo are already tagged with stamp variables: the `{name}_stamped_ci.tags.txt` files produced by `go_image` / `apko_image` contain tags like `main-abc1234` (derived from `BUILD_SCM_BRANCH` + `BUILD_SCM_COMMIT`). This is the repo standard and it is intentionally unchanged.
+Images in this repo are already tagged with stamp variables: the `{name}.tags.txt` files produced by `go_image` / `apko_image` contain tags like `main-abc1234` (derived from `BUILD_SCM_BRANCH` + `BUILD_SCM_COMMIT`). This is the repo standard and it is intentionally unchanged.
 
 Stamp tags are:
 
-- **Human-readable.** `main-abc1234` immediately tells you the branch and commit. `sha256:3f2e1a4b…` is opaque — developers cannot reason about it at a glance.
-- **Compatible with ArgoCD Image Updater.** Image Updater's tag subscriptions match on tag patterns (e.g. `^main-[a-f0-9]+$`). Digest references bypass the updater entirely, breaking the automated rollout pipeline.
+- **Human-readable.** `main-abc1234` immediately tells you the branch and commit. `sha256:3f2e1a4b…` is opaque.
+- **Compatible with ArgoCD Image Updater.** Image Updater's tag subscriptions match on tag patterns (e.g. `^main-[a-f0-9]+$`). Digest references bypass the updater entirely, breaking automated rollouts.
 - **Compatible with Kargo.** Kargo OCI repository subscriptions also operate on tags. Switching to digests would require significant Kargo reconfiguration.
-- **Consistent with the rest of the repo.** Every other image push in this monorepo uses stamp tags. The `helm_image_values` rule follows the same pattern.
+- **Consistent with the rest of the repo.** Every image push in this monorepo uses stamp tags.
 
-### What the rule looks like
+---
+
+## Standardised image interface
+
+For `helm_chart` to consume any image target generically, every image macro (`go_image`, `apko_image`) exposes two standard outputs and returns an `OciImageInfo` provider:
 
 ```starlark
-# rules_helm/image_values.bzl
-
-def helm_image_values(name, image, repository, out = None):
-    """Generate a Helm values fragment wiring a stamp-tagged image into chart values.
-
-    Reads the stamp tag file already produced by go_image / apko_image and
-    emits a values YAML with image.repository and image.tag populated.
-
-    Args:
-        name:       Rule name.
-        image:      Label of the stamped tags file, e.g. "//charts/todo/image:image_stamped_ci.tags.txt"
-        repository: OCI repository URL string, e.g. "ghcr.io/jomcgi/homelab/charts/todo"
-        out:        Output filename (default: "{name}.yaml").
-    """
-    if out == None:
-        out = name + ".yaml"
-
-    native.genrule(
-        name = name,
-        srcs = [image],
-        outs = [out],
-        cmd = """
-tag=$$(head -1 $(location {image}))
-printf 'image:\\n  repository: {repo}\\n  tag: %s\\n' "$$tag" > $@
-""".format(image = image, repo = repository),
-    )
+OciImageInfo = provider(
+    doc = "Standard interface for OCI image targets consumed by helm_chart.",
+    fields = {
+        "repository": "File: plain text OCI repository URL (e.g. ghcr.io/jomcgi/homelab/myapp)",
+        "tags_file":  "File: stamp-resolved tag, one tag per line (e.g. main-abc1234)",
+    },
+)
 ```
 
-No external tools required — just `head` and `printf`, which are always available in the Bazel sandbox. The stamp tag file already exists as a build artifact; this rule simply surfaces its value into a YAML fragment that Helm can consume.
+| Output | Description |
+|---|---|
+| `{name}.tags.txt` | Stamp-resolved tag — already produced by most image macros |
+| `{name}.repository` | Plain text file containing the OCI repository URL |
+
+These outputs are added to the macros once. `helm_chart` reads `OciImageInfo.repository` and `OciImageInfo.tags_file` from every entry in `images` without needing to know whether the image is a Go binary, an apko base, or anything else.
 
 ---
 
@@ -91,13 +102,13 @@ This is a **workflow-level** ordering guarantee. No build graph enforcement is n
 
 ### OCI Helm chart versioning
 
-OCI Helm charts get an auto-incrementing version tag on every push (this automation already exists). The chart version is the identity of the chart release — it is not tied to the image tag. This is intentional: charts can be released independently of image builds (e.g. config-only changes), and the GitOps layer (ArgoCD Image Updater, Kargo) manages image tag updates separately.
+OCI Helm charts get an auto-incrementing version tag on every push (this automation already exists). The chart version is the identity of the chart release — it is not tied to the image tag. Charts can be released independently of image builds (e.g. config-only changes), and the GitOps layer (ArgoCD Image Updater, Kargo) manages image tag updates separately.
 
 ---
 
 ## Integration with ArgoCD Image Updater and Kargo
 
-Because `helm_image_values` emits a stamp tag rather than a digest, the full GitOps pipeline continues to work without modification:
+Because `helm_chart` emits stamp tags rather than digests, the full GitOps pipeline continues to work without modification:
 
 **ArgoCD Image Updater** watches the registry for new tags matching the configured pattern (e.g. `^main-[a-f0-9]+$`) and writes the latest tag back to the overlay `values.yaml`. This is the live rollout mechanism and is unchanged.
 
@@ -133,8 +144,67 @@ image:
 
 ```starlark
 # charts/todo/BUILD
-load("//rules_helm:defs.bzl", "helm_chart", "helm_image_values")
+load("//rules_helm:defs.bzl", "helm_chart")
 
+helm_chart(
+    name = "chart",
+    publish = True,
+    images = {
+        "image": "//charts/todo/image:image",
+    },
+    visibility = ["//overlays/prod/todo:__pkg__"],
+)
+```
+
+```yaml
+# charts/todo/values.yaml
+image:
+  repository: ""  # set by Bazel via images dict
+  tag: ""         # set by Bazel via images dict; ArgoCD Image Updater overrides in overlay
+```
+
+The `image.repository` duplication is eliminated. The `image.tag` in the overlay `values.yaml` is still managed by ArgoCD Image Updater at runtime — the Bazel-generated values are used for CI template testing and as the initial seed when a service is first deployed.
+
+### Multi-image chart
+
+A chart deploying multiple images is just a bigger dict — no extra targets:
+
+```starlark
+# charts/trips/BUILD
+load("//rules_helm:defs.bzl", "helm_chart")
+
+helm_chart(
+    name = "chart",
+    publish = True,
+    images = {
+        "image":         "//services/trips/api/image:image",
+        "sidecar.image": "//services/trips/sidecar:image",
+    },
+    visibility = ["//overlays/prod/trips:__pkg__"],
+)
+```
+
+This generates:
+
+```yaml
+image:
+  repository: ghcr.io/jomcgi/homelab/services/trips/api
+  tag: main-abc1234
+sidecar:
+  image:
+    repository: ghcr.io/jomcgi/homelab/services/trips/sidecar
+    tag: main-abc1234
+```
+
+---
+
+## What was considered and rejected
+
+### `helm_image_values` as a separate rule
+
+A previous version of this RFC proposed a standalone `helm_image_values` target wired into `helm_chart` via an `image_values` attribute:
+
+```starlark
 helm_image_values(
     name = "image_values",
     image = "//charts/todo/image:image_stamped_ci.tags.txt",
@@ -143,42 +213,12 @@ helm_image_values(
 
 helm_chart(
     name = "chart",
-    publish = True,
     image_values = ":image_values",
-    visibility = ["//overlays/prod/todo:__pkg__"],
+    ...
 )
 ```
 
-```yaml
-# charts/todo/values.yaml
-image:
-  repository: ""  # set by Bazel via :image_values
-  tag: ""         # set by Bazel via :image_values; ArgoCD Image Updater overrides in overlay
-```
-
-The `image.repository` duplication is eliminated. The `image.tag` in the overlay `values.yaml` is still managed by ArgoCD Image Updater at runtime — the Bazel-generated values are used for CI template testing and as the initial seed when a service is first deployed.
-
-### Multi-image chart
-
-For charts deploying multiple images (e.g. API + sidecar), add one `helm_image_values` target per image and pass them both to `helm_chart`:
-
-```starlark
-helm_image_values(
-    name = "api_image_values",
-    image = "//services/trips/api/image:image_stamped_ci.tags.txt",
-    repository = "ghcr.io/jomcgi/homelab/services/trips/api",
-)
-
-helm_image_values(
-    name = "imgproxy_image_values",
-    image = "//services/trips/imgproxy/image:image_stamped_ci.tags.txt",
-    repository = "ghcr.io/jomcgi/homelab/services/trips/imgproxy",
-)
-```
-
----
-
-## What was considered and rejected
+**Rejected because the `images` dict is strictly better DX.** The separate target is unnecessary boilerplate: callers must declare an intermediate target per image and manually supply the `repository` string (duplicating what's already in the image macro). The `images` dict eliminates both: `helm_chart` reads `OciImageInfo.repository` directly from the image label, and no intermediate target is needed. `helm_image_values` works, but it adds ceremony with no benefit.
 
 ### Digest pinning
 
@@ -190,26 +230,20 @@ An earlier version of this RFC proposed using `{name}.digest` targets from `rule
 
 2. **Breaks Kargo.** Kargo promotion pipelines operate on tags. Digest-only references are not supported by Kargo's OCI repository subscriptions without significant reconfiguration.
 
-3. **Developer opacity.** `sha256:3f2e1a4b8c9d…` carries no human-readable signal. `main-abc1234` immediately communicates branch, recency, and traceability to a commit. Readable values are better for GitOps workflows where developers inspect and reason about what's deployed.
+3. **Developer opacity.** `sha256:3f2e1a4b8c9d…` carries no human-readable signal. `main-abc1234` immediately communicates branch, recency, and traceability to a commit.
 
 Stamp tags are the correct primitive. Digest references are appropriate for security-critical supply chain use cases (SBOM pinning, policy enforcement), but that is out of scope for this repo's current needs.
-
-### `{name}.repository` genrule
-
-Also proposed in the earlier RFC: emit the repository URL as a Bazel file artifact from each image macro so downstream rules could depend on it at build time.
-
-**Rejected because it's unnecessary.** The `helm_image_values` rule takes `repository` as a string attribute. The repository URL is stable — it only changes if the image is renamed, at which point both the `apko_image` / `go_image` call and the `helm_image_values` call need updating anyway. There is no runtime derivation needed; a string argument is sufficient and simpler.
 
 ---
 
 ## Implementation plan
 
-Three small steps:
+Four steps:
 
 | Step | File | Effort |
 |---|---|---|
-| **1** | `rules_helm/image_values.bzl` — new `helm_image_values` rule | Small |
-| **2** | `rules_helm/chart.bzl` — add optional `image_values` attr to `helm_chart` | Small |
+| **1** | `tools/oci/go_image.bzl` + `apko_image.bzl` — add `{name}.repository` output and return `OciImageInfo` | Small |
+| **2** | `rules_helm/chart.bzl` — add `images` dict attr; read `OciImageInfo` → generate merged values fragment | Small |
 | **3** | Pilot on `charts/todo`, then roll out to other first-party charts | Mechanical |
 
-Start with steps 1–2 as a single PR. Pilot separately. The rule is simple enough to implement and test in under a day.
+Steps 1–2 land as a single PR. Pilot separately. The rule is simple enough to implement and test in under a day.


### PR DESCRIPTION
## Summary

Revises `docs/rfcs/helm-image-wiring.md` to replace the `helm_image_values` separate-target design with a first-class `images` dict attribute on `helm_chart`.

## What changed

The previous RFC introduced a standalone `helm_image_values` rule that callers wired into `helm_chart` via an `image_values` attribute. This revision replaces that with a cleaner API:

```starlark
helm_chart(
    name = "chart",
    publish = True,
    images = {
        "image":         "//charts/todo/image:image",
        "sidecar.image": "//services/trips/sidecar:image",
    },
)
```

Key changes:

1. **`images` dict on `helm_chart`** — dict keys are dot-notation Helm values paths; dict values are Bazel image labels. `helm_chart` resolves each to repository + stamp tag and generates the merged values fragment itself. No separate targets needed.

2. **`OciImageInfo` provider** — standardises the interface between image macros and `helm_chart`. Each image macro (`go_image`, `apko_image`) exposes `{name}.repository` + `{name}.tags.txt` and returns `OciImageInfo`. `helm_chart` reads these generically — no knowledge of image macro internals required.

3. **Multi-image charts are just a bigger dict** — previously required one `helm_image_values` target per image. Now it's more entries in the `images` dict and nothing else.

4. **`helm_image_values` moved to "considered and rejected"** — it works, but the `images` dict is strictly better DX: no intermediate targets, no manually duplicated repository strings.

5. **Everything else preserved** — stamp rationale, CI ordering guarantee (PR #932), ArgoCD Image Updater and Kargo compatibility. That reasoning is sound and unchanged.

## Test plan

- [ ] Read the revised RFC and verify the design is sound
- [ ] Confirm `OciImageInfo` provider fields match actual `go_image` / `apko_image` output conventions
- [ ] Follow up with implementation PR (steps 1–2: add `OciImageInfo` to image macros + `images` attr to `chart.bzl`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
