### PR TITLE
test(ships): add edge case tests for null coords and static data

### DIFF
--- a/projects/ships/backend/tests/coverage_gaps_test.py
+++ b/projects/ships/backend/tests/coverage_gaps_test.py
@@ -670,3 +670,78 @@ class TestWebsocketLiveDisconnect:
 
         # Even on exception, finally block must call disconnect
         mock_disconnect.assert_called_once_with(mock_ws)
+
+
+# ---------------------------------------------------------------------------
+# 6. Database.should_insert_position() — missing lat/lon keys
+# ---------------------------------------------------------------------------
+
+
+class TestShouldInsertPositionMissingCoordinates:
+    """Test should_insert_position() when lat/lon keys are missing or zero."""
+
+    def test_missing_lat_lon_keys_defaults_to_zero(self):
+        """When lat/lon keys are absent, they default to 0 (equator/prime meridian).
+        A position with no lat/lon but a cached vessel at the same origin
+        is treated as close together, goes through time check."""
+        db = _make_bare_db()
+        # Cache a vessel at origin (0, 0) with a recent timestamp
+        db._position_cache["777"] = _cached(
+            lat=0.0,
+            lon=0.0,
+            speed=0.0,
+            timestamp="2024-06-01T10:00:00Z",
+        )
+
+        # No lat/lon keys: defaults to 0.0 — same location as cache → distance ~0m
+        # Timestamp only 30s later → below DEDUP_TIME_THRESHOLD → deduplicated
+        data = {
+            "mmsi": "777",
+            # lat and lon keys absent — both default to 0
+            "speed": 0.0,
+            "timestamp": "2024-06-01T10:00:30Z",
+        }
+        should_insert, _ = db.should_insert_position(data)
+        # Effectively at same location, within time threshold → deduplicated
+        assert should_insert is False
+
+    def test_missing_lat_key_first_vessel_inserts(self):
+        """First position for a vessel with missing lat/lon still inserts (no cache entry)."""
+        db = _make_bare_db()
+        # No cache entry for this MMSI — first position always inserts
+
+        data = {
+            "mmsi": "888",
+            # lat and lon keys absent — both default to 0
+            "speed": 0.0,
+            "timestamp": "2024-06-01T10:00:00Z",
+        }
+        should_insert, first_seen = db.should_insert_position(data)
+        assert should_insert is True
+        assert first_seen == "2024-06-01T10:00:00Z"
+
+    def test_lat_lon_zero_is_valid_equatorial_position(self):
+        """lat=0, lon=0 is a valid equatorial position - should work with deduplication."""
+        db = _make_bare_db()
+        # Cache a vessel at origin
+        db._position_cache["999"] = _cached(
+            lat=0.0,
+            lon=0.0,
+            speed=0.0,
+            timestamp="2024-06-01T10:00:00Z",
+            first_seen="2024-06-01T09:00:00Z",
+        )
+
+        # Explicit lat=0, lon=0 — same location, well beyond time threshold
+        data = {
+            "mmsi": "999",
+            "lat": 0.0,
+            "lon": 0.0,
+            "speed": 0.0,
+            "timestamp": "2024-06-01T11:00:00Z",  # 1 hour later → beyond time threshold
+        }
+        should_insert, first_seen = db.should_insert_position(data)
+        # Distance = 0 m (not > DEDUP_DISTANCE_METERS), but time > DEDUP_TIME_THRESHOLD → insert
+        assert should_insert is True
+        # Still within moored radius → first_seen preserved from cache
+        assert first_seen == "2024-06-01T09:00:00Z"

--- a/projects/ships/chart/Chart.yaml
+++ b/projects/ships/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: marine
 description: Marine services - AIS vessel tracking and API
 type: application
-version: 0.3.20
+version: 0.3.21
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/ships/deploy/application.yaml
+++ b/projects/ships/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: marine
-      targetRevision: 0.3.20
+      targetRevision: 0.3.21
       helm:
         releaseName: marine
         valueFiles:

