### PR TITLE
fix: add bash symlink to py3_image, wire oci-model-cache to helm_images_values

### DIFF
--- a/bazel/tools/oci/py3_image.bzl
+++ b/bazel/tools/oci/py3_image.bzl
@@ -39,9 +39,15 @@ def py3_image(name, binary, main = None, root = "/", layer_groups = {}, env = {}
         "PYTHONPATH": workspace_root,
     }, **env)
 
+    # Wolfi installs bash to /usr/bin/bash but py_venv_binary shebangs use /bin/bash
+    tar(
+        name = name + "_bash_symlink",
+        mtree = ["./bin/bash type=link link=/usr/bin/bash"],
+    )
+
     # py_venv_binary omits ctx.file.main from runfiles — create a supplementary
     # tar layer to include the source file at the correct runfiles path.
-    src_tars = []
+    src_tars = [name + "_bash_symlink"]
     if main == None and binary.package == native.package_name():
         main = binary.name + ".py"
     if main:

--- a/projects/operators/oci-model-cache/deploy/application.yaml
+++ b/projects/operators/oci-model-cache/deploy/application.yaml
@@ -5,14 +5,18 @@ metadata:
   namespace: argocd
 spec:
   project: default
-  source:
-    repoURL: https://github.com/jomcgi/homelab.git
-    targetRevision: HEAD
-    path: projects/operators/oci-model-cache/helm/oci-model-cache-operator
-    helm:
-      valueFiles:
-        - values.yaml
-        - ../../deploy/values.yaml
+  sources:
+    # Chart from OCI registry (pushed by CI via Bazel helm_push)
+    - repoURL: ghcr.io/jomcgi/homelab/charts
+      chart: oci-model-cache-operator
+      targetRevision: 0.1.2
+      helm:
+        valueFiles:
+          - $values/projects/operators/oci-model-cache/deploy/values.yaml
+    # Git repo for environment-specific values
+    - repoURL: https://github.com/jomcgi/homelab.git
+      targetRevision: HEAD
+      ref: values
   destination:
     server: https://kubernetes.default.svc
     namespace: oci-model-cache

--- a/projects/operators/oci-model-cache/deploy/values.yaml
+++ b/projects/operators/oci-model-cache/deploy/values.yaml
@@ -3,7 +3,7 @@ imagePullSecrets:
 controllerManager:
   image:
     repository: ghcr.io/jomcgi/homelab/projects/operators/oci-model-cache
-    tag: main@sha256:5daee534bd2dfd0fedc95df029a9a11122d09fa093f65a8b7823c3d64fdfa5a5
+    tag: "" # Pinned at build time by helm_images_values
     pullPolicy: Always
   tracing:
     serviceName: "oci-model-cache-operator"
@@ -27,18 +27,7 @@ hfToken:
   onepassword:
     itemPath: "vaults/k8s-homelab/items/oci-model-cache"
 imageUpdater:
-  enabled: true
-  images:
-    - alias: operator
-      imageName: ghcr.io/jomcgi/homelab/projects/operators/oci-model-cache:main
-      helm:
-        name: controllerManager.image.repository
-        tag: controllerManager.image.tag
-  writeBack:
-    method: git:secret:argocd/argocd-image-updater-token
-    repository: https://github.com/jomcgi/homelab.git
-    branch: main
-    target: helmvalues:projects/operators/oci-model-cache/deploy/values.yaml
+  enabled: false
 extraResources:
   - apiVersion: onepassword.com/v1
     kind: OnePasswordItem

--- a/projects/operators/oci-model-cache/helm/oci-model-cache-operator/BUILD
+++ b/projects/operators/oci-model-cache/helm/oci-model-cache-operator/BUILD
@@ -2,6 +2,9 @@ load("//bazel/helm:defs.bzl", "helm_chart")
 
 helm_chart(
     name = "chart",
+    images = {
+        "controllerManager.image": "//projects/operators/oci-model-cache:image.info",
+    },
     publish = True,
     visibility = ["//overlays:__subpackages__"],
 )

--- a/projects/operators/oci-model-cache/helm/oci-model-cache-operator/Chart.yaml
+++ b/projects/operators/oci-model-cache/helm/oci-model-cache-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: oci-model-cache-operator
 description: A Helm chart for the OCI Model Cache Operator - caches HuggingFace models as OCI artifacts
 type: application
-version: 0.1.1
+version: 0.1.2
 appVersion: "latest"
 keywords:
   - oci


### PR DESCRIPTION
## Summary

- **marine-ingest CrashLoopBackOff**: Add `/bin/bash -> /usr/bin/bash` symlink layer to `py3_image.bzl`. Wolfi puts bash at `/usr/bin/bash` but `py_venv_binary` shebangs expect `/bin/bash`, causing instant startup crashes with zero logs. Fixing in the macro prevents this for all Python services.
- **oci-model-cache-operator ImagePullBackOff (4 days)**: Wire up `helm_images_values` in the chart BUILD so Bazel pins image digests at build time. Remove the stale hardcoded `@sha256:` digest and disable ArgoCD Image Updater (Bazel now owns pinning). Switch `application.yaml` to OCI multi-source pattern.

## Changes

| File | Change |
|------|--------|
| `bazel/tools/oci/py3_image.bzl` | Add bash symlink tar layer to all Python images |
| `projects/operators/oci-model-cache/helm/.../BUILD` | Add `images` param to `helm_chart` |
| `projects/operators/oci-model-cache/helm/.../Chart.yaml` | Bump version 0.1.1 → 0.1.2 |
| `projects/operators/oci-model-cache/deploy/values.yaml` | Remove stale digest, disable Image Updater |
| `projects/operators/oci-model-cache/deploy/application.yaml` | Switch to OCI multi-source with `targetRevision: 0.1.2` |

## Test plan

- [ ] CI passes (Bazel builds, semgrep, format check)
- [ ] After merge, verify marine-ingest pod starts successfully (no CrashLoopBackOff)
- [ ] After merge, verify oci-model-cache-operator pod exits ImagePullBackOff
- [ ] Confirm both ArgoCD apps transition from Degraded to Healthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)