### PR TITLE
feat(monolith): add Linkerd edge metrics (volume, latency, error rate)

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.42.5
+version: 0.42.6
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.42.5
+      targetRevision: 0.42.6
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/routes/public/slos/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/slos/+page.svelte
@@ -112,6 +112,26 @@
   const groups = $derived(activeLayout ? portLayout.groups : landLayout.groups);
   const groupById = $derived(activeLayout ? portLayout.groupById : landLayout.groupById);
 
+  // Midpoints for edges with Linkerd metrics — reuses box-exit logic from drawGraph().
+  // Placed after groupById/nodeById so reactive tracking picks up layout changes.
+  const edgeLinkerdMidpoints = $derived.by(() => {
+    const result = {};
+    for (const e of edges) {
+      if (!e.linkerd) continue;
+      const fromPos = nodeById[e.from] || groupById[e.from];
+      const toPos = nodeById[e.to] || groupById[e.to];
+      if (!fromPos || !toPos) continue;
+      const fromNode = nodeById[e.from] || groupById[e.from];
+      const toNode = nodeById[e.to] || groupById[e.to];
+      const fromIsGroup = !!groupById[e.from];
+      const toIsGroup = !!groupById[e.to];
+      const p1 = boxExit(fromPos.x, fromPos.y, (fromIsGroup ? fromNode.hw : fromNode.hw + 6), (fromIsGroup ? fromNode.hh : HH + 4), toPos.x, toPos.y);
+      const p2 = boxExit(toPos.x, toPos.y, (toIsGroup ? toNode.hw : toNode.hw + 6), (toIsGroup ? toNode.hh : HH + 4), fromPos.x, fromPos.y);
+      result[e.from + '-' + e.to] = { x: (p1.x + p2.x) / 2, y: (p1.y + p2.y) / 2 };
+    }
+    return result;
+  });
+
   let flipPhase = $state("none");   // "none" | "out" | "in"
   let scribbling = $state(false);   // true during scribble-out + fade
   let flipTimer = null;
@@ -1697,6 +1717,32 @@
           </text>
         {/if}
       {/each}
