### PR TITLE
docs(adr): mark ADR 012 as superseded by ADR 013

### DIFF
--- a/docs/decisions/agents/012-knowledge-gardener-model-pipeline.md
+++ b/docs/decisions/agents/012-knowledge-gardener-model-pipeline.md
@@ -1,9 +1,10 @@
 # ADR 012: Knowledge Gardener Two-Tier Model Pipeline
 
 **Author:** jomcgi
-**Status:** Draft
+**Status:** Superseded by [ADR 013](013-knowledge-gardener-gemma4-only.md)
 **Created:** 2026-04-09
 **Supersedes:** N/A
+**Superseded by:** [ADR 013](013-knowledge-gardener-gemma4-only.md)
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds the back-reference from [ADR 012](https://github.com/jomcgi/homelab/blob/main/docs/decisions/agents/012-knowledge-gardener-model-pipeline.md) to [ADR 013](https://github.com/jomcgi/homelab/blob/main/docs/decisions/agents/013-knowledge-gardener-gemma4-only.md)
- Updates Status from Draft to Superseded
- Both ADRs are now self-describing historical records

🤖 Generated with [Claude Code](https://claude.com/claude-code)