### PR TITLE
fix(agent-platform): narrow ignoreDifferences to allow image syncs

### DIFF
--- a/projects/agent_platform/deploy/application.yaml
+++ b/projects/agent_platform/deploy/application.yaml
@@ -26,10 +26,8 @@ spec:
     - group: apps
       kind: Deployment
       jqPathExpressions:
-        - .spec.template.metadata.annotations
-        - .spec.template.spec.containers
-        - .spec.template.spec.initContainers
-        - .spec.template.spec.volumes
+        - .spec.template.metadata.annotations."otel.injected-by"
+        - .spec.template.spec.containers[].env
   syncPolicy:
     automated:
       prune: true


### PR DESCRIPTION
## Summary
- Narrows `ignoreDifferences` jqPathExpressions from broad `.spec.template.spec.containers` (entire array) to specific `.spec.template.spec.containers[].env`
- The broad path was preventing ArgoCD from syncing image updates, even when the OCI chart had correct baked-in tagged images
- Matches the pattern used by marine's Application
- Removes ignore for `initContainers` and `volumes` (Linkerd proxy injection is handled by the mesh, not ArgoCD)

## Test plan
- [ ] ArgoCD syncs agent-platform and replaces `services/agent-orchestrator:main` with the chart's baked-in image
- [ ] OTel env var mutations don't cause OutOfSync flapping

🤖 Generated with [Claude Code](https://claude.com/claude-code)