### PR TITLE
docs(trips): fix README inaccuracies

### DIFF
--- a/projects/trips/backend/README.md
+++ b/projects/trips/backend/README.md
@@ -62,7 +62,7 @@ MaxAge: 8760h # 365 days
 **Startup sequence:**
 
 1. Connect to NATS
-2. Subscribe to `trips.points` stream from sequence 0
+2. Subscribe to `trips.>` stream from sequence 0
 3. Process all existing messages (add to cache)
 4. Continue consuming new messages in real-time
 5. Start HTTP server when replay complete
@@ -320,7 +320,7 @@ WebSocket endpoint for real-time updates (see WebSocket Protocol section above).
 | `lat`           | float  | Latitude                    | Yes      | `49.2827`                  |
 | `lng`           | float  | Longitude                   | Yes      | `-123.1207`                |
 | `timestamp`     | string | ISO 8601 timestamp          | Yes      | `2024-01-15T12:00:00Z`     |
-| `image`         | string | Image filename              | Yes      | `photo.jpg`                |
+| `image`         | string | Image filename              | No       | `photo.jpg`                |
 | `source`        | string | Image source                | Yes      | `gopro`, `camera`, `phone` |
 | `tags`          | array  | Classification tags         | No       | `["car", "highway"]`       |
 | `elevation`     | float  | Elevation (meters)          | No       | `125.5`                    |


### PR DESCRIPTION
## Summary

- Fix NATS subscription subject: `trips.points` → `trips.>` (wildcard, matches actual code)
- Fix `image` field in data model table: Required `Yes` → `No` (field is `str | None = None` — optional for gap/route-only points)

## Test plan

- [ ] Verify `"trips.>"` in `projects/trips/backend/main.py`
- [ ] Verify `image: str | None = None` in `projects/trips/backend/main.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)