### PR TITLE
fix(monolith): gardener atomizer must preserve atom aliases

### DIFF
--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -30,7 +30,6 @@ exec_filegroup(
 py_venv_binary(
     name = "main",
     srcs = glob(
-        # keep
         [
             "app/**/*.py",
             "chat/**/*.py",
@@ -44,7 +43,7 @@ py_venv_binary(
             "*/tests/**/*.py",
             "shared/testing/**/*.py",
         ],
-    ),
+    ),  # keep
     data = [":frontend_dist"],
     imports = ["."],  # keep
     main = "app/main.py",
@@ -55,7 +54,6 @@ py_venv_binary(
 py_library(
     name = "monolith_backend",
     srcs = glob(
-        # keep
         [
             "app/**/*.py",
             "chat/**/*.py",
@@ -69,7 +67,7 @@ py_library(
             "*/tests/**/*.py",
             "shared/testing/**/*.py",
         ],
-    ),
+    ),  # keep
     visibility = ["//:__subpackages__"],
     deps = [
         "@pip//discord_py",

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.55.0
+version: 0.55.1
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.55.1
+version: 0.55.2
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.55.0
+      targetRevision: 0.55.1
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.55.1
+      targetRevision: 0.55.2
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/knowledge/gardener.py
+++ b/projects/monolith/knowledge/gardener.py
@@ -60,6 +60,7 @@ Steps:
 ---
 id: <slug-of-title>
 title: "<concise title — MUST be quoted if it contains a colon>"
+aliases: [<optional list of alternative wikilink forms — see Aliases section below>]
 type: atom|fact|active
 derived_from_raw: {raw_id}
 tags: [optional]
@@ -75,6 +76,34 @@ edges:
    `staff-engineers-path`, the file must be `{processed_root}/staff-engineers-path.md`.
 6. Patch edges on related existing notes using the Edit tool.
 7. Each note covers exactly one concept. Prefer many small notes over one large note.
+
+## Aliases (frontmatter field)
+
+The `aliases:` field lists alternative human-readable forms of the title that
+should resolve to this same atom in Obsidian. It also feeds the gap-classifier:
+when a referencing note contains `[[Some Title]]`, the classifier checks both
+`_processed/<slug>.md` filenames AND existing atoms' `aliases:` lists before
+queueing a gap. Every variant of the title that shows up as a wikilink in
+referencing notes should appear here.
+
+When CREATING a new atom, populate `aliases:` with any of:
+- The title-cased form if it differs from the slugified id
+- Possessive variants (`Bayes's Theorem`, `Bayes' Theorem`)
+- Plural/singular alternates (`Blameless Postmortem`, `Blameless Postmortems`)
+- Article variations (`The Software Engineer's Guidebook`)
+- Common abbreviations or expansions (`DORA Metrics` ↔ `Four Key DORA Metrics`)
+
+Omit the field (or use `[]`) if the slug already matches the only wikilink form.
+
+When UPDATING an existing atom (i.e. when this raw mentions a concept that
+already exists at `{processed_root}/<slug>.md`), use the **Edit** tool — never
+Write. Edit lets you modify specific sections (body, individual frontmatter
+fields) without touching `aliases:` or any other user-curated frontmatter.
+Write would overwrite the whole file and silently strip fields that aren't
+in this prompt's schema, which is a real bug we are explicitly guarding
+against. If you genuinely need to rewrite an atom from scratch, first Read
+its current frontmatter, copy the `aliases:` array verbatim into your new
+content, then Write — never lose alias entries.
 
 Title: {title}
 


### PR DESCRIPTION
## Bug

The gardener spawns a `claude --print` subprocess (`gardener.py:_run_claude_subprocess`) to atomize raw notes into `_processed/`. The subprocess prompt (`_CLAUDE_PROMPT_HEADER`) specifies the atom frontmatter schema as `id, title, type, derived_from_raw, tags, edges` — **`aliases:` is not mentioned**. When the subprocess encounters a raw mentioning a concept that already has a canonical atom in `_processed/`, it Writes a fresh atom using the prompt-specified schema, **silently stripping any `aliases:` field** the user or downstream tooling added.

## Empirical evidence

During a vault-triage session this week, ~11 manually-added aliases on canonical atoms (e.g. `_processed/one-on-one-agenda-setting.md`, `_processed/book-accelerate.md`, `_processed/technical-leader-business-value-alignment.md`) silently disappeared across gardener cycles. Aliases on atoms whose raws were not re-processed during the same window survived intact (e.g. `_processed/bayes-theorem.md`, `_processed/blameless-postmortem-culture.md`, `_processed/feature-flags.md`). The stripping correlates exactly with the gardener re-processing the raw that derived the atom.

## Why this matters beyond Obsidian wikilink resolution

The vault's gap-classifier checks both `_processed/<slug>.md` filenames AND existing atoms' `aliases:` lists when deciding whether a wikilinked concept is already covered. Stripping aliases re-introduces the gap, which the classifier then queues as a stub, which has to be triaged and acted on. The triage tooling we shipped this week (`tools/knowledge_research/`) handles the symptom; this PR fixes the cause.

## Fix

Two changes to `_CLAUDE_PROMPT_HEADER`:

1. **`aliases:` added to the documented frontmatter schema** alongside `id / title / type / etc`. The prompt explains when to populate it (possessive variants, plural alternates, article drops, abbreviations) and when to omit it (slug already matches the only wikilink form).
2. **New "Aliases" section explicitly instructs Edit-not-Write for updates.** When the atomizer encounters an existing atom file in `_processed/`, it must use the Edit tool to modify specific sections rather than Write to overwrite the file. Write was the silent-stripping mechanism; Edit-only on updates is the safety guarantee. If a full rewrite is genuinely necessary, the prompt explicitly tells the subprocess to first Read the existing `aliases:` array and copy it into the new content.

29-line prompt change. No code logic changes.

## Test plan

- [ ] CI green
- [ ] After merge, manually re-add the 11+19 aliases that were stripped earlier (one-shot Python heredoc; documented in the related triage tooling PRs)
- [ ] Run a manual gardener cycle (or wait for the scheduled `knowledge.garden` job) and verify no alias regression on the re-added entries
- [ ] Confirm the gap-classifier no longer queues stubs whose canonical exists with the appropriate alias

🤖 Generated with [Claude Code](https://claude.com/claude-code)