### PR TITLE
fix(tools): mark already_covered/garbage stubs as triaged: discardable

### DIFF
--- a/tools/knowledge_research/bin/triage-stubs.sh
+++ b/tools/knowledge_research/bin/triage-stubs.sh
@@ -71,18 +71,25 @@ cd "$VAULT"
 shopt -s nullglob
 all=0
 eligible=0
-skipped_triaged=0
+skipped_keep=0
+skipped_discardable=0
 for stub in _researching/*.md; do
 	all=$((all + 1))
 	slug="$(basename "$stub" .md)"
 	[ -f "$slug.md" ] && continue
 	[ -f "$STAGING/$slug.md" ] && continue
-	# Skip stubs a prior triage round already flagged as keep.
+	# Skip stubs a prior triage round already classified.
 	triaged="$(awk '/^triaged:/ {print $2; exit}' "$stub" | tr -d '"')"
-	if [ "$triaged" = "keep" ]; then
-		skipped_triaged=$((skipped_triaged + 1))
+	case "$triaged" in
+	keep)
+		skipped_keep=$((skipped_keep + 1))
 		continue
-	fi
+		;;
+	discardable)
+		skipped_discardable=$((skipped_discardable + 1))
+		continue
+		;;
+	esac
 	if [ -n "$FILTER" ] && [[ ! "$slug" =~ $FILTER ]]; then
 		continue
 	fi
@@ -102,7 +109,7 @@ to_process=$eligible
 ts="$(date -u +%Y%m%dT%H%M%SZ)"
 report_path="$STAGING/triage-$ts.md"
 
-echo "Triaging $to_process stubs (of $eligible eligible / $all total; $skipped_triaged previously triaged as keep)"
+echo "Triaging $to_process stubs (of $eligible eligible / $all total; $skipped_keep keep, $skipped_discardable discardable already triaged)"
 echo "Batch size: $BATCH_SIZE"
 echo "Report path: $report_path"
 echo
@@ -123,42 +130,74 @@ fi
 echo
 echo "Report written: $report_path"
 
-# Mark all valid_external / valid_internal slugs as triaged: keep
-# in their stub frontmatter so future runs skip them.
-keeper_slugs=$(awk '
-	/^## Valid (external|internal)/ { in_section=1; next }
-	in_section && /^## [^V]/        { in_section=0 }
-	in_section && /^\| [a-z0-9]/ {
-		gsub(/^\| /, "")
-		gsub(/ \|.*$/, "")
-		print
-	}
-' "$report_path")
-
-marked=0
-while IFS= read -r slug; do
-	[ -z "$slug" ] && continue
-	stub="_researching/$slug.md"
-	[ ! -f "$stub" ] && continue
-	# Skip if already marked.
-	grep -q "^triaged: keep" "$stub" && continue
-	# Insert "triaged: keep" inside the frontmatter (right after the opening ---).
-	tmp=$(mktemp)
-	awk '
-		BEGIN { inserted = 0 }
-		NR == 1 && /^---$/ { print; next }
-		!inserted && /^[a-zA-Z]/ {
-			print "triaged: keep"
-			inserted = 1
+mark_section() {
+	# $1 = decision (keep | discardable)
+	# remaining args = section header regex (e.g. "Valid (external|internal)")
+	local decision="$1"
+	shift
+	local section_regex="$1"
+	local slugs
+	slugs=$(awk -v re="$section_regex" '
+		$0 ~ "^## " re { in_section=1; next }
+		in_section && /^## /          { in_section=0 }
+		in_section && /^\| [a-z0-9]/ {
+			gsub(/^\| /, "")
+			gsub(/ \|.*$/, "")
+			print
 		}
-		{ print }
-	' "$stub" >"$tmp" && mv "$tmp" "$stub"
-	marked=$((marked + 1))
-done <<<"$keeper_slugs"
+	' "$report_path")
 
-if [ "$marked" -gt 0 ]; then
-	echo "Marked $marked stub(s) as triaged: keep so future runs skip them."
-fi
+	local count=0
+	while IFS= read -r slug; do
+		[ -z "$slug" ] && continue
+		# Defensive: ignore obvious table sentinels like "_none_".
+		[[ "$slug" == _* ]] && continue
+		local stub="_researching/$slug.md"
+		[ ! -f "$stub" ] && continue
+		# Skip if already marked the same way (idempotent).
+		local existing
+		existing="$(awk '/^triaged:/ {print $2; exit}' "$stub" | tr -d '"')"
+		[ "$existing" = "$decision" ] && continue
+		local tmp
+		tmp=$(mktemp)
+		awk -v decision="$decision" '
+			BEGIN { inserted = 0 }
+			NR == 1 && /^---$/ { print; next }
+			# If a different triaged: line already exists, replace it.
+			!inserted && /^triaged:/ {
+				print "triaged: " decision
+				inserted = 1
+				next
+			}
+			!inserted && /^[a-zA-Z]/ {
+				print "triaged: " decision
+				inserted = 1
+			}
+			{ print }
+		' "$stub" >"$tmp" && mv "$tmp" "$stub"
+		count=$((count + 1))
+	done <<<"$slugs"
+	echo "$count"
+}
+
+# `triaged: keep` for real research targets — wrapper skips them so they
+# don't get re-triaged, and research-gap.sh can pick them up.
+marked_keep=$(mark_section keep "Valid (external|internal)")
+
+# `triaged: discardable` for stubs the user can clean up at any time.
+# Marking instead of deleting prevents the gap-detector from re-creating
+# them (the classifier doesn't check aliases on canonical atoms, so a
+# deleted stub gets regenerated on the next gap-detection cycle). The
+# marker is invisible to gap-detector (which is create-if-not-exists)
+# and to the wrapper's eligibility loop.
+marked_discardable=0
+for section in "Already covered" "Garbage" "Misclassified"; do
+	count=$(mark_section discardable "$section")
+	marked_discardable=$((marked_discardable + count))
+done
+
+[ "$marked_keep" -gt 0 ] && echo "Marked $marked_keep stub(s) as triaged: keep."
+[ "$marked_discardable" -gt 0 ] && echo "Marked $marked_discardable stub(s) as triaged: discardable."
 
 echo
 echo "Top-of-file summary:"

--- a/tools/knowledge_research/prompts/triage-stubs.system.md
+++ b/tools/knowledge_research/prompts/triage-stubs.system.md
@@ -48,10 +48,19 @@ The user message will specify:
      (`<slug>.md` at the root would mean it's already been researched)
    - The slug does not have a corresponding staged research file
      (`.opus-research/<slug>.md` would mean it's mid-research)
-   - The frontmatter does NOT contain `triaged: keep` (these are stubs
-     a prior triage round flagged as `valid_external` or `valid_internal`
-     — they're real research targets, not candidates for re-triage; the
-     wrapper marks them automatically after each run)
+   - The frontmatter does NOT contain `triaged: keep` or
+     `triaged: discardable` — these are stubs a prior triage round
+     already classified. The wrapper marks them automatically after
+     each run:
+     - `triaged: keep` — a real research target (`valid_external`
+       or `valid_internal`); kept in `_researching/` for
+       `research-gap.sh` to pick up.
+     - `triaged: discardable` — already covered, garbage, or
+       misclassified; the user can `rm` them at any time, but
+       leaving the marker prevents the gap-detector from
+       regenerating the stub on its next cycle (it's
+       create-if-not-exists, so an existing-but-marked stub is a
+       no-op).
 
    Apply `--filter` if provided. Cap at `--limit`.
 


### PR DESCRIPTION
## Bug

We hit a regenerative loop after PR #2213. The cycle:

1. Triage flags a stub as `already_covered`.
2. User runs the suggested `rm` to clean it up.
3. Gap-detector pipeline runs in the background. Its slug-classifier checks `_processed/<slug>.md` (filename match only — does **not** consult `aliases:` on canonical atoms).
4. Gap-detector sees the wikilink as unresolved (because resolution-via-aliases is an Obsidian feature, not a classifier feature) and re-creates the stub.
5. Next triage run picks it up again, evaluates it the same way, treadmill.

Empirical confirmation: between sessions of triage runs deleting 205 stubs, the queue size dropped only by 103. Roughly half the deletions got regenerated within minutes.

## Why marking works

The `triaged: keep` markers from PR #2213 survived multiple gap-detector cycles unchanged — proving the gap-detector is **create-if-not-exists** (existing stubs are no-ops). This change leverages the same property for the discard side: instead of `rm`, mark with `triaged: discardable` and the existing-but-marked stub becomes a no-op for both the gap-detector AND the wrapper's eligibility loop.

## Wrapper changes (`triage-stubs.sh`)

- Eligibility loop now skips both `triaged: keep` and `triaged: discardable`. Counts reported separately in the run summary line.
- Refactored the marking logic into a `mark_section <decision> <section_regex>` helper.
- Post-triage marks two sets:
  - `triaged: keep` for `Valid external` + `Valid internal` (unchanged).
  - `triaged: discardable` for `Already covered` + `Garbage` + `Misclassified`.
- Marking is idempotent: skips stubs already marked the same way; replaces wrong markers in-place via awk.
- Defensive against the `_none_` table sentinel.

## Prompt changes (`triage-stubs.system.md`)

The Phase 1 enumeration rule now lists both markers in the exclusion set, with brief explanations of what each means and why marking-not-deleting is the right answer to the gap-detector regeneration loop.

## Backfill for prior runs

After merge, a one-shot script over the 5 prior reports will mark all the slugs that the gap-detector has regenerated. Most of these were `rm`-ed in earlier runs but came back; this run will catch them and stamp `triaged: discardable`. Future runs auto-mark in the same flow.

## Test plan

- [ ] CI green (format, semgrep, etc.)
- [ ] After merge, run the backfill one-liner against the 5 reports
- [ ] Run `triage-stubs.sh --limit 10` and verify the run summary line shows both `keep` and `discardable` skip counts
- [ ] Run twice: second run should report close to 100% skip + 0 new evaluations on the same alphabetical band

🤖 Generated with [Claude Code](https://claude.com/claude-code)