### PR TITLE
test(cli): add coverage for auth, main, output, and knowledge_cmd gaps

### DIFF
--- a/tools/cli/BUILD
+++ b/tools/cli/BUILD
@@ -103,3 +103,20 @@ semgrep_test(
     srcs = ["output_test.py"],
     rules = ["//bazel/semgrep/rules:python_rules"],
 )
+
+py_test(
+    name = "knowledge_unit_test",
+    srcs = ["knowledge_unit_test.py"],
+    deps = [
+        ":cli",
+        "@pip//httpx",
+        "@pip//pytest",
+        "@pip//typer",
+    ],
+)
+
+semgrep_test(
+    name = "knowledge_unit_test_semgrep_test",
+    srcs = ["knowledge_unit_test.py"],
+    rules = ["//bazel/semgrep/rules:python_rules"],
+)

--- a/tools/cli/auth_test.py
+++ b/tools/cli/auth_test.py
@@ -42,3 +42,69 @@ class TestGetCfToken:
             result = get_cf_token()
             assert result == "fresh-token"
             assert call_count == 1
+
+    def test_custom_hostname_reads_matching_token(self, tmp_path):
+        """Custom hostname resolves the file containing that hostname in its name."""
+        token_file = tmp_path / "custom.example.com-token"
+        token_file.write_text("custom-host-token")
+        with patch("tools.cli.auth.CF_TOKEN_DIR", tmp_path):
+            result = get_cf_token("custom.example.com")
+        assert result == "custom-host-token"
+
+    def test_custom_hostname_does_not_match_default_token(self, tmp_path):
+        """A token file for the default hostname is not returned for a different hostname."""
+        # Only the default hostname token exists.
+        default_token = tmp_path / "private.jomcgi.dev-token"
+        default_token.write_text("default-token")
+        with (
+            patch("tools.cli.auth.CF_TOKEN_DIR", tmp_path),
+            patch("tools.cli.auth.shutil.which", return_value=None),
+        ):
+            # No matching file for "other.example.com" → triggers SystemExit (no cloudflared).
+            with pytest.raises(SystemExit):
+                get_cf_token("other.example.com")
+
+    def test_strips_leading_and_trailing_whitespace_from_token(self, tmp_path):
+        """Token files with surrounding whitespace are stripped before returning."""
+        token_file = tmp_path / "private.jomcgi.dev-token"
+        token_file.write_text("  \n  actual-token  \n  ")
+        with patch("tools.cli.auth.CF_TOKEN_DIR", tmp_path):
+            result = get_cf_token()
+        assert result == "actual-token"
+
+    def test_strips_newline_only_whitespace(self, tmp_path):
+        """Token files ending with a trailing newline (common in editors) are stripped."""
+        token_file = tmp_path / "private.jomcgi.dev-token"
+        token_file.write_text("newline-token\n")
+        with patch("tools.cli.auth.CF_TOKEN_DIR", tmp_path):
+            result = get_cf_token()
+        assert result == "newline-token"
+
+    def test_permission_error_reading_token_file_propagates(self, tmp_path):
+        """PermissionError when reading the token file propagates to the caller."""
+        token_file = tmp_path / "private.jomcgi.dev-token"
+        token_file.write_text("secret")
+
+        def mock_read_text(self, *args, **kwargs):
+            raise PermissionError("Permission denied: token file")
+
+        with (
+            patch("tools.cli.auth.CF_TOKEN_DIR", tmp_path),
+            patch.object(Path, "read_text", mock_read_text),
+        ):
+            with pytest.raises(PermissionError):
+                get_cf_token()
+
+    def test_most_recent_token_file_wins(self, tmp_path):
+        """When multiple token files match, the most recently modified one is used."""
+        import time
+
+        old_file = tmp_path / "private.jomcgi.dev-old"
+        old_file.write_text("old-token")
+        time.sleep(0.01)  # ensure mtime difference
+        new_file = tmp_path / "private.jomcgi.dev-new"
+        new_file.write_text("new-token")
+
+        with patch("tools.cli.auth.CF_TOKEN_DIR", tmp_path):
+            result = get_cf_token()
+        assert result == "new-token"

