### PR TITLE
fix(mcp): re-enable Context Forge migration Job

### DIFF
--- a/projects/mcp/context-forge-gateway/deploy/values.yaml
+++ b/projects/mcp/context-forge-gateway/deploy/values.yaml
@@ -1,7 +1,5 @@
 # ── Context Forge Gateway ──────────────────────────────────────────────────
 mcp-stack:
-  migration:
-    enabled: false
   mcpContextForge:
     config:
       PLATFORM_ADMIN_EMAIL: "admin@jomcgi.dev"


### PR DESCRIPTION
## Summary
- Re-enable the mcp-stack migration Job now that the 1Password operator has created the gateway secret
- The gateway is crash-looping because the database schema hasn't been initialized

## Context
The migration was disabled in PR #1004 because the secret didn't exist during initial sync. Now that the secret exists, re-enable it so the DB schema gets bootstrapped.

## Test plan
- [ ] Migration Job completes successfully
- [ ] `context-forge-gateway-mcp-stack-mcpgateway` becomes healthy
- [ ] `https://mcp.jomcgi.dev/mcp` responds

🤖 Generated with [Claude Code](https://claude.com/claude-code)