### PR TITLE
feat(knowledge): sync Obsidian wikilinks section from frontmatter edges

### DIFF
--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -1875,6 +1875,16 @@ py_test(
 )
 
 py_test(
+    name = "knowledge_wikilinks_test",
+    srcs = ["knowledge/wikilinks_test.py"],
+    imports = ["."],
+    deps = [
+        ":monolith_backend",
+        "@pip//pytest",
+    ],
+)
+
+py_test(
     name = "knowledge_gardener_test",
     srcs = ["knowledge/gardener_test.py"],
     imports = ["."],

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.30.0
+version: 0.30.1
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.29.1
+version: 0.30.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.30.0
+      targetRevision: 0.30.1
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.29.1
+      targetRevision: 0.30.0
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/knowledge/reconciler.py
+++ b/projects/monolith/knowledge/reconciler.py
@@ -12,7 +12,7 @@ from typing import Protocol
 
 from sqlalchemy import text
 
-from knowledge import frontmatter, links
+from knowledge import frontmatter, links, wikilinks
 from knowledge.frontmatter import FrontmatterError
 from knowledge.store import KnowledgeStore
 from shared.chunker import chunk_markdown
@@ -231,6 +231,18 @@ class Reconciler:
                     " refusing to ingest with ephemeral id"
                 ) from exc
 
+        # Sync ## Links section from frontmatter edges (template or update).
+        updated = wikilinks.sync_links(raw, meta)
+        if updated is not None:
+            try:
+                raw, content_hash = self._write_back_links(abs_path, updated)
+            except OSError:
+                logger.warning(
+                    "knowledge: vault read-only, skipping links sync for %s", rel_path
+                )
+            else:
+                _, body = frontmatter.parse(raw)
+
         chunks = chunk_markdown(body)
         if not chunks:
             chunks = [{"index": 0, "section_header": "", "text": body or title}]
@@ -268,6 +280,13 @@ class Reconciler:
             # No existing frontmatter — default to LF.
             new_raw = f"---\nid: {note_id}\n---\n{raw}"
         # newline="" preserves whatever EOLs are already in new_raw.
+        with open(abs_path, "w", encoding="utf-8", newline="") as f:
+            f.write(new_raw)
+        new_hash = hashlib.sha256(new_raw.encode("utf-8")).hexdigest()
+        return new_raw, new_hash
+
+    def _write_back_links(self, abs_path: Path, new_raw: str) -> tuple[str, str]:
+        """Write the updated file (with synced ## Links section) and return (raw, hash)."""
         with open(abs_path, "w", encoding="utf-8", newline="") as f:
             f.write(new_raw)
         new_hash = hashlib.sha256(new_raw.encode("utf-8")).hexdigest()

--- a/projects/monolith/knowledge/reconciler.py
+++ b/projects/monolith/knowledge/reconciler.py
@@ -232,6 +232,10 @@ class Reconciler:
                 ) from exc
 
         # Sync ## Links section from frontmatter edges (template or update).
+        # Capture authored_body before the sync so chunks and link extraction
+        # use only the hand-written content — the generated ## Links section
+        # must not be embedded or re-ingested as wikilinks.
+        authored_body = body
         updated = wikilinks.sync_links(raw, meta)
         if updated is not None:
             try:
@@ -240,14 +244,14 @@ class Reconciler:
                 logger.warning(
                     "knowledge: vault read-only, skipping links sync for %s", rel_path
                 )
-            else:
-                _, body = frontmatter.parse(raw)
 
-        chunks = chunk_markdown(body)
+        chunks = chunk_markdown(authored_body)
         if not chunks:
-            chunks = [{"index": 0, "section_header": "", "text": body or title}]
+            chunks = [
+                {"index": 0, "section_header": "", "text": authored_body or title}
+            ]
         vectors = await self.embed_client.embed_batch([c["text"] for c in chunks])
