### PR TITLE
fix(agent-platform): raise sandbox pod quota from 15 to 20

### DIFF
--- a/projects/agent_platform/deploy/values.yaml
+++ b/projects/agent_platform/deploy/values.yaml
@@ -193,6 +193,9 @@ agent-orchestrator:
 
 # ── Goose Sandboxes ─────────────────────────────────────────────────────────
 goose-sandboxes:
+  namespace:
+    resourceQuota:
+      pods: "20"
   sandboxTemplate:
     env:
       contextForgeUrl: "http://context-forge-gateway-mcp-stack-mcpgateway.mcp.svc.cluster.local:80/mcp"


### PR DESCRIPTION
## Summary

- Raises the sandbox namespace pod quota from **15 → 20** in the `goose-sandboxes` values override
- The previous limit caused sandbox scheduling failures under concurrent agent load (warm pool + active sandboxes + MCP server pods)
- This was a contributing factor to the `cluster-agents Unreachable` alert cascade: investigation sandboxes failed to schedule, masking the root OOMKill fix already merged in `750040c`

## Root Cause (from investigation)

The agent-platform sandbox namespace was capped at 15 pods. With:
- 1 warm pool sandbox
- 5+ MCP server pods (signoz-mcp, kubernetes-mcp, argocd-mcp, todo-mcp, agent-orchestrator-mcp)
- agent-orchestrator + NATS
- Any concurrent goose agent sandboxes

...the namespace hits quota quickly, causing `FailedScheduling` for new sandboxes. The orchestrator then surfaces those sandboxes as "unreachable" (DNS not resolving because the pod never started).

## Test plan

- [ ] CI passes `bazel test //...`
- [ ] ArgoCD syncs agent-platform (values come from Git HEAD — no chart version bump needed)
- [ ] New sandboxes schedule successfully when concurrent jobs run
- [ ] `cluster-agents Unreachable` alert does not re-fire

🤖 Generated with [Claude Code](https://claude.com/claude-code)