### PR TITLE
feat(monolith): add roast changelog for ColinCee/homelab

### DIFF
--- a/docs/plans/2026-04-16-roast-changelog-design.md
+++ b/docs/plans/2026-04-16-roast-changelog-design.md
@@ -1,0 +1,156 @@
+# Roast Changelog for ColinCee/homelab
+
+**Date**: 2026-04-16
+**Status**: Proposed
+
+## Problem
+
+We have hourly changelog summaries for jomcgi/homelab that post to Discord. We want the same for a friend's public repo (ColinCee/homelab) — but with a roasting tone, posted every 3 hours to the same channel.
+
+## Approach
+
+Generalize `run_changelog_iteration()` to accept a config object instead of reading env vars. Register two scheduled jobs with different configs.
+
+## Design
+
+### ChangelogConfig dataclass
+
+New frozen dataclass in `changelog.py`:
+
+```python
+@dataclasses.dataclass(frozen=True)
+class ChangelogConfig:
+    github_repo: str
+    channel_id: str
+    system_prompt: str
+    embed_title: str
+    embed_color: int
+    lookback_hours: int = 1
+    commit_filter: re.Pattern | None = None  # None = all commits
+```
+
+### Two configs
+
+**Existing changelog** (unchanged behavior):
+
+- `github_repo`: from `CHANGELOG_GITHUB_REPO` env var
+- `channel_id`: from `CHANGELOG_CHANNEL_ID` env var
+- `system_prompt`: existing professional changelog prompt
+- `embed_title`: "Homelab Changelog"
+- `embed_color`: `0x2ECC71` (green)
+- `lookback_hours`: 1
+- `commit_filter`: `re.compile(r"^(feat)(\(.+?\))?!?:\s")` (feat only)
+
+**Roast changelog** (new):
+
+- `github_repo`: from `ROAST_CHANGELOG_GITHUB_REPO` env var
+- `channel_id`: from `ROAST_CHANGELOG_CHANNEL_ID` env var
+- `system_prompt`: roast prompt (see below)
+- `embed_title`: "Colin's Homelab Roast"
+- `embed_color`: `0xE74C3C` (red)
+- `lookback_hours`: 3
+- `commit_filter`: `None` (all commits)
+
+### Roast prompt
+
+```
+You are Colin's close friend and a cynical senior engineer who has seen
+too many homelabs. You're reviewing his recent git commits to roast him
+in the group chat. He can take it — don't soften anything.
+
+Below are his recent commits:
+<commits>
+{{COMMITS}}
+</commits>
+
+Write a changelog-style roast. Format:
+
+Colin homelab changelog:
+- <entry>
+- <entry>
+- <entry>
+
+3-5 entries. Each one is a single line written as if it's a real
+changelog bullet, but the content is the roast. Examples of the shape:
+- "Added three ADRs to justify turning a Beelink on."
+- "Replaced working Grafana dashboard with a worse one. Wrote a runbook about it."
+- "Four commits to fix one typo. Copilot did the last three."
+
+Target specific things in the commits — pretentious messages, features
+added then ripped out, yak-shaving, ADRs for three lines of YAML,
+Copilot cleaning up after him, enterprise patterns on a mini-PC,
+README brags that are one commit old, bike-shedding. Name the thing.
+
+Rules:
+- Past tense, declarative, changelog voice. No "Colin did X" — the
+  entries are the changes themselves, deadpan.
+- Punch at choices, not at him. "Docker Swarm in 2026" is fair.
+  Personal attacks are lazy.
+- Dry > loud. A good callback to an earlier entry beats exclamation marks.
+- No hedging, no "but seriously", no constructive feedback.
+- No markdown headers, no emoji, no preamble or outro. Just the header
+  line and bullets.
+- If a commit is genuinely boring, skip it. Don't manufacture heat.
+Optionally end with one entry in square brackets, e.g. [No breaking changes. Nothing worked in the first place.]
+```
+
+### Refactored function signature
+
+`run_changelog_iteration()` changes to:
+
+```python
+async def run_changelog_iteration(
+    bot: discord.Client,
+    llm_call: Callable[[str], Awaitable[str]],
+    config: ChangelogConfig,
+    store_message: Callable[..., Awaitable[None]] | None = None,
+) -> None:
+```
+
+- Uses `config.lookback_hours` for the `timedelta`
+- Applies `config.commit_filter` if set, otherwise passes all commits
+- Passes `config.system_prompt` to `_summarize_with_gemma` (which loses its hardcoded prompt)
+- Uses `config.embed_title` and `config.embed_color` in `_build_embed`
+
+### Scheduled jobs
+
+**Existing** (`chat.changelog`): 3600s interval, aligned to hour boundaries. Unchanged.
+
+**New** (`chat.changelog_roast`): 10800s interval, aligned to 3-hour boundaries (0:00, 3:00, 6:00, etc.).
+
+Both registered in `summarizer.py` with the same `store_message` pattern.
+
+### Helm values
+
+```yaml
+chat:
+  changelog:
+    enabled: true
+    channelId: "1491186550472708117"
+    githubRepo: "jomcgi/homelab"
+  roastChangelog:
+    enabled: true
+    channelId: "1491186550472708117"
+    githubRepo: "ColinCee/homelab"
+```
+
+### Deployment template additions
+
+New env vars under `chat.roastChangelog.enabled`:
+
+- `ROAST_CHANGELOG_CHANNEL_ID` from `chat.roastChangelog.channelId`
+- `ROAST_CHANGELOG_GITHUB_REPO` from `chat.roastChangelog.githubRepo`
+
+Reuses existing `GITHUB_TOKEN` (public repo, token just avoids rate limits).
+
+### Silent when empty
+
+Same as existing — if no commits in the lookback window, no message posted.
+
+## Files changed
+
+1. `projects/monolith/chat/changelog.py` — add `ChangelogConfig`, refactor functions to use it
+2. `projects/monolith/chat/summarizer.py` — register second scheduled job
+3. `projects/monolith/chart/templates/deployment.yaml` — add roast env vars
+4. `projects/monolith/deploy/values.yaml` — add `roastChangelog` config
+5. `projects/monolith/chat/changelog_test.py` — update tests for new signature, add roast config tests

--- a/docs/plans/2026-04-16-roast-changelog-design.md
+++ b/docs/plans/2026-04-16-roast-changelog-design.md
@@ -1,7 +1,7 @@
 # Roast Changelog for ColinCee/homelab
 
 **Date**: 2026-04-16
-**Status**: Proposed
+**Status**: Approved
 
 ## Problem
 
@@ -9,7 +9,7 @@ We have hourly changelog summaries for jomcgi/homelab that post to Discord. We w
 
 ## Approach
 
-Generalize `run_changelog_iteration()` to accept a config object instead of reading env vars. Register two scheduled jobs with different configs.
+Generalize `run_changelog_iteration()` to accept a config object instead of reading env vars. Use a list-based config in Helm values with a single `CHANGELOG_CONFIGS` JSON env var. Prompts are referenced by key and defined in Python code.
 
 ## Design
 
@@ -20,36 +20,83 @@ New frozen dataclass in `changelog.py`:
 ```python
 @dataclasses.dataclass(frozen=True)
 class ChangelogConfig:
+    name: str
     github_repo: str
     channel_id: str
-    system_prompt: str
+    prompt: str              # key into PROMPTS dict
     embed_title: str
     embed_color: int
-    lookback_hours: int = 1
+    interval_hours: int = 1
     commit_filter: re.Pattern | None = None  # None = all commits
 ```
 
-### Two configs
+### Prompt registry
 
-**Existing changelog** (unchanged behavior):
+Prompts live in Python code, referenced by key from config:
 
-- `github_repo`: from `CHANGELOG_GITHUB_REPO` env var
-- `channel_id`: from `CHANGELOG_CHANNEL_ID` env var
-- `system_prompt`: existing professional changelog prompt
-- `embed_title`: "Homelab Changelog"
-- `embed_color`: `0x2ECC71` (green)
-- `lookback_hours`: 1
-- `commit_filter`: `re.compile(r"^(feat)(\(.+?\))?!?:\s")` (feat only)
+```python
+PROMPTS: dict[str, str] = {
+    "professional": "You are a changelog writer for a Kubernetes homelab project...",
+    "roast": "You are Colin's close friend and a cynical senior engineer...",
+}
+```
 
-**Roast changelog** (new):
+The prompt template uses `{commits}` as a placeholder for the formatted commit list.
 
-- `github_repo`: from `ROAST_CHANGELOG_GITHUB_REPO` env var
-- `channel_id`: from `ROAST_CHANGELOG_CHANNEL_ID` env var
-- `system_prompt`: roast prompt (see below)
-- `embed_title`: "Colin's Homelab Roast"
-- `embed_color`: `0xE74C3C` (red)
-- `lookback_hours`: 3
-- `commit_filter`: `None` (all commits)
+### Refactored functions
+
+`_summarize_with_gemma` takes the prompt template from `PROMPTS[config.prompt]` instead of hardcoding it.
+
+`_build_embed` takes `title` and `color` parameters instead of hardcoding them.
+
+`run_changelog_iteration` takes a `ChangelogConfig` instead of reading env vars. Uses `config.interval_hours` for lookback, applies `config.commit_filter` if set.
+
+### Config loading
+
+`load_changelog_configs()` parses `CHANGELOG_CONFIGS` env var (JSON list) into `list[ChangelogConfig]`. Each entry maps to the dataclass fields. The `commitFilter` field in JSON is optional — when present, it's compiled to a regex pattern.
+
+### Scheduled jobs
+
+One job registered per config entry in `summarizer.py`:
+
+- Job name: `f"chat.changelog.{config.name}"` (e.g. `chat.changelog.homelab`, `chat.changelog.roast`)
+- Interval: `config.interval_hours * 3600`
+- Aligned to interval boundaries
+
+### Helm values
+
+```yaml
+chat:
+  changelogs:
+    - name: "homelab"
+      channelId: "1491186550472708117"
+      githubRepo: "jomcgi/homelab"
+      prompt: "professional"
+      embedTitle: "Homelab Changelog"
+      embedColor: "0x2ECC71"
+      intervalHours: 1
+      commitFilter: "^(feat)(\\(.+?\\))?!?:\\s"
+    - name: "roast"
+      channelId: "1491186550472708117"
+      githubRepo: "ColinCee/homelab"
+      prompt: "roast"
+      embedTitle: "Colin's Homelab Roast"
+      embedColor: "0xE74C3C"
+      intervalHours: 3
+```
+
+### Deployment template
+
+Replaces `CHANGELOG_CHANNEL_ID` + `CHANGELOG_GITHUB_REPO` with a single JSON env var:
+
+```yaml
+{{- if .Values.chat.changelogs }}
+- name: CHANGELOG_CONFIGS
+  value: {{ .Values.chat.changelogs | toJson | quote }}
+{{- end }}
+```
+
+`GITHUB_TOKEN` stays as-is — shared across all changelog configs.
 
 ### Roast prompt
 
