### PR TITLE
fix(cluster-agents): bump chart to 0.6.25 to publish Linkerd annotation fix

### DIFF
--- a/projects/agent_platform/cluster_agents/deploy/Chart.yaml
+++ b/projects/agent_platform/cluster_agents/deploy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cluster-agents
 description: Autonomous cluster monitoring agents
 type: application
-version: 0.6.24
+version: 0.6.25
 appVersion: "0.2.0"
 annotations:
   org.opencontainers.image.source: "https://github.com/jomcgi/homelab"

--- a/projects/agent_platform/cluster_agents/deploy/application.yaml
+++ b/projects/agent_platform/cluster_agents/deploy/application.yaml
@@ -8,7 +8,7 @@ spec:
   source:
     repoURL: ghcr.io/jomcgi/homelab/charts
     chart: cluster-agents
-    targetRevision: 0.6.24
+    targetRevision: 0.6.25
     helm:
       releaseName: cluster-agents
       # IMPORTANT: Do NOT add podAnnotations here. The chart-version-bot regenerates


### PR DESCRIPTION
## Summary

- Chart `0.6.24` was published to the OCI registry (`ghcr.io/jomcgi/homelab/charts/cluster-agents`) **before** the `config.linkerd.io/skip-inbound-ports: "8080"` annotation was added to `values.yaml`
- OCI registries are immutable — republishing the same version is not possible
- Bumps chart to `0.6.25` and updates `targetRevision` in `application.yaml` to match, so CI publishes a new OCI artifact with the Linkerd annotation baked into the default `values.yaml`
- Once ArgoCD deploys `0.6.25`, the Linkerd proxy will stop intercepting inbound port 8080 connections from the unmeshed SigNoz httpcheck receiver, resolving the **'cluster-agents Unreachable'** alert (rule `019cda4d-9837-76b0-b625-0149055459fa`)

## Root Cause

The `cluster-agents` namespace has Linkerd injection enabled (via Kyverno). SigNoz's `httpcheck` receiver polls `http://cluster-agents.cluster-agents.svc.cluster.local:8080/health` from the `signoz` namespace, which is **outside** the mesh. Without `config.linkerd.io/skip-inbound-ports: "8080"`, Linkerd's inbound proxy silently drops TCP connections from unmeshed clients, returning `httpcheck.status = 0` — alert fires after the 10-minute evaluation window.

The annotation was added to `values.yaml` (with regression tests in `BUILD` and `deployment_test.yaml`) but the OCI chart at `0.6.24` predates that change, so a new version is required.

## Test plan

- [ ] CI passes `bazel test //...` — specifically `linkerd_annotation_test` and `linkerd_annotation_production_values_test` in `projects/agent_platform/cluster_agents/deploy/BUILD`
- [ ] CI publishes chart `0.6.25` to `ghcr.io/jomcgi/homelab/charts/cluster-agents`
- [ ] ArgoCD syncs the `cluster-agents` application and deploys the pod with the annotation present
- [ ] SigNoz `httpcheck.status` returns `1` for the health endpoint
- [ ] The 'cluster-agents Unreachable' alert clears

🤖 Generated with [Claude Code](https://claude.com/claude-code)