### PR TITLE
fix(monolith): disable thinking to fix response latency

### DIFF
--- a/projects/agent_platform/inference/deploy/templates/_helpers.tpl
+++ b/projects/agent_platform/inference/deploy/templates/_helpers.tpl
@@ -109,7 +109,7 @@ vLLM CLI arguments.
 --chat-template /etc/chat-template/chat-template.jinja \
 {{- end }}
 {{- range .Values.vllm.extraArgs }}
-{{ . }} \
+{{ . | quote }} \
 {{- end }}
 --dtype {{ .Values.vllm.dtype }}
 {{- end }}

--- a/projects/agent_platform/inference/deploy/values-prod.yaml
+++ b/projects/agent_platform/inference/deploy/values-prod.yaml
@@ -188,6 +188,8 @@ vllm:
     - "qwen3_coder"
     - "--reasoning-parser"
     - "qwen3"
+    - "--reasoning-config"
+    - '{"reasoning_start_str": "<think>", "reasoning_end_str": "</think>"}'
 
 # vLLM runs as root and needs writable fs for compiled kernels
 podSecurityContext:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.52.4
+version: 0.52.5
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chat/agent.py
+++ b/projects/monolith/chat/agent.py
@@ -136,7 +136,7 @@ def create_agent(base_url: str | None = None) -> Agent[ChatDeps]:
         model,
         system_prompt=build_system_prompt(),
         model_settings=ModelSettings(
-            extra_body={"thinking_token_budget": 1024},
+            extra_body={"chat_template_kwargs": {"enable_thinking": False}},
         ),
         prepare_tools=inject_signposts,
     )

--- a/projects/monolith/chat/explorer.py
+++ b/projects/monolith/chat/explorer.py
@@ -44,7 +44,7 @@ def create_explorer_agent() -> Agent[ExplorerDeps]:
         model,
         system_prompt=SYSTEM_PROMPT,
         model_settings=ModelSettings(
-            extra_body={"thinking_token_budget": 1024},
+            extra_body={"chat_template_kwargs": {"enable_thinking": False}},
         ),
     )
 

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.52.4
+      targetRevision: 0.52.5
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
## Summary
- Replace `thinking_token_budget: 1024` with `chat_template_kwargs: {"enable_thinking": false}`
- `thinking_token_budget` has known bugs in vLLM v0.19.1 (silently ignored, not enforced with MTP)
- `enable_thinking: false` uses the Qwen3.6 template's native support — inserts empty `<think></think>` block, zero thinking tokens generated
- Applied to both Discord chat agent and KG explorer agent

## Test plan
- [ ] Discord bot responds in seconds instead of minutes
- [ ] KG explorer responds in seconds instead of minutes  
- [ ] Response quality is acceptable without thinking

🤖 Generated with [Claude Code](https://claude.com/claude-code)