### PR TITLE
feat(inference): update vLLM to v0.19.1

### DIFF
--- a/projects/agent_platform/inference/deploy/values-prod.yaml
+++ b/projects/agent_platform/inference/deploy/values-prod.yaml
@@ -6,7 +6,7 @@ image:
   llamaCpp:
     tag: "server-cuda-b8643"
   vllm:
-    tag: "v0.9.1"
+    tag: "v0.19.1"
 
 imagePullSecret:
   enabled: true


### PR DESCRIPTION
## Summary

- Updates vLLM image tag from `v0.9.1` to `v0.19.1`
- v0.19.0+ is the recommended minimum for Qwen 3.6 hybrid Mamba+Attention architecture support

## Test plan

- [ ] Inference pod starts with v0.19.1 image
- [ ] Model loads and health checks pass
- [ ] Chat responds via Discord

🤖 Generated with [Claude Code](https://claude.com/claude-code)