### PR TITLE
fix(agent-orchestrator): periodic reconciliation for stuck RUNNING jobs

### DIFF
--- a/projects/agent_platform/chart/Chart.yaml
+++ b/projects/agent_platform/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: agent-platform
 description: Agent platform — umbrella chart bundling goose sandboxes, MCP servers, and supporting components
 type: application
-version: 0.23.0
+version: 0.23.1
 appVersion: "0.2.0"
 annotations:
   org.opencontainers.image.source: "https://github.com/jomcgi/homelab"
@@ -20,7 +20,7 @@ dependencies:
     condition: goose-sandboxes.enabled
 
   - name: agent-orchestrator
-    version: "0.6.0"
+    version: "0.7.0"
     repository: "file://./orchestrator"
     condition: agent-orchestrator.enabled
 

--- a/projects/agent_platform/chart/orchestrator/Chart.yaml
+++ b/projects/agent_platform/chart/orchestrator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: agent-orchestrator
 description: Orchestrates Goose agent tasks via REST API with NATS-backed queue and state
 type: application
-version: 0.6.0
+version: 0.7.0
 appVersion: "0.1.0"
 annotations:
   org.opencontainers.image.source: "https://github.com/jomcgi/homelab"

--- a/projects/agent_platform/chart/orchestrator/templates/deployment.yaml
+++ b/projects/agent_platform/chart/orchestrator/templates/deployment.yaml
@@ -57,6 +57,8 @@ spec:
           value: {{ .Values.config.jobInactivityTimeout | quote }}
         - name: JOB_MAX_DURATION
           value: {{ .Values.config.jobMaxDuration | quote }}
+        - name: RECONCILE_INTERVAL
+          value: {{ .Values.config.reconcileInterval | quote }}
         {{- if .Values.config.inferenceUrl }}
         - name: INFERENCE_URL
           value: {{ .Values.config.inferenceUrl | quote }}

--- a/projects/agent_platform/chart/orchestrator/values.yaml
+++ b/projects/agent_platform/chart/orchestrator/values.yaml
@@ -60,6 +60,7 @@ config:
   httpPort: "8080"
   jobInactivityTimeout: "10m"
   jobMaxDuration: "168h"
+  reconcileInterval: "60s"
   # OpenAI-compatible inference endpoint for pipeline planning.
   # The orchestrator proxies POST /infer to this URL.
   inferenceUrl: ""

--- a/projects/agent_platform/deploy/application.yaml
+++ b/projects/agent_platform/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: agent-platform
-      targetRevision: 0.23.0
+      targetRevision: 0.23.1
       helm:
         releaseName: agent-platform
         valueFiles:

--- a/projects/agent_platform/orchestrator/main.go
+++ b/projects/agent_platform/orchestrator/main.go
@@ -47,6 +47,11 @@ func main() {
 		logger.Error("invalid JOB_MAX_DURATION", "error", err)
 		os.Exit(1)
 	}
+	reconcileInterval, err := time.ParseDuration(envOr("RECONCILE_INTERVAL", "60s"))
+	if err != nil {
+		logger.Error("invalid RECONCILE_INTERVAL", "error", err)
+		os.Exit(1)
+	}
 
 	// Connect to NATS.
 	nc, err := nats.Connect(natsURL,
@@ -118,12 +123,15 @@ func main() {
 		ReadHeaderTimeout: 10 * time.Second,
 	}
 
-	// Reconcile orphaned jobs before starting the consumer.
-	// After a restart, jobs left in RUNNING state may still have active
-	// runners (HTTP) or may be truly orphaned. Check runner status first,
-	// then reset stale jobs for retry.
+	// Reconcile orphaned jobs before starting the consumer, then
+	// continue reconciling periodically. After a restart, the initial
+	// pass may find runners still active ("running") and leave them
+	// alone. The periodic loop catches those jobs once the runner
+	// finishes — without it, completed jobs stay stuck in RUNNING
+	// forever because the consumer only processes PENDING jobs.
 	if sandbox != nil {
 		reconcileOrphanedJobs(ctx, store, sandbox.dynClient, sandboxNamespace, sandbox.CheckRunnerForClaim, sandbox.FetchOutputForClaim, logger)
+		go runPeriodicReconcile(ctx, reconcileInterval, store, sandbox, sandboxNamespace, logger)
 	}
 
 	// Start consumer if sandbox is available.
@@ -260,4 +268,22 @@ func envOr(key, fallback string) string {
 		return v
 	}
 	return fallback
+}
+
+// runPeriodicReconcile runs reconcileOrphanedJobs on a ticker until ctx is
+// cancelled. This catches jobs whose runners finish after the startup
+// reconciliation pass — without it, those jobs stay RUNNING forever.
+func runPeriodicReconcile(ctx context.Context, interval time.Duration, store Store, sandbox *SandboxExecutor, namespace string, logger *slog.Logger) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	logger.Info("periodic reconciler started", "interval", interval)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			reconcileOrphanedJobs(ctx, store, sandbox.dynClient, namespace, sandbox.CheckRunnerForClaim, sandbox.FetchOutputForClaim, logger)
+		}
+	}
 }

