### PR TITLE
feat(knowledge): add vault git clone and daily backup

### DIFF
--- a/docs/plans/2026-04-09-vault-git-sync-design.md
+++ b/docs/plans/2026-04-09-vault-git-sync-design.md
@@ -1,0 +1,55 @@
+# Vault Git Sync Design
+
+**Date:** 2026-04-09
+**Status:** Approved
+
+## Problem
+
+The monolith's knowledge vault lives on an `emptyDir` volume. On pod restart, the Obsidian headless-sync sidecar re-downloads every file sequentially over its WebSocket protocol — this is slow and has been unreliable (last sync was 2 weeks ago as of writing).
+
+## Solution
+
+Add two git-based features to the monolith Python app:
+
+1. **Startup clone** — `git clone --depth=1` the vault repo before the scheduler starts. Replaces the 5-minute polling loop in `_wait_for_vault_sync()`.
+2. **Daily backup job** — A scheduler job that commits and pushes vault changes to GitHub once per day. One pod acquires the lock via `SKIP LOCKED`.
+
+Obsidian headless-sync stays as the live sync source of truth. Git is write-only (no pull) — purely a backup mechanism.
+
+## Architecture
+
+### Startup Flow
+
+```
+lifespan starts
+  → git clone --depth=1 $VAULT_GIT_REMOTE /vault
+  → obsidian headless-sync overwrites with any newer files
+  → scheduler starts (reconciler, gardener, vault-backup)
+```
+
+### Daily Backup Job
+
+Registered as `knowledge.vault-backup` alongside existing jobs. Handler:
+
+1. Check for uncommitted changes (`git status --porcelain`)
+2. If changes exist: `git add -A`, `git commit -m "sync: vault backup"`, `git push`
+3. If no changes: no-op
+
+### Credentials
+
+- `GITHUB_TOKEN` from the existing `obsidian` 1Password secret
+- Token embedded in clone URL at runtime: `https://x-access-token:{token}@github.com/...`
+- Git user config already set via `GIT_CONFIG_*` env vars on the backend container
+
+## File Changes
+
+- `knowledge/service.py` — add `vault_backup_handler()`, `clone_vault()`, register backup job
+- `app/main.py` — replace `_wait_for_vault_sync()` with `clone_vault()` call
+- `chart/templates/deployment.yaml` — add `VAULT_GIT_REMOTE` and `GITHUB_TOKEN` env vars to backend
+- `deploy/values.yaml` — add `gitRemote` under `knowledge`
+
+## Non-Goals
+
+- No `git pull` — Obsidian Sync is the source of truth for file content
+- No replacement of the obsidian sidecar — it handles live sync
+- No change to the knowledge reconciler or gardener

