### PR TITLE
fix(inference): add component label to prevent service selector overlap

### DIFF
--- a/projects/agent_platform/inference/deploy/Chart.yaml
+++ b/projects/agent_platform/inference/deploy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: inference
 description: A Helm chart for LLM inference (llama.cpp and vLLM backends)
 type: application
-version: 2.4.0
+version: 2.4.1
 appVersion: "b5270"
 keywords:
   - llm

--- a/projects/agent_platform/inference/deploy/templates/deployment.yaml
+++ b/projects/agent_platform/inference/deploy/templates/deployment.yaml
@@ -13,6 +13,7 @@ spec:
   selector:
     matchLabels:
       {{- include "inference.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: inference
   template:
     metadata:
       {{- with .Values.podAnnotations }}
@@ -21,6 +22,7 @@ spec:
       {{- end }}
       labels:
         {{- include "inference.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: inference
     spec:
       {{- with .Values.runtimeClassName }}
       runtimeClassName: {{ . }}

--- a/projects/agent_platform/inference/deploy/templates/service.yaml
+++ b/projects/agent_platform/inference/deploy/templates/service.yaml
@@ -13,3 +13,4 @@ spec:
       name: http
   selector:
     {{- include "inference.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: inference


### PR DESCRIPTION
## Summary

- The `inference` Service selector matched **both** the vLLM pod and the embeddings pod, causing Kubernetes to load-balance chat completion requests ~50/50 between Qwen3.6-27B (correct) and voyage-4-nano (embedding model that produces garbage like "kg")
- Adds `app.kubernetes.io/component: inference` to the main deployment pod labels and service selector, mirroring how embeddings already uses `component: embeddings`
- Verified via `helm template` that selectors are now fully disjoint

## Test plan

- [ ] CI passes (helm template renders correctly)
- [ ] After merge, verify `kubectl get endpoints inference -n inference` shows only the vLLM pod IP (10.42.3.x for inference pod, not the embeddings pod)
- [ ] Send a test message to the bot and confirm coherent responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)