### PR TITLE
docs(obsidian_vault): fix README inaccuracies

### DIFF
--- a/projects/obsidian_vault/README.md
+++ b/projects/obsidian_vault/README.md
@@ -55,7 +55,7 @@ secrets:
     itemPath: "vaults/<your-1password-vault>/items/<item-name>"
 ```
 
-The 1Password item should contain a `token` field with your GitHub personal access token.
+The 1Password item should contain a `GITHUB_TOKEN` field with your GitHub personal access token.
 
 ### Enabling Obsidian Cloud Sync
 
@@ -80,7 +80,7 @@ gateway:
     itemPath: "vaults/<your-1password-vault>/items/<gateway-secret>"
 ```
 
-A Helm post-install hook will automatically register the server with the gateway.
+A Helm post-install and post-upgrade hook will automatically register the server with the gateway.
 
 ### Full Values Reference
 


### PR DESCRIPTION
## Summary

- Corrects the 1Password field name: the README said `token` but `deployment.yaml` reads the secret using `key: GITHUB_TOKEN`.
- Fixes the gateway hook description: the README said "post-install hook" but `registration-job.yaml` declares `post-install,post-upgrade` — it fires on upgrades too.

## Test plan

- [ ] Verify `GITHUB_TOKEN` field name matches `projects/obsidian_vault/chart/templates/deployment.yaml`
- [ ] Verify `post-install,post-upgrade` annotation matches `projects/obsidian_vault/chart/templates/registration-job.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)