### PR TITLE
fix(monolith): gap-detector consults atom aliases before queueing stubs

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.55.2
+version: 0.55.3
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.55.2
+      targetRevision: 0.55.3
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/knowledge/gap_lifecycle_test.py
+++ b/projects/monolith/knowledge/gap_lifecycle_test.py
@@ -119,6 +119,41 @@ def test_discover_gaps_skips_resolved_links(session, tmp_path):
     )
 
 
+def test_discover_gaps_skips_links_resolved_via_alias(session, tmp_path):
+    """Wikilinks slugged to a canonical atom's alias are not gaps.
+
+    Pre-fix, only ``note_id`` was checked — so ``[[Bayes' Theorem]]``
+    slugified to ``bayes-theorem`` would be a false-positive gap when the
+    canonical atom lives at a different slug with "Bayes' Theorem" in
+    ``aliases:``. Post-fix, slugified aliases participate in the coverage
+    check.
+    """
+    src = _make_note(session, "source-note", title="Source")
+    # Canonical lives at a different slug than the wikilink's slugified target.
+    target = Note(
+        note_id="probability-update-rule",
+        path="_processed/probability-update-rule.md",
+        title="Probability Update Rule",
+        content_hash="hash-probability-update-rule",
+        type="atom",
+        aliases=["Bayes' Theorem", "Bayes' Rule"],
+    )
+    session.add(target)
+    session.commit()
+
+    # The wikilink extractor would produce this slug from body text
+    # ``[[Bayes' Theorem]]``; absent alias-awareness this would be a gap.
+    _add_body_link(session, src_fk=src.id, target_id="bayes-theorem")
+
+    created = discover_gaps(session, tmp_path)
+
+    assert created == 0
+    assert session.execute(select(Gap)).scalars().all() == []
+    assert not (tmp_path / RESEARCHING_DIR).exists() or not list(
+        (tmp_path / RESEARCHING_DIR).iterdir()
+    )
+
+
 def test_discover_gaps_is_idempotent(session, tmp_path):
     src = _make_note(session, "src", title="Src")
     _add_body_link(session, src_fk=src.id, target_id="missing")

--- a/projects/monolith/knowledge/gaps.py
+++ b/projects/monolith/knowledge/gaps.py
@@ -93,8 +93,20 @@ def discover_gaps(session: Session, vault_root: Path) -> int:
     Idempotent: a subsequent run with no changes returns 0.
     """
     # Collect existing note_ids once so the unresolved filter is a set
-    # membership check (avoids a correlated subquery per row).
-    existing_note_ids = set(session.execute(select(Note.note_id)).scalars().all())
+    # membership check (avoids a correlated subquery per row). Includes
+    # slugified frontmatter aliases so wikilinks pointing at a canonical
+    # atom under one of its aliases (e.g. `[[Bayes' Theorem]]` slugifies
+    # to `bayes-theorem`, but the canonical atom may live at a different
+    # slug with "Bayes' Theorem" in `aliases:`) don't get queued as
+    # false-positive gaps. Mirrors the gardener atomizer's alias-preserving
+    # contract — wherever the gardener writes aliases, the gap-detector
+    # consults them.
+    existing_note_ids: set[str] = set()
+    for note_id, aliases in session.execute(select(Note.note_id, Note.aliases)).all():
+        if note_id:
+            existing_note_ids.add(note_id)
+        for alias in aliases or []:
+            existing_note_ids.add(_slugify(alias))
 
     # All body-wikilink rows. Frontmatter edges (kind='edge') are not
     # treated as gaps — those are typed assertions, not unresolved


### PR DESCRIPTION
## Bug

`gaps.py:discover_gaps` builds the "is this slug already covered?" set from `Note.note_id` only — frontmatter aliases on canonical atoms are never consulted. As a result, a wikilink whose slugified target matches an existing atom's alias (but not its filename slug) gets queued as a stub, even though the concept is genuinely covered.

This is the upstream cause of the regenerative loop we worked around with the `triaged: discardable` marker scheme.

## Empirical evidence

Across 4 triage runs covering 255 stubs, ~80% were `already_covered` — and the dominant pattern was slug-variant collisions:

- Possessive: `[[Bayes' Theorem]]` → `bayes-theorem` slug; canonical at `bayes-theorem.md`, but other body wikilinks like `[[Bayes's Theorem]]` slug to a different form
- Article drops: `[[The Software Engineer's Guidebook]]` → `the-software-engineers-guidebook`; canonical is at the same slug but with the `book-` prefix variant also referenced
- Prefix variants: `[[Accelerate]]` → `accelerate` slug; canonical at `book-accelerate.md`
- Renamed canonicals: old slug appears in body wikilinks; atom moved to a new id with the old slug as an alias

The gardener atomizer was taught to preserve aliases on canonical atoms in #2215. This PR closes the loop — the gap-detector now respects those aliases.

## Fix

In `discover_gaps`, expand the coverage set to include slugified aliases:

```python
existing_note_ids: set[str] = set()
for note_id, aliases in session.execute(
    select(Note.note_id, Note.aliases)
).all():
    if note_id:
        existing_note_ids.add(note_id)
    for alias in aliases or []:
        existing_note_ids.add(_slugify(alias))
```

A wikilink target is considered covered if it matches either `Note.note_id` OR `_slugify(alias)` for any alias on any Note. Aliases are already loaded into the Note model (`models.py:67`) and populated by `store.py` from frontmatter at ingestion time, so no schema changes needed.

## Test

`test_discover_gaps_skips_links_resolved_via_alias` — wikilink `[[Bayes' Theorem]]` (slugifies to `bayes-theorem`) against a Note at `probability-update-rule` with `aliases: ["Bayes' Theorem", "Bayes' Rule"]`. Asserts no Gap row is created, no stub written.

## Knock-on benefit

Once this lands and the `knowledge.classify-gaps` job runs a cycle:
- The 134 `triaged: discardable` stubs in `_researching/` become safely deletable — gap-detector will not regenerate them because the wikilinks resolve via alias
- Future gap-detection produces dramatically fewer false-positive stubs (the upstream root cause is gone)

This unlocks closing the cleanup loop and restoring `_researching/` as a small, real-research-target-only queue.

## Test plan

- [ ] CI green (format + the new test)
- [ ] After merge + next gardener cycle, run `triage-stubs.sh --limit 10` against a fresh alphabetical region — should see far fewer `already_covered` decisions
- [ ] After ~24h, verify the 134 discardable stubs are safe to bulk-delete (gap-detector hasn't regenerated them under the new logic)

🤖 Generated with [Claude Code](https://claude.com/claude-code)