### PR TITLE
fix(tools): track triage state via triaged: keep frontmatter

### DIFF
--- a/tools/knowledge_research/bin/triage-stubs.sh
+++ b/tools/knowledge_research/bin/triage-stubs.sh
@@ -71,11 +71,18 @@ cd "$VAULT"
 shopt -s nullglob
 all=0
 eligible=0
+skipped_triaged=0
 for stub in _researching/*.md; do
 	all=$((all + 1))
 	slug="$(basename "$stub" .md)"
 	[ -f "$slug.md" ] && continue
 	[ -f "$STAGING/$slug.md" ] && continue
+	# Skip stubs a prior triage round already flagged as keep.
+	triaged="$(awk '/^triaged:/ {print $2; exit}' "$stub" | tr -d '"')"
+	if [ "$triaged" = "keep" ]; then
+		skipped_triaged=$((skipped_triaged + 1))
+		continue
+	fi
 	if [ -n "$FILTER" ] && [[ ! "$slug" =~ $FILTER ]]; then
 		continue
 	fi
@@ -95,7 +102,7 @@ to_process=$eligible
 ts="$(date -u +%Y%m%dT%H%M%SZ)"
 report_path="$STAGING/triage-$ts.md"
 
-echo "Triaging $to_process stubs (of $eligible eligible / $all total)"
+echo "Triaging $to_process stubs (of $eligible eligible / $all total; $skipped_triaged previously triaged as keep)"
 echo "Batch size: $BATCH_SIZE"
 echo "Report path: $report_path"
 echo
@@ -108,13 +115,51 @@ claude --print \
 	-- \
 	"Triage gap stubs in this vault. Working directory is the vault root. Process up to $to_process stubs in batches of $BATCH_SIZE.${FILTER:+ Filter slugs by regex: $FILTER.} Write the consolidated report to \`.opus-research/triage-$ts.md\` per the system prompt."
 
-if [ -f "$report_path" ]; then
-	echo
-	echo "Report written: $report_path"
-	echo
-	echo "Top-of-file summary:"
-	head -30 "$report_path"
-else
+if [ ! -f "$report_path" ]; then
 	echo "WARN: expected report not written at $report_path" >&2
 	exit 3
 fi
+
+echo
+echo "Report written: $report_path"
+
+# Mark all valid_external / valid_internal slugs as triaged: keep
+# in their stub frontmatter so future runs skip them.
+keeper_slugs=$(awk '
+	/^## Valid (external|internal)/ { in_section=1; next }
+	in_section && /^## [^V]/        { in_section=0 }
+	in_section && /^\| [a-z0-9]/ {
+		gsub(/^\| /, "")
+		gsub(/ \|.*$/, "")
+		print
+	}
+' "$report_path")
+
+marked=0
+while IFS= read -r slug; do
+	[ -z "$slug" ] && continue
+	stub="_researching/$slug.md"
+	[ ! -f "$stub" ] && continue
+	# Skip if already marked.
+	grep -q "^triaged: keep" "$stub" && continue
+	# Insert "triaged: keep" inside the frontmatter (right after the opening ---).
+	tmp=$(mktemp)
+	awk '
+		BEGIN { inserted = 0 }
+		NR == 1 && /^---$/ { print; next }
+		!inserted && /^[a-zA-Z]/ {
+			print "triaged: keep"
+			inserted = 1
+		}
+		{ print }
+	' "$stub" >"$tmp" && mv "$tmp" "$stub"
+	marked=$((marked + 1))
+done <<<"$keeper_slugs"
+
+if [ "$marked" -gt 0 ]; then
+	echo "Marked $marked stub(s) as triaged: keep so future runs skip them."
+fi
+
+echo
+echo "Top-of-file summary:"
+head -30 "$report_path"

--- a/tools/knowledge_research/prompts/triage-stubs.system.md
+++ b/tools/knowledge_research/prompts/triage-stubs.system.md
@@ -43,9 +43,17 @@ The user message will specify:
 
 ## Phase 1 — Plan the triage
 
-1. **Enumerate eligible stubs.** List `_researching/*.md` whose slug
-   does not have a corresponding vault-root file or staged research
-   file. Apply `--filter` if provided. Cap at `--limit`.
+1. **Enumerate eligible stubs.** List `_researching/*.md` where ALL of:
+   - The slug does not have a corresponding vault-root file
+     (`<slug>.md` at the root would mean it's already been researched)
+   - The slug does not have a corresponding staged research file
+     (`.opus-research/<slug>.md` would mean it's mid-research)
+   - The frontmatter does NOT contain `triaged: keep` (these are stubs
+     a prior triage round flagged as `valid_external` or `valid_internal`
+     — they're real research targets, not candidates for re-triage; the
+     wrapper marks them automatically after each run)
+
+   Apply `--filter` if provided. Cap at `--limit`.
 
 2. **Sample-read 3-5 stubs** to confirm the format is what you expect:
    frontmatter with `id`, `title`, `gap_class`, `referenced_by`.


### PR DESCRIPTION
## Bug

Without state, `triage-stubs.sh` re-evaluates previously-flagged keepers on every alphabetical walk:

- Run 1 flags `activation-energy` as `valid_external`. Stub stays in `_researching/`.
- Run 2 walks alphabetically; first 40 entries include all prior keepers; Opus re-evaluates them and produces identical decisions.
- Each round costs ~$5-8 API for zero new information.

## Fix

Persist triage state in the data, not in a sidecar.

**Wrapper changes (`triage-stubs.sh`)**:
1. Eligibility loop skips stubs whose frontmatter contains `triaged: keep`. Counter (`skipped_triaged`) is reported in the run summary.
2. After each successful run, the wrapper parses the report's `Valid external` and `Valid internal` sections and inserts `triaged: keep` into each keeper stub's frontmatter via an idempotent awk insert (skips already-marked stubs).

**Prompt changes (`triage-stubs.system.md`)**:
The Phase 1 enumeration instruction now lists three eligibility predicates explicitly, including the new `triaged: keep` skip.

## Why state-in-data over state-in-sidecar

The triaged-keep field lives next to the stub it describes:
- Survives vault syncs (Obsidian / git)
- Survives pod restarts (no in-memory state)
- Survives branch checkouts
- Wrapper stays stateless

A sidecar file (`.opus-research/triaged.txt`) would have created its own consistency-management problems.

## Backfill for existing keepers

40 keepers from runs prior to this PR don't have the marker. After merge, a one-liner backfills them by re-parsing the prior reports:

```fish
for report in /Users/jomcgi/Documents/jomcgi/.opus-research/triage-*.md
  awk '/^## Valid (external|internal)/{f=1; next} f && /^## [^V]/{f=0} f && /^\| [a-z0-9]/ {gsub(/^\| /,""); gsub(/ \|.*$/,""); print}' \$report
end | sort -u | while read slug
  stub="/Users/jomcgi/Documents/jomcgi/_researching/\$slug.md"
  test -f \$stub; or continue
  grep -q "^triaged: keep" \$stub; and continue
  awk 'NR==1 && /^---$/ {print; next} !i && /^[a-zA-Z]/ {print "triaged: keep"; i=1} {print}' \$stub > \$stub.tmp; and mv \$stub.tmp \$stub
end
```

Future runs auto-mark; this is a one-time cleanup.

## Test plan

- [ ] CI green
- [ ] Run `triage-stubs.sh --limit 5` after merge: keeper count in summary should reflect any pre-marked stubs
- [ ] Run twice: second run should report N keepers skipped (matching the first run's `valid_*` count)
- [ ] No regression: a fresh stub (no `triaged:` field) is still triaged normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)