### PR TITLE
test(operators/cloudflare): verify ReadyToTrip threshold and combined access policy rules

### DIFF
--- a/projects/operators/cloudflare/internal/cloudflare/access_test.go
+++ b/projects/operators/cloudflare/internal/cloudflare/access_test.go
@@ -152,6 +152,58 @@ var _ = Describe("Access operations", func() {
 			entry := result[0].(map[string]interface{})
 			Expect(entry).To(HaveKey("group"))
 		})
+
+		It("combines IPRanges and Countries into a single cfRule entry", func() {
+			// Both IPRanges and Countries are stored in cfRule (not appended directly
+			// to cfRules), so a rule with both fields produces exactly one combined entry.
+			rules := []AccessPolicyRule{
+				{
+					IPRanges:  []string{"10.0.0.0/8", "192.168.0.0/16"},
+					Countries: []string{"US", "DE"},
+				},
+			}
+			result := convertAccessPolicyRules(rules)
+			Expect(result).To(HaveLen(1), "IPRanges and Countries in the same rule produce one combined entry")
+
+			entry := result[0].(map[string]interface{})
+			Expect(entry).To(HaveKey("ip"), "combined entry must contain the 'ip' key")
+			Expect(entry).To(HaveKey("geo"), "combined entry must contain the 'geo' key")
+
+			ip := entry["ip"].(map[string]interface{})
+			Expect(ip["ip"]).To(ConsistOf("10.0.0.0/8", "192.168.0.0/16"))
+
+			geo := entry["geo"].(map[string]interface{})
+			Expect(geo["country_code"]).To(ConsistOf("US", "DE"))
+		})
+
+		It("emits email entries plus a combined cfRule entry when Emails, IPRanges, and Countries are all set", func() {
+			// Emails are appended individually to cfRules; IPRanges and Countries
+			// land in cfRule together. The result has len(emails)+1 entries.
+			rules := []AccessPolicyRule{
+				{
+					Emails:    []string{"alice@example.com", "bob@example.com"},
+					IPRanges:  []string{"10.0.0.0/8"},
+					Countries: []string{"GB"},
+				},
+			}
+			result := convertAccessPolicyRules(rules)
+			// 2 email entries + 1 combined ip+geo entry = 3 total
+			Expect(result).To(HaveLen(3))
+
+			emailCount := 0
+			for _, r := range result {
+				entry := r.(map[string]interface{})
+				if _, ok := entry["email"]; ok {
+					emailCount++
+				}
+			}
+			Expect(emailCount).To(Equal(2), "two individual email entries expected")
+
+			// The combined ip+geo entry is the last element.
+			last := result[2].(map[string]interface{})
+			Expect(last).To(HaveKey("ip"))
+			Expect(last).To(HaveKey("geo"))
+		})
 	})
 
 	Describe("CreateAccessApplication", func() {

--- a/projects/operators/cloudflare/internal/cloudflare/circuit_breaker_test.go
+++ b/projects/operators/cloudflare/internal/cloudflare/circuit_breaker_test.go
@@ -300,4 +300,118 @@ var _ = Describe("Circuit breaker state transitions", func() {
 			Expect(callCount).To(Equal(5), "all 5 calls should reach the mock — breaker is CLOSED")
 		})
 	})
