### PR TITLE
fix(knowledge): separate RawInput and Note savepoints in reconcile phase

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.31.13
+version: 0.31.14
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.31.13
+      targetRevision: 0.31.14
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/knowledge/raw_ingest.py
+++ b/projects/monolith/knowledge/raw_ingest.py
@@ -178,12 +178,22 @@ def reconcile_raw_phase(*, vault_root: Path, session: Session) -> ReconcileRawSt
         try:
             with session.begin_nested():
                 session.add(ri)
-                session.add(note)
         except Exception:
             logger.warning(
-                "reconcile_raw_phase: failed to insert %s", rel, exc_info=True
+                "reconcile_raw_phase: failed to insert raw_input %s",
+                rel,
+                exc_info=True,
             )
             continue
+
+        try:
+            with session.begin_nested():
+                session.add(note)
+        except Exception:
+            # Note may already exist from the decomposition pipeline —
+            # that's fine, the RawInput is what tracks reconciliation.
+            logger.debug("reconcile_raw_phase: mirror note already exists for %s", rel)
+
         inserted += 1
 
     return ReconcileRawStats(inserted=inserted, skipped=skipped)

--- a/projects/monolith/knowledge/raw_ingest_test.py
+++ b/projects/monolith/knowledge/raw_ingest_test.py
@@ -9,7 +9,6 @@ from sqlmodel.pool import StaticPool
 
 from knowledge.models import Note, RawInput
 from knowledge.raw_ingest import (
-    MovePhaseStats,
     ReconcileRawStats,
     move_phase,
     reconcile_raw_phase,
@@ -125,6 +124,37 @@ class TestReconcileRawPhase:
         assert stats.inserted == 0
         assert stats.skipped == 1
         assert len(session.exec(select(RawInput)).all()) == 1
+
+    def test_inserts_raw_input_when_note_already_exists(self, tmp_path, session):
+        """RawInput must be recorded even if a Note with the same note_id
+        already exists (e.g. from the decomposition pipeline)."""
+        content = "---\ntitle: Pre-existing\n---\nBody."
+        raw_file = tmp_path / "_raw" / "2026" / "04" / "09" / "abc1-pre.md"
+        raw_file.parent.mkdir(parents=True)
+        raw_file.write_text(content, encoding="utf-8")
+
+        from knowledge.raw_paths import compute_raw_id
+
+        note_id = compute_raw_id(content)
+        existing_note = Note(
+            note_id=note_id,
+            path="_processed/atoms/pre.md",
+            title="Pre-existing",
+            content_hash=note_id,
+            type="atom",
+            source="decomposition",
+            indexed_at=datetime.now(timezone.utc),
+        )
+        session.add(existing_note)
+        session.commit()
+
+        stats = reconcile_raw_phase(vault_root=tmp_path, session=session)
+        session.commit()
+
+        assert stats.inserted == 1
+        rows = session.exec(select(RawInput)).all()
+        assert len(rows) == 1
+        assert rows[0].raw_id == note_id
 
     def test_missing_raw_dir_is_noop(self, tmp_path, session):
         stats = reconcile_raw_phase(vault_root=tmp_path, session=session)


### PR DESCRIPTION
## Summary
- `reconcile_raw_phase` used a single savepoint for both `RawInput` and mirror `Note` inserts
- When the Note already existed (from decomposition pipeline), the UniqueViolation rolled back *both* — so the `RawInput` was never recorded
- This caused an infinite retry loop: every gardener cycle re-attempted the same file
- Fix: separate into independent savepoints so `RawInput` is recorded regardless of Note conflicts

## Test plan
- [ ] New test: `test_inserts_raw_input_when_note_already_exists` covers the exact scenario
- [ ] CI passes (existing tests still green)
- [ ] Verify `knowledge.garden` completes without UniqueViolation after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)