### PR TITLE
feat(semgrep): extend no-broad-except-swallow to catch unbound except Exception

### DIFF
--- a/bazel/semgrep/rules/python/no-broad-except-swallow.yaml
+++ b/bazel/semgrep/rules/python/no-broad-except-swallow.yaml
@@ -1,11 +1,17 @@
 rules:
   - id: no-broad-except-swallow
     patterns:
-      - pattern: |
-          try:
-            ...
-          except Exception as $E:
-            $BODY
+      - pattern-either:
+          - pattern: |
+              try:
+                ...
+              except Exception as $E:
+                $BODY
+          - pattern: |
+              try:
+                ...
+              except Exception:
+                $BODY
       - pattern-not: |
           try:
             ...
@@ -30,8 +36,26 @@ rules:
           except Exception as $E:
             ...
             logging.$METHOD(...)
+      - pattern-not: |
+          try:
+            ...
+          except Exception:
+            ...
+            raise
+      - pattern-not: |
+          try:
+            ...
+          except Exception:
+            ...
+            logger.$METHOD(...)
+      - pattern-not: |
+          try:
+            ...
+          except Exception:
+            ...
+            logging.$METHOD(...)
     message: >
-      `except Exception as $E` block does not re-raise the exception or log it.
+      `except Exception` block does not re-raise the exception or log it.
       This silently swallows all exceptions, hiding bugs and making failures
       invisible in production. Either log the exception (at minimum
       `logger.exception("...")`) or re-raise it with `raise`.

--- a/bazel/semgrep/tests/fixtures/no-broad-except-swallow.py
+++ b/bazel/semgrep/tests/fixtures/no-broad-except-swallow.py
@@ -53,5 +53,48 @@ def ok_log_and_reraise():
         raise
 
 
+# --- unbound except Exception: (no "as e") ---
+
+
+# ruleid: no-broad-except-swallow
+def bad_unbound_swallow():
+    try:
+        risky_operation()
+    except Exception:
+        pass  # silent failure, no binding!
+
+
+# ruleid: no-broad-except-swallow
+def bad_unbound_return_none():
+    try:
+        risky_operation()
+    except Exception:
+        return None  # hides the error
+
+
+# ok: re-raises (unbound form)
+def ok_unbound_reraise():
+    try:
+        risky_operation()
+    except Exception:
+        raise
+
+
+# ok: logs with logger (unbound form)
+def ok_unbound_log():
+    try:
+        risky_operation()
+    except Exception:
+        logger.exception("unexpected error in risky_operation")
+
+
+# ok: logs with logging module (unbound form)
+def ok_unbound_logging():
+    try:
+        risky_operation()
+    except Exception:
+        logging.warning("risky_operation failed")
+
+
 def risky_operation():
     pass

--- a/bazel/tools/semgrep/upload.py
+++ b/bazel/tools/semgrep/upload.py
@@ -33,6 +33,7 @@ def _git(cmd: str) -> str:
             timeout=5,
         ).stdout.strip()
     except Exception:
+        logging.debug("git command %r failed", cmd)
         return ""
 
 

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.53.14
+version: 0.53.15
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.53.14
+      targetRevision: 0.53.15
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/knowledge/gardener.py
+++ b/projects/monolith/knowledge/gardener.py
@@ -860,7 +860,10 @@ class Gardener:
                     )
                     note_id = file_meta.note_id
                 except Exception:
-                    logger.debug("gardener: failed to parse frontmatter for %s, skipping", new_file)
+                    logger.debug(
+                        "gardener: failed to parse frontmatter for %s, skipping",
+                        new_file,
+                    )
                     continue
                 if not note_id:
                     continue

--- a/projects/monolith/knowledge/gardener.py
+++ b/projects/monolith/knowledge/gardener.py
@@ -860,6 +860,7 @@ class Gardener:
                     )
                     note_id = file_meta.note_id
                 except Exception:
+                    logger.debug("gardener: failed to parse frontmatter for %s, skipping", new_file)
                     continue
                 if not note_id:
                     continue

--- a/projects/monolith/knowledge/raw_ingest.py
+++ b/projects/monolith/knowledge/raw_ingest.py
@@ -82,7 +82,9 @@ def move_phase(*, vault_root: Path, now: datetime) -> MovePhaseStats:
             meta, _ = frontmatter.parse(content)
             title = meta.title or source.stem
         except Exception:
