### PR TITLE
fix(cluster-agents): bump chart to 0.5.4 to resolve stale image digest

### DIFF
--- a/projects/agent_platform/cluster_agents/deploy/Chart.yaml
+++ b/projects/agent_platform/cluster_agents/deploy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cluster-agents
 description: Autonomous cluster monitoring agents
 type: application
-version: 0.5.3
+version: 0.5.4
 appVersion: "0.2.0"
 annotations:
   org.opencontainers.image.source: "https://github.com/jomcgi/homelab"

--- a/projects/agent_platform/cluster_agents/deploy/application.yaml
+++ b/projects/agent_platform/cluster_agents/deploy/application.yaml
@@ -8,7 +8,7 @@ spec:
   source:
     repoURL: ghcr.io/jomcgi/homelab/charts
     chart: cluster-agents
-    targetRevision: 0.5.3
+    targetRevision: 0.5.4
     helm:
       releaseName: cluster-agents
       valuesObject:


### PR DESCRIPTION
## Summary

- Bumps `cluster-agents` Helm chart version from `0.5.3` → `0.5.4` in both `Chart.yaml` and `application.yaml` (`targetRevision`)
- Fixes the `cluster-agents Unreachable` alert (rule `019cda4d-9837-76b0-b625-0149055459fa`) by forcing CI to publish a fresh OCI chart with the current image digest
- The `/health` endpoint has no dependency checks and always returns HTTP 200 if the pod is running — the alert firing is conclusive evidence the pod was down

## Root Cause

The `helm_chart` Bazel rule bakes the container image digest into the OCI chart at publish time. When CI rebuilds the image on `main`, the image tag `main` moves to a new digest. If the OCI chart registry treats version tags as immutable (or the old `0.5.3` chart was cached), ArgoCD kept deploying the stale chart referencing the old, now-deleted digest — causing `ImagePullBackOff`.

Bumping the chart version to `0.5.4` forces:
1. CI to publish a brand-new OCI chart (`ghcr.io/jomcgi/homelab/charts/cluster-agents:0.5.4`) with the latest image digest baked in
2. ArgoCD to pull and reconcile the new chart version, resolving the `ImagePullBackOff`

## Test plan

- [ ] CI (`bazel test //...`) passes on this PR
- [ ] CI on merge publishes `cluster-agents` chart as `0.5.4` to GHCR
- [ ] ArgoCD syncs `cluster-agents` application and pod reaches `Running` state
- [ ] `cluster-agents Unreachable` alert stops firing

🤖 Generated with [Claude Code](https://claude.com/claude-code)