### PR TITLE
test(cli): add tests for clear_cf_token, _request, and follow_redirects

### DIFF
--- a/tools/cli/auth_test.py
+++ b/tools/cli/auth_test.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 
 import pytest
 
-from tools.cli.auth import _read_token, get_cf_token
+from tools.cli.auth import _read_token, clear_cf_token, get_cf_token
 
 
 class TestGetCfToken:
@@ -178,3 +178,62 @@ class TestReadToken:
         with patch("tools.cli.auth.CF_TOKEN_DIR", tmp_path):
             result = _read_token("my.hostname.com")
         assert result is None
+
+
+class TestClearCfToken:
+    """Tests for clear_cf_token() — removes cached CF token files for a hostname."""
+
+    def test_deletes_matching_token_file(self, tmp_path):
+        """Matching token file is removed from CF_TOKEN_DIR."""
+        token_file = tmp_path / "private.jomcgi.dev-token"
+        token_file.write_text("stale-token")
+        with patch("tools.cli.auth.CF_TOKEN_DIR", tmp_path):
+            clear_cf_token()
+        assert not token_file.exists()
+
+    def test_deletes_multiple_matching_files(self, tmp_path):
+        """All files matching the hostname glob are deleted."""
+        file_a = tmp_path / "private.jomcgi.dev-old"
+        file_b = tmp_path / "private.jomcgi.dev-new"
+        file_a.write_text("old-token")
+        file_b.write_text("new-token")
+        with patch("tools.cli.auth.CF_TOKEN_DIR", tmp_path):
+            clear_cf_token()
+        assert not file_a.exists()
+        assert not file_b.exists()
+
+    def test_no_op_when_cf_token_dir_does_not_exist(self, tmp_path):
+        """Does not raise when CF_TOKEN_DIR doesn't exist."""
+        nonexistent = tmp_path / "no-such-dir"
+        with patch("tools.cli.auth.CF_TOKEN_DIR", nonexistent):
+            clear_cf_token()  # must not raise
+
+    def test_no_op_when_no_files_match_hostname(self, tmp_path):
+        """No files are deleted when none match the hostname."""
+        unrelated = tmp_path / "other.example.com-token"
+        unrelated.write_text("unrelated-token")
+        with patch("tools.cli.auth.CF_TOKEN_DIR", tmp_path):
+            clear_cf_token("private.jomcgi.dev")
+        assert unrelated.exists()
+
+    def test_does_not_delete_unrelated_files(self, tmp_path):
+        """Only files containing the hostname are deleted; others remain."""
+        match = tmp_path / "private.jomcgi.dev-token"
+        no_match = tmp_path / "other.example.com-token"
+        match.write_text("my-token")
+        no_match.write_text("other-token")
+        with patch("tools.cli.auth.CF_TOKEN_DIR", tmp_path):
+            clear_cf_token("private.jomcgi.dev")
+        assert not match.exists()
+        assert no_match.exists()
+
+    def test_custom_hostname_deletes_only_matching_files(self, tmp_path):
+        """Custom hostname targets only files containing that hostname."""
+        target = tmp_path / "custom.example.com-access"
+        other = tmp_path / "private.jomcgi.dev-token"
+        target.write_text("custom-token")
+        other.write_text("default-token")
+        with patch("tools.cli.auth.CF_TOKEN_DIR", tmp_path):
+            clear_cf_token("custom.example.com")
+        assert not target.exists()
+        assert other.exists()

--- a/tools/cli/knowledge_unit_test.py
+++ b/tools/cli/knowledge_unit_test.py
@@ -67,6 +67,15 @@ class TestClientHelper:
             finally:
                 client.close()
 
+    def test_follow_redirects_is_false(self):
+        """_client() disables automatic redirect following so 3xx responses are surfaced."""
+        with patch("tools.cli.knowledge_cmd.get_cf_token", return_value="test-token"):
+            client = knowledge_cmd._client()
+            try:
+                assert client.follow_redirects is False
+            finally:
+                client.close()
+
 
 # ---------------------------------------------------------------------------
 # Helpers: mock _client() as a context manager
