### PR TITLE
test(knowledge): add coverage for _has_changes and Gardener init

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.31.22
+version: 0.31.23
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.31.22
+      targetRevision: 0.31.23
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/knowledge/gardener_test.py
+++ b/projects/monolith/knowledge/gardener_test.py
@@ -778,6 +778,63 @@ class TestGardenerRunPhases:
         assert stats.ingested == 1
 
 
+class TestGardenerInit:
+    """Verify that Gardener.__init__() stores all constructor parameters correctly."""
+
+    def test_stores_vault_root_as_path(self, tmp_path):
+        """vault_root is stored as a Path object."""
+        gardener = Gardener(vault_root=tmp_path)
+        assert gardener.vault_root == Path(tmp_path)
+
+    def test_vault_root_string_is_coerced_to_path(self, tmp_path):
+        """A string vault_root is coerced to a Path by the constructor."""
+        gardener = Gardener(vault_root=str(tmp_path))
+        assert isinstance(gardener.vault_root, Path)
+        assert gardener.vault_root == Path(tmp_path)
+
+    def test_stores_max_files_per_run(self, tmp_path):
+        """max_files_per_run is stored as provided."""
+        gardener = Gardener(vault_root=tmp_path, max_files_per_run=5)
+        assert gardener.max_files_per_run == 5
+
+    def test_default_max_files_per_run(self, tmp_path):
+        """max_files_per_run defaults to 10 when not provided."""
+        gardener = Gardener(vault_root=tmp_path)
+        assert gardener.max_files_per_run == 10
+
+    def test_stores_claude_bin(self, tmp_path):
+        """claude_bin is stored as provided."""
+        gardener = Gardener(vault_root=tmp_path, claude_bin="/usr/local/bin/claude")
+        assert gardener.claude_bin == "/usr/local/bin/claude"
+
+    def test_default_claude_bin(self, tmp_path):
+        """claude_bin defaults to 'claude' when not provided."""
+        gardener = Gardener(vault_root=tmp_path)
+        assert gardener.claude_bin == "claude"
+
+    def test_stores_session(self, tmp_path, session):
+        """session is stored as provided."""
+        gardener = Gardener(vault_root=tmp_path, session=session)
+        assert gardener.session is session
+
+    def test_default_session_is_none(self, tmp_path):
+        """session defaults to None when not provided."""
+        gardener = Gardener(vault_root=tmp_path)
+        assert gardener.session is None
+
+    def test_processed_root_derived_from_vault_root(self, tmp_path):
+        """processed_root is derived as vault_root/_processed."""
+        gardener = Gardener(vault_root=tmp_path)
+        assert gardener.processed_root == tmp_path / "_processed"
+
+    def test_processed_root_uses_resolved_vault_root(self, tmp_path):
+        """processed_root is always relative to the stored vault_root Path."""
+        vault = tmp_path / "my-vault"
+        vault.mkdir()
+        gardener = Gardener(vault_root=vault)
+        assert gardener.processed_root == vault / "_processed"
+
+
 class TestResolvePendingProvenance:
     def test_resolves_note_id_to_atom_fk(self, tmp_path, session):
         from knowledge.gardener import GARDENER_VERSION

--- a/projects/monolith/knowledge/service_test.py
+++ b/projects/monolith/knowledge/service_test.py
@@ -506,3 +506,49 @@ class TestVaultSyncGate:
         assert not _real_vault_sync_ready()
         (tmp_path / ".sync-ready").touch()
         assert _real_vault_sync_ready()
