### PR TITLE
fix(obsidian): configure root logger for reconcile loop visibility

### DIFF
--- a/projects/obsidian_vault/chart/Chart.yaml
+++ b/projects/obsidian_vault/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: obsidian-vault
 description: Obsidian vault sync with git audit trail and MCP server
 type: application
-version: 0.5.3
+version: 0.5.4
 appVersion: "0.2.0"
 dependencies:
   - name: qdrant

--- a/projects/obsidian_vault/deploy/application.yaml
+++ b/projects/obsidian_vault/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: obsidian-vault
-      targetRevision: 0.5.3
+      targetRevision: 0.5.4
       helm:
         releaseName: obsidian-vault
         valueFiles:

--- a/projects/obsidian_vault/vault_mcp/app/main.py
+++ b/projects/obsidian_vault/vault_mcp/app/main.py
@@ -361,6 +361,7 @@ async def _reconcile_loop(settings: Settings) -> None:
 
 
 def main():
+    logging.basicConfig(level=logging.INFO)
     settings = Settings()
     configure(settings)
 


### PR DESCRIPTION
## Summary
- Adds `logging.basicConfig(level=logging.INFO)` to `main()` so that `logging.getLogger(__name__)` calls in the reconcile loop actually emit output
- Without this, the retry init loop and all reconciler error logging was silently dropped because the root logger had no handler
- Bumps chart to 0.5.4

## Context
The semantic search init retry loop (added in #1569) was working correctly but its log output was invisible — uvicorn configures its own loggers but not the root Python logger. This made it impossible to tell whether init was succeeding, failing, or stuck in retries.

## Test plan
- [ ] CI passes (format, test, push images)
- [ ] After deploy, check pod logs for "Initialising embedder" / "Semantic search initialised successfully" messages
- [ ] Verify semantic search works via MCP tool

🤖 Generated with [Claude Code](https://claude.com/claude-code)