### PR TITLE
chore: extend scheduler TTLs and bump vLLM concurrency

### DIFF
--- a/projects/agent_platform/inference/deploy/Chart.yaml
+++ b/projects/agent_platform/inference/deploy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: inference
 description: A Helm chart for LLM inference (llama.cpp and vLLM backends)
 type: application
-version: 2.5.0
+version: 2.5.1
 appVersion: "b5270"
 keywords:
   - llm

--- a/projects/agent_platform/inference/deploy/values-prod.yaml
+++ b/projects/agent_platform/inference/deploy/values-prod.yaml
@@ -190,7 +190,7 @@ vllm:
     - "--reasoning-config"
     - '{"reasoning_start_str": "<think>", "reasoning_end_str": "</think>"}'
     - "--max-num-seqs"
-    - "1"
+    - "3"
     - "--kv-cache-dtype"
     - "fp8"
 

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.54.0
+version: 0.54.1
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chat/changelog.py
+++ b/projects/monolith/chat/changelog.py
@@ -173,7 +173,7 @@ async def run_changelog_iteration(
 
     since = datetime.now(timezone.utc) - timedelta(hours=config.interval_hours)
 
-    async with httpx.AsyncClient(timeout=httpx.Timeout(30.0)) as client:
+    async with httpx.AsyncClient(timeout=httpx.Timeout(600.0)) as client:
         commits = await _fetch_commits_since(
             client, config.github_repo, github_token, since
         )

--- a/projects/monolith/chat/summarizer.py
+++ b/projects/monolith/chat/summarizer.py
@@ -292,7 +292,7 @@ def on_startup(
                 name=f"chat.changelog.{cfg.name}",
                 interval_secs=cfg.interval_hours * 3600,
                 handler=_make_handler(cfg),
-                ttl_secs=300,
+                ttl_secs=1200,
             )
 
 
@@ -302,7 +302,7 @@ _RETRYABLE_STATUS_CODES = {502, 503, 504}
 def build_llm_caller(base_url: str | None = None) -> Callable[[str], Awaitable[str]]:
     """Create an async callable that sends a prompt to Qwen via llama.cpp."""
     url = base_url or os.environ.get("LLAMA_CPP_URL", "")
-    client = httpx.AsyncClient(timeout=httpx.Timeout(60.0))
+    client = httpx.AsyncClient(timeout=httpx.Timeout(600.0))
 
     async def call_llm(prompt: str, *, max_retries: int = 3) -> str:
         last_exc: Exception | None = None

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.54.0
+      targetRevision: 0.54.1
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/knowledge/service.py
+++ b/projects/monolith/knowledge/service.py
@@ -17,15 +17,16 @@ logger = logging.getLogger(__name__)
 
 VAULT_ROOT_ENV = "VAULT_ROOT"
 DEFAULT_VAULT_ROOT = "/vault"
-# 5-minute reconcile cycle. The companion _TTL_SECS=600 ensures at
-# most one missed run before alerting fires (the scheduler considers
-# a job stale after ttl_secs).
+# 5-minute reconcile cycle. _TTL_SECS is the lock-lease: a worker holding
+# the row past this is treated as crashed and the lock can be reclaimed.
+# We keep it generous (20m) so LLM-heavy handlers can finish without being
+# preempted; the tradeoff is slower recovery if a pod actually dies mid-job.
 _INTERVAL_SECS = 300
-_TTL_SECS = 600
+_TTL_SECS = 1200
 _BACKUP_INTERVAL_SECS = 900  # 15 minutes
-_BACKUP_TTL_SECS = 600  # 10 minute timeout
+_BACKUP_TTL_SECS = 1200  # 20 minute lock-lease (git push can be slow)
 _INGEST_INTERVAL_SECS = 300
-_INGEST_TTL_SECS = 600
+_INGEST_TTL_SECS = 1200
 _CLASSIFY_INTERVAL_SECS = 60  # 1-minute tick
 # Scheduler reclaims jobs whose lock-lease exceeds ttl_secs. Must comfortably
 # exceed gap_classifier._CLASSIFY_TIMEOUT_SECS (300s) — otherwise a long-
@@ -34,7 +35,7 @@ _CLASSIFY_INTERVAL_SECS = 60  # 1-minute tick
 _CLASSIFY_TTL_SECS = 360  # 300s subprocess timeout + 60s headroom
 _CLASSIFY_BATCH_SIZE = 10
 _RESEARCH_INTERVAL_SECS = 300
-_RESEARCH_TTL_SECS = 600  # 5min interval + 5min headroom (Qwen + Sonnet round-trips)
+_RESEARCH_TTL_SECS = 1200  # 20min lock-lease (Qwen + Sonnet round-trips can be slow)
 _GIT_READY_SENTINEL = ".git-ready"
 _SYNC_READY_SENTINEL = ".sync-ready"
 _GIT_AUTHOR = b"vault-backup <vault-backup@monolith.local>"

--- a/projects/monolith/knowledge/service_test.py
+++ b/projects/monolith/knowledge/service_test.py
@@ -620,7 +620,7 @@ class TestClassifyGapsHandler:
             select(ScheduledJob).where(ScheduledJob.name == "knowledge.research-gaps")
         ).scalar_one()
         assert job.interval_secs == 300
