### PR TITLE
fix(obsidian): bump vault-mcp memory limit to 3Gi

### DIFF
--- a/projects/obsidian_vault/chart/Chart.yaml
+++ b/projects/obsidian_vault/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: obsidian-vault
 description: Obsidian vault sync with git audit trail and MCP server
 type: application
-version: 0.5.8
+version: 0.5.9
 appVersion: "0.2.0"
 dependencies:
   - name: qdrant

--- a/projects/obsidian_vault/chart/values.yaml
+++ b/projects/obsidian_vault/chart/values.yaml
@@ -57,10 +57,10 @@ resources:
       memory: "64Mi"
   vaultMcp:
     requests:
-      memory: "1536Mi"
+      memory: "2Gi"
       cpu: "100m"
     limits:
-      memory: "2Gi"
+      memory: "3Gi"
 
 gateway:
   url: ""

--- a/projects/obsidian_vault/deploy/application.yaml
+++ b/projects/obsidian_vault/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: obsidian-vault
-      targetRevision: 0.5.8
+      targetRevision: 0.5.9
       helm:
         releaseName: obsidian-vault
         valueFiles:


### PR DESCRIPTION
## Summary
- Bump vault-mcp memory limit from 2Gi to 3Gi, requests from 1536Mi to 2Gi
- ONNX Runtime's model loading + inference session creation for nomic-embed-text-v1.5 needs more headroom than expected

## Test plan
- [ ] CI passes
- [ ] Pod starts without OOMKill
- [ ] Semantic search initializes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)