### PR TITLE
fix(semgrep): broaden no-stale-force-rollout paths to cover platform services

### DIFF
--- a/bazel/semgrep/rules/yaml/no-stale-force-rollout.yaml
+++ b/bazel/semgrep/rules/yaml/no-stale-force-rollout.yaml
@@ -12,6 +12,7 @@ rules:
       category: correctness
     paths:
       include:
-        - "**/deploy/values.yaml"
-        - "**/deploy/values.*.yaml"
+        - "**/values.yaml"
+        - "**/values-*.yaml"
+        - "**/values.*.yaml"
     pattern-regex: 'homelab/force-rollout\s*:'


### PR DESCRIPTION
## Summary
- Broadens `no-stale-force-rollout` semgrep rule path filter from `**/deploy/values.yaml` to `**/values.yaml`, `**/values-*.yaml`, and `**/values.*.yaml`
- Platform services (signoz, argocd, linkerd, kyverno, etc.) store values files directly in `projects/platform/<service>/` without a `deploy/` subdirectory — these were previously missed
- Confirmed live undetected annotation in `projects/platform/signoz/values-prod.yaml`

## Test plan
- [ ] CI semgrep tests pass (fixtures use `SEMGREP_TEST_MODE=1` which disables path filters, so no fixture changes needed)
- [ ] Rule now catches `homelab/force-rollout` in platform service values files

🤖 Generated with [Claude Code](https://claude.com/claude-code)