### PR TITLE
fix(monolith): add package directory to PYTHONPATH in py3_image

### DIFF
--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -60,6 +60,12 @@ py_library(
 py3_image(
     name = "image",
     binary = "//projects/monolith:main",
+    env = {
+        # py3_image sets PYTHONPATH to the workspace root (_main/) but this
+        # project's sibling packages (app/, todo/) need the package directory
+        # on the path too, matching the imports = ["."] used by py_venv_binary.
+        "PYTHONPATH": "/projects/monolith/main.runfiles/_main:/projects/monolith/main.runfiles/_main/projects/monolith",
+    },
     main = "app/main.py",
     repository = "ghcr.io/jomcgi/homelab/projects/monolith/backend",
 )

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.4.3
+version: 0.4.4
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.4.3
+      targetRevision: 0.4.4
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
## Summary
- Adds the monolith package directory to `PYTHONPATH` in the `py3_image` call, fixing `ModuleNotFoundError: No module named 'todo'` at container startup
- `py3_image` sets `PYTHONPATH` to just the workspace root (`_main/`), but sibling packages (`app/`, `todo/`) need the package directory too — matching the `imports=["."]` already used by `py_venv_binary`
- Bumps chart 0.4.3 → 0.4.4 with matching `targetRevision`

## Test plan
- [ ] CI passes (bazel test)
- [ ] Monolith pod starts without ModuleNotFoundError
- [ ] `private.jomcgi.dev` serves the todo UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)