### PR TITLE
fix(semgrep): broaden no-valuesobject-helm-overrides paths to cover platform services

### DIFF
--- a/bazel/semgrep/rules/yaml/no-valuesobject-helm-overrides.yaml
+++ b/bazel/semgrep/rules/yaml/no-valuesobject-helm-overrides.yaml
@@ -12,5 +12,5 @@ rules:
       category: correctness
     paths:
       include:
-        - "**/deploy/application.yaml"
+        - "**/application.yaml"
     pattern-regex: 'valuesObject:[\s\S]*?\n\s*(podAnnotations|podLabels|resources|nodeSelector|tolerations|env):'

--- a/bazel/tools/hooks/check-valuesobject-overrides.sh
+++ b/bazel/tools/hooks/check-valuesobject-overrides.sh
@@ -19,8 +19,8 @@ if [[ -z "$CONTENT" ]]; then
 	exit 0
 fi
 
-# Only check */deploy/application.yaml files
-if ! echo "$FILE_PATH" | grep -qE '.*/deploy/application\.yaml$'; then
+# Only check application.yaml files (both deploy/ and platform/ layouts)
+if ! echo "$FILE_PATH" | grep -qE '.*/application\.yaml$'; then
 	exit 0
 fi
 

--- a/bazel/tools/hooks/check-valuesobject-overrides_test.sh
+++ b/bazel/tools/hooks/check-valuesobject-overrides_test.sh
@@ -159,10 +159,10 @@ run_test "write_values_yaml_not_checked" \
 	'{"tool_input":{"file_path":"projects/myservice/deploy/values.yaml","content":"spec:\n  source:\n    helm:\n      valuesObject:\n        podAnnotations:\n          foo: bar\n"}}' \
 	0 ""
 
-# (h) Non-deploy path application.yaml → silent
-run_test "write_non_deploy_application_yaml_silent" \
+# (h) Platform path application.yaml with valuesObject → WARNING (platform services don't use deploy/ subdir)
+run_test "write_platform_application_yaml_warns" \
 	'{"tool_input":{"file_path":"projects/myservice/application.yaml","content":"spec:\n  source:\n    helm:\n      valuesObject:\n        podAnnotations:\n          foo: bar\n"}}' \
-	0 ""
+	0 "WARNING"
 
 # (i) Empty content → silent
 run_test "write_empty_content_silent" \
@@ -187,6 +187,11 @@ run_test "warning_message_mentions_values_yaml" \
 # (m) Nested deploy path still matched
 run_test "write_nested_deploy_application_yaml_warns" \
 	'{"tool_input":{"file_path":"projects/agent_platform/cluster_agents/deploy/application.yaml","content":"spec:\n  source:\n    helm:\n      valuesObject:\n        env:\n          - name: MY_VAR\n            value: hello\n"}}' \
+	0 "WARNING"
+
+# (n) Platform service path (projects/platform/<svc>/application.yaml) with valuesObject + env → WARNING
+run_test "write_platform_service_application_yaml_warns" \
+	'{"tool_input":{"file_path":"projects/platform/signoz/application.yaml","content":"spec:\n  source:\n    helm:\n      valuesObject:\n        env:\n          - name: MY_VAR\n            value: hello\n"}}' \
 	0 "WARNING"
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Broadens `no-valuesobject-helm-overrides` semgrep rule path filter from `**/deploy/application.yaml` to `**/application.yaml`
- Updates `check-valuesobject-overrides.sh` hook to match any `application.yaml`, not just those under `deploy/`
- Updates hook tests: test (h) now expects a WARNING for non-deploy paths (previously expected silence), adds new test (n) for `projects/platform/<svc>/application.yaml`
- Platform services (signoz, argocd, linkerd, kyverno, etc.) store `application.yaml` directly in `projects/platform/<service>/` — these were previously missed by both the semgrep rule and the hook

## Test plan
- [ ] CI semgrep tests pass (fixtures use `SEMGREP_TEST_MODE=1` which disables path filters, so no fixture changes needed)
- [ ] Hook unit tests pass with updated test (h) and new test (n)
- [ ] Rule and hook now catch `valuesObject` overrides in platform service application.yaml files

🤖 Generated with [Claude Code](https://claude.com/claude-code)