### PR TITLE
fix(knowledge): skip reconcile cycle when vault is empty but DB has notes

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.27.10
+version: 0.27.11
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.27.10
+      targetRevision: 0.27.11
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/knowledge/reconciler.py
+++ b/projects/monolith/knowledge/reconciler.py
@@ -70,22 +70,6 @@ class Reconciler:
         indexed = self.store.get_indexed()
         on_disk = self._walk(previous_indexed=indexed)
 
-        # Guard against the cold-start race: the vault is an emptyDir that the
-        # Obsidian sidecar populates asynchronously. If the scheduler fires
-        # before sync completes, on_disk will be empty while the DB still has
-        # notes from a prior pod lifetime. Pruning in that state would wipe the
-        # entire knowledge base. Skip this cycle — the next tick will run after
-        # sync has had more time to complete.
-        if not on_disk and indexed:
-            logger.warning(
-                "knowledge: _processed/ is empty but DB has %d indexed notes; "
-                "skipping cycle (vault sync likely in progress)",
-                len(indexed),
-            )
-            return ReconcileStats(
-                upserted=0, deleted=0, unchanged=0, failed=0, skipped_locked=0
-            )
-
         to_upsert = sorted(
             path for path, h in on_disk.items() if indexed.get(path) != h
         )

--- a/projects/monolith/knowledge/reconciler.py
+++ b/projects/monolith/knowledge/reconciler.py
@@ -70,6 +70,22 @@ class Reconciler:
         indexed = self.store.get_indexed()
         on_disk = self._walk(previous_indexed=indexed)
 
+        # Guard against the cold-start race: the vault is an emptyDir that the
+        # Obsidian sidecar populates asynchronously. If the scheduler fires
+        # before sync completes, on_disk will be empty while the DB still has
+        # notes from a prior pod lifetime. Pruning in that state would wipe the
+        # entire knowledge base. Skip this cycle — the next tick will run after
+        # sync has had more time to complete.
+        if not on_disk and indexed:
+            logger.warning(
+                "knowledge: _processed/ is empty but DB has %d indexed notes; "
+                "skipping cycle (vault sync likely in progress)",
+                len(indexed),
+            )
+            return ReconcileStats(
+                upserted=0, deleted=0, unchanged=0, failed=0, skipped_locked=0
+            )
+
         to_upsert = sorted(
             path for path, h in on_disk.items() if indexed.get(path) != h
         )

--- a/projects/monolith/knowledge/reconciler_coverage_test.py
+++ b/projects/monolith/knowledge/reconciler_coverage_test.py
@@ -10,6 +10,10 @@ Fills gaps identified in the coverage review:
 - UnicodeDecodeError in _read_text: logged and re-raised; outer loop counts failure.
 - Nested rollback failures: the three logger.exception("rollback after ... failed")
   paths are exercised via mock injection.
