### PR TITLE
fix(hooks): handle single-quoted :shared_testing label in dep check

### DIFF
--- a/bazel/tools/hooks/check-bdd-shared-testing-dep.sh
+++ b/bazel/tools/hooks/check-bdd-shared-testing-dep.sh
@@ -43,8 +43,9 @@ if ! echo "$CONTENT" | grep -q 'shared\.testing\.plugin'; then
 	exit 0
 fi
 
-# Warn if :shared_testing is not present in a deps list
-if ! echo "$CONTENT" | grep -q '":shared_testing"'; then
+# Warn if :shared_testing is not present in a deps list.
+# Match either quoting style: ":shared_testing" or ':shared_testing' (both valid Starlark).
+if ! echo "$CONTENT" | grep -qE '["'"'"']:shared_testing["'"'"']'; then
 	cat >&2 <<-EOF
 		WARNING: ':shared_testing' missing from deps while 'shared.testing.plugin' is used in env.
 

--- a/bazel/tools/hooks/check-bdd-shared-testing-dep_test.sh
+++ b/bazel/tools/hooks/check-bdd-shared-testing-dep_test.sh
@@ -203,6 +203,23 @@ run_test "build_bazel_filename_warns" \
 	"{\"tool_input\":{\"file_path\":\"${TEST_TMPDIR}/t6/BUILD.bazel\"}}" \
 	0 "WARNING.*shared_testing"
 
+# 7. Single-quoted ':shared_testing' dep is equally valid Starlark — no warning
+mkdir -p "${TEST_TMPDIR}/t7"
+cat >"${TEST_TMPDIR}/t7/BUILD" <<'EOF'
+py_test(
+    name = "test_suite",
+    srcs = ["test.py"],
+    env = {"PYTEST_ADDOPTS": "-p shared.testing.plugin"},
+    deps = [
+        ':shared_testing',
+        '//other:dep',
+    ],
+)
+EOF
+run_test "single_quoted_dep_no_warning" \
+	"{\"tool_input\":{\"file_path\":\"${TEST_TMPDIR}/t7/BUILD\"}}" \
+	0 ""
+
 # ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Fixes a false-positive warning in `check-bdd-shared-testing-dep.sh` where targets using `':shared_testing'` (single-quoted, valid Starlark) would incorrectly trigger the missing-dep warning
- Switches dep detection from `grep -q '":shared_testing"'` to `grep -qE` with a character class matching both double and single quote styles
- Adds test case `t7` (`single_quoted_dep_no_warning`) to the test suite

## Root cause

PR #2141 introduced the hook with a `grep` that only matched double-quoted labels. Starlark allows both quote styles, so `':shared_testing'` is equally valid but wasn't recognised, causing a spurious warning every time a BUILD file with a single-quoted dep was written or edited.

## Test plan
- [x] Regex verified inline: double-quoted match, single-quoted match, no false positives
- [ ] CI: `//bazel/tools/hooks:check_bdd_shared_testing_dep_test` passes with 7 test cases (was 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)