### PR TITLE
docs(trips): fix README inaccuracies

### DIFF
--- a/projects/trips/backend/README.md
+++ b/projects/trips/backend/README.md
@@ -425,16 +425,6 @@ Deployed via ArgoCD to Kubernetes cluster.
 
 ## Observability
 
-### Metrics
-
-Exposed at `/metrics` (Prometheus format):
-
-- `trips_points_total` - Total points in cache
-- `trips_uploads_total` - Total photo uploads
-- `trips_websocket_connections` - Active WebSocket connections
-- `trips_nats_messages_total` - NATS messages processed
-- `trips_elevation_api_failures` - Elevation API failures
-
 ### Traces
 
 Instrumented with OpenTelemetry (auto-injected by Kyverno):


### PR DESCRIPTION
## Summary

- Remove the non-existent `/metrics` Prometheus endpoint section from `backend/README.md` — the endpoint does not exist in `main.py` (routes are only `/health`, `/api/points`, `/api/stats`, `/ws/live`)
- Remove `trips_uploads_total` metric (uploads are not handled by this service)
- Add `detect-wildlife` tool to the `tools/` description in the top-level README

## Test plan

- [x] API endpoint docs now match actual routes in `main.py`
- [x] `tools/` description matches actual directory contents