### PR TITLE
chore(monolith): bump chart version to 0.31.11

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.31.10
+version: 0.31.11
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.31.10
+      targetRevision: 0.31.11
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
## Summary

- Bumps chart version to pick up the indexed_at fix from #1971
- The fix merged after the chart-version-bot's 0.31.10 bump, so ArgoCD is still deploying the old image

🤖 Generated with [Claude Code](https://claude.com/claude-code)