### PR TITLE
test(semgrep): add ok fixture for cluster-agents valuesObject pattern

### DIFF
--- a/bazel/semgrep/tests/fixtures/no-valuesobject-helm-overrides.yaml
+++ b/bazel/semgrep/tests/fixtures/no-valuesobject-helm-overrides.yaml
@@ -115,3 +115,22 @@ spec:
           tag: "1.0.0"
         service:
           port: 8080
+
+---
+# ok: no-valuesobject-helm-overrides — ArgoCD-only toggles (imagePullSecret, priorityClassName, podDisruptionBudget) are safe
+# Real-world pattern from cluster-agents: these keys are not Helm overrideable values
+# that should live in values.yaml; they are ArgoCD deployment policy toggles.
+# The Linkerd skip-inbound-ports annotation correctly lives in values.yaml, not here.
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: cluster-agents
+spec:
+  source:
+    helm:
+      valuesObject:
+        imagePullSecret:
+          enabled: true
+        priorityClassName: system-cluster-critical
+        podDisruptionBudget:
+          enabled: false


### PR DESCRIPTION
## Summary

- Adds an explicit `ok` fixture to the `no-valuesobject-helm-overrides` semgrep test documenting that ArgoCD-only deployment toggles (`imagePullSecret`, `priorityClassName`, `podDisruptionBudget`) are safe inside `valuesObject`
- Documents the real-world cluster-agents pattern — these are not Helm-overrideable values that should live in `values.yaml`
- The Linkerd `skip-inbound-ports: "8080"` annotation correctly lives in `values.yaml` (not `valuesObject`) to survive `chart-version-bot` bumps, as documented in the fixture comment

## Background

The `cluster-agents Unreachable` alert was caused by Linkerd's proxy dropping inbound httpcheck connections from the unmeshed SigNoz OTel collector. The fix (`config.linkerd.io/skip-inbound-ports: "8080"` in `values.yaml`) previously regressed 4+ times when it was accidentally placed in `application.yaml`'s `valuesObject` block — which gets silently overwritten by `chart-version-bot` on every version bump.

The `no-valuesobject-helm-overrides` semgrep rule catches that regression. This PR adds an `ok` fixture documenting that the cluster-agents deployment policy keys (`imagePullSecret`, `priorityClassName`, `podDisruptionBudget`) in `valuesObject` are intentional and not a violation.

## Test plan

- [ ] `bazel test //bazel/semgrep/rules:yaml_rules_test` — semgrep fixture validates the new ok case passes without false-positive
- [ ] `bazel test //projects/agent_platform/cluster_agents/deploy:cluster-agents` — helm chart tests including Linkerd annotation regression test pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)