### PR TITLE
docs(hikes): update README to match current structure

### DIFF
--- a/projects/hikes/README.md
+++ b/projects/hikes/README.md
@@ -24,7 +24,7 @@ flowchart LR
 
 ## Data Collected
 
-- Route names, descriptions, and difficulty ratings
+- Route names and descriptions
 - GPS coordinates
 - Distance, elevation gain, and estimated duration
 - Weather forecasts for route locations
@@ -45,7 +45,6 @@ Environment variables:
 
 | Variable                          | Description                | Default                           |
 | --------------------------------- | -------------------------- | --------------------------------- |
-| `LOG_LEVEL`                       | Logging verbosity          | `INFO`                            |
 | `CLOUDFLARE_S3_ENDPOINT`          | Cloudflare R2 endpoint URL | *(required for update_forecast)*  |
 | `CLOUDFLARE_S3_ACCESS_KEY_ID`     | R2 access key ID           | *(required for update_forecast)*  |
 | `CLOUDFLARE_S3_ACCESS_KEY_SECRET` | R2 access key secret       | *(required for update_forecast)*  |


### PR DESCRIPTION
## Summary

- Removes "difficulty ratings" from the Data Collected section — the `Walk` model (`scrape_walkhighlands/scrape.py`) has no difficulty field and the scraper never collects it
- Removes `LOG_LEVEL` from the Configuration table — the variable appears in `.env.example` but is not read by either `scrape_walkhighlands` or `update_forecast`

No new content added; only inaccurate claims corrected.

## Test plan

- [x] `bazel test //...` passes in CI (README-only change, no code modified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)