### PR TITLE
docs(agent_platform): fix README inaccuracies

### DIFF
--- a/projects/agent_platform/chart/Chart.yaml
+++ b/projects/agent_platform/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: agent-platform
 description: Agent platform — umbrella chart bundling goose sandboxes, MCP servers, and supporting components
 type: application
-version: 0.35.7
+version: 0.35.8
 appVersion: "0.2.0"
 annotations:
   org.opencontainers.image.source: "https://github.com/jomcgi/homelab"

--- a/projects/agent_platform/chart/README.md
+++ b/projects/agent_platform/chart/README.md
@@ -104,9 +104,9 @@ Client → agent-orchestrator REST API
 | `agent-sandbox`              | SandboxTemplate CRDs (`sandboxes.agents.x-k8s.io`) + controller   | ✅      |
 | `nats`                       | NATS JetStream (upstream chart)                                   | ✅      |
 
-> **Not in this chart:** Context Forge and MCP OAuth Proxy are deployed
-> separately in the `mcp` namespace. See `projects/mcp/` for their ArgoCD
-> Applications.
+> **Not in this chart:** Context Forge is deployed separately in the `mcp`
+> namespace. See `projects/mcp/context-forge-gateway/` for its ArgoCD
+> Application.
 
 ---
 
@@ -307,8 +307,8 @@ by CI on every merge to `main`. The ArgoCD Application in
 registry and overlays environment-specific values from
 `projects/agent_platform/deploy/values.yaml`.
 
-**ArgoCD Image Updater** watches the chart OCI artifact and automatically bumps
-`targetRevision` in the Application when a new chart version is pushed.
+The **chart-version-bot** automatically bumps `targetRevision` in the
+Application when a new chart version is pushed to the OCI registry.
 
 To change cluster configuration, edit `deploy/values.yaml` and push — ArgoCD
 auto-syncs within ~5–10 seconds. **Never use `kubectl apply` or `helm install`

--- a/projects/agent_platform/deploy/application.yaml
+++ b/projects/agent_platform/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: agent-platform
-      targetRevision: 0.35.7
+      targetRevision: 0.35.8
       helm:
         releaseName: agent-platform
         valueFiles:


### PR DESCRIPTION
## Summary

- Replace incorrect claim that "ArgoCD Image Updater" bumps `targetRevision` — it is the `chart-version-bot` that does this; Image Updater only manages container image digest pins
- Remove phantom "MCP OAuth Proxy" reference: only `context-forge-gateway` exists under `projects/mcp/`; there is no OAuth Proxy deployed

## Test plan

- [ ] Confirm no `imageupdater.yaml` in `projects/agent_platform/deploy/` (no Image Updater config for chart version)
- [ ] Confirm `ls projects/mcp/` only shows `context-forge-gateway/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)