### PR TITLE
fix(cluster-agents): increase memory limits to prevent OOMKilled

### DIFF
--- a/projects/agent_platform/cluster_agents/deploy/Chart.yaml
+++ b/projects/agent_platform/cluster_agents/deploy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cluster-agents
 description: Autonomous cluster monitoring agents
 type: application
-version: 0.5.9
+version: 0.6.0
 appVersion: "0.2.0"
 annotations:
   org.opencontainers.image.source: "https://github.com/jomcgi/homelab"

--- a/projects/agent_platform/cluster_agents/deploy/application.yaml
+++ b/projects/agent_platform/cluster_agents/deploy/application.yaml
@@ -8,7 +8,7 @@ spec:
   source:
     repoURL: ghcr.io/jomcgi/homelab/charts
     chart: cluster-agents
-    targetRevision: 0.5.9
+    targetRevision: 0.6.0
     helm:
       releaseName: cluster-agents
       valuesObject:

--- a/projects/agent_platform/cluster_agents/deploy/values.yaml
+++ b/projects/agent_platform/cluster_agents/deploy/values.yaml
@@ -41,10 +41,10 @@ service:
 resources:
   requests:
     cpu: 10m
-    memory: 64Mi
+    memory: 128Mi
   limits:
     cpu: 200m
-    memory: 256Mi
+    memory: 512Mi
 
 config:
   signozUrl: "http://signoz.signoz.svc.cluster.local:8080"


### PR DESCRIPTION
## Summary

- Bumps memory **request** from `64Mi` → `128Mi` and **limit** from `256Mi` → `512Mi`
- The pod runs 5 concurrent agents (patrol, test-coverage, readme-freshness, rules, pr-fix) all making outbound GitHub and SigNoz API calls whose response payloads can exceed the previous 256Mi ceiling, causing OOMKilled → CrashLoopBackOff → service unreachable
- Bumps chart version `0.5.9` → `0.6.0` and syncs `targetRevision` in `application.yaml` (required: both must stay in sync per repo convention)

## Root Cause

Alert `019cda4d-9837-76b0-b625-0149055459fa` (cluster-agents Unreachable) fired because the pod was OOMKilled due to insufficient memory. With 5 concurrent agent goroutines each potentially holding large API response bodies in memory simultaneously, 256Mi is insufficient.

## Test plan

- [ ] CI passes `bazel test //...`
- [ ] ArgoCD deploys chart `0.6.0` to `cluster-agents` namespace
- [ ] Pod stays Running (no OOMKilled events in `kubectl describe pod`)
- [ ] `/health` returns 200 and SigNoz httpcheck alert resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)