### PR TITLE
test(knowledge): add resolved_note_id coverage to store_note_links_test

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.33.0
+version: 0.33.1
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.33.0
+      targetRevision: 0.33.1
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/knowledge/store_note_links_test.py
+++ b/projects/monolith/knowledge/store_note_links_test.py
@@ -311,7 +311,7 @@ class TestResolveEdgeTargets:
         _upsert(store, note_id="linked", path="linked.md", title="Linked")
 
         rows = [
-            _make_row("link", "linked"),   # kind='link' — must be ignored
+            _make_row("link", "linked"),  # kind='link' — must be ignored
             _make_row("edge", "missing"),  # kind='edge' but target absent
         ]
         result = _resolve_edge_targets(session, rows)

--- a/projects/monolith/knowledge/store_note_links_test.py
+++ b/projects/monolith/knowledge/store_note_links_test.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import types
 
 import pytest
 from sqlmodel import Session, SQLModel, create_engine
@@ -10,7 +11,7 @@ from sqlmodel import Session, SQLModel, create_engine
 from knowledge.frontmatter import ParsedFrontmatter
 from knowledge.links import Link
 from knowledge.models import Chunk, Note, NoteLink
-from knowledge.store import KnowledgeStore
+from knowledge.store import KnowledgeStore, _resolve_edge_targets
 
 _PG_URL = os.environ.get("TEST_POSTGRES_URL")
 
@@ -126,19 +127,56 @@ class TestGetNoteLinks:
         assert b_link["edge_type"] is None
 
     def test_note_with_edges_returns_correct_dicts(self, store):
-        """Typed frontmatter edges are returned with kind='edge' and edge_type set."""
+        """Typed frontmatter edges are returned with kind='edge', edge_type set,
+        and resolved_note_id indicating whether the target exists."""
         _upsert(
             store,
             note_id="a-id",
             path="a.md",
             metadata=_meta(title="A", edges={"refines": ["parent-id"]}),
         )
+        # "parent-id" has not been inserted, so it should be unresolved.
         links = store.get_note_links("a-id")
         assert len(links) == 1
         assert links[0]["target_id"] == "parent-id"
         assert links[0]["kind"] == "edge"
         assert links[0]["edge_type"] == "refines"
         assert links[0]["target_title"] is None
+        assert "resolved_note_id" in links[0]
+        assert links[0]["resolved_note_id"] is None
+
+    def test_edge_resolved_when_target_exists(self, store):
+        """resolved_note_id equals target_id when the target note exists in the DB."""
+        _upsert(
+            store,
+            note_id="src",
+            path="src.md",
+            title="Source",
+            metadata=_meta(title="Source", edges={"refines": ["tgt"]}),
+        )
+        _upsert(store, note_id="tgt", path="tgt.md", title="Target")
+
+        links = store.get_note_links("src")
+        edges = [e for e in links if e["kind"] == "edge"]
+        assert len(edges) == 1
+        assert edges[0]["target_id"] == "tgt"
+        assert edges[0]["resolved_note_id"] == "tgt"
+
+    def test_edge_unresolved_when_target_missing(self, store):
+        """resolved_note_id is None when the target note does not exist."""
+        _upsert(
+            store,
+            note_id="src",
+            path="src.md",
+            title="Source",
+            metadata=_meta(title="Source", edges={"related": ["ghost"]}),
+        )
+
+        links = store.get_note_links("src")
+        edges = [e for e in links if e["kind"] == "edge"]
+        assert len(edges) == 1
+        assert edges[0]["target_id"] == "ghost"
+        assert edges[0]["resolved_note_id"] is None
 
     def test_note_with_no_links_returns_empty_list(self, store):
         """A note with no links or edges returns []."""
@@ -174,8 +212,8 @@ class TestGetNoteLinks:
         assert len(links_a) == 1
         assert links_a[0]["target_id"] == "X"
 
