### PR TITLE
docs(hikes): fix requests-cache description

### DIFF
--- a/projects/hikes/README.md
+++ b/projects/hikes/README.md
@@ -91,7 +91,7 @@ The frontend reads `public/config.js` (not environment variables):
 
 ## Architecture Notes
 
-- Uses `requests-cache` for HTTP caching during development
+- Uses `requests-cache` for HTTP caching (avoids re-scraping WalkHighlands.co.uk on repeated runs)
 - `scrape_walkhighlands` uses Pydantic models with SQLite persistence via `pydantic-sqlite`; `update_forecast` reads `walks.db` directly via the stdlib `sqlite3` module
 - Retry decorators for network resilience in the scraper
 - Performance logging for scrape operations


### PR DESCRIPTION
## Summary

- The README stated `requests-cache` was used "during development" — in reality it is always active when `scrape_walkhighlands` runs, using a `CachedSession` backed by SQLite to avoid re-scraping WalkHighlands.co.uk on every execution.

## Audit scope

All source files, BUILD files, `values.yaml`, `config.js`, `playwright.config.js`, `wrangler.jsonc`, and test files in `projects/hikes/` were reviewed. This was the only inaccuracy found; all other README claims match the code exactly.

## Test plan

- [ ] README renders correctly in GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)