### PR TITLE
docs(hikes): remove incorrect daylight hours filter from frontend section

### DIFF
--- a/projects/hikes/README.md
+++ b/projects/hikes/README.md
@@ -50,7 +50,6 @@ A static Cloudflare Pages app (`public/` directory) served from the `jomcgi-hike
 - Duration, distance, and ascent preferences
 - Available dates and preferred start/finish times
 - Weather thresholds (cloud cover, precipitation, wind speed, temperature)
-- Daylight hours (7 am–7 pm UK time)
 
 User preferences are persisted to `localStorage`. The app has no server-side component.
 


### PR DESCRIPTION
## Summary

- The frontend section of `projects/hikes/README.md` listed "Daylight hours (7 am–7 pm UK time)" as a filter applied by the frontend app
- This is inaccurate: the frontend does **not** apply a fixed daylight-hours filter — it only filters by user-supplied `startAfter`/`finishBefore` preferences
- Daylight pre-filtering (hours 7–19 UTC) is done by `update_forecast` when building the bundle; the bundle already contains only viable daylight windows by the time the frontend receives it

## Test plan

- [ ] Verify `app.js` `filterWindowsByWeather` applies no fixed daylight window (confirmed: uses `startAfter`/`finishBefore` user inputs only)
- [ ] Verify `update_forecast/update.py` `is_daylight_hour` applies `7 <= local_hour <= 19` on UTC timestamps (confirmed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)