### PR TITLE
perf(llama-cpp): tune Qwen 3.6 for faster inference

### DIFF
--- a/projects/agent_platform/llama_cpp/deploy/values-prod.yaml
+++ b/projects/agent_platform/llama_cpp/deploy/values-prod.yaml
@@ -13,7 +13,7 @@ modelVolume:
 
 server:
   nGpuLayers: 999
-  ctxSize: 65536
+  ctxSize: 32768
   flashAttn: "on"
   cacheTypeK: "f16"
   cacheTypeV: "q8_0"
@@ -30,7 +30,11 @@ server:
     - "--alias"
     - "qwen3.6-27b"
     - "--reasoning-budget"
-    - "8192"
+    - "2048"
+    - "--spec-type"
+    - "ngram-simple"
+    - "--draft"
+    - "8"
     - "--cache-ram"
     - "4096"
 


### PR DESCRIPTION
## Summary
- Reduce context size 65536 → 32768 (bot prompts peak at ~3K tokens, 32K gives ample headroom)
- Cap reasoning budget 8192 → 2048 tokens (prevents 4+ min invisible thinking for Discord chat)
- Enable n-gram speculative decoding (`--spec-type ngram-simple --draft 8`) for ~1.3-1.8x generation speedup with zero VRAM cost

## Context
After swapping from Gemma 4 (MoE, ~8B active params) to Qwen 3.6 27B (dense), Discord chat responses were hanging due to:
1. Dense model generating at ~20-32 tok/s vs Gemma's faster MoE inference
2. 8192-token reasoning budget adding up to 4 minutes of hidden thinking before visible response
3. No speculative decoding to accelerate token generation

## Test plan
- [ ] Verify llama-cpp pod starts successfully with new args
- [ ] Send a Discord message and confirm response arrives in <30s
- [ ] Check llama-cpp logs for `reasoning-budget: activated, budget=2048`
- [ ] Check logs for speculative decoding activity

🤖 Generated with [Claude Code](https://claude.com/claude-code)