### PR TITLE
fix(chat): parse JSON tool args and use authoritative stream output

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.53.0
+version: 0.53.1
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chat/bot.py
+++ b/projects/monolith/chat/bot.py
@@ -2,11 +2,13 @@
 
 import asyncio
 import hashlib
+import json
 import logging
 import os
 
 import discord
 from pydantic_ai import (
+    AgentRunResultEvent,
     BinaryContent,
     FunctionToolCallEvent,
     PartDeltaEvent,
@@ -399,7 +401,12 @@ class ChatBot(discord.Client):
             async for event in self.agent.run_stream_events(agent_prompt, deps=deps):
                 had_events = True
 
-                if isinstance(event, PartDeltaEvent):
+                if isinstance(event, AgentRunResultEvent):
+                    # Use the authoritative final output if available
+                    final_output = event.result.output
+                    if final_output and isinstance(final_output, str):
+                        response_text = final_output
+                elif isinstance(event, PartDeltaEvent):
                     if isinstance(event.delta, ThinkingPartDelta):
                         await _ensure_sent("\U0001f4ad Thinking...")
                         thinking_parts.append(event.delta.content_delta)
@@ -409,6 +416,11 @@ class ChatBot(discord.Client):
                         await _edit_if_due(response_text)
                 elif isinstance(event, FunctionToolCallEvent):
                     args = event.part.args
+                    if isinstance(args, str):
+                        try:
+                            args = json.loads(args)
+                        except (json.JSONDecodeError, TypeError):
+                            pass
                     if isinstance(args, dict):
                         query = args.get("query", str(args))
                     else:

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.53.0
+      targetRevision: 0.53.1
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
## Summary

- Parse JSON string args from PydanticAI tool call events so search indicator shows clean query text instead of raw JSON
- Use `AgentRunResultEvent.result.output` as authoritative final response, preventing truncated output when `TextPartDelta` events are incomplete

## Test plan

- [ ] Verify search indicator shows "• query text" not JSON
- [ ] Verify full response text appears (no "NG" truncation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)