### PR TITLE
fix(linkerd): set webhookFailurePolicy to Fail

### DIFF
--- a/projects/platform/linkerd/values.yaml
+++ b/projects/platform/linkerd/values.yaml
@@ -63,6 +63,10 @@ linkerd-control-plane:
       request: 50Mi
       limit: 100Mi
 
+  # Fail pod creation if the proxy injector is unavailable, rather than
+  # silently creating pods without sidecars (which then crash-loop for days).
+  webhookFailurePolicy: Fail
+
   # Proxy injector
   proxyInjectorResources:
     cpu:


### PR DESCRIPTION
## Summary
- Change Linkerd proxy-injector `webhookFailurePolicy` from `Ignore` (default) to `Fail`
- Prevents pods from being silently created without Linkerd sidecars when the injector is temporarily unavailable
- Root cause of the orchestrator crash-looping for 2.5 days — pod was created without sidecar, container restarts never re-trigger the admission webhook

## Test plan
- [ ] CI passes
- [ ] Linkerd control plane syncs with new webhook config
- [ ] Verify with `kubectl get mutatingwebhookconfiguration linkerd-proxy-injector-webhook-config -o jsonpath='{.webhooks[0].failurePolicy}'` returns `Fail`

🤖 Generated with [Claude Code](https://claude.com/claude-code)