### PR TITLE
fix(signoz): remove dead signoz.k8sInfra config and clarify subchart structure

### DIFF
--- a/projects/platform/signoz/values-prod.yaml
+++ b/projects/platform/signoz/values-prod.yaml
@@ -160,6 +160,9 @@ k8s-infra:
             exporters:
               - otlp
 
+# signoz subchart configuration
+# NOTE: k8s-infra is a sibling subchart (not nested inside signoz). Configure
+# the OTel agent/deployment resources and receivers under the top-level k8s-infra key above.
 signoz:
   clickhouse:
     resources:
@@ -208,20 +211,3 @@ signoz:
       limits:
         cpu: 2
         memory: 4Gi
-  k8sInfra:
-    otelAgent:
-      resources:
-        requests:
-          cpu: 100m
-          memory: 200Mi
-        limits:
-          cpu: 500m
-          memory: 500Mi
-    otelDeployment:
-      resources:
-        requests:
-          cpu: 100m
-          memory: 200Mi
-        limits:
-          cpu: 500m
-          memory: 400Mi


### PR DESCRIPTION
## Summary

- Removes the `signoz.k8sInfra` stanza from `values-prod.yaml` that was silently ignored by the Helm chart. The signoz subchart (v0.113.0) does not have k8s-infra as a dependency; k8s-infra is a **sibling** subchart.
- Adds a comment to the `signoz:` section header clarifying that k8s-infra must be configured at the top-level `k8s-infra:` key, preventing this dead config from being re-introduced.

## Context

Triggered by investigation of the **`cluster-agents Unreachable`** SigNoz alert (rule `019cda4d-9837-76b0-b625-0149055459fa`). Root causes identified and addressed:

1. **Linkerd mesh boundary** — `config.linkerd.io/skip-inbound-ports: "8080"` annotation on the cluster-agents Deployment ensures SigNoz's OTel httpcheck (running in the unmeshed `signoz` namespace) can reach port 8080. This annotation is set in `values.yaml` defaults (not `valuesObject`) so it persists across chart-version-bot bumps. Two `helm_annotation_test` BUILD targets and two Helm unit tests enforce this as a regression check.

2. **Stale OTel httpcheck receiver state** — `homelab/force-rollout: "2026-03-26"` in `k8s-infra.otelDeployment.podAnnotations` triggers a fresh pod restart that resets the backed-off receiver state. The dead `signoz.k8sInfra` section was redundant with the top-level `k8s-infra:` config and could mislead operators into thinking resource limits were applied there.

## Test plan

- [ ] CI passes `bazel test //...` — this includes `helm_annotation_test` targets verifying the Linkerd annotation survives production valuesObject overrides
- [ ] `argocd_app` Helm template test for `signoz` renders cleanly without the removed stanza
- [ ] Verify ArgoCD syncs `signoz` app after merge and `otelDeployment` rolls out with the force-rollout annotation

🤖 Generated with [Claude Code](https://claude.com/claude-code)