### PR TITLE
fix(cluster-agents): bump chart to 0.6.28 to deploy Linkerd skip-inbound-ports annotation

### DIFF
--- a/projects/agent_platform/cluster_agents/deploy/Chart.yaml
+++ b/projects/agent_platform/cluster_agents/deploy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cluster-agents
 description: Autonomous cluster monitoring agents
 type: application
-version: 0.6.27
+version: 0.6.28
 appVersion: "0.2.0"
 annotations:
   org.opencontainers.image.source: "https://github.com/jomcgi/homelab"

--- a/projects/agent_platform/cluster_agents/deploy/application.yaml
+++ b/projects/agent_platform/cluster_agents/deploy/application.yaml
@@ -8,7 +8,7 @@ spec:
   source:
     repoURL: ghcr.io/jomcgi/homelab/charts
     chart: cluster-agents
-    targetRevision: 0.6.27
+    targetRevision: 0.6.28
     helm:
       releaseName: cluster-agents
       # IMPORTANT: Do NOT add podAnnotations here. The chart-version-bot regenerates


### PR DESCRIPTION
## Summary

- The OCI chart artifact at `0.6.27` was published before `config.linkerd.io/skip-inbound-ports: "8080"` was added to `values.yaml`
- Without this annotation, Linkerd's sidecar proxy drops inbound connections from the unmeshed `signoz` namespace on port 8080, causing `httpcheck.status = 0` and firing the **'cluster-agents Unreachable'** alert (SigNoz rule `019cda4d-9837-76b0-b625-0149055459fa`)
- Bumps `Chart.yaml` version `0.6.27 → 0.6.28` and syncs `application.yaml` `targetRevision` accordingly
- CI will republish the chart OCI artifact at `0.6.28` with the annotation included; ArgoCD auto-syncs within ~5–10s

## Test plan

- [ ] CI passes `bazel test //...` (includes `helm_annotation_test` and `deployment_test.yaml` regression tests that enforce the annotation is present)
- [ ] ArgoCD syncs `cluster-agents` application to `0.6.28`
- [ ] `cluster-agents` pod restarts with `config.linkerd.io/skip-inbound-ports: "8080"` annotation
- [ ] SigNoz `httpcheck.status` returns to `1` for the `cluster-agents` health endpoint
- [ ] 'cluster-agents Unreachable' alert resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)