### PR TITLE
fix(obsidian): fix git-sidecar OOM by untracking model cache

### DIFF
--- a/projects/obsidian_vault/chart/Chart.yaml
+++ b/projects/obsidian_vault/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: obsidian-vault
 description: Obsidian vault sync with git audit trail and MCP server
 type: application
-version: 0.5.15
+version: 0.5.16
 appVersion: "0.2.0"
 dependencies:
   - name: qdrant

--- a/projects/obsidian_vault/chart/templates/configmap.yaml
+++ b/projects/obsidian_vault/chart/templates/configmap.yaml
@@ -34,6 +34,12 @@ data:
         echo '.cache/' >> .gitignore
     fi
 
+    # Remove model cache from git index if previously tracked (prevents OOM on git add -A)
+    if [ -d .git ] && git ls-files --error-unmatch .cache/ >/dev/null 2>&1; then
+        git rm -r --cached .cache/
+        git commit -m "sync: untrack model cache"
+    fi
+
     # Initialize git repo if needed
     if [ ! -d .git ]; then
         git init

--- a/projects/obsidian_vault/chart/values.yaml
+++ b/projects/obsidian_vault/chart/values.yaml
@@ -54,7 +54,7 @@ resources:
       memory: "128Mi"
       cpu: "10m"
     limits:
-      memory: "512Mi"
+      memory: "1Gi"
   vaultMcp:
     requests:
       memory: "8Gi"

--- a/projects/obsidian_vault/deploy/application.yaml
+++ b/projects/obsidian_vault/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: obsidian-vault
-      targetRevision: 0.5.15
+      targetRevision: 0.5.16
       helm:
         releaseName: obsidian-vault
         valueFiles:


### PR DESCRIPTION
## Summary
- Add `git rm -r --cached .cache/` to sidecar script to remove the ~550MB fastembed model cache from the git index (previously tracked by `git add -A`)
- Bump git-sidecar memory limit from 512Mi to 1Gi for headroom during git operations
- Chart 0.5.15 → 0.5.16

## Context
The `.gitignore` fix in #1585 prevents future staging of `.cache/`, but files already in the git index remain tracked. Git operations on these large tracked files cause the sidecar to OOMKill, which prevents the pod from reaching 4/4 ready — blocking Service endpoints and making vault-mcp unreachable.

## Test plan
- [ ] CI passes
- [ ] Pod reaches 4/4 ready (git-sidecar no longer OOMKilled)
- [ ] Semantic search responds via MCP tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)