### PR TITLE
fix(obsidian): bump vault-mcp to 16Gi and disable ONNX arena

### DIFF
--- a/projects/obsidian_vault/chart/Chart.yaml
+++ b/projects/obsidian_vault/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: obsidian-vault
 description: Obsidian vault sync with git audit trail and MCP server
 type: application
-version: 0.5.13
+version: 0.5.14
 appVersion: "0.2.0"
 dependencies:
   - name: qdrant

--- a/projects/obsidian_vault/chart/templates/deployment.yaml
+++ b/projects/obsidian_vault/chart/templates/deployment.yaml
@@ -102,6 +102,8 @@ spec:
             - name: mcp
               containerPort: {{ .Values.vaultMcp.port }}
           env:
+            - name: ORT_DISABLE_ARENA
+              value: "1"
             - name: VAULT_PATH
               value: /vault
             - name: VAULT_PORT

--- a/projects/obsidian_vault/chart/values.yaml
+++ b/projects/obsidian_vault/chart/values.yaml
@@ -51,16 +51,16 @@ resources:
       memory: "384Mi"
   gitSidecar:
     requests:
-      memory: "64Mi"
+      memory: "128Mi"
       cpu: "10m"
     limits:
-      memory: "192Mi"
+      memory: "512Mi"
   vaultMcp:
     requests:
-      memory: "4Gi"
+      memory: "8Gi"
       cpu: "100m"
     limits:
-      memory: "8Gi"
+      memory: "16Gi"
 
 gateway:
   url: ""

--- a/projects/obsidian_vault/deploy/application.yaml
+++ b/projects/obsidian_vault/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: obsidian-vault
-      targetRevision: 0.5.13
+      targetRevision: 0.5.14
       helm:
         releaseName: obsidian-vault
         valueFiles:


### PR DESCRIPTION
## Summary
- Bump vault-mcp memory to 8Gi request / 16Gi limit — nomic-embed-text-v1.5 model loading via ONNX Runtime spikes past 8Gi during graph optimization
- Add `ORT_DISABLE_ARENA=1` env var to prevent ONNX Runtime arena allocator from hoarding memory between inference calls
- Bump git-sidecar to 128Mi request / 512Mi limit — git operations on the vault OOMKill at 192Mi
- Chart version 0.5.14

## Test plan
- [ ] CI passes
- [ ] Pod starts without OOMKill on node-4
- [ ] Reconciler completes initial bulk indexing (check logs for "Reconciled:" message)
- [ ] Semantic search works via MCP tool
- [ ] After stable indexing, roll back memory to lower values in a follow-up PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)