### PR TITLE
fix(knowledge): pass repo path as positional arg to dulwich push

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.30.1
+version: 0.30.2
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.30.1
+      targetRevision: 0.30.2
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/knowledge/service.py
+++ b/projects/monolith/knowledge/service.py
@@ -86,11 +86,11 @@ async def vault_backup_handler(session: Session) -> datetime | None:
         porcelain.add(str(vault_root))
         porcelain.commit(str(vault_root), message=b"sync: vault backup")
         token = os.environ.get("GITHUB_TOKEN", "")
-        push_kwargs: dict = {"path": str(vault_root)}
+        push_kwargs: dict = {}
         if token:
             push_kwargs["username"] = "x-access-token"
             push_kwargs["password"] = token
-        porcelain.push(**push_kwargs)
+        porcelain.push(str(vault_root), **push_kwargs)
         logger.info("knowledge.vault-backup: committed and pushed")
     except Exception as exc:
         logger.warning("knowledge.vault-backup: push failed: %s", exc)

--- a/projects/monolith/knowledge/service_test.py
+++ b/projects/monolith/knowledge/service_test.py
@@ -390,7 +390,7 @@ class TestVaultBackupHandler:
             str(tmp_path), message=b"sync: vault backup"
         )
         mock_push.assert_called_once_with(
-            path=str(tmp_path), username="x-access-token", password="ghp_test"
+            str(tmp_path), username="x-access-token", password="ghp_test"
         )
 
     @pytest.mark.asyncio
@@ -450,5 +450,5 @@ class TestVaultBackupHandler:
         ):
             await service.vault_backup_handler(MagicMock())
         mock_push.assert_called_once_with(
-            path=str(tmp_path), username="x-access-token", password="ghp_secret"
+            str(tmp_path), username="x-access-token", password="ghp_secret"
         )


### PR DESCRIPTION
## Summary
- `porcelain.push()` expects the repo path as its first positional argument, not a `path=` keyword argument
- The previous code passed `path=str(vault_root)` in kwargs, causing dulwich to use its default repo path and fail with "no username found" since it couldn't locate the git config
- Fix: pass vault_root as the first positional arg, keep only credentials in kwargs

## Test plan
- [x] Updated test assertions to match positional arg call signature
- [ ] Merge, then trigger `knowledge.vault-backup` job via postgres to verify push succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)