### PR TITLE
fix(knowledge): grandfather pre-existing raws + 15m backup interval

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.32.3
+version: 0.32.4
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.32.2
+version: 0.32.3
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.32.2
+      targetRevision: 0.32.3
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.32.3
+      targetRevision: 0.32.4
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/knowledge/gardener.py
+++ b/projects/monolith/knowledge/gardener.py
@@ -224,6 +224,10 @@ class Gardener:
         if resolved_count and self.session is not None:
             self.session.commit()
 
+        # Grandfather pre-existing raws BEFORE move/reconcile so that newly
+        # reconciled raws are still eligible for decomposition.
+        self._grandfather_untracked_raws()
+
         now = datetime.now(timezone.utc)
         move_stats = move_phase(vault_root=self.vault_root, now=now)
 
@@ -233,8 +237,6 @@ class Gardener:
                 vault_root=self.vault_root, session=self.session
             )
             self.session.commit()
-
-        self._grandfather_untracked_raws()
 
         raws = self._raws_needing_decomposition()
         if self.max_files_per_run > 0 and len(raws) > self.max_files_per_run:

--- a/projects/monolith/knowledge/gardener.py
+++ b/projects/monolith/knowledge/gardener.py
@@ -155,29 +155,16 @@ class Gardener:
             resolved += 1
         return resolved
 
-    def _backfill_provenance_from_notes(self) -> int:
-        """Bulk-insert sentinel provenance for raws already linked to notes.
+    def _grandfather_untracked_raws(self) -> int:
+        """Mark all raws without provenance as pre-migration.
 
