### PR TITLE
test(cluster-agents): add coverage for gate error paths and agent edge cases

### DIFF
--- a/projects/agent_platform/cluster_agents/deploy/Chart.yaml
+++ b/projects/agent_platform/cluster_agents/deploy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cluster-agents
 description: Autonomous cluster monitoring agents
 type: application
-version: 0.6.32
+version: 0.6.33
 appVersion: "0.2.0"
 annotations:
   org.opencontainers.image.source: "https://github.com/jomcgi/homelab"

--- a/projects/agent_platform/cluster_agents/deploy/Chart.yaml
+++ b/projects/agent_platform/cluster_agents/deploy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cluster-agents
 description: Autonomous cluster monitoring agents
 type: application
-version: 0.6.31
+version: 0.6.32
 appVersion: "0.2.0"
 annotations:
   org.opencontainers.image.source: "https://github.com/jomcgi/homelab"

--- a/projects/agent_platform/cluster_agents/deploy/application.yaml
+++ b/projects/agent_platform/cluster_agents/deploy/application.yaml
@@ -8,7 +8,7 @@ spec:
   source:
     repoURL: ghcr.io/jomcgi/homelab/charts
     chart: cluster-agents
-    targetRevision: 0.6.31
+    targetRevision: 0.6.32
     helm:
       releaseName: cluster-agents
       # IMPORTANT: Do NOT add podAnnotations here. The chart-version-bot regenerates

--- a/projects/agent_platform/cluster_agents/deploy/application.yaml
+++ b/projects/agent_platform/cluster_agents/deploy/application.yaml
@@ -8,7 +8,7 @@ spec:
   source:
     repoURL: ghcr.io/jomcgi/homelab/charts
     chart: cluster-agents
-    targetRevision: 0.6.32
+    targetRevision: 0.6.33
     helm:
       releaseName: cluster-agents
       # IMPORTANT: Do NOT add podAnnotations here. The chart-version-bot regenerates

--- a/projects/agent_platform/cluster_agents/git_activity_gate_test.go
+++ b/projects/agent_platform/cluster_agents/git_activity_gate_test.go
@@ -258,3 +258,121 @@ func TestGitActivityGate_JobWithoutSHATag_TreatedAsFirstRun(t *testing.T) {
 		t.Errorf("expected commitRange=5ef12dd3 (first-run), got %s", commitRange)
 	}
 }
