### PR TITLE
feat(semgrep): add stale-copyright-year rule

### DIFF
--- a/bazel/semgrep/rules/golang/stale-copyright-year.yaml
+++ b/bazel/semgrep/rules/golang/stale-copyright-year.yaml
@@ -1,0 +1,16 @@
+rules:
+  - id: stale-copyright-year
+    languages: [generic]
+    severity: WARNING
+    message: >-
+      Copyright year is 2025 but the current year is 2026. Update the copyright
+      header to reflect the current year.
+    metadata:
+      category: style
+      subcategory: copyright
+      confidence: HIGH
+      likelihood: LOW
+      impact: LOW
+      technology: [go]
+      description: Copyright year 2025 is stale — should be 2026
+    pattern-regex: 'Copyright 2025'

--- a/bazel/semgrep/tests/fixtures/stale-copyright-year.yaml
+++ b/bazel/semgrep/tests/fixtures/stale-copyright-year.yaml
@@ -1,0 +1,11 @@
+# Tests for stale-copyright-year rule.
+# Fixtures use YAML comment-style annotations.
+
+# ruleid: stale-copyright-year
+# Copyright 2025 Block, Inc.
+
+# ok: current year is correct
+# Copyright 2026 Block, Inc.
+
+# ok: older historical year is not flagged by this rule (only 2025 is stale)
+# Copyright 2024 Block, Inc.


### PR DESCRIPTION
## Summary
- Adds a new semgrep rule `stale-copyright-year` that flags `Copyright 2025` as stale (current year is 2026)
- Uses `language: generic` with `pattern-regex` to match any file type
- Adds test fixture with `ruleid`/`ok` annotations for semgrep test mode

## Test plan
- [ ] CI semgrep tests pass
- [ ] `golang_rules` picks up the new rule via glob
- [ ] Test fixture is included in `yaml_fixtures` filegroup

🤖 Generated with [Claude Code](https://claude.com/claude-code)