### PR TITLE
fix(monolith): homepage polish — drop SLO badge, widen DAG, live ticker

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.62.6
+version: 0.62.7
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.62.5
+version: 0.62.6
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.62.7
+version: 0.62.8
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.62.5
+      targetRevision: 0.62.6
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.62.7
+      targetRevision: 0.62.8
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.62.6
+      targetRevision: 0.62.7
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/lib/public/components/dag/DagRenderer.svelte
+++ b/projects/monolith/frontend/src/lib/public/components/dag/DagRenderer.svelte
@@ -265,17 +265,6 @@
         >
           {n.label}
         </text>
-        {#if n.slo?.current != null}
-          {@const pct = Math.round(n.slo.current * 100) / 100}
-          {@const badgeColor = pct >= 99.9 ? "var(--teal, #0d9488)" : pct >= 99 ? "var(--accent, #f59e0b)" : "var(--coral, #e53e3e)"}
-          <text
-            x={pos.x} y={pos.y + HH + 12}
-            class="slo-badge"
-            fill={badgeColor}
-          >
-            {pct.toFixed(2)}%
-          </text>
-        {/if}
       </g>
     {/if}
   {/each}
@@ -345,14 +334,6 @@
   }
 
   .node-label--active { text-decoration: underline; }
-
-  .slo-badge {
-    font-family: var(--mono, "JetBrains Mono", monospace);
-    font-size: 7px;
-    font-weight: 700;
-    text-anchor: middle;
-    letter-spacing: 0.04em;
-  }
 
   .hit-area {
     outline: none;

--- a/projects/monolith/frontend/src/routes/public/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/+page.svelte
@@ -5,13 +5,14 @@
 
   let { data } = $props();
 
-  /** Build marquee items from /stats data, falling back to non-numeric items
-   *  when a metric is unavailable so the ticker never shows fabricated numbers. */
+  /** Build marquee items from /stats data, skipping any item whose source
+   *  is unavailable so the ticker never shows fabricated numbers. */
   function buildMarquee(stats) {
     const items = ["~/homelab"];
     const c = stats?.cluster;
     const g = stats?.gpu;
     const k = stats?.knowledge;
+    const d = stats?.deploy;
 
     if (c?.nodes != null && c?.pods != null) items.push(`${c.nodes} nodes · ${c.pods} pods`);
     if (c?.cpu_used_cores != null && c?.cpu_capacity_cores != null) {
@@ -28,8 +29,22 @@
     }
     if (c?.argocd_apps != null) items.push(`argocd: ${c.argocd_apps} apps`);
     if (k?.facts != null) items.push(`kg: ${k.facts.toLocaleString()} notes`);
-    items.push("go · python · sveltekit");
+    if (d?.latest_commit_sha) items.push(`last commit: ${d.latest_commit_sha}`);
+    if (d?.deployed_at) {
+      const ago = formatAgo(d.deployed_at);
+      if (ago) items.push(`deployed ${ago} ago`);
+    }
     return items;
+  }
+
+  function formatAgo(iso) {
+    const then = Date.parse(iso);
+    if (!Number.isFinite(then)) return null;
+    const minutes = Math.max(0, Math.round((Date.now() - then) / 60_000));
+    if (minutes < 60) return `${minutes}m`;
+    const hours = Math.round(minutes / 60);
+    if (hours < 48) return `${hours}h`;
+    return `${Math.round(hours / 24)}d`;
   }
 
   const MARQUEE_ITEMS = buildMarquee(data.stats);

--- a/projects/monolith/frontend/src/routes/public/HomepageTopology.svelte
+++ b/projects/monolith/frontend/src/routes/public/HomepageTopology.svelte
@@ -198,7 +198,7 @@
   }
 
   .topology-wrap {
-    max-width: 1360px;
+    max-width: 1500px;
     margin: 0 auto;
     padding: 0 32px;
   }

