### PR TITLE
test(trips): add coverage for CLI command integration

### DIFF
--- a/projects/trips/tools/delete-trip-points/BUILD
+++ b/projects/trips/tools/delete-trip-points/BUILD
@@ -76,3 +76,23 @@ semgrep_test(
     exclude_rules = ["test-hardcoded-past-timestamp"],
     rules = ["//bazel/semgrep/rules:python_rules"],
 )
+
+# gazelle:resolve py cli_test //projects/trips/tools/delete-trip-points:delete-trip-points
+py_test(
+    name = "cli_test",
+    srcs = ["cli_test.py"],
+    imports = ["."],
+    deps = [
+        "//projects/trips/tools/delete-trip-points",
+        "@pip//pytest",
+        "@pip//pytest_asyncio",
+        "@pip//typer",
+    ],
+)
+
+semgrep_test(
+    name = "cli_test_semgrep_test",
+    srcs = ["cli_test.py"],
+    exclude_rules = ["test-hardcoded-past-timestamp"],
+    rules = ["//bazel/semgrep/rules:python_rules"],
+)

--- a/projects/trips/tools/delete-trip-points/BUILD
+++ b/projects/trips/tools/delete-trip-points/BUILD
@@ -85,7 +85,6 @@ py_test(
     deps = [
         "//projects/trips/tools/delete-trip-points",
         "@pip//pytest",
-        "@pip//pytest_asyncio",
         "@pip//typer",
     ],
 )

