### PR TITLE
feat(chat): persist model thinking for durable Show thinking button

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.27.14
+version: 0.28.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.28.0
+version: 0.28.1
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/migrations/20260409000000_chat_thinking.sql
+++ b/projects/monolith/chart/migrations/20260409000000_chat_thinking.sql
@@ -1,0 +1,3 @@
+-- Add thinking column to chat.messages for storing raw model reasoning.
+-- Not embedded -- stored as plain text for retrieval via Discord's "Show thinking" button.
+ALTER TABLE chat.messages ADD COLUMN IF NOT EXISTS thinking TEXT;

--- a/projects/monolith/chart/migrations/atlas.sum
+++ b/projects/monolith/chart/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:8k4z+v1LMA7rE6ZjfJ8Lp6y3fhMfDAKyyWGaEdKmCqc=
+h1:e9H1N14h8mmDuoeUZUyErl4cYas9VapEkUsAZhDmyLc=
 20260330000000_initial_schema.sql h1:J2futpSW0nJAIRR7nR7ssT7LwXIYrvRI+PkHb5Y4tLI=
 20260403000000_chat_schema.sql h1:pERUFC0vzM95etRuzp43XzkCV7lBCzrrtY5Mk7aF3CA=
 20260404000000_chat_attachments.sql h1:tv+Fdbr1rQC5nzUxfaBC0O6fu2OMGgLWf+YNg1WQXi4=
@@ -9,3 +9,4 @@ h1:8k4z+v1LMA7rE6ZjfJ8Lp6y3fhMfDAKyyWGaEdKmCqc=
 20260405200000_message_locks.sql h1:gCeDEd22NoSpyyv1lN6YxMbfniPQnfgl2NB/mWqeBPE=
 20260407000000_scheduled_jobs.sql h1:yJWdqtl20F4KfdMQEvV61hkpPV2pphXnWtwqHMn33ds=
 20260408000000_knowledge_schema.sql h1:FQwkeboWSNNX+VofzkKOuPkfaiH+wAunGlF0W5d0mUA=
+20260409000000_chat_thinking.sql h1:COqiIyBl96tkB31Q3mELcyveb3RSZegl/iKDuaNOghU=

--- a/projects/monolith/chat/bot.py
+++ b/projects/monolith/chat/bot.py
@@ -184,6 +184,23 @@ class ChatBot(discord.Client):
 
     async def on_ready(self):
         logger.info("Discord bot connected as %s", self.user)
+        # Re-register ThinkingView for recent bot messages so the "Show thinking"
+        # button keeps working after a pod restart.
+        try:
+            with Session(get_engine()) as session:
+                store = MessageStore(session=session, embed_client=self.embed_client)
+                messages_with_thinking = store.get_messages_with_thinking()
+            for msg in messages_with_thinking:
+                self.add_view(
+                    ThinkingView(msg.thinking),
+                    message_id=int(msg.discord_message_id),
+                )
+            logger.info(
+                "Re-registered ThinkingView for %d bot messages",
+                len(messages_with_thinking),
+            )
+        except Exception:
+            logger.exception("Failed to re-register ThinkingViews on ready")
 
     async def on_message(self, message: discord.Message):
         # Skip own messages — bot responses are stored explicitly after sending
@@ -276,7 +293,7 @@ class ChatBot(discord.Client):
                 store.mark_completed(msg_id)
             return
 
-        # Store bot response separately
+        # Store bot response separately, including thinking for button persistence
         try:
             with Session(get_engine()) as session:
                 store = MessageStore(session=session, embed_client=self.embed_client)
@@ -287,6 +304,7 @@ class ChatBot(discord.Client):
                     username=self.user.display_name,
                     content=response_text,
                     is_bot=True,
+                    thinking=thinking,
                 )
         except Exception:
             logger.exception("Failed to store bot response for message %s", msg_id)

--- a/projects/monolith/chat/bot_thinking_test.py
+++ b/projects/monolith/chat/bot_thinking_test.py
@@ -256,6 +256,9 @@ class TestThinkingIntegration:
         call_kwargs = message.reply.call_args
         assert call_kwargs[0][0] == "Hello!"
         assert isinstance(call_kwargs[1].get("view"), ThinkingView)
+        # Verify thinking was passed to save_message for the bot response
+        bot_save_call = mock_store.save_message.call_args_list[-1]
+        assert bot_save_call.kwargs.get("thinking") == "reasoning here"
 
     @pytest.mark.asyncio
     async def test_response_without_thinking_no_view(self):
