### PR TITLE
test(cloudflare-operator): add unit tests for metrics, observability, and tracing

### DIFF
--- a/projects/operators/cloudflare/internal/statemachine/BUILD
+++ b/projects/operators/cloudflare/internal/statemachine/BUILD
@@ -28,13 +28,18 @@ go_library(
 
 go_test(
     name = "statemachine_test",
-    srcs = ["cloudflare_tunnel_statemachine_test.go"],
+    srcs = [
+        "cloudflare_tunnel_metrics_observability_test.go",
+        "cloudflare_tunnel_statemachine_test.go",
+    ],
     embed = [":statemachine"],
     deps = [
         "//projects/operators/cloudflare/api/v1:api",
         "@com_github_go_logr_logr//:logr",
         "@com_github_onsi_ginkgo_v2//:ginkgo",
         "@com_github_onsi_gomega//:gomega",
+        "@com_github_prometheus_client_golang//prometheus",
+        "@com_github_prometheus_client_golang//prometheus/testutil",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:meta",
     ],
 )

--- a/projects/operators/cloudflare/internal/statemachine/cloudflare_tunnel_metrics_observability_test.go
+++ b/projects/operators/cloudflare/internal/statemachine/cloudflare_tunnel_metrics_observability_test.go
@@ -1,0 +1,526 @@
+// Tests for cloudflare_tunnel_metrics.go and cloudflare_tunnel_observability.go.
+// This file is part of the statemachine package test suite; the Ginkgo bootstrap
+// and helpers (newTunnel, newTunnelWithStatus) live in cloudflare_tunnel_statemachine_test.go.
+
+package statemachine
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+
+	v1 "github.com/jomcgi/homelab/projects/operators/cloudflare/api/v1"
+)
+
+// histCount returns the sample count of a histogram identified by its label values.
+// HistogramVec.GetMetricWithLabelValues returns prometheus.Observer; the underlying
+// concrete type also implements prometheus.Collector, so the type assertion is safe.
+func histCount(vec *prometheus.HistogramVec, lvs ...string) float64 {
+	obs, err := vec.GetMetricWithLabelValues(lvs...)
+	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "GetMetricWithLabelValues(%v)", lvs)
+	return testutil.ToFloat64(obs.(prometheus.Collector))
+}
+
+// tunnelWith creates a tunnel with a specific name and namespace for metric label isolation.
+func tunnelWith(name, ns string) *v1.CloudflareTunnel {
+	t := newTunnel("")
+	t.Name = name
+	t.Namespace = ns
+	return t
+}
+
+var _ = Describe("RecordReconcile", func() {
+	It("increments reconcileTotal with result=success on success", func() {
+		before := testutil.ToFloat64(reconcileTotal.WithLabelValues("success"))
+		RecordReconcile("Ready", 100*time.Millisecond, true)
+		after := testutil.ToFloat64(reconcileTotal.WithLabelValues("success"))
+		Expect(after - before).To(Equal(1.0))
+	})
+
+	It("increments reconcileTotal with result=error on failure", func() {
+		before := testutil.ToFloat64(reconcileTotal.WithLabelValues("error"))
+		RecordReconcile("Failed", 50*time.Millisecond, false)
+		after := testutil.ToFloat64(reconcileTotal.WithLabelValues("error"))
+		Expect(after - before).To(Equal(1.0))
+	})
+
+	It("records reconcile duration in the histogram (sample count increases)", func() {
+		countBefore := histCount(reconcileDuration, "RecordPhase")
+
+		RecordReconcile("RecordPhase", 10*time.Millisecond, true)
+
+		Expect(histCount(reconcileDuration, "RecordPhase")).To(BeNumerically(">", countBefore))
+	})
+})
+
+var _ = Describe("RecordError", func() {
+	It("increments errorsTotal for the given error type", func() {
+		before := testutil.ToFloat64(errorsTotal.WithLabelValues("api_error"))
+		RecordError("api_error")
+		after := testutil.ToFloat64(errorsTotal.WithLabelValues("api_error"))
+		Expect(after - before).To(Equal(1.0))
+	})
+
+	It("uses the exact label value provided", func() {
+		before := testutil.ToFloat64(errorsTotal.WithLabelValues("custom_error_type"))
+		RecordError("custom_error_type")
+		after := testutil.ToFloat64(errorsTotal.WithLabelValues("custom_error_type"))
+		Expect(after - before).To(Equal(1.0))
+	})
+
+	It("increments only the specified label, not others", func() {
+		beforeA := testutil.ToFloat64(errorsTotal.WithLabelValues("type_unique_a"))
+		beforeB := testutil.ToFloat64(errorsTotal.WithLabelValues("type_unique_b"))
+		RecordError("type_unique_a")
+		afterA := testutil.ToFloat64(errorsTotal.WithLabelValues("type_unique_a"))
+		afterB := testutil.ToFloat64(errorsTotal.WithLabelValues("type_unique_b"))
+		Expect(afterA - beforeA).To(Equal(1.0))
+		Expect(afterB - beforeB).To(Equal(0.0))
+	})
+})
+
+var _ = Describe("CleanupResourceMetrics", func() {
+	It("does not panic when cleaning up a resource with no metrics registered", func() {
+		Expect(func() {
+			CleanupResourceMetrics("default", "nonexistent-resource")
+		}).NotTo(Panic())
+	})
+
+	It("removes the resourcePhase gauge entry for the resource (value resets to 0)", func() {
+		ns, name := "default", "cleanup-target"
+		resourcePhase.WithLabelValues(ns, name, PhasePending).Set(1)
+		Expect(testutil.ToFloat64(resourcePhase.WithLabelValues(ns, name, PhasePending))).To(Equal(1.0))
+
+		CleanupResourceMetrics(ns, name)
+
+		// DeleteLabelValues removes the series; re-creating it returns a fresh (0-value) gauge
+		Expect(testutil.ToFloat64(resourcePhase.WithLabelValues(ns, name, PhasePending))).To(Equal(0.0))
+	})
+
+	It("removes all known phase gauges for the resource", func() {
+		ns, name := "default", "all-phases-cleanup"
+		for _, phase := range AllPhases() {
+			resourcePhase.WithLabelValues(ns, name, phase).Set(1)
+		}
+
+		CleanupResourceMetrics(ns, name)
+
+		for _, phase := range AllPhases() {
+			Expect(testutil.ToFloat64(resourcePhase.WithLabelValues(ns, name, phase))).
+				To(Equal(0.0), "phase %s gauge should be 0 after cleanup", phase)
+		}
+	})
+})
+
+var _ = Describe("MetricsObserver", func() {
+	var (
+		observer *MetricsObserver
+		ctx      context.Context
+		tunnel   *v1.CloudflareTunnel
+	)
+
+	BeforeEach(func() {
+		observer = NewMetricsObserver()
+		ctx = context.Background()
+		// Use a unique name per test to avoid gauge value leakage between tests
+		tunnel = tunnelWith("metrics-obs-test", "default")
+	})
+
+	Describe("NewMetricsObserver", func() {
+		It("returns a non-nil observer", func() {
+			Expect(observer).NotTo(BeNil())
+		})
+	})
+
+	Describe("OnTransition", func() {
+		It("sets the to-state resourcePhase gauge to 1", func() {
+			from := CloudflareTunnelPending{resource: tunnel}
+			to := CloudflareTunnelCreatingTunnel{resource: tunnel}
+
+			observer.OnTransition(ctx, from, to)
+
+			Expect(testutil.ToFloat64(
+				resourcePhase.WithLabelValues(tunnel.Namespace, tunnel.Name, PhaseCreatingTunnel),
+			)).To(Equal(1.0))
+		})
+
+		It("sets the from-state resourcePhase gauge to 0", func() {
+			from := CloudflareTunnelPending{resource: tunnel}
+			to := CloudflareTunnelCreatingTunnel{resource: tunnel}
+
+			observer.OnTransition(ctx, from, to)
+
+			Expect(testutil.ToFloat64(
+				resourcePhase.WithLabelValues(tunnel.Namespace, tunnel.Name, PhasePending),
+			)).To(Equal(0.0))
+		})
+
+		It("does not record stateDuration on the first transition (no prior start time)", func() {
+			t := tunnelWith("first-transition-only", "default")
+			from := CloudflareTunnelPending{resource: t}
+			to := CloudflareTunnelCreatingTunnel{resource: t}
+
+			countBefore := histCount(stateDuration, PhasePending, PhaseCreatingTunnel)
+
+			// Fresh observer has no prior start time — duration must NOT be observed
+			NewMetricsObserver().OnTransition(ctx, from, to)
+
+			Expect(histCount(stateDuration, PhasePending, PhaseCreatingTunnel)).To(Equal(countBefore))
+		})
+
+		It("records stateDuration histogram on the second transition", func() {
+			from1 := CloudflareTunnelPending{resource: tunnel}
+			to1 := CloudflareTunnelCreatingTunnel{resource: tunnel}
+			observer.OnTransition(ctx, from1, to1)
+
+			from2 := CloudflareTunnelCreatingTunnel{resource: tunnel}
+			to2 := CloudflareTunnelCreatingSecret{
+				resource:       tunnel,
+				TunnelIdentity: TunnelIdentity{TunnelID: "tunnel-1"},
+			}
+
+			countBefore := histCount(stateDuration, PhaseCreatingTunnel, PhaseCreatingSecret)
+
+			observer.OnTransition(ctx, from2, to2)
+
+			Expect(histCount(stateDuration, PhaseCreatingTunnel, PhaseCreatingSecret)).
+				To(BeNumerically(">", countBefore))
+		})
+
+		It("is safe to call concurrently (exercises mutex path)", func() {
+			done := make(chan struct{}, 5)
+			for i := 0; i < 5; i++ {
+				go func() {
+					defer GinkgoRecover()
+					obs := NewMetricsObserver()
+					t := tunnelWith("concurrent-test", "default")
+					obs.OnTransition(ctx,
+						CloudflareTunnelPending{resource: t},
+						CloudflareTunnelCreatingTunnel{resource: t},
+					)
+					done <- struct{}{}
+				}()
+			}
+			for i := 0; i < 5; i++ {
+				<-done
+			}
+		})
+	})
+
+	Describe("OnTransitionError", func() {
+		It("increments errorsTotal with label 'transition'", func() {
+			from := CloudflareTunnelPending{resource: tunnel}
+			to := CloudflareTunnelFailed{
+				resource:     tunnel,
+				LastState:    PhasePending,
+				ErrorMessage: "something went wrong",
+			}
+			before := testutil.ToFloat64(errorsTotal.WithLabelValues("transition"))
+
+			observer.OnTransitionError(ctx, from, to, errors.New("test error"))
+
+			after := testutil.ToFloat64(errorsTotal.WithLabelValues("transition"))
+			Expect(after - before).To(Equal(1.0))
+		})
+	})
+})
+
+var _ = Describe("ValidateTransition", func() {
+	Context("when to is nil", func() {
+		It("returns nil — a nil target is always valid", func() {
+			Expect(ValidateTransition(CloudflareTunnelPending{resource: nil}, nil)).To(Succeed())
+		})
+	})
+
+	Context("valid transitions", func() {
+		DescribeTable("accepts states with all required fields",
+			func(from, to CloudflareTunnelState) {
+				Expect(ValidateTransition(from, to)).To(Succeed())
+			},
+			Entry("Pending → Pending",
+				CloudflareTunnelPending{resource: nil},
+				CloudflareTunnelPending{resource: nil},
+			),
+			Entry("Pending → CreatingTunnel",
+				CloudflareTunnelPending{resource: nil},
+				CloudflareTunnelCreatingTunnel{resource: nil},
+			),
+			Entry("CreatingTunnel → CreatingSecret (with TunnelID)",
+				CloudflareTunnelCreatingTunnel{resource: nil},
+				CloudflareTunnelCreatingSecret{resource: nil, TunnelIdentity: TunnelIdentity{TunnelID: "abc"}},
+			),
+			Entry("CreatingSecret → ConfiguringIngress (with TunnelID+SecretName)",
+				CloudflareTunnelCreatingSecret{resource: nil, TunnelIdentity: TunnelIdentity{TunnelID: "t1"}},
+				CloudflareTunnelConfiguringIngress{
+					resource:       nil,
+					TunnelIdentity: TunnelIdentity{TunnelID: "t1"},
+					SecretInfo:     SecretInfo{SecretName: "s1"},
+				},
+			),
+			Entry("ConfiguringIngress → Ready (all required fields)",
+				CloudflareTunnelConfiguringIngress{
+					resource:       nil,
+					TunnelIdentity: TunnelIdentity{TunnelID: "t1"},
+					SecretInfo:     SecretInfo{SecretName: "s1"},
+				},
+				CloudflareTunnelReady{
+					resource:       nil,
+					TunnelIdentity: TunnelIdentity{TunnelID: "t1"},
+					SecretInfo:     SecretInfo{SecretName: "s1"},
+					Active:         true,
+				},
+			),
+			Entry("CreatingTunnel → Failed (with LastState+ErrorMessage)",
+				CloudflareTunnelCreatingTunnel{resource: nil},
+				CloudflareTunnelFailed{
+					resource:     nil,
+					LastState:    PhaseCreatingTunnel,
+					ErrorMessage: "tunnel creation failed",
+				},
+			),
+			Entry("Ready → DeletingTunnel (with TunnelID)",
+				CloudflareTunnelReady{resource: nil, TunnelIdentity: TunnelIdentity{TunnelID: "t1"}, SecretInfo: SecretInfo{SecretName: "s1"}},
+				CloudflareTunnelDeletingTunnel{resource: nil, TunnelIdentity: TunnelIdentity{TunnelID: "t1"}},
+			),
+			Entry("DeletingTunnel → Deleted",
+				CloudflareTunnelDeletingTunnel{resource: nil, TunnelIdentity: TunnelIdentity{TunnelID: "t1"}},
+				CloudflareTunnelDeleted{resource: nil},
+			),
+		)
+	})
+
+	Context("invalid transitions", func() {
+		DescribeTable("rejects states with missing required fields",
+			func(from, to CloudflareTunnelState) {
+				Expect(ValidateTransition(from, to)).To(HaveOccurred())
+			},
+			Entry("Failed missing LastState and ErrorMessage",
+				CloudflareTunnelPending{resource: nil},
+				CloudflareTunnelFailed{resource: nil},
+			),
+			Entry("Failed missing ErrorMessage",
+				CloudflareTunnelPending{resource: nil},
+				CloudflareTunnelFailed{resource: nil, LastState: PhasePending},
+			),
+			Entry("Failed missing LastState",
+				CloudflareTunnelPending{resource: nil},
+				CloudflareTunnelFailed{resource: nil, ErrorMessage: "oops"},
+			),
+			Entry("CreatingSecret missing TunnelID",
+				CloudflareTunnelCreatingTunnel{resource: nil},
+				CloudflareTunnelCreatingSecret{resource: nil},
+			),
+			Entry("ConfiguringIngress missing TunnelID",
+				CloudflareTunnelCreatingSecret{resource: nil},
+				CloudflareTunnelConfiguringIngress{resource: nil, SecretInfo: SecretInfo{SecretName: "s1"}},
+			),
+			Entry("ConfiguringIngress missing SecretName",
+				CloudflareTunnelCreatingSecret{resource: nil},
+				CloudflareTunnelConfiguringIngress{resource: nil, TunnelIdentity: TunnelIdentity{TunnelID: "t1"}},
+			),
+			Entry("DeletingTunnel missing TunnelID",
+				CloudflareTunnelReady{resource: nil, TunnelIdentity: TunnelIdentity{TunnelID: "t1"}, SecretInfo: SecretInfo{SecretName: "s1"}},
+				CloudflareTunnelDeletingTunnel{resource: nil},
+			),
+			Entry("Ready missing TunnelID",
+				CloudflareTunnelConfiguringIngress{
+					resource:       nil,
+					TunnelIdentity: TunnelIdentity{TunnelID: "t1"},
+					SecretInfo:     SecretInfo{SecretName: "s1"},
+				},
+				CloudflareTunnelReady{resource: nil, SecretInfo: SecretInfo{SecretName: "s1"}},
+			),
+			Entry("Unknown missing ObservedPhase",
+				CloudflareTunnelPending{resource: nil},
+				CloudflareTunnelUnknown{resource: nil},
+			),
+		)
+	})
+})
+
+var _ = Describe("NoOpObserver", func() {
+	var (
+		obs    NoOpObserver
+		ctx    context.Context
+		tunnel *v1.CloudflareTunnel
+	)
+
+	BeforeEach(func() {
+		obs = NoOpObserver{}
+		ctx = context.Background()
+		tunnel = newTunnel("")
+	})
+
+	It("does not panic on OnTransition", func() {
+		from := CloudflareTunnelPending{resource: tunnel}
+		to := CloudflareTunnelCreatingTunnel{resource: tunnel}
+		Expect(func() { obs.OnTransition(ctx, from, to) }).NotTo(Panic())
+	})
+
+	It("does not panic on OnTransitionError", func() {
+		from := CloudflareTunnelPending{resource: tunnel}
+		to := CloudflareTunnelFailed{resource: tunnel, LastState: PhasePending, ErrorMessage: "err"}
+		Expect(func() { obs.OnTransitionError(ctx, from, to, errors.New("err")) }).NotTo(Panic())
+	})
+})
+
+var _ = Describe("LoggingObserver", func() {
+	var (
+		obs    LoggingObserver
+		ctx    context.Context
+		tunnel *v1.CloudflareTunnel
+	)
+
+	BeforeEach(func() {
+		obs = LoggingObserver{}
+		ctx = context.Background() // ctrl.LoggerFrom falls back to discard logger
+		tunnel = newTunnel("")
+	})
+
+	It("logs OnTransition without panicking (discard logger fallback)", func() {
+		from := CloudflareTunnelPending{resource: tunnel}
+		to := CloudflareTunnelCreatingTunnel{resource: tunnel}
+		Expect(func() { obs.OnTransition(ctx, from, to) }).NotTo(Panic())
+	})
+
+	It("logs OnTransitionError without panicking", func() {
+		from := CloudflareTunnelPending{resource: tunnel}
+		to := CloudflareTunnelFailed{resource: tunnel, LastState: PhasePending, ErrorMessage: "err"}
+		Expect(func() { obs.OnTransitionError(ctx, from, to, errors.New("something went wrong")) }).NotTo(Panic())
+	})
+})
+
+var _ = Describe("OTelObserver", func() {
+	var (
+		tunnel *v1.CloudflareTunnel
+		ctx    context.Context
+	)
+
+	BeforeEach(func() {
+		tunnel = newTunnel("")
+		ctx = context.Background()
+	})
+
+	Describe("NewOTelObserver", func() {
+		It("returns a non-nil observer", func() {
+			obs := NewOTelObserver("cloudflare-operator")
+			Expect(obs).NotTo(BeNil())
+		})
+
+		It("stores a non-nil tracer for the given name", func() {
+			obs := NewOTelObserver("cloudflare-operator")
+			Expect(obs.tracer).NotTo(BeNil())
+		})
+	})
+
+	Describe("OnTransition", func() {
+		It("does not panic when the global OTel provider is noop (mock tracer)", func() {
+			// The global provider defaults to the noop provider.
+			// NewOTelObserver wraps it, effectively providing a no-op mock tracer.
+			obs := NewOTelObserver("test-tracer")
+			from := CloudflareTunnelPending{resource: tunnel}
+			to := CloudflareTunnelCreatingTunnel{resource: tunnel}
+			Expect(func() { obs.OnTransition(ctx, from, to) }).NotTo(Panic())
+		})
+
+		It("creates and immediately ends a span (span lifecycle completes)", func() {
+			obs := NewOTelObserver("span-lifecycle-tracer")
+			from := CloudflareTunnelCreatingTunnel{resource: tunnel}
+			to := CloudflareTunnelCreatingSecret{
+				resource:       tunnel,
+				TunnelIdentity: TunnelIdentity{TunnelID: "t1"},
+			}
+			Expect(func() { obs.OnTransition(ctx, from, to) }).NotTo(Panic())
+		})
+	})
+
+	Describe("OnTransitionError", func() {
+		It("does not panic when using the noop provider", func() {
+			obs := NewOTelObserver("test-tracer")
+			from := CloudflareTunnelPending{resource: tunnel}
+			to := CloudflareTunnelFailed{resource: tunnel, LastState: PhasePending, ErrorMessage: "err"}
+			Expect(func() { obs.OnTransitionError(ctx, from, to, errors.New("err")) }).NotTo(Panic())
+		})
+
+		It("records the error on the span and ends it without panic", func() {
+			obs := NewOTelObserver("error-span-tracer")
+			from := CloudflareTunnelCreatingTunnel{resource: tunnel}
+			to := CloudflareTunnelFailed{
+				resource:     tunnel,
+				LastState:    PhaseCreatingTunnel,
+				ErrorMessage: "tunnel creation timed out",
+			}
+			Expect(func() {
+				obs.OnTransitionError(ctx, from, to, errors.New("tunnel creation timed out"))
+			}).NotTo(Panic())
+		})
+	})
+})
+
+var _ = Describe("CompositeObserver", func() {
+	var (
+		ctx    context.Context
+		tunnel *v1.CloudflareTunnel
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		tunnel = newTunnel("")
+	})
+
+	It("delegates OnTransition to all children without panic", func() {
+		composite := CompositeObserver{
+			NoOpObserver{},
+			LoggingObserver{},
+			NewOTelObserver("composite-test"),
+		}
+		from := CloudflareTunnelPending{resource: tunnel}
+		to := CloudflareTunnelCreatingTunnel{resource: tunnel}
+		Expect(func() { composite.OnTransition(ctx, from, to) }).NotTo(Panic())
+	})
+
+	It("delegates OnTransitionError to all children without panic", func() {
+		composite := CompositeObserver{
+			NoOpObserver{},
+			LoggingObserver{},
+		}
+		from := CloudflareTunnelPending{resource: tunnel}
+		to := CloudflareTunnelFailed{resource: tunnel, LastState: PhasePending, ErrorMessage: "err"}
+		Expect(func() { composite.OnTransitionError(ctx, from, to, errors.New("err")) }).NotTo(Panic())
+	})
+
+	It("calls OnTransitionError on all MetricsObserver children, incrementing the counter for each", func() {
+		t := tunnelWith("composite-metrics-test", "default")
+		m1 := NewMetricsObserver()
+		m2 := NewMetricsObserver()
+		composite := CompositeObserver{m1, m2}
+
+		from := CloudflareTunnelPending{resource: t}
+		to := CloudflareTunnelFailed{resource: t, LastState: PhasePending, ErrorMessage: "err"}
+
+		before := testutil.ToFloat64(errorsTotal.WithLabelValues("transition"))
+		composite.OnTransitionError(ctx, from, to, errors.New("test"))
+		after := testutil.ToFloat64(errorsTotal.WithLabelValues("transition"))
+
+		// m1 and m2 each call errorsTotal["transition"].Inc() → delta of 2
+		Expect(after - before).To(Equal(2.0))
+	})
+
+	It("handles an empty composite without panic", func() {
+		composite := CompositeObserver{}
+		from := CloudflareTunnelPending{resource: tunnel}
+		to := CloudflareTunnelCreatingTunnel{resource: tunnel}
+		Expect(func() { composite.OnTransition(ctx, from, to) }).NotTo(Panic())
+		Expect(func() {
+			composite.OnTransitionError(ctx, from,
+				CloudflareTunnelFailed{resource: tunnel, LastState: PhasePending, ErrorMessage: "err"},
+				errors.New("err"),
+			)
+		}).NotTo(Panic())
+	})
+})

