### PR TITLE
feat(agent-orchestrator): fix pipeline ordering, add summary, and UI polish

### DIFF
--- a/projects/agent_platform/chart/Chart.yaml
+++ b/projects/agent_platform/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: agent-platform
 description: Agent platform — umbrella chart bundling goose sandboxes, MCP servers, and supporting components
 type: application
-version: 0.17.1
+version: 0.18.0
 appVersion: "0.2.0"
 annotations:
   org.opencontainers.image.source: "https://github.com/jomcgi/homelab"
@@ -20,7 +20,7 @@ dependencies:
     condition: goose-sandboxes.enabled
 
   - name: agent-orchestrator
-    version: "0.4.0"
+    version: "0.5.0"
     repository: "file://./orchestrator"
     condition: agent-orchestrator.enabled
 

--- a/projects/agent_platform/chart/orchestrator/Chart.yaml
+++ b/projects/agent_platform/chart/orchestrator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: agent-orchestrator
 description: Orchestrates Goose agent tasks via REST API with NATS-backed queue and state
 type: application
-version: 0.4.0
+version: 0.5.0
 appVersion: "0.1.0"
 annotations:
   org.opencontainers.image.source: "https://github.com/jomcgi/homelab"

--- a/projects/agent_platform/orchestrator/api.go
+++ b/projects/agent_platform/orchestrator/api.go
@@ -322,7 +322,7 @@ func (a *API) handlePipeline(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// LLM enrichment (best-effort).
-	enrichments, _ := enrichPipeline(r.Context(), a.inferenceURL, req.Steps)
+	enriched, _ := enrichPipeline(r.Context(), a.inferenceURL, req.Steps)
 
 	var jobs []SubmitResponse
 	for i, step := range req.Steps {
@@ -353,10 +353,11 @@ func (a *API) handlePipeline(w http.ResponseWriter, r *http.Request) {
 		}
 
 		// Apply enrichment if available.
-		if enrichments != nil && i < len(enrichments) {
-			job.Title = enrichments[i].Title
-			job.Summary = enrichments[i].Summary
+		if i < len(enriched.Steps) {
+			job.Title = enriched.Steps[i].Title
+			job.Summary = enriched.Steps[i].Summary
 		}
+		job.PipelineSummary = enriched.PipelineSummary
 
 		if err := a.store.Put(r.Context(), job); err != nil {
 			a.logger.Error("failed to store pipeline job", "step", i, "error", err)

--- a/projects/agent_platform/orchestrator/enrich.go
+++ b/projects/agent_platform/orchestrator/enrich.go
@@ -16,11 +16,17 @@ type enrichment struct {
 	Summary string `json:"summary"`
 }
 
-// enrichPipeline calls the inference endpoint to generate titles and summaries
-// for each pipeline step. Returns nil on empty URL (graceful degradation).
-func enrichPipeline(ctx context.Context, inferenceURL string, steps []PipelineStep) ([]enrichment, error) {
+// enrichResult holds per-step enrichments plus a pipeline-level summary.
+type enrichResult struct {
+	Steps           []enrichment `json:"steps"`
+	PipelineSummary string       `json:"pipeline_summary"`
+}
+
+// enrichPipeline calls the inference endpoint to generate titles, summaries,
+// and an overall pipeline summary. Returns zero value on empty URL (graceful degradation).
+func enrichPipeline(ctx context.Context, inferenceURL string, steps []PipelineStep) (enrichResult, error) {
 	if inferenceURL == "" || len(steps) == 0 {
-		return nil, nil
+		return enrichResult{}, nil
 	}
 
 	var sb strings.Builder
@@ -28,11 +34,11 @@ func enrichPipeline(ctx context.Context, inferenceURL string, steps []PipelineSt
 		fmt.Fprintf(&sb, "Step %d: agent=%s, task=%s\n", i+1, s.Agent, s.Task)
 	}
 
-	prompt := fmt.Sprintf(`Generate a short title (max 6 words) and summary (max 2 sentences) for each pipeline step.
+	prompt := fmt.Sprintf(`Generate a short title (max 6 words) and summary (max 2 sentences) for each pipeline step, plus a brief overall pipeline summary (max 10 words).
 
 Steps:
 %s
-Return a JSON array: [{"title": "...", "summary": "..."}] with one entry per step. Only JSON, no other text.`, sb.String())
+Return JSON: {"steps": [{"title": "...", "summary": "..."}], "pipeline_summary": "..."} with one entry per step. Only JSON, no other text.`, sb.String())
 
 	body, _ := json.Marshal(map[string]any{
 		"model": "qwen3.5-35b-a3b",
@@ -48,18 +54,18 @@ Return a JSON array: [{"title": "...", "summary": "..."}] with one entry per ste
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, inferenceURL, bytes.NewReader(body))
 	if err != nil {
-		return nil, fmt.Errorf("creating enrichment request: %w", err)
+		return enrichResult{}, fmt.Errorf("creating enrichment request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return nil, nil // Graceful degradation — don't block pipeline creation.
+		return enrichResult{}, nil // Graceful degradation — don't block pipeline creation.
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, nil
+		return enrichResult{}, nil
 	}
 
 	var llmResp struct {
@@ -70,11 +76,11 @@ Return a JSON array: [{"title": "...", "summary": "..."}] with one entry per ste
 		} `json:"choices"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&llmResp); err != nil {
-		return nil, nil
+		return enrichResult{}, nil
 	}
 
 	if len(llmResp.Choices) == 0 {
-		return nil, nil
+		return enrichResult{}, nil
 	}
 
 	content := strings.TrimSpace(llmResp.Choices[0].Message.Content)
@@ -82,10 +88,17 @@ Return a JSON array: [{"title": "...", "summary": "..."}] with one entry per ste
 	content = strings.TrimSuffix(content, "```")
 	content = strings.TrimSpace(content)
 
-	var enrichments []enrichment
-	if err := json.Unmarshal([]byte(content), &enrichments); err != nil {
-		return nil, nil
+	// Try new format first: {"steps": [...], "pipeline_summary": "..."}
+	var result enrichResult
+	if err := json.Unmarshal([]byte(content), &result); err == nil && len(result.Steps) > 0 {
+		return result, nil
 	}
 
-	return enrichments, nil
+	// Fall back to old format: [{"title": "...", "summary": "..."}]
+	var stepEnrichments []enrichment
+	if err := json.Unmarshal([]byte(content), &stepEnrichments); err != nil {
+		return enrichResult{}, nil
+	}
+
+	return enrichResult{Steps: stepEnrichments}, nil
 }

--- a/projects/agent_platform/orchestrator/enrich_test.go
+++ b/projects/agent_platform/orchestrator/enrich_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestEnrichPipeline(t *testing.T) {
-	// Mock LLM server returning structured JSON.
+	// Mock LLM server returning old array format (backward-compat).
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := map[string]any{
 			"choices": []map[string]any{
@@ -27,25 +27,59 @@ func TestEnrichPipeline(t *testing.T) {
 		{Agent: "code-fix", Task: "Fix the issue", Condition: "on success"},
 	}
 
-	enrichments, err := enrichPipeline(context.Background(), server.URL, steps)
+	result, err := enrichPipeline(context.Background(), server.URL, steps)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if len(enrichments) != 2 {
-		t.Fatalf("expected 2 enrichments, got %d", len(enrichments))
+	if len(result.Steps) != 2 {
+		t.Fatalf("expected 2 enrichments, got %d", len(result.Steps))
 	}
-	if enrichments[0].Title != "Debug CI" {
-		t.Fatalf("expected 'Debug CI', got %q", enrichments[0].Title)
+	if result.Steps[0].Title != "Debug CI" {
+		t.Fatalf("expected 'Debug CI', got %q", result.Steps[0].Title)
+	}
+}
+
+func TestEnrichPipeline_NewFormat(t *testing.T) {
+	// Mock LLM server returning new object format with pipeline_summary.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := map[string]any{
+			"choices": []map[string]any{
+				{"message": map[string]any{
+					"content": `{"steps":[{"title":"Debug CI","summary":"Investigate failures"},{"title":"Fix Code","summary":"Apply fixes"}],"pipeline_summary":"Debug and fix CI failures"}`,
+				}},
+			},
+		}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	steps := []PipelineStep{
+		{Agent: "ci-debug", Task: "Debug the CI failure", Condition: "always"},
+		{Agent: "code-fix", Task: "Fix the issue", Condition: "on success"},
+	}
+
+	result, err := enrichPipeline(context.Background(), server.URL, steps)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Steps) != 2 {
+		t.Fatalf("expected 2 enrichments, got %d", len(result.Steps))
+	}
+	if result.Steps[0].Title != "Debug CI" {
+		t.Fatalf("expected 'Debug CI', got %q", result.Steps[0].Title)
+	}
+	if result.PipelineSummary != "Debug and fix CI failures" {
+		t.Fatalf("expected pipeline summary, got %q", result.PipelineSummary)
 	}
 }
 
 func TestEnrichPipeline_InferenceUnavailable(t *testing.T) {
-	// When inference URL is empty, return nil (graceful degradation).
-	enrichments, err := enrichPipeline(context.Background(), "", nil)
+	// When inference URL is empty, return zero value (graceful degradation).
+	result, err := enrichPipeline(context.Background(), "", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if enrichments != nil {
-		t.Fatalf("expected nil enrichments, got %v", enrichments)
+	if len(result.Steps) != 0 {
+		t.Fatalf("expected empty steps, got %v", result.Steps)
 	}
 }

--- a/projects/agent_platform/orchestrator/model.go
+++ b/projects/agent_platform/orchestrator/model.go
@@ -45,11 +45,12 @@ type JobRecord struct {
 	Tags       []string  `json:"tags,omitempty"`
 
 	// Pipeline execution fields.
-	PipelineID    string `json:"pipeline_id,omitempty"`    // shared ULID grouping linked jobs
-	StepIndex     int    `json:"step_index,omitempty"`     // 0-based position in pipeline
-	StepCondition string `json:"step_condition,omitempty"` // "always" | "on success" | "on failure"
-	Title         string `json:"title,omitempty"`          // LLM-generated short title
-	Summary       string `json:"summary,omitempty"`        // LLM-generated 1-2 sentence summary
+	PipelineID      string `json:"pipeline_id,omitempty"`      // shared ULID grouping linked jobs
+	StepIndex       int    `json:"step_index"`                 // 0-based position in pipeline
+	StepCondition   string `json:"step_condition,omitempty"`   // "always" | "on success" | "on failure"
+	Title           string `json:"title,omitempty"`            // LLM-generated short title
+	Summary         string `json:"summary,omitempty"`          // LLM-generated 1-2 sentence summary
+	PipelineSummary string `json:"pipeline_summary,omitempty"` // LLM-generated overall pipeline summary
 
 	// Reserved for webhook/DLQ integration.
 	GithubIssue    int    `json:"github_issue,omitempty"`

--- a/projects/agent_platform/orchestrator/ui/src/App.jsx
+++ b/projects/agent_platform/orchestrator/ui/src/App.jsx
@@ -950,6 +950,7 @@ function JobRow({ job, agents, onCancel, isMobile }) {
 function PipelineRow({ pipelineJobs, agents, onCancel, isMobile }) {
   const [open, setOpen] = useState(false);
   const firstJob = pipelineJobs[0];
+  const pipelineSummary = firstJob.pipeline_summary;
   const hasRunning = pipelineJobs.some((j) => j.status === "RUNNING");
   const hasFailed = pipelineJobs.some((j) => j.status === "FAILED");
   const allDone = pipelineJobs.every((j) =>
@@ -995,6 +996,20 @@ function PipelineRow({ pipelineJobs, agents, onCancel, isMobile }) {
       >
         <Dot status={overallStatus} />
         <div style={{ flex: 1, minWidth: 0 }}>
+          {pipelineSummary && (
+            <p
+              style={{
+                fontSize: 12,
+                color: "#6b7280",
+                margin: "0 0 4px",
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+                whiteSpace: "nowrap",
+              }}
+            >
+              {pipelineSummary}
+            </p>
+          )}
           <PipelineFlow jobs={pipelineJobs} agents={agents} />
         </div>
         <div

--- a/projects/agent_platform/orchestrator/ui/src/PipelineComposer.jsx
+++ b/projects/agent_platform/orchestrator/ui/src/PipelineComposer.jsx
@@ -427,7 +427,12 @@ function Composer({ onInfer, inferring, mentionCats }) {
       pill.appendChild(iconSpan);
       pill.appendChild(document.createTextNode(item.id));
 
-      const spacer = document.createTextNode("\u00A0");
+      // Wrap spacer in a span to create a clean style boundary — prevents
+      // the pill's background from bleeding into subsequently typed text.
+      const spacer = document.createElement("span");
+      spacer.style.cssText =
+        "background:none;color:inherit;font-weight:normal;";
+      spacer.textContent = "\u00A0";
       range.insertNode(spacer);
       range.insertNode(pill);
 
@@ -794,6 +799,7 @@ export default function PipelineComposer({ agents, onSubmit }) {
   const [inferring, setInferring] = useState(false);
   const [inferSource, setInferSource] = useState(null); // "inferred" | "manual" | null
   const [submitting, setSubmitting] = useState(false);
+  const [composerKey, setComposerKey] = useState(0);
   const dragRef = useRef(null);
 
   const mentionCats = useMemo(() => buildMentionCats(agents), [agents]);
@@ -880,6 +886,10 @@ export default function PipelineComposer({ agents, onSubmit }) {
         })),
       };
       await onSubmit?.(spec);
+      // Clear composer after successful submit.
+      setPipeline([]);
+      setInferSource(null);
+      setComposerKey((k) => k + 1);
     } finally {
       setSubmitting(false);
     }
@@ -891,6 +901,7 @@ export default function PipelineComposer({ agents, onSubmit }) {
       {/* Phase 1: Composer */}
       <Label>Task prompt</Label>
       <Composer
+        key={composerKey}
         onInfer={handleInfer}
         inferring={inferring}
         mentionCats={mentionCats}


### PR DESCRIPTION
## Summary
- **Fix step ordering bug**: `step_index` had `omitempty` in Go JSON tag, causing step 0 to be omitted from API responses — frontend sort fell back to alphabetical order instead of DAG order
- **Add pipeline summary**: Extend LLM enrichment to generate a pipeline-level summary (max 10 words) displayed above the compact pipeline flow
- **Fix pill text highlighting**: Wrap contentEditable spacer in a styled `<span>` to prevent pill background color from bleeding into subsequently typed text
- **Clear composer after submit**: Reset pipeline state and remount the Composer component after successful pipeline submission

## Test plan
- [ ] Submit a multi-step pipeline and verify steps display in correct DAG order (not alphabetical)
- [ ] Verify pipeline summary text appears above the compact flow view
- [ ] Type text after an @mention pill — confirm no background color bleed
- [ ] Submit a pipeline and verify the composer clears (both prompt text and pipeline steps)
- [ ] Verify backward-compat: old enrichment format (JSON array) still works via fallback parsing

🤖 Generated with [Claude Code](https://claude.com/claude-code)