### PR TITLE
fix(knowledge): set created_at on RawInput rows in reconcile phase

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.31.12
+version: 0.31.13
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.31.12
+      targetRevision: 0.31.13
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/knowledge/raw_ingest.py
+++ b/projects/monolith/knowledge/raw_ingest.py
@@ -164,6 +164,7 @@ def reconcile_raw_phase(*, vault_root: Path, session: Session) -> ReconcileRawSt
             original_path=original_path,
             content=content,
             content_hash=raw_id,
+            created_at=datetime.now(timezone.utc),
         )
         note = Note(
             note_id=raw_id,


### PR DESCRIPTION
## Summary
- `reconcile_raw_phase` creates `RawInput` without `created_at`, causing `NotNullViolation` in Postgres
- SQLAlchemy sends explicit NULL when the Python field defaults to `None`, bypassing the DB server default
- Same class of bug fixed for `Note.indexed_at` in 7bd4a9fda but missed for `RawInput.created_at`

## Test plan
- [ ] CI passes (`raw_ingest_test`)
- [ ] Verify `knowledge.garden` scheduler job completes without `NotNullViolation` after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)