### PR TITLE
fix(ships): remove RespectIgnoreDifferences blocking env var updates

### DIFF
--- a/projects/ships/deploy/application.yaml
+++ b/projects/ships/deploy/application.yaml
@@ -34,4 +34,3 @@ spec:
       selfHeal: true
     syncOptions:
       - CreateNamespace=true
-      - RespectIgnoreDifferences=true


### PR DESCRIPTION
## Summary

- `RespectIgnoreDifferences=true` combined with `containers[].env` in `ignoreDifferences` was causing ArgoCD to preserve stale LIVE env vars during sync, overriding chart values
- This blocked the `PUBLIC_DIR` fix from PR #1182 (chart 0.2.1) from taking effect — the frontend still served "Not Found"
- Removing `RespectIgnoreDifferences` allows ArgoCD to apply the correct chart values during sync while still ignoring env diffs for OutOfSync detection (no Kyverno flapping)

## Test plan

- [ ] CI passes
- [ ] After merge + ArgoCD sync, verify `marine-frontend` pod shows `PUBLIC_DIR: /app/public`
- [ ] Verify `ships.jomcgi.dev` loads the frontend
- [ ] Verify ArgoCD doesn't enter a sync loop from Kyverno OTel injection drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)