### PR TITLE
docs(grimoire): fix secrets operator reference in gcp README

### DIFF
--- a/projects/grimoire/gcp/README.md
+++ b/projects/grimoire/gcp/README.md
@@ -19,7 +19,7 @@ After setup:
 
 1. Create a Gemini API key at https://aistudio.google.com/apikey
 2. Store it in 1Password (vault: **Homelab**, item: **grimoire-gemini-api-key**, field: **key**)
-3. The External Secrets Operator syncs it to the cluster automatically
+3. The 1Password Operator syncs it to the cluster automatically via a `OnePasswordItem` resource
 
 ## Deploy
 


### PR DESCRIPTION
## Summary

- **grimoire/gcp**: Replace "External Secrets Operator" with "1Password Operator" — this cluster uses `OnePasswordItem` CRDs via the 1Password Operator, not the External Secrets Operator

## Test plan
- [ ] Confirm cluster uses 1Password Operator (check `projects/platform/` for the operator deployment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)