### PR TITLE
fix(knowledge): record sentinel provenance when gardener produces no notes

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.31.16
+version: 0.31.17
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.31.16
+      targetRevision: 0.31.17
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/knowledge/gardener.py
+++ b/projects/monolith/knowledge/gardener.py
@@ -340,6 +340,16 @@ class Gardener:
                 path,
                 self._last_stdout.decode(errors="replace")[:500],
             )
+            # Record a sentinel so this raw is not reprocessed every cycle.
+            if raw_row is not None and self.session is not None:
+                self.session.add(
+                    AtomRawProvenance(
+                        raw_fk=raw_row.id,
+                        derived_note_id="no-new-notes",
+                        gardener_version=GARDENER_VERSION,
+                    )
+                )
+                self.session.commit()
             return
 
         if raw_row is not None and self.session is not None:

--- a/projects/monolith/knowledge/gardener_test.py
+++ b/projects/monolith/knowledge/gardener_test.py
@@ -567,6 +567,44 @@ class TestIngestOneRecordsPendingProvenance:
         assert rows[0].gardener_version == GARDENER_VERSION
 
 
+class TestIngestOneNoNoteSentinel:
+    @pytest.mark.asyncio
+    async def test_records_sentinel_when_no_notes_produced(self, tmp_path, session):
+        """When claude exits 0 but creates no new files, a sentinel
+        provenance row prevents the raw from being reprocessed."""
+        from knowledge.gardener import GARDENER_VERSION
+        from knowledge.models import AtomRawProvenance, RawInput
+
+        (tmp_path / "_raw" / "2026" / "04" / "09").mkdir(parents=True)
+        raw_rel_path = "_raw/2026/04/09/r1-n.md"
+        (tmp_path / raw_rel_path).write_text("Body.", encoding="utf-8")
+
+        raw = RawInput(
+            raw_id="r1",
+            path=raw_rel_path,
+            source="vault-drop",
+            content="Body.",
+            content_hash="r1",
+        )
+        session.add(raw)
+        session.commit()
+
+        gardener = Gardener(vault_root=tmp_path, session=session)
+
+        async def fake_subprocess(prompt: str) -> None:
+            pass  # produces no files
+
+        gardener._run_claude_subprocess = fake_subprocess  # type: ignore[method-assign]
+
+        await gardener._ingest_one(tmp_path / raw_rel_path)
+
+        rows = session.exec(select(AtomRawProvenance)).all()
+        assert len(rows) == 1
+        assert rows[0].raw_fk == raw.id
+        assert rows[0].derived_note_id == "no-new-notes"
+        assert rows[0].gardener_version == GARDENER_VERSION
+
+
 class TestGardenerRunPhases:
     @pytest.mark.asyncio
     async def test_run_invokes_move_then_reconcile_then_decompose(


### PR DESCRIPTION
## Summary
- When claude exits 0 but produces no new files (already-decomposed raws), `_ingest_one` returned without recording provenance
- This caused every gardener cycle to re-send these raws to Claude, wasting API calls
- Fix: record a sentinel `AtomRawProvenance` row with `derived_note_id="no-new-notes"` so `_raws_needing_decomposition` skips them

## Test plan
- [ ] New test: `test_records_sentinel_when_no_notes_produced`
- [ ] CI passes
- [ ] Verify gardener stops reprocessing already-decomposed raws after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)