### PR TITLE
perf(ci): enable remote caching for Tar operations

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -42,18 +42,6 @@ build:ci --disk_cache=
 # CI: Use default repository cache location (ephemeral per-runner)
 # Longhorn RWX volumes have I/O errors, BuildBuddy handles remote caching
 
-# =============================================================================
-# Remote Cache Control - Handle large artifacts
-# =============================================================================
-# Disable remote caching for ALL Tar operations in CI builds (--config=ci)
-# This prevents BuildBuddy cache eviction failures caused by large ML model
-# tarballs (5GB+ weight files) that exceed cache retention limits.
-#
-# Trade-off: ALL pkg_tar operations skip remote cache in CI, not just large
-# models. However, small tarballs build quickly enough that the performance
-# impact is negligible. Local (non-CI) builds still benefit from Tar caching.
-build:ci --modify_execution_info=Tar=+no-remote-cache
-
 # rules_python is working to enable this default to avoid dependency on a system interpreter
 # See https://github.com/bazel-contrib/rules_python/issues/3187
 # NB: some tools run py_binary targets even if the user didn't select to add Python to their project


### PR DESCRIPTION
## Summary
- Remove `--modify_execution_info=Tar=+no-remote-cache` from CI config
- This was originally added to prevent BuildBuddy cache eviction from large ML model tarballs (5GB+), but ML images are now built separately by the operator
- All remaining `pkg_tar` operations are small application layers that will now benefit from remote cache hits

## Test plan
- [ ] CI passes (format + tests)
- [ ] Verify BuildBuddy invocation shows Tar cache hits on subsequent runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)