### PR TITLE
test(cli): add missing coverage for tasks subcommands

### DIFF
--- a/tools/cli/tasks_test.py
+++ b/tools/cli/tasks_test.py
@@ -117,7 +117,9 @@ class TestListTasksFilters:
 
     def test_status_and_json_combined(self, runner):
         """`knowledge tasks --status blocked --json` passes status param and returns JSON."""
-        data = {"tasks": [{"note_id": "task-7", "title": "Blocked", "status": "blocked"}]}
+        data = {
+            "tasks": [{"note_id": "task-7", "title": "Blocked", "status": "blocked"}]
+        }
         resp = _mock_response(data)
         with patch("tools.cli.tasks_cmd._request", return_value=resp) as mock_req:
             result = runner.invoke(

--- a/tools/cli/tasks_test.py
+++ b/tools/cli/tasks_test.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
+import json
+from contextlib import contextmanager
 from unittest.mock import MagicMock, patch
 
 import pytest
 from typer.testing import CliRunner
 
 from tools.cli.main import app
+from tools.cli.tasks_cmd import _request
 
 
 @pytest.fixture
@@ -68,6 +71,67 @@ class TestListTasks:
         assert "No tasks." in result.output
 
 
+class TestListTasksFilters:
+    def test_status_filter(self, runner):
+        """`knowledge tasks --status active` passes status param to _request."""
+        resp = _mock_response(
+            {
+                "tasks": [
+                    {
+                        "note_id": "task-5",
+                        "title": "Active task",
+                        "status": "active",
+                    }
+                ]
+            }
+        )
+        with patch("tools.cli.tasks_cmd._request", return_value=resp) as mock_req:
+            result = runner.invoke(app, ["knowledge", "tasks", "--status", "active"])
+
+        assert result.exit_code == 0
+        mock_req.assert_called_once_with(
+            "get", "/api/knowledge/tasks", params={"status": "active"}
+        )
+        assert "task-5" in result.output
+
+    def test_json_output(self, runner):
+        """`knowledge tasks --json` prints raw JSON instead of formatted output."""
+        data = {
+            "tasks": [
+                {
+                    "note_id": "task-6",
+                    "title": "JSON task",
+                    "status": "active",
+                }
+            ]
+        }
+        resp = _mock_response(data)
+        with patch("tools.cli.tasks_cmd._request", return_value=resp):
+            result = runner.invoke(app, ["knowledge", "tasks", "--json"])
+
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert parsed == data
+        # Should not contain the formatted task_line output style
+        assert "[active]" not in result.output
+
+    def test_status_and_json_combined(self, runner):
+        """`knowledge tasks --status blocked --json` passes status param and returns JSON."""
+        data = {"tasks": [{"note_id": "task-7", "title": "Blocked", "status": "blocked"}]}
+        resp = _mock_response(data)
+        with patch("tools.cli.tasks_cmd._request", return_value=resp) as mock_req:
+            result = runner.invoke(
+                app, ["knowledge", "tasks", "--status", "blocked", "--json"]
+            )
+
+        assert result.exit_code == 0
+        mock_req.assert_called_once_with(
+            "get", "/api/knowledge/tasks", params={"status": "blocked"}
+        )
+        parsed = json.loads(result.output)
+        assert parsed == data
+
+
 class TestMarkDone:
     def test_marks_done(self, runner):
         """`knowledge tasks done <id>` calls PATCH with done status."""
@@ -123,3 +187,259 @@ class TestSearch:
         )
         assert "task-3" in result.output
         assert "Search result" in result.output
