### PR TITLE
fix(monolith): add ClickHouse auth for SLO queries

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.41.3
+version: 0.42.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/templates/deployment.yaml
+++ b/projects/monolith/chart/templates/deployment.yaml
@@ -53,6 +53,18 @@ spec:
             - name: CLICKHOUSE_URL
               value: {{ .Values.backend.clickhouseUrl | quote }}
             {{- end }}
+            {{- if .Values.clickhouse.onepassword.itemPath }}
+            - name: CLICKHOUSE_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "monolith.fullname" . }}-clickhouse
+                  key: USER
+            - name: CLICKHOUSE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "monolith.fullname" . }}-clickhouse
+                  key: PASSWORD
+            {{- end }}
             - name: FRONTEND_HEALTH_URL
               value: "http://localhost:3000/"
             {{- if .Values.chat.enabled }}

--- a/projects/monolith/chart/templates/onepassworditem-clickhouse.yaml
+++ b/projects/monolith/chart/templates/onepassworditem-clickhouse.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.clickhouse.onepassword.itemPath }}
+apiVersion: onepassword.com/v1
+kind: OnePasswordItem
+metadata:
+  name: {{ include "monolith.fullname" . }}-clickhouse
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "monolith.labels" . | nindent 4 }}
+spec:
+  itemPath: {{ .Values.clickhouse.onepassword.itemPath | quote }}
+{{- end }}

--- a/projects/monolith/chart/values.yaml
+++ b/projects/monolith/chart/values.yaml
@@ -53,6 +53,10 @@ onepassword:
   enabled: false
   itemPath: ""
 
+clickhouse:
+  onepassword:
+    itemPath: ""
+
 knowledge:
   enabled: false
   gitRemote: ""

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.41.3
+      targetRevision: 0.42.0
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/deploy/values.yaml
+++ b/projects/monolith/deploy/values.yaml
@@ -18,6 +18,10 @@ onepassword:
   enabled: true
   itemPath: "vaults/k8s-homelab/items/private-homepage"
 
+clickhouse:
+  onepassword:
+    itemPath: "vaults/k8s-homelab/items/signoz-clickhouse"
+
 cfIngress:
   public:
     enabled: true

--- a/projects/monolith/observability/clickhouse.py
+++ b/projects/monolith/observability/clickhouse.py
@@ -13,10 +13,14 @@ class ClickHouseClient:
     def __init__(
         self,
         base_url: str = "http://chi-signoz-clickhouse-cluster-0-0.signoz.svc.cluster.local:8123",
+        user: str = "",
+        password: str = "",
         transport: httpx.AsyncBaseTransport | None = None,
         timeout: float = 30.0,
     ):
         kwargs: dict = {"base_url": base_url}
+        if user and password:
+            kwargs["auth"] = httpx.BasicAuth(user, password)
         if transport is not None:
             kwargs["transport"] = transport
         self._client = httpx.AsyncClient(timeout=timeout, **kwargs)

--- a/projects/monolith/observability/router.py
+++ b/projects/monolith/observability/router.py
@@ -95,7 +95,11 @@ async def build_topology() -> dict:
         "CLICKHOUSE_URL",
         "http://chi-signoz-clickhouse-cluster-0-0.signoz.svc.cluster.local:8123",
     )
-    client = ClickHouseClient(base_url=ch_url)
+    client = ClickHouseClient(
+        base_url=ch_url,
+        user=os.environ.get("CLICKHOUSE_USER", ""),
+        password=os.environ.get("CLICKHOUSE_PASSWORD", ""),
+    )
 
     try:
         # Query all nodes in parallel


### PR DESCRIPTION
## Summary
- **Add ClickHouse authentication** — SLO queries were returning 401 Unauthorized because ClickHouse requires credentials from non-localhost sources
- **OnePasswordItem** syncs `signoz-clickhouse` from 1Password into monolith namespace as `monolith-clickhouse` secret
- **HTTP Basic Auth** via `CLICKHOUSE_USER` and `CLICKHOUSE_PASSWORD` env vars, passed through `httpx.BasicAuth`
- **Chart bump** 0.41.3 → 0.42.0

## Test plan
- [ ] CI passes
- [ ] 1Password item `signoz-clickhouse` saved with USER and PASSWORD fields
- [ ] Pod starts, `warm_cache()` succeeds (no more 401 errors in logs)
- [ ] `/public/slos` shows live SLO data

🤖 Generated with [Claude Code](https://claude.com/claude-code)