### PR TITLE
docs(trips): fix README inaccuracies

### DIFF
--- a/projects/trips/backend/README.md
+++ b/projects/trips/backend/README.md
@@ -448,18 +448,11 @@ View in SigNoz: https://signoz.jomcgi.dev
 
 ### Logs
 
-Structured JSON logs via `logging.structlog`:
+Standard Python logging:
 
-```json
-{
-  "timestamp": "2024-01-15T12:00:00Z",
-  "level": "info",
-  "event": "point_added",
-  "point_id": "abc123def456",
-  "lat": 49.2827,
-  "lng": -123.1207,
-  "source": "gopro"
-}
+```
+INFO:trips_api:Catchup complete. 1523 points loaded.
+INFO:trips_api:WebSocket client connected. Total: 1
 ```
 
 ## Related Services

--- a/projects/trips/frontend/README.md
+++ b/projects/trips/frontend/README.md
@@ -11,7 +11,7 @@ Interactive trip viewer for exploring travel routes and photos.
 
 ## Tech Stack
 
-- React 18 + TypeScript
+- React 19
 - Vite for bundling
 - MapLibre GL for maps
 - TailwindCSS for styling


### PR DESCRIPTION
## Summary

- **trips/frontend**: Update tech stack from "React 18 + TypeScript" to "React 19" — package.json has `react@^19.2.0` and no `typescript` build dependency
- **trips/backend**: Replace fictional `logging.structlog` JSON logs example with the actual standard Python logging used in the code

## Test plan
- [ ] Verify `projects/trips/frontend/package.json` has `react: ^19.x`
- [ ] Verify `projects/trips/backend/main.py` uses `logging.basicConfig` not structlog

🤖 Generated with [Claude Code](https://claude.com/claude-code)