### PR TITLE
fix(knowledge): set explicit git author for dulwich commit

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.30.1
+version: 0.30.2
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.30.1
+      targetRevision: 0.30.2
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/knowledge/service.py
+++ b/projects/monolith/knowledge/service.py
@@ -25,6 +25,7 @@ _TTL_SECS = 600
 _BACKUP_INTERVAL_SECS = 86400  # 24 hours
 _BACKUP_TTL_SECS = 3600  # 1 hour timeout
 _GIT_READY_SENTINEL = ".git-ready"
+_GIT_AUTHOR = b"vault-backup <vault-backup@monolith.local>"
 
 
 async def clone_vault() -> None:
@@ -84,7 +85,12 @@ async def vault_backup_handler(session: Session) -> datetime | None:
 
     try:
         porcelain.add(str(vault_root))
-        porcelain.commit(str(vault_root), message=b"sync: vault backup")
+        porcelain.commit(
+            str(vault_root),
+            message=b"sync: vault backup",
+            author=_GIT_AUTHOR,
+            committer=_GIT_AUTHOR,
+        )
         token = os.environ.get("GITHUB_TOKEN", "")
         push_kwargs: dict = {"path": str(vault_root)}
         if token:

--- a/projects/monolith/knowledge/service_test.py
+++ b/projects/monolith/knowledge/service_test.py
@@ -387,7 +387,10 @@ class TestVaultBackupHandler:
         assert result is None
         mock_add.assert_called_once_with(str(tmp_path))
         mock_commit.assert_called_once_with(
-            str(tmp_path), message=b"sync: vault backup"
+            str(tmp_path),
+            message=b"sync: vault backup",
+            author=b"vault-backup <vault-backup@monolith.local>",
+            committer=b"vault-backup <vault-backup@monolith.local>",
         )
         mock_push.assert_called_once_with(
             path=str(tmp_path), username="x-access-token", password="ghp_test"


### PR DESCRIPTION
## Summary
- `porcelain.commit()` fails with "no username found" because the container has no `~/.gitconfig` or repo-level `user.name`/`user.email`
- Pass explicit `author` and `committer` bytes (`vault-backup <vault-backup@monolith.local>`) to the commit call
- Follow-up to #1957 which fixed the push positional arg but didn't address the missing author config

## Test plan
- [x] Updated test assertions to verify author/committer params
- [ ] Merge, then trigger `knowledge.vault-backup` via postgres to verify commit+push succeeds end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)