### PR TITLE
fix(orchestrator): add consecutive error limit to pollUntilDone

### DIFF
--- a/projects/agent_platform/chart/Chart.yaml
+++ b/projects/agent_platform/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: agent-platform
 description: Agent platform — umbrella chart bundling goose sandboxes, MCP servers, and supporting components
 type: application
-version: 0.28.8
+version: 0.28.9
 appVersion: "0.2.0"
 annotations:
   org.opencontainers.image.source: "https://github.com/jomcgi/homelab"

--- a/projects/agent_platform/deploy/application.yaml
+++ b/projects/agent_platform/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: agent-platform
-      targetRevision: 0.28.8
+      targetRevision: 0.28.9
       helm:
         releaseName: agent-platform
         valueFiles:

--- a/projects/agent_platform/orchestrator/sandbox.go
+++ b/projects/agent_platform/orchestrator/sandbox.go
@@ -41,6 +41,7 @@ type SandboxExecutor struct {
 	namespace         string
 	template          string
 	inactivityTimeout time.Duration
+	maxPollErrors     int // consecutive poll failures before giving up (default 10 ≈ 5 min)
 	logger            *slog.Logger
 	httpClient        *http.Client
 }
@@ -70,6 +71,7 @@ func NewSandboxExecutor(config *rest.Config, namespace, template string, inactiv
 		namespace:         namespace,
 		template:          template,
 		inactivityTimeout: inactivityTimeout,
+		maxPollErrors:     10,
 		logger:            logger,
 		httpClient:        &http.Client{Timeout: 30 * time.Second},
 	}, nil
@@ -301,6 +303,11 @@ func (s *SandboxExecutor) dispatchTask(ctx context.Context, baseURL, task, recip
 
 func (s *SandboxExecutor) pollUntilDone(ctx context.Context, baseURL, claimName string, cancelFn func() bool, outputBuf *syncBuffer, planBuf *planTracker) (*ExecResult, error) {
 	offset := 0
+	consecutiveErrors := 0
+	maxErrors := s.maxPollErrors
+	if maxErrors <= 0 {
+		maxErrors = 10
+	}
 	// Short initial wait, then poll every 30 seconds.
 	timer := time.NewTimer(5 * time.Second)
 	defer timer.Stop()
@@ -326,9 +333,14 @@ func (s *SandboxExecutor) pollUntilDone(ctx context.Context, baseURL, claimName 
 		// Check status (with plan progress)
 		state, exitCode, plan, err := s.pollStatusWithPlan(ctx, baseURL)
 		if err != nil {
-			s.logger.Warn("poll status error", "error", err)
+			consecutiveErrors++
+			s.logger.Warn("poll status error", "error", err, "consecutive", consecutiveErrors)
+			if consecutiveErrors >= maxErrors {
+				return nil, fmt.Errorf("sandbox unreachable after %d consecutive poll failures: %w", maxErrors, err)
+			}
 			continue
 		}
+		consecutiveErrors = 0
 		// Update plan tracker for real-time progress.
 		if planBuf != nil && len(plan) > 0 {
 			currentStep := 0

--- a/projects/agent_platform/orchestrator/sandbox_k8s_test.go
+++ b/projects/agent_platform/orchestrator/sandbox_k8s_test.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -719,6 +720,81 @@ func TestPollUntilDone_CancelFn(t *testing.T) {
 	const want = "cancelled during execution"
 	if err.Error() != want {
 		t.Errorf("error = %q, want %q", err.Error(), want)
+	}
+}
+
+// TestPollUntilDone_ConsecutiveErrors verifies that persistent status poll
+// failures cause pollUntilDone to give up after maxPollErrors consecutive errors
+// instead of retrying forever.
+// NOTE: pollUntilDone has a 5-second initial timer, so this test takes ~5s.
+func TestPollUntilDone_ConsecutiveErrors(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/output":
+			w.WriteHeader(http.StatusOK)
+		case "/status":
+			http.Error(w, "sandbox gone", http.StatusServiceUnavailable)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	s := newTestSandbox()
+	s.maxPollErrors = 1 // give up after first failure
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := s.pollUntilDone(ctx, srv.URL, "claim-errors",
+		func() bool { return false }, newSyncBuffer(0), nil)
+	if err == nil {
+		t.Fatal("expected error from consecutive poll failures, got nil")
+	}
+	if !strings.Contains(err.Error(), "consecutive poll failures") {
+		t.Errorf("error = %q, want substring %q", err.Error(), "consecutive poll failures")
+	}
+}
+
+// TestPollUntilDone_ErrorCounterResets verifies that a successful status poll
+// resets the consecutive error counter, allowing transient errors to recover.
+// NOTE: pollUntilDone has a 5-second initial timer, so this test takes ~5s.
+func TestPollUntilDone_ErrorCounterResets(t *testing.T) {
+	callCount := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/output":
+			w.WriteHeader(http.StatusOK)
+		case "/status":
+			callCount++
+			// First call fails, second succeeds with "done".
+			if callCount == 1 {
+				http.Error(w, "transient error", http.StatusServiceUnavailable)
+				return
+			}
+			json.NewEncoder(w).Encode(map[string]any{
+				"state":     "done",
+				"exit_code": 0,
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	s := newTestSandbox()
+	s.maxPollErrors = 2 // would fail at 2, but the error resets after success
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	result, err := s.pollUntilDone(ctx, srv.URL, "claim-reset",
+		func() bool { return false }, newSyncBuffer(0), nil)
+	if err != nil {
+		t.Fatalf("pollUntilDone: %v", err)
+	}
+	if result.ExitCode != 0 {
+		t.Errorf("ExitCode = %d, want 0", result.ExitCode)
 	}
 }
 


### PR DESCRIPTION
## Summary

- **Root cause**: `pollUntilDone` retries status polls forever when a sandbox pod is deleted before the poller reads "done" status. DNS errors loop indefinitely, and each leaked goroutine holds a NATS consumer slot via `msg.InProgress()`. With `MaxAckPending=3`, just 3 stuck goroutines block all new job delivery.
- **Fix**: Add `maxPollErrors` field (default 10 ≈ ~5 min at 30s poll intervals) that tracks consecutive status poll failures. After the threshold, the goroutine returns an error instead of looping forever. The counter resets on any successful poll.
- **Chart bump**: 0.28.8 → 0.28.9 (with matching `targetRevision` update)

## Test plan

- [x] `TestPollUntilDone_ConsecutiveErrors` — verifies persistent failures trigger the error limit
- [x] `TestPollUntilDone_ErrorCounterResets` — verifies transient errors recover when followed by a successful poll
- [ ] CI passes (`bazel test //projects/agent_platform/orchestrator/...`)
- [ ] After deploy, verify stuck PENDING jobs start processing again

🤖 Generated with [Claude Code](https://claude.com/claude-code)