### PR TITLE
docs(trips): fix README inaccuracies

### DIFF
--- a/projects/trips/chart/README.md
+++ b/projects/trips/chart/README.md
@@ -12,7 +12,7 @@ flowchart LR
     Nginx -->|/trips/full/| SeaweedFS[SeaweedFS\nS3 Storage]
     Nginx -->|/trips/thumb/\n/trips/display/\n/trips/gallery/| Imgproxy[imgproxy\nImage Resizer]
     Imgproxy --> SeaweedFS
-    Nginx -->|/trips/api/| API[Go/Python API]
+    Nginx -->|/trips/api/| API[Python API]
     Nginx -->|/trips/ws/| API
     API --> SeaweedFS
     API --> NATS[NATS\nEvent Bus]


### PR DESCRIPTION
## Summary

- Correct architecture diagram label from `Go/Python API` to `Python API` — the trips API server is entirely Python (FastAPI + uvicorn), there is no Go component

## Test plan

- [ ] Confirm `projects/trips/` contains only Python source (FastAPI/uvicorn), no Go files

🤖 Generated with [Claude Code](https://claude.com/claude-code)