### PR TITLE
test(trips): add coverage for logging and httpx timeout across tools

### DIFF
--- a/projects/trips/tools/backfill-elevation/backfill_elevation_test.py
+++ b/projects/trips/tools/backfill-elevation/backfill_elevation_test.py
@@ -622,3 +622,67 @@ class TestRunBackfillFiltering:
         point.elevation = _FakeResult.elevation
         assert point.elevation == pytest.approx(350.5)
         assert point.to_dict()["elevation"] == pytest.approx(350.5)
+
+
+# ---------------------------------------------------------------------------
+# replay_stream logging tests
+# ---------------------------------------------------------------------------
+
+
+class TestReplayStreamLogging:
+    """Verify logger.warning is called when NATS messages can't be parsed."""
+
+    @pytest.mark.asyncio
+    async def test_warning_logged_when_message_parse_fails(self):
+        """logger.warning must be called when a NATS message cannot be parsed."""
+        import nats.errors
+
+        import main as _main_mod
+
+        mock_msg = MagicMock()
+        mock_msg.data = b"not valid json {{{"
+
+        mock_consumer = AsyncMock()
+        mock_consumer.fetch = AsyncMock(
+            side_effect=[[mock_msg], nats.errors.TimeoutError()]
+        )
+        mock_consumer.unsubscribe = AsyncMock()
+
+        mock_js = AsyncMock()
+        mock_js.pull_subscribe = AsyncMock(return_value=mock_consumer)
+
+        with patch.object(_main_mod.logger, "warning") as mock_warn:
+            await replay_stream(mock_js)
+
+        mock_warn.assert_called()
+        warning_args = mock_warn.call_args[0]
+        assert "Could not parse NATS message" in warning_args[0]
+
+    @pytest.mark.asyncio
+    async def test_warning_includes_exception_as_argument(self):
+        """logger.warning is called with the exception as the second argument."""
+        import nats.errors
+
+        import main as _main_mod
+
+        mock_msg = MagicMock()
+        mock_msg.data = b"invalid json"
+
+        mock_consumer = AsyncMock()
+        mock_consumer.fetch = AsyncMock(
+            side_effect=[[mock_msg], nats.errors.TimeoutError()]
+        )
+        mock_consumer.unsubscribe = AsyncMock()
+
+        mock_js = AsyncMock()
+        mock_js.pull_subscribe = AsyncMock(return_value=mock_consumer)
+
+        with patch.object(_main_mod.logger, "warning") as mock_warn:
+            await replay_stream(mock_js)
+
+        mock_warn.assert_called()
+        # Should have been called with format string and exception
+        assert mock_warn.call_count >= 1
+        call_args = mock_warn.call_args[0]
+        # format string + exception object
+        assert len(call_args) >= 2

--- a/projects/trips/tools/delete-trip-points/delete_trip_points_test.py
+++ b/projects/trips/tools/delete-trip-points/delete_trip_points_test.py
@@ -294,3 +294,30 @@ class TestBatchPublishLogic:
             for pid in point_ids:
                 await publish_delete(mock_js, pid)
         mock_js.publish.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# httpx timeout tests
+# ---------------------------------------------------------------------------
+
+
+class TestHttpxTimeout:
+    """Verify httpx.AsyncClient is constructed with timeout=30.0 in HTTP commands."""
+
+    def test_by_date_source_uses_30_second_timeout(self):
+        """by_date creates AsyncClient with timeout=30.0 (verified from source)."""
+        import inspect
+
+        import main as _main_mod
+
+        source = inspect.getsource(_main_mod.by_date)
+        assert "timeout=30.0" in source
+
+    def test_list_gaps_source_uses_30_second_timeout(self):
+        """list_gaps creates AsyncClient with timeout=30.0 (verified from source)."""
+        import inspect
+
+        import main as _main_mod
+
+        source = inspect.getsource(_main_mod.list_gaps)
+        assert "timeout=30.0" in source

--- a/projects/trips/tools/detect-wildlife/BUILD
+++ b/projects/trips/tools/detect-wildlife/BUILD
@@ -69,11 +69,14 @@ semgrep_test(
     rules = ["//bazel/semgrep/rules:python_rules"],
 )
 
+# gazelle:resolve py main.download_worker //projects/trips/tools/detect-wildlife:detect-wildlife
 py_test(
     name = "detect_wildlife_test",
     srcs = ["detect_wildlife_test.py"],
+    imports = ["."],
     deps = [
         "//projects/trips/tools/detect-wildlife",
         "@pip//pytest",
+        "@pip//pytest_asyncio",
     ],
 )

--- a/projects/trips/tools/detect-wildlife/detect_wildlife_test.py
+++ b/projects/trips/tools/detect-wildlife/detect_wildlife_test.py
@@ -1,12 +1,14 @@
 """Tests for detect-wildlife/main.py."""
 
