### PR TITLE
test(ships): add coverage for identified gaps

### DIFF
--- a/projects/ships/backend/tests/BUILD
+++ b/projects/ships/backend/tests/BUILD
@@ -294,3 +294,24 @@ semgrep_test(
     exclude_rules = ["test-hardcoded-past-timestamp"],
     rules = ["//bazel/semgrep/rules:python_rules"],
 )
+
+py_test(
+    name = "identified_gaps_test",
+    srcs = ["identified_gaps_test.py"],
+    imports = [".."],
+    deps = [
+        ":conftest",
+        "//projects/ships/backend:ships-api",
+        "@pip//aiosqlite",
+        "@pip//httpx",
+        "@pip//pytest",
+        "@pip//pytest_asyncio",  # keep
+    ],
+)
+
+semgrep_test(
+    name = "identified_gaps_test_semgrep_test",
+    srcs = ["identified_gaps_test.py"],
+    exclude_rules = ["test-hardcoded-past-timestamp"],
+    rules = ["//bazel/semgrep/rules:python_rules"],
+)

--- a/projects/ships/backend/tests/BUILD
+++ b/projects/ships/backend/tests/BUILD
@@ -303,7 +303,6 @@ py_test(
         ":conftest",
         "//projects/ships/backend:ships-api",
         "@pip//aiosqlite",
-        "@pip//httpx",
         "@pip//pytest",
         "@pip//pytest_asyncio",  # keep
     ],

--- a/projects/ships/backend/tests/identified_gaps_test.py
+++ b/projects/ships/backend/tests/identified_gaps_test.py
@@ -375,7 +375,9 @@ class TestUpsertVesselsBatchCoalesceAllFields:
             assert row["dimension_b"] == 50, "dimension_b must be preserved"
             assert row["dimension_c"] == 20, "dimension_c must be preserved"
             assert row["dimension_d"] == 10, "dimension_d must be preserved"
-            assert row["destination"] == "ORIGINAL DEST", "destination must be preserved"
+            assert row["destination"] == "ORIGINAL DEST", (
+                "destination must be preserved"
+            )
             assert row["eta"] == "2027-01-01T00:00:00Z", "eta must be preserved"
             assert row["draught"] == pytest.approx(9.5), "draught must be preserved"
         finally:
@@ -440,9 +442,7 @@ class TestUpsertVesselsBatchCoalesceAllFields:
             await db.commit()
 
             # Update only destination — name, eta, draught should be preserved
