### PR TITLE
chore: add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Global code owner — tagged on all PRs (including automated ones)
+* @jomcgi


### PR DESCRIPTION
## Summary
- Adds `.github/CODEOWNERS` with `@jomcgi` as global code owner
- Ensures automatic reviewer tagging on all PRs, including those from CI bots and Claude Code agents

## Test plan
- [x] Verify file is at `.github/CODEOWNERS` (GitHub's expected location)
- [ ] Confirm reviewer auto-assignment on next automated PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)