### PR TITLE
fix(cluster-agents): add severity label to alert, switch to RollingUpdate

### DIFF
--- a/projects/agent_platform/cluster_agents/deploy/httpcheck-alert.yaml
+++ b/projects/agent_platform/cluster_agents/deploy/httpcheck-alert.yaml
@@ -23,7 +23,8 @@ data:
       "severity": "critical",
       "labels": {
         "service": "cluster-agents",
-        "environment": "production"
+        "environment": "production",
+        "severity": "critical"
       },
       "annotations": {
         "summary": "cluster-agents at http://cluster-agents.cluster-agents.svc.cluster.local:8080/health is unreachable",

--- a/projects/agent_platform/cluster_agents/deploy/templates/deployment.yaml
+++ b/projects/agent_platform/cluster_agents/deploy/templates/deployment.yaml
@@ -7,7 +7,10 @@ metadata:
 spec:
   replicas: {{ .Values.replicaCount }}
   strategy:
-    type: Recreate
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
   selector:
     matchLabels:
       {{- include "cluster-agents.selectorLabels" . | nindent 6 }}


### PR DESCRIPTION
## Summary

Fixes two recurring bugs in cluster-agents that caused the \"cluster-agents Unreachable\" alert to misbehave. Both were identified in incident [#910](https://github.com/jomcgi/homelab/issues/910) (2026-03-08) but were never applied, surviving the repo reorganizations in PRs #951 and #975.

- **Bug 1 — Wrong severity escalation**: `httpcheck-alert.yaml` sets `"severity": "critical"` at the top-level rule field but NOT inside the `labels{}` map. The patrol agent reads severity via `rule.Labels["severity"]`, so `mapSeverity("")` returns `SeverityInfo` — causing escalated orchestrator jobs to report `Severity: info` instead of `critical`. Fix: add `"severity": "critical"` to the `labels` object.

- **Bug 2 — `Recreate` strategy causes avoidable alerts**: The deployment uses `strategy: Recreate`, creating a hard downtime gap on every image update. During rapid image churn (e.g., two CI pushes ~100s apart), the combined gaps span the full 10-minute eval window, firing the alert for a non-incident. Fix: switch to `RollingUpdate` with `maxSurge: 1, maxUnavailable: 0` so the new pod becomes ready before the old one is killed.

## Context

The **current** alert firing (rule `019cda4d-9837-76b0-b625-0149055459fa`, 2026-03-11 00:35 UTC) was most likely triggered by the ArgoCD app rename in PR #975 (merged 00:30:34 UTC), which caused a brief pod reconciliation gap. ArgoCD should self-heal within minutes — no additional action needed for the outage itself.

## Test plan

- [ ] CI passes
- [ ] After merge, ArgoCD re-applies the ConfigMap — verify SigNoz alert rule shows `severity: critical` in its labels
- [ ] Verify next image update rolls out without downtime (new pod healthy before old is terminated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)