### PR TITLE
feat(monolith): add initial database migration for todo schema

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.4.5
+version: 0.5.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/migrations/20260330000000_initial_schema.sql
+++ b/projects/monolith/chart/migrations/20260330000000_initial_schema.sql
@@ -1,0 +1,16 @@
+-- Create todo schema and tables for the monolith todo app.
+CREATE SCHEMA IF NOT EXISTS todo;
+
+CREATE TABLE todo.tasks (
+    id SERIAL PRIMARY KEY,
+    task TEXT NOT NULL DEFAULT '',
+    done BOOLEAN NOT NULL DEFAULT FALSE,
+    kind TEXT NOT NULL DEFAULT 'daily',
+    position INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE TABLE todo.archives (
+    id SERIAL PRIMARY KEY,
+    date DATE NOT NULL,
+    content TEXT NOT NULL
+);

--- a/projects/monolith/chart/migrations/atlas.sum
+++ b/projects/monolith/chart/migrations/atlas.sum
@@ -1,0 +1,2 @@
+h1:Auyh8m3P4hyK3kV3pE08mFgrsxESLa+0XXhs0GopUuI=
+20260330000000_initial_schema.sql h1:J2futpSW0nJAIRR7nR7ssT7LwXIYrvRI+PkHb5Y4tLI=

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.4.5
+      targetRevision: 0.5.0
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
## Summary
- Adds the initial SQL migration creating the `todo` schema with `tasks` and `archives` tables
- Generates `atlas.sum` checksum file for Atlas Operator integrity verification
- Fixes the `AtlasMigration` resource that was failing with "checksum mismatch" due to empty migrations ConfigMap
- Bumps chart 0.4.5 → 0.5.0 with matching `targetRevision`

## Test plan
- [ ] CI passes
- [ ] AtlasMigration transitions from Degraded to Healthy
- [ ] `private.jomcgi.dev` serves the todo UI with working database

🤖 Generated with [Claude Code](https://claude.com/claude-code)