### PR TITLE
test(obsidian-vault): add unit tests for vault MCP app modules

### DIFF
--- a/projects/obsidian_vault/vault_mcp/tests/chunker_test.py
+++ b/projects/obsidian_vault/vault_mcp/tests/chunker_test.py
@@ -85,3 +85,53 @@ class TestChunkMarkdown:
             title="hello.md",
         )
         assert chunks[0]["title"] == "hello.md"
+
+    def test_h4_header_not_a_split_boundary(self):
+        """H4+ headers are NOT section boundaries — they stay in the parent body."""
+        content = "# Main\n\nIntro body.\n\n#### Detail\n\nDetail body."
+        chunks = chunk_markdown(
+            content=content,
+            content_hash="h4test",
+            source_url="vault://h4.md",
+            title="h4.md",
+        )
+        # h4 never splits; everything under "# Main" is one section
+        assert len(chunks) == 1
+        assert chunks[0]["section_header"] == "# Main"
+        assert "#### Detail" in chunks[0]["chunk_text"]
+        assert "Detail body." in chunks[0]["chunk_text"]
+
+    def test_chunk_indices_are_sequential_starting_at_zero(self):
+        """chunk_index is sequential, starting at 0, across all output chunks."""
+        content = "# A\n\nSection A.\n\n## B\n\nSection B.\n\n### C\n\nSection C."
+        chunks = chunk_markdown(
+            content=content,
+            content_hash="seq",
+            source_url="vault://seq.md",
+            title="seq.md",
+        )
+        indices = [c["chunk_index"] for c in chunks]
+        assert indices == list(range(len(chunks)))
+
+    def test_whitespace_only_content_returns_empty(self):
+        """Content that is only whitespace/newlines returns an empty list."""
+        chunks = chunk_markdown(
+            content="   \n\n\t  \n",
+            content_hash="ws",
+            source_url="vault://ws.md",
+            title="ws.md",
+        )
+        assert chunks == []
+
+    def test_all_chunk_payload_keys_present(self):
+        """Every returned chunk contains all six required ChunkPayload keys."""
+        chunks = chunk_markdown(
+            content="# Key Test\n\nBody text for key coverage.",
+            content_hash="keys",
+            source_url="vault://keys.md",
+            title="keys.md",
+        )
+        assert len(chunks) >= 1
+        required = {"content_hash", "chunk_index", "chunk_text", "section_header", "source_url", "title"}
+        for chunk in chunks:
+            assert required == set(chunk.keys())

--- a/projects/obsidian_vault/vault_mcp/tests/chunker_test.py
+++ b/projects/obsidian_vault/vault_mcp/tests/chunker_test.py
@@ -132,6 +132,13 @@ class TestChunkMarkdown:
             title="keys.md",
         )
         assert len(chunks) >= 1
-        required = {"content_hash", "chunk_index", "chunk_text", "section_header", "source_url", "title"}
+        required = {
+            "content_hash",
+            "chunk_index",
+            "chunk_text",
+            "section_header",
+            "source_url",
+            "title",
+        }
         for chunk in chunks:
             assert required == set(chunk.keys())

--- a/projects/obsidian_vault/vault_mcp/tests/embedder_test.py
+++ b/projects/obsidian_vault/vault_mcp/tests/embedder_test.py
@@ -41,3 +41,35 @@ class TestVaultEmbedder:
         ):
             embedder = VaultEmbedder(model="test-model", cache_dir="/tmp/cache")
         assert embedder.dimension == 768
