### PR TITLE
fix(llama-cpp): pin to b8643 for gemma4 architecture support

### DIFF
--- a/projects/agent_platform/llama_cpp/deploy/values-prod.yaml
+++ b/projects/agent_platform/llama_cpp/deploy/values-prod.yaml
@@ -1,7 +1,7 @@
 fullnameOverride: "llama-cpp"
 
 image:
-  tag: "server-cuda"
+  tag: "server-cuda-b8643"
 
 imagePullSecret:
   enabled: true


### PR DESCRIPTION
## Summary
- Pin llama.cpp image to `server-cuda-b8643` — the rolling `server-cuda` tag predates gemma4 arch support (added in b8637)
- Fixes `CrashLoopBackOff` from `unknown model architecture: 'gemma4'`

## Test plan
- [ ] Pod starts and loads gemma-4-26B-A4B-it GGUF successfully
- [ ] `/health` endpoint returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)