### PR TITLE
fix(agent-platform): add explicit Linkerd injection for orchestrator

### DIFF
--- a/projects/agent_platform/deploy/application.yaml
+++ b/projects/agent_platform/deploy/application.yaml
@@ -21,7 +21,7 @@ spec:
   destination:
     server: https://kubernetes.default.svc
     namespace: agent-platform
-  # Ignore OTel fields injected by Kyverno mutation policy.
+  # Ignore fields injected by Kyverno/Linkerd mutation policies.
   # IMPORTANT: Do NOT ignore the entire env array — that prevents ArgoCD from
   # syncing new env vars added by the Helm chart (e.g. INFERENCE_URL).
   ignoreDifferences:
@@ -29,6 +29,8 @@ spec:
       kind: Deployment
       jqPathExpressions:
         - .spec.template.metadata.annotations."otel.injected-by"
+        - .spec.template.metadata.annotations."linkerd.io/inject"
+        - .spec.template.metadata.annotations."linkerd.io/injected-by"
   syncPolicy:
     automated:
       prune: true

--- a/projects/agent_platform/deploy/values.yaml
+++ b/projects/agent_platform/deploy/values.yaml
@@ -213,6 +213,7 @@ agent-orchestrator:
     onepassword:
       itemPath: "vaults/k8s-homelab/items/ghcr-read-permissions"
   podAnnotations:
+    linkerd.io/inject: enabled
     instrumentation.opentelemetry.io/inject-go: "go"
     instrumentation.opentelemetry.io/otel-go-auto-target-exe: "/opt/app"
   httpRoute:


### PR DESCRIPTION
The orchestrator pod is in CrashLoopBackOff because it cannot communicate
with NATS over Linkerd mTLS — the pod has no Linkerd sidecar while NATS
does. Add linkerd.io/inject: enabled explicitly to orchestrator pod
annotations so injection doesn't depend on the namespace-level annotation
(which ArgoCD self-heal may revert). Also add Linkerd annotations to
ignoreDifferences so ArgoCD doesn't conflict with webhook-injected metadata.

https://claude.ai/code/session_01HS1HR2xzDnN8b1ZAPtAH5a