### PR TITLE
ci: add hook to warn on missing argocd_app BUILD target

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -196,6 +196,11 @@
             "type": "command",
             "command": "bazel/tools/hooks/check-missing-imageupdater.sh",
             "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "bazel/tools/hooks/check-missing-argocd-app-build.sh",
+            "timeout": 5
           }
         ]
       }

--- a/bazel/tools/hooks/check-missing-argocd-app-build.sh
+++ b/bazel/tools/hooks/check-missing-argocd-app-build.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+# PreToolUse hook: warns when writing to a deploy/ directory that contains both
+# Chart.yaml and application.yaml but the BUILD file lacks an argocd_app rule.
+# Without an argocd_app BUILD target, the service won't get CI coverage via
+# helm_template_test and semgrep validation.
+#
+# Input: JSON on stdin from Claude Code hook system
+# Exit 0: always (warning only, not a blocker)
+
+set -euo pipefail
+
+INPUT=$(cat)
+
+# Extract file path from Write (content) or Edit (new_string) tool input
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
+
+if [[ -z "$FILE_PATH" ]]; then
+	exit 0
+fi
+
+# Only check files under */deploy/ directories
+if ! echo "$FILE_PATH" | grep -qE '.*/deploy/'; then
+	exit 0
+fi
+
+# Derive the deploy directory from the file path
+DEPLOY_DIR=$(dirname "$FILE_PATH")
+
+# Only warn if both Chart.yaml (chart/) and application.yaml exist alongside
+# Wait - Chart.yaml is in the chart/ directory, one level up from deploy/
+# Check if application.yaml exists in the deploy dir
+if [[ ! -f "$DEPLOY_DIR/application.yaml" ]]; then
+	exit 0
+fi
+
+# Check for Chart.yaml in the sibling chart/ directory
+SERVICE_DIR=$(dirname "$DEPLOY_DIR")
+if [[ ! -f "$SERVICE_DIR/chart/Chart.yaml" ]]; then
+	exit 0
+fi
+
+# Check if BUILD file exists and has an argocd_app rule
+BUILD_FILE="$DEPLOY_DIR/BUILD"
+if [[ ! -f "$BUILD_FILE" ]]; then
+	cat >&2 <<-'EOF'
+		WARNING: This deploy/ directory has a Chart.yaml (custom chart) and
+		application.yaml but is missing a BUILD file entirely. Add a BUILD file
+		with an argocd_app rule for CI helm template and semgrep coverage.
+		See bazel/rules/argocd_app.bzl for the rule definition.
+	EOF
+	exit 0
+fi
+
+if ! grep -q 'argocd_app' "$BUILD_FILE"; then
+	cat >&2 <<-'EOF'
+		WARNING: This deploy/ directory has a Chart.yaml (custom chart) and
+		application.yaml but the BUILD file is missing an argocd_app rule.
+		Add an argocd_app BUILD target to enable CI helm template testing and
+		semgrep validation coverage for this service.
+		See bazel/rules/argocd_app.bzl for the rule definition.
+	EOF
+fi
+
+exit 0


### PR DESCRIPTION
## Summary

- Adds a new PreToolUse hook (`check-missing-argocd-app-build.sh`) that warns when writing to a `deploy/` directory that has a custom Helm chart (`chart/Chart.yaml`) and `application.yaml` but is missing an `argocd_app` BUILD target
- Without an `argocd_app` BUILD target, services don't get CI coverage via `helm_template_test` and semgrep validation
- Registers the hook in `.claude/settings.json` under the `Write|Edit` matcher alongside the other pre-tool-use hooks

This work was motivated by the analysis in https://gist.github.com/jomcgi/2f98aed2a2c738d9691d925674d5f358 and follows the pattern established by the BUILD target additions in PRs #1488–#1499.

## Test plan

- [ ] Write or edit a file in a `deploy/` directory that has a sibling `chart/Chart.yaml` and `application.yaml` but no `BUILD` file — verify warning appears on stderr
- [ ] Write or edit a file in a `deploy/` directory with a `BUILD` file missing `argocd_app` — verify warning appears on stderr
- [ ] Write or edit a file in a `deploy/` directory with a complete `BUILD` file containing `argocd_app` — verify no warning is emitted
- [ ] Write or edit a file outside a `deploy/` directory — verify no warning is emitted

🤖 Generated with [Claude Code](https://claude.com/claude-code)