### PR TITLE
docs(agent_platform): fix README inaccuracies

### DIFF
--- a/projects/agent_platform/README.md
+++ b/projects/agent_platform/README.md
@@ -15,8 +15,7 @@ See [docs/agents.md](../../docs/agents.md) for the full architecture.
 | **cluster_agents**       | Go service that monitors cluster health and runs autonomous improvement agents (patrol, escalator, PR fix, README freshness, test coverage, etc.) |
 | **api_gateway**          | Nginx-based API gateway with route-based backend selection for api.jomcgi.dev |
 | **goose_agent**          | Goose agent container and configuration |
-| **llama_cpp**            | On-cluster LLM inference (model configured per environment) |
-| **llama_cpp_embeddings** | On-cluster embedding inference (model configured per environment) |
+| **inference**            | On-cluster LLM inference and embedding inference (model configured per environment) |
 | **vllm**                 | Alternative LLM serving backend (Helm chart and values only — not wired to ArgoCD) |
 | **chart**                | Umbrella Helm chart for all agent platform components |
 | **deploy**               | ArgoCD Application, kustomization, and cluster-specific values |


### PR DESCRIPTION
## Summary

- Replace incorrect component names `llama_cpp` and `llama_cpp_embeddings` with the actual directory name `inference/`

## Test plan

- [ ] Verify `projects/agent_platform/inference/` exists in the repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)