### PR TITLE
fix(obsidian-vault): configure git in vault-mcp container

### DIFF
--- a/projects/obsidian_vault/chart/Chart.yaml
+++ b/projects/obsidian_vault/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: obsidian-vault
 description: Obsidian vault sync with git audit trail and MCP server
 type: application
-version: 0.5.17
+version: 0.5.18
 appVersion: "0.2.0"
 dependencies:
   - name: qdrant

--- a/projects/obsidian_vault/chart/templates/deployment.yaml
+++ b/projects/obsidian_vault/chart/templates/deployment.yaml
@@ -104,6 +104,23 @@ spec:
           env:
             - name: ORT_DISABLE_ARENA
               value: "1"
+            # Git config via env vars — the git-sidecar's ~/.gitconfig is not
+            # visible from this container, so we must configure safe.directory
+            # and committer identity here for MCP git operations to succeed.
+            - name: GIT_CONFIG_COUNT
+              value: "3"
+            - name: GIT_CONFIG_KEY_0
+              value: safe.directory
+            - name: GIT_CONFIG_VALUE_0
+              value: /vault
+            - name: GIT_CONFIG_KEY_1
+              value: user.email
+            - name: GIT_CONFIG_VALUE_1
+              value: vault-mcp@homelab.local
+            - name: GIT_CONFIG_KEY_2
+              value: user.name
+            - name: GIT_CONFIG_VALUE_2
+              value: vault-mcp
             - name: VAULT_PATH
               value: /vault
             - name: VAULT_PORT

--- a/projects/obsidian_vault/deploy/application.yaml
+++ b/projects/obsidian_vault/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: obsidian-vault
-      targetRevision: 0.5.17
+      targetRevision: 0.5.18
       helm:
         releaseName: obsidian-vault
         valueFiles:

--- a/projects/obsidian_vault/vault_mcp/app/main.py
+++ b/projects/obsidian_vault/vault_mcp/app/main.py
@@ -19,6 +19,8 @@ from projects.obsidian_vault.vault_mcp.app.embedder import VaultEmbedder
 from projects.obsidian_vault.vault_mcp.app.qdrant_client import QdrantClient
 from projects.obsidian_vault.vault_mcp.app.reconciler import VaultReconciler
 
+logger = logging.getLogger(__name__)
+
 
 class Settings(BaseSettings):
     model_config = SettingsConfigDict(env_prefix="VAULT_")
@@ -176,9 +178,13 @@ async def search_semantic(query: str, limit: int = 5) -> dict:
 
 def _git_commit(files: list[str], message: str) -> dict:
     """Stage files and commit with the given message."""
-    for f in files:
-        _git("add", f)
-    _git("commit", "-m", message)
+    try:
+        for f in files:
+            _git("add", f)
+        _git("commit", "-m", message)
+    except subprocess.CalledProcessError as exc:
+        logger.error("git failed: %s\nstderr: %s", exc, exc.stderr)
+        return {"error": f"git failed: {exc.stderr.strip() or exc}"}
     return {"status": "ok", "commit_message": message}
 
 


### PR DESCRIPTION
## Summary
- **Root cause**: vault-mcp container runs `git add`/`git commit` when creating notes via MCP, but had no git config — `safe.directory`, `user.name`, and `user.email` were only configured in the git-sidecar container's `~/.gitconfig`, which isn't visible across containers in the same pod.
- **Fix**: Inject git config via `GIT_CONFIG_COUNT`/`GIT_CONFIG_KEY_N`/`GIT_CONFIG_VALUE_N` env vars in the deployment template — no shared volumes or init containers needed.
- **Bonus**: Added error handling in `_git_commit()` to log stderr and return a structured error dict instead of letting `CalledProcessError` propagate as a 500.

## Test plan
- [ ] CI passes (chart renders correctly with new env vars)
- [ ] After deploy, POST to `/api/notes` returns 201 instead of 502
- [ ] Verify note appears in Obsidian and git log shows vault-mcp as committer

🤖 Generated with [Claude Code](https://claude.com/claude-code)