### PR TITLE
feat(monolith): observability demo UX polish

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.36.0
+version: 0.37.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.36.0
+      targetRevision: 0.37.0
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/routes/+layout.svelte
+++ b/projects/monolith/frontend/src/routes/+layout.svelte
@@ -41,9 +41,9 @@
     --fg: #111;
     --fg-secondary: #555;
     --fg-tertiary: #999;
-    --bg: #f2f0ed;
-    --border: #ccc;
-    --surface: #e8e6e3;
+    --bg: #fff;
+    --border: #d4d4d4;
+    --surface: #f5f5f5;
     --danger: #c53030;
   }
 
@@ -74,9 +74,9 @@
     --fg: #111;
     --fg-secondary: #555;
     --fg-tertiary: #999;
-    --bg: #f2f0ed;
-    --border: #ccc;
-    --surface: #e8e6e3;
+    --bg: #fff;
+    --border: #d4d4d4;
+    --surface: #f5f5f5;
     --danger: #c53030;
   }
 

--- a/projects/monolith/frontend/src/routes/+layout.svelte
+++ b/projects/monolith/frontend/src/routes/+layout.svelte
@@ -59,6 +59,27 @@
     }
   }
 
+  /* Manual theme overrides via toggle button — applied to :root */
+  :global(:root.theme-dark) {
+    --fg: #e8e6e3;
+    --fg-secondary: #999;
+    --fg-tertiary: #666;
+    --bg: #111;
+    --border: #333;
+    --surface: #1a1a1a;
+    --danger: #f56565;
+  }
+
+  :global(:root.theme-light) {
+    --fg: #111;
+    --fg-secondary: #555;
+    --fg-tertiary: #999;
+    --bg: #f2f0ed;
+    --border: #ccc;
+    --surface: #e8e6e3;
+    --danger: #c53030;
+  }
+
   @media (prefers-reduced-motion: reduce) {
     :global(*),
     :global(*::before),

--- a/projects/monolith/frontend/src/routes/public/observability-demo/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/observability-demo/+page.svelte
@@ -139,7 +139,9 @@
   let selected = $state(null);
   let hovered = $state(null);
   let drawing = $state(true);
-  let drawStartTime = 0; // set when animation begins (performance.now())
+  let drawStartTime = 0;
+  let drawTimer = null;
+  let scribbleG = $state(null); // overlay group for scribble-out effect
   let mapSvg = $state(null);
   let roughEdges = $state(null);
   let roughNodes = $state(null);
@@ -152,13 +154,19 @@
   let drawerBorderG = $state(null);
   const active = $derived(hovered || selected);
 
-  let isDark = $state(false);
+  let isDark = $state((() => {
+    const stored = localStorage.getItem("theme");
+    const dark = stored !== null ? stored === "dark" : window.matchMedia("(prefers-color-scheme: dark)").matches;
+    // Apply synchronously to prevent flash on first render
+    document.documentElement.classList.toggle("theme-dark", dark);
+    document.documentElement.classList.toggle("theme-light", !dark);
+    return dark;
+  })());
   $effect(() => {
-    isDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
-  });
-  $effect(() => {
+    // Keep in sync on subsequent toggles
     document.documentElement.classList.toggle("theme-dark", isDark);
     document.documentElement.classList.toggle("theme-light", !isDark);
+    localStorage.setItem("theme", isDark ? "dark" : "light");
   });
   function toggleTheme() {
     isDark = !isDark;
@@ -166,7 +174,19 @@
 
   // ── Responsive layout ────────────────────
   let containerW = $state(960);
-  let containerH = $state(470);
+  let containerH = $state(700);
+
+  // Use window dimensions (not element dimensions) to avoid
+  // feedback loops when CSS 3D transforms change element size
+  $effect(() => {
+    function onResize() {
+      containerW = window.innerWidth;
+      containerH = window.innerHeight;
+    }
+    onResize();
+    window.addEventListener("resize", onResize);
+    return () => window.removeEventListener("resize", onResize);
+  });
 
   // Pick layout that minimizes whitespace by matching container aspect ratio
   const LAND_AR = 960 / 470;  // ~2.04
@@ -175,7 +195,142 @@
     const ar = containerW / containerH;
     return Math.abs(ar - PORT_AR) < Math.abs(ar - LAND_AR);
   });
