### PR TITLE
test(semgrep): add fixtures for no-stale-force-rollout and no-valuesobject-helm-overrides

### DIFF
--- a/bazel/semgrep/tests/fixtures/no-stale-force-rollout.yaml
+++ b/bazel/semgrep/tests/fixtures/no-stale-force-rollout.yaml
@@ -1,0 +1,28 @@
+# Tests for no-stale-force-rollout rule.
+# The homelab/force-rollout annotation is intentionally temporary — it should
+# be removed after the forced rollout is verified.
+---
+# ruleid: no-stale-force-rollout
+podAnnotations:
+  homelab/force-rollout: "20240301-1"
+
+---
+# ruleid: no-stale-force-rollout
+podAnnotations:
+  app.kubernetes.io/name: myservice
+  homelab/force-rollout: "abc123"
+
+---
+# ok: no-stale-force-rollout — no force-rollout annotation present
+podAnnotations:
+  app.kubernetes.io/name: myservice
+  app.kubernetes.io/version: "1.0"
+
+---
+# ok: no-stale-force-rollout — empty podAnnotations block
+podAnnotations: {}
+
+---
+# ok: no-stale-force-rollout — unrelated annotation key mentioning rollout
+podAnnotations:
+  homelab/last-rollout-date: "2024-03-01"

--- a/bazel/semgrep/tests/fixtures/no-valuesobject-helm-overrides.yaml
+++ b/bazel/semgrep/tests/fixtures/no-valuesobject-helm-overrides.yaml
@@ -1,0 +1,117 @@
+# Tests for no-valuesobject-helm-overrides rule.
+# Overrideable Helm values (podAnnotations, podLabels, resources, etc.) found
+# inside a valuesObject block should live in values.yaml instead for CI coverage.
+---
+# ruleid: no-valuesobject-helm-overrides
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: my-service
+spec:
+  source:
+    helm:
+      valuesObject:
+        podAnnotations:
+          prometheus.io/scrape: "true"
+        replicaCount: 1
+
+---
+# ruleid: no-valuesobject-helm-overrides
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: my-service
+spec:
+  source:
+    helm:
+      valuesObject:
+        image:
+          tag: latest
+        resources:
+          limits:
+            memory: 512Mi
+
+---
+# ruleid: no-valuesobject-helm-overrides
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: my-service
+spec:
+  source:
+    helm:
+      valuesObject:
+        podLabels:
+          team: platform
+        config:
+          key: value
+
+---
+# ruleid: no-valuesobject-helm-overrides
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: my-service
+spec:
+  source:
+    helm:
+      valuesObject:
+        nodeSelector:
+          kubernetes.io/arch: amd64
+
+---
+# ruleid: no-valuesobject-helm-overrides
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: my-service
+spec:
+  source:
+    helm:
+      valuesObject:
+        tolerations:
+          - key: "dedicated"
+            operator: "Equal"
+
+---
+# ruleid: no-valuesobject-helm-overrides
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: my-service
+spec:
+  source:
+    helm:
+      valuesObject:
+        env:
+          - name: MY_VAR
+            value: "hello"
+
+---
+# ok: no-valuesobject-helm-overrides — no valuesObject block
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: my-service
+spec:
+  source:
+    helm:
+      valueFiles:
+        - values.yaml
+
+---
+# ok: no-valuesobject-helm-overrides — valuesObject without overrideable keys
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: my-service
+spec:
+  source:
+    helm:
+      valuesObject:
+        replicaCount: 2
+        image:
+          repository: myrepo/myimage
+          tag: "1.0.0"
+        service:
+          port: 8080


### PR DESCRIPTION
## Summary
- Add `bazel/semgrep/tests/fixtures/no-stale-force-rollout.yaml` with `# ruleid:` and `# ok:` annotated test cases for the `homelab/force-rollout` pattern-regex rule in deploy values files
- Add `bazel/semgrep/tests/fixtures/no-valuesobject-helm-overrides.yaml` with annotated cases testing `valuesObject:` followed by overrideable keys (podAnnotations, podLabels, resources, nodeSelector, tolerations, env) in application.yaml paths
- Both fixtures are auto-included via `glob(["fixtures/*.yaml"])` in `yaml_fixtures`

## Test plan
- [ ] CI passes bazel test //...
- [ ] Fixture files contain valid YAML with proper `# ruleid:` and `# ok:` annotations
- [ ] `no-stale-force-rollout.yaml` covers the `homelab/force-rollout:` pattern (matching) and safe annotation keys (non-matching)
- [ ] `no-valuesobject-helm-overrides.yaml` covers all 6 overrideable Helm keys inside valuesObject (matching) and valuesObject without them (non-matching)

🤖 Generated with [Claude Code](https://claude.com/claude-code)