### PR TITLE
test(sextant): add schema and xstate type tests

### DIFF
--- a/projects/sextant/pkg/schema/BUILD
+++ b/projects/sextant/pkg/schema/BUILD
@@ -16,8 +16,12 @@ go_test(
     name = "schema_test",
     srcs = [
         "reserved_test.go",
+        "types_test.go",
         "validate_extra_test.go",
         "validate_test.go",
     ],
-    deps = [":schema"],
+    deps = [
+        ":schema",
+        "@in_gopkg_yaml_v3//:yaml_v3",
+    ],
 )

--- a/projects/sextant/pkg/schema/types_test.go
+++ b/projects/sextant/pkg/schema/types_test.go
@@ -1,0 +1,383 @@
+package schema_test
+
+import (
+	"testing"
+	"time"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/jomcgi/homelab/projects/sextant/pkg/schema"
+)
+
+// --- Duration tests ---
+
+func TestDuration_UnmarshalYAML_ValidDurations(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  time.Duration
+	}{
+		{"seconds", "5s", 5 * time.Second},
+		{"minutes", "2m", 2 * time.Minute},
+		{"hours", "1h", time.Hour},
+		{"milliseconds", "500ms", 500 * time.Millisecond},
+		{"composite", "1h30m", 90 * time.Minute},
+		{"empty string", "", 0},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			type wrapper struct {
+				D schema.Duration `yaml:"d"`
+			}
+			data := "d: " + tc.input
+			if tc.input == "" {
+				data = "d: \"\""
+			}
+			var w wrapper
+			if err := yaml.Unmarshal([]byte(data), &w); err != nil {
+				t.Fatalf("UnmarshalYAML(%q) error: %v", tc.input, err)
+			}
+			if w.D.Duration != tc.want {
+				t.Errorf("UnmarshalYAML(%q) = %v, want %v", tc.input, w.D.Duration, tc.want)
+			}
+		})
+	}
+}
+
+func TestDuration_UnmarshalYAML_InvalidDuration(t *testing.T) {
+	type wrapper struct {
+		D schema.Duration `yaml:"d"`
+	}
+	var w wrapper
+	err := yaml.Unmarshal([]byte("d: not-a-duration"), &w)
+	if err == nil {
+		t.Error("expected error for invalid duration string, got nil")
+	}
+}
+
+func TestDuration_MarshalYAML_Zero(t *testing.T) {
+	type wrapper struct {
+		D schema.Duration `yaml:"d"`
+	}
+	w := wrapper{D: schema.Duration{}}
+	data, err := yaml.Marshal(&w)
+	if err != nil {
+		t.Fatalf("MarshalYAML failed: %v", err)
+	}
+	// Zero duration should marshal to empty string
+	var w2 wrapper
+	if err := yaml.Unmarshal(data, &w2); err != nil {
+		t.Fatalf("round-trip unmarshal failed: %v", err)
+	}
+	if w2.D.Duration != 0 {
+		t.Errorf("expected zero duration after round-trip, got %v", w2.D.Duration)
+	}
+}
+
+func TestDuration_MarshalYAML_NonZero(t *testing.T) {
+	type wrapper struct {
+		D schema.Duration `yaml:"d"`
+	}
+	w := wrapper{D: schema.Duration{Duration: 5 * time.Second}}
+	data, err := yaml.Marshal(&w)
+	if err != nil {
+		t.Fatalf("MarshalYAML failed: %v", err)
+	}
+	// Should round-trip correctly
+	var w2 wrapper
+	if err := yaml.Unmarshal(data, &w2); err != nil {
+		t.Fatalf("round-trip unmarshal failed: %v", err)
+	}
+	if w2.D.Duration != 5*time.Second {
+		t.Errorf("round-trip: got %v, want 5s", w2.D.Duration)
+	}
+}
+
+// --- TransitionSource tests ---
+
+func TestTransitionSource_UnmarshalYAML_SingleString(t *testing.T) {
+	type wrapper struct {
+		From schema.TransitionSource `yaml:"from"`
+	}
+	var w wrapper
+	if err := yaml.Unmarshal([]byte("from: Pending"), &w); err != nil {
+		t.Fatalf("UnmarshalYAML failed: %v", err)
+	}
+	if len(w.From.States) != 1 || w.From.States[0] != "Pending" {
+		t.Errorf("got states %v, want [Pending]", w.From.States)
+	}
+}
+
+func TestTransitionSource_UnmarshalYAML_List(t *testing.T) {
+	type wrapper struct {
+		From schema.TransitionSource `yaml:"from"`
+	}
+	var w wrapper
+	yaml := "from:\n  - Pending\n  - Running\n"
+	if err := yaml_unmarshal([]byte(yaml), &w); err != nil {
+		t.Fatalf("UnmarshalYAML failed: %v", err)
+	}
+	if len(w.From.States) != 2 {
+		t.Fatalf("got %d states, want 2", len(w.From.States))
+	}
+	if w.From.States[0] != "Pending" || w.From.States[1] != "Running" {
+		t.Errorf("got states %v, want [Pending Running]", w.From.States)
+	}
+}
+
+func TestTransitionSource_MarshalYAML_Single(t *testing.T) {
+	type wrapper struct {
+		From schema.TransitionSource `yaml:"from"`
+	}
+	w := wrapper{From: schema.TransitionSource{States: []string{"Pending"}}}
+	data, err := yaml_marshal(&w)
+	if err != nil {
+		t.Fatalf("MarshalYAML failed: %v", err)
+	}
+	// Should round-trip as single string
+	var w2 wrapper
+	if err := yaml_unmarshal(data, &w2); err != nil {
+		t.Fatalf("round-trip unmarshal failed: %v", err)
+	}
+	if len(w2.From.States) != 1 || w2.From.States[0] != "Pending" {
+		t.Errorf("round-trip: got %v, want [Pending]", w2.From.States)
+	}
+}
+
+func TestTransitionSource_MarshalYAML_Multiple(t *testing.T) {
+	type wrapper struct {
+		From schema.TransitionSource `yaml:"from"`
+	}
+	w := wrapper{From: schema.TransitionSource{States: []string{"Pending", "Running"}}}
+	data, err := yaml_marshal(&w)
+	if err != nil {
+		t.Fatalf("MarshalYAML failed: %v", err)
+	}
+	// Should round-trip as list
+	var w2 wrapper
+	if err := yaml_unmarshal(data, &w2); err != nil {
+		t.Fatalf("round-trip unmarshal failed: %v", err)
+	}
+	if len(w2.From.States) != 2 {
+		t.Fatalf("round-trip: got %d states, want 2", len(w2.From.States))
+	}
+}
+
+func TestTransitionSource_MarshalYAML_Empty(t *testing.T) {
+	type wrapper struct {
+		From schema.TransitionSource `yaml:"from"`
+	}
+	w := wrapper{From: schema.TransitionSource{States: []string{}}}
+	data, err := yaml_marshal(&w)
+	if err != nil {
+		t.Fatalf("MarshalYAML failed: %v", err)
+	}
+	// Empty list should marshal to list (not single string)
+	var w2 wrapper
+	if err := yaml_unmarshal(data, &w2); err != nil {
+		t.Fatalf("round-trip unmarshal failed: %v", err)
+	}
+	if len(w2.From.States) != 0 {
+		t.Errorf("round-trip: got %v, want empty", w2.From.States)
+	}
+}
+
+// --- TransitionParam tests ---
+
+func TestTransitionParam_UnmarshalYAML(t *testing.T) {
+	tests := []struct {
+		name     string
+		yaml     string
+		wantName string
+		wantType string
+	}{
+		{
+			name:     "string type",
+			yaml:     "tunnelID: string",
+			wantName: "tunnelID",
+			wantType: "string",
+		},
+		{
+			name:     "int type",
+			yaml:     "count: int",
+			wantName: "count",
+			wantType: "int",
+		},
+		{
+			name:     "bool type",
+			yaml:     "enabled: bool",
+			wantName: "enabled",
+			wantType: "bool",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var p schema.TransitionParam
+			if err := yaml_unmarshal([]byte(tc.yaml), &p); err != nil {
+				t.Fatalf("UnmarshalYAML failed: %v", err)
+			}
+			if p.Name != tc.wantName {
+				t.Errorf("Name = %q, want %q", p.Name, tc.wantName)
+			}
+			if p.Type != tc.wantType {
+				t.Errorf("Type = %q, want %q", p.Type, tc.wantType)
+			}
+		})
+	}
+}
+
+func TestTransitionParam_MarshalYAML_RoundTrip(t *testing.T) {
+	original := schema.TransitionParam{Name: "tunnelID", Type: "string"}
+	data, err := yaml_marshal(original)
+	if err != nil {
+		t.Fatalf("MarshalYAML failed: %v", err)
+	}
+	var got schema.TransitionParam
+	if err := yaml_unmarshal(data, &got); err != nil {
+		t.Fatalf("round-trip unmarshal failed: %v", err)
+	}
+	if got.Name != original.Name || got.Type != original.Type {
+		t.Errorf("round-trip: got {%q, %q}, want {%q, %q}", got.Name, got.Type, original.Name, original.Type)
+	}
+}
+
+// --- State.Resolve tests ---
+
+func TestState_Resolve_NoFieldGroups(t *testing.T) {
+	s := schema.State{
+		Name:   "Pending",
+		Fields: map[string]string{"tunnelID": "string"},
+	}
+	resolved := s.Resolve(nil)
+	if resolved.AllFields["tunnelID"] != "string" {
+		t.Errorf("AllFields[tunnelID] = %q, want %q", resolved.AllFields["tunnelID"], "string")
+	}
+	if len(resolved.AllFields) != 1 {
+		t.Errorf("len(AllFields) = %d, want 1", len(resolved.AllFields))
+	}
+}
+
+func TestState_Resolve_WithFieldGroups(t *testing.T) {
+	groups := map[string]schema.FieldGroup{
+		"common": {"id": "string", "name": "string"},
+	}
+	s := schema.State{
+		Name:        "Pending",
+		FieldGroups: []string{"common"},
+	}
+	resolved := s.Resolve(groups)
+	if resolved.AllFields["id"] != "string" {
+		t.Errorf("AllFields[id] = %q, want string", resolved.AllFields["id"])
+	}
+	if resolved.AllFields["name"] != "string" {
+		t.Errorf("AllFields[name] = %q, want string", resolved.AllFields["name"])
+	}
+	if len(resolved.AllFields) != 2 {
+		t.Errorf("len(AllFields) = %d, want 2", len(resolved.AllFields))
+	}
+}
+
+func TestState_Resolve_DirectFieldsOverrideGroups(t *testing.T) {
+	groups := map[string]schema.FieldGroup{
+		"common": {"id": "string", "count": "int"},
+	}
+	s := schema.State{
+		Name:        "Running",
+		FieldGroups: []string{"common"},
+		Fields:      map[string]string{"count": "int64"}, // override
+	}
+	resolved := s.Resolve(groups)
+	if resolved.AllFields["count"] != "int64" {
+		t.Errorf("AllFields[count] = %q, want int64 (direct field should override group)", resolved.AllFields["count"])
+	}
+	if resolved.AllFields["id"] != "string" {
+		t.Errorf("AllFields[id] = %q, want string (from group)", resolved.AllFields["id"])
+	}
+}
+
+func TestState_Resolve_MultipleFieldGroups(t *testing.T) {
+	groups := map[string]schema.FieldGroup{
+		"ids":   {"tunnelID": "string"},
+		"times": {"createdAt": "string"},
+	}
+	s := schema.State{
+		Name:        "Active",
+		FieldGroups: []string{"ids", "times"},
+	}
+	resolved := s.Resolve(groups)
+	if len(resolved.AllFields) != 2 {
+		t.Errorf("len(AllFields) = %d, want 2", len(resolved.AllFields))
+	}
+	if resolved.AllFields["tunnelID"] != "string" {
+		t.Error("expected tunnelID from ids group")
+	}
+	if resolved.AllFields["createdAt"] != "string" {
+		t.Error("expected createdAt from times group")
+	}
+}
+
+func TestState_Resolve_MissingGroupIgnored(t *testing.T) {
+	groups := map[string]schema.FieldGroup{
+		"existing": {"foo": "string"},
+	}
+	s := schema.State{
+		Name:        "Pending",
+		FieldGroups: []string{"existing", "missing"},
+	}
+	// Should not panic; missing group is silently ignored
+	resolved := s.Resolve(groups)
+	if resolved.AllFields["foo"] != "string" {
+		t.Errorf("AllFields[foo] = %q, want string", resolved.AllFields["foo"])
+	}
+	if len(resolved.AllFields) != 1 {
+		t.Errorf("len(AllFields) = %d, want 1 (missing group should be ignored)", len(resolved.AllFields))
+	}
+}
+
+func TestState_Resolve_NilGroups(t *testing.T) {
+	s := schema.State{
+		Name:   "Pending",
+		Fields: map[string]string{"x": "string"},
+	}
+	// nil groups map should not panic
+	resolved := s.Resolve(nil)
+	if resolved.AllFields["x"] != "string" {
+		t.Errorf("AllFields[x] = %q, want string", resolved.AllFields["x"])
+	}
+}
+
+func TestState_Resolve_PreservesStateFields(t *testing.T) {
+	s := schema.State{
+		Name:     "Pending",
+		Initial:  true,
+		Terminal: false,
+		Error:    false,
+		Deletion: false,
+	}
+	resolved := s.Resolve(nil)
+	if resolved.Name != "Pending" {
+		t.Errorf("resolved.Name = %q, want Pending", resolved.Name)
+	}
+	if !resolved.Initial {
+		t.Error("expected Initial to be preserved")
+	}
+}
+
+func TestState_Resolve_EmptyFields(t *testing.T) {
+	s := schema.State{Name: "Pending"}
+	resolved := s.Resolve(map[string]schema.FieldGroup{})
+	if len(resolved.AllFields) != 0 {
+		t.Errorf("expected empty AllFields, got %v", resolved.AllFields)
+	}
+}
+
+// yaml_unmarshal and yaml_marshal are thin wrappers to allow easy YAML testing.
+func yaml_unmarshal(data []byte, v interface{}) error {
+	return yaml.Unmarshal(data, v)
+}
+
+func yaml_marshal(v interface{}) ([]byte, error) {
+	return yaml.Marshal(v)
+}

