### PR TITLE
docs(stargazer): add tests component to README

### DIFF
--- a/projects/stargazer/README.md
+++ b/projects/stargazer/README.md
@@ -9,7 +9,7 @@ Multi-phase pipeline: light pollution atlas + OSM road data to identify dark zon
 | Component   | Description |
 | ----------- | ----------- |
 | **backend** | Pipeline that combines light pollution data, OSM roads, and weather forecasts |
-| **tests**   | Additional coverage and integration tests for the backend pipeline |
+| **tests**   | Additional unit tests for the backend pipeline (separate from backend/tests/) |
 | **chart**   | Helm chart with CronJob and API server templates |
 | **deploy**  | ArgoCD Application, kustomization, and cluster-specific values |
 

--- a/projects/stargazer/README.md
+++ b/projects/stargazer/README.md
@@ -9,6 +9,7 @@ Multi-phase pipeline: light pollution atlas + OSM road data to identify dark zon
 | Component   | Description |
 | ----------- | ----------- |
 | **backend** | Pipeline that combines light pollution data, OSM roads, and weather forecasts |
+| **tests**   | Additional coverage and integration tests for the backend pipeline |
 | **chart**   | Helm chart with CronJob and API server templates |
 | **deploy**  | ArgoCD Application, kustomization, and cluster-specific values |
 


### PR DESCRIPTION
## Summary
- The `tests/` directory contains 16 additional coverage and integration test files for the backend pipeline, separate from the unit tests co-located in `backend/`
- These tests were missing from the README components table

## Test plan
- [ ] Verify `tests/` directory exists and has 16 test files: `ls projects/stargazer/tests/`
- [ ] Confirm README renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)