### PR TITLE
fix(agent-platform): bump chart to 0.20.1 for deep-plan rollout

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -88,16 +88,17 @@ Breaking changes: add `!` after type/scope — `feat!: redesign auth token forma
 
 ## Key Patterns
 
-| Pattern                   | Implementation                                                             |
-| ------------------------- | -------------------------------------------------------------------------- |
-| **Secrets**               | 1Password Operator (`OnePasswordItem` CRD) — never hardcode                |
-| **Container images**      | apko + rules_apko (not Dockerfiles) — always dual-arch (x86_64 + aarch64)  |
-| **Auto image updates**    | ArgoCD Image Updater (`imageupdater.yaml` in `projects/{service}/deploy/`) |
-| **Image pinning**         | Bazel `helm_images_values` deep-merges pinned tags into `values.yaml` at build time — never manually set `@sha256:` digests in deploy values files |
-| **Package deps (Python)** | `@pip//package` via aspect_rules_py (not `requirement()`)                  |
-| **Package deps (JS)**     | pnpm + rules_js                                                            |
-| **Non-root containers**   | uid 65532 convention, `runAsNonRoot: true`                                 |
-| **Helm service names**    | Helm prepends `<release-name>-` to service names. A service `agent-orchestrator` in release `agent-platform` is reachable at `agent-platform-agent-orchestrator.<namespace>.svc.cluster.local`. Never hardcode these URLs in Go application defaults — inject from `values.yaml` env vars. |
+| Pattern                   | Implementation                                                                                                                                                                                                                                                                                                        |
+| ------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Secrets**               | 1Password Operator (`OnePasswordItem` CRD) — never hardcode                                                                                                                                                                                                                                                           |
+| **Container images**      | apko + rules_apko (not Dockerfiles) — always dual-arch (x86_64 + aarch64)                                                                                                                                                                                                                                             |
+| **Auto image updates**    | ArgoCD Image Updater (`imageupdater.yaml` in `projects/{service}/deploy/`)                                                                                                                                                                                                                                            |
+| **Image pinning**         | Bazel `helm_images_values` deep-merges pinned tags into `values.yaml` at build time — never manually set `@sha256:` digests in deploy values files                                                                                                                                                                    |
+| **Package deps (Python)** | `@pip//package` via aspect_rules_py (not `requirement()`)                                                                                                                                                                                                                                                             |
+| **Package deps (JS)**     | pnpm + rules_js                                                                                                                                                                                                                                                                                                       |
+| **Non-root containers**   | uid 65532 convention, `runAsNonRoot: true`                                                                                                                                                                                                                                                                            |
+| **Helm service names**    | Helm prepends `<release-name>-` to service names. A service `agent-orchestrator` in release `agent-platform` is reachable at `agent-platform-agent-orchestrator.<namespace>.svc.cluster.local`. Never hardcode these URLs in Go application defaults — inject from `values.yaml` env vars.                            |
+| **Chart version bumps**   | When bumping `Chart.yaml` version, ALWAYS also update `targetRevision` in the service's `deploy/application.yaml`. A `chart-version-bot` automates this, but if you bump manually both files must stay in sync. ArgoCD pulls charts from OCI by version — a stale `targetRevision` means the new chart never deploys. |
 
 ## Cluster Investigation
 
@@ -170,4 +171,5 @@ Static sites deploy via `bazel run //projects/websites:push_all_pages` on main b
 - **Using kubectl/argocd CLI for cluster reads** — use MCP tools via Context Forge; PreToolUse hooks enforce this
 - **Hardcoding `.svc.cluster.local` URLs in Go defaults** — when a Helm release is renamed the service name prefix changes silently; set via `envOr("URL", "")` (no default) and configure in `values.yaml`; semgrep rule `no-hardcoded-k8s-service-url` catches this in CI
 - **Manually pinning `@sha256:` image digests in values files** — digests go stale after CI rebuilds, causing `ImagePullBackOff`; the Bazel pipeline manages pinning automatically; semgrep rule `no-hardcoded-image-digest` catches this in CI
+- **Bumping `Chart.yaml` without `application.yaml`** — the `chart-version-bot` keeps these in sync, but manual bumps must update both `chart/Chart.yaml` version AND `deploy/application.yaml` `targetRevision`; a mismatch means ArgoCD keeps deploying the old chart version with stale image digests
 - **Over-engineering** simple services

--- a/projects/agent_platform/chart/Chart.yaml
+++ b/projects/agent_platform/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: agent-platform
 description: Agent platform — umbrella chart bundling goose sandboxes, MCP servers, and supporting components
 type: application
-version: 0.20.0
+version: 0.20.1
 appVersion: "0.2.0"
 annotations:
   org.opencontainers.image.source: "https://github.com/jomcgi/homelab"

--- a/projects/agent_platform/deploy/application.yaml
+++ b/projects/agent_platform/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: agent-platform
-      targetRevision: 0.20.0
+      targetRevision: 0.20.1
       helm:
         releaseName: agent-platform
         valueFiles:


### PR DESCRIPTION
## Summary
- Bumps chart version 0.20.0 → 0.20.1 and application targetRevision to match
- The chart-version-bot bumped to 0.20.0 before the deep-plan PR merged, so ArgoCD deployed the old image without deep-plan code
- Documents the Chart.yaml + application.yaml sync requirement in CLAUDE.md

## Test plan
- [ ] ArgoCD syncs to 0.20.1, pods roll with new image containing deep-plan UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)