### PR TITLE
fix(monolith): configure MCP server with SSE transport

### DIFF
--- a/projects/monolith/app/main.py
+++ b/projects/monolith/app/main.py
@@ -158,19 +158,28 @@ async def lifespan(app: FastAPI):
     logger.info("Monolith shutting down")
 
 
-app = FastAPI(title="Monolith", lifespan=lifespan)
+import knowledge.mcp  # noqa: F401 — registers tools on shared MCP instance
+
+from app.mcp_app import mcp as monolith_mcp
+
+_mcp_app = monolith_mcp.http_app(transport="sse", path="/")
+
+
+@asynccontextmanager
+async def _combined_lifespan(app: FastAPI):
+    async with lifespan(app):
+        async with _mcp_app.lifespan(app):
+            yield
+
+
+app = FastAPI(title="Monolith", lifespan=_combined_lifespan)
 
 app.include_router(schedule_router)
 app.include_router(chat_router)
 app.include_router(knowledge_router)
 app.include_router(tasks_router)
 app.include_router(observability_router)
-
-import knowledge.mcp  # noqa: F401 — registers tools on shared MCP instance
-
-from app.mcp_app import mcp as monolith_mcp
-
-app.mount("/mcp", monolith_mcp.http_app())
+app.mount("/mcp", _mcp_app)
 
 
 @app.get("/healthz")

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.49.0
+version: 0.49.1
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.49.0
+      targetRevision: 0.49.1
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
## Summary
- Fixed MCP endpoint returning 502 when connecting from Context Forge
- Set `transport="sse"` on `http_app()` (was defaulting to `'http'` which Context Forge doesn't support)
- Fixed path double-nesting: `path="/"` + mount at `/mcp` (was `/mcp/mcp`)
- Composed MCP lifespan with app lifespan for proper session management

## Test plan
- [ ] CI passes
- [ ] Port-forward to monolith backend and verify `/mcp/sse` responds with SSE stream
- [ ] Add `http://monolith.monolith.svc.cluster.local:8000/mcp/sse` to Context Forge with SSE transport
- [ ] Verify MCP tools (search_knowledge, get_note, etc.) are discoverable

🤖 Generated with [Claude Code](https://claude.com/claude-code)