### PR TITLE
feat(monolith): add /api/public/stats endpoint with async k8s client

### DIFF
--- a/bazel/requirements/all.txt
+++ b/bazel/requirements/all.txt
@@ -148,6 +148,7 @@ aiohttp==3.13.5 \
     #   -c bazel/requirements/runtime.txt
     #   -r bazel/requirements/runtime.txt
     #   discord-py
+    #   kubernetes-asyncio
 aiosignal==1.4.0 \
     --hash=sha256:053243f8b92b990551949e63930a839ff0cf0b0ebbe0597b0f3fb19e1a0fe82e \
     --hash=sha256:f47eecd9468083c2029cc99945502cb7708b082c232f9aca65da147157b251c7
@@ -517,6 +518,7 @@ certifi==2026.2.25 \
     #   -r bazel/requirements/runtime.txt
     #   httpcore
     #   httpx
+    #   kubernetes-asyncio
     #   pyogrio
     #   pyproj
     #   rasterio
@@ -1765,6 +1767,12 @@ keyring==25.7.0 \
     #   -c bazel/requirements/runtime.txt
     #   -r bazel/requirements/runtime.txt
     #   py-key-value-aio
+kubernetes-asyncio==35.0.1 \
+    --hash=sha256:244ef45943e89c5c5104276a646bfcbf1a9dc3d060876c2094aa601e932f1c03 \
+    --hash=sha256:975870e3097b647c265a59b9175ab0841f0de06cd2162268273ca210b1fa672e
+    # via
+    #   -c bazel/requirements/runtime.txt
+    #   -r bazel/requirements/runtime.txt
 logfire-api==4.31.0 \
     --hash=sha256:3c1f502fd4eb8ef0996427a5cf275fd8f327f38600650a1f53071a8171c812db \
     --hash=sha256:fc4b01257ebd4ce297ad374ed201eb1a9213b999f6ae6df45cfca5bd0ef378f8
@@ -3716,6 +3724,7 @@ python-dateutil==2.9.0.post0 \
     #   htmldate
     #   icalendar
     #   jsii
+    #   kubernetes-asyncio
     #   pandas
     #   sqlite-utils
 python-dotenv==1.2.2 \
@@ -3858,6 +3867,7 @@ pyyaml==6.0.3 \
     #   huggingface-hub
     #   jinja2-ansible-filters
     #   jsonschema-path
+    #   kubernetes-asyncio
     #   uvicorn
 questionary==2.1.1 \
     --hash=sha256:3d7e980292bb0107abaa79c68dd3eee3c561b83a0f89ae482860b181c8bd412d \
@@ -4368,6 +4378,7 @@ six==1.17.0 \
     # via
     #   -c bazel/requirements/runtime.txt
     #   -r bazel/requirements/runtime.txt
+    #   kubernetes-asyncio
     #   parse-type
     #   python-dateutil
 sniffio==1.3.1 \
@@ -4749,6 +4760,7 @@ urllib3==2.6.3 \
     #   courlan
     #   dulwich
     #   htmldate
+    #   kubernetes-asyncio
     #   requests
     #   requests-cache
     #   semgrep

--- a/bazel/requirements/runtime.txt
+++ b/bazel/requirements/runtime.txt
@@ -138,6 +138,7 @@ aiohttp==3.13.5 \
     # via
     #   homelab (pyproject.toml)
     #   discord-py
+    #   kubernetes-asyncio
 aiosignal==1.4.0 \
     --hash=sha256:053243f8b92b990551949e63930a839ff0cf0b0ebbe0597b0f3fb19e1a0fe82e \
     --hash=sha256:f47eecd9468083c2029cc99945502cb7708b082c232f9aca65da147157b251c7
@@ -432,6 +433,7 @@ certifi==2026.2.25 \
     #   homelab (pyproject.toml)
     #   httpcore
     #   httpx
