### PR TITLE
fix(agent-orchestrator): show Apply Pipeline button after page refresh

### DIFF
--- a/projects/agent_platform/chart/Chart.yaml
+++ b/projects/agent_platform/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: agent-platform
 description: Agent platform — umbrella chart bundling goose sandboxes, MCP servers, and supporting components
 type: application
-version: 0.20.3
+version: 0.20.4
 appVersion: "0.2.0"
 annotations:
   org.opencontainers.image.source: "https://github.com/jomcgi/homelab"

--- a/projects/agent_platform/deploy/application.yaml
+++ b/projects/agent_platform/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: agent-platform
-      targetRevision: 0.20.3
+      targetRevision: 0.20.4
       helm:
         releaseName: agent-platform
         valueFiles:

--- a/projects/agent_platform/orchestrator/ui/src/App.jsx
+++ b/projects/agent_platform/orchestrator/ui/src/App.jsx
@@ -1280,6 +1280,30 @@ export default function App() {
     [fetchJobs],
   );
 
+  // Hydrate deep plan state from job list on load. If the user refreshes the
+  // page (or the deep plan was submitted from another tab), the in-memory
+  // deepPlanJobId is lost. Scan the already-fetched job list for the most
+  // recent successful deep-plan job and restore its result so the "Apply
+  // pipeline" button appears without re-running the plan.
+  useEffect(() => {
+    // Only hydrate when no deep plan is active (avoid overwriting in-flight state)
+    if (deepPlanStatus) return;
+    if (!jobs.length) return;
+
+    const recent = jobs.find(
+      (j) => j.profile === "deep-plan" && j.status === "SUCCEEDED",
+    );
+    if (!recent) return;
+
+    const result = getResult(recent);
+    if (result?.pipeline?.length > 0) {
+      setDeepPlanJobId(recent.id);
+      setDeepPlanResult(result.pipeline);
+      setDeepPlanStatus("done");
+      setAnalysisUrl(result.url || null);
+    }
+  }, [jobs, deepPlanStatus]);
+
   // ── Deep Plan ───────────────────────────────────────────────────────────
   const handleDeepPlan = useCallback(async (prompt, currentPipeline) => {
     // Reset state before the async gap to prevent polling the old job ID


### PR DESCRIPTION
## Summary
- Hydrates deep plan state from the job list on page load
- Scans for the most recent successful `deep-plan` job and restores its pipeline result
- The "Apply pipeline" button now appears even after page refresh or if the job was submitted from another tab

## Problem
The "Apply pipeline" button only showed when the deep-plan job was triggered from the PipelineComposer's "Deep Plan" button in the same session. The button state lived in React `useState` — lost on any page refresh. Users would see a successful deep-plan job with a Gist link but no way to apply the pipeline.

## Test plan
- [ ] CI passes
- [ ] Submit a deep-plan job, refresh the page, verify "Apply pipeline" button appears in PipelineComposer
- [ ] Verify clicking "Apply pipeline" loads the steps into the composer
- [ ] Verify that triggering a new deep plan from the button still works (doesn't conflict with hydration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)