### PR TITLE
test(monolith): add Helm template tests for obsidian readiness probe

### DIFF
--- a/projects/monolith/chart/BUILD
+++ b/projects/monolith/chart/BUILD
@@ -28,15 +28,14 @@ sh_test(
     srcs = ["obsidian_readiness_probe_test.sh"],
     args = [
         "$(rootpath @multitool//tools/helm)",
-        "$(rootpath :Chart.yaml)",
+        "$(rootpath :chart.package)",
         "$(rootpath //projects/monolith/obsidian-image:entrypoint.sh)",
     ],
     data = [
-        ":Chart.yaml",
-        ":values.yaml",
+        ":chart.package",
         "//projects/monolith/obsidian-image:entrypoint.sh",
         "@multitool//tools/helm",
-    ] + glob(["templates/**"]),
+    ],
 )
 
 helm_chart(

--- a/projects/monolith/chart/BUILD
+++ b/projects/monolith/chart/BUILD
@@ -23,6 +23,22 @@ sh_test(
     },
 )
 
+sh_test(
+    name = "obsidian_readiness_probe_test",
+    srcs = ["obsidian_readiness_probe_test.sh"],
+    args = [
+        "$(rootpath @multitool//tools/helm)",
+        "$(rootpath :Chart.yaml)",
+        "$(rootpath //projects/monolith/obsidian-image:entrypoint.sh)",
+    ],
+    data = [
+        ":Chart.yaml",
+        ":values.yaml",
+        "//projects/monolith/obsidian-image:entrypoint.sh",
+        "@multitool//tools/helm",
+    ] + glob(["templates/**"]),
+)
+
 helm_chart(
     name = "chart",
     images = {

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.28.1
+version: 0.28.2
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/obsidian_readiness_probe_test.sh
+++ b/projects/monolith/chart/obsidian_readiness_probe_test.sh
@@ -16,8 +16,8 @@
 set -euo pipefail
 
 if [[ $# -lt 3 ]]; then
-    echo "Usage: $0 <helm-binary> <chart-yaml> <entrypoint-sh>"
-    exit 1
+	echo "Usage: $0 <helm-binary> <chart-yaml> <entrypoint-sh>"
+	exit 1
 fi
 
 HELM="$1"
@@ -29,13 +29,13 @@ PASSED=0
 FAILED=0
 
 pass() {
-    echo "PASSED: $*"
-    PASSED=$((PASSED + 1))
+	echo "PASSED: $*"
+	PASSED=$((PASSED + 1))
 }
 
 fail() {
-    echo "FAILED: $*"
-    FAILED=$((FAILED + 1))
+	echo "FAILED: $*"
+	FAILED=$((FAILED + 1))
 }
 
 # ---------------------------------------------------------------------------
@@ -44,24 +44,24 @@ fail() {
 echo "--- Test 1: obsidian container absent when knowledge.enabled=false ---"
 RENDERED_DEFAULT=$("$HELM" template monolith "$CHART_DIR")
 if echo "$RENDERED_DEFAULT" | grep -q "name: obsidian"; then
-    fail "obsidian container should NOT be present when knowledge.enabled=false"
+	fail "obsidian container should NOT be present when knowledge.enabled=false"
 else
-    pass "obsidian container absent when knowledge.enabled=false (default)"
+	pass "obsidian container absent when knowledge.enabled=false (default)"
 fi
 
 # Render with knowledge enabled for remaining tests
 RENDERED=$("$HELM" template monolith "$CHART_DIR" \
-    --set knowledge.enabled=true \
-    --set knowledge.headlessSync.vaultName=test-vault)
+	--set knowledge.enabled=true \
+	--set knowledge.headlessSync.vaultName=test-vault)
 
 # ---------------------------------------------------------------------------
 # Test 2: obsidian container is present when knowledge.enabled=true
 # ---------------------------------------------------------------------------
 echo "--- Test 2: obsidian container present when knowledge.enabled=true ---"
 if echo "$RENDERED" | grep -q "name: obsidian"; then
-    pass "obsidian container present when knowledge.enabled=true"
+	pass "obsidian container present when knowledge.enabled=true"
 else
-    fail "obsidian container NOT found when knowledge.enabled=true"
+	fail "obsidian container NOT found when knowledge.enabled=true"
 fi
 
 # ---------------------------------------------------------------------------
@@ -72,9 +72,9 @@ echo "--- Test 3: obsidian readiness probe type is exec ---"
 # Verify by checking exec appears after the obsidian container definition.
 # We grep the section between 'name: obsidian' and the next container or volume block.
 if echo "$RENDERED" | grep -A 30 "name: obsidian" | grep -q "exec:"; then
-    pass "obsidian readiness probe uses exec type"
+	pass "obsidian readiness probe uses exec type"
 else
-    fail "obsidian readiness probe exec type NOT found"
+	fail "obsidian readiness probe exec type NOT found"
 fi
 
 # ---------------------------------------------------------------------------
@@ -85,21 +85,21 @@ OBSIDIAN_SECTION=$(echo "$RENDERED" | grep -A 40 "name: obsidian")
 
 # Check for each element of the command (helm may render as flow or block sequence)
 if echo "$OBSIDIAN_SECTION" | grep -qE '"test"|^[[:space:]]+- test$'; then
-    pass "probe command includes 'test'"
+	pass "probe command includes 'test'"
 else
-    fail "probe command 'test' NOT found in obsidian container section"
+	fail "probe command 'test' NOT found in obsidian container section"
 fi
 
 if echo "$OBSIDIAN_SECTION" | grep -qE '"-f"|^[[:space:]]+-[[:space:]]+-f$|^[[:space:]]+"?-f"?$'; then
-    pass "probe command includes '-f' flag"
+	pass "probe command includes '-f' flag"
 else
-    fail "probe command '-f' flag NOT found in obsidian container section"
+	fail "probe command '-f' flag NOT found in obsidian container section"
 fi
 
 if echo "$OBSIDIAN_SECTION" | grep -q "/tmp/ready"; then
-    pass "probe command references /tmp/ready sentinel"
+	pass "probe command references /tmp/ready sentinel"
 else
-    fail "probe command /tmp/ready sentinel NOT found in obsidian container section"
+	fail "probe command /tmp/ready sentinel NOT found in obsidian container section"
 fi
 
 # ---------------------------------------------------------------------------
@@ -107,9 +107,9 @@ fi
 # ---------------------------------------------------------------------------
 echo "--- Test 5: obsidian readiness probe initialDelaySeconds=5 ---"
 if echo "$OBSIDIAN_SECTION" | grep -q "initialDelaySeconds: 5"; then
-    pass "obsidian readiness probe initialDelaySeconds: 5"
+	pass "obsidian readiness probe initialDelaySeconds: 5"
 else
-    fail "obsidian readiness probe initialDelaySeconds: 5 NOT found"
+	fail "obsidian readiness probe initialDelaySeconds: 5 NOT found"
 fi
 
 # ---------------------------------------------------------------------------
@@ -117,9 +117,9 @@ fi
 # ---------------------------------------------------------------------------
 echo "--- Test 6: obsidian readiness probe periodSeconds=10 ---"
 if echo "$OBSIDIAN_SECTION" | grep -q "periodSeconds: 10"; then
-    pass "obsidian readiness probe periodSeconds: 10"
+	pass "obsidian readiness probe periodSeconds: 10"
 else
-    fail "obsidian readiness probe periodSeconds: 10 NOT found"
+	fail "obsidian readiness probe periodSeconds: 10 NOT found"
 fi
 
 # ---------------------------------------------------------------------------
@@ -127,9 +127,9 @@ fi
 # ---------------------------------------------------------------------------
 echo "--- Test 7: /tmp/ready sentinel path consistent with entrypoint.sh ---"
 if grep -q "/tmp/ready" "$ENTRYPOINT"; then
-    pass "entrypoint.sh references /tmp/ready sentinel (consistent with deployment.yaml)"
+	pass "entrypoint.sh references /tmp/ready sentinel (consistent with deployment.yaml)"
 else
-    fail "entrypoint.sh does NOT reference /tmp/ready — sentinel path mismatch!"
+	fail "entrypoint.sh does NOT reference /tmp/ready — sentinel path mismatch!"
 fi
 
 # ---------------------------------------------------------------------------
@@ -138,6 +138,6 @@ fi
 echo ""
 echo "Results: $PASSED passed, $FAILED failed"
 if [[ $FAILED -eq 0 ]]; then
-    echo "All tests passed."
+	echo "All tests passed."
 fi
 exit "$FAILED"

--- a/projects/monolith/chart/obsidian_readiness_probe_test.sh
+++ b/projects/monolith/chart/obsidian_readiness_probe_test.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+# obsidian_readiness_probe_test.sh - Validates the obsidian sidecar readiness probe
+# configuration in the monolith Helm chart.
+#
+# Usage: obsidian_readiness_probe_test.sh <helm-binary> <chart-yaml> <entrypoint-sh>
+#
+# Verifies:
+#   1. The obsidian container is absent when knowledge.enabled=false (default)
+#   2. The obsidian container is present when knowledge.enabled=true
+#   3. The readiness probe uses exec (not httpGet/tcpSocket)
+#   4. The probe command is: test -f /tmp/ready
+#   5. initialDelaySeconds is 5
+#   6. periodSeconds is 10
+#   7. The /tmp/ready sentinel path is consistent with entrypoint.sh
+
+set -euo pipefail
+
+if [[ $# -lt 3 ]]; then
+    echo "Usage: $0 <helm-binary> <chart-yaml> <entrypoint-sh>"
+    exit 1
+fi
+
+HELM="$1"
+CHART_YAML="$2"
+CHART_DIR="$(dirname "$CHART_YAML")"
+ENTRYPOINT="$3"
+
+PASSED=0
+FAILED=0
+
+pass() {
+    echo "PASSED: $*"
+    PASSED=$((PASSED + 1))
+}
+
+fail() {
+    echo "FAILED: $*"
+    FAILED=$((FAILED + 1))
+}
+
+# ---------------------------------------------------------------------------
+# Test 1: obsidian container is absent when knowledge.enabled=false (default)
+# ---------------------------------------------------------------------------
+echo "--- Test 1: obsidian container absent when knowledge.enabled=false ---"
+RENDERED_DEFAULT=$("$HELM" template monolith "$CHART_DIR")
+if echo "$RENDERED_DEFAULT" | grep -q "name: obsidian"; then
+    fail "obsidian container should NOT be present when knowledge.enabled=false"
+else
+    pass "obsidian container absent when knowledge.enabled=false (default)"
+fi
+
+# Render with knowledge enabled for remaining tests
+RENDERED=$("$HELM" template monolith "$CHART_DIR" \
+    --set knowledge.enabled=true \
+    --set knowledge.headlessSync.vaultName=test-vault)
+
+# ---------------------------------------------------------------------------
+# Test 2: obsidian container is present when knowledge.enabled=true
+# ---------------------------------------------------------------------------
+echo "--- Test 2: obsidian container present when knowledge.enabled=true ---"
+if echo "$RENDERED" | grep -q "name: obsidian"; then
+    pass "obsidian container present when knowledge.enabled=true"
+else
+    fail "obsidian container NOT found when knowledge.enabled=true"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 3: readiness probe uses exec (not httpGet or tcpSocket)
+# ---------------------------------------------------------------------------
+echo "--- Test 3: obsidian readiness probe type is exec ---"
+# The obsidian container section should contain 'exec:' in its readinessProbe
+# Verify by checking exec appears after the obsidian container definition.
+# We grep the section between 'name: obsidian' and the next container or volume block.
+if echo "$RENDERED" | grep -A 30 "name: obsidian" | grep -q "exec:"; then
+    pass "obsidian readiness probe uses exec type"
+else
+    fail "obsidian readiness probe exec type NOT found"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 4: probe command is ["test", "-f", "/tmp/ready"]
+# ---------------------------------------------------------------------------
+echo "--- Test 4: probe command contains 'test -f /tmp/ready' ---"
+OBSIDIAN_SECTION=$(echo "$RENDERED" | grep -A 40 "name: obsidian")
+
+# Check for each element of the command (helm may render as flow or block sequence)
+if echo "$OBSIDIAN_SECTION" | grep -qE '"test"|^[[:space:]]+- test$'; then
+    pass "probe command includes 'test'"
+else
+    fail "probe command 'test' NOT found in obsidian container section"
+fi
+
+if echo "$OBSIDIAN_SECTION" | grep -qE '"-f"|^[[:space:]]+-[[:space:]]+-f$|^[[:space:]]+"?-f"?$'; then
+    pass "probe command includes '-f' flag"
+else
+    fail "probe command '-f' flag NOT found in obsidian container section"
+fi
+
+if echo "$OBSIDIAN_SECTION" | grep -q "/tmp/ready"; then
+    pass "probe command references /tmp/ready sentinel"
+else
+    fail "probe command /tmp/ready sentinel NOT found in obsidian container section"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 5: initialDelaySeconds is 5
+# ---------------------------------------------------------------------------
+echo "--- Test 5: obsidian readiness probe initialDelaySeconds=5 ---"
+if echo "$OBSIDIAN_SECTION" | grep -q "initialDelaySeconds: 5"; then
+    pass "obsidian readiness probe initialDelaySeconds: 5"
+else
+    fail "obsidian readiness probe initialDelaySeconds: 5 NOT found"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 6: periodSeconds is 10
+# ---------------------------------------------------------------------------
+echo "--- Test 6: obsidian readiness probe periodSeconds=10 ---"
+if echo "$OBSIDIAN_SECTION" | grep -q "periodSeconds: 10"; then
+    pass "obsidian readiness probe periodSeconds: 10"
+else
+    fail "obsidian readiness probe periodSeconds: 10 NOT found"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 7: /tmp/ready sentinel path is consistent with entrypoint.sh
+# ---------------------------------------------------------------------------
+echo "--- Test 7: /tmp/ready sentinel path consistent with entrypoint.sh ---"
+if grep -q "/tmp/ready" "$ENTRYPOINT"; then
+    pass "entrypoint.sh references /tmp/ready sentinel (consistent with deployment.yaml)"
+else
+    fail "entrypoint.sh does NOT reference /tmp/ready — sentinel path mismatch!"
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+echo "Results: $PASSED passed, $FAILED failed"
+if [[ $FAILED -eq 0 ]]; then
+    echo "All tests passed."
+fi
+exit "$FAILED"

--- a/projects/monolith/chart/obsidian_readiness_probe_test.sh
+++ b/projects/monolith/chart/obsidian_readiness_probe_test.sh
@@ -2,7 +2,7 @@
 # obsidian_readiness_probe_test.sh - Validates the obsidian sidecar readiness probe
 # configuration in the monolith Helm chart.
 #
-# Usage: obsidian_readiness_probe_test.sh <helm-binary> <chart-yaml> <entrypoint-sh>
+# Usage: obsidian_readiness_probe_test.sh <helm-binary> <chart-tgz> <entrypoint-sh>
 #
 # Verifies:
 #   1. The obsidian container is absent when knowledge.enabled=false (default)
@@ -16,13 +16,12 @@
 set -euo pipefail
 
 if [[ $# -lt 3 ]]; then
-	echo "Usage: $0 <helm-binary> <chart-yaml> <entrypoint-sh>"
+	echo "Usage: $0 <helm-binary> <chart-tgz> <entrypoint-sh>"
 	exit 1
 fi
 
 HELM="$1"
-CHART_YAML="$2"
-CHART_DIR="$(dirname "$CHART_YAML")"
+CHART_TGZ="$2"
 ENTRYPOINT="$3"
 
 PASSED=0
@@ -42,7 +41,7 @@ fail() {
 # Test 1: obsidian container is absent when knowledge.enabled=false (default)
 # ---------------------------------------------------------------------------
 echo "--- Test 1: obsidian container absent when knowledge.enabled=false ---"
-RENDERED_DEFAULT=$("$HELM" template monolith "$CHART_DIR")
+RENDERED_DEFAULT=$("$HELM" template monolith "$CHART_TGZ")
 if echo "$RENDERED_DEFAULT" | grep -q "name: obsidian"; then
 	fail "obsidian container should NOT be present when knowledge.enabled=false"
 else
@@ -50,7 +49,7 @@ else
 fi
 
 # Render with knowledge enabled for remaining tests
-RENDERED=$("$HELM" template monolith "$CHART_DIR" \
+RENDERED=$("$HELM" template monolith "$CHART_TGZ" \
 	--set knowledge.enabled=true \
 	--set knowledge.headlessSync.vaultName=test-vault)
 

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.28.1
+      targetRevision: 0.28.2
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/obsidian-image/BUILD
+++ b/projects/monolith/obsidian-image/BUILD
@@ -3,6 +3,10 @@
 load("@aspect_bazel_lib//lib:tar.bzl", "tar")
 load("//bazel/tools/oci:apko_image.bzl", "apko_image")
 
+# Export entrypoint.sh so it can be referenced by Helm chart tests that verify
+# the /tmp/ready sentinel path is consistent with the readiness probe in deployment.yaml.
+exports_files(["entrypoint.sh"])
+
 # Package obsidian-headless CLI with all transitive JavaScript dependencies.
 # pnpm hoist=false means transitive deps (bindings, file-uri-to-path) are not
 # siblings of obsidian-headless — they must be listed explicitly.


### PR DESCRIPTION
## Summary

- Add `obsidian_readiness_probe_test.sh` with 9 unit tests for the obsidian sidecar readiness probe in the monolith Helm chart
- Add `sh_test` target `obsidian_readiness_probe_test` to `projects/monolith/chart/BUILD`
- Export `entrypoint.sh` from `projects/monolith/obsidian-image/BUILD` so it can be referenced by the chart tests

## Tests

The test covers all required scenarios:
1. **knowledge.enabled=false (default):** obsidian container is absent from rendered output
2. **knowledge.enabled=true:** obsidian container is present in rendered output
3. **Probe type:** readinessProbe uses `exec` (not `httpGet` or `tcpSocket`)
4. **Probe command - test:** command array contains `test`
5. **Probe command - flag:** command array contains `-f`
6. **Probe command - path:** command array references `/tmp/ready` sentinel
7. **initialDelaySeconds:** value is `5`
8. **periodSeconds:** value is `10`
9. **Sentinel consistency:** `/tmp/ready` path in `entrypoint.sh` matches the probe in `deployment.yaml`

## Test plan

- [x] Test script validated locally with mock helm binary (9/9 passed)
- [ ] `bb remote test //projects/monolith/chart:obsidian_readiness_probe_test --config=ci` passes in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)