### PR TITLE
ci(claude): document helm naming and image digest anti-patterns

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -93,9 +93,11 @@ Breaking changes: add `!` after type/scope — `feat!: redesign auth token forma
 | **Secrets**               | 1Password Operator (`OnePasswordItem` CRD) — never hardcode                |
 | **Container images**      | apko + rules_apko (not Dockerfiles) — always dual-arch (x86_64 + aarch64)  |
 | **Auto image updates**    | ArgoCD Image Updater (`imageupdater.yaml` in `projects/{service}/deploy/`) |
+| **Image pinning**         | Bazel `helm_images_values` deep-merges pinned tags into `values.yaml` at build time — never manually set `@sha256:` digests in deploy values files |
 | **Package deps (Python)** | `@pip//package` via aspect_rules_py (not `requirement()`)                  |
 | **Package deps (JS)**     | pnpm + rules_js                                                            |
 | **Non-root containers**   | uid 65532 convention, `runAsNonRoot: true`                                 |
+| **Helm service names**    | Helm prepends `<release-name>-` to service names. A service `agent-orchestrator` in release `agent-platform` is reachable at `agent-platform-agent-orchestrator.<namespace>.svc.cluster.local`. Never hardcode these URLs in Go application defaults — inject from `values.yaml` env vars. |
 
 ## Cluster Investigation
 
@@ -166,4 +168,6 @@ Static sites deploy via `bazel run //projects/websites:push_all_pages` on main b
 - **Using `@rules_python` syntax** — this repo uses `@aspect_rules_py`
 - **Building a custom Helm chart when upstream provides one** — always check the upstream project repo for an existing chart before creating a custom one
 - **Using kubectl/argocd CLI for cluster reads** — use MCP tools via Context Forge; PreToolUse hooks enforce this
+- **Hardcoding `.svc.cluster.local` URLs in Go defaults** — when a Helm release is renamed the service name prefix changes silently; set via `envOr("URL", "")` (no default) and configure in `values.yaml`; semgrep rule `no-hardcoded-k8s-service-url` catches this in CI
+- **Manually pinning `@sha256:` image digests in values files** — digests go stale after CI rebuilds, causing `ImagePullBackOff`; the Bazel pipeline manages pinning automatically; semgrep rule `no-hardcoded-image-digest` catches this in CI
 - **Over-engineering** simple services


### PR DESCRIPTION
## Summary

- Adds **Image pinning** row to Key Patterns table: Bazel pipeline deep-merges pinned tags — no manual `@sha256:` overrides needed
- Adds **Helm service names** row: Helm prepends `<release-name>-` to service names; never hardcode `.svc.cluster.local` URLs in Go defaults
- Adds two new Anti-Patterns with CI rule references for early detection

## Motivation

Two repeated bugs from today's cluster-agents incident (#980 / PRs #1057–#1059):

**Bug 1: Wrong Helm service name in hardcoded Go default** — required *two* fix PRs because the first PR corrected the namespace but still had the wrong service name (missing the `agent-platform-` release prefix). The root cause was that the URL was a hardcoded default in Go source rather than being driven by `values.yaml`.

**Bug 2: Stale image digest in `values-prod.yaml`** — a manually pinned `@sha256:` digest went stale after CI rebuilt the image. This is a manual workaround for a pipeline problem that has since been fixed by PR #1048 (Bazel now deep-merges pins into `values.yaml`).

Both anti-patterns now have semgrep rules that catch them in CI:
- `no-hardcoded-k8s-service-url` (PR #1062)
- `no-hardcoded-image-digest` (PR #1063)

This CLAUDE.md update ensures agents know the correct patterns *before* writing code, not just after CI fails.

## Test plan
- [ ] CLAUDE.md renders correctly (no broken Markdown)
- [ ] Key Patterns table column alignment still looks reasonable

🤖 Generated with [Claude Code](https://claude.com/claude-code)