### PR TITLE
fix(agent-orchestrator): fix deep-plan recipe error and improve pipeline UX

### DIFF
--- a/projects/agent_platform/chart/Chart.yaml
+++ b/projects/agent_platform/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: agent-platform
 description: Agent platform — umbrella chart bundling goose sandboxes, MCP servers, and supporting components
 type: application
-version: 0.20.1
+version: 0.20.2
 appVersion: "0.2.0"
 annotations:
   org.opencontainers.image.source: "https://github.com/jomcgi/homelab"

--- a/projects/agent_platform/chart/values.yaml
+++ b/projects/agent_platform/chart/values.yaml
@@ -526,10 +526,8 @@ agent-orchestrator:
               name: developer
             - type: streamable_http
               name: context-forge
-              uri: http://context-forge.mcp-gateway.svc.cluster.local:8000/mcp
+              uri: http://context-forge-gateway-mcp-stack-mcpgateway.mcp.svc.cluster.local:80/mcp/
               timeout: 300
-              headers:
-                Authorization: "Bearer ${CI_DEBUG_MCP_TOKEN}"
             - type: stdio
               name: github
               cmd: pnpm

--- a/projects/agent_platform/deploy/application.yaml
+++ b/projects/agent_platform/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: agent-platform
-      targetRevision: 0.20.1
+      targetRevision: 0.20.2
       helm:
         releaseName: agent-platform
         valueFiles:

--- a/projects/agent_platform/goose_agent/image/recipes/deep-plan.yaml
+++ b/projects/agent_platform/goose_agent/image/recipes/deep-plan.yaml
@@ -67,10 +67,8 @@ extensions:
     name: developer
   - type: streamable_http
     name: context-forge
-    uri: http://context-forge.mcp-gateway.svc.cluster.local:8000/mcp
+    uri: http://context-forge-gateway-mcp-stack-mcpgateway.mcp.svc.cluster.local:80/mcp/
     timeout: 300
-    headers:
-      Authorization: "Bearer ${CI_DEBUG_MCP_TOKEN}"
   - type: stdio
     name: github
     cmd: pnpm

--- a/projects/agent_platform/orchestrator/ui/src/App.jsx
+++ b/projects/agent_platform/orchestrator/ui/src/App.jsx
@@ -1001,7 +1001,6 @@ function PipelineRow({ pipelineJobs, agents, onCancel, isMobile }) {
           cursor: "pointer",
         }}
       >
