### PR TITLE
fix(mcp): add X-Forwarded-Proto to OAuth proxy HTTPRoute

### DIFF
--- a/projects/mcp/oauth-proxy/chart/templates/httproute.yaml
+++ b/projects/mcp/oauth-proxy/chart/templates/httproute.yaml
@@ -16,6 +16,12 @@ spec:
         - path:
             type: PathPrefix
             value: /
+      filters:
+        - type: RequestHeaderModifier
+          requestHeaderModifier:
+            set:
+              - name: X-Forwarded-Proto
+                value: https
       backendRefs:
         - name: {{ include "mcp-oauth-proxy.fullname" . }}
           port: 8080


### PR DESCRIPTION
## Summary
- Adds `X-Forwarded-Proto: https` header via HTTPRoute RequestHeaderModifier filter
- Fixes OAuth metadata returning `http://` URLs instead of `https://`

## Context
The proxy derives its issuer URL from the request scheme. Behind TLS termination (Cloudflare), it only sees plain HTTP. Confirmed the proxy respects `X-Forwarded-Proto` via port-forward testing.

## Test plan
- [ ] `https://mcp.jomcgi.dev/.well-known/oauth-authorization-server` returns `https://` in issuer and endpoints
- [ ] Claude.ai MCP connector can complete OAuth flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)