### PR TITLE
fix(context-forge): set admin email to match Google OIDC identity

### DIFF
--- a/projects/mcp/context-forge-gateway/deploy/values.yaml
+++ b/projects/mcp/context-forge-gateway/deploy/values.yaml
@@ -2,7 +2,7 @@
 mcp-stack:
   mcpContextForge:
     config:
-      PLATFORM_ADMIN_EMAIL: "admin@jomcgi.dev"
+      PLATFORM_ADMIN_EMAIL: "joe@jomcgi.dev"
       MCPGATEWAY_UI_ENABLED: "true"
       MCPGATEWAY_CATALOG_ENABLED: "true"
       MCPGATEWAY_TOOL_CANCELLATION_ENABLED: "true"


### PR DESCRIPTION
## Summary
- Update `PLATFORM_ADMIN_EMAIL` from `admin@jomcgi.dev` to `joe@jomcgi.dev`
- This must match the Google OIDC email injected by mcp-oauth-proxy via `X-Forwarded-User` header, otherwise the UI won't grant admin privileges

## Test plan
- [ ] Visit mcp.jomcgi.dev, authenticate via Google, confirm admin access to the UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)