### PR TITLE
ci(semgrep): add no-github-mcp-server rule

### DIFF
--- a/bazel/semgrep/rules/yaml/no-github-mcp-server.yaml
+++ b/bazel/semgrep/rules/yaml/no-github-mcp-server.yaml
@@ -1,0 +1,13 @@
+rules:
+  - id: no-github-mcp-server
+    languages: [yaml]
+    severity: WARNING
+    message: >-
+      Do not use `@modelcontextprotocol/server-github` as a stdio extension.
+      The `gh` CLI is available in the container with GITHUB_TOKEN pre-configured
+      and has zero startup overhead compared to `pnpm dlx @modelcontextprotocol/server-github`,
+      which incurs slow pnpm resolution on every agent invocation. Use `gh` CLI
+      commands directly instead.
+    metadata:
+      category: performance
+    pattern-regex: "@modelcontextprotocol/server-github"

--- a/bazel/semgrep/tests/fixtures/no-github-mcp-server.yaml
+++ b/bazel/semgrep/tests/fixtures/no-github-mcp-server.yaml
@@ -1,0 +1,22 @@
+# Tests for no-github-mcp-server rule.
+# Goose recipes must not use @modelcontextprotocol/server-github as a stdio extension —
+# the gh CLI is available in the container with GITHUB_TOKEN pre-configured and has zero startup overhead.
+---
+# ruleid: no-github-mcp-server
+extensions:
+  - type: stdio
+    name: github
+    cmd: pnpm
+    args:
+      - dlx
+      - "@modelcontextprotocol/server-github"
+    env_keys:
+      - GITHUB_TOKEN
+
+---
+# ok: no-github-mcp-server — using gh CLI directly instead of the npm package
+extensions:
+  - type: streamable_http
+    name: context-forge
+    uri: http://context-forge-gateway-mcp-stack-mcpgateway.mcp.svc.cluster.local:80/mcp/
+    timeout: 300


### PR DESCRIPTION
## Summary

- Adds `bazel/semgrep/rules/yaml/no-github-mcp-server.yaml` — a WARNING-severity semgrep rule that detects `@modelcontextprotocol/server-github` references in YAML files
- Adds `bazel/semgrep/tests/fixtures/no-github-mcp-server.yaml` — test fixture with `ruleid:` annotation for the bad case (stdio extension using pnpm dlx) and `ok:` annotation for the correct pattern

Prevents re-introduction of the slow stdio GitHub MCP extension removed in PR #1339. The `gh` CLI is available in containers with `GITHUB_TOKEN` pre-configured and has zero startup overhead vs `pnpm dlx @modelcontextprotocol/server-github`.

## Test plan

- [ ] `bazel test //bazel/semgrep/rules:yaml_rules_test` passes with the new rule and fixture
- [ ] Rule fires on the `ruleid:` annotated bad case (stdio extension with pnpm dlx)
- [ ] Rule does not fire on the `ok:` annotated good case (streamable_http extension)

🤖 Generated with [Claude Code](https://claude.com/claude-code)