### PR TITLE
test(cloudflare-operator): add controller reconciliation tests

### DIFF
--- a/projects/operators/cloudflare/internal/controller/BUILD
+++ b/projects/operators/cloudflare/internal/controller/BUILD
@@ -45,7 +45,12 @@ go_library(
 go_test(
     name = "controller_test",
     srcs = [
+        "cloudflareaccesspolicy_controller_test.go",
         "cloudflaretunnel_controller_test.go",
+        "gateway_controller_test.go",
+        "gatewayclass_controller_test.go",
+        "httproute_controller_test.go",
+        "service_controller_test.go",
         "suite_test.go",
     ],
     embed = [":controller"],
@@ -53,13 +58,16 @@ go_test(
     deps = [
         "//projects/operators/cloudflare/api/v1:api",
         "//projects/operators/cloudflare/internal/cloudflare",
+        "//projects/operators/cloudflare/internal/telemetry",
         "@com_github_cloudflare_cloudflare_go//:cloudflare-go",
         "@com_github_onsi_ginkgo_v2//:ginkgo",
         "@com_github_onsi_gomega//:gomega",
+        "@io_k8s_api//core/v1:core",
         "@io_k8s_apimachinery//pkg/api/errors",
         "@io_k8s_apimachinery//pkg/api/meta",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:meta",
         "@io_k8s_apimachinery//pkg/types",
+        "@io_k8s_apimachinery//pkg/util/intstr",
         "@io_k8s_client_go//kubernetes/scheme",
         "@io_k8s_client_go//rest",
         "@io_k8s_sigs_controller_runtime//pkg/client",
@@ -67,5 +75,7 @@ go_test(
         "@io_k8s_sigs_controller_runtime//pkg/log",
         "@io_k8s_sigs_controller_runtime//pkg/log/zap",
         "@io_k8s_sigs_controller_runtime//pkg/reconcile",
+        "@io_k8s_sigs_gateway_api//apis/v1:apis",
+        "@io_k8s_utils//ptr",
     ],
 )

--- a/projects/operators/cloudflare/internal/controller/cloudflareaccesspolicy_controller_test.go
+++ b/projects/operators/cloudflare/internal/controller/cloudflareaccesspolicy_controller_test.go
@@ -1,0 +1,586 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	tunnelsv1 "github.com/jomcgi/homelab/projects/operators/cloudflare/api/v1"
+	"github.com/jomcgi/homelab/projects/operators/cloudflare/internal/telemetry"
+)
+
+var _ = Describe("CloudflareAccessPolicy Controller", func() {
+	Context("When reconciling a CloudflareAccessPolicy", func() {
+		var (
+			ctx                context.Context
+			resourceName       string
+			typeNamespacedName types.NamespacedName
+		)
+
+		BeforeEach(func() {
+			ctx = context.Background()
+			resourceName = fmt.Sprintf("test-policy-%d", time.Now().UnixNano())
+			typeNamespacedName = types.NamespacedName{
+				Name:      resourceName,
+				Namespace: "default",
+			}
+		})
+
+		AfterEach(func() {
+			policy := &tunnelsv1.CloudflareAccessPolicy{}
+			err := k8sClient.Get(ctx, typeNamespacedName, policy)
+			if err == nil {
+				policy.Finalizers = []string{}
+				_ = k8sClient.Update(ctx, policy)
+				_ = k8sClient.Delete(ctx, policy)
+				Eventually(func() bool {
+					return errors.IsNotFound(k8sClient.Get(ctx, typeNamespacedName, policy))
+				}, time.Second*5).Should(BeTrue())
+			}
+		})
+
+		newReconciler := func() *CloudflareAccessPolicyReconciler {
+			return &CloudflareAccessPolicyReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+				tracer: telemetry.GetTracer("test-accesspolicy"),
+			}
+		}
+
+		createAccessPolicy := func(targetKind, targetName string) *tunnelsv1.CloudflareAccessPolicy {
+			policy := &tunnelsv1.CloudflareAccessPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      resourceName,
+					Namespace: "default",
+				},
+				Spec: tunnelsv1.CloudflareAccessPolicySpec{
+					TargetRef: tunnelsv1.PolicyTargetReference{
+						Group: "gateway.networking.k8s.io",
+						Kind:  targetKind,
+						Name:  targetName,
+					},
+					Application: tunnelsv1.ApplicationConfig{
+						Name:            "Test App",
+						SessionDuration: "24h",
+						Type:            "self_hosted",
+					},
+					Policies: []tunnelsv1.AccessPolicy{
+						{
+							Name:     "allow-all",
+							Decision: "allow",
+							Rules: []tunnelsv1.AccessPolicyRule{
+								{Everyone: true},
+							},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, policy)).To(Succeed())
+			return policy
+		}
+
+		It("should return nil when CloudflareAccessPolicy is not found", func() {
+			r := newReconciler()
+			result, err := r.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: "does-not-exist", Namespace: "default"},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).To(Equal(time.Duration(0)))
+		})
+
+		It("should add finalizer on first reconcile", func() {
+			By("Creating a CloudflareAccessPolicy")
+			createAccessPolicy("HTTPRoute", "my-route")
+
+			By("Reconciling — should add finalizer")
+			r := newReconciler()
+			_, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Checking that finalizer was added")
+			policy := &tunnelsv1.CloudflareAccessPolicy{}
+			Expect(k8sClient.Get(ctx, typeNamespacedName, policy)).To(Succeed())
+			Expect(policy.Finalizers).To(ContainElement(AccessPolicyFinalizerName))
+		})
+
+		It("should handle deletion when no target exists (removes finalizer)", func() {
+			By("Creating a CloudflareAccessPolicy with finalizer")
+			policy := createAccessPolicy("HTTPRoute", "nonexistent-route")
+
+			r := newReconciler()
+			_, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Deleting the policy")
+			Expect(k8sClient.Delete(ctx, policy)).To(Succeed())
+
+			By("Reconciling deletion — should remove finalizer even without Gateway client")
+			_, err = r.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Checking resource is fully deleted")
+			Eventually(func() bool {
+				return errors.IsNotFound(k8sClient.Get(ctx, typeNamespacedName, policy))
+			}, time.Second*5).Should(BeTrue())
+		})
+
+		It("should set ResolvedRefs=False when target HTTPRoute is not found", func() {
+			By("Creating a CloudflareAccessPolicy with finalizer already set")
+			policy := &tunnelsv1.CloudflareAccessPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       resourceName,
+					Namespace:  "default",
+					Finalizers: []string{AccessPolicyFinalizerName},
+				},
+				Spec: tunnelsv1.CloudflareAccessPolicySpec{
+					TargetRef: tunnelsv1.PolicyTargetReference{
+						Group: "gateway.networking.k8s.io",
+						Kind:  "HTTPRoute",
+						Name:  "nonexistent-httproute",
+					},
+					Application: tunnelsv1.ApplicationConfig{
+						Name: "Test App",
+					},
+					Policies: []tunnelsv1.AccessPolicy{
+						{
+							Decision: "allow",
+							Rules:    []tunnelsv1.AccessPolicyRule{{Everyone: true}},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, policy)).To(Succeed())
+
+			By("Reconciling")
+			r := newReconciler()
+			result, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+			Expect(err).To(HaveOccurred())
+			Expect(result.RequeueAfter).To(Equal(30 * time.Second))
+
+			By("Checking ResolvedRefs condition is False")
+			updated := &tunnelsv1.CloudflareAccessPolicy{}
+			Expect(k8sClient.Get(ctx, typeNamespacedName, updated)).To(Succeed())
+			resolvedRefs := meta.FindStatusCondition(updated.Status.Conditions, tunnelsv1.TypeResolvedRefs)
+			Expect(resolvedRefs).NotTo(BeNil())
+			Expect(resolvedRefs.Status).To(Equal(metav1.ConditionFalse))
+			Expect(resolvedRefs.Reason).To(Equal(tunnelsv1.ReasonTargetNotFound))
+		})
+
+		It("should set Programmed=False when Cloudflare client cannot be obtained (no Gateway)", func() {
+			By("Creating an HTTPRoute as target (but no parent Gateway)")
+			routeName := fmt.Sprintf("test-route-%d", time.Now().UnixNano())
+			route := &gatewayv1.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      routeName,
+					Namespace: "default",
+				},
+				Spec: gatewayv1.HTTPRouteSpec{
+					Hostnames: []gatewayv1.Hostname{"test.example.com"},
+					Rules: []gatewayv1.HTTPRouteRule{
+						{
+							BackendRefs: []gatewayv1.HTTPBackendRef{
+								{
+									BackendRef: gatewayv1.BackendRef{
+										BackendObjectReference: gatewayv1.BackendObjectReference{
+											Name: "backend",
+											Port: ptr.To(gatewayv1.PortNumber(8080)),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, route)).To(Succeed())
+			DeferCleanup(func() {
+				route.Finalizers = []string{}
+				_ = k8sClient.Update(ctx, route)
+				_ = k8sClient.Delete(ctx, route)
+			})
+
+			By("Creating a CloudflareAccessPolicy targeting the HTTPRoute (with finalizer)")
+			policy := &tunnelsv1.CloudflareAccessPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       resourceName,
+					Namespace:  "default",
+					Finalizers: []string{AccessPolicyFinalizerName},
+				},
+				Spec: tunnelsv1.CloudflareAccessPolicySpec{
+					TargetRef: tunnelsv1.PolicyTargetReference{
+						Group: "gateway.networking.k8s.io",
+						Kind:  "HTTPRoute",
+						Name:  routeName,
+					},
+					Application: tunnelsv1.ApplicationConfig{
+						Name: "Test App",
+					},
+					Policies: []tunnelsv1.AccessPolicy{
+						{
+							Decision: "allow",
+							Rules:    []tunnelsv1.AccessPolicyRule{{Everyone: true}},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, policy)).To(Succeed())
+
+			By("Reconciling — target resolves but no Cloudflare Gateway exists")
+			r := newReconciler()
+			result, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+			Expect(err).To(HaveOccurred())
+			Expect(result.RequeueAfter).To(Equal(30 * time.Second))
+		})
+
+		It("should set Programmed=False when target Gateway exists but missing account ID", func() {
+			By("Creating a cloudflare Gateway without account ID annotation")
+			gwName := fmt.Sprintf("cf-gw-noacct-%d", time.Now().UnixNano())
+			gw := &gatewayv1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      gwName,
+					Namespace: "default",
+				},
+				Spec: gatewayv1.GatewaySpec{
+					GatewayClassName: "cloudflare",
+					Listeners: []gatewayv1.Listener{
+						{Name: "https", Protocol: gatewayv1.HTTPSProtocolType, Port: 443},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, gw)).To(Succeed())
+			DeferCleanup(func() {
+				gw.Finalizers = []string{}
+				_ = k8sClient.Update(ctx, gw)
+				_ = k8sClient.Delete(ctx, gw)
+			})
+
+			By("Creating a CloudflareAccessPolicy targeting the Gateway (with finalizer)")
+			policy := &tunnelsv1.CloudflareAccessPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       resourceName,
+					Namespace:  "default",
+					Finalizers: []string{AccessPolicyFinalizerName},
+				},
+				Spec: tunnelsv1.CloudflareAccessPolicySpec{
+					TargetRef: tunnelsv1.PolicyTargetReference{
+						Group: "gateway.networking.k8s.io",
+						Kind:  "Gateway",
+						Name:  gwName,
+					},
+					Application: tunnelsv1.ApplicationConfig{
+						Name:   "Test App",
+						Domain: "test.example.com",
+					},
+					Policies: []tunnelsv1.AccessPolicy{
+						{
+							Decision: "allow",
+							Rules:    []tunnelsv1.AccessPolicyRule{{Everyone: true}},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, policy)).To(Succeed())
+
+			By("Reconciling — Gateway found but no account ID → Cloudflare client creation fails")
+			r := newReconciler()
+			result, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+			Expect(err).To(HaveOccurred())
+			Expect(result.RequeueAfter).To(Equal(30 * time.Second))
+		})
+
+		It("should return error for unsupported targetRef kind during resolveTargetDomain", func() {
+			By("Creating a CloudflareAccessPolicy with unsupported kind (with finalizer)")
+			policy := &tunnelsv1.CloudflareAccessPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       resourceName,
+					Namespace:  "default",
+					Finalizers: []string{AccessPolicyFinalizerName},
+				},
+				Spec: tunnelsv1.CloudflareAccessPolicySpec{
+					TargetRef: tunnelsv1.PolicyTargetReference{
+						Group: "gateway.networking.k8s.io",
+						Kind:  "GatewayClass",
+						Name:  "some-class",
+					},
+					Application: tunnelsv1.ApplicationConfig{},
+					Policies: []tunnelsv1.AccessPolicy{
+						{
+							Decision: "allow",
+							Rules:    []tunnelsv1.AccessPolicyRule{{Everyone: true}},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, policy)).To(Succeed())
+
+			By("Reconciling — should fail with unsupported targetRef kind")
+			r := newReconciler()
+			result, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("unsupported targetRef kind"))
+			Expect(result.RequeueAfter).To(Equal(30 * time.Second))
+		})
+
+		It("should return error when HTTPRoute has no hostnames", func() {
+			By("Creating an HTTPRoute without hostnames")
+			routeName := fmt.Sprintf("no-hostname-route-%d", time.Now().UnixNano())
+			route := &gatewayv1.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      routeName,
+					Namespace: "default",
+				},
+				Spec: gatewayv1.HTTPRouteSpec{
+					Rules: []gatewayv1.HTTPRouteRule{
+						{
+							BackendRefs: []gatewayv1.HTTPBackendRef{
+								{
+									BackendRef: gatewayv1.BackendRef{
+										BackendObjectReference: gatewayv1.BackendObjectReference{
+											Name: "backend",
+											Port: ptr.To(gatewayv1.PortNumber(8080)),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, route)).To(Succeed())
+			DeferCleanup(func() {
+				route.Finalizers = []string{}
+				_ = k8sClient.Update(ctx, route)
+				_ = k8sClient.Delete(ctx, route)
+			})
+
+			By("Creating policy targeting the no-hostname route")
+			policy := &tunnelsv1.CloudflareAccessPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       resourceName,
+					Namespace:  "default",
+					Finalizers: []string{AccessPolicyFinalizerName},
+				},
+				Spec: tunnelsv1.CloudflareAccessPolicySpec{
+					TargetRef: tunnelsv1.PolicyTargetReference{
+						Group: "gateway.networking.k8s.io",
+						Kind:  "HTTPRoute",
+						Name:  routeName,
+					},
+					Application: tunnelsv1.ApplicationConfig{},
+					Policies: []tunnelsv1.AccessPolicy{
+						{
+							Decision: "allow",
+							Rules:    []tunnelsv1.AccessPolicyRule{{Everyone: true}},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, policy)).To(Succeed())
+
+			By("Reconciling — should fail because HTTPRoute has no hostnames")
+			r := newReconciler()
+			result, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("no hostnames"))
+			Expect(result.RequeueAfter).To(Equal(30 * time.Second))
+		})
+
+		It("should return error when targeting a Gateway without explicit domain", func() {
+			By("Creating a cloudflare Gateway")
+			gwName := fmt.Sprintf("gw-nodomain-%d", time.Now().UnixNano())
+			gw := &gatewayv1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      gwName,
+					Namespace: "default",
+				},
+				Spec: gatewayv1.GatewaySpec{
+					GatewayClassName: "cloudflare",
+					Listeners: []gatewayv1.Listener{
+						{Name: "https", Protocol: gatewayv1.HTTPSProtocolType, Port: 443},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, gw)).To(Succeed())
+			DeferCleanup(func() {
+				gw.Finalizers = []string{}
+				_ = k8sClient.Update(ctx, gw)
+				_ = k8sClient.Delete(ctx, gw)
+			})
+
+			By("Creating a policy targeting the Gateway with no domain")
+			policy := &tunnelsv1.CloudflareAccessPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       resourceName,
+					Namespace:  "default",
+					Finalizers: []string{AccessPolicyFinalizerName},
+				},
+				Spec: tunnelsv1.CloudflareAccessPolicySpec{
+					TargetRef: tunnelsv1.PolicyTargetReference{
+						Group: "gateway.networking.k8s.io",
+						Kind:  "Gateway",
+						Name:  gwName,
+					},
+					Application: tunnelsv1.ApplicationConfig{
+						// Domain intentionally not set
+					},
+					Policies: []tunnelsv1.AccessPolicy{
+						{
+							Decision: "allow",
+							Rules:    []tunnelsv1.AccessPolicyRule{{Everyone: true}},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, policy)).To(Succeed())
+
+			By("Reconciling — should fail because Gateway target requires explicit domain")
+			r := newReconciler()
+			result, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("explicit application.domain"))
+			Expect(result.RequeueAfter).To(Equal(30 * time.Second))
+		})
+
+		It("buildApplicationConfig should populate fields correctly", func() {
+			r := newReconciler()
+			policy := &tunnelsv1.CloudflareAccessPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "default",
+				},
+				Spec: tunnelsv1.CloudflareAccessPolicySpec{
+					Application: tunnelsv1.ApplicationConfig{
+						Name:                   "My App",
+						Type:                   "self_hosted",
+						SessionDuration:        "8h",
+						AutoRedirectToIdentity: true,
+						EnableBindingCookie:    true,
+						CustomDenyMessage:      "Access Denied",
+						CustomDenyURL:          "https://deny.example.com",
+					},
+					TargetRef: tunnelsv1.PolicyTargetReference{Kind: "HTTPRoute", Name: "test"},
+					Policies:  []tunnelsv1.AccessPolicy{{Decision: "allow", Rules: []tunnelsv1.AccessPolicyRule{{Everyone: true}}}},
+				},
+			}
+
+			config := r.buildApplicationConfig(policy, "myapp.example.com")
+			Expect(config.Name).To(Equal("My App"))
+			Expect(config.Domain).To(Equal("myapp.example.com"))
+			Expect(config.Type).To(Equal("self_hosted"))
+			Expect(config.SessionDuration).To(Equal("8h"))
+			Expect(config.AutoRedirectToIdentity).To(BeTrue())
+			Expect(config.EnableBindingCookie).To(BeTrue())
+			Expect(config.CustomDenyMessage).To(Equal("Access Denied"))
+			Expect(config.CustomDenyURL).To(Equal("https://deny.example.com"))
+		})
+
+		It("buildApplicationConfig should use defaults for missing fields", func() {
+			r := newReconciler()
+			policy := &tunnelsv1.CloudflareAccessPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "minimal",
+					Namespace: "default",
+				},
+				Spec: tunnelsv1.CloudflareAccessPolicySpec{
+					Application: tunnelsv1.ApplicationConfig{},
+					TargetRef:   tunnelsv1.PolicyTargetReference{Kind: "HTTPRoute", Name: "test"},
+					Policies:    []tunnelsv1.AccessPolicy{{Decision: "allow", Rules: []tunnelsv1.AccessPolicyRule{{Everyone: true}}}},
+				},
+			}
+
+			config := r.buildApplicationConfig(policy, "default.example.com")
+			Expect(config.Name).To(ContainSubstring("access-default-minimal"))
+			Expect(config.Type).To(Equal("self_hosted"))
+			Expect(config.SessionDuration).To(Equal("24h"))
+		})
+
+		It("buildPolicyConfig should handle inline rules correctly", func() {
+			r := newReconciler()
+			policy := &tunnelsv1.CloudflareAccessPolicy{
+				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+				Spec: tunnelsv1.CloudflareAccessPolicySpec{
+					TargetRef: tunnelsv1.PolicyTargetReference{Kind: "HTTPRoute", Name: "test"},
+					Policies:  []tunnelsv1.AccessPolicy{},
+				},
+			}
+
+			p := tunnelsv1.AccessPolicy{
+				Name:     "email-policy",
+				Decision: "allow",
+				Rules: []tunnelsv1.AccessPolicyRule{
+					{Emails: []string{"user@example.com"}, EmailDomains: []string{"example.com"}},
+				},
+			}
+			config := r.buildPolicyConfig(policy, p, 0)
+			Expect(config.Name).To(Equal("email-policy"))
+			Expect(config.Decision).To(Equal("allow"))
+			Expect(config.Include).To(HaveLen(1))
+			Expect(config.Include[0].Emails).To(ContainElement("user@example.com"))
+			Expect(config.Include[0].EmailDomains).To(ContainElement("example.com"))
+		})
+
+		It("buildPolicyConfig should use external policy ID as a group reference", func() {
+			r := newReconciler()
+			policy := &tunnelsv1.CloudflareAccessPolicy{
+				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+				Spec: tunnelsv1.CloudflareAccessPolicySpec{
+					TargetRef: tunnelsv1.PolicyTargetReference{Kind: "HTTPRoute", Name: "test"},
+					Policies:  []tunnelsv1.AccessPolicy{},
+				},
+			}
+
+			p := tunnelsv1.AccessPolicy{
+				Decision:         "allow",
+				ExternalPolicyID: "ext-policy-123",
+				Rules:            []tunnelsv1.AccessPolicyRule{{Everyone: true}},
+			}
+			config := r.buildPolicyConfig(policy, p, 0)
+			Expect(config.Include).To(HaveLen(1))
+			Expect(config.Include[0].GroupID).To(Equal("ext-policy-123"))
+		})
+
+		It("buildPolicyConfig should default missing name and decision", func() {
+			r := newReconciler()
+			policy := &tunnelsv1.CloudflareAccessPolicy{
+				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+				Spec: tunnelsv1.CloudflareAccessPolicySpec{
+					TargetRef: tunnelsv1.PolicyTargetReference{Kind: "HTTPRoute", Name: "test"},
+					Policies:  []tunnelsv1.AccessPolicy{},
+				},
+			}
+
+			p := tunnelsv1.AccessPolicy{
+				Rules: []tunnelsv1.AccessPolicyRule{{Everyone: true}},
+			}
+			config := r.buildPolicyConfig(policy, p, 2)
+			Expect(config.Name).To(Equal("policy-2"))
+			Expect(config.Decision).To(Equal("allow"))
+		})
+	})
+})

