### PR TITLE
fix(context-forge): move admin email to 1Password secret

### DIFF
--- a/projects/mcp/context-forge-gateway/deploy/values.yaml
+++ b/projects/mcp/context-forge-gateway/deploy/values.yaml
@@ -2,7 +2,6 @@
 mcp-stack:
   mcpContextForge:
     config:
-      PLATFORM_ADMIN_EMAIL: "joe@jomcgi.dev"
       MCPGATEWAY_UI_ENABLED: "true"
       MCPGATEWAY_CATALOG_ENABLED: "true"
       MCPGATEWAY_TOOL_CANCELLATION_ENABLED: "true"


### PR DESCRIPTION
## Summary
- Remove `PLATFORM_ADMIN_EMAIL` from the deploy values `config:` block
- Both `PLATFORM_ADMIN_EMAIL` and `PLATFORM_ADMIN_PASSWORD` are now sourced from the 1Password `context-forge` secret via `extraEnvFrom`
- Avoids env var precedence conflict between ConfigMap and Secret

## Test plan
- [ ] Verify ArgoCD syncs and pod restarts with new config
- [ ] Log in to mcp.jomcgi.dev UI with joe@jomcgi.dev credentials

🤖 Generated with [Claude Code](https://claude.com/claude-code)