### PR TITLE
docs(ships): document that deployed chart/app/namespace are named marine

### DIFF
--- a/projects/ships/README.md
+++ b/projects/ships/README.md
@@ -13,3 +13,11 @@ Real-time AIS vessel tracking with a MapLibre GL frontend.
 | **deploy**   | ArgoCD Application, kustomization, and cluster-specific values    |
 
 Detailed component documentation exists in [backend/README.md](backend/README.md), [ingest/README.md](ingest/README.md), and [chart/README.md](chart/README.md).
+
+## Deployment Note
+
+The Helm chart, ArgoCD Application, and Kubernetes namespace are all named **`marine`** (not `ships`). The `projects/ships/` directory is the source-code convention; the deployed name differs.
+
+- ArgoCD app: `argocd app get marine`
+- Namespace: `kubectl -n marine`
+- OCI chart: `ghcr.io/jomcgi/homelab/charts/marine`


### PR DESCRIPTION
## Summary

- The Helm chart, ArgoCD Application, and Kubernetes namespace are all named `marine`, not `ships`
- Add a **Deployment Note** section to the README so operators know to use `argocd app get marine` and `kubectl -n marine`
- Without this, anyone looking up `ships` in ArgoCD or the cluster would find nothing

## Changes

`projects/ships/README.md` — new Deployment Note section with correct ArgoCD app name, namespace, and OCI chart path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)