+    #   kubernetes-asyncio
     #   pyogrio
     #   pyproj
     #   rasterio
@@ -1481,6 +1483,10 @@ keyring==25.7.0 \
     --hash=sha256:be4a0b195f149690c166e850609a477c532ddbfbaed96a404d4e43f8d5e2689f \
     --hash=sha256:fe01bd85eb3f8fb3dd0405defdeac9a5b4f6f0439edbb3149577f244a2e8245b
     # via py-key-value-aio
+kubernetes-asyncio==35.0.1 \
+    --hash=sha256:244ef45943e89c5c5104276a646bfcbf1a9dc3d060876c2094aa601e932f1c03 \
+    --hash=sha256:975870e3097b647c265a59b9175ab0841f0de06cd2162268273ca210b1fa672e
+    # via homelab (pyproject.toml)
 logfire-api==4.31.0 \
     --hash=sha256:3c1f502fd4eb8ef0996427a5cf275fd8f327f38600650a1f53071a8171c812db \
     --hash=sha256:fc4b01257ebd4ce297ad374ed201eb1a9213b999f6ae6df45cfca5bd0ef378f8
@@ -3201,6 +3207,7 @@ python-dateutil==2.9.0.post0 \
     #   htmldate
     #   icalendar
     #   jsii
+    #   kubernetes-asyncio
     #   pandas
     #   sqlite-utils
 python-dotenv==1.2.2 \
@@ -3328,6 +3335,7 @@ pyyaml==6.0.3 \
     #   fastmcp
     #   huggingface-hub
     #   jsonschema-path
+    #   kubernetes-asyncio
     #   uvicorn
 rasterio==1.5.0 \
     --hash=sha256:015c1ab6e5453312c5e29692752e7ad73568fe4d13567cbd448d7893128cbd2d \
@@ -3723,6 +3731,7 @@ six==1.17.0 \
     --hash=sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274 \
     --hash=sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81
     # via
+    #   kubernetes-asyncio
     #   parse-type
     #   python-dateutil
 sniffio==1.3.1 \
@@ -4032,6 +4041,7 @@ urllib3==2.6.3 \
     #   courlan
     #   dulwich
     #   htmldate
+    #   kubernetes-asyncio
     #   requests
     #   requests-cache
     #   trafilatura

--- a/docs/plans/2026-04-18-stats-endpoint-design.md
+++ b/docs/plans/2026-04-18-stats-endpoint-design.md
@@ -1,0 +1,100 @@
+# Design: Public Stats Endpoint + Kubernetes Client
+
+**Date:** 2026-04-18
+**Status:** Approved
+
+## Goal
+
+Add a `/api/public/stats` endpoint to the monolith that exposes non-sensitive cluster and knowledge-graph metrics. Provides a live window into the platform for the repo README and external visitors.
+
+Secondary goal: introduce a reusable async Kubernetes client to the monolith, positioned for future observability MCP tooling.
+
+## Architecture
+
+```
+monolith/
+├── shared/
+│   └── kubernetes.py          # Async k8s client wrapper (reusable)
+└── observability/
+    ├── stats.py               # Stats collection + caching
+    └── router.py              # Register /api/public/stats route
+```
+
+### Kubernetes Client (`shared/kubernetes.py`)
+
+Thin wrapper around `kubernetes_asyncio`. In-cluster config, scoped to read-only list operations. Lives in `shared/` for reuse by future observability MCP.
+
+Interface:
+
+```python
+class KubernetesClient:
+    async def count_nodes() -> int
+    async def count_deployments() -> int
+    async def count_pods() -> int
+    async def count_argocd_applications() -> int
+```
+
+### Stats Endpoint (`observability/stats.py`)
+
+Gathers stats from two sources:
+
+1. **Kubernetes API** — node, deployment, pod, ArgoCD application counts
+2. **PostgreSQL** — knowledge.notes, knowledge.chunks, knowledge.raw_inputs counts
+
+Response shape:
+
+```json
+{
+  "cluster": {
+    "nodes": 4,
+    "deployments": 64,
+    "services": 28,
+    "pods": 135
+  },
+  "knowledge": {
+    "facts": 1309,
+    "chunks": 5948,
+    "raw_inputs": 366
+  },
+  "platform": {
+    "in_production_since": "2025-01"
+  },
+  "cached_at": "2026-04-18T14:30:00Z"
+}
+```
+
+### Caching
+
+24h TTL, same pattern as topology endpoint. Warm-loaded on startup via lifespan. No manual refresh endpoint — wait for TTL expiry.
+
+### RBAC
+
+ClusterRole for monolith ServiceAccount:
+
+```yaml
+rules:
+  - apiGroups: [""]
+    resources: ["nodes", "pods"]
+    verbs: ["list"]
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["list"]
+  - apiGroups: ["argoproj.io"]
+    resources: ["applications"]
+    verbs: ["list"]
+```
+
+### Dependencies
+
+- `kubernetes-asyncio` added to monolith Python deps (pip + Bazel `@pip//kubernetes_asyncio`)
+
+## Deferred
+
+- Ships vessel count (needs HTTP client to ships backend — ships will eventually move into monolith)
+- Agent job counts (needs NATS or orchestrator API — same)
+- Observability MCP server (future work, k8s client is designed for it)
+
+## Testing
+
+- Unit tests for stats collection with mocked k8s client and DB session
+- Integration test via `bb remote test`