+
+// TestGitActivityGate_GitHubAPIError verifies that when the GitHub commits
+// endpoint returns a non-200 response, Check propagates the error with a
+// "fetching latest commit" wrapper.
+func TestGitActivityGate_GitHubAPIError(t *testing.T) {
+	githubServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+	}))
+	defer githubServer.Close()
+
+	gate := &GitActivityGate{
+		github:       NewGitHubClient(githubServer.URL, "test-token", "jomcgi/homelab"),
+		orchestrator: NewOrchestratorClient("http://should-not-be-called"),
+		botAuthors:   []string{"ci-format-bot"},
+		branch:       "main",
+	}
+
+	_, _, hasActivity, err := gate.Check(context.Background(), "ci:main")
+	if err == nil {
+		t.Fatal("expected error when GitHub API fails, got nil")
+	}
+	if hasActivity {
+		t.Error("expected hasActivity=false on error")
+	}
+	errStr := err.Error()
+	if len(errStr) == 0 || errStr[:len("fetching latest commit")] != "fetching latest commit" {
+		t.Errorf("expected error to start with 'fetching latest commit', got: %v", err)
+	}
+}
+
+// TestGitActivityGate_OrchestratorNon200 verifies that when the orchestrator
+// returns a non-200 status from the jobs endpoint, lastProcessedCommit returns
+// an error and Check wraps it with "fetching last processed commit".
+func TestGitActivityGate_OrchestratorNon200(t *testing.T) {
+	orchestratorServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "service unavailable", http.StatusServiceUnavailable)
+	}))
+	defer orchestratorServer.Close()
+
+	githubServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		commits := []ghCommit{
+			{
+				SHA: "abc999",
+				Commit: ghCommitDetail{
+					Author:  ghAuthor{Name: "jomcgi", Date: time.Now()},
+					Message: "feat: something",
+				},
+			},
+		}
+		json.NewEncoder(w).Encode(commits)
+	}))
+	defer githubServer.Close()
+
+	gate := &GitActivityGate{
+		github:       NewGitHubClient(githubServer.URL, "test-token", "jomcgi/homelab"),
+		orchestrator: NewOrchestratorClient(orchestratorServer.URL),
+		botAuthors:   []string{"ci-format-bot"},
+		branch:       "main",
+	}
+
+	_, _, hasActivity, err := gate.Check(context.Background(), "ci:main")
+	if err == nil {
+		t.Fatal("expected error when orchestrator returns non-200, got nil")
+	}
+	if hasActivity {
+		t.Error("expected hasActivity=false on error")
+	}
+	errStr := err.Error()
+	const wantPrefix = "fetching last processed commit"
+	if len(errStr) < len(wantPrefix) || errStr[:len(wantPrefix)] != wantPrefix {
+		t.Errorf("expected error to start with %q, got: %v", wantPrefix, err)
+	}
+}
+
+// TestGitActivityGate_OrchestratorMalformedJSON verifies that when the
+// orchestrator returns 200 OK with invalid JSON, lastProcessedCommit returns an
+// error and Check wraps it with "fetching last processed commit".
+func TestGitActivityGate_OrchestratorMalformedJSON(t *testing.T) {
+	orchestratorServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("not-valid-json{{{"))
+	}))
+	defer orchestratorServer.Close()
+
+	githubServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		commits := []ghCommit{
+			{
+				SHA: "def777",
+				Commit: ghCommitDetail{
+					Author:  ghAuthor{Name: "jomcgi", Date: time.Now()},
+					Message: "fix: another fix",
+				},
+			},
+		}
+		json.NewEncoder(w).Encode(commits)
+	}))
+	defer githubServer.Close()
+
+	gate := &GitActivityGate{
+		github:       NewGitHubClient(githubServer.URL, "test-token", "jomcgi/homelab"),
+		orchestrator: NewOrchestratorClient(orchestratorServer.URL),
+		botAuthors:   []string{"ci-format-bot"},
+		branch:       "main",
+	}
+
+	_, _, hasActivity, err := gate.Check(context.Background(), "ci:main")
+	if err == nil {
+		t.Fatal("expected error when orchestrator returns malformed JSON, got nil")
+	}
+	if hasActivity {
+		t.Error("expected hasActivity=false on error")
+	}
+	const wantPrefix = "fetching last processed commit"
+	errStr := err.Error()
+	if len(errStr) < len(wantPrefix) || errStr[:len(wantPrefix)] != wantPrefix {
+		t.Errorf("expected error to start with %q, got: %v", wantPrefix, err)
+	}
+}

