### PR TITLE
docs(agent_platform): fix README inaccuracies

### DIFF
--- a/projects/agent_platform/mcp_servers/README.md
+++ b/projects/agent_platform/mcp_servers/README.md
@@ -75,7 +75,7 @@ For third-party images (e.g., `docker.io/signoz/signoz-mcp-server`), skip the im
 ### 4. Render and verify
 
 ```bash
-helm template agent-platform-mcp-servers projects/agent_platform/mcp_servers/ \
+helm template agent-platform-mcp-servers projects/agent_platform/chart/mcp-servers/ \
   -f projects/agent_platform/deploy/values.yaml
 ```
 


### PR DESCRIPTION
## Summary

- Fix `helm template` path in `mcp_servers/README.md`: was pointing to `projects/agent_platform/mcp_servers/` (the Python source directory), now correctly points to `projects/agent_platform/chart/mcp-servers/` where the Helm chart lives.

## Test plan

- [x] Verified `projects/agent_platform/chart/mcp-servers/` exists and contains `Chart.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)