### PR TITLE
test(todo_app): add error-path coverage for loadData and HTTP handlers

### DIFF
--- a/projects/todo_app/cmd/BUILD
+++ b/projects/todo_app/cmd/BUILD
@@ -16,6 +16,7 @@ go_binary(
 go_test(
     name = "cmd_test",
     srcs = [
+        "extra_test.go",
         "git_commit_test.go",
         "main_test.go",
     ],

--- a/projects/todo_app/cmd/extra_test.go
+++ b/projects/todo_app/cmd/extra_test.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// setupCorruptData writes an invalid JSON file to dataDir/data.json so that
+// loadData returns an error, allowing handlers' 500 error paths to be exercised.
+func setupCorruptData(t *testing.T, dir string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, "data.json"), []byte("{corrupt json}"), 0o644); err != nil {
+		t.Fatalf("setupCorruptData: %v", err)
+	}
+}
+
+// TestLoadDataReturnsErrorOnInvalidJSON verifies that loadData returns an error
+// when data.json exists but contains invalid JSON (e.g., due to file corruption).
+// This covers the json.Unmarshal error path that the missing-file test does not.
+func TestLoadDataReturnsErrorOnInvalidJSON(t *testing.T) {
+	dir := t.TempDir()
+	origDataDir := dataDir
+	dataDir = dir
+	defer func() { dataDir = origDataDir }()
+
+	if err := os.WriteFile(filepath.Join(dir, "data.json"), []byte("{not valid json}"), 0o644); err != nil {
+		t.Fatalf("setup: write corrupt data.json: %v", err)
+	}
+
+	_, err := loadData()
+	if err == nil {
+		t.Error("expected error when data.json contains invalid JSON, got nil")
+	}
+}
+
+// TestHandleWeeklyInternalServerError verifies that handleWeekly returns HTTP 500
+// when loadData fails (e.g., due to a corrupted data.json file).
+func TestHandleWeeklyInternalServerError(t *testing.T) {
+	dir, _ := setupDirs(t)
+	setupCorruptData(t, dir)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/weekly", nil)
+	w := httptest.NewRecorder()
+	handleWeekly(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500 when loadData fails, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// TestHandleDailyInternalServerError verifies that handleDaily returns HTTP 500
+// when loadData fails (e.g., due to a corrupted data.json file).
+func TestHandleDailyInternalServerError(t *testing.T) {
+	dir, _ := setupDirs(t)
+	setupCorruptData(t, dir)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/daily", nil)
+	w := httptest.NewRecorder()
+	handleDaily(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500 when loadData fails, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// TestHandleTodoGetInternalServerError verifies that handleTodo (GET) returns
+// HTTP 500 when loadData fails due to a corrupted data.json file.
+func TestHandleTodoGetInternalServerError(t *testing.T) {
+	dir, _ := setupDirs(t)
+	setupCorruptData(t, dir)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/todo", nil)
+	w := httptest.NewRecorder()
+	handleTodo(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500 when loadData fails, got %d: %s", w.Code, w.Body.String())
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `extra_test.go` with 4 tests targeting the error paths identified as missing in the coverage gap report for commits `0d4d1a1..5f583e2`
- `TestLoadDataReturnsErrorOnInvalidJSON` — covers the `json.Unmarshal` error branch in `loadData()` when `data.json` is corrupted (previously only the file-not-found path was tested)
- `TestHandleWeeklyInternalServerError` — covers the HTTP 500 response from `handleWeekly` when `loadData` fails
- `TestHandleDailyInternalServerError` — covers the HTTP 500 response from `handleDaily` when `loadData` fails
- `TestHandleTodoGetInternalServerError` — covers the HTTP 500 response from `handleTodo` GET when `loadData` fails

## Test plan

- [ ] CI runs `bazel test //projects/todo_app/...` and all tests pass
- [ ] No production code modified (tests only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)