--- a/projects/agent_platform/cluster_agents/pr_fix_agent_test.go
+++ b/projects/agent_platform/cluster_agents/pr_fix_agent_test.go
@@ -372,8 +372,6 @@ func TestPRFixAgent_CollectMultiplePRsProducesMultipleFindings(t *testing.T) {
 // numbers produce distinct fingerprints so the escalator dedup tag is unique
 // per PR and multiple PRs can be tracked independently.
 func TestPRFixAgent_FingerprintUniquenessAcrossPRs(t *testing.T) {
-	agent := NewPRFixAgent(nil, nil, time.Hour, 30*time.Minute)
-
 	findings := []Finding{
 		{Data: map[string]any{"pr_number": 1, "branch": "a"}},
 		{Data: map[string]any{"pr_number": 2, "branch": "b"}},

--- a/projects/agent_platform/cluster_agents/pr_fix_agent_test.go
+++ b/projects/agent_platform/cluster_agents/pr_fix_agent_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -273,5 +274,161 @@ func TestPRFixAgent_AnalyzeTaskContainsPRNumberAndBranch(t *testing.T) {
 		if !strings.Contains(task, want) {
 			t.Errorf("Payload[\"task\"] missing %q:\n%s", want, task)
 		}
+	}
+}
+
+// TestPRFixAgent_CollectFiltersFreshPRs verifies that PRs updated within the
+// staleThreshold window are excluded from the results even when they have
+// failing checks.
+func TestPRFixAgent_CollectFiltersFreshPRs(t *testing.T) {
+	githubServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "check-suites") {
+			// Would have failing checks if called.
+			resp := ghCheckSuitesResponse{
+				CheckSuites: []ghCheckSuite{{Conclusion: "failure"}},
+			}
+			json.NewEncoder(w).Encode(resp)
+			return
+		}
+		// Return one PR that was updated 5 minutes ago — well within a 30-minute threshold.
+		prs := []ghPullRequest{
+			{
+				Number:    55,
+				Head:      ghHead{Ref: "feat/fresh", SHA: "freshsha"},
+				UpdatedAt: time.Now().Add(-5 * time.Minute),
+			},
+		}
+		json.NewEncoder(w).Encode(prs)
+	}))
+	defer githubServer.Close()
+
+	agent := NewPRFixAgent(
+		NewGitHubClient(githubServer.URL, "test-token", "jomcgi/homelab"),
+		nil,
+		time.Hour,
+		30*time.Minute, // staleThreshold: 30 minutes
+	)
+
+	findings, err := agent.Collect(context.Background())
+	if err != nil {
+		t.Fatalf("Collect: unexpected error: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Errorf("expected 0 findings for a fresh PR (updated 5m ago vs 30m threshold), got %d", len(findings))
+	}
+}
+
+// TestPRFixAgent_CollectMultiplePRsProducesMultipleFindings verifies that when
+// multiple stale PRs with failing checks exist, Collect returns one finding per
+// PR in the same order.
+func TestPRFixAgent_CollectMultiplePRsProducesMultipleFindings(t *testing.T) {
+	githubServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "check-suites") {
+			resp := ghCheckSuitesResponse{
+				CheckSuites: []ghCheckSuite{{Conclusion: "failure"}},
+			}
+			json.NewEncoder(w).Encode(resp)
+			return
+		}
+		prs := []ghPullRequest{
+			{
+				Number:    10,
+				Head:      ghHead{Ref: "fix/issue-10", SHA: "sha10"},
+				UpdatedAt: time.Now().Add(-2 * time.Hour),
+			},
+			{
+				Number:    20,
+				Head:      ghHead{Ref: "fix/issue-20", SHA: "sha20"},
+				UpdatedAt: time.Now().Add(-3 * time.Hour),
+			},
+		}
+		json.NewEncoder(w).Encode(prs)
+	}))
+	defer githubServer.Close()
+
+	agent := NewPRFixAgent(
+		NewGitHubClient(githubServer.URL, "test-token", "jomcgi/homelab"),
+		nil,
+		time.Hour,
+		30*time.Minute,
+	)
+
+	findings, err := agent.Collect(context.Background())
+	if err != nil {
+		t.Fatalf("Collect: unexpected error: %v", err)
+	}
+	if len(findings) != 2 {
+		t.Fatalf("expected 2 findings for 2 stale failing PRs, got %d", len(findings))
+	}
+	if findings[0].Data["pr_number"].(int) != 10 {
+		t.Errorf("expected first finding for PR #10, got pr_number=%v", findings[0].Data["pr_number"])
+	}
+	if findings[1].Data["pr_number"].(int) != 20 {
+		t.Errorf("expected second finding for PR #20, got pr_number=%v", findings[1].Data["pr_number"])
+	}
+}
+
+// TestPRFixAgent_FingerprintUniquenessAcrossPRs verifies that different PR
+// numbers produce distinct fingerprints so the escalator dedup tag is unique
+// per PR and multiple PRs can be tracked independently.
+func TestPRFixAgent_FingerprintUniquenessAcrossPRs(t *testing.T) {
+	agent := NewPRFixAgent(nil, nil, time.Hour, 30*time.Minute)
+
+	findings := []Finding{
+		{Data: map[string]any{"pr_number": 1, "branch": "a"}},
+		{Data: map[string]any{"pr_number": 2, "branch": "b"}},
+		{Data: map[string]any{"pr_number": 1000, "branch": "c"}},
+	}
+
+	// Simulate Collect fingerprint generation by reproducing the Collect logic.
+	seen := map[string]bool{}
+	for _, f := range findings {
+		prNumber := f.Data["pr_number"].(int)
+		fp := fmt.Sprintf("improvement:pr-fix:%d", prNumber)
+		if seen[fp] {
+			t.Errorf("fingerprint collision for pr_number=%d: %s", prNumber, fp)
+		}
+		seen[fp] = true
+	}
+	if len(seen) != 3 {
+		t.Errorf("expected 3 unique fingerprints, got %d", len(seen))
+	}
+}
+
+// TestPRFixAgent_AnalyzeMissingDataFallsBack verifies that Analyze handles
+// missing or wrong-type pr_number and branch fields gracefully via type
+// assertion fallbacks (yields 0 and ""), producing a non-panicking task string.
+func TestPRFixAgent_AnalyzeMissingDataFallsBack(t *testing.T) {
+	agent := NewPRFixAgent(nil, nil, time.Hour, 30*time.Minute)
+
+	findings := []Finding{
+		{
+			Fingerprint: "improvement:pr-fix:0",
+			Source:      "improvement:pr-fix",
+			Severity:    SeverityInfo,
+			Title:       "PR with missing data",
+			Data:        map[string]any{}, // no pr_number, no branch
+			Timestamp:   time.Now(),
+		},
+	}
+
+	actions, err := agent.Analyze(context.Background(), findings)
+	if err != nil {
+		t.Fatalf("Analyze: unexpected error: %v", err)
+	}
+	if len(actions) != 1 {
+		t.Fatalf("expected 1 action, got %d", len(actions))
+	}
+
+	task, ok := actions[0].Payload["task"].(string)
+	if !ok {
+		t.Fatalf("expected Payload[\"task\"] to be a string")
+	}
+	if task == "" {
+		t.Error("expected non-empty task even when pr_number and branch are missing")
+	}
+	// Zero-value fallbacks: pr_number=0, branch=""
+	if !strings.Contains(task, "0") {
+		t.Errorf("expected task to contain fallback PR number 0, got:\n%s", task)
 	}
 }

