### PR TITLE
fix(cluster-agents): remove stale image digest

### DIFF
--- a/projects/agent_platform/cluster_agents/deploy/values-prod.yaml
+++ b/projects/agent_platform/cluster_agents/deploy/values-prod.yaml
@@ -1,8 +1,5 @@
 imagePullSecret:
   enabled: true
-image:
-  tag: main@sha256:7724bd0b50026e3241c8d898cca56a36c869defba3225c8dee21a4ae779606d7
-  repository: ghcr.io/jomcgi/homelab/projects/agent_platform/cluster_agents
 podAnnotations:
   instrumentation.opentelemetry.io/inject-go: "go"
   instrumentation.opentelemetry.io/otel-go-auto-target-exe: "/opt/app"


### PR DESCRIPTION
## Summary
- Removes stale image digest override from `values-prod.yaml` that was causing `ImagePullBackOff`
- The digest `sha256:7724bd...` no longer exists in GHCR after CI rebuilt the image
- Falls back to `values.yaml` which uses `:main` tag directly

## Test plan
- [ ] PR merges and ArgoCD syncs
- [ ] New pod starts successfully with `:main` tag
- [ ] Old degraded pod is replaced

🤖 Generated with [Claude Code](https://claude.com/claude-code)