### PR TITLE
fix(mcp): add fsGroup for OAuth proxy PostgreSQL PVC

### DIFF
--- a/projects/mcp/oauth-proxy/chart/values.yaml
+++ b/projects/mcp/oauth-proxy/chart/values.yaml
@@ -51,6 +51,7 @@ resources:
 
 podSecurityContext:
   runAsNonRoot: true
+  fsGroup: 70
   seccompProfile:
     type: RuntimeDefault
 


### PR DESCRIPTION
## Summary
- Adds `fsGroup: 70` to podSecurityContext so the Longhorn PVC is writable by the postgres user (uid 70)
- Fixes `CrashLoopBackOff` from PR #1016 where postgres couldn't create PGDATA directory

## Test plan
- [ ] New pod starts without permission errors
- [ ] `https://mcp.jomcgi.dev/.well-known/oauth-authorization-server` returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)