### PR TITLE
fix(cloudflare-ingress): correct Envoy proxy targetPort to 10080

### DIFF
--- a/projects/platform/cloudflare/ingress/deploy/templates/service.yaml
+++ b/projects/platform/cloudflare/ingress/deploy/templates/service.yaml
@@ -9,7 +9,7 @@ spec:
   type: ClusterIP
   ports:
     - port: {{ .Values.service.port }}
-      targetPort: {{ .Values.gateway.listener.port }}
+      targetPort: {{ add .Values.gateway.listener.port 10000 }}
       protocol: TCP
       name: http
   selector:


### PR DESCRIPTION
## Summary
- Envoy Gateway maps Gateway listener port 80 to container port 10080 (port + 10000 offset)
- The stable `cloudflare-ingress` Service (used by the tunnel catch-all) was targeting port 80 directly on the Envoy proxy pod, where nothing listens
- This caused 502 Bad Gateway for all traffic routed via HTTPRoutes through the Gateway

## Test plan
- [ ] Verify `agents.jomcgi.dev` loads after ArgoCD syncs the updated Service
- [ ] Confirm Endpoints show port 10080 instead of 80

🤖 Generated with [Claude Code](https://claude.com/claude-code)