+
+    def test_embed_batch_size_is_32(self):
+        """EMBED_BATCH_SIZE class constant must be 32 for CPU safety."""
+        mock_model = MagicMock()
+        with patch(
+            "projects.obsidian_vault.vault_mcp.app.embedder.TextEmbedding",
+            return_value=mock_model,
+        ):
+            embedder = VaultEmbedder(model="test-model", cache_dir="/tmp/cache")
+        assert embedder.EMBED_BATCH_SIZE == 32
+
+    def test_embed_initialises_with_single_thread(self):
+        """TextEmbedding must be initialised with threads=1 for CPU safety."""
+        with patch(
+            "projects.obsidian_vault.vault_mcp.app.embedder.TextEmbedding"
+        ) as mock_cls:
+            mock_cls.return_value = MagicMock()
+            VaultEmbedder(model="test-model", cache_dir="/tmp/cache")
+        _, kwargs = mock_cls.call_args
+        assert kwargs.get("threads") == 1
+
+    def test_embed_returns_python_lists(self):
+        """embed() must return plain Python lists, not numpy arrays."""
+        mock_model = MagicMock()
+        mock_model.embed.return_value = iter([np.full(768, 0.5)])
+        with patch(
+            "projects.obsidian_vault.vault_mcp.app.embedder.TextEmbedding",
+            return_value=mock_model,
+        ):
+            embedder = VaultEmbedder(model="test-model", cache_dir="/tmp/cache")
+        result = embedder.embed(["text"])
+        assert isinstance(result[0], list)

--- a/projects/obsidian_vault/vault_mcp/tests/qdrant_client_test.py
+++ b/projects/obsidian_vault/vault_mcp/tests/qdrant_client_test.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import uuid
 from unittest.mock import AsyncMock, patch
 
 import httpx
@@ -13,6 +14,22 @@ from projects.obsidian_vault.vault_mcp.app.qdrant_client import QdrantClient
 @pytest.fixture
 def qdrant():
     return QdrantClient(url="http://localhost:6333", collection="test_collection")
+
+
+class TestQdrantClientInit:
+    def test_trailing_slash_stripped_from_url(self):
+        """URL with trailing slash is normalised on construction."""
+        client = QdrantClient(url="http://qdrant:6333/", collection="vault")
+        assert not client._url.endswith("/")
+        assert client._url == "http://qdrant:6333"
+
+    def test_url_without_trailing_slash_unchanged(self):
+        client = QdrantClient(url="http://qdrant:6333", collection="vault")
+        assert client._url == "http://qdrant:6333"
+
+    def test_collection_name_stored(self):
+        client = QdrantClient(url="http://localhost:6333", collection="my_notes")
+        assert client._collection == "my_notes"
 
 
 def _mock_response(status_code: int = 200, json: dict | None = None) -> httpx.Response:
@@ -155,3 +172,73 @@ class TestGetIndexedSources:
         with patch(_PATCH_TARGET, return_value=mock):
             result = await qdrant.get_indexed_sources()
         assert result == {"vault://a.md": "hash_a", "vault://b.md": "hash_b"}
+
+    @pytest.mark.asyncio
+    async def test_empty_collection_returns_empty_dict(self, qdrant):
+        """get_indexed_sources returns {} when no points exist."""
+        mock = _mock_async_client(
+            post=_mock_response(
+                200,
+                {"result": {"points": [], "next_page_offset": None}},
+            ),
+        )
+        with patch(_PATCH_TARGET, return_value=mock):
+            result = await qdrant.get_indexed_sources()
+        assert result == {}
+
+
+class TestUpsertPointId:
+    @pytest.mark.asyncio
+    async def test_point_id_is_uuid_string(self, qdrant):
+        """upsert_chunks generates a UUID string as the point ID."""
+        captured: list[dict] = []
+
+        async def capture_put(url, *, json):
+            captured.extend(json["points"])
+            return _mock_response(200)
+
+        mock = _mock_async_client()
+        mock.put.side_effect = capture_put
+        chunk = {
+            "content_hash": "deadbeef",
+            "chunk_index": 0,
+            "chunk_text": "hello",
+            "section_header": "# Title",
+            "source_url": "vault://note.md",
+            "title": "note.md",
+        }
+        with patch(_PATCH_TARGET, return_value=mock):
+            await qdrant.upsert_chunks([chunk], [[0.1] * 768])
+        assert len(captured) == 1
+        # Must be parseable as a UUID
+        parsed = uuid.UUID(captured[0]["id"])
+        assert parsed.version == 5
+
+    @pytest.mark.asyncio
+    async def test_upsert_includes_all_payload_fields(self, qdrant):
+        """upsert_chunks stores all six ChunkPayload fields in the point payload."""
+        captured: list[dict] = []
+
+        async def capture_put(url, *, json):
+            captured.extend(json["points"])
+            return _mock_response(200)
+
+        mock = _mock_async_client()
+        mock.put.side_effect = capture_put
+        chunk = {
+            "content_hash": "abc",
+            "chunk_index": 2,
+            "chunk_text": "some text",
+            "section_header": "## Section",
+            "source_url": "vault://doc.md",
+            "title": "doc.md",
+        }
+        with patch(_PATCH_TARGET, return_value=mock):
+            await qdrant.upsert_chunks([chunk], [[0.0] * 768])
+        payload = captured[0]["payload"]
+        assert payload["content_hash"] == "abc"
+        assert payload["chunk_index"] == 2
+        assert payload["chunk_text"] == "some text"
+        assert payload["section_header"] == "## Section"
+        assert payload["source_url"] == "vault://doc.md"
+        assert payload["title"] == "doc.md"

