### PR TITLE
test(blog-knowledge-graph): add coverage for httpx AsyncClient timeout values

### DIFF
--- a/projects/blog_knowledge_graph/knowledge_graph/tests/embedders_test.py
+++ b/projects/blog_knowledge_graph/knowledge_graph/tests/embedders_test.py
@@ -527,3 +527,88 @@ class TestOllamaEmbedderEmbedQuery:
 
             with pytest.raises(httpx.HTTPStatusError):
                 await ollama.embed_query("query")
+
+
+# ---------------------------------------------------------------------------
+# Timeout verification tests
+# ---------------------------------------------------------------------------
+
+
+class TestGeminiEmbedderTimeout:
+    """Verify httpx.AsyncClient timeout values in GeminiEmbedder."""
+
+    @pytest.mark.asyncio
+    async def test_embed_uses_120_second_timeout(self, gemini):
+        """embed() must construct AsyncClient with timeout=120.0."""
+        with patch(
+            "projects.blog_knowledge_graph.knowledge_graph.app.embedders.gemini.httpx.AsyncClient"
+        ) as mock_cls:
+            mock_client = AsyncMock()
+            mock_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+            mock_response = MagicMock()
+            mock_response.raise_for_status = MagicMock()
+            mock_response.json.return_value = {"embeddings": [{"values": [0.1]}]}
+            mock_client.post.return_value = mock_response
+
+            await gemini.embed(["text"])
+
+        mock_cls.assert_called_once_with(timeout=120.0)
+
+    @pytest.mark.asyncio
+    async def test_embed_query_uses_60_second_timeout(self, gemini):
+        """embed_query() must construct AsyncClient with timeout=60.0."""
+        with patch(
+            "projects.blog_knowledge_graph.knowledge_graph.app.embedders.gemini.httpx.AsyncClient"
+        ) as mock_cls:
+            mock_client = AsyncMock()
+            mock_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+            mock_response = MagicMock()
+            mock_response.raise_for_status = MagicMock()
+            mock_response.json.return_value = {"embedding": {"values": [0.1]}}
+            mock_client.post.return_value = mock_response
+
+            await gemini.embed_query("query")
+
+        mock_cls.assert_called_once_with(timeout=60.0)
+
+
+class TestOllamaEmbedderTimeout:
+    """Verify httpx.AsyncClient timeout values in OllamaEmbedder."""
+
+    @pytest.mark.asyncio
+    async def test_embed_uses_120_second_timeout(self, ollama):
+        """embed() must construct AsyncClient with timeout=120.0."""
+        with patch(
+            "projects.blog_knowledge_graph.knowledge_graph.app.embedders.ollama.httpx.AsyncClient"
+        ) as mock_cls:
+            mock_client = AsyncMock()
+            mock_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+            mock_response = MagicMock()
+            mock_response.raise_for_status = MagicMock()
+            mock_response.json.return_value = {"embeddings": [[0.1]]}
+            mock_client.post.return_value = mock_response
+
+            await ollama.embed(["text"])
+
+        mock_cls.assert_called_once_with(timeout=120.0)
+
+    @pytest.mark.asyncio
+    async def test_embed_query_uses_60_second_timeout(self, ollama):
+        """embed_query() must construct AsyncClient with timeout=60.0."""
+        with patch(
+            "projects.blog_knowledge_graph.knowledge_graph.app.embedders.ollama.httpx.AsyncClient"
+        ) as mock_cls:
+            mock_client = AsyncMock()
+            mock_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+            mock_response = MagicMock()
+            mock_response.raise_for_status = MagicMock()
+            mock_response.json.return_value = {"embeddings": [[0.1]]}
+            mock_client.post.return_value = mock_response
+
+            await ollama.embed_query("query")
+
+        mock_cls.assert_called_once_with(timeout=60.0)

--- a/projects/blog_knowledge_graph/knowledge_graph/tests/notifications_test.py
+++ b/projects/blog_knowledge_graph/knowledge_graph/tests/notifications_test.py
@@ -383,6 +383,26 @@ class TestSlackNotifierErrorHandling:
         )
 
 
+class TestSlackNotifierTimeout:
+    """Verify httpx.AsyncClient timeout in SlackNotifier._post()."""
+
+    @pytest.mark.asyncio
+    async def test_post_uses_10_second_timeout(self):
+        """_post() must construct AsyncClient with timeout=10.0."""
+        with patch(_NOTIF_PATH) as mock_cls:
+            mock_client = AsyncMock()
+            mock_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+            mock_response = AsyncMock()
+            mock_response.raise_for_status = AsyncMock()
+            mock_client.post.return_value = mock_response
+
+            notifier = SlackNotifier("https://hooks.slack.com/test")
+            await notifier._post("test message")
+
+        mock_cls.assert_called_once_with(timeout=10.0)
+
+
 class TestSlackNotifierBatchEdgeCases:
     """Edge-case tests for notify_batch message content."""
 

