### PR TITLE
fix(hooks): expand chart-bump scope to full service directory

### DIFF
--- a/bazel/tools/hooks/check-unnecessary-chart-bump.sh
+++ b/bazel/tools/hooks/check-unnecessary-chart-bump.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # PreToolUse hook: warns when Chart.yaml version is bumped but only test files
-# changed under chart/ or deploy/ — a chart version bump triggers a redeployment
-# and is unnecessary if only test files were modified.
+# changed anywhere under the service directory root — a chart version bump
+# triggers a redeployment and is unnecessary if only test files were modified.
 #
 # Input: JSON on stdin from Claude Code hook system
 # Exit 0: allow the operation (warning only, never blocks)
@@ -59,14 +59,14 @@ SERVICE_DIR=$(dirname "$(dirname "$FILE_PATH")")
 SERVICE_DIR_REL="${SERVICE_DIR#$REPO_ROOT/}"
 CHART_YAML_REL="${FILE_PATH#$REPO_ROOT/}"
 
-# Collect all changed files under chart/ and deploy/ (staged, unstaged, working tree)
+# Collect all changed files under the service directory root (staged, unstaged, working tree)
 ALL_CHANGED=$(
 	git -C "$REPO_ROOT" diff --cached --name-only -- \
-		"${SERVICE_DIR_REL}/chart/" "${SERVICE_DIR_REL}/deploy/" 2>/dev/null || true
+		"${SERVICE_DIR_REL}/" 2>/dev/null || true
 	git -C "$REPO_ROOT" diff --name-only HEAD -- \
-		"${SERVICE_DIR_REL}/chart/" "${SERVICE_DIR_REL}/deploy/" 2>/dev/null || true
+		"${SERVICE_DIR_REL}/" 2>/dev/null || true
 	git -C "$REPO_ROOT" status --porcelain -- \
-		"${SERVICE_DIR_REL}/chart/" "${SERVICE_DIR_REL}/deploy/" 2>/dev/null |
+		"${SERVICE_DIR_REL}/" 2>/dev/null |
 		awk '{print $NF}' || true
 )
 

--- a/bazel/tools/hooks/check-unnecessary-chart-bump_test.sh
+++ b/bazel/tools/hooks/check-unnecessary-chart-bump_test.sh
@@ -6,7 +6,7 @@
 #     (or .tool_input.content for Write tool)
 #   - Exits 0 always (warning only, never blocks)
 #   - Prints WARNING to stderr when Chart.yaml version is bumped but only test
-#     files changed under chart/ or deploy/
+#     files changed anywhere under the service directory root
 #
 # This test mocks jq via a minimal Python3 stub and git via a Python3 stub,
 # both placed earlier on PATH so the hook can run in the hermetic Bazel sandbox.
@@ -411,6 +411,31 @@ run_git_test \
 	"" \
 	"" \
 	"WARNING:"
+
+# 18. Version changing, test file outside chart/deploy (e.g. backend/tests/) -- WARNING emitted
+#     This validates that the scope expansion covers the full service directory root,
+#     not just chart/ and deploy/ subdirectories.
+run_git_test \
+	"version_bump_test_outside_chart_deploy_emits_warning" \
+	"$CHART_PATH" \
+	"version: 0.2.0" \
+	"$FIXTURE" \
+	"projects/myservice/backend/tests/foo_test.py" \
+	"" \
+	"" \
+	"WARNING:"
+
+# 19. Version changing, non-test file outside chart/deploy (e.g. backend/main.go) -- no warning
+#     A real source-code change in the backend warrants the chart bump.
+run_git_test \
+	"version_bump_with_backend_source_no_warning" \
+	"$CHART_PATH" \
+	"version: 0.2.0" \
+	"$FIXTURE" \
+	"projects/myservice/backend/main.go" \
+	"" \
+	"" \
+	""
 
 # ---------------------------------------------------------------------------
 # Summary


### PR DESCRIPTION
## Summary
- Expand lines 63-71 of `check-unnecessary-chart-bump.sh` to scan **all** changed files under the service directory root (`SERVICE_DIR_REL/`) instead of only `chart/` and `deploy/` subdirectories
- Test files outside `chart/` and `deploy/` (e.g. `backend/tests/foo_test.py`) now correctly trigger the warning when they are the only changes alongside a Chart.yaml version bump
- Add test case 18: test file outside chart/deploy (e.g. `projects/myservice/backend/tests/foo_test.py`) emits WARNING
- Add test case 19: non-test source file outside chart/deploy (e.g. `projects/myservice/backend/main.go`) does NOT emit WARNING

## Test plan
- [ ] `bb remote --os=linux --arch=amd64 test //bazel/tools/hooks:check_unnecessary_chart_bump_test --config=ci` passes
- [ ] CI `bazel test //...` passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)