### PR TITLE
feat(semgrep): add no-hardcoded-claude-model-subprocess rule and hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -88,6 +88,11 @@
             "type": "command",
             "command": "bazel/tools/hooks/check-deployment-component-label.sh",
             "timeout": 10
+          },
+          {
+            "type": "command",
+            "command": "bazel/tools/hooks/check-hardcoded-model-subprocess.sh",
+            "timeout": 10
           }
         ]
       }

--- a/bazel/semgrep/rules/python/no-hardcoded-claude-model-subprocess.py
+++ b/bazel/semgrep/rules/python/no-hardcoded-claude-model-subprocess.py
@@ -1,0 +1,60 @@
+# Tests for no-hardcoded-claude-model-subprocess rule.
+# Flags create_subprocess_exec calls where '--model' is followed by a string literal.
+import asyncio
+import os
+
+
+# ruleid: no-hardcoded-claude-model-subprocess
+async def bad_hardcoded_model_exec():
+    await asyncio.create_subprocess_exec(
+        "claude",
+        "--model",
+        "claude-opus-4-5",
+    )
+
+
+# ruleid: no-hardcoded-claude-model-subprocess
+async def bad_hardcoded_model_exec_multiarg():
+    proc = await asyncio.create_subprocess_exec(
+        "claude",
+        "--no-color",
+        "--model",
+        "claude-sonnet-4-5",
+        "--max-turns",
+        "10",
+    )
+    return proc
+
+
+# ok: model name is read from an environment variable
+async def ok_model_from_env():
+    model = os.environ.get("CLAUDE_MODEL", "claude-opus-4-5")
+    await asyncio.create_subprocess_exec(
+        "claude",
+        "--model",
+        model,
+    )
+
+
+# ok: model name comes from a variable (computed elsewhere)
+async def ok_model_variable():
+    model = get_model_name()
+    await asyncio.create_subprocess_exec(
+        "claude",
+        "--model",
+        model,
+    )
+
+
+# ok: no --model flag at all
+async def ok_no_model_flag():
+    await asyncio.create_subprocess_exec(
+        "claude",
+        "--no-color",
+        "--max-turns",
+        "5",
+    )
+
+
+def get_model_name() -> str:
+    return os.environ.get("CLAUDE_MODEL", "claude-opus-4-5")

