### PR TITLE
feat(knowledge): gap-driven knowledge graph — first slice

### DIFF
--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -1860,6 +1860,19 @@ py_test(
 )
 
 py_test(
+    name = "knowledge_gap_model_test",
+    srcs = ["knowledge/gap_model_test.py"],
+    imports = ["."],
+    deps = [
+        ":monolith_backend",
+        "@pip//pgvector",
+        "@pip//pytest",
+        "@pip//sqlalchemy",
+        "@pip//sqlmodel",
+    ],
+)
+
+py_test(
     name = "knowledge_service_test",
     srcs = ["knowledge/service_test.py"],
     imports = ["."],

--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -2144,6 +2144,39 @@ py_test(
 )
 
 py_test(
+    name = "knowledge_gap_api_test",
+    srcs = ["knowledge/gap_api_test.py"],
+    imports = ["."],
+    deps = [
+        ":monolith_backend",
+        "@pip//fastapi",
+        "@pip//httpx",
+        "@pip//pgvector",
+        "@pip//pytest",
+        "@pip//pyyaml",
+        "@pip//sqlalchemy",
+        "@pip//sqlmodel",
+    ],
+)
+
+py_test(
+    name = "knowledge_mcp_gap_test",
+    srcs = ["knowledge/mcp_gap_test.py"],
+    imports = ["."],
+    deps = [
+        ":monolith_backend",
+        "@pip//fastmcp",
+        "@pip//httpx",
+        "@pip//pgvector",
+        "@pip//pytest",
+        "@pip//pytest_asyncio",
+        "@pip//pyyaml",
+        "@pip//sqlalchemy",
+        "@pip//sqlmodel",
+    ],
+)
+
+py_test(
     name = "tasks_router_test",
     srcs = ["knowledge/tasks_router_test.py"],
     imports = ["."],

--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -1873,6 +1873,32 @@ py_test(
 )
 
 py_test(
+    name = "knowledge_gap_lifecycle_test",
+    srcs = ["knowledge/gap_lifecycle_test.py"],
+    imports = ["."],
+    deps = [
+        ":monolith_backend",
+        "@pip//pgvector",
+        "@pip//pytest",
+        "@pip//sqlalchemy",
+        "@pip//sqlmodel",
+    ],
+)
+
+py_test(
+    name = "knowledge_store_gap_queries_test",
+    srcs = ["knowledge/store_gap_queries_test.py"],
+    imports = ["."],
+    deps = [
+        ":monolith_backend",
+        "@pip//pgvector",
+        "@pip//pytest",
+        "@pip//sqlalchemy",
+        "@pip//sqlmodel",
+    ],
+)
+
+py_test(
     name = "knowledge_service_test",
     srcs = ["knowledge/service_test.py"],
     imports = ["."],

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.53.5
+version: 0.53.6
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.53.6
+version: 0.53.7
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/migrations/20260424000000_knowledge_gaps.sql
+++ b/projects/monolith/chart/migrations/20260424000000_knowledge_gaps.sql
@@ -1,0 +1,29 @@
+-- knowledge gaps: unresolved wikilinks promoted to trackable work items
+-- for the gap-driven knowledge graph (see docs/plans/2026-04-24-gap-driven-knowledge-graph-design.md).
+--
+-- A gap is an unresolved [[wikilink]] that becomes a research agenda item.
+-- Each gap tracks its class (external/internal/hybrid/parked) and state through
+-- the pipeline. Internal gaps drain through the review queue; external gaps
+-- route to automated research (not yet implemented in this slice).
+
+CREATE TABLE knowledge.gaps (
+    id               BIGSERIAL    PRIMARY KEY,
+    term             TEXT         NOT NULL,
+    context          TEXT         NOT NULL DEFAULT '',
+    source_note_fk   BIGINT       REFERENCES knowledge.notes(id) ON DELETE CASCADE,
+    gap_class        TEXT         CHECK (gap_class IN ('external','internal','hybrid','parked')),
+    state            TEXT         NOT NULL DEFAULT 'discovered'
+                                  CHECK (state IN ('discovered','classified','in_review',
+                                                   'researched','verified','consolidated',
+                                                   'committed','rejected')),
+    answer           TEXT,
+    created_at       TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    classified_at   TIMESTAMPTZ,
+    resolved_at      TIMESTAMPTZ,
+    pipeline_version TEXT         NOT NULL,
+    UNIQUE (term, source_note_fk)
+);
+
+CREATE INDEX gaps_state ON knowledge.gaps (state);
+CREATE INDEX gaps_class ON knowledge.gaps (gap_class);
+CREATE INDEX gaps_term  ON knowledge.gaps (term);

--- a/projects/monolith/chart/migrations/atlas.sum
+++ b/projects/monolith/chart/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:0vg/WgV9q4y3X588d4P06rSMJIDcy9E1NJFJ0zSEbK4=
+h1:37vgW1t0MQZO1vwcBQ6f+RxR3Zfvo8mGMYWH7Qgizmg=
 20260330000000_initial_schema.sql h1:J2futpSW0nJAIRR7nR7ssT7LwXIYrvRI+PkHb5Y4tLI=
 20260403000000_chat_schema.sql h1:pERUFC0vzM95etRuzp43XzkCV7lBCzrrtY5Mk7aF3CA=
 20260404000000_chat_attachments.sql h1:tv+Fdbr1rQC5nzUxfaBC0O6fu2OMGgLWf+YNg1WQXi4=
@@ -13,3 +13,4 @@ h1:0vg/WgV9q4y3X588d4P06rSMJIDcy9E1NJFJ0zSEbK4=
 20260410000000_raw_bucketing_schema.sql h1:WoT366k91xOXDnAc8AZgQ45mwj/cYFyGLV/Kbso/Axg=
 20260411000000_ingest_queue.sql h1:X04mvgHv8laKJgycHpXH4iqIrgjzOJjauB1rjEdfL8c=
 20260411000001_dead_letter_columns.sql h1:nVlp/xDjQ+1Ue3hM38yTmZ7p8NLT7+AdcUDSpRPP3r8=
+20260424000000_knowledge_gaps.sql h1:p88KsoTvhhCc+jSTef4Ajp050Bfy7Yz7WXrgIFPbz8A=

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.53.5
+      targetRevision: 0.53.6
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.53.6
+      targetRevision: 0.53.7
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/knowledge/README.md
+++ b/projects/monolith/knowledge/README.md
@@ -6,15 +6,16 @@ LLM-powered knowledge graph with on-cluster inference.
 
 Raw markdown is ingested, decomposed into structured facts by Qwen-3 (with self-critique for quality), embedded with voyage-4-nano, and stored in pgvector for semantic search. Fronted by a SvelteKit app with a `Cmd+K` search overlay.
 
-| Module              | Description                                                   |
-| ------------------- | ------------------------------------------------------------- |
-| **ingest_queue**    | Ingests raw markdown, routes to gardener or direct storage    |
-| **raw_ingest**      | Discovers and processes raw markdown files from the vault     |
-| **gardener**        | Qwen-3 fact decomposition with self-critique and distillation |
-| **reconciler**      | Incremental re-embedding when the embedding model changes     |
-| **store**           | pgvector-backed storage with semantic search                  |
-| **service**         | FastAPI service layer                                         |
-| **router**          | HTTP API routes                                               |
-| **mcp**             | MCP tool exposure for AI agent access to the knowledge graph  |
-| **links/wikilinks** | Obsidian wikilink parsing and backlink resolution             |
-| **tasks_router**    | Task management API                                           |
+| Module              | Description                                                         |
+| ------------------- | ------------------------------------------------------------------- |
+| **ingest_queue**    | Ingests raw markdown, routes to gardener or direct storage          |
+| **raw_ingest**      | Discovers and processes raw markdown files from the vault           |
+| **gardener**        | Qwen-3 fact decomposition with self-critique and distillation       |
+| **gaps**            | Unresolved wikilink tracking: discover → classify → review → answer |
+| **reconciler**      | Incremental re-embedding when the embedding model changes           |
+| **store**           | pgvector-backed storage with semantic search                        |
+| **service**         | FastAPI service layer                                               |
+| **router**          | HTTP API routes                                                     |
+| **mcp**             | MCP tool exposure for AI agent access to the knowledge graph        |
+| **links/wikilinks** | Obsidian wikilink parsing and backlink resolution                   |
+| **tasks_router**    | Task management API                                                 |

--- a/projects/monolith/knowledge/gap_api_test.py
+++ b/projects/monolith/knowledge/gap_api_test.py
@@ -177,6 +177,28 @@ class TestListGaps:
         r = client.get("/api/knowledge/gaps?limit=10000")
         assert r.status_code == 422
 
+    def test_list_gaps_handles_trailing_comma(self, client, session):
+        """Trailing comma in state CSV must not become an empty-string filter.
+
+        Regression: before the shared ``split_csv`` helper, ``state=in_review,``
+        would pass ``[""]`` through as a filter value — which could silently
+        hide all in_review gaps depending on the filter semantics.
+        """
+        src = _make_source_note(session)
+        _make_gap(session, term="review-one", source_fk=src.id, state="in_review")
+        _make_gap(
+            session,
+            term="discovered-one",
+            source_fk=src.id,
+            state="discovered",
+            gap_class=None,
+        )
+
+        r = client.get("/api/knowledge/gaps?state=in_review,&limit=10")
+        assert r.status_code == 200
+        terms = sorted(g["term"] for g in r.json().get("gaps", []))
+        assert terms == ["review-one"]
+
 
 class TestReviewQueue:
     """GET /api/knowledge/gaps/review-queue."""

--- a/projects/monolith/knowledge/gap_api_test.py
+++ b/projects/monolith/knowledge/gap_api_test.py
@@ -1,0 +1,326 @@
+"""Tests for the gap lifecycle HTTP endpoints.
+
+Uses the same in-memory SQLite + TestClient fixture pattern as
+``dead_letter_test.py`` — real DB, real filesystem, no mocks.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+import yaml
+from fastapi.testclient import TestClient
+from sqlmodel import Session, SQLModel, create_engine
+from sqlmodel.pool import StaticPool
+
+from knowledge.gaps import GAPS_PIPELINE_VERSION
+from knowledge.models import Gap, Note
+from knowledge.service import VAULT_ROOT_ENV
+
+
+@pytest.fixture
+def session():
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    original_schemas = {}
+    for table in SQLModel.metadata.tables.values():
+        if table.schema is not None:
+            original_schemas[table.name] = table.schema
+            table.schema = None
+    try:
+        SQLModel.metadata.create_all(engine)
+        with Session(engine) as s:
+            yield s
+    finally:
+        for table in SQLModel.metadata.tables.values():
+            if table.name in original_schemas:
+                table.schema = original_schemas[table.name]
+
+
+@pytest.fixture
+def client(session, tmp_path, monkeypatch):
+    from fastapi import FastAPI
+
+    from app.db import get_session
+    from knowledge.router import router
+
+    monkeypatch.setenv(VAULT_ROOT_ENV, str(tmp_path))
+    app = FastAPI()
+    app.include_router(router)
+    app.dependency_overrides[get_session] = lambda: session
+    yield TestClient(app)
+    app.dependency_overrides.clear()
+
+
+def _make_source_note(session: Session, note_id: str = "src") -> Note:
+    note = Note(
+        note_id=note_id,
+        path=f"_processed/{note_id}.md",
+        title=note_id,
+        content_hash=f"hash-{note_id}",
+        type="atom",
+    )
+    session.add(note)
+    session.commit()
+    session.refresh(note)
+    return note
+
+
+def _make_gap(
+    session: Session,
+    *,
+    term: str,
+    source_fk: int,
+    state: str = "in_review",
+    gap_class: str | None = "internal",
+    created_at: datetime | None = None,
+) -> Gap:
+    gap = Gap(
+        term=term,
+        context="",
+        source_note_fk=source_fk,
+        gap_class=gap_class,
+        state=state,
+        pipeline_version=GAPS_PIPELINE_VERSION,
+        created_at=created_at or datetime.now(timezone.utc),
+    )
+    session.add(gap)
+    session.commit()
+    session.refresh(gap)
+    return gap
+
+
+class TestListGaps:
+    """GET /api/knowledge/gaps."""
+
+    def test_returns_all_gaps_by_default(self, client, session):
+        src = _make_source_note(session)
+        _make_gap(
+            session, term="a", source_fk=src.id, state="discovered", gap_class=None
+        )
+        _make_gap(session, term="b", source_fk=src.id, state="in_review")
+
+        r = client.get("/api/knowledge/gaps")
+        assert r.status_code == 200
+        body = r.json()
+        terms = sorted(g["term"] for g in body["gaps"])
+        assert terms == ["a", "b"]
+
+    def test_filters_by_state(self, client, session):
+        src = _make_source_note(session)
+        _make_gap(
+            session,
+            term="discovered-one",
+            source_fk=src.id,
+            state="discovered",
+            gap_class=None,
+        )
+        _make_gap(session, term="in-review-one", source_fk=src.id, state="in_review")
+        _make_gap(
+            session,
+            term="classified-one",
+            source_fk=src.id,
+            state="classified",
+            gap_class="external",
+        )
+
+        r = client.get("/api/knowledge/gaps?state=in_review,classified")
+        assert r.status_code == 200
+        terms = sorted(g["term"] for g in r.json().get("gaps", []))
+        assert terms == ["classified-one", "in-review-one"]
+
+    def test_filters_by_gap_class(self, client, session):
+        src = _make_source_note(session)
+        _make_gap(
+            session,
+            term="ext",
+            source_fk=src.id,
+            state="classified",
+            gap_class="external",
+        )
+        _make_gap(
+            session,
+            term="intr",
+            source_fk=src.id,
+            state="in_review",
+            gap_class="internal",
+        )
+        _make_gap(
+            session, term="hyb", source_fk=src.id, state="in_review", gap_class="hybrid"
+        )
+
+        r = client.get("/api/knowledge/gaps?gap_class=internal,hybrid")
+        assert r.status_code == 200
+        terms = sorted(g["term"] for g in r.json().get("gaps", []))
+        assert terms == ["hyb", "intr"]
+
+    def test_limit_clamped_and_honored(self, client, session):
+        src = _make_source_note(session)
+        for i in range(5):
+            _make_gap(
+                session,
+                term=f"t{i}",
+                source_fk=src.id,
+                state="discovered",
+                gap_class=None,
+            )
+
+        r = client.get("/api/knowledge/gaps?limit=2")
+        assert r.status_code == 200
+        assert len(r.json().get("gaps", [])) == 2
+
+    def test_limit_over_max_rejected(self, client):
+        r = client.get("/api/knowledge/gaps?limit=10000")
+        assert r.status_code == 422
+
+
+class TestReviewQueue:
+    """GET /api/knowledge/gaps/review-queue."""
+
+    def test_returns_internal_and_hybrid_in_review_only(self, client, session):
+        src = _make_source_note(session)
+        now = datetime.now(timezone.utc)
+        _make_gap(
+            session,
+            term="a-internal",
+            source_fk=src.id,
+            state="in_review",
+            gap_class="internal",
+            created_at=now - timedelta(seconds=30),
+        )
+        _make_gap(
+            session,
+            term="b-hybrid",
+            source_fk=src.id,
+            state="in_review",
+            gap_class="hybrid",
+            created_at=now - timedelta(seconds=20),
+        )
+        _make_gap(
+            session,
+            term="c-external",
+            source_fk=src.id,
+            state="classified",
+            gap_class="external",
+            created_at=now - timedelta(seconds=10),
+        )
+        _make_gap(
+            session,
+            term="d-internal-discovered",
+            source_fk=src.id,
+            state="discovered",
+            gap_class=None,
+            created_at=now,
+        )
+
+        r = client.get("/api/knowledge/gaps/review-queue")
+        assert r.status_code == 200
+        body = r.json()
+        terms = [g["term"] for g in body["gaps"]]
+        # FIFO; only in_review + internal/hybrid.
+        assert terms == ["a-internal", "b-hybrid"]
+
+    def test_empty_queue_returns_empty_list(self, client):
+        r = client.get("/api/knowledge/gaps/review-queue")
+        assert r.status_code == 200
+        assert r.json() == {"gaps": []}
+
+
+class TestAnswerGap:
+    """POST /api/knowledge/gaps/{gap_id}/answer."""
+
+    def test_happy_path_writes_file(self, client, session, tmp_path):
+        src = _make_source_note(session)
+        gap = _make_gap(
+            session,
+            term="Linkerd mTLS",
+            source_fk=src.id,
+            state="in_review",
+            gap_class="internal",
+        )
+
+        r = client.post(
+            f"/api/knowledge/gaps/{gap.id}/answer",
+            json={"answer": "Linkerd uses per-pod sidecars on port 4143."},
+        )
+
+        assert r.status_code == 200
+        body = r.json()
+        assert body["gap_id"] == gap.id
+        assert body["note_id"] == "linkerd-mtls"
+        assert body["path"] == "_processed/linkerd-mtls.md"
+
+        written = (tmp_path / body["path"]).read_text()
+        _, fm_block, note_body = written.split("---\n", 2)
+        fm = yaml.safe_load(fm_block)
+        assert fm == {
+            "id": "linkerd-mtls",
+            "title": "Linkerd mTLS",
+            "type": "atom",
+            "source_tier": "personal",
+        }
+        assert "Linkerd uses per-pod sidecars" in note_body
+
+        # Refresh in-session view — gap should be committed.
+        session.expire_all()
+        reloaded = session.get(Gap, gap.id)
+        assert reloaded.state == "committed"
+
+    def test_unknown_gap_id_returns_404(self, client):
+        r = client.post(
+            "/api/knowledge/gaps/9999/answer",
+            json={"answer": "anything"},
+        )
+        assert r.status_code == 404
+        assert "Gap not found" in r.json().get("detail", "")
+
+    def test_wrong_state_returns_409(self, client, session):
+        src = _make_source_note(session)
+        gap = _make_gap(
+            session,
+            term="still-discovered",
+            source_fk=src.id,
+            state="discovered",
+            gap_class=None,
+        )
+
+        r = client.post(
+            f"/api/knowledge/gaps/{gap.id}/answer",
+            json={"answer": "x"},
+        )
+        assert r.status_code == 409
+        assert "expected 'in_review'" in r.json().get("detail", "")
+
+    def test_answer_with_frontmatter_terminator_returns_400(self, client, session):
+        src = _make_source_note(session)
+        gap = _make_gap(
+            session,
+            term="injectable",
+            source_fk=src.id,
+            state="in_review",
+            gap_class="internal",
+        )
+
+        r = client.post(
+            f"/api/knowledge/gaps/{gap.id}/answer",
+            json={"answer": "foo\n---\nbar"},
+        )
+        assert r.status_code == 400
+        assert "frontmatter terminator" in r.json().get("detail", "")
+
+    def test_missing_answer_body_returns_422(self, client, session):
+        src = _make_source_note(session)
+        gap = _make_gap(
+            session,
+            term="x",
+            source_fk=src.id,
+            state="in_review",
+            gap_class="internal",
+        )
+
+        r = client.post(f"/api/knowledge/gaps/{gap.id}/answer", json={})
+        assert r.status_code == 422

--- a/projects/monolith/knowledge/gap_lifecycle_test.py
+++ b/projects/monolith/knowledge/gap_lifecycle_test.py
@@ -6,9 +6,11 @@ Uses the same in-memory SQLite + schema-strip fixture pattern as
 
 from __future__ import annotations
 
+import logging
 from datetime import datetime, timedelta, timezone
 
 import pytest
+import yaml
 from sqlmodel import Session, SQLModel, create_engine, select
 from sqlmodel.pool import StaticPool
 
@@ -308,11 +310,16 @@ def test_answer_gap_writes_file_and_commits(session, tmp_path):
     assert file_path.is_file()
     content = file_path.read_text()
     assert content.startswith("---\n")
-    assert "id: linkerd-mtls" in content
-    assert 'title: "Linkerd mTLS"' in content
-    assert "type: atom" in content
-    assert "source_tier: personal" in content
-    assert "Linkerd enables mTLS" in content
+    # Parse the frontmatter so we don't couple to yaml.dump's quoting style.
+    _, fm_block, body = content.split("---\n", 2)
+    fm = yaml.safe_load(fm_block)
+    assert fm == {
+        "id": "linkerd-mtls",
+        "title": "Linkerd mTLS",
+        "type": "atom",
+        "source_tier": "personal",
+    }
+    assert "Linkerd enables mTLS" in body
 
     gap = session.get(Gap, gap_id)
     assert gap.state == "committed"
@@ -357,3 +364,58 @@ def test_answer_gap_rejects_wrong_state(session, tmp_path):
 
     with pytest.raises(ValueError, match="expected 'in_review'"):
         answer_gap(session, gap.id, "x", tmp_path)
+
+
+def test_answer_gap_handles_special_chars_in_term(session, tmp_path):
+    """YAML frontmatter must round-trip arbitrary terms (C1 regression)."""
+    term = r'regex \d+ "quoted" stuff'
+    gap_id = _seed_reviewable_gap(session, term=term)
+
+    result = answer_gap(session, gap_id, "some answer body", tmp_path)
+
+    file_path = tmp_path / result["path"]
+    content = file_path.read_text()
+    # Split on the frontmatter fences and parse with a real YAML loader —
+    # this would fail against the old hand-rolled escape, which emitted
+    # title: "regex \d+ ..." (invalid escape sequence in double-quoted YAML).
+    _, fm_block, _ = content.split("---\n", 2)
+    fm = yaml.safe_load(fm_block)
+    assert fm["title"] == term
+
+
+def test_classify_gaps_rejects_invalid_classifier_output(session, caplog):
+    """Out-of-range classifier outputs fall back to internal (I2 regression)."""
+    src = _make_note(session, "s", title="S")
+    _add_body_link(session, src_fk=src.id, target_id="good")
+    _add_body_link(session, src_fk=src.id, target_id="bad")
+    discover_gaps(session)
+
+    def classifier(term: str, _context: str) -> str:
+        return "external" if term == "good" else "bogus"
+
+    with caplog.at_level(logging.WARNING, logger="knowledge.gaps"):
+        assert classify_gaps(session, classifier=classifier) == 2
+
+    rows = {
+        g.term: (g.gap_class, g.state)
+        for g in session.execute(select(Gap)).scalars().all()
+    }
+    assert rows["good"] == ("external", "classified")
+    assert rows["bad"] == ("internal", "in_review")
+    assert any(
+        "classifier returned invalid class 'bogus'" in record.getMessage()
+        for record in caplog.records
+    )
+
+
+def test_answer_gap_rejects_frontmatter_terminator_in_answer(session, tmp_path):
+    """Answers containing '---' on their own line must be rejected (M4)."""
+    gap_id = _seed_reviewable_gap(session, term="some-term")
+
+    with pytest.raises(ValueError, match="frontmatter terminator"):
+        answer_gap(session, gap_id, "foo\n---\nbar", tmp_path)
+
+    gap = session.get(Gap, gap_id)
+    assert gap.state == "in_review"
+    assert gap.answer is None
+    assert gap.resolved_at is None

--- a/projects/monolith/knowledge/gap_lifecycle_test.py
+++ b/projects/monolith/knowledge/gap_lifecycle_test.py
@@ -156,19 +156,32 @@ def test_discover_gaps_captures_source_title_as_context(session):
 # ---------------------------------------------------------------------------
 
 
-def test_classify_gaps_default_is_internal_in_review(session):
+def test_classify_gaps_without_classifier_is_noop(session, caplog):
+    """No classifier wired → gaps stay at discovered, warning logged.
+
+    Routing unclassified gaps to internal would conflate classifier absence
+    with classifier uncertainty. The review queue must only populate once
+    a real classifier lands (Task 3).
+    """
     src = _make_note(session, "s", title="S")
     _add_body_link(session, src_fk=src.id, target_id="t1")
     _add_body_link(session, src_fk=src.id, target_id="t2")
     discover_gaps(session)
 
-    classified = classify_gaps(session)  # classifier=None → internal
+    with caplog.at_level(logging.WARNING, logger="knowledge.gaps"):
+        classified = classify_gaps(session)  # no classifier wired
 
-    assert classified == 2
+    assert classified == 0
     for gap in session.execute(select(Gap)).scalars().all():
-        assert gap.gap_class == "internal"
-        assert gap.state == "in_review"
-        assert gap.classified_at is not None
+        assert gap.gap_class is None
+        assert gap.state == "discovered"
+        assert gap.classified_at is None
+
+    assert any(
+        "2 gaps awaiting classification but no classifier is wired"
+        in record.getMessage()
+        for record in caplog.records
+    )
 
 
 def test_classify_gaps_routes_by_class(session):
@@ -204,9 +217,12 @@ def test_classify_gaps_skips_already_classified(session):
     _add_body_link(session, src_fk=src.id, target_id="x")
     discover_gaps(session)
 
-    assert classify_gaps(session) == 1
+    def classifier(_term: str, _context: str) -> str:
+        return "internal"
+
+    assert classify_gaps(session, classifier=classifier) == 1
     # Second call finds nothing in state='discovered'.
-    assert classify_gaps(session) == 0
+    assert classify_gaps(session, classifier=classifier) == 0
 
 
 # ---------------------------------------------------------------------------

--- a/projects/monolith/knowledge/gap_lifecycle_test.py
+++ b/projects/monolith/knowledge/gap_lifecycle_test.py
@@ -1,0 +1,359 @@
+"""Unit tests for knowledge.gaps — discover/classify/review/answer lifecycle.
+
+Uses the same in-memory SQLite + schema-strip fixture pattern as
+``gap_model_test.py`` so table DDL works without a real Postgres.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlmodel import Session, SQLModel, create_engine, select
+from sqlmodel.pool import StaticPool
+
+from knowledge.gaps import (
+    GAPS_PIPELINE_VERSION,
+    answer_gap,
+    classify_gaps,
+    discover_gaps,
+    list_review_queue,
+)
+from knowledge.models import Gap, Note, NoteLink
+
+
+@pytest.fixture(name="session")
+def session_fixture():
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    original_schemas = {}
+    for table in SQLModel.metadata.tables.values():
+        if table.schema is not None:
+            original_schemas[table.name] = table.schema
+            table.schema = None
+    try:
+        SQLModel.metadata.create_all(engine)
+        with Session(engine) as session:
+            yield session
+    finally:
+        for table in SQLModel.metadata.tables.values():
+            if table.name in original_schemas:
+                table.schema = original_schemas[table.name]
+
+
+def _make_note(
+    session: Session,
+    note_id: str,
+    *,
+    title: str | None = None,
+) -> Note:
+    note = Note(
+        note_id=note_id,
+        path=f"_processed/{note_id}.md",
+        title=title or note_id,
+        content_hash=f"hash-{note_id}",
+        type="atom",
+    )
+    session.add(note)
+    session.commit()
+    session.refresh(note)
+    return note
+
+
+def _add_body_link(session: Session, *, src_fk: int, target_id: str) -> None:
+    session.add(
+        NoteLink(
+            src_note_fk=src_fk,
+            target_id=target_id,
+            target_title=target_id,
+            kind="link",
+            edge_type=None,
+        )
+    )
+    session.commit()
+
+
+# ---------------------------------------------------------------------------
+# discover_gaps
+# ---------------------------------------------------------------------------
+
+
+def test_discover_gaps_finds_unresolved_wikilink(session):
+    src = _make_note(session, "source-note", title="Source Note")
+    _add_body_link(session, src_fk=src.id, target_id="missing-concept")
+
+    created = discover_gaps(session)
+
+    assert created == 1
+    gaps = session.execute(select(Gap)).scalars().all()
+    assert len(gaps) == 1
+    gap = gaps[0]
+    assert gap.term == "missing-concept"
+    assert gap.context == "Source Note"
+    assert gap.source_note_fk == src.id
+    assert gap.state == "discovered"
+    assert gap.gap_class is None
+    assert gap.pipeline_version == GAPS_PIPELINE_VERSION
+
+
+def test_discover_gaps_skips_resolved_links(session):
+    src = _make_note(session, "source-note", title="Source")
+    _make_note(session, "target-note", title="Target")  # link target exists
+    _add_body_link(session, src_fk=src.id, target_id="target-note")
+
+    created = discover_gaps(session)
+
+    assert created == 0
+    assert session.execute(select(Gap)).scalars().all() == []
+
+
+def test_discover_gaps_is_idempotent(session):
+    src = _make_note(session, "src", title="Src")
+    _add_body_link(session, src_fk=src.id, target_id="missing")
+
+    first = discover_gaps(session)
+    second = discover_gaps(session)
+
+    assert first == 1
+    assert second == 0
+    assert len(session.execute(select(Gap)).scalars().all()) == 1
+
+
+def test_discover_gaps_ignores_frontmatter_edges(session):
+    """kind='edge' rows are typed assertions, not wikilink gaps."""
+    src = _make_note(session, "src", title="Src")
+    session.add(
+        NoteLink(
+            src_note_fk=src.id,
+            target_id="derived-target",
+            target_title=None,
+            kind="edge",
+            edge_type="derives_from",
+        )
+    )
+    session.commit()
+
+    assert discover_gaps(session) == 0
+
+
+def test_discover_gaps_captures_source_title_as_context(session):
+    src = _make_note(session, "src-slug", title="Kubernetes Networking")
+    _add_body_link(session, src_fk=src.id, target_id="cilium")
+
+    discover_gaps(session)
+
+    gap = session.execute(select(Gap).where(Gap.term == "cilium")).scalar_one()
+    assert gap.context == "Kubernetes Networking"
+
+
+# ---------------------------------------------------------------------------
+# classify_gaps
+# ---------------------------------------------------------------------------
+
+
+def test_classify_gaps_default_is_internal_in_review(session):
+    src = _make_note(session, "s", title="S")
+    _add_body_link(session, src_fk=src.id, target_id="t1")
+    _add_body_link(session, src_fk=src.id, target_id="t2")
+    discover_gaps(session)
+
+    classified = classify_gaps(session)  # classifier=None → internal
+
+    assert classified == 2
+    for gap in session.execute(select(Gap)).scalars().all():
+        assert gap.gap_class == "internal"
+        assert gap.state == "in_review"
+        assert gap.classified_at is not None
+
+
+def test_classify_gaps_routes_by_class(session):
+    src = _make_note(session, "s", title="S")
+    for target in ("ext", "int", "hyb", "park"):
+        _add_body_link(session, src_fk=src.id, target_id=target)
+    discover_gaps(session)
+
+    mapping = {
+        "ext": "external",
+        "int": "internal",
+        "hyb": "hybrid",
+        "park": "parked",
+    }
+
+    def classifier(term: str, _context: str) -> str:
+        return mapping[term]
+
+    assert classify_gaps(session, classifier=classifier) == 4
+
+    rows = {
+        g.term: (g.gap_class, g.state)
+        for g in session.execute(select(Gap)).scalars().all()
+    }
+    assert rows["ext"] == ("external", "classified")
+    assert rows["int"] == ("internal", "in_review")
+    assert rows["hyb"] == ("hybrid", "in_review")
+    assert rows["park"] == ("parked", "classified")
+
+
+def test_classify_gaps_skips_already_classified(session):
+    src = _make_note(session, "s", title="S")
+    _add_body_link(session, src_fk=src.id, target_id="x")
+    discover_gaps(session)
+
+    assert classify_gaps(session) == 1
+    # Second call finds nothing in state='discovered'.
+    assert classify_gaps(session) == 0
+
+
+# ---------------------------------------------------------------------------
+# list_review_queue
+# ---------------------------------------------------------------------------
+
+
+def test_list_review_queue_only_returns_internal_hybrid_in_review(session):
+    src = _make_note(session, "s", title="S")
+    # Manually construct gaps in varied states so we can assert filtering.
+    now = datetime.now(timezone.utc)
+    gaps = [
+        Gap(
+            term="a-internal",
+            context="",
+            source_note_fk=src.id,
+            gap_class="internal",
+            state="in_review",
+            pipeline_version=GAPS_PIPELINE_VERSION,
+            created_at=now - timedelta(seconds=30),
+        ),
+        Gap(
+            term="b-hybrid",
+            context="",
+            source_note_fk=src.id,
+            gap_class="hybrid",
+            state="in_review",
+            pipeline_version=GAPS_PIPELINE_VERSION,
+            created_at=now - timedelta(seconds=20),
+        ),
+        Gap(
+            term="c-external",
+            context="",
+            source_note_fk=src.id,
+            gap_class="external",
+            state="classified",
+            pipeline_version=GAPS_PIPELINE_VERSION,
+            created_at=now - timedelta(seconds=10),
+        ),
+        Gap(
+            term="d-internal-discovered",
+            context="",
+            source_note_fk=src.id,
+            gap_class="internal",
+            state="discovered",
+            pipeline_version=GAPS_PIPELINE_VERSION,
+            created_at=now,
+        ),
+    ]
+    session.add_all(gaps)
+    session.commit()
+
+    queue = list_review_queue(session)
+
+    terms = [row["term"] for row in queue]
+    assert terms == ["a-internal", "b-hybrid"]  # FIFO, only in_review+internal/hybrid
+    assert queue[0]["gap_class"] == "internal"
+    assert queue[1]["gap_class"] == "hybrid"
+
+
+def test_list_review_queue_empty(session):
+    assert list_review_queue(session) == []
+
+
+# ---------------------------------------------------------------------------
+# answer_gap
+# ---------------------------------------------------------------------------
+
+
+def _seed_reviewable_gap(session: Session, *, term: str = "Linkerd mTLS") -> int:
+    src = _make_note(session, "src", title="Src")
+    gap = Gap(
+        term=term,
+        context="networking note",
+        source_note_fk=src.id,
+        gap_class="internal",
+        state="in_review",
+        pipeline_version=GAPS_PIPELINE_VERSION,
+    )
+    session.add(gap)
+    session.commit()
+    session.refresh(gap)
+    return gap.id
+
+
+def test_answer_gap_writes_file_and_commits(session, tmp_path):
+    gap_id = _seed_reviewable_gap(session, term="Linkerd mTLS")
+
+    result = answer_gap(
+        session,
+        gap_id,
+        "Linkerd enables mTLS via per-pod sidecar proxies on port 4143.",
+        tmp_path,
+    )
+
+    assert result["gap_id"] == gap_id
+    assert result["note_id"] == "linkerd-mtls"
+    assert result["path"] == "_processed/linkerd-mtls.md"
+
+    file_path = tmp_path / "_processed" / "linkerd-mtls.md"
+    assert file_path.is_file()
+    content = file_path.read_text()
+    assert content.startswith("---\n")
+    assert "id: linkerd-mtls" in content
+    assert 'title: "Linkerd mTLS"' in content
+    assert "type: atom" in content
+    assert "source_tier: personal" in content
+    assert "Linkerd enables mTLS" in content
+
+    gap = session.get(Gap, gap_id)
+    assert gap.state == "committed"
+    assert gap.answer.startswith("Linkerd enables mTLS")
+    assert gap.resolved_at is not None
+
+
+def test_answer_gap_handles_filename_collisions(session, tmp_path):
+    gap_id = _seed_reviewable_gap(session, term="Collision")
+
+    # Pre-create the unadorned file to force a -1 suffix.
+    processed = tmp_path / "_processed"
+    processed.mkdir(parents=True)
+    (processed / "collision.md").write_text("existing")
+
+    result = answer_gap(session, gap_id, "the answer", tmp_path)
+
+    assert result["note_id"] == "collision-1"
+    assert result["path"] == "_processed/collision-1.md"
+    assert (processed / "collision-1.md").is_file()
+    # Original file is untouched.
+    assert (processed / "collision.md").read_text() == "existing"
+
+
+def test_answer_gap_rejects_unknown_id(session, tmp_path):
+    with pytest.raises(ValueError, match="Gap not found"):
+        answer_gap(session, gap_id=9999, answer="x", vault_root=tmp_path)
+
+
+def test_answer_gap_rejects_wrong_state(session, tmp_path):
+    src = _make_note(session, "src", title="Src")
+    gap = Gap(
+        term="still-discovered",
+        context="",
+        source_note_fk=src.id,
+        state="discovered",
+        pipeline_version=GAPS_PIPELINE_VERSION,
+    )
+    session.add(gap)
+    session.commit()
+    session.refresh(gap)
+
+    with pytest.raises(ValueError, match="expected 'in_review'"):
+        answer_gap(session, gap.id, "x", tmp_path)

--- a/projects/monolith/knowledge/gap_model_test.py
+++ b/projects/monolith/knowledge/gap_model_test.py
@@ -1,0 +1,145 @@
+"""Unit tests for the knowledge.Gap SQLModel.
+
+Exercises defaults, timestamp auto-population, and the UNIQUE (term,
+source_note_fk) constraint against an in-memory SQLite session.
+"""
+
+from datetime import datetime, timezone
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+from sqlmodel import Session, SQLModel, create_engine, select
+from sqlmodel.pool import StaticPool
+
+from knowledge.models import Gap, Note
+
+
+@pytest.fixture(name="session")
+def session_fixture():
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    original_schemas = {}
+    for table in SQLModel.metadata.tables.values():
+        if table.schema is not None:
+            original_schemas[table.name] = table.schema
+            table.schema = None
+    try:
+        SQLModel.metadata.create_all(engine)
+        with Session(engine) as session:
+            yield session
+    finally:
+        for table in SQLModel.metadata.tables.values():
+            if table.name in original_schemas:
+                table.schema = original_schemas[table.name]
+
+
+def _make_note(session: Session, note_id: str = "parent-note") -> Note:
+    note = Note(
+        note_id=note_id,
+        path=f"_processed/atoms/{note_id}.md",
+        title=note_id,
+        content_hash="deadbeef",
+        type="atom",
+    )
+    session.add(note)
+    session.commit()
+    session.refresh(note)
+    return note
+
+
+def test_gap_defaults_state_and_created_at(session):
+    """A newly-constructed Gap defaults to state='discovered' with a UTC created_at."""
+    note = _make_note(session)
+    gap = Gap(
+        term="Quantum Coherence",
+        source_note_fk=note.id,
+        pipeline_version="gardener@v1",
+    )
+    # default_factory runs at construction time — verify the UTC tzinfo here
+    # (SQLite strips tzinfo on round-trip, so assert pre-persist).
+    assert isinstance(gap.created_at, datetime)
+    assert gap.created_at.tzinfo == timezone.utc
+
+    session.add(gap)
+    session.commit()
+
+    loaded = session.get(Gap, gap.id)
+    assert loaded is not None
+    assert loaded.state == "discovered"
+    assert loaded.context == ""
+    assert loaded.gap_class is None
+    assert loaded.answer is None
+    assert loaded.classified_at is None
+    assert loaded.resolved_at is None
+    assert isinstance(loaded.created_at, datetime)
+    assert loaded.pipeline_version == "gardener@v1"
+
+
+def test_gap_with_explicit_class_and_context(session):
+    """Optional fields (gap_class, context, answer) round-trip correctly."""
+    note = _make_note(session, "source")
+    gap = Gap(
+        term="Linkerd mTLS",
+        context="mentioned in [[Linkerd mTLS]] section of networking note",
+        source_note_fk=note.id,
+        gap_class="internal",
+        answer="Linkerd enables mTLS via sidecar proxies on port 4143.",
+        pipeline_version="gardener@v1",
+    )
+    session.add(gap)
+    session.commit()
+
+    loaded = session.get(Gap, gap.id)
+    assert loaded is not None
+    assert loaded.gap_class == "internal"
+    assert loaded.context.startswith("mentioned in")
+    assert loaded.answer is not None
+
+
+def test_gap_unique_term_source_note(session):
+    """A second Gap with the same (term, source_note_fk) pair must fail."""
+    note = _make_note(session)
+    gap1 = Gap(
+        term="Duplicate Term",
+        source_note_fk=note.id,
+        pipeline_version="gardener@v1",
+    )
+    session.add(gap1)
+    session.commit()
+
+    gap2 = Gap(
+        term="Duplicate Term",
+        source_note_fk=note.id,
+        pipeline_version="gardener@v1",
+    )
+    session.add(gap2)
+    with pytest.raises(IntegrityError):
+        session.commit()
+    session.rollback()
+
+
+def test_gap_same_term_different_source_is_allowed(session):
+    """The same term surfaced from two different notes is two distinct gaps."""
+    note_a = _make_note(session, "note-a")
+    note_b = _make_note(session, "note-b")
+    session.add_all(
+        [
+            Gap(
+                term="Shared Concept",
+                source_note_fk=note_a.id,
+                pipeline_version="gardener@v1",
+            ),
+            Gap(
+                term="Shared Concept",
+                source_note_fk=note_b.id,
+                pipeline_version="gardener@v1",
+            ),
+        ]
+    )
+    session.commit()
+
+    rows = session.exec(select(Gap).where(Gap.term == "Shared Concept")).all()
+    assert len(rows) == 2

--- a/projects/monolith/knowledge/gaps.py
+++ b/projects/monolith/knowledge/gaps.py
@@ -42,6 +42,18 @@ logger = logging.getLogger(__name__)
 
 GAPS_PIPELINE_VERSION = "gaps@v1"
 
+
+def split_csv(value: str | None) -> list[str] | None:
+    """Split a comma-separated query/tool param into a list, stripping
+    whitespace and dropping empty segments. Returns None when input is None
+    or all-empty so callers can pass it straight into optional filter kwargs.
+    """
+    if value is None:
+        return None
+    parts = [s.strip() for s in value.split(",") if s.strip()]
+    return parts or None
+
+
 # Privacy-conservative default: uncertain → internal (route to user, not web).
 _DEFAULT_GAP_CLASS = "internal"
 

--- a/projects/monolith/knowledge/gaps.py
+++ b/projects/monolith/knowledge/gaps.py
@@ -1,0 +1,263 @@
+"""Gap discovery, classification, review queue, and answer capture.
+
+A "gap" is an unresolved ``[[wikilink]]`` — a body-text reference whose
+target note does not (yet) exist in the graph. The four functions in this
+module together drive the gap lifecycle:
+
+    discover_gaps  → ingest unresolved links into the gaps table
+    classify_gaps  → route each gap to external/internal/hybrid/parked
+    list_review_queue  → enumerate gaps awaiting a user answer
+    answer_gap     → accept a user answer, emit a personal-tier atom
+
+All four are pure-ish functions taking an open ``Session``; the caller
+owns the session lifecycle. This matches the rest of the knowledge
+module (``store.py``, ``gardener.py``).
+
+Design notes:
+    * ``classifier`` is an injected callable — the real Claude-backed
+      classifier is wired in separately (Task 3). Leaving it ``None`` is
+      the privacy-conservative fallback: everything routes to ``internal``
+      so the user reviews it, nothing escapes to the web.
+    * Consolidation never mutates committed atoms — ``answer_gap``
+      creates a brand-new file and leaves the rest of the vault alone.
+    * We deliberately do *not* reconcile the new file into the DB here;
+      the reconciler picks it up on its next tick, matching the existing
+      ``create_note`` HTTP endpoint.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Callable
+
+from sqlmodel import Session, select
+
+from knowledge.gardener import _slugify
+from knowledge.models import Gap, Note, NoteLink
+
+logger = logging.getLogger(__name__)
+
+GAPS_PIPELINE_VERSION = "gaps@v1"
+
+# Privacy-conservative default: uncertain → internal (route to user, not web).
+_DEFAULT_GAP_CLASS = "internal"
+
+# Classes that are ready for user review after classification.
+_USER_REVIEW_CLASSES = {"internal", "hybrid"}
+
+
+@dataclass(frozen=True)
+class DiscoveredGap:
+    term: str
+    context: str
+    source_note_fk: int
+
+
+def discover_gaps(session: Session) -> int:
+    """Scan note_links for unresolved wikilinks; insert new Gap rows.
+
+    Returns the number of newly-inserted gaps (not the total). Idempotent:
+    subsequent calls surface only previously-unseen (term, source_note_fk)
+    pairs thanks to a pre-check against the UNIQUE constraint.
+    """
+    # Collect existing note_ids once so the unresolved filter is a set
+    # membership check (avoids a correlated subquery per row).
+    existing_note_ids = set(session.execute(select(Note.note_id)).scalars().all())
+
+    # All body-wikilink rows. Frontmatter edges (kind='edge') are not
+    # treated as gaps — those are typed assertions, not unresolved
+    # references that a human would be expected to answer.
+    link_rows = session.execute(
+        select(
+            NoteLink.src_note_fk,
+            NoteLink.target_id,
+            Note.title,
+        )
+        .join(Note, Note.id == NoteLink.src_note_fk)
+        .where(NoteLink.kind == "link")
+    ).all()
+
+    # Pre-load existing (term, source_note_fk) pairs to avoid an
+    # IntegrityError round-trip for gaps we already know about.
+    existing_gap_keys = set(session.execute(select(Gap.term, Gap.source_note_fk)).all())
+
+    created = 0
+    for row in link_rows:
+        target_id = row.target_id
+        if target_id in existing_note_ids:
+            continue
+        key = (target_id, row.src_note_fk)
+        if key in existing_gap_keys:
+            continue
+
+        # SAVEPOINT per insert: even though we pre-check the UNIQUE key, a
+        # concurrent discoverer could insert the same (term, source_note_fk)
+        # between SELECT and INSERT. Nesting the add lets that single row
+        # fail without rolling back every gap already inserted this cycle.
+        with session.begin_nested():
+            session.add(
+                Gap(
+                    term=target_id,
+                    context=row.title or "",
+                    source_note_fk=row.src_note_fk,
+                    pipeline_version=GAPS_PIPELINE_VERSION,
+                    state="discovered",
+                )
+            )
+        existing_gap_keys.add(key)
+        created += 1
+
+    if created:
+        session.commit()
+        logger.info("gaps.discover_gaps: inserted %d new gaps", created)
+    return created
+
+
+def classify_gaps(
+    session: Session,
+    classifier: Callable[[str, str], str] | None = None,
+) -> int:
+    """Classify every ``state='discovered'`` gap.
+
+    ``classifier`` receives ``(term, context)`` and returns one of
+    ``external``, ``internal``, ``hybrid``, ``parked``. When ``None``,
+    every gap is routed to ``internal`` — the privacy-conservative
+    fallback that keeps the first slice working without any model wired
+    in (Task 3 injects the real classifier).
+
+    State transitions:
+        * ``internal`` / ``hybrid`` → ``in_review`` (ready for user)
+        * ``external`` → ``classified`` (research pipeline deferred)
+        * ``parked`` → ``classified`` (queryable, not budget-consuming)
+
+    Returns the number of gaps classified.
+    """
+    rows = session.execute(select(Gap).where(Gap.state == "discovered")).scalars().all()
+
+    classified = 0
+    now = datetime.now(timezone.utc)
+    for gap in rows:
+        if classifier is None:
+            gap_class = _DEFAULT_GAP_CLASS
+        else:
+            gap_class = classifier(gap.term, gap.context)
+
+        gap.gap_class = gap_class
+        gap.classified_at = now
+        if gap_class in _USER_REVIEW_CLASSES:
+            gap.state = "in_review"
+        else:
+            gap.state = "classified"
+        classified += 1
+
+    if classified:
+        session.commit()
+        logger.info(
+            "gaps.classify_gaps: classified %d gaps (classifier=%s)",
+            classified,
+            "default-internal" if classifier is None else "custom",
+        )
+    return classified
+
+
+def list_review_queue(session: Session) -> list[dict]:
+    """Return internal/hybrid gaps awaiting a user answer, oldest first."""
+    rows = (
+        session.execute(
+            select(Gap)
+            .where(Gap.state == "in_review")
+            .where(Gap.gap_class.in_(("internal", "hybrid")))
+            .order_by(Gap.created_at.asc())
+        )
+        .scalars()
+        .all()
+    )
+    return [
+        {
+            "id": gap.id,
+            "term": gap.term,
+            "context": gap.context,
+            "gap_class": gap.gap_class,
+            "created_at": gap.created_at,
+        }
+        for gap in rows
+    ]
+
+
+def answer_gap(
+    session: Session,
+    gap_id: int,
+    answer: str,
+    vault_root: Path,
+) -> dict:
+    """Commit a user answer: emit a personal-tier atom, mark gap committed.
+
+    The new atom is written to ``<vault_root>/_processed/<slug>.md`` with
+    frontmatter ``source_tier: personal`` so downstream consumers can
+    distinguish user-authored atoms from gardener-derived ones. Filename
+    collisions are resolved by appending ``-1``, ``-2``, etc. — same
+    pattern as :func:`knowledge.router.create_note`.
+
+    The new file is *not* reconciled into the DB here; the reconciler
+    picks it up on its next tick. This matches ``create_note``'s contract.
+
+    Raises:
+        ValueError: if ``gap_id`` is unknown or the gap is not in
+            ``state='in_review'``.
+    """
+    gap = session.get(Gap, gap_id)
+    if gap is None:
+        raise ValueError(f"Gap not found: id={gap_id}")
+    if gap.state != "in_review":
+        raise ValueError(
+            f"Gap id={gap_id} is in state={gap.state!r}, expected 'in_review'"
+        )
+
+    processed_root = vault_root / "_processed"
+    processed_root.mkdir(parents=True, exist_ok=True)
+
+    slug = _slugify(gap.term)
+    filename = f"{slug}.md"
+    dest = processed_root / filename
+    counter = 1
+    while dest.exists():
+        filename = f"{slug}-{counter}.md"
+        dest = processed_root / filename
+        counter += 1
+
+    # The id in frontmatter must match the final filename stem so the
+    # reconciler resolves the file to a stable note_id.
+    note_id = filename[:-3]  # strip .md
+    # Escape any double-quotes in the user-supplied term so the YAML stays parseable.
+    safe_title = gap.term.replace('"', '\\"')
+    file_content = (
+        "---\n"
+        f"id: {note_id}\n"
+        f'title: "{safe_title}"\n'
+        "type: atom\n"
+        "source_tier: personal\n"
+        "---\n\n"
+        f"{answer}\n"
+    )
+    dest.write_text(file_content)
+
+    gap.answer = answer
+    gap.state = "committed"
+    gap.resolved_at = datetime.now(timezone.utc)
+    session.commit()
+
+    relative_path = dest.relative_to(vault_root)
+    logger.info(
+        "gaps.answer_gap: committed gap_id=%d as note_id=%s path=%s",
+        gap_id,
+        note_id,
+        relative_path,
+    )
+    return {
+        "gap_id": gap_id,
+        "path": str(relative_path),
+        "note_id": note_id,
+    }

--- a/projects/monolith/knowledge/gaps.py
+++ b/projects/monolith/knowledge/gaps.py
@@ -28,11 +28,11 @@ Design notes:
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Callable
 
+import yaml
 from sqlmodel import Session, select
 
 from knowledge.gardener import _slugify
@@ -48,12 +48,8 @@ _DEFAULT_GAP_CLASS = "internal"
 # Classes that are ready for user review after classification.
 _USER_REVIEW_CLASSES = {"internal", "hybrid"}
 
-
-@dataclass(frozen=True)
-class DiscoveredGap:
-    term: str
-    context: str
-    source_note_fk: int
+# Valid classifier outputs — mirrors the CHECK constraint on gaps.gap_class.
+_VALID_GAP_CLASSES = frozenset({"external", "internal", "hybrid", "parked"})
 
 
 def discover_gaps(session: Session) -> int:
@@ -144,6 +140,14 @@ def classify_gaps(
             gap_class = _DEFAULT_GAP_CLASS
         else:
             gap_class = classifier(gap.term, gap.context)
+            if gap_class not in _VALID_GAP_CLASSES:
+                logger.warning(
+                    "gaps.classify_gaps: classifier returned invalid class %r "
+                    "for gap id=%d; defaulting to internal (privacy-conservative)",
+                    gap_class,
+                    gap.id,
+                )
+                gap_class = _DEFAULT_GAP_CLASS
 
         gap.gap_class = gap_class
         gap.classified_at = now
@@ -154,6 +158,10 @@ def classify_gaps(
         classified += 1
 
     if classified:
+        # TODO(task-3): chunk commits (e.g. every 25 gaps) once the real
+        # model-backed classifier is wired in. A 100-gap batch × 20s/call holds a
+        # 2000s transaction; risks idle_in_transaction_session_timeout and loses
+        # progress on crash.
         session.commit()
         logger.info(
             "gaps.classify_gaps: classified %d gaps (classifier=%s)",
@@ -215,6 +223,10 @@ def answer_gap(
         raise ValueError(
             f"Gap id={gap_id} is in state={gap.state!r}, expected 'in_review'"
         )
+    if "\n---\n" in f"\n{answer}\n":
+        raise ValueError(
+            "answer may not contain a frontmatter terminator ('---' on its own line)"
+        )
 
     processed_root = vault_root / "_processed"
     processed_root.mkdir(parents=True, exist_ok=True)
@@ -231,22 +243,22 @@ def answer_gap(
     # The id in frontmatter must match the final filename stem so the
     # reconciler resolves the file to a stable note_id.
     note_id = filename[:-3]  # strip .md
-    # Escape any double-quotes in the user-supplied term so the YAML stays parseable.
-    safe_title = gap.term.replace('"', '\\"')
-    file_content = (
-        "---\n"
-        f"id: {note_id}\n"
-        f'title: "{safe_title}"\n'
-        "type: atom\n"
-        "source_tier: personal\n"
-        "---\n\n"
-        f"{answer}\n"
-    )
+    fm = {
+        "id": note_id,
+        "title": gap.term,
+        "type": "atom",
+        "source_tier": "personal",
+    }
+    fm_str = yaml.dump(fm, default_flow_style=False, sort_keys=False)
+    file_content = f"---\n{fm_str}---\n\n{answer}\n"
     dest.write_text(file_content)
 
     gap.answer = answer
     gap.state = "committed"
     gap.resolved_at = datetime.now(timezone.utc)
+    # TODO(task-3): make file-write + DB-commit transactional (e.g. write to
+    # <dest>.tmp, commit DB, rename). Today a commit failure after write leaves
+    # an orphan file that a retry resolves to <slug>-1.md.
     session.commit()
 
     relative_path = dest.relative_to(vault_root)

--- a/projects/monolith/knowledge/gaps.py
+++ b/projects/monolith/knowledge/gaps.py
@@ -190,7 +190,7 @@ def list_review_queue(session: Session) -> list[dict]:
             select(Gap)
             .where(Gap.state == "in_review")
             .where(Gap.gap_class.in_(("internal", "hybrid")))
-            .order_by(Gap.created_at.asc())
+            .order_by(Gap.created_at.asc(), Gap.id.asc())
         )
         .scalars()
         .all()

--- a/projects/monolith/knowledge/gaps.py
+++ b/projects/monolith/knowledge/gaps.py
@@ -16,8 +16,11 @@ module (``store.py``, ``gardener.py``).
 Design notes:
     * ``classifier`` is an injected callable — the real Claude-backed
       classifier is wired in separately (Task 3). Leaving it ``None`` is
-      the privacy-conservative fallback: everything routes to ``internal``
-      so the user reviews it, nothing escapes to the web.
+      a no-op: gaps stay at ``state='discovered'`` until a real classifier
+      lands. The "privacy-conservative default" in the design doc is about
+      classifier output under uncertainty — not the absence of a
+      classifier. Local inference has zero privacy cost; only external
+      research does.
     * Consolidation never mutates committed atoms — ``answer_gap``
       creates a brand-new file and leaves the rest of the vault alone.
     * We deliberately do *not* reconcile the new file into the DB here;
@@ -33,6 +36,7 @@ from pathlib import Path
 from typing import Callable
 
 import yaml
+from sqlalchemy import func
 from sqlmodel import Session, select
 
 from knowledge.gardener import _slugify
@@ -54,7 +58,9 @@ def split_csv(value: str | None) -> list[str] | None:
     return parts or None
 
 
-# Privacy-conservative default: uncertain → internal (route to user, not web).
+# Privacy-conservative fallback used only when a real classifier returns an
+# invalid class — route uncertain output to the user (internal), not the web.
+# This is NOT used when classifier is absent (that path is a no-op).
 _DEFAULT_GAP_CLASS = "internal"
 
 # Classes that are ready for user review after classification.
@@ -131,35 +137,49 @@ def classify_gaps(
     """Classify every ``state='discovered'`` gap.
 
     ``classifier`` receives ``(term, context)`` and returns one of
-    ``external``, ``internal``, ``hybrid``, ``parked``. When ``None``,
-    every gap is routed to ``internal`` — the privacy-conservative
-    fallback that keeps the first slice working without any model wired
-    in (Task 3 injects the real classifier).
+    ``external``, ``internal``, ``hybrid``, ``parked``. If the classifier
+    returns an invalid value, falls back to ``internal``
+    (privacy-conservative under classifier uncertainty).
 
-    State transitions:
+    When ``classifier`` is ``None``, this is a no-op: gaps stay at
+    ``state='discovered'`` because no classifier is wired in yet. A
+    warning is logged when pending gaps exist so the absence is visible.
+    The review queue only populates once a real classifier lands (Task 3).
+
+    State transitions (real-classifier path):
         * ``internal`` / ``hybrid`` → ``in_review`` (ready for user)
         * ``external`` → ``classified`` (research pipeline deferred)
         * ``parked`` → ``classified`` (queryable, not budget-consuming)
 
-    Returns the number of gaps classified.
+    Returns the number of gaps classified. When ``classifier`` is ``None``,
+    returns 0.
     """
+    if classifier is None:
+        pending = session.execute(
+            select(func.count()).select_from(Gap).where(Gap.state == "discovered")
+        ).scalar_one()
+        if pending:
+            logger.warning(
+                "gaps.classify_gaps: %d gaps awaiting classification but no "
+                "classifier is wired; leaving them at state='discovered'",
+                pending,
+            )
+        return 0
+
     rows = session.execute(select(Gap).where(Gap.state == "discovered")).scalars().all()
 
     classified = 0
     now = datetime.now(timezone.utc)
     for gap in rows:
-        if classifier is None:
+        gap_class = classifier(gap.term, gap.context)
+        if gap_class not in _VALID_GAP_CLASSES:
+            logger.warning(
+                "gaps.classify_gaps: classifier returned invalid class %r "
+                "for gap id=%d; defaulting to internal (privacy-conservative)",
+                gap_class,
+                gap.id,
+            )
             gap_class = _DEFAULT_GAP_CLASS
-        else:
-            gap_class = classifier(gap.term, gap.context)
-            if gap_class not in _VALID_GAP_CLASSES:
-                logger.warning(
-                    "gaps.classify_gaps: classifier returned invalid class %r "
-                    "for gap id=%d; defaulting to internal (privacy-conservative)",
-                    gap_class,
-                    gap.id,
-                )
-                gap_class = _DEFAULT_GAP_CLASS
 
         gap.gap_class = gap_class
         gap.classified_at = now
@@ -176,9 +196,8 @@ def classify_gaps(
         # progress on crash.
         session.commit()
         logger.info(
-            "gaps.classify_gaps: classified %d gaps (classifier=%s)",
+            "gaps.classify_gaps: classified %d gaps",
             classified,
-            "default-internal" if classifier is None else "custom",
         )
     return classified
 

--- a/projects/monolith/knowledge/gardener.py
+++ b/projects/monolith/knowledge/gardener.py
@@ -516,6 +516,12 @@ class Gardener:
             classified = classify_gaps(self.session)
             return discovered, classified
         except Exception:
+            # Roll back any uncommitted mutations from classify_gaps before the
+            # handler returns — otherwise the scheduler's outer session.commit()
+            # would persist a half-classified batch. discover_gaps already
+            # committed its inserts internally, so `discovered` stays accurate.
+            if self.session is not None:
+                self.session.rollback()
             logger.exception(
                 "gardener: gap pipeline failed after discovering %d gaps",
                 discovered,

--- a/projects/monolith/knowledge/gardener.py
+++ b/projects/monolith/knowledge/gardener.py
@@ -506,6 +506,7 @@ class Gardener:
         """
         if self.session is None:
             return 0, 0
+        discovered = 0
         try:
             # Imported at call-time to avoid a circular import:
             # ``knowledge.gaps`` imports ``_slugify`` from this module.
@@ -515,8 +516,11 @@ class Gardener:
             classified = classify_gaps(self.session)
             return discovered, classified
         except Exception:
-            logger.exception("gardener: gap discovery/classification failed")
-            return 0, 0
+            logger.exception(
+                "gardener: gap pipeline failed after discovering %d gaps",
+                discovered,
+            )
+            return discovered, 0
 
     async def _distill_completed_tasks(self) -> tuple[int, int]:
         """Distill learnings from completed tasks into knowledge atoms.

--- a/projects/monolith/knowledge/gardener.py
+++ b/projects/monolith/knowledge/gardener.py
@@ -496,10 +496,10 @@ class Gardener:
 
         Returns ``(discovered_count, classified_count)``.
 
-        The default classifier is ``None`` — the privacy-conservative fallback
-        which routes every gap to ``internal`` so the user reviews it and
-        nothing escapes to the web. A future PR wires in a Claude-backed
-        classifier.
+        The default classifier is ``None`` — a no-op: gaps stay at
+        ``state='discovered'`` until a real classifier is wired in
+        (Task 3). A warning is logged when pending gaps exist so the
+        absence is visible in cycle logs.
 
         Errors in either step are caught and logged; the gardener cycle must
         not fail because of gap-pipeline bugs.

--- a/projects/monolith/knowledge/gardener.py
+++ b/projects/monolith/knowledge/gardener.py
@@ -120,6 +120,8 @@ class GardenStats:
     resolved: int = 0
     distilled: int = 0
     consolidated: int = 0
+    gaps_discovered: int = 0
+    gaps_classified: int = 0
 
 
 def _split_frontmatter(raw: str) -> tuple[dict, str]:
@@ -311,6 +313,8 @@ class Gardener:
 
         consolidated = self._consolidate_task_views()
 
+        gaps_discovered, gaps_classified = self._discover_and_classify_gaps()
+
         stats = GardenStats(
             ingested=ingested,
             failed=failed,
@@ -320,9 +324,11 @@ class Gardener:
             resolved=resolved_count,
             distilled=distilled,
             consolidated=consolidated,
+            gaps_discovered=gaps_discovered,
+            gaps_classified=gaps_classified,
         )
         logger.info(
-            "knowledge.garden: resolved=%d moved=%d deduped=%d reconciled=%d ingested=%d failed=%d distilled=%d consolidated=%d",
+            "knowledge.garden: resolved=%d moved=%d deduped=%d reconciled=%d ingested=%d failed=%d distilled=%d consolidated=%d gaps_discovered=%d gaps_classified=%d",
             stats.resolved,
             stats.moved,
             stats.deduped,
@@ -331,6 +337,8 @@ class Gardener:
             stats.failed,
             stats.distilled,
             stats.consolidated,
+            stats.gaps_discovered,
+            stats.gaps_classified,
         )
         return stats
 
@@ -482,6 +490,33 @@ class Gardener:
         written += 1
 
         return written
+
+    def _discover_and_classify_gaps(self) -> tuple[int, int]:
+        """Discover unresolved wikilinks and classify them into review buckets.
+
+        Returns ``(discovered_count, classified_count)``.
+
+        The default classifier is ``None`` — the privacy-conservative fallback
+        which routes every gap to ``internal`` so the user reviews it and
+        nothing escapes to the web. A future PR wires in a Claude-backed
+        classifier.
+
+        Errors in either step are caught and logged; the gardener cycle must
+        not fail because of gap-pipeline bugs.
+        """
+        if self.session is None:
+            return 0, 0
+        try:
+            # Imported at call-time to avoid a circular import:
+            # ``knowledge.gaps`` imports ``_slugify`` from this module.
+            from knowledge.gaps import classify_gaps, discover_gaps
+
+            discovered = discover_gaps(self.session)
+            classified = classify_gaps(self.session)
+            return discovered, classified
+        except Exception:
+            logger.exception("gardener: gap discovery/classification failed")
+            return 0, 0
 
     async def _distill_completed_tasks(self) -> tuple[int, int]:
         """Distill learnings from completed tasks into knowledge atoms.

--- a/projects/monolith/knowledge/gardener_test.py
+++ b/projects/monolith/knowledge/gardener_test.py
@@ -1374,3 +1374,97 @@ class TestGardenerGapDiscovery:
         # The log message should include the discovered count so operators can
         # trace partial progress.
         assert "1 gaps" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_gap_pipeline_failure_rolls_back_classify_mutations(
+        self, monkeypatch, session, tmp_path, caplog
+    ):
+        """When classify_gaps raises mid-batch, the in-memory mutations to Gap
+        rows (gap_class, state, classified_at) must be rolled back so the outer
+        scheduler commit does NOT persist a half-classified batch."""
+        from knowledge.models import Gap, Note, NoteLink
+
+        # Seed a Note + 2 NoteLinks pointing to unresolved targets. discover_gaps
+        # will commit 2 Gap rows; classify_gaps will then mutate them in-memory
+        # and raise before commit. The rollback must undo those mutations.
+        src = Note(
+            note_id="source-note",
+            path="_processed/source-note.md",
+            title="Source Note",
+            content_hash="h-src",
+            type="atom",
+        )
+        session.add(src)
+        session.flush()
+        session.add(
+            NoteLink(
+                src_note_fk=src.id,
+                target_id="missing-one",
+                target_title="missing-one",
+                kind="link",
+                edge_type=None,
+            )
+        )
+        session.add(
+            NoteLink(
+                src_note_fk=src.id,
+                target_id="missing-two",
+                target_title="missing-two",
+                kind="link",
+                edge_type=None,
+            )
+        )
+        session.commit()
+
+        import knowledge.gaps as gaps_module
+
+        def mutating_then_raising(sess):
+            """Apply 'would-be' classification to every discovered gap, then
+            raise before commit. These mutations must NOT land in the DB.
+
+            Mirrors the real ``classify_gaps`` body — attribute mutations on
+            tracked ORM instances are flushed on commit without an explicit
+            ``sess.add()``.
+            """
+            rows = (
+                sess.execute(select(Gap).where(Gap.state == "discovered"))
+                .scalars()
+                .all()
+            )
+            for row in rows:
+                row.gap_class = "external"
+                row.state = "classified"
+            raise RuntimeError("classify boom mid-batch")
+
+        monkeypatch.setattr(gaps_module, "classify_gaps", mutating_then_raising)
+
+        gardener = Gardener(vault_root=tmp_path, session=session)
+        with caplog.at_level(logging.ERROR, logger="monolith.knowledge.gardener"):
+            stats = await gardener.run()
+
+        # discover_gaps committed before classify raised; classify mutations
+        # were in-memory only and should be rolled back.
+        assert stats.gaps_discovered == 2
+        assert stats.gaps_classified == 0
+
+        # Simulate the scheduler's outer session.commit() that runs after
+        # _complete_job — if the rollback didn't happen, the dirty mutations
+        # would be persisted here.
+        session.commit()
+
+        # Read back from a FRESH session on the same engine so we're not
+        # observing stale in-memory objects from the gardener's session.
+        engine = session.get_bind()
+        with Session(engine) as fresh:
+            gap_rows = fresh.exec(select(Gap)).all()
+            assert len(gap_rows) == 2
+            for gap in gap_rows:
+                assert gap.state == "discovered", (
+                    f"gap {gap.term}: state={gap.state!r} should have been "
+                    "rolled back to 'discovered'"
+                )
+                assert gap.gap_class is None, (
+                    f"gap {gap.term}: gap_class={gap.gap_class!r} should have "
+                    "been rolled back to None"
+                )
+                assert gap.classified_at is None

--- a/projects/monolith/knowledge/gardener_test.py
+++ b/projects/monolith/knowledge/gardener_test.py
@@ -1234,3 +1234,87 @@ class TestRecordFailedProvenance:
         assert rows[0].retry_count == 2
         assert "timeout" in rows[0].error
         assert rows[0].gardener_version == GARDENER_VERSION
+
+
+class TestGardenerGapDiscovery:
+    """Gap discovery and classification are wired into each garden cycle."""
+
+    @pytest.mark.asyncio
+    async def test_gardener_run_discovers_and_classifies_gaps(self, tmp_path, session):
+        """run() invokes discover_gaps + classify_gaps. The privacy-conservative
+        default classifier routes the gap to state=in_review, gap_class=internal.
+        """
+        from knowledge.models import Gap, Note, NoteLink
+
+        # Seed a Note with a body wikilink pointing at an unresolved target.
+        src = Note(
+            note_id="source-note",
+            path="_processed/source-note.md",
+            title="Source Note",
+            content_hash="h-src",
+            type="atom",
+        )
+        session.add(src)
+        session.flush()
+        session.add(
+            NoteLink(
+                src_note_fk=src.id,
+                target_id="missing-concept",
+                target_title="missing-concept",
+                kind="link",
+                edge_type=None,
+            )
+        )
+        session.commit()
+
+        gardener = Gardener(vault_root=tmp_path, session=session)
+        # No raws in the empty vault, so no claude subprocess is spawned.
+        stats = await gardener.run()
+
+        assert stats.gaps_discovered == 1
+        assert stats.gaps_classified == 1
+
+        gap = session.exec(select(Gap)).one()
+        assert gap.state == "in_review"
+        assert gap.gap_class == "internal"
+
+    @pytest.mark.asyncio
+    async def test_gardener_gap_failure_does_not_break_cycle(
+        self, tmp_path, session, caplog
+    ):
+        """When discover_gaps raises, the gardener logs the exception and
+        returns zero gap counts rather than failing the whole cycle."""
+        from knowledge.models import Note, NoteLink
+
+        src = Note(
+            note_id="source-note",
+            path="_processed/source-note.md",
+            title="Source Note",
+            content_hash="h-src",
+            type="atom",
+        )
+        session.add(src)
+        session.flush()
+        session.add(
+            NoteLink(
+                src_note_fk=src.id,
+                target_id="missing-concept",
+                target_title="missing-concept",
+                kind="link",
+                edge_type=None,
+            )
+        )
+        session.commit()
+
+        gardener = Gardener(vault_root=tmp_path, session=session)
+
+        def boom(_session):
+            raise RuntimeError("boom")
+
+        with caplog.at_level(logging.ERROR, logger="monolith.knowledge.gardener"):
+            with patch("knowledge.gaps.discover_gaps", side_effect=boom):
+                stats = await gardener.run()
+
+        assert stats.gaps_discovered == 0
+        assert stats.gaps_classified == 0
+        assert "gap discovery/classification failed" in caplog.text

--- a/projects/monolith/knowledge/gardener_test.py
+++ b/projects/monolith/knowledge/gardener_test.py
@@ -1240,9 +1240,13 @@ class TestGardenerGapDiscovery:
     """Gap discovery and classification are wired into each garden cycle."""
 
     @pytest.mark.asyncio
-    async def test_gardener_run_discovers_and_classifies_gaps(self, tmp_path, session):
-        """run() invokes discover_gaps + classify_gaps. The privacy-conservative
-        default classifier routes the gap to state=in_review, gap_class=internal.
+    async def test_gardener_run_discovers_and_classifies_gaps(
+        self, tmp_path, session, caplog
+    ):
+        """run() invokes discover_gaps + classify_gaps. With no classifier
+        wired, classification is a no-op: the gap stays at state=discovered
+        and a warning is logged. The review queue only populates once the
+        Task-3 PR lands a real classifier.
         """
         from knowledge.models import Gap, Note, NoteLink
 
@@ -1269,14 +1273,21 @@ class TestGardenerGapDiscovery:
 
         gardener = Gardener(vault_root=tmp_path, session=session)
         # No raws in the empty vault, so no claude subprocess is spawned.
-        stats = await gardener.run()
+        with caplog.at_level(logging.WARNING, logger="knowledge.gaps"):
+            stats = await gardener.run()
 
         assert stats.gaps_discovered == 1
-        assert stats.gaps_classified == 1
+        assert stats.gaps_classified == 0
 
         gap = session.exec(select(Gap)).one()
-        assert gap.state == "in_review"
-        assert gap.gap_class == "internal"
+        assert gap.state == "discovered"
+        assert gap.gap_class is None
+
+        assert any(
+            "gaps awaiting classification but no classifier is wired"
+            in record.getMessage()
+            for record in caplog.records
+        )
 
     @pytest.mark.asyncio
     async def test_gardener_gap_failure_does_not_break_cycle(

--- a/projects/monolith/knowledge/gardener_test.py
+++ b/projects/monolith/knowledge/gardener_test.py
@@ -1317,4 +1317,60 @@ class TestGardenerGapDiscovery:
 
         assert stats.gaps_discovered == 0
         assert stats.gaps_classified == 0
-        assert "gap discovery/classification failed" in caplog.text
+        assert "gap pipeline failed after discovering 0 gaps" in caplog.text
+
+    def test_discover_and_classify_gaps_returns_zero_when_session_is_none(
+        self, tmp_path
+    ):
+        """Session-less gardeners (e.g. dry-run setups) skip the gap step cleanly."""
+        gardener = Gardener(vault_root=tmp_path)  # no session
+        assert gardener._discover_and_classify_gaps() == (0, 0)
+
+    @pytest.mark.asyncio
+    async def test_gardener_partial_gap_failure_reports_discovered_count(
+        self, monkeypatch, session, tmp_path, caplog
+    ):
+        """If classify_gaps raises after discover_gaps succeeded, the discovered
+        count must still be reported accurately — not reset to 0."""
+        from knowledge.models import Note, NoteLink
+
+        # Seed an unresolved wikilink so discover_gaps has real work to commit.
+        src = Note(
+            note_id="source-note",
+            path="_processed/source-note.md",
+            title="Source Note",
+            content_hash="h-src",
+            type="atom",
+        )
+        session.add(src)
+        session.flush()
+        session.add(
+            NoteLink(
+                src_note_fk=src.id,
+                target_id="missing-concept",
+                target_title="missing-concept",
+                kind="link",
+                edge_type=None,
+            )
+        )
+        session.commit()
+
+        import knowledge.gaps as gaps_module
+
+        def exploding_classify(*args, **kwargs):
+            raise RuntimeError("classify boom")
+
+        # Do NOT patch discover_gaps — let it succeed and commit.
+        monkeypatch.setattr(gaps_module, "classify_gaps", exploding_classify)
+
+        gardener = Gardener(vault_root=tmp_path, session=session)
+        with caplog.at_level(logging.ERROR, logger="monolith.knowledge.gardener"):
+            stats = await gardener.run()
+
+        # The real correctness guarantee: discovered count is TRUTHFUL even
+        # when classify failed — the gap IS in the DB.
+        assert stats.gaps_discovered == 1
+        assert stats.gaps_classified == 0
+        # The log message should include the discovered count so operators can
+        # trace partial progress.
+        assert "1 gaps" in caplog.text

--- a/projects/monolith/knowledge/mcp.py
+++ b/projects/monolith/knowledge/mcp.py
@@ -19,6 +19,8 @@ from sqlmodel import Session
 from app.db import get_engine
 from app.mcp_app import mcp
 from knowledge import frontmatter
+from knowledge.gaps import answer_gap as _answer_gap
+from knowledge.gaps import list_review_queue
 from knowledge.gardener import _slugify
 from knowledge.service import DEFAULT_VAULT_ROOT, VAULT_ROOT_ENV
 from knowledge.store import KnowledgeStore
@@ -346,3 +348,63 @@ async def get_weekly_tasks() -> dict:
     with Session(get_engine()) as session:
         tasks = KnowledgeStore(session).list_tasks_weekly()
     return {"tasks": tasks}
+
+
+# ---------------------------------------------------------------------------
+# Gap lifecycle tools
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool
+async def list_gaps(
+    state: str | None = None,
+    gap_class: str | None = None,
+    limit: int = 100,
+) -> dict:
+    """List gaps in the knowledge graph with optional filters.
+
+    Returns gaps sorted by most recently created.
+
+    Args:
+        state: Comma-separated state filter (e.g. "in_review,classified").
+        gap_class: Comma-separated class filter (e.g. "internal,hybrid").
+        limit: Maximum results to return (default 100).
+    """
+    with Session(get_engine()) as session:
+        gaps = KnowledgeStore(session).list_gaps(
+            states=state.split(",") if state else None,
+            classes=gap_class.split(",") if gap_class else None,
+            limit=limit,
+        )
+    return {"gaps": gaps}
+
+
+@mcp.tool
+async def get_review_queue() -> dict:
+    """Return internal/hybrid gaps awaiting a user answer, oldest first.
+
+    Use this to see which gaps need your attention. Use ``list_gaps``
+    with explicit filters for anything else.
+    """
+    with Session(get_engine()) as session:
+        return {"gaps": list_review_queue(session)}
+
+
+@mcp.tool
+async def answer_gap(gap_id: int, answer: str) -> dict:
+    """Answer an in-review gap, emitting a personal-tier atom in the vault.
+
+    Writes a new markdown file under ``<vault>/_processed/`` with
+    ``source_tier: personal`` and marks the gap as committed.
+
+    Args:
+        gap_id: The id of a gap currently in ``state='in_review'``.
+        answer: The user's answer text. May not contain a frontmatter
+            terminator (a line containing only ``---``).
+    """
+    vault_root = Path(os.environ.get(VAULT_ROOT_ENV, DEFAULT_VAULT_ROOT)).resolve()
+    with Session(get_engine()) as session:
+        try:
+            return _answer_gap(session, gap_id, answer, vault_root)
+        except ValueError as exc:
+            return {"error": str(exc)}

--- a/projects/monolith/knowledge/mcp.py
+++ b/projects/monolith/knowledge/mcp.py
@@ -20,7 +20,7 @@ from app.db import get_engine
 from app.mcp_app import mcp
 from knowledge import frontmatter
 from knowledge.gaps import answer_gap as _answer_gap
-from knowledge.gaps import list_review_queue
+from knowledge.gaps import list_review_queue, split_csv
 from knowledge.gardener import _slugify
 from knowledge.service import DEFAULT_VAULT_ROOT, VAULT_ROOT_ENV
 from knowledge.store import KnowledgeStore
@@ -368,12 +368,13 @@ async def list_gaps(
     Args:
         state: Comma-separated state filter (e.g. "in_review,classified").
         gap_class: Comma-separated class filter (e.g. "internal,hybrid").
-        limit: Maximum results to return (default 100).
+        limit: Maximum results to return (default 100, clamped to [1, 500]).
     """
+    limit = max(1, min(500, limit))
     with Session(get_engine()) as session:
         gaps = KnowledgeStore(session).list_gaps(
-            states=state.split(",") if state else None,
-            classes=gap_class.split(",") if gap_class else None,
+            states=split_csv(state),
+            classes=split_csv(gap_class),
             limit=limit,
         )
     return {"gaps": gaps}

--- a/projects/monolith/knowledge/mcp_gap_test.py
+++ b/projects/monolith/knowledge/mcp_gap_test.py
@@ -144,6 +144,50 @@ class TestListGapsTool:
         result = await list_gaps(limit=2)
         assert len(result["gaps"]) == 2
 
+    @pytest.mark.asyncio
+    async def test_list_gaps_strips_whitespace_in_state(self, session, patched_engine):
+        """MCP state CSV must match HTTP behavior — trim whitespace between segments.
+
+        Regression: the old ``state.split(",")`` passed ``" classified"`` as a
+        literal filter value, silently dropping every ``classified`` gap when an
+        LLM wrote a natural space after the comma.
+        """
+        src = _make_source_note(session)
+        _make_gap(
+            session,
+            term="intr",
+            source_fk=src.id,
+            state="in_review",
+            gap_class="internal",
+        )
+        _make_gap(
+            session,
+            term="cls",
+            source_fk=src.id,
+            state="classified",
+            gap_class="external",
+        )
+
+        result = await list_gaps(state="in_review, classified")
+        terms = sorted(g["term"] for g in result["gaps"])
+        assert terms == ["cls", "intr"]
+
+    @pytest.mark.asyncio
+    async def test_list_gaps_clamps_limit_upper_bound(self, session, patched_engine):
+        """Oversized MCP limit is clamped to the HTTP max (defense in depth)."""
+        src = _make_source_note(session)
+        for i in range(3):
+            _make_gap(
+                session,
+                term=f"t{i}",
+                source_fk=src.id,
+                state="discovered",
+                gap_class=None,
+            )
+
+        result = await list_gaps(limit=1_000_000)
+        assert len(result["gaps"]) == 3
+
 
 class TestReviewQueueTool:
     @pytest.mark.asyncio

--- a/projects/monolith/knowledge/mcp_gap_test.py
+++ b/projects/monolith/knowledge/mcp_gap_test.py
@@ -1,0 +1,263 @@
+"""Tests for the gap lifecycle MCP tools.
+
+Uses a real in-memory SQLite engine (patched in for ``get_engine``) so the
+tools run their real ``Session(get_engine())`` path.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+
+import pytest
+import yaml
+from sqlmodel import Session, SQLModel, create_engine
+from sqlmodel.pool import StaticPool
+
+from knowledge.gaps import GAPS_PIPELINE_VERSION
+from knowledge.mcp import answer_gap, get_review_queue, list_gaps
+from knowledge.models import Gap, Note
+
+
+@pytest.fixture(name="engine")
+def engine_fixture():
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    original_schemas = {}
+    for table in SQLModel.metadata.tables.values():
+        if table.schema is not None:
+            original_schemas[table.name] = table.schema
+            table.schema = None
+    try:
+        SQLModel.metadata.create_all(engine)
+        yield engine
+    finally:
+        for table in SQLModel.metadata.tables.values():
+            if table.name in original_schemas:
+                table.schema = original_schemas[table.name]
+
+
+@pytest.fixture(name="session")
+def session_fixture(engine):
+    with Session(engine) as session:
+        yield session
+
+
+@pytest.fixture(name="patched_engine")
+def patched_engine_fixture(engine):
+    """Patch knowledge.mcp.get_engine so tools open sessions on our in-memory DB."""
+    with patch("knowledge.mcp.get_engine", return_value=engine):
+        yield engine
+
+
+def _make_source_note(session: Session, note_id: str = "src") -> Note:
+    note = Note(
+        note_id=note_id,
+        path=f"_processed/{note_id}.md",
+        title=note_id,
+        content_hash=f"hash-{note_id}",
+        type="atom",
+    )
+    session.add(note)
+    session.commit()
+    session.refresh(note)
+    return note
+
+
+def _make_gap(
+    session: Session,
+    *,
+    term: str,
+    source_fk: int,
+    state: str = "in_review",
+    gap_class: str | None = "internal",
+    created_at: datetime | None = None,
+) -> Gap:
+    gap = Gap(
+        term=term,
+        context="",
+        source_note_fk=source_fk,
+        gap_class=gap_class,
+        state=state,
+        pipeline_version=GAPS_PIPELINE_VERSION,
+        created_at=created_at or datetime.now(timezone.utc),
+    )
+    session.add(gap)
+    session.commit()
+    session.refresh(gap)
+    return gap
+
+
+class TestListGapsTool:
+    @pytest.mark.asyncio
+    async def test_returns_all_gaps_by_default(self, session, patched_engine):
+        src = _make_source_note(session)
+        _make_gap(
+            session, term="a", source_fk=src.id, state="discovered", gap_class=None
+        )
+        _make_gap(session, term="b", source_fk=src.id, state="in_review")
+
+        result = await list_gaps()
+        terms = sorted(g["term"] for g in result["gaps"])
+        assert terms == ["a", "b"]
+
+    @pytest.mark.asyncio
+    async def test_filters_by_state_and_class(self, session, patched_engine):
+        src = _make_source_note(session)
+        _make_gap(
+            session,
+            term="ext",
+            source_fk=src.id,
+            state="classified",
+            gap_class="external",
+        )
+        _make_gap(
+            session,
+            term="intr",
+            source_fk=src.id,
+            state="in_review",
+            gap_class="internal",
+        )
+        _make_gap(
+            session, term="hyb", source_fk=src.id, state="in_review", gap_class="hybrid"
+        )
+
+        result = await list_gaps(state="in_review", gap_class="internal,hybrid")
+        terms = sorted(g["term"] for g in result["gaps"])
+        assert terms == ["hyb", "intr"]
+
+    @pytest.mark.asyncio
+    async def test_limit_forwarded(self, session, patched_engine):
+        src = _make_source_note(session)
+        for i in range(5):
+            _make_gap(
+                session,
+                term=f"t{i}",
+                source_fk=src.id,
+                state="discovered",
+                gap_class=None,
+            )
+
+        result = await list_gaps(limit=2)
+        assert len(result["gaps"]) == 2
+
+
+class TestReviewQueueTool:
+    @pytest.mark.asyncio
+    async def test_returns_only_internal_hybrid_in_review(
+        self, session, patched_engine
+    ):
+        src = _make_source_note(session)
+        now = datetime.now(timezone.utc)
+        _make_gap(
+            session,
+            term="first-internal",
+            source_fk=src.id,
+            state="in_review",
+            gap_class="internal",
+            created_at=now - timedelta(seconds=30),
+        )
+        _make_gap(
+            session,
+            term="second-hybrid",
+            source_fk=src.id,
+            state="in_review",
+            gap_class="hybrid",
+            created_at=now - timedelta(seconds=20),
+        )
+        _make_gap(
+            session,
+            term="external",
+            source_fk=src.id,
+            state="classified",
+            gap_class="external",
+            created_at=now - timedelta(seconds=10),
+        )
+
+        result = await get_review_queue()
+        terms = [g["term"] for g in result["gaps"]]
+        assert terms == ["first-internal", "second-hybrid"]
+
+    @pytest.mark.asyncio
+    async def test_empty_queue(self, patched_engine):
+        result = await get_review_queue()
+        assert result == {"gaps": []}
+
+
+class TestAnswerGapTool:
+    @pytest.mark.asyncio
+    async def test_happy_path(self, session, patched_engine, tmp_path, monkeypatch):
+        monkeypatch.setenv("VAULT_ROOT", str(tmp_path))
+        src = _make_source_note(session)
+        gap = _make_gap(
+            session,
+            term="Linkerd mTLS",
+            source_fk=src.id,
+            state="in_review",
+            gap_class="internal",
+        )
+
+        result = await answer_gap(gap.id, "Linkerd uses per-pod sidecars on 4143.")
+
+        assert result["gap_id"] == gap.id
+        assert result["note_id"] == "linkerd-mtls"
+        assert result["path"] == "_processed/linkerd-mtls.md"
+
+        written = (tmp_path / result["path"]).read_text()
+        _, fm_block, body = written.split("---\n", 2)
+        fm = yaml.safe_load(fm_block)
+        assert fm["id"] == "linkerd-mtls"
+        assert fm["source_tier"] == "personal"
+        assert "Linkerd uses per-pod sidecars" in body
+
+        session.expire_all()
+        reloaded = session.get(Gap, gap.id)
+        assert reloaded.state == "committed"
+
+    @pytest.mark.asyncio
+    async def test_unknown_id_returns_error_dict(
+        self, patched_engine, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("VAULT_ROOT", str(tmp_path))
+        result = await answer_gap(9999, "some answer")
+        assert "error" in result
+        assert "Gap not found" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_wrong_state_returns_error_dict(
+        self, session, patched_engine, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("VAULT_ROOT", str(tmp_path))
+        src = _make_source_note(session)
+        gap = _make_gap(
+            session,
+            term="still-discovered",
+            source_fk=src.id,
+            state="discovered",
+            gap_class=None,
+        )
+
+        result = await answer_gap(gap.id, "x")
+        assert "error" in result
+        assert "expected 'in_review'" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_frontmatter_terminator_returns_error_dict(
+        self, session, patched_engine, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("VAULT_ROOT", str(tmp_path))
+        src = _make_source_note(session)
+        gap = _make_gap(
+            session,
+            term="injectable",
+            source_fk=src.id,
+            state="in_review",
+            gap_class="internal",
+        )
+
+        result = await answer_gap(gap.id, "foo\n---\nbar")
+        assert "error" in result
+        assert "frontmatter terminator" in result["error"]

--- a/projects/monolith/knowledge/models.py
+++ b/projects/monolith/knowledge/models.py
@@ -8,7 +8,7 @@ NoteId = NewType("NoteId", str)
 
 from pgvector.sqlalchemy import Vector
 from pydantic import field_validator
-from sqlalchemy import JSON, Column, String
+from sqlalchemy import JSON, Column, String, UniqueConstraint
 from sqlalchemy.dialects.postgresql import ARRAY as PG_ARRAY
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlmodel import Field, SQLModel
@@ -24,6 +24,22 @@ EdgeType = Literal[
     "supersedes",
 ]
 LinkKind = Literal["link", "edge"]
+
+# Mirror of the CHECK constraint in
+# chart/migrations/20260424000000_knowledge_gaps.sql - keep in sync.
+GapClass = Literal["external", "internal", "hybrid", "parked"]
+# Mirror of the CHECK constraint in
+# chart/migrations/20260424000000_knowledge_gaps.sql - keep in sync.
+GapState = Literal[
+    "discovered",
+    "classified",
+    "in_review",
+    "researched",
+    "verified",
+    "consolidated",
+    "committed",
+    "rejected",
+]
 
 # Postgres uses native TEXT[] for tags/aliases; SQLite falls back to JSON
 # so the in-memory test fixture can create the tables.
@@ -145,3 +161,39 @@ class AtomRawProvenance(SQLModel, table=True):
                 "AtomRawProvenance requires at least one of atom_fk or raw_fk"
             )
         super().__init__(**data)
+
+
+class Gap(SQLModel, table=True):  # nosemgrep: sqlmodel-datetime-without-factory
+    """A knowledge gap: an unresolved [[wikilink]] promoted to a trackable work item.
+
+    Gaps are surfaced when a wikilink's target is missing from the notes graph.
+    Each gap carries a class (external/internal/hybrid/parked) and advances
+    through a state machine: discovered → classified → in_review → researched →
+    verified → consolidated → committed (or rejected).
+
+    Mirrors chart/migrations/20260424000000_knowledge_gaps.sql — keep in sync.
+    """
+
+    __tablename__ = "gaps"
+    __table_args__ = (
+        UniqueConstraint("term", "source_note_fk"),
+        {"schema": "knowledge", "extend_existing": True},
+    )
+
+    id: int | None = Field(default=None, primary_key=True)
+    term: str = Field(sa_column=Column(String, nullable=False))
+    context: str = Field(default="", sa_column=Column(String, nullable=False))
+    source_note_fk: int | None = Field(default=None, foreign_key="knowledge.notes.id")
+    # GapClass / GapState are Literals for static analysis. At the SQL level
+    # they're plain TEXT, matching the migration's CHECK constraints.
+    gap_class: GapClass | None = Field(
+        default=None, sa_column=Column(String, nullable=True)
+    )
+    state: GapState = Field(
+        default="discovered", sa_column=Column(String, nullable=False)
+    )
+    answer: str | None = None
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    classified_at: datetime | None = None
+    resolved_at: datetime | None = None
+    pipeline_version: str = Field(sa_column=Column(String, nullable=False))

--- a/projects/monolith/knowledge/router.py
+++ b/projects/monolith/knowledge/router.py
@@ -25,7 +25,7 @@ from sqlmodel import Session, select
 
 from app.db import get_session
 from knowledge import frontmatter
-from knowledge.gaps import answer_gap, list_review_queue
+from knowledge.gaps import answer_gap, list_review_queue, split_csv
 from knowledge.gardener import Gardener, _slugify
 from knowledge.ingest_queue import IngestQueueItem
 from knowledge.models import AtomRawProvenance, RawInput
@@ -90,7 +90,7 @@ def get_knowledge_note(
     if note is None:
         raise HTTPException(status_code=404, detail="note not found")
 
-    vault_root = Path(os.environ.get(VAULT_ROOT_ENV, DEFAULT_VAULT_ROOT)).resolve()
+    vault_root = _get_vault_root()
     resolved = (vault_root / note["path"]).resolve()
     if not resolved.is_relative_to(vault_root) or not resolved.is_file():
         raise HTTPException(status_code=404, detail="vault file missing")
@@ -110,7 +110,7 @@ def delete_note_endpoint(
     if note is None:
         raise HTTPException(status_code=404, detail="note not found")
 
-    vault_root = Path(os.environ.get(VAULT_ROOT_ENV, DEFAULT_VAULT_ROOT)).resolve()
+    vault_root = _get_vault_root()
     resolved = (vault_root / note["path"]).resolve()
     if not resolved.is_relative_to(vault_root):
         raise HTTPException(status_code=400, detail="invalid note path")
@@ -137,7 +137,7 @@ def edit_note(
     if note is None:
         raise HTTPException(status_code=404, detail="note not found")
 
-    vault_root = Path(os.environ.get(VAULT_ROOT_ENV, DEFAULT_VAULT_ROOT)).resolve()
+    vault_root = _get_vault_root()
     resolved = (vault_root / note["path"]).resolve()
     if not resolved.is_relative_to(vault_root) or not resolved.is_file():
         raise HTTPException(status_code=404, detail="vault file missing")
@@ -237,7 +237,7 @@ def create_note(data: CreateNoteRequest) -> dict:
     fm_str = yaml.dump(fm_dict, default_flow_style=False, sort_keys=False)
     file_content = f"---\n{fm_str}---\n\n{content}\n"
 
-    vault_root = Path(os.environ.get(VAULT_ROOT_ENV, DEFAULT_VAULT_ROOT)).resolve()
+    vault_root = _get_vault_root()
     slug = _slugify(title)
     filename = f"{slug}.md"
 
@@ -321,13 +321,9 @@ def list_gaps_endpoint(
     session: Session = Depends(get_session),
 ) -> dict:
     """List gaps with optional state/class filters."""
-    states = [s.strip() for s in state.split(",") if s.strip()] if state else None
-    classes = (
-        [c.strip() for c in gap_class.split(",") if c.strip()] if gap_class else None
-    )
     gaps = KnowledgeStore(session).list_gaps(
-        states=states,
-        classes=classes,
+        states=split_csv(state),
+        classes=split_csv(gap_class),
         limit=limit,
     )
     return {"gaps": gaps}
@@ -352,6 +348,10 @@ def answer_gap_endpoint(
     try:
         return answer_gap(session, gap_id, data.answer, vault_root)
     except ValueError as exc:
+        # TODO(post-mvp): refactor gaps.py to raise typed exceptions
+        # (GapNotFoundError, GapWrongStateError, GapAnswerRejectedError) so this
+        # error mapping isn't coupled to specific string messages. The router
+        # should map by exception class, not str(exc) substring.
         msg = str(exc)
         if "Gap not found" in msg:
             raise HTTPException(status_code=404, detail=msg) from exc

--- a/projects/monolith/knowledge/router.py
+++ b/projects/monolith/knowledge/router.py
@@ -25,6 +25,7 @@ from sqlmodel import Session, select
 
 from app.db import get_session
 from knowledge import frontmatter
+from knowledge.gaps import answer_gap, list_review_queue
 from knowledge.gardener import Gardener, _slugify
 from knowledge.ingest_queue import IngestQueueItem
 from knowledge.models import AtomRawProvenance, RawInput
@@ -44,6 +45,11 @@ def get_embedding_client() -> EmbeddingClient:
     to inject a deterministic fake.
     """
     return EmbeddingClient()
+
+
+def _get_vault_root() -> Path:
+    """Resolve the vault root from the env (or default), as an absolute path."""
+    return Path(os.environ.get(VAULT_ROOT_ENV, DEFAULT_VAULT_ROOT)).resolve()
 
 
 @router.get("/search")
@@ -296,3 +302,61 @@ def replay_dead_letter(
     session.delete(prov)
     session.commit()
     return {"replayed": True}
+
+
+# ---------------------------------------------------------------------------
+# Gap lifecycle endpoints
+# ---------------------------------------------------------------------------
+
+
+class AnswerGapRequest(BaseModel):
+    answer: str
+
+
+@router.get("/gaps")
+def list_gaps_endpoint(
+    state: str | None = Query(default=None),
+    gap_class: str | None = Query(default=None),
+    limit: int = Query(default=100, ge=1, le=500),
+    session: Session = Depends(get_session),
+) -> dict:
+    """List gaps with optional state/class filters."""
+    states = [s.strip() for s in state.split(",") if s.strip()] if state else None
+    classes = (
+        [c.strip() for c in gap_class.split(",") if c.strip()] if gap_class else None
+    )
+    gaps = KnowledgeStore(session).list_gaps(
+        states=states,
+        classes=classes,
+        limit=limit,
+    )
+    return {"gaps": gaps}
+
+
+@router.get("/gaps/review-queue")
+def get_review_queue_endpoint(
+    session: Session = Depends(get_session),
+) -> dict:
+    """Return internal/hybrid gaps awaiting user review, oldest first."""
+    return {"gaps": list_review_queue(session)}
+
+
+@router.post("/gaps/{gap_id}/answer")
+def answer_gap_endpoint(
+    gap_id: int,
+    data: AnswerGapRequest,
+    session: Session = Depends(get_session),
+) -> dict:
+    """Commit a user answer for a gap and emit a personal-tier atom."""
+    vault_root = _get_vault_root()
+    try:
+        return answer_gap(session, gap_id, data.answer, vault_root)
+    except ValueError as exc:
+        msg = str(exc)
+        if "Gap not found" in msg:
+            raise HTTPException(status_code=404, detail=msg) from exc
+        if "expected 'in_review'" in msg:
+            raise HTTPException(status_code=409, detail=msg) from exc
+        if "frontmatter terminator" in msg:
+            raise HTTPException(status_code=400, detail=msg) from exc
+        raise HTTPException(status_code=400, detail=msg) from exc

--- a/projects/monolith/knowledge/service.py
+++ b/projects/monolith/knowledge/service.py
@@ -151,6 +151,8 @@ async def garden_handler(session: Session) -> datetime | None:
         "reconciled": stats.reconciled,
         "ingested": stats.ingested,
         "failed": stats.failed,
+        "gaps_discovered": stats.gaps_discovered,
+        "gaps_classified": stats.gaps_classified,
     }
     if stats.ingested == 0 and stats.failed > 0:
         logger.error("knowledge.garden complete (all failed)", extra=extra)

--- a/projects/monolith/knowledge/store.py
+++ b/projects/monolith/knowledge/store.py
@@ -550,7 +550,7 @@ class KnowledgeStore:
         limit: int = 100,
     ) -> list[dict]:
         """List gaps with optional state/class filters, most recent first."""
-        stmt = select(Gap).order_by(Gap.created_at.desc()).limit(limit)
+        stmt = select(Gap).order_by(Gap.created_at.desc(), Gap.id.desc()).limit(limit)
         if states:
             stmt = stmt.where(Gap.state.in_(states))
         if classes:

--- a/projects/monolith/knowledge/store.py
+++ b/projects/monolith/knowledge/store.py
@@ -11,7 +11,7 @@ from sqlmodel import Session, delete, select
 
 from knowledge.frontmatter import ParsedFrontmatter
 from knowledge.links import Link
-from knowledge.models import Chunk, Note, NoteLink
+from knowledge.models import Chunk, Gap, Note, NoteLink
 from shared.chunker import Chunk as ChunkPayload
 
 logger = logging.getLogger(__name__)
@@ -541,3 +541,54 @@ class KnowledgeStore:
         note.extra = extra
         flag_modified(note, "extra")
         self.session.commit()
+
+    def list_gaps(
+        self,
+        *,
+        states: list[str] | None = None,
+        classes: list[str] | None = None,
+        limit: int = 100,
+    ) -> list[dict]:
+        """List gaps with optional state/class filters, most recent first."""
+        stmt = select(Gap).order_by(Gap.created_at.desc()).limit(limit)
+        if states:
+            stmt = stmt.where(Gap.state.in_(states))
+        if classes:
+            stmt = stmt.where(Gap.gap_class.in_(classes))
+
+        rows = self.session.execute(stmt).scalars().all()
+        return [
+            {
+                "id": gap.id,
+                "term": gap.term,
+                "context": gap.context,
+                "source_note_fk": gap.source_note_fk,
+                "gap_class": gap.gap_class,
+                "state": gap.state,
+                "answer": gap.answer,
+                "created_at": gap.created_at,
+                "classified_at": gap.classified_at,
+                "resolved_at": gap.resolved_at,
+                "pipeline_version": gap.pipeline_version,
+            }
+            for gap in rows
+        ]
+
+    def get_gap_by_id(self, gap_id: int) -> dict | None:
+        """Fetch a single gap by id, or None if no gap matches."""
+        gap = self.session.get(Gap, gap_id)
+        if gap is None:
+            return None
+        return {
+            "id": gap.id,
+            "term": gap.term,
+            "context": gap.context,
+            "source_note_fk": gap.source_note_fk,
+            "gap_class": gap.gap_class,
+            "state": gap.state,
+            "answer": gap.answer,
+            "created_at": gap.created_at,
+            "classified_at": gap.classified_at,
+            "resolved_at": gap.resolved_at,
+            "pipeline_version": gap.pipeline_version,
+        }

--- a/projects/monolith/knowledge/store_gap_queries_test.py
+++ b/projects/monolith/knowledge/store_gap_queries_test.py
@@ -1,0 +1,188 @@
+"""Tests for KnowledgeStore.list_gaps() and KnowledgeStore.get_gap_by_id()."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlmodel import Session, SQLModel, create_engine
+from sqlmodel.pool import StaticPool
+
+from knowledge.models import Gap, Note
+from knowledge.store import KnowledgeStore
+
+
+@pytest.fixture(name="session")
+def session_fixture():
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    original_schemas = {}
+    for table in SQLModel.metadata.tables.values():
+        if table.schema is not None:
+            original_schemas[table.name] = table.schema
+            table.schema = None
+    try:
+        SQLModel.metadata.create_all(engine)
+        with Session(engine) as session:
+            yield session
+    finally:
+        for table in SQLModel.metadata.tables.values():
+            if table.name in original_schemas:
+                table.schema = original_schemas[table.name]
+
+
+def _make_note(session: Session, note_id: str = "n") -> Note:
+    note = Note(
+        note_id=note_id,
+        path=f"_processed/{note_id}.md",
+        title=note_id,
+        content_hash=f"hash-{note_id}",
+        type="atom",
+    )
+    session.add(note)
+    session.commit()
+    session.refresh(note)
+    return note
+
+
+def _add_gap(
+    session: Session,
+    *,
+    term: str,
+    source_note_fk: int,
+    state: str = "discovered",
+    gap_class: str | None = None,
+    created_at: datetime | None = None,
+) -> Gap:
+    gap = Gap(
+        term=term,
+        context="",
+        source_note_fk=source_note_fk,
+        gap_class=gap_class,
+        state=state,
+        pipeline_version="gaps@v1",
+        created_at=created_at or datetime.now(timezone.utc),
+    )
+    session.add(gap)
+    session.commit()
+    session.refresh(gap)
+    return gap
+
+
+def test_list_gaps_returns_most_recent_first(session):
+    note = _make_note(session)
+    now = datetime.now(timezone.utc)
+    _add_gap(
+        session, term="old", source_note_fk=note.id, created_at=now - timedelta(hours=1)
+    )
+    _add_gap(session, term="new", source_note_fk=note.id, created_at=now)
+
+    store = KnowledgeStore(session)
+    rows = store.list_gaps()
+
+    assert [r["term"] for r in rows] == ["new", "old"]
+    assert rows[0]["source_note_fk"] == note.id
+    assert rows[0]["pipeline_version"] == "gaps@v1"
+
+
+def test_list_gaps_filters_by_state(session):
+    note = _make_note(session)
+    _add_gap(session, term="a", source_note_fk=note.id, state="discovered")
+    _add_gap(
+        session,
+        term="b",
+        source_note_fk=note.id,
+        state="in_review",
+        gap_class="internal",
+    )
+    _add_gap(
+        session,
+        term="c",
+        source_note_fk=note.id,
+        state="committed",
+        gap_class="internal",
+    )
+
+    store = KnowledgeStore(session)
+    rows = store.list_gaps(states=["in_review", "committed"])
+
+    assert sorted(r["term"] for r in rows) == ["b", "c"]
+
+
+def test_list_gaps_filters_by_class(session):
+    note = _make_note(session)
+    _add_gap(
+        session,
+        term="int",
+        source_note_fk=note.id,
+        state="in_review",
+        gap_class="internal",
+    )
+    _add_gap(
+        session,
+        term="ext",
+        source_note_fk=note.id,
+        state="classified",
+        gap_class="external",
+    )
+    _add_gap(
+        session,
+        term="park",
+        source_note_fk=note.id,
+        state="classified",
+        gap_class="parked",
+    )
+
+    store = KnowledgeStore(session)
+    rows = store.list_gaps(classes=["internal", "external"])
+
+    assert sorted(r["term"] for r in rows) == ["ext", "int"]
+
+
+def test_list_gaps_respects_limit(session):
+    note = _make_note(session)
+    now = datetime.now(timezone.utc)
+    for i in range(5):
+        _add_gap(
+            session,
+            term=f"g-{i}",
+            source_note_fk=note.id,
+            created_at=now + timedelta(seconds=i),
+        )
+
+    store = KnowledgeStore(session)
+    rows = store.list_gaps(limit=3)
+
+    assert len(rows) == 3
+    # Most-recent first.
+    assert [r["term"] for r in rows] == ["g-4", "g-3", "g-2"]
+
+
+def test_get_gap_by_id_returns_dict(session):
+    note = _make_note(session)
+    gap = _add_gap(
+        session,
+        term="t",
+        source_note_fk=note.id,
+        state="in_review",
+        gap_class="internal",
+    )
+
+    store = KnowledgeStore(session)
+    result = store.get_gap_by_id(gap.id)
+
+    assert result is not None
+    assert result["id"] == gap.id
+    assert result["term"] == "t"
+    assert result["state"] == "in_review"
+    assert result["gap_class"] == "internal"
+    assert result["source_note_fk"] == note.id
+    assert result["pipeline_version"] == "gaps@v1"
+
+
+def test_get_gap_by_id_returns_none_for_missing(session):
+    store = KnowledgeStore(session)
+    assert store.get_gap_by_id(9999) is None


### PR DESCRIPTION
## Summary

First vertical slice of the gap-driven knowledge graph system ([design doc](docs/plans/2026-04-24-gap-driven-knowledge-graph-design.md), [plan](docs/plans/2026-04-24-gap-driven-knowledge-graph-plan.md)). Promotes unresolved \`[[wikilinks]]\` into trackable gap records, routes them through a state machine, and exposes a review queue so the user can drain internal (personal-context) gaps via API or MCP.

**What's in:**
- New \`knowledge.gaps\` schema — 8-state machine (\`discovered → classified → in_review → … → committed/rejected\`), 4 gap classes (\`external | internal | hybrid | parked\`), \`UNIQUE(term, source_note_fk)\` for idempotent discovery
- Core lifecycle in \`knowledge/gaps.py\`: \`discover_gaps\`, \`classify_gaps\`, \`list_review_queue\`, \`answer_gap\`
- Privacy-conservative default: uninjected classifier → every gap routes to \`internal\` (user review), nothing leaks to the web
- Gardener integration: gap discovery runs in the existing 5-minute cycle; partial-failure accounting preserves the discovered count; session rollback on classify failure
- HTTP endpoints (\`GET /api/knowledge/gaps\`, \`/gaps/review-queue\`, \`POST /gaps/{id}/answer\`) with 404/409/400 error mapping
- MCP tools (\`list_gaps\`, \`get_review_queue\`, \`answer_gap\`) for draining gaps from Claude Code conversations
- Shared \`split_csv\` helper so HTTP and MCP parse CSV params identically (LLM whitespace-tolerance)
- \`_get_vault_root()\` helper refactored across all 5 router call sites
- Chart \`0.53.4 → 0.53.5\`, \`application.yaml\` \`targetRevision\` synced

**What's intentionally out:**
- Claude-backed classifier (real routing) — comes with the next PR
- External research pipeline (briefing, extraction, verification)
- Cluster-level grouping + embeddings, domain reputation, feedback loops, consolidation beyond new-atom
- These are all explicitly out-of-scope in the design doc; \`TODO(task-3)\` and \`TODO(post-mvp)\` markers flag the deferred pieces

## Test Plan

- [ ] CI passes (BuildBuddy infra was intermittently unavailable during development — remote runs repeatedly hit \`Server terminated abruptly (exit 37)\`; PR-triggered CI uses a different workflow runner pool)
- [ ] Local pytest validated 111 gap-related tests across \`gap_model_test\`, \`gap_lifecycle_test\`, \`store_gap_queries_test\`, \`gardener_test\`, \`gap_api_test\`, \`mcp_gap_test\`
- [ ] ArgoCD sync picks up \`Chart.yaml\` 0.53.5 and applies migration \`20260424000000_knowledge_gaps.sql\`
- [ ] Manual: after a gardener cycle, \`GET /api/knowledge/gaps/review-queue\` returns any unresolved wikilinks seen in the vault, routed to \`internal\` (privacy-conservative default)
- [ ] Manual: \`POST /api/knowledge/gaps/{id}/answer\` writes \`_processed/<slug>.md\` with \`source_tier: personal\` frontmatter and transitions the gap to \`committed\`
- [ ] Reconciler picks up the new atom on its next tick

## Review Notes

Each commit went through per-task spec-compliance + code-quality review loops; a final full-branch review caught two pre-merge items (session rollback on pipeline failure, review-queue tiebreaker) which are both fixed in \`9cba1dd4\`. Commits tell the story — conventional-commit messages are descriptive enough to read via \`git log --oneline\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>