### PR TITLE
fix(monolith): unify domain-to-route rerouting in SvelteKit hooks

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.43.3
+version: 0.43.4
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/templates/httproute-private.yaml
+++ b/projects/monolith/chart/templates/httproute-private.yaml
@@ -28,17 +28,11 @@ spec:
       backendRefs:
         - name: {{ include "monolith.fullname" . }}
           port: {{ .Values.service.apiPort | int }}
-    # Everything else — rewrite to /private/
+    # Everything else — SvelteKit reroute hook maps to /private/ internally
     - matches:
         - path:
             type: PathPrefix
             value: /
-      filters:
-        - type: URLRewrite
-          urlRewrite:
-            path:
-              type: ReplacePrefixMatch
-              replacePrefixMatch: /private/
       backendRefs:
         - name: {{ include "monolith.fullname" . }}
           port: {{ .Values.cfIngress.private.servicePort | int }}

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.43.3
+      targetRevision: 0.43.4
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/hooks.js
+++ b/projects/monolith/frontend/src/hooks.js
@@ -1,10 +1,25 @@
+/**
+ * Maps subdomain prefixes to SvelteKit route prefixes.
+ * Requests to `<subdomain>.jomcgi.dev/foo` are rerouted internally
+ * to `/<prefix>/foo` so SvelteKit's file-based router resolves them
+ * from `src/routes/<prefix>/`.
+ *
+ * This replaces gateway-level ReplacePrefixMatch rewrites which have
+ * inconsistent slash-joining behaviour across implementations.
+ */
+const DOMAIN_PREFIX_MAP = {
+  "public.": "/public",
+  "private.": "/private",
+};
+
 /** @type {import('@sveltejs/kit').Reroute} */
 export function reroute({ url }) {
-  // public.jomcgi.dev/foo → internally route to /public/foo
-  if (
-    url.hostname.startsWith("public.") &&
-    !url.pathname.startsWith("/public/")
-  ) {
-    return `/public${url.pathname}`;
+  for (const [domain, prefix] of Object.entries(DOMAIN_PREFIX_MAP)) {
+    if (
+      url.hostname.startsWith(domain) &&
+      !url.pathname.startsWith(`${prefix}/`)
+    ) {
+      return `${prefix}${url.pathname}`;
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Replace broken gateway-level `ReplacePrefixMatch` with SvelteKit `reroute()` hook for private routes
- Add shared `DOMAIN_PREFIX_MAP` in `hooks.js` that maps both `public.*` and `private.*` subdomains to their route prefixes
- Removes the recurring slash-joining bug where `/private` + `chat` = `/privatechat` instead of `/private/chat`

## What was broken
The private HTTPRoute used `ReplacePrefixMatch: /private/` to rewrite paths at the gateway level. The Cloudflare gateway implementation was joining `/private/` + `chat` as `/privatechat` (missing slash), causing 404s on `private.jomcgi.dev/chat`.

The public route already used the correct pattern — no gateway rewrite, just the SvelteKit `reroute()` hook. Now both domains use the same approach.

## Test plan
- [ ] Verify `private.jomcgi.dev/chat` resolves (was 404)
- [ ] Verify `public.jomcgi.dev` still works (no regression)
- [ ] Verify `private.jomcgi.dev` root page works

🤖 Generated with [Claude Code](https://claude.com/claude-code)