### PR TITLE
fix(agent-platform): narrow ignoreDifferences to allow chart env syncing

### DIFF
--- a/projects/agent_platform/deploy/application.yaml
+++ b/projects/agent_platform/deploy/application.yaml
@@ -21,13 +21,14 @@ spec:
   destination:
     server: https://kubernetes.default.svc
     namespace: agent-platform
-  # Merge ignoreDifferences from former mcp-servers app (OTel, Kyverno, Linkerd mutations)
+  # Ignore OTel fields injected by Kyverno mutation policy.
+  # IMPORTANT: Do NOT ignore the entire env array — that prevents ArgoCD from
+  # syncing new env vars added by the Helm chart (e.g. INFERENCE_URL).
   ignoreDifferences:
     - group: apps
       kind: Deployment
       jqPathExpressions:
         - .spec.template.metadata.annotations."otel.injected-by"
-        - .spec.template.spec.containers[].env
   syncPolicy:
     automated:
       prune: true


### PR DESCRIPTION
## Summary
- Removes `.spec.template.spec.containers[].env` from ArgoCD `ignoreDifferences` on the agent-platform Application
- This overly broad rule combined with `RespectIgnoreDifferences=true` caused ArgoCD to silently drop **all** new env vars from the Helm chart during sync — including `INFERENCE_URL` added in #1077
- ServerSideApply field ownership already handles Kyverno-injected OTel env vars (`OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_EXPORTER_OTLP_PROTOCOL`) correctly, so the broad ignore was unnecessary

## Root Cause
The "Infer" button on the Pipeline Composer UI was non-functional because the orchestrator pod never received the `INFERENCE_URL` env var, even though:
1. The Go proxy handler was deployed (image `7859bd9`)
2. The Helm chart template conditionally renders `INFERENCE_URL`
3. The deploy values set the URL to the in-cluster llama-cpp service

ArgoCD's `RespectIgnoreDifferences` told it to preserve the **live** env array during sync, discarding the chart's desired state.

## Test plan
- [ ] After merge, verify ArgoCD re-syncs agent-platform and the orchestrator pod has `INFERENCE_URL` in its env
- [ ] Verify the "Infer" button on https://agents.jomcgi.dev/ returns a pipeline from llama-cpp
- [ ] Verify no sync loop from Kyverno OTel env injection (SSA field ownership should handle it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)