### PR TITLE
feat(semgrep): add python-shadow-module-import rule

### DIFF
--- a/bazel/semgrep/rules/python/python-shadow-module-import.py
+++ b/bazel/semgrep/rules/python/python-shadow-module-import.py
@@ -1,0 +1,62 @@
+# Tests for python-shadow-module-import rule.
+# Positive cases have `# ruleid:` on the line before the shadowing assignment.
+# Negative cases have `# ok:` on the line before.
+
+from knowledge import links, wikilinks
+import os
+import re
+
+# --- Violations (should be flagged) ---
+
+
+def bad_shadow_from_import():
+    body = "[[some-note]]"
+    # ruleid: python-shadow-module-import
+    wikilinks = links.extract(body)
+    return wikilinks
+
+
+def bad_shadow_bare_import():
+    # ruleid: python-shadow-module-import
+    os = "/tmp/workdir"
+    return os
+
+
+class Reconciler:
+    async def upsert_note(self, body: str):
+        # ruleid: python-shadow-module-import
+        wikilinks = links.extract(body)
+        return wikilinks
+
+    def compile_pattern(self, pattern: str):
+        # ruleid: python-shadow-module-import
+        re = pattern + r"\w+"
+        return re
+
+
+# --- OK cases (should not be flagged) ---
+
+
+def ok_renamed_variable():
+    body = "[[some-note]]"
+    # ok: note_links has a different name than the wikilinks module
+    note_links = wikilinks.extract(body)
+    return note_links
+
+
+def ok_uses_module_not_reassigned():
+    # ok: os is used but not reassigned
+    return os.path.join("/tmp", "file.txt")
+
+
+def ok_augmented_assignment():
+    items = []
+    # ok: augmented assignment appends to a list, not shadowing the module
+    items += [1, 2, 3]
+    return items
+
+
+def ok_unrelated_name():
+    # ok: `path` is not an imported module name
+    path = "/tmp/file.txt"
+    return path

--- a/bazel/semgrep/rules/python/python-shadow-module-import.yaml
+++ b/bazel/semgrep/rules/python/python-shadow-module-import.yaml
@@ -1,0 +1,30 @@
+rules:
+  - id: python-shadow-module-import
+    languages: [python]
+    severity: WARNING
+    message: >-
+      Variable `$MOD` shadows an imported module with the same name. Rename the
+      variable to avoid hiding the module binding, which can cause NameError or
+      subtle bugs when the module is referenced later in the same file.
+    metadata:
+      category: maintainability
+      subcategory: imports
+      confidence: HIGH
+      likelihood: MEDIUM
+      impact: MEDIUM
+      technology: [python]
+      description: local variable assignment shadows a module-level import with the same name
+    patterns:
+      - pattern-either:
+          - pattern: |
+              import $MOD
+              ...
+              $MOD = $EXPR
+          - pattern: |
+              from $PKG import $MOD
+              ...
+              $MOD = $EXPR
+    paths:
+      exclude:
+        - "*_test.py"
+        - "**/tests/**"

--- a/bazel/semgrep/tests/BUILD
+++ b/bazel/semgrep/tests/BUILD
@@ -13,6 +13,7 @@ filegroup(
             "fixtures/no-create-extension-sql.yaml",
             "fixtures/no-discarded-json-marshal.yaml",
             "fixtures/no-shared-preload-libraries-cnpg.yaml",
+            "fixtures/python-shadow-module-import.yaml",
             "fixtures/require-cnpg-cluster-resources.yaml",
             "fixtures/unsafe-json-field-access.yaml",
         ],

--- a/bazel/semgrep/tests/fixtures/python-shadow-module-import.yaml
+++ b/bazel/semgrep/tests/fixtures/python-shadow-module-import.yaml
@@ -1,0 +1,62 @@
+# Reference fixture for the python-shadow-module-import semgrep rule.
+# This file documents ok/bad patterns for human review.
+# The actual semgrep test fixture is bazel/semgrep/rules/python/python-shadow-module-import.py.
+#
+# Evidence: commit 54169c2b (wikilinks local var shadowed wikilinks module import)
+#           commit d5df2b2b (note var shadowed outer scope)
+
+examples:
+  bad:
+    - description: >-
+        local variable `wikilinks` inside a method shadows the module-level
+        `from knowledge import wikilinks` import (real bug from commit 54169c2b)
+      code: |
+        from knowledge import links, wikilinks
+
+        class Reconciler:
+            async def upsert_note(self, body: str):
+                wikilinks = links.extract(body)  # BUG: shadows wikilinks module
+                self.store.upsert_note(links=wikilinks)
+
+    - description: bare `import os` shadowed by a local variable
+      code: |
+        import os
+
+        def process(workdir: str):
+            os = workdir  # BUG: shadows the os module
+            return os
+
+    - description: >-
+        `from module import helper` shadowed by a local variable
+        of the same name inside a function
+      code: |
+        from utils import helper
+
+        def run():
+            helper = lambda x: x  # BUG: shadows the imported helper
+            return helper("data")
+
+  ok:
+    - description: rename the local variable to avoid shadowing (correct fix for 54169c2b)
+      code: |
+        from knowledge import links, wikilinks
+
+        class Reconciler:
+            async def upsert_note(self, body: str):
+                note_links = links.extract(body)  # OK: different name
+                self.store.upsert_note(links=note_links)
+
+    - description: use the imported module without reassigning its name
+      code: |
+        import os
+
+        def get_cwd():
+            return os.getcwd()  # OK: os is used, not rebound
+
+    - description: assign to a clearly different name
+      code: |
+        from utils import helper
+
+        def run():
+            result = helper("data")  # OK: result != helper
+            return result


### PR DESCRIPTION
## Summary

- Adds new semgrep rule `python-shadow-module-import` that flags local variable assignments using the same name as an imported module in the same file
- Motivated by two real bugs: commit 54169c2b (`wikilinks` local var shadowed `from knowledge import wikilinks`) and d5df2b2b (note var shadowed outer scope)
- Covers both `import $MOD` and `from $PKG import $MOD` patterns, catching same-scope and nested-scope (function/method inside file) shadowing

## Files changed

- `bazel/semgrep/rules/python/python-shadow-module-import.yaml` — rule definition
- `bazel/semgrep/rules/python/python-shadow-module-import.py` — semgrep test fixture with `# ruleid:` / `# ok:` annotations (picked up by `python_rules_test`)
- `bazel/semgrep/tests/fixtures/python-shadow-module-import.yaml` — human-readable reference fixture (excluded from yaml_fixtures glob)
- `bazel/semgrep/tests/BUILD` — exclude new YAML reference fixture from `yaml_fixtures` glob

## Test plan

- [ ] `bb remote test //bazel/semgrep/rules:python_rules_test --config=ci` passes with all `# ruleid:` cases detected and all `# ok:` cases clean
- [ ] No regressions in other semgrep test targets

🤖 Generated with [Claude Code](https://claude.com/claude-code)