### PR TITLE
fix(knowledge): DB-based provenance backfill instead of disk scan

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.31.18
+version: 0.31.19
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.31.18
+      targetRevision: 0.31.19
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/knowledge/gardener.py
+++ b/projects/monolith/knowledge/gardener.py
@@ -155,28 +155,25 @@ class Gardener:
             resolved += 1
         return resolved
 
-    def _backfill_provenance_from_processed(self) -> int:
-        """Bulk-insert sentinel provenance for raws already decomposed on disk.
+    def _backfill_provenance_from_notes(self) -> int:
+        """Bulk-insert sentinel provenance for raws already linked to notes.
 
-        Scans _processed/ atoms for derived_from_raw frontmatter and creates
-        provenance rows for any matching raws that lack them. This avoids
-        sending already-decomposed raws to Claude just to hear "already done".
+        Queries the notes table for derived_from_raw JSONB values and creates
+        provenance rows for any matching raws that lack them.  This is
+        deterministic (DB-only, no disk scan) and avoids sending
+        already-decomposed raws to Claude.
         """
         if self.session is None:
             return 0
-        if not self.processed_root.exists():
-            return 0
 
-        # Collect raw_ids referenced by existing atoms on disk.
-        processed_raw_ids: set[str] = set()
-        for atom_path in self.processed_root.glob("*.md"):
-            try:
-                meta, _ = frontmatter.parse(atom_path.read_text(encoding="utf-8"))
-                if meta.extra and meta.extra.get("derived_from_raw"):
-                    processed_raw_ids.add(meta.extra["derived_from_raw"])
-            except Exception:
-                continue
-
+        # Collect raw_ids referenced by existing atom notes in the DB.
+        processed_raw_ids: set[str] = set(
+            self.session.exec(
+                select(Note.extra["derived_from_raw"].as_string()).where(
+                    Note.extra["derived_from_raw"].as_string().is_not(None)
+                )
+            ).all()
+        )
         if not processed_raw_ids:
             return 0
 
@@ -198,7 +195,7 @@ class Gardener:
                 self.session.add(
                     AtomRawProvenance(
                         raw_fk=raw.id,
-                        derived_note_id="backfill-from-disk",
+                        derived_note_id="backfill-from-notes",
                         gardener_version=GARDENER_VERSION,
                     )
                 )
@@ -253,7 +250,7 @@ class Gardener:
             )
             self.session.commit()
 
-        self._backfill_provenance_from_processed()
+        self._backfill_provenance_from_notes()
 
         raws = self._raws_needing_decomposition()
         if self.max_files_per_run > 0 and len(raws) > self.max_files_per_run:

--- a/projects/monolith/knowledge/gardener_test.py
+++ b/projects/monolith/knowledge/gardener_test.py
@@ -567,72 +567,67 @@ class TestIngestOneRecordsPendingProvenance:
         assert rows[0].gardener_version == GARDENER_VERSION
 
 
-class TestBackfillProvenanceFromProcessed:
-    def test_backfills_provenance_for_already_processed_raws(self, tmp_path, session):
-        """Raws whose atoms already exist on disk get sentinel provenance
+class TestBackfillProvenanceFromNotes:
+    def test_backfills_provenance_for_raws_linked_to_notes(self, tmp_path, session):
+        """Raws whose atoms exist in the notes table get sentinel provenance
         without calling Claude."""
         from knowledge.gardener import GARDENER_VERSION
-        from knowledge.models import AtomRawProvenance, RawInput
+        from knowledge.models import AtomRawProvenance, Note, RawInput
 
-        # Create a raw input row.
-        (tmp_path / "_raw" / "2026" / "04" / "09").mkdir(parents=True)
-        raw_path = "_raw/2026/04/09/r1-n.md"
-        (tmp_path / raw_path).write_text("Body.", encoding="utf-8")
         raw = RawInput(
             raw_id="r1",
-            path=raw_path,
+            path="_raw/2026/04/09/r1-n.md",
             source="vault-drop",
             content="Body.",
             content_hash="r1",
         )
