### PR TITLE
ci(semgrep): add claude-print-missing-permission-mode rule

### DIFF
--- a/bazel/semgrep/rules/BUILD
+++ b/bazel/semgrep/rules/BUILD
@@ -263,3 +263,19 @@ semgrep_test(
     rules = [":sql_rules"],
     tags = ["semgrep"],
 )
+
+# claude-print-missing-permission-mode uses languages: [generic] so its fixture is a YAML file.
+# This test wires the rule to its annotation fixture independently of shell_rules_test
+# (which scans shell/*.bash sources and does not include YAML-annotated generic fixtures).
+filegroup(
+    name = "claude_print_missing_permission_mode_rule",
+    srcs = ["shell/claude-print-missing-permission-mode.yaml"],
+)
+
+semgrep_test(
+    name = "claude_print_missing_permission_mode_test",
+    srcs = ["//bazel/semgrep/tests:claude_print_missing_permission_mode_fixtures"],
+    env = {"SEMGREP_TEST_MODE": "1"},
+    rules = [":claude_print_missing_permission_mode_rule"],
+    tags = ["semgrep"],
+)

--- a/bazel/semgrep/rules/shell/claude-print-missing-permission-mode.yaml
+++ b/bazel/semgrep/rules/shell/claude-print-missing-permission-mode.yaml
@@ -1,0 +1,27 @@
+rules:
+  - id: claude-print-missing-permission-mode
+    languages: [generic]
+    severity: ERROR
+    message: >-
+      'claude --print' is invoked without '--permission-mode'. When running
+      claude non-interactively with --print, always pass '--permission-mode'
+      (e.g. '--permission-mode bypassPermissions') to prevent interactive
+      permission prompts from hanging CI/CD pipelines or unattended scripts.
+    metadata:
+      category: best-practices
+      subcategory: shell
+      confidence: HIGH
+      likelihood: HIGH
+      impact: MEDIUM
+      technology: [claude, shell]
+      description: >-
+        Detects 'claude --print' invocations that omit '--permission-mode'.
+        Without this flag, claude may pause waiting for interactive input,
+        causing CI/CD pipelines or automated scripts to hang indefinitely.
+    paths:
+      include:
+        - "tools/**/*.sh"
+        - "bazel/**/*.sh"
+    patterns:
+      - pattern-regex: 'claude\b[^\n]*--print\b[^\n]*'
+      - pattern-not-regex: '--permission-mode'

--- a/bazel/semgrep/tests/BUILD
+++ b/bazel/semgrep/tests/BUILD
@@ -9,6 +9,7 @@ filegroup(
         # Exclude Go-rule reference fixtures that are not tested against yaml_rules.
         # Exclude SQL/generic and kubernetes-specific fixtures that are tested separately.
         exclude = [
+            "fixtures/claude-print-missing-permission-mode.yaml",
             "fixtures/fastapi-bare-tuple-return.yaml",
             "fixtures/no-create-extension-sql.yaml",
             "fixtures/no-discarded-json-marshal.yaml",
@@ -67,6 +68,13 @@ filegroup(
 filegroup(
     name = "require_component_label_in_selector_fixtures",
     srcs = ["fixtures/require-component-label-in-selector.yaml"],
+)
+
+# Fixture for the claude-print-missing-permission-mode rule (languages: generic, paths: shell *.sh).
+# Referenced by //bazel/semgrep/rules:claude_print_missing_permission_mode_test.
+filegroup(
+    name = "claude_print_missing_permission_mode_fixtures",
+    srcs = ["fixtures/claude-print-missing-permission-mode.yaml"],
 )
 
 # Fixtures for kubernetes rules (require-readiness-probe, require-resource-limits, etc.).

--- a/bazel/semgrep/tests/fixtures/claude-print-missing-permission-mode.yaml
+++ b/bazel/semgrep/tests/fixtures/claude-print-missing-permission-mode.yaml
@@ -1,0 +1,30 @@
+# Tests for claude-print-missing-permission-mode rule.
+# Shell scripts invoking 'claude --print' must also pass '--permission-mode'
+# to avoid interactive permission prompts that hang in CI/CD pipelines.
+---
+# ruleid: claude-print-missing-permission-mode
+claude --print "$(cat prompt.txt)"
+
+---
+# ruleid: claude-print-missing-permission-mode
+claude --output-format text --print "$(cat prompt.txt)"
+
+---
+# ruleid: claude-print-missing-permission-mode
+claude --model claude-opus-4-5 --print < prompt.txt
+
+---
+# ok: claude-print-missing-permission-mode — includes --permission-mode after --print
+claude --print --permission-mode bypassPermissions "$(cat prompt.txt)"
+
+---
+# ok: claude-print-missing-permission-mode — includes --permission-mode before --print
+claude --permission-mode bypassPermissions --print "$(cat prompt.txt)"
+
+---
+# ok: claude-print-missing-permission-mode — includes --permission-mode with other flags
+claude --model claude-opus-4-5 --permission-mode acceptEdits --print < prompt.txt
+
+---
+# ok: claude-print-missing-permission-mode — no --print flag at all
+claude --permission-mode bypassPermissions "$(cat prompt.txt)"


### PR DESCRIPTION
## Summary

- Adds a new semgrep rule `claude-print-missing-permission-mode` at `bazel/semgrep/rules/shell/claude-print-missing-permission-mode.yaml`
- Catches shell scripts that invoke `claude --print` without also passing `--permission-mode`, which can hang CI/CD pipelines waiting for interactive input
- Scoped to `tools/**/*.sh` and `bazel/**/*.sh` using `languages: [generic]` with regex patterns
- Adds test fixture at `bazel/semgrep/tests/fixtures/claude-print-missing-permission-mode.yaml` with `ruleid:` and `ok:` annotations
- Registers a dedicated `claude_print_missing_permission_mode_test` Bazel target in `rules/BUILD` following the existing generic-rule convention
- Excludes the fixture from `yaml_fixtures` in `tests/BUILD` (consistent with other non-yaml-language fixtures)

## Test plan

- [ ] CI semgrep test `//bazel/semgrep/rules:claude_print_missing_permission_mode_test` passes with 3 expected findings and 4 non-findings
- [ ] `//bazel/semgrep/rules:shell_rules_test` continues to pass (existing `.bash` fixtures unaffected)
- [ ] `//bazel/semgrep/rules:yaml_rules_test` continues to pass (new fixture excluded from `yaml_fixtures`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)