### PR TITLE
chore(obsidian-vault): bump chart version to 0.4.4

### DIFF
--- a/projects/obsidian_vault/chart/Chart.yaml
+++ b/projects/obsidian_vault/chart/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: obsidian-vault
 description: Obsidian vault sync with git audit trail and MCP server
 type: application
-version: 0.4.3
+version: 0.4.4
 appVersion: "0.1.0"

--- a/projects/obsidian_vault/deploy/application.yaml
+++ b/projects/obsidian_vault/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: obsidian-vault
-      targetRevision: 0.4.3
+      targetRevision: 0.4.4
       helm:
         releaseName: obsidian-vault
         valueFiles:


### PR DESCRIPTION
## Summary
- Bumps obsidian-vault chart version 0.4.3 → 0.4.4
- Triggers chart rebuild with new image containing the `/healthz` endpoint
- Resolves CrashLoopBackOff caused by failed liveness probes (404 on `/healthz`)

## Context
PRs #1436, #1440, #1441 fixed the vault-mcp container image (apko base, bash_symlink, /healthz), but the chart at 0.4.3 still pins the old image without `/healthz`. This bump will rebuild the chart with the latest image digest.

## Test plan
- [ ] CI passes (chart builds, tests pass)
- [ ] After merge, verify obsidian-vault pod reaches 3/3 Ready

🤖 Generated with [Claude Code](https://claude.com/claude-code)