### PR TITLE
feat(llama-cpp): switch model to gemma-4-26B-A4B-it Q4_K_M

### DIFF
--- a/projects/agent_platform/chart/Chart.yaml
+++ b/projects/agent_platform/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: agent-platform
 description: Agent platform — umbrella chart bundling goose sandboxes, MCP servers, and supporting components
 type: application
-version: 0.34.4
+version: 0.34.5
 appVersion: "0.2.0"
 annotations:
   org.opencontainers.image.source: "https://github.com/jomcgi/homelab"
@@ -20,7 +20,7 @@ dependencies:
     condition: goose-sandboxes.enabled
 
   - name: agent-orchestrator
-    version: "0.11.2"
+    version: "0.11.3"
     repository: "file://./orchestrator"
     condition: agent-orchestrator.enabled
 
@@ -33,4 +33,3 @@ dependencies:
     version: "0.1.0"
     repository: "file://./agent-sandbox"
     condition: agent-sandbox.enabled
-

--- a/projects/agent_platform/chart/orchestrator/Chart.yaml
+++ b/projects/agent_platform/chart/orchestrator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: agent-orchestrator
 description: Orchestrates Goose agent tasks via REST API with NATS-backed queue and state
 type: application
-version: 0.11.2
+version: 0.11.3
 appVersion: "0.1.0"
 annotations:
   org.opencontainers.image.source: "https://github.com/jomcgi/homelab"

--- a/projects/agent_platform/chart/orchestrator/values.yaml
+++ b/projects/agent_platform/chart/orchestrator/values.yaml
@@ -62,7 +62,7 @@ config:
   jobMaxDuration: "168h"
   reconcileInterval: "60s"
   inferenceUrl: ""
-  inferenceModel: "qwen3.5-35b-a3b"
+  inferenceModel: "gemma-4-26b-a4b"
 
 httpRoute:
   enabled: false

--- a/projects/agent_platform/deploy/application.yaml
+++ b/projects/agent_platform/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: agent-platform
-      targetRevision: 0.34.4
+      targetRevision: 0.34.5
       helm:
         releaseName: agent-platform
         valueFiles:

--- a/projects/agent_platform/llama_cpp/deploy/values-prod.yaml
+++ b/projects/agent_platform/llama_cpp/deploy/values-prod.yaml
@@ -1,14 +1,14 @@
 fullnameOverride: "llama-cpp"
 
 image:
-  tag: "server-cuda@sha256:a8ad9d1fd95640cec092d2ac27cb16d71183114c776f2a342e65a1196195c873"
+  tag: "server-cuda"
 
 imagePullSecret:
   enabled: true
 
 modelVolume:
   enabled: true
-  reference: "hf.co/unsloth/Qwen3.5-35B-A3B-GGUF:Qwen3.5-35B-A3B-Q3_K_M"
+  reference: "ghcr.io/jomcgi/models/google/gemma-4-26b-a4b-it:unsloth-gguf-ud-q4-k-m"
   mountPath: "/model-image"
 
 server:
@@ -28,7 +28,7 @@ server:
     - "1"
     - "--metrics"
     - "--alias"
-    - "qwen3.5-35b-a3b"
+    - "gemma-4-26b-a4b"
 
 nodeSelector:
   kubernetes.io/hostname: node-4


### PR DESCRIPTION
## Summary
- Mirror `unsloth/gemma-4-26B-A4B-it-GGUF` (Q4_K_M quantization) to GHCR via hf2oci
- Update llama-cpp `modelVolume.reference` to pull from `ghcr.io/jomcgi/models/google/gemma-4-26b-a4b-it:unsloth-gguf-ud-q4-k-m`
- Update orchestrator `inferenceModel` alias to `gemma-4-26b-a4b`
- Remove pre-existing hardcoded image digest (caught by semgrep)
- Bump orchestrator chart 0.11.2 → 0.11.3, agent-platform chart 0.34.4 → 0.34.5

## Test plan
- [ ] CI passes (format, semgrep, bazel test)
- [ ] ArgoCD syncs llama-cpp with new model volume
- [ ] llama-cpp pod starts and loads gemma-4 GGUF from GHCR
- [ ] Orchestrator picks up new model alias

🤖 Generated with [Claude Code](https://claude.com/claude-code)