### PR TITLE
chore: remove BuildBuddy MCP references

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -102,7 +102,7 @@ Breaking changes: add `!` after type/scope — `feat!: redesign auth token forma
 
 ## Cluster Investigation
 
-**MCP-first.** PreToolUse hooks enforce using MCP tools (via Context Forge) instead of CLI commands. Use `ToolSearch` with `+kubernetes`, `+argocd`, `+buildbuddy`, or `+signoz` to load tools. Tool names below are shortened — actual IDs have the `mcp__claude_ai_Homelab__` prefix (e.g., `mcp__claude_ai_Homelab__kubernetes-mcp-resources-list`).
+**MCP-first.** PreToolUse hooks enforce using MCP tools (via Context Forge) instead of CLI commands. Use `ToolSearch` with `+kubernetes`, `+argocd`, or `+signoz` to load tools. Tool names below are shortened — actual IDs have the `mcp__claude_ai_Homelab__` prefix (e.g., `mcp__claude_ai_Homelab__kubernetes-mcp-resources-list`).
 
 | Need                 | Tool                                                                                                      |
 | -------------------- | --------------------------------------------------------------------------------------------------------- |


### PR DESCRIPTION
## Summary
- Remove `+buildbuddy` from ToolSearch hints in CLAUDE.md cluster investigation section
- BuildBuddy MCP server was removed from Context Forge — the `bb` CLI and `/buildbuddy` skill remain as the way to interact with BuildBuddy CI

Also cleaned up auto-memory to remove stale BuildBuddy MCP tool quirks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)