### PR TITLE
fix(obsidian): increase vault-mcp memory for fastembed ONNX model

### DIFF
--- a/projects/obsidian_vault/chart/Chart.yaml
+++ b/projects/obsidian_vault/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: obsidian-vault
 description: Obsidian vault sync with git audit trail and MCP server
 type: application
-version: 0.5.6
+version: 0.5.7
 appVersion: "0.2.0"
 dependencies:
   - name: qdrant

--- a/projects/obsidian_vault/chart/values.yaml
+++ b/projects/obsidian_vault/chart/values.yaml
@@ -57,10 +57,10 @@ resources:
       memory: "64Mi"
   vaultMcp:
     requests:
-      memory: "512Mi"
+      memory: "1Gi"
       cpu: "100m"
     limits:
-      memory: "768Mi"
+      memory: "1536Mi"
 
 gateway:
   url: ""

--- a/projects/obsidian_vault/deploy/application.yaml
+++ b/projects/obsidian_vault/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: obsidian-vault
-      targetRevision: 0.5.6
+      targetRevision: 0.5.7
       helm:
         releaseName: obsidian-vault
         valueFiles:


### PR DESCRIPTION
## Summary
- Increase vault-mcp memory requests from 512Mi to 1Gi, limits from 768Mi to 1536Mi
- The nomic-embed-text-v1.5 ONNX model needs ~1GB when loaded into ONNX Runtime
- Previous limit caused OOMKill during model initialization (the reconcile loop now starts correctly after #1575)

## Test plan
- [ ] CI passes
- [ ] Pod starts without OOMKill
- [ ] Logs show "Semantic search initialised successfully"
- [ ] `search-semantic` MCP tool returns results

🤖 Generated with [Claude Code](https://claude.com/claude-code)