+        atom = Note(
+            note_id="atom-1",
+            path="_processed/atom.md",
+            title="Atom",
+            content_hash="abc",
+            type="atom",
+            extra={"derived_from_raw": "r1"},
+        )
         session.add(raw)
+        session.add(atom)
         session.commit()
 
-        # Simulate a processed atom referencing this raw_id.
-        processed = tmp_path / "_processed"
-        processed.mkdir()
-        (processed / "atom.md").write_text(
-            "---\nid: atom-1\ntitle: Atom\ntype: atom\nderived_from_raw: r1\n---\nBody.\n",
-            encoding="utf-8",
-        )
-
         gardener = Gardener(vault_root=tmp_path, session=session)
-        count = gardener._backfill_provenance_from_processed()
+        count = gardener._backfill_provenance_from_notes()
 
         assert count == 1
         rows = session.exec(select(AtomRawProvenance)).all()
         assert len(rows) == 1
         assert rows[0].raw_fk == raw.id
-        assert rows[0].derived_note_id == "backfill-from-disk"
+        assert rows[0].derived_note_id == "backfill-from-notes"
         assert rows[0].gardener_version == GARDENER_VERSION
 
-    def test_skips_raws_without_matching_atoms(self, tmp_path, session):
-        """Raws with no matching atoms on disk are left for Claude."""
-        from knowledge.models import AtomRawProvenance, RawInput
+    def test_skips_raws_without_matching_notes(self, tmp_path, session):
+        """Raws with no matching notes in the DB are left for Claude."""
+        from knowledge.models import AtomRawProvenance, Note, RawInput
 
-        (tmp_path / "_raw" / "2026" / "04" / "09").mkdir(parents=True)
-        raw_path = "_raw/2026/04/09/r1-n.md"
-        (tmp_path / raw_path).write_text("Body.", encoding="utf-8")
         raw = RawInput(
             raw_id="r1",
-            path=raw_path,
+            path="_raw/2026/04/09/r1-n.md",
             source="vault-drop",
             content="Body.",
             content_hash="r1",
         )
+        atom = Note(
+            note_id="other",
+            path="_processed/other.md",
+            title="Other",
+            content_hash="xyz",
+            type="atom",
+            extra={"derived_from_raw": "r999"},
+        )
         session.add(raw)
+        session.add(atom)
         session.commit()
 
-        # Processed dir exists but has no atoms referencing r1.
-        processed = tmp_path / "_processed"
-        processed.mkdir()
-        (processed / "unrelated.md").write_text(
-            "---\nid: other\ntitle: Other\ntype: atom\nderived_from_raw: r999\n---\nBody.\n",
-            encoding="utf-8",
-        )
-
         gardener = Gardener(vault_root=tmp_path, session=session)
-        count = gardener._backfill_provenance_from_processed()
+        count = gardener._backfill_provenance_from_notes()
 
         assert count == 0
         assert session.exec(select(AtomRawProvenance)).all() == []


### PR DESCRIPTION
## Summary
- Replace `_backfill_provenance_from_processed()` (disk scan of `_processed/*.md`) with `_backfill_provenance_from_notes()` (DB query on `Note.extra->>'derived_from_raw'`)
- The disk-based approach was fragile — container filesystem doesn't persist across pod restarts, so it found nothing and ~360 raws were sent to Claude Sonnet each cycle just to hear "already decomposed"
- The DB query is deterministic and correctly marks already-linked raws with sentinel provenance rows

## Test plan
- [x] Updated `TestBackfillProvenanceFromProcessed` → `TestBackfillProvenanceFromNotes` with DB-backed test fixtures
- [ ] CI tests pass
- [ ] After rollout: verify gardener logs show `backfilled provenance for N already-processed raws` on first cycle, then 0 raws needing decomposition

🤖 Generated with [Claude Code](https://claude.com/claude-code)