### PR TITLE
fix(orchestrator-ui): prevent active step outline clipping

### DIFF
--- a/projects/agent_platform/chart/Chart.yaml
+++ b/projects/agent_platform/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: agent-platform
 description: Agent platform — umbrella chart bundling goose sandboxes, MCP servers, and supporting components
 type: application
-version: 0.28.2
+version: 0.28.3
 appVersion: "0.2.0"
 annotations:
   org.opencontainers.image.source: "https://github.com/jomcgi/homelab"

--- a/projects/agent_platform/deploy/application.yaml
+++ b/projects/agent_platform/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: agent-platform
-      targetRevision: 0.28.2
+      targetRevision: 0.28.3
       helm:
         releaseName: agent-platform
         valueFiles:

--- a/projects/agent_platform/orchestrator/ui/src/App.jsx
+++ b/projects/agent_platform/orchestrator/ui/src/App.jsx
@@ -202,7 +202,7 @@ function PipelineFlow({ plan, activeStep, onStepClick }) {
         gap: 0,
         overflowX: "auto",
         minWidth: 0,
-        paddingBottom: 2,
+        padding: 3,
       }}
     >
       {plan.map((step, i) => {


### PR DESCRIPTION
## Summary
- Add `padding: 3` to pipeline flow container so the active step's outline (2px solid + 1px offset) isn't clipped by `overflowX: auto`

## Test plan
- [ ] Click a pipeline node — outline should be fully visible on all sides

🤖 Generated with [Claude Code](https://claude.com/claude-code)