### PR TITLE
fix(agent-orchestrator): prevent ghost NATS messages from blocking job dispatch

### DIFF
--- a/services/agent-orchestrator/consumer.go
+++ b/services/agent-orchestrator/consumer.go
@@ -89,8 +89,11 @@ func (c *Consumer) processJob(ctx context.Context, msg jetstream.Msg) {
 		return
 	}
 
-	if job.Status == JobCancelled {
-		logger.Info("skipping cancelled job")
+	// Only process jobs in PENDING state. RUNNING means another attempt is
+	// active (e.g. NATS redelivery after restart); SUCCEEDED/FAILED are terminal.
+	// This prevents duplicate long-running jobs after orchestrator restarts.
+	if job.Status != JobPending {
+		logger.Info("skipping job, not in pending state", "status", job.Status)
 		_ = msg.Ack()
 		return
 	}
@@ -137,7 +140,9 @@ func (c *Consumer) processJob(ctx context.Context, msg jetstream.Msg) {
 		resultCh <- sandboxResult{r, err}
 	}()
 
-	// Periodic output flush.
+	// Periodic output flush and NATS ack deadline extension.
+	// InProgress() resets the AckWait timer so NATS doesn't redeliver the
+	// message while the job is still actively running.
 	ticker := time.NewTicker(30 * time.Second)
 	defer ticker.Stop()
 
@@ -148,6 +153,7 @@ loop:
 		case res = <-resultCh:
 			break loop
 		case <-ticker.C:
+			_ = msg.InProgress()
 			c.flushOutput(jobCtx, jobID, outputBuf)
 		}
 	}

--- a/services/agent-orchestrator/consumer_test.go
+++ b/services/agent-orchestrator/consumer_test.go
@@ -224,6 +224,58 @@ func TestProcessJob_SkipsCancelledJob(t *testing.T) {
 	}
 }
 
