### PR TITLE
feat(semgrep): add fastapi-bare-tuple-return rule

### DIFF
--- a/bazel/semgrep/rules/python/fastapi-bare-tuple-return.py
+++ b/bazel/semgrep/rules/python/fastapi-bare-tuple-return.py
@@ -1,0 +1,46 @@
+# Tests for fastapi-bare-tuple-return rule.
+from fastapi import FastAPI, HTTPException
+
+app = FastAPI()
+
+
+# ruleid: fastapi-bare-tuple-return
+@app.get("/bad-404")
+async def bad_404_route():
+    return {"error": "not found"}, 404
+
+
+# ruleid: fastapi-bare-tuple-return
+@app.get("/bad-500")
+async def bad_500_route():
+    return {"error": "server error"}, 500
+
+
+# ruleid: fastapi-bare-tuple-return
+@app.get("/bad-403")
+async def bad_403_route():
+    return {"error": "forbidden"}, 403
+
+
+# ruleid: fastapi-bare-tuple-return
+@app.get("/vessels/{mmsi}")
+async def get_vessel(mmsi: str):
+    return {"error": "Vessel not found"}, 404
+
+
+# ok: using HTTPException raises a proper HTTP response with correct status code
+@app.get("/good-404")
+async def good_404_route():
+    raise HTTPException(status_code=404, detail="Not found")
+
+
+# ok: 2xx status codes are not error responses and are not caught by this rule
+@app.get("/good-200")
+async def good_200_route():
+    return {"data": "ok"}, 200
+
+
+# ok: 3xx status codes are redirects and not caught by this rule
+@app.get("/good-301")
+async def good_301_route():
+    return {"location": "/new"}, 301

--- a/bazel/semgrep/rules/python/fastapi-bare-tuple-return.yaml
+++ b/bazel/semgrep/rules/python/fastapi-bare-tuple-return.yaml
@@ -1,0 +1,24 @@
+rules:
+  - id: fastapi-bare-tuple-return
+    patterns:
+      - pattern: return {...}, $STATUS
+      - metavariable-regex:
+          metavariable: $STATUS
+          regex: "^[45]\\d{2}$"
+    message: >-
+      FastAPI ignores bare-tuple status codes — use
+      `raise HTTPException(status_code=N, detail=...)` instead.
+    languages: [python]
+    severity: ERROR
+    metadata:
+      category: correctness
+      subcategory: fastapi
+      confidence: HIGH
+      likelihood: HIGH
+      impact: HIGH
+      technology: [python, fastapi]
+      description: >-
+        Returning a (dict, int) tuple from a FastAPI route handler does not set
+        the HTTP status code. FastAPI serialises the entire tuple as a JSON array
+        and returns HTTP 200. Use `raise HTTPException(status_code=N, detail=...)`
+        instead.

--- a/bazel/semgrep/tests/BUILD
+++ b/bazel/semgrep/tests/BUILD
@@ -9,6 +9,7 @@ filegroup(
         # Exclude Go-rule reference fixtures that are not tested against yaml_rules.
         # Exclude SQL/generic and kubernetes-specific fixtures that are tested separately.
         exclude = [
+            "fixtures/fastapi-bare-tuple-return.yaml",
             "fixtures/no-create-extension-sql.yaml",
             "fixtures/no-discarded-json-marshal.yaml",
             "fixtures/no-shared-preload-libraries-cnpg.yaml",

--- a/bazel/semgrep/tests/fixtures/fastapi-bare-tuple-return.yaml
+++ b/bazel/semgrep/tests/fixtures/fastapi-bare-tuple-return.yaml
@@ -1,0 +1,54 @@
+# Reference fixture for the fastapi-bare-tuple-return semgrep rule.
+# This file documents ok/bad patterns for human review.
+# The actual semgrep test fixture is bazel/semgrep/rules/python/fastapi-bare-tuple-return.py.
+
+examples:
+  bad:
+    - description: returning a bare (dict, 404) tuple from a FastAPI route handler
+      code: |
+        @app.get("/vessels/{mmsi}")
+        async def get_vessel(mmsi: str):
+            vessel = await db.get_vessel(mmsi)
+            if vessel is None:
+                return {"error": "Vessel not found"}, 404  # BUG: always returns HTTP 200 with JSON array
+            return vessel
+
+    - description: returning a bare (dict, 500) tuple for server errors
+      code: |
+        @app.post("/process")
+        async def process():
+            try:
+                result = await do_work()
+            except Exception:
+                return {"error": "Internal error"}, 500  # BUG: FastAPI ignores the 500
+
+    - description: returning a bare (dict, 403) tuple for permission errors
+      code: |
+        @app.get("/admin")
+        async def admin_only():
+            if not is_admin():
+                return {"error": "Forbidden"}, 403  # BUG: client receives HTTP 200
+
+  ok:
+    - description: raise HTTPException with status_code and detail
+      code: |
+        from fastapi import HTTPException
+
+        @app.get("/vessels/{mmsi}")
+        async def get_vessel(mmsi: str):
+            vessel = await db.get_vessel(mmsi)
+            if vessel is None:
+                raise HTTPException(status_code=404, detail="Vessel not found")
+            return vessel
+
+    - description: 2xx status codes are not error tuples and are not caught
+      code: |
+        @app.get("/ok")
+        async def ok_route():
+            return {"data": "value"}, 200
+
+    - description: returning a plain dict (no tuple) is fine
+      code: |
+        @app.get("/data")
+        async def data_route():
+            return {"key": "value"}


### PR DESCRIPTION
## Summary

- Adds a new Python semgrep rule `fastapi-bare-tuple-return` that detects the common FastAPI bug where returning a bare `(dict, int)` tuple with a 4xx/5xx status code results in HTTP 200 with a JSON array body instead of the intended error status code
- Fix message directs developers to use `raise HTTPException(status_code=N, detail=...)` instead
- Includes annotated test fixture at `bazel/semgrep/rules/python/fastapi-bare-tuple-return.py` (picked up by `python_rules_test`)
- Includes human-readable reference fixture at `bazel/semgrep/tests/fixtures/fastapi-bare-tuple-return.yaml`
- Excludes the reference YAML fixture from `yaml_rules_test` to prevent false test failures

## Test plan

- [ ] `bazel test //bazel/semgrep/rules:python_rules_test` — verifies `ruleid` annotations in the fixture are caught and `ok` cases are not flagged
- [ ] `bazel test //...` — full CI run passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)