### PR TITLE
ci(hooks): add check-bdd-shared-testing-dep PreToolUse hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -78,6 +78,11 @@
             "type": "command",
             "command": "bazel/tools/hooks/check-python-file-shadows-package.sh",
             "timeout": 10
+          },
+          {
+            "type": "command",
+            "command": "bazel/tools/hooks/check-bdd-shared-testing-dep.sh",
+            "timeout": 10
           }
         ]
       }

--- a/bazel/tools/hooks/BUILD
+++ b/bazel/tools/hooks/BUILD
@@ -15,3 +15,9 @@ sh_test(
     srcs = ["check-python-file-shadows-package_test.sh"],
     data = [":check-python-file-shadows-package.sh"],
 )
+
+sh_test(
+    name = "check_bdd_shared_testing_dep_test",
+    srcs = ["check-bdd-shared-testing-dep_test.sh"],
+    data = [":check-bdd-shared-testing-dep.sh"],
+)

--- a/bazel/tools/hooks/check-bdd-shared-testing-dep.sh
+++ b/bazel/tools/hooks/check-bdd-shared-testing-dep.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+# PreToolUse hook: warns when a BUILD file references shared.testing.plugin
+# in an env dict but does not include :shared_testing in a deps list.
+#
+# This catches the pattern where the pytest plugin is registered via env var
+# (PYTEST_ADDOPTS=-p shared.testing.plugin) but the BUILD target is missing
+# the actual dependency, causing ImportError at test runtime.
+#
+# Input: JSON on stdin from Claude Code hook system
+# Exit 0: always (warning only — never blocks)
+
+set -euo pipefail
+
+INPUT=$(cat)
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
+
+# No file path — nothing to check
+if [[ -z "$FILE_PATH" ]]; then
+	exit 0
+fi
+
+# Only check BUILD files
+BASENAME=$(basename "$FILE_PATH")
+if [[ "$BASENAME" != "BUILD" ]] && [[ "$BASENAME" != "BUILD.bazel" ]]; then
+	exit 0
+fi
+
+# Get content being written (Write tool) or read current file (Edit tool)
+CONTENT=$(echo "$INPUT" | jq -r '.tool_input.content // empty')
+if [[ -z "$CONTENT" ]]; then
+	# Edit tool — read current file if it exists
+	if [[ -f "$FILE_PATH" ]]; then
+		CONTENT=$(cat "$FILE_PATH")
+	fi
+fi
+
+if [[ -z "$CONTENT" ]]; then
+	exit 0
+fi
+
+# Check if the content references shared.testing.plugin in an env dict
+if ! echo "$CONTENT" | grep -q 'shared\.testing\.plugin'; then
+	exit 0
+fi
+
+# Warn if :shared_testing is not present in a deps list
+if ! echo "$CONTENT" | grep -q '":shared_testing"'; then
+	cat >&2 <<-EOF
+		WARNING: BUILD file references 'shared.testing.plugin' in env but
+		':shared_testing' is not present in a deps list.
+
+		File: $FILE_PATH
+
+		When using PYTEST_ADDOPTS=-p shared.testing.plugin in an env dict,
+		the :shared_testing target must be listed in deps to ensure the plugin
+		module is available at test runtime.
+
+		Add to the target's deps:
+		  deps = [
+		      ...
+		      ":shared_testing",
+		  ],
+	EOF
+fi
+
+exit 0

--- a/bazel/tools/hooks/check-bdd-shared-testing-dep.sh
+++ b/bazel/tools/hooks/check-bdd-shared-testing-dep.sh
@@ -46,8 +46,7 @@ fi
 # Warn if :shared_testing is not present in a deps list
 if ! echo "$CONTENT" | grep -q '":shared_testing"'; then
 	cat >&2 <<-EOF
-		WARNING: BUILD file references 'shared.testing.plugin' in env but
-		':shared_testing' is not present in a deps list.
+		WARNING: ':shared_testing' missing from deps while 'shared.testing.plugin' is used in env.
 
 		File: $FILE_PATH
 

