### PR TITLE
feat(monolith): add stars domain for dark-sky locations

### DIFF
--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -7,6 +7,7 @@
 # gazelle:exclude home
 # gazelle:exclude scheduler
 # gazelle:exclude shared
+# gazelle:exclude stars
 # gazelle:semgrep_exclude_rules avoid-sqlalchemy-text,sqlmodel-datetime-without-factory,tainted-fastapi-http-request-httpx,tainted-path-traversal-stdlib-fastapi
 load("@aspect_bazel_lib//lib:tar.bzl", "tar")
 load("@aspect_rules_py//py:defs.bzl", "py_library")
@@ -37,6 +38,7 @@ py_venv_binary(
             "home/**/*.py",
             "scheduler/**/*.py",
             "shared/**/*.py",
+            "stars/**/*.py",
         ],
         exclude = [
             "**/*_test.py",
@@ -61,6 +63,7 @@ py_library(
             "home/**/*.py",
             "scheduler/**/*.py",
             "shared/**/*.py",
+            "stars/**/*.py",
         ],
         exclude = [
             "**/*_test.py",
@@ -70,6 +73,7 @@ py_library(
     ),  # keep
     visibility = ["//:__subpackages__"],
     deps = [
+        "@pip//astral",
         "@pip//discord_py",
         "@pip//dulwich",
         "@pip//fastapi",
@@ -2714,5 +2718,40 @@ py_test(
         ":monolith_backend",
         ":shared_testing",
         "@pip//pytest",
+    ],
+)
+
+py_test(
+    name = "stars_scoring_test",
+    srcs = ["stars/scoring_test.py"],
+    imports = ["."],
+    deps = [
+        ":monolith_backend",
+        "@pip//pydantic",
+        "@pip//pytest",
+    ],
+)
+
+py_test(
+    name = "stars_service_test",
+    srcs = ["stars/service_test.py"],
+    imports = ["."],
+    deps = [
+        ":monolith_backend",
+        "@pip//pytest",
+        "@pip//sqlmodel",
+    ],
+)
+
+py_test(
+    name = "stars_router_test",
+    srcs = ["stars/router_test.py"],
+    imports = ["."],
+    deps = [
+        ":monolith_backend",
+        "@pip//fastapi",
+        "@pip//httpx",
+        "@pip//pytest",
+        "@pip//sqlmodel",
     ],
 )

--- a/projects/monolith/app/main.py
+++ b/projects/monolith/app/main.py
@@ -14,6 +14,7 @@ import chat
 import home
 import knowledge
 import scheduler
+import stars
 from home.observability.router import warm_cache, warm_stats_cache
 
 configure_logging()
@@ -64,6 +65,7 @@ async def lifespan(app: FastAPI):
 
         knowledge_startup(session)
         home.on_startup_jobs(session)
+        stars.on_startup_jobs(session)
 
     # Start Discord bot + chat jobs if configured
     bot = None
@@ -196,6 +198,7 @@ home.register(app)
 chat.register(app)
 knowledge.register(app)
 scheduler.register(app)
+stars.register(app)
 app.mount("/mcp", _mcp_app)
 
 

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.64.0
+version: 0.65.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/migrations/20260426000000_stars_schema.sql
+++ b/projects/monolith/chart/migrations/20260426000000_stars_schema.sql
@@ -1,0 +1,19 @@
+-- Stars domain: dark-sky locations refresh history.
+-- One row per scheduled refresh; reads always target the latest status='ok' row.
+
+CREATE SCHEMA IF NOT EXISTS stars;
+
+CREATE TABLE stars.refresh_runs (
+    id              BIGSERIAL PRIMARY KEY,
+    started_at      TIMESTAMPTZ NOT NULL,
+    completed_at    TIMESTAMPTZ,
+    status          TEXT NOT NULL,           -- 'ok' | 'error' | 'running'
+    locations_count INTEGER,
+    payload         JSONB,
+    error           TEXT
+);
+
+-- Hot path: latest successful refresh.
+CREATE INDEX idx_stars_refresh_runs_ok_completed
+    ON stars.refresh_runs (completed_at DESC)
+    WHERE status = 'ok';

--- a/projects/monolith/chart/migrations/atlas.sum
+++ b/projects/monolith/chart/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:w9IX5seo9AER1s6PtKEuGwBWuMoNRJxFh8tRjxGUJDM=
+h1:eVEYqzumHhNnVCX8y3x726HyxXgTVTqWk5leooo6DIw=
 20260330000000_initial_schema.sql h1:J2futpSW0nJAIRR7nR7ssT7LwXIYrvRI+PkHb5Y4tLI=
 20260403000000_chat_schema.sql h1:pERUFC0vzM95etRuzp43XzkCV7lBCzrrtY5Mk7aF3CA=
 20260404000000_chat_attachments.sql h1:tv+Fdbr1rQC5nzUxfaBC0O6fu2OMGgLWf+YNg1WQXi4=
@@ -19,3 +19,4 @@ h1:w9IX5seo9AER1s6PtKEuGwBWuMoNRJxFh8tRjxGUJDM=
 20260425020000_drop_gap_source_note_fk.sql h1:yY9oqtTSmywdZx7Ft5MtICfc2h1wyZicxppeEkWzLjs=
 20260425030000_knowledge_gaps_research_attempts.sql h1:aRmYysVgqThjJGiuI8qZPHnCtcO21666xNKayUN+lpI=
 20260425040000_knowledge_gaps_state_check_widen.sql h1:6NWOB+AVKMdGzLytpHAsV1CkTNN7f286idqR5wh87IE=
+20260426000000_stars_schema.sql h1:hkWnyNG7b3ls4Ui04FFQRqRu3e+zdjgWioR5+bwa6iM=

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.64.0
+      targetRevision: 0.65.0
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/stars/__init__.py
+++ b/projects/monolith/stars/__init__.py
@@ -1,0 +1,31 @@
+"""Stars domain — best stargazing locations in Scotland for the next 72 hours.
+
+Refresh-on-schedule pattern: a registered job hits MET Norway, scores each
+seed location, and writes one ``stars.refresh_runs`` row per refresh. The read
+endpoint serves the most recent successful row, so failed refreshes never
+break the read path — the last good payload keeps serving until the next
+success.
+"""
+
+from fastapi import FastAPI
+
+
+def register(app: FastAPI) -> None:
+    from stars.router import router
+
+    app.include_router(router)
+
+
+def on_startup_jobs(session) -> None:
+    from shared.scheduler import register_job
+    from stars.service import refresh_handler
+
+    # MET Norway updates hourly; refresh slightly more often so we don't drift
+    # if a refresh fails and the next one is delayed by ttl_secs.
+    register_job(
+        session,
+        name="stars.refresh",
+        interval_secs=3600,
+        handler=refresh_handler,
+        ttl_secs=900,
+    )

--- a/projects/monolith/stars/models.py
+++ b/projects/monolith/stars/models.py
@@ -1,0 +1,33 @@
+"""SQLModel definitions for the stars schema.
+
+Single history table: each refresh writes one row capturing the run's status
++ scored payload. Reads always target the latest ``status='ok'`` row, so
+failed refreshes never break the read path — the last good payload keeps
+serving until the next success.
+"""
+
+from datetime import datetime
+from typing import Any, Literal
+
+from sqlalchemy import JSON, Column
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlmodel import Field, SQLModel
+
+# Postgres uses JSONB; SQLite test fixture falls back to JSON.
+_JSONB = JSONB().with_variant(JSON(), "sqlite")
+
+RefreshStatus = Literal["ok", "error", "running"]
+
+
+# nosemgrep: sqlmodel-datetime-without-factory (completed_at is intentionally NULL until set)
+class RefreshRun(SQLModel, table=True):
+    __tablename__ = "refresh_runs"
+    __table_args__ = {"schema": "stars", "extend_existing": True}
+
+    id: int | None = Field(default=None, primary_key=True)
+    started_at: datetime
+    completed_at: datetime | None = None
+    status: RefreshStatus = Field(default="running")
+    locations_count: int | None = None
+    payload: dict[str, Any] | None = Field(default=None, sa_column=Column(_JSONB))
+    error: str | None = None

--- a/projects/monolith/stars/router.py
+++ b/projects/monolith/stars/router.py
@@ -1,0 +1,49 @@
+"""HTTP router for the stars domain.
+
+Exposes one read endpoint, anonymous and cookie-free, with cache headers per
+ADR 002 (docs/decisions/platform/002-cdn-cached-data-fetching.md). The 5-minute
+``s-maxage`` matches the freshness expectation of an hourly refresh — clients
+poll the edge, not origin.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, Depends, Response
+from sqlmodel import Session
+
+from app.db import get_session
+from stars.service import get_latest_payload
+
+logger = logging.getLogger("monolith.stars.router")
+
+# ADR 002: anonymous JSON endpoints set s-maxage so the Cloudflare edge can
+# cache. SWR=24h means the edge can keep serving the last good response while
+# revalidating in the background, even if origin briefly fails.
+_CACHE_CONTROL = "public, s-maxage=300, stale-while-revalidate=86400"
+
+router = APIRouter(prefix="/api/stars", tags=["stars"])
+
+
+@router.get("/best")
+def get_best_locations(
+    response: Response,
+    session: Session = Depends(get_session),
+) -> dict:
+    """Latest scored stargazing locations.
+
+    Returns the most recent successful refresh payload. If no refresh has
+    completed yet (cold start, fresh deploy), returns an empty-but-shaped
+    response so the frontend can render gracefully.
+    """
+    response.headers["Cache-Control"] = _CACHE_CONTROL
+    payload = get_latest_payload(session)
+    if payload is None:
+        return {
+            "locations": [],
+            "total_locations": 0,
+            "ranked_count": 0,
+            "cached_at": None,
+        }
+    return payload

--- a/projects/monolith/stars/router_test.py
+++ b/projects/monolith/stars/router_test.py
@@ -1,0 +1,99 @@
+"""Integration tests for stars.router — read path + cache headers."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlmodel import Session, SQLModel, create_engine
+from sqlmodel.pool import StaticPool
+
+from app.db import get_session
+from stars.models import RefreshRun
+from stars.router import router
+
+
+@pytest.fixture(name="app_client")
+def app_client_fixture():
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    original_schemas = {}
+    for table in SQLModel.metadata.tables.values():
+        if table.schema is not None:
+            original_schemas[table.name] = table.schema
+            table.schema = None
+    SQLModel.metadata.create_all(engine)
+    session = Session(engine)
+
+    app = FastAPI()
+    app.include_router(router)
+
+    def _session_override():
+        yield session
+
+    app.dependency_overrides[get_session] = _session_override
+    yield TestClient(app), session
+    session.close()
+    for table in SQLModel.metadata.tables.values():
+        if table.name in original_schemas:
+            table.schema = original_schemas[table.name]
+
+
+class TestGetBest:
+    def test_empty_state_returns_empty_payload_with_cache_header(self, app_client):
+        client, _ = app_client
+        resp = client.get("/api/stars/best")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["ranked_count"] == 0
+        assert body["locations"] == []
+        assert body["cached_at"] is None
+        # ADR 002: anonymous endpoints set s-maxage so the edge can cache.
+        assert "s-maxage=300" in resp.headers["cache-control"]
+        assert "stale-while-revalidate=86400" in resp.headers["cache-control"]
+
+    def test_returns_latest_ok_payload(self, app_client):
+        client, session = app_client
+        row = RefreshRun(
+            started_at=datetime.now(timezone.utc),
+            completed_at=datetime.now(timezone.utc),
+            status="ok",
+            payload={
+                "locations": [
+                    {"id": "tomintoul", "name": "Tomintoul", "best_score": 87.4}
+                ],
+                "ranked_count": 1,
+                "total_locations": 30,
+                "min_display_score": 60,
+                "cached_at": "2026-04-26T22:00:00+00:00",
+            },
+        )
+        session.add(row)
+        session.commit()
+
+        resp = client.get("/api/stars/best")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["ranked_count"] == 1
+        assert body["locations"][0]["id"] == "tomintoul"
+
+    def test_error_only_history_returns_empty(self, app_client):
+        client, session = app_client
+        row = RefreshRun(
+            started_at=datetime.now(timezone.utc),
+            completed_at=datetime.now(timezone.utc),
+            status="error",
+            error="MET Norway 503",
+        )
+        session.add(row)
+        session.commit()
+
+        resp = client.get("/api/stars/best")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["ranked_count"] == 0

--- a/projects/monolith/stars/scoring.py
+++ b/projects/monolith/stars/scoring.py
@@ -1,0 +1,99 @@
+"""Astronomy suitability scoring for weather forecasts.
+
+Ported verbatim from projects/stargazer/backend/scoring.py — pure functions,
+no I/O, no external deps beyond pydantic. Behaviour parity is asserted by
+the corresponding scoring_test.py also ported from stargazer.
+"""
+
+from pydantic import BaseModel, Field
+
+
+class WeatherData(BaseModel):
+    """Weather data from MET Norway API."""
+
+    cloud_area_fraction: float = Field(ge=0, le=100)
+    relative_humidity: float = Field(ge=0, le=100)
+    fog_area_fraction: float = Field(default=0, ge=0, le=100)
+    wind_speed: float = Field(ge=0)
+    air_temperature: float
+    dew_point_temperature: float
+    air_pressure_at_sea_level: float = Field(default=1013.25)
+
+
+class ScoredForecast(BaseModel):
+    """Forecast with astronomy suitability score."""
+
+    time: str
+    score: float = Field(ge=0, le=100)
+    cloud_area_fraction: float
+    relative_humidity: float
+    fog_area_fraction: float
+    wind_speed: float
+    air_temperature: float
+    dew_spread: float
+    air_pressure: float
+    symbol: str = ""
+
+
+def calculate_astronomy_score(weather: WeatherData) -> float:
+    """Calculate astronomy suitability score (0-100).
+
+    Weights: cloud 50%, humidity 15%, fog 10%, wind 10%, dew 15%, pressure +0-10 bonus.
+    """
+    if weather.cloud_area_fraction < 20:
+        cloud_score = 100
+    elif weather.cloud_area_fraction < 50:
+        cloud_score = 100 - (weather.cloud_area_fraction - 20) * 1.67
+    else:
+        cloud_score = max(0, 50 - (weather.cloud_area_fraction - 50))
+
+    if weather.relative_humidity < 70:
+        humidity_score = 100
+    elif weather.relative_humidity < 85:
+        humidity_score = 100 - (weather.relative_humidity - 70) * 3.33
+    else:
+        humidity_score = max(0, 50 - (weather.relative_humidity - 85) * 3.33)
+
+    if weather.fog_area_fraction < 5:
+        fog_score = 100
+    elif weather.fog_area_fraction < 20:
+        fog_score = 100 - (weather.fog_area_fraction - 5) * 3.33
+    else:
+        fog_score = max(0, 50 - (weather.fog_area_fraction - 20) * 1.67)
+
+    if weather.wind_speed < 5:
+        wind_score = 100
+    elif weather.wind_speed < 10:
+        wind_score = 100 - (weather.wind_speed - 5) * 10
+    else:
+        wind_score = max(0, 50 - (weather.wind_speed - 10) * 5)
+
+    dew_spread = weather.air_temperature - weather.dew_point_temperature
+    if dew_spread > 5:
+        dew_score = 100
+    elif dew_spread > 2:
+        dew_score = 100 - (5 - dew_spread) * 16.67
+    else:
+        dew_score = max(0, 50 - (2 - dew_spread) * 25)
+
+    pressure_bonus = 0
+    if weather.air_pressure_at_sea_level > 1015:
+        pressure_bonus = min(10, (weather.air_pressure_at_sea_level - 1015) * 2)
+
+    weighted = (
+        cloud_score * 0.50
+        + humidity_score * 0.15
+        + fog_score * 0.10
+        + wind_score * 0.10
+        + dew_score * 0.15
+        + pressure_bonus
+    )
+    return min(100, max(0, weighted))
+
+
+def is_dark_enough(
+    sun_altitude: float,
+    astronomical_darkness_threshold: float = -18.0,
+) -> bool:
+    """Astronomical darkness: sun > 18° below horizon."""
+    return sun_altitude <= astronomical_darkness_threshold

--- a/projects/monolith/stars/scoring_test.py
+++ b/projects/monolith/stars/scoring_test.py
@@ -1,0 +1,310 @@
+"""Unit tests for stars.scoring (ported from projects/stargazer/backend/scoring_test.py)."""
+
+import pytest
+
+from stars.scoring import (
+    ScoredForecast,
+    WeatherData,
+    calculate_astronomy_score,
+    is_dark_enough,
+)
+
+
+class TestWeatherDataValidation:
+    def test_accepts_valid_data(self):
+        w = WeatherData(
+            cloud_area_fraction=10.0,
+            relative_humidity=60.0,
+            wind_speed=3.0,
+            air_temperature=10.0,
+            dew_point_temperature=5.0,
+        )
+        assert w.cloud_area_fraction == 10.0
+
+    def test_fog_defaults_to_zero(self):
+        w = WeatherData(
+            cloud_area_fraction=50.0,
+            relative_humidity=70.0,
+            wind_speed=5.0,
+            air_temperature=10.0,
+            dew_point_temperature=5.0,
+        )
+        assert w.fog_area_fraction == 0.0
+
+    def test_pressure_defaults_to_standard(self):
+        w = WeatherData(
+            cloud_area_fraction=50.0,
+            relative_humidity=70.0,
+            wind_speed=5.0,
+            air_temperature=10.0,
+            dew_point_temperature=5.0,
+        )
+        assert w.air_pressure_at_sea_level == 1013.25
+
+    def test_rejects_negative_cloud_fraction(self):
+        with pytest.raises(ValueError):
+            WeatherData(
+                cloud_area_fraction=-1.0,
+                relative_humidity=50.0,
+                wind_speed=5.0,
+                air_temperature=10.0,
+                dew_point_temperature=5.0,
+            )
+
+    def test_rejects_cloud_fraction_over_100(self):
+        with pytest.raises(ValueError):
+            WeatherData(
+                cloud_area_fraction=101.0,
+                relative_humidity=50.0,
+                wind_speed=5.0,
+                air_temperature=10.0,
+                dew_point_temperature=5.0,
+            )
+
+    def test_rejects_negative_humidity(self):
+        with pytest.raises(ValueError):
+            WeatherData(
+                cloud_area_fraction=50.0,
+                relative_humidity=-5.0,
+                wind_speed=5.0,
+                air_temperature=10.0,
+                dew_point_temperature=5.0,
+            )
+
+    def test_rejects_humidity_over_100(self):
+        with pytest.raises(ValueError):
+            WeatherData(
+                cloud_area_fraction=50.0,
+                relative_humidity=105.0,
+                wind_speed=5.0,
+                air_temperature=10.0,
+                dew_point_temperature=5.0,
+            )
+
+    def test_rejects_negative_wind_speed(self):
+        with pytest.raises(ValueError):
+            WeatherData(
+                cloud_area_fraction=50.0,
+                relative_humidity=50.0,
+                wind_speed=-1.0,
+                air_temperature=10.0,
+                dew_point_temperature=5.0,
+            )
+
+    def test_accepts_zero_wind_speed(self):
+        w = WeatherData(
+            cloud_area_fraction=50.0,
+            relative_humidity=50.0,
+            wind_speed=0.0,
+            air_temperature=10.0,
+            dew_point_temperature=5.0,
+        )
+        assert w.wind_speed == 0.0
+
+    def test_accepts_boundary_cloud_values(self):
+        w_clear = WeatherData(
+            cloud_area_fraction=0.0,
+            relative_humidity=50.0,
+            wind_speed=5.0,
+            air_temperature=10.0,
+            dew_point_temperature=5.0,
+        )
+        assert w_clear.cloud_area_fraction == 0.0
+
+        w_overcast = WeatherData(
+            cloud_area_fraction=100.0,
+            relative_humidity=50.0,
+            wind_speed=5.0,
+            air_temperature=10.0,
+            dew_point_temperature=5.0,
+        )
+        assert w_overcast.cloud_area_fraction == 100.0
+
+    def test_negative_temperature_is_valid(self):
+        w = WeatherData(
+            cloud_area_fraction=10.0,
+            relative_humidity=50.0,
+            wind_speed=3.0,
+            air_temperature=-10.0,
+            dew_point_temperature=-15.0,
+        )
+        assert w.air_temperature == -10.0
+
+
+class TestScoredForecastModel:
+    def test_accepts_valid_scored_forecast(self):
+        sf = ScoredForecast(
+            time="2024-01-15T22:00:00Z",
+            score=85.0,
+            cloud_area_fraction=10.0,
+            relative_humidity=60.0,
+            fog_area_fraction=0.0,
+            wind_speed=3.0,
+            air_temperature=8.0,
+            dew_spread=5.0,
+            air_pressure=1018.0,
+        )
+        assert sf.score == 85.0
+        assert sf.symbol == ""
+
+    def test_score_must_be_0_to_100(self):
+        with pytest.raises(ValueError):
+            ScoredForecast(
+                time="2024-01-15T22:00:00Z",
+                score=101.0,
+                cloud_area_fraction=10.0,
+                relative_humidity=60.0,
+                fog_area_fraction=0.0,
+                wind_speed=3.0,
+                air_temperature=8.0,
+                dew_spread=5.0,
+                air_pressure=1018.0,
+            )
+
+
+class TestCalculateAstronomyScore:
+    def _make_weather(self, **kwargs) -> WeatherData:
+        defaults = {
+            "cloud_area_fraction": 0.0,
+            "relative_humidity": 40.0,
+            "fog_area_fraction": 0.0,
+            "wind_speed": 2.0,
+            "air_temperature": 15.0,
+            "dew_point_temperature": 5.0,
+            "air_pressure_at_sea_level": 1030.0,
+        }
+        defaults.update(kwargs)
+        return WeatherData(**defaults)
+
+    def test_score_always_in_0_to_100_range(self):
+        worst = self._make_weather(
+            cloud_area_fraction=100.0,
+            relative_humidity=100.0,
+            fog_area_fraction=100.0,
+            wind_speed=100.0,
+            air_temperature=0.0,
+            dew_point_temperature=0.0,
+            air_pressure_at_sea_level=900.0,
+        )
+        assert 0.0 <= calculate_astronomy_score(worst) <= 100.0
+        best = self._make_weather()
+        assert 0.0 <= calculate_astronomy_score(best) <= 100.0
+
+    def test_ideal_conditions_score_near_100(self):
+        score = calculate_astronomy_score(self._make_weather())
+        assert score >= 95.0
+
+    def test_full_cloud_cover_penalises_heavily(self):
+        clear_score = calculate_astronomy_score(
+            self._make_weather(cloud_area_fraction=0.0)
+        )
+        cloudy_score = calculate_astronomy_score(
+            self._make_weather(cloud_area_fraction=100.0)
+        )
+        assert clear_score - cloudy_score >= 40.0
+
+    def test_high_humidity_penalises_score(self):
+        score_low = calculate_astronomy_score(
+            self._make_weather(relative_humidity=50.0)
+        )
+        score_high = calculate_astronomy_score(
+            self._make_weather(relative_humidity=95.0)
+        )
+        assert score_low > score_high
+
+    def test_calm_wind_better_than_strong_wind(self):
+        base = {
+            "cloud_area_fraction": 30.0,
+            "relative_humidity": 75.0,
+            "fog_area_fraction": 5.0,
+            "air_temperature": 10.0,
+            "dew_point_temperature": 7.0,
+            "air_pressure_at_sea_level": 1013.0,
+        }
+        calm = calculate_astronomy_score(self._make_weather(wind_speed=2.0, **base))
+        strong = calculate_astronomy_score(self._make_weather(wind_speed=20.0, **base))
+        assert calm > strong
+
+    def test_good_dew_spread_scores_higher(self):
+        good = self._make_weather(air_temperature=15.0, dew_point_temperature=5.0)
+        poor = self._make_weather(air_temperature=10.0, dew_point_temperature=9.5)
+        assert calculate_astronomy_score(good) > calculate_astronomy_score(poor)
+
+    def test_high_pressure_gives_bonus(self):
+        low_p = self._make_weather(
+            cloud_area_fraction=30.0, air_pressure_at_sea_level=1005.0
+        )
+        high_p = self._make_weather(
+            cloud_area_fraction=30.0, air_pressure_at_sea_level=1025.0
+        )
+        assert calculate_astronomy_score(high_p) > calculate_astronomy_score(low_p)
+
+    def test_pressure_bonus_capped_at_10(self):
+        moderate = self._make_weather(
+            cloud_area_fraction=50.0, air_pressure_at_sea_level=1020.0
+        )
+        extreme = self._make_weather(
+            cloud_area_fraction=50.0, air_pressure_at_sea_level=1100.0
+        )
+        assert calculate_astronomy_score(extreme) == pytest.approx(
+            calculate_astronomy_score(moderate), abs=0.1
+        )
+
+    def test_score_capped_at_100(self):
+        perfect = self._make_weather(air_pressure_at_sea_level=9999.0)
+        assert calculate_astronomy_score(perfect) <= 100.0
+
+    def test_score_clamped_at_0(self):
+        terrible = WeatherData(
+            cloud_area_fraction=100.0,
+            relative_humidity=100.0,
+            fog_area_fraction=100.0,
+            wind_speed=100.0,
+            air_temperature=0.0,
+            dew_point_temperature=10.0,
+            air_pressure_at_sea_level=900.0,
+        )
+        assert calculate_astronomy_score(terrible) >= 0.0
+
+    def test_weighted_average_components(self):
+        base = WeatherData(
+            cloud_area_fraction=0.0,
+            relative_humidity=40.0,
+            fog_area_fraction=0.0,
+            wind_speed=2.0,
+            air_temperature=15.0,
+            dew_point_temperature=5.0,
+            air_pressure_at_sea_level=1013.0,
+        )
+        all_cloud = WeatherData(
+            cloud_area_fraction=100.0,
+            relative_humidity=40.0,
+            fog_area_fraction=0.0,
+            wind_speed=2.0,
+            air_temperature=15.0,
+            dew_point_temperature=5.0,
+            air_pressure_at_sea_level=1013.0,
+        )
+        diff = calculate_astronomy_score(base) - calculate_astronomy_score(all_cloud)
+        assert 40.0 <= diff <= 60.0
+
+
+class TestIsDarkEnough:
+    def test_sun_at_minus_18_is_dark(self):
+        assert is_dark_enough(-18.0) is True
+
+    def test_sun_below_minus_18_is_dark(self):
+        assert is_dark_enough(-20.0) is True
+
+    def test_sun_just_above_threshold_is_not_dark(self):
+        assert is_dark_enough(-17.9) is False
+
+    def test_nautical_twilight_not_dark(self):
+        assert is_dark_enough(-12.0) is False
+
+    def test_daytime_not_dark(self):
+        assert is_dark_enough(0.0) is False
+
+    def test_custom_threshold_civil(self):
+        assert is_dark_enough(-6.0, astronomical_darkness_threshold=-6.0) is True
+        assert is_dark_enough(-5.9, astronomical_darkness_threshold=-6.0) is False

--- a/projects/monolith/stars/seed.py
+++ b/projects/monolith/stars/seed.py
@@ -1,0 +1,276 @@
+"""Hand-curated dark-sky locations in Scotland.
+
+Replaces stargazer's geospatial pipeline (LP atlas + OSM roads + DEM → grid
+of ~500 sample points) with a curated seed list. The shape matches the
+original ``sample_points_enriched.geojson`` rows (id/lat/lon/altitude_m/lp_zone)
+plus a human-readable ``name`` so the UI can label results.
+
+Coverage targets the recognised dark-sky destinations: International Dark Sky
+Park designations (Galloway Forest, Tomintoul-Glenlivet), Dark Sky Communities
+(Coll), and well-known remote viewing spots across the Highlands, Islands,
+and Borders. ``lp_zone`` is the DJ Lorenz Light Pollution Atlas band (1a-3a
+covers natural-sky-dominant areas; 1a is the darkest).
+"""
+
+from typing import TypedDict
+
+
+class SeedLocation(TypedDict):
+    id: str
+    name: str
+    lat: float
+    lon: float
+    altitude_m: int
+    lp_zone: str
+
+
+SCOTLAND_DARK_SKY_LOCATIONS: list[SeedLocation] = [
+    # Galloway Forest — International Dark Sky Park (2009)
+    {
+        "id": "galloway-forest",
+        "name": "Galloway Forest Park",
+        "lat": 55.083,
+        "lon": -4.500,
+        "altitude_m": 110,
+        "lp_zone": "1a",
+    },
+    {
+        "id": "bruces-stone",
+        "name": "Bruce's Stone, Loch Trool",
+        "lat": 55.083,
+        "lon": -4.483,
+        "altitude_m": 130,
+        "lp_zone": "1a",
+    },
+    {
+        "id": "loch-doon",
+        "name": "Loch Doon",
+        "lat": 55.244,
+        "lon": -4.392,
+        "altitude_m": 240,
+        "lp_zone": "1b",
+    },
+    {
+        "id": "clatteringshaws",
+        "name": "Clatteringshaws Loch",
+        "lat": 55.063,
+        "lon": -4.290,
+        "altitude_m": 200,
+        "lp_zone": "1a",
+    },
+    # Cairngorms / Tomintoul-Glenlivet — International Dark Sky Park (2018)
+    {
+        "id": "tomintoul",
+        "name": "Tomintoul",
+        "lat": 57.249,
+        "lon": -3.371,
+        "altitude_m": 345,
+        "lp_zone": "1a",
+    },
+    {
+        "id": "glenlivet",
+        "name": "Glenlivet",
+        "lat": 57.349,
+        "lon": -3.302,
+        "altitude_m": 260,
+        "lp_zone": "1a",
+    },
+    {
+        "id": "glen-tanar",
+        "name": "Glen Tanar, Cairngorms",
+        "lat": 57.040,
+        "lon": -2.870,
+        "altitude_m": 220,
+        "lp_zone": "1b",
+    },
+    {
+        "id": "glenmore-forest",
+        "name": "Glenmore Forest, Cairngorms",
+        "lat": 57.166,
+        "lon": -3.690,
+        "altitude_m": 320,
+        "lp_zone": "1b",
+    },
+    {
+        "id": "loch-morlich",
+        "name": "Loch Morlich",
+        "lat": 57.166,
+        "lon": -3.706,
+        "altitude_m": 305,
+        "lp_zone": "1b",
+    },
+    # West Highlands
+    {
+        "id": "glen-affric",
+        "name": "Glen Affric",
+        "lat": 57.282,
+        "lon": -4.918,
+        "altitude_m": 250,
+        "lp_zone": "1a",
+    },
+    {
+        "id": "glen-coe",
+        "name": "Glen Coe",
+        "lat": 56.673,
+        "lon": -4.989,
+        "altitude_m": 100,
+        "lp_zone": "1b",
+    },
+    {
+        "id": "rannoch-moor",
+        "name": "Rannoch Moor",
+        "lat": 56.626,
+        "lon": -4.687,
+        "altitude_m": 320,
+        "lp_zone": "1a",
+    },
+    {
+        "id": "knoydart",
+        "name": "Knoydart",
+        "lat": 57.040,
+        "lon": -5.700,
+        "altitude_m": 50,
+        "lp_zone": "1a",
+    },
+    # Inner Hebrides
+    {
+        "id": "isle-of-coll",
+        "name": "Isle of Coll (Dark Sky Community)",
+        "lat": 56.620,
+        "lon": -6.550,
+        "altitude_m": 30,
+        "lp_zone": "1a",
+    },
+    {
+        "id": "tiree",
+        "name": "Tiree",
+        "lat": 56.504,
+        "lon": -6.880,
+        "altitude_m": 15,
+        "lp_zone": "1a",
+    },
+    {
+        "id": "mull-dervaig",
+        "name": "Mull (Dervaig)",
+        "lat": 56.589,
+        "lon": -6.182,
+        "altitude_m": 30,
+        "lp_zone": "1a",
+    },
+    {
+        "id": "iona",
+        "name": "Iona",
+        "lat": 56.330,
+        "lon": -6.396,
+        "altitude_m": 20,
+        "lp_zone": "1a",
+    },
+    {
+        "id": "skye-trotternish",
+        "name": "Skye (Trotternish)",
+        "lat": 57.580,
+        "lon": -6.180,
+        "altitude_m": 100,
+        "lp_zone": "1a",
+    },
+    # Outer Hebrides
+    {
+        "id": "north-uist",
+        "name": "North Uist",
+        "lat": 57.595,
+        "lon": -7.319,
+        "altitude_m": 20,
+        "lp_zone": "1a",
+    },
+    {
+        "id": "lewis-callanish",
+        "name": "Lewis (Callanish)",
+        "lat": 58.195,
+        "lon": -6.745,
+        "altitude_m": 30,
+        "lp_zone": "1a",
+    },
+    {
+        "id": "harris-luskentyre",
+        "name": "Harris (Luskentyre)",
+        "lat": 57.881,
+        "lon": -6.945,
+        "altitude_m": 10,
+        "lp_zone": "1a",
+    },
+    {
+        "id": "barra",
+        "name": "Barra",
+        "lat": 56.978,
+        "lon": -7.477,
+        "altitude_m": 15,
+        "lp_zone": "1a",
+    },
+    # Northern Highlands
+    {
+        "id": "assynt",
+        "name": "Assynt",
+        "lat": 58.158,
+        "lon": -5.066,
+        "altitude_m": 130,
+        "lp_zone": "1a",
+    },
+    {
+        "id": "cape-wrath",
+        "name": "Cape Wrath",
+        "lat": 58.552,
+        "lon": -4.957,
+        "altitude_m": 50,
+        "lp_zone": "1a",
+    },
+    {
+        "id": "dunnet-head",
+        "name": "Dunnet Head, Caithness",
+        "lat": 58.671,
+        "lon": -3.376,
+        "altitude_m": 100,
+        "lp_zone": "1a",
+    },
+    # Orkney + Shetland
+    {
+        "id": "orkney-birsay",
+        "name": "Orkney (Birsay)",
+        "lat": 59.130,
+        "lon": -3.279,
+        "altitude_m": 25,
+        "lp_zone": "1a",
+    },
+    {
+        "id": "orkney-hoy",
+        "name": "Orkney (Hoy)",
+        "lat": 58.851,
+        "lon": -3.297,
+        "altitude_m": 60,
+        "lp_zone": "1a",
+    },
+    {
+        "id": "shetland-mainland",
+        "name": "Shetland (South Mainland)",
+        "lat": 60.299,
+        "lon": -1.342,
+        "altitude_m": 30,
+        "lp_zone": "1a",
+    },
+    {
+        "id": "shetland-unst",
+        "name": "Unst, Shetland",
+        "lat": 60.756,
+        "lon": -0.831,
+        "altitude_m": 50,
+        "lp_zone": "1a",
+    },
+    # Borders / South-East
+    {
+        "id": "moffat",
+        "name": "Moffat (Dark Sky Town)",
+        "lat": 55.331,
+        "lon": -3.443,
+        "altitude_m": 110,
+        "lp_zone": "2a",
+    },
+]

--- a/projects/monolith/stars/service.py
+++ b/projects/monolith/stars/service.py
@@ -1,0 +1,215 @@
+"""Stars refresh service: fetch MET Norway forecasts, score them, write a row."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from datetime import datetime, timezone
+
+import httpx
+from astral import LocationInfo
+from astral.sun import elevation
+from sqlmodel import Session, desc, select
+
+from stars.models import RefreshRun
+from stars.scoring import WeatherData, calculate_astronomy_score
+from stars.seed import SCOTLAND_DARK_SKY_LOCATIONS, SeedLocation
+
+logger = logging.getLogger("monolith.stars")
+
+MET_NORWAY_URL = "https://api.met.no/weatherapi/locationforecast/2.0/complete"
+USER_AGENT = os.environ.get(
+    "STARS_USER_AGENT", "monolith-stars/1.0 github.com/jomcgi/homelab"
+)
+RATE_LIMIT_PER_SEC = int(os.environ.get("STARS_RATE_LIMIT", "15"))
+MIN_DISPLAY_SCORE = int(os.environ.get("STARS_MIN_DISPLAY_SCORE", "60"))
+TOP_HOURS_PER_LOCATION = 5
+HTTP_TIMEOUT = 30.0
+
+
+async def _fetch_one(
+    client: httpx.AsyncClient, loc: SeedLocation
+) -> tuple[str, dict | None]:
+    """Fetch a single forecast; None on transport failure (don't fail the whole refresh)."""
+    try:
+        resp = await client.get(
+            MET_NORWAY_URL,
+            params={
+                "lat": loc["lat"],
+                "lon": loc["lon"],
+                "altitude": loc["altitude_m"],
+            },
+            headers={"User-Agent": USER_AGENT},
+            timeout=HTTP_TIMEOUT,
+        )
+        resp.raise_for_status()
+        return loc["id"], resp.json()
+    except httpx.HTTPError as exc:
+        logger.warning("Forecast fetch failed for %s: %s", loc["id"], exc)
+        return loc["id"], None
+
+
+async def _fetch_all(locations: list[SeedLocation]) -> dict[str, dict]:
+    """Fetch forecasts for every seed location with bounded concurrency."""
+    semaphore = asyncio.Semaphore(RATE_LIMIT_PER_SEC)
+
+    async with httpx.AsyncClient(timeout=httpx.Timeout(HTTP_TIMEOUT)) as client:
+
+        async def _bounded(loc: SeedLocation) -> tuple[str, dict | None]:
+            async with semaphore:
+                result = await _fetch_one(client, loc)
+                # Spread requests over time so we don't burst above MET's 20/s limit.
+                await asyncio.sleep(1.0 / RATE_LIMIT_PER_SEC)
+                return result
+
+        results = await asyncio.gather(*(_bounded(loc) for loc in locations))
+
+    return {loc_id: forecast for loc_id, forecast in results if forecast is not None}
+
+
+def _score_location(loc: SeedLocation, forecast: dict) -> dict | None:
+    """Score every dark hour in a forecast; return the location's ranked summary or None."""
+    observer = LocationInfo(latitude=loc["lat"], longitude=loc["lon"]).observer
+    timeseries = forecast.get("properties", {}).get("timeseries", [])
+    scored_hours: list[dict] = []
+
+    for entry in timeseries:
+        time_str = entry["time"]
+        try:
+            t = datetime.fromisoformat(time_str.replace("Z", "+00:00"))
+        except ValueError as exc:
+            logger.debug("skip unparseable timeseries time %r: %s", time_str, exc)
+            continue
+
+        try:
+            sun_alt = elevation(observer, t)
+        except Exception as exc:  # pragma: no cover — defensive vs astral edge cases
+            logger.debug("astral elevation failed at %s: %s", t, exc)
+            continue
+        if sun_alt > -12:  # nautical twilight or brighter — skip
+            continue
+
+        instant = entry.get("data", {}).get("instant", {}).get("details", {})
+        next_1h = entry.get("data", {}).get("next_1_hours", {})
+        try:
+            weather = WeatherData(
+                cloud_area_fraction=instant.get("cloud_area_fraction", 100),
+                relative_humidity=instant.get("relative_humidity", 100),
+                fog_area_fraction=instant.get("fog_area_fraction", 0),
+                wind_speed=instant.get("wind_speed", 0),
+                air_temperature=instant.get("air_temperature", 10),
+                dew_point_temperature=instant.get("dew_point_temperature", 5),
+                air_pressure_at_sea_level=instant.get(
+                    "air_pressure_at_sea_level", 1013.25
+                ),
+            )
+        except Exception as exc:
+            logger.debug("skip malformed weather entry at %s: %s", time_str, exc)
+            continue
+
+        score = calculate_astronomy_score(weather)
+        if score < MIN_DISPLAY_SCORE:
+            continue
+
+        scored_hours.append(
+            {
+                "time": time_str,
+                "score": round(score, 1),
+                "cloud_area_fraction": weather.cloud_area_fraction,
+                "relative_humidity": weather.relative_humidity,
+                "wind_speed": weather.wind_speed,
+                "air_temperature": weather.air_temperature,
+                "dew_spread": round(
+                    weather.air_temperature - weather.dew_point_temperature, 1
+                ),
+                "symbol": next_1h.get("summary", {}).get("symbol_code", ""),
+            }
+        )
+
+    if not scored_hours:
+        return None
+
+    scored_hours.sort(key=lambda h: h["score"], reverse=True)
+    return {
+        "id": loc["id"],
+        "name": loc["name"],
+        "lat": loc["lat"],
+        "lon": loc["lon"],
+        "altitude_m": loc["altitude_m"],
+        "lp_zone": loc["lp_zone"],
+        "best_score": scored_hours[0]["score"],
+        "best_hours": scored_hours[:TOP_HOURS_PER_LOCATION],
+    }
+
+
+def build_payload(forecasts: dict[str, dict]) -> dict:
+    """Score each forecast and assemble the final ranked payload."""
+    by_id = {loc["id"]: loc for loc in SCOTLAND_DARK_SKY_LOCATIONS}
+    ranked: list[dict] = []
+    for loc_id, forecast in forecasts.items():
+        loc = by_id.get(loc_id)
+        if loc is None:
+            continue
+        scored = _score_location(loc, forecast)
+        if scored is not None:
+            ranked.append(scored)
+
+    ranked.sort(key=lambda r: r["best_score"], reverse=True)
+    return {
+        "locations": ranked,
+        "total_locations": len(SCOTLAND_DARK_SKY_LOCATIONS),
+        "ranked_count": len(ranked),
+        "min_display_score": MIN_DISPLAY_SCORE,
+        "cached_at": datetime.now(timezone.utc).isoformat(),
+    }
+
+
+async def refresh_handler(session: Session) -> None:
+    """Scheduled job: fetch + score + write one row.
+
+    Records every run (success or failure) so the read endpoint can surface
+    "last good payload" and the operator can see refresh history. A failed
+    refresh never overwrites the last good payload — it just adds an
+    ``error`` row.
+    """
+    started = datetime.now(timezone.utc)
+    run = RefreshRun(started_at=started, status="running")
+    session.add(run)
+    session.commit()
+    session.refresh(run)
+
+    try:
+        forecasts = await _fetch_all(SCOTLAND_DARK_SKY_LOCATIONS)
+        payload = build_payload(forecasts)
+        run.completed_at = datetime.now(timezone.utc)
+        run.status = "ok"
+        run.payload = payload
+        run.locations_count = payload["ranked_count"]
+        session.add(run)
+        session.commit()
+        logger.info(
+            "stars.refresh ok: %d/%d locations ranked",
+            payload["ranked_count"],
+            payload["total_locations"],
+        )
+    except Exception as exc:
+        run.completed_at = datetime.now(timezone.utc)
+        run.status = "error"
+        run.error = str(exc)[:1000]
+        session.add(run)
+        session.commit()
+        logger.exception("stars.refresh failed")
+        raise
+
+
+def get_latest_payload(session: Session) -> dict | None:
+    """Return the most recent successful refresh payload, or None if there isn't one yet."""
+    stmt = (
+        select(RefreshRun)
+        .where(RefreshRun.status == "ok")
+        .order_by(desc(RefreshRun.completed_at))
+        .limit(1)
+    )
+    row = session.exec(stmt).first()
+    return row.payload if row else None

--- a/projects/monolith/stars/service_test.py
+++ b/projects/monolith/stars/service_test.py
@@ -1,0 +1,190 @@
+"""Tests for stars.service — refresh handler + last-good read."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+
+import pytest
+from sqlmodel import Session, SQLModel, create_engine, select
+from sqlmodel.pool import StaticPool
+
+import stars.service as service
+from stars.models import RefreshRun
+
+
+@pytest.fixture(name="session")
+def session_fixture():
+    """In-memory SQLite session with stars schema stripped (SQLite has no schemas)."""
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    original_schemas = {}
+    for table in SQLModel.metadata.tables.values():
+        if table.schema is not None:
+            original_schemas[table.name] = table.schema
+            table.schema = None
+    SQLModel.metadata.create_all(engine)
+    with Session(engine) as session:
+        yield session
+    for table in SQLModel.metadata.tables.values():
+        if table.name in original_schemas:
+            table.schema = original_schemas[table.name]
+
+
+def _fake_forecast(score_band: str = "clear") -> dict:
+    """Build a MET-Norway-shaped forecast with one dark hour matching the requested band."""
+    cloud = {"clear": 5.0, "overcast": 95.0}[score_band]
+    # Pick a winter midnight to guarantee astronomical darkness in Scotland.
+    t = (
+        datetime(2026, 1, 15, 0, 0, tzinfo=timezone.utc)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+    return {
+        "properties": {
+            "timeseries": [
+                {
+                    "time": t,
+                    "data": {
+                        "instant": {
+                            "details": {
+                                "cloud_area_fraction": cloud,
+                                "relative_humidity": 50.0,
+                                "wind_speed": 3.0,
+                                "air_temperature": 5.0,
+                                "dew_point_temperature": 0.0,
+                                "air_pressure_at_sea_level": 1020.0,
+                            }
+                        },
+                        "next_1_hours": {"summary": {"symbol_code": "clearsky_night"}},
+                    },
+                },
+            ]
+        }
+    }
+
+
+class TestBuildPayload:
+    def test_ranks_clear_above_overcast(self):
+        forecasts = {
+            "galloway-forest": _fake_forecast("clear"),
+            "tomintoul": _fake_forecast("overcast"),
+        }
+        payload = service.build_payload(forecasts)
+        # Overcast should be filtered out by MIN_DISPLAY_SCORE (60); only clear shown.
+        assert payload["ranked_count"] == 1
+        assert payload["locations"][0]["id"] == "galloway-forest"
+        assert payload["locations"][0]["best_score"] >= 90.0
+
+    def test_includes_human_readable_name(self):
+        forecasts = {"galloway-forest": _fake_forecast("clear")}
+        payload = service.build_payload(forecasts)
+        assert payload["locations"][0]["name"] == "Galloway Forest Park"
+
+    def test_payload_includes_cached_at(self):
+        payload = service.build_payload({})
+        assert payload["cached_at"] is not None
+
+    def test_unknown_location_id_is_dropped(self):
+        forecasts = {"not-a-real-place": _fake_forecast("clear")}
+        payload = service.build_payload(forecasts)
+        assert payload["ranked_count"] == 0
+
+    def test_total_locations_reflects_seed_size(self):
+        payload = service.build_payload({})
+        assert payload["total_locations"] >= 25
+
+
+class TestRefreshHandlerSuccess:
+    def test_writes_ok_row_with_payload(self, session):
+        async def fake_fetch_all(locations):
+            return {locations[0]["id"]: _fake_forecast("clear")}
+
+        with patch.object(service, "_fetch_all", fake_fetch_all):
+            asyncio.run(service.refresh_handler(session))
+
+        rows = session.exec(select(RefreshRun)).all()
+        assert len(rows) == 1
+        row = rows[0]
+        assert row.status == "ok"
+        assert row.completed_at is not None
+        assert row.payload is not None
+        assert row.payload["ranked_count"] >= 1
+
+    def test_get_latest_payload_returns_most_recent_ok(self, session):
+        # Stale ok row first
+        stale = RefreshRun(
+            started_at=datetime.now(timezone.utc) - timedelta(hours=2),
+            completed_at=datetime.now(timezone.utc) - timedelta(hours=2),
+            status="ok",
+            payload={"marker": "stale"},
+        )
+        # Newer ok row second
+        fresh = RefreshRun(
+            started_at=datetime.now(timezone.utc),
+            completed_at=datetime.now(timezone.utc),
+            status="ok",
+            payload={"marker": "fresh"},
+        )
+        session.add_all([stale, fresh])
+        session.commit()
+
+        payload = service.get_latest_payload(session)
+        assert payload == {"marker": "fresh"}
+
+
+class TestRefreshHandlerFailure:
+    def test_writes_error_row_and_re_raises(self, session):
+        async def boom(_locations):
+            raise RuntimeError("network down")
+
+        with patch.object(service, "_fetch_all", boom):
+            with pytest.raises(RuntimeError, match="network down"):
+                asyncio.run(service.refresh_handler(session))
+
+        rows = session.exec(select(RefreshRun)).all()
+        assert len(rows) == 1
+        assert rows[0].status == "error"
+        assert rows[0].error == "network down"
+        assert rows[0].payload is None
+
+    def test_failed_refresh_does_not_clobber_last_good_payload(self, session):
+        # Pre-existing successful refresh
+        good = RefreshRun(
+            started_at=datetime.now(timezone.utc) - timedelta(hours=1),
+            completed_at=datetime.now(timezone.utc) - timedelta(hours=1),
+            status="ok",
+            payload={"marker": "good"},
+        )
+        session.add(good)
+        session.commit()
+
+        async def boom(_locations):
+            raise RuntimeError("temporary failure")
+
+        with patch.object(service, "_fetch_all", boom):
+            with pytest.raises(RuntimeError):
+                asyncio.run(service.refresh_handler(session))
+
+        # Read path still serves the good payload.
+        assert service.get_latest_payload(session) == {"marker": "good"}
+
+
+class TestGetLatestPayloadEmpty:
+    def test_returns_none_when_no_rows(self, session):
+        assert service.get_latest_payload(session) is None
+
+    def test_returns_none_when_only_error_rows(self, session):
+        err = RefreshRun(
+            started_at=datetime.now(timezone.utc),
+            completed_at=datetime.now(timezone.utc),
+            status="error",
+            error="boom",
+        )
+        session.add(err)
+        session.commit()
+        assert service.get_latest_payload(session) is None


### PR DESCRIPTION
## Summary

- Ports the dynamic half of `projects/stargazer/` (weather fetch + scoring) into a new `monolith/stars/` domain
- Replaces the broken geospatial pipeline with ~30 curated Scottish dark-sky locations (`stars/seed.py`); atlas-driven grid generation deliberately deferred per `OK Option 1`
- Adds `stars.refresh_runs` Postgres table (single-row JSONB blob history); refresh registered as an hourly distributed-locked job via `shared.scheduler`
- `GET /api/stars/best` serves the latest `status='ok'` payload with ADR 002 cache headers (`s-maxage=300, swr=86400`)

## Why

The existing `projects/stargazer/` CronJob has been failing for 16+ hours (last 3 runs `Failed`, `/data/processed/` only has T5/T6 outputs). A monolith port + curated seed list is the simplest path to a working dark-sky service without unbreaking the upstream pipeline first. Migration is non-destructive — old `projects/stargazer/` stays in place until the new domain is verified.

## Test plan

- [ ] CI green on the pushed branch
- [ ] `stars_scoring_test`, `stars_service_test`, `stars_router_test` all pass
- [ ] After merge: monitor `stars.refresh` job in `scheduler.scheduled_jobs` for the first successful run
- [ ] After merge: hit `/api/stars/best` once a payload exists, confirm ranked locations come back with `Cache-Control: public, s-maxage=300, stale-while-revalidate=86400`
- [ ] Follow-up PR: decommission `projects/stargazer/` once the monolith path is proven

🤖 Generated with [Claude Code](https://claude.com/claude-code)