### PR TITLE
test(knowledge): add unit tests for get_note_links, search edges, ingest_queue internals

### DIFF
--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -2203,6 +2203,29 @@ py_test(
 )
 
 py_test(
+    name = "knowledge_store_note_links_test",
+    srcs = ["knowledge/store_note_links_test.py"],
+    imports = ["."],
+    deps = [
+        ":monolith_backend",
+        "@pip//pgvector",
+        "@pip//pytest",
+        "@pip//sqlmodel",
+    ],
+)
+
+py_test(
+    name = "knowledge_ingest_queue_extra_test",
+    srcs = ["knowledge/ingest_queue_extra_test.py"],
+    imports = ["."],
+    deps = [
+        ":monolith_backend",
+        "@pip//pytest",
+        "@pip//pytest_asyncio",
+    ],
+)
+
+py_test(
     name = "notes_router_whitespace_test",
     srcs = ["notes/router_whitespace_test.py"],
     imports = ["."],

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.32.4
+version: 0.32.5
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.32.4
+      targetRevision: 0.32.5
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/knowledge/ingest_queue_extra_test.py
+++ b/projects/monolith/knowledge/ingest_queue_extra_test.py
@@ -1,0 +1,367 @@
+"""Extra unit tests for ingest_queue: _extract_video_id, _write_raw_md, ingest_handler.
+
+Covers edge cases and paths not exercised by ingest_queue_test.py:
+
+_extract_video_id:
+  - youtu.be short URL
+  - embed URL
+  - query param fallback (v= in arbitrary position)
+  - invalid URL raises ValueError
+
+_write_raw_md:
+  - writes correct frontmatter (title, source, original_url) and body
+  - file is created under _raw/ and parent dirs are created
+
+ingest_handler:
+  - empty queue returns None without touching session
+  - successful youtube ingest calls fetcher + write + commit
+  - successful webpage ingest calls fetcher + write + commit
+  - failed fetch triggers rollback + failed-status update + commit
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, call, patch
+
+import pytest
+
+from knowledge.ingest_queue import (
+    IngestQueueItem,
+    _extract_video_id,
+    _write_raw_md,
+    ingest_handler,
+)
+
+
+# ---------------------------------------------------------------------------
+# _extract_video_id
+# ---------------------------------------------------------------------------
+
+
+class TestExtractVideoId:
+    def test_standard_watch_url(self):
+        url = "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+        assert _extract_video_id(url) == "dQw4w9WgXcQ"
+
+    def test_youtu_be_short_url(self):
+        """youtu.be/<id> is matched by the regex pattern."""
+        assert _extract_video_id("https://youtu.be/dQw4w9WgXcQ") == "dQw4w9WgXcQ"
+
+    def test_embed_url(self):
+        """youtube.com/embed/<id> is matched by the regex pattern."""
+        assert _extract_video_id("https://www.youtube.com/embed/dQw4w9WgXcQ") == "dQw4w9WgXcQ"
+
+    def test_watch_url_with_extra_query_params_regex(self):
+        """v= in a URL where other params precede it — regex still matches."""
+        url = "https://www.youtube.com/watch?v=abcdefghijk&t=5s"
+        assert _extract_video_id(url) == "abcdefghijk"
+
+    def test_query_param_fallback_when_v_not_in_path(self):
+        """When the regex does not match, falls back to parse_qs v= lookup."""
+        # A URL where v= is present but not preceded by the path patterns the
+        # regex expects — this exercises the parse_qs fallback branch.
+        url = "https://www.youtube.com/results?search_query=test&v=xxxxxxxxxxx"
+        assert _extract_video_id(url) == "xxxxxxxxxxx"
+
+    def test_invalid_url_raises_value_error(self):
+        """A URL with no video ID raises ValueError."""
+        with pytest.raises(ValueError, match="cannot extract video ID"):
+            _extract_video_id("https://example.com/not-a-youtube-url")
+
+    def test_bare_youtube_homepage_raises_value_error(self):
+        """youtube.com root with no v= param raises ValueError."""
+        with pytest.raises(ValueError, match="cannot extract video ID"):
+            _extract_video_id("https://www.youtube.com/")
+
+    def test_empty_string_raises_value_error(self):
+        """Empty string raises ValueError."""
+        with pytest.raises(ValueError, match="cannot extract video ID"):
+            _extract_video_id("")
+
+
+# ---------------------------------------------------------------------------
+# _write_raw_md
+# ---------------------------------------------------------------------------
+
+
+class TestWriteRawMd:
+    _NOW = datetime(2026, 4, 11, 12, 0, 0, tzinfo=timezone.utc)
+
+    def _call(self, vault_root, **kw):
+        kwargs = dict(
+            vault_root=vault_root,
+            title="Test Title",
+            body="Body content here.",
+            source_type="youtube",
+            original_url="https://youtube.com/watch?v=abc123",
+            now=self._NOW,
+        )
+        kwargs.update(kw)
+        return _write_raw_md(**kwargs)
+
+    def test_returns_path_object(self, tmp_path):
+        result = self._call(tmp_path)
+        assert isinstance(result, Path)
+
+    def test_file_exists_after_write(self, tmp_path):
+        result = self._call(tmp_path)
+        assert result.exists()
+
+    def test_file_is_under_raw_directory(self, tmp_path):
+        result = self._call(tmp_path)
+        assert str(result).startswith(str(tmp_path / "_raw"))
+
+    def test_creates_parent_directories(self, tmp_path):
+        """Parent dirs under _raw/ are created even if they don't exist."""
+        result = self._call(tmp_path)
+        assert result.parent.is_dir()
+        assert (tmp_path / "_raw").is_dir()
+
+    def test_frontmatter_contains_title(self, tmp_path):
+        result = self._call(tmp_path, title="My Video Title")
+        content = result.read_text(encoding="utf-8")
+        assert 'title: "My Video Title"' in content
+
+    def test_frontmatter_contains_source_type(self, tmp_path):
+        result = self._call(tmp_path, source_type="webpage")
+        content = result.read_text(encoding="utf-8")
+        assert "source: webpage" in content
+
+    def test_frontmatter_contains_original_url(self, tmp_path):
+        url = "https://example.com/some/article"
+        result = self._call(tmp_path, original_url=url)
+        content = result.read_text(encoding="utf-8")
+        assert f"original_url: {url}" in content
+
+    def test_body_written_after_frontmatter(self, tmp_path):
+        result = self._call(tmp_path, body="This is the transcript body.")
+        content = result.read_text(encoding="utf-8")
+        assert "This is the transcript body." in content
+
+    def test_frontmatter_delimited_by_triple_dash(self, tmp_path):
+        result = self._call(tmp_path)
+        content = result.read_text(encoding="utf-8")
+        # Standard YAML frontmatter block
+        assert content.startswith("---\n")
+        # Second --- closes the block
+        assert "\n---\n" in content
+
+    def test_same_content_same_path(self, tmp_path):
+        """Deterministic: same inputs produce the same output path."""
+        path1 = self._call(tmp_path, title="Stable", body="Content")
+        path2 = self._call(
+            tmp_path,
+            title="Stable",
+            body="Content",
+            source_type="youtube",
+            original_url="https://youtube.com/watch?v=abc123",
+        )
+        assert path1 == path2
+
+
+# ---------------------------------------------------------------------------
+# ingest_handler
+# ---------------------------------------------------------------------------
+
+
+def _make_item(source_type="youtube", url="https://youtube.com/watch?v=abc", item_id=1):
+    return IngestQueueItem(
+        id=item_id,
+        url=url,
+        source_type=source_type,
+        status="processing",
+    )
+
+
+class TestIngestHandler:
+    @pytest.mark.asyncio
+    async def test_empty_queue_returns_none(self):
+        """When _claim_one returns None (empty queue), ingest_handler returns None."""
+        session = MagicMock()
+        with patch("knowledge.ingest_queue._claim_one", return_value=None):
+            result = await ingest_handler(session)
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_empty_queue_does_not_commit_or_rollback(self):
+        """Empty queue leaves the session untouched."""
+        session = MagicMock()
+        with patch("knowledge.ingest_queue._claim_one", return_value=None):
+            await ingest_handler(session)
+        session.commit.assert_not_called()
+        session.rollback.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_successful_youtube_ingest_calls_fetcher(self, tmp_path):
+        """youtube source_type dispatches to fetch_youtube_transcript."""
+        item = _make_item(source_type="youtube", url="https://youtube.com/watch?v=abc")
+        session = MagicMock()
+        mock_fetch = AsyncMock(return_value=("YouTube: abc", "transcript here"))
+        with (
+            patch("knowledge.ingest_queue._claim_one", return_value=item),
+            patch("knowledge.ingest_queue.fetch_youtube_transcript", mock_fetch),
+            patch("knowledge.ingest_queue._write_raw_md", return_value=tmp_path / "out.md"),
+            patch.dict("os.environ", {"VAULT_ROOT": str(tmp_path)}),
+        ):
+            await ingest_handler(session)
+        mock_fetch.assert_awaited_once_with(item.url)
+
+    @pytest.mark.asyncio
+    async def test_successful_youtube_ingest_commits(self, tmp_path):
+        """Successful youtube ingest calls session.commit() exactly once."""
+        item = _make_item(source_type="youtube")
+        session = MagicMock()
+        with (
+            patch("knowledge.ingest_queue._claim_one", return_value=item),
+            patch(
+                "knowledge.ingest_queue.fetch_youtube_transcript",
+                AsyncMock(return_value=("Title", "body")),
+            ),
+            patch("knowledge.ingest_queue._write_raw_md", return_value=tmp_path / "out.md"),
+            patch.dict("os.environ", {"VAULT_ROOT": str(tmp_path)}),
+        ):
+            result = await ingest_handler(session)
+        assert result is None
+        session.commit.assert_called_once()
+        session.rollback.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_successful_youtube_ingest_updates_status_to_done(self, tmp_path):
+        """Successful youtube ingest executes an UPDATE with status='done'."""
+        item = _make_item(source_type="youtube", item_id=42)
+        session = MagicMock()
+        with (
+            patch("knowledge.ingest_queue._claim_one", return_value=item),
+            patch(
+                "knowledge.ingest_queue.fetch_youtube_transcript",
+                AsyncMock(return_value=("Title", "body")),
+            ),
+            patch("knowledge.ingest_queue._write_raw_md", return_value=tmp_path / "out.md"),
+            patch.dict("os.environ", {"VAULT_ROOT": str(tmp_path)}),
+        ):
+            await ingest_handler(session)
+        # At least one execute call should mention 'done'
+        execute_sqls = [str(c.args[0]) for c in session.execute.call_args_list]
+        assert any("done" in sql for sql in execute_sqls)
+
+    @pytest.mark.asyncio
+    async def test_successful_webpage_ingest_calls_fetcher(self, tmp_path):
+        """webpage source_type dispatches to fetch_webpage."""
+        item = _make_item(source_type="webpage", url="https://example.com/post")
+        session = MagicMock()
+        mock_fetch = AsyncMock(return_value=("Example Post", "article body"))
+        with (
+            patch("knowledge.ingest_queue._claim_one", return_value=item),
+            patch("knowledge.ingest_queue.fetch_webpage", mock_fetch),
+            patch("knowledge.ingest_queue._write_raw_md", return_value=tmp_path / "out.md"),
+            patch.dict("os.environ", {"VAULT_ROOT": str(tmp_path)}),
+        ):
+            await ingest_handler(session)
+        mock_fetch.assert_awaited_once_with(item.url)
+
+    @pytest.mark.asyncio
+    async def test_successful_webpage_ingest_commits(self, tmp_path):
+        """Successful webpage ingest calls session.commit() exactly once."""
+        item = _make_item(source_type="webpage", url="https://example.com")
+        session = MagicMock()
+        with (
+            patch("knowledge.ingest_queue._claim_one", return_value=item),
+            patch(
+                "knowledge.ingest_queue.fetch_webpage",
+                AsyncMock(return_value=("Title", "body")),
+            ),
+            patch("knowledge.ingest_queue._write_raw_md", return_value=tmp_path / "out.md"),
+            patch.dict("os.environ", {"VAULT_ROOT": str(tmp_path)}),
+        ):
+            result = await ingest_handler(session)
+        assert result is None
+        session.commit.assert_called_once()
+        session.rollback.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_failed_fetch_triggers_rollback(self, tmp_path):
+        """When the fetcher raises, session.rollback() is called."""
+        item = _make_item(source_type="youtube")
+        session = MagicMock()
+        with (
+            patch("knowledge.ingest_queue._claim_one", return_value=item),
+            patch(
+                "knowledge.ingest_queue.fetch_youtube_transcript",
+                AsyncMock(side_effect=RuntimeError("transcript unavailable")),
+            ),
+            patch.dict("os.environ", {"VAULT_ROOT": str(tmp_path)}),
+        ):
+            result = await ingest_handler(session)
+        assert result is None
+        session.rollback.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_failed_fetch_commits_failure_update(self, tmp_path):
+        """After a fetch failure, session.commit() is called for the failed-status update."""
+        item = _make_item(source_type="youtube")
+        session = MagicMock()
+        with (
+            patch("knowledge.ingest_queue._claim_one", return_value=item),
+            patch(
+                "knowledge.ingest_queue.fetch_youtube_transcript",
+                AsyncMock(side_effect=RuntimeError("oops")),
+            ),
+            patch.dict("os.environ", {"VAULT_ROOT": str(tmp_path)}),
+        ):
+            await ingest_handler(session)
+        session.commit.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_failed_fetch_updates_status_to_failed(self, tmp_path):
+        """Failed fetch executes an UPDATE with status='failed'."""
+        item = _make_item(source_type="youtube", item_id=99)
+        session = MagicMock()
+        with (
+            patch("knowledge.ingest_queue._claim_one", return_value=item),
+            patch(
+                "knowledge.ingest_queue.fetch_youtube_transcript",
+                AsyncMock(side_effect=RuntimeError("boom")),
+            ),
+            patch.dict("os.environ", {"VAULT_ROOT": str(tmp_path)}),
+        ):
+            await ingest_handler(session)
+        execute_sqls = [str(c.args[0]) for c in session.execute.call_args_list]
+        assert any("failed" in sql for sql in execute_sqls)
+
+    @pytest.mark.asyncio
+    async def test_failed_fetch_error_message_passed_to_update(self, tmp_path):
+        """The error message is included in the failed-status UPDATE parameters."""
+        item = _make_item(source_type="youtube")
+        session = MagicMock()
+        error_text = "transcript unavailable for this video"
+        with (
+            patch("knowledge.ingest_queue._claim_one", return_value=item),
+            patch(
+                "knowledge.ingest_queue.fetch_youtube_transcript",
+                AsyncMock(side_effect=RuntimeError(error_text)),
+            ),
+            patch.dict("os.environ", {"VAULT_ROOT": str(tmp_path)}),
+        ):
+            await ingest_handler(session)
+        # The error message should appear in the execute call params
+        all_call_kwargs = [str(c) for c in session.execute.call_args_list]
+        assert any(error_text in kw for kw in all_call_kwargs)
+
+    @pytest.mark.asyncio
+    async def test_ingest_handler_returns_none_on_success(self, tmp_path):
+        """ingest_handler always returns None (not a datetime)."""
+        item = _make_item(source_type="webpage", url="https://example.com")
+        session = MagicMock()
+        with (
+            patch("knowledge.ingest_queue._claim_one", return_value=item),
+            patch(
+                "knowledge.ingest_queue.fetch_webpage",
+                AsyncMock(return_value=("Title", "body")),
+            ),
+            patch("knowledge.ingest_queue._write_raw_md", return_value=tmp_path / "out.md"),
+            patch.dict("os.environ", {"VAULT_ROOT": str(tmp_path)}),
+        ):
+            result = await ingest_handler(session)
+        assert result is None

--- a/projects/monolith/knowledge/ingest_queue_extra_test.py
+++ b/projects/monolith/knowledge/ingest_queue_extra_test.py
@@ -51,7 +51,10 @@ class TestExtractVideoId:
 
     def test_embed_url(self):
         """youtube.com/embed/<id> is matched by the regex pattern."""
-        assert _extract_video_id("https://www.youtube.com/embed/dQw4w9WgXcQ") == "dQw4w9WgXcQ"
+        assert (
+            _extract_video_id("https://www.youtube.com/embed/dQw4w9WgXcQ")
+            == "dQw4w9WgXcQ"
+        )
 
     def test_watch_url_with_extra_query_params_regex(self):
         """v= in a URL where other params precede it — regex still matches."""
@@ -202,7 +205,9 @@ class TestIngestHandler:
         with (
             patch("knowledge.ingest_queue._claim_one", return_value=item),
             patch("knowledge.ingest_queue.fetch_youtube_transcript", mock_fetch),
-            patch("knowledge.ingest_queue._write_raw_md", return_value=tmp_path / "out.md"),
+            patch(
+                "knowledge.ingest_queue._write_raw_md", return_value=tmp_path / "out.md"
+            ),
             patch.dict("os.environ", {"VAULT_ROOT": str(tmp_path)}),
         ):
             await ingest_handler(session)
@@ -219,7 +224,9 @@ class TestIngestHandler:
                 "knowledge.ingest_queue.fetch_youtube_transcript",
                 AsyncMock(return_value=("Title", "body")),
             ),