@@ -60,7 +107,7 @@ in the group chat. He can take it — don't soften anything.
 
 Below are his recent commits:
 <commits>
-{{COMMITS}}
+{commits}
 </commits>
 
 Write a changelog-style roast. Format:
@@ -94,63 +141,14 @@ Rules:
 Optionally end with one entry in square brackets, e.g. [No breaking changes. Nothing worked in the first place.]
 ```
 
-### Refactored function signature
-
-`run_changelog_iteration()` changes to:
-
-```python
-async def run_changelog_iteration(
-    bot: discord.Client,
-    llm_call: Callable[[str], Awaitable[str]],
-    config: ChangelogConfig,
-    store_message: Callable[..., Awaitable[None]] | None = None,
-) -> None:
-```
-
-- Uses `config.lookback_hours` for the `timedelta`
-- Applies `config.commit_filter` if set, otherwise passes all commits
-- Passes `config.system_prompt` to `_summarize_with_gemma` (which loses its hardcoded prompt)
-- Uses `config.embed_title` and `config.embed_color` in `_build_embed`
-
-### Scheduled jobs
-
-**Existing** (`chat.changelog`): 3600s interval, aligned to hour boundaries. Unchanged.
-
-**New** (`chat.changelog_roast`): 10800s interval, aligned to 3-hour boundaries (0:00, 3:00, 6:00, etc.).
-
-Both registered in `summarizer.py` with the same `store_message` pattern.
-
-### Helm values
-
-```yaml
-chat:
-  changelog:
-    enabled: true
-    channelId: "1491186550472708117"
-    githubRepo: "jomcgi/homelab"
-  roastChangelog:
-    enabled: true
-    channelId: "1491186550472708117"
-    githubRepo: "ColinCee/homelab"
-```
-
-### Deployment template additions
-
-New env vars under `chat.roastChangelog.enabled`:
-
-- `ROAST_CHANGELOG_CHANNEL_ID` from `chat.roastChangelog.channelId`
-- `ROAST_CHANGELOG_GITHUB_REPO` from `chat.roastChangelog.githubRepo`
-
-Reuses existing `GITHUB_TOKEN` (public repo, token just avoids rate limits).
-
 ### Silent when empty
 
 Same as existing — if no commits in the lookback window, no message posted.
 
 ## Files changed
 
-1. `projects/monolith/chat/changelog.py` — add `ChangelogConfig`, refactor functions to use it
-2. `projects/monolith/chat/summarizer.py` — register second scheduled job
-3. `projects/monolith/chart/templates/deployment.yaml` — add roast env vars
-4. `projects/monolith/deploy/values.yaml` — add `roastChangelog` config
-5. `projects/monolith/chat/changelog_test.py` — update tests for new signature, add roast config tests
+1. `projects/monolith/chat/changelog.py` — add `ChangelogConfig`, `PROMPTS`, `load_changelog_configs()`, refactor functions to use config
+2. `projects/monolith/chat/summarizer.py` — loop over configs, register one job per entry
+3. `projects/monolith/chart/templates/deployment.yaml` — replace old env vars with `CHANGELOG_CONFIGS`
+4. `projects/monolith/deploy/values.yaml` — replace `changelog` block with `changelogs` list
+5. `projects/monolith/chat/changelog_test.py` — update tests for new signature, add config loading tests

--- a/docs/plans/2026-04-17-roast-changelog-plan.md
+++ b/docs/plans/2026-04-17-roast-changelog-plan.md
@@ -1,0 +1,620 @@
+# Roast Changelog Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Generalize the changelog system to support multiple repos with different prompts, then add a roast changelog for ColinCee/homelab.
+
+**Architecture:** Refactor `changelog.py` to be config-driven via a `ChangelogConfig` dataclass. Helm values defines a list of changelog entries, serialized as a single `CHANGELOG_CONFIGS` JSON env var. Prompts are registered by key in Python code. One scheduled job per config entry.
+
+**Tech Stack:** Python, discord.py, httpx, Helm, pytest
+
+---
+
+### Task 1: Add ChangelogConfig dataclass and PROMPTS registry
+
+**Files:**
+
+- Modify: `projects/monolith/chat/changelog.py:1-16`
+- Test: `projects/monolith/chat/changelog_test.py`
+
+**Step 1: Write failing tests for config loading**
+
+Add to `changelog_test.py`:
+
+```python
+import json
+from chat.changelog import ChangelogConfig, PROMPTS, load_changelog_configs
+
+
+class TestChangelogConfig:
+    def test_load_configs_from_json(self):
+        """JSON list is parsed into ChangelogConfig objects."""
+        raw = json.dumps([{
+            "name": "test",
+            "channelId": "123",
+            "githubRepo": "owner/repo",
+            "prompt": "professional",
+            "embedTitle": "Test",
+            "embedColor": "0x2ECC71",
+            "intervalHours": 1,
+        }])
+        configs = load_changelog_configs(raw)
+        assert len(configs) == 1
+        assert configs[0].name == "test"
+        assert configs[0].github_repo == "owner/repo"
+        assert configs[0].channel_id == "123"
+        assert configs[0].embed_color == 0x2ECC71
+        assert configs[0].interval_hours == 1
+        assert configs[0].commit_filter is None
+
+    def test_load_configs_with_commit_filter(self):
+        """commitFilter string is compiled to a regex pattern."""
+        raw = json.dumps([{
+            "name": "filtered",
+            "channelId": "123",
+            "githubRepo": "owner/repo",
+            "prompt": "professional",
+            "embedTitle": "Test",
+            "embedColor": "0x2ECC71",
+            "intervalHours": 1,
+            "commitFilter": "^(feat)(\\(.+?\\))?!?:\\s",
+        }])
+        configs = load_changelog_configs(raw)
+        assert configs[0].commit_filter is not None
+        assert configs[0].commit_filter.match("feat: something")
+        assert not configs[0].commit_filter.match("fix: something")
+
+    def test_load_configs_empty_json(self):
+        """Empty JSON list returns empty config list."""
+        assert load_changelog_configs("[]") == []
+
+    def test_load_configs_empty_string(self):
+        """Empty string returns empty config list."""
+        assert load_changelog_configs("") == []
+
+    def test_prompts_registry_has_professional(self):
+        """PROMPTS dict contains 'professional' key."""
+        assert "professional" in PROMPTS
+
+    def test_prompts_registry_has_roast(self):
+        """PROMPTS dict contains 'roast' key."""
+        assert "roast" in PROMPTS
+
+    def test_prompts_contain_commits_placeholder(self):
+        """All prompts contain {commits} placeholder."""
+        for key, prompt in PROMPTS.items():
+            assert "{commits}" in prompt, f"Prompt '{key}' missing {{commits}} placeholder"
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `bb remote test //projects/monolith:changelog_test --config=ci`
+Expected: FAIL — `ChangelogConfig`, `PROMPTS`, `load_changelog_configs` don't exist yet.
+
+**Step 3: Implement ChangelogConfig, PROMPTS, and load_changelog_configs**
+
+In `changelog.py`, add after the imports:
+
+```python
+import dataclasses
+import json
+
+@dataclasses.dataclass(frozen=True)
+class ChangelogConfig:
+    name: str
+    github_repo: str
+    channel_id: str
+    prompt: str
+    embed_title: str
+    embed_color: int
+    interval_hours: int = 1
+    commit_filter: re.Pattern | None = None
+
+
+PROMPTS: dict[str, str] = {
+    "professional": (
+        "You are a changelog writer for a Kubernetes homelab project.\n"
+        "Below are recent git commits (new features only).\n"
+        "Write a concise changelog summarizing what changed. "
+        "For each item, explain what it does in "
+        "one clear sentence — don't just repeat the commit message. "
+        "Use plain language. No markdown headers, just plain text with bullet points.\n\n"
+        "Commits:\n{commits}"
+    ),
+    "roast": (
+        "You are Colin's close friend and a cynical senior engineer who has seen\n"
+        "too many homelabs. You're reviewing his recent git commits to roast him\n"
+        "in the group chat. He can take it — don't soften anything.\n\n"
+        "Below are his recent commits:\n"
+        "<commits>\n{commits}\n</commits>\n\n"
+        "Write a changelog-style roast. Format:\n\n"
+        "Colin homelab changelog:\n"
+        "- <entry>\n- <entry>\n- <entry>\n\n"
+        "3-5 entries. Each one is a single line written as if it's a real\n"
+        "changelog bullet, but the content is the roast. Examples of the shape:\n"
+        '- "Added three ADRs to justify turning a Beelink on."\n'
+        '- "Replaced working Grafana dashboard with a worse one. Wrote a runbook about it."\n'
+        '- "Four commits to fix one typo. Copilot did the last three."\n\n'
+        "Target specific things in the commits — pretentious messages, features\n"
+        "added then ripped out, yak-shaving, ADRs for three lines of YAML,\n"
+        "Copilot cleaning up after him, enterprise patterns on a mini-PC,\n"
+        "README brags that are one commit old, bike-shedding. Name the thing.\n\n"
+        "Rules:\n"
+        '- Past tense, declarative, changelog voice. No "Colin did X" — the\n'
+        "  entries are the changes themselves, deadpan.\n"
+        '- Punch at choices, not at him. "Docker Swarm in 2026" is fair.\n'
+        "  Personal attacks are lazy.\n"
+        "- Dry > loud. A good callback to an earlier entry beats exclamation marks.\n"
+        '- No hedging, no "but seriously", no constructive feedback.\n'
+        "- No markdown headers, no emoji, no preamble or outro. Just the header\n"
+        "  line and bullets.\n"
+        "- If a commit is genuinely boring, skip it. Don't manufacture heat.\n"
+        "Optionally end with one entry in square brackets, e.g. "
+        "[No breaking changes. Nothing worked in the first place.]"
+    ),
+}
+
+
+def load_changelog_configs(raw: str) -> list[ChangelogConfig]:
+    """Parse a JSON string into a list of ChangelogConfig objects."""
+    if not raw:
+        return []
+    entries = json.loads(raw)
+    configs = []
+    for entry in entries:
+        commit_filter = None
+        if "commitFilter" in entry:
+            commit_filter = re.compile(entry["commitFilter"])
+        configs.append(ChangelogConfig(
+            name=entry["name"],
+            github_repo=entry["githubRepo"],
+            channel_id=entry["channelId"],
+            prompt=entry["prompt"],
+            embed_title=entry["embedTitle"],
+            embed_color=int(entry["embedColor"], 16) if isinstance(entry["embedColor"], str) else entry["embedColor"],
+            interval_hours=entry.get("intervalHours", 1),
+            commit_filter=commit_filter,
+        ))
+    return configs
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `bb remote test //projects/monolith:changelog_test --config=ci`
+Expected: New tests PASS, existing tests still PASS.
+
+**Step 5: Commit**
+
+```bash
+git add projects/monolith/chat/changelog.py projects/monolith/chat/changelog_test.py
+git commit -m "feat(monolith): add ChangelogConfig dataclass and prompt registry"
+```
+
+---
+
+### Task 2: Refactor \_summarize_with_gemma and \_build_embed to accept config
+
+**Files:**
+
+- Modify: `projects/monolith/chat/changelog.py:51-84`
+- Test: `projects/monolith/chat/changelog_test.py`
+
+**Step 1: Update existing tests to pass config parameters**
+
+Update `TestSummarizeWithGemma` — `_summarize_with_gemma` now takes a `prompt_template` string parameter instead of hardcoding the prompt. Update calls:
+
+```python
+class TestSummarizeWithGemma:
+    @pytest.mark.asyncio
+    async def test_prompt_includes_commit_messages(self):
+        commits = [_make_commit("feat: add search", "Bob")]
+        mock_llm = AsyncMock(return_value="Added search functionality.")
+        await _summarize_with_gemma(commits, mock_llm, PROMPTS["professional"])
+        call_args = mock_llm.call_args[0][0]
+        assert "feat: add search" in call_args
+```
+
+(Same pattern for all tests in this class — add `PROMPTS["professional"]` as third arg.)
+
+Update `TestBuildEmbed` — `_build_embed` now takes `title` and `color` parameters:
+
+```python
+class TestBuildEmbed:
+    def test_embed_title(self):
+        embed = _build_embed("Some summary", commit_count=3, title="Homelab Changelog", color=0x2ECC71)
+        assert embed.title == "Homelab Changelog"
+
+    def test_embed_color(self):
+        embed = _build_embed("Some summary", commit_count=3, title="Homelab Changelog", color=0x2ECC71)
+        assert embed.colour.value == 0x2ECC71
+
+    def test_custom_title_and_color(self):
+        embed = _build_embed("Roast", commit_count=1, title="Colin's Homelab Roast", color=0xE74C3C)
+        assert embed.title == "Colin's Homelab Roast"
+        assert embed.colour.value == 0xE74C3C
+```
+
+(Update all other `_build_embed` calls to include `title` and `color` kwargs.)
+
+**Step 2: Run tests to verify they fail**
+
+Run: `bb remote test //projects/monolith:changelog_test --config=ci`
+Expected: FAIL — function signatures don't match yet.
+
+**Step 3: Update function signatures**
+
+In `changelog.py`:
+
+```python
+async def _summarize_with_gemma(
+    commits: list[dict],
+    llm_call: Callable[[str], Awaitable[str]],
+    prompt_template: str,
+) -> str:
+    """Ask Gemma to produce a concise changelog from commit data."""
+    commit_descriptions = []
+    for c in commits:
+        msg = c["commit"]["message"].split("\n", 1)[0]
+        author = c["commit"]["author"]["name"]
+        commit_descriptions.append(f"- {msg} (by {author})")
+
+    commits_text = "\n".join(commit_descriptions)
+    prompt = prompt_template.format(commits=commits_text)
+    return await llm_call(prompt)
+
+
+def _build_embed(summary: str, commit_count: int, title: str, color: int) -> discord.Embed:
+    """Build a Discord embed for the changelog notification."""
+    embed = discord.Embed(
+        title=title,
+        description=summary,
+        color=color,
+        timestamp=datetime.now(timezone.utc),
+    )
+    embed.set_footer(text=f"{commit_count} commit(s)")
+    return embed
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `bb remote test //projects/monolith:changelog_test --config=ci`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add projects/monolith/chat/changelog.py projects/monolith/chat/changelog_test.py
+git commit -m "refactor(monolith): parameterize _summarize_with_gemma and _build_embed"
+```
+
+---
+
+### Task 3: Refactor run_changelog_iteration to accept ChangelogConfig
+
+**Files:**
+
+- Modify: `projects/monolith/chat/changelog.py:87-145`
+- Test: `projects/monolith/chat/changelog_test.py`
+
+**Step 1: Update TestRunChangelogIteration tests**
+
+All tests in `TestRunChangelogIteration` need to:
+
+1. Pass a `ChangelogConfig` instead of relying on env vars
+2. Remove `patch.dict("os.environ", ...)` for changelog-specific vars (keep `GITHUB_TOKEN` as env var since it's shared)
+
+Create a test helper:
+
+```python
+def _make_config(**overrides) -> "ChangelogConfig":
+    from chat.changelog import ChangelogConfig
+    defaults = {
+        "name": "test",
+        "github_repo": "owner/repo",
+        "channel_id": "123",
+        "prompt": "professional",
+        "embed_title": "Test Changelog",
+        "embed_color": 0x2ECC71,
+        "interval_hours": 1,
+        "commit_filter": None,
+    }
+    defaults.update(overrides)
+    return ChangelogConfig(**defaults)
+```
+
+Update test: `test_missing_all_env_vars_returns_early` → `test_missing_github_token_returns_early`:
+
+```python
+@pytest.mark.asyncio
+async def test_missing_github_token_returns_early(self):
+    """When GITHUB_TOKEN is absent the function exits without error."""
+    bot = MagicMock(spec=discord.Client)
+    mock_llm = AsyncMock()
+    config = _make_config()
+
+    with patch.dict("os.environ", {}, clear=True):
+        import os
+        os.environ.pop("GITHUB_TOKEN", None)
+        await run_changelog_iteration(bot, mock_llm, config)
+
+    mock_llm.assert_not_called()
+```
+
+Remove `test_missing_single_env_var_returns_early` (no longer applicable — config fields are required).
+
+Update remaining tests to pass `config=_make_config(channel_id="999", ...)` and set only `GITHUB_TOKEN` in env.
+
+Add new test for commit_filter=None (all commits pass through):
+
+```python
+@pytest.mark.asyncio
+async def test_no_commit_filter_passes_all_commits(self):
+    """When commit_filter is None, all commits are included."""
+    config = _make_config(commit_filter=None)
+    # ... setup with fix: and chore: commits ...
+    # Assert llm_call IS called (all commits pass through)
+```
+
+Add test for lookback_hours:
+
+```python
+@pytest.mark.asyncio
+async def test_lookback_hours_used_for_since(self):
+    """The since parameter uses config.interval_hours for lookback."""
+    config = _make_config(interval_hours=3)
+    # ... verify _fetch_commits_since is called with since ~3 hours ago
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `bb remote test //projects/monolith:changelog_test --config=ci`
+Expected: FAIL — `run_changelog_iteration` doesn't accept `config` yet.
+
+**Step 3: Refactor run_changelog_iteration**
+
+```python
+async def run_changelog_iteration(
+    bot: discord.Client,
+    llm_call: Callable[[str], Awaitable[str]],
+    config: ChangelogConfig,
+    store_message: "Callable[[str, str, str, str, str], Awaitable[None]] | None" = None,
+) -> None:
+    """Single iteration: fetch recent commits, summarize, post to Discord."""
+    github_token = os.environ.get("GITHUB_TOKEN", "")
+
+    if not github_token:
+        logger.warning("Changelog[%s] disabled: missing GITHUB_TOKEN", config.name)
+        return
+
+    since = datetime.now(timezone.utc) - timedelta(hours=config.interval_hours)
+
+    async with httpx.AsyncClient(timeout=httpx.Timeout(30.0)) as client:
+        commits = await _fetch_commits_since(client, config.github_repo, github_token, since)
+
+        if not commits:
+            logger.info("Changelog[%s]: no new commits in the last %dh", config.name, config.interval_hours)
+            return
+
+        if config.commit_filter is not None:
+            commits = _filter_changelog_commits(commits, config.commit_filter)
+
+    if not commits:
+        logger.info("Changelog[%s]: commits found but none match filter", config.name)
+        return
+
+    prompt_template = PROMPTS[config.prompt]
+    summary = await _summarize_with_gemma(commits, llm_call, prompt_template)
+    embed = _build_embed(summary, len(commits), title=config.embed_title, color=config.embed_color)
+
+    channel = bot.get_channel(int(config.channel_id))
+    if channel:
+        sent = await channel.send(embed=embed)
+        logger.info("Changelog[%s]: posted %d changes to channel %s", config.name, len(commits), config.channel_id)
+        if store_message is not None and bot.user is not None:
+            try:
+                await store_message(
+                    str(sent.id),
+                    config.channel_id,
+                    str(bot.user.id),
+                    bot.user.display_name,
+                    f"{config.embed_title}\n{summary}",
+                )
+            except Exception:
+                logger.exception("Changelog[%s]: failed to store sent message %s", config.name, sent.id)
+    else:
+        logger.warning("Changelog[%s]: channel %s not found", config.name, config.channel_id)
+```
+
+Also update `_filter_changelog_commits` to accept a pattern parameter:
+
+```python
+def _filter_changelog_commits(commits: list[dict], pattern: re.Pattern) -> list[dict]:
+    """Keep only commits matching the given pattern."""
+    result = []
+    for c in commits:
+        msg = c["commit"]["message"].split("\n", 1)[0]
+        if pattern.match(msg):
+            result.append(c)
+    return result
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `bb remote test //projects/monolith:changelog_test --config=ci`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add projects/monolith/chat/changelog.py projects/monolith/chat/changelog_test.py
+git commit -m "refactor(monolith): make run_changelog_iteration config-driven"
+```
+
+---
+
+### Task 4: Update summarizer.py to register jobs from config list
+
+**Files:**
+
+- Modify: `projects/monolith/chat/summarizer.py:220-260`
+
+**Step 1: Update the changelog job registration**
+
+Replace the single changelog job registration with a loop over configs:
+
+```python
+    if bot is not None:
+        from chat.changelog import ChangelogConfig, load_changelog_configs, run_changelog_iteration
+        from shared.embedding import EmbeddingClient
+
+        changelog_configs = load_changelog_configs(
+            os.environ.get("CHANGELOG_CONFIGS", "")
+        )
+
+        for cfg in changelog_configs:
+            def _make_handler(config: ChangelogConfig):
+                async def _changelog_handler(session: "Session") -> datetime | None:
+                    embed_client = EmbeddingClient()
+
+                    async def _store_message(
+                        discord_message_id: str,
+                        channel_id: str,
+                        user_id: str,
+                        username: str,
+                        content: str,
+                    ) -> None:
+                        from chat.store import MessageStore
+                        store = MessageStore(session=session, embed_client=embed_client)
+                        await store.save_message(
+                            discord_message_id=discord_message_id,
+                            channel_id=channel_id,
+                            user_id=user_id,
+                            username=username,
+                            content=content,
+                            is_bot=True,
+                        )
+
+                    await run_changelog_iteration(bot, llm_call, config, store_message=_store_message)
+                    now = datetime.now(timezone.utc)
+                    interval = timedelta(hours=config.interval_hours)
+                    # Align to next interval boundary
+                    epoch = now.replace(hour=0, minute=0, second=0, microsecond=0)
+                    elapsed = now - epoch
+                    periods = int(elapsed / interval) + 1
+                    return epoch + interval * periods
+
+                return _changelog_handler
+
+            register_job(
+                session,
+                name=f"chat.changelog.{cfg.name}",
+                interval_secs=cfg.interval_hours * 3600,
+                handler=_make_handler(cfg),
+                ttl_secs=300,
+            )
+```
+
+Note: `_make_handler` closure is needed to capture `cfg` by value, not by reference (classic Python loop variable capture bug).
+
+**Step 2: Run all tests**
+
+Run: `bb remote test //projects/monolith/... --config=ci`
+Expected: PASS
+
+**Step 3: Commit**
+
+```bash
+git add projects/monolith/chat/summarizer.py
+git commit -m "feat(monolith): register changelog jobs from CHANGELOG_CONFIGS list"
+```
+
+---
+
+### Task 5: Update Helm chart and values
+
+**Files:**
+
+- Modify: `projects/monolith/chart/templates/deployment.yaml:84-94`
+- Modify: `projects/monolith/deploy/values.yaml:95-98`
+- Modify: `projects/monolith/chart/Chart.yaml` (version bump)
+- Modify: `projects/monolith/deploy/application.yaml` (targetRevision bump)
+
+**Step 1: Update deployment template**
+
+Replace lines 84-94 in `deployment.yaml`:
+
+```yaml
+            {{- if .Values.chat.changelogs }}
+            - name: GITHUB_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "monolith.fullname" . }}-chat-secrets
+                  key: GITHUB_TOKEN
+            - name: CHANGELOG_CONFIGS
+              value: {{ .Values.chat.changelogs | toJson | quote }}
+            {{- end }}
+```
+
+**Step 2: Update values.yaml**
+
+Replace the `changelog` block (lines 95-98) with:
+
+```yaml
+changelogs:
+  - name: "homelab"
+    channelId: "1491186550472708117"
+    githubRepo: "jomcgi/homelab"
+    prompt: "professional"
+    embedTitle: "Homelab Changelog"
+    embedColor: "0x2ECC71"
+    intervalHours: 1
+    commitFilter: "^(feat)(\\(.+?\\))?!?:\\s"
+  - name: "roast"
+    channelId: "1491186550472708117"
+    githubRepo: "ColinCee/homelab"
+    prompt: "roast"
+    embedTitle: "Colin's Homelab Roast"
+    embedColor: "0xE74C3C"
+    intervalHours: 3
+```
+
+**Step 3: Verify Helm renders correctly**
+
+Run: `helm template monolith projects/monolith/chart/ -f projects/monolith/deploy/values.yaml | grep -A5 CHANGELOG`
+Expected: `CHANGELOG_CONFIGS` env var with JSON array value.
+
+**Step 4: Bump chart version**
+
+Bump version in `projects/monolith/chart/Chart.yaml` and update `targetRevision` in `projects/monolith/deploy/application.yaml` to match.
+
+**Step 5: Commit**
+
+```bash
+git add projects/monolith/chart/ projects/monolith/deploy/
+git commit -m "feat(monolith): switch changelog config to list-based CHANGELOG_CONFIGS env var"
+```
+
+---
+
+### Task 6: Run full test suite and verify helm rendering
+
+**Step 1: Run all monolith tests**
+
+Run: `bb remote test //projects/monolith/... --config=ci`
+Expected: All PASS
+
+**Step 2: Verify Helm template renders cleanly**
+
+Run: `helm template monolith projects/monolith/chart/ -f projects/monolith/deploy/values.yaml`
+Expected: No errors, valid YAML, `CHANGELOG_CONFIGS` env var present with JSON.
+
+**Step 3: Run format**
+
+Run: `format`
+Expected: No changes (or auto-fixed formatting).
+
+**Step 4: Commit any format fixes**
+
+```bash
+git add -A && git commit -m "style(monolith): format fixes"
+```

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.46.0
+version: 0.46.1
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.45.1
+version: 0.46.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/templates/deployment.yaml
+++ b/projects/monolith/chart/templates/deployment.yaml
@@ -81,16 +81,14 @@ spec:
               value: {{ .Values.chat.embeddingUrl | quote }}
             - name: SEARXNG_URL
               value: {{ .Values.chat.searxngUrl | quote }}
