### PR TITLE
fix(monolith): revert chart version 1.0.0 to 0.49.0

### DIFF
--- a/bazel/helm/chart-version.sh
+++ b/bazel/helm/chart-version.sh
@@ -68,9 +68,16 @@ while IFS= read -r subject; do
 	esac
 
 	# Check for breaking change (! before colon)
+	# Pre-1.0: breaking changes bump minor (semver allows breaking changes in 0.x)
+	# Post-1.0: breaking changes bump major
 	BREAKING_RE='^[a-z]+(\([^)]*\))?!:'
 	if [[ "$subject" =~ $BREAKING_RE ]]; then
-		BUMP="major"
+		IFS='.' read -r CUR_MAJOR _ _ <<<"$CURRENT_VERSION"
+		if [[ "$CUR_MAJOR" -ge 1 ]]; then
+			BUMP="major"
+		else
+			BUMP="minor"
+		fi
 		break # Can't go higher
 	fi
 

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 1.0.0
+version: 0.49.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 1.0.0
+      targetRevision: 0.49.0
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
## Summary

- Reverts monolith chart version from `1.0.0` to `0.49.0` — the `1.0.0` was an incorrect major bump by chart-version-bot on a `refactor!:` commit
- Fixes `chart-version.sh` to treat breaking changes (`!:`) as minor bumps when the current major version is `0` (per semver, pre-1.0 allows breaking changes without a major bump)
- Deleted the `1.0.0` tag from GHCR

## Test plan

- [ ] CI passes
- [ ] ArgoCD picks up `0.49.0` chart and syncs monolith successfully
- [ ] Future `!:` commits on pre-1.0 charts bump minor, not major

🤖 Generated with [Claude Code](https://claude.com/claude-code)