### PR TITLE
fix(monolith): simplify roast prompt and fix heading duplication

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.50.0
+version: 0.50.1
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chat/changelog.py
+++ b/projects/monolith/chat/changelog.py
@@ -43,34 +43,20 @@ PROMPTS: dict[str, str] = {
         "Commits:\n{commits}"
     ),
     "roast": (
-        "You are Colin's close friend and a cynical senior engineer who has seen\n"
-        "too many homelabs. You're reviewing his recent git commits to roast him\n"
-        "in the group chat. He can take it — don't soften anything.\n\n"
-        "Below are his recent commits:\n"
-        "<commits>\n{commits}\n</commits>\n\n"
-        "Write a changelog-style roast. Format:\n\n"
-        "Colin homelab changelog:\n"
-        "- <entry>\n- <entry>\n- <entry>\n\n"
-        "3-5 entries. Each one is a single line written as if it's a real\n"
-        "changelog bullet, but the content is the roast. Examples of the shape:\n"
-        '- "Added three ADRs to justify turning a Beelink on."\n'
-        '- "Replaced working Grafana dashboard with a worse one. Wrote a runbook about it."\n'
-        '- "Four commits to fix one typo. Copilot did the last three."\n\n'
-        "Target specific things in the commits — pretentious messages, features\n"
-        "added then ripped out, yak-shaving, ADRs for three lines of YAML,\n"
-        "Copilot cleaning up after him, enterprise patterns on a mini-PC,\n"
-        "README brags that are one commit old, bike-shedding. Name the thing.\n\n"
+        "You are a cynical senior engineer roasting a friend's homelab commits\n"
+        "in the group chat. Don't soften anything.\n\n"
+        "Commits:\n<commits>\n{commits}\n</commits>\n\n"
+        "Write one roast entry per commit (max 5). Each entry reads like a\n"
+        "real changelog bullet, but the content is the roast. Format:\n"
+        "- <entry>\n"
+        "- <entry>\n\n"
+        'Example: "Added three config files to manage one environment variable."\n\n'
         "Rules:\n"
-        '- Past tense, declarative, changelog voice. No "Colin did X" — the\n'
-        "  entries are the changes themselves, deadpan.\n"
-        '- Punch at choices, not at him. "Docker Swarm in 2026" is fair.\n'
-        "  Personal attacks are lazy.\n"
-        "- Dry > loud. A good callback to an earlier entry beats exclamation marks.\n"
-        '- No hedging, no "but seriously", no constructive feedback.\n'
-        "- No markdown headers, no emoji, no preamble or outro. Just the header\n"
-        "  line and bullets.\n"
-        "- If a commit is genuinely boring, skip it. Don't manufacture heat.\n"
-        "Optionally end with one entry in square brackets, e.g. "
+        "- Past tense, declarative. No preamble, no markdown, no emoji.\n"
+        "- Target specific choices in the commits — don't invent things.\n"
+        '- Dry humor only. No hedging, no compliments, no "but seriously".\n'
+        "- Skip genuinely boring commits. Don't manufacture heat.\n\n"
+        "Optionally end with a bracketed aside, e.g.\n"
         "[No breaking changes. Nothing worked in the first place.]"
     ),
 }

--- a/projects/monolith/chat/changelog_test.py
+++ b/projects/monolith/chat/changelog_test.py
@@ -264,9 +264,9 @@ class TestBuildEmbed:
     def test_custom_title_and_color(self):
         """Custom title and color are used in the embed."""
         embed = _build_embed(
-            "Roast", commit_count=1, title="Colin's Homelab Roast", color=0xE74C3C
+            "Roast", commit_count=1, title="Colin's Homelab Changelog", color=0xE74C3C
         )
-        assert embed.title == "Colin's Homelab Roast"
+        assert embed.title == "Colin's Homelab Changelog"
         assert embed.colour.value == 0xE74C3C
 
 

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.50.0
+      targetRevision: 0.50.1
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/deploy/values.yaml
+++ b/projects/monolith/deploy/values.yaml
@@ -105,9 +105,9 @@ chat:
       channelId: "1491186550472708117"
       githubRepo: "ColinCee/homelab"
       prompt: "roast"
-      embedTitle: "Colin's Homelab Roast"
+      embedTitle: "Colin's Homelab Changelog"
       embedColor: "0xE74C3C"
-      intervalHours: 3
+      intervalHours: 1
   onepassword:
     itemPath: "vaults/k8s-homelab/items/discord-bot"
 


### PR DESCRIPTION
## Summary
- Rewrites the roast prompt to be ~50% shorter and more suitable for Gemma 4 (less capable model)
- Removes the redundant "Colin homelab changelog:" header from LLM output — the embed title already serves as the heading
- Scales entries to "one per commit, max 5" instead of always requesting 3-5
- Removes hardcoded "Colin" from the prompt — author names are already in the commit data
- Renames embed title from "Colin's Homelab Roast" to "Colin's Homelab Changelog"
- Sets polling interval to 1h (was 3h) to match the homelab changelog

## Test plan
- [ ] CI passes (changelog_test.py)
- [ ] Verify next Discord roast post has no duplicate heading
- [ ] Verify roast entries scale with commit count

🤖 Generated with [Claude Code](https://claude.com/claude-code)