### PR TITLE
feat(chat): knowledge graph explorer with rough.js visualization

### DIFF
--- a/docs/plans/2026-04-14-kg-explorer-design.md
+++ b/docs/plans/2026-04-14-kg-explorer-design.md
@@ -1,0 +1,153 @@
+# Knowledge Graph Explorer Design
+
+## Problem
+
+The knowledge graph has semantic search and typed edges (refines, contradicts, derives_from, etc.) but no way to interactively explore it. Search results are flat lists — you can't see how concepts connect or watch the retrieval process unfold.
+
+## Solution
+
+A chat-driven knowledge graph explorer at `private.jomcgi.dev/chat`. The user asks questions, Gemma-4 searches and traverses the KG using tools, and a rough.js hand-drawn graph animates below the chat as nodes are discovered, connected, and discarded.
+
+## Architecture
+
+### SSE Event Protocol
+
+A single SSE stream per user message carries interleaved text and graph events:
+
+| Event             | Payload                                                                  | Trigger                                        |
+| ----------------- | ------------------------------------------------------------------------ | ---------------------------------------------- |
+| `node_discovered` | `{note_id, title, tags, type, snippet, edges: [{target_id, edge_type}]}` | Agent calls `search_kg` or `expand_node`       |
+| `node_discarded`  | `{note_id, reason}`                                                      | Agent calls `discard_node`                     |
+| `edge_traversed`  | `{from_id, to_id, edge_type}`                                            | Agent calls `expand_node`                      |
+| `text_chunk`      | `{text}`                                                                 | Gemma streamed response tokens                 |
+| `thinking`        | `{text}`                                                                 | Gemma reasoning_content (collapsed by default) |
+| `done`            | `{}`                                                                     | Stream complete                                |
+| `error`           | `{message}`                                                              | Failure                                        |
+
+`node_discovered` includes outgoing edges so the frontend can draw connections between nodes already in the graph without a separate fetch. Edges to undiscovered nodes are deferred.
+
+### Backend — PydanticAI Agent
+
+**New file: `chat/explorer.py`**
+
+A PydanticAI agent with Gemma-4 and three tools:
+
+- **`search_kg(query)`** — Embed query via EmbeddingClient, vector search via KnowledgeStore. Emits `node_discovered` per result. Returns formatted results to Gemma.
+- **`expand_node(note_id)`** — Fetch edges via KnowledgeStore.get_note_links(), fetch linked note metadata. Emits `edge_traversed` then `node_discovered` for new nodes. Returns edge summaries to Gemma.
+- **`discard_node(note_id, reason)`** — Emits `node_discarded`. Returns confirmation to Gemma.
+
+Each tool receives an SSE emitter via `ctx.deps` to push graph events onto the same stream as text tokens.
+
+**New endpoint in `chat/router.py`:**
+
+```
+POST /api/chat/explore
+Body: {"message": "...", "history": [...]}
+Response: text/event-stream (SSE)
+```
+
+History array carries prior turns — no server-side session state. The system prompt instructs Gemma to search the KG before answering, expand promising nodes, discard irrelevant results explicitly, and synthesize answers referencing discovered nodes.
+
+### Frontend — SvelteKit Page
+
+**Route: `private/chat/`** — `+page.svelte` (SSR disabled), `+server.js` proxies SSE from FastAPI.
+
+#### Layout
+
+Brutalist / MotherDuck-inspired aesthetic:
+
+- **Dark header bar** (`#1a1a1a`): "KNOWLEDGE EXPLORER — powered by gemma-4"
+- **Chat card** (`#f5f0e8`, 2px hard border): scrollable message log + input bar at bottom. Gemma messages left-aligned with thin left-border accent, user messages right-aligned. Monospace throughout, uppercase headings.
+- **Graph canvas** (below chat, separated by horizontal rules — no bounding box): rough.js SVG that grows unbounded as nodes are discovered. Scrolls vertically, pans horizontally.
+- **Page background**: `#faf8f4` (slightly cooler than cards)
+
+#### Graph Rendering
+
+Rough.js hand-drawn nodes with pencil-to-ink-to-fill animation (reused from observability-demo). Nodes color-coded by note type:
+
+- `note` — muted blue
+- `paper` — muted green
+- `article` — muted amber
+- `recipe` — muted rose
+- `discarded` — grey with rough.js diagonal strikethrough
+
+Edge labels show relationship type in small monospace text at midpoint.
+
+#### Incremental Layout with Smooth Transitions
+
+Each `node_discovered` event triggers a dagre re-layout:
+
+1. Add node to graph state
+2. Re-run `dagre.layout()` with all current nodes + edges
+3. Existing nodes: lerp from old position to new over 300ms (`transition: transform`)
+4. New nodes: pencil-to-ink-to-fill animation
+5. New edges: pencil-to-ink after both endpoints are drawn
+
+Smooth position transitions are critical — the graph must not feel janky when dagre rearranges existing nodes to accommodate new ones.
+
+#### Interactions
+
+- **Hover**: highlight node + connected edges (same system as observability-demo)
+- **Click node**: slide-out drawer from right with rendered markdown note content, metadata, tags, and outgoing edges list
+- **Discarded nodes**: rough.js diagonal strikethrough, fill fades to grey, no longer interactive
+
+#### Note Drawer
+
+Same pattern as observability-demo detail drawer:
+
+- Header: note title (uppercase monospace), type badge, tag pills
+- Metadata: type, source, indexed date
+- Body: rendered markdown (via `marked` or similar)
+- Edges: outgoing edges grouped by type, clicking in-graph targets highlights them
+
+2px hard border, warm cream background. Overlaps graph canvas with subtle shadow. Dismiss via click-outside, Escape, or re-click node.
+
+## Persistence
+
+**MVP: no persistence.** Refresh clears graph and chat. The feature is an exploration session, not a saved artifact.
+
+**Future:** Server-side event storage with session IDs, replay endpoint for reconnection, localStorage for graceful recovery.
+
+## Scope
+
+### MVP
+
+- Chat input with SSE streaming to Gemma-4 PydanticAI agent
+- Three KG tools (search, expand, discard) emitting graph events
+- Rough.js animated graph growing across chat turns
+- Smooth dagre re-layout with position lerping
+- Color-coded nodes by note type
+- Rough.js strikethrough for discarded nodes
+- Hover highlights, click opens note drawer with markdown
+- Dark/light theme support (warm cream on both)
+- Private route behind existing auth
+
+### Not in scope
+
+- Session persistence / replay
+- Potential edge discovery on highlight (ghost nodes)
+- Bring-into-context from unloaded edges
+- Pinch-to-zoom / minimap
+- Mobile-optimized layout
+- Conversation history sidebar
+- Sharing explorations
+
+## Dependencies
+
+- `roughjs` ^4.6.6 (existing)
+- `@dagrejs/dagre` ^1.1.4 (existing)
+- Markdown renderer (new frontend dep)
+- PydanticAI (existing)
+- FastAPI StreamingResponse or sse-starlette for SSE (check availability)
+
+## Edge Map
+
+```
+user message → POST /api/chat/explore
+  → PydanticAI agent.run_stream()
+    → search_kg() → SSE: node_discovered (×N)
+    → expand_node() → SSE: edge_traversed (×N), node_discovered (×N)
+    → discard_node() → SSE: node_discarded
+    → text generation → SSE: text_chunk (×N)
+  → SSE: done
+```

