### PR TITLE
fix(ships): correct frontend publicDir path

### DIFF
--- a/projects/ships/chart/Chart.yaml
+++ b/projects/ships/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: marine
 description: Marine services - AIS vessel tracking and API
 type: application
-version: 0.2.10
+version: 0.2.11
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/ships/chart/values.yaml
+++ b/projects/ships/chart/values.yaml
@@ -170,9 +170,7 @@ frontend:
   replicas: 1
 
   # Directory containing built frontend assets
-  # NOTE: pkg_tar strip_prefix doesn't work with TreeArtifacts, so the Vite
-  # dist ends up nested under the full Bazel package path inside the image.
-  publicDir: /app/public/projects/ships/frontend/web/dist
+  publicDir: /app/public/dist
 
   # Service configuration
   service:

--- a/projects/ships/deploy/application.yaml
+++ b/projects/ships/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: marine
-      targetRevision: 0.2.10
+      targetRevision: 0.2.11
       helm:
         releaseName: marine
         valueFiles:


### PR DESCRIPTION
## Summary
- The marine frontend was returning 404 on all pages because `publicDir` pointed to `/app/public/projects/ships/frontend/web/dist` (old Bazel TreeArtifact layout), but the actual image has assets at `/app/public/dist`
- Pods were healthy and ready, but the site showed "Not Found"

## Test plan
- [ ] CI passes
- [ ] After merge, verify `ships.jomcgi.dev` loads the map UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)