### PR TITLE
test(hf2oci): add resolve command and copy edge case tests

### DIFF
--- a/bazel/tools/hf2oci/cmd/hf2oci/cmd/BUILD
+++ b/bazel/tools/hf2oci/cmd/hf2oci/cmd/BUILD
@@ -22,10 +22,12 @@ go_test(
     srcs = [
         "copy_test.go",
         "output_test.go",
+        "resolve_test.go",
     ],
     embed = [":cmd"],
     deps = [
         "//bazel/tools/hf2oci/pkg/copy",
+        "@com_github_spf13_cobra//:cobra",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
     ],

--- a/bazel/tools/hf2oci/cmd/hf2oci/cmd/copy_test.go
+++ b/bazel/tools/hf2oci/cmd/hf2oci/cmd/copy_test.go
@@ -2,6 +2,10 @@ package cmd
 
 import (
 	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestParseByteSize(t *testing.T) {
@@ -48,6 +52,20 @@ func TestParseByteSize(t *testing.T) {
 		{input: "-1G", wantErr: true},
 		// Fractional sizes cannot be parsed (ParseInt does not support floats)
 		{input: "4.5G", wantErr: true},
+
+		// Zero with a suffix — treated as 0 * multiplier = 0 (not the "0" fast path)
+		{input: "0K", want: 0},
+		{input: "0M", want: 0},
+		{input: "0G", want: 0},
+
+		// Terabyte and above are not recognised — suffix falls through to ParseInt
+		// which fails because "T" is not a valid digit sequence.
+		{input: "1T", wantErr: true},
+		{input: "1TB", wantErr: true},
+		{input: "1TiB", wantErr: true},
+
+		// Whitespace-only string is an error
+		{input: "   ", wantErr: true},
 	}
 
 	for _, tt := range tests {
@@ -68,4 +86,119 @@ func TestParseByteSize(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestCopyCmdArgsValidation verifies that copyCmd enforces exactly one
+// positional argument via cobra.ExactArgs(1).
+func TestCopyCmdArgsValidation(t *testing.T) {
+	argsValidator := copyCmd.Args
+	require.NotNil(t, argsValidator, "copyCmd.Args should be set")
+
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr bool
+	}{
+		{name: "no args", args: []string{}, wantErr: true},
+		{name: "two args", args: []string{"Org/Repo", "extra"}, wantErr: true},
+		{name: "one arg (valid)", args: []string{"Org/Repo"}, wantErr: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := argsValidator(copyCmd, tt.args)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+// TestCopyCmdFlagDefaults verifies the default values for all copy flags.
+func TestCopyCmdFlagDefaults(t *testing.T) {
+	flags := copyCmd.Flags()
+
+	revision, err := flags.GetString("revision")
+	require.NoError(t, err)
+	assert.Equal(t, "main", revision, "revision should default to 'main'")
+
+	maxShard, err := flags.GetString("max-shard-size")
+	require.NoError(t, err)
+	assert.Equal(t, "500M", maxShard, "max-shard-size should default to '500M'")
+
+	maxParallel, err := flags.GetInt("max-parallel")
+	require.NoError(t, err)
+	assert.Equal(t, 0, maxParallel, "max-parallel should default to 0 (auto)")
+
+	dryRun, err := flags.GetBool("dry-run")
+	require.NoError(t, err)
+	assert.False(t, dryRun, "dry-run should default to false")
+
+	registry, err := flags.GetString("registry")
+	require.NoError(t, err)
+	assert.Equal(t, "", registry)
+
+	tag, err := flags.GetString("tag")
+	require.NoError(t, err)
+	assert.Equal(t, "", tag)
+
+	modelDir, err := flags.GetString("model-dir")
+	require.NoError(t, err)
+	assert.Equal(t, "", modelDir)
+
+	file, err := flags.GetString("file")
+	require.NoError(t, err)
+	assert.Equal(t, "", file)
+}
+
+// TestCopyCmdRegistryRequired verifies that --registry is marked required.
+func TestCopyCmdRegistryRequired(t *testing.T) {
+	registryFlag := copyCmd.Flags().Lookup("registry")
+	require.NotNil(t, registryFlag, "registry flag must exist")
+
+	annotations := registryFlag.Annotations
+	_, required := annotations[cobra.BashCompOneRequiredFlag]
+	assert.True(t, required, "registry flag must be marked required")
+}
+
+// TestRunCopyInvalidMaxShardSize verifies that runCopy returns an error for
+// invalid --max-shard-size before any network I/O is attempted.
+func TestRunCopyInvalidMaxShardSize(t *testing.T) {
+	origShardSize := copyMaxShardSize
+	origFormat := outputFormat
+	defer func() {
+		copyMaxShardSize = origShardSize
+		outputFormat = origFormat
+	}()
+
+	// Ensure output format is valid so the first failure is the shard size.
+	outputFormat = "text"
+	// "notabytes" cannot be parsed — parseByteSize must return an error and
+	// runCopy must propagate it without touching the network.
+	copyMaxShardSize = "notabytes"
+
+	err := runCopy(copyCmd, []string{"Org/Repo"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid --max-shard-size")
+}
+
+// TestRunCopyInvalidOutputFormat verifies that runCopy returns an error for
+// an unrecognised --output format before any network I/O is attempted.
+func TestRunCopyInvalidOutputFormat(t *testing.T) {
+	origFormat := outputFormat
+	origShardSize := copyMaxShardSize
+	defer func() {
+		outputFormat = origFormat
+		copyMaxShardSize = origShardSize
+	}()
+
+	// Reset shard size to a valid value so the first failure is the format check.
+	copyMaxShardSize = "500M"
+	outputFormat = "yaml" // not "text" or "json"
+
+	err := runCopy(copyCmd, []string{"Org/Repo"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid --output")
 }

--- a/bazel/tools/hf2oci/cmd/hf2oci/cmd/resolve_test.go
+++ b/bazel/tools/hf2oci/cmd/hf2oci/cmd/resolve_test.go
@@ -1,0 +1,151 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestResolveCmdArgsValidation verifies that resolveCmd enforces exactly one
+// positional argument via cobra.ExactArgs(1).
+func TestResolveCmdArgsValidation(t *testing.T) {
+	argsValidator := resolveCmd.Args
+	require.NotNil(t, argsValidator, "resolveCmd.Args should be set")
+
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr bool
+	}{
+		{name: "no args", args: []string{}, wantErr: true},
+		{name: "two args", args: []string{"Org/Repo", "extra"}, wantErr: true},
+		{name: "three args", args: []string{"Org/Repo", "extra1", "extra2"}, wantErr: true},
+		{name: "one arg (valid)", args: []string{"Org/Repo"}, wantErr: false},
+		{name: "one arg with slash", args: []string{"NousResearch/Hermes-4.3-Llama-3-36B-AWQ"}, wantErr: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := argsValidator(resolveCmd, tt.args)
+			if tt.wantErr {
+				assert.Error(t, err, "expected argument validation error")
+			} else {
+				assert.NoError(t, err, "expected no argument validation error")
+			}
+		})
+	}
+}
+
+// TestResolveCmdFlagDefaults verifies the default values for all flags.
+func TestResolveCmdFlagDefaults(t *testing.T) {
+	flags := resolveCmd.Flags()
+
+	revision, err := flags.GetString("revision")
+	require.NoError(t, err)
+	assert.Equal(t, "main", revision, "revision should default to 'main'")
+
+	registry, err := flags.GetString("registry")
+	require.NoError(t, err)
+	assert.Equal(t, "", registry, "registry should default to empty string")
+
+	tag, err := flags.GetString("tag")
+	require.NoError(t, err)
+	assert.Equal(t, "", tag, "tag should default to empty string")
+}
+
+// TestResolveCmdRegistryRequired verifies that --registry is marked required.
+func TestResolveCmdRegistryRequired(t *testing.T) {
+	registryFlag := resolveCmd.Flags().Lookup("registry")
+	require.NotNil(t, registryFlag, "registry flag must exist")
+
+	annotations := registryFlag.Annotations
+	_, required := annotations[cobra.BashCompOneRequiredFlag]
+	assert.True(t, required, "registry flag must be marked required")
+}
+
+// TestResolveCmdHasOutputFlag verifies the resolve command inherits -o/--output
+// from the root persistent flags.
+func TestResolveCmdHasOutputFlag(t *testing.T) {
+	// The output flag is a persistent flag on rootCmd, so it appears on all
+	// subcommands via InheritedFlags.
+	f := resolveCmd.InheritedFlags().Lookup("output")
+	require.NotNil(t, f, "output flag must be inherited from root")
+	assert.Equal(t, "text", f.DefValue, "output flag should default to 'text'")
+}
+
+// TestValidateOutputFormatAllValues covers all branches of validateOutputFormat.
+func TestValidateOutputFormatAllValues(t *testing.T) {
+	origFormat := outputFormat
+	origFile := outputFile
+	defer func() {
+		outputFormat = origFormat
+		outputFile = origFile
+	}()
+
+	tests := []struct {
+		name    string
+		format  string
+		file    string
+		wantErr string
+	}{
+		{
+			name:   "text format is valid",
+			format: "text",
+			file:   "",
+		},
+		{
+			name:   "json format is valid",
+			format: "json",
+			file:   "",
+		},
+		{
+			name:    "unknown format returns error",
+			format:  "xml",
+			wantErr: `invalid --output "xml"`,
+		},
+		{
+			name:    "empty format returns error",
+			format:  "",
+			wantErr: `invalid --output ""`,
+		},
+		{
+			name:    "output-file without json returns error",
+			format:  "text",
+			file:    "/tmp/result.json",
+			wantErr: "--output-file requires --output json",
+		},
+		{
+			name:   "output-file with json and existing dir is valid",
+			format: "json",
+			file:   "/tmp/result.json",
+		},
+		{
+			name:   "termination-log path is allowed without dir check",
+			format: "json",
+			file:   "/dev/termination-log",
+		},
+		{
+			name:    "output-file with non-existent dir returns error",
+			format:  "json",
+			file:    "/nonexistent-dir/result.json",
+			wantErr: `output file directory "/nonexistent-dir"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			outputFormat = tt.format
+			outputFile = tt.file
+
+			err := validateOutputFormat()
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `cmd/hf2oci/cmd/resolve_test.go` (new): tests `ExactArgs(1)` validation, default flag values, required `--registry` annotation, inherited `--output` flag, and all branches of `validateOutputFormat`
- Extends `cmd/hf2oci/cmd/copy_test.go`: edge cases for `parseByteSize` (zero-with-suffix, unrecognised TB/T/TiB suffixes, whitespace-only); copy command arg count validation; flag defaults and required `--registry` annotation; `runCopy` early-exit paths for invalid `--max-shard-size` and invalid `--output` format
- Updates `cmd/hf2oci/cmd/BUILD`: adds `resolve_test.go` to srcs and `@com_github_spf13_cobra//:cobra` dependency

All new tests avoid network I/O — they exercise only the pre-flight validation paths.

## Test plan

- [ ] `bazel test //bazel/tools/hf2oci/cmd/hf2oci/cmd:cmd_test` passes (runs in CI via BuildBuddy)
- [ ] No existing tests broken

🤖 Generated with [Claude Code](https://claude.com/claude-code)