### PR TITLE
fix(knowledge): add USER env var for dulwich clone identity

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.30.6
+version: 0.30.7
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/templates/deployment.yaml
+++ b/projects/monolith/chart/templates/deployment.yaml
@@ -88,6 +88,8 @@ spec:
             {{- if .Values.knowledge.gitRemote }}
             - name: VAULT_GIT_REMOTE
               value: {{ .Values.knowledge.gitRemote | quote }}
+            - name: USER
+              value: "vault-backup"
             - name: GIT_AUTHOR_NAME
               value: "vault-backup"
             - name: GIT_AUTHOR_EMAIL

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.30.6
+      targetRevision: 0.30.7
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
## Summary
- dulwich's `_get_default_identity()` checks `USER`/`LOGNAME` env vars and `pwd.getpwuid()` to resolve identity
- The nonroot container (uid 65532) has none of these, causing `clone()` to fail after downloading objects — refs never get created
- The `GIT_AUTHOR_NAME`/`GIT_COMMITTER_NAME` vars from #1961 only fix `get_user_identity()` (used by commit), not `_get_default_identity()` (used by clone)
- Fix: add `USER=vault-backup` env var to satisfy the low-level identity check

## Test plan
- [ ] Merge, restart pod, verify clone completes without warning
- [ ] Verify `refs/heads/master` exists in `/vault/.git/`
- [ ] Create test file, trigger vault-backup, verify push lands on remote `master`

🤖 Generated with [Claude Code](https://claude.com/claude-code)