### PR TITLE
fix(knowledge): add minimum similarity threshold to search

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.31.5
+version: 0.31.6
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.31.5
+      targetRevision: 0.31.6
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/knowledge/store.py
+++ b/projects/monolith/knowledge/store.py
@@ -15,6 +15,11 @@ from shared.chunker import Chunk as ChunkPayload
 
 logger = logging.getLogger(__name__)
 
+# Minimum cosine similarity (1 - cosine_distance) to include in search
+# results.  Results below this threshold are noise — short or generic
+# embeddings that happen to be nearest-neighbours without real relevance.
+MIN_SEARCH_SCORE = 0.3
+
 
 class KnowledgeStore:
     def __init__(self, session: Session) -> None:
@@ -135,6 +140,7 @@ class KnowledgeStore:
             )
             .join(Chunk, Chunk.note_fk == Note.id)
             .group_by(Note.id)
+            .having(func.min(distance) <= 1 - MIN_SEARCH_SCORE)
             .order_by(func.min(distance))
             .limit(limit)
         )
@@ -187,6 +193,7 @@ class KnowledgeStore:
             )
             .join(Chunk, Chunk.note_fk == Note.id)
             .group_by(Note.id)
+            .having(func.min(distance) <= 1 - MIN_SEARCH_SCORE)
             .order_by(func.min(distance))
             .limit(limit)
         )


### PR DESCRIPTION
## Summary
- Adds `MIN_SEARCH_SCORE = 0.3` constant and `HAVING` clause to both `search_notes` and `search_notes_with_context`
- Filters out results where `1 - cosine_distance < 0.3` (i.e. cosine distance > 0.7)
- Fixes noisy results like "Liran (BenchSci CEO)" appearing for a "baking" query — short/generic embeddings no longer surface as false positives

## Test plan
- [ ] CI passes (store_test.py Postgres tests verify search still returns relevant results)
- [ ] Search "baking" at `private.jomcgi.dev` — should show recipes/food notes, not unrelated facts
- [ ] Search a specific topic — verify relevant results still appear
- [ ] Search gibberish — should return no results instead of random noise

🤖 Generated with [Claude Code](https://claude.com/claude-code)