### PR TITLE
test(obsidian-vault): add edge case tests for edit_note and _git_commit

### DIFF
--- a/projects/obsidian_vault/vault_mcp/tests/gaps_test.py
+++ b/projects/obsidian_vault/vault_mcp/tests/gaps_test.py
@@ -444,7 +444,12 @@ class TestEditNoteTextNotFound:
         # Create a note with known content
         note = tmp_path / "my_note.md"
         note.write_text("Hello world")
-        result = await edit_note(path="my_note.md", old_text="nonexistent text", new_text="replacement", reason="test")
+        result = await edit_note(
+            path="my_note.md",
+            old_text="nonexistent text",
+            new_text="replacement",
+            reason="test",
+        )
         assert "error" in result
         assert "Text not found" in result["error"]
 
@@ -453,7 +458,9 @@ class TestEditNoteTextNotFound:
         Python's str.replace('', new, 1) inserts new_text at position 0."""
         note = tmp_path / "note.md"
         note.write_text("existing content")
-        result = await edit_note(path="note.md", old_text="", new_text="PREFIX", reason="test")
+        result = await edit_note(
+            path="note.md", old_text="", new_text="PREFIX", reason="test"
+        )
         # Empty string is "found" in any content — edit proceeds
         # str.replace("", "PREFIX", 1) inserts PREFIX at position 0
         assert "error" not in result or result.get("error") is None
@@ -474,6 +481,7 @@ class TestGitCommitErrorHandling:
         from unittest.mock import patch, MagicMock
 
         call_count = 0
+
         def add_succeeds_commit_fails(*args, **kwargs):
             nonlocal call_count
             call_count += 1
@@ -484,6 +492,7 @@ class TestGitCommitErrorHandling:
             return MagicMock()
 
         import projects.obsidian_vault.vault_mcp.app.main as _mod
+
         with patch.object(_mod, "_git", side_effect=add_succeeds_commit_fails):
             result = _git_commit(["some_file.md"], "test message")
 
@@ -496,6 +505,7 @@ class TestGitCommitErrorHandling:
         from unittest.mock import patch, MagicMock
 
         commit_called = False
+
         def add_fails(*args, **kwargs):
             nonlocal commit_called
             if args[0] == "add":
@@ -506,6 +516,7 @@ class TestGitCommitErrorHandling:
             return MagicMock()
 
         import projects.obsidian_vault.vault_mcp.app.main as _mod
+
         with patch.object(_mod, "_git", side_effect=add_fails):
             result = _git_commit(["bad_file.md"], "test message")
 

--- a/projects/obsidian_vault/vault_mcp/tests/gaps_test.py
+++ b/projects/obsidian_vault/vault_mcp/tests/gaps_test.py
@@ -431,3 +431,83 @@ class TestReconcilerGcCollect:
 
         # gc.collect() should be called once per embedded file (2 files)
         assert mock_gc.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# main — edit_note edge cases: old_text not found and empty string
+# ---------------------------------------------------------------------------
+
+
+class TestEditNoteTextNotFound:
+    async def test_old_text_not_in_content_returns_error(self, tmp_path):
+        """edit_note returns error when old_text doesn't exist in the note."""
+        # Create a note with known content
+        note = tmp_path / "my_note.md"
+        note.write_text("Hello world")
+        result = await edit_note(path="my_note.md", old_text="nonexistent text", new_text="replacement", reason="test")
+        assert "error" in result
+        assert "Text not found" in result["error"]
+
+    async def test_old_text_empty_string_matches_start(self, tmp_path):
+        """edit_note with old_text='' always finds the empty string (it's in every string).
+        Python's str.replace('', new, 1) inserts new_text at position 0."""
+        note = tmp_path / "note.md"
+        note.write_text("existing content")
+        result = await edit_note(path="note.md", old_text="", new_text="PREFIX", reason="test")
+        # Empty string is "found" in any content — edit proceeds
+        # str.replace("", "PREFIX", 1) inserts PREFIX at position 0
+        assert "error" not in result or result.get("error") is None
+        # Verify the file was modified — PREFIX should appear at start
+        updated = note.read_text()
+        assert updated.startswith("PREFIX")
+
+
+# ---------------------------------------------------------------------------
+# main — _git_commit partial failure: add succeeds but commit fails
+# ---------------------------------------------------------------------------
+
+
+class TestGitCommitErrorHandling:
+    def test_git_commit_step_failure_returns_error(self, tmp_path):
+        """_git_commit returns error dict when git commit raises CalledProcessError."""
+        import subprocess
+        from unittest.mock import patch, MagicMock
+
+        call_count = 0
+        def add_succeeds_commit_fails(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if args[0] == "commit":
+                err = subprocess.CalledProcessError(1, ["git", "commit"])
+                err.stderr = "nothing to commit"
+                raise err
+            return MagicMock()
+
+        import projects.obsidian_vault.vault_mcp.app.main as _mod
+        with patch.object(_mod, "_git", side_effect=add_succeeds_commit_fails):
+            result = _git_commit(["some_file.md"], "test message")
+
+        assert "error" in result
+        assert "git failed" in result["error"]
+
+    def test_git_add_failure_returns_error_without_commit(self, tmp_path):
+        """_git_commit returns error dict immediately when git add raises CalledProcessError."""
+        import subprocess
+        from unittest.mock import patch, MagicMock
+
+        commit_called = False
+        def add_fails(*args, **kwargs):
+            nonlocal commit_called
+            if args[0] == "add":
+                err = subprocess.CalledProcessError(1, ["git", "add"])
+                err.stderr = "pathspec not found"
+                raise err
+            commit_called = True
+            return MagicMock()
+
+        import projects.obsidian_vault.vault_mcp.app.main as _mod
+        with patch.object(_mod, "_git", side_effect=add_fails):
+            result = _git_commit(["bad_file.md"], "test message")
+
+        assert "error" in result
+        assert not commit_called


### PR DESCRIPTION
## Summary

- Adds tests for `edit_note()` text-not-found path and empty `old_text` edge case
- Adds tests for `_git_commit()` partial failure scenarios: add succeeds/commit fails, and add fails immediately

## Test plan
- [x] `TestEditNoteTextNotFound.test_old_text_not_in_content_returns_error` — verifies `{"error": "Text not found"}` when text missing
- [x] `TestEditNoteTextNotFound.test_old_text_empty_string_matches_start` — `""` is always found; `str.replace("", PREFIX, 1)` inserts at position 0
- [x] `TestGitCommitErrorHandling.test_git_commit_step_failure_returns_error` — git add succeeds but git commit raises → error dict returned
- [x] `TestGitCommitErrorHandling.test_git_add_failure_returns_error_without_commit` — git add raises → commit never called, error dict returned

🤖 Generated with [Claude Code](https://claude.com/claude-code)