### PR TITLE
fix(monolith): use recommended Qwen3.6 thinking-mode sampling params

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.52.5
+version: 0.52.6
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chat/agent.py
+++ b/projects/monolith/chat/agent.py
@@ -136,7 +136,12 @@ def create_agent(base_url: str | None = None) -> Agent[ChatDeps]:
         model,
         system_prompt=build_system_prompt(),
         model_settings=ModelSettings(
-            extra_body={"chat_template_kwargs": {"enable_thinking": False}},
+            temperature=1.0,
+            top_p=0.95,
+            extra_body={
+                "top_k": 20,
+                "presence_penalty": 1.5,
+            },
         ),
         prepare_tools=inject_signposts,
     )

--- a/projects/monolith/chat/explorer.py
+++ b/projects/monolith/chat/explorer.py
@@ -44,7 +44,12 @@ def create_explorer_agent() -> Agent[ExplorerDeps]:
         model,
         system_prompt=SYSTEM_PROMPT,
         model_settings=ModelSettings(
-            extra_body={"chat_template_kwargs": {"enable_thinking": False}},
+            temperature=1.0,
+            top_p=0.95,
+            extra_body={
+                "top_k": 20,
+                "presence_penalty": 1.5,
+            },
         ),
     )
 

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.52.5
+      targetRevision: 0.52.6
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
## Summary
- Re-enable thinking mode (reverts disable from #2169)
- Set official Qwen3.6 recommended sampling params: `temperature=1.0`, `top_p=0.95`, `top_k=20`, `presence_penalty=1.5`
- The 5-min response times were caused by missing `presence_penalty` — without it the model loops endlessly in `<think>` blocks
- `presence_penalty=1.5` forces the model to reach conclusions instead of re-treading the same reasoning

## Test plan
- [ ] Discord bot responds within ~30s-1min with thinking enabled
- [ ] KG explorer responds within ~30s-1min with thinking enabled
- [ ] Response quality is good (thinking should improve tool-calling accuracy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)