--- a/projects/operators/cloudflare/internal/controller/gateway_controller_test.go
+++ b/projects/operators/cloudflare/internal/controller/gateway_controller_test.go
@@ -1,0 +1,485 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	tunnelsv1 "github.com/jomcgi/homelab/projects/operators/cloudflare/api/v1"
+	"github.com/jomcgi/homelab/projects/operators/cloudflare/internal/telemetry"
+)
+
+var _ = Describe("Gateway Controller", func() {
+	Context("When reconciling a Gateway", func() {
+		var (
+			ctx                context.Context
+			resourceName       string
+			typeNamespacedName types.NamespacedName
+		)
+
+		BeforeEach(func() {
+			ctx = context.Background()
+			resourceName = fmt.Sprintf("test-gateway-%d", time.Now().UnixNano())
+			typeNamespacedName = types.NamespacedName{
+				Name:      resourceName,
+				Namespace: "default",
+			}
+		})
+
+		AfterEach(func() {
+			gw := &gatewayv1.Gateway{}
+			err := k8sClient.Get(ctx, typeNamespacedName, gw)
+			if err == nil {
+				gw.Finalizers = []string{}
+				_ = k8sClient.Update(ctx, gw)
+				_ = k8sClient.Delete(ctx, gw)
+				Eventually(func() bool {
+					return errors.IsNotFound(k8sClient.Get(ctx, typeNamespacedName, gw))
+				}, time.Second*5).Should(BeTrue())
+			}
+		})
+
+		newReconciler := func() *GatewayReconciler {
+			return &GatewayReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+				tracer: telemetry.GetTracer("test-gateway"),
+			}
+		}
+
+		createGateway := func(gatewayClassName string) *gatewayv1.Gateway {
+			gw := &gatewayv1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      resourceName,
+					Namespace: "default",
+				},
+				Spec: gatewayv1.GatewaySpec{
+					GatewayClassName: gatewayv1.ObjectName(gatewayClassName),
+					Listeners: []gatewayv1.Listener{
+						{
+							Name:     "https",
+							Protocol: gatewayv1.HTTPSProtocolType,
+							Port:     443,
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, gw)).To(Succeed())
+			return gw
+		}
+
+		It("should return nil when Gateway is not found", func() {
+			r := newReconciler()
+			result, err := r.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: "does-not-exist", Namespace: "default"},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).To(Equal(time.Duration(0)))
+		})
+
+		It("should skip reconciliation for non-cloudflare GatewayClass", func() {
+			By("Creating a Gateway with a different GatewayClass")
+			createGateway("other-gateway-class")
+
+			By("Reconciling")
+			r := newReconciler()
+			result, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).To(Equal(time.Duration(0)))
+
+			By("Verifying no finalizer was added")
+			gw := &gatewayv1.Gateway{}
+			Expect(k8sClient.Get(ctx, typeNamespacedName, gw)).To(Succeed())
+			Expect(gw.Finalizers).NotTo(ContainElement(GatewayFinalizerName))
+		})
+
+		It("should add finalizer on first reconcile for cloudflare Gateway", func() {
+			By("Creating a cloudflare Gateway")
+			createGateway("cloudflare")
+
+			By("First reconcile should add finalizer")
+			r := newReconciler()
+			_, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Checking that finalizer was added")
+			gw := &gatewayv1.Gateway{}
+			Expect(k8sClient.Get(ctx, typeNamespacedName, gw)).To(Succeed())
+			Expect(gw.Finalizers).To(ContainElement(GatewayFinalizerName))
+		})
+
+		It("should attempt tunnel creation after finalizer and set status when GatewayClass missing", func() {
+			By("Creating a cloudflare Gateway (no GatewayClass)")
+			createGateway("cloudflare")
+
+			r := newReconciler()
+
+			By("First reconcile — adds finalizer")
+			_, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Second reconcile — tries to get account ID, fails because no GatewayClass")
+			result, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+			// Error is propagated as it failed to get GatewayClass
+			Expect(err).To(HaveOccurred())
+			// Should requeue after backoff
+			Expect(result.RequeueAfter).To(Equal(30 * time.Second))
+
+			By("Checking that Accepted=False condition is set")
+			gw := &gatewayv1.Gateway{}
+			Expect(k8sClient.Get(ctx, typeNamespacedName, gw)).To(Succeed())
+			accepted := apimeta.FindStatusCondition(gw.Status.Conditions, string(gatewayv1.GatewayConditionAccepted))
+			Expect(accepted).NotTo(BeNil())
+			Expect(accepted.Status).To(Equal(metav1.ConditionFalse))
+		})
+
+		It("should handle deletion by removing finalizer", func() {
+			By("Creating a cloudflare Gateway")
+			gw := createGateway("cloudflare")
+
+			r := newReconciler()
+
+			By("First reconcile — adds finalizer")
+			_, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Deleting the Gateway")
+			Expect(k8sClient.Delete(ctx, gw)).To(Succeed())
+
+			By("Reconciling to handle deletion")
+			_, err = r.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Checking that the resource was deleted (finalizer removed)")
+			Eventually(func() bool {
+				return errors.IsNotFound(k8sClient.Get(ctx, typeNamespacedName, gw))
+			}, time.Second*5).Should(BeTrue())
+		})
+
+		It("should update tunnel status when tunnelID annotation is present and tunnel CRD exists", func() {
+			By("Creating a cloudflare Gateway with tunnel annotation")
+			tunnelID := "test-tunnel-123"
+			accountID := "test-account-456"
+			gw := &gatewayv1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      resourceName,
+					Namespace: "default",
+					Annotations: map[string]string{
+						GatewayAnnotationTunnelID:  tunnelID,
+						GatewayAnnotationAccountID: accountID,
+					},
+					Finalizers: []string{GatewayFinalizerName},
+				},
+				Spec: gatewayv1.GatewaySpec{
+					GatewayClassName: "cloudflare",
+					Listeners: []gatewayv1.Listener{
+						{Name: "https", Protocol: gatewayv1.HTTPSProtocolType, Port: 443},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, gw)).To(Succeed())
+
+			By("Creating a ready CloudflareTunnel CRD")
+			tunnelCRDName := fmt.Sprintf("%s-gateway-tunnel", resourceName)
+			tunnel := &tunnelsv1.CloudflareTunnel{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      tunnelCRDName,
+					Namespace: "default",
+				},
+				Spec: tunnelsv1.CloudflareTunnelSpec{
+					Name:      tunnelCRDName,
+					AccountID: accountID,
+				},
+			}
+			Expect(k8sClient.Create(ctx, tunnel)).To(Succeed())
+			DeferCleanup(func() {
+				tunnel.Finalizers = []string{}
+				_ = k8sClient.Update(ctx, tunnel)
+				_ = k8sClient.Delete(ctx, tunnel)
+			})
+
+			By("Setting tunnel status to active")
+			tunnel.Status.TunnelID = tunnelID
+			tunnel.Status.Ready = true
+			tunnel.Status.Active = true
+			Expect(k8sClient.Status().Update(ctx, tunnel)).To(Succeed())
+
+			By("Reconciling")
+			r := newReconciler()
+			_, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Checking Gateway Programmed condition reflects active tunnel")
+			updated := &gatewayv1.Gateway{}
+			Expect(k8sClient.Get(ctx, typeNamespacedName, updated)).To(Succeed())
+			programmed := apimeta.FindStatusCondition(updated.Status.Conditions, string(gatewayv1.GatewayConditionProgrammed))
+			Expect(programmed).NotTo(BeNil())
+			Expect(programmed.Status).To(Equal(metav1.ConditionTrue))
+			Expect(programmed.Reason).To(Equal("Programmed"))
+		})
+
+		It("should set Programmed=True with ready-but-inactive tunnel", func() {
+			By("Creating a cloudflare Gateway with tunnel annotation")
+			tunnelID := "test-tunnel-ready-only"
+			accountID := "test-account-789"
+			gw := &gatewayv1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      resourceName,
+					Namespace: "default",
+					Annotations: map[string]string{
+						GatewayAnnotationTunnelID:  tunnelID,
+						GatewayAnnotationAccountID: accountID,
+					},
+					Finalizers: []string{GatewayFinalizerName},
+				},
+				Spec: gatewayv1.GatewaySpec{
+					GatewayClassName: "cloudflare",
+					Listeners: []gatewayv1.Listener{
+						{Name: "https", Protocol: gatewayv1.HTTPSProtocolType, Port: 443},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, gw)).To(Succeed())
+
+			By("Creating a ready-but-not-active CloudflareTunnel CRD")
+			tunnelCRDName := fmt.Sprintf("%s-gateway-tunnel", resourceName)
+			tunnel := &tunnelsv1.CloudflareTunnel{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      tunnelCRDName,
+					Namespace: "default",
+				},
+				Spec: tunnelsv1.CloudflareTunnelSpec{
+					Name:      tunnelCRDName,
+					AccountID: accountID,
+				},
+			}
+			Expect(k8sClient.Create(ctx, tunnel)).To(Succeed())
+			DeferCleanup(func() {
+				tunnel.Finalizers = []string{}
+				_ = k8sClient.Update(ctx, tunnel)
+				_ = k8sClient.Delete(ctx, tunnel)
+			})
+
+			tunnel.Status.TunnelID = tunnelID
+			tunnel.Status.Ready = true
+			tunnel.Status.Active = false
+			Expect(k8sClient.Status().Update(ctx, tunnel)).To(Succeed())
+
+			By("Reconciling")
+			r := newReconciler()
+			_, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Checking Gateway Programmed condition is True (ready but no connections)")
+			updated := &gatewayv1.Gateway{}
+			Expect(k8sClient.Get(ctx, typeNamespacedName, updated)).To(Succeed())
+			programmed := apimeta.FindStatusCondition(updated.Status.Conditions, string(gatewayv1.GatewayConditionProgrammed))
+			Expect(programmed).NotTo(BeNil())
+			Expect(programmed.Status).To(Equal(metav1.ConditionTrue))
+		})
+
+		It("should set Programmed=Unknown when tunnel CRD not ready", func() {
+			By("Creating a cloudflare Gateway with tunnel annotation")
+			tunnelID := "test-tunnel-not-ready"
+			accountID := "test-account-notready"
+			gw := &gatewayv1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      resourceName,
+					Namespace: "default",
+					Annotations: map[string]string{
+						GatewayAnnotationTunnelID:  tunnelID,
+						GatewayAnnotationAccountID: accountID,
+					},
+					Finalizers: []string{GatewayFinalizerName},
+				},
+				Spec: gatewayv1.GatewaySpec{
+					GatewayClassName: "cloudflare",
+					Listeners: []gatewayv1.Listener{
+						{Name: "https", Protocol: gatewayv1.HTTPSProtocolType, Port: 443},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, gw)).To(Succeed())
+
+			By("Creating a not-ready CloudflareTunnel CRD")
+			tunnelCRDName := fmt.Sprintf("%s-gateway-tunnel", resourceName)
+			tunnel := &tunnelsv1.CloudflareTunnel{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      tunnelCRDName,
+					Namespace: "default",
+				},
+				Spec: tunnelsv1.CloudflareTunnelSpec{
+					Name:      tunnelCRDName,
+					AccountID: accountID,
+				},
+			}
+			Expect(k8sClient.Create(ctx, tunnel)).To(Succeed())
+			DeferCleanup(func() {
+				tunnel.Finalizers = []string{}
+				_ = k8sClient.Update(ctx, tunnel)
+				_ = k8sClient.Delete(ctx, tunnel)
+			})
+			// Leave status as zero value (not ready)
+
+			By("Reconciling")
+			r := newReconciler()
+			_, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Checking Gateway Programmed condition is Unknown (pending)")
+			updated := &gatewayv1.Gateway{}
+			Expect(k8sClient.Get(ctx, typeNamespacedName, updated)).To(Succeed())
+			programmed := apimeta.FindStatusCondition(updated.Status.Conditions, string(gatewayv1.GatewayConditionProgrammed))
+			Expect(programmed).NotTo(BeNil())
+			Expect(programmed.Status).To(Equal(metav1.ConditionUnknown))
+		})
+
+		It("should trigger tunnel recreation when CRD is not found", func() {
+			By("Creating a cloudflare Gateway with tunnelID annotation but no CRD")
+			gw := &gatewayv1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      resourceName,
+					Namespace: "default",
+					Annotations: map[string]string{
+						GatewayAnnotationTunnelID:  "ghost-tunnel",
+						GatewayAnnotationAccountID: "test-account",
+					},
+					Finalizers: []string{GatewayFinalizerName},
+				},
+				Spec: gatewayv1.GatewaySpec{
+					GatewayClassName: "cloudflare",
+					Listeners: []gatewayv1.Listener{
+						{Name: "https", Protocol: gatewayv1.HTTPSProtocolType, Port: 443},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, gw)).To(Succeed())
+
+			By("Reconciling — tunnel CRD not found, should clear annotation and requeue")
+			r := newReconciler()
+			result, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.Requeue).To(BeTrue())
+
+			By("Verifying the tunnelID annotation was cleared")
+			updated := &gatewayv1.Gateway{}
+			Expect(k8sClient.Get(ctx, typeNamespacedName, updated)).To(Succeed())
+			Expect(updated.Annotations[GatewayAnnotationTunnelID]).To(Equal(""))
+		})
+
+		It("should configure custom cloudflared image when set", func() {
+			r := newReconciler()
+			r.CloudflaredImage = "my-registry/cloudflared:custom"
+			Expect(r.getCloudflaredImage()).To(Equal("my-registry/cloudflared:custom"))
+		})
+
+		It("should return default cloudflared image when not customised", func() {
+			r := newReconciler()
+			Expect(r.getCloudflaredImage()).To(Equal(DefaultCloudflaredImage))
+		})
+
+		It("should create a CloudflareTunnel CRD when GatewayClass 'cloudflare' and credentials exist", func() {
+			// The Gateway controller only reconciles gateways whose GatewayClassName == "cloudflare"
+			// (hardcoded check in the controller), so the GatewayClass resource must also be named "cloudflare".
+			By("Creating a credentials Secret")
+			secretName := fmt.Sprintf("gw-creds-%d", time.Now().UnixNano())
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      secretName,
+					Namespace: "default",
+				},
+				Data: map[string][]byte{
+					"CLOUDFLARE_API_TOKEN":  []byte("test-token"),
+					"CLOUDFLARE_ACCOUNT_ID": []byte("test-account-id"),
+				},
+			}
+			Expect(k8sClient.Create(ctx, secret)).To(Succeed())
+			DeferCleanup(func() { _ = k8sClient.Delete(ctx, secret) })
+
+			By("Creating (or adopting) a GatewayClass named 'cloudflare'")
+			ns := gatewayv1.Namespace("default")
+			gc := &gatewayv1.GatewayClass{
+				ObjectMeta: metav1.ObjectMeta{Name: "cloudflare"},
+				Spec: gatewayv1.GatewayClassSpec{
+					ControllerName: ControllerName,
+					ParametersRef: &gatewayv1.ParametersReference{
+						Group:     "v1",
+						Kind:      "Secret",
+						Name:      secretName,
+						Namespace: &ns,
+					},
+				},
+			}
+			gcErr := k8sClient.Create(ctx, gc)
+			if gcErr != nil && !errors.IsAlreadyExists(gcErr) {
+				Fail(fmt.Sprintf("failed to create GatewayClass: %v", gcErr))
+			}
+			gcCreated := gcErr == nil
+			DeferCleanup(func() {
+				if gcCreated {
+					_ = k8sClient.Delete(ctx, gc)
+				}
+			})
+
+			By("Creating a Gateway with GatewayClassName 'cloudflare' and finalizer already set")
+			gw := &gatewayv1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       resourceName,
+					Namespace:  "default",
+					Finalizers: []string{GatewayFinalizerName},
+				},
+				Spec: gatewayv1.GatewaySpec{
+					GatewayClassName: "cloudflare",
+					Listeners: []gatewayv1.Listener{
+						{Name: "https", Protocol: gatewayv1.HTTPSProtocolType, Port: 443},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, gw)).To(Succeed())
+
+			By("Reconciling — should create CloudflareTunnel CRD and wait for readiness")
+			r := newReconciler()
+			result, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+			Expect(err).NotTo(HaveOccurred())
+			// Gateway waits for tunnel to become ready
+			Expect(result.RequeueAfter).To(Equal(5 * time.Second))
+
+			By("Verifying CloudflareTunnel CRD was created")
+			tunnelName := fmt.Sprintf("%s-gateway-tunnel", resourceName)
+			tunnel := &tunnelsv1.CloudflareTunnel{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: tunnelName, Namespace: "default"}, tunnel)).To(Succeed())
+			Expect(tunnel.Spec.AccountID).To(Equal("test-account-id"))
+			DeferCleanup(func() {
+				tunnel.Finalizers = []string{}
+				_ = k8sClient.Update(ctx, tunnel)
+				_ = k8sClient.Delete(ctx, tunnel)
+			})
+		})
+	})
+})

