### PR TITLE
feat(cluster-agents): make sweep timeout configurable via SWEEP_TIMEOUT

### DIFF
--- a/projects/agent_platform/cluster_agents/deploy/Chart.yaml
+++ b/projects/agent_platform/cluster_agents/deploy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cluster-agents
 description: Autonomous cluster monitoring agents
 type: application
-version: 0.6.20
+version: 0.6.21
 appVersion: "0.2.0"
 annotations:
   org.opencontainers.image.source: "https://github.com/jomcgi/homelab"

--- a/projects/agent_platform/cluster_agents/deploy/application.yaml
+++ b/projects/agent_platform/cluster_agents/deploy/application.yaml
@@ -8,7 +8,7 @@ spec:
   source:
     repoURL: ghcr.io/jomcgi/homelab/charts
     chart: cluster-agents
-    targetRevision: 0.6.20
+    targetRevision: 0.6.21
     helm:
       releaseName: cluster-agents
       # IMPORTANT: Do NOT add podAnnotations here. The chart-version-bot regenerates

--- a/projects/agent_platform/cluster_agents/deploy/templates/deployment.yaml
+++ b/projects/agent_platform/cluster_agents/deploy/templates/deployment.yaml
@@ -78,6 +78,10 @@ spec:
           value: {{ .Values.config.prFixStaleThreshold | quote }}
         - name: NATS_URL
           value: {{ .Values.config.natsUrl | quote }}
+        {{- if .Values.config.sweepTimeout }}
+        - name: SWEEP_TIMEOUT
+          value: {{ .Values.config.sweepTimeout | quote }}
+        {{- end }}
         livenessProbe:
           httpGet:
             path: /health

--- a/projects/agent_platform/cluster_agents/deploy/values.yaml
+++ b/projects/agent_platform/cluster_agents/deploy/values.yaml
@@ -57,6 +57,11 @@ config:
   orchestratorUrl: "http://agent-platform-agent-orchestrator.agent-platform.svc.cluster.local:8080"
   httpPort: "8080"
   patrolInterval: "1h"
+  # sweepTimeout caps how long a single agent sweep (collect→analyze→execute) may run.
+  # A hung HTTP call to SigNoz or the orchestrator cannot block the patrol loop beyond
+  # this deadline. Must be well below patrolInterval (default 5m is intentionally low).
+  # Set to "" to use the compiled-in default (5m).
+  sweepTimeout: ""
   githubRepo: "jomcgi/homelab"
   botAuthors: "ci-format-bot,argocd-image-updater,chart-version-bot"
   testCoverageInterval: "1h"

