### PR TITLE
fix(obsidian): prevent GC of reconcile loop background task

### DIFF
--- a/projects/obsidian_vault/chart/Chart.yaml
+++ b/projects/obsidian_vault/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: obsidian-vault
 description: Obsidian vault sync with git audit trail and MCP server
 type: application
-version: 0.5.4
+version: 0.5.5
 appVersion: "0.2.0"
 dependencies:
   - name: qdrant

--- a/projects/obsidian_vault/deploy/application.yaml
+++ b/projects/obsidian_vault/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: obsidian-vault
-      targetRevision: 0.5.4
+      targetRevision: 0.5.5
       helm:
         releaseName: obsidian-vault
         valueFiles:

--- a/projects/obsidian_vault/vault_mcp/app/main.py
+++ b/projects/obsidian_vault/vault_mcp/app/main.py
@@ -38,6 +38,7 @@ _settings: Settings | None = None
 _lock: asyncio.Lock | None = None
 _embedder: VaultEmbedder | None = None
 _qdrant: QdrantClient | None = None
+_background_tasks: set[asyncio.Task] = set()  # prevent GC of fire-and-forget tasks
 
 
 def configure(settings: Settings) -> None:
@@ -376,7 +377,9 @@ def main():
 
     @app.on_event("startup")
     async def _start_reconciler():
-        asyncio.create_task(_reconcile_loop(settings))
+        task = asyncio.create_task(_reconcile_loop(settings))
+        _background_tasks.add(task)
+        task.add_done_callback(_background_tasks.discard)
 
     import uvicorn
 


### PR DESCRIPTION
## Summary
- Store `asyncio.create_task()` result in a module-level `set` to prevent garbage collection
- The reconcile loop task was being silently destroyed by GC before it ever ran, because the event loop only holds weak references to tasks
- This explains why semantic search never initialized despite the retry loop fix in #1569

## Context
Python's `asyncio.create_task()` [docs warn](https://docs.python.org/3/library/asyncio-task.html#creating-tasks): *"Save a reference to the result of this function, to avoid a task disappearing mid-execution."* The recommended pattern is to store tasks in a set and use `add_done_callback` for cleanup.

## Test plan
- [ ] CI passes
- [ ] After deploy, pod logs show "Initialising embedder" and "Semantic search initialised successfully"
- [ ] `search-semantic` MCP tool returns results instead of "Semantic search not configured"

🤖 Generated with [Claude Code](https://claude.com/claude-code)