### PR TITLE
chore: remove clusters/homelab redirect after ArgoCD cutover

### DIFF
--- a/clusters/homelab/kustomization.yaml
+++ b/clusters/homelab/kustomization.yaml
@@ -1,5 +1,0 @@
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-
-resources:
-  - ../../projects/home-cluster

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -51,8 +51,7 @@ This is a GitOps monorepo where related code and deployment configuration live t
                                  ▼
 ┌─────────────────────────────────────────────────────────────────────┐
 │  Step 4: ArgoCD Auto-Discovery                                      │
-│  clusters/homelab/kustomization.yaml redirects to                    │
-│  projects/home-cluster/ which lists all deploy/ dirs.                │
+│  projects/home-cluster/kustomization.yaml lists all deploy/ dirs.    │
 │                                                                      │
 │  The "canada" Application is the root app-of-apps.                   │
 │  ArgoCD runs "kustomize build" and discovers all                     │

--- a/projects/platform/argocd/README.md
+++ b/projects/platform/argocd/README.md
@@ -30,9 +30,8 @@ flowchart LR
 ArgoCD discovers applications through the `projects/home-cluster/` auto-discovery pattern:
 
 ```
-clusters/homelab/kustomization.yaml (redirect)
-  → projects/home-cluster/kustomization.yaml (auto-generated)
-    → projects/{service}/deploy/application.yaml
+projects/home-cluster/kustomization.yaml (auto-generated)
+  → projects/{service}/deploy/application.yaml
 ```
 
 Each `application.yaml` points to its colocated Helm chart in `projects/{service}/chart/`.


### PR DESCRIPTION
## Summary
- Deletes `clusters/homelab/kustomization.yaml` — the redirect that pointed to `projects/home-cluster/`
- The ArgoCD "canada" root app was updated to watch `projects/home-cluster/` directly, making this redirect dead code
- Updates `docs/contributing.md` and `projects/platform/argocd/README.md` to remove stale references

## Context
This is a follow-up to PR #975 (ArgoCD colocation). After the canada app's source path was changed in the ArgoCD UI, the `clusters/homelab/` directory serves no purpose.

## Test plan
- [x] Verified canada app is Synced + Healthy pointing at `projects/home-cluster/`
- [ ] CI passes (no BUILD files reference `clusters/`)
- [ ] ArgoCD continues syncing normally after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)