### PR TITLE
test(advent-of-code): add unit tests for generateGoTest, generatePythonTest, generateTests, getSession

### DIFF
--- a/projects/advent_of_code/cmd/aoc/main_test.go
+++ b/projects/advent_of_code/cmd/aoc/main_test.go
@@ -743,8 +743,8 @@ func TestGenerateGoTest_OverwritesExistingFile(t *testing.T) {
 
 func TestGenerateGoTest_DataPathContainsYearAndDay(t *testing.T) {
 	tests := []struct {
-		year    int
-		day     int
+		year     int
+		day      int
 		wantYear string
 		wantDay  string
 	}{


### PR DESCRIPTION
## Summary

- **`generateGoTest`**: file creation, content assertions (TestPart1, TestPart2, answers.json, input.txt, year/day data path), overwrite behaviour, and table-driven year/day zero-padding check.
- **`generatePythonTest`**: file creation, content assertions (test_part1, test_part2, @pytest.fixture, import path, answers.json, input.txt), import path year/day formatting, and overwrite behaviour.
- **`generateTests`** (orchestrator): both-solutions-exist, only-Go, only-Python, and neither-exists scenarios. Introduces a `makeAocDayDir` test helper that places the temp directory tree under `advent_of_code/` so `ensurePythonPackage` stops at the right boundary and never walks into system directories.
- **`getSession`**: sessionVar happy path (direct return, no error), sessionVar takes precedence regardless of environment, and empty-sessionVar fallthrough that delegates to `cookies.GetSession()`.

## Test plan

- [ ] `bazel test //projects/advent_of_code/cmd/aoc:aoc_test` passes with all 20 new test cases green.
- [ ] No production code was modified.
- [ ] All new tests follow existing patterns: `t.TempDir()`, `t.Cleanup` for global restores, table-driven subtests where appropriate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)