### PR TITLE
ci(semgrep): add no-waituntil-passthrough rule

### DIFF
--- a/bazel/semgrep/rules/typescript/no-waituntil-passthrough.yaml
+++ b/bazel/semgrep/rules/typescript/no-waituntil-passthrough.yaml
@@ -1,0 +1,21 @@
+rules:
+  - id: no-waituntil-passthrough
+    languages: [typescript, javascript]
+    severity: ERROR
+    message: >-
+      waitUntil callback is an identity function — it returns its argument
+      instead of capturing it. This silently drops the background task promise
+      because the Cloudflare Workers / service-worker `waitUntil` API expects
+      the callback to capture the promise via closure (e.g. `(task) => {
+      captured = task }`) not to return it. Replace the identity arrow with a
+      closure that stores or chains the task.
+    metadata:
+      category: correctness
+      subcategory: async
+      confidence: HIGH
+      likelihood: HIGH
+      impact: HIGH
+      technology: [typescript, javascript, cloudflare-workers]
+      description: waitUntil identity callback silently drops the background task promise
+    patterns:
+      - pattern: "waitUntil: ($X) => $X"

--- a/bazel/semgrep/tests/fixtures/no-waituntil-passthrough.ts
+++ b/bazel/semgrep/tests/fixtures/no-waituntil-passthrough.ts
@@ -1,0 +1,20 @@
+// Tests for no-waituntil-passthrough rule.
+
+// ruleid: no-waituntil-passthrough
+const badConfig = {
+  waitUntil: (task) => task,
+};
+
+// ok: no-waituntil-passthrough
+let captured: Promise<unknown>;
+const goodClosureConfig = {
+  waitUntil: (task) => {
+    captured = task;
+  },
+};
+
+// ok: no-waituntil-passthrough
+const tasks: Promise<unknown>[] = [];
+const goodPushConfig = {
+  waitUntil: (task) => tasks.push(task),
+};


### PR DESCRIPTION
## Summary

- Adds semgrep rule `no-waituntil-passthrough` (severity: ERROR) that catches identity-function callbacks on `waitUntil` — e.g. `waitUntil: (task) => task`
- This pattern silently drops the background task promise instead of capturing it via closure, which caused the production crash loop documented in PRs #1344, #1345, #1352
- Includes test fixture with `ruleid:` annotation for the bad case and `ok:` annotations for two correct closure-capture patterns

## Test plan

- [ ] `bazel test //bazel/semgrep/rules:typescript_rules_test` passes
- [ ] Rule correctly flags `waitUntil: (task) => task` (identity arrow)
- [ ] Rule does not flag `waitUntil: (task) => { captured = task }` (closure capture)
- [ ] Rule does not flag `waitUntil: (task) => tasks.push(task)` (void push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)