### PR TITLE
fix(inference): use --enforce-eager to avoid CUDA OOM on 4090

### DIFF
--- a/projects/agent_platform/inference/deploy/values-prod.yaml
+++ b/projects/agent_platform/inference/deploy/values-prod.yaml
@@ -23,8 +23,7 @@ vllm:
   extraArgs:
     - "--served-model-name"
     - "qwen3.6-27b"
-    - "--cpu-offload-gb"
-    - "10"
+    - "--enforce-eager"
     - "--enable-auto-tool-choice"
     - "--tool-call-parser"
     - "hermes"
@@ -55,10 +54,10 @@ podAnnotations:
 resources:
   requests:
     cpu: 4
-    memory: "34Gi"
+    memory: "24Gi"
     nvidia.com/gpu: 1
   limits:
-    memory: "48Gi"
+    memory: "32Gi"
     nvidia.com/gpu: 1
 
 embeddings:


### PR DESCRIPTION
## Summary
- Replaces `--cpu-offload-gb 10` with `--enforce-eager` (cpu-offload is broken in v0.19.1, see vllm-project/vllm#18298)
- Disables torch.compile which adds ~5 GiB overhead, exceeding 4090's 23.5 GiB VRAM
- Reverts memory limits to original values (no CPU offload = no extra RAM needed)

## Test plan
- [ ] CI passes
- [ ] Inference pod starts without OOM
- [ ] `/v1/chat/completions` responds with qwen3.6-27b model

🤖 Generated with [Claude Code](https://claude.com/claude-code)