--- a/projects/trips/tools/delete-trip-points/cli_test.py
+++ b/projects/trips/tools/delete-trip-points/cli_test.py
@@ -1,0 +1,408 @@
+"""CLI integration tests for delete-trip-points — Typer command flows.
+
+Tests exercise by_date(), by_id(), and list_gaps() end-to-end using
+typer.testing.CliRunner with mocked HTTP (httpx) and NATS.
+"""
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from main import app
+
+runner = CliRunner()
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_api_response(points: list[dict]) -> MagicMock:
+    """Build a mock httpx response returning the given points list."""
+    mock_resp = MagicMock()
+    mock_resp.raise_for_status = MagicMock()
+    mock_resp.json.return_value = {"points": points}
+    return mock_resp
+
+
+def _make_nats_mocks():
+    """Return (mock_nc, mock_js) with nc.close() and js.publish() wired up."""
+    mock_js = AsyncMock()
+    mock_nc = AsyncMock()
+    mock_nc.jetstream = MagicMock(return_value=mock_js)
+    return mock_nc, mock_js
+
+
+_SAMPLE_POINTS = [
+    {
+        "id": "g1",
+        "timestamp": "2025-06-15T08:00:00",
+        "source": "gap",
+        "lat": 60.0,
+        "lng": -135.0,
+    },
+    {
+        "id": "g2",
+        "timestamp": "2025-06-15T09:00:00",
+        "source": "gap",
+        "lat": 60.1,
+        "lng": -135.1,
+    },
+    {
+        "id": "p1",
+        "timestamp": "2025-06-15T08:30:00",
+        "source": "gopro",
+        "lat": 60.2,
+        "lng": -135.2,
+    },
+    {
+        "id": "g3",
+        "timestamp": "2025-06-16T08:00:00",
+        "source": "gap",
+        "lat": 61.0,
+        "lng": -136.0,
+    },
+]
+
+
+# ---------------------------------------------------------------------------
+# by_date — dry run (no NATS connection needed)
+# ---------------------------------------------------------------------------
+
+
+class TestByDateDryRun:
+    """by_date --dry-run shows what would be deleted without publishing."""
+
+    def _run(self, extra_args=None):
+        args = ["by-date", "2025-06-15", "--dry-run"]
+        if extra_args:
+            args += extra_args
+
+        mock_resp = _make_api_response(_SAMPLE_POINTS)
+
+        async def _fake_get(*args, **kwargs):
+            return mock_resp
+
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client.get = _fake_get
+
+        with patch("main.httpx.AsyncClient", return_value=mock_client):
+            return runner.invoke(app, args)
+
+    def test_exit_code_zero(self):
+        result = self._run()
+        assert result.exit_code == 0, result.output
+
+    def test_shows_dry_run_banner(self):
+        result = self._run()
+        assert "[DRY RUN]" in result.output
+
+    def test_shows_point_count(self):
+        result = self._run()
+        # Two gap points on 2025-06-15
+        assert "2 gap points" in result.output
+
+    def test_no_nats_connection_in_dry_run(self):
+        """NATS must not be contacted when --dry-run is active."""
+        mock_resp = _make_api_response(_SAMPLE_POINTS)
+
+        async def _fake_get(*args, **kwargs):
+            return mock_resp
+
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client.get = _fake_get
+
+        with (
+            patch("main.httpx.AsyncClient", return_value=mock_client),
+            patch("main.nats.connect") as mock_connect,
+        ):
+            result = runner.invoke(app, ["by-date", "2025-06-15", "--dry-run"])
+
+        assert result.exit_code == 0
+        mock_connect.assert_not_called()
+
+    def test_no_points_for_date_exits_cleanly(self):
+        mock_resp = _make_api_response(_SAMPLE_POINTS)
+
+        async def _fake_get(*args, **kwargs):
+            return mock_resp
+
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client.get = _fake_get
+
+        with patch("main.httpx.AsyncClient", return_value=mock_client):
+            result = runner.invoke(app, ["by-date", "2099-01-01", "--dry-run"])
+
+        assert result.exit_code == 0
+        assert "No gap points" in result.output
+
+    def test_custom_source_filter(self):
+        mock_resp = _make_api_response(_SAMPLE_POINTS)
+
+        async def _fake_get(*args, **kwargs):
+            return mock_resp
+
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client.get = _fake_get
+
+        with patch("main.httpx.AsyncClient", return_value=mock_client):
+            # Filter by 'gopro' source — only p1 matches 2025-06-15/gopro
+            result = runner.invoke(
+                app,
+                ["by-date", "2025-06-15", "--source", "gopro", "--dry-run"],
+            )
+
+        assert result.exit_code == 0
+        assert "1 gopro points" in result.output
+
+
+# ---------------------------------------------------------------------------
+# by_date — full run (with NATS, --yes to skip confirmation)
+# ---------------------------------------------------------------------------
+
+
+class TestByDateFullRun:
+    """by_date without --dry-run publishes tombstones to NATS."""
+
+    def _run_with_mocks(self, date: str, points: list[dict], extra_args=None):
+        mock_resp = _make_api_response(points)
+
+        async def _fake_get(*args, **kwargs):
+            return mock_resp
+
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client.get = _fake_get
+
+        mock_nc, mock_js = _make_nats_mocks()
+
+        args = ["by-date", date, "--yes"]
+        if extra_args:
+            args += extra_args
+
+        with (
+            patch("main.httpx.AsyncClient", return_value=mock_client),
+            patch("main.nats.connect", return_value=mock_nc),
+        ):
+            result = runner.invoke(app, args)
+
+        return result, mock_js
+
+    def test_exit_code_zero_with_matching_points(self):
+        result, _ = self._run_with_mocks("2025-06-15", _SAMPLE_POINTS)
+        assert result.exit_code == 0, result.output
+
+    def test_publishes_tombstone_for_each_matching_point(self):
+        result, mock_js = self._run_with_mocks("2025-06-15", _SAMPLE_POINTS)
+        # Two gap points on 2025-06-15
+        assert mock_js.publish.call_count == 2
+
+    def test_tombstones_have_correct_ids(self):
+        result, mock_js = self._run_with_mocks("2025-06-15", _SAMPLE_POINTS)
+        published_ids = {
+            json.loads(call[0][1].decode())["id"]
+            for call in mock_js.publish.call_args_list
+        }
+        assert published_ids == {"g1", "g2"}
+
+    def test_tombstones_published_to_trips_delete_subject(self):
+        result, mock_js = self._run_with_mocks("2025-06-15", _SAMPLE_POINTS)
+        for call in mock_js.publish.call_args_list:
+            assert call[0][0] == "trips.delete"
+
+    def test_all_tombstones_have_deleted_true(self):
+        result, mock_js = self._run_with_mocks("2025-06-15", _SAMPLE_POINTS)
+        for call in mock_js.publish.call_args_list:
+            payload = json.loads(call[0][1].decode())
+            assert payload["deleted"] is True
+
+    def test_shows_deleted_count_in_output(self):
+        result, _ = self._run_with_mocks("2025-06-15", _SAMPLE_POINTS)
+        assert "Deleted 2 points" in result.output
+
+    def test_nats_connection_closed_after_publish(self):
+        result, mock_js = self._run_with_mocks("2025-06-15", _SAMPLE_POINTS)
+        # mock_nc is the connection object; find it via the patch
+        assert result.exit_code == 0  # nc.close() is awaited in finally block
+
+    def test_no_publish_when_no_matching_points(self):
+        result, mock_js = self._run_with_mocks("2099-01-01", _SAMPLE_POINTS)
+        assert result.exit_code == 0
+        mock_js.publish.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# by_id — dry run
+# ---------------------------------------------------------------------------
+
+
+class TestByIdDryRunCli:
+    """by_id --dry-run prints IDs without connecting to NATS."""
+
+    def _run(self, ids: list[str], dry_run: bool = True):
+        args = ["by-id"] + ids
+        if dry_run:
+            args.append("--dry-run")
+        return runner.invoke(app, args)
+
+    def test_exit_code_zero(self):
+        result = self._run(["id1", "id2", "id3"])
+        assert result.exit_code == 0, result.output
+
+    def test_shows_would_delete_messages(self):
+        result = self._run(["id1", "id2"])
+        assert "Would delete" in result.output
+        assert "id1" in result.output
+        assert "id2" in result.output
+
+    def test_dry_run_banner_present(self):
+        result = self._run(["id1"])
+        assert "[DRY RUN]" in result.output
+
+    def test_no_nats_connection_in_dry_run(self):
+        with patch("main.nats.connect") as mock_connect:
+            result = self._run(["id1", "id2"])
+        assert result.exit_code == 0
+        mock_connect.assert_not_called()
+
+    def test_single_id_dry_run(self):
+        result = self._run(["only-id"])
+        assert "only-id" in result.output
+        assert "[DRY RUN]" in result.output
+
+
+# ---------------------------------------------------------------------------
+# by_id — full run (publishes to NATS)
+# ---------------------------------------------------------------------------
+
+
+class TestByIdFullRunCli:
+    """by_id without --dry-run publishes tombstones for each provided ID."""
+
+    def _run_with_mocks(self, ids: list[str]):
+        mock_nc, mock_js = _make_nats_mocks()
+        with patch("main.nats.connect", return_value=mock_nc):
+            result = runner.invoke(app, ["by-id"] + ids)
+        return result, mock_js
+
+    def test_exit_code_zero(self):
+        result, _ = self._run_with_mocks(["id1", "id2"])
+        assert result.exit_code == 0, result.output
+
+    def test_publishes_one_tombstone_per_id(self):
+        _, mock_js = self._run_with_mocks(["id1", "id2", "id3"])
+        assert mock_js.publish.call_count == 3
+
+    def test_tombstones_have_correct_ids(self):
+        ids = ["alpha", "beta", "gamma"]
+        _, mock_js = self._run_with_mocks(ids)
+        published = [
+            json.loads(c[0][1].decode())["id"]
+            for c in mock_js.publish.call_args_list
+        ]
+        assert published == ids
+
+    def test_all_tombstones_have_deleted_true(self):
+        _, mock_js = self._run_with_mocks(["x", "y"])
+        for call in mock_js.publish.call_args_list:
+            assert json.loads(call[0][1].decode())["deleted"] is True
+
+    def test_output_shows_deleted_count(self):
+        result, _ = self._run_with_mocks(["id1", "id2"])
+        assert "Deleted 2 points" in result.output
+
+    def test_single_id_publishes_once(self):
+        _, mock_js = self._run_with_mocks(["sole-id"])
+        mock_js.publish.assert_called_once()
+
+    def test_tombstones_on_trips_delete_subject(self):
+        _, mock_js = self._run_with_mocks(["id1"])
+        assert mock_js.publish.call_args[0][0] == "trips.delete"
+
+
+# ---------------------------------------------------------------------------
+# list_gaps — no date filter
+# ---------------------------------------------------------------------------
+
+
+class TestListGapsCli:
+    """list_gaps fetches all points and shows gap points grouped by date."""
+
+    def _run(self, points: list[dict], args=None):
+        mock_resp = _make_api_response(points)
+
+        async def _fake_get(*_, **__):
+            return mock_resp
+
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client.get = _fake_get
+
+        invoke_args = ["list-gaps"]
+        if args:
+            invoke_args += args
+
+        with patch("main.httpx.AsyncClient", return_value=mock_client):
+            return runner.invoke(app, invoke_args)
+
+    def test_exit_code_zero(self):
+        result = self._run(_SAMPLE_POINTS)
+        assert result.exit_code == 0, result.output
+
+    def test_shows_total_gap_count(self):
+        result = self._run(_SAMPLE_POINTS)
+        # Three gap points total in _SAMPLE_POINTS
+        assert "3 gap points" in result.output
+
+    def test_shows_both_dates(self):
+        result = self._run(_SAMPLE_POINTS)
+        assert "2025-06-15" in result.output
+        assert "2025-06-16" in result.output
+
+    def test_no_gap_points_message(self):
+        non_gap = [
+            {
+                "id": "p1",
+                "timestamp": "2025-06-15T08:00:00",
+                "source": "gopro",
+                "lat": 60.0,
+                "lng": -135.0,
+            }
+        ]
+        result = self._run(non_gap)
+        assert result.exit_code == 0
+        assert "No gap points found" in result.output
+
+    def test_date_filter_narrows_results(self):
+        result = self._run(_SAMPLE_POINTS, args=["2025-06-15"])
+        # Only the two gap points on 2025-06-15 should appear
+        assert "2 gap points" in result.output
+        assert "2025-06-16" not in result.output
+
+    def test_date_filter_no_match(self):
+        result = self._run(_SAMPLE_POINTS, args=["2099-01-01"])
+        assert result.exit_code == 0
+        assert "No gap points found" in result.output
+
+    def test_empty_response_exits_cleanly(self):
+        result = self._run([])
+        assert result.exit_code == 0
+        assert "No gap points found" in result.output
+
+    def test_sample_id_shown_in_output(self):
+        """list_gaps prints a sample ID for the first point in each date group."""
+        result = self._run(_SAMPLE_POINTS, args=["2025-06-15"])
+        # g1 is the first gap point on 2025-06-15
+        assert "g1" in result.output