--- a/bazel/tools/hooks/check-bdd-shared-testing-dep_test.sh
+++ b/bazel/tools/hooks/check-bdd-shared-testing-dep_test.sh
@@ -1,0 +1,213 @@
+#!/usr/bin/env bash
+# Unit tests for check-bdd-shared-testing-dep.sh PreToolUse hook.
+#
+# The hook:
+#   - Reads JSON from stdin with .tool_input.file_path (and optionally .tool_input.content)
+#   - Exits 0 always (warning-only, never blocks)
+#   - Emits a WARNING on stderr when a BUILD file references shared.testing.plugin
+#     without :shared_testing in deps
+#   - Skips non-BUILD files and files without shared.testing.plugin
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Locate hook from Bazel runfiles
+# ---------------------------------------------------------------------------
+HOOK_REL="bazel/tools/hooks/check-bdd-shared-testing-dep.sh"
+HOOK=""
+for candidate in \
+	"${RUNFILES_DIR:-}/_main/${HOOK_REL}" \
+	"${TEST_SRCDIR:-}/_main/${HOOK_REL}" \
+	"${BASH_SOURCE[0]%/*}/check-bdd-shared-testing-dep.sh"; do
+	if [[ -f "$candidate" ]]; then
+		HOOK="$candidate"
+		break
+	fi
+done
+if [[ -z "$HOOK" ]]; then
+	echo "ERROR: cannot locate check-bdd-shared-testing-dep.sh in runfiles" >&2
+	exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Install a minimal jq stub so the hook runs in the hermetic sandbox.
+# The hook uses exactly two expressions:
+#   jq -r '.tool_input.file_path // empty'
+#   jq -r '.tool_input.content // empty'
+# ---------------------------------------------------------------------------
+mkdir -p "${TEST_TMPDIR}/bin"
+cat >"${TEST_TMPDIR}/bin/jq" <<'JQ_STUB'
+#!/usr/bin/env python3
+"""Minimal jq stub covering expressions used by check-bdd-shared-testing-dep.sh."""
+import json, sys
+
+args = sys.argv[1:]
+raw = False
+if args and args[0] == "-r":
+    raw = True
+    args = args[1:]
+
+expr = args[0] if args else "."
+data = json.load(sys.stdin)
+
+def jq_eval(obj, expr):
+    """Evaluate '.a.b // .c.d // empty' style expressions."""
+    for alt in expr.split("//"):
+        alt = alt.strip()
+        if alt == "empty":
+            return None
+        keys = [k for k in alt.lstrip(".").split(".") if k]
+        val = obj
+        try:
+            for k in keys:
+                val = val[k] if isinstance(val, dict) else None
+                if val is None:
+                    break
+        except (KeyError, TypeError):
+            val = None
+        if val is not None:
+            return val
+    return None
+
+result = jq_eval(data, expr)
+if result is None:
+    pass  # empty — print nothing
+elif raw:
+    print(result)
+else:
+    print(json.dumps(result))
+JQ_STUB
+chmod +x "${TEST_TMPDIR}/bin/jq"
+export PATH="${TEST_TMPDIR}/bin:${PATH}"
+
+# ---------------------------------------------------------------------------
+# Temp directory for BUILD file fixtures
+# ---------------------------------------------------------------------------
+BUILDS_DIR="${TEST_TMPDIR}/builds"
+mkdir -p "$BUILDS_DIR"
+
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
+PASS=0
+FAIL=0
+
+run_test() {
+	local name="$1"
+	local input_json="$2"
+	local want_exit="$3"      # expected exit code (always 0 for this hook)
+	local want_stderr_re="$4" # regex that must match stderr (empty = no output expected)
+
+	local stderr_out
+	local got_exit=0
+	stderr_out=$(printf '%s' "$input_json" | bash "$HOOK" 2>&1 >/dev/null) || got_exit=$?
+
+	local ok=true
+
+	if [[ "$got_exit" -ne "$want_exit" ]]; then
+		echo "FAIL [$name]: exit $got_exit, want $want_exit"
+		ok=false
+	fi
+
+	if [[ -n "$want_stderr_re" ]]; then
+		if ! echo "$stderr_out" | grep -qE "$want_stderr_re"; then
+			echo "FAIL [$name]: stderr $(printf '%q' "$stderr_out") did not match /$want_stderr_re/"
+			ok=false
+		fi
+	else
+		if [[ -n "$stderr_out" ]]; then
+			echo "FAIL [$name]: unexpected stderr: $(printf '%q' "$stderr_out")"
+			ok=false
+		fi
+	fi
+
+	if $ok; then
+		echo "PASS [$name]"
+		PASS=$((PASS + 1))
+	else
+		FAIL=$((FAIL + 1))
+	fi
+}
+
+# ---------------------------------------------------------------------------
+# Tests using actual temp files (hook reads file when no content field)
+# ---------------------------------------------------------------------------
+
+# 1. BUILD file with shared.testing.plugin but no :shared_testing dep → warns
+cat >"$BUILDS_DIR/missing_dep_BUILD" <<'EOF'
+py_test(
+    name = "test_suite",
+    srcs = glob(["**/*_test.py"]),
+    env = {
+        "PYTEST_ADDOPTS": "-p shared.testing.plugin",
+    },
+)
+EOF
+run_test "missing_shared_testing_dep_warns" \
+	"{\"tool_input\":{\"file_path\":\"$BUILDS_DIR/missing_dep_BUILD\"}}" \
+	0 "WARNING.*shared_testing"
+
+# 2. BUILD file with both shared.testing.plugin and :shared_testing dep → no warning
+cat >"$BUILDS_DIR/has_dep_BUILD" <<'EOF'
+py_test(
+    name = "test_suite",
+    srcs = glob(["**/*_test.py"]),
+    env = {
+        "PYTEST_ADDOPTS": "-p shared.testing.plugin",
+    },
+    deps = [
+        ":shared_testing",
+        "//other:dep",
+    ],
+)
+EOF
+run_test "has_shared_testing_dep_no_warning" \
+	"{\"tool_input\":{\"file_path\":\"$BUILDS_DIR/has_dep_BUILD\"}}" \
+	0 ""
+
+# 3. Non-BUILD file → skip even if content references shared.testing.plugin
+cat >"$BUILDS_DIR/conftest.py" <<'EOF'
+pytest_plugins = ["shared.testing.plugin"]
+EOF
+run_test "non_build_file_skipped" \
+	"{\"tool_input\":{\"file_path\":\"$BUILDS_DIR/conftest.py\"}}" \
+	0 ""
+
+# 4. BUILD file without shared.testing.plugin → no warning
+cat >"$BUILDS_DIR/plain_BUILD" <<'EOF'
+py_test(
+    name = "test_suite",
+    srcs = glob(["**/*_test.py"]),
+    deps = [":some_dep"],
+)
+EOF
+run_test "no_plugin_no_warning" \
+	"{\"tool_input\":{\"file_path\":\"$BUILDS_DIR/plain_BUILD\"}}" \
+	0 ""
+
+# 5. Empty JSON (no tool_input) → skip
+run_test "empty_json_allowed" \
+	'{}' \
+	0 ""
+
+# 6. BUILD.bazel filename variant — also checked
+cat >"$BUILDS_DIR/missing_dep_BUILD.bazel" <<'EOF'
+py_test(
+    name = "test_suite",
+    srcs = ["test.py"],
+    env = {"PYTEST_ADDOPTS": "-p shared.testing.plugin"},
+)
+EOF
+run_test "build_bazel_filename_warns" \
+	"{\"tool_input\":{\"file_path\":\"$BUILDS_DIR/missing_dep_BUILD.bazel\"}}" \
+	0 "WARNING.*shared_testing"
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+echo "Results: ${PASS} passed, ${FAIL} failed"
+if [[ "$FAIL" -gt 0 ]]; then
+	exit 1
+fi
+exit 0