-        Queries the notes table for derived_from_raw JSONB values and creates
-        provenance rows for any matching raws that lack them.  This is
-        deterministic (DB-only, no disk scan) and avoids sending
-        already-decomposed raws to Claude.
+        All existing raws predate the provenance system — they were already
+        decomposed before tracking was added.  Inserting pre-migration
+        sentinels prevents the gardener from sending them to Claude.
         """
         if self.session is None:
             return 0
 
-        # Collect raw_ids referenced by existing atom notes in the DB.
-        processed_raw_ids: set[str] = set(
-            self.session.exec(
-                select(Note.extra["derived_from_raw"].as_string()).where(
-                    Note.extra["derived_from_raw"].as_string().is_not(None)
-                )
-            ).all()
-        )
-        if not processed_raw_ids:
-            return 0
-
-        # Find raws that have no provenance at all.
         has_prov = (
             select(AtomRawProvenance.raw_fk)
             .where(AtomRawProvenance.raw_fk.is_not(None))
@@ -189,25 +176,22 @@ class Gardener:
             ).all()
         )
 
-        backfilled = 0
         for raw in unhandled:
-            if raw.raw_id in processed_raw_ids:
-                self.session.add(
-                    AtomRawProvenance(
-                        raw_fk=raw.id,
-                        derived_note_id="backfill-from-notes",
-                        gardener_version=GARDENER_VERSION,
-                    )
+            self.session.add(
+                AtomRawProvenance(
+                    raw_fk=raw.id,
+                    derived_note_id="pre-migration",
+                    gardener_version="pre-migration",
                 )
-                backfilled += 1
+            )
 
-        if backfilled:
+        if unhandled:
             self.session.commit()
             logger.info(
-                "gardener: backfilled provenance for %d already-processed raws",
-                backfilled,
+                "gardener: grandfathered %d pre-migration raws",
+                len(unhandled),
             )
-        return backfilled
+        return len(unhandled)
 
     def _raws_needing_decomposition(self) -> list[RawInput]:
         """Return raws that have no current-version provenance and no sentinel."""
@@ -250,7 +234,7 @@ class Gardener:
             )
             self.session.commit()
 
-        self._backfill_provenance_from_notes()
+        self._grandfather_untracked_raws()
 
         raws = self._raws_needing_decomposition()
         if self.max_files_per_run > 0 and len(raws) > self.max_files_per_run:

--- a/projects/monolith/knowledge/gardener_coverage_test.py
+++ b/projects/monolith/knowledge/gardener_coverage_test.py
@@ -10,7 +10,7 @@ from sqlmodel import Session, SQLModel, create_engine
 from sqlmodel.pool import StaticPool
 
 from knowledge.gardener import Gardener
-from knowledge.models import RawInput
+from knowledge.models import AtomRawProvenance, RawInput
 
 
 def _write(tmp_path: Path, rel: str, content: str) -> None:
@@ -67,6 +67,16 @@ class TestIngestOneFileIOError:
         )
         session.add(raw)
         session.commit()
+        # Add outdated provenance so _grandfather_untracked_raws skips this
+        # raw but _raws_needing_decomposition still picks it up.
+        session.add(
+            AtomRawProvenance(
+                raw_fk=raw.id,
+                derived_note_id="outdated",
+                gardener_version="v0-outdated",
+            )
+        )
+        session.commit()
 
         gardener = Gardener(vault_root=tmp_path, session=session)
         stats = await gardener.run()
@@ -94,6 +104,16 @@ class TestIngestOneSubprocessFailure:
             content_hash="abc1",
         )
         session.add(raw)
+        session.commit()
+        # Add outdated provenance so _grandfather_untracked_raws skips this
+        # raw but _raws_needing_decomposition still picks it up.
+        session.add(
+            AtomRawProvenance(
+                raw_fk=raw.id,
+                derived_note_id="outdated",
+                gardener_version="v0-outdated",
+            )
+        )
         session.commit()
 
         proc_mock = AsyncMock()

--- a/projects/monolith/knowledge/gardener_test.py
+++ b/projects/monolith/knowledge/gardener_test.py
@@ -567,70 +567,65 @@ class TestIngestOneRecordsPendingProvenance:
         assert rows[0].gardener_version == GARDENER_VERSION
 
 
-class TestBackfillProvenanceFromNotes:
-    def test_backfills_provenance_for_raws_linked_to_notes(self, tmp_path, session):
-        """Raws whose atoms exist in the notes table get sentinel provenance
-        without calling Claude."""
-        from knowledge.gardener import GARDENER_VERSION
-        from knowledge.models import AtomRawProvenance, Note, RawInput
+class TestGrandfatherUntrackedRaws:
+    def test_grandfathers_all_raws_without_provenance(self, tmp_path, session):
+        """All raws without provenance get pre-migration sentinels."""
+        from knowledge.models import AtomRawProvenance, RawInput
 
-        raw = RawInput(
+        r1 = RawInput(
             raw_id="r1",
-            path="_raw/2026/04/09/r1-n.md",
+            path="_raw/r1.md",
             source="vault-drop",
-            content="Body.",
+            content="A.",
             content_hash="r1",
         )
-        atom = Note(
-            note_id="atom-1",
-            path="_processed/atom.md",
-            title="Atom",
-            content_hash="abc",
-            type="atom",
-            extra={"derived_from_raw": "r1"},
+        r2 = RawInput(
+            raw_id="r2",
+            path="_raw/r2.md",
+            source="vault-drop",
+            content="B.",
+            content_hash="r2",
         )
-        session.add(raw)
-        session.add(atom)
+        session.add(r1)
+        session.add(r2)
         session.commit()
 
         gardener = Gardener(vault_root=tmp_path, session=session)
-        count = gardener._backfill_provenance_from_notes()
+        count = gardener._grandfather_untracked_raws()
 
-        assert count == 1
+        assert count == 2
         rows = session.exec(select(AtomRawProvenance)).all()
-        assert len(rows) == 1
-        assert rows[0].raw_fk == raw.id
-        assert rows[0].derived_note_id == "backfill-from-notes"
-        assert rows[0].gardener_version == GARDENER_VERSION
+        assert len(rows) == 2
+        assert all(r.gardener_version == "pre-migration" for r in rows)
+        assert all(r.derived_note_id == "pre-migration" for r in rows)
 
-    def test_skips_raws_without_matching_notes(self, tmp_path, session):
-        """Raws with no matching notes in the DB are left for Claude."""
-        from knowledge.models import AtomRawProvenance, Note, RawInput
+    def test_skips_raws_that_already_have_provenance(self, tmp_path, session):
+        """Raws with existing provenance are not grandfathered."""
+        from knowledge.gardener import GARDENER_VERSION
+        from knowledge.models import AtomRawProvenance, RawInput
 
         raw = RawInput(
             raw_id="r1",
-            path="_raw/2026/04/09/r1-n.md",
+            path="_raw/r1.md",
             source="vault-drop",
-            content="Body.",
+            content="A.",
             content_hash="r1",
         )
-        atom = Note(
-            note_id="other",
-            path="_processed/other.md",
-            title="Other",
-            content_hash="xyz",
-            type="atom",
-            extra={"derived_from_raw": "r999"},
-        )
         session.add(raw)
-        session.add(atom)
+        session.commit()
+        session.add(
+            AtomRawProvenance(
+                raw_fk=raw.id,
+                derived_note_id="some-note",
+                gardener_version=GARDENER_VERSION,
+            )
+        )
         session.commit()
 
         gardener = Gardener(vault_root=tmp_path, session=session)
-        count = gardener._backfill_provenance_from_notes()
+        count = gardener._grandfather_untracked_raws()
 
         assert count == 0
-        assert session.exec(select(AtomRawProvenance)).all() == []
 
     def test_returns_zero_when_session_is_none(self, tmp_path):
         """Gardener with session=None returns 0 without touching the DB."""

--- a/projects/monolith/knowledge/gardener_test.py
+++ b/projects/monolith/knowledge/gardener_test.py
@@ -630,83 +630,8 @@ class TestGrandfatherUntrackedRaws:
     def test_returns_zero_when_session_is_none(self, tmp_path):
         """Gardener with session=None returns 0 without touching the DB."""
         gardener = Gardener(vault_root=tmp_path, session=None)
-        count = gardener._backfill_provenance_from_notes()
+        count = gardener._grandfather_untracked_raws()
         assert count == 0
-
-    def test_returns_zero_when_no_notes_have_derived_from_raw(self, tmp_path, session):
-        """When no Note rows carry derived_from_raw in their extra JSON,
-        the method returns 0 and creates no provenance rows."""
-        from knowledge.models import AtomRawProvenance, Note, RawInput
-
-        raw = RawInput(
-            raw_id="r1",
-            path="_raw/2026/04/09/r1-n.md",
-            source="vault-drop",
-            content="Body.",
-            content_hash="r1",
-        )
-        # Note with no derived_from_raw field in extra
-        note = Note(
-            note_id="orphan",
-            path="_processed/orphan.md",
-            title="Orphan Note",
-            content_hash="abc",
-            type="atom",
-            extra={"tags": ["misc"]},
-        )
-        session.add(raw)
-        session.add(note)
-        session.commit()
-
-        gardener = Gardener(vault_root=tmp_path, session=session)
-        count = gardener._backfill_provenance_from_notes()
-
-        assert count == 0
-        assert session.exec(select(AtomRawProvenance)).all() == []
-
-    def test_skips_raws_that_already_have_provenance(self, tmp_path, session):
-        """If a raw already has an AtomRawProvenance row, it must NOT be
-        backfilled again even if a Note references its raw_id."""
-        from knowledge.gardener import GARDENER_VERSION
-        from knowledge.models import AtomRawProvenance, Note, RawInput
-
-        raw = RawInput(
-            raw_id="r1",
-            path="_raw/2026/04/09/r1-n.md",
-            source="vault-drop",
-            content="Body.",
-            content_hash="r1",
-        )
-        session.add(raw)
-        session.flush()
-        # Pre-existing provenance for this raw
-        session.add(
-            AtomRawProvenance(
-                raw_fk=raw.id,
-                derived_note_id="already-recorded",
-                gardener_version=GARDENER_VERSION,
-            )
-        )
-        # A note that references the same raw_id — backfill should ignore it
-        atom = Note(
-            note_id="atom-dup",
-            path="_processed/atom-dup.md",
-            title="Atom Dup",
-            content_hash="dup",
-            type="atom",
-            extra={"derived_from_raw": "r1"},
-        )
-        session.add(atom)
-        session.commit()
-
-        gardener = Gardener(vault_root=tmp_path, session=session)
-        count = gardener._backfill_provenance_from_notes()
-
-        assert count == 0
-        # Only the original provenance row must exist; no duplicate created
-        rows = session.exec(select(AtomRawProvenance)).all()
-        assert len(rows) == 1
-        assert rows[0].derived_note_id == "already-recorded"
 
 
 class TestIngestOneNoNoteSentinel:

--- a/projects/monolith/knowledge/knowledge_fixes_coverage_test.py
+++ b/projects/monolith/knowledge/knowledge_fixes_coverage_test.py
@@ -677,48 +677,34 @@ class TestGrandfatherRawsBadFrontmatter:
 
 
 # ---------------------------------------------------------------------------
-# gardener.py – _backfill_provenance_from_notes
+# gardener.py – _grandfather_untracked_raws
 # ---------------------------------------------------------------------------
 
 
-class TestBackfillProvenanceFromNotes:
-    """_backfill_provenance_from_notes inserts sentinel provenance rows for
-    raws that are referenced by existing atom notes via derived_from_raw but
-    have no provenance row yet."""
+class TestGrandfatherUntrackedRawsCoverage:
+    """_grandfather_untracked_raws marks all raws without provenance as
+    pre-migration so they are not sent to Claude for decomposition."""
 
     def test_returns_zero_when_session_is_none(self, tmp_path):
         """Returns 0 immediately when session is None."""
         from knowledge.gardener import Gardener
 
         gardener = Gardener(vault_root=tmp_path, session=None)
-        result = gardener._backfill_provenance_from_notes()
+        result = gardener._grandfather_untracked_raws()
         assert result == 0
 
-    def test_returns_zero_when_no_derived_from_raw_notes(self, tmp_path, session):
-        """Returns 0 when no notes have a derived_from_raw extra field."""
+    def test_returns_zero_when_no_raws_in_db(self, tmp_path, session):
+        """Returns 0 when no RawInput rows exist."""
         from knowledge.gardener import Gardener
 
-        # Add an atom note without derived_from_raw
-        note = Note(
-            note_id="no-derived",
-            path="_processed/no-derived.md",
-            title="No Derived",
-            content_hash="h1",
-            type="atom",
-        )
-        session.add(note)
-        session.commit()
-
         gardener = Gardener(vault_root=tmp_path, session=session)
-        result = gardener._backfill_provenance_from_notes()
+        result = gardener._grandfather_untracked_raws()
         assert result == 0
 
-    def test_inserts_sentinel_for_raw_referenced_by_note(self, tmp_path, session):
-        """When an atom note references a raw_id via derived_from_raw and that
-        raw has no provenance row, a sentinel provenance row is inserted."""
-        from knowledge.gardener import Gardener, GARDENER_VERSION
+    def test_grandfathers_raw_without_provenance(self, tmp_path, session):
+        """A raw with no provenance gets a pre-migration sentinel."""
+        from knowledge.gardener import Gardener
 
-        # Create a raw input row
         raw = RawInput(
             raw_id="my-raw-id",
             path="_raw/2026/04/10/abc1-test.md",
@@ -729,34 +715,21 @@ class TestBackfillProvenanceFromNotes:
         session.add(raw)
         session.commit()
 
-        # Create an atom note that references the raw_id
-        note = Note(
-            note_id="my-atom",
-            path="_processed/my-atom.md",
-            title="My Atom",
-            content_hash="h2",
-            type="atom",
-            extra={"derived_from_raw": "my-raw-id"},
-        )
-        session.add(note)
-        session.commit()
-
         gardener = Gardener(vault_root=tmp_path, session=session)
-        result = gardener._backfill_provenance_from_notes()
+        result = gardener._grandfather_untracked_raws()
 
         assert result == 1
 
-        # A sentinel provenance row should now exist
         prov_rows = session.exec(
             select(AtomRawProvenance).where(AtomRawProvenance.raw_fk == raw.id)
         ).all()
         assert len(prov_rows) == 1
-        assert prov_rows[0].derived_note_id == "backfill-from-notes"
-        assert prov_rows[0].gardener_version == GARDENER_VERSION
+        assert prov_rows[0].derived_note_id == "pre-migration"
+        assert prov_rows[0].gardener_version == "pre-migration"
 
     def test_skips_raws_that_already_have_provenance(self, tmp_path, session):
         """Does not insert a duplicate sentinel if the raw already has a