--- a/projects/monolith/home/observability/stats.py
+++ b/projects/monolith/home/observability/stats.py
@@ -1,10 +1,12 @@
 """Public stats endpoint — exposes non-sensitive cluster and knowledge metrics.
 
-Gathers data from three sources:
+Gathers data from four sources:
 1. Kubernetes API — node, deployment, pod, ArgoCD application counts
-   plus aggregate CPU/memory usage and capacity from the metrics API.
+   plus aggregate CPU/memory usage and capacity from the metrics API,
+   and the monolith ArgoCD Application's last sync time.
 2. ClickHouse (SigNoz) — DCGM GPU utilization and frame buffer usage.
 3. PostgreSQL — knowledge.notes, knowledge.chunks, knowledge.raw_inputs counts.
+4. GitHub API — latest commit on main (unauthenticated; public repo).
 
 Cached for 60 seconds so live metrics (CPU/mem/GPU) feel current without
 hammering ClickHouse or the metrics-server on every page load.
@@ -18,11 +20,15 @@ import os
 import time
 from datetime import datetime, timezone
 
+import httpx
 from sqlalchemy import text
 
 from app.db import get_engine
 from home.observability.clickhouse import ClickHouseClient
 from shared.kubernetes import KubernetesClient
+
+GITHUB_REPO = "jomcgi/homelab"
+ARGOCD_APP_NAME = "monolith"
 
 logger = logging.getLogger(__name__)
 
@@ -142,20 +148,87 @@ async def _query_gpu() -> dict:
         await client.close()
 
 
+async def _query_github_latest_commit() -> dict | None:
+    """Fetch the latest commit on main from the public GitHub API.
+
+    Returns {"sha": <7-char>, "committed_at": <iso>} or None on any failure.
+    Unauthenticated (60 req/hr per IP); the 60s stats cache keeps us under that.
+    """
+    try:
+        async with httpx.AsyncClient(timeout=5.0) as http:
+            resp = await http.get(
+                f"https://api.github.com/repos/{GITHUB_REPO}/commits/main",
+                headers={"Accept": "application/vnd.github+json"},
+            )
+        if resp.status_code != 200:
+            return None
+        data = resp.json()
+        return {
+            "sha": data["sha"][:7],
+            "committed_at": data["commit"]["committer"]["date"],
+        }
+    except Exception:
+        logger.exception("GitHub commit fetch failed")
+        return None
+
+
+async def _query_argocd_monolith_deploy() -> dict | None:
+    """Last-sync timestamp of the monolith ArgoCD Application.
+
+    Reads status.operationState.finishedAt — the wall-clock moment the most
+    recent sync (manual or auto) finished, regardless of result. None if the
+    Application is missing or has no operationState yet.
+    """
+    k8s = KubernetesClient()
+    try:
+        status = await k8s.get_argocd_app_status(ARGOCD_APP_NAME)
+        if not status:
+            return None
+        finished_at = (status.get("operationState") or {}).get("finishedAt")
+        return {"finished_at": finished_at} if finished_at else None
+    except Exception:
+        logger.exception("ArgoCD monolith status fetch failed")
+        return None
+    finally:
+        await k8s.close()
+
+
+async def _query_deploy() -> dict:
+    """Combine 'latest commit on main' + 'last deploy' into one block.
+
+    Each subquery is independent and fail-soft — if one source is unavailable,
+    the other still surfaces. Returns {} if both fail; the frontend skips
+    items whose data is absent.
+    """
+    commit, deploy = await asyncio.gather(
+        _query_github_latest_commit(),
+        _query_argocd_monolith_deploy(),
+    )
+    out: dict = {}
+    if commit:
+        out["latest_commit_sha"] = commit["sha"]
+        out["latest_commit_at"] = commit["committed_at"]
+    if deploy:
+        out["deployed_at"] = deploy["finished_at"]
+    return out
+
+
 async def build_stats() -> dict:
     """Collect all stats and return the response payload."""
     engine = get_engine()
 
-    cluster_counts, knowledge_counts, gpu = await asyncio.gather(
+    cluster_counts, knowledge_counts, gpu, deploy = await asyncio.gather(
         _query_cluster_counts(),
         _query_knowledge_counts(engine),
         _query_gpu(),
+        _query_deploy(),
     )
 
     return {
         "cluster": cluster_counts,
         "knowledge": knowledge_counts,
         "gpu": gpu,
+        "deploy": deploy,
         "platform": {
             "in_production_since": "2025-01",
         },

--- a/projects/monolith/home/observability/stats_test.py
+++ b/projects/monolith/home/observability/stats_test.py
@@ -87,6 +87,15 @@ async def test_build_stats_returns_expected_shape():
         patch("home.observability.stats.ClickHouseClient", return_value=mock_ch),
         patch("home.observability.stats.get_engine", return_value=MagicMock()),
         patch("sqlmodel.Session", return_value=mock_session),
+        patch(
+            "home.observability.stats._query_deploy",
+            new_callable=AsyncMock,
+            return_value={
+                "latest_commit_sha": "abc1234",
+                "latest_commit_at": "2026-04-25T10:00:00Z",
+                "deployed_at": "2026-04-25T10:05:00Z",
+            },
+        ),
     ):
         mock_session.__enter__ = MagicMock(return_value=mock_session)
         mock_session.__exit__ = MagicMock(return_value=False)
@@ -107,8 +116,65 @@ async def test_build_stats_returns_expected_shape():
     assert result["knowledge"]["facts"] == 1309
     assert result["knowledge"]["chunks"] == 5948
     assert result["knowledge"]["raw_inputs"] == 366
+    assert result["deploy"]["latest_commit_sha"] == "abc1234"
+    assert result["deploy"]["deployed_at"] == "2026-04-25T10:05:00Z"
     assert result["platform"]["in_production_since"] == "2025-01"
     assert "cached_at" in result
+
+
+@pytest.mark.asyncio
+async def test_query_deploy_combines_github_and_argocd():
+    commit_payload = {
+        "sha": "abcdef1234567890",
+        "commit": {"committer": {"date": "2026-04-25T10:00:00Z"}},
+    }
+    mock_resp = MagicMock(status_code=200)
+    mock_resp.json = MagicMock(return_value=commit_payload)
+    mock_http = MagicMock()
+    mock_http.get = AsyncMock(return_value=mock_resp)
+    mock_http.__aenter__ = AsyncMock(return_value=mock_http)
+    mock_http.__aexit__ = AsyncMock(return_value=False)
+
+    mock_k8s = MagicMock()
+    mock_k8s.get_argocd_app_status = AsyncMock(
+        return_value={"operationState": {"finishedAt": "2026-04-25T10:05:00Z"}}
+    )
+    mock_k8s.close = AsyncMock()
+
+    with (
+        patch("home.observability.stats.httpx.AsyncClient", return_value=mock_http),
+        patch("home.observability.stats.KubernetesClient", return_value=mock_k8s),
+    ):
+        result = await stats._query_deploy()
+
+    assert result["latest_commit_sha"] == "abcdef1"
+    assert result["latest_commit_at"] == "2026-04-25T10:00:00Z"
+    assert result["deployed_at"] == "2026-04-25T10:05:00Z"
+
+
+@pytest.mark.asyncio
+async def test_query_deploy_returns_partial_when_one_source_fails():
+    """If GitHub is down but ArgoCD answers, the deployed_at item still surfaces."""
+    mock_resp = MagicMock(status_code=503)
+    mock_http = MagicMock()
+    mock_http.get = AsyncMock(return_value=mock_resp)
+    mock_http.__aenter__ = AsyncMock(return_value=mock_http)
+    mock_http.__aexit__ = AsyncMock(return_value=False)
+
+    mock_k8s = MagicMock()
+    mock_k8s.get_argocd_app_status = AsyncMock(
+        return_value={"operationState": {"finishedAt": "2026-04-25T10:05:00Z"}}
+    )
+    mock_k8s.close = AsyncMock()
+
+    with (
+        patch("home.observability.stats.httpx.AsyncClient", return_value=mock_http),
+        patch("home.observability.stats.KubernetesClient", return_value=mock_k8s),
+    ):
+        result = await stats._query_deploy()
+
+    assert "latest_commit_sha" not in result
+    assert result["deployed_at"] == "2026-04-25T10:05:00Z"
 
 
 @pytest.mark.asyncio

--- a/projects/monolith/shared/kubernetes.py
+++ b/projects/monolith/shared/kubernetes.py
@@ -88,6 +88,29 @@ class KubernetesClient:
         )
         return len(result.get("items", []))
 
+    async def get_argocd_app_status(
+        self, name: str, namespace: str = "argocd"
+    ) -> dict | None:
+        """Return the raw status block of a single ArgoCD Application, or None on miss.
+
+        Lets callers pull whatever subfield they need (operationState.finishedAt,
+        sync.revision, health.status, ...) without baking field choices into the
+        client.
+        """
+        api = await self._ensure_client()
+        custom = client.CustomObjectsApi(api)
+        try:
+            result = await custom.get_namespaced_custom_object(
+                group="argoproj.io",
+                version="v1alpha1",
+                namespace=namespace,
+                plural="applications",
+                name=name,
+            )
+        except client.exceptions.ApiException:
+            return None
+        return result.get("status")
+
     async def aggregate_node_resources(self) -> dict[str, float]:
         """Sum CPU and memory across all nodes from the metrics API.
 


