### PR TITLE
build(ships): bump chart to 0.2.12 to include publicDir fix

### DIFF
--- a/projects/ships/chart/Chart.yaml
+++ b/projects/ships/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: marine
 description: Marine services - AIS vessel tracking and API
 type: application
-version: 0.2.11
+version: 0.2.12
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/ships/deploy/application.yaml
+++ b/projects/ships/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: marine
-      targetRevision: 0.2.11
+      targetRevision: 0.2.12
       helm:
         releaseName: marine
         valueFiles:


### PR DESCRIPTION
## Summary
- Chart 0.2.11 was pushed to OCI by the chart-version-bot **before** the publicDir fix landed, so it doesn't contain the correction
- This bumps to 0.2.12 so CI pushes a new chart with the fix from #1314

## Test plan
- [ ] CI passes and pushes chart 0.2.12
- [ ] ArgoCD syncs and `ships.jomcgi.dev` serves the map UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)