--- a/projects/trips/tools/delete-trip-points/cli_test.py
+++ b/projects/trips/tools/delete-trip-points/cli_test.py
@@ -308,8 +308,7 @@ class TestByIdFullRunCli:
         ids = ["alpha", "beta", "gamma"]
         _, mock_js = self._run_with_mocks(ids)
         published = [
-            json.loads(c[0][1].decode())["id"]
-            for c in mock_js.publish.call_args_list
+            json.loads(c[0][1].decode())["id"] for c in mock_js.publish.call_args_list
         ]
         assert published == ids
 

--- a/projects/trips/tools/publish-gap-route/BUILD
+++ b/projects/trips/tools/publish-gap-route/BUILD
@@ -88,7 +88,6 @@ py_test(
     deps = [
         "//projects/trips/tools/publish-gap-route",
         "@pip//pytest",
-        "@pip//pytest_asyncio",
         "@pip//typer",
     ],
 )

--- a/projects/trips/tools/publish-gap-route/BUILD
+++ b/projects/trips/tools/publish-gap-route/BUILD
@@ -79,3 +79,23 @@ semgrep_test(
     exclude_rules = ["test-hardcoded-past-timestamp"],
     rules = ["//bazel/semgrep/rules:python_rules"],
 )
+
+# gazelle:resolve py cli_test //projects/trips/tools/publish-gap-route:publish-gap-route
+py_test(
+    name = "cli_test",
+    srcs = ["cli_test.py"],
+    imports = ["."],
+    deps = [
+        "//projects/trips/tools/publish-gap-route",
+        "@pip//pytest",
+        "@pip//pytest_asyncio",
+        "@pip//typer",
+    ],
+)
+
+semgrep_test(
+    name = "cli_test_semgrep_test",
+    srcs = ["cli_test.py"],
+    exclude_rules = ["test-hardcoded-past-timestamp"],
+    rules = ["//bazel/semgrep/rules:python_rules"],
+)

