### PR TITLE
docs(trips): fix README inaccuracies

### DIFF
--- a/projects/trips/frontend/README.md
+++ b/projects/trips/frontend/README.md
@@ -26,7 +26,7 @@ pnpm install
 pnpm dev
 ```
 
-The app connects to the trips API (`trips.jomcgi.dev/api`) for photo and route data.
+The app connects to the trips API (`api.jomcgi.dev/trips`) for photo and route data.
 
 ## Deployment
 


### PR DESCRIPTION
## Summary

- Correct the API URL in `trips/frontend/README.md` from `trips.jomcgi.dev/api` to `api.jomcgi.dev/trips`, matching the actual base URL in `src/constants/api.js`.

## Test plan

- [x] Confirmed `src/constants/api.js` uses `https://api.jomcgi.dev/trips` as the API base URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)