### PR TITLE
docs(todo_app): fix README daily reset schedule inaccuracy

### DIFF
--- a/projects/todo_app/todo_mcp/README.md
+++ b/projects/todo_app/todo_mcp/README.md
@@ -151,7 +151,7 @@ Changes auto-save after 500ms of inactivity.
 
 The internal scheduler automatically triggers:
 
-- **Daily reset** (midnight PST, Monday-Friday) - Archives current day, clears daily tasks
+- **Daily reset** (midnight PST, Sunday-Friday) - Archives current day, clears daily tasks
 - **Weekly reset** (Saturday midnight PST) - Archives current day, clears both weekly and daily tasks
 
 ## API Reference


### PR DESCRIPTION
## Summary

- The README at `projects/todo_app/todo_mcp/README.md` incorrectly stated that daily reset runs "Monday-Friday"
- The actual scheduler in `projects/todo_app/cmd/main.go` triggers weekly reset only on Saturday (`time.Saturday`), and daily reset on every other day (Sunday through Friday)
- Fixed the description to say "Sunday-Friday" to match the actual implementation

## Test plan

- [ ] Verify `cmd/main.go` scheduler logic: weekly reset fires on `time.Saturday`, daily reset fires on all other days
- [ ] Verify README line 154 now reads "Sunday-Friday" instead of "Monday-Friday"

🤖 Generated with [Claude Code](https://claude.com/claude-code)