-    def test_result_dict_has_required_keys(self, store):
-        """Every returned dict contains target_id, target_title, kind, edge_type."""
+    def test_link_kind_dict_has_four_keys(self, store):
+        """Wikilink (kind='link') dicts have exactly 4 keys — no resolved_note_id."""
         _upsert(
             store,
             note_id="a-id",
@@ -191,6 +229,25 @@ class TestGetNoteLinks:
             "edge_type",
         }
 
+    def test_edge_kind_dict_has_five_keys(self, store):
+        """Edge (kind='edge') dicts have exactly 5 keys, including resolved_note_id."""
+        _upsert(
+            store,
+            note_id="a-id",
+            path="a.md",
+            metadata=_meta(title="A", edges={"related": ["some-note"]}),
+        )
+        links = store.get_note_links("a-id")
+        edge_links = [lnk for lnk in links if lnk["kind"] == "edge"]
+        assert len(edge_links) == 1
+        assert set(edge_links[0].keys()) == {
+            "target_id",
+            "target_title",
+            "kind",
+            "edge_type",
+            "resolved_note_id",
+        }
+
     def test_mixed_links_and_edges(self, store):
         """A note with both wikilinks and frontmatter edges returns all of them."""
         _upsert(
@@ -204,6 +261,70 @@ class TestGetNoteLinks:
         assert len(links) == 2
         kinds = {lnk["kind"] for lnk in links}
         assert kinds == {"link", "edge"}
+
+
+# ---------------------------------------------------------------------------
+# _resolve_edge_targets — direct unit tests (SQLite)
+# ---------------------------------------------------------------------------
+
+
+def _make_row(kind: str, target_id: str):
+    """Build a minimal row-like object for _resolve_edge_targets."""
+    return types.SimpleNamespace(kind=kind, target_id=target_id)
+
+
+class TestResolveEdgeTargets:
+    """Direct unit tests for the module-level _resolve_edge_targets helper."""
+
+    def test_empty_rows_returns_empty_set(self, session):
+        result = _resolve_edge_targets(session, [])
+        assert result == set()
+
+    def test_all_targets_exist_returns_all_ids(self, session, store):
+        """When all edge targets are present as notes, returns all their IDs."""
+        _upsert(store, note_id="n1", path="n1.md", title="N1")
+        _upsert(store, note_id="n2", path="n2.md", title="N2")
+
+        rows = [_make_row("edge", "n1"), _make_row("edge", "n2")]
+        result = _resolve_edge_targets(session, rows)
+        assert result == {"n1", "n2"}
+
+    def test_no_targets_exist_returns_empty_set(self, session):
+        """When no edge target notes exist, returns empty set."""
+        rows = [_make_row("edge", "ghost-1"), _make_row("edge", "ghost-2")]
+        result = _resolve_edge_targets(session, rows)
+        assert result == set()
+
+    def test_mixed_existing_and_missing_returns_only_existing(self, session, store):
+        """Returns only the subset of target_ids that resolve to real notes."""
+        _upsert(store, note_id="real", path="real.md", title="Real")
+
+        rows = [
+            _make_row("edge", "real"),
+            _make_row("edge", "phantom"),
+        ]
+        result = _resolve_edge_targets(session, rows)
+        assert result == {"real"}
+
+    def test_non_edge_rows_are_ignored(self, session, store):
+        """Rows with kind != 'edge' are not queried even if target_id exists as a note."""
+        _upsert(store, note_id="linked", path="linked.md", title="Linked")
+
+        rows = [
+            _make_row("link", "linked"),   # kind='link' — must be ignored
+            _make_row("edge", "missing"),  # kind='edge' but target absent
+        ]
+        result = _resolve_edge_targets(session, rows)
+        # "linked" is kind='link' so not included; "missing" doesn't exist.
+        assert result == set()
+
+    def test_only_link_rows_returns_empty_set(self, session, store):
+        """If all rows are kind='link', no DB query is issued and result is empty."""
+        _upsert(store, note_id="n1", path="n1.md", title="N1")
+
+        rows = [_make_row("link", "n1"), _make_row("link", "n2")]
+        result = _resolve_edge_targets(session, rows)
+        assert result == set()
 
 
 # ---------------------------------------------------------------------------
@@ -287,8 +408,8 @@ class TestSearchNotesWithContextEdges:
         assert edges[0]["kind"] == "edge"
         assert edges[0]["edge_type"] == "refines"
 
-    def test_edges_dict_keys(self):
-        """Each edge dict has the four required keys."""
+    def test_edges_dict_keys_for_link_kind(self):
+        """Wikilink (kind='link') edge dicts have exactly 4 keys."""
         _upsert(
             self.store,
             note_id="n1",
@@ -300,6 +421,64 @@ class TestSearchNotesWithContextEdges:
         results = self.store.search_notes_with_context(query_embedding=[0.0] * 1024)
         edge = results[0]["edges"][0]
         assert set(edge.keys()) == {"target_id", "target_title", "kind", "edge_type"}
+
+    def test_edges_dict_keys_for_edge_kind(self):
+        """Typed edge (kind='edge') dicts have 5 keys, including resolved_note_id."""
+        _upsert(
+            self.store,
+            note_id="n1",
+            path="a.md",
+            title="Alpha",
+            n_chunks=1,
+            metadata=_meta(title="Alpha", edges={"related": ["some-target"]}),
+        )
+        results = self.store.search_notes_with_context(query_embedding=[0.0] * 1024)
+        edge = results[0]["edges"][0]
+        assert set(edge.keys()) == {
+            "target_id",
+            "target_title",
+            "kind",
+            "edge_type",
+            "resolved_note_id",
+        }
+
+    def test_edge_resolved_note_id_when_target_exists(self):
+        """resolved_note_id equals target_id when the target note is in the DB."""
+        # Insert both source and target notes.
+        _upsert(
+            self.store,
+            note_id="n1",
+            path="a.md",
+            title="Alpha",
+            n_chunks=1,
+            metadata=_meta(title="Alpha", edges={"refines": ["n2"]}),
+        )
+        _upsert(self.store, note_id="n2", path="b.md", title="Beta", n_chunks=1)
+
+        results = self.store.search_notes_with_context(query_embedding=[0.0] * 1024)
+        n1 = next(r for r in results if r["note_id"] == "n1")
+        edges = [e for e in n1["edges"] if e["kind"] == "edge"]
+        assert len(edges) == 1
+        assert edges[0]["target_id"] == "n2"
+        assert edges[0]["resolved_note_id"] == "n2"
+
+    def test_edge_resolved_note_id_none_when_target_missing(self):
+        """resolved_note_id is None when the target note does not exist."""
+        _upsert(
+            self.store,
+            note_id="n1",
+            path="a.md",
+            title="Alpha",
+            n_chunks=1,
+            metadata=_meta(title="Alpha", edges={"related": ["ghost-note"]}),
+        )
+
+        results = self.store.search_notes_with_context(query_embedding=[0.0] * 1024)
+        assert len(results) == 1
+        edges = [e for e in results[0]["edges"] if e["kind"] == "edge"]
+        assert len(edges) == 1
+        assert edges[0]["target_id"] == "ghost-note"
+        assert edges[0]["resolved_note_id"] is None
 
     def test_edges_independent_per_note(self):
         """Each result only includes edges belonging to that note."""


### PR DESCRIPTION
## Summary

- Update `TestGetNoteLinks` (SQLite) in `store_note_links_test.py`: assert `resolved_note_id` is present on typed edge dicts, add tests for resolved (target exists) vs unresolved (target missing) edges, and verify edge-kind dicts have 5 keys while link-kind dicts have 4
- Add `TestResolveEdgeTargets` with direct unit tests for `_resolve_edge_targets()`: empty input, all targets exist, no targets exist, mixed existing/missing, and non-edge rows ignored
- Update `TestSearchNotesWithContextEdges` (Postgres): add `test_edge_resolved_note_id_when_target_exists` and `test_edge_resolved_note_id_none_when_target_missing`, split `test_edges_dict_keys` into per-kind tests covering the 5-key edge-kind shape

## Test plan

- [x] `bb remote test //projects/monolith:knowledge_store_note_links_test` — PASSED
- [x] `bb remote test //projects/monolith:knowledge_store_test` — PASSED (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)