### PR TITLE
feat(knowledge): close the research-pipeline loop with web access and forward wikilinks

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.63.0
+version: 0.64.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.63.0
+      targetRevision: 0.64.0
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/knowledge/gardener.py
+++ b/projects/monolith/knowledge/gardener.py
@@ -105,6 +105,40 @@ against. If you genuinely need to rewrite an atom from scratch, first Read
 its current frontmatter, copy the `aliases:` array verbatim into your new
 content, then Write — never lose alias entries.
 
+## Linking to neighboring concepts (forward links)
+
+When the body of an atom names another distinct concept — a named tool,
+heuristic, person, framework, book, method, or term that could stand on
+its own as an atom — wrap it in `[[Concept Name]]`. Examples:
+
+- "Inspired by [[Conway's Law]], we split the team along the seam..."
+- "We measured this with [[DORA Metrics]] over six weeks."
+- "Borrowed the framing from [[The Staff Engineer's Path]]."
+
+Body wikilinks are the gardener's primary mechanism for organic graph
+growth. Unresolved links queue as gaps and feed the external-research
+pipeline — so forward-linking is how a concept earns the right to exist
+on its own atom. This complements `aliases:` (which handles inbound
+resolution from other notes) and typed `edges:` (which captures
+structured semantic relations).
+
+Guardrails — DO wikilink:
+- Named concepts that could each be their own atom (proper nouns,
+  named heuristics, named tools, named frameworks, book titles)
+- The load-bearing 3–5 references per atom — pick the ones a future
+  reader would want to navigate to
+
+Guardrails — DON'T wikilink:
+- Generic words ("the team", "the meeting", "yesterday", "production")
+- Multi-clause phrases — wikilinks must name a single concept
+- Restatements of the atom's own title
+- Every domain noun that happens to appear — quality over quantity
+
+If a wikilink target already exists at `{processed_root}/<slug>.md`,
+prefer that exact slug as the link target. If it doesn't exist, write
+the natural title-cased form — the gap-classifier and aliases system
+handle resolution.
+
 Title: {title}
 
 """
@@ -124,6 +158,19 @@ Steps:
    - id, title, type (atom or fact), tags
    - edges: derives_from: [{note_id}]
 6. Do NOT create a new active/task note. Only create atom or fact notes.
+
+## Linking to neighboring concepts (forward links)
+
+When the body of a distilled atom names another distinct concept — a
+named tool, heuristic, framework, book, or term that could stand on its
+own — wrap it in `[[Concept Name]]`. Body wikilinks queue as gaps and
+feed the external-research pipeline; forward-linking is how the graph
+grows organically from each new atom.
+
+Wikilink load-bearing concepts only (3–5 max per atom). Skip generic
+words ("the team", "production"), multi-clause phrases, and the atom's
+own title. If a target already exists at `{processed_root}/<slug>.md`,
+prefer that slug; otherwise write the natural title-cased form.
 
 Title: {title}
 
@@ -690,7 +737,7 @@ class Gardener:
             "--print",
             "--dangerously-skip-permissions",
             "--allowedTools",
-            "Bash,Read,Write,Edit",
+            "Bash,Read,Write,Edit,WebSearch,WebFetch",
             "-p",
             prompt,
             stdout=asyncio.subprocess.PIPE,

--- a/projects/monolith/knowledge/gardener_test.py
+++ b/projects/monolith/knowledge/gardener_test.py
@@ -12,6 +12,7 @@ from sqlmodel.pool import StaticPool
 from knowledge.gardener import (
     Gardener,
     _CLAUDE_PROMPT_HEADER,
+    _DISTILL_PROMPT,
     _slugify,
     _split_frontmatter,
 )
@@ -1392,6 +1393,21 @@ class TestPromptTemplateInstructions:
         silently drop the path and Claude will have no file to read.
         """
         assert "{raw_file_path}" in _CLAUDE_PROMPT_HEADER
+
+    def test_prompt_header_encourages_forward_wikilinks(self):
+        """Guard against losing the body-wikilink guidance.
+
+        Body wikilinks ([[...]] in prose) are the trigger for the gap →
+        research → atom pipeline (store.py captures them as kind='link'
+        which feeds gap_classifier). Without this section the gardener
+        emits typed edges only, the graph stops growing organically, and
+        the research pipeline starves for inputs. If this guidance is
+        removed the loop breaks silently — there's no other test that
+        would catch it.
+        """
+        assert "Linking to neighboring concepts" in _CLAUDE_PROMPT_HEADER
+        assert "[[Concept Name]]" in _CLAUDE_PROMPT_HEADER
+        assert "Linking to neighboring concepts" in _DISTILL_PROMPT
 
 
 class TestRecordFailedProvenance:

--- a/tools/knowledge_research/bin/research-gap.sh
+++ b/tools/knowledge_research/bin/research-gap.sh
@@ -105,9 +105,18 @@ for stub in _researching/*.md; do
 	fi
 
 	echo "==> researching: $slug"
-	if claude --print \
+	# Why bypassPermissions + explicit --allowedTools: in --print
+	# (non-interactive) mode there's no permission prompt UI, so tool
+	# permissions must come from settings.json or be bypassed. We bypass
+	# and pin the allowlist instead, because this script runs from the
+	# vault dir (not a homelab worktree), so project allowlists in
+	# `homelab/.claude/settings.json` don't apply. The allowlist mirrors
+	# the prompt's two-phase flow — Read/Bash/Glob/Grep for Phase 1 vault
+	# exploration, Task to dispatch the Phase 2 research subagent, and
+	# WebSearch/WebFetch so that subagent can actually fetch sources.
+	if claude --print --permission-mode bypassPermissions \
 		--model "$MODEL" \
-		--permission-mode acceptEdits \
+		--allowedTools "Bash,Read,Write,Edit,Glob,Grep,Task,WebSearch,WebFetch" \
 		--append-system-prompt "$(cat "$PROMPT_FILE")" \
 		--add-dir "$VAULT" \
 		-- \


### PR DESCRIPTION
## Summary

Three compounding fixes that close the gap → research → atom pipeline. Each one in isolation is incremental; together they're a step change for organic knowledge-graph growth.

1. **Gardener gets web access.** `projects/monolith/knowledge/gardener.py:740` — `WebSearch,WebFetch` added to the Sonnet subprocess `--allowedTools`. The existing `_research_source_tier` classifier already buckets research raws by web_fetch source count (0 → personal, 1 → direct, 2+ → research) but those entries could never appear because the subprocess could never call WebFetch. Tier code was dormant; it isn't anymore.

2. **research-gap.sh gets web access.** `tools/knowledge_research/bin/research-gap.sh` — switched from `--permission-mode acceptEdits` to `--permission-mode bypassPermissions` with an explicit `--allowedTools` allowlist (`Bash,Read,Write,Edit,Glob,Grep,Task,WebSearch,WebFetch`). The script `cd`s into the vault before invoking claude, so the homelab project's `.claude/settings.json` allowlist doesn't apply. The new allowlist covers the prompt's two-phase flow: Phase 1 vault exploration, Phase 2 Task-dispatched research subagent, and the actual web tools that subagent needs.

3. **Gardener prompts teach forward wikilinks.** `_CLAUDE_PROMPT_HEADER` and `_DISTILL_PROMPT` now have a "Linking to neighboring concepts" section telling the gardener to wrap load-bearing named concepts in `[[Concept Name]]`. `projects/monolith/knowledge/store.py:112-122` captures body wikilinks as `kind='link'` rows, which feed the gap-classifier — but the prompts previously only taught inbound `aliases:` resolution and typed `edges:`, never outbound prose linking. Combined with (1) and (2), the loop closes: atoms emit wikilinks → unresolved links queue as gaps → gaps classify as external → research-gap.sh fetches sources → new atoms emit their own wikilinks → graph densifies on its own.

A regression test pins the new wikilink guidance in both prompts, mirroring the existing `TestPromptTemplateInstructions` guards. Silent removal of the section would break the loop without any other signal.

## Test plan

- [ ] CI: `gardener_test.py::TestPromptTemplateInstructions::test_prompt_header_encourages_forward_wikilinks` passes
- [ ] CI: existing `gardener_test.py` allowlist assertion (`"Bash" in allowed_tools and "Write" in allowed_tools`) still passes — additive change, should be unaffected
- [ ] CI: semgrep `claude-print-missing-permission-mode` passes — `--permission-mode bypassPermissions` is on the same line as `claude --print` to satisfy the line-bounded regex
- [ ] After merge + rollout: trigger a gardener tick on a vault with research-tier raws and confirm `web_fetch` entries appear in `sources` (so tier classification produces `direct`/`research` instead of always `personal`)
- [ ] After merge: run `research-gap.sh --max 1` against a real `_researching/<external>.md` stub and confirm a researched atom lands at vault root with grounded URL citations
- [ ] After a few gardener cycles: spot-check a freshly-decomposed atom for `[[wikilink]]` body references; confirm new gap stubs appear in `_researching/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)