### PR TITLE
ci(semgrep): add mcp-http-app-explicit-transport rule

### DIFF
--- a/bazel/semgrep/rules/python/mcp-http-app-explicit-transport.py
+++ b/bazel/semgrep/rules/python/mcp-http-app-explicit-transport.py
@@ -1,0 +1,29 @@
+# Tests for mcp-http-app-explicit-transport rule.
+import uvicorn
+from mcp.server.fastmcp import FastMCP
+
+mcp = FastMCP("my-server")
+
+
+# ruleid: mcp-http-app-explicit-transport
+app = mcp.http_app()
+
+
+# ruleid: mcp-http-app-explicit-transport
+app = mcp.http_app(path="/mcp")
+
+
+# ruleid: mcp-http-app-explicit-transport
+app = mcp.http_app(middleware=[])
+
+
+# ok: mcp-http-app-explicit-transport — explicit sse transport
+app = mcp.http_app(transport="sse")
+
+
+# ok: mcp-http-app-explicit-transport — explicit streamable-http transport
+app = mcp.http_app(transport="streamable-http")
+
+
+# ok: mcp-http-app-explicit-transport — explicit transport with other kwargs
+app = mcp.http_app(path="/mcp", transport="sse", middleware=[])

--- a/bazel/semgrep/rules/python/mcp-http-app-explicit-transport.yaml
+++ b/bazel/semgrep/rules/python/mcp-http-app-explicit-transport.yaml
@@ -1,0 +1,20 @@
+rules:
+  - id: mcp-http-app-explicit-transport
+    patterns:
+      - pattern: $MCP.http_app(...)
+      - pattern-not: $MCP.http_app(..., transport=..., ...)
+    message: >
+      `http_app()` was called without an explicit `transport=` keyword argument.
+      The default transport may not be what you intend — always pass
+      `transport="sse"` or `transport="streamable-http"` explicitly to avoid
+      silent mis-configuration. See PR #2118 for the bug this caught.
+    languages: [python]
+    severity: WARNING
+    metadata:
+      category: correctness
+      subcategory: networking
+      confidence: HIGH
+      likelihood: MEDIUM
+      impact: MEDIUM
+      technology: [python, mcp]
+      description: mcp.http_app() called without explicit transport= kwarg

--- a/projects/agent_platform/chart/Chart.yaml
+++ b/projects/agent_platform/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: agent-platform
 description: Agent platform — umbrella chart bundling goose sandboxes, MCP servers, and supporting components
 type: application
-version: 0.36.1
+version: 0.36.2
 appVersion: "0.2.0"
 annotations:
   org.opencontainers.image.source: "https://github.com/jomcgi/homelab"

--- a/projects/agent_platform/deploy/application.yaml
+++ b/projects/agent_platform/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: agent-platform
-      targetRevision: 0.36.1
+      targetRevision: 0.36.2
       helm:
         releaseName: agent-platform
         valueFiles:

--- a/projects/agent_platform/orchestrator/mcp/app/main.py
+++ b/projects/agent_platform/orchestrator/mcp/app/main.py
@@ -153,7 +153,7 @@ def main():
     settings = Settings()
     configure(settings)
 
-    app = mcp.http_app()
+    app = mcp.http_app(transport="sse")
 
     async def healthz(request):
         from starlette.responses import JSONResponse


### PR DESCRIPTION
## Summary

- Adds new semgrep rule `mcp-http-app-explicit-transport` that flags calls to `.http_app()` on FastMCP instances without an explicit `transport=` kwarg
- Catches the class of bug from PR #2118 where `mcp.http_app()` silently used the wrong default transport
- Rule pattern: `$MCP.http_app(...)` with `pattern-not` for `$MCP.http_app(..., transport=..., ...)`
- Severity: WARNING; message references PR #2118 and explains that `transport=` must be explicit (`sse` or `streamable-http`)

## Test plan

- [ ] `//bazel/semgrep/rules:python_rules_test` passes with 3 `ruleid` cases and 3 `ok` cases in the fixture
- [ ] Rule YAML and fixture follow existing `no-mcp-run-http` style

🤖 Generated with [Claude Code](https://claude.com/claude-code)