### PR TITLE
test(monolith): add prompt template regression guards for title-prefix and filename rules

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.33.1
+version: 0.33.2
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.33.2
+version: 0.33.3
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.33.1
+      targetRevision: 0.33.2
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.33.2
+      targetRevision: 0.33.3
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/knowledge/gardener_test.py
+++ b/projects/monolith/knowledge/gardener_test.py
@@ -850,4 +850,3 @@ class TestPromptTemplateInstructions:
         ensures the instruction is never accidentally removed.
         """
         assert "filename MUST be" in _CLAUDE_PROMPT_HEADER
-        assert row.derived_note_id == "ghost"

--- a/projects/monolith/knowledge/gardener_test.py
+++ b/projects/monolith/knowledge/gardener_test.py
@@ -11,6 +11,7 @@ from sqlmodel.pool import StaticPool
 
 from knowledge.gardener import (
     Gardener,
+    _CLAUDE_PROMPT_HEADER,
     _slugify,
     _split_frontmatter,
 )
@@ -821,4 +822,32 @@ class TestResolvePendingProvenance:
         assert gardener._resolve_pending_provenance() == 0
         row = session.exec(select(AtomRawProvenance)).first()
         assert row.atom_fk is None
+
+
+class TestPromptTemplateInstructions:
+    """Regression guards for critical instructions in _CLAUDE_PROMPT_HEADER.
+
+    Each test pins a specific instruction keyword so that accidental deletions
+    or edits are caught immediately by CI rather than surfacing as silent
+    model-behaviour regressions.
+    """
+
+    def test_prompt_includes_no_title_prefix_instruction(self):
+        """Guard against regression where category-label prefixes reappear in titles.
+
+        Commit 7e6b7a20 added the instruction 'Do NOT prefix titles with
+        category labels' to prevent Claude from emitting titles like
+        '(Book) Staff Engineer's Path'. This assertion ensures the instruction
+        is never accidentally removed.
+        """
+        assert "Do NOT prefix titles with category labels" in _CLAUDE_PROMPT_HEADER
+
+    def test_prompt_includes_filename_must_match_id_instruction(self):
+        """Guard against regression where filenames diverge from their note id.
+
+        Commit 7e6b7a20 added the instruction 'filename MUST be' to enforce
+        that each written file is named exactly '<id>.md'. This assertion
+        ensures the instruction is never accidentally removed.
+        """
+        assert "filename MUST be" in _CLAUDE_PROMPT_HEADER
         assert row.derived_note_id == "ghost"


### PR DESCRIPTION
## Summary

- Adds `TestPromptTemplateInstructions` class to `gardener_test.py` with two simple string-in-constant assertions on `_CLAUDE_PROMPT_HEADER`
- Asserts `'Do NOT prefix titles with category labels'` is present — prevents regression of the title-prefixing fix from commit 7e6b7a20
- Asserts `'filename MUST be'` is present — prevents regression of the filename-must-match-id fix from commit 7e6b7a20

## Test plan

- [x] Patch applied cleanly to remote runner; `bb remote` confirmed code changes are correct
- [x] CI will run `bazel test //...` on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)