### PR TITLE
fix(cluster-agents): bump chart to 0.6.14 to deploy Linkerd healthcheck fix

### DIFF
--- a/projects/agent_platform/cluster_agents/deploy/Chart.yaml
+++ b/projects/agent_platform/cluster_agents/deploy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cluster-agents
 description: Autonomous cluster monitoring agents
 type: application
-version: 0.6.13
+version: 0.6.14
 appVersion: "0.2.0"
 annotations:
   org.opencontainers.image.source: "https://github.com/jomcgi/homelab"

--- a/projects/agent_platform/cluster_agents/deploy/application.yaml
+++ b/projects/agent_platform/cluster_agents/deploy/application.yaml
@@ -8,7 +8,7 @@ spec:
   source:
     repoURL: ghcr.io/jomcgi/homelab/charts
     chart: cluster-agents
-    targetRevision: 0.6.13
+    targetRevision: 0.6.14
     helm:
       releaseName: cluster-agents
       valuesObject:


### PR DESCRIPTION
## Summary

- Chart `0.6.13` was published to GHCR **before** the `config.linkerd.io/skip-inbound-ports: "8080"` annotation was added to `values.yaml`, so ArgoCD is pulling a version that doesn't include the fix
- Bumping to `0.6.14` ensures CI publishes a fresh chart with the annotation included, unblocking the 'cluster-agents Unreachable' alert

## Root Cause

The `cluster-agents` namespace has Linkerd injection enabled (via Kyverno), but the SigNoz `otelDeployment` in the `signoz` namespace runs **outside** the Linkerd mesh. When the unmeshed httpcheck sender makes plain HTTP connections to the meshed pod on port 8080, Linkerd's inbound proxy intercepts and drops them — causing `httpcheck.status = 0` and firing the alert.

**Fix already in `values.yaml`:**
\`\`\`yaml
podAnnotations:
  config.linkerd.io/skip-inbound-ports: "8080"
\`\`\`

This tells Linkerd to bypass its proxy for port 8080, allowing the unmeshed httpcheck to reach the Go health endpoint directly.

## Test plan

- [ ] CI passes Helm unit tests (regression test \`should set Linkerd skip-inbound-ports annotation by default\` in \`deployment_test.yaml\`)
- [ ] CI pushes chart \`0.6.14\` to \`ghcr.io/jomcgi/homelab/charts\`
- [ ] ArgoCD syncs \`cluster-agents\` to \`0.6.14\`
- [ ] Pod restarts with the Linkerd annotation on port 8080
- [ ] \`cluster-agents Unreachable\` alert resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)