### PR TITLE
fix(cloudnative-pg): enable ServerSideApply for large CRDs

### DIFF
--- a/projects/platform/cloudnative-pg/deploy/application.yaml
+++ b/projects/platform/cloudnative-pg/deploy/application.yaml
@@ -25,6 +25,7 @@ spec:
       selfHeal: true
     syncOptions:
       - CreateNamespace=true
+      - ServerSideApply=true
     retry:
       limit: 5
       backoff:


### PR DESCRIPTION
## Summary
- Adds `ServerSideApply=true` sync option to the CloudNativePG ArgoCD Application
- The `poolers.postgresql.cnpg.io` CRD exceeds the 262144-byte annotation limit, same issue we fixed for Atlas in #1591
- Without the Pooler CRD, the operator crashes → webhook has no endpoints → all CNPG Cluster resources fail to sync

## Test plan
- [ ] PR merges and CI passes
- [ ] ArgoCD syncs the `cloudnative-pg` app successfully
- [ ] `poolers.postgresql.cnpg.io` CRD is created
- [ ] CNPG operator pod becomes Ready
- [ ] Monolith's `monolith-pg` CNPG Cluster syncs successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)