-  const viewBox = $derived(isPortrait ? "0 10 500 510" : "30 40 960 470");
+
+  // activeLayout is what rough.js is currently rendering.
+  // It lags behind isPortrait during the paper-turn transition.
+  let activeLayout = $state((() => {
+    const ar = window.innerWidth / window.innerHeight;
+    return Math.abs(ar - PORT_AR) < Math.abs(ar - LAND_AR);
+  })()); // matches initial isPortrait so no spurious flip
+  let flipPhase = $state("none");   // "none" | "out" | "in"
+  let scribbling = $state(false);   // true during scribble-out + fade
+  let flipTimer = null;
+  const FLIP_HALF = 300; // ms per half-turn
+  // Initialize to current layout so first $effect run is a no-op (no spurious flip on mount)
+  let lastFlipTarget = (() => {
+    const ar = window.innerWidth / window.innerHeight;
+    return Math.abs(ar - PORT_AR) < Math.abs(ar - LAND_AR);
+  })();
+  let drawGen = $state(0);
+  const SCRIBBLE_DUR = 450; // ms — scribble lines draw across content
+  const FADE_DUR = 350;     // ms — content fades out after scribble
+
+  function doScribbleOut() {
+    if (!scribbleG || !mapSvg) return;
+    clearChildren(scribbleG);
+    const c = colors();
+    const rc = rough.svg(mapSvg);
+    const vb = viewBox.split(" ").map(Number);
+    const [vx, vy, vw, vh] = vb;
+    const margin = 20;
+    const now = Date.now();
+
+    // Random jitter helper — different every time
+    function j(i, axis) {
+      const h = seed("scr" + i + axis + now);
+      return ((h % 80) - 40); // ±40 SVG units
+    }
+
+    // 12 scratchy lines with jittered endpoints — chaotic cross-hatch
+    const lines = [];
+    for (let i = 0; i < 12; i++) {
+      // Alternate between diagonal directions for cross-hatch feel
+      const flip = i % 3;
+      let x1, y1, x2, y2;
+      if (flip === 0) {
+        // top-left to bottom-right
+        x1 = vx + margin + j(i,"x1"); y1 = vy + vh * (0.1 + (i * 0.07) % 0.5) + j(i,"y1");
+        x2 = vx + vw - margin + j(i,"x2"); y2 = vy + vh * (0.4 + (i * 0.05) % 0.5) + j(i,"y2");
+      } else if (flip === 1) {
+        // top-right to bottom-left
+        x1 = vx + vw - margin + j(i,"x1"); y1 = vy + vh * (0.05 + (i * 0.06) % 0.4) + j(i,"y1");
+        x2 = vx + margin + j(i,"x2"); y2 = vy + vh * (0.5 + (i * 0.04) % 0.45) + j(i,"y2");
+      } else {
+        // more horizontal zigzag
+        x1 = vx + vw * (0.1 + (i * 0.08) % 0.3) + j(i,"x1"); y1 = vy + vh * (0.3 + (i * 0.09) % 0.5) + j(i,"y1");
+        x2 = vx + vw * (0.6 + (i * 0.05) % 0.35) + j(i,"x2"); y2 = vy + vh * (0.2 + (i * 0.07) % 0.6) + j(i,"y2");
+      }
+      lines.push([x1, y1, x2, y2]);
+    }
+
+    lines.forEach((coords, i) => {
+      const el = rc.line(coords[0], coords[1], coords[2], coords[3], {
+        stroke: c.danger,
+        roughness: 2.5 + (seed("scr-r" + i + now) % 20) / 10,
+        bowing: 1.5 + (seed("scr-b" + i + now) % 15) / 10,
+        strokeWidth: 1 + (seed("scr-w" + i + now) % 10) / 10,
+        seed: seed("scribble" + i + now),
+      });
+      const stagger = i * 0.03;
+      el.querySelectorAll("path").forEach((path) => {
+        try {
+          const len = path.getTotalLength();
+          path.style.strokeDasharray = String(len);
+          path.style.strokeDashoffset = String(len);
+          path.style.animation = `edgeDraw ${SCRIBBLE_DUR * 0.001}s ease-out ${stagger}s forwards`;
+        } catch { /* ignore */ }
+      });
+      el.style.opacity = String(0.4 + (seed("scr-o" + i + now) % 30) / 100);
+      scribbleG.appendChild(el);
+    });
+  }
+
+  function resetTransitionState() {
+    // Kill all in-flight timers and animation state
+    if (flipTimer) { clearTimeout(flipTimer); flipTimer = null; }
+    if (drawTimer) { clearTimeout(drawTimer); drawTimer = null; }
+    scribbling = false;
+    flipPhase = "none";
+    if (scribbleG) clearChildren(scribbleG);
+  }
+
+  function startFlip(target) {
+    // Clean up any in-progress transition first
+    resetTransitionState();
+
+    const wasMidDraw = drawing;
+
+    if (wasMidDraw) {
+      // Phase 0: scribble lines draw across existing content
+      scribbling = true;
+      doScribbleOut();
+
+      flipTimer = setTimeout(() => {
+        // Phase 1: after scribble, fade out (CSS handles the opacity)
+        flipTimer = setTimeout(() => {
+          // Phase 2: swap layout, full reset, start fresh
+          scribbling = false;
+          if (scribbleG) clearChildren(scribbleG);
+          activeLayout = target;
+          hasAnimated = false;
+          drawStartTime = 0;
+          drawing = true;
+          drawGen++;
+        }, FADE_DUR);
+      }, SCRIBBLE_DUR);
+    } else {
+      // Already done drawing — paper turn flip
+      flipPhase = "out";
+      flipTimer = setTimeout(() => {
+        activeLayout = target;
+        drawGen++;
+        flipPhase = "in";
+        flipTimer = setTimeout(() => {
+          flipPhase = "none";
+        }, FLIP_HALF);
+      }, FLIP_HALF);
+    }
+  }
+
+  // Only track isPortrait — everything else is untracked
+  $effect(() => {
+    const target = isPortrait;
+    if (target === lastFlipTarget) return;
+    lastFlipTarget = target;
+    startFlip(target);
+  });
+
+  const viewBox = $derived(activeLayout ? "0 10 500 510" : "30 40 960 470");
 
   // Portrait node positions (top-to-bottom flow)
   // Longhorn at bottom-left so its storage edges (→postgres, →clickhouse)