--- a/bazel/semgrep/rules/python/no-hardcoded-claude-model-subprocess.yaml
+++ b/bazel/semgrep/rules/python/no-hardcoded-claude-model-subprocess.yaml
@@ -1,0 +1,27 @@
+rules:
+  - id: no-hardcoded-claude-model-subprocess
+    patterns:
+      - pattern: asyncio.create_subprocess_exec(..., "--model", $MODEL, ...)
+      - metavariable-regex:
+          metavariable: $MODEL
+          regex: ^["']
+    message: >
+      `create_subprocess_exec` is invoked with a hardcoded `--model` string literal.
+      Hardcoded model names prevent runtime model selection and require a code change to
+      upgrade or switch models. Read the model name from an environment variable instead:
+      `model = os.environ.get("CLAUDE_MODEL", "claude-opus-4-5")`.
+    languages: [python]
+    severity: WARNING
+    metadata:
+      category: maintainability
+      subcategory: configuration
+      confidence: HIGH
+      likelihood: MEDIUM
+      impact: MEDIUM
+      technology: [python, asyncio, claude]
+      description: hardcoded Claude model name in subprocess args — use an env var so the model can change without redeploy
+    paths:
+      exclude:
+        - "*_test.py"
+        - "test_*.py"
+        - "tests/**"

--- a/bazel/tools/hooks/check-hardcoded-model-subprocess.sh
+++ b/bazel/tools/hooks/check-hardcoded-model-subprocess.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# PreToolUse hook: warn when Write/Edit content contains create_subprocess_exec
+# with a hardcoded '--model' string literal argument.
+#
+# Using a hardcoded model name means the model can only be changed by editing
+# and redeploying code. Reading the model from an env var (e.g. CLAUDE_MODEL)
+# allows runtime configuration without a code change.
+#
+# Input: JSON on stdin from Claude Code hook system
+# Exit 0: allow (warnings emitted on stderr — advisory only)
+# Exit 2: block (not used)
+
+set -euo pipefail
+
+INPUT=$(cat)
+
+# Only check Python files
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
+if [[ -z "$FILE_PATH" ]]; then
+	exit 0
+fi
+if [[ "$FILE_PATH" != *.py ]]; then
+	exit 0
+fi
+
+# Get the content being written (Write tool) or the replacement string (Edit tool)
+NEW_CONTENT=$(echo "$INPUT" | jq -r '.tool_input.new_string // .tool_input.content // empty')
+if [[ -z "$NEW_CONTENT" ]]; then
+	exit 0
+fi
+
+# Only relevant if create_subprocess_exec is used
+if ! echo "$NEW_CONTENT" | grep -q 'create_subprocess_exec'; then
+	exit 0
+fi
+
+# Check for '--model' followed (on the same line or the next) by a string literal.
+# This uses grep with -A1 (after context) to handle multi-line argument style.
+if echo "$NEW_CONTENT" | grep -qE '"--model"|'"'"'--model'"'"; then
+	# Check if there's a string literal near the --model flag.
+	# We look for '--model' on a line and either:
+	#   a) a string literal following it on the same line, or
+	#   b) a string literal on the immediately following line.
+	HAS_ISSUE=$(echo "$NEW_CONTENT" | awk '
+		/create_subprocess_exec/ { in_call = 1 }
+		in_call && /["'"'"']--model["'"'"']/ {
+			# Same line: --model followed by a string literal?
+			if (/["'"'"']--model["'"'"'][[:space:]]*,[[:space:]]*["'"'"']/) {
+				print "yes"; exit
+			}
+			saw_model = 1
+			next
+		}
+		saw_model {
+			# Next line: is it a string literal argument?
+			if (/^[[:space:]]*["'"'"']/) {
+				print "yes"; exit
+			}
+			saw_model = 0
+		}
+	')
+
+	if [[ "$HAS_ISSUE" == "yes" ]]; then
+		cat >&2 <<-EOF
+			WARNING: create_subprocess_exec called with a hardcoded '--model' string literal.
+
+			File: $FILE_PATH
+
+			Hardcoded model names require a code change + redeploy to switch models.
+			Read the model from an environment variable instead:
+
+			  model = os.environ.get("CLAUDE_MODEL", "claude-opus-4-5")
+			  await asyncio.create_subprocess_exec("claude", "--model", model, ...)
+
+			The semgrep rule 'no-hardcoded-claude-model-subprocess' will flag this in CI.
+		EOF
+	fi
+fi
+
+exit 0

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.53.14
+version: 0.53.15
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.53.14
+      targetRevision: 0.53.15
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/knowledge/research_validator.py
+++ b/projects/monolith/knowledge/research_validator.py
@@ -22,6 +22,10 @@ logger = logging.getLogger(__name__)
 
 VALIDATOR_VERSION = "sonnet-4-6@v1"
 
+# Model is read from the environment so it can be overridden without a code
+# change (e.g. to switch between claude-sonnet-4-5 and claude-sonnet-4-6).
+_CLAUDE_MODEL = os.getenv("CLAUDE_MODEL", "sonnet")
+
 _VALIDATE_TIMEOUT_SECS = 180
 _JSON_BLOCK_RE = re.compile(r"\{[\s\S]*\}")
 
@@ -128,7 +132,7 @@ async def validate_research(
         "--print",
         "--dangerously-skip-permissions",
         "--model",
-        "sonnet",
+        _CLAUDE_MODEL,
         "-p",
         prompt,
         stdout=asyncio.subprocess.PIPE,


### PR DESCRIPTION
## Summary

- **New semgrep rule** `no-hardcoded-claude-model-subprocess`: catches `asyncio.create_subprocess_exec` calls where `'--model'` is followed by a string literal instead of a variable/env-var reference; excludes test files
- **Test fixture** `bazel/semgrep/rules/python/no-hardcoded-claude-model-subprocess.py`: 2 `# ruleid:` bad cases + 3 `# ok:` good cases covering env-var, variable, and no-flag scenarios
- **PreToolUse hook** `check-hardcoded-model-subprocess.sh`: advisory-only (exit 0) warning emitted to stderr when a `.py` Write/Edit contains `create_subprocess_exec` with a literal `--model` arg; registered in `.claude/settings.json` under the `Write|Edit` matcher

## Why

Hardcoded Claude model names in subprocess args require a code change + redeploy to switch models. Reading from an env var (e.g. `CLAUDE_MODEL`) allows runtime configuration.

## Test plan

- [ ] CI semgrep `python_rules_test` picks up the new fixture via `glob(["python/*.py"])` and verifies the 2 bad / 3 ok annotations
- [ ] Hook script is advisory-only (always exits 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)