### PR TITLE
fix(helm): move targetRevision update to PR branch

### DIFF
--- a/bazel/helm/push.sh.tpl
+++ b/bazel/helm/push.sh.tpl
@@ -68,29 +68,6 @@ fi
 if [[ "$CURRENT_BRANCH" == "main" ]]; then
   # --- Main branch: push with semver from Chart.yaml (already bumped by PR) ---
   echo "On main — pushing chart with semver from Chart.yaml"
-
-  # Update targetRevision in the deploy application.yaml so ArgoCD picks up the new chart version.
-  # Convention: chart at projects/<svc>/chart → deploy at projects/<svc>/deploy/application.yaml
-  if [[ -n "$ABS_CHART_DIR" ]]; then
-    DEPLOY_APP_YAML="$(dirname "$ABS_CHART_DIR")/deploy/application.yaml"
-    if [[ -f "$DEPLOY_APP_YAML" ]]; then
-      CHART_VERSION=$(grep '^version:' "${ABS_CHART_DIR}/Chart.yaml" | head -1 | awk '{print $2}' | tr -d '"')
-      CURRENT_TARGET=$(grep 'targetRevision:' "$DEPLOY_APP_YAML" | head -1 | awk '{print $2}' | tr -d '"')
-      if [[ -n "$CHART_VERSION" ]] && [[ "$CHART_VERSION" != "$CURRENT_TARGET" ]]; then
-        echo "Updating targetRevision: ${CURRENT_TARGET} -> ${CHART_VERSION}"
-        DEPLOY_DIR="$(dirname "$CHART_DIR")/deploy"
-        sed "s/targetRevision: ${CURRENT_TARGET}/targetRevision: ${CHART_VERSION}/" "$DEPLOY_APP_YAML" > "${DEPLOY_APP_YAML}.tmp"
-        mv "${DEPLOY_APP_YAML}.tmp" "$DEPLOY_APP_YAML"
-        cd "$WORKSPACE"
-        git config user.name "chart-version-bot"
-        git config user.email "chart-version-bot@users.noreply.github.com"
-        git add "${DEPLOY_DIR}/application.yaml"
-        git commit -m "chore: update targetRevision to ${CHART_VERSION}"
-        git push origin HEAD:main
-        echo "targetRevision updated and pushed"
-      fi
-    fi
-  fi
 elif [[ "$CAN_VERSION" == "true" ]]; then
   # --- PR branch: compute version bump, commit to PR, push with datestamp ---
   BAZEL_PKG="//${CHART_DIR}:chart.package"
@@ -99,7 +76,7 @@ elif [[ "$CAN_VERSION" == "true" ]]; then
   # Compute next semver version from conventional commits
   NEW_VERSION=$(cd "$WORKSPACE" && "$CHART_VERSION_SH" "$CHART_DIR" "$BAZEL_PKG") || true
 
-  # Commit version bump to the PR branch if changed
+  # Commit version bump + targetRevision update to the PR branch if changed
   if [[ -n "$NEW_VERSION" ]] && [[ "$NEW_VERSION" != "$CURRENT_VERSION" ]]; then
     echo "Chart version bump: ${CURRENT_VERSION} -> ${NEW_VERSION}"
     ABS_CHART_YAML="${ABS_CHART_DIR}/Chart.yaml"
@@ -112,6 +89,21 @@ elif [[ "$CAN_VERSION" == "true" ]]; then
     git config user.name "chart-version-bot"
     git config user.email "chart-version-bot@users.noreply.github.com"
     git add "${CHART_DIR}/Chart.yaml"
+
+    # Also update targetRevision in the ArgoCD Application so it deploys the new chart version.
+    # Convention: chart at projects/<svc>/chart → deploy at projects/<svc>/deploy/application.yaml
+    DEPLOY_APP_YAML="$(dirname "$ABS_CHART_DIR")/deploy/application.yaml"
+    if [[ -f "$DEPLOY_APP_YAML" ]]; then
+      CURRENT_TARGET=$(grep 'targetRevision:' "$DEPLOY_APP_YAML" | head -1 | awk '{print $2}' | tr -d '"')
+      if [[ -n "$CURRENT_TARGET" ]] && [[ "$CURRENT_TARGET" != "$NEW_VERSION" ]]; then
+        echo "Updating targetRevision: ${CURRENT_TARGET} -> ${NEW_VERSION}"
+        sed "s/targetRevision: ${CURRENT_TARGET}/targetRevision: ${NEW_VERSION}/" "$DEPLOY_APP_YAML" > "${DEPLOY_APP_YAML}.tmp"
+        mv "${DEPLOY_APP_YAML}.tmp" "$DEPLOY_APP_YAML"
+        DEPLOY_DIR="$(dirname "$CHART_DIR")/deploy"
+        git add "${DEPLOY_DIR}/application.yaml"
+      fi
+    fi
+
     git commit -m "chore(${CHART_NAME_LOWER}): bump chart version to ${NEW_VERSION}"
     git push origin HEAD:"${CURRENT_BRANCH}"
     echo "Version bump committed and pushed to ${CURRENT_BRANCH}"


### PR DESCRIPTION
## Summary
- Moves the `targetRevision` auto-update from the main branch push (which fails due to branch protection) into the PR branch section
- Chart.yaml bump and application.yaml targetRevision update are now committed together on the PR branch
- Main branch just pushes the chart — no more direct-to-main commits needed

## Test plan
- [ ] On a future PR that changes chart deps, verify chart-version-bot commits both `Chart.yaml` and `application.yaml` changes together
- [ ] Verify main branch CI just pushes the chart without attempting git commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)