-            patch("knowledge.ingest_queue._write_raw_md", return_value=tmp_path / "out.md"),
+            patch(
+                "knowledge.ingest_queue._write_raw_md", return_value=tmp_path / "out.md"
+            ),
             patch.dict("os.environ", {"VAULT_ROOT": str(tmp_path)}),
         ):
             result = await ingest_handler(session)
@@ -238,7 +245,9 @@ class TestIngestHandler:
                 "knowledge.ingest_queue.fetch_youtube_transcript",
                 AsyncMock(return_value=("Title", "body")),
             ),
-            patch("knowledge.ingest_queue._write_raw_md", return_value=tmp_path / "out.md"),
+            patch(
+                "knowledge.ingest_queue._write_raw_md", return_value=tmp_path / "out.md"
+            ),
             patch.dict("os.environ", {"VAULT_ROOT": str(tmp_path)}),
         ):
             await ingest_handler(session)
@@ -255,7 +264,9 @@ class TestIngestHandler:
         with (
             patch("knowledge.ingest_queue._claim_one", return_value=item),
             patch("knowledge.ingest_queue.fetch_webpage", mock_fetch),
-            patch("knowledge.ingest_queue._write_raw_md", return_value=tmp_path / "out.md"),
+            patch(
+                "knowledge.ingest_queue._write_raw_md", return_value=tmp_path / "out.md"
+            ),
             patch.dict("os.environ", {"VAULT_ROOT": str(tmp_path)}),
         ):
             await ingest_handler(session)