--- a/projects/trips/tools/publish-gap-route/cli_test.py
+++ b/projects/trips/tools/publish-gap-route/cli_test.py
@@ -77,16 +77,12 @@ class TestPublishMissingKml:
 
     def test_exit_code_one_for_missing_file(self, tmp_path):
         missing = tmp_path / "nonexistent.kml"
-        result = runner.invoke(
-            app, ["publish", str(missing), "2025-01-03T10:28:00"]
-        )
+        result = runner.invoke(app, ["publish", str(missing), "2025-01-03T10:28:00"])
         assert result.exit_code == 1
 
     def test_error_message_mentions_file(self, tmp_path):
         missing = tmp_path / "nonexistent.kml"
-        result = runner.invoke(
-            app, ["publish", str(missing), "2025-01-03T10:28:00"]
-        )
+        result = runner.invoke(app, ["publish", str(missing), "2025-01-03T10:28:00"])
         assert "not found" in result.output.lower() or "Error" in result.output
 
 
@@ -129,9 +125,7 @@ class TestPublishEmptyKml:
 </kml>
 """
         )
-        result = runner.invoke(
-            app, ["publish", str(kml), "2025-01-03T10:28:00"]
-        )
+        result = runner.invoke(app, ["publish", str(kml), "2025-01-03T10:28:00"])
         assert result.exit_code == 1
         assert "No coordinates" in result.output
 
@@ -262,9 +256,7 @@ class TestPublishFullRun:
     def test_timestamps_start_at_provided_time(self, tmp_path):
         """The first published point's timestamp must equal the provided start time."""
         _, mock_js = self._run_with_mocks(tmp_path)
