### PR TITLE
test(sextant): add Execute() integration tests via full Cobra command tree

### DIFF
--- a/projects/sextant/cmd/sextant/cmd/cmd_test.go
+++ b/projects/sextant/cmd/sextant/cmd/cmd_test.go
@@ -389,3 +389,364 @@ func TestRunValidate_OutputFileWriteError(t *testing.T) {
 		t.Fatal("expected error when output file path is unwritable, got nil")
 	}
 }
+
+// ---- Execute() integration tests (full Cobra command tree) ----
+//
+// The tests above call runValidate/runGenerate directly, bypassing Cobra's
+// argument parsing, flag binding, and subcommand routing. The tests below call
+// Execute() (which in turn calls rootCmd.Execute()) to exercise the full
+// command tree end-to-end: subcommand dispatch, flag parsing, ExactArgs
+// enforcement, and error propagation back to the caller.
+
+// setRootArgs is a helper that sets rootCmd args for a test and registers a
+// cleanup to reset them, ensuring subsequent tests use their own args.
+func setRootArgs(t *testing.T, args []string) {
+	t.Helper()
+	rootCmd.SetArgs(args)
+	t.Cleanup(func() { rootCmd.SetArgs(nil) })
+}
+
+// TestExecute_NoArgs exercises the root command with no subcommand. Cobra
+// prints usage and returns nil when the root command has no RunE of its own.
+func TestExecute_NoArgs(t *testing.T) {
+	setRootArgs(t, []string{})
+
+	err := Execute()
+	if err != nil {
+		t.Fatalf("expected no error from root command with no args, got: %v", err)
+	}
+}
+
+// TestExecute_UnknownSubcommand verifies that an unrecognised subcommand
+// propagates an error back through Execute().
+func TestExecute_UnknownSubcommand(t *testing.T) {
+	setRootArgs(t, []string{"unknown-subcommand"})
+
+	err := Execute()
+	if err == nil {
+		t.Fatal("expected error for unknown subcommand, got nil")
+	}
+}
+
+// TestExecute_Validate_ValidFile exercises the full validate path via Execute()
+// with a well-formed YAML file. Verifies subcommand routing and RunE success.
+func TestExecute_Validate_ValidFile(t *testing.T) {
+	defer resetValidateFlags()
+	filePath := writeYAMLFile(t, validStateMachineYAML)
+	setRootArgs(t, []string{"validate", filePath})
+
+	err := Execute()
+	if err != nil {
+		t.Fatalf("expected no error for valid file, got: %v", err)
+	}
+}
+
+// TestExecute_Validate_FileNotFound verifies error propagation when the input
+// file does not exist.
+func TestExecute_Validate_FileNotFound(t *testing.T) {
+	defer resetValidateFlags()
+	setRootArgs(t, []string{"validate", "/nonexistent/path/does-not-exist.sextant.yaml"})
+
+	err := Execute()
+	if err == nil {
+		t.Fatal("expected error for nonexistent file, got nil")
+	}
+}
+
+// TestExecute_Validate_InvalidYAML verifies error propagation when the input
+// file contains invalid YAML.
+func TestExecute_Validate_InvalidYAML(t *testing.T) {
+	defer resetValidateFlags()
+	filePath := writeYAMLFile(t, invalidYAML)
+	setRootArgs(t, []string{"validate", filePath})
+
+	err := Execute()
+	if err == nil {
+		t.Fatal("expected error for invalid YAML, got nil")
+	}
+}
+
+// TestExecute_Validate_NoArgs_ReturnsError verifies that Cobra's ExactArgs(1)
+// enforcement returns an error when validate is called without a file argument.
+func TestExecute_Validate_NoArgs_ReturnsError(t *testing.T) {
+	defer resetValidateFlags()
+	setRootArgs(t, []string{"validate"})
+
+	err := Execute()
+	if err == nil {
+		t.Fatal("expected error when validate called with no args, got nil")
+	}
+}
+
+// TestExecute_Validate_TooManyArgs_ReturnsError verifies ExactArgs(1) rejection
+// of more than one positional argument.
+func TestExecute_Validate_TooManyArgs_ReturnsError(t *testing.T) {
+	defer resetValidateFlags()
+	filePath := writeYAMLFile(t, validStateMachineYAML)
+	setRootArgs(t, []string{"validate", filePath, "extra-arg"})
+
+	err := Execute()
+	if err == nil {
+		t.Fatal("expected error when validate called with too many args, got nil")
+	}
+}
+
+// TestExecute_Validate_XStateFlag_WritesToStdout verifies that the --xstate flag
+// is correctly parsed from the command line and results in JSON written to stdout.
+func TestExecute_Validate_XStateFlag_WritesToStdout(t *testing.T) {
+	defer resetValidateFlags()
+	filePath := writeYAMLFile(t, validStateMachineYAML)
+	setRootArgs(t, []string{"validate", "--xstate", filePath})
+
+	// Capture stdout so we can inspect the JSON output.
+	origStdout := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("failed to create pipe: %v", err)
+	}
+	os.Stdout = w
+
+	runErr := Execute()
+
+	w.Close()
+	os.Stdout = origStdout
+
+	if runErr != nil {
+		t.Fatalf("expected no error, got: %v", runErr)
+	}
+
+	buf := make([]byte, 65536)
+	n, _ := r.Read(buf)
+	output := string(buf[:n])
+
+	if !json.Valid([]byte(output)) {
+		t.Errorf("expected valid JSON on stdout with --xstate flag, got: %s", output)
+	}
+}
+
+// TestExecute_Validate_XStateOutputFile verifies that --xstate combined with
+// --output writes valid JSON to the specified file.
+func TestExecute_Validate_XStateOutputFile(t *testing.T) {
+	defer resetValidateFlags()
+	outFile := filepath.Join(t.TempDir(), "out.xstate.json")
+	filePath := writeYAMLFile(t, validStateMachineYAML)
+	setRootArgs(t, []string{"validate", "--xstate", "--output", outFile, filePath})
+
+	err := Execute()
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	content, err := os.ReadFile(outFile)
+	if err != nil {
+		t.Fatalf("expected output file to exist: %v", err)
+	}
+	if !json.Valid(content) {
+		t.Errorf("expected valid JSON in output file, got: %s", content)
+	}
+}
+
+// TestExecute_Validate_XStateShortOutputFlag verifies the short -o flag alias
+// for --output is honoured when routing through the full command tree.
+func TestExecute_Validate_XStateShortOutputFlag(t *testing.T) {
+	defer resetValidateFlags()
+	outFile := filepath.Join(t.TempDir(), "short.xstate.json")
+	filePath := writeYAMLFile(t, validStateMachineYAML)
+	setRootArgs(t, []string{"validate", "--xstate", "-o", outFile, filePath})
+
+	err := Execute()
+	if err != nil {
+		t.Fatalf("expected no error with short -o flag, got: %v", err)
+	}
+
+	content, err := os.ReadFile(outFile)
+	if err != nil {
+		t.Fatalf("expected output file to exist: %v", err)
+	}
+	if !json.Valid(content) {
+		t.Errorf("expected valid JSON in output file, got: %s", content)
+	}
+}
+
+// TestExecute_Generate_ValidFile exercises the full generate path via Execute().
+// Verifies that subcommand routing and flag parsing produce output files.
+func TestExecute_Generate_ValidFile(t *testing.T) {
+	defer resetGenerateFlags()
+	outDir := t.TempDir()
+	filePath := writeYAMLFile(t, validStateMachineYAML)
+	setRootArgs(t, []string{"generate", "--output", outDir, "--package", "testpkg", filePath})
+
+	err := Execute()
+	if err != nil {
+		t.Fatalf("expected no error for valid file, got: %v", err)
+	}
+
+	entries, err := os.ReadDir(outDir)
+	if err != nil {
+		t.Fatalf("failed to read output dir: %v", err)
+	}
+	if len(entries) == 0 {
+		t.Error("expected generated files in output directory, found none")
+	}
+}
+
+// TestExecute_Generate_FileNotFound verifies error propagation for a missing
+// input file through the full Cobra command tree.
+func TestExecute_Generate_FileNotFound(t *testing.T) {
+	defer resetGenerateFlags()
+	outDir := t.TempDir()
+	setRootArgs(t, []string{"generate", "--output", outDir, "--package", "testpkg", "/nonexistent/file.sextant.yaml"})
+
+	err := Execute()
+	if err == nil {
+		t.Fatal("expected error for nonexistent file, got nil")
+	}
+}
+
+// TestExecute_Generate_InvalidYAML verifies error propagation for malformed
+// YAML through the full Cobra command tree.
+func TestExecute_Generate_InvalidYAML(t *testing.T) {
+	defer resetGenerateFlags()
+	outDir := t.TempDir()
+	filePath := writeYAMLFile(t, invalidYAML)
+	setRootArgs(t, []string{"generate", "--output", outDir, "--package", "testpkg", filePath})
+
+	err := Execute()
+	if err == nil {
+		t.Fatal("expected error for invalid YAML, got nil")
+	}
+}
+
+// TestExecute_Generate_NoArgs_ReturnsError verifies ExactArgs(1) enforcement
+// for the generate subcommand when no positional argument is provided.
+func TestExecute_Generate_NoArgs_ReturnsError(t *testing.T) {
+	defer resetGenerateFlags()
+	setRootArgs(t, []string{"generate"})
+
+	err := Execute()
+	if err == nil {
+		t.Fatal("expected error when generate called with no args, got nil")
+	}
+}
+
+// TestExecute_Generate_ShortOutputFlag verifies that the -o short flag alias
+// for --output is correctly parsed through the full command tree.
+func TestExecute_Generate_ShortOutputFlag(t *testing.T) {
+	defer resetGenerateFlags()
+	outDir := t.TempDir()
+	filePath := writeYAMLFile(t, validStateMachineYAML)
+	setRootArgs(t, []string{"generate", "-o", outDir, "-p", "shortpkg", filePath})
+
+	err := Execute()
+	if err != nil {
+		t.Fatalf("expected no error with short -o/-p flags, got: %v", err)
+	}
+
+	entries, err := os.ReadDir(outDir)
+	if err != nil {
+		t.Fatalf("failed to read output dir: %v", err)
+	}
+	if len(entries) == 0 {
+		t.Error("expected generated files in output directory, found none")
+	}
+
+	// Verify the short -p flag was correctly parsed and used as the package name.
+	found := false
+	for _, e := range entries {
+		content, err := os.ReadFile(filepath.Join(outDir, e.Name()))
+		if err != nil {
+			continue
+		}
+		if strings.Contains(string(content), "package shortpkg") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected at least one generated file to contain 'package shortpkg'")
+	}
+}
+
+// TestExecute_Generate_WithModuleAndAPIFlags verifies that --module and --api
+// flags are correctly parsed and forwarded through the full command tree.
+func TestExecute_Generate_WithModuleAndAPIFlags(t *testing.T) {
+	defer resetGenerateFlags()
+	outDir := t.TempDir()
+	filePath := writeYAMLFile(t, validStateMachineYAML)
+	setRootArgs(t, []string{
+		"generate",
+		"--output", outDir,
+		"--package", "testpkg",
+		"--module", "github.com/example/operator",
+		"--api", "github.com/example/operator/api/v1alpha1",
+		filePath,
+	})
+
+	err := Execute()
+	if err != nil {
+		t.Fatalf("expected no error with --module and --api flags, got: %v", err)
+	}
+}
+
+// TestExecute_Generate_AutoDerivesAPIPath verifies that when --module is set
+// but --api is omitted the API import path is auto-derived through the full
+// command tree (exercises the branch at generate.go lines 73-75).
+func TestExecute_Generate_AutoDerivesAPIPath(t *testing.T) {
+	defer resetGenerateFlags()
+	outDir := t.TempDir()
+	filePath := writeYAMLFile(t, validStateMachineYAML)
+	setRootArgs(t, []string{
+		"generate",
+		"--output", outDir,
+		"--package", "testpkg",
+		"--module", "github.com/example/myoperator",
+		filePath,
+	})
+
+	err := Execute()
+	if err != nil {
+		t.Fatalf("expected no error when --module is set and --api omitted, got: %v", err)
+	}
+
+	entries, err := os.ReadDir(outDir)
+	if err != nil {
+		t.Fatalf("failed to read output dir: %v", err)
+	}
+	if len(entries) == 0 {
+		t.Error("expected generated files in output directory, found none")
+	}
+}
+
+// TestExecute_Generate_DefaultsPackageFromDirName verifies that omitting
+// --package causes the package name to be derived from the output directory
+// name when routed through the full command tree.
+func TestExecute_Generate_DefaultsPackageFromDirName(t *testing.T) {
+	defer resetGenerateFlags()
+	outDir := filepath.Join(t.TempDir(), "mynamedpkg")
+	if err := os.MkdirAll(outDir, 0o755); err != nil {
+		t.Fatalf("failed to create output dir: %v", err)
+	}
+	filePath := writeYAMLFile(t, validStateMachineYAML)
+	setRootArgs(t, []string{"generate", "--output", outDir, filePath})
+
+	err := Execute()
+	if err != nil {
+		t.Fatalf("expected no error when --package omitted, got: %v", err)
+	}
+
+	found := false
+	entries, _ := os.ReadDir(outDir)
+	for _, e := range entries {
+		content, err := os.ReadFile(filepath.Join(outDir, e.Name()))
+		if err != nil {
+			continue
+		}
+		if strings.Contains(string(content), "package mynamedpkg") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected at least one generated file to contain 'package mynamedpkg'")
+	}
+}


### PR DESCRIPTION
## Summary

- Adds 18 integration tests in `cmd_test.go` that call `Execute()` (via `rootCmd.Execute()` with `SetArgs`) instead of calling `runValidate`/`runGenerate` directly
- Covers subcommand routing (validate and generate), flag parsing (`--xstate`, `--output`/`-o`, `--package`/`-p`, `--module`, `--api`), `ExactArgs` enforcement end-to-end, and error propagation through the full Cobra command tree
- Adds a reusable `setRootArgs` helper that sets args and registers `t.Cleanup` for automatic teardown
- Existing tests already cover unit-level behaviour; these tests specifically verify the CLI contract between `Execute()` and the command tree

## Test plan

- [ ] `bazel test //projects/sextant/cmd/sextant/cmd:cmd_test` passes
- [ ] `bazel test //...` green in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)