### PR TITLE
test(cluster_agents): add Execute transport error and gate network failure tests

### DIFF
--- a/projects/agent_platform/cluster_agents/deploy/Chart.yaml
+++ b/projects/agent_platform/cluster_agents/deploy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cluster-agents
 description: Autonomous cluster monitoring agents
 type: application
-version: 0.6.33
+version: 0.6.34
 appVersion: "0.2.0"
 annotations:
   org.opencontainers.image.source: "https://github.com/jomcgi/homelab"

--- a/projects/agent_platform/cluster_agents/deploy/application.yaml
+++ b/projects/agent_platform/cluster_agents/deploy/application.yaml
@@ -8,7 +8,7 @@ spec:
   source:
     repoURL: ghcr.io/jomcgi/homelab/charts
     chart: cluster-agents
-    targetRevision: 0.6.33
+    targetRevision: 0.6.34
     helm:
       releaseName: cluster-agents
       # IMPORTANT: Do NOT add podAnnotations here. The chart-version-bot regenerates

--- a/projects/agent_platform/cluster_agents/git_activity_gate_test.go
+++ b/projects/agent_platform/cluster_agents/git_activity_gate_test.go
@@ -332,6 +332,50 @@ func TestGitActivityGate_OrchestratorNon200(t *testing.T) {
 	}
 }
 
+// TestGitActivityGate_OrchestratorTransportError verifies that when the
+// orchestrator is completely unreachable (transport-level failure, not a
+// non-200 HTTP status), lastProcessedCommit returns an error and Check wraps
+// it with "fetching last processed commit". This is distinct from
+// TestGitActivityGate_OrchestratorNon200 which tests the HTTP-level error path.
+func TestGitActivityGate_OrchestratorTransportError(t *testing.T) {
+	// Use a valid GitHub server so LatestNonBotCommit succeeds.
+	githubServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		commits := []ghCommit{
+			{
+				SHA: "abc999",
+				Commit: ghCommitDetail{
+					Author:  ghAuthor{Name: "jomcgi", Date: time.Now()},
+					Message: "feat: something",
+				},
+			},
+		}
+		json.NewEncoder(w).Encode(commits)
+	}))
+	defer githubServer.Close()
+
+	// Point orchestrator at port 0 which refuses connections — this triggers
+	// a transport-level error (client.Do fails) rather than a non-200 response.
+	gate := &GitActivityGate{
+		github:       NewGitHubClient(githubServer.URL, "test-token", "jomcgi/homelab"),
+		orchestrator: NewOrchestratorClient("http://127.0.0.1:0"),
+		botAuthors:   []string{"ci-format-bot"},
+		branch:       "main",
+	}
+
+	_, _, hasActivity, err := gate.Check(context.Background(), "ci:main")
+	if err == nil {
+		t.Fatal("expected error when orchestrator is unreachable at transport level, got nil")
+	}
+	if hasActivity {
+		t.Error("expected hasActivity=false on transport error")
+	}
+	const wantPrefix = "fetching last processed commit"
+	errStr := err.Error()
+	if len(errStr) < len(wantPrefix) || errStr[:len(wantPrefix)] != wantPrefix {
+		t.Errorf("expected error to start with %q, got: %v", wantPrefix, err)
+	}
+}
+
 // TestGitActivityGate_OrchestratorMalformedJSON verifies that when the
 // orchestrator returns 200 OK with invalid JSON, lastProcessedCommit returns an
 // error and Check wraps it with "fetching last processed commit".

--- a/projects/agent_platform/cluster_agents/pr_fix_agent_test.go
+++ b/projects/agent_platform/cluster_agents/pr_fix_agent_test.go
@@ -393,6 +393,34 @@ func TestPRFixAgent_FingerprintUniquenessAcrossPRs(t *testing.T) {
 	}
 }
 
+// TestPRFixAgent_ExecuteEscalatorTransportError verifies that when the
+// orchestrator is unreachable (transport-level failure), Execute returns nil
+// rather than propagating the network error — the escalator logs errors and
+// continues, so the agent's Execute contract is always nil on return.
+func TestPRFixAgent_ExecuteEscalatorTransportError(t *testing.T) {
+	// Point the orchestrator client at an address that refuses connections so
+	// the HTTP client.Do call itself fails (transport error, not a non-200 status).
+	escalator := NewEscalator(NewOrchestratorClient("http://127.0.0.1:0"))
+	agent := NewPRFixAgent(nil, escalator, time.Hour, 30*time.Minute)
+
+	actions := []Action{{
+		Type: ActionOrchestratorJob,
+		Finding: Finding{
+			Fingerprint: "improvement:pr-fix:42",
+			Source:      "improvement:pr-fix",
+			Title:       "PR #42 has failing CI checks",
+		},
+		Payload: map[string]any{"task": "Fix CI failure for PR #42"},
+	}}
+
+	// Execute must return nil even when the underlying orchestrator call fails
+	// at the transport level — errors are swallowed inside Escalator.Execute.
+	err := agent.Execute(context.Background(), actions)
+	if err != nil {
+		t.Fatalf("Execute: expected nil when escalator encounters transport error, got: %v", err)
+	}
+}
+
 // TestPRFixAgent_AnalyzeMissingDataFallsBack verifies that Analyze handles
 // missing or wrong-type pr_number and branch fields gracefully via type
 // assertion fallbacks (yields 0 and ""), producing a non-panicking task string.

