### PR TITLE
feat(chat): mirror discord summaries to obsidian vault

### DIFF
--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -592,6 +592,17 @@ py_test(
 )
 
 py_test(
+    name = "chat_vault_export_test",
+    srcs = ["chat/vault_export_test.py"],
+    imports = ["."],
+    deps = [
+        ":monolith_backend",
+        "@pip//pytest",
+        "@pip//pyyaml",
+    ],
+)
+
+py_test(
     name = "main_extra_test",
     srcs = ["app/main_extra_test.py"],
     imports = ["."],

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.53.15
+version: 0.54.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chat/summarizer.py
+++ b/projects/monolith/chat/summarizer.py
@@ -10,6 +10,7 @@ import httpx
 from sqlmodel import Session, select
 
 from chat.models import ChannelSummary, Message, UserChannelSummary
+from chat.vault_export import write_channel_summary, write_user_summary
 
 logger = logging.getLogger(__name__)
 
@@ -80,12 +81,13 @@ async def generate_summaries(
                 )
 
             summary_text = await llm_call(prompt)
+            now = datetime.now(timezone.utc)
 
             if existing:
                 existing.summary = summary_text
                 existing.username = username
                 existing.last_message_id = new_max_id
-                existing.updated_at = datetime.now(timezone.utc)
+                existing.updated_at = now
                 session.add(existing)
             else:
                 session.add(
@@ -98,6 +100,14 @@ async def generate_summaries(
                     )
                 )
             session.commit()
+            write_user_summary(
+                channel_id=channel_id,
+                user_id=user_id,
+                username=username,
+                summary=summary_text,
+                last_message_id=new_max_id,
+                updated_at=now,
+            )
         except Exception:
             logger.exception(
                 "Failed to generate summary for %s/%s", channel_id, username
@@ -171,11 +181,12 @@ async def generate_channel_summaries(
 
             summary_text = await llm_call(prompt)
 
+            now = datetime.now(timezone.utc)
             if existing:
                 existing.summary = summary_text
                 existing.last_message_id = new_max_id
                 existing.message_count = total_count
-                existing.updated_at = datetime.now(timezone.utc)
+                existing.updated_at = now
                 session.add(existing)
             else:
                 session.add(
@@ -187,6 +198,13 @@ async def generate_channel_summaries(
                     )
                 )
             session.commit()
+            write_channel_summary(
+                channel_id=channel_id,
+                summary=summary_text,
+                message_count=total_count,
+                last_message_id=new_max_id,
+                updated_at=now,
+            )
         except Exception:
             logger.exception("Failed to generate channel summary for %s", channel_id)
             continue

--- a/projects/monolith/chat/vault_export.py
+++ b/projects/monolith/chat/vault_export.py
@@ -1,0 +1,109 @@
+"""Mirror chat summary rows to the Obsidian vault for human reasoning.
+
+Each summary row in the database (UserChannelSummary, ChannelSummary) is
+mirrored to a markdown file under ``_discord/{channel_id}/`` in the vault.
+Files are replaced in-place when the row updates -- there are no dated
+snapshots. These files are intentionally NOT ingested by the knowledge
+graph; they exist so a human can browse what the bot understands.
+"""
+
+import logging
+import os
+from datetime import datetime
+from pathlib import Path
+
+import yaml
+
+logger = logging.getLogger(__name__)
+
+_VAULT_ROOT_ENV = "VAULT_ROOT"
+_DEFAULT_VAULT_ROOT = "/vault"
+_SYNC_READY_SENTINEL = ".sync-ready"
+_DISCORD_ROOT = "_discord"
+
+
+def _vault_root() -> Path:
+    return Path(os.environ.get(_VAULT_ROOT_ENV, _DEFAULT_VAULT_ROOT))
+
+
+def _vault_ready() -> bool:
+    return (_vault_root() / _SYNC_READY_SENTINEL).exists()
+
+
+def _render(frontmatter: dict, body: str) -> str:
+    fm = yaml.safe_dump(frontmatter, sort_keys=False, allow_unicode=True)
+    return f"---\n{fm}---\n\n{body.rstrip()}\n"
+
+
+def _write_atomic(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(content, encoding="utf-8")
+    tmp.replace(path)
+
+
+def write_user_summary(
+    *,
+    channel_id: str,
+    user_id: str,
+    username: str,
+    summary: str,
+    last_message_id: int,
+    updated_at: datetime,
+) -> None:
+    """Mirror a UserChannelSummary row to ``_discord/{channel_id}/users/{user_id}.md``."""
+    if not _vault_ready():
+        logger.debug(
+            "Vault not ready; skipping user summary export for %s/%s",
+            channel_id,
+            user_id,
+        )
+        return
+    path = _vault_root() / _DISCORD_ROOT / channel_id / "users" / f"{user_id}.md"
+    content = _render(
+        {
+            "type": "discord-user-summary",
+            "channel_id": channel_id,
+            "user_id": user_id,
+            "username": username,
+            "last_message_id": last_message_id,
+            "updated_at": updated_at.isoformat(),
+        },
+        summary,
+    )
+    try:
+        _write_atomic(path, content)
+    except OSError:
+        logger.exception("Failed to write user summary file %s", path)
+
+
+def write_channel_summary(
+    *,
+    channel_id: str,
+    summary: str,
+    message_count: int,
+    last_message_id: int,
+    updated_at: datetime,
+) -> None:
+    """Mirror a ChannelSummary row to ``_discord/{channel_id}/channel.md``."""
+    if not _vault_ready():
+        logger.debug(
+            "Vault not ready; skipping channel summary export for %s",
+            channel_id,
+        )
+        return
+    path = _vault_root() / _DISCORD_ROOT / channel_id / "channel.md"
+    content = _render(
+        {
+            "type": "discord-channel-summary",
+            "channel_id": channel_id,
+            "message_count": message_count,
+            "last_message_id": last_message_id,
+            "updated_at": updated_at.isoformat(),
+        },
+        summary,
+    )
+    try:
+        _write_atomic(path, content)
+    except OSError:
+        logger.exception("Failed to write channel summary file %s", path)

--- a/projects/monolith/chat/vault_export_test.py
+++ b/projects/monolith/chat/vault_export_test.py
@@ -1,0 +1,134 @@
+"""Tests for chat.vault_export."""
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+import yaml
+
+from chat.vault_export import write_channel_summary, write_user_summary
+
+
+@pytest.fixture
+def vault(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Return a vault root with the sync-ready sentinel in place."""
+    monkeypatch.setenv("VAULT_ROOT", str(tmp_path))
+    (tmp_path / ".sync-ready").touch()
+    return tmp_path
+
+
+def _split_frontmatter(text: str) -> tuple[dict, str]:
+    assert text.startswith("---\n")
+    fm_end = text.index("\n---\n", 4)
+    fm = yaml.safe_load(text[4:fm_end])
+    body = text[fm_end + 5 :].strip()
+    return fm, body
+
+
+def test_write_user_summary_creates_file(vault: Path) -> None:
+    write_user_summary(
+        channel_id="123",
+        user_id="456",
+        username="alice",
+        summary="Loves cats and Rust.",
+        last_message_id=789,
+        updated_at=datetime(2026, 4, 25, 12, 0, 0, tzinfo=timezone.utc),
+    )
+
+    path = vault / "_discord" / "123" / "users" / "456.md"
+    fm, body = _split_frontmatter(path.read_text(encoding="utf-8"))
+    assert fm == {
+        "type": "discord-user-summary",
+        "channel_id": "123",
+        "user_id": "456",
+        "username": "alice",
+        "last_message_id": 789,
+        "updated_at": "2026-04-25T12:00:00+00:00",
+    }
+    assert body == "Loves cats and Rust."
+
+
+def test_write_channel_summary_creates_file(vault: Path) -> None:
+    write_channel_summary(
+        channel_id="123",
+        summary="A general chat channel about software.",
+        message_count=1234,
+        last_message_id=789,
+        updated_at=datetime(2026, 4, 25, 12, 0, 0, tzinfo=timezone.utc),
+    )
+
+    path = vault / "_discord" / "123" / "channel.md"
+    fm, body = _split_frontmatter(path.read_text(encoding="utf-8"))
+    assert fm == {
+        "type": "discord-channel-summary",
+        "channel_id": "123",
+        "message_count": 1234,
+        "last_message_id": 789,
+        "updated_at": "2026-04-25T12:00:00+00:00",
+    }
+    assert body == "A general chat channel about software."
+
+
+def test_skip_when_vault_not_ready(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("VAULT_ROOT", str(tmp_path))
+    # Note: no .sync-ready sentinel.
+
+    write_user_summary(
+        channel_id="123",
+        user_id="456",
+        username="alice",
+        summary="Hi",
+        last_message_id=1,
+        updated_at=datetime(2026, 4, 25, tzinfo=timezone.utc),
+    )
+    write_channel_summary(
+        channel_id="123",
+        summary="Hi",
+        message_count=1,
+        last_message_id=1,
+        updated_at=datetime(2026, 4, 25, tzinfo=timezone.utc),
+    )
+
+    assert not (tmp_path / "_discord").exists()
+
+
+def test_replaces_existing_file(vault: Path) -> None:
+    write_user_summary(
+        channel_id="123",
+        user_id="456",
+        username="alice",
+        summary="First version.",
+        last_message_id=1,
+        updated_at=datetime(2026, 4, 25, tzinfo=timezone.utc),
+    )
+    write_user_summary(
+        channel_id="123",
+        user_id="456",
+        username="alice",
+        summary="Second version.",
+        last_message_id=2,
+        updated_at=datetime(2026, 4, 26, tzinfo=timezone.utc),
+    )
+
+    text = (vault / "_discord" / "123" / "users" / "456.md").read_text(encoding="utf-8")
+    assert "Second version." in text
+    assert "First version." not in text
+
+
+def test_username_with_special_chars_round_trips(vault: Path) -> None:
+    """Tricky usernames must survive a YAML write/read cycle."""
+    tricky = 'alice "the great": #1 \U0001f600'
+    write_user_summary(
+        channel_id="123",
+        user_id="456",
+        username=tricky,
+        summary="Hi",
+        last_message_id=1,
+        updated_at=datetime(2026, 4, 25, tzinfo=timezone.utc),
+    )
+
+    text = (vault / "_discord" / "123" / "users" / "456.md").read_text(encoding="utf-8")
+    fm, _ = _split_frontmatter(text)
+    assert fm["username"] == tricky

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.53.15
+      targetRevision: 0.54.0
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
## Summary

- Each `UserChannelSummary` and `ChannelSummary` row is now mirrored to a markdown file under `_discord/{channel_id}/` in the vault as it's written. Files are replaced in-place when the row updates — no dated snapshots, no extra LLM calls.
- New module `chat/vault_export.py` with `write_user_summary` + `write_channel_summary`. Atomic write (tmp + rename), YAML frontmatter via `pyyaml`, no-op when the vault sync sentinel is missing.
- Wired into `chat/summarizer.py` after each `session.commit()` so the DB row is durable before the file is written.

Path layout:
```
_discord/{channel_id}/channel.md
_discord/{channel_id}/users/{user_id}.md
```

Channel/user IDs are used directly because the `Message` schema doesn't store guild_id or display names. A follow-up could add a `Channel`/`Guild` lookup table and rename folders to be human-readable, but the current shape unblocks browsing today.

These files are intentionally NOT ingested by the knowledge graph (they're conversational time-series, not reference knowledge).

## Test plan

- [ ] CI passes (`chat_vault_export_test` covers happy path, replace-in-place, sentinel-missing skip, special-char usernames; existing `chat_summarizer_*` tests should still pass since the export functions are no-ops without the sentinel)
- [ ] After deploy, observe `_discord/` directory appearing in the vault repo on next 24h `chat.summary_generation` run
- [ ] Open one of the markdown files in Obsidian and confirm the YAML frontmatter parses

🤖 Generated with [Claude Code](https://claude.com/claude-code)