### PR TITLE
build(semgrep): add rule for hardcoded image digest in helm values

### DIFF
--- a/bazel/semgrep/rules/kubernetes/no-hardcoded-image-digest.yaml
+++ b/bazel/semgrep/rules/kubernetes/no-hardcoded-image-digest.yaml
@@ -1,0 +1,18 @@
+rules:
+  - id: no-hardcoded-image-digest
+    languages: [yaml]
+    severity: WARNING
+    message: >-
+      Hardcoded image digest (@sha256:...) in Helm values. Manual digests go
+      stale when CI rebuilds the image, causing ImagePullBackOff. Image pinning
+      is managed by the Bazel helm_images_values pipeline — remove this
+      override and let the build system manage image versions.
+    metadata:
+      category: best-practices
+    patterns:
+      - pattern: |
+          image:
+            tag: $TAG
+      - metavariable-regex:
+          metavariable: $TAG
+          regex: '.*@sha256:[0-9a-f]{64}.*'


### PR DESCRIPTION
## Summary

- Adds `no-hardcoded-image-digest` semgrep rule for YAML files
- Detects manually pinned `@sha256:` digests in Helm `image.tag` fields
- Auto-discovered by the existing `kubernetes_rules` filegroup glob

## Motivation

PR #1057 had to be filed to remove a stale hardcoded image digest from `values-prod.yaml` that was causing `ImagePullBackOff`. The digest `sha256:7724bd...` no longer existed in GHCR after CI rebuilt the image.

This repo has a Bazel pipeline (`helm_images_values` / `helm_package`) that manages image pinning at build time by merging generated values into `values.yaml`. Manual digest overrides in deploy values files are therefore never needed and always risky.

## Pattern caught

```yaml
# FLAGGED — manual digest goes stale after CI rebuilds
image:
  tag: main@sha256:7724bd0b50026e3241c8d898cca56a36c869defba3225c8dee21a4ae779606d7
  repository: ghcr.io/jomcgi/homelab/projects/agent_platform/cluster_agents

# OK — semver or mutable tag managed by image updater
image:
  tag: main
  repository: ghcr.io/jomcgi/homelab/projects/agent_platform/cluster_agents
```

## Note on tests

Kubernetes YAML rules in this repo are validated via `semgrep_manifest_test` targets in chart packages (which render Helm templates first), not standalone test files. This follows the existing pattern for `no-privileged` and `no-host-network`.

## Test plan
- [ ] CI passes and `kubernetes_rules` filegroup picks up the new rule
- [ ] `semgrep_manifest_test` targets continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)