### PR TITLE
fix(obsidian): set git identity globally for pod restarts

### DIFF
--- a/projects/obsidian_vault/chart/Chart.yaml
+++ b/projects/obsidian_vault/chart/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: obsidian-vault
 description: Obsidian vault sync with git audit trail and MCP server
 type: application
-version: 0.4.7
+version: 0.4.8
 appVersion: "0.1.0"

--- a/projects/obsidian_vault/chart/templates/configmap.yaml
+++ b/projects/obsidian_vault/chart/templates/configmap.yaml
@@ -19,6 +19,8 @@ data:
 
     # Mark vault path as safe (fsGroup chown triggers git's dubious ownership check)
     git config --global --add safe.directory "$VAULT_PATH"
+    git config --global user.email "vault-sidecar@homelab.local"
+    git config --global user.name "vault-sidecar"
 
     # Configure HTTPS auth if GITHUB_TOKEN is provided
     if [ -n "$GITHUB_TOKEN" ]; then
@@ -30,8 +32,6 @@ data:
     # Initialize git repo if needed
     if [ ! -d .git ]; then
         git init
-        git config user.email "vault-sidecar@homelab.local"
-        git config user.name "vault-sidecar"
         if [ -n "$REMOTE" ]; then
             git remote add origin "$REMOTE"
             # Pull existing history if any

--- a/projects/obsidian_vault/deploy/application.yaml
+++ b/projects/obsidian_vault/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: obsidian-vault
-      targetRevision: 0.4.7
+      targetRevision: 0.4.8
       helm:
         releaseName: obsidian-vault
         valueFiles:


### PR DESCRIPTION
## Summary
- Git sidecar crashes with "Author identity unknown" because `git config user.email/name` was only set inside the `if [ ! -d .git ]` init block
- On pod restarts, the PVC-backed `.git` directory already exists, so the init block is skipped
- Moves identity config to `--global` so it's always set on startup

## Test plan
- [ ] Git sidecar no longer crashes with identity error
- [ ] Sidecar commits and pushes synced notes to GitHub repo
- [ ] Pod reaches 4/4 Ready

🤖 Generated with [Claude Code](https://claude.com/claude-code)