### PR TITLE
fix(context-forge): remove admin email from chart defaults

### DIFF
--- a/projects/mcp/context-forge-gateway/chart/Chart.yaml
+++ b/projects/mcp/context-forge-gateway/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: context-forge
 description: MCP gateway aggregating observability and infrastructure tools
 type: application
-version: 2.0.0
+version: 2.0.1
 appVersion: "1.0.0-RC1"
 annotations:
   org.opencontainers.image.source: "https://github.com/jomcgi/homelab"

--- a/projects/mcp/context-forge-gateway/chart/values.yaml
+++ b/projects/mcp/context-forge-gateway/chart/values.yaml
@@ -14,7 +14,6 @@ mcp-stack:
       enabled: false
     config:
       GUNICORN_WORKERS: "2"
-      PLATFORM_ADMIN_EMAIL: "admin@jomcgi.dev"
       MCPGATEWAY_UI_ENABLED: "false"
       MCPGATEWAY_A2A_ENABLED: "false"
       LLMCHAT_ENABLED: "false"
@@ -83,7 +82,7 @@ mcp-stack:
   mcpFastTimeServer:
     enabled: false
 
-# 1Password secret — provides JWT_SECRET_KEY, AUTH_ENCRYPTION_SECRET
+# 1Password secret — provides JWT_SECRET_KEY, AUTH_ENCRYPTION_SECRET, PLATFORM_ADMIN_EMAIL
 secret:
   name: context-forge
   itemPath: ""


### PR DESCRIPTION
The chart default `PLATFORM_ADMIN_EMAIL: admin@jomcgi.dev` in the config block was overriding the value from the 1Password secret (`extraEnvFrom`), because in Kubernetes explicit `env` entries take precedence over `envFrom`.

This caused the admin UI login to fail — the gateway was matching against the stale `admin@jomcgi.dev` email instead of the correct identity from the 1Password secret.

**Changes:**
- Remove `PLATFORM_ADMIN_EMAIL` from chart default config (now solely managed via 1Password)
- Update secret comment to reflect it now provides `PLATFORM_ADMIN_EMAIL`
- Bump chart version to 2.0.1