-            await db.upsert_vessels_batch(
-                [{"mmsi": mmsi, "destination": "PORT B"}]
-            )
+            await db.upsert_vessels_batch([{"mmsi": mmsi, "destination": "PORT B"}])
             await db.commit()
 
             cursor = await db.db.execute(

--- a/projects/ships/backend/tests/identified_gaps_test.py
+++ b/projects/ships/backend/tests/identified_gaps_test.py
@@ -1,0 +1,458 @@
+"""
+Tests for identified coverage gaps in Ships API backend.
+
+Covers:
+1. Database.connect() _read_db path — file connection, URI mode, and PRAGMA settings
+2. Database.get_vessel() error parse — ValueError/TypeError on malformed
+   first_seen_at_location sets time_at_location_* and is_moored to None
+3. /ready endpoint "starting" reason — 503 with reason="starting" when
+   replay_complete=True but ready=False
+4. upsert_vessels_batch() COALESCE — NULL-preserving behaviour for all 11
+   COALESCE fields on re-upsert
+"""
+
+import os
+import tempfile
+from datetime import datetime, timezone
+
+import pytest
+
+from projects.ships.backend.main import Database
+
+
+# ---------------------------------------------------------------------------
+# 1. Database.connect() _read_db file connection path (lines 206-214)
+# ---------------------------------------------------------------------------
+
+
+class TestDatabaseConnectReadDbFilePath:
+    """Database.connect() opens a separate read-only file connection for
+    file-backed databases (not :memory:)."""
+
+    @pytest.mark.asyncio
+    async def test_file_db_opens_separate_read_connection(self, tmp_path):
+        """For a file-backed DB, _read_db is a distinct connection object."""
+        db_path = str(tmp_path / "test_read_path.db")
+        db = Database(db_path)
+        await db.connect()
+        try:
+            assert db._read_db is not None
+            assert db._read_db is not db.db
+        finally:
+            await db.close()
+
+    @pytest.mark.asyncio
+    async def test_file_db_read_connection_has_mmap_pragma(self, tmp_path):
+        """_read_db has PRAGMA mmap_size=268435456 (256 MB) set."""
+        db_path = str(tmp_path / "test_pragma_read.db")
+        db = Database(db_path)
+        await db.connect()
+        try:
+            cursor = await db._read_db.execute("PRAGMA mmap_size")
+            row = await cursor.fetchone()
+            assert row[0] == 268435456
+        finally:
+            await db.close()
+
+    @pytest.mark.asyncio
+    async def test_file_db_read_connection_has_cache_size_pragma(self, tmp_path):
+        """_read_db has PRAGMA cache_size=-512000 set (negative = kibibytes)."""
+        db_path = str(tmp_path / "test_pragma_cache.db")
+        db = Database(db_path)
+        await db.connect()
+        try:
+            cursor = await db._read_db.execute("PRAGMA cache_size")
+            row = await cursor.fetchone()
+            # Negative value means kibibytes — -512000 = 512 MB cache
+            assert row[0] < 0
+        finally:
+            await db.close()
+
+    @pytest.mark.asyncio
+    async def test_file_db_read_connection_row_factory_set(self, tmp_path):
+        """_read_db has row_factory set so columns are accessible by name."""
+        import aiosqlite
+
+        db_path = str(tmp_path / "test_row_factory.db")
+        db = Database(db_path)
+        await db.connect()
+        try:
+            assert db._read_db.row_factory == aiosqlite.Row
+        finally:
+            await db.close()
+
+    @pytest.mark.asyncio
+    async def test_memory_db_read_db_is_same_as_write_db(self):
+        """For :memory: DB, _read_db must be the same object as self.db.
+
+        SQLite :memory: databases are connection-scoped — a second connection
+        would see a completely empty schema, so we reuse the write connection.
+        """
+        db = Database(":memory:")
+        await db.connect()
+        try:
+            assert db._read_db is db.db
+        finally:
+            await db.close()
+
+    @pytest.mark.asyncio
+    async def test_file_db_read_connection_can_see_committed_data(self, tmp_path):
+        """After committing data on the write connection, _read_db can read it."""
+        db_path = str(tmp_path / "test_read_sees_data.db")
+        db = Database(db_path)
+        await db.connect()
+        try:
+            now = datetime.now(timezone.utc).isoformat()
+            await db.insert_positions_batch(
+                [
+                    (
+                        {
+                            "mmsi": "888888888",
+                            "lat": 49.0,
+                            "lon": -124.0,
+                            "speed": 5.0,
+                            "timestamp": now,
+                        },
+                        now,
+                    )
+                ]
+            )
+            await db.commit()
+
+            cursor = await db._read_db.execute(
+                "SELECT COUNT(*) FROM latest_positions WHERE mmsi = ?", ("888888888",)
+            )
+            row = await cursor.fetchone()
+            assert row[0] == 1
+        finally:
+            await db.close()
+
+
+# ---------------------------------------------------------------------------
+# 2. Database.get_vessel() error parse (lines 570-573)
+# ---------------------------------------------------------------------------
+
+
+class TestGetVesselErrorParse:
+    """get_vessel() sets time_at_location_* and is_moored to None when
+    first_seen_at_location cannot be parsed (ValueError or TypeError)."""
+
+    @pytest.mark.asyncio
+    async def test_malformed_first_seen_returns_none_analytics(self):
+        """A non-ISO-format first_seen string triggers ValueError → None fields."""
+        db = Database(":memory:")
+        await db.connect()
+        try:
+            ts = datetime.now(timezone.utc).isoformat()
+            # Insert position with a malformed first_seen_at_location
+            await db.insert_positions_batch(
+                [
+                    (
+                        {
+                            "mmsi": "100000001",
+                            "lat": 48.5,
+                            "lon": -123.4,
+                            "speed": 0.0,
+                            "timestamp": ts,
+                        },
+                        "this-is-not-a-valid-timestamp",  # triggers ValueError
+                    )
+                ]
+            )
+            await db.commit()
+
+            vessel = await db.get_vessel("100000001")
+            assert vessel is not None
+            assert vessel.get("time_at_location_seconds") is None
+            assert vessel.get("time_at_location_hours") is None
+            assert vessel.get("is_moored") is None
+        finally:
+            await db.close()
+
+    @pytest.mark.asyncio
+    async def test_none_first_seen_skips_analytics_block(self):
+        """None first_seen_at_location causes the analytics block to be skipped
+        entirely (no time_at_location_* keys added)."""
+        db = Database(":memory:")
+        await db.connect()
+        try:
+            ts = datetime.now(timezone.utc).isoformat()
+            await db.insert_positions_batch(
+                [
+                    (
+                        {
+                            "mmsi": "100000002",
+                            "lat": 48.5,
+                            "lon": -123.4,
+                            "speed": 0.0,
+                            "timestamp": ts,
+                        },
+                        None,  # No first_seen → analytics block not entered
+                    )
+                ]
+            )
+            await db.commit()
+
+            vessel = await db.get_vessel("100000002")
+            assert vessel is not None
+            assert vessel.get("time_at_location_seconds") is None
+            assert vessel.get("time_at_location_hours") is None
+            assert vessel.get("is_moored") is None
+        finally:
+            await db.close()
+
+    @pytest.mark.asyncio
+    async def test_garbage_string_first_seen_returns_none_analytics(self):
+        """Completely garbage string triggers ValueError → None analytics fields."""
+        db = Database(":memory:")
+        await db.connect()
+        try:
+            ts = datetime.now(timezone.utc).isoformat()
+            await db.insert_positions_batch(
+                [
+                    (
+                        {
+                            "mmsi": "100000003",
+                            "lat": 49.0,
+                            "lon": -124.0,
+                            "speed": 0.0,
+                            "timestamp": ts,
+                        },
+                        "not-a-date-at-all-!@#$%",
+                    )
+                ]
+            )
+            await db.commit()
+
+            vessel = await db.get_vessel("100000003")
+            assert vessel is not None
+            # All three fields must be None (ValueError path)
+            assert vessel["time_at_location_seconds"] is None
+            assert vessel["time_at_location_hours"] is None
+            assert vessel["is_moored"] is None
+        finally:
+            await db.close()
+
+
+# ---------------------------------------------------------------------------
+# 3. /ready endpoint "starting" reason
+# ---------------------------------------------------------------------------
+
+
+class TestReadyEndpointStartingReason:
+    """The /ready endpoint returns 503 with reason='starting' when
+    replay_complete=True but ready=False simultaneously."""
+
+    @pytest.mark.asyncio
+    async def test_ready_starting_reason_503(self, test_client):
+        """Returns 503 with reason='starting' when replay is done but service not ready."""
+        from projects.ships.backend.main import service
+
+        original_ready = service.ready
+        original_replay = service.replay_complete
+
+        service.ready = False
+        service.replay_complete = True
+        try:
+            response = await test_client.get("/ready")
+            assert response.status_code == 503
+            body = response.json()
+            assert body["status"] == "not_ready"
+            assert body["reason"] == "starting"
+        finally:
+            service.ready = original_ready
+            service.replay_complete = original_replay
+
+    @pytest.mark.asyncio
+    async def test_ready_catching_up_reason_503(self, test_client):
+        """Returns 503 with reason='catching_up' when replay_complete=False."""
+        from projects.ships.backend.main import service
+
+        original_ready = service.ready
+        original_replay = service.replay_complete
+
+        service.ready = False
+        service.replay_complete = False
+        try:
+            response = await test_client.get("/ready")
+            assert response.status_code == 503
+            body = response.json()
+            assert body["reason"] == "catching_up"
+        finally:
+            service.ready = original_ready
+            service.replay_complete = original_replay
+
+    @pytest.mark.asyncio
+    async def test_ready_200_when_ready(self, test_client):
+        """Returns 200 with status='ready' when service is ready."""
+        from projects.ships.backend.main import service
+
+        original_ready = service.ready
+        original_replay = service.replay_complete
+
+        service.ready = True
+        service.replay_complete = True
+        try:
+            response = await test_client.get("/ready")
+            assert response.status_code == 200
+            assert response.json()["status"] == "ready"
+        finally:
+            service.ready = original_ready
+            service.replay_complete = original_replay
+
+
+# ---------------------------------------------------------------------------
+# 4. upsert_vessels_batch() COALESCE null-preservation for all 11 fields
+# ---------------------------------------------------------------------------
+
+
+class TestUpsertVesselsBatchCoalesceAllFields:
+    """Verify that all 11 COALESCE fields in upsert_vessels_batch() preserve
+    existing non-NULL values when the re-upsert provides NULL for each field."""
+
+    @pytest.mark.asyncio
+    async def test_all_11_coalesce_fields_preserved_on_null_reupsert(self):
+        """Re-upserting with all 11 nullable fields set to None must NOT overwrite
+        the values that were set in the first insert."""
+        db = Database(":memory:")
+        await db.connect()
+        try:
+            mmsi = "200000001"
+            first = {
+                "mmsi": mmsi,
+                "imo": "IMO9999999",
+                "call_sign": "CALLX",
+                "name": "ORIGINAL NAME",
+                "ship_type": 70,
+                "dimension_a": 100,
+                "dimension_b": 50,
+                "dimension_c": 20,
+                "dimension_d": 10,
+                "destination": "ORIGINAL DEST",
+                "eta": "2027-01-01T00:00:00Z",
+                "draught": 9.5,
+            }
+            # First insert — establishes all values
+            await db.upsert_vessels_batch([first])
+            await db.commit()
+
+            # Second insert — all 11 nullable fields are NULL
+            null_update = {
+                "mmsi": mmsi,
+                "imo": None,
+                "call_sign": None,
+                "name": None,
+                "ship_type": None,
+                "dimension_a": None,
+                "dimension_b": None,
+                "dimension_c": None,
+                "dimension_d": None,
+                "destination": None,
+                "eta": None,
+                "draught": None,
+            }
+            await db.upsert_vessels_batch([null_update])
+            await db.commit()
+
+            cursor = await db.db.execute(
+                """
+                SELECT imo, call_sign, name, ship_type,
+                       dimension_a, dimension_b, dimension_c, dimension_d,
+                       destination, eta, draught
+                FROM vessels WHERE mmsi = ?
+                """,
+                (mmsi,),
+            )
+            row = await cursor.fetchone()
+            assert row is not None, "Vessel row must exist"
+
+            # All 11 COALESCE fields must retain their original values
+            assert row["imo"] == "IMO9999999", "imo must be preserved"
+            assert row["call_sign"] == "CALLX", "call_sign must be preserved"
+            assert row["name"] == "ORIGINAL NAME", "name must be preserved"
+            assert row["ship_type"] == 70, "ship_type must be preserved"
+            assert row["dimension_a"] == 100, "dimension_a must be preserved"
+            assert row["dimension_b"] == 50, "dimension_b must be preserved"
+            assert row["dimension_c"] == 20, "dimension_c must be preserved"
+            assert row["dimension_d"] == 10, "dimension_d must be preserved"
+            assert row["destination"] == "ORIGINAL DEST", "destination must be preserved"
+            assert row["eta"] == "2027-01-01T00:00:00Z", "eta must be preserved"
+            assert row["draught"] == pytest.approx(9.5), "draught must be preserved"
+        finally:
+            await db.close()
+
+    @pytest.mark.asyncio
+    async def test_coalesce_replaces_null_with_non_null_value(self):
+        """COALESCE allows updating a previously-NULL field with a real value."""
+        db = Database(":memory:")
+        await db.connect()
+        try:
+            mmsi = "200000002"
+            # First insert — all optional fields NULL
+            await db.upsert_vessels_batch(
+                [{"mmsi": mmsi, "name": None, "imo": None, "destination": None}]
+            )
+            await db.commit()
+
+            # Second insert — provide values now
+            await db.upsert_vessels_batch(
+                [
+                    {
+                        "mmsi": mmsi,
+                        "name": "NEW NAME",
+                        "imo": "IMO1111111",
+                        "destination": "NEW DEST",
+                    }
+                ]
+            )
+            await db.commit()
+
+            cursor = await db.db.execute(
+                "SELECT name, imo, destination FROM vessels WHERE mmsi = ?", (mmsi,)
+            )
+            row = await cursor.fetchone()
+            assert row["name"] == "NEW NAME"
+            assert row["imo"] == "IMO1111111"
+            assert row["destination"] == "NEW DEST"
+        finally:
+            await db.close()
+
+    @pytest.mark.asyncio
+    async def test_coalesce_each_field_independently(self):
+        """Each COALESCE field operates independently — updating one field does
+        not reset others to NULL."""
+        db = Database(":memory:")
+        await db.connect()
+        try:
+            mmsi = "200000003"
+            # First insert sets destination and eta
+            await db.upsert_vessels_batch(
+                [
+                    {
+                        "mmsi": mmsi,
+                        "name": "ORIGINAL",
+                        "destination": "PORT A",
+                        "eta": "2027-06-01T12:00:00Z",
+                        "draught": 8.0,
+                    }
+                ]
+            )
+            await db.commit()
+
+            # Update only destination — name, eta, draught should be preserved
+            await db.upsert_vessels_batch(
+                [{"mmsi": mmsi, "destination": "PORT B"}]
+            )
+            await db.commit()
+
+            cursor = await db.db.execute(
+                "SELECT name, destination, eta, draught FROM vessels WHERE mmsi = ?",
+                (mmsi,),
+            )
+            row = await cursor.fetchone()
+            assert row["name"] == "ORIGINAL", "name preserved"
+            assert row["destination"] == "PORT B", "destination updated"
+            assert row["eta"] == "2027-06-01T12:00:00Z", "eta preserved"
+            assert row["draught"] == pytest.approx(8.0), "draught preserved"
+        finally:
+            await db.close()

--- a/projects/ships/chart/Chart.yaml
+++ b/projects/ships/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: marine
 description: Marine services - AIS vessel tracking and API
 type: application
-version: 0.3.40
+version: 0.3.41
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/ships/deploy/application.yaml
+++ b/projects/ships/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: marine
-      targetRevision: 0.3.40
+      targetRevision: 0.3.41
       helm:
         releaseName: marine
         valueFiles:

--- a/projects/ships/ingest/BUILD
+++ b/projects/ships/ingest/BUILD
@@ -205,3 +205,22 @@ semgrep_test(
     exclude_rules = ["test-hardcoded-past-timestamp"],
     rules = ["//bazel/semgrep/rules:python_rules"],
 )
+
+py_test(
+    name = "identified_gaps_test",
+    srcs = ["identified_gaps_test.py"],
+    imports = ["."],
+    deps = [
+        ":ais-ingest",
+        "@pip//nats_py",
+        "@pip//pytest",
+        "@pip//pytest_asyncio",  # keep
+    ],
+)
+
+semgrep_test(
+    name = "identified_gaps_test_semgrep_test",
+    srcs = ["identified_gaps_test.py"],
+    exclude_rules = ["test-hardcoded-past-timestamp"],
+    rules = ["//bazel/semgrep/rules:python_rules"],
+)

--- a/projects/ships/ingest/identified_gaps_test.py
+++ b/projects/ships/ingest/identified_gaps_test.py
@@ -1,0 +1,213 @@
+"""
+Tests for identified coverage gaps in AIS ingest service.
+
+Covers:
+5. connect_nats() update_stream failure propagation — if the "already in use"
+   recovery path itself raises, the exception propagates uncaught (no test existed)
+6. publish_static() counter asymmetry — unlike publish_position(), publish_static()
+   does NOT increment messages_published or update last_message_time
+"""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+# ---------------------------------------------------------------------------
+# 5. connect_nats() update_stream failure propagation
+# ---------------------------------------------------------------------------
+
+
+class TestConnectNatsUpdateStreamFailure:
+    """When connect_nats() enters the 'already in use' recovery path but
+    update_stream() itself raises, the exception propagates uncaught."""
+
+    @pytest.mark.asyncio
+    async def test_update_stream_error_propagates(self):
+        """If update_stream raises after the 'already in use' add_stream error,
+        the exception bubbles out of connect_nats() uncaught."""
+        import nats as nats_module
+        import nats.js.errors
+
+        from projects.ships.ingest.main import AISIngestService
+
+        class _AlreadyInUse(nats.js.errors.BadRequestError):
+            def __str__(self):
+                return "stream name already in use"
+
+        service = AISIngestService()
+        mock_nc = MagicMock()
+        mock_js = AsyncMock()
+        mock_nc.jetstream.return_value = mock_js
+        mock_js.add_stream.side_effect = _AlreadyInUse()
+        mock_js.update_stream.side_effect = RuntimeError(
+            "NATS update rejected: quota exceeded"
+        )
+
+        with patch.object(nats_module, "connect", AsyncMock(return_value=mock_nc)):
+            with pytest.raises(RuntimeError, match="quota exceeded"):
+                await service.connect_nats()
+
+    @pytest.mark.asyncio
+    async def test_update_stream_os_error_propagates(self):
+        """OSError from update_stream is not caught — propagates to caller."""
+        import nats as nats_module
+        import nats.js.errors
+
+        from projects.ships.ingest.main import AISIngestService
+
+        class _AlreadyInUse(nats.js.errors.BadRequestError):
+            def __str__(self):
+                return "already in use"
+
+        service = AISIngestService()
+        mock_nc = MagicMock()
+        mock_js = AsyncMock()
+        mock_nc.jetstream.return_value = mock_js
+        mock_js.add_stream.side_effect = _AlreadyInUse()
+        mock_js.update_stream.side_effect = OSError("connection reset")
+
+        with patch.object(nats_module, "connect", AsyncMock(return_value=mock_nc)):
+            with pytest.raises(OSError, match="connection reset"):
+                await service.connect_nats()
+
+    @pytest.mark.asyncio
+    async def test_update_stream_value_error_propagates(self):
+        """ValueError from update_stream is not swallowed — propagates."""
+        import nats as nats_module
+        import nats.js.errors
+
+        from projects.ships.ingest.main import AISIngestService
+
+        class _AlreadyInUse(nats.js.errors.BadRequestError):
+            def __str__(self):
+                return "stream name already in use"
+
+        service = AISIngestService()
+        mock_nc = MagicMock()
+        mock_js = AsyncMock()
+        mock_nc.jetstream.return_value = mock_js
+        mock_js.add_stream.side_effect = _AlreadyInUse()
+        mock_js.update_stream.side_effect = ValueError("bad stream config")
+
+        with patch.object(nats_module, "connect", AsyncMock(return_value=mock_nc)):
+            with pytest.raises(ValueError, match="bad stream config"):
+                await service.connect_nats()
+
+    @pytest.mark.asyncio
+    async def test_update_stream_success_does_not_raise(self):
+        """When update_stream succeeds after 'already in use', connect_nats() completes
+        without error — baseline sanity check."""
+        import nats as nats_module
+        import nats.js.errors
+
+        from projects.ships.ingest.main import AISIngestService
+
+        class _AlreadyInUse(nats.js.errors.BadRequestError):
+            def __str__(self):
+                return "stream name already in use"
+
+        service = AISIngestService()
+        mock_nc = MagicMock()
+        mock_js = AsyncMock()
+        mock_nc.jetstream.return_value = mock_js
+        mock_js.add_stream.side_effect = _AlreadyInUse()
+        # update_stream returns normally (no side_effect = returns AsyncMock default)
+
+        with patch.object(nats_module, "connect", AsyncMock(return_value=mock_nc)):
+            await service.connect_nats()  # Must not raise
+
+        mock_js.update_stream.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# 6. publish_static() counter asymmetry vs publish_position()
+# ---------------------------------------------------------------------------
+
+
+class TestPublishStaticCounterAsymmetry:
+    """publish_static() does NOT increment messages_published and does NOT
+    update last_message_time — unlike publish_position() which does both."""
+
+    @pytest.mark.asyncio
+    async def test_publish_static_does_not_increment_messages_published(self):
+        """After calling publish_static(), messages_published remains 0."""
+        from projects.ships.ingest.main import AISIngestService
+
+        service = AISIngestService()
+        service.js = AsyncMock()
+
+        data = {"mmsi": "123456789", "name": "TEST VESSEL", "timestamp": "2027-01-01T00:00:00Z"}
+        await service.publish_static("123456789", data)
+
+        assert service.messages_published == 0
+
+    @pytest.mark.asyncio
+    async def test_publish_static_does_not_update_last_message_time(self):
+        """After calling publish_static(), last_message_time remains None."""
+        from projects.ships.ingest.main import AISIngestService
+
+        service = AISIngestService()
+        service.js = AsyncMock()
+
+        data = {"mmsi": "123456789", "name": "TEST", "timestamp": "2027-01-01T00:00:00Z"}
+        await service.publish_static("123456789", data)
+
+        assert service.last_message_time is None
+
+    @pytest.mark.asyncio
+    async def test_publish_position_increments_messages_published(self):
+        """Contrast: publish_position() DOES increment messages_published."""
+        from projects.ships.ingest.main import AISIngestService
+
+        service = AISIngestService()
+        service.js = AsyncMock()
+
+        data = {
+            "mmsi": "123456789",
+            "lat": 48.5,
+            "lon": -123.4,
+            "timestamp": "2027-01-01T00:00:00Z",
+        }
+        await service.publish_position("123456789", data)
+
+        assert service.messages_published == 1
+
+    @pytest.mark.asyncio
+    async def test_publish_position_updates_last_message_time(self):
+        """Contrast: publish_position() DOES update last_message_time."""
+        from projects.ships.ingest.main import AISIngestService
+
+        service = AISIngestService()
+        service.js = AsyncMock()
+
+        ts = "2027-01-01T00:00:00Z"
+        data = {"mmsi": "123456789", "lat": 48.5, "lon": -123.4, "timestamp": ts}
+        await service.publish_position("123456789", data)
+
+        assert service.last_message_time == ts
+
+    @pytest.mark.asyncio
+    async def test_counter_asymmetry_multiple_calls(self):
+        """After N publish_static() + M publish_position() calls, only the M
+        position calls are counted in messages_published."""
+        from projects.ships.ingest.main import AISIngestService
+
+        service = AISIngestService()
+        service.js = AsyncMock()
+
+        static_data = {"mmsi": "111", "name": "VESSEL", "timestamp": "2027-01-01T00:00:00Z"}
+        pos_data = {"mmsi": "111", "lat": 48.5, "lon": -123.4, "timestamp": "2027-01-01T00:01:00Z"}
+
+        # 3 static publishes (should NOT count)
+        await service.publish_static("111", static_data)
+        await service.publish_static("111", static_data)
+        await service.publish_static("111", static_data)
+
+        # 2 position publishes (SHOULD count)
+        await service.publish_position("111", pos_data)
+        await service.publish_position("111", {**pos_data, "timestamp": "2027-01-01T00:02:00Z"})
+
+        # Only the 2 position publishes should be counted
+        assert service.messages_published == 2
+        # last_message_time reflects only position publishes
+        assert service.last_message_time == "2027-01-01T00:02:00Z"

--- a/projects/ships/ingest/identified_gaps_test.py
+++ b/projects/ships/ingest/identified_gaps_test.py
@@ -136,7 +136,11 @@ class TestPublishStaticCounterAsymmetry:
         service = AISIngestService()
         service.js = AsyncMock()
 
-        data = {"mmsi": "123456789", "name": "TEST VESSEL", "timestamp": "2027-01-01T00:00:00Z"}
+        data = {
+            "mmsi": "123456789",
+            "name": "TEST VESSEL",
+            "timestamp": "2027-01-01T00:00:00Z",
+        }
         await service.publish_static("123456789", data)
 
         assert service.messages_published == 0
@@ -149,7 +153,11 @@ class TestPublishStaticCounterAsymmetry:
         service = AISIngestService()
         service.js = AsyncMock()
 
-        data = {"mmsi": "123456789", "name": "TEST", "timestamp": "2027-01-01T00:00:00Z"}
+        data = {
+            "mmsi": "123456789",
+            "name": "TEST",
+            "timestamp": "2027-01-01T00:00:00Z",
+        }
         await service.publish_static("123456789", data)
 
         assert service.last_message_time is None
@@ -195,8 +203,17 @@ class TestPublishStaticCounterAsymmetry:
         service = AISIngestService()
         service.js = AsyncMock()
 
-        static_data = {"mmsi": "111", "name": "VESSEL", "timestamp": "2027-01-01T00:00:00Z"}
-        pos_data = {"mmsi": "111", "lat": 48.5, "lon": -123.4, "timestamp": "2027-01-01T00:01:00Z"}
+        static_data = {
+            "mmsi": "111",
+            "name": "VESSEL",
+            "timestamp": "2027-01-01T00:00:00Z",
+        }
+        pos_data = {
+            "mmsi": "111",
+            "lat": 48.5,
+            "lon": -123.4,
+            "timestamp": "2027-01-01T00:01:00Z",
+        }
 
         # 3 static publishes (should NOT count)
         await service.publish_static("111", static_data)
@@ -205,7 +222,9 @@ class TestPublishStaticCounterAsymmetry:
 
         # 2 position publishes (SHOULD count)
         await service.publish_position("111", pos_data)
-        await service.publish_position("111", {**pos_data, "timestamp": "2027-01-01T00:02:00Z"})
+        await service.publish_position(
+            "111", {**pos_data, "timestamp": "2027-01-01T00:02:00Z"}
+        )
 
         # Only the 2 position publishes should be counted
         assert service.messages_published == 2


### PR DESCRIPTION
## Summary
- Add test for `Database.connect()` read-only file connection and PRAGMA settings
- Add test for `get_vessel()` malformed date parse (`ValueError`/`TypeError` → `None`)
- Add test for `/ready` endpoint `"starting"` reason (503 with `replay_complete=True, ready=False`)
- Add test for `upsert_vessels_batch()` COALESCE null-preservation behavior for all 11 fields
- Add test for `connect_nats()` `update_stream` failure propagation
- Add test documenting `publish_static()` counter asymmetry vs `publish_position()`

## Test plan
- [ ] `bb remote --os=linux --arch=amd64 test //projects/ships/... --config=ci` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)