--- a/docs/plans/2026-04-09-vault-git-sync.md
+++ b/docs/plans/2026-04-09-vault-git-sync.md
@@ -1,0 +1,432 @@
+# Vault Git Sync Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Replace the slow `_wait_for_vault_sync()` polling loop with a fast `git clone`, and add a daily scheduled job that commits+pushes vault changes to GitHub as a backup.
+
+**Architecture:** The monolith Python app clones the vault repo on startup (pre-seeding the `emptyDir` volume), then the obsidian headless-sync sidecar handles live sync as before. A new scheduler job (`knowledge.vault-backup`) runs once per day, committing and pushing any changes to GitHub. Only one pod acquires the scheduler lock via `SKIP LOCKED`.
+
+**Tech Stack:** Python, subprocess (git), existing scheduler framework, Helm
+
+---
+
+### Task 1: Add `clone_vault()` and `vault_backup_handler()` to knowledge/service.py
+
+**Files:**
+
+- Modify: `projects/monolith/knowledge/service.py`
+- Test: `projects/monolith/knowledge/service_test.py`
+
+**Step 1: Write tests for `clone_vault()`**
+
+Add a new `TestCloneVault` class to `service_test.py` with these tests:
+
+```python
+class TestCloneVault:
+    @pytest.mark.asyncio
+    async def test_skips_when_git_remote_unset(self, monkeypatch, caplog):
+        """clone_vault returns immediately when VAULT_GIT_REMOTE is empty."""
+        monkeypatch.delenv("VAULT_GIT_REMOTE", raising=False)
+        with caplog.at_level(logging.INFO, logger="knowledge.service"):
+            await service.clone_vault()
+        assert any("VAULT_GIT_REMOTE not set" in r.message for r in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_skips_when_already_cloned(self, monkeypatch, tmp_path, caplog):
+        """clone_vault skips clone when .git already exists in vault root."""
+        monkeypatch.setenv("VAULT_GIT_REMOTE", "https://github.com/test/repo.git")
+        monkeypatch.setenv("GITHUB_TOKEN", "ghp_test")
+        monkeypatch.setenv("VAULT_ROOT", str(tmp_path))
+        (tmp_path / ".git").mkdir()
+        with caplog.at_level(logging.INFO, logger="knowledge.service"):
+            await service.clone_vault()
+        assert any("already initialised" in r.message for r in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_clones_repo(self, monkeypatch, tmp_path):
+        """clone_vault runs git clone with depth=1 and token-embedded URL."""
+        monkeypatch.setenv("VAULT_GIT_REMOTE", "https://github.com/test/repo.git")
+        monkeypatch.setenv("GITHUB_TOKEN", "ghp_test")
+        monkeypatch.setenv("VAULT_ROOT", str(tmp_path))
+        with patch("knowledge.service.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            await service.clone_vault()
+        mock_run.assert_called_once()
+        cmd = mock_run.call_args[0][0]
+        assert cmd[0] == "git"
+        assert "clone" in cmd
+        assert "--depth=1" in cmd
+        assert "x-access-token:ghp_test@github.com" in cmd[3]
+        assert str(tmp_path) in cmd
+
+    @pytest.mark.asyncio
+    async def test_clone_failure_logs_warning_and_continues(self, monkeypatch, tmp_path, caplog):
+        """clone_vault logs a warning but does not raise on clone failure."""
+        monkeypatch.setenv("VAULT_GIT_REMOTE", "https://github.com/test/repo.git")
+        monkeypatch.setenv("GITHUB_TOKEN", "ghp_test")
+        monkeypatch.setenv("VAULT_ROOT", str(tmp_path))
+        with patch("knowledge.service.subprocess.run", side_effect=subprocess.CalledProcessError(1, "git")):
+            with caplog.at_level(logging.WARNING, logger="knowledge.service"):
+                await service.clone_vault()
+        assert any("clone failed" in r.message.lower() for r in caplog.records)
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `bb remote test //projects/monolith:knowledge_service_test --config=ci`
+Expected: FAIL — `clone_vault` does not exist yet.
+
+**Step 3: Write `clone_vault()` implementation**
+
+Add to `knowledge/service.py`:
+
+```python
+import subprocess
+
+async def clone_vault() -> None:
+    """Clone the vault repo to pre-seed the emptyDir volume.
+
+    Skips if VAULT_GIT_REMOTE is not set or if the vault already has a .git dir.
+    Embeds GITHUB_TOKEN in the clone URL for auth.
+    """
+    remote = os.environ.get("VAULT_GIT_REMOTE", "")
+    if not remote:
+        logger.info("VAULT_GIT_REMOTE not set, skipping clone")
+        return
+
+    vault_root = Path(os.environ.get(_VAULT_ROOT_ENV, _DEFAULT_VAULT_ROOT))
+    if (vault_root / ".git").exists():
+        logger.info("Vault at %s already initialised, skipping clone", vault_root)
+        return
+
+    token = os.environ.get("GITHUB_TOKEN", "")
+    if token:
+        remote = remote.replace("https://", f"https://x-access-token:{token}@")
+
+    try:
+        subprocess.run(
+            ["git", "clone", "--depth=1", remote, str(vault_root)],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        logger.info("Vault cloned from git to %s", vault_root)
+    except subprocess.CalledProcessError as exc:
+        logger.warning("Vault clone failed, proceeding without pre-seed: %s", exc.stderr)
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `bb remote test //projects/monolith:knowledge_service_test --config=ci`
+Expected: PASS
+
+**Step 5: Write tests for `vault_backup_handler()`**
+
+Add a `TestVaultBackupHandler` class:
+
+```python
+class TestVaultBackupHandler:
+    @pytest.mark.asyncio
+    async def test_skips_when_no_changes(self, monkeypatch, tmp_path):
+        """vault_backup_handler does nothing when git status is clean."""
+        monkeypatch.setenv("VAULT_ROOT", str(tmp_path))
+        (tmp_path / ".git").mkdir()
+        with patch("knowledge.service.subprocess.run") as mock_run:
+            # git status --porcelain returns empty
+            mock_run.return_value = MagicMock(stdout="", returncode=0)
+            result = await service.vault_backup_handler(MagicMock())
+        assert result is None
+        # Only git status was called, no commit/push
+        assert mock_run.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_commits_and_pushes_when_changes_exist(self, monkeypatch, tmp_path):
+        """vault_backup_handler commits and pushes when there are uncommitted changes."""
+        monkeypatch.setenv("VAULT_ROOT", str(tmp_path))
+        (tmp_path / ".git").mkdir()
+        calls = []
+        def fake_run(cmd, **kwargs):
+            calls.append(cmd)
+            if "status" in cmd:
+                return MagicMock(stdout=" M file.md\n", returncode=0)
+            return MagicMock(returncode=0)
+        with patch("knowledge.service.subprocess.run", side_effect=fake_run):
+            result = await service.vault_backup_handler(MagicMock())
+        assert result is None
+        cmds = [" ".join(c) for c in calls]
+        assert any("git add -A" in c for c in cmds)
+        assert any("git commit" in c for c in cmds)
+        assert any("git push" in c for c in cmds)
+
+    @pytest.mark.asyncio
+    async def test_skips_when_no_git_dir(self, monkeypatch, tmp_path):
+        """vault_backup_handler skips when vault has no .git directory."""
+        monkeypatch.setenv("VAULT_ROOT", str(tmp_path))
+        # No .git dir
+        result = await service.vault_backup_handler(MagicMock())
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_push_failure_logs_warning(self, monkeypatch, tmp_path, caplog):
+        """vault_backup_handler logs a warning when push fails."""
+        monkeypatch.setenv("VAULT_ROOT", str(tmp_path))
+        (tmp_path / ".git").mkdir()
+        call_count = [0]
+        def fake_run(cmd, **kwargs):
+            call_count[0] += 1
+            if "status" in cmd:
+                return MagicMock(stdout=" M file.md\n", returncode=0)
+            if "push" in cmd:
+                raise subprocess.CalledProcessError(1, "git push", stderr="rejected")
+            return MagicMock(returncode=0)
+        with patch("knowledge.service.subprocess.run", side_effect=fake_run):
+            with caplog.at_level(logging.WARNING, logger="knowledge.service"):
+                await service.vault_backup_handler(MagicMock())
+        assert any("push failed" in r.message.lower() for r in caplog.records)
+```
+
+**Step 6: Run tests to verify they fail**
+
+Run: `bb remote test //projects/monolith:knowledge_service_test --config=ci`
+Expected: FAIL — `vault_backup_handler` does not exist yet.
+
+**Step 7: Write `vault_backup_handler()` implementation**
+
+Add to `knowledge/service.py`:
+
+```python
+_BACKUP_INTERVAL_SECS = 86400  # 24 hours
+_BACKUP_TTL_SECS = 3600  # 1 hour timeout
+
+
+def _git_in_vault(*args: str) -> subprocess.CompletedProcess:
+    vault_root = Path(os.environ.get(_VAULT_ROOT_ENV, _DEFAULT_VAULT_ROOT))
+    return subprocess.run(
+        ["git", *args],
+        cwd=vault_root,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+
+async def vault_backup_handler(session: Session) -> datetime | None:
+    """Scheduler handler: commit and push vault changes to GitHub."""
+    vault_root = Path(os.environ.get(_VAULT_ROOT_ENV, _DEFAULT_VAULT_ROOT))
+    if not (vault_root / ".git").exists():
+        logger.info("knowledge.vault-backup: no .git dir, skipping")
+        return None
+
+    status = subprocess.run(
+        ["git", "status", "--porcelain"],
+        cwd=vault_root,
+        capture_output=True,
+        text=True,
+    )
+    if not status.stdout.strip():
+        logger.info("knowledge.vault-backup: no changes to commit")
+        return None
+
+    try:
+        _git_in_vault("add", "-A")
+        _git_in_vault("commit", "-m", "sync: vault backup")
+        _git_in_vault("push")
+        logger.info("knowledge.vault-backup: committed and pushed")
+    except subprocess.CalledProcessError as exc:
+        logger.warning("knowledge.vault-backup: push failed: %s", exc.stderr)
+    return None
+```
+
+**Step 8: Register the backup job in `on_startup()`**
+
+Add to the end of `on_startup()`:
+
+```python
+    register_job(
+        session,
+        name="knowledge.vault-backup",
+        interval_secs=_BACKUP_INTERVAL_SECS,
+        handler=vault_backup_handler,
+        ttl_secs=_BACKUP_TTL_SECS,
+    )
+```
+
+**Step 9: Update `TestOnStartup` tests**
+
+Update `test_registers_garden_and_reconcile_jobs` to also assert `"knowledge.vault-backup" in names`.
+
+**Step 10: Run all tests**
+
+Run: `bb remote test //projects/monolith:knowledge_service_test --config=ci`
+Expected: PASS
+
+**Step 11: Commit**
+
+```bash
+git add projects/monolith/knowledge/service.py projects/monolith/knowledge/service_test.py
+git commit -m "feat(knowledge): add vault git clone and daily backup job"
+```
+
+---
+
+### Task 2: Replace `_wait_for_vault_sync()` with `clone_vault()` in app/main.py
+
+**Files:**
+
+- Modify: `projects/monolith/app/main.py`
+- Modify: `projects/monolith/app/main_vault_sync_test.py`
+
+**Step 1: Update `main.py`**
+
+Replace the `_wait_for_vault_sync()` function body and its call site in the lifespan:
+
+```python
+# Remove the _wait_for_vault_sync() function entirely.
+# In lifespan(), replace:
+#     await _wait_for_vault_sync()
+# with:
+    from knowledge.service import clone_vault
+    await clone_vault()
+```
+
+**Step 2: Rewrite `main_vault_sync_test.py`**
+
+Replace all existing tests with tests for the new clone_vault call in lifespan. The clone_vault function itself is tested in service_test.py — here we just verify the lifespan calls it:
+
+```python
+"""Tests that lifespan calls clone_vault on startup."""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+os.environ.pop("STATIC_DIR", None)
+
+
+@pytest.mark.asyncio
+async def test_lifespan_calls_clone_vault():
+    """Lifespan calls clone_vault() before starting the scheduler."""
+    mock_clone = AsyncMock()
+    with (
+        patch("knowledge.service.clone_vault", mock_clone),
+        patch("app.main._wait_for_sidecar", new_callable=AsyncMock),
+        patch("shared.scheduler.run_scheduler_loop", new_callable=AsyncMock),
+        patch("app.db.get_engine"),
+        patch("home.service.on_startup"),
+        patch("knowledge.service.on_startup"),
+        patch("shared.service.on_startup"),
+    ):
+        from app.main import lifespan, app
+        async with lifespan(app):
+            pass
+    mock_clone.assert_awaited_once()
+```
+
+**Step 3: Run tests**
+
+Run: `bb remote test //projects/monolith:main_vault_sync_test --config=ci`
+Expected: PASS
+
+**Step 4: Commit**
+
+```bash
+git add projects/monolith/app/main.py projects/monolith/app/main_vault_sync_test.py
+git commit -m "refactor(monolith): replace vault sync polling with git clone"
+```
+
+---
+
+### Task 3: Add Helm values and env vars for vault git sync
+
+**Files:**
+
+- Modify: `projects/monolith/chart/values.yaml`
+- Modify: `projects/monolith/chart/templates/deployment.yaml`
+- Modify: `projects/monolith/deploy/values.yaml`
+
+**Step 1: Add `gitRemote` to chart defaults**
+
+In `projects/monolith/chart/values.yaml`, add under `knowledge`:
+
+```yaml
+knowledge:
+  enabled: false
+  gitRemote: ""
+  headlessSync:
+    # ... existing
+```
+
+**Step 2: Add env vars to deployment template**
+
+In `projects/monolith/chart/templates/deployment.yaml`, add inside the backend container's `env:` block, within the `{{- if .Values.knowledge.enabled }}` guard (after the existing `VAULT_ROOT` area or alongside other knowledge env vars). Since `VAULT_ROOT` is currently set implicitly via the mount path, we need to add both `VAULT_GIT_REMOTE` and `VAULT_ROOT`:
+
+```yaml
+            {{- if .Values.knowledge.enabled }}
+            - name: VAULT_ROOT
+              value: {{ .Values.knowledge.vault.mountPath }}
+            {{- if .Values.knowledge.gitRemote }}
+            - name: VAULT_GIT_REMOTE
+              value: {{ .Values.knowledge.gitRemote | quote }}
+            {{- end }}
+            {{- end }}
+```
+
+Note: `GITHUB_TOKEN` is already set on the backend container from the `chat.changelog` section.
+
+**Step 3: Set deploy values**
+
+In `projects/monolith/deploy/values.yaml`, add under `knowledge`:
+
+```yaml
+knowledge:
+  enabled: true
+  gitRemote: "https://github.com/jomcgi/obsidian-vault.git"
+  headlessSync:
+    vaultName: "jomcgi"
+```
+
+**Step 4: Verify Helm renders correctly**
+
+Run: `helm template monolith projects/monolith/chart/ -f projects/monolith/deploy/values.yaml | grep -A2 VAULT_GIT_REMOTE`
+Expected: Shows the env var with the correct value.
+
+**Step 5: Commit**
+
+```bash
+git add projects/monolith/chart/values.yaml projects/monolith/chart/templates/deployment.yaml projects/monolith/deploy/values.yaml
+git commit -m "feat(monolith): add vault git sync helm configuration"
+```
+
+---
+
+### Task 4: Run full test suite and bump chart version
+
+**Step 1: Run all monolith tests**
+
+Run: `bb remote test //projects/monolith/... --config=ci`
+Expected: PASS
+
+**Step 2: Bump chart version**
+
+Bump the patch version in `projects/monolith/chart/Chart.yaml` and update `targetRevision` in `projects/monolith/deploy/application.yaml` to match.
+
+**Step 3: Run format**
+
+Run: `format`
+
+**Step 4: Commit**
+
+```bash
+git add projects/monolith/chart/Chart.yaml projects/monolith/deploy/application.yaml
+git commit -m "chore(monolith): bump chart version to <new-version>"
+```
+
+**Step 5: Push and create PR**
+
+```bash
+git push -u origin feat/vault-git-sync
+gh pr create --title "feat(knowledge): add vault git clone and daily backup" --body "..."
+```

