### PR TITLE
feat(semgrep): add no-unquoted-helm-range-args rule

### DIFF
--- a/bazel/semgrep/rules/BUILD
+++ b/bazel/semgrep/rules/BUILD
@@ -182,6 +182,22 @@ semgrep_test(
     tags = ["semgrep"],
 )
 
+# no-unquoted-helm-range-args uses languages: [generic] so its fixture is a YAML
+# file. This test wires the rule to its annotation fixture independently of
+# yaml_rules_test (which scans yaml_fixtures, excluding this fixture).
+filegroup(
+    name = "no_unquoted_helm_range_args_rule",
+    srcs = ["yaml/no-unquoted-helm-range-args.yaml"],
+)
+
+semgrep_test(
+    name = "no_unquoted_helm_range_args_test",
+    srcs = ["//bazel/semgrep/tests:no_unquoted_helm_range_args_fixtures"],
+    env = {"SEMGREP_TEST_MODE": "1"},
+    rules = [":no_unquoted_helm_range_args_rule"],
+    tags = ["semgrep"],
+)
+
 # stale-copyright-year uses languages: [generic] so its fixture is a YAML file.
 # This test wires the rule to its annotation fixture independently of
 # golang_rules_test (which only scans *.go sources).

--- a/bazel/semgrep/rules/yaml/no-unquoted-helm-range-args.yaml
+++ b/bazel/semgrep/rules/yaml/no-unquoted-helm-range-args.yaml
@@ -1,0 +1,28 @@
+rules:
+  - id: no-unquoted-helm-range-args
+    languages: [generic]
+    severity: WARNING
+    message: >-
+      Helm range loop variable rendered without | quote filter in chart template.
+      When iterating over .Values.* lists, {{ . }} renders the raw value without
+      quoting — JSON or string values containing colons, braces, or special
+      characters will break the rendered YAML manifest. Use {{ . | quote }} to
+      safely render each loop value. See PR #2168 where vLLM extraArgs JSON
+      values broke the container entrypoint due to unquoted {{ . }} in a range
+      block.
+    metadata:
+      category: correctness
+      subcategory: helm
+      confidence: HIGH
+      likelihood: HIGH
+      impact: HIGH
+      technology: [helm, kubernetes]
+      description: >-
+        Detects unquoted range loop variable rendering in Helm chart templates.
+        Bare {{ . }} in a range block renders raw values that can break YAML
+        manifests when values contain JSON, colons, braces, or other special
+        characters.
+    paths:
+      include:
+        - "**/chart/templates/**"
+    pattern-regex: '\{\{-?\s*\.\s*-?\}\}'

--- a/bazel/semgrep/tests/BUILD
+++ b/bazel/semgrep/tests/BUILD
@@ -13,6 +13,7 @@ filegroup(
             "fixtures/no-create-extension-sql.yaml",
             "fixtures/no-discarded-json-marshal.yaml",
             "fixtures/no-shared-preload-libraries-cnpg.yaml",
+            "fixtures/no-unquoted-helm-range-args.yaml",
             "fixtures/python-shadow-module-import.yaml",
             "fixtures/require-cnpg-cluster-resources.yaml",
             "fixtures/unsafe-json-field-access.yaml",
@@ -51,6 +52,13 @@ filegroup(
 filegroup(
     name = "no_generic_test_filename_fixtures",
     srcs = ["fixtures/no-generic-test-filename.py"],
+)
+
+# Fixture for the no-unquoted-helm-range-args rule (languages: generic).
+# Referenced by //bazel/semgrep/rules:no_unquoted_helm_range_args_test.
+filegroup(
+    name = "no_unquoted_helm_range_args_fixtures",
+    srcs = ["fixtures/no-unquoted-helm-range-args.yaml"],
 )
 
 # Fixtures for kubernetes rules (require-readiness-probe, require-resource-limits, etc.).

--- a/bazel/semgrep/tests/fixtures/no-unquoted-helm-range-args.yaml
+++ b/bazel/semgrep/tests/fixtures/no-unquoted-helm-range-args.yaml
@@ -1,0 +1,50 @@
+# Tests for no-unquoted-helm-range-args rule.
+# Helm range loops over .Values.* must quote the loop variable — bare {{ . }}
+# renders raw values that can contain JSON, colons, or braces that break the
+# rendered YAML manifest. Based on PR #2168 where vLLM extraArgs JSON values
+# broke the container entrypoint due to unquoted {{ . }} in a range block.
+---
+{{- range .Values.extraArgs }}
+# ruleid: no-unquoted-helm-range-args
+- {{ . }}
+{{- end }}
+
+---
+{{- range .Values.command }}
+# ruleid: no-unquoted-helm-range-args
+- {{.}}
+{{- end }}
+
+---
+{{- range .Values.args }}
+# ruleid: no-unquoted-helm-range-args
+- {{- . }}
+{{- end }}
+
+---
+{{- range .Values.extraArgs }}
+# ruleid: no-unquoted-helm-range-args
+- {{ . -}}
+{{- end }}
+
+---
+# ok: no-unquoted-helm-range-args — uses quote filter to safely render loop value
+{{- range .Values.extraArgs }}
+- {{ . | quote }}
+{{- end }}
+
+---
+# ok: no-unquoted-helm-range-args — uses toJson to render complex objects
+{{- range .Values.extraArgs }}
+- {{ toJson . }}
+{{- end }}
+
+---
+# ok: no-unquoted-helm-range-args — explicit named value reference, not bare loop variable
+- {{ .Values.someKey | quote }}
+
+---
+# ok: no-unquoted-helm-range-args — trimmed range with quote filter
+{{- range .Values.args }}
+- {{- . | quote }}
+{{- end }}


### PR DESCRIPTION
## Summary

- Adds a new semgrep rule `no-unquoted-helm-range-args` that flags Helm chart template `range` loops where the loop variable `.` is rendered without a `| quote` filter (e.g. `{{ . }}`)
- Catches the class of bug from PR #2168 where vLLM `extraArgs` JSON values were rendered unquoted, breaking the container entrypoint
- Rule uses `languages: [generic]` (Helm templates mix YAML + Go template syntax) with `pattern-regex` scoped to `**/chart/templates/**`
- Includes test fixture with positive (bad) and negative (ok) examples following existing conventions
- Wired into BUILD with a dedicated `no_unquoted_helm_range_args_test` target, mirroring `stale_copyright_year_test` pattern for `languages: [generic]` rules

## Files

- `bazel/semgrep/rules/yaml/no-unquoted-helm-range-args.yaml` — rule definition
- `bazel/semgrep/tests/fixtures/no-unquoted-helm-range-args.yaml` — test fixture
- `bazel/semgrep/rules/BUILD` — dedicated filegroup + test target
- `bazel/semgrep/tests/BUILD` — fixture filegroup + exclusion from `yaml_fixtures`

## Test plan

- [ ] CI passes `bazel test //...`
- [ ] `no_unquoted_helm_range_args_test` target builds and passes (SEMGREP_TEST_MODE=1 exits 0)
- [ ] `yaml_rules_test` passes (fixture excluded from `yaml_fixtures`)
- [ ] Rule pattern correctly matches `{{ . }}`, `{{.}}`, `{{- . }}`, `{{ . -}}` but not `{{ . | quote }}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)