### PR TITLE
chore(agent-platform): bump application targetRevision to 0.18.0

### DIFF
--- a/projects/agent_platform/deploy/application.yaml
+++ b/projects/agent_platform/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: agent-platform
-      targetRevision: 0.17.1
+      targetRevision: 0.18.0
       helm:
         releaseName: agent-platform
         valueFiles:


### PR DESCRIPTION
## Summary
- Bump `targetRevision` in `application.yaml` from `0.17.1` to `0.18.0` to match the chart version pushed by CI after #1091 merged

Without this, ArgoCD keeps pulling the old `0.17.1` chart and the orchestrator pod never rolls with the new code.

## Test plan
- [ ] ArgoCD syncs and pulls `0.18.0` chart from OCI registry
- [ ] Orchestrator pod rolls with updated image

🤖 Generated with [Claude Code](https://claude.com/claude-code)