### PR TITLE
feat(semgrep): add require-component-label-in-selector rule and hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -88,6 +88,11 @@
             "type": "command",
             "command": "bazel/tools/hooks/check-large-inline-template.sh",
             "timeout": 10
+          },
+          {
+            "type": "command",
+            "command": "bazel/tools/hooks/check-deployment-component-label.sh",
+            "timeout": 10
           }
         ]
       }

--- a/bazel/semgrep/rules/BUILD
+++ b/bazel/semgrep/rules/BUILD
@@ -198,6 +198,22 @@ semgrep_test(
     tags = ["semgrep"],
 )
 
+# require-component-label-in-selector uses languages: [generic] with deployment path filters.
+# This test wires the rule to its annotation fixture independently of
+# kubernetes_rules_test (which uses yaml-language fixtures).
+filegroup(
+    name = "require_component_label_in_selector_rule",
+    srcs = ["kubernetes/require-component-label-in-selector.yaml"],
+)
+
+semgrep_test(
+    name = "require_component_label_in_selector_test",
+    srcs = ["//bazel/semgrep/tests:require_component_label_in_selector_fixtures"],
+    env = {"SEMGREP_TEST_MODE": "1"},
+    rules = [":require_component_label_in_selector_rule"],
+    tags = ["semgrep"],
+)
+
 # stale-copyright-year uses languages: [generic] so its fixture is a YAML file.
 # This test wires the rule to its annotation fixture independently of
 # golang_rules_test (which only scans *.go sources).

--- a/bazel/semgrep/rules/kubernetes/require-component-label-in-selector.yaml
+++ b/bazel/semgrep/rules/kubernetes/require-component-label-in-selector.yaml
@@ -1,0 +1,29 @@
+rules:
+  - id: require-component-label-in-selector
+    languages: [generic]
+    severity: WARNING
+    message: >-
+      Deployment `spec.selector.matchLabels` uses a shared `include "*.selectorLabels"`
+      helper without an `app.kubernetes.io/component` label. In a chart with multiple
+      Deployments, all pods share the same name+instance selector labels — Services
+      will route traffic to pods from ALL Deployments instead of the intended one.
+      Add `app.kubernetes.io/component: <component>` to both `spec.selector.matchLabels`
+      and `spec.template.metadata.labels`. See PR #2181.
+    metadata:
+      category: correctness
+      subcategory: kubernetes
+      confidence: HIGH
+      likelihood: HIGH
+      impact: HIGH
+      technology: [kubernetes, helm]
+      description: >-
+        Detects Helm Deployment templates where spec.selector.matchLabels uses a shared
+        selectorLabels include helper without app.kubernetes.io/component, causing
+        Services to route traffic to pods from all Deployments in a multi-Deployment chart.
+    paths:
+      include:
+        - "**/chart/templates/**deployment**"
+        - "**/chart/templates/**Deployment**"
+        - "**/deploy/templates/**deployment**"
+        - "**/deploy/templates/**Deployment**"
+    pattern-regex: 'matchLabels:\n[ \t]+\{\{-?\s+include\s+"[^"]*[Ss]electorLabels[^"]*"[^\n]*\n(?![ \t]+app\.kubernetes\.io/component:)'

--- a/bazel/semgrep/tests/BUILD
+++ b/bazel/semgrep/tests/BUILD
@@ -16,6 +16,7 @@ filegroup(
             "fixtures/no-unquoted-helm-range-args.yaml",
             "fixtures/python-shadow-module-import.yaml",
             "fixtures/require-cnpg-cluster-resources.yaml",
+            "fixtures/require-component-label-in-selector.yaml",
             "fixtures/unsafe-json-field-access.yaml",
         ],
     ),
