### PR TITLE
test(semgrep): add missing fixture coverage for all rule categories

### DIFF
--- a/bazel/semgrep/rules/BUILD
+++ b/bazel/semgrep/rules/BUILD
@@ -173,3 +173,27 @@ semgrep_test(
     rules = [":stale_copyright_year_rule"],
     tags = ["semgrep"],
 )
+
+semgrep_test(
+    name = "shell_rules_test",
+    srcs = glob(["shell/*.bash"]),
+    env = {"SEMGREP_TEST_MODE": "1"},
+    rules = [":shell_rules"],
+    tags = ["semgrep"],
+)
+
+semgrep_test(
+    name = "bazel_rules_test",
+    srcs = glob(["bazel/*.build"]),
+    env = {"SEMGREP_TEST_MODE": "1"},
+    rules = [":bazel_rules"],
+    tags = ["semgrep"],
+)
+
+semgrep_test(
+    name = "dockerfile_rules_test",
+    srcs = glob(["dockerfile/*.dockerfile"]),
+    env = {"SEMGREP_TEST_MODE": "1"},
+    rules = [":dockerfile_rules"],
+    tags = ["semgrep"],
+)

--- a/bazel/semgrep/rules/python/httpx-client-no-timeout.py
+++ b/bazel/semgrep/rules/python/httpx-client-no-timeout.py
@@ -1,0 +1,32 @@
+# Tests for httpx-client-no-timeout rule.
+import httpx
+
+
+async def bad_client_no_timeout():
+    # ruleid: httpx-client-no-timeout
+    async with httpx.AsyncClient() as client:
+        return await client.get("https://example.com")
+
+
+async def bad_client_only_other_params():
+    # ruleid: httpx-client-no-timeout
+    async with httpx.AsyncClient(headers={"X-Custom": "value"}) as client:
+        return await client.get("https://example.com")
+
+
+async def ok_client_with_timeout():
+    # ok: timeout is specified
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        return await client.get("https://example.com")
+
+
+async def ok_client_with_timeout_object():
+    # ok: using httpx.Timeout object
+    async with httpx.AsyncClient(timeout=httpx.Timeout(10.0, connect=5.0)) as client:
+        return await client.get("https://example.com")
+
+
+async def ok_client_with_none_timeout():
+    # ok: explicit None is an intentional choice (no timeout)
+    async with httpx.AsyncClient(timeout=None) as client:
+        return await client.get("https://internal-service")

--- a/bazel/semgrep/rules/python/no-broad-except-swallow.py
+++ b/bazel/semgrep/rules/python/no-broad-except-swallow.py
@@ -1,0 +1,57 @@
+# Tests for no-broad-except-swallow rule.
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+# ruleid: no-broad-except-swallow
+def bad_swallow():
+    try:
+        risky_operation()
+    except Exception as e:
+        pass  # silent failure!
+
+
+# ruleid: no-broad-except-swallow
+def bad_return_none():
+    try:
+        risky_operation()
+    except Exception as e:
+        return None  # hides the error
+
+
+# ok: logs the exception
+def ok_with_log():
+    try:
+        risky_operation()
+    except Exception as e:
+        logger.error("risky_operation failed: %s", e)
+
+
+# ok: re-raises
+def ok_reraise():
+    try:
+        risky_operation()
+    except Exception as e:
+        raise
+
+
+# ok: re-raises the caught exception
+def ok_reraise_e():
+    try:
+        risky_operation()
+    except Exception as e:
+        raise e
+
+
+# ok: logs then re-raises
+def ok_log_and_reraise():
+    try:
+        risky_operation()
+    except Exception as e:
+        logger.exception("unexpected error")
+        raise
+
+
+def risky_operation():
+    pass

--- a/bazel/semgrep/rules/python/no-mcp-run-http.py
+++ b/bazel/semgrep/rules/python/no-mcp-run-http.py
@@ -1,0 +1,28 @@
+# Tests for no-mcp-run-http rule.
+import mcp
+import uvicorn
+
+
+# ruleid: no-mcp-run-http
+mcp.run(transport="http")
+
+
+# ruleid: no-mcp-run-http
+mcp.run(host="0.0.0.0", port=8080, transport="http")
+
+
+# ruleid: no-mcp-run-http
+mcp.run(transport="http", port=9000)
+
+
+# ok: no-mcp-run-http — http_app() + uvicorn is the correct pattern
+app = mcp.http_app()
+uvicorn.run(app, host="0.0.0.0", port=8080)
+
+
+# ok: no-mcp-run-http — stdio transport is fine
+mcp.run(transport="stdio")
+
+
+# ok: no-mcp-run-http — sse transport is a different concern
+mcp.run(transport="sse")


### PR DESCRIPTION
## Summary

Cross-referenced all 35 semgrep rules in `bazel/semgrep/rules/**/*.yaml` against test fixtures and `semgrep_test` targets. Found and fixed three categories of missing coverage:

- **Orphaned Python fixtures**: `httpx-client-no-timeout.py`, `no-broad-except-swallow.py`, and `no-mcp-run-http.py` existed in `tests/fixtures/` but were never exercised — `python_rules_test` only globs `rules/python/*.py`. Copied fixtures to `rules/python/` so the glob picks them up.
- **Shell rules** (`no-direct-test`, `no-kubectl-mutate`): inline `.bash` fixtures existed but no `shell_rules_test` target was wired in `rules/BUILD`.
- **Bazel rule** (`no-rules-python`): inline `.build` fixture existed but no `bazel_rules_test` target.
- **Dockerfile rule** (`no-dockerfile`): inline `.dockerfile` fixture existed but no `dockerfile_rules_test` target.

## Test plan
- [ ] `bazel test //bazel/semgrep/rules:python_rules_test` — now validates httpx-client-no-timeout, no-broad-except-swallow, no-mcp-run-http fixtures
- [ ] `bazel test //bazel/semgrep/rules:shell_rules_test` — new; validates no-direct-test and no-kubectl-mutate
- [ ] `bazel test //bazel/semgrep/rules:bazel_rules_test` — new; validates no-rules-python
- [ ] `bazel test //bazel/semgrep/rules:dockerfile_rules_test` — new; validates no-dockerfile
- [ ] `bazel test //...` — full CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)