### PR TITLE
fix(cluster-agents): move all agent intervals to weekly to reduce token usage

### DIFF
--- a/projects/agent_platform/cluster_agents/deploy/Chart.yaml
+++ b/projects/agent_platform/cluster_agents/deploy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cluster-agents
 description: Autonomous cluster monitoring agents
 type: application
-version: 0.6.34
+version: 0.6.35
 appVersion: "0.2.0"
 annotations:
   org.opencontainers.image.source: "https://github.com/jomcgi/homelab"

--- a/projects/agent_platform/cluster_agents/deploy/application.yaml
+++ b/projects/agent_platform/cluster_agents/deploy/application.yaml
@@ -8,7 +8,7 @@ spec:
   source:
     repoURL: ghcr.io/jomcgi/homelab/charts
     chart: cluster-agents
-    targetRevision: 0.6.34
+    targetRevision: 0.6.35
     helm:
       releaseName: cluster-agents
       # IMPORTANT: Do NOT add podAnnotations here. The chart-version-bot regenerates

--- a/projects/agent_platform/cluster_agents/deploy/values.yaml
+++ b/projects/agent_platform/cluster_agents/deploy/values.yaml
@@ -59,7 +59,7 @@ config:
   signozUrl: "http://signoz.signoz.svc.cluster.local:8080"
   orchestratorUrl: "http://agent-platform-agent-orchestrator.agent-platform.svc.cluster.local:8080"
   httpPort: "8080"
-  patrolInterval: "1h"
+  patrolInterval: "168h"
   # sweepTimeout caps how long a single agent sweep (collect→analyze→execute) may run.
   # A hung HTTP call to SigNoz or the orchestrator cannot block the patrol loop beyond
   # this deadline. Must be well below patrolInterval (default 5m is intentionally low).
@@ -68,10 +68,10 @@ config:
   githubRepo: "jomcgi/homelab"
   githubBranch: "main"
   botAuthors: "ci-format-bot,argocd-image-updater,chart-version-bot"
-  testCoverageInterval: "1h"
+  testCoverageInterval: "168h"
   readmeFreshnessInterval: "168h"
-  rulesInterval: "24h"
-  prFixInterval: "1h"
+  rulesInterval: "168h"
+  prFixInterval: "168h"
   prFixStaleThreshold: "1h"
   natsUrl: "nats://agent-platform-nats.agent-platform.svc.cluster.local:4222"
 


### PR DESCRIPTION
## Summary

- Changed `patrolInterval` from `1h` → `168h` (weekly)
- Changed `testCoverageInterval` from `1h` → `168h` (weekly)
- Changed `rulesInterval` from `24h` → `168h` (weekly)
- Changed `prFixInterval` from `1h` → `168h` (weekly)
- `readmeFreshnessInterval` left unchanged at `168h` (already weekly)

No test files assert on these interval values, so no test changes required.

## Test plan

- [ ] CI passes `bazel test //...`
- [ ] Helm chart renders correctly with new interval values

🤖 Generated with [Claude Code](https://claude.com/claude-code)