### PR TITLE
ci: add semgrep rule to flag stale force-rollout annotations

### DIFF
--- a/bazel/semgrep/rules/yaml/no-stale-force-rollout.yaml
+++ b/bazel/semgrep/rules/yaml/no-stale-force-rollout.yaml
@@ -1,0 +1,17 @@
+rules:
+  - id: no-stale-force-rollout
+    languages: [yaml]
+    severity: WARNING
+    message: >-
+      `homelab/force-rollout` annotation detected in a values YAML file. This
+      annotation is intentionally temporary — it forces a pod rollout by injecting
+      a unique value into the pod spec. Once the forced rollout is verified, remove
+      this annotation to avoid unnecessary restarts on future deploys. See PRs
+      #1488-#1499 for context on this pattern.
+    metadata:
+      category: correctness
+    paths:
+      include:
+        - "**/deploy/values.yaml"
+        - "**/deploy/values.*.yaml"
+    pattern-regex: 'homelab/force-rollout'


### PR DESCRIPTION
## Summary

- Adds a new semgrep rule `no-stale-force-rollout` that warns when a `homelab/force-rollout` annotation is left in a `values.yaml` or `values.*.yaml` deploy file
- The `force-rollout` annotation is intentionally temporary — it injects a unique value into pod specs to force a rollout, but leaving it in place causes unnecessary pod restarts on every future deploy
- This rule catches accidental omissions after a forced rollout has been verified

## Context

- Analysis gist: https://gist.github.com/jomcgi/2f98aed2a2c738d9691d925674d5f358
- Pattern introduced and used in PRs #1488–#1499

## Test plan

- [ ] CI semgrep scan passes on this branch (no `force-rollout` annotations present in values files)
- [ ] Verify the rule fires correctly by temporarily adding `homelab/force-rollout` to a `values.yaml` and confirming semgrep reports a WARNING

🤖 Generated with [Claude Code](https://claude.com/claude-code)