### PR TITLE
fix(ci): add packages:read permission to hikes workflow

### DIFF
--- a/.github/workflows/cf-pages-deploy-hikes.yaml
+++ b/.github/workflows/cf-pages-deploy-hikes.yaml
@@ -15,6 +15,9 @@ concurrency:
   group: hikes-update-data-${{ github.ref }}
   cancel-in-progress: false
 
+permissions:
+  packages: read
+
 jobs:
   update-data:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Adds `permissions: packages: read` to the hikes update workflow so `github-actions[bot]` can pull the private GHCR image on scheduled runs

Closes #1082

## Test plan

- [ ] Next scheduled run (`:00` or `:30`) should pass the "Pull pre-built hikes update image" step

🤖 Generated with [Claude Code](https://claude.com/claude-code)