### PR TITLE
fix(inference): remove deprecated --num-speculative-tokens flag

### DIFF
--- a/projects/agent_platform/inference/deploy/values-prod.yaml
+++ b/projects/agent_platform/inference/deploy/values-prod.yaml
@@ -23,8 +23,6 @@ vllm:
   extraArgs:
     - "--served-model-name"
     - "qwen3.6-27b"
-    - "--num-speculative-tokens"
-    - "4"
     - "--enable-auto-tool-choice"
     - "--tool-call-parser"
     - "hermes"


### PR DESCRIPTION
## Summary
- Removes `--num-speculative-tokens 4` from vLLM extraArgs in prod values
- vLLM v0.19.1 consolidated speculative decoding into `--speculative-config` JSON arg
- Unblocks inference pod startup (currently in CrashLoopBackOff due to unrecognized arg)

## Test plan
- [ ] CI passes
- [ ] Inference pod starts successfully after merge
- [ ] vLLM serves the Qwen 3.6 27B model on `/v1/chat/completions`

🤖 Generated with [Claude Code](https://claude.com/claude-code)