### PR TITLE
perf(inference): tune vLLM for single-user latency

### DIFF
--- a/projects/agent_platform/inference/deploy/values-prod.yaml
+++ b/projects/agent_platform/inference/deploy/values-prod.yaml
@@ -182,7 +182,6 @@ vllm:
   extraArgs:
     - "--served-model-name"
     - "qwen3.6-27b"
-    - "--enforce-eager"
     - "--enable-auto-tool-choice"
     - "--tool-call-parser"
     - "qwen3_coder"
@@ -190,6 +189,10 @@ vllm:
     - "qwen3"
     - "--reasoning-config"
     - '{"reasoning_start_str": "<think>", "reasoning_end_str": "</think>"}'
+    - "--max-num-seqs"
+    - "1"
+    - "--speculative-config"
+    - '{"method": "mtp", "num_speculative_tokens": 1}'
 
 # vLLM runs as root and needs writable fs for compiled kernels
 podSecurityContext:


### PR DESCRIPTION
## Summary
Three optimizations targeting single-request latency on the RTX 4090:

- **Remove `--enforce-eager`** — Re-enables CUDA graphs and torch.compile. CUDA graphs alone can provide ~5-8x decode speedup by replaying captured GPU kernel sequences instead of re-launching them each step.
- **Add `--max-num-seqs 1`** — Tells the scheduler we only serve one request at a time, eliminating batching overhead.
- **Enable MTP speculative decoding** — Qwen3.6-27B has native multi-token prediction. `num_speculative_tokens=1` predicts one extra token per step (~10-15% latency improvement) with no draft model needed.

### Rollback plan
If CUDA graph capture OOMs during startup, add `--enforce-eager` back. If MTP causes issues with tool calling or reasoning, remove the `--speculative-config` arg.

## Test plan
- [ ] Inference pod starts successfully (no OOM during CUDA graph capture)
- [ ] Discord bot responds noticeably faster
- [ ] KG explorer responds noticeably faster
- [ ] Tool calling still works correctly
- [ ] Thinking mode still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)