### PR TITLE
fix(agent-platform): update chart targetRevision to 0.10.0

### DIFF
--- a/projects/agent_platform/deploy/application.yaml
+++ b/projects/agent_platform/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: agent-platform
-      targetRevision: 0.8.1
+      targetRevision: 0.10.0
       helm:
         releaseName: agent-platform
         valueFiles:


### PR DESCRIPTION
## Summary
- Updates agent-platform Application `targetRevision` from `0.8.1` to `0.10.0`
- CI pushed `agent-platform:0.10.0` to OCI but the auto-commit to update targetRevision was rejected by branch protection
- The new chart version has fresh image tags baked in via `helm_images_values`, replacing stale `main` tag references

## Test plan
- [ ] ArgoCD syncs agent-platform with chart `0.10.0`
- [ ] Orchestrator pod uses tagged image instead of `services/agent-orchestrator:main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)