### PR TITLE
fix(cluster-agents): bump chart to 0.6.2 to refresh stale image digest

### DIFF
--- a/projects/agent_platform/cluster_agents/deploy/Chart.yaml
+++ b/projects/agent_platform/cluster_agents/deploy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cluster-agents
 description: Autonomous cluster monitoring agents
 type: application
-version: 0.6.1
+version: 0.6.2
 appVersion: "0.2.0"
 annotations:
   org.opencontainers.image.source: "https://github.com/jomcgi/homelab"

--- a/projects/agent_platform/cluster_agents/deploy/application.yaml
+++ b/projects/agent_platform/cluster_agents/deploy/application.yaml
@@ -8,7 +8,7 @@ spec:
   source:
     repoURL: ghcr.io/jomcgi/homelab/charts
     chart: cluster-agents
-    targetRevision: 0.6.1
+    targetRevision: 0.6.2
     helm:
       releaseName: cluster-agents
       valuesObject:


### PR DESCRIPTION
## Summary

- **Alert:** \`cluster-agents Unreachable\` (SigNoz rule \`019cda4d-9837-76b0-b625-0149055459fa\`)
- **Root cause:** Bazel CI pins the container image digest into the Helm chart via \`helm_images_values\` at publish time. If the cluster-agents image was rebuilt on main after chart \`0.6.1\` was published, ArgoCD continues pulling the old chart with the stale pinned digest, causing \`ImagePullBackOff\` and a completely down pod.
- **Fix:** Bump \`Chart.yaml\` version → \`0.6.2\` and \`application.yaml\` targetRevision → \`0.6.2\` in sync. CI will rebuild and republish the chart with the current image digest; ArgoCD will pull the new chart and deploy successfully.

## Test plan

- [ ] CI (\`bazel test //...\`) passes
- [ ] CI publishes new chart \`cluster-agents:0.6.2\` to GHCR with the current image digest pinned
- [ ] ArgoCD syncs \`cluster-agents\` application to chart \`0.6.2\`
- [ ] Pod enters \`Running\` state in the \`cluster-agents\` namespace
- [ ] SigNoz \`cluster-agents Unreachable\` alert resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)