### PR TITLE
fix(semgrep): extend httpx-client-no-timeout to cover sync Client

### DIFF
--- a/bazel/semgrep/rules/python/httpx-client-no-timeout.py
+++ b/bazel/semgrep/rules/python/httpx-client-no-timeout.py
@@ -30,3 +30,27 @@ async def ok_client_with_none_timeout():
     # ok: explicit None is an intentional choice (no timeout)
     async with httpx.AsyncClient(timeout=None) as client:
         return await client.get("https://internal-service")
+
+
+def bad_sync_client_no_timeout():
+    # ruleid: httpx-client-no-timeout
+    with httpx.Client() as client:
+        return client.get("https://example.com")
+
+
+def bad_sync_client_only_other_params():
+    # ruleid: httpx-client-no-timeout
+    with httpx.Client(headers={"X-Custom": "value"}) as client:
+        return client.get("https://example.com")
+
+
+def ok_sync_client_with_timeout():
+    # ok: timeout is specified
+    with httpx.Client(timeout=30.0) as client:
+        return client.get("https://example.com")
+
+
+def ok_sync_client_with_none_timeout():
+    # ok: explicit None is an intentional choice (no timeout)
+    with httpx.Client(timeout=None) as client:
+        return client.get("https://internal-service")

--- a/bazel/semgrep/rules/python/httpx-client-no-timeout.yaml
+++ b/bazel/semgrep/rules/python/httpx-client-no-timeout.yaml
@@ -18,3 +18,22 @@ rules:
       impact: HIGH
       technology: [python, httpx]
       description: httpx.AsyncClient missing timeout parameter — will hang forever
+  - id: httpx-client-no-timeout
+    patterns:
+      - pattern: httpx.Client(...)
+      - pattern-not: httpx.Client(..., timeout=..., ...)
+    message: >
+      `httpx.Client()` created without a `timeout=` parameter. Without an
+      explicit timeout the client will hang forever on unresponsive servers,
+      eventually exhausting connection pools.
+      Add `timeout=httpx.Timeout(30.0)` or a suitable value.
+    languages: [python]
+    severity: WARNING
+    metadata:
+      category: correctness
+      subcategory: networking
+      confidence: HIGH
+      likelihood: MEDIUM
+      impact: HIGH
+      technology: [python, httpx]
+      description: httpx.Client missing timeout parameter — will hang forever

--- a/bazel/semgrep/rules/python/httpx-client-no-timeout.yaml
+++ b/bazel/semgrep/rules/python/httpx-client-no-timeout.yaml
@@ -1,11 +1,14 @@
 rules:
   - id: httpx-client-no-timeout
     patterns:
-      - pattern: httpx.AsyncClient(...)
+      - pattern-either:
+          - pattern: httpx.AsyncClient(...)
+          - pattern: httpx.Client(...)
       - pattern-not: httpx.AsyncClient(..., timeout=..., ...)
+      - pattern-not: httpx.Client(..., timeout=..., ...)
     message: >
-      `httpx.AsyncClient()` created without a `timeout=` parameter. Without an
-      explicit timeout the client will hang forever on unresponsive servers,
+      `httpx.AsyncClient()` or `httpx.Client()` created without a `timeout=` parameter.
+      Without an explicit timeout the client will hang forever on unresponsive servers,
       blocking the event loop and eventually exhausting connection pools.
       Add `timeout=httpx.Timeout(30.0)` or a suitable value.
     languages: [python]
@@ -17,23 +20,4 @@ rules:
       likelihood: MEDIUM
       impact: HIGH
       technology: [python, httpx]
-      description: httpx.AsyncClient missing timeout parameter — will hang forever
-  - id: httpx-client-no-timeout
-    patterns:
-      - pattern: httpx.Client(...)
-      - pattern-not: httpx.Client(..., timeout=..., ...)
-    message: >
-      `httpx.Client()` created without a `timeout=` parameter. Without an
-      explicit timeout the client will hang forever on unresponsive servers,
-      eventually exhausting connection pools.
-      Add `timeout=httpx.Timeout(30.0)` or a suitable value.
-    languages: [python]
-    severity: WARNING
-    metadata:
-      category: correctness
-      subcategory: networking
-      confidence: HIGH
-      likelihood: MEDIUM
-      impact: HIGH
-      technology: [python, httpx]
-      description: httpx.Client missing timeout parameter — will hang forever
+      description: httpx.AsyncClient or httpx.Client missing timeout parameter — will hang forever

--- a/bazel/tools/image/python_deps_test.py
+++ b/bazel/tools/image/python_deps_test.py
@@ -25,7 +25,7 @@ def test_httpx_client_constructible():
     """Sanity-check that httpx.Client can be instantiated (not just imported)."""
     import httpx
 
-    client = httpx.Client()
+    client = httpx.Client(timeout=5.0)
     assert client is not None
     client.close()
 


### PR DESCRIPTION
## Summary

- Extends `bazel/semgrep/rules/python/httpx-client-no-timeout.yaml` to also flag `httpx.Client(...)` (sync) without a `timeout=` parameter — previously only `httpx.AsyncClient(...)` was caught
- Adds sync-client test fixture cases to `httpx-client-no-timeout.py`

## Test plan

- [ ] `bb remote --os=linux --arch=amd64 test //bazel/semgrep/... --config=ci` passes
- [ ] `ruleid` case: `httpx.Client()` without `timeout=` is flagged
- [ ] `ruleid` case: `httpx.Client(headers=...)` without `timeout=` is flagged
- [ ] `ok` case: `httpx.Client(timeout=30.0)` is not flagged
- [ ] `ok` case: `httpx.Client(timeout=None)` is not flagged (intentional choice)
- [ ] Existing `httpx.AsyncClient` cases still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)