### PR TITLE
fix(agent-platform): fix orchestrator RBAC namespace and increase sandbox pod quota

### DIFF
--- a/projects/agent_platform/chart/Chart.yaml
+++ b/projects/agent_platform/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: agent-platform
 description: Agent platform — umbrella chart bundling goose sandboxes, MCP servers, and supporting components
 type: application
-version: 0.34.1
+version: 0.34.2
 appVersion: "0.2.0"
 annotations:
   org.opencontainers.image.source: "https://github.com/jomcgi/homelab"
@@ -20,7 +20,7 @@ dependencies:
     condition: goose-sandboxes.enabled
 
   - name: agent-orchestrator
-    version: "0.11.1"
+    version: "0.11.2"
     repository: "file://./orchestrator"
     condition: agent-orchestrator.enabled
 

--- a/projects/agent_platform/chart/orchestrator/Chart.yaml
+++ b/projects/agent_platform/chart/orchestrator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: agent-orchestrator
 description: Orchestrates Goose agent tasks via REST API with NATS-backed queue and state
 type: application
-version: 0.11.1
+version: 0.11.2
 appVersion: "0.1.0"
 annotations:
   org.opencontainers.image.source: "https://github.com/jomcgi/homelab"

--- a/projects/agent_platform/chart/orchestrator/templates/rbac.yaml
+++ b/projects/agent_platform/chart/orchestrator/templates/rbac.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ include "agent-orchestrator.fullname" . }}
-  namespace: {{ .Values.config.sandboxNamespace }}
+  namespace: {{ .Values.config.sandboxNamespace | default .Release.Namespace }}
   labels:
     {{- include "agent-orchestrator.labels" . | nindent 4 }}
 rules:
@@ -24,7 +24,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ include "agent-orchestrator.fullname" . }}
-  namespace: {{ .Values.config.sandboxNamespace }}
+  namespace: {{ .Values.config.sandboxNamespace | default .Release.Namespace }}
   labels:
     {{- include "agent-orchestrator.labels" . | nindent 4 }}
 roleRef:

--- a/projects/agent_platform/deploy/application.yaml
+++ b/projects/agent_platform/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: agent-platform
-      targetRevision: 0.34.1
+      targetRevision: 0.34.2
       helm:
         releaseName: agent-platform
         valueFiles:

--- a/projects/agent_platform/deploy/values.yaml
+++ b/projects/agent_platform/deploy/values.yaml
@@ -196,7 +196,7 @@ agent-orchestrator:
 goose-sandboxes:
   namespace:
     resourceQuota:
-      pods: "10"
+      pods: "15"
   sandboxTemplate:
     env:
       contextForgeUrl: "http://context-forge-gateway-mcp-stack-mcpgateway.mcp.svc.cluster.local:80/mcp"


### PR DESCRIPTION
## Summary

Fixes two bugs that caused orchestrator sandbox pods to be unreachable (DNS resolution failures and pod scheduling failures):

- **RBAC namespace bug**: `orchestrator/templates/rbac.yaml` used `{{ .Values.config.sandboxNamespace }}` directly. Since `sandboxNamespace` defaults to `""`, the Role and RoleBinding were created with an empty namespace, making them invalid — the orchestrator silently lacked permissions to create `SandboxClaim` resources. Fixed to use `| default .Release.Namespace` (consistent with `deployment.yaml` line 45 which already handles this correctly).

- **ResourceQuota too tight**: The `agent-platform` namespace quota was capped at 10 pods in `deploy/values.yaml`. With 9 infrastructure pods + 1 warm-pool pod = 10 at baseline, there was zero headroom for sandbox pods. Any sandbox creation attempt immediately hit the quota ceiling, causing pods to remain unscheduled and their DNS names unresolvable. Increased to 15 (the chart default) to allow up to 5 concurrent sandboxes (matching `MAX_CONCURRENT`).

Chart bumps: orchestrator `0.11.1 → 0.11.2`, umbrella `0.34.1 → 0.34.2`, `application.yaml` `targetRevision` updated to match.

## Test plan

- [ ] CI passes (`bazel test //...` via BuildBuddy)
- [ ] ArgoCD syncs `agent-platform` to chart `0.34.2`
- [ ] Orchestrator Role/RoleBinding appear in `agent-platform` namespace (not empty namespace)
- [ ] `kubectl get resourcequota -n agent-platform` shows pods: 15
- [ ] Submit a test job via `agent-orchestrator-mcp` and verify sandbox pod reaches `Running` state

🤖 Generated with [Claude Code](https://claude.com/claude-code)