@@ -390,3 +393,80 @@ class TestThinkingIntegration:
             await bot.on_message(message)
 
         message.reply.assert_called_once_with(literal_output)
+
+
+class TestOnReadyThinkingRegistration:
+    @pytest.mark.asyncio
+    async def test_on_ready_registers_views_for_messages_with_thinking(self):
+        """on_ready calls add_view for each stored bot message that has thinking."""
+        bot = _make_bot()
+
+        msg1 = MagicMock()
+        msg1.discord_message_id = "111"
+        msg1.thinking = "thought A"
+        msg2 = MagicMock()
+        msg2.discord_message_id = "222"
+        msg2.thinking = "thought B"
+
+        mock_store = MagicMock()
+        mock_store.get_messages_with_thinking.return_value = [msg1, msg2]
+
+        bot.add_view = MagicMock()
+
+        with (
+            patch("chat.bot.get_engine"),
+            patch("chat.bot.Session") as mock_session_cls,
+            patch("chat.bot.MessageStore", return_value=mock_store),
+        ):
+            ctx = MagicMock()
+            mock_session_cls.return_value.__enter__ = MagicMock(return_value=ctx)
+            mock_session_cls.return_value.__exit__ = MagicMock(return_value=False)
+            await bot.on_ready()
+
+        assert bot.add_view.call_count == 2
+        calls = bot.add_view.call_args_list
+        assert calls[0].kwargs["message_id"] == 111
+        assert calls[1].kwargs["message_id"] == 222
+        assert isinstance(calls[0].args[0], ThinkingView)
+        assert isinstance(calls[1].args[0], ThinkingView)
+
+    @pytest.mark.asyncio
+    async def test_on_ready_no_views_when_no_thinking_messages(self):
+        """on_ready does not call add_view when there are no stored thinking messages."""
+        bot = _make_bot()
+
+        mock_store = MagicMock()
+        mock_store.get_messages_with_thinking.return_value = []
+
+        bot.add_view = MagicMock()
+
+        with (
+            patch("chat.bot.get_engine"),
+            patch("chat.bot.Session") as mock_session_cls,
+            patch("chat.bot.MessageStore", return_value=mock_store),
+        ):
+            ctx = MagicMock()
+            mock_session_cls.return_value.__enter__ = MagicMock(return_value=ctx)
+            mock_session_cls.return_value.__exit__ = MagicMock(return_value=False)
+            await bot.on_ready()
+
+        bot.add_view.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_on_ready_store_failure_does_not_crash(self):
+        """on_ready swallows store errors so the bot still starts."""
+        bot = _make_bot()
+        bot.add_view = MagicMock()
+
+        with (
+            patch("chat.bot.get_engine"),
+            patch("chat.bot.Session") as mock_session_cls,
+            patch("chat.bot.MessageStore", side_effect=Exception("db error")),
+        ):
+            ctx = MagicMock()
+            mock_session_cls.return_value.__enter__ = MagicMock(return_value=ctx)
+            mock_session_cls.return_value.__exit__ = MagicMock(return_value=False)
+            # Should not raise
+            await bot.on_ready()
+
+        bot.add_view.assert_not_called()

--- a/projects/monolith/chat/models.py
+++ b/projects/monolith/chat/models.py
@@ -20,6 +20,7 @@ class Message(SQLModel, table=True):
     username: str
     content: str
     is_bot: bool = Field(default=False)
+    thinking: str | None = Field(default=None)
     embedding: list[float] = Field(sa_column=Column(Vector(1024)))
     created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
 

--- a/projects/monolith/chat/models_test.py
+++ b/projects/monolith/chat/models_test.py
@@ -51,6 +51,7 @@ class TestMessageModel:
             "is_bot",
             "embedding",
             "created_at",
+            "thinking",
         }
         assert expected == columns
 

--- a/projects/monolith/chat/store.py
+++ b/projects/monolith/chat/store.py
@@ -72,6 +72,7 @@ class MessageStore:
                     username=m["username"],
                     content=m["content"],
                     is_bot=m["is_bot"],
+                    thinking=m.get("thinking"),
                     embedding=embedding,
                 )
                 self.session.add(msg)
@@ -116,6 +117,7 @@ class MessageStore:
         content: str,
         is_bot: bool,
         attachments: list[dict] | None = None,
+        thinking: str | None = None,
     ) -> Message | None:
         """Embed and persist a message. Returns None if already stored."""
         msg_dict = {
@@ -126,6 +128,7 @@ class MessageStore:
             "content": content,
             "is_bot": is_bot,
             "attachments": attachments,
+            "thinking": thinking,
         }
         result = await self.save_messages([msg_dict])
         if result.skipped:
@@ -314,6 +317,16 @@ class MessageStore:
         stmt = select(UserChannelSummary).where(
             UserChannelSummary.channel_id == channel_id,
             UserChannelSummary.user_id.in_(user_ids),
+        )
+        return list(self.session.exec(stmt).all())
+
+    def get_messages_with_thinking(self, limit: int = 200) -> list[Message]:
+        """Return recent bot messages that have stored thinking, newest first."""
+        stmt = (
+            select(Message)
+            .where(Message.is_bot == True, Message.thinking != None)  # noqa: E711,E712
+            .order_by(Message.created_at.desc())
+            .limit(limit)
         )
         return list(self.session.exec(stmt).all())
 

--- a/projects/monolith/chat/store_test.py
+++ b/projects/monolith/chat/store_test.py
@@ -236,10 +236,10 @@ class TestThinking:
     @pytest.mark.asyncio
     async def test_get_messages_with_thinking(self, store):
         """get_messages_with_thinking returns only bot messages with thinking."""
-        store.embed_client.embed_batch.return_value = [
-            [0.0] * 1024,
-            [0.0] * 1024,
-            [0.0] * 1024,
+        store.embed_client.embed_batch.side_effect = [
+            [[0.0] * 1024],
+            [[0.0] * 1024],
+            [[0.0] * 1024],
         ]
 
         await store.save_message(

--- a/projects/monolith/chat/store_test.py
+++ b/projects/monolith/chat/store_test.py
@@ -202,3 +202,53 @@ class TestGetAttachments:
         att, blob = result[msg.id][0]
         assert att.filename == "a.png"
         assert blob.description == "Cat"
+
+
+class TestThinking:
+    @pytest.mark.asyncio
+    async def test_save_message_stores_thinking(self, store):
+        """Thinking text is persisted alongside the message."""
+        msg = await store.save_message(
+            discord_message_id="t1",
+            channel_id="ch1",
+            user_id="u1",
+            username="Bot",
+            content="Hello!",
+            is_bot=True,
+            thinking="my reasoning here",
+        )
+        assert msg is not None
+        assert msg.thinking == "my reasoning here"
+
+    @pytest.mark.asyncio
+    async def test_save_message_no_thinking_defaults_none(self, store):
+        """Messages saved without thinking have thinking=None."""
+        msg = await store.save_message(
+            discord_message_id="t2",
+            channel_id="ch1",
+            user_id="u1",
+            username="Alice",
+            content="Hi",
+            is_bot=False,
+        )
+        assert msg.thinking is None
+
+    @pytest.mark.asyncio
+    async def test_get_messages_with_thinking(self, store):
+        """get_messages_with_thinking returns only bot messages with thinking."""
+        store.embed_client.embed_batch.return_value = [
+            [0.0] * 1024,
+            [0.0] * 1024,
+            [0.0] * 1024,
+        ]
+
+        await store.save_message(
+            "m1", "ch1", "u1", "Bot", "resp1", True, thinking="thought1"
+        )
+        await store.save_message("m2", "ch1", "u1", "Bot", "resp2", True, thinking=None)
+        await store.save_message("m3", "ch1", "u2", "Alice", "human msg", False)
+
+        results = store.get_messages_with_thinking()
+        assert len(results) == 1
+        assert results[0].discord_message_id == "m1"
+        assert results[0].thinking == "thought1"

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.28.0
+      targetRevision: 0.28.1
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.27.14
+      targetRevision: 0.28.0
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
## Summary

- Adds `thinking TEXT` column to `chat.messages` (nullable, not embedded) via migration
- Saves raw model thinking text alongside bot responses in the DB
- On `on_ready`, re-registers `ThinkingView` for recent bot messages with stored thinking so the button survives pod restarts
- Adds tests: `TestThinking` in store tests, `TestOnReadyThinkingRegistration` in bot thinking tests, and verifies thinking is passed through to `save_message` in the integration test

## Test plan

- [ ] `store_test.py::TestThinking` — thinking persisted and queryable
- [ ] `bot_thinking_test.py::TestOnReadyThinkingRegistration` — views re-registered on startup
- [ ] `bot_thinking_test.py::TestThinkingIntegration::test_response_with_thinking_adds_view` — thinking kwarg passed to save_message

🤖 Generated with [Claude Code](https://claude.com/claude-code)