@@ -198,3 +207,120 @@ class TestReplayNon404ErrorHandling:
         assert result.exit_code == 1
         assert "42" in result.output
         assert "not found" in result.output.lower()
+
+
+# ---------------------------------------------------------------------------
+# _request() wrapper
+#
+# _request() calls _client() as a context manager.  On a non-redirect response
+# it returns immediately.  On a 3xx (is_redirect=True) it calls clear_cf_token()
+# and retries with a fresh client.  All kwargs are forwarded to the underlying
+# httpx method.
+# ---------------------------------------------------------------------------
+
+
+def _make_single_response_client(is_redirect: bool = False) -> object:
+    """Return a _client factory whose HTTP methods return one fixed response."""
+    mock_resp = MagicMock()
+    mock_resp.is_redirect = is_redirect
+    mock_client = MagicMock()
+    mock_client.get.return_value = mock_resp
+    mock_client.post.return_value = mock_resp
+
+    @contextmanager
+    def _ctx():
+        yield mock_client
+
+    def _factory():
+        return _ctx()
+
+    return _factory, mock_client, mock_resp
+
+
+def _make_redirect_then_ok_client():
+    """Return a _client factory: first call returns 3xx, second returns 200."""
+    responses = [
+        MagicMock(is_redirect=True),
+        MagicMock(is_redirect=False),
+    ]
+    call_idx = [0]
+
+    def _factory():
+        resp = responses[call_idx[0]]
+        call_idx[0] = min(call_idx[0] + 1, len(responses) - 1)
+        mock_client = MagicMock()
+        mock_client.get.return_value = resp
+        mock_client.post.return_value = resp
+
+        @contextmanager
+        def _ctx():
+            yield mock_client
+
+        return _ctx()
+
+    return _factory, responses
+
+
+class TestRequest:
+    """Tests for _request() — the HTTP wrapper with auto re-auth on 3xx."""
+
+    def test_non_redirect_response_returned_as_is(self):
+        """A 2xx response is returned directly without calling clear_cf_token."""
+        factory, mock_client, mock_resp = _make_single_response_client(is_redirect=False)
+        with (
+            patch("tools.cli.knowledge_cmd._client", factory),
+            patch("tools.cli.knowledge_cmd.clear_cf_token") as mock_clear,
+        ):
+            result = knowledge_cmd._request("get", "/api/knowledge/search")
+
+        assert result is mock_resp
+        mock_clear.assert_not_called()
+
+    def test_redirect_triggers_clear_cf_token(self):
+        """A 3xx response causes clear_cf_token() to be called before retrying."""
+        factory, responses = _make_redirect_then_ok_client()
+        with (
+            patch("tools.cli.knowledge_cmd._client", factory),
+            patch("tools.cli.knowledge_cmd.clear_cf_token") as mock_clear,
+        ):
+            knowledge_cmd._request("get", "/api/knowledge/search")
+
+        mock_clear.assert_called_once()
+
+    def test_redirect_returns_retry_response(self):
+        """After a 3xx, the response from the retry request is returned."""
+        factory, responses = _make_redirect_then_ok_client()
+        with (
+            patch("tools.cli.knowledge_cmd._client", factory),
+            patch("tools.cli.knowledge_cmd.clear_cf_token"),
+        ):
+            result = knowledge_cmd._request("get", "/api/knowledge/search")
+
+        # The second (non-redirect) response should be returned
+        assert result is responses[1]
+
+    def test_kwargs_forwarded_to_client_method(self):
+        """Extra kwargs (e.g. params) are passed through to the underlying httpx method."""
+        factory, mock_client, mock_resp = _make_single_response_client(is_redirect=False)
+        params = {"q": "test query", "limit": 5}
+        with (
+            patch("tools.cli.knowledge_cmd._client", factory),
+            patch("tools.cli.knowledge_cmd.clear_cf_token"),
+        ):
+            knowledge_cmd._request("get", "/api/knowledge/search", params=params)
+
+        mock_client.get.assert_called_once_with("/api/knowledge/search", params=params)
+
+    def test_post_kwargs_forwarded_to_client_method(self):
+        """kwargs are forwarded correctly for POST requests too."""
+        factory, mock_client, mock_resp = _make_single_response_client(is_redirect=False)
+        json_body = {"key": "value"}
+        with (
+            patch("tools.cli.knowledge_cmd._client", factory),
+            patch("tools.cli.knowledge_cmd.clear_cf_token"),
+        ):
+            knowledge_cmd._request("post", "/api/knowledge/dead-letter/1/replay", json=json_body)
+
+        mock_client.post.assert_called_once_with(
+            "/api/knowledge/dead-letter/1/replay", json=json_body
+        )

