### PR TITLE
perf(monolith): limit thinking tokens to reduce response latency

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.52.3
+version: 0.52.4
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chat/agent.py
+++ b/projects/monolith/chat/agent.py
@@ -135,7 +135,9 @@ def create_agent(base_url: str | None = None) -> Agent[ChatDeps]:
     agent: Agent[ChatDeps] = Agent(
         model,
         system_prompt=build_system_prompt(),
-        model_settings=ModelSettings(),
+        model_settings=ModelSettings(
+            extra_body={"thinking_token_budget": 1024},
+        ),
         prepare_tools=inject_signposts,
     )
 

--- a/projects/monolith/chat/explorer.py
+++ b/projects/monolith/chat/explorer.py
@@ -43,7 +43,9 @@ def create_explorer_agent() -> Agent[ExplorerDeps]:
     agent: Agent[ExplorerDeps] = Agent(
         model,
         system_prompt=SYSTEM_PROMPT,
-        model_settings=ModelSettings(),
+        model_settings=ModelSettings(
+            extra_body={"thinking_token_budget": 1024},
+        ),
     )
 
     @agent.tool

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.52.3
+      targetRevision: 0.52.4
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
## Summary
- Set `thinking_token_budget=1024` via `extra_body` in PydanticAI `ModelSettings` for both the Discord chat agent and KG explorer agent
- Qwen3.6 enables thinking by default, generating extensive `<think>` blocks that were causing ~5min response times on the 4090
- At 31.7 tok/s, 1024 tokens caps thinking to ~30s while still allowing useful reasoning

## Test plan
- [ ] Verify Discord bot responds within ~1min instead of ~5min
- [ ] Verify KG explorer `/api/chat/explore` responds within ~1min
- [ ] Confirm response quality is still reasonable with limited thinking budget

🤖 Generated with [Claude Code](https://claude.com/claude-code)