### PR TITLE
fix(knowledge): set indexed_at on raw mirror Note rows

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.31.9
+version: 0.31.10
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.31.9
+      targetRevision: 0.31.10
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/knowledge/migrate_raw_bucketing.py
+++ b/projects/monolith/knowledge/migrate_raw_bucketing.py
@@ -11,6 +11,7 @@ import argparse
 import logging
 import os
 import shutil
+from datetime import datetime, timezone
 from pathlib import Path
 
 import yaml
@@ -108,6 +109,7 @@ def _grandfather_raws(vault_root: Path, session: Session) -> int:
                     content_hash=raw_id,
                     type="raw",
                     source="grandfathered",
+                    indexed_at=datetime.now(timezone.utc),
                 )
             )
             session.add(

--- a/projects/monolith/knowledge/raw_ingest.py
+++ b/projects/monolith/knowledge/raw_ingest.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 from sqlmodel import Session, select
@@ -172,6 +172,7 @@ def reconcile_raw_phase(*, vault_root: Path, session: Session) -> ReconcileRawSt
             content_hash=raw_id,
             type="raw",
             source=source,
+            indexed_at=datetime.now(timezone.utc),
         )
         try:
             with session.begin_nested():


### PR DESCRIPTION
## Summary

- Fixes `NotNullViolation` on `knowledge.notes.indexed_at` when `reconcile_raw_phase` creates mirror Note rows for raw inputs
- The column has `DEFAULT now()` in Postgres, but SQLAlchemy sends explicit NULL when the Python field is None — Postgres defaults only apply when the column is omitted from INSERT
- Sets `indexed_at=datetime.now(utc)` in both `reconcile_raw_phase` and `migrate_raw_bucketing`

## Test plan

- [ ] `bb remote test //projects/monolith/... --config=ci`
- [ ] Verify monolith pod starts without `NotNullViolation` errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)