### PR TITLE
ci(hooks): restore unnecessary chart bump warning

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -146,6 +146,11 @@
             "type": "command",
             "command": "bazel/tools/hooks/pretooluse-write-edit.sh",
             "timeout": 10
+          },
+          {
+            "type": "command",
+            "command": "bazel/tools/hooks/check-unnecessary-chart-bump.sh",
+            "timeout": 10
           }
         ]
       }

--- a/bazel/tools/hooks/check-unnecessary-chart-bump.sh
+++ b/bazel/tools/hooks/check-unnecessary-chart-bump.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# PreToolUse hook: warn when bumping Chart.yaml for test-only branch changes.
+#
+# A chart version bump triggers an ArgoCD redeploy and pod restart.
+# If all other branch changes are in test files, the bump is likely unnecessary.
+#
+# Input: JSON on stdin from Claude Code hook system
+# Exit 0: allow (warnings emitted on stderr)
+# Exit 2: block (not used — this is advisory only)
+
+set -euo pipefail
+
+INPUT=$(cat)
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
+
+# Only trigger on chart/Chart.yaml edits
+[[ "$FILE_PATH" == */chart/Chart.yaml ]] || exit 0
+
+REPO_ROOT=$(git -C "$(dirname "$FILE_PATH")" rev-parse --show-toplevel 2>/dev/null) || exit 0
+
+# Get all files changed vs origin/main on the current branch
+CHANGED_FILES=$(git -C "$REPO_ROOT" diff --name-only origin/main...HEAD 2>/dev/null) || exit 0
+
+# Nothing staged yet — nothing to warn about
+[[ -n "$CHANGED_FILES" ]] || exit 0
+
+# Find non-test changes, excluding any Chart.yaml files themselves
+NON_TEST=$(echo "$CHANGED_FILES" | grep -Ev '(chart/Chart\.yaml|_test\.(go|py)$)' | grep -Ev '^test_.*\.py$' || true)
+
+if [[ -z "$NON_TEST" ]]; then
+	cat >&2 <<-EOF
+		WARNING: Bumping Chart.yaml when all branch changes appear to be test-only.
+
+		Chart version bumps trigger an ArgoCD redeploy and pod restart.
+		If no production code changed, skip the chart version bump.
+
+		Branch changes so far:
+		$(echo "$CHANGED_FILES" | head -10)
+
+		If this bump is intentional (e.g. the chart itself changed), proceed.
+		Otherwise, revert the version change in Chart.yaml.
+	EOF
+fi
+
+exit 0


### PR DESCRIPTION
## Summary

- Adds a new PreToolUse hook `check-unnecessary-chart-bump.sh` that warns when `Chart.yaml` is being edited but all other branch changes are test-only files
- Registers the hook in `.claude/settings.json` alongside the existing `pretooluse-write-edit.sh` under the `Write|Edit` matcher
- Chart version bumps trigger ArgoCD redeployments and pod restarts — this advisory warning (exit 0, stderr only) helps avoid unnecessary churn as seen in PR #2062

## Test plan

- [ ] Verify hook fires when editing `chart/Chart.yaml` on a branch with only test file changes
- [ ] Verify hook is silent when there are non-test production code changes alongside the chart bump
- [ ] Verify hook is silent when editing non-`Chart.yaml` files
- [ ] Confirm `.claude/settings.json` is valid JSON and CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)