--- a/projects/agent_platform/cluster_agents/main.go
+++ b/projects/agent_platform/cluster_agents/main.go
@@ -24,6 +24,7 @@ func main() {
 	orchestratorURL := os.Getenv("ORCHESTRATOR_URL")
 	httpPort := envOr("HTTP_PORT", "8080")
 	patrolInterval := envDurationOr("PATROL_INTERVAL", 1*time.Hour)
+	sweepTimeout := envDurationOr("SWEEP_TIMEOUT", 0)
 
 	collector := NewAlertCollector(signozURL, signozToken)
 	orchestrator := NewOrchestratorClient(orchestratorURL)
@@ -55,7 +56,7 @@ func main() {
 		NewPRFixAgent(githubClient, escalator, prFixInterval, prFixStaleThreshold),
 	}
 
-	runner := NewRunner(agents)
+	runner := NewRunner(agents, sweepTimeout)
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
@@ -74,6 +75,7 @@ func main() {
 	slog.Info("cluster-agents starting",
 		"agent_count", len(agents),
 		"patrol_interval", patrolInterval,
+		"sweep_timeout", runner.sweepTimeout,
 		"test_coverage_interval", testCoverageInterval,
 		"readme_freshness_interval", readmeFreshnessInterval,
 		"rules_interval", rulesInterval,

--- a/projects/agent_platform/cluster_agents/runner.go
+++ b/projects/agent_platform/cluster_agents/runner.go
@@ -24,10 +24,14 @@ type Runner struct {
 }
 
 // NewRunner creates a runner for the given agents.
-func NewRunner(agents []Agent) *Runner {
+// If sweepTimeout is zero, defaultSweepTimeout (5 minutes) is used.
+func NewRunner(agents []Agent, sweepTimeout time.Duration) *Runner {
+	if sweepTimeout <= 0 {
+		sweepTimeout = defaultSweepTimeout
+	}
 	return &Runner{
 		agents:       agents,
-		sweepTimeout: defaultSweepTimeout,
+		sweepTimeout: sweepTimeout,
 	}
 }
 

--- a/projects/agent_platform/cluster_agents/runner_test.go
+++ b/projects/agent_platform/cluster_agents/runner_test.go
@@ -48,7 +48,7 @@ func TestRunnerExecutesAgentLoop(t *testing.T) {
 		interval: 50 * time.Millisecond,
 	}
 
-	r := NewRunner([]Agent{agent})
+	r := NewRunner([]Agent{agent}, 0)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 	defer cancel()
@@ -65,7 +65,7 @@ func TestRunnerRunsMultipleAgents(t *testing.T) {
 	a1 := &fakeAgent{name: "agent-1", interval: 50 * time.Millisecond}
 	a2 := &fakeAgent{name: "agent-2", interval: 50 * time.Millisecond}
 
-	r := NewRunner([]Agent{a1, a2})
+	r := NewRunner([]Agent{a1, a2}, 0)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 	defer cancel()
@@ -378,7 +378,7 @@ func TestRunnerContinuesAfterSweepTimeout(t *testing.T) {
 // TestRunnerWithZeroAgents verifies that Run returns immediately (without
 // blocking) when no agents are registered.
 func TestRunnerWithZeroAgents(t *testing.T) {
-	r := NewRunner([]Agent{})
+	r := NewRunner([]Agent{}, 0)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
@@ -394,6 +394,25 @@ func TestRunnerWithZeroAgents(t *testing.T) {
 		// Run returned without waiting for ctx cancellation — correct behaviour.
 	case <-time.After(500 * time.Millisecond):
 		t.Error("Run() with zero agents did not return promptly")
+	}
+}
+
+// TestNewRunnerUsesDefaultSweepTimeoutWhenZero verifies that NewRunner uses
+// defaultSweepTimeout when sweepTimeout is zero, preserving backward compatibility.
+func TestNewRunnerUsesDefaultSweepTimeoutWhenZero(t *testing.T) {
+	r := NewRunner([]Agent{}, 0)
+	if r.sweepTimeout != defaultSweepTimeout {
+		t.Errorf("NewRunner(0): sweepTimeout = %v, want %v", r.sweepTimeout, defaultSweepTimeout)
+	}
+}
+
+// TestNewRunnerHonoursSweepTimeout verifies that NewRunner stores the
+// caller-supplied sweep timeout when it is positive (i.e., non-zero).
+func TestNewRunnerHonoursSweepTimeout(t *testing.T) {
+	want := 2 * time.Minute
+	r := NewRunner([]Agent{}, want)
+	if r.sweepTimeout != want {
+		t.Errorf("NewRunner(%v): sweepTimeout = %v, want %v", want, r.sweepTimeout, want)
 	}
 }
 


### PR DESCRIPTION
## Summary

- **Root cause of the `cluster-agents Unreachable` alert (019cda4d)**: Linkerd service mesh was intercepting and dropping plain HTTP health-check connections from the unmeshed SigNoz OTel `httpcheck` receiver. The fix (Linkerd `config.linkerd.io/skip-inbound-ports: "8080"` annotation) was already applied in chart 0.6.20. This PR ships a follow-up improvement that makes the complementary sweep-timeout mechanism operationally tuneable.
- **What this PR adds**: The `sweepTimeout` that prevents a hung HTTP call to SigNoz or the orchestrator from blocking the patrol loop forever was previously hardcoded at 5 minutes in `runner.go`. It is now wired to a `SWEEP_TIMEOUT` env var (injected from `config.sweepTimeout` in `values.yaml`), so operators can tune it without a code change. The default remains 5 minutes.
- **Observability**: `sweep_timeout` is now logged on startup alongside other intervals, making the effective value visible in SigNoz logs.

## Test plan

- [ ] All existing Go unit tests pass: `//projects/agent_platform/cluster_agents:cluster_agents_test`
- [ ] Two new tests added to `runner_test.go`:
  - `TestNewRunnerUsesDefaultSweepTimeoutWhenZero` — zero input → `defaultSweepTimeout`
  - `TestNewRunnerHonoursSweepTimeout` — positive input stored correctly
- [ ] Helm lint, template, and Linkerd annotation regression tests pass: `//projects/agent_platform/cluster_agents/deploy:*`
- [ ] Chart bumped 0.6.20 → 0.6.21 and `targetRevision` synced in `application.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)