### PR TITLE
fix(cluster-agents): bump chart to 0.6.18 to publish Linkerd annotation fix

### DIFF
--- a/projects/agent_platform/cluster_agents/deploy/Chart.yaml
+++ b/projects/agent_platform/cluster_agents/deploy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cluster-agents
 description: Autonomous cluster monitoring agents
 type: application
-version: 0.6.17
+version: 0.6.18
 appVersion: "0.2.0"
 annotations:
   org.opencontainers.image.source: "https://github.com/jomcgi/homelab"

--- a/projects/agent_platform/cluster_agents/deploy/application.yaml
+++ b/projects/agent_platform/cluster_agents/deploy/application.yaml
@@ -8,7 +8,7 @@ spec:
   source:
     repoURL: ghcr.io/jomcgi/homelab/charts
     chart: cluster-agents
-    targetRevision: 0.6.17
+    targetRevision: 0.6.18
     helm:
       releaseName: cluster-agents
       # IMPORTANT: Do NOT add podAnnotations here. The chart-version-bot regenerates


### PR DESCRIPTION
## Summary

- The `config.linkerd.io/skip-inbound-ports: "8080"` annotation was previously added to `values.yaml` to prevent Linkerd's sidecar from intercepting health-check traffic from the unmeshed SigNoz OTel httpcheck receiver
- However, the chart version was not bumped — the OCI chart tarball at `0.6.17` predates the annotation fix
- ArgoCD continued deploying pods without the annotation, causing Linkerd to drop inbound port 8080 connections and firing the **'cluster-agents Unreachable'** alert (rule `019cda4d-9837-76b0-b625-0149055459fa`)
- This PR bumps `Chart.yaml` and `application.yaml` `targetRevision` from `0.6.17` → `0.6.18` to trigger CI to publish a new chart including the annotation

## Root Cause

The `cluster-agents` namespace has Linkerd injection enabled via Kyverno. SigNoz's OTel httpcheck runs from the `signoz` namespace (outside the Linkerd mesh). Without the skip annotation, Linkerd intercepts inbound connections from unmeshed clients on port 8080 and drops them — making the `/health` endpoint unreachable.

## Test plan

- [ ] CI publishes chart `cluster-agents:0.6.18` to `ghcr.io/jomcgi/homelab/charts`
- [ ] ArgoCD detects the new `targetRevision` and syncs
- [ ] Running pod has `config.linkerd.io/skip-inbound-ports: "8080"` annotation
- [ ] SigNoz httpcheck succeeds on `http://cluster-agents.cluster-agents.svc.cluster.local:8080/health`
- [ ] 'cluster-agents Unreachable' alert resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)