--- a/docs/plans/2026-04-14-kg-explorer-plan.md
+++ b/docs/plans/2026-04-14-kg-explorer-plan.md
@@ -1,0 +1,1329 @@
+# Knowledge Graph Explorer Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Build a chat-driven knowledge graph explorer at `private/chat` where Gemma-4 searches the KG via tools and a rough.js graph animates in real-time via SSE.
+
+**Architecture:** PydanticAI agent with 3 tools (search_kg, expand_node, discard_node) streaming SSE events through a FastAPI endpoint, proxied by a SvelteKit `+server.js` to a Svelte 5 page that renders an incremental rough.js graph with smooth dagre re-layout transitions.
+
+**Tech Stack:** PydanticAI, FastAPI StreamingResponse, SvelteKit, rough.js, dagre, marked (new dep)
+
+**Design doc:** `docs/plans/2026-04-14-kg-explorer-design.md`
+
+---
+
+### Task 1: Add marked dependency for markdown rendering
+
+**Files:**
+
+- Modify: `projects/monolith/frontend/package.json`
+
+**Step 1: Add marked**
+
+```bash
+cd projects/monolith/frontend && pnpm add marked
+```
+
+**Step 2: Verify install**
+
+```bash
+pnpm ls marked
+```
+
+Expected: `marked` version listed.
+
+**Step 3: Commit**
+
+```bash
+git add projects/monolith/frontend/package.json projects/monolith/frontend/pnpm-lock.yaml
+git commit -m "build(monolith): add marked for runtime markdown rendering"
+```
+
+---
+
+### Task 2: Backend — SSE emitter utility
+
+**Files:**
+
+- Create: `projects/monolith/chat/sse.py`
+- Create: `projects/monolith/chat/sse_test.py`
+
+The SSE emitter is a thin wrapper that formats events as `data: {json}\n\n` and pushes them onto an asyncio queue. The agent tools write to it; the endpoint drains it.
+
+**Step 1: Write the test**
+
+```python
+# projects/monolith/chat/sse_test.py
+import json
+import pytest
+from chat.sse import SSEEmitter
+
+
+@pytest.mark.anyio
+async def test_emit_and_drain():
+    emitter = SSEEmitter()
+    emitter.emit("node_discovered", {"note_id": "abc", "title": "Test"})
+    emitter.emit("done", {})
+    emitter.close()
+
+    events = []
+    async for chunk in emitter.stream():
+        events.append(chunk)
+
+    assert len(events) == 2
+    first = json.loads(events[0].removeprefix("data: ").strip())
+    assert first["type"] == "node_discovered"
+    assert first["data"]["note_id"] == "abc"
+
+
+@pytest.mark.anyio
+async def test_close_terminates_stream():
+    emitter = SSEEmitter()
+    emitter.close()
+    events = []
+    async for chunk in emitter.stream():
+        events.append(chunk)
+    assert events == []
+```
+
+**Step 2: Run test to verify it fails**
+
+```bash
+bb remote --os=linux --arch=amd64 test //projects/monolith:sse_test --config=ci
+```
+
+Expected: FAIL — module `chat.sse` does not exist.
+
+**Step 3: Write the implementation**
+
+```python
+# projects/monolith/chat/sse.py
+import asyncio
+import json
+
+
+class SSEEmitter:
+    """Async queue-backed SSE event emitter.
+
+    Tools call emit() to push events. The endpoint iterates stream()
+    to drain them as text/event-stream lines.
+    """
+
+    def __init__(self) -> None:
+        self._queue: asyncio.Queue[str | None] = asyncio.Queue()
+
+    def emit(self, event_type: str, data: dict) -> None:
+        payload = json.dumps({"type": event_type, "data": data})
+        self._queue.put_nowait(f"data: {payload}\n\n")
+
+    def close(self) -> None:
+        self._queue.put_nowait(None)
+
+    async def stream(self):
+        while True:
+            chunk = await self._queue.get()
+            if chunk is None:
+                break
+            yield chunk
+```
+
+**Step 4: Run test to verify it passes**
+
+```bash
+bb remote --os=linux --arch=amd64 test //projects/monolith:sse_test --config=ci
+```
+
+Expected: PASS
+
+**Step 5: Add BUILD target** (gazelle should handle this, but verify)
+
+```bash
+format
+```
+
+**Step 6: Commit**
+
+```bash
+git add projects/monolith/chat/sse.py projects/monolith/chat/sse_test.py
+git commit -m "feat(chat): add SSE emitter utility for streaming graph events"
+```
+
+---
+
+### Task 3: Backend — PydanticAI explorer agent
+
+**Files:**
+
+- Create: `projects/monolith/chat/explorer.py`
+- Create: `projects/monolith/chat/explorer_test.py`
+
+This is the core agent with three tools. Each tool emits SSE events via the emitter in `ctx.deps`, then returns formatted text to Gemma.
+
+**Step 1: Write the test for search_kg tool**
+
+```python
+# projects/monolith/chat/explorer_test.py
+import json
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+from chat.explorer import create_explorer_agent, ExplorerDeps
+from chat.sse import SSEEmitter
+
+
+def make_deps(emitter: SSEEmitter) -> ExplorerDeps:
+    store = MagicMock()
+    store.search_notes_with_context.return_value = [
+        {
+            "note_id": "note-1",
+            "title": "Kubernetes Networking",
+            "type": "note",
+            "tags": ["k8s", "networking"],
+            "score": 0.92,
+            "snippet": "Service mesh overview...",
+            "edges": [
+                {"target_id": "note-2", "target_title": "Linkerd", "kind": "edge", "edge_type": "refines"}
+            ],
+        }
+    ]
+    store.get_note_links.return_value = [
+        {"target_id": "note-3", "target_title": "Cilium", "kind": "edge", "edge_type": "related"}
+    ]
+    store.get_note_by_id.return_value = {
+        "note_id": "note-3",
+        "title": "Cilium",
+        "type": "article",
+        "tags": ["networking"],
+    }
+
+    embed_client = AsyncMock()
+    embed_client.embed.return_value = [0.1] * 1024
+
+    return ExplorerDeps(
+        store=store,
+        embed_client=embed_client,
+        emitter=emitter,
+    )
+
+
+@pytest.mark.anyio
+async def test_search_kg_emits_node_discovered():
+    emitter = SSEEmitter()
+    deps = make_deps(emitter)
+
+    # Call the tool function directly
+    from chat.explorer import _search_kg
+    result = await _search_kg(deps, "kubernetes networking")
+
+    emitter.close()
+    events = []
+    async for chunk in emitter.stream():
+        parsed = json.loads(chunk.removeprefix("data: ").strip())
+        events.append(parsed)
+
+    assert len(events) == 1
+    assert events[0]["type"] == "node_discovered"
+    assert events[0]["data"]["note_id"] == "note-1"
+    assert events[0]["data"]["title"] == "Kubernetes Networking"
+    assert "refines" in str(events[0]["data"]["edges"])
+    assert "kubernetes" in result.lower()
+
+
+@pytest.mark.anyio
+async def test_expand_node_emits_edge_and_node():
+    emitter = SSEEmitter()
+    deps = make_deps(emitter)
+
+    from chat.explorer import _expand_node
+    result = await _expand_node(deps, "note-1")
+
+    emitter.close()
+    events = []
+    async for chunk in emitter.stream():
+        parsed = json.loads(chunk.removeprefix("data: ").strip())
+        events.append(parsed)
+
+    types = [e["type"] for e in events]
+    assert "edge_traversed" in types
+    assert "node_discovered" in types
+
+
+@pytest.mark.anyio
+async def test_discard_node_emits_event():
+    emitter = SSEEmitter()
+    deps = make_deps(emitter)
+
+    from chat.explorer import _discard_node
+    result = await _discard_node(deps, "note-1", "not relevant to query")
+
+    emitter.close()
+    events = []
+    async for chunk in emitter.stream():
+        parsed = json.loads(chunk.removeprefix("data: ").strip())
+        events.append(parsed)
+
+    assert len(events) == 1
+    assert events[0]["type"] == "node_discarded"
+    assert events[0]["data"]["note_id"] == "note-1"
+    assert events[0]["data"]["reason"] == "not relevant to query"
+```
+
+**Step 2: Run test to verify it fails**
+
+```bash
+bb remote --os=linux --arch=amd64 test //projects/monolith:explorer_test --config=ci
+```
+
+Expected: FAIL — `chat.explorer` does not exist.
+
+**Step 3: Write the implementation**
+
+```python
+# projects/monolith/chat/explorer.py
+import os
+from dataclasses import dataclass
+
+from pydantic_ai import Agent, ModelSettings, RunContext
+from pydantic_ai.models.openai import OpenAIChatModel
+from pydantic_ai.providers.openai import OpenAIProvider
+
+from chat.sse import SSEEmitter
+from knowledge.store import KnowledgeStore
+from shared.embedding import EmbeddingClient
+
+SYSTEM_PROMPT = """\
+You are a knowledge graph explorer. The user asks questions and you search \
+their personal knowledge graph to find relevant notes and connections.
+
+Your workflow:
+1. Use search_kg to find notes matching the user's question.
+2. Use expand_node to follow edges from promising notes and discover connections.
+3. Use discard_node to explicitly mark irrelevant results (with a reason).
+4. Synthesize your findings into a clear answer, referencing the notes you found.
+
+Always search before answering. Expand at least one promising node to discover \
+deeper connections. Discard results that aren't relevant — be decisive. \
+Reference notes by title when answering."""
+
+
+@dataclass
+class ExplorerDeps:
+    store: KnowledgeStore
+    embed_client: EmbeddingClient
+    emitter: SSEEmitter
+
+
+def create_explorer_agent() -> Agent[ExplorerDeps]:
+    url = os.environ.get("LLAMA_CPP_URL", "http://localhost:8000")
+    model = OpenAIChatModel(
+        "gemma-4-26b-a4b",
+        provider=OpenAIProvider(base_url=f"{url}/v1", api_key="not-needed"),
+    )
+    agent: Agent[ExplorerDeps] = Agent(
+        model,
+        system_prompt=SYSTEM_PROMPT,
+        model_settings=ModelSettings(max_tokens=4096),
+    )
+
+    @agent.tool
+    async def search_kg(ctx: RunContext[ExplorerDeps], query: str) -> str:
+        """Semantic search across the knowledge graph. Returns matching notes."""
+        return await _search_kg(ctx.deps, query)
+
+    @agent.tool
+    async def expand_node(ctx: RunContext[ExplorerDeps], note_id: str) -> str:
+        """Follow edges from a node to discover connected notes."""
+        return await _expand_node(ctx.deps, note_id)
+
+    @agent.tool
+    async def discard_node(
+        ctx: RunContext[ExplorerDeps], note_id: str, reason: str
+    ) -> str:
+        """Mark a node as irrelevant to the current exploration."""
+        return await _discard_node(ctx.deps, note_id, reason)
+
+    return agent
+
+
+async def _search_kg(deps: ExplorerDeps, query: str) -> str:
+    vector = await deps.embed_client.embed(query)
+    results = deps.store.search_notes_with_context(
+        query_embedding=vector, limit=5
+    )
+    lines = []
+    for r in results:
+        deps.emitter.emit(
+            "node_discovered",
+            {
+                "note_id": r["note_id"],
+                "title": r["title"],
+                "type": r["type"],
+                "tags": r["tags"],
+                "snippet": r["snippet"],
+                "edges": r.get("edges", []),
+            },
+        )
+        lines.append(
+            f"- {r['title']} (score: {r['score']:.2f}, type: {r['type']}): "
+            f"{r['snippet'][:200]}"
+        )
+    if not lines:
+        return "No results found."
+    return "Found notes:\n" + "\n".join(lines)
+
+
+async def _expand_node(deps: ExplorerDeps, note_id: str) -> str:
+    links = deps.store.get_note_links(note_id)
+    if not links:
+        return f"No edges found from {note_id}."
+
+    lines = []
+    for link in links:
+        target_id = link.get("resolved_note_id") or link["target_id"]
+        deps.emitter.emit(
+            "edge_traversed",
+            {
+                "from_id": note_id,
+                "to_id": target_id,
+                "edge_type": link.get("edge_type", "link"),
+            },
+        )
+        target = deps.store.get_note_by_id(target_id)
+        if target:
+            deps.emitter.emit(
+                "node_discovered",
+                {
+                    "note_id": target["note_id"],
+                    "title": target["title"],
+                    "type": target["type"],
+                    "tags": target.get("tags", []),
+                    "snippet": "",
+                    "edges": [],
+                },
+            )
+            edge_label = link.get("edge_type", "link")
+            lines.append(f"- {target['title']} ({edge_label})")
+        else:
+            lines.append(f"- {target_id} (unresolved)")
+
+    return f"Edges from {note_id}:\n" + "\n".join(lines)
+
+
+async def _discard_node(deps: ExplorerDeps, note_id: str, reason: str) -> str:
+    deps.emitter.emit("node_discarded", {"note_id": note_id, "reason": reason})
+    return f"Discarded {note_id}: {reason}"
+```
+
+**Step 4: Run tests**
+
+```bash
+bb remote --os=linux --arch=amd64 test //projects/monolith:explorer_test --config=ci
+```
+
+Expected: PASS
+
+**Step 5: Format and commit**
+
+```bash
+format
+git add projects/monolith/chat/explorer.py projects/monolith/chat/explorer_test.py
+git commit -m "feat(chat): add PydanticAI explorer agent with KG tools"
+```
+
+---
+
+### Task 4: Backend — SSE streaming endpoint
+
+**Files:**
+
+- Modify: `projects/monolith/chat/router.py`
+- Create: `projects/monolith/chat/explore_endpoint_test.py`
+
+Wire the agent into a FastAPI endpoint that returns `text/event-stream`.
+
+**Step 1: Write the test**
+
+```python
+# projects/monolith/chat/explore_endpoint_test.py
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def client():
+    """Create a test client with mocked dependencies."""
+    from app.main import app
+    return TestClient(app)
+
+
+def test_explore_returns_sse_content_type(client):
+    with patch("chat.router.create_explorer_agent") as mock_agent_fn:
+        mock_agent = MagicMock()
+        mock_agent_fn.return_value = mock_agent
+
+        # Mock run_stream to return an async context manager
+        mock_stream = AsyncMock()
+        mock_stream.__aenter__ = AsyncMock(return_value=mock_stream)
+        mock_stream.__aexit__ = AsyncMock(return_value=False)
+        mock_stream.stream_text.return_value = AsyncMock()
+        mock_agent.run_stream.return_value = mock_stream
+
+        response = client.post(
+            "/api/chat/explore",
+            json={"message": "test query", "history": []},
+        )
+        assert response.headers["content-type"].startswith("text/event-stream")
+
+
+def test_explore_rejects_empty_message(client):
+    response = client.post(
+        "/api/chat/explore",
+        json={"message": "", "history": []},
+    )
+    assert response.status_code == 422
+```
+
+**Step 2: Run test to verify it fails**
+
+```bash
+bb remote --os=linux --arch=amd64 test //projects/monolith:explore_endpoint_test --config=ci
+```
+
+Expected: FAIL — endpoint does not exist.
+
+**Step 3: Write the endpoint**
+
+Add to `projects/monolith/chat/router.py`:
+
+```python
+import asyncio
+from fastapi import Request
+from fastapi.responses import StreamingResponse
+from pydantic import BaseModel, Field
+
+from chat.explorer import ExplorerDeps, create_explorer_agent
+from chat.sse import SSEEmitter
+from knowledge.store import KnowledgeStore
+from shared.embedding import EmbeddingClient
+
+
+class ExploreRequest(BaseModel):
+    message: str = Field(min_length=1)
+    history: list[dict] = Field(default_factory=list)
+
+
+_explorer_agent = None
+
+
+def get_explorer_agent():
+    global _explorer_agent
+    if _explorer_agent is None:
+        _explorer_agent = create_explorer_agent()
+    return _explorer_agent
+
+
+@router.post("/explore")
+async def explore(body: ExploreRequest, request: Request):
+    session = next(get_session())
+    emitter = SSEEmitter()
+    agent = get_explorer_agent()
+
+    deps = ExplorerDeps(
+        store=KnowledgeStore(session),
+        embed_client=EmbeddingClient(),
+        emitter=emitter,
+    )
+
+    # Build message list from history + current message
+    messages = []
+    for turn in body.history:
+        messages.append({"role": turn["role"], "content": turn["content"]})
+    messages.append({"role": "user", "content": body.message})
+
+    async def generate():
+        try:
+            async with agent.run_stream(
+                body.message,
+                message_history=messages[:-1] if len(messages) > 1 else None,
+                deps=deps,
+            ) as stream:
+                # Drain emitter events (from tool calls) concurrently with text
+                async def drain_events():
+                    async for chunk in emitter.stream():
+                        yield chunk
+
+                # Stream text chunks
+                async for text in stream.stream_text(delta=True):
+                    emitter.emit("text_chunk", {"text": text})
+
+            emitter.emit("done", {})
+            emitter.close()
+        except Exception as e:
+            emitter.emit("error", {"message": str(e)})
+            emitter.close()
+
+        async for event in emitter.stream():
+            yield event
+
+    return StreamingResponse(generate(), media_type="text/event-stream")
+```
+
+> **Note to implementer:** The concurrent streaming of tool-emitted events and text chunks is tricky. PydanticAI's `run_stream` calls tools synchronously during iteration. The emitter queue collects events from tools, and `stream_text(delta=True)` yields text deltas. Both types of events go through the emitter, so the `generate()` function just drains the emitter after the stream completes. If real-time interleaving is needed (tool events arrive _during_ text generation), refactor to use `asyncio.create_task` for the agent run and drain the emitter concurrently. Start with the simpler sequential approach and optimize if latency feels wrong.
+
+**Step 4: Run tests**
+
+```bash
+bb remote --os=linux --arch=amd64 test //projects/monolith:explore_endpoint_test --config=ci
+```
+
+Expected: PASS
+
+**Step 5: Format and commit**
+
+```bash
+format
+git add projects/monolith/chat/router.py projects/monolith/chat/explore_endpoint_test.py
+git commit -m "feat(chat): add /api/chat/explore SSE endpoint"
+```
+
+---
+
+### Task 5: Frontend — Route skeleton and SSE proxy
+
+**Files:**
+
+- Create: `projects/monolith/frontend/src/routes/private/chat/+page.ts`
+- Create: `projects/monolith/frontend/src/routes/private/chat/+server.js`
+- Create: `projects/monolith/frontend/src/routes/private/chat/+page.svelte` (skeleton)
+
+**Step 1: Create the SSR-disabled page loader**
+
+```javascript
+// projects/monolith/frontend/src/routes/private/chat/+page.ts
+export const ssr = false;
+```
+
+**Step 2: Create the SSE proxy**
+
+The `+server.js` file forwards POST requests to the FastAPI backend and streams the SSE response back to the browser.
+
+```javascript
+// projects/monolith/frontend/src/routes/private/chat/+server.js
+const API_BASE = process.env.API_BASE || "http://localhost:8000";
+
+export async function POST({ request }) {
+  const body = await request.json();
+
+  const upstream = await fetch(`${API_BASE}/api/chat/explore`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+
+  if (!upstream.ok) {
+    return new Response(JSON.stringify({ error: "upstream failed" }), {
+      status: upstream.status,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  // Pass through the SSE stream
+  return new Response(upstream.body, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+      Connection: "keep-alive",
+    },
+  });
+}
+```
+
+**Step 3: Create the page skeleton**
+
+```svelte
+<!-- projects/monolith/frontend/src/routes/private/chat/+page.svelte -->
+<script>
+  // Minimal skeleton — will be fleshed out in subsequent tasks
+  let messages = $state([]);
+  let inputText = $state("");
+  let isStreaming = $state(false);
+</script>
+
+<svelte:head>
+  <title>Knowledge Explorer</title>
+</svelte:head>
+
+<div class="explorer">
+  <header class="explorer-header">
+    <span class="header-title">KNOWLEDGE EXPLORER</span>
+    <span class="header-sub">powered by gemma-4</span>
+  </header>
+
+  <main class="explorer-body">
+    <p style="font-family: monospace; padding: 2rem;">Page skeleton — chat and graph coming next.</p>
+  </main>
+</div>
+
+<style>
+  .explorer {
+    display: flex;
+    flex-direction: column;
+    height: 100vh;
+    background: #faf8f4;
+  }
+  .explorer-header {
+    background: #1a1a1a;
+    color: #fff;
+    font-family: monospace;
+    padding: 0.5rem 1rem;
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+  }
+  .header-title {
+    font-weight: 700;
+    letter-spacing: 0.05em;
+  }
+  .header-sub {
+    opacity: 0.5;
+    font-size: 0.8em;
+  }
+  .explorer-body {
+    flex: 1;
+    overflow: hidden;
+  }
+</style>
+```
+
+**Step 4: Verify the page loads locally** (if local dev server available) or just format and commit.
+
+```bash
+format
+git add projects/monolith/frontend/src/routes/private/chat/
+git commit -m "feat(chat): add SvelteKit route skeleton with SSE proxy"
+```
+
+---
+
+### Task 6: Frontend — Chat UI
+
+**Files:**
+
+- Modify: `projects/monolith/frontend/src/routes/private/chat/+page.svelte`
+
+Build the chat card with input bar and streaming message display. No graph yet — just the chat portion.
+
+**Step 1: Implement the chat UI and SSE consumer**
+
+Replace the page skeleton with full chat implementation. Key pieces:
+
+- `messages` array of `{role: "user"|"assistant", content: string}`
+- `graphEvents` array of SSE graph events (consumed by graph in next task)
+- `sendMessage()` function: POST to `+server.js`, parse SSE stream, append text chunks to assistant message, collect graph events
+- Input bar with Enter-to-submit
+- Scrollable chat log with brutalist styling
+
+```svelte
+<script>
+  let messages = $state([]);
+  let graphEvents = $state([]);
+  let inputText = $state("");
+  let isStreaming = $state(false);
+  let chatLog;
+
+  function scrollToBottom() {
+    if (chatLog) chatLog.scrollTop = chatLog.scrollHeight;
+  }
+
+  async function sendMessage() {
+    const text = inputText.trim();
+    if (!text || isStreaming) return;
+
+    inputText = "";
+    messages.push({ role: "user", content: text });
+    messages.push({ role: "assistant", content: "" });
+    isStreaming = true;
+    scrollToBottom();
+
+    try {
+      const res = await fetch("/private/chat", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          message: text,
+          history: messages.slice(0, -2).map((m) => ({
+            role: m.role,
+            content: m.content,
+          })),
+        }),
+      });
+
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+
+      const reader = res.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = "";
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split("\n\n");
+        buffer = lines.pop() || "";
+
+        for (const line of lines) {
+          if (!line.startsWith("data: ")) continue;
+          const event = JSON.parse(line.slice(6));
+
+          if (event.type === "text_chunk") {
+            messages[messages.length - 1].content += event.data.text;
+            scrollToBottom();
+          } else if (event.type === "error") {
+            messages[messages.length - 1].content += `\n[Error: ${event.data.message}]`;
+          } else if (event.type === "done") {
+            // Stream complete
+          } else {
+            // Graph events — collected for the graph component
+            graphEvents.push(event);
+          }
+        }
+      }
+    } catch (err) {
+      messages[messages.length - 1].content += `\n[Connection error: ${err.message}]`;
+    } finally {
+      isStreaming = false;
+    }
+  }
+
+  function onKeydown(e) {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      sendMessage();
+    }
+  }
+</script>
+```
+
+Template:
+
+```svelte
+<div class="explorer">
+  <header class="explorer-header">
+    <span class="header-title">KNOWLEDGE EXPLORER</span>
+    <span class="header-sub">powered by gemma-4</span>
+  </header>
+
+  <div class="chat-card">
+    <div class="chat-log" bind:this={chatLog}>
+      {#each messages as msg}
+        <div class="chat-msg chat-msg--{msg.role}">
+          <span class="chat-role">{msg.role === "user" ? "you" : "gemma"}</span>
+          <span class="chat-text">{msg.content}</span>
+          {#if msg === messages[messages.length - 1] && isStreaming && msg.role === "assistant"}
+            <span class="chat-cursor">|</span>
+          {/if}
+        </div>
+      {/each}
+    </div>
+    <div class="chat-input-bar">
+      <input
+        type="text"
+        bind:value={inputText}
+        onkeydown={onKeydown}
+        placeholder="explore your knowledge..."
+        disabled={isStreaming}
+      />
+      <button onclick={sendMessage} disabled={isStreaming || !inputText.trim()}>
+        &rarr;
+      </button>
+    </div>
+  </div>
+
+  <hr class="graph-rule" />
+  <div class="graph-area">
+    <!-- Graph canvas — Task 7+ -->
+    {#if graphEvents.length === 0}
+      <p class="graph-empty">Ask a question to start exploring</p>
+    {/if}
+  </div>
+</div>
+```
+
+**Step 2: Add brutalist styles**
+
+```css
+.chat-card {
+  margin: 1rem;
+  border: 2px solid #1a1a1a;
+  background: #f5f0e8;
+  display: flex;
+  flex-direction: column;
+  max-height: 35vh;
+  font-family: monospace;
+}
+.chat-log {
+  flex: 1;
+  overflow-y: auto;
+  padding: 1rem;
+}
+.chat-msg {
+  margin-bottom: 0.75rem;
+  line-height: 1.5;
+}
+.chat-msg--user {
+  text-align: right;
+}
+.chat-msg--assistant {
+  border-left: 3px solid #1a1a1a;
+  padding-left: 0.75rem;
+}
+.chat-role {
+  font-weight: 700;
+  text-transform: uppercase;
+  font-size: 0.75em;
+  letter-spacing: 0.05em;
+  display: block;
+  margin-bottom: 0.1rem;
+  opacity: 0.5;
+}
+.chat-text {
+  white-space: pre-wrap;
+}
+.chat-cursor {
+  animation: blink 0.8s step-end infinite;
+}
+@keyframes blink {
+  50% {
+    opacity: 0;
+  }
+}
+.chat-input-bar {
+  border-top: 2px solid #1a1a1a;
+  display: flex;
+}
+.chat-input-bar input {
+  flex: 1;
+  padding: 0.75rem 1rem;
+  font-family: monospace;
+  font-size: 0.95rem;
+  border: none;
+  background: transparent;
+  outline: none;
+}
+.chat-input-bar button {
+  padding: 0.75rem 1.25rem;
+  font-family: monospace;
+  font-weight: 700;
+  font-size: 1.1rem;
+  border: none;
+  border-left: 2px solid #1a1a1a;
+  background: transparent;
+  cursor: pointer;
+}
+.chat-input-bar button:disabled {
+  opacity: 0.3;
+  cursor: default;
+}
+.graph-rule {
+  border: none;
+  border-top: 1.5px solid #c0b8a8;
+  margin: 0 1rem;
+}
+.graph-area {
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+  position: relative;
+}
+.graph-empty {
+  font-family: monospace;
+  text-align: center;
+  padding: 3rem;
+  opacity: 0.4;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+}
+```
+
+**Step 3: Commit**
+
+```bash
+format
+git add projects/monolith/frontend/src/routes/private/chat/+page.svelte
+git commit -m "feat(chat): implement chat UI with SSE streaming"
+```
+
+---
+
+### Task 7: Frontend — Graph state and incremental dagre layout
+
+**Files:**
+
+- Create: `projects/monolith/frontend/src/routes/private/chat/graph-layout.js`
+
+Extracted layout module that manages incremental graph state and dagre re-layout with position lerping.
+
+**Step 1: Write the layout module**
+
+```javascript
+// projects/monolith/frontend/src/routes/private/chat/graph-layout.js
+import * as dagre from "@dagrejs/dagre";
+
+const CHAR_WIDTH = 6.5;
+const NODE_PAD = 12;
+const HH = 18;
+
+function computeHW(label) {
+  return Math.max(
+    24,
+    Math.ceil((label.length * CHAR_WIDTH) / 2) + NODE_PAD / 2,
+  );
+}
+
+/**
+ * Manages incremental graph layout.
+ * Call addNode/addEdge as SSE events arrive, then call layout()
+ * to get positioned nodes with smooth transitions.
+ */
+export function createGraphState() {
+  let nodes = [];
+  let edges = [];
+  let nodeMap = {};
+  let prevPositions = {};
+
+  function addNode(node) {
+    if (nodeMap[node.note_id]) return false; // Already exists
+    const entry = {
+      id: node.note_id,
+      label: node.title,
+      type: node.type,
+      tags: node.tags || [],
+      snippet: node.snippet || "",
+      edges: node.edges || [],
+      discarded: false,
+      isNew: true,
+    };
+    nodes.push(entry);
+    nodeMap[node.note_id] = entry;
+    return true;
+  }
+
+  function addEdge(from_id, to_id, edge_type) {
+    const exists = edges.some((e) => e.from === from_id && e.to === to_id);
+    if (exists) return false;
+    edges.push({ from: from_id, to: to_id, type: edge_type });
+    return true;
+  }
+
+  function discardNode(note_id) {
+    if (nodeMap[note_id]) {
+      nodeMap[note_id].discarded = true;
+    }
+  }
+
+  function layout() {
+    // Save previous positions for lerping
+    prevPositions = {};
+    for (const n of nodes) {
+      if (n.x !== undefined) {
+        prevPositions[n.id] = { x: n.x, y: n.y };
+      }
+    }
+
+    const g = new dagre.graphlib.Graph();
+    g.setGraph({
+      rankdir: "TB",
+      nodesep: 50,
+      ranksep: 60,
+      marginx: 40,
+      marginy: 40,
+    });
+    g.setDefaultEdgeLabel(() => ({}));
+
+    for (const node of nodes) {
+      const hw = computeHW(node.label);
+      g.setNode(node.id, {
+        width: hw * 2 + NODE_PAD,
+        height: HH * 2 + 6,
+      });
+    }
+
+    for (const edge of edges) {
+      if (g.hasNode(edge.from) && g.hasNode(edge.to)) {
+        g.setEdge(edge.from, edge.to);
+      }
+    }
+
+    dagre.layout(g);
+
+    const positioned = nodes.map((n) => {
+      const pos = g.node(n.id);
+      if (!pos) return n;
+      const hw = computeHW(n.label);
+      const prev = prevPositions[n.id];
+      return {
+        ...n,
+        x: pos.x,
+        y: pos.y,
+        hw,
+        prevX: prev?.x,
+        prevY: prev?.y,
+        isNew: prev === undefined,
+      };
+    });
+
+    // Reset isNew after layout
+    nodes.forEach((n) => (n.isNew = false));
+
+    return {
+      nodes: positioned,
+      edges: edges.filter((e) => g.hasNode(e.from) && g.hasNode(e.to)),
+      nodeMap,
+    };
+  }
+
+  return { addNode, addEdge, discardNode, layout, getNodes: () => nodes };
+}
+```
+
+**Step 2: Commit**
+
+```bash
+format
+git add projects/monolith/frontend/src/routes/private/chat/graph-layout.js
+git commit -m "feat(chat): add incremental dagre layout with position lerping"
+```
+
+---
+
+### Task 8: Frontend — Rough.js graph rendering and animations
+
+**Files:**
+
+- Modify: `projects/monolith/frontend/src/routes/private/chat/+page.svelte`
+
+Wire the graph state to an SVG canvas with rough.js rendering. Reuse the observability-demo's drawing patterns.
+
+**Step 1: Add graph rendering**
+
+Add to the `<script>` section:
+
+- Import rough.js and the graph-layout module
+- Create `graphState` using `createGraphState()`
+- Add `$effect` that processes `graphEvents` queue: for each event, call `graphState.addNode/addEdge/discardNode`, then `graphState.layout()`, then draw with rough.js
+- Position lerping: existing nodes use CSS `transition: transform 300ms ease-out`
+- New nodes: pencil→ink→fill animation (simplified from observability-demo — single rough.js rectangle with opacity animation instead of the full 4-side sequential draw)
+- Edge rendering: rough.js lines between node centers with arrowheads
+
+**Color map by note type:**
+
+```javascript
+const TYPE_COLORS = {
+  note: { fill: "#dbeafe", border: "#3b82f6", pencil: "#93c5fd" },
+  paper: { fill: "#dcfce7", border: "#22c55e", pencil: "#86efac" },
+  article: { fill: "#fef3c7", border: "#f59e0b", pencil: "#fcd34d" },
+  recipe: { fill: "#ffe4e6", border: "#f43f5e", pencil: "#fda4af" },
+};
+```
+
+**Key implementation detail:** Use `<g>` groups per node with `transform="translate(x, y)"` and CSS `transition: transform 300ms ease-out` for smooth position lerping. New nodes start with `opacity: 0` and animate in.
+
+**Discarded nodes:** On discard, draw two `rc.line()` diagonals across the node and transition fill to grey.
+
+**Step 2: Implement the SVG canvas in the template**
+
+Replace the `<!-- Graph canvas — Task 7+ -->` placeholder with an `<svg>` element and the rough.js rendering `$effect`.
+
+> **Note to implementer:** Reference `projects/monolith/frontend/src/routes/public/observability-demo/+page.svelte` for the exact rough.js patterns — how `rc = rough.svg(svgEl)` is created, how elements are appended to `<g>` groups, and how the animation CSS works. Simplify the 4-side sequential draw to a single rectangle draw for MVP — the full sequential animation can be added later.
+
+**Step 3: Commit**
+
+```bash
+format
+git add projects/monolith/frontend/src/routes/private/chat/+page.svelte
+git commit -m "feat(chat): add rough.js graph rendering with smooth transitions"
+```
+
+---
+
+### Task 9: Frontend — Hover highlights and click interactions
+
+**Files:**
+
+- Modify: `projects/monolith/frontend/src/routes/private/chat/+page.svelte`
+
+**Step 1: Add interaction handlers**
+
+- Transparent hit-area `<rect>` elements over each node (same pattern as observability-demo)
+- `hoveredNode` state — on hover, highlight the node + connected edges (dim others to opacity 0.45)
+- `selectedNode` state — on click, set selected and open the drawer
+- Edge highlighting: connected edges get full opacity, others dim
+
+**Step 2: Commit**
+
+```bash
+format
+git add projects/monolith/frontend/src/routes/private/chat/+page.svelte
+git commit -m "feat(chat): add hover highlights and click selection"
+```
+
+---
+
+### Task 10: Frontend — Note drawer with markdown
+
+**Files:**
+
+- Modify: `projects/monolith/frontend/src/routes/private/chat/+page.svelte`
+- Modify: `projects/monolith/frontend/src/routes/private/chat/+server.js` (add note fetch)
+
+**Step 1: Add note fetch endpoint to +server.js**
+
+Add a GET handler that proxies `/api/knowledge/notes/{id}`:
+
+```javascript
+export async function GET({ url }) {
+  const noteId = url.searchParams.get("note_id");
+  if (!noteId) return new Response("missing note_id", { status: 400 });
+
+  const res = await fetch(
+    `${API_BASE}/api/knowledge/notes/${encodeURIComponent(noteId)}`,
+    { signal: AbortSignal.timeout(10000) },
+  );
+  return new Response(res.body, {
+    status: res.status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+```
+
+**Step 2: Add the drawer component**
+
+In `+page.svelte`:
+
+- When `selectedNode` is set, fetch the full note from the GET endpoint
+- Render a slide-out drawer on the right (same pattern as observability-demo)
+- Use `marked` to render the markdown body to HTML
+- Display: title, type badge, tags, rendered markdown, outgoing edges list
+- Dismiss on click-outside, Escape, or re-click
+
+**Styling:**
+
+```css
+.note-drawer {
+  position: fixed;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  width: 420px;
+  max-width: 90vw;
+  background: #f5f0e8;
+  border-left: 2px solid #1a1a1a;
+  overflow-y: auto;
+  padding: 1.5rem;
+  font-family: monospace;
+  z-index: 100;
+  box-shadow: -4px 0 12px rgba(0, 0, 0, 0.1);
+  transition: transform 200ms ease-out;
+}
+```
+
+**Step 3: Commit**
+
+```bash
+format
+git add projects/monolith/frontend/src/routes/private/chat/
+git commit -m "feat(chat): add note drawer with markdown rendering"
+```
+
+---
+
+### Task 11: Frontend — Dark/light theme support
+
+**Files:**
+
+- Modify: `projects/monolith/frontend/src/routes/private/chat/+page.svelte`
+
+**Step 1: Add theme switching**
+
+Reuse the observability-demo theme pattern:
+
+- Read `localStorage.getItem("theme")` on mount
+- Toggle via a button in the header bar
+- CSS variables for light/dark variants
+- Graph area uses warm cream (`#f5f0e8`) on both themes (same "light island" pattern from topology groups)
+- Text, borders, and page background adapt to theme
+
+**Step 2: Commit**
+
+```bash
+format
+git add projects/monolith/frontend/src/routes/private/chat/+page.svelte
+git commit -m "feat(chat): add dark/light theme support"
+```
+
+---
+
+### Task 12: Integration — Wire everything together and test end-to-end
+
+**Files:**
+
+- Possibly modify: `projects/monolith/app/main.py` (if router not auto-registered)
+- Verify: all pieces connected
+
+**Step 1: Verify router registration**
+
+Check that `chat/router.py` is already included in `app/main.py` (it should be — the `/explore` endpoint is on the existing chat router). If not, add it.
+
+**Step 2: Run all backend tests**
+
+```bash
+bb remote --os=linux --arch=amd64 test //projects/monolith/... --config=ci
+```
+
+Expected: All PASS.
+
+**Step 3: Format check**
+
+```bash
+format
+```
+
+**Step 4: Manual end-to-end test** (if local dev available)
+
+1. Start the monolith backend
+2. Navigate to `localhost:5173/private/chat`
+3. Type a query — verify SSE stream arrives
+4. Verify nodes appear in graph
+5. Click a node — verify drawer opens with markdown
+6. Verify discarded nodes get strikethrough
+
+**Step 5: Final commit and PR**
+
+```bash
+git add -A
+git commit -m "feat(chat): knowledge graph explorer — integration wiring"
+```
+
+Use `superpowers:finishing-a-development-branch` skill to create PR.
+
+---
+
+## Task Summary
+
+| Task | Component   | Description                               |
+| ---- | ----------- | ----------------------------------------- |
+| 1    | Dep         | Add `marked` for markdown rendering       |
+| 2    | Backend     | SSE emitter utility                       |
+| 3    | Backend     | PydanticAI explorer agent with 3 KG tools |
+| 4    | Backend     | `/api/chat/explore` SSE endpoint          |
+| 5    | Frontend    | SvelteKit route skeleton + SSE proxy      |
+| 6    | Frontend    | Chat UI with SSE consumer                 |
+| 7    | Frontend    | Incremental dagre layout module           |
+| 8    | Frontend    | Rough.js graph rendering + animations     |
+| 9    | Frontend    | Hover highlights + click interactions     |
+| 10   | Frontend    | Note drawer with markdown                 |
+| 11   | Frontend    | Dark/light theme                          |
+| 12   | Integration | Wire together + test                      |
+
+**Parallelizable:** Tasks 2-4 (backend) and Tasks 5-7 (frontend skeleton) can run in parallel since they don't share files. Tasks 8-11 are sequential frontend work. Task 12 is the final integration.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -259,6 +259,9 @@ importers:
       vite:
         specifier: ^6.4.2
         version: 6.4.2(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
+      vitest:
+        specifier: ^4.0.18
+        version: 4.0.18(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(happy-dom@20.8.9)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
 
   projects/ships/frontend/web:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -228,6 +228,9 @@ importers:
       "@opentelemetry/semantic-conventions":
         specifier: ^1.28.0
         version: 1.40.0
+      marked:
+        specifier: ^18.0.0
+        version: 18.0.0
       roughjs:
         specifier: ^4.6.6
         version: 4.6.6
@@ -8283,6 +8286,14 @@ packages:
     resolution:
       {
         integrity: sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==,
+      }
+    engines: { node: ">= 20" }
+    hasBin: true
+
+  marked@18.0.0:
+    resolution:
+      {
+        integrity: sha512-2e7Qiv/HJSXj8rDEpgTvGKsP8yYtI9xXHKDnrftrmnrJPaFNM7VRb2YCzWaX4BP1iCJ/XPduzDJZMFoqTCcIMA==,
       }
     engines: { node: ">= 20" }
     hasBin: true
@@ -17565,6 +17576,8 @@ snapshots:
   marked@12.0.2: {}
 
   marked@16.4.2: {}
+
+  marked@18.0.0: {}
 
   matcher@3.0.0:
     dependencies:

--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -2320,6 +2320,19 @@ py_test(
 )
 
 py_test(
+    name = "explore_router_test",
+    srcs = ["chat/explore_router_test.py"],
+    imports = ["."],
+    deps = [
+        ":monolith_backend",
+        "@pip//fastapi",
+        "@pip//httpx",
+        "@pip//pydantic_ai_slim",
+        "@pip//pytest",
+    ],
+)
+
+py_test(
     name = "knowledge_ingest_queue_router_test",
     srcs = ["knowledge/ingest_queue_router_test.py"],
     imports = ["."],

--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -2301,6 +2301,7 @@ py_test(
     srcs = ["chat/sse_test.py"],
     imports = ["."],
     deps = [
+        ":monolith_backend",
         "@pip//anyio",
         "@pip//pytest",
     ],

--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -2307,6 +2307,18 @@ py_test(
 )
 
 py_test(
+    name = "explorer_test",
+    srcs = ["chat/explorer_test.py"],
+    imports = ["."],
+    deps = [
+        ":monolith_backend",
+        "@pip//anyio",
+        "@pip//pydantic_ai_slim",
+        "@pip//pytest",
+    ],
+)
+
+py_test(
     name = "knowledge_ingest_queue_router_test",
     srcs = ["knowledge/ingest_queue_router_test.py"],
     imports = ["."],

--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -2297,6 +2297,16 @@ py_test(
 )
 
 py_test(
+    name = "sse_test",
+    srcs = ["chat/sse_test.py"],
+    imports = ["."],
+    deps = [
+        "@pip//anyio",
+        "@pip//pytest",
+    ],
+)
+
+py_test(
     name = "knowledge_ingest_queue_router_test",
     srcs = ["knowledge/ingest_queue_router_test.py"],
     imports = ["."],

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.43.2
+version: 0.43.3
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.42.12
+version: 0.43.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.43.1
+version: 0.43.2
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.43.0
+version: 0.43.1
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chat/explore_router_test.py
+++ b/projects/monolith/chat/explore_router_test.py
@@ -1,0 +1,255 @@
+"""Integration test for POST /api/chat/explore.
+
+Mocks only externals (LLM model, embedding service, knowledge store).
+Exercises the full HTTP path: request parsing -> agent tool dispatch ->
+SSE event emission -> streaming response.
+"""
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+from pydantic_ai.messages import ModelResponse, TextPart, ToolCallPart, ToolReturnPart
+from pydantic_ai.models.function import FunctionModel
+
+from app.main import app
+from chat.explorer import create_explorer_agent
+
+
+# ---------------------------------------------------------------------------
+# Mock data — represents what KnowledgeStore / EmbeddingClient would return
+# ---------------------------------------------------------------------------
+
+MOCK_SEARCH_RESULTS = [
+    {
+        "note_id": "note-1",
+        "title": "Kubernetes Networking",
+        "type": "note",
+        "tags": ["k8s", "networking"],
+        "score": 0.92,
+        "snippet": "Service mesh overview and comparison of CNI plugins.",
+        "edges": [{"target_id": "note-2", "edge_type": "refines"}],
+    },
+]
+
+MOCK_LINKS = [
+    {
+        "target_id": "note-2",
+        "resolved_note_id": "note-2",
+        "edge_type": "related",
+    },
+]
+
+MOCK_NOTE = {
+    "note_id": "note-2",
+    "title": "Linkerd",
+    "type": "article",
+    "tags": ["service-mesh"],
+}
+
+
+# ---------------------------------------------------------------------------
+# FunctionModel — scripts the tool call sequence
+# ---------------------------------------------------------------------------
+
+
+def _scripted_model(messages, info):
+    """search_kg -> expand_node -> discard_node -> text answer."""
+    tool_returns = [
+        part
+        for msg in messages
+        if hasattr(msg, "parts")
+        for part in msg.parts
+        if isinstance(part, ToolReturnPart)
+    ]
+
+    if len(tool_returns) == 0:
+        return ModelResponse(
+            parts=[
+                ToolCallPart(
+                    tool_name="search_kg",
+                    args={"query": "kubernetes networking"},
+                    tool_call_id="c1",
+                )
+            ]
+        )
+    elif len(tool_returns) == 1:
+        return ModelResponse(
+            parts=[
+                ToolCallPart(
+                    tool_name="expand_node",
+                    args={"note_id": "note-1"},
+                    tool_call_id="c2",
+                )
+            ]
+        )
+    elif len(tool_returns) == 2:
+        return ModelResponse(
+            parts=[
+                ToolCallPart(
+                    tool_name="discard_node",
+                    args={"note_id": "note-2", "reason": "not relevant to query"},
+                    tool_call_id="c3",
+                )
+            ]
+        )
+    else:
+        return ModelResponse(
+            parts=[
+                TextPart("Kubernetes networking uses CNI plugins and service meshes.")
+            ]
+        )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_sse(raw: str) -> list[dict]:
+    """Parse SSE text into a list of event dicts."""
+    events = []
+    for line in raw.strip().split("\n"):
+        line = line.strip()
+        if line.startswith("data: "):
+            events.append(json.loads(line.removeprefix("data: ")))
+    return events
+
+
+def _mock_get_session():
+    yield MagicMock()
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def mock_store():
+    store = MagicMock()
+    store.search_notes_with_context.return_value = MOCK_SEARCH_RESULTS
+    store.get_note_links.return_value = MOCK_LINKS
+    store.get_note_by_id.return_value = MOCK_NOTE
+    return store
+
+
+@pytest.fixture()
+def mock_embed_client():
+    client = AsyncMock()
+    client.embed.return_value = [0.1] * 1024
+    return client
+
+
+@pytest.fixture()
+def client(mock_store, mock_embed_client):
+    agent = create_explorer_agent()
+
+    with (
+        patch("chat.router._explorer_agent", agent),
+        patch("chat.router.KnowledgeStore", return_value=mock_store),
+        patch("chat.router.EmbeddingClient", return_value=mock_embed_client),
+        patch("app.db.get_session", _mock_get_session),
+        agent.override(model=FunctionModel(_scripted_model)),
+    ):
+        yield TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestExploreEndpoint:
+    def test_returns_sse_stream(self, client):
+        resp = client.post(
+            "/api/chat/explore", json={"message": "kubernetes networking"}
+        )
+
+        assert resp.status_code == 200
+        assert "text/event-stream" in resp.headers["content-type"]
+
+    def test_event_sequence(self, client):
+        resp = client.post(
+            "/api/chat/explore", json={"message": "kubernetes networking"}
+        )
+        events = _parse_sse(resp.text)
+        types = [e["type"] for e in events]
+
+        # Tools fire in scripted order, then text, then done
+        assert "node_discovered" in types
+        assert "edge_traversed" in types
+        assert "node_discarded" in types
+        assert "text_chunk" in types
+        assert types[-1] == "done"
+
+    def test_node_discovered_payload(self, client):
+        resp = client.post(
+            "/api/chat/explore", json={"message": "kubernetes networking"}
+        )
+        events = _parse_sse(resp.text)
+        discovered = [e for e in events if e["type"] == "node_discovered"]
+
+        # search_kg discovers note-1, expand_node discovers note-2
+        ids = {e["data"]["note_id"] for e in discovered}
+        assert "note-1" in ids
+        assert "note-2" in ids
+
+        note1 = next(e for e in discovered if e["data"]["note_id"] == "note-1")
+        assert note1["data"]["title"] == "Kubernetes Networking"
+        assert note1["data"]["type"] == "note"
+        assert "k8s" in note1["data"]["tags"]
+
+    def test_edge_traversed_payload(self, client):
+        resp = client.post(
+            "/api/chat/explore", json={"message": "kubernetes networking"}
+        )
+        events = _parse_sse(resp.text)
+        edges = [e for e in events if e["type"] == "edge_traversed"]
+
+        assert len(edges) >= 1
+        assert edges[0]["data"]["from_id"] == "note-1"
+        assert edges[0]["data"]["to_id"] == "note-2"
+        assert edges[0]["data"]["edge_type"] == "related"
+
+    def test_node_discarded_payload(self, client):
+        resp = client.post(
+            "/api/chat/explore", json={"message": "kubernetes networking"}
+        )
+        events = _parse_sse(resp.text)
+        discarded = [e for e in events if e["type"] == "node_discarded"]
+
+        assert len(discarded) == 1
+        assert discarded[0]["data"]["note_id"] == "note-2"
+        assert discarded[0]["data"]["reason"] == "not relevant to query"
+
+    def test_text_chunk_contains_response(self, client):
+        resp = client.post(
+            "/api/chat/explore", json={"message": "kubernetes networking"}
+        )
+        events = _parse_sse(resp.text)
+        chunks = [e for e in events if e["type"] == "text_chunk"]
+
+        full_text = "".join(c["data"]["text"] for c in chunks)
+        assert "CNI plugins" in full_text
+
+    def test_empty_message_rejected(self, client):
+        resp = client.post("/api/chat/explore", json={"message": ""})
+        assert resp.status_code == 422
+
+    def test_history_forwarded(self, client, mock_store, mock_embed_client):
+        resp = client.post(
+            "/api/chat/explore",
+            json={
+                "message": "tell me more",
+                "history": [
+                    {"role": "user", "content": "kubernetes networking"},
+                    {"role": "assistant", "content": "Here are some notes..."},
+                ],
+            },
+        )
+
+        assert resp.status_code == 200
+        events = _parse_sse(resp.text)
+        assert any(e["type"] == "done" for e in events)

--- a/projects/monolith/chat/explore_router_test.py
+++ b/projects/monolith/chat/explore_router_test.py
@@ -11,7 +11,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from fastapi.testclient import TestClient
 from pydantic_ai.messages import ModelResponse, TextPart, ToolCallPart, ToolReturnPart
-from pydantic_ai.models.function import FunctionModel
+from pydantic_ai.models.function import DeltaToolCall, DeltaToolCalls, FunctionModel
 
 from app.main import app
 from chat.explorer import create_explorer_agent
@@ -50,56 +50,53 @@ MOCK_NOTE = {
 
 
 # ---------------------------------------------------------------------------
-# FunctionModel — scripts the tool call sequence
+# Scripted tool-call sequence for both function and stream_function
 # ---------------------------------------------------------------------------
 
+_TOOL_STEPS: list[tuple[str, dict, str]] = [
+    ("search_kg", {"query": "kubernetes networking"}, "c1"),
+    ("expand_node", {"note_id": "note-1"}, "c2"),
+    ("discard_node", {"note_id": "note-2", "reason": "not relevant to query"}, "c3"),
+]
 
-def _scripted_model(messages, info):
-    """search_kg -> expand_node -> discard_node -> text answer."""
-    tool_returns = [
-        part
+_FINAL_TEXT = "Kubernetes networking uses CNI plugins and service meshes."
+
+
+def _count_tool_returns(messages) -> int:
+    return sum(
+        1
         for msg in messages
         if hasattr(msg, "parts")
         for part in msg.parts
         if isinstance(part, ToolReturnPart)
-    ]
+    )
 
-    if len(tool_returns) == 0:
+
+def _scripted_model(messages, info):
+    """Non-streaming: search_kg -> expand_node -> discard_node -> text."""
+    n = _count_tool_returns(messages)
+    if n < len(_TOOL_STEPS):
+        name, args, cid = _TOOL_STEPS[n]
         return ModelResponse(
-            parts=[
-                ToolCallPart(
-                    tool_name="search_kg",
-                    args={"query": "kubernetes networking"},
-                    tool_call_id="c1",
-                )
-            ]
+            parts=[ToolCallPart(tool_name=name, args=args, tool_call_id=cid)]
         )
-    elif len(tool_returns) == 1:
-        return ModelResponse(
-            parts=[
-                ToolCallPart(
-                    tool_name="expand_node",
-                    args={"note_id": "note-1"},
-                    tool_call_id="c2",
-                )
-            ]
-        )
-    elif len(tool_returns) == 2:
-        return ModelResponse(
-            parts=[
-                ToolCallPart(
-                    tool_name="discard_node",
-                    args={"note_id": "note-2", "reason": "not relevant to query"},
-                    tool_call_id="c3",
-                )
-            ]
-        )
+    return ModelResponse(parts=[TextPart(_FINAL_TEXT)])
+
+
+async def _scripted_stream(messages, info):
+    """Streaming: yields DeltaToolCalls for tool steps, str for text step."""
+    n = _count_tool_returns(messages)
+    if n < len(_TOOL_STEPS):
+        name, args, cid = _TOOL_STEPS[n]
+        yield {
+            0: DeltaToolCall(
+                name=name,
+                json_args=json.dumps(args),
+                tool_call_id=cid,
+            )
+        }
     else:
-        return ModelResponse(
-            parts=[
-                TextPart("Kubernetes networking uses CNI plugins and service meshes.")
-            ]
-        )
+        yield _FINAL_TEXT
 
 
 # ---------------------------------------------------------------------------
@@ -151,7 +148,9 @@ def client(mock_store, mock_embed_client):
         patch("chat.router.KnowledgeStore", return_value=mock_store),
         patch("chat.router.EmbeddingClient", return_value=mock_embed_client),
         patch("app.db.get_session", _mock_get_session),
-        agent.override(model=FunctionModel(_scripted_model)),
+        agent.override(
+            model=FunctionModel(_scripted_model, stream_function=_scripted_stream)
+        ),
     ):
         yield TestClient(app)
 

--- a/projects/monolith/chat/explorer.py
+++ b/projects/monolith/chat/explorer.py
@@ -1,0 +1,133 @@
+"""PydanticAI explorer agent -- searches and traverses the knowledge graph."""
+
+import os
+from dataclasses import dataclass
+
+from pydantic_ai import Agent, ModelSettings, RunContext
+from pydantic_ai.models.openai import OpenAIChatModel
+from pydantic_ai.providers.openai import OpenAIProvider
+
+from chat.sse import SSEEmitter
+from knowledge.store import KnowledgeStore
+from shared.embedding import EmbeddingClient
+
+SYSTEM_PROMPT = """\
+You are a knowledge graph explorer. The user asks questions and you search \
+their personal knowledge graph to find relevant notes and connections.
+
+Your workflow:
+1. Use search_kg to find notes matching the user's question.
+2. Use expand_node to follow edges from promising notes and discover connections.
+3. Use discard_node to explicitly mark irrelevant results (with a reason).
+4. Synthesize your findings into a clear answer, referencing the notes you found.
+
+Always search before answering. Expand at least one promising node to discover \
+deeper connections. Discard results that aren't relevant — be decisive. \
+Reference notes by title when answering."""
+
+
+@dataclass
+class ExplorerDeps:
+    store: KnowledgeStore
+    embed_client: EmbeddingClient
+    emitter: SSEEmitter
+
+
+def create_explorer_agent() -> Agent[ExplorerDeps]:
+    """Create a PydanticAI agent configured for KG exploration via Gemma."""
+    url = os.environ.get("LLAMA_CPP_URL", "http://localhost:8000")
+    model = OpenAIChatModel(
+        "gemma-4-26b-a4b",
+        provider=OpenAIProvider(base_url=f"{url}/v1", api_key="not-needed"),
+    )
+    agent: Agent[ExplorerDeps] = Agent(
+        model,
+        system_prompt=SYSTEM_PROMPT,
+        model_settings=ModelSettings(max_tokens=4096),
+    )
+
+    @agent.tool
+    async def search_kg(ctx: RunContext[ExplorerDeps], query: str) -> str:
+        """Semantic search across the knowledge graph. Returns matching notes."""
+        return await _search_kg(ctx.deps, query)
+
+    @agent.tool
+    async def expand_node(ctx: RunContext[ExplorerDeps], note_id: str) -> str:
+        """Follow edges from a node to discover connected notes."""
+        return await _expand_node(ctx.deps, note_id)
+
+    @agent.tool
+    async def discard_node(
+        ctx: RunContext[ExplorerDeps], note_id: str, reason: str
+    ) -> str:
+        """Mark a node as irrelevant to the current exploration."""
+        return await _discard_node(ctx.deps, note_id, reason)
+
+    return agent
+
+
+async def _search_kg(deps: ExplorerDeps, query: str) -> str:
+    vector = await deps.embed_client.embed(query)
+    results = deps.store.search_notes_with_context(query_embedding=vector, limit=5)
+    lines = []
+    for r in results:
+        deps.emitter.emit(
+            "node_discovered",
+            {
+                "note_id": r["note_id"],
+                "title": r["title"],
+                "type": r["type"],
+                "tags": r["tags"],
+                "snippet": r["snippet"],
+                "edges": r.get("edges", []),
+            },
+        )
+        lines.append(
+            f"- {r['title']} (score: {r['score']:.2f}, type: {r['type']}): "
+            f"{r['snippet'][:200]}"
+        )
+    if not lines:
+        return "No results found."
+    return "Found notes:\n" + "\n".join(lines)
+
+
+async def _expand_node(deps: ExplorerDeps, note_id: str) -> str:
+    links = deps.store.get_note_links(note_id)
+    if not links:
+        return f"No edges found from {note_id}."
+
+    lines = []
+    for link in links:
+        target_id = link.get("resolved_note_id") or link["target_id"]
+        deps.emitter.emit(
+            "edge_traversed",
+            {
+                "from_id": note_id,
+                "to_id": target_id,
+                "edge_type": link.get("edge_type", "link"),
+            },
+        )
+        target = deps.store.get_note_by_id(target_id)
+        if target:
+            deps.emitter.emit(
+                "node_discovered",
+                {
+                    "note_id": target["note_id"],
+                    "title": target["title"],
+                    "type": target["type"],
+                    "tags": target.get("tags", []),
+                    "snippet": "",
+                    "edges": [],
+                },
+            )
+            edge_label = link.get("edge_type", "link")
+            lines.append(f"- {target['title']} ({edge_label})")
+        else:
+            lines.append(f"- {target_id} (unresolved)")
+
+    return f"Edges from {note_id}:\n" + "\n".join(lines)
+
+
+async def _discard_node(deps: ExplorerDeps, note_id: str, reason: str) -> str:
+    deps.emitter.emit("node_discarded", {"note_id": note_id, "reason": reason})
+    return f"Discarded {note_id}: {reason}"

--- a/projects/monolith/chat/explorer_test.py
+++ b/projects/monolith/chat/explorer_test.py
@@ -1,0 +1,111 @@
+import json
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from chat.explorer import ExplorerDeps, _search_kg, _expand_node, _discard_node
+from chat.sse import SSEEmitter
+
+
+def make_deps(emitter: SSEEmitter) -> ExplorerDeps:
+    store = MagicMock()
+    store.search_notes_with_context.return_value = [
+        {
+            "note_id": "note-1",
+            "title": "Kubernetes Networking",
+            "type": "note",
+            "tags": ["k8s", "networking"],
+            "score": 0.92,
+            "snippet": "Service mesh overview...",
+            "edges": [
+                {
+                    "target_id": "note-2",
+                    "target_title": "Linkerd",
+                    "kind": "edge",
+                    "edge_type": "refines",
+                }
+            ],
+        }
+    ]
+    store.get_note_links.return_value = [
+        {
+            "target_id": "note-3",
+            "target_title": "Cilium",
+            "kind": "edge",
+            "edge_type": "related",
+            "resolved_note_id": "note-3",
+        }
+    ]
+    store.get_note_by_id.return_value = {
+        "note_id": "note-3",
+        "title": "Cilium",
+        "type": "article",
+        "tags": ["networking"],
+    }
+
+    embed_client = AsyncMock()
+    embed_client.embed.return_value = [0.1] * 1024
+
+    return ExplorerDeps(
+        store=store,
+        embed_client=embed_client,
+        emitter=emitter,
+    )
+
+
+@pytest.mark.anyio
+async def test_search_kg_emits_node_discovered():
+    emitter = SSEEmitter()
+    deps = make_deps(emitter)
+
+    result = await _search_kg(deps, "kubernetes networking")
+
+    emitter.close()
+    events = []
+    async for chunk in emitter.stream():
+        parsed = json.loads(chunk.removeprefix("data: ").strip())
+        events.append(parsed)
+
+    assert len(events) == 1
+    assert events[0]["type"] == "node_discovered"
+    assert events[0]["data"]["note_id"] == "note-1"
+    assert events[0]["data"]["title"] == "Kubernetes Networking"
+    assert "refines" in str(events[0]["data"]["edges"])
+    assert "kubernetes" in result.lower()
+
+
+@pytest.mark.anyio
+async def test_expand_node_emits_edge_and_node():
+    emitter = SSEEmitter()
+    deps = make_deps(emitter)
+
+    result = await _expand_node(deps, "note-1")
+
+    emitter.close()
+    events = []
+    async for chunk in emitter.stream():
+        parsed = json.loads(chunk.removeprefix("data: ").strip())
+        events.append(parsed)
+
+    types = [e["type"] for e in events]
+    assert "edge_traversed" in types
+    assert "node_discovered" in types
+
+
+@pytest.mark.anyio
+async def test_discard_node_emits_event():
+    emitter = SSEEmitter()
+    deps = make_deps(emitter)
+
+    result = await _discard_node(deps, "note-1", "not relevant to query")
+
+    emitter.close()
+    events = []
+    async for chunk in emitter.stream():
+        parsed = json.loads(chunk.removeprefix("data: ").strip())
+        events.append(parsed)
+
+    assert len(events) == 1
+    assert events[0]["type"] == "node_discarded"
+    assert events[0]["data"]["note_id"] == "note-1"
+    assert events[0]["data"]["reason"] == "not relevant to query"

--- a/projects/monolith/chat/router.py
+++ b/projects/monolith/chat/router.py
@@ -1,11 +1,17 @@
-"""Chat API routes -- backfill endpoint."""
+"""Chat API routes -- backfill and explore endpoints."""
 
 import asyncio
 import logging
 
 from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import StreamingResponse
+from pydantic import BaseModel, Field
 
 from chat.backfill import run_backfill
+from chat.explorer import ExplorerDeps, create_explorer_agent
+from chat.sse import SSEEmitter
+from knowledge.store import KnowledgeStore
+from shared.embedding import EmbeddingClient
 
 logger = logging.getLogger(__name__)
 
@@ -36,3 +42,60 @@ async def backfill(request: Request):
 
     channels = [c for g in bot.guilds for c in g.text_channels]
     return {"status": "started", "channels": len(channels)}
+
+
+class ExploreRequest(BaseModel):
+    message: str = Field(min_length=1)
+    history: list[dict] = Field(default_factory=list)
+
+
+_explorer_agent = None
+
+
+def get_explorer_agent():
+    global _explorer_agent
+    if _explorer_agent is None:
+        _explorer_agent = create_explorer_agent()
+    return _explorer_agent
+
+
+@router.post("/explore")
+async def explore(body: ExploreRequest, request: Request):
+    from app.db import get_session
+
+    session = next(get_session())
+    emitter = SSEEmitter()
+    agent = get_explorer_agent()
+
+    deps = ExplorerDeps(
+        store=KnowledgeStore(session),
+        embed_client=EmbeddingClient(),
+        emitter=emitter,
+    )
+
+    # Build message list from history
+    messages = []
+    for turn in body.history:
+        messages.append({"role": turn["role"], "content": turn["content"]})
+
+    async def generate():
+        try:
+            async with agent.run_stream(
+                body.message,
+                message_history=messages if messages else None,
+                deps=deps,
+            ) as stream:
+                async for text in stream.stream_text(delta=True):
+                    emitter.emit("text_chunk", {"text": text})
+
+            emitter.emit("done", {})
+            emitter.close()
+        except Exception as e:
+            logger.exception("Explorer stream failed")
+            emitter.emit("error", {"message": str(e)})
+            emitter.close()
+
+        async for event in emitter.stream():
+            yield event
+
+    return StreamingResponse(generate(), media_type="text/event-stream")

--- a/projects/monolith/chat/sse.py
+++ b/projects/monolith/chat/sse.py
@@ -1,0 +1,27 @@
+import asyncio
+import json
+
+
+class SSEEmitter:
+    """Async queue-backed SSE event emitter.
+
+    Tools call emit() to push events. The endpoint iterates stream()
+    to drain them as text/event-stream lines.
+    """
+
+    def __init__(self) -> None:
+        self._queue: asyncio.Queue[str | None] = asyncio.Queue()
+
+    def emit(self, event_type: str, data: dict) -> None:
+        payload = json.dumps({"type": event_type, "data": data})
+        self._queue.put_nowait(f"data: {payload}\n\n")
+
+    def close(self) -> None:
+        self._queue.put_nowait(None)
+
+    async def stream(self):
+        while True:
+            chunk = await self._queue.get()
+            if chunk is None:
+                break
+            yield chunk

--- a/projects/monolith/chat/sse_test.py
+++ b/projects/monolith/chat/sse_test.py
@@ -1,0 +1,32 @@
+import json
+
+import pytest
+
+from chat.sse import SSEEmitter
+
+
+@pytest.mark.anyio
+async def test_emit_and_drain():
+    emitter = SSEEmitter()
+    emitter.emit("node_discovered", {"note_id": "abc", "title": "Test"})
+    emitter.emit("done", {})
+    emitter.close()
+
+    events = []
+    async for chunk in emitter.stream():
+        events.append(chunk)
+
+    assert len(events) == 2
+    first = json.loads(events[0].removeprefix("data: ").strip())
+    assert first["type"] == "node_discovered"
+    assert first["data"]["note_id"] == "abc"
+
+
+@pytest.mark.anyio
+async def test_close_terminates_stream():
+    emitter = SSEEmitter()
+    emitter.close()
+    events = []
+    async for chunk in emitter.stream():
+        events.append(chunk)
+    assert events == []

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.43.0
+      targetRevision: 0.43.1
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.43.1
+      targetRevision: 0.43.2
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.42.12
+      targetRevision: 0.43.0
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.43.2
+      targetRevision: 0.43.3
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/BUILD
+++ b/projects/monolith/frontend/BUILD
@@ -3,6 +3,7 @@ load("@aspect_rules_js//js:defs.bzl", "js_library", "js_run_binary")
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@npm//projects/monolith/frontend:vite/package_json.bzl", vite_bin = "bin")
+load("@npm//projects/monolith/frontend:vitest/package_json.bzl", vitest_bin = "bin")
 load("//bazel/tools/oci:apko_image.bzl", "apko_image")
 
 npm_link_all_packages(name = "node_modules")
@@ -17,6 +18,9 @@ js_library(
             "static/**/*",
         ],
         allow_empty = True,
+        exclude = [
+            "src/**/*.test.js",
+        ],
     ) + [
         "package.json",
         "svelte.config.js",
@@ -78,6 +82,32 @@ genrule(
         chown -R 65532:65532 tmp/app 2>/dev/null || true
         tar -C tmp --owner=65532 --group=65532 -cf $@ .
     """,
+)
+
+# Test library
+js_library(
+    name = "test_lib",
+    srcs = glob(
+        ["src/**/*.test.js"],
+        allow_empty = True,
+    ) + [
+        "vitest.config.js",
+    ],
+    deps = [
+        ":node_modules/vitest",
+        ":src",
+    ],
+)
+
+# Run vitest tests
+vitest_bin.vitest_test(
+    name = "test",
+    args = ["run"],
+    chdir = package_name(),
+    data = [
+        ":src",
+        ":test_lib",
+    ],
 )
 
 apko_image(

--- a/projects/monolith/frontend/BUILD
+++ b/projects/monolith/frontend/BUILD
@@ -33,6 +33,8 @@ js_library(
         ":node_modules/roughjs",
         # DAG layout engine
         ":node_modules/@dagrejs/dagre",
+        # Runtime markdown rendering
+        ":node_modules/marked",
         # OpenTelemetry browser tracing
         ":node_modules/@opentelemetry/api",
         ":node_modules/@opentelemetry/sdk-trace-web",

--- a/projects/monolith/frontend/package.json
+++ b/projects/monolith/frontend/package.json
@@ -17,6 +17,7 @@
     "@opentelemetry/resources": "^1.30.0",
     "@opentelemetry/sdk-trace-web": "^1.30.0",
     "@opentelemetry/semantic-conventions": "^1.28.0",
+    "marked": "^18.0.0",
     "roughjs": "^4.6.6"
   },
   "devDependencies": {

--- a/projects/monolith/frontend/package.json
+++ b/projects/monolith/frontend/package.json
@@ -28,6 +28,7 @@
     "@sveltejs/vite-plugin-svelte": "^4.0.0",
     "mdsvex": "^0.12.0",
     "svelte": "^5.0.0",
-    "vite": "^6.4.2"
+    "vite": "^6.4.2",
+    "vitest": "^4.0.18"
   }
 }

--- a/projects/monolith/frontend/src/routes/private/chat/+page.svelte
+++ b/projects/monolith/frontend/src/routes/private/chat/+page.svelte
@@ -12,6 +12,21 @@
   let selectedNode = $state(null);
   let drawerNote = $state(null);
   let drawerLoading = $state(false);
+  let isDark = $state(false);
+
+  $effect(() => {
+    isDark = localStorage.getItem("theme") === "dark";
+  });
+
+  function toggleTheme() {
+    isDark = !isDark;
+    localStorage.setItem("theme", isDark ? "dark" : "light");
+    document.documentElement.classList.toggle("dark", isDark);
+  }
+
+  $effect(() => {
+    document.documentElement.classList.toggle("dark", isDark);
+  });
 
   const graphState = createGraphState();
   let layoutResult = $state({ nodes: [], edges: [], nodeMap: {} });
@@ -316,6 +331,9 @@
   <header class="explorer-header">
     <span class="header-title">KNOWLEDGE EXPLORER</span>
     <span class="header-sub">powered by gemma-4</span>
+    <button class="theme-toggle" onclick={toggleTheme}>
+      {isDark ? "LIGHT" : "DARK"}
+    </button>
   </header>
 
   <div class="chat-card">
@@ -710,5 +728,25 @@
     padding: 2rem;
     text-transform: uppercase;
     letter-spacing: 0.05em;
+  }
+  .theme-toggle {
+    margin-left: auto;
+    background: none;
+    border: 1px solid rgba(255, 255, 255, 0.3);
+    color: #fff;
+    font-family: monospace;
+    font-size: 0.75rem;
+    padding: 0.2rem 0.6rem;
+    cursor: pointer;
+    letter-spacing: 0.05em;
+  }
+  :global(.dark) .explorer {
+    background: #1a1a1a;
+  }
+  :global(.dark) .graph-rule {
+    border-color: #3a3530;
+  }
+  :global(.dark) .graph-empty {
+    color: #8a8070;
   }
 </style>

--- a/projects/monolith/frontend/src/routes/private/chat/+page.svelte
+++ b/projects/monolith/frontend/src/routes/private/chat/+page.svelte
@@ -1,9 +1,32 @@
 <script>
+  import rough from "roughjs";
+  import { createGraphState } from "./graph-layout.js";
+
   let messages = $state([]);
   let graphEvents = $state([]);
   let inputText = $state("");
   let isStreaming = $state(false);
   let chatLog;
+
+  const graphState = createGraphState();
+  let layoutResult = $state({ nodes: [], edges: [], nodeMap: {} });
+  let svgEl;
+  let processedCount = $state(0);
+
+  const TYPE_COLORS = {
+    note: { fill: "#dbeafe", border: "#3b82f6", pencil: "#93c5fd" },
+    paper: { fill: "#dcfce7", border: "#22c55e", pencil: "#86efac" },
+    article: { fill: "#fef3c7", border: "#f59e0b", pencil: "#fcd34d" },
+    recipe: { fill: "#ffe4e6", border: "#f43f5e", pencil: "#fda4af" },
+  };
+
+  /** Remove all child nodes from an element. */
+  function clearChildren(el) {
+    if (!el) return;
+    while (el.firstChild) {
+      el.removeChild(el.firstChild);
+    }
+  }
 
   function scrollToBottom() {
     if (chatLog) {
@@ -86,6 +109,151 @@
       sendMessage();
     }
   }
+
+  // Process new graph events into layout (declared before drawing effect)
+  $effect(() => {
+    if (graphEvents.length <= processedCount) return;
+
+    for (let i = processedCount; i < graphEvents.length; i++) {
+      const evt = graphEvents[i];
+      if (evt.type === "node_discovered") {
+        graphState.addNode(evt.data);
+        for (const edge of evt.data.edges || []) {
+          graphState.addEdge(
+            evt.data.note_id,
+            edge.target_id,
+            edge.edge_type || "link",
+          );
+        }
+      } else if (evt.type === "edge_traversed") {
+        graphState.addEdge(
+          evt.data.from_id,
+          evt.data.to_id,
+          evt.data.edge_type,
+        );
+      } else if (evt.type === "node_discarded") {
+        graphState.discardNode(evt.data.note_id);
+      }
+    }
+    processedCount = graphEvents.length;
+
+    layoutResult = graphState.layout();
+  });
+
+  // Draw rough.js elements when layout changes
+  $effect(() => {
+    if (!svgEl || layoutResult.nodes.length === 0) return;
+    const rc = rough.svg(svgEl);
+
+    const nodeG = svgEl.querySelector(".graph-nodes");
+    const edgeG = svgEl.querySelector(".graph-edges");
+    const discardG = svgEl.querySelector(".graph-discards");
+    clearChildren(nodeG);
+    clearChildren(edgeG);
+    clearChildren(discardG);
+
+    // Compute viewBox to fit all nodes
+    let minX = Infinity,
+      minY = Infinity,
+      maxX = -Infinity,
+      maxY = -Infinity;
+    for (const n of layoutResult.nodes) {
+      minX = Math.min(minX, n.x - n.hw - 10);
+      maxX = Math.max(maxX, n.x + n.hw + 10);
+      minY = Math.min(minY, n.y - 21);
+      maxY = Math.max(maxY, n.y + 21);
+    }
+    const pad = 40;
+    svgEl.setAttribute(
+      "viewBox",
+      `${minX - pad} ${minY - pad} ${maxX - minX + pad * 2} ${maxY - minY + pad * 2}`,
+    );
+
+    // Draw edges
+    for (const edge of layoutResult.edges) {
+      const from = layoutResult.nodeMap[edge.from];
+      const to = layoutResult.nodeMap[edge.to];
+      if (!from?.x || !to?.x) continue;
+
+      const line = rc.line(from.x, from.y, to.x, to.y, {
+        stroke: "#8a8070",
+        strokeWidth: 1.5,
+        roughness: 0.8,
+      });
+      edgeG.appendChild(line);
+
+      const midX = (from.x + to.x) / 2;
+      const midY = (from.y + to.y) / 2;
+      const label = document.createElementNS(
+        "http://www.w3.org/2000/svg",
+        "text",
+      );
+      label.setAttribute("x", midX);
+      label.setAttribute("y", midY - 6);
+      label.setAttribute("text-anchor", "middle");
+      label.setAttribute("class", "edge-label");
+      label.textContent = edge.type || "";
+      edgeG.appendChild(label);
+    }
+
+    // Draw nodes
+    for (const node of layoutResult.nodes) {
+      const colors = TYPE_COLORS[node.type] || TYPE_COLORS.note;
+      const w = node.hw * 2 + 12;
+      const h = 42;
+
+      const rect = rc.rectangle(node.x - w / 2, node.y - h / 2, w, h, {
+        fill: node.discarded ? "#e5e5e5" : colors.fill,
+        stroke: node.discarded ? "#999" : colors.border,
+        strokeWidth: 2,
+        roughness: 1,
+        fillStyle: "solid",
+      });
+
+      const g = document.createElementNS("http://www.w3.org/2000/svg", "g");
+      if (node.isNew) {
+        g.classList.add("node-enter");
+      }
+      g.appendChild(rect);
+
+      const text = document.createElementNS(
+        "http://www.w3.org/2000/svg",
+        "text",
+      );
+      text.setAttribute("x", node.x);
+      text.setAttribute("y", node.y + 4);
+      text.setAttribute("text-anchor", "middle");
+      text.setAttribute(
+        "class",
+        `node-label${node.discarded ? " node-label--discarded" : ""}`,
+      );
+      text.textContent = node.label;
+      g.appendChild(text);
+
+      nodeG.appendChild(g);
+
+      // Discard strikethrough
+      if (node.discarded) {
+        const x1 = node.x - w / 2 + 4;
+        const y1 = node.y - h / 2 + 4;
+        const x2 = node.x + w / 2 - 4;
+        const y2 = node.y + h / 2 - 4;
+
+        const strike1 = rc.line(x1, y1, x2, y2, {
+          stroke: "#dc2626",
+          strokeWidth: 2.5,
+          roughness: 1.5,
+        });
+        const strike2 = rc.line(x2, y1, x1, y2, {
+          stroke: "#dc2626",
+          strokeWidth: 2.5,
+          roughness: 1.5,
+        });
+        discardG.appendChild(strike1);
+        discardG.appendChild(strike2);
+      }
+    }
+  });
 </script>
 
 <svelte:head>
@@ -130,18 +298,14 @@
   <hr class="graph-rule" />
 
   <div class="graph-area">
-    {#if graphEvents.length === 0 && messages.length === 0}
+    {#if graphState.getNodeCount() === 0}
       <p class="graph-empty">Ask a question to start exploring</p>
-    {:else if graphEvents.length > 0}
-      <p class="graph-empty">
-        {graphEvents.filter((e) => e.type === "node_discovered").length} nodes discovered
-        &middot;
-        {graphEvents.filter((e) => e.type === "edge_traversed").length} edges traversed
-        {#if graphEvents.some((e) => e.type === "node_discarded")}
-          &middot;
-          {graphEvents.filter((e) => e.type === "node_discarded").length} discarded
-        {/if}
-      </p>
+    {:else}
+      <svg bind:this={svgEl} class="graph-svg" xmlns="http://www.w3.org/2000/svg">
+        <g class="graph-edges"></g>
+        <g class="graph-nodes"></g>
+        <g class="graph-discards"></g>
+      </svg>
     {/if}
   </div>
 </div>
@@ -277,5 +441,42 @@
     text-transform: uppercase;
     letter-spacing: 0.1em;
     font-size: 0.85em;
+  }
+  .graph-svg {
+    width: 100%;
+    height: 100%;
+    min-height: 300px;
+  }
+  .node-label {
+    font-family: monospace;
+    font-size: 11px;
+    font-weight: 600;
+    fill: #1a1a1a;
+    pointer-events: none;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+  }
+  .node-label--discarded {
+    text-decoration: line-through;
+    opacity: 0.5;
+  }
+  .edge-label {
+    font-family: monospace;
+    font-size: 9px;
+    fill: #8a8070;
+    pointer-events: none;
+  }
+  .node-enter {
+    animation: fadeIn 400ms ease-out;
+  }
+  @keyframes fadeIn {
+    from {
+      opacity: 0;
+      transform: scale(0.9);
+    }
+    to {
+      opacity: 1;
+      transform: scale(1);
+    }
   }
 </style>

--- a/projects/monolith/frontend/src/routes/private/chat/+page.svelte
+++ b/projects/monolith/frontend/src/routes/private/chat/+page.svelte
@@ -1,0 +1,50 @@
+<script>
+  let messages = $state([]);
+  let inputText = $state("");
+  let isStreaming = $state(false);
+</script>
+
+<svelte:head>
+  <title>Knowledge Explorer</title>
+</svelte:head>
+
+<div class="explorer">
+  <header class="explorer-header">
+    <span class="header-title">KNOWLEDGE EXPLORER</span>
+    <span class="header-sub">powered by gemma-4</span>
+  </header>
+
+  <main class="explorer-body">
+    <p style="font-family: monospace; padding: 2rem;">Page skeleton — chat and graph coming next.</p>
+  </main>
+</div>
+
+<style>
+  .explorer {
+    display: flex;
+    flex-direction: column;
+    height: 100vh;
+    background: #faf8f4;
+  }
+  .explorer-header {
+    background: #1a1a1a;
+    color: #fff;
+    font-family: monospace;
+    padding: 0.5rem 1rem;
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+  }
+  .header-title {
+    font-weight: 700;
+    letter-spacing: 0.05em;
+  }
+  .header-sub {
+    opacity: 0.5;
+    font-size: 0.8em;
+  }
+  .explorer-body {
+    flex: 1;
+    overflow: hidden;
+  }
+</style>

--- a/projects/monolith/frontend/src/routes/private/chat/+page.svelte
+++ b/projects/monolith/frontend/src/routes/private/chat/+page.svelte
@@ -1,5 +1,6 @@
 <script>
   import rough from "roughjs";
+  import { marked } from "marked";
   import { createGraphState } from "./graph-layout.js";
 
   let messages = $state([]);
@@ -9,6 +10,8 @@
   let chatLog;
   let hoveredNode = $state(null);
   let selectedNode = $state(null);
+  let drawerNote = $state(null);
+  let drawerLoading = $state(false);
 
   const graphState = createGraphState();
   let layoutResult = $state({ nodes: [], edges: [], nodeMap: {} });
@@ -111,6 +114,31 @@
       sendMessage();
     }
   }
+
+  function onGlobalKeydown(e) {
+    if (e.key === "Escape" && selectedNode) {
+      selectedNode = null;
+    }
+  }
+
+  // Fetch note content when a node is selected
+  $effect(() => {
+    if (!selectedNode) {
+      drawerNote = null;
+      return;
+    }
+    drawerLoading = true;
+    fetch(`/private/chat?note_id=${encodeURIComponent(selectedNode)}`)
+      .then((r) => (r.ok ? r.json() : null))
+      .then((note) => {
+        drawerNote = note;
+        drawerLoading = false;
+      })
+      .catch(() => {
+        drawerNote = null;
+        drawerLoading = false;
+      });
+  });
 
   // Process new graph events into layout (declared before drawing effect)
   $effect(() => {
@@ -278,6 +306,8 @@
   });
 </script>
 
+<svelte:window onkeydown={onGlobalKeydown} />
+
 <svelte:head>
   <title>Knowledge Explorer</title>
 </svelte:head>
@@ -350,6 +380,45 @@
       </svg>
     {/if}
   </div>
+
+  {#if selectedNode}
+    <div
+      class="note-drawer"
+      role="complementary"
+      aria-label="Note details"
+    >
+      <button class="drawer-close" onclick={() => (selectedNode = null)}>
+        &times;
+      </button>
+      {#if drawerLoading}
+        <p class="drawer-loading">Loading...</p>
+      {:else if drawerNote}
+        <h2 class="drawer-title">{drawerNote.title}</h2>
+        <div class="drawer-meta">
+          <span class="drawer-type">{drawerNote.type}</span>
+          {#each drawerNote.tags || [] as tag}
+            <span class="drawer-tag">{tag}</span>
+          {/each}
+        </div>
+        <div class="drawer-content">
+          {@html marked(drawerNote.content || "")}
+        </div>
+        {#if drawerNote.edges?.length > 0}
+          <div class="drawer-edges">
+            <h3 class="drawer-edges-title">EDGES</h3>
+            {#each drawerNote.edges as edge}
+              <div class="drawer-edge">
+                <span class="drawer-edge-type">{edge.edge_type || edge.kind || "link"}</span>
+                <span class="drawer-edge-target">{edge.target_title || edge.target_id}</span>
+              </div>
+            {/each}
+          </div>
+        {/if}
+      {:else}
+        <p class="drawer-loading">Note not found</p>
+      {/if}
+    </div>
+  {/if}
 </div>
 
 <style>
@@ -520,5 +589,126 @@
       opacity: 1;
       transform: scale(1);
     }
+  }
+  .note-drawer {
+    position: fixed;
+    right: 0;
+    top: 0;
+    bottom: 0;
+    width: 420px;
+    max-width: 90vw;
+    background: #f5f0e8;
+    border-left: 2px solid #1a1a1a;
+    overflow-y: auto;
+    padding: 1.5rem;
+    font-family: monospace;
+    z-index: 100;
+    box-shadow: -4px 0 12px rgba(0, 0, 0, 0.1);
+    animation: slideIn 200ms ease-out;
+  }
+  @keyframes slideIn {
+    from {
+      transform: translateX(100%);
+    }
+    to {
+      transform: translateX(0);
+    }
+  }
+  .drawer-close {
+    position: absolute;
+    top: 0.75rem;
+    right: 0.75rem;
+    background: none;
+    border: none;
+    font-size: 1.5rem;
+    cursor: pointer;
+    font-family: monospace;
+    line-height: 1;
+  }
+  .drawer-title {
+    font-size: 1.1rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    margin: 0 0 0.75rem 0;
+  }
+  .drawer-meta {
+    display: flex;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+    margin-bottom: 1rem;
+  }
+  .drawer-type {
+    background: #1a1a1a;
+    color: #fff;
+    padding: 0.15rem 0.5rem;
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+  .drawer-tag {
+    background: #e5e0d8;
+    padding: 0.15rem 0.5rem;
+    font-size: 0.75rem;
+  }
+  .drawer-content {
+    font-size: 0.85rem;
+    line-height: 1.6;
+    border-top: 1px solid #c0b8a8;
+    padding-top: 1rem;
+  }
+  .drawer-content :global(h1),
+  .drawer-content :global(h2),
+  .drawer-content :global(h3) {
+    font-size: 0.95rem;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+    margin: 1rem 0 0.5rem 0;
+  }
+  .drawer-content :global(p) {
+    margin: 0.5rem 0;
+  }
+  .drawer-content :global(code) {
+    background: #e5e0d8;
+    padding: 0.1rem 0.3rem;
+    font-size: 0.8rem;
+  }
+  .drawer-content :global(pre) {
+    background: #1a1a1a;
+    color: #f5f0e8;
+    padding: 0.75rem;
+    overflow-x: auto;
+    font-size: 0.8rem;
+    margin: 0.5rem 0;
+  }
+  .drawer-edges {
+    border-top: 1px solid #c0b8a8;
+    padding-top: 1rem;
+    margin-top: 1rem;
+  }
+  .drawer-edges-title {
+    font-size: 0.8rem;
+    font-weight: 700;
+    letter-spacing: 0.05em;
+    margin: 0 0 0.5rem 0;
+    opacity: 0.5;
+  }
+  .drawer-edge {
+    display: flex;
+    gap: 0.5rem;
+    align-items: center;
+    padding: 0.25rem 0;
+    font-size: 0.8rem;
+  }
+  .drawer-edge-type {
+    opacity: 0.5;
+    min-width: 80px;
+  }
+  .drawer-loading {
+    text-align: center;
+    opacity: 0.4;
+    padding: 2rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
   }
 </style>

--- a/projects/monolith/frontend/src/routes/private/chat/+page.svelte
+++ b/projects/monolith/frontend/src/routes/private/chat/+page.svelte
@@ -1,7 +1,91 @@
 <script>
   let messages = $state([]);
+  let graphEvents = $state([]);
   let inputText = $state("");
   let isStreaming = $state(false);
+  let chatLog;
+
+  function scrollToBottom() {
+    if (chatLog) {
+      requestAnimationFrame(() => {
+        chatLog.scrollTop = chatLog.scrollHeight;
+      });
+    }
+  }
+
+  async function sendMessage() {
+    const text = inputText.trim();
+    if (!text || isStreaming) return;
+
+    inputText = "";
+    messages.push({ role: "user", content: text });
+    messages.push({ role: "assistant", content: "" });
+    isStreaming = true;
+    scrollToBottom();
+
+    try {
+      const res = await fetch("/private/chat", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          message: text,
+          history: messages.slice(0, -2).map((m) => ({
+            role: m.role,
+            content: m.content,
+          })),
+        }),
+      });
+
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+
+      const reader = res.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = "";
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split("\n\n");
+        buffer = lines.pop() || "";
+
+        for (const line of lines) {
+          if (!line.startsWith("data: ")) continue;
+          try {
+            const event = JSON.parse(line.slice(6));
+
+            if (event.type === "text_chunk") {
+              messages[messages.length - 1].content += event.data.text;
+              scrollToBottom();
+            } else if (event.type === "error") {
+              messages[messages.length - 1].content +=
+                `\n[Error: ${event.data.message}]`;
+            } else if (event.type === "done") {
+              // Stream complete
+            } else {
+              // Graph events: node_discovered, node_discarded, edge_traversed
+              graphEvents.push(event);
+            }
+          } catch {
+            // Skip malformed events
+          }
+        }
+      }
+    } catch (err) {
+      messages[messages.length - 1].content +=
+        `\n[Connection error: ${err.message}]`;
+    } finally {
+      isStreaming = false;
+    }
+  }
+
+  function onKeydown(e) {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      sendMessage();
+    }
+  }
 </script>
 
 <svelte:head>
@@ -14,12 +98,59 @@
     <span class="header-sub">powered by gemma-4</span>
   </header>
 
-  <main class="explorer-body">
-    <p style="font-family: monospace; padding: 2rem;">Page skeleton — chat and graph coming next.</p>
-  </main>
+  <div class="chat-card">
+    <div class="chat-log" bind:this={chatLog}>
+      {#each messages as msg, i}
+        <div class="chat-msg chat-msg--{msg.role}">
+          <span class="chat-role">{msg.role === "user" ? "you" : "gemma"}</span>
+          <span class="chat-text">{msg.content}</span>
+          {#if i === messages.length - 1 && isStreaming && msg.role === "assistant"}
+            <span class="chat-cursor">|</span>
+          {/if}
+        </div>
+      {/each}
+      {#if messages.length === 0}
+        <p class="chat-empty">Ask a question to start exploring your knowledge graph</p>
+      {/if}
+    </div>
+    <div class="chat-input-bar">
+      <input
+        type="text"
+        bind:value={inputText}
+        onkeydown={onKeydown}
+        placeholder="explore your knowledge..."
+        disabled={isStreaming}
+      />
+      <button onclick={sendMessage} disabled={isStreaming || !inputText.trim()}>
+        &rarr;
+      </button>
+    </div>
+  </div>
+
+  <hr class="graph-rule" />
+
+  <div class="graph-area">
+    {#if graphEvents.length === 0 && messages.length === 0}
+      <p class="graph-empty">Ask a question to start exploring</p>
+    {:else if graphEvents.length > 0}
+      <p class="graph-empty">
+        {graphEvents.filter((e) => e.type === "node_discovered").length} nodes discovered
+        &middot;
+        {graphEvents.filter((e) => e.type === "edge_traversed").length} edges traversed
+        {#if graphEvents.some((e) => e.type === "node_discarded")}
+          &middot;
+          {graphEvents.filter((e) => e.type === "node_discarded").length} discarded
+        {/if}
+      </p>
+    {/if}
+  </div>
 </div>
 
 <style>
+  :global(body) {
+    margin: 0;
+    padding: 0;
+  }
   .explorer {
     display: flex;
     flex-direction: column;
@@ -34,6 +165,7 @@
     display: flex;
     align-items: center;
     gap: 1rem;
+    flex-shrink: 0;
   }
   .header-title {
     font-weight: 700;
@@ -43,8 +175,107 @@
     opacity: 0.5;
     font-size: 0.8em;
   }
-  .explorer-body {
+  .chat-card {
+    margin: 1rem 1rem 0 1rem;
+    border: 2px solid #1a1a1a;
+    background: #f5f0e8;
+    display: flex;
+    flex-direction: column;
+    max-height: 35vh;
+    font-family: monospace;
+    flex-shrink: 0;
+  }
+  .chat-log {
     flex: 1;
-    overflow: hidden;
+    overflow-y: auto;
+    padding: 1rem;
+    min-height: 80px;
+  }
+  .chat-msg {
+    margin-bottom: 0.75rem;
+    line-height: 1.5;
+  }
+  .chat-msg--user {
+    text-align: right;
+  }
+  .chat-msg--assistant {
+    border-left: 3px solid #1a1a1a;
+    padding-left: 0.75rem;
+  }
+  .chat-role {
+    font-weight: 700;
+    text-transform: uppercase;
+    font-size: 0.75em;
+    letter-spacing: 0.05em;
+    display: block;
+    margin-bottom: 0.1rem;
+    opacity: 0.5;
+  }
+  .chat-text {
+    white-space: pre-wrap;
+    word-break: break-word;
+  }
+  .chat-cursor {
+    animation: blink 0.8s step-end infinite;
+  }
+  @keyframes blink {
+    50% {
+      opacity: 0;
+    }
+  }
+  .chat-empty {
+    text-align: center;
+    opacity: 0.4;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    font-size: 0.85em;
+    padding: 1rem;
+  }
+  .chat-input-bar {
+    border-top: 2px solid #1a1a1a;
+    display: flex;
+  }
+  .chat-input-bar input {
+    flex: 1;
+    padding: 0.75rem 1rem;
+    font-family: monospace;
+    font-size: 0.95rem;
+    border: none;
+    background: transparent;
+    outline: none;
+  }
+  .chat-input-bar button {
+    padding: 0.75rem 1.25rem;
+    font-family: monospace;
+    font-weight: 700;
+    font-size: 1.1rem;
+    border: none;
+    border-left: 2px solid #1a1a1a;
+    background: transparent;
+    cursor: pointer;
+  }
+  .chat-input-bar button:disabled {
+    opacity: 0.3;
+    cursor: default;
+  }
+  .graph-rule {
+    border: none;
+    border-top: 1.5px solid #c0b8a8;
+    margin: 1rem 1rem 0 1rem;
+  }
+  .graph-area {
+    flex: 1;
+    min-height: 0;
+    overflow: auto;
+    position: relative;
+  }
+  .graph-empty {
+    font-family: monospace;
+    text-align: center;
+    padding: 3rem;
+    opacity: 0.4;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    font-size: 0.85em;
   }
 </style>

--- a/projects/monolith/frontend/src/routes/private/chat/+page.svelte
+++ b/projects/monolith/frontend/src/routes/private/chat/+page.svelte
@@ -7,6 +7,8 @@
   let inputText = $state("");
   let isStreaming = $state(false);
   let chatLog;
+  let hoveredNode = $state(null);
+  let selectedNode = $state(null);
 
   const graphState = createGraphState();
   let layoutResult = $state({ nodes: [], edges: [], nodeMap: {} });
@@ -140,6 +142,17 @@
     layoutResult = graphState.layout();
   });
 
+  /** Return the set of node IDs connected to focusId (including itself). */
+  function getConnectedNodes(focusId) {
+    if (!focusId) return null;
+    const connected = new Set([focusId]);
+    for (const edge of layoutResult.edges) {
+      if (edge.from === focusId) connected.add(edge.to);
+      if (edge.to === focusId) connected.add(edge.from);
+    }
+    return connected;
+  }
+
   // Draw rough.js elements when layout changes
   $effect(() => {
     if (!svgEl || layoutResult.nodes.length === 0) return;
@@ -151,6 +164,9 @@
     clearChildren(nodeG);
     clearChildren(edgeG);
     clearChildren(discardG);
+
+    const focusId = selectedNode || hoveredNode;
+    const connected = getConnectedNodes(focusId);
 
     // Compute viewBox to fit all nodes
     let minX = Infinity,
@@ -175,11 +191,14 @@
       const to = layoutResult.nodeMap[edge.to];
       if (!from?.x || !to?.x) continue;
 
+      const edgeDimmed =
+        connected && !connected.has(edge.from) && !connected.has(edge.to);
       const line = rc.line(from.x, from.y, to.x, to.y, {
         stroke: "#8a8070",
         strokeWidth: 1.5,
         roughness: 0.8,
       });
+      line.style.opacity = edgeDimmed ? "0.25" : "1";
       edgeG.appendChild(line);
 
       const midX = (from.x + to.x) / 2;
@@ -193,6 +212,7 @@
       label.setAttribute("text-anchor", "middle");
       label.setAttribute("class", "edge-label");
       label.textContent = edge.type || "";
+      label.style.opacity = edgeDimmed ? "0.25" : "1";
       edgeG.appendChild(label);
     }
 
@@ -210,7 +230,9 @@
         fillStyle: "solid",
       });
 
+      const dimmed = connected && !connected.has(node.id);
       const g = document.createElementNS("http://www.w3.org/2000/svg", "g");
+      g.style.opacity = dimmed ? "0.25" : "1";
       if (node.isNew) {
         g.classList.add("node-enter");
       }
@@ -305,6 +327,26 @@
         <g class="graph-edges"></g>
         <g class="graph-nodes"></g>
         <g class="graph-discards"></g>
+        <g class="graph-hit-areas">
+          {#each layoutResult.nodes as node}
+            {#if !node.discarded}
+              <rect
+                x={node.x - (node.hw + 6)}
+                y={node.y - 21}
+                width={(node.hw + 6) * 2}
+                height={42}
+                fill="transparent"
+                style="cursor: pointer;"
+                role="button"
+                tabindex="0"
+                aria-label={node.label}
+                onmouseenter={() => (hoveredNode = node.id)}
+                onmouseleave={() => (hoveredNode = null)}
+                onclick={() => (selectedNode = selectedNode === node.id ? null : node.id)}
+              />
+            {/if}
+          {/each}
+        </g>
       </svg>
     {/if}
   </div>

--- a/projects/monolith/frontend/src/routes/private/chat/+page.ts
+++ b/projects/monolith/frontend/src/routes/private/chat/+page.ts
@@ -1,0 +1,1 @@
+export const ssr = false;

--- a/projects/monolith/frontend/src/routes/private/chat/+server.js
+++ b/projects/monolith/frontend/src/routes/private/chat/+server.js
@@ -1,0 +1,41 @@
+const API_BASE = process.env.API_BASE || "http://localhost:8000";
+
+export async function POST({ request }) {
+  const body = await request.json();
+
+  const upstream = await fetch(`${API_BASE}/api/chat/explore`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+    signal: AbortSignal.timeout(120000),
+  });
+
+  if (!upstream.ok) {
+    return new Response(JSON.stringify({ error: "upstream failed" }), {
+      status: upstream.status,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  return new Response(upstream.body, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+      Connection: "keep-alive",
+    },
+  });
+}
+
+export async function GET({ url }) {
+  const noteId = url.searchParams.get("note_id");
+  if (!noteId) return new Response("missing note_id", { status: 400 });
+
+  const res = await fetch(
+    `${API_BASE}/api/knowledge/notes/${encodeURIComponent(noteId)}`,
+    { signal: AbortSignal.timeout(10000) },
+  );
+  return new Response(res.body, {
+    status: res.status,
+    headers: { "Content-Type": "application/json" },
+  });
+}

--- a/projects/monolith/frontend/src/routes/private/chat/graph-layout.js
+++ b/projects/monolith/frontend/src/routes/private/chat/graph-layout.js
@@ -1,0 +1,134 @@
+import * as dagre from "@dagrejs/dagre";
+
+const CHAR_WIDTH = 6.5;
+const NODE_PAD = 12;
+const HH = 18;
+
+function computeHW(label) {
+  return Math.max(
+    24,
+    Math.ceil((label.length * CHAR_WIDTH) / 2) + NODE_PAD / 2,
+  );
+}
+
+/**
+ * Manages incremental graph layout.
+ * Call addNode/addEdge as SSE events arrive, then call layout()
+ * to get positioned nodes with smooth transitions.
+ */
+export function createGraphState() {
+  let nodes = [];
+  let edges = [];
+  let nodeMap = {};
+  let prevPositions = {};
+
+  function addNode(node) {
+    if (nodeMap[node.note_id]) return false;
+    const entry = {
+      id: node.note_id,
+      label: node.title,
+      type: node.type,
+      tags: node.tags || [],
+      snippet: node.snippet || "",
+      sseEdges: node.edges || [],
+      discarded: false,
+    };
+    nodes.push(entry);
+    nodeMap[node.note_id] = entry;
+    return true;
+  }
+
+  function addEdge(from_id, to_id, edge_type) {
+    const exists = edges.some((e) => e.from === from_id && e.to === to_id);
+    if (exists) return false;
+    edges.push({ from: from_id, to: to_id, type: edge_type });
+    return true;
+  }
+
+  function discardNode(note_id) {
+    if (nodeMap[note_id]) {
+      nodeMap[note_id].discarded = true;
+    }
+  }
+
+  function layout() {
+    if (nodes.length === 0) return { nodes: [], edges: [], nodeMap };
+
+    // Save previous positions for lerping
+    prevPositions = {};
+    for (const n of nodes) {
+      if (n.x !== undefined) {
+        prevPositions[n.id] = { x: n.x, y: n.y };
+      }
+    }
+
+    const g = new dagre.graphlib.Graph();
+    g.setGraph({
+      rankdir: "TB",
+      nodesep: 50,
+      ranksep: 60,
+      marginx: 40,
+      marginy: 40,
+    });
+    g.setDefaultEdgeLabel(() => ({}));
+
+    for (const node of nodes) {
+      const hw = computeHW(node.label);
+      g.setNode(node.id, {
+        width: hw * 2 + NODE_PAD,
+        height: HH * 2 + 6,
+      });
+    }
+
+    for (const edge of edges) {
+      if (g.hasNode(edge.from) && g.hasNode(edge.to)) {
+        g.setEdge(edge.from, edge.to);
+      }
+    }
+
+    dagre.layout(g);
+
+    const positioned = nodes.map((n) => {
+      const pos = g.node(n.id);
+      if (!pos) return n;
+      const hw = computeHW(n.label);
+      const prev = prevPositions[n.id];
+      return {
+        ...n,
+        x: pos.x,
+        y: pos.y,
+        hw,
+        prevX: prev?.x,
+        prevY: prev?.y,
+        isNew: prev === undefined,
+      };
+    });
+
+    // Update stored positions
+    for (const p of positioned) {
+      if (nodeMap[p.id]) {
+        nodeMap[p.id].x = p.x;
+        nodeMap[p.id].y = p.y;
+      }
+    }
+
+    return {
+      nodes: positioned,
+      edges: edges.filter((e) => g.hasNode(e.from) && g.hasNode(e.to)),
+      nodeMap,
+    };
+  }
+
+  function getNodeCount() {
+    return nodes.length;
+  }
+
+  function reset() {
+    nodes = [];
+    edges = [];
+    nodeMap = {};
+    prevPositions = {};
+  }
+
+  return { addNode, addEdge, discardNode, layout, getNodeCount, reset };
+}

--- a/projects/monolith/frontend/src/routes/private/chat/graph-layout.test.js
+++ b/projects/monolith/frontend/src/routes/private/chat/graph-layout.test.js
@@ -1,0 +1,177 @@
+import { describe, it, expect } from "vitest";
+import { createGraphState } from "./graph-layout.js";
+
+describe("createGraphState", () => {
+  it("starts empty", () => {
+    const gs = createGraphState();
+    const result = gs.layout();
+    expect(result.nodes).toEqual([]);
+    expect(result.edges).toEqual([]);
+  });
+
+  it("adds a node and assigns position after layout", () => {
+    const gs = createGraphState();
+    const added = gs.addNode({
+      note_id: "n1",
+      title: "Kubernetes",
+      type: "note",
+      tags: ["k8s"],
+      snippet: "Overview",
+      edges: [],
+    });
+
+    expect(added).toBe(true);
+    expect(gs.getNodeCount()).toBe(1);
+
+    const result = gs.layout();
+    expect(result.nodes).toHaveLength(1);
+    expect(result.nodes[0].id).toBe("n1");
+    expect(result.nodes[0].x).toBeTypeOf("number");
+    expect(result.nodes[0].y).toBeTypeOf("number");
+    expect(result.nodes[0].isNew).toBe(true);
+  });
+
+  it("deduplicates nodes", () => {
+    const gs = createGraphState();
+    gs.addNode({ note_id: "n1", title: "A", type: "note" });
+    const second = gs.addNode({ note_id: "n1", title: "A", type: "note" });
+
+    expect(second).toBe(false);
+    expect(gs.getNodeCount()).toBe(1);
+  });
+
+  it("adds edges between nodes", () => {
+    const gs = createGraphState();
+    gs.addNode({ note_id: "n1", title: "A", type: "note" });
+    gs.addNode({ note_id: "n2", title: "B", type: "article" });
+    const added = gs.addEdge("n1", "n2", "related");
+
+    expect(added).toBe(true);
+
+    const result = gs.layout();
+    expect(result.edges).toHaveLength(1);
+    expect(result.edges[0]).toEqual({ from: "n1", to: "n2", type: "related" });
+  });
+
+  it("deduplicates edges", () => {
+    const gs = createGraphState();
+    gs.addNode({ note_id: "n1", title: "A", type: "note" });
+    gs.addNode({ note_id: "n2", title: "B", type: "article" });
+    gs.addEdge("n1", "n2", "related");
+    const second = gs.addEdge("n1", "n2", "related");
+
+    expect(second).toBe(false);
+  });
+
+  it("tracks previous positions for smooth transitions", () => {
+    const gs = createGraphState();
+    gs.addNode({ note_id: "n1", title: "A", type: "note" });
+    const first = gs.layout();
+
+    // Add a second node — dagre will reposition n1
+    gs.addNode({ note_id: "n2", title: "B", type: "article" });
+    gs.addEdge("n1", "n2", "link");
+    const second = gs.layout();
+
+    const n1 = second.nodes.find((n) => n.id === "n1");
+    // n1 existed before, so it should have prev positions
+    expect(n1.isNew).toBe(false);
+    expect(n1.prevX).toBe(first.nodes[0].x);
+    expect(n1.prevY).toBe(first.nodes[0].y);
+
+    // n2 is new — no prev positions
+    const n2 = second.nodes.find((n) => n.id === "n2");
+    expect(n2.isNew).toBe(true);
+    expect(n2.prevX).toBeUndefined();
+  });
+
+  it("marks discarded nodes", () => {
+    const gs = createGraphState();
+    gs.addNode({ note_id: "n1", title: "A", type: "note" });
+    gs.discardNode("n1");
+
+    const result = gs.layout();
+    expect(result.nodes[0].discarded).toBe(true);
+  });
+
+  it("discarding unknown node is a no-op", () => {
+    const gs = createGraphState();
+    gs.discardNode("nonexistent"); // should not throw
+    expect(gs.getNodeCount()).toBe(0);
+  });
+
+  it("reset clears all state", () => {
+    const gs = createGraphState();
+    gs.addNode({ note_id: "n1", title: "A", type: "note" });
+    gs.addNode({ note_id: "n2", title: "B", type: "article" });
+    gs.addEdge("n1", "n2", "link");
+
+    gs.reset();
+
+    expect(gs.getNodeCount()).toBe(0);
+    const result = gs.layout();
+    expect(result.nodes).toEqual([]);
+    expect(result.edges).toEqual([]);
+  });
+
+  it("computes hw proportional to label length", () => {
+    const gs = createGraphState();
+    gs.addNode({ note_id: "short", title: "Hi", type: "note" });
+    gs.addNode({
+      note_id: "long",
+      title: "A Very Long Title For Testing",
+      type: "note",
+    });
+
+    const result = gs.layout();
+    const short = result.nodes.find((n) => n.id === "short");
+    const long = result.nodes.find((n) => n.id === "long");
+    expect(long.hw).toBeGreaterThan(short.hw);
+  });
+
+  it("handles full exploration sequence matching backend events", () => {
+    const gs = createGraphState();
+
+    // Simulate the SSE event sequence from the backend integration test:
+    // 1. search_kg discovers note-1
+    gs.addNode({
+      note_id: "note-1",
+      title: "Kubernetes Networking",
+      type: "note",
+      tags: ["k8s", "networking"],
+      snippet: "Service mesh overview...",
+      edges: [{ target_id: "note-2", edge_type: "refines" }],
+    });
+
+    // 2. expand_node traverses edge and discovers note-2
+    gs.addEdge("note-1", "note-2", "related");
+    gs.addNode({
+      note_id: "note-2",
+      title: "Linkerd",
+      type: "article",
+      tags: ["service-mesh"],
+    });
+
+    // 3. discard_node marks note-2 as irrelevant
+    gs.discardNode("note-2");
+
+    const result = gs.layout();
+
+    // Both nodes positioned
+    expect(result.nodes).toHaveLength(2);
+    expect(result.nodes.every((n) => typeof n.x === "number")).toBe(true);
+
+    // Edge connects them
+    expect(result.edges).toHaveLength(1);
+    expect(result.edges[0].from).toBe("note-1");
+    expect(result.edges[0].to).toBe("note-2");
+
+    // note-2 is discarded
+    const note2 = result.nodes.find((n) => n.id === "note-2");
+    expect(note2.discarded).toBe(true);
+
+    // note-1 is not discarded
+    const note1 = result.nodes.find((n) => n.id === "note-1");
+    expect(note1.discarded).toBe(false);
+  });
+});

--- a/projects/monolith/frontend/vitest.config.js
+++ b/projects/monolith/frontend/vitest.config.js
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.js"],
+  },
+});


### PR DESCRIPTION
## Summary
- **Backend:** PydanticAI agent with Gemma-4 and 3 KG tools (`search_kg`, `expand_node`, `discard_node`) streaming SSE events through `POST /api/chat/explore`
- **Frontend:** Chat-driven explorer at `private/chat` with brutalist/MotherDuck-inspired UI — chat card at top, rough.js animated graph below growing as Gemma searches
- **Graph features:** Color-coded nodes by note type, hover highlights with edge dimming, click-to-open note drawer with rendered markdown, rough.js strikethrough for discarded nodes, incremental dagre re-layout with smooth transitions, dark/light theme

## Design
- Design doc: `docs/plans/2026-04-14-kg-explorer-design.md`
- Implementation plan: `docs/plans/2026-04-14-kg-explorer-plan.md`

## Test Plan
- [ ] Backend: `bb remote test //projects/monolith:sse_test --config=ci`
- [ ] Backend: `bb remote test //projects/monolith:explorer_test --config=ci`
- [ ] CI format check passes (gazelle, prettier)
- [ ] Navigate to `private/chat`, type a query, verify SSE stream + graph rendering
- [ ] Click a node — verify drawer opens with markdown content
- [ ] Hover nodes — verify connected edges highlight, others dim
- [ ] Verify dark/light theme toggle works
- [ ] Verify discarded nodes get rough.js strikethrough

🤖 Generated with [Claude Code](https://claude.com/claude-code)