### PR TITLE
fix(obsidian): enable headless sync

### DIFF
--- a/projects/obsidian_vault/deploy/values.yaml
+++ b/projects/obsidian_vault/deploy/values.yaml
@@ -1,3 +1,6 @@
+headlessSync:
+  enabled: true
+
 gitSidecar:
   remote: "https://github.com/jomcgi/obsidian-vault.git"
 


### PR DESCRIPTION
## Summary
- Enables the `headlessSync` container in the obsidian-vault deployment
- The headless sync was disabled, so no notes were being pulled from Obsidian Sync — the vault MCP server and git sidecar were running on an empty vault
- With this enabled, `npx obsidian-headless sync --continuous` will pull notes into `/vault`, the git sidecar will commit/push them, and the MCP tools will return actual data

## Test plan
- [ ] Verify the pod restarts with 4/4 containers (headless-sync + git-sidecar + vault-mcp + linkerd-proxy)
- [ ] Check headless-sync container logs for successful Obsidian Sync connection
- [ ] Confirm `obsidian-vault-list-notes` MCP tool returns notes
- [ ] Verify git history appears in the `obsidian-vault` GitHub repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)