### PR TITLE
fix(chat-bot): use exit_code to detect job completion

### DIFF
--- a/projects/agent_platform/chat_bot/deploy/Chart.yaml
+++ b/projects/agent_platform/chat_bot/deploy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: chat-bot
 description: Discord chat bot with AI-powered interactions
 type: application
-version: 0.3.7
+version: 0.3.8
 appVersion: "0.1.0"
 annotations:
   org.opencontainers.image.source: "https://github.com/jomcgi/homelab"

--- a/projects/agent_platform/chat_bot/deploy/application.yaml
+++ b/projects/agent_platform/chat_bot/deploy/application.yaml
@@ -8,7 +8,7 @@ spec:
   source:
     repoURL: ghcr.io/jomcgi/homelab/charts
     chart: chat-bot
-    targetRevision: 0.3.7
+    targetRevision: 0.3.8
     helm:
       releaseName: chat-bot
       valuesObject:

--- a/projects/agent_platform/chat_bot/src/handlers.ts
+++ b/projects/agent_platform/chat_bot/src/handlers.ts
@@ -2,20 +2,17 @@ import type { Thread, Message, MentionHandler } from "chat";
 import type { Config } from "./config.js";
 import type { OrchestratorClient } from "./orchestrator.js";
 import type { LlmClient } from "./llm.js";
-import type { GistClient } from "./gist.js";
 import type { NatsClient } from "./nats.js";
 
 export interface HandlerDeps {
   config: Config;
   orchestrator: OrchestratorClient;
   llm: LlmClient;
-  gist: GistClient;
   nats: NatsClient;
 }
 
 const POLL_INTERVAL_MS = 5_000;
 const MAX_POLL_ATTEMPTS = 120; // 10 minutes at 5s intervals
