### PR TITLE
ci(semgrep): add py-glob-missing-tests-exclude rule

### DIFF
--- a/bazel/semgrep/rules/bazel/py-glob-missing-tests-exclude.build
+++ b/bazel/semgrep/rules/bazel/py-glob-missing-tests-exclude.build
@@ -1,0 +1,54 @@
+# Tests for py-glob-missing-tests-exclude rule.
+load("@aspect_rules_py//py:defs.bzl", "py_library", "py_venv_binary")
+
+# ruleid: py-glob-missing-tests-exclude
+py_library(
+    name = "bad_inline",
+    srcs = glob(["**/*.py"]),
+)
+
+# ruleid: py-glob-missing-tests-exclude
+py_library(
+    name = "bad_multiline",
+    srcs = glob(
+        ["**/*.py"],
+    ),
+)
+
+# ruleid: py-glob-missing-tests-exclude
+py_venv_binary(
+    name = "bad_binary",
+    main = "main.py",
+    srcs = glob(["**/*.py"]),
+)
+
+# ok: py-glob-missing-tests-exclude
+py_library(
+    name = "good_with_tests_exclude",
+    srcs = glob(
+        ["**/*.py"],
+        exclude = ["*/tests/**"],
+    ),
+)
+
+# ok: py-glob-missing-tests-exclude
+py_venv_binary(
+    name = "good_binary_with_exclude",
+    main = "main.py",
+    srcs = glob(
+        ["**/*.py"],
+        exclude = ["*/tests/**", "*_test.py"],
+    ),
+)
+
+# ok: py-glob-missing-tests-exclude
+py_library(
+    name = "explicit_srcs",
+    srcs = ["main.py", "utils.py"],
+)
+
+# ok: py-glob-missing-tests-exclude
+py_test(
+    name = "not_a_library",
+    srcs = glob(["**/*.py"]),
+)

--- a/bazel/semgrep/rules/bazel/py-glob-missing-tests-exclude.yaml
+++ b/bazel/semgrep/rules/bazel/py-glob-missing-tests-exclude.yaml
@@ -1,0 +1,17 @@
+rules:
+  - id: py-glob-missing-tests-exclude
+    languages: [generic]
+    severity: WARNING
+    message: >-
+      py_library or py_venv_binary uses glob(["**/*.py"]) without excluding
+      test directories. Add exclude=["*/tests/**"] to prevent conftest.py and
+      fixture files from being bundled into the production library target.
+      This was the root cause in commit 61fcaa4 where domain tests/conftest.py
+      files were inadvertently included in monolith_backend.
+    metadata:
+      category: correctness
+    paths:
+      include:
+        - "**/BUILD"
+        - "**/BUILD.bazel"
+    pattern-regex: '(?s)(py_library|py_venv_binary)\s*\([^(]*glob\s*\(\s*\[\s*"[^"]*\*\*/\*\.py"[^\]]*\]\s*,?\s*\)'


### PR DESCRIPTION
## Summary

- Adds semgrep rule `py-glob-missing-tests-exclude` to catch `py_library` and `py_venv_binary` targets that use `glob(["**/*.py"])` without excluding test directories
- Prevents the class of bug from commit 61fcaa4 where `tests/conftest.py` files were bundled into `monolith_backend`
- Includes annotated `.build` fixture with both violating and passing examples

## Test plan

- [ ] `bazel test //bazel/semgrep/rules:bazel_rules_test` passes
- [ ] Rule correctly flags `glob(["**/*.py"])` without `exclude=["*/tests/**"]`
- [ ] Rule does not flag targets with proper exclude

🤖 Generated with [Claude Code](https://claude.com/claude-code)