-            {{- if .Values.chat.changelog.enabled }}
+            {{- if .Values.chat.changelogs }}
             - name: GITHUB_TOKEN
               valueFrom:
                 secretKeyRef:
                   name: {{ include "monolith.fullname" . }}-chat-secrets
                   key: GITHUB_TOKEN
-            - name: CHANGELOG_CHANNEL_ID
-              value: {{ .Values.chat.changelog.channelId | quote }}
-            - name: CHANGELOG_GITHUB_REPO
-              value: {{ .Values.chat.changelog.githubRepo | quote }}
+            - name: CHANGELOG_CONFIGS
+              value: {{ .Values.chat.changelogs | toJson | quote }}
             {{- end }}
             {{- end }}
             {{- if .Values.gardener.enabled }}

--- a/projects/monolith/chat/changelog.py
+++ b/projects/monolith/chat/changelog.py
@@ -136,6 +136,7 @@ def _filter_changelog_commits(commits: list[dict]) -> list[dict]:
 async def _summarize_with_gemma(
     commits: list[dict],
     llm_call: Callable[[str], Awaitable[str]],
+    prompt_template: str,
 ) -> str:
     """Ask Gemma to produce a concise changelog from commit data."""
     commit_descriptions = []
@@ -145,24 +146,18 @@ async def _summarize_with_gemma(
         commit_descriptions.append(f"- {msg} (by {author})")
 
     commits_text = "\n".join(commit_descriptions)
-    prompt = (
-        "You are a changelog writer for a Kubernetes homelab project.\n"
-        "Below are recent git commits (new features only).\n"
-        "Write a concise changelog summarizing what changed. "
-        "For each item, explain what it does in "
-        "one clear sentence — don't just repeat the commit message. "
-        "Use plain language. No markdown headers, just plain text with bullet points.\n\n"
-        f"Commits:\n{commits_text}"
-    )
+    prompt = prompt_template.format(commits=commits_text)
     return await llm_call(prompt)
 
 
-def _build_embed(summary: str, commit_count: int) -> discord.Embed:
+def _build_embed(
+    summary: str, commit_count: int, title: str, color: int
+) -> discord.Embed:
     """Build a Discord embed for the changelog notification."""
     embed = discord.Embed(
-        title="Homelab Changelog",
+        title=title,
         description=summary,
-        color=0x2ECC71,
+        color=color,
         timestamp=datetime.now(timezone.utc),
     )
     embed.set_footer(text=f"{commit_count} commit(s)")
@@ -203,8 +198,12 @@ async def run_changelog_iteration(
         logger.info("Changelog: %d new commits but none are feat", len(commits))
         return
 
-    summary = await _summarize_with_gemma(changelog_commits, llm_call)
-    embed = _build_embed(summary, len(changelog_commits))
+    summary = await _summarize_with_gemma(
+        changelog_commits, llm_call, PROMPTS["professional"]
+    )
+    embed = _build_embed(
+        summary, len(changelog_commits), title="Homelab Changelog", color=0x2ECC71
+    )
 
     channel = bot.get_channel(int(channel_id))
     if channel:

--- a/projects/monolith/chat/changelog.py
+++ b/projects/monolith/chat/changelog.py
@@ -123,12 +123,12 @@ async def _fetch_commits_since(
     return resp.json()
 
 
-def _filter_changelog_commits(commits: list[dict]) -> list[dict]:
-    """Keep only feat conventional commits."""
+def _filter_changelog_commits(commits: list[dict], pattern: re.Pattern) -> list[dict]:
+    """Keep only commits matching the given pattern."""
     result = []
     for c in commits:
         msg = c["commit"]["message"].split("\n", 1)[0]
-        if _CHANGELOG_TYPES.match(msg):
+        if pattern.match(msg):
             result.append(c)
     return result
 
@@ -167,6 +167,7 @@ def _build_embed(
 async def run_changelog_iteration(
     bot: discord.Client,
     llm_call: Callable[[str], Awaitable[str]],
+    config: ChangelogConfig,
     store_message: "Callable[[str, str, str, str, str], Awaitable[None]] | None" = None,
 ) -> None:
     """Single iteration: fetch recent commits, summarize, post to Discord.
@@ -175,54 +176,65 @@ async def run_changelog_iteration(
     user_id, username, content) after a successful send so the changelog message
     is searchable in history.
     """
-    channel_id = os.environ.get("CHANGELOG_CHANNEL_ID", "")
     github_token = os.environ.get("GITHUB_TOKEN", "")
-    github_repo = os.environ.get("CHANGELOG_GITHUB_REPO", "")
 
-    if not all([channel_id, github_token, github_repo]):
-        logger.warning("Changelog disabled: missing env vars")
+    if not github_token:
+        logger.warning("Changelog[%s] disabled: missing GITHUB_TOKEN", config.name)
         return
 
-    since = datetime.now(timezone.utc) - timedelta(hours=1)
+    since = datetime.now(timezone.utc) - timedelta(hours=config.interval_hours)
 
     async with httpx.AsyncClient(timeout=httpx.Timeout(30.0)) as client:
-        commits = await _fetch_commits_since(client, github_repo, github_token, since)
+        commits = await _fetch_commits_since(
+            client, config.github_repo, github_token, since
+        )
 
         if not commits:
-            logger.info("Changelog: no new commits in the last hour")
+            logger.info(
+                "Changelog[%s]: no new commits in the last %dh",
+                config.name,
+                config.interval_hours,
+            )
             return
 
-        changelog_commits = _filter_changelog_commits(commits)
+        if config.commit_filter is not None:
+            commits = _filter_changelog_commits(commits, config.commit_filter)
 
-    if not changelog_commits:
-        logger.info("Changelog: %d new commits but none are feat", len(commits))
+    if not commits:
+        logger.info("Changelog[%s]: commits found but none match filter", config.name)
         return
 
-    summary = await _summarize_with_gemma(
-        changelog_commits, llm_call, PROMPTS["professional"]
-    )
+    prompt_template = PROMPTS[config.prompt]
+    summary = await _summarize_with_gemma(commits, llm_call, prompt_template)
     embed = _build_embed(
-        summary, len(changelog_commits), title="Homelab Changelog", color=0x2ECC71
+        summary, len(commits), title=config.embed_title, color=config.embed_color
     )
 
-    channel = bot.get_channel(int(channel_id))
+    channel = bot.get_channel(int(config.channel_id))
     if channel:
         sent = await channel.send(embed=embed)
         logger.info(
-            "Changelog: posted %d changes to channel %s",
-            len(changelog_commits),
-            channel_id,
+            "Changelog[%s]: posted %d changes to channel %s",
+            config.name,
+            len(commits),
+            config.channel_id,
         )
         if store_message is not None and bot.user is not None:
             try:
                 await store_message(
                     str(sent.id),
-                    channel_id,
+                    config.channel_id,
                     str(bot.user.id),
                     bot.user.display_name,
-                    f"Homelab Changelog\n{summary}",
+                    f"{config.embed_title}\n{summary}",
                 )
             except Exception:
-                logger.exception("Changelog: failed to store sent message %s", sent.id)
+                logger.exception(
+                    "Changelog[%s]: failed to store sent message %s",
+                    config.name,
+                    sent.id,
+                )
     else:
-        logger.warning("Changelog: channel %s not found", channel_id)
+        logger.warning(
+            "Changelog[%s]: channel %s not found", config.name, config.channel_id
+        )

--- a/projects/monolith/chat/changelog.py
+++ b/projects/monolith/chat/changelog.py
@@ -1,5 +1,7 @@
 """Hourly changelog notifier — polls GitHub for new feat commits, summarizes via Gemma, posts to Discord."""
 
+import dataclasses
+import json
 import logging
 import os
 import re
@@ -16,6 +18,89 @@ _CHANGELOG_TYPES = re.compile(r"^(feat)(\(.+?\))?!?:\s")
 
 GITHUB_API = "https://api.github.com"
 _GITHUB_HEADERS = {"Accept": "application/vnd.github+json"}
+
+
+@dataclasses.dataclass(frozen=True)
+class ChangelogConfig:
+    name: str
+    github_repo: str
+    channel_id: str
+    prompt: str
+    embed_title: str
+    embed_color: int
+    interval_hours: int = 1
+    commit_filter: re.Pattern | None = None
+
+
+PROMPTS: dict[str, str] = {
+    "professional": (
+        "You are a changelog writer for a Kubernetes homelab project.\n"
+        "Below are recent git commits (new features only).\n"
+        "Write a concise changelog summarizing what changed. "
+        "For each item, explain what it does in "
+        "one clear sentence — don't just repeat the commit message. "
+        "Use plain language. No markdown headers, just plain text with bullet points.\n\n"
+        "Commits:\n{commits}"
+    ),
+    "roast": (
+        "You are Colin's close friend and a cynical senior engineer who has seen\n"
+        "too many homelabs. You're reviewing his recent git commits to roast him\n"
+        "in the group chat. He can take it — don't soften anything.\n\n"
+        "Below are his recent commits:\n"
+        "<commits>\n{commits}\n</commits>\n\n"
+        "Write a changelog-style roast. Format:\n\n"
+        "Colin homelab changelog:\n"
+        "- <entry>\n- <entry>\n- <entry>\n\n"
+        "3-5 entries. Each one is a single line written as if it's a real\n"
+        "changelog bullet, but the content is the roast. Examples of the shape:\n"
+        '- "Added three ADRs to justify turning a Beelink on."\n'
+        '- "Replaced working Grafana dashboard with a worse one. Wrote a runbook about it."\n'
+        '- "Four commits to fix one typo. Copilot did the last three."\n\n'
+        "Target specific things in the commits — pretentious messages, features\n"
+        "added then ripped out, yak-shaving, ADRs for three lines of YAML,\n"
+        "Copilot cleaning up after him, enterprise patterns on a mini-PC,\n"
+        "README brags that are one commit old, bike-shedding. Name the thing.\n\n"
+        "Rules:\n"
+        '- Past tense, declarative, changelog voice. No "Colin did X" — the\n'
+        "  entries are the changes themselves, deadpan.\n"
+        '- Punch at choices, not at him. "Docker Swarm in 2026" is fair.\n'
+        "  Personal attacks are lazy.\n"
+        "- Dry > loud. A good callback to an earlier entry beats exclamation marks.\n"
+        '- No hedging, no "but seriously", no constructive feedback.\n'
+        "- No markdown headers, no emoji, no preamble or outro. Just the header\n"
+        "  line and bullets.\n"
+        "- If a commit is genuinely boring, skip it. Don't manufacture heat.\n"
+        "Optionally end with one entry in square brackets, e.g. "
+        "[No breaking changes. Nothing worked in the first place.]"
+    ),
+}
+
+
+def load_changelog_configs(raw: str) -> list[ChangelogConfig]:
+    """Parse a JSON string into a list of ChangelogConfig objects."""
+    if not raw:
+        return []
+    entries = json.loads(raw)
+    configs = []
+    for entry in entries:
+        commit_filter = None
+        if "commitFilter" in entry:
+            commit_filter = re.compile(entry["commitFilter"])
+        configs.append(
+            ChangelogConfig(
+                name=entry["name"],
+                github_repo=entry["githubRepo"],
+                channel_id=entry["channelId"],
+                prompt=entry["prompt"],
+                embed_title=entry["embedTitle"],
+                embed_color=int(entry["embedColor"], 16)
+                if isinstance(entry["embedColor"], str)
+                else entry["embedColor"],
+                interval_hours=entry.get("intervalHours", 1),
+                commit_filter=commit_filter,
+            )
+        )
+    return configs
 
 
 def _auth_headers(token: str) -> dict[str, str]:

--- a/projects/monolith/chat/changelog_test.py
+++ b/projects/monolith/chat/changelog_test.py
@@ -1,17 +1,91 @@
 """Tests for the hourly changelog notifier module."""
 
+import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import discord
 import pytest
 
 from chat.changelog import (
+    ChangelogConfig,
+    PROMPTS,
     _auth_headers,
     _build_embed,
     _filter_changelog_commits,
     _summarize_with_gemma,
+    load_changelog_configs,
     run_changelog_iteration,
 )
+
+
+class TestChangelogConfig:
+    def test_load_configs_from_json(self):
+        """JSON list is parsed into ChangelogConfig objects."""
+        raw = json.dumps(
+            [
+                {
+                    "name": "test",
+                    "channelId": "123",
+                    "githubRepo": "owner/repo",
+                    "prompt": "professional",
+                    "embedTitle": "Test",
+                    "embedColor": "0x2ECC71",
+                    "intervalHours": 1,
+                }
+            ]
+        )
+        configs = load_changelog_configs(raw)
+        assert len(configs) == 1
+        assert configs[0].name == "test"
+        assert configs[0].github_repo == "owner/repo"
+        assert configs[0].channel_id == "123"
+        assert configs[0].embed_color == 0x2ECC71
+        assert configs[0].interval_hours == 1
+        assert configs[0].commit_filter is None
+
+    def test_load_configs_with_commit_filter(self):
+        """commitFilter string is compiled to a regex pattern."""
+        raw = json.dumps(
+            [
+                {
+                    "name": "filtered",
+                    "channelId": "123",
+                    "githubRepo": "owner/repo",
+                    "prompt": "professional",
+                    "embedTitle": "Test",
+                    "embedColor": "0x2ECC71",
+                    "intervalHours": 1,
+                    "commitFilter": "^(feat)(\\(.+?\\))?!?:\\s",
+                }
+            ]
+        )
+        configs = load_changelog_configs(raw)
+        assert configs[0].commit_filter is not None
+        assert configs[0].commit_filter.match("feat: something")
+        assert not configs[0].commit_filter.match("fix: something")
+
+    def test_load_configs_empty_json(self):
+        """Empty JSON list returns empty config list."""
+        assert load_changelog_configs("[]") == []
+
+    def test_load_configs_empty_string(self):
+        """Empty string returns empty config list."""
+        assert load_changelog_configs("") == []
+
+    def test_prompts_registry_has_professional(self):
+        """PROMPTS dict contains 'professional' key."""
+        assert "professional" in PROMPTS
+
+    def test_prompts_registry_has_roast(self):
+        """PROMPTS dict contains 'roast' key."""
+        assert "roast" in PROMPTS
+
+    def test_prompts_contain_commits_placeholder(self):
+        """All prompts contain {commits} placeholder."""
+        for key, prompt in PROMPTS.items():
+            assert "{commits}" in prompt, (
+                f"Prompt '{key}' missing {{commits}} placeholder"
+            )
 
 
 def _make_commit(message: str, author: str = "Alice") -> dict:

--- a/projects/monolith/chat/changelog_test.py
+++ b/projects/monolith/chat/changelog_test.py
@@ -1,6 +1,7 @@
 """Tests for the hourly changelog notifier module."""
 
 import json
+import re
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import discord
@@ -9,6 +10,7 @@ import pytest
 from chat.changelog import (
     ChangelogConfig,
     PROMPTS,
+    _CHANGELOG_TYPES,
     _auth_headers,
     _build_embed,
     _filter_changelog_commits,
@@ -98,6 +100,22 @@ def _make_commit(message: str, author: str = "Alice") -> dict:
     }
 
 
+def _make_config(**overrides) -> ChangelogConfig:
+    """Helper to build a ChangelogConfig with sensible defaults."""
+    defaults = {
+        "name": "test",
+        "github_repo": "owner/repo",
+        "channel_id": "123",
+        "prompt": "professional",
+        "embed_title": "Test Changelog",
+        "embed_color": 0x2ECC71,
+        "interval_hours": 1,
+        "commit_filter": None,
+    }
+    defaults.update(overrides)
+    return ChangelogConfig(**defaults)
+
+
 # ---------------------------------------------------------------------------
 # _filter_changelog_commits
 # ---------------------------------------------------------------------------
@@ -106,62 +124,62 @@ def _make_commit(message: str, author: str = "Alice") -> dict:
 class TestFilterChangelogCommits:
     def test_empty_list_returns_empty(self):
         """Empty input returns empty list."""
-        assert _filter_changelog_commits([]) == []
+        assert _filter_changelog_commits([], _CHANGELOG_TYPES) == []
 
     def test_feat_commit_passes(self):
         """feat: commits are included."""
         commits = [_make_commit("feat: add dark mode")]
-        assert len(_filter_changelog_commits(commits)) == 1
+        assert len(_filter_changelog_commits(commits, _CHANGELOG_TYPES)) == 1
 
     def test_fix_commit_excluded(self):
         """fix: commits are excluded (feat-only filter)."""
         commits = [_make_commit("fix: correct typo in footer")]
-        assert _filter_changelog_commits(commits) == []
+        assert _filter_changelog_commits(commits, _CHANGELOG_TYPES) == []
 
     def test_chore_commit_excluded(self):
         """chore: commits are not included."""
         commits = [_make_commit("chore: update dependencies")]
-        assert _filter_changelog_commits(commits) == []
+        assert _filter_changelog_commits(commits, _CHANGELOG_TYPES) == []
 
     def test_docs_commit_excluded(self):
         """docs: commits are not included."""
         commits = [_make_commit("docs: improve README")]
-        assert _filter_changelog_commits(commits) == []
+        assert _filter_changelog_commits(commits, _CHANGELOG_TYPES) == []
 
     def test_refactor_commit_excluded(self):
         """refactor: commits are not included."""
         commits = [_make_commit("refactor: extract helper function")]
-        assert _filter_changelog_commits(commits) == []
+        assert _filter_changelog_commits(commits, _CHANGELOG_TYPES) == []
 
     def test_ci_commit_excluded(self):
         """ci: commits are not included."""
         commits = [_make_commit("ci: add lint step")]
-        assert _filter_changelog_commits(commits) == []
+        assert _filter_changelog_commits(commits, _CHANGELOG_TYPES) == []
 
     def test_feat_with_scope_passes(self):
         """feat(auth): scoped feature commits are included."""
         commits = [_make_commit("feat(auth): add OAuth2 support")]
-        assert len(_filter_changelog_commits(commits)) == 1
+        assert len(_filter_changelog_commits(commits, _CHANGELOG_TYPES)) == 1
 
     def test_feat_breaking_change_passes(self):
         """feat!: breaking change feature commits are included."""
         commits = [_make_commit("feat!: redesign auth token format")]
-        assert len(_filter_changelog_commits(commits)) == 1
+        assert len(_filter_changelog_commits(commits, _CHANGELOG_TYPES)) == 1
 
     def test_feat_scope_breaking_change_passes(self):
         """feat(auth)!: scoped breaking change is included."""
         commits = [_make_commit("feat(auth)!: drop legacy token support")]
-        assert len(_filter_changelog_commits(commits)) == 1
+        assert len(_filter_changelog_commits(commits, _CHANGELOG_TYPES)) == 1
 
     def test_multiline_commit_uses_first_line_only(self):
         """Only the subject line (before first newline) is matched."""
         commits = [_make_commit("feat: add feature\n\nLong description here.")]
-        assert len(_filter_changelog_commits(commits)) == 1
+        assert len(_filter_changelog_commits(commits, _CHANGELOG_TYPES)) == 1
 
     def test_multiline_commit_fix_excluded(self):
         """fix: with body is still excluded even when body mentions feat."""
         commits = [_make_commit("fix: patch crash\n\nfeat: unrelated note")]
-        assert _filter_changelog_commits(commits) == []
+        assert _filter_changelog_commits(commits, _CHANGELOG_TYPES) == []
 
     def test_mixed_commits_returns_only_feat(self):
         """Only feat commits are returned from a mixed list."""
@@ -171,7 +189,7 @@ class TestFilterChangelogCommits:
             _make_commit("chore: bump versions"),
             _make_commit("feat(ui): dark mode toggle"),
         ]
-        result = _filter_changelog_commits(commits)
+        result = _filter_changelog_commits(commits, _CHANGELOG_TYPES)
         assert len(result) == 2
         assert result[0]["commit"]["message"] == "feat: new dashboard"
         assert result[1]["commit"]["message"] == "feat(ui): dark mode toggle"
@@ -179,12 +197,12 @@ class TestFilterChangelogCommits:
     def test_partial_word_feat_excluded(self):
         """A commit message starting with 'feature:' (not 'feat:') is excluded."""
         commits = [_make_commit("feature: add something")]
-        assert _filter_changelog_commits(commits) == []
+        assert _filter_changelog_commits(commits, _CHANGELOG_TYPES) == []
 
     def test_feat_without_colon_excluded(self):
         """'feat add something' (no colon) is excluded."""
         commits = [_make_commit("feat add something")]
-        assert _filter_changelog_commits(commits) == []
+        assert _filter_changelog_commits(commits, _CHANGELOG_TYPES) == []
 
 
 # ---------------------------------------------------------------------------
@@ -356,39 +374,17 @@ class TestSummarizeWithGemma:
 
 class TestRunChangelogIteration:
     @pytest.mark.asyncio
-    async def test_missing_all_env_vars_returns_early(self):
-        """When all env vars are absent the function exits without error."""
+    async def test_missing_github_token_returns_early(self):
+        """When GITHUB_TOKEN is absent the function exits without error."""
         bot = MagicMock(spec=discord.Client)
         mock_llm = AsyncMock()
+        config = _make_config()
 
         with patch.dict("os.environ", {}, clear=True):
-            # Remove relevant keys if present
             import os
 
-            for key in (
-                "CHANGELOG_CHANNEL_ID",
-                "GITHUB_TOKEN",
-                "CHANGELOG_GITHUB_REPO",
-            ):
-                os.environ.pop(key, None)
-
-            await run_changelog_iteration(bot, mock_llm)
-
-        mock_llm.assert_not_called()
-
-    @pytest.mark.asyncio
-    async def test_missing_single_env_var_returns_early(self):
-        """Missing just one env var causes early return (AND logic)."""
-        bot = MagicMock(spec=discord.Client)
-        mock_llm = AsyncMock()
-
-        env = {
-            "CHANGELOG_CHANNEL_ID": "123456",
-            "GITHUB_TOKEN": "ghp_xxx",
-            # CHANGELOG_GITHUB_REPO intentionally omitted
-        }
-        with patch.dict("os.environ", env, clear=True):
-            await run_changelog_iteration(bot, mock_llm)
+            os.environ.pop("GITHUB_TOKEN", None)
+            await run_changelog_iteration(bot, mock_llm, config)
 
         mock_llm.assert_not_called()
 
@@ -397,12 +393,7 @@ class TestRunChangelogIteration:
         """When GitHub returns no commits, no Discord message is sent."""
         bot = MagicMock(spec=discord.Client)
         mock_llm = AsyncMock()
-
-        env = {
-            "CHANGELOG_CHANNEL_ID": "111",
-            "GITHUB_TOKEN": "ghp_tok",
-            "CHANGELOG_GITHUB_REPO": "owner/repo",
-        }
+        config = _make_config(channel_id="111")
 
         mock_response = MagicMock()
         mock_response.json.return_value = []
@@ -413,24 +404,22 @@ class TestRunChangelogIteration:
         mock_client.__aenter__ = AsyncMock(return_value=mock_client)
         mock_client.__aexit__ = AsyncMock(return_value=False)
 
-        with patch.dict("os.environ", env):
+        with patch.dict("os.environ", {"GITHUB_TOKEN": "ghp_tok"}):
             with patch("chat.changelog.httpx.AsyncClient", return_value=mock_client):
-                await run_changelog_iteration(bot, mock_llm)
+                await run_changelog_iteration(bot, mock_llm, config)
 
         mock_llm.assert_not_called()
         bot.get_channel.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_no_matching_commits_returns_early(self):
-        """When commits exist but none are feat, no Discord message is sent."""
+        """When commits exist but none match filter, no Discord message is sent."""
         bot = MagicMock(spec=discord.Client)
         mock_llm = AsyncMock()
-
-        env = {
-            "CHANGELOG_CHANNEL_ID": "111",
-            "GITHUB_TOKEN": "ghp_tok",
-            "CHANGELOG_GITHUB_REPO": "owner/repo",
-        }
+        config = _make_config(
+            channel_id="111",
+            commit_filter=re.compile(r"^(feat)(\(.+?\))?!?:\s"),
+        )
 
         commits = [
             _make_commit("fix: patch null pointer"),
@@ -445,27 +434,53 @@ class TestRunChangelogIteration:
         mock_client.__aenter__ = AsyncMock(return_value=mock_client)
         mock_client.__aexit__ = AsyncMock(return_value=False)
 
-        with patch.dict("os.environ", env):
+        with patch.dict("os.environ", {"GITHUB_TOKEN": "ghp_tok"}):
             with patch("chat.changelog.httpx.AsyncClient", return_value=mock_client):
-                await run_changelog_iteration(bot, mock_llm)
+                await run_changelog_iteration(bot, mock_llm, config)
 
         mock_llm.assert_not_called()
         bot.get_channel.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_successful_post_sends_embed(self):
-        """With valid env vars and feat commits, an embed is posted to Discord."""
+    async def test_no_filter_passes_all_commits(self):
+        """When commit_filter is None, all commits are included."""
         mock_channel = AsyncMock()
         bot = MagicMock(spec=discord.Client)
         bot.get_channel.return_value = mock_channel
+        mock_llm = AsyncMock(return_value="Summary of all commits.")
+        config = _make_config(channel_id="999", commit_filter=None)
 
+        commits = [
+            _make_commit("fix: patch null pointer", "Alice"),
+            _make_commit("chore: update deps", "Bob"),
+        ]
+        mock_response = MagicMock()
+        mock_response.json.return_value = commits
+        mock_response.raise_for_status = MagicMock()
+
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=mock_response)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch.dict("os.environ", {"GITHUB_TOKEN": "ghp_tok"}):
+            with patch("chat.changelog.httpx.AsyncClient", return_value=mock_client):
+                await run_changelog_iteration(bot, mock_llm, config)
+
+        mock_llm.assert_called_once()
+        mock_channel.send.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_successful_post_sends_embed(self):
+        """With valid config and matching commits, an embed is posted to Discord."""
+        mock_channel = AsyncMock()
+        bot = MagicMock(spec=discord.Client)
+        bot.get_channel.return_value = mock_channel
         mock_llm = AsyncMock(return_value="Added a great new feature.")
-
-        env = {
-            "CHANGELOG_CHANNEL_ID": "999",
-            "GITHUB_TOKEN": "ghp_tok",
-            "CHANGELOG_GITHUB_REPO": "owner/repo",
-        }
+        config = _make_config(
+            channel_id="999",
+            commit_filter=re.compile(r"^(feat)(\(.+?\))?!?:\s"),
+        )
 
         commits = [_make_commit("feat: amazing new feature", "Alice")]
         mock_response = MagicMock()
@@ -477,9 +492,9 @@ class TestRunChangelogIteration:
         mock_client.__aenter__ = AsyncMock(return_value=mock_client)
         mock_client.__aexit__ = AsyncMock(return_value=False)
 
-        with patch.dict("os.environ", env):
+        with patch.dict("os.environ", {"GITHUB_TOKEN": "ghp_tok"}):
             with patch("chat.changelog.httpx.AsyncClient", return_value=mock_client):
-                await run_changelog_iteration(bot, mock_llm)
+                await run_changelog_iteration(bot, mock_llm, config)
 
         bot.get_channel.assert_called_once_with(999)
         mock_channel.send.assert_called_once()
@@ -492,14 +507,8 @@ class TestRunChangelogIteration:
         """When bot.get_channel returns None, no error is raised."""
         bot = MagicMock(spec=discord.Client)
         bot.get_channel.return_value = None
-
         mock_llm = AsyncMock(return_value="Summary text.")
-
-        env = {
-            "CHANGELOG_CHANNEL_ID": "888",
-            "GITHUB_TOKEN": "ghp_tok",
-            "CHANGELOG_GITHUB_REPO": "owner/repo",
-        }
+        config = _make_config(channel_id="888")
 
         commits = [_make_commit("feat: something cool", "Dave")]
         mock_response = MagicMock()
@@ -511,11 +520,10 @@ class TestRunChangelogIteration:
         mock_client.__aenter__ = AsyncMock(return_value=mock_client)
         mock_client.__aexit__ = AsyncMock(return_value=False)
 
-        with patch.dict("os.environ", env):
+        with patch.dict("os.environ", {"GITHUB_TOKEN": "ghp_tok"}):
             with patch("chat.changelog.httpx.AsyncClient", return_value=mock_client):
-                await run_changelog_iteration(bot, mock_llm)
+                await run_changelog_iteration(bot, mock_llm, config)
 
-        # Should log a warning but not crash
         bot.get_channel.assert_called_once_with(888)
 
     @pytest.mark.asyncio
@@ -535,12 +543,7 @@ class TestRunChangelogIteration:
 
         mock_llm = AsyncMock(return_value="A great new feature landed.")
         store_message = AsyncMock()
-
-        env = {
-            "CHANGELOG_CHANNEL_ID": "777",
-            "GITHUB_TOKEN": "ghp_tok",
-            "CHANGELOG_GITHUB_REPO": "owner/repo",
-        }
+        config = _make_config(channel_id="777", embed_title="Test Changelog")
 
         commits = [_make_commit("feat: cool thing", "Alice")]
         mock_response = MagicMock()
@@ -552,10 +555,10 @@ class TestRunChangelogIteration:
         mock_client.__aenter__ = AsyncMock(return_value=mock_client)
         mock_client.__aexit__ = AsyncMock(return_value=False)
 
-        with patch.dict("os.environ", env):
+        with patch.dict("os.environ", {"GITHUB_TOKEN": "ghp_tok"}):
             with patch("chat.changelog.httpx.AsyncClient", return_value=mock_client):
                 await run_changelog_iteration(
-                    bot, mock_llm, store_message=store_message
+                    bot, mock_llm, config, store_message=store_message
                 )
 
         store_message.assert_called_once()
@@ -576,12 +579,7 @@ class TestRunChangelogIteration:
 
         mock_llm = AsyncMock(return_value="Summary.")
         store_message = AsyncMock()
-
-        env = {
-            "CHANGELOG_CHANNEL_ID": "777",
-            "GITHUB_TOKEN": "ghp_tok",
-            "CHANGELOG_GITHUB_REPO": "owner/repo",
-        }
+        config = _make_config(channel_id="777")
 
         commits = [_make_commit("feat: thing", "Alice")]
         mock_response = MagicMock()
@@ -593,10 +591,10 @@ class TestRunChangelogIteration:
         mock_client.__aenter__ = AsyncMock(return_value=mock_client)
         mock_client.__aexit__ = AsyncMock(return_value=False)
 
-        with patch.dict("os.environ", env):
+        with patch.dict("os.environ", {"GITHUB_TOKEN": "ghp_tok"}):
             with patch("chat.changelog.httpx.AsyncClient", return_value=mock_client):
                 await run_changelog_iteration(
-                    bot, mock_llm, store_message=store_message
+                    bot, mock_llm, config, store_message=store_message
                 )
 
         store_message.assert_not_called()

--- a/projects/monolith/chat/changelog_test.py
+++ b/projects/monolith/chat/changelog_test.py
@@ -195,39 +195,61 @@ class TestFilterChangelogCommits:
 class TestBuildEmbed:
     def test_embed_title(self):
         """Embed title is 'Homelab Changelog'."""
-        embed = _build_embed("Some summary", commit_count=3)
+        embed = _build_embed(
+            "Some summary", commit_count=3, title="Homelab Changelog", color=0x2ECC71
+        )
         assert embed.title == "Homelab Changelog"
 
     def test_embed_color(self):
         """Embed color is 0x2ECC71 (green)."""
-        embed = _build_embed("Some summary", commit_count=3)
+        embed = _build_embed(
+            "Some summary", commit_count=3, title="Homelab Changelog", color=0x2ECC71
+        )
         assert embed.colour.value == 0x2ECC71
 
     def test_embed_description_matches_summary(self):
         """Embed description equals the provided summary string."""
         summary = "Added dark mode and fixed login bug."
-        embed = _build_embed(summary, commit_count=2)
+        embed = _build_embed(
+            summary, commit_count=2, title="Homelab Changelog", color=0x2ECC71
+        )
         assert embed.description == summary
 
     def test_embed_footer_singular(self):
         """Footer text shows commit count."""
-        embed = _build_embed("x", commit_count=1)
+        embed = _build_embed(
+            "x", commit_count=1, title="Homelab Changelog", color=0x2ECC71
+        )
         assert embed.footer.text == "1 commit(s)"
 
     def test_embed_footer_plural(self):
         """Footer text with multiple commits."""
-        embed = _build_embed("x", commit_count=5)
+        embed = _build_embed(
+            "x", commit_count=5, title="Homelab Changelog", color=0x2ECC71
+        )
         assert embed.footer.text == "5 commit(s)"
 
     def test_embed_has_timestamp(self):
         """Embed has a timestamp set."""
-        embed = _build_embed("x", commit_count=1)
+        embed = _build_embed(
+            "x", commit_count=1, title="Homelab Changelog", color=0x2ECC71
+        )
         assert embed.timestamp is not None
 
     def test_embed_returns_discord_embed(self):
         """Return type is discord.Embed."""
-        embed = _build_embed("x", commit_count=1)
+        embed = _build_embed(
+            "x", commit_count=1, title="Homelab Changelog", color=0x2ECC71
+        )
         assert isinstance(embed, discord.Embed)
+
+    def test_custom_title_and_color(self):
+        """Custom title and color are used in the embed."""
+        embed = _build_embed(
+            "Roast", commit_count=1, title="Colin's Homelab Roast", color=0xE74C3C
+        )
+        assert embed.title == "Colin's Homelab Roast"
+        assert embed.colour.value == 0xE74C3C
 
 
 # ---------------------------------------------------------------------------
@@ -272,7 +294,7 @@ class TestSummarizeWithGemma:
         commits = [_make_commit("feat: add search", "Bob")]
         mock_llm = AsyncMock(return_value="Added search functionality.")
 
-        await _summarize_with_gemma(commits, mock_llm)
+        await _summarize_with_gemma(commits, mock_llm, PROMPTS["professional"])
 
         call_args = mock_llm.call_args[0][0]
         assert "feat: add search" in call_args
@@ -283,7 +305,7 @@ class TestSummarizeWithGemma:
         commits = [_make_commit("feat: add feature", "Charlie")]
         mock_llm = AsyncMock(return_value="Added a feature.")
 
-        await _summarize_with_gemma(commits, mock_llm)
+        await _summarize_with_gemma(commits, mock_llm, PROMPTS["professional"])
 
         call_args = mock_llm.call_args[0][0]
         assert "Charlie" in call_args
@@ -295,7 +317,7 @@ class TestSummarizeWithGemma:
         expected = "Users can now toggle dark mode."
         mock_llm = AsyncMock(return_value=expected)
 
-        result = await _summarize_with_gemma(commits, mock_llm)
+        result = await _summarize_with_gemma(commits, mock_llm, PROMPTS["professional"])
 
         assert result == expected
 
@@ -305,7 +327,7 @@ class TestSummarizeWithGemma:
         commits = [_make_commit("feat: a"), _make_commit("feat: b")]
         mock_llm = AsyncMock(return_value="summary")
 
-        await _summarize_with_gemma(commits, mock_llm)
+        await _summarize_with_gemma(commits, mock_llm, PROMPTS["professional"])
 
         mock_llm.assert_called_once()
 
@@ -318,7 +340,7 @@ class TestSummarizeWithGemma:
         ]
         mock_llm = AsyncMock(return_value="Two features added.")
 
-        await _summarize_with_gemma(commits, mock_llm)
+        await _summarize_with_gemma(commits, mock_llm, PROMPTS["professional"])
 
         call_args = mock_llm.call_args[0][0]
         assert "feat: feature A" in call_args

--- a/projects/monolith/chat/startup_test.py
+++ b/projects/monolith/chat/startup_test.py
@@ -1,9 +1,25 @@
+import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from chat import summarizer
+from chat.changelog import ChangelogConfig
 from shared.scheduler import _registry
+
+_TEST_CHANGELOG_CONFIGS = json.dumps(
+    [
+        {
+            "name": "test",
+            "channelId": "123",
+            "githubRepo": "owner/repo",
+            "prompt": "professional",
+            "embedTitle": "Test",
+            "embedColor": "0x2ECC71",
+            "intervalHours": 1,
+        }
+    ]
+)
 
 
 @pytest.fixture(autouse=True)
@@ -27,18 +43,34 @@ def test_on_startup_without_bot_skips_changelog():
     assert call_kwargs[1]["name"] == "chat.summary_generation"
 
 
-def test_on_startup_with_bot_registers_both():
-    """Calling on_startup with bot registers both summary_generation and changelog."""
+def test_on_startup_with_bot_registers_changelog_per_config():
+    """Calling on_startup with bot registers summary_generation + one job per changelog config."""
     session = MagicMock()
     bot = MagicMock()
     llm_call = AsyncMock()
 
-    with patch("shared.scheduler.register_job") as mock_register:
-        summarizer.on_startup(session, bot=bot, llm_call=llm_call)
+    with patch.dict("os.environ", {"CHANGELOG_CONFIGS": _TEST_CHANGELOG_CONFIGS}):
+        with patch("shared.scheduler.register_job") as mock_register:
+            summarizer.on_startup(session, bot=bot, llm_call=llm_call)
 
     assert mock_register.call_count == 2
     names = {call[1]["name"] for call in mock_register.call_args_list}
-    assert names == {"chat.summary_generation", "chat.changelog"}
+    assert names == {"chat.summary_generation", "chat.changelog.test"}
+
+
+def test_on_startup_with_bot_no_configs_registers_only_summary():
+    """With bot but empty CHANGELOG_CONFIGS, only summary_generation is registered."""
+    session = MagicMock()
+    bot = MagicMock()
+    llm_call = AsyncMock()
+
+    with patch.dict("os.environ", {"CHANGELOG_CONFIGS": "[]"}):
+        with patch("shared.scheduler.register_job") as mock_register:
+            summarizer.on_startup(session, bot=bot, llm_call=llm_call)
+
+    assert mock_register.call_count == 1
+    names = {call[1]["name"] for call in mock_register.call_args_list}
+    assert names == {"chat.summary_generation"}
 
 
 @pytest.mark.asyncio
@@ -71,7 +103,7 @@ async def test_summary_handler_calls_generate_functions():
 
 @pytest.mark.asyncio
 async def test_changelog_handler_calls_run_changelog_iteration():
-    """The changelog handler calls run_changelog_iteration with bot and llm_call."""
+    """The changelog handler calls run_changelog_iteration with bot, llm_call, and config."""
     session = MagicMock()
     bot = MagicMock()
     llm_call = AsyncMock()
@@ -79,18 +111,22 @@ async def test_changelog_handler_calls_run_changelog_iteration():
     with patch(
         "chat.changelog.run_changelog_iteration", new_callable=AsyncMock
     ) as mock_iter:
-        with patch(
-            "shared.scheduler.register_job",
-            side_effect=lambda _s, **kw: _registry.__setitem__(
-                kw["name"], kw["handler"]
-            ),
-        ):
-            summarizer.on_startup(session, bot=bot, llm_call=llm_call)
+        with patch.dict("os.environ", {"CHANGELOG_CONFIGS": _TEST_CHANGELOG_CONFIGS}):
+            with patch(
+                "shared.scheduler.register_job",
+                side_effect=lambda _s, **kw: _registry.__setitem__(
+                    kw["name"], kw["handler"]
+                ),
+            ):
+                summarizer.on_startup(session, bot=bot, llm_call=llm_call)
 
-        handler = _registry["chat.changelog"]
+        handler = _registry["chat.changelog.test"]
         await handler(session)
 
     mock_iter.assert_called_once()
     args, kwargs = mock_iter.call_args
-    assert args == (bot, llm_call)
+    assert args[0] is bot
+    assert args[1] is llm_call
+    assert isinstance(args[2], ChangelogConfig)
+    assert args[2].name == "test"
     assert callable(kwargs.get("store_message"))

--- a/projects/monolith/chat/summarizer.py
+++ b/projects/monolith/chat/summarizer.py
@@ -218,46 +218,62 @@ def on_startup(
     )
 
     if bot is not None:
-        from chat.changelog import run_changelog_iteration
+        from chat.changelog import (
+            ChangelogConfig,
+            load_changelog_configs,
+            run_changelog_iteration,
+        )
         from shared.embedding import EmbeddingClient
 
-        async def _changelog_handler(session: "Session") -> datetime | None:
-            from chat.store import MessageStore
-
-            embed_client = EmbeddingClient()
-
-            async def _store_message(
-                discord_message_id: str,
-                channel_id: str,
-                user_id: str,
-                username: str,
-                content: str,
-            ) -> None:
-                store = MessageStore(session=session, embed_client=embed_client)
-                await store.save_message(
-                    discord_message_id=discord_message_id,
-                    channel_id=channel_id,
-                    user_id=user_id,
-                    username=username,
-                    content=content,
-                    is_bot=True,
-                )
-
-            await run_changelog_iteration(bot, llm_call, store_message=_store_message)
-            # Always align to the next hour boundary
-            now = datetime.now(timezone.utc)
-            next_hour = now.replace(minute=0, second=0, microsecond=0) + timedelta(
-                hours=1
-            )
-            return next_hour
-
-        register_job(
-            session,
-            name="chat.changelog",
-            interval_secs=3600,
-            handler=_changelog_handler,
-            ttl_secs=300,
+        changelog_configs = load_changelog_configs(
+            os.environ.get("CHANGELOG_CONFIGS", "")
         )
+
+        for cfg in changelog_configs:
+
+            def _make_handler(config: ChangelogConfig):
+                async def _changelog_handler(session: "Session") -> datetime | None:
+                    from chat.store import MessageStore
+
+                    embed_client = EmbeddingClient()
+
+                    async def _store_message(
+                        discord_message_id: str,
+                        channel_id: str,
+                        user_id: str,
+                        username: str,
+                        content: str,
+                    ) -> None:
+                        store = MessageStore(session=session, embed_client=embed_client)
+                        await store.save_message(
+                            discord_message_id=discord_message_id,
+                            channel_id=channel_id,
+                            user_id=user_id,
+                            username=username,
+                            content=content,
+                            is_bot=True,
+                        )
+
+                    await run_changelog_iteration(
+                        bot, llm_call, config, store_message=_store_message
+                    )
+                    # Align to next interval boundary
+                    now = datetime.now(timezone.utc)
+                    interval = timedelta(hours=config.interval_hours)
+                    epoch = now.replace(hour=0, minute=0, second=0, microsecond=0)
+                    elapsed = now - epoch
+                    periods = int(elapsed / interval) + 1
+                    return epoch + interval * periods
+
+                return _changelog_handler
+
+            register_job(
+                session,
+                name=f"chat.changelog.{cfg.name}",
+                interval_secs=cfg.interval_hours * 3600,
+                handler=_make_handler(cfg),
+                ttl_secs=300,
+            )
 
 
 _RETRYABLE_STATUS_CODES = {502, 503, 504}

--- a/projects/monolith/chat/summarizer_startup_test.py
+++ b/projects/monolith/chat/summarizer_startup_test.py
@@ -1,15 +1,31 @@
 """Tests covering the on_startup branches that were not exercised in startup_test.py:
 - llm_call=None triggers build_llm_caller() internally
-- the _changelog_handler returns a next-hour-aligned datetime
+- the _changelog_handler returns an interval-aligned datetime
 """
 
+import json
 from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from chat import summarizer
+from chat.changelog import ChangelogConfig
 from shared.scheduler import _registry
+
+_TEST_CHANGELOG_CONFIGS = json.dumps(
+    [
+        {
+            "name": "test",
+            "channelId": "123",
+            "githubRepo": "owner/repo",
+            "prompt": "professional",
+            "embedTitle": "Test",
+            "embedColor": "0x2ECC71",
+            "intervalHours": 1,
+        }
+    ]
+)
 
 
 @pytest.fixture(autouse=True)
@@ -66,9 +82,9 @@ class TestOnStartupWithNullLlmCall:
 
 class TestChangelogHandlerReturnValue:
     @pytest.mark.asyncio
-    async def test_changelog_handler_returns_next_hour_boundary(self):
+    async def test_changelog_handler_returns_next_interval_boundary(self):
         """The _changelog_handler returned by on_startup returns a datetime aligned to
-        the start of the next full UTC hour."""
+        the next interval boundary from midnight."""
         session = MagicMock()
         bot = MagicMock()
         llm_call = AsyncMock()
@@ -81,10 +97,11 @@ class TestChangelogHandlerReturnValue:
         with (
             patch("shared.scheduler.register_job", side_effect=_capture_register),
             patch("chat.changelog.run_changelog_iteration", new_callable=AsyncMock),
+            patch.dict("os.environ", {"CHANGELOG_CONFIGS": _TEST_CHANGELOG_CONFIGS}),
         ):
             summarizer.on_startup(session, bot=bot, llm_call=llm_call)
 
-        handler = captured_handlers["chat.changelog"]
+        handler = captured_handlers["chat.changelog.test"]
         result = await handler(session)
 
         assert result is not None
@@ -95,14 +112,14 @@ class TestChangelogHandlerReturnValue:
         now = datetime.now(timezone.utc)
         assert result > now
 
-        # Must be at exactly HH:00:00 (next whole hour)
+        # Must be at an interval boundary (minute=0, second=0 for 1h interval)
         assert result.minute == 0
         assert result.second == 0
         assert result.microsecond == 0
 
     @pytest.mark.asyncio
-    async def test_changelog_handler_next_hour_at_most_one_hour_away(self):
-        """The next-hour boundary returned is within 60 minutes of now."""
+    async def test_changelog_handler_next_boundary_at_most_one_interval_away(self):
+        """The next boundary returned is within one interval of now."""
         session = MagicMock()
         bot = MagicMock()
         llm_call = AsyncMock()
@@ -115,20 +132,21 @@ class TestChangelogHandlerReturnValue:
         with (
             patch("shared.scheduler.register_job", side_effect=_capture_register),
             patch("chat.changelog.run_changelog_iteration", new_callable=AsyncMock),
+            patch.dict("os.environ", {"CHANGELOG_CONFIGS": _TEST_CHANGELOG_CONFIGS}),
         ):
             summarizer.on_startup(session, bot=bot, llm_call=llm_call)
 
-        handler = captured_handlers["chat.changelog"]
+        handler = captured_handlers["chat.changelog.test"]
         now_before = datetime.now(timezone.utc)
         result = await handler(session)
         now_after = datetime.now(timezone.utc)
 
-        # result must be within (now, now + 3600s]
+        # result must be within (now, now + 3600s] for a 1h interval
         assert result <= now_after + timedelta(seconds=3600)
 
     @pytest.mark.asyncio
     async def test_changelog_handler_calls_run_changelog_iteration(self):
-        """The _changelog_handler invokes run_changelog_iteration with bot and llm_call."""
+        """The _changelog_handler invokes run_changelog_iteration with bot, llm_call, and config."""
         session = MagicMock()
         bot = MagicMock()
         llm_call = AsyncMock()
@@ -143,11 +161,15 @@ class TestChangelogHandlerReturnValue:
             patch(
                 "chat.changelog.run_changelog_iteration", new_callable=AsyncMock
             ) as mock_iter,
+            patch.dict("os.environ", {"CHANGELOG_CONFIGS": _TEST_CHANGELOG_CONFIGS}),
         ):
             summarizer.on_startup(session, bot=bot, llm_call=llm_call)
-            await captured_handlers["chat.changelog"](session)
+            await captured_handlers["chat.changelog.test"](session)
 
         mock_iter.assert_called_once()
         args, kwargs = mock_iter.call_args
-        assert args == (bot, llm_call)
+        assert args[0] is bot
+        assert args[1] is llm_call
+        assert isinstance(args[2], ChangelogConfig)
+        assert args[2].name == "test"
         assert callable(kwargs.get("store_message"))

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.46.0
+      targetRevision: 0.46.1
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.45.1
+      targetRevision: 0.46.0
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/deploy/values.yaml
+++ b/projects/monolith/deploy/values.yaml
@@ -92,10 +92,22 @@ chat:
   llamaCppUrl: "http://llama-cpp.llama-cpp.svc.cluster.local:8080"
   embeddingUrl: "http://llama-cpp-embeddings.llama-cpp.svc.cluster.local:8080"
   searxngUrl: "http://monolith-searxng:8080"
-  changelog:
-    enabled: true
-    channelId: "1491186550472708117"
-    githubRepo: "jomcgi/homelab"
+  changelogs:
+    - name: "homelab"
+      channelId: "1491186550472708117"
+      githubRepo: "jomcgi/homelab"
+      prompt: "professional"
+      embedTitle: "Homelab Changelog"
+      embedColor: "0x2ECC71"
+      intervalHours: 1
+      commitFilter: "^(feat)(\\(.+?\\))?!?:\\s"
+    - name: "roast"
+      channelId: "1491186550472708117"
+      githubRepo: "ColinCee/homelab"
+      prompt: "roast"
+      embedTitle: "Colin's Homelab Roast"
+      embedColor: "0xE74C3C"
+      intervalHours: 3
   onepassword:
     itemPath: "vaults/k8s-homelab/items/discord-bot"
 


### PR DESCRIPTION
## Summary

- Generalizes the changelog system from a single hardcoded config to a list-based `CHANGELOG_CONFIGS` JSON env var
- Adds a roast changelog for `ColinCee/homelab` — posts every 3h to the same Discord channel with a roasting prompt
- Refactors `run_changelog_iteration` to accept a `ChangelogConfig` dataclass instead of reading env vars
- Prompts are registered by key in Python (`professional` + `roast`), referenced from Helm values
- Adding a new repo changelog is now a single values.yaml entry — no Python changes needed
- Bumps chart version to 0.46.0

## Test plan

- [ ] Verify `bb remote test //projects/monolith:changelog_test --config=ci` passes (BuildBuddy infra was down during dev — all pre-commit hooks passed)
- [ ] Verify `helm template` renders `CHANGELOG_CONFIGS` JSON correctly
- [ ] After deploy, verify professional changelog still posts hourly
- [ ] After deploy, verify roast changelog posts every 3h for ColinCee/homelab

🤖 Generated with [Claude Code](https://claude.com/claude-code)