### PR TITLE
feat(semgrep): add argocd-retry-under-spec rule

### DIFF
--- a/bazel/semgrep/rules/yaml/argocd-retry-under-spec.yaml
+++ b/bazel/semgrep/rules/yaml/argocd-retry-under-spec.yaml
@@ -1,0 +1,17 @@
+rules:
+  - id: argocd-retry-under-spec
+    languages: [yaml]
+    severity: ERROR
+    message: >-
+      `retry` is a direct child of `spec` but must be nested under
+      `spec.syncPolicy`. ArgoCD silently ignores `spec.retry` — the retry
+      policy will never take effect. Move the `retry` block to
+      `spec.syncPolicy.retry`.
+    metadata:
+      category: correctness
+    patterns:
+      - pattern: |
+          kind: Application
+          ...
+          spec:
+            retry: ...

--- a/bazel/semgrep/tests/fixtures/argocd-retry-under-spec.yaml
+++ b/bazel/semgrep/tests/fixtures/argocd-retry-under-spec.yaml
@@ -1,0 +1,56 @@
+# Tests for argocd-retry-under-spec rule.
+# ArgoCD retry must be under spec.syncPolicy, not spec directly.
+---
+# ruleid: argocd-retry-under-spec
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: my-app
+  namespace: argocd
+spec:
+  retry:
+    limit: 5
+    backoff:
+      duration: 5s
+  project: default
+  source:
+    repoURL: https://github.com/example/repo
+    targetRevision: HEAD
+    path: deploy
+
+---
+# ok: argocd-retry-under-spec — retry correctly under syncPolicy
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: my-app
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/example/repo
+    targetRevision: HEAD
+    path: deploy
+  syncPolicy:
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+
+---
+# ok: argocd-retry-under-spec — no retry at all
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: my-app
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/example/repo
+    targetRevision: HEAD
+    path: deploy
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true


### PR DESCRIPTION
## Summary

- Adds a new semgrep rule `argocd-retry-under-spec` that detects the common mistake of placing `retry` directly under `spec` in ArgoCD Application manifests
- ArgoCD silently ignores `spec.retry` — the retry policy must be under `spec.syncPolicy.retry` to take effect
- Includes a test fixture with one positive case (misplaced retry) and two negative cases (correct placement and no retry)

## Test plan

- [ ] CI semgrep tests pass with the new rule and fixture
- [ ] Positive case (`spec.retry`) is flagged as ERROR
- [ ] Negative cases (`spec.syncPolicy.retry` and no retry) are not flagged

🤖 Generated with [Claude Code](https://claude.com/claude-code)