### PR TITLE
feat(semgrep): add no-hardcoded-max-tokens-dict rule for dict payload literals

### DIFF
--- a/bazel/semgrep/rules/python/no-hardcoded-max-tokens-dict.py
+++ b/bazel/semgrep/rules/python/no-hardcoded-max-tokens-dict.py
@@ -1,0 +1,53 @@
+# Tests for no-hardcoded-max-tokens-dict rule.
+# Flags {"max_tokens": <integer>} in raw Python dict literals.
+import os
+
+
+def bad_hardcoded_max_tokens_dict():
+    # ruleid: no-hardcoded-max-tokens-dict
+    payload = {"max_tokens": 256}
+    return payload
+
+
+def bad_hardcoded_max_tokens_with_messages():
+    # ruleid: no-hardcoded-max-tokens-dict
+    payload = {"max_tokens": 4096, "messages": []}
+    return payload
+
+
+def bad_hardcoded_max_tokens_inline():
+    # ruleid: no-hardcoded-max-tokens-dict
+    return call_api({"model": "gpt-4", "max_tokens": 8192, "temperature": 0.7})
+
+
+def ok_max_tokens_from_env():
+    # ok: reading from environment variable is configurable
+    payload = {"max_tokens": int(os.environ.get("MAX_TOKENS", "4096"))}
+    return payload
+
+
+def ok_max_tokens_variable():
+    # ok: using a variable is fine — caller controls the value
+    limit = get_token_limit()
+    payload = {"max_tokens": limit}
+    return payload
+
+
+def ok_no_max_tokens():
+    # ok: no max_tokens key in dict
+    payload = {"model": "gpt-4", "messages": []}
+    return payload
+
+
+def ok_max_tokens_string_value():
+    # ok: string value, not an integer literal
+    payload = {"max_tokens": "4096"}
+    return payload
+
+
+def get_token_limit() -> int:
+    return int(os.environ.get("MAX_TOKENS", "4096"))
+
+
+def call_api(payload):
+    pass

--- a/bazel/semgrep/rules/python/no-hardcoded-max-tokens-dict.yaml
+++ b/bazel/semgrep/rules/python/no-hardcoded-max-tokens-dict.yaml
@@ -1,0 +1,29 @@
+rules:
+  - id: no-hardcoded-max-tokens-dict
+    patterns:
+      - pattern: |
+          {"max_tokens": $N, ...}
+      - metavariable-regex:
+          metavariable: $N
+          regex: ^\d+$
+    message: >
+      `"max_tokens": <integer>` is hardcoded to a literal integer value in a dict payload.
+      Hardcoded token limits cause context overflow when model context windows change
+      (e.g. upgrading from a 4k to an 8k model, or switching model providers).
+      Read the limit from an environment variable instead:
+      `"max_tokens": int(os.environ.get("MAX_TOKENS", "4096"))`.
+    languages: [python]
+    severity: WARNING
+    metadata:
+      category: correctness
+      subcategory: configuration
+      confidence: HIGH
+      likelihood: MEDIUM
+      impact: HIGH
+      technology: [python]
+      description: Dict payload max_tokens is hardcoded — use an env var so limits can change without redeploy
+    paths:
+      exclude:
+        - "*_test.py"
+        - "test_*.py"
+        - "tests/**"

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.53.4
+version: 0.53.5
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chat/summarizer.py
+++ b/projects/monolith/chat/summarizer.py
@@ -13,6 +13,8 @@ from chat.models import ChannelSummary, Message, UserChannelSummary
 
 logger = logging.getLogger(__name__)
 
+_LLM_MAX_TOKENS = int(os.environ.get("LLM_MAX_TOKENS", "16384"))
+
 
 async def generate_summaries(
     session: Session,
@@ -293,7 +295,7 @@ def build_llm_caller(base_url: str | None = None) -> Callable[[str], Awaitable[s
                     json={
                         "model": "qwen3.6-27b",
                         "messages": [{"role": "user", "content": prompt}],
-                        "max_tokens": 16384,
+                        "max_tokens": _LLM_MAX_TOKENS,
                     },
                 )
                 resp.raise_for_status()

--- a/projects/monolith/chat/vision.py
+++ b/projects/monolith/chat/vision.py
@@ -26,6 +26,7 @@ VISION_RETRY_TIMEOUT = 300.0  # 5 min total deadline
 # while slow vision inference still has time to complete.
 VISION_CONNECT_TIMEOUT = 5.0
 VISION_READ_TIMEOUT = 60.0
+VISION_MAX_TOKENS = int(os.environ.get("VISION_MAX_TOKENS", "4096"))
 
 
 def _is_retryable(exc: Exception) -> bool:
@@ -65,7 +66,7 @@ class VisionClient:
                     ],
                 },
             ],
-            "max_tokens": 4096,
+            "max_tokens": VISION_MAX_TOKENS,
             # Disable thinking so tokens are used for the description, not
             # <think> reasoning that fills the entire max_tokens budget.
             "chat_template_kwargs": {"enable_thinking": False},

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.53.4
+      targetRevision: 0.53.5
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
## Summary

- Adds new semgrep rule `no-hardcoded-max-tokens-dict` in `bazel/semgrep/rules/python/`
- Catches hardcoded integer values for `"max_tokens"` in raw Python dict literals (e.g. `{"max_tokens": 256}`)
- The existing `no-hardcoded-max-tokens` rule only catches `ModelSettings(max_tokens=N)`; this closes the gap exposed in PR #2185 where `vision.py` used a raw dict API payload
- Excludes test files (`*_test.py`, `test_*.py`, `tests/**`) consistent with existing rules
- Adds test fixture `no-hardcoded-max-tokens-dict.py` with `ruleid:` / `ok:` annotations following the existing pattern; auto-discovered by `glob(["python/*.py"])` in the BUILD file

## Test plan

- [x] Rule YAML follows exact structure of `no-hardcoded-max-tokens.yaml`
- [x] Test fixture covers: single-key dict, multi-key dict, inline dict call, env-var value (ok), variable value (ok), no key (ok), string value (ok)
- [x] BUILD files unchanged — new files auto-discovered via `glob(["python/*.yaml"])` and `glob(["python/*.py"])`
- [ ] `//bazel/semgrep/rules:python_rules_test` passes in BuildBuddy CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)