--- a/projects/monolith/app/main.py
+++ b/projects/monolith/app/main.py
@@ -39,31 +39,6 @@ async def _wait_for_sidecar() -> None:
             await asyncio.sleep(2)
 
 
-async def _wait_for_vault_sync() -> None:
-    """Block until the Obsidian vault volume contains at least one markdown file.
-
-    The vault is an emptyDir populated asynchronously by the headless-sync
-    sidecar. The sidecar's /tmp/ready signal is in its own container filesystem
-    and cannot be read here; instead we poll the shared volume directly.
-
-    Returns immediately if VAULT_ROOT does not exist (knowledge not configured).
-    Times out after 5 minutes and proceeds with a warning so a sync failure
-    does not permanently stall the app.
-    """
-    vault_root = Path(os.environ.get("VAULT_ROOT", "/vault"))
-    if not vault_root.exists():
-        return
-    logger.info("Waiting for Obsidian vault sync at %s", vault_root)
-    for _ in range(60):  # 60 × 5 s = 5-minute cap
-        if any(vault_root.rglob("*.md")):
-            logger.info("Vault sync ready")
-            return
-        await asyncio.sleep(5)
-    logger.warning(
-        "Vault sync wait timed out after 5 minutes; proceeding with empty vault"
-    )
-
-
 def _log_task_exception(task: "asyncio.Task[object]") -> None:
     """Log unhandled exceptions from background tasks instead of silently dropping them."""
     if not task.cancelled() and task.exception():
