### PR TITLE
fix(cluster-agents): bump chart to 0.6.20 to publish Linkerd annotation fix

### DIFF
--- a/projects/agent_platform/cluster_agents/deploy/Chart.yaml
+++ b/projects/agent_platform/cluster_agents/deploy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cluster-agents
 description: Autonomous cluster monitoring agents
 type: application
-version: 0.6.19
+version: 0.6.20
 appVersion: "0.2.0"
 annotations:
   org.opencontainers.image.source: "https://github.com/jomcgi/homelab"

--- a/projects/agent_platform/cluster_agents/deploy/application.yaml
+++ b/projects/agent_platform/cluster_agents/deploy/application.yaml
@@ -8,7 +8,7 @@ spec:
   source:
     repoURL: ghcr.io/jomcgi/homelab/charts
     chart: cluster-agents
-    targetRevision: 0.6.19
+    targetRevision: 0.6.20
     helm:
       releaseName: cluster-agents
       # IMPORTANT: Do NOT add podAnnotations here. The chart-version-bot regenerates


### PR DESCRIPTION
## Summary

- Bumps `cluster-agents` Helm chart from `0.6.19` → `0.6.20` and updates `targetRevision` in `application.yaml` to match
- Chart versions 0.6.14–0.6.19 were blocked from publishing because `bazel/helm/helm-assert-annotations.sh` was not executable, causing `linkerd_annotation_test` to fail and preventing the **Push images** CI step from running
- The Linkerd `config.linkerd.io/skip-inbound-ports: "8080"` annotation already exists in `values.yaml` — this PR ensures it actually gets published in a chart ArgoCD can sync

## Root Cause

The `cluster-agents Unreachable` alert fires because the SigNoz OTel httpcheck receiver (running in the unmeshed `signoz` namespace) cannot reach the `/health` endpoint on port 8080. The `cluster-agents` namespace has Linkerd injection enabled via a Kyverno policy. Without the `skip-inbound-ports` annotation, Linkerd's inbound proxy intercepts and silently drops plain HTTP connections from unmeshed clients.

## Fix Chain

1. `config.linkerd.io/skip-inbound-ports: "8080"` added to `podAnnotations` in `values.yaml` (existing)
2. Regression test added in `deployment_test.yaml` and `BUILD` (`linkerd_annotation_test`) (existing)
3. `helm-assert-annotations.sh` made executable (previous commit on main)
4. **This PR:** bump chart version to 0.6.20 so CI publishes the fixed chart

## Test plan

- [ ] CI passes `bazel test //projects/agent_platform/cluster_agents/...` including `linkerd_annotation_test`
- [ ] Chart 0.6.20 is pushed to `ghcr.io/jomcgi/homelab/charts`
- [ ] ArgoCD syncs `cluster-agents` to chart 0.6.20 (~5-10s after merge)
- [ ] SigNoz `cluster-agents Unreachable` alert resolves within one 10-min evaluation window

🤖 Generated with [Claude Code](https://claude.com/claude-code)