+
+Note: the cold-start vault race (empty _processed/ while DB has notes) is handled
+by _wait_for_vault_sync() in main.py, which gates the scheduler from starting until
+the vault has populated. The reconciler itself does not guard against this case.
 """
 
 from __future__ import annotations
@@ -394,49 +398,3 @@ class TestRollbackFailurePaths:
 
         assert result.failed == 1
         assert any("rollback after frontmatter" in r.message for r in caplog.records)
-
-
-# ---------------------------------------------------------------------------
-# Empty-vault guard: skip deletions when _processed/ is empty but DB has notes
-# ---------------------------------------------------------------------------
-
-
-class TestEmptyVaultGuard:
-    @pytest.mark.asyncio
-    async def test_skips_cycle_when_vault_empty_and_db_has_notes(
-        self, reconciler, tmp_path, session, caplog
-    ):
-        """If _processed/ is empty but the DB still has indexed notes, skip
-        the reconcile cycle entirely.
-
-        This guards against the cold-start race where the scheduler fires
-        before the Obsidian sidecar has finished syncing the emptyDir vault.
-        Without the guard, an empty walk result would cause all DB notes to
-        be pruned.
-        """
-        import logging
-
-        # Seed the DB with one note via a normal run.
-        _write(tmp_path, "seed.md", "---\nid: seed\ntitle: Seed\n---\nBody.")
-        await reconciler.run()
-        assert session.scalars(select(Note)).first() is not None
-
-        # Now empty _processed/ to simulate a pod restart with unsync'd vault.
-        (tmp_path / "_processed" / "seed.md").unlink()
-
-        with caplog.at_level(logging.WARNING, logger="monolith.knowledge.reconciler"):
-            result = await reconciler.run()
-
-        # Cycle skipped: no deletions, DB entry preserved.
-        assert result == _stats()
-        assert session.scalars(select(Note)).first() is not None
-        assert any("vault sync likely in progress" in r.message for r in caplog.records)
-
-    @pytest.mark.asyncio
-    async def test_allows_deletion_when_vault_empty_and_db_empty(
-        self, reconciler, tmp_path, session
-    ):
-        """When both _processed/ and the DB are empty, no guard fires and
-        the cycle completes normally with all-zero stats."""
-        result = await reconciler.run()
-        assert result == _stats()

--- a/projects/monolith/knowledge/reconciler_coverage_test.py
+++ b/projects/monolith/knowledge/reconciler_coverage_test.py
@@ -394,3 +394,49 @@ class TestRollbackFailurePaths:
 
         assert result.failed == 1
         assert any("rollback after frontmatter" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# Empty-vault guard: skip deletions when _processed/ is empty but DB has notes
+# ---------------------------------------------------------------------------
+
+
+class TestEmptyVaultGuard:
+    @pytest.mark.asyncio
+    async def test_skips_cycle_when_vault_empty_and_db_has_notes(
+        self, reconciler, tmp_path, session, caplog
+    ):
+        """If _processed/ is empty but the DB still has indexed notes, skip
+        the reconcile cycle entirely.
+
+        This guards against the cold-start race where the scheduler fires
+        before the Obsidian sidecar has finished syncing the emptyDir vault.
+        Without the guard, an empty walk result would cause all DB notes to
+        be pruned.
+        """
+        import logging
+
+        # Seed the DB with one note via a normal run.
+        _write(tmp_path, "seed.md", "---\nid: seed\ntitle: Seed\n---\nBody.")
+        await reconciler.run()
+        assert session.scalars(select(Note)).first() is not None
+
+        # Now empty _processed/ to simulate a pod restart with unsync'd vault.
+        (tmp_path / "_processed" / "seed.md").unlink()
+
+        with caplog.at_level(logging.WARNING, logger="monolith.knowledge.reconciler"):
+            result = await reconciler.run()
+
+        # Cycle skipped: no deletions, DB entry preserved.
+        assert result == _stats()
+        assert session.scalars(select(Note)).first() is not None
+        assert any("vault sync likely in progress" in r.message for r in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_allows_deletion_when_vault_empty_and_db_empty(
+        self, reconciler, tmp_path, session
+    ):
+        """When both _processed/ and the DB are empty, no guard fires and
+        the cycle completes normally with all-zero stats."""
+        result = await reconciler.run()
+        assert result == _stats()


### PR DESCRIPTION
## Summary

- The vault is an `emptyDir` populated asynchronously by the Obsidian headless-sync sidecar.
- On pod restart, the scheduler fires within 30s — before sync completes. `_walk()` returns empty, and the reconciler prunes all DB entries (`deleted=32` observed in production).
- Fix: if `on_disk` is empty but `indexed` is non-empty, skip the cycle and log a warning. The next tick (30s later) runs after sync has had more time to complete.
- Two tests added: guard fires when vault empty + DB non-empty; guard does not fire when both are empty.

## Test plan
- [ ] CI passes
- [ ] Next pod restart: reconciler logs "vault sync likely in progress" instead of 30 deletion lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)