@@ -114,9 +89,11 @@ async def lifespan(app: FastAPI):
         bot_task.add_done_callback(_log_task_exception)
         logger.info("Discord bot starting")
 
-    # Wait for Obsidian vault sync before starting the scheduler so the
-    # reconciler never sees an empty vault and prunes the DB on pod restart.
-    await _wait_for_vault_sync()
+    # Pre-seed the vault with a fast git clone so the reconciler never sees
+    # an empty vault and prunes the DB on pod restart.
+    from knowledge.service import clone_vault
+
+    await clone_vault()
 
     # Start the shared scheduler loop (replaces 4 separate asyncio tasks)
     scheduler_task = asyncio.create_task(run_scheduler_loop())

--- a/projects/monolith/app/main_vault_sync_test.py
+++ b/projects/monolith/app/main_vault_sync_test.py
@@ -1,247 +1,30 @@
-"""Tests for _wait_for_vault_sync() in app.main.
-
-Covers:
-- Returns immediately when vault_root does not exist
-- Returns after logging 'ready' when .md files are present on first check
-- Polls until .md files appear after a few iterations, then returns
-- Times out after 60 iterations, logs a warning, and returns
-"""
+"""Tests that lifespan calls clone_vault on startup."""
 
 from __future__ import annotations
 
 import os
-import tempfile
-from pathlib import Path
-from unittest.mock import AsyncMock, patch, call
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
-# Ensure no valid static directory is set (mirrors other main_* test files)
 os.environ.pop("STATIC_DIR", None)
 
-from app.main import _wait_for_vault_sync  # noqa: E402
-
-
-# ---------------------------------------------------------------------------
-# (1) Returns immediately when vault_root does not exist
-# ---------------------------------------------------------------------------
-
 
 @pytest.mark.asyncio
