### PR TITLE
fix(agent-orchestrator): use goose --params for recipe template substitution

### DIFF
--- a/projects/agent_platform/chart/Chart.yaml
+++ b/projects/agent_platform/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: agent-platform
 description: Agent platform — umbrella chart bundling goose sandboxes, MCP servers, and supporting components
 type: application
-version: 0.18.0
+version: 0.19.0
 appVersion: "0.2.0"
 annotations:
   org.opencontainers.image.source: "https://github.com/jomcgi/homelab"
@@ -20,7 +20,7 @@ dependencies:
     condition: goose-sandboxes.enabled
 
   - name: agent-orchestrator
-    version: "0.5.0"
+    version: "0.6.0"
     repository: "file://./orchestrator"
     condition: agent-orchestrator.enabled
 

--- a/projects/agent_platform/chart/orchestrator/Chart.yaml
+++ b/projects/agent_platform/chart/orchestrator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: agent-orchestrator
 description: Orchestrates Goose agent tasks via REST API with NATS-backed queue and state
 type: application
-version: 0.5.0
+version: 0.6.0
 appVersion: "0.1.0"
 annotations:
   org.opencontainers.image.source: "https://github.com/jomcgi/homelab"

--- a/projects/agent_platform/orchestrator/cmd/runner/main.go
+++ b/projects/agent_platform/orchestrator/cmd/runner/main.go
@@ -180,8 +180,9 @@ func (r *runner) handleRun(w http.ResponseWriter, req *http.Request) {
 }
 
 // buildGooseCmd constructs the goose command arguments.
