### PR TITLE
fix(stargazer): bump cronjob memory 512Mi -> 2Gi for T7 pyosmium peak

### DIFF
--- a/projects/stargazer/chart/Chart.yaml
+++ b/projects/stargazer/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: stargazer
 description: Dark Sky Location Finder - identifies best stargazing locations in Scotland
 type: application
-version: 0.2.1
+version: 0.2.2
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/stargazer/chart/values.yaml
+++ b/projects/stargazer/chart/values.yaml
@@ -40,10 +40,10 @@ securityContext:
 resources:
   limits:
     cpu: 100m
-    memory: 512Mi
+    memory: 2Gi
   requests:
     cpu: 100m
-    memory: 512Mi
+    memory: 2Gi
 
 # Persistent storage for data
 persistence:

--- a/projects/stargazer/deploy/values.yaml
+++ b/projects/stargazer/deploy/values.yaml
@@ -11,16 +11,18 @@ persistence:
   storageClass: longhorn
   accessMode: ReadWriteMany # Allow multiple pods to access the same volume
   size: 5Gi
-# Resource limits — pyosmium streams a 120MB OSM PBF in T7 (extract_roads)
-# and the BackReferenceWriter holds way→node references in memory; 256Mi
-# OOM-killed every cronjob run. 512Mi gives ~2x headroom over observed peak.
+# Resource limits — pyosmium streams a 120MB OSM PBF in T7 (extract_roads).
+# 256Mi OOMed in <1 min; 512Mi OOMed at ~10 min into T7. The BackReferenceWriter
+# holds a way→node index for ~5M Scottish nodes plus working set; raising to
+# 2Gi to escape the doubling treadmill. We can right-size later once we see a
+# real run-to-completion peak.
 resources:
   limits:
     cpu: 100m
-    memory: 512Mi
+    memory: 2Gi
   requests:
     cpu: 100m
-    memory: 512Mi
+    memory: 2Gi
 # OpenTelemetry configuration
 config:
   opentelemetry:


### PR DESCRIPTION
## Summary

Follow-up to #2237. After the 256Mi -> 512Mi bump, the manual seed run made it ~10 minutes into T7 (`extract_roads` via pyosmium) before OOMKilling again. The BackReferenceWriter has to hold a way->node index across ~5M Scottish OSM nodes; total working set is bigger than my initial estimate.

Bumping to 2Gi to escape the doubling treadmill rather than guessing again. We can right-size later once the pipeline has actually completed end-to-end and we have a real peak observation.

Continues to unblock PR #2236 (stars-domain migration).

## Test plan

- [ ] CI green
- [ ] After merge: ArgoCD syncs (~10s)
- [ ] Re-trigger manual cronjob run, wait for completion
- [ ] `/data/processed/sample_points_enriched.geojson` exists on the PVC

🤖 Generated with [Claude Code](https://claude.com/claude-code)