### PR TITLE
fix(cluster-agents): use correct orchestrator service name

### DIFF
--- a/projects/agent_platform/cluster_agents/deploy/values.yaml
+++ b/projects/agent_platform/cluster_agents/deploy/values.yaml
@@ -48,7 +48,7 @@ resources:
 
 config:
   signozUrl: "http://signoz.signoz.svc.cluster.local:8080"
-  orchestratorUrl: "http://agent-orchestrator.agent-platform.svc.cluster.local:8080"
+  orchestratorUrl: "http://agent-platform-agent-orchestrator.agent-platform.svc.cluster.local:8080"
   httpPort: "8080"
   patrolInterval: "1h"
   githubRepo: "jomcgi/homelab"

--- a/projects/agent_platform/cluster_agents/main.go
+++ b/projects/agent_platform/cluster_agents/main.go
@@ -21,7 +21,7 @@ func main() {
 
 	signozURL := envOr("SIGNOZ_URL", "http://signoz.signoz.svc.cluster.local:8080")
 	signozToken := os.Getenv("SIGNOZ_API_KEY")
-	orchestratorURL := envOr("ORCHESTRATOR_URL", "http://agent-orchestrator.agent-platform.svc.cluster.local:8080")
+	orchestratorURL := envOr("ORCHESTRATOR_URL", "http://agent-platform-agent-orchestrator.agent-platform.svc.cluster.local:8080")
 	httpPort := envOr("HTTP_PORT", "8080")
 	patrolInterval := envDurationOr("PATROL_INTERVAL", 1*time.Hour)
 


### PR DESCRIPTION
## Summary
- Helm prepends the release name `agent-platform` to service names
- Correct service: `agent-platform-agent-orchestrator.agent-platform.svc.cluster.local:8080`
- Previous fix (#1058) had the right namespace but wrong service name

## Test plan
- [ ] Agents resolve orchestrator without DNS errors
- [ ] Improvement agents complete sweeps and submit jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)