### PR TITLE
docs(agent_platform): fix README inaccuracies

### DIFF
--- a/projects/agent_platform/api_gateway/README.md
+++ b/projects/agent_platform/api_gateway/README.md
@@ -11,13 +11,13 @@ flowchart LR
     CF[Cloudflare] --> GW[API Gateway]
     GW -->|/trips/*| Trips[trips-api]
     GW -->|/stargazer/*| Star[stargazer-api]
-    GW -->|/status| Status[cluster-info]
+    GW -->|/cluster-info| Status[cluster-info]
 ```
 
 ## Key Features
 
 - **Path-based routing** - Route to backends by URL prefix
-- **Cluster status** - `/status` endpoint with node/pod health
+- **Cluster status** - `/cluster-info` endpoint with node/pod health (legacy: `/status.json`)
 - **CDN caching** - Stale-while-revalidate for resilience during outages
 
 ## Configuration

--- a/projects/agent_platform/mcp_servers/README.md
+++ b/projects/agent_platform/mcp_servers/README.md
@@ -19,7 +19,7 @@ The chart iterates over a `servers` array in values.yaml. Each entry generates:
 
 ### 1. Add the server entry
 
-Add an entry to the `servers` array in `overlays/prod/mcp-servers/values.yaml`:
+Add an entry to the `servers` array in `projects/agent_platform/deploy/values.yaml` under `agent-platform-mcp-servers.servers`:
 
 ```yaml
 - name: my-mcp-server
@@ -112,4 +112,4 @@ HTTPCheck alerts use these defaults (overridable per server):
 | `frequency`  | `2m0s`                | Check frequency                    |
 | `matchType`  | `5`                   | Consecutive failures before firing |
 | `severity`   | `critical`            | Alert severity                     |
-| `channels`   | `[pagerduty-homelab]` | Notification channels              |
+| `channels`   | `[]`                  | Notification channels              |


### PR DESCRIPTION
## Summary

- Fix `api_gateway/README.md`: update status endpoint from `/status` to `/cluster-info` (noting `/status.json` as legacy) in both the mermaid diagram and Key Features list
- Fix `mcp_servers/README.md`: correct the config file path from non-existent `overlays/prod/mcp-servers/values.yaml` to the actual `projects/agent_platform/deploy/values.yaml` under `agent-platform-mcp-servers.servers`
- Fix `mcp_servers/README.md`: correct the `channels` alert default from `[pagerduty-homelab]` to `[]` (empty list) — `pagerduty-homelab` is only a deployment-specific override, not the chart default

## Test plan

- [ ] Verify the mermaid diagram in `api_gateway/README.md` shows `/cluster-info`
- [ ] Verify the Key Features section references `/cluster-info` with legacy `/status.json` noted
- [ ] Verify `mcp_servers/README.md` points to `projects/agent_platform/deploy/values.yaml`
- [ ] Verify `channels` default shows `[]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)