--- a/projects/agent_platform/orchestrator/reconcile_test.go
+++ b/projects/agent_platform/orchestrator/reconcile_test.go
@@ -330,6 +330,62 @@ func TestReconcileOrphanedJobs_FailedRunnerRetries(t *testing.T) {
 	}
 }
 
+// TestReconcileOrphanedJobs_PeriodicCatchesCompletedJob simulates the bug
+// where a runner finishes after the initial reconciliation pass. The first
+// pass sees "running" and leaves the job alone; the second pass (periodic)
+// sees "done" and correctly marks it SUCCEEDED.
+func TestReconcileOrphanedJobs_PeriodicCatchesCompletedJob(t *testing.T) {
+	store := newMemStore()
+	ctx := context.Background()
+
+	store.Put(ctx, &JobRecord{
+		ID:         "job-late-finish",
+		Task:       "task that finishes after first reconcile",
+		Status:     JobRunning,
+		CreatedAt:  time.Now().Add(-1 * time.Hour),
+		MaxRetries: 2,
+		Attempts: []Attempt{{
+			Number:           1,
+			SandboxClaimName: "orch-job-late-finish-1",
+			StartedAt:        time.Now().Add(-1 * time.Hour),
+		}},
+	})
+
+	callCount := 0
+	// First call: runner is still going. Second call: runner finished.
+	checkRunner := func(_ context.Context, claimName string) (string, int, error) {
+		callCount++
+		if callCount == 1 {
+			return "running", 0, nil
+		}
+		return "done", 0, nil
+	}
+
+	fetchOutput := func(_ context.Context, claimName string) (string, error) {
+		return "task completed successfully\n", nil
+	}
+
+	// First pass: should leave job as RUNNING.
+	reconcileOrphanedJobs(ctx, store, nil, "goose-sandboxes", checkRunner, fetchOutput, slog.Default())
+
+	job, _ := store.Get(ctx, "job-late-finish")
+	if job.Status != JobRunning {
+		t.Fatalf("after first pass: status = %s, want RUNNING", job.Status)
+	}
+
+	// Second pass (simulates periodic tick): should mark SUCCEEDED.
+	reconcileOrphanedJobs(ctx, store, nil, "goose-sandboxes", checkRunner, fetchOutput, slog.Default())
+
+	job, _ = store.Get(ctx, "job-late-finish")
+	if job.Status != JobSucceeded {
+		t.Errorf("after second pass: status = %s, want SUCCEEDED", job.Status)
+	}
+	last := job.Attempts[len(job.Attempts)-1]
+	if last.Output != "task completed successfully\n" {
+		t.Errorf("output = %q, want task output", last.Output)
+	}
+}
+
 func TestReconcileOrphanedJobs_RunnerUnreachableFallsBack(t *testing.T) {
 	store := newMemStore()
 	ctx := context.Background()


### PR DESCRIPTION
## Summary

- After an orchestrator restart, the startup reconciler sees still-active runners and leaves jobs as RUNNING ("will re-attach"). But the consumer only processes PENDING jobs — it ACKs and discards RUNNING ones. If a runner finishes after the initial reconciliation pass, the job stays stuck in RUNNING forever.
- Adds a periodic reconciliation loop (default 60s, configurable via `RECONCILE_INTERVAL`) that re-runs `reconcileOrphanedJobs` on a ticker, catching jobs that transition from running → done/failed between passes.

## Test plan

- [ ] New test `TestReconcileOrphanedJobs_PeriodicCatchesCompletedJob` verifies two-pass behavior (first pass sees "running", second sees "done" → SUCCEEDED)
- [ ] Existing reconcile tests still pass
- [ ] CI builds and pushes successfully
- [ ] After deploy, verify the two currently stuck jobs get reconciled

🤖 Generated with [Claude Code](https://claude.com/claude-code)