### PR TITLE
ci: add max_retries and reduce resource requests for all workflow actions

### DIFF
--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -3,8 +3,9 @@ actions:
   # Runs in parallel with Test action
   - name: "Format check"
     container_image: "ubuntu-24.04"
+    max_retries: 1
     resource_requests:
-      disk: "30GB" # Slightly larger for format tools
+      disk: "20GB" # Slightly larger for format tools
     triggers:
       push:
         branches:
@@ -90,10 +91,11 @@ actions:
   # "Push images" and "Push pages" both depend on this and run in parallel after it succeeds
   - name: "Test"
     container_image: "ubuntu-24.04"
+    max_retries: 1
     resource_requests:
-      cpu: "8"
-      memory: "12GB"
-      disk: "75GB"
+      cpu: "6"
+      memory: "10GB"
+      disk: "60GB"
     triggers:
       push:
         branches:
@@ -118,10 +120,11 @@ actions:
   # verified before merge.
   - name: "Push images"
     container_image: "ubuntu-24.04"
+    max_retries: 1
     resource_requests:
-      cpu: "8"
-      memory: "12GB"
-      disk: "75GB"
+      cpu: "6"
+      memory: "10GB"
+      disk: "60GB"
     depends_on: ["Test"]
     triggers:
       push:
@@ -148,8 +151,9 @@ actions:
   # No dependency on "Push images" — static site deploys are independent of container images
   - name: "Push pages"
     container_image: "ubuntu-24.04"
+    max_retries: 1
     resource_requests:
-      disk: "30GB"
+      disk: "20GB"
     depends_on: ["Test"]
     triggers:
       push:


### PR DESCRIPTION
## Summary

- Add `max_retries: 1` to all four BuildBuddy workflow actions (**Format check**, **Test**, **Push images**, **Push pages**) to automatically retry on transient failures
- Reduce resource requests across all actions:
  - CPU: `8` → `6` (Test, Push images)
  - Memory: `12GB` → `10GB` (Test, Push images)
  - Disk: `75GB` → `60GB` (Test, Push images) and `30GB` → `20GB` (Format check, Push pages)

## Test plan

- [ ] Verify CI runs successfully on this PR with the new resource limits
- [ ] Confirm BuildBuddy picks up the `max_retries` field and retries on any transient failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)