-        <Dot status={overallStatus} />
         <div style={{ flex: 1, minWidth: 0 }}>
           {pipelineSummary && (
             <p

--- a/projects/agent_platform/orchestrator/ui/src/PipelineComposer.jsx
+++ b/projects/agent_platform/orchestrator/ui/src/PipelineComposer.jsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useCallback, useMemo, useEffect } from "react";
+import { useState, useRef, useCallback, useMemo } from "react";
 import {
   CONDITIONS,
   CONDITION_STYLES,
@@ -847,18 +847,12 @@ export default function PipelineComposer({
   const [submitting, setSubmitting] = useState(false);
   const [composerKey, setComposerKey] = useState(0);
   const dragRef = useRef(null);
-  const appliedResultRef = useRef(null);
 
   const mentionCats = useMemo(() => buildMentionCats(agents), [agents]);
 
-  // When a deep plan result arrives, populate the pipeline (only once per result)
-  useEffect(() => {
-    if (
-      deepPlanResult &&
-      deepPlanResult.length > 0 &&
-      deepPlanResult !== appliedResultRef.current
-    ) {
-      appliedResultRef.current = deepPlanResult;
+  // Apply deep plan result to the pipeline (called explicitly by user)
+  const applyDeepPlan = useCallback(() => {
+    if (deepPlanResult?.length > 0) {
       setPipeline(deepPlanResult);
       setInferSource("deep-plan");
     }
@@ -1000,39 +994,82 @@ export default function PipelineComposer({
                   : "build manually"}
             </span>
           )}
-          {analysisUrl && (
-            <a
-              href={analysisUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              style={{
-                display: "inline-flex",
-                alignItems: "center",
-                gap: 3,
-                marginLeft: 8,
-                fontSize: 10,
-                color: "#6b7280",
-                textDecoration: "none",
-                textTransform: "none",
-                letterSpacing: 0,
-                fontWeight: 400,
-                transition: "color 0.15s",
-              }}
-              onMouseEnter={(e) => (e.currentTarget.style.color = "#1f2937")}
-              onMouseLeave={(e) => (e.currentTarget.style.color = "#6b7280")}
-            >
-              <svg
-                width={10}
-                height={10}
-                viewBox="0 0 24 24"
-                fill="currentColor"
-              >
-                <path d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0 1 12 6.844a9.59 9.59 0 0 1 2.504.337c1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.02 10.02 0 0 0 22 12.017C22 6.484 17.522 2 12 2z" />
-              </svg>
-              View analysis
-            </a>
-          )}
         </Label>
+
+        {/* Deep Plan result actions */}
+        {deepPlanStatus === "done" && deepPlanResult?.length > 0 && (
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 8,
+              marginBottom: 10,
+              padding: "8px 12px",
+              background: "#f0f0ff",
+              borderRadius: 8,
+              border: "0.5px solid #e0e0ff",
+            }}
+          >
+            <span style={{ fontSize: 11.5, color: "#4f46e5", fontWeight: 500 }}>
+              Deep Plan ready
+            </span>
+            {analysisUrl && (
+              <a
+                href={analysisUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                style={{
+                  display: "inline-flex",
+                  alignItems: "center",
+                  gap: 4,
+                  fontSize: 11,
+                  color: "#6b7280",
+                  border: "1px solid #e5e7eb",
+                  borderRadius: 4,
+                  padding: "1px 6px",
+                  textDecoration: "none",
+                  transition: "color 0.15s",
+                }}
+                onMouseEnter={(e) => (e.currentTarget.style.color = "#1f2937")}
+                onMouseLeave={(e) => (e.currentTarget.style.color = "#6b7280")}
+              >
+                <svg
+                  width={10}
+                  height={10}
+                  viewBox="0 0 24 24"
+                  fill="currentColor"
+                >
+                  <path d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0 1 12 6.844a9.59 9.59 0 0 1 2.504.337c1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.02 10.02 0 0 0 22 12.017C22 6.484 17.522 2 12 2z" />
+                </svg>
+                Analysis
+              </a>
+            )}
+            <button
+              onClick={applyDeepPlan}
+              style={{
+                marginLeft: "auto",
+                fontSize: 11,
+                fontWeight: 500,
+                padding: "3px 10px",
+                background: "#4f46e5",
+                color: "#fff",
+                borderRadius: 5,
+                border: "none",
+                cursor: "pointer",
+                fontFamily: "inherit",
+                transition: "background 0.15s",
+              }}
+              onMouseEnter={(e) =>
+                (e.currentTarget.style.background = "#6366f1")
+              }
+              onMouseLeave={(e) =>
+                (e.currentTarget.style.background = "#4f46e5")
+              }
+            >
+              Apply pipeline
+            </button>
+          </div>
+        )}
 
         {pipeline.length === 0 ? (
           <div


### PR DESCRIPTION
## Summary
- **Fix deep-plan recipe failure** — removed unsupported `headers` field from the `streamable_http` extension that caused goose to error with "Invalid recipe: did not find expected key". Now uses the same MCP gateway URL as all other recipes.
- **Fix duplicate status dots** — removed the pipeline-level status dot from `PipelineRow` since per-node dots in the inline flow already communicate status.
- **Improve deep plan UX** — replaced silent auto-populate with an explicit "Deep Plan ready" bar containing an "Analysis" gist link and an "Apply pipeline" button, so users can review the plan before loading it.

## Test plan
- [ ] Submit a deep-plan job and verify it no longer fails with "Invalid recipe"
- [ ] Verify deep plan results show "Deep Plan ready" bar with Analysis + Apply buttons
- [ ] Click "Apply pipeline" and verify steps populate the composer
- [ ] Verify pipeline rows in job list no longer show double status dots
- [ ] Verify existing fast-infer and manual pipeline flows still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)