### PR TITLE
feat(observability-demo): add hierarchical topology groups

### DIFF
--- a/docs/plans/2026-04-12-topology-groups-design.md
+++ b/docs/plans/2026-04-12-topology-groups-design.md
@@ -1,0 +1,91 @@
+# Topology Groups (Buckets) Design
+
+## Problem
+
+The observability demo renders all services as flat peer nodes. This doesn't capture:
+
+- Sub-services within the monolith (home, knowledge, chat)
+- MCP server types hosted inside Context Forge
+
+## Solution
+
+Add hierarchical groups to the topology. A group is a visual boundary (rough.js rectangle) containing child nodes.
+
+## Groups
+
+**MONOLITH** (critical, ingress) — children: HOME, KNOWLEDGE, CHAT
+**CONTEXT FORGE** (critical, ingress) — children: K8S, ARGOCD, SIGNOZ
+
+## New Node
+
+**DISCORD** — external-tier node representing the Discord API
+
+## Data Model
+
+New `groups` array in `topology.json`:
+
+```json
+{
+  "groups": [
+    {
+      "id": "monolith",
+      "label": "MONOLITH",
+      "children": ["home", "knowledge", "chat"],
+      ...metrics
+    },
+    {
+      "id": "context-forge",
+      "label": "CONTEXT FORGE",
+      "children": ["k8s-mcp", "argocd-mcp", "signoz-mcp"],
+      ...metrics
+    }
+  ]
+}
+```
+
+Children are full nodes in the `nodes` array. Edges reference child IDs directly.
+
+## Edge Map
+
+- cloudflare → home
+- cloudflare → knowledge
+- cloudflare → agent-platform
+- home → postgres
+- knowledge → postgres
+- knowledge → voyage-embedder
+- knowledge → llama-cpp (gemma 4)
+- chat → llama-cpp (gemma 4)
+- chat → discord
+- nats ↔ agent-platform
+- agent-platform → context-forge (group boundary)
+- context-forge internal: k8s, argocd, signoz (MCP servers)
+
+## Layout
+
+Dagre compound graphs via `g.setParent(childId, groupId)`. Group nodes get extra padding so dagre leaves room for the boundary. Children positioned inside automatically.
+
+## Rendering
+
+- **Group boundary:** Rough.js rectangle around children's bounding box + padding
+- **Group label:** Top-left corner, smaller/lighter weight
+- **Tier fill:** Same tier color at ~30% opacity (subtle wash)
+- **Child nodes:** Full rough.js rectangles as today
+
+## Animation Sequence
+
+1. BFS proceeds normally — child nodes draw individually (pencil → ink → fill → text)
+2. Edges pierce through group boundary to connect directly to children
+3. After ALL children in a group complete their ink phase, group boundary animates:
+   - Pencil sketch of boundary (sequential sides)
+   - Ink retrace follows
+   - Group label jots in
+   - Subtle fill wash fades in
+
+## Detail Drawer
+
+- Click group boundary → aggregate group metrics
+- Click child → child metrics with "part of: GROUP" breadcrumb
+
+## Label Simplification
+
+MCP server children use short labels (K8S, ARGOCD, SIGNOZ) since the group label provides context.

