### PR TITLE
feat(claude): add buildbuddy MCP server to project config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,7 @@ credentials.json
 kubeconfig
 *.kubeconfig
 **/.claude/settings.local.json
+.mcp.local.json
 
 # OS files
 .DS_Store

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "buildbuddy": {
+      "type": "http",
+      "url": "https://jomcgi.buildbuddy.io/mcp",
+      "headers": {
+        "Authorization": "Bearer ${BUILDBUDDY_API_KEY}"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Adds project-scoped \`.mcp.json\` registering the BuildBuddy MCP server (\`https://jomcgi.buildbuddy.io/mcp\`) so the config travels with the repo instead of living in user-scope \`~/.claude.json\`.
- The \`Authorization\` header templates \`\${BUILDBUDDY_API_KEY}\` from the shell env — no secret enters version control.
- Gitignores \`.mcp.local.json\` as a safety belt in case a per-user fallback config (with literal token) is ever needed.

## Why
BuildBuddy MCP requires \`Authorization: Bearer <api-key>\`; the original \`claude mcp add\` ran without the \`-H\` flag, so the server failed to authenticate. Moving the config into the repo means any clone of homelab (or future contributor) gets the wiring for free; only the secret needs per-machine setup.

## Test plan
- [ ] After merge, run \`claude mcp remove buildbuddy\` to drop the user-scope dupe.
- [ ] Confirm \`BUILDBUDDY_API_KEY\` is in the shell env where \`claude\` is launched.
- [ ] Restart \`claude\`, approve the project-scoped MCP server when prompted, and run \`/mcp\` to verify it connects.
- [ ] If \`/mcp\` shows auth failure, Claude Code did not expand \`\${VAR}\` in HTTP headers — fall back to a gitignored \`.mcp.local.json\` with the literal key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)