### PR TITLE
fix(obsidian): reduce embedding memory with batch_size=32 and GC

### DIFF
--- a/projects/obsidian_vault/chart/Chart.yaml
+++ b/projects/obsidian_vault/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: obsidian-vault
 description: Obsidian vault sync with git audit trail and MCP server
 type: application
-version: 0.5.11
+version: 0.5.12
 appVersion: "0.2.0"
 dependencies:
   - name: qdrant

--- a/projects/obsidian_vault/deploy/application.yaml
+++ b/projects/obsidian_vault/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: obsidian-vault
-      targetRevision: 0.5.11
+      targetRevision: 0.5.12
       helm:
         releaseName: obsidian-vault
         valueFiles:

--- a/projects/obsidian_vault/vault_mcp/app/embedder.py
+++ b/projects/obsidian_vault/vault_mcp/app/embedder.py
@@ -8,12 +8,17 @@ from fastembed import TextEmbedding
 class VaultEmbedder:
     """Embed text using fastembed (CPU, in-process)."""
 
+    EMBED_BATCH_SIZE = 32
+
     def __init__(self, model: str, cache_dir: str):
-        self._model = TextEmbedding(model_name=model, cache_dir=cache_dir)
+        self._model = TextEmbedding(model_name=model, cache_dir=cache_dir, threads=1)
 
     def embed(self, texts: list[str]) -> list[list[float]]:
         """Embed a batch of texts for indexing."""
-        return [v.tolist() for v in self._model.embed(texts)]
+        return [
+            v.tolist()
+            for v in self._model.embed(texts, batch_size=self.EMBED_BATCH_SIZE)
+        ]
 
     def embed_query(self, text: str) -> list[float]:
         """Embed a single search query."""

--- a/projects/obsidian_vault/vault_mcp/app/reconciler.py
+++ b/projects/obsidian_vault/vault_mcp/app/reconciler.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import gc
 import hashlib
 import logging
 from pathlib import Path
@@ -73,6 +74,8 @@ class VaultReconciler:
             texts = [c["chunk_text"] for c in chunks]
             vectors = self._embedder.embed(texts)
             await self._qdrant.upsert_chunks(chunks, vectors)
+            del texts, vectors, chunks
+            gc.collect()
 
         logger.info(
             "Reconciled: %d embedded, %d deleted, %d unchanged",


### PR DESCRIPTION
## Summary
- Set fastembed `batch_size=32` (down from default 256) — reduces ONNX Runtime intermediate tensor allocation by ~8x per forward pass
- Set `threads=1` on TextEmbedding to limit ONNX Runtime thread pool memory
- Add `gc.collect()` after each file in the reconciler to reclaim memory between embedding batches

Root cause: ONNX Runtime's default batch_size=256 allocates massive intermediate tensors (256 sequences x 512 tokens x multiple layers). The arena allocator never shrinks between calls, so memory accumulated across vault files until OOMKill — even at 8Gi.

## Test plan
- [ ] CI tests pass
- [ ] Pod starts and reconciler completes initial bulk indexing without OOMKill
- [ ] Semantic search returns results
- [ ] After stable, roll back memory limits from 8Gi to ~4Gi

🤖 Generated with [Claude Code](https://claude.com/claude-code)