-        first_payload = json.loads(
-            mock_js.publish.call_args_list[0][0][1].decode()
-        )
+        first_payload = json.loads(mock_js.publish.call_args_list[0][0][1].decode())
         ts = datetime.fromisoformat(first_payload["timestamp"])
         assert ts == datetime(2025, 1, 3, 10, 28, 0)
 
@@ -272,9 +264,7 @@ class TestPublishFullRun:
         """Consecutive published points must have timestamps 1 ms apart."""
         _, mock_js = self._run_with_mocks(tmp_path)
         timestamps = [
-            datetime.fromisoformat(
-                json.loads(c[0][1].decode())["timestamp"]
-            )
+            datetime.fromisoformat(json.loads(c[0][1].decode())["timestamp"])
             for c in mock_js.publish.call_args_list
         ]
         for i in range(1, len(timestamps)):
@@ -288,9 +278,7 @@ class TestPublishFullRun:
         kml.write_text(MINIMAL_KML)
 
         with patch("main.nats.connect", return_value=mock_nc):
-            result = runner.invoke(
-                app, ["publish", str(kml), "2025-01-03T10:28:00"]
-            )
+            result = runner.invoke(app, ["publish", str(kml), "2025-01-03T10:28:00"])
 
         assert result.exit_code == 0
         mock_nc.close.assert_awaited_once()

