### PR TITLE
docs: update all documentation for projects/-centric repo structure

### DIFF
--- a/.claude/AGENTS.md
+++ b/.claude/AGENTS.md
@@ -70,15 +70,15 @@ environment:
 
 ```bash
 # Update lock file after modifying apko.yaml
-bazel run @rules_apko//apko -- lock charts/<service>/image/apko.yaml
+bazel run @rules_apko//apko -- lock projects/<service>/image/apko.yaml
 
 # Or run format to update ALL apko locks
 format
 
 # Build / push / run
-bazel build //charts/<service>/image:image
-bazel run //charts/<service>/image:image.push
-bazel run //charts/<service>/image:image.run
+bazel build //projects/<service>/image:image
+bazel run //projects/<service>/image:image.push
+bazel run //projects/<service>/image:image.run
 ```
 
 ### BUILD.bazel Patterns
@@ -91,7 +91,7 @@ load("//bazel/tools/oci:apko_image.bzl", "apko_image")
 
 pkg_tar(
     name = "static_tar",
-    srcs = ["//charts/myservice:static_files"],
+    srcs = ["//projects/myservice:static_files"],
     mode = "0644",
     owner = "65532.65532",
     package_dir = "/app/static",
@@ -101,7 +101,7 @@ apko_image(
     name = "image",
     config = "apko.yaml",
     contents = "@myservice_lock//:contents",
-    repository = "ghcr.io/jomcgi/homelab/charts/myservice",
+    repository = "ghcr.io/jomcgi/homelab/projects/myservice",
     tars = [":static_tar"],
     # multiarch_tars = [":binary_tar"],  # For arch-specific binaries
 )
@@ -115,7 +115,7 @@ load("@aspect_bazel_lib//lib:transitions.bzl", "platform_transition_filegroup")
 
 platform_transition_filegroup(
     name = "binary_amd64",
-    srcs = ["//charts/myservice/cmd"],
+    srcs = ["//projects/myservice/cmd"],
     target_platform = "@rules_go//go/toolchain:linux_amd64",
 )
 
@@ -132,7 +132,7 @@ apko_image(
     config = "apko.yaml",
     contents = "@myservice_lock//:contents",
     multiarch_tars = [":binary_tar"],  # Macro uses _amd64/_arm64 suffixes
-    repository = "ghcr.io/jomcgi/homelab/charts/myservice",
+    repository = "ghcr.io/jomcgi/homelab/projects/myservice",
 )
 ```
 
@@ -142,7 +142,7 @@ apko_image(
 apko = use_extension("@rules_apko//apko:extensions.bzl", "apko")
 apko.translate_lock(
     name = "myservice_lock",
-    lock = "//charts/myservice/image:apko.lock.json",
+    lock = "//projects/myservice/image:apko.lock.json",
 )
 use_repo(apko, "myservice_lock")
 ```
@@ -171,9 +171,9 @@ use_repo(apko, "myservice_lock")
 ### Debugging Image Issues
 
 ```bash
-crane manifest ghcr.io/jomcgi/homelab/charts/myservice:latest | jq
-crane export ghcr.io/jomcgi/homelab/charts/myservice:latest - | tar -tvf - | head -50
-jq '.contents.packages[] | {name, version}' charts/myservice/image/apko.lock.json
+crane manifest ghcr.io/jomcgi/homelab/projects/myservice:latest | jq
+crane export ghcr.io/jomcgi/homelab/projects/myservice:latest - | tar -tvf - | head -50
+jq '.contents.packages[] | {name, version}' projects/myservice/image/apko.lock.json
 ```
 
 ---
@@ -184,7 +184,7 @@ Go development specialist, especially for Kubernetes operators and controllers.
 
 ### Pre-requisite Reading
 
-**Always read first:** `operators/best-practices.md`
+**Always read first:** `projects/operators/best-practices.md`
 
 ### When to Use
 
@@ -196,10 +196,10 @@ Go development specialist, especially for Kubernetes operators and controllers.
 ### Key Commands
 
 ```bash
-bazel build //operators/...
-bazel test //operators/...
+bazel build //projects/operators/...
+bazel test //projects/operators/...
 bazel run //:gazelle          # Update BUILD files after adding imports
-bazel run //operators/<name>/cmd:cmd
+bazel run //projects/operators/<name>/cmd:cmd
 ```
 
 ### Reconcile Return Values
@@ -242,7 +242,7 @@ Kubernetes and cloud-native security specialist.
 ```bash
 trivy image --severity HIGH,CRITICAL <image:tag>     # CVE scanning
 trivy k8s --report summary cluster                   # Manifest scanning
-checkov -d charts/                                    # Policy scanning
+checkov -d projects/                                   # Policy scanning
 gitleaks detect --source .                            # Secret scanning
 cosign sign --key cosign.key <image:tag>              # Image signing
 ```
@@ -252,8 +252,8 @@ cosign sign --key cosign.key <image:tag>              # Image signing
 > **Note:** `kubectl get` and `kubectl describe` are redirected to Kubernetes MCP tools by PreToolUse hooks. Use `kubernetes-mcp-resources-list` and `kubernetes-mcp-resources-get` instead.
 
 ```bash
-helm template kyverno charts/kyverno/ -s templates/linkerd-injection-policy.yaml
-helm template kyverno charts/kyverno/ -s templates/otel-injection-policy.yaml
+helm template kyverno projects/platform/kyverno/ -s templates/linkerd-injection-policy.yaml
+helm template kyverno projects/platform/kyverno/ -s templates/otel-injection-policy.yaml
 ```
 
 ### Pod Security Standards
@@ -425,7 +425,7 @@ Pre-requisite reading is context-dependent — see "Context Loading Rules" in CL
 **Helm Chart Changes:**
 
 - [ ] `values.yaml` has sensible defaults
-- [ ] Templates render: `helm template <release> charts/<chart>/`
+- [ ] Templates render: `helm template <release> projects/<service>/chart/`
 - [ ] Resource limits set, health checks configured
 - [ ] NetworkPolicy in place
 
@@ -508,7 +508,7 @@ Kyverno policies automatically inject OpenTelemetry instrumentation:
 
 ## cloudflare
 
-Cloudflare operator specialist for the custom operator in `operators/cloudflare/`.
+Cloudflare operator specialist for the custom operator in `projects/operators/cloudflare/`.
 
 ### When to Use
 
@@ -519,7 +519,7 @@ Cloudflare operator specialist for the custom operator in `operators/cloudflare/
 
 ### Pre-requisite Reading
 
-**Always read first:** `operators/cloudflare/README.md` and `operators/best-practices.md`
+**Always read first:** `projects/operators/cloudflare/README.md` and `projects/operators/best-practices.md`
 
 ### Architecture
 
@@ -533,7 +533,7 @@ The operator manages cluster ingress via Cloudflare tunnels using a state machin
 ### Key Directories
 
 ```
-operators/cloudflare/
+projects/operators/cloudflare/
 ├── api/v1/                    # CRD type definitions
 ├── internal/
 │   ├── cloudflare/            # Cloudflare API client (dns, access, routes)
@@ -549,8 +549,8 @@ operators/cloudflare/
 > **Note:** `kubectl get` and `describe` are redirected to MCP tools by PreToolUse hooks. Use `kubernetes-mcp-resources-list` and `kubernetes-mcp-resources-get` instead.
 
 ```bash
-bazel build //operators/cloudflare/...
-bazel test //operators/cloudflare/...
+bazel build //projects/operators/cloudflare/...
+bazel test //projects/operators/cloudflare/...
 bazel run //:gazelle                    # After adding Go imports
 
 # Debug tunnel status (via MCP)
@@ -580,8 +580,8 @@ Linkerd service mesh specialist for the mesh running in `cluster-critical`.
 
 ### Key Configuration (This Repo)
 
-- **Deploy config:** `projects/linkerd/deploy/`
-- **Chart:** `charts/linkerd/`
+- **Deploy config:** `projects/platform/linkerd/`
+- **Chart:** `projects/platform/linkerd/`
 - **Injection:** Kyverno policy `inject-linkerd-namespace-annotation` auto-injects namespaces
 - **Priority:** Control plane runs with `system-cluster-critical` priority class
 - **Log level:** Set to `warn` to suppress benign connection-closed messages from health checks

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -9,11 +9,12 @@ Hosted at **https://github.com/jomcgi/homelab**. The `gh` CLI is authenticated.
 ```
 homelab/
 ├── projects/            # All services, operators, websites — colocated with deploy configs
-│   ├── {service}/         # Each service has chart/, deploy/, src/ as needed
+│   ├── platform/          # Cluster-critical infra (ArgoCD, Linkerd, SigNoz, etc.)
+│   ├── agent_platform/    # Agent services (Context Forge, MCP servers, orchestrator)
+│   ├── {service}/         # Each service has chart/, deploy/, backend/ as needed
 │   │   ├── chart/         # Helm chart (if custom)
 │   │   └── deploy/        # ArgoCD Application, values, kustomization
 │   └── home-cluster/      # Auto-generated ArgoCD root kustomization
-├── charts/              # Shared/upstream Helm charts — ls to discover available charts
 ├── bazel/               # All Bazel build infrastructure (rules, tools, images, semgrep)
 ├── docs/               # Design docs, ADRs, and plans — ls to discover available docs
 │   └── decisions/       # Architecture Decision Records — ls decisions/<category>/
@@ -28,11 +29,11 @@ homelab/
 ```bash
 # Local development (no Bazel needed)
 format                        # Format code + update BUILD files (standalone)
-helm template <release> charts/<chart>/ -f projects/<service>/deploy/values.yaml  # Render Helm templates (NEVER helm install)
+helm template <release> projects/<service>/chart/ -f projects/<service>/deploy/values.yaml  # Render Helm templates (NEVER helm install)
 
 # CI-only (runs remotely via BuildBuddy)
 bazel test //...              # Test everything
-bazel run //charts/<service>/image:push  # Push container images
+bazel run //projects/<service>/image:push  # Push container images
 ```
 
 Bazel runs **remotely via BuildBuddy CI** — not locally. Shell aliases route `bazel`/`bazelisk` to the BuildBuddy CLI (`bb`). Locally, use `format` for formatting + BUILD file generation, and push to let CI handle builds/tests.
@@ -98,7 +99,7 @@ Breaking changes: add `!` after type/scope — `feat!: redesign auth token forma
 
 ## Cluster Investigation
 
-**MCP-first.** PreToolUse hooks enforce using MCP tools (via Context Forge) instead of CLI commands. Use `ToolSearch` with `+kubernetes`, `+argocd`, `+buildbuddy`, or `+signoz` to load tools. Tool names below are shortened — actual IDs have the `mcp__context-forge__` prefix (e.g., `mcp__context-forge__kubernetes-mcp-resources-list`).
+**MCP-first.** PreToolUse hooks enforce using MCP tools (via Context Forge) instead of CLI commands. Use `ToolSearch` with `+kubernetes`, `+argocd`, `+buildbuddy`, or `+signoz` to load tools. Tool names below are shortened — actual IDs have the `mcp__claude_ai_Homelab__` prefix (e.g., `mcp__claude_ai_Homelab__kubernetes-mcp-resources-list`).
 
 | Need                 | Tool                                                                                                      |
 | -------------------- | --------------------------------------------------------------------------------------------------------- |
@@ -163,6 +164,6 @@ Static sites deploy via `bazel run //projects/websites:push_all_pages` on main b
 - **Direct internet exposure** — all traffic goes through Cloudflare
 - **Running tests locally** — tests run in CI via Bazel; no `pytest`, `go test`, `npm test` directly
 - **Using `@rules_python` syntax** — this repo uses `@aspect_rules_py`
-- **Building a custom Helm chart when upstream provides one** — always check the upstream project repo for an existing chart before creating `charts/<service>/`
+- **Building a custom Helm chart when upstream provides one** — always check the upstream project repo for an existing chart before creating a custom one
 - **Using kubectl/argocd CLI for cluster reads** — use MCP tools via Context Forge; PreToolUse hooks enforce this
 - **Over-engineering** simple services

--- a/README.md
+++ b/README.md
@@ -6,67 +6,65 @@ Personal monorepo. The goal is to make shipping a new service as low-friction as
 
 ### sextant
 
-`sextant/` - Every operator I wrote had the same category of bugs: invalid state transitions, missing observability, hand-rolled switch statements. So I built a generator to eliminate the category. Define states and transitions in YAML, get Go code with compiler-enforced transitions, sealed interfaces, and OpenTelemetry tracing. Used by both operators below.
+`projects/sextant/` - Every operator I wrote had the same category of bugs: invalid state transitions, missing observability, hand-rolled switch statements. So I built a generator to eliminate the category. Define states and transitions in YAML, get Go code with compiler-enforced transitions, sealed interfaces, and OpenTelemetry tracing. Used by both operators below.
 
 ### Operators
 
-- `operators/cloudflare` - Manages Cloudflare Tunnel routing, DNS records, and Zero Trust policies from Kubernetes annotations via Gateway API
-- `operators/oci-model-cache` - Syncs HuggingFace models to OCI registries using a `ModelCache` CRD
-
-### hf2oci
-
-`tools/hf2oci` - CLI that converts HuggingFace model repos to multi-platform OCI images by streaming weight files directly into layers, no temp files.
+- `projects/operators/cloudflare` - Manages Cloudflare Tunnel routing, DNS records, and Zero Trust policies from Kubernetes annotations via Gateway API
+- `projects/operators/oci-model-cache` - Syncs HuggingFace models to OCI registries using a `ModelCache` CRD
 
 ### Bazel rules
 
-- `rules_helm/` - Helm chart lint, template, package, and OCI push as Bazel targets. Includes an ArgoCD application macro with live diff support
-- `rules_semgrep/` - Hermetic Semgrep scanning as native Bazel tests. Vendors semgrep-core as OCI artifacts, supports Pro rules, auto-generates scan targets via Gazelle
-- `rules_wrangler/` - Cloudflare Pages deployment via Wrangler as Bazel targets
+- `bazel/helm/` - Helm chart lint, template, package, and OCI push as Bazel targets. Includes an ArgoCD application macro with live diff support
+- `bazel/semgrep/` - Hermetic Semgrep scanning as native Bazel tests. Vendors semgrep-core as OCI artifacts, supports Pro rules, auto-generates scan targets via Gazelle
+- `bazel/wrangler/` - Cloudflare Pages deployment via Wrangler as Bazel targets
 
 ## Projects
 
 See [docs/services.md](docs/services.md) for everything running in the cluster.
 
+### Agent platform
+
+`projects/agent_platform/` - Full autonomous agent infrastructure. Claude and Goose agents run in isolated Kubernetes sandbox pods, dispatched by an orchestrator over NATS JetStream, with tool access governed by Context Forge (IBM's MCP gateway) and RBAC-scoped per team. Includes MCP servers for ArgoCD, Kubernetes, SigNoz, and BuildBuddy — so agents can investigate CI failures, query observability data, and manage deployments without direct cluster access. See [docs/agents.md](docs/agents.md) for the full architecture.
+
 ### Marine tracking
 
 Real-time AIS vessel tracking for the Pacific Northwest coast.
 
-- `services/ais_ingest` - Streams AIS position reports from AISStream.io via WebSocket, filters to a coastal bounding box, publishes to NATS JetStream
-- `services/ships_api` - Consumes positions from NATS, stores in SQLite (7-day retention), serves REST + WebSocket API with moored-vessel deduplication
-- `websites/ships.jomcgi.dev` - MapLibre GL map showing live vessel positions, types, and courses
+- `projects/ships/backend/` - Streams AIS position reports, stores in SQLite (7-day retention), serves REST + WebSocket API with moored-vessel deduplication
+- `projects/ships/frontend/` - MapLibre GL map showing live vessel positions, types, and courses
 
 ### Trip tracker
 
 Photo-based GPS trip logging - upload travel photos and it reconstructs the route from EXIF data.
 
-- `services/trips_api` - Extracts GPS from photo EXIF, enriches with elevation from NRCan CDEM API, broadcasts via WebSocket. Replays NATS stream on startup to rebuild state
-- `websites/trips.jomcgi.dev` - Timeline view with day-by-day maps and elevation profiles
+- `projects/trips/backend/` - Extracts GPS from photo EXIF, enriches with elevation from NRCan CDEM API, broadcasts via WebSocket. Replays NATS stream on startup to rebuild state
+- `projects/websites/trips.jomcgi.dev/` - Timeline view with day-by-day maps and elevation profiles
 
 ### Stargazer
 
 Finds the best stargazing spots in Scotland for the next 72 hours.
 
-- `services/stargazer` - Multi-phase pipeline: downloads light pollution atlas + OSM road data, identifies dark zones near roads, scores by weather forecast clarity
+- `projects/stargazer/backend/` - Multi-phase pipeline: downloads light pollution atlas + OSM road data, identifies dark zones near roads, scores by weather forecast clarity
 
 ### Grimoire
 
 AI-assisted D&D campaign manager.
 
-- `services/grimoire/api` - Go REST API with Firestore persistence, campaign/character/encounter management
-- `services/grimoire/ws-gateway` - WebSocket gateway for real-time session events
+- `projects/grimoire/api/` - Go REST API with Firestore persistence, campaign/character/encounter management
 
 ### Knowledge graph
 
 RAG pipeline that scrapes, embeds, and searches content.
 
-- `services/knowledge_graph` - Three components: RSS/HTML scraper with SSRF protection → text chunker + vector embedder (Ollama or Gemini) → MCP server for semantic search over Qdrant
+- `projects/blog_knowledge_graph/` - Three components: RSS/HTML scraper with SSRF protection → text chunker + vector embedder (Ollama or Gemini) → MCP server for semantic search over Qdrant
 
 ### Hiking routes
 
 Scottish route finder with weather-aware surfacing.
 
-- `services/hikes` - Scrapes routes from WalkHighlands, enriches with weather forecasts
-- `websites/hikes.jomcgi.dev` - Surfaces hikes with good conditions for the coming days
+- `projects/hikes/` - Scrapes routes from WalkHighlands, enriches with weather forecasts
+- `projects/websites/hikes.jomcgi.dev/` - Surfaces hikes with good conditions for the coming days (static, Cloudflare R2)
 
 ## Infrastructure patterns
 
@@ -88,20 +86,25 @@ See [docs/security.md](docs/security.md) for the defense-in-depth model and [doc
 ## Repo layout
 
 ```
-services/             # Go, Python backends
-websites/             # Vite + React, Astro frontends
-operators/            # Kubernetes controllers (Go, controller-runtime)
-charts/               # Helm charts (custom + upstream wrappers)
-projects/             # Service code + colocated deploy/ dirs (ArgoCD Applications)
-clusters/             # ArgoCD root entry point (redirects to projects/home-cluster)
-sextant/              # State machine code generator
-tools/                # Build helpers (hf2oci, formatting, hooks)
-rules_helm/           # Custom Bazel rules for Helm
-rules_wrangler/       # Custom Bazel rules for Cloudflare Pages
-docs/         # Design docs and ADRs
+projects/             # All services, operators, websites — colocated with deploy configs
+├── platform/         #   Cluster-critical infrastructure (ArgoCD, Linkerd, SigNoz, etc.)
+├── agent_platform/   #   Agent services (Context Forge, MCP servers, orchestrator, etc.)
+├── ships/            #   Marine vessel tracking
+├── trips/            #   Trip tracker
+├── grimoire/         #   D&D campaign manager
+├── stargazer/        #   Dark sky finder
+├── hikes/            #   Scottish hiking routes
+├── operators/        #   Custom Kubernetes operators
+├── websites/         #   Static sites (VitePress, Astro)
+├── sextant/          #   State machine code generator
+└── home-cluster/     #   Auto-generated ArgoCD root kustomization
+bazel/                # Build infrastructure (rules, tools, images, semgrep)
+docs/                 # Design docs, ADRs, and plans
 ```
 
-See [docs/contributing.md](docs/contributing.md) for the full structure and how to add a new service. Architecture decisions are tracked in [docs/decisions/](docs/decisions/).
+See [docs/contributing.md](docs/contributing.md) for the full structure and how to add a new service.
+
+Architecture decisions are tracked in [docs/decisions/](docs/decisions/).
 
 ## License
 

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -11,14 +11,14 @@ Claude.ai / Claude Code (external)
     ▼
 ┌─────────────────────────────────────────────────────────────────┐
 │  MCP OAuth Proxy  (prod / mcp-gateway namespace)                │
-│  charts/mcp-oauth-proxy                                         │
+│  projects/agent_platform/mcp_oauth_proxy                                         │
 │  OAuth 2.1 AS — Google OIDC — injects X-Forwarded-User         │
 └──────────────────────────┬──────────────────────────────────────┘
                            │ proxies to ClusterIP :8000
                            ▼
 ┌─────────────────────────────────────────────────────────────────┐
 │  Context Forge  (prod / mcp-gateway namespace)                  │
-│  charts/context-forge  ·  IBM mcp-context-forge v1.0.0-RC1      │
+│  projects/agent_platform/context_forge  ·  IBM mcp-context-forge v1.0.0-RC1      │
 │  MCP gateway — aggregates tool servers, RBAC by team            │
 │  Backends: Postgres (state) + Redis (sessions)                  │
 └───────┬──────────────────┬─────────────────┬────────────────────┘
@@ -26,27 +26,27 @@ Claude.ai / Claude Code (external)
         ▼                  ▼                 ▼
   signoz-mcp         buildbuddy-mcp    agent-orchestrator-mcp
   argocd-mcp         kubernetes-mcp    todo-mcp
-  (charts/mcp-servers — one pod per server, registered at startup)
+  (projects/agent_platform/mcp_servers_chart — one pod per server, registered at startup)
                                              │
                                              │ HTTP  ClusterIP :8080
                                              ▼
 ┌─────────────────────────────────────────────────────────────────┐
 │  Agent Orchestrator  (prod / agent-orchestrator namespace)      │
-│  services/agent-orchestrator  ·  charts/agent-orchestrator      │
+│  projects/agent_platform/orchestrator  ·  projects/agent_platform/orchestrator/deploy      │
 │  Go service — HTTP API + NATS JetStream consumer                │
 └──────────┬──────────────────────────────────────────────────────┘
            │ SandboxClaim CRUD  +  pod/exec
            ▼
 ┌─────────────────────────────────────────────────────────────────┐
 │  Agent Sandbox Controller  (cluster-critical)                   │
-│  charts/agent-sandbox  ·  registry.k8s.io/agent-sandbox v0.1.1  │
+│  projects/platform/agent-sandbox  ·  registry.k8s.io/agent-sandbox v0.1.1  │
 │  CRDs: Sandbox · SandboxTemplate · SandboxClaim · SandboxWarmPool│
 └──────────┬──────────────────────────────────────────────────────┘
            │ allocates pod from warm pool / creates pod
            ▼
 ┌─────────────────────────────────────────────────────────────────┐
 │  Goose Sandbox Pod  (prod / goose-sandboxes namespace)          │
-│  charts/goose-sandboxes  +  charts/goose-agent (apko image)     │
+│  projects/agent_platform/sandboxes  +  projects/agent_platform/goose_agent (apko image)     │
 │  Runs: goose run --text <task>                                   │
 │  Tools: developer (builtin) · context-forge (MCP) · github      │
 │  LLM: Claude Max via LiteLLM proxy (claude-code provider)       │
@@ -57,7 +57,7 @@ Claude.ai / Claude Code (external)
 
 ## 1. Agent Provisioning
 
-**Controller:** `charts/agent-sandbox` — runs in `agent-sandbox-system` (cluster-critical)
+**Controller:** `projects/platform/agent-sandbox` — runs in `agent-sandbox-system` (cluster-critical)
 
 The [`kubernetes-sigs/agent-sandbox`](https://github.com/kubernetes-sigs/agent-sandbox) controller (SIG Apps, v0.1.1) manages isolated agent pod lifecycle via purpose-built CRDs. It fills the gap between Deployments and StatefulSets with a single stateful pod abstraction.
 
@@ -72,7 +72,7 @@ The [`kubernetes-sigs/agent-sandbox`](https://github.com/kubernetes-sigs/agent-s
 
 ### Goose Sandboxes
 
-**Chart:** `charts/goose-sandboxes/` — deployed to `goose-sandboxes` namespace
+**Chart:** `projects/agent_platform/sandboxes/` — deployed to `goose-sandboxes` namespace
 
 Installs:
 
@@ -84,7 +84,7 @@ Installs:
 
 ### Goose Agent Image
 
-**Built with:** apko + rules_apko (`charts/goose-agent/image/apko.yaml`)
+**Built with:** apko + rules_apko (`projects/agent_platform/goose_agent/image/apko.yaml`)
 **Registry:** `ghcr.io/jomcgi/homelab/goose-agent`
 **Architectures:** x86_64 + aarch64 · **User:** uid/gid 65532
 
@@ -117,11 +117,11 @@ Profiles narrow tool access for specific task types. Each maps to a Goose recipe
 | `ci-debug` | `buildbuddy-mcp` only | CI failure investigation                   |
 | `code-fix` | No cluster tools      | Pure code changes, no observability access |
 
-Profile definitions are documented in `charts/goose-sandboxes/profiles.yaml`. Recipes live in `charts/goose-agent/image/recipes/`.
+Profile definitions are documented in `projects/agent_platform/sandboxes/profiles.yaml`. Recipes live in `projects/agent_platform/goose_agent/image/recipes/`.
 
 ### Long-Lived Agents
 
-`charts/goose-sandboxes` also supports persistent agents as Kubernetes Deployments. Each entry under `agents:` in `values.yaml` generates a `ConfigMap` (prompt) + `Deployment` (Goose runner). A `checksum/prompt` annotation on the pod template triggers rollouts when the prompt changes.
+`projects/agent_platform/sandboxes` also supports persistent agents as Kubernetes Deployments. Each entry under `agents:` in `values.yaml` generates a `ConfigMap` (prompt) + `Deployment` (Goose runner). A `checksum/prompt` annotation on the pod template triggers rollouts when the prompt changes.
 
 ```yaml
 # projects/agent_platform/goose-sandboxes/deploy/values.yaml
@@ -139,7 +139,7 @@ agents:
 All container images are built **remotely and hermetically** via BuildBuddy RBE — never locally.
 
 ```
-charts/goose-agent/image/
+projects/agent_platform/goose_agent/image/
 ├── apko.yaml          # Wolfi packages, uid 65532, dual-arch declaration
 ├── apko.lock.json     # Pinned package SHAs — hermetic builds
 ├── config.yaml        # Goose extensions baked into image
@@ -151,7 +151,7 @@ charts/goose-agent/image/
 **Image pipeline for `goose-agent`:**
 
 ```
-bazel run //charts/goose-agent/image:push
+bazel run //projects/agent_platform/goose_agent/image:push
     │
     ├─ BuildBuddy RBE builds apko image (rules_apko)
     ├─ Hermetic: all deps from apko.lock.json SHAs
@@ -165,8 +165,8 @@ bazel run //charts/goose-agent/image:push
 The `agent-orchestrator` Go binary follows the same pattern:
 
 ```
-services/agent-orchestrator/ -> go_binary -> go_image (apko base)
-    -> ghcr.io/jomcgi/homelab/services/agent-orchestrator
+projects/agent_platform/orchestrator/ -> go_binary -> go_image (apko base)
+    -> ghcr.io/jomcgi/homelab/projects/agent_platform/orchestrator
 ```
 
 No Dockerfiles. All images: apko-based, dual-arch, non-root (uid 65532), `capabilities.drop: [ALL]`.
@@ -175,8 +175,8 @@ No Dockerfiles. All images: apko-based, dual-arch, non-root (uid 65532), `capabi
 
 ## 3. Agent Orchestrator
 
-**Source:** `services/agent-orchestrator/` (Go)
-**Chart:** `charts/agent-orchestrator/`
+**Source:** `projects/agent_platform/orchestrator/` (Go)
+**Chart:** `projects/agent_platform/orchestrator/deploy/`
 **Deploy:** `projects/agent_platform/agent-orchestrator/deploy/`
 **In-cluster:** `http://agent-orchestrator.agent-orchestrator.svc.cluster.local:8080` (ClusterIP only)
 
@@ -317,12 +317,12 @@ The orchestrator's `ServiceAccount` has the minimum permissions needed to drive 
 
 ## 4. Claude Chat -> Agent Orchestrator MCP
 
-**Source:** `services/agent_orchestrator_mcp/` (Python, FastMCP + httpx)
+**Source:** `projects/agent_platform/orchestrator/mcp/` (Python, FastMCP + httpx)
 **Transport:** `STREAMABLEHTTP`
-**Deployed via:** `charts/mcp-servers/` (entry in `projects/agent_platform/mcp-servers/deploy/values.yaml`)
+**Deployed via:** `projects/agent_platform/mcp_servers_chart/` (entry in `projects/agent_platform/mcp-servers/deploy/values.yaml`)
 **In-cluster:** `http://agent-orchestrator-mcp.mcp-servers.svc.cluster.local:8000`
 
-A thin FastMCP wrapper around the orchestrator REST API. Registered with Context Forge at deploy time by `charts/mcp-servers/templates/registration-job.yaml`.
+A thin FastMCP wrapper around the orchestrator REST API. Registered with Context Forge at deploy time by `projects/agent_platform/mcp_servers_chart/templates/registration-job.yaml`.
 
 ### MCP Tools
 
@@ -383,7 +383,7 @@ sequenceDiagram
 
 ## 5. Context Forge
 
-**Chart:** `charts/context-forge/` (wraps upstream IBM `mcp-stack` Helm chart)
+**Chart:** `projects/agent_platform/context_forge/` (wraps upstream IBM `mcp-stack` Helm chart)
 **Deploy:** `projects/agent_platform/context-forge/deploy/`
 **Namespace:** `mcp-gateway`
 **External:** `https://mcp.jomcgi.dev/mcp/` (Cloudflare tunnel -> MCP OAuth Proxy -> Context Forge)
@@ -468,7 +468,7 @@ The orchestrator uses **NATS JetStream** as both job queue and state store.
 | `job-records` KV bucket | KeyValue     | keyed by ULID, TTL 7 days                    |
 | `orchestrator` consumer | Durable pull | MaxAckPending=3, AckWait=JOB_MAX_DURATION+1m |
 
-All three are self-provisioned on orchestrator startup. Single-node NATS at `nats://nats.nats.svc.cluster.local:4222` (`charts/nats/`, `projects/agent_platform/nats/deploy/`).
+All three are self-provisioned on orchestrator startup. Single-node NATS at `nats://nats.nats.svc.cluster.local:4222` (`projects/platform/nats/`).
 
 ### Event Flow
 
@@ -520,16 +520,14 @@ This is the intended extension point for future webhook dispatch, DLQ handling, 
 
 ```bash
 # Explore the agent platform
-ls charts/agent-sandbox/             # Controller chart + CRDs
-ls charts/goose-sandboxes/           # SandboxTemplate, warm pool, namespace config
-ls charts/goose-agent/image/         # apko spec, Goose config, recipes
-ls services/agent-orchestrator/      # Go service source (api.go, consumer.go, sandbox.go)
-ls services/agent_orchestrator_mcp/  # Python MCP wrapper (app/main.py)
-ls charts/agent-orchestrator/        # Helm chart
-ls charts/context-forge/             # MCP gateway chart (wraps IBM mcp-stack)
-ls charts/mcp-servers/               # All MCP server pods + registration jobs
-ls projects/agent_platform/goose-sandboxes/deploy/    # Prod sandbox values + image tags
-ls projects/agent_platform/agent-orchestrator/deploy/ # Prod orchestrator values
-ls projects/agent_platform/context-forge/deploy/      # Prod gateway resource overrides
-ls projects/agent_platform/mcp-servers/deploy/        # Prod MCP servers (values.yaml has all definitions)
+ls projects/platform/agent-sandbox/              # Controller chart + CRDs
+ls projects/agent_platform/sandboxes/            # SandboxTemplate, warm pool, namespace config
+ls projects/agent_platform/goose_agent/image/    # apko spec, Goose config, recipes
+ls projects/agent_platform/orchestrator/         # Go service source (api.go, consumer.go, sandbox.go)
+ls projects/agent_platform/orchestrator/mcp/     # Python MCP wrapper
+ls projects/agent_platform/orchestrator/deploy/  # Orchestrator Helm chart + ArgoCD Application
+ls projects/agent_platform/context_forge/deploy/ # MCP gateway (wraps IBM mcp-stack)
+ls projects/agent_platform/mcp_servers_chart/deploy/  # All MCP server pods + registration jobs
+ls projects/agent_platform/sandboxes/deploy/     # Prod sandbox values + image tags
+ls projects/agent_platform/mcp_servers/deploy/   # MCP servers deploy config
 ```

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -6,16 +6,16 @@ This document covers common tasks and workflows for contributing to the homelab.
 
 This is a GitOps monorepo where related code and deployment configuration live together.
 
-| Directory                | Purpose                                                                           |
-| ------------------------ | --------------------------------------------------------------------------------- |
-| `projects/<project>/`    | Project groups containing services, operators, and their deployment configs       |
-| `charts/<service>/`      | Helm charts with templates, values, and source code for service-specific binaries |
-| `projects/home-cluster/` | Auto-generated root kustomization that discovers all deploy/ directories          |
-| `operators/`             | Custom Kubernetes operators                                                       |
-| `services/`              | Standalone services not deployed via Helm                                         |
-| `images/`                | Container image definitions (apko)                                                |
+| Directory                  | Purpose                                                                  |
+| -------------------------- | ------------------------------------------------------------------------ |
+| `projects/`                | All services, operators, websites — colocated with deploy configs        |
+| `projects/platform/`       | Cluster-critical infrastructure (ArgoCD, Linkerd, SigNoz, etc.)          |
+| `projects/agent_platform/` | Agent services (Context Forge, MCP servers, orchestrator, etc.)          |
+| `projects/home-cluster/`   | Auto-generated root kustomization that discovers all deploy/ directories |
+| `bazel/`                   | Build infrastructure (Helm rules, tools, images, semgrep, wrangler)      |
+| `docs/`                    | Design docs, ADRs, and plans                                             |
 
-**Colocation principle:** Each service's deployment configuration (ArgoCD Application, Helm values) lives in a `deploy/` directory next to its source code, not in a separate overlays directory. This makes it easy to understand what belongs together.
+**Colocation principle:** Each service's deployment configuration (ArgoCD Application, Helm values) lives next to its source code, not in a separate overlays directory. This makes it easy to understand what belongs together.
 
 ## Adding a New Service
 
@@ -24,34 +24,32 @@ This is a GitOps monorepo where related code and deployment configuration live t
 ```
 ┌─────────────────────────────────────────────────────────────────────┐
 │  Step 1: Create Helm Chart (if needed)                              │
-│  charts/<service>/                                                   │
-│    ├── Chart.yaml                                                    │
-│    ├── values.yaml (defaults)                                        │
-│    └── templates/                                                    │
+│  projects/<service>/chart/  (custom chart)                          │
+│  — or use an upstream chart via Chart.yaml dependencies             │
 └────────────────────────────────┬────────────────────────────────────┘
                                  │
                                  ▼
 ┌─────────────────────────────────────────────────────────────────────┐
-│  Step 2: Create Colocated deploy/ Directory                         │
-│  projects/<project>/<service>/deploy/                                │
-│    ├── application.yaml    (ArgoCD Application manifest)             │
-│    ├── kustomization.yaml  (makes app discoverable)                  │
-│    └── values.yaml         (Helm value overrides)                    │
+│  Step 2: Create deploy/ Directory                                   │
+│  projects/<service>/deploy/                                         │
+│    ├── application.yaml    (ArgoCD Application manifest)            │
+│    ├── kustomization.yaml  (makes app discoverable)                 │
+│    └── values.yaml         (Helm value overrides)                   │
 └────────────────────────────────┬────────────────────────────────────┘
                                  │
                                  ▼
 ┌─────────────────────────────────────────────────────────────────────┐
 │  Step 3: Auto-Discovery                                             │
-│  Run: bazel/images/generate-home-cluster.sh                         │
-│  This scans projects/ for deploy/ dirs containing                    │
-│  application.yaml and regenerates                                    │
-│  projects/home-cluster/kustomization.yaml                            │
+│  Run: format                                                        │
+│  This runs bazel/images/generate-home-cluster.sh which scans        │
+│  projects/ for deploy/ dirs containing application.yaml and         │
+│  regenerates projects/home-cluster/kustomization.yaml               │
 └────────────────────────────────┬────────────────────────────────────┘
                                  │
                                  ▼
 ┌─────────────────────────────────────────────────────────────────────┐
 │  Step 4: ArgoCD Auto-Discovery                                      │
-│  projects/home-cluster/kustomization.yaml lists all deploy/ dirs.    │
+│  projects/home-cluster/kustomization.yaml lists all deploy/ dirs.   │
 │                                                                      │
 │  The "canada" Application is the root app-of-apps.                   │
 │  ArgoCD runs "kustomize build" and discovers all                     │
@@ -71,26 +69,28 @@ This is a GitOps monorepo where related code and deployment configuration live t
 
 ```
 projects/
-├── platform/              # Core infrastructure
+├── platform/              # Core infrastructure (flat layout: chart + deploy in same dir)
 │   ├── argocd/
+│   │   ├── Chart.yaml
 │   │   ├── application.yaml
 │   │   ├── kustomization.yaml
 │   │   └── values.yaml
-│   ├── envoy/
+│   ├── linkerd/
 │   ├── kyverno/
 │   └── kustomization.yaml  ← references all platform services
 │
 ├── agent_platform/        # Agent services
-│   ├── agent-orchestrator/deploy/
-│   ├── context-forge/deploy/
+│   ├── orchestrator/deploy/
+│   ├── context_forge/deploy/
 │   └── kustomization.yaml  ← references all agent services
 │
 ├── grimoire/              # Individual project with colocated deploy/
-│   ├── deploy/
+│   ├── chart/             # Custom Helm chart
+│   ├── deploy/            # ArgoCD Application + values
 │   │   ├── application.yaml
 │   │   ├── kustomization.yaml
 │   │   └── values.yaml
-│   └── src/               # Source code lives alongside deploy/
+│   └── api/               # Source code lives alongside
 │
 └── home-cluster/          # Auto-generated root (DO NOT EDIT)
     └── kustomization.yaml  ← lists all deploy/ dirs
@@ -98,15 +98,15 @@ projects/
 
 ### Steps
 
-1. Create Helm chart in `charts/<name>/` with default values (or use an upstream chart)
+1. Create Helm chart in `projects/<service>/chart/` with default values (or use an upstream chart via Chart.yaml dependencies)
 2. Create a `deploy/` directory colocated with your service source:
-   - `projects/<project>/<service>/deploy/application.yaml` - ArgoCD Application pointing to your chart
-   - `projects/<project>/<service>/deploy/kustomization.yaml` - Reference to application.yaml
-   - `projects/<project>/<service>/deploy/values.yaml` - Helm value overrides
-3. Run `bazel/images/generate-home-cluster.sh` to regenerate the root kustomization
+   - `projects/<service>/deploy/application.yaml` - ArgoCD Application pointing to your chart
+   - `projects/<service>/deploy/kustomization.yaml` - Reference to application.yaml
+   - `projects/<service>/deploy/values.yaml` - Helm value overrides
+3. Run `format` to regenerate the root kustomization and format code
 4. Add health checks and observability to the chart
 5. Test the complete deployment path:
-   - `helm template <service> charts/<service>/ --namespace <namespace>` to verify rendering
+   - `helm template <service> projects/<service>/chart/ --namespace <namespace>` to verify rendering
    - Commit and push to Git
    - ArgoCD automatically discovers and syncs the new application to the cluster
 
@@ -124,6 +124,7 @@ This command:
 - **Updates apko lock files** (container image definitions)
 - **Updates Python lock files** (from pyproject.toml)
 - **Validates apko configurations**
+- **Regenerates `projects/home-cluster/kustomization.yaml`**
 - **Runs in parallel** using Bazel for fast builds
 
 Note: Helm manifests are rendered by ArgoCD at deploy time, not committed to the repo.
@@ -138,19 +139,13 @@ When adding a new Python dependency to `pyproject.toml`:
 format
 ```
 
-## CLI Tools
-
-- **Directory tree viewer**: Use `lstr -L <depth> <path>` instead of `tree`
-  - Example: `lstr -L 2 charts/` to view 2 levels deep
-  - Use `-d` for directories only, `--icons` for file icons
-
 ## Development Workflow
 
 1. **Make changes** in feature branch (via worktree)
 2. **Run `format`** to format code and update lock files
 3. **Verify deployment** works end-to-end
 4. **Check observability** - metrics, logs, traces
-5. **Create PR** - GitHub Actions runs integration tests
+5. **Create PR** - BuildBuddy CI runs format check + `bazel test //...`
 6. **Merge** - ArgoCD automatically syncs changes to production cluster
 
 ## Testing Philosophy

--- a/docs/observability-alerting.md
+++ b/docs/observability-alerting.md
@@ -178,7 +178,7 @@ Located in `projects/platform/signoz-addons/alerts/`:
 
 ### SLO-Based Alerts
 
-Services can define SLOs using the `signoz-alerts` library chart (`charts/signoz-alerts/`). Each SLO definition generates two alerts using multi-window multi-burn-rate principles:
+Services can define SLOs using the `signoz-alerts` library chart (`projects/platform/signoz-addons/alerts/`). Each SLO definition generates two alerts using multi-window multi-burn-rate principles:
 
 1. **Burn-fast** (`<name>-slo-burn-fast`) — Short eval window (5m), fires when the metric sustains a threshold violation. Detects active incidents that would rapidly consume the error budget.
 
@@ -203,11 +203,11 @@ To add SLO alerts to a chart:
 2. Add `sloDefaults` and `slos` to `values.yaml`
 3. Create `templates/slo-alerts.yaml` that ranges over `.Values.slos` and includes `signoz-alerts.slo`
 
-See `charts/api-gateway/` for a working example.
+See `projects/agent_platform/api_gateway/deploy/` for a working example.
 
 ## Sidecar Architecture
 
-The `signoz-dashboard-sidecar` (Go, in `charts/signoz-dashboard-sidecar/`) watches for ConfigMaps labeled `signoz.io/alert: "true"` across all namespaces. It:
+The `signoz-dashboard-sidecar` (Go, in `projects/platform/signoz-addons/dashboard-sidecar/`) watches for ConfigMaps labeled `signoz.io/alert: "true"` across all namespaces. It:
 
 1. **Watches** — Kubernetes watch on ConfigMaps with the alert label
 2. **Reconciles** — Every 5 minutes, force-updates all known alerts (drift correction)

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -92,7 +92,7 @@ The following diagram shows how observability is automatically added to every po
 - `OTEL_EXPORTER_OTLP_PROTOCOL=grpc`
 - Applications with OTEL SDKs get automatic instrumentation
 - Applications without OTEL SDKs ignore the vars (harmless)
-- **Policy:** `charts/kyverno/templates/otel-injection-policy.yaml`
+- **Policy:** `projects/platform/kyverno/templates/otel-injection-policy.yaml`
 
 ### 2. OTel Operator Auto-Instrumentation (Language-Level)
 
@@ -102,7 +102,7 @@ The following diagram shows how observability is automatically added to every po
 - **Python:** Injects `autoinstrumentation-python` init container that patches the runtime
 - **Node.js:** Injects `autoinstrumentation-nodejs` init container with require hooks
 - Kyverno sets the OTEL endpoint; the Operator provides the SDK — they complement each other
-- **Configuration:** `charts/opentelemetry-operator/` with namespace list in overlay values
+- **Configuration:** `projects/platform/opentelemetry-operator/` with namespace list in values
 
 ### 3. Linkerd Service Mesh (Infrastructure-Level)
 
@@ -110,7 +110,7 @@ The following diagram shows how observability is automatically added to every po
 - Linkerd webhook injects sidecars into all pods
 - Captures ALL HTTP/HTTPS traffic (no SDK needed!)
 - Automatic distributed tracing for everything
-- **Policy:** `charts/kyverno/templates/linkerd-injection-policy.yaml`
+- **Policy:** `projects/platform/kyverno/templates/linkerd-injection-policy.yaml`
 
 ## Observable by Default Philosophy
 
@@ -143,8 +143,8 @@ metadata:
 
 ## Configuration
 
-- OTEL: `charts/kyverno/values.yaml` (otelInjection section)
-- Linkerd: `charts/kyverno/values.yaml` (linkerdInjection section)
+- OTEL: `projects/platform/kyverno/values.yaml` (otelInjection section)
+- Linkerd: `projects/platform/kyverno/values.yaml` (linkerdInjection section)
 
 ## Excluded Namespaces (Kyverno policies)
 

--- a/docs/services.md
+++ b/docs/services.md
@@ -4,60 +4,61 @@ This document provides an overview of all services running in the cluster.
 
 ## Core Infrastructure (cluster-critical)
 
-| Service                      | Purpose                                                                        | Chart                                                                  |
-| ---------------------------- | ------------------------------------------------------------------------------ | ---------------------------------------------------------------------- |
-| **Agent Sandbox**            | Controller for isolated agent execution pods                                   | [charts/agent-sandbox](../charts/agent-sandbox/)                       |
-| **ArgoCD**                   | GitOps controller for declarative cluster management                           | [charts/argocd](../charts/argocd/)                                     |
-| **ArgoCD Image Updater**     | Automatic image updates for ArgoCD-managed applications                        | [charts/argocd-image-updater](../charts/argocd-image-updater/)         |
-| **cert-manager**             | X.509 certificate management; required by Linkerd for mTLS                     | [charts/cert-manager](../charts/cert-manager/)                         |
-| **CoreDNS**                  | Cluster DNS resolution for Kubernetes services                                 | [charts/coredns](../charts/coredns/)                                   |
-| **Kyverno**                  | Policy engine with auto OTEL/Linkerd injection                                 | [charts/kyverno](../charts/kyverno/)                                   |
-| **Linkerd**                  | Service mesh providing default mTLS and metrics; optional tracing when enabled | [charts/linkerd](../charts/linkerd/)                                   |
-| **Longhorn**                 | Distributed persistent storage with automated backups                          | [charts/longhorn](../charts/longhorn/)                                 |
-| **NVIDIA GPU Operator**      | GPU support for LLM inference workloads                                        | [charts/nvidia-gpu-operator](../charts/nvidia-gpu-operator/)           |
-| **OpenTelemetry Operator**   | Auto-instrumentation for Go, Python, Node.js                                   | [charts/opentelemetry-operator](../charts/opentelemetry-operator/)     |
-| **SigNoz**                   | Self-hosted observability (metrics, logs, traces)                              | [charts/signoz](../charts/signoz/)                                     |
-| **SigNoz Dashboard Sidecar** | GitOps sidecar for syncing SigNoz dashboards                                   | [charts/signoz-dashboard-sidecar](../charts/signoz-dashboard-sidecar/) |
-| **1Password Operator**       | Secret management via OnePasswordItem CRDs                                     | External chart (Helm install, outside ArgoCD)                          |
+| Service                      | Purpose                                                                        | Location                                                                                                   |
+| ---------------------------- | ------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------- |
+| **Agent Sandbox**            | Controller for isolated agent execution pods                                   | [projects/platform/agent-sandbox](../projects/platform/agent-sandbox/)                                     |
+| **ArgoCD**                   | GitOps controller for declarative cluster management                           | [projects/platform/argocd](../projects/platform/argocd/)                                                   |
+| **ArgoCD Image Updater**     | Automatic image updates for ArgoCD-managed applications                        | [projects/platform/argocd-image-updater](../projects/platform/argocd-image-updater/)                       |
+| **cert-manager**             | X.509 certificate management; required by Linkerd for mTLS                     | [projects/platform/cert-manager](../projects/platform/cert-manager/)                                       |
+| **CoreDNS**                  | Cluster DNS resolution for Kubernetes services                                 | [projects/platform/coredns](../projects/platform/coredns/)                                                 |
+| **Kyverno**                  | Policy engine with auto OTEL/Linkerd injection                                 | [projects/platform/kyverno](../projects/platform/kyverno/)                                                 |
+| **Linkerd**                  | Service mesh providing default mTLS and metrics; optional tracing when enabled | [projects/platform/linkerd](../projects/platform/linkerd/)                                                 |
+| **Longhorn**                 | Distributed persistent storage with automated backups                          | [projects/platform/longhorn](../projects/platform/longhorn/)                                               |
+| **NVIDIA GPU Operator**      | GPU support for LLM inference workloads                                        | [projects/platform/nvidia-gpu-operator](../projects/platform/nvidia-gpu-operator/)                         |
+| **OpenTelemetry Operator**   | Auto-instrumentation for Go, Python, Node.js                                   | [projects/platform/opentelemetry-operator](../projects/platform/opentelemetry-operator/)                   |
+| **SigNoz**                   | Self-hosted observability (metrics, logs, traces)                              | [projects/platform/signoz](../projects/platform/signoz/)                                                   |
+| **SigNoz Dashboard Sidecar** | GitOps sidecar for syncing SigNoz dashboards                                   | [projects/platform/signoz-addons/dashboard-sidecar](../projects/platform/signoz-addons/dashboard-sidecar/) |
+| **1Password Operator**       | Secret management via OnePasswordItem CRDs                                     | External chart (Helm install, outside ArgoCD)                                                              |
 
 ## Production Services (prod)
 
-| Service               | Purpose                                                             | Chart                                                    |
-| --------------------- | ------------------------------------------------------------------- | -------------------------------------------------------- |
-| **API Gateway**       | External service routing with rate limiting                         | [charts/api-gateway](../charts/api-gateway/)             |
-| **Cloudflare Tunnel** | Zero Trust ingress (no open firewall ports)                         | [charts/cloudflare-tunnel](../charts/cloudflare-tunnel/) |
-| **Context Forge**     | MCP gateway for aggregating tool servers                            | [charts/context-forge](../charts/context-forge/)         |
-| **Goose Sandboxes**   | Goose agent sandbox deployments                                     | [charts/goose-sandboxes](../charts/goose-sandboxes/)     |
-| **Knowledge Graph**   | RSS scraping, embedding, and MCP search                             | [charts/knowledge-graph](../charts/knowledge-graph/)     |
-| **llama-cpp**         | Local LLM inference (Hermes 4.3-36B)                                | [charts/llama-cpp](../charts/llama-cpp/)                 |
-| **MCP OAuth Proxy**   | OAuth 2.1 auth layer for remote MCP access                          | [charts/mcp-oauth-proxy](../charts/mcp-oauth-proxy/)     |
-| **MCP Servers**       | Consolidated ArgoCD, Kubernetes, BuildBuddy, and SigNoz MCP servers | [charts/mcp-servers](../charts/mcp-servers/)             |
-| **NATS**              | High-performance messaging with JetStream                           | [charts/nats](../charts/nats/)                           |
-| **SeaweedFS**         | Distributed S3-compatible object storage                            | [charts/seaweedfs](../charts/seaweedfs/)                 |
-| **Todo**              | Git-backed todo list with static UI                                 | [charts/todo](../charts/todo/)                           |
-| **Trips**             | Trip management service                                             | [charts/trips](../charts/trips/)                         |
+| Service                | Purpose                                                             | Location                                                                                   |
+| ---------------------- | ------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| **API Gateway**        | External service routing with rate limiting                         | [projects/agent_platform/api_gateway](../projects/agent_platform/api_gateway/)             |
+| **Cloudflare Gateway** | Zero Trust ingress (no open firewall ports)                         | [projects/platform/cloudflare-gateway](../projects/platform/cloudflare-gateway/)           |
+| **Context Forge**      | MCP gateway for aggregating tool servers                            | [projects/agent_platform/context_forge](../projects/agent_platform/context_forge/)         |
+| **Goose Sandboxes**    | Goose agent sandbox deployments                                     | [projects/agent_platform/sandboxes](../projects/agent_platform/sandboxes/)                 |
+| **Knowledge Graph**    | RSS scraping, embedding, and MCP search                             | [projects/blog_knowledge_graph](../projects/blog_knowledge_graph/)                         |
+| **llama-cpp**          | Local LLM inference                                                 | [projects/agent_platform/llama_cpp](../projects/agent_platform/llama_cpp/)                 |
+| **MCP OAuth Proxy**    | OAuth 2.1 auth layer for remote MCP access                          | [projects/agent_platform/mcp_oauth_proxy](../projects/agent_platform/mcp_oauth_proxy/)     |
+| **MCP Servers**        | Consolidated ArgoCD, Kubernetes, BuildBuddy, and SigNoz MCP servers | [projects/agent_platform/mcp_servers_chart](../projects/agent_platform/mcp_servers_chart/) |
+| **NATS**               | High-performance messaging with JetStream                           | [projects/platform/nats](../projects/platform/nats/)                                       |
+| **SeaweedFS**          | Distributed S3-compatible object storage                            | [projects/platform/seaweedfs](../projects/platform/seaweedfs/)                             |
+| **Todo**               | Git-backed todo list with static UI                                 | [projects/todo_app](../projects/todo_app/)                                                 |
+| **Trips**              | Trip management service                                             | [projects/trips](../projects/trips/)                                                       |
 
 ## Development Services (dev)
 
-| Service             | Purpose                                          | Chart                                                      |
-| ------------------- | ------------------------------------------------ | ---------------------------------------------------------- |
-| **Grimoire**        | D&D knowledge management with Redis              | [charts/grimoire](../charts/grimoire/)                     |
-| **Marine**          | Real-time AIS vessel tracking (ships.jomcgi.dev) | [charts/marine](../charts/marine/)                         |
-| **OCI Model Cache** | HuggingFace model caching operator               | [operators/oci-model-cache](../operators/oci-model-cache/) |
-| **Stargazer**       | Dark sky location finder with weather scoring    | [charts/stargazer](../charts/stargazer/)                   |
+| Service             | Purpose                                          | Location                                                                     |
+| ------------------- | ------------------------------------------------ | ---------------------------------------------------------------------------- |
+| **Grimoire**        | D&D knowledge management with Redis              | [projects/grimoire](../projects/grimoire/)                                   |
+| **Marine**          | Real-time AIS vessel tracking (ships.jomcgi.dev) | [projects/ships](../projects/ships/)                                         |
+| **OCI Model Cache** | HuggingFace model caching operator               | [projects/operators/oci-model-cache](../projects/operators/oci-model-cache/) |
+| **Stargazer**       | Dark sky location finder with weather scoring    | [projects/stargazer](../projects/stargazer/)                                 |
 
 ## Static Websites
 
-| Site                 | Description                                                  |
-| -------------------- | ------------------------------------------------------------ |
-| **docs.jomcgi.dev**  | Architecture docs and ADRs (VitePress, Cloudflare Pages)     |
-| **hikes.jomcgi.dev** | Hiking route finder (static, Cloudflare R2)                  |
-| **jomcgi.dev**       | Personal website (Astro, Cloudflare Pages)                   |
-| **ships.jomcgi.dev** | Real-time vessel tracking UI (React/MapLibre)                |
-| **trips.jomcgi.dev** | Road trip tracker and photo viewer (Astro, Cloudflare Pages) |
+| Site                 | Description                                                  | Location                                                                     |
+| -------------------- | ------------------------------------------------------------ | ---------------------------------------------------------------------------- |
+| **docs.jomcgi.dev**  | Architecture docs and ADRs (VitePress, Cloudflare Pages)     | [projects/websites/docs.jomcgi.dev](../projects/websites/docs.jomcgi.dev/)   |
+| **hikes.jomcgi.dev** | Hiking route finder (static, Cloudflare R2)                  | [projects/hikes/frontend](../projects/hikes/frontend/)                       |
+| **jomcgi.dev**       | Personal website (Astro, Cloudflare Pages)                   | [projects/websites/jomcgi.dev](../projects/websites/jomcgi.dev/)             |
+| **ships.jomcgi.dev** | Real-time vessel tracking UI (React/MapLibre)                | [projects/ships/frontend](../projects/ships/frontend/)                       |
+| **trips.jomcgi.dev** | Road trip tracker and photo viewer (Astro, Cloudflare Pages) | [projects/websites/trips.jomcgi.dev](../projects/websites/trips.jomcgi.dev/) |
 
 ## Service Details
 
-For detailed information about specific services, see the README in each chart:
+For detailed information about specific services, see the README in each project directory:
 
-- `charts/<service>/README.md`
+- `projects/<service>/README.md`
+- `projects/platform/<service>/README.md`


### PR DESCRIPTION
## Summary

- Updated 8 documentation files to reflect the completed migration to `projects/`-centric structure
- All references to old top-level directories (`charts/`, `services/`, `operators/`, `websites/`, `tools/`, `rules_helm/`, `rules_wrangler/`, `clusters/`) replaced with correct `projects/` paths
- Added agent platform section to README (most usable project currently)
- Fixed MCP tool prefix in CLAUDE.md (`mcp__context-forge__` → `mcp__claude_ai_Homelab__`)

### Files updated

| File | Changes |
|---|---|
| `README.md` | Repo layout rewritten, all project paths updated, agent platform highlighted |
| `docs/services.md` | All chart links (25+) now point to actual `projects/` locations |
| `docs/contributing.md` | Directory table, ArgoCD flow, steps all updated; GitHub Actions → BuildBuddy |
| `docs/agents.md` | All `charts/` and `services/` paths updated to `projects/agent_platform/` |
| `docs/observability.md` | Kyverno and OTel operator paths updated |
| `docs/observability-alerting.md` | signoz-alerts and sidecar paths updated |
| `.claude/CLAUDE.md` | Structure tree, commands, MCP prefix, anti-patterns |
| `.claude/AGENTS.md` | Container, golang, security, reviewer, linkerd agent paths |

### Not updated (intentionally)

- `docs/plans/` — historical point-in-time records
- `docs/decisions/` — ADRs record what was decided at the time
- `.claude/skills/adr/SKILL.md` — single historical example in a checklist

## Test plan

- [ ] Verify markdown links resolve correctly on GitHub
- [ ] Spot-check `docs/services.md` links against actual directory structure
- [ ] Confirm `docs/contributing.md` ArgoCD flow matches current workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)