### PR TITLE
fix(monolith): skip embedding for content-free Discord messages

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.27.13
+version: 0.27.14
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chat/bot.py
+++ b/projects/monolith/chat/bot.py
@@ -163,6 +163,16 @@ async def download_image_attachments(
     return results
 
 
+def _has_embeddable_content(message: discord.Message) -> bool:
+    """Return True if the message has text or image attachments that produce a description."""
+    if message.content.strip():
+        return True
+    return any(
+        a.content_type and a.content_type.startswith("image/")
+        for a in message.attachments
+    )
+
+
 class ChatBot(discord.Client):
     def __init__(self):
         intents = discord.Intents.default()
@@ -201,6 +211,15 @@ class ChatBot(discord.Client):
         msg_id = str(message.id)
         channel_id = str(message.channel.id)
         attachments: list[dict] = []
+
+        if not _has_embeddable_content(message):
+            logger.debug(
+                "Message %s has no embeddable content, marking completed", msg_id
+            )
+            with Session(get_engine()) as session:
+                store = MessageStore(session=session, embed_client=self.embed_client)
+                store.mark_completed(msg_id)
+            return
 
         try:
             with Session(get_engine()) as session:

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.27.13
+      targetRevision: 0.27.14
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
## Summary

- Adds `_has_embeddable_content()` helper that returns `True` if a message has text or image attachments (which produce vision descriptions)
- `_process_message` now calls this guard early and marks the lock completed immediately for content-free messages (file uploads, stickers, PDFs)
- Prevents the 400 Bad Request from llama.cpp embeddings endpoint on empty input, and stops the sweep from retrying these messages indefinitely

## Test plan

- [ ] CI passes (existing `bot_test`, `bot_reprocess_test` cover the surrounding paths)
- [ ] Send a Discord message with only a file attachment — should no longer produce `Failed to store message` errors in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)