### PR TITLE
fix(oci-model-cache): use --max-parallel instead of GOMAXPROCS

### DIFF
--- a/operators/oci-model-cache/helm/oci-model-cache-operator/templates/deployment.yaml
+++ b/operators/oci-model-cache/helm/oci-model-cache-operator/templates/deployment.yaml
@@ -82,8 +82,8 @@ spec:
         - name: SYNC_MEMORY_LIMIT
           value: {{ . | quote }}
         {{- end }}
-        {{- with .Values.controllerManager.syncGOMAXPROCS }}
-        - name: SYNC_GOMAXPROCS
+        {{- with .Values.controllerManager.syncMaxParallel }}
+        - name: SYNC_MAX_PARALLEL
           value: {{ . | quote }}
         {{- end }}
         {{- if .Values.controllerManager.tracing.endpoint }}

--- a/operators/oci-model-cache/helm/oci-model-cache-operator/values.yaml
+++ b/operators/oci-model-cache/helm/oci-model-cache-operator/values.yaml
@@ -53,9 +53,9 @@ controllerManager:
   syncMemoryRequest: ""
   syncMemoryLimit: ""
 
-  # -- GOMAXPROCS override for sync Job containers.
-  # Limits OS-thread parallelism to cap concurrent network connections during model upload.
-  syncGOMAXPROCS: ""
+  # -- Max concurrent layer uploads/downloads for sync Job containers.
+  # Passed as --max-parallel to hf2oci (0 or empty = auto from GOMEMLIMIT, fallback 100).
+  syncMaxParallel: ""
 
   env:
     ociRegistry: "ghcr.io/jomcgi/models"

--- a/operators/oci-model-cache/internal/config/config.go
+++ b/operators/oci-model-cache/internal/config/config.go
@@ -42,9 +42,9 @@ type Config struct {
 	// SyncMemoryLimit is the Kubernetes memory limit for sync Job containers (e.g. "2Gi").
 	SyncMemoryLimit string
 
-	// SyncGOMAXPROCS overrides GOMAXPROCS for sync Job containers, capping
-	// OS-thread parallelism to limit concurrent network connections.
-	SyncGOMAXPROCS string
+	// SyncMaxParallel caps concurrent layer uploads/downloads in sync Job
+	// containers via the hf2oci --max-parallel flag (0 = auto from GOMEMLIMIT).
+	SyncMaxParallel string
 }
 
 // BindFlags registers config flags on the given FlagSet.
@@ -66,7 +66,7 @@ func (c *Config) BindFlags(fs *flag.FlagSet) {
 	}
 	c.SyncMemoryRequest = envOrDefault("SYNC_MEMORY_REQUEST", "")
 	c.SyncMemoryLimit = envOrDefault("SYNC_MEMORY_LIMIT", "")
