### PR TITLE
fix(monolith): bundle @dagrejs/dagre into SSR chunks for homepage

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.62.4
+version: 0.62.5
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.62.4
+      targetRevision: 0.62.5
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/vite.config.js
+++ b/projects/monolith/frontend/vite.config.js
@@ -6,6 +6,12 @@ export default defineConfig({
   build: {
     target: "es2022",
   },
+  ssr: {
+    // The runtime image ships only the SvelteKit `build/` output — there is
+    // no node_modules. Any package imported by SSR-rendered code must be
+    // bundled into the server chunks, not externalized.
+    noExternal: ["@dagrejs/dagre"],
+  },
   server: {
     proxy: {
       "/api": "http://localhost:8000",


### PR DESCRIPTION
## Summary
- Fix `ERR_MODULE_NOT_FOUND: Cannot find package '@dagrejs/dagre'` 500-ing every `GET /` after the homepage SLO topology PR (#82fe75f26) merged.
- Tell Vite SSR to bundle `@dagrejs/dagre` into the server chunks (`ssr.noExternal`) instead of leaving it as an external `import` that needs `node_modules`.

## Root cause
The new `public/+page.svelte` SSRs `HomepageTopology.svelte` → `dag/index.js` → `dag-layout.js` → `import * as dagre from "@dagrejs/dagre"`. Vite SSR auto-externalizes anything in `package.json` `dependencies`, so the SSR chunk contained a literal `import '@dagrejs/dagre'`. The runtime apko image only contains `nodejs-22` and the SvelteKit `build/` output — no `node_modules` — so Node throws on every request.

The existing dagre usages in `slos/` and `chat/` were unaffected because they each `export const ssr = false`, keeping dagre out of the SSR bundle entirely.

## Why `noExternal` and not other options
- **`ssr = false` for the homepage** — kills SEO/first-paint for the public landing page; the Marquee/Nav/Footer/copy genuinely benefits from SSR.
- **Dynamic `await import()` in a `$effect`** — would convert `$derived` layout to async and add a hydration flicker.
- **Move dagre to `devDependencies`** — semantically wrong; dagre is a runtime dep in the client bundle.

## Test plan
- [ ] CI builds and pushes a new `monolith/frontend` image
- [ ] ArgoCD Image Updater rolls the new digest (the deploy uses `imageupdater.yaml` digest strategy — no chart bump needed)
- [ ] `curl -s https://<homepage> | head` returns rendered HTML (not 500)
- [ ] Browser load shows the topology DAG renders (client-side, gated by `browser`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)