### PR TITLE
fix(orchestrator): add grace period to reconciler for fresh attempts

### DIFF
--- a/projects/agent_platform/chart/Chart.yaml
+++ b/projects/agent_platform/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: agent-platform
 description: Agent platform — umbrella chart bundling goose sandboxes, MCP servers, and supporting components
 type: application
-version: 0.28.10
+version: 0.28.11
 appVersion: "0.2.0"
 annotations:
   org.opencontainers.image.source: "https://github.com/jomcgi/homelab"

--- a/projects/agent_platform/deploy/application.yaml
+++ b/projects/agent_platform/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: agent-platform
-      targetRevision: 0.28.10
+      targetRevision: 0.28.11
       helm:
         releaseName: agent-platform
         valueFiles:

--- a/projects/agent_platform/orchestrator/reconcile.go
+++ b/projects/agent_platform/orchestrator/reconcile.go
@@ -52,6 +52,19 @@ func reconcileOrphanedJobs(ctx context.Context, store Store, dynClient dynamic.I
 	for _, job := range jobs {
 		jlog := logger.With("jobID", job.ID)
 
+		// Skip jobs whose latest attempt just started — the sandbox may still
+		// be booting and the runner will report "idle" until goose launches.
+		// Without this grace period the reconciler races with the consumer:
+		// it sees "idle", deletes the freshly-created SandboxClaim, and the
+		// consumer's waitPodRunning fails with "not found".
+		if len(job.Attempts) > 0 {
+			lastAttempt := job.Attempts[len(job.Attempts)-1]
+			if time.Since(lastAttempt.StartedAt) < 2*time.Minute {
+				jlog.Info("reconcile: attempt too recent, skipping", "startedAt", lastAttempt.StartedAt)
+				continue
+			}
+		}
+
 		// With HTTP runner, check if goose is still running before resetting.
 		if checkRunner != nil && len(job.Attempts) > 0 {
 			lastAttempt := job.Attempts[len(job.Attempts)-1]

--- a/projects/agent_platform/orchestrator/reconcile_test.go
+++ b/projects/agent_platform/orchestrator/reconcile_test.go
@@ -426,6 +426,73 @@ func TestReconcileOrphanedJobs_RunnerUnreachableFallsBack(t *testing.T) {
 	}
 }
 
+// TestReconcileOrphanedJobs_GracePeriodSkipsRecentAttempt verifies that the
+// reconciler does not touch jobs whose latest attempt started less than 2
+// minutes ago. This prevents a race where the reconciler sees a freshly-
+// created sandbox as "idle" (goose hasn't launched yet) and deletes the
+// SandboxClaim before the consumer can use it.
+func TestReconcileOrphanedJobs_GracePeriodSkipsRecentAttempt(t *testing.T) {
+	store := newMemStore()
+	ctx := context.Background()
+
+	// Job with an attempt that just started (30 seconds ago).
+	store.Put(ctx, &JobRecord{
+		ID:         "job-fresh",
+		Task:       "just started task",
+		Status:     JobRunning,
+		CreatedAt:  time.Now().Add(-30 * time.Second),
+		MaxRetries: 2,
+		Attempts: []Attempt{{
+			Number:           1,
+			SandboxClaimName: "orch-job-fresh-1",
+			StartedAt:        time.Now().Add(-30 * time.Second),
+		}},
+	})
+
+	// Job with an old attempt (1 hour ago) — should still be reconciled.
+	store.Put(ctx, &JobRecord{
+		ID:         "job-old",
+		Task:       "stale task",
+		Status:     JobRunning,
+		CreatedAt:  time.Now().Add(-1 * time.Hour),
+		MaxRetries: 2,
+		Attempts: []Attempt{{
+			Number:           1,
+			SandboxClaimName: "orch-job-old-1",
+			StartedAt:        time.Now().Add(-1 * time.Hour),
+		}},
+	})
+
+	// Runner reports "idle" for both — without the grace period, both would
+	// be reset to PENDING with their sandbox claims deleted.
+	checkRunner := func(_ context.Context, claimName string) (string, int, error) {
+		return "idle", 0, nil
+	}
+
+	reconcileOrphanedJobs(ctx, store, nil, "goose-sandboxes", checkRunner, nil, slog.Default())
+
+	// Fresh job should be untouched — still RUNNING with no FinishedAt.
+	fresh, err := store.Get(ctx, "job-fresh")
+	if err != nil {
+		t.Fatalf("Get(job-fresh): %v", err)
+	}
+	if fresh.Status != JobRunning {
+		t.Errorf("job-fresh: status = %s, want RUNNING (grace period should skip it)", fresh.Status)
+	}
+	if fresh.Attempts[0].FinishedAt != nil {
+		t.Error("job-fresh: FinishedAt should be nil (attempt not interrupted)")
+	}
+
+	// Old job should be reset to PENDING.
+	old, err := store.Get(ctx, "job-old")
+	if err != nil {
+		t.Fatalf("Get(job-old): %v", err)
+	}
+	if old.Status != JobPending {
+		t.Errorf("job-old: status = %s, want PENDING", old.Status)
+	}
+}
+
 // TestParseGooseResult_OnRawOutputBeforeClean documents and verifies the
 // intentional call ordering in both reconcile.go and consumer.go:
 //


### PR DESCRIPTION
## Summary

- **Root cause**: The reconciler runs every 60s and checks runner status for RUNNING jobs. When a sandbox is freshly created, the runner reports "idle" (goose hasn't launched yet). The reconciler treats "idle" as orphaned, deletes the brand-new SandboxClaim, and resets the job to PENDING — burning a retry attempt every time.
- **Fix**: Skip jobs whose latest attempt started less than 2 minutes ago, giving the sandbox time to boot before the reconciler evaluates it.
- **Chart bump**: 0.28.10 → 0.28.11

## Evidence

From orchestrator logs at `00:02:20–00:02:22`:
```
creating sandbox claim  claim=orch-...-1         # consumer creates claim
reconcile: runner idle or unknown state           # reconciler sees "idle" 2s later
reconcile: deleted orphaned sandbox claim         # reconciler deletes the claim
task failed  error="sandboxclaims...not found"    # consumer fails because claim is gone
```

## Test plan

- [x] `TestReconcileOrphanedJobs_GracePeriodSkipsRecentAttempt` — verifies fresh attempts are skipped while old ones are still reconciled
- [ ] CI passes
- [ ] After deploy, verify new Discord jobs don't waste a retry on attempt 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)