--- a/projects/blog_knowledge_graph/knowledge_graph/tests/qdrant_client_test.py
+++ b/projects/blog_knowledge_graph/knowledge_graph/tests/qdrant_client_test.py
@@ -393,3 +393,69 @@ class TestHasContentHash:
         must_clause = call_json["filter"]["must"][0]
         assert must_clause["key"] == "content_hash"
         assert must_clause["match"]["value"] == "targethash"
+
+
+class TestQdrantClientTimeouts:
+    """Verify httpx.AsyncClient timeout values in QdrantClient methods."""
+
+    @pytest.mark.asyncio
+    async def test_ensure_collection_uses_10_second_timeout(self, qdrant):
+        """ensure_collection must construct AsyncClient with timeout=10.0."""
+        with patch(_QDRANT_PATH) as mock_cls:
+            mock_client = AsyncMock()
+            mock_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+            get_resp = MagicMock()
+            get_resp.status_code = 200
+            mock_client.get.return_value = get_resp
+
+            await qdrant.ensure_collection(vector_size=768)
+
+        mock_cls.assert_called_once_with(timeout=10.0)
+
+    @pytest.mark.asyncio
+    async def test_upsert_chunks_uses_30_second_timeout(self, qdrant):
+        """upsert_chunks must construct AsyncClient with timeout=30.0."""
+        with patch(_QDRANT_PATH) as mock_cls:
+            mock_client = AsyncMock()
+            mock_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+            put_resp = MagicMock()
+            put_resp.raise_for_status = MagicMock()
+            mock_client.put.return_value = put_resp
+
+            await qdrant.upsert_chunks([], [])
+
+        mock_cls.assert_called_once_with(timeout=30.0)
+
+    @pytest.mark.asyncio
+    async def test_search_uses_10_second_timeout(self, qdrant):
+        """search must construct AsyncClient with timeout=10.0."""
+        with patch(_QDRANT_PATH) as mock_cls:
+            mock_client = AsyncMock()
+            mock_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+            resp = MagicMock()
+            resp.raise_for_status = MagicMock()
+            resp.json.return_value = {"result": {"points": []}}
+            mock_client.post.return_value = resp
+
+            await qdrant.search([0.1, 0.2])
+
+        mock_cls.assert_called_once_with(timeout=10.0)
+
+    @pytest.mark.asyncio
+    async def test_has_content_hash_uses_10_second_timeout(self, qdrant):
+        """has_content_hash must construct AsyncClient with timeout=10.0."""
+        with patch(_QDRANT_PATH) as mock_cls:
+            mock_client = AsyncMock()
+            mock_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+            resp = MagicMock()
+            resp.raise_for_status = MagicMock()
+            resp.json.return_value = {"result": {"points": []}}
+            mock_client.post.return_value = resp
+
+            await qdrant.has_content_hash("abc123")
+
+        mock_cls.assert_called_once_with(timeout=10.0)

--- a/projects/blog_knowledge_graph/knowledge_graph/tests/scraper_main_test.py
+++ b/projects/blog_knowledge_graph/knowledge_graph/tests/scraper_main_test.py
@@ -487,3 +487,40 @@ class TestStatusEndpoint:
                 response = await client.get("/status/https://example.com/article")
 
         assert response.json()["scraped"] is False
+
+
+_SCRAPER_CLIENT_PATH = (
+    "projects.blog_knowledge_graph.knowledge_graph.app.scraper_main.httpx.AsyncClient"
+)
+
+
+class TestScraperHttpxTimeout:
+    """Verify httpx.AsyncClient timeout values in scraper endpoints."""
+
+    @pytest.mark.asyncio
+    async def test_scrape_endpoint_uses_30_second_timeout(self):
+        """The /scrape handler must construct AsyncClient with timeout=30.0."""
+        from unittest.mock import AsyncMock
+
+        from projects.blog_knowledge_graph.knowledge_graph.app.scraper_main import (
+            ScrapeRequest,
+            scrape,
+        )
+
+        req = ScrapeRequest(url="https://example.com/test", type="html", force=False)
+
+        with patch(_SCRAPER_CLIENT_PATH) as mock_cls:
+            mock_client = AsyncMock()
+            mock_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            with patch(
+                "projects.blog_knowledge_graph.knowledge_graph.app.scraper_main._scrape_source",
+                new=AsyncMock(return_value=[]),
+            ):
+                with patch(
+                    "projects.blog_knowledge_graph.knowledge_graph.app.scraper_main._validate_url"
+                ):
+                    await scrape(req)
+
+        mock_cls.assert_called_with(timeout=30.0)


### PR DESCRIPTION
## Summary
- Add `TestGeminiEmbedderTimeout` and `TestOllamaEmbedderTimeout` classes verifying `timeout=120.0` for `embed()` and `timeout=60.0` for `embed_query()`
- Add `TestSlackNotifierTimeout` verifying `timeout=10.0` in `_post()`
- Add `TestQdrantClientTimeouts` verifying timeouts across all 4 Qdrant methods (`ensure_collection`, `upsert_chunks`, `search`, `has_content_hash`)
- Add `TestScraperHttpxTimeout` verifying `timeout=30.0` in the `/scrape` endpoint handler

## Test plan
- [ ] `bazel test //projects/blog_knowledge_graph/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)