### PR TITLE
fix(knowledge): push to main branch via explicit refspec

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.30.3
+version: 0.30.4
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.30.3
+      targetRevision: 0.30.4
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/knowledge/service.py
+++ b/projects/monolith/knowledge/service.py
@@ -96,7 +96,11 @@ async def vault_backup_handler(session: Session) -> datetime | None:
         if token:
             push_kwargs["username"] = "x-access-token"
             push_kwargs["password"] = token
-        porcelain.push(str(vault_root), **push_kwargs)
+        porcelain.push(
+            str(vault_root),
+            refspecs=[b"refs/heads/master:refs/heads/main"],
+            **push_kwargs,
+        )
         logger.info("knowledge.vault-backup: committed and pushed")
     except Exception as exc:
         logger.warning("knowledge.vault-backup: push failed: %s", exc)

--- a/projects/monolith/knowledge/service_test.py
+++ b/projects/monolith/knowledge/service_test.py
@@ -393,7 +393,10 @@ class TestVaultBackupHandler:
             committer=b"vault-backup <vault-backup@monolith.local>",
         )
         mock_push.assert_called_once_with(
-            str(tmp_path), username="x-access-token", password="ghp_test"
+            str(tmp_path),
+            refspecs=[b"refs/heads/master:refs/heads/main"],
+            username="x-access-token",
+            password="ghp_test",
         )
 
     @pytest.mark.asyncio
@@ -453,5 +456,8 @@ class TestVaultBackupHandler:
         ):
             await service.vault_backup_handler(MagicMock())
         mock_push.assert_called_once_with(
-            str(tmp_path), username="x-access-token", password="ghp_secret"
+            str(tmp_path),
+            refspecs=[b"refs/heads/master:refs/heads/main"],
+            username="x-access-token",
+            password="ghp_secret",
         )


### PR DESCRIPTION
## Summary
- dulwich `clone()` creates a local `master` branch regardless of the remote's default branch (`main`)
- Without an explicit refspec, `push()` targets `refs/heads/master`, creating a stale branch on GitHub instead of updating `main`
- Fix: pass `refspecs=[b"refs/heads/master:refs/heads/main"]` to map the local branch to the correct remote
- Includes chart bump to 0.30.4 to trigger deployment

## Test plan
- [x] Deleted accidental `master` branch from obsidian-vault repo
- [x] Updated test assertions to verify refspec parameter
- [ ] Merge, trigger vault-backup job, verify push lands on `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)