### PR TITLE
fix(monolith): use time_series_v4_6hrs for SLO fingerprint lookups

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.42.0
+version: 0.42.1
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.42.0
+      targetRevision: 0.42.1
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/observability/topology_config.py
+++ b/projects/monolith/observability/topology_config.py
@@ -26,7 +26,7 @@ WITH per_minute AS (
   SELECT intDiv(s.unix_milli, 60000) AS mb, max(s.value) AS ready
   FROM signoz_metrics.distributed_samples_v4 s
   WHERE s.fingerprint IN (
-    SELECT DISTINCT fingerprint FROM signoz_metrics.distributed_time_series_v4
+    SELECT DISTINCT fingerprint FROM signoz_metrics.distributed_time_series_v4_6hrs
     WHERE metric_name = 'k8s.container.ready'
       AND JSONExtractString(labels, 'k8s.namespace.name') = '{namespace}'
       AND JSONExtractString(labels, 'k8s.container.name') = '{container}'
@@ -44,7 +44,7 @@ bad AS (
   SELECT intDiv(unix_milli, 60000) AS mb, sum(value) AS v
   FROM signoz_metrics.distributed_samples_v4
   WHERE fingerprint IN (
-    SELECT DISTINCT fingerprint FROM signoz_metrics.distributed_time_series_v4
+    SELECT DISTINCT fingerprint FROM signoz_metrics.distributed_time_series_v4_6hrs
     WHERE metric_name = 'envoy_cluster_upstream_rq_xx'
       AND JSONExtractString(labels, 'envoy_cluster_name') LIKE '%{cluster_pattern}%'
       AND JSONExtractString(labels, 'envoy_response_code_class') = '5'
@@ -55,7 +55,7 @@ total AS (
   SELECT intDiv(unix_milli, 60000) AS mb, sum(value) AS v
   FROM signoz_metrics.distributed_samples_v4
   WHERE fingerprint IN (
-    SELECT DISTINCT fingerprint FROM signoz_metrics.distributed_time_series_v4
+    SELECT DISTINCT fingerprint FROM signoz_metrics.distributed_time_series_v4_6hrs
     WHERE metric_name = 'envoy_cluster_upstream_rq_xx'
       AND JSONExtractString(labels, 'envoy_cluster_name') LIKE '%{cluster_pattern}%'
   ) AND unix_milli >= toUnixTimestamp(now() - INTERVAL {WINDOW_DAYS} DAY) * 1000
@@ -72,7 +72,7 @@ WITH per_minute AS (
   SELECT intDiv(s.unix_milli, 60000) AS mb, max(s.value) AS up
   FROM signoz_metrics.distributed_samples_v4 s
   WHERE s.fingerprint IN (
-    SELECT DISTINCT fingerprint FROM signoz_metrics.distributed_time_series_v4
+    SELECT DISTINCT fingerprint FROM signoz_metrics.distributed_time_series_v4_6hrs
     WHERE metric_name = 'cnpg_collector_up'
   ) AND s.unix_milli >= toUnixTimestamp(now() - INTERVAL {WINDOW_DAYS} DAY) * 1000
   GROUP BY mb


### PR DESCRIPTION
## Summary
- **Fix ClickHouse OOM** — fingerprint lookups against the full `time_series_v4` table scan ~4.8 GiB of labels and exceed the 7.2 GiB memory limit
- **Use `time_series_v4_6hrs`** — the rolling 6-hour materialized view is tiny and contains the same fingerprints for any currently-running container
- The outer `samples_v4` query still covers the full 30-day SLO window — only the fingerprint lookup is narrowed
- Verified via port-forward: all 3 query patterns (container readiness, envoy success rate, CNPG up) return 100% in <1s

## Test plan
- [x] Port-forward test: container readiness (nats) — 100%, 0.97s
- [x] Port-forward test: envoy success rate (monolith-public) — 100%, 0.64s
- [x] Port-forward test: CNPG collector up — 100%, 0.61s
- [ ] CI passes
- [ ] Pod starts with successful cache warm (no 500s in logs)
- [ ] `/public/slos` shows live SLO data

🤖 Generated with [Claude Code](https://claude.com/claude-code)