### PR TITLE
fix(chat-bot): resolve discord-api-types version conflict

### DIFF
--- a/projects/agent_platform/chat_bot/BUILD
+++ b/projects/agent_platform/chat_bot/BUILD
@@ -55,9 +55,16 @@ genrule(
                 TARGET_DIR="tmp/app/node_modules/$$PACKAGE_NAME"
             fi
 
-            # Skip if already copied
+            # When duplicate packages exist (different versions), keep the newer one.
+            # pnpm isolates versions but our flat node_modules can only have one.
             if [ -d "$$TARGET_DIR" ]; then
-                continue
+                EXISTING_VER=$$(grep -o '"version"[[:space:]]*:[[:space:]]*"[^"]*"' "$$TARGET_DIR/package.json" 2>/dev/null | head -1 | cut -d'"' -f4 || echo "0.0.0")
+                NEW_VER=$$(grep -o '"version"[[:space:]]*:[[:space:]]*"[^"]*"' "$$pkg" | head -1 | cut -d'"' -f4 || echo "0.0.0")
+                HIGHER=$$(printf '%s\n%s' "$$EXISTING_VER" "$$NEW_VER" | sort -V | tail -1)
+                if [ "$$HIGHER" = "$$EXISTING_VER" ]; then
+                    continue
+                fi
+                rm -rf "$$TARGET_DIR"
             fi
 
             mkdir -p "$$(dirname "$$TARGET_DIR")"

--- a/projects/agent_platform/chat_bot/deploy/Chart.yaml
+++ b/projects/agent_platform/chat_bot/deploy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: chat-bot
 description: Discord chat bot with AI-powered interactions
 type: application
-version: 0.3.4
+version: 0.3.5
 appVersion: "0.1.0"
 annotations:
   org.opencontainers.image.source: "https://github.com/jomcgi/homelab"

--- a/projects/agent_platform/chat_bot/deploy/application.yaml
+++ b/projects/agent_platform/chat_bot/deploy/application.yaml
@@ -8,7 +8,7 @@ spec:
   source:
     repoURL: ghcr.io/jomcgi/homelab/charts
     chart: chat-bot
-    targetRevision: 0.3.4
+    targetRevision: 0.3.5
     helm:
       releaseName: chat-bot
       valuesObject:


### PR DESCRIPTION
## Summary
- The `node_modules_tar` genrule copies packages into a flat directory, but when the same package exists at multiple versions (e.g. `discord-api-types` at `0.37.120` and `0.38.42`), the first version found wins
- `@discordjs/builders` v2 needs enums from `discord-api-types@0.38.42` but was getting `0.37.120`, causing a `TypeError: Cannot convert undefined or null to object` crash
- Fix: compare versions with `sort -V` and keep the newer one, instead of unconditionally skipping duplicates

## Test plan
- [ ] CI passes (Bazel build + push)
- [ ] ArgoCD syncs chart 0.3.5
- [ ] chat-bot pod starts without `NativeEnumValidator` crash
- [ ] Bot connects to Discord gateway

🤖 Generated with [Claude Code](https://claude.com/claude-code)