### PR TITLE
ci(semgrep): add no-httproute-rule-without-timeout rule

### DIFF
--- a/bazel/semgrep/rules/yaml/no-httproute-rule-without-timeout.yaml
+++ b/bazel/semgrep/rules/yaml/no-httproute-rule-without-timeout.yaml
@@ -1,0 +1,40 @@
+rules:
+  - id: no-httproute-rule-without-timeout
+    languages: [yaml]
+    severity: WARNING
+    message: >-
+      HTTPRoute rule has `backendRefs` but no `timeouts` section. Envoy's
+      default 15s timeout silently drops long-running requests (streaming,
+      uploads, LLM inference, etc.). Add a `timeouts` block with an explicit
+      `request` value — or set `request: 0s` to disable the timeout — so the
+      behaviour is intentional and visible in Git.
+    metadata:
+      category: correctness
+      subcategory: helm
+      confidence: HIGH
+      likelihood: HIGH
+      impact: HIGH
+      technology: [helm, kubernetes, gateway-api]
+    paths:
+      include:
+        - "**/chart/templates/**"
+    patterns:
+      - pattern: |
+          rules:
+            - ...
+              backendRefs:
+                ...
+      - pattern-not: |
+          rules:
+            - ...
+              backendRefs:
+                ...
+              timeouts:
+                ...
+      - pattern-not: |
+          rules:
+            - ...
+              timeouts:
+                ...
+              backendRefs:
+                ...

--- a/bazel/semgrep/tests/fixtures/no-httproute-rule-without-timeout.yaml
+++ b/bazel/semgrep/tests/fixtures/no-httproute-rule-without-timeout.yaml
@@ -1,0 +1,91 @@
+# Tests for no-httproute-rule-without-timeout rule.
+# HTTPRoute rules with backendRefs must declare a timeouts section so that
+# Envoy's default 15-second timeout does not silently drop long-running
+# requests (streaming, uploads, LLM inference, etc.).
+---
+# ruleid: no-httproute-rule-without-timeout
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: my-service
+spec:
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: my-service
+          port: 8080
+
+---
+# ruleid: no-httproute-rule-without-timeout
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: api-route
+spec:
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /api
+      backendRefs:
+        - name: api-service
+          port: 80
+          weight: 100
+
+---
+# ok: no-httproute-rule-without-timeout — timeouts section present after backendRefs
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: my-service-with-timeout
+spec:
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: my-service
+          port: 8080
+      timeouts:
+        request: 30s
+
+---
+# ok: no-httproute-rule-without-timeout — timeout disabled explicitly (0s) for long-running streams
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: streaming-route
+spec:
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /stream
+      backendRefs:
+        - name: streaming-service
+          port: 8080
+      timeouts:
+        request: 0s
+
+---
+# ok: no-httproute-rule-without-timeout — timeouts section present before backendRefs
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: reverse-order-route
+spec:
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /reverse
+      timeouts:
+        request: 60s
+        backendRequest: 55s
+      backendRefs:
+        - name: reverse-service
+          port: 9090


### PR DESCRIPTION
## Summary

- Adds a new semgrep rule `no-httproute-rule-without-timeout` in `bazel/semgrep/rules/yaml/` that warns when an HTTPRoute rule has `backendRefs` but no `timeouts` section
- Envoy's default 15 s timeout silently drops long-running requests (streaming, LLM inference, file uploads) — this rule makes the gap visible at review time
- Scoped to `**/chart/templates/**` to avoid false positives on non-Helm YAML
- Includes test fixtures with failing cases (missing timeouts) and passing cases (explicit timeout value, `0s` disabled timeout, and timeouts declared before backendRefs)

## Test plan

- [ ] `bazel test //bazel/semgrep/rules:yaml_rules_test` passes with new rule and fixtures
- [ ] `bazel test //...` passes (full CI)
- [ ] Failing fixtures trigger `ruleid: no-httproute-rule-without-timeout` annotation
- [ ] Passing fixtures do not trigger the rule (`ok:` annotations pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)