### PR TITLE
chore(cluster-agents): bump chart version to 0.2.0

### DIFF
--- a/projects/agent_platform/cluster_agents/deploy/Chart.yaml
+++ b/projects/agent_platform/cluster_agents/deploy/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: cluster-agents
 description: Autonomous cluster monitoring agents
 type: application
-version: 0.1.0
-appVersion: "0.1.0"
+version: 0.2.0
+appVersion: "0.2.0"
 annotations:
   org.opencontainers.image.source: "https://github.com/jomcgi/homelab"
   org.opencontainers.image.url: "https://github.com/jomcgi/homelab"


### PR DESCRIPTION
## Summary
- Bumps cluster-agents chart from 0.1.0 → 0.2.0 (minor: new features added)
- Should have been included with the improvement agents PRs

## Test plan
- [ ] ArgoCD syncs with new chart version

🤖 Generated with [Claude Code](https://claude.com/claude-code)