### PR TITLE
fix(knowledge): prevent gardener from prefixing titles with category labels

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.33.0
+version: 0.33.1
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.33.0
+      targetRevision: 0.33.1
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/knowledge/gardener.py
+++ b/projects/monolith/knowledge/gardener.py
@@ -52,6 +52,10 @@ edges:
 <markdown body>
    IMPORTANT: Always wrap the title value in double quotes to avoid YAML parse errors
    (e.g. `title: "Atomic Note: One Concept"`, NOT `title: Atomic Note: One Concept`).
+   IMPORTANT: Do NOT prefix titles with category labels like "(Book)", "(Concept)", etc.
+   The `type` field already captures the category. The title should be the concept itself.
+   IMPORTANT: The filename MUST be `<id>.md` — i.e. the slugified title. If the id is
+   `staff-engineers-path`, the file must be `{processed_root}/staff-engineers-path.md`.
 5. Patch edges on related existing notes using the Edit tool.
 6. Each note covers exactly one concept. Prefer many small notes over one large note.
 


### PR DESCRIPTION
## Summary
- Adds prompt rules to prevent Claude from prefixing note titles with category labels like "(Book)", "(Concept)", etc.
- Enforces that the filename must match the `id` field (`<id>.md`), preventing title/id/filename divergence that breaks wikilinks

## Test plan
- [ ] Verify CI passes
- [ ] Run gardener on a book-type raw note and confirm title has no parenthetical prefix
- [ ] Confirm generated filename matches the `id` frontmatter field

🤖 Generated with [Claude Code](https://claude.com/claude-code)