### PR DESCRIPTION
## Summary
Three small quality-of-life changes on the homelab homepage, bundled because they all ship via the same monolith chart bump.

1. **Remove SLO percentage badge** under each topology node (`DagRenderer.svelte`). The number was visual noise next to the status color; the full SLO breakdown is still in the detail panel when a node is selected.
2. **Widen the topology DAG by ~10%** (`max-width: 1360 -> 1500px`). The SVG uses `preserveAspectRatio="meet"`, so a single container width acts as a uniform zoom — no layout reflow.
3. **Replace the static ticker stack with live signals.** Drops `go * python * sveltekit` (re-shown every marquee loop with no signal). Adds two items sourced from existing infra:
   - `last commit: <shortsha>` via the public GitHub API (unauthenticated; the existing 60s stats cache stays under the 60/hr rate limit).
   - `deployed Nm ago` from the monolith ArgoCD Application's `status.operationState.finishedAt`, via a new `KubernetesClient.get_argocd_app_status` helper.
   Both follow the existing 'skip if data is absent' convention — a GitHub/ArgoCD outage just hides the affected item.

Chart bumped 0.62.5 -> 0.62.8 (one bump per concern); `application.yaml` `targetRevision` kept in sync.

## Test plan
- [ ] CI green (includes the new `_query_deploy` unit tests in `stats_test.py`)
- [ ] After ArgoCD sync, visit `/`:
  - [ ] No `99.90%` numbers under topology nodes
  - [ ] DAG visibly wider on screens >=1500px
  - [ ] Ticker shows `last commit: <sha>` and `deployed Nm ago` (no `go * python * sveltekit`)
- [ ] Click a topology node and confirm the detail panel still shows the SLO percentage

🤖 Generated with [Claude Code](https://claude.com/claude-code)