+
+
+class TestHasChanges:
+    """Unit tests for the _has_changes(vault_root) helper.
+
+    The function delegates to dulwich porcelain.status() and returns True if
+    any staged, unstaged, or untracked changes are present.
+    """
+
+    def test_staged_add_returns_true(self, tmp_path):
+        """Staged (added) files are detected as changes."""
+        with patch(
+            "knowledge.service.porcelain.status",
+            return_value=_dirty_status(staged_add=[b"new-note.md"]),
+        ):
+            assert service._has_changes(tmp_path) is True
+
+    def test_unstaged_changes_returns_true(self, tmp_path):
+        """Unstaged modifications are detected as changes."""
+        with patch(
+            "knowledge.service.porcelain.status",
+            return_value=_dirty_status(unstaged=[b"modified-note.md"]),
+        ):
+            assert service._has_changes(tmp_path) is True
+
+    def test_untracked_files_returns_true(self, tmp_path):
+        """Untracked files are detected as changes."""
+        with patch(
+            "knowledge.service.porcelain.status",
+            return_value=_dirty_status(untracked=["untracked-note.md"]),
+        ):
+            assert service._has_changes(tmp_path) is True
+
+    def test_clean_tree_returns_false(self, tmp_path):
+        """A clean working tree with no staged, unstaged, or untracked changes returns False."""
+        with patch(
+            "knowledge.service.porcelain.status",
+            return_value=_empty_status(),
+        ):
+            assert service._has_changes(tmp_path) is False
+
+    def test_passes_vault_root_as_string_to_porcelain(self, tmp_path):
+        """porcelain.status() is called with the vault_root as a string."""
+        with patch("knowledge.service.porcelain.status", return_value=_empty_status()) as mock_status:
+            service._has_changes(tmp_path)
+        mock_status.assert_called_once_with(str(tmp_path))

--- a/projects/monolith/knowledge/service_test.py
+++ b/projects/monolith/knowledge/service_test.py
@@ -549,6 +549,8 @@ class TestHasChanges:
 
     def test_passes_vault_root_as_string_to_porcelain(self, tmp_path):
         """porcelain.status() is called with the vault_root as a string."""
-        with patch("knowledge.service.porcelain.status", return_value=_empty_status()) as mock_status:
+        with patch(
+            "knowledge.service.porcelain.status", return_value=_empty_status()
+        ) as mock_status:
             service._has_changes(tmp_path)
         mock_status.assert_called_once_with(str(tmp_path))


### PR DESCRIPTION
## Summary

- Add `TestHasChanges` class to `service_test.py` covering all four branches of `_has_changes()`: staged adds detected, unstaged modifications detected, untracked files detected, and clean tree returns `False`. Includes a fifth test verifying `porcelain.status` is invoked with `str(vault_root)`.
- Add `TestGardenerInit` class to `gardener_test.py` (10 tests) verifying `Gardener.__init__` stores `vault_root` (coercing strings to `Path`), `max_files_per_run` (custom and default of 10), `claude_bin` (custom and default of `"claude"`), `session` (custom and default of `None`), and that `processed_root` is always derived as `vault_root / "_processed"`.

## Test plan

- [x] `TestHasChanges` — staged add → `True`
- [x] `TestHasChanges` — unstaged change → `True`
- [x] `TestHasChanges` — untracked file → `True`
- [x] `TestHasChanges` — clean tree → `False`
- [x] `TestHasChanges` — `porcelain.status` called with `str(vault_root)`
- [x] `TestGardenerInit` — `vault_root` stored as `Path`
- [x] `TestGardenerInit` — string `vault_root` coerced to `Path`
- [x] `TestGardenerInit` — custom `max_files_per_run` stored
- [x] `TestGardenerInit` — default `max_files_per_run` is 10
- [x] `TestGardenerInit` — custom `claude_bin` stored
- [x] `TestGardenerInit` — default `claude_bin` is `"claude"`
- [x] `TestGardenerInit` — custom `session` stored
- [x] `TestGardenerInit` — default `session` is `None`
- [x] `TestGardenerInit` — `processed_root` == `vault_root/_processed`
- [x] `TestGardenerInit` — `processed_root` uses resolved vault path

🤖 Generated with [Claude Code](https://claude.com/claude-code)