### PR TITLE
ci(semgrep): add no-pytest-plugins-in-conftest rule

### DIFF
--- a/bazel/semgrep/rules/python/no-pytest-plugins-in-conftest.py
+++ b/bazel/semgrep/rules/python/no-pytest-plugins-in-conftest.py
@@ -1,0 +1,19 @@
+# Tests for no-pytest-plugins-in-conftest rule.
+
+# ruleid: no-pytest-plugins-in-conftest
+pytest_plugins = ["my_plugin"]
+
+# ruleid: no-pytest-plugins-in-conftest
+pytest_plugins = "my_plugin"
+
+# ruleid: no-pytest-plugins-in-conftest
+pytest_plugins = [
+    "my_plugin",
+    "another_plugin",
+]
+
+# ok: no-pytest-plugins-in-conftest
+plugins = ["my_plugin"]
+
+# ok: no-pytest-plugins-in-conftest
+some_plugins = ["my_plugin"]

--- a/bazel/semgrep/rules/python/no-pytest-plugins-in-conftest.yaml
+++ b/bazel/semgrep/rules/python/no-pytest-plugins-in-conftest.yaml
@@ -1,0 +1,15 @@
+rules:
+  - id: no-pytest-plugins-in-conftest
+    languages: [python]
+    severity: ERROR
+    message: >-
+      Avoid declaring pytest_plugins in conftest.py — under Bazel, pytest
+      rootdir is the workspace root, making non-root conftest declarations
+      fail with pytest 8.x. Use PYTEST_ADDOPTS=-p <plugin> in the BUILD
+      target env instead.
+    metadata:
+      category: correctness
+    paths:
+      include:
+        - "**/conftest.py"
+    pattern: pytest_plugins = ...


### PR DESCRIPTION
## Summary

- Adds semgrep rule `no-pytest-plugins-in-conftest` to detect `pytest_plugins = ` declarations in `conftest.py` files
- Under Bazel, pytest rootdir is the workspace root, making non-root conftest declarations fail with pytest 8.x
- Directs developers to use `PYTEST_ADDOPTS=-p <plugin>` in the BUILD target `env` instead
- Includes annotated `.py` fixture with violating and passing examples

## Test plan

- [ ] `bazel test //bazel/semgrep/rules:python_rules_test` passes
- [ ] Rule correctly flags `pytest_plugins = ` in conftest.py
- [ ] Rule does not flag other variable assignments

🤖 Generated with [Claude Code](https://claude.com/claude-code)