--- a/projects/operators/cloudflare/internal/controller/gatewayclass_controller_test.go
+++ b/projects/operators/cloudflare/internal/controller/gatewayclass_controller_test.go
@@ -1,0 +1,347 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/jomcgi/homelab/projects/operators/cloudflare/internal/telemetry"
+)
+
+var _ = Describe("GatewayClass Controller", func() {
+	Context("When reconciling a GatewayClass", func() {
+		var (
+			ctx                context.Context
+			resourceName       string
+			typeNamespacedName types.NamespacedName
+		)
+
+		BeforeEach(func() {
+			ctx = context.Background()
+			resourceName = fmt.Sprintf("test-gatewayclass-%d", time.Now().UnixNano())
+			typeNamespacedName = types.NamespacedName{Name: resourceName}
+		})
+
+		AfterEach(func() {
+			gatewayClass := &gatewayv1.GatewayClass{}
+			err := k8sClient.Get(ctx, typeNamespacedName, gatewayClass)
+			if err == nil {
+				Expect(k8sClient.Delete(ctx, gatewayClass)).To(Succeed())
+				Eventually(func() bool {
+					err := k8sClient.Get(ctx, typeNamespacedName, gatewayClass)
+					return errors.IsNotFound(err)
+				}, time.Second*5).Should(BeTrue())
+			}
+		})
+
+		newReconciler := func() *GatewayClassReconciler {
+			return &GatewayClassReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+				tracer: telemetry.GetTracer("test-gatewayclass"),
+			}
+		}
+
+		It("should return nil for a GatewayClass not managed by this controller", func() {
+			By("Creating a GatewayClass with a different controller name")
+			gc := &gatewayv1.GatewayClass{
+				ObjectMeta: metav1.ObjectMeta{Name: resourceName},
+				Spec: gatewayv1.GatewayClassSpec{
+					ControllerName: "other.io/controller",
+				},
+			}
+			Expect(k8sClient.Create(ctx, gc)).To(Succeed())
+
+			By("Reconciling")
+			r := newReconciler()
+			result, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).To(Equal(time.Duration(0)))
+		})
+
+		It("should return nil when GatewayClass is not found", func() {
+			r := newReconciler()
+			result, err := r.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: "does-not-exist"},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).To(Equal(time.Duration(0)))
+		})
+
+		It("should set Accepted condition to True when Secret has required fields", func() {
+			By("Creating a valid credentials Secret")
+			secretName := fmt.Sprintf("cf-creds-%d", time.Now().UnixNano())
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      secretName,
+					Namespace: "default",
+				},
+				Data: map[string][]byte{
+					"CLOUDFLARE_API_TOKEN":  []byte("test-token"),
+					"CLOUDFLARE_ACCOUNT_ID": []byte("test-account-id"),
+				},
+			}
+			Expect(k8sClient.Create(ctx, secret)).To(Succeed())
+			DeferCleanup(func() {
+				_ = k8sClient.Delete(ctx, secret)
+			})
+
+			By("Creating a GatewayClass referencing the Secret")
+			ns := gatewayv1.Namespace("default")
+			gc := &gatewayv1.GatewayClass{
+				ObjectMeta: metav1.ObjectMeta{Name: resourceName},
+				Spec: gatewayv1.GatewayClassSpec{
+					ControllerName: ControllerName,
+					ParametersRef: &gatewayv1.ParametersReference{
+						Group:     "v1",
+						Kind:      "Secret",
+						Name:      secretName,
+						Namespace: &ns,
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, gc)).To(Succeed())
+
+			By("Reconciling")
+			r := newReconciler()
+			_, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Checking Accepted condition is True")
+			updated := &gatewayv1.GatewayClass{}
+			Expect(k8sClient.Get(ctx, typeNamespacedName, updated)).To(Succeed())
+			accepted := meta.FindStatusCondition(updated.Status.Conditions, string(gatewayv1.GatewayClassConditionStatusAccepted))
+			Expect(accepted).NotTo(BeNil())
+			Expect(accepted.Status).To(Equal(metav1.ConditionTrue))
+			Expect(accepted.Reason).To(Equal(GatewayClassConditionReasonAccepted))
+		})
+
+		It("should set Accepted condition to False when Secret is missing", func() {
+			By("Creating a GatewayClass referencing a non-existent Secret")
+			ns := gatewayv1.Namespace("default")
+			gc := &gatewayv1.GatewayClass{
+				ObjectMeta: metav1.ObjectMeta{Name: resourceName},
+				Spec: gatewayv1.GatewayClassSpec{
+					ControllerName: ControllerName,
+					ParametersRef: &gatewayv1.ParametersReference{
+						Group:     "v1",
+						Kind:      "Secret",
+						Name:      "nonexistent-secret",
+						Namespace: &ns,
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, gc)).To(Succeed())
+
+			By("Reconciling")
+			r := newReconciler()
+			_, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Checking Accepted condition is False with InvalidParameters reason")
+			updated := &gatewayv1.GatewayClass{}
+			Expect(k8sClient.Get(ctx, typeNamespacedName, updated)).To(Succeed())
+			accepted := meta.FindStatusCondition(updated.Status.Conditions, string(gatewayv1.GatewayClassConditionStatusAccepted))
+			Expect(accepted).NotTo(BeNil())
+			Expect(accepted.Status).To(Equal(metav1.ConditionFalse))
+			Expect(accepted.Reason).To(Equal(GatewayClassConditionReasonInvalidParameters))
+		})
+
+		It("should set Accepted condition to False when Secret is missing CLOUDFLARE_API_TOKEN", func() {
+			By("Creating a Secret without CLOUDFLARE_API_TOKEN")
+			secretName := fmt.Sprintf("cf-creds-missing-%d", time.Now().UnixNano())
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      secretName,
+					Namespace: "default",
+				},
+				Data: map[string][]byte{
+					"CLOUDFLARE_ACCOUNT_ID": []byte("test-account-id"),
+					// deliberately missing CLOUDFLARE_API_TOKEN
+				},
+			}
+			Expect(k8sClient.Create(ctx, secret)).To(Succeed())
+			DeferCleanup(func() {
+				_ = k8sClient.Delete(ctx, secret)
+			})
+
+			By("Creating a GatewayClass referencing the incomplete Secret")
+			ns := gatewayv1.Namespace("default")
+			gc := &gatewayv1.GatewayClass{
+				ObjectMeta: metav1.ObjectMeta{Name: resourceName},
+				Spec: gatewayv1.GatewayClassSpec{
+					ControllerName: ControllerName,
+					ParametersRef: &gatewayv1.ParametersReference{
+						Group:     "v1",
+						Kind:      "Secret",
+						Name:      secretName,
+						Namespace: &ns,
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, gc)).To(Succeed())
+
+			By("Reconciling")
+			r := newReconciler()
+			_, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Checking Accepted condition is False")
+			updated := &gatewayv1.GatewayClass{}
+			Expect(k8sClient.Get(ctx, typeNamespacedName, updated)).To(Succeed())
+			accepted := meta.FindStatusCondition(updated.Status.Conditions, string(gatewayv1.GatewayClassConditionStatusAccepted))
+			Expect(accepted).NotTo(BeNil())
+			Expect(accepted.Status).To(Equal(metav1.ConditionFalse))
+		})
+
+		It("should set Accepted condition to False when Secret is missing CLOUDFLARE_ACCOUNT_ID", func() {
+			By("Creating a Secret without CLOUDFLARE_ACCOUNT_ID")
+			secretName := fmt.Sprintf("cf-creds-noacct-%d", time.Now().UnixNano())
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      secretName,
+					Namespace: "default",
+				},
+				Data: map[string][]byte{
+					"CLOUDFLARE_API_TOKEN": []byte("test-token"),
+					// deliberately missing CLOUDFLARE_ACCOUNT_ID
+				},
+			}
+			Expect(k8sClient.Create(ctx, secret)).To(Succeed())
+			DeferCleanup(func() {
+				_ = k8sClient.Delete(ctx, secret)
+			})
+
+			By("Creating a GatewayClass referencing the incomplete Secret")
+			ns := gatewayv1.Namespace("default")
+			gc := &gatewayv1.GatewayClass{
+				ObjectMeta: metav1.ObjectMeta{Name: resourceName},
+				Spec: gatewayv1.GatewayClassSpec{
+					ControllerName: ControllerName,
+					ParametersRef: &gatewayv1.ParametersReference{
+						Group:     "v1",
+						Kind:      "Secret",
+						Name:      secretName,
+						Namespace: &ns,
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, gc)).To(Succeed())
+
+			By("Reconciling")
+			r := newReconciler()
+			_, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Checking Accepted condition is False")
+			updated := &gatewayv1.GatewayClass{}
+			Expect(k8sClient.Get(ctx, typeNamespacedName, updated)).To(Succeed())
+			accepted := meta.FindStatusCondition(updated.Status.Conditions, string(gatewayv1.GatewayClassConditionStatusAccepted))
+			Expect(accepted).NotTo(BeNil())
+			Expect(accepted.Status).To(Equal(metav1.ConditionFalse))
+		})
+
+		It("should set Accepted condition to True when no parametersRef is provided", func() {
+			By("Creating a GatewayClass without parametersRef")
+			gc := &gatewayv1.GatewayClass{
+				ObjectMeta: metav1.ObjectMeta{Name: resourceName},
+				Spec: gatewayv1.GatewayClassSpec{
+					ControllerName: ControllerName,
+				},
+			}
+			Expect(k8sClient.Create(ctx, gc)).To(Succeed())
+
+			By("Reconciling")
+			r := newReconciler()
+			_, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Checking Accepted condition is True (no params to validate)")
+			updated := &gatewayv1.GatewayClass{}
+			Expect(k8sClient.Get(ctx, typeNamespacedName, updated)).To(Succeed())
+			accepted := meta.FindStatusCondition(updated.Status.Conditions, string(gatewayv1.GatewayClassConditionStatusAccepted))
+			Expect(accepted).NotTo(BeNil())
+			Expect(accepted.Status).To(Equal(metav1.ConditionTrue))
+		})
+
+		It("should reject parametersRef with unsupported Kind", func() {
+			By("Creating a GatewayClass with a ConfigMap parametersRef")
+			ns := gatewayv1.Namespace("default")
+			gc := &gatewayv1.GatewayClass{
+				ObjectMeta: metav1.ObjectMeta{Name: resourceName},
+				Spec: gatewayv1.GatewayClassSpec{
+					ControllerName: ControllerName,
+					ParametersRef: &gatewayv1.ParametersReference{
+						Group:     "v1",
+						Kind:      "ConfigMap",
+						Name:      "some-config",
+						Namespace: &ns,
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, gc)).To(Succeed())
+
+			By("Reconciling")
+			r := newReconciler()
+			_, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Checking Accepted condition is False")
+			updated := &gatewayv1.GatewayClass{}
+			Expect(k8sClient.Get(ctx, typeNamespacedName, updated)).To(Succeed())
+			accepted := meta.FindStatusCondition(updated.Status.Conditions, string(gatewayv1.GatewayClassConditionStatusAccepted))
+			Expect(accepted).NotTo(BeNil())
+			Expect(accepted.Status).To(Equal(metav1.ConditionFalse))
+			Expect(accepted.Reason).To(Equal(GatewayClassConditionReasonInvalidParameters))
+		})
+
+		It("should reject parametersRef missing namespace", func() {
+			By("Creating a GatewayClass with parametersRef missing namespace")
+			gc := &gatewayv1.GatewayClass{
+				ObjectMeta: metav1.ObjectMeta{Name: resourceName},
+				Spec: gatewayv1.GatewayClassSpec{
+					ControllerName: ControllerName,
+					ParametersRef: &gatewayv1.ParametersReference{
+						Group:     "v1",
+						Kind:      "Secret",
+						Name:      "some-secret",
+						Namespace: ptr.To(gatewayv1.Namespace("")),
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, gc)).To(Succeed())
+
+			By("Reconciling — Namespace is an empty string but non-nil, so lookup will fail")
+			r := newReconciler()
+			_, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+})

--- a/projects/operators/cloudflare/internal/controller/httproute_controller_test.go
+++ b/projects/operators/cloudflare/internal/controller/httproute_controller_test.go
@@ -1,0 +1,417 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/jomcgi/homelab/projects/operators/cloudflare/internal/telemetry"
+)
+
+var _ = Describe("HTTPRoute Controller", func() {
+	Context("When reconciling an HTTPRoute", func() {
+		var (
+			ctx                context.Context
+			resourceName       string
+			typeNamespacedName types.NamespacedName
+		)
+
+		BeforeEach(func() {
+			ctx = context.Background()
+			resourceName = fmt.Sprintf("test-httproute-%d", time.Now().UnixNano())
+			typeNamespacedName = types.NamespacedName{
+				Name:      resourceName,
+				Namespace: "default",
+			}
+		})
+
+		AfterEach(func() {
+			route := &gatewayv1.HTTPRoute{}
+			err := k8sClient.Get(ctx, typeNamespacedName, route)
+			if err == nil {
+				route.Finalizers = []string{}
+				_ = k8sClient.Update(ctx, route)
+				_ = k8sClient.Delete(ctx, route)
+				Eventually(func() bool {
+					return errors.IsNotFound(k8sClient.Get(ctx, typeNamespacedName, route))
+				}, time.Second*5).Should(BeTrue())
+			}
+		})
+
+		newReconciler := func() *HTTPRouteReconciler {
+			return &HTTPRouteReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+				tracer: telemetry.GetTracer("test-httproute"),
+			}
+		}
+
+		createHTTPRoute := func(parentGatewayName string) *gatewayv1.HTTPRoute {
+			route := &gatewayv1.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      resourceName,
+					Namespace: "default",
+				},
+				Spec: gatewayv1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayv1.CommonRouteSpec{
+						ParentRefs: []gatewayv1.ParentReference{
+							{
+								Name:      gatewayv1.ObjectName(parentGatewayName),
+								Namespace: ptr.To(gatewayv1.Namespace("default")),
+							},
+						},
+					},
+					Hostnames: []gatewayv1.Hostname{"test.example.com"},
+					Rules: []gatewayv1.HTTPRouteRule{
+						{
+							BackendRefs: []gatewayv1.HTTPBackendRef{
+								{
+									BackendRef: gatewayv1.BackendRef{
+										BackendObjectReference: gatewayv1.BackendObjectReference{
+											Name: "backend-svc",
+											Port: ptr.To(gatewayv1.PortNumber(8080)),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, route)).To(Succeed())
+			return route
+		}
+
+		It("should return nil when HTTPRoute is not found", func() {
+			r := newReconciler()
+			result, err := r.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: "does-not-exist", Namespace: "default"},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).To(Equal(time.Duration(0)))
+		})
+
+		It("should add finalizer on first reconcile", func() {
+			By("Creating an HTTPRoute")
+			createHTTPRoute("my-gateway")
+
+			By("Reconciling — should add finalizer")
+			r := newReconciler()
+			_, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Checking the finalizer was added")
+			route := &gatewayv1.HTTPRoute{}
+			Expect(k8sClient.Get(ctx, typeNamespacedName, route)).To(Succeed())
+			Expect(route.Finalizers).To(ContainElement(HTTPRouteFinalizerName))
+		})
+
+		It("should handle deletion when no Cloudflare Gateway exists (skip cleanup, remove finalizer)", func() {
+			By("Creating an HTTPRoute with finalizer")
+			route := createHTTPRoute("nonexistent-gateway")
+
+			r := newReconciler()
+			_, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Deleting the HTTPRoute")
+			Expect(k8sClient.Delete(ctx, route)).To(Succeed())
+
+			By("Reconciling deletion — should remove finalizer even without Gateway")
+			_, err = r.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Checking resource is fully deleted")
+			Eventually(func() bool {
+				return errors.IsNotFound(k8sClient.Get(ctx, typeNamespacedName, route))
+			}, time.Second*5).Should(BeTrue())
+		})
+
+		It("should return error and update status when no Cloudflare Gateway found in parentRefs", func() {
+			By("Creating an HTTPRoute with finalizer already set")
+			route := &gatewayv1.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       resourceName,
+					Namespace:  "default",
+					Finalizers: []string{HTTPRouteFinalizerName},
+				},
+				Spec: gatewayv1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayv1.CommonRouteSpec{
+						ParentRefs: []gatewayv1.ParentReference{
+							{
+								Name:      "nonexistent-gateway",
+								Namespace: ptr.To(gatewayv1.Namespace("default")),
+							},
+						},
+					},
+					Hostnames: []gatewayv1.Hostname{"test.example.com"},
+					Rules: []gatewayv1.HTTPRouteRule{
+						{
+							BackendRefs: []gatewayv1.HTTPBackendRef{
+								{
+									BackendRef: gatewayv1.BackendRef{
+										BackendObjectReference: gatewayv1.BackendObjectReference{
+											Name: "backend-svc",
+											Port: ptr.To(gatewayv1.PortNumber(8080)),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, route)).To(Succeed())
+
+			By("Reconciling — handleCreateOrUpdate fails, no Cloudflare Gateway")
+			r := newReconciler()
+			result, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+			Expect(err).To(HaveOccurred())
+			Expect(result.RequeueAfter).To(Equal(30 * time.Second))
+		})
+
+		It("should return error when Gateway exists but is not cloudflare class", func() {
+			By("Creating a non-cloudflare Gateway")
+			gwName := fmt.Sprintf("other-gw-%d", time.Now().UnixNano())
+			gw := &gatewayv1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      gwName,
+					Namespace: "default",
+				},
+				Spec: gatewayv1.GatewaySpec{
+					GatewayClassName: "not-cloudflare",
+					Listeners: []gatewayv1.Listener{
+						{Name: "http", Protocol: gatewayv1.HTTPProtocolType, Port: 80},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, gw)).To(Succeed())
+			DeferCleanup(func() { _ = k8sClient.Delete(ctx, gw) })
+
+			By("Creating HTTPRoute with finalizer pointing to the non-cloudflare Gateway")
+			route := &gatewayv1.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       resourceName,
+					Namespace:  "default",
+					Finalizers: []string{HTTPRouteFinalizerName},
+				},
+				Spec: gatewayv1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayv1.CommonRouteSpec{
+						ParentRefs: []gatewayv1.ParentReference{
+							{
+								Name:      gatewayv1.ObjectName(gwName),
+								Namespace: ptr.To(gatewayv1.Namespace("default")),
+							},
+						},
+					},
+					Hostnames: []gatewayv1.Hostname{"test.example.com"},
+					Rules: []gatewayv1.HTTPRouteRule{
+						{
+							BackendRefs: []gatewayv1.HTTPBackendRef{
+								{
+									BackendRef: gatewayv1.BackendRef{
+										BackendObjectReference: gatewayv1.BackendObjectReference{
+											Name: "backend-svc",
+											Port: ptr.To(gatewayv1.PortNumber(8080)),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, route)).To(Succeed())
+
+			By("Reconciling — no Cloudflare Gateway found")
+			r := newReconciler()
+			result, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+			Expect(err).To(HaveOccurred())
+			Expect(result.RequeueAfter).To(Equal(30 * time.Second))
+		})
+
+		It("should return error when Gateway exists but missing tunnel metadata", func() {
+			By("Creating a cloudflare Gateway without tunnel annotations")
+			gwName := fmt.Sprintf("cf-gw-%d", time.Now().UnixNano())
+			gw := &gatewayv1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      gwName,
+					Namespace: "default",
+				},
+				Spec: gatewayv1.GatewaySpec{
+					GatewayClassName: "cloudflare",
+					Listeners: []gatewayv1.Listener{
+						{Name: "https", Protocol: gatewayv1.HTTPSProtocolType, Port: 443},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, gw)).To(Succeed())
+			DeferCleanup(func() {
+				gw.Finalizers = []string{}
+				_ = k8sClient.Update(ctx, gw)
+				_ = k8sClient.Delete(ctx, gw)
+			})
+
+			By("Creating HTTPRoute with finalizer pointing to the cloudflare Gateway")
+			route := &gatewayv1.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       resourceName,
+					Namespace:  "default",
+					Finalizers: []string{HTTPRouteFinalizerName},
+				},
+				Spec: gatewayv1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayv1.CommonRouteSpec{
+						ParentRefs: []gatewayv1.ParentReference{
+							{
+								Name:      gatewayv1.ObjectName(gwName),
+								Namespace: ptr.To(gatewayv1.Namespace("default")),
+							},
+						},
+					},
+					Hostnames: []gatewayv1.Hostname{"test.example.com"},
+					Rules: []gatewayv1.HTTPRouteRule{
+						{
+							BackendRefs: []gatewayv1.HTTPBackendRef{
+								{
+									BackendRef: gatewayv1.BackendRef{
+										BackendObjectReference: gatewayv1.BackendObjectReference{
+											Name: "backend-svc",
+											Port: ptr.To(gatewayv1.PortNumber(8080)),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, route)).To(Succeed())
+
+			By("Reconciling — Gateway exists but missing tunnel metadata")
+			r := newReconciler()
+			result, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+			Expect(err).To(HaveOccurred())
+			Expect(result.RequeueAfter).To(Equal(30 * time.Second))
+		})
+
+		It("getBackendServiceURL should return error when HTTPRoute has no rules", func() {
+			r := newReconciler()
+			route := &gatewayv1.HTTPRoute{
+				Spec: gatewayv1.HTTPRouteSpec{},
+			}
+			_, err := r.getBackendServiceURL(ctx, route)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("no rules"))
+		})
+
+		It("getBackendServiceURL should return error when rule has no backendRefs", func() {
+			r := newReconciler()
+			route := &gatewayv1.HTTPRoute{
+				Spec: gatewayv1.HTTPRouteSpec{
+					Rules: []gatewayv1.HTTPRouteRule{{}},
+				},
+			}
+			_, err := r.getBackendServiceURL(ctx, route)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("no backendRefs"))
+		})
+
+		It("getBackendServiceURL should return error for unsupported backend kind", func() {
+			r := newReconciler()
+			kind := gatewayv1.Kind("CustomBackend")
+			route := &gatewayv1.HTTPRoute{
+				Spec: gatewayv1.HTTPRouteSpec{
+					Rules: []gatewayv1.HTTPRouteRule{
+						{
+							BackendRefs: []gatewayv1.HTTPBackendRef{
+								{
+									BackendRef: gatewayv1.BackendRef{
+										BackendObjectReference: gatewayv1.BackendObjectReference{
+											Kind: &kind,
+											Name: "something",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			_, err := r.getBackendServiceURL(ctx, route)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("unsupported backendRef kind"))
+		})
+
+		It("getBackendServiceURL should construct correct URL for existing Service", func() {
+			By("Creating a backend Service")
+			svcName := fmt.Sprintf("backend-%d", time.Now().UnixNano())
+			svc := &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      svcName,
+					Namespace: "default",
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{Port: 8080, TargetPort: intstr.FromInt(8080)},
+					},
+					Selector: map[string]string{"app": "test"},
+				},
+			}
+			Expect(k8sClient.Create(ctx, svc)).To(Succeed())
+			DeferCleanup(func() { _ = k8sClient.Delete(ctx, svc) })
+
+			r := newReconciler()
+			route := &gatewayv1.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+				},
+				Spec: gatewayv1.HTTPRouteSpec{
+					Rules: []gatewayv1.HTTPRouteRule{
+						{
+							BackendRefs: []gatewayv1.HTTPBackendRef{
+								{
+									BackendRef: gatewayv1.BackendRef{
+										BackendObjectReference: gatewayv1.BackendObjectReference{
+											Name: gatewayv1.ObjectName(svcName),
+											Port: ptr.To(gatewayv1.PortNumber(9090)),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			url, err := r.getBackendServiceURL(ctx, route)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(url).To(Equal(fmt.Sprintf("http://%s.default.svc:9090", svcName)))
+		})
+	})
+})

--- a/projects/operators/cloudflare/internal/controller/service_controller_test.go
+++ b/projects/operators/cloudflare/internal/controller/service_controller_test.go
@@ -1,0 +1,483 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	tunnelsv1 "github.com/jomcgi/homelab/projects/operators/cloudflare/api/v1"
+	"github.com/jomcgi/homelab/projects/operators/cloudflare/internal/telemetry"
+)
+
+var _ = Describe("Service Controller", func() {
+	Context("When reconciling a Service", func() {
+		var (
+			ctx                context.Context
+			resourceName       string
+			typeNamespacedName types.NamespacedName
+		)
+
+		BeforeEach(func() {
+			ctx = context.Background()
+			resourceName = fmt.Sprintf("test-svc-%d", time.Now().UnixNano())
+			typeNamespacedName = types.NamespacedName{
+				Name:      resourceName,
+				Namespace: "default",
+			}
+		})
+
+		AfterEach(func() {
+			svc := &corev1.Service{}
+			if err := k8sClient.Get(ctx, typeNamespacedName, svc); err == nil {
+				_ = k8sClient.Delete(ctx, svc)
+				Eventually(func() bool {
+					return errors.IsNotFound(k8sClient.Get(ctx, typeNamespacedName, svc))
+				}, time.Second*5).Should(BeTrue())
+			}
+		})
+
+		newReconciler := func() *ServiceReconciler {
+			return &ServiceReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+				tracer: telemetry.GetTracer("test-service"),
+			}
+		}
+
+		createService := func(annotations map[string]string) *corev1.Service {
+			svc := &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        resourceName,
+					Namespace:   "default",
+					Annotations: annotations,
+				},
+				Spec: corev1.ServiceSpec{
+					Selector: map[string]string{"app": resourceName},
+					Ports: []corev1.ServicePort{
+						{Name: "http", Port: 8080, TargetPort: intstr.FromInt(8080)},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, svc)).To(Succeed())
+			return svc
+		}
+
+		It("should return nil when Service is not found", func() {
+			r := newReconciler()
+			result, err := r.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: "does-not-exist", Namespace: "default"},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).To(Equal(time.Duration(0)))
+		})
+
+		It("should skip reconciliation when cloudflare annotation is absent", func() {
+			By("Creating a Service without cloudflare annotation")
+			createService(nil)
+
+			By("Reconciling")
+			r := newReconciler()
+			_, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying no Gateway was created")
+			gwName := getDefaultGatewayName("default")
+			gw := &gatewayv1.Gateway{}
+			err = k8sClient.Get(ctx, types.NamespacedName{Name: gwName, Namespace: "default"}, gw)
+			Expect(errors.IsNotFound(err)).To(BeTrue())
+		})
+
+		It("should skip reconciliation when hostname annotation is empty", func() {
+			By("Creating a Service with empty hostname annotation")
+			createService(map[string]string{
+				AnnotationHostname: "",
+			})
+
+			By("Reconciling")
+			r := newReconciler()
+			_, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should create Gateway and HTTPRoute when hostname annotation is set", func() {
+			By("Creating a Service with cloudflare annotation")
+			createService(map[string]string{
+				AnnotationHostname:         "myapp.example.com",
+				AnnotationZeroTrustEnabled: "false",
+			})
+
+			By("Reconciling")
+			r := newReconciler()
+			_, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying Gateway was created")
+			gwName := getDefaultGatewayName("default")
+			gw := &gatewayv1.Gateway{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: gwName, Namespace: "default"}, gw)).To(Succeed())
+			Expect(string(gw.Spec.GatewayClassName)).To(Equal("cloudflare"))
+			DeferCleanup(func() {
+				gw.Finalizers = []string{}
+				_ = k8sClient.Update(ctx, gw)
+				_ = k8sClient.Delete(ctx, gw)
+			})
+
+			By("Verifying HTTPRoute was created")
+			routeName := fmt.Sprintf("%s-route", resourceName)
+			route := &gatewayv1.HTTPRoute{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: routeName, Namespace: "default"}, route)).To(Succeed())
+			Expect(string(route.Spec.Hostnames[0])).To(Equal("myapp.example.com"))
+			DeferCleanup(func() {
+				route.Finalizers = []string{}
+				_ = k8sClient.Update(ctx, route)
+				_ = k8sClient.Delete(ctx, route)
+			})
+		})
+
+		It("should create AccessPolicy when zero-trust is enabled (default)", func() {
+			By("Creating a Service with cloudflare annotation and zero-trust enabled (default)")
+			createService(map[string]string{
+				AnnotationHostname: "secure.example.com",
+				// AnnotationZeroTrustEnabled intentionally omitted (defaults to true)
+			})
+
+			By("Reconciling")
+			r := newReconciler()
+			_, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying CloudflareAccessPolicy was created")
+			policyName := fmt.Sprintf("%s-access", resourceName)
+			policy := &tunnelsv1.CloudflareAccessPolicy{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: policyName, Namespace: "default"}, policy)).To(Succeed())
+			Expect(policy.Spec.Application.Name).To(ContainSubstring(resourceName))
+			DeferCleanup(func() {
+				policy.Finalizers = []string{}
+				_ = k8sClient.Update(ctx, policy)
+				_ = k8sClient.Delete(ctx, policy)
+			})
+
+			By("Cleaning up Gateway and HTTPRoute")
+			gwName := getDefaultGatewayName("default")
+			gw := &gatewayv1.Gateway{}
+			if err := k8sClient.Get(ctx, types.NamespacedName{Name: gwName, Namespace: "default"}, gw); err == nil {
+				gw.Finalizers = []string{}
+				_ = k8sClient.Update(ctx, gw)
+				_ = k8sClient.Delete(ctx, gw)
+			}
+			routeName := fmt.Sprintf("%s-route", resourceName)
+			route := &gatewayv1.HTTPRoute{}
+			if err := k8sClient.Get(ctx, types.NamespacedName{Name: routeName, Namespace: "default"}, route); err == nil {
+				route.Finalizers = []string{}
+				_ = k8sClient.Update(ctx, route)
+				_ = k8sClient.Delete(ctx, route)
+			}
+		})
+
+		It("should not create AccessPolicy when zero-trust is disabled", func() {
+			By("Creating a Service with zero-trust disabled")
+			createService(map[string]string{
+				AnnotationHostname:         "public.example.com",
+				AnnotationZeroTrustEnabled: "false",
+			})
+
+			By("Reconciling")
+			r := newReconciler()
+			_, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying no CloudflareAccessPolicy was created")
+			policyName := fmt.Sprintf("%s-access", resourceName)
+			policy := &tunnelsv1.CloudflareAccessPolicy{}
+			err = k8sClient.Get(ctx, types.NamespacedName{Name: policyName, Namespace: "default"}, policy)
+			Expect(errors.IsNotFound(err)).To(BeTrue())
+
+			DeferCleanup(func() {
+				gwName := getDefaultGatewayName("default")
+				gw := &gatewayv1.Gateway{}
+				if err := k8sClient.Get(ctx, types.NamespacedName{Name: gwName, Namespace: "default"}, gw); err == nil {
+					gw.Finalizers = []string{}
+					_ = k8sClient.Update(ctx, gw)
+					_ = k8sClient.Delete(ctx, gw)
+				}
+				routeName := fmt.Sprintf("%s-route", resourceName)
+				route := &gatewayv1.HTTPRoute{}
+				if err := k8sClient.Get(ctx, types.NamespacedName{Name: routeName, Namespace: "default"}, route); err == nil {
+					route.Finalizers = []string{}
+					_ = k8sClient.Update(ctx, route)
+					_ = k8sClient.Delete(ctx, route)
+				}
+			})
+		})
+
+		It("should create AccessPolicy with external policy reference", func() {
+			By("Creating a Service with external policy annotation")
+			createService(map[string]string{
+				AnnotationHostname:        "protected.example.com",
+				AnnotationZeroTrustPolicy: "external-policy-id",
+			})
+
+			By("Reconciling")
+			r := newReconciler()
+			_, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying CloudflareAccessPolicy uses external policy")
+			policyName := fmt.Sprintf("%s-access", resourceName)
+			policy := &tunnelsv1.CloudflareAccessPolicy{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: policyName, Namespace: "default"}, policy)).To(Succeed())
+			Expect(policy.Spec.Policies[0].ExternalPolicyID).To(Equal("external-policy-id"))
+			DeferCleanup(func() {
+				policy.Finalizers = []string{}
+				_ = k8sClient.Update(ctx, policy)
+				_ = k8sClient.Delete(ctx, policy)
+			})
+
+			DeferCleanup(func() {
+				gwName := getDefaultGatewayName("default")
+				gw := &gatewayv1.Gateway{}
+				if err := k8sClient.Get(ctx, types.NamespacedName{Name: gwName, Namespace: "default"}, gw); err == nil {
+					gw.Finalizers = []string{}
+					_ = k8sClient.Update(ctx, gw)
+					_ = k8sClient.Delete(ctx, gw)
+				}
+				routeName := fmt.Sprintf("%s-route", resourceName)
+				route := &gatewayv1.HTTPRoute{}
+				if err := k8sClient.Get(ctx, types.NamespacedName{Name: routeName, Namespace: "default"}, route); err == nil {
+					route.Finalizers = []string{}
+					_ = k8sClient.Update(ctx, route)
+					_ = k8sClient.Delete(ctx, route)
+				}
+			})
+		})
+
+		It("should clean up HTTPRoute and AccessPolicy when annotation is removed", func() {
+			By("Creating Service resources manually to simulate pre-existing state")
+			routeName := fmt.Sprintf("%s-route", resourceName)
+			policyName := fmt.Sprintf("%s-access", resourceName)
+
+			svc := createService(nil) // no annotation
+
+			// Create an HTTPRoute as if the operator had previously made it
+			route := &gatewayv1.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      routeName,
+					Namespace: "default",
+				},
+				Spec: gatewayv1.HTTPRouteSpec{
+					Rules: []gatewayv1.HTTPRouteRule{
+						{
+							BackendRefs: []gatewayv1.HTTPBackendRef{
+								{
+									BackendRef: gatewayv1.BackendRef{
+										BackendObjectReference: gatewayv1.BackendObjectReference{
+											Name: gatewayv1.ObjectName(resourceName),
+											Port: func() *gatewayv1.PortNumber { p := gatewayv1.PortNumber(8080); return &p }(),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, route)).To(Succeed())
+
+			// Create an AccessPolicy as if the operator had previously made it
+			policy := &tunnelsv1.CloudflareAccessPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      policyName,
+					Namespace: "default",
+				},
+				Spec: tunnelsv1.CloudflareAccessPolicySpec{
+					TargetRef: tunnelsv1.PolicyTargetReference{
+						Group: "gateway.networking.k8s.io",
+						Kind:  "HTTPRoute",
+						Name:  routeName,
+					},
+					Policies: []tunnelsv1.AccessPolicy{
+						{
+							Decision: "allow",
+							Rules: []tunnelsv1.AccessPolicyRule{
+								{Everyone: true},
+							},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, policy)).To(Succeed())
+
+			By("Reconciling the unannotated Service — should clean up route and policy")
+			r := newReconciler()
+			_, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying HTTPRoute was deleted")
+			Eventually(func() bool {
+				return errors.IsNotFound(
+					k8sClient.Get(ctx, types.NamespacedName{Name: routeName, Namespace: "default"}, route),
+				)
+			}, time.Second*5).Should(BeTrue())
+
+			By("Verifying AccessPolicy was deleted")
+			Eventually(func() bool {
+				return errors.IsNotFound(
+					k8sClient.Get(ctx, types.NamespacedName{Name: policyName, Namespace: "default"}, policy),
+				)
+			}, time.Second*5).Should(BeTrue())
+
+			_ = svc
+		})
+
+		It("should use explicit port annotation when provided", func() {
+			By("Parsing annotations with explicit port")
+			r := newReconciler()
+			svc := &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						AnnotationHostname:    "explicit-port.example.com",
+						AnnotationServicePort: "9443",
+					},
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{Port: 8080},
+					},
+				},
+			}
+			config := r.parseAnnotations(svc)
+			Expect(config.Port).To(Equal(int32(9443)))
+		})
+
+		It("should fall back to first Service port when no port annotation", func() {
+			r := newReconciler()
+			svc := &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Annotations: map[string]string{
+						AnnotationHostname: "fallback-port.example.com",
+					},
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{Port: 3000},
+					},
+				},
+			}
+			config := r.parseAnnotations(svc)
+			Expect(config.Port).To(Equal(int32(3000)))
+		})
+
+		It("should use namespace-scoped Gateway name", func() {
+			r := newReconciler()
+			svc := &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "my-namespace",
+					Annotations: map[string]string{
+						AnnotationHostname: "scoped.example.com",
+					},
+				},
+			}
+			config := r.parseAnnotations(svc)
+			Expect(config.GatewayName).To(Equal("namespace-my-namespace"))
+			Expect(config.GatewayNamespace).To(Equal("my-namespace"))
+		})
+
+		It("should return error when ensureGateway finds a non-cloudflare Gateway", func() {
+			By("Creating a Gateway with a different class")
+			gwName := getDefaultGatewayName("default")
+			gw := &gatewayv1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      gwName,
+					Namespace: "default",
+				},
+				Spec: gatewayv1.GatewaySpec{
+					GatewayClassName: "nginx",
+					Listeners: []gatewayv1.Listener{
+						{Name: "http", Protocol: gatewayv1.HTTPProtocolType, Port: 80},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, gw)).To(Succeed())
+			DeferCleanup(func() {
+				gw.Finalizers = []string{}
+				_ = k8sClient.Update(ctx, gw)
+				_ = k8sClient.Delete(ctx, gw)
+			})
+
+			By("Creating a Service with cloudflare annotation")
+			createService(map[string]string{
+				AnnotationHostname: "conflict.example.com",
+			})
+
+			By("Reconciling — should fail because existing Gateway is not cloudflare class")
+			r := newReconciler()
+			_, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("not a Cloudflare Gateway"))
+		})
+
+		It("should update existing HTTPRoute on second reconcile", func() {
+			By("Creating a Service with cloudflare annotation")
+			createService(map[string]string{
+				AnnotationHostname:         "update-test.example.com",
+				AnnotationZeroTrustEnabled: "false",
+			})
+
+			r := newReconciler()
+
+			By("First reconcile — creates Gateway and HTTPRoute")
+			_, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Second reconcile — updates existing HTTPRoute")
+			_, err = r.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("HTTPRoute still exists and is correct")
+			routeName := fmt.Sprintf("%s-route", resourceName)
+			route := &gatewayv1.HTTPRoute{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: routeName, Namespace: "default"}, route)).To(Succeed())
+			Expect(string(route.Spec.Hostnames[0])).To(Equal("update-test.example.com"))
+
+			DeferCleanup(func() {
+				gwName := getDefaultGatewayName("default")
+				gw := &gatewayv1.Gateway{}
+				if err := k8sClient.Get(ctx, types.NamespacedName{Name: gwName, Namespace: "default"}, gw); err == nil {
+					gw.Finalizers = []string{}
+					_ = k8sClient.Update(ctx, gw)
+					_ = k8sClient.Delete(ctx, gw)
+				}
+				route.Finalizers = []string{}
+				_ = k8sClient.Update(ctx, route)
+				_ = k8sClient.Delete(ctx, route)
+			})
+		})
+	})
+})

