### PR TITLE
ci: add semgrep rule and hook to prevent valuesObject Helm overrides

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -196,6 +196,11 @@
             "type": "command",
             "command": "bazel/tools/hooks/check-missing-imageupdater.sh",
             "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "bazel/tools/hooks/check-valuesobject-overrides.sh",
+            "timeout": 5
           }
         ]
       }

--- a/bazel/semgrep/rules/yaml/no-valuesobject-helm-overrides.yaml
+++ b/bazel/semgrep/rules/yaml/no-valuesobject-helm-overrides.yaml
@@ -1,0 +1,16 @@
+rules:
+  - id: no-valuesobject-helm-overrides
+    languages: [yaml]
+    severity: WARNING
+    message: >-
+      Helm value overrides (podAnnotations, podLabels, resources, nodeSelector,
+      tolerations, env) found inside a `valuesObject` block in application.yaml.
+      These values should live in `values.yaml` so they receive CI coverage via
+      `helm_template_test`. Move them to the service's `deploy/values.yaml` instead.
+      See PRs #1488-#1499 for examples.
+    metadata:
+      category: correctness
+    paths:
+      include:
+        - "**/deploy/application.yaml"
+    pattern-regex: '^\s*(podAnnotations|podLabels|resources|nodeSelector|tolerations|env):'

--- a/bazel/tools/hooks/check-valuesobject-overrides.sh
+++ b/bazel/tools/hooks/check-valuesobject-overrides.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# PreToolUse hook: warns when application.yaml files contain overrideable Helm
+# values (podAnnotations, podLabels, resources, nodeSelector, tolerations, env)
+# inside a valuesObject block. These values should live in values.yaml so they
+# get CI coverage via helm_template_test.
+#
+# Input: JSON on stdin from Claude Code hook system
+# Exit 0: always (warning only, not a blocker)
+
+set -euo pipefail
+
+INPUT=$(cat)
+
+# Extract file path and content from Write (content) or Edit (new_string) tool input
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
+CONTENT=$(echo "$INPUT" | jq -r '.tool_input.content // .tool_input.new_string // empty')
+
+if [[ -z "$CONTENT" ]]; then
+	exit 0
+fi
+
+# Only check */deploy/application.yaml files
+if ! echo "$FILE_PATH" | grep -qE '.*/deploy/application\.yaml$'; then
+	exit 0
+fi
+
+# Only warn if the file contains a valuesObject block
+if ! echo "$CONTENT" | grep -qF 'valuesObject:'; then
+	exit 0
+fi
+
+# Check for overrideable Helm values inside valuesObject
+if echo "$CONTENT" | grep -qE '^\s*(podAnnotations|podLabels|resources|nodeSelector|tolerations|env):'; then
+	cat >&2 <<-'EOF'
+		WARNING: application.yaml contains overrideable Helm values (podAnnotations,
+		podLabels, resources, nodeSelector, tolerations, or env) inside a valuesObject
+		block. These values should live in values.yaml so they receive CI coverage via
+		helm_template_test. Move them to the service's deploy/values.yaml instead.
+		See PRs #1488-#1499 for examples of this pattern.
+	EOF
+fi
+
+exit 0


### PR DESCRIPTION
## Summary

- Adds a semgrep rule (`no-valuesobject-helm-overrides`) that flags common Helm value overrides (`podAnnotations`, `podLabels`, `resources`, `nodeSelector`, `tolerations`, `env`) placed inside `valuesObject` blocks in `deploy/application.yaml` files
- Adds a PreToolUse hook (`check-valuesobject-overrides.sh`) that warns Claude Code when writing such values into `application.yaml`, guiding values to live in `values.yaml` where they receive CI coverage via `helm_template_test`
- Registers the new hook in `.claude/settings.json`

These guards enforce the pattern analysed in https://gist.github.com/jomcgi/2f98aed2a2c738d9691d925674d5f358 and migrated across the fleet in PRs #1488–#1499.

## Test plan

- [ ] Verify semgrep rule fires on an `application.yaml` containing `resources:` inside a `valuesObject:` block
- [ ] Verify hook emits a warning (not a block) when writing such a file via Claude Code
- [ ] Verify no false positives on existing `deploy/application.yaml` files that do not use `valuesObject`
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)