### PR TITLE
feat(monolith): add task management MCP tools

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.49.3
+version: 0.50.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.49.3
+      targetRevision: 0.50.0
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/knowledge/mcp.py
+++ b/projects/monolith/knowledge/mcp.py
@@ -1,7 +1,9 @@
-"""MCP tools for knowledge graph search and note retrieval.
+"""MCP tools for knowledge graph search, note management, and task tracking.
 
-Registers ``search_knowledge``, ``get_note``, ``create_note``,
-``edit_note``, and ``delete_note`` on the shared monolith MCP instance.
+Registers note tools (``search_knowledge``, ``get_note``, ``create_note``,
+``edit_note``, ``delete_note``) and task tools (``list_tasks``,
+``search_tasks``, ``update_task``, ``get_daily_tasks``, ``get_weekly_tasks``)
+on the shared monolith MCP instance.
 Tools call KnowledgeStore directly (no HTTP round-trip).
 """
 
@@ -223,3 +225,124 @@ async def delete_note(note_id: str) -> dict:
 
         store.delete_note(note["path"])
         return {"deleted": True, "note_id": note_id}
+
+
+# ---------------------------------------------------------------------------
+# Task tools
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool
+async def list_tasks(
+    status: str | None = None,
+    due_before: str | None = None,
+    due_after: str | None = None,
+    size: str | None = None,
+    include_someday: bool = False,
+) -> dict:
+    """List tasks with optional filters.
+
+    Returns tasks sorted by most recently indexed. Someday tasks are
+    excluded by default.
+
+    Args:
+        status: Comma-separated status filter (e.g. "todo,in-progress").
+        due_before: ISO date — only tasks due on or before this date.
+        due_after: ISO date — only tasks due on or after this date.
+        size: Comma-separated size filter (e.g. "small,medium").
+        include_someday: Include tasks with status "someday" (default false).
+    """
+    with Session(get_engine()) as session:
+        tasks = KnowledgeStore(session).list_tasks(
+            statuses=status.split(",") if status else None,
+            due_before=due_before,
+            due_after=due_after,
+            sizes=size.split(",") if size else None,
+            include_someday=include_someday,
+        )
+    return {"tasks": tasks}
+
+
+@mcp.tool
+async def search_tasks(
+    query: str,
+    status: str | None = None,
+    include_someday: bool = False,
+    limit: int = 20,
+) -> dict:
+    """Semantic search over tasks.
+
+    Embeds the query and searches task notes by cosine similarity.
+
+    Args:
+        query: Natural language search query (minimum 2 characters).
+        status: Comma-separated status filter (e.g. "todo,in-progress").
+        include_someday: Include tasks with status "someday" (default false).
+        limit: Maximum results to return (default 20).
+    """
+    if len(query) < 2:
+        return {"tasks": []}
+
+    embed_client = EmbeddingClient()
+    try:
+        vector = await embed_client.embed(query)
+    except Exception:
+        logger.exception("tasks mcp: embedding call failed")
+        return {"error": "embedding unavailable"}
+
+    with Session(get_engine()) as session:
+        tasks = KnowledgeStore(session).search_tasks(
+            query_embedding=vector,
+            statuses=status.split(",") if status else None,
+            include_someday=include_someday,
+            limit=limit,
+        )
+    return {"tasks": tasks}
+
+
+@mcp.tool
+async def update_task(
+    note_id: str,
+    fields: dict,
+) -> dict:
+    """Update fields on a task.
+
+    Merges the provided fields into the task's metadata. Automatically
+    sets ``task-completed`` date when status transitions to done/cancelled,
+    and clears it when moving away from those statuses.
+
+    Args:
+        note_id: The stable task identifier.
+        fields: Dictionary of fields to update (e.g. {"status": "done"}).
+    """
+    with Session(get_engine()) as session:
+        store = KnowledgeStore(session)
+        try:
+            store.patch_task(note_id, fields)
+        except ValueError as exc:
+            return {"error": str(exc)}
+    return {"updated": True, "note_id": note_id}
+
+
+@mcp.tool
+async def get_daily_tasks() -> dict:
+    """Get tasks due today or overdue.
+
+    Returns tasks with a due date on or before today, excluding
+    someday tasks.
+    """
+    with Session(get_engine()) as session:
+        tasks = KnowledgeStore(session).list_tasks_daily()
+    return {"tasks": tasks}
+
+
+@mcp.tool
+async def get_weekly_tasks() -> dict:
+    """Get tasks due this week.
+
+    Returns tasks with a due date between now and the end of the
+    current week (Sunday), excluding someday tasks.
+    """
+    with Session(get_engine()) as session:
+        tasks = KnowledgeStore(session).list_tasks_weekly()
+    return {"tasks": tasks}

--- a/projects/monolith/knowledge/mcp_test.py
+++ b/projects/monolith/knowledge/mcp_test.py
@@ -1,4 +1,4 @@
-"""Unit tests for knowledge/mcp.py — MCP tools for knowledge search and retrieval."""
+"""Unit tests for knowledge/mcp.py — MCP tools for knowledge search, notes, and tasks."""
 
 from __future__ import annotations
 
@@ -10,8 +10,13 @@ from knowledge.mcp import (
     create_note,
     delete_note,
     edit_note,
+    get_daily_tasks,
     get_note,
+    get_weekly_tasks,
+    list_tasks,
     search_knowledge,
+    search_tasks,
+    update_task,
 )
 
 FAKE_EMBEDDING = [0.1] * 1024
@@ -349,3 +354,206 @@ class TestDeleteNoteTool:
         MockStore.return_value.delete_note.assert_called_once_with(
             "papers/attention.md"
         )
+
+
+# ---------------------------------------------------------------------------
+# Task tool tests
+# ---------------------------------------------------------------------------
+
+CANNED_TASKS = [
+    {
+        "note_id": "t1",
+        "title": "Fix auth bug",
+        "tags": ["backend"],
+        "status": "todo",
+        "due": "2026-04-20",
+        "size": "small",
+        "blocked_by": [],
+        "task_completed": None,
+    },
+]
+
+
+class TestListTasks:
+    """Tests for the list_tasks MCP tool."""
+
+    @pytest.mark.asyncio
+    async def test_returns_tasks(self):
+        mock_session = MagicMock()
+        with (
+            patch("knowledge.mcp.Session", return_value=mock_session),
+            patch("knowledge.mcp.get_engine"),
+            patch("knowledge.mcp.KnowledgeStore") as MockStore,
+        ):
+            MockStore.return_value.list_tasks.return_value = CANNED_TASKS
+            result = await list_tasks()
+
+        assert len(result["tasks"]) == 1
+        assert result["tasks"][0]["note_id"] == "t1"
+        MockStore.return_value.list_tasks.assert_called_once_with(
+            statuses=None,
+            due_before=None,
+            due_after=None,
+            sizes=None,
+            include_someday=False,
+        )
+
+    @pytest.mark.asyncio
+    async def test_forwards_filters(self):
+        mock_session = MagicMock()
+        with (
+            patch("knowledge.mcp.Session", return_value=mock_session),
+            patch("knowledge.mcp.get_engine"),
+            patch("knowledge.mcp.KnowledgeStore") as MockStore,
+        ):
+            MockStore.return_value.list_tasks.return_value = []
+            await list_tasks(
+                status="todo,in-progress",
+                due_before="2026-04-25",
+                due_after="2026-04-18",
+                size="small,medium",
+                include_someday=True,
+            )
+
+            MockStore.return_value.list_tasks.assert_called_once_with(
+                statuses=["todo", "in-progress"],
+                due_before="2026-04-25",
+                due_after="2026-04-18",
+                sizes=["small", "medium"],
+                include_someday=True,
+            )
+
+
+class TestSearchTasks:
+    """Tests for the search_tasks MCP tool."""
+
+    @pytest.mark.asyncio
+    async def test_returns_results(self):
+        mock_session = MagicMock()
+        mock_embed = AsyncMock()
+        mock_embed.embed.return_value = FAKE_EMBEDDING
+
+        with (
+            patch("knowledge.mcp.Session", return_value=mock_session),
+            patch("knowledge.mcp.get_engine"),
+            patch("knowledge.mcp.EmbeddingClient", return_value=mock_embed),
+            patch("knowledge.mcp.KnowledgeStore") as MockStore,
+        ):
+            MockStore.return_value.search_tasks.return_value = CANNED_TASKS
+            result = await search_tasks("fix auth")
+
+        assert len(result["tasks"]) == 1
+        assert result["tasks"][0]["note_id"] == "t1"
+
+    @pytest.mark.asyncio
+    async def test_short_query_returns_empty(self):
+        result = await search_tasks("a")
+        assert result == {"tasks": []}
+
+    @pytest.mark.asyncio
+    async def test_forwards_filters(self):
+        mock_session = MagicMock()
+        mock_embed = AsyncMock()
+        mock_embed.embed.return_value = FAKE_EMBEDDING
+
+        with (
+            patch("knowledge.mcp.Session", return_value=mock_session),
+            patch("knowledge.mcp.get_engine"),
+            patch("knowledge.mcp.EmbeddingClient", return_value=mock_embed),
+            patch("knowledge.mcp.KnowledgeStore") as MockStore,
+        ):
+            MockStore.return_value.search_tasks.return_value = []
+            await search_tasks(
+                "auth", status="todo,in-progress", include_someday=True, limit=5
+            )
+
+            MockStore.return_value.search_tasks.assert_called_once_with(
+                query_embedding=FAKE_EMBEDDING,
+                statuses=["todo", "in-progress"],
+                include_someday=True,
+                limit=5,
+            )
+
+    @pytest.mark.asyncio
+    async def test_embedding_failure_returns_error(self):
+        mock_embed = AsyncMock()
+        mock_embed.embed.side_effect = RuntimeError("boom")
+
+        with (
+            patch("knowledge.mcp.Session"),
+            patch("knowledge.mcp.get_engine"),
+            patch("knowledge.mcp.EmbeddingClient", return_value=mock_embed),
+        ):
+            result = await search_tasks("hello world")
+
+        assert "error" in result
+
+
+class TestUpdateTask:
+    """Tests for the update_task MCP tool."""
+
+    @pytest.mark.asyncio
+    async def test_successful_update(self):
+        mock_session = MagicMock()
+        with (
+            patch("knowledge.mcp.Session", return_value=mock_session),
+            patch("knowledge.mcp.get_engine"),
+            patch("knowledge.mcp.KnowledgeStore") as MockStore,
+        ):
+            result = await update_task("t1", {"status": "done"})
+
+        assert result == {"updated": True, "note_id": "t1"}
+        MockStore.return_value.patch_task.assert_called_once_with(
+            "t1", {"status": "done"}
+        )
+
+    @pytest.mark.asyncio
+    async def test_not_found_returns_error(self):
+        mock_session = MagicMock()
+        with (
+            patch("knowledge.mcp.Session", return_value=mock_session),
+            patch("knowledge.mcp.get_engine"),
+            patch("knowledge.mcp.KnowledgeStore") as MockStore,
+        ):
+            MockStore.return_value.patch_task.side_effect = ValueError(
+                "Task not found: nope"
+            )
+            result = await update_task("nope", {"status": "done"})
+
+        assert result == {"error": "Task not found: nope"}
+
+
+class TestGetDailyTasks:
+    """Tests for the get_daily_tasks MCP tool."""
+
+    @pytest.mark.asyncio
+    async def test_returns_daily_tasks(self):
+        mock_session = MagicMock()
+        with (
+            patch("knowledge.mcp.Session", return_value=mock_session),
+            patch("knowledge.mcp.get_engine"),
+            patch("knowledge.mcp.KnowledgeStore") as MockStore,
+        ):
+            MockStore.return_value.list_tasks_daily.return_value = CANNED_TASKS
+            result = await get_daily_tasks()
+
+        assert len(result["tasks"]) == 1
+        MockStore.return_value.list_tasks_daily.assert_called_once()
+
+
+class TestGetWeeklyTasks:
+    """Tests for the get_weekly_tasks MCP tool."""
+
+    @pytest.mark.asyncio
+    async def test_returns_weekly_tasks(self):
+        mock_session = MagicMock()
+        with (
+            patch("knowledge.mcp.Session", return_value=mock_session),
+            patch("knowledge.mcp.get_engine"),
+            patch("knowledge.mcp.KnowledgeStore") as MockStore,
+        ):
+            MockStore.return_value.list_tasks_weekly.return_value = CANNED_TASKS
+            result = await get_weekly_tasks()
+
+        assert len(result["tasks"]) == 1
+        MockStore.return_value.list_tasks_weekly.assert_called_once()


### PR DESCRIPTION
## Summary
- Adds 5 new MCP tools for task tracking: `list_tasks`, `search_tasks`, `update_task`, `get_daily_tasks`, `get_weekly_tasks`
- Mirrors existing REST endpoints at `/api/knowledge/tasks`, calling KnowledgeStore directly (no HTTP round-trip)
- Follows the same patterns as the existing note MCP tools in `knowledge/mcp.py`

## Test plan
- [ ] CI passes (`knowledge_mcp_test` target)
- [ ] Verify new tools appear in monolith MCP tool listing after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)