--- a/projects/sextant/pkg/xstate/BUILD
+++ b/projects/sextant/pkg/xstate/BUILD
@@ -16,6 +16,7 @@ go_test(
     srcs = [
         "convert_extra_test.go",
         "convert_test.go",
+        "types_test.go",
     ],
     deps = [
         ":xstate",

--- a/projects/sextant/pkg/xstate/types_test.go
+++ b/projects/sextant/pkg/xstate/types_test.go
@@ -1,0 +1,401 @@
+package xstate_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/jomcgi/homelab/projects/sextant/pkg/xstate"
+)
+
+// --- Transition.MarshalJSON tests ---
+
+func TestTransition_MarshalJSON_SimpleTarget(t *testing.T) {
+	tr := xstate.Transition{Target: "Ready"}
+	data, err := json.Marshal(tr)
+	if err != nil {
+		t.Fatalf("MarshalJSON failed: %v", err)
+	}
+	// Simple transition should marshal as a string, not an object
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		t.Fatalf("expected string marshaling for simple transition, got: %s", data)
+	}
+	if s != "Ready" {
+		t.Errorf("MarshalJSON() = %q, want %q", s, "Ready")
+	}
+}
+
+func TestTransition_MarshalJSON_WithActions(t *testing.T) {
+	tr := xstate.Transition{
+		Target:  "Ready",
+		Actions: []string{"doSomething"},
+	}
+	data, err := json.Marshal(tr)
+	if err != nil {
+		t.Fatalf("MarshalJSON failed: %v", err)
+	}
+	// Should marshal as an object since it has actions
+	var obj map[string]interface{}
+	if err := json.Unmarshal(data, &obj); err != nil {
+		t.Fatalf("expected object marshaling for transition with actions, got: %s, err: %v", data, err)
+	}
+	if obj["target"] != "Ready" {
+		t.Errorf("target = %v, want Ready", obj["target"])
+	}
+	actions, ok := obj["actions"].([]interface{})
+	if !ok || len(actions) != 1 || actions[0] != "doSomething" {
+		t.Errorf("actions = %v, want [doSomething]", obj["actions"])
+	}
+}
+
+func TestTransition_MarshalJSON_WithCond(t *testing.T) {
+	tr := xstate.Transition{
+		Target: "Ready",
+		Cond:   "hasPermission",
+	}
+	data, err := json.Marshal(tr)
+	if err != nil {
+		t.Fatalf("MarshalJSON failed: %v", err)
+	}
+	// Should marshal as an object since it has a condition
+	var obj map[string]interface{}
+	if err := json.Unmarshal(data, &obj); err != nil {
+		t.Fatalf("expected object marshaling for transition with cond: %s", data)
+	}
+	if obj["cond"] != "hasPermission" {
+		t.Errorf("cond = %v, want hasPermission", obj["cond"])
+	}
+}
+
+func TestTransition_MarshalJSON_WithInternal(t *testing.T) {
+	tr := xstate.Transition{
+		Target:   "Ready",
+		Internal: true,
+	}
+	data, err := json.Marshal(tr)
+	if err != nil {
+		t.Fatalf("MarshalJSON failed: %v", err)
+	}
+	// Should marshal as an object since internal=true
+	var obj map[string]interface{}
+	if err := json.Unmarshal(data, &obj); err != nil {
+		t.Fatalf("expected object marshaling for internal transition: %s", data)
+	}
+	if obj["internal"] != true {
+		t.Errorf("internal = %v, want true", obj["internal"])
+	}
+}
+
+func TestTransition_MarshalJSON_EmptyTarget(t *testing.T) {
+	tr := xstate.Transition{Target: ""}
+	data, err := json.Marshal(tr)
+	if err != nil {
+		t.Fatalf("MarshalJSON failed: %v", err)
+	}
+	// Empty target with no other fields marshals as empty string
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		t.Fatalf("expected string marshaling for empty target: %s", data)
+	}
+	if s != "" {
+		t.Errorf("MarshalJSON() = %q, want empty string", s)
+	}
+}
+
+// --- Transition.UnmarshalJSON tests ---
+
+func TestTransition_UnmarshalJSON_FromString(t *testing.T) {
+	data := `"Ready"`
+	var tr xstate.Transition
+	if err := json.Unmarshal([]byte(data), &tr); err != nil {
+		t.Fatalf("UnmarshalJSON failed: %v", err)
+	}
+	if tr.Target != "Ready" {
+		t.Errorf("Target = %q, want Ready", tr.Target)
+	}
+	if tr.Cond != "" {
+		t.Errorf("Cond = %q, want empty", tr.Cond)
+	}
+	if len(tr.Actions) != 0 {
+		t.Errorf("Actions = %v, want empty", tr.Actions)
+	}
+	if tr.Internal {
+		t.Error("Internal should be false for simple string unmarshal")
+	}
+}
+
+func TestTransition_UnmarshalJSON_FromObject(t *testing.T) {
+	data := `{"target":"Ready","actions":["doSomething"],"cond":"hasPermission","internal":true}`
+	var tr xstate.Transition
+	if err := json.Unmarshal([]byte(data), &tr); err != nil {
+		t.Fatalf("UnmarshalJSON failed: %v", err)
+	}
+	if tr.Target != "Ready" {
+		t.Errorf("Target = %q, want Ready", tr.Target)
+	}
+	if tr.Cond != "hasPermission" {
+		t.Errorf("Cond = %q, want hasPermission", tr.Cond)
+	}
+	if len(tr.Actions) != 1 || tr.Actions[0] != "doSomething" {
+		t.Errorf("Actions = %v, want [doSomething]", tr.Actions)
+	}
+	if !tr.Internal {
+		t.Error("Internal should be true")
+	}
+}
+
+func TestTransition_UnmarshalJSON_FromObjectWithoutOptionalFields(t *testing.T) {
+	data := `{"target":"Pending"}`
+	var tr xstate.Transition
+	if err := json.Unmarshal([]byte(data), &tr); err != nil {
+		t.Fatalf("UnmarshalJSON failed: %v", err)
+	}
+	if tr.Target != "Pending" {
+		t.Errorf("Target = %q, want Pending", tr.Target)
+	}
+	if tr.Cond != "" || len(tr.Actions) != 0 || tr.Internal {
+		t.Error("optional fields should be zero values")
+	}
+}
+
+func TestTransition_UnmarshalJSON_InvalidJSON(t *testing.T) {
+	data := `{invalid json`
+	var tr xstate.Transition
+	err := json.Unmarshal([]byte(data), &tr)
+	if err == nil {
+		t.Error("expected error for invalid JSON, got nil")
+	}
+}
+
+// --- Round-trip tests ---
+
+func TestTransition_RoundTrip_Simple(t *testing.T) {
+	original := xstate.Transition{Target: "Ready"}
+	data, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("MarshalJSON failed: %v", err)
+	}
+	var got xstate.Transition
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("UnmarshalJSON failed: %v", err)
+	}
+	if got.Target != original.Target {
+		t.Errorf("round-trip Target = %q, want %q", got.Target, original.Target)
+	}
+}
+
+func TestTransition_RoundTrip_Complex(t *testing.T) {
+	original := xstate.Transition{
+		Target:   "Ready",
+		Actions:  []string{"action1", "action2"},
+		Cond:     "myGuard",
+		Internal: true,
+	}
+	data, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("MarshalJSON failed: %v", err)
+	}
+	var got xstate.Transition
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("UnmarshalJSON failed: %v", err)
+	}
+	if got.Target != original.Target {
+		t.Errorf("Target = %q, want %q", got.Target, original.Target)
+	}
+	if got.Cond != original.Cond {
+		t.Errorf("Cond = %q, want %q", got.Cond, original.Cond)
+	}
+	if len(got.Actions) != len(original.Actions) {
+		t.Errorf("len(Actions) = %d, want %d", len(got.Actions), len(original.Actions))
+	}
+	if !got.Internal {
+		t.Error("Internal should be true after round-trip")
+	}
+}
+
+// --- Machine and State JSON marshaling tests ---
+
+func TestMachine_MarshalJSON(t *testing.T) {
+	machine := xstate.Machine{
+		ID:      "TestMachine",
+		Initial: "Pending",
+		States: map[string]xstate.State{
+			"Pending": {Type: ""},
+			"Ready":   {Type: "final"},
+		},
+	}
+	data, err := json.Marshal(machine)
+	if err != nil {
+		t.Fatalf("json.Marshal(Machine) failed: %v", err)
+	}
+	var got xstate.Machine
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("json.Unmarshal(Machine) failed: %v", err)
+	}
+	if got.ID != machine.ID {
+		t.Errorf("ID = %q, want %q", got.ID, machine.ID)
+	}
+	if got.Initial != machine.Initial {
+		t.Errorf("Initial = %q, want %q", got.Initial, machine.Initial)
+	}
+	if len(got.States) != 2 {
+		t.Errorf("len(States) = %d, want 2", len(got.States))
+	}
+}
+
+func TestMachine_ContextOmittedWhenEmpty(t *testing.T) {
+	machine := xstate.Machine{
+		ID:      "TestMachine",
+		Initial: "Pending",
+		States:  map[string]xstate.State{},
+	}
+	data, err := json.Marshal(machine)
+	if err != nil {
+		t.Fatalf("json.Marshal failed: %v", err)
+	}
+	// context field should be omitted when nil/empty
+	var raw map[string]interface{}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+	if _, ok := raw["context"]; ok {
+		t.Error("expected 'context' to be omitted from JSON when empty")
+	}
+}
+
+func TestMachine_ContextIncludedWhenSet(t *testing.T) {
+	machine := xstate.Machine{
+		ID:      "TestMachine",
+		Initial: "Pending",
+		Context: map[string]interface{}{"retryCount": 0},
+		States:  map[string]xstate.State{},
+	}
+	data, err := json.Marshal(machine)
+	if err != nil {
+		t.Fatalf("json.Marshal failed: %v", err)
+	}
+	var raw map[string]interface{}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+	if _, ok := raw["context"]; !ok {
+		t.Error("expected 'context' to be included in JSON when set")
+	}
+}
+
+func TestState_MetaOmittedWhenNil(t *testing.T) {
+	s := xstate.State{Type: "final"}
+	data, err := json.Marshal(s)
+	if err != nil {
+		t.Fatalf("json.Marshal failed: %v", err)
+	}
+	var raw map[string]interface{}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+	if _, ok := raw["meta"]; ok {
+		t.Error("expected 'meta' to be omitted when nil")
+	}
+}
+
+func TestState_MetaIncludedWhenSet(t *testing.T) {
+	s := xstate.State{
+		Meta: &xstate.StateMeta{Requeue: "30s", Error: true},
+	}
+	data, err := json.Marshal(s)
+	if err != nil {
+		t.Fatalf("json.Marshal failed: %v", err)
+	}
+	var got xstate.State
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+	if got.Meta == nil {
+		t.Fatal("expected Meta to be set")
+	}
+	if got.Meta.Requeue != "30s" {
+		t.Errorf("Meta.Requeue = %q, want 30s", got.Meta.Requeue)
+	}
+	if !got.Meta.Error {
+		t.Error("expected Meta.Error to be true")
+	}
+}
+
+func TestStateMeta_AllFields(t *testing.T) {
+	meta := xstate.StateMeta{
+		Requeue:     "1m",
+		Description: "A test state",
+		Error:       true,
+		Deletion:    true,
+		Fields:      map[string]string{"foo": "string"},
+	}
+	data, err := json.Marshal(meta)
+	if err != nil {
+		t.Fatalf("json.Marshal failed: %v", err)
+	}
+	var got xstate.StateMeta
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("json.Unmarshal failed: %v", err)
+	}
+	if got.Requeue != meta.Requeue {
+		t.Errorf("Requeue = %q, want %q", got.Requeue, meta.Requeue)
+	}
+	if got.Description != meta.Description {
+		t.Errorf("Description = %q, want %q", got.Description, meta.Description)
+	}
+	if !got.Error {
+		t.Error("Error should be true")
+	}
+	if !got.Deletion {
+		t.Error("Deletion should be true")
+	}
+	if got.Fields["foo"] != "string" {
+		t.Errorf("Fields[foo] = %q, want string", got.Fields["foo"])
+	}
+}
+
+func TestState_TagsRoundTrip(t *testing.T) {
+	s := xstate.State{
+		Tags: []string{"ready", "terminal"},
+	}
+	data, err := json.Marshal(s)
+	if err != nil {
+		t.Fatalf("json.Marshal failed: %v", err)
+	}
+	var got xstate.State
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("json.Unmarshal failed: %v", err)
+	}
+	if len(got.Tags) != 2 || got.Tags[0] != "ready" || got.Tags[1] != "terminal" {
+		t.Errorf("Tags = %v, want [ready terminal]", got.Tags)
+	}
+}
+
+func TestState_OnTransitionsRoundTrip(t *testing.T) {
+	s := xstate.State{
+		On: map[string]xstate.Transition{
+			"MARK_READY": {Target: "Ready"},
+			"FAIL":       {Target: "Failed", Cond: "hasErrors"},
+		},
+	}
+	data, err := json.Marshal(s)
+	if err != nil {
+		t.Fatalf("json.Marshal failed: %v", err)
+	}
+	var got xstate.State
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("json.Unmarshal failed: %v", err)
+	}
+	if len(got.On) != 2 {
+		t.Fatalf("len(On) = %d, want 2", len(got.On))
+	}
+	if got.On["MARK_READY"].Target != "Ready" {
+		t.Errorf("On[MARK_READY].Target = %q, want Ready", got.On["MARK_READY"].Target)
+	}
+	if got.On["FAIL"].Target != "Failed" {
+		t.Errorf("On[FAIL].Target = %q, want Failed", got.On["FAIL"].Target)
+	}
+	if got.On["FAIL"].Cond != "hasErrors" {
+		t.Errorf("On[FAIL].Cond = %q, want hasErrors", got.On["FAIL"].Cond)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `types_test.go` for `projects/sextant/pkg/schema/` covering `Duration`, `TransitionSource`, `TransitionParam` YAML marshaling and `State.Resolve` field-group expansion
- Adds `types_test.go` for `projects/sextant/pkg/xstate/` covering `Transition` custom JSON marshal/unmarshal and `Machine`/`State`/`StateMeta` round-trip serialization
- Updates both BUILD files to include new test sources and the `@in_gopkg_yaml_v3` dependency for the schema test

## Test plan
- [ ] `Duration.UnmarshalYAML`: valid durations (5s, 2m, 1h, 500ms, 1h30m), empty string → 0, invalid string → error
- [ ] `Duration.MarshalYAML`: zero → empty string round-trip, non-zero → string round-trip
- [ ] `TransitionSource.UnmarshalYAML`: single string, list, round-trip for both forms
- [ ] `TransitionParam.UnmarshalYAML` / `MarshalYAML`: string/int/bool types, round-trip
- [ ] `State.Resolve`: no groups, single group, multiple groups, direct fields override group, missing group silently ignored, nil groups, empty fields
- [ ] `Transition.MarshalJSON`: simple target → string, with actions/cond/internal → object
- [ ] `Transition.UnmarshalJSON`: from string, from full object, from minimal object, invalid JSON → error
- [ ] `Transition` round-trip: simple and complex
- [ ] `Machine`/`State`/`StateMeta` JSON round-trips; context/meta omitted when empty, included when set

🤖 Generated with [Claude Code](https://claude.com/claude-code)