### PR TITLE
fix(knowledge): add default_factory for created_at/indexed_at on all models

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.31.15
+version: 0.31.16
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.31.15
+      targetRevision: 0.31.16
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/knowledge/migrate_raw_bucketing.py
+++ b/projects/monolith/knowledge/migrate_raw_bucketing.py
@@ -11,7 +11,7 @@ import argparse
 import logging
 import os
 import shutil
-from datetime import datetime, timezone
+
 from pathlib import Path
 
 import yaml
@@ -109,7 +109,6 @@ def _grandfather_raws(vault_root: Path, session: Session) -> int:
                     content_hash=raw_id,
                     type="raw",
                     source="grandfathered",
-                    indexed_at=datetime.now(timezone.utc),
                 )
             )
             session.add(

--- a/projects/monolith/knowledge/models.py
+++ b/projects/monolith/knowledge/models.py
@@ -1,7 +1,7 @@
 """SQLModel definitions for the knowledge schema."""
 
 import json
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Literal, NewType
 
 NoteId = NewType("NoteId", str)
@@ -49,10 +49,10 @@ class Note(SQLModel, table=True):
     source: str | None = None
     tags: list[str] = Field(default_factory=list, sa_column=Column(_STRING_ARRAY))
     aliases: list[str] = Field(default_factory=list, sa_column=Column(_STRING_ARRAY))
-    created_at: datetime | None = None
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     updated_at: datetime | None = None
     extra: dict[str, Any] = Field(default_factory=dict, sa_column=Column(_JSONB))
-    indexed_at: datetime | None = None
+    indexed_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
 
 
 class Chunk(SQLModel, table=True):
@@ -118,7 +118,7 @@ class RawInput(SQLModel, table=True):
     original_path: str | None = None
     content: str
     content_hash: str
-    created_at: datetime | None = None
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     extra: dict[str, Any] = Field(default_factory=dict, sa_column=Column(_JSONB))
 
 
@@ -131,7 +131,7 @@ class AtomRawProvenance(SQLModel, table=True):
     raw_fk: int | None = Field(default=None, foreign_key="knowledge.raw_inputs.id")
     derived_note_id: str | None = None
     gardener_version: str
-    created_at: datetime | None = None
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
 
     def __init__(self, **data: Any) -> None:
         # Mirror the SQL CHECK (atom_fk IS NOT NULL OR raw_fk IS NOT NULL).

--- a/projects/monolith/knowledge/raw_ingest.py
+++ b/projects/monolith/knowledge/raw_ingest.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime
 from pathlib import Path
 
 from sqlmodel import Session, select
@@ -127,6 +127,7 @@ def reconcile_raw_phase(*, vault_root: Path, session: Session) -> ReconcileRawSt
     skipped = 0
 
     existing_paths = set(session.exec(select(RawInput.path)).all())
+    existing_raw_ids = set(session.exec(select(RawInput.raw_id)).all())
 
     for file_path in sorted(raw_root.rglob("*.md")):
         rel = file_path.relative_to(vault_root).as_posix()
@@ -148,6 +149,10 @@ def reconcile_raw_phase(*, vault_root: Path, session: Session) -> ReconcileRawSt
             meta = None
 
         raw_id = compute_raw_id(content)
+        if raw_id in existing_raw_ids:
+            skipped += 1
+            continue
+
         title = meta.title if meta and meta.title else file_path.stem
         source = _infer_source(
             meta.source if meta else None,
@@ -164,7 +169,6 @@ def reconcile_raw_phase(*, vault_root: Path, session: Session) -> ReconcileRawSt
             original_path=original_path,
             content=content,
             content_hash=raw_id,
-            created_at=datetime.now(timezone.utc),
         )
         note = Note(
             note_id=raw_id,
@@ -173,7 +177,6 @@ def reconcile_raw_phase(*, vault_root: Path, session: Session) -> ReconcileRawSt
             content_hash=raw_id,
             type="raw",
             source=source,
-            indexed_at=datetime.now(timezone.utc),
         )
         try:
             with session.begin_nested():


### PR DESCRIPTION
## Summary
- All three knowledge models (`Note`, `RawInput`, `AtomRawProvenance`) had `created_at: datetime | None = None` — SQLAlchemy sends explicit NULL, bypassing Postgres `DEFAULT now()`
- Fix at the model level with `default_factory=lambda: datetime.now(timezone.utc)` so every constructor gets a timestamp automatically — no more whack-a-mole at call sites
- Also fixes `reconcile_raw_phase` skip check to include `raw_id` (not just `path`), preventing `UniqueViolation` on `raw_inputs_raw_id_key` for content-duplicate files
- Removes now-redundant explicit timestamp assignments from `raw_ingest.py` and `migrate_raw_bucketing.py`

## Test plan
- [ ] CI passes (existing tests still green)
- [ ] Verify `knowledge.garden` completes without any IntegrityErrors after deploy
- [ ] Verify `AtomRawProvenance` rows get proper `created_at` values

🤖 Generated with [Claude Code](https://claude.com/claude-code)