### PR TITLE
feat(semgrep): add no-hardcoded-max-tokens rule for Python

### DIFF
--- a/bazel/semgrep/rules/python/no-hardcoded-max-tokens.py
+++ b/bazel/semgrep/rules/python/no-hardcoded-max-tokens.py
@@ -1,0 +1,44 @@
+# Tests for no-hardcoded-max-tokens rule.
+import os
+
+from pydantic_ai import ModelSettings
+
+
+def bad_hardcoded_max_tokens():
+    # ruleid: no-hardcoded-max-tokens
+    return ModelSettings(max_tokens=4096)
+
+
+def bad_hardcoded_max_tokens_with_other_params():
+    # ruleid: no-hardcoded-max-tokens
+    return ModelSettings(temperature=0.7, max_tokens=8192)
+
+
+def bad_hardcoded_max_tokens_trailing():
+    # ruleid: no-hardcoded-max-tokens
+    return ModelSettings(max_tokens=2048, temperature=0.5)
+
+
+def ok_max_tokens_from_env():
+    # ok: reading from environment variable is configurable
+    return ModelSettings(max_tokens=int(os.environ.get("MAX_TOKENS", "4096")))
+
+
+def ok_max_tokens_variable():
+    # ok: using a variable is fine — caller controls the value
+    limit = get_token_limit()
+    return ModelSettings(max_tokens=limit)
+
+
+def ok_no_max_tokens():
+    # ok: no max_tokens set — model default applies
+    return ModelSettings(temperature=0.7)
+
+
+def ok_max_tokens_none():
+    # ok: explicit None means no limit — intentional
+    return ModelSettings(max_tokens=None)
+
+
+def get_token_limit() -> int:
+    return int(os.environ.get("MAX_TOKENS", "4096"))

--- a/bazel/semgrep/rules/python/no-hardcoded-max-tokens.py
+++ b/bazel/semgrep/rules/python/no-hardcoded-max-tokens.py
@@ -1,4 +1,5 @@
 # Tests for no-hardcoded-max-tokens rule.
+# Flags ModelSettings(max_tokens=<integer>) with literal token limits.
 import os
 
 from pydantic_ai import ModelSettings

--- a/bazel/semgrep/rules/python/no-hardcoded-max-tokens.yaml
+++ b/bazel/semgrep/rules/python/no-hardcoded-max-tokens.yaml
@@ -1,0 +1,28 @@
+rules:
+  - id: no-hardcoded-max-tokens
+    patterns:
+      - pattern: ModelSettings(..., max_tokens=$N, ...)
+      - metavariable-regex:
+          metavariable: $N
+          regex: ^\d+$
+    message: >
+      `ModelSettings(max_tokens=<integer>)` is hardcoded to a literal integer value.
+      Hardcoded token limits cause context overflow when model context windows change
+      (e.g. upgrading from a 4k to an 8k model, or switching model providers).
+      Read the limit from an environment variable instead:
+      `max_tokens=int(os.environ.get("MAX_TOKENS", "4096"))`.
+    languages: [python]
+    severity: WARNING
+    metadata:
+      category: correctness
+      subcategory: configuration
+      confidence: HIGH
+      likelihood: MEDIUM
+      impact: HIGH
+      technology: [python, pydantic-ai]
+      description: ModelSettings max_tokens is hardcoded — use an env var so limits can change without redeploy
+    paths:
+      exclude:
+        - "*_test.py"
+        - "test_*.py"
+        - "tests/**"


### PR DESCRIPTION
## Summary

- Adds semgrep rule `no-hardcoded-max-tokens` that flags `ModelSettings(max_tokens=<integer>)` calls with literal integer token limits
- Hardcoded max_tokens causes context overflow when model context windows change (e.g. upgrading model versions or switching providers)
- Rule excludes test files (`*_test.py`, `test_*.py`, `tests/**`)
- Includes colocated test fixture `no-hardcoded-max-tokens.py` with 3 positive and 4 negative cases
- No BUILD changes needed — `python_rules` and `python_rules_test` use globs that pick up new files automatically

Catches the bug class from PR #2162 where a hardcoded max_tokens caused context overflow.

## Test plan

- [ ] `bazel test //bazel/semgrep/rules:python_rules_test` passes
- [ ] Rule fires on `ModelSettings(max_tokens=4096)` and `ModelSettings(max_tokens=8192, temperature=0.7)`
- [ ] Rule does not fire on `ModelSettings(max_tokens=int(os.environ.get("MAX_TOKENS", "4096")))` or `ModelSettings(max_tokens=limit)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)