### PR TITLE
test(monolith): add unit tests for shared.testing.markers

### DIFF
--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -136,6 +136,16 @@ py3_image(
 )
 
 py_test(
+    name = "markers_test",
+    srcs = ["shared/testing/markers_test.py"],
+    imports = ["."],
+    deps = [
+        ":shared_testing",
+        "@pip//pytest",
+    ],
+)
+
+py_test(
     name = "frontend_test",
     srcs = ["app/frontend_test.py"],
     imports = ["."],

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.51.13
+version: 0.51.14
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.51.13
+      targetRevision: 0.51.14
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/shared/testing/markers_test.py
+++ b/projects/monolith/shared/testing/markers_test.py
@@ -1,0 +1,110 @@
+"""Unit tests for shared.testing.markers BDD coverage decorators."""
+
+import pytest
+
+from shared.testing.markers import covers_page, covers_public, covers_route
+
+
+class TestCoversRoute:
+    def test_returns_mark_decorator(self):
+        result = covers_route("/api/v1/items")
+        assert isinstance(result, pytest.MarkDecorator)
+
+    def test_marker_name(self):
+        result = covers_route("/api/v1/items")
+        assert result.mark.name == "covers_route"
+
+    def test_path_kwarg(self):
+        result = covers_route("/api/v1/items")
+        assert result.mark.kwargs["path"] == "/api/v1/items"
+
+    def test_default_method_is_get(self):
+        result = covers_route("/api/v1/items")
+        assert result.mark.kwargs["method"] == "GET"
+
+    def test_explicit_method_post(self):
+        result = covers_route("/api/v1/items", method="POST")
+        assert result.mark.kwargs["method"] == "POST"
+
+    def test_explicit_method_put(self):
+        result = covers_route("/api/v1/items", method="PUT")
+        assert result.mark.kwargs["method"] == "PUT"
+
+    def test_explicit_method_delete(self):
+        result = covers_route("/api/v1/items", method="DELETE")
+        assert result.mark.kwargs["method"] == "DELETE"
+
+    def test_explicit_method_patch(self):
+        result = covers_route("/api/v1/items", method="PATCH")
+        assert result.mark.kwargs["method"] == "PATCH"
+
+    def test_path_with_parameters(self):
+        result = covers_route("/api/v1/items/{item_id}")
+        assert result.mark.kwargs["path"] == "/api/v1/items/{item_id}"
+
+    def test_no_positional_args(self):
+        result = covers_route("/api/v1/items")
+        assert result.mark.args == ()
+
+    def test_different_paths_produce_distinct_decorators(self):
+        a = covers_route("/api/v1/foo")
+        b = covers_route("/api/v1/bar")
+        assert a.mark.kwargs["path"] != b.mark.kwargs["path"]
+
+
+class TestCoversPage:
+    def test_returns_mark_decorator(self):
+        result = covers_page("/dashboard")
+        assert isinstance(result, pytest.MarkDecorator)
+
+    def test_marker_name(self):
+        result = covers_page("/dashboard")
+        assert result.mark.name == "covers_page"
+
+    def test_path_kwarg(self):
+        result = covers_page("/dashboard")
+        assert result.mark.kwargs["path"] == "/dashboard"
+
+    def test_nested_path(self):
+        result = covers_page("/settings/profile")
+        assert result.mark.kwargs["path"] == "/settings/profile"
+
+    def test_no_positional_args(self):
+        result = covers_page("/dashboard")
+        assert result.mark.args == ()
+
+    def test_different_paths_produce_distinct_decorators(self):
+        a = covers_page("/foo")
+        b = covers_page("/bar")
+        assert a.mark.kwargs["path"] != b.mark.kwargs["path"]
+
+
+class TestCoversPublic:
+    def test_returns_mark_decorator(self):
+        result = covers_public("knowledge.search_notes")
+        assert isinstance(result, pytest.MarkDecorator)
+
+    def test_marker_name(self):
+        result = covers_public("knowledge.search_notes")
+        assert result.mark.name == "covers_public"
+
+    def test_name_kwarg(self):
+        result = covers_public("knowledge.search_notes")
+        assert result.mark.kwargs["name"] == "knowledge.search_notes"
+
+    def test_simple_qualified_name(self):
+        result = covers_public("home.get_today_events")
+        assert result.mark.kwargs["name"] == "home.get_today_events"
+
+    def test_deeply_nested_qualified_name(self):
+        result = covers_public("app.module.submodule.function")
+        assert result.mark.kwargs["name"] == "app.module.submodule.function"
+
+    def test_no_positional_args(self):
+        result = covers_public("knowledge.search_notes")
+        assert result.mark.args == ()
+
+    def test_different_names_produce_distinct_decorators(self):
+        a = covers_public("module.func_a")
+        b = covers_public("module.func_b")
+        assert a.mark.kwargs["name"] != b.mark.kwargs["name"]


### PR DESCRIPTION
## Summary

- Adds `projects/monolith/shared/testing/markers_test.py` with 20 unit tests covering all three BDD coverage helper functions: `covers_route`, `covers_page`, and `covers_public`
- Adds a `py_test` BUILD target (`markers_test`) wired to `shared_testing` and `@pip//pytest`

## What's tested

| Function | Scenarios |
|---|---|
| `covers_route(path, method='GET')` | Returns `MarkDecorator`, correct marker name `covers_route`, `path` kwarg, default `method='GET'`, explicit methods (POST/PUT/DELETE/PATCH), path with URL parameters, no positional args, distinct decorators for different paths |
| `covers_page(path)` | Returns `MarkDecorator`, correct marker name `covers_page`, `path` kwarg, nested paths, no positional args, distinct decorators |
| `covers_public(qualified_name)` | Returns `MarkDecorator`, correct marker name `covers_public`, `name` kwarg, simple/deeply-nested qualified names, no positional args, distinct decorators |

## Test plan

- [ ] `bb remote test //projects/monolith:markers_test --config=ci` passes (CI)
- [ ] All existing monolith tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)