--- a/tools/cli/knowledge_unit_test.py
+++ b/tools/cli/knowledge_unit_test.py
@@ -266,7 +266,9 @@ class TestRequest:
 
     def test_non_redirect_response_returned_as_is(self):
         """A 2xx response is returned directly without calling clear_cf_token."""
-        factory, mock_client, mock_resp = _make_single_response_client(is_redirect=False)
+        factory, mock_client, mock_resp = _make_single_response_client(
+            is_redirect=False
+        )
         with (
             patch("tools.cli.knowledge_cmd._client", factory),
             patch("tools.cli.knowledge_cmd.clear_cf_token") as mock_clear,
@@ -301,7 +303,9 @@ class TestRequest:
 
     def test_kwargs_forwarded_to_client_method(self):
         """Extra kwargs (e.g. params) are passed through to the underlying httpx method."""
-        factory, mock_client, mock_resp = _make_single_response_client(is_redirect=False)
+        factory, mock_client, mock_resp = _make_single_response_client(
+            is_redirect=False
+        )
         params = {"q": "test query", "limit": 5}
         with (
             patch("tools.cli.knowledge_cmd._client", factory),
@@ -313,13 +317,17 @@ class TestRequest:
 
     def test_post_kwargs_forwarded_to_client_method(self):
         """kwargs are forwarded correctly for POST requests too."""
-        factory, mock_client, mock_resp = _make_single_response_client(is_redirect=False)
+        factory, mock_client, mock_resp = _make_single_response_client(
+            is_redirect=False
+        )
         json_body = {"key": "value"}
         with (
             patch("tools.cli.knowledge_cmd._client", factory),
             patch("tools.cli.knowledge_cmd.clear_cf_token"),
         ):
-            knowledge_cmd._request("post", "/api/knowledge/dead-letter/1/replay", json=json_body)
+            knowledge_cmd._request(
+                "post", "/api/knowledge/dead-letter/1/replay", json=json_body
+            )
 
         mock_client.post.assert_called_once_with(
             "/api/knowledge/dead-letter/1/replay", json=json_body


### PR DESCRIPTION
## Summary

- **`auth_test.py`**: Added `TestClearCfToken` class with 6 tests covering `clear_cf_token()`: deletes matching files, deletes multiple matches, no-op when `CF_TOKEN_DIR` missing, no-op when no files match, leaves unrelated files intact, handles custom hostnames.
- **`knowledge_unit_test.py`**: Added `test_follow_redirects_is_false` to `TestClientHelper` asserting `_client()` sets `follow_redirects=False`.
- **`knowledge_unit_test.py`**: Added `TestRequest` class with 5 tests covering `_request()`: non-redirect response returned as-is, 3xx triggers `clear_cf_token()`, retry response returned after redirect, `params` kwargs forwarded for GET, `json` kwargs forwarded for POST.

## Test plan

- [x] `bb test //tools/cli:auth_test` — PASSED
- [x] `bb test //tools/cli:knowledge_unit_test` — PASSED
- [ ] CI runs `bazel test //...` on PR push

🤖 Generated with [Claude Code](https://claude.com/claude-code)