+      {#each edges.filter(e => e.linkerd) as e}
+        {@const key = e.from + '-' + e.to}
+        {@const mid = edgeLinkerdMidpoints[key]}
+        {@const lk = e.linkerd}
+        {#if mid && !drawing}
+          {@const parts = [
+            lk.rps != null ? lk.rps + '/s' : null,
+            lk.latency_ms != null ? lk.latency_ms + 'ms' : null,
+            lk.error_pct != null ? lk.error_pct + '%' : null,
+          ].filter(Boolean)}
+          {#if parts.length}
+            {@const label = parts.join(' · ')}
+            {@const labelW = label.length * 4.2 + 8}
+            <rect
+              x={mid.x - labelW / 2} y={mid.y - 7}
+              width={labelW} height={13}
+              rx="2"
+              fill="var(--bg)"
+              stroke="var(--border)"
+              stroke-width="0.5"
+              opacity="0.92"
+            />
+            <text x={mid.x} y={mid.y + 4} class="edge-label">{label}</text>
+          {/if}
+        {/if}
+      {/each}
     {/key}
 
     <g bind:this={scribbleG}></g>
@@ -2059,6 +2105,16 @@
     text-transform: uppercase;
     letter-spacing: 0.1em;
     transition: opacity 0.2s ease;
+  }
+
+  .edge-label {
+    font-family: var(--font);
+    font-size: 7px;
+    font-weight: 600;
+    fill: var(--fg-tertiary);
+    text-anchor: middle;
+    letter-spacing: 0.02em;
+    pointer-events: none;
   }
 
   .node-label--dimmed { opacity: 0.25; }

--- a/projects/monolith/observability/config.py
+++ b/projects/monolith/observability/config.py
@@ -49,10 +49,20 @@ class GroupConfig:
 
 
 @dataclass
+class LinkerdEdge:
+    """Pre-generated Linkerd metric queries for an HTTP edge."""
+
+    rps_query: str
+    latency_query: str
+    error_rate_query: str
+
+
+@dataclass
 class EdgeConfig:
     source: str
     target: str
     bidi: bool = False
+    linkerd: LinkerdEdge | None = None
 
 
 @dataclass

--- a/projects/monolith/observability/router.py
+++ b/projects/monolith/observability/router.py
@@ -8,7 +8,7 @@ import time
 from fastapi import APIRouter
 
 from observability.clickhouse import ClickHouseClient
-from observability.config import NodeConfig, GroupConfig, TopologyConfig
+from observability.config import EdgeConfig, GroupConfig, NodeConfig, TopologyConfig
 from observability.slo import (
     aggregate_group,
     compute_brief,
@@ -121,6 +121,33 @@ async def _query_node(client: ClickHouseClient, node: NodeConfig) -> dict:
     return result
 
 
+async def _query_edge(client: ClickHouseClient, edge: EdgeConfig) -> dict:
+    """Serialize an edge, running Linkerd metric queries if configured."""
+    result: dict = {"from": edge.source, "to": edge.target}
+    if edge.bidi:
+        result["bidi"] = True
+    if edge.linkerd is None:
+        return result
+    lk = edge.linkerd
+    try:
+        rps, latency, error_rate = await asyncio.gather(
+            _ch_scalar(client, lk.rps_query),
+            _ch_scalar(client, lk.latency_query),
+            _ch_scalar(client, lk.error_rate_query),
+            return_exceptions=True,
+        )
+        result["linkerd"] = {
+            "rps": rps if not isinstance(rps, Exception) else None,
+            "latency_ms": latency if not isinstance(latency, Exception) else None,
+            "error_pct": error_rate if not isinstance(error_rate, Exception) else None,
+        }
+    except Exception:
+        logger.exception(
+            "Linkerd edge query failed for %s->%s", edge.source, edge.target
+        )
+    return result
+
+
 async def build_topology() -> dict:
     """Execute all queries and build the full topology response."""
     cfg = TOPOLOGY
@@ -135,10 +162,16 @@ async def build_topology() -> dict:
     )
 
     try:
-        # Query all nodes in parallel
-        node_results = await asyncio.gather(
-            *[_query_node(client, n) for n in cfg.nodes],
-            return_exceptions=True,
+        # Query all nodes and edges in parallel
+        node_results, edge_results = await asyncio.gather(
+            asyncio.gather(
+                *[_query_node(client, n) for n in cfg.nodes],
+                return_exceptions=True,
+            ),
+            asyncio.gather(
+                *[_query_edge(client, e) for e in cfg.edges],
+                return_exceptions=True,
+            ),
         )
 
         # Build node lookup, handling exceptions
@@ -186,11 +219,16 @@ async def build_topology() -> dict:
 
         # Edges
         edges = []
-        for e in cfg.edges:
-            edge = {"from": e.source, "to": e.target}
-            if e.bidi:
-                edge["bidi"] = True
-            edges.append(edge)
+        for i, r in enumerate(edge_results):
+            if isinstance(r, Exception):
+                e = cfg.edges[i]
+                logger.error("Edge %s->%s failed: %s", e.source, e.target, r)
+                edge: dict = {"from": e.source, "to": e.target}
+                if e.bidi:
+                    edge["bidi"] = True
+                edges.append(edge)
+            else:
+                edges.append(r)
 
         return {"groups": groups, "nodes": nodes, "edges": edges}
     finally:

--- a/projects/monolith/observability/topology_config.py
+++ b/projects/monolith/observability/topology_config.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 from observability.config import (
     EdgeConfig,
     GroupConfig,
+    LinkerdEdge,
     MetricConfig,
     NodeConfig,
     SloConfig,
@@ -247,6 +248,101 @@ WITH latest AS (
   GROUP BY fingerprint
 )
 SELECT round(sum(v)) AS value FROM latest"""
+
+
+def _linkerd_rps_query(src: str, dst_ns: str, dst_svc: str) -> str:
+    """Metric query: requests per second over the last 5 minutes (Linkerd outbound)."""
+    return f"""\
+WITH c AS (
+  SELECT fingerprint, max(value) - min(value) AS delta
+  FROM signoz_metrics.distributed_samples_v4
+  WHERE metric_name = 'outbound_http_route_request_duration_seconds.count'
+    AND fingerprint IN (
+    SELECT DISTINCT fingerprint FROM signoz_metrics.distributed_time_series_v4_6hrs
+    WHERE metric_name = 'outbound_http_route_request_duration_seconds.count'
+      AND JSONExtractString(labels, 'k8s.deployment.name') = '{src}'
+      AND JSONExtractString(labels, 'parent_name') = '{dst_svc}'
+      AND JSONExtractString(labels, 'parent_namespace') = '{dst_ns}'
+  ) AND unix_milli >= toUnixTimestamp(now() - INTERVAL 5 MINUTE) * 1000
+  GROUP BY fingerprint
+)
+SELECT round(sum(delta) / 300, 2) AS value FROM c"""
+
+
+def _linkerd_latency_query(src: str, dst_ns: str, dst_svc: str) -> str:
+    """Metric query: average request latency in ms over the last 5 minutes (Linkerd outbound)."""
+    return f"""\
+WITH
+s AS (
+  SELECT fingerprint, max(value) - min(value) AS delta
+  FROM signoz_metrics.distributed_samples_v4
+  WHERE metric_name = 'outbound_http_route_request_duration_seconds.sum'
+    AND fingerprint IN (
+    SELECT DISTINCT fingerprint FROM signoz_metrics.distributed_time_series_v4_6hrs
+    WHERE metric_name = 'outbound_http_route_request_duration_seconds.sum'
+      AND JSONExtractString(labels, 'k8s.deployment.name') = '{src}'
+      AND JSONExtractString(labels, 'parent_name') = '{dst_svc}'
+      AND JSONExtractString(labels, 'parent_namespace') = '{dst_ns}'
+  ) AND unix_milli >= toUnixTimestamp(now() - INTERVAL 5 MINUTE) * 1000
+  GROUP BY fingerprint
+),
+c AS (
+  SELECT fingerprint, max(value) - min(value) AS delta
+  FROM signoz_metrics.distributed_samples_v4
+  WHERE metric_name = 'outbound_http_route_request_duration_seconds.count'
+    AND fingerprint IN (
+    SELECT DISTINCT fingerprint FROM signoz_metrics.distributed_time_series_v4_6hrs
+    WHERE metric_name = 'outbound_http_route_request_duration_seconds.count'
+      AND JSONExtractString(labels, 'k8s.deployment.name') = '{src}'
+      AND JSONExtractString(labels, 'parent_name') = '{dst_svc}'
+      AND JSONExtractString(labels, 'parent_namespace') = '{dst_ns}'
+  ) AND unix_milli >= toUnixTimestamp(now() - INTERVAL 5 MINUTE) * 1000
+  GROUP BY fingerprint
+)
+SELECT round(sum(s.delta) / nullIf(sum(c.delta), 0) * 1000, 1) AS value
+FROM s JOIN c ON s.fingerprint = c.fingerprint
+WHERE c.delta > 0"""
+
+
+def _linkerd_error_rate_query(src: str, dst_ns: str, dst_svc: str) -> str:
+    """Metric query: HTTP error rate % over the last 5 minutes (Linkerd outbound).
+
+    Errors = 5xx responses OR non-empty Linkerd error label (e.g. FAIL_FAST).
+    """
+    return f"""\
+WITH
+ts AS (
+  SELECT fingerprint,
+    JSONExtractString(labels, 'http_status') AS http_status,
+    JSONExtractString(labels, 'error') AS error_label
+  FROM signoz_metrics.distributed_time_series_v4_6hrs
+  WHERE metric_name = 'outbound_http_route_backend_response_statuses_total'
+    AND JSONExtractString(labels, 'k8s.deployment.name') = '{src}'
+    AND JSONExtractString(labels, 'parent_name') = '{dst_svc}'
+    AND JSONExtractString(labels, 'parent_namespace') = '{dst_ns}'
+),
+deltas AS (
+  SELECT fingerprint, max(value) - min(value) AS delta
+  FROM signoz_metrics.distributed_samples_v4
+  WHERE metric_name = 'outbound_http_route_backend_response_statuses_total'
+    AND fingerprint IN (SELECT fingerprint FROM ts)
+    AND unix_milli >= toUnixTimestamp(now() - INTERVAL 5 MINUTE) * 1000
+  GROUP BY fingerprint
+)
+SELECT round(
+  100.0 * sumIf(d.delta, t.http_status LIKE '5%' OR t.error_label != '')
+  / nullIf(sum(d.delta), 0),
+  1
+) AS value
+FROM deltas d JOIN ts t ON d.fingerprint = t.fingerprint"""
+
+
+def _linkerd(src: str, dst_ns: str, dst_svc: str) -> LinkerdEdge:
+    return LinkerdEdge(
+        rps_query=_linkerd_rps_query(src, dst_ns, dst_svc),
+        latency_query=_linkerd_latency_query(src, dst_ns, dst_svc),
+        error_rate_query=_linkerd_error_rate_query(src, dst_ns, dst_svc),
+    )
 
 
 def _slo(query: str) -> SloConfig:
@@ -560,9 +656,17 @@ TOPOLOGY = TopologyConfig(
         EdgeConfig(source="home", target="postgres", bidi=True),
         EdgeConfig(source="knowledge", target="postgres", bidi=True),
         EdgeConfig(source="knowledge", target="voyage-embedder"),
-        EdgeConfig(source="knowledge", target="llama-cpp"),
+        EdgeConfig(
+            source="knowledge",
+            target="llama-cpp",
+            linkerd=_linkerd("monolith", "llama-cpp", "llama-cpp"),
+        ),
         EdgeConfig(source="chat", target="postgres", bidi=True),
-        EdgeConfig(source="chat", target="llama-cpp"),
+        EdgeConfig(
+            source="chat",
+            target="llama-cpp",
+            linkerd=_linkerd("monolith", "llama-cpp", "llama-cpp"),
+        ),
         EdgeConfig(source="chat", target="discord"),
         EdgeConfig(source="nats", target="agent-platform", bidi=True),
         EdgeConfig(source="agent-platform", target="k8s-mcp"),


### PR DESCRIPTION
## Summary

- Adds `LinkerdEdge` to `EdgeConfig` — stores pre-generated ClickHouse queries for volume/latency/error rate (consistent with how `MetricConfig.query` works for nodes)
- Three Linkerd metrics per HTTP edge: `outbound_http_route_request_duration_seconds` (RPS + avg latency) and `outbound_http_route_backend_response_statuses_total` (error rate: 5xx + Linkerd `error` label)
- Wires up `knowledge→llama-cpp` and `chat→llama-cpp` edges — both use `monolith → llama-cpp/llama-cpp` since both services run in the same deployment
- `_query_edge()` runs all 3 queries in parallel; edge queries run alongside node queries via nested `asyncio.gather`
- Frontend: edge labels appear at the edge midpoint (computed reactively via `$derived.by`) after the draw animation completes — format: `0.2/s · 123ms · 0%`

## Test plan

- [ ] CI passes (Python tests, semgrep, format)
- [ ] ArgoCD syncs monolith 0.42.6
- [ ] SLOs page shows metric labels on knowledge→llama-cpp and chat→llama-cpp edges after draw animation
- [ ] Labels absent on edges without linkerd config (postgres, NATS, etc.)
- [ ] Dark mode: labels readable with `--fg-tertiary` and `--bg` background

🤖 Generated with [Claude Code](https://claude.com/claude-code)