### PR TITLE
ci: add Go semgrep rule for hardcoded test timestamps

### DIFF
--- a/bazel/semgrep/rules/golang/test-hardcoded-past-timestamp.yaml
+++ b/bazel/semgrep/rules/golang/test-hardcoded-past-timestamp.yaml
@@ -1,0 +1,30 @@
+rules:
+  - id: test-hardcoded-past-timestamp
+    patterns:
+      - pattern-either:
+          - pattern: $VAR := "$TIMESTAMP"
+          - pattern: $VAR = "$TIMESTAMP"
+      - metavariable-regex:
+          metavariable: $TIMESTAMP
+          regex: '^\d{4}-\d{2}-\d{2}(T\d{2}:\d{2}(:\d{2})?(\.\d+)?(Z|[+-]\d{2}:?\d{2})?)?$'
+    message: >-
+      Hardcoded timestamp string `"$TIMESTAMP"` assigned to `$VAR` in test code.
+      As time passes this date will move further into the past, making test intent
+      unclear and potentially masking time-sensitive bugs. Use
+      `time.Now()` or a test helper to generate timestamps dynamically, or use a
+      clock abstraction to freeze time explicitly.
+    languages: [go]
+    severity: WARNING
+    paths:
+      include:
+        - "*_test.go"
+    metadata:
+      category: correctness
+      subcategory: testing
+      confidence: MEDIUM
+      likelihood: MEDIUM
+      impact: LOW
+      technology: [go]
+      description: >-
+        Hardcoded ISO-8601 timestamp in test file — prefer dynamic timestamps or
+        explicit time-freezing helpers to keep tests reliable over time.

--- a/bazel/semgrep/rules/golang/test_hardcoded_past_timestamp_test.go
+++ b/bazel/semgrep/rules/golang/test_hardcoded_past_timestamp_test.go
@@ -1,0 +1,37 @@
+// Tests for test-hardcoded-past-timestamp rule.
+// This file is named *_test.go to match the path filter in the rule's paths.include section.
+package example_test
+
+import "time"
+
+func ExampleHardcodedTimestamps() {
+	// ruleid: test-hardcoded-past-timestamp
+	ts := "2024-03-01T12:00:00Z"
+
+	// ruleid: test-hardcoded-past-timestamp
+	timestamp := "2025-01-15T09:30:00+00:00"
+
+	// ruleid: test-hardcoded-past-timestamp
+	createdAt := "2023-06-15"
+
+	// ruleid: test-hardcoded-past-timestamp
+	eventTime := "2024-12-31T23:59:59.999Z"
+
+	// ruleid: test-hardcoded-past-timestamp
+	var assignedTs string
+	assignedTs = "2023-01-01T00:00:00Z"
+
+	// ok: test-hardcoded-past-timestamp - dynamic timestamp, not a string literal
+	nowDynamic := time.Now().UTC().Format(time.RFC3339)
+
+	// ok: test-hardcoded-past-timestamp - not a date string
+	name := "hello world"
+
+	// ok: test-hardcoded-past-timestamp - not a date string
+	status := "active"
+
+	// ok: test-hardcoded-past-timestamp - not a date string (version number)
+	version := "2024.1.0"
+
+	_, _, _, _, _, _, _, _, _ = ts, timestamp, createdAt, eventTime, assignedTs, nowDynamic, name, status, version
+}


### PR DESCRIPTION
## Summary

- Adds `bazel/semgrep/rules/golang/test-hardcoded-past-timestamp.yaml` — a Go variant of the existing Python rule that flags hardcoded ISO-8601 timestamp string literals in `*_test.go` files
- Adds `bazel/semgrep/rules/golang/test_hardcoded_past_timestamp_test.go` with `// ruleid:` and `// ok:` annotations covering short-assignment (`:=`), plain assignment (`=`), and non-timestamp strings
- No BUILD changes required — the `golang_rules` filegroup and `golang_rules_test` already glob `golang/*.yaml` and `golang/*.go` respectively

## Test plan

- [ ] `//bazel/semgrep/rules:golang_rules_test` passes with the new rule and fixture
- [ ] `ruleid` cases: `"2024-03-01T12:00:00Z"`, `"2025-01-15T09:30:00+00:00"`, `"2023-06-15"`, `"2024-12-31T23:59:59.999Z"`, `"2023-01-01T00:00:00Z"` are all flagged
- [ ] `ok` cases: `time.Now()` call, `"hello world"`, `"active"`, `"2024.1.0"` are not flagged

🤖 Generated with [Claude Code](https://claude.com/claude-code)