### PR TITLE
docs(stargazer): fix inaccurate backend/tests/ path reference

### DIFF
--- a/projects/stargazer/README.md
+++ b/projects/stargazer/README.md
@@ -9,7 +9,7 @@ Multi-phase pipeline: light pollution atlas + OSM road data to identify dark zon
 | Component   | Description |
 | ----------- | ----------- |
 | **backend** | Pipeline that combines light pollution data, OSM roads, and weather forecasts |
-| **tests**   | Additional unit tests for the backend pipeline (separate from backend/tests/) |
+| **tests**   | Additional unit tests for the backend pipeline (separate from tests co-located in `backend/`) |
 | **chart**   | Helm chart with CronJob and API server templates |
 | **deploy**  | ArgoCD Application, kustomization, and cluster-specific values |
 


### PR DESCRIPTION
## Summary

- Fixes README inaccuracy in `projects/stargazer/README.md`
- The `tests` component description referenced `backend/tests/` as a subdirectory, but no such directory exists
- Backend tests are co-located directly in `backend/` as `*_test.py` files (e.g., `backend/preprocessing_test.py`)
- The top-level `tests/` directory contains additional tests separate from those embedded files

## What changed

```diff
-| **tests**   | Additional unit tests for the backend pipeline (separate from backend/tests/) |
+| **tests**   | Additional unit tests for the backend pipeline (separate from tests co-located in `backend/`) |
```

## Audit scope

All 5 project READMEs were audited (`agent_platform`, `hikes`, `ships`, `stargazer`, `trips`). This was the only factual inaccuracy found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)