--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -66,6 +66,7 @@ py_library(
         "@pip//fastmcp",
         "@pip//httpx",
         "@pip//icalendar",
+        "@pip//kubernetes_asyncio",
         "@pip//lxml_html_clean",  # explicit: overrides.txt strips lxml[html-clean] extra
         "@pip//opentelemetry_exporter_otlp_proto_http",
         "@pip//opentelemetry_instrumentation_fastapi",
@@ -2363,4 +2364,28 @@ semgrep_target_test(
     ],
     rules = ["//bazel/semgrep/rules:python_rules"],
     target = ":main",
+)
+
+py_test(
+    name = "stats_test",
+    srcs = ["observability/stats_test.py"],
+    imports = ["."],
+    deps = [
+        ":monolith_backend",
+        "@pip//pytest",
+        "@pip//pytest_asyncio",
+        "@pip//sqlmodel",
+    ],
+)
+
+py_test(
+    name = "kubernetes_client_test",
+    srcs = ["shared/kubernetes_test.py"],
+    imports = ["."],
+    deps = [
+        ":monolith_backend",
+        "@pip//kubernetes_asyncio",
+        "@pip//pytest",
+        "@pip//pytest_asyncio",
+    ],
 )

--- a/projects/monolith/app/main.py
+++ b/projects/monolith/app/main.py
@@ -14,7 +14,11 @@ from knowledge.router import router as knowledge_router
 from knowledge.tasks_router import router as tasks_router
 from chat.router import router as chat_router
 from shared.router import router as schedule_router
-from observability.router import router as observability_router, warm_cache
+from observability.router import (
+    router as observability_router,
+    warm_cache,
+    warm_stats_cache,
+)
 
 configure_logging()
 logger = logging.getLogger("monolith.main")
@@ -143,6 +147,13 @@ async def lifespan(app: FastAPI):
         await warm_cache()
     except Exception:
         logger.exception("Initial topology cache warm failed — continuing anyway")
+
+    # Warm the public stats cache (k8s + knowledge counts).
+    # Non-blocking: failures are logged but don't prevent startup.
+    try:
+        await warm_stats_cache()
+    except Exception:
+        logger.exception("Initial stats cache warm failed — continuing anyway")
 
     logger.info("Monolith started")
     yield

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.50.1
+version: 0.51.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/templates/deployment.yaml
+++ b/projects/monolith/chart/templates/deployment.yaml
@@ -22,6 +22,7 @@ spec:
         app.kubernetes.io/component: app
       annotations: {}
     spec:
