### PR TITLE
fix(inference): add --reasoning-config for thinking token budget

### DIFF
--- a/projects/agent_platform/inference/deploy/values-prod.yaml
+++ b/projects/agent_platform/inference/deploy/values-prod.yaml
@@ -188,6 +188,8 @@ vllm:
     - "qwen3_coder"
     - "--reasoning-parser"
     - "qwen3"
+    - "--reasoning-config"
+    - '{"reasoning_start_str": "<think>", "reasoning_end_str": "</think>"}'
 
 # vLLM runs as root and needs writable fs for compiled kernels
 podSecurityContext:


### PR DESCRIPTION
## Summary
- Add `--reasoning-config '{"reasoning_start_str": "<think>", "reasoning_end_str": "</think>"}'` to vLLM server args
- Required for vLLM to enforce `thinking_token_budget` set in PR #2166
- Without this, vLLM rejects requests with: `thinking_token_budget is set but reasoning_config is not configured`

## Test plan
- [ ] Inference pod starts without errors
- [ ] Discord bot responds within ~1min (thinking capped at 1024 tokens)
- [ ] KG explorer responds within ~1min

🤖 Generated with [Claude Code](https://claude.com/claude-code)