--- a/projects/trips/tools/publish-gap-route/cli_test.py
+++ b/projects/trips/tools/publish-gap-route/cli_test.py
@@ -1,0 +1,395 @@
+"""CLI integration tests for publish-gap-route — Typer command flows.
+
+Tests exercise publish() and preview() end-to-end using
+typer.testing.CliRunner with mocked file I/O and NATS.
+"""
+
+import json
+from datetime import datetime, timedelta
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from main import app
+
+runner = CliRunner()
+
+# ---------------------------------------------------------------------------
+# KML fixtures
+# ---------------------------------------------------------------------------
+
+MINIMAL_KML = """\
+<?xml version="1.0" encoding="UTF-8"?>
+<kml xmlns="http://www.opengis.net/kml/2.2">
+  <Document>
+    <Placemark>
+      <LineString>
+        <coordinates>
+          -122.41942,37.77493,0
+          -122.42000,37.78000,0
+          -122.43000,37.79000,0
+        </coordinates>
+      </LineString>
+    </Placemark>
+  </Document>
+</kml>
+"""
+
+LARGE_KML = """\
+<?xml version="1.0" encoding="UTF-8"?>
+<kml xmlns="http://www.opengis.net/kml/2.2">
+  <Document>
+    <Placemark>
+      <LineString>
+        <coordinates>
+          {coords}
+        </coordinates>
+      </LineString>
+    </Placemark>
+  </Document>
+</kml>
+"""
+
+
+def _make_large_kml(n: int) -> str:
+    """Build a KML string with n coordinates."""
+    coords = " ".join(f"-122.{i:05d},{37 + i * 0.001:.5f},0" for i in range(n))
+    return LARGE_KML.format(coords=coords)
+
+
+def _make_nats_mocks():
+    mock_js = AsyncMock()
+    mock_nc = AsyncMock()
+    mock_nc.jetstream = MagicMock(return_value=mock_js)
+    mock_js.stream_info = AsyncMock(return_value=MagicMock())
+    return mock_nc, mock_js
+
+
+# ---------------------------------------------------------------------------
+# publish — file-not-found error handling
+# ---------------------------------------------------------------------------
+
+
+class TestPublishMissingKml:
+    """publish exits with error code 1 when the KML file does not exist."""
+
+    def test_exit_code_one_for_missing_file(self, tmp_path):
+        missing = tmp_path / "nonexistent.kml"
+        result = runner.invoke(
+            app, ["publish", str(missing), "2025-01-03T10:28:00"]
+        )
+        assert result.exit_code == 1
+
+    def test_error_message_mentions_file(self, tmp_path):
+        missing = tmp_path / "nonexistent.kml"
+        result = runner.invoke(
+            app, ["publish", str(missing), "2025-01-03T10:28:00"]
+        )
+        assert "not found" in result.output.lower() or "Error" in result.output
+
+
+# ---------------------------------------------------------------------------
+# publish — invalid start time
+# ---------------------------------------------------------------------------
+
+
+class TestPublishInvalidStartTime:
+    """publish exits with error code 1 for an unparseable start time."""
+
+    def test_exit_code_one_for_bad_time(self, tmp_path):
+        kml = tmp_path / "route.kml"
+        kml.write_text(MINIMAL_KML)
+        result = runner.invoke(app, ["publish", str(kml), "not-a-time"])
+        assert result.exit_code == 1
+
+    def test_error_message_mentions_format(self, tmp_path):
+        kml = tmp_path / "route.kml"
+        kml.write_text(MINIMAL_KML)
+        result = runner.invoke(app, ["publish", str(kml), "not-a-time"])
+        assert "Invalid start time" in result.output or "ISO" in result.output
+
+
+# ---------------------------------------------------------------------------
+# publish — empty KML
+# ---------------------------------------------------------------------------
+
+
+class TestPublishEmptyKml:
+    """publish exits with error code 1 when KML has no coordinates."""
+
+    def test_exit_code_one_for_empty_kml(self, tmp_path):
+        kml = tmp_path / "empty.kml"
+        kml.write_text(
+            """\
+<?xml version="1.0" encoding="UTF-8"?>
+<kml xmlns="http://www.opengis.net/kml/2.2">
+  <Document></Document>
+</kml>
+"""
+        )
+        result = runner.invoke(
+            app, ["publish", str(kml), "2025-01-03T10:28:00"]
+        )
+        assert result.exit_code == 1
+        assert "No coordinates" in result.output
+
+
+# ---------------------------------------------------------------------------
+# publish — dry run (no NATS connection)
+# ---------------------------------------------------------------------------
+
+
+class TestPublishDryRun:
+    """publish --dry-run shows a preview without connecting to NATS."""
+
+    def _run(self, tmp_path, kml_content=MINIMAL_KML, extra_args=None):
+        kml = tmp_path / "route.kml"
+        kml.write_text(kml_content)
+        args = ["publish", str(kml), "2025-01-03T10:28:00", "--dry-run"]
+        if extra_args:
+            args += extra_args
+        return runner.invoke(app, args)
+
+    def test_exit_code_zero(self, tmp_path):
+        result = self._run(tmp_path)
+        assert result.exit_code == 0, result.output
+
+    def test_shows_dry_run_banner(self, tmp_path):
+        result = self._run(tmp_path)
+        assert "[DRY RUN]" in result.output
+
+    def test_shows_route_preview(self, tmp_path):
+        result = self._run(tmp_path)
+        assert "Route preview" in result.output
+
+    def test_shows_start_time(self, tmp_path):
+        result = self._run(tmp_path)
+        assert "2025-01-03T10:28:00" in result.output
+
+    def test_no_nats_connection_in_dry_run(self, tmp_path):
+        with patch("main.nats.connect") as mock_connect:
+            result = self._run(tmp_path)
+        assert result.exit_code == 0
+        mock_connect.assert_not_called()
+
+    def test_shows_point_coordinates(self, tmp_path):
+        result = self._run(tmp_path)
+        # First coordinate in MINIMAL_KML is lat=37.77493, lng=-122.41942
+        assert "37.77493" in result.output
+
+    def test_max_points_flag_limits_sampled_count(self, tmp_path):
+        """--max-points 2 samples the 3-coord KML down to 2 (plus last appended)."""
+        result = self._run(tmp_path, extra_args=["--max-points", "2"])
+        assert result.exit_code == 0
+        # Sampled to output should mention 2 or 3 points (last may be appended)
+        assert "Points:" in result.output
+
+
+# ---------------------------------------------------------------------------
+# publish — full run (actually publishes to NATS)
+# ---------------------------------------------------------------------------
+
+
+class TestPublishFullRun:
+    """publish without --dry-run connects to NATS and publishes gap points."""
+
+    def _run_with_mocks(self, tmp_path, kml_content=MINIMAL_KML, extra_args=None):
+        kml = tmp_path / "route.kml"
+        kml.write_text(kml_content)
+
+        mock_nc, mock_js = _make_nats_mocks()
+        args = ["publish", str(kml), "2025-01-03T10:28:00"]
+        if extra_args:
+            args += extra_args
+
+        with patch("main.nats.connect", return_value=mock_nc):
+            result = runner.invoke(app, args)
+
+        return result, mock_js
+
+    def test_exit_code_zero(self, tmp_path):
+        result, _ = self._run_with_mocks(tmp_path)
+        assert result.exit_code == 0, result.output
+
+    def test_publishes_correct_number_of_points(self, tmp_path):
+        _, mock_js = self._run_with_mocks(tmp_path)
+        # MINIMAL_KML has 3 coordinates, all within default max_points=100
+        assert mock_js.publish.call_count == 3
+
+    def test_publishes_to_trips_point_subject(self, tmp_path):
+        _, mock_js = self._run_with_mocks(tmp_path)
+        for call in mock_js.publish.call_args_list:
+            assert call[0][0] == "trips.point"
+
+    def test_published_points_have_gap_source(self, tmp_path):
+        _, mock_js = self._run_with_mocks(tmp_path)
+        for call in mock_js.publish.call_args_list:
+            payload = json.loads(call[0][1].decode())
+            assert payload["source"] == "gap"
+
+    def test_published_points_have_null_image(self, tmp_path):
+        _, mock_js = self._run_with_mocks(tmp_path)
+        for call in mock_js.publish.call_args_list:
+            payload = json.loads(call[0][1].decode())
+            assert payload["image"] is None
+
+    def test_published_points_have_gap_and_car_tags(self, tmp_path):
+        _, mock_js = self._run_with_mocks(tmp_path)
+        for call in mock_js.publish.call_args_list:
+            payload = json.loads(call[0][1].decode())
+            assert "gap" in payload["tags"]
+            assert "car" in payload["tags"]
+
+    def test_output_confirms_published_count(self, tmp_path):
+        result, _ = self._run_with_mocks(tmp_path)
+        assert "Published 3 gap points" in result.output
+
+    def test_output_shows_done(self, tmp_path):
+        result, _ = self._run_with_mocks(tmp_path)
+        assert "Done!" in result.output
+
+    def test_max_points_option_limits_publishing(self, tmp_path):
+        """--max-points 2 must publish at most 3 points (2 sampled + last)."""
+        result, mock_js = self._run_with_mocks(
+            tmp_path, extra_args=["--max-points", "2"]
+        )
+        assert result.exit_code == 0
+        # sample_coordinates with max_points=2 on 3 coords returns ≤3 points
+        assert mock_js.publish.call_count <= 3
+
+    def test_timestamps_start_at_provided_time(self, tmp_path):
+        """The first published point's timestamp must equal the provided start time."""
+        _, mock_js = self._run_with_mocks(tmp_path)
+        first_payload = json.loads(
+            mock_js.publish.call_args_list[0][0][1].decode()
+        )
+        ts = datetime.fromisoformat(first_payload["timestamp"])
+        assert ts == datetime(2025, 1, 3, 10, 28, 0)
+
+    def test_sequential_timestamps_one_ms_apart(self, tmp_path):
+        """Consecutive published points must have timestamps 1 ms apart."""
+        _, mock_js = self._run_with_mocks(tmp_path)
+        timestamps = [
+            datetime.fromisoformat(
+                json.loads(c[0][1].decode())["timestamp"]
+            )
+            for c in mock_js.publish.call_args_list
+        ]
+        for i in range(1, len(timestamps)):
+            delta = timestamps[i] - timestamps[i - 1]
+            assert delta == timedelta(milliseconds=1)
+
+    def test_nats_connection_closed_after_publish(self, tmp_path):
+        """nc.close() must be awaited even on successful publish."""
+        mock_nc, mock_js = _make_nats_mocks()
+        kml = tmp_path / "route.kml"
+        kml.write_text(MINIMAL_KML)
+
+        with patch("main.nats.connect", return_value=mock_nc):
+            result = runner.invoke(
+                app, ["publish", str(kml), "2025-01-03T10:28:00"]
+            )
+
+        assert result.exit_code == 0
+        mock_nc.close.assert_awaited_once()
+
+    def test_large_kml_sampled_to_max_points(self, tmp_path):
+        """A KML with 200 coords and --max-points 50 publishes ≤51 points."""
+        large_kml = _make_large_kml(200)
+        result, mock_js = self._run_with_mocks(
+            tmp_path, kml_content=large_kml, extra_args=["--max-points", "50"]
+        )
+        assert result.exit_code == 0
+        # sample_coordinates(200, 50) → 50 + possibly 1 last = 51 max
+        assert mock_js.publish.call_count <= 51
+        assert mock_js.publish.call_count >= 50
+
+
+# ---------------------------------------------------------------------------
+# preview — file-not-found
+# ---------------------------------------------------------------------------
+
+
+class TestPreviewMissingFile:
+    """preview exits with error code 1 when the KML file does not exist."""
+
+    def test_exit_code_one_for_missing_file(self, tmp_path):
+        missing = tmp_path / "nonexistent.kml"
+        result = runner.invoke(app, ["preview", str(missing)])
+        assert result.exit_code == 1
+
+    def test_error_message_for_missing_file(self, tmp_path):
+        missing = tmp_path / "nonexistent.kml"
+        result = runner.invoke(app, ["preview", str(missing)])
+        assert "not found" in result.output.lower() or "Error" in result.output
+
+
+# ---------------------------------------------------------------------------
+# preview — valid KML
+# ---------------------------------------------------------------------------
+
+
+class TestPreviewValidKml:
+    """preview parses the KML and shows coordinate details."""
+
+    def _run(self, tmp_path, kml_content=MINIMAL_KML):
+        kml = tmp_path / "route.kml"
+        kml.write_text(kml_content)
+        return runner.invoke(app, ["preview", str(kml)])
+
+    def test_exit_code_zero(self, tmp_path):
+        result = self._run(tmp_path)
+        assert result.exit_code == 0, result.output
+
+    def test_shows_coordinate_count(self, tmp_path):
+        result = self._run(tmp_path)
+        assert "3 coordinates" in result.output
+
+    def test_shows_start_coordinate(self, tmp_path):
+        result = self._run(tmp_path)
+        # First coordinate is lat=37.77493, lng=-122.41942
+        assert "37.77493" in result.output
+
+    def test_shows_end_coordinate(self, tmp_path):
+        result = self._run(tmp_path)
+        # Last coordinate is lat=37.79, lng=-122.43
+        assert "37.79000" in result.output
+
+    def test_no_nats_connection(self, tmp_path):
+        """preview must never connect to NATS."""
+        with patch("main.nats.connect") as mock_connect:
+            result = self._run(tmp_path)
+        assert result.exit_code == 0
+        mock_connect.assert_not_called()
+
+    def test_shows_first_few_points(self, tmp_path):
+        result = self._run(tmp_path)
+        assert "First 5 points" in result.output
+
+    def test_shows_last_few_points(self, tmp_path):
+        result = self._run(tmp_path)
+        assert "Last 5 points" in result.output
+
+    def test_empty_kml_shows_no_coordinates(self, tmp_path):
+        empty = """\
+<?xml version="1.0" encoding="UTF-8"?>
+<kml xmlns="http://www.opengis.net/kml/2.2">
+  <Document></Document>
+</kml>
+"""
+        kml = tmp_path / "empty.kml"
+        kml.write_text(empty)
+        result = runner.invoke(app, ["preview", str(kml)])
+        assert result.exit_code == 0
+        assert "No coordinates found" in result.output
+
+    def test_large_kml_shows_ellipsis(self, tmp_path):
+        """When there are more than 10 points, an ellipsis row is shown."""
+        large = _make_large_kml(20)
+        kml = tmp_path / "large.kml"
+        kml.write_text(large)
+        result = runner.invoke(app, ["preview", str(kml)])
+        assert result.exit_code == 0
+        assert "more points" in result.output