-// When a recipe is provided, it writes it to a temp file and returns a cleanup
-// function that removes the file. The caller must call cleanup when done.
+// When a recipe is provided, it writes it to a temp file and passes the task
+// via --params so goose's MiniJinja engine handles template substitution.
+// The caller must call the returned cleanup function when done.
 func buildGooseCmd(body RunRequest) ([]string, func()) {
 	if body.Recipe != "" {
 		f, err := os.CreateTemp("", "goose-recipe-*.yaml")
@@ -195,6 +196,7 @@ func buildGooseCmd(body RunRequest) ([]string, func()) {
 		return []string{
 			"goose", "run",
 			"--recipe", f.Name(),
+			"--params", "task_description=" + body.Task,
 			"--no-profile",
 		}, cleanup
 	}

--- a/projects/agent_platform/orchestrator/cmd/runner/main_test.go
+++ b/projects/agent_platform/orchestrator/cmd/runner/main_test.go
@@ -236,20 +236,32 @@ func TestBuildGooseCmd_NoRecipe(t *testing.T) {
 
 func TestBuildGooseCmd_WithRecipe(t *testing.T) {
 	recipeYAML := "version: '1.0.0'\ntitle: Test\n"
-	args, cleanup := buildGooseCmd(RunRequest{Task: "do it", Recipe: recipeYAML})
+	task := "do it"
+	args, cleanup := buildGooseCmd(RunRequest{Task: task, Recipe: recipeYAML})
 	if cleanup == nil {
 		t.Fatal("expected cleanup function for temp file")
 	}
 	defer cleanup()
 
-	expected := []string{"goose", "run", "--recipe", args[3], "--no-profile"}
-	if len(args) != 5 {
-		t.Fatalf("expected 5 args, got %d: %v", len(args), args)
+	// Expected: goose run --recipe <file> --params task_description=<task> --no-profile
+	if len(args) != 7 {
+		t.Fatalf("expected 7 args, got %d: %v", len(args), args)
 	}
-	for i := range expected {
-		if args[i] != expected[i] {
-			t.Fatalf("arg[%d]: expected %q, got %q", i, expected[i], args[i])
-		}
+	if args[0] != "goose" || args[1] != "run" {
+		t.Fatalf("expected goose run, got %s %s", args[0], args[1])
+	}
+	if args[2] != "--recipe" {
+		t.Fatalf("expected --recipe at args[2], got %s", args[2])
+	}
+	if args[4] != "--params" {
+		t.Fatalf("expected --params at args[4], got %s", args[4])
+	}
+	expectedParams := "task_description=" + task
+	if args[5] != expectedParams {
+		t.Fatalf("expected params %q, got %q", expectedParams, args[5])
+	}
+	if args[6] != "--no-profile" {
+		t.Fatalf("expected --no-profile at args[6], got %s", args[6])
 	}
 
 	// Verify temp file exists and contains recipe content.
@@ -260,4 +272,49 @@ func TestBuildGooseCmd_WithRecipe(t *testing.T) {
 	if string(content) != recipeYAML {
 		t.Fatalf("expected recipe content %q, got %q", recipeYAML, string(content))
 	}
+}
+
+func TestBuildGooseCmd_RecipeTempFilePreservesTemplateVars(t *testing.T) {
+	recipeYAML := "prompt: '{{ task_description | indent(2) }}'\n"
+	args, cleanup := buildGooseCmd(RunRequest{
+		Task:   "fix the auth bug",
+		Recipe: recipeYAML,
+	})
+	if cleanup != nil {
+		defer cleanup()
+	}
+
+	// Read temp file and verify template variables are preserved (not substituted).
+	content, err := os.ReadFile(args[3])
+	if err != nil {
+		t.Fatalf("failed to read temp recipe: %v", err)
+	}
+	if !strings.Contains(string(content), "task_description") {
+		t.Fatal("template variable should be preserved in temp file for goose to handle")
+	}
+}
+
+func TestBuildGooseCmd_YAMLHostileTask(t *testing.T) {
+	// YAML-special characters in the task are safe because they're passed via
+	// --params (CLI arg), not embedded in the recipe YAML.
+	hostileTask := `Fix the "auth" bug. Check: key: value. Don't break it.`
+	args, cleanup := buildGooseCmd(RunRequest{
+		Task:   hostileTask,
+		Recipe: "version: '1.0.0'\ntitle: Test\n",
+	})
+	if cleanup != nil {
+		defer cleanup()
+	}
+
+	// Find --params value.
+	for i, arg := range args {
+		if arg == "--params" && i+1 < len(args) {
+			expected := "task_description=" + hostileTask
+			if args[i+1] != expected {
+				t.Fatalf("expected params %q, got %q", expected, args[i+1])
+			}
+			return
+		}
+	}
+	t.Fatal("--params flag not found")
 }

--- a/projects/agent_platform/orchestrator/consumer.go
+++ b/projects/agent_platform/orchestrator/consumer.go
@@ -138,7 +138,7 @@ func (c *Consumer) processJob(ctx context.Context, msg jetstream.Msg) {
 	if job.Profile != "" && c.recipes != nil {
 		if recipe, ok := c.recipes[job.Profile]; ok {
 			var err error
-			recipeYAML, err = renderRecipeYAML(recipe, task)
+			recipeYAML, err = renderRecipeYAML(recipe)
 			if err != nil {
 				c.logger.Error("failed to render recipe", "agent", job.Profile, "error", err)
 			}

--- a/projects/agent_platform/orchestrator/recipe.go
+++ b/projects/agent_platform/orchestrator/recipe.go
@@ -2,58 +2,25 @@ package main
 
 import (
 	"fmt"
-	"regexp"
 
 	"gopkg.in/yaml.v3"
 )
 
-// templateVarRe matches {{ task_description }} with or without an indent filter.
-// The indent filter (e.g. {{ task_description | indent(2) }}) is a MiniJinja
-// directive — it is meaningful only when goose's own template engine renders
-// the recipe. Since the orchestrator pre-substitutes the variable before
-// handing the recipe to goose, the indent filter is stripped: yaml.Marshal
-// handles block-scalar indentation correctly on its own.
-var templateVarRe = regexp.MustCompile(`\{\{\s*task_description\s*(?:\|[^}]*)?\}\}`)
-
-// renderRecipeYAML takes a recipe map, substitutes {{ task_description }}
-// template variables with the given task, and returns the rendered YAML string.
+// renderRecipeYAML marshals a recipe map to YAML for writing to a temp file.
 //
-// Substitution happens at the map level (before yaml.Marshal) so that
-// yaml.Marshal sees the final string content and chooses correct quoting.
-// Doing it post-marshal broke in two ways:
-//  1. YAML-special characters in the task (apostrophes, colons) inherited
-//     incompatible quoting from the template variable placeholder.
-//  2. The indent(N) filter added leading spaces that caused yaml.Marshal
-//     to emit explicit indent indicators (e.g. |4) which serde_yaml in
-//     goose rejected with "did not find expected key".
-func renderRecipeYAML(recipe map[string]any, task string) (string, error) {
-	rendered := substituteVars(recipe, task)
-	raw, err := yaml.Marshal(rendered)
+// The recipe is marshaled as-is — template variables like {{ task_description }}
+// are preserved so that goose's MiniJinja engine can substitute them at runtime
+// via `goose run --recipe <file> --params task_description=<value>`.
+//
+// Earlier versions pre-substituted template variables in Go, but this caused a
+// cascade of bugs: YAML-special characters in tasks broke quoting, indent
+// filters produced explicit indent indicators (|4) that serde_yaml rejected,
+// and orphaned parameter declarations triggered "Unnecessary parameter
+// definitions" errors from goose's recipe validator.
+func renderRecipeYAML(recipe map[string]any) (string, error) {
+	raw, err := yaml.Marshal(recipe)
 	if err != nil {
 		return "", fmt.Errorf("marshaling recipe: %w", err)
 	}
 	return string(raw), nil
-}
-
-// substituteVars recursively walks a value tree and replaces template
-// variables in string values with the task content.
-func substituteVars(v any, task string) any {
-	switch val := v.(type) {
-	case map[string]any:
-		out := make(map[string]any, len(val))
-		for k, child := range val {
-			out[k] = substituteVars(child, task)
-		}
-		return out
-	case []any:
-		out := make([]any, len(val))
-		for i, child := range val {
-			out[i] = substituteVars(child, task)
-		}
-		return out
-	case string:
-		return templateVarRe.ReplaceAllString(val, task)
-	default:
-		return v
-	}
 }

--- a/projects/agent_platform/orchestrator/recipe_test.go
+++ b/projects/agent_platform/orchestrator/recipe_test.go
@@ -10,44 +10,17 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-func TestRenderRecipe_SimpleSubstitution(t *testing.T) {
-	recipe := map[string]any{
-		"prompt": "{{ task_description }}",
-	}
-	rendered, err := renderRecipeYAML(recipe, "fix the build")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !strings.Contains(rendered, "fix the build") {
-		t.Fatalf("expected rendered recipe to contain task, got:\n%s", rendered)
-	}
-	if strings.Contains(rendered, "{{ task_description }}") {
-		t.Fatal("template variable was not replaced")
-	}
-}
-
-func TestRenderRecipe_IndentFilterStripped(t *testing.T) {
-	// The indent filter is a MiniJinja directive — the orchestrator strips it
-	// during substitution and lets yaml.Marshal handle block scalar indentation.
+func TestRenderRecipe_MarshalOnly(t *testing.T) {
 	recipe := map[string]any{
 		"prompt": "{{ task_description | indent(2) }}",
 	}
-	rendered, err := renderRecipeYAML(recipe, "line1\nline2")
+	rendered, err := renderRecipeYAML(recipe)
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	var parsed map[string]any
-	if err := yaml.Unmarshal([]byte(rendered), &parsed); err != nil {
-		t.Fatalf("rendered YAML is invalid:\n%s\nparse error: %v", rendered, err)
-	}
-	prompt, _ := parsed["prompt"].(string)
-	// Task text should appear as-is (no extra indentation from the filter).
-	if !strings.Contains(prompt, "line1\nline2") {
-		t.Fatalf("expected unmodified task in prompt, got:\n%s", prompt)
-	}
-	if strings.Contains(prompt, "  line1") {
-		t.Fatal("indent filter should not be applied by the orchestrator")
+	// Template variable must be preserved — goose handles substitution.
+	if !strings.Contains(rendered, "task_description") {
+		t.Fatalf("expected template variable to be preserved, got:\n%s", rendered)
 	}
 }
 
@@ -68,7 +41,7 @@ func TestRenderRecipe_RenderedYAMLIsValid(t *testing.T) {
 		},
 	}
 
-	rendered, err := renderRecipeYAML(recipe, "fix the bug in api.go")
+	rendered, err := renderRecipeYAML(recipe)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -77,117 +50,16 @@ func TestRenderRecipe_RenderedYAMLIsValid(t *testing.T) {
 	if err := yaml.Unmarshal([]byte(rendered), &parsed); err != nil {
 		t.Fatalf("rendered YAML is not valid:\n%s\nparse error: %v", rendered, err)
 	}
-}
 
-// TestRenderRecipe_YAMLHostileTask verifies that task descriptions containing
-// characters that are special in YAML don't corrupt the rendered recipe.
-// This is the root cause of the "did not find expected key" error from goose.
-func TestRenderRecipe_YAMLHostileTask(t *testing.T) {
-	recipe := map[string]any{
-		"version":      "1.0.0",
-		"title":        "Test",
-		"description":  "Test recipe",
-		"instructions": "Do the thing",
-		"prompt":       "{{ task_description | indent(2) }}",
-		"parameters": []any{
-			map[string]any{
-				"key":         "task_description",
-				"description": "The task",
-				"input_type":  "string",
-				"requirement": "required",
-			},
-		},
-	}
-
-	hostileTasks := []struct {
-		name string
-		task string
-	}{
-		{
-			"double_quotes",
-			`Fix the "authentication" bug in the "login" handler`,
-		},
-		{
-			"single_quotes",
-			`Don't break the parser's ability to handle apostrophes`,
-		},
-		{
-			"colons",
-			"Fix config: update key: value pairs in settings: section",
-		},
-		{
-			"yaml_document_separator",
-			"First part\n---\nSecond part after separator",
-		},
-		{
-			"yaml_end_marker",
-			"Some task\n...\nMore text",
-		},
-		{
-			"curly_braces",
-			`Fix the template: {{ not_a_var }} and {key: value}`,
-		},
-		{
-			"multiline_with_special_chars",
-			"Review files changed in commits abc..def on main.\nFor each Go or Python source file:\n- Check `gh pr list --search \"test\"`\n- Skip files in generated code (zz_generated.*, *_types.go deepcopy)\nCreate one PR per project. Use conventional commit format: test(<project>): add coverage",
-		},
-		{
-			"hash_comments",
-			"Fix the bug # this is not a comment\n# but this line starts with hash",
-		},
-		{
-			"square_brackets",
-			"Update [array] values and fix [nested [brackets]]",
-		},
-		{
-			"ampersand_and_asterisk",
-			"Fix &anchor and *alias references in YAML config",
-		},
-		{
-			"percent_and_at",
-			"Check %TAG and @annotation handling",
-		},
-		{
-			"pipe_and_gt",
-			"Use | for block scalar and > for folded scalar",
-		},
-		{
-			"backticks_with_code",
-			"Run `bazel test //...` and check `go test -v ./...` output",
-		},
-	}
-
-	for _, tc := range hostileTasks {
-		t.Run(tc.name, func(t *testing.T) {
-			rendered, err := renderRecipeYAML(recipe, tc.task)
-			if err != nil {
-				t.Fatalf("renderRecipeYAML failed: %v", err)
-			}
-
-			var parsed map[string]any
-			if err := yaml.Unmarshal([]byte(rendered), &parsed); err != nil {
-				t.Fatalf("rendered YAML is not parseable:\n%s\nparse error: %v", rendered, err)
-			}
-
-			// Verify the prompt field contains the task text.
-			prompt, ok := parsed["prompt"].(string)
-			if !ok {
-				t.Fatalf("prompt field missing or not a string in parsed YAML")
-			}
-			// After indentation, lines get prefixed with spaces, so check
-			// that at least the first line of the task appears.
-			firstLine := strings.SplitN(tc.task, "\n", 2)[0]
-			if !strings.Contains(prompt, strings.TrimSpace(firstLine)) {
-				t.Errorf("prompt doesn't contain first line of task %q:\n%s", firstLine, prompt)
-			}
-		})
+	// Verify template variable is preserved for goose.
+	prompt, _ := parsed["prompt"].(string)
+	if !strings.Contains(prompt, "{{ task_description") {
+		t.Fatalf("template variable should be preserved for goose, got:\n%s", prompt)
 	}
 }
 
 // TestRenderRecipe_JSONRoundtrip simulates the Helm values → ConfigMap JSON →
 // Go map[string]any → renderRecipeYAML path that recipes take in production.
-// The JSON roundtrip can lose YAML block scalar formatting, so this test
-// verifies the rendered YAML is still valid after that transformation.
 func TestRenderRecipe_JSONRoundtrip(t *testing.T) {
 	original := map[string]any{
 		"version":     "1.0.0",
@@ -197,7 +69,7 @@ func TestRenderRecipe_JSONRoundtrip(t *testing.T) {
 			"Run bazel test //... to verify.\n" +
 			"Commit using conventional commits.\n\n" +
 			"## Output Format\n" +
-			"```goose-result\ntype: pr | issue\nurl: <URL>\n```\n",
+			"```goose-result\ntype: pr | issue\nurl: <URL>\nsummary: <summary>\n```\n",
 		"prompt": "{{ task_description | indent(2) }}",
 		"parameters": []any{
 			map[string]any{
@@ -206,13 +78,6 @@ func TestRenderRecipe_JSONRoundtrip(t *testing.T) {
 				"input_type":  "string",
 				"requirement": "required",
 			},
-		},
-		"extensions": []any{
-			map[string]any{"type": "builtin", "name": "developer"},
-		},
-		"settings": map[string]any{
-			"max_turns":            50,
-			"max_tool_repetitions": 5,
 		},
 	}
 
@@ -226,11 +91,7 @@ func TestRenderRecipe_JSONRoundtrip(t *testing.T) {
 		t.Fatalf("json.Unmarshal: %v", err)
 	}
 
-	task := "Review files changed in commits abc..def.\n" +
-		"For each Go file: check `gh pr list --search \"test\"`\n" +
-		"Create one PR per project. Format: test(<project>): add coverage"
-
-	rendered, err := renderRecipeYAML(roundtripped, task)
+	rendered, err := renderRecipeYAML(roundtripped)
 	if err != nil {
 		t.Fatalf("renderRecipeYAML: %v", err)
 	}
@@ -243,8 +104,10 @@ func TestRenderRecipe_JSONRoundtrip(t *testing.T) {
 	if parsed["title"] != "Code Fix" {
 		t.Errorf("title mismatch: got %v", parsed["title"])
 	}
-	if parsed["version"] != "1.0.0" {
-		t.Errorf("version mismatch: got %v", parsed["version"])
+	// Template variable must survive the roundtrip.
+	prompt, _ := parsed["prompt"].(string)
+	if !strings.Contains(prompt, "task_description") {
+		t.Errorf("template variable lost after JSON roundtrip, prompt: %s", prompt)
 	}
 }
 
@@ -261,15 +124,6 @@ func TestRenderRecipe_RealRecipeFiles(t *testing.T) {
 	if len(entries) == 0 {
 		t.Fatal("no recipe files found")
 	}
-
-	// A realistic multi-line task with YAML-special characters.
-	task := "Review files changed in commits 01KKJ150C7Y10SQG0E7Z88K84G..8a950f25 on main.\n" +
-		"For each Go or Python source file that was modified and lacks a corresponding _test file, write tests.\n" +
-		"Before starting:\n" +
-		"- Check `gh pr list --search \"test\"` for existing test coverage PRs\n" +
-		"- Check `gh issue list --search \"test\"` for related issues\n" +
-		"- Skip files in generated code (zz_generated.*, *_types.go deepcopy)\n" +
-		"Create one PR per project. Use conventional commit format: test(<project>): add coverage for <description>"
 
 	for _, entry := range entries {
 		if entry.IsDir() || filepath.Ext(entry.Name()) != ".yaml" {
@@ -299,7 +153,7 @@ func TestRenderRecipe_RealRecipeFiles(t *testing.T) {
 				t.Fatalf("json.Unmarshal recipe: %v", err)
 			}
 
-			rendered, err := renderRecipeYAML(roundtripped, task)
+			rendered, err := renderRecipeYAML(roundtripped)
 			if err != nil {
 				t.Fatalf("renderRecipeYAML failed: %v", err)
 			}
@@ -316,12 +170,10 @@ func TestRenderRecipe_RealRecipeFiles(t *testing.T) {
 				t.Error("rendered recipe missing 'prompt' field")
 			}
 
+			// Template variables must be preserved.
 			prompt, _ := parsed["prompt"].(string)
-			if strings.Contains(prompt, "{{ task_description") {
-				t.Error("template variable was not substituted in prompt")
-			}
-			if !strings.Contains(prompt, "Review files changed") {
-				t.Error("rendered prompt doesn't contain the task text")
+			if !strings.Contains(prompt, "task_description") {
+				t.Error("template variable was not preserved in prompt")
 			}
 		})
 	}
@@ -329,7 +181,6 @@ func TestRenderRecipe_RealRecipeFiles(t *testing.T) {
 
 // TestRenderRecipe_ValuesYAMLRecipes validates recipes as they appear in the
 // orchestrator Helm values (the authoritative source for production recipes).
-// This catches recipes that exist in values.yaml but not as standalone files.
 func TestRenderRecipe_ValuesYAMLRecipes(t *testing.T) {
 	agentsJSON := `{
 		"agents": [
@@ -354,17 +205,6 @@ func TestRenderRecipe_ValuesYAMLRecipes(t *testing.T) {
 					"prompt": "{{ task_description | indent(2) }}",
 					"parameters": [{"key": "task_description", "description": "The feature", "input_type": "string", "requirement": "required"}]
 				}
-			},
-			{
-				"id": "pr-review",
-				"recipe": {
-					"version": "1.0.0",
-					"title": "PR Review",
-					"description": "Review a pull request",
-					"instructions": "Review the specified pull request.\nEvaluate for correctness, style, security, tests.",
-					"prompt": "{{ task_description | indent(2) }}",
-					"parameters": [{"key": "task_description", "description": "PR to review", "input_type": "string", "requirement": "required"}]
-				}
 			}
 		]
 	}`
@@ -379,15 +219,9 @@ func TestRenderRecipe_ValuesYAMLRecipes(t *testing.T) {
 		t.Fatalf("failed to parse test agents JSON: %v", err)
 	}
 
-	task := "Fix the \"authentication\" bug in login handler.\n" +
-		"Check:\n" +
-		"- Token expiry: value should be 3600s\n" +
-		"- Session store: must use Redis (not in-memory)\n" +
-		"Create PR with format: fix(auth): correct token expiry"
-
 	for _, agent := range cfg.Agents {
 		t.Run(agent.ID, func(t *testing.T) {
-			rendered, err := renderRecipeYAML(agent.Recipe, task)
+			rendered, err := renderRecipeYAML(agent.Recipe)
 			if err != nil {
 				t.Fatalf("renderRecipeYAML failed for %s: %v", agent.ID, err)
 			}
@@ -395,6 +229,12 @@ func TestRenderRecipe_ValuesYAMLRecipes(t *testing.T) {
 			var parsed map[string]any
 			if err := yaml.Unmarshal([]byte(rendered), &parsed); err != nil {
 				t.Fatalf("rendered YAML for %s is not valid:\n%s\nparse error: %v", agent.ID, rendered, err)
+			}
+
+			// Template variables must be preserved.
+			prompt, _ := parsed["prompt"].(string)
+			if !strings.Contains(prompt, "task_description") {
+				t.Errorf("template variable lost for %s, prompt: %s", agent.ID, prompt)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
- Stop pre-substituting `{{ task_description }}` in Go — let goose's MiniJinja engine handle it natively
- Pass task content via `goose run --params task_description=<value>` instead of embedding in recipe YAML
- Fixes "Unnecessary parameter definitions: task_description" error from goose's recipe validator
- Adds runner tests for `--params` flag, temp file template preservation, and YAML-hostile task safety

## Context
Three iterations of recipe rendering bugs (PRs #1088, #1090) revealed that pre-substituting template variables in Go is fundamentally wrong:
1. YAML-special chars in tasks broke quoting
2. `indent(2)` filter produced `|4` block scalar indicators that serde_yaml rejected
3. Orphaned parameter declarations triggered goose validation errors

The fix delegates template substitution entirely to goose.

## Test plan
- [ ] CI passes (`bazel test //projects/agent_platform/orchestrator:orchestrator_unit_test`)
- [ ] Runner tests pass (`bazel test //projects/agent_platform/orchestrator/cmd/runner:runner_test`)
- [ ] Recipe validation tests pass (`bazel test //projects/agent_platform/goose_agent/image:recipe_validate_test`)
- [ ] Post-deploy: submit a test job and verify no "Unnecessary parameter definitions" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)