-async def test_wait_for_vault_sync_returns_immediately_when_root_missing():
-    """_wait_for_vault_sync returns at once when VAULT_ROOT path does not exist."""
-    with patch.dict(os.environ, {"VAULT_ROOT": "/nonexistent/vault/path/xyz123"}):
-        sleep_mock = AsyncMock()
-        with patch("asyncio.sleep", sleep_mock):
-            await _wait_for_vault_sync()
+async def test_lifespan_calls_clone_vault():
+    """Lifespan calls clone_vault() before starting the scheduler."""
+    mock_clone = AsyncMock()
+    with (
+        patch("knowledge.service.clone_vault", mock_clone),
+        patch("app.main._wait_for_sidecar", new_callable=AsyncMock),
+        patch("shared.scheduler.run_scheduler_loop", new_callable=AsyncMock),
+        patch("app.db.get_engine"),
+        patch("home.service.on_startup"),
+        patch("knowledge.service.on_startup"),
+        patch("shared.service.on_startup"),
+    ):
+        from app.main import lifespan, app
 
-    sleep_mock.assert_not_called()
-
-
-@pytest.mark.asyncio
-async def test_wait_for_vault_sync_never_logs_ready_when_root_missing():
-    """No 'Vault sync ready' log when vault_root does not exist."""
-    with patch.dict(os.environ, {"VAULT_ROOT": "/nonexistent/vault/path/xyz123"}):
-        with patch("app.main.logger") as mock_logger:
-            await _wait_for_vault_sync()
-
-    info_msgs = [str(c) for c in mock_logger.info.call_args_list]
-    assert not any("ready" in m.lower() for m in info_msgs)
-    mock_logger.warning.assert_not_called()
-
-
-# ---------------------------------------------------------------------------
-# (2) Returns after logging 'ready' when .md files exist on first check
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.asyncio
-async def test_wait_for_vault_sync_returns_on_first_check_with_md_file():
-    """Returns immediately after first rglob finds a .md file without sleeping."""
-    with tempfile.TemporaryDirectory() as vault_dir:
-        # Create a markdown file in the vault
-        (Path(vault_dir) / "note.md").write_text("# Note")
-
-        sleep_mock = AsyncMock()
-        with patch.dict(os.environ, {"VAULT_ROOT": vault_dir}):
-            with patch("asyncio.sleep", sleep_mock):
-                await _wait_for_vault_sync()
-
-    sleep_mock.assert_not_called()
-
-
-@pytest.mark.asyncio
-async def test_wait_for_vault_sync_logs_ready_when_md_found():
-    """Logs 'Vault sync ready' when .md files are found."""
-    with tempfile.TemporaryDirectory() as vault_dir:
-        (Path(vault_dir) / "note.md").write_text("# Note")
-
-        with patch.dict(os.environ, {"VAULT_ROOT": vault_dir}):
-            with patch("app.main.logger") as mock_logger:
-                with patch("asyncio.sleep", new_callable=AsyncMock):
-                    await _wait_for_vault_sync()
-
-    info_msgs = [str(c) for c in mock_logger.info.call_args_list]
-    assert any("Vault sync ready" in m for m in info_msgs)
-
-
-@pytest.mark.asyncio
-async def test_wait_for_vault_sync_logs_waiting_message_before_polling():
-    """Logs an informational 'Waiting' message at startup."""
-    with tempfile.TemporaryDirectory() as vault_dir:
-        (Path(vault_dir) / "note.md").write_text("# Note")
-
-        with patch.dict(os.environ, {"VAULT_ROOT": vault_dir}):
-            with patch("app.main.logger") as mock_logger:
-                with patch("asyncio.sleep", new_callable=AsyncMock):
-                    await _wait_for_vault_sync()
-
-    info_msgs = [str(c) for c in mock_logger.info.call_args_list]
-    assert any("Waiting for Obsidian vault sync" in m for m in info_msgs)
-
-
-@pytest.mark.asyncio
-async def test_wait_for_vault_sync_finds_nested_md_file():
-    """Finds .md files in subdirectories (rglob, not just top-level)."""
-    with tempfile.TemporaryDirectory() as vault_dir:
-        subdir = Path(vault_dir) / "subfolder" / "nested"
-        subdir.mkdir(parents=True)
-        (subdir / "deep.md").write_text("# Deep note")
-
-        sleep_mock = AsyncMock()
-        with patch.dict(os.environ, {"VAULT_ROOT": vault_dir}):
-            with patch("asyncio.sleep", sleep_mock):
-                await _wait_for_vault_sync()
-
-    sleep_mock.assert_not_called()
-
-
-@pytest.mark.asyncio
-async def test_wait_for_vault_sync_ignores_non_md_files():
-    """Does not treat non-.md files (e.g. .txt, .json) as vault-ready signal."""
-    with tempfile.TemporaryDirectory() as vault_dir:
-        (Path(vault_dir) / "config.json").write_text("{}")
-        (Path(vault_dir) / "readme.txt").write_text("readme")
-
-        sleep_mock = AsyncMock()
-
-        # Create an .md file after 2 sleeps — verifies the function kept polling
-        async def side_effect_sleep(seconds):  # noqa: ARG001
-            if sleep_mock.call_count == 2:
-                (Path(vault_dir) / "note.md").write_text("# Note")
-
-        sleep_mock.side_effect = side_effect_sleep
-        with patch.dict(os.environ, {"VAULT_ROOT": vault_dir}):
-            with patch("asyncio.sleep", sleep_mock):
-                await _wait_for_vault_sync()
-
-    # Slept exactly 2 times (found on 3rd iteration)
-    assert sleep_mock.call_count == 2
-
-
-# ---------------------------------------------------------------------------
-# (3) Polls until .md files appear after a few iterations
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.asyncio
-async def test_wait_for_vault_sync_polls_until_md_file_appears():
-    """Sleeps between iterations until .md file is created in vault."""
-    with tempfile.TemporaryDirectory() as vault_dir:
-        sleep_count = [0]
-
-        async def side_effect_sleep(seconds):  # noqa: ARG001
-            sleep_count[0] += 1
-            if sleep_count[0] == 3:
-                # Create the markdown file after 3 sleeps
-                (Path(vault_dir) / "note.md").write_text("# Note")
-
-        with patch.dict(os.environ, {"VAULT_ROOT": vault_dir}):
-            with patch("asyncio.sleep", side_effect=side_effect_sleep):
-                await _wait_for_vault_sync()
-
-    assert sleep_count[0] == 3
-
-
-@pytest.mark.asyncio
-async def test_wait_for_vault_sync_sleeps_5_seconds_per_iteration():
-    """Each iteration sleeps exactly 5 seconds."""
-    with tempfile.TemporaryDirectory() as vault_dir:
-        sleep_args = []
-
-        async def capturing_sleep(seconds):
-            sleep_args.append(seconds)
-            if len(sleep_args) == 2:
-                (Path(vault_dir) / "note.md").write_text("# Note")
-
-        with patch.dict(os.environ, {"VAULT_ROOT": vault_dir}):
-            with patch("asyncio.sleep", side_effect=capturing_sleep):
-                await _wait_for_vault_sync()
-
-    assert all(s == 5 for s in sleep_args)
-
-
-# ---------------------------------------------------------------------------
-# (4) Timeout after 60 iterations — logs warning and returns
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.asyncio
-async def test_wait_for_vault_sync_times_out_after_60_iterations():
-    """After 60 iterations without finding .md files, returns without blocking."""
-    with tempfile.TemporaryDirectory() as vault_dir:
-        sleep_mock = AsyncMock()
-
-        with patch.dict(os.environ, {"VAULT_ROOT": vault_dir}):
-            with patch("asyncio.sleep", sleep_mock):
-                await _wait_for_vault_sync()
-
-    # 60 iterations × sleep(5) each
-    assert sleep_mock.call_count == 60
-
-
-@pytest.mark.asyncio
-async def test_wait_for_vault_sync_logs_warning_on_timeout():
-    """Logs a warning message when the 5-minute timeout is reached."""
-    with tempfile.TemporaryDirectory() as vault_dir:
-        with patch.dict(os.environ, {"VAULT_ROOT": vault_dir}):
-            with patch("asyncio.sleep", new_callable=AsyncMock):
-                with patch("app.main.logger") as mock_logger:
-                    await _wait_for_vault_sync()
-
-    assert mock_logger.warning.called
-    warning_msgs = [str(c) for c in mock_logger.warning.call_args_list]
-    assert any("timed out" in m.lower() for m in warning_msgs)
-
-
-@pytest.mark.asyncio
-async def test_wait_for_vault_sync_sleeps_exactly_5s_in_timeout_path():
-    """Each of the 60 timeout-path iterations sleeps exactly 5 seconds."""
-    with tempfile.TemporaryDirectory() as vault_dir:
-        sleep_mock = AsyncMock()
-
-        with patch.dict(os.environ, {"VAULT_ROOT": vault_dir}):
-            with patch("asyncio.sleep", sleep_mock):
-                await _wait_for_vault_sync()
-
-    for c in sleep_mock.call_args_list:
-        assert c == call(5)
-
-
-# ---------------------------------------------------------------------------
-# Default VAULT_ROOT value
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.asyncio
-async def test_wait_for_vault_sync_uses_default_vault_root_when_env_unset():
-    """Uses '/vault' as default VAULT_ROOT when env var is not set."""
-    env_without_vault = {k: v for k, v in os.environ.items() if k != "VAULT_ROOT"}
-
-    with patch.dict(os.environ, env_without_vault, clear=True):
-        sleep_mock = AsyncMock()
-        with patch("asyncio.sleep", sleep_mock):
-            # /vault does not exist in test environment — returns immediately
-            await _wait_for_vault_sync()
-
-    sleep_mock.assert_not_called()
+        async with lifespan(app):
+            pass
+    mock_clone.assert_awaited_once()

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.28.6
+version: 0.29.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/templates/deployment.yaml
+++ b/projects/monolith/chart/templates/deployment.yaml
@@ -82,6 +82,14 @@ spec:
                   name: {{ include "monolith.fullname" . }}-gardener
                   key: CLAUDE_AUTH_TOKEN
             {{- end }}
