### PR TITLE
fix(cloudflare): update MCP tunnel route to mcp namespace

### DIFF
--- a/projects/platform/cloudflare-gateway/values-prod.yaml
+++ b/projects/platform/cloudflare-gateway/values-prod.yaml
@@ -32,7 +32,7 @@ tunnel:
       - hostname: longhorn.jomcgi.dev
         service: http://longhorn-frontend.longhorn.svc.cluster.local:80
       - hostname: mcp.jomcgi.dev
-        service: http://mcp-oauth-proxy.mcp-gateway.svc.cluster.local:8080
+        service: http://mcp-oauth-proxy.mcp.svc.cluster.local:8080
       - hostname: n8n.jomcgi.dev
         service: http://n8n.n8n.svc.cluster.local:80
       - hostname: feeds.jomcgi.dev


### PR DESCRIPTION
## Summary
- Update Cloudflare tunnel ingress route for `mcp.jomcgi.dev` from `mcp-gateway` to `mcp` namespace
- The OAuth proxy was moved in PR #1000 (MCP namespace refactor) but the tunnel route wasn't updated

## Test plan
- [ ] ArgoCD syncs `cloudflare-gateway` app successfully
- [ ] `https://mcp.jomcgi.dev/authorize` responds (no 5xx)
- [ ] Claude.ai custom MCP connector re-registers successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)