### PR TITLE
build(semgrep): add require-fsgroup-with-pvc rule

### DIFF
--- a/bazel/semgrep/rules/kubernetes/require-fsgroup-with-pvc.yaml
+++ b/bazel/semgrep/rules/kubernetes/require-fsgroup-with-pvc.yaml
@@ -1,0 +1,33 @@
+rules:
+  - id: require-fsgroup-with-pvc
+    patterns:
+      - pattern: |
+          volumes:
+            - name: $VOLUME
+              persistentVolumeClaim:
+                ...
+      - pattern-not: |
+          securityContext:
+            ...
+            fsGroup: ...
+    message: >
+      A `persistentVolumeClaim` volume is defined but `podSecurityContext.fsGroup`
+      is not set. Non-root containers (uid 65532) cannot write to a PVC without
+      `fsGroup: 65532` in `spec.template.spec.securityContext`. Without it, the
+      volume is owned by root and the container will fail with a permission denied
+      error. Add `fsGroup: 65532` to your `podSecurityContext` values.
+    languages: [yaml]
+    severity: ERROR
+    metadata:
+      category: correctness
+      subcategory: kubernetes
+      confidence: HIGH
+      likelihood: HIGH
+      impact: HIGH
+      technology: [kubernetes]
+      description: >
+        Helm chart templates with PVC volumes must set podSecurityContext.fsGroup
+        so non-root containers (uid 65532) can write to the volume
+    paths:
+      include:
+        - "**/chart/templates/**"

--- a/bazel/semgrep/tests/fixtures/require-fsgroup-with-pvc.yaml
+++ b/bazel/semgrep/tests/fixtures/require-fsgroup-with-pvc.yaml
@@ -1,0 +1,92 @@
+# Tests for require-fsgroup-with-pvc rule.
+---
+# ok: PVC volume with fsGroup set in podSecurityContext
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ok-with-fsgroup
+spec:
+  template:
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        fsGroup: 65532
+      containers:
+        - name: app
+          image: myapp:latest
+          resources:
+            limits:
+              memory: "256Mi"
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: my-pvc
+
+---
+# ok: no PVC volume, no fsGroup needed
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ok-no-pvc
+spec:
+  template:
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+      containers:
+        - name: app
+          image: myapp:latest
+          resources:
+            limits:
+              memory: "256Mi"
+      volumes:
+        - name: config
+          configMap:
+            name: my-config
+
+---
+# ruleid: require-fsgroup-with-pvc
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: bad-pvc-no-fsgroup
+spec:
+  template:
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        # fsGroup missing — non-root container cannot write to PVC
+      containers:
+        - name: app
+          image: myapp:latest
+          resources:
+            limits:
+              memory: "256Mi"
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: my-pvc
+
+---
+# ruleid: require-fsgroup-with-pvc
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: bad-pvc-no-security-context
+spec:
+  template:
+    spec:
+      # no securityContext at all
+      containers:
+        - name: app
+          image: myapp:latest
+          resources:
+            limits:
+              memory: "256Mi"
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: my-pvc


### PR DESCRIPTION
## Summary

- Adds `bazel/semgrep/rules/kubernetes/require-fsgroup-with-pvc.yaml` — flags Helm chart templates with PVC volumes that are missing `fsGroup` in `podSecurityContext`
- Adds `bazel/semgrep/tests/fixtures/require-fsgroup-with-pvc.yaml` with `ok` and `ruleid` test cases

## Problem

PR #1430 root cause: non-root containers (uid 65532) cannot write to a PVC volume without `fsGroup: 65532` in `podSecurityContext`. The volume is owned by root and the container crashes with permission denied. No rule enforced this pattern — at least 4 services with PVC mounts (`obsidian_vault`, `oauth-proxy`, `stargazer` ×2, `todo_app`) are potentially affected.

## Test plan

- [ ] `bazel test //bazel/semgrep/...` passes
- [ ] The `bad-pvc-no-fsgroup` fixture case triggers the rule
- [ ] The `ok-with-fsgroup` fixture case is not flagged

🤖 Generated with [Claude Code](https://claude.com/claude-code)