### PR TITLE
feat(hooks): add copyright year check hook for Write|Edit

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -38,6 +38,11 @@
             "type": "command",
             "command": "bazel/tools/hooks/check-chart-version-sync.sh",
             "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "bazel/tools/hooks/check-copyright-year.sh",
+            "timeout": 5
           }
         ]
       }

--- a/bazel/tools/hooks/check-copyright-year.sh
+++ b/bazel/tools/hooks/check-copyright-year.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# PreToolUse hook: warns when writing/editing file content that contains a
+# stale copyright year (Copyright 2025). The current year is 2026.
+#
+# Input: JSON on stdin from Claude Code hook system
+# Exit 0: allow the operation (with optional warning on stderr)
+# Exit 2: block the operation (not used here — warning only)
+
+set -euo pipefail
+
+INPUT=$(cat)
+
+# Extract content from Write tool (content field) or Edit tool (new_string field)
+CONTENT=$(echo "$INPUT" | jq -r '.tool_input.content // .tool_input.new_string // empty')
+
+if [[ -z "$CONTENT" ]]; then
+	exit 0
+fi
+
+if echo "$CONTENT" | grep -q 'Copyright 2025'; then
+	cat >&2 <<-EOF
+		WARNING: File content contains stale copyright year "Copyright 2025".
+		The current year is 2026 — please update the copyright header to:
+		    Copyright 2026 Block, Inc.
+	EOF
+fi
+
+# Always allow — this is a warning, not a blocker
+exit 0


### PR DESCRIPTION
## Summary
- Adds `bazel/tools/hooks/check-copyright-year.sh` — a PreToolUse hook that warns when file content contains `Copyright 2025`
- Hook reads stdin JSON, extracts `content` (Write) or `new_string` (Edit), checks for stale year, and warns to stderr
- Registers the hook in `.claude/settings.json` under the existing `Write|Edit` matcher
- Warning only (exit 0) — does not block the operation

## Test plan
- [ ] Hook script is executable
- [ ] Writing a file with `Copyright 2025` shows a warning on stderr
- [ ] Writing a file with `Copyright 2026` produces no warning
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)