### PR TITLE
fix(agent-platform): update targetRevision to 0.16.0

### DIFF
--- a/projects/agent_platform/deploy/application.yaml
+++ b/projects/agent_platform/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: agent-platform
-      targetRevision: 0.15.0
+      targetRevision: 0.16.0
       helm:
         releaseName: agent-platform
         valueFiles:


### PR DESCRIPTION
## Summary

- Update ArgoCD Application `targetRevision` from `0.15.0` to `0.16.0` to deploy the pipeline execution engine chart

This was missed in #1086 — the chart version was bumped but the Application wasn't updated to pull the new version from the OCI registry.

## Test plan

- [ ] ArgoCD syncs and pods roll with the new chart version
- [ ] Pipeline endpoint is reachable at `/pipeline`

🤖 Generated with [Claude Code](https://claude.com/claude-code)