--- a/projects/agent_platform/cluster_agents/readme_freshness_agent_test.go
+++ b/projects/agent_platform/cluster_agents/readme_freshness_agent_test.go
@@ -289,3 +289,51 @@ func TestReadmeFreshnessAgent_AnalyzeTaskContentMentionsREADME(t *testing.T) {
 		t.Errorf("expected task to mention README, got:\n%s", task)
 	}
 }
+
+// TestReadmeFreshnessAgent_CollectFindingContainsLatestSHA verifies that
+// Collect stores "latest_sha" in the finding's Data map so the escalator can
+// attach a sha: tag for deduplication on the next cycle (mirrors
+// TestTestCoverageAgent_CollectWithActivity).
+func TestReadmeFreshnessAgent_CollectFindingContainsLatestSHA(t *testing.T) {
+	githubServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		commits := []ghCommit{
+			{
+				SHA: "readme555sha",
+				Commit: ghCommitDetail{
+					Author:  ghAuthor{Name: "jomcgi", Date: time.Now()},
+					Message: "feat: restructure service configs",
+				},
+			},
+		}
+		json.NewEncoder(w).Encode(commits)
+	}))
+	defer githubServer.Close()
+
+	orchestratorServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(orchestratorListResponse{Total: 0})
+	}))
+	defer orchestratorServer.Close()
+
+	gate := NewGitActivityGate(
+		NewGitHubClient(githubServer.URL, "test-token", "jomcgi/homelab"),
+		NewOrchestratorClient(orchestratorServer.URL),
+		[]string{"ci-format-bot"},
+		"main",
+	)
+
+	agent := NewReadmeFreshnessAgent(gate, nil, time.Hour)
+	findings, err := agent.Collect(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(findings))
+	}
+	latestSHA, ok := findings[0].Data["latest_sha"].(string)
+	if !ok || latestSHA == "" {
+		t.Errorf("expected findings[0].Data[latest_sha] to be set, got %v", findings[0].Data["latest_sha"])
+	}
+	if latestSHA != "readme555sha" {
+		t.Errorf("expected latest_sha=readme555sha, got %s", latestSHA)
+	}
+}

--- a/projects/agent_platform/cluster_agents/rules_agent_test.go
+++ b/projects/agent_platform/cluster_agents/rules_agent_test.go
@@ -221,6 +221,101 @@ func TestRulesAgent_NameAndInterval(t *testing.T) {
 	}
 }
 
