### PR TITLE
fix(mcp): route mcp.jomcgi.dev via HTTPRoute instead of inline tunnel

### DIFF
--- a/projects/mcp/oauth-proxy/chart/templates/httproute.yaml
+++ b/projects/mcp/oauth-proxy/chart/templates/httproute.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.httpRoute.enabled }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "mcp-oauth-proxy.fullname" . }}
+  labels:
+    {{- include "mcp-oauth-proxy.labels" . | nindent 4 }}
+spec:
+  parentRefs:
+    - name: {{ .Values.httpRoute.gatewayRef.name }}
+      namespace: {{ .Values.httpRoute.gatewayRef.namespace }}
+  hostnames:
+    - {{ .Values.httpRoute.hostname | quote }}
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: {{ include "mcp-oauth-proxy.fullname" . }}
+          port: 8080
+{{- end }}

--- a/projects/mcp/oauth-proxy/chart/values.yaml
+++ b/projects/mcp/oauth-proxy/chart/values.yaml
@@ -59,6 +59,13 @@ securityContext:
     drop:
       - ALL
 
+httpRoute:
+  enabled: false
+  hostname: ""
+  gatewayRef:
+    name: cloudflare-ingress
+    namespace: envoy-gateway-system
+
 networkPolicy:
   enabled: true
   gateway:

--- a/projects/mcp/oauth-proxy/deploy/values.yaml
+++ b/projects/mcp/oauth-proxy/deploy/values.yaml
@@ -5,3 +5,7 @@ secret:
 config:
   # Context Forge is now in the same mcp namespace
   MCP_SERVER_URL: "http://context-forge-gateway-mcp-stack-mcpgateway.mcp.svc.cluster.local:80"
+
+httpRoute:
+  enabled: true
+  hostname: mcp.jomcgi.dev

--- a/projects/platform/cloudflare-gateway/values-prod.yaml
+++ b/projects/platform/cloudflare-gateway/values-prod.yaml
@@ -31,8 +31,6 @@ tunnel:
         service: http://argocd-server.argocd.svc.cluster.local:80
       - hostname: longhorn.jomcgi.dev
         service: http://longhorn-frontend.longhorn.svc.cluster.local:80
-      - hostname: mcp.jomcgi.dev
-        service: http://mcp-oauth-proxy.mcp.svc.cluster.local:8080
       - hostname: n8n.jomcgi.dev
         service: http://n8n.n8n.svc.cluster.local:80
       - hostname: feeds.jomcgi.dev


### PR DESCRIPTION
## Summary
- Adds an HTTPRoute to the mcp-oauth-proxy Helm chart to route `mcp.jomcgi.dev` through Envoy Gateway
- Removes the inline Cloudflare tunnel route for `mcp.jomcgi.dev` (which was stuck resolving the old `mcp-gateway` namespace)
- Traffic now flows: Cloudflare tunnel catch-all → Envoy Gateway → HTTPRoute → mcp-oauth-proxy:8080

## Context
After the MCP namespace refactor (PR #1000), the Cloudflare tunnel ConfigMap never synced the updated service DNS name. The tunnel kept trying `mcp-oauth-proxy.mcp-gateway.svc.cluster.local` (old namespace) instead of `mcp-oauth-proxy.mcp.svc.cluster.local`. Moving to HTTPRoute bypasses this by using the tunnel's catch-all route through Envoy Gateway.

## Test plan
- [ ] ArgoCD syncs both `cloudflare-gateway` and `mcp-oauth-proxy` apps
- [ ] `https://mcp.jomcgi.dev/.well-known/oauth-authorization-server` returns 200
- [ ] `https://mcp.jomcgi.dev/mcp` returns 401 (unauthenticated) instead of 502

🤖 Generated with [Claude Code](https://claude.com/claude-code)