### PR TITLE
build(semgrep): add no-empty-1password-itempath rule

### DIFF
--- a/bazel/semgrep/rules/yaml/no-empty-1password-itempath.yaml
+++ b/bazel/semgrep/rules/yaml/no-empty-1password-itempath.yaml
@@ -1,0 +1,19 @@
+rules:
+  - id: no-empty-1password-itempath
+    languages: [yaml]
+    severity: WARNING
+    message: >-
+      Empty `itemPath` on a 1Password Operator secret reference. An empty
+      `itemPath` means the 1Password Operator will never fetch the secret —
+      the resulting Kubernetes Secret will be empty or stale. If a
+      OnePasswordItem reference is declared, `itemPath` must point to a valid
+      vault item (e.g. `vaults/k8s-homelab/items/my-secret`). Remove the
+      secret block entirely if not needed, or fill in the correct path.
+    metadata:
+      category: correctness
+    paths:
+      include:
+        - "**/deploy/values.yaml"
+        - "**/deploy/values.*.yaml"
+    pattern-regex: |-
+      itemPath:\s*["']?["']?\s*$

--- a/bazel/semgrep/tests/fixtures/no-empty-1password-itempath.yaml
+++ b/bazel/semgrep/tests/fixtures/no-empty-1password-itempath.yaml
@@ -1,0 +1,20 @@
+# Tests for no-empty-1password-itempath rule.
+---
+# ok: no-empty-1password-itempath — filled itemPath is valid
+onepassword:
+  itemPath: "vaults/k8s-homelab/items/my-secret"
+
+---
+# ruleid: no-empty-1password-itempath
+onepassword:
+  itemPath: ""
+
+---
+# ruleid: no-empty-1password-itempath
+onepassword:
+  itemPath: ''
+
+---
+# ruleid: no-empty-1password-itempath
+onepassword:
+  itemPath:


### PR DESCRIPTION
## Summary

- Adds a new semgrep rule `no-empty-1password-itempath` that detects empty `itemPath` fields in 1Password Operator secret references within deploy values files
- An empty `itemPath` causes the 1Password Operator to never fetch the secret, resulting in an empty or stale Kubernetes Secret
- Scoped to `**/deploy/values.yaml` and `**/deploy/values.*.yaml` to avoid false positives in other YAML files

## Test plan

- [ ] CI semgrep tests pass against the new fixture (`bazel/semgrep/tests/fixtures/no-empty-1password-itempath.yaml`)
- [ ] Rule correctly flags `itemPath: ""`, `itemPath: ''`, and bare `itemPath:` (no value)
- [ ] Rule does not flag `itemPath: "vaults/k8s-homelab/items/my-secret"` (valid path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)