### PR TITLE
chore(signoz): remove stale otelDeployment force-rollout annotation

### DIFF
--- a/projects/platform/signoz/values-prod.yaml
+++ b/projects/platform/signoz/values-prod.yaml
@@ -25,11 +25,6 @@ k8s-infra:
       limits:
         cpu: 500m
         memory: 400Mi
-    # Force pod rollout so the otelDeployment picks up config changes.
-    # OTel does not hot-reload its config — a pod restart is required.
-    # Update this value to trigger a new rollout when config changes land.
-    podAnnotations:
-      homelab/force-rollout: "2026-03-26"
     # Inject Cloudflare Access service token for Zero Trust bypass
     # Create a service token in Cloudflare Zero Trust dashboard:
     # Zero Trust > Access > Service Auth > Create Service Token


### PR DESCRIPTION
## Summary

- Removes the temporary `homelab/force-rollout: "2026-03-26"` annotation from `projects/platform/signoz/values-prod.yaml`
- This annotation was added to force an `otelDeployment` pod restart to clear a stale OTel httpcheck backoff state that caused the `cluster-agents Unreachable` alert to fire
- The root cause (Linkerd dropping inbound connections from the unmeshed `signoz` namespace on port 8080) is permanently fixed via `config.linkerd.io/skip-inbound-ports=8080` in `cluster-agents/deploy/values.yaml`, enforced by regression tests

## Background

The `cluster-agents Unreachable` SigNoz alert (rule ID: `019cda4d-9837-76b0-b625-0149055459fa`) was firing due to two root causes:

1. **Root Cause A — Linkerd mesh interop (permanent fix):** The `cluster-agents` namespace has Linkerd injection enabled via Kyverno. The SigNoz OTel `httpcheck` receiver runs from the `signoz` namespace (outside the mesh), so Linkerd's inbound proxy dropped its connections on port 8080. Fixed by adding `config.linkerd.io/skip-inbound-ports: "8080"` to `cluster-agents/deploy/values.yaml` with two regression tests enforcing the annotation persists across chart bumps.

2. **Root Cause B — OTel stale backoff (operational fix, commit `68e7b5c`):** After pod recovery failures around 2026-03-23, the OTel `otelDeployment` httpcheck receiver entered a backed-off state and stopped emitting `httpcheck.status` metrics. Added `homelab/force-rollout: "2026-03-26"` to trigger a pod restart and reset receiver state.

With the pod restarted and the Linkerd fix in place, the `cluster-agents` health endpoint is now reliably reachable. This PR removes the now-stale force-rollout annotation to prevent unnecessary pod restarts on future ArgoCD syncs.

## Test plan

- [ ] `bazel test //...` passes (Helm unit tests for Linkerd annotation regression remain in place)
- [ ] ArgoCD syncs `signoz` application without unexpected pod restarts
- [ ] `cluster-agents Unreachable` alert remains resolved in SigNoz

🤖 Generated with [Claude Code](https://claude.com/claude-code)