+func TestProcessJob_SkipsRunningJob(t *testing.T) {
+	store := newMemStore()
+	job := pendingJob("JOB-ALREADY-RUNNING")
+	job.Status = JobRunning
+	_ = store.Put(context.Background(), job)
+
+	msg := newFakeMsg([]byte(job.ID))
+	executed := false
+	sandbox := &fakeSandbox{
+		runFn: func(_ context.Context, _, _, _ string, _ func() bool, _ *syncBuffer) (*ExecResult, error) {
+			executed = true
+			return &ExecResult{ExitCode: 0}, nil
+		},
+	}
+
+	c := newTestConsumer(store, sandbox)
+	c.processJob(context.Background(), msg)
+
+	if executed {
+		t.Fatal("sandbox should not execute for an already-running job")
+	}
+	if !msg.acked.Load() {
+		t.Fatal("expected ACK for already-running job")
+	}
+}
+
+func TestProcessJob_SkipsSucceededJob(t *testing.T) {
+	store := newMemStore()
+	job := pendingJob("JOB-ALREADY-DONE")
+	job.Status = JobSucceeded
+	_ = store.Put(context.Background(), job)
+
+	msg := newFakeMsg([]byte(job.ID))
+	executed := false
+	sandbox := &fakeSandbox{
+		runFn: func(_ context.Context, _, _, _ string, _ func() bool, _ *syncBuffer) (*ExecResult, error) {
+			executed = true
+			return &ExecResult{ExitCode: 0}, nil
+		},
+	}
+
+	c := newTestConsumer(store, sandbox)
+	c.processJob(context.Background(), msg)
+
+	if executed {
+		t.Fatal("sandbox should not execute for a succeeded job")
+	}
+	if !msg.acked.Load() {
+		t.Fatal("expected ACK for succeeded job")
+	}
+}
+
 func TestProcessJob_CancelledDuringExecution(t *testing.T) {
 	store := newMemStore()
 	job := pendingJob("JOB-CANCEL-MID")

--- a/services/agent-orchestrator/main.go
+++ b/services/agent-orchestrator/main.go
@@ -90,7 +90,7 @@ func main() {
 		Durable:       "orchestrator",
 		AckPolicy:     jetstream.AckExplicitPolicy,
 		MaxAckPending: maxConcurrent,
-		AckWait:       maxDuration + time.Minute,
+		AckWait:       2 * time.Minute,
 	})
 	if err != nil {
 		logger.Error("failed to create consumer", "error", err)
@@ -141,7 +141,7 @@ func main() {
 	// runners (HTTP) or may be truly orphaned. Check runner status first,
 	// then reset stale jobs for retry.
 	if sandbox != nil {
-		reconcileOrphanedJobs(ctx, store, publish, sandbox.dynClient, sandboxNamespace, sandbox.CheckRunnerForClaim, logger)
+		reconcileOrphanedJobs(ctx, store, sandbox.dynClient, sandboxNamespace, sandbox.CheckRunnerForClaim, logger)
 	}
 
 	// Start consumer if sandbox is available.

--- a/services/agent-orchestrator/reconcile.go
+++ b/services/agent-orchestrator/reconcile.go
@@ -29,8 +29,8 @@ type RunnerStatusFunc func(ctx context.Context, sandboxClaimName string) (state 
 //  2. If checkRunner is nil, returns error, or returns "idle":
 //     - Clean up stale SandboxClaim
 //     - Reset to PENDING for retry (or FAILED if retries exhausted)
-//     - Re-publish to NATS stream
-func reconcileOrphanedJobs(ctx context.Context, store Store, publish func(string) error, dynClient dynamic.Interface, namespace string, checkRunner RunnerStatusFunc, logger *slog.Logger) {
+//     - NATS redelivers the message automatically after AckWait expires
+func reconcileOrphanedJobs(ctx context.Context, store Store, dynClient dynamic.Interface, namespace string, checkRunner RunnerStatusFunc, logger *slog.Logger) {
 	jobs, _, err := store.List(ctx, []string{string(JobRunning)}, nil, 100, 0)
 	if err != nil {
 		logger.Error("reconcile: failed to list running jobs", "error", err)
@@ -118,15 +118,14 @@ func reconcileOrphanedJobs(ctx context.Context, store Store, publish func(string
 			continue
 		}
 
+		// Reset to PENDING so the consumer retries when NATS redelivers the
+		// message after AckWait expires. No need to re-publish — NATS handles
+		// redelivery natively, and re-publishing would create duplicates.
 		jlog.Info("reconcile: resetting to pending for retry", "retriesRemaining", retriesRemaining)
 		job.Status = JobPending
 		if err := store.Put(ctx, &job); err != nil {
 			jlog.Error("reconcile: failed to reset job", "error", err)
 			continue
-		}
-
-		if err := publish(job.ID); err != nil {
-			jlog.Error("reconcile: failed to re-publish job", "error", err)
 		}
 	}
 }

--- a/services/agent-orchestrator/reconcile_test.go
+++ b/services/agent-orchestrator/reconcile_test.go
@@ -46,15 +46,10 @@ func TestReconcileOrphanedJobs_ResetsRunningJobs(t *testing.T) {
 		CreatedAt: time.Now(),
 	})
 
-	var republished []string
-	publish := func(jobID string) error {
-		republished = append(republished, jobID)
-		return nil
-	}
-
-	reconcileOrphanedJobs(ctx, store, publish, nil, "goose-sandboxes", nil, slog.Default())
+	reconcileOrphanedJobs(ctx, store, nil, "goose-sandboxes", nil, slog.Default())
 
 	// Both orphaned jobs should be reset to PENDING.
+	// NATS will redeliver the messages automatically after AckWait expires.
 	for _, id := range []string{"job-orphan-1", "job-orphan-2"} {
 		job, err := store.Get(ctx, id)
 		if err != nil {
@@ -71,11 +66,6 @@ func TestReconcileOrphanedJobs_ResetsRunningJobs(t *testing.T) {
 		if last.FinishedAt == nil {
 			t.Errorf("%s: last attempt FinishedAt should be set", id)
 		}
-	}
-
-	// Both should be re-published to NATS.
-	if len(republished) != 2 {
-		t.Fatalf("republished count = %d, want 2", len(republished))
 	}
 
 	// PENDING job should be untouched.
@@ -101,22 +91,11 @@ func TestReconcileOrphanedJobs_ExhaustedRetriesMarksFailed(t *testing.T) {
 		},
 	})
 
-	var republished []string
-	publish := func(jobID string) error {
-		republished = append(republished, jobID)
-		return nil
-	}
-
-	reconcileOrphanedJobs(ctx, store, publish, nil, "goose-sandboxes", nil, slog.Default())
+	reconcileOrphanedJobs(ctx, store, nil, "goose-sandboxes", nil, slog.Default())
 
 	job, _ := store.Get(ctx, "job-exhausted")
 	if job.Status != JobFailed {
 		t.Errorf("status = %s, want FAILED", job.Status)
-	}
-
-	// Should NOT be re-published since retries are exhausted.
-	if len(republished) != 0 {
-		t.Errorf("republished count = %d, want 0", len(republished))
 	}
 }
 
@@ -130,18 +109,8 @@ func TestReconcileOrphanedJobs_NoRunningJobs(t *testing.T) {
 		Status: JobSucceeded,
 	})
 
-	published := false
-	publish := func(string) error {
-		published = true
-		return nil
-	}
-
 	// Should be a no-op.
-	reconcileOrphanedJobs(ctx, store, publish, nil, "goose-sandboxes", nil, slog.Default())
-
-	if published {
-		t.Error("should not have published anything")
-	}
+	reconcileOrphanedJobs(ctx, store, nil, "goose-sandboxes", nil, slog.Default())
 }
 
 func TestReconcileOrphanedJobs_ReAttachRunning(t *testing.T) {
@@ -161,18 +130,12 @@ func TestReconcileOrphanedJobs_ReAttachRunning(t *testing.T) {
 		}},
 	})
 
