### PR TITLE
fix(inference): use qwen3_coder tool parser for Qwen3.6

### DIFF
--- a/projects/agent_platform/inference/deploy/Chart.yaml
+++ b/projects/agent_platform/inference/deploy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: inference
 description: A Helm chart for LLM inference (llama.cpp and vLLM backends)
 type: application
-version: 2.3.0
+version: 2.4.0
 appVersion: "b5270"
 keywords:
   - llm

--- a/projects/agent_platform/inference/deploy/values-prod.yaml
+++ b/projects/agent_platform/inference/deploy/values-prod.yaml
@@ -11,98 +11,6 @@ image:
 imagePullSecret:
   enabled: true
 
-server:
-  chatTemplate: |
-    {%- if tools %}
-        {{- '<|im_start|>system\n' }}
-        {%- if messages[0].role == 'system' %}
-            {{- messages[0].content + '\n\n' }}
-        {%- endif %}
-        {{- "# Tools\n\nYou may call one or more functions to assist with the user query.\n\nYou are provided with function signatures within <tools></tools> XML tags:\n<tools>" }}
-        {%- for tool in tools %}
-            {{- "\n" }}
-            {{- tool | tojson }}
-        {%- endfor %}
-        {{- "\n</tools>\n\nFor each function call, return a json object with function name and arguments within <tool_call></tool_call> XML tags:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call><|im_end|>\n" }}
-    {%- else %}
-        {%- if messages[0].role == 'system' %}
-            {{- '<|im_start|>system\n' + messages[0].content + '<|im_end|>\n' }}
-        {%- endif %}
-    {%- endif %}
-    {%- set ns = namespace(multi_step_tool=true, last_query_index=messages|length - 1) %}
-    {%- for message in messages[::-1] %}
-        {%- set index = (messages|length - 1) - loop.index0 %}
-        {%- if ns.multi_step_tool and message.role == "user" and message.content is string and not(message.content.startswith('<tool_response>') and message.content.endswith('</tool_response>')) %}
-            {%- set ns.multi_step_tool = false %}
-            {%- set ns.last_query_index = index %}
-        {%- endif %}
-    {%- endfor %}
-    {%- for message in messages %}
-        {%- if message.content is string %}
-            {%- set content = message.content %}
-        {%- else %}
-            {%- set content = '' %}
-        {%- endif %}
-        {%- if (message.role == "user") or (message.role == "system" and not loop.first) %}
-            {{- '<|im_start|>' + message.role + '\n' + content + '<|im_end|>' + '\n' }}
-        {%- elif message.role == "assistant" %}
-            {%- set reasoning_content = '' %}
-            {%- if message.reasoning_content is string %}
-                {%- set reasoning_content = message.reasoning_content %}
-            {%- else %}
-                {%- if '</think>' in content %}
-                    {%- set reasoning_content = content.split('</think>')[0].rstrip('\n').split('<think>')[-1].lstrip('\n') %}
-                    {%- set content = content.split('</think>')[-1].lstrip('\n') %}
-                {%- endif %}
-            {%- endif %}
-            {%- if loop.index0 > ns.last_query_index %}
-                {%- if loop.last or (not loop.last and reasoning_content) %}
-                    {{- '<|im_start|>' + message.role + '\n<think>\n' + reasoning_content.strip('\n') + '\n</think>\n\n' + content.lstrip('\n') }}
-                {%- else %}
-                    {{- '<|im_start|>' + message.role + '\n' + content }}
-                {%- endif %}
-            {%- else %}
-                {{- '<|im_start|>' + message.role + '\n' + content }}
-            {%- endif %}
-            {%- if message.tool_calls %}
-                {%- for tool_call in message.tool_calls %}
-                    {%- if (loop.first and content) or (not loop.first) %}
-                        {{- '\n' }}
-                    {%- endif %}
-                    {%- if tool_call.function %}
-                        {%- set tool_call = tool_call.function %}
-                    {%- endif %}
-                    {{- '<tool_call>\n{"name": "' }}
-                    {{- tool_call.name }}
-                    {{- '", "arguments": ' }}
-                    {%- if tool_call.arguments is string %}
-                        {{- tool_call.arguments }}
-                    {%- else %}
-                        {{- tool_call.arguments | tojson }}
-                    {%- endif %}
-                    {{- '}\n</tool_call>' }}
-                {%- endfor %}
-            {%- endif %}
-            {{- '<|im_end|>\n' }}
-        {%- elif message.role == "tool" %}
-            {%- if loop.first or (messages[loop.index0 - 1].role != "tool") %}
-                {{- '<|im_start|>user' }}
-            {%- endif %}
-            {{- '\n<tool_response>\n' }}
-            {{- content }}
-            {{- '\n</tool_response>' }}
-            {%- if loop.last or (messages[loop.index0 + 1].role != "tool") %}
-                {{- '<|im_end|>\n' }}
-            {%- endif %}
-        {%- endif %}
-    {%- endfor %}
-    {%- if add_generation_prompt %}
-        {{- '<|im_start|>assistant\n' }}
-        {%- if enable_thinking is defined and enable_thinking is false %}
-            {{- '<think>\n\n</think>\n\n' }}
-        {%- endif %}
-    {%- endif %}
-
 modelVolume:
   enabled: true
   reference: "ghcr.io/jomcgi/models/qwen/qwen3.6-27b:lorbus-qwen3.6-27b-int4-autoround"
@@ -118,7 +26,9 @@ vllm:
     - "--enforce-eager"
     - "--enable-auto-tool-choice"
     - "--tool-call-parser"
-    - "hermes"
+    - "qwen3_coder"
+    - "--reasoning-parser"
+    - "qwen3"
 
 # vLLM runs as root and needs writable fs for compiled kernels
 podSecurityContext:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.52.1
+version: 0.52.2
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chat/explorer.py
+++ b/projects/monolith/chat/explorer.py
@@ -43,7 +43,7 @@ def create_explorer_agent() -> Agent[ExplorerDeps]:
     agent: Agent[ExplorerDeps] = Agent(
         model,
         system_prompt=SYSTEM_PROMPT,
-        model_settings=ModelSettings(max_tokens=4096),
+        model_settings=ModelSettings(),
     )
 
     @agent.tool

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.52.1
+      targetRevision: 0.52.2
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
## Summary
- Switch `--tool-call-parser` from `hermes` to `qwen3_coder` per [vLLM's Qwen3.5/3.6 recipe](https://docs.vllm.ai/projects/recipes/en/latest/Qwen/Qwen3.5.html)
- Add `--reasoning-parser qwen3` for proper thinking/reasoning extraction
- Remove custom Hermes-style chat template — use model's built-in template which aligns with `qwen3_coder` parser
- Remove hardcoded `max_tokens=4096` from KG explorer agent (same fix as cf57ba20b for Discord chat agent)

## Context
The KG chat API was returning garbled output with `[Error: Failed to parse input at pos 22:` errors. Root cause: the `hermes` tool call parser was designed for Qwen2.5 and doesn't match Qwen3.6's tool call output format, causing parse failures that leak corrupted text into the response stream.

## Test plan
- [ ] Verify inference pod starts cleanly with new vLLM args
- [ ] Test Discord bot still responds correctly (uses same inference backend)
- [ ] Test KG explorer chat API returns coherent responses
- [ ] Verify tool calling works (explorer should call `search_kg`, `expand_node`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)