### PR TITLE
feat(tools): knowledge_research toolkit for vault gap research

### DIFF
--- a/tools/knowledge_research/README.md
+++ b/tools/knowledge_research/README.md
@@ -1,0 +1,181 @@
+# knowledge_research
+
+Opus 4.7 prompts and wrappers for researching gaps in Joe's Obsidian
+vault. A local complement to the in-cluster `knowledge.research-gaps`
+scheduled job — useful when:
+
+- The cluster's Qwen-driven pipeline is backlogged and you want to drain
+  some of the queue from a Mac with weekly-token headroom.
+- The gap is `internal` / `personal` (Joe's own thinking) and needs a
+  conversational extraction rather than a web-research pass.
+
+## Architecture
+
+Both flows are **two-phase** to maximize output quality:
+
+1. **Phase 1 — Explore the local neighborhood.** The parent claude
+   session reads the stub, walks `referenced_by` edges, finds adjacent
+   clusters via grep + tag overlap, and produces a research brief
+   summarizing Joe's existing coverage and the precise gap.
+2. **Phase 2 — Do the focused work.**
+   - **External flow** dispatches a subagent (`Task` tool,
+     `subagent_type: general-purpose`) with the Phase 1 brief. The
+     subagent does the open-web research and returns structured findings.
+     This keeps the parent's context clean and gives the web research a
+     tight, cluster-aware framing.
+   - **Internal flow** opens a conversation with Joe instead, using the
+     Phase 1 hypothesis to ask a single focused question rather than a
+     blank "what do you mean by X". No subagent — the conversation is
+     the value-add.
+
+Then the parent synthesizes Phase-1 vault findings + Phase-2 output into
+the final note.
+
+## Two-step write flow
+
+The vault has a Phase-A ingest job that periodically scans `<vault>/*.md`
+and moves found files into `_raw/`. To avoid that job racing in-progress
+edits, both flows write into a **staging directory** first and the
+wrapper script atomically promotes the file to vault root once the
+session is complete.
+
+```
+<vault>/.opus-research/<slug>.md   ← claude writes here (Phase A skips, dot-prefixed)
+                ↓ atomic mv on clean exit
+<vault>/<slug>.md                  ← Phase A picks up here, normal ingest happens
+                ↓ Phase A
+<vault>/_raw/YYYY/MM/DD/<hash>.md
+                ↓ gardener
+<vault>/_processed/<atom>.md
+                ↓ reconciler
+gap stub in _researching/ resolved
+```
+
+The dot-prefix is auto-excluded by `_discover_vault_root_drops()` and
+hidden by Obsidian — no pipeline changes needed.
+
+## Layout
+
+```
+tools/knowledge_research/
+├── prompts/
+│   ├── research-external.system.md   # web + vault research, non-interactive
+│   └── research-internal.system.md   # conversational, asks Joe directly
+├── bin/
+│   ├── research-gap.sh               # batch external research
+│   └── research-gap-interactive.sh   # one-at-a-time interactive
+└── README.md
+```
+
+## Setup
+
+1. Install the `claude` CLI (already done if you're reading this).
+2. Set `VAULT` once in your shell rc:
+   ```bash
+   export VAULT="$HOME/Documents/Obsidian/<vault>"
+   ```
+3. Add the bin dir to PATH so the wrappers are globally callable:
+   ```bash
+   export PATH="$HOME/repos/homelab/tools/knowledge_research/bin:$PATH"
+   ```
+   Or symlink: `ln -s ~/repos/homelab/tools/knowledge_research/bin/* ~/bin/`.
+
+The wrappers resolve their prompt files relative to their own location,
+so they work from any cwd as long as the `tools/knowledge_research/`
+checkout is intact.
+
+## Usage
+
+### Batch external research
+
+Pulls `_researching/*.md` stubs with `gap_class: external`, runs Opus to
+research each, stages the output at `<vault>/.opus-research/<slug>.md`,
+and promotes it to `<vault>/<slug>.md` after each session. Resumable —
+re-runs skip stubs that already have a staged or promoted file.
+
+```bash
+research-gap.sh                      # default: up to 50 stubs
+research-gap.sh --max 10
+research-gap.sh --filter '^ddd-'     # regex over slug
+research-gap.sh --vault ~/path/to/vault --max 5
+```
+
+Each stub costs roughly 5-15K input tokens and 3-5K output. On Max-20×
+that's ~0.3-0.5% of the weekly all-models limit per stub.
+
+### Interactive personal research
+
+Drops into a conversational `claude` session for a single internal/
+personal gap. Opus opens with a synthesis of what it's already read from
+`referenced_by`, asks one focused question, and after 3-5 turns drafts a
+note for your review in `.opus-research/<slug>.md`. On approval you
+exit the session and the wrapper promotes the file.
+
+```bash
+research-gap-interactive.sh ruinous-empathy-trap   # by slug
+research-gap-interactive.sh --pick                 # fzf picker over eligible
+research-gap-interactive.sh --no-promote <slug>    # leave staged for inspection
+```
+
+The picker requires `fzf` (`brew install fzf`).
+
+The interactive flow caps itself at 5 questions and shows the draft
+before exit. You can always say "no, change X" before approving.
+
+## What lands in the vault
+
+Both flows produce a markdown file at `<vault>/<slug>.md` with this shape:
+
+```markdown
+---
+title: <Title>
+tags: [<lowercase-kebab-tags>]
+source: opus-research # or opus-interactive
+researched_at: 2026-04-25T16:30:00Z
+references:
+  - <note_id_1>
+  - <note_id_2>
+---
+
+# <Title>
+
+<3-5 sentence framing>
+
+## Key claims
+
+- <claim 1>
+- <claim 2>
+
+## Why it matters in this vault # external flow
+
+## Joe's framing # interactive flow
+
+<...>
+
+## Sources
+
+- [[<note_id>]] — <what was used>
+- <https://...> — <what was used> # external only
+```
+
+The vault's existing pipeline owns everything after promotion — move to
+`_raw/`, atomize claims, populate `_processed/`, reconcile the gap stub,
+eventually consolidate near-duplicates. We don't reach inside those
+stages.
+
+## Hard guarantees
+
+- **Idempotent.** Re-running on stubs that already have output (staged or
+  promoted) is a no-op.
+- **No silent overwrite.** Both prompts refuse if the target file already
+  exists; the user must explicitly confirm.
+- **No race with Phase A.** Files in `.opus-research/` are invisible to
+  the ingest scanner until promotion.
+- **No invented citations.** Sources are mechanically tied to actual tool
+  calls — every `[[note_id]]` was Read, every URL was WebFetched.
+- **No vault writes outside `<vault>/<slug>.md` and `.opus-research/`.**
+  Stubs in `_researching/` are not touched directly; the reconciler
+  resolves them after atomization.
+- **Abort-safe.** If you Ctrl-C an interactive session or claude crashes,
+  the staged file is left in `.opus-research/` for inspection. No
+  partial promotions.

--- a/tools/knowledge_research/README.md
+++ b/tools/knowledge_research/README.md
@@ -59,13 +59,30 @@ hidden by Obsidian — no pipeline changes needed.
 ```
 tools/knowledge_research/
 ├── prompts/
+│   ├── triage-stubs.system.md        # batch read-only triage of the queue
 │   ├── research-external.system.md   # web + vault research, non-interactive
 │   └── research-internal.system.md   # conversational, asks Joe directly
 ├── bin/
+│   ├── triage-stubs.sh               # produce a markdown triage report
 │   ├── research-gap.sh               # batch external research
 │   └── research-gap-interactive.sh   # one-at-a-time interactive
 └── README.md
 ```
+
+## Recommended workflow
+
+For a fresh queue (e.g. 700+ stubs from a recent gap-detection sweep):
+
+1. **`triage-stubs.sh --limit 200`** to flag stubs that are already
+   covered, misclassified, or garbage. Read the report, take bulk
+   actions (delete, reclassify) manually.
+2. **`research-gap.sh --max 30`** to drain the surviving external
+   stubs in batches. Resumable.
+3. **`research-gap-interactive.sh --pick`** when you have time to sit
+   with an internal/personal gap.
+
+Triage first compresses the queue substantially before you spend tokens
+on real research.
 
 ## Setup
 
@@ -85,6 +102,27 @@ so they work from any cwd as long as the `tools/knowledge_research/`
 checkout is intact.
 
 ## Usage
+
+### Stub triage (read-only)
+
+Walks `_researching/*.md` and decides which stubs are worth researching.
+Read-only — produces a markdown report at
+`<vault>/.opus-research/triage-<UTC>.md` listing each stub with one of
+five decisions: `already_covered`, `misclassified`, `garbage`,
+`valid_external`, `valid_internal`. You review and take bulk actions
+manually (the report includes suggested `rm` commands).
+
+```bash
+triage-stubs.sh                          # up to 100 stubs, batch size 25
+triage-stubs.sh --limit 200
+triage-stubs.sh --filter '^ddd-' --limit 50
+triage-stubs.sh --batch-size 10          # smaller batches if you hit rate limits
+```
+
+Internally the parent dispatches subagents in parallel batches so 100+
+stubs don't blow the parent's context window. Each subagent emits a
+structured per-stub decision; the parent aggregates into a single report
+with a top-of-file summary table.
 
 ### Batch external research
 

--- a/tools/knowledge_research/bin/research-gap-interactive.sh
+++ b/tools/knowledge_research/bin/research-gap-interactive.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+# Interactively research an internal/personal gap with Opus 4.7.
+#
+# Usage:
+#   research-gap-interactive.sh [--vault PATH] <slug>
+#   research-gap-interactive.sh [--vault PATH] --pick      # fzf picker
+#
+# Drops you into a conversational claude session. Opus reads the stub
+# and Joe's referenced notes, opens with a focused question, and after
+# 3-5 turns drafts a note for review. Joe approves, exits the session,
+# and this wrapper atomically promotes the staged file to vault root.
+#
+# Two-step write flow:
+#   1. Opus writes/edits at <vault>/.opus-research/<slug>.md while you
+#      converse. Phase A skips dot-prefixed dirs so no race.
+#   2. On clean session exit, this wrapper moves the staged file to
+#      <vault>/<slug>.md for Phase A to pick up.
+#   3. If you Ctrl-C / abort, the staged file is left in place for you
+#      to inspect or rerun.
+
+set -euo pipefail
+
+SELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROMPT_FILE="$SELF_DIR/../prompts/research-internal.system.md"
+[ -f "$PROMPT_FILE" ] || {
+	echo "missing prompt: $PROMPT_FILE" >&2
+	exit 1
+}
+
+VAULT="${VAULT:-}"
+PICK=0
+SLUG=""
+NO_PROMOTE=0
+
+while [ $# -gt 0 ]; do
+	case "$1" in
+	--vault)
+		VAULT="$2"
+		shift 2
+		;;
+	--pick)
+		PICK=1
+		shift
+		;;
+	--no-promote)
+		NO_PROMOTE=1
+		shift
+		;;
+	-h | --help)
+		sed -n '2,/^$/p' "${BASH_SOURCE[0]}" | sed 's/^# \?//'
+		exit 0
+		;;
+	*)
+		if [ -z "$SLUG" ]; then
+			SLUG="$1"
+			shift
+		else
+			echo "unexpected arg: $1" >&2
+			exit 2
+		fi
+		;;
+	esac
+done
+
+[ -n "$VAULT" ] || {
+	echo "set VAULT env var or pass --vault PATH" >&2
+	exit 2
+}
+[ -d "$VAULT/_researching" ] || {
+	echo "no _researching/ dir at $VAULT" >&2
+	exit 2
+}
+
+STAGING="$VAULT/.opus-research"
+mkdir -p "$STAGING"
+
+cd "$VAULT"
+
+if [ "$PICK" = "1" ]; then
+	if ! command -v fzf >/dev/null 2>&1; then
+		echo "--pick requires fzf; install via 'brew install fzf'" >&2
+		exit 2
+	fi
+	candidates=$(
+		for stub in _researching/*.md; do
+			slug="$(basename "$stub" .md)"
+			[ -f "$slug.md" ] && continue
+			[ -f "$STAGING/$slug.md" ] && continue
+			cls="$(awk '/^gap_class:/ {print $2; exit}' "$stub" | tr -d '"')"
+			[ "$cls" = "external" ] && continue
+			printf '%s\t%s\n' "$slug" "$cls"
+		done
+	)
+	[ -n "$candidates" ] || {
+		echo "no eligible stubs"
+		exit 0
+	}
+	picked=$(printf '%s\n' "$candidates" | fzf --with-nth=1,2 --delimiter=$'\t' --prompt="gap> ")
+	SLUG="${picked%%	*}"
+fi
+
+[ -n "$SLUG" ] || {
+	echo "supply a slug or use --pick" >&2
+	exit 2
+}
+
+stub="_researching/${SLUG}.md"
+[ -f "$stub" ] || {
+	echo "no stub at $stub" >&2
+	exit 2
+}
+
+if [ -f "${SLUG}.md" ]; then
+	echo "WARN: ${SLUG}.md already exists at vault root." >&2
+	echo "       Continuing — claude will refuse to overwrite unless you confirm." >&2
+fi
+
+# Run claude interactively. The system prompt instructs Opus to write
+# to .opus-research/<slug>.md and let the wrapper promote.
+set +e
+claude \
+	--model claude-opus-4-7 \
+	--append-system-prompt "$(cat "$PROMPT_FILE")" \
+	--add-dir "$VAULT" \
+	"Research the gap at \`_researching/${SLUG}.md\`. Vault root is the current working directory. Stage your output at \`.opus-research/${SLUG}.md\` per the system prompt — do not write at vault root, the wrapper handles promotion. Begin with your synthesis + first question."
+rc=$?
+set -e
+
+if [ "$rc" -ne 0 ]; then
+	echo "claude exited with status $rc — leaving staged file (if any) in place at $STAGING/" >&2
+	exit "$rc"
+fi
+
+# Promote staged file to vault root.
+if [ "$NO_PROMOTE" = "1" ]; then
+	echo "[--no-promote] staged file left at $STAGING/${SLUG}.md"
+	exit 0
+fi
+
+if [ -f "$STAGING/${SLUG}.md" ]; then
+	if [ -f "${SLUG}.md" ]; then
+		echo "REFUSE: ${SLUG}.md exists at vault root and staged version also exists." >&2
+		echo "        Manually resolve: keep one or the other." >&2
+		echo "        Staged: $STAGING/${SLUG}.md" >&2
+		exit 3
+	fi
+	mv "$STAGING/${SLUG}.md" "${SLUG}.md"
+	echo "promoted to vault root: ${SLUG}.md"
+else
+	echo "no staged file at $STAGING/${SLUG}.md — claude may have skipped or aborted before writing" >&2
+	exit 4
+fi

--- a/tools/knowledge_research/bin/research-gap.sh
+++ b/tools/knowledge_research/bin/research-gap.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# Batch-research external gaps via Opus 4.7.
+#
+# Usage:
+#   research-gap.sh [--max N] [--vault PATH] [--filter PATTERN]
+#
+# Iterates _researching/*.md, skips already-researched and non-external
+# gaps, invokes claude per stub. Resumable.
+#
+# Two-step write flow:
+#   1. Opus writes to <vault>/.opus-research/<slug>.md (Phase A skips
+#      dot-prefixed dirs, so no race with the ingest job).
+#   2. After claude exits cleanly, this script atomically promotes the
+#      staged file to <vault>/<slug>.md, where Phase A picks it up.
+
+set -euo pipefail
+
+# Resolve our prompt regardless of cwd.
+SELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROMPT_FILE="$SELF_DIR/../prompts/research-external.system.md"
+[ -f "$PROMPT_FILE" ] || {
+	echo "missing prompt: $PROMPT_FILE" >&2
+	exit 1
+}
+
+VAULT="${VAULT:-}"
+MAX=50
+FILTER=""
+
+while [ $# -gt 0 ]; do
+	case "$1" in
+	--max)
+		MAX="$2"
+		shift 2
+		;;
+	--vault)
+		VAULT="$2"
+		shift 2
+		;;
+	--filter)
+		FILTER="$2"
+		shift 2
+		;;
+	-h | --help)
+		sed -n '2,/^$/p' "${BASH_SOURCE[0]}" | sed 's/^# \?//'
+		exit 0
+		;;
+	*)
+		echo "unknown arg: $1" >&2
+		exit 2
+		;;
+	esac
+done
+
+[ -n "$VAULT" ] || {
+	echo "set VAULT env var or pass --vault PATH" >&2
+	exit 2
+}
+[ -d "$VAULT/_researching" ] || {
+	echo "no _researching/ dir at $VAULT" >&2
+	exit 2
+}
+
+STAGING="$VAULT/.opus-research"
+mkdir -p "$STAGING"
+
+cd "$VAULT"
+
+count=0
+skipped_exists=0
+skipped_class=0
+failed=0
+promoted=0
+
+shopt -s nullglob
+for stub in _researching/*.md; do
+	[ "$count" -ge "$MAX" ] && break
+
+	slug="$(basename "$stub" .md)"
+
+	if [ -n "$FILTER" ] && [[ ! "$slug" =~ $FILTER ]]; then
+		continue
+	fi
+
+	# Skip if already promoted at vault root, or already staged.
+	if [ -f "$slug.md" ] || [ -f "$STAGING/$slug.md" ]; then
+		skipped_exists=$((skipped_exists + 1))
+		continue
+	fi
+
+	# Skip non-external fast (don't burn a Claude call).
+	gap_class="$(awk '/^gap_class:/ {print $2; exit}' "$stub" | tr -d '"')"
+	if [ "$gap_class" != "external" ]; then
+		skipped_class=$((skipped_class + 1))
+		continue
+	fi
+
+	echo "==> researching: $slug"
+	if claude --print \
+		--model claude-opus-4-7 \
+		--append-system-prompt "$(cat "$PROMPT_FILE")" \
+		--add-dir "$VAULT" \
+		"Research the gap at \`_researching/${slug}.md\`. Vault root is the current working directory. Stage your output at \`.opus-research/${slug}.md\` per the system prompt — do not write at vault root, the wrapper handles promotion."; then
+		count=$((count + 1))
+	else
+		echo "    FAILED: $slug — continuing" >&2
+		failed=$((failed + 1))
+		continue
+	fi
+
+	# Promote staged file to vault root.
+	if [ -f "$STAGING/$slug.md" ]; then
+		mv "$STAGING/$slug.md" "$slug.md"
+		echo "    promoted: $slug.md"
+		promoted=$((promoted + 1))
+	else
+		# Opus may have used a different filename (allowed). Promote any
+		# files created during this run and not already at vault root.
+		found_any=0
+		while IFS= read -r staged; do
+			base="$(basename "$staged")"
+			if [ -f "$base" ]; then
+				echo "    skip-promote (vault root collision): $base" >&2
+				continue
+			fi
+			mv "$staged" "$base"
+			echo "    promoted: $base"
+			promoted=$((promoted + 1))
+			found_any=1
+		done < <(find "$STAGING" -maxdepth 1 -type f -name "*.md" -newer "$stub" 2>/dev/null)
+		[ "$found_any" = "0" ] && echo "    NOTE: no staged file found for $slug — claude may have skipped it" >&2
+	fi
+
+	sleep 2 # rate-limit politeness
+done
+
+cat <<EOF
+
+Done.
+  researched (claude calls): $count
+  promoted to vault root:    $promoted
+  skipped (already exists):  $skipped_exists
+  skipped (non-external):    $skipped_class
+  failed:                    $failed
+EOF

--- a/tools/knowledge_research/bin/triage-stubs.sh
+++ b/tools/knowledge_research/bin/triage-stubs.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# Triage gap stubs in _researching/ — flag already-covered, misclassified,
+# or garbage stubs before spending tokens on real research.
+#
+# Usage:
+#   triage-stubs.sh [--vault PATH] [--limit N] [--filter REGEX] [--batch-size N]
+#
+# Output: a markdown report at <vault>/.opus-research/triage-<UTC>.md.
+# The wrapper does NOT promote this file — it is a working document for
+# review, not a vault note. You decide what bulk actions to take based
+# on the report.
+
+set -euo pipefail
+
+SELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROMPT_FILE="$SELF_DIR/../prompts/triage-stubs.system.md"
+[ -f "$PROMPT_FILE" ] || {
+	echo "missing prompt: $PROMPT_FILE" >&2
+	exit 1
+}
+
+VAULT="${VAULT:-}"
+LIMIT=100
+FILTER=""
+BATCH_SIZE=25
+
+while [ $# -gt 0 ]; do
+	case "$1" in
+	--vault)
+		VAULT="$2"
+		shift 2
+		;;
+	--limit)
+		LIMIT="$2"
+		shift 2
+		;;
+	--filter)
+		FILTER="$2"
+		shift 2
+		;;
+	--batch-size)
+		BATCH_SIZE="$2"
+		shift 2
+		;;
+	-h | --help)
+		sed -n '2,/^$/p' "${BASH_SOURCE[0]}" | sed 's/^# \?//'
+		exit 0
+		;;
+	*)
+		echo "unknown arg: $1" >&2
+		exit 2
+		;;
+	esac
+done
+
+[ -n "$VAULT" ] || {
+	echo "set VAULT env var or pass --vault PATH" >&2
+	exit 2
+}
+[ -d "$VAULT/_researching" ] || {
+	echo "no _researching/ dir at $VAULT" >&2
+	exit 2
+}
+
+STAGING="$VAULT/.opus-research"
+mkdir -p "$STAGING"
+
+cd "$VAULT"
+
+# Quick eligibility count for the user.
+shopt -s nullglob
+all=0
+eligible=0
+for stub in _researching/*.md; do
+	all=$((all + 1))
+	slug="$(basename "$stub" .md)"
+	[ -f "$slug.md" ] && continue
+	[ -f "$STAGING/$slug.md" ] && continue
+	if [ -n "$FILTER" ] && [[ ! "$slug" =~ $FILTER ]]; then
+		continue
+	fi
+	eligible=$((eligible + 1))
+done
+shopt -u nullglob
+
+[ "$eligible" = "0" ] && {
+	echo "no eligible stubs (total: $all)"
+	exit 0
+}
+
+# Cap eligible at limit.
+to_process=$eligible
+[ "$to_process" -gt "$LIMIT" ] && to_process="$LIMIT"
+
+ts="$(date -u +%Y%m%dT%H%M%SZ)"
+report_path="$STAGING/triage-$ts.md"
+
+echo "Triaging $to_process stubs (of $eligible eligible / $all total)"
+echo "Batch size: $BATCH_SIZE"
+echo "Report path: $report_path"
+echo
+
+claude --print \
+	--model claude-opus-4-7 \
+	--append-system-prompt "$(cat "$PROMPT_FILE")" \
+	--add-dir "$VAULT" \
+	"Triage gap stubs in this vault. Working directory is the vault root. Process up to $to_process stubs in batches of $BATCH_SIZE.${FILTER:+ Filter slugs by regex: $FILTER.} Write the consolidated report to \`.opus-research/triage-$ts.md\` per the system prompt."
+
+if [ -f "$report_path" ]; then
+	echo
+	echo "Report written: $report_path"
+	echo
+	echo "Top-of-file summary:"
+	head -30 "$report_path"
+else
+	echo "WARN: expected report not written at $report_path" >&2
+	exit 3
+fi

--- a/tools/knowledge_research/prompts/research-external.system.md
+++ b/tools/knowledge_research/prompts/research-external.system.md
@@ -1,0 +1,215 @@
+# Knowledge research agent — external gap
+
+You are a research agent for Joe's personal Obsidian knowledge graph.
+Your job is to research a single term that has been referenced in his
+vault but does not yet have its own definition note, and produce a
+high-quality grounded note at vault root.
+
+You operate in **two phases** to maximize output quality:
+
+1. **Explore the local neighborhood** in this session — read backlinks,
+   walk edges, identify the cluster this gap belongs to, work out what
+   Joe already covers vs what's actually missing.
+2. **Dispatch the focused research task to a subagent** via the Task /
+   Agent tool, passing a tight brief that summarizes Phase 1's findings.
+   The subagent does the open-web research without burning your context
+   window or losing the local-cluster framing.
+
+Then synthesize subagent output + Phase 1 vault material into the final
+note and stage it for the wrapper to promote.
+
+## Two-step write flow (important)
+
+Joe's vault has a Phase-A ingest job that periodically scans for `.md`
+files at vault root and moves them into `_raw/`. To avoid that job
+racing your in-progress edits, write into a **staging directory** first;
+the wrapper script promotes the finished file to vault root after you
+exit.
+
+- **Write/edit** all output at `.opus-research/<slug>.md` (vault-root
+  relative). The leading dot makes Phase A skip this directory entirely
+  and Obsidian hides it from the file explorer.
+- **Do not write directly to `<vault>/<slug>.md`.** The wrapper handles
+  promotion atomically.
+- **Do not touch `_researching/`, `_inbox/`, `_raw/`, or `_processed/`.**
+
+## Inputs
+
+1. A stub file path: `_researching/<slug>.md`. Read it. Frontmatter:
+   - `id`: the canonical slug
+   - `title`: the human-readable term
+   - `gap_class`: must be `external`. Skip and exit if not.
+   - `referenced_by`: a list of note ids that mention this term
+2. The vault root (working directory). Layout:
+   - `_processed/` — atomized canonical notes (Joe's prior thinking, MOST trusted)
+   - `_raw/` — historical raw captures
+   - `_researching/` — gap stubs (placeholders, not content)
+   - `.opus-research/` — your staging directory (created by the wrapper)
+
+## Phase 1 — Explore the local neighborhood
+
+Cheap, vault-only work. Stays in your context window.
+
+1. **Read the stub.** Confirm `gap_class: external`; if not, exit.
+
+2. **Walk the inbound edges.** For each id in `referenced_by`, Read
+   `_processed/<id>.md`. Note its tags, its other wikilinks, the _role_
+   the term plays in that note (definition? aside? contrast?
+   load-bearing?).
+
+3. **Find adjacent clusters.** From the referencing notes, extract the
+   3-5 most-mentioned other concepts. Grep `_processed/` and `_raw/` for
+   each. Read up to 5 neighbor notes. You're looking for the
+   _neighborhood_ — the cluster of concepts this term sits inside.
+
+4. **Triangulate with tag overlap.** Note tags shared across the
+   referencing notes and the neighbors. Tags reveal Joe's mental
+   bucketing — the cluster's identity often lives in shared tags.
+
+5. **Compose a research brief** (in your scratchpad). It must answer:
+   - **Cluster name** — Joe's mental neighborhood for this term
+     (e.g. "writing-quality metrics", "agent-design heuristics",
+     "team-dynamics anti-patterns")
+   - **Joe's existing coverage** — what `_processed/` already says about
+     adjacent concepts (1-3 sentences citing specific note ids)
+   - **The actual gap** — precisely what's missing, in one sentence.
+     "Joe references X but never defines it" is too generic; aim for
+     "Joe uses X as a measurable signal in writing-quality contexts but
+     hasn't committed to a definition or measurement protocol".
+   - **Tone register** — pragmatic / theoretical / opinion-driven /
+     reference-citing? Match Joe's adjacent notes.
+   - **Suggested research angles** — 2-4 specific things the subagent
+     should look up (not just the term itself).
+
+The brief should fit in ~200-400 words. Don't skip this — it's the
+input that makes Phase 2 produce sharp output instead of generic
+encyclopedic prose.
+
+## Phase 2 — Dispatch the focused research
+
+Use the **Task** (Agent) tool with `subagent_type: general-purpose` and a
+prompt structured exactly like this:
+
+```
+You are researching a term for Joe's personal knowledge graph.
+
+# Term
+
+<title> (slug: <slug>)
+
+# Local cluster (from vault exploration)
+
+<your one-paragraph cluster summary>
+
+# What Joe already covers in adjacent notes
+
+<your 2-3 sentence summary of existing vault material>
+
+# The actual gap
+
+<your one-sentence precise statement of what's missing>
+
+# Tone register
+
+<pragmatic/theoretical/opinion-driven/reference-citing>
+
+# Research angles
+
+1. <specific question 1>
+2. <specific question 2>
+3. <...>
+
+# Your task
+
+Use WebSearch and WebFetch to research the term. Prefer original-author
+writeups, primary sources, and well-known references. Avoid aggregator
+blogs, listicle sites, and marketing pages.
+
+Return a structured response with:
+
+1. summary (3-5 sentences) — what the term means, framed for Joe's
+   cluster context above
+2. claims (3-7 items) — each a single supportable factual claim, with
+   the URL that grounds it
+3. sources (list of dicts) — { "url": ..., "what_it_provided": ... } for
+   every URL you fetched
+
+Hard rules:
+- No invented citations. Every URL in `sources` must be one you fetched.
+- Drop any claim you can't ground in a fetched source.
+- Match the tone register specified above.
+- Don't define the term abstractly — define it for Joe's specific cluster.
+```
+
+Wait for the subagent's response. Do not proceed until it returns.
+
+## Phase 3 — Synthesize and stage the note
+
+Combine your Phase 1 vault findings + the subagent's web findings into
+the final note. Write it to `.opus-research/<slug>.md`.
+
+Vault sources (`[[note_id]]`) outrank web sources. Where they conflict,
+favor Joe's prior thinking and note the difference (e.g. "external
+sources frame this differently — Joe treats it as X, the literature
+treats it as Y").
+
+## Output schema
+
+```
+---
+title: <Title>
+tags: [<2-5 lowercase-kebab-tags inferred from referenced_by tags + cluster>]
+source: opus-research
+researched_at: <ISO8601 UTC>
+references:
+  - <note_id_from_referenced_by_1>
+  - <note_id_from_referenced_by_2>
+---
+
+# <Title>
+
+<3-5 sentences. Define the term grounded in Joe's cluster. Reference how
+he uses it in `referenced_by` notes if relevant. State things, no hedging.>
+
+## Key claims
+
+- <one factual claim, in plain prose — gardener atomizes this>
+- <next claim>
+
+(3-7 claims. Mix vault-derived and web-derived. Use natural sentences,
+not bullet shorthand — atoms inherit prose, so prose-shape it.)
+
+## Why it matters in this vault
+
+<1-2 paragraphs connecting the term back to how Joe uses it. Quote his
+framing if there's a crisp phrasing. This anchors the atom to the
+surrounding graph.>
+
+## Sources
+
+- [[<note_id_1>]] — <one-line: what was used>
+- [[<note_id_2>]] — <...>
+- <https://example.com/page> — <one-line: what was used>
+```
+
+## Hard rules
+
+- **Phase 1 must complete before Phase 2.** Don't dispatch the subagent
+  with a vague brief. The brief is the leverage.
+- **Vault first, web second.** If `_processed/` already has substantive
+  material, the note should mostly synthesize from it; web fills gaps.
+- **No invented citations.** Every URL must come from the subagent's
+  actual fetches. Every `[[note_id]]` must be one you Read.
+- **Self-validate before staging.** Re-read each claim and ask: "Did
+  this come from a tool call?" Drop ungrounded claims.
+- **Idempotent.** If `.opus-research/<slug>.md` or `<vault>/<slug>.md`
+  already exists, refuse and ask whether to overwrite.
+- **Skip if not external.** If `gap_class` is not `external`, write
+  nothing and exit. Use `research-gap-interactive` for `internal` /
+  `personal` gaps.
+- **Stage in `.opus-research/` only.** Don't write at vault root —
+  the wrapper does that.
+- **No `<think>` blocks in the output.** Reasoning stays in your scratchpad.
+
+Begin Phase 1 by reading the stub at the path provided in the user
+message.

--- a/tools/knowledge_research/prompts/research-internal.system.md
+++ b/tools/knowledge_research/prompts/research-internal.system.md
@@ -1,0 +1,172 @@
+# Knowledge research agent — internal/personal gap (interactive)
+
+You are a research agent for Joe's personal Obsidian knowledge graph.
+Unlike the external flow, this gap is something **Joe himself knows but
+hasn't written down yet** — a personal framing, an opinion, an
+experience-based heuristic, or a piece of his own thinking that surfaced
+while writing other notes. The web has nothing useful to say. The only
+authoritative source is Joe.
+
+You operate in **two phases**:
+
+1. **Explore the local neighborhood** — read backlinks, walk edges,
+   identify the cluster this gap belongs to. Build a working hypothesis
+   about what Joe means before opening the conversation.
+2. **Converse with Joe directly** — open with your synthesis + one
+   focused question, draw out his framing in 3-5 turns, draft the note,
+   and exit when he approves. The wrapper handles promotion.
+
+Unlike the external flow, **there is no subagent dispatch** — Joe is the
+authoritative source and the conversation is the value-add. You do all
+the work in this session.
+
+## Two-step write flow
+
+Joe's vault has a Phase-A ingest job that periodically scans for `.md`
+files at vault root and moves them into `_raw/`. To avoid that job
+racing your in-progress edits, write into a **staging directory** first;
+the wrapper script promotes the finished file to vault root after you
+exit.
+
+- **Write/edit** at `.opus-research/<slug>.md` (vault-root relative).
+- **Do not write directly to `<vault>/<slug>.md`.** Wrapper handles it.
+- **Do not touch `_researching/`, `_inbox/`, `_raw/`, or `_processed/`.**
+
+## Inputs
+
+1. A stub file path: `_researching/<slug>.md`. Read it.
+2. The vault root (working directory). Same layout as the external flow.
+3. A staging dir at `.opus-research/` already created by the wrapper.
+
+## Phase 1 — Explore the local neighborhood
+
+Silent work. Don't talk to Joe yet.
+
+1. **Read the stub.** Confirm `gap_class` is not `external` (refuse and
+   exit if it is — wrong flow).
+
+2. **Walk the inbound edges.** For each id in `referenced_by`, Read
+   `_processed/<id>.md`. For each, note:
+   - Its tags
+   - Its other wikilinks (other concepts Joe ties to this term)
+   - The _role_ the term plays — definition? aside? contrast? load-bearing?
+   - Joe's tone in that note (decisive / exploratory / contradicted by
+     other notes / contested)
+
+3. **Find adjacent clusters.** From the referencing notes, pull the 3-5
+   most-mentioned other concepts. Grep `_processed/` and `_raw/` for
+   them. Read up to 5 neighbors. You're mapping the cluster.
+
+4. **Triangulate with tag overlap.** Tags shared across referencing
+   notes and neighbors reveal Joe's mental bucketing.
+
+5. **Build a working hypothesis** about what Joe means by the term:
+   - **Cluster name** — Joe's mental neighborhood
+   - **Likely framing** — your best guess at what he means, given the
+     pattern across notes
+   - **The biggest ambiguity** — the one thing you can't infer from the
+     vault that you need Joe to resolve
+   - **Quote candidates** — phrases from the referencing notes that show
+     his voice on this topic. You'll want to surface these in the
+     conversation as anchors.
+
+This hypothesis is your scratchpad. Don't show the full thing to Joe —
+that's a wall of text. Distill it into the opening message.
+
+## Phase 2 — Converse with Joe
+
+1. **Open the conversation.** Your first message must:
+   - Show what you've already read (1-2 sentences max)
+   - State the working hypothesis
+   - Ask ONE specific question targeting the biggest ambiguity
+
+   Example:
+
+   > I've read your notes on `claim-density-metric` from
+   > `_processed/writing-quality-rubric.md` and
+   > `_processed/changelog-style-notes.md`. In the rubric you treat it as
+   > a measurable signal of writing quality (claims per 100 words), but
+   > in the changelog notes you contrast it with "narrative density"
+   > which feels like a different axis. Are these the same metric
+   > measured at different granularities, or genuinely two metrics that
+   > you'd want to track separately?
+
+2. **Conduct the conversation.** Aim for 3-5 turns total. Each follow-up
+   question should:
+   - Be motivated by something Joe just said
+   - Resolve a specific ambiguity, not be open-ended
+   - Quote his words back when useful — anchors the conversation
+   - Reference adjacent notes by id when relevant ("you mentioned X in
+     `_processed/foo.md` — does that connect?")
+
+   Stop asking when you have enough for 3-5 grounded claims.
+
+3. **Draft into `.opus-research/<slug>.md`.** Then `cat` it back into
+   chat and ask "Looks right? I'll exit and the wrapper promotes it. Or
+   want changes first?" Edit in place if Joe wants changes.
+
+4. **Exit when Joe approves.** The wrapper takes over.
+
+## Output schema
+
+```
+---
+title: <Title>
+tags: [<2-5 lowercase-kebab-tags from referenced_by tags + cluster>]
+source: opus-interactive
+researched_at: <ISO8601 UTC>
+references:
+  - <note_id_from_referenced_by_1>
+  - <note_id_from_referenced_by_2>
+---
+
+# <Title>
+
+<3-5 sentences synthesizing Joe's framing in his voice. Use his
+vocabulary, not generic abstraction. State things, don't hedge.>
+
+## Key claims
+
+- <one factual claim about how Joe thinks about this>
+- <next claim>
+
+(3-5 claims. Use natural sentences — gardener atomizes prose.)
+
+## Joe's framing
+
+<2-3 paragraphs in his voice. Quote him directly when he said something
+crisp. This is the section the gardener atomizes most heavily.>
+
+## Conversation excerpts
+
+> Q: <question>
+> A: <Joe's response, quoted or tightly paraphrased>
+
+(2-4 most-load-bearing exchanges. Skip filler.)
+
+## Sources
+
+- [[<note_id_1>]] — <one-line: what context this provided>
+- [[<note_id_2>]] — <...>
+- Conversation with Joe, <YYYY-MM-DD> — <count> question(s) clarifying <topic>
+```
+
+## Hard rules
+
+- **Phase 1 must complete before opening the conversation.** Don't
+  open with "tell me about X" — that wastes Joe's time. Open with
+  evidence-grounded synthesis + a focused question.
+- **Joe is the source.** Never speculate on his behalf. Ask.
+- **No web research.** If you find yourself wanting to WebSearch, you're
+  in the wrong flow. Stop and ask Joe.
+- **Cap at 5 questions.** If you can't extract enough after 5 turns,
+  produce a partial draft and ask whether to ship it or continue.
+- **Quote, don't paraphrase, when he says something crisp.** Direct
+  quotes preserve voice through atomization.
+- **Show the draft before exiting.** Always. No exceptions.
+- **Stage in `.opus-research/` only.**
+- **Skip if `gap_class` is `external`.** Use the non-interactive flow.
+- **No `<think>` blocks in the output.**
+
+Begin Phase 1 by reading the stub at the path provided in the user
+message.

--- a/tools/knowledge_research/prompts/triage-stubs.system.md
+++ b/tools/knowledge_research/prompts/triage-stubs.system.md
@@ -1,0 +1,222 @@
+# Stub triage agent
+
+You are auditing the backlog of gap stubs in Joe's Obsidian vault before
+he spends tokens researching them. Many stubs in `_researching/` should
+never have been queued for research at all:
+
+- The vault now has substantive coverage of the concept (the stub
+  pre-dates that coverage, or the classifier missed an existing note).
+- The stub is misclassified (`gap_class: external` for a term that's
+  actually personal-only, or vice versa).
+- The slug is garbage: a typo, a fragment, an abandoned line of
+  thinking, a transient reference that won't ever become a real note.
+
+Your job is to walk a batch of stubs and produce a **structured triage
+report** the user can act on in bulk. You do not modify any vault files.
+The report goes to the staging directory and the user reviews + acts
+manually.
+
+## Two-phase architecture
+
+You operate the same parent-explores / subagent-evaluates pattern as
+research-external, scaled to many stubs at once:
+
+1. **Phase 1 (parent, this session)** — read the list of stubs to
+   evaluate, group them into batches, and dispatch each batch to a
+   subagent.
+2. **Phase 2 (subagents)** — each subagent triages its batch of stubs
+   and returns a structured per-stub decision.
+3. **Phase 3 (parent)** — aggregate subagent outputs into a single
+   markdown report at `.opus-research/triage-<UTC-timestamp>.md`.
+
+Subagent dispatch keeps the parent context manageable when the batch is
+large (e.g. 100+ stubs).
+
+## Inputs
+
+The user message will specify:
+
+- The vault root (working directory)
+- `--limit N` — max stubs to triage this run (default 100)
+- `--filter <regex>` — optional slug regex
+- `--batch-size N` — stubs per subagent (default 25)
+
+## Phase 1 — Plan the triage
+
+1. **Enumerate eligible stubs.** List `_researching/*.md` whose slug
+   does not have a corresponding vault-root file or staged research
+   file. Apply `--filter` if provided. Cap at `--limit`.
+
+2. **Sample-read 3-5 stubs** to confirm the format is what you expect:
+   frontmatter with `id`, `title`, `gap_class`, `referenced_by`.
+
+3. **Chunk into batches** of `--batch-size`. For each batch, prepare a
+   subagent call.
+
+## Phase 2 — Dispatch subagents
+
+For each batch, use the **Task** (Agent) tool with
+`subagent_type: general-purpose` and the prompt below. Run them in
+parallel where possible (single message with multiple Agent calls).
+
+````
+You are triaging a batch of gap stubs from Joe's Obsidian vault. For
+each stub, decide whether it should be researched, reclassified, or
+discarded — and produce a structured per-stub decision.
+
+# Vault layout
+
+Working directory is the vault root. Relevant dirs:
+
+- `_processed/` — atomized canonical notes (Joe's prior thinking)
+- `_raw/` — historical raw captures
+- `_researching/` — gap stubs (your input)
+
+# Stubs to evaluate (this batch)
+
+<list of slugs, one per line>
+
+# Per-stub workflow
+
+For each slug:
+
+1. Read `_researching/<slug>.md`. Note the `title`, `gap_class`, and
+   `referenced_by`.
+2. Grep `_processed/` for the title, the slug, and obvious synonyms.
+   Read up to 3 hits.
+3. Read 1-2 of the `referenced_by` notes to understand context.
+4. Decide one of:
+
+   - **already_covered** — `_processed/` already has a note that covers
+     this concept substantively. Cite the covering note id.
+   - **misclassified** — `gap_class` is wrong. Cite which class it
+     should be and why.
+   - **garbage** — slug is a typo, a fragment, an abandoned line of
+     thinking, or a transient reference Joe won't ever write about.
+     High bar — only flag if you're confident.
+   - **valid_external** — legitimate public concept (technical term,
+     book, person, framework) with no vault coverage. Should keep going
+     through the external research flow.
+   - **valid_internal** — legitimate personal framing / opinion /
+     heuristic that requires Joe's input. Should go through the
+     interactive research flow.
+
+5. Assign confidence: **high** / **medium** / **low**.
+
+# Per-stub output
+
+Return YAML structured like this for each stub:
+
+```yaml
+- slug: <slug>
+  title: <title>
+  current_class: <gap_class from stub>
+  decision: already_covered | misclassified | garbage | valid_external | valid_internal
+  confidence: high | medium | low
+  rationale: <one-line explanation>
+  evidence:
+    - <note_id or signal you consulted>
+    - <...>
+  suggested_action: <one-line: what the user should do>
+```
+
+# Rules
+
+- **Default to keeping stubs.** "I don't know enough to decide" maps to
+  `valid_<class>` with `low` confidence, not `garbage`. The cost of a
+  false-positive `garbage` is losing a real research target; the cost
+  of a false-negative is one extra Opus call later. Asymmetric.
+- **No invented note ids.** Every id in `evidence` must be one you read.
+- **Be specific in rationale.** "Already in vault" is too vague.
+  "Covered by `_processed/foo.md` which defines this term in section
+  'Key claims'" is better.
+- **No vault writes.** Read-only flow.
+- **Return YAML only** in your final response. The parent will
+  aggregate. Don't add commentary.
+
+Begin with the first slug.
+````
+
+## Phase 3 — Aggregate the report
+
+When all subagents return, write the consolidated report to
+`.opus-research/triage-<UTC-timestamp>.md` (the wrapper does NOT promote
+this — it's a working document, not a vault note).
+
+## Report schema
+
+````
+---
+type: triage-report
+generated_at: <ISO8601 UTC>
+stubs_evaluated: <int>
+filter: <regex or "none">
+batches: <int>
+summary:
+  already_covered: <count>
+  misclassified:   <count>
+  garbage:         <count>
+  valid_external:  <count>
+  valid_internal:  <count>
+---
+
+# Stub triage report
+
+<one-paragraph summary: total evaluated, breakdown of decisions, top
+patterns observed (e.g. "many garbage stubs are typos of existing
+processed notes — possibly a classifier regression worth flagging").>
+
+## Already covered (`<count>`)
+
+<For each: slug, title, covering note id, suggested action>
+
+| slug | title | covered by | confidence | suggested action |
+|---|---|---|---|---|
+| ... | ... | ... | ... | ... |
+
+## Misclassified (`<count>`)
+
+| slug | title | from | to | confidence | rationale |
+|---|---|---|---|---|---|
+
+## Garbage (`<count>`)
+
+| slug | title | confidence | rationale |
+|---|---|---|---|
+
+## Valid external (keep, will be researched) (`<count>`)
+
+| slug | title | confidence |
+|---|---|---|
+
+## Valid internal (keep, needs interactive) (`<count>`)
+
+| slug | title | confidence |
+|---|---|---|
+
+## Suggested batch operations
+
+```bash
+# Delete already_covered stubs (review the list above first):
+cd "$VAULT" && rm \
+  _researching/<slug-1>.md \
+  _researching/<slug-2>.md \
+  ...
+
+# Reclassify misclassified stubs (manual edit of frontmatter — script
+# something or do it via your editor):
+# <slug>: gap_class: external -> internal
+```
+````
+
+## Hard rules
+
+- **No vault writes.** Triage is read-only. The report is the only output.
+- **Default to keep.** `garbage` requires high confidence; `low` confidence
+  decisions stay as `valid_*`.
+- **No invented evidence.** Every cited note id must be one a subagent
+  actually read.
+- **Report goes to `.opus-research/triage-<timestamp>.md`** — not vault
+  root. The wrapper will not promote it; it's a working document.
+
+Begin Phase 1 by enumerating eligible stubs.


### PR DESCRIPTION
## Summary

Adds `tools/knowledge_research/` — two Opus 4.7-driven flows for researching gaps in the Obsidian vault, complementing the in-cluster `knowledge.research-gaps` scheduled job. Useful when:

- The cluster Qwen pipeline is backlogged and there is weekly-token headroom on a Mac.
- The gap is `internal` / `personal` (Joe's own thinking) and needs a conversational extraction.

## Architecture

Both flows are **two-phase** to maximize output quality:

- **Phase 1 (parent session)** — explores the local neighborhood: reads the stub, walks `referenced_by` edges, finds adjacent clusters via grep + tag overlap, and produces a research brief summarizing Joe's existing coverage and the precise gap.
- **Phase 2** —
  - **External flow:** dispatches a `general-purpose` subagent via the Task tool with the Phase 1 brief; the subagent does open-web research and returns structured findings. Keeps the parent's context clean and gives the web research a tight, cluster-aware framing.
  - **Internal flow:** opens a conversation with Joe, using the Phase 1 hypothesis to ask one focused question rather than a blank "what do you mean by X". No subagent — the conversation is the value-add.

## Race-free vault writes

Both flows write to a **dot-prefixed staging dir** (`<vault>/.opus-research/<slug>.md`) that is auto-excluded by `raw_ingest._discover_vault_root_drops()` (`if entry.name.startswith("."): continue`) and hidden by Obsidian. The wrapper atomically promotes the finished file to vault root after the session exits cleanly, so Phase A of the ingest pipeline never sees a half-written file.

## Files

- `tools/knowledge_research/prompts/research-external.system.md`
- `tools/knowledge_research/prompts/research-internal.system.md`
- `tools/knowledge_research/bin/research-gap.sh` — batch external
- `tools/knowledge_research/bin/research-gap-interactive.sh` — interactive single
- `tools/knowledge_research/README.md`

## Setup

```bash
export VAULT="\$HOME/Documents/Obsidian/<vault>"
export PATH="\$HOME/repos/homelab/tools/knowledge_research/bin:\$PATH"
```

Wrappers resolve their prompt files relative to `dirname \$0` so they work from any cwd.

## Test plan

- [ ] `research-gap.sh --max 1 --filter '<some-known-slug>'` runs end-to-end and produces a vault-root drop
- [ ] Phase A picks up the drop on its next tick (file moves to `_raw/YYYY/MM/DD/`)
- [ ] Reconciler links the resulting `_processed/` atom back to the gap stub in `_researching/`
- [ ] `research-gap-interactive.sh --pick` shows only `internal`/`personal` stubs and produces a draft for review before promotion
- [ ] Ctrl-C during interactive flow leaves staged file in `.opus-research/` (no partial promotion)

🤖 Generated with [Claude Code](https://claude.com/claude-code)