+
+    def test_search_json_output(self, runner):
+        """`knowledge tasks search --json` prints raw JSON for search results."""
+        data = {
+            "tasks": [
+                {
+                    "note_id": "task-4",
+                    "title": "JSON search result",
+                    "status": "active",
+                }
+            ]
+        }
+        resp = _mock_response(data)
+        with patch("tools.cli.tasks_cmd._request", return_value=resp) as mock_req:
+            result = runner.invoke(
+                app, ["knowledge", "tasks", "search", "--json", "my query"]
+            )
+
+        assert result.exit_code == 0
+        mock_req.assert_called_once_with(
+            "get", "/api/knowledge/tasks", params={"q": "my query"}
+        )
+        parsed = json.loads(result.output)
+        assert parsed == data
+        # Should not contain formatted task_line output
+        assert "[active]" not in result.output
+
+    def test_search_empty_results(self, runner):
+        """`knowledge tasks search` with no results prints 'No tasks.'."""
+        resp = _mock_response({"tasks": []})
+        with patch("tools.cli.tasks_cmd._request", return_value=resp):
+            result = runner.invoke(app, ["knowledge", "tasks", "search", "nothing"])
+
+        assert result.exit_code == 0
+        assert "No tasks." in result.output
+
+
+class TestBlock:
+    def test_block(self, runner):
+        """`knowledge tasks block <id>` calls PATCH with blocked status."""
+        resp = _mock_response({})
+        with patch("tools.cli.tasks_cmd._request", return_value=resp) as mock_req:
+            result = runner.invoke(app, ["knowledge", "tasks", "block", "task-10"])
+
+        assert result.exit_code == 0
+        mock_req.assert_called_once_with(
+            "patch",
+            "/api/knowledge/tasks/task-10",
+            json={"status": "blocked"},
+        )
+        assert "blocked" in result.output.lower()
+
+    def test_block_includes_note_id_in_output(self, runner):
+        """`knowledge tasks block <id>` includes the task ID in the output."""
+        resp = _mock_response({})
+        with patch("tools.cli.tasks_cmd._request", return_value=resp):
+            result = runner.invoke(app, ["knowledge", "tasks", "block", "task-99"])
+
+        assert result.exit_code == 0
+        assert "task-99" in result.output
+
+
+class TestActivate:
+    def test_activate(self, runner):
+        """`knowledge tasks activate <id>` calls PATCH with active status."""
+        resp = _mock_response({})
+        with patch("tools.cli.tasks_cmd._request", return_value=resp) as mock_req:
+            result = runner.invoke(app, ["knowledge", "tasks", "activate", "task-20"])
+
+        assert result.exit_code == 0
+        mock_req.assert_called_once_with(
+            "patch",
+            "/api/knowledge/tasks/task-20",
+            json={"status": "active"},
+        )
+        assert "active" in result.output.lower()
+
+    def test_activate_includes_note_id_in_output(self, runner):
+        """`knowledge tasks activate <id>` includes the task ID in the output."""
+        resp = _mock_response({})
+        with patch("tools.cli.tasks_cmd._request", return_value=resp):
+            result = runner.invoke(app, ["knowledge", "tasks", "activate", "task-42"])
+
+        assert result.exit_code == 0
+        assert "task-42" in result.output
+
+
+class TestAdd:
+    def test_add_not_implemented(self, runner):
+        """`knowledge tasks add` prints 'Not implemented yet' to stderr and exits 1."""
+        result = runner.invoke(app, ["knowledge", "tasks", "add"])
+
+        assert result.exit_code == 1
+        # CliRunner mixes stderr into output by default
+        assert "Not implemented yet" in result.output
+
+
+class TestDaily:
+    def test_daily_formatted_output(self, runner):
+        """`knowledge tasks daily` calls GET /api/knowledge/tasks/daily and formats output."""
+        resp = _mock_response(
+            {
+                "tasks": [
+                    {
+                        "note_id": "daily-1",
+                        "title": "Morning standup",
+                        "status": "active",
+                    }
+                ]
+            }
+        )
+        with patch("tools.cli.tasks_cmd._request", return_value=resp) as mock_req:
+            result = runner.invoke(app, ["knowledge", "tasks", "daily"])
+
+        assert result.exit_code == 0
+        mock_req.assert_called_once_with("get", "/api/knowledge/tasks/daily")
+        assert "daily-1" in result.output
+        assert "Morning standup" in result.output
+        assert "[active]" in result.output
+
+    def test_daily_empty(self, runner):
+        """`knowledge tasks daily` with no tasks prints 'No tasks.'."""
+        resp = _mock_response({"tasks": []})
+        with patch("tools.cli.tasks_cmd._request", return_value=resp):
+            result = runner.invoke(app, ["knowledge", "tasks", "daily"])
+
+        assert result.exit_code == 0
+        assert "No tasks." in result.output
+
+    def test_daily_json_output(self, runner):
+        """`knowledge tasks daily --json` prints raw JSON output."""
+        data = {
+            "tasks": [
+                {
+                    "note_id": "daily-2",
+                    "title": "Review PRs",
+                    "status": "active",
+                }
+            ]
+        }
+        resp = _mock_response(data)
+        with patch("tools.cli.tasks_cmd._request", return_value=resp) as mock_req:
+            result = runner.invoke(app, ["knowledge", "tasks", "daily", "--json"])
+
+        assert result.exit_code == 0
+        mock_req.assert_called_once_with("get", "/api/knowledge/tasks/daily")
+        parsed = json.loads(result.output)
+        assert parsed == data
+        assert "[active]" not in result.output
+
+
+class TestWeekly:
+    def test_weekly_formatted_output(self, runner):
+        """`knowledge tasks weekly` calls GET /api/knowledge/tasks/weekly and formats output."""
+        resp = _mock_response(
+            {
+                "tasks": [
+                    {
+                        "note_id": "weekly-1",
+                        "title": "Weekly planning",
+                        "status": "active",
+                        "size": "M",
+                    }
+                ]
+            }
+        )
+        with patch("tools.cli.tasks_cmd._request", return_value=resp) as mock_req:
+            result = runner.invoke(app, ["knowledge", "tasks", "weekly"])
+
+        assert result.exit_code == 0
+        mock_req.assert_called_once_with("get", "/api/knowledge/tasks/weekly")
+        assert "weekly-1" in result.output
+        assert "Weekly planning" in result.output
+        assert "[active]" in result.output
+
+    def test_weekly_empty(self, runner):
+        """`knowledge tasks weekly` with no tasks prints 'No tasks.'."""
+        resp = _mock_response({"tasks": []})
+        with patch("tools.cli.tasks_cmd._request", return_value=resp):
+            result = runner.invoke(app, ["knowledge", "tasks", "weekly"])
+
+        assert result.exit_code == 0
+        assert "No tasks." in result.output
+
+    def test_weekly_json_output(self, runner):
+        """`knowledge tasks weekly --json` prints raw JSON output."""
+        data = {
+            "tasks": [
+                {
+                    "note_id": "weekly-2",
+                    "title": "Retrospective",
+                    "status": "done",
+                }
+            ]
+        }
+        resp = _mock_response(data)
+        with patch("tools.cli.tasks_cmd._request", return_value=resp) as mock_req:
+            result = runner.invoke(app, ["knowledge", "tasks", "weekly", "--json"])
+
+        assert result.exit_code == 0
+        mock_req.assert_called_once_with("get", "/api/knowledge/tasks/weekly")
+        parsed = json.loads(result.output)
+        assert parsed == data
+        assert "[done]" not in result.output
+
+
+class TestRequestReauth:
+    def test_reauth_on_redirect(self):
+        """_request calls clear_cf_token and retries when first response is_redirect=True."""
+        redirect_resp = MagicMock()
+        redirect_resp.is_redirect = True
+
+        final_resp = MagicMock()
+        final_resp.is_redirect = False
+        final_resp.json.return_value = {"tasks": []}
+        final_resp.raise_for_status.return_value = None
+
+        # Both calls share the same client mock so we can track call order
+        mock_client = MagicMock()
+        mock_client.get.side_effect = [redirect_resp, final_resp]
+
+        # _request uses `with _client() as client:` twice, so _client() must
+        # return a fresh context manager on every invocation.
+        @contextmanager
+        def make_ctx():
+            yield mock_client
+
+        with (
+            patch("tools.cli.tasks_cmd._client", side_effect=make_ctx),
+            patch("tools.cli.tasks_cmd.clear_cf_token") as mock_clear,
+        ):
+            result = _request("get", "/api/knowledge/tasks/daily")
+
+        mock_clear.assert_called_once()
+        assert result is final_resp
+
+    def test_no_reauth_when_not_redirect(self):
+        """_request does NOT call clear_cf_token when response is not a redirect."""
+        normal_resp = MagicMock()
+        normal_resp.is_redirect = False
+
+        mock_client = MagicMock()
+        mock_client.get.return_value = normal_resp
+
+        @contextmanager
+        def make_ctx():
+            yield mock_client
+
+        with (
+            patch("tools.cli.tasks_cmd._client", side_effect=make_ctx),
+            patch("tools.cli.tasks_cmd.clear_cf_token") as mock_clear,
+        ):
+            result = _request("get", "/api/knowledge/tasks")
+
+        mock_clear.assert_not_called()
+        assert result is normal_resp


### PR DESCRIPTION
## Summary

- Adds 17 new tests across 7 new test classes covering all previously untested paths in `tools/cli/tasks_cmd.py`
- `TestListTasksFilters`: `--status` param forwarded to `_request`, `--json` prints raw JSON, combined flags work together
- `TestSearch`: `--json` output, empty results print "No tasks."
- `TestBlock`: PATCH with `status=blocked`, note_id echoed in output
- `TestActivate`: PATCH with `status=active`, note_id echoed in output
- `TestAdd`: prints "Not implemented yet" to stderr and exits with code 1
- `TestDaily`: GET `/api/knowledge/tasks/daily`, formatted output, empty state, `--json` output
- `TestWeekly`: GET `/api/knowledge/tasks/weekly`, formatted output, empty state, `--json` output
- `TestRequestReauth`: `clear_cf_token` called on redirect, not called on normal response

## Test plan

- [ ] CI runs `bazel test //tools/cli:tasks_test` and all 21 tests pass (17 new + 4 existing)
- [ ] Semgrep linting passes on the updated test file

🤖 Generated with [Claude Code](https://claude.com/claude-code)