### PR TITLE
fix(monolith): grant 'get' on argoproj.io applications for deploy ticker

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.62.8
+version: 0.62.9
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/templates/rbac.yaml
+++ b/projects/monolith/chart/templates/rbac.yaml
@@ -13,7 +13,7 @@ rules:
     verbs: ["list"]
   - apiGroups: ["argoproj.io"]
     resources: ["applications"]
-    verbs: ["list"]
+    verbs: ["list", "get"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.62.8
+      targetRevision: 0.62.9
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
## Summary
PR #2220 added a 'deployed Nm ago' marquee item that reads the monolith ArgoCD Application's last sync timestamp via 'get_namespaced_custom_object'. The ClusterRole only granted 'list' on 'argoproj.io/applications' (used by the existing app-count helper), so the GET was silently denied and the item never rendered on https://public.jomcgi.dev/.

This grants 'get' alongside 'list' (least-privilege) and bumps the chart so ArgoCD picks it up.

## Test plan
- [ ] CI green
- [ ] After ArgoCD sync, hard-refresh https://public.jomcgi.dev/ and confirm the marquee includes 'deployed Nm ago' alongside 'last commit: <sha>'
- [ ] Verify 'argocd: 27 apps' still works (regression check on the 'list' verb)

## Lesson
Adding new K8s API calls in app code needs a paired RBAC audit -- 'list' and 'get' are independent verbs. The fail-soft swallow in 'get_argocd_app_status' made this look like a missing app rather than a denied request. Future iteration: rate-limited WARN log on first ApiException so the failure mode is visible in SigNoz instead of by absence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)