### PR TITLE
fix(monolith): optimize SLO queries and add live metrics to topology

### DIFF
--- a/projects/agent_platform/llama_cpp/deploy/values-prod.yaml
+++ b/projects/agent_platform/llama_cpp/deploy/values-prod.yaml
@@ -39,6 +39,8 @@ nodeSelector:
 
 podAnnotations:
   linkerd.io/inject: disabled
+  prometheus.io/scrape: "true"
+  prometheus.io/port: "8080"
 
 resources:
   requests:

--- a/projects/agent_platform/llama_cpp_embeddings/deploy/values.yaml
+++ b/projects/agent_platform/llama_cpp_embeddings/deploy/values.yaml
@@ -23,12 +23,15 @@ server:
     - "--embedding"
     - "--alias"
     - "voyage-4-nano"
+    - "--metrics"
 
 nodeSelector:
   kubernetes.io/hostname: node-4
 
 podAnnotations:
   linkerd.io/inject: disabled
+  prometheus.io/scrape: "true"
+  prometheus.io/port: "8080"
 
 runtimeClassName: null
 

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.42.2
+version: 0.42.3
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.42.1
+version: 0.42.2
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.42.2
+      targetRevision: 0.42.3
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.42.1
+      targetRevision: 0.42.2
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/routes/public/slos/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/slos/+page.svelte
@@ -352,6 +352,7 @@
 
   function budgetColor(consumed, elapsed) {
     const c = colors();
+    if (consumed >= 100) return c.danger;
     if (consumed > elapsed * 1.5) return c.danger;
     if (consumed > elapsed) return c.warn;
     return c.fgTer;

--- a/projects/monolith/observability/config_test.py
+++ b/projects/monolith/observability/config_test.py
@@ -36,7 +36,7 @@ class TestTopologyConfig:
         for n in TOPOLOGY.nodes:
             if n.slo is not None:
                 assert n.slo.query is not None, f"node {n.id} has SLO but no query"
-                assert n.slo.target == 99.0
+                assert n.slo.target == 98.0
                 assert n.slo.window_days == 30
 
     def test_edges(self):

--- a/projects/monolith/observability/router.py
+++ b/projects/monolith/observability/router.py
@@ -22,10 +22,15 @@ router = APIRouter(prefix="/api/public/observability", tags=["observability"])
 
 _cache: dict | None = None
 _cache_time: float = 0.0
+_ch_semaphore = asyncio.Semaphore(2)
 
 
 async def _query_node(client: ClickHouseClient, node: NodeConfig) -> dict:
-    """Execute all queries for a single node and return topology JSON."""
+    """Execute all queries for a single node and return topology JSON.
+
+    Acquires _ch_semaphore before each ClickHouse call to limit concurrent
+    queries and avoid ClickHouse OOM-killing under memory pressure.
+    """
     result: dict = {
         "id": node.id,
         "label": node.label,
@@ -41,7 +46,8 @@ async def _query_node(client: ClickHouseClient, node: NodeConfig) -> dict:
     availability = None
     if node.slo and node.slo.query:
         try:
-            availability = await client.query_scalar(node.slo.query)
+            async with _ch_semaphore:
+                availability = await client.query_scalar(node.slo.query)
         except Exception:
             logger.exception("SLO query failed for %s", node.id)
 
@@ -64,7 +70,8 @@ async def _query_node(client: ClickHouseClient, node: NodeConfig) -> dict:
             metrics.append({"k": m.key, "v": m.static})
         elif m.query:
             try:
-                val = await client.query_scalar(m.query)
+                async with _ch_semaphore:
+                    val = await client.query_scalar(m.query)
                 suffix = m.unit or ""
                 v = f"{val}{suffix}" if val is not None else "—"
                 metrics.append({"k": m.key, "v": v})
@@ -80,7 +87,8 @@ async def _query_node(client: ClickHouseClient, node: NodeConfig) -> dict:
     # Spark query
     if node.spark:
         try:
-            rows = await client.query_rows(node.spark.query)
+            async with _ch_semaphore:
+                rows = await client.query_rows(node.spark.query)
             result["spark"] = [r.get("value", 0) for r in rows]
         except Exception:
             logger.exception("Spark query failed for %s", node.id)

--- a/projects/monolith/observability/slo.py
+++ b/projects/monolith/observability/slo.py
@@ -84,7 +84,7 @@ def aggregate_group(children: list[dict], target: float, window_days: int) -> di
                 rps_total += float(v)
             except (ValueError, TypeError):
                 pass
-        elif k == "p99":
+        elif k in ("p99", "latency"):
             has_p99 = True
             num = re.sub(r"[^\d.]", "", str(v))
             try:
@@ -98,7 +98,7 @@ def aggregate_group(children: list[dict], target: float, window_days: int) -> di
     if has_rps:
         aggregated_metrics.append({"k": "rps", "v": f"{rps_total:.1f}"})
     if has_p99:
-        aggregated_metrics.append({"k": "p99", "v": p99_label})
+        aggregated_metrics.append({"k": "latency", "v": p99_label})
 
     result: dict = {"status": worst_status, "metrics": aggregated_metrics}
 

--- a/projects/monolith/observability/slo_test.py
+++ b/projects/monolith/observability/slo_test.py
@@ -92,12 +92,12 @@ class TestAggregateGroup:
         assert rps is not None
         assert float(rps["v"]) == pytest.approx(8.2, abs=0.1)
 
-    def test_max_p99(self):
+    def test_max_latency(self):
         children = [
             {"slo": {"current": 100.0}, "metrics": [{"k": "p99", "v": "42ms"}]},
             {"slo": {"current": 100.0}, "metrics": [{"k": "p99", "v": "180ms"}]},
         ]
         result = aggregate_group(children, target=99.0, window_days=30)
-        p99 = next((m for m in result["metrics"] if m["k"] == "p99"), None)
-        assert p99 is not None
-        assert p99["v"] == "180ms"
+        latency = next((m for m in result["metrics"] if m["k"] == "latency"), None)
+        assert latency is not None
+        assert latency["v"] == "180ms"

--- a/projects/monolith/observability/topology_config.py
+++ b/projects/monolith/observability/topology_config.py
@@ -16,20 +16,29 @@ from observability.config import (
 )
 
 WINDOW_DAYS = 30
-SLO_TARGET = 99.0
+SLO_TARGET = 98.0
 
 
-def _container_ready_query(namespace: str, container: str) -> str:
+def _container_ready_query(
+    namespace: str, container: str, pod_prefix: str | None = None
+) -> str:
     """SLO query: percentage of minutes where k8s.container.ready >= 1."""
+    pod_filter = ""
+    if pod_prefix is not None:
+        pod_filter = (
+            f"\n      AND JSONExtractString(labels, 'k8s.pod.name')"
+            f" LIKE '{pod_prefix}%'"
+        )
     return f"""\
 WITH per_minute AS (
   SELECT intDiv(s.unix_milli, 60000) AS mb, max(s.value) AS ready
   FROM signoz_metrics.distributed_samples_v4 s
-  WHERE s.fingerprint IN (
+  WHERE s.metric_name = 'k8s.container.ready'
+    AND s.fingerprint IN (
     SELECT DISTINCT fingerprint FROM signoz_metrics.distributed_time_series_v4_6hrs
     WHERE metric_name = 'k8s.container.ready'
       AND JSONExtractString(labels, 'k8s.namespace.name') = '{namespace}'
-      AND JSONExtractString(labels, 'k8s.container.name') = '{container}'
+      AND JSONExtractString(labels, 'k8s.container.name') = '{container}'{pod_filter}
   ) AND s.unix_milli >= toUnixTimestamp(now() - INTERVAL {WINDOW_DAYS} DAY) * 1000
   GROUP BY mb
 )
@@ -43,7 +52,8 @@ WITH
 bad AS (
   SELECT intDiv(unix_milli, 60000) AS mb, sum(value) AS v
   FROM signoz_metrics.distributed_samples_v4
-  WHERE fingerprint IN (
+  WHERE metric_name = 'envoy_cluster_upstream_rq_xx'
+    AND fingerprint IN (
     SELECT DISTINCT fingerprint FROM signoz_metrics.distributed_time_series_v4_6hrs
     WHERE metric_name = 'envoy_cluster_upstream_rq_xx'
       AND JSONExtractString(labels, 'envoy_cluster_name') LIKE '%{cluster_pattern}%'
@@ -54,7 +64,8 @@ bad AS (
 total AS (
   SELECT intDiv(unix_milli, 60000) AS mb, sum(value) AS v
   FROM signoz_metrics.distributed_samples_v4
-  WHERE fingerprint IN (
+  WHERE metric_name = 'envoy_cluster_upstream_rq_xx'
+    AND fingerprint IN (
     SELECT DISTINCT fingerprint FROM signoz_metrics.distributed_time_series_v4_6hrs
     WHERE metric_name = 'envoy_cluster_upstream_rq_xx'
       AND JSONExtractString(labels, 'envoy_cluster_name') LIKE '%{cluster_pattern}%'
@@ -71,13 +82,119 @@ def _cnpg_up_query() -> str:
 WITH per_minute AS (
   SELECT intDiv(s.unix_milli, 60000) AS mb, max(s.value) AS up
   FROM signoz_metrics.distributed_samples_v4 s
-  WHERE s.fingerprint IN (
+  WHERE s.metric_name = 'cnpg_collector_up'
+    AND s.fingerprint IN (
     SELECT DISTINCT fingerprint FROM signoz_metrics.distributed_time_series_v4_6hrs
     WHERE metric_name = 'cnpg_collector_up'
   ) AND s.unix_milli >= toUnixTimestamp(now() - INTERVAL {WINDOW_DAYS} DAY) * 1000
   GROUP BY mb
 )
 SELECT round(countIf(up >= 1) / count() * 100, 4) AS value FROM per_minute"""
+
+
+def _envoy_rps_query(cluster_pattern: str) -> str:
+    """Metric query: average requests per second over the last 5 minutes."""
+    return f"""\
+WITH per_minute AS (
+  SELECT intDiv(unix_milli, 60000) AS mb, sum(value) AS v
+  FROM signoz_metrics.distributed_samples_v4
+  WHERE metric_name = 'envoy_cluster_upstream_rq_xx'
+    AND fingerprint IN (
+    SELECT DISTINCT fingerprint FROM signoz_metrics.distributed_time_series_v4_6hrs
+    WHERE metric_name = 'envoy_cluster_upstream_rq_xx'
+      AND JSONExtractString(labels, 'envoy_cluster_name') LIKE '%{cluster_pattern}%'
+  ) AND unix_milli >= toUnixTimestamp(now() - INTERVAL 5 MINUTE) * 1000
+  GROUP BY mb
+)
+SELECT round(avg(v) / 60, 1) AS value FROM per_minute"""
+
+
+def _envoy_avg_latency_query(cluster_pattern: str) -> str:
+    """Metric query: average upstream latency (ms) from histogram sum/count."""
+    return f"""\
+WITH
+s AS (
+  SELECT max(value) AS v FROM signoz_metrics.distributed_samples_v4
+  WHERE metric_name = 'envoy_cluster_upstream_rq_time.sum'
+    AND fingerprint IN (
+    SELECT DISTINCT fingerprint FROM signoz_metrics.distributed_time_series_v4_6hrs
+    WHERE metric_name = 'envoy_cluster_upstream_rq_time.sum'
+      AND attrs['envoy_cluster_name'] LIKE '%{cluster_pattern}%'
+  ) AND unix_milli >= toUnixTimestamp(now() - INTERVAL 5 MINUTE) * 1000
+),
+c AS (
+  SELECT max(value) AS v FROM signoz_metrics.distributed_samples_v4
+  WHERE metric_name = 'envoy_cluster_upstream_rq_time.count'
+    AND fingerprint IN (
+    SELECT DISTINCT fingerprint FROM signoz_metrics.distributed_time_series_v4_6hrs
+    WHERE metric_name = 'envoy_cluster_upstream_rq_time.count'
+      AND attrs['envoy_cluster_name'] LIKE '%{cluster_pattern}%'
+  ) AND unix_milli >= toUnixTimestamp(now() - INTERVAL 5 MINUTE) * 1000
+)
+SELECT round(s.v / c.v, 1) AS value FROM s, c WHERE c.v > 0"""
+
+
+def _cnpg_backends_query() -> str:
+    """Metric query: current active backends."""
+    return """\
+SELECT round(max(value)) AS value
+FROM signoz_metrics.distributed_samples_v4
+WHERE metric_name = 'cnpg_backends_total'
+  AND fingerprint IN (
+  SELECT DISTINCT fingerprint FROM signoz_metrics.distributed_time_series_v4_6hrs
+  WHERE metric_name = 'cnpg_backends_total'
+) AND unix_milli >= toUnixTimestamp(now() - INTERVAL 5 MINUTE) * 1000"""
+
+
+def _cnpg_db_size_query() -> str:
+    """Metric query: database size in MB for the monolith database."""
+    return """\
+SELECT round(max(value) / 1048576, 1) AS value
+FROM signoz_metrics.distributed_samples_v4
+WHERE metric_name = 'cnpg_pg_database_size_bytes'
+  AND fingerprint IN (
+  SELECT DISTINCT fingerprint FROM signoz_metrics.distributed_time_series_v4_6hrs
+  WHERE metric_name = 'cnpg_pg_database_size_bytes'
+    AND JSONExtractString(labels, 'datname') = 'monolith'
+) AND unix_milli >= toUnixTimestamp(now() - INTERVAL 5 MINUTE) * 1000"""
+
+
+def _seaweedfs_disk_query() -> str:
+    """Metric query: total disk usage in GB."""
+    return """\
+SELECT round(max(value) / 1073741824, 1) AS value
+FROM signoz_metrics.distributed_samples_v4
+WHERE metric_name = 'SeaweedFS_volumeServer_total_disk_size'
+  AND fingerprint IN (
+  SELECT DISTINCT fingerprint FROM signoz_metrics.distributed_time_series_v4_6hrs
+  WHERE metric_name = 'SeaweedFS_volumeServer_total_disk_size'
+) AND unix_milli >= toUnixTimestamp(now() - INTERVAL 5 MINUTE) * 1000"""
+
+
+def _argocd_apps_synced_query() -> str:
+    """Metric query: number of ArgoCD applications."""
+    return """\
+SELECT round(max(value)) AS value
+FROM signoz_metrics.distributed_samples_v4
+WHERE metric_name = 'argocd_app_info'
+  AND fingerprint IN (
+  SELECT DISTINCT fingerprint FROM signoz_metrics.distributed_time_series_v4_6hrs
+  WHERE metric_name = 'argocd_app_info'
+) AND unix_milli >= toUnixTimestamp(now() - INTERVAL 5 MINUTE) * 1000"""
+
+
+def _container_memory_mb_query(namespace: str, deployment: str) -> str:
+    """Metric query: container memory usage in MB (via resource_attrs Map)."""
+    return f"""\
+SELECT round(max(value) / 1048576) AS value
+FROM signoz_metrics.distributed_samples_v4
+WHERE metric_name = 'container.memory.usage'
+  AND fingerprint IN (
+  SELECT DISTINCT fingerprint FROM signoz_metrics.distributed_time_series_v4_6hrs
+  WHERE metric_name = 'container.memory.usage'
+    AND resource_attrs['k8s.namespace.name'] = '{namespace}'
+    AND resource_attrs['k8s.deployment.name'] = '{deployment}'
+) AND unix_milli >= toUnixTimestamp(now() - INTERVAL 5 MINUTE) * 1000"""
 
 
 def _slo(query: str) -> SloConfig:
@@ -152,6 +269,17 @@ TOPOLOGY = TopologyConfig(
             group="monolith",
             description="dashboard + notes + schedule",
             slo=_slo(_envoy_success_rate_query("monolith-public")),
+            metrics=[
+                MetricConfig(
+                    key="rps",
+                    query=_envoy_rps_query("monolith-public"),
+                ),
+                MetricConfig(
+                    key="latency",
+                    query=_envoy_avg_latency_query("monolith-public"),
+                    unit="ms",
+                ),
+            ],
         ),
         NodeConfig(
             id="knowledge",
@@ -160,6 +288,17 @@ TOPOLOGY = TopologyConfig(
             group="monolith",
             description="search · ingest · gardener",
             slo=_slo(_envoy_success_rate_query("monolith-private")),
+            metrics=[
+                MetricConfig(
+                    key="rps",
+                    query=_envoy_rps_query("monolith-private"),
+                ),
+                MetricConfig(
+                    key="latency",
+                    query=_envoy_avg_latency_query("monolith-private"),
+                    unit="ms",
+                ),
+            ],
         ),
         NodeConfig(
             id="chat",
@@ -168,6 +307,12 @@ TOPOLOGY = TopologyConfig(
             group="monolith",
             description="discord backfill + summarization",
             slo=_slo(_envoy_success_rate_query("monolith-private")),
+            metrics=[
+                MetricConfig(
+                    key="rps",
+                    query=_envoy_rps_query("monolith-private"),
+                ),
+            ],
         ),
         NodeConfig(
             id="postgres",
@@ -175,6 +320,17 @@ TOPOLOGY = TopologyConfig(
             tier="critical",
             description="cnpg + pgvector",
             slo=_slo(_cnpg_up_query()),
+            metrics=[
+                MetricConfig(
+                    key="backends",
+                    query=_cnpg_backends_query(),
+                ),
+                MetricConfig(
+                    key="size",
+                    query=_cnpg_db_size_query(),
+                    unit=" MB",
+                ),
+            ],
         ),
         NodeConfig(
             id="nats",
@@ -190,20 +346,51 @@ TOPOLOGY = TopologyConfig(
             ingress=True,
             description="orchestrator + mcp clients",
             slo=_slo(_envoy_success_rate_query("agent-orchestrator")),
+            metrics=[
+                MetricConfig(
+                    key="rps",
+                    query=_envoy_rps_query("agent-orchestrator"),
+                ),
+                MetricConfig(
+                    key="latency",
+                    query=_envoy_avg_latency_query("agent-orchestrator"),
+                    unit="ms",
+                ),
+            ],
         ),
         NodeConfig(
             id="llama-cpp",
             label="GEMMA 4",
             tier="critical",
             description="gemma 4 inference",
-            slo=_slo(_container_ready_query("gpu-operator", "llama-cpp")),
+            slo=_slo(_container_ready_query("llama-cpp", "llama-server", "llama-cpp-")),
+            metrics=[
+                MetricConfig(
+                    key="mem",
+                    query=_container_memory_mb_query("llama-cpp", "llama-cpp"),
+                    unit=" MB",
+                ),
+            ],
         ),
         NodeConfig(
             id="voyage-embedder",
             label="VOYAGE EMBEDDER",
             tier="critical",
             description="voyage-4 embedding",
-            slo=_slo(_container_ready_query("gpu-operator", "voyage-embedder")),
+            slo=_slo(
+                _container_ready_query(
+                    "llama-cpp", "llama-server", "llama-cpp-embeddings-"
+                )
+            ),
+            metrics=[
+                MetricConfig(
+                    key="mem",
+                    query=_container_memory_mb_query(
+                        "llama-cpp", "llama-cpp-embeddings"
+                    ),
+                    unit=" MB",
+                ),
+            ],
         ),
         # --- context-forge children ---
         NodeConfig(
@@ -212,7 +399,7 @@ TOPOLOGY = TopologyConfig(
             tier="critical",
             group="context-forge",
             description="kubernetes mcp server",
-            slo=_slo(_container_ready_query("mcp", "k8s-mcp")),
+            slo=_slo(_container_ready_query("mcp", "mcp-context-forge")),
         ),
         NodeConfig(
             id="argocd-mcp",
@@ -220,7 +407,7 @@ TOPOLOGY = TopologyConfig(
             tier="critical",
             group="context-forge",
             description="argocd mcp server",
-            slo=_slo(_container_ready_query("mcp", "argocd-mcp")),
+            slo=_slo(_container_ready_query("mcp", "mcp-context-forge")),
         ),
         NodeConfig(
             id="signoz-mcp",
@@ -228,7 +415,7 @@ TOPOLOGY = TopologyConfig(
             tier="critical",
             group="context-forge",
             description="signoz mcp server",
-            slo=_slo(_container_ready_query("mcp", "signoz-mcp")),
+            slo=_slo(_container_ready_query("mcp", "mcp-context-forge")),
         ),
         # --- cluster / infra ---
         NodeConfig(
@@ -238,6 +425,12 @@ TOPOLOGY = TopologyConfig(
             group="cluster",
             description="gitops controller",
             slo=_slo(_container_ready_query("argocd", "application-controller")),
+            metrics=[
+                MetricConfig(
+                    key="apps",
+                    query=_argocd_apps_synced_query(),
+                ),
+            ],
         ),
         NodeConfig(
             id="signoz",
@@ -261,7 +454,7 @@ TOPOLOGY = TopologyConfig(
             tier="infra",
             group="cluster",
             description="distributed storage",
-            slo=_slo(_container_ready_query("longhorn-system", "longhorn-manager")),
+            slo=_slo(_container_ready_query("longhorn", "longhorn-manager")),
         ),
         NodeConfig(
             id="seaweedfs",
@@ -270,6 +463,13 @@ TOPOLOGY = TopologyConfig(
             group="cluster",
             description="object storage",
             slo=_slo(_container_ready_query("seaweedfs", "seaweedfs")),
+            metrics=[
+                MetricConfig(
+                    key="disk",
+                    query=_seaweedfs_disk_query(),
+                    unit=" GB",
+                ),
+            ],
         ),
         NodeConfig(
             id="otel-operator",
@@ -277,9 +477,7 @@ TOPOLOGY = TopologyConfig(
             tier="infra",
             group="cluster",
             description="opentelemetry operator",
-            slo=_slo(
-                _container_ready_query("opentelemetry-operator-system", "manager")
-            ),
+            slo=_slo(_container_ready_query("opentelemetry-operator", "manager")),
         ),
         NodeConfig(
             id="linkerd",

--- a/projects/platform/nats/values.yaml
+++ b/projects/platform/nats/values.yaml
@@ -10,6 +10,9 @@ nats:
       metadata:
         annotations:
           config.linkerd.io/opaque-ports: "4222"
+          prometheus.io/scrape: "true"
+          prometheus.io/port: "7777"
+          prometheus.io/path: "/metrics"
       spec:
         nodeSelector:
           kubernetes.io/hostname: node-4
@@ -82,10 +85,3 @@ nats:
       nats:
         enabled: true
         port: 4222
-    # Prometheus scrape annotations for SigNoz
-    merge:
-      metadata:
-        annotations:
-          prometheus.io/scrape: "true"
-          prometheus.io/port: "7777"
-          prometheus.io/path: "/metrics"

--- a/projects/platform/signoz/values-prod.yaml
+++ b/projects/platform/signoz/values-prod.yaml
@@ -41,18 +41,6 @@ k8s-infra:
             key: cloudflare-client-secret
     config:
       receivers:
-        # Prometheus scraper for NATS JetStream metrics
-        prometheus/nats:
-          config:
-            scrape_configs:
-              - job_name: "nats"
-                scrape_interval: 30s
-                static_configs:
-                  - targets:
-                      - "nats.nats.svc.cluster.local:7777"
-                    labels:
-                      service: nats
-
         # Prometheus scraper for NVIDIA GPU metrics (DCGM exporter)
         prometheus/dcgm:
           config:
@@ -157,7 +145,6 @@ k8s-infra:
           # Add NATS metrics to the scraper pipeline
           metrics/scraper:
             receivers:
-              - prometheus/nats
               - prometheus/dcgm
               - prometheus/cnpg
               - httpcheck/k8s-services


### PR DESCRIPTION
## Summary
- **ClickHouse query optimization**: Added `metric_name` filter to all `samples_v4` queries, enabling primary key index usage (829M → ~8M rows scanned, 6.9GB → 0.34GB read). Added `asyncio.Semaphore(2)` to prevent OOM under ClickHouse's 7.2 GiB memory budget.
- **Live metrics**: Added dynamic envoy rps/latency, CNPG backends/size, SeaweedFS disk, ArgoCD apps, and container memory queries to the topology dashboard.
- **Bug fixes**: Error budget bar now shows red when exhausted (was gray), SLO target lowered to 98% for failing services, NATS prometheus annotations moved from Service to Pod for correct OTel discovery.
- **Metrics scraping**: Enabled Prometheus endpoints on llama-cpp and voyage-embedder, removed redundant static NATS receiver from SigNoz config.

## Test plan
- [x] Topology config loads without errors (21 nodes, 3 groups, 15 edges)
- [x] All pre-commit hooks pass (semgrep, format, conventional commit)
- [ ] BuildBuddy CI tests (blocked by JVM runner crashes — infra issue, not code)
- [ ] Verify topology page renders with live metrics after deploy
- [ ] Verify NATS metrics appear in ClickHouse after pod restart picks up new annotations

🤖 Generated with [Claude Code](https://claude.com/claude-code)