### PR TITLE
fix(monolith): parameterize OTEL endpoint via Helm values

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.44.0
+version: 0.44.1
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/templates/deployment.yaml
+++ b/projects/monolith/chart/templates/deployment.yaml
@@ -68,7 +68,7 @@ spec:
             - name: FRONTEND_HEALTH_URL
               value: "http://localhost:3000/"
             - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
-              value: "http://signoz-k8s-infra-otel-agent.signoz.svc.cluster.local:4318/v1/traces"
+              value: {{ .Values.backend.otelEndpoint | quote }}
             {{- if .Values.chat.enabled }}
             - name: DISCORD_BOT_TOKEN
               valueFrom:

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.44.0
+      targetRevision: 0.44.1
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/deploy/values.yaml
+++ b/projects/monolith/deploy/values.yaml
@@ -2,6 +2,7 @@ backend:
   replicas: 1
   vaultApiUrl: "http://obsidian-vault.obsidian.svc.cluster.local:8000"
   clickhouseUrl: "http://chi-signoz-clickhouse-cluster-0-0.signoz.svc.cluster.local:8123"
+  otelEndpoint: "http://signoz-k8s-infra-otel-agent.signoz.svc.cluster.local:4318/v1/traces"
   resources:
     requests:
       memory: "256Mi"


### PR DESCRIPTION
## Summary

- Replaces hardcoded OTEL traces endpoint in `deployment.yaml` with `{{ .Values.backend.otelEndpoint | quote }}`
- Adds `otelEndpoint` key under the `backend:` section in `deploy/values.yaml` with the original value
- Bumps chart version from `0.44.0` to `0.44.1` and updates `targetRevision` in `application.yaml` to match

## Test plan

- [ ] Verify Helm template renders the correct env var value: `helm template monolith projects/monolith/chart/ -f projects/monolith/deploy/values.yaml`
- [ ] Confirm ArgoCD syncs successfully after chart version update
- [ ] Check that OTEL traces continue to flow to SigNoz

🤖 Generated with [Claude Code](https://claude.com/claude-code)