+import asyncio
 import signal
 import sqlite3
 import time
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+import pytest_asyncio  # noqa: F401 — needed to register pytest-asyncio plugin
 
 from main import (
     CaptureQueue,
@@ -14,6 +16,7 @@ from main import (
     DownloadStatus,
     GracefulShutdown,
     PerfStats,
+    download_worker,
 )
 
 
@@ -254,3 +257,74 @@ class TestPerfStats:
         summary = stats.summary()
         assert "Effective rate:" in summary
         assert "photos/min" in summary
+
+
+# ---------------------------------------------------------------------------
+# download_worker logging tests
+# ---------------------------------------------------------------------------
+
+
+class TestDownloadWorkerLogging:
+    """Verify logger.exception is called in download_worker when a download fails."""
+
+    @pytest.mark.asyncio
+    async def test_exception_logged_when_download_fails(self, tmp_path):
+        """logger.exception must fire when gopro.http_command.download_file raises."""
+        import main as _main_mod
+
+        queue = CaptureQueue(tmp_path / "queue.db")
+        rid = queue.add("GOPR0001.JPG", tmp_path / "photo.jpg")
+
+        # GoPro mock whose download_file always raises
+        mock_gopro = MagicMock()
+        mock_gopro.http_command.download_file = AsyncMock(
+            side_effect=RuntimeError("network error")
+        )
+
+        # Shutdown that stops after the first iteration
+        shutdown = GracefulShutdown()
+        download_event = asyncio.Event()
+        download_event.set()  # signal that work is available
+
+        async def _run():
+            # Run the worker until the record is exhausted from pending
+            task = asyncio.create_task(
+                download_worker(mock_gopro, queue, shutdown, download_event)
+            )
+            # Give worker time to process the one record
+            await asyncio.sleep(0.05)
+            shutdown.shutdown_requested = True
+            await task
+
+        with patch.object(_main_mod.logger, "exception") as mock_exc:
+            await _run()
+
+        mock_exc.assert_called()
+        call_args = mock_exc.call_args[0]
+        assert "Download failed for" in call_args[0]
+        assert "GOPR0001.JPG" in call_args[1]
+
+    @pytest.mark.asyncio
+    async def test_record_marked_failed_after_exception(self, tmp_path):
+        """The queue record is marked failed when the download raises."""
+        queue = CaptureQueue(tmp_path / "queue.db")
+        rid = queue.add("GOPR0002.JPG", tmp_path / "photo.jpg")
+
+        mock_gopro = MagicMock()
+        mock_gopro.http_command.download_file = AsyncMock(
+            side_effect=OSError("disk full")
+        )
+
+        shutdown = GracefulShutdown()
+        download_event = asyncio.Event()
+        download_event.set()
+
+        task = asyncio.create_task(
+            download_worker(mock_gopro, queue, shutdown, download_event)
+        )
+        await asyncio.sleep(0.05)
+        shutdown.shutdown_requested = True
+        await task
+
+        stats = queue.get_stats()
+        assert stats.get(DownloadStatus.FAILED.value, 0) >= 1

--- a/projects/trips/tools/publish-trip-images/rebuild_test.py
+++ b/projects/trips/tools/publish-trip-images/rebuild_test.py
@@ -520,3 +520,52 @@ class TestRunRebuild:
         )
 
         js.publish.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# TestExtractExifLogging
+# ---------------------------------------------------------------------------
+
+
+class TestExtractExifLogging:
+    """Verify logger.warning is called in extract_exif when an image can't be opened."""
+
+    def test_warning_logged_when_image_cannot_be_opened(self, tmp_path):
+        """logger.warning must be called when Image.open raises an exception."""
+        import main as _main_mod
+        from main import extract_exif
+
+        nonexistent_path = tmp_path / "nonexistent.jpg"
+
+        with patch.object(_main_mod.logger, "warning") as mock_warn:
+            lat, lng, timestamp, optics = extract_exif(nonexistent_path)
+
+        mock_warn.assert_called_once()
+        call_args = mock_warn.call_args[0]
+        assert "Could not extract EXIF from" in call_args[0]
+
+    def test_returns_nones_when_image_cannot_be_opened(self, tmp_path):
+        """extract_exif returns (None, None, None, None) when Image.open fails."""
+        from main import extract_exif
+
+        nonexistent = tmp_path / "bad.jpg"
+        result = extract_exif(nonexistent)
+        assert result == (None, None, None, None)
+
+    def test_warning_includes_filename_in_format_string(self, tmp_path):
+        """logger.warning is called with the filename and exception as arguments."""
+        import main as _main_mod
+        from main import extract_exif
+
+        bad_path = tmp_path / "corrupt_image.jpg"
+        # Write a non-image file so PIL raises on open
+        bad_path.write_bytes(b"not an image")
+
+        with patch.object(_main_mod.logger, "warning") as mock_warn:
+            extract_exif(bad_path)
+
+        mock_warn.assert_called_once()
+        call_args = mock_warn.call_args[0]
+        # Format: "Could not extract EXIF from %s: %s", filename, exception
+        assert len(call_args) >= 3
+        assert call_args[1] == "corrupt_image.jpg"


### PR DESCRIPTION
## Summary
- Add `TestReplayStreamLogging` to `backfill_elevation_test.py` — verifies `logger.warning` fires with the correct message and exception argument when a NATS message fails JSON parsing in `replay_stream()`
- Add `TestHttpxTimeout` to `delete_trip_points_test.py` — verifies `httpx.AsyncClient(timeout=30.0)` is used in both `by_date` and `list_gaps` commands via source inspection
- Add `TestDownloadWorkerLogging` to `detect_wildlife_test.py` — verifies `logger.exception("Download failed for %s", ...)` fires and the queue record is marked failed when a download raises in `download_worker()`; also updates the BUILD target to add `imports = ["."]` and `pytest_asyncio` dep
- Add `TestExtractExifLogging` to `rebuild_test.py` — verifies `logger.warning` fires with filename as argument, and that `extract_exif()` returns `(None, None, None, None)` on failure

## Test plan
- [ ] `bazel test //projects/trips/tools/backfill-elevation:backfill_elevation_test` passes
- [ ] `bazel test //projects/trips/tools/delete-trip-points:delete_trip_points_test` passes
- [ ] `bazel test //projects/trips/tools/detect-wildlife:detect_wildlife_test` passes
- [ ] `bazel test //projects/trips/tools/publish-trip-images:rebuild_test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)