### PR TITLE
fix(agent-orchestrator): add missing useEffect import

### DIFF
--- a/projects/agent_platform/chart/Chart.yaml
+++ b/projects/agent_platform/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: agent-platform
 description: Agent platform — umbrella chart bundling goose sandboxes, MCP servers, and supporting components
 type: application
-version: 0.20.5
+version: 0.20.6
 appVersion: "0.2.0"
 annotations:
   org.opencontainers.image.source: "https://github.com/jomcgi/homelab"

--- a/projects/agent_platform/deploy/application.yaml
+++ b/projects/agent_platform/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: agent-platform
-      targetRevision: 0.20.5
+      targetRevision: 0.20.6
       helm:
         releaseName: agent-platform
         valueFiles:

--- a/projects/agent_platform/orchestrator/ui/src/PipelineComposer.jsx
+++ b/projects/agent_platform/orchestrator/ui/src/PipelineComposer.jsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useCallback, useMemo } from "react";
+import { useState, useEffect, useRef, useCallback, useMemo } from "react";
 import {
   CONDITIONS,
   CONDITION_STYLES,


### PR DESCRIPTION
## Summary
- Adds `useEffect` to the React import in `PipelineComposer.jsx` — it was used by the auto-apply deep plan logic but never imported, causing `ReferenceError: useEffect is not defined` which broke the entire page.

## Test plan
- [ ] Page loads without console errors
- [ ] Deep Plan auto-apply still works when Apply Pipeline is clicked on a job row

🤖 Generated with [Claude Code](https://claude.com/claude-code)