### PR TITLE
fix(monolith): reroute public domain via SvelteKit hook

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.35.1
+version: 0.35.2
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/templates/httproute-public.yaml
+++ b/projects/monolith/chart/templates/httproute-public.yaml
@@ -20,17 +20,11 @@ spec:
       backendRefs:
         - name: {{ include "monolith.fullname" . }}
           port: {{ .Values.cfIngress.public.servicePort | int }}
-    # Everything else — rewrite to /public/
+    # Everything else — SvelteKit reroute hook maps to /public/ internally
     - matches:
         - path:
             type: PathPrefix
             value: /
-      filters:
-        - type: URLRewrite
-          urlRewrite:
-            path:
-              type: ReplacePrefixMatch
-              replacePrefixMatch: /public/
       backendRefs:
         - name: {{ include "monolith.fullname" . }}
           port: {{ .Values.cfIngress.public.servicePort | int }}

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.35.1
+      targetRevision: 0.35.2
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/hooks.js
+++ b/projects/monolith/frontend/src/hooks.js
@@ -1,0 +1,10 @@
+/** @type {import('@sveltejs/kit').Reroute} */
+export function reroute({ url }) {
+  // public.jomcgi.dev/foo → internally route to /public/foo
+  if (
+    url.hostname.startsWith("public.") &&
+    !url.pathname.startsWith("/public/")
+  ) {
+    return `/public${url.pathname}`;
+  }
+}


### PR DESCRIPTION
## Summary
- Envoy Gateway's `ReplacePrefixMatch` on root prefix `/` drops the path separator, producing `/publicobservability-demo` instead of `/public/observability-demo`
- Add SvelteKit `reroute` hook in `src/hooks.js` that internally maps `public.jomcgi.dev/*` to `/public/*` routes without changing the browser URL
- Remove the broken URL rewrite filter from the public HTTPRoute
- Bump chart to 0.35.2

## Test plan
- [ ] Visit `https://public.jomcgi.dev/observability-demo` and verify the page loads
- [ ] Confirm `/_app/` static assets still load correctly
- [ ] Verify `private.jomcgi.dev` routing is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)