### PR TITLE
docs(platform): fix README inaccuracies

### DIFF
--- a/projects/platform/argocd-image-updater/README.md
+++ b/projects/platform/argocd-image-updater/README.md
@@ -42,5 +42,6 @@ Authentication uses a GitHub token stored in a Kubernetes Secret (sourced from 1
 | `argocd-image-updater.authScripts.enabled`     | Enable Git credential helper scripts | `true`                                     |
 | `argocd-image-updater.env`                     | Environment variables (GitHub token) | Secret ref to `argocd-image-updater-token` |
 | `argocd-image-updater.metrics.enabled`         | Enable Prometheus metrics            | `true`                                     |
-| `argocd-image-updater.resources.limits.memory` | Memory limit                         | `1Gi`                                      |
-| `argocd-image-updater.resources.requests.cpu`  | CPU request                          | `500m`                                     |
+| `argocd-image-updater.resources.limits.memory`    | Memory limit                         | `1Gi`                                      |
+| `argocd-image-updater.resources.requests.cpu`     | CPU request                          | `500m`                                     |
+| `argocd-image-updater.resources.requests.memory`  | Memory request                       | `1Gi`                                      |

--- a/projects/platform/coredns/README.md
+++ b/projects/platform/coredns/README.md
@@ -20,7 +20,7 @@ See `values.yaml` for all configuration options.
 ### Key Settings
 
 - **DNS Forwarders:** By default uses Cloudflare (1.1.1.1) and Google (8.8.8.8)
-- **Cache TTL:** 30 seconds
+- **Cache TTL:** 300 seconds (5 minutes)
 - **Max Concurrent:** 1000 concurrent DNS requests
 - **Prometheus:** Metrics exposed on `:9153/metrics`
 
@@ -35,7 +35,7 @@ forwarders:
   - 8.8.8.8 # Google
 
 # Increase cache TTL
-cacheTTL: 60
+cacheTTL: 300
 ```
 
 ## ArgoCD Integration


### PR DESCRIPTION
## Summary

- **coredns/README.md**: Corrected cache TTL from the inaccurate `30 seconds` (and example `cacheTTL: 60`) to the actual value of `300 seconds (5 minutes)`, matching `values.yaml` which has `cache 300` and `cacheTTL: 300`
- **argocd-image-updater/README.md**: Added missing `argocd-image-updater.resources.requests.memory` row (`1Gi`) to the configuration table — the actual `values.yaml` specifies both request and limit as `1Gi`

## Test plan

- [ ] Verify coredns README now shows `300 seconds (5 minutes)` for Cache TTL
- [ ] Verify coredns README example shows `cacheTTL: 300`
- [ ] Verify argocd-image-updater README configuration table includes the memory request row

🤖 Generated with [Claude Code](https://claude.com/claude-code)