### PR TITLE
ci(semgrep): add no-generic-test-filename rule

### DIFF
--- a/bazel/semgrep/rules/BUILD
+++ b/bazel/semgrep/rules/BUILD
@@ -166,6 +166,22 @@ semgrep_test(
     tags = ["semgrep"],
 )
 
+# no-generic-test-filename uses languages: [generic] so its fixture is a Python file.
+# This test wires the rule to its annotation fixture independently of
+# generic_rules_test (which only scans no-stale-repo-paths fixtures).
+filegroup(
+    name = "no_generic_test_filename_rule",
+    srcs = ["generic/no-generic-test-filename.yaml"],
+)
+
+semgrep_test(
+    name = "no_generic_test_filename_test",
+    srcs = ["//bazel/semgrep/tests:no_generic_test_filename_fixtures"],
+    env = {"SEMGREP_TEST_MODE": "1"},
+    rules = [":no_generic_test_filename_rule"],
+    tags = ["semgrep"],
+)
+
 # stale-copyright-year uses languages: [generic] so its fixture is a YAML file.
 # This test wires the rule to its annotation fixture independently of
 # golang_rules_test (which only scans *.go sources).

--- a/bazel/semgrep/rules/generic/no-generic-test-filename.yaml
+++ b/bazel/semgrep/rules/generic/no-generic-test-filename.yaml
@@ -1,0 +1,37 @@
+rules:
+  - id: no-generic-test-filename
+    languages: [generic]
+    severity: WARNING
+    message: >-
+      Test file has a vague or temporary name. Names like `coverage_test`,
+      `gaps_test`, `remaining_test`, `final_*_test`, `new_*_test`, or
+      `identified_test` describe a coding session artifact, not a stable
+      test suite. Rename to reflect the behaviour under test
+      (e.g. `auth_token_expiry_test.go`, `batch_ingest_test.py`).
+    metadata:
+      category: maintainability
+      subcategory: naming
+      confidence: HIGH
+      likelihood: LOW
+      impact: LOW
+      technology: [python, go]
+      description: >-
+        Flags test files whose basenames contain vague or temporary words
+        (coverage, gaps, remaining, final_, new_, identified) that suggest
+        they were created as a one-off session artifact rather than a
+        permanent test suite.
+    paths:
+      include:
+        - "**/*coverage*_test.py"
+        - "**/*coverage*_test.go"
+        - "**/*gaps*_test.py"
+        - "**/*gaps*_test.go"
+        - "**/*remaining*_test.py"
+        - "**/*remaining*_test.go"
+        - "**/final_*_test.py"
+        - "**/final_*_test.go"
+        - "**/new_*_test.py"
+        - "**/new_*_test.go"
+        - "**/*identified*_test.py"
+        - "**/*identified*_test.go"
+    pattern-regex: '(def\s+test_\w+|func\s+Test\w+)'

--- a/bazel/semgrep/tests/BUILD
+++ b/bazel/semgrep/tests/BUILD
@@ -46,6 +46,13 @@ filegroup(
     srcs = ["fixtures/no-create-extension-sql.yaml"],
 )
 
+# Fixture for the no-generic-test-filename rule (languages: generic, paths-filtered).
+# Referenced by //bazel/semgrep/rules:no_generic_test_filename_test.
+filegroup(
+    name = "no_generic_test_filename_fixtures",
+    srcs = ["fixtures/no-generic-test-filename.py"],
+)
+
 # Fixtures for kubernetes rules (require-readiness-probe, require-resource-limits, etc.).
 # Referenced by //bazel/semgrep/rules:kubernetes_rules_test.
 # New rule fixtures should be added here as they are created.

--- a/bazel/semgrep/tests/fixtures/no-generic-test-filename.py
+++ b/bazel/semgrep/tests/fixtures/no-generic-test-filename.py
@@ -1,0 +1,24 @@
+# Tests for no-generic-test-filename rule.
+# This fixture simulates a vague-named test file (e.g. coverage_test.py).
+# In production the rule only fires on files matching the paths.include patterns;
+# paths.include is not applied in semgrep --test mode, so content anchors
+# (def test_ / func Test) drive the annotations here.
+
+# ruleid: no-generic-test-filename
+def test_coverage():
+    assert True
+
+
+# ruleid: no-generic-test-filename
+def test_identified_gaps():
+    pass
+
+
+# ok: no-generic-test-filename — helper, not a test function
+def setup_fixtures():
+    return {}
+
+
+# ok: no-generic-test-filename — not a test function definition
+class SomeHelper:
+    pass


### PR DESCRIPTION
## Summary

- Adds a new semgrep rule `no-generic-test-filename` that flags test files with vague or temporary names (e.g. `coverage_test.py`, `gaps_test.go`, `final_*_test.py`) that describe a coding session artifact rather than a stable test suite
- Wires the rule to a dedicated fixture and Bazel test target (`no_generic_test_filename_test`), following the same pattern as `stale_copyright_year_test` and `sql_rules_test`

## Test plan

- [ ] `//bazel/semgrep/rules:no_generic_test_filename_test` passes with the fixture annotations (`ruleid` / `ok` lines)
- [ ] `//bazel/semgrep/rules:generic_rules_test` continues to pass (no regression)
- [ ] New fixture file `no-generic-test-filename.py` is excluded from unrelated fixture filegroups (it is only in `no_generic_test_filename_fixtures`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)