### PR TITLE
feat(semgrep): add bdd-test-missing-covers-marker rule

### DIFF
--- a/bazel/semgrep/rules/python/bdd-test-missing-covers-marker.py
+++ b/bazel/semgrep/rules/python/bdd-test-missing-covers-marker.py
@@ -35,6 +35,7 @@ class TestScheduleAPI:
     @covers_public("home.services.schedule.get_today")
     def test_with_covers_public(self, live_server):
         from home.services import schedule
+
         result = schedule.get_today()
         assert result is not None
 

--- a/bazel/semgrep/rules/python/bdd-test-missing-covers-marker.py
+++ b/bazel/semgrep/rules/python/bdd-test-missing-covers-marker.py
@@ -1,0 +1,66 @@
+# Tests for bdd-test-missing-covers-marker rule.
+#
+# This rule targets **/tests/bdd_*_test.py files only.
+# Test methods (def test_*) MUST have a @covers_route, @covers_page, or
+# @covers_public decorator from shared.testing.markers.
+import httpx
+
+from shared.testing.markers import covers_page, covers_public, covers_route
+
+
+class TestScheduleAPI:
+    # ruleid: bdd-test-missing-covers-marker
+    def test_missing_marker(self, live_server):
+        r = httpx.get(f"{live_server}/api/home/schedule/today")
+        assert r.status_code == 200
+
+    # ruleid: bdd-test-missing-covers-marker
+    def test_another_missing_marker(self, live_server):
+        r = httpx.get(f"{live_server}/api/home/schedule/week")
+        assert r.status_code == 200
+
+    # ok: bdd-test-missing-covers-marker — has @covers_route decorator
+    @covers_route("/api/home/schedule/today")
+    def test_with_covers_route(self, live_server):
+        r = httpx.get(f"{live_server}/api/home/schedule/today")
+        assert r.status_code == 200
+
+    # ok: bdd-test-missing-covers-marker — has @covers_page decorator
+    @covers_page("/home/schedule")
+    def test_with_covers_page(self, live_server):
+        r = httpx.get(f"{live_server}/home/schedule")
+        assert r.status_code == 200
+
+    # ok: bdd-test-missing-covers-marker — has @covers_public decorator
+    @covers_public("home.services.schedule.get_today")
+    def test_with_covers_public(self, live_server):
+        from home.services import schedule
+        result = schedule.get_today()
+        assert result is not None
+
+
+class TestPublicPages:
+    # ruleid: bdd-test-missing-covers-marker
+    def test_page_loads_without_marker(self, live_server):
+        r = httpx.get(f"{live_server}/home")
+        assert r.status_code == 200
+
+    # ok: bdd-test-missing-covers-marker — has @covers_route with method kwarg
+    @covers_route("/api/home/items", method="POST")
+    def test_post_endpoint(self, live_server):
+        r = httpx.post(f"{live_server}/api/home/items", json={"name": "test"})
+        assert r.status_code == 201
+
+
+# ok: bdd-test-missing-covers-marker — helper functions (not test_*) are exempt
+def _setup_fixture(server):
+    return httpx.get(f"{server}/api/health")
+
+
+# ok: bdd-test-missing-covers-marker — non-test methods in test classes are exempt
+class TestHelpers:
+    def setup_method(self):
+        pass
+
+    def teardown_method(self):
+        pass

--- a/bazel/semgrep/rules/python/bdd-test-missing-covers-marker.yaml
+++ b/bazel/semgrep/rules/python/bdd-test-missing-covers-marker.yaml
@@ -1,0 +1,40 @@
+rules:
+  - id: bdd-test-missing-covers-marker
+    patterns:
+      - pattern: |
+          def test_$METHOD(...):
+              ...
+      - pattern-not: |
+          @covers_route(...)
+          def test_$METHOD(...):
+              ...
+      - pattern-not: |
+          @covers_page(...)
+          def test_$METHOD(...):
+              ...
+      - pattern-not: |
+          @covers_public(...)
+          def test_$METHOD(...):
+              ...
+    message: >-
+      BDD test `test_$METHOD` in a `bdd_*_test.py` file is missing a coverage
+      marker. Add `@covers_route(path)`, `@covers_page(path)`, or
+      `@covers_public(qualified_name)` from `shared.testing.markers` so that
+      `bdd_completeness_test.py` can verify the route/page/symbol is exercised.
+    languages: [python]
+    severity: ERROR
+    metadata:
+      category: correctness
+      subcategory: testing
+      confidence: HIGH
+      likelihood: HIGH
+      impact: MEDIUM
+      technology: [python, pytest]
+      description: >-
+        BDD test method lacks a @covers_route, @covers_page, or @covers_public
+        decorator, making it invisible to the BDD completeness checker. A second
+        test for an already-covered route can silently omit the marker and still
+        pass CI — this rule catches it statically.
+    paths:
+      include:
+        - "**/tests/bdd_*_test.py"


### PR DESCRIPTION
## Summary

- Adds `bazel/semgrep/rules/python/bdd-test-missing-covers-marker.yaml`: a new semgrep rule that flags `def test_*` methods in `**/tests/bdd_*_test.py` files that are missing a `@covers_route`, `@covers_page`, or `@covers_public` decorator
- Adds `bazel/semgrep/rules/python/bdd-test-missing-covers-marker.py`: test fixture with `# ruleid:` (positive) and `# ok:` (negative) annotation examples following existing rule conventions
- Both files are auto-discovered by `glob(["python/*.yaml"])` and `glob(["python/*.py"])` in `bazel/semgrep/rules/BUILD` — no BUILD changes required

## Problem

`bdd_completeness_test.py` has a blind spot: if a route is already covered by one compliant test, a second `test_*` method can be added **without a marker** and CI still passes. The marker-less test runs but contributes nothing to coverage tracking and is invisible to the BDD completeness checker.

## Test plan

- [ ] `bazel/semgrep/rules:python_rules_test` passes (SEMGREP_TEST_MODE=1 skips annotation validation; test validates rule YAML is syntactically valid and picked up)
- [ ] `bazel test //...` passes — rule fires on no existing source files (all existing `bdd_*_test.py` files already have markers)
- [ ] Fixture documents both bad patterns (`# ruleid:`) and OK patterns (`# ok:`) for the three decorator variants

Closes #2149

🤖 Generated with [Claude Code](https://claude.com/claude-code)