### PR TITLE
fix(monolith): use py3_image entrypoint instead of uvicorn command

### DIFF
--- a/projects/monolith/app/main.py
+++ b/projects/monolith/app/main.py
@@ -58,3 +58,8 @@ try:
     logger.info("OpenTelemetry instrumentation enabled")
 except ImportError:
     logger.info("OpenTelemetry not available, skipping instrumentation")
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.4.1
+version: 0.4.2
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/templates/deployment.yaml
+++ b/projects/monolith/chart/templates/deployment.yaml
@@ -37,7 +37,6 @@ spec:
                 secretKeyRef:
                   name: {{ include "monolith.fullname" . }}-pg-app
                   key: uri
-          command: ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]
           livenessProbe:
             httpGet:
               path: /healthz

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.4.1
+      targetRevision: 0.4.2
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
## Summary
- Removes explicit `command: ["uvicorn", ...]` from the deployment template — `uvicorn` isn't on PATH in apko/py3_image containers
- Adds `if __name__ == "__main__": uvicorn.run(...)` to `main.py` so the py3_image entrypoint starts the server
- Bumps chart to 0.4.2 + targetRevision

The py3_image bundles uvicorn as a Python dependency inside the venv, but it's not a standalone binary on PATH. The image entrypoint runs `main.py` directly, so we need the `uvicorn.run()` call there.

## Test plan
- [ ] CI passes
- [ ] Monolith pod starts successfully (no more CrashLoopBackOff)
- [ ] `private.jomcgi.dev/todo` serves the todo UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)