### PR TITLE
feat(scheduler): run due jobs concurrently with bounded parallelism

### DIFF
--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -2692,6 +2692,15 @@ bdd_test(
     ],
 )
 
+bdd_test(
+    name = "shared_bdd_scheduler_test",
+    srcs = [
+        "shared/tests/__init__.py",
+        "shared/tests/bdd_scheduler_test.py",
+        "shared/tests/conftest.py",
+    ],
+)
+
 py_test(
     name = "bdd_completeness_test",
     size = "small",

--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -2709,7 +2709,7 @@ py_test(
         "app/bdd_completeness_test.py",
     ],
     data = glob(["*/tests/*_test.py"]),
-    env = {"PYTEST_ADDOPTS": "--import-mode=importlib --ignore=projects/monolith/home/tests --ignore=projects/monolith/chat/tests --ignore=projects/monolith/knowledge/tests"},
+    env = {"PYTEST_ADDOPTS": "--import-mode=importlib --ignore=projects/monolith/home/tests --ignore=projects/monolith/chat/tests --ignore=projects/monolith/knowledge/tests --ignore=projects/monolith/shared/tests"},
     imports = ["."],
     tags = ["bdd"],
     deps = [

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.54.1
+version: 0.55.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.54.1
+      targetRevision: 0.55.0
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/shared/scheduler.py
+++ b/projects/monolith/shared/scheduler.py
@@ -86,24 +86,55 @@ def purge_stale_jobs(session: Session) -> None:
     session.commit()
 
 
-async def run_scheduler_loop(poll_interval: int = 30) -> None:
-    """Poll for due jobs and run them. Runs forever."""
-    logger.info("Scheduler loop started (poll every %ds)", poll_interval)
+async def run_scheduler_loop(poll_interval: int = 30, max_concurrent: int = 5) -> None:
+    """Poll for due jobs and run them with bounded concurrency. Runs forever."""
+    logger.info(
+        "Scheduler loop started (poll=%ds, max_concurrent=%d)",
+        poll_interval,
+        max_concurrent,
+    )
     while True:
         try:
-            await _tick()
+            await dispatch_due_jobs(max_concurrent=max_concurrent)
         except Exception:
             logger.exception("Scheduler tick failed")
         await asyncio.sleep(poll_interval)
 
 
-async def _tick() -> None:
-    """Single scheduler tick: claim one due job and run it."""
-    with Session(get_engine()) as session:
-        job_name = _claim_next_job(session)
-        if job_name is None:
-            return
+async def dispatch_due_jobs(max_concurrent: int = 5) -> int:
+    """Claim every currently-due job and run it, up to ``max_concurrent`` in
+    parallel. Awaits all spawned handlers before returning.
 
+    Each handler runs on its own ``Session`` because SQLAlchemy sessions are
+    not safe to share across concurrently awaiting coroutines.
+    """
+    if max_concurrent < 1:
+        raise ValueError(f"max_concurrent must be >= 1, got {max_concurrent}")
+
+    job_names: list[str] = []
+    with Session(get_engine()) as session:
+        while True:
+            name = _claim_next_job(session)
+            if name is None:
+                break
+            job_names.append(name)
+
+    if not job_names:
+        return 0
+
+    semaphore = asyncio.Semaphore(max_concurrent)
+
+    async def _run(name: str) -> None:
+        async with semaphore:
+            await _run_claimed_job(name)
+
+    await asyncio.gather(*(_run(name) for name in job_names))
+    return len(job_names)
+
+
+async def _run_claimed_job(job_name: str) -> None:
+    """Execute a single already-claimed job in its own DB session."""
+    with Session(get_engine()) as session:
         job = session.get(ScheduledJob, job_name)
         if job is None:
             return

--- a/projects/monolith/shared/scheduler_loop_extra_test.py
+++ b/projects/monolith/shared/scheduler_loop_extra_test.py
@@ -1,12 +1,12 @@
 """Extra tests for run_scheduler_loop() — poll_interval propagation and iteration counts.
 
-The existing scheduler_loop_test.py verifies that _tick() exceptions are
-caught and the loop continues.  These tests cover the complementary cases:
+scheduler_loop_test.py covers the exception-handling path for dispatch_due_jobs.
+These tests cover the complementary cases:
 
 - poll_interval is forwarded verbatim to asyncio.sleep on every iteration
 - The default poll_interval of 30 seconds is used when none is specified
 - The loop executes multiple successful iterations without termination
-- asyncio.sleep is called once per loop iteration (after each _tick call)
+- asyncio.sleep is called once per loop iteration (after each dispatch call)
 """
 
 import pytest
@@ -21,14 +21,14 @@ class TestRunSchedulerLoopPollInterval:
         """asyncio.sleep is called with the provided poll_interval value."""
         tick_count = 0
 
-        async def tick_side_effect():
+        async def tick_side_effect(*_args, **_kwargs):
             nonlocal tick_count
             tick_count += 1
             if tick_count >= 2:
                 raise KeyboardInterrupt
 
         with (
-            patch("shared.scheduler._tick", side_effect=tick_side_effect),
+            patch("shared.scheduler.dispatch_due_jobs", side_effect=tick_side_effect),
             patch(
                 "shared.scheduler.asyncio.sleep", new_callable=AsyncMock
             ) as mock_sleep,
@@ -48,14 +48,14 @@ class TestRunSchedulerLoopPollInterval:
         """When poll_interval is not specified, asyncio.sleep uses 30 seconds."""
         tick_count = 0
 
-        async def tick_side_effect():
+        async def tick_side_effect(*_args, **_kwargs):
             nonlocal tick_count
             tick_count += 1
             if tick_count >= 2:
                 raise KeyboardInterrupt
 
         with (
-            patch("shared.scheduler._tick", side_effect=tick_side_effect),
+            patch("shared.scheduler.dispatch_due_jobs", side_effect=tick_side_effect),
             patch(
                 "shared.scheduler.asyncio.sleep", new_callable=AsyncMock
             ) as mock_sleep,
@@ -74,14 +74,14 @@ class TestRunSchedulerLoopPollInterval:
         """poll_interval=0 is a valid value and is forwarded to asyncio.sleep."""
         tick_count = 0
 
-        async def tick_side_effect():
+        async def tick_side_effect(*_args, **_kwargs):
             nonlocal tick_count
             tick_count += 1
             if tick_count >= 2:
                 raise KeyboardInterrupt
 
         with (
-            patch("shared.scheduler._tick", side_effect=tick_side_effect),
+            patch("shared.scheduler.dispatch_due_jobs", side_effect=tick_side_effect),
             patch(
                 "shared.scheduler.asyncio.sleep", new_callable=AsyncMock
             ) as mock_sleep,
@@ -97,17 +97,17 @@ class TestRunSchedulerLoopPollInterval:
 class TestRunSchedulerLoopIterations:
     @pytest.mark.asyncio
     async def test_runs_multiple_successful_iterations(self):
-        """The loop executes multiple _tick() calls successfully."""
+        """The loop executes multiple dispatch_due_jobs() calls successfully."""
         tick_count = 0
 
-        async def tick_side_effect():
+        async def tick_side_effect(*_args, **_kwargs):
             nonlocal tick_count
             tick_count += 1
             if tick_count >= 5:
                 raise KeyboardInterrupt
 
         with (
-            patch("shared.scheduler._tick", side_effect=tick_side_effect),
+            patch("shared.scheduler.dispatch_due_jobs", side_effect=tick_side_effect),
             patch("shared.scheduler.asyncio.sleep", new_callable=AsyncMock),
         ):
             with pytest.raises(KeyboardInterrupt):
@@ -121,7 +121,7 @@ class TestRunSchedulerLoopIterations:
         tick_count = 0
         sleep_count = 0
 
-        async def tick_side_effect():
+        async def tick_side_effect(*_args, **_kwargs):
             nonlocal tick_count
             tick_count += 1
             if tick_count >= 4:
@@ -132,7 +132,7 @@ class TestRunSchedulerLoopIterations:
             sleep_count += 1
 
         with (
-            patch("shared.scheduler._tick", side_effect=tick_side_effect),
+            patch("shared.scheduler.dispatch_due_jobs", side_effect=tick_side_effect),
             patch("shared.scheduler.asyncio.sleep", side_effect=sleep_side_effect),
         ):
             with pytest.raises(KeyboardInterrupt):
@@ -144,11 +144,11 @@ class TestRunSchedulerLoopIterations:
 
     @pytest.mark.asyncio
     async def test_sleep_called_after_failed_ticks_too(self):
-        """asyncio.sleep is called even when _tick() raises a caught exception."""
+        """asyncio.sleep is called even when dispatch_due_jobs() raises a caught exception."""
         tick_count = 0
         sleep_count = 0
 
-        async def tick_side_effect():
+        async def tick_side_effect(*_args, **_kwargs):
             nonlocal tick_count
             tick_count += 1
             if tick_count <= 2:
@@ -161,7 +161,7 @@ class TestRunSchedulerLoopIterations:
             sleep_count += 1
 
         with (
-            patch("shared.scheduler._tick", side_effect=tick_side_effect),
+            patch("shared.scheduler.dispatch_due_jobs", side_effect=tick_side_effect),
             patch("shared.scheduler.asyncio.sleep", side_effect=sleep_side_effect),
         ):
             with pytest.raises(KeyboardInterrupt):
@@ -177,7 +177,7 @@ class TestRunSchedulerLoopIterations:
         tick_count = 0
         sleep_args_seen = []
 
-        async def tick_side_effect():
+        async def tick_side_effect(*_args, **_kwargs):
             nonlocal tick_count
             tick_count += 1
             if tick_count == 1:
@@ -189,7 +189,7 @@ class TestRunSchedulerLoopIterations:
             sleep_args_seen.append(interval)
 
         with (
-            patch("shared.scheduler._tick", side_effect=tick_side_effect),
+            patch("shared.scheduler.dispatch_due_jobs", side_effect=tick_side_effect),
             patch("shared.scheduler.asyncio.sleep", side_effect=sleep_side_effect),
         ):
             with pytest.raises(KeyboardInterrupt):

--- a/projects/monolith/shared/scheduler_loop_test.py
+++ b/projects/monolith/shared/scheduler_loop_test.py
@@ -1,6 +1,5 @@
-"""Unit tests for scheduler loop functions (_tick, _complete_job, _fail_job, etc.)."""
+"""Unit tests for scheduler loop helpers (_run_claimed_job, _complete_job, _fail_job, etc.)."""
 
-import asyncio
 from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -14,7 +13,7 @@ from shared.scheduler import (
     _fail_job,
     _registry,
     _release_lock,
-    _tick,
+    _run_claimed_job,
     run_scheduler_loop,
 )
 
@@ -203,14 +202,14 @@ class TestReleaseLock:
 
 
 # ---------------------------------------------------------------------------
-# _tick (mocked)
+# _run_claimed_job (mocked)
 # ---------------------------------------------------------------------------
 
 
-class TestTick:
+class TestRunClaimedJob:
     @pytest.mark.asyncio
-    async def test_calls_handler_on_claimed_job(self):
-        """When _claim_next_job returns a name, the handler is called."""
+    async def test_calls_handler(self):
+        """The registered handler is invoked with the job's session."""
         handler = AsyncMock(return_value=None)
         _registry["my-job"] = handler
 
@@ -229,36 +228,16 @@ class TestTick:
         with (
             patch("shared.scheduler.get_engine"),
             patch("shared.scheduler.Session") as mock_session_cls,
-            patch("shared.scheduler._claim_next_job", return_value="my-job"),
             patch("shared.scheduler._complete_job") as mock_complete,
         ):
             mock_session_cls.return_value.__enter__ = MagicMock(
                 return_value=mock_session
             )
             mock_session_cls.return_value.__exit__ = MagicMock(return_value=False)
-            await _tick()
+            await _run_claimed_job("my-job")
 
         handler.assert_called_once_with(mock_session)
         mock_complete.assert_called_once_with(mock_session, fake_job, None)
-
-    @pytest.mark.asyncio
-    async def test_skips_when_no_due_jobs(self):
-        """When _claim_next_job returns None, no handler is called."""
-        handler = AsyncMock()
-        _registry["some-job"] = handler
-
-        with (
-            patch("shared.scheduler.get_engine"),
-            patch("shared.scheduler.Session") as mock_session_cls,
-            patch("shared.scheduler._claim_next_job", return_value=None),
-        ):
-            mock_session_cls.return_value.__enter__ = MagicMock(
-                return_value=MagicMock(spec=Session)
-            )
-            mock_session_cls.return_value.__exit__ = MagicMock(return_value=False)
-            await _tick()
-
-        handler.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_calls_fail_on_handler_exception(self):
@@ -281,20 +260,19 @@ class TestTick:
         with (
             patch("shared.scheduler.get_engine"),
             patch("shared.scheduler.Session") as mock_session_cls,
-            patch("shared.scheduler._claim_next_job", return_value="fail-job"),
             patch("shared.scheduler._fail_job") as mock_fail,
         ):
             mock_session_cls.return_value.__enter__ = MagicMock(
                 return_value=mock_session
             )
             mock_session_cls.return_value.__exit__ = MagicMock(return_value=False)
-            await _tick()
+            await _run_claimed_job("fail-job")
 
         mock_fail.assert_called_once_with(mock_session, fake_job, "boom")
 
     @pytest.mark.asyncio
     async def test_releases_lock_for_missing_handler(self):
-        """When a job is claimed but no handler exists, _release_lock is called."""
+        """When a job was claimed but no handler is registered, the lock is released."""
         now = datetime.now(timezone.utc)
         fake_job = ScheduledJob(
             name="orphan-job",
@@ -310,14 +288,13 @@ class TestTick:
         with (
             patch("shared.scheduler.get_engine"),
             patch("shared.scheduler.Session") as mock_session_cls,
-            patch("shared.scheduler._claim_next_job", return_value="orphan-job"),
             patch("shared.scheduler._release_lock") as mock_release,
         ):
             mock_session_cls.return_value.__enter__ = MagicMock(
                 return_value=mock_session
             )
             mock_session_cls.return_value.__exit__ = MagicMock(return_value=False)
-            await _tick()
+            await _run_claimed_job("orphan-job")
 
         mock_release.assert_called_once_with(mock_session, fake_job)
 
@@ -329,20 +306,23 @@ class TestTick:
 
 class TestRunSchedulerLoop:
     @pytest.mark.asyncio
-    async def test_catches_tick_exceptions(self):
-        """The loop continues after _tick raises an exception."""
+    async def test_catches_dispatch_exceptions(self):
+        """The loop continues after dispatch_due_jobs raises an exception."""
         call_count = 0
 
-        async def tick_side_effect():
+        async def dispatch_side_effect(**_kwargs):
             nonlocal call_count
             call_count += 1
             if call_count == 1:
-                raise RuntimeError("tick exploded")
+                raise RuntimeError("dispatch exploded")
             if call_count >= 3:
                 raise KeyboardInterrupt  # break the loop
+            return 0
 
         with (
-            patch("shared.scheduler._tick", side_effect=tick_side_effect),
+            patch(
+                "shared.scheduler.dispatch_due_jobs", side_effect=dispatch_side_effect
+            ),
             patch(
                 "shared.scheduler.asyncio.sleep", new_callable=AsyncMock
             ) as mock_sleep,
@@ -350,7 +330,7 @@ class TestRunSchedulerLoop:
             with pytest.raises(KeyboardInterrupt):
                 await run_scheduler_loop(poll_interval=1)
 
-        # tick was called at least 3 times (first errored, second succeeded, third broke)
+        # dispatch was called at least 3 times (first errored, second succeeded, third broke)
         assert call_count >= 3
-        # sleep was called between ticks
+        # sleep was called between dispatch calls
         assert mock_sleep.call_count >= 2

--- a/projects/monolith/shared/scheduler_tick_missing_job_test.py
+++ b/projects/monolith/shared/scheduler_tick_missing_job_test.py
@@ -1,19 +1,17 @@
-"""Tests for the _tick branch where session.get(ScheduledJob, job_name) returns None."""
+"""Tests for the _run_claimed_job branch where session.get(ScheduledJob, job_name) returns None.
 
-from datetime import datetime, timezone
+This can happen legitimately: dispatch_due_jobs claims a batch of jobs in one
+session, then spawns each handler with its own session. Between the claim
+commit and the handler re-fetching the row, another process could delete it
+(e.g. purge_stale_jobs in a second pod).
+"""
+
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from sqlmodel import Session
 
-from shared.scheduler import (
-    ScheduledJob,
-    _complete_job,
-    _fail_job,
-    _registry,
-    _release_lock,
-    _tick,
-)
+from shared.scheduler import _registry, _run_claimed_job
 
 
 @pytest.fixture(autouse=True)
@@ -24,21 +22,20 @@ def _clear_registry():
     _registry.clear()
 
 
-class TestTickMissingJob:
+class TestRunClaimedJobMissingRow:
     @pytest.mark.asyncio
     async def test_returns_early_when_job_row_not_found(self):
-        """When _claim_next_job returns a name but session.get returns None, _tick returns early
+        """When session.get returns None, _run_claimed_job returns early
         without calling any of _complete_job, _fail_job, or _release_lock."""
         handler = AsyncMock()
         _registry["ghost-job"] = handler
 
         mock_session = MagicMock(spec=Session)
-        mock_session.get.return_value = None  # job row disappeared after claiming
+        mock_session.get.return_value = None  # row disappeared between claim and run
 
         with (
             patch("shared.scheduler.get_engine"),
             patch("shared.scheduler.Session") as mock_session_cls,
-            patch("shared.scheduler._claim_next_job", return_value="ghost-job"),
             patch("shared.scheduler._complete_job") as mock_complete,
             patch("shared.scheduler._fail_job") as mock_fail,
             patch("shared.scheduler._release_lock") as mock_release,
@@ -47,29 +44,26 @@ class TestTickMissingJob:
                 return_value=mock_session
             )
             mock_session_cls.return_value.__exit__ = MagicMock(return_value=False)
-            await _tick()
+            await _run_claimed_job("ghost-job")
 
-        # The row vanished — no state transitions should occur
         mock_complete.assert_not_called()
         mock_fail.assert_not_called()
         mock_release.assert_not_called()
-        # Handler should not run either
         handler.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_does_not_raise_when_job_row_missing(self):
-        """_tick with a missing job row must not propagate any exception."""
+        """_run_claimed_job with a missing job row must not propagate any exception."""
         mock_session = MagicMock(spec=Session)
         mock_session.get.return_value = None
 
         with (
             patch("shared.scheduler.get_engine"),
             patch("shared.scheduler.Session") as mock_session_cls,
-            patch("shared.scheduler._claim_next_job", return_value="no-such-job"),
         ):
             mock_session_cls.return_value.__enter__ = MagicMock(
                 return_value=mock_session
             )
             mock_session_cls.return_value.__exit__ = MagicMock(return_value=False)
             # Should complete silently
-            await _tick()
+            await _run_claimed_job("no-such-job")

--- a/projects/monolith/shared/tests/bdd_scheduler_test.py
+++ b/projects/monolith/shared/tests/bdd_scheduler_test.py
@@ -1,0 +1,203 @@
+"""BDD tests for the concurrent scheduler dispatcher.
+
+Uses a real PostgreSQL instance because ``FOR UPDATE SKIP LOCKED`` and the
+advisory-lock semantics are PG-specific and cannot be faithfully mocked.
+
+The key concurrency oracle is wall-clock time: if N jobs each sleep S seconds
+and the dispatcher finishes in ~S seconds (not ~N*S), they ran in parallel.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlmodel import Session
+
+from shared.scheduler import (
+    ScheduledJob,
+    dispatch_due_jobs,
+    register_job,
+)
+
+
+def _due_now(session: Session, name: str) -> None:
+    """Move a job's next_run_at into the past so it's immediately due."""
+    job = session.get(ScheduledJob, name)
+    assert job is not None, f"Job {name} was not registered"
+    job.next_run_at = datetime.now(timezone.utc) - timedelta(seconds=1)
+    session.add(job)
+    session.commit()
+
+
+class TestConcurrentDispatch:
+    async def test_due_jobs_run_in_parallel(self, scheduler_db: Session):
+        """Three jobs each sleeping 0.4s should finish in <1s when dispatched
+        with max_concurrent=3 — proving they ran concurrently, not serially."""
+        completed: list[str] = []
+
+        def _make_handler(name: str):
+            async def handler(_: Session) -> None:
+                await asyncio.sleep(0.4)
+                completed.append(name)
+
+            return handler
+
+        for name in ("job-a", "job-b", "job-c"):
+            register_job(
+                scheduler_db,
+                name=name,
+                interval_secs=3600,
+                handler=lambda s, _name=name: _make_handler(_name)(s),
+            )
+            _due_now(scheduler_db, name)
+
+        start = time.monotonic()
+        count = await dispatch_due_jobs(max_concurrent=3)
+        elapsed = time.monotonic() - start
+
+        assert count == 3, f"Expected 3 jobs dispatched, got {count}"
+        assert set(completed) == {"job-a", "job-b", "job-c"}
+        # Serial would be ~1.2s (3 x 0.4s). Parallel is ~0.4s.
+        # Generous ceiling of 0.9s to tolerate CI jitter but still catch serial runs.
+        assert elapsed < 0.9, (
+            f"Jobs ran serially (elapsed={elapsed:.2f}s); expected ~0.4s for parallel"
+        )
+
+    async def test_bounded_concurrency(self, scheduler_db: Session):
+        """With max_concurrent=2 and 4 due jobs, total time is ~2 waves of 0.3s,
+        not 1 wave (too permissive) or 4 waves (not concurrent at all)."""
+
+        def _make_handler():
+            async def handler(_: Session) -> None:
+                await asyncio.sleep(0.3)
+
+            return handler
+
+        for name in ("b-1", "b-2", "b-3", "b-4"):
+            register_job(
+                scheduler_db,
+                name=name,
+                interval_secs=3600,
+                handler=lambda s, _h=_make_handler(): _h(s),
+            )
+            _due_now(scheduler_db, name)
+
+        start = time.monotonic()
+        count = await dispatch_due_jobs(max_concurrent=2)
+        elapsed = time.monotonic() - start
+
+        assert count == 4
+        # 2 waves of 0.3s = 0.6s. Allow [0.5s, 1.1s]:
+        # < 0.5s means we exceeded max_concurrent=2 (would be ~0.3s for full parallel).
+        # > 1.1s means we ran serially or slower than expected.
+        assert 0.5 < elapsed < 1.1, (
+            f"elapsed={elapsed:.2f}s; expected ~0.6s for 2 waves of 2-at-a-time"
+        )
+
+    async def test_failed_job_does_not_block_others(self, scheduler_db: Session):
+        """When one job raises, the other still runs and is marked ok; the
+        failing one gets last_status='error: ...' and its next_run_at advances."""
+
+        async def good_handler(_: Session) -> None:
+            await asyncio.sleep(0.1)
+
+        async def bad_handler(_: Session) -> None:
+            raise RuntimeError("boom")
+
+        register_job(scheduler_db, name="good", interval_secs=120, handler=good_handler)
+        register_job(scheduler_db, name="bad", interval_secs=120, handler=bad_handler)
+        _due_now(scheduler_db, "good")
+        _due_now(scheduler_db, "bad")
+
+        count = await dispatch_due_jobs(max_concurrent=2)
+        assert count == 2
+
+        scheduler_db.expire_all()
+        good = scheduler_db.get(ScheduledJob, "good")
+        bad = scheduler_db.get(ScheduledJob, "bad")
+        assert good is not None and bad is not None
+        assert good.last_status == "ok"
+        assert bad.last_status is not None
+        assert bad.last_status.startswith("error: boom")
+        # Both locks released
+        assert good.locked_by is None
+        assert bad.locked_by is None
+        # Both rescheduled into the future
+        now = datetime.now(timezone.utc)
+        good_next = (
+            good.next_run_at.replace(tzinfo=timezone.utc)
+            if good.next_run_at.tzinfo is None
+            else good.next_run_at
+        )
+        bad_next = (
+            bad.next_run_at.replace(tzinfo=timezone.utc)
+            if bad.next_run_at.tzinfo is None
+            else bad.next_run_at
+        )
+        assert good_next > now
+        assert bad_next > now
+
+    async def test_no_double_claim_under_concurrent_dispatch(
+        self, scheduler_db: Session
+    ):
+        """Two dispatcher coroutines racing on the same rows must not cause
+        any job to run twice (FOR UPDATE SKIP LOCKED contract)."""
+        runs: list[str] = []
+
+        def _make_handler(name: str):
+            async def handler(_: Session) -> None:
+                await asyncio.sleep(0.05)
+                runs.append(name)
+
+            return handler
+
+        names = [f"race-{i}" for i in range(6)]
+        for name in names:
+            register_job(
+                scheduler_db,
+                name=name,
+                interval_secs=3600,
+                handler=lambda s, _name=name: _make_handler(_name)(s),
+            )
+            _due_now(scheduler_db, name)
+
+        # Simulate two pods dispatching simultaneously.
+        results = await asyncio.gather(
+            dispatch_due_jobs(max_concurrent=3),
+            dispatch_due_jobs(max_concurrent=3),
+        )
+
+        assert sum(results) == len(names), (
+            f"Expected exactly {len(names)} total dispatches, got {sum(results)}"
+        )
+        assert sorted(runs) == sorted(names), "No job ran twice"
+
+    async def test_returns_zero_when_no_jobs_due(self, scheduler_db: Session):
+        """When no jobs are due, dispatch_due_jobs returns 0 without blocking."""
+        scheduler_db.add(
+            ScheduledJob(
+                name="future",
+                interval_secs=60,
+                next_run_at=datetime.now(timezone.utc) + timedelta(hours=1),
+            )
+        )
+        scheduler_db.commit()
+
+        count = await dispatch_due_jobs(max_concurrent=5)
+        assert count == 0
+
+        scheduler_db.expire_all()
+        future = scheduler_db.get(ScheduledJob, "future")
+        assert future is not None
+        assert future.last_run_at is None
+        assert future.locked_by is None
+
+
+@pytest.fixture(autouse=True)
+def _autouse_scheduler_db(scheduler_db):
+    """Make scheduler_db always active so tests don't need to request it
+    explicitly — cleanup is wired via its teardown."""
+    yield

--- a/projects/monolith/shared/tests/conftest.py
+++ b/projects/monolith/shared/tests/conftest.py
@@ -1,0 +1,43 @@
+"""BDD test fixtures for the shared scheduler domain.
+
+Scheduler handlers claim their own DB sessions via ``get_engine()``, so the
+SAVEPOINT-based ``session`` fixture from the shared plugin can't be used —
+scheduler commits happen on separate connections and wouldn't be visible to
+a SAVEPOINT-wrapped session. Instead, we point ``DATABASE_URL`` at the real
+test Postgres, clear ``get_engine``'s cache, and rely on explicit cleanup.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+from sqlmodel import Session, create_engine, text
+
+
+@pytest.fixture()
+def scheduler_db(pg):
+    """Real Postgres session for the scheduler, with cleanup between tests."""
+    raw_url = pg.url.replace("postgresql+psycopg://", "postgresql://", 1)
+    os.environ["DATABASE_URL"] = raw_url
+
+    from app.db import get_engine
+    from shared.scheduler import _registry
+
+    get_engine.cache_clear()
+    _registry.clear()
+
+    engine = create_engine(pg.url)
+    with engine.connect() as conn:
+        conn.execute(text("DELETE FROM scheduler.scheduled_jobs"))
+        conn.commit()
+
+    with Session(engine) as session:
+        yield session
+
+    with engine.connect() as conn:
+        conn.execute(text("DELETE FROM scheduler.scheduled_jobs"))
+        conn.commit()
+    engine.dispose()
+    _registry.clear()
+    get_engine.cache_clear()


### PR DESCRIPTION
## Summary

- The monolith scheduler serialized all jobs: `_tick` claimed one row per 30s poll via `LIMIT 1 FOR UPDATE SKIP LOCKED`, awaited the handler, then slept. A single 5-minute gardener run would hold back every other due job for 5 minutes.
- New `dispatch_due_jobs(max_concurrent=5)` claims every currently-due job each tick and runs up to `max_concurrent` handlers in parallel with an `asyncio.Semaphore`. Each handler gets its own `Session` because SQLAlchemy sessions are not coroutine-safe.
- Cross-pod safety unchanged — `FOR UPDATE SKIP LOCKED` still prevents the same job from being claimed twice, so scaling replicas stays safe.

## Design notes

- **Per-tick drain, not persistent pool.** Simplest change that eliminates within-batch head-of-line blocking. A slow job still blocks the *next* tick (HOL across ticks); if that becomes painful we can upgrade to a persistent in-flight pool in a follow-up.
- **`max_concurrent=5` default.** Picked conservatively. Heaviest user is the knowledge gardener (spawns a Claude subprocess per raw); we'd rather not DOS the sidecar.
- **`_tick` removed.** It was private and only used by tests. Unit tests retargeted to `_run_claimed_job` (same semantics, modulo the session-per-job split).

## Test plan

New BDD test `shared_bdd_scheduler_test` exercises the dispatcher against a real PostgreSQL instance (the `FOR UPDATE SKIP LOCKED` contract is PG-specific and can't be faithfully mocked). Wall-clock timing is the concurrency oracle:

- [x] `test_due_jobs_run_in_parallel` — 3 jobs × 0.4s finish in <0.9s (serial would be ~1.2s)
- [x] `test_bounded_concurrency` — 4 jobs with `max_concurrent=2` finish in 0.5s–1.1s (2 waves of 2)
- [x] `test_failed_job_does_not_block_others` — one raising handler + one succeeding handler: both sessions land correct `last_status` values
- [x] `test_no_double_claim_under_concurrent_dispatch` — two `dispatch_due_jobs` coroutines racing on the same rows run each job exactly once
- [x] `test_returns_zero_when_no_jobs_due` — fast path when the queue is empty

Existing unit tests updated in-place:
- [x] `scheduler_loop_test.TestTick` → `TestRunClaimedJob` (tests the per-job execution path)
- [x] `TestRunSchedulerLoop` now patches `dispatch_due_jobs` rather than `_tick`
- [x] `scheduler_loop_extra_test` patches retargeted to `dispatch_due_jobs` with `*args, **kwargs` side effects
- [x] `scheduler_tick_missing_job_test` retargeted to `_run_claimed_job` (same race: claim commits, row deleted in another pod, handler session re-fetches and finds nothing)

**Local test verification blocked by infra.** `bb remote test --config=ci` repeatedly crashes the Bazel JVM (1.684kB `jvm.out` on every attempt, reproducible even on unchanged existing targets) — looks like the `bb remote` pool has a smaller memory allotment than CI workflows (which request 8GB). Relying on CI here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)