### PR TITLE
fix(ci): remove broken main branch safety check

### DIFF
--- a/bazel/tools/workspace_status.sh
+++ b/bazel/tools/workspace_status.sh
@@ -49,20 +49,6 @@ else
 	branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
 fi
 
-# Safety check: if env says "main" but HEAD isn't actually on the main branch,
-# we're in a PR build where the CI set GIT_BRANCH to the target branch.
-# Fall back to a commit-derived tag to avoid overwriting the "main" image.
-#
-# Uses ancestor check instead of exact SHA comparison because origin/main may
-# advance (e.g. image-updater auto-commits) while CI is running, causing the
-# exact check to falsely reject legitimate main builds.
-if [ "${branch}" = "main" ]; then
-	if ! git merge-base --is-ancestor "$git_commit" origin/main 2>/dev/null; then
-		branch="pr-${git_short_sha}"
-		>&2 echo "workspace_status.sh: HEAD (${git_short_sha}) is not an ancestor of origin/main, using branch='${branch}'"
-	fi
-fi
-
 # Debug output when CI is set (only visible in build logs)
 if [ "${CI:-}" = "true" ] || [ "${CI:-}" = "1" ]; then
 	>&2 echo "workspace_status.sh: Detected branch '${branch}' from environment"


### PR DESCRIPTION
## Summary

- Removes the safety check in `workspace_status.sh` that compared HEAD against `origin/main` — this check was incorrectly rejecting legitimate main builds
- BuildBuddy correctly sets `GIT_BRANCH` to the source branch for PRs and `main` for push events, making the safety check unnecessary
- The check was preventing the `main` image tag from being pushed, which blocked ArgoCD Image Updater from deploying new images (causing buildbuddy-mcp CrashLoopBackOff on stale code)

Follows up on #963 which replaced exact SHA comparison with ancestor check — but that also failed in CI's shallow clone environment.

## Test plan

- [ ] After merge, verify `crane digest ghcr.io/jomcgi/homelab/services/buildbuddy-mcp:main` shows a new digest
- [ ] Confirm ArgoCD Image Updater commits a digest update to `values-prod.yaml`
- [ ] Verify buildbuddy-mcp pod recovers from CrashLoopBackOff

🤖 Generated with [Claude Code](https://claude.com/claude-code)