### PR TITLE
feat(context-forge): enable catalog and tool cancellation

### DIFF
--- a/projects/mcp/context-forge-gateway/deploy/values.yaml
+++ b/projects/mcp/context-forge-gateway/deploy/values.yaml
@@ -4,6 +4,8 @@ mcp-stack:
     config:
       PLATFORM_ADMIN_EMAIL: "admin@jomcgi.dev"
       MCPGATEWAY_UI_ENABLED: "true"
+      MCPGATEWAY_CATALOG_ENABLED: "true"
+      MCPGATEWAY_TOOL_CANCELLATION_ENABLED: "true"
     probes:
       startup:
         type: exec


### PR DESCRIPTION
## Summary
- Enable `MCPGATEWAY_CATALOG_ENABLED` — browsable catalog of registered MCP servers with health checks
- Enable `MCPGATEWAY_TOOL_CANCELLATION_ENABLED` — ability to cancel long-running tool executions

## Test plan
- [ ] Verify ArgoCD syncs the updated config
- [ ] Confirm catalog is accessible via the admin UI
- [ ] Test tool cancellation on a long-running tool invocation

🤖 Generated with [Claude Code](https://claude.com/claude-code)