### PR TITLE
test(ships): add SQLite PRAGMA, read-only DB, event-loop yield and reconnect-cap tests

### DIFF
--- a/projects/ships/backend/tests/BUILD
+++ b/projects/ships/backend/tests/BUILD
@@ -274,3 +274,23 @@ semgrep_test(
     exclude_rules = ["test-hardcoded-past-timestamp"],
     rules = ["//bazel/semgrep/rules:python_rules"],
 )
+
+py_test(
+    name = "pragma_and_yield_test",
+    srcs = ["pragma_and_yield_test.py"],
+    imports = [".."],
+    deps = [
+        ":conftest",
+        "//projects/ships/backend:ships-api",
+        "@pip//aiosqlite",
+        "@pip//pytest",
+        "@pip//pytest_asyncio",  # keep
+    ],
+)
+
+semgrep_test(
+    name = "pragma_and_yield_test_semgrep_test",
+    srcs = ["pragma_and_yield_test.py"],
+    exclude_rules = ["test-hardcoded-past-timestamp"],
+    rules = ["//bazel/semgrep/rules:python_rules"],
+)

--- a/projects/ships/backend/tests/pragma_and_yield_test.py
+++ b/projects/ships/backend/tests/pragma_and_yield_test.py
@@ -24,9 +24,8 @@ Covers gaps not addressed by the existing test suite:
 import asyncio
 import json
 import os
-import tempfile
 from datetime import datetime, timezone
-from unittest.mock import AsyncMock, MagicMock, call, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -223,28 +222,20 @@ class TestReadOnlyDbConnection:
 
 
 class TestEventLoopYielding:
-    """Verify asyncio.sleep(0) is called at every i % 500 == 0 within a batch."""
+    """Verify asyncio.sleep(0) is called at every i % 500 == 0 within a batch.
 
-    @pytest.mark.asyncio
-    async def test_sleep_called_at_i_0(self):
-        """asyncio.sleep(0) is called at i=0 (start of every batch)."""
-        service = ShipsAPIService()
-        service.running = True
-        service.replay_complete = True
-        service.ready = True
+    These tests run subscribe_ais_stream() with a direct ``await`` (not
+    asyncio.create_task) so that asyncio.sleep is patched without breaking
+    the test's own event-loop yielding.  A closure-based fetch mock stops the
+    service after the first batch by setting ``running=False`` on the second
+    call, which causes the outer ``while self.running:`` loop to exit cleanly.
+    """
 
-        db = Database(":memory:")
-        await db.connect()
-        service.db = db
-
-        sleep_calls = []
-
-        async def track_sleep(n):
-            sleep_calls.append(n)
-
-        # Build exactly 1 message (so i=0 only)
+    @staticmethod
+    def _make_pos_msg(mmsi: str, ship_name: str) -> AsyncMock:
+        """Build a mock NATS message carrying a position payload."""
         pos_data = {
-            "mmsi": "100000001",
+            "mmsi": mmsi,
             "lat": 51.0,
             "lon": -1.0,
             "speed": 5.0,
@@ -253,41 +244,71 @@ class TestEventLoopYielding:
             "nav_status": 0,
             "rate_of_turn": 0,
             "position_accuracy": 1,
-            "ship_name": "YIELD_TEST",
+            "ship_name": ship_name,
             "timestamp": datetime.now(timezone.utc).isoformat(),
         }
-        mock_msg = AsyncMock()
-        mock_msg.subject = "ais.position.100000001"
-        mock_msg.data = json.dumps(pos_data).encode()
-        mock_msg.ack = AsyncMock()
+        m = AsyncMock()
+        m.subject = f"ais.position.{mmsi}"
+        m.data = json.dumps(pos_data).encode()
+        m.ack = AsyncMock()
+        return m
 
+    @staticmethod
+    def _stopping_fetch(service, first_batch):
+        """Return an async fetch callable that stops the service on 2nd call."""
+        call_count = 0
+
+        async def _fetch(batch, timeout):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return first_batch
+            service.running = False
+            raise asyncio.TimeoutError()
+
+        return _fetch
+
+    @staticmethod
+    async def _make_service():
+        """Create a ShipsAPIService wired to an in-memory DB, ready for tests."""
+        service = ShipsAPIService()
+        service.running = True
+        service.replay_complete = True
+        service.ready = True
+        db = Database(":memory:")
+        await db.connect()
+        service.db = db
+        service.ws_manager.broadcast = AsyncMock()
+        return service, db
+
+    @staticmethod
+    def _mock_js(service, first_batch):
+        """Return a mock JetStream context backed by the stopping fetch."""
         mock_psub = AsyncMock()
-        mock_psub.fetch = AsyncMock(side_effect=[[mock_msg], asyncio.TimeoutError()])
+        mock_psub.fetch = TestEventLoopYielding._stopping_fetch(service, first_batch)
         consumer_info_mock = MagicMock()
         consumer_info_mock.num_pending = 0
         mock_psub.consumer_info = AsyncMock(return_value=consumer_info_mock)
-
         mock_js = AsyncMock()
         mock_js.pull_subscribe = AsyncMock(return_value=mock_psub)
-        service.js = mock_js
+        return mock_js
 
-        with patch(
-            "projects.ships.backend.main.asyncio.sleep",
-            side_effect=track_sleep,
-        ):
-            task = asyncio.create_task(service.subscribe_ais_stream())
-            await asyncio.sleep(0.05)
-            service.running = False
-            try:
-                await asyncio.wait_for(task, timeout=2.0)
-            except (asyncio.TimeoutError, asyncio.CancelledError, Exception):
-                task.cancel()
-                try:
-                    await task
-                except (asyncio.CancelledError, Exception):
-                    pass
+    @pytest.mark.asyncio
+    async def test_sleep_called_at_i_0(self):
+        """asyncio.sleep(0) is called at i=0 (start of every batch)."""
+        service, db = await self._make_service()
 
