### PR TITLE
fix(monolith): add 10m timeout for chat and knowledge API routes

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.44.2
+version: 0.44.3
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/templates/httproute-private.yaml
+++ b/projects/monolith/chart/templates/httproute-private.yaml
@@ -25,9 +25,23 @@ spec:
         - path:
             type: PathPrefix
             value: /api/knowledge
+      timeouts:
+        request: 600s
+        backendRequest: 600s
       backendRefs:
         - name: {{ include "monolith.fullname" . }}
           port: {{ .Values.service.apiPort | int }}
+    # Chat interface — SvelteKit SSR calls LLM backend, needs long timeout
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /private/chat
+      timeouts:
+        request: 600s
+        backendRequest: 600s
+      backendRefs:
+        - name: {{ include "monolith.fullname" . }}
+          port: {{ .Values.cfIngress.private.servicePort | int }}
     # Everything else — SvelteKit reroute hook maps to /private/ internally
     - matches:
         - path:

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.44.2
+      targetRevision: 0.44.3
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
## Summary
- Chat interface POST to `/private/chat` was hitting Envoy's default 15s timeout, returning 504s
- Added `timeouts: {request: 600s, backendRequest: 600s}` to the `/api/knowledge` and a new `/private/chat` HTTPRoute rule
- Bumped chart version 0.44.2 → 0.44.3

## Test plan
- [ ] CI passes (helm template renders correctly — verified locally)
- [ ] After deploy, POST to `/private/chat` no longer returns 504 after 15s
- [ ] Long-running knowledge queries complete successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)