### PR TITLE
fix(agent-platform): bump research recipe limits

### DIFF
--- a/projects/agent_platform/chart/Chart.yaml
+++ b/projects/agent_platform/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: agent-platform
 description: Agent platform — umbrella chart bundling goose sandboxes, MCP servers, and supporting components
 type: application
-version: 0.20.6
+version: 0.20.7
 appVersion: "0.2.0"
 annotations:
   org.opencontainers.image.source: "https://github.com/jomcgi/homelab"

--- a/projects/agent_platform/deploy/application.yaml
+++ b/projects/agent_platform/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: agent-platform
-      targetRevision: 0.20.6
+      targetRevision: 0.20.7
       helm:
         releaseName: agent-platform
         valueFiles:

--- a/projects/agent_platform/goose_agent/image/recipes/research.yaml
+++ b/projects/agent_platform/goose_agent/image/recipes/research.yaml
@@ -49,5 +49,5 @@ extensions:
     args: ["dlx", "@modelcontextprotocol/server-github"]
     env_keys: ["GITHUB_TOKEN"]
 settings:
-  max_turns: 30
-  max_tool_repetitions: 5
+  max_turns: 60
+  max_tool_repetitions: 15


### PR DESCRIPTION
## Summary
- Bumps `max_turns` from 30 → 60 and `max_tool_repetitions` from 5 → 15 for the research recipe
- Research tasks with multiple subtopics were exhausting the turn limit before creating the gist output, resulting in jobs marked SUCCEEDED but with no result artifact

## Test plan
- [ ] Submit a multi-topic research job and verify it completes with a gist URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)