+      serviceAccountName: {{ include "monolith.fullname" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/projects/monolith/chart/templates/rbac.yaml
+++ b/projects/monolith/chart/templates/rbac.yaml
@@ -1,0 +1,31 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "monolith.fullname" . }}
+  labels:
+    {{- include "monolith.labels" . | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources: ["nodes", "pods"]
+    verbs: ["list"]
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["list"]
+  - apiGroups: ["argoproj.io"]
+    resources: ["applications"]
+    verbs: ["list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "monolith.fullname" . }}
+  labels:
+    {{- include "monolith.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "monolith.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "monolith.fullname" . }}
+    namespace: {{ .Release.Namespace }}

--- a/projects/monolith/chart/templates/serviceaccount.yaml
+++ b/projects/monolith/chart/templates/serviceaccount.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "monolith.fullname" . }}
+  labels:
+    {{- include "monolith.labels" . | nindent 4 }}

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.50.1
+      targetRevision: 0.51.0
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/observability/router.py
+++ b/projects/monolith/observability/router.py
@@ -15,6 +15,7 @@ from observability.slo import (
     compute_budget,
     compute_status,
 )
+from observability.stats import get_cached_stats, warm_stats_cache
 from observability.topology_config import TOPOLOGY
 
 logger = logging.getLogger(__name__)
@@ -240,6 +241,12 @@ async def warm_cache() -> None:
     _cache = result
     _cache_time = time.monotonic()
     logger.info("Topology cache warmed (%d nodes)", len(result.get("nodes", [])))
+
+
+@router.get("/stats", tags=["stats"])
+async def get_stats():
+    """Return public platform stats, cached for 24 hours."""
+    return await get_cached_stats()
 
 
 @router.get("/topology")

--- a/projects/monolith/observability/stats.py
+++ b/projects/monolith/observability/stats.py
@@ -1,0 +1,112 @@
+"""Public stats endpoint — exposes non-sensitive cluster and knowledge metrics.
+
+Gathers data from two sources:
+1. Kubernetes API — node, deployment, pod, ArgoCD application counts
+2. PostgreSQL — knowledge.notes, knowledge.chunks, knowledge.raw_inputs counts
+
+Cached for 24 hours; warmed on startup via lifespan.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from datetime import datetime, timezone
+
+from sqlalchemy import text
+
+from app.db import get_engine
+from shared.kubernetes import KubernetesClient
+
+logger = logging.getLogger(__name__)
+
+_CACHE_TTL = 86400  # 24 hours
+_cache: dict | None = None
+_cache_time: float = 0.0
+
+
+async def _query_knowledge_counts(engine) -> dict:
+    """Query knowledge graph table counts from PostgreSQL."""
+    queries = {
+        "facts": "SELECT count(*) FROM knowledge.notes",
+        "chunks": "SELECT count(*) FROM knowledge.chunks",
+        "raw_inputs": "SELECT count(*) FROM knowledge.raw_inputs",
+    }
+    counts = {}
+    from sqlmodel import Session
+
+    with Session(engine) as session:
+        for key, query in queries.items():
+            try:
+                result = session.exec(text(query)).one()
+                counts[key] = result[0]
+            except Exception:
+                logger.exception("Failed to query %s count", key)
+                counts[key] = 0
+    return counts
+
+
+async def _query_cluster_counts() -> dict:
+    """Query Kubernetes cluster resource counts."""
+    k8s = KubernetesClient()
+    try:
+        nodes, deployments, pods, argo_apps = await asyncio.gather(
+            k8s.count_nodes(),
+            k8s.count_deployments(),
+            k8s.count_pods(),
+            k8s.count_argocd_applications(),
+            return_exceptions=True,
+        )
+        return {
+            "nodes": nodes if not isinstance(nodes, Exception) else 0,
+            "deployments": deployments if not isinstance(deployments, Exception) else 0,
+            "pods": pods if not isinstance(pods, Exception) else 0,
+            "argocd_apps": argo_apps if not isinstance(argo_apps, Exception) else 0,
+        }
+    finally:
+        await k8s.close()
+
+
+async def build_stats() -> dict:
+    """Collect all stats and return the response payload."""
+    engine = get_engine()
+
+    cluster_counts, knowledge_counts = await asyncio.gather(
+        _query_cluster_counts(),
+        _query_knowledge_counts(engine),
+    )
+
+    return {
+        "cluster": cluster_counts,
+        "knowledge": knowledge_counts,
+        "platform": {
+            "in_production_since": "2025-01",
+        },
+        "cached_at": datetime.now(timezone.utc).isoformat(),
+    }
+
+
+async def warm_stats_cache() -> None:
+    """Build stats and populate the module cache. Called at startup."""
+    global _cache, _cache_time
+    logger.info("Warming stats cache...")
+    try:
+        result = await build_stats()
+        _cache = result
+        _cache_time = time.monotonic()
+        logger.info("Stats cache warmed")
+    except Exception:
+        logger.exception("Stats cache warm failed — will retry on first request")
+
+
+async def get_cached_stats() -> dict:
+    """Return stats, using cache if within TTL."""
+    global _cache, _cache_time
+    now = time.monotonic()
+    if _cache is not None and (now - _cache_time) < _CACHE_TTL:
+        return _cache
+    result = await build_stats()
+    _cache = result
+    _cache_time = now
+    return result

--- a/projects/monolith/observability/stats_test.py
+++ b/projects/monolith/observability/stats_test.py
@@ -1,0 +1,116 @@
+"""Tests for the public stats endpoint."""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from observability import stats
+
+
+@pytest.fixture(autouse=True)
+def _reset_cache():
+    """Clear module-level cache between tests."""
+    stats._cache = None
+    stats._cache_time = 0.0
+    yield
+    stats._cache = None
+    stats._cache_time = 0.0
+
+
+def _mock_k8s_client():
+    """Return a mocked KubernetesClient with preset counts."""
+    mock = MagicMock()
+    mock.count_nodes = AsyncMock(return_value=4)
+    mock.count_pods = AsyncMock(return_value=135)
+    mock.count_deployments = AsyncMock(return_value=64)
+    mock.count_argocd_applications = AsyncMock(return_value=28)
+    mock.close = AsyncMock()
+    return mock
+
+
+def _mock_session():
+    """Return a mock SQLModel Session that returns preset counts."""
+    session = MagicMock()
+    call_count = 0
+    expected = [1309, 5948, 366]
+
+    def exec_side_effect(query):
+        nonlocal call_count
+        result = MagicMock()
+        result.one.return_value = (expected[call_count],)
+        call_count += 1
+        return result
+
+    session.exec = MagicMock(side_effect=exec_side_effect)
+    return session
+
+
+@pytest.mark.asyncio
+async def test_build_stats_returns_expected_shape():
+    mock_client = _mock_k8s_client()
+    mock_session = _mock_session()
+
+    with (
+        patch("observability.stats.KubernetesClient", return_value=mock_client),
+        patch("observability.stats.get_engine", return_value=MagicMock()),
+        patch("sqlmodel.Session", return_value=mock_session),
+    ):
+        mock_session.__enter__ = MagicMock(return_value=mock_session)
+        mock_session.__exit__ = MagicMock(return_value=False)
+
+        result = await stats.build_stats()
+
+    assert result["cluster"]["nodes"] == 4
+    assert result["cluster"]["pods"] == 135
+    assert result["cluster"]["deployments"] == 64
+    assert result["cluster"]["argocd_apps"] == 28
+    assert result["knowledge"]["facts"] == 1309
+    assert result["knowledge"]["chunks"] == 5948
+    assert result["knowledge"]["raw_inputs"] == 366
+    assert result["platform"]["in_production_since"] == "2025-01"
+    assert "cached_at" in result
+
+
+@pytest.mark.asyncio
+async def test_get_cached_stats_uses_cache():
+    fake_stats = {"cluster": {}, "cached_at": "test"}
+    stats._cache = fake_stats
+    stats._cache_time = time.monotonic()
+
+    result = await stats.get_cached_stats()
+    assert result is fake_stats
+
+
+@pytest.mark.asyncio
+async def test_get_cached_stats_refreshes_after_ttl():
+    fake_stats = {"cluster": {}, "cached_at": "old"}
+    stats._cache = fake_stats
+    stats._cache_time = time.monotonic() - stats._CACHE_TTL - 1
+
+    new_stats = {"cluster": {}, "cached_at": "new"}
+    with patch(
+        "observability.stats.build_stats",
+        new_callable=AsyncMock,
+        return_value=new_stats,
+    ):
+        result = await stats.get_cached_stats()
+
+    assert result["cached_at"] == "new"
+
+
+@pytest.mark.asyncio
+async def test_cluster_counts_handles_k8s_errors():
+    mock_client = _mock_k8s_client()
+    mock_client.count_nodes = AsyncMock(side_effect=Exception("k8s unreachable"))
+    mock_client.count_pods = AsyncMock(return_value=10)
+    mock_client.count_deployments = AsyncMock(return_value=5)
+    mock_client.count_argocd_applications = AsyncMock(return_value=2)
+
+    with patch("observability.stats.KubernetesClient", return_value=mock_client):
+        result = await stats._query_cluster_counts()
+
+    assert result["nodes"] == 0  # failed, falls back to 0
+    assert result["pods"] == 10

--- a/projects/monolith/shared/kubernetes.py
+++ b/projects/monolith/shared/kubernetes.py
@@ -1,0 +1,61 @@
+"""Async Kubernetes client wrapper for read-only cluster queries.
+
+Thin layer over kubernetes_asyncio. Designed for reuse by future
+observability MCP tooling — keep the interface minimal and read-only.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from kubernetes_asyncio import client, config
+from kubernetes_asyncio.client import ApiClient
+
+logger = logging.getLogger(__name__)
+
+
+class KubernetesClient:
+    """Lightweight async k8s client scoped to list operations."""
+
+    def __init__(self) -> None:
+        self._api: ApiClient | None = None
+
+    async def _ensure_client(self) -> ApiClient:
+        if self._api is None:
+            config.load_incluster_config()
+            self._api = ApiClient()
+        return self._api
+
+    async def count_nodes(self) -> int:
+        api = await self._ensure_client()
+        v1 = client.CoreV1Api(api)
+        nodes = await v1.list_node()
+        return len(nodes.items)
+
+    async def count_pods(self) -> int:
+        api = await self._ensure_client()
+        v1 = client.CoreV1Api(api)
+        pods = await v1.list_pod_for_all_namespaces()
+        return len(pods.items)
+
+    async def count_deployments(self) -> int:
+        api = await self._ensure_client()
+        apps = client.AppsV1Api(api)
+        deps = await apps.list_deployment_for_all_namespaces()
+        return len(deps.items)
+
+    async def count_argocd_applications(self) -> int:
+        api = await self._ensure_client()
+        custom = client.CustomObjectsApi(api)
+        result = await custom.list_namespaced_custom_object(
+            group="argoproj.io",
+            version="v1alpha1",
+            namespace="argocd",
+            plural="applications",
+        )
+        return len(result.get("items", []))
+
+    async def close(self) -> None:
+        if self._api:
+            await self._api.close()
+            self._api = None

--- a/projects/monolith/shared/kubernetes_test.py
+++ b/projects/monolith/shared/kubernetes_test.py
@@ -1,0 +1,69 @@
+"""Tests for the async Kubernetes client wrapper."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from shared.kubernetes import KubernetesClient
+
+
+@pytest.fixture
+def k8s_client():
+    return KubernetesClient()
+
+
+@pytest.mark.asyncio
+async def test_count_nodes(k8s_client):
+    mock_api = MagicMock()
+    mock_v1 = MagicMock()
+    mock_v1.list_node = AsyncMock(
+        return_value=MagicMock(items=[MagicMock(), MagicMock(), MagicMock()])
+    )
+
+    with (
+        patch("shared.kubernetes.config.load_incluster_config"),
+        patch("shared.kubernetes.ApiClient", return_value=mock_api),
+        patch("shared.kubernetes.client.CoreV1Api", return_value=mock_v1),
+    ):
+        count = await k8s_client.count_nodes()
+
+    assert count == 3
+
+
+@pytest.mark.asyncio
+async def test_count_argocd_applications(k8s_client):
+    mock_api = MagicMock()
+    mock_custom = MagicMock()
+    mock_custom.list_namespaced_custom_object = AsyncMock(
+        return_value={
+            "items": [{"metadata": {"name": "app1"}}, {"metadata": {"name": "app2"}}]
+        }
+    )
+
+    with (
+        patch("shared.kubernetes.config.load_incluster_config"),
+        patch("shared.kubernetes.ApiClient", return_value=mock_api),
+        patch("shared.kubernetes.client.CustomObjectsApi", return_value=mock_custom),
+    ):
+        count = await k8s_client.count_argocd_applications()
+
+    assert count == 2
+
+
+@pytest.mark.asyncio
+async def test_close_cleans_up(k8s_client):
+    mock_api = MagicMock()
+    mock_api.close = AsyncMock()
+
+    with (
+        patch("shared.kubernetes.config.load_incluster_config"),
+        patch("shared.kubernetes.ApiClient", return_value=mock_api),
+    ):
+        # Force client creation
+        await k8s_client._ensure_client()
+        await k8s_client.close()
+
+    mock_api.close.assert_called_once()
+    assert k8s_client._api is None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,8 @@ dependencies = [
     "anthropic>=0.92",
     "icalendar~=6.0",
     "tzdata",
+    # Kubernetes API client (async) — stats endpoint, future observability MCP
+    "kubernetes-asyncio>=31.0",
     # Knowledge vault git sync (pure Python, no system git binary)
     "dulwich",
     # URL ingest queue — YouTube transcripts and webpage extraction


### PR DESCRIPTION
## Summary

- Add `/api/public/observability/stats` endpoint exposing non-sensitive cluster and knowledge-graph metrics (node/deployment/pod/ArgoCD app counts, knowledge facts/chunks/raw_inputs)
- Introduce reusable async Kubernetes client (`shared/kubernetes.py`) using `kubernetes-asyncio`, designed for future observability MCP tooling
- Add RBAC: ServiceAccount, ClusterRole (read-only list), ClusterRoleBinding for the monolith deployment
- 24h TTL cache, warm-loaded on startup (same pattern as topology endpoint)
- Bump chart version to 0.51.0

## New files

| File | Purpose |
|------|---------|
| `shared/kubernetes.py` | Async k8s client wrapper (reusable) |
| `observability/stats.py` | Stats collection + caching |
| `chart/templates/rbac.yaml` | ClusterRole + ClusterRoleBinding |
| `chart/templates/serviceaccount.yaml` | ServiceAccount for k8s API access |
| `docs/plans/2026-04-18-stats-endpoint-design.md` | Design doc |

## Test plan

- [x] Unit tests for stats collection with mocked k8s client and DB session
- [x] Unit tests for KubernetesClient with mocked k8s API
- [x] Helm template renders correctly (`helm template` verified locally)
- [ ] Integration test via `bb remote test` (BuildBuddy runners currently down — JVM crash)
- [ ] Verify endpoint returns expected JSON after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)