### PR TITLE
build(semgrep): add no-ebpf-otel-annotations rule

### DIFF
--- a/bazel/semgrep/rules/yaml/no-ebpf-otel-annotations.yaml
+++ b/bazel/semgrep/rules/yaml/no-ebpf-otel-annotations.yaml
@@ -1,0 +1,13 @@
+rules:
+  - id: no-ebpf-otel-annotations
+    languages: [yaml]
+    severity: WARNING
+    message: >-
+      eBPF-based OpenTelemetry auto-instrumentation is not supported in this
+      cluster. The `instrumentation.opentelemetry.io/inject-*` annotations
+      silently add init containers that can crash or hang pods at startup. Use
+      manual OTel SDK instrumentation instead — import the SDK directly in your
+      application code and configure it via environment variables.
+    metadata:
+      category: correctness
+    pattern-regex: 'instrumentation\.opentelemetry\.io/inject-\w+'

--- a/bazel/semgrep/tests/fixtures/no-ebpf-otel-annotations.yaml
+++ b/bazel/semgrep/tests/fixtures/no-ebpf-otel-annotations.yaml
@@ -1,0 +1,52 @@
+# Tests for no-ebpf-otel-annotations rule.
+# eBPF-based OTel auto-instrumentation annotations are not supported in this cluster —
+# inject-* annotations add init containers that can crash or hang pods.
+---
+# ok: no-ebpf-otel-annotations
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ok-deployment
+  annotations:
+    app.kubernetes.io/name: my-service
+spec:
+  template:
+    metadata:
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8080"
+    spec:
+      containers:
+        - name: app
+          image: myapp:latest
+
+---
+# ruleid: no-ebpf-otel-annotations
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: bad-go-deployment
+spec:
+  template:
+    metadata:
+      annotations:
+        instrumentation.opentelemetry.io/inject-go: "go"
+    spec:
+      containers:
+        - name: app
+          image: myapp:latest
+
+---
+# ruleid: no-ebpf-otel-annotations
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: bad-python-deployment
+  annotations:
+    instrumentation.opentelemetry.io/inject-python: "true"
+spec:
+  template:
+    spec:
+      containers:
+        - name: app
+          image: myapp:latest


### PR DESCRIPTION
## Summary

- Adds `bazel/semgrep/rules/yaml/no-ebpf-otel-annotations.yaml`: a semgrep rule using `pattern-regex` to catch `instrumentation.opentelemetry.io/inject-*` annotations in YAML files
- Adds `bazel/semgrep/tests/fixtures/no-ebpf-otel-annotations.yaml`: test fixture with one `ok:` case and two `ruleid:` cases (inject-go in podAnnotations, inject-python in metadata.annotations)
- Identified from PR #1446 where these eBPF annotations had to be removed due to init containers crashing/hanging pods

## Test plan

- [ ] CI runs `bazel test //bazel/semgrep/rules:yaml_rules_test` and passes with the new rule and fixture
- [ ] Rule fires on `instrumentation.opentelemetry.io/inject-go` and `inject-python` annotations
- [ ] Rule does not fire on normal (non-OTel-inject) annotations

🤖 Generated with [Claude Code](https://claude.com/claude-code)