### PR TITLE
fix(obsidian-vault): make git sidecar resilient to container restarts

### DIFF
--- a/projects/obsidian_vault/chart/Chart.yaml
+++ b/projects/obsidian_vault/chart/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: obsidian-vault
 description: Obsidian vault sync with git audit trail and MCP server
 type: application
-version: 0.4.8
+version: 0.4.9
 appVersion: "0.1.0"

--- a/projects/obsidian_vault/deploy/application.yaml
+++ b/projects/obsidian_vault/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: obsidian-vault
-      targetRevision: 0.4.8
+      targetRevision: 0.4.9
       helm:
         releaseName: obsidian-vault
         valueFiles:

--- a/projects/obsidian_vault/scripts/git-sidecar.sh
+++ b/projects/obsidian_vault/scripts/git-sidecar.sh
@@ -1,5 +1,4 @@
 #!/bin/sh
-set -e
 
 VAULT_PATH="${VAULT_PATH:-/vault}"
 REMOTE="${GIT_REMOTE}"
@@ -9,28 +8,45 @@ LOCKFILE="$VAULT_PATH/.git/mcp.lock"
 
 cd "$VAULT_PATH"
 
-# Configure HTTPS auth if GITHUB_TOKEN is provided
-if [ -n "$GITHUB_TOKEN" ]; then
-	git config --global credential.helper store
-	printf 'https://x-access-token:%s@github.com\n' "$GITHUB_TOKEN" >~/.git-credentials
-	chmod 600 ~/.git-credentials
+# Build remote URL with embedded token (more reliable than credential helper)
+if [ -n "$REMOTE" ] && [ -n "$GITHUB_TOKEN" ]; then
+	TOKEN_REMOTE=$(echo "$REMOTE" | sed "s|https://|https://x-access-token:${GITHUB_TOKEN}@|")
 fi
 
 # Initialize git repo if needed
 if [ ! -d .git ]; then
-	git init
-	git config user.email "vault-sidecar@homelab.local"
-	git config user.name "vault-sidecar"
-	if [ -n "$REMOTE" ]; then
-		git remote add origin "$REMOTE"
-		# Pull existing history if any
-		git fetch origin "$BRANCH" 2>/dev/null &&
-			git checkout -B "$BRANCH" "origin/$BRANCH" 2>/dev/null ||
-			git checkout -b "$BRANCH"
-	fi
+	git init -b "$BRANCH"
 	# Initial commit of any existing files
 	git add -A
 	git diff --cached --quiet || git commit -m "sync: initial vault state"
+fi
+
+# Ensure correct config on every startup (survives restarts)
+git config user.email "vault-sidecar@homelab.local"
+git config user.name "vault-sidecar"
+
+# Ensure remote is configured with current token
+if [ -n "$TOKEN_REMOTE" ]; then
+	if git remote get-url origin >/dev/null 2>&1; then
+		git remote set-url origin "$TOKEN_REMOTE"
+	else
+		git remote add origin "$TOKEN_REMOTE"
+	fi
+fi
+
+# Ensure we're on the correct branch
+CURRENT_BRANCH=$(git branch --show-current)
+if [ "$CURRENT_BRANCH" != "$BRANCH" ]; then
+	git branch -m "$CURRENT_BRANCH" "$BRANCH"
+fi
+
+# Sync with remote if configured
+if [ -n "$TOKEN_REMOTE" ]; then
+	if git fetch origin "$BRANCH" 2>/dev/null; then
+		# Set up tracking and rebase local work on top of remote
+		git branch --set-upstream-to="origin/$BRANCH" "$BRANCH" 2>/dev/null
+		git rebase "origin/$BRANCH" 2>/dev/null || git rebase --abort 2>/dev/null
+	fi
 fi
 
 echo "Git sidecar started. Watching $VAULT_PATH for changes..."
@@ -49,9 +65,16 @@ while true; do
 		git add -A
 		git commit -m "sync: external changes"
 
-		if [ -n "$REMOTE" ]; then
-			git push origin "$BRANCH" 2>/dev/null ||
-				(git pull --rebase origin "$BRANCH" && git push origin "$BRANCH")
+		if [ -n "$TOKEN_REMOTE" ]; then
+			if ! git push origin "$BRANCH" 2>&1; then
+				echo "Push failed, attempting pull --rebase then push..."
+				if git pull --rebase origin "$BRANCH" 2>&1; then
+					git push origin "$BRANCH" 2>&1 || echo "Push failed after rebase, will retry next cycle"
+				else
+					echo "Pull --rebase failed, aborting rebase. Will retry next cycle"
+					git rebase --abort 2>/dev/null
+				fi
+			fi
 		fi
 	fi
 done


### PR DESCRIPTION
## Summary
- **Fix missing remote on restart**: Remote URL + user config + branch name are now re-configured on every container startup, not just during initial `git init`
- **Fix broken auth**: Replaced unreliable `credential.helper store` with token embedded directly in remote URL
- **Fix crash loop**: Removed `set -e`, added explicit error handling so push failures log and retry next cycle instead of killing the sidecar

## Context
The git sidecar was crashing after pod restarts because `.git` persists on the PVC but the init block (which sets up the remote) was skipped on restart. Push failures then crashed the loop via `set -e`. Diagnosed by checking previous container logs which showed `fatal: 'origin' does not appear to be a git repository`.

## Test plan
- [ ] CI passes (format + semgrep)
- [ ] After deploy, verify git-sidecar container logs show startup message without errors
- [ ] Make a change in Obsidian, verify a new commit appears on `obsidian-vault` repo within ~20s

🤖 Generated with [Claude Code](https://claude.com/claude-code)