### PR TITLE
fix(atlas-operator): migrate chart source to OCI registry

### DIFF
--- a/projects/platform/atlas-operator/deploy/application.yaml
+++ b/projects/platform/atlas-operator/deploy/application.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   project: default
   sources:
-    - repoURL: https://atlasgo.io/charts
+    - repoURL: ghcr.io/ariga/charts
       chart: atlas-operator
       targetRevision: 0.7.28
       helm:


### PR DESCRIPTION
## Summary
- Atlas moved their Helm chart from `https://atlasgo.io/charts` (now 404) to `oci://ghcr.io/ariga/charts/atlas-operator`
- One-line fix: update `repoURL` in the ArgoCD Application
- Blocking monolith deployment (AtlasMigration CRD missing without the operator)

## Test plan
- [ ] CI passes
- [ ] Atlas operator syncs in ArgoCD
- [ ] Monolith app syncs after CRDs become available

🤖 Generated with [Claude Code](https://claude.com/claude-code)