### PR TITLE
ci(semgrep): add Python no-hardcoded-k8s-service-url rule

### DIFF
--- a/bazel/semgrep/rules/python/no-hardcoded-k8s-service-url.py
+++ b/bazel/semgrep/rules/python/no-hardcoded-k8s-service-url.py
@@ -22,7 +22,10 @@ def bad_os_environ_get():
 
 def bad_os_environ_get_inline():
     # ruleid: no-hardcoded-k8s-service-url
-    url = os.environ.get("OTEL_ENDPOINT", "http://signoz-otel-agent.signoz.svc.cluster.local:4318/v1/traces")
+    url = os.environ.get(
+        "OTEL_ENDPOINT",
+        "http://signoz-otel-agent.signoz.svc.cluster.local:4318/v1/traces",
+    )
     return url
 
 

--- a/bazel/semgrep/rules/python/no-hardcoded-k8s-service-url.py
+++ b/bazel/semgrep/rules/python/no-hardcoded-k8s-service-url.py
@@ -1,0 +1,57 @@
+# Tests for no-hardcoded-k8s-service-url rule.
+# Hardcoded .svc.cluster.local URLs silently break when Helm release names change.
+# Configure service URLs via environment variables injected from Helm values.yaml.
+import os
+
+
+def bad_default_parameter(
+    # ruleid: no-hardcoded-k8s-service-url
+    base_url: str = "http://chi-signoz-clickhouse-cluster-0-0.signoz.svc.cluster.local:8123",
+):
+    return base_url
+
+
+def bad_os_environ_get():
+    # ruleid: no-hardcoded-k8s-service-url
+    url = os.environ.get(
+        "CLICKHOUSE_URL",
+        "http://chi-signoz-clickhouse-cluster-0-0.signoz.svc.cluster.local:8123",
+    )
+    return url
+
+
+def bad_os_environ_get_inline():
+    # ruleid: no-hardcoded-k8s-service-url
+    url = os.environ.get("OTEL_ENDPOINT", "http://signoz-otel-agent.signoz.svc.cluster.local:4318/v1/traces")
+    return url
+
+
+def bad_hardcoded_assignment():
+    # ruleid: no-hardcoded-k8s-service-url
+    url = "http://my-service.default.svc.cluster.local:8080"
+    return url
+
+
+def ok_empty_string_default(
+    # ok: no-hardcoded-k8s-service-url — empty string, URL injected via env
+    base_url: str = "",
+):
+    return base_url
+
+
+def ok_os_environ_get_no_fallback():
+    # ok: no-hardcoded-k8s-service-url — no hardcoded fallback
+    url = os.environ.get("CLICKHOUSE_URL", "")
+    return url
+
+
+def ok_external_url():
+    # ok: no-hardcoded-k8s-service-url — not a cluster-local URL
+    url = "http://example.com/api"
+    return url
+
+
+def ok_localhost():
+    # ok: no-hardcoded-k8s-service-url — localhost is fine
+    url = "http://localhost:8080"
+    return url

--- a/bazel/semgrep/rules/python/no-hardcoded-k8s-service-url.yaml
+++ b/bazel/semgrep/rules/python/no-hardcoded-k8s-service-url.yaml
@@ -1,0 +1,22 @@
+rules:
+  - id: no-hardcoded-k8s-service-url
+    patterns:
+      - pattern-regex: '\.svc\.cluster\.local'
+    message: >-
+      Hardcoded Kubernetes in-cluster service URL detected. When a Helm release
+      name changes (e.g. renaming an ArgoCD app), the release name prefix on
+      service names changes too — hardcoded defaults silently break DNS
+      resolution. Configure service URLs via environment variables injected
+      from Helm values.yaml instead.
+    languages: [python]
+    severity: WARNING
+    metadata:
+      category: best-practices
+    paths:
+      include:
+        - "**/*.py"
+      exclude:
+        - "**/*_test.py"
+        - "**/test_*.py"
+        - "**/tests/**"
+        - "**/conftest.py"

--- a/projects/monolith/app/main.py
+++ b/projects/monolith/app/main.py
@@ -199,10 +199,7 @@ _tracer_provider = TracerProvider(
 _tracer_provider.add_span_processor(
     BatchSpanProcessor(
         OTLPSpanExporter(
-            endpoint=os.environ.get(
-                "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
-                "http://signoz-k8s-infra-otel-agent.signoz.svc.cluster.local:4318/v1/traces",
-            ),
+            endpoint=os.environ.get("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", ""),
         )
     )
 )

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.42.10
+version: 0.42.11
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.42.10
+      targetRevision: 0.42.11
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/observability/clickhouse.py
+++ b/projects/monolith/observability/clickhouse.py
@@ -12,7 +12,7 @@ class ClickHouseClient:
 
     def __init__(
         self,
-        base_url: str = "http://chi-signoz-clickhouse-cluster-0-0.signoz.svc.cluster.local:8123",
+        base_url: str = "",
         user: str = "",
         password: str = "",
         transport: httpx.AsyncBaseTransport | None = None,

--- a/projects/monolith/observability/router.py
+++ b/projects/monolith/observability/router.py
@@ -151,10 +151,7 @@ async def _query_edge(client: ClickHouseClient, edge: EdgeConfig) -> dict:
 async def build_topology() -> dict:
     """Execute all queries and build the full topology response."""
     cfg = TOPOLOGY
-    ch_url = os.environ.get(
-        "CLICKHOUSE_URL",
-        "http://chi-signoz-clickhouse-cluster-0-0.signoz.svc.cluster.local:8123",
-    )
+    ch_url = os.environ.get("CLICKHOUSE_URL", "")
     client = ClickHouseClient(
         base_url=ch_url,
         user=os.environ.get("CLICKHOUSE_USER", ""),


### PR DESCRIPTION
## Summary

- Adds `bazel/semgrep/rules/python/no-hardcoded-k8s-service-url.yaml` — mirrors the existing Go rule; catches `.svc.cluster.local` in Python string literals so hardcoded Kubernetes service URLs are flagged before they can silently break on Helm release renames
- Adds `bazel/semgrep/rules/python/no-hardcoded-k8s-service-url.py` — inline test fixture with `# ruleid:` / `# ok:` annotations covering function defaults, `os.environ.get()` fallbacks, and plain assignments; excludes test files via `paths.exclude`
- Fixes 3 existing violations in `projects/monolith/`:
  - `observability/clickhouse.py:15` — `base_url` default changed from hardcoded URL → `""`
  - `observability/router.py:156` — `os.environ.get("CLICKHOUSE_URL", "<url>")` → `os.environ.get("CLICKHOUSE_URL", "")`
  - `app/main.py:204` — `os.environ.get("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "<url>")` → `os.environ.get("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "")` — URL is already injected via Helm `values.yaml`

## Test plan

- [ ] `//bazel/semgrep/rules:python_rules_test` passes (semgrep test mode validates `# ruleid:` / `# ok:` annotations)
- [ ] Monolith Python files no longer trigger the new rule
- [ ] Existing Go semgrep tests unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)