### PR TITLE
fix(monolith): expose SSR error message to debug live 500

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.62.4
+version: 0.62.5
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.62.4
+      targetRevision: 0.62.5
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/hooks.server.js
+++ b/projects/monolith/frontend/src/hooks.server.js
@@ -1,0 +1,15 @@
+/**
+ * Surface the real SSR error message to the client/HTML response.
+ * The default `handleError` masks all errors as "Internal Error" once
+ * NODE_ENV=production, which is unhelpful when chasing why the public
+ * homepage 500s only in the cluster pod and not under local pnpm/vite.
+ *
+ * @type {import('@sveltejs/kit').HandleServerError}
+ */
+export function handleError({ error, message }) {
+  // eslint-disable-next-line no-console
+  console.error("SSR error:", error?.stack || error);
+  return {
+    message: error instanceof Error ? error.message : message,
+  };
+}


### PR DESCRIPTION
## Summary
- The home/frontend → src move (PR #2217) is on main, CI pushed a fresh image, and ArgoCD rotated the pod, but `https://public.jomcgi.dev/` still returns 500. Locally the same source renders fine under the production adapter, so the runtime error is invisible to me from outside the cluster.
- Add `src/hooks.server.js` with a `handleError` hook that returns the real `error.message` instead of SvelteKit's masked `"Internal Error"`. Next response from the live pod will tell us what's actually throwing during +page.server.js load.
- Bump chart `0.62.4` → `0.62.5` (and the `application.yaml targetRevision` in lockstep) so ArgoCD is guaranteed to roll the pod once CI finishes pushing — no risk of staring at a stale digest.

## Test plan
- [ ] CI green
- [ ] Merge to main, wait for rollout
- [ ] Hit `https://public.jomcgi.dev/`, confirm the error body now contains the real message
- [ ] Use that message to land the actual fix, then revert the diagnostic hook in a follow-up

https://claude.ai/code/session_017CeZaUV4MbefwuA5ui9gNe

---
_Generated by [Claude Code](https://claude.ai/code/session_017CeZaUV4MbefwuA5ui9gNe)_