### PR TITLE
test(trips): add coverage for backend API handlers

### DIFF
--- a/projects/trips/backend/trips_api_test.py
+++ b/projects/trips/backend/trips_api_test.py
@@ -896,8 +896,8 @@ class TestTripsStateAdditional:
     async def test_connect_stores_nats_connection(self, state):
         """connect() should store the NATS connection in self.nc and self.js."""
         mock_nc = AsyncMock()
-        mock_js = AsyncMock()
-        mock_nc.jetstream.return_value = mock_js
+        mock_js = MagicMock()
+        mock_nc.jetstream = MagicMock(return_value=mock_js)
 
         with patch("nats.connect", return_value=mock_nc):
             state.replay_stream = AsyncMock()


### PR DESCRIPTION
## Summary

- Extends `trips_api_test.py` with 50+ new tests across 7 new test classes, covering previously untested handlers and code paths in `projects/trips/backend/main.py`
- New classes: `TestConnectionManagerAdditional`, `TestTripsStateAdditional`, `TestJetStreamReplayAdditional`, `TestWebSocketEndpoint`, `TestRequireApiKeyAdditional`, `TestTripPointAdditional`
- Key gaps filled: `TripsState.close()`, `TripsState.connect()` lifecycle, WebSocket `/ws/live` endpoint (connect/ping-pong/disconnect), `broadcast_viewer_count`, combined pagination, HOSTNAME-derived consumer names, error recovery in `replay_stream`/`subscribe_live`/`_process_subscription`

## Test plan

- [ ] CI runs `bazel test //projects/trips/backend:trips_api_test` green
- [ ] No production code modified
- [ ] All new tests follow existing `@pytest.mark.asyncio` / `MagicMock` / `patch.object` patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)