### PR TITLE
feat(chat): randomize changelog roasts across all repos

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.51.2
+version: 0.51.3
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chat/changelog.py
+++ b/projects/monolith/chat/changelog.py
@@ -4,6 +4,7 @@ import dataclasses
 import json
 import logging
 import os
+import random
 import re
 from collections.abc import Awaitable, Callable
 from datetime import datetime, timedelta, timezone
@@ -30,6 +31,7 @@ class ChangelogConfig:
     embed_color: int
     interval_hours: int = 1
     commit_filter: re.Pattern | None = None
+    roast_chance: float = 0.0
 
 
 PROMPTS: dict[str, str] = {
@@ -84,6 +86,7 @@ def load_changelog_configs(raw: str) -> list[ChangelogConfig]:
                 else entry["embedColor"],
                 interval_hours=entry.get("intervalHours", 1),
                 commit_filter=commit_filter,
+                roast_chance=entry.get("roastChance", 0.0),
             )
         )
     return configs
@@ -190,7 +193,11 @@ async def run_changelog_iteration(
         logger.info("Changelog[%s]: commits found but none match filter", config.name)
         return
 
-    prompt_template = PROMPTS[config.prompt]
+    prompt_key = config.prompt
+    if config.roast_chance > 0 and random.random() < config.roast_chance:
+        prompt_key = "roast"
+        logger.info("Changelog[%s]: roast mode activated", config.name)
+    prompt_template = PROMPTS[prompt_key]
     summary = await _summarize_with_gemma(commits, llm_call, prompt_template)
     embed = _build_embed(
         summary, len(commits), title=config.embed_title, color=config.embed_color

--- a/projects/monolith/chat/changelog_test.py
+++ b/projects/monolith/chat/changelog_test.py
@@ -44,6 +44,7 @@ class TestChangelogConfig:
         assert configs[0].embed_color == 0x2ECC71
         assert configs[0].interval_hours == 1
         assert configs[0].commit_filter is None
+        assert configs[0].roast_chance == 0.0
 
     def test_load_configs_with_commit_filter(self):
         """commitFilter string is compiled to a regex pattern."""
@@ -73,6 +74,24 @@ class TestChangelogConfig:
     def test_load_configs_empty_string(self):
         """Empty string returns empty config list."""
         assert load_changelog_configs("") == []
+
+    def test_load_configs_with_roast_chance(self):
+        """roastChance is parsed into roast_chance float."""
+        raw = json.dumps(
+            [
+                {
+                    "name": "test",
+                    "channelId": "123",
+                    "githubRepo": "owner/repo",
+                    "prompt": "professional",
+                    "embedTitle": "Test",
+                    "embedColor": "0x2ECC71",
+                    "roastChance": 0.1,
+                }
+            ]
+        )
+        configs = load_changelog_configs(raw)
+        assert configs[0].roast_chance == 0.1
 
     def test_prompts_registry_has_professional(self):
         """PROMPTS dict contains 'professional' key."""
@@ -598,3 +617,56 @@ class TestRunChangelogIteration:
                 )
 
         store_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_roast_chance_triggers_roast_prompt(self):
+        """When random roll is below roast_chance, the roast prompt is used."""
+        mock_channel = AsyncMock()
+        bot = MagicMock(spec=discord.Client)
+        bot.get_channel.return_value = mock_channel
+        mock_llm = AsyncMock(return_value="Roasted.")
+        config = _make_config(channel_id="999", roast_chance=1.0)
+
+        commits = [_make_commit("feat: add thing", "Alice")]
+        mock_response = MagicMock()
+        mock_response.json.return_value = commits
+        mock_response.raise_for_status = MagicMock()
+
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=mock_response)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch.dict("os.environ", {"GITHUB_TOKEN": "ghp_tok"}):
+            with patch("chat.changelog.httpx.AsyncClient", return_value=mock_client):
+                await run_changelog_iteration(bot, mock_llm, config)
+
+        prompt_used = mock_llm.call_args[0][0]
+        assert "roasting" in prompt_used
+
+    @pytest.mark.asyncio
+    async def test_roast_chance_zero_uses_normal_prompt(self):
+        """When roast_chance is 0, the configured prompt is always used."""
+        mock_channel = AsyncMock()
+        bot = MagicMock(spec=discord.Client)
+        bot.get_channel.return_value = mock_channel
+        mock_llm = AsyncMock(return_value="Normal changelog.")
+        config = _make_config(channel_id="999", roast_chance=0.0)
+
+        commits = [_make_commit("feat: add thing", "Alice")]
+        mock_response = MagicMock()
+        mock_response.json.return_value = commits
+        mock_response.raise_for_status = MagicMock()
+
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=mock_response)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch.dict("os.environ", {"GITHUB_TOKEN": "ghp_tok"}):
+            with patch("chat.changelog.httpx.AsyncClient", return_value=mock_client):
+                await run_changelog_iteration(bot, mock_llm, config)
+
+        prompt_used = mock_llm.call_args[0][0]
+        assert "roasting" not in prompt_used
+        assert "changelog writer" in prompt_used

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.51.2
+      targetRevision: 0.51.3
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/deploy/values.yaml
+++ b/projects/monolith/deploy/values.yaml
@@ -101,13 +101,15 @@ chat:
       embedColor: "0x2ECC71"
       intervalHours: 1
       commitFilter: "^(feat)(\\(.+?\\))?!?:\\s"
-    - name: "roast"
+      roastChance: 0.1
+    - name: "colin-homelab"
       channelId: "1491186550472708117"
       githubRepo: "ColinCee/homelab"
-      prompt: "roast"
+      prompt: "professional"
       embedTitle: "Colin's Homelab Changelog"
-      embedColor: "0xE74C3C"
+      embedColor: "0x2ECC71"
       intervalHours: 1
+      roastChance: 0.1
   onepassword:
     itemPath: "vaults/k8s-homelab/items/discord-bot"
 


### PR DESCRIPTION
## Summary
- Replaces the dedicated always-roast config for Colin's repo with a probabilistic `roastChance` field (0.0–1.0) on all changelog configs
- Both repos now post professional changelogs by default, with a 10% chance of the bot randomly going full roast mode
- Colin's changelog entry now uses the same green embed color and professional styling — the roast is indistinguishable from a normal changelog until you read the content

## Test plan
- [ ] Verify `roastChance` is parsed correctly from config JSON
- [ ] Verify `roast_chance=1.0` always triggers roast prompt
- [ ] Verify `roast_chance=0.0` never triggers roast prompt
- [ ] CI passes all existing + new changelog tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)