### PR TITLE
fix(docs): add missing ADR 007 and 008 to VitePress sidebar

### DIFF
--- a/projects/websites/docs.jomcgi.dev/.vitepress/config.js
+++ b/projects/websites/docs.jomcgi.dev/.vitepress/config.js
@@ -60,6 +60,14 @@ export default defineConfig({
                 text: "006 - OIDC Auth MCP Gateway",
                 link: "/docs/decisions/agents/006-oidc-auth-mcp-gateway",
               },
+              {
+                text: "007 - Agent Run Orchestration",
+                link: "/docs/decisions/agents/007-agent-orchestrator",
+              },
+              {
+                text: "008 - Cluster Patrol Loop Resilience",
+                link: "/docs/decisions/agents/008-cluster-patrol-loop-resilience",
+              },
             ],
           },
           {


### PR DESCRIPTION
## Summary
- ADRs 007 (Agent Run Orchestration) and 008 (Cluster Patrol Loop Resilience) were added to `docs/decisions/agents/` but never registered in the VitePress sidebar config
- Pages were being built but invisible in the docs.jomcgi.dev navigation
- Adds both entries to the Agents section of the sidebar

## Test plan
- [ ] CI passes (VitePress build succeeds)
- [ ] Verify ADR 007 and 008 appear in sidebar on docs.jomcgi.dev after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)