### PR TITLE
fix(knowledge): pass raw file path to claude instead of inline content

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.34.2
+version: 0.34.3
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.34.2
+      targetRevision: 0.34.3
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/knowledge/gardener.py
+++ b/projects/monolith/knowledge/gardener.py
@@ -29,17 +29,18 @@ GARDENER_VERSION = "claude-sonnet-4-6@v1"
 _SLUG_RE = re.compile(r"[^a-z0-9]+")
 
 _CLAUDE_PROMPT_HEADER = """\
-You are a knowledge gardener. Decompose the raw note below into atomic knowledge artifacts.
+You are a knowledge gardener. Decompose a raw note into atomic knowledge artifacts.
 
 Source raw_id: {raw_id}
 Include `derived_from_raw: {raw_id}` as a frontmatter field in every note you create.
 
 Steps:
-1. Run `knowledge-search "<topic>"` (Bash) to find related existing notes.
-2. Read related notes from {processed_root}/ using the Read tool.
-3. Create each atomic note as a new file in {processed_root}/ using the Write tool.
+1. Read the raw note from {raw_file_path} using the Read tool.
+2. Run `knowledge-search "<topic>"` (Bash) to find related existing notes.
+3. Read related notes from {processed_root}/ using the Read tool.
+4. Create each atomic note as a new file in {processed_root}/ using the Write tool.
    Allowed types: atom (concept/principle), fact (verifiable claim), active (journal/TODO).
-4. Each file must start with YAML frontmatter:
+5. Each file must start with YAML frontmatter:
 ---
 id: <slug-of-title>
 title: "<concise title — MUST be quoted if it contains a colon>"
@@ -56,8 +57,8 @@ edges:
    The `type` field already captures the category. The title should be the concept itself.
    IMPORTANT: The filename MUST be `<id>.md` — i.e. the slugified title. If the id is
    `staff-engineers-path`, the file must be `{processed_root}/staff-engineers-path.md`.
-5. Patch edges on related existing notes using the Edit tool.
-6. Each note covers exactly one concept. Prefer many small notes over one large note.
+6. Patch edges on related existing notes using the Edit tool.
+7. Each note covers exactly one concept. Prefer many small notes over one large note.
 
 Title: {title}
 
@@ -390,13 +391,11 @@ class Gardener:
             if raw_row is not None:
                 raw_id = raw_row.raw_id
 
-        prompt = (
-            _CLAUDE_PROMPT_HEADER.format(
-                processed_root=self.processed_root,
-                title=title,
-                raw_id=raw_id,
-            )
-            + raw_text
+        prompt = _CLAUDE_PROMPT_HEADER.format(
+            processed_root=self.processed_root,
+            title=title,
+            raw_id=raw_id,
+            raw_file_path=path,
         )
 
         before = (

--- a/projects/monolith/knowledge/gardener_test.py
+++ b/projects/monolith/knowledge/gardener_test.py
@@ -94,10 +94,11 @@ class TestIngestOneClaude:
     async def test_prompt_includes_full_raw_content_for_frontmatter_only_note(
         self, tmp_path
     ):
-        """Frontmatter-only notes (e.g. book refs) must include the raw YAML in the prompt.
+        """The prompt references the raw file by path so Claude reads it via the Read tool.
 
-        If only `body` is passed, Claude receives an empty string and has nothing
-        to decompose, causing timeouts and producing no notes.
+        Previously the raw content was inlined in the prompt, but large files
+        (e.g. YouTube transcripts) exceed Linux ARG_MAX. Now the prompt just
+        contains the file path.
         """
         vault = tmp_path / "vault"
         vault.mkdir()
@@ -134,11 +135,8 @@ class TestIngestOneClaude:
         # The prompt is passed via the -p flag as the last positional arg
         p_idx = list(args).index("-p")
         prompt = args[p_idx + 1]
-        assert "Tanya Reilly" in prompt, "frontmatter author must appear in prompt"
-        assert "9781098118709" in prompt, "frontmatter isbn must appear in prompt"
-        assert "A book about staff engineering." in prompt, (
-            "description must appear in prompt"
-        )
+        assert str(note) in prompt, "raw file path must appear in prompt"
+        assert "Tanya Reilly" not in prompt, "raw content must not be inlined"
 
     @pytest.mark.asyncio
     async def test_spawns_claude_with_correct_flags(self, tmp_path):


### PR DESCRIPTION
## Summary
- YouTube transcripts exceed Linux `ARG_MAX` when passed as `-p` argument to the Claude subprocess
- Changed the gardener prompt to reference the raw file by path, letting Claude read it via the Read tool
- The prompt is now a consistent small size regardless of input length

## Context
Follow-up to #2017. After deploying the dead letter queue, the YouTube videos failed with `OSError: [Errno 7] Argument list too long` — the full transcript was being passed as a CLI argument.

## Test plan
- [ ] CI passes (gardener tests still assert prompt content)
- [ ] Gardener picks up YouTube videos after deploy
- [ ] Verify via SigNoz logs that ingestion succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)