### PR TITLE
fix(knowledge): add git identity env vars for dulwich in container

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.30.4
+version: 0.30.5
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/templates/deployment.yaml
+++ b/projects/monolith/chart/templates/deployment.yaml
@@ -88,6 +88,14 @@ spec:
             {{- if .Values.knowledge.gitRemote }}
             - name: VAULT_GIT_REMOTE
               value: {{ .Values.knowledge.gitRemote | quote }}
+            - name: GIT_AUTHOR_NAME
+              value: "vault-backup"
+            - name: GIT_AUTHOR_EMAIL
+              value: "vault-backup@monolith.local"
+            - name: GIT_COMMITTER_NAME
+              value: "vault-backup"
+            - name: GIT_COMMITTER_EMAIL
+              value: "vault-backup@monolith.local"
             {{- end }}
             {{- end }}
           livenessProbe:

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.30.4
+      targetRevision: 0.30.5
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
## Summary
- dulwich's `_get_default_identity()` checks `USER`/`LOGNAME` env vars and `/etc/passwd` to find the committer identity
- The nonroot container (uid 65532) has neither, causing both `clone()` and `commit()` to fail with "no username found"
- Fix: set `GIT_AUTHOR_NAME`, `GIT_AUTHOR_EMAIL`, `GIT_COMMITTER_NAME`, `GIT_COMMITTER_EMAIL` env vars in the deployment template when `knowledge.gitRemote` is configured
- This is the root cause behind the clone warning and push failures seen since the dulwich migration

## Test plan
- [ ] Merge, wait for rollout, trigger vault-backup job via postgres
- [ ] Verify clone succeeds without warning in startup logs
- [ ] Verify push lands on `main` branch of obsidian-vault repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)