-	var republished []string
-	publish := func(jobID string) error {
-		republished = append(republished, jobID)
-		return nil
-	}
-
 	// Mock runner that reports goose is still running.
 	checkRunner := func(_ context.Context, claimName string) (string, int, error) {
 		return "running", 0, nil
 	}
 
-	reconcileOrphanedJobs(ctx, store, publish, nil, "goose-sandboxes", checkRunner, slog.Default())
+	reconcileOrphanedJobs(ctx, store, nil, "goose-sandboxes", checkRunner, slog.Default())
 
 	job, err := store.Get(ctx, "job-still-running")
 	if err != nil {
@@ -185,10 +148,6 @@ func TestReconcileOrphanedJobs_ReAttachRunning(t *testing.T) {
 	last := job.Attempts[len(job.Attempts)-1]
 	if last.FinishedAt != nil {
 		t.Errorf("FinishedAt should be nil for still-running job")
-	}
-	// Should NOT be re-published.
-	if len(republished) != 0 {
-		t.Errorf("republished count = %d, want 0", len(republished))
 	}
 }
 
@@ -209,18 +168,12 @@ func TestReconcileOrphanedJobs_CollectsDone(t *testing.T) {
 		}},
 	})
 
-	var republished []string
-	publish := func(jobID string) error {
-		republished = append(republished, jobID)
-		return nil
-	}
-
 	// Mock runner that reports goose finished successfully.
 	checkRunner := func(_ context.Context, claimName string) (string, int, error) {
 		return "done", 0, nil
 	}
 
-	reconcileOrphanedJobs(ctx, store, publish, nil, "goose-sandboxes", checkRunner, slog.Default())
+	reconcileOrphanedJobs(ctx, store, nil, "goose-sandboxes", checkRunner, slog.Default())
 
 	job, err := store.Get(ctx, "job-done-unnoticed")
 	if err != nil {
@@ -235,10 +188,6 @@ func TestReconcileOrphanedJobs_CollectsDone(t *testing.T) {
 	}
 	if last.ExitCode == nil || *last.ExitCode != 0 {
 		t.Errorf("exit code = %v, want 0", last.ExitCode)
-	}
-	// Should NOT be re-published.
-	if len(republished) != 0 {
-		t.Errorf("republished count = %d, want 0", len(republished))
 	}
 }
 
@@ -259,24 +208,19 @@ func TestReconcileOrphanedJobs_FailedRunnerRetries(t *testing.T) {
 		}},
 	})
 
