### PR TITLE
test(knowledge): cover default_factory timestamps and indexed_at migration

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.31.18
+version: 0.31.19
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.31.18
+      targetRevision: 0.31.19
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/knowledge/migrate_raw_bucketing_test.py
+++ b/projects/monolith/knowledge/migrate_raw_bucketing_test.py
@@ -66,6 +66,10 @@ class TestRunMigration:
 
         mirror = session.exec(select(Note).where(Note.type == "raw")).all()
         assert len(mirror) == 1
+        # indexed_at must be set — previously this was passed explicitly; after
+        # commit 1a7de3b0 it is omitted from the call site and relies on the
+        # default_factory on Note.indexed_at.
+        assert mirror[0].indexed_at is not None
 
         sentinels = session.exec(
             select(AtomRawProvenance).where(

--- a/projects/monolith/knowledge/models_test.py
+++ b/projects/monolith/knowledge/models_test.py
@@ -1,6 +1,7 @@
 """Unit tests for knowledge.models — NoteLink validation and Chunk._parse_embedding."""
 
 import json
+from datetime import datetime, timezone
 
 import pytest
 from sqlmodel import Session, SQLModel, create_engine
@@ -216,3 +217,102 @@ def test_atom_raw_provenance_rejects_both_null():
             raw_fk=None,
             gardener_version="claude-sonnet-4-6@v1",
         )
+
+
+class TestDefaultFactoryTimestamps:
+    """Models with default_factory timestamps auto-populate UTC datetimes on construction.
+
+    Verifies commit 1a7de3b0: created_at/indexed_at use default_factory so
+    explicit NULL is never sent to Postgres, bypassing the DEFAULT now() column.
+    """
+
+    def test_note_created_at_auto_populated(self):
+        """Note.created_at is a UTC datetime when no explicit value is given."""
+        from knowledge.models import Note
+
+        note = Note(
+            note_id="auto-ts-note",
+            path="_processed/atoms/auto-ts-note.md",
+            title="Auto TS",
+            content_hash="abc",
+            type="atom",
+        )
+        assert isinstance(note.created_at, datetime)
+        assert note.created_at.tzinfo == timezone.utc
+
+    def test_note_indexed_at_auto_populated(self):
+        """Note.indexed_at is a UTC datetime when no explicit value is given."""
+        from knowledge.models import Note
+
+        note = Note(
+            note_id="auto-ts-note2",
+            path="_processed/atoms/auto-ts-note2.md",
+            title="Auto TS 2",
+            content_hash="def",
+            type="atom",
+        )
+        assert isinstance(note.indexed_at, datetime)
+        assert note.indexed_at.tzinfo == timezone.utc
+
+    def test_note_timestamps_are_independent_instances(self):
+        """Each Note construction produces independent timestamp values (no shared reference)."""
+        from knowledge.models import Note
+
+        n1 = Note(
+            note_id="ts-a",
+            path="_processed/atoms/ts-a.md",
+            title="A",
+            content_hash="h1",
+            type="atom",
+        )
+        n2 = Note(
+            note_id="ts-b",
+            path="_processed/atoms/ts-b.md",
+            title="B",
+            content_hash="h2",
+            type="atom",
+        )
+        # Both are datetimes but not the same object — default_factory calls
+        # datetime.now() each time, so they should differ by at most a few ms.
+        assert n1.created_at is not n2.created_at
+        assert n1.indexed_at is not n2.indexed_at
+
+    def test_raw_input_created_at_auto_populated(self):
+        """RawInput.created_at is a UTC datetime when no explicit value is given."""
+        from knowledge.models import RawInput
+
+        ri = RawInput(
+            raw_id="ri-auto-ts",
+            path="_raw/2026/04/10/ri-auto-ts.md",
+            source="vault-drop",
+            content="Body.",
+            content_hash="ri-auto-ts",
+        )
+        assert isinstance(ri.created_at, datetime)
+        assert ri.created_at.tzinfo == timezone.utc
+
+    def test_atom_raw_provenance_created_at_auto_populated(self):
+        """AtomRawProvenance.created_at is a UTC datetime when no explicit value is given."""
+        from knowledge.models import AtomRawProvenance
+
+        prov = AtomRawProvenance(
+            raw_fk=1,
+            gardener_version="v1",
+        )
+        assert isinstance(prov.created_at, datetime)
+        assert prov.created_at.tzinfo == timezone.utc
+
+    def test_explicit_created_at_is_respected(self):
+        """Passing an explicit created_at overrides the default_factory."""
+        from knowledge.models import RawInput
+
+        explicit_ts = datetime(2025, 1, 15, 12, 0, 0, tzinfo=timezone.utc)
+        ri = RawInput(
+            raw_id="ri-explicit-ts",
+            path="_raw/2026/04/10/ri-explicit-ts.md",
+            source="vault-drop",
+            content="Body.",
+            content_hash="ri-explicit-ts",
+            created_at=explicit_ts,
+        )
+        assert ri.created_at == explicit_ts

--- a/projects/monolith/knowledge/models_test.py
+++ b/projects/monolith/knowledge/models_test.py
@@ -7,7 +7,7 @@ import pytest
 from sqlmodel import Session, SQLModel, create_engine
 from sqlmodel.pool import StaticPool
 
-from knowledge.models import Chunk, NoteLink
+from knowledge.models import AtomRawProvenance, Chunk, Note, NoteLink, RawInput
 
 
 @pytest.fixture(name="session")
@@ -154,8 +154,6 @@ class TestChunkParseEmbedding:
 
 
 def test_raw_input_roundtrip(session):
-    from knowledge.models import RawInput
-
     ri = RawInput(
         raw_id="abc123",
         path="_raw/2026/04/09/abc1-my-note.md",
@@ -175,8 +173,6 @@ def test_raw_input_roundtrip(session):
 
 
 def test_atom_raw_provenance_roundtrip(session):
-    from knowledge.models import AtomRawProvenance, Note, RawInput
-
     note = Note(
         note_id="hello-world",
         path="_processed/atoms/hello-world.md",
@@ -209,8 +205,6 @@ def test_atom_raw_provenance_roundtrip(session):
 
 
 def test_atom_raw_provenance_rejects_both_null():
-    from knowledge.models import AtomRawProvenance
-
     with pytest.raises(ValueError, match="at least one of atom_fk or raw_fk"):
         AtomRawProvenance(
             atom_fk=None,
@@ -228,8 +222,6 @@ class TestDefaultFactoryTimestamps:
 
     def test_note_created_at_auto_populated(self):
         """Note.created_at is a UTC datetime when no explicit value is given."""
-        from knowledge.models import Note
-
         note = Note(
             note_id="auto-ts-note",
             path="_processed/atoms/auto-ts-note.md",
@@ -242,8 +234,6 @@ class TestDefaultFactoryTimestamps:
 
     def test_note_indexed_at_auto_populated(self):
         """Note.indexed_at is a UTC datetime when no explicit value is given."""
-        from knowledge.models import Note
-
         note = Note(
             note_id="auto-ts-note2",
             path="_processed/atoms/auto-ts-note2.md",
@@ -255,9 +245,7 @@ class TestDefaultFactoryTimestamps:
         assert note.indexed_at.tzinfo == timezone.utc
 
     def test_note_timestamps_are_independent_instances(self):
-        """Each Note construction produces independent timestamp values (no shared reference)."""
-        from knowledge.models import Note
-
+        """Each Note construction produces independent timestamp values (default_factory, not default)."""
         n1 = Note(
             note_id="ts-a",
             path="_processed/atoms/ts-a.md",
@@ -272,15 +260,16 @@ class TestDefaultFactoryTimestamps:
             content_hash="h2",
             type="atom",
         )
-        # Both are datetimes but not the same object — default_factory calls
-        # datetime.now() each time, so they should differ by at most a few ms.
-        assert n1.created_at is not n2.created_at
-        assert n1.indexed_at is not n2.indexed_at
+        # default_factory=lambda: datetime.now(timezone.utc) is called fresh
+        # for each construction, so values differ.  Using != (not `is not`)
+        # catches the classic bug where default= would share a single evaluated
+        # object — Pydantic copies on validation so identity always differs, but
+        # value equality correctly distinguishes the two cases.
+        assert n1.created_at != n2.created_at
+        assert n1.indexed_at != n2.indexed_at
 
     def test_raw_input_created_at_auto_populated(self):
         """RawInput.created_at is a UTC datetime when no explicit value is given."""
-        from knowledge.models import RawInput
-
         ri = RawInput(
             raw_id="ri-auto-ts",
             path="_raw/2026/04/10/ri-auto-ts.md",
@@ -293,8 +282,6 @@ class TestDefaultFactoryTimestamps:
 
     def test_atom_raw_provenance_created_at_auto_populated(self):
         """AtomRawProvenance.created_at is a UTC datetime when no explicit value is given."""
-        from knowledge.models import AtomRawProvenance
-
         prov = AtomRawProvenance(
             raw_fk=1,
             gardener_version="v1",
@@ -304,8 +291,6 @@ class TestDefaultFactoryTimestamps:
 
     def test_explicit_created_at_is_respected(self):
         """Passing an explicit created_at overrides the default_factory."""
-        from knowledge.models import RawInput
-
         explicit_ts = datetime(2025, 1, 15, 12, 0, 0, tzinfo=timezone.utc)
         ri = RawInput(
             raw_id="ri-explicit-ts",


### PR DESCRIPTION
## Summary

- Adds `TestDefaultFactoryTimestamps` class to `models_test.py` with 6 tests verifying that `Note`, `RawInput`, and `AtomRawProvenance` auto-populate `created_at` and `indexed_at` as UTC datetimes when constructed without explicit timestamp arguments (covers commit `1a7de3b0`)
- Adds `assert mirror[0].indexed_at is not None` to `test_moves_deleted_ttl_files_into_raw_grandfathered` in `migrate_raw_bucketing_test.py`, asserting the mirror `Note` row has a populated `indexed_at` after the explicit `indexed_at=datetime.now(timezone.utc)` was removed from the `_grandfather_raws` call site (covers commit `1a7de3b0`)

## Test plan

- [ ] `//projects/monolith:knowledge_models_test` — 6 new `TestDefaultFactoryTimestamps` tests pass
- [ ] `//projects/monolith:knowledge_migrate_raw_bucketing_test` — extended `test_moves_deleted_ttl_files_into_raw_grandfathered` passes with `indexed_at is not None` assertion
- [ ] No production code modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)