### PR TITLE
fix(agent-platform): use hyphenated keys in NOTES.txt template

### DIFF
--- a/projects/agent_platform/chart/templates/NOTES.txt
+++ b/projects/agent_platform/chart/templates/NOTES.txt
@@ -54,19 +54,19 @@ With ArgoCD, also add to the Application spec:
 
 ## Context Forge & MCP OAuth Proxy
 
-{{ if .Values.contextForge.enabled -}}
+{{ if (index .Values "context-forge" "enabled") -}}
 Context Forge (MCP gateway) is ENABLED in this release.
 {{ else -}}
 Context Forge is DISABLED. Enable with:
-  contextForge:
+  context-forge:
     enabled: true
 {{ end -}}
-{{ if .Values.mcpOAuthProxy.enabled -}}
+{{ if (index .Values "mcp-oauth-proxy" "enabled") -}}
 MCP OAuth Proxy is ENABLED in this release (Google OIDC auth, ADR 006).
 {{ else -}}
 MCP OAuth Proxy is DISABLED. Enable with:
-  mcpOAuthProxy:
+  mcp-oauth-proxy:
     enabled: true
-Requires a Context Forge instance (contextForge.enabled: true or external URL
+Requires a Context Forge instance (context-forge.enabled: true or external URL
 configured in mcp-oauth-proxy.config.MCP_SERVER_URL).
 {{ end -}}


### PR DESCRIPTION
## Summary
- NOTES.txt referenced old camelCase keys (`contextForge`, `mcpOAuthProxy`) causing `helm template` to fail with nil pointer error
- Updated to use `index .Values "context-forge"` syntax for hyphenated key access

## Test plan
- [ ] ArgoCD agent-platform app syncs without ComparisonError

🤖 Generated with [Claude Code](https://claude.com/claude-code)