### PR TITLE
fix(cluster-agents): update test to match default Linkerd annotation (chart 0.6.9)

### DIFF
--- a/projects/agent_platform/cluster_agents/deploy/Chart.yaml
+++ b/projects/agent_platform/cluster_agents/deploy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cluster-agents
 description: Autonomous cluster monitoring agents
 type: application
-version: 0.6.8
+version: 0.6.9
 appVersion: "0.2.0"
 annotations:
   org.opencontainers.image.source: "https://github.com/jomcgi/homelab"

--- a/projects/agent_platform/cluster_agents/deploy/application.yaml
+++ b/projects/agent_platform/cluster_agents/deploy/application.yaml
@@ -8,7 +8,7 @@ spec:
   source:
     repoURL: ghcr.io/jomcgi/homelab/charts
     chart: cluster-agents
-    targetRevision: 0.6.8
+    targetRevision: 0.6.9
     helm:
       releaseName: cluster-agents
       valuesObject:

--- a/projects/agent_platform/cluster_agents/deploy/tests/deployment_test.yaml
+++ b/projects/agent_platform/cluster_agents/deploy/tests/deployment_test.yaml
@@ -74,20 +74,12 @@ tests:
           path: spec.template.spec.containers[0].readinessProbe.httpGet.path
           value: /health
 
-  - it: should not set pod annotations by default
-    asserts:
-      - notExists:
-          path: spec.template.metadata.annotations
-
-  - it: should render Linkerd skip-inbound-ports annotation when configured
+  - it: should set Linkerd skip-inbound-ports annotation by default
     # Regression: cluster-agents namespace has Linkerd injection enabled (via Kyverno).
     # SigNoz OTel httpcheck runs from the signoz namespace (outside the mesh).
     # Without this annotation, Linkerd intercepts inbound port 8080 connections from
     # unmeshed clients and drops them, causing the health check alert to fire.
-    # This annotation tells proxy-init to bypass the proxy for port 8080.
-    set:
-      podAnnotations:
-        config.linkerd.io/skip-inbound-ports: "8080"
+    # This annotation is now set by default in values.yaml to ensure the fix is always active.
     asserts:
       - equal:
           path: spec.template.metadata.annotations["config.linkerd.io/skip-inbound-ports"]


### PR DESCRIPTION
## Summary

- Updates the helm-unittest test `"should not set pod annotations by default"` which was asserting `notExists: spec.template.metadata.annotations` — this broke after PR #1490 added the Linkerd `skip-inbound-ports` annotation as a default in `values.yaml`
- Replaces the stale test with `"should set Linkerd skip-inbound-ports annotation by default"` that verifies the annotation IS present (matching the actual default)
- Bumps chart version `0.6.8 → 0.6.9` and updates `application.yaml` `targetRevision` in sync

## Root Cause

PR #1490 fixed the `cluster-agents Unreachable` alert by adding `config.linkerd.io/skip-inbound-ports: "8080"` to `podAnnotations` in `values.yaml`. Linkerd's `proxy-init` was intercepting inbound plain-HTTP connections from the unmeshed `signoz` namespace and rejecting them (no mTLS), causing the OTel httpcheck to fail.

However, the deployment test was never updated to reflect the new default — `bazel test //...` now fails on chart `0.6.8`, blocking the chart from being published to GHCR and the fix from ever being deployed by ArgoCD.

## Test Plan

- [ ] `bazel test //projects/agent_platform/cluster_agents/deploy/...` passes
- [ ] CI passes (no more helm-unittest failures)
- [ ] ArgoCD syncs chart `0.6.9` and the Linkerd annotation is applied to the pod
- [ ] SigNoz `cluster-agents Unreachable` alert stops firing

🤖 Generated with [Claude Code](https://claude.com/claude-code)