--- a/tools/cli/knowledge_unit_test.py
+++ b/tools/cli/knowledge_unit_test.py
@@ -1,0 +1,200 @@
+"""Unit tests for knowledge_cmd internals: _client(), timeout, and non-404 errors.
+
+These tests do NOT use the FastAPI integration stack — they exercise the CLI
+layer in isolation using mocked httpx responses. This keeps them fast and
+free of monolith dependencies.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+from typer.testing import CliRunner
+
+import tools.cli.knowledge_cmd as knowledge_cmd
+from tools.cli.main import app
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+# ---------------------------------------------------------------------------
+# _client() helper
+# ---------------------------------------------------------------------------
+
+
+class TestClientHelper:
+    def test_uses_cf_token_as_cookie(self):
+        """_client() injects the CF token as the CF_Authorization cookie."""
+        with patch("tools.cli.knowledge_cmd.get_cf_token", return_value="test-token"):
+            client = knowledge_cmd._client()
+            try:
+                assert client.cookies.get("CF_Authorization") == "test-token"
+            finally:
+                client.close()
+
+    def test_sets_correct_base_url(self):
+        """_client() sets the base URL to the private homelab domain."""
+        with patch("tools.cli.knowledge_cmd.get_cf_token", return_value="test-token"):
+            client = knowledge_cmd._client()
+            try:
+                assert "private.jomcgi.dev" in str(client.base_url)
+            finally:
+                client.close()
+
+    def test_sets_30_second_timeout(self):
+        """_client() configures a 30-second read timeout."""
+        with patch("tools.cli.knowledge_cmd.get_cf_token", return_value="test-token"):
+            client = knowledge_cmd._client()
+            try:
+                assert client.timeout.read == 30.0
+            finally:
+                client.close()
+
+    def test_different_tokens_produce_different_cookies(self):
+        """Each unique token returned by get_cf_token() appears in the cookie jar."""
+        with patch(
+            "tools.cli.knowledge_cmd.get_cf_token", return_value="unique-token-xyz"
+        ):
+            client = knowledge_cmd._client()
+            try:
+                assert client.cookies.get("CF_Authorization") == "unique-token-xyz"
+            finally:
+                client.close()
+
+
+# ---------------------------------------------------------------------------
+# Helpers: mock _client() as a context manager
+#
+# knowledge_cmd commands use:  `with _client() as client:`
+# so patching _client with a plain function that returns a @contextmanager
+# correctly intercepts both the call and the `with` block.
+# ---------------------------------------------------------------------------
+
+
+def _make_timeout_client() -> object:
+    """Return a _client replacement that raises TimeoutException on every request."""
+    mock_client = MagicMock()
+    mock_client.get.side_effect = httpx.TimeoutException("timed out")
+    mock_client.post.side_effect = httpx.TimeoutException("timed out")
+
+    @contextmanager
+    def _ctx():
+        yield mock_client
+
+    def _factory():
+        return _ctx()
+
+    return _factory
+
+
+def _make_error_client(status_code: int) -> object:
+    """Return a _client replacement that returns an HTTP error response."""
+    mock_resp = MagicMock()
+    mock_resp.status_code = status_code
+    mock_resp.raise_for_status.side_effect = httpx.HTTPStatusError(
+        f"HTTP {status_code}",
+        request=MagicMock(),
+        response=mock_resp,
+    )
+    mock_client = MagicMock()
+    mock_client.get.return_value = mock_resp
+    mock_client.post.return_value = mock_resp
+
+    @contextmanager
+    def _ctx():
+        yield mock_client
+
+    def _factory():
+        return _ctx()
+
+    return _factory
+
+
+# ---------------------------------------------------------------------------
+# Timeout propagation
+# ---------------------------------------------------------------------------
+
+
+class TestTimeoutHandling:
+    def test_search_timeout_exits_nonzero(self, runner):
+        """Network timeout during `knowledge search` results in a non-zero exit."""
+        with patch("tools.cli.knowledge_cmd._client", _make_timeout_client()):
+            result = runner.invoke(app, ["knowledge", "search", "query"])
+        assert result.exit_code != 0
+
+    def test_note_timeout_exits_nonzero(self, runner):
+        """Network timeout during `knowledge note` results in a non-zero exit."""
+        with patch("tools.cli.knowledge_cmd._client", _make_timeout_client()):
+            result = runner.invoke(app, ["knowledge", "note", "n1"])
+        assert result.exit_code != 0
+
+    def test_dead_letters_timeout_exits_nonzero(self, runner):
+        """Network timeout during `knowledge dead-letters` results in a non-zero exit."""
+        with patch("tools.cli.knowledge_cmd._client", _make_timeout_client()):
+            result = runner.invoke(app, ["knowledge", "dead-letters"])
+        assert result.exit_code != 0
+
+    def test_replay_timeout_exits_nonzero(self, runner):
+        """Network timeout during `knowledge replay` results in a non-zero exit."""
+        with patch("tools.cli.knowledge_cmd._client", _make_timeout_client()):
+            result = runner.invoke(app, ["knowledge", "replay", "1"])
+        assert result.exit_code != 0
+
+
+# ---------------------------------------------------------------------------
+# replay() non-404 error handling
+#
+# The replay() command handles 404 explicitly (prints message, Exit(1)).
+# All other HTTP error codes must propagate via raise_for_status() → non-zero exit.
+# ---------------------------------------------------------------------------
+
+
+class TestReplayNon404ErrorHandling:
+    def test_replay_500_exits_nonzero(self, runner):
+        """500 Internal Server Error from replay propagates as a non-zero exit."""
+        with patch("tools.cli.knowledge_cmd._client", _make_error_client(500)):
+            result = runner.invoke(app, ["knowledge", "replay", "1"])
+        assert result.exit_code != 0
+
+    def test_replay_403_exits_nonzero(self, runner):
+        """403 Forbidden from replay propagates as a non-zero exit."""
+        with patch("tools.cli.knowledge_cmd._client", _make_error_client(403)):
+            result = runner.invoke(app, ["knowledge", "replay", "1"])
+        assert result.exit_code != 0
+
+    def test_replay_503_exits_nonzero(self, runner):
+        """503 Service Unavailable from replay propagates as a non-zero exit."""
+        with patch("tools.cli.knowledge_cmd._client", _make_error_client(503)):
+            result = runner.invoke(app, ["knowledge", "replay", "1"])
+        assert result.exit_code != 0
+
+    def test_replay_404_prints_friendly_message(self, runner):
+        """404 from replay prints a human-readable 'not found' message to stderr."""
+        mock_resp = MagicMock()
+        mock_resp.status_code = 404
+        # raise_for_status should NOT be called for 404 — the code checks status directly.
+        mock_resp.raise_for_status.side_effect = AssertionError(
+            "raise_for_status should not be called for 404"
+        )
+        mock_client = MagicMock()
+        mock_client.post.return_value = mock_resp
+
+        @contextmanager
+        def _ctx():
+            yield mock_client
+
+        def _factory():
+            return _ctx()
+
+        with patch("tools.cli.knowledge_cmd._client", _factory):
+            result = runner.invoke(app, ["knowledge", "replay", "42"])
+
+        assert result.exit_code == 1
+        assert "42" in result.output
+        assert "not found" in result.output.lower()

--- a/tools/cli/main_test.py
+++ b/tools/cli/main_test.py
@@ -1,9 +1,11 @@
 """Smoke tests for tools/cli/main.py."""
 
+from unittest.mock import MagicMock, patch
+
 import pytest
 from typer.testing import CliRunner
 
-from tools.cli.main import app
+from tools.cli.main import app, main
 
 
 class TestMainHelp:
@@ -21,3 +23,54 @@ class TestMainHelp:
         assert result.exit_code == 0
         assert "search" in result.output
         assert "note" in result.output
+
+
+class TestMainFunction:
+    def test_main_delegates_to_app(self):
+        """main() simply calls app() — verify the delegation."""
+        with patch("tools.cli.main.app") as mock_app:
+            main()
+        mock_app.assert_called_once_with()
+
+    def test_main_passes_through_app_return_value(self):
+        """main() propagates whatever app() returns (normally None)."""
+        with patch("tools.cli.main.app", return_value=None):
+            result = main()
+        assert result is None
+
+
+class TestSubcommandRegistration:
+    def test_knowledge_subcommand_appears_in_top_level_help(self):
+        """'knowledge' sub-group is listed in the top-level help text."""
+        runner = CliRunner()
+        result = runner.invoke(app, ["--help"])
+        assert result.exit_code == 0
+        assert "knowledge" in result.output
+
+    def test_dead_letters_subcommand_listed_under_knowledge(self):
+        """'dead-letters' command appears when listing knowledge subcommands."""
+        runner = CliRunner()
+        result = runner.invoke(app, ["knowledge", "--help"])
+        assert result.exit_code == 0
+        assert "dead-letters" in result.output
+
+    def test_replay_subcommand_listed_under_knowledge(self):
+        """'replay' command appears when listing knowledge subcommands."""
+        runner = CliRunner()
+        result = runner.invoke(app, ["knowledge", "--help"])
+        assert result.exit_code == 0
+        assert "replay" in result.output
+
+    def test_no_args_prints_help(self):
+        """Invoking with no arguments prints the help text (no_args_is_help=True)."""
+        runner = CliRunner()
+        result = runner.invoke(app, [])
+        # no_args_is_help=True: help is printed (exit 0), not an error
+        assert "knowledge" in result.output
+        assert "Token-efficient" in result.output
+
+    def test_unknown_subcommand_exits_nonzero(self):
+        """An unrecognised subcommand exits with a non-zero code."""
+        runner = CliRunner()
+        result = runner.invoke(app, ["does-not-exist"])
+        assert result.exit_code != 0

--- a/tools/cli/output_test.py
+++ b/tools/cli/output_test.py
@@ -78,3 +78,123 @@ class TestSearchLine:
         result = search_line(0.70, "n4", "Link Note", "note", edges)
         # No edge line appended for plain wikilinks
         assert "\n" not in result
+
+    def test_very_long_title_renders_without_truncation(self):
+        """A very long title is preserved verbatim — no truncation occurs."""
+        long_title = "Very Long Title Word " * 50  # 1050 chars
+        result = search_line(0.50, "n5", long_title, "note", [])
+        assert long_title in result
+
+    def test_unicode_in_note_id_and_title(self):
+        """Unicode characters in note_id and title render correctly."""
+        result = search_line(0.88, "ノート-001", "人工知能の未来", "concept", [])
+        assert "ノート-001" in result
+        assert "人工知能の未来" in result
+
+    def test_zero_score(self):
+        """Score of exactly 0.0 renders as [0.00]."""
+        result = search_line(0.0, "n6", "Zero Score Note", "note", [])
+        assert result.startswith("[0.00]")
+
+    def test_empty_note_type_renders_empty_parens(self):
+        """An empty string note type still renders with parentheses."""
+        result = search_line(0.75, "n7", "Untyped Note", "", [])
+        assert "()" in result
+
+
+class TestCompactLineBoundary:
+    def test_very_long_path_renders_without_truncation(self):
+        """A very long path is preserved verbatim in the output."""
+        long_path = "a/b/" * 200 + "note.md"  # ~803 chars
+        result = compact_line(1, long_path, "obsidian", None, 0)
+        assert long_path in result
+
+    def test_unicode_in_path_source_and_error(self):
+        """Unicode characters in path, source, and error all render correctly."""
+        result = compact_line(
+            99,
+            "日本語/ノート.md",
+            "黒曜石",
+            "エラー: JSON解析失敗",
+            2,
+        )
+        assert "日本語/ノート.md" in result
+        assert "黒曜石" in result
+        assert "エラー: JSON解析失敗" in result
+
+    def test_empty_string_error_treated_as_no_error(self):
+        """Empty string error (falsy) produces the no-error branch — no '—' separator."""
+        result = compact_line(1, "path.md", "src", "", 0)
+        assert "—" not in result
+        assert "retries" not in result
+
+    def test_zero_id(self):
+        """id=0 is a valid integer boundary and renders correctly."""
+        result = compact_line(0, "path.md", "src", None, 0)
+        assert result.startswith("[0]")
+
+    def test_large_retry_count(self):
+        """Very large retry_count renders as a number without truncation."""
+        result = compact_line(1, "path.md", "src", "boom", 9999)
+        assert "[9999 retries]" in result
+
+
+class TestFormatEdgesBoundary:
+    def test_missing_kind_key_excluded(self):
+        """An edge dict without a 'kind' key at all is excluded (get returns None)."""
+        edges = [{"edge_type": "related", "target_id": "note-x"}]
+        result = format_edges(edges)
+        assert result == ""
+
+    def test_none_kind_excluded(self):
+        """An edge with kind=None is excluded (None != 'edge')."""
+        edges = [{"kind": None, "edge_type": "related", "target_id": "note-x"}]
+        result = format_edges(edges)
+        assert result == ""
+
+    def test_none_edge_type_renders_as_string_none(self):
+        """kind='edge' with edge_type=None renders via str() as 'None→target'."""
+        edges = [{"kind": "edge", "edge_type": None, "target_id": "note-x"}]
+        result = format_edges(edges)
+        assert "None→note-x" in result
+
+    def test_unicode_edge_type_and_target(self):
+        """Unicode edge_type and target_id are preserved in the compact representation."""
+        edges = [{"kind": "edge", "edge_type": "関連", "target_id": "ノート-1"}]
+        result = format_edges(edges)
+        assert "関連→ノート-1" in result
+
+    def test_mixed_edge_and_non_edge_kinds(self):
+        """Only 'edge' kind entries appear; other kinds are silently dropped."""
+        edges = [
+            {"kind": "edge", "edge_type": "derives_from", "target_id": "note-a"},
+            {"kind": "link", "edge_type": None, "target_id": "note-b"},
+            {"kind": "unknown", "edge_type": "foo", "target_id": "note-c"},
+        ]
+        result = format_edges(edges)
+        assert "derives_from→note-a" in result
+        assert "note-b" not in result
+        assert "note-c" not in result
+
+
+class TestWriteToTmpfileBoundary:
+    def test_unicode_content_round_trips_correctly(self, tmp_path):
+        """Unicode content (CJK, emoji) is written and read back identically."""
+        content = "# こんにちは 🌍\n\n世界のデータ"
+        with patch("tools.cli.output.TMPDIR", tmp_path):
+            path = write_to_tmpfile("unicode-note", content)
+        assert path.read_text() == content
+
+    def test_empty_content_creates_empty_file(self, tmp_path):
+        """Writing an empty string creates an empty file without error."""
+        with patch("tools.cli.output.TMPDIR", tmp_path):
+            path = write_to_tmpfile("empty-note", "")
+        assert path.exists()
+        assert path.read_text() == ""
+
+    def test_very_large_content(self, tmp_path):
+        """Very large content (>1 MB) is written and read back correctly."""
+        content = "x" * (1024 * 1024)  # 1 MB
+        with patch("tools.cli.output.TMPDIR", tmp_path):
+            path = write_to_tmpfile("big-note", content)
+        assert len(path.read_text()) == 1024 * 1024


### PR DESCRIPTION
## Summary

- **auth_test**: custom hostname parameter, whitespace stripping, permission error propagation, multi-file mtime ordering
- **main_test**: invoke `main()` directly, verify all subcommand registrations (`knowledge`, `dead-letters`, `replay`), no-args help, unknown subcommand error path
- **output_test**: very long paths/titles (boundary), unicode (CJK + emoji), empty-string error falsy path, missing/None edge `kind` filtering, `None` edge_type string rendering, large content write
- **knowledge_unit_test** (new file): `_client()` cookie/base\_url/timeout assertions; timeout propagation for all four commands; non-404 HTTP errors (500, 403, 503) via `raise_for_status()`; 404 friendly-message path

Total: **34 new test cases** across 4 files (3 extended, 1 new).

## Test plan

- [ ] `//tools/cli:auth_test` — passes (custom hostname, whitespace, permission error, mtime)
- [ ] `//tools/cli:main_test` — passes (main() delegation, subcommand registration, edge cases)
- [ ] `//tools/cli:output_test` — passes (boundary, unicode, None handling)
- [ ] `//tools/cli:knowledge_unit_test` — passes (_client helper, timeouts, non-404 errors)
- [ ] CI `bazel test //...` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)