-        # sleep(0) must have been called (at i=0)
+        sleep_calls: list[int | float] = []
+
+        async def track_sleep(n):
+            sleep_calls.append(n)
+
+        msg = self._make_pos_msg("100000001", "YIELD_TEST")
+        service.js = self._mock_js(service, [msg])
+
+        with patch("projects.ships.backend.main.asyncio.sleep", new=track_sleep):
+            await service.subscribe_ais_stream()
+
         assert 0 in sleep_calls, (
             f"Expected asyncio.sleep(0) at i=0, sleep calls: {sleep_calls}"
         )
@@ -297,159 +318,55 @@ class TestEventLoopYielding:
     @pytest.mark.asyncio
     async def test_sleep_called_at_i_500_boundary(self):
         """asyncio.sleep(0) is called at i=500 when processing 501+ messages."""
-        service = ShipsAPIService()
-        service.running = True
-        service.replay_complete = True
-        service.ready = True
+        service, db = await self._make_service()
 
-        db = Database(":memory:")
-        await db.connect()
-        service.db = db
-        service.ws_manager.broadcast = AsyncMock()
-
-        sleep_call_count = 0
+        zero_sleep_count = 0
 
         async def count_zero_sleeps(n):
-            nonlocal sleep_call_count
+            nonlocal zero_sleep_count
             if n == 0:
-                sleep_call_count += 1
+                zero_sleep_count += 1
 
-        # Build 501 messages to trigger sleep at i=0 and i=500
-        msgs = []
-        for i in range(501):
-            pos_data = {
-                "mmsi": f"1{i:08d}",
-                "lat": 50.0 + i * 0.0001,
-                "lon": -1.0,
-                "speed": 5.0,
-                "course": 90.0,
-                "heading": 88,
-                "nav_status": 0,
-                "rate_of_turn": 0,
-                "position_accuracy": 1,
-                "ship_name": f"VESSEL{i}",
-                "timestamp": datetime.now(timezone.utc).isoformat(),
-            }
-            m = AsyncMock()
-            m.subject = f"ais.position.1{i:08d}"
-            m.data = json.dumps(pos_data).encode()
-            m.ack = AsyncMock()
-            msgs.append(m)
-
-        mock_psub = AsyncMock()
-        mock_psub.fetch = AsyncMock(side_effect=[msgs, asyncio.TimeoutError()])
-        consumer_info_mock = MagicMock()
-        consumer_info_mock.num_pending = 0
-        mock_psub.consumer_info = AsyncMock(return_value=consumer_info_mock)
-
-        mock_js = AsyncMock()
-        mock_js.pull_subscribe = AsyncMock(return_value=mock_psub)
-        service.js = mock_js
+        # 501 distinct MMSIs to avoid deduplication collapsing the batch
+        msgs = [
+            self._make_pos_msg(f"1{i:08d}", f"VESSEL{i}") for i in range(501)
+        ]
+        service.js = self._mock_js(service, msgs)
 
         with patch(
-            "projects.ships.backend.main.asyncio.sleep",
-            side_effect=count_zero_sleeps,
+            "projects.ships.backend.main.asyncio.sleep", new=count_zero_sleeps
         ):
-            task = asyncio.create_task(service.subscribe_ais_stream())
-            await asyncio.sleep(0.1)
-            service.running = False
-            try:
-                await asyncio.wait_for(task, timeout=5.0)
-            except (asyncio.TimeoutError, asyncio.CancelledError, Exception):
-                task.cancel()
-                try:
-                    await task
-                except (asyncio.CancelledError, Exception):
-                    pass
+            await service.subscribe_ais_stream()
 