-	c.SyncGOMAXPROCS = envOrDefault("SYNC_GOMAXPROCS", "")
+	c.SyncMaxParallel = envOrDefault("SYNC_MAX_PARALLEL", "")
 }
 
 func envOrDefault(key, fallback string) string {

--- a/operators/oci-model-cache/internal/controller/job_builder.go
+++ b/operators/oci-model-cache/internal/controller/job_builder.go
@@ -39,6 +39,9 @@ func buildCopyJob(mc *v1alpha1.ModelCache, cfg config.Config) *batchv1.Job {
 	if mc.Spec.ModelDir != "" {
 		args = append(args, "--model-dir", mc.Spec.ModelDir)
 	}
+	if cfg.SyncMaxParallel != "" {
+		args = append(args, "--max-parallel", cfg.SyncMaxParallel)
+	}
 
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
@@ -113,13 +116,6 @@ func buildCopyJob(mc *v1alpha1.ModelCache, cfg config.Config) *batchv1.Job {
 			)
 		}
 		job.Spec.Template.Spec.Containers[0].Resources = resources
-	}
-
-	if cfg.SyncGOMAXPROCS != "" {
-		job.Spec.Template.Spec.Containers[0].Env = append(
-			job.Spec.Template.Spec.Containers[0].Env,
-			corev1.EnvVar{Name: "GOMAXPROCS", Value: cfg.SyncGOMAXPROCS},
-		)
 	}
 
 	if cfg.SyncServiceAccount != "" {

--- a/operators/oci-model-cache/internal/controller/job_builder_test.go
+++ b/operators/oci-model-cache/internal/controller/job_builder_test.go
@@ -217,29 +217,27 @@ func TestBuildCopyJob_NoResourcesWhenUnset(t *testing.T) {
 	assert.Empty(t, resources.Limits)
 }
 
-// TestBuildCopyJob_GOMAXPROCSEnv verifies GOMAXPROCS is set when SyncGOMAXPROCS is configured.
-func TestBuildCopyJob_GOMAXPROCSEnv(t *testing.T) {
+// TestBuildCopyJob_MaxParallelArg verifies --max-parallel is added to args when configured.
+func TestBuildCopyJob_MaxParallelArg(t *testing.T) {
 	mc := minimalModelCache()
 	cfg := minimalConfig()
-	cfg.SyncGOMAXPROCS = "8"
+	cfg.SyncMaxParallel = "8"
 
 	job := buildCopyJob(mc, cfg)
-	envVars := job.Spec.Template.Spec.Containers[0].Env
+	args := job.Spec.Template.Spec.Containers[0].Args
 
-	goMaxProcs := findEnv(envVars, "GOMAXPROCS")
-	assert.Equal(t, "8", goMaxProcs)
+	assertConsecutive(t, args, "--max-parallel", "8")
 }
 
-// TestBuildCopyJob_NoGOMAXPROCSWhenEmpty verifies GOMAXPROCS is not set when unconfigured.
-func TestBuildCopyJob_NoGOMAXPROCSWhenEmpty(t *testing.T) {
+// TestBuildCopyJob_NoMaxParallelWhenEmpty verifies --max-parallel is not added when unconfigured.
+func TestBuildCopyJob_NoMaxParallelWhenEmpty(t *testing.T) {
 	mc := minimalModelCache()
 	cfg := minimalConfig()
 
 	job := buildCopyJob(mc, cfg)
-	envVars := job.Spec.Template.Spec.Containers[0].Env
+	args := job.Spec.Template.Spec.Containers[0].Args
 
-	goMaxProcs := findEnv(envVars, "GOMAXPROCS")
-	assert.Empty(t, goMaxProcs)
+	assert.NotContains(t, args, "--max-parallel")
 }
 
 // TestBuildCopyJob_NodeSelector verifies node selectors are applied when configured.

--- a/overlays/dev/grimoire/values.yaml
+++ b/overlays/dev/grimoire/values.yaml
@@ -4,16 +4,16 @@
 imageUpdater:
   enabled: true
   images:
-  - alias: frontend
-    imageName: ghcr.io/jomcgi/homelab/services/grimoire-frontend:main
-    helm:
-      name: frontend.image.repository
-      tag: frontend.image.tag
-  - alias: ws-gateway
-    imageName: ghcr.io/jomcgi/homelab/services/grimoire-ws-gateway:main
-    helm:
-      name: wsGateway.image.repository
-      tag: wsGateway.image.tag
+    - alias: frontend
+      imageName: ghcr.io/jomcgi/homelab/services/grimoire-frontend:main
+      helm:
+        name: frontend.image.repository
+        tag: frontend.image.tag
+    - alias: ws-gateway
+      imageName: ghcr.io/jomcgi/homelab/services/grimoire-ws-gateway:main
+      helm:
+        name: wsGateway.image.repository
+        tag: wsGateway.image.tag
   writeBack:
     method: git:secret:argocd/argocd-image-updater-token
     repository: https://github.com/jomcgi/homelab.git

--- a/overlays/dev/marine/values.yaml
+++ b/overlays/dev/marine/values.yaml
@@ -4,21 +4,21 @@
 imageUpdater:
   enabled: true
   images:
-  - alias: ingest
-    imageName: ghcr.io/jomcgi/homelab/services/ais_ingest:main
-    helm:
-      name: ingest.image.repository
-      tag: ingest.image.tag
-  - alias: api
-    imageName: ghcr.io/jomcgi/homelab/services/ships_api:main
-    helm:
-      name: api.image.repository
-      tag: api.image.tag
-  - alias: frontend
-    imageName: ghcr.io/jomcgi/homelab/services/ships_frontend:main
-    helm:
-      name: frontend.image.repository
-      tag: frontend.image.tag
+    - alias: ingest
+      imageName: ghcr.io/jomcgi/homelab/services/ais_ingest:main
+      helm:
+        name: ingest.image.repository
+        tag: ingest.image.tag
+    - alias: api
+      imageName: ghcr.io/jomcgi/homelab/services/ships_api:main
+      helm:
+        name: api.image.repository
+        tag: api.image.tag
+    - alias: frontend
+      imageName: ghcr.io/jomcgi/homelab/services/ships_frontend:main
+      helm:
+        name: frontend.image.repository
+        tag: frontend.image.tag
   writeBack:
     method: git:secret:argocd/argocd-image-updater-token
     repository: https://github.com/jomcgi/homelab.git
@@ -29,7 +29,7 @@ imagePullSecret:
   enabled: true
 # Configure pods to use the image pull secret
 imagePullSecrets:
-- name: ghcr-imagepull-secret
+  - name: ghcr-imagepull-secret
 # AIS Ingest component
 ingest:
   image:

--- a/overlays/dev/oci-model-cache/values.yaml
+++ b/overlays/dev/oci-model-cache/values.yaml
@@ -1,5 +1,5 @@
 imagePullSecrets:
-- name: ghcr-pull-secret
+  - name: ghcr-pull-secret
 controllerManager:
   image:
     repository: ghcr.io/jomcgi/homelab/operators/oci-model-cache
@@ -17,7 +17,7 @@ controllerManager:
     kubernetes.io/hostname: node-4
   syncMemoryRequest: "4Gi"
   syncMemoryLimit: "8Gi"
-  syncGOMAXPROCS: "8"
+  syncMaxParallel: "8"
   env:
     ociRegistry: "ghcr.io/jomcgi/models"
 registryPushSecret: "oci-model-cache-operator-hf-token"
@@ -29,21 +29,21 @@ hfToken:
 imageUpdater:
   enabled: true
   images:
-  - alias: operator
-    imageName: ghcr.io/jomcgi/homelab/operators/oci-model-cache:main
-    helm:
-      name: controllerManager.image.repository
-      tag: controllerManager.image.tag
+    - alias: operator
+      imageName: ghcr.io/jomcgi/homelab/operators/oci-model-cache:main
+      helm:
+        name: controllerManager.image.repository
+        tag: controllerManager.image.tag
   writeBack:
     method: git:secret:argocd/argocd-image-updater-token
     repository: https://github.com/jomcgi/homelab.git
     branch: main
     target: helmvalues:../../../../overlays/dev/oci-model-cache/values.yaml
 extraResources:
-- apiVersion: onepassword.com/v1
-  kind: OnePasswordItem
-  metadata:
-    name: ghcr-pull-secret
-  spec:
-    itemPath: "vaults/k8s-homelab/items/argocd-image-updater"
-  type: "kubernetes.io/dockerconfigjson"
+  - apiVersion: onepassword.com/v1
+    kind: OnePasswordItem
+    metadata:
+      name: ghcr-pull-secret
+    spec:
+      itemPath: "vaults/k8s-homelab/items/argocd-image-updater"
+    type: "kubernetes.io/dockerconfigjson"

--- a/overlays/dev/stargazer/values.yaml
+++ b/overlays/dev/stargazer/values.yaml
@@ -4,11 +4,11 @@
 imageUpdater:
   enabled: true
   images:
-  - alias: stargazer
-    imageName: ghcr.io/jomcgi/homelab/services/stargazer:main
-    helm:
-      name: image.repository
-      tag: image.tag
+    - alias: stargazer
+      imageName: ghcr.io/jomcgi/homelab/services/stargazer:main
+      helm:
+        name: image.repository
+        tag: image.tag
   writeBack:
     method: git:secret:argocd/argocd-image-updater-token
     repository: https://github.com/jomcgi/homelab.git
@@ -64,7 +64,7 @@ imagePullSecret:
   enabled: true
 # Configure pods to use the image pull secret
 imagePullSecrets:
-- name: ghcr-imagepull-secret
+  - name: ghcr-imagepull-secret
 # Pre-populate OTEL annotation to match Kyverno injection (prevents ArgoCD drift)
 podAnnotations:
   otel.injected-by: kyverno/inject-otel-env-vars


### PR DESCRIPTION
## Summary
- **GOMAXPROCS doesn't control hf2oci parallelism** — it only limits OS threads, not goroutine I/O concurrency. The tool's `AutoParallel()` derives concurrency from `GOMEMLIMIT`, so the previous fix had no effect (~52 concurrent streams still caused TLS handshake timeouts).
- Replaces the `SYNC_GOMAXPROCS` env var with `SYNC_MAX_PARALLEL`, which maps to hf2oci's `--max-parallel` CLI flag — directly capping concurrent layer uploads/downloads.
- Dev overlay sets `syncMaxParallel: "8"` (same value as the old GOMAXPROCS setting, but now actually enforced).

## Changes
- `config.go`: `SyncGOMAXPROCS` → `SyncMaxParallel`, `SYNC_GOMAXPROCS` → `SYNC_MAX_PARALLEL`
- `job_builder.go`: Removed GOMAXPROCS env var injection, added `--max-parallel` to Job args
- `job_builder_test.go`: Updated tests to verify `--max-parallel` in args instead of GOMAXPROCS env
- `deployment.yaml` + `values.yaml` (chart + overlay): Updated Helm template and values

## Test plan
- [ ] CI passes (unit tests updated)
- [ ] After merge + image rebuild, verify new sync Jobs include `--max-parallel 8` in args
- [ ] Confirm model sync completes without TLS handshake timeouts

🤖 Generated with [Claude Code](https://claude.com/claude-code)