### PR TITLE
fix(gardener): pass full raw note content (including frontmatter) to claude

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.27.12
+version: 0.27.13
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.27.12
+      targetRevision: 0.27.13
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/knowledge/gardener.py
+++ b/projects/monolith/knowledge/gardener.py
@@ -175,7 +175,7 @@ class Gardener:
                 processed_root=self.processed_root,
                 title=title,
             )
-            + body
+            + raw
         )
 
         before = (

--- a/projects/monolith/knowledge/gardener_test.py
+++ b/projects/monolith/knowledge/gardener_test.py
@@ -216,6 +216,56 @@ class TestSoftDelete:
 
 class TestIngestOneClaude:
     @pytest.mark.asyncio
+    async def test_prompt_includes_full_raw_content_for_frontmatter_only_note(
+        self, tmp_path
+    ):
+        """Frontmatter-only notes (e.g. book refs) must include the raw YAML in the prompt.
+
+        If only `body` is passed, Claude receives an empty string and has nothing
+        to decompose, causing timeouts and producing no notes.
+        """
+        vault = tmp_path / "vault"
+        vault.mkdir()
+        note = vault / "book.md"
+        raw = (
+            "---\n"
+            "title: The Staff Engineer's Path\n"
+            "author: Tanya Reilly\n"
+            "description: A book about staff engineering.\n"
+            "isbn13: 9781098118709\n"
+            "---\n"
+        )
+        note.write_text(raw)
+        processed = vault / "_processed"
+        processed.mkdir()
+
+        proc_mock = AsyncMock()
+        proc_mock.returncode = 0
+
+        async def fake_communicate():
+            (processed / "staff-path.md").write_text(
+                "---\nid: staff-path\ntitle: Staff Path\ntype: atom\n---\nbody"
+            )
+            return b"", b""
+
+        proc_mock.communicate = fake_communicate
+
+        with patch(
+            "asyncio.create_subprocess_exec", return_value=proc_mock
+        ) as mock_exec:
+            await Gardener(vault_root=vault)._ingest_one(note)
+
+        args = mock_exec.call_args[0]
+        # The prompt is passed via the -p flag as the last positional arg
+        p_idx = list(args).index("-p")
+        prompt = args[p_idx + 1]
+        assert "Tanya Reilly" in prompt, "frontmatter author must appear in prompt"
+        assert "9781098118709" in prompt, "frontmatter isbn must appear in prompt"
+        assert "A book about staff engineering." in prompt, (
+            "description must appear in prompt"
+        )
+
+    @pytest.mark.asyncio
     async def test_spawns_claude_with_correct_flags(self, tmp_path):
         """_ingest_one spawns claude with --dangerously-skip-permissions and cwd=vault_root."""
         vault = tmp_path / "vault"


### PR DESCRIPTION
## Summary

- Notes that store all content as YAML frontmatter (e.g. book references from the Obsidian Books plugin) produced an empty `body` after frontmatter parsing
- Claude received an empty string to decompose, made many reasoning API round-trips with no content, and timed out after 300s
- Fix: pass `raw` (full file content) instead of `body` — frontmatter fields like `description`, `author`, `isbn13` are now visible to Claude

## Root cause

`frontmatter.parse(raw)` returns `(meta, body)` where `body = raw[match.end():]`. For pure-frontmatter notes the body is `""`. The gardener was building the Claude prompt as `header + body`, silently discarding all YAML properties.

## Test

Added `test_prompt_includes_full_raw_content_for_frontmatter_only_note` — verifies that `author`, `isbn13`, and `description` frontmatter fields appear in the prompt passed to Claude.

🤖 Generated with [Claude Code](https://claude.com/claude-code)