### PR TITLE
feat(observability-demo): config-driven DAG with brutalist redesign

### DIFF
--- a/docs/plans/2026-04-12-observability-dag-redesign-design.md
+++ b/docs/plans/2026-04-12-observability-dag-redesign-design.md
@@ -1,0 +1,75 @@
+# Observability Demo DAG Redesign
+
+## Goal
+
+Replace the hardcoded 9-node topology in the observability demo with a config-driven, auto-laid-out DAG that reflects the actual homelab architecture. Add a brutalist visual style inspired by MotherDuck.
+
+## Topology
+
+### Ingress
+
+- **Cloudflare** — tunnel + gateway, sole entry point to the cluster
+  - Connects to: monolith, context-forge, agent-platform (all ingress-exposed services)
+
+### Critical Path
+
+- **Monolith** (+ sub-services & postgres with distinct SLOs)
+- **llama-cpp** — gemma-4 inference
+- **voyage-embedder** — embedding model
+- **agent-platform** — agent orchestration
+- **context-forge** — MCP gateway
+- **NATS** — JetStream message bus
+- **postgres** — CNPG + pgvector
+
+### Critical Path Edges
+
+```
+monolith ──sql──→ postgres
+monolith ──nats──→ NATS
+monolith ──grpc──→ context-forge
+monolith ──http──→ llama-cpp
+monolith ──http──→ voyage-embedder
+NATS ──nats──→ agent-platform
+agent-platform ──grpc──→ context-forge
+context-forge ──mcp──→ k8s-mcp (virtual)
+context-forge ──mcp──→ argocd-mcp (virtual)
+context-forge ──mcp──→ signoz-mcp (virtual)
+```
+
+### Infrastructure (separate SLOs, no inter-relationships drawn)
+
+ArgoCD, SigNoz, Envoy Gateway, Longhorn, SeaweedFS, OTel Operator, Linkerd
+
+## Config Format
+
+Single JSON file (`topology.json`) importable by Vite at build time. Each node has:
+
+- `id`, `label`, `tier` (ingress | critical | infra)
+- `ingress: true` flag for nodes exposed via Cloudflare
+- Service metadata: `description`, `brief`, `status`, `slo`, `metrics`, `spark`
+
+Edges: `{ from, to, protocol }`
+
+## Layout Engine
+
+**dagre** computes node positions from the graph structure.
+
+- `rankdir: LR` (landscape) / `TB` (portrait)
+- Tier → rank constraints: ingress=0, critical=auto, infra=separate band
+- Infra nodes pinned to bottom/right via hidden anchor edges
+- Node width computed from label length
+- Re-run dagre on orientation change (replaces two hand-tuned coordinate sets)
+
+## Visual Style (MotherDuck Brutalist)
+
+- Background: warm cream `#f5f0e8` (light) / deep charcoal `#1a1a1a` (dark)
+- Node boxes: thick black Rough.js rectangles, filled with tier color
+- Critical tier: pale yellow `#fff3c4` / `#3d3520`
+- Infra tier: light grey `#e8e8e8` / `#2a2a2a`
+- Ingress: light blue `#dbeafe` / `#1e3a5f`
+- Typography: monospace, uppercase labels, bold
+- Edges: Rough.js lines with protocol labels
+
+## What Stays
+
+All animation infrastructure: BFS draw sequencing, dual-pass pencil→ink, scribble highlight, paper-flip transition, detail drawer, dark mode, staggered pen cursors.

