### PR TITLE
fix(agent-platform): increase job inactivity timeout to 30m

### DIFF
--- a/projects/agent_platform/deploy/values.yaml
+++ b/projects/agent_platform/deploy/values.yaml
@@ -182,6 +182,7 @@ agent-orchestrator:
       itemPath: "vaults/k8s-homelab/items/ghcr-read-permissions"
   config:
     inferenceUrl: "http://llama-cpp.llama-cpp.svc.cluster.local:8080"
+    jobInactivityTimeout: "30m"
   podAnnotations:
     linkerd.io/inject: enabled
   httpRoute:


### PR DESCRIPTION
## Summary

- Increases `jobInactivityTimeout` from `10m` to `30m` for the agent-orchestrator in the agent-platform deployment
- Root cause of recurring `cluster-agents Unreachable` SigNoz alert and `sandbox unreachable after 10 consecutive poll failures` errors: investigation jobs with multiple slow MCP tool calls (SigNoz traces, pod listings, ArgoCD checks) exceed the 10m inactivity window
- When the goose runner times out, its pod exits, Kubernetes removes the sandbox Service, and subsequent DNS lookups for the sandbox FQDN fail with `no such host`

## Test plan

- [ ] CI passes (`bazel test //...`)
- [ ] ArgoCD syncs the agent-platform application with the new config
- [ ] Verify `JOB_INACTIVITY_TIMEOUT=30m` is set in the orchestrator pod env
- [ ] Monitor SigNoz for absence of `cluster-agents Unreachable` alerts during subsequent investigation jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)