### PR TITLE
fix(semgrep): harden fastapi-bare-tuple-return rule and clean up tests

### DIFF
--- a/bazel/semgrep/rules/python/fastapi-bare-tuple-return.py
+++ b/bazel/semgrep/rules/python/fastapi-bare-tuple-return.py
@@ -28,13 +28,29 @@ async def get_vessel(mmsi: str):
     return {"error": "Vessel not found"}, 404
 
 
+# ruleid: fastapi-bare-tuple-return
+@app.get("/sync-bad-404")
+def sync_bad_404_route():
+    # Synchronous handlers are equally affected — FastAPI silently ignores the
+    # integer element of the tuple and returns HTTP 200 with a JSON array.
+    return {"error": "not found"}, 404
+
+
 # ok: using HTTPException raises a proper HTTP response with correct status code
 @app.get("/good-404")
 async def good_404_route():
     raise HTTPException(status_code=404, detail="Not found")
 
 
-# ok: 2xx status codes are not error responses and are not caught by this rule
+# ok: plain dict return (no status code) — not a bare-tuple pattern
+@app.get("/good-plain-dict")
+async def good_plain_dict_route():
+    return {"data": "value"}
+
+
+# ok: 2xx and 3xx codes are not matched — note that returning (dict, 200) is
+# also a FastAPI anti-pattern (produces a JSON array instead of a plain dict),
+# but it is out of scope for this rule which targets error-status misuse
 @app.get("/good-200")
 async def good_200_route():
     return {"data": "ok"}, 200

--- a/bazel/semgrep/rules/python/fastapi-bare-tuple-return.yaml
+++ b/bazel/semgrep/rules/python/fastapi-bare-tuple-return.yaml
@@ -5,6 +5,15 @@ rules:
       - metavariable-regex:
           metavariable: $STATUS
           regex: "^[45]\\d{2}$"
+      - pattern-either:
+        - pattern-inside: |
+            @$APP.$METHOD(...)
+            async def $FUNC(...):
+                ...
+        - pattern-inside: |
+            @$APP.$METHOD(...)
+            def $FUNC(...):
+                ...
     message: >-
       FastAPI ignores bare-tuple status codes — use
       `raise HTTPException(status_code=N, detail=...)` instead.
@@ -21,4 +30,5 @@ rules:
         Returning a (dict, int) tuple from a FastAPI route handler does not set
         the HTTP status code. FastAPI serialises the entire tuple as a JSON array
         and returns HTTP 200. Use `raise HTTPException(status_code=N, detail=...)`
-        instead.
+        instead. Note: only literal 4xx/5xx status codes are matched; variable-bound
+        status codes (e.g. `return {...}, status_code`) are out of scope.

--- a/bazel/semgrep/tests/fixtures/fastapi-bare-tuple-return.yaml
+++ b/bazel/semgrep/tests/fixtures/fastapi-bare-tuple-return.yaml
@@ -13,12 +13,12 @@ examples:
                 return {"error": "Vessel not found"}, 404  # BUG: always returns HTTP 200 with JSON array
             return vessel
 
-    - description: returning a bare (dict, 500) tuple for server errors
+    - description: returning a bare (dict, 500) tuple for server errors (sync handler)
       code: |
         @app.post("/process")
-        async def process():
+        def process():
             try:
-                result = await do_work()
+                result = do_work()
             except Exception:
                 return {"error": "Internal error"}, 500  # BUG: FastAPI ignores the 500
 
@@ -41,14 +41,25 @@ examples:
                 raise HTTPException(status_code=404, detail="Vessel not found")
             return vessel
 
-    - description: 2xx status codes are not error tuples and are not caught
+    - description: returning a plain dict (no tuple) — the most common correct pattern
+      code: |
+        @app.get("/data")
+        async def data_route():
+            return {"key": "value"}
+
+    - description: >-
+        2xx and 3xx codes are out of scope for this rule.
+        Note: returning (dict, 200) is also a FastAPI anti-pattern (produces a JSON
+        array instead of a plain dict), but it silently returns the right status code
+        so it is less dangerous and is excluded to reduce noise.
       code: |
         @app.get("/ok")
         async def ok_route():
             return {"data": "value"}, 200
 
-    - description: returning a plain dict (no tuple) is fine
+    - description: variable-bound status codes are out of scope (only literals are matched)
       code: |
-        @app.get("/data")
-        async def data_route():
-            return {"key": "value"}
+        @app.get("/dynamic")
+        async def dynamic_route():
+            status_code = 404
+            return {"error": "not found"}, status_code

--- a/projects/ships/backend/tests/new_coverage_test.py
+++ b/projects/ships/backend/tests/new_coverage_test.py
@@ -66,19 +66,6 @@ class TestGetVesselHttp404Bug:
         assert body == {"detail": "Vessel not found"}
 
     @pytest.mark.asyncio
-    async def test_get_vessel_missing_mmsi_body_is_not_json_array(self, test_client):
-        """Response body must be a JSON object, not the erroneous JSON array.
-
-        Before the fix, the body was ``[{"error": "Vessel not found"}, 404]``.
-        """
-        response = await test_client.get("/api/vessels/000000000")
-        body = response.json()
-        assert not isinstance(body, list), (
-            "Response body must not be a list; "
-            "got the old bare-tuple serialisation instead of HTTPException"
-        )
-
-    @pytest.mark.asyncio
     async def test_get_vessel_existing_mmsi_returns_vessel_data(
         self, test_client_with_data, multiple_vessels_data
     ):

--- a/projects/ships/chart/Chart.yaml
+++ b/projects/ships/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: marine
 description: Marine services - AIS vessel tracking and API
 type: application
-version: 0.3.27
+version: 0.3.28
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/ships/deploy/application.yaml
+++ b/projects/ships/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: marine
-      targetRevision: 0.3.27
+      targetRevision: 0.3.28
       helm:
         releaseName: marine
         valueFiles:


### PR DESCRIPTION
## Summary

Follow-up to #1941 and #1942, addressing critic review feedback:

- **Semgrep rule guard** — add `pattern-inside: @$APP.$METHOD(...)` decorator constraint (both `async def` and `def`) so the rule only fires inside FastAPI route handlers, eliminating latent false-positive risk if Flask or aiohttp is introduced
- **Sync handler coverage** — add `# ruleid:` test case for a non-`async` route handler; the rule had no test exercising synchronous handlers
- **Plain-dict `# ok:` case** — add baseline `return {"key": "value"}` fixture case to document the rule does not over-fire on normal dict returns
- **Fix misleading 200-status comment** — `# ok: 2xx not caught` now explicitly notes that `return dict, 200` is *also* a FastAPI anti-pattern but is out of scope to reduce noise
- **Variable-bound status codes** — extend rule description and reference fixture to document that `return {...}, status_code` (non-literal) is out of scope
- **Remove redundant test** — drop `test_get_vessel_missing_mmsi_body_is_not_json_array` from ships; if `body == {"detail": "..."}` passes, the body is provably not a list — the third test added no detection power

## Test plan

- [ ] CI semgrep scan runs against updated `.py` fixture — all `# ruleid:` lines fire, all `# ok:` lines are clean
- [ ] `bazel test //projects/ships/...` passes with two 404-regression tests remaining
- [ ] `bazel test //bazel/semgrep/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)