+            {{- if .Values.knowledge.enabled }}
+            - name: VAULT_ROOT
+              value: {{ .Values.knowledge.vault.mountPath }}
+            {{- if .Values.knowledge.gitRemote }}
+            - name: VAULT_GIT_REMOTE
+              value: {{ .Values.knowledge.gitRemote | quote }}
+            {{- end }}
+            {{- end }}
           livenessProbe:
             httpGet:
               path: /healthz

--- a/projects/monolith/chart/values.yaml
+++ b/projects/monolith/chart/values.yaml
@@ -54,6 +54,7 @@ onepassword:
 
 knowledge:
   enabled: false
+  gitRemote: ""
   headlessSync:
     image:
       repository: ghcr.io/jomcgi/homelab/projects/monolith/obsidian-image

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.28.6
+      targetRevision: 0.29.0
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/deploy/values.yaml
+++ b/projects/monolith/deploy/values.yaml
@@ -62,6 +62,7 @@ cfIngress:
 
 knowledge:
   enabled: true
+  gitRemote: "https://github.com/jomcgi/obsidian-vault.git"
   headlessSync:
     vaultName: "jomcgi"
   onepassword:

--- a/projects/monolith/knowledge/service.py
+++ b/projects/monolith/knowledge/service.py
@@ -2,6 +2,7 @@
 
 import logging
 import os