--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -27,7 +27,8 @@ exec_filegroup(
 
 py_venv_binary(
     name = "main",
-    srcs = glob(  # keep
+    srcs = glob(
+        # keep
         [
             "app/**/*.py",
             "chat/**/*.py",
@@ -47,7 +48,8 @@ py_venv_binary(
 
 py_library(
     name = "monolith_backend",
-    srcs = glob(  # keep
+    srcs = glob(
+        # keep
         [
             "app/**/*.py",
             "chat/**/*.py",

--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -27,8 +27,7 @@ exec_filegroup(
 
 py_venv_binary(
     name = "main",
-    srcs = glob(
-        # keep
+    srcs = glob(  # keep
         [
             "app/**/*.py",
             "chat/**/*.py",
@@ -48,8 +47,7 @@ py_venv_binary(
 
 py_library(
     name = "monolith_backend",
-    srcs = glob(
-        # keep
+    srcs = glob(  # keep
         [
             "app/**/*.py",
             "chat/**/*.py",

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.40.0
+version: 0.40.1
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.39.0
+version: 0.40.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.39.0
+      targetRevision: 0.40.0
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.40.0
+      targetRevision: 0.40.1
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/routes/public/observability-demo/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/observability-demo/+page.svelte
@@ -11,7 +11,18 @@
   const portLayout = computeLayout(topology, "TB");
 
   // ── Service data (from config) ─────────────
-  const svc = Object.fromEntries(topology.nodes.map((n) => [n.id, n]));
+  const svc = Object.fromEntries([
+    ...topology.nodes.map((n) => [n.id, n]),
+    ...(topology.groups || []).map((g) => [g.id, g]),
+  ]);
+
+  // ── Group lookups ─────────────────────────
+  const groupDefs = topology.groups || [];
+  const childToGroup = {};
+  for (const g of groupDefs) {
+    for (const cid of g.children) childToGroup[cid] = g.id;
+  }
+  const groupChildIds = new Set(Object.keys(childToGroup));
 
   // ── State ──────────────────────────────────
   let selected = $state(null);
@@ -31,7 +42,9 @@
   let drawerBorderSvg = $state(null);
   let drawerBorderG = $state(null);
   let hoverBorderG = $state(null);
+  let groupLabelBorderG = $state(null);
   let roughArrows = $state(null);
+  let roughGroups = $state(null);
   let mapPanG = $state(null);
   const active = $derived(hovered || selected);
 
@@ -95,6 +108,8 @@
   const nodes = $derived(activeLayout ? portLayout.nodes : landLayout.nodes);
   const edges = $derived(activeLayout ? portLayout.edges : landLayout.edges);
   const nodeById = $derived(activeLayout ? portLayout.nodeById : landLayout.nodeById);
+  const groups = $derived(activeLayout ? portLayout.groups : landLayout.groups);
+  const groupById = $derived(activeLayout ? portLayout.groupById : landLayout.groupById);
 
   let flipPhase = $state("none");   // "none" | "out" | "in"
   let scribbling = $state(false);   // true during scribble-out + fade
@@ -233,6 +248,12 @@
       maxX = Math.max(maxX, n.x + n.hw + 20);
       maxY = Math.max(maxY, n.y + HH + 20);
     }
+    for (const g of layout.groups || []) {
+      minX = Math.min(minX, g.bounds.minX - 10);
+      minY = Math.min(minY, g.bounds.minY - 10);
+      maxX = Math.max(maxX, g.bounds.maxX + 10);
+      maxY = Math.max(maxY, g.bounds.maxY + 10);
+    }
     const pad = 40;
     return `${minX - pad} ${minY - pad} ${maxX - minX + pad * 2} ${maxY - minY + pad * 2}`;
   });
@@ -275,14 +296,45 @@
   function isHighlighted(nodeId) {
     const src = hovered || selected;
     if (!src) return true;
-    return nodeId === src;
+    if (nodeId === src) return true;
+    // Selecting a group highlights its children and their edge-connected nodes
+    const srcGroup = groupDefs.find((g) => g.id === src);
+    if (srcGroup) {
+      if (srcGroup.children.includes(nodeId)) return true;
+      // Check if nodeId is connected via edge to any child
+      const childSet = new Set(srcGroup.children);
+      for (const e of edges) {
+        if (childSet.has(e.from) && e.to === nodeId) return true;
+        if (childSet.has(e.to) && e.from === nodeId) return true;
+      }
+      // Check if nodeId is a group that contains an edge-connected node
+      const grp = groupDefs.find((g) => g.id === nodeId);
+      if (grp) {
+        for (const cid of grp.children) {
+          for (const e of edges) {
+            if (childSet.has(e.from) && e.to === cid) return true;
+            if (childSet.has(e.to) && e.from === cid) return true;
+          }
+        }
+      }
+    }
+    // Selecting a child highlights its group
+    if (childToGroup[src] === nodeId) return true;
+    // Selecting a child highlights siblings
+    if (childToGroup[nodeId] && childToGroup[nodeId] === childToGroup[src]) return true;
+    return false;
   }
 
   function nodeDrawn(id) {
     if (!drawing) return true;
     if (!drawStartTime) return false;
     const elapsed = (performance.now() - drawStartTime) / 1000;
-    return elapsed >= animDelay.node[id].box;
+    // For groups, interactive once the fill + text are both complete
+    const ga = animDelay.group?.[id];
+    if (ga) return elapsed >= ga.text + ga.textDur;
+    const a = animDelay.node[id];
+    if (!a) return true;
+    return elapsed >= a.text;
   }
 
   function selectNode(id) {
@@ -357,12 +409,18 @@
     const __nodes = _nodes;
     const __edges = _edges;
     const __nodeById = _nodeById;
+    const __groupById = activeLayout ? portLayout.groupById : landLayout.groupById;
+    const __lookup = (id) => __nodeById[id] || __groupById[id];
 
     const adj = {};
     __nodes.forEach((n) => (adj[n.id] = []));
+    // Also add group IDs as valid adjacency entries
+    for (const g of groupDefs) adj[g.id] = [];
     __edges.forEach((e) => {
-      adj[e.from].push({ nb: e.to, edge: e });
-      adj[e.to].push({ nb: e.from, edge: e });
+      if (adj[e.from] && adj[e.to]) {
+        adj[e.from].push({ nb: e.to, edge: e });
+        adj[e.to].push({ nb: e.from, edge: e });
+      }
     });
 
     function textDur(s) {
@@ -383,6 +441,7 @@
 
     // Edge duration scales with actual distance between nodes
     function edgeDur(from, to, key) {
+      if (!from || !to) return MIN_EDGE_DUR;
       const dist = Math.sqrt((from.x - to.x) ** 2 + (from.y - to.y) ** 2);
       return Math.max(MIN_EDGE_DUR, (dist / EDGE_PEN_SPEED) * jitter(key));
     }
@@ -394,7 +453,9 @@
       const dx = fromX - n.x;
       const dy = fromY - n.y;
       if (dx === 0 && dy === 0) return 0;
-      const w = n.hw * 2 + 12, h = HH * 2 + 6;
+      const isGrp = !!__groupById[n.id];
+      const w = isGrp ? n.hw * 2 : n.hw * 2 + 12;
+      const h = isGrp ? n.hh * 2 : HH * 2 + 6;
       // Normalize by half-dimensions so rectangles behave like squares
       const sx = Math.abs(dx) / (w / 2);
       const sy = Math.abs(dy) / (h / 2);
@@ -420,7 +481,8 @@
     // Schedule a node's pencil box. Returns pencil cursor after box completes.
     function scheduleNode(c, item) {
       const { id, fromX, fromY } = item;
-      const n = __nodeById[id];
+      const n = __lookup(id);
+      if (!n) return c;
       const side = arrivalSide(n, fromX, fromY);
       const sides = boxSideDurs(n);
       const bDur = sides.reduce((a, b) => a + b, 0);
@@ -448,8 +510,8 @@
     function scheduleEdge(pencilStart, parentId, edge, siblingIdx) {
       const key = edge.from + "-" + edge.to;
       edDir[key] = edge.from === parentId;
-      const from = __nodeById[edge.from];
-      const to = __nodeById[edge.to];
+      const from = __lookup(edge.from);
+      const to = __lookup(edge.to);
       const eDur = edgeDur(from, to, key);
 
       // Ink line waits for: parent's ink box + stagger, AND pencil line to complete + pause
@@ -469,7 +531,8 @@
 
     // Collect unvisited children
     function collectChildren(item) {
-      const n = __nodeById[item.id];
+      const n = __lookup(item.id);
+      if (!n) return [];
       const children = [];
       let sibIdx = 0;
       for (const { nb: nbId, edge } of adj[item.id]) {
@@ -488,7 +551,7 @@
       return scheduleNode(c, item);
     }
 
-    let batch = [{ id: "external", fromX: 0, fromY: __nodeById["external"]?.y ?? 240, viaEdge: null, parentId: null }];
+    let batch = [{ id: "external", fromX: 0, fromY: __lookup("external")?.y ?? 240, viaEdge: null, parentId: null }];
     let cursor = 0.2;
 
     while (batch.length > 0) {
@@ -523,7 +586,7 @@
     __edges.forEach((e) => {
       const key = e.from + "-" + e.to;
       if (ed[key]) return;
-      const eDur = edgeDur(__nodeById[e.from], __nodeById[e.to], key);
+      const eDur = edgeDur(__lookup(e.from), __lookup(e.to), key);
       const fromDone = (nd[e.from]?.box ?? 0) + (nd[e.from]?.boxDur ?? 0);
       const toDone = (nd[e.to]?.box ?? 0) + (nd[e.to]?.boxDur ?? 0);
       edDir[key] = fromDone <= toDone;
@@ -535,26 +598,63 @@
     });
 
     // Schedule unvisited nodes (infra tier — no edges from critical path)
-    // Sort left-to-right (by x) and stagger from the start of the animation
-    // so they draw concurrently with the critical path
+    // Single cursor fills left-to-right sequentially
     const unvisited = __nodes
       .filter((n) => !visited.has(n.id))
       .sort((a, b) => a.x - b.x);
     if (unvisited.length > 0) {
-      const infraStart = 0.8; // start shortly after cloudflare
-      const infraSpacing = 0.4; // seconds between each infra node
-      unvisited.forEach((n, i) => {
+      let infraCursor = 0.8; // start shortly after cloudflare
+      unvisited.forEach((n) => {
         visited.add(n.id);
-        const t = infraStart + i * infraSpacing * jitter(n.id + "infra");
-        scheduleNode(t, { id: n.id, fromX: n.x, fromY: n.y - 80 });
+        infraCursor = scheduleNode(infraCursor, { id: n.id, fromX: n.x, fromY: n.y - 80 });
+        infraCursor += TRAVEL_PAUSE * 0.5; // brief pause between infra nodes
       });
+    }
+
+    // Schedule group boundaries — draw after all children complete their ink phase
+    const gd = {};
+    for (const group of groupDefs) {
+      let latestChildInkDone = 0;
+      for (const cid of group.children) {
+        if (nd[cid]) {
+          const childDone = nd[cid].inkBox + nd[cid].inkBoxDur;
+          latestChildInkDone = Math.max(latestChildInkDone, childDone);
+        }
+      }
+      const gStart = latestChildInkDone + TRAVEL_PAUSE;
+      // Group boundary is larger — estimate perimeter for timing
+      const gNode = groups.find((g) => g.id === group.id);
+      if (!gNode) continue;
+      const perim = (gNode.hw + gNode.hh) * 4;
+      const gSides = [
+        Math.max(MIN_SIDE_DUR, (gNode.hw * 2 / BOX_PEN_SPEED) * jitter(group.id + "top")),
+        Math.max(MIN_SIDE_DUR, (gNode.hh * 2 / BOX_PEN_SPEED) * jitter(group.id + "right")),
+        Math.max(MIN_SIDE_DUR, (gNode.hw * 2 / BOX_PEN_SPEED) * jitter(group.id + "bottom")),
+        Math.max(MIN_SIDE_DUR, (gNode.hh * 2 / BOX_PEN_SPEED) * jitter(group.id + "left")),
+      ];
+      const gDur = gSides.reduce((a, b) => a + b, 0);
+      const tDur = textDur(group.label);
+      gd[group.id] = {
+        box: gStart,
+        boxSides: gSides,
+        boxStartSide: 0,
+        boxDur: gDur,
+        inkBox: gStart + gDur,
+        inkBoxDur: gDur * INK_SPEED,
+        inkBoxSides: gSides.map((d) => d * INK_SPEED),
+        fill: gStart + gDur + gDur * INK_SPEED,
+        fillDur: 0.35,
+        text: gStart + gDur + gDur * INK_SPEED + 0.1,
+        textDur: tDur,
+      };
     }
 
     let maxT = 0;
     for (const v of Object.values(nd)) maxT = Math.max(maxT, v.inkBox + v.inkBoxDur);
     for (const v of Object.values(ed)) maxT = Math.max(maxT, v.inkLine + v.inkLineDur);
+    for (const v of Object.values(gd)) maxT = Math.max(maxT, v.inkBox + v.inkBoxDur);
 
-    return { node: nd, edge: ed, edgeDir: edDir, totalDur: maxT + 0.5 };
+    return { node: nd, edge: ed, edgeDir: edDir, group: gd, totalDur: maxT + 0.5 };
   });
 
   // ── Draw topology ──────────────────────────
@@ -563,7 +663,7 @@
   // that updates opacity on existing elements, allowing CSS transitions to work.
   let hasAnimated = false;
   $effect(() => {
-    if (!mapSvg || !roughEdges || !roughNodes || !roughArrows) return;
+    if (!mapSvg || !roughEdges || !roughNodes || !roughArrows || !roughGroups) return;
     const _layout = activeLayout;
     const _gen = drawGen; // bump to force redraw after flip
 
@@ -572,6 +672,7 @@
     clearChildren(roughEdges);
     clearChildren(roughNodes);
     clearChildren(roughArrows);
+    clearChildren(roughGroups);
     const shouldAnimate = !hasAnimated;
 
     // Helper: draw a hand-drawn chevron arrowhead (two rough lines forming a ">")
@@ -625,12 +726,15 @@
     edges.forEach((e) => {
       const key = e.from + "-" + e.to;
 
-      const fromPos = getNodePos(e.from);
-      const toPos = getNodePos(e.to);
-      const fromNode = nodeById[e.from];
-      const toNode = nodeById[e.to];
-      const p1 = boxExit(fromPos.x, fromPos.y, fromNode.hw + 6, HH + 4, toPos.x, toPos.y);
-      const p2 = boxExit(toPos.x, toPos.y, toNode.hw + 6, HH + 4, fromPos.x, fromPos.y);
+      const fromPos = getNodePos(e.from) || groupById[e.from];
+      const toPos = getNodePos(e.to) || groupById[e.to];
+      if (!fromPos || !toPos) return;
+      const fromNode = nodeById[e.from] || groupById[e.from];
+      const toNode = nodeById[e.to] || groupById[e.to];
+      const fromIsGroup = !!groupById[e.from];
+      const toIsGroup = !!groupById[e.to];
+      const p1 = boxExit(fromPos.x, fromPos.y, (fromIsGroup ? fromNode.hw : fromNode.hw + 6), (fromIsGroup ? fromNode.hh : HH + 4), toPos.x, toPos.y);
+      const p2 = boxExit(toPos.x, toPos.y, (toIsGroup ? toNode.hw : toNode.hw + 6), (toIsGroup ? toNode.hh : HH + 4), fromPos.x, fromPos.y);
 
       // Draw line from BFS-earlier node toward BFS-later node
       const fwd = animDelay.edgeDir[key];
@@ -714,8 +818,8 @@
         // Arrowheads: draw in after edge ink + target node ink both complete
         const edgeInkDone = anim.inkLine + anim.inkLineDur;
         // Find when the "to" node's ink box finishes (if it has anim data)
-        const toNodeAnim = animDelay.node[fwd ? e.to : e.from];
-        const fromNodeAnim = animDelay.node[fwd ? e.from : e.to];
+        const toNodeAnim = animDelay.node[fwd ? e.to : e.from] || animDelay.group?.[fwd ? e.to : e.from];
+        const fromNodeAnim = animDelay.node[fwd ? e.from : e.to] || animDelay.group?.[fwd ? e.from : e.to];
         const toInkDone = toNodeAnim ? toNodeAnim.inkBox + toNodeAnim.inkBoxDur : 0;
         const arrowStart = Math.max(edgeInkDone, toInkDone);
         const arrowDur = 0.375;
@@ -753,12 +857,19 @@
       const pos = getNodePos(n.id);
       const w = n.hw * 2 + 12;
       const h = HH * 2 + 6;
-      const inkCol = n.status === "degraded" ? c.danger : n.status === "warning" ? c.warn : c.borderInk;
+      // Nodes inside groups: during animation, draw with theme colors then flip when group fill appears.
+      // When not animating, use dark strokes immediately since group fill is already visible.
+      const inGroup = !!childToGroup[n.id];
+      const LIGHT_BORDER = "#1a1a1a";
+      const useGroupColors = inGroup && !shouldAnimate;
+      const pencilCol = useGroupColors ? LIGHT_BORDER : c.border;
+      const inkCol = n.status === "degraded" ? c.danger : n.status === "warning" ? c.warn : (useGroupColors ? LIGHT_BORDER : c.borderInk);
       const r = nodeRoughness(n.status);
       const bow = n.status === "warning" ? 1.2 : 0.5;
 
       const g = document.createElementNS("http://www.w3.org/2000/svg", "g");
       g.dataset.node = n.id;
+      g.dataset.inGroup = inGroup ? "true" : "";
       g.style.transition = "opacity 0.25s ease";
 
       // Solid fill — starts transparent, scrubs in after ink outline completes
@@ -807,7 +918,7 @@
 
         // Pencil sketch
         const pencil = rc.line(side.from[0], side.from[1], side.to[0], side.to[1], {
-          stroke: c.border,
+          stroke: pencilCol,
           roughness: r,
           bowing: bow,
           strokeWidth: 1.0,
@@ -871,6 +982,130 @@
       roughNodes.appendChild(g);
     });
 
+    // ── Draw group boundaries ────────────────
+    groups.forEach((grp) => {
+      const anim = shouldAnimate ? animDelay.group[grp.id] : null;
+      const b = grp.bounds;
+      const w = b.maxX - b.minX;
+      const h = b.maxY - b.minY;
+      const g = document.createElementNS("http://www.w3.org/2000/svg", "g");
+      g.dataset.group = grp.id;
+      g.style.transition = "opacity 0.25s ease";
+
+      // Fill — always warm cream so child labels stay high-contrast black-on-light
+      const GROUP_FILL = "#f5f0e8";
+      const fillEl = rc.rectangle(b.minX, b.minY, w, h, {
+        stroke: "none", fill: GROUP_FILL, fillStyle: "solid",
+        roughness: 0.6, seed: seed(grp.id + "grp-fill"),
+      });
+      fillEl.dataset.layer = "fill";
+      fillEl.style.opacity = shouldAnimate ? "0" : "1";
+      g.appendChild(fillEl);
+
+      // 4 sequential border strokes (same pattern as node boxes)
+      const x1 = b.minX, y1 = b.minY;
+      const x2 = b.maxX, y2 = b.maxY;
+      const allSides = [
+        { from: [x1, y1], to: [x2, y1], key: "top" },
+        { from: [x2, y1], to: [x2, y2], key: "right" },
+        { from: [x2, y2], to: [x1, y2], key: "bottom" },
+        { from: [x1, y2], to: [x1, y1], key: "left" },
+      ];
+
+      const pencilDurs = anim ? anim.boxSides : null;
+      const inkDurs = anim ? anim.inkBoxSides : null;
+      let pencilOffset = 0;
+      let inkOffset = 0;
+
+      allSides.forEach((side, i) => {
+        const sideSeed = seed(grp.id + side.key + "grp");
+
+        const pencil = rc.line(side.from[0], side.from[1], side.to[0], side.to[1], {
+          stroke: "#c0b8a8", roughness: 1.2, bowing: 1.0,
+          strokeWidth: 1.0, seed: sideSeed,
+        });
+        pencil.style.opacity = "0.5";
+        pencil.dataset.layer = "pencil";
+
+        const ink = rc.line(side.from[0], side.from[1], side.to[0], side.to[1], {
+          stroke: "#8a8070", roughness: 1.2, bowing: 1.0,
+          strokeWidth: 1.8, seed: sideSeed + 7,
+        });
+        ink.dataset.layer = "ink";
+
+        if (anim) {
+          const pencilStart = anim.box + pencilOffset;
+          const pDur = pencilDurs[i];
+          pencil.querySelectorAll("path").forEach((path) => {
+            try {
+              const len = path.getTotalLength();
+              path.style.strokeDasharray = String(len);
+              path.style.strokeDashoffset = String(len);
+              path.style.animation = `edgeDraw ${pDur.toFixed(3)}s ${PEN_EASE} ${pencilStart.toFixed(3)}s forwards`;
+            } catch {
+              path.style.opacity = "0";
+              path.style.animation = `nodeIn 0.15s ease ${pencilStart.toFixed(3)}s forwards`;
+            }
+          });
+          pencilOffset += pDur;
+
+          const inkStart = anim.inkBox + inkOffset;
+          const iDur = inkDurs[i];
+          ink.querySelectorAll("path").forEach((path) => {
+            try {
+              const len = path.getTotalLength();
+              path.style.strokeDasharray = String(len);
+              path.style.strokeDashoffset = String(len);
+              path.style.animation = `edgeDraw ${iDur.toFixed(3)}s ${PEN_EASE} ${inkStart.toFixed(3)}s forwards`;
+            } catch {
+              path.style.opacity = "0";
+              path.style.animation = `nodeIn 0.15s ease ${inkStart.toFixed(3)}s forwards`;
+            }
+          });
+          inkOffset += iDur;
+        }
+        g.appendChild(pencil);
+        g.appendChild(ink);
+      });
+
+      // Animate fill scrub — use groupFillIn which targets 0.25 opacity
+      if (anim) {
+        fillEl.style.animation = `groupFillIn ${anim.fillDur.toFixed(3)}s ease-out ${anim.fill.toFixed(3)}s forwards`;
+      }
+
+      roughGroups.appendChild(g);
+    });
+
+    // When group fill fades in, transition child node strokes from theme → dark
+    if (shouldAnimate && roughNodes) {
+      const LIGHT_BORDER = "#1a1a1a";
+      for (const group of groupDefs) {
+        const gAnim = animDelay.group[group.id];
+        if (!gAnim) continue;
+        const flipTime = gAnim.fill * 1000; // ms — when group fill starts
+        const flipDur = gAnim.fillDur; // seconds — match fill duration
+        for (const cid of group.children) {
+          const el = roughNodes.querySelector(`[data-node="${cid}"]`);
+          if (!el) continue;
+          // Set CSS transition on stroke, then flip after delay
+          setTimeout(() => {
+            el.querySelectorAll("[data-layer='pencil'] path").forEach((p) => {
+              p.style.transition = `stroke ${flipDur}s ease`;
+              p.setAttribute("stroke", LIGHT_BORDER);
+            });
+            el.querySelectorAll("[data-layer='ink'] path").forEach((p) => {
+              // Keep status colors (degraded/warning), only flip normal ink
+              const n = nodeById[cid];
+              if (n && n.status !== "degraded" && n.status !== "warning") {
+                p.style.transition = `stroke ${flipDur}s ease`;
+                p.setAttribute("stroke", LIGHT_BORDER);
+              }
+            });
+          }, flipTime);
+        }
+      }
+    }
+
     if (shouldAnimate) {
       hasAnimated = true;
       drawStartTime = performance.now();
@@ -902,15 +1137,41 @@
     }
     // Recolor nodes
     if (roughNodes) {
+      const elapsed = drawStartTime ? (performance.now() - drawStartTime) / 1000 : Infinity;
       roughNodes.querySelectorAll("[data-node]").forEach((g) => {
         const id = g.dataset.node;
         const n = nodeById[id];
-        const inkCol = n.status === "degraded" ? c.danger : n.status === "warning" ? c.warn : c.borderInk;
-        g.querySelectorAll("[data-layer='pencil'] path").forEach((p) => { p.setAttribute("stroke", c.border); });
+        const inGroup = g.dataset.inGroup === "true";
+        const LIGHT_BORDER = "#1a1a1a";
+        // During animation, only use dark strokes if the group fill has already appeared
+        let groupFillVisible = !drawing; // post-animation: fill is visible
+        if (inGroup && drawing) {
+          const gid = childToGroup[id];
+          const gAnim = animDelay.group?.[gid];
+          groupFillVisible = gAnim ? elapsed >= gAnim.fill : false;
+        }
+        const useDark = inGroup && groupFillVisible;
+        const inkCol = n.status === "degraded" ? c.danger : n.status === "warning" ? c.warn : (useDark ? LIGHT_BORDER : c.borderInk);
+        const pencilCol = useDark ? LIGHT_BORDER : c.border;
+        g.querySelectorAll("[data-layer='pencil'] path").forEach((p) => { p.setAttribute("stroke", pencilCol); });
         g.querySelectorAll("[data-layer='ink'] path").forEach((p) => { p.setAttribute("stroke", inkCol); });
         const fill = g.querySelector("[data-layer='fill']");
         if (fill) fill.querySelectorAll("path").forEach((p) => {
           p.setAttribute("fill", tierFill(n.tier, c));
+        });
+      });
+    }
+    // Recolor groups
+    if (roughGroups) {
+      roughGroups.querySelectorAll("[data-group]").forEach((g) => {
+        const gid = g.dataset.group;
+        const grp = groupById[gid];
+        if (!grp) return;
+        g.querySelectorAll("[data-layer='pencil'] path").forEach((p) => { p.setAttribute("stroke", "#c0b8a8"); });
+        g.querySelectorAll("[data-layer='ink'] path").forEach((p) => { p.setAttribute("stroke", "#8a8070"); });
+        const fill = g.querySelector("[data-layer='fill']");
+        if (fill) fill.querySelectorAll("path").forEach((p) => {
+          p.setAttribute("fill", "#f5f0e8");
         });
       });
     }
@@ -930,8 +1191,14 @@
     const connectedNodes = new Set();
     if (dimSource) {
       connectedNodes.add(dimSource);
+      // If source is a group, expand to include all children
+      const expandedSources = new Set([dimSource]);
+      const srcGroup = groupDefs.find((g) => g.id === dimSource);
+      if (srcGroup) {
+        srcGroup.children.forEach((cid) => { expandedSources.add(cid); connectedNodes.add(cid); });
+      }
       edges.forEach((e) => {
-        if (e.from === dimSource || e.to === dimSource) {
+        if (expandedSources.has(e.from) || expandedSources.has(e.to)) {
           connectedEdges.add(e.from + "-" + e.to);
           connectedNodes.add(e.from);
           connectedNodes.add(e.to);
@@ -973,6 +1240,50 @@
       const id = g.dataset.node;
       g.style.opacity = (!dimSource || connectedNodes.has(id)) ? "1" : "0.15";
     });
+
+    // Group label border: bottom + right lines matching group ink, only on focused group
+    if (groupLabelBorderG && mapSvg) {
+      clearChildren(groupLabelBorderG);
+      if (dimSource && groupById[dimSource] && nodeDrawn(dimSource)) {
+        const grp = groupById[dimSource];
+        const labelW = grp.label.length * 5.5 + 8;
+        const lx = grp.bounds.minX + 4;
+        const ly = grp.bounds.minY + 3;
+        const rx = lx + labelW;
+        const by = ly + 14;
+        const rc = rough.svg(mapSvg);
+        const lineOpts = { stroke: "#3a3530", roughness: 1.0, bowing: 0.8, strokeWidth: 1.8, seed: seed("lbl-" + dimSource) };
+        // Bottom edge: left to right
+        groupLabelBorderG.appendChild(rc.line(lx, by, rx, by, lineOpts));
+        // Right edge: top to bottom (connects to bottom)
+        groupLabelBorderG.appendChild(rc.line(rx, ly, rx, by, { ...lineOpts, seed: lineOpts.seed + 3 }));
+      }
+    }
+
+    // Groups: highlight if any child is connected, darken borders when focused
+    if (roughGroups) {
+      roughGroups.querySelectorAll("[data-group]").forEach((g) => {
+        const gid = g.dataset.group;
+        if (!dimSource) {
+          g.style.opacity = "1";
+          g.querySelectorAll("[data-layer='ink'] path").forEach((p) => { p.setAttribute("stroke", "#8a8070"); p.style.strokeWidth = ""; });
+          g.querySelectorAll("[data-layer='pencil'] path").forEach((p) => { p.setAttribute("stroke", "#c0b8a8"); });
+          return;
+        }
+        const grp = groupDefs.find((gr) => gr.id === gid);
+        const anyChildConnected = grp && grp.children.some((cid) => connectedNodes.has(cid));
+        const isActive = connectedNodes.has(gid) || anyChildConnected;
+        g.style.opacity = isActive ? "1" : "0.15";
+        if (isActive && gid === dimSource) {
+          // Darken borders for the focused group
+          g.querySelectorAll("[data-layer='ink'] path").forEach((p) => { p.setAttribute("stroke", "#3a3530"); p.style.strokeWidth = "2.5"; });
+          g.querySelectorAll("[data-layer='pencil'] path").forEach((p) => { p.setAttribute("stroke", "#6a6050"); });
+        } else {
+          g.querySelectorAll("[data-layer='ink'] path").forEach((p) => { p.setAttribute("stroke", "#8a8070"); p.style.strokeWidth = ""; });
+          g.querySelectorAll("[data-layer='pencil'] path").forEach((p) => { p.setAttribute("stroke", "#c0b8a8"); });
+        }
+      });
+    }
 
   });
 
@@ -1035,19 +1346,34 @@
   });
 
   function startScribble(target) {
-      const n = nodeById[target];
-      const pos = getNodePos(target);
+      const n = nodeById[target] || groupById[target];
+      const pos = getNodePos(target) || groupById[target];
+      if (!n || !pos) return;
       const rc = rough.svg(mapSvg);
+      const isGroup = !!groupById[target];
+
+      // For groups, scribble the group boundary; for nodes, scribble the node
       const pad = 20;
-      const hw = n.hw + 6 + pad;
-      const hh = HH + 3 + pad;
+      let scribbleHw, scribbleHh, scribbleCx, scribbleCy;
+      if (isGroup) {
+        const b = pos.bounds;
+        scribbleCx = (b.minX + b.maxX) / 2;
+        scribbleCy = (b.minY + b.maxY) / 2;
+        scribbleHw = (b.maxX - b.minX) / 2 + pad;
+        scribbleHh = (b.maxY - b.minY) / 2 + pad;
+      } else {
+        scribbleCx = pos.x;
+        scribbleCy = pos.y;
+        scribbleHw = n.hw + 6 + pad;
+        scribbleHh = HH + 3 + pad;
+      }
 
       // MotherDuck-inspired brutalist palette — vibrant everywhere
       const scribbleCol = n.status === "degraded"
         ? (isDark ? "#ff3333" : "#dc2626")
         : n.status === "warning"
           ? "#ff9500"
-          : (isDark ? "#7dd3fc" : "#38bdf8");
+          : (isDark ? "#c084fc" : "#9333ea");
 
       const wrap = document.createElementNS("http://www.w3.org/2000/svg", "g");
       wrap.dataset.node = target;
@@ -1055,36 +1381,32 @@
 
       function addScribbleBurst(batch, baseDelay) {
         const now = Date.now();
-        const linesPerBurst = 6;
+        // Scale density by area — a wide group needs more lines than a small node
+        const area = scribbleHw * scribbleHh * 4;
+        const baseArea = 60 * 40; // approximate single node area
+        const linesPerBurst = Math.min(24, Math.max(6, Math.round(6 * Math.sqrt(area / baseArea))));
+        const clusterSize = 2 + (seed(target + "cl" + batch + now) % 2); // 2-3 lines per cluster
         for (let i = 0; i < linesPerBurst; i++) {
           const idx = batch * linesPerBurst + i;
           const s = seed(target + "scr" + idx + now);
-          const jx = ((s % 80) - 40);
-          const jy = ((seed(target + "jy" + idx + now) % 60) - 30);
-          const direction = s % 5;
-
-          let x1, y1, x2, y2;
-          if (direction === 0) {
-            // diagonal TL→BR
-            x1 = pos.x - hw + jx; y1 = pos.y - hh + jy;
-            x2 = pos.x + hw + jx * 0.3; y2 = pos.y + hh + jy * 0.3;
-          } else if (direction === 1) {
-            // diagonal TR→BL
-            x1 = pos.x + hw + jx; y1 = pos.y - hh + jy;
-            x2 = pos.x - hw + jx * 0.3; y2 = pos.y + hh + jy * 0.3;
-          } else if (direction === 2) {
-            // horizontal
-            x1 = pos.x - hw + jx; y1 = pos.y + jy;
-            x2 = pos.x + hw + jx * 0.4; y2 = pos.y + jy * 0.6;
-          } else if (direction === 3) {
-            // vertical
-            x1 = pos.x + jx * 0.8; y1 = pos.y - hh + jy;
-            x2 = pos.x + jx * 0.5; y2 = pos.y + hh + jy * 0.3;
-          } else {
-            // steep diagonal
-            x1 = pos.x - hw * 0.6 + jx; y1 = pos.y - hh + jy;
-            x2 = pos.x + hw * 0.6 + jx * 0.2; y2 = pos.y + hh + jy * 0.2;
-          }
+          // Cluster lines share an angle — pick new angle every clusterSize lines
+          const clusterIdx = Math.floor(i / clusterSize);
+          const sAngle = seed(target + "ang" + clusterIdx + batch + now);
+          const angle = ((sAngle % 360) / 360) * Math.PI * 2;
+          // Small jitter within cluster so lines aren't perfectly parallel
+          const angleJitter = ((s % 20) - 10) / 180 * Math.PI; // ±10°
+          const finalAngle = angle + angleJitter;
+          const s2 = seed(target + "jy" + idx + now);
+          const offsetX = ((s2 % 100) - 50) / 50;
+          const offsetY = ((seed(target + "oz" + idx + now) % 100) - 50) / 50;
+          const cos = Math.cos(finalAngle), sin = Math.sin(finalAngle);
+          const reach = 0.7 + (s % 30) / 100;
+          const cx = scribbleCx + offsetX * scribbleHw * 0.4;
+          const cy = scribbleCy + offsetY * scribbleHh * 0.4;
+          const x1 = cx - cos * scribbleHw * reach;
+          const y1 = cy - sin * scribbleHh * reach;
+          const x2 = cx + cos * scribbleHw * reach;
+          const y2 = cy + sin * scribbleHh * reach;
 
           const line = rc.line(x1, y1, x2, y2, {
             stroke: scribbleCol,
@@ -1104,7 +1426,6 @@
               path.style.animation = `hoverBorderDraw ${dur}s ease-out ${stagger}s forwards`;
             } catch { /* ignore */ }
           });
-          // No opacity — bold brutalist strokes, color does the work
 
           wrap.appendChild(line);
         }
@@ -1132,14 +1453,15 @@
     const _hovered = hovered;
     if (!_hovered || selected) return;
 
-    const pos = getNodePos(_hovered);
+    const pos = getNodePos(_hovered) || groupById[_hovered];
     const s = svc[_hovered];
-    if (!s?.brief) return;
+    if (!pos || !s?.brief) return;
 
     const c = colors();
     const rc = rough.svg(mapSvg);
     const tipW = s.brief.length * 5.2 + 20;
-    const tipY = pos.y - HH - 24;
+    const isGroup = !!groupById[_hovered];
+    const tipY = isGroup ? (pos.bounds?.minY ?? pos.y) - 14 : pos.y - HH - 24;
 
     tooltipRough.appendChild(
       rc.rectangle(pos.x - tipW / 2, tipY - 9, tipW, 18, {
@@ -1265,7 +1587,8 @@
       return;
     }
 
-    const pos = getNodePos(_sel);
+    const pos = getNodePos(_sel) || groupById[_sel];
+    if (!pos) { mapPanG.style.transform = "translate(0, 0)"; return; }
     const vb = viewBox.split(" ").map(Number);
     const [vbX, vbY, vbW, vbH] = vb;
 
@@ -1328,11 +1651,34 @@
     <defs></defs>
     <g bind:this={mapPanG} class="map-pan">
     <g bind:this={hoverBorderG}></g>
+    <g bind:this={roughGroups}></g>
     <g bind:this={roughEdges}></g>
     <g bind:this={roughNodes}></g>
     <g bind:this={roughArrows}></g>
 
+    <g bind:this={groupLabelBorderG}></g>
     {#key drawGen}
+      {#each groups as grp}
+        {@const anim = animDelay.group?.[grp.id]}
+        {@const labelW = grp.label.length * 5.5 + 8}
+        {@const labelAnim = drawing && anim && flipPhase === "none" ? `opacity:0;animation:textJot ${anim.textDur.toFixed(3)}s cubic-bezier(0.2,0,0.1,1) ${anim.text.toFixed(3)}s forwards` : ''}
+        <rect
+          x={grp.bounds.minX + 4} y={grp.bounds.minY + 3}
+          width={labelW} height={14}
+          rx="2"
+          fill={isHighlighted(grp.id) ? "#f5f0e8" : "none"}
+          stroke="none"
+          style={labelAnim}
+        />
+        <text
+          x={grp.bounds.minX + 8} y={grp.bounds.minY + 12}
+          class="group-label"
+          class:node-label--subtle={!isHighlighted(grp.id)}
+          style={labelAnim}
+        >
+          {grp.label}
+        </text>
+      {/each}
       {#each nodes as n}
         {@const pos = getNodePos(n.id)}
         {@const dimmed = !isHighlighted(n.id)}
@@ -1341,7 +1687,7 @@
           <text
             x={pos.x} y={pos.y + 4}
             class="node-label"
-            class:node-label--dimmed={dimmed}
+            class:node-label--subtle={dimmed}
             class:node-label--active={active === n.id}
             style={drawing && flipPhase === "none" ? `opacity:0;animation:textJot ${animDelay.node[n.id].textDur.toFixed(3)}s cubic-bezier(0.2,0,0.1,1) ${animDelay.node[n.id].text.toFixed(3)}s forwards` : visible ? '' : 'opacity:0'}
           >
@@ -1355,13 +1701,35 @@
     <g bind:this={tooltipRough}></g>
 
     {#if hovered && !selected}
-      {@const pos = getNodePos(hovered)}
+      {@const pos = getNodePos(hovered) || groupById[hovered]}
       {@const s = svc[hovered]}
-      {#if s?.brief}
-        <text x={pos.x} y={pos.y - HH - 24} class="tooltip-text" dominant-baseline="central">{s.brief}</text>
+      {#if pos && s?.brief}
+        <text x={pos.x} y={(getNodePos(hovered) ? pos.y - HH - 24 : (pos.bounds?.minY ?? pos.y) - 14)} class="tooltip-text" dominant-baseline="central">{s.brief}</text>
       {/if}
     {/if}
 
+    {#each groups as grp}
+      <rect
+        x={grp.bounds.minX}
+        y={grp.bounds.minY}
+        width={grp.bounds.maxX - grp.bounds.minX}
+        height={grp.bounds.maxY - grp.bounds.minY}
+        fill="transparent"
+        class="hit-area"
+        style:cursor={!drawing || nodeDrawn(grp.id) ? "pointer" : "default"}
+        role="button"
+        tabindex="0"
+        aria-label="{grp.label} group — {svc[grp.id]?.brief ?? ''}"
+        onclick={() => selectNode(grp.id)}
+        onkeydown={(ev) => {
+          if (ev.key === "Enter" || ev.key === " ") { ev.preventDefault(); selectNode(grp.id); }
+        }}
+        onmouseenter={() => { if (!drawing || nodeDrawn(grp.id)) hovered = grp.id; }}
+        onmouseleave={() => { hovered = null; }}
+        onfocus={() => { if (!drawing || nodeDrawn(grp.id)) hovered = grp.id; }}
+        onblur={() => { hovered = null; }}
+      />
+    {/each}
     {#each nodes as n}
       {@const pos = getNodePos(n.id)}
       {@const w = n.hw * 2 + 12}
@@ -1412,9 +1780,12 @@
 
       <div class="drawer-content">
         <button class="drawer-back" onclick={() => (selected = null)}>&larr; esc</button>
+        {#if childToGroup[selected]}
+          <div class="drawer-breadcrumb">part of {svc[childToGroup[selected]]?.label ?? childToGroup[selected]}</div>
+        {/if}
         <div class="drawer-title-row">
-          <h2 class="drawer-name">{nodeById[selected].label}</h2>
-          <span class="drawer-status" style="color: {statusColor(nodeById[selected].status)}">{nodeById[selected].status}</span>
+          <h2 class="drawer-name">{(nodeById[selected] || groupById[selected])?.label ?? selected}</h2>
+          <span class="drawer-status" style="color: {statusColor((nodeById[selected] || groupById[selected])?.status ?? 'healthy')}">{(nodeById[selected] || groupById[selected])?.status ?? ''}</span>
         </div>
         <p class="drawer-desc">{svc[selected].description}</p>
 
@@ -1645,6 +2016,11 @@
     to { stroke-dashoffset: 0; }
   }
 
+  @keyframes -global-groupFillIn {
+    from { opacity: 0; }
+    to { opacity: 1; }
+  }
+
   @keyframes -global-hoverBorderDraw {
     to { stroke-dashoffset: 0; }
   }
@@ -1672,7 +2048,19 @@
     transition: opacity 0.2s ease;
   }
 
+  .group-label {
+    font-family: var(--font);
+    font-size: 8px;
+    font-weight: 700;
+    fill: #555;
+    text-anchor: start;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    transition: opacity 0.2s ease;
+  }
+
   .node-label--dimmed { opacity: 0.25; }
+  .node-label--subtle { opacity: 0.45; }
   .node-label--active { text-decoration: underline; }
 
   .tooltip-text {
@@ -1740,6 +2128,15 @@
   }
 
   .drawer-back:hover { color: var(--fg-secondary); }
+
+  .drawer-breadcrumb {
+    font-size: 0.6rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: var(--fg-tertiary);
+    margin-bottom: 0.25rem;
+  }
 
   .drawer-title-row {
     display: flex;

--- a/projects/monolith/frontend/src/routes/public/observability-demo/layout.js
+++ b/projects/monolith/frontend/src/routes/public/observability-demo/layout.js
@@ -3,6 +3,8 @@ import * as dagre from "@dagrejs/dagre";
 const HH = 18; // half-height of a node (matches +page.svelte)
 const CHAR_WIDTH = 6.5; // approximate monospace character width at 11px
 const NODE_PAD = 12; // padding around label text
+const GROUP_PAD = 16; // padding inside group boundary around children
+const GROUP_LABEL_H = 14; // extra top padding for group label
 
 /**
  * Compute half-width from label length.
@@ -15,14 +17,14 @@ function computeHW(label) {
 }
 
 /**
- * Run dagre layout on the topology config.
+ * Run dagre layout on the topology config, with compound graph support for groups.
  *
- * @param {Object} topology - The topology.json structure ({ nodes, edges })
+ * @param {Object} topology - The topology.json structure ({ nodes, edges, groups })
  * @param {"LR"|"TB"} rankdir - Layout direction
- * @returns {{ nodes: Array, edges: Array, nodeById: Object }}
+ * @returns {{ nodes: Array, edges: Array, groups: Array, nodeById: Object, groupById: Object }}
  */
 export function computeLayout(topology, rankdir) {
-  const g = new dagre.graphlib.Graph();
+  const g = new dagre.graphlib.Graph({ compound: true });
   g.setGraph({
     rankdir,
     nodesep: rankdir === "LR" ? 40 : 50,
@@ -32,11 +34,33 @@ export function computeLayout(topology, rankdir) {
   });
   g.setDefaultEdgeLabel(() => ({}));
 
+  const groups = topology.groups || [];
+  const groupIds = new Set(groups.map((g) => g.id));
+  const childToGroup = {};
+  for (const group of groups) {
+    for (const childId of group.children) {
+      childToGroup[childId] = group.id;
+    }
+  }
+
   // Only add non-infra nodes to dagre — infra nodes are positioned manually
   const infraNodeIds = new Set(
     topology.nodes.filter((n) => n.tier === "infra").map((n) => n.id),
   );
 
+  // Register group nodes in dagre (compound parents)
+  // Groups need explicit padding so dagre leaves room for the boundary
+  for (const group of groups) {
+    g.setNode(group.id, {
+      clusterLabelPos: "top",
+      paddingTop: GROUP_PAD + GROUP_LABEL_H,
+      paddingBottom: GROUP_PAD,
+      paddingLeft: GROUP_PAD,
+      paddingRight: GROUP_PAD,
+    });
+  }
+
+  // Register child + standalone nodes
   for (const node of topology.nodes) {
     if (infraNodeIds.has(node.id)) continue;
     const hw = computeHW(node.label);
@@ -45,12 +69,24 @@ export function computeLayout(topology, rankdir) {
       height: HH * 2 + 6,
       tier: node.tier,
     });
+    // Set parent for compound grouping
+    if (childToGroup[node.id]) {
+      g.setParent(node.id, childToGroup[node.id]);
+    }
   }
 
+  // Add edges — only edges between leaf nodes go to dagre.
+  // Edges involving group IDs are rendered visually but don't participate in layout.
+  // Edges between a group parent and its children are purely structural (skip).
   for (const edge of topology.edges) {
-    if (!infraNodeIds.has(edge.from) && !infraNodeIds.has(edge.to)) {
-      g.setEdge(edge.from, edge.to);
-    }
+    const from = edge.from;
+    const to = edge.to;
+    // Skip edges involving infra nodes
+    if (infraNodeIds.has(from) || infraNodeIds.has(to)) continue;
+    // Skip any edge that involves a group ID — dagre can't route to compound parents
+    if (groupIds.has(from) || groupIds.has(to)) continue;
+    if (!g.hasNode(from) || !g.hasNode(to)) continue;
+    g.setEdge(from, to);
   }
 
   dagre.layout(g);
@@ -63,18 +99,18 @@ export function computeLayout(topology, rankdir) {
   for (const n of topology.nodes) {
     if (infraNodeIds.has(n.id)) continue;
     const pos = g.node(n.id);
+    if (!pos) continue;
     positioned.push({ ...n, x: pos.x, y: pos.y, hw: computeHW(n.label) });
     maxY = Math.max(maxY, pos.y);
     maxX = Math.max(maxX, pos.x + computeHW(n.label));
     minX = Math.min(minX, pos.x - computeHW(n.label));
   }
 
-  // Position infra nodes in a row below the critical path
+  // Position infra nodes in a row below the critical path (before group boundary computation)
   const infraNodes = topology.nodes.filter((n) => n.tier === "infra");
-  const infraGap = 30; // gap below last critical rank
+  const infraGap = 90; // gap below last critical rank (accounts for group boundary padding above)
   const infraSep = 18; // spacing between infra nodes
   if (infraNodes.length > 0) {
-    // Calculate total width of all infra nodes
     const infraWidths = infraNodes.map(
       (n) => computeHW(n.label) * 2 + NODE_PAD,
     );
@@ -82,7 +118,6 @@ export function computeLayout(topology, rankdir) {
       infraWidths.reduce((a, b) => a + b, 0) +
       infraSep * (infraNodes.length - 1);
 
-    // Center the infra row under the critical path
     const critCenterX = (minX + maxX) / 2;
     let infraX = critCenterX - totalInfraW / 2;
     const infraY = maxY + infraGap + HH * 2 + 6;
@@ -95,9 +130,55 @@ export function computeLayout(topology, rankdir) {
     });
   }
 
+  // Compute group boundaries from their children's positioned bounding boxes
+  // (runs after all nodes — including infra — are positioned)
+  const positionedGroups = [];
+  for (const group of groups) {
+    const children = positioned.filter((n) => childToGroup[n.id] === group.id);
+    if (children.length === 0) continue;
+
+    let gMinX = Infinity,
+      gMinY = Infinity,
+      gMaxX = -Infinity,
+      gMaxY = -Infinity;
+    for (const c of children) {
+      const w = c.hw + NODE_PAD / 2;
+      gMinX = Math.min(gMinX, c.x - w);
+      gMaxX = Math.max(gMaxX, c.x + w);
+      gMinY = Math.min(gMinY, c.y - HH - 3);
+      gMaxY = Math.max(gMaxY, c.y + HH + 3);
+    }
+
+    // Add padding for the group boundary
+    gMinX -= GROUP_PAD;
+    gMaxX += GROUP_PAD;
+    gMinY -= GROUP_PAD + GROUP_LABEL_H;
+    gMaxY += GROUP_PAD;
+
+    const cx = (gMinX + gMaxX) / 2;
+    const cy = (gMinY + gMaxY) / 2;
+    const hw = (gMaxX - gMinX) / 2;
+    const hh = (gMaxY - gMinY) / 2;
+
+    positionedGroups.push({
+      ...group,
+      x: cx,
+      y: cy,
+      hw,
+      hh,
+      bounds: { minX: gMinX, minY: gMinY, maxX: gMaxX, maxY: gMaxY },
+    });
+  }
+
   const nodes = positioned;
-
   const nodeById = Object.fromEntries(nodes.map((n) => [n.id, n]));
+  const groupById = Object.fromEntries(positionedGroups.map((g) => [g.id, g]));
 
-  return { nodes, edges: topology.edges, nodeById };
+  return {
+    nodes,
+    edges: topology.edges,
+    groups: positionedGroups,
+    nodeById,
+    groupById,
+  };
 }

--- a/projects/monolith/frontend/src/routes/public/observability-demo/topology.json
+++ b/projects/monolith/frontend/src/routes/public/observability-demo/topology.json
@@ -1,27 +1,5 @@
 {
-  "nodes": [
-    {
-      "id": "external",
-      "label": "EXTERNAL",
-      "tier": "ingress",
-      "status": "healthy",
-      "description": "webpage · claude · cli",
-      "brief": "all external clients",
-      "metrics": [{ "k": "clients", "v": "webpage, claude, cli" }]
-    },
-    {
-      "id": "cloudflare",
-      "label": "CLOUDFLARE TUNNEL",
-      "tier": "critical",
-      "status": "healthy",
-      "description": "cloudflare tunnel",
-      "brief": "14.2k req/24h",
-      "metrics": [
-        { "k": "tunnel", "v": "connected" },
-        { "k": "requests 24h", "v": "14.2k" },
-        { "k": "cached", "v": "62%" }
-      ]
-    },
+  "groups": [
     {
       "id": "monolith",
       "label": "MONOLITH",
@@ -30,6 +8,7 @@
       "status": "healthy",
       "description": "fastapi + sveltekit",
       "brief": "99.97% · 12.5 rps",
+      "children": ["home", "knowledge", "chat"],
       "slo": { "target": 99.9, "current": 99.97 },
       "budget": {
         "consumed": 28,
@@ -46,6 +25,134 @@
       "spark": [
         38, 42, 45, 41, 39, 44, 42, 40, 43, 41, 38, 42, 47, 44, 42, 39, 41, 43,
         42, 40, 38, 41, 43, 42
+      ]
+    },
+    {
+      "id": "context-forge",
+      "label": "CONTEXT FORGE",
+      "tier": "critical",
+      "ingress": true,
+      "status": "healthy",
+      "description": "mcp gateway",
+      "brief": "99.98% · 8 rps",
+      "children": ["k8s-mcp", "argocd-mcp", "signoz-mcp"],
+      "slo": { "target": 99.9, "current": 99.98 },
+      "budget": {
+        "consumed": 12,
+        "elapsed": 40,
+        "remaining": "38.2 min",
+        "window": "30d"
+      },
+      "latency": { "p99": 180, "target": 500, "unit": "ms" },
+      "metrics": [
+        { "k": "rps", "v": "8" },
+        { "k": "mcp servers", "v": "3" },
+        { "k": "p99", "v": "180ms" }
+      ],
+      "spark": [
+        120, 140, 180, 160, 150, 170, 190, 165, 155, 175, 145, 160, 185, 170,
+        160, 150, 165, 180, 160, 155, 140, 160, 175, 165
+      ]
+    },
+    {
+      "id": "cluster",
+      "label": "CLUSTER",
+      "tier": "infra",
+      "status": "healthy",
+      "description": "k3s infrastructure",
+      "brief": "healthy · 7 services",
+      "children": [
+        "argocd",
+        "signoz",
+        "envoy-gateway",
+        "longhorn",
+        "seaweedfs",
+        "otel-operator",
+        "linkerd"
+      ],
+      "metrics": [
+        { "k": "services", "v": "7" },
+        { "k": "nodes", "v": "4" },
+        { "k": "pods", "v": "42" }
+      ]
+    }
+  ],
+  "nodes": [
+    {
+      "id": "external",
+      "label": "EXTERNAL",
+      "tier": "ingress",
+      "status": "healthy",
+      "description": "webpage · claude · cli",
+      "brief": "all external clients",
+      "metrics": [{ "k": "clients", "v": "webpage, claude, cli" }]
+    },
+    {
+      "id": "discord",
+      "label": "DISCORD",
+      "tier": "ingress",
+      "status": "healthy",
+      "description": "discord api",
+      "brief": "external api",
+      "metrics": [{ "k": "service", "v": "discord api" }]
+    },
+    {
+      "id": "cloudflare",
+      "label": "CLOUDFLARE TUNNEL",
+      "tier": "critical",
+      "status": "healthy",
+      "description": "cloudflare tunnel",
+      "brief": "14.2k req/24h",
+      "metrics": [
+        { "k": "tunnel", "v": "connected" },
+        { "k": "requests 24h", "v": "14.2k" },
+        { "k": "cached", "v": "62%" }
+      ]
+    },
+    {
+      "id": "home",
+      "label": "HOME",
+      "tier": "critical",
+      "status": "healthy",
+      "group": "monolith",
+      "description": "dashboard + notes + schedule",
+      "brief": "100% · 4.2 rps",
+      "metrics": [
+        { "k": "rps", "v": "4.2" },
+        { "k": "routes", "v": "todo, notes, schedule" }
+      ]
+    },
+    {
+      "id": "knowledge",
+      "label": "KNOWLEDGE",
+      "tier": "critical",
+      "status": "healthy",
+      "group": "monolith",
+      "description": "search · ingest · gardener",
+      "brief": "99.98% · 6.1 rps",
+      "slo": { "target": 99.9, "current": 99.98 },
+      "latency": { "p99": 65, "target": 200, "unit": "ms" },
+      "metrics": [
+        { "k": "rps", "v": "6.1" },
+        { "k": "vault notes", "v": "1.2k" },
+        { "k": "p99", "v": "65ms" }
+      ],
+      "spark": [
+        50, 55, 65, 60, 52, 58, 70, 62, 55, 68, 58, 54, 66, 72, 60, 55, 62, 68,
+        58, 54, 50, 58, 65, 60
+      ]
+    },
+    {
+      "id": "chat",
+      "label": "CHAT",
+      "tier": "critical",
+      "status": "healthy",
+      "group": "monolith",
+      "description": "discord backfill + summarization",
+      "brief": "healthy · 2.2 rps",
+      "metrics": [
+        { "k": "rps", "v": "2.2" },
+        { "k": "backfills 24h", "v": "3" }
       ]
     },
     {
@@ -94,32 +201,6 @@
       "spark": [
         40, 42, 48, 45, 43, 47, 44, 41, 46, 43, 42, 45, 50, 47, 44, 42, 45, 48,
         44, 43, 41, 44, 46, 45
-      ]
-    },
-    {
-      "id": "context-forge",
-      "label": "CONTEXT FORGE",
-      "tier": "critical",
-      "ingress": true,
-      "status": "healthy",
-      "description": "mcp gateway",
-      "brief": "99.98% · 8 rps",
-      "slo": { "target": 99.9, "current": 99.98 },
-      "budget": {
-        "consumed": 12,
-        "elapsed": 40,
-        "remaining": "38.2 min",
-        "window": "30d"
-      },
-      "latency": { "p99": 180, "target": 500, "unit": "ms" },
-      "metrics": [
-        { "k": "rps", "v": "8" },
-        { "k": "mcp servers", "v": "3" },
-        { "k": "p99", "v": "180ms" }
-      ],
-      "spark": [
-        120, 140, 180, 160, 150, 170, 190, 165, 155, 175, 145, 160, 185, 170,
-        160, 150, 165, 180, 160, 155, 140, 160, 175, 165
       ]
     },
     {
@@ -188,9 +269,10 @@
     },
     {
       "id": "k8s-mcp",
-      "label": "K8S MCP",
+      "label": "K8S",
       "tier": "critical",
       "status": "healthy",
+      "group": "context-forge",
       "description": "kubernetes mcp server",
       "brief": "healthy",
       "metrics": [
@@ -200,9 +282,10 @@
     },
     {
       "id": "argocd-mcp",
-      "label": "ARGOCD MCP",
+      "label": "ARGOCD",
       "tier": "critical",
       "status": "healthy",
+      "group": "context-forge",
       "description": "argocd mcp server",
       "brief": "healthy",
       "metrics": [
@@ -212,9 +295,10 @@
     },
     {
       "id": "signoz-mcp",
-      "label": "SIGNOZ MCP",
+      "label": "SIGNOZ",
       "tier": "critical",
       "status": "healthy",
+      "group": "context-forge",
       "description": "signoz mcp server",
       "brief": "healthy",
       "metrics": [
@@ -227,6 +311,7 @@
       "label": "ARGOCD",
       "tier": "infra",
       "status": "healthy",
+      "group": "cluster",
       "description": "gitops controller",
       "brief": "14/14 synced",
       "metrics": [
@@ -240,6 +325,7 @@
       "label": "SIGNOZ",
       "tier": "infra",
       "status": "warning",
+      "group": "cluster",
       "description": "observability platform",
       "brief": "99.84% · 450 spans/s",
       "slo": { "target": 99.9, "current": 99.84 },
@@ -265,6 +351,7 @@
       "label": "ENVOY GATEWAY",
       "tier": "infra",
       "status": "healthy",
+      "group": "cluster",
       "description": "api gateway",
       "brief": "healthy · 14.2k req/24h",
       "metrics": [
@@ -278,6 +365,7 @@
       "label": "LONGHORN",
       "tier": "infra",
       "status": "healthy",
+      "group": "cluster",
       "description": "distributed storage",
       "brief": "340 / 1000 GiB",
       "metrics": [
@@ -291,6 +379,7 @@
       "label": "SEAWEEDFS",
       "tier": "infra",
       "status": "healthy",
+      "group": "cluster",
       "description": "object storage",
       "brief": "healthy · 28 GiB",
       "metrics": [
@@ -304,6 +393,7 @@
       "label": "OTEL OPERATOR",
       "tier": "infra",
       "status": "healthy",
+      "group": "cluster",
       "description": "opentelemetry operator",
       "brief": "healthy · 3 collectors",
       "metrics": [
@@ -316,6 +406,7 @@
       "label": "LINKERD",
       "tier": "infra",
       "status": "healthy",
+      "group": "cluster",
       "description": "service mesh",
       "brief": "healthy · 12 meshed",
       "metrics": [
@@ -326,23 +417,20 @@
     }
   ],
   "edges": [
-    { "from": "external", "to": "cloudflare", "protocol": "https" },
-    { "from": "cloudflare", "to": "monolith", "protocol": "https" },
-    { "from": "cloudflare", "to": "context-forge", "protocol": "https" },
-    { "from": "cloudflare", "to": "agent-platform", "protocol": "https" },
-    { "from": "monolith", "to": "postgres", "protocol": "sql", "bidi": true },
-    { "from": "monolith", "to": "context-forge", "protocol": "grpc" },
-    { "from": "monolith", "to": "llama-cpp", "protocol": "http" },
-    { "from": "monolith", "to": "voyage-embedder", "protocol": "http" },
-    {
-      "from": "nats",
-      "to": "agent-platform",
-      "protocol": "nats",
-      "bidi": true
-    },
-    { "from": "agent-platform", "to": "context-forge", "protocol": "grpc" },
-    { "from": "context-forge", "to": "k8s-mcp", "protocol": "mcp" },
-    { "from": "context-forge", "to": "argocd-mcp", "protocol": "mcp" },
-    { "from": "context-forge", "to": "signoz-mcp", "protocol": "mcp" }
+    { "from": "external", "to": "cloudflare" },
+    { "from": "cloudflare", "to": "home" },
+    { "from": "cloudflare", "to": "knowledge" },
+    { "from": "cloudflare", "to": "agent-platform" },
+    { "from": "home", "to": "postgres" },
+    { "from": "knowledge", "to": "postgres" },
+    { "from": "knowledge", "to": "voyage-embedder" },
+    { "from": "knowledge", "to": "llama-cpp" },
+    { "from": "chat", "to": "postgres" },
+    { "from": "chat", "to": "llama-cpp" },
+    { "from": "chat", "to": "discord" },
+    { "from": "nats", "to": "agent-platform", "bidi": true },
+    { "from": "agent-platform", "to": "k8s-mcp" },
+    { "from": "agent-platform", "to": "argocd-mcp" },
+    { "from": "agent-platform", "to": "signoz-mcp" }
   ]
 }


### PR DESCRIPTION
## Summary
- Add **MONOLITH**, **CONTEXT FORGE**, and **CLUSTER** group containers that visually organize child services with hand-drawn rough.js boundaries
- Groups use theme-independent cream fill (`#f5f0e8`) with animated stroke transitions — child nodes sketch in theme colors, then smoothly flip to dark when the group fill fades in
- Infra nodes draw sequentially left-to-right and are wrapped in a CLUSTER group for SLO aggregation
- Purple scribble highlights with area-scaled density for groups, animation-gated interactivity (no hover/click until group text is visible)
- New DISCORD external node, edges connect directly to child nodes (piercing group boundaries)

## Test plan
- [x] Verify groups render correctly in both light and dark modes
- [x] Toggle theme mid-animation — child strokes stay visible throughout
- [x] Click/hover groups — scribble covers group boundary, label gets shelf border
- [x] Infra nodes draw left-to-right sequentially
- [x] Groups not interactive until fill + text complete
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)