### PR TITLE
feat(monolith): knowledge search overlay (ADR 003)

### DIFF
--- a/docs/plans/2026-04-09-knowledge-search-overlay-design.md
+++ b/docs/plans/2026-04-09-knowledge-search-overlay-design.md
@@ -1,0 +1,254 @@
+# Knowledge Search Overlay — Design
+
+**Date:** 2026-04-09
+**Status:** Approved
+**ADR:** [003-knowledge-search-overlay](../decisions/services/003-knowledge-search-overlay.md)
+
+---
+
+## Summary
+
+Implement ADR 003 in a single PR: add a ⌘K-triggered full-viewport search
+overlay to the homepage, backed by two new FastAPI endpoints that expose the
+existing pgvector knowledge store. The monolith e2e Playwright suite (real
+FastAPI + real Postgres) covers end-to-end correctness.
+
+This document records the implementation choices that the ADR left to
+implementation time, plus gaps found while reading the current code against
+the ADR.
+
+---
+
+## Gaps verified against current code
+
+| ADR claim                                | Reality                                                                           |
+| ---------------------------------------- | --------------------------------------------------------------------------------- |
+| `Note.type`, `Note.tags` exist           | ✅ `knowledge/models.py:47,50` — `type: str \| None`, `tags: list[str]`           |
+| `Chunk.section_header` exists            | ✅ `knowledge/models.py:65` — `section_header: str = ""`                          |
+| `VAULT_ROOT` env var pattern             | ✅ already used in `knowledge/service.py:33`                                      |
+| `KnowledgeStore.search_notes()` reusable | ⚠ Returns only `note_id/title/path/score` — needs a sibling method, not a rewrite |
+| Playwright e2e covers capture UI         | ✅ `e2e/e2e_playwright_test.py:406` drives `.capture-input` with `Meta+Enter`     |
+
+The store method gap is the only one that shapes the design: a new
+`search_notes_with_context()` leaves existing callers (`gardener.py`,
+`tools/knowledge-search`, 6+ tests) untouched.
+
+---
+
+## Backend
+
+### New file: `projects/monolith/knowledge/router.py`
+
+```python
+router = APIRouter(prefix="/api/knowledge", tags=["knowledge"])
+
+@router.get("/search")
+async def search(q: str, type: str | None = None, limit: int = 20) -> dict:
+    if len(q) < 2:
+        return {"results": []}
+    vector = await EmbeddingClient().embed(q)
+    with session_scope() as session:
+        results = KnowledgeStore(session).search_notes_with_context(
+            query_embedding=vector, type_filter=type, limit=limit,
+        )
+    return {"results": results}
+
+@router.get("/notes/{note_id}")
+def get_note(note_id: str) -> dict:
+    with session_scope() as session:
+        note = KnowledgeStore(session).get_note_by_id(note_id)
+    if note is None:
+        raise HTTPException(404, "note not found")
+    vault_root = Path(os.environ.get("VAULT_ROOT", "/vault"))
+    file_path = vault_root / note["path"]
+    if not file_path.is_file():
+        raise HTTPException(404, "vault file missing")
+    return {**note, "content": file_path.read_text()}
+```
+
+Registered in `app/main.py` alongside the existing routers.
+
+### New store method: `search_notes_with_context()`
+
+Additive to `store.py`. Two round-trips, no N+1:
+
+1. **Top-N notes query** — extends the existing cosine-distance `SELECT` with
+   `Note.type`, `Note.tags`, and an optional `WHERE Note.type = :type_filter`.
+   Same `best_score = 1 - min(distance)` aggregation, same ordering.
+
+2. **Best chunk per note** — single batched query over the returned `note_fk`
+   set:
+
+   ```sql
+   SELECT DISTINCT ON (note_fk)
+     note_fk, section_header, chunk_text
+   FROM knowledge.chunks
+   WHERE note_fk = ANY(:ids)
+   ORDER BY note_fk, embedding <=> :vector
+   ```
+
+3. **Stitch** in Python — build result dicts with `{note_id, title, path,
+type, tags, score, snippet, section}`. `snippet` is `chunk_text[:240]`.
+
+### New store helper: `get_note_by_id(note_id)`
+
+Trivial `SELECT` that returns `{note_id, title, path, type, tags}`. Used by
+`GET /notes/{note_id}`. Returns `None` if missing.
+
+### Error shape
+
+Both endpoints raise `HTTPException` on failure; the frontend distinguishes
+`503` (embedding down) from `404` (note missing) and surfaces each with a
+distinct message.
+
+---
+
+## Frontend
+
+All state and markup lives in `projects/monolith/frontend/src/routes/private/+page.svelte`.
+No new component files — matches the ADR's "mode shift, not modal" principle
+and the repo's "don't extract abstractions for one-time use" rule.
+
+### State (Svelte 5 runes)
+
+```js
+let searchOpen = $state(false);
+let searchQuery = $state("");
+let searchResults = $state([]);
+let selectedNote = $state(null);
+let activeIndex = $state(-1);
+let searching = $state(false);
+let searchType = $state("all"); // persists across open/close
+let savedCapture = $state(""); // preserves textarea value on ⌘K
+```
+
+### Global keydown handler
+
+Mounted on `document` via a `$effect` that registers/tears down the listener.
+
+- `⌘K` / `Ctrl+K`: if overlay closed, save `note` → `savedCapture`, set
+  `searchOpen = true`, focus search input. If overlay already open, no-op.
+- `Esc`: if preview open, close preview entirely (back to closed). If
+  only results open, close overlay. Restore `note = savedCapture`.
+- `↑`/`↓`: move `activeIndex` within `[-1, results.length - 1]`.
+- `Enter`: if `activeIndex >= 0`, fetch note, set `selectedNote`.
+- `←` (only in preview): return to results view, keep results and query.
+
+Keys bubble only when the overlay is open, so the capture textarea still
+handles `⌘+Enter` normally in its closed state.
+
+### Debounced fetch
+
+```js
+let searchTimer;
+$effect(() => {
+  clearTimeout(searchTimer);
+  const q = searchQuery;
+  if (q.length < 2) {
+    searchResults = [];
+    searching = false;
+    return;
+  }
+  searching = true;
+  searchTimer = setTimeout(async () => {
+    const params = new URLSearchParams({ q });
+    if (searchType !== "all") params.set("type", searchType);
+    const res = await fetch(`/api/knowledge/search?${params}`);
+    if (res.ok) searchResults = (await res.json()).results;
+    searching = false;
+  }, 300);
+});
+```
+
+### Heading-only markdown renderer
+
+Inline function in `+page.svelte`:
+
+```js
+function slugify(s) {
+  return s
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "");
+}
+
+function renderNote(md) {
+  const blocks = md.replace(/^---\n[\s\S]*?\n---\n?/, "").split(/\n\n+/);
+  return blocks.map((block) => {
+    const h = block.match(/^(#{1,3}) (.+)$/);
+    if (h) return { tag: `h${h[1].length}`, id: slugify(h[2]), text: h[2] };
+    return { tag: "p", text: block };
+  });
+}
+```
+
+Svelte `{#each}` renders into an `{:else if}` chain over `tag`. Frontmatter
+(the leading `---` block) is stripped so users never see YAML in the preview.
+
+On preview mount, a `$effect` calls
+`document.getElementById(slug)?.scrollIntoView({ block: "start" })` where
+`slug` comes from the result's `section` field.
+
+---
+
+## Tests
+
+### Unit tests (Bazel `py_test`)
+
+- `projects/monolith/knowledge/router_test.py` — new. Covers happy path,
+  empty `q`, `type` filter, missing `note_id`, missing vault file, `503` from
+  mocked `EmbeddingClient`.
+- `projects/monolith/knowledge/store_test.py` — extend with cases for
+  `search_notes_with_context` and `get_note_by_id`. Seed notes with `type`
+  and `tags`; assert snippet/section present and best chunk picked per note.
+
+### E2E tests (`e2e/e2e_playwright_test.py`)
+
+The real test for UI + Postgres + backend integration:
+
+- `test_knowledge_overlay_opens_and_closes` — `⌘K` opens, `Esc` closes.
+- `test_knowledge_overlay_preserves_capture` — type in textarea, press
+  `⌘K`, close, verify textarea value restored.
+- `test_knowledge_search_returns_results` — seed a known note in the vault +
+  DB, type query, assert result row appears with expected title.
+- `test_knowledge_search_preview` — `Enter` on result opens preview with
+  content; `← back` returns to results; `Esc` closes overlay.
+- `test_knowledge_search_zero_results` — query that matches nothing shows
+  `no results`.
+
+**Embedding handling in tests:** before writing any test code, check
+`e2e_playwright_test.py` and `store_test.py` for the current embedding
+stub/fixture. If a stub client already exists, reuse it. If not, introduce a
+fixture that injects a deterministic fake `EmbeddingClient` via the FastAPI
+dependency system.
+
+---
+
+## Risks & mitigations
+
+| Risk                                                           | Mitigation                                                        |
+| -------------------------------------------------------------- | ----------------------------------------------------------------- |
+| Embedding latency flakes e2e tests                             | Use a fake embedding client in tests; don't hit voyage-4          |
+| PR grows past ~800 LOC                                         | If it does, split backend into its own PR first, UI second        |
+| `search_notes_with_context` duplicates SQL with `search_notes` | Acceptable — the alternative is bloating every caller             |
+| `⌘K` conflicts with browser defaults                           | `e.preventDefault()` in the global handler; existing apps do this |
+
+---
+
+## Out of scope
+
+- "Open in Obsidian" deep link (ADR notes this as a future enhancement)
+- Recent-notes list in the idle state (ADR explicitly rejects this)
+- Highlighting search term within the snippet
+- Syntax highlighting in the preview
+- Any markdown beyond headings and paragraphs (no lists, links, code fences)
+
+---
+
+## References
+
+- [ADR 003: Knowledge Search Overlay](../decisions/services/003-knowledge-search-overlay.md)
+- `projects/monolith/knowledge/store.py` — existing `search_notes()`
+- `projects/monolith/knowledge/models.py` — `Note`, `Chunk` SQLModel
+- `projects/monolith/frontend/src/routes/private/+page.svelte` — homepage
+- `projects/monolith/e2e/e2e_playwright_test.py` — e2e Playwright suite

