### PR TITLE
fix(bazel): improve build hermeticity for semgrep tests and pgvector

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -260,6 +260,7 @@ use_repo(oci, "gdal_python_base", "gdal_python_base_linux_amd64", "gdal_python_b
 # PostgreSQL 16 + pgvector for e2e integration tests
 oci.pull(
     name = "pgvector_pg16",
+    digest = "sha256:6f2fedef8e4311682b3a5989a21bf527d3310ab5421258ad6e41e52955c16294",
     image = "docker.io/pgvector/pgvector",
     platforms = ["linux/amd64"],
     tag = "pg16",

--- a/bazel/semgrep/defs/semgrep-manifest-test.sh
+++ b/bazel/semgrep/defs/semgrep-manifest-test.sh
@@ -13,7 +13,6 @@
 # Env: SEMGREP_EXCLUDE_RULES — comma-separated items to skip. Each item is used in two ways:
 #      1. Matched against YAML filename (basename without .yaml) to exclude entire config files
 #      2. Matched as a suffix against semgrep check_ids to exclude individual rule findings
-#      UPLOAD_SCRIPT          — path to upload binary; uploads results to Semgrep App
 
 set -euo pipefail
 
@@ -185,10 +184,7 @@ if merged["results"]:
     sys.exit(1)
 PYEOF
 
-# Best-effort upload (never affects exit code)
-if [[ -n "${SEMGREP_APP_TOKEN:-}" && -n "${UPLOAD_SCRIPT:-}" && -f "$MERGED_FILE" ]]; then
-	"$UPLOAD_SCRIPT" "$MERGED_FILE" "$SCAN_EXIT" 2>&1 || true
-fi
+# Upload disabled — see semgrep-test.sh comment for rationale.
 
 # When rule-ID exclusions are set, post-filter the JSON results.
 if [[ "$SCAN_EXIT" -ne 0 && ${#EXCLUDE_IDS[@]} -gt 0 ]]; then

--- a/bazel/semgrep/defs/semgrep-test.sh
+++ b/bazel/semgrep/defs/semgrep-test.sh
@@ -13,7 +13,6 @@
 #      1. Matched against YAML filename (basename without .yaml) to exclude entire config files
 #      2. Matched as a suffix against semgrep check_ids to exclude individual rule findings
 # Env: SEMGREP_TEST_MODE — if "1", emits warning and exits 0 (test mode requires pysemgrep)
-#      UPLOAD_SCRIPT     — path to upload binary; uploads results to Semgrep App
 
 set -euo pipefail
 
@@ -520,10 +519,9 @@ PYEOF
 	fi
 fi
 
-# Best-effort upload (never affects exit code)
-if [[ -n "${SEMGREP_APP_TOKEN:-}" && -n "${UPLOAD_SCRIPT:-}" && -f "$MERGED_FILE" ]]; then
-	"$UPLOAD_SCRIPT" "$MERGED_FILE" "$SCAN_EXIT" 2>&1 || true
-fi
+# Upload disabled — semgrep-core scan results are not uploaded to Semgrep App.
+# The upload required network access and git CLI, which broke sandbox hermeticity.
+# Re-enable when Semgrep App integration is set up.
 
 # When rule-ID exclusions are set, post-filter the JSON results.
 # semgrep-core check_ids may or may not be prefixed — suffix matching handles both.

--- a/bazel/semgrep/defs/target_test.bzl
+++ b/bazel/semgrep/defs/target_test.bzl
@@ -28,10 +28,6 @@ def _semgrep_target_test_impl(ctx):
             ",".join(ctx.attr.exclude_rules),
         ))
 
-    # Upload script path
-    upload = ctx.attr._upload[DefaultInfo].files_to_run.executable
-    env_lines.append("export UPLOAD_SCRIPT=\"{}\"".format(upload.short_path))
-
     # Build args: <rule-files> <sca-rule-files> -- <source-files> [-- <lockfile-files>]
     test_runner = ctx.file._test_runner
 
@@ -69,7 +65,6 @@ def _semgrep_target_test_impl(ctx):
     runfiles = ctx.runfiles(files = all_files)
 
     runfiles = runfiles.merge(ctx.attr._engine[DefaultInfo].default_runfiles)
-    runfiles = runfiles.merge(ctx.attr._upload[DefaultInfo].default_runfiles)
     if ctx.attr.pro_engine:
         runfiles = runfiles.merge(ctx.attr.pro_engine[DefaultInfo].default_runfiles)
 
@@ -108,7 +103,6 @@ _semgrep_target_test = rule(
             allow_single_file = True,
         ),
         "_engine": attr.label(default = "//bazel/semgrep/third_party/semgrep:engine"),
-        "_upload": attr.label(default = "//bazel/tools/semgrep:upload"),
     },
 )
 
@@ -129,10 +123,6 @@ def semgrep_target_test(name, target, rules, lockfiles = [], sca_rules = [], exc
         pro_engine: Optional label for semgrep-core-proprietary binary.
         **kwargs: Additional arguments passed to the test rule.
     """
-    tags = kwargs.pop("tags", [])
-    if "no-sandbox" not in tags:
-        tags = tags + ["no-sandbox"]
-
     _semgrep_target_test(
         name = name,
         target = target,
@@ -141,6 +131,6 @@ def semgrep_target_test(name, target, rules, lockfiles = [], sca_rules = [], exc
         sca_rules = sca_rules,
         exclude_rules = exclude_rules,
         pro_engine = pro_engine,
-        tags = tags,
+        tags = kwargs.pop("tags", []),
         **kwargs
     )

--- a/bazel/semgrep/defs/test.bzl
+++ b/bazel/semgrep/defs/test.bzl
@@ -21,7 +21,7 @@ def semgrep_test(
     The semgrep-core binary is discovered at runtime via find(1) in the
     runfiles tree, rather than passed as an argument, because Bazel's
     $(rootpath) can't resolve platform-specific select() targets in sh_test
-    args. GHCR_TOKEN and SEMGREP_APP_TOKEN are required.
+    args. GHCR_TOKEN is required for fetching the engine.
 
     Args:
         name: Name of the test target
@@ -41,13 +41,10 @@ def semgrep_test(
     env = kwargs.pop("env", {})
     if exclude_rules:
         env["SEMGREP_EXCLUDE_RULES"] = ",".join(exclude_rules)
-    env["UPLOAD_SCRIPT"] = "$(rootpath //bazel/tools/semgrep:upload)"
-
     tags = kwargs.pop("tags", [])
 
     data = [
         "//bazel/semgrep/third_party/semgrep:engine",
-        "//bazel/tools/semgrep:upload",
     ] + rules + sca_rules + srcs + lockfiles
 
     if pro_engine:
@@ -86,7 +83,7 @@ def semgrep_manifest_test(
     Args:
         name: Name of the test target
         chart: Path to chart directory (e.g., "charts/todo")
-        chart_files: Label for chart's filegroup (e.g., "//charts/todo:chart")
+        chart_files: Label for chart's filegroup (e.g., "//projects/todo/chart:chart")
         release_name: Helm release name
         namespace: Kubernetes namespace for rendering
         values_files: List of values file labels in order
@@ -99,13 +96,10 @@ def semgrep_manifest_test(
     env = kwargs.pop("env", {})
     if exclude_rules:
         env["SEMGREP_EXCLUDE_RULES"] = ",".join(exclude_rules)
-    env["UPLOAD_SCRIPT"] = "$(rootpath //bazel/tools/semgrep:upload)"
-
     tags = kwargs.pop("tags", [])
 
     data = [
         "//bazel/semgrep/third_party/semgrep:engine",
-        "//bazel/tools/semgrep:upload",
         "@multitool//tools/helm",
         chart_files,
     ] + rules + values_files


### PR DESCRIPTION
## Summary
- Pin `pgvector/pgvector:pg16` OCI image digest in MODULE.bazel — was the only `oci.pull` without a digest, causing non-cacheable fetches and the "Fetching without integrity hash" warning
- Remove non-functional Semgrep App upload from test runners — the upload required network access and git CLI, which was the reason for the `no-sandbox` tag
- Drop automatic `no-sandbox` tag from `semgrep_target_test` — tests now run in Bazel's sandbox for proper hermeticity and remote cacheability

## Test plan
- [ ] CI passes (semgrep tests run sandboxed without errors)
- [ ] Verify pgvector "fetching without integrity hash" warning is gone on next clean fetch

🤖 Generated with [Claude Code](https://claude.com/claude-code)