### PR TITLE
fix(signoz): force otelDeployment rollout to activate cluster-agents httpcheck

### DIFF
--- a/projects/platform/signoz/values-prod.yaml
+++ b/projects/platform/signoz/values-prod.yaml
@@ -25,6 +25,11 @@ k8s-infra:
       limits:
         cpu: 500m
         memory: 400Mi
+    # Force pod rollout so the otelDeployment picks up config changes.
+    # OTel does not hot-reload its config — a pod restart is required.
+    # Update this value to trigger a new rollout when config changes land.
+    podAnnotations:
+      homelab/force-rollout: "2026-03-23"
     # Inject Cloudflare Access service token for Zero Trust bypass
     # Create a service token in Cloudflare Zero Trust dashboard:
     # Zero Trust > Access > Service Auth > Create Service Token


### PR DESCRIPTION
## Summary

- The `signoz-k8s-infra-otel-deployment` pod has been running since March 8 without restart, predating the addition of the cluster-agents httpcheck target to `values-prod.yaml`
- OTel does not hot-reload config — the pod must restart to pick up the httpcheck receiver config
- Without the httpcheck receiver running, `httpcheck.status` metrics for `cluster-agents` are never scraped, so SigNoz evaluates absent data as 0 and the **'cluster-agents Unreachable'** alert fires continuously

## Fix

Adds `podAnnotations.homelab/force-rollout: "2026-03-23"` to `otelDeployment` in `values-prod.yaml`. This changes the pod spec, causing ArgoCD to trigger a rolling restart of the deployment. After restart, the OTel pod loads the httpcheck receiver config and begins scraping `http://cluster-agents.cluster-agents.svc.cluster.local:8080/health` every 120s.

The `cluster-agents` chart already contains `config.linkerd.io/skip-inbound-ports: "8080"` in `podAnnotations` (added in chart 0.6.9) to allow plain-HTTP probes from the unmeshed SigNoz namespace.

## Test plan

- [ ] CI passes (`bazel test //...`)
- [ ] ArgoCD syncs `signoz` app and rolls out a new `signoz-k8s-infra-otel-deployment` pod
- [ ] `httpcheck.status` metric appears in SigNoz for `cluster-agents.cluster-agents.svc.cluster.local:8080/health`
- [ ] `cluster-agents Unreachable` alert transitions to resolved within 10 minutes of rollout

🤖 Generated with [Claude Code](https://claude.com/claude-code)