### PR TITLE
fix(ships): use current timestamp in zero-deleted cleanup test

### DIFF
--- a/projects/ships/backend/tests/unit_test.py
+++ b/projects/ships/backend/tests/unit_test.py
@@ -1295,8 +1295,9 @@ class TestDatabaseCleanupOldPositionsMultiBatch:
     @pytest.mark.asyncio
     async def test_zero_deleted_returns_zero_and_no_position_count_change(self, mem_db):
         """When nothing is old enough to delete, return 0 and leave count unchanged."""
-        # Insert a fresh position — timestamp is now, well within retention window
-        now = "2024-03-01T10:00:00+00:00"
+        # Insert a fresh position — timestamp is within the last minute, well inside
+        # the retention window regardless of POSITION_RETENTION_DAYS setting.
+        now = datetime.now(timezone.utc).isoformat()
         await mem_db.insert_positions_batch(
             [
                 (


### PR DESCRIPTION
## Summary
- Fixes the one failing test in PR #2004: `test_zero_deleted_returns_zero_and_no_position_count_change`
- The test used a hardcoded `2024-03-01` timestamp which is >2 years old (outside 7-day retention window), causing the position to be deleted
- Replace with `datetime.now(timezone.utc).isoformat()` so the timestamp is always within the retention window

## Test plan
- [ ] `bb remote test //projects/ships/backend/tests:unit_test` passes (all 146 tests)
- [ ] PR #2004 CI passes after this fix merges into the branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)