### PR TITLE
chore(monolith): bump chart version to 0.30.3

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.30.2
+version: 0.30.3
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.30.2
+      targetRevision: 0.30.3
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
## Summary
- The commit-author fix (#1958) landed after the chart-version-bot's 0.30.2 bump, so ArgoCD deployed 0.30.2 with the old image
- Bump to 0.30.3 so CI rebuilds the chart with the fix baked in

🤖 Generated with [Claude Code](https://claude.com/claude-code)