### PR TITLE
fix(linkerd): stop selfHeal rollout loop

### DIFF
--- a/projects/platform/linkerd/application.yaml
+++ b/projects/platform/linkerd/application.yaml
@@ -18,6 +18,14 @@ spec:
   destination:
     server: https://kubernetes.default.svc
     namespace: linkerd
+  ignoreDifferences:
+    - group: apps
+      kind: Deployment
+      jqPathExpressions:
+        - .spec.template.metadata.annotations
+        - .spec.template.spec.containers
+        - .spec.template.spec.initContainers
+        - .spec.template.spec.volumes
   syncPolicy:
     automated:
       prune: true


### PR DESCRIPTION
## Summary
- Adds `ignoreDifferences` to the Linkerd ArgoCD Application to prevent the proxy injector webhook mutations from triggering infinite selfHeal syncs
- The webhook-mutated fields (annotations, containers, initContainers, volumes) on Deployments in the linkerd namespace are now ignored during diff comparison
- This stops the rollout churn that was creating ~11 ReplicaSets every 80 minutes and causing `Failed to connect` / `Unexpected policy controller response` warnings across all meshed proxy sidecars

## Context
ArgoCD's `selfHeal: true` + `ServerSideApply=true` was fighting with the Linkerd proxy injector MutatingWebhookConfiguration. Each sync applied the Helm-rendered Deployment, the webhook mutated the pod template, ArgoCD detected drift, and re-synced — creating a feedback loop that continuously rolled the destination and proxy-injector pods.

## Test plan
- [ ] CI passes
- [ ] After merge, verify the linkerd ArgoCD app stabilizes (no more rapid `Synced → OutOfSync` cycling)
- [ ] Confirm `linkerd-destination` ReplicaSet count stops growing
- [ ] Check proxy logs on a sample pod (e.g. `api-gateway`) for absence of new `Failed to connect` bursts

🤖 Generated with [Claude Code](https://claude.com/claude-code)