### PR TITLE
style: fix ASCII box alignment in documentation

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -9,48 +9,48 @@ Claude.ai / Claude Code (external)
     │
     │  HTTPS  mcp.jomcgi.dev
     ▼
-┌─────────────────────────────────────────────────────────────────┐
-│  MCP OAuth Proxy  (prod / mcp-gateway namespace)                │
-│  projects/agent_platform/mcp_oauth_proxy                                         │
-│  OAuth 2.1 AS — Google OIDC — injects X-Forwarded-User         │
-└──────────────────────────┬──────────────────────────────────────┘
-                           │ proxies to ClusterIP :8000
-                           ▼
-┌─────────────────────────────────────────────────────────────────┐
-│  Context Forge  (prod / mcp-gateway namespace)                  │
-│  projects/agent_platform/context_forge  ·  IBM mcp-context-forge v1.0.0-RC1      │
-│  MCP gateway — aggregates tool servers, RBAC by team            │
-│  Backends: Postgres (state) + Redis (sessions)                  │
-└───────┬──────────────────┬─────────────────┬────────────────────┘
-        │                  │                 │
-        ▼                  ▼                 ▼
-  signoz-mcp         buildbuddy-mcp    agent-orchestrator-mcp
-  argocd-mcp         kubernetes-mcp    todo-mcp
+┌────────────────────────────────────────────────────────────────────────────────────────────┐
+│  MCP OAuth Proxy  (prod / mcp-gateway namespace)                                           │
+│  projects/agent_platform/mcp_oauth_proxy                                                   │
+│  OAuth 2.1 AS — Google OIDC — injects X-Forwarded-User                                     │
+└──────────────────────────────────────────┬─────────────────────────────────────────────────┘
+                                           │ proxies to ClusterIP :8000
+                                           ▼
+┌────────────────────────────────────────────────────────────────────────────────────────────┐
+│  Context Forge  (prod / mcp-gateway namespace)                                             │
+│  projects/agent_platform/context_forge  ·  IBM mcp-context-forge v1.0.0-RC1                │
+│  MCP gateway — aggregates tool servers, RBAC by team                                       │
+│  Backends: Postgres (state) + Redis (sessions)                                             │
+└───────┬──────────────────────────────────┬───────────────────────┬─────────────────────────┘
+        │                                  │                       │
+        ▼                                  ▼                       ▼
+  signoz-mcp                         buildbuddy-mcp          agent-orchestrator-mcp
+  argocd-mcp                         kubernetes-mcp          todo-mcp
   (projects/agent_platform/mcp_servers_chart — one pod per server, registered at startup)
-                                             │
-                                             │ HTTP  ClusterIP :8080
-                                             ▼
-┌─────────────────────────────────────────────────────────────────┐
-│  Agent Orchestrator  (prod / agent-orchestrator namespace)      │
+                                                                   │
+                                                                   │ HTTP  ClusterIP :8080
+                                                                   ▼
+┌────────────────────────────────────────────────────────────────────────────────────────────┐
+│  Agent Orchestrator  (prod / agent-orchestrator namespace)                                 │
 │  projects/agent_platform/orchestrator  ·  projects/agent_platform/orchestrator/deploy      │
-│  Go service — HTTP API + NATS JetStream consumer                │
-└──────────┬──────────────────────────────────────────────────────┘
+│  Go service — HTTP API + NATS JetStream consumer                                           │
+└──────────┬─────────────────────────────────────────────────────────────────────────────────┘
            │ SandboxClaim CRUD  +  pod/exec
            ▼
-┌─────────────────────────────────────────────────────────────────┐
-│  Agent Sandbox Controller  (cluster-critical)                   │
-│  projects/platform/agent-sandbox  ·  registry.k8s.io/agent-sandbox v0.1.1  │
-│  CRDs: Sandbox · SandboxTemplate · SandboxClaim · SandboxWarmPool│
-└──────────┬──────────────────────────────────────────────────────┘
+┌────────────────────────────────────────────────────────────────────────────────────────────┐
+│  Agent Sandbox Controller  (cluster-critical)                                              │
+│  projects/platform/agent-sandbox  ·  registry.k8s.io/agent-sandbox v0.1.1                  │
+│  CRDs: Sandbox · SandboxTemplate · SandboxClaim · SandboxWarmPool                          │
+└──────────┬─────────────────────────────────────────────────────────────────────────────────┘
            │ allocates pod from warm pool / creates pod
            ▼
