### PR TITLE
feat(semgrep): add dulwich-commit-missing-author rule

### DIFF
--- a/bazel/semgrep/rules/python/dulwich-commit-missing-author.py
+++ b/bazel/semgrep/rules/python/dulwich-commit-missing-author.py
@@ -1,0 +1,16 @@
+# Tests for dulwich-commit-missing-author rule.
+from dulwich import porcelain
+
+# ruleid: dulwich-commit-missing-author
+porcelain.commit(repo, message=b"fix: update config")
+
+# ruleid: dulwich-commit-missing-author
+porcelain.commit(repo, message=b"chore: bump version", committer=b"Bot <bot@example.com>")
+
+# ok: dulwich-commit-missing-author
+porcelain.commit(
+    repo,
+    message=b"fix: update config",
+    author=b"Bot <bot@example.com>",
+    committer=b"Bot <bot@example.com>",
+)

--- a/bazel/semgrep/rules/python/dulwich-commit-missing-author.py
+++ b/bazel/semgrep/rules/python/dulwich-commit-missing-author.py
@@ -5,7 +5,9 @@ from dulwich import porcelain
 porcelain.commit(repo, message=b"fix: update config")
 
 # ruleid: dulwich-commit-missing-author
-porcelain.commit(repo, message=b"chore: bump version", committer=b"Bot <bot@example.com>")
+porcelain.commit(
+    repo, message=b"chore: bump version", committer=b"Bot <bot@example.com>"
+)
 
 # ok: dulwich-commit-missing-author
 porcelain.commit(

--- a/bazel/semgrep/rules/python/dulwich-commit-missing-author.yaml
+++ b/bazel/semgrep/rules/python/dulwich-commit-missing-author.yaml
@@ -1,0 +1,23 @@
+rules:
+  - id: dulwich-commit-missing-author
+    patterns:
+      - pattern: porcelain.commit(...)
+      - pattern-not: porcelain.commit(..., author=..., ...)
+    message: >
+      `porcelain.commit(...)` called without an `author=` keyword argument.
+      In containers without a `~/.gitconfig`, dulwich cannot infer the author
+      identity and will raise an error at runtime. Pass explicit `author=` and
+      `committer=` byte-string arguments, e.g.
+      `author=b"Bot <bot@example.com>"`.
+    languages: [python]
+    severity: WARNING
+    metadata:
+      category: correctness
+      subcategory: dulwich
+      confidence: HIGH
+      likelihood: HIGH
+      impact: HIGH
+      technology: [python, dulwich]
+      description: >
+        dulwich porcelain.commit() called without author= — fails in containers
+        where ~/.gitconfig is absent; pass explicit author= and committer=


### PR DESCRIPTION
## Summary

- Adds a new semgrep rule `dulwich-commit-missing-author` that detects `porcelain.commit(...)` calls missing an explicit `author=` keyword argument
- In containers without `~/.gitconfig`, dulwich cannot infer author identity and raises a runtime error — the rule catches this at lint time
- Includes a test fixture `.py` file with annotated bad/good cases using `# ruleid:` / `# ok:` conventions

## Test plan

- [ ] `//bazel/semgrep/rules:python_rules_test` passes (semgrep validates the rule against the fixture file)
- [ ] Bad cases (`porcelain.commit` without `author=`) are flagged
- [ ] Good case (`porcelain.commit` with both `author=` and `committer=`) is not flagged

🤖 Generated with [Claude Code](https://claude.com/claude-code)