### PR TITLE
fix(tools): -- separator before prompt arg in knowledge_research wrappers

### DIFF
--- a/tools/knowledge_research/bin/research-gap-interactive.sh
+++ b/tools/knowledge_research/bin/research-gap-interactive.sh
@@ -122,6 +122,7 @@ claude \
 	--model claude-opus-4-7 \
 	--append-system-prompt "$(cat "$PROMPT_FILE")" \
 	--add-dir "$VAULT" \
+	-- \
 	"Research the gap at \`_researching/${SLUG}.md\`. Vault root is the current working directory. Stage your output at \`.opus-research/${SLUG}.md\` per the system prompt — do not write at vault root, the wrapper handles promotion. Begin with your synthesis + first question."
 rc=$?
 set -e

--- a/tools/knowledge_research/bin/research-gap.sh
+++ b/tools/knowledge_research/bin/research-gap.sh
@@ -100,6 +100,7 @@ for stub in _researching/*.md; do
 		--model claude-opus-4-7 \
 		--append-system-prompt "$(cat "$PROMPT_FILE")" \
 		--add-dir "$VAULT" \
+		-- \
 		"Research the gap at \`_researching/${slug}.md\`. Vault root is the current working directory. Stage your output at \`.opus-research/${slug}.md\` per the system prompt — do not write at vault root, the wrapper handles promotion."; then
 		count=$((count + 1))
 	else

--- a/tools/knowledge_research/bin/triage-stubs.sh
+++ b/tools/knowledge_research/bin/triage-stubs.sh
@@ -104,6 +104,7 @@ claude --print \
 	--model claude-opus-4-7 \
 	--append-system-prompt "$(cat "$PROMPT_FILE")" \
 	--add-dir "$VAULT" \
+	-- \
 	"Triage gap stubs in this vault. Working directory is the vault root. Process up to $to_process stubs in batches of $BATCH_SIZE.${FILTER:+ Filter slugs by regex: $FILTER.} Write the consolidated report to \`.opus-research/triage-$ts.md\` per the system prompt."
 
 if [ -f "$report_path" ]; then


### PR DESCRIPTION
## Bug

All three knowledge_research wrappers (`triage-stubs.sh`, `research-gap.sh`, `research-gap-interactive.sh`) error on every invocation:

```
Error: Input must be provided either through stdin or as a prompt argument when using --print
```

## Root cause

The `claude` CLI's `--add-dir <directories...>` flag is **variadic**. When the prompt argument follows `--add-dir` as a trailing positional, commander.js consumes it as a second directory rather than as the prompt:

```
claude --print --add-dir "$VAULT" "Triage gap stubs..."
                          ^^^^^^^^ ^^^^^^^^^^^^^^^^^^^
                          both consumed by --add-dir variadic
```

The prompt never reaches claude, hence the "Input must be provided" error.

## Fix

Add `--` before the prompt to terminate option parsing. Standard POSIX-ish convention, supported by commander.js:

```
claude --print --add-dir "$VAULT" -- "Triage gap stubs..."
                                  ^^^ stops --add-dir consumption
```

Applied to all three wrappers. Three-line diff total.

## Verification

```bash
$ claude --print --model claude-haiku-4-5-20251001 --add-dir /tmp -- "Reply with the single word: ARG"
ARG
```

Without `--`:

```bash
$ claude --print --model claude-haiku-4-5-20251001 --add-dir /tmp "Reply..."
Error: Input must be provided either through stdin or as a prompt argument when using --print
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)