### PR TITLE
ci(semgrep): add httpx-cf-auth-must-disable-redirects rule

### DIFF
--- a/bazel/semgrep/rules/python/httpx-cf-auth-must-disable-redirects.py
+++ b/bazel/semgrep/rules/python/httpx-cf-auth-must-disable-redirects.py
@@ -1,0 +1,27 @@
+# Tests for httpx-cf-auth-must-disable-redirects rule.
+# When CF tokens expire, the server returns 302 to the login page;
+# httpx silently follows it, returning HTML instead of JSON.
+import httpx
+
+
+def bad_client_cf_auth_follows_redirects(url: str, token: str):
+    # ruleid: httpx-cf-auth-must-disable-redirects
+    client = httpx.Client(base_url=url, cookies={"CF_Authorization": token}, timeout=30.0)
+    return client
+
+
+def ok_client_cf_auth_no_redirects(url: str, token: str):
+    # ok: follow_redirects=False prevents silent redirect to CF login page
+    client = httpx.Client(
+        base_url=url,
+        cookies={"CF_Authorization": token},
+        follow_redirects=False,
+        timeout=30.0,
+    )
+    return client
+
+
+async def ok_async_client_cf_auth_no_redirects(token: str):
+    # ok: AsyncClient also safe when follow_redirects=False
+    client = httpx.AsyncClient(cookies={"CF_Authorization": token}, follow_redirects=False)
+    return client

--- a/bazel/semgrep/rules/python/httpx-cf-auth-must-disable-redirects.py
+++ b/bazel/semgrep/rules/python/httpx-cf-auth-must-disable-redirects.py
@@ -6,7 +6,9 @@ import httpx
 
 def bad_client_cf_auth_follows_redirects(url: str, token: str):
     # ruleid: httpx-cf-auth-must-disable-redirects
-    client = httpx.Client(base_url=url, cookies={"CF_Authorization": token}, timeout=30.0)
+    client = httpx.Client(
+        base_url=url, cookies={"CF_Authorization": token}, timeout=30.0
+    )
     return client
 
 
@@ -23,5 +25,7 @@ def ok_client_cf_auth_no_redirects(url: str, token: str):
 
 async def ok_async_client_cf_auth_no_redirects(token: str):
     # ok: AsyncClient also safe when follow_redirects=False
-    client = httpx.AsyncClient(cookies={"CF_Authorization": token}, follow_redirects=False)
+    client = httpx.AsyncClient(
+        cookies={"CF_Authorization": token}, follow_redirects=False
+    )
     return client

--- a/bazel/semgrep/rules/python/httpx-cf-auth-must-disable-redirects.yaml
+++ b/bazel/semgrep/rules/python/httpx-cf-auth-must-disable-redirects.yaml
@@ -1,0 +1,26 @@
+rules:
+  - id: httpx-cf-auth-must-disable-redirects
+    patterns:
+      - pattern-either:
+          - pattern: httpx.Client(..., cookies={..., "CF_Authorization": ..., ...}, ...)
+          - pattern: httpx.AsyncClient(..., cookies={..., "CF_Authorization": ..., ...}, ...)
+      - pattern-not: httpx.Client(..., follow_redirects=False, ...)
+      - pattern-not: httpx.AsyncClient(..., follow_redirects=False, ...)
+    message: >
+      `httpx.Client` or `httpx.AsyncClient` with a `CF_Authorization` cookie must
+      set `follow_redirects=False`. When a Cloudflare Access token expires the
+      server returns a 302 redirect to the login page; httpx silently follows it
+      and returns HTML instead of JSON, causing hard-to-debug parse failures.
+      Add `follow_redirects=False` to prevent this. See PR #2106.
+    languages: [python]
+    severity: ERROR
+    metadata:
+      category: correctness
+      subcategory: networking
+      confidence: HIGH
+      likelihood: HIGH
+      impact: HIGH
+      technology: [python, httpx, cloudflare]
+      description: >-
+        httpx client with CF_Authorization cookie must set follow_redirects=False —
+        expired tokens cause silent 302 redirects to the CF login page returning HTML.


### PR DESCRIPTION
## Summary

- Adds `bazel/semgrep/rules/python/httpx-cf-auth-must-disable-redirects.yaml` — a new semgrep rule that flags `httpx.Client(...)` or `httpx.AsyncClient(...)` created with a `CF_Authorization` cookie but without `follow_redirects=False`
- When CF Access tokens expire, Cloudflare returns a 302 to the login page; httpx silently follows it, returning HTML instead of JSON (see PR #2106 for the bug this prevents)
- Adds corresponding test fixture `httpx-cf-auth-must-disable-redirects.py` with one `ruleid` case and two `ok` cases

## Test plan

- [ ] `bb remote --os=linux --arch=amd64 test //bazel/semgrep/... --config=ci` passes
- [ ] `ruleid` case: `httpx.Client(cookies={"CF_Authorization": token})` without `follow_redirects=False` is flagged
- [ ] `ok` case: `httpx.Client(cookies={"CF_Authorization": token}, follow_redirects=False)` is not flagged
- [ ] `ok` case: `httpx.AsyncClient(cookies={"CF_Authorization": token}, follow_redirects=False)` is not flagged

🤖 Generated with [Claude Code](https://claude.com/claude-code)