### PR TITLE
feat(knowledge): add resolved_note_id to typed edge responses

### DIFF
--- a/.claude/skills/knowledge/SKILL.md
+++ b/.claude/skills/knowledge/SKILL.md
@@ -69,10 +69,18 @@ Returns:
           "target_id": "def",
           "kind": "edge",
           "edge_type": "refines",
-          "target_title": null
+          "target_title": null,
+          "resolved_note_id": "def"
         },
         {
-          "target_id": "ghi",
+          "target_id": "ghost-note",
+          "kind": "edge",
+          "edge_type": "related",
+          "target_title": null,
+          "resolved_note_id": null
+        },
+        {
+          "target_id": "Linked Note Title",
           "kind": "link",
           "edge_type": null,
           "target_title": "Linked Note"
@@ -82,6 +90,12 @@ Returns:
   ]
 }
 ```
+
+**Edge resolution:**
+
+- Typed edges (`kind: "edge"`) include `resolved_note_id` — if non-null, you can fetch that note via `/notes/{resolved_note_id}`
+- `resolved_note_id: null` means the target note doesn't exist in the vault (yet)
+- Body wikilinks (`kind: "link"`) do not include `resolved_note_id` — they are visible inline when you read the note content
 
 ### Read note: `GET /api/knowledge/notes/{note_id}`
 
@@ -100,6 +114,30 @@ Returns full note content + edges.
    Do NOT auto-fetch all results. Use the snippet and metadata to decide.
 4. **Read selectively** — fetch full content for relevant notes via the notes endpoint
 5. **Use the context** — reference it, quote it, or let it inform your reasoning
+
+## Graph Traversal
+
+When a search result has edges with `resolved_note_id`, you can follow them to build deeper context. Prioritize `derives_from` and `refines` edges — they indicate direct conceptual lineage.
+
+**Example:** User asks "what's the basis for the SLO work?"
+
+1. Search for "SLO" → find `benchsci-slo-shortlist` (score 0.62)
+2. Check edges → `derives_from: ["benchsci-observability-implementation"]` with `resolved_note_id: "benchsci-observability-implementation"`
+3. Fetch `/notes/benchsci-observability-implementation` → find further `derives_from: ["benchsci-observability-problem-brief"]`
+4. Fetch the problem brief → now you have the full chain: problem → strategy → SLO shortlist
+
+**When to traverse:**
+
+- User asks "why" or "what led to" something — follow `derives_from` edges upstream
+- User asks for detail — follow `refines` edges downstream
+- User asks for related work — follow `related` edges laterally
+- Stop after 2-3 hops or when `resolved_note_id` is null (target doesn't exist)
+
+**When NOT to traverse:**
+
+- The search snippet already answers the question
+- You have enough context from the initial results
+- The edges are all `related` with low relevance to the query
 
 ## Tips
 

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.32.5
+version: 0.33.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.32.5
+      targetRevision: 0.33.0
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/knowledge/router_test.py
+++ b/projects/monolith/knowledge/router_test.py
@@ -145,7 +145,7 @@ class TestSearchEndpoint:
             )
 
     def test_search_results_include_edges(self, client, fake_embed_client):
-        """Search results include edges from NoteLink table."""
+        """Search results include edges with resolved_note_id for typed edges."""
         results_with_edges = [
             {
                 **CANNED_RESULTS[0],
@@ -155,6 +155,7 @@ class TestSearchEndpoint:
                         "kind": "edge",
                         "edge_type": "refines",
                         "target_title": None,
+                        "resolved_note_id": "n2",
                     },
                 ],
             },
@@ -171,6 +172,7 @@ class TestSearchEndpoint:
         assert "edges" in result
         assert result["edges"][0]["target_id"] == "n2"
         assert result["edges"][0]["edge_type"] == "refines"
+        assert result["edges"][0]["resolved_note_id"] == "n2"
 
 
 SAMPLE_NOTE = {

--- a/projects/monolith/knowledge/store.py
+++ b/projects/monolith/knowledge/store.py
@@ -23,6 +23,18 @@ MIN_SEARCH_SCORE = 0.4
 _CHUNK_LEN_RAMP = 100  # chars at which the length penalty reaches 1.0
 
 
+def _resolve_edge_targets(session: Session, rows: list) -> set[str]:
+    """Return the set of target_id values (for kind='edge' rows) that exist as notes."""
+    edge_ids = {r.target_id for r in rows if r.kind == "edge"}
+    if not edge_ids:
+        return set()
+    return set(
+        session.execute(select(Note.note_id).where(Note.note_id.in_(edge_ids)))
+        .scalars()
+        .all()
+    )
+
+
 class KnowledgeStore:
     def __init__(self, session: Session) -> None:
         self.session = session
@@ -254,16 +266,24 @@ class KnowledgeStore:
                 NoteLink.edge_type,
             ).where(NoteLink.src_note_fk.in_(top_ids))
         ).all()
+
+        # Resolve typed edges: check which target note_ids exist so
+        # consumers know which edges are navigable.
+        resolved = _resolve_edge_targets(self.session, edge_rows)
+
         edges_by_note: dict[int, list[dict]] = {}
         for row in edge_rows:
-            edges_by_note.setdefault(row.src_note_fk, []).append(
-                {
-                    "target_id": row.target_id,
-                    "target_title": row.target_title,
-                    "kind": row.kind,
-                    "edge_type": row.edge_type,
-                }
-            )
+            edge: dict = {
+                "target_id": row.target_id,
+                "target_title": row.target_title,
+                "kind": row.kind,
+                "edge_type": row.edge_type,
+            }
+            if row.kind == "edge":
+                edge["resolved_note_id"] = (
+                    row.target_id if row.target_id in resolved else None
+                )
+            edges_by_note.setdefault(row.src_note_fk, []).append(edge)
 
         results: list[dict] = []
         for row in note_rows:
@@ -326,15 +346,23 @@ class KnowledgeStore:
                 NoteLink.edge_type,
             ).where(NoteLink.src_note_fk == note_fk)
         ).all()
-        return [
-            {
+
+        resolved = _resolve_edge_targets(self.session, rows)
+
+        results: list[dict] = []
+        for row in rows:
+            edge: dict = {
                 "target_id": row.target_id,
                 "target_title": row.target_title,
                 "kind": row.kind,
                 "edge_type": row.edge_type,
             }
-            for row in rows
-        ]
+            if row.kind == "edge":
+                edge["resolved_note_id"] = (
+                    row.target_id if row.target_id in resolved else None
+                )
+            results.append(edge)
+        return results
 
     def delete_note(self, path: str) -> None:
         existing = self.session.execute(

--- a/projects/monolith/knowledge/store_test.py
+++ b/projects/monolith/knowledge/store_test.py
@@ -468,3 +468,56 @@ class TestGetNoteById:
 
     def test_returns_none_when_missing(self, store):
         assert store.get_note_by_id("nope") is None
+
+
+class TestGetNoteLinks:
+    def test_edge_resolved_when_target_exists(self, store):
+        """Typed edges include resolved_note_id when target note exists."""
+        _upsert(
+            store,
+            note_id="src",
+            path="src.md",
+            title="Source",
+            metadata=_meta(title="Source", edges={"refines": ["tgt"]}),
+        )
+        _upsert(store, note_id="tgt", path="tgt.md", title="Target")
+
+        links = store.get_note_links("src")
+        edges = [e for e in links if e["kind"] == "edge"]
+        assert len(edges) == 1
+        assert edges[0]["target_id"] == "tgt"
+        assert edges[0]["resolved_note_id"] == "tgt"
+
+    def test_edge_unresolved_when_target_missing(self, store):
+        """Typed edges have resolved_note_id=None when target doesn't exist."""
+        _upsert(
+            store,
+            note_id="src",
+            path="src.md",
+            title="Source",
+            metadata=_meta(title="Source", edges={"related": ["ghost"]}),
+        )
+
+        links = store.get_note_links("src")
+        edges = [e for e in links if e["kind"] == "edge"]
+        assert len(edges) == 1
+        assert edges[0]["target_id"] == "ghost"
+        assert edges[0]["resolved_note_id"] is None
+
+    def test_link_has_no_resolved_note_id(self, store):
+        """Body wikilinks (kind='link') do not include resolved_note_id."""
+        _upsert(
+            store,
+            note_id="src",
+            path="src.md",
+            title="Source",
+            links=[Link(target="Some Title", display=None)],
+        )
+
+        links = store.get_note_links("src")
+        wikilinks = [e for e in links if e["kind"] == "link"]
+        assert len(wikilinks) == 1
+        assert "resolved_note_id" not in wikilinks[0]
+
+    def test_missing_note_returns_empty(self, store):
+        assert store.get_note_links("nonexistent") == []


### PR DESCRIPTION
## Summary

- Typed edges (`kind='edge'`) in knowledge search and note detail responses now include `resolved_note_id` — non-null when the target note exists in the vault, enabling graph traversal
- Body wikilinks (`kind='link'`) are unchanged — they're visible inline when note content is fetched
- Updated `/knowledge` skill with edge resolution docs and a graph traversal workflow example

## Motivation

Both Claude (via the knowledge skill) and the frontend need to know which edges are navigable. Previously, typed edges included a `target_id` but no signal about whether that target actually existed. Now consumers can check `resolved_note_id` to decide whether to follow an edge.

## Changes

| File | Change |
|------|--------|
| `store.py` | Added `_resolve_edge_targets()` helper; updated `search_notes_with_context()` and `get_note_links()` to include `resolved_note_id` on typed edges |
| `store_test.py` | Added `TestGetNoteLinks` class with 4 tests: resolved, unresolved, link-excluded, missing-note |
| `router_test.py` | Updated canned edge data to include `resolved_note_id` |
| `SKILL.md` | Updated response example, added edge resolution docs and graph traversal workflow |

## Test plan

- [ ] `bb remote test //projects/monolith:knowledge_store_test --config=ci` passes
- [ ] `bb remote test //projects/monolith:knowledge_router_test --config=ci` passes
- [ ] CI passes on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)