+
+	// -----------------------------------------------------------------------
+	// Production ReadyToTrip threshold: ConsecutiveFailures >= 5
+	//
+	// NewTunnelClient creates a circuit breaker with threshold 5. All other
+	// tests use a fast-trip breaker (threshold 1) for convenience. These tests
+	// verify the production threshold directly by calling NewTunnelClient and
+	// swapping in the mock API.
+	// -----------------------------------------------------------------------
+
+	Describe("ReadyToTrip production threshold = 5 (NewTunnelClient settings)", func() {
+		var productionClient *TunnelClient
+
+		BeforeEach(func() {
+			// Create a client using the production NewTunnelClient, which
+			// configures a circuit breaker with ConsecutiveFailures >= 5.
+			// Then swap in the test mock and remove rate limiting.
+			var err error
+			productionClient, err = NewTunnelClient("test-token-threshold")
+			Expect(err).NotTo(HaveOccurred())
+			productionClient.api = mockAPI
+			productionClient.limiter = rate.NewLimiter(rate.Inf, 0)
+		})
+
+		It("keeps the circuit CLOSED after 4 consecutive retryable failures", func() {
+			retryableErr := &cloudflare.Error{StatusCode: http.StatusInternalServerError}
+			mockAPI.createTunnelFunc = func(_ context.Context, _ *cloudflare.ResourceContainer, _ cloudflare.TunnelCreateParams) (cloudflare.Tunnel, error) {
+				return cloudflare.Tunnel{}, retryableErr
+			}
+
+			// 4 consecutive retryable failures — threshold not yet reached.
+			for _, name := range []string{"t-fail-1", "t-fail-2", "t-fail-3", "t-fail-4"} {
+				_, _, err := productionClient.CreateTunnel(ctx, "account-1", name)
+				Expect(err).To(HaveOccurred())
+			}
+
+			// Switch mock to succeed. If circuit is CLOSED the call goes through.
+			reachCount := 0
+			mockAPI.createTunnelFunc = func(_ context.Context, _ *cloudflare.ResourceContainer, _ cloudflare.TunnelCreateParams) (cloudflare.Tunnel, error) {
+				reachCount++
+				return cloudflare.Tunnel{ID: "ok"}, nil
+			}
+
+			_, _, err := productionClient.CreateTunnel(ctx, "account-1", "probe-after-4")
+			Expect(err).NotTo(HaveOccurred(),
+				"circuit must still be CLOSED after only 4 consecutive failures (threshold is 5)")
+			Expect(reachCount).To(Equal(1), "mock must be reached — circuit is CLOSED")
+		})
+
+		It("opens the circuit after exactly 5 consecutive retryable failures", func() {
+			retryableErr := &cloudflare.Error{StatusCode: http.StatusInternalServerError}
+			mockAPI.createTunnelFunc = func(_ context.Context, _ *cloudflare.ResourceContainer, _ cloudflare.TunnelCreateParams) (cloudflare.Tunnel, error) {
+				return cloudflare.Tunnel{}, retryableErr
+			}
+
+			// 5 consecutive retryable failures — exactly at the threshold.
+			for _, name := range []string{"t-fail-1", "t-fail-2", "t-fail-3", "t-fail-4", "t-fail-5"} {
+				_, _, err := productionClient.CreateTunnel(ctx, "account-1", name)
+				Expect(err).To(HaveOccurred())
+			}
+
+			// Circuit is now OPEN. The next call must not reach the mock.
+			reachCount := 0
+			mockAPI.createTunnelFunc = func(_ context.Context, _ *cloudflare.ResourceContainer, _ cloudflare.TunnelCreateParams) (cloudflare.Tunnel, error) {
+				reachCount++
+				return cloudflare.Tunnel{}, nil
+			}
+
+			_, _, errOpen := productionClient.CreateTunnel(ctx, "account-1", "post-5-failures")
+			Expect(errOpen).To(HaveOccurred(),
+				"circuit must be OPEN after exactly 5 consecutive failures")
+			Expect(reachCount).To(Equal(0),
+				"mock must NOT be reached when circuit is open")
+		})
+
+		It("requires consecutive failures — a success resets the count", func() {
+			retryableErr := &cloudflare.Error{StatusCode: http.StatusInternalServerError}
+			failCount := 0
+
+			// Alternate fail / succeed: 4 failures, then 1 success, then 4 more
+			// failures. Circuit should never open because the run of consecutive
+			// failures never reaches 5.
+			for call := 0; call < 9; call++ {
+				if call == 4 {
+					// Success resets the consecutive failure count.
+					mockAPI.createTunnelFunc = func(_ context.Context, _ *cloudflare.ResourceContainer, _ cloudflare.TunnelCreateParams) (cloudflare.Tunnel, error) {
+						return cloudflare.Tunnel{ID: "reset"}, nil
+					}
+					_, _, err := productionClient.CreateTunnel(ctx, "account-1", "reset-call")
+					Expect(err).NotTo(HaveOccurred())
+				} else {
+					mockAPI.createTunnelFunc = func(_ context.Context, _ *cloudflare.ResourceContainer, _ cloudflare.TunnelCreateParams) (cloudflare.Tunnel, error) {
+						failCount++
+						return cloudflare.Tunnel{}, retryableErr
+					}
+					_, _, err := productionClient.CreateTunnel(ctx, "account-1", "fail-call")
+					Expect(err).To(HaveOccurred())
+				}
+			}
+
+			// After 4 + reset + 4 failures (8 failures total, max 4 consecutive),
+			// the circuit must still be CLOSED.
+			reachCount := 0
+			mockAPI.createTunnelFunc = func(_ context.Context, _ *cloudflare.ResourceContainer, _ cloudflare.TunnelCreateParams) (cloudflare.Tunnel, error) {
+				reachCount++
+				return cloudflare.Tunnel{ID: "still-closed"}, nil
+			}
+
+			_, _, err := productionClient.CreateTunnel(ctx, "account-1", "final-probe")
+			Expect(err).NotTo(HaveOccurred(),
+				"circuit should be CLOSED — 4 consecutive failures then a reset never reaches threshold 5")
+			Expect(reachCount).To(Equal(1))
+		})
+	})
 })


### PR DESCRIPTION
## Summary

Fills two coverage gaps identified in the audit of `projects/operators/cloudflare/internal/cloudflare/`:

- **ReadyToTrip threshold = 5**: three new tests in `circuit_breaker_test.go` use `NewTunnelClient` directly (the real production code path) to verify the configured threshold. Tests confirm 4 consecutive failures keep the circuit closed, 5 open it, and a successful call resets the consecutive count.

- **`convertAccessPolicyRules` combined IPRanges + Countries**: two new tests in `access_test.go` verify that both fields in the same rule produce a single merged `cfRule` entry containing both `"ip"` and `"geo"` keys (previously tested only in isolation).

## Test plan
- [ ] `//projects/operators/cloudflare/internal/cloudflare:cloudflare_test` passes in CI
- [ ] No production code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)