--- a/bazel/tools/hooks/check-bdd-shared-testing-dep_test.sh
+++ b/bazel/tools/hooks/check-bdd-shared-testing-dep_test.sh
@@ -81,12 +81,6 @@ chmod +x "${TEST_TMPDIR}/bin/jq"
 export PATH="${TEST_TMPDIR}/bin:${PATH}"
 
 # ---------------------------------------------------------------------------
-# Temp directory for BUILD file fixtures
-# ---------------------------------------------------------------------------
-BUILDS_DIR="${TEST_TMPDIR}/builds"
-mkdir -p "$BUILDS_DIR"
-
-# ---------------------------------------------------------------------------
 # Test helpers
 # ---------------------------------------------------------------------------
 PASS=0
@@ -130,11 +124,14 @@ run_test() {
 }
 
 # ---------------------------------------------------------------------------
-# Tests using actual temp files (hook reads file when no content field)
+# Tests using actual temp files (hook reads file when no content field).
+# Each test case uses its own subdirectory so filenames are exactly BUILD
+# or BUILD.bazel (the hook checks basename strictly).
 # ---------------------------------------------------------------------------
 
 # 1. BUILD file with shared.testing.plugin but no :shared_testing dep → warns
-cat >"$BUILDS_DIR/missing_dep_BUILD" <<'EOF'
+mkdir -p "${TEST_TMPDIR}/t1"
+cat >"${TEST_TMPDIR}/t1/BUILD" <<'EOF'
 py_test(
     name = "test_suite",
     srcs = glob(["**/*_test.py"]),
@@ -144,11 +141,12 @@ py_test(
 )
 EOF
 run_test "missing_shared_testing_dep_warns" \
-	"{\"tool_input\":{\"file_path\":\"$BUILDS_DIR/missing_dep_BUILD\"}}" \
+	"{\"tool_input\":{\"file_path\":\"${TEST_TMPDIR}/t1/BUILD\"}}" \
 	0 "WARNING.*shared_testing"
 
 # 2. BUILD file with both shared.testing.plugin and :shared_testing dep → no warning
-cat >"$BUILDS_DIR/has_dep_BUILD" <<'EOF'
+mkdir -p "${TEST_TMPDIR}/t2"
+cat >"${TEST_TMPDIR}/t2/BUILD" <<'EOF'
 py_test(
     name = "test_suite",
     srcs = glob(["**/*_test.py"]),
@@ -162,19 +160,21 @@ py_test(
 )
 EOF
 run_test "has_shared_testing_dep_no_warning" \
-	"{\"tool_input\":{\"file_path\":\"$BUILDS_DIR/has_dep_BUILD\"}}" \
+	"{\"tool_input\":{\"file_path\":\"${TEST_TMPDIR}/t2/BUILD\"}}" \
 	0 ""
 
 # 3. Non-BUILD file → skip even if content references shared.testing.plugin
-cat >"$BUILDS_DIR/conftest.py" <<'EOF'
+mkdir -p "${TEST_TMPDIR}/t3"
+cat >"${TEST_TMPDIR}/t3/conftest.py" <<'EOF'
 pytest_plugins = ["shared.testing.plugin"]
 EOF
 run_test "non_build_file_skipped" \
-	"{\"tool_input\":{\"file_path\":\"$BUILDS_DIR/conftest.py\"}}" \
+	"{\"tool_input\":{\"file_path\":\"${TEST_TMPDIR}/t3/conftest.py\"}}" \
 	0 ""
 
 # 4. BUILD file without shared.testing.plugin → no warning
-cat >"$BUILDS_DIR/plain_BUILD" <<'EOF'
+mkdir -p "${TEST_TMPDIR}/t4"
+cat >"${TEST_TMPDIR}/t4/BUILD" <<'EOF'
 py_test(
     name = "test_suite",
     srcs = glob(["**/*_test.py"]),
@@ -182,7 +182,7 @@ py_test(
 )
 EOF
 run_test "no_plugin_no_warning" \
-	"{\"tool_input\":{\"file_path\":\"$BUILDS_DIR/plain_BUILD\"}}" \
+	"{\"tool_input\":{\"file_path\":\"${TEST_TMPDIR}/t4/BUILD\"}}" \
 	0 ""
 
 # 5. Empty JSON (no tool_input) → skip
@@ -191,7 +191,8 @@ run_test "empty_json_allowed" \
 	0 ""
 
 # 6. BUILD.bazel filename variant — also checked
-cat >"$BUILDS_DIR/missing_dep_BUILD.bazel" <<'EOF'
+mkdir -p "${TEST_TMPDIR}/t6"
+cat >"${TEST_TMPDIR}/t6/BUILD.bazel" <<'EOF'
 py_test(
     name = "test_suite",
     srcs = ["test.py"],
@@ -199,7 +200,7 @@ py_test(
 )
 EOF
 run_test "build_bazel_filename_warns" \
-	"{\"tool_input\":{\"file_path\":\"$BUILDS_DIR/missing_dep_BUILD.bazel\"}}" \
+	"{\"tool_input\":{\"file_path\":\"${TEST_TMPDIR}/t6/BUILD.bazel\"}}" \
 	0 "WARNING.*shared_testing"
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds `check-bdd-shared-testing-dep.sh`, a warning-only PreToolUse hook that detects when a BUILD file references `shared.testing.plugin` via `PYTEST_ADDOPTS` in an env dict but is missing `:shared_testing` in its deps list
- Adds `check-bdd-shared-testing-dep_test.sh` with 6 unit tests covering: missing dep warns, present dep silent, non-BUILD file skipped, no plugin no warning, empty JSON, and `BUILD.bazel` filename variant
- Registers the hook in `.claude/settings.json` under the `Write|Edit` matcher after the existing `check-python-file-shadows-package.sh` entry

## Test plan

- [ ] `bb remote test //bazel/tools/hooks:check_bdd_shared_testing_dep_test --config=ci` passes
- [ ] Hook emits a WARNING when a BUILD file has `shared.testing.plugin` but no `:shared_testing` dep
- [ ] Hook is silent when `:shared_testing` is present in deps
- [ ] Hook skips non-BUILD files (e.g. `.py` files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)