### PR TITLE
docs(agent_platform): add rules agent to cluster_agents description

### DIFF
--- a/projects/agent_platform/README.md
+++ b/projects/agent_platform/README.md
@@ -12,7 +12,7 @@ See [docs/agents.md](../../docs/agents.md) for the full architecture.
 | ------------------------ | ----------- |
 | **orchestrator**         | Go service that dispatches agent jobs via NATS JetStream |
 | **sandboxes**            | Shell setup script for MCP profiles (`setup-mcp-profiles.sh`); Kubernetes sandbox pod definitions live in `chart/sandboxes/` and `chart/agent-sandbox/` |
-| **cluster_agents**       | Go service that monitors cluster health and runs autonomous improvement agents (patrol, escalator, PR fix, README freshness, test coverage, etc.) |
+| **cluster_agents**       | Go service that monitors cluster health and runs autonomous improvement agents (patrol, escalator, PR fix, README freshness, test coverage, and rules) |
 | **api_gateway**          | Nginx-based API gateway with route-based backend selection for api.jomcgi.dev |
 | **goose_agent**          | Goose agent container and configuration |
 | **inference**            | On-cluster LLM inference and embedding inference (model configured per environment) |


### PR DESCRIPTION
## Summary

- The `cluster_agents` row in `projects/agent_platform/README.md` listed agents as "patrol, escalator, PR fix, README freshness, test coverage, etc." but omitted the **rules agent** (`rules_agent.go`, registered as `NewRulesAgent` in `main.go`)
- Updated the description to explicitly list all 6 agents: patrol, escalator, PR fix, README freshness, test coverage, and rules

## Test plan

- [ ] Verify the README renders correctly on GitHub
- [ ] Confirm all 6 agents are now listed in the `cluster_agents` row

🤖 Generated with [Claude Code](https://claude.com/claude-code)