### PR TITLE
docs(agent_platform): update README to match current project structure

### DIFF
--- a/projects/agent_platform/README.md
+++ b/projects/agent_platform/README.md
@@ -11,12 +11,12 @@ See [docs/agents.md](../../docs/agents.md) for the full architecture.
 | Component                | Description |
 | ------------------------ | ----------- |
 | **orchestrator**         | Go service that dispatches agent jobs via NATS JetStream |
-| **sandboxes**            | Isolated Kubernetes pod definitions for agent execution |
-| **cluster_agents**       | Agent configurations for cluster-scoped operations |
+| **sandboxes**            | Shell setup scripts for MCP profiles; Kubernetes sandbox pod definitions live in `chart/sandboxes/` and `chart/agent-sandbox/` |
+| **cluster_agents**       | Go service that monitors cluster health and runs autonomous improvement agents (patrol, escalator, PR fix, README freshness, test coverage, etc.) |
 | **api_gateway**          | Nginx-based API gateway with route-based backend selection for api.jomcgi.dev |
 | **goose_agent**          | Goose agent container and configuration |
 | **llama_cpp**            | On-cluster LLM inference (Gemma 4) |
 | **llama_cpp_embeddings** | On-cluster embedding inference (voyage-4-nano) |
-| **vllm**                 | Alternative LLM serving backend |
+| **vllm**                 | Alternative LLM serving backend (Helm chart and values only — not wired to ArgoCD) |
 | **chart**                | Umbrella Helm chart for all agent platform components |
 | **deploy**               | ArgoCD Application, kustomization, and cluster-specific values |


### PR DESCRIPTION
## Summary

- **`cluster_agents`**: corrected description from "Agent configurations" to accurately reflect it's a Go service binary running autonomous improvement agents (patrol, escalator, PR fix, README freshness, test coverage, etc.)
- **`sandboxes`**: clarified that the root `sandboxes/` directory contains shell setup scripts for MCP profiles; the actual Kubernetes pod definitions live in `chart/sandboxes/` and `chart/agent-sandbox/`
- **`vllm`**: noted that this component has no `application.yaml` or `kustomization.yaml` and is not wired to ArgoCD — it cannot be deployed via GitOps

## Test plan

- [x] README content matches actual directory structure and source files
- [x] No functional code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)