### PR TITLE
fix(cluster-agents): skip Linkerd proxy on port 8080 for OTel health checks

### DIFF
--- a/projects/agent_platform/cluster_agents/deploy/Chart.yaml
+++ b/projects/agent_platform/cluster_agents/deploy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cluster-agents
 description: Autonomous cluster monitoring agents
 type: application
-version: 0.6.5
+version: 0.6.6
 appVersion: "0.2.0"
 annotations:
   org.opencontainers.image.source: "https://github.com/jomcgi/homelab"

--- a/projects/agent_platform/cluster_agents/deploy/application.yaml
+++ b/projects/agent_platform/cluster_agents/deploy/application.yaml
@@ -8,7 +8,7 @@ spec:
   source:
     repoURL: ghcr.io/jomcgi/homelab/charts
     chart: cluster-agents
-    targetRevision: 0.6.5
+    targetRevision: 0.6.6
     helm:
       releaseName: cluster-agents
       valuesObject:


### PR DESCRIPTION
## Summary

- The `cluster-agents` namespace has Linkerd proxy injection enabled (via Kyverno policy)
- The OTel synthetic httpcheck runs from the `signoz` namespace which is **not** in the Linkerd mesh
- The Linkerd proxy intercepts inbound connections from unmeshed clients and returns non-2xx responses, causing the `cluster-agents Unreachable` SigNoz alert to fire continuously since day 1 (2026-03-11)
- Add `config.linkerd.io/skip-inbound-ports: "8080"` to pod annotations so Linkerd bypasses the proxy on port 8080, allowing the OTel httpcheck to reach `/health` directly

K8s liveness/readiness probes were unaffected because Linkerd treats kubelet probe traffic specially — only the OTel synthetic check was failing.

Closes #1485

## Test plan

- [ ] CI passes (`bazel test //...`)
- [ ] ArgoCD syncs cluster-agents with the new annotation (pod restarts with updated annotations)
- [ ] SigNoz `cluster-agents Unreachable` alert stops firing after the pod is redeployed

🤖 Generated with [Claude Code](https://claude.com/claude-code)