### PR TITLE
fix(coredns): correct YAML structure in application.yaml

### DIFF
--- a/projects/platform/coredns/application.yaml
+++ b/projects/platform/coredns/application.yaml
@@ -24,6 +24,12 @@ spec:
     syncOptions:
       - CreateNamespace=false
       - RespectIgnoreDifferences=true
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m
   # Ignore fields that K3s manages
   ignoreDifferences:
     - group: ""
@@ -33,9 +39,3 @@ spec:
         - /data/NodeHosts
         - /metadata/annotations
         - /metadata/labels
-    retry:
-      limit: 5
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 3m


### PR DESCRIPTION
## Summary
- Moved `retry` block from under `ignoreDifferences` to under `syncPolicy` where it belongs
- Fixes `kustomize build` failure: `MalformedYAMLError: yaml: line 28: did not find expected '-' indicator`

## Test plan
- [ ] CI passes (kustomize build no longer fails)
- [ ] ArgoCD syncs coredns-config application successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)