### PR TITLE
fix(chat-bot): restore gateway task capture to prevent restart loop

### DIFF
--- a/projects/agent_platform/chat_bot/deploy/Chart.yaml
+++ b/projects/agent_platform/chat_bot/deploy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: chat-bot
 description: Discord chat bot with AI-powered interactions
 type: application
-version: 0.3.8
+version: 0.3.9
 appVersion: "0.1.0"
 annotations:
   org.opencontainers.image.source: "https://github.com/jomcgi/homelab"

--- a/projects/agent_platform/chat_bot/deploy/application.yaml
+++ b/projects/agent_platform/chat_bot/deploy/application.yaml
@@ -8,7 +8,7 @@ spec:
   source:
     repoURL: ghcr.io/jomcgi/homelab/charts
     chart: chat-bot
-    targetRevision: 0.3.8
+    targetRevision: 0.3.9
     helm:
       releaseName: chat-bot
       valuesObject:

--- a/projects/agent_platform/chat_bot/src/index.ts
+++ b/projects/agent_platform/chat_bot/src/index.ts
@@ -194,11 +194,17 @@ async function main(): Promise<void> {
     while (!abortController.signal.aborted) {
       try {
         console.log("Starting Discord Gateway listener...");
+        let gatewayTask: Promise<unknown> | undefined;
         await discord.startGatewayListener(
-          { waitUntil: (task) => task },
+          {
+            waitUntil: (task: Promise<unknown>) => {
+              gatewayTask = task;
+            },
+          },
           24 * 60 * 60 * 1000, // 24 hours
           abortController.signal,
         );
+        if (gatewayTask) await gatewayTask;
       } catch (err) {
         if (abortController.signal.aborted) break;
         console.error("Gateway listener error, reconnecting in 5s:", err);


### PR DESCRIPTION
## Summary

- The chat-bot new pod (`2fbe3f2`) is crash-looping due to a gateway reconnect loop
- The previous refactor changed `waitUntil` to `(task) => task`, which discards the background WebSocket promise. Since `startGatewayListener` is serverless-oriented and returns immediately, the loop spins continuously, flooding Discord with connections
- Restores the closure-based capture so the loop blocks until the connection ends before reconnecting
- Bumps chart version 0.3.8 → 0.3.9

## Test plan

- [ ] CI passes (build + format)
- [ ] After merge, verify the new chat-bot pod starts with a single "Starting Discord Gateway listener..." log and stays running
- [ ] Confirm the old crash-looping pod is replaced and ArgoCD health returns to "Healthy"

🤖 Generated with [Claude Code](https://claude.com/claude-code)