-            logger.debug("move_phase: failed to parse frontmatter for %s, using stem", source)
+            logger.debug(
+                "move_phase: failed to parse frontmatter for %s, using stem", source
+            )
             title = source.stem
 
         target = raw_target_path(
@@ -154,7 +156,9 @@ def reconcile_raw_phase(*, vault_root: Path, session: Session) -> ReconcileRawSt
         try:
             meta, _body = frontmatter.parse(content)
         except Exception:
-            logger.debug("reconcile_raw_phase: failed to parse frontmatter for %s", file_path)
+            logger.debug(
+                "reconcile_raw_phase: failed to parse frontmatter for %s", file_path
+            )
             meta = None
 
         raw_id = compute_raw_id(content)

--- a/projects/monolith/knowledge/raw_ingest.py
+++ b/projects/monolith/knowledge/raw_ingest.py
@@ -82,6 +82,7 @@ def move_phase(*, vault_root: Path, now: datetime) -> MovePhaseStats:
             meta, _ = frontmatter.parse(content)
             title = meta.title or source.stem
         except Exception:
+            logger.debug("move_phase: failed to parse frontmatter for %s, using stem", source)
             title = source.stem
 
         target = raw_target_path(
@@ -153,6 +154,7 @@ def reconcile_raw_phase(*, vault_root: Path, session: Session) -> ReconcileRawSt
         try:
             meta, _body = frontmatter.parse(content)
         except Exception:
+            logger.debug("reconcile_raw_phase: failed to parse frontmatter for %s", file_path)
             meta = None
 
         raw_id = compute_raw_id(content)

--- a/projects/monolith/knowledge/research_agent.py
+++ b/projects/monolith/knowledge/research_agent.py
@@ -9,11 +9,14 @@ faithfully list its own citations.
 
 from __future__ import annotations
 
+import logging
 import os
 import re
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
+
+logger = logging.getLogger(__name__)
 
 from pydantic import BaseModel, Field
 from pydantic_ai import Agent, ModelSettings, RunContext
@@ -242,6 +245,7 @@ def _call_args_as_dict(call: Any) -> dict[str, Any]:
         try:
             return fn() or {}
         except Exception:
+            logger.debug("args_as_dict() failed on tool call, returning empty dict")
             return {}
     args = getattr(call, "args", None)
     return args if isinstance(args, dict) else {}

--- a/projects/ships/backend/main.py
+++ b/projects/ships/backend/main.py
@@ -652,7 +652,9 @@ class WebSocketManager:
             try:
                 await connection.send_json(message)
             except Exception:
-                logger.debug("broadcast: client disconnected during send, queuing removal")
+                logger.debug(
+                    "broadcast: client disconnected during send, queuing removal"
+                )
                 disconnected.append(connection)
 
         for connection in disconnected:

--- a/projects/ships/backend/main.py
+++ b/projects/ships/backend/main.py
@@ -652,6 +652,7 @@ class WebSocketManager:
             try:
                 await connection.send_json(message)
             except Exception:
+                logger.debug("broadcast: client disconnected during send, queuing removal")
                 disconnected.append(connection)
 
         for connection in disconnected:

--- a/projects/ships/chart/Chart.yaml
+++ b/projects/ships/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: marine
 description: Marine services - AIS vessel tracking and API
 type: application
-version: 0.3.47
+version: 0.3.48
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/ships/deploy/application.yaml
+++ b/projects/ships/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: marine
-      targetRevision: 0.3.47
+      targetRevision: 0.3.48
       helm:
         releaseName: marine
         valueFiles:

--- a/projects/stargazer/backend/weather.py
+++ b/projects/stargazer/backend/weather.py
@@ -130,7 +130,7 @@ def score_locations(settings: Settings) -> Path:
                 if sun_alt > -12:
                     continue
             except Exception:
-                # If sun calculation fails, skip
+                logger.debug("sun altitude calculation failed at %s, skipping", time)
                 continue
 
             # Extract weather data

--- a/projects/trips/backend/main.py
+++ b/projects/trips/backend/main.py
@@ -121,7 +121,9 @@ class ConnectionManager:
             try:
                 await connection.send_json(message)
             except Exception:
-                logger.debug("broadcast: client disconnected during send, queuing removal")
+                logger.debug(
+                    "broadcast: client disconnected during send, queuing removal"
+                )
                 disconnected.append(connection)
 
         for conn in disconnected:

--- a/projects/trips/backend/main.py
+++ b/projects/trips/backend/main.py
@@ -121,6 +121,7 @@ class ConnectionManager:
             try:
                 await connection.send_json(message)
             except Exception:
+                logger.debug("broadcast: client disconnected during send, queuing removal")
                 disconnected.append(connection)
 
         for conn in disconnected:

--- a/projects/trips/tools/elevation/client.py
+++ b/projects/trips/tools/elevation/client.py
@@ -8,11 +8,14 @@ Fetches elevation from Natural Resources Canada's CDEM API with:
 """
 
 import asyncio
+import logging
 import sqlite3
 from dataclasses import dataclass
 from pathlib import Path
 
 import aiohttp
+
+logger = logging.getLogger(__name__)
 
 # NRCan CDEM API endpoint
 API_BASE = "https://geogratis.gc.ca/services/elevation/cdem/altitude"
@@ -181,6 +184,7 @@ class ElevationClient:
                     return data.get("altitude")
                 return None
         except Exception:
+            logger.debug("elevation API request failed for %s", url)
             return None
 
     async def get_elevation(self, lat: float, lng: float) -> ElevationResult:

--- a/projects/trips/tools/publish-trip-images/main.py
+++ b/projects/trips/tools/publish-trip-images/main.py
@@ -1292,6 +1292,7 @@ def backfill_optics(
                 cache.put(image_key, optics)
                 return False, optics
             except Exception:
+                logger.warning("failed to download or extract EXIF for %s", image_key)
                 return False, None
 
     async def _backfill():
@@ -1321,6 +1322,7 @@ def backfill_optics(
                             if not point_data.get("deleted"):
                                 points.append(point_data)
                         except Exception:
+                            logger.warning("failed to decode NATS message, skipping")
                             pass
                 except nats.errors.TimeoutError:
                     break


### PR DESCRIPTION
## Summary

- Restructures the `no-broad-except-swallow` rule to use `pattern-either`, matching both the bound form (`except Exception as $E:`) and the bare unbound form (`except Exception:`)
- Adds `pattern-not` entries for the unbound variant covering all the same safe exits: bare `raise`, `logger.<method>(...)`, and `logging.<method>(...)`
- Updates the test fixture with five new cases (2 bad / 3 ok) for the unbound form

## Motivation

The bare `except Exception:` form (without `as e`) is common — especially in quick fixes and copy-pasta — and previously bypassed the rule entirely, silently swallowing exceptions with no detection.

## Test plan

- [ ] CI semgrep test target passes — `bad_unbound_swallow` and `bad_unbound_return_none` are flagged as `ruleid`
- [ ] `ok_unbound_reraise`, `ok_unbound_log`, `ok_unbound_logging` are not flagged
- [ ] Existing bound-form cases remain unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)