### PR TITLE
fix(cluster-agents): correct orchestrator URL namespace

### DIFF
--- a/projects/agent_platform/cluster_agents/deploy/values.yaml
+++ b/projects/agent_platform/cluster_agents/deploy/values.yaml
@@ -48,7 +48,7 @@ resources:
 
 config:
   signozUrl: "http://signoz.signoz.svc.cluster.local:8080"
-  orchestratorUrl: "http://agent-orchestrator.agent-orchestrator.svc.cluster.local:8080"
+  orchestratorUrl: "http://agent-orchestrator.agent-platform.svc.cluster.local:8080"
   httpPort: "8080"
   patrolInterval: "1h"
   githubRepo: "jomcgi/homelab"

--- a/projects/agent_platform/cluster_agents/main.go
+++ b/projects/agent_platform/cluster_agents/main.go
@@ -21,7 +21,7 @@ func main() {
 
 	signozURL := envOr("SIGNOZ_URL", "http://signoz.signoz.svc.cluster.local:8080")
 	signozToken := os.Getenv("SIGNOZ_API_KEY")
-	orchestratorURL := envOr("ORCHESTRATOR_URL", "http://agent-orchestrator.agent-orchestrator.svc.cluster.local:8080")
+	orchestratorURL := envOr("ORCHESTRATOR_URL", "http://agent-orchestrator.agent-platform.svc.cluster.local:8080")
 	httpPort := envOr("HTTP_PORT", "8080")
 	patrolInterval := envDurationOr("PATROL_INTERVAL", 1*time.Hour)
 


### PR DESCRIPTION
## Summary
- Orchestrator lives in `agent-platform` namespace, not `agent-orchestrator`
- Fixes DNS resolution failures causing all improvement agents to fail on startup
- Updated both Go default and Helm values

## Test plan
- [ ] Agents resolve orchestrator and complete sweeps without DNS errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)