### PR TITLE
fix(obsidian): use correct ob CLI for headless sync

### DIFF
--- a/projects/obsidian_vault/chart/Chart.yaml
+++ b/projects/obsidian_vault/chart/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: obsidian-vault
 description: Obsidian vault sync with git audit trail and MCP server
 type: application
-version: 0.4.4
+version: 0.4.5
 appVersion: "0.1.0"

--- a/projects/obsidian_vault/chart/templates/deployment.yaml
+++ b/projects/obsidian_vault/chart/templates/deployment.yaml
@@ -33,10 +33,16 @@ spec:
             - sh
             - -c
             - |
-              npx obsidian-headless sync --continuous --vault /vault
+              set -e
+              npm install -g obsidian-headless
+              ob login --email "$OBSIDIAN_EMAIL" --password "$OBSIDIAN_PASSWORD"
+              ob sync-setup --vault "$VAULT_NAME" --path /vault --password "$OBSIDIAN_PASSWORD"
+              exec ob sync --continuous
           env:
             - name: HOME
               value: /home/vault
+            - name: VAULT_NAME
+              value: {{ .Values.headlessSync.vaultName | quote }}
             - name: OBSIDIAN_EMAIL
               valueFrom:
                 secretKeyRef:

--- a/projects/obsidian_vault/chart/values.yaml
+++ b/projects/obsidian_vault/chart/values.yaml
@@ -1,5 +1,6 @@
 headlessSync:
   enabled: false
+  vaultName: ""
   image:
     repository: node
     tag: "22-alpine"

--- a/projects/obsidian_vault/deploy/application.yaml
+++ b/projects/obsidian_vault/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: obsidian-vault
-      targetRevision: 0.4.4
+      targetRevision: 0.4.5
       helm:
         releaseName: obsidian-vault
         valueFiles:

--- a/projects/obsidian_vault/deploy/values.yaml
+++ b/projects/obsidian_vault/deploy/values.yaml
@@ -1,5 +1,6 @@
 headlessSync:
   enabled: true
+  vaultName: "jomcgi"
 
 gitSidecar:
   remote: "https://github.com/jomcgi/obsidian-vault.git"


### PR DESCRIPTION
## Summary
- Fixes crashlooping headless-sync container — was using invalid `npx obsidian-headless sync` command
- Uses the correct `ob` CLI flow: `ob login` → `ob sync-setup` → `ob sync --continuous`
- Adds `headlessSync.vaultName` config value for `ob sync-setup --vault` flag
- Bumps chart 0.4.4 → 0.4.5 + matching targetRevision

## Test plan
- [ ] Pod starts with 4/4 containers ready (no crashloop)
- [ ] headless-sync logs show successful login, setup, and continuous sync
- [ ] `obsidian-vault-list-notes` MCP tool returns notes
- [ ] Git sidecar starts committing synced notes to GitHub repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)