### PR TITLE
test(cli): add tests for search, note, search_line, and main --help

### DIFF
--- a/tools/cli/BUILD
+++ b/tools/cli/BUILD
@@ -64,6 +64,16 @@ py_test(
     ],
 )
 
+py_test(
+    name = "main_test",
+    srcs = ["main_test.py"],
+    deps = [
+        ":cli",
+        "@pip//pytest",
+        "@pip//typer",
+    ],
+)
+
 semgrep_target_test(
     name = "main_semgrep_test",
     rules = ["//bazel/semgrep/rules:python_rules"],
@@ -79,6 +89,12 @@ semgrep_test(
 semgrep_test(
     name = "knowledge_test_semgrep_test",
     srcs = ["knowledge_test.py"],
+    rules = ["//bazel/semgrep/rules:python_rules"],
+)
+
+semgrep_test(
+    name = "main_test_semgrep_test",
+    srcs = ["main_test.py"],
     rules = ["//bazel/semgrep/rules:python_rules"],
 )
 

--- a/tools/cli/knowledge_test.py
+++ b/tools/cli/knowledge_test.py
@@ -5,13 +5,15 @@ CLI command -> httpx call -> FastAPI handler -> response -> formatted output.
 """
 
 from contextlib import contextmanager
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from typer.testing import CliRunner
 
 from knowledge.gardener import Gardener
 from knowledge.models import AtomRawProvenance, RawInput
+from knowledge.router import get_embedding_client
+from knowledge.service import VAULT_ROOT_ENV
 from tools.cli.main import app
 
 
@@ -101,6 +103,57 @@ def _make_dead_letter(session, raw, *, error="boom", retry_count=3):
     return prov
 
 
+# ---------------------------------------------------------------------------
+# Canned data shared across search / note tests
+# ---------------------------------------------------------------------------
+
+_FAKE_EMBEDDING = [0.1] * 1024
+
+_CANNED_RESULTS = [
+    {
+        "note_id": "n1",
+        "title": "Attention Is All You Need",
+        "path": "papers/attention.md",
+        "type": "paper",
+        "tags": ["ml", "transformers"],
+        "score": 0.95,
+        "snippet": "The transformer replaces recurrence entirely with attention.",
+        "section": "## Architecture",
+        "edges": [],
+    },
+]
+
+_CANNED_RESULTS_WITH_EDGES = [
+    {
+        **_CANNED_RESULTS[0],
+        "edges": [
+            {
+                "target_id": "n2",
+                "kind": "edge",
+                "edge_type": "refines",
+                "target_title": None,
+                "resolved_note_id": "n2",
+            },
+        ],
+    },
+]
+
+_SAMPLE_NOTE = {
+    "note_id": "n1",
+    "title": "Attention Is All You Need",
+    "path": "papers/attention.md",
+    "type": "paper",
+    "tags": ["ml", "transformers"],
+}
+
+
+def _fake_embed_override():
+    """Return a FastAPI DI factory that yields a fake async EmbeddingClient."""
+    fake = AsyncMock()
+    fake.embed.return_value = _FAKE_EMBEDDING
+    return lambda: fake
+
+
 class TestDeadLetters:
     def test_lists_dead_letters(self, runner, session):
         raw = _make_raw(session)
@@ -134,3 +187,211 @@ class TestReplay:
     def test_404_for_unknown(self, runner, session):
         result = runner.invoke(app, ["knowledge", "replay", "9999"])
         assert result.exit_code == 1
+
+
+class TestSearch:
+    """Tests for the `knowledge search` CLI command."""
+
+    def test_empty_query_returns_no_results(self, runner):
+        """Single-char query hits the router's 2-char fast-path → 'No results.'"""
+        result = runner.invoke(app, ["knowledge", "search", "x"])
+        assert result.exit_code == 0
+        assert "No results." in result.output
+
+    def test_search_with_results(self, runner):
+        """Successful search prints score, note_id, title, and type."""
+        from app.main import app as fastapi_app
+
+        fastapi_app.dependency_overrides[get_embedding_client] = _fake_embed_override()
+        try:
+            with patch("knowledge.router.KnowledgeStore") as MockStore:
+                MockStore.return_value.search_notes_with_context.return_value = (
+                    _CANNED_RESULTS
+                )
+                result = runner.invoke(app, ["knowledge", "search", "attention"])
+        finally:
+            del fastapi_app.dependency_overrides[get_embedding_client]
+
+        assert result.exit_code == 0
+        assert "0.95" in result.output
+        assert "n1" in result.output
+        assert "Attention Is All You Need" in result.output
+        assert "paper" in result.output
+
+    def test_search_no_results(self, runner):
+        """Store returning [] prints 'No results.'"""
+        from app.main import app as fastapi_app
+
+        fastapi_app.dependency_overrides[get_embedding_client] = _fake_embed_override()
+        try:
+            with patch("knowledge.router.KnowledgeStore") as MockStore:
+                MockStore.return_value.search_notes_with_context.return_value = []
+                result = runner.invoke(app, ["knowledge", "search", "nothing here"])
+        finally:
+            del fastapi_app.dependency_overrides[get_embedding_client]
+
+        assert result.exit_code == 0
+        assert "No results." in result.output
+
+    def test_json_flag(self, runner):
+        """--json flag emits raw JSON instead of formatted lines."""
+        from app.main import app as fastapi_app
+
+        fastapi_app.dependency_overrides[get_embedding_client] = _fake_embed_override()
+        try:
+            with patch("knowledge.router.KnowledgeStore") as MockStore:
+                MockStore.return_value.search_notes_with_context.return_value = (
+                    _CANNED_RESULTS
+                )
+                result = runner.invoke(
+                    app, ["knowledge", "search", "--json", "attention"]
+                )
+        finally:
+            del fastapi_app.dependency_overrides[get_embedding_client]
+
+        assert result.exit_code == 0
+        assert '"results"' in result.output
+        assert '"note_id"' in result.output
+        assert '"n1"' in result.output
+
+    def test_type_filter_forwarded(self, runner):
+        """--type value is forwarded to the store as type_filter."""
+        from app.main import app as fastapi_app
+
+        fastapi_app.dependency_overrides[get_embedding_client] = _fake_embed_override()
+        try:
+            with patch("knowledge.router.KnowledgeStore") as MockStore:
+                MockStore.return_value.search_notes_with_context.return_value = []
+                runner.invoke(
+                    app, ["knowledge", "search", "--type", "paper", "attention"]
+                )
+                MockStore.return_value.search_notes_with_context.assert_called_once_with(
+                    query_embedding=_FAKE_EMBEDDING,
+                    limit=10,
+                    type_filter="paper",
+                )
+        finally:
+            del fastapi_app.dependency_overrides[get_embedding_client]
+
+    def test_limit_forwarded(self, runner):
+        """--limit value is forwarded to the store."""
+        from app.main import app as fastapi_app
+
+        fastapi_app.dependency_overrides[get_embedding_client] = _fake_embed_override()
+        try:
+            with patch("knowledge.router.KnowledgeStore") as MockStore:
+                MockStore.return_value.search_notes_with_context.return_value = []
+                runner.invoke(app, ["knowledge", "search", "--limit", "5", "attention"])
+                MockStore.return_value.search_notes_with_context.assert_called_once_with(
+                    query_embedding=_FAKE_EMBEDDING,
+                    limit=5,
+                    type_filter=None,
+                )
+        finally:
+            del fastapi_app.dependency_overrides[get_embedding_client]
+
+    def test_search_with_edges_displays_edge_info(self, runner):
+        """Results with typed edges render edge type and target in output."""
+        from app.main import app as fastapi_app
+
+        fastapi_app.dependency_overrides[get_embedding_client] = _fake_embed_override()
+        try:
+            with patch("knowledge.router.KnowledgeStore") as MockStore:
+                MockStore.return_value.search_notes_with_context.return_value = (
+                    _CANNED_RESULTS_WITH_EDGES
+                )
+                result = runner.invoke(app, ["knowledge", "search", "attention"])
+        finally:
+            del fastapi_app.dependency_overrides[get_embedding_client]
+
+        assert result.exit_code == 0
+        assert "refines" in result.output
+        assert "n2" in result.output
+
+
+class TestNote:
+    """Tests for the `knowledge note` CLI command."""
+
+    def test_note_fetches_metadata_and_writes_tmpfile(
+        self, runner, tmp_path, monkeypatch
+    ):
+        """Successful note fetch prints title/type and writes content to tmpfile."""
+        vault_dir = tmp_path / "vault"
+        vault_dir.mkdir()
+        note_file = vault_dir / "papers" / "attention.md"
+        note_file.parent.mkdir(parents=True)
+        note_file.write_text("# Attention\n\nSelf-attention mechanism.")
+
+        monkeypatch.setenv(VAULT_ROOT_ENV, str(vault_dir))
+
+        with (
+            patch("knowledge.router.KnowledgeStore") as MockStore,
+            patch("tools.cli.output.TMPDIR", tmp_path / "notes"),
+        ):
+            MockStore.return_value.get_note_by_id.return_value = _SAMPLE_NOTE
+            MockStore.return_value.get_note_links.return_value = []
+            result = runner.invoke(app, ["knowledge", "note", "n1"])
+
+        assert result.exit_code == 0
+        assert "Attention Is All You Need" in result.output
+        assert "paper" in result.output
+        assert "Content:" in result.output
+
+    def test_note_json_output(self, runner, tmp_path, monkeypatch):
+        """--json flag emits raw JSON for the note instead of formatted text."""
+        vault_dir = tmp_path / "vault"
+        vault_dir.mkdir()
+        note_file = vault_dir / "papers" / "attention.md"
+        note_file.parent.mkdir(parents=True)
+        note_file.write_text("# Attention\n\nContent.")
+
+        monkeypatch.setenv(VAULT_ROOT_ENV, str(vault_dir))
+
+        with patch("knowledge.router.KnowledgeStore") as MockStore:
+            MockStore.return_value.get_note_by_id.return_value = _SAMPLE_NOTE
+            MockStore.return_value.get_note_links.return_value = []
+            result = runner.invoke(app, ["knowledge", "note", "--json", "n1"])
+
+        assert result.exit_code == 0
+        assert '"note_id"' in result.output
+        assert '"n1"' in result.output
+        assert '"title"' in result.output
+
+    def test_note_displays_typed_edges(self, runner, tmp_path, monkeypatch):
+        """Note with typed edges shows 'Edges:' line with edge type and target."""
+        vault_dir = tmp_path / "vault"
+        vault_dir.mkdir()
+        note_file = vault_dir / "papers" / "attention.md"
+        note_file.parent.mkdir(parents=True)
+        note_file.write_text("# Attention\n\nContent.")
+
+        monkeypatch.setenv(VAULT_ROOT_ENV, str(vault_dir))
+
+        with (
+            patch("knowledge.router.KnowledgeStore") as MockStore,
+            patch("tools.cli.output.TMPDIR", tmp_path / "notes"),
+        ):
+            MockStore.return_value.get_note_by_id.return_value = _SAMPLE_NOTE
+            MockStore.return_value.get_note_links.return_value = [
+                {
+                    "target_id": "n2",
+                    "kind": "edge",
+                    "edge_type": "refines",
+                    "target_title": None,
+                    "resolved_note_id": "n2",
+                },
+            ]
+            result = runner.invoke(app, ["knowledge", "note", "n1"])
+
+        assert result.exit_code == 0
+        assert "Edges:" in result.output
+        assert "refines" in result.output
+        assert "n2" in result.output
+
+    def test_note_not_found_exits_nonzero(self, runner):
+        """Requesting a non-existent note ID causes a non-zero exit code."""
+        with patch("knowledge.router.KnowledgeStore") as MockStore:
+            MockStore.return_value.get_note_by_id.return_value = None
+            result = runner.invoke(app, ["knowledge", "note", "does-not-exist"])
+
+        assert result.exit_code != 0

--- a/tools/cli/main_test.py
+++ b/tools/cli/main_test.py
@@ -1,0 +1,23 @@
+"""Smoke tests for tools/cli/main.py."""
+
+import pytest
+from typer.testing import CliRunner
+
+from tools.cli.main import app
+
+
+class TestMainHelp:
+    def test_help_exits_zero(self):
+        """Top-level --help returns exit code 0 and shows the app description."""
+        runner = CliRunner()
+        result = runner.invoke(app, ["--help"])
+        assert result.exit_code == 0
+        assert "Token-efficient" in result.output
+
+    def test_knowledge_subcommand_help_exits_zero(self):
+        """knowledge --help returns exit code 0 without real auth."""
+        runner = CliRunner()
+        result = runner.invoke(app, ["knowledge", "--help"])
+        assert result.exit_code == 0
+        assert "search" in result.output
+        assert "note" in result.output

--- a/tools/cli/output_test.py
+++ b/tools/cli/output_test.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 
 import pytest
 
-from tools.cli.output import compact_line, write_to_tmpfile, format_edges
+from tools.cli.output import compact_line, format_edges, search_line, write_to_tmpfile
 
 
 class TestCompactLine:
@@ -44,3 +44,37 @@ class TestWriteToTmpfile:
             write_to_tmpfile("note", "v1")
             path = write_to_tmpfile("note", "v2")
             assert path.read_text() == "v2"
+
+
+class TestSearchLine:
+    def test_basic_format_no_edges(self):
+        """Score, note_id, title, and type are all present in the output line."""
+        result = search_line(0.95, "n1", "Attention Is All You Need", "paper", [])
+        assert result == "[0.95] n1 — Attention Is All You Need (paper)"
+
+    def test_score_formatted_to_two_decimal_places(self):
+        """Score is always rendered with exactly two decimal places."""
+        result = search_line(1.0, "n2", "Some Note", "concept", [])
+        assert result.startswith("[1.00]")
+
+    def test_with_typed_edges_appends_edge_line(self):
+        """Typed edges are appended as an indented second line."""
+        edges = [
+            {"kind": "edge", "edge_type": "derives_from", "target_id": "note-a"},
+            {"kind": "edge", "edge_type": "related", "target_id": "note-b"},
+        ]
+        result = search_line(0.80, "n3", "My Note", "note", edges)
+        lines = result.splitlines()
+        assert len(lines) == 2
+        assert lines[0] == "[0.80] n3 — My Note (note)"
+        assert "derives_from→note-a" in lines[1]
+        assert "related→note-b" in lines[1]
+
+    def test_link_kind_edges_excluded(self):
+        """Edges with kind='link' (not 'edge') are filtered out and not shown."""
+        edges = [
+            {"kind": "link", "edge_type": None, "target_id": "other-note"},
+        ]
+        result = search_line(0.70, "n4", "Link Note", "note", edges)
+        # No edge line appended for plain wikilinks
+        assert "\n" not in result


### PR DESCRIPTION
## Summary

- **`knowledge_test.py`** — adds `TestSearch` (7 tests) and `TestNote` (4 tests) covering the previously-untested `search` and `note` commands. Uses the same FastAPI TestClient + patched `_client` fixture pattern as the existing `TestDeadLetters`/`TestReplay` tests. Search tests additionally override `get_embedding_client` via FastAPI DI and patch `KnowledgeStore.search_notes_with_context` (pgvector is not available in the SQLite test env).
- **`output_test.py`** — adds `TestSearchLine` (4 tests) for the untested `search_line()` function, covering score precision, basic formatting, typed-edge appended line, and link-kind-only exclusion.
- **`main_test.py`** (new) — smoke tests confirming `--help` exits 0 for both the top-level app and the `knowledge` subcommand.
- **`BUILD`** — adds `main_test` py_test target and `main_test_semgrep_test` semgrep lint target.

## Test plan

- [ ] CI runs `bazel test //tools/cli/...` — all new targets pass
- [ ] `knowledge_test` — `TestSearch` and `TestNote` pass (11 new tests)
- [ ] `output_test` — `TestSearchLine` passes (4 new tests)
- [ ] `main_test` — help smoke tests pass (2 new tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)