### PR TITLE
feat(monolith): edge-cache public home page via shared headers module

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.62.13
+version: 0.63.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.62.13
+      targetRevision: 0.63.0
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/lib/cache-headers.js
+++ b/projects/monolith/frontend/src/lib/cache-headers.js
@@ -1,0 +1,5 @@
+const ONE_DAY = 86_400;
+const ONE_YEAR = 31_536_000;
+
+// 60s fresh · 24h SWR (background refresh) · 1y SIE (cluster-down resilience)
+export const PAGE_CACHE_CONTROL = `public, s-maxage=60, stale-while-revalidate=${ONE_DAY}, stale-if-error=${ONE_YEAR}`;

--- a/projects/monolith/frontend/src/routes/public/+page.server.js
+++ b/projects/monolith/frontend/src/routes/public/+page.server.js
@@ -1,3 +1,5 @@
+import { PAGE_CACHE_CONTROL } from "$lib/cache-headers.js";
+
 const API_BASE = process.env.API_BASE || "http://localhost:8000";
 
 const STATIC_TOPOLOGY = {
@@ -211,11 +213,12 @@ async function _fetchJson(fetchFn, path) {
   }
 }
 
-export async function load({ fetch }) {
+export async function load({ fetch, setHeaders }) {
   const [topology, stats] = await Promise.all([
     _fetchJson(fetch, "/api/home/observability/topology"),
     _fetchJson(fetch, "/api/home/observability/stats"),
   ]);
+  setHeaders({ "cache-control": PAGE_CACHE_CONTROL });
   return {
     topology: topology ?? STATIC_TOPOLOGY,
     stats,


### PR DESCRIPTION
## Summary

- Adds `projects/monolith/frontend/src/lib/cache-headers.js` exporting a single reusable `PAGE_CACHE_CONTROL` constant (`public, s-maxage=60, stale-while-revalidate=86400, stale-if-error=31536000`).
- Wires it into `routes/public/+page.server.js` so `public.jomcgi.dev/` returns a `Cache-Control` header — Cloudflare currently returns `cf-cache-status: DYNAMIC` on every request because no caching directive is set, so every visitor is paying the full origin round-trip (CF → cloudflared → Envoy → SvelteKit SSR → FastAPI → ClickHouse).

## Edge behavior after this change

| Time since cache | Origin healthy | Origin erroring |
|---|---|---|
| 0–60s | Pure edge hit | Pure edge hit |
| 60s–24h | Stale to user · refresh in background (SWR) | Stale to user · SIE keeps it alive |
| 24h–1y | Sync refresh (user waits) | Stale to user (SIE) |

Users perceive edge-speed latency (~40ms) on any hit within 24h of any prior visit, healthy origin or not.

## Test plan

- [ ] CI green (format + semgrep + tests)
- [ ] After deploy: `curl -sI https://public.jomcgi.dev/` returns `cache-control: public, s-maxage=60, stale-while-revalidate=86400, stale-if-error=31536000`
- [ ] After deploy: second `curl -sI` shows `cf-cache-status: HIT` (within ~60s of the first)
- [ ] TTFB on subsequent loads is sub-100ms regardless of FastAPI in-memory cache state

🤖 Generated with [Claude Code](https://claude.com/claude-code)