### PR TITLE
fix(signoz): bump force-rollout to restart OTel deployment and fix cluster-agents alert

### DIFF
--- a/projects/platform/signoz/values-prod.yaml
+++ b/projects/platform/signoz/values-prod.yaml
@@ -29,7 +29,7 @@ k8s-infra:
     # OTel does not hot-reload its config — a pod restart is required.
     # Update this value to trigger a new rollout when config changes land.
     podAnnotations:
-      homelab/force-rollout: "2026-03-24"
+      homelab/force-rollout: "2026-03-24-2"
     # Inject Cloudflare Access service token for Zero Trust bypass
     # Create a service token in Cloudflare Zero Trust dashboard:
     # Zero Trust > Access > Service Auth > Create Service Token


### PR DESCRIPTION
## Summary

- Bumps the `homelab/force-rollout` annotation on `signoz-k8s-infra-otel-deployment` from `2026-03-24` to `2026-03-24-2` to trigger a rolling restart
- This causes the OTel process to reload its config, picking up the cluster-agents httpcheck target that was added ~2026-03-11 but never loaded

## Root Cause

The **'cluster-agents Unreachable'** SigNoz alert (rule `019cda4d-9837-76b0-b625-0149055459fa`) has been firing continuously because `httpcheck.status` metrics for `http://cluster-agents.cluster-agents.svc.cluster.local:8080/health` are absent from SigNoz — not because the service is actually unreachable.

The `signoz-k8s-infra-otel-deployment` pod (which runs the httpcheck receivers) **does not hot-reload its OTel config** when the mounted ConfigMap changes. The cluster-agents httpcheck target was added to `values-prod.yaml` on ~2026-03-11, but the OTel pod had been running since 2026-03-08 — it started before the httpcheck target was added and never restarted, so it has been running without the cluster-agents target ever since.

When httpcheck.status has no data for a URL, the SigNoz alert evaluates `httpcheck.status < 1` as true (empty result treated as 0) → alert fires.

## Fix

Changing the `podAnnotations.homelab/force-rollout` value causes the Deployment's pod template spec to differ, which triggers a Kubernetes rolling update. After restart, the OTel process loads the current ConfigMap including:
- `httpcheck/k8s-services` with the cluster-agents `/health` target
- All other httpcheck targets added since March 8

Once the OTel pod restarts and the cluster-agents pod has its Linkerd `config.linkerd.io/skip-inbound-ports: "8080"` annotation (already in values.yaml since chart 0.6.20), httpcheck will succeed and the alert will auto-resolve within ~10 minutes.

## Test plan

- [ ] CI passes (Format ✅, Test ✅)
- [ ] ArgoCD syncs the signoz app and rolls out a new `signoz-k8s-infra-otel-deployment` pod
- [ ] SigNoz begins receiving `httpcheck.status` = 1 for `http://cluster-agents.cluster-agents.svc.cluster.local:8080/health`
- [ ] Alert `019cda4d-9837-76b0-b625-0149055459fa` auto-resolves within one 10-minute eval window

## Related Issues

Closes #1470 — root cause identified there (OTel not hot-reloading config)
See also: #1528, #1530 (Linkerd annotation also verified as fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)