### PR TITLE
feat(semgrep): add no-stale-repo-paths rule for deprecated directory references

### DIFF
--- a/.semgrepignore
+++ b/.semgrepignore
@@ -1,0 +1,4 @@
+# Historical documentation directories contain intentional references to the
+# old directory layout and should not be flagged by structural linting rules.
+docs/plans/
+docs/decisions/

--- a/bazel/semgrep/rules/BUILD
+++ b/bazel/semgrep/rules/BUILD
@@ -93,6 +93,14 @@ filegroup(
 )
 
 filegroup(
+    name = "generic_rules",
+    srcs = glob(
+        ["generic/*.yaml"],
+        allow_empty = True,
+    ),
+)
+
+filegroup(
     name = "all_rules",
     srcs = glob(["**/*.yaml"]) + [
         "@semgrep_pro_rules_golang//:rules",
@@ -131,6 +139,14 @@ semgrep_test(
     srcs = ["//bazel/semgrep/tests:typescript_fixtures"],
     env = {"SEMGREP_TEST_MODE": "1"},
     rules = [":typescript_rules"],
+    tags = ["semgrep"],
+)
+
+semgrep_test(
+    name = "generic_rules_test",
+    srcs = ["//bazel/semgrep/tests:no_stale_repo_paths_fixtures"],
+    env = {"SEMGREP_TEST_MODE": "1"},
+    rules = [":generic_rules"],
     tags = ["semgrep"],
 )
 

--- a/bazel/semgrep/rules/generic/no-stale-repo-paths.yaml
+++ b/bazel/semgrep/rules/generic/no-stale-repo-paths.yaml
@@ -1,0 +1,19 @@
+rules:
+  - id: no-stale-repo-paths
+    languages: [generic]
+    severity: WARNING
+    message: >-
+      Found a reference to a deprecated repository path. The old directory
+      structure (overlays/prod/, //services/*, //charts/*) has been replaced
+      by 'projects/<service>/deploy|chart|backend'. Update to the current layout.
+    metadata:
+      category: maintainability
+      subcategory: repo-structure
+      confidence: HIGH
+      likelihood: MEDIUM
+      impact: LOW
+      description: >-
+        Detects stale references to the pre-reorganisation directory layout.
+        Use 'projects/<service>/deploy', 'projects/<service>/chart', or
+        'projects/<service>/backend' instead.
+    pattern-regex: '(overlays/prod/|//services/[a-z]|//charts/[a-z])'

--- a/bazel/semgrep/tests/BUILD
+++ b/bazel/semgrep/tests/BUILD
@@ -18,3 +18,10 @@ filegroup(
     name = "typescript_fixtures",
     srcs = glob(["fixtures/*.ts"]),
 )
+
+# Fixture for the no-stale-repo-paths rule (languages: generic).
+# Referenced by //bazel/semgrep/rules:generic_rules_test.
+filegroup(
+    name = "no_stale_repo_paths_fixtures",
+    srcs = ["fixtures/no-stale-repo-paths.md"],
+)

--- a/bazel/semgrep/tests/fixtures/no-stale-repo-paths.md
+++ b/bazel/semgrep/tests/fixtures/no-stale-repo-paths.md
@@ -1,0 +1,44 @@
+# Test fixtures for the no-stale-repo-paths semgrep rule.
+#
+# Annotations:
+#   # ruleid: no-stale-repo-paths  — the next non-annotation line MUST be flagged
+#   # ok: no-stale-repo-paths      — the next non-annotation line MUST NOT be flagged
+
+## Positive examples (should be flagged)
+
+The following reference an old overlays/prod/ path:
+
+# ruleid: no-stale-repo-paths
+overlays/prod/values.yaml
+
+Old Bazel target for a service binary:
+
+# ruleid: no-stale-repo-paths
+//services/myapp:image
+
+Old Bazel target for a Helm chart:
+
+# ruleid: no-stale-repo-paths
+//charts/mychart:chart
+
+## Negative examples (should not be flagged)
+
+Current GitOps deploy path:
+
+# ok: no-stale-repo-paths
+projects/myservice/deploy/values.yaml
+
+Current Helm chart path:
+
+# ok: no-stale-repo-paths
+projects/myservice/chart/Chart.yaml
+
+Current Bazel target under projects/:
+
+# ok: no-stale-repo-paths
+//projects/myservice/image:push
+
+A word that merely contains the substring "services" but is not a Bazel target:
+
+# ok: no-stale-repo-paths
+This document describes the services architecture.


### PR DESCRIPTION
## Summary

- Adds `bazel/semgrep/rules/generic/no-stale-repo-paths.yaml` — a new `languages: [generic]` semgrep rule (severity WARNING) that detects stale references to the old repo layout:
  - `overlays/prod/` — old Kustomize overlay path
  - `//services/[a-z]*` — old Bazel service targets
  - `//charts/[a-z]*` — old Bazel chart targets
- Adds `bazel/semgrep/tests/fixtures/no-stale-repo-paths.md` with annotated positive and negative test cases.
- Wires a `generic_rules` filegroup and `generic_rules_test` semgrep_test target into `bazel/semgrep/rules/BUILD`.
- Adds the `no_stale_repo_paths_fixtures` filegroup to `bazel/semgrep/tests/BUILD`.
- Creates `.semgrepignore` excluding `docs/plans/` and `docs/decisions/` so historical documentation does not trigger the rule.

## Test plan

- [ ] \`bazel test //bazel/semgrep/rules:generic_rules_test\` passes (positive matches flagged, negatives clean)
- [ ] \`bazel test //...\` green overall
- [ ] \`.semgrepignore\` excludes historical docs from scan

🤖 Generated with [Claude Code](https://claude.com/claude-code)