### PR TITLE
fix(knowledge): pre-sync Links sections for already-indexed notes

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.31.4
+version: 0.31.5
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.31.4
+      targetRevision: 0.31.5
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/knowledge/reconciler.py
+++ b/projects/monolith/knowledge/reconciler.py
@@ -67,6 +67,10 @@ class Reconciler:
 
     async def run(self) -> ReconcileStats:
         """Reconcile the vault. Returns a ReconcileStats breakdown."""
+        # Sync ## Links sections across all processed notes before hash
+        # comparison so that notes with missing or stale sections get
+        # re-ingested in this cycle via the normal hash-change path.
+        self._pre_sync_links()
         indexed = self.store.get_indexed()
         on_disk = self._walk(previous_indexed=indexed)
 
@@ -288,6 +292,26 @@ class Reconciler:
             f.write(new_raw)
         new_hash = hashlib.sha256(new_raw.encode("utf-8")).hexdigest()
         return new_raw, new_hash
+
+    def _pre_sync_links(self) -> None:
+        """Sync the ## Links section for every note in _processed/ before reconcile.
+
+        Files whose links section is missing or stale are rewritten so their
+        on-disk hash changes, causing the main reconcile loop to re-ingest them
+        via the normal hash-change path.
+        """
+        if not self.processed_root.exists():
+            return
+        for p in self.processed_root.rglob("*.md"):
+            try:
+                raw = self._read_text(p)
+                meta, _ = frontmatter.parse(raw)
+                updated = wikilinks.sync_links(raw, meta)
+                if updated is not None:
+                    self._write_back_links(p, updated)
+                    logger.debug("knowledge: pre-synced links in %s", p.name)
+            except Exception:  # noqa: BLE001 — best-effort, never block reconcile
+                logger.warning("knowledge: failed to pre-sync links for %s", p)
 
     def _write_back_links(self, abs_path: Path, new_raw: str) -> tuple[str, str]:
         """Write the updated file (with synced ## Links section) and return (raw, hash)."""

--- a/projects/monolith/knowledge/reconciler.py
+++ b/projects/monolith/knowledge/reconciler.py
@@ -236,10 +236,10 @@ class Reconciler:
                 ) from exc
 
         # Sync ## Links section from frontmatter edges (template or update).
-        # Capture authored_body before the sync so chunks and link extraction
-        # use only the hand-written content — the generated ## Links section
-        # must not be embedded or re-ingested as wikilinks.
-        authored_body = body
+        # Strip the generated section from body for chunking/link extraction —
+        # the pre-sync pass may have already written it before _ingest_one ran,
+        # so we cannot rely on capturing body before the sync call.
+        authored_body = wikilinks.strip_links_section(body)
         updated = wikilinks.sync_links(raw, meta)
         if updated is not None:
             try:

--- a/projects/monolith/knowledge/reconciler_test.py
+++ b/projects/monolith/knowledge/reconciler_test.py
@@ -552,16 +552,17 @@ class TestReconcilerWikilinks:
     async def test_pre_sync_backfills_already_indexed_notes(
         self, reconciler, session, tmp_path
     ):
-        # Ingest a note without edges so it gets indexed with no Links section.
-        _write(tmp_path, "a.md", "---\nid: a\ntitle: A\ntype: atom\n---\n\nBody.\n")
+        # No type and no edges — no Links section generated.
+        _write(tmp_path, "a.md", "---\nid: a\ntitle: A\n---\n\nBody.\n")
         await reconciler.run()
         assert "## Links" not in (tmp_path / "_processed" / "a.md").read_text()
 
-        # Now add edges — simulating the gardener enriching frontmatter.
+        # Gardener enriches with edges — pre-sync backfills the Links section
+        # even though the note was already indexed (stable hash).
         _write(
             tmp_path,
             "a.md",
-            "---\nid: a\ntitle: A\ntype: atom\nedges:\n  derives_from: [source]\n---\n\nBody.\n",
+            "---\nid: a\ntitle: A\nedges:\n  derives_from: [source]\n---\n\nBody.\n",
         )
         await reconciler.run()
         written = (tmp_path / "_processed" / "a.md").read_text()

--- a/projects/monolith/knowledge/reconciler_test.py
+++ b/projects/monolith/knowledge/reconciler_test.py
@@ -549,6 +549,26 @@ class TestReconcilerWikilinks:
         assert "old-source" not in written
 
     @pytest.mark.asyncio
+    async def test_pre_sync_backfills_already_indexed_notes(
+        self, reconciler, session, tmp_path
+    ):
+        # Ingest a note without edges so it gets indexed with no Links section.
+        _write(tmp_path, "a.md", "---\nid: a\ntitle: A\ntype: atom\n---\n\nBody.\n")
+        await reconciler.run()
+        assert "## Links" not in (tmp_path / "_processed" / "a.md").read_text()
+
+        # Now add edges — simulating the gardener enriching frontmatter.
+        _write(
+            tmp_path,
+            "a.md",
+            "---\nid: a\ntitle: A\ntype: atom\nedges:\n  derives_from: [source]\n---\n\nBody.\n",
+        )
+        await reconciler.run()
+        written = (tmp_path / "_processed" / "a.md").read_text()
+        assert "## Links" in written
+        assert "Up: [[_processed/source|source]]" in written
+
+    @pytest.mark.asyncio
     async def test_current_links_section_not_rewritten(
         self, reconciler, embed_client, tmp_path
     ):

--- a/projects/monolith/knowledge/wikilinks.py
+++ b/projects/monolith/knowledge/wikilinks.py
@@ -50,6 +50,16 @@ def render_links_section(meta: ParsedFrontmatter) -> str | None:
     return "\n## Links\n\n" + "\n".join(lines) + "\n"
 
 
+def strip_links_section(body: str) -> str:
+    """Return body with any ## Links section removed.
+
+    Used by the reconciler to obtain the authored body for chunking and
+    link extraction, regardless of whether the Links section was already
+    written by the pre-sync pass.
+    """
+    return _LINKS_RE.sub("", body)
+
+
 def sync_links(raw: str, meta: ParsedFrontmatter) -> str | None:
     """Return updated file text with ## Links synced, or None if already current.
 


### PR DESCRIPTION
## Summary

- Fixes the reconciler not writing `## Links` to notes already in the index
- Without this, only newly-ingested or modified notes got the Links section — existing stable notes were silently skipped
- Adds `_pre_sync_links()` that runs before `_walk()` each cycle, rewrites any note with a missing or stale Links section, causing its hash to change and triggering re-ingestion via the normal path

## Test plan

- [ ] `test_pre_sync_backfills_already_indexed_notes` — verifies that a note ingested without edges gets its Links section on the next cycle after the gardener adds edges
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)