--- a/docs/plans/2026-04-12-observability-dag-redesign.md
+++ b/docs/plans/2026-04-12-observability-dag-redesign.md
@@ -1,0 +1,890 @@
+# Observability Demo DAG Redesign — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Replace the hardcoded 9-node observability demo topology with a config-driven, dagre-auto-laid-out DAG reflecting the real homelab architecture, styled with a MotherDuck-inspired brutalist palette.
+
+**Architecture:** A JSON config file defines nodes (with tier/status/SLO metadata) and edges (with protocols). At render time, dagre computes node positions from the graph structure (`rankdir: LR` for landscape, `TB` for portrait). The existing Rough.js animation pipeline (BFS sequencing, pencil→ink dual-pass, scribble highlights) renders the computed layout unchanged. CSS variables shift to a warm cream/charcoal brutalist palette.
+
+**Tech Stack:** Svelte 5, Rough.js, dagre (new dep), Vite (JSON import), Bazel (pnpm workspace)
+
+---
+
+### Task 1: Add dagre dependency
+
+**Files:**
+
+- Modify: `projects/monolith/frontend/package.json`
+- Modify: `pnpm-lock.yaml` (auto-generated)
+- Modify: `projects/monolith/frontend/BUILD:25-46` (add `":node_modules/@dagrejs/dagre"`)
+
+**Step 1: Add dagre to package.json**
+
+Add `"@dagrejs/dagre": "^1.1.4"` to the `dependencies` object in `projects/monolith/frontend/package.json`. Use `@dagrejs/dagre` — the modern maintained fork under the dagrejs org.
+
+```json
+"dependencies": {
+    "@dagrejs/dagre": "^1.1.4",
+    "@opentelemetry/api": "^1.9.0",
+    ...
+}
+```
+
+**Step 2: Install dependency**
+
+Run: `cd /tmp/claude-worktrees/observability-dag-redesign && pnpm install --filter monolith-frontend`
+Expected: lockfile updates, `node_modules/@dagrejs/dagre` appears
+
+**Step 3: Add to BUILD deps**
+
+Add `":node_modules/@dagrejs/dagre",` to the `js_library` deps list in `projects/monolith/frontend/BUILD` (after the roughjs line):
+
+```starlark
+        # Hand-drawn SVG rendering
+        ":node_modules/roughjs",
+        # DAG layout engine
+        ":node_modules/@dagrejs/dagre",
+```
+
+**Step 4: Verify build**
+
+Run: `bb remote --os=linux --arch=amd64 test //projects/monolith/frontend:build_test --config=ci`
+Expected: PASS — frontend builds with dagre available
+
+**Step 5: Commit**
+
+```bash
+git add projects/monolith/frontend/package.json projects/monolith/frontend/BUILD pnpm-lock.yaml
+git commit -m "build(monolith/frontend): add @dagrejs/dagre for auto-layout"
+```
+
+---
+
+### Task 2: Create topology config file
+
+**Files:**
+
+- Create: `projects/monolith/frontend/src/routes/public/observability-demo/topology.json`
+
+**Step 1: Write the topology config**
+
+Create `topology.json` with the full node/edge/metadata structure. Vite imports JSON natively — no loader needed.
+
+```json
+{
+  "nodes": [
+    {
+      "id": "cloudflare",
+      "label": "CLOUDFLARE",
+      "tier": "ingress",
+      "status": "healthy",
+      "description": "tunnel + gateway",
+      "brief": "14.2k req/24h",
+      "metrics": [
+        { "k": "tunnel", "v": "connected" },
+        { "k": "requests 24h", "v": "14.2k" },
+        { "k": "cached", "v": "62%" }
+      ]
+    },
+    {
+      "id": "monolith",
+      "label": "MONOLITH",
+      "tier": "critical",
+      "ingress": true,
+      "status": "healthy",
+      "description": "fastapi + sveltekit",
+      "brief": "99.97% · 12.5 rps",
+      "slo": { "target": 99.9, "current": 99.97 },
+      "budget": {
+        "consumed": 28,
+        "elapsed": 40,
+        "remaining": "31.1 min",
+        "window": "30d"
+      },
+      "latency": { "p99": 42, "target": 200, "unit": "ms" },
+      "metrics": [
+        { "k": "rps", "v": "12.5" },
+        { "k": "error rate", "v": "0.02%" },
+        { "k": "p99", "v": "42ms" }
+      ],
+      "spark": [
+        38, 42, 45, 41, 39, 44, 42, 40, 43, 41, 38, 42, 47, 44, 42, 39, 41, 43,
+        42, 40, 38, 41, 43, 42
+      ]
+    },
+    {
+      "id": "postgres",
+      "label": "POSTGRES",
+      "tier": "critical",
+      "status": "healthy",
+      "description": "cnpg + pgvector",
+      "brief": "100% · 8ms p99",
+      "slo": { "target": 99.95, "current": 100 },
+      "budget": {
+        "consumed": 0,
+        "elapsed": 40,
+        "remaining": "21.6 min",
+        "window": "30d"
+      },
+      "latency": { "p99": 8, "target": 50, "unit": "ms" },
+      "metrics": [
+        { "k": "connections", "v": "12 / 100" },
+        { "k": "query p99", "v": "8ms" },
+        { "k": "storage", "v": "2.1 GiB" }
+      ],
+      "spark": [
+        6, 7, 8, 7, 6, 8, 7, 7, 8, 7, 6, 7, 9, 8, 7, 6, 7, 8, 7, 7, 6, 7, 8, 7
+      ]
+    },
+    {
+      "id": "nats",
+      "label": "NATS",
+      "tier": "critical",
+      "status": "healthy",
+      "description": "jetstream message bus",
+      "brief": "100% · 45 msg/s",
+      "slo": { "target": 99.99, "current": 100 },
+      "budget": {
+        "consumed": 0,
+        "elapsed": 40,
+        "remaining": "4.3 min",
+        "window": "30d"
+      },
+      "metrics": [
+        { "k": "msg/s", "v": "45" },
+        { "k": "consumers", "v": "3" },
+        { "k": "lag", "v": "0" }
+      ],
+      "spark": [
+        40, 42, 48, 45, 43, 47, 44, 41, 46, 43, 42, 45, 50, 47, 44, 42, 45, 48,
+        44, 43, 41, 44, 46, 45
+      ]
+    },
+    {
+      "id": "context-forge",
+      "label": "CONTEXT FORGE",
+      "tier": "critical",
+      "ingress": true,
+      "status": "healthy",
+      "description": "mcp gateway",
+      "brief": "99.98% · 8 rps",
+      "slo": { "target": 99.9, "current": 99.98 },
+      "budget": {
+        "consumed": 12,
+        "elapsed": 40,
+        "remaining": "38.2 min",
+        "window": "30d"
+      },
+      "latency": { "p99": 180, "target": 500, "unit": "ms" },
+      "metrics": [
+        { "k": "rps", "v": "8" },
+        { "k": "mcp servers", "v": "3" },
+        { "k": "p99", "v": "180ms" }
+      ],
+      "spark": [
+        120, 140, 180, 160, 150, 170, 190, 165, 155, 175, 145, 160, 185, 170,
+        160, 150, 165, 180, 160, 155, 140, 160, 175, 165
+      ]
+    },
+    {
+      "id": "agent-platform",
+      "label": "AGENT PLATFORM",
+      "tier": "critical",
+      "ingress": true,
+      "status": "degraded",
+      "description": "orchestrator + mcp clients",
+      "brief": "99.31% · 2 active",
+      "slo": { "target": 99.5, "current": 99.31 },
+      "budget": {
+        "consumed": 138,
+        "elapsed": 40,
+        "remaining": "0 min",
+        "window": "30d"
+      },
+      "latency": { "p99": 890, "target": 500, "unit": "ms" },
+      "metrics": [
+        { "k": "active jobs", "v": "2" },
+        { "k": "completed 24h", "v": "47" },
+        { "k": "mcp servers", "v": "4" }
+      ],
+      "spark": [
+        420, 510, 680, 890, 750, 820, 940, 870, 780, 910, 850, 720, 880, 930,
+        810, 760, 890, 950, 870, 820, 780, 850, 910, 890
+      ]
+    },
+    {
+      "id": "llama-cpp",
+      "label": "LLAMA.CPP",
+      "tier": "critical",
+      "status": "healthy",
+      "description": "gemma 4 inference",
+      "brief": "99.9% · 1.2 rps",
+      "slo": { "target": 99.5, "current": 99.9 },
+      "latency": { "p99": 2400, "target": 5000, "unit": "ms" },
+      "metrics": [
+        { "k": "model", "v": "gemma-4" },
+        { "k": "rps", "v": "1.2" },
+        { "k": "vram", "v": "18.4 / 24 GiB" }
+      ],
+      "spark": [
+        1800, 2100, 2400, 2200, 1900, 2300, 2600, 2400, 2100, 2500, 2300, 2000,
+        2400, 2700, 2300, 2100, 2400, 2500, 2200, 2000, 1900, 2200, 2400, 2300
+      ]
+    },
+    {
+      "id": "voyage-embedder",
+      "label": "VOYAGE EMBEDDER",
+      "tier": "critical",
+      "status": "healthy",
+      "description": "voyage-4 embedding",
+      "brief": "100% · 3.1 rps",
+      "slo": { "target": 99.9, "current": 100 },
+      "latency": { "p99": 85, "target": 200, "unit": "ms" },
+      "metrics": [
+        { "k": "model", "v": "voyage-4" },
+        { "k": "rps", "v": "3.1" },
+        { "k": "vram", "v": "5.8 / 6.2 GiB" }
+      ],
+      "spark": [
+        60, 70, 85, 75, 65, 80, 90, 80, 70, 85, 75, 65, 80, 95, 80, 70, 85, 90,
+        75, 70, 65, 75, 85, 80
+      ]
+    },
+    {
+      "id": "k8s-mcp",
+      "label": "K8S MCP",
+      "tier": "critical",
+      "status": "healthy",
+      "description": "kubernetes mcp server",
+      "brief": "healthy",
+      "metrics": [
+        { "k": "resources", "v": "pods, svc, deploy" },
+        { "k": "cluster", "v": "home-cluster" }
+      ]
+    },
+    {
+      "id": "argocd-mcp",
+      "label": "ARGOCD MCP",
+      "tier": "critical",
+      "status": "healthy",
+      "description": "argocd mcp server",
+      "brief": "healthy",
+      "metrics": [
+        { "k": "applications", "v": "14" },
+        { "k": "synced", "v": "14 / 14" }
+      ]
+    },
+    {
+      "id": "signoz-mcp",
+      "label": "SIGNOZ MCP",
+      "tier": "critical",
+      "status": "healthy",
+      "description": "signoz mcp server",
+      "brief": "healthy",
+      "metrics": [
+        { "k": "queries 24h", "v": "2.4k" },
+        { "k": "p99", "v": "120ms" }
+      ]
+    },
+    {
+      "id": "argocd",
+      "label": "ARGOCD",
+      "tier": "infra",
+      "status": "healthy",
+      "description": "gitops controller",
+      "brief": "14/14 synced",
+      "metrics": [
+        { "k": "applications", "v": "14" },
+        { "k": "synced", "v": "14 / 14" },
+        { "k": "last sync", "v": "12s ago" }
+      ]
+    },
+    {
+      "id": "signoz",
+      "label": "SIGNOZ",
+      "tier": "infra",
+      "status": "warning",
+      "description": "observability platform",
+      "brief": "99.84% · 450 spans/s",
+      "slo": { "target": 99.9, "current": 99.84 },
+      "budget": {
+        "consumed": 66,
+        "elapsed": 40,
+        "remaining": "14.7 min",
+        "window": "30d"
+      },
+      "latency": { "p99": 320, "target": 500, "unit": "ms" },
+      "metrics": [
+        { "k": "spans/s", "v": "450" },
+        { "k": "ingestion p99", "v": "320ms" },
+        { "k": "storage", "v": "82 / 150 GiB" }
+      ],
+      "spark": [
+        280, 310, 350, 320, 290, 340, 380, 320, 310, 340, 290, 300, 360, 340,
+        320, 300, 330, 350, 320, 310, 290, 320, 340, 320
+      ]
+    },
+    {
+      "id": "envoy-gateway",
+      "label": "ENVOY GATEWAY",
+      "tier": "infra",
+      "status": "healthy",
+      "description": "api gateway",
+      "brief": "healthy · 14.2k req/24h",
+      "metrics": [
+        { "k": "routes", "v": "8" },
+        { "k": "requests 24h", "v": "14.2k" },
+        { "k": "error rate", "v": "0.01%" }
+      ]
+    },
+    {
+      "id": "longhorn",
+      "label": "LONGHORN",
+      "tier": "infra",
+      "status": "healthy",
+      "description": "distributed storage",
+      "brief": "340 / 1000 GiB",
+      "metrics": [
+        { "k": "volumes", "v": "8" },
+        { "k": "replicas", "v": "healthy" },
+        { "k": "used", "v": "340 / 1000 GiB" }
+      ]
+    },
+    {
+      "id": "seaweedfs",
+      "label": "SEAWEEDFS",
+      "tier": "infra",
+      "status": "healthy",
+      "description": "object storage",
+      "brief": "healthy · 28 GiB",
+      "metrics": [
+        { "k": "buckets", "v": "4" },
+        { "k": "objects", "v": "12.4k" },
+        { "k": "storage", "v": "28 GiB" }
+      ]
+    },
+    {
+      "id": "otel-operator",
+      "label": "OTEL OPERATOR",
+      "tier": "infra",
+      "status": "healthy",
+      "description": "opentelemetry operator",
+      "brief": "healthy · 3 collectors",
+      "metrics": [
+        { "k": "collectors", "v": "3" },
+        { "k": "pipelines", "v": "traces, metrics, logs" }
+      ]
+    },
+    {
+      "id": "linkerd",
+      "label": "LINKERD",
+      "tier": "infra",
+      "status": "healthy",
+      "description": "service mesh",
+      "brief": "healthy · 12 meshed",
+      "metrics": [
+        { "k": "meshed pods", "v": "12" },
+        { "k": "mtls", "v": "100%" },
+        { "k": "success rate", "v": "99.99%" }
+      ]
+    }
+  ],
+  "edges": [
+    { "from": "cloudflare", "to": "monolith", "protocol": "https" },
+    { "from": "cloudflare", "to": "context-forge", "protocol": "https" },
+    { "from": "cloudflare", "to": "agent-platform", "protocol": "https" },
+    { "from": "monolith", "to": "postgres", "protocol": "sql" },
+    { "from": "monolith", "to": "nats", "protocol": "nats" },
+    { "from": "monolith", "to": "context-forge", "protocol": "grpc" },
+    { "from": "monolith", "to": "llama-cpp", "protocol": "http" },
+    { "from": "monolith", "to": "voyage-embedder", "protocol": "http" },
+    { "from": "nats", "to": "agent-platform", "protocol": "nats" },
+    { "from": "agent-platform", "to": "context-forge", "protocol": "grpc" },
+    { "from": "context-forge", "to": "k8s-mcp", "protocol": "mcp" },
+    { "from": "context-forge", "to": "argocd-mcp", "protocol": "mcp" },
+    { "from": "context-forge", "to": "signoz-mcp", "protocol": "mcp" }
+  ]
+}
+```
+
+**Step 2: Verify JSON is valid**
+
+Run: `node -e "require('./projects/monolith/frontend/src/routes/public/observability-demo/topology.json')"`
+Expected: no error
+
+**Step 3: Commit**
+
+```bash
+git add projects/monolith/frontend/src/routes/public/observability-demo/topology.json
+git commit -m "feat(observability-demo): add topology config with real homelab services"
+```
+
+---
+
+### Task 3: Add dagre layout module
+
+**Files:**
+
+- Create: `projects/monolith/frontend/src/routes/public/observability-demo/layout.js`
+
+This module takes the topology config and returns positioned nodes for a given `rankdir`. It encapsulates all dagre interaction so `+page.svelte` never imports dagre directly.
+
+**Step 1: Write the layout module**
+
+```javascript
+import dagre from "@dagrejs/dagre";
+
+const HH = 18; // half-height of a node (matches +page.svelte)
+const CHAR_WIDTH = 6.5; // approximate monospace character width at 11px
+const NODE_PAD = 12; // padding around label text
+
+/**
+ * Compute half-width from label length.
+ * Ensures all nodes size to fit their uppercase label.
+ */
+function computeHW(label) {
+  return Math.max(
+    24,
+    Math.ceil((label.length * CHAR_WIDTH) / 2) + NODE_PAD / 2,
+  );
+}
+
+/**
+ * Run dagre layout on the topology config.
+ *
+ * @param {Object} topology - The topology.json structure ({ nodes, edges })
+ * @param {"LR"|"TB"} rankdir - Layout direction
+ * @returns {{ nodes: Array<{id,label,x,y,hw,status,...}>, edges: Array, nodeById: Object }}
+ */
+export function computeLayout(topology, rankdir) {
+  const g = new dagre.Graph();
+  g.setGraph({
+    rankdir,
+    nodesep: rankdir === "LR" ? 40 : 50,
+    ranksep: rankdir === "LR" ? 80 : 60,
+    marginx: 40,
+    marginy: 40,
+  });
+  g.setDefaultEdgeLabel(() => ({}));
+
+  // Add all nodes with computed dimensions
+  for (const node of topology.nodes) {
+    const hw = computeHW(node.label);
+    g.setNode(node.id, {
+      width: hw * 2 + NODE_PAD,
+      height: HH * 2 + 6,
+      tier: node.tier,
+    });
+  }
+
+  // Add edges (only critical-path edges — infra nodes are unconnected)
+  for (const edge of topology.edges) {
+    g.setEdge(edge.from, edge.to);
+  }
+
+  // Pin infra nodes to the last rank by adding invisible edges from an anchor
+  const infraNodes = topology.nodes.filter((n) => n.tier === "infra");
+  if (infraNodes.length > 0) {
+    // Create an invisible anchor node at the same rank as the deepest critical node
+    g.setNode("__infra_anchor", { width: 0, height: 0 });
+    // Connect anchor to a deep critical node to push it down
+    const lastCritical = topology.nodes
+      .filter((n) => n.tier === "critical")
+      .at(-1);
+    if (lastCritical) {
+      g.setEdge(lastCritical.id, "__infra_anchor", { minlen: 2 });
+    }
+    for (const n of infraNodes) {
+      g.setEdge("__infra_anchor", n.id, { minlen: 1 });
+    }
+  }
+
+  dagre.layout(g);
+
+  // Build positioned nodes (exclude anchor)
+  const nodes = topology.nodes.map((n) => {
+    const pos = g.node(n.id);
+    return {
+      ...n,
+      x: pos.x,
+      y: pos.y,
+      hw: computeHW(n.label),
+    };
+  });
+
+  const nodeById = Object.fromEntries(nodes.map((n) => [n.id, n]));
+
+  return { nodes, edges: topology.edges, nodeById };
+}
+```
+
+**Step 2: Commit**
+
+```bash
+git add projects/monolith/frontend/src/routes/public/observability-demo/layout.js
+git commit -m "feat(observability-demo): add dagre layout module"
+```
+
+---
+
+### Task 4: Update +page.svelte — replace hardcoded topology with config + dagre
+
+This is the largest task. It modifies `+page.svelte` to:
+
+1. Import the topology config and layout module
+2. Replace hardcoded `nodes`, `edges`, `nodeById`, portrait positions with dagre-computed layouts
+3. Replace the `svc` metadata object with config-driven lookups
+4. Update the viewBox to use dagre's computed graph dimensions
+5. Update the BFS animation to use `"cloudflare"` as root (unchanged) but with dynamic node/edge lists
+6. Update the brutalist color palette CSS variables
+
+**Files:**
+
+- Modify: `projects/monolith/frontend/src/routes/public/observability-demo/+page.svelte`
+
+**Step 1: Replace topology section (lines 1-32)**
+
+Remove the hardcoded `nodes`, `edges`, `nodeById`, and `HH` constant. Replace with imports:
+
+```javascript
+import rough from "roughjs";
+import { fly, fade } from "svelte/transition";
+import { cubicOut } from "svelte/easing";
+import topology from "./topology.json";
+import { computeLayout } from "./layout.js";
+
+// ── Topology ───────────────────────────────
+const HH = 18;
+```
+
+**Step 2: Replace service data section (lines 34-136)**
+
+Remove the entire `const svc = { ... }` object. Replace with a config-driven lookup:
+
+```javascript
+// ── Service data (from config) ─────────────
+const svc = Object.fromEntries(topology.nodes.map((n) => [n.id, n]));
+```
+
+This works because the topology config already has `description`, `brief`, `metrics`, `slo`, `budget`, `latency`, `spark` on each node — the same shape the drawer expects.
+
+**Step 3: Replace layout computation (lines 7-17, 340-360)**
+
+Remove the hardcoded `nodes` and `portraitNodes` arrays and the `getNodePos` function. Replace with dagre-computed reactive layouts:
+
+```javascript
+// ── Layout (dagre-computed) ────────────────
+// Re-run dagre when orientation changes — replaces hand-tuned coordinate sets
+const landLayout = computeLayout(topology, "LR");
+const portLayout = computeLayout(topology, "TB");
+
+// Expose the active layout's data
+const nodes = $derived(activeLayout ? portLayout.nodes : landLayout.nodes);
+const edges = $derived(activeLayout ? portLayout.edges : landLayout.edges);
+const nodeById = $derived(
+  activeLayout ? portLayout.nodeById : landLayout.nodeById,
+);
+
+function getNodePos(id) {
+  const n = nodeById[id];
+  return { x: n.x, y: n.y };
+}
+```
+
+**Step 4: Replace viewBox computation (line 335)**
+
+Remove the hardcoded viewBox strings. Compute from dagre's graph dimensions:
+
+```javascript
+const viewBox = $derived.by(() => {
+  const layout = activeLayout ? portLayout : landLayout;
+  // Find bounding box of all nodes
+  let minX = Infinity,
+    minY = Infinity,
+    maxX = -Infinity,
+    maxY = -Infinity;
+  for (const n of layout.nodes) {
+    minX = Math.min(minX, n.x - n.hw - 20);
+    minY = Math.min(minY, n.y - HH - 20);
+    maxX = Math.max(maxX, n.x + n.hw + 20);
+    maxY = Math.max(maxY, n.y + HH + 20);
+  }
+  const pad = 40;
+  return `${minX - pad} ${minY - pad} ${maxX - minX + pad * 2} ${maxY - minY + pad * 2}`;
+});
+```
+
+**Step 5: Update aspect ratio constants**
+
+The aspect ratio constants need to adapt to the dagre-computed graph dimensions. Replace the hardcoded `LAND_AR` and `PORT_AR`:
+
+```javascript
+const LAND_AR = $derived.by(() => {
+  const ns = landLayout.nodes;
+  let minX = Infinity,
+    maxX = -Infinity,
+    minY = Infinity,
+    maxY = -Infinity;
+  for (const n of ns) {
+    minX = Math.min(minX, n.x - n.hw);
+    maxX = Math.max(maxX, n.x + n.hw);
+    minY = Math.min(minY, n.y - HH);
+    maxY = Math.max(maxY, n.y + HH);
+  }
+  return (maxX - minX) / (maxY - minY);
+});
+const PORT_AR = $derived.by(() => {
+  const ns = portLayout.nodes;
+  let minX = Infinity,
+    maxX = -Infinity,
+    minY = Infinity,
+    maxY = -Infinity;
+  for (const n of ns) {
+    minX = Math.min(minX, n.x - n.hw);
+    maxX = Math.max(maxX, n.x + n.hw);
+    minY = Math.min(minY, n.y - HH);
+    maxY = Math.max(maxY, n.y + HH);
+  }
+  return (maxX - minX) / (maxY - minY);
+});
+```
+
+**Step 6: Fix BFS animation timeline**
+
+The `animDelay` IIFE (lines 458-636) references `nodes` and `edges` directly. Since those are now `$derived`, the IIFE needs to become a `$derived` or a function that recomputes when layout changes.
+
+The simplest approach: make `animDelay` a `$derived.by()` that recomputes when `drawGen` bumps (which happens on layout flip). The existing code inside stays nearly identical — just wrap it:
+
+```javascript
+const animDelay = $derived.by(() => {
+  const _gen = drawGen; // recompute on layout flip
+  const _nodes = nodes;
+  const _edges = edges;
+  const _nodeById = nodeById;
+
+  // ... existing BFS code, but replace bare `nodes` with `_nodes`,
+  // `edges` with `_edges`, `nodeById` with `_nodeById`
+  // Change the BFS start: { id: "cloudflare", fromX: 0, fromY: _nodeById["cloudflare"]?.y ?? 240 }
+
+  // Return { node: nd, edge: ed, edgeDir: edDir, totalDur: maxT + 0.5 };
+});
+```
+
+Key changes inside the BFS:
+
+- `nodes.forEach(...)` → `_nodes.forEach(...)`
+- `edges.forEach(...)` → `_edges.forEach(...)`
+- `nodeById[id]` → `_nodeById[id]`
+- BFS start position uses computed cloudflare position
+
+**Step 7: Update the draw effect**
+
+The draw effect (lines 643-848) uses `nodes` and `edges`. Since these are now `$derived`, the effect will automatically re-run when layout changes. Just ensure:
+
+- `nodes.forEach(...)` works with the new node shape (it does — same `id`, `hw`, `status` fields)
+- `nodeById[id]` lookups work (they do — same lookup)
+
+One change needed: the fill rectangle currently uses `c.bg`. For the brutalist style, use tier-based fills:
+
+```javascript
+function tierFill(tier, c) {
+  const dark = isDark;
+  if (tier === "ingress") return dark ? "#1e3a5f" : "#dbeafe";
+  if (tier === "infra") return dark ? "#2a2a2a" : "#e8e8e8";
+  return dark ? "#3d3520" : "#fff3c4"; // critical
+}
+```
+
+Update the fill rectangle in the node drawing loop:
+
+```javascript
+const fillEl = rc.rectangle(pos.x - w / 2, pos.y - h / 2, w, h, {
+  stroke: "none",
+  fill: tierFill(n.tier, c),
+  fillStyle: "solid",
+  roughness: r,
+  seed: seed(n.id + "fill"),
+});
+```
+
+**Step 8: Update CSS variables for brutalist palette**
+
+The CSS variables are defined in the global `<style>` or a parent layout. Since this page uses inline theme classes, update the `:global(.theme-light)` and `:global(.theme-dark)` blocks. If these are defined elsewhere, check the parent layout. If they're in this file's `<style>`, update them here.
+
+The key color changes:
+
+```css
+:global(.theme-light) {
+  --bg: #f5f0e8; /* warm cream (was white/grey) */
+  --surface: #ebe5d9; /* slightly darker cream */
+  --fg: #1a1a1a; /* near-black */
+  --fg-secondary: #4a4a4a;
+  --fg-tertiary: #7a7a7a;
+  --border: #c8c0b4; /* warm grey border */
+  --danger: #dc2626;
+  --font: "JetBrains Mono", "SF Mono", "Fira Code", monospace;
+}
+
+:global(.theme-dark) {
+  --bg: #1a1a1a; /* deep charcoal */
+  --surface: #242424;
+  --fg: #e8e0d4; /* warm off-white */
+  --fg-secondary: #a89f94;
+  --fg-tertiary: #6e665c;
+  --border: #3a3530;
+  --danger: #f87171;
+  --font: "JetBrains Mono", "SF Mono", "Fira Code", monospace;
+}
+```
+
+**Step 9: Update node label font**
+
+Change `.node-label` to uppercase to match the brutalist style (labels are already uppercase in the config, but add CSS `text-transform` as a safety net):
+
+```css
+.node-label {
+  font-family: var(--font);
+  font-size: 10px; /* slightly smaller for more nodes */
+  font-weight: 800; /* extra bold */
+  fill: var(--fg);
+  text-anchor: middle;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  transition: opacity 0.2s ease;
+}
+```
+
+**Step 10: Update Rough.js stroke widths for brutalism**
+
+In the node drawing code, increase stroke widths for the brutalist thick-border aesthetic:
+
+- Pencil box sides: `strokeWidth: 0.7` → `strokeWidth: 1.0`
+- Ink box sides: `strokeWidth: 1` → `strokeWidth: 2`
+- Edge pencil: `strokeWidth: 0.8` → `strokeWidth: 1.0`
+- Edge ink: `strokeWidth: 1` → `strokeWidth: 1.5`
+
+**Step 11: Add protocol labels on edges**
+
+After drawing each edge, add a small text label at the midpoint showing the protocol. In the edge drawing loop (inside the `edges.forEach` in the draw effect), after appending the ink line:
+
+```javascript
+// Protocol label at edge midpoint
+const midX = (startPt.x + endPt.x) / 2;
+const midY = (startPt.y + endPt.y) / 2;
+const label = document.createElementNS("http://www.w3.org/2000/svg", "text");
+label.textContent = e.protocol;
+label.setAttribute("x", String(midX));
+label.setAttribute("y", String(midY - 4));
+label.setAttribute("class", "edge-protocol");
+label.dataset.layer = "protocol";
+if (shouldAnimate) {
+  const anim = animDelay.edge[key];
+  label.style.opacity = "0";
+  label.style.animation = `textJot 0.2s ease ${(anim.inkLine + anim.inkLineDur * 0.5).toFixed(3)}s forwards`;
+}
+g.appendChild(label);
+```
+
+Add CSS for the protocol label:
+
+```css
+.edge-protocol {
+  font-family: var(--font);
+  font-size: 7px;
+  font-weight: 600;
+  fill: var(--fg-tertiary);
+  text-anchor: middle;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+```
+
+**Step 12: Verify build**
+
+Run: `bb remote --os=linux --arch=amd64 test //projects/monolith/frontend:build_test --config=ci`
+Expected: PASS
+
+**Step 13: Commit**
+
+```bash
+git add projects/monolith/frontend/src/routes/public/observability-demo/+page.svelte
+git commit -m "feat(observability-demo): config-driven dagre layout with brutalist palette"
+```
+
+---
+
+### Task 5: Visual verification
+
+**Step 1: Run dev server**
+
+Run: `cd /tmp/claude-worktrees/observability-dag-redesign/projects/monolith/frontend && pnpm dev`
+Open: `http://localhost:5173/public/observability-demo`
+
+**Step 2: Verify visually**
+
+Check:
+
+- [ ] All 19 nodes render without overlap
+- [ ] Cloudflare is at the left/top entry point
+- [ ] Critical path flows left-to-right (landscape) or top-to-bottom (portrait)
+- [ ] Infra nodes cluster at the bottom/right, visually separated
+- [ ] Warm cream background in light mode, charcoal in dark mode
+- [ ] Tier-based node fills: yellow (critical), grey (infra), blue (cloudflare)
+- [ ] Thick Rough.js borders (brutalist style)
+- [ ] Protocol labels on edges (https, sql, nats, grpc, http, mcp)
+- [ ] BFS draw animation plays from cloudflare outward
+- [ ] Paper-flip transition works between portrait/landscape
+- [ ] Click on any node opens the drawer with correct metadata
+- [ ] Dark mode toggle works and recolors all elements
+- [ ] Scribble highlight appears on hover/select
+
+**Step 3: Fix any layout issues**
+
+If dagre produces a layout that's too wide/tall or has awkward spacing, tune the `nodesep` and `ranksep` values in `layout.js`. If infra nodes overlap with critical path nodes, increase the `minlen` on the anchor edge.
+
+**Step 4: Commit any fixes**
+
+```bash
+git add -u
+git commit -m "fix(observability-demo): tune dagre layout spacing"
+```
+
+---
+
+### Task 6: Push and create PR
+
+**Step 1: Push branch**
+
+```bash
+cd /tmp/claude-worktrees/observability-dag-redesign
+git push -u origin feat/observability-dag-redesign
+```
+
+**Step 2: Create PR**
+
+```bash
+gh pr create --title "feat(observability-demo): config-driven DAG with real services" --body "$(cat <<'EOF'
+## Summary
+- Replace hardcoded 9-node topology with 19-node config-driven DAG reflecting actual homelab architecture
+- Add dagre for automatic graph layout (replaces hand-tuned coordinates)
+- Three tiers: ingress (Cloudflare), critical path (monolith → postgres/NATS/context-forge/agent-platform/llama-cpp/voyage-embedder), infrastructure (ArgoCD, SigNoz, Envoy Gateway, Longhorn, SeaweedFS, OTel Operator, Linkerd)
+- MotherDuck-inspired brutalist palette: warm cream background, thick borders, bold monospace, tier-based fills
+- Protocol labels on edges (https, sql, nats, grpc, http, mcp)
+- All existing animations preserved: BFS draw, pencil→ink dual-pass, scribble highlight, paper-flip transition
+
+## Test plan
+- [ ] Visual verification at `/public/observability-demo`
+- [ ] Landscape and portrait layouts render correctly
+- [ ] Dark mode toggle works
+- [ ] Node click opens drawer with correct metadata
+- [ ] CI build passes
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+**Step 3: Wait for CI**
+
+Run: `gh pr checks --watch`
+Expected: All checks pass

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -201,6 +201,9 @@ importers:
 
   projects/monolith/frontend:
     dependencies:
+      "@dagrejs/dagre":
+        specifier: ^1.1.4
+        version: 1.1.8
       "@opentelemetry/api":
         specifier: ^1.9.0
         version: 1.9.1
@@ -988,6 +991,19 @@ packages:
         integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==,
       }
     engines: { node: ">=12" }
+
+  "@dagrejs/dagre@1.1.8":
+    resolution:
+      {
+        integrity: sha512-5SEDlndt4W/LaVzPYJW+bSmSEZc9EzTf8rJ20WCKvjS5EAZAN0b+x0Yww7VMT4R3Wootkg+X9bUfUxazYw6Blw==,
+      }
+
+  "@dagrejs/graphlib@2.2.4":
+    resolution:
+      {
+        integrity: sha512-mepCf/e9+SKYy1d02/UkvSy6+6MoyXhVxP8lLDfA7BPE1X1d4dR0sZznmbM8/XVJ1GPM+Svnx7Xj6ZweByWUkw==,
+      }
+    engines: { node: ">17.0.0" }
 
   "@docsearch/css@3.8.2":
     resolution:
@@ -13091,6 +13107,12 @@ snapshots:
   "@cspotcode/source-map-support@0.8.1":
     dependencies:
       "@jridgewell/trace-mapping": 0.3.9
+
+  "@dagrejs/dagre@1.1.8":
+    dependencies:
+      "@dagrejs/graphlib": 2.2.4
+
+  "@dagrejs/graphlib@2.2.4": {}
 
   "@docsearch/css@3.8.2": {}
 

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.38.4
+version: 0.39.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.38.4
+      targetRevision: 0.39.0
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/BUILD
+++ b/projects/monolith/frontend/BUILD
@@ -31,6 +31,8 @@ js_library(
         ":node_modules/vite",
         # Hand-drawn SVG rendering
         ":node_modules/roughjs",
+        # DAG layout engine
+        ":node_modules/@dagrejs/dagre",
         # OpenTelemetry browser tracing
         ":node_modules/@opentelemetry/api",
         ":node_modules/@opentelemetry/sdk-trace-web",

--- a/projects/monolith/frontend/package.json
+++ b/projects/monolith/frontend/package.json
@@ -8,6 +8,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@dagrejs/dagre": "^1.1.4",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/exporter-trace-otlp-http": "^0.57.0",
     "@opentelemetry/instrumentation": "^0.57.0",

--- a/projects/monolith/frontend/src/routes/public/observability-demo/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/observability-demo/+page.svelte
@@ -2,138 +2,16 @@
   import rough from "roughjs";
   import { fly, fade } from "svelte/transition";
   import { cubicOut } from "svelte/easing";
+  import topology from "./topology.json";
+  import { computeLayout } from "./layout.js";
 
-  // ── Topology ───────────────────────────────
-  const nodes = [
-    { id: "cloudflare", label: "cloudflare", x: 150, y: 240, hw: 48, status: "healthy" },
-    { id: "monolith", label: "monolith", x: 420, y: 240, hw: 40, status: "healthy" },
-    { id: "postgres", label: "postgres", x: 680, y: 110, hw: 40, status: "healthy" },
-    { id: "nats", label: "nats", x: 680, y: 240, hw: 24, status: "healthy" },
-    { id: "signoz", label: "signoz", x: 680, y: 370, hw: 34, status: "warning" },
-    { id: "agents", label: "agents", x: 900, y: 240, hw: 34, status: "degraded" },
-    { id: "clickhouse", label: "clickhouse", x: 900, y: 370, hw: 48, status: "healthy" },
-    { id: "argocd", label: "argocd", x: 150, y: 440, hw: 34, status: "healthy" },
-    { id: "longhorn", label: "longhorn", x: 420, y: 440, hw: 40, status: "healthy" },
-  ];
-
-  const edges = [
-    { from: "cloudflare", to: "monolith", protocol: "https" },
-    { from: "monolith", to: "postgres", protocol: "sql" },
-    { from: "monolith", to: "nats", protocol: "nats" },
-    { from: "monolith", to: "signoz", protocol: "otlp" },
-    { from: "nats", to: "agents", protocol: "nats" },
-    { from: "signoz", to: "clickhouse", protocol: "tcp" },
-    { from: "argocd", to: "monolith", protocol: "gitops" },
-    { from: "longhorn", to: "postgres", protocol: "pvc" },
-    { from: "longhorn", to: "clickhouse", protocol: "pvc" },
-  ];
-
-  const nodeById = Object.fromEntries(nodes.map((n) => [n.id, n]));
+  // ── Topology (config-driven) ─────────────
   const HH = 18;
+  const landLayout = computeLayout(topology, "LR");
+  const portLayout = computeLayout(topology, "TB");
 
-  // ── Service data ───────────────────────────
-  const svc = {
-    cloudflare: {
-      description: "edge proxy + tunnel",
-      brief: "14.2k req/24h",
-      metrics: [
-        { k: "tunnel", v: "connected" },
-        { k: "requests 24h", v: "14.2k" },
-        { k: "cached", v: "62%" },
-      ],
-    },
-    monolith: {
-      description: "fastapi + sveltekit",
-      brief: "99.97% · 12.5 rps",
-      slo: { target: 99.9, current: 99.97 },
-      budget: { consumed: 28, elapsed: 40, remaining: "31.1 min", window: "30d" },
-      latency: { p99: 42, target: 200, unit: "ms" },
-      metrics: [
-        { k: "rps", v: "12.5" },
-        { k: "error rate", v: "0.02%" },
-        { k: "p99", v: "42ms" },
-      ],
-      spark: [38, 42, 45, 41, 39, 44, 42, 40, 43, 41, 38, 42, 47, 44, 42, 39, 41, 43, 42, 40, 38, 41, 43, 42],
-    },
-    postgres: {
-      description: "cnpg + pgvector",
-      brief: "100% · 8ms p99",
-      slo: { target: 99.95, current: 100 },
-      budget: { consumed: 0, elapsed: 40, remaining: "21.6 min", window: "30d" },
-      latency: { p99: 8, target: 50, unit: "ms" },
-      metrics: [
-        { k: "connections", v: "12 / 100" },
-        { k: "query p99", v: "8ms" },
-        { k: "storage", v: "2.1 GiB" },
-      ],
-      spark: [6, 7, 8, 7, 6, 8, 7, 7, 8, 7, 6, 7, 9, 8, 7, 6, 7, 8, 7, 7, 6, 7, 8, 7],
-    },
-    nats: {
-      description: "jetstream message bus",
-      brief: "100% · 45 msg/s",
-      slo: { target: 99.99, current: 100 },
-      budget: { consumed: 0, elapsed: 40, remaining: "4.3 min", window: "30d" },
-      metrics: [
-        { k: "msg/s", v: "45" },
-        { k: "consumers", v: "3" },
-        { k: "lag", v: "0" },
-      ],
-      spark: [40, 42, 48, 45, 43, 47, 44, 41, 46, 43, 42, 45, 50, 47, 44, 42, 45, 48, 44, 43, 41, 44, 46, 45],
-    },
-    signoz: {
-      description: "observability platform",
-      brief: "99.84% · 450 spans/s",
-      slo: { target: 99.9, current: 99.84 },
-      budget: { consumed: 66, elapsed: 40, remaining: "14.7 min", window: "30d" },
-      latency: { p99: 320, target: 500, unit: "ms" },
-      metrics: [
-        { k: "spans/s", v: "450" },
-        { k: "ingestion p99", v: "320ms" },
-        { k: "storage", v: "82 / 150 GiB" },
-      ],
-      spark: [280, 310, 350, 320, 290, 340, 380, 320, 310, 340, 290, 300, 360, 340, 320, 300, 330, 350, 320, 310, 290, 320, 340, 320],
-    },
-    agents: {
-      description: "mcp + orchestrator",
-      brief: "99.31% · 2 active",
-      slo: { target: 99.5, current: 99.31 },
-      budget: { consumed: 138, elapsed: 40, remaining: "0 min", window: "30d" },
-      latency: { p99: 890, target: 500, unit: "ms" },
-      metrics: [
-        { k: "active jobs", v: "2" },
-        { k: "completed 24h", v: "47" },
-        { k: "mcp servers", v: "4" },
-      ],
-      spark: [420, 510, 680, 890, 750, 820, 940, 870, 780, 910, 850, 720, 880, 930, 810, 760, 890, 950, 870, 820, 780, 850, 910, 890],
-    },
-    clickhouse: {
-      description: "signoz storage backend",
-      brief: "34% cpu · 82 GiB",
-      metrics: [
-        { k: "cpu", v: "34%" },
-        { k: "memory", v: "5.2 / 8 GiB" },
-        { k: "storage", v: "82 GiB" },
-      ],
-    },
-    argocd: {
-      description: "gitops controller",
-      brief: "14/14 synced",
-      metrics: [
-        { k: "applications", v: "14" },
-        { k: "synced", v: "14 / 14" },
-        { k: "last sync", v: "12s ago" },
-      ],
-    },
-    longhorn: {
-      description: "distributed storage",
-      brief: "340 / 1000 GiB",
-      metrics: [
-        { k: "volumes", v: "8" },
-        { k: "replicas", v: "healthy" },
-        { k: "used", v: "340 / 1000 GiB" },
-      ],
-    },
-  };
+  // ── Service data (from config) ─────────────
+  const svc = Object.fromEntries(topology.nodes.map((n) => [n.id, n]));
 
   // ── State ──────────────────────────────────
   let selected = $state(null);
@@ -153,6 +31,7 @@
   let drawerBorderSvg = $state(null);
   let drawerBorderG = $state(null);
   let hoverBorderG = $state(null);
+  let roughArrows = $state(null);
   let mapPanG = $state(null);
   const active = $derived(hovered || selected);
 
@@ -191,8 +70,16 @@
   });
 
   // Pick layout that minimizes whitespace by matching container aspect ratio
-  const LAND_AR = 960 / 470;  // ~2.04
-  const PORT_AR = 500 / 510;  // ~0.98
+  function computeAR(layout) {
+    let minX = Infinity, maxX = -Infinity, minY = Infinity, maxY = -Infinity;
+    for (const n of layout.nodes) {
+      minX = Math.min(minX, n.x - n.hw); maxX = Math.max(maxX, n.x + n.hw);
+      minY = Math.min(minY, n.y - HH); maxY = Math.max(maxY, n.y + HH);
+    }
+    return (maxX - minX) / (maxY - minY);
+  }
+  const LAND_AR = computeAR(landLayout);
+  const PORT_AR = computeAR(portLayout);
   const isPortrait = $derived.by(() => {
     const ar = containerW / containerH;
     return Math.abs(ar - PORT_AR) < Math.abs(ar - LAND_AR);
@@ -204,6 +91,11 @@
     const ar = window.innerWidth / window.innerHeight;
     return Math.abs(ar - PORT_AR) < Math.abs(ar - LAND_AR);
   })()); // matches initial isPortrait so no spurious flip
+
+  const nodes = $derived(activeLayout ? portLayout.nodes : landLayout.nodes);
+  const edges = $derived(activeLayout ? portLayout.edges : landLayout.edges);
+  const nodeById = $derived(activeLayout ? portLayout.nodeById : landLayout.nodeById);
+
   let flipPhase = $state("none");   // "none" | "out" | "in"
   let scribbling = $state(false);   // true during scribble-out + fade
   let flipTimer = null;
@@ -332,31 +224,21 @@
     startFlip(target);
   });
 
-  const viewBox = $derived(activeLayout ? "0 10 500 510" : "30 40 960 470");
-
-  // Portrait node positions (top-to-bottom flow)
-  // Longhorn at bottom-left so its storage edges (→postgres, →clickhouse)
-  // run vertically and horizontally without crossing signoz/nats.
-  const portraitNodes = [
-    { id: "cloudflare", x: 250, y: 70 },
-    { id: "argocd", x: 80, y: 190 },
-    { id: "monolith", x: 250, y: 190 },
-    { id: "postgres", x: 100, y: 320 },
-    { id: "nats", x: 250, y: 320 },
-    { id: "signoz", x: 400, y: 320 },
-    { id: "longhorn", x: 100, y: 430 },
-    { id: "clickhouse", x: 400, y: 430 },
-    { id: "agents", x: 250, y: 470 },
-  ];
-  const portraitById = Object.fromEntries(portraitNodes.map((n) => [n.id, n]));
+  const viewBox = $derived.by(() => {
+    const layout = activeLayout ? portLayout : landLayout;
+    let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+    for (const n of layout.nodes) {
+      minX = Math.min(minX, n.x - n.hw - 20);
+      minY = Math.min(minY, n.y - HH - 20);
+      maxX = Math.max(maxX, n.x + n.hw + 20);
+      maxY = Math.max(maxY, n.y + HH + 20);
+    }
+    const pad = 40;
+    return `${minX - pad} ${minY - pad} ${maxX - minX + pad * 2} ${maxY - minY + pad * 2}`;
+  });
 
   function getNodePos(id) {
-    if (activeLayout) {
-      const p = portraitById[id];
-      return { x: p.x, y: p.y };
-    }
-    const n = nodes.find((n) => n.id === id);
-    return { x: n.x, y: n.y };
+    return nodeById[id];
   }
 
 
@@ -379,9 +261,14 @@
       fgTer: s.getPropertyValue("--fg-tertiary").trim(),
       bg: s.getPropertyValue("--bg").trim(),
       border: s.getPropertyValue("--border").trim(),
+      borderInk: s.getPropertyValue("--border-ink").trim(),
       surface: s.getPropertyValue("--surface").trim(),
       danger: s.getPropertyValue("--danger").trim(),
-      warn: document.documentElement.classList.contains("theme-dark") ? "#ecc94b" : "#d97706",
+      warn: s.getPropertyValue("--warn").trim(),
+      tierIngress: s.getPropertyValue("--tier-ingress").trim(),
+      tierCritical: s.getPropertyValue("--tier-critical").trim(),
+      tierInfra: s.getPropertyValue("--tier-infra").trim(),
+      tooltipBg: s.getPropertyValue("--tooltip-bg").trim(),
     };
   }
 
@@ -427,9 +314,15 @@
     return { x: cx + dx * s, y: cy + dy * s };
   }
 
+  function tierFill(tier, c) {
+    if (tier === "ingress") return c.tierIngress;
+    if (tier === "infra") return c.tierInfra;
+    return c.tierCritical;
+  }
+
   function nodeRoughness(status) {
-    if (status === "degraded") return 2.5;
-    if (status === "warning") return 1.8;
+    if (status === "degraded") return 0.8;
+    if (status === "warning") return 0.8;
     return 0.8;
   }
 
@@ -455,10 +348,19 @@
 
   // ── Sequential BFS animation timeline ─────
   // Each step blocks the next: box sides draw sequentially → text jots → travel pause → edge → next box
-  const animDelay = (() => {
+  const animDelay = $derived.by(() => {
+    const _nodes = nodes;
+    const _edges = edges;
+    const _nodeById = nodeById;
+    const _gen = drawGen;
+
+    const __nodes = _nodes;
+    const __edges = _edges;
+    const __nodeById = _nodeById;
+
     const adj = {};
-    nodes.forEach((n) => (adj[n.id] = []));
-    edges.forEach((e) => {
+    __nodes.forEach((n) => (adj[n.id] = []));
+    __edges.forEach((e) => {
       adj[e.from].push({ nb: e.to, edge: e });
       adj[e.to].push({ nb: e.from, edge: e });
     });
@@ -510,7 +412,7 @@
     // Pencil cursor drives the flow; ink/text are non-blocking overlays.
     const INK_SPEED = 0.85; // ink pass is 85% the duration of pencil (pencil sketches ahead, ink follows)
 
-    const visited = new Set(["cloudflare"]);
+    const visited = new Set(["external"]);
     const nd = {};
     const ed = {};
     const edDir = {};
@@ -518,12 +420,14 @@
     // Schedule a node's pencil box. Returns pencil cursor after box completes.
     function scheduleNode(c, item) {
       const { id, fromX, fromY } = item;
-      const n = nodeById[id];
+      const n = __nodeById[id];
       const side = arrivalSide(n, fromX, fromY);
       const sides = boxSideDurs(n);
       const bDur = sides.reduce((a, b) => a + b, 0);
       const tDur = textDur(n.label);
 
+      const fillStart = c + bDur + bDur * INK_SPEED; // fill scrubs in after ink completes
+      const fillDur = 0.25;                          // quick color scrub
       nd[id] = {
         box: c,                              // pencil box start
         boxSides: sides,                     // pencil per-side durations
@@ -532,7 +436,9 @@
         inkBox: c + bDur,                    // ink retrace starts when pencil box finishes
         inkBoxDur: bDur * INK_SPEED,
         inkBoxSides: sides.map((d) => d * INK_SPEED),
-        text: c + bDur,                      // text jots at same time as ink
+        fill: fillStart,                     // color fill after ink outline
+        fillDur,
+        text: fillStart + fillDur * 0.5,     // text jots in as fill is completing
         textDur: tDur,
       };
       return c + bDur; // pencil cursor: box done, ready for edges
@@ -542,8 +448,8 @@
     function scheduleEdge(pencilStart, parentId, edge, siblingIdx) {
       const key = edge.from + "-" + edge.to;
       edDir[key] = edge.from === parentId;
-      const from = nodeById[edge.from];
-      const to = nodeById[edge.to];
+      const from = __nodeById[edge.from];
+      const to = __nodeById[edge.to];
       const eDur = edgeDur(from, to, key);
 
       // Ink line waits for: parent's ink box + stagger, AND pencil line to complete + pause
@@ -563,7 +469,7 @@
 
     // Collect unvisited children
     function collectChildren(item) {
-      const n = nodeById[item.id];
+      const n = __nodeById[item.id];
       const children = [];
       let sibIdx = 0;
       for (const { nb: nbId, edge } of adj[item.id]) {
@@ -582,7 +488,7 @@
       return scheduleNode(c, item);
     }
 
-    let batch = [{ id: "cloudflare", fromX: 0, fromY: 240, viaEdge: null, parentId: null }];
+    let batch = [{ id: "external", fromX: 0, fromY: __nodeById["external"]?.y ?? 240, viaEdge: null, parentId: null }];
     let cursor = 0.2;
 
     while (batch.length > 0) {
@@ -614,10 +520,10 @@
     }
 
     // Cross-edges (both endpoints already visited)
-    edges.forEach((e) => {
+    __edges.forEach((e) => {
       const key = e.from + "-" + e.to;
       if (ed[key]) return;
-      const eDur = edgeDur(nodeById[e.from], nodeById[e.to], key);
+      const eDur = edgeDur(__nodeById[e.from], __nodeById[e.to], key);
       const fromDone = (nd[e.from]?.box ?? 0) + (nd[e.from]?.boxDur ?? 0);
       const toDone = (nd[e.to]?.box ?? 0) + (nd[e.to]?.boxDur ?? 0);
       edDir[key] = fromDone <= toDone;
@@ -628,12 +534,28 @@
       cursor += eDur + TRAVEL_PAUSE;
     });
 
+    // Schedule unvisited nodes (infra tier — no edges from critical path)
+    // Sort left-to-right (by x) and stagger from the start of the animation
+    // so they draw concurrently with the critical path
+    const unvisited = __nodes
+      .filter((n) => !visited.has(n.id))
+      .sort((a, b) => a.x - b.x);
+    if (unvisited.length > 0) {
+      const infraStart = 0.8; // start shortly after cloudflare
+      const infraSpacing = 0.4; // seconds between each infra node
+      unvisited.forEach((n, i) => {
+        visited.add(n.id);
+        const t = infraStart + i * infraSpacing * jitter(n.id + "infra");
+        scheduleNode(t, { id: n.id, fromX: n.x, fromY: n.y - 80 });
+      });
+    }
+
     let maxT = 0;
     for (const v of Object.values(nd)) maxT = Math.max(maxT, v.inkBox + v.inkBoxDur);
     for (const v of Object.values(ed)) maxT = Math.max(maxT, v.inkLine + v.inkLineDur);
 
     return { node: nd, edge: ed, edgeDir: edDir, totalDur: maxT + 0.5 };
-  })();
+  });
 
   // ── Draw topology ──────────────────────────
   // This effect draws all Rough.js elements once (and on dark mode change).
@@ -641,7 +563,7 @@
   // that updates opacity on existing elements, allowing CSS transitions to work.
   let hasAnimated = false;
   $effect(() => {
-    if (!mapSvg || !roughEdges || !roughNodes) return;
+    if (!mapSvg || !roughEdges || !roughNodes || !roughArrows) return;
     const _layout = activeLayout;
     const _gen = drawGen; // bump to force redraw after flip
 
@@ -649,7 +571,56 @@
     const rc = rough.svg(mapSvg);
     clearChildren(roughEdges);
     clearChildren(roughNodes);
+    clearChildren(roughArrows);
     const shouldAnimate = !hasAnimated;
+
+    // Helper: draw a hand-drawn chevron arrowhead (two rough lines forming a ">")
+    function drawArrowhead(rc, x, y, fromX, fromY, color, arrowSeed, hidden) {
+      const dx = x - fromX;
+      const dy = y - fromY;
+      const len = Math.sqrt(dx * dx + dy * dy);
+      if (len === 0) return null;
+      const ux = dx / len;
+      const uy = dy / len;
+      const px = -uy;
+      const py = ux;
+      const size = 10;
+      const spread = 6;
+      // Two barb endpoints behind the tip
+      const leftX = x - ux * size + px * spread;
+      const leftY = y - uy * size + py * spread;
+      const rightX = x - ux * size - px * spread;
+      const rightY = y - uy * size - py * spread;
+
+      const g = document.createElementNS("http://www.w3.org/2000/svg", "g");
+      // First barb: outer → tip (drawing inward)
+      const leftBarb = rc.line(leftX, leftY, x, y, {
+        stroke: color, roughness: 1.0, bowing: 0.8,
+        strokeWidth: 1.5, seed: arrowSeed,
+      });
+      leftBarb.dataset.barb = "left";
+      g.appendChild(leftBarb);
+      // Second barb: tip → outer (drawing outward, continuous stroke)
+      const rightBarb = rc.line(x, y, rightX, rightY, {
+        stroke: color, roughness: 1.0, bowing: 0.8,
+        strokeWidth: 1.5, seed: arrowSeed + 3,
+      });
+      rightBarb.dataset.barb = "right";
+      g.appendChild(rightBarb);
+      // Hide all paths when animating — they'll be revealed via edgeDraw
+      if (hidden) {
+        g.querySelectorAll("path").forEach((p) => {
+          try {
+            const pLen = p.getTotalLength();
+            p.style.strokeDasharray = String(pLen);
+            p.style.strokeDashoffset = String(pLen);
+          } catch {
+            p.style.opacity = "0";
+          }
+        });
+      }
+      return g;
+    }
 
     edges.forEach((e) => {
       const key = e.from + "-" + e.to;
@@ -676,7 +647,7 @@
         stroke: c.border,
         roughness: 1.5,
         bowing: 1.2,
-        strokeWidth: 0.8,
+        strokeWidth: 1.0,
         seed: edgeSeed,
       });
       pencil.style.opacity = "0.6";
@@ -687,10 +658,29 @@
         stroke: c.fgTer,
         roughness: 1.5,
         bowing: 1.2,
-        strokeWidth: 1,
+        strokeWidth: 1.5,
         seed: edgeSeed + 7,
       });
       ink.dataset.layer = "ink";
+
+      // Rough.js arrowheads — rendered in separate layer on top of nodes
+      const fwdArrow = drawArrowhead(rc, endPt.x, endPt.y, startPt.x, startPt.y, c.fgTer, edgeSeed + 20, shouldAnimate);
+      if (fwdArrow) {
+        fwdArrow.dataset.edge = key;
+        fwdArrow.style.transition = "opacity 0.25s ease";
+        roughArrows.appendChild(fwdArrow);
+      }
+
+      // Bidirectional: arrowhead at the "from" end too
+      let revArrow = null;
+      if (e.bidi) {
+        revArrow = drawArrowhead(rc, startPt.x, startPt.y, endPt.x, endPt.y, c.fgTer, edgeSeed + 30, shouldAnimate);
+        if (revArrow) {
+          revArrow.dataset.edge = key;
+          revArrow.style.transition = "opacity 0.25s ease";
+          roughArrows.appendChild(revArrow);
+        }
+      }
 
       if (shouldAnimate) {
         const anim = animDelay.edge[key];
@@ -720,6 +710,38 @@
             path.style.animation = `nodeIn 0.3s ease ${anim.inkLine.toFixed(3)}s forwards`;
           }
         });
+
+        // Arrowheads: draw in after edge ink + target node ink both complete
+        const edgeInkDone = anim.inkLine + anim.inkLineDur;
+        // Find when the "to" node's ink box finishes (if it has anim data)
+        const toNodeAnim = animDelay.node[fwd ? e.to : e.from];
+        const fromNodeAnim = animDelay.node[fwd ? e.from : e.to];
+        const toInkDone = toNodeAnim ? toNodeAnim.inkBox + toNodeAnim.inkBoxDur : 0;
+        const arrowStart = Math.max(edgeInkDone, toInkDone);
+        const arrowDur = 0.375;
+
+        const barbStagger = 0.08; // slight delay between left and right barb
+        function animateArrow(arrow, delay) {
+          if (!arrow) return;
+          // Animate each barb separately with stagger
+          arrow.querySelectorAll("[data-barb]").forEach((barbG, i) => {
+            const barbDelay = delay + i * barbStagger;
+            barbG.querySelectorAll("path").forEach((p) => {
+              try {
+                p.style.animation = `edgeDraw ${arrowDur}s ${PEN_EASE} ${barbDelay.toFixed(3)}s forwards`;
+              } catch {
+                p.style.opacity = "0";
+                p.style.animation = `nodeIn ${arrowDur}s ease ${barbDelay.toFixed(3)}s forwards`;
+              }
+            });
+          });
+        }
+        animateArrow(fwdArrow, arrowStart);
+        if (e.bidi) {
+          const fromInkDone = fromNodeAnim ? fromNodeAnim.inkBox + fromNodeAnim.inkBoxDur : 0;
+          const revStart = Math.max(edgeInkDone, fromInkDone);
+          animateArrow(revArrow, revStart);
+        }
       }
       g.appendChild(pencil);
       g.appendChild(ink);
@@ -731,7 +753,7 @@
       const pos = getNodePos(n.id);
       const w = n.hw * 2 + 12;
       const h = HH * 2 + 6;
-      const inkCol = n.status === "degraded" ? c.danger : n.status === "warning" ? c.warn : c.fg;
+      const inkCol = n.status === "degraded" ? c.danger : n.status === "warning" ? c.warn : c.borderInk;
       const r = nodeRoughness(n.status);
       const bow = n.status === "warning" ? 1.2 : 0.5;
 
@@ -739,12 +761,16 @@
       g.dataset.node = n.id;
       g.style.transition = "opacity 0.25s ease";
 
-      // Solid fill — always visible so scribble lines don't bleed through text
+      // Solid fill — starts transparent, scrubs in after ink outline completes
+      const fillCol = tierFill(n.tier, c);
       const fillEl = rc.rectangle(pos.x - w / 2, pos.y - h / 2, w, h, {
-        stroke: "none", fill: c.bg, fillStyle: "solid",
+        stroke: "none", fill: fillCol, fillStyle: "solid",
         roughness: r, seed: seed(n.id + "fill"),
       });
       fillEl.dataset.layer = "fill";
+      if (shouldAnimate) {
+        fillEl.style.opacity = "0";
+      }
       g.appendChild(fillEl);
 
       // 4 sequential strokes, rotated to start from the nearest corner to the incoming edge
@@ -784,7 +810,7 @@
           stroke: c.border,
           roughness: r,
           bowing: bow,
-          strokeWidth: 0.7,
+          strokeWidth: 1.0,
           seed: sideSeed,
         });
         pencil.style.opacity = "0.5";
@@ -795,7 +821,7 @@
           stroke: inkCol,
           roughness: r,
           bowing: bow,
-          strokeWidth: 1,
+          strokeWidth: 2,
           seed: sideSeed + 7,
         });
         ink.dataset.layer = "ink";
@@ -836,6 +862,12 @@
         g.appendChild(pencil);
         g.appendChild(ink);
       });
+
+      // Animate fill scrub: fade in after ink outline completes
+      if (anim) {
+        fillEl.style.animation = `nodeIn ${anim.fillDur.toFixed(3)}s ease-out ${anim.fill.toFixed(3)}s forwards`;
+      }
+
       roughNodes.appendChild(g);
     });
 
@@ -862,39 +894,84 @@
         g.querySelector("[data-layer='ink']")?.querySelectorAll("path").forEach((p) => { p.setAttribute("stroke", c.fgTer); });
       });
     }
+    // Recolor arrowheads
+    if (roughArrows) {
+      roughArrows.querySelectorAll("[data-edge]").forEach((g) => {
+        g.querySelectorAll("path").forEach((p) => { p.setAttribute("stroke", c.fgTer); });
+      });
+    }
     // Recolor nodes
     if (roughNodes) {
       roughNodes.querySelectorAll("[data-node]").forEach((g) => {
         const id = g.dataset.node;
         const n = nodeById[id];
-        const inkCol = n.status === "degraded" ? c.danger : n.status === "warning" ? c.warn : c.fg;
+        const inkCol = n.status === "degraded" ? c.danger : n.status === "warning" ? c.warn : c.borderInk;
         g.querySelectorAll("[data-layer='pencil'] path").forEach((p) => { p.setAttribute("stroke", c.border); });
         g.querySelectorAll("[data-layer='ink'] path").forEach((p) => { p.setAttribute("stroke", inkCol); });
         const fill = g.querySelector("[data-layer='fill']");
-        if (fill) fill.querySelectorAll("path").forEach((p) => { p.setAttribute("fill", c.surface); });
+        if (fill) fill.querySelectorAll("path").forEach((p) => {
+          p.setAttribute("fill", tierFill(n.tier, c));
+        });
       });
     }
   });
 
   // ── Highlight effect ──────────────────────────
-  // Updates opacity on existing Rough.js elements when active changes.
-  // Separated from draw effect so selection/hover doesn't trigger a full redraw,
-  // allowing CSS transitions to produce smooth fades.
+  // When a node is focused: connected edges become bold, others dim.
+  // Separated from draw effect so selection/hover doesn't trigger a full redraw.
   $effect(() => {
-    if (!roughEdges || !roughNodes) return;
+    if (!roughEdges || !roughNodes || !roughArrows) return;
     const _hov = hovered;
     const _sel = selected;
     const dimSource = _hov || _sel;
 
-    // Edges: dim all when any node is focused
+    // Build set of connected edge keys for the focused node
+    const connectedEdges = new Set();
+    const connectedNodes = new Set();
+    if (dimSource) {
+      connectedNodes.add(dimSource);
+      edges.forEach((e) => {
+        if (e.from === dimSource || e.to === dimSource) {
+          connectedEdges.add(e.from + "-" + e.to);
+          connectedNodes.add(e.from);
+          connectedNodes.add(e.to);
+        }
+      });
+    }
+
+    // Edges: connected ones become bold, others dim
     roughEdges.querySelectorAll("[data-edge]").forEach((g) => {
-      g.style.opacity = dimSource ? "0.15" : "1";
+      const key = g.dataset.edge;
+      if (!dimSource) {
+        g.style.opacity = "1";
+        g.querySelectorAll("path").forEach((p) => { p.style.strokeWidth = ""; });
+      } else if (connectedEdges.has(key)) {
+        g.style.opacity = "1";
+        // Bold up the ink layer paths
+        const ink = g.querySelector("[data-layer='ink']");
+        if (ink) ink.querySelectorAll("path").forEach((p) => { p.style.strokeWidth = "3"; });
+      } else {
+        g.style.opacity = "0.08";
+        g.querySelectorAll("path").forEach((p) => { p.style.strokeWidth = ""; });
+      }
     });
 
-    // Nodes: only the focused node stays bright
+    // Arrowheads: match their edge's visibility
+    roughArrows.querySelectorAll("[data-edge]").forEach((g) => {
+      const key = g.dataset.edge;
+      if (!dimSource) {
+        g.style.opacity = "1";
+      } else if (connectedEdges.has(key)) {
+        g.style.opacity = "1";
+      } else {
+        g.style.opacity = "0.08";
+      }
+    });
+
+    // Nodes: focused + connected neighbors stay bright
     roughNodes.querySelectorAll("[data-node]").forEach((g) => {
       const id = g.dataset.node;
-      g.style.opacity = (!dimSource || id === dimSource) ? "1" : "0.25";
+      g.style.opacity = (!dimSource || connectedNodes.has(id)) ? "1" : "0.15";
     });
 
   });
@@ -967,9 +1044,9 @@
 
       // MotherDuck-inspired brutalist palette — vibrant everywhere
       const scribbleCol = n.status === "degraded"
-        ? (isDark ? "#f87171" : "#dc2626")
+        ? (isDark ? "#ff3333" : "#dc2626")
         : n.status === "warning"
-          ? (isDark ? "#fbbf24" : "#f59e0b")
+          ? "#ff9500"
           : (isDark ? "#7dd3fc" : "#38bdf8");
 
       const wrap = document.createElementNS("http://www.w3.org/2000/svg", "g");
@@ -1067,7 +1144,7 @@
     tooltipRough.appendChild(
       rc.rectangle(pos.x - tipW / 2, tipY - 9, tipW, 18, {
         stroke: c.border,
-        fill: c.bg,
+        fill: c.tooltipBg,
         fillStyle: "solid",
         roughness: 0.5,
         strokeWidth: 0.6,
@@ -1248,10 +1325,12 @@
     aria-label="Service topology"
     preserveAspectRatio="xMidYMin meet"
   >
+    <defs></defs>
     <g bind:this={mapPanG} class="map-pan">
-    <g bind:this={roughEdges}></g>
     <g bind:this={hoverBorderG}></g>
+    <g bind:this={roughEdges}></g>
     <g bind:this={roughNodes}></g>
+    <g bind:this={roughArrows}></g>
 
     {#key drawGen}
       {#each nodes as n}
@@ -1424,6 +1503,42 @@
 </div>
 
 <style>
+  :global(.theme-light) {
+    --bg: #f5f0e8;
+    --surface: #ebe5d9;
+    --tooltip-bg: #f5f0e8;
+    --fg: #1a1a1a;
+    --fg-secondary: #4a4a4a;
+    --fg-tertiary: #7a7a7a;
+    --border: #1a1a1a;
+    --border-ink: #1a1a1a;
+    --danger: #dc2626;
+    --warn: #ff9500;
+    --tier-ingress: #bfdbfe;
+    --tier-critical: #fef08a;
+    --tier-infra: #bbf7d0;
+    --node-text: #1a1a1a;
+    --font: "JetBrains Mono", "SF Mono", "Fira Code", ui-monospace, monospace;
+  }
+
+  :global(.theme-dark) {
+    --bg: #0f0f0f;
+    --surface: #1a1a1a;
+    --tooltip-bg: #d4cfc7;
+    --fg: #f0f0f0;
+    --fg-secondary: #b0b0b0;
+    --fg-tertiary: #808080;
+    --border: #ffffff;
+    --border-ink: #ffffff;
+    --danger: #ff4444;
+    --warn: #ff9500;
+    --tier-ingress: #93c5fd;
+    --tier-critical: #fde047;
+    --tier-infra: #86efac;
+    --node-text: #1a1a1a;
+    --font: "JetBrains Mono", "SF Mono", "Fira Code", ui-monospace, monospace;
+  }
+
   /* ── Layout ──────────────────────────────── */
 
   .root {
@@ -1458,6 +1573,10 @@
   .map {
     width: 100%;
     height: 100%;
+  }
+  .map :global(path) {
+    stroke-linecap: round;
+    stroke-linejoin: round;
   }
 
   /* Scribble-out: scribble draws (250ms), then content fades out (200ms) */
@@ -1544,11 +1663,13 @@
 
   .node-label {
     font-family: var(--font);
-    font-size: 11px;
-    font-weight: 700;
-    fill: var(--fg);
+    font-size: 9px;
+    font-weight: 800;
+    fill: var(--node-text);
     text-anchor: middle;
-    transition: opacity 0.2s ease, x 0.5s cubic-bezier(0.4, 0, 0.2, 1), y 0.5s cubic-bezier(0.4, 0, 0.2, 1);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    transition: opacity 0.2s ease;
   }
 
   .node-label--dimmed { opacity: 0.25; }
@@ -1558,9 +1679,10 @@
     font-family: var(--font);
     font-size: 8px;
     font-weight: 700;
-    fill: var(--fg-secondary);
+    fill: var(--node-text);
     text-anchor: middle;
   }
+
 
   .hit-area {
     outline: none;

--- a/projects/monolith/frontend/src/routes/public/observability-demo/layout.js
+++ b/projects/monolith/frontend/src/routes/public/observability-demo/layout.js
@@ -1,4 +1,4 @@
-import dagre from "@dagrejs/dagre";
+import * as dagre from "@dagrejs/dagre";
 
 const HH = 18; // half-height of a node (matches +page.svelte)
 const CHAR_WIDTH = 6.5; // approximate monospace character width at 11px
@@ -22,17 +22,23 @@ function computeHW(label) {
  * @returns {{ nodes: Array, edges: Array, nodeById: Object }}
  */
 export function computeLayout(topology, rankdir) {
-  const g = new dagre.Graph();
+  const g = new dagre.graphlib.Graph();
   g.setGraph({
     rankdir,
     nodesep: rankdir === "LR" ? 40 : 50,
-    ranksep: rankdir === "LR" ? 80 : 60,
+    ranksep: rankdir === "LR" ? 60 : 45,
     marginx: 40,
     marginy: 40,
   });
   g.setDefaultEdgeLabel(() => ({}));
 
+  // Only add non-infra nodes to dagre — infra nodes are positioned manually
+  const infraNodeIds = new Set(
+    topology.nodes.filter((n) => n.tier === "infra").map((n) => n.id),
+  );
+
   for (const node of topology.nodes) {
+    if (infraNodeIds.has(node.id)) continue;
     const hw = computeHW(node.label);
     g.setNode(node.id, {
       width: hw * 2 + NODE_PAD,
@@ -42,35 +48,54 @@ export function computeLayout(topology, rankdir) {
   }
 
   for (const edge of topology.edges) {
-    g.setEdge(edge.from, edge.to);
-  }
-
-  // Pin infra nodes to a separate rank band via invisible anchor edges
-  const infraNodes = topology.nodes.filter((n) => n.tier === "infra");
-  if (infraNodes.length > 0) {
-    g.setNode("__infra_anchor", { width: 0, height: 0 });
-    const lastCritical = topology.nodes
-      .filter((n) => n.tier === "critical")
-      .at(-1);
-    if (lastCritical) {
-      g.setEdge(lastCritical.id, "__infra_anchor", { minlen: 2 });
-    }
-    for (const n of infraNodes) {
-      g.setEdge("__infra_anchor", n.id, { minlen: 1 });
+    if (!infraNodeIds.has(edge.from) && !infraNodeIds.has(edge.to)) {
+      g.setEdge(edge.from, edge.to);
     }
   }
 
   dagre.layout(g);
 
-  const nodes = topology.nodes.map((n) => {
+  // Collect dagre-positioned nodes and find the bounding box
+  const positioned = [];
+  let maxY = -Infinity;
+  let maxX = -Infinity;
+  let minX = Infinity;
+  for (const n of topology.nodes) {
+    if (infraNodeIds.has(n.id)) continue;
     const pos = g.node(n.id);
-    return {
-      ...n,
-      x: pos.x,
-      y: pos.y,
-      hw: computeHW(n.label),
-    };
-  });
+    positioned.push({ ...n, x: pos.x, y: pos.y, hw: computeHW(n.label) });
+    maxY = Math.max(maxY, pos.y);
+    maxX = Math.max(maxX, pos.x + computeHW(n.label));
+    minX = Math.min(minX, pos.x - computeHW(n.label));
+  }
+
+  // Position infra nodes in a row below the critical path
+  const infraNodes = topology.nodes.filter((n) => n.tier === "infra");
+  const infraGap = 30; // gap below last critical rank
+  const infraSep = 18; // spacing between infra nodes
+  if (infraNodes.length > 0) {
+    // Calculate total width of all infra nodes
+    const infraWidths = infraNodes.map(
+      (n) => computeHW(n.label) * 2 + NODE_PAD,
+    );
+    const totalInfraW =
+      infraWidths.reduce((a, b) => a + b, 0) +
+      infraSep * (infraNodes.length - 1);
+
+    // Center the infra row under the critical path
+    const critCenterX = (minX + maxX) / 2;
+    let infraX = critCenterX - totalInfraW / 2;
+    const infraY = maxY + infraGap + HH * 2 + 6;
+
+    infraNodes.forEach((n, i) => {
+      const hw = computeHW(n.label);
+      const w = hw * 2 + NODE_PAD;
+      positioned.push({ ...n, x: infraX + w / 2, y: infraY, hw });
+      infraX += w + infraSep;
+    });
+  }
+
+  const nodes = positioned;
 
   const nodeById = Object.fromEntries(nodes.map((n) => [n.id, n]));
 

--- a/projects/monolith/frontend/src/routes/public/observability-demo/layout.js
+++ b/projects/monolith/frontend/src/routes/public/observability-demo/layout.js
@@ -1,0 +1,78 @@
+import dagre from "@dagrejs/dagre";
+
+const HH = 18; // half-height of a node (matches +page.svelte)
+const CHAR_WIDTH = 6.5; // approximate monospace character width at 11px
+const NODE_PAD = 12; // padding around label text
+
+/**
+ * Compute half-width from label length.
+ */
+function computeHW(label) {
+  return Math.max(
+    24,
+    Math.ceil((label.length * CHAR_WIDTH) / 2) + NODE_PAD / 2,
+  );
+}
+
+/**
+ * Run dagre layout on the topology config.
+ *
+ * @param {Object} topology - The topology.json structure ({ nodes, edges })
+ * @param {"LR"|"TB"} rankdir - Layout direction
+ * @returns {{ nodes: Array, edges: Array, nodeById: Object }}
+ */
+export function computeLayout(topology, rankdir) {
+  const g = new dagre.Graph();
+  g.setGraph({
+    rankdir,
+    nodesep: rankdir === "LR" ? 40 : 50,
+    ranksep: rankdir === "LR" ? 80 : 60,
+    marginx: 40,
+    marginy: 40,
+  });
+  g.setDefaultEdgeLabel(() => ({}));
+
+  for (const node of topology.nodes) {
+    const hw = computeHW(node.label);
+    g.setNode(node.id, {
+      width: hw * 2 + NODE_PAD,
+      height: HH * 2 + 6,
+      tier: node.tier,
+    });
+  }
+
+  for (const edge of topology.edges) {
+    g.setEdge(edge.from, edge.to);
+  }
+
+  // Pin infra nodes to a separate rank band via invisible anchor edges
+  const infraNodes = topology.nodes.filter((n) => n.tier === "infra");
+  if (infraNodes.length > 0) {
+    g.setNode("__infra_anchor", { width: 0, height: 0 });
+    const lastCritical = topology.nodes
+      .filter((n) => n.tier === "critical")
+      .at(-1);
+    if (lastCritical) {
+      g.setEdge(lastCritical.id, "__infra_anchor", { minlen: 2 });
+    }
+    for (const n of infraNodes) {
+      g.setEdge("__infra_anchor", n.id, { minlen: 1 });
+    }
+  }
+
+  dagre.layout(g);
+
+  const nodes = topology.nodes.map((n) => {
+    const pos = g.node(n.id);
+    return {
+      ...n,
+      x: pos.x,
+      y: pos.y,
+      hw: computeHW(n.label),
+    };
+  });
+
+  const nodeById = Object.fromEntries(nodes.map((n) => [n.id, n]));
+
+  return { nodes, edges: topology.edges, nodeById };
+}

--- a/projects/monolith/frontend/src/routes/public/observability-demo/topology.json
+++ b/projects/monolith/frontend/src/routes/public/observability-demo/topology.json
@@ -1,11 +1,20 @@
 {
   "nodes": [
     {
-      "id": "cloudflare",
-      "label": "CLOUDFLARE",
+      "id": "external",
+      "label": "EXTERNAL",
       "tier": "ingress",
       "status": "healthy",
-      "description": "tunnel + gateway",
+      "description": "webpage · claude · cli",
+      "brief": "all external clients",
+      "metrics": [{ "k": "clients", "v": "webpage, claude, cli" }]
+    },
+    {
+      "id": "cloudflare",
+      "label": "CLOUDFLARE TUNNEL",
+      "tier": "critical",
+      "status": "healthy",
+      "description": "cloudflare tunnel",
       "brief": "14.2k req/24h",
       "metrics": [
         { "k": "tunnel", "v": "connected" },
@@ -141,7 +150,7 @@
     },
     {
       "id": "llama-cpp",
-      "label": "LLAMA.CPP",
+      "label": "GEMMA 4",
       "tier": "critical",
       "status": "healthy",
       "description": "gemma 4 inference",
@@ -317,15 +326,20 @@
     }
   ],
   "edges": [
+    { "from": "external", "to": "cloudflare", "protocol": "https" },
     { "from": "cloudflare", "to": "monolith", "protocol": "https" },
     { "from": "cloudflare", "to": "context-forge", "protocol": "https" },
     { "from": "cloudflare", "to": "agent-platform", "protocol": "https" },
-    { "from": "monolith", "to": "postgres", "protocol": "sql" },
-    { "from": "monolith", "to": "nats", "protocol": "nats" },
+    { "from": "monolith", "to": "postgres", "protocol": "sql", "bidi": true },
     { "from": "monolith", "to": "context-forge", "protocol": "grpc" },
     { "from": "monolith", "to": "llama-cpp", "protocol": "http" },
     { "from": "monolith", "to": "voyage-embedder", "protocol": "http" },
-    { "from": "nats", "to": "agent-platform", "protocol": "nats" },
+    {
+      "from": "nats",
+      "to": "agent-platform",
+      "protocol": "nats",
+      "bidi": true
+    },
     { "from": "agent-platform", "to": "context-forge", "protocol": "grpc" },
     { "from": "context-forge", "to": "k8s-mcp", "protocol": "mcp" },
     { "from": "context-forge", "to": "argocd-mcp", "protocol": "mcp" },

--- a/projects/monolith/frontend/src/routes/public/observability-demo/topology.json
+++ b/projects/monolith/frontend/src/routes/public/observability-demo/topology.json
@@ -1,0 +1,334 @@
+{
+  "nodes": [
+    {
+      "id": "cloudflare",
+      "label": "CLOUDFLARE",
+      "tier": "ingress",
+      "status": "healthy",
+      "description": "tunnel + gateway",
+      "brief": "14.2k req/24h",
+      "metrics": [
+        { "k": "tunnel", "v": "connected" },
+        { "k": "requests 24h", "v": "14.2k" },
+        { "k": "cached", "v": "62%" }
+      ]
+    },
+    {
+      "id": "monolith",
+      "label": "MONOLITH",
+      "tier": "critical",
+      "ingress": true,
+      "status": "healthy",
+      "description": "fastapi + sveltekit",
+      "brief": "99.97% · 12.5 rps",
+      "slo": { "target": 99.9, "current": 99.97 },
+      "budget": {
+        "consumed": 28,
+        "elapsed": 40,
+        "remaining": "31.1 min",
+        "window": "30d"
+      },
+      "latency": { "p99": 42, "target": 200, "unit": "ms" },
+      "metrics": [
+        { "k": "rps", "v": "12.5" },
+        { "k": "error rate", "v": "0.02%" },
+        { "k": "p99", "v": "42ms" }
+      ],
+      "spark": [
+        38, 42, 45, 41, 39, 44, 42, 40, 43, 41, 38, 42, 47, 44, 42, 39, 41, 43,
+        42, 40, 38, 41, 43, 42
+      ]
+    },
+    {
+      "id": "postgres",
+      "label": "POSTGRES",
+      "tier": "critical",
+      "status": "healthy",
+      "description": "cnpg + pgvector",
+      "brief": "100% · 8ms p99",
+      "slo": { "target": 99.95, "current": 100 },
+      "budget": {
+        "consumed": 0,
+        "elapsed": 40,
+        "remaining": "21.6 min",
+        "window": "30d"
+      },
+      "latency": { "p99": 8, "target": 50, "unit": "ms" },
+      "metrics": [
+        { "k": "connections", "v": "12 / 100" },
+        { "k": "query p99", "v": "8ms" },
+        { "k": "storage", "v": "2.1 GiB" }
+      ],
+      "spark": [
+        6, 7, 8, 7, 6, 8, 7, 7, 8, 7, 6, 7, 9, 8, 7, 6, 7, 8, 7, 7, 6, 7, 8, 7
+      ]
+    },
+    {
+      "id": "nats",
+      "label": "NATS",
+      "tier": "critical",
+      "status": "healthy",
+      "description": "jetstream message bus",
+      "brief": "100% · 45 msg/s",
+      "slo": { "target": 99.99, "current": 100 },
+      "budget": {
+        "consumed": 0,
+        "elapsed": 40,
+        "remaining": "4.3 min",
+        "window": "30d"
+      },
+      "metrics": [
+        { "k": "msg/s", "v": "45" },
+        { "k": "consumers", "v": "3" },
+        { "k": "lag", "v": "0" }
+      ],
+      "spark": [
+        40, 42, 48, 45, 43, 47, 44, 41, 46, 43, 42, 45, 50, 47, 44, 42, 45, 48,
+        44, 43, 41, 44, 46, 45
+      ]
+    },
+    {
+      "id": "context-forge",
+      "label": "CONTEXT FORGE",
+      "tier": "critical",
+      "ingress": true,
+      "status": "healthy",
+      "description": "mcp gateway",
+      "brief": "99.98% · 8 rps",
+      "slo": { "target": 99.9, "current": 99.98 },
+      "budget": {
+        "consumed": 12,
+        "elapsed": 40,
+        "remaining": "38.2 min",
+        "window": "30d"
+      },
+      "latency": { "p99": 180, "target": 500, "unit": "ms" },
+      "metrics": [
+        { "k": "rps", "v": "8" },
+        { "k": "mcp servers", "v": "3" },
+        { "k": "p99", "v": "180ms" }
+      ],
+      "spark": [
+        120, 140, 180, 160, 150, 170, 190, 165, 155, 175, 145, 160, 185, 170,
+        160, 150, 165, 180, 160, 155, 140, 160, 175, 165
+      ]
+    },
+    {
+      "id": "agent-platform",
+      "label": "AGENT PLATFORM",
+      "tier": "critical",
+      "ingress": true,
+      "status": "degraded",
+      "description": "orchestrator + mcp clients",
+      "brief": "99.31% · 2 active",
+      "slo": { "target": 99.5, "current": 99.31 },
+      "budget": {
+        "consumed": 138,
+        "elapsed": 40,
+        "remaining": "0 min",
+        "window": "30d"
+      },
+      "latency": { "p99": 890, "target": 500, "unit": "ms" },
+      "metrics": [
+        { "k": "active jobs", "v": "2" },
+        { "k": "completed 24h", "v": "47" },
+        { "k": "mcp servers", "v": "4" }
+      ],
+      "spark": [
+        420, 510, 680, 890, 750, 820, 940, 870, 780, 910, 850, 720, 880, 930,
+        810, 760, 890, 950, 870, 820, 780, 850, 910, 890
+      ]
+    },
+    {
+      "id": "llama-cpp",
+      "label": "LLAMA.CPP",
+      "tier": "critical",
+      "status": "healthy",
+      "description": "gemma 4 inference",
+      "brief": "99.9% · 1.2 rps",
+      "slo": { "target": 99.5, "current": 99.9 },
+      "latency": { "p99": 2400, "target": 5000, "unit": "ms" },
+      "metrics": [
+        { "k": "model", "v": "gemma-4" },
+        { "k": "rps", "v": "1.2" },
+        { "k": "vram", "v": "18.4 / 24 GiB" }
+      ],
+      "spark": [
+        1800, 2100, 2400, 2200, 1900, 2300, 2600, 2400, 2100, 2500, 2300, 2000,
+        2400, 2700, 2300, 2100, 2400, 2500, 2200, 2000, 1900, 2200, 2400, 2300
+      ]
+    },
+    {
+      "id": "voyage-embedder",
+      "label": "VOYAGE EMBEDDER",
+      "tier": "critical",
+      "status": "healthy",
+      "description": "voyage-4 embedding",
+      "brief": "100% · 3.1 rps",
+      "slo": { "target": 99.9, "current": 100 },
+      "latency": { "p99": 85, "target": 200, "unit": "ms" },
+      "metrics": [
+        { "k": "model", "v": "voyage-4" },
+        { "k": "rps", "v": "3.1" },
+        { "k": "vram", "v": "5.8 / 6.2 GiB" }
+      ],
+      "spark": [
+        60, 70, 85, 75, 65, 80, 90, 80, 70, 85, 75, 65, 80, 95, 80, 70, 85, 90,
+        75, 70, 65, 75, 85, 80
+      ]
+    },
+    {
+      "id": "k8s-mcp",
+      "label": "K8S MCP",
+      "tier": "critical",
+      "status": "healthy",
+      "description": "kubernetes mcp server",
+      "brief": "healthy",
+      "metrics": [
+        { "k": "resources", "v": "pods, svc, deploy" },
+        { "k": "cluster", "v": "home-cluster" }
+      ]
+    },
+    {
+      "id": "argocd-mcp",
+      "label": "ARGOCD MCP",
+      "tier": "critical",
+      "status": "healthy",
+      "description": "argocd mcp server",
+      "brief": "healthy",
+      "metrics": [
+        { "k": "applications", "v": "14" },
+        { "k": "synced", "v": "14 / 14" }
+      ]
+    },
+    {
+      "id": "signoz-mcp",
+      "label": "SIGNOZ MCP",
+      "tier": "critical",
+      "status": "healthy",
+      "description": "signoz mcp server",
+      "brief": "healthy",
+      "metrics": [
+        { "k": "queries 24h", "v": "2.4k" },
+        { "k": "p99", "v": "120ms" }
+      ]
+    },
+    {
+      "id": "argocd",
+      "label": "ARGOCD",
+      "tier": "infra",
+      "status": "healthy",
+      "description": "gitops controller",
+      "brief": "14/14 synced",
+      "metrics": [
+        { "k": "applications", "v": "14" },
+        { "k": "synced", "v": "14 / 14" },
+        { "k": "last sync", "v": "12s ago" }
+      ]
+    },
+    {
+      "id": "signoz",
+      "label": "SIGNOZ",
+      "tier": "infra",
+      "status": "warning",
+      "description": "observability platform",
+      "brief": "99.84% · 450 spans/s",
+      "slo": { "target": 99.9, "current": 99.84 },
+      "budget": {
+        "consumed": 66,
+        "elapsed": 40,
+        "remaining": "14.7 min",
+        "window": "30d"
+      },
+      "latency": { "p99": 320, "target": 500, "unit": "ms" },
+      "metrics": [
+        { "k": "spans/s", "v": "450" },
+        { "k": "ingestion p99", "v": "320ms" },
+        { "k": "storage", "v": "82 / 150 GiB" }
+      ],
+      "spark": [
+        280, 310, 350, 320, 290, 340, 380, 320, 310, 340, 290, 300, 360, 340,
+        320, 300, 330, 350, 320, 310, 290, 320, 340, 320
+      ]
+    },
+    {
+      "id": "envoy-gateway",
+      "label": "ENVOY GATEWAY",
+      "tier": "infra",
+      "status": "healthy",
+      "description": "api gateway",
+      "brief": "healthy · 14.2k req/24h",
+      "metrics": [
+        { "k": "routes", "v": "8" },
+        { "k": "requests 24h", "v": "14.2k" },
+        { "k": "error rate", "v": "0.01%" }
+      ]
+    },
+    {
+      "id": "longhorn",
+      "label": "LONGHORN",
+      "tier": "infra",
+      "status": "healthy",
+      "description": "distributed storage",
+      "brief": "340 / 1000 GiB",
+      "metrics": [
+        { "k": "volumes", "v": "8" },
+        { "k": "replicas", "v": "healthy" },
+        { "k": "used", "v": "340 / 1000 GiB" }
+      ]
+    },
+    {
+      "id": "seaweedfs",
+      "label": "SEAWEEDFS",
+      "tier": "infra",
+      "status": "healthy",
+      "description": "object storage",
+      "brief": "healthy · 28 GiB",
+      "metrics": [
+        { "k": "buckets", "v": "4" },
+        { "k": "objects", "v": "12.4k" },
+        { "k": "storage", "v": "28 GiB" }
+      ]
+    },
+    {
+      "id": "otel-operator",
+      "label": "OTEL OPERATOR",
+      "tier": "infra",
+      "status": "healthy",
+      "description": "opentelemetry operator",
+      "brief": "healthy · 3 collectors",
+      "metrics": [
+        { "k": "collectors", "v": "3" },
+        { "k": "pipelines", "v": "traces, metrics, logs" }
+      ]
+    },
+    {
+      "id": "linkerd",
+      "label": "LINKERD",
+      "tier": "infra",
+      "status": "healthy",
+      "description": "service mesh",
+      "brief": "healthy · 12 meshed",
+      "metrics": [
+        { "k": "meshed pods", "v": "12" },
+        { "k": "mtls", "v": "100%" },
+        { "k": "success rate", "v": "99.99%" }
+      ]
+    }
+  ],
+  "edges": [
+    { "from": "cloudflare", "to": "monolith", "protocol": "https" },
+    { "from": "cloudflare", "to": "context-forge", "protocol": "https" },
+    { "from": "cloudflare", "to": "agent-platform", "protocol": "https" },
+    { "from": "monolith", "to": "postgres", "protocol": "sql" },
+    { "from": "monolith", "to": "nats", "protocol": "nats" },
+    { "from": "monolith", "to": "context-forge", "protocol": "grpc" },
+    { "from": "monolith", "to": "llama-cpp", "protocol": "http" },
+    { "from": "monolith", "to": "voyage-embedder", "protocol": "http" },
+    { "from": "nats", "to": "agent-platform", "protocol": "nats" },
+    { "from": "agent-platform", "to": "context-forge", "protocol": "grpc" },
+    { "from": "context-forge", "to": "k8s-mcp", "protocol": "mcp" },
+    { "from": "context-forge", "to": "argocd-mcp", "protocol": "mcp" },
+    { "from": "context-forge", "to": "signoz-mcp", "protocol": "mcp" }
+  ]
+}


### PR DESCRIPTION
## Summary

- Replace hardcoded 9-node topology with 19-node config-driven DAG (`topology.json`) reflecting actual homelab architecture
- Auto-layout via dagre with manual infra tier positioning — no more hand-tuned coordinates
- Three tiers: Ingress (EXTERNAL), Critical Path (Cloudflare Tunnel, Monolith, Postgres, NATS, Context Forge, Agent Platform, Gemma 4, Voyage Embedder, MCP servers), Infrastructure (ArgoCD, SigNoz, Envoy Gateway, Longhorn, SeaweedFS, OTel Operator, Linkerd)
- Rough.js hand-drawn chevron arrowheads with staggered barb animation
- Bidirectional edge support (monolith ↔ postgres, nats ↔ agent-platform)
- Dark mode improvements: pure white borders, warm grey tooltip background, dark tooltip text
- Rounded stroke line caps/joins for natural hand-drawn feel
- EXTERNAL → CLOUDFLARE TUNNEL ingress flow showing sole entry point

## Test plan

- [ ] Verify topology renders correctly in both landscape and portrait orientations
- [ ] Verify draw animation plays through cleanly (nodes, edges, arrowheads in sequence)
- [ ] Verify dark mode toggle doesn't re-trigger animation
- [ ] Verify node hover/select dims unconnected edges and highlights connected ones
- [ ] Verify bidirectional edges show arrowheads on both ends
- [ ] Verify infra tier renders as compact row below critical path

🤖 Generated with [Claude Code](https://claude.com/claude-code)