### PR TITLE
docs(hikes): fix README inaccuracies

### DIFF
--- a/projects/hikes/README.md
+++ b/projects/hikes/README.md
@@ -66,7 +66,7 @@ bazel run //projects/hikes/update_forecast:update
 
 # Run frontend Playwright tests
 cd projects/hikes/frontend
-pnpm test
+npm test
 ```
 
 ## Configuration


### PR DESCRIPTION
## Summary

- Replace `pnpm test` with `npm test` in `hikes/README.md`: the frontend uses npm (has `package-lock.json`, no `pnpm-lock.yaml`).

## Test plan

- [x] Confirmed `projects/hikes/frontend/package-lock.json` exists (npm) and no `pnpm-lock.yaml`
- [x] `package.json` `scripts.test` is a standard npm-compatible script

🤖 Generated with [Claude Code](https://claude.com/claude-code)