### PR TITLE
fix(inference): quote vLLM extraArgs to preserve JSON values

### DIFF
--- a/projects/agent_platform/inference/deploy/templates/_helpers.tpl
+++ b/projects/agent_platform/inference/deploy/templates/_helpers.tpl
@@ -109,7 +109,7 @@ vLLM CLI arguments.
 --chat-template /etc/chat-template/chat-template.jinja \
 {{- end }}
 {{- range .Values.vllm.extraArgs }}
-{{ . }} \
+{{ . | quote }} \
 {{- end }}
 --dtype {{ .Values.vllm.dtype }}
 {{- end }}

--- a/projects/agent_platform/inference/deploy/values-prod.yaml
+++ b/projects/agent_platform/inference/deploy/values-prod.yaml
@@ -188,6 +188,8 @@ vllm:
     - "qwen3_coder"
     - "--reasoning-parser"
     - "qwen3"
+    - "--reasoning-config"
+    - '{"reasoning_start_str": "<think>", "reasoning_end_str": "</think>"}'
 
 # vLLM runs as root and needs writable fs for compiled kernels
 podSecurityContext:


### PR DESCRIPTION
## Summary
- Add `| quote` to vLLM `extraArgs` template rendering (matching llama.cpp's existing approach)
- Without quoting, JSON values like `--reasoning-config '{"reasoning_start_str": ...}'` get word-split by the shell, causing parse errors
- This was preventing `--reasoning-config` (added in #2167) from working

## Test plan
- [ ] Inference pod starts without `json_invalid` error
- [ ] `helm template` renders extraArgs with proper shell quoting
- [ ] Discord bot and KG explorer respond with limited thinking time

🤖 Generated with [Claude Code](https://claude.com/claude-code)