@@ -272,7 +283,9 @@ class TestIngestHandler:
                 "knowledge.ingest_queue.fetch_webpage",
                 AsyncMock(return_value=("Title", "body")),
             ),
-            patch("knowledge.ingest_queue._write_raw_md", return_value=tmp_path / "out.md"),
+            patch(
+                "knowledge.ingest_queue._write_raw_md", return_value=tmp_path / "out.md"
+            ),
             patch.dict("os.environ", {"VAULT_ROOT": str(tmp_path)}),
         ):
             result = await ingest_handler(session)
@@ -360,7 +373,9 @@ class TestIngestHandler:
                 "knowledge.ingest_queue.fetch_webpage",
                 AsyncMock(return_value=("Title", "body")),
             ),
-            patch("knowledge.ingest_queue._write_raw_md", return_value=tmp_path / "out.md"),
+            patch(
+                "knowledge.ingest_queue._write_raw_md", return_value=tmp_path / "out.md"
+            ),
             patch.dict("os.environ", {"VAULT_ROOT": str(tmp_path)}),
         ):
             result = await ingest_handler(session)

--- a/projects/monolith/knowledge/store_note_links_test.py
+++ b/projects/monolith/knowledge/store_note_links_test.py
@@ -1,0 +1,320 @@
+"""Tests for KnowledgeStore.get_note_links() and edges in search_notes_with_context()."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+from sqlmodel import Session, SQLModel, create_engine
+
+from knowledge.frontmatter import ParsedFrontmatter
+from knowledge.links import Link
+from knowledge.models import Chunk, Note, NoteLink
+from knowledge.store import KnowledgeStore
+
+_PG_URL = os.environ.get("TEST_POSTGRES_URL")
+
+
+@pytest.fixture(name="session")
+def session_fixture():
+    from sqlmodel.pool import StaticPool
+
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    original_schemas = {}
+    for table in SQLModel.metadata.tables.values():
+        if table.schema is not None:
+            original_schemas[table.name] = table.schema
+            table.schema = None
+    SQLModel.metadata.create_all(engine)
+    with Session(engine) as session:
+        yield session
+    for table in SQLModel.metadata.tables.values():
+        if table.name in original_schemas:
+            table.schema = original_schemas[table.name]
+
+
+@pytest.fixture(name="pg_session")
+def pg_session_fixture():
+    """Real Postgres session with pgvector for search tests.
+
+    Set TEST_POSTGRES_URL to enable (e.g. ``postgresql://user:pass@host/db``).
+    """
+    if _PG_URL is None:
+        pytest.skip("TEST_POSTGRES_URL not set — skipping Postgres tests")
+    engine = create_engine(_PG_URL)
+    SQLModel.metadata.create_all(engine)
+    with Session(engine) as session:
+        yield session
+    with Session(engine) as session:
+        session.execute(Chunk.__table__.delete())
+        session.execute(NoteLink.__table__.delete())
+        session.execute(Note.__table__.delete())
+        session.commit()
+
+
+@pytest.fixture
+def store(session):
+    return KnowledgeStore(session=session)
+
+
+def _meta(**kw):
+    return ParsedFrontmatter(**kw)
+
+
+def _chunks(n):
+    return [
+        {"index": i, "section_header": f"H{i}", "text": f"chunk {i}"} for i in range(n)
+    ]
+
+
+def _vecs(n):
+    return [[float(i)] * 1024 for i in range(n)]
+
+
+def _upsert(
+    store,
+    *,
+    note_id="a-id",
+    path="a.md",
+    content_hash="h1",
+    title="A",
+    metadata=None,
+    n_chunks=1,
+    links=None,
+):
+    metadata = metadata or _meta(title=title)
+    store.upsert_note(
+        note_id=note_id,
+        path=path,
+        content_hash=content_hash,
+        title=title,
+        metadata=metadata,
+        chunks=_chunks(n_chunks),
+        vectors=_vecs(n_chunks),
+        links=links or [],
+    )
+
+
+# ---------------------------------------------------------------------------
+# get_note_links — unit tests (SQLite)
+# ---------------------------------------------------------------------------
+
+
+class TestGetNoteLinks:
+    def test_note_with_links_returns_correct_dicts(self, store):
+        """A note with wikilinks returns the expected list of link dicts."""
+        _upsert(
+            store,
+            note_id="a-id",
+            path="a.md",
+            links=[
+                Link(target="B", display="the B"),
+                Link(target="C", display=None),
+            ],
+        )
+        links = store.get_note_links("a-id")
+        assert len(links) == 2
+        targets = {lnk["target_id"] for lnk in links}
+        assert targets == {"B", "C"}
+        b_link = next(lnk for lnk in links if lnk["target_id"] == "B")
+        assert b_link["target_title"] == "the B"
+        assert b_link["kind"] == "link"
+        assert b_link["edge_type"] is None
+
+    def test_note_with_edges_returns_correct_dicts(self, store):
+        """Typed frontmatter edges are returned with kind='edge' and edge_type set."""
+        _upsert(
+            store,
+            note_id="a-id",
+            path="a.md",
+            metadata=_meta(title="A", edges={"refines": ["parent-id"]}),
+        )
+        links = store.get_note_links("a-id")
+        assert len(links) == 1
+        assert links[0]["target_id"] == "parent-id"
+        assert links[0]["kind"] == "edge"
+        assert links[0]["edge_type"] == "refines"
+        assert links[0]["target_title"] is None
+
+    def test_note_with_no_links_returns_empty_list(self, store):
+        """A note with no links or edges returns []."""
+        _upsert(store, note_id="a-id", path="a.md", links=[])
+        links = store.get_note_links("a-id")
+        assert links == []
+
+    def test_nonexistent_note_id_returns_empty_list(self, store):
+        """get_note_links for an unknown note_id returns [] without error."""
+        links = store.get_note_links("does-not-exist")
+        assert links == []
+
+    def test_nonexistent_note_id_on_empty_db_returns_empty_list(self, store):
+        """get_note_links on an empty database returns []."""
+        links = store.get_note_links("ghost")
+        assert links == []
+
+    def test_returns_only_links_for_specified_note(self, store):
+        """Links from other notes are not included in the result."""
+        _upsert(
+            store,
+            note_id="a-id",
+            path="a.md",
+            links=[Link(target="X", display=None)],
+        )
+        _upsert(
+            store,
+            note_id="b-id",
+            path="b.md",
+            links=[Link(target="Y", display=None)],
+        )
+        links_a = store.get_note_links("a-id")
+        assert len(links_a) == 1
+        assert links_a[0]["target_id"] == "X"
+
+    def test_result_dict_has_required_keys(self, store):
+        """Every returned dict contains target_id, target_title, kind, edge_type."""
+        _upsert(
+            store,
+            note_id="a-id",
+            path="a.md",
+            links=[Link(target="Z", display="Zee")],
+        )
+        links = store.get_note_links("a-id")
+        assert len(links) == 1
+        assert set(links[0].keys()) == {"target_id", "target_title", "kind", "edge_type"}
+
+    def test_mixed_links_and_edges(self, store):
+        """A note with both wikilinks and frontmatter edges returns all of them."""
+        _upsert(
+            store,
+            note_id="a-id",
+            path="a.md",
+            metadata=_meta(title="A", edges={"related": ["rel-1"]}),
+            links=[Link(target="wiki-1", display=None)],
+        )
+        links = store.get_note_links("a-id")
+        assert len(links) == 2
+        kinds = {lnk["kind"] for lnk in links}
+        assert kinds == {"link", "edge"}
+
+
+# ---------------------------------------------------------------------------
+# search_notes_with_context — edges (Postgres only)
+# ---------------------------------------------------------------------------
+
+
+class TestSearchNotesWithContextEdges:
+    """Verify the ``edges`` key in search_notes_with_context results.
+
+    Requires pgvector (Postgres). Tests are skipped when TEST_POSTGRES_URL
+    is unset, matching the pattern used by TestSearchNotesWithContext in
+    store_test.py.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _setup(self, pg_session):
+        self.session = pg_session
+        self.store = KnowledgeStore(session=pg_session)
+
+    def test_search_result_includes_edges_key(self):
+        """Every search result must have an 'edges' key."""
+        _upsert(self.store, note_id="n1", path="a.md", title="Alpha", n_chunks=1)
+        results = self.store.search_notes_with_context(query_embedding=[0.0] * 1024)
+        assert len(results) == 1
+        assert "edges" in results[0]
+
+    def test_edges_is_list(self):
+        """The 'edges' value is always a list (not None, not dict)."""
+        _upsert(self.store, note_id="n1", path="a.md", title="Alpha", n_chunks=1)
+        results = self.store.search_notes_with_context(query_embedding=[0.0] * 1024)
+        assert isinstance(results[0]["edges"], list)
+
+    def test_empty_edges_when_note_has_no_links(self):
+        """A note with no links or edges produces edges=[]."""
+        _upsert(
+            self.store,
+            note_id="n1",
+            path="a.md",
+            title="Alpha",
+            n_chunks=1,
+            links=[],
+        )
+        results = self.store.search_notes_with_context(query_embedding=[0.0] * 1024)
+        assert results[0]["edges"] == []
+
+    def test_edges_contain_wikilink_data(self):
+        """Wikilinks appear in edges with kind='link' and edge_type=None."""
+        _upsert(
+            self.store,
+            note_id="n1",
+            path="a.md",
+            title="Alpha",
+            n_chunks=1,
+            links=[Link(target="n2", display="Beta")],
+        )
+        results = self.store.search_notes_with_context(query_embedding=[0.0] * 1024)
+        assert len(results) == 1
+        edges = results[0]["edges"]
+        assert len(edges) == 1
+        assert edges[0]["target_id"] == "n2"
+        assert edges[0]["target_title"] == "Beta"
+        assert edges[0]["kind"] == "link"
+        assert edges[0]["edge_type"] is None
+
+    def test_edges_contain_frontmatter_edge_data(self):
+        """Typed frontmatter edges appear in edges with kind='edge' and edge_type set."""
+        _upsert(
+            self.store,
+            note_id="n1",
+            path="a.md",
+            title="Alpha",
+            n_chunks=1,
+            metadata=_meta(title="Alpha", edges={"refines": ["parent-id"]}),
+        )
+        results = self.store.search_notes_with_context(query_embedding=[0.0] * 1024)
+        assert len(results) == 1
+        edges = results[0]["edges"]
+        assert len(edges) == 1
+        assert edges[0]["target_id"] == "parent-id"
+        assert edges[0]["kind"] == "edge"
+        assert edges[0]["edge_type"] == "refines"
+
+    def test_edges_dict_keys(self):
+        """Each edge dict has the four required keys."""
+        _upsert(
+            self.store,
+            note_id="n1",
+            path="a.md",
+            title="Alpha",
+            n_chunks=1,
+            links=[Link(target="x", display="X")],
+        )
+        results = self.store.search_notes_with_context(query_embedding=[0.0] * 1024)
+        edge = results[0]["edges"][0]
+        assert set(edge.keys()) == {"target_id", "target_title", "kind", "edge_type"}
+
+    def test_edges_independent_per_note(self):
+        """Each result only includes edges belonging to that note."""
+        _upsert(
+            self.store,
+            note_id="n1",
+            path="a.md",
+            title="Alpha",
+            n_chunks=1,
+            links=[Link(target="link-a", display=None)],
+        )
+        _upsert(
+            self.store,
+            note_id="n2",
+            path="b.md",
+            title="Beta",
+            n_chunks=1,
+            links=[Link(target="link-b", display=None)],
+        )
+        results = self.store.search_notes_with_context(query_embedding=[0.0] * 1024)
+        by_id = {r["note_id"]: r for r in results}
+        assert by_id["n1"]["edges"][0]["target_id"] == "link-a"
+        assert by_id["n2"]["edges"][0]["target_id"] == "link-b"

--- a/projects/monolith/knowledge/store_note_links_test.py
+++ b/projects/monolith/knowledge/store_note_links_test.py
@@ -184,7 +184,12 @@ class TestGetNoteLinks:
         )
         links = store.get_note_links("a-id")
         assert len(links) == 1
