### PR TITLE
test(semgrep): add fixture for no-hardcoded-claude-model-subprocess rule

### DIFF
--- a/bazel/semgrep/tests/fixtures/no-hardcoded-claude-model-subprocess.py
+++ b/bazel/semgrep/tests/fixtures/no-hardcoded-claude-model-subprocess.py
@@ -1,0 +1,60 @@
+# Tests for no-hardcoded-claude-model-subprocess rule.
+# Flags create_subprocess_exec calls where '--model' is followed by a string literal.
+import asyncio
+import os
+
+
+# ruleid: no-hardcoded-claude-model-subprocess
+async def bad_hardcoded_model_exec():
+    await asyncio.create_subprocess_exec(
+        "claude",
+        "--model",
+        "claude-opus-4-5",
+    )
+
+
+# ruleid: no-hardcoded-claude-model-subprocess
+async def bad_hardcoded_model_exec_multiarg():
+    proc = await asyncio.create_subprocess_exec(
+        "claude",
+        "--no-color",
+        "--model",
+        "claude-sonnet-4-5",
+        "--max-turns",
+        "10",
+    )
+    return proc
+
+
+# ok: model name is read from an environment variable
+async def ok_model_from_env():
+    model = os.environ.get("CLAUDE_MODEL", "claude-opus-4-5")
+    await asyncio.create_subprocess_exec(
+        "claude",
+        "--model",
+        model,
+    )
+
+
+# ok: model name comes from a variable (computed elsewhere)
+async def ok_model_variable():
+    model = get_model_name()
+    await asyncio.create_subprocess_exec(
+        "claude",
+        "--model",
+        model,
+    )
+
+
+# ok: no --model flag at all
+async def ok_no_model_flag():
+    await asyncio.create_subprocess_exec(
+        "claude",
+        "--no-color",
+        "--max-turns",
+        "5",
+    )
+
+
+def get_model_name() -> str:
+    return os.environ.get("CLAUDE_MODEL", "claude-opus-4-5")


### PR DESCRIPTION
## Summary
- Adds `bazel/semgrep/tests/fixtures/no-hardcoded-claude-model-subprocess.py` to provide test coverage for the `no-hardcoded-claude-model-subprocess` semgrep rule
- Includes 2 `# ruleid:` cases (hardcoded string literal after `--model`) and 3 `# ok:` cases (env var, variable, no `--model` flag)
- Follows the exact fixture pattern used by existing rules (e.g., `no-broad-except-swallow.py`)

## Test plan
- [ ] CI semgrep test run validates the fixture against the rule and confirms expected match/no-match behaviour

🤖 Generated with [Claude Code](https://claude.com/claude-code)