+import subprocess
 from datetime import datetime
 from pathlib import Path
 
@@ -20,6 +21,80 @@ _DEFAULT_VAULT_ROOT = "/vault"
 # a job stale after ttl_secs).
 _INTERVAL_SECS = 300
 _TTL_SECS = 600
+_BACKUP_INTERVAL_SECS = 86400  # 24 hours
+_BACKUP_TTL_SECS = 3600  # 1 hour timeout
+
+
+async def clone_vault() -> None:
+    """Clone the vault repo to pre-seed the emptyDir volume.
+
+    Skips if VAULT_GIT_REMOTE is not set or if the vault already has a .git dir.
+    Embeds GITHUB_TOKEN in the clone URL for auth.
+    """
+    remote = os.environ.get("VAULT_GIT_REMOTE", "")
+    if not remote:
+        logger.info("VAULT_GIT_REMOTE not set, skipping clone")
+        return
+
+    vault_root = Path(os.environ.get(_VAULT_ROOT_ENV, _DEFAULT_VAULT_ROOT))
+    if (vault_root / ".git").exists():
+        logger.info("Vault at %s already initialised, skipping clone", vault_root)
+        return
+
+    token = os.environ.get("GITHUB_TOKEN", "")
+    if token:
+        remote = remote.replace("https://", f"https://x-access-token:{token}@")
+
+    try:
+        subprocess.run(
+            ["git", "clone", "--depth=1", remote, str(vault_root)],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        logger.info("Vault cloned from git to %s", vault_root)
+    except subprocess.CalledProcessError as exc:
+        logger.warning(
+            "Vault clone failed, proceeding without pre-seed: %s", exc.stderr
+        )
+
+
+def _git_in_vault(*args: str) -> subprocess.CompletedProcess:
+    vault_root = Path(os.environ.get(_VAULT_ROOT_ENV, _DEFAULT_VAULT_ROOT))
+    return subprocess.run(
+        ["git", *args],
+        cwd=vault_root,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+
+async def vault_backup_handler(session: Session) -> datetime | None:
+    """Scheduler handler: commit and push vault changes to GitHub."""
+    vault_root = Path(os.environ.get(_VAULT_ROOT_ENV, _DEFAULT_VAULT_ROOT))
+    if not (vault_root / ".git").exists():
+        logger.info("knowledge.vault-backup: no .git dir, skipping")
+        return None
+
+    status = subprocess.run(
+        ["git", "status", "--porcelain"],
+        cwd=vault_root,
+        capture_output=True,
+        text=True,
+    )
+    if not status.stdout.strip():
+        logger.info("knowledge.vault-backup: no changes to commit")
+        return None
+
+    try:
+        _git_in_vault("add", "-A")
+        _git_in_vault("commit", "-m", "sync: vault backup")
+        _git_in_vault("push")
+        logger.info("knowledge.vault-backup: committed and pushed")
+    except subprocess.CalledProcessError as exc:
+        logger.warning("knowledge.vault-backup: push failed: %s", exc.stderr)
+    return None
 
 
 async def garden_handler(session: Session) -> datetime | None:
@@ -102,4 +177,11 @@ def on_startup(session: Session) -> None:
         interval_secs=_INTERVAL_SECS,
         handler=reconcile_handler,
         ttl_secs=_TTL_SECS,
+    )
+    register_job(
+        session,
+        name="knowledge.vault-backup",
+        interval_secs=_BACKUP_INTERVAL_SECS,
+        handler=vault_backup_handler,
+        ttl_secs=_BACKUP_TTL_SECS,
     )

--- a/projects/monolith/knowledge/service_test.py
+++ b/projects/monolith/knowledge/service_test.py
@@ -1,6 +1,7 @@
 """Tests for knowledge service startup registration and handlers."""
 
 import logging
+import subprocess
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -14,13 +15,14 @@ from knowledge.service import garden_handler, on_startup
 
 class TestOnStartup:
     def test_registers_garden_and_reconcile_jobs(self):
-        """on_startup registers both knowledge.garden and knowledge.reconcile."""
+        """on_startup registers garden, reconcile, and vault-backup jobs."""
         session = MagicMock()
         with patch("shared.scheduler.register_job") as mock_register:
             on_startup(session)
         names = [call.kwargs["name"] for call in mock_register.call_args_list]
         assert "knowledge.garden" in names
         assert "knowledge.reconcile" in names
+        assert "knowledge.vault-backup" in names
 
     def test_garden_registered_before_reconcile(self):
         """Documentary convention: knowledge.garden is registered first.
@@ -254,3 +256,121 @@ class TestGardenHandler:
         ) as mock_gardener:
             await garden_handler(session)
         assert mock_gardener.call_args.kwargs["max_files_per_run"] == 10
+
+
+class TestCloneVault:
+    @pytest.mark.asyncio
+    async def test_skips_when_git_remote_unset(self, monkeypatch, caplog):
+        """clone_vault returns immediately when VAULT_GIT_REMOTE is empty."""
+        monkeypatch.delenv("VAULT_GIT_REMOTE", raising=False)
+        with caplog.at_level(logging.INFO, logger="knowledge.service"):
+            await service.clone_vault()
+        assert any("VAULT_GIT_REMOTE not set" in r.message for r in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_skips_when_already_cloned(self, monkeypatch, tmp_path, caplog):
+        """clone_vault skips clone when .git already exists in vault root."""
+        monkeypatch.setenv("VAULT_GIT_REMOTE", "https://github.com/test/repo.git")
+        monkeypatch.setenv("GITHUB_TOKEN", "ghp_test")
+        monkeypatch.setenv("VAULT_ROOT", str(tmp_path))
+        (tmp_path / ".git").mkdir()
+        with caplog.at_level(logging.INFO, logger="knowledge.service"):
+            await service.clone_vault()
+        assert any("already initialised" in r.message for r in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_clones_repo(self, monkeypatch, tmp_path):
+        """clone_vault runs git clone with depth=1 and token-embedded URL."""
+        monkeypatch.setenv("VAULT_GIT_REMOTE", "https://github.com/test/repo.git")
+        monkeypatch.setenv("GITHUB_TOKEN", "ghp_test")
+        monkeypatch.setenv("VAULT_ROOT", str(tmp_path))
+        with patch("knowledge.service.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            await service.clone_vault()
+        mock_run.assert_called_once()
+        cmd = mock_run.call_args[0][0]
+        assert cmd[0] == "git"
+        assert "clone" in cmd
+        assert "--depth=1" in cmd
+        assert "x-access-token:ghp_test@github.com" in cmd[3]
+        assert str(tmp_path) in cmd
+
+    @pytest.mark.asyncio
+    async def test_clone_failure_logs_warning_and_continues(
+        self, monkeypatch, tmp_path, caplog
+    ):
+        """clone_vault logs a warning but does not raise on clone failure."""
+        monkeypatch.setenv("VAULT_GIT_REMOTE", "https://github.com/test/repo.git")
+        monkeypatch.setenv("GITHUB_TOKEN", "ghp_test")
+        monkeypatch.setenv("VAULT_ROOT", str(tmp_path))
+        with patch(
+            "knowledge.service.subprocess.run",
+            side_effect=subprocess.CalledProcessError(1, "git"),
+        ):
+            with caplog.at_level(logging.WARNING, logger="knowledge.service"):
+                await service.clone_vault()
+        assert any("clone failed" in r.message.lower() for r in caplog.records)
+
+
+class TestVaultBackupHandler:
+    @pytest.mark.asyncio
+    async def test_skips_when_no_changes(self, monkeypatch, tmp_path):
+        """vault_backup_handler does nothing when git status is clean."""
+        monkeypatch.setenv("VAULT_ROOT", str(tmp_path))
+        (tmp_path / ".git").mkdir()
+        with patch("knowledge.service.subprocess.run") as mock_run:
+            # git status --porcelain returns empty
+            mock_run.return_value = MagicMock(stdout="", returncode=0)
+            result = await service.vault_backup_handler(MagicMock())
+        assert result is None
+        # Only git status was called, no commit/push
+        assert mock_run.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_commits_and_pushes_when_changes_exist(self, monkeypatch, tmp_path):
+        """vault_backup_handler commits and pushes when there are uncommitted changes."""
+        monkeypatch.setenv("VAULT_ROOT", str(tmp_path))
+        (tmp_path / ".git").mkdir()
+        calls = []
+
+        def fake_run(cmd, **kwargs):
+            calls.append(cmd)
+            if "status" in cmd:
+                return MagicMock(stdout=" M file.md\n", returncode=0)
+            return MagicMock(returncode=0)
+
+        with patch("knowledge.service.subprocess.run", side_effect=fake_run):
+            result = await service.vault_backup_handler(MagicMock())
+        assert result is None
+        cmds = [" ".join(c) for c in calls]
+        assert any("git add -A" in c for c in cmds)
+        assert any("git commit" in c for c in cmds)
+        assert any("git push" in c for c in cmds)
+
+    @pytest.mark.asyncio
+    async def test_skips_when_no_git_dir(self, monkeypatch, tmp_path):
+        """vault_backup_handler skips when vault has no .git directory."""
+        monkeypatch.setenv("VAULT_ROOT", str(tmp_path))
+        # No .git dir
+        result = await service.vault_backup_handler(MagicMock())
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_push_failure_logs_warning(self, monkeypatch, tmp_path, caplog):
+        """vault_backup_handler logs a warning when push fails."""
+        monkeypatch.setenv("VAULT_ROOT", str(tmp_path))
+        (tmp_path / ".git").mkdir()
+        call_count = [0]
+
+        def fake_run(cmd, **kwargs):
+            call_count[0] += 1
+            if "status" in cmd:
+                return MagicMock(stdout=" M file.md\n", returncode=0)
+            if "push" in cmd:
+                raise subprocess.CalledProcessError(1, "git push", stderr="rejected")
+            return MagicMock(returncode=0)
+
+        with patch("knowledge.service.subprocess.run", side_effect=fake_run):
+            with caplog.at_level(logging.WARNING, logger="knowledge.service"):
+                await service.vault_backup_handler(MagicMock())
+        assert any("push failed" in r.message.lower() for r in caplog.records)


### PR DESCRIPTION
## Summary

- Replace the slow `_wait_for_vault_sync()` polling loop with a fast `git clone --depth=1` on startup, pre-seeding the vault `emptyDir` volume
- Add a daily `knowledge.vault-backup` scheduled job that commits and pushes vault changes to GitHub (backup only, no git pull — Obsidian Sync remains the source of truth)
- Add `VAULT_GIT_REMOTE` and `VAULT_ROOT` env vars to the backend container via Helm

## Test plan

- [ ] CI passes (all monolith tests)
- [ ] Helm template renders `VAULT_GIT_REMOTE` and `VAULT_ROOT` correctly
- [ ] Pod starts, clones vault from git, and obsidian sidecar overwrites with live data
- [ ] After 24h, `knowledge.vault-backup` job commits and pushes to GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)