### PR TITLE
feat(hooks): add check-large-inline-template PreToolUse hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -83,6 +83,11 @@
             "type": "command",
             "command": "bazel/tools/hooks/check-bdd-shared-testing-dep.sh",
             "timeout": 10
+          },
+          {
+            "type": "command",
+            "command": "bazel/tools/hooks/check-large-inline-template.sh",
+            "timeout": 10
           }
         ]
       }

--- a/bazel/tools/hooks/check-large-inline-template.sh
+++ b/bazel/tools/hooks/check-large-inline-template.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# PreToolUse hook: warn when embedding a large multi-line string block in a values YAML file.
+#
+# Inline Jinja2 / prompt templates > 30 lines make values files hard to review,
+# diff, and audit. Large templates should live in their own file and be loaded
+# at runtime (e.g. via a ConfigMap or mounted secret).
+#
+# Input: JSON on stdin from Claude Code hook system
+# Exit 0: allow (warnings emitted on stderr)
+# Exit 2: block (not used — this is advisory only)
+
+set -euo pipefail
+
+INPUT=$(cat)
+
+# Only trigger on values YAML files (deploy/values*.yaml)
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
+[[ "$FILE_PATH" == **/deploy/values*.yaml ]] || [[ "$FILE_PATH" == */deploy/values*.yaml ]] || exit 0
+
+# Get the new content being written (Write tool) or the replacement string (Edit tool)
+NEW_STRING=$(echo "$INPUT" | jq -r '.tool_input.new_string // .tool_input.content // empty')
+[[ -n "$NEW_STRING" ]] || exit 0
+
+# Check for YAML block scalar indicators (| or >) followed by more than 30 lines
+# We look for any block scalar that introduces a run of > 30 lines before the next
+# non-indented key or end of string.
+LINE_COUNT=$(echo "$NEW_STRING" | awk '
+  /[|>][+-]?[[:space:]]*$/ { in_block=1; count=0; next }
+  in_block && /^[[:space:]]+/ { count++; if (count > 30) { print count; exit } }
+  in_block && !/^[[:space:]]/ { in_block=0; count=0 }
+' | head -1)
+
+if [[ -n "$LINE_COUNT" ]]; then
+	cat >&2 <<-EOF
+		WARNING: Large inline multi-line block (${LINE_COUNT}+ lines) in a values YAML file.
+
+		Embedding long Jinja2 templates, prompts, or configuration blocks directly in
+		deploy/values*.yaml makes files hard to review, diff, and audit in pull requests.
+
+		Consider:
+		  - Moving the template to a standalone file and loading it via a ConfigMap
+		  - Referencing the content via a 1Password secret
+		  - Splitting the template into a dedicated chart/templates/ file
+
+		If this is intentional (e.g. a short example), proceed.
+	EOF
+fi
+
+exit 0


### PR DESCRIPTION
## Summary

- Adds `bazel/tools/hooks/check-large-inline-template.sh` — a PreToolUse Write|Edit hook that warns when a YAML block scalar (`|` or `>`) exceeding 30 lines is written to a `deploy/values*.yaml` file
- Updates `.claude/settings.json` to register the hook in the `Write|Edit` matcher's hooks array
- Advisory only (exit 0) — warns but never blocks
- Catches the pattern from PRs #2161/#2164 where 90-160 line Jinja2 chat templates were embedded inline in values-prod.yaml, making review and diffing difficult

## Test plan

- [ ] Hook fires a WARNING when writing a values YAML with >30-line block scalar
- [ ] Hook is silent for short blocks (≤30 lines) or non-values YAML files
- [ ] Hook exits 0 in all cases (advisory only)
- [ ] CI Format check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)