### PR TITLE
fix(knowledge): handle note_id collision when path changes during upsert

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.31.11
+version: 0.31.12
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.31.11
+      targetRevision: 0.31.12
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/knowledge/store.py
+++ b/projects/monolith/knowledge/store.py
@@ -50,9 +50,15 @@ class KnowledgeStore:
             # Delete existing note and its dependents. Explicit cascade for
             # portability across Postgres and SQLite (which needs PRAGMA
             # foreign_keys=ON for FK cascades to fire).
+            # Fall back to note_id lookup to handle path migrations (e.g.
+            # notes moved from their original vault path into _processed/).
             existing = self.session.execute(
                 select(Note.id).where(Note.path == path)
             ).scalar_one_or_none()
+            if existing is None:
+                existing = self.session.execute(
+                    select(Note.id).where(Note.note_id == note_id)
+                ).scalar_one_or_none()
             if existing is not None:
                 self.session.execute(delete(Chunk).where(Chunk.note_fk == existing))
                 self.session.execute(

--- a/projects/monolith/knowledge/store_test.py
+++ b/projects/monolith/knowledge/store_test.py
@@ -141,6 +141,18 @@ class TestUpsertNote:
         assert len(notes) == 1
         assert notes[0].content_hash == "h2"
 
+    def test_upsert_with_changed_path_replaces_old_row(self, store, session):
+        # Simulates the raw-bucketing migration: same note_id but path moves
+        # from e.g. "notes/foo.md" → "_processed/foo.md". The old row must be
+        # deleted by note_id fallback so the INSERT doesn't hit the unique
+        # constraint on note_id.
+        _upsert(store, note_id="migrated", path="notes/foo.md", content_hash="h1")
+        _upsert(store, note_id="migrated", path="_processed/foo.md", content_hash="h2")
+        notes = list(session.scalars(select(Note)))
+        assert len(notes) == 1
+        assert notes[0].path == "_processed/foo.md"
+        assert notes[0].content_hash == "h2"
+
     def test_edges_emit_typed_link_rows(self, store, session):
         _upsert(
             store,


### PR DESCRIPTION
## Summary

- `upsert_note` looked up existing rows by `path` only — when the raw bucketing migration changed note paths to `_processed/...`, the lookup found nothing, skipped the cascade delete, then failed with `UniqueViolation` on `notes_note_id_key`
- Fix: fall back to a `note_id` lookup when the path lookup returns nothing, covering the path-migration case without changing normal update behaviour
- Adds a regression test: upsert same `note_id` at a new path replaces the old row

## Test plan

- [ ] `//projects/monolith:store_test` passes (new test `test_upsert_with_changed_path_replaces_old_row` covers the fix)
- [ ] Next reconcile cycle in prod should log `upserted=N failed=0` for the previously-failing note (`book-site-reliability-engineering`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)