### PR TITLE
fix(obsidian): use lifespan wrapper instead of on_event for reconciler

### DIFF
--- a/projects/obsidian_vault/chart/Chart.yaml
+++ b/projects/obsidian_vault/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: obsidian-vault
 description: Obsidian vault sync with git audit trail and MCP server
 type: application
-version: 0.5.5
+version: 0.5.6
 appVersion: "0.2.0"
 dependencies:
   - name: qdrant

--- a/projects/obsidian_vault/deploy/application.yaml
+++ b/projects/obsidian_vault/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: obsidian-vault
-      targetRevision: 0.5.5
+      targetRevision: 0.5.6
       helm:
         releaseName: obsidian-vault
         valueFiles:

--- a/projects/obsidian_vault/vault_mcp/app/main.py
+++ b/projects/obsidian_vault/vault_mcp/app/main.py
@@ -8,6 +8,7 @@ import logging
 import os
 import shutil
 import subprocess
+from contextlib import asynccontextmanager
 from pathlib import Path
 
 from fastmcp import FastMCP
@@ -368,18 +369,27 @@ def main():
 
     app = mcp.http_app()
 
+    # Wrap the existing lifespan to start the reconcile loop.
+    # Starlette ignores on_event("startup") when a lifespan handler exists
+    # (which FastMCP sets up), so we must extend the lifespan instead.
+    original_lifespan = app.router.lifespan_context
+
+    @asynccontextmanager
+    async def lifespan(app):
+        async with original_lifespan(app):
+            task = asyncio.create_task(_reconcile_loop(settings))
+            _background_tasks.add(task)
+            task.add_done_callback(_background_tasks.discard)
+            yield
+
+    app.router.lifespan_context = lifespan
+
     async def healthz(request):
         from starlette.responses import JSONResponse
 
         return JSONResponse({"status": "ok"})
 
     app.add_route("/healthz", healthz)
-
-    @app.on_event("startup")
-    async def _start_reconciler():
-        task = asyncio.create_task(_reconcile_loop(settings))
-        _background_tasks.add(task)
-        task.add_done_callback(_background_tasks.discard)
 
     import uvicorn
 


### PR DESCRIPTION
## Summary
- Replace `@app.on_event("startup")` with a lifespan context manager wrapper
- Starlette **silently ignores** `on_event` handlers when a lifespan handler exists (FastMCP sets one up)
- This was the real root cause: the reconcile loop startup handler was never executing

## Root cause analysis
Three layers of bugs prevented semantic search from initializing:
1. **#1569** — Missing try/except around init (exceptions silently swallowed by `create_task`)
2. **#1573** — Missing `logging.basicConfig()` (log output invisible)
3. **#1574** — Task GC risk (no strong reference to created task)
4. **This PR** — `on_event("startup")` silently ignored by Starlette when FastMCP's lifespan exists

The lifespan wrapper extends FastMCP's existing lifespan to also start the reconcile loop background task.

## Test plan
- [ ] CI passes
- [ ] Pod logs show "Initialising embedder" and "Semantic search initialised successfully"
- [ ] `search-semantic` MCP tool returns actual results

🤖 Generated with [Claude Code](https://claude.com/claude-code)