### PR TITLE
fix(cluster-agents): bump chart to 0.5.7 to resolve stale image digest

### DIFF
--- a/projects/agent_platform/cluster_agents/deploy/Chart.yaml
+++ b/projects/agent_platform/cluster_agents/deploy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cluster-agents
 description: Autonomous cluster monitoring agents
 type: application
-version: 0.5.6
+version: 0.5.7
 appVersion: "0.2.0"
 annotations:
   org.opencontainers.image.source: "https://github.com/jomcgi/homelab"

--- a/projects/agent_platform/cluster_agents/deploy/application.yaml
+++ b/projects/agent_platform/cluster_agents/deploy/application.yaml
@@ -8,7 +8,7 @@ spec:
   source:
     repoURL: ghcr.io/jomcgi/homelab/charts
     chart: cluster-agents
-    targetRevision: 0.5.6
+    targetRevision: 0.5.7
     helm:
       releaseName: cluster-agents
       valuesObject:


### PR DESCRIPTION
## Summary

- Bumps `cluster-agents` chart from `0.5.6` → `0.5.7` in both `Chart.yaml` and `application.yaml`
- Triggered by the `cluster-agents Unreachable` critical alert (SigNoz rule `019cda4d-9837-76b0-b625-0149055459fa`)
- Root cause: stale image digest baked into chart `0.5.6` caused `ImagePullBackOff`, leaving no healthy pod endpoints — the `/health` check fails at TCP level

## Root Cause

Every CI push to `main` stamps a new image digest. If the chart version hasn't changed, ArgoCD keeps using the old digest which becomes invalid, causing `ImagePullBackOff`. Bumping the chart version forces CI to rebuild and publish `0.5.7` with the current image digest.

## Test plan

- [ ] CI passes `bazel test //...`
- [ ] CI pushes chart `0.5.7` to OCI registry
- [ ] ArgoCD syncs `cluster-agents` to `0.5.7` and pod becomes `Running`/`Ready`
- [ ] SigNoz alert `cluster-agents Unreachable` auto-resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)