### PR TITLE
fix(monolith): add tzdata runtime dependency

### DIFF
--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -34,6 +34,7 @@ py_venv_binary(
         "@pip//opentelemetry_instrumentation_fastapi",
         "@pip//pydantic",
         "@pip//sqlmodel",
+        "@pip//tzdata",
         "@pip//uvicorn",
     ],
 )
@@ -53,6 +54,7 @@ py_library(
         "@pip//opentelemetry_instrumentation_fastapi",
         "@pip//pydantic",
         "@pip//sqlmodel",
+        "@pip//tzdata",
         "@pip//uvicorn",
     ],
 )

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.4.4
+version: 0.4.5
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.4.4
+      targetRevision: 0.4.5
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
## Summary
- Adds `@pip//tzdata` to `py_venv_binary` and `py_library` runtime deps
- The apko container has no system tz database — `tzdata` is required for `ZoneInfo("America/Vancouver")` in the scheduler
- Was only a test dependency, causing `ZoneInfoNotFoundError` at container startup
- Bumps chart 0.4.4 → 0.4.5 with matching `targetRevision`

## Test plan
- [ ] CI passes
- [ ] Monolith pod starts without ZoneInfoNotFoundError
- [ ] `private.jomcgi.dev` serves the todo UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)