### PR TITLE
test: add missing ok-case and multi-field fixtures for semgrep python rules

### DIFF
--- a/bazel/semgrep/rules/python/dulwich-commit-missing-author.py
+++ b/bazel/semgrep/rules/python/dulwich-commit-missing-author.py
@@ -16,3 +16,10 @@ porcelain.commit(
     author=b"Bot <bot@example.com>",
     committer=b"Bot <bot@example.com>",
 )
+
+# ok: dulwich-commit-missing-author
+porcelain.commit(
+    repo,
+    message=b"fix: update config",
+    author=b"Bot <bot@example.com>",
+)

--- a/bazel/semgrep/rules/python/sqlmodel-datetime-without-factory.py
+++ b/bazel/semgrep/rules/python/sqlmodel-datetime-without-factory.py
@@ -50,3 +50,16 @@ class OkItemBaseNotTable(SQLModel):
 # ok: sqlmodel-datetime-without-factory
 class OkItemBaseOptionalNotTable(SQLModel):
     indexed_at: Optional[datetime] = None
+
+
+# ruleid: sqlmodel-datetime-without-factory
+class BadItemMultipleDatetimeFields(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    created_at: datetime | None = None
+    updated_at: Optional[datetime] = None
+
+
+# ok: sqlmodel-datetime-without-factory
+class OkItemNosemgrep(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    created_at: datetime | None = None  # nosemgrep: sqlmodel-datetime-without-factory


### PR DESCRIPTION
## Summary

- **dulwich-commit-missing-author**: adds an `# ok:` fixture case where `author=` is present but `committer=` is absent — the rule only requires `author=`, so this should pass without flagging
- **sqlmodel-datetime-without-factory**: adds two new fixture cases:
  - A multi-field bad-case class (`BadItemMultipleDatetimeFields`) with multiple datetime fields lacking `default_factory`, exercising the rule against classes with more than one datetime field
  - A `nosemgrep` inline-suppression `# ok:` case (`OkItemNosemgrep`) verifying that `# nosemgrep: sqlmodel-datetime-without-factory` suppresses the finding as expected

## Test plan

- [ ] CI `python_rules_test` semgrep test passes with the new fixtures
- [ ] No existing fixtures are broken

🤖 Generated with [Claude Code](https://claude.com/claude-code)