### PR TITLE
fix(monolith): set OTEL_EXPORTER_OTLP_TRACES_ENDPOINT for backend

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.43.4
+version: 0.43.5
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/templates/deployment.yaml
+++ b/projects/monolith/chart/templates/deployment.yaml
@@ -67,6 +67,8 @@ spec:
             {{- end }}
             - name: FRONTEND_HEALTH_URL
               value: "http://localhost:3000/"
+            - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
+              value: "http://signoz-k8s-infra-otel-agent.signoz.svc.cluster.local:4318/v1/traces"
             {{- if .Values.chat.enabled }}
             - name: DISCORD_BOT_TOKEN
               valueFrom:

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.43.4
+      targetRevision: 0.43.5
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
## Summary
- Add missing `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` env var to backend container
- Points to the HTTP OTLP endpoint (`http://...:4318/v1/traces`) matching the `OTLPSpanExporter` proto-http exporter

## What was broken
The backend code reads `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` but this was never set in the Helm template. The SDK fell back to a bare hostname without `http://` scheme, causing `No connection adapters were found` errors.

## Test plan
- [ ] Verify backend OTel traces appear in SigNoz after rollout
- [ ] No more `Failed to export span batch` errors in backend logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)