### PR TITLE
test(knowledge): cover fetch_webpage title fallback and move_phase OSError

### DIFF
--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -2246,6 +2246,27 @@ py_test(
 )
 
 py_test(
+    name = "knowledge_ingest_queue_webpage_title_test",
+    srcs = ["knowledge/ingest_queue_webpage_title_test.py"],
+    imports = ["."],
+    deps = [
+        ":monolith_backend",
+        "@pip//pytest",
+        "@pip//pytest_asyncio",
+    ],
+)
+
+py_test(
+    name = "knowledge_raw_ingest_move_phase_oserror_test",
+    srcs = ["knowledge/raw_ingest_move_phase_oserror_test.py"],
+    imports = ["."],
+    deps = [
+        ":monolith_backend",
+        "@pip//pytest",
+    ],
+)
+
+py_test(
     name = "notes_router_whitespace_test",
     srcs = ["notes/router_whitespace_test.py"],
     imports = ["."],

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.38.3
+version: 0.38.4
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.38.3
+      targetRevision: 0.38.4
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/knowledge/ingest_queue_webpage_title_test.py
+++ b/projects/monolith/knowledge/ingest_queue_webpage_title_test.py
@@ -1,0 +1,100 @@
+"""Tests for fetch_webpage() title fallback branches.
+
+The title extraction logic in fetch_webpage() has three branches:
+
+    meta = trafilatura.extract_metadata(html)
+    title = meta.title if meta and meta.title else urlparse(url).netloc
+
+1. meta is None            → falls back to urlparse(url).netloc
+2. meta.title is None      → falls back to urlparse(url).netloc
+3. meta.title is ""        → falls back to urlparse(url).netloc (falsy)
+
+The existing ingest_queue_test.py always exercises the happy path where
+meta.title is a non-empty string.  None of these three branches are
+covered by any existing test file.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from knowledge.ingest_queue import fetch_webpage
+
+
+class TestFetchWebpageTitleFallback:
+    """fetch_webpage() uses urlparse(url).netloc as title when metadata is absent."""
+
+    @pytest.mark.asyncio
+    async def test_meta_none_falls_back_to_netloc(self):
+        """When trafilatura.extract_metadata returns None, title is the netloc."""
+        with patch("knowledge.ingest_queue.trafilatura") as mock_traf:
+            mock_traf.fetch_url.return_value = "<html><body>Content</body></html>"
+            mock_traf.extract.return_value = "Article body text."
+            mock_traf.extract_metadata.return_value = None  # ← the gap
+
+            title, body = await fetch_webpage("https://example.com/article")
+
+        assert title == "example.com"
+        assert body == "Article body text."
+
+    @pytest.mark.asyncio
+    async def test_meta_title_none_falls_back_to_netloc(self):
+        """When meta is not None but meta.title is None, title is the netloc."""
+        meta = MagicMock()
+        meta.title = None  # ← the gap
+
+        with patch("knowledge.ingest_queue.trafilatura") as mock_traf:
+            mock_traf.fetch_url.return_value = "<html><body>Content</body></html>"
+            mock_traf.extract.return_value = "Article body text."
+            mock_traf.extract_metadata.return_value = meta
+
+            title, body = await fetch_webpage("https://news.example.org/story")
+
+        assert title == "news.example.org"
+        assert body == "Article body text."
+
+    @pytest.mark.asyncio
+    async def test_meta_title_empty_string_falls_back_to_netloc(self):
+        """When meta.title is an empty string (falsy), title is the netloc."""
+        meta = MagicMock()
+        meta.title = ""  # ← the gap
+
+        with patch("knowledge.ingest_queue.trafilatura") as mock_traf:
+            mock_traf.fetch_url.return_value = "<html><body>Content</body></html>"
+            mock_traf.extract.return_value = "Article body text."
+            mock_traf.extract_metadata.return_value = meta
+
+            title, body = await fetch_webpage("https://blog.example.net/post/1")
+
+        assert title == "blog.example.net"
+
+    @pytest.mark.asyncio
+    async def test_happy_path_with_meta_title_not_affected(self):
+        """Sanity: when meta.title is set, it is used verbatim (no regression)."""
+        meta = MagicMock()
+        meta.title = "My Article Title"
+
+        with patch("knowledge.ingest_queue.trafilatura") as mock_traf:
+            mock_traf.fetch_url.return_value = "<html><body>Content</body></html>"
+            mock_traf.extract.return_value = "Body."
+            mock_traf.extract_metadata.return_value = meta
+
+            title, _ = await fetch_webpage("https://example.com/article")
+
+        assert title == "My Article Title"
+
+    @pytest.mark.asyncio
+    async def test_netloc_extracted_from_complex_url(self):
+        """Title fallback correctly extracts netloc from a URL with path and query."""
+        with patch("knowledge.ingest_queue.trafilatura") as mock_traf:
+            mock_traf.fetch_url.return_value = "<html><body>Text</body></html>"
+            mock_traf.extract.return_value = "Some content here."
+            mock_traf.extract_metadata.return_value = None
+
+            title, _ = await fetch_webpage(
+                "https://sub.domain.example.co.uk/path/to/page?q=1&ref=2"
+            )
+
+        assert title == "sub.domain.example.co.uk"

--- a/projects/monolith/knowledge/raw_ingest_move_phase_oserror_test.py
+++ b/projects/monolith/knowledge/raw_ingest_move_phase_oserror_test.py
@@ -1,0 +1,122 @@
+"""Tests for move_phase() OSError on file read.
+
+raw_ingest.py move_phase() catches OSError when read_text() fails and
+continues to the next file (lines 69-73):
+
+    try:
+        content = source.read_text(encoding="utf-8")
+    except OSError as read_err:
+        logger.warning("move_phase: failed to read %s: %s", source, read_err)
+        continue
+
+This branch is not covered by any existing test file — raw_ingest_test.py
+only exercises the happy paths.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from knowledge.raw_ingest import MovePhaseStats, move_phase
+
+
+def _write(p: Path, content: str) -> None:
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(content, encoding="utf-8")
+
+
+_NOW = datetime(2026, 4, 12, 10, 0, tzinfo=timezone.utc)
+
+
+class TestMovePhaseOSError:
+    """move_phase() silently skips files that fail to read with OSError."""
+
+    def test_oserror_on_read_skips_file_and_logs_warning(self, tmp_path, caplog):
+        """A file that raises OSError during read_text is skipped with a warning."""
+        _write(tmp_path / "inbox" / "bad.md", "---\ntitle: Bad\n---\nContent.")
+
+        original_read_text = Path.read_text
+
+        def raise_for_bad(p: Path, *args, **kwargs) -> str:
+            if p.name == "bad.md":
+                raise OSError("permission denied")
+            return original_read_text(p, *args, **kwargs)
+
+        with (
+            patch.object(Path, "read_text", raise_for_bad),
+            caplog.at_level(logging.WARNING, logger="monolith.knowledge.raw_ingest"),
+        ):
+            stats = move_phase(vault_root=tmp_path, now=_NOW)
+
+        # The unreadable file was not moved.
+        assert stats.moved == 0
+        assert stats.deduped == 0
+        # A warning was emitted for the bad file.
+        assert any("move_phase" in r.message and "failed" in r.message for r in caplog.records)
+
+    def test_oserror_skipped_file_does_not_count_as_moved(self, tmp_path):
+        """An OSError'd file increments neither moved nor deduped."""
+        _write(tmp_path / "inbox" / "bad.md", "Body.")
+
+        original_read_text = Path.read_text
+
+        def always_raise(p: Path, *args, **kwargs) -> str:
+            raise OSError("disk error")
+
+        with patch.object(Path, "read_text", always_raise):
+            stats = move_phase(vault_root=tmp_path, now=_NOW)
+
+        assert isinstance(stats, MovePhaseStats)
+        assert stats.moved == 0
+        assert stats.deduped == 0
+
+    def test_good_file_moved_despite_bad_file_oserror(self, tmp_path):
+        """move_phase continues processing after an OSError — good files are moved."""
+        # Sorted order: a_bad.md comes before b_good.md
+        _write(tmp_path / "inbox" / "a_bad.md", "---\ntitle: Bad\n---\nBad body.")
+        _write(tmp_path / "inbox" / "b_good.md", "---\ntitle: Good\n---\nGood body.")
+
+        original_read_text = Path.read_text
+
+        def raise_for_bad(p: Path, *args, **kwargs) -> str:
+            if p.name == "a_bad.md":
+                raise OSError("permission denied")
+            return original_read_text(p, *args, **kwargs)
+
+        with patch.object(Path, "read_text", raise_for_bad):
+            stats = move_phase(vault_root=tmp_path, now=_NOW)
+
+        # Good file was moved; bad file was skipped.
+        assert stats.moved == 1
+        assert stats.deduped == 0
+        # The good file has been relocated to _raw/.
+        assert not (tmp_path / "inbox" / "b_good.md").exists()
+        raw_files = list((tmp_path / "_raw").rglob("*.md"))
+        assert len(raw_files) == 1
+
+    def test_oserror_message_includes_file_path(self, tmp_path, caplog):
+        """The warning message includes the path of the unreadable file."""
+        bad_file = tmp_path / "inbox" / "secret.md"
+        _write(bad_file, "---\ntitle: Secret\n---\nPrivate.")
+
+        original_read_text = Path.read_text
+
+        def raise_for_bad(p: Path, *args, **kwargs) -> str:
+            if p.name == "secret.md":
+                raise OSError("access denied")
+            return original_read_text(p, *args, **kwargs)
+
+        with (
+            patch.object(Path, "read_text", raise_for_bad),
+            caplog.at_level(logging.WARNING, logger="monolith.knowledge.raw_ingest"),
+        ):
+            move_phase(vault_root=tmp_path, now=_NOW)
+
+        warning_messages = [r.message for r in caplog.records if r.levelno == logging.WARNING]
+        # At least one warning should mention the file path.
+        assert any("secret.md" in msg for msg in warning_messages)

--- a/projects/monolith/knowledge/raw_ingest_move_phase_oserror_test.py
+++ b/projects/monolith/knowledge/raw_ingest_move_phase_oserror_test.py
@@ -57,7 +57,9 @@ class TestMovePhaseOSError:
         assert stats.moved == 0
         assert stats.deduped == 0
         # A warning was emitted for the bad file.
-        assert any("move_phase" in r.message and "failed" in r.message for r in caplog.records)
+        assert any(
+            "move_phase" in r.message and "failed" in r.message for r in caplog.records
+        )
 
     def test_oserror_skipped_file_does_not_count_as_moved(self, tmp_path):
         """An OSError'd file increments neither moved nor deduped."""
@@ -117,6 +119,8 @@ class TestMovePhaseOSError:
         ):
             move_phase(vault_root=tmp_path, now=_NOW)
 
-        warning_messages = [r.message for r in caplog.records if r.levelno == logging.WARNING]
+        warning_messages = [
+            r.message for r in caplog.records if r.levelno == logging.WARNING
+        ]
         # At least one warning should mention the file path.
         assert any("secret.md" in msg for msg in warning_messages)


### PR DESCRIPTION
## Summary

- **`fetch_webpage()` title fallback** (`ingest_queue.py` line 74): covers the 3 untested branches where `trafilatura.extract_metadata` returns `None`, returns an object with `title=None`, or returns an object with `title=""` — all should fall back to `urlparse(url).netloc`
- **`move_phase()` OSError on read** (`raw_ingest.py` lines 71–73): covers the silent-skip path where `source.read_text()` raises `OSError` — warning is logged, file is skipped, processing continues for remaining files

## Test plan

- [ ] `//projects/monolith:knowledge_ingest_queue_webpage_title_test` — 5 new tests for `fetch_webpage` title fallback
- [ ] `//projects/monolith:knowledge_raw_ingest_move_phase_oserror_test` — 4 new tests for `move_phase` OSError handling
- [ ] CI `bazel test //...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)