-┌─────────────────────────────────────────────────────────────────┐
-│  Goose Sandbox Pod  (prod / goose-sandboxes namespace)          │
-│  projects/agent_platform/sandboxes  +  projects/agent_platform/goose_agent (apko image)     │
-│  Runs: goose run --text <task>                                   │
-│  Tools: developer (builtin) · context-forge (MCP) · github      │
-│  LLM: Claude Max via LiteLLM proxy (claude-code provider)       │
-└─────────────────────────────────────────────────────────────────┘
+┌────────────────────────────────────────────────────────────────────────────────────────────┐
+│  Goose Sandbox Pod  (prod / goose-sandboxes namespace)                                     │
+│  projects/agent_platform/sandboxes  +  projects/agent_platform/goose_agent (apko image)    │
+│  Runs: goose run --text <task>                                                             │
+│  Tools: developer (builtin) · context-forge (MCP) · github                                 │
+│  LLM: Claude Max via LiteLLM proxy (claude-code provider)                                  │
+└────────────────────────────────────────────────────────────────────────────────────────────┘
 ```
 
 ---
@@ -185,27 +185,27 @@ A single Go binary combining an HTTP API and a NATS JetStream consumer. Accepts 
 ### Architecture
 
 ```
-┌───────────────────────────────────────────────────────┐
+┌────────────────────────────────────────────────────────┐
 │               agent-orchestrator                       │
 │                                                        │
 │  HTTP :8080                                            │
 │  ┌──────────┐    NATS JetStream                        │
-│  │ REST API ├──▶ stream: agent-jobs                   │
+│  │ REST API ├──▶ stream: agent-jobs                    │
 │  │          │    subject: agent.jobs                   │
 │  │          │    WorkQueue · max 1000 msgs             │
-│  └────┬─────┘         │                               │
+│  └────┬─────┘         │                                │
 │       │               │ pull (MaxAckPending=3)         │
-│       │               ▼                               │
-│       │    ┌────────────────────┐                     │
+│       │               ▼                                │
+│       │    ┌────────────────────┐                      │
 │       │    │ Consumer goroutine  │                     │
 │       │    │ (up to 3 concurrent)│                     │
-│       ▼    └─────────┬──────────┘                     │
-│  ┌──────────┐        │                                │
-│  │ NATS KV  │◀───────┘                                │
+│       ▼    └─────────┬──────────┘                      │
+│  ┌──────────┐        │                                 │
+│  │ NATS KV  │◀───────┘                                 │
 │  │ bucket:  │   job records (TTL 7 days)               │
 │  │job-records│                                         │
-│  └──────────┘                                         │
-└───────────────────────────────────────────────────────┘
+│  └──────────┘                                          │
+└────────────────────────────────────────────────────────┘
 ```
 
 Both the JetStream stream (`agent-jobs`) and KV bucket (`job-records`) are **self-provisioned** on startup via idempotent `CreateOrUpdate` calls — no manual NATS setup required.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -50,10 +50,10 @@ This is a GitOps monorepo where related code and deployment configuration live t
 ┌─────────────────────────────────────────────────────────────────────┐
 │  Step 4: ArgoCD Auto-Discovery                                      │
 │  projects/home-cluster/kustomization.yaml lists all deploy/ dirs.   │
-│                                                                      │
-│  The "canada" Application is the root app-of-apps.                   │
-│  ArgoCD runs "kustomize build" and discovers all                     │
-│  Application manifests automatically.                                │
+│                                                                     │
+│  The "canada" Application is the root app-of-apps.                  │
+│  ArgoCD runs "kustomize build" and discovers all                    │
+│  Application manifests automatically.                               │
 └────────────────────────────────┬────────────────────────────────────┘
                                  │
                                  ▼

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -16,41 +16,41 @@ The following diagram shows how observability is automatically added to every po
 
 ```
 ┌─────────────────────────────────────────────────────────────────────┐
-│                         Pod Creation Request                         │
-│                     (kubectl apply / ArgoCD sync)                    │
+│                        Pod Creation Request                         │
+│                    (kubectl apply / ArgoCD sync)                    │
 └────────────────────────────────┬────────────────────────────────────┘
                                  │
                                  ▼
 ┌─────────────────────────────────────────────────────────────────────┐
-│                    Layer 1: Kyverno Policies                         │
+│                    Layer 1: Kyverno Policies                        │
 ├─────────────────────────────────────────────────────────────────────┤
