### PR TITLE
feat(inference): fp8 KV cache + 49K context, bump monolith token caps

### DIFF
--- a/projects/agent_platform/inference/deploy/Chart.yaml
+++ b/projects/agent_platform/inference/deploy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: inference
 description: A Helm chart for LLM inference (llama.cpp and vLLM backends)
 type: application
-version: 2.4.1
+version: 2.5.0
 appVersion: "b5270"
 keywords:
   - llm

--- a/projects/agent_platform/inference/deploy/values-prod.yaml
+++ b/projects/agent_platform/inference/deploy/values-prod.yaml
@@ -176,7 +176,7 @@ modelVolume:
   mountPath: "/model-image"
 
 vllm:
-  maxModelLen: 16384
+  maxModelLen: 49152
   gpuMemoryUtilization: 0.95
   dtype: "auto"
   extraArgs:
@@ -191,6 +191,8 @@ vllm:
     - '{"reasoning_start_str": "<think>", "reasoning_end_str": "</think>"}'
     - "--max-num-seqs"
     - "1"
+    - "--kv-cache-dtype"
+    - "fp8"
 
 # vLLM runs as root and needs writable fs for compiled kernels
 podSecurityContext:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.53.13
+version: 0.53.14
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.53.12
+version: 0.53.13
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chat/summarizer.py
+++ b/projects/monolith/chat/summarizer.py
@@ -13,7 +13,7 @@ from chat.models import ChannelSummary, Message, UserChannelSummary
 
 logger = logging.getLogger(__name__)
 
-_LLM_MAX_TOKENS = int(os.environ.get("LLM_MAX_TOKENS", "16384"))
+_LLM_MAX_TOKENS = int(os.environ.get("LLM_MAX_TOKENS", "32768"))
 
 
 async def generate_summaries(

--- a/projects/monolith/chat/summarizer_llm_caller_test.py
+++ b/projects/monolith/chat/summarizer_llm_caller_test.py
@@ -85,7 +85,7 @@ class TestBuildLlmCaller:
         assert payload["model"] == "qwen3.6-27b"
         assert payload["messages"][0]["role"] == "user"
         assert payload["messages"][0]["content"] == "Summarize this conversation."
-        assert payload["max_tokens"] == 16384
+        assert payload["max_tokens"] == 32768
 
     @pytest.mark.asyncio
     async def test_raises_runtime_error_on_missing_choices(self):

--- a/projects/monolith/chat/vision.py
+++ b/projects/monolith/chat/vision.py
@@ -26,7 +26,7 @@ VISION_RETRY_TIMEOUT = 300.0  # 5 min total deadline
 # while slow vision inference still has time to complete.
 VISION_CONNECT_TIMEOUT = 5.0
 VISION_READ_TIMEOUT = 60.0
-VISION_MAX_TOKENS = int(os.environ.get("VISION_MAX_TOKENS", "4096"))
+VISION_MAX_TOKENS = int(os.environ.get("VISION_MAX_TOKENS", "8192"))
 
 
 def _is_retryable(exc: Exception) -> bool:

--- a/projects/monolith/chat/vision_timeout_test.py
+++ b/projects/monolith/chat/vision_timeout_test.py
@@ -276,8 +276,8 @@ class TestVisionClientPayload:
         assert payload["model"] == "qwen3.6-27b"
 
     @pytest.mark.asyncio
-    async def test_payload_includes_max_tokens_4096(self):
-        """describe() sends max_tokens=4096 in the payload."""
+    async def test_payload_includes_max_tokens_default(self):
+        """describe() sends the VISION_MAX_TOKENS default in the payload."""
         client = VisionClient(base_url="http://fake:8080")
 
         with patch("chat.vision.httpx.AsyncClient") as mock_cls:
@@ -285,7 +285,7 @@ class TestVisionClientPayload:
             await client.describe(b"\x89PNG", "image/png")
 
         payload = mock_cls.return_value.post.call_args.kwargs.get("json")
-        assert payload["max_tokens"] == 4096
+        assert payload["max_tokens"] == 8192
 
     @pytest.mark.asyncio
     async def test_payload_system_prompt_matches_module_constant(self):

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.53.12
+      targetRevision: 0.53.14
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
## Summary

- Switches the vLLM engine to fp8 KV cache (`--kv-cache-dtype fp8`) — roughly doubles on-GPU KV pool capacity at negligible accuracy cost on Ada Lovelace.
- Bumps `maxModelLen` from 16,384 → 49,152 (3×) to actually use the new headroom.
- Bumps monolith completion-budget defaults (`LLM_MAX_TOKENS` 16384→32768, `VISION_MAX_TOKENS` 4096→8192) so prompts and generations can take advantage of the larger window.

## Sizing rationale

Pulled live from the engine startup log at the prior config (`max-model-len=16384`, `gpu-memory-utilization=0.95`, default bf16 KV, `max-num-seqs=1`):

```
GPU KV cache size: 10,976 tokens
Maximum concurrency for 16,384 tokens per request: 2.38x
```

Effective bf16 KV pool: 10,976 × 2.38 ≈ **26K tokens**. Switching to fp8 KV roughly doubles per-token capacity → **~52K tokens**. Setting `maxModelLen=49152` keeps ~3K margin for CUDA-graph allocation drift between vLLM versions.

The model (Qwen3.6-27B, lorbus AutoRound INT4) is hybrid (Mamba + attention), and `config.json` confirms `max_position_embeddings: 262144` — context ceiling here is purely VRAM, not architectural.

## Test plan

- [ ] CI green on the PR (build/test/format)
- [ ] After merge, confirm the inference pod restarts cleanly on `node-4` and look for the new `Maximum concurrency for 49,152 tokens per request: Nx` line in startup logs (should be ≥1.0×)
- [ ] `nvidia-smi` on `node-4` shows VRAM still in the 22-23 GB band (not OOM)
- [ ] Smoke a long-prompt completion through the monolith chat path to verify >16K input still serves without truncation

🤖 Generated with [Claude Code](https://claude.com/claude-code)