### PR TITLE
fix(obsidian): gitignore fastembed cache to prevent git-sidecar OOM

### DIFF
--- a/projects/obsidian_vault/chart/Chart.yaml
+++ b/projects/obsidian_vault/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: obsidian-vault
 description: Obsidian vault sync with git audit trail and MCP server
 type: application
-version: 0.5.14
+version: 0.5.15
 appVersion: "0.2.0"
 dependencies:
   - name: qdrant

--- a/projects/obsidian_vault/chart/templates/configmap.yaml
+++ b/projects/obsidian_vault/chart/templates/configmap.yaml
@@ -29,6 +29,11 @@ data:
         chmod 600 ~/.git-credentials
     fi
 
+    # Ensure .gitignore excludes non-vault data (fastembed model cache, etc.)
+    if ! grep -q '^\.cache/' .gitignore 2>/dev/null; then
+        echo '.cache/' >> .gitignore
+    fi
+
     # Initialize git repo if needed
     if [ ! -d .git ]; then
         git init

--- a/projects/obsidian_vault/deploy/application.yaml
+++ b/projects/obsidian_vault/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: obsidian-vault
-      targetRevision: 0.5.14
+      targetRevision: 0.5.15
       helm:
         releaseName: obsidian-vault
         valueFiles:


### PR DESCRIPTION
## Summary
- Add `.cache/` to `.gitignore` in the git-sidecar init script
- The fastembed ONNX model cache (~550MB) at `/vault/.cache/fastembed` was being staged by `git add -A`, causing the git-sidecar to OOMKill at 512Mi
- Chart version 0.5.15

## Test plan
- [ ] CI passes
- [ ] git-sidecar stops OOMKilling (currently 6+ restarts)
- [ ] vault-mcp continues indexing without interruption

🤖 Generated with [Claude Code](https://claude.com/claude-code)