### PR TITLE
chore(chat): shorten changelog embed titles

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.51.3
+version: 0.51.4
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.51.3
+      targetRevision: 0.51.4
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/deploy/values.yaml
+++ b/projects/monolith/deploy/values.yaml
@@ -97,7 +97,7 @@ chat:
       channelId: "1491186550472708117"
       githubRepo: "jomcgi/homelab"
       prompt: "professional"
-      embedTitle: "Homelab Changelog"
+      embedTitle: "Joe - Homelab"
       embedColor: "0x2ECC71"
       intervalHours: 1
       commitFilter: "^(feat)(\\(.+?\\))?!?:\\s"
@@ -106,7 +106,7 @@ chat:
       channelId: "1491186550472708117"
       githubRepo: "ColinCee/homelab"
       prompt: "professional"
-      embedTitle: "Colin's Homelab Changelog"
+      embedTitle: "Colin - Homelab"
       embedColor: "0x2ECC71"
       intervalHours: 1
       roastChance: 0.1


### PR DESCRIPTION
## Summary
- Renames embed titles from "Homelab Changelog" / "Colin's Homelab Changelog" to "Joe - Homelab" / "Colin - Homelab"
- Cleaner, more consistent naming — "changelog" is implied by the embed itself

## Test plan
- [ ] Values-only change, no code changes — CI should pass
- [ ] Verify embed titles render correctly in Discord after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)