### PR TITLE
fix(chat): add custom_id to ThinkingView button for persistence

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.28.5
+version: 0.28.6
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chat/bot.py
+++ b/projects/monolith/chat/bot.py
@@ -93,7 +93,11 @@ class ThinkingView(discord.ui.View):
         super().__init__(timeout=None)
         self.thinking_text = thinking_text
 
-    @discord.ui.button(label="Show thinking", style=discord.ButtonStyle.secondary)
+    @discord.ui.button(
+        label="Show thinking",
+        style=discord.ButtonStyle.secondary,
+        custom_id="show_thinking",
+    )
     async def show_thinking(
         self, interaction: discord.Interaction, button: discord.ui.Button
     ):

--- a/projects/monolith/chat/bot_thinking_test.py
+++ b/projects/monolith/chat/bot_thinking_test.py
@@ -156,6 +156,12 @@ class TestThinkingView:
         view = ThinkingView("some thinking")
         assert view.timeout is None
 
+    def test_button_has_custom_id_for_persistence(self):
+        """ThinkingView button has a fixed custom_id so add_view() works after restarts."""
+        view = ThinkingView("some thinking")
+        buttons = [c for c in view.children if isinstance(c, discord.ui.Button)]
+        assert buttons[0].custom_id == "show_thinking"
+
     @pytest.mark.asyncio
     async def test_button_sends_ephemeral(self):
         """Clicking the button sends thinking as an ephemeral message."""

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.28.5
+      targetRevision: 0.28.6
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
## Summary

- `discord.py`'s `add_view()` requires all button/item components to have a fixed `custom_id`
- Without it, a random ID is auto-generated per instance, causing `ValueError: View is not persistent` on `on_ready` — breaking the Show thinking button after every pod restart
- One-line fix: add `custom_id="show_thinking"` to the `@discord.ui.button` decorator

## Test plan

- [ ] New test `test_button_has_custom_id_for_persistence` verifies the fixed ID is set
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)