### PR TITLE
fix(mcp): disable migration Job, let gateway self-migrate

### DIFF
--- a/projects/mcp/context-forge-gateway/deploy/values.yaml
+++ b/projects/mcp/context-forge-gateway/deploy/values.yaml
@@ -9,15 +9,15 @@ mcp-stack:
         command: ["sh", "-c", "sleep 10"]
         timeoutSeconds: 15
         periodSeconds: 10
-        failureThreshold: 6
+        failureThreshold: 18
       liveness:
         type: http
         path: /health
         port: 4444
-        initialDelaySeconds: 30
+        initialDelaySeconds: 60
         periodSeconds: 15
         timeoutSeconds: 5
-        failureThreshold: 3
+        failureThreshold: 5
     resources:
       requests:
         cpu: 50m
@@ -25,6 +25,8 @@ mcp-stack:
       limits:
         cpu: 200m
         memory: 1Gi
+  migration:
+    enabled: false
   postgres:
     persistence:
       storageClassName: longhorn


### PR DESCRIPTION
## Summary
- Disable the mcp-stack migration Job — it can't reach Postgres because it lacks Linkerd injection and the meshed Postgres pod requires mTLS
- The gateway already runs Alembic migrations on startup (confirmed in logs), making the Job redundant
- Increase startup probe tolerance to 3 minutes for first-run migration
- Increase liveness probe initialDelaySeconds to 60s

## Context
The migration Job has `linkerd.io/inject: disabled` (upstream chart annotation), so it connects to Postgres without mTLS. The Postgres pod's Linkerd sidecar rejects the plaintext connection. The gateway pod has Linkerd injected and successfully connects to Postgres and runs Alembic.

## Test plan
- [ ] No migration Job created
- [ ] Gateway completes Alembic migration on startup
- [ ] Gateway becomes healthy and passes probes
- [ ] `https://mcp.jomcgi.dev/mcp` responds

🤖 Generated with [Claude Code](https://claude.com/claude-code)