### PR TITLE
feat(monolith): redesign knowledge explorer UI

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.43.5
+version: 0.44.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.43.5
+      targetRevision: 0.44.0
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/routes/private/chat/+page.svelte
+++ b/projects/monolith/frontend/src/routes/private/chat/+page.svelte
@@ -3,8 +3,17 @@
   import { marked } from "marked";
   import { createGraphState } from "./graph-layout.js";
 
+  /** Strip YAML frontmatter and the auto-generated LINKS section from note markdown. */
+  function cleanNoteContent(md) {
+    if (!md) return "";
+    // Remove YAML frontmatter (---\n...\n---)
+    let cleaned = md.replace(/^---\n[\s\S]*?\n---\n?/, "");
+    // Remove trailing Links section (any heading level or bare line, case-insensitive)
+    cleaned = cleaned.replace(/\n#{0,3}\s*Links\s*\n[\s\S]*$/i, "");
+    return cleaned.trim();
+  }
+
   let messages = $state([]);
-  let graphEvents = $state([]);
   let inputText = $state("");
   let isStreaming = $state(false);
   let chatLog;
@@ -12,32 +21,25 @@
   let selectedNode = $state(null);
   let drawerNote = $state(null);
   let drawerLoading = $state(false);
-  let isDark = $state(false);
-
-  $effect(() => {
-    isDark = localStorage.getItem("theme") === "dark";
-  });
-
-  function toggleTheme() {
-    isDark = !isDark;
-    localStorage.setItem("theme", isDark ? "dark" : "light");
-    document.documentElement.classList.toggle("dark", isDark);
-  }
-
-  $effect(() => {
-    document.documentElement.classList.toggle("dark", isDark);
-  });
 
   const graphState = createGraphState();
   let layoutResult = $state({ nodes: [], edges: [], nodeMap: {} });
-  let svgEl;
-  let processedCount = $state(0);
+  let svgEl = $state(null);
 
   const TYPE_COLORS = {
-    note: { fill: "#dbeafe", border: "#3b82f6", pencil: "#93c5fd" },
-    paper: { fill: "#dcfce7", border: "#22c55e", pencil: "#86efac" },
-    article: { fill: "#fef3c7", border: "#f59e0b", pencil: "#fcd34d" },
-    recipe: { fill: "#ffe4e6", border: "#f43f5e", pencil: "#fda4af" },
+    note: { border: "#ffd54f" },
+    atom: { border: "#64a0ff" },
+    fact: { border: "#00c853" },
+    paper: { border: "#2979ff" },
+    article: { border: "#ff6d00" },
+    recipe: { border: "#d500f9" },
+  };
+
+  const EDGE_COLORS = {
+    link: "#bbb",
+    related: "#ffd54f",
+    derives_from: "#1a1a1a",
+    edge: "#bbb",
   };
 
   /** Remove all child nodes from an element. */
@@ -108,7 +110,7 @@
               // Stream complete
             } else {
               // Graph events: node_discovered, node_discarded, edge_traversed
-              graphEvents.push(event);
+              enqueueGraphEvent(event);
             }
           } catch {
             // Skip malformed events
@@ -155,35 +157,154 @@
       });
   });
 
