### PR TITLE
fix(atlas-operator): enable ServerSideApply for large CRDs

### DIFF
--- a/projects/platform/atlas-operator/deploy/application.yaml
+++ b/projects/platform/atlas-operator/deploy/application.yaml
@@ -25,6 +25,7 @@ spec:
       selfHeal: true
     syncOptions:
       - CreateNamespace=true
+      - ServerSideApply=true
     retry:
       limit: 5
       backoff:


### PR DESCRIPTION
## Summary
- Atlas CRDs exceed the 262144-byte `last-applied-configuration` annotation limit
- `ServerSideApply=true` avoids this annotation entirely
- Follow-up to #1590 (OCI migration)

## Test plan
- [ ] CI passes
- [ ] Atlas operator CRDs apply successfully
- [ ] Monolith app syncs (depends on AtlasMigration CRD)

🤖 Generated with [Claude Code](https://claude.com/claude-code)