-│  ┌──────────────────────────┐  ┌───────────────────────────────┐   │
-│  │  OTEL Injection Policy   │  │  Linkerd Injection Policy     │   │
-│  ├──────────────────────────┤  ├───────────────────────────────┤   │
-│  │ Adds env vars:           │  │ Adds namespace annotation:    │   │
-│  │ - OTEL_EXPORTER_         │  │   linkerd.io/inject=enabled   │   │
-│  │   OTLP_ENDPOINT          │  │                               │   │
-│  │ - OTEL_EXPORTER_         │  │ (applies to namespace,        │   │
-│  │   OTLP_PROTOCOL=grpc     │  │  affects all pods in it)      │   │
-│  └──────────────────────────┘  └───────────────────────────────┘   │
+│  ┌──────────────────────────┐  ┌───────────────────────────────┐    │
+│  │  OTEL Injection Policy   │  │  Linkerd Injection Policy     │    │
+│  ├──────────────────────────┤  ├───────────────────────────────┤    │
+│  │ Adds env vars:           │  │ Adds namespace annotation:    │    │
+│  │ - OTEL_EXPORTER_         │  │   linkerd.io/inject=enabled   │    │
+│  │   OTLP_ENDPOINT          │  │                               │    │
+│  │ - OTEL_EXPORTER_         │  │ (applies to namespace,        │    │
+│  │   OTLP_PROTOCOL=grpc     │  │  affects all pods in it)      │    │
+│  └──────────────────────────┘  └───────────────────────────────┘    │
 └────────────────────────────────┬────────────────────────────────────┘
                                  │
                                  ▼
 ┌─────────────────────────────────────────────────────────────────────┐
-│              Layer 2: OpenTelemetry Operator (opt-in)                │
+│             Layer 2: OpenTelemetry Operator (opt-in)                │
 ├─────────────────────────────────────────────────────────────────────┤
 │  Per-namespace Instrumentation custom resources (CRs) inject:       │
 │  - Go: eBPF auto-instrumentation (autoinstrumentation-go)           │
 │  - Python: auto-instrument init container                           │
 │  - Node.js: require-hook init container                             │
-│                                                                      │
+│                                                                     │
 │  Currently enabled for: trips, knowledge-graph, api-gateway,        │
 │  mcp-servers, todo, grimoire                                        │
 └────────────────────────────────┬────────────────────────────────────┘
                                  │
                                  ▼
 ┌─────────────────────────────────────────────────────────────────────┐
-│                   Layer 3: Linkerd Proxy Injection                   │
+│                   Layer 3: Linkerd Proxy Injection                  │
 ├─────────────────────────────────────────────────────────────────────┤
 │  Linkerd webhook sees namespace annotation and injects:             │
 │  - linkerd-proxy sidecar container                                  │
@@ -60,17 +60,17 @@ The following diagram shows how observability is automatically added to every po
                                  │
                                  ▼
 ┌─────────────────────────────────────────────────────────────────────┐
-│                          Running Pod                                 │
+│                         Running Pod                                 │
 ├─────────────────────────────────────────────────────────────────────┤
-│  ┌────────────────────┐          ┌──────────────────────────────┐  │
-│  │  Application       │          │  linkerd-proxy sidecar       │  │
-│  │  Container         │◄────────►│  (intercepts all traffic)    │  │
-│  ├────────────────────┤          ├──────────────────────────────┤  │
-│  │ OTEL env vars set  │          │ Sends traces to SigNoz       │  │
-│  │ OTel SDK injected  │          │ via control plane            │  │
-│  │ (if namespace opted│          │                              │  │
-│  │  into Operator)    │          │                              │  │
-│  └────────────────────┘          └──────────────────────────────┘  │
+│  ┌────────────────────┐          ┌──────────────────────────────┐   │
+│  │  Application       │          │  linkerd-proxy sidecar       │   │
+│  │  Container         │◄────────►│  (intercepts all traffic)    │   │
+│  ├────────────────────┤          ├──────────────────────────────┤   │
+│  │ OTEL env vars set  │          │ Sends traces to SigNoz       │   │
+│  │ OTel SDK injected  │          │ via control plane            │   │
+│  │ (if namespace opted│          │                              │   │
+│  │  into Operator)    │          │                              │   │
+│  └────────────────────┘          └──────────────────────────────┘   │
 └────────────────────────────────┬────────────────────────────────────┘
                                  │
                                  ▼


### PR DESCRIPTION
## Summary

- Widen `docs/agents.md` Component Map boxes from 67→94 chars to fit `projects/agent_platform/...` paths
- Fix architecture diagram inconsistent widths (mix of 57/58 chars → standardized)
- Fix `docs/contributing.md` Step 4 box content overflow
- Standardize `docs/observability.md` Pod Creation Flow box widths to 71 chars

Follow-up to #988 which replaced short `charts/*` paths with longer `projects/*` paths, breaking box-drawing alignment.

## Test plan

- [ ] Verify ASCII boxes render correctly in GitHub markdown preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)