-        note_links = links.extract(body)
+        note_links = links.extract(authored_body)
 
         self.store.upsert_note(
             note_id=note_id,

--- a/projects/monolith/knowledge/reconciler.py
+++ b/projects/monolith/knowledge/reconciler.py
@@ -247,7 +247,7 @@ class Reconciler:
         if not chunks:
             chunks = [{"index": 0, "section_header": "", "text": body or title}]
         vectors = await self.embed_client.embed_batch([c["text"] for c in chunks])
-        wikilinks = links.extract(body)
+        note_links = links.extract(body)
 
         self.store.upsert_note(
             note_id=note_id,
@@ -257,7 +257,7 @@ class Reconciler:
             metadata=meta,
             chunks=chunks,
             vectors=vectors,
-            links=wikilinks,
+            links=note_links,
         )
         return True
 

--- a/projects/monolith/knowledge/reconciler_test.py
+++ b/projects/monolith/knowledge/reconciler_test.py
@@ -495,3 +495,68 @@ class TestWriteBackIdNoFrontmatter:
         # Confirm the backfilled id was written to disk.
         written = (tmp_path / "_processed" / "bare.md").read_text()
         assert "id: bare" in written
+
+
+class TestReconcilerWikilinks:
+    @pytest.mark.asyncio
+    async def test_links_section_written_for_note_with_edges(
+        self, reconciler, tmp_path
+    ):
+        _write(
+            tmp_path,
+            "a.md",
+            "---\nid: a\ntitle: A\nedges:\n  derives_from: [source-book]\n  related: [b]\n---\n\nBody.\n",
+        )
+        await reconciler.run()
+        written = (tmp_path / "_processed" / "a.md").read_text()
+        assert "## Links" in written
+        assert "Up: [[_processed/source-book|source-book]]" in written
+        assert "- [[_processed/b|b]]" in written
+
+    @pytest.mark.asyncio
+    async def test_links_section_written_for_note_with_type_only(
+        self, reconciler, tmp_path
+    ):
+        _write(
+            tmp_path,
+            "a.md",
+            "---\nid: a\ntitle: A\ntype: feedback\n---\n\nBody.\n",
+        )
+        await reconciler.run()
+        written = (tmp_path / "_processed" / "a.md").read_text()
+        assert "## Links" in written
+        assert "Up: [[feedback]]" in written
+
+    @pytest.mark.asyncio
+    async def test_links_section_not_written_when_no_edges_or_type(
+        self, reconciler, tmp_path
+    ):
+        _write(tmp_path, "a.md", "---\nid: a\ntitle: A\n---\n\nBody.\n")
+        await reconciler.run()
+        written = (tmp_path / "_processed" / "a.md").read_text()
+        assert "## Links" not in written
+
+    @pytest.mark.asyncio
+    async def test_stale_links_section_is_updated(self, reconciler, tmp_path):
+        _write(
+            tmp_path,
+            "a.md",
+            "---\nid: a\ntitle: A\nedges:\n  derives_from: [new-source]\n---\n\nBody.\n\n## Links\n\nUp: [[_processed/old-source|old-source]]\n",
+        )
+        await reconciler.run()
+        written = (tmp_path / "_processed" / "a.md").read_text()
+        assert "new-source" in written
+        assert "old-source" not in written
+
+    @pytest.mark.asyncio
+    async def test_current_links_section_not_rewritten(
+        self, reconciler, embed_client, tmp_path
+    ):
+        content = "---\nid: a\ntitle: A\ntype: atom\n---\n\nBody.\n\n## Links\n\nUp: [[atom]]\n"
+        _write(tmp_path, "a.md", content)
+        await reconciler.run()
+        # embed_batch is called once for the first ingest
+        first_call_count = embed_client.embed_batch.call_count
+        # Second run: content unchanged — file must not be rewritten
+        await reconciler.run()
+        assert embed_client.embed_batch.call_count == first_call_count

--- a/projects/monolith/knowledge/wikilinks.py
+++ b/projects/monolith/knowledge/wikilinks.py
@@ -1,0 +1,63 @@
+"""Generate and sync the ## Links section in Obsidian notes from frontmatter edges."""
+
+from __future__ import annotations
+
+import re
+
+from knowledge.frontmatter import ParsedFrontmatter
+
+_LINKS_RE = re.compile(r"\n## Links\n.*", re.DOTALL)
+
+# Edge types whose targets become Up: links, in priority order.
+_UP_EDGE_TYPES = ("derives_from", "refines")
+
+# Remaining edge types rendered as labelled bullet lists.
+_LABELLED_EDGE_TYPES: dict[str, str] = {
+    "related": "Related",
+    "generalizes": "Generalizes",
+    "contradicts": "Contradicts",
+    "supersedes": "Supersedes",
+}
+
+
+def _wikilink(note_id: str) -> str:
+    return f"[[_processed/{note_id}|{note_id}]]"
+
+
+def render_links_section(meta: ParsedFrontmatter) -> str | None:
+    """Return the full ## Links block (leading newline included), or None if empty."""
+    lines: list[str] = []
+
+    # Up: — first matching up-type edge wins; fall back to type hub.
+    for edge_type in _UP_EDGE_TYPES:
+        if edge_type in meta.edges:
+            for target in meta.edges[edge_type]:
+                lines.append(f"Up: {_wikilink(target)}")
+            break
+    else:
+        if meta.type:
+            lines.append(f"Up: [[{meta.type}]]")
+
+    for edge_type, label in _LABELLED_EDGE_TYPES.items():
+        if edge_type in meta.edges:
+            lines.append(f"{label}:")
+            for ref in meta.edges[edge_type]:
+                lines.append(f"- {_wikilink(ref)}")
+
+    if not lines:
+        return None
+
+    return "\n## Links\n\n" + "\n".join(lines) + "\n"
+
+
+def sync_links(raw: str, meta: ParsedFrontmatter) -> str | None:
+    """Return updated file text with ## Links synced, or None if already current.
+
+    Strips any existing ## Links section (including everything after it) and
+    appends the freshly rendered one. Returns None if the result is identical
+    to the input so callers can skip the write.
+    """
+    expected = render_links_section(meta)
+    stripped = _LINKS_RE.sub("", raw).rstrip()
+    new_raw = stripped + ("\n" + expected if expected else "\n")
+    return None if new_raw == raw else new_raw

--- a/projects/monolith/knowledge/wikilinks_test.py
+++ b/projects/monolith/knowledge/wikilinks_test.py
@@ -1,0 +1,124 @@
+"""Tests for the wikilinks Links section generator."""
+
+from knowledge.frontmatter import ParsedFrontmatter
+from knowledge.wikilinks import render_links_section, sync_links
+
+
+def _meta(**kwargs) -> ParsedFrontmatter:
+    m = ParsedFrontmatter()
+    for k, v in kwargs.items():
+        setattr(m, k, v)
+    return m
+
+
+class TestRenderLinksSection:
+    def test_derives_from_produces_up(self):
+        meta = _meta(edges={"derives_from": ["book-field-guide"]})
+        section = render_links_section(meta)
+        assert (
+            section
+            == "\n## Links\n\nUp: [[_processed/book-field-guide|book-field-guide]]\n"
+        )
+
+    def test_refines_used_as_up_when_no_derives_from(self):
+        meta = _meta(edges={"refines": ["parent-note"]})
+        section = render_links_section(meta)
+        assert "Up: [[_processed/parent-note|parent-note]]" in section
+
+    def test_derives_from_takes_priority_over_refines(self):
+        meta = _meta(edges={"derives_from": ["source"], "refines": ["parent"]})
+        section = render_links_section(meta)
+        assert "Up: [[_processed/source|source]]" in section
+        assert "refines" not in section
+        assert "parent" not in section
+
+    def test_type_hub_fallback_when_no_up_edges(self):
+        meta = _meta(type="feedback", edges={"related": ["other"]})
+        section = render_links_section(meta)
+        assert "Up: [[feedback]]" in section
+
+    def test_type_hub_when_no_edges_at_all(self):
+        meta = _meta(type="project")
+        section = render_links_section(meta)
+        assert section == "\n## Links\n\nUp: [[project]]\n"
+
+    def test_none_when_no_edges_and_no_type(self):
+        meta = _meta()
+        assert render_links_section(meta) is None
+
+    def test_related_rendered_as_bullets(self):
+        meta = _meta(edges={"related": ["note-a", "note-b"]})
+        section = render_links_section(meta)
+        assert (
+            "Related:\n- [[_processed/note-a|note-a]]\n- [[_processed/note-b|note-b]]"
+            in section
+        )
+
+    def test_all_labelled_edge_types(self):
+        meta = _meta(
+            edges={
+                "derives_from": ["source"],
+                "related": ["r"],
+                "generalizes": ["g"],
+                "contradicts": ["c"],
+                "supersedes": ["s"],
+            }
+        )
+        section = render_links_section(meta)
+        assert "Up:" in section
+        assert "Related:" in section
+        assert "Generalizes:" in section
+        assert "Contradicts:" in section
+        assert "Supersedes:" in section
+
+    def test_multiple_derives_from_targets(self):
+        meta = _meta(edges={"derives_from": ["source-a", "source-b"]})
+        section = render_links_section(meta)
+        assert "Up: [[_processed/source-a|source-a]]" in section
+        assert "Up: [[_processed/source-b|source-b]]" in section
+
+
+class TestSyncLinks:
+    def test_appends_section_when_missing(self):
+        raw = "---\nid: test\ntype: atom\n---\n\nSome content.\n"
+        meta = _meta(type="atom")
+        result = sync_links(raw, meta)
+        assert result is not None
+        assert "## Links" in result
+        assert "Up: [[atom]]" in result
+
+    def test_returns_none_when_already_current(self):
+        meta = _meta(type="atom")
+        raw = "---\nid: test\ntype: atom\n---\n\nSome content.\n\n## Links\n\nUp: [[atom]]\n"
+        assert sync_links(raw, meta) is None
+
+    def test_updates_stale_section(self):
+        # Edges changed — old Related list is now wrong
+        raw = "---\nid: test\n---\n\nContent.\n\n## Links\n\nUp: [[old-parent|old-parent]]\n"
+        meta = _meta(edges={"derives_from": ["new-parent"]})
+        result = sync_links(raw, meta)
+        assert result is not None
+        assert "new-parent" in result
+        assert "old-parent" not in result
+
+    def test_strips_entire_old_section(self):
+        raw = (
+            "---\nid: x\n---\n\nBody.\n\n## Links\n\nUp: [[a|a]]\nRelated:\n- [[b|b]]\n"
+        )
+        meta = _meta(edges={"derives_from": ["c"]})
+        result = sync_links(raw, meta)
+        assert result is not None
+        assert "[[a|a]]" not in result
+        assert "[[b|b]]" not in result
+
+    def test_no_section_and_no_edges_returns_none(self):
+        raw = "---\nid: x\n---\n\nBody.\n"
+        meta = _meta()
+        assert sync_links(raw, meta) is None
+
+    def test_idempotent(self):
+        meta = _meta(edges={"derives_from": ["src"], "related": ["rel"]})
+        raw = "---\nid: x\n---\n\nContent.\n"
+        first = sync_links(raw, meta)
+        assert first is not None
+        assert sync_links(first, meta) is None


### PR DESCRIPTION
## Summary

- Adds `wikilinks.py` module that generates/syncs a `## Links` section in processed notes from frontmatter `edges`
- Integrates into the reconciler: templates the section on first ingest, updates it when edges change, skips write when already current
- `Up:` derives from `derives_from` → `refines` → `type` hub (fallback chain)
- All other edge types (`related`, `generalizes`, `contradicts`, `supersedes`) rendered as labelled bullet lists

## Test plan

- [ ] `knowledge_wikilinks_test` — unit tests for `render_links_section` and `sync_links` covering all edge types, priority ordering, idempotency
- [ ] `knowledge_reconciler_test` — integration tests for write-back (template, update stale, no rewrite when current)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)