### PR TITLE
fix(obsidian): cd to vault path before running ob sync

### DIFF
--- a/projects/obsidian_vault/chart/Chart.yaml
+++ b/projects/obsidian_vault/chart/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: obsidian-vault
 description: Obsidian vault sync with git audit trail and MCP server
 type: application
-version: 0.4.6
+version: 0.4.7
 appVersion: "0.1.0"

--- a/projects/obsidian_vault/chart/templates/deployment.yaml
+++ b/projects/obsidian_vault/chart/templates/deployment.yaml
@@ -39,6 +39,7 @@ spec:
               npm install -g obsidian-headless
               ob login --email "$OBSIDIAN_EMAIL" --password "$OBSIDIAN_PASSWORD"
               ob sync-setup --vault "$VAULT_NAME" --path /vault --password "$OBSIDIAN_PASSWORD"
+              cd /vault
               exec ob sync --continuous
           env:
             - name: HOME

--- a/projects/obsidian_vault/deploy/application.yaml
+++ b/projects/obsidian_vault/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: obsidian-vault
-      targetRevision: 0.4.6
+      targetRevision: 0.4.7
       helm:
         releaseName: obsidian-vault
         valueFiles:


### PR DESCRIPTION
## Summary
- `ob sync --continuous` was running from `/` instead of `/vault`
- The `ob` CLI resolves vault config from the current working directory, not from the `--path` used during `sync-setup`
- Adds `cd /vault` before `exec ob sync --continuous`

## Test plan
- [ ] headless-sync container no longer crashes with "No sync configuration found"
- [ ] Continuous sync runs and pulls notes from Obsidian Sync
- [ ] MCP tools return vault data

🤖 Generated with [Claude Code](https://claude.com/claude-code)