### PR TITLE
ci: add hook to warn when deploy/ is missing argocd_app BUILD target

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -199,6 +199,11 @@
           },
           {
             "type": "command",
+            "command": "bazel/tools/hooks/check-missing-argocd-app-build.sh",
+            "timeout": 5
+          },
+          {
+            "type": "command",
             "command": "bazel/tools/hooks/check-valuesobject-overrides.sh",
             "timeout": 5
           }

--- a/bazel/tools/hooks/check-missing-argocd-app-build.sh
+++ b/bazel/tools/hooks/check-missing-argocd-app-build.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# PreToolUse hook: warns when writing to a deploy/ directory that contains both
+# Chart.yaml and application.yaml but the BUILD file lacks an argocd_app rule.
+# Without an argocd_app BUILD target, the service won't get CI coverage via
+# helm_template_test and semgrep validation.
+#
+# Input: JSON on stdin from Claude Code hook system
+# Exit 0: always (warning only, not a blocker)
+
+set -euo pipefail
+
+INPUT=$(cat)
+
+# Extract file path from Write (content) or Edit (new_string) tool input
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
+
+if [[ -z "$FILE_PATH" ]]; then
+	exit 0
+fi
+
+# Only check files under */deploy/ directories
+if ! echo "$FILE_PATH" | grep -qE '.*/deploy/'; then
+	exit 0
+fi
+
+# Derive the deploy directory from the file path
+DEPLOY_DIR=$(dirname "$FILE_PATH")
+
+# Only warn if application.yaml exists in the deploy dir
+if [[ ! -f "$DEPLOY_DIR/application.yaml" ]]; then
+	exit 0
+fi
+
+# Check for Chart.yaml in the sibling chart/ directory
+SERVICE_DIR=$(dirname "$DEPLOY_DIR")
+if [[ ! -f "$SERVICE_DIR/chart/Chart.yaml" ]]; then
+	exit 0
+fi
+
+# Check if BUILD file exists and has an argocd_app rule
+BUILD_FILE="$DEPLOY_DIR/BUILD"
+if [[ ! -f "$BUILD_FILE" ]]; then
+	cat >&2 <<-'EOF'
+		WARNING: This deploy/ directory has a Chart.yaml (custom chart) and
+		application.yaml but is missing a BUILD file entirely. Add a BUILD file
+		with an argocd_app rule for CI helm template and semgrep coverage.
+		See bazel/helm/defs.bzl for the rule definition.
+	EOF
+	exit 0
+fi
+
+if ! grep -q 'argocd_app' "$BUILD_FILE"; then
+	cat >&2 <<-'EOF'
+		WARNING: This deploy/ directory has a Chart.yaml (custom chart) and
+		application.yaml but the BUILD file is missing an argocd_app rule.
+		Add an argocd_app BUILD target to enable CI helm template testing and
+		semgrep validation coverage for this service.
+		See bazel/helm/defs.bzl for the rule definition.
+	EOF
+fi
+
+exit 0


### PR DESCRIPTION
## Summary

Replaces the conflicted and buggy PR #1502 (`ci/check-missing-argocd-app-build`) with a clean implementation on top of current main:

- Adds `check-missing-argocd-app-build.sh` PreToolUse hook that warns when writing to a `deploy/` directory that has both a custom Helm chart (`chart/Chart.yaml`) and `application.yaml` but is missing an `argocd_app` BUILD rule
- Fixes the hook warning message: references `bazel/helm/defs.bzl` (the correct path where `argocd_app` is defined) instead of the non-existent `bazel/rules/argocd_app.bzl` from the original branch
- Registers the hook in `.claude/settings.json` between `check-missing-imageupdater.sh` and `check-valuesobject-overrides.sh`, avoiding the merge conflict that affected the original PR

Without an `argocd_app` BUILD target, services don't get CI coverage via `helm_template_test` and semgrep validation.

## Test plan

- [ ] Write or edit a file in a `deploy/` directory with a sibling `chart/Chart.yaml` and `application.yaml` but no `BUILD` file — verify warning appears on stderr
- [ ] Write or edit a file in a `deploy/` directory with a `BUILD` file missing `argocd_app` — verify warning appears on stderr
- [ ] Write or edit a file in a `deploy/` directory with a complete `BUILD` file containing `argocd_app` — verify no warning is emitted
- [ ] Write or edit a file outside a `deploy/` directory — verify no warning is emitted
- [ ] CI passes

Closes #1502

🤖 Generated with [Claude Code](https://claude.com/claude-code)