-        assert set(links[0].keys()) == {"target_id", "target_title", "kind", "edge_type"}
+        assert set(links[0].keys()) == {
+            "target_id",
+            "target_title",
+            "kind",
+            "edge_type",
+        }
 
     def test_mixed_links_and_edges(self, store):
         """A note with both wikilinks and frontmatter edges returns all of them."""


### PR DESCRIPTION
## Summary

Adds missing unit tests for code introduced in d32e3af..8083294 (knowledge URL ingest queue and store edges features):

- **`store_note_links_test.py`** — 15 tests for `get_note_links()` (SQLite, no pgvector needed) and for the `edges` key in `search_notes_with_context()` results (Postgres, skipped when `TEST_POSTGRES_URL` unset):
  - `get_note_links()`: note with wikilinks, note with frontmatter edges, note with no links, nonexistent `note_id` returns `[]`, empty DB, scoping to correct note, mixed links+edges, required dict keys
  - `search_notes_with_context` edges: `edges` key present, always a list, empty when no links, wikilink data, frontmatter edge data, required edge dict keys, independent per note

- **`ingest_queue_extra_test.py`** — 27 tests covering three internal functions:
  - `_extract_video_id()`: standard watch URL, `youtu.be` short URL, embed URL, extra query params, query-param fallback (`v=` in non-standard position), invalid URL → `ValueError`, bare homepage → `ValueError`, empty string → `ValueError`
  - `_write_raw_md()`: returns `Path`, file exists, under `_raw/`, parent dirs created, frontmatter contains title/source/original_url, body written, triple-dash delimiters, deterministic path for same inputs
  - `ingest_handler()`: empty queue returns `None` without session touch, youtube success calls fetcher + commits, webpage success calls fetcher + commits, failed fetch triggers rollback + failure-status update + commit, correct status strings in SQL params, always returns `None`

## Test plan

- [x] Tests written following existing pytest + `unittest.mock` + SQLite-in-memory patterns
- [ ] CI: `bazel test //projects/monolith:knowledge_store_note_links_test //projects/monolith:knowledge_ingest_queue_extra_test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)