### PR TITLE
ci(semgrep): add no-inline-subchart rule

### DIFF
--- a/bazel/semgrep/rules/yaml/no-inline-subchart.yaml
+++ b/bazel/semgrep/rules/yaml/no-inline-subchart.yaml
@@ -1,0 +1,32 @@
+rules:
+  - id: no-inline-subchart
+    languages: [yaml]
+    severity: WARNING
+    message: >-
+      Inline subchart configuration block with `enabled: true` detected.
+      Enabling bundled subcharts (postgresql, redis, etc.) pulls in an unvetted
+      dependency and bypasses the homelab GitOps review process. Provision the
+      dependency as a standalone ArgoCD Application with its own
+      `projects/<service>/deploy/` directory instead.
+    metadata:
+      category: maintainability
+      subcategory: chart-structure
+      confidence: HIGH
+      likelihood: MEDIUM
+      impact: MEDIUM
+      technology: [helm, kubernetes]
+      description: >-
+        Detects enabling of bundled subchart dependencies (postgresql, redis,
+        etc.) in values.yaml. These should be standalone ArgoCD Applications.
+    paths:
+      include:
+        - "**/values*.yaml"
+    patterns:
+      - pattern: |
+          $CHART:
+            ...
+            enabled: true
+            ...
+      - metavariable-regex:
+          metavariable: $CHART
+          regex: '^(postgresql|redis|mariadb|mysql|mongodb|rabbitmq|elasticsearch|kafka|minio|memcached|clickhouse|opensearch)$'

--- a/bazel/semgrep/tests/fixtures/no-inline-subchart.yaml
+++ b/bazel/semgrep/tests/fixtures/no-inline-subchart.yaml
@@ -1,0 +1,31 @@
+# Tests for no-inline-subchart rule.
+---
+# ruleid: no-inline-subchart
+postgresql:
+  enabled: true
+  postgresqlUsername: myuser
+  postgresqlDatabase: mydb
+
+---
+# ruleid: no-inline-subchart
+redis:
+  enabled: true
+  auth:
+    enabled: false
+
+---
+# ok: no-inline-subchart — subchart is explicitly disabled
+redis:
+  enabled: false
+
+---
+# ok: no-inline-subchart — not a known subchart key
+myapp:
+  enabled: true
+  port: 8080
+
+---
+# ok: no-inline-subchart — no enabled key
+postgresql:
+  host: postgres.svc.cluster.local
+  port: 5432


### PR DESCRIPTION
## Summary
- Adds a new semgrep rule `no-inline-subchart` that warns when bundled subcharts (postgresql, redis, mariadb, etc.) are enabled in `values*.yaml` files
- Adds test fixtures covering both positive (should warn) and negative (should not warn) cases
- No BUILD file changes needed — rule and fixture globs pick up new files automatically

## Test plan
- [ ] CI runs `//bazel/semgrep/rules:yaml_rules_test` and passes
- [ ] Rule fires on `postgresql: enabled: true` and `redis: enabled: true` patterns
- [ ] Rule does not fire on disabled subcharts, unknown keys, or missing `enabled` key

🤖 Generated with [Claude Code](https://claude.com/claude-code)