### PR TITLE
feat(inference): switch to vLLM backend with AutoRound INT4

### DIFF
--- a/projects/agent_platform/inference/deploy/Chart.yaml
+++ b/projects/agent_platform/inference/deploy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: inference
 description: A Helm chart for LLM inference (llama.cpp and vLLM backends)
 type: application
-version: 2.1.0
+version: 2.2.0
 appVersion: "b5270"
 keywords:
   - llm

--- a/projects/agent_platform/inference/deploy/templates/deployment.yaml
+++ b/projects/agent_platform/inference/deploy/templates/deployment.yaml
@@ -152,7 +152,8 @@ spec:
         {{- end }}
         {{- if eq .Values.backend "vllm" }}
         - name: vllm-cache
-          emptyDir: {}
+          persistentVolumeClaim:
+            claimName: {{ include "inference.fullname" . }}-vllm-cache
         {{- end }}
         - name: dshm
           emptyDir:

--- a/projects/agent_platform/inference/deploy/templates/deployment.yaml
+++ b/projects/agent_platform/inference/deploy/templates/deployment.yaml
@@ -39,11 +39,6 @@ spec:
           imagePullPolicy: {{ $img.pullPolicy }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          {{- if eq .Values.backend "vllm" }}
-          env:
-            - name: VLLM_USE_PRECOMPILED
-              value: "1"
-          {{- end }}
           {{- if eq .Values.backend "llama-cpp" }}
           {{- if .Values.llamaCpp.modelPath }}
           command: ["/bin/sh", "-c"]

--- a/projects/agent_platform/inference/deploy/templates/deployment.yaml
+++ b/projects/agent_platform/inference/deploy/templates/deployment.yaml
@@ -90,9 +90,13 @@ spec:
           command: ["/bin/sh", "-c"]
           args:
             - |
-              MODEL=$(find {{ .Values.modelVolume.mountPath }} -maxdepth 2 -name '*.gguf' ! -name 'mmproj*' -type f | sort | head -1)
+              # Auto-discover model: HuggingFace format (config.json) or GGUF.
+              MODEL=$(find {{ .Values.modelVolume.mountPath }} -maxdepth 2 -name 'config.json' -type f -exec dirname {} \; | head -1)
               if [ -z "$MODEL" ]; then
-                echo "ERROR: no .gguf file found under {{ .Values.modelVolume.mountPath }}" >&2
+                MODEL=$(find {{ .Values.modelVolume.mountPath }} -maxdepth 2 -name '*.gguf' ! -name 'mmproj*' -type f | sort | head -1)
+              fi
+              if [ -z "$MODEL" ]; then
+                echo "ERROR: no model found under {{ .Values.modelVolume.mountPath }}" >&2
                 exit 1
               fi
               echo "Auto-discovered model: $MODEL"
@@ -128,6 +132,10 @@ spec:
               mountPath: /etc/llama-cpp
               readOnly: true
             {{- end }}
+            {{- if eq .Values.backend "vllm" }}
+            - name: vllm-cache
+              mountPath: /root/.cache
+            {{- end }}
             - name: dshm
               mountPath: /dev/shm
       volumes:
@@ -141,6 +149,10 @@ spec:
         - name: chat-template
           configMap:
             name: {{ include "inference.fullname" . }}-chat-template
+        {{- end }}
+        {{- if eq .Values.backend "vllm" }}
+        - name: vllm-cache
+          emptyDir: {}
         {{- end }}
         - name: dshm
           emptyDir:

--- a/projects/agent_platform/inference/deploy/templates/deployment.yaml
+++ b/projects/agent_platform/inference/deploy/templates/deployment.yaml
@@ -39,6 +39,11 @@ spec:
           imagePullPolicy: {{ $img.pullPolicy }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
+          {{- if eq .Values.backend "vllm" }}
+          env:
+            - name: VLLM_USE_PRECOMPILED
+              value: "1"
+          {{- end }}
           {{- if eq .Values.backend "llama-cpp" }}
           {{- if .Values.llamaCpp.modelPath }}
           command: ["/bin/sh", "-c"]

--- a/projects/agent_platform/inference/deploy/templates/pvc-vllm-cache.yaml
+++ b/projects/agent_platform/inference/deploy/templates/pvc-vllm-cache.yaml
@@ -1,0 +1,14 @@
+{{- if eq .Values.backend "vllm" }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "inference.fullname" . }}-vllm-cache
+  labels:
+    {{- include "inference.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 2Gi
+{{- end }}

--- a/projects/agent_platform/inference/deploy/values-prod.yaml
+++ b/projects/agent_platform/inference/deploy/values-prod.yaml
@@ -1,45 +1,48 @@
 fullnameOverride: "inference"
 
-backend: "llama-cpp"
+backend: "vllm"
 
 image:
   llamaCpp:
     tag: "server-cuda-b8643"
+  vllm:
+    tag: "v0.9.1"
 
 imagePullSecret:
   enabled: true
 
 modelVolume:
   enabled: true
-  reference: "ghcr.io/jomcgi/models/qwen/qwen3.6-27b:unsloth-gguf-q4-k-m-mmproj"
+  reference: "ghcr.io/jomcgi/models/qwen/qwen3.6-27b:lorbus-qwen3.6-27b-int4-autoround"
   mountPath: "/model-image"
 
-llamaCpp:
-  nGpuLayers: 999
-  ctxSize: 32768
-  flashAttn: "on"
-  cacheTypeK: "f16"
-  cacheTypeV: "q8_0"
-  threads: 8
-  jinja: true
+vllm:
+  maxModelLen: 16384
+  gpuMemoryUtilization: 0.95
+  dtype: "auto"
   extraArgs:
-    - "--batch-size"
-    - "2048"
-    - "--ubatch-size"
-    - "512"
-    - "--parallel"
-    - "1"
-    - "--metrics"
-    - "--alias"
+    - "--served-model-name"
     - "qwen3.6-27b"
-    - "--reasoning-budget"
-    - "2048"
-    - "--spec-type"
-    - "ngram-simple"
-    - "--draft"
-    - "8"
-    - "--cache-ram"
-    - "4096"
+    - "--num-speculative-tokens"
+    - "4"
+    - "--enable-auto-tool-choice"
+    - "--tool-call-parser"
+    - "hermes"
+
+# vLLM runs as root and needs writable fs for compiled kernels
+podSecurityContext:
+  runAsUser: 0
+  runAsGroup: 0
+  fsGroup: 0
+  seccompProfile:
+    type: RuntimeDefault
+
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: false
+  capabilities:
+    drop:
+      - ALL
 
 nodeSelector:
   kubernetes.io/hostname: node-4
@@ -51,11 +54,11 @@ podAnnotations:
 
 resources:
   requests:
-    cpu: 2
-    memory: "8Gi"
+    cpu: 4
+    memory: "24Gi"
     nvidia.com/gpu: 1
   limits:
-    memory: "16Gi"
+    memory: "32Gi"
     nvidia.com/gpu: 1
 
 embeddings:


### PR DESCRIPTION
## Summary

- Switches inference backend from `llama-cpp` to `vllm` for Qwen 3.6 27B
- Uses `Lorbus/Qwen3.6-27B-int4-AutoRound` (W4A16, 18GB) — native MTP speculative decoding preserved
- Updates deployment template to auto-discover HuggingFace-format models (config.json)
- Adds writable cache volume for vLLM's compiled CUDA/Triton kernels
- Adjusts security context for vLLM (runs as root, writable rootfs)

## Why

llama.cpp's hybrid Mamba+Attention support causes 34 CUDA graph splits per token, starving the GPU (0% util, 86W power). vLLM has fused Mamba kernels that should unlock 40-50+ tok/s. The AutoRound INT4 model preserves the MTP head for native speculative decoding (~90% draft acceptance, ~2x throughput).

## Rollback

If vLLM fails, change `backend: "vllm"` back to `backend: "llama-cpp"` and revert model image reference to the GGUF variant.

## Test plan

- [ ] vLLM pod starts and loads model successfully
- [ ] Health checks pass
- [ ] Discord chat responds (test via monolith)
- [ ] Compare tok/s with previous llama-cpp setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)