### PR TITLE
fix(inference): disable MTP speculative decoding to fix gibberish

### DIFF
--- a/projects/agent_platform/inference/deploy/values-prod.yaml
+++ b/projects/agent_platform/inference/deploy/values-prod.yaml
@@ -191,8 +191,6 @@ vllm:
     - '{"reasoning_start_str": "<think>", "reasoning_end_str": "</think>"}'
     - "--max-num-seqs"
     - "1"
-    - "--speculative-config"
-    - '{"method": "mtp", "num_speculative_tokens": 1}'
 
 # vLLM runs as root and needs writable fs for compiled kernels
 podSecurityContext:


### PR DESCRIPTION
## Summary
- Removes `--speculative-config` (MTP) from vLLM inference args to fix corrupted multilingual gibberish output
- MTP speculative decoding is buggy with INT4 quantized models on vLLM v0.19.1 (vllm-project/vllm#36872, #35288, #34650)
- Keeps CUDA graphs and `--max-num-seqs 1` for stable single-request inference

## Test plan
- [ ] Verify inference pod restarts with updated args (no `--speculative-config` in process args)
- [ ] Send test messages to the Discord bot and confirm coherent responses (no gibberish)
- [ ] Check monolith logs for absence of `openai.APIError: Failed to parse input` errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)