### PR TITLE
fix: update .tools-version to Bazel-built image path

### DIFF
--- a/.tools-version
+++ b/.tools-version
@@ -1,1 +1,1 @@
-ghcr.io/jomcgi/homelab-tools:main
+ghcr.io/jomcgi/homelab/bazel/tools/image:main


### PR DESCRIPTION
## Summary
- `.tools-version` still pointed to old `ghcr.io/jomcgi/homelab-tools:main`
- Updated to `ghcr.io/jomcgi/homelab/bazel/tools/image:main` where Bazel CI pushes

## Test plan
- [ ] `./bootstrap.sh` pulls the updated image
- [ ] `homelab --help` works after bootstrap

🤖 Generated with [Claude Code](https://claude.com/claude-code)