### PR TITLE
chore(marine): bump chart version to 0.3.3

### DIFF
--- a/projects/ships/chart/Chart.yaml
+++ b/projects/ships/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: marine
 description: Marine services - AIS vessel tracking and API
 type: application
-version: 0.3.2
+version: 0.3.3
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/ships/deploy/application.yaml
+++ b/projects/ships/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: marine
-      targetRevision: 0.3.2
+      targetRevision: 0.3.3
       helm:
         releaseName: marine
         valueFiles:


### PR DESCRIPTION
## Summary

- Bump marine chart version 0.3.2 → 0.3.3 and update `targetRevision` in `application.yaml`
- Triggers CI to rebuild the ingest image with the `/bin/bash` symlink fix from `py3_image.bzl` (merged in #1434) and publish it as a new OCI chart

## Context

The marine-ingest pod is in CrashLoopBackOff because the current image (chart 0.3.2) lacks `/bin/bash`, which `py_venv_binary` shebangs require. The fix landed in `py3_image.bzl` but needs a chart version bump to trigger a new OCI chart publish.

## Test plan

- [ ] CI builds and pushes chart 0.3.3 to OCI registry
- [ ] ArgoCD picks up new `targetRevision: 0.3.3`
- [ ] marine-ingest pod starts successfully (no CrashLoopBackOff)
- [ ] Marine app transitions from Degraded to Healthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)