### PR TITLE
test(chat): cover empty-string edge case in vision content guard

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.53.4
+version: 0.53.5
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chat/vision_timeout_test.py
+++ b/projects/monolith/chat/vision_timeout_test.py
@@ -325,3 +325,15 @@ class TestVisionClientPayload:
             )
             with pytest.raises(ValueError, match="empty content"):
                 await client.describe(b"\x89PNG", "image/png")
+
+    @pytest.mark.asyncio
+    async def test_raises_on_empty_string_content(self):
+        """describe() raises ValueError when the model returns content: ""."""
+        client = VisionClient(base_url="http://fake:8080")
+
+        with patch("chat.vision.httpx.AsyncClient") as mock_cls:
+            mock_cls.return_value = _make_mock_http_client(
+                response=_ok_response(content="")
+            )
+            with pytest.raises(ValueError, match="empty content"):
+                await client.describe(b"\x89PNG", "image/png")

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.53.4
+      targetRevision: 0.53.5
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
## Summary

- Adds `test_raises_on_empty_string_content` to `TestVisionClientPayload` in `vision_timeout_test.py`
- Exercises the `if not content: raise ValueError` guard with `content=""`, complementing the existing `test_raises_on_null_content` which covers `content=None`
- Follows the exact same pattern as the null-content test

## Test plan

- [ ] `//projects/monolith/chat:vision_timeout_test` passes with both `test_raises_on_null_content` and `test_raises_on_empty_string_content`

🤖 Generated with [Claude Code](https://claude.com/claude-code)