### PR TITLE
feat(cluster-agents): set recipe profiles on orchestrator jobs

### DIFF
--- a/projects/agent_platform/cluster_agents/escalator.go
+++ b/projects/agent_platform/cluster_agents/escalator.go
@@ -135,6 +135,10 @@ func (e *Escalator) submitOrchestratorJob(ctx context.Context, action Action, ta
 			"create a GitHub issue summarizing your findings.",
 			action.Finding.Title, ruleID, action.Finding.Severity,
 			action.Finding.Detail)
+		// Ensure payload exists for profile extraction below.
+		if action.Payload == nil {
+			action.Payload = map[string]any{"profile": "research"}
+		}
 	}
 
 	source := action.Finding.Source
@@ -142,11 +146,16 @@ func (e *Escalator) submitOrchestratorJob(ctx context.Context, action Action, ta
 		source = fmt.Sprintf("patrol:%s", ruleIDFromFinding(action.Finding))
 	}
 
-	body, _ := json.Marshal(map[string]any{
+	jobReq := map[string]any{
 		"task":   task,
 		"source": source,
 		"tags":   []string{tag},
-	})
+	}
+	if profile, ok := action.Payload["profile"].(string); ok && profile != "" {
+		jobReq["profile"] = profile
+	}
+
+	body, _ := json.Marshal(jobReq)
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, e.orchestrator.baseURL+"/jobs", bytes.NewReader(body))
 	if err != nil {

--- a/projects/agent_platform/cluster_agents/escalator_test.go
+++ b/projects/agent_platform/cluster_agents/escalator_test.go
@@ -90,6 +90,11 @@ func TestEscalator_SubmitsJobWhenNoActiveJob(t *testing.T) {
 	if !ok || len(tags) != 1 || tags[0] != "alert:42" {
 		t.Errorf("expected tags [alert:42], got %v", received["tags"])
 	}
+	// Patrol jobs should default to research profile.
+	profile, ok := received["profile"].(string)
+	if !ok || profile != "research" {
+		t.Errorf("expected profile research, got %v", received["profile"])
+	}
 }
 
 func TestEscalator_UsesPayloadTaskWhenPresent(t *testing.T) {
@@ -117,7 +122,8 @@ func TestEscalator_UsesPayloadTaskWhenPresent(t *testing.T) {
 			Title:       "New commits for test coverage review",
 		},
 		Payload: map[string]any{
-			"task": "Custom task prompt here",
+			"task":    "Custom task prompt here",
+			"profile": "code-fix",
 		},
 	}}
 
@@ -139,6 +145,11 @@ func TestEscalator_UsesPayloadTaskWhenPresent(t *testing.T) {
 	source, ok := received["source"].(string)
 	if !ok || source != "improvement:test-coverage" {
 		t.Errorf("expected source improvement:test-coverage, got %v", received["source"])
+	}
+	// Profile should be passed through.
+	profile, ok := received["profile"].(string)
+	if !ok || profile != "code-fix" {
+		t.Errorf("expected profile code-fix, got %v", received["profile"])
 	}
 }
 

--- a/projects/agent_platform/cluster_agents/pr_fix_agent.go
+++ b/projects/agent_platform/cluster_agents/pr_fix_agent.go
@@ -128,7 +128,8 @@ fix(<scope>): resolve CI failure in PR #%d`, prNumber, branch, prNumber, prNumbe
 			Type:    ActionOrchestratorJob,
 			Finding: f,
 			Payload: map[string]any{
-				"task": task,
+				"task":    task,
+				"profile": "ci-debug",
 			},
 		})
 	}

--- a/projects/agent_platform/cluster_agents/readme_freshness_agent.go
+++ b/projects/agent_platform/cluster_agents/readme_freshness_agent.go
@@ -74,7 +74,8 @@ docs(<project>): update README to match current structure`
 			Type:    ActionOrchestratorJob,
 			Finding: findings[0],
 			Payload: map[string]any{
-				"task": task,
+				"task":    task,
+				"profile": "code-fix",
 			},
 		},
 	}, nil

--- a/projects/agent_platform/cluster_agents/rules_agent.go
+++ b/projects/agent_platform/cluster_agents/rules_agent.go
@@ -78,7 +78,8 @@ Create one PR per rule/config change. Use conventional commit format:
 			Type:    ActionOrchestratorJob,
 			Finding: findings[0],
 			Payload: map[string]any{
-				"task": task,
+				"task":    task,
+				"profile": "code-fix",
 			},
 		},
 	}, nil

--- a/projects/agent_platform/cluster_agents/test_coverage_agent.go
+++ b/projects/agent_platform/cluster_agents/test_coverage_agent.go
@@ -70,7 +70,8 @@ test(<project>): add coverage for <description>`, commitRange)
 			Type:    ActionOrchestratorJob,
 			Finding: findings[0],
 			Payload: map[string]any{
-				"task": task,
+				"task":    task,
+				"profile": "code-fix",
 			},
 		},
 	}, nil


### PR DESCRIPTION
## Summary
- Improvement agents now specify `profile` in job payloads so the orchestrator loads the correct recipe
- Recipes provide structured `goose-result` output format (type/url/summary) that the UI renders as links
- Profile mapping: test-coverage/readme/rules → `code-fix`, pr-fix → `ci-debug`, patrol → `research`
- Escalator passes `profile` through to the orchestrator submit request

## Test plan
- [ ] Escalator tests verify profile is included in submitted job payload
- [ ] Next agent sweep produces jobs with `profile` field set
- [ ] Job output includes `goose-result` block that UI renders as links

🤖 Generated with [Claude Code](https://claude.com/claude-code)