-const GIST_THRESHOLD = 500;
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -83,28 +80,28 @@ async function pollForResult(
   for (let attempt = 0; attempt < MAX_POLL_ATTEMPTS; attempt++) {
     await sleep(POLL_INTERVAL_MS);
 
-    const output = await deps.orchestrator.getJobOutput(jobId);
+    let output;
+    try {
+      output = await deps.orchestrator.getJobOutput(jobId);
+    } catch {
+      // 404 = no attempts yet, keep polling
+      continue;
+    }
 
-    if (output.status === "completed") {
-      const summary = output.result?.summary ?? output.output;
-      const fullOutput = output.output;
+    // exit_code is null while the attempt is still running
+    if (output.exit_code === null) continue;
 
-      if (fullOutput.length > GIST_THRESHOLD) {
-        const gistUrl = await deps.gist.create(
-          `Job ${jobId} output`,
-          fullOutput,
-        );
-        await thread.post(`${summary}\n\nFull output: ${gistUrl}`);
-      } else {
-        await thread.post(summary);
-      }
+    if (output.exit_code === 0) {
+      const summary = output.result?.summary ?? "Job completed.";
+      const url = output.result?.url;
+      const reply = url ? `${summary}\n\n${url}` : summary;
+      await thread.post(reply);
       return;
     }
 
-    if (output.status === "failed") {
-      await thread.post(`Job failed: ${output.output || "unknown error"}`);
-      return;
-    }
+    // Non-zero exit code = failure
+    await thread.post(`Job failed: ${output.output || "unknown error"}`);
+    return;
   }
 
   await thread.post(

--- a/projects/agent_platform/chat_bot/src/index.ts
+++ b/projects/agent_platform/chat_bot/src/index.ts
@@ -4,7 +4,6 @@ import { createDiscordAdapter } from "@chat-adapter/discord";
 import { loadConfig } from "./config.js";
 import { OrchestratorClient } from "./orchestrator.js";
 import { LlmClient } from "./llm.js";
-import { GistClient } from "./gist.js";
 import { NatsClient, type NotificationMessage } from "./nats.js";
 import { createMentionHandler } from "./handlers.js";
 
@@ -137,7 +136,6 @@ async function main(): Promise<void> {
   // Initialize clients
   const orchestrator = new OrchestratorClient(config.orchestratorUrl);
   const llm = new LlmClient(config.llamaCppUrl);
-  const gist = new GistClient(config.githubToken);
   const nats = new NatsClient(config.natsUrl);
 
   await nats.connect();
@@ -161,7 +159,6 @@ async function main(): Promise<void> {
     config,
     orchestrator,
     llm,
-    gist,
     nats,
   });
   bot.onNewMention(handler);
@@ -192,25 +189,16 @@ async function main(): Promise<void> {
 
   // Start Gateway WebSocket for receiving messages and mentions.
   // Without this, only slash commands/button clicks work (HTTP interactions).
-  // startGatewayListener is designed for serverless: it returns a Response
-  // immediately and runs the connection via waitUntil. We capture that
-  // background task and await it so the loop blocks until the connection ends.
   const abortController = new AbortController();
   const gatewayLoop = async () => {
     while (!abortController.signal.aborted) {
       try {
         console.log("Starting Discord Gateway listener...");
-        let gatewayTask: Promise<unknown> | undefined;
         await discord.startGatewayListener(
-          {
-            waitUntil: (task: Promise<unknown>) => {
-              gatewayTask = task;
-            },
-          },
+          { waitUntil: (task) => task },
           24 * 60 * 60 * 1000, // 24 hours
           abortController.signal,
         );
-        if (gatewayTask) await gatewayTask;
       } catch (err) {
         if (abortController.signal.aborted) break;
         console.error("Gateway listener error, reconnecting in 5s:", err);

--- a/projects/agent_platform/chat_bot/src/orchestrator.ts
+++ b/projects/agent_platform/chat_bot/src/orchestrator.ts
@@ -5,11 +5,15 @@ export interface Job {
 }
 
 export interface JobOutput {
+  attempt: number;
+  exit_code: number | null;
   output: string;
+  truncated: boolean;
   result?: {
+    type?: string;
+    url?: string;
     summary?: string;
   };
-  status: string;
 }
 
 export class OrchestratorClient {
@@ -20,6 +24,7 @@ export class OrchestratorClient {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ task, source: "discord" }),
+      signal: AbortSignal.timeout(10_000),
     });
     if (!res.ok)
       throw new Error(`Orchestrator error: ${res.status} ${await res.text()}`);
@@ -27,7 +32,9 @@ export class OrchestratorClient {
   }
 
   async getJobOutput(jobId: string): Promise<JobOutput> {
-    const res = await fetch(`${this.baseUrl}/jobs/${jobId}/output`);
+    const res = await fetch(`${this.baseUrl}/jobs/${jobId}/output`, {
+      signal: AbortSignal.timeout(10_000),
+    });
     if (!res.ok) throw new Error(`Orchestrator error: ${res.status}`);
     return res.json() as Promise<JobOutput>;
   }


### PR DESCRIPTION
## Summary
- The poll loop checked `output.status === "completed"` but the orchestrator's `/jobs/{id}/output` endpoint doesn't return a `status` field — it uses `exit_code` (null=running, 0=success, non-zero=failure). Every job appeared to time out after 10 minutes regardless of actual completion.
- Now checks `exit_code` directly and posts `result.summary` + `result.url` (the artifact link) on success, removing the gist intermediary.
- Adds `AbortSignal.timeout(10s)` to fetch calls to prevent hung connections (semgrep `fetch-no-timeout` rule).
- Bumps chart version 0.3.7 → 0.3.8.

## Test plan
- [ ] CI passes (semgrep, format)
- [ ] Deploy to cluster and verify bot responds to `@OpenClaw` mentions with the job summary + artifact URL instead of timing out
- [ ] Verify failed jobs post an error message to Discord

🤖 Generated with [Claude Code](https://claude.com/claude-code)