### PR TITLE
test(bazel): add unit tests for python_deps image shim

### DIFF
--- a/bazel/tools/image/BUILD
+++ b/bazel/tools/image/BUILD
@@ -1,5 +1,6 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
-load("//bazel/semgrep/defs:defs.bzl", "semgrep_target_test")
+load("//bazel/semgrep/defs:defs.bzl", "semgrep_target_test", "semgrep_test")
+load("//bazel/tools/pytest:defs.bzl", "py_test")
 
 # gazelle:exclude python_deps.py
 
@@ -241,6 +242,25 @@ semgrep_target_test(
     rules = ["//bazel/semgrep/rules:python_rules"],
     sca_rules = ["//bazel/semgrep/rules:sca_python_rules"],
     target = ":python_deps",
+)
+
+# Unit tests verifying that the pip deps declared in python_deps.py are
+# importable and the key public APIs are constructible.
+py_test(
+    name = "python_deps_test",
+    srcs = ["python_deps_test.py"],
+    deps = [
+        "@pip//httpx",
+        "@pip//pytest",
+        "@pip//typer",
+    ],
+)
+
+semgrep_test(
+    name = "python_deps_test_semgrep_test",
+    srcs = ["python_deps_test.py"],
+    rules = ["//bazel/semgrep/rules:python_rules"],
+    tags = ["semgrep"],
 )
 
 bzl_library(

--- a/bazel/tools/image/BUILD
+++ b/bazel/tools/image/BUILD
@@ -251,7 +251,6 @@ py_test(
     srcs = ["python_deps_test.py"],
     deps = [
         "@pip//httpx",
-        "@pip//pytest",
         "@pip//typer",
     ],
 )

--- a/bazel/tools/image/BUILD
+++ b/bazel/tools/image/BUILD
@@ -251,6 +251,7 @@ py_test(
     srcs = ["python_deps_test.py"],
     deps = [
         "@pip//httpx",
+        "@pip//pytest",
         "@pip//typer",
     ],
 )

--- a/bazel/tools/image/python_deps_test.py
+++ b/bazel/tools/image/python_deps_test.py
@@ -11,16 +11,13 @@ declaration drifts out of sync with what is actually needed.
 
 import importlib
 
-
-def test_httpx_importable():
-    """httpx is needed by the homelab CLI (tools/cli/) at runtime."""
-    mod = importlib.import_module("httpx")
-    assert mod is not None
+import pytest
 
 
-def test_typer_importable():
-    """typer is needed by the homelab CLI (tools/cli/main.py) at runtime."""
-    mod = importlib.import_module("typer")
+@pytest.mark.parametrize("module_name", ["httpx", "typer"])
+def test_dep_importable(module_name: str):
+    """Verify that each pip dep declared in python_deps.py is importable at test time."""
+    mod = importlib.import_module(module_name)
     assert mod is not None
 
 

--- a/bazel/tools/image/python_deps_test.py
+++ b/bazel/tools/image/python_deps_test.py
@@ -1,0 +1,41 @@
+"""Tests for python_deps.py — the shim binary that packages pip deps into the tools image.
+
+python_deps.py has no functions of its own; it is a shim that imports the
+pip packages that must be present in the tools image (httpx, typer) so that
+py_image_layer can discover and package their transitive dependency trees.
+
+These tests verify that those imports are actually resolvable at test time,
+which catches cases where a package is removed from the dep list or the dep
+declaration drifts out of sync with what is actually needed.
+"""
+
+import importlib
+
+
+def test_httpx_importable():
+    """httpx is needed by the homelab CLI (tools/cli/) at runtime."""
+    mod = importlib.import_module("httpx")
+    assert mod is not None
+
+
+def test_typer_importable():
+    """typer is needed by the homelab CLI (tools/cli/main.py) at runtime."""
+    mod = importlib.import_module("typer")
+    assert mod is not None
+
+
+def test_httpx_client_constructible():
+    """Sanity-check that httpx.Client can be instantiated (not just imported)."""
+    import httpx
+
+    client = httpx.Client()
+    assert client is not None
+    client.close()
+
+
+def test_typer_app_constructible():
+    """Sanity-check that typer.Typer can be instantiated (not just imported)."""
+    import typer
+
+    app = typer.Typer()
+    assert app is not None


### PR DESCRIPTION
## Summary

- Add `bazel/tools/image/python_deps_test.py`: pytest-based tests verifying that the pip packages declared in the `python_deps` shim (`httpx`, `typer`) are importable and their core APIs are constructible at test time
- Update `bazel/tools/image/BUILD` to wire in `py_test` (`:python_deps_test`) and `semgrep_test` (`:python_deps_test_semgrep_test`) targets for the new test file

**Note on the two semgrep rule fixtures:** The gap report listed `no-hardcoded-k8s-service-url.py` and `no-stale-clickhouse-timeseries-table.py` as missing test fixtures. These files already exist in `origin/main` with correct `# ruleid:` and `# ok:` annotations, and are covered by the existing `python_rules_test` target via `glob(["python/*.py"])` in `bazel/semgrep/rules/BUILD`. No changes were needed for those.

## Test plan
- [ ] `bb remote test //bazel/tools/image:python_deps_test --config=ci` passes (httpx and typer are importable)
- [ ] `bb remote test //bazel/semgrep/rules:python_rules_test --config=ci` passes (no-hardcoded-k8s-service-url and no-stale-clickhouse-timeseries-table fixtures validate correctly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)