-  // Process new graph events into layout (declared before drawing effect)
-  $effect(() => {
-    if (graphEvents.length <= processedCount) return;
+  // Animated graph event queue — pencil→ink drawing for new nodes
+  //
+  // Flow per cycle:
+  //   1. Absorb all queued events into graph state at once
+  //   2. Re-layout → existing nodes CSS-transition to new positions (MOVE_MS)
+  //   3. After slide settles, draw each new node: pencil sketch → ink retrace → text jot
+  //   4. Drain again (absorbs anything that arrived during animation)
+  const MOVE_MS = 400;
+  const PEN_EASE = "cubic-bezier(0.65, 0, 0.15, 1)";
+  const PENCIL_MS = 600;   // pencil sketch total (4 sides)
+  const INK_MS = 500;      // ink retrace total (4 sides)
+  const TEXT_MS = 300;      // text fade-in
+  const EDGE_PENCIL_MS = 400; // pencil line between nodes
+  const EDGE_INK_MS = 340;    // ink retrace on edge
+  let eventQueue = [];
+  let draining = false;
+  let pendingRevealIds = new Set();
+  let pendingEdgeKeys = new Set();
 
-    for (let i = processedCount; i < graphEvents.length; i++) {
-      const evt = graphEvents[i];
+  function enqueueGraphEvent(evt) {
+    eventQueue.push(evt);
+    if (!draining) drainQueue();
+  }
+
+  function drainQueue() {
+    if (eventQueue.length === 0) { draining = false; return; }
+    draining = true;
+
+    // Absorb ALL queued events at once into graph state
+    const newNodeIds = [];
+    while (eventQueue.length > 0) {
+      const evt = eventQueue.shift();
       if (evt.type === "node_discovered") {
+        newNodeIds.push(evt.data.note_id);
+        pendingRevealIds.add(evt.data.note_id);
         graphState.addNode(evt.data);
         for (const edge of evt.data.edges || []) {
-          graphState.addEdge(
-            evt.data.note_id,
-            edge.target_id,
-            edge.edge_type || "link",
-          );
+          graphState.addEdge(evt.data.note_id, edge.target_id, edge.edge_type || "link");
         }
       } else if (evt.type === "edge_traversed") {
-        graphState.addEdge(
-          evt.data.from_id,
-          evt.data.to_id,
-          evt.data.edge_type,
-        );
+        graphState.addEdge(evt.data.from_id, evt.data.to_id, evt.data.edge_type);
       } else if (evt.type === "node_discarded") {
         graphState.discardNode(evt.data.note_id);
       }
     }
-    processedCount = graphEvents.length;
 
+    // Re-layout — existing nodes slide via CSS transition, new nodes drawn hidden
     layoutResult = graphState.layout();
-  });
+
+    if (newNodeIds.length === 0) {
+      // No new nodes, just edge/discard events — settle quickly
+      setTimeout(drainQueue, 60);
+      return;
+    }
+
+    // After existing nodes finish sliding, sequentially reveal each new node
+    setTimeout(() => revealNodes(newNodeIds, 0), MOVE_MS);
+  }
+
+  function revealNodes(ids, idx) {
+    if (idx >= ids.length) {
+      // All revealed — drain again to pick up anything that queued during animation
+      drainQueue();
+      return;
+    }
+    const id = ids[idx];
+    pendingRevealIds.delete(id);
+    const entry = drawnNodes.get(id);
+    if (!entry) { revealNodes(ids, idx + 1); return; }
+
+    // Animate the node box: pencil → ink → fill → text
+    animateNodeEntry(entry);
+
+    // Animate any pending edges connected to this node (after node ink starts)
+    setTimeout(() => {
+      for (const [key, edgeEntry] of drawnEdges) {
+        if (pendingEdgeKeys.has(key) && (edgeEntry.from === id || edgeEntry.to === id)) {
+          pendingEdgeKeys.delete(key);
+          animateEdgeEntry(edgeEntry);
+        }
+      }
+    }, PENCIL_MS + INK_MS * 0.3); // start edge draw as node ink is partway through
+
+    // Total animation time for one node + its edges, then start next
+    const nodeAnimMs = PENCIL_MS + INK_MS + Math.max(TEXT_MS, EDGE_PENCIL_MS + EDGE_INK_MS) * 0.6;
+    setTimeout(() => revealNodes(ids, idx + 1), nodeAnimMs);
+  }
+
+  /** Animate a node's pencil sketch → ink retrace → fill → text appearance. */
+  function animateNodeEntry(entry) {
+    const { g } = entry;
+
+    // Show the group container (was opacity 0)
+    g.style.transition = "none";
+    g.style.opacity = "1";
+    g.style.transform = `translate(${entry.origX}px, ${entry.origY}px) scale(1)`;
+
+    // Collect pencil elements (one per side, each may have 1-2 paths)
+    const pencilEls = g.querySelectorAll("[data-layer='pencil']");
+    const inkEls = g.querySelectorAll("[data-layer='ink']");
+    const numSides = Math.max(pencilEls.length, 1);
+    const pencilPerSide = PENCIL_MS / numSides;
+    const inkPerSide = INK_MS / numSides;
+
+    // Phase 1: Pencil sketch — light gray lines draw in sequentially
+    pencilEls.forEach((el, sideIdx) => {
+      el.style.opacity = "0.5"; // make visible (was 0 for pending)
+      const delay = sideIdx * pencilPerSide;
+      el.querySelectorAll("path").forEach((path) => {
+        try {
+          const len = path.getTotalLength();
+          path.style.strokeDasharray = String(len);
+          path.style.strokeDashoffset = String(len);
+          path.style.animation = `edgeDraw ${pencilPerSide}ms ${PEN_EASE} ${delay}ms forwards`;
+        } catch {
+          path.style.opacity = "0";
+          path.style.animation = `nodeIn 100ms ease ${delay}ms forwards`;
+        }
+      });
+    });
+
+    // Phase 2: Ink retrace — colored border draws over pencil, starts after pencil completes
+    inkEls.forEach((el, sideIdx) => {
+      const delay = PENCIL_MS + sideIdx * inkPerSide;
+      el.querySelectorAll("path").forEach((path) => {
+        // strokeDasharray/offset was set in drawNode for pending nodes
+        path.style.animation = `edgeDraw ${inkPerSide}ms ${PEN_EASE} ${delay}ms forwards`;
+      });
+    });
+
+    // Phase 3: Fill scrubs in after ink outline completes
+    const fillEl = g.querySelector("[data-layer='fill']");
+    if (fillEl) {
+      fillEl.style.animation = `nodeIn ${TEXT_MS}ms ease-out ${PENCIL_MS + INK_MS}ms forwards`;
+    }
+
+    // Phase 4: Text jots in (overlaps with ink tail end)
+    const textEl = g.querySelector("text");
+    if (textEl) {
+      textEl.style.animation = `textJot ${TEXT_MS}ms ease ${PENCIL_MS + INK_MS * 0.6}ms forwards`;
+    }
+
+    // Re-enable CSS transition for future position changes
+    const totalMs = PENCIL_MS + INK_MS + TEXT_MS;
+    setTimeout(() => {
+      g.style.transition = `transform ${MOVE_MS}ms ease, opacity 0.25s ease`;
+    }, totalMs);
+  }
 
   /** Return the set of node IDs connected to focusId (including itself). */
   function getConnectedNodes(focusId) {
@@ -196,7 +317,178 @@
     return connected;
   }
 
-  // Draw rough.js elements when layout changes
+  const NODE_H = 44;
+
+  // Persistent refs — survive across effect runs so we can diff
+  let drawnNodes = new Map();   // id → { g, origX, origY }
+  let drawnEdges = new Map();   // "from|to" → { el, from, to }
+  let nodeElsForDim = new Map();
+  let edgeElsForDim = new Map();
+
+  /** Deterministic seed from string. */
+  function seed(str) {
+    let h = 0;
+    for (let i = 0; i < str.length; i++) h = ((h << 5) - h + str.charCodeAt(i)) | 0;
+    return Math.abs(h);
+  }
+
+  /** Draw pencil + ink rough.js lines inside an edge group. */
+  function fillEdgeGroup(rc, g, x1, y1, x2, y2, color, edgeSeed, isPending) {
+    // Pencil: light gray sketch
+    const pencil = rc.line(x1, y1, x2, y2, {
+      stroke: "#c0b8a8",
+      roughness: 1,
+      strokeWidth: 1,
+      seed: edgeSeed,
+    });
+    pencil.dataset.layer = "pencil";
+    pencil.style.opacity = isPending ? "0" : "0.4";
+    g.appendChild(pencil);
+
+    // Ink: colored retrace
+    const ink = rc.line(x1, y1, x2, y2, {
+      stroke: color,
+      roughness: 1,
+      strokeWidth: 1.2,
+      seed: edgeSeed + 7,
+    });
+    ink.dataset.layer = "ink";
+    if (isPending) {
+      ink.querySelectorAll("path").forEach((p) => {
+        try {
+          const len = p.getTotalLength();
+          p.style.strokeDasharray = String(len);
+          p.style.strokeDashoffset = String(len);
+        } catch { /* fallback handled in animation */ }
+      });
+    } else {
+      ink.style.opacity = "0.5";
+    }
+    g.appendChild(ink);
+  }
+
+  /** Animate a new edge's pencil→ink draw-in. */
+  function animateEdgeEntry(edgeEntry) {
+    const { el: g } = edgeEntry;
+    const pencilEl = g.querySelector("[data-layer='pencil']");
+    const inkEl = g.querySelector("[data-layer='ink']");
+
+    // Pencil sketch draws in
+    if (pencilEl) {
+      pencilEl.style.opacity = "0.4";
+      pencilEl.querySelectorAll("path").forEach((path) => {
+        try {
+          const len = path.getTotalLength();
+          path.style.strokeDasharray = String(len);
+          path.style.strokeDashoffset = String(len);
+          path.style.animation = `edgeDraw ${EDGE_PENCIL_MS}ms ${PEN_EASE} 0ms forwards`;
+        } catch {
+          path.style.opacity = "0";
+          path.style.animation = `nodeIn 150ms ease forwards`;
+        }
+      });
+    }
+
+    // Ink chases after pencil
+    if (inkEl) {
+      inkEl.style.opacity = "0.5";
+      inkEl.querySelectorAll("path").forEach((path) => {
+        path.style.animation = `edgeDraw ${EDGE_INK_MS}ms ${PEN_EASE} ${EDGE_PENCIL_MS}ms forwards`;
+      });
+    }
+  }
+
+  function drawNode(rc, node) {
+    const colors = TYPE_COLORS[node.type] || TYPE_COLORS.note;
+    const w = node.hw * 2 + 16;
+    const h = NODE_H;
+    const isPending = pendingRevealIds.has(node.id);
+
+    const g = document.createElementNS("http://www.w3.org/2000/svg", "g");
+    g.style.transformOrigin = "0 0";
+
+    if (isPending) {
+      // Hidden — will be revealed by animateNodeEntry
+      g.style.opacity = "0";
+      g.style.transform = `translate(${node.x}px, ${node.y}px) scale(1)`;
+    } else {
+      g.style.opacity = "1";
+      g.style.transform = `translate(${node.x}px, ${node.y}px) scale(1)`;
+      g.style.transition = `transform ${MOVE_MS}ms ease, opacity 0.25s ease`;
+    }
+
+    // Solid fill — starts transparent for pending, visible for pre-existing
+    const fillEl = rc.rectangle(-w / 2, -h / 2, w, h, {
+      stroke: "none",
+      fill: node.discarded ? "#eee" : "#fff",
+      fillStyle: "solid",
+      roughness: 1.2,
+      seed: seed(node.id + "fill"),
+    });
+    fillEl.dataset.layer = "fill";
+    if (isPending) fillEl.style.opacity = "0";
+    g.appendChild(fillEl);
+
+    // Draw 4 sides as individual lines — enables per-side pencil→ink animation
+    const x1 = -w / 2, y1 = -h / 2;
+    const x2 = w / 2, y2 = h / 2;
+    const sides = [
+      { from: [x1, y1], to: [x2, y1], key: "top" },
+      { from: [x2, y1], to: [x2, y2], key: "right" },
+      { from: [x2, y2], to: [x1, y2], key: "bottom" },
+      { from: [x1, y2], to: [x1, y1], key: "left" },
+    ];
+
+    for (const side of sides) {
+      const sideSeed = seed(node.id + side.key);
+
+      // Pencil: light gray sketch
+      const pencil = rc.line(side.from[0], side.from[1], side.to[0], side.to[1], {
+        stroke: "#c0b8a8",
+        roughness: 1.2,
+        strokeWidth: 1,
+        seed: sideSeed,
+      });
+      pencil.style.opacity = isPending ? "0" : "0.5";
+      pencil.dataset.layer = "pencil";
+      g.appendChild(pencil);
+
+      // Ink: colored border retrace
+      const ink = rc.line(side.from[0], side.from[1], side.to[0], side.to[1], {
+        stroke: node.discarded ? "#999" : colors.border,
+        roughness: 1.2,
+        strokeWidth: 1.8,
+        seed: sideSeed + 7,
+      });
+      ink.dataset.layer = "ink";
+      if (isPending) {
+        // Hide ink paths — animation will reveal via strokeDashoffset
+        ink.querySelectorAll("path").forEach((p) => {
+          try {
+            const len = p.getTotalLength();
+            p.style.strokeDasharray = String(len);
+            p.style.strokeDashoffset = String(len);
+          } catch { /* fill paths — handled by nodeIn */ }
+        });
+      }
+      g.appendChild(ink);
+    }
+
+    // Label text
+    const text = document.createElementNS("http://www.w3.org/2000/svg", "text");
+    text.setAttribute("x", 0);
+    text.setAttribute("y", 4);
+    text.setAttribute("text-anchor", "middle");
+    text.setAttribute("font-size", "10");
+    text.setAttribute("class", `node-label${node.discarded ? " node-label--discarded" : ""}`);
+    text.textContent = node.label;
+    if (isPending) text.style.opacity = "0";
+    g.appendChild(text);
+
+    return { g, origX: node.x, origY: node.y };
+  }
+
+  // Incremental draw — only creates rough.js elements for new nodes/edges
   $effect(() => {
     if (!svgEl || layoutResult.nodes.length === 0) return;
     const rc = rough.svg(svgEl);
@@ -204,119 +496,131 @@
     const nodeG = svgEl.querySelector(".graph-nodes");
     const edgeG = svgEl.querySelector(".graph-edges");
     const discardG = svgEl.querySelector(".graph-discards");
-    clearChildren(nodeG);
-    clearChildren(edgeG);
-    clearChildren(discardG);
 
-    const focusId = selectedNode || hoveredNode;
-    const connected = getConnectedNodes(focusId);
-
-    // Compute viewBox to fit all nodes
-    let minX = Infinity,
-      minY = Infinity,
-      maxX = -Infinity,
-      maxY = -Infinity;
+    // Compute viewBox
+    let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
     for (const n of layoutResult.nodes) {
-      minX = Math.min(minX, n.x - n.hw - 10);
-      maxX = Math.max(maxX, n.x + n.hw + 10);
-      minY = Math.min(minY, n.y - 21);
-      maxY = Math.max(maxY, n.y + 21);
+      minX = Math.min(minX, n.x - n.hw - 16);
+      maxX = Math.max(maxX, n.x + n.hw + 16);
+      minY = Math.min(minY, n.y - NODE_H / 2 - 8);
+      maxY = Math.max(maxY, n.y + NODE_H / 2 + 8);
     }
-    const pad = 40;
+    const pad = 20;
     svgEl.setAttribute(
       "viewBox",
       `${minX - pad} ${minY - pad} ${maxX - minX + pad * 2} ${maxY - minY + pad * 2}`,
     );
+    svgEl.setAttribute("preserveAspectRatio", "xMidYMin meet");
 
-    // Draw edges
+    // --- Nodes: add new, move existing ---
+    const currentIds = new Set(layoutResult.nodes.map((n) => n.id));
+
+    // Remove nodes no longer in layout
+    for (const [id, entry] of drawnNodes) {
+      if (!currentIds.has(id)) {
+        entry.g.remove();
+        drawnNodes.delete(id);
+      }
+    }
+
+    for (const node of layoutResult.nodes) {
+      const existing = drawnNodes.get(node.id);
+      if (existing) {
+        // Slide to new position via CSS transition — no rough.js redraw
+        existing.g.style.transform = `translate(${node.x}px, ${node.y}px) scale(1)`;
+        existing.origX = node.x;
+        existing.origY = node.y;
+      } else {
+        // New node — draw with rough.js once
+        const entry = drawNode(rc, node);
+        nodeG.appendChild(entry.g);
+        drawnNodes.set(node.id, entry);
+      }
+    }
+
+    // --- Edges: rough.js pencil + ink with draw animation for new edges ---
+    clearChildren(discardG);
+    const currentEdgeKeys = new Set();
+    const newEdgeEls = new Map();
+    const newEdgeIds = []; // edges that need pencil→ink animation
+
     for (const edge of layoutResult.edges) {
       const from = layoutResult.nodeMap[edge.from];
       const to = layoutResult.nodeMap[edge.to];
-      if (!from?.x || !to?.x) continue;
+      if (from?.x == null || to?.x == null) continue;
 
-      const edgeDimmed =
-        connected && !connected.has(edge.from) && !connected.has(edge.to);
-      const line = rc.line(from.x, from.y, to.x, to.y, {
-        stroke: "#8a8070",
-        strokeWidth: 1.5,
-        roughness: 0.8,
-      });
-      line.style.opacity = edgeDimmed ? "0.25" : "1";
-      edgeG.appendChild(line);
+      const key = `${edge.from}|${edge.to}`;
+      currentEdgeKeys.add(key);
+      const edgeColor = EDGE_COLORS[edge.type] || EDGE_COLORS.link;
+      const edgeSeed = seed(edge.from + edge.to);
 
-      const midX = (from.x + to.x) / 2;
-      const midY = (from.y + to.y) / 2;
-      const label = document.createElementNS(
-        "http://www.w3.org/2000/svg",
-        "text",
-      );
-      label.setAttribute("x", midX);
-      label.setAttribute("y", midY - 6);
-      label.setAttribute("text-anchor", "middle");
-      label.setAttribute("class", "edge-label");
-      label.textContent = edge.type || "";
-      label.style.opacity = edgeDimmed ? "0.25" : "1";
-      edgeG.appendChild(label);
+      const existing = drawnEdges.get(key);
+      if (existing) {
+        // Only redraw if endpoints actually moved
+        if (existing.fx !== from.x || existing.fy !== from.y || existing.tx !== to.x || existing.ty !== to.y) {
+          clearChildren(existing.el);
+          fillEdgeGroup(rc, existing.el, from.x, from.y, to.x, to.y, edgeColor, edgeSeed, false);
+        }
+        existing.fx = from.x; existing.fy = from.y;
+        existing.tx = to.x; existing.ty = to.y;
+        newEdgeEls.set(key, existing);
+      } else {
+        // New edge — create group, draw hidden, queue for animation
+        const g = document.createElementNS("http://www.w3.org/2000/svg", "g");
+        g.style.transition = "opacity 0.15s";
+        fillEdgeGroup(rc, g, from.x, from.y, to.x, to.y, edgeColor, edgeSeed, true);
+        edgeG.appendChild(g);
+        newEdgeEls.set(key, { el: g, from: edge.from, to: edge.to, fx: from.x, fy: from.y, tx: to.x, ty: to.y });
+        newEdgeIds.push(key);
+      }
     }
 
-    // Draw nodes
+    // Remove stale edges
+    for (const [key, entry] of drawnEdges) {
+      if (!currentEdgeKeys.has(key)) entry.el.remove();
+    }
+    drawnEdges = newEdgeEls;
+
+    // Queue edge animations — they'll play alongside node reveals
+    for (const key of newEdgeIds) {
+      pendingEdgeKeys.add(key);
+    }
+
+    // Discard marks
     for (const node of layoutResult.nodes) {
-      const colors = TYPE_COLORS[node.type] || TYPE_COLORS.note;
-      const w = node.hw * 2 + 12;
-      const h = 42;
+      if (!node.discarded) continue;
+      const w = node.hw * 2 + 16;
+      const h = NODE_H;
+      const x1 = node.x - w / 2 + 3;
+      const x2 = node.x + w / 2 - 3;
+      const y1 = node.y - h / 2 + 3;
+      const y2 = node.y + h / 2 - 3;
+      discardG.appendChild(rc.line(x1, y1, x2, y2, {
+        stroke: "#ff3d00", strokeWidth: 2, roughness: 1.5,
+      }));
+      discardG.appendChild(rc.line(x2, y1, x1, y2, {
+        stroke: "#ff3d00", strokeWidth: 2, roughness: 1.5,
+      }));
+    }
 
-      const rect = rc.rectangle(node.x - w / 2, node.y - h / 2, w, h, {
-        fill: node.discarded ? "#e5e5e5" : colors.fill,
-        stroke: node.discarded ? "#999" : colors.border,
-        strokeWidth: 2,
-        roughness: 1,
-        fillStyle: "solid",
-      });
+    // Update refs for dimming effect
+    nodeElsForDim = new Map([...drawnNodes].map(([id, e]) => [id, e.g]));
+    edgeElsForDim = newEdgeEls;
+  });
 
-      const dimmed = connected && !connected.has(node.id);
-      const g = document.createElementNS("http://www.w3.org/2000/svg", "g");
-      g.style.opacity = dimmed ? "0.25" : "1";
-      if (node.isNew) {
-        g.classList.add("node-enter");
-      }
-      g.appendChild(rect);
+  // Hover/select dimming — just opacity, no redraw
+  $effect(() => {
+    const focusId = selectedNode || hoveredNode;
+    const connected = getConnectedNodes(focusId);
 
-      const text = document.createElementNS(
-        "http://www.w3.org/2000/svg",
-        "text",
-      );
-      text.setAttribute("x", node.x);
-      text.setAttribute("y", node.y + 4);
-      text.setAttribute("text-anchor", "middle");
-      text.setAttribute(
-        "class",
-        `node-label${node.discarded ? " node-label--discarded" : ""}`,
-      );
-      text.textContent = node.label;
-      g.appendChild(text);
-
-      nodeG.appendChild(g);
-
-      // Discard strikethrough
-      if (node.discarded) {
-        const x1 = node.x - w / 2 + 4;
-        const y1 = node.y - h / 2 + 4;
-        const x2 = node.x + w / 2 - 4;
-        const y2 = node.y + h / 2 - 4;
-
-        const strike1 = rc.line(x1, y1, x2, y2, {
-          stroke: "#dc2626",
-          strokeWidth: 2.5,
-          roughness: 1.5,
-        });
-        const strike2 = rc.line(x2, y1, x1, y2, {
-          stroke: "#dc2626",
-          strokeWidth: 2.5,
-          roughness: 1.5,
-        });
-        discardG.appendChild(strike1);
-        discardG.appendChild(strike2);
-      }
+    for (const [id, el] of nodeElsForDim) {
+      if (pendingRevealIds.has(id)) continue; // don't touch nodes mid-reveal
+      el.style.opacity = connected && !connected.has(id) ? "0.15" : "1";
+    }
+    for (const [key, edge] of edgeElsForDim) {
+      if (pendingEdgeKeys.has(key)) continue; // don't touch edges mid-reveal
+      const dim = connected && !connected.has(edge.from) && !connected.has(edge.to);
+      edge.el.style.opacity = dim ? "0.1" : "1";
     }
   });
 </script>
@@ -328,75 +632,74 @@
 </svelte:head>
 
 <div class="explorer">
-  <header class="explorer-header">
-    <span class="header-title">KNOWLEDGE EXPLORER</span>
-    <span class="header-sub">powered by gemma-4</span>
-    <button class="theme-toggle" onclick={toggleTheme}>
-      {isDark ? "LIGHT" : "DARK"}
-    </button>
-  </header>
+  <div class="explorer-body">
+    <aside class="chat-panel">
+      <header class="explorer-header">
+        <span class="header-title">KNOWLEDGE</span>
+      </header>
+      <div class="chat-log" bind:this={chatLog}>
+        {#each messages as msg, i}
+          <div class="chat-msg chat-msg--{msg.role}">
+            <span class="chat-role">{msg.role === "user" ? "you" : "gemma"}</span>
+            {#if msg.role === "assistant"}
+              <span class="chat-text">{@html marked(msg.content)}</span>
+            {:else}
+              <span class="chat-text">{msg.content}</span>
+            {/if}
+            {#if i === messages.length - 1 && isStreaming && msg.role === "assistant"}
+              <span class="chat-cursor">|</span>
+            {/if}
+          </div>
+        {/each}
+        {#if messages.length === 0}
+          <p class="chat-empty">Ask a question to explore your knowledge graph</p>
+        {/if}
+      </div>
+      <div class="chat-input-bar">
+        <input
+          type="text"
+          bind:value={inputText}
+          onkeydown={onKeydown}
+          placeholder="explore your knowledge..."
+          disabled={isStreaming}
+        />
+        <button onclick={sendMessage} disabled={isStreaming || !inputText.trim()}>
+          &rarr;
+        </button>
+      </div>
+    </aside>
 
-  <div class="chat-card">
-    <div class="chat-log" bind:this={chatLog}>
-      {#each messages as msg, i}
-        <div class="chat-msg chat-msg--{msg.role}">
-          <span class="chat-role">{msg.role === "user" ? "you" : "gemma"}</span>
-          <span class="chat-text">{msg.content}</span>
-          {#if i === messages.length - 1 && isStreaming && msg.role === "assistant"}
-            <span class="chat-cursor">|</span>
-          {/if}
-        </div>
-      {/each}
-      {#if messages.length === 0}
-        <p class="chat-empty">Ask a question to start exploring your knowledge graph</p>
+    <div class="graph-area">
+      {#if layoutResult.nodes.length === 0}
+        <p class="graph-empty">Ask a question to start exploring</p>
+      {:else}
+        <svg bind:this={svgEl} class="graph-svg" xmlns="http://www.w3.org/2000/svg">
+          <g class="graph-edges"></g>
+          <g class="graph-nodes"></g>
+          <g class="graph-discards"></g>
+          <g class="graph-hit-areas">
+            {#each layoutResult.nodes as node}
+              {#if !node.discarded}
+                <rect
+                  x={node.x - (node.hw + 8)}
+                  y={node.y - 22}
+                  width={(node.hw + 8) * 2}
+                  height={44}
+                  fill="transparent"
+                  style="cursor: pointer;"
+                  role="button"
+                  tabindex="0"
+                  aria-label={node.label}
+                  onmouseenter={() => (hoveredNode = node.id)}
+                  onmouseleave={() => (hoveredNode = null)}
+                  onclick={() => (selectedNode = selectedNode === node.id ? null : node.id)}
+                />
+              {/if}
+            {/each}
+          </g>
+        </svg>
       {/if}
     </div>
-    <div class="chat-input-bar">
-      <input
-        type="text"
-        bind:value={inputText}
-        onkeydown={onKeydown}
-        placeholder="explore your knowledge..."
-        disabled={isStreaming}
-      />
-      <button onclick={sendMessage} disabled={isStreaming || !inputText.trim()}>
-        &rarr;
-      </button>
-    </div>
-  </div>
-
-  <hr class="graph-rule" />
-
-  <div class="graph-area">
-    {#if graphState.getNodeCount() === 0}
-      <p class="graph-empty">Ask a question to start exploring</p>
-    {:else}
-      <svg bind:this={svgEl} class="graph-svg" xmlns="http://www.w3.org/2000/svg">
-        <g class="graph-edges"></g>
-        <g class="graph-nodes"></g>
-        <g class="graph-discards"></g>
-        <g class="graph-hit-areas">
-          {#each layoutResult.nodes as node}
-            {#if !node.discarded}
-              <rect
-                x={node.x - (node.hw + 6)}
-                y={node.y - 21}
-                width={(node.hw + 6) * 2}
-                height={42}
-                fill="transparent"
-                style="cursor: pointer;"
-                role="button"
-                tabindex="0"
-                aria-label={node.label}
-                onmouseenter={() => (hoveredNode = node.id)}
-                onmouseleave={() => (hoveredNode = null)}
-                onclick={() => (selectedNode = selectedNode === node.id ? null : node.id)}
-              />
-            {/if}
-          {/each}
-        </g>
-      </svg>
-    {/if}
   </div>
 
   {#if selectedNode}
@@ -413,13 +716,13 @@
       {:else if drawerNote}
         <h2 class="drawer-title">{drawerNote.title}</h2>
         <div class="drawer-meta">
-          <span class="drawer-type">{drawerNote.type}</span>
+          <span class="drawer-type" style="background: {TYPE_COLORS[drawerNote.type]?.border || '#ffd54f'}">{drawerNote.type}</span>
           {#each drawerNote.tags || [] as tag}
             <span class="drawer-tag">{tag}</span>
           {/each}
         </div>
         <div class="drawer-content">
-          {@html marked(drawerNote.content || "")}
+          {@html marked(cleanNoteContent(drawerNote.content))}
         </div>
         {#if drawerNote.edges?.length > 0}
           <div class="drawer-edges">
@@ -445,68 +748,112 @@
     padding: 0;
   }
   .explorer {
-    display: flex;
-    flex-direction: column;
     height: 100vh;
     background: #faf8f4;
+    color: #1a1a1a;
+  }
+  .explorer-body {
+    display: flex;
+    height: 100%;
+  }
+  .chat-panel {
+    width: 35%;
+    min-width: 380px;
+    max-width: 600px;
+    flex-shrink: 0;
+    display: flex;
+    flex-direction: column;
+    border-right: 2px solid #1a1a1a;
+    background: #fffef7;
+    font-family: monospace;
+    font-size: 13px;
   }
   .explorer-header {
-    background: #1a1a1a;
-    color: #fff;
+    background: #ffd54f;
+    color: #1a1a1a;
     font-family: monospace;
-    padding: 0.5rem 1rem;
+    padding: 4px 12px;
     display: flex;
     align-items: center;
-    gap: 1rem;
     flex-shrink: 0;
+    border-bottom: 2px solid #1a1a1a;
   }
   .header-title {
     font-weight: 700;
-    letter-spacing: 0.05em;
-  }
-  .header-sub {
-    opacity: 0.5;
-    font-size: 0.8em;
-  }
-  .chat-card {
-    margin: 1rem 1rem 0 1rem;
-    border: 2px solid #1a1a1a;
-    background: #f5f0e8;
-    display: flex;
-    flex-direction: column;
-    max-height: 35vh;
-    font-family: monospace;
-    flex-shrink: 0;
+    font-size: 12px;
+    letter-spacing: 0.15em;
   }
   .chat-log {
-    flex: 1;
+    flex: 1 1 0;
     overflow-y: auto;
-    padding: 1rem;
-    min-height: 80px;
+    padding: 10px 12px;
+    min-height: 0;
   }
   .chat-msg {
-    margin-bottom: 0.75rem;
-    line-height: 1.5;
+    margin-bottom: 8px;
+    line-height: 1.45;
   }
   .chat-msg--user {
     text-align: right;
   }
   .chat-msg--assistant {
-    border-left: 3px solid #1a1a1a;
-    padding-left: 0.75rem;
+    border-left: 3px solid #ffd54f;
+    padding-left: 10px;
   }
   .chat-role {
     font-weight: 700;
     text-transform: uppercase;
-    font-size: 0.75em;
+    font-size: 10px;
     letter-spacing: 0.05em;
     display: block;
-    margin-bottom: 0.1rem;
+    margin-bottom: 1px;
     opacity: 0.5;
   }
   .chat-text {
-    white-space: pre-wrap;
     word-break: break-word;
+    display: block;
+  }
+  .chat-msg--user .chat-text {
+    white-space: pre-wrap;
+  }
+  .chat-text :global(h1),
+  .chat-text :global(h2),
+  .chat-text :global(h3) {
+    font-size: 13px;
+    font-weight: 700;
+    margin: 6px 0 3px 0;
+  }
+  .chat-text :global(p) {
+    margin: 3px 0;
+  }
+  .chat-text :global(ul),
+  .chat-text :global(ol) {
+    padding-left: 18px;
+    margin: 3px 0;
+  }
+  .chat-text :global(li) {
+    margin: 2px 0;
+  }
+  .chat-text :global(code) {
+    background: #e5e0d8;
+    padding: 1px 3px;
+    font-size: 12px;
+  }
+  .chat-text :global(pre) {
+    background: #1a1a1a;
+    color: #f5f0e8;
+    padding: 6px;
+    overflow-x: auto;
+    font-size: 12px;
+    margin: 3px 0;
+  }
+  .chat-text :global(pre code) {
+    background: none;
+    padding: 0;
+    color: inherit;
+  }
+  .chat-text :global(strong) {
+    font-weight: 700;
   }
   .chat-cursor {
     animation: blink 0.8s step-end infinite;
@@ -521,29 +868,29 @@
     opacity: 0.4;
     text-transform: uppercase;
     letter-spacing: 0.05em;
-    font-size: 0.85em;
-    padding: 1rem;
+    font-size: 12px;
+    padding: 12px;
   }
   .chat-input-bar {
-    border-top: 2px solid #1a1a1a;
+    border-top: 1.5px solid #1a1a1a;
     display: flex;
   }
   .chat-input-bar input {
     flex: 1;
-    padding: 0.75rem 1rem;
+    padding: 12px;
     font-family: monospace;
-    font-size: 0.95rem;
+    font-size: 13px;
     border: none;
     background: transparent;
     outline: none;
   }
   .chat-input-bar button {
-    padding: 0.75rem 1.25rem;
+    padding: 12px 14px;
     font-family: monospace;
     font-weight: 700;
-    font-size: 1.1rem;
+    font-size: 14px;
     border: none;
-    border-left: 2px solid #1a1a1a;
+    border-left: 1.5px solid #1a1a1a;
     background: transparent;
     cursor: pointer;
   }
@@ -551,71 +898,59 @@
     opacity: 0.3;
     cursor: default;
   }
-  .graph-rule {
-    border: none;
-    border-top: 1.5px solid #c0b8a8;
-    margin: 1rem 1rem 0 1rem;
-  }
   .graph-area {
     flex: 1;
     min-height: 0;
-    overflow: auto;
+    overflow: hidden;
     position: relative;
   }
   .graph-empty {
     font-family: monospace;
     text-align: center;
-    padding: 3rem;
+    padding: 40px;
     opacity: 0.4;
     text-transform: uppercase;
     letter-spacing: 0.1em;
-    font-size: 0.85em;
+    font-size: 13px;
   }
   .graph-svg {
     width: 100%;
     height: 100%;
-    min-height: 300px;
+  }
+  .graph-svg :global(path) {
+    stroke-linecap: round;
+    stroke-linejoin: round;
   }
   .node-label {
     font-family: monospace;
-    font-size: 11px;
-    font-weight: 600;
+    font-weight: 700;
     fill: #1a1a1a;
     pointer-events: none;
-    text-transform: uppercase;
-    letter-spacing: 0.03em;
   }
   .node-label--discarded {
     text-decoration: line-through;
-    opacity: 0.5;
+    opacity: 0.4;
   }
-  .edge-label {
-    font-family: monospace;
-    font-size: 9px;
-    fill: #8a8070;
-    pointer-events: none;
+  /* Pencil→ink draw animation keyframes (global — targets dynamic SVG elements) */
+  @keyframes -global-edgeDraw {
+    to { stroke-dashoffset: 0; }
   }
-  .node-enter {
-    animation: fadeIn 400ms ease-out;
+  @keyframes -global-nodeIn {
+    from { opacity: 0; }
+    to { opacity: 1; }
   }
-  @keyframes fadeIn {
-    from {
-      opacity: 0;
-      transform: scale(0.9);
-    }
-    to {
-      opacity: 1;
-      transform: scale(1);
-    }
+  @keyframes -global-textJot {
+    0% { opacity: 0; transform: translate(-1px, 0.5px); }
+    40% { opacity: 0.85; }
+    100% { opacity: 1; transform: translate(0, 0); }
   }
   .note-drawer {
     position: fixed;
     right: 0;
     top: 0;
     bottom: 0;
-    width: 420px;
-    max-width: 90vw;
-    background: #f5f0e8;
+    width: 75vw;
+    background: #fffef7;
     border-left: 2px solid #1a1a1a;
     overflow-y: auto;
     padding: 1.5rem;
@@ -657,12 +992,12 @@
     margin-bottom: 1rem;
   }
   .drawer-type {
-    background: #1a1a1a;
-    color: #fff;
+    color: #1a1a1a;
     padding: 0.15rem 0.5rem;
     font-size: 0.75rem;
     text-transform: uppercase;
     letter-spacing: 0.05em;
+    font-weight: 700;
   }
   .drawer-tag {
     background: #e5e0d8;
@@ -699,6 +1034,42 @@
     font-size: 0.8rem;
     margin: 0.5rem 0;
   }
+  .drawer-content :global(pre code) {
+    background: none;
+    padding: 0;
+    color: inherit;
+    font-size: inherit;
+  }
+  .drawer-content :global(ol),
+  .drawer-content :global(ul) {
+    padding-left: 1.5rem;
+    margin: 0.5rem 0;
+  }
+  .drawer-content :global(li) {
+    margin: 0.25rem 0;
+  }
+  .drawer-content :global(table) {
+    width: 100%;
+    border-collapse: collapse;
+    margin: 0.75rem 0;
+    font-size: 0.8rem;
+  }
+  .drawer-content :global(th),
+  .drawer-content :global(td) {
+    border: 1px solid #c0b8a8;
+    padding: 0.4rem 0.6rem;
+    text-align: left;
+  }
+  .drawer-content :global(th) {
+    background: #f0ebe3;
+    font-weight: 700;
+    text-transform: uppercase;
+    font-size: 0.75rem;
+    letter-spacing: 0.03em;
+  }
+  .drawer-content :global(tr:nth-child(even)) {
+    background: #f8f5ef;
+  }
   .drawer-edges {
     border-top: 1px solid #c0b8a8;
     padding-top: 1rem;
@@ -728,25 +1099,5 @@
     padding: 2rem;
     text-transform: uppercase;
     letter-spacing: 0.05em;
-  }
-  .theme-toggle {
-    margin-left: auto;
-    background: none;
-    border: 1px solid rgba(255, 255, 255, 0.3);
-    color: #fff;
-    font-family: monospace;
-    font-size: 0.75rem;
-    padding: 0.2rem 0.6rem;
-    cursor: pointer;
-    letter-spacing: 0.05em;
-  }
-  :global(.dark) .explorer {
-    background: #1a1a1a;
-  }
-  :global(.dark) .graph-rule {
-    border-color: #3a3530;
-  }
-  :global(.dark) .graph-empty {
-    color: #8a8070;
   }
 </style>

--- a/projects/monolith/frontend/src/routes/private/chat/graph-layout.js
+++ b/projects/monolith/frontend/src/routes/private/chat/graph-layout.js
@@ -1,20 +1,118 @@
 import * as dagre from "@dagrejs/dagre";
 
-const CHAR_WIDTH = 6.5;
-const NODE_PAD = 12;
-const HH = 18;
+const CHAR_WIDTH = 7;
+const NODE_PAD = 28;
+const HH = 22;
+const NODE_H = 44;
+const GAP_X = 60;
+const GAP_Y = 60;
+const MAX_LABEL_LEN = 22;
+
+function truncateLabel(title) {
+  if (!title || title.length <= MAX_LABEL_LEN) return title || "";
+  const cut = title.lastIndexOf(" ", MAX_LABEL_LEN);
+  return (
+    (cut > 8 ? title.slice(0, cut) : title.slice(0, MAX_LABEL_LEN)) + "\u2026"
+  );
+}
 
 function computeHW(label) {
   return Math.max(
-    24,
+    32,
     Math.ceil((label.length * CHAR_WIDTH) / 2) + NODE_PAD / 2,
   );
 }
 
+/** Find connected components via union-find. */
+function findComponents(nodes, edges) {
+  const parent = {};
+  const find = (x) => (parent[x] === x ? x : (parent[x] = find(parent[x])));
+  const union = (a, b) => {
+    parent[find(a)] = find(b);
+  };
+
+  for (const n of nodes) parent[n.id] = n.id;
+  for (const e of edges) {
+    if (parent[e.from] !== undefined && parent[e.to] !== undefined) {
+      union(e.from, e.to);
+    }
+  }
+
+  const groups = new Map();
+  for (const n of nodes) {
+    const root = find(n.id);
+    if (!groups.has(root)) groups.set(root, []);
+    groups.get(root).push(n);
+  }
+  return [...groups.values()];
+}
+
+/** Layout a single connected component with dagre, returns positioned nodes. */
+function layoutComponent(compNodes, allEdges) {
+  const ids = new Set(compNodes.map((n) => n.id));
+  const compEdges = allEdges.filter((e) => ids.has(e.from) && ids.has(e.to));
+
+  if (compNodes.length === 1) {
+    const n = compNodes[0];
+    const hw = computeHW(n.label);
+    return {
+      nodes: [{ ...n, x: 0, y: 0, hw }],
+      edges: [],
+      w: hw * 2 + NODE_PAD,
+      h: NODE_H,
+    };
+  }
+
+  const g = new dagre.graphlib.Graph();
+  g.setGraph({
+    rankdir: "TB",
+    nodesep: GAP_X,
+    ranksep: GAP_Y,
+    marginx: 0,
+    marginy: 0,
+  });
+  g.setDefaultEdgeLabel(() => ({}));
+
+  for (const node of compNodes) {
+    const hw = computeHW(node.label);
+    g.setNode(node.id, { width: hw * 2 + NODE_PAD, height: NODE_H });
+  }
+  for (const e of compEdges) g.setEdge(e.from, e.to);
+
+  dagre.layout(g);
+
+  let minX = Infinity,
+    minY = Infinity,
+    maxX = -Infinity,
+    maxY = -Infinity;
+  const positioned = compNodes.map((n) => {
+    const pos = g.node(n.id);
+    const hw = computeHW(n.label);
+    const x = pos?.x ?? 0;
+    const y = pos?.y ?? 0;
+    minX = Math.min(minX, x - hw - NODE_PAD / 2);
+    maxX = Math.max(maxX, x + hw + NODE_PAD / 2);
+    minY = Math.min(minY, y - NODE_H / 2);
+    maxY = Math.max(maxY, y + NODE_H / 2);
+    return { ...n, x, y, hw };
+  });
+
+  // Normalize to origin
+  for (const n of positioned) {
+    n.x -= minX;
+    n.y -= minY;
+  }
+
+  return {
+    nodes: positioned,
+    edges: compEdges,
+    w: maxX - minX,
+    h: maxY - minY,
+  };
+}
+
 /**
  * Manages incremental graph layout.
- * Call addNode/addEdge as SSE events arrive, then call layout()
- * to get positioned nodes with smooth transitions.
  */
 export function createGraphState() {
   let nodes = [];
@@ -24,9 +122,11 @@ export function createGraphState() {
 
   function addNode(node) {
     if (nodeMap[node.note_id]) return false;
+    const fullTitle = node.title || node.note_id || "untitled";
     const entry = {
       id: node.note_id,
-      label: node.title,
+      label: truncateLabel(fullTitle),
+      fullTitle,
       type: node.type,
       tags: node.tags || [],
       snippet: node.snippet || "",
@@ -54,7 +154,6 @@ export function createGraphState() {
   function layout() {
     if (nodes.length === 0) return { nodes: [], edges: [], nodeMap };
 
-    // Save previous positions for lerping
     prevPositions = {};
     for (const n of nodes) {
       if (n.x !== undefined) {
@@ -62,61 +161,62 @@ export function createGraphState() {
       }
     }
 
-    const g = new dagre.graphlib.Graph();
-    g.setGraph({
-      rankdir: "TB",
-      nodesep: 50,
-      ranksep: 60,
-      marginx: 40,
-      marginy: 40,
-    });
-    g.setDefaultEdgeLabel(() => ({}));
+    // Split into connected components, layout each independently
+    const components = findComponents(nodes, edges);
+    const laid = components.map((comp) => layoutComponent(comp, edges));
 
-    for (const node of nodes) {
-      const hw = computeHW(node.label);
-      g.setNode(node.id, {
-        width: hw * 2 + NODE_PAD,
-        height: HH * 2 + 6,
-      });
-    }
+    // Sort: larger components first, then isolates
+    laid.sort((a, b) => b.nodes.length - a.nodes.length);
 
-    for (const edge of edges) {
-      if (g.hasNode(edge.from) && g.hasNode(edge.to)) {
-        g.setEdge(edge.from, edge.to);
+    // Pack components into rows with a max width
+    const MAX_ROW_W = Math.max(
+      600,
+      laid.reduce((s, c) => s + c.w, 0) / Math.ceil(Math.sqrt(laid.length)),
+    );
+
+    let cx = 0,
+      cy = 0,
+      rowH = 0;
+    for (const comp of laid) {
+      if (cx > 0 && cx + comp.w > MAX_ROW_W) {
+        // Wrap to next row
+        cx = 0;
+        cy += rowH + GAP_Y;
+        rowH = 0;
       }
+      // Offset all nodes in this component
+      for (const n of comp.nodes) {
+        n.x += cx;
+        n.y += cy;
+      }
+      cx += comp.w + GAP_X;
+      rowH = Math.max(rowH, comp.h);
     }
 
-    dagre.layout(g);
-
-    const positioned = nodes.map((n) => {
-      const pos = g.node(n.id);
-      if (!pos) return n;
-      const hw = computeHW(n.label);
-      const prev = prevPositions[n.id];
-      return {
-        ...n,
-        x: pos.x,
-        y: pos.y,
-        hw,
-        prevX: prev?.x,
-        prevY: prev?.y,
-        isNew: prev === undefined,
-      };
-    });
+    // Flatten and add metadata
+    const allPositioned = laid.flatMap((comp) =>
+      comp.nodes.map((n) => {
+        const prev = prevPositions[n.id];
+        return {
+          ...n,
+          prevX: prev?.x,
+          prevY: prev?.y,
+          isNew: prev === undefined,
+        };
+      }),
+    );
 
     // Update stored positions
-    for (const p of positioned) {
+    for (const p of allPositioned) {
       if (nodeMap[p.id]) {
         nodeMap[p.id].x = p.x;
         nodeMap[p.id].y = p.y;
       }
     }
 
-    return {
-      nodes: positioned,
-      edges: edges.filter((e) => g.hasNode(e.from) && g.hasNode(e.to)),
-      nodeMap,
-    };
+    const allEdges = laid.flatMap((c) => c.edges);
+
+    return { nodes: allPositioned, edges: allEdges, nodeMap };
   }
 
   function getNodeCount() {


### PR DESCRIPTION
## Summary
- **Side-by-side layout**: Chat panel (35% width) on the left, graph canvas filling the rest — replaces the previous vertical stack
- **Pencil→ink drawing animation**: New nodes draw in with a rough.js pencil sketch followed by a colored ink retrace, matching the SLO page's hand-drawn aesthetic
- **Incremental graph rendering**: SSE events are batch-absorbed then animated sequentially — nodes appear organically as the backend discovers them, with existing nodes smoothly sliding to make room
- **Brutalist styling**: Yellow header, vibrant type-colored borders with white fills, monospace typography, px-based sizing for consistent rendering across screen sizes
- **Improved content display**: Markdown rendering for chat responses, YAML frontmatter/LINKS stripping in note drawer, proper table/list/code block styling

## Test plan
- [ ] Navigate to `private.jomcgi.dev/chat` and verify side-by-side layout renders correctly
- [ ] Submit a query and verify nodes appear with pencil→ink animation
- [ ] Verify existing nodes slide smoothly when new nodes are added
- [ ] Click a node to open the drawer — verify frontmatter is stripped and tables/lists render correctly
- [ ] Verify type badge color matches the node border color
- [ ] Test on both laptop and 5K display for consistent sizing

🤖 Generated with [Claude Code](https://claude.com/claude-code)