### PR TITLE
fix(ci): use ancestor check for main branch detection

### DIFF
--- a/bazel/tools/workspace_status.sh
+++ b/bazel/tools/workspace_status.sh
@@ -49,14 +49,17 @@ else
 	branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
 fi
 
-# Safety check: if env says "main" but HEAD isn't actually origin/main,
+# Safety check: if env says "main" but HEAD isn't actually on the main branch,
 # we're in a PR build where the CI set GIT_BRANCH to the target branch.
 # Fall back to a commit-derived tag to avoid overwriting the "main" image.
+#
+# Uses ancestor check instead of exact SHA comparison because origin/main may
+# advance (e.g. image-updater auto-commits) while CI is running, causing the
+# exact check to falsely reject legitimate main builds.
 if [ "${branch}" = "main" ]; then
-	main_sha=$(git rev-parse origin/main 2>/dev/null || echo "")
-	if [ -n "$main_sha" ] && [ "$git_commit" != "$main_sha" ]; then
+	if ! git merge-base --is-ancestor "$git_commit" origin/main 2>/dev/null; then
 		branch="pr-${git_short_sha}"
-		>&2 echo "workspace_status.sh: HEAD (${git_short_sha}) != origin/main, using branch='${branch}'"
+		>&2 echo "workspace_status.sh: HEAD (${git_short_sha}) is not an ancestor of origin/main, using branch='${branch}'"
 	fi
 fi
 


### PR DESCRIPTION
## Summary

- The workspace status script compared `HEAD == origin/main` to verify main branch builds, but this exact SHA check fails when `origin/main` advances during CI (e.g. image-updater auto-commits)
- Main branch builds were being tagged as `pr-<sha>` instead of `main`, so ArgoCD Image Updater never picked up new images — causing **buildbuddy-mcp** (and potentially other services) to stay on stale images
- Replaced with `git merge-base --is-ancestor` which correctly identifies any commit that was on main, regardless of subsequent commits

## Test plan

- [ ] CI passes on this PR (workspace status produces correct `pr-*` or `feat-*` tags for the PR build)
- [ ] After merge, verify the next main build tags images with `main` (check `crane ls ghcr.io/jomcgi/homelab/services/buildbuddy-mcp` for a fresh `main` tag)
- [ ] Confirm ArgoCD Image Updater picks up the new buildbuddy-mcp image and the pod recovers from CrashLoopBackOff

🤖 Generated with [Claude Code](https://claude.com/claude-code)