-        provenance row (regardless of derived_note_id value)."""
+        provenance row."""
         from knowledge.gardener import Gardener, GARDENER_VERSION
 
         raw = RawInput(
@@ -769,7 +742,6 @@ class TestBackfillProvenanceFromNotes:
         session.add(raw)
         session.commit()
 
-        # Pre-existing provenance row for this raw
         prov = AtomRawProvenance(
             raw_fk=raw.id,
             derived_note_id="already-done",
@@ -778,50 +750,15 @@ class TestBackfillProvenanceFromNotes:
         session.add(prov)
         session.commit()
 
-        # An atom note that references this raw_id
-        note = Note(
-            note_id="another-atom",
-            path="_processed/another-atom.md",
-            title="Another Atom",
-            content_hash="h4",
-            type="atom",
-            extra={"derived_from_raw": "handled-raw"},
-        )
-        session.add(note)
-        session.commit()
-
         gardener = Gardener(vault_root=tmp_path, session=session)
-        result = gardener._backfill_provenance_from_notes()
+        result = gardener._grandfather_untracked_raws()
 
-        # Should be 0 — the raw already has provenance, nothing to backfill
         assert result == 0
 
-        # Confirm no additional provenance rows were added
         prov_rows = session.exec(
             select(AtomRawProvenance).where(AtomRawProvenance.raw_fk == raw.id)
         ).all()
         assert len(prov_rows) == 1
-
-    def test_returns_zero_when_no_raw_inputs_in_db(self, tmp_path, session):
-        """Returns 0 when derived_from_raw notes exist but no matching RawInput rows."""
-        from knowledge.gardener import Gardener
-
-        # Note references a raw_id that doesn't exist in raw_inputs
-        note = Note(
-            note_id="orphan-atom",
-            path="_processed/orphan.md",
-            title="Orphan",
-            content_hash="h5",
-            type="atom",
-            extra={"derived_from_raw": "nonexistent-raw-id"},
-        )
-        session.add(note)
-        session.commit()
-
-        gardener = Gardener(vault_root=tmp_path, session=session)
-        result = gardener._backfill_provenance_from_notes()
-        # No RawInput row with raw_id "nonexistent-raw-id" → nothing to backfill
-        assert result == 0
 
 
 # ---------------------------------------------------------------------------

--- a/projects/monolith/knowledge/service.py
+++ b/projects/monolith/knowledge/service.py
@@ -22,8 +22,8 @@ DEFAULT_VAULT_ROOT = "/vault"
 # a job stale after ttl_secs).
 _INTERVAL_SECS = 300
 _TTL_SECS = 600
-_BACKUP_INTERVAL_SECS = 86400  # 24 hours
-_BACKUP_TTL_SECS = 3600  # 1 hour timeout
+_BACKUP_INTERVAL_SECS = 900  # 15 minutes
+_BACKUP_TTL_SECS = 600  # 10 minute timeout
 _INGEST_INTERVAL_SECS = 300
 _INGEST_TTL_SECS = 600
 _GIT_READY_SENTINEL = ".git-ready"


### PR DESCRIPTION
## Summary
- Replace `_backfill_provenance_from_notes()` with `_grandfather_untracked_raws()` — marks ALL raws without provenance as `pre-migration` instead of trying to match them to notes via `derived_from_raw` (only 260/842 notes have that field)
- This stops the gardener from sending ~312 raws to Claude Sonnet each cycle just to hear "already decomposed" and editing files that sync back everywhere
- Reduce vault git backup interval from 24h to 15m — fresher backups mean the git clone on pod restart has more recent files, reducing the sync window

## Test plan
- [x] `TestGrandfatherUntrackedRaws` covers both paths (grandfathers untracked, skips tracked)
- [ ] CI passes
- [ ] After rollout: gardener logs show "grandfathered N pre-migration raws" once, then 0 raws needing decomposition

🤖 Generated with [Claude Code](https://claude.com/claude-code)