--- a/projects/obsidian_vault/vault_mcp/tests/reconciler_test.py
+++ b/projects/obsidian_vault/vault_mcp/tests/reconciler_test.py
@@ -180,9 +180,9 @@ class TestReconcile:
         """run() processes new, changed, and deleted files in one cycle."""
         note1_hash = _hash((vault_dir / "note1.md").read_text())
         mock_qdrant.get_indexed_sources.return_value = {
-            "vault://note1.md": note1_hash,    # unchanged
+            "vault://note1.md": note1_hash,  # unchanged
             "vault://note2.md": "stale_hash",  # changed
-            "vault://ghost.md": "old_hash",    # deleted (not on disk)
+            "vault://ghost.md": "old_hash",  # deleted (not on disk)
         }
         reconciler = VaultReconciler(
             vault_path=str(vault_dir), embedder=mock_embedder, qdrant=mock_qdrant

--- a/projects/obsidian_vault/vault_mcp/tests/reconciler_test.py
+++ b/projects/obsidian_vault/vault_mcp/tests/reconciler_test.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+import re
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -70,6 +71,27 @@ class TestWalkVault:
         files = reconciler._walk_vault()
         assert "vault://_archive/old.md" in files
 
+    def test_hash_values_are_sha256_hex(self, vault_dir, mock_qdrant, mock_embedder):
+        """_walk_vault produces 64-character lowercase hex SHA-256 digests."""
+        reconciler = VaultReconciler(
+            vault_path=str(vault_dir), embedder=mock_embedder, qdrant=mock_qdrant
+        )
+        files = reconciler._walk_vault()
+        sha256_pattern = re.compile(r"^[0-9a-f]{64}$")
+        for source_url, content_hash in files.items():
+            assert sha256_pattern.match(content_hash), (
+                f"Hash for {source_url!r} is not a 64-char hex string: {content_hash!r}"
+            )
+
+    def test_source_urls_use_vault_scheme(self, vault_dir, mock_qdrant, mock_embedder):
+        """All source URLs returned by _walk_vault use the vault:// scheme."""
+        reconciler = VaultReconciler(
+            vault_path=str(vault_dir), embedder=mock_embedder, qdrant=mock_qdrant
+        )
+        files = reconciler._walk_vault()
+        for key in files:
+            assert key.startswith("vault://"), f"Key {key!r} missing vault:// prefix"
+
 
 class TestReconcile:
     async def test_embeds_new_files(self, vault_dir, mock_qdrant, mock_embedder):
@@ -126,3 +148,46 @@ class TestReconcile:
         )
         await reconciler.run()
         assert mock_qdrant.upsert_chunks.call_count == 0
