### PR TITLE
fix(cluster-agents): expose GITHUB_BRANCH config and bump chart to 0.6.27

### DIFF
--- a/projects/agent_platform/cluster_agents/deploy/Chart.yaml
+++ b/projects/agent_platform/cluster_agents/deploy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cluster-agents
 description: Autonomous cluster monitoring agents
 type: application
-version: 0.6.26
+version: 0.6.27
 appVersion: "0.2.0"
 annotations:
   org.opencontainers.image.source: "https://github.com/jomcgi/homelab"

--- a/projects/agent_platform/cluster_agents/deploy/application.yaml
+++ b/projects/agent_platform/cluster_agents/deploy/application.yaml
@@ -8,7 +8,7 @@ spec:
   source:
     repoURL: ghcr.io/jomcgi/homelab/charts
     chart: cluster-agents
-    targetRevision: 0.6.26
+    targetRevision: 0.6.27
     helm:
       releaseName: cluster-agents
       # IMPORTANT: Do NOT add podAnnotations here. The chart-version-bot regenerates

--- a/projects/agent_platform/cluster_agents/deploy/templates/deployment.yaml
+++ b/projects/agent_platform/cluster_agents/deploy/templates/deployment.yaml
@@ -64,6 +64,8 @@ spec:
               key: GITHUB_TOKEN
         - name: GITHUB_REPO
           value: {{ .Values.config.githubRepo | quote }}
+        - name: GITHUB_BRANCH
+          value: {{ .Values.config.githubBranch | quote }}
         - name: BOT_AUTHORS
           value: {{ .Values.config.botAuthors | quote }}
         - name: TEST_COVERAGE_INTERVAL

--- a/projects/agent_platform/cluster_agents/deploy/tests/deployment_test.yaml
+++ b/projects/agent_platform/cluster_agents/deploy/tests/deployment_test.yaml
@@ -85,6 +85,14 @@ tests:
           path: spec.template.metadata.annotations["config.linkerd.io/skip-inbound-ports"]
           value: "8080"
 
+  - it: should set GITHUB_BRANCH env var from config
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GITHUB_BRANCH
+            value: "main"
+
   - it: should retain Linkerd annotation with production valuesObject settings
     # Regression: simulates the exact valuesObject applied by application.yaml in production.
     # The chart-version-bot regenerates valuesObject on every chart bump — if podAnnotations

--- a/projects/agent_platform/cluster_agents/deploy/values.yaml
+++ b/projects/agent_platform/cluster_agents/deploy/values.yaml
@@ -66,6 +66,7 @@ config:
   # Set to "" to use the compiled-in default (5m).
   sweepTimeout: ""
   githubRepo: "jomcgi/homelab"
+  githubBranch: "main"
   botAuthors: "ci-format-bot,argocd-image-updater,chart-version-bot"
   testCoverageInterval: "1h"
   readmeFreshnessInterval: "168h"


### PR DESCRIPTION
## Summary

- **Root cause**: The `cluster-agents Unreachable` alert (SigNoz rule `019cda4d-9837-76b0-b625-0149055459fa`) fires because Linkerd intercepts inbound connections on port 8080 from the unmeshed `signoz` namespace. The `config.linkerd.io/skip-inbound-ports: "8080"` annotation was already added to `values.yaml` defaults in chart 0.6.26, but the chart in the OCI registry needs to be republished so ArgoCD deploys a pod with the annotation.
- **Fix**: Bump chart to **0.6.27** to force ArgoCD to pull and redeploy. The new pod will have the Linkerd bypass annotation, allowing the SigNoz httpcheck receiver to reach `/health` and auto-resolve the alert (~10 min after rollout).
- **Bonus**: Wire `GITHUB_BRANCH` through `values.yaml` → `deployment.yaml` env block. `main.go` reads `GITHUB_BRANCH` via `envOr("GITHUB_BRANCH", "main")` but the env var was not set in the Deployment — it was relying on the Go-level default rather than being explicitly configurable via GitOps.

## Changes

| File | Change |
|------|--------|
| `deploy/values.yaml` | Add `githubBranch: "main"` under `config:` |
| `deploy/templates/deployment.yaml` | Add `GITHUB_BRANCH` env var |
| `deploy/tests/deployment_test.yaml` | Add test asserting `GITHUB_BRANCH` is set |
| `deploy/Chart.yaml` | Bump version `0.6.26` → `0.6.27` |
| `deploy/application.yaml` | Update `targetRevision` `0.6.26` → `0.6.27` |

## Test plan

- [ ] CI: `bazel test //projects/agent_platform/cluster_agents/deploy/...` passes (includes `linkerd_annotation_test`, `linkerd_annotation_production_values_test`, `template_test`, `semgrep_test`)
- [ ] ArgoCD auto-syncs chart 0.6.27 and rolls out new pod with `config.linkerd.io/skip-inbound-ports: "8080"` annotation
- [ ] SigNoz httpcheck reaches `/health` on port 8080 → alert auto-resolves within 10 minutes

🤖 Generated with [Claude Code](https://claude.com/claude-code)