### PR TITLE
fix(monolith): parameterize frontend OTEL collector URL

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.44.3
+version: 0.44.4
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/templates/deployment.yaml
+++ b/projects/monolith/chart/templates/deployment.yaml
@@ -188,7 +188,7 @@ spec:
             - name: API_BASE
               value: "http://localhost:8000"
             - name: OTEL_COLLECTOR_HTTP_URL
-              value: "http://signoz-k8s-infra-otel-agent.signoz.svc.cluster.local:4318"
+              value: {{ .Values.frontend.otelCollectorUrl | quote }}
           livenessProbe:
             tcpSocket:
               port: http

--- a/projects/monolith/chart/values.yaml
+++ b/projects/monolith/chart/values.yaml
@@ -13,6 +13,7 @@ backend:
       memory: "256Mi"
 
 frontend:
+  otelCollectorUrl: ""
   image:
     repository: ghcr.io/jomcgi/homelab/projects/monolith/frontend
     tag: latest

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.44.3
+      targetRevision: 0.44.4
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/deploy/values.yaml
+++ b/projects/monolith/deploy/values.yaml
@@ -10,6 +10,9 @@ backend:
     limits:
       memory: "512Mi"
 
+frontend:
+  otelCollectorUrl: "http://signoz-k8s-infra-otel-agent.signoz.svc.cluster.local:4318"
+
 postgres:
   instances: 1
   storage:


### PR DESCRIPTION
## Summary

- Replaces hardcoded `.svc.cluster.local` URL for `OTEL_COLLECTOR_HTTP_URL` in the frontend container with a Helm value reference (`{{ .Values.frontend.otelCollectorUrl | quote }}`)
- Adds `frontend.otelCollectorUrl` to `chart/values.yaml` (default empty) and sets the cluster-specific value in `deploy/values.yaml`
- Follows the same pattern as `backend.otelEndpoint`
- Bumps chart version from 0.44.3 to 0.44.4 and updates `targetRevision` in `application.yaml` accordingly

## Test plan

- [ ] CI passes (Bazel test + helm template renders correctly)
- [ ] ArgoCD syncs with new chart version 0.44.4
- [ ] Frontend container has correct `OTEL_COLLECTOR_HTTP_URL` env var

🤖 Generated with [Claude Code](https://claude.com/claude-code)