@@ -194,7 +349,7 @@
   const portraitById = Object.fromEntries(portraitNodes.map((n) => [n.id, n]));
 
   function getNodePos(id) {
-    if (isPortrait) {
+    if (activeLayout) {
       const p = portraitById[id];
       return { x: p.x, y: p.y };
     }
@@ -224,7 +379,7 @@
       border: s.getPropertyValue("--border").trim(),
       surface: s.getPropertyValue("--surface").trim(),
       danger: s.getPropertyValue("--danger").trim(),
-      warn: isDark ? "#ecc94b" : "#d97706",
+      warn: document.documentElement.classList.contains("theme-dark") ? "#ecc94b" : "#d97706",
     };
   }
 
@@ -487,11 +642,8 @@
   let hasAnimated = false;
   $effect(() => {
     if (!mapSvg || !roughEdges || !roughNodes) return;
-    const _dark = isDark;
-    const _portrait = isPortrait;
-
-    // During animation, allow theme changes to redraw with remaining timings
-    // but don't re-trigger the full animation sequence
+    const _layout = activeLayout;
+    const _gen = drawGen; // bump to force redraw after flip
 
     const c = colors();
     const rc = rough.svg(mapSvg);
@@ -500,6 +652,8 @@
     const shouldAnimate = !hasAnimated;
 
     edges.forEach((e) => {
+      const key = e.from + "-" + e.to;
+
       const fromPos = getNodePos(e.from);
       const toPos = getNodePos(e.to);
       const fromNode = nodeById[e.from];
@@ -508,13 +662,13 @@
       const p2 = boxExit(toPos.x, toPos.y, toNode.hw + 6, HH + 4, fromPos.x, fromPos.y);
 
       // Draw line from BFS-earlier node toward BFS-later node
-      const fwd = animDelay.edgeDir[e.from + "-" + e.to];
+      const fwd = animDelay.edgeDir[key];
       const startPt = fwd ? p1 : p2;
       const endPt = fwd ? p2 : p1;
       const edgeSeed = seed(e.from + e.to);
 
       const g = document.createElementNS("http://www.w3.org/2000/svg", "g");
-      g.dataset.edge = e.from + "-" + e.to;
+      g.dataset.edge = key;
       g.style.transition = "opacity 0.25s ease";
 
       // Pencil sketch (light guide)
@@ -539,7 +693,7 @@
       ink.dataset.layer = "ink";
 
       if (shouldAnimate) {
-        const anim = animDelay.edge[e.from + "-" + e.to];
+        const anim = animDelay.edge[key];
 
         // Pencil: grey sketch, starts with parent's edges
         pencil.querySelectorAll("path").forEach((path) => {
@@ -573,6 +727,7 @@
     });
 
     nodes.forEach((n) => {
+
       const pos = getNodePos(n.id);
       const w = n.hw * 2 + 12;
       const h = HH * 2 + 6;
@@ -689,7 +844,37 @@
     if (shouldAnimate) {
       hasAnimated = true;
       drawStartTime = performance.now();
-      setTimeout(() => { drawing = false; }, animDelay.totalDur * 1000);
+      if (drawTimer) clearTimeout(drawTimer);
+      drawTimer = setTimeout(() => { drawing = false; }, animDelay.totalDur * 1000);
+    }
+  });
+
+  // Recolor rough.js strokes in-place when theme changes (no redraw needed)
+  let prevDark = isDark;
+  $effect(() => {
+    const dark = isDark;
+    if (dark === prevDark) return;
+    prevDark = dark;
+
+    const c = colors();
+    // Recolor edges
+    if (roughEdges) {
+      roughEdges.querySelectorAll("[data-edge]").forEach((g) => {
+        g.querySelector("[data-layer='pencil']")?.querySelectorAll("path").forEach((p) => { p.setAttribute("stroke", c.border); });
+        g.querySelector("[data-layer='ink']")?.querySelectorAll("path").forEach((p) => { p.setAttribute("stroke", c.fgTer); });
+      });
+    }
+    // Recolor nodes
+    if (roughNodes) {
+      roughNodes.querySelectorAll("[data-node]").forEach((g) => {
+        const id = g.dataset.node;
+        const n = nodeById[id];
+        const inkCol = n.status === "degraded" ? c.danger : n.status === "warning" ? c.warn : c.fg;
+        g.querySelectorAll("[data-layer='pencil'] path").forEach((p) => { p.setAttribute("stroke", c.border); });
+        g.querySelectorAll("[data-layer='ink'] path").forEach((p) => { p.setAttribute("stroke", inkCol); });
+        const fill = g.querySelector("[data-layer='fill']");
+        if (fill) fill.querySelectorAll("path").forEach((p) => { p.setAttribute("fill", c.surface); });
+      });
     }
   });
 
@@ -865,7 +1050,7 @@
 
 </script>
 
-<div class="root" class:theme-dark={isDark} class:theme-light={!isDark} class:portrait={isPortrait}>
+<div class="root" class:portrait={isPortrait}>
   <button class="theme-toggle" onclick={toggleTheme} aria-label="Toggle theme">
     {#if isDark}
       <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="5"/><path d="M12 1v2m0 18v2M4.22 4.22l1.42 1.42m12.72 12.72l1.42 1.42M1 12h2m18 0h2M4.22 19.78l1.42-1.42m12.72-12.72l1.42-1.42"/></svg>
@@ -873,6 +1058,12 @@
       <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z"/></svg>
     {/if}
   </button>
+  <div
+    class="map-wrap"
+    class:scribbling
+    class:flip-out={flipPhase === "out"}
+    class:flip-in={flipPhase === "in"}
+  >
   <svg
     bind:this={mapSvg}
     viewBox={viewBox}
@@ -880,27 +1071,30 @@
     role="img"
     aria-label="Service topology"
     preserveAspectRatio="xMidYMin meet"
-    bind:clientWidth={containerW}
-    bind:clientHeight={containerH}
-    style="will-change: contents;"
   >
     <g bind:this={roughEdges}></g>
     <g bind:this={roughNodes}></g>
 
-    {#each nodes as n}
-      {@const pos = getNodePos(n.id)}
-      {@const dimmed = active && !connectedTo(n.id)}
-      <text
-        x={pos.x} y={pos.y + 4}
-        class="node-label"
-        class:node-label--dimmed={dimmed}
-        class:node-label--active={active === n.id}
-        style={drawing ? `opacity:0;animation:textJot ${animDelay.node[n.id].textDur.toFixed(3)}s cubic-bezier(0.2,0,0.1,1) ${animDelay.node[n.id].text.toFixed(3)}s forwards` : ''}
-      >
-        {n.label}
-      </text>
-    {/each}
+    {#key drawGen}
+      {#each nodes as n}
+        {@const pos = getNodePos(n.id)}
+        {@const dimmed = active && !connectedTo(n.id)}
+        {@const visible = nodeDrawn(n.id)}
+        {#if visible || flipPhase === "none"}
+          <text
+            x={pos.x} y={pos.y + 4}
+            class="node-label"
+            class:node-label--dimmed={dimmed}
+            class:node-label--active={active === n.id}
+            style={drawing && flipPhase === "none" ? `opacity:0;animation:textJot ${animDelay.node[n.id].textDur.toFixed(3)}s cubic-bezier(0.2,0,0.1,1) ${animDelay.node[n.id].text.toFixed(3)}s forwards` : visible ? '' : 'opacity:0'}
+          >
+            {n.label}
+          </text>
+        {/if}
+      {/each}
+    {/key}
 
+    <g bind:this={scribbleG}></g>
     <g bind:this={tooltipRough}></g>
 
     {#if hovered && !selected}
@@ -936,6 +1130,7 @@
       />
     {/each}
   </svg>
+  </div>
 
 
   <!-- ── Detail drawer ────────────────────── -->
@@ -1067,12 +1262,53 @@
     -webkit-font-feature-settings: "liga" 0;
     font-feature-settings: "liga" 0;
     transition: color 0.3s ease, background 0.3s ease;
+    perspective: 1200px;
+  }
+
+  .map-wrap {
+    flex: 1;
+    width: 100%;
+    min-height: 0;
+    padding: 16px;
+    overflow: hidden;
+    transform-origin: center center;
+    transform-style: preserve-3d;
+    transition: opacity 0.15s ease;
   }
 
   .map {
-    flex: 1;
     width: 100%;
-    padding: 16px;
+    height: 100%;
+  }
+
+  /* Scribble-out: scribble draws (250ms), then content fades out (200ms) */
+  .map-wrap.scribbling {
+    animation: scribbleFade 0.8s ease-in forwards;
+  }
+
+  @keyframes scribbleFade {
+    0%   { opacity: 1; }
+    56%  { opacity: 1; }   /* hold while scribble lines draw (450/800) */
+    100% { opacity: 0; }   /* fade to nothing over remaining 350ms */
+  }
+
+  /* Paper turn: used for post-draw layout transitions only */
+  .map-wrap.flip-out {
+    animation: flipOut 0.3s ease-in forwards;
+  }
+
+  .map-wrap.flip-in {
+    animation: flipIn 0.3s ease-out forwards;
+  }
+
+  @keyframes flipOut {
+    from { transform: rotateY(0deg); }
+    to   { transform: rotateY(90deg); }
+  }
+
+  @keyframes flipIn {
+    from { transform: rotateY(-90deg); }
+    to   { transform: rotateY(0deg); }
   }
 
   /* ── Theme toggle ─────────────────────────── */

--- a/projects/monolith/frontend/src/routes/public/observability-demo/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/observability-demo/+page.svelte
@@ -150,17 +150,58 @@
   let budgetRoughG = $state(null);
   let drawerBorderSvg = $state(null);
   let drawerBorderG = $state(null);
-
   const active = $derived(hovered || selected);
 
   let isDark = $state(false);
   $effect(() => {
-    const mq = window.matchMedia("(prefers-color-scheme: dark)");
-    isDark = mq.matches;
-    const handler = (e) => { isDark = e.matches; };
-    mq.addEventListener("change", handler);
-    return () => mq.removeEventListener("change", handler);
+    isDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
   });
+  $effect(() => {
+    document.documentElement.classList.toggle("theme-dark", isDark);
+    document.documentElement.classList.toggle("theme-light", !isDark);
+  });
+  function toggleTheme() {
+    isDark = !isDark;
+  }
+
+  // ── Responsive layout ────────────────────
+  let containerW = $state(960);
+  let containerH = $state(470);
+
+  // Pick layout that minimizes whitespace by matching container aspect ratio
+  const LAND_AR = 960 / 470;  // ~2.04
+  const PORT_AR = 500 / 510;  // ~0.98
+  const isPortrait = $derived.by(() => {
+    const ar = containerW / containerH;
+    return Math.abs(ar - PORT_AR) < Math.abs(ar - LAND_AR);
+  });
+  const viewBox = $derived(isPortrait ? "0 10 500 510" : "30 40 960 470");
+
+  // Portrait node positions (top-to-bottom flow)
+  // Longhorn at bottom-left so its storage edges (→postgres, →clickhouse)
+  // run vertically and horizontally without crossing signoz/nats.
+  const portraitNodes = [
+    { id: "cloudflare", x: 250, y: 70 },
+    { id: "argocd", x: 80, y: 190 },
+    { id: "monolith", x: 250, y: 190 },
+    { id: "postgres", x: 100, y: 320 },
+    { id: "nats", x: 250, y: 320 },
+    { id: "signoz", x: 400, y: 320 },
+    { id: "longhorn", x: 100, y: 430 },
+    { id: "clickhouse", x: 400, y: 430 },
+    { id: "agents", x: 250, y: 470 },
+  ];
+  const portraitById = Object.fromEntries(portraitNodes.map((n) => [n.id, n]));
+
+  function getNodePos(id) {
+    if (isPortrait) {
+      const p = portraitById[id];
+      return { x: p.x, y: p.y };
+    }
+    const n = nodes.find((n) => n.id === id);
+    return { x: n.x, y: n.y };
+  }
+
 
   // ── Helpers ────────────────────────────────
   function seed(s) {
@@ -183,7 +224,7 @@
       border: s.getPropertyValue("--border").trim(),
       surface: s.getPropertyValue("--surface").trim(),
       danger: s.getPropertyValue("--danger").trim(),
-      warn: isDark ? "#d69e2e" : "#b7791f",
+      warn: isDark ? "#ecc94b" : "#d97706",
     };
   }
 
@@ -447,9 +488,10 @@
   $effect(() => {
     if (!mapSvg || !roughEdges || !roughNodes) return;
     const _dark = isDark;
+    const _portrait = isPortrait;
 
-    // Skip dark-mode redraws while the initial animation is still running
-    if (hasAnimated && drawStartTime && (performance.now() - drawStartTime) / 1000 < animDelay.totalDur) return;
+    // During animation, allow theme changes to redraw with remaining timings
+    // but don't re-trigger the full animation sequence
 
     const c = colors();
     const rc = rough.svg(mapSvg);
@@ -458,10 +500,12 @@
     const shouldAnimate = !hasAnimated;
 
     edges.forEach((e) => {
-      const from = nodeById[e.from];
-      const to = nodeById[e.to];
-      const p1 = boxExit(from.x, from.y, from.hw + 6, HH + 4, to.x, to.y);
-      const p2 = boxExit(to.x, to.y, to.hw + 6, HH + 4, from.x, from.y);
+      const fromPos = getNodePos(e.from);
+      const toPos = getNodePos(e.to);
+      const fromNode = nodeById[e.from];
+      const toNode = nodeById[e.to];
+      const p1 = boxExit(fromPos.x, fromPos.y, fromNode.hw + 6, HH + 4, toPos.x, toPos.y);
+      const p2 = boxExit(toPos.x, toPos.y, toNode.hw + 6, HH + 4, fromPos.x, fromPos.y);
 
       // Draw line from BFS-earlier node toward BFS-later node
       const fwd = animDelay.edgeDir[e.from + "-" + e.to];
@@ -529,6 +573,7 @@
     });
 
     nodes.forEach((n) => {
+      const pos = getNodePos(n.id);
       const w = n.hw * 2 + 12;
       const h = HH * 2 + 6;
       const inkCol = n.status === "degraded" ? c.danger : n.status === "warning" ? c.warn : c.fg;
@@ -540,7 +585,7 @@
       g.style.transition = "opacity 0.25s ease";
 
       // Fill rectangle (hidden by default, shown when active via highlight effect)
-      const fillEl = rc.rectangle(n.x - w / 2, n.y - h / 2, w, h, {
+      const fillEl = rc.rectangle(pos.x - w / 2, pos.y - h / 2, w, h, {
         stroke: "none", fill: c.surface, fillStyle: "solid",
         roughness: r, seed: seed(n.id + "fill"),
       });
@@ -550,8 +595,8 @@
       g.appendChild(fillEl);
 
       // 4 sequential strokes, rotated to start from the nearest corner to the incoming edge
-      const x1 = n.x - w / 2, y1 = n.y - h / 2;
-      const x2 = n.x + w / 2, y2 = n.y + h / 2;
+      const x1 = pos.x - w / 2, y1 = pos.y - h / 2;
+      const x2 = pos.x + w / 2, y2 = pos.y + h / 2;
       // Canonical order starting from each corner (clockwise):
       // Corner 0 (TL): top→right→bottom→left
       // Corner 1 (TR): right→bottom→left→top
@@ -686,17 +731,17 @@
     const _hovered = hovered;
     if (!_hovered || selected) return;
 
-    const n = nodeById[_hovered];
+    const pos = getNodePos(_hovered);
     const s = svc[_hovered];
     if (!s?.brief) return;
 
     const c = colors();
     const rc = rough.svg(mapSvg);
     const tipW = s.brief.length * 5.2 + 20;
-    const tipY = n.y - HH - 24;
+    const tipY = pos.y - HH - 24;
 
     tooltipRough.appendChild(
-      rc.rectangle(n.x - tipW / 2, tipY - 9, tipW, 18, {
+      rc.rectangle(pos.x - tipW / 2, tipY - 9, tipW, 18, {
         stroke: c.border,
         fill: c.bg,
         fillStyle: "solid",
@@ -820,22 +865,33 @@
 
 </script>
 
-<div class="root">
+<div class="root" class:theme-dark={isDark} class:theme-light={!isDark} class:portrait={isPortrait}>
+  <button class="theme-toggle" onclick={toggleTheme} aria-label="Toggle theme">
+    {#if isDark}
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="5"/><path d="M12 1v2m0 18v2M4.22 4.22l1.42 1.42m12.72 12.72l1.42 1.42M1 12h2m18 0h2M4.22 19.78l1.42-1.42m12.72-12.72l1.42-1.42"/></svg>
+    {:else}
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z"/></svg>
+    {/if}
+  </button>
   <svg
     bind:this={mapSvg}
-    viewBox="30 40 960 470"
+    viewBox={viewBox}
     class="map"
     role="img"
     aria-label="Service topology"
-    preserveAspectRatio="xMidYMid meet"
+    preserveAspectRatio="xMidYMin meet"
+    bind:clientWidth={containerW}
+    bind:clientHeight={containerH}
+    style="will-change: contents;"
   >
     <g bind:this={roughEdges}></g>
     <g bind:this={roughNodes}></g>
 
     {#each nodes as n}
+      {@const pos = getNodePos(n.id)}
       {@const dimmed = active && !connectedTo(n.id)}
       <text
-        x={n.x} y={n.y + 4}
+        x={pos.x} y={pos.y + 4}
         class="node-label"
         class:node-label--dimmed={dimmed}
         class:node-label--active={active === n.id}
@@ -848,18 +904,19 @@
     <g bind:this={tooltipRough}></g>
 
     {#if hovered && !selected}
-      {@const n = nodeById[hovered]}
+      {@const pos = getNodePos(hovered)}
       {@const s = svc[hovered]}
       {#if s?.brief}
-        <text x={n.x} y={n.y - HH - 24} class="tooltip-text" dominant-baseline="central">{s.brief}</text>
+        <text x={pos.x} y={pos.y - HH - 24} class="tooltip-text" dominant-baseline="central">{s.brief}</text>
       {/if}
     {/if}
 
     {#each nodes as n}
+      {@const pos = getNodePos(n.id)}
       {@const w = n.hw * 2 + 12}
       <rect
-        x={n.x - w / 2}
-        y={n.y - HH - 3}
+        x={pos.x - w / 2}
+        y={pos.y - HH - 3}
         width={w}
         height={HH * 2 + 6}
         fill="transparent"
@@ -996,24 +1053,51 @@
   /* ── Layout ──────────────────────────────── */
 
   .root {
+    position: relative;
     display: flex;
     flex-direction: column;
     height: 100vh;
     width: 100%;
     font-family: var(--font);
-    font-size: 1rem;
+    font-size: 16px;
     line-height: 1.5;
     color: var(--fg);
     background: var(--bg);
     overflow: hidden;
     -webkit-font-feature-settings: "liga" 0;
     font-feature-settings: "liga" 0;
+    transition: color 0.3s ease, background 0.3s ease;
   }
 
   .map {
     flex: 1;
     width: 100%;
-    padding: 1.5rem 2rem;
+    padding: 16px;
+  }
+
+  /* ── Theme toggle ─────────────────────────── */
+
+  .theme-toggle {
+    position: absolute;
+    top: 0.75rem;
+    right: 0.75rem;
+    z-index: 30;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    color: var(--fg-secondary);
+    cursor: pointer;
+    padding: 0.35rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: color 0.2s ease, background 0.2s ease, border-color 0.2s ease;
+    line-height: 0;
+  }
+
+  .theme-toggle:hover {
+    color: var(--fg);
+    background: var(--border);
   }
 
   /* ── Drawing animation: per-element DFS stagger */
@@ -1041,7 +1125,7 @@
     font-weight: 700;
     fill: var(--fg);
     text-anchor: middle;
-    transition: opacity 0.2s ease;
+    transition: opacity 0.2s ease, x 0.5s cubic-bezier(0.4, 0, 0.2, 1), y 0.5s cubic-bezier(0.4, 0, 0.2, 1);
   }
 
   .node-label--dimmed { opacity: 0.25; }
@@ -1057,6 +1141,7 @@
 
   .hit-area {
     outline: none;
+    transition: x 0.5s cubic-bezier(0.4, 0, 0.2, 1), y 0.5s cubic-bezier(0.4, 0, 0.2, 1);
   }
 
   /* ── Backdrop + Drawer ───────────────────── */


### PR DESCRIPTION
## Summary
- **Responsive layout**: Portrait/landscape switching based on aspect ratio, minimizing whitespace
- **Paper turn transition**: 3D rotateY flip for post-draw layout changes; scribble-out + fade for mid-draw transitions (12 jittered rough.js cross-hatch lines)
- **Dark mode**: Toggle button with localStorage persistence and system preference fallback. In-place SVG stroke recoloring mid-animation (no restart)
- **Clean palette**: White (#fff) light mode background for stronger brutalist contrast
- **Smooth scaling**: Fixed viewBox with xMidYMin meet, window-based dimensions to avoid 3D transform feedback loops
- **State management**: Proper timer/animation reset on rapid layout transitions, {#key drawGen} for CSS animation restart

## Test plan
- [ ] Page loads and drawing animation plays smoothly
- [ ] Resize browser h→v mid-draw: scribble-out, fade, fresh draw in new layout
- [ ] Resize browser h→v→h rapidly: clean state reset, no stale rendering
- [ ] Resize after drawing completes: paper turn flip, instant static render
- [ ] Dark mode toggle mid-draw: ink recolors instantly, animation continues
- [ ] Dark mode persists across page reload
- [ ] No background flash on first load (light or dark)
- [ ] Click nodes to open drawer, Escape to close
- [ ] Reduced motion: all animations disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)