-        # With 501 messages, sleep(0) is called at i=0 and i=500 → 2 calls
-        assert sleep_call_count >= 2, (
+        # sleep(0) fires at i=0 and i=500 → at least 2 calls
+        assert zero_sleep_count >= 2, (
             f"Expected at least 2 sleep(0) calls (at i=0 and i=500), "
-            f"got {sleep_call_count}"
+            f"got {zero_sleep_count}"
         )
-
         await db.close()
 
     @pytest.mark.asyncio
     async def test_sleep_not_called_at_non_multiple_of_500(self):
         """asyncio.sleep(0) is NOT called for i=1..499 (only at multiples of 500)."""
-        service = ShipsAPIService()
-        service.running = True
-        service.replay_complete = True
-        service.ready = True
+        service, db = await self._make_service()
 
-        db = Database(":memory:")
-        await db.connect()
-        service.db = db
-        service.ws_manager.broadcast = AsyncMock()
+        zero_sleep_count = 0
 
-        zero_sleep_indices: list[int] = []
-        current_index = [-1]
-
-        async def track_sleep(n):
+        async def track_zero_sleep(n):
+            nonlocal zero_sleep_count
             if n == 0:
-                zero_sleep_indices.append(current_index[0])
+                zero_sleep_count += 1
 
-        # Patch the loop index tracking by intercepting message processing
-        original_process = service._process_message_sync
-
-        def tracking_process(subject, data):
-            current_index[0] += 1
-            return original_process(subject, data)
-
-        service._process_message_sync = tracking_process
-
-        # Build exactly 3 messages (i=0,1,2) → only i=0 triggers sleep
-        msgs = []
-        for i in range(3):
-            pos_data = {
-                "mmsi": f"2{i:08d}",
-                "lat": 51.0,
-                "lon": -2.0,
-                "speed": 3.0,
-                "course": 45.0,
-                "heading": 44,
-                "nav_status": 0,
-                "rate_of_turn": 0,
-                "position_accuracy": 1,
-                "ship_name": f"V{i}",
-                "timestamp": datetime.now(timezone.utc).isoformat(),
-            }
-            m = AsyncMock()
-            m.subject = f"ais.position.2{i:08d}"
-            m.data = json.dumps(pos_data).encode()
-            m.ack = AsyncMock()
-            msgs.append(m)
-
-        mock_psub = AsyncMock()
-        mock_psub.fetch = AsyncMock(side_effect=[msgs, asyncio.TimeoutError()])
-        consumer_info_mock = MagicMock()
-        consumer_info_mock.num_pending = 0
-        mock_psub.consumer_info = AsyncMock(return_value=consumer_info_mock)
-
-        mock_js = AsyncMock()
-        mock_js.pull_subscribe = AsyncMock(return_value=mock_psub)
-        service.js = mock_js
+        # 3 messages → sleep(0) called exactly once (at i=0)
+        msgs = [self._make_pos_msg(f"2{i:08d}", f"V{i}") for i in range(3)]
+        service.js = self._mock_js(service, msgs)
 
         with patch(
-            "projects.ships.backend.main.asyncio.sleep",
-            side_effect=track_sleep,
+            "projects.ships.backend.main.asyncio.sleep", new=track_zero_sleep
         ):
-            task = asyncio.create_task(service.subscribe_ais_stream())
-            await asyncio.sleep(0.05)
-            service.running = False
-            try:
-                await asyncio.wait_for(task, timeout=2.0)
-            except (asyncio.TimeoutError, asyncio.CancelledError, Exception):
-                task.cancel()
-                try:
-                    await task
-                except (asyncio.CancelledError, Exception):
-                    pass
+            await service.subscribe_ais_stream()
 
-        # For 3 messages, sleep(0) should only fire at i=0
-        assert len(zero_sleep_indices) == 1, (
-            f"Expected 1 sleep(0) call (only at i=0), got {zero_sleep_indices}"
+        assert zero_sleep_count == 1, (
+            f"Expected exactly 1 sleep(0) call (only at i=0), got {zero_sleep_count}"
         )
-
         await db.close()

--- a/projects/ships/backend/tests/pragma_and_yield_test.py
+++ b/projects/ships/backend/tests/pragma_and_yield_test.py
@@ -328,14 +328,10 @@ class TestEventLoopYielding:
                 zero_sleep_count += 1
 
         # 501 distinct MMSIs to avoid deduplication collapsing the batch
-        msgs = [
-            self._make_pos_msg(f"1{i:08d}", f"VESSEL{i}") for i in range(501)
-        ]
+        msgs = [self._make_pos_msg(f"1{i:08d}", f"VESSEL{i}") for i in range(501)]
         service.js = self._mock_js(service, msgs)
 
-        with patch(
-            "projects.ships.backend.main.asyncio.sleep", new=count_zero_sleeps
-        ):
+        with patch("projects.ships.backend.main.asyncio.sleep", new=count_zero_sleeps):
             await service.subscribe_ais_stream()
 
         # sleep(0) fires at i=0 and i=500 → at least 2 calls
@@ -361,9 +357,7 @@ class TestEventLoopYielding:
         msgs = [self._make_pos_msg(f"2{i:08d}", f"V{i}") for i in range(3)]
         service.js = self._mock_js(service, msgs)
 
-        with patch(
-            "projects.ships.backend.main.asyncio.sleep", new=track_zero_sleep
-        ):
+        with patch("projects.ships.backend.main.asyncio.sleep", new=track_zero_sleep):
             await service.subscribe_ais_stream()
 
         assert zero_sleep_count == 1, (

--- a/projects/ships/backend/tests/pragma_and_yield_test.py
+++ b/projects/ships/backend/tests/pragma_and_yield_test.py
@@ -1,0 +1,461 @@
+"""
+Tests for SQLite PRAGMA settings and event-loop yielding in ships/backend.
+
+Covers gaps not addressed by the existing test suite:
+
+1. Main DB PRAGMA settings after connect():
+   - synchronous=OFF
+   - temp_store=MEMORY
+   - wal_autocheckpoint=1000
+   - busy_timeout=5000
+   - mmap_size=268435456 (256 MB)
+
+2. Read-only DB connection mode:
+   - _read_db is a *separate* connection object (not the same as self.db)
+   - Connection string uses URI mode with ?mode=ro
+   - _read_db has its own PRAGMA settings (mmap_size, cache_size)
+
+3. Event-loop yielding in subscribe_ais_stream():
+   - asyncio.sleep(0) is called at every i % 500 == 0
+     (i=0, 500, 1000, …) to allow health-check coroutines to run
+     during large batch processing.
+"""
+
+import asyncio
+import json
+import os
+import tempfile
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, call, patch
+
+import pytest
+
+from projects.ships.backend.main import Database, ShipsAPIService
+
+
+# ---------------------------------------------------------------------------
+# Helper — open a real file-based Database (not :memory:)
+# ---------------------------------------------------------------------------
+
+
+async def _file_db(tmp_path) -> Database:
+    """Create and connect a real file-backed Database for PRAGMA testing."""
+    db_path = os.path.join(str(tmp_path), "pragma_test.db")
+    db = Database(db_path)
+    await db.connect()
+    return db
+
+
+# ---------------------------------------------------------------------------
+# 1. Main DB PRAGMA settings
+# ---------------------------------------------------------------------------
+
+
+class TestMainDbPragmaSettings:
+    """Verify that Database.connect() sets all expected PRAGMAs on the main connection."""
+
+    @pytest.mark.asyncio
+    async def test_synchronous_is_off(self, tmp_path):
+        """PRAGMA synchronous=OFF is set on the write connection."""
+        db = await _file_db(tmp_path)
+        try:
+            cursor = await db.db.execute("PRAGMA synchronous")
+            row = await cursor.fetchone()
+            # 0 = OFF in SQLite
+            assert row[0] == 0, f"Expected synchronous=0 (OFF), got {row[0]}"
+        finally:
+            await db.close()
+
+    @pytest.mark.asyncio
+    async def test_temp_store_is_memory(self, tmp_path):
+        """PRAGMA temp_store=MEMORY (2) is set on the write connection."""
+        db = await _file_db(tmp_path)
+        try:
+            cursor = await db.db.execute("PRAGMA temp_store")
+            row = await cursor.fetchone()
+            # 2 = MEMORY in SQLite
+            assert row[0] == 2, f"Expected temp_store=2 (MEMORY), got {row[0]}"
+        finally:
+            await db.close()
+
+    @pytest.mark.asyncio
+    async def test_wal_autocheckpoint_is_1000(self, tmp_path):
+        """PRAGMA wal_autocheckpoint=1000 is set on the write connection."""
+        db = await _file_db(tmp_path)
+        try:
+            cursor = await db.db.execute("PRAGMA wal_autocheckpoint")
+            row = await cursor.fetchone()
+            assert row[0] == 1000, f"Expected wal_autocheckpoint=1000, got {row[0]}"
+        finally:
+            await db.close()
+
+    @pytest.mark.asyncio
+    async def test_busy_timeout_is_5000(self, tmp_path):
+        """PRAGMA busy_timeout=5000 is set on the write connection."""
+        db = await _file_db(tmp_path)
+        try:
+            cursor = await db.db.execute("PRAGMA busy_timeout")
+            row = await cursor.fetchone()
+            assert row[0] == 5000, f"Expected busy_timeout=5000, got {row[0]}"
+        finally:
+            await db.close()
+
+    @pytest.mark.asyncio
+    async def test_mmap_size_is_256mb(self, tmp_path):
+        """PRAGMA mmap_size=268435456 (256 MB) is set on the write connection."""
+        db = await _file_db(tmp_path)
+        try:
+            cursor = await db.db.execute("PRAGMA mmap_size")
+            row = await cursor.fetchone()
+            assert row[0] == 268435456, (
+                f"Expected mmap_size=268435456, got {row[0]}"
+            )
+        finally:
+            await db.close()
+
+
+# ---------------------------------------------------------------------------
+# 2. Read-only DB connection
+# ---------------------------------------------------------------------------
+
+
+class TestReadOnlyDbConnection:
+    """Verify that a file-backed Database opens a separate read-only connection."""
+
+    @pytest.mark.asyncio
+    async def test_read_db_is_separate_from_write_db(self, tmp_path):
+        """_read_db must be a different connection object than self.db."""
+        db = await _file_db(tmp_path)
+        try:
+            assert db._read_db is not db.db, (
+                "_read_db should be a separate connection from db"
+            )
+        finally:
+            await db.close()
+
+    @pytest.mark.asyncio
+    async def test_memory_db_read_db_is_same_as_write_db(self):
+        """In-memory DB uses the same connection for reads and writes (no URI mode)."""
+        db = Database(":memory:")
+        await db.connect()
+        try:
+            assert db._read_db is db.db, (
+                "In-memory DB should reuse the same connection"
+            )
+        finally:
+            await db.close()
+
+    @pytest.mark.asyncio
+    async def test_read_db_can_read_data_written_by_write_db(self, tmp_path):
+        """After a write-then-commit on db, _read_db can see the data."""
+        db = await _file_db(tmp_path)
+        try:
+            now = datetime.now(timezone.utc).isoformat()
+            await db.insert_positions_batch(
+                [
+                    (
+                        {
+                            "mmsi": "777777777",
+                            "lat": 48.5,
+                            "lon": -123.4,
+                            "speed": 5.0,
+                            "timestamp": now,
+                        },
+                        now,
+                    )
+                ]
+            )
+            await db.commit()
+
+            cursor = await db._read_db.execute(
+                "SELECT COUNT(*) FROM latest_positions WHERE mmsi = ?", ("777777777",)
+            )
+            row = await cursor.fetchone()
+            assert row[0] == 1, "Read-only connection should see committed data"
+        finally:
+            await db.close()
+
+    @pytest.mark.asyncio
+    async def test_read_db_mmap_size_is_256mb(self, tmp_path):
+        """PRAGMA mmap_size=268435456 is set on the read-only connection."""
+        db = await _file_db(tmp_path)
+        try:
+            cursor = await db._read_db.execute("PRAGMA mmap_size")
+            row = await cursor.fetchone()
+            assert row[0] == 268435456, (
+                f"Expected _read_db mmap_size=268435456, got {row[0]}"
+            )
+        finally:
+            await db.close()
+
+    @pytest.mark.asyncio
+    async def test_read_db_cache_size_is_set(self, tmp_path):
+        """PRAGMA cache_size=-512000 is set on the read-only connection.
+
+        SQLite normalises cache_size: a negative value means kilobytes,
+        so -512000 = 512 MB.  The exact value returned may differ across
+        SQLite versions; we just verify it is non-zero and negative.
+        """
+        db = await _file_db(tmp_path)
+        try:
+            cursor = await db._read_db.execute("PRAGMA cache_size")
+            row = await cursor.fetchone()
+            # Negative value means kibibytes — we expect -512000
+            assert row[0] < 0, (
+                f"Expected cache_size to be a negative (KB) value, got {row[0]}"
+            )
+        finally:
+            await db.close()
+
+    @pytest.mark.asyncio
+    async def test_close_closes_both_connections(self, tmp_path):
+        """Database.close() closes both db and _read_db without error."""
+        db = await _file_db(tmp_path)
+        # Should not raise
+        await db.close()
+        # After close, connections should not be usable
+        # (aiosqlite raises ProgrammingError on closed connections)
+        import aiosqlite
+
+        with pytest.raises(Exception):
+            await db.db.execute("SELECT 1")
+
+
+# ---------------------------------------------------------------------------
+# 3. Event-loop yielding in subscribe_ais_stream()
+# ---------------------------------------------------------------------------
+
+
+class TestEventLoopYielding:
+    """Verify asyncio.sleep(0) is called at every i % 500 == 0 within a batch."""
+
+    @pytest.mark.asyncio
+    async def test_sleep_called_at_i_0(self):
+        """asyncio.sleep(0) is called at i=0 (start of every batch)."""
+        service = ShipsAPIService()
+        service.running = True
+        service.replay_complete = True
+        service.ready = True
+
+        db = Database(":memory:")
+        await db.connect()
+        service.db = db
+
+        sleep_calls = []
+
+        async def track_sleep(n):
+            sleep_calls.append(n)
+
+        # Build exactly 1 message (so i=0 only)
+        pos_data = {
+            "mmsi": "100000001",
+            "lat": 51.0,
+            "lon": -1.0,
+            "speed": 5.0,
+            "course": 90.0,
+            "heading": 88,
+            "nav_status": 0,
+            "rate_of_turn": 0,
+            "position_accuracy": 1,
+            "ship_name": "YIELD_TEST",
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        }
+        mock_msg = AsyncMock()
+        mock_msg.subject = "ais.position.100000001"
+        mock_msg.data = json.dumps(pos_data).encode()
+        mock_msg.ack = AsyncMock()
+
+        mock_psub = AsyncMock()
+        mock_psub.fetch = AsyncMock(
+            side_effect=[[mock_msg], asyncio.TimeoutError()]
+        )
+        consumer_info_mock = MagicMock()
+        consumer_info_mock.num_pending = 0
+        mock_psub.consumer_info = AsyncMock(return_value=consumer_info_mock)
+
+        mock_js = AsyncMock()
+        mock_js.pull_subscribe = AsyncMock(return_value=mock_psub)
+        service.js = mock_js
+
+        with patch(
+            "projects.ships.backend.main.asyncio.sleep",
+            side_effect=track_sleep,
+        ):
+            task = asyncio.create_task(service.subscribe_ais_stream())
+            await asyncio.sleep(0.05)
+            service.running = False
+            try:
+                await asyncio.wait_for(task, timeout=2.0)
+            except (asyncio.TimeoutError, asyncio.CancelledError, Exception):
+                task.cancel()
+                try:
+                    await task
+                except (asyncio.CancelledError, Exception):
+                    pass
+
+        # sleep(0) must have been called (at i=0)
+        assert 0 in sleep_calls, (
+            f"Expected asyncio.sleep(0) at i=0, sleep calls: {sleep_calls}"
+        )
+
+        await db.close()
+
+    @pytest.mark.asyncio
+    async def test_sleep_called_at_i_500_boundary(self):
+        """asyncio.sleep(0) is called at i=500 when processing 501+ messages."""
+        service = ShipsAPIService()
+        service.running = True
+        service.replay_complete = True
+        service.ready = True
+
+        db = Database(":memory:")
+        await db.connect()
+        service.db = db
+        service.ws_manager.broadcast = AsyncMock()
+
+        sleep_call_count = 0
+
+        async def count_zero_sleeps(n):
+            nonlocal sleep_call_count
+            if n == 0:
+                sleep_call_count += 1
+
+        # Build 501 messages to trigger sleep at i=0 and i=500
+        msgs = []
+        for i in range(501):
+            pos_data = {
+                "mmsi": f"1{i:08d}",
+                "lat": 50.0 + i * 0.0001,
+                "lon": -1.0,
+                "speed": 5.0,
+                "course": 90.0,
+                "heading": 88,
+                "nav_status": 0,
+                "rate_of_turn": 0,
+                "position_accuracy": 1,
+                "ship_name": f"VESSEL{i}",
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+            }
+            m = AsyncMock()
+            m.subject = f"ais.position.1{i:08d}"
+            m.data = json.dumps(pos_data).encode()
+            m.ack = AsyncMock()
+            msgs.append(m)
+
+        mock_psub = AsyncMock()
+        mock_psub.fetch = AsyncMock(side_effect=[msgs, asyncio.TimeoutError()])
+        consumer_info_mock = MagicMock()
+        consumer_info_mock.num_pending = 0
+        mock_psub.consumer_info = AsyncMock(return_value=consumer_info_mock)
+
+        mock_js = AsyncMock()
+        mock_js.pull_subscribe = AsyncMock(return_value=mock_psub)
+        service.js = mock_js
+
+        with patch(
+            "projects.ships.backend.main.asyncio.sleep",
+            side_effect=count_zero_sleeps,
+        ):
+            task = asyncio.create_task(service.subscribe_ais_stream())
+            await asyncio.sleep(0.1)
+            service.running = False
+            try:
+                await asyncio.wait_for(task, timeout=5.0)
+            except (asyncio.TimeoutError, asyncio.CancelledError, Exception):
+                task.cancel()
+                try:
+                    await task
+                except (asyncio.CancelledError, Exception):
+                    pass
+
+        # With 501 messages, sleep(0) is called at i=0 and i=500 → 2 calls
+        assert sleep_call_count >= 2, (
+            f"Expected at least 2 sleep(0) calls (at i=0 and i=500), "
+            f"got {sleep_call_count}"
+        )
+
+        await db.close()
+
+    @pytest.mark.asyncio
+    async def test_sleep_not_called_at_non_multiple_of_500(self):
+        """asyncio.sleep(0) is NOT called for i=1..499 (only at multiples of 500)."""
+        service = ShipsAPIService()
+        service.running = True
+        service.replay_complete = True
+        service.ready = True
+
+        db = Database(":memory:")
+        await db.connect()
+        service.db = db
+        service.ws_manager.broadcast = AsyncMock()
+
+        zero_sleep_indices: list[int] = []
+        current_index = [-1]
+
+        async def track_sleep(n):
+            if n == 0:
+                zero_sleep_indices.append(current_index[0])
+
+        # Patch the loop index tracking by intercepting message processing
+        original_process = service._process_message_sync
+
+        def tracking_process(subject, data):
+            current_index[0] += 1
+            return original_process(subject, data)
+
+        service._process_message_sync = tracking_process
+
+        # Build exactly 3 messages (i=0,1,2) → only i=0 triggers sleep
+        msgs = []
+        for i in range(3):
+            pos_data = {
+                "mmsi": f"2{i:08d}",
+                "lat": 51.0,
+                "lon": -2.0,
+                "speed": 3.0,
+                "course": 45.0,
+                "heading": 44,
+                "nav_status": 0,
+                "rate_of_turn": 0,
+                "position_accuracy": 1,
+                "ship_name": f"V{i}",
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+            }
+            m = AsyncMock()
+            m.subject = f"ais.position.2{i:08d}"
+            m.data = json.dumps(pos_data).encode()
+            m.ack = AsyncMock()
+            msgs.append(m)
+
+        mock_psub = AsyncMock()
+        mock_psub.fetch = AsyncMock(side_effect=[msgs, asyncio.TimeoutError()])
+        consumer_info_mock = MagicMock()
+        consumer_info_mock.num_pending = 0
+        mock_psub.consumer_info = AsyncMock(return_value=consumer_info_mock)
+
+        mock_js = AsyncMock()
+        mock_js.pull_subscribe = AsyncMock(return_value=mock_psub)
+        service.js = mock_js
+
+        with patch(
+            "projects.ships.backend.main.asyncio.sleep",
+            side_effect=track_sleep,
+        ):
+            task = asyncio.create_task(service.subscribe_ais_stream())
+            await asyncio.sleep(0.05)
+            service.running = False
+            try:
+                await asyncio.wait_for(task, timeout=2.0)
+            except (asyncio.TimeoutError, asyncio.CancelledError, Exception):
+                task.cancel()
+                try:
+                    await task
+                except (asyncio.CancelledError, Exception):
+                    pass
+
+        # For 3 messages, sleep(0) should only fire at i=0
+        assert len(zero_sleep_indices) == 1, (
+            f"Expected 1 sleep(0) call (only at i=0), got {zero_sleep_indices}"
+        )
+
+        await db.close()

--- a/projects/ships/backend/tests/pragma_and_yield_test.py
+++ b/projects/ships/backend/tests/pragma_and_yield_test.py
@@ -107,9 +107,7 @@ class TestMainDbPragmaSettings:
         try:
             cursor = await db.db.execute("PRAGMA mmap_size")
             row = await cursor.fetchone()
-            assert row[0] == 268435456, (
-                f"Expected mmap_size=268435456, got {row[0]}"
-            )
+            assert row[0] == 268435456, f"Expected mmap_size=268435456, got {row[0]}"
         finally:
             await db.close()
 
@@ -139,9 +137,7 @@ class TestReadOnlyDbConnection:
         db = Database(":memory:")
         await db.connect()
         try:
-            assert db._read_db is db.db, (
-                "In-memory DB should reuse the same connection"
-            )
+            assert db._read_db is db.db, "In-memory DB should reuse the same connection"
         finally:
             await db.close()
 
@@ -266,9 +262,7 @@ class TestEventLoopYielding:
         mock_msg.ack = AsyncMock()
 
         mock_psub = AsyncMock()
-        mock_psub.fetch = AsyncMock(
-            side_effect=[[mock_msg], asyncio.TimeoutError()]
-        )
+        mock_psub.fetch = AsyncMock(side_effect=[[mock_msg], asyncio.TimeoutError()])
         consumer_info_mock = MagicMock()
         consumer_info_mock.num_pending = 0
         mock_psub.consumer_info = AsyncMock(return_value=consumer_info_mock)

--- a/projects/ships/chart/Chart.yaml
+++ b/projects/ships/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: marine
 description: Marine services - AIS vessel tracking and API
 type: application
-version: 0.3.38
+version: 0.3.39
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/ships/chart/Chart.yaml
+++ b/projects/ships/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: marine
 description: Marine services - AIS vessel tracking and API
 type: application
-version: 0.3.39
+version: 0.3.40
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/ships/deploy/application.yaml
+++ b/projects/ships/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: marine
-      targetRevision: 0.3.38
+      targetRevision: 0.3.39
       helm:
         releaseName: marine
         valueFiles:

--- a/projects/ships/deploy/application.yaml
+++ b/projects/ships/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: marine
-      targetRevision: 0.3.39
+      targetRevision: 0.3.40
       helm:
         releaseName: marine
         valueFiles:

--- a/projects/ships/ingest/BUILD
+++ b/projects/ships/ingest/BUILD
@@ -186,3 +186,22 @@ semgrep_test(
     exclude_rules = ["test-hardcoded-past-timestamp"],
     rules = ["//bazel/semgrep/rules:python_rules"],
 )
+
+py_test(
+    name = "reconnect_cap_test",
+    srcs = ["reconnect_cap_test.py"],
+    imports = ["."],
+    deps = [
+        ":ais-ingest",
+        "@pip//pytest",
+        "@pip//pytest_asyncio",  # keep
+        "@pip//websockets",
+    ],
+)
+
+semgrep_test(
+    name = "reconnect_cap_test_semgrep_test",
+    srcs = ["reconnect_cap_test.py"],
+    exclude_rules = ["test-hardcoded-past-timestamp"],
+    rules = ["//bazel/semgrep/rules:python_rules"],
+)

--- a/projects/ships/ingest/reconnect_cap_test.py
+++ b/projects/ships/ingest/reconnect_cap_test.py
@@ -1,0 +1,286 @@
+"""
+Tests for AISIngestService reconnect delay cap and ConnectionClosed mid-loop.
+
+Covers remaining gaps not addressed by subscribe_test.py:
+
+1. Reconnect delay caps at MAX_RECONNECT_DELAY (60 s) — existing tests confirm
+   the delay *increases* but don't verify it stops growing beyond 60 s.
+
+2. ConnectionClosed raised during *message iteration* (not on __aenter__) —
+   the existing subscribe_test.py raises on __aenter__; here we raise it inside
+   the async-for loop to exercise the same outer except clause via a different
+   code path.
+
+3. AISSTREAM_API_KEY is included verbatim in the subscription message.
+"""
+
+import asyncio
+import json
+from unittest.mock import patch
+
+import pytest
+import websockets.exceptions
+
+from projects.ships.ingest.main import (
+    INITIAL_RECONNECT_DELAY,
+    MAX_RECONNECT_DELAY,
+    RECONNECT_BACKOFF_FACTOR,
+    AISIngestService,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _EmptyWS:
+    """WebSocket that returns no messages and exits the loop immediately."""
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        pass
+
+    async def send(self, _msg):
+        pass
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        raise StopAsyncIteration
+
+
+class _AlwaysFailWS:
+    """WebSocket whose connect always raises a generic Exception."""
+
+    async def __aenter__(self):
+        raise Exception("connection refused")
+
+    async def __aexit__(self, *args):
+        pass
+
+
+class _ConnectionClosedDuringIterWS:
+    """WebSocket that raises ConnectionClosed during the async-for message loop."""
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        pass
+
+    async def send(self, _msg):
+        pass
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        raise websockets.exceptions.ConnectionClosed(rcvd=None, sent=None)
+
+
+# ---------------------------------------------------------------------------
+# 1. Reconnect delay caps at MAX_RECONNECT_DELAY
+# ---------------------------------------------------------------------------
+
+
+class TestReconnectDelayCap:
+    """Reconnect delay must not grow beyond MAX_RECONNECT_DELAY (60 s)."""
+
+    @pytest.fixture
+    def service(self):
+        return AISIngestService()
+
+    @pytest.mark.asyncio
+    async def test_delay_caps_at_max_reconnect_delay(self, service):
+        """After enough failures the delay stabilises at MAX_RECONNECT_DELAY."""
+        service.running = True
+        sleep_delays: list[float] = []
+
+        # Enough iterations to guarantee we hit the cap
+        # INITIAL=1.0, FACTOR=2.0 → 1,2,4,8,16,32,64(→60),60,60,...
+        max_iterations = 10
+
+        async def fake_sleep(delay: float):
+            sleep_delays.append(delay)
+            if len(sleep_delays) >= max_iterations:
+                service.running = False
+
+        with (
+            patch(
+                "projects.ships.ingest.main.websockets.connect",
+                return_value=_AlwaysFailWS(),
+            ),
+            patch("projects.ships.ingest.main.asyncio.sleep", side_effect=fake_sleep),
+        ):
+            await service.subscribe_to_aisstream()
+
+        # All delays must be ≤ MAX_RECONNECT_DELAY
+        for d in sleep_delays:
+            assert d <= MAX_RECONNECT_DELAY, (
+                f"Delay {d} exceeds MAX_RECONNECT_DELAY={MAX_RECONNECT_DELAY}"
+            )
+
+        # Once capped, consecutive delays stay equal to MAX_RECONNECT_DELAY
+        # (they don't keep growing)
+        capped = [d for d in sleep_delays if d >= MAX_RECONNECT_DELAY]
+        assert len(capped) >= 1, (
+            "Expected at least one delay to reach MAX_RECONNECT_DELAY"
+        )
+        for d in capped:
+            assert d == MAX_RECONNECT_DELAY, (
+                f"Capped delay {d} ≠ MAX_RECONNECT_DELAY={MAX_RECONNECT_DELAY}"
+            )
+
+    @pytest.mark.asyncio
+    async def test_delay_doubles_before_cap(self, service):
+        """Delay doubles correctly before hitting the cap."""
+        service.running = True
+        sleep_delays: list[float] = []
+
+        async def fake_sleep(delay: float):
+            sleep_delays.append(delay)
+            if len(sleep_delays) >= 4:
+                service.running = False
+
+        with (
+            patch(
+                "projects.ships.ingest.main.websockets.connect",
+                return_value=_AlwaysFailWS(),
+            ),
+            patch("projects.ships.ingest.main.asyncio.sleep", side_effect=fake_sleep),
+        ):
+            await service.subscribe_to_aisstream()
+
+        assert len(sleep_delays) >= 2
+        # First delay is INITIAL_RECONNECT_DELAY
+        assert sleep_delays[0] == INITIAL_RECONNECT_DELAY
+        # Second delay is INITIAL * FACTOR
+        assert sleep_delays[1] == pytest.approx(
+            INITIAL_RECONNECT_DELAY * RECONNECT_BACKOFF_FACTOR
+        )
+
+
+# ---------------------------------------------------------------------------
+# 2. ConnectionClosed raised during message iteration
+# ---------------------------------------------------------------------------
+
+
+class TestConnectionClosedDuringIteration:
+    """ConnectionClosed raised inside the async-for message loop is caught."""
+
+    @pytest.fixture
+    def service(self):
+        return AISIngestService()
+
+    @pytest.mark.asyncio
+    async def test_connection_closed_mid_loop_does_not_propagate(self, service):
+        """ConnectionClosed during message iteration is caught; loop continues."""
+        service.running = True
+
+        async def fake_sleep(_):
+            service.running = False
+
+        with (
+            patch(
+                "projects.ships.ingest.main.websockets.connect",
+                return_value=_ConnectionClosedDuringIterWS(),
+            ),
+            patch("projects.ships.ingest.main.asyncio.sleep", side_effect=fake_sleep),
+        ):
+            # Must not raise
+            await service.subscribe_to_aisstream()
+
+        assert service.running is False
+
+    @pytest.mark.asyncio
+    async def test_ready_reset_after_connection_closed_mid_loop(self, service):
+        """After ConnectionClosed mid-iteration, ready is reset to False."""
+        service.running = True
+        service.ready = True  # pretend it was connected
+
+        async def fake_sleep(_):
+            service.running = False
+
+        with (
+            patch(
+                "projects.ships.ingest.main.websockets.connect",
+                return_value=_ConnectionClosedDuringIterWS(),
+            ),
+            patch("projects.ships.ingest.main.asyncio.sleep", side_effect=fake_sleep),
+        ):
+            await service.subscribe_to_aisstream()
+
+        assert service.ready is False
+
+
+# ---------------------------------------------------------------------------
+# 3. AISSTREAM_API_KEY in subscription message
+# ---------------------------------------------------------------------------
+
+
+class TestSubscriptionApiKey:
+    """AISSTREAM_API_KEY is included in the subscription message sent to the WS."""
+
+    @pytest.fixture
+    def service(self):
+        return AISIngestService()
+
+    @pytest.mark.asyncio
+    async def test_api_key_included_in_subscription(self, service):
+        """The subscription JSON contains the AISSTREAM_API_KEY value."""
+        service.running = True
+        sent_messages: list[str] = []
+
+        class _CaptureSendWS(_EmptyWS):
+            async def send(self, msg: str):
+                sent_messages.append(msg)
+
+        fake_key = "test-api-key-12345"
+        async def fake_sleep(_):
+            service.running = False
+
+        with (
+            patch("projects.ships.ingest.main.AISSTREAM_API_KEY", fake_key),
+            patch(
+                "projects.ships.ingest.main.websockets.connect",
+                return_value=_CaptureSendWS(),
+            ),
+            patch("projects.ships.ingest.main.asyncio.sleep", side_effect=fake_sleep),
+        ):
+            await service.subscribe_to_aisstream()
+
+        assert len(sent_messages) == 1, "Expected exactly one message to be sent"
+        payload = json.loads(sent_messages[0])
+        assert payload["APIKey"] == fake_key, (
+            f"Expected APIKey={fake_key!r}, got {payload.get('APIKey')!r}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_filter_message_types_in_subscription(self, service):
+        """FilterMessageTypes contains both PositionReport and ShipStaticData."""
+        service.running = True
+        sent_messages: list[str] = []
+
+        class _CaptureSendWS(_EmptyWS):
+            async def send(self, msg: str):
+                sent_messages.append(msg)
+
+        async def fake_sleep(_):
+            service.running = False
+
+        with (
+            patch(
+                "projects.ships.ingest.main.websockets.connect",
+                return_value=_CaptureSendWS(),
+            ),
+            patch("projects.ships.ingest.main.asyncio.sleep", side_effect=fake_sleep),
+        ):
+            await service.subscribe_to_aisstream()
+
+        payload = json.loads(sent_messages[0])
+        assert "PositionReport" in payload["FilterMessageTypes"]
+        assert "ShipStaticData" in payload["FilterMessageTypes"]

--- a/projects/ships/ingest/reconnect_cap_test.py
+++ b/projects/ships/ingest/reconnect_cap_test.py
@@ -240,6 +240,7 @@ class TestSubscriptionApiKey:
                 sent_messages.append(msg)
 
         fake_key = "test-api-key-12345"
+
         async def fake_sleep(_):
             service.running = False
 


### PR DESCRIPTION
## Summary

- **`pragma_and_yield_test.py`** (ships/backend): 9 new tests covering previously untested SQLite PRAGMA settings on both the write connection (`synchronous=OFF`, `temp_store=MEMORY`, `wal_autocheckpoint=1000`, `busy_timeout=5000`, `mmap_size=268435456`) and the read-only connection (`mmap_size`, `cache_size`). Also verifies the read-only connection is a _separate_ object from the write connection (only exercised for file-based DBs — the in-memory test path skips this). 3 tests verify `asyncio.sleep(0)` is called at every `i % 500 == 0` during `subscribe_ais_stream()` batch processing to yield the event loop for health checks.
- **`reconnect_cap_test.py`** (ships/ingest): 5 new tests verifying the reconnect delay caps at `MAX_RECONNECT_DELAY` (60 s), doubles correctly before capping, `ConnectionClosed` raised _during_ message iteration is caught gracefully, and `AISSTREAM_API_KEY` / `FilterMessageTypes` appear in the subscription message.

## Test plan

- [ ] `//projects/ships/backend/tests:pragma_and_yield_test` passes
- [ ] `//projects/ships/ingest:reconnect_cap_test` passes
- [ ] All other ships tests continue to pass (`//projects/ships/...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)