### PR TITLE
fix(chat): disable thinking for vision requests and increase max_tokens

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.53.2
+version: 0.53.3
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.53.3
+version: 0.53.4
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chat/vision.py
+++ b/projects/monolith/chat/vision.py
@@ -65,7 +65,10 @@ class VisionClient:
                     ],
                 },
             ],
-            "max_tokens": 256,
+            "max_tokens": 4096,
+            # Disable thinking so tokens are used for the description, not
+            # <think> reasoning that fills the entire max_tokens budget.
+            "chat_template_kwargs": {"enable_thinking": False},
         }
 
         timeout = httpx.Timeout(VISION_READ_TIMEOUT, connect=VISION_CONNECT_TIMEOUT)
@@ -81,11 +84,14 @@ class VisionClient:
                     )
                     resp.raise_for_status()
                     try:
-                        return resp.json()["choices"][0]["message"]["content"]
+                        content = resp.json()["choices"][0]["message"]["content"]
                     except (KeyError, IndexError) as e:
                         raise ValueError(
                             f"unexpected vision response shape: {e}"
                         ) from e
+                    if not content:
+                        raise ValueError("vision response returned empty content")
+                    return content
             except Exception as exc:
                 last_exc = exc
                 if not _is_retryable(exc):

--- a/projects/monolith/chat/vision_timeout_test.py
+++ b/projects/monolith/chat/vision_timeout_test.py
@@ -276,8 +276,8 @@ class TestVisionClientPayload:
         assert payload["model"] == "qwen3.6-27b"
 
     @pytest.mark.asyncio
-    async def test_payload_includes_max_tokens_256(self):
-        """describe() sends max_tokens=256 in the payload."""
+    async def test_payload_includes_max_tokens_4096(self):
+        """describe() sends max_tokens=4096 in the payload."""
         client = VisionClient(base_url="http://fake:8080")
 
         with patch("chat.vision.httpx.AsyncClient") as mock_cls:
@@ -285,7 +285,7 @@ class TestVisionClientPayload:
             await client.describe(b"\x89PNG", "image/png")
 
         payload = mock_cls.return_value.post.call_args.kwargs.get("json")
-        assert payload["max_tokens"] == 256
+        assert payload["max_tokens"] == 4096
 
     @pytest.mark.asyncio
     async def test_payload_system_prompt_matches_module_constant(self):
@@ -301,3 +301,27 @@ class TestVisionClientPayload:
         system_messages = [m for m in messages if m["role"] == "system"]
         assert len(system_messages) == 1
         assert system_messages[0]["content"] == VISION_SYSTEM_PROMPT
+
+    @pytest.mark.asyncio
+    async def test_payload_disables_thinking(self):
+        """describe() sends chat_template_kwargs with enable_thinking=False."""
+        client = VisionClient(base_url="http://fake:8080")
+
+        with patch("chat.vision.httpx.AsyncClient") as mock_cls:
+            mock_cls.return_value = _make_mock_http_client(response=_ok_response())
+            await client.describe(b"\x89PNG", "image/png")
+
+        payload = mock_cls.return_value.post.call_args.kwargs.get("json")
+        assert payload["chat_template_kwargs"] == {"enable_thinking": False}
+
+    @pytest.mark.asyncio
+    async def test_raises_on_null_content(self):
+        """describe() raises ValueError when the model returns content: null."""
+        client = VisionClient(base_url="http://fake:8080")
+
+        with patch("chat.vision.httpx.AsyncClient") as mock_cls:
+            mock_cls.return_value = _make_mock_http_client(
+                response=_ok_response(content=None)
+            )
+            with pytest.raises(ValueError, match="empty content"):
+                await client.describe(b"\x89PNG", "image/png")

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.53.2
+      targetRevision: 0.53.3
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.53.3
+      targetRevision: 0.53.4
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
## Summary

- vLLM's reasoning mode (`--reasoning-parser qwen3`) causes `<think>` blocks to consume the entire `max_tokens` budget on vision requests, returning `content: null`
- This `None` description cascades into empty embed text, which llama.cpp rejects with `400 Bad Request`
- Adds `chat_template_kwargs: {"enable_thinking": false}` to skip reasoning for image descriptions
- Increases `max_tokens` from 256 to 4096 — vision requests describe a single image so the budget can be generous
- Adds a null/empty content guard that raises `ValueError` instead of silently propagating `None`

Follow-up to #2181 which fixed the service selector overlap — that fix exposed this issue by routing vision requests consistently to vLLM instead of randomly hitting the embeddings pod.

## Test plan

- [ ] CI passes
- [ ] Send an image to the bot in Discord, confirm it gets a description (not a 400 error)
- [ ] Verify the description appears in stored message attachments

🤖 Generated with [Claude Code](https://claude.com/claude-code)