### PR TITLE
docs(obsidian_vault): add missing gateway.secret.itemPath to values table

### DIFF
--- a/projects/obsidian_vault/README.md
+++ b/projects/obsidian_vault/README.md
@@ -120,6 +120,7 @@ A Helm post-install and post-upgrade hook will automatically register the server
 | `gateway.image.repository`           | `ghcr.io/ibm/mcp-context-forge`  | Gateway registration init container image repository  |
 | `gateway.image.tag`                  | `v1.0.0-RC1`                     | Gateway registration init container image tag         |
 | `gateway.secret.name`                | `context-forge-gateway`          | Secret name for gateway credentials                   |
+| `gateway.secret.itemPath`            | `""`                             | 1Password item path for gateway credentials           |
 | `secrets.obsidian.name`              | `obsidian`                       | 1Password item name for the Kubernetes secret         |
 | `secrets.obsidian.itemPath`          | `""`                             | 1Password item path for Obsidian/GitHub credentials   |
 


### PR DESCRIPTION
## Summary

- The "Full Values Reference" table was missing `gateway.secret.itemPath` — a required value when registering with a Context Forge gateway via the 1Password Operator. The key exists in `chart/values.yaml` and is referenced in the MCP Gateway Registration config example, but was absent from the table.

## Audit scope

All source files, BUILD files, Helm templates, `values.yaml`, `Chart.yaml`, and `main.py` in `projects/obsidian_vault/` were reviewed. This was the only gap found; all other README claims (MCP tool list, REST API spec, resource defaults, Chart version, config defaults, git sidecar script notes) match the code exactly.

## Test plan

- [ ] README renders correctly in GitHub
- [ ] `gateway.secret.itemPath` row appears between `gateway.secret.name` and `secrets.obsidian.name` in the table

🤖 Generated with [Claude Code](https://claude.com/claude-code)