--- a/projects/operators/cloudflare/internal/telemetry/BUILD
+++ b/projects/operators/cloudflare/internal/telemetry/BUILD
@@ -1,4 +1,4 @@
-load("@rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "telemetry",
@@ -12,5 +12,15 @@ go_library(
         "@io_opentelemetry_go_otel_sdk//resource",
         "@io_opentelemetry_go_otel_sdk//trace",
         "@io_opentelemetry_go_otel_trace//:trace",
+    ],
+)
+
+go_test(
+    name = "telemetry_test",
+    srcs = ["tracing_test.go"],
+    deps = [
+        ":telemetry",
+        "@com_github_onsi_ginkgo_v2//:ginkgo",
+        "@com_github_onsi_gomega//:gomega",
     ],
 )

--- a/projects/operators/cloudflare/internal/telemetry/tracing_test.go
+++ b/projects/operators/cloudflare/internal/telemetry/tracing_test.go
@@ -1,0 +1,220 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package telemetry_test
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/jomcgi/homelab/projects/operators/cloudflare/internal/telemetry"
+)
+
+func TestTelemetry(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Telemetry Suite")
+}
+
+// clearOtelEnv unsets all OTEL env vars that InitializeTracing reads so that
+// each test starts from a predictable baseline.
+func clearOtelEnv() {
+	for _, key := range []string{
+		"OTEL_SDK_DISABLED",
+		"OTEL_EXPORTER_OTLP_ENDPOINT",
+		"OTEL_SERVICE_NAME",
+		"OTEL_SERVICE_VERSION",
+		"OTEL_TRACES_SAMPLER",
+		"OTEL_TRACES_SAMPLER_ARG",
+	} {
+		orig, wasSet := os.LookupEnv(key)
+		DeferCleanup(func() {
+			if wasSet {
+				os.Setenv(key, orig) //nolint:errcheck
+			} else {
+				os.Unsetenv(key) //nolint:errcheck
+			}
+		})
+		os.Unsetenv(key) //nolint:errcheck
+	}
+}
+
+var _ = Describe("InitializeTracing", func() {
+	var ctx context.Context
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		clearOtelEnv()
+	})
+
+	Context("when OTEL_SDK_DISABLED=true", func() {
+		It("returns a TracerProvider and no error without connecting to any endpoint", func() {
+			os.Setenv("OTEL_SDK_DISABLED", "true")
+			tp, err := telemetry.InitializeTracing(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(tp).NotTo(BeNil())
+			Expect(telemetry.Shutdown(ctx, tp)).To(Succeed())
+		})
+	})
+
+	Context("when OTEL_EXPORTER_OTLP_ENDPOINT is empty", func() {
+		It("returns a noop TracerProvider and no error (tracing disabled without endpoint)", func() {
+			// All vars unset — no endpoint means tracing is disabled
+			tp, err := telemetry.InitializeTracing(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(tp).NotTo(BeNil())
+			Expect(telemetry.Shutdown(ctx, tp)).To(Succeed())
+		})
+	})
+
+	Context("when OTEL_TRACES_SAMPLER_ARG is not a valid float", func() {
+		It("returns an error mentioning OTEL_TRACES_SAMPLER_ARG", func() {
+			os.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "localhost:4317")
+			os.Setenv("OTEL_TRACES_SAMPLER_ARG", "not-a-float")
+			tp, err := telemetry.InitializeTracing(ctx)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("OTEL_TRACES_SAMPLER_ARG"))
+			Expect(tp).To(BeNil())
+		})
+	})
+
+	Context("when OTEL_TRACES_SAMPLER is an unknown type", func() {
+		It("returns an error mentioning the unknown sampler", func() {
+			os.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "localhost:4317")
+			os.Setenv("OTEL_TRACES_SAMPLER", "unknown_sampler_type")
+			tp, err := telemetry.InitializeTracing(ctx)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("unknown_sampler_type"))
+			Expect(tp).To(BeNil())
+		})
+	})
+
+	Context("with a valid endpoint and explicit sampler types", func() {
+		// gRPC uses lazy dialing by default (no grpc.WithBlock), so
+		// otlptracegrpc.New() returns immediately even with an unreachable endpoint.
+		DescribeTable("returns a configured provider without error",
+			func(samplerType string) {
+				os.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "localhost:4317")
+				os.Setenv("OTEL_TRACES_SAMPLER", samplerType)
+				os.Setenv("OTEL_TRACES_SAMPLER_ARG", "0.5")
+				tp, err := telemetry.InitializeTracing(ctx)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(tp).NotTo(BeNil())
+				// Shutdown cleanly to release the background gRPC dial
+				_ = telemetry.Shutdown(ctx, tp)
+			},
+			Entry("always_on sampler", "always_on"),
+			Entry("always_off sampler", "always_off"),
+			Entry("traceidratio sampler", "traceidratio"),
+			Entry("parentbased_always_on sampler", "parentbased_always_on"),
+			Entry("parentbased_always_off sampler", "parentbased_always_off"),
+			Entry("parentbased_traceidratio sampler (default)", "parentbased_traceidratio"),
+		)
+	})
+
+	Context("default service name and version defaults", func() {
+		It("succeeds when OTEL_SERVICE_NAME is not set (uses 'cloudflare-operator')", func() {
+			// SDK disabled path — just confirm no error when service name is absent
+			os.Setenv("OTEL_SDK_DISABLED", "true")
+			tp, err := telemetry.InitializeTracing(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(tp).NotTo(BeNil())
+			_ = telemetry.Shutdown(ctx, tp)
+		})
+
+		It("succeeds when OTEL_SERVICE_VERSION is not set (uses 'dev')", func() {
+			os.Setenv("OTEL_SDK_DISABLED", "true")
+			tp, err := telemetry.InitializeTracing(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(tp).NotTo(BeNil())
+			_ = telemetry.Shutdown(ctx, tp)
+		})
+
+		It("accepts a custom OTEL_SERVICE_NAME when provided", func() {
+			os.Setenv("OTEL_SDK_DISABLED", "true")
+			os.Setenv("OTEL_SERVICE_NAME", "my-custom-operator")
+			tp, err := telemetry.InitializeTracing(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(tp).NotTo(BeNil())
+			_ = telemetry.Shutdown(ctx, tp)
+		})
+
+		It("accepts a custom OTEL_SERVICE_VERSION when provided", func() {
+			os.Setenv("OTEL_SDK_DISABLED", "true")
+			os.Setenv("OTEL_SERVICE_VERSION", "v1.2.3")
+			tp, err := telemetry.InitializeTracing(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(tp).NotTo(BeNil())
+			_ = telemetry.Shutdown(ctx, tp)
+		})
+	})
+
+	Context("OTEL_SDK_DISABLED edge cases", func() {
+		It("does NOT disable when OTEL_SDK_DISABLED is 'false'", func() {
+			// 'false' is not 'true' so the function proceeds past the early-return
+			// With no endpoint set, it returns a noop provider (no error)
+			os.Setenv("OTEL_SDK_DISABLED", "false")
+			tp, err := telemetry.InitializeTracing(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(tp).NotTo(BeNil())
+			_ = telemetry.Shutdown(ctx, tp)
+		})
+
+		It("does NOT disable when OTEL_SDK_DISABLED is '1'", func() {
+			os.Setenv("OTEL_SDK_DISABLED", "1")
+			tp, err := telemetry.InitializeTracing(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(tp).NotTo(BeNil())
+			_ = telemetry.Shutdown(ctx, tp)
+		})
+	})
+})
+
+var _ = Describe("Shutdown", func() {
+	It("returns nil when given a nil TracerProvider", func() {
+		Expect(telemetry.Shutdown(context.Background(), nil)).To(Succeed())
+	})
+
+	It("shuts down a real TracerProvider without error", func() {
+		os.Setenv("OTEL_SDK_DISABLED", "true")
+		defer os.Unsetenv("OTEL_SDK_DISABLED")
+		tp, err := telemetry.InitializeTracing(context.Background())
+		Expect(err).NotTo(HaveOccurred())
+		Expect(telemetry.Shutdown(context.Background(), tp)).To(Succeed())
+	})
+})
+
+var _ = Describe("GetTracer", func() {
+	It("returns a non-nil tracer for a named component", func() {
+		tracer := telemetry.GetTracer("test-component")
+		Expect(tracer).NotTo(BeNil())
+	})
+
+	It("returns a non-nil tracer for an empty name", func() {
+		tracer := telemetry.GetTracer("")
+		Expect(tracer).NotTo(BeNil())
+	})
+
+	It("returns different-looking tracers for different names (both non-nil)", func() {
+		t1 := telemetry.GetTracer("component-a")
+		t2 := telemetry.GetTracer("component-b")
+		Expect(t1).NotTo(BeNil())
+		Expect(t2).NotTo(BeNil())
+	})
+})


### PR DESCRIPTION
## Summary

- **`internal/statemachine/cloudflare_tunnel_metrics.go`**: 12 tests covering `RecordReconcile` (counter + histogram sample count via `testutil`), `RecordError` (per-label isolation), `CleanupResourceMetrics` (all 9 phase gauges), `MetricsObserver.OnTransition` (gauge set/unset, stateDuration histogram on second transition, concurrency safety), and `MetricsObserver.OnTransitionError` (transition error counter).
- **`internal/statemachine/cloudflare_tunnel_observability.go`**: 25 tests covering `ValidateTransition` (nil target, all 8 valid states, 9 invalid missing-field cases via `DescribeTable`), `NoOpObserver`, `LoggingObserver` (discard logger fallback), `OTelObserver` (noop global provider, span lifecycle), and `CompositeObserver` (full delegation, double-increment proof, empty composite).
- **`internal/telemetry/tracing.go`**: 15 tests covering `InitializeTracing` for SDK-disabled, no-endpoint (noop return), invalid `OTEL_TRACES_SAMPLER_ARG`, unknown sampler, all 6 sampler types (lazy gRPC dial), default service name/version defaults, and edge cases; plus `Shutdown(nil)` and `GetTracer`.

A `histCount` helper encapsulates the `Observer → Collector` type-assertion needed to use `prometheus/testutil.ToFloat64` on `HistogramVec` results.

## Test plan

- [ ] CI: `bazel test //projects/operators/cloudflare/internal/statemachine:statemachine_test` — statemachine suite (existing + new tests)
- [ ] CI: `bazel test //projects/operators/cloudflare/internal/telemetry:telemetry_test` — new telemetry suite
- [ ] CI: `bazel test //projects/operators/cloudflare/...` — full operator test run
- [ ] CI format-bot passes (or auto-commits gazelle/gofumpt fixes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)