### PR TITLE
fix(cluster-agents): bump chart to 0.6.11 to deploy Linkerd healthcheck fix

### DIFF
--- a/projects/agent_platform/cluster_agents/deploy/Chart.yaml
+++ b/projects/agent_platform/cluster_agents/deploy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cluster-agents
 description: Autonomous cluster monitoring agents
 type: application
-version: 0.6.10
+version: 0.6.11
 appVersion: "0.2.0"
 annotations:
   org.opencontainers.image.source: "https://github.com/jomcgi/homelab"

--- a/projects/agent_platform/cluster_agents/deploy/application.yaml
+++ b/projects/agent_platform/cluster_agents/deploy/application.yaml
@@ -8,7 +8,7 @@ spec:
   source:
     repoURL: ghcr.io/jomcgi/homelab/charts
     chart: cluster-agents
-    targetRevision: 0.6.10
+    targetRevision: 0.6.11
     helm:
       releaseName: cluster-agents
       valuesObject:


### PR DESCRIPTION
## Summary

- Bumps `Chart.yaml` version from `0.6.10` → `0.6.11`
- Bumps `application.yaml` `targetRevision` from `0.6.10` → `0.6.11` to match

## Root Cause

The `cluster-agents Unreachable` SigNoz alert fires because Linkerd's proxy was intercepting inbound port 8080 connections from the SigNoz OTel httpcheck collector (which runs in the `signoz` namespace, outside the Linkerd mesh).

The fix — `config.linkerd.io/skip-inbound-ports: "8080"` pod annotation in `values.yaml` — was already present, but the OCI chart published at version `0.6.10` is immutable and predates the annotation being added. ArgoCD cannot pick up the change until a new chart version is published to the OCI registry.

## Fix

Bumping the chart version to `0.6.11` causes CI to publish a new OCI chart that includes the Linkerd skip annotation. ArgoCD will then auto-sync and deploy pods with the annotation, allowing the httpcheck health probe to reach `/health` and clearing the alert.

## Test plan
- [ ] CI passes `bazel test //...` (Helm unit tests validate annotation is present via `deployment_test.yaml`)
- [ ] ArgoCD syncs `cluster-agents` to `0.6.11` after merge
- [ ] SigNoz `httpcheck.status` metric returns `1` for `cluster-agents.cluster-agents.svc.cluster.local:8080/health`
- [ ] `cluster-agents Unreachable` alert stops firing

🤖 Generated with [Claude Code](https://claude.com/claude-code)