### PR TITLE
docs(trips): fix elevation profiles claim and add wildlife detection

### DIFF
--- a/projects/trips/README.md
+++ b/projects/trips/README.md
@@ -7,7 +7,7 @@ Photo-based GPS trip logging with elevation enrichment.
 | Component    | Description                                                                                |
 | ------------ | ------------------------------------------------------------------------------------------ |
 | **backend**  | FastAPI server that replays trip data from NATS JetStream and serves REST + WebSocket APIs |
-| **frontend** | Timeline view with day-by-day maps and elevation profiles                                  |
-| **tools**    | CLI tools for image ingestion with EXIF extraction, elevation enrichment, trip point management, KML route import, and GoPro camera control |
+| **frontend** | Timeline view with day-by-day maps and per-day elevation stats (ascent, descent, min/max)  |
+| **tools**    | CLI tools for image ingestion with EXIF extraction, elevation enrichment, trip point management, KML route import, wildlife detection inference (`detect-wildlife`), and GoPro camera control |
 | **chart**    | Helm chart for Kubernetes deployment                                                       |
 | **deploy**   | ArgoCD Application, kustomization, and cluster-specific values                             |


### PR DESCRIPTION
## Summary

- The README said the frontend has "elevation profiles" — no such chart/graph UI exists; the frontend shows elevation *stats* (ascent/descent/min/max text values) in DayStatsCard
- The tools description omitted wildlife detection as the primary purpose of `detect-wildlife/`; GoPro camera control is a sub-feature, not the main function

## Changes

`projects/trips/README.md` — two table row corrections in the Overview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)