### PR TITLE
fix(monolith): use urlFrom for AtlasMigration secret reference

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.4.0
+version: 0.4.1
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/templates/atlas-migration.yaml
+++ b/projects/monolith/chart/templates/atlas-migration.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "monolith.labels" . | nindent 4 }}
 spec:
-  url:
+  urlFrom:
     secretKeyRef:
       name: {{ include "monolith.fullname" . }}-pg-app
       key: uri

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.4.0
+      targetRevision: 0.4.1
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
## Summary
- Atlas operator CRD expects `urlFrom.secretKeyRef` for secret references, not `url` (plain string only)
- Bumps chart 0.4.0 → 0.4.1

## Test plan
- [ ] CI passes
- [ ] AtlasMigration resource syncs in ArgoCD

🤖 Generated with [Claude Code](https://claude.com/claude-code)