### PR TITLE
fix(agent-platform): correct image updater chart registry path

### DIFF
--- a/projects/agent_platform/deploy/imageupdater.yaml
+++ b/projects/agent_platform/deploy/imageupdater.yaml
@@ -8,9 +8,9 @@ spec:
     - images:
         - alias: agent-platform-chart
           commonUpdateSettings:
-            updateStrategy: digest
+            updateStrategy: semver
             forceUpdate: false
-          imageName: ghcr.io/jomcgi/homelab/projects/agent_platform/chart
+          imageName: ghcr.io/jomcgi/homelab/charts/agent-platform
           manifestTargets:
             helm:
               name: ""


### PR DESCRIPTION
## Summary
- Fix Image Updater `imageName` from non-existent path (`ghcr.io/jomcgi/homelab/projects/agent_platform/chart`) to actual chart location (`ghcr.io/jomcgi/homelab/charts/agent-platform`)
- Switch `updateStrategy` from `digest` to `semver` — we're tracking chart version tags (0.8.0 → 0.8.1), not digest changes at a fixed tag

## Context
Chart 0.8.1 was pushed to GHCR but Image Updater never bumped `targetRevision` from 0.8.0. The registry path in `imageupdater.yaml` was wrong — it pointed to a path that doesn't exist in GHCR.

## Test plan
- [ ] Verify Image Updater detects chart 0.8.1 and commits a `targetRevision` bump to `application.yaml`
- [ ] Verify ArgoCD syncs the agent-platform app with the new chart version

🤖 Generated with [Claude Code](https://claude.com/claude-code)