--- a/projects/ships/ingest/coverage_gaps_test.py
+++ b/projects/ships/ingest/coverage_gaps_test.py
@@ -317,11 +317,7 @@ class TestProcessStaticDataDimensionEdgeCases:
         service.js = mock_js
 
         # ShipStaticData is an empty dict — falsy → early return
-        message = {
-            "Message": {
-                "ShipStaticData": {}
-            }
-        }
+        message = {"Message": {"ShipStaticData": {}}}
         metadata = {"time_utc": "2024-06-01T10:00:00Z"}
 
         await service._process_static_data(message, "123456789", metadata)

--- a/projects/ships/ingest/coverage_gaps_test.py
+++ b/projects/ships/ingest/coverage_gaps_test.py
@@ -268,3 +268,63 @@ class TestMetricsCounterIncrements:
 
         assert payload["messages_published"] == 0
         assert payload["last_message_time"] is None
+
+
+# ---------------------------------------------------------------------------
+# 4. _process_static_data() — dimension edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestProcessStaticDataDimensionEdgeCases:
+    """Test _process_static_data() dimension handling."""
+
+    @pytest.mark.asyncio
+    async def test_missing_dimension_key_all_none(self):
+        """When Dimension key is absent, dimension_a/b/c/d are all None."""
+        service = AISIngestService()
+        mock_js = AsyncMock()
+        service.js = mock_js
+
+        message = {
+            "Message": {
+                "ShipStaticData": {
+                    "ImoNumber": 1234567,
+                    "CallSign": "ABCD1",
+                    "Name": "TEST VESSEL",
+                    "Type": 70,
+                    # Dimension key is absent
+                    "Destination": "PORT",
+                    "MaximumStaticDraught": 5.5,
+                }
+            }
+        }
+        metadata = {"time_utc": "2024-06-01T10:00:00Z"}
+
+        await service._process_static_data(message, "123456789", metadata)
+
+        mock_js.publish.assert_called_once()
+        published_payload = json.loads(mock_js.publish.call_args[0][1])
+        assert published_payload["dimension_a"] is None
+        assert published_payload["dimension_b"] is None
+        assert published_payload["dimension_c"] is None
+        assert published_payload["dimension_d"] is None
+
+    @pytest.mark.asyncio
+    async def test_empty_ship_static_data_returns_none(self):
+        """When ShipStaticData is empty, function returns without publishing."""
+        service = AISIngestService()
+        mock_js = AsyncMock()
+        service.js = mock_js
+
+        # ShipStaticData is an empty dict — falsy → early return
+        message = {
+            "Message": {
+                "ShipStaticData": {}
+            }
+        }
+        metadata = {"time_utc": "2024-06-01T10:00:00Z"}
+
+        await service._process_static_data(message, "123456789", metadata)
+
+        # publish must NOT have been called
+        mock_js.publish.assert_not_called()


### PR DESCRIPTION
## Summary

- Adds tests for `should_insert_position()` when `lat`/`lon` keys are missing (default to `0`) and when explicitly set to `0.0` (equatorial position)
- Adds tests for `_process_static_data()` with absent `Dimension` key (verifies all dimension fields are `None`) and with empty `ShipStaticData` (verifies no publish occurs)

## Test plan
- [x] `TestShouldInsertPositionMissingCoordinates.test_missing_lat_lon_keys_defaults_to_zero` — missing keys default to `0`, nearby time → deduped
- [x] `TestShouldInsertPositionMissingCoordinates.test_missing_lat_key_first_vessel_inserts` — first-ever position always inserts
- [x] `TestShouldInsertPositionMissingCoordinates.test_lat_lon_zero_is_valid_equatorial_position` — lat=0,lon=0 works normally through dedup logic
- [x] `TestProcessStaticDataDimensionEdgeCases.test_missing_dimension_key_all_none` — absent Dimension → all None dims in published payload
- [x] `TestProcessStaticDataDimensionEdgeCases.test_empty_ship_static_data_returns_none` — empty ShipStaticData → no publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)