### PR TITLE
fix(obsidian): bump memory to 2Gi and clear corrupt fastembed cache

### DIFF
--- a/projects/obsidian_vault/chart/Chart.yaml
+++ b/projects/obsidian_vault/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: obsidian-vault
 description: Obsidian vault sync with git audit trail and MCP server
 type: application
-version: 0.5.7
+version: 0.5.8
 appVersion: "0.2.0"
 dependencies:
   - name: qdrant

--- a/projects/obsidian_vault/chart/values.yaml
+++ b/projects/obsidian_vault/chart/values.yaml
@@ -57,10 +57,10 @@ resources:
       memory: "64Mi"
   vaultMcp:
     requests:
-      memory: "1Gi"
+      memory: "1536Mi"
       cpu: "100m"
     limits:
-      memory: "1536Mi"
+      memory: "2Gi"
 
 gateway:
   url: ""

--- a/projects/obsidian_vault/deploy/application.yaml
+++ b/projects/obsidian_vault/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: obsidian-vault
-      targetRevision: 0.5.7
+      targetRevision: 0.5.8
       helm:
         releaseName: obsidian-vault
         valueFiles:

--- a/projects/obsidian_vault/vault_mcp/app/main.py
+++ b/projects/obsidian_vault/vault_mcp/app/main.py
@@ -348,6 +348,11 @@ async def _reconcile_loop(settings: Settings) -> None:
         except Exception:
             _embedder = None
             _qdrant = None
+            # Clear corrupt fastembed cache so next attempt re-downloads
+            cache = Path(settings.embed_cache_dir)
+            if cache.exists():
+                log.info("Clearing fastembed cache at %s", cache)
+                shutil.rmtree(cache, ignore_errors=True)
             log.exception("Failed to initialise semantic search, retrying in 30s")
             await asyncio.sleep(30)
 


### PR DESCRIPTION
## Summary
- Bump vault-mcp memory limit from 1536Mi to 2Gi (requests from 1Gi to 1536Mi)
- Add cache cleanup in the init retry loop — clears `/vault/.cache/fastembed/` on failure
- Previous OOMKills during model download left partial caches causing persistent `NoSuchFile` errors

## Test plan
- [ ] CI passes
- [ ] Pod starts without OOMKill
- [ ] Logs show successful semantic search initialization
- [ ] `search-semantic` returns results

🤖 Generated with [Claude Code](https://claude.com/claude-code)