### PR TITLE
fix(knowledge): gate handlers on obsidian sync readiness

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.31.20
+version: 0.31.21
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.31.19
+version: 0.31.20
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/obsidian_readiness_probe_test.sh
+++ b/projects/monolith/chart/obsidian_readiness_probe_test.sh
@@ -132,6 +132,16 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# Test 8: .sync-ready sentinel written to shared vault volume
+# ---------------------------------------------------------------------------
+echo "--- Test 8: .sync-ready sentinel written to shared vault volume ---"
+if grep -q '\.sync-ready' "$ENTRYPOINT"; then
+	pass "entrypoint.sh writes .sync-ready sentinel to vault volume"
+else
+	fail "entrypoint.sh does NOT write .sync-ready — knowledge handlers will never run!"
+fi
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 echo ""

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.31.19
+      targetRevision: 0.31.20
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.31.20
+      targetRevision: 0.31.21
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/knowledge/reconciler_coverage_test.py
+++ b/projects/monolith/knowledge/reconciler_coverage_test.py
@@ -12,8 +12,8 @@ Fills gaps identified in the coverage review:
   paths are exercised via mock injection.
 
 Note: the cold-start vault race (empty _processed/ while DB has notes) is handled
-by _wait_for_vault_sync() in main.py, which gates the scheduler from starting until
-the vault has populated. The reconciler itself does not guard against this case.
+by _vault_sync_ready() in service.py, which gates each handler from running until
+the obsidian sidecar writes .sync-ready to the shared vault volume.
 """
 
 from __future__ import annotations

--- a/projects/monolith/knowledge/service.py
+++ b/projects/monolith/knowledge/service.py
@@ -25,7 +25,14 @@ _TTL_SECS = 600
 _BACKUP_INTERVAL_SECS = 86400  # 24 hours
 _BACKUP_TTL_SECS = 3600  # 1 hour timeout
 _GIT_READY_SENTINEL = ".git-ready"
+_SYNC_READY_SENTINEL = ".sync-ready"
 _GIT_AUTHOR = b"vault-backup <vault-backup@monolith.local>"
+
+
+def _vault_sync_ready() -> bool:
+    """Return True if the obsidian sidecar has completed its initial sync."""
+    vault_root = Path(os.environ.get(VAULT_ROOT_ENV, DEFAULT_VAULT_ROOT))
+    return (vault_root / _SYNC_READY_SENTINEL).exists()
 
 
 async def clone_vault() -> None:
@@ -74,6 +81,9 @@ def _has_changes(vault_root: Path) -> bool:
 
 async def vault_backup_handler(session: Session) -> datetime | None:
     """Scheduler handler: commit and push vault changes to GitHub."""
+    if not _vault_sync_ready():
+        logger.info("knowledge.vault-backup: vault sync not ready, deferring")
+        return None
     vault_root = Path(os.environ.get(VAULT_ROOT_ENV, DEFAULT_VAULT_ROOT))
     if not (vault_root / ".git").exists():
         logger.info("knowledge.vault-backup: no .git dir, skipping")
@@ -105,6 +115,9 @@ async def vault_backup_handler(session: Session) -> datetime | None:
 
 async def garden_handler(session: Session) -> datetime | None:
     """Scheduler handler: run the knowledge vault gardener."""
+    if not _vault_sync_ready():
+        logger.info("knowledge.garden: vault sync not ready, deferring")
+        return None
     if not os.environ.get("CLAUDE_CODE_OAUTH_TOKEN"):
         logger.warning("knowledge.garden: CLAUDE_CODE_OAUTH_TOKEN not set, skipping")
         return None
@@ -143,6 +156,9 @@ async def garden_handler(session: Session) -> datetime | None:
 
 async def reconcile_handler(session: Session) -> datetime | None:
     """Scheduler handler: run the knowledge vault reconciler."""
+    if not _vault_sync_ready():
+        logger.info("knowledge.reconcile: vault sync not ready, deferring")
+        return None
     vault_root = Path(os.environ.get(VAULT_ROOT_ENV, DEFAULT_VAULT_ROOT))
     reconciler = Reconciler(
         store=KnowledgeStore(session=session),

--- a/projects/monolith/knowledge/service_coverage_test.py
+++ b/projects/monolith/knowledge/service_coverage_test.py
@@ -9,6 +9,13 @@ import pytest
 from knowledge import service
 
 
+@pytest.fixture(autouse=True)
+def _vault_sync_ready_by_default():
+    """Most handler tests assume the vault sync is complete."""
+    with patch("knowledge.service._vault_sync_ready", return_value=True):
+        yield
+
+
 class TestGardenHandlerExceptionPropagation:
     @pytest.mark.asyncio
     async def test_propagates_exception_from_gardener_run(self, monkeypatch, tmp_path):

--- a/projects/monolith/knowledge/service_test.py
+++ b/projects/monolith/knowledge/service_test.py
@@ -11,6 +11,9 @@ from knowledge.gardener import GardenStats
 from knowledge.reconciler import ReconcileStats
 from knowledge.service import garden_handler, on_startup
 
+# Save a reference before autouse fixture patches it.
+_real_vault_sync_ready = service._vault_sync_ready
+
 
 @pytest.fixture(autouse=True)
 def _vault_sync_ready_by_default():
@@ -500,10 +503,6 @@ class TestVaultSyncGate:
 
     def test_vault_sync_ready_checks_sentinel(self, monkeypatch, tmp_path):
         monkeypatch.setenv("VAULT_ROOT", str(tmp_path))
-        # Override the autouse fixture for this test
-        with patch.object(
-            service, "_vault_sync_ready", wraps=service._vault_sync_ready
-        ):
-            assert not service._vault_sync_ready()
-            (tmp_path / ".sync-ready").touch()
-            assert service._vault_sync_ready()
+        assert not _real_vault_sync_ready()
+        (tmp_path / ".sync-ready").touch()
+        assert _real_vault_sync_ready()

--- a/projects/monolith/knowledge/service_test.py
+++ b/projects/monolith/knowledge/service_test.py
@@ -12,6 +12,13 @@ from knowledge.reconciler import ReconcileStats
 from knowledge.service import garden_handler, on_startup
 
 
+@pytest.fixture(autouse=True)
+def _vault_sync_ready_by_default():
+    """Most handler tests assume the vault sync is complete."""
+    with patch("knowledge.service._vault_sync_ready", return_value=True):
+        yield
+
+
 class TestOnStartup:
     def test_registers_garden_and_reconcile_jobs(self):
         """on_startup registers garden, reconcile, and vault-backup jobs."""
@@ -456,3 +463,47 @@ class TestVaultBackupHandler:
         mock_push.assert_called_once_with(
             str(tmp_path), username="x-access-token", password="ghp_secret"
         )
+
+
+class TestVaultSyncGate:
+    """All knowledge handlers defer when the obsidian sidecar hasn't synced yet."""
+
+    @pytest.mark.asyncio
+    async def test_reconcile_defers_when_sync_not_ready(self, caplog):
+        with patch("knowledge.service._vault_sync_ready", return_value=False):
+            with caplog.at_level(logging.INFO, logger="knowledge.service"):
+                result = await service.reconcile_handler(MagicMock())
+        assert result is None
+        assert any(
+            "vault sync not ready" in m for m in [r.message for r in caplog.records]
+        )
+
+    @pytest.mark.asyncio
+    async def test_garden_defers_when_sync_not_ready(self, caplog):
+        with patch("knowledge.service._vault_sync_ready", return_value=False):
+            with caplog.at_level(logging.INFO, logger="knowledge.service"):
+                result = await service.garden_handler(MagicMock())
+        assert result is None
+        assert any(
+            "vault sync not ready" in m for m in [r.message for r in caplog.records]
+        )
+
+    @pytest.mark.asyncio
+    async def test_backup_defers_when_sync_not_ready(self, caplog):
+        with patch("knowledge.service._vault_sync_ready", return_value=False):
+            with caplog.at_level(logging.INFO, logger="knowledge.service"):
+                result = await service.vault_backup_handler(MagicMock())
+        assert result is None
+        assert any(
+            "vault sync not ready" in m for m in [r.message for r in caplog.records]
+        )
+
+    def test_vault_sync_ready_checks_sentinel(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("VAULT_ROOT", str(tmp_path))
+        # Override the autouse fixture for this test
+        with patch.object(
+            service, "_vault_sync_ready", wraps=service._vault_sync_ready
+        ):
+            assert not service._vault_sync_ready()
+            (tmp_path / ".sync-ready").touch()
+            assert service._vault_sync_ready()

--- a/projects/monolith/obsidian-image/entrypoint.sh
+++ b/projects/monolith/obsidian-image/entrypoint.sh
@@ -28,5 +28,6 @@ cd "$VAULT_PATH"
 # The readiness probe checks for /tmp/ready so the pod stays not-ready until
 # the initial vault download finishes.
 ob sync
+touch "$VAULT_PATH/.sync-ready"
 touch /tmp/ready
 exec ob sync --continuous


### PR DESCRIPTION
## Summary
- The vault is an `emptyDir` volume wiped on every pod restart
- The obsidian headless-sync sidecar re-populates it from cloud, but the knowledge reconciler was running before sync completed
- This caused the reconciler to see an empty `_processed/` directory and **mass-delete all indexed notes, embeddings, and graph edges from the database**
- Fix: sidecar now writes `.sync-ready` to the shared vault volume after initial `ob sync`; all three knowledge handlers (reconcile, garden, vault-backup) check for this sentinel and defer until it exists

## Test plan
- [x] Added `TestVaultSyncGate` class with tests for all three handlers deferring
- [x] Added sentinel existence test (`_vault_sync_ready()`)
- [x] Updated obsidian readiness probe test (Test 8: .sync-ready sentinel)
- [x] Existing handler tests pass via autouse `_vault_sync_ready_by_default` fixture
- [ ] CI passes
- [ ] After rollout: verify knowledge handlers log "vault sync not ready, deferring" during startup, then run normally after obsidian sync completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)