### PR TITLE
feat(semgrep): add no-hardcoded-email-in-config rule

### DIFF
--- a/bazel/semgrep/rules/yaml/no-hardcoded-email-in-config.yaml
+++ b/bazel/semgrep/rules/yaml/no-hardcoded-email-in-config.yaml
@@ -1,0 +1,12 @@
+rules:
+  - id: no-hardcoded-email-in-config
+    languages: [yaml]
+    severity: WARNING
+    message: >-
+      Hardcoded email in a *_EMAIL config key. Values set directly in
+      values.yaml shadow envFrom secrets — the literal address will be used
+      instead of the value from your 1Password Operator OnePasswordItem. Remove
+      the value and inject it via a secret reference instead.
+    metadata:
+      category: security
+    pattern-regex: '[A-Z_]*_EMAIL:\s*["\']?[^@\s"'']+@[^@\s"'']+["\']?'

--- a/bazel/semgrep/tests/fixtures/no-hardcoded-email-in-config.yaml
+++ b/bazel/semgrep/tests/fixtures/no-hardcoded-email-in-config.yaml
@@ -1,0 +1,16 @@
+# Tests for no-hardcoded-email-in-config rule.
+---
+# ruleid: no-hardcoded-email-in-config
+ADMIN_EMAIL: admin@example.com
+
+---
+# ruleid: no-hardcoded-email-in-config
+SMTP_EMAIL: "noreply@myservice.io"
+
+---
+# ok: no-hardcoded-email-in-config — no @ symbol
+ADMIN_EMAIL: ""
+
+---
+# ok: no-hardcoded-email-in-config — not an email key
+description: contact@example.com


### PR DESCRIPTION
## Summary

- Adds a new Semgrep rule `no-hardcoded-email-in-config` that detects hardcoded email addresses in YAML config keys ending in `_EMAIL`
- Includes test fixtures with both positive (ruleid) and negative (ok) cases covering unquoted, quoted, empty-value, and non-email-key scenarios
- Rule flags `WARNING` severity under the `security` category, explaining that hardcoded values shadow `envFrom` secrets from the 1Password Operator

## Test plan

- [ ] CI `yaml_rules_test` semgrep test passes with the new rule and fixtures
- [ ] Verify `ADMIN_EMAIL: admin@example.com` triggers the rule
- [ ] Verify `SMTP_EMAIL: "noreply@myservice.io"` triggers the rule
- [ ] Verify `ADMIN_EMAIL: ""` (no `@`) does not trigger
- [ ] Verify `description: contact@example.com` (non-`_EMAIL` key) does not trigger

🤖 Generated with [Claude Code](https://claude.com/claude-code)