### PR TITLE
fix(signoz): bump otelDeployment force-rollout to clear stale httpcheck state

### DIFF
--- a/projects/platform/signoz/values-prod.yaml
+++ b/projects/platform/signoz/values-prod.yaml
@@ -29,7 +29,7 @@ k8s-infra:
     # OTel does not hot-reload its config — a pod restart is required.
     # Update this value to trigger a new rollout when config changes land.
     podAnnotations:
-      homelab/force-rollout: "2026-03-24-2"
+      homelab/force-rollout: "2026-03-26"
     # Inject Cloudflare Access service token for Zero Trust bypass
     # Create a service token in Cloudflare Zero Trust dashboard:
     # Zero Trust > Access > Service Auth > Create Service Token


### PR DESCRIPTION
## Summary

- Bumps `homelab/force-rollout` annotation in `k8s-infra.otelDeployment.podAnnotations` from `2026-03-24-2` to `2026-03-26`
- Forces a fresh SigNoz otelDeployment pod restart to clear stale/backed-off OTel httpcheck receiver state
- Restores `httpcheck.status` metrics for the cluster-agents health endpoint, resolving the `cluster-agents Unreachable` alert (SigNoz rule `019cda4d-9837-76b0-b625-0149055459fa`)

## Root Cause

Investigation confirmed the cluster-agents pod is healthy (2/2 Running, 0 restarts, ArgoCD Synced/Healthy, Linkerd annotation present). The alert is firing because the SigNoz OTel httpcheck receiver stopped producing successful metrics after 2026-03-23T07:21Z — most likely due to a stale/backed-off collector state following repeated failures during pod recovery (PR #1492 force rollout).

OTel does not hot-reload its config; a pod restart is required to reset retry state.

## Test plan

- [ ] CI passes (`bazel test //...`)
- [ ] ArgoCD syncs the signoz app after merge
- [ ] otelDeployment pod restarts with new annotation
- [ ] `httpcheck.status` metric for `cluster-agents.cluster-agents.svc.cluster.local:8080/health` returns to 1
- [ ] `cluster-agents Unreachable` alert stops firing in SigNoz

🤖 Generated with [Claude Code](https://claude.com/claude-code)