+// TestRulesAgent_CollectFindingContainsLatestSHA verifies that Collect stores
+// "latest_sha" in the finding's Data map so the escalator can attach a sha:
+// tag and gate re-entry on the next cycle (mirrors TestTestCoverageAgent_CollectWithActivity).
+func TestRulesAgent_CollectFindingContainsLatestSHA(t *testing.T) {
+	githubServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		commits := []ghCommit{
+			{
+				SHA: "sha999abc",
+				Commit: ghCommitDetail{
+					Author:  ghAuthor{Name: "jomcgi", Date: time.Now()},
+					Message: "feat: something new",
+				},
+			},
+		}
+		json.NewEncoder(w).Encode(commits)
+	}))
+	defer githubServer.Close()
+
+	orchestratorServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(orchestratorListResponse{Total: 0})
+	}))
+	defer orchestratorServer.Close()
+
+	gate := NewGitActivityGate(
+		NewGitHubClient(githubServer.URL, "test-token", "jomcgi/homelab"),
+		NewOrchestratorClient(orchestratorServer.URL),
+		[]string{"ci-format-bot"},
+		"main",
+	)
+
+	agent := NewRulesAgent(gate, nil, time.Hour)
+	findings, err := agent.Collect(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(findings))
+	}
+	latestSHA, ok := findings[0].Data["latest_sha"].(string)
+	if !ok || latestSHA == "" {
+		t.Errorf("expected findings[0].Data[latest_sha] to be set, got %v", findings[0].Data["latest_sha"])
+	}
+	if latestSHA != "sha999abc" {
+		t.Errorf("expected latest_sha=sha999abc, got %s", latestSHA)
+	}
+}
+
+// TestRulesAgent_AnalyzeMultipleFindingsProducesOneAction verifies that Analyze
+// emits exactly one action regardless of how many findings are passed — only
+// findings[0] is used (the gate produces at most one finding, but the contract
+// should be explicit).
+func TestRulesAgent_AnalyzeMultipleFindingsProducesOneAction(t *testing.T) {
+	agent := NewRulesAgent(nil, nil, time.Hour)
+
+	findings := []Finding{
+		{
+			Fingerprint: rulesTag,
+			Source:      rulesTag,
+			Severity:    SeverityInfo,
+			Title:       "Rules improvement opportunity",
+			Data:        map[string]any{"commit_range": "aaa..bbb", "latest_sha": "bbb"},
+			Timestamp:   time.Now(),
+		},
+		{
+			Fingerprint: rulesTag + "-extra",
+			Source:      rulesTag,
+			Severity:    SeverityInfo,
+			Title:       "Rules improvement opportunity extra",
+			Data:        map[string]any{"commit_range": "ccc..ddd", "latest_sha": "ddd"},
+			Timestamp:   time.Now(),
+		},
+	}
+
+	actions, err := agent.Analyze(context.Background(), findings)
+	if err != nil {
+		t.Fatalf("Analyze: unexpected error: %v", err)
+	}
+	// Analyze only uses findings[0]; the second finding is intentionally ignored.
+	if len(actions) != 1 {
+		t.Fatalf("expected 1 action even with multiple findings, got %d", len(actions))
+	}
+	if actions[0].Finding.Fingerprint != rulesTag {
+		t.Errorf("expected action to use first finding fingerprint %q, got %q",
+			rulesTag, actions[0].Finding.Fingerprint)
+	}
+	// The task should contain the first finding's commit range, not the second.
+	task, ok := actions[0].Payload["task"].(string)
+	if !ok {
+		t.Fatalf("expected Payload[\"task\"] to be a string")
+	}
+	if !strings.Contains(task, "aaa..bbb") {
+		t.Errorf("expected task to reference first finding's commit range aaa..bbb, got:\n%s", task)
+	}
+}
+
 // TestRulesAgent_AnalyzeMissingCommitRangeFallsBackToEmpty verifies that when
 // the finding's Data map has no "commit_range" key (or the value is not a
 // string), the task is still well-formed and does not contain a placeholder or


### PR DESCRIPTION
## Summary

- **GitActivityGate** (3 tests): GitHub API non-200 error propagation, orchestrator non-200 error propagation, orchestrator malformed JSON error propagation
- **RulesAgent** (2 tests): latest_sha data field in collected findings; multiple-findings single-action contract
- **ReadmeFreshnessAgent** (1 test): latest_sha data field in collected findings
- **PRFixAgent** (4 tests): fresh PR filtering, multiple PRs to multiple findings, fingerprint uniqueness, missing data fallbacks

## Test plan

- [ ] CI runs bazel test //projects/agent_platform/cluster_agents:cluster_agents_test
- [ ] All 12 new tests pass alongside existing suite

Generated with [Claude Code](https://claude.com/claude-code)