### PR TITLE
test(knowledge): add coverage for migrate_raw_bucketing.main() CLI entrypoint

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.31.29
+version: 0.31.30
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.31.29
+      targetRevision: 0.31.30
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/knowledge/migrate_raw_bucketing_test.py
+++ b/projects/monolith/knowledge/migrate_raw_bucketing_test.py
@@ -1,12 +1,14 @@
 """Tests for the one-shot raw bucketing migration script."""
 
+import sys
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 from sqlmodel import Session, SQLModel, create_engine, select
 from sqlmodel.pool import StaticPool
 
-from knowledge.migrate_raw_bucketing import run_migration
+from knowledge.migrate_raw_bucketing import main, run_migration
 from knowledge.models import AtomRawProvenance, Note, RawInput
 
 
@@ -132,3 +134,119 @@ class TestRunMigration:
         ).all()
         # One raw sentinel + one atom sentinel.
         assert len(sentinels) == 2
+
+
+class TestMain:
+    """Tests for the main() CLI entrypoint."""
+
+    def test_main_raises_systemexit_when_no_dsn(self, tmp_path, monkeypatch):
+        """main() raises SystemExit when --dsn is absent and DATABASE_URL is unset."""
+        monkeypatch.delenv("DATABASE_URL", raising=False)
+        monkeypatch.setattr(
+            sys, "argv", ["migrate_raw_bucketing", "--vault-root", str(tmp_path)]
+        )
+        with pytest.raises(SystemExit, match="--dsn or DATABASE_URL is required"):
+            main()
+
+    def test_main_uses_database_url_env_var(self, tmp_path, monkeypatch):
+        """main() uses DATABASE_URL env var when --dsn is not passed on the CLI.
+
+        run_migration is mocked to avoid the need for a real schema — the goal
+        here is to verify that DATABASE_URL is accepted as the DSN source.
+        """
+        monkeypatch.setenv("DATABASE_URL", "sqlite://")
+        monkeypatch.setattr(
+            sys, "argv", ["migrate_raw_bucketing", "--vault-root", str(tmp_path)]
+        )
+        with patch("knowledge.migrate_raw_bucketing.run_migration") as mock_run:
+            main()
+        mock_run.assert_called_once()
+        _, kwargs = mock_run.call_args
+        assert kwargs["vault_root"] == tmp_path
+
+    def test_main_uses_vault_root_env_var(self, tmp_path, monkeypatch):
+        """main() uses VAULT_ROOT env var as the default for --vault-root."""
+        monkeypatch.setenv("VAULT_ROOT", str(tmp_path))
+        monkeypatch.setenv("DATABASE_URL", "sqlite://")
+        monkeypatch.setattr(sys, "argv", ["migrate_raw_bucketing"])
+        with patch("knowledge.migrate_raw_bucketing.run_migration") as mock_run:
+            main()
+        mock_run.assert_called_once()
+        _, kwargs = mock_run.call_args
+        assert kwargs["vault_root"] == tmp_path
+
+    def test_main_happy_path_with_cli_args(self, tmp_path, monkeypatch):
+        """main() passes correct vault_root and a live session when called with --dsn and --vault-root."""
+        monkeypatch.delenv("DATABASE_URL", raising=False)
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            [
+                "migrate_raw_bucketing",
+                "--vault-root",
+                str(tmp_path),
+                "--dsn",
+                "sqlite://",
+            ],
+        )
+        with patch("knowledge.migrate_raw_bucketing.run_migration") as mock_run:
+            main()
+        mock_run.assert_called_once()
+        _, kwargs = mock_run.call_args
+        assert kwargs["vault_root"] == tmp_path
+        # session is the second keyword argument; it should be a live Session.
+        assert kwargs["session"] is not None
+
+    def test_main_migrates_files_end_to_end(self, tmp_path, monkeypatch):
+        """main() with an SQLite DSN actually moves files and inserts DB rows.
+
+        The SQLModel models carry ``schema="knowledge"`` for Postgres but SQLite
+        does not support schemas.  The same technique used by session_fixture is
+        applied here: schemas are nulled for the entire duration of the test
+        (both DDL and DML), then restored in a finally block.
+        """
+        deleted_dir = tmp_path / "_deleted_with_ttl"
+        deleted_dir.mkdir()
+        (deleted_dir / "note.md").write_text(
+            "---\ntitle: Legacy\nttl: 2026-01-01T00:00:00Z\n---\nContent.",
+            encoding="utf-8",
+        )
+
+        # Use a file-based SQLite DB so it persists across two engine instances.
+        db_path = tmp_path / "test.db"
+        dsn = f"sqlite:///{db_path}"
+
+        # Null schemas for the whole test: DDL + the main() call (DML).
+        original_schemas = {}
+        for table in SQLModel.metadata.tables.values():
+            if table.schema is not None:
+                original_schemas[table.name] = table.schema
+                table.schema = None
+        try:
+            setup_engine = create_engine(dsn, connect_args={"check_same_thread": False})
+            SQLModel.metadata.create_all(setup_engine)
+            setup_engine.dispose()
+
+            monkeypatch.delenv("DATABASE_URL", raising=False)
+            monkeypatch.setattr(
+                sys,
+                "argv",
+                [
+                    "migrate_raw_bucketing",
+                    "--vault-root",
+                    str(tmp_path),
+                    "--dsn",
+                    dsn,
+                ],
+            )
+            main()
+        finally:
+            for table in SQLModel.metadata.tables.values():
+                if table.name in original_schemas:
+                    table.schema = original_schemas[table.name]
+
+        # _deleted_with_ttl directory should be gone after migration.
+        assert not deleted_dir.exists()
+        # Grandfathered file should exist under _raw/grandfathered/.
+        gf_files = list((tmp_path / "_raw" / "grandfathered").glob("*.md"))
+        assert len(gf_files) == 1


### PR DESCRIPTION
## Summary

- `migrate_raw_bucketing.main()` had zero test coverage — the CLI entrypoint was the only public-facing function in the module without tests
- Adds a `TestMain` class to the existing `migrate_raw_bucketing_test.py` with 5 tests

## Test cases added

- **`test_main_raises_systemexit_when_no_dsn`** — verifies `SystemExit` is raised with the expected message when neither `--dsn` nor `DATABASE_URL` is provided
- **`test_main_uses_database_url_env_var`** — verifies `DATABASE_URL` env var is accepted as the DSN fallback (mocks `run_migration`)
- **`test_main_uses_vault_root_env_var`** — verifies `VAULT_ROOT` env var is used as the vault-root default (mocks `run_migration`)
- **`test_main_happy_path_with_cli_args`** — verifies correct `vault_root` and live `session` are passed when both `--dsn` and `--vault-root` are provided (mocks `run_migration`)
- **`test_main_migrates_files_end_to_end`** — end-to-end test with file-based SQLite: creates a `_deleted_with_ttl/` fixture, calls `main()`, asserts the directory is gone and the file was moved to `_raw/grandfathered/`

## Test plan

- [ ] `bb remote test //projects/monolith:knowledge_migrate_raw_bucketing_test --config=ci` passes
- [ ] No production code changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)