### PR TITLE
fix(monolith): proxy knowledge search through SvelteKit server routes

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.31.1
+version: 0.31.2
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.31.1
+      targetRevision: 0.31.2
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/routes/api/knowledge/notes/[note_id]/+server.js
+++ b/projects/monolith/frontend/src/routes/api/knowledge/notes/[note_id]/+server.js
@@ -1,0 +1,16 @@
+import { env } from "$env/dynamic/private";
+
+const API_BASE = env.API_BASE || "http://localhost:8000";
+
+/** @type {import('./$types').RequestHandler} */
+export async function GET({ params }) {
+  const resp = await fetch(
+    `${API_BASE}/api/knowledge/notes/${encodeURIComponent(params.note_id)}`,
+    { signal: AbortSignal.timeout(10000) },
+  );
+
+  return new Response(resp.body, {
+    status: resp.status,
+    headers: { "Content-Type": "application/json" },
+  });
+}

--- a/projects/monolith/frontend/src/routes/api/knowledge/search/+server.js
+++ b/projects/monolith/frontend/src/routes/api/knowledge/search/+server.js
@@ -1,0 +1,15 @@
+import { env } from "$env/dynamic/private";
+
+const API_BASE = env.API_BASE || "http://localhost:8000";
+
+/** @type {import('./$types').RequestHandler} */
+export async function GET({ url }) {
+  const resp = await fetch(`${API_BASE}/api/knowledge/search${url.search}`, {
+    signal: AbortSignal.timeout(10000),
+  });
+
+  return new Response(resp.body, {
+    status: resp.status,
+    headers: { "Content-Type": "application/json" },
+  });
+}

--- a/projects/monolith/frontend/src/routes/private/+page.svelte
+++ b/projects/monolith/frontend/src/routes/private/+page.svelte
@@ -21,6 +21,7 @@
   let selectedNote = $state(null);
   let activeIndex = $state(-1);
   let searching = $state(false);
+  let searchError = $state("");
   let searchType = $state("all");
   let savedCapture = $state("");
   let searchInputRef = $state(null);
@@ -39,6 +40,7 @@
     selectedNote = null;
     activeIndex = -1;
     searching = false;
+    searchError = "";
     tick().then(() => captureRef?.focus());
   }
 
@@ -125,6 +127,7 @@
       return;
     }
     searching = true;
+    searchError = "";
     searchTimer = setTimeout(async () => {
       const controller = new AbortController();
       searchController = controller;
@@ -134,12 +137,21 @@
         const res = await fetch(`/api/knowledge/search?${params}`, {
           signal: controller.signal,
         });
-        if (res.ok && !controller.signal.aborted) {
+        if (controller.signal.aborted) return;
+        if (res.ok) {
           searchResults = (await res.json()).results;
           activeIndex = -1;
+          searchError = "";
+        } else if (res.status === 503) {
+          searchError = "embedding unavailable";
+          searchResults = [];
+        } else {
+          searchError = `search failed (${res.status})`;
+          searchResults = [];
         }
       } catch (e) {
         if (e.name !== "AbortError") {
+          searchError = "search unavailable";
           searchResults = [];
         }
       } finally {
@@ -547,7 +559,9 @@
           </div>
         </div>
       {:else}
-        {#if searching && searchResults.length === 0}
+        {#if searchError}
+          <p class="search-status search-status--error">{searchError}</p>
+        {:else if searching && searchResults.length === 0}
           <p class="search-status">searching...</p>
         {:else if !searching && searchQuery.length >= 2 && searchResults.length === 0}
           <p class="search-status">no results</p>
@@ -993,6 +1007,10 @@
     color: var(--fg-tertiary);
     margin-top: 1rem;
     font-size: 0.85rem;
+  }
+
+  .search-status--error {
+    color: var(--danger);
   }
 
   /* ── Note preview ─────────────────────────── */


### PR DESCRIPTION
## Summary
- The knowledge search overlay was calling `/api/knowledge/*` directly from the browser, but traffic routes through the SvelteKit Node server (port 3000), not FastAPI (port 8000) — causing 404s on every search
- Adds SvelteKit `+server.js` proxy routes (matching the existing otel trace pattern) to forward knowledge API calls to the FastAPI backend
- Surfaces API errors (503, network failures) in the overlay instead of silently showing "no results"

## Test plan
- [ ] Open `private.jomcgi.dev`, press `⌘K`, search for a known note — results should appear
- [ ] If embedding service is down, overlay should show "embedding unavailable" in red instead of "no results"
- [ ] Verify existing e2e tests still pass (they hit FastAPI directly, unaffected by this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)