### PR TITLE
ci(semgrep): add no-hardcoded-k8s-url-in-helm-env rule

### DIFF
--- a/bazel/semgrep/rules/yaml/no-hardcoded-k8s-url-in-helm-env.yaml
+++ b/bazel/semgrep/rules/yaml/no-hardcoded-k8s-url-in-helm-env.yaml
@@ -1,0 +1,27 @@
+rules:
+  - id: no-hardcoded-k8s-url-in-helm-env
+    languages: [yaml]
+    severity: WARNING
+    message: >-
+      Hardcoded Kubernetes in-cluster service URL in a Helm template env var
+      value. When a Helm release is renamed the service DNS prefix changes —
+      hardcoded .svc.cluster.local URLs silently break. Inject the URL via
+      values.yaml and reference it with {{ .Values.serviceUrl | quote }} so
+      operators can override it without touching the chart template.
+    metadata:
+      category: best-practices
+      subcategory: helm
+      confidence: HIGH
+      likelihood: HIGH
+      impact: HIGH
+      technology: [helm, kubernetes]
+    paths:
+      include:
+        - "**/chart/templates/**"
+    patterns:
+      - pattern: |
+          - name: $NAME
+            value: $URL
+      - metavariable-regex:
+          metavariable: $URL
+          regex: '.*\.svc\.cluster\.local.*'

--- a/bazel/semgrep/tests/fixtures/no-hardcoded-k8s-url-in-helm-env.yaml
+++ b/bazel/semgrep/tests/fixtures/no-hardcoded-k8s-url-in-helm-env.yaml
@@ -1,0 +1,40 @@
+# Tests for no-hardcoded-k8s-url-in-helm-env rule.
+# Helm template env vars must not hardcode .svc.cluster.local URLs — inject
+# via values.yaml so operators can override without editing the chart template.
+---
+# ruleid: no-hardcoded-k8s-url-in-helm-env
+- name: CLICKHOUSE_URL
+  value: http://chi-signoz-clickhouse.signoz.svc.cluster.local:8123
+
+---
+# ruleid: no-hardcoded-k8s-url-in-helm-env
+- name: OTEL_EXPORTER_OTLP_ENDPOINT
+  value: "http://signoz-otel-collector.signoz.svc.cluster.local:4317"
+
+---
+# ruleid: no-hardcoded-k8s-url-in-helm-env
+- name: DATABASE_URL
+  value: 'postgres://user:pass@my-db.default.svc.cluster.local:5432/mydb'
+
+---
+# ok: no-hardcoded-k8s-url-in-helm-env — URL injected from values via template
+- name: CLICKHOUSE_URL
+  value: "{{ .Values.clickhouse.url | quote }}"
+
+---
+# ok: no-hardcoded-k8s-url-in-helm-env — references a ConfigMap / env injection, no hardcoded URL
+- name: SERVICE_URL
+  valueFrom:
+    configMapKeyRef:
+      name: my-config
+      key: service-url
+
+---
+# ok: no-hardcoded-k8s-url-in-helm-env — external URL, not a cluster-local address
+- name: EXTERNAL_API
+  value: https://api.example.com/v1
+
+---
+# ok: no-hardcoded-k8s-url-in-helm-env — localhost is not a cluster-local service URL
+- name: METRICS_ADDR
+  value: http://localhost:9090


### PR DESCRIPTION
## Summary

- Adds `bazel/semgrep/rules/yaml/no-hardcoded-k8s-url-in-helm-env.yaml`: a YAML semgrep rule that catches hardcoded `.svc.cluster.local` URLs in Helm template `env[].value:` fields (paths scoped to `**/chart/templates/**`)
- Adds `bazel/semgrep/tests/fixtures/no-hardcoded-k8s-url-in-helm-env.yaml`: annotated test fixture with `# ruleid:` (3 bad cases) and `# ok:` (4 allowed cases) examples
- No BUILD changes needed — new rule and fixture are auto-discovered by existing `glob()` patterns in `yaml_rules` and `yaml_fixtures`

When a Helm release is renamed, the `<release-name>-` service DNS prefix changes silently, breaking any hardcoded `.svc.cluster.local` URLs. Service URLs should be injected via `values.yaml` and referenced with `{{ .Values.serviceUrl | quote }}`.

## Test plan

- [ ] `bazel/semgrep/rules:yaml_rules_test` passes (rule YAML is syntactically valid, test mode exits 0)
- [ ] `bazel test //...` passes with no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)