### PR TITLE
ci(semgrep): add no-stale-clickhouse-timeseries-table rule

### DIFF
--- a/bazel/semgrep/rules/python/no-stale-clickhouse-timeseries-table.py
+++ b/bazel/semgrep/rules/python/no-stale-clickhouse-timeseries-table.py
@@ -1,0 +1,13 @@
+# Tests for no-stale-clickhouse-timeseries-table rule.
+
+# ruleid: no-stale-clickhouse-timeseries-table
+query = "SELECT * FROM distributed_time_series_v4"
+
+# ruleid: no-stale-clickhouse-timeseries-table
+query = "SELECT fingerprint FROM distributed_time_series_v4 WHERE"
+
+# ok: no-stale-clickhouse-timeseries-table
+query = "SELECT * FROM distributed_time_series_v4_6hrs"
+
+# ok: no-stale-clickhouse-timeseries-table
+query = "SELECT * FROM distributed_time_series_v4_1day"

--- a/bazel/semgrep/rules/python/no-stale-clickhouse-timeseries-table.yaml
+++ b/bazel/semgrep/rules/python/no-stale-clickhouse-timeseries-table.yaml
@@ -1,0 +1,12 @@
+rules:
+  - id: no-stale-clickhouse-timeseries-table
+    languages: [python]
+    severity: WARNING
+    message: >
+      Use distributed_time_series_v4_6hrs instead of distributed_time_series_v4
+      for fingerprint lookups — the non-aggregated table is slower and can cause
+      ClickHouse OOMs.
+    paths:
+      include:
+        - "**/*.py"
+    pattern-regex: 'distributed_time_series_v4(?!_)'


### PR DESCRIPTION
## Summary
- Adds semgrep rule `python/no-stale-clickhouse-timeseries-table` to catch usage of the stale `distributed_time_series_v4` table (without `_6hrs` or `_1day` suffix) in Python files
- The non-aggregated table is slower and can cause ClickHouse OOMs on long time ranges (PR #2071 fixed 4 such instances)
- Includes inline test fixture with pass/fail examples

## Test plan
- [ ] `bb remote --os=linux --arch=amd64 test //bazel/semgrep/... --config=ci` passes
- [ ] Rule correctly flags `distributed_time_series_v4` without suffix
- [ ] Rule correctly allows `distributed_time_series_v4_6hrs` and `distributed_time_series_v4_1day`

🤖 Generated with [Claude Code](https://claude.com/claude-code)