-        assert job.ttl_secs == 600
+        assert job.ttl_secs == 1200  # was 600
 
     @pytest.mark.asyncio
     async def test_classify_gaps_handler_skips_when_no_token(

--- a/projects/monolith/shared/scheduler.py
+++ b/projects/monolith/shared/scheduler.py
@@ -27,7 +27,7 @@ class ScheduledJob(SQLModel, table=True):
     last_status: str | None = None
     locked_by: str | None = None
     locked_at: datetime | None = None
-    ttl_secs: int = Field(default=300)
+    ttl_secs: int = Field(default=1200)
 
 
 # Handler signature: receives a Session, returns optional next_run_at override.
@@ -45,7 +45,7 @@ def register_job(
     name: str,
     interval_secs: int,
     handler: Handler,
-    ttl_secs: int = 300,
+    ttl_secs: int = 1200,
 ) -> None:
     """Register a job handler and upsert its row in the database."""
     _registry[name] = handler

--- a/projects/monolith/shared/scheduler_test.py
+++ b/projects/monolith/shared/scheduler_test.py
@@ -80,14 +80,14 @@ class TestScheduledJobDefaults:
         assert job.locked_by is None
         assert job.locked_at is None
 
-    def test_ttl_secs_defaults_to_300(self):
-        """ttl_secs defaults to 300 when not provided."""
+    def test_ttl_secs_defaults_to_1200(self):
+        """ttl_secs defaults to 1200 (20m) when not provided."""
         job = ScheduledJob(
             name="test",
             interval_secs=60,
             next_run_at=datetime.now(timezone.utc),
         )
-        assert job.ttl_secs == 300
+        assert job.ttl_secs == 1200
 
     def test_explicit_ttl_overrides_default(self):
         """Explicitly provided ttl_secs overrides the default."""
@@ -153,7 +153,7 @@ class TestRegisterJobNew:
         job = session.get(ScheduledJob, "fresh")
         assert job is not None
         assert job.interval_secs == 30
-        assert job.ttl_secs == 300
+        assert job.ttl_secs == 1200
         assert job.next_run_at is not None
 
     def test_new_job_uses_custom_ttl(self, session):


### PR DESCRIPTION
## Summary

- **Scheduler TTLs**: raised LLM-heavy jobs (knowledge garden/reconcile/ingest/research-gaps/vault-backup, chat changelog) from 5–10m to **20m**, plus the `shared/scheduler.py` default. The TTL is the lock-lease — it controls how long a worker can hold a row before another worker considers them dead. 20m gives Qwen-driven handlers room to finish without preemption.
- **HTTP client timeouts**: bumped `chat/summarizer.py` `build_llm_caller` from `60s` → `600s` and `chat/changelog.py` from `30s` → `600s`. **This is the actual fix** for the `chat.summarizer` httpx errors — the scheduler TTL never governed those.
- **vLLM `--max-num-seqs`**: `1` → `3` in `inference/deploy/values-prod.yaml` to enable parallel chat-channel summarization. KV fit will be verified from vLLM startup logs after rollout (Qwen3.5 hybrid Mamba+attn — pure-transformer KV math doesn't apply).

Untouched on purpose: `home.calendar_poll` (just a Google Calendar poll, 120s is fine), `chat.summary_generation` (already 30m), `_CLASSIFY_TTL_SECS` (paired to a subprocess timeout — see existing comment).

## Test plan

- [ ] CI passes (scheduler tests updated for new default of 1200)
- [ ] After deploy, watch vLLM startup logs in inference namespace — confirm it accepts `--max-num-seqs=3` (no KV-cache rejection); roll back to 2 if it fails to start
- [ ] Watch `chat.summarizer` job in monolith for absence of httpx timeout traces
- [ ] Spot-check `scheduler-list` via the homelab CLI to confirm new ttl_secs values are persisted on next registration

🤖 Generated with [Claude Code](https://claude.com/claude-code)