### PR TITLE
fix(monolith): drop cringe staff-eng-shaped phrasing from home meta

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.62.10
+version: 0.62.11
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.62.10
+      targetRevision: 0.62.11
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/routes/public/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/+page.svelte
@@ -73,7 +73,7 @@
   <title>jomcgi</title>
   <meta
     name="description"
-    content="Platform engineering, observability, developer experience."
+    content="Platform Engineer @ Semgrep. Observability obsessed. Caremad about developer experience."
   />
 </svelte:head>
 

--- a/projects/monolith/frontend/src/routes/public/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/+page.svelte
@@ -73,7 +73,7 @@
   <title>jomcgi</title>
   <meta
     name="description"
-    content="Platform engineering, observability, developer experience. Ten years of staff-eng-shaped moves."
+    content="Platform engineering, observability, developer experience."
   />
 </svelte:head>
 


### PR DESCRIPTION
Trims the public homepage meta description down to the substantive bit.