### PR TITLE
fix(knowledge): drop refspec from dulwich push

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.30.5
+version: 0.30.6
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.30.5
+      targetRevision: 0.30.6
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/knowledge/service.py
+++ b/projects/monolith/knowledge/service.py
@@ -96,11 +96,7 @@ async def vault_backup_handler(session: Session) -> datetime | None:
         if token:
             push_kwargs["username"] = "x-access-token"
             push_kwargs["password"] = token
-        porcelain.push(
-            str(vault_root),
-            refspecs=[b"refs/heads/master:refs/heads/main"],
-            **push_kwargs,
-        )
+        porcelain.push(str(vault_root), **push_kwargs)
         logger.info("knowledge.vault-backup: committed and pushed")
     except Exception as exc:
         logger.warning("knowledge.vault-backup: push failed: %s", exc)

--- a/projects/monolith/knowledge/service_test.py
+++ b/projects/monolith/knowledge/service_test.py
@@ -393,10 +393,7 @@ class TestVaultBackupHandler:
             committer=b"vault-backup <vault-backup@monolith.local>",
         )
         mock_push.assert_called_once_with(
-            str(tmp_path),
-            refspecs=[b"refs/heads/master:refs/heads/main"],
-            username="x-access-token",
-            password="ghp_test",
+            str(tmp_path), username="x-access-token", password="ghp_test"
         )
 
     @pytest.mark.asyncio
@@ -456,8 +453,5 @@ class TestVaultBackupHandler:
         ):
             await service.vault_backup_handler(MagicMock())
         mock_push.assert_called_once_with(
-            str(tmp_path),
-            refspecs=[b"refs/heads/master:refs/heads/main"],
-            username="x-access-token",
-            password="ghp_secret",
+            str(tmp_path), username="x-access-token", password="ghp_secret"
         )


### PR DESCRIPTION
## Summary
- dulwich 1.1.0 clones to the remote's default branch name (`main`), not `master`
- The refspec `refs/heads/master:refs/heads/main` from #1960 fails with `KeyError` since there's no local `master` ref
- Fix: remove the refspec entirely — dulwich pushes the current branch to its matching remote ref
- Verified end-to-end locally with a clean-env subprocess (no inherited git config): clone → commit → push succeeded

## Test plan
- [x] Local clean-env test: push landed on `main` with correct author
- [ ] Merge, deploy, trigger vault-backup job to verify in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)