### PR TITLE
fix(obsidian): install obsidian-headless to user prefix for non-root

### DIFF
--- a/projects/obsidian_vault/chart/Chart.yaml
+++ b/projects/obsidian_vault/chart/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: obsidian-vault
 description: Obsidian vault sync with git audit trail and MCP server
 type: application
-version: 0.4.5
+version: 0.4.6
 appVersion: "0.1.0"

--- a/projects/obsidian_vault/chart/templates/deployment.yaml
+++ b/projects/obsidian_vault/chart/templates/deployment.yaml
@@ -34,6 +34,8 @@ spec:
             - -c
             - |
               set -e
+              npm config set prefix "$HOME/.npm-global"
+              export PATH="$HOME/.npm-global/bin:$PATH"
               npm install -g obsidian-headless
               ob login --email "$OBSIDIAN_EMAIL" --password "$OBSIDIAN_PASSWORD"
               ob sync-setup --vault "$VAULT_NAME" --path /vault --password "$OBSIDIAN_PASSWORD"

--- a/projects/obsidian_vault/deploy/application.yaml
+++ b/projects/obsidian_vault/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: obsidian-vault
-      targetRevision: 0.4.5
+      targetRevision: 0.4.6
       helm:
         releaseName: obsidian-vault
         valueFiles:


### PR DESCRIPTION
## Summary
- `npm install -g` fails with EACCES when running as non-root (uid 65532)
- Sets npm prefix to `$HOME/.npm-global` so the `ob` CLI installs to user-writable directory
- Bumps chart 0.4.5 → 0.4.6

## Test plan
- [ ] headless-sync container starts without EACCES error
- [ ] `ob` CLI is available and login/sync-setup/sync succeed
- [ ] Notes appear in vault MCP tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)