### PR TITLE
fix(semgrep): scope valuesobject rule to valuesObject context; tighten force-rollout regex

### DIFF
--- a/bazel/semgrep/rules/yaml/no-stale-force-rollout.yaml
+++ b/bazel/semgrep/rules/yaml/no-stale-force-rollout.yaml
@@ -14,4 +14,4 @@ rules:
       include:
         - "**/deploy/values.yaml"
         - "**/deploy/values.*.yaml"
-    pattern-regex: 'homelab/force-rollout'
+    pattern-regex: 'homelab/force-rollout\s*:'

--- a/bazel/semgrep/rules/yaml/no-valuesobject-helm-overrides.yaml
+++ b/bazel/semgrep/rules/yaml/no-valuesobject-helm-overrides.yaml
@@ -13,4 +13,4 @@ rules:
     paths:
       include:
         - "**/deploy/application.yaml"
-    pattern-regex: '^\s*(podAnnotations|podLabels|resources|nodeSelector|tolerations|env):'
+    pattern-regex: 'valuesObject:[\s\S]*?\n\s*(podAnnotations|podLabels|resources|nodeSelector|tolerations|env):'


### PR DESCRIPTION
## Summary

Follow-up fixes for two semgrep rules merged in PRs #1500 and #1501:

- **no-valuesobject-helm-overrides** (PR #1501): The `pattern-regex` matched `podAnnotations`, `resources`, `env`, etc. *anywhere* in `application.yaml`, not just inside `valuesObject:` blocks. Changed to a multiline regex requiring `valuesObject:` as a prefix context before the matched key.
- **no-stale-force-rollout** (PR #1500): The regex `homelab/force-rollout` would match comment lines that merely mention the annotation. Tightened to `homelab/force-rollout\s*:` so it only fires on actual YAML key assignments.

## Test plan

- [ ] Verify `no-valuesobject-helm-overrides` does NOT fire on an `application.yaml` that has `resources:` directly under `spec.source.helm` (outside `valuesObject`)
- [ ] Verify `no-valuesobject-helm-overrides` DOES fire on an `application.yaml` with `resources:` nested inside a `valuesObject:` block
- [ ] Verify `no-stale-force-rollout` does NOT fire on a comment line like `# homelab/force-rollout is a temporary annotation`
- [ ] Verify `no-stale-force-rollout` DOES fire on a YAML key like `homelab/force-rollout: "abc123"`
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)