@@ -59,6 +60,13 @@ filegroup(
 filegroup(
     name = "no_unquoted_helm_range_args_fixtures",
     srcs = ["fixtures/no-unquoted-helm-range-args.yaml"],
+)
+
+# Fixture for the require-component-label-in-selector rule (languages: generic).
+# Referenced by //bazel/semgrep/rules:require_component_label_in_selector_test.
+filegroup(
+    name = "require_component_label_in_selector_fixtures",
+    srcs = ["fixtures/require-component-label-in-selector.yaml"],
 )
 
 # Fixtures for kubernetes rules (require-readiness-probe, require-resource-limits, etc.).

--- a/bazel/semgrep/tests/fixtures/require-component-label-in-selector.yaml
+++ b/bazel/semgrep/tests/fixtures/require-component-label-in-selector.yaml
@@ -1,0 +1,37 @@
+# Tests for require-component-label-in-selector rule.
+# When a chart has multiple Deployments, their pods share generic selectorLabels
+# (name + instance) — Services route to pods from ALL Deployments. Each
+# spec.selector.matchLabels must include app.kubernetes.io/component.
+---
+# ruleid: require-component-label-in-selector
+    matchLabels:
+      {{- include "myapp.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "myapp.selectorLabels" . | nindent 8 }}
+
+---
+# ruleid: require-component-label-in-selector
+    matchLabels:
+      {{- include "myservice.selectorLabels" . | nindent 6 }}
+  strategy:
+    type: RollingUpdate
+
+---
+# ok: require-component-label-in-selector
+    matchLabels:
+      {{- include "myapp.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: api
+  template:
+    metadata:
+      labels:
+        {{- include "myapp.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: api
+
+---
+# ok: require-component-label-in-selector
+    matchLabels:
+      {{- include "myapp.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: worker
+  template:

--- a/bazel/tools/hooks/BUILD
+++ b/bazel/tools/hooks/BUILD
@@ -21,3 +21,9 @@ sh_test(
     srcs = ["check-bdd-shared-testing-dep_test.sh"],
     data = [":check-bdd-shared-testing-dep.sh"],
 )
+
+sh_test(
+    name = "check_deployment_component_label_test",
+    srcs = ["check-deployment-component-label_test.sh"],
+    data = [":check-deployment-component-label.sh"],
+)

--- a/bazel/tools/hooks/check-deployment-component-label.sh
+++ b/bazel/tools/hooks/check-deployment-component-label.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+# PreToolUse hook: warn when writing a Helm Deployment template where
+# spec.selector.matchLabels uses a shared selectorLabels include helper
+# without app.kubernetes.io/component.
+#
+# In a chart with multiple Deployments, pods share generic name+instance
+# selector labels. Without a component label, Services route traffic to
+# pods from ALL Deployments instead of the intended one. See PR #2181.
+#
+# Input: JSON on stdin from Claude Code hook system
+# Exit 0: allow (warnings emitted on stderr)
+# Exit 2: block (not used — this is advisory only)
+
+set -euo pipefail
+
+INPUT=$(cat)
+
+# Only trigger on Helm chart deployment template files
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
+if [[ -z "$FILE_PATH" ]]; then
+	exit 0
+fi
+
+# Match deployment templates in chart/ or deploy/ template directories
+BASENAME=$(basename "$FILE_PATH")
+DIRPATH=$(dirname "$FILE_PATH")
+if [[ "$DIRPATH" != *chart/templates* ]] && [[ "$DIRPATH" != *deploy/templates* ]]; then
+	exit 0
+fi
+if [[ "$BASENAME" != *deployment* ]] && [[ "$BASENAME" != *Deployment* ]]; then
+	exit 0
+fi
+
+# Get the content being written (Write tool) or the replacement string (Edit tool)
+NEW_CONTENT=$(echo "$INPUT" | jq -r '.tool_input.new_string // .tool_input.content // empty')
+if [[ -z "$NEW_CONTENT" ]]; then
+	exit 0
+fi
+
+# Skip if no matchLabels present
+if ! echo "$NEW_CONTENT" | grep -q 'matchLabels:'; then
+	exit 0
+fi
+# Skip if no selectorLabels include present
+if ! echo "$NEW_CONTENT" | grep -qE 'include\s+"[^"]*[Ss]electorLabels'; then
+	exit 0
+fi
+
+# Use awk to detect matchLabels block with selectorLabels include but without component label.
+# Sliding-window: after seeing matchLabels: then include "*.selectorLabels", check the next line.
+HAS_ISSUE=$(echo "$NEW_CONTENT" | awk '
+  prev_selector {
+    if ($0 !~ /app\.kubernetes\.io\/component:/) { print "yes"; exit }
+    prev_selector = 0
+  }
+  /matchLabels:/ { expect_include = 1; next }
+  expect_include && /include[[:space:]]+"[^"]*[Ss]electorLabels/ {
+    prev_selector = 1
+    expect_include = 0
+    next
+  }
+  { expect_include = 0 }
+')
+
+if [[ "$HAS_ISSUE" == "yes" ]]; then
+	cat >&2 <<-EOF
+		WARNING: Deployment selector uses selectorLabels include without app.kubernetes.io/component.
+
+		In a chart with multiple Deployments, all pods share the same name+instance
+		selector labels. Services will route traffic to pods from ALL Deployments
+		instead of the intended one (PR #2181).
+
+		Add app.kubernetes.io/component: <component> to both:
+		  - spec.selector.matchLabels
+		  - spec.template.metadata.labels
+
+		Example:
+		  matchLabels:
+		    {{- include "mychart.selectorLabels" . | nindent 6 }}
+		    app.kubernetes.io/component: api
+
+		If this chart has only one Deployment, proceed. Otherwise add the component label.
+	EOF
+fi
+
+exit 0

--- a/bazel/tools/hooks/check-deployment-component-label_test.sh
+++ b/bazel/tools/hooks/check-deployment-component-label_test.sh
@@ -1,0 +1,196 @@
+#!/usr/bin/env bash
+# Unit tests for check-deployment-component-label.sh PreToolUse hook.
+#
+# The hook:
+#   - Reads JSON from stdin with .tool_input.file_path and .tool_input.content
+#     (Write) or .tool_input.new_string (Edit)
+#   - Exits 0 always (warning-only, never blocks)
+#   - Emits a WARNING on stderr when a deployment template's matchLabels uses
+#     a selectorLabels include without app.kubernetes.io/component
+#   - Skips non-deployment files, non-template directories, and files without
+#     selectorLabels includes
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Locate hook from Bazel runfiles
+# ---------------------------------------------------------------------------
+HOOK_REL="bazel/tools/hooks/check-deployment-component-label.sh"
+HOOK=""
+for candidate in \
+	"${RUNFILES_DIR:-}/_main/${HOOK_REL}" \
+	"${TEST_SRCDIR:-}/_main/${HOOK_REL}" \
+	"${BASH_SOURCE[0]%/*}/check-deployment-component-label.sh"; do
+	if [[ -f "$candidate" ]]; then
+		HOOK="$candidate"
+		break
+	fi
+done
+if [[ -z "$HOOK" ]]; then
+	echo "ERROR: cannot locate check-deployment-component-label.sh in runfiles" >&2
+	exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Install a minimal jq stub so the hook runs in the hermetic sandbox.
+# The hook uses:
+#   jq -r '.tool_input.file_path // empty'
+#   jq -r '.tool_input.new_string // .tool_input.content // empty'
+# ---------------------------------------------------------------------------
+mkdir -p "${TEST_TMPDIR}/bin"
+cat >"${TEST_TMPDIR}/bin/jq" <<'JQ_STUB'
+#!/usr/bin/env python3
+"""Minimal jq stub covering expressions used by check-deployment-component-label.sh."""
+import json, sys
+
+args = sys.argv[1:]
+raw = False
+if args and args[0] == "-r":
+    raw = True
+    args = args[1:]
+
+expr = args[0] if args else "."
+data = json.load(sys.stdin)
+
+def jq_eval(obj, expr):
+    """Evaluate '.a.b // .c.d // empty' style expressions."""
+    for alt in expr.split("//"):
+        alt = alt.strip()
+        if alt == "empty":
+            return None
+        keys = [k for k in alt.lstrip(".").split(".") if k]
+        val = obj
+        try:
+            for k in keys:
+                val = val[k] if isinstance(val, dict) else None
+                if val is None:
+                    break
+        except (KeyError, TypeError):
+            val = None
+        if val is not None:
+            return val
+    return None
+
+result = jq_eval(data, expr)
+if result is None:
+    pass  # empty — print nothing
+elif raw:
+    print(result)
+else:
+    print(json.dumps(result))
+JQ_STUB
+chmod +x "${TEST_TMPDIR}/bin/jq"
+export PATH="${TEST_TMPDIR}/bin:${PATH}"
+
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
+PASS=0
+FAIL=0
+
+run_test() {
+	local name="$1"
+	local input_json="$2"
+	local want_exit="$3"      # expected exit code (always 0 for this hook)
+	local want_stderr_re="$4" # regex that must match stderr (empty = no output expected)
+
+	local stderr_out
+	local got_exit=0
+	stderr_out=$(printf '%s' "$input_json" | bash "$HOOK" 2>&1 >/dev/null) || got_exit=$?
+
+	local ok=true
+
+	if [[ "$got_exit" -ne "$want_exit" ]]; then
+		echo "FAIL [$name]: exit $got_exit, want $want_exit"
+		ok=false
+	fi
+
+	if [[ -n "$want_stderr_re" ]]; then
+		if ! echo "$stderr_out" | grep -qE "$want_stderr_re"; then
+			echo "FAIL [$name]: stderr $(printf '%q' "$stderr_out") did not match /$want_stderr_re/"
+			ok=false
+		fi
+	else
+		if [[ -n "$stderr_out" ]]; then
+			echo "FAIL [$name]: unexpected stderr: $(printf '%q' "$stderr_out")"
+			ok=false
+		fi
+	fi
+
+	if $ok; then
+		echo "PASS [$name]"
+		PASS=$((PASS + 1))
+	else
+		FAIL=$((FAIL + 1))
+	fi
+}
+
+# ---------------------------------------------------------------------------
+# Test cases
+# ---------------------------------------------------------------------------
+
+BAD_CONTENT='    matchLabels:
+      {{- include "myapp.selectorLabels" . | nindent 6 }}
+  template:'
+
+GOOD_CONTENT='    matchLabels:
+      {{- include "myapp.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: api
+  template:'
+
+# 1. Deployment template missing component label → warns
+run_test "missing_component_warns" \
+	"$(jq -cn --arg fp "/project/chart/templates/deployment.yaml" --arg content "$BAD_CONTENT" \
+		'{tool_input: {file_path: $fp, content: $content}}')" \
+	0 "WARNING.*component"
+
+# 2. Deployment template with component label → no warning
+run_test "has_component_no_warning" \
+	"$(jq -cn --arg fp "/project/chart/templates/deployment.yaml" --arg content "$GOOD_CONTENT" \
+		'{tool_input: {file_path: $fp, content: $content}}')" \
+	0 ""
+
+# 3. Non-deployment file → skip
+run_test "non_deployment_skipped" \
+	"$(jq -cn --arg fp "/project/chart/templates/service.yaml" --arg content "$BAD_CONTENT" \
+		'{tool_input: {file_path: $fp, content: $content}}')" \
+	0 ""
+
+# 4. Non-template directory → skip
+run_test "non_template_dir_skipped" \
+	"$(jq -cn --arg fp "/project/deploy/values.yaml" --arg content "$BAD_CONTENT" \
+		'{tool_input: {file_path: $fp, content: $content}}')" \
+	0 ""
+
+# 5. Edit tool (new_string) — missing component warns
+run_test "edit_tool_missing_component_warns" \
+	"$(jq -cn --arg fp "/project/chart/templates/api-deployment.yaml" --arg ns "$BAD_CONTENT" \
+		'{tool_input: {file_path: $fp, new_string: $ns}}')" \
+	0 "WARNING"
+
+# 6. No matchLabels in content → skip
+run_test "no_matchlabels_skipped" \
+	"$(jq -cn --arg fp "/project/chart/templates/deployment.yaml" --arg content "kind: Deployment" \
+		'{tool_input: {file_path: $fp, content: $content}}')" \
+	0 ""
+
+# 7. Empty JSON → skip
+run_test "empty_json_allowed" \
+	'{}' \
+	0 ""
+
+# 8. deploy/templates path also triggers check
+run_test "deploy_templates_path_warns" \
+	"$(jq -cn --arg fp "/project/deploy/templates/deployment.yaml" --arg content "$BAD_CONTENT" \
+		'{tool_input: {file_path: $fp, content: $content}}')" \
+	0 "WARNING"
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+echo "Results: ${PASS} passed, ${FAIL} failed"
+if [[ "$FAIL" -gt 0 ]]; then
+	exit 1
+fi
+exit 0

--- a/bazel/tools/hooks/check-deployment-component-label_test.sh
+++ b/bazel/tools/hooks/check-deployment-component-label_test.sh
@@ -138,40 +138,45 @@ GOOD_CONTENT='    matchLabels:
       app.kubernetes.io/component: api
   template:'
 
+# Build JSON inputs using Python (guaranteed available in the hermetic Bazel sandbox).
+# This avoids calling jq with -cn/--arg flags that our minimal stub does not support.
+make_json() {
+	local fp="$1" key="$2" val="$3"
+	python3 - "$fp" "$key" "$val" <<'PY'
+import json, sys
+fp, key, val = sys.argv[1], sys.argv[2], sys.argv[3]
+print(json.dumps({"tool_input": {"file_path": fp, key: val}}))
+PY
+}
+
 # 1. Deployment template missing component label → warns
 run_test "missing_component_warns" \
-	"$(jq -cn --arg fp "/project/chart/templates/deployment.yaml" --arg content "$BAD_CONTENT" \
-		'{tool_input: {file_path: $fp, content: $content}}')" \
+	"$(make_json "/project/chart/templates/deployment.yaml" "content" "$BAD_CONTENT")" \
 	0 "WARNING.*component"
 
 # 2. Deployment template with component label → no warning
 run_test "has_component_no_warning" \
-	"$(jq -cn --arg fp "/project/chart/templates/deployment.yaml" --arg content "$GOOD_CONTENT" \
-		'{tool_input: {file_path: $fp, content: $content}}')" \
+	"$(make_json "/project/chart/templates/deployment.yaml" "content" "$GOOD_CONTENT")" \
 	0 ""
 
 # 3. Non-deployment file → skip
 run_test "non_deployment_skipped" \
-	"$(jq -cn --arg fp "/project/chart/templates/service.yaml" --arg content "$BAD_CONTENT" \
-		'{tool_input: {file_path: $fp, content: $content}}')" \
+	"$(make_json "/project/chart/templates/service.yaml" "content" "$BAD_CONTENT")" \
 	0 ""
 
 # 4. Non-template directory → skip
 run_test "non_template_dir_skipped" \
-	"$(jq -cn --arg fp "/project/deploy/values.yaml" --arg content "$BAD_CONTENT" \
-		'{tool_input: {file_path: $fp, content: $content}}')" \
+	"$(make_json "/project/deploy/values.yaml" "content" "$BAD_CONTENT")" \
 	0 ""
 
 # 5. Edit tool (new_string) — missing component warns
 run_test "edit_tool_missing_component_warns" \
-	"$(jq -cn --arg fp "/project/chart/templates/api-deployment.yaml" --arg ns "$BAD_CONTENT" \
-		'{tool_input: {file_path: $fp, new_string: $ns}}')" \
+	"$(make_json "/project/chart/templates/api-deployment.yaml" "new_string" "$BAD_CONTENT")" \
 	0 "WARNING"
 
 # 6. No matchLabels in content → skip
 run_test "no_matchlabels_skipped" \
-	"$(jq -cn --arg fp "/project/chart/templates/deployment.yaml" --arg content "kind: Deployment" \
-		'{tool_input: {file_path: $fp, content: $content}}')" \
+	"$(make_json "/project/chart/templates/deployment.yaml" "content" "kind: Deployment")" \
 	0 ""
 
 # 7. Empty JSON → skip
@@ -181,8 +186,7 @@ run_test "empty_json_allowed" \
 
 # 8. deploy/templates path also triggers check
 run_test "deploy_templates_path_warns" \
-	"$(jq -cn --arg fp "/project/deploy/templates/deployment.yaml" --arg content "$BAD_CONTENT" \
-		'{tool_input: {file_path: $fp, content: $content}}')" \
+	"$(make_json "/project/deploy/templates/deployment.yaml" "content" "$BAD_CONTENT")" \
 	0 "WARNING"
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds semgrep rule `require-component-label-in-selector` that detects Helm Deployment templates where `spec.selector.matchLabels` uses a shared `include "*.selectorLabels"` helper without `app.kubernetes.io/component`
- Adds complementary PreToolUse hook `check-deployment-component-label.sh` that warns at write/edit time
- Motivated by PR #2181 where multi-Deployment charts with shared selectorLabels caused Services to route to the wrong pods

## Changes

### Semgrep Rule (`bazel/semgrep/rules/kubernetes/require-component-label-in-selector.yaml`)
- Uses `languages: [generic]` with `pattern-regex` to detect the missing component label pattern
- Scoped to `**/chart/templates/**deployment**` and `**/deploy/templates/**deployment**` paths
- Dedicated `semgrep_test` target wired to annotation fixture (separate from `kubernetes_rules_test`)

### Test Fixture (`bazel/semgrep/tests/fixtures/require-component-label-in-selector.yaml`)
- 2 `ruleid:` cases: `matchLabels` with selectorLabels include but no component label
- 2 `ok:` cases: `matchLabels` with selectorLabels include AND component label

### Hook (`bazel/tools/hooks/check-deployment-component-label.sh`)
- PreToolUse hook registered in `.claude/settings.json` under `Write|Edit` matcher
- Uses awk sliding-window to detect `matchLabels:` followed by selectorLabels include without component label
- Advisory only (exit 0), warns on stderr with remediation guidance

## Test plan

- [ ] `bazel test //bazel/semgrep/... --config=ci` passes (including new `require_component_label_in_selector_test`)
- [ ] `bazel test //bazel/tools/hooks/... --config=ci` passes (including new `check_deployment_component_label_test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)