### PR TITLE
fix(chat-bot): await gateway background task instead of response

### DIFF
--- a/projects/agent_platform/chat_bot/deploy/Chart.yaml
+++ b/projects/agent_platform/chat_bot/deploy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: chat-bot
 description: Discord chat bot with AI-powered interactions
 type: application
-version: 0.3.6
+version: 0.3.7
 appVersion: "0.1.0"
 annotations:
   org.opencontainers.image.source: "https://github.com/jomcgi/homelab"

--- a/projects/agent_platform/chat_bot/deploy/application.yaml
+++ b/projects/agent_platform/chat_bot/deploy/application.yaml
@@ -8,7 +8,7 @@ spec:
   source:
     repoURL: ghcr.io/jomcgi/homelab/charts
     chart: chat-bot
-    targetRevision: 0.3.6
+    targetRevision: 0.3.7
     helm:
       releaseName: chat-bot
       valuesObject:

--- a/projects/agent_platform/chat_bot/src/index.ts
+++ b/projects/agent_platform/chat_bot/src/index.ts
@@ -192,16 +192,25 @@ async function main(): Promise<void> {
 
   // Start Gateway WebSocket for receiving messages and mentions.
   // Without this, only slash commands/button clicks work (HTTP interactions).
+  // startGatewayListener is designed for serverless: it returns a Response
+  // immediately and runs the connection via waitUntil. We capture that
+  // background task and await it so the loop blocks until the connection ends.
   const abortController = new AbortController();
   const gatewayLoop = async () => {
     while (!abortController.signal.aborted) {
       try {
         console.log("Starting Discord Gateway listener...");
+        let gatewayTask: Promise<unknown> | undefined;
         await discord.startGatewayListener(
-          { waitUntil: (task) => task },
+          {
+            waitUntil: (task: Promise<unknown>) => {
+              gatewayTask = task;
+            },
+          },
           24 * 60 * 60 * 1000, // 24 hours
           abortController.signal,
         );
+        if (gatewayTask) await gatewayTask;
       } catch (err) {
         if (abortController.signal.aborted) break;
         console.error("Gateway listener error, reconnecting in 5s:", err);


### PR DESCRIPTION
## Summary
- `startGatewayListener()` returns a Response immediately (serverless pattern) and runs the WebSocket via `waitUntil` callback
- Previous code awaited the Response, causing the reconnect loop to spin instantly
- Now captures the background task promise from `waitUntil` and awaits it, so the loop blocks until the gateway connection actually ends

## Test plan
- [ ] CI passes
- [ ] Pod starts without rapid restart loop
- [ ] Logs show single "Starting Discord Gateway listener..." followed by stable connection
- [ ] Bot responds when @mentioned

🤖 Generated with [Claude Code](https://claude.com/claude-code)