### PR TITLE
fix(obsidian-vault): fill in deploy values

### DIFF
--- a/projects/obsidian_vault/deploy/values.yaml
+++ b/projects/obsidian_vault/deploy/values.yaml
@@ -1,5 +1,5 @@
 gitSidecar:
-  remote: ""
+  remote: "https://github.com/jomcgi/obsidian-vault.git"
 
 gateway:
   url: "http://context-forge-gateway-mcp-stack-mcpgateway.mcp.svc.cluster.local:80"
@@ -8,4 +8,4 @@ gateway:
 
 secrets:
   obsidian:
-    itemPath: ""
+    itemPath: "vaults/k8s-homelab/items/obsidian"


### PR DESCRIPTION
## Summary
- Set git sidecar remote to `https://github.com/jomcgi/obsidian-vault.git`
- Set 1Password itemPath to `vaults/k8s-homelab/items/obsidian`

## Test plan
- [ ] ArgoCD syncs the obsidian-vault application
- [ ] 1Password operator provisions the secret
- [ ] Pods start successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)