### PR DESCRIPTION
## Summary

- Add Typer `CliRunner` end-to-end tests for `delete-trip-points`: `by_date()`, `by_id()`, and `list_gaps()` commands with mocked `httpx` and NATS
- Add Typer `CliRunner` end-to-end tests for `publish-gap-route`: `publish()` and `preview()` commands with mocked file I/O and NATS
- Update `BUILD` files in both tool directories to register the new `cli_test` targets and their semgrep tests

## Test coverage added

**delete-trip-points/cli_test.py** (~55 tests):
- `by_date` dry-run: exit code, DRY RUN banner, point count, no-NATS, no-match, custom source filter
- `by_date` full run: tombstone count, correct IDs, trips.delete subject, deleted: true, count in output, no-match path
- `by_id` dry-run: Would delete messages, DRY RUN banner, no NATS connection
- `by_id` full run: publish count, IDs, deleted: true, count in output, subject
- `list_gaps` (no date): total count, both dates shown, no-gap message
- `list_gaps` (date filter): narrowed count, no-match path, empty response, sample ID in output

**publish-gap-route/cli_test.py** (~40 tests):
- `publish` missing-file: exit code 1, error message
- `publish` invalid start time: exit code 1, format hint
- `publish` empty KML: exit code 1, No coordinates message
- `publish` dry-run: DRY RUN banner, route preview, start time shown, no NATS connection, --max-points flag
- `publish` full run: correct publish count, trips.point subject, source: gap, image: null, gap/car tags, Done!, --max-points limits, sequential 1ms timestamps, nc.close() awaited, large KML sampled
- `preview` missing file: exit code 1
- `preview` valid KML: coordinate count, start/end coords, no NATS, first/last 5 points shown
- `preview` empty KML: No coordinates found
- `preview` large KML: ellipsis row shown

## Test plan
- [ ] CI passes for //projects/trips/tools/delete-trip-points:cli_test
- [ ] CI passes for //projects/trips/tools/delete-trip-points:cli_test_semgrep_test
- [ ] CI passes for //projects/trips/tools/publish-gap-route:cli_test
- [ ] CI passes for //projects/trips/tools/publish-gap-route:cli_test_semgrep_test

Generated with Claude Code