### PR TITLE
chore(monolith): restore replicas after raw bucketing migration

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.31.9
+version: 0.31.10
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.31.9
+      targetRevision: 0.31.10
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/deploy/values.yaml
+++ b/projects/monolith/deploy/values.yaml
@@ -1,5 +1,5 @@
 backend:
-  replicas: 0
+  replicas: 1
   vaultApiUrl: "http://obsidian-vault.obsidian.svc.cluster.local:8000"
   resources:
     requests:


### PR DESCRIPTION
## Summary

- Restores `backend.replicas` from 0 → 1 after raw bucketing maintenance window
- Schema migration applied (Atlas auto-applied `20260410000000_raw_bucketing_schema.sql`)
- 615 atom sentinel provenance rows inserted
- 90 vault files grandfathered from `_deleted_with_ttl/` → `_raw/grandfathered/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)