### PR TITLE
fix(inference): add CPU offload to prevent CUDA OOM on 4090

### DIFF
--- a/projects/agent_platform/inference/deploy/values-prod.yaml
+++ b/projects/agent_platform/inference/deploy/values-prod.yaml
@@ -23,6 +23,8 @@ vllm:
   extraArgs:
     - "--served-model-name"
     - "qwen3.6-27b"
+    - "--cpu-offload-gb"
+    - "10"
     - "--enable-auto-tool-choice"
     - "--tool-call-parser"
     - "hermes"
@@ -53,10 +55,10 @@ podAnnotations:
 resources:
   requests:
     cpu: 4
-    memory: "24Gi"
+    memory: "34Gi"
     nvidia.com/gpu: 1
   limits:
-    memory: "32Gi"
+    memory: "48Gi"
     nvidia.com/gpu: 1
 
 embeddings:


### PR DESCRIPTION
## Summary
- Adds `--cpu-offload-gb 10` to offload model weights to system RAM
- Bumps pod memory requests/limits (34Gi/48Gi) to accommodate offloaded tensors
- Fixes CUDA OOM: vLLM v0.19.1 torch.compile overhead + 17.5 GiB model exceeds 23.5 GiB VRAM

## Context
```
torch.OutOfMemoryError: CUDA out of memory. Tried to allocate 1.53 GiB.
GPU 0 has a total capacity of 23.52 GiB of which 545.81 MiB is free.
```

## Test plan
- [ ] CI passes
- [ ] Inference pod starts without OOM
- [ ] `/v1/chat/completions` responds with qwen3.6-27b model

🤖 Generated with [Claude Code](https://claude.com/claude-code)