+
+    async def test_delete_called_before_upsert_for_changed_file(
+        self, vault_dir, mock_qdrant, mock_embedder
+    ):
+        """For a changed file, delete must be called before upsert."""
+        call_order: list[str] = []
+
+        async def track_delete(*a, **kw):
+            call_order.append("delete")
+
+        async def track_upsert(*a, **kw):
+            call_order.append("upsert")
+
+        mock_qdrant.delete_by_source_url.side_effect = track_delete
+        mock_qdrant.upsert_chunks.side_effect = track_upsert
+        mock_qdrant.get_indexed_sources.return_value = {
+            "vault://note1.md": "stale_hash",
+        }
+        reconciler = VaultReconciler(
+            vault_path=str(vault_dir), embedder=mock_embedder, qdrant=mock_qdrant
+        )
+        await reconciler.run()
+        assert "delete" in call_order
+        assert "upsert" in call_order
+        assert call_order.index("delete") < call_order.index("upsert")
+
+    async def test_run_handles_mixed_new_changed_deleted(
+        self, vault_dir, mock_qdrant, mock_embedder
+    ):
+        """run() processes new, changed, and deleted files in one cycle."""
+        note1_hash = _hash((vault_dir / "note1.md").read_text())
+        mock_qdrant.get_indexed_sources.return_value = {
+            "vault://note1.md": note1_hash,    # unchanged
+            "vault://note2.md": "stale_hash",  # changed
+            "vault://ghost.md": "old_hash",    # deleted (not on disk)
+        }
+        reconciler = VaultReconciler(
+            vault_path=str(vault_dir), embedder=mock_embedder, qdrant=mock_qdrant
+        )
+        await reconciler.run()
+        # note2 changed → delete + upsert; ghost deleted → delete only; note1 unchanged
+        assert mock_qdrant.delete_by_source_url.call_count == 2
+        assert mock_qdrant.upsert_chunks.call_count == 1


### PR DESCRIPTION
## Summary

Add targeted unit tests to the four primary `{source}_test.py` files, covering behaviours specified in the task and edge cases not yet present in the primary test files.

### Files changed

| Test file | New tests added |
|---|---|
| `chunker_test.py` | H4+ headers not split, sequential `chunk_index` starting at 0, whitespace-only → `[]`, all six `ChunkPayload` keys present |
| `embedder_test.py` | `EMBED_BATCH_SIZE == 32`, `threads=1` on init, `embed()` returns Python lists (not numpy) |
| `qdrant_client_test.py` | Trailing-slash URL normalisation, collection name stored, `get_indexed_sources` on empty collection, point ID is UUID5, all payload fields present on upsert |
| `reconciler_test.py` | Hash values are 64-char SHA-256 hex, all source URLs use `vault://` scheme, delete-before-upsert ordering for changed files, mixed new/changed/deleted single-cycle |

### What is tested

- **chunker.py** – `chunk_markdown` function: h4+ header passthrough, index sequencing, whitespace guard, payload shape
- **embedder.py** – `VaultEmbedder` class: `EMBED_BATCH_SIZE`, single-thread init, `embed()` list output
- **qdrant_client.py** – `QdrantClient` class: URL normalisation, `ensure_collection`, `upsert_chunks` (UUID5 ID + payload), `search`, `delete_by_source_url`, `get_indexed_sources`
- **reconciler.py** – `VaultReconciler` class: `_walk_vault` hash format + URL scheme, `run()` ordering and multi-action cycles

### External dependencies mocked

- `fastembed.TextEmbedding` (via `unittest.mock.patch`)
- `httpx.AsyncClient` (via `unittest.mock.patch` + `AsyncMock`)
- Filesystem via `pytest` `tmp_path` fixture

## Test plan

- [ ] CI: `bazel test //projects/obsidian_vault/vault_mcp/tests:chunker_test` passes
- [ ] CI: `bazel test //projects/obsidian_vault/vault_mcp/tests:embedder_test` passes
- [ ] CI: `bazel test //projects/obsidian_vault/vault_mcp/tests:qdrant_client_test` passes
- [ ] CI: `bazel test //projects/obsidian_vault/vault_mcp/tests:reconciler_test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)