--- a/projects/operators/cloudflare/internal/controller/suite_test.go
+++ b/projects/operators/cloudflare/internal/controller/suite_test.go
@@ -32,6 +32,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	tunnelsv1 "github.com/jomcgi/homelab/projects/operators/cloudflare/api/v1"
 	cfclient "github.com/jomcgi/homelab/projects/operators/cloudflare/internal/cloudflare"
@@ -259,6 +260,9 @@ var _ = BeforeSuite(func() {
 
 	var err error
 	err = tunnelsv1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	err = gatewayv1.Install(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
 	// +kubebuilder:scaffold:scheme


### PR DESCRIPTION
## Summary

- Adds envtest-based Ginkgo tests for the 5 previously untested controllers: `GatewayClassReconciler`, `GatewayReconciler`, `HTTPRouteReconciler`, `ServiceReconciler`, and `CloudflareAccessPolicyReconciler`
- Follows the existing `suite_test.go` / `cloudflaretunnel_controller_test.go` patterns (MockTunnelClient, envtest environment, Ginkgo + Gomega)
- Registers Gateway API types in `BeforeSuite` and updates `BUILD` deps accordingly

Coverage per controller:
- **GatewayClass**: Accepted/InvalidParameters conditions, missing/incomplete Secret, unsupported kind, missing namespace
- **Gateway**: finalizer lifecycle, cloudflare-class filtering, tunnel CRD creation flow, status sync (active/ready/pending), deletion, tunnel recreation on missing CRD, image configuration
- **HTTPRoute**: finalizer lifecycle, graceful deletion without Gateway, all error paths (missing Gateway, non-cloudflare class, missing tunnel metadata), `getBackendServiceURL` unit tests (no rules, no backendRefs, unsupported kind, correct URL construction)
- **Service**: annotation-driven resource creation (Gateway + HTTPRoute + AccessPolicy), zero-trust enable/disable, external policy references, annotation-removal cleanup, `parseAnnotations` unit tests, non-cloudflare Gateway conflict detection
- **CloudflareAccessPolicy**: finalizer lifecycle, graceful deletion, all error paths (missing HTTPRoute, no parent Gateway, missing account ID, unsupported targetRef kind, no hostnames, Gateway target without domain), `buildApplicationConfig` and `buildPolicyConfig` unit tests

Closes #1233

## Test plan

- [ ] CI runs `bazel test //projects/operators/cloudflare/internal/controller:controller_test` (tagged `manual`, requires envtest)
- [ ] `go vet ./projects/operators/cloudflare/...` passes locally (verified ✅)
- [ ] `go build ./projects/operators/cloudflare/...` passes locally (verified ✅)

🤖 Generated with [Claude Code](https://claude.com/claude-code)