### PR TITLE
fix(knowledge): backfill provenance from processed atoms before decomposition

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.31.17
+version: 0.31.18
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.31.17
+      targetRevision: 0.31.18
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/knowledge/gardener.py
+++ b/projects/monolith/knowledge/gardener.py
@@ -155,6 +155,63 @@ class Gardener:
             resolved += 1
         return resolved
 
+    def _backfill_provenance_from_processed(self) -> int:
+        """Bulk-insert sentinel provenance for raws already decomposed on disk.
+
+        Scans _processed/ atoms for derived_from_raw frontmatter and creates
+        provenance rows for any matching raws that lack them. This avoids
+        sending already-decomposed raws to Claude just to hear "already done".
+        """
+        if self.session is None:
+            return 0
+        if not self.processed_root.exists():
+            return 0
+
+        # Collect raw_ids referenced by existing atoms on disk.
+        processed_raw_ids: set[str] = set()
+        for atom_path in self.processed_root.glob("*.md"):
+            try:
+                meta, _ = frontmatter.parse(atom_path.read_text(encoding="utf-8"))
+                if meta.extra and meta.extra.get("derived_from_raw"):
+                    processed_raw_ids.add(meta.extra["derived_from_raw"])
+            except Exception:
+                continue
+
+        if not processed_raw_ids:
+            return 0
+
+        # Find raws that have no provenance at all.
+        has_prov = (
+            select(AtomRawProvenance.raw_fk)
+            .where(AtomRawProvenance.raw_fk.is_not(None))
+            .subquery()
+        )
+        unhandled = list(
+            self.session.exec(
+                select(RawInput).where(not_(RawInput.id.in_(select(has_prov.c.raw_fk))))
+            ).all()
+        )
+
+        backfilled = 0
+        for raw in unhandled:
+            if raw.raw_id in processed_raw_ids:
+                self.session.add(
+                    AtomRawProvenance(
+                        raw_fk=raw.id,
+                        derived_note_id="backfill-from-disk",
+                        gardener_version=GARDENER_VERSION,
+                    )
+                )
+                backfilled += 1
+
+        if backfilled:
+            self.session.commit()
+            logger.info(
+                "gardener: backfilled provenance for %d already-processed raws",
+                backfilled,
+            )
+        return backfilled
+
     def _raws_needing_decomposition(self) -> list[RawInput]:
         """Return raws that have no current-version provenance and no sentinel."""
         if self.session is None:
@@ -195,6 +252,8 @@ class Gardener:
                 vault_root=self.vault_root, session=self.session
             )
             self.session.commit()
+
+        self._backfill_provenance_from_processed()
 
         raws = self._raws_needing_decomposition()
         if self.max_files_per_run > 0 and len(raws) > self.max_files_per_run:

--- a/projects/monolith/knowledge/gardener_test.py
+++ b/projects/monolith/knowledge/gardener_test.py
@@ -567,6 +567,77 @@ class TestIngestOneRecordsPendingProvenance:
         assert rows[0].gardener_version == GARDENER_VERSION
 
 
+class TestBackfillProvenanceFromProcessed:
+    def test_backfills_provenance_for_already_processed_raws(self, tmp_path, session):
+        """Raws whose atoms already exist on disk get sentinel provenance
+        without calling Claude."""
+        from knowledge.gardener import GARDENER_VERSION
+        from knowledge.models import AtomRawProvenance, RawInput
+
+        # Create a raw input row.
+        (tmp_path / "_raw" / "2026" / "04" / "09").mkdir(parents=True)
+        raw_path = "_raw/2026/04/09/r1-n.md"
+        (tmp_path / raw_path).write_text("Body.", encoding="utf-8")
+        raw = RawInput(
+            raw_id="r1",
+            path=raw_path,
+            source="vault-drop",
+            content="Body.",
+            content_hash="r1",
+        )
+        session.add(raw)
+        session.commit()
+
+        # Simulate a processed atom referencing this raw_id.
+        processed = tmp_path / "_processed"
+        processed.mkdir()
+        (processed / "atom.md").write_text(
+            "---\nid: atom-1\ntitle: Atom\ntype: atom\nderived_from_raw: r1\n---\nBody.\n",
+            encoding="utf-8",
+        )
+
+        gardener = Gardener(vault_root=tmp_path, session=session)
+        count = gardener._backfill_provenance_from_processed()
+
+        assert count == 1
+        rows = session.exec(select(AtomRawProvenance)).all()
+        assert len(rows) == 1
+        assert rows[0].raw_fk == raw.id
+        assert rows[0].derived_note_id == "backfill-from-disk"
+        assert rows[0].gardener_version == GARDENER_VERSION
+
+    def test_skips_raws_without_matching_atoms(self, tmp_path, session):
+        """Raws with no matching atoms on disk are left for Claude."""
+        from knowledge.models import AtomRawProvenance, RawInput
+
+        (tmp_path / "_raw" / "2026" / "04" / "09").mkdir(parents=True)
+        raw_path = "_raw/2026/04/09/r1-n.md"
+        (tmp_path / raw_path).write_text("Body.", encoding="utf-8")
+        raw = RawInput(
+            raw_id="r1",
+            path=raw_path,
+            source="vault-drop",
+            content="Body.",
+            content_hash="r1",
+        )
+        session.add(raw)
+        session.commit()
+
+        # Processed dir exists but has no atoms referencing r1.
+        processed = tmp_path / "_processed"
+        processed.mkdir()
+        (processed / "unrelated.md").write_text(
+            "---\nid: other\ntitle: Other\ntype: atom\nderived_from_raw: r999\n---\nBody.\n",
+            encoding="utf-8",
+        )
+
+        gardener = Gardener(vault_root=tmp_path, session=session)
+        count = gardener._backfill_provenance_from_processed()
+
+        assert count == 0
+        assert session.exec(select(AtomRawProvenance)).all() == []
+
+
 class TestIngestOneNoNoteSentinel:
     @pytest.mark.asyncio
     async def test_records_sentinel_when_no_notes_produced(self, tmp_path, session):


### PR DESCRIPTION
## Summary
- The gardener was sending ~360 already-decomposed raws to Claude each cycle, wasting API calls to hear "already done"
- Before decomposition, scan `_processed/` atoms for `derived_from_raw` frontmatter and bulk-insert sentinel provenance for matching raws
- Only genuinely new raws (no atoms on disk) get sent to Claude
- One-time backfill runs each cycle but is a no-op once all sentinels are in place

## Test plan
- [ ] New tests: `TestBackfillProvenanceFromProcessed` (backfill + skip)
- [ ] CI passes
- [ ] Verify gardener log shows `backfilled provenance for N already-processed raws` on first cycle, then `ingested=0` on subsequent cycles

🤖 Generated with [Claude Code](https://claude.com/claude-code)