### PR TITLE
fix(gardener): revert GARDENER_VERSION to v1

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.49.2
+version: 0.49.3
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.49.2
+      targetRevision: 0.49.3
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/knowledge/gardener.py
+++ b/projects/monolith/knowledge/gardener.py
@@ -24,7 +24,7 @@ _EXCLUDED_DIRS = {"_processed", "_raw", ".obsidian", ".trash"}
 
 # Version stamp recorded on every provenance row the gardener produces.
 # Bump this when the prompt or model changes to trigger a manual reprocess.
-GARDENER_VERSION = "claude-sonnet-4-6@v2"
+GARDENER_VERSION = "claude-sonnet-4-6@v1"
 
 _SLUG_RE = re.compile(r"[^a-z0-9]+")
 


### PR DESCRIPTION
## Summary

- Reverts accidental `GARDENER_VERSION` bump from `v1` to `v2` introduced in the task note emission commit
- The bump caused 163 raws to be queued for unnecessary reprocessing (~17 gardener cycles)
- The ~10 raws already reprocessed with `v2` will get one more pass — no harm done

## Test plan

- [ ] CI passes
- [ ] Gardener stops logging "163 raws need decomposition"

🤖 Generated with [Claude Code](https://claude.com/claude-code)