### PR TITLE
fix(tools): set permission-mode acceptEdits in knowledge_research wrappers

### DIFF
--- a/tools/knowledge_research/bin/research-gap-interactive.sh
+++ b/tools/knowledge_research/bin/research-gap-interactive.sh
@@ -120,6 +120,7 @@ fi
 set +e
 claude \
 	--model claude-opus-4-7 \
+	--permission-mode acceptEdits \
 	--append-system-prompt "$(cat "$PROMPT_FILE")" \
 	--add-dir "$VAULT" \
 	-- \

--- a/tools/knowledge_research/bin/research-gap.sh
+++ b/tools/knowledge_research/bin/research-gap.sh
@@ -98,6 +98,7 @@ for stub in _researching/*.md; do
 	echo "==> researching: $slug"
 	if claude --print \
 		--model claude-opus-4-7 \
+		--permission-mode acceptEdits \
 		--append-system-prompt "$(cat "$PROMPT_FILE")" \
 		--add-dir "$VAULT" \
 		-- \

--- a/tools/knowledge_research/bin/triage-stubs.sh
+++ b/tools/knowledge_research/bin/triage-stubs.sh
@@ -102,6 +102,7 @@ echo
 
 claude --print \
 	--model claude-opus-4-7 \
+	--permission-mode acceptEdits \
 	--append-system-prompt "$(cat "$PROMPT_FILE")" \
 	--add-dir "$VAULT" \
 	-- \


### PR DESCRIPTION
## Bug

After the `--` separator fix (#2209), wrappers reach claude correctly but the file never lands. Symptom from a real `triage-stubs.sh --limit 5` run:

> The Write was blocked twice — I need permission to write to `.opus-research/triage-...md`. Could you grant the permission, or would you prefer a different output path?
> WARN: expected report not written at `/Users/jomcgi/Documents/jomcgi/.opus-research/triage-....md`

The triage logic completed (5 stubs evaluated, 3 already_covered + 2 misclassified) but the report stayed in claude's context because it couldn't write the file.

## Root cause

`claude --print` runs with the default permission mode, which prompts for confirmation on Write/Edit operations. There's no human at the keyboard in `--print` mode, so the prompts time out and the file never gets written. All the LLM work is wasted.

## Fix

Add `--permission-mode acceptEdits` to all three wrappers. This auto-accepts Edit/Write operations for the session — the right semantic for a scripted invocation where the caller has already chosen the output path. Read access is already covered by `--add-dir`.

For the interactive wrapper, the same flag also prevents permission prompts from interrupting Joe's conversation with Opus mid-flow. The conversational review-before-write contract in the system prompt is the safety mechanism — Opus shows the draft and asks Joe to approve before exiting, and only then the wrapper promotes.

## Verification

After applying locally, re-run reproduces the same triage decisions and the report file now actually lands at the expected path. End-to-end works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)