-	var republished []string
-	publish := func(jobID string) error {
-		republished = append(republished, jobID)
-		return nil
-	}
-
 	// Mock runner that reports goose failed.
 	checkRunner := func(_ context.Context, claimName string) (string, int, error) {
 		return "failed", 1, nil
 	}
 
-	reconcileOrphanedJobs(ctx, store, publish, nil, "goose-sandboxes", checkRunner, slog.Default())
+	reconcileOrphanedJobs(ctx, store, nil, "goose-sandboxes", checkRunner, slog.Default())
 
 	job, err := store.Get(ctx, "job-failed-runner")
 	if err != nil {
 		t.Fatalf("Get: %v", err)
 	}
 	// Should be reset to PENDING for retry (has retries remaining).
+	// NATS will redeliver the message automatically after AckWait expires.
 	if job.Status != JobPending {
 		t.Errorf("status = %s, want PENDING", job.Status)
 	}
@@ -286,10 +230,6 @@ func TestReconcileOrphanedJobs_FailedRunnerRetries(t *testing.T) {
 	}
 	if last.FinishedAt == nil {
 		t.Error("FinishedAt should be set")
-	}
-	// Should be re-published for retry.
-	if len(republished) != 1 {
-		t.Errorf("republished count = %d, want 1", len(republished))
 	}
 }
 
@@ -310,33 +250,24 @@ func TestReconcileOrphanedJobs_RunnerUnreachableFallsBack(t *testing.T) {
 		}},
 	})
 
-	var republished []string
-	publish := func(jobID string) error {
-		republished = append(republished, jobID)
-		return nil
-	}
-
 	// Mock runner that is unreachable.
 	checkRunner := func(_ context.Context, claimName string) (string, int, error) {
 		return "", -1, fmt.Errorf("connection refused")
 	}
 
-	reconcileOrphanedJobs(ctx, store, publish, nil, "goose-sandboxes", checkRunner, slog.Default())
+	reconcileOrphanedJobs(ctx, store, nil, "goose-sandboxes", checkRunner, slog.Default())
 
 	job, err := store.Get(ctx, "job-unreachable")
 	if err != nil {
 		t.Fatalf("Get: %v", err)
 	}
 	// Should fall back to existing behavior: reset to PENDING.
+	// NATS will redeliver the message automatically after AckWait expires.
 	if job.Status != JobPending {
 		t.Errorf("status = %s, want PENDING", job.Status)
 	}
 	last := job.Attempts[len(job.Attempts)-1]
 	if last.ExitCode == nil || *last.ExitCode != -1 {
 		t.Errorf("exit code = %v, want -1", last.ExitCode)
-	}
-	// Should be re-published.
-	if len(republished) != 1 {
-		t.Errorf("republished count = %d, want 1", len(republished))
 	}
 }


### PR DESCRIPTION
## Summary

- **Root cause**: `AckWait` was set to `maxDuration + 1min` (168h), meaning unacked messages from crashed orchestrator pods remained "pending" in the NATS durable consumer for up to 7 days, counting against `MaxAckPending` and preventing new jobs from being dispatched
- **Fix**: Shorten `AckWait` to 2 minutes, use `msg.InProgress()` heartbeats (every 30s via existing ticker) to extend the deadline while jobs are actively running. Stale messages from crashed pods now expire in 2 minutes instead of 7 days
- **Status guard**: `processJob` now only processes `PENDING` jobs — skips `RUNNING`/`SUCCEEDED`/`FAILED`/`CANCELLED`, preventing duplicate execution from NATS redelivery
- **Remove re-publish from reconciliation**: NATS redelivery handles retries natively after `AckWait` expires, avoiding duplicate messages in the stream

## Test plan

- [ ] Existing `reconcile_test.go` tests pass (updated to remove publish parameter)
- [ ] New `TestProcessJob_SkipsRunningJob` and `TestProcessJob_SkipsSucceededJob` tests verify status guard
- [ ] CI green
- [ ] After deploy, verify pending jobs get dispatched within ~2 minutes

🤖 Generated with [Claude Code](https://claude.com/claude-code)