### PR TITLE
docs(obsidian_vault): fix README inaccuracies

### DIFF
--- a/projects/obsidian_vault/README.md
+++ b/projects/obsidian_vault/README.md
@@ -36,9 +36,8 @@ All write operations require a `reason` parameter which becomes part of the git 
 ## Installation
 
 ```bash
-helm repo add oci://ghcr.io/jomcgi/homelab/charts
 helm install obsidian-vault oci://ghcr.io/jomcgi/homelab/charts/obsidian-vault \
-  --version 0.5.16 \
+  --version 0.5.19 \
   --namespace obsidian --create-namespace \
   -f my-values.yaml
 ```


### PR DESCRIPTION
## Summary

- Remove invalid `helm repo add oci://...` line — OCI registries are not compatible with `helm repo add` and the command would fail
- Fix install snippet chart version: `0.5.16` → `0.5.19` to match the current `Chart.yaml`

## Test plan

- [ ] Verify `projects/obsidian_vault/chart/Chart.yaml` version is `0.5.19`
- [ ] Verify the install snippet now works: `helm install ... oci://... --version 0.5.19`

🤖 Generated with [Claude Code](https://claude.com/claude-code)