--- a/projects/agent_platform/cluster_agents/readme_freshness_agent_test.go
+++ b/projects/agent_platform/cluster_agents/readme_freshness_agent_test.go
@@ -290,6 +290,31 @@ func TestReadmeFreshnessAgent_AnalyzeTaskContentMentionsREADME(t *testing.T) {
 	}
 }
 
+// TestReadmeFreshnessAgent_ExecuteEscalatorTransportError verifies that when
+// the orchestrator is unreachable (transport-level failure), Execute returns
+// nil — the escalator logs errors and continues, so the agent's Execute
+// contract is always nil on return.
+func TestReadmeFreshnessAgent_ExecuteEscalatorTransportError(t *testing.T) {
+	// Port 0 refuses connections, causing a transport-level error in client.Do.
+	escalator := NewEscalator(NewOrchestratorClient("http://127.0.0.1:0"))
+	agent := NewReadmeFreshnessAgent(nil, escalator, time.Hour)
+
+	actions := []Action{{
+		Type: ActionOrchestratorJob,
+		Finding: Finding{
+			Fingerprint: readmeFreshnessTag,
+			Source:      readmeFreshnessTag,
+			Title:       "README freshness check",
+		},
+		Payload: map[string]any{"task": "Audit README files for accuracy"},
+	}}
+
+	err := agent.Execute(context.Background(), actions)
+	if err != nil {
+		t.Fatalf("Execute: expected nil when escalator encounters transport error, got: %v", err)
+	}
+}
+
 // TestReadmeFreshnessAgent_CollectFindingContainsLatestSHA verifies that
 // Collect stores "latest_sha" in the finding's Data map so the escalator can
 // attach a sha: tag for deduplication on the next cycle (mirrors

--- a/projects/agent_platform/cluster_agents/rules_agent_test.go
+++ b/projects/agent_platform/cluster_agents/rules_agent_test.go
@@ -316,6 +316,31 @@ func TestRulesAgent_AnalyzeMultipleFindingsProducesOneAction(t *testing.T) {
 	}
 }
 
+// TestRulesAgent_ExecuteEscalatorTransportError verifies that when the
+// orchestrator is unreachable (transport-level failure), Execute returns nil —
+// the escalator logs errors and continues, so the agent's Execute contract is
+// always nil on return.
+func TestRulesAgent_ExecuteEscalatorTransportError(t *testing.T) {
+	// Port 0 refuses connections, causing a transport-level error in client.Do.
+	escalator := NewEscalator(NewOrchestratorClient("http://127.0.0.1:0"))
+	agent := NewRulesAgent(nil, escalator, time.Hour)
+
+	actions := []Action{{
+		Type: ActionOrchestratorJob,
+		Finding: Finding{
+			Fingerprint: rulesTag,
+			Source:      rulesTag,
+			Title:       "Rules improvement",
+		},
+		Payload: map[string]any{"task": "Review semgrep rules for new patterns"},
+	}}
+
+	err := agent.Execute(context.Background(), actions)
+	if err != nil {
+		t.Fatalf("Execute: expected nil when escalator encounters transport error, got: %v", err)
+	}
+}
+
 // TestRulesAgent_AnalyzeMissingCommitRangeFallsBackToEmpty verifies that when
 // the finding's Data map has no "commit_range" key (or the value is not a
 // string), the task is still well-formed and does not contain a placeholder or


### PR DESCRIPTION
## Summary

- Add `TestPRFixAgent_ExecuteEscalatorTransportError`, `TestReadmeFreshnessAgent_ExecuteEscalatorTransportError`, and `TestRulesAgent_ExecuteEscalatorTransportError` — verify that all three agents return `nil` from `Execute` when the orchestrator is completely unreachable at the transport level (the escalator logs errors internally and never propagates them)
- Add `TestGitActivityGate_OrchestratorTransportError` — verify that a transport-level network failure in `lastProcessedCommit` is correctly wrapped as `"fetching last processed commit: ..."`, filling the gap between the existing non-200 HTTP status test and a full connection-refused scenario

## Test plan

- [x] `go test ./projects/agent_platform/cluster_agents/...` passes locally
- [ ] CI (`bb remote test //projects/agent_platform/cluster_agents/... --config=ci`) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)