### PR TITLE
fix(cluster-agents): bump chart to 0.6.15 to deploy Linkerd skip-inbound-ports fix

### DIFF
--- a/projects/agent_platform/cluster_agents/deploy/Chart.yaml
+++ b/projects/agent_platform/cluster_agents/deploy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cluster-agents
 description: Autonomous cluster monitoring agents
 type: application
-version: 0.6.14
+version: 0.6.15
 appVersion: "0.2.0"
 annotations:
   org.opencontainers.image.source: "https://github.com/jomcgi/homelab"

--- a/projects/agent_platform/cluster_agents/deploy/application.yaml
+++ b/projects/agent_platform/cluster_agents/deploy/application.yaml
@@ -8,7 +8,7 @@ spec:
   source:
     repoURL: ghcr.io/jomcgi/homelab/charts
     chart: cluster-agents
-    targetRevision: 0.6.14
+    targetRevision: 0.6.15
     helm:
       releaseName: cluster-agents
       valuesObject:


### PR DESCRIPTION
## Summary

- Bumps `cluster-agents` chart version `0.6.14` → `0.6.15` in both `Chart.yaml` and `application.yaml`
- The `config.linkerd.io/skip-inbound-ports: "8080"` annotation was already committed to `values.yaml` but the live pod was deployed from chart `0.6.14` (before the annotation was added)
- Bumping the chart version causes ArgoCD to pull the new OCI chart, rolling-restart the pod, and Linkerd injects the annotation at pod creation — allowing plain-text inbound probes from the unmeshed SigNoz OTel httpcheck collector

## Root Cause

The `signoz` namespace is excluded from Linkerd injection (to prevent circular tracing). The SigNoz OTel httpcheck collector pod therefore has no Linkerd identity. When it probes `http://cluster-agents.cluster-agents.svc.cluster.local:8080/health`, the Linkerd sidecar on the cluster-agents pod rejects the plain-text connection, causing `httpcheck.status = 0` → `cluster-agents Unreachable` alert fires.

## Test plan

- [ ] CI passes `bazel test //...` (includes regression test `deploy/tests/regression_test.yaml` that guards the annotation)
- [ ] ArgoCD rolls out new pod after merge
- [ ] `httpcheck.status` metric for cluster-agents returns to 1 in SigNoz
- [ ] `cluster-agents Unreachable` alert stops firing

🤖 Generated with [Claude Code](https://claude.com/claude-code)