### PR TITLE
docs(platform): fix README inaccuracies

### DIFF
--- a/projects/platform/argocd/README.md
+++ b/projects/platform/argocd/README.md
@@ -34,4 +34,4 @@ projects/home-cluster/kustomization.yaml (auto-generated)
   → projects/{service}/deploy/application.yaml
 ```
 
-Each `application.yaml` points to its colocated Helm chart in `projects/{service}/chart/`.
+Each `application.yaml` points to either a colocated Helm chart in `projects/{service}/chart/` or an upstream chart from an OCI/Helm registry.

--- a/projects/platform/kyverno/README.md
+++ b/projects/platform/kyverno/README.md
@@ -4,7 +4,7 @@ Policy engine for Kubernetes with custom ClusterPolicies for automated observabi
 
 ## Overview
 
-Kyverno acts as a Kubernetes admission controller that mutates resources to enforce cluster-wide conventions. This chart wraps the upstream Kyverno chart and adds two custom ClusterPolicies that automatically inject OpenTelemetry configuration and Linkerd service mesh annotations into all workloads.
+Kyverno acts as a Kubernetes admission controller that mutates resources to enforce cluster-wide conventions. This chart wraps the upstream Kyverno chart and adds three custom ClusterPolicies that automatically inject OpenTelemetry configuration, Linkerd service mesh annotations, and disable Linkerd injection on Jobs.
 
 ```mermaid
 flowchart LR
@@ -23,7 +23,7 @@ flowchart LR
 
 ## Architecture
 
-The chart deploys four Kyverno controllers plus two custom ClusterPolicies:
+The chart deploys four Kyverno controllers plus three custom ClusterPolicies:
 
 - **Admission Controller** - Intercepts API server requests to mutate and validate resources against policies
 - **Background Controller** - Applies policies retroactively to existing resources (not just new ones)
@@ -34,6 +34,7 @@ Custom policies included:
 
 - **OTel Injection** (`inject-otel-env-vars`) - Mutates Deployments, StatefulSets, and DaemonSets to inject `OTEL_EXPORTER_OTLP_ENDPOINT` and `OTEL_EXPORTER_OTLP_PROTOCOL` environment variables
 - **Linkerd Injection** (`inject-linkerd-namespace-annotation`) - Mutates Namespaces to add `linkerd.io/inject: enabled` annotation for automatic sidecar injection
+- **Linkerd Jobs Disable** (`disable-linkerd-on-jobs`) - Annotates Job pods with `linkerd.io/inject: disabled` to prevent the sidecar from blocking Job completion
 
 ## Key Features
 

--- a/projects/platform/linkerd/charts/linkerd-control-plane/README.md
+++ b/projects/platform/linkerd/charts/linkerd-control-plane/README.md
@@ -5,7 +5,7 @@ for your microservices — with no code change required.
 
 ![Version: 2025.11.1](https://img.shields.io/badge/Version-2025.11.1-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
-![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
+![AppVersion: edge-25.11.1](https://img.shields.io/badge/AppVersion-edge--25.11.1-informational?style=flat-square)
 
 **Homepage:** <https://linkerd.io>
 


### PR DESCRIPTION
## Summary

- **argocd/README.md**: Clarify that `application.yaml` may point to either a colocated `chart/` directory or an upstream OCI/Helm registry chart — the previous wording implied all services have a local `chart/` directory.
- **kyverno/README.md**: Document the third custom ClusterPolicy (`disable-linkerd-on-jobs`) that was omitted. Updated count from "two" to "three" in both the overview and architecture sections.
- **linkerd-control-plane/README.md**: Replace unsubstituted `edge-XX.X.X` AppVersion badge placeholder with the actual version `edge-25.11.1` from `Chart.yaml`.

## Test plan

- [x] Verified `projects/platform/kyverno/templates/linkerd-disable-jobs-policy.yaml` exists with `name: disable-linkerd-on-jobs`
- [x] Confirmed `Chart.yaml` `appVersion: edge-25.11.1`
- [x] ArgoCD itself uses upstream chart — no local `chart/` directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)