--- a/docs/plans/2026-04-09-knowledge-search-overlay-plan.md
+++ b/docs/plans/2026-04-09-knowledge-search-overlay-plan.md
@@ -1,0 +1,1264 @@
+# Knowledge Search Overlay Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Ship ADR 003 — add a ⌘K-triggered full-viewport knowledge search overlay to the homepage, backed by two new FastAPI endpoints over the existing pgvector knowledge store.
+
+**Architecture:** A new `KnowledgeStore.search_notes_with_context()` method runs two batched SQL queries (top-N notes + best chunk per note). A new FastAPI router (`/api/knowledge/search`, `/api/knowledge/notes/{id}`) uses dependency injection for the embedding client so e2e tests can inject a deterministic fake. All frontend state lives inline in `private/+page.svelte`. The monolith e2e Playwright suite covers UI + Postgres + FastAPI integration in one test.
+
+**Tech Stack:** Python 3.12 · FastAPI · SQLModel · pgvector · Svelte 5 runes · Playwright · `bb remote test` for CI iteration.
+
+---
+
+## Context for the engineer
+
+### Repo-specific things you need to know
+
+- **Tests run remotely.** Never run `pytest` locally. Use `bb remote test //projects/monolith/knowledge:<target> --config=ci` to iterate. Only push when green.
+- **Never commit to main.** Everything happens in the worktree at `/tmp/claude-worktrees/knowledge-search-overlay` on branch `feat/knowledge-search-overlay`.
+- **Format before commit.** Run `format` (vendored). A pre-commit hook will reject unformatted files.
+- **Conventional commits required.** `feat(knowledge): …`, `test(knowledge): …`, etc. A `commit-msg` hook enforces this.
+- **Embedding is async.** `EmbeddingClient.embed(text)` is a coroutine — `await` it.
+- **The embedding server runs at `EMBEDDING_URL`** (real voyage-4-nano). Tests MUST NOT hit it. Use the `deterministic_embedding` helper in `projects/monolith/e2e/conftest.py:414` and `embed_client` fixture at `:424`.
+- **No N+1.** The whole point of the second `DISTINCT ON` query is to fetch best-chunk-per-note in one round-trip.
+
+### Files you'll touch
+
+| File                                                         | Action                                                   |
+| ------------------------------------------------------------ | -------------------------------------------------------- |
+| `projects/monolith/knowledge/store.py`                       | Add `search_notes_with_context()` and `get_note_by_id()` |
+| `projects/monolith/knowledge/store_test.py`                  | Add tests for the two new methods                        |
+| `projects/monolith/knowledge/router.py`                      | **Create** — new FastAPI router                          |
+| `projects/monolith/knowledge/router_test.py`                 | **Create** — unit tests with TestClient                  |
+| `projects/monolith/knowledge/BUILD.bazel`                    | Add new `py_library`/`py_test` targets (use `format`)    |
+| `projects/monolith/app/main.py`                              | Register the new router                                  |
+| `projects/monolith/e2e/conftest.py`                          | Add embedding client override + vault fixture            |
+| `projects/monolith/e2e/e2e_playwright_test.py`               | Add knowledge overlay e2e tests                          |
+| `projects/monolith/frontend/src/routes/private/+page.svelte` | Add overlay state, markup, styles                        |
+
+### Reference skills
+
+- `@buildbuddy` — when CI fails, pull logs with `bb view`/`bb ask`
+- `@bazel` — for BUILD file edits and understanding build targets
+- `@superpowers:test-driven-development` — red/green discipline
+- `@superpowers:verification-before-completion` — prove every step with command output
+
+---
+
+## Phase 0: Setup verification
+
+### Task 0: Confirm worktree and branch
+
+**Step 1: Verify you are in the worktree**
+
+Run: `pwd && git branch --show-current`
+Expected: `/tmp/claude-worktrees/knowledge-search-overlay` and `feat/knowledge-search-overlay`.
+
+**Step 2: Verify the design doc is committed**
+
+Run: `git log --oneline -3 -- docs/plans/`
+Expected: most recent commit references `docs(plans): add knowledge search overlay design`.
+
+**Step 3: Verify tests pass on main before touching anything**
+
+Run: `bb remote test //projects/monolith/knowledge:store_test --config=ci`
+Expected: PASS. Baseline captured.
+
+---
+
+## Phase 1: Backend store — `search_notes_with_context()`
+
+### Task 1: Write failing test for `search_notes_with_context` happy path
+
+**Files:**
+
+- Modify: `projects/monolith/knowledge/store_test.py` (add a new test class at end)
+
+**Step 1: Write the failing test**
+
+Add at the bottom of `store_test.py`:
+
+```python
+class TestSearchNotesWithContext(StoreTestBase):
+    """KnowledgeStore.search_notes_with_context — overlay-facing search."""
+
+    def test_returns_type_tags_snippet_and_section(self):
+        n1 = self._insert_note(
+            note_id="n1",
+            path="papers/attention.md",
+            title="Attention Is All You Need",
+            type="paper",
+            tags=["ml", "transformers"],
+        )
+        self._insert_chunk(
+            note_fk=n1.id,
+            chunk_index=0,
+            section_header="## Architecture",
+            chunk_text="The transformer replaces recurrence entirely with attention.",
+            embedding=[0.0] * 1024,
+        )
+
+        results = self.store.search_notes_with_context(
+            query_embedding=[0.0] * 1024, limit=5
+        )
+
+        assert len(results) == 1
+        r = results[0]
+        assert r["note_id"] == "n1"
+        assert r["title"] == "Attention Is All You Need"
+        assert r["type"] == "paper"
+        assert r["tags"] == ["ml", "transformers"]
+        assert r["section"] == "## Architecture"
+        assert "transformer replaces recurrence" in r["snippet"]
+        assert 0.0 <= r["score"] <= 1.0
+```
+
+If `StoreTestBase` or the `_insert_note`/`_insert_chunk` helpers don't already exist, look at how existing tests in the file construct test data and mirror that pattern rather than inventing new helpers.
+
+**Step 2: Run test to verify it fails**
+
+Run: `bb remote test //projects/monolith/knowledge:store_test --config=ci --test_filter=TestSearchNotesWithContext`
+Expected: FAIL with `AttributeError: 'KnowledgeStore' object has no attribute 'search_notes_with_context'`.
+
+**Step 3: Do not commit yet.** We commit after green.
+
+---
+
+### Task 2: Implement `search_notes_with_context`
+
+**Files:**
+
+- Modify: `projects/monolith/knowledge/store.py` (add a new method after `search_notes`)
+
+**Step 1: Add the method**
+
+```python
+def search_notes_with_context(
+    self,
+    query_embedding: list[float],
+    limit: int = 20,
+    type_filter: str | None = None,
+) -> list[dict]:
+    """Semantic search that also returns the best-matching chunk snippet.
+
+    Two round-trips, no N+1:
+      1. Top-N notes ranked by min(cosine_distance) over their chunks.
+      2. For the returned notes, pick the single closest chunk via
+         ``DISTINCT ON (note_fk)`` and stitch snippet + section.
+    """
+    distance = Chunk.embedding.cosine_distance(query_embedding)
+    best_score = (1 - func.min(distance)).label("score")
+
+    note_stmt = (
+        select(
+            Note.id,
+            Note.note_id,
+            Note.title,
+            Note.path,
+            Note.type,
+            Note.tags,
+            best_score,
+        )
+        .join(Chunk, Chunk.note_fk == Note.id)
+        .group_by(Note.id)
+        .order_by(func.min(distance))
+        .limit(limit)
+    )
+    if type_filter:
+        note_stmt = note_stmt.where(Note.type == type_filter)
+
+    note_rows = self.session.execute(note_stmt).all()
+    if not note_rows:
+        return []
+
+    note_fks = [row.id for row in note_rows]
+
+    # Best chunk per note, single round-trip.
+    chunk_stmt = (
+        select(
+            Chunk.note_fk,
+            Chunk.section_header,
+            Chunk.chunk_text,
+        )
+        .where(Chunk.note_fk.in_(note_fks))
+        .order_by(Chunk.note_fk, distance)
+        .distinct(Chunk.note_fk)
+    )
+    chunks_by_fk = {
+        row.note_fk: (row.section_header, row.chunk_text)
+        for row in self.session.execute(chunk_stmt).all()
+    }
+
+    results: list[dict] = []
+    for row in note_rows:
+        section, text = chunks_by_fk.get(row.id, ("", ""))
+        results.append(
+            {
+                "note_id": row.note_id,
+                "title": row.title,
+                "path": row.path,
+                "type": row.type,
+                "tags": list(row.tags or []),
+                "score": float(row.score),
+                "section": section,
+                "snippet": text[:240],
+            }
+        )
+    return results
+```
+
+**Step 2: Run test to verify it passes**
+
+Run: `bb remote test //projects/monolith/knowledge:store_test --config=ci --test_filter=TestSearchNotesWithContext`
+Expected: PASS.
+
+**Step 3: Format and commit**
+
+```bash
+format
+git add projects/monolith/knowledge/store.py projects/monolith/knowledge/store_test.py
+git commit -m "feat(knowledge): add search_notes_with_context store method"
+```
+
+---
+
+### Task 3: Add `type_filter` and "no results" tests
+
+**Step 1: Write tests**
+
+Add to `TestSearchNotesWithContext`:
+
+```python
+def test_filters_by_type(self):
+    n1 = self._insert_note(note_id="n1", path="a.md", title="Paper", type="paper")
+    n2 = self._insert_note(note_id="n2", path="b.md", title="Journal", type="journal")
+    self._insert_chunk(note_fk=n1.id, chunk_index=0, chunk_text="x", embedding=[0.0] * 1024)
+    self._insert_chunk(note_fk=n2.id, chunk_index=0, chunk_text="y", embedding=[0.0] * 1024)
+
+    paper_only = self.store.search_notes_with_context(
+        query_embedding=[0.0] * 1024, type_filter="paper"
+    )
+    assert {r["note_id"] for r in paper_only} == {"n1"}
+
+def test_empty_db_returns_empty_list(self):
+    results = self.store.search_notes_with_context(query_embedding=[0.0] * 1024)
+    assert results == []
+```
+
+**Step 2: Run tests**
+
+Run: `bb remote test //projects/monolith/knowledge:store_test --config=ci --test_filter=TestSearchNotesWithContext`
+Expected: PASS (all three tests).
+
+**Step 3: Commit**
+
+```bash
+git add projects/monolith/knowledge/store_test.py
+git commit -m "test(knowledge): cover type filter and empty-db paths for search_notes_with_context"
+```
+
+---
+
+### Task 4: Add `get_note_by_id` with test
+
+**Step 1: Write the failing test**
+
+In `store_test.py`, add:
+
+```python
+class TestGetNoteById(StoreTestBase):
+    def test_returns_note_metadata(self):
+        self._insert_note(
+            note_id="n1",
+            path="folder/note.md",
+            title="My Note",
+            type="paper",
+            tags=["x"],
+        )
+        got = self.store.get_note_by_id("n1")
+        assert got == {
+            "note_id": "n1",
+            "title": "My Note",
+            "path": "folder/note.md",
+            "type": "paper",
+            "tags": ["x"],
+        }
+
+    def test_returns_none_when_missing(self):
+        assert self.store.get_note_by_id("nope") is None
+```
+
+**Step 2: Run — expect FAIL** (`AttributeError`).
+
+Run: `bb remote test //projects/monolith/knowledge:store_test --config=ci --test_filter=TestGetNoteById`
+
+**Step 3: Implement in `store.py`**
+
+```python
+def get_note_by_id(self, note_id: str) -> dict | None:
+    row = self.session.execute(
+        select(Note.note_id, Note.title, Note.path, Note.type, Note.tags).where(
+            Note.note_id == note_id
+        )
+    ).first()
+    if row is None:
+        return None
+    return {
+        "note_id": row.note_id,
+        "title": row.title,
+        "path": row.path,
+        "type": row.type,
+        "tags": list(row.tags or []),
+    }
+```
+
+**Step 4: Run — expect PASS.**
+
+**Step 5: Format and commit**
+
+```bash
+format
+git add projects/monolith/knowledge/store.py projects/monolith/knowledge/store_test.py
+git commit -m "feat(knowledge): add get_note_by_id store helper"
+```
+
+---
+
+## Phase 2: Backend router
+
+### Task 5: Create router skeleton with dependency injection
+
+**Files:**
+
+- Create: `projects/monolith/knowledge/router.py`
+- Modify: `projects/monolith/knowledge/BUILD.bazel` (add `py_library`)
+- Modify: `projects/monolith/app/main.py` (register)
+
+**Step 1: Create `router.py`**
+
+```python
+"""FastAPI router for the knowledge search overlay (ADR 003)."""
+
+import logging
+import os
+from pathlib import Path
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlmodel import Session
+
+from app.db import get_session
+from shared.embedding import EmbeddingClient
+
+from .store import KnowledgeStore
+
+logger = logging.getLogger(__name__)
+router = APIRouter(prefix="/api/knowledge", tags=["knowledge"])
+
+_VAULT_ROOT_ENV = "VAULT_ROOT"
+_DEFAULT_VAULT_ROOT = "/vault"
+_MIN_QUERY_LENGTH = 2
+
+
+def get_embedding_client() -> EmbeddingClient:
+    """Dependency-injectable EmbeddingClient. Override in tests."""
+    return EmbeddingClient()
+
+
+@router.get("/search")
+async def search(
+    q: str = Query(default=""),
+    type: str | None = Query(default=None),
+    limit: int = Query(default=20, ge=1, le=100),
+    session: Session = Depends(get_session),
+    embed_client: EmbeddingClient = Depends(get_embedding_client),
+) -> dict:
+    if len(q) < _MIN_QUERY_LENGTH:
+        return {"results": []}
+    try:
+        vector = await embed_client.embed(q)
+    except Exception:  # noqa: BLE001
+        logger.exception("knowledge search: embedding failed")
+        raise HTTPException(status_code=503, detail="embedding unavailable")
+    results = KnowledgeStore(session).search_notes_with_context(
+        query_embedding=vector, limit=limit, type_filter=type,
+    )
+    return {"results": results}
+
+
+@router.get("/notes/{note_id}")
+def get_note(
+    note_id: str,
+    session: Session = Depends(get_session),
+) -> dict:
+    note = KnowledgeStore(session).get_note_by_id(note_id)
+    if note is None:
+        raise HTTPException(status_code=404, detail="note not found")
+    vault_root = Path(os.environ.get(_VAULT_ROOT_ENV, _DEFAULT_VAULT_ROOT))
+    file_path = vault_root / note["path"]
+    if not file_path.is_file():
+        raise HTTPException(status_code=404, detail="vault file missing")
+    return {**note, "content": file_path.read_text()}
+```
+
+**Step 2: Wire into `app/main.py`**
+
+Add next to the existing imports:
+
+```python
+from knowledge.router import router as knowledge_router
+```
+
+And next to the existing `app.include_router(...)` block:
+
+```python
+app.include_router(knowledge_router)
+```
+
+**Step 3: Update BUILD.bazel**
+
+Add a `py_library` entry for `router.py` mirroring the existing store library. If unsure of exact syntax, run `format` — the bazel gazelle plugin will generate/update BUILD targets automatically.
+
+**Step 4: Verify the whole tree still builds**
+
+Run: `bb remote test //projects/monolith/app:main_test --config=ci`
+Expected: PASS (proves the router is importable and `app.main` still assembles).
+
+**Step 5: Commit**
+
+```bash
+format
+git add projects/monolith/knowledge/router.py projects/monolith/knowledge/BUILD.bazel projects/monolith/app/main.py
+git commit -m "feat(knowledge): add search overlay FastAPI router"
+```
+
+---
+
+### Task 6: Router unit tests — happy path
+
+**Files:**
+
+- Create: `projects/monolith/knowledge/router_test.py`
+
+**Step 1: Write the tests**
+
+```python
+"""Unit tests for knowledge/router.py."""
+
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.db import get_session
+from app.main import app
+from knowledge.router import get_embedding_client
+from knowledge.store import KnowledgeStore
+
+
+@pytest.fixture()
+def client(session, embed_client):
+    """TestClient with overridden session and embedding client."""
+    app.dependency_overrides[get_session] = lambda: session
+    app.dependency_overrides[get_embedding_client] = lambda: embed_client
+    yield TestClient(app, raise_server_exceptions=False)
+    app.dependency_overrides.clear()
+
+
+class TestSearchEndpoint:
+    def test_empty_query_returns_empty_results(self, client):
+        r = client.get("/api/knowledge/search?q=")
+        assert r.status_code == 200
+        assert r.json() == {"results": []}
+
+    def test_single_char_query_returns_empty_results(self, client):
+        r = client.get("/api/knowledge/search?q=a")
+        assert r.status_code == 200
+        assert r.json() == {"results": []}
+
+    def test_search_returns_seeded_note(self, client, session):
+        # Seed one note + one chunk via KnowledgeStore for realism.
+        store = KnowledgeStore(session)
+        store.upsert_note(...)  # Use same helper as existing tests — mirror store_test.py
+        # ...
+        r = client.get("/api/knowledge/search?q=attention")
+        assert r.status_code == 200
+        body = r.json()
+        assert len(body["results"]) == 1
+        assert body["results"][0]["note_id"] == "seeded"
+
+    def test_embedding_failure_returns_503(self, session):
+        app.dependency_overrides[get_session] = lambda: session
+        failing = AsyncMock()
+        failing.embed.side_effect = RuntimeError("boom")
+        app.dependency_overrides[get_embedding_client] = lambda: failing
+        c = TestClient(app, raise_server_exceptions=False)
+        r = c.get("/api/knowledge/search?q=hello")
+        app.dependency_overrides.clear()
+        assert r.status_code == 503
+```
+
+Look at `store_test.py` to see exactly how notes + chunks are seeded — the `...` placeholders above should be filled with that pattern. Do NOT invent new fixtures.
+
+**Step 2: Add `router_test` to BUILD.bazel**
+
+Run: `format` — gazelle will add the `py_test` target. Verify it added a target that depends on `:router` and the test-only deps.
+
+**Step 3: Run the tests**
+
+Run: `bb remote test //projects/monolith/knowledge:router_test --config=ci`
+Expected: PASS on all four tests.
+
+**Step 4: Commit**
+
+```bash
+git add projects/monolith/knowledge/router_test.py projects/monolith/knowledge/BUILD.bazel
+git commit -m "test(knowledge): cover search endpoint happy path and 503"
+```
+
+---
+
+### Task 7: Router unit tests — notes endpoint
+
+**Step 1: Add these test cases to `router_test.py`:**
+
+```python
+class TestGetNoteEndpoint:
+    def test_returns_note_content(self, client, session, tmp_path, monkeypatch):
+        # Seed note row
+        # ...mirror seeding from store_test.py...
+        note_path = tmp_path / "folder" / "note.md"
+        note_path.parent.mkdir(parents=True)
+        note_path.write_text("# Title\n\nBody text.\n")
+        monkeypatch.setenv("VAULT_ROOT", str(tmp_path))
+
+        r = client.get("/api/knowledge/notes/n1")
+        assert r.status_code == 200
+        body = r.json()
+        assert body["note_id"] == "n1"
+        assert "Body text" in body["content"]
+
+    def test_missing_note_row_returns_404(self, client):
+        r = client.get("/api/knowledge/notes/does-not-exist")
+        assert r.status_code == 404
+
+    def test_missing_vault_file_returns_404(self, client, session, tmp_path, monkeypatch):
+        # Seed note row but don't create the file on disk
+        # ...
+        monkeypatch.setenv("VAULT_ROOT", str(tmp_path))
+        r = client.get("/api/knowledge/notes/n1")
+        assert r.status_code == 404
+```
+
+**Step 2: Run**
+
+Run: `bb remote test //projects/monolith/knowledge:router_test --config=ci`
+Expected: PASS on all seven tests.
+
+**Step 3: Commit**
+
+```bash
+git add projects/monolith/knowledge/router_test.py
+git commit -m "test(knowledge): cover notes endpoint and 404 paths"
+```
+
+---
+
+## Phase 3: E2E embedding override + HTTP-level integration test
+
+### Task 8: Add embedding override to the live_server fixture
+
+**Files:**
+
+- Modify: `projects/monolith/e2e/conftest.py`
+
+**Step 1: Add a fixture that overrides the embedding dependency on the live app**
+
+Add after the existing `embed_client` fixture (around line 435):
+
+```python
+@pytest.fixture(scope="session")
+def live_server_with_fake_embedding(live_server):
+    """Override the knowledge router's embedding dependency for the live server.
+
+    The live FastAPI instance reads from the ``app`` module-level singleton
+    imported inside ``live_server``. Registering an override on that instance
+    is enough to route every ``/api/knowledge/search`` request through the
+    deterministic fake.
+    """
+    from unittest.mock import AsyncMock
+
+    from app.main import app  # noqa: E402
+    from knowledge.router import get_embedding_client  # noqa: E402
+
+    fake = AsyncMock()
+    fake.embed = AsyncMock(side_effect=deterministic_embedding)
+
+    app.dependency_overrides[get_embedding_client] = lambda: fake
+    yield live_server
+    app.dependency_overrides.pop(get_embedding_client, None)
+```
+
+**Step 2: Sanity check — does the dependency override actually apply?**
+
+Add this HTTP-only test in `e2e_playwright_test.py` under a new class:
+
+```python
+class TestKnowledgeSearchHttp:
+    """HTTP-level tests for /api/knowledge (no browser needed)."""
+
+    def test_empty_query_returns_empty_results(self, live_server_with_fake_embedding):
+        base = live_server_with_fake_embedding
+        r = httpx.get(f"{base}/api/knowledge/search?q=")
+        assert r.status_code == 200
+        assert r.json() == {"results": []}
+
+    def test_search_uses_fake_embedding(self, live_server_with_fake_embedding, pg):
+        # Seed a note + chunk directly in pg so we have something to find.
+        # Use the same pg fixture + engine pattern the chat tests use.
+        # ...
+        base = live_server_with_fake_embedding
+        r = httpx.get(f"{base}/api/knowledge/search?q=transformers")
+        assert r.status_code == 200
+        assert len(r.json()["results"]) >= 1
+```
+
+**Step 3: Run**
+
+Run: `bb remote test //projects/monolith/e2e:e2e_playwright_test --config=ci --test_filter=TestKnowledgeSearchHttp`
+Expected: PASS. (This proves the backend is integrated end-to-end before we touch any JS.)
+
+**Step 4: Commit**
+
+```bash
+git add projects/monolith/e2e/conftest.py projects/monolith/e2e/e2e_playwright_test.py
+git commit -m "test(e2e): cover knowledge search HTTP endpoints with fake embedding"
+```
+
+---
+
+## Phase 4: Frontend — overlay shell + search
+
+### Task 9: Add overlay state and ⌘K open/close
+
+**Files:**
+
+- Modify: `projects/monolith/frontend/src/routes/private/+page.svelte`
+
+**Step 1: Add state block**
+
+Inside the `<script>`, after the existing capture state, add:
+
+```js
+// ── Knowledge search ─────────────────────────
+let searchOpen = $state(false);
+let searchQuery = $state("");
+let searchResults = $state([]);
+let selectedNote = $state(null);
+let activeIndex = $state(-1);
+let searching = $state(false);
+let searchType = $state("all");
+let savedCapture = $state("");
+let searchInputRef = $state(null);
+let searchTimer;
+
+function openSearch() {
+  if (searchOpen) return;
+  savedCapture = note;
+  searchOpen = true;
+  setTimeout(() => searchInputRef?.focus(), 0);
+}
+
+function closeSearch() {
+  searchOpen = false;
+  selectedNote = null;
+  searchQuery = "";
+  searchResults = [];
+  activeIndex = -1;
+  note = savedCapture;
+  setTimeout(() => captureRef?.focus(), 0);
+}
+
+$effect(() => {
+  function onKeydown(e) {
+    if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "k") {
+      e.preventDefault();
+      openSearch();
+      return;
+    }
+    if (!searchOpen) return;
+    if (e.key === "Escape") {
+      e.preventDefault();
+      closeSearch();
+    }
+  }
+  document.addEventListener("keydown", onKeydown);
+  return () => document.removeEventListener("keydown", onKeydown);
+});
+```
+
+**Step 2: Add minimal overlay markup** (just enough to verify it renders)
+
+Before `</div>` closing `.root`, add:
+
+```svelte
+{#if searchOpen}
+  <div class="search-overlay">
+    <div class="search-overlay-inner">
+      <input
+        bind:this={searchInputRef}
+        class="search-input"
+        bind:value={searchQuery}
+        placeholder="search notes..."
+        spellcheck="false"
+      />
+    </div>
+  </div>
+{/if}
+```
+
+**Step 3: Add styles inside the existing `<style>` block**
+
+```css
+.search-overlay {
+  position: fixed;
+  inset: 0;
+  background: var(--bg);
+  z-index: 100;
+  overflow-y: auto;
+}
+
+.search-overlay-inner {
+  max-width: 72ch;
+  margin: 0 auto;
+  padding: 2.5rem;
+}
+
+.search-input {
+  width: 100%;
+  font-family: var(--font);
+  font-size: 1.15rem;
+  background: transparent;
+  border: none;
+  border-bottom: 0.06rem solid var(--border);
+  outline: none;
+  color: var(--fg);
+  padding: 0.5rem 0;
+}
+```
+
+**Step 4: Smoke test the frontend build**
+
+Run: `bb remote test //projects/monolith/frontend:build --config=ci` (or whatever the frontend build target is — check `projects/monolith/frontend/BUILD.bazel`)
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+format
+git add projects/monolith/frontend/src/routes/private/+page.svelte
+git commit -m "feat(frontend): add knowledge search overlay shell with cmdk toggle"
+```
+
+---
+
+### Task 10: Debounced search + results rendering
+
+**Step 1: Add the debounced fetch effect below the keydown effect**
+
+```js
+$effect(() => {
+  clearTimeout(searchTimer);
+  const q = searchQuery;
+  if (q.length < 2) {
+    searchResults = [];
+    searching = false;
+    return;
+  }
+  searching = true;
+  searchTimer = setTimeout(async () => {
+    const params = new URLSearchParams({ q });
+    if (searchType !== "all") params.set("type", searchType);
+    try {
+      const res = await fetch(`/api/knowledge/search?${params}`);
+      if (res.ok) {
+        searchResults = (await res.json()).results;
+        activeIndex = -1;
+      }
+    } finally {
+      searching = false;
+    }
+  }, 300);
+});
+```
+
+**Step 2: Add results list markup after the `<input>`**
+
+```svelte
+{#if searchQuery.length < 2}
+  <!-- idle state, no message -->
+{:else if searching && searchResults.length === 0}
+  <p class="search-hint">searching...</p>
+{:else if searchResults.length === 0}
+  <p class="search-hint">no results</p>
+{:else}
+  <ul class="search-results" class:search-results--ghost={searching}>
+    {#each searchResults as r, i}
+      <li
+        class="search-result"
+        class:search-result--active={i === activeIndex}
+        onclick={() => openPreview(r)}
+        role="button"
+        tabindex="0"
+      >
+        <div class="search-result-title">{r.title}</div>
+        <div class="search-result-section">{r.section}</div>
+        <div class="search-result-snippet">{r.snippet}</div>
+      </li>
+    {/each}
+  </ul>
+{/if}
+```
+
+Add the navigation handler to the existing `$effect` keydown listener (inside the `if (!searchOpen) return;` branch):
+
+```js
+if (e.key === "ArrowDown") {
+  e.preventDefault();
+  activeIndex = Math.min(activeIndex + 1, searchResults.length - 1);
+} else if (e.key === "ArrowUp") {
+  e.preventDefault();
+  activeIndex = Math.max(activeIndex - 1, -1);
+} else if (e.key === "Enter" && activeIndex >= 0) {
+  e.preventDefault();
+  openPreview(searchResults[activeIndex]);
+}
+```
+
+Add stub `openPreview`:
+
+```js
+function openPreview(result) {
+  selectedNote = { ...result, content: null };
+  // Phase 5 will fetch and render
+}
+```
+
+**Step 3: Add styles for results**
+
+```css
+.search-hint {
+  color: var(--fg-tertiary);
+  font-size: 0.85rem;
+  margin-top: 1rem;
+}
+
+.search-results {
+  list-style: none;
+  padding: 0;
+  margin: 1.5rem 0 0 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.search-results--ghost {
+  opacity: 0.5;
+}
+
+.search-result {
+  cursor: pointer;
+  padding: 0.5rem 0;
+  border-bottom: 0.04rem solid var(--border);
+}
+
+.search-result--active {
+  background: var(--surface);
+}
+
+.search-result-title {
+  font-weight: 700;
+  font-size: 0.95rem;
+}
+
+.search-result-section {
+  font-size: 0.7rem;
+  color: var(--fg-tertiary);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.search-result-snippet {
+  font-size: 0.85rem;
+  color: var(--fg-secondary);
+  margin-top: 0.2rem;
+}
+```
+
+**Step 4: Commit**
+
+```bash
+format
+git add projects/monolith/frontend/src/routes/private/+page.svelte
+git commit -m "feat(frontend): add debounced search and results list to overlay"
+```
+
+---
+
+## Phase 5: Frontend — note preview with section scroll
+
+### Task 11: Preview fetch + heading-only renderer
+
+**Step 1: Add the renderer helpers at the top of the `<script>`**
+
+```js
+function slugify(s) {
+  return s
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "");
+}
+
+function renderNote(md) {
+  const body = md.replace(/^---\n[\s\S]*?\n---\n?/, "");
+  return body.split(/\n\n+/).map((block) => {
+    const h = block.match(/^(#{1,3}) (.+)$/);
+    if (h) {
+      const level = h[1].length;
+      return { tag: `h${level}`, id: slugify(h[2]), text: h[2] };
+    }
+    return { tag: "p", text: block };
+  });
+}
+```
+
+**Step 2: Replace the stub `openPreview` with a real fetch**
+
+```js
+async function openPreview(result) {
+  selectedNote = { ...result, content: null, blocks: [] };
+  const res = await fetch(`/api/knowledge/notes/${result.note_id}`);
+  if (!res.ok) {
+    selectedNote = {
+      ...result,
+      content: "note not found",
+      blocks: [{ tag: "p", text: "note not found" }],
+    };
+    return;
+  }
+  const body = await res.json();
+  selectedNote = {
+    ...result,
+    content: body.content,
+    blocks: renderNote(body.content),
+  };
+  // Scroll to matching section on next tick
+  setTimeout(() => {
+    const slug = slugify(result.section.replace(/^#+\s*/, ""));
+    document.getElementById(slug)?.scrollIntoView({ block: "start" });
+  }, 0);
+}
+
+function closePreview() {
+  selectedNote = null;
+}
+```
+
+**Step 3: Wire `Esc`/`←` handling**
+
+In the keydown handler, replace the single `Escape` branch with:
+
+```js
+if (e.key === "Escape") {
+  e.preventDefault();
+  if (selectedNote) {
+    closePreview();
+  } else {
+    closeSearch();
+  }
+  return;
+}
+if (e.key === "ArrowLeft" && selectedNote) {
+  e.preventDefault();
+  closePreview();
+  return;
+}
+```
+
+**Step 4: Add preview markup inside the overlay, conditional on `selectedNote`**
+
+Replace the results block with:
+
+```svelte
+{#if selectedNote && selectedNote.blocks}
+  <div class="preview">
+    <button class="preview-back" onclick={closePreview}>← back · esc</button>
+    <article class="preview-body">
+      {#each selectedNote.blocks as block}
+        {#if block.tag === "h1"}
+          <h1 id={block.id}>{block.text}</h1>
+        {:else if block.tag === "h2"}
+          <h2 id={block.id}>{block.text}</h2>
+        {:else if block.tag === "h3"}
+          <h3 id={block.id}>{block.text}</h3>
+        {:else}
+          <p>{block.text}</p>
+        {/if}
+      {/each}
+    </article>
+  </div>
+{:else}
+  <!-- ... existing results list markup ... -->
+{/if}
+```
+
+**Step 5: Add preview styles**
+
+```css
+.preview {
+  position: relative;
+}
+
+.preview-back {
+  position: sticky;
+  top: 0;
+  background: var(--bg);
+  border: none;
+  color: var(--fg-tertiary);
+  font-family: var(--font);
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  padding: 0.5rem 0;
+  cursor: pointer;
+}
+
+.preview-body {
+  padding-top: 1rem;
+}
+
+.preview-body h1,
+.preview-body h2,
+.preview-body h3 {
+  font-weight: 700;
+  margin: 1.5rem 0 0.5rem;
+}
+
+.preview-body p {
+  margin: 0.75rem 0;
+  line-height: 1.7;
+}
+```
+
+**Step 6: Commit**
+
+```bash
+format
+git add projects/monolith/frontend/src/routes/private/+page.svelte
+git commit -m "feat(frontend): add note preview with heading-only markdown and section scroll"
+```
+
+---
+
+## Phase 6: E2E Playwright coverage
+
+### Task 12: Overlay open/close and capture preservation
+
+**Files:**
+
+- Modify: `projects/monolith/e2e/e2e_playwright_test.py`
+
+**Step 1: Add test class**
+
+```python
+class TestKnowledgeSearchOverlay:
+    def test_cmdk_opens_and_esc_closes(self, page, sveltekit_server, live_server_with_fake_embedding):
+        page.goto(f"{sveltekit_server}/private")
+        page.wait_for_selector(".capture-input")
+        page.keyboard.press("Meta+k")
+        page.wait_for_selector(".search-overlay")
+        page.keyboard.press("Escape")
+        assert page.locator(".search-overlay").count() == 0
+
+    def test_cmdk_preserves_capture_value(self, page, sveltekit_server, live_server_with_fake_embedding):
+        page.goto(f"{sveltekit_server}/private")
+        capture = page.locator(".capture-input")
+        capture.fill("draft thought")
+        page.keyboard.press("Meta+k")
+        page.wait_for_selector(".search-overlay")
+        page.keyboard.press("Escape")
+        # Capture textarea should still contain the draft
+        assert capture.input_value() == "draft thought"
+```
+
+**Step 2: Run**
+
+Run: `bb remote test //projects/monolith/e2e:e2e_playwright_test --config=ci --test_filter=TestKnowledgeSearchOverlay`
+Expected: PASS.
+
+**Step 3: Commit**
+
+```bash
+git add projects/monolith/e2e/e2e_playwright_test.py
+git commit -m "test(e2e): cover knowledge overlay open/close and capture preservation"
+```
+
+---
+
+### Task 13: Search results + preview + zero results
+
+**Step 1: Add tests. Seed a note in `pg` using the same helper the HTTP test added in Task 8.**
+
+```python
+def test_search_renders_results_and_opens_preview(
+    self, page, sveltekit_server, live_server_with_fake_embedding, pg, tmp_path, monkeypatch
+):
+    # Seed one note in pg + write file to tmp vault; point the live server at it
+    # via VAULT_ROOT env override. ⚠ The live_server fixture is session-scoped, so
+    # the env var must be set before that fixture instantiates — use a session-scoped
+    # autouse fixture that sets VAULT_ROOT to a stable tmp dir, then write files into it.
+    # ...seed note id=n1 with a chunk whose text contains "attention"...
+
+    page.goto(f"{sveltekit_server}/private")
+    page.keyboard.press("Meta+k")
+    page.wait_for_selector(".search-input")
+    page.locator(".search-input").fill("attention")
+    page.wait_for_selector(".search-result")
+    assert page.locator(".search-result").count() >= 1
+
+    page.keyboard.press("ArrowDown")
+    page.keyboard.press("Enter")
+    page.wait_for_selector(".preview-body")
+    assert "attention" in page.locator(".preview-body").inner_text().lower()
+
+def test_zero_results_shows_hint(
+    self, page, sveltekit_server, live_server_with_fake_embedding
+):
+    page.goto(f"{sveltekit_server}/private")
+    page.keyboard.press("Meta+k")
+    page.locator(".search-input").fill("zxqvfnonsense")
+    page.wait_for_selector(".search-hint")
+    assert "no results" in page.locator(".search-hint").inner_text()
+```
+
+**Step 2: Important — `VAULT_ROOT` handling**
+
+The `live_server` fixture sets env vars before importing `app.main`. You'll need to add `VAULT_ROOT` setup to the same place (around `projects/monolith/e2e/conftest.py:473`) so both the HTTP tests (Task 8) and the Playwright tests find vault files. Use a session-scoped `tmp_path_factory.mktemp("vault")` and call `os.environ["VAULT_ROOT"] = str(...)` before `from app.main import app`.
+
+Refactor Task 8's HTTP test seed helper into a reusable `knowledge_seed` session fixture that the Playwright test can share.
+
+**Step 3: Run**
+
+Run: `bb remote test //projects/monolith/e2e:e2e_playwright_test --config=ci --test_filter=TestKnowledgeSearchOverlay`
+Expected: PASS on all four tests.
+
+**Step 4: Commit**
+
+```bash
+git add projects/monolith/e2e/conftest.py projects/monolith/e2e/e2e_playwright_test.py
+git commit -m "test(e2e): cover knowledge search results, preview, and zero results"
+```
+
+---
+
+## Phase 7: Final integration check and PR
+
+### Task 14: Full knowledge + e2e test suite green
+
+**Step 1: Run the full test set**
+
+Run:
+
+```
+bb remote test //projects/monolith/knowledge/... --config=ci
+bb remote test //projects/monolith/e2e:e2e_playwright_test --config=ci
+bb remote test //projects/monolith/app:main_test --config=ci
+```
+
+Expected: all PASS.
+
+**Step 2: Verify nothing else broke**
+
+Run: `bb remote test //projects/monolith/... --config=ci`
+Expected: PASS. If anything downstream fails, read the BuildBuddy log via `bb view` before patching.
+
+**Step 3: Verify the frontend hint is wired**
+
+Visually check the capture footer in `+page.svelte` — add a `⌘ k` hint alongside the existing `⌘ enter` hint. Trivial edit, no new tests needed since the visual change is cosmetic.
+
+```svelte
+<span class="capture-hint">... ⌘ k search</span>
+```
+
+Commit:
+
+```bash
+format
+git add projects/monolith/frontend/src/routes/private/+page.svelte
+git commit -m "feat(frontend): add cmdk search hint to capture footer"
+```
+
+---
+
+### Task 15: Push and open PR
+
+**Step 1: Push**
+
+```bash
+git push -u origin feat/knowledge-search-overlay
+```
+
+**Step 2: Open PR**
+
+```bash
+gh pr create --title "feat(knowledge): add knowledge search overlay to homepage" --body "$(cat <<'EOF'
+## Summary
+
+Implements [ADR 003](../decisions/services/003-knowledge-search-overlay.md): a ⌘K-triggered full-viewport knowledge search overlay on the homepage, backed by two new FastAPI endpoints over the existing pgvector knowledge store.
+
+- New `KnowledgeStore.search_notes_with_context()` — top-N notes + batched best-chunk lookup, no N+1
+- New `/api/knowledge/search` and `/api/knowledge/notes/{id}` endpoints with DI-swappable embedding client
+- New overlay + preview state in `private/+page.svelte`, heading-only markdown renderer for section-level scroll targeting
+- Playwright e2e coverage against real FastAPI + real Postgres with deterministic fake embedding
+
+## Test plan
+
+- [ ] `bb remote test //projects/monolith/knowledge/... --config=ci`
+- [ ] `bb remote test //projects/monolith/e2e:e2e_playwright_test --config=ci`
+- [ ] Manual: open homepage, press ⌘K, type a query, navigate results with arrows, open preview, verify section scroll
+- [ ] Manual: verify capture textarea value is preserved across ⌘K open/close
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+**Step 3: Enable auto-merge if desired**
+
+```bash
+gh pr merge --auto --rebase
+```
+
+**Step 4: Poll until merged**
+
+Per CLAUDE.md: `gh pr view <number> --json state,mergeStateStatus` until merged, then verify the rollout via ArgoCD MCP tools.
+
+---
+
+## Summary of commits the plan produces
+
+1. `feat(knowledge): add search_notes_with_context store method`
+2. `test(knowledge): cover type filter and empty-db paths for search_notes_with_context`
+3. `feat(knowledge): add get_note_by_id store helper`
+4. `feat(knowledge): add search overlay FastAPI router`
+5. `test(knowledge): cover search endpoint happy path and 503`
+6. `test(knowledge): cover notes endpoint and 404 paths`
+7. `test(e2e): cover knowledge search HTTP endpoints with fake embedding`
+8. `feat(frontend): add knowledge search overlay shell with cmdk toggle`
+9. `feat(frontend): add debounced search and results list to overlay`
+10. `feat(frontend): add note preview with heading-only markdown and section scroll`
+11. `test(e2e): cover knowledge overlay open/close and capture preservation`
+12. `test(e2e): cover knowledge search results, preview, and zero results`
+13. `feat(frontend): add cmdk search hint to capture footer`
+
+Fifteen short-lived tasks, each independently testable and revertible.

--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -2168,7 +2168,6 @@ semgrep_target_test(
     exclude_rules = [
         # keep
         "avoid-sqlalchemy-text",
-        "generic-sql-fastapi",
         "tainted-fastapi-http-request-httpx",
     ],
     rules = ["//bazel/semgrep/rules:python_rules"],

--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -2168,6 +2168,7 @@ semgrep_target_test(
     exclude_rules = [
         # keep
         "avoid-sqlalchemy-text",
+        "generic-sql-fastapi",
         "tainted-fastapi-http-request-httpx",
     ],
     rules = ["//bazel/semgrep/rules:python_rules"],

--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -2126,6 +2126,18 @@ py_test(
 )
 
 py_test(
+    name = "knowledge_router_test",
+    srcs = ["knowledge/router_test.py"],
+    imports = ["."],
+    deps = [
+        ":monolith_backend",
+        "@pip//fastapi",
+        "@pip//httpx",
+        "@pip//pytest",
+    ],
+)
+
+py_test(
     name = "notes_router_whitespace_test",
     srcs = ["notes/router_whitespace_test.py"],
     imports = ["."],

--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -2168,6 +2168,7 @@ semgrep_target_test(
     exclude_rules = [
         # keep
         "avoid-sqlalchemy-text",
+        "generic-sql-fastapi",  # keep
         "tainted-fastapi-http-request-httpx",
     ],
     rules = ["//bazel/semgrep/rules:python_rules"],

--- a/projects/monolith/app/main.py
+++ b/projects/monolith/app/main.py
@@ -11,6 +11,7 @@ from fastapi.staticfiles import StaticFiles
 
 from app.log import configure_logging
 from home.router import router as home_router
+from knowledge.router import router as knowledge_router
 from notes.router import router as notes_router
 from chat.router import router as chat_router
 from shared.router import router as schedule_router
@@ -158,6 +159,7 @@ app.include_router(home_router)
 app.include_router(schedule_router)
 app.include_router(notes_router)
 app.include_router(chat_router)
+app.include_router(knowledge_router)
 
 
 @app.get("/healthz")

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.31.0
+version: 0.31.1
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.30.7
+version: 0.31.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.31.0
+      targetRevision: 0.31.1
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.30.7
+      targetRevision: 0.31.0
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/e2e/conftest.py
+++ b/projects/monolith/e2e/conftest.py
@@ -650,3 +650,30 @@ def sveltekit_server(live_server):
     except subprocess.TimeoutExpired:
         proc.kill()
         proc.wait(timeout=5)
+
+
+# ---------------------------------------------------------------------------
+# Session-scoped: live server with fake embedding client
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="session")
+def live_server_with_fake_embedding(live_server):
+    """Override the knowledge router's embedding dependency for the live server.
+
+    The live FastAPI instance reads from the ``app`` module-level singleton
+    imported inside ``live_server``. Registering an override on that instance
+    is enough to route every ``/api/knowledge/search`` request through the
+    deterministic fake.
+    """
+    from unittest.mock import AsyncMock
+
+    from app.main import app  # noqa: E402
+    from knowledge.router import get_embedding_client  # noqa: E402
+
+    fake = AsyncMock()
+    fake.embed = AsyncMock(side_effect=deterministic_embedding)
+
+    app.dependency_overrides[get_embedding_client] = lambda: fake
+    yield live_server
+    app.dependency_overrides.pop(get_embedding_client, None)

--- a/projects/monolith/e2e/e2e_playwright_test.py
+++ b/projects/monolith/e2e/e2e_playwright_test.py
@@ -621,3 +621,55 @@ class TestKnowledgeSearchHttp:
         base = live_server_with_fake_embedding
         r = httpx.get(f"{base}/api/knowledge/notes/nonexistent")
         assert r.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Browser: Knowledge search overlay (requires SvelteKit + Playwright)
+# ---------------------------------------------------------------------------
+
+
+class TestKnowledgeOverlay:
+    """Playwright tests for the Cmd+K knowledge search overlay.
+
+    Covers open/close behaviour, capture preservation, search results,
+    note preview, and zero-results state.
+    """
+
+    # -- Task 12: open/close + capture preservation -------------------------
+
+    def test_cmdk_opens_and_esc_closes(
+        self, page, sveltekit_server, live_server_with_fake_embedding
+    ):
+        """Press Cmd+K to open overlay, Escape to close it."""
+        page.goto(f"{sveltekit_server}/private")
+        page.wait_for_selector(".capture-input")
+
+        # Open overlay
+        page.keyboard.press("Meta+k")
+        overlay = page.locator(".search-overlay")
+        overlay.wait_for(state="visible")
+
+        # Search input should be focused
+        search_input = page.locator(".search-input")
+        assert search_input.evaluate("el => el === document.activeElement")
+
+        # Close overlay
+        page.keyboard.press("Escape")
+        assert page.locator(".search-overlay").count() == 0
+
+    def test_cmdk_preserves_capture_value(
+        self, page, sveltekit_server, live_server_with_fake_embedding
+    ):
+        """Capture textarea value is preserved across overlay open/close."""
+        page.goto(f"{sveltekit_server}/private")
+        capture = page.locator(".capture-input")
+        capture.wait_for(state="visible")
+        capture.fill("draft thought")
+
+        # Open and close overlay
+        page.keyboard.press("Meta+k")
+        page.locator(".search-overlay").wait_for(state="visible")
+        page.keyboard.press("Escape")
+
+        # Capture value should be restored
+        assert capture.input_value() == "draft thought"

--- a/projects/monolith/e2e/e2e_playwright_test.py
+++ b/projects/monolith/e2e/e2e_playwright_test.py
@@ -423,3 +423,201 @@ class TestBrowserUI:
         # (The vault isn't mocked at server level so this may fail,
         # but we can at least verify the key binding triggers the action)
         page.wait_for_timeout(300)
+
+
+# ---------------------------------------------------------------------------
+# Knowledge search HTTP tests (no browser needed)
+# ---------------------------------------------------------------------------
+
+
+def _seed_knowledge_note(
+    pg,
+    *,
+    note_id: str,
+    title: str,
+    path: str,
+    note_type: str = "note",
+    tags: list[str] | None = None,
+    chunk_texts: list[str],
+) -> None:
+    """Insert a note + chunks with deterministic embeddings into the test DB.
+
+    Uses a fresh engine+session per call so the data is committed and visible
+    to the live server (which uses its own connection pool).
+    """
+    from conftest import deterministic_embedding
+    from sqlmodel import Session as SMSession
+    from sqlmodel import create_engine as sm_create_engine
+
+    engine = sm_create_engine(pg.url)
+    with SMSession(engine) as session:
+        from knowledge.models import Chunk, Note
+
+        note = Note(
+            note_id=note_id,
+            path=path,
+            title=title,
+            content_hash="e2e-test-hash",
+            type=note_type,
+            tags=tags or [],
+        )
+        session.add(note)
+        session.flush()
+
+        for idx, text in enumerate(chunk_texts):
+            session.add(
+                Chunk(
+                    note_fk=note.id,
+                    chunk_index=idx,
+                    section_header=f"Section {idx}",
+                    chunk_text=text,
+                    embedding=deterministic_embedding(text),
+                )
+            )
+        session.commit()
+    engine.dispose()
+
+
+def _cleanup_knowledge(pg) -> None:
+    """Remove all knowledge rows so tests are isolated."""
+    from sqlalchemy import text
+    from sqlmodel import create_engine as sm_create_engine
+
+    engine = sm_create_engine(pg.url)
+    with engine.begin() as conn:
+        conn.execute(text("DELETE FROM knowledge.chunks"))
+        conn.execute(text("DELETE FROM knowledge.note_links"))
+        conn.execute(text("DELETE FROM knowledge.notes"))
+    engine.dispose()
+
+
+class TestKnowledgeSearchHttp:
+    """HTTP-level tests for /api/knowledge endpoints (no browser needed).
+
+    These hit the real live FastAPI server + real Postgres, but use a
+    deterministic embedding client so no external embedding service is needed.
+    """
+
+    def test_knowledge_search_empty_query(self, live_server_with_fake_embedding):
+        """GET /api/knowledge/search?q= returns empty results."""
+        base = live_server_with_fake_embedding
+        r = httpx.get(f"{base}/api/knowledge/search?q=")
+        assert r.status_code == 200
+        assert r.json() == {"results": []}
+
+    def test_knowledge_search_returns_results(
+        self, live_server_with_fake_embedding, pg
+    ):
+        """Seed a note, search with matching text, expect it in results."""
+        _cleanup_knowledge(pg)
+        _seed_knowledge_note(
+            pg,
+            note_id="e2e-transformers-001",
+            title="Transformer Architecture",
+            path="notes/transformers.md",
+            note_type="note",
+            tags=["ml", "architecture"],
+            chunk_texts=["Transformers use self-attention to process sequences."],
+        )
+
+        base = live_server_with_fake_embedding
+        r = httpx.get(
+            f"{base}/api/knowledge/search",
+            params={"q": "Transformers use self-attention to process sequences."},
+        )
+        assert r.status_code == 200
+        data = r.json()
+        assert len(data["results"]) >= 1
+
+        hit = data["results"][0]
+        assert hit["note_id"] == "e2e-transformers-001"
+        assert hit["title"] == "Transformer Architecture"
+        assert hit["type"] == "note"
+        assert hit["tags"] == ["ml", "architecture"]
+        assert hit["score"] > 0
+        assert "snippet" in hit
+        assert "section" in hit
+
+        _cleanup_knowledge(pg)
+
+    def test_knowledge_search_type_filter(self, live_server_with_fake_embedding, pg):
+        """Seed two notes with different types, filter by type, expect only matching."""
+        _cleanup_knowledge(pg)
+        shared_text = "Neural network training and optimization techniques."
+        _seed_knowledge_note(
+            pg,
+            note_id="e2e-filter-article",
+            title="Training Neural Nets",
+            path="notes/training.md",
+            note_type="article",
+            chunk_texts=[shared_text],
+        )
+        _seed_knowledge_note(
+            pg,
+            note_id="e2e-filter-log",
+            title="Training Log Entry",
+            path="notes/training-log.md",
+            note_type="log",
+            chunk_texts=[shared_text],
+        )
+
+        base = live_server_with_fake_embedding
+        r = httpx.get(
+            f"{base}/api/knowledge/search",
+            params={"q": shared_text, "type": "article"},
+        )
+        assert r.status_code == 200
+        data = r.json()
+        results = data["results"]
+        assert len(results) >= 1
+        assert all(hit["type"] == "article" for hit in results)
+        assert any(hit["note_id"] == "e2e-filter-article" for hit in results)
+        assert not any(hit["note_id"] == "e2e-filter-log" for hit in results)
+
+        _cleanup_knowledge(pg)
+
+    def test_knowledge_note_returns_content(
+        self, live_server_with_fake_embedding, pg, tmp_path_factory
+    ):
+        """Seed a note whose vault file exists, GET it by id, expect content."""
+        _cleanup_knowledge(pg)
+
+        vault_dir = tmp_path_factory.mktemp("vault")
+        md_file = vault_dir / "notes" / "e2e-content.md"
+        md_file.parent.mkdir(parents=True, exist_ok=True)
+        md_file.write_text("# E2E Content\n\nThis is the vault file content.")
+
+        import os
+
+        old_vault_root = os.environ.get("VAULT_ROOT")
+        os.environ["VAULT_ROOT"] = str(vault_dir)
+
+        try:
+            _seed_knowledge_note(
+                pg,
+                note_id="e2e-content-001",
+                title="E2E Content Note",
+                path="notes/e2e-content.md",
+                chunk_texts=["E2E content for testing."],
+            )
+
+            base = live_server_with_fake_embedding
+            r = httpx.get(f"{base}/api/knowledge/notes/e2e-content-001")
+            assert r.status_code == 200
+            data = r.json()
+            assert data["note_id"] == "e2e-content-001"
+            assert data["title"] == "E2E Content Note"
+            assert "content" in data
+            assert "E2E Content" in data["content"]
+        finally:
+            if old_vault_root is None:
+                os.environ.pop("VAULT_ROOT", None)
+            else:
+                os.environ["VAULT_ROOT"] = old_vault_root
+            _cleanup_knowledge(pg)
+
+    def test_knowledge_note_missing_returns_404(self, live_server_with_fake_embedding):
+        """GET /api/knowledge/notes/nonexistent returns 404."""
+        base = live_server_with_fake_embedding
+        r = httpx.get(f"{base}/api/knowledge/notes/nonexistent")
+        assert r.status_code == 404

--- a/projects/monolith/e2e/e2e_playwright_test.py
+++ b/projects/monolith/e2e/e2e_playwright_test.py
@@ -673,3 +673,115 @@ class TestKnowledgeOverlay:
 
         # Capture value should be restored
         assert capture.input_value() == "draft thought"
+
+    # -- Task 13: results + preview + zero results --------------------------
+
+    def test_search_renders_results(
+        self, page, sveltekit_server, live_server_with_fake_embedding, pg
+    ):
+        """Seed a note, search, verify result title appears."""
+        _cleanup_knowledge(pg)
+        _seed_knowledge_note(
+            pg,
+            note_id="e2e-overlay-attn",
+            title="Attention Mechanisms",
+            path="notes/attention.md",
+            note_type="note",
+            tags=["ml"],
+            chunk_texts=[
+                "Attention mechanisms allow models to focus on relevant parts."
+            ],
+        )
+
+        try:
+            page.goto(f"{sveltekit_server}/private")
+            page.keyboard.press("Meta+k")
+            page.locator(".search-input").wait_for(state="visible")
+            page.locator(".search-input").fill(
+                "Attention mechanisms allow models to focus on relevant parts."
+            )
+            page.locator(".search-result").first.wait_for(
+                state="visible", timeout=10000
+            )
+
+            assert page.locator(".search-result").count() >= 1
+            first_title = page.locator(".search-result-title").first.inner_text()
+            assert "Attention Mechanisms" in first_title
+        finally:
+            _cleanup_knowledge(pg)
+
+    def test_search_preview_and_back(
+        self, page, sveltekit_server, live_server_with_fake_embedding, pg, tmp_path
+    ):
+        """Select a result, verify preview renders, ArrowLeft returns to results."""
+        import os
+
+        _cleanup_knowledge(pg)
+
+        # Write a vault file for the note
+        vault_dir = tmp_path / "vault"
+        md_file = vault_dir / "notes" / "preview-test.md"
+        md_file.parent.mkdir(parents=True, exist_ok=True)
+        md_file.write_text(
+            "# Preview Test\n\nAttention is a mechanism for weighting inputs."
+        )
+
+        old_vault_root = os.environ.get("VAULT_ROOT")
+        os.environ["VAULT_ROOT"] = str(vault_dir)
+
+        try:
+            _seed_knowledge_note(
+                pg,
+                note_id="e2e-overlay-preview",
+                title="Preview Test Note",
+                path="notes/preview-test.md",
+                note_type="note",
+                chunk_texts=["Attention is a mechanism for weighting inputs."],
+            )
+
+            page.goto(f"{sveltekit_server}/private")
+            page.keyboard.press("Meta+k")
+            page.locator(".search-input").wait_for(state="visible")
+            page.locator(".search-input").fill(
+                "Attention is a mechanism for weighting inputs."
+            )
+            page.locator(".search-result").first.wait_for(
+                state="visible", timeout=10000
+            )
+
+            # Select the first result
+            page.keyboard.press("ArrowDown")
+            page.keyboard.press("Enter")
+
+            # Preview should appear
+            preview = page.locator(".search-preview-content")
+            preview.wait_for(state="visible", timeout=10000)
+            assert "attention" in preview.inner_text().lower()
+
+            # ArrowLeft goes back to results
+            page.keyboard.press("ArrowLeft")
+            assert page.locator(".search-preview-content").count() == 0
+            assert page.locator(".search-results").count() >= 1
+
+            # Escape closes overlay
+            page.keyboard.press("Escape")
+            assert page.locator(".search-overlay").count() == 0
+        finally:
+            if old_vault_root is None:
+                os.environ.pop("VAULT_ROOT", None)
+            else:
+                os.environ["VAULT_ROOT"] = old_vault_root
+            _cleanup_knowledge(pg)
+
+    def test_zero_results_shows_no_results(
+        self, page, sveltekit_server, live_server_with_fake_embedding
+    ):
+        """Type a nonsense query and verify 'no results' status appears."""
+        page.goto(f"{sveltekit_server}/private")
+        page.keyboard.press("Meta+k")
+        page.locator(".search-input").wait_for(state="visible")
+        page.locator(".search-input").fill("zxqvfnonsensequery")
+
+        status = page.locator(".search-status")
+        status.wait_for(state="visible", timeout=10000)
+        assert "no results" in status.inner_text().lower()

--- a/projects/monolith/frontend/src/routes/private/+page.svelte
+++ b/projects/monolith/frontend/src/routes/private/+page.svelte
@@ -1,4 +1,6 @@
 <script>
+  import { tick } from "svelte";
+
   let { data } = $props();
 
   // ── Capture ──────────────────────────────────
@@ -11,6 +13,49 @@
   });
 
   let error = $state(false);
+
+  // ── Knowledge search overlay ─────────────────
+  let searchOpen = $state(false);
+  let searchQuery = $state("");
+  let searchResults = $state([]);
+  let selectedNote = $state(null);
+  let activeIndex = $state(-1);
+  let searching = $state(false);
+  let searchType = $state("all");
+  let savedCapture = $state("");
+  let searchInputRef = $state(null);
+
+  function openSearch() {
+    savedCapture = note;
+    searchOpen = true;
+    tick().then(() => searchInputRef?.focus());
+  }
+
+  function closeSearch() {
+    searchOpen = false;
+    note = savedCapture;
+    searchQuery = "";
+    searchResults = [];
+    selectedNote = null;
+    activeIndex = -1;
+    searching = false;
+    tick().then(() => captureRef?.focus());
+  }
+
+  $effect(() => {
+    function handleGlobalKeyDown(e) {
+      if ((e.metaKey || e.ctrlKey) && e.key === "k") {
+        e.preventDefault();
+        if (!searchOpen) openSearch();
+      }
+      if (e.key === "Escape" && searchOpen) {
+        e.preventDefault();
+        closeSearch();
+      }
+    }
+    document.addEventListener("keydown", handleGlobalKeyDown);
+    return () => document.removeEventListener("keydown", handleGlobalKeyDown);
+  });
 
   async function submitCapture() {
     if (!note.trim()) return;
@@ -348,6 +393,20 @@
   </aside>
 </div>
 
+{#if searchOpen}
+  <div class="search-overlay">
+    <div class="search-container">
+      <input
+        type="text"
+        class="search-input"
+        placeholder="search knowledge..."
+        bind:value={searchQuery}
+        bind:this={searchInputRef}
+      />
+    </div>
+  </div>
+{/if}
+
 <style>
   /* ── Layout ────────────────────────────────── */
 
@@ -628,5 +687,37 @@
 
   .todo-dash--empty {
     color: var(--danger);
+  }
+
+  /* ── Knowledge search overlay ───────────────── */
+
+  .search-overlay {
+    position: fixed;
+    inset: 0;
+    background: var(--bg);
+    z-index: 100;
+    overflow-y: auto;
+  }
+
+  .search-container {
+    max-width: 72ch;
+    margin: 0 auto;
+    padding: 2.5rem;
+  }
+
+  .search-input {
+    width: 100%;
+    font-family: var(--font);
+    font-size: 1.1rem;
+    background: transparent;
+    border: none;
+    border-bottom: 0.06rem solid var(--border);
+    padding: 0.5rem 0;
+    color: var(--fg);
+    outline: none;
+  }
+
+  .search-input::placeholder {
+    color: var(--fg-tertiary);
   }
 </style>

--- a/projects/monolith/frontend/src/routes/private/+page.svelte
+++ b/projects/monolith/frontend/src/routes/private/+page.svelte
@@ -42,6 +42,17 @@
     tick().then(() => captureRef?.focus());
   }
 
+  async function selectResult(result) {
+    try {
+      const res = await fetch(`/api/knowledge/notes/${result.note_id}`);
+      if (res.ok) {
+        selectedNote = await res.json();
+      }
+    } catch (e) {
+      console.error("Failed to fetch note:", e);
+    }
+  }
+
   $effect(() => {
     function handleGlobalKeyDown(e) {
       if ((e.metaKey || e.ctrlKey) && e.key === "k") {
@@ -52,24 +63,18 @@
         e.preventDefault();
         closeSearch();
       }
-      if (searchOpen && e.key === "ArrowDown") {
+      if (searchOpen && e.key === "ArrowDown" && searchResults.length > 0) {
         e.preventDefault();
         activeIndex = Math.min(activeIndex + 1, searchResults.length - 1);
       }
-      if (searchOpen && e.key === "ArrowUp") {
+      if (searchOpen && e.key === "ArrowUp" && searchResults.length > 0) {
         e.preventDefault();
         activeIndex = Math.max(activeIndex - 1, -1);
       }
       if (searchOpen && e.key === "Enter" && activeIndex >= 0) {
         e.preventDefault();
         const result = searchResults[activeIndex];
-        if (result) {
-          fetch(`/api/knowledge/notes/${result.note_id}`)
-            .then((res) => (res.ok ? res.json() : null))
-            .then((data) => {
-              if (data) selectedNote = data;
-            });
-        }
+        if (result) selectResult(result);
       }
     }
     document.addEventListener("keydown", handleGlobalKeyDown);
@@ -78,8 +83,10 @@
 
   // ── Debounced search ───────────────────────────
   let searchTimer;
+  let searchController;
   $effect(() => {
     clearTimeout(searchTimer);
+    searchController?.abort();
     const q = searchQuery;
     const type = searchType;
     if (q.length < 2) {
@@ -89,15 +96,32 @@
     }
     searching = true;
     searchTimer = setTimeout(async () => {
-      const params = new URLSearchParams({ q });
-      if (type !== "all") params.set("type", type);
-      const res = await fetch(`/api/knowledge/search?${params}`);
-      if (res.ok) {
-        searchResults = (await res.json()).results;
-        activeIndex = -1;
+      const controller = new AbortController();
+      searchController = controller;
+      try {
+        const params = new URLSearchParams({ q });
+        if (type !== "all") params.set("type", type);
+        const res = await fetch(`/api/knowledge/search?${params}`, {
+          signal: controller.signal,
+        });
+        if (res.ok && !controller.signal.aborted) {
+          searchResults = (await res.json()).results;
+          activeIndex = -1;
+        }
+      } catch (e) {
+        if (e.name !== "AbortError") {
+          searchResults = [];
+        }
+      } finally {
+        if (!controller.signal.aborted) {
+          searching = false;
+        }
       }
-      searching = false;
     }, 300);
+    return () => {
+      clearTimeout(searchTimer);
+      searchController?.abort();
+    };
   });
 
   async function submitCapture() {
@@ -466,18 +490,18 @@
         <ul
           class="search-results"
           class:search-results--stale={searching}
+          role="listbox"
+          aria-label="Search results"
         >
           {#each searchResults as result, i}
             <li
               class="search-result"
               class:active={activeIndex === i}
+              role="option"
+              aria-selected={activeIndex === i}
               onclick={() => {
                 activeIndex = i;
-                fetch(`/api/knowledge/notes/${result.note_id}`)
-                  .then((res) => (res.ok ? res.json() : null))
-                  .then((data) => {
-                    if (data) selectedNote = data;
-                  });
+                selectResult(result);
               }}
             >
               <div class="search-result-title">

--- a/projects/monolith/frontend/src/routes/private/+page.svelte
+++ b/projects/monolith/frontend/src/routes/private/+page.svelte
@@ -357,16 +357,19 @@
       aria-label="Quick note"
     ></textarea>
     <footer class="capture-footer">
-      <span class="capture-hint" class:capture-hint--error={error}>
-        {#if error}
-          failed
-        {:else if sent}
-          sent
-        {:else if note.trim()}
-          ⌘ enter
-        {:else}
-          &nbsp;
-        {/if}
+      <span class="capture-hints">
+        <span class="capture-hint" class:capture-hint--error={error}>
+          {#if error}
+            failed
+          {:else if sent}
+            sent
+          {:else if note.trim()}
+            ⌘ enter
+          {:else}
+            &nbsp;
+          {/if}
+        </span>
+        <span class="capture-hint">⌘K</span>
       </span>
       {#if note.length > 0}
         <span class="capture-count">{note.length}</span>
@@ -659,6 +662,12 @@
     color: var(--fg-tertiary);
     letter-spacing: 0.04em;
     transition: opacity 0.2s ease;
+  }
+
+  .capture-hints {
+    display: flex;
+    gap: 1rem;
+    align-items: center;
   }
 
   .capture-hint--error {

--- a/projects/monolith/frontend/src/routes/private/+page.svelte
+++ b/projects/monolith/frontend/src/routes/private/+page.svelte
@@ -52,9 +52,52 @@
         e.preventDefault();
         closeSearch();
       }
+      if (searchOpen && e.key === "ArrowDown") {
+        e.preventDefault();
+        activeIndex = Math.min(activeIndex + 1, searchResults.length - 1);
+      }
+      if (searchOpen && e.key === "ArrowUp") {
+        e.preventDefault();
+        activeIndex = Math.max(activeIndex - 1, -1);
+      }
+      if (searchOpen && e.key === "Enter" && activeIndex >= 0) {
+        e.preventDefault();
+        const result = searchResults[activeIndex];
+        if (result) {
+          fetch(`/api/knowledge/notes/${result.note_id}`)
+            .then((res) => (res.ok ? res.json() : null))
+            .then((data) => {
+              if (data) selectedNote = data;
+            });
+        }
+      }
     }
     document.addEventListener("keydown", handleGlobalKeyDown);
     return () => document.removeEventListener("keydown", handleGlobalKeyDown);
+  });
+
+  // ── Debounced search ───────────────────────────
+  let searchTimer;
+  $effect(() => {
+    clearTimeout(searchTimer);
+    const q = searchQuery;
+    const type = searchType;
+    if (q.length < 2) {
+      searchResults = [];
+      searching = false;
+      return;
+    }
+    searching = true;
+    searchTimer = setTimeout(async () => {
+      const params = new URLSearchParams({ q });
+      if (type !== "all") params.set("type", type);
+      const res = await fetch(`/api/knowledge/search?${params}`);
+      if (res.ok) {
+        searchResults = (await res.json()).results;
+        activeIndex = -1;
+      }
+      searching = false;
+    }, 300);
   });
 
   async function submitCapture() {
@@ -403,6 +446,64 @@
         bind:value={searchQuery}
         bind:this={searchInputRef}
       />
+      <div class="search-type-filters">
+        {#each ["all", "note", "paper", "article", "recipe"] as type}
+          <button
+            class="search-type-pill"
+            class:active={searchType === type}
+            onclick={() => (searchType = type)}
+          >
+            {type}
+          </button>
+        {/each}
+      </div>
+      {#if searching && searchResults.length === 0}
+        <p class="search-status">searching...</p>
+      {:else if !searching && searchQuery.length >= 2 && searchResults.length === 0}
+        <p class="search-status">no results</p>
+      {/if}
+      {#if searchResults.length > 0}
+        <ul
+          class="search-results"
+          class:search-results--stale={searching}
+        >
+          {#each searchResults as result, i}
+            <li
+              class="search-result"
+              class:active={activeIndex === i}
+              onclick={() => {
+                activeIndex = i;
+                fetch(`/api/knowledge/notes/${result.note_id}`)
+                  .then((res) => (res.ok ? res.json() : null))
+                  .then((data) => {
+                    if (data) selectedNote = data;
+                  });
+              }}
+            >
+              <div class="search-result-title">
+                {result.title}
+                {#if result.type}
+                  <span class="search-result-badge">{result.type}</span>
+                {/if}
+              </div>
+              {#if result.section || result.tags?.length}
+                <div class="search-result-meta">
+                  {#if result.section}{result.section}{/if}
+                  {#if result.section && result.tags?.length}
+                    &nbsp;&middot;&nbsp;
+                  {/if}
+                  {#if result.tags?.length}
+                    {result.tags.join(" \u00b7 ")}
+                  {/if}
+                </div>
+              {/if}
+              {#if result.snippet}
+                <div class="search-result-snippet">{result.snippet}</div>
+              {/if}
+            </li>
+          {/each}
+        </ul>
+      {/if}
     </div>
   </div>
 {/if}
@@ -719,5 +820,81 @@
 
   .search-input::placeholder {
     color: var(--fg-tertiary);
+  }
+
+  .search-type-filters {
+    display: flex;
+    gap: 1rem;
+    margin: 1rem 0;
+  }
+
+  .search-type-pill {
+    font-size: 0.65rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.14em;
+    color: var(--fg-tertiary);
+    cursor: pointer;
+    background: none;
+    border: none;
+    padding: 0;
+    font-family: var(--font);
+  }
+
+  .search-type-pill.active {
+    color: var(--fg);
+  }
+
+  .search-results {
+    list-style: none;
+    padding: 0;
+    margin: 1rem 0 0 0;
+  }
+
+  .search-results--stale {
+    opacity: 0.5;
+  }
+
+  .search-result {
+    padding: 0.75rem 0;
+    border-bottom: 0.04rem solid var(--border);
+    cursor: pointer;
+  }
+
+  .search-result.active {
+    background: var(--surface);
+  }
+
+  .search-result-title {
+    font-weight: 700;
+    color: var(--fg);
+  }
+
+  .search-result-badge {
+    font-size: 0.65rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.14em;
+    color: var(--fg-tertiary);
+    margin-left: 0.5rem;
+  }
+
+  .search-result-meta {
+    font-size: 0.75rem;
+    color: var(--fg-tertiary);
+    margin-top: 0.25rem;
+  }
+
+  .search-result-snippet {
+    font-size: 0.85rem;
+    color: var(--fg-secondary);
+    margin-top: 0.25rem;
+    line-height: 1.5;
+  }
+
+  .search-status {
+    color: var(--fg-tertiary);
+    margin-top: 1rem;
+    font-size: 0.85rem;
   }
 </style>

--- a/projects/monolith/frontend/src/routes/private/+page.svelte
+++ b/projects/monolith/frontend/src/routes/private/+page.svelte
@@ -42,16 +42,42 @@
     tick().then(() => captureRef?.focus());
   }
 
+  function slugify(s) {
+    return s
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-|-$/g, "");
+  }
+
+  function renderNote(md) {
+    const blocks = md.replace(/^---\n[\s\S]*?\n---\n?/, "").split(/\n\n+/);
+    return blocks.map((block) => {
+      const h = block.match(/^(#{1,3}) (.+)$/);
+      if (h) return { tag: `h${h[1].length}`, id: slugify(h[2]), text: h[2] };
+      return { tag: "p", text: block };
+    });
+  }
+
   async function selectResult(result) {
     try {
       const res = await fetch(`/api/knowledge/notes/${result.note_id}`);
       if (res.ok) {
-        selectedNote = await res.json();
+        const note = await res.json();
+        selectedNote = { ...note, section: result.section };
       }
     } catch (e) {
       console.error("Failed to fetch note:", e);
     }
   }
+
+  $effect(() => {
+    if (selectedNote?.content && selectedNote?.section) {
+      tick().then(() => {
+        const slug = slugify(selectedNote.section.replace(/^#+\s*/, ""));
+        document.getElementById(slug)?.scrollIntoView({ block: "start" });
+      });
+    }
+  });
 
   $effect(() => {
     function handleGlobalKeyDown(e) {
@@ -63,15 +89,19 @@
         e.preventDefault();
         closeSearch();
       }
-      if (searchOpen && e.key === "ArrowDown" && searchResults.length > 0) {
+      if (searchOpen && e.key === "ArrowLeft" && selectedNote) {
+        e.preventDefault();
+        selectedNote = null;
+      }
+      if (searchOpen && e.key === "ArrowDown" && !selectedNote && searchResults.length > 0) {
         e.preventDefault();
         activeIndex = Math.min(activeIndex + 1, searchResults.length - 1);
       }
-      if (searchOpen && e.key === "ArrowUp" && searchResults.length > 0) {
+      if (searchOpen && e.key === "ArrowUp" && !selectedNote && searchResults.length > 0) {
         e.preventDefault();
         activeIndex = Math.max(activeIndex - 1, -1);
       }
-      if (searchOpen && e.key === "Enter" && activeIndex >= 0) {
+      if (searchOpen && e.key === "Enter" && !selectedNote && activeIndex >= 0) {
         e.preventDefault();
         const result = searchResults[activeIndex];
         if (result) selectResult(result);
@@ -481,52 +511,86 @@
           </button>
         {/each}
       </div>
-      {#if searching && searchResults.length === 0}
-        <p class="search-status">searching...</p>
-      {:else if !searching && searchQuery.length >= 2 && searchResults.length === 0}
-        <p class="search-status">no results</p>
-      {/if}
-      {#if searchResults.length > 0}
-        <ul
-          class="search-results"
-          class:search-results--stale={searching}
-          role="listbox"
-          aria-label="Search results"
-        >
-          {#each searchResults as result, i}
-            <li
-              class="search-result"
-              class:active={activeIndex === i}
-              role="option"
-              aria-selected={activeIndex === i}
+      {#if selectedNote}
+        <div class="search-preview">
+          <div class="search-preview-header">
+            <button
+              class="search-back"
               onclick={() => {
-                activeIndex = i;
-                selectResult(result);
+                selectedNote = null;
               }}
             >
-              <div class="search-result-title">
-                {result.title}
-                {#if result.type}
-                  <span class="search-result-badge">{result.type}</span>
-                {/if}
+              &larr; back &middot; esc
+            </button>
+            <h2 class="search-preview-title">{selectedNote.title}</h2>
+            {#if selectedNote.tags?.length}
+              <div class="search-preview-tags">
+                {selectedNote.tags.join(" \u00b7 ")}
               </div>
-              {#if result.section || result.tags?.length}
-                <div class="search-result-meta">
-                  {#if result.section}{result.section}{/if}
-                  {#if result.section && result.tags?.length}
-                    &nbsp;&middot;&nbsp;
-                  {/if}
-                  {#if result.tags?.length}
-                    {result.tags.join(" \u00b7 ")}
+            {/if}
+          </div>
+          <div class="search-preview-content">
+            {#each renderNote(selectedNote.content) as block}
+              {#if block.tag === "h1"}
+                <h1 id={block.id}>{block.text}</h1>
+              {:else if block.tag === "h2"}
+                <h2 id={block.id}>{block.text}</h2>
+              {:else if block.tag === "h3"}
+                <h3 id={block.id}>{block.text}</h3>
+              {:else}
+                <p>{block.text}</p>
+              {/if}
+            {/each}
+          </div>
+        </div>
+      {:else}
+        {#if searching && searchResults.length === 0}
+          <p class="search-status">searching...</p>
+        {:else if !searching && searchQuery.length >= 2 && searchResults.length === 0}
+          <p class="search-status">no results</p>
+        {/if}
+        {#if searchResults.length > 0}
+          <ul
+            class="search-results"
+            class:search-results--stale={searching}
+            role="listbox"
+            aria-label="Search results"
+          >
+            {#each searchResults as result, i}
+              <li
+                class="search-result"
+                class:active={activeIndex === i}
+                role="option"
+                aria-selected={activeIndex === i}
+                onclick={() => {
+                  activeIndex = i;
+                  selectResult(result);
+                }}
+              >
+                <div class="search-result-title">
+                  {result.title}
+                  {#if result.type}
+                    <span class="search-result-badge">{result.type}</span>
                   {/if}
                 </div>
-              {/if}
-              {#if result.snippet}
-                <div class="search-result-snippet">{result.snippet}</div>
-              {/if}
-            </li>
-          {/each}
-        </ul>
+                {#if result.section || result.tags?.length}
+                  <div class="search-result-meta">
+                    {#if result.section}{result.section}{/if}
+                    {#if result.section && result.tags?.length}
+                      &nbsp;&middot;&nbsp;
+                    {/if}
+                    {#if result.tags?.length}
+                      {result.tags.join(" \u00b7 ")}
+                    {/if}
+                  </div>
+                {/if}
+                {#if result.snippet}
+                  <div class="search-result-snippet">{result.snippet}</div>
+                {/if}
+              </li>
+            {/each}
+          </ul>
+        {/if}
       {/if}
     </div>
   </div>
@@ -920,5 +984,58 @@
     color: var(--fg-tertiary);
     margin-top: 1rem;
     font-size: 0.85rem;
+  }
+
+  /* ── Note preview ─────────────────────────── */
+
+  .search-preview-header {
+    border-bottom: 0.06rem solid var(--border);
+    padding-bottom: 1rem;
+    margin-bottom: 1.5rem;
+  }
+  .search-back {
+    font-family: var(--font);
+    font-size: 0.75rem;
+    color: var(--fg-tertiary);
+    background: none;
+    border: none;
+    padding: 0;
+    cursor: pointer;
+    margin-bottom: 1rem;
+  }
+  .search-back:hover {
+    color: var(--fg-secondary);
+  }
+  .search-preview-title {
+    font-size: 1.25rem;
+    font-weight: 700;
+    color: var(--fg);
+    margin: 0;
+  }
+  .search-preview-tags {
+    font-size: 0.75rem;
+    color: var(--fg-tertiary);
+    margin-top: 0.5rem;
+  }
+  .search-preview-content h1,
+  .search-preview-content h2,
+  .search-preview-content h3 {
+    color: var(--fg);
+    margin: 1.5rem 0 0.75rem 0;
+  }
+  .search-preview-content h1 {
+    font-size: 1.15rem;
+  }
+  .search-preview-content h2 {
+    font-size: 1rem;
+  }
+  .search-preview-content h3 {
+    font-size: 0.9rem;
+  }
+  .search-preview-content p {
+    color: var(--fg-secondary);
+    line-height: 1.6;
+    margin: 0 0 1rem 0;
+    white-space: pre-wrap;
   }
 </style>

--- a/projects/monolith/frontend/src/routes/private/+page.svelte
+++ b/projects/monolith/frontend/src/routes/private/+page.svelte
@@ -52,7 +52,7 @@
   function renderNote(md) {
     const blocks = md.replace(/^---\n[\s\S]*?\n---\n?/, "").split(/\n\n+/);
     return blocks.map((block) => {
-      const h = block.match(/^(#{1,3}) (.+)$/);
+      const h = block.match(/^(#{1,3}) (.+)$/m);
       if (h) return { tag: `h${h[1].length}`, id: slugify(h[2]), text: h[2] };
       return { tag: "p", text: block };
     });
@@ -62,8 +62,8 @@
     try {
       const res = await fetch(`/api/knowledge/notes/${result.note_id}`);
       if (res.ok) {
-        const note = await res.json();
-        selectedNote = { ...note, section: result.section };
+        const fetchedNote = await res.json();
+        selectedNote = { ...fetchedNote, section: result.section };
       }
     } catch (e) {
       console.error("Failed to fetch note:", e);

--- a/projects/monolith/knowledge/router.py
+++ b/projects/monolith/knowledge/router.py
@@ -1,0 +1,84 @@
+"""HTTP API for the knowledge search overlay.
+
+Two endpoints back the cmdk-style search UI:
+
+- ``GET /api/knowledge/search`` — embed the query via ``EmbeddingClient`` and
+  hand off to ``KnowledgeStore.search_notes_with_context``.
+- ``GET /api/knowledge/notes/{note_id}`` — fetch a note by id and read its
+  vault markdown off disk so the preview pane can render it.
+
+The embedding client is injected through ``get_embedding_client`` so e2e tests
+can override it with a deterministic fake via ``app.dependency_overrides``.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlmodel import Session
+
+from app.db import get_session
+from knowledge.service import _DEFAULT_VAULT_ROOT, _VAULT_ROOT_ENV
+from knowledge.store import KnowledgeStore
+from shared.embedding import EmbeddingClient
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/knowledge", tags=["knowledge"])
+
+
+def get_embedding_client() -> EmbeddingClient:
+    """DI seam for the embedding client.
+
+    Tests override this via ``app.dependency_overrides[get_embedding_client]``
+    to inject a deterministic fake.
+    """
+    return EmbeddingClient()
+
+
+@router.get("/search")
+async def search_knowledge(
+    q: str = "",
+    type: str | None = Query(default=None),
+    limit: int = Query(default=20, ge=1, le=100),
+    session: Session = Depends(get_session),
+    embed_client: EmbeddingClient = Depends(get_embedding_client),
+) -> dict:
+    # Mirror the frontend's 2-char debounce threshold: skip the embed call
+    # entirely for empty / single-char queries so we never hit the embed
+    # service for no reason.
+    if len(q) < 2:
+        return {"results": []}
+
+    try:
+        vector = await embed_client.embed(q)
+    except Exception:
+        logger.exception("knowledge.search: embedding call failed")
+        raise HTTPException(status_code=503, detail="embedding unavailable")
+
+    results = KnowledgeStore(session).search_notes_with_context(
+        query_embedding=vector,
+        limit=limit,
+        type_filter=type,
+    )
+    return {"results": results}
+
+
+@router.get("/notes/{note_id}")
+def get_knowledge_note(
+    note_id: int,
+    session: Session = Depends(get_session),
+) -> dict:
+    note = KnowledgeStore(session).get_note_by_id(note_id)
+    if note is None:
+        raise HTTPException(status_code=404, detail="note not found")
+
+    vault_root = Path(os.environ.get(_VAULT_ROOT_ENV, _DEFAULT_VAULT_ROOT))
+    file_path = vault_root / note["path"]
+    if not file_path.is_file():
+        raise HTTPException(status_code=404, detail="vault file missing")
+
+    return {**note, "content": file_path.read_text()}

--- a/projects/monolith/knowledge/router.py
+++ b/projects/monolith/knowledge/router.py
@@ -21,7 +21,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlmodel import Session
 
 from app.db import get_session
-from knowledge.service import _DEFAULT_VAULT_ROOT, _VAULT_ROOT_ENV
+from knowledge.service import DEFAULT_VAULT_ROOT, VAULT_ROOT_ENV
 from knowledge.store import KnowledgeStore
 from shared.embedding import EmbeddingClient
 
@@ -69,16 +69,16 @@ async def search_knowledge(
 
 @router.get("/notes/{note_id}")
 def get_knowledge_note(
-    note_id: int,
+    note_id: str,
     session: Session = Depends(get_session),
 ) -> dict:
     note = KnowledgeStore(session).get_note_by_id(note_id)
     if note is None:
         raise HTTPException(status_code=404, detail="note not found")
 
-    vault_root = Path(os.environ.get(_VAULT_ROOT_ENV, _DEFAULT_VAULT_ROOT))
-    file_path = vault_root / note["path"]
-    if not file_path.is_file():
+    vault_root = Path(os.environ.get(VAULT_ROOT_ENV, DEFAULT_VAULT_ROOT)).resolve()
+    resolved = (vault_root / note["path"]).resolve()
+    if not resolved.is_relative_to(vault_root) or not resolved.is_file():
         raise HTTPException(status_code=404, detail="vault file missing")
 
-    return {**note, "content": file_path.read_text()}
+    return {**note, "content": resolved.read_text()}

--- a/projects/monolith/knowledge/router_test.py
+++ b/projects/monolith/knowledge/router_test.py
@@ -122,14 +122,14 @@ class TestSearchEndpoint:
         failing_client.embed.side_effect = RuntimeError("boom")
         app.dependency_overrides[get_session] = lambda: fake_session
         app.dependency_overrides[get_embedding_client] = lambda: failing_client
-        c = TestClient(app, raise_server_exceptions=False)
-
-        r = c.get("/api/knowledge/search?q=hello")
-
-        app.dependency_overrides.clear()
-        assert r.status_code == 503
-        body = r.json()
-        assert body.get("detail") == "embedding unavailable"
+        try:
+            c = TestClient(app, raise_server_exceptions=False)
+            r = c.get("/api/knowledge/search?q=hello")
+            assert r.status_code == 503
+            body = r.json()
+            assert body.get("detail") == "embedding unavailable"
+        finally:
+            app.dependency_overrides.clear()
 
     def test_default_limit_is_20(self, client):
         """When limit is not specified, store is called with limit=20."""

--- a/projects/monolith/knowledge/router_test.py
+++ b/projects/monolith/knowledge/router_test.py
@@ -1,0 +1,144 @@
+"""Unit tests for knowledge/router.py — /search endpoint."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.db import get_session
+from app.main import app
+from knowledge.router import get_embedding_client
+
+FAKE_EMBEDDING = [0.1] * 1024
+
+CANNED_RESULTS = [
+    {
+        "note_id": "n1",
+        "title": "Attention Is All You Need",
+        "path": "papers/attention.md",
+        "type": "paper",
+        "tags": ["ml", "transformers"],
+        "score": 0.95,
+        "snippet": "The transformer replaces recurrence entirely with attention.",
+        "section": "## Architecture",
+    },
+]
+
+
+@pytest.fixture()
+def fake_embed_client():
+    client = AsyncMock()
+    client.embed.return_value = FAKE_EMBEDDING
+    return client
+
+
+@pytest.fixture()
+def fake_session():
+    return MagicMock()
+
+
+@pytest.fixture()
+def client(fake_session, fake_embed_client):
+    """TestClient with overridden session and embedding client."""
+    app.dependency_overrides[get_session] = lambda: fake_session
+    app.dependency_overrides[get_embedding_client] = lambda: fake_embed_client
+    yield TestClient(app, raise_server_exceptions=False)
+    app.dependency_overrides.clear()
+
+
+class TestSearchEndpoint:
+    """Tests for GET /api/knowledge/search."""
+
+    def test_happy_path_returns_canned_results(self, client, fake_embed_client):
+        """Query >= 2 chars returns results with all expected fields."""
+        with patch("knowledge.router.KnowledgeStore") as MockStore:
+            MockStore.return_value.search_notes_with_context.return_value = (
+                CANNED_RESULTS
+            )
+            r = client.get("/api/knowledge/search?q=attention")
+
+        assert r.status_code == 200
+        body = r.json()
+        assert len(body["results"]) == 1
+        result = body["results"][0]
+        assert result["note_id"] == "n1"
+        assert result["title"] == "Attention Is All You Need"
+        assert result["path"] == "papers/attention.md"
+        assert result["type"] == "paper"
+        assert result["tags"] == ["ml", "transformers"]
+        assert result["score"] == 0.95
+        assert "transformer replaces recurrence" in result["snippet"]
+        assert result["section"] == "## Architecture"
+
+        fake_embed_client.embed.assert_awaited_once_with("attention")
+
+    def test_empty_query_returns_empty_results(self, client, fake_embed_client):
+        """Empty query returns [] without calling embed or store."""
+        with patch("knowledge.router.KnowledgeStore") as MockStore:
+            r = client.get("/api/knowledge/search?q=")
+
+            assert r.status_code == 200
+            assert r.json() == {"results": []}
+            fake_embed_client.embed.assert_not_awaited()
+            MockStore.assert_not_called()
+
+    def test_single_char_query_returns_empty_results(self, client, fake_embed_client):
+        """Single-char query returns [] without calling embed."""
+        with patch("knowledge.router.KnowledgeStore") as MockStore:
+            r = client.get("/api/knowledge/search?q=a")
+
+            assert r.status_code == 200
+            assert r.json() == {"results": []}
+            fake_embed_client.embed.assert_not_awaited()
+            MockStore.assert_not_called()
+
+    def test_type_filter_forwarded_to_store(self, client):
+        """type query param is passed as type_filter to the store."""
+        with patch("knowledge.router.KnowledgeStore") as MockStore:
+            MockStore.return_value.search_notes_with_context.return_value = []
+            client.get("/api/knowledge/search?q=attention&type=paper")
+
+            MockStore.return_value.search_notes_with_context.assert_called_once_with(
+                query_embedding=FAKE_EMBEDDING,
+                limit=20,
+                type_filter="paper",
+            )
+
+    def test_limit_forwarded_to_store(self, client):
+        """limit query param is passed through to the store."""
+        with patch("knowledge.router.KnowledgeStore") as MockStore:
+            MockStore.return_value.search_notes_with_context.return_value = []
+            client.get("/api/knowledge/search?q=attention&limit=5")
+
+            MockStore.return_value.search_notes_with_context.assert_called_once_with(
+                query_embedding=FAKE_EMBEDDING,
+                limit=5,
+                type_filter=None,
+            )
+
+    def test_embedding_failure_returns_503(self, fake_session):
+        """Embedding client exception produces HTTP 503."""
+        failing_client = AsyncMock()
+        failing_client.embed.side_effect = RuntimeError("boom")
+        app.dependency_overrides[get_session] = lambda: fake_session
+        app.dependency_overrides[get_embedding_client] = lambda: failing_client
+        c = TestClient(app, raise_server_exceptions=False)
+
+        r = c.get("/api/knowledge/search?q=hello")
+
+        app.dependency_overrides.clear()
+        assert r.status_code == 503
+        body = r.json()
+        assert body.get("detail") == "embedding unavailable"
+
+    def test_default_limit_is_20(self, client):
+        """When limit is not specified, store is called with limit=20."""
+        with patch("knowledge.router.KnowledgeStore") as MockStore:
+            MockStore.return_value.search_notes_with_context.return_value = []
+            client.get("/api/knowledge/search?q=attention")
+
+            MockStore.return_value.search_notes_with_context.assert_called_once_with(
+                query_embedding=FAKE_EMBEDDING,
+                limit=20,
+                type_filter=None,
+            )

--- a/projects/monolith/knowledge/router_test.py
+++ b/projects/monolith/knowledge/router_test.py
@@ -1,6 +1,5 @@
 """Unit tests for knowledge/router.py — /search and /notes endpoints."""
 
-import os
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -166,7 +165,9 @@ def note_client(fake_session):
 class TestGetNoteEndpoint:
     """Tests for GET /api/knowledge/notes/{note_id}."""
 
-    def test_happy_path_returns_note_with_content(self, tmp_path, fake_session):
+    def test_happy_path_returns_note_with_content(
+        self, tmp_path, fake_session, monkeypatch
+    ):
         """Existing note + vault file returns all fields plus content."""
         vault_dir = tmp_path / "vault"
         vault_dir.mkdir()
@@ -174,19 +175,14 @@ class TestGetNoteEndpoint:
         note_file.parent.mkdir(parents=True)
         note_file.write_text("# Attention\n\nSelf-attention mechanism.")
 
+        monkeypatch.setenv(VAULT_ROOT_ENV, str(vault_dir))
         app.dependency_overrides[get_session] = lambda: fake_session
-        old_val = os.environ.get(VAULT_ROOT_ENV)
-        os.environ[VAULT_ROOT_ENV] = str(vault_dir)
         try:
             c = TestClient(app, raise_server_exceptions=False)
             with patch("knowledge.router.KnowledgeStore") as MockStore:
                 MockStore.return_value.get_note_by_id.return_value = SAMPLE_NOTE
                 r = c.get("/api/knowledge/notes/n1")
         finally:
-            if old_val is None:
-                os.environ.pop(VAULT_ROOT_ENV, None)
-            else:
-                os.environ[VAULT_ROOT_ENV] = old_val
             app.dependency_overrides.clear()
 
         assert r.status_code == 200
@@ -208,27 +204,48 @@ class TestGetNoteEndpoint:
         body = r.json()
         assert body.get("detail") == "note not found"
 
-    def test_missing_vault_file_returns_404(self, note_client):
+    def test_missing_vault_file_returns_404(self, tmp_path, fake_session, monkeypatch):
         """Note exists in DB but vault file missing on disk -> 404."""
-        with patch("knowledge.router.KnowledgeStore") as MockStore:
-            MockStore.return_value.get_note_by_id.return_value = {
-                **SAMPLE_NOTE,
-                "path": "nonexistent/missing.md",
-            }
-            r = note_client.get("/api/knowledge/notes/n1")
+        vault_dir = tmp_path / "vault"
+        vault_dir.mkdir()
+        monkeypatch.setenv(VAULT_ROOT_ENV, str(vault_dir))
+
+        app.dependency_overrides[get_session] = lambda: fake_session
+        try:
+            with patch("knowledge.router.KnowledgeStore") as MockStore:
+                MockStore.return_value.get_note_by_id.return_value = {
+                    **SAMPLE_NOTE,
+                    "path": "nonexistent/missing.md",
+                }
+                c = TestClient(app, raise_server_exceptions=False)
+                r = c.get("/api/knowledge/notes/n1")
+        finally:
+            app.dependency_overrides.clear()
 
         assert r.status_code == 404
         body = r.json()
         assert body.get("detail") == "vault file missing"
 
-    def test_path_traversal_returns_404(self, note_client):
-        """Path containing ../ is caught by is_relative_to guard -> 404."""
-        with patch("knowledge.router.KnowledgeStore") as MockStore:
-            MockStore.return_value.get_note_by_id.return_value = {
-                **SAMPLE_NOTE,
-                "path": "../../../etc/passwd",
-            }
-            r = note_client.get("/api/knowledge/notes/n1")
+    def test_path_traversal_returns_404(self, tmp_path, fake_session, monkeypatch):
+        """Path traversal is caught by is_relative_to guard."""
+        vault_dir = tmp_path / "vault"
+        vault_dir.mkdir()
+        # Create a file outside vault that the traversal path would reach
+        secret = tmp_path / "secret.txt"
+        secret.write_text("should not be readable")
+        monkeypatch.setenv(VAULT_ROOT_ENV, str(vault_dir))
+
+        app.dependency_overrides[get_session] = lambda: fake_session
+        try:
+            with patch("knowledge.router.KnowledgeStore") as MockStore:
+                MockStore.return_value.get_note_by_id.return_value = {
+                    **SAMPLE_NOTE,
+                    "path": "../secret.txt",
+                }
+                c = TestClient(app, raise_server_exceptions=False)
+                r = c.get("/api/knowledge/notes/n1")
+        finally:
+            app.dependency_overrides.clear()
 
         assert r.status_code == 404
         body = r.json()

--- a/projects/monolith/knowledge/router_test.py
+++ b/projects/monolith/knowledge/router_test.py
@@ -1,5 +1,6 @@
-"""Unit tests for knowledge/router.py — /search endpoint."""
+"""Unit tests for knowledge/router.py — /search and /notes endpoints."""
 
+import os
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -8,6 +9,7 @@ from fastapi.testclient import TestClient
 from app.db import get_session
 from app.main import app
 from knowledge.router import get_embedding_client
+from knowledge.service import VAULT_ROOT_ENV
 
 FAKE_EMBEDDING = [0.1] * 1024
 
@@ -142,3 +144,92 @@ class TestSearchEndpoint:
                 limit=20,
                 type_filter=None,
             )
+
+
+SAMPLE_NOTE = {
+    "note_id": "n1",
+    "title": "Attention Is All You Need",
+    "path": "papers/attention.md",
+    "type": "paper",
+    "tags": ["ml", "transformers"],
+}
+
+
+@pytest.fixture()
+def note_client(fake_session):
+    """TestClient with only session override — /notes doesn't need embed."""
+    app.dependency_overrides[get_session] = lambda: fake_session
+    yield TestClient(app, raise_server_exceptions=False)
+    app.dependency_overrides.clear()
+
+
+class TestGetNoteEndpoint:
+    """Tests for GET /api/knowledge/notes/{note_id}."""
+
+    def test_happy_path_returns_note_with_content(self, tmp_path, fake_session):
+        """Existing note + vault file returns all fields plus content."""
+        vault_dir = tmp_path / "vault"
+        vault_dir.mkdir()
+        note_file = vault_dir / "papers" / "attention.md"
+        note_file.parent.mkdir(parents=True)
+        note_file.write_text("# Attention\n\nSelf-attention mechanism.")
+
+        app.dependency_overrides[get_session] = lambda: fake_session
+        old_val = os.environ.get(VAULT_ROOT_ENV)
+        os.environ[VAULT_ROOT_ENV] = str(vault_dir)
+        try:
+            c = TestClient(app, raise_server_exceptions=False)
+            with patch("knowledge.router.KnowledgeStore") as MockStore:
+                MockStore.return_value.get_note_by_id.return_value = SAMPLE_NOTE
+                r = c.get("/api/knowledge/notes/n1")
+        finally:
+            if old_val is None:
+                os.environ.pop(VAULT_ROOT_ENV, None)
+            else:
+                os.environ[VAULT_ROOT_ENV] = old_val
+            app.dependency_overrides.clear()
+
+        assert r.status_code == 200
+        body = r.json()
+        assert body["note_id"] == "n1"
+        assert body["title"] == "Attention Is All You Need"
+        assert body["path"] == "papers/attention.md"
+        assert body["type"] == "paper"
+        assert body["tags"] == ["ml", "transformers"]
+        assert body["content"] == "# Attention\n\nSelf-attention mechanism."
+
+    def test_missing_note_returns_404(self, note_client):
+        """get_note_by_id returns None -> 404 'note not found'."""
+        with patch("knowledge.router.KnowledgeStore") as MockStore:
+            MockStore.return_value.get_note_by_id.return_value = None
+            r = note_client.get("/api/knowledge/notes/nonexistent")
+
+        assert r.status_code == 404
+        body = r.json()
+        assert body.get("detail") == "note not found"
+
+    def test_missing_vault_file_returns_404(self, note_client):
+        """Note exists in DB but vault file missing on disk -> 404."""
+        with patch("knowledge.router.KnowledgeStore") as MockStore:
+            MockStore.return_value.get_note_by_id.return_value = {
+                **SAMPLE_NOTE,
+                "path": "nonexistent/missing.md",
+            }
+            r = note_client.get("/api/knowledge/notes/n1")
+
+        assert r.status_code == 404
+        body = r.json()
+        assert body.get("detail") == "vault file missing"
+
+    def test_path_traversal_returns_404(self, note_client):
+        """Path containing ../ is caught by is_relative_to guard -> 404."""
+        with patch("knowledge.router.KnowledgeStore") as MockStore:
+            MockStore.return_value.get_note_by_id.return_value = {
+                **SAMPLE_NOTE,
+                "path": "../../../etc/passwd",
+            }
+            r = note_client.get("/api/knowledge/notes/n1")
+
+        assert r.status_code == 404
+        body = r.json()
+        assert body.get("detail") == "vault file missing"

--- a/projects/monolith/knowledge/service.py
+++ b/projects/monolith/knowledge/service.py
@@ -34,7 +34,7 @@ async def clone_vault() -> None:
     Skips if VAULT_GIT_REMOTE is not set or if the vault already has a .git dir.
     Always writes a .git-ready sentinel so the obsidian sidecar can start.
     """
-    vault_root = Path(os.environ.get(_VAULT_ROOT_ENV, _DEFAULT_VAULT_ROOT))
+    vault_root = Path(os.environ.get(VAULT_ROOT_ENV, DEFAULT_VAULT_ROOT))
     try:
         remote = os.environ.get("VAULT_GIT_REMOTE", "")
         if not remote:
@@ -74,7 +74,7 @@ def _has_changes(vault_root: Path) -> bool:
 
 async def vault_backup_handler(session: Session) -> datetime | None:
     """Scheduler handler: commit and push vault changes to GitHub."""
-    vault_root = Path(os.environ.get(_VAULT_ROOT_ENV, _DEFAULT_VAULT_ROOT))
+    vault_root = Path(os.environ.get(VAULT_ROOT_ENV, DEFAULT_VAULT_ROOT))
     if not (vault_root / ".git").exists():
         logger.info("knowledge.vault-backup: no .git dir, skipping")
         return None

--- a/projects/monolith/knowledge/service.py
+++ b/projects/monolith/knowledge/service.py
@@ -15,8 +15,8 @@ from shared.embedding import EmbeddingClient
 
 logger = logging.getLogger(__name__)
 
-_VAULT_ROOT_ENV = "VAULT_ROOT"
-_DEFAULT_VAULT_ROOT = "/vault"
+VAULT_ROOT_ENV = "VAULT_ROOT"
+DEFAULT_VAULT_ROOT = "/vault"
 # 5-minute reconcile cycle. The companion _TTL_SECS=600 ensures at
 # most one missed run before alerting fires (the scheduler considers
 # a job stale after ttl_secs).
@@ -111,7 +111,7 @@ async def garden_handler(session: Session) -> datetime | None:
 
     from knowledge.gardener import Gardener
 
-    vault_root = Path(os.environ.get(_VAULT_ROOT_ENV, _DEFAULT_VAULT_ROOT))
+    vault_root = Path(os.environ.get(VAULT_ROOT_ENV, DEFAULT_VAULT_ROOT))
     try:
         max_files = int(os.environ.get("GARDENER_MAX_FILES_PER_RUN", "10"))
     except ValueError:
@@ -139,7 +139,7 @@ async def garden_handler(session: Session) -> datetime | None:
 
 async def reconcile_handler(session: Session) -> datetime | None:
     """Scheduler handler: run the knowledge vault reconciler."""
-    vault_root = Path(os.environ.get(_VAULT_ROOT_ENV, _DEFAULT_VAULT_ROOT))
+    vault_root = Path(os.environ.get(VAULT_ROOT_ENV, DEFAULT_VAULT_ROOT))
     reconciler = Reconciler(
         store=KnowledgeStore(session=session),
         embed_client=EmbeddingClient(),

--- a/projects/monolith/knowledge/store.py
+++ b/projects/monolith/knowledge/store.py
@@ -193,9 +193,8 @@ class KnowledgeStore:
         if type_filter is not None:
             notes_stmt = notes_stmt.where(Note.type == type_filter)
 
-        note_rows = self.session.execute(
-            notes_stmt
-        ).all()  # nosemgrep: generic-sql-fastapi
+        # nosemgrep: generic-sql-fastapi
+        note_rows = self.session.execute(notes_stmt).all()
         if not note_rows:
             return []
 
@@ -212,6 +211,7 @@ class KnowledgeStore:
             .order_by(Chunk.note_fk, chunk_distance)
             .distinct(Chunk.note_fk)
         )
+        # nosemgrep: generic-sql-fastapi
         chunk_rows = self.session.execute(chunks_stmt).all()
         best_chunk_by_note = {
             row.note_fk: (row.section_header, row.chunk_text) for row in chunk_rows

--- a/projects/monolith/knowledge/store.py
+++ b/projects/monolith/knowledge/store.py
@@ -232,6 +232,34 @@ class KnowledgeStore:
             )
         return results
 
+    def get_note_by_id(self, note_id: str) -> dict | None:
+        """Fetch lightweight note metadata by stable ``note_id``.
+
+        Returns ``None`` if no note matches. Used by the knowledge search
+        overlay's preview pane (ADR 003) to resolve a selected result to
+        its displayable metadata without re-running the vector query.
+        """
+        row = self.session.execute(
+            select(
+                Note.note_id,
+                Note.title,
+                Note.path,
+                Note.type,
+                Note.tags,
+            )
+            .where(Note.note_id == note_id)
+            .limit(1)
+        ).first()
+        if row is None:
+            return None
+        return {
+            "note_id": row.note_id,
+            "title": row.title,
+            "path": row.path,
+            "type": row.type,
+            "tags": list(row.tags or []),
+        }
+
     def delete_note(self, path: str) -> None:
         existing = self.session.execute(
             select(Note.id).where(Note.path == path)

--- a/projects/monolith/knowledge/store.py
+++ b/projects/monolith/knowledge/store.py
@@ -193,7 +193,9 @@ class KnowledgeStore:
         if type_filter is not None:
             notes_stmt = notes_stmt.where(Note.type == type_filter)
 
-        note_rows = self.session.execute(notes_stmt).all()
+        note_rows = self.session.execute(
+            notes_stmt
+        ).all()  # nosemgrep: generic-sql-fastapi
         if not note_rows:
             return []
 

--- a/projects/monolith/knowledge/store.py
+++ b/projects/monolith/knowledge/store.py
@@ -193,7 +193,6 @@ class KnowledgeStore:
         if type_filter is not None:
             notes_stmt = notes_stmt.where(Note.type == type_filter)
 
-        # nosemgrep: generic-sql-fastapi
         note_rows = self.session.execute(notes_stmt).all()
         if not note_rows:
             return []
@@ -211,7 +210,7 @@ class KnowledgeStore:
             .order_by(Chunk.note_fk, chunk_distance)
             .distinct(Chunk.note_fk)
         )
-        # nosemgrep: generic-sql-fastapi
+
         chunk_rows = self.session.execute(chunks_stmt).all()
         best_chunk_by_note = {
             row.note_fk: (row.section_header, row.chunk_text) for row in chunk_rows

--- a/projects/monolith/knowledge/store.py
+++ b/projects/monolith/knowledge/store.py
@@ -153,6 +153,85 @@ class KnowledgeStore:
             for row in rows
         ]
 
+    def search_notes_with_context(
+        self,
+        query_embedding: list[float],
+        limit: int = 20,
+        type_filter: str | None = None,
+    ) -> list[dict]:
+        """Semantic search returning type, tags, best chunk section + snippet.
+
+        Powers the knowledge search overlay (ADR 003). Runs two SQL
+        round-trips:
+
+        1. Top-N notes ranked by ``best_score = 1 - min(cosine_distance)``
+           across their chunks, with optional ``Note.type`` filter.
+        2. A single batched ``SELECT DISTINCT ON (note_fk)`` to pick the
+           best-matching chunk per top-N note — no N+1.
+
+        Results are stitched in Python into dicts with keys:
+        ``note_id, title, path, type, tags, score, section, snippet``.
+        """
+        distance = Chunk.embedding.cosine_distance(query_embedding)
+        best_score = (1 - func.min(distance)).label("score")
+
+        notes_stmt = (
+            select(
+                Note.id,
+                Note.note_id,
+                Note.title,
+                Note.path,
+                Note.type,
+                Note.tags,
+                best_score,
+            )
+            .join(Chunk, Chunk.note_fk == Note.id)
+            .group_by(Note.id)
+            .order_by(func.min(distance))
+            .limit(limit)
+        )
+        if type_filter is not None:
+            notes_stmt = notes_stmt.where(Note.type == type_filter)
+
+        note_rows = self.session.execute(notes_stmt).all()
+        if not note_rows:
+            return []
+
+        top_ids = [row.id for row in note_rows]
+
+        chunk_distance = Chunk.embedding.cosine_distance(query_embedding)
+        chunks_stmt = (
+            select(
+                Chunk.note_fk,
+                Chunk.section_header,
+                Chunk.chunk_text,
+            )
+            .where(Chunk.note_fk.in_(top_ids))
+            .order_by(Chunk.note_fk, chunk_distance)
+            .distinct(Chunk.note_fk)
+        )
+        chunk_rows = self.session.execute(chunks_stmt).all()
+        best_chunk_by_note = {
+            row.note_fk: (row.section_header, row.chunk_text) for row in chunk_rows
+        }
+
+        results: list[dict] = []
+        for row in note_rows:
+            section, chunk_text = best_chunk_by_note.get(row.id, ("", ""))
+            results.append(
+                {
+                    "note_id": row.note_id,
+                    "title": row.title,
+                    "path": row.path,
+                    "type": row.type,
+                    "tags": list(row.tags or []),
+                    "score": float(row.score),
+                    "section": section,
+                    "snippet": (chunk_text or "")[:240],
+                }
+            )
+        return results
+
     def delete_note(self, path: str) -> None:
         existing = self.session.execute(
             select(Note.id).where(Note.path == path)

--- a/projects/monolith/knowledge/store_test.py
+++ b/projects/monolith/knowledge/store_test.py
@@ -434,3 +434,25 @@ class TestSearchNotesWithContext:
     def test_empty_db_returns_empty_list(self):
         results = self.store.search_notes_with_context(query_embedding=[0.0] * 1024)
         assert results == []
+
+
+class TestGetNoteById:
+    def test_returns_note_metadata(self, store):
+        _upsert(
+            store,
+            note_id="n1",
+            path="folder/note.md",
+            title="My Note",
+            metadata=_meta(title="My Note", type="paper", tags=["x"]),
+        )
+        got = store.get_note_by_id("n1")
+        assert got == {
+            "note_id": "n1",
+            "title": "My Note",
+            "path": "folder/note.md",
+            "type": "paper",
+            "tags": ["x"],
+        }
+
+    def test_returns_none_when_missing(self, store):
+        assert store.get_note_by_id("nope") is None

--- a/projects/monolith/knowledge/store_test.py
+++ b/projects/monolith/knowledge/store_test.py
@@ -406,3 +406,31 @@ class TestSearchNotesWithContext:
         assert row["section"] == "## Ones"
         assert ones_text in row["snippet"]
         assert zeros_text not in row["snippet"]
+
+    def test_filters_by_type(self):
+        _upsert(
+            self.store,
+            note_id="n1",
+            path="a.md",
+            title="Paper",
+            metadata=_meta(title="Paper", type="paper"),
+            n_chunks=1,
+        )
+        _upsert(
+            self.store,
+            note_id="n2",
+            path="b.md",
+            title="Journal",
+            metadata=_meta(title="Journal", type="journal"),
+            n_chunks=1,
+        )
+        results = self.store.search_notes_with_context(
+            query_embedding=[0.0] * 1024, type_filter="paper"
+        )
+        assert len(results) == 1
+        assert results[0]["note_id"] == "n1"
+        assert results[0]["type"] == "paper"
+
+    def test_empty_db_returns_empty_list(self):
+        results = self.store.search_notes_with_context(query_embedding=[0.0] * 1024)
+        assert results == []

--- a/projects/monolith/knowledge/store_test.py
+++ b/projects/monolith/knowledge/store_test.py
@@ -316,3 +316,93 @@ class TestSearchNotes:
         # chunk_0 embedding is all 0.0s, chunk_1 is all 1.0s.
         # Query is all 0.0s, so chunk_0 is a perfect match (distance=0, score=1).
         assert results[0]["score"] == pytest.approx(1.0, abs=1e-6)
+
+
+class TestSearchNotesWithContext:
+    """search_notes_with_context requires pgvector cosine_distance (Postgres only)."""
+
+    @pytest.fixture(autouse=True)
+    def _setup(self, pg_session):
+        self.session = pg_session
+        self.store = KnowledgeStore(session=pg_session)
+
+    def test_returns_type_tags_snippet_and_section(self):
+        # Insert a note with a distinctive chunk under "## Architecture".
+        distinctive = "transformer replaces recurrence entirely"
+        self.store.upsert_note(
+            note_id="n1",
+            path="attention.md",
+            content_hash="h1",
+            title="Attention",
+            metadata=_meta(
+                title="Attention",
+                type="paper",
+                tags=["ml", "transformers"],
+            ),
+            chunks=[
+                {
+                    "index": 0,
+                    "section_header": "## Architecture",
+                    "text": distinctive,
+                }
+            ],
+            vectors=[[0.0] * 1024],
+            links=[],
+        )
+
+        results = self.store.search_notes_with_context(query_embedding=[0.0] * 1024)
+        assert len(results) == 1
+        row = results[0]
+        assert set(row.keys()) == {
+            "note_id",
+            "title",
+            "path",
+            "type",
+            "tags",
+            "score",
+            "section",
+            "snippet",
+        }
+        assert row["note_id"] == "n1"
+        assert row["title"] == "Attention"
+        assert row["path"] == "attention.md"
+        assert row["type"] == "paper"
+        assert row["tags"] == ["ml", "transformers"]
+        assert row["section"] == "## Architecture"
+        assert distinctive in row["snippet"]
+
+    def test_best_chunk_snippet_used_for_multi_chunk_note(self):
+        # One note with two chunks whose embeddings are far apart. The
+        # DISTINCT ON query must pick the chunk whose embedding is closest
+        # to the query — not the first one, not an arbitrary one.
+        zeros_text = "zeros chunk about attention heads"
+        ones_text = "ones chunk about positional encoding"
+        self.store.upsert_note(
+            note_id="n1",
+            path="multi.md",
+            content_hash="h1",
+            title="Multi",
+            metadata=_meta(title="Multi", type="paper", tags=["ml"]),
+            chunks=[
+                {
+                    "index": 0,
+                    "section_header": "## Zeros",
+                    "text": zeros_text,
+                },
+                {
+                    "index": 1,
+                    "section_header": "## Ones",
+                    "text": ones_text,
+                },
+            ],
+            vectors=[[0.0] * 1024, [1.0] * 1024],
+            links=[],
+        )
+
+        # Query matches the all-ones chunk exactly.
+        results = self.store.search_notes_with_context(query_embedding=[1.0] * 1024)
+        assert len(results) == 1
+        row = results[0]
+        assert row["section"] == "## Ones"
+        assert ones_text in row["snippet"]
+        assert zeros_text not in row["snippet"]


### PR DESCRIPTION
## Summary

- Add ⌘K-triggered full-viewport search overlay to the homepage, backed by two new FastAPI endpoints (`GET /api/knowledge/search`, `GET /api/knowledge/notes/{note_id}`) that expose the existing pgvector knowledge store
- Implement heading-only markdown renderer for note preview with section-level scroll targeting
- Add keyboard navigation (arrow keys, Enter to preview, Esc to close, ArrowLeft to go back)
- Type filter pills persist across open/close cycles
- Debounced semantic search with ghost results, zero-results state, and AbortController-based fetch lifecycle

## Backend changes

- **`knowledge/router.py`** (new): Two endpoints with DI seams for embedding client and session, path traversal guard on vault file reads
- **`knowledge/store.py`**: New `search_notes_with_context()` (top-N notes + batched best-chunk query, no N+1) and `get_note_by_id()` methods — additive, existing callers untouched
- **`knowledge/service.py`**: Promoted `VAULT_ROOT_ENV` and `DEFAULT_VAULT_ROOT` to public constants
- **`app/main.py`**: Router registration

## Frontend changes

- **`+page.svelte`**: Overlay shell, state management (Svelte 5 runes), debounced search with AbortController, type filter pills, results list with ARIA attributes, note preview with heading-only renderer and section scroll, ⌘K hint in capture footer

## Test plan

- [x] Unit tests: `knowledge/router_test.py` — 11 tests covering /search (happy path, empty/short query, type filter, limit, 503) and /notes (happy path, missing note, missing file, path traversal)
- [x] Unit tests: `knowledge/store_test.py` — 7 new tests for `search_notes_with_context` and `get_note_by_id`
- [x] E2E HTTP: 5 integration tests against real FastAPI + Postgres with deterministic embedding client
- [x] E2E Playwright: 5 browser tests — overlay open/close, capture preservation, search results, preview + back navigation, zero results

## References

- [ADR 003: Knowledge Search Overlay](docs/decisions/services/003-knowledge-search-overlay.md)
- [Design doc](docs/plans/2026-04-09-knowledge-search-overlay-design.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)