### PR TITLE
fix(notes): SSR 500, HOME href, active-state detection

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.66.1
+version: 0.66.2
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.66.1
+      targetRevision: 0.66.2
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/lib/public/components/Nav.svelte
+++ b/projects/monolith/frontend/src/lib/public/components/Nav.svelte
@@ -3,7 +3,7 @@
   let { route = "home" } = $props();
 
   const items = [
-    { slug: "home", label: "HOME", href: "https://public.jomcgi.dev/public" },
+    { slug: "home", label: "HOME", href: "https://public.jomcgi.dev/" },
     { slug: "notes", label: "NOTES", href: "https://private.jomcgi.dev/notes" },
     {
       slug: "engineering",

--- a/projects/monolith/frontend/src/routes/+layout.svelte
+++ b/projects/monolith/frontend/src/routes/+layout.svelte
@@ -5,12 +5,17 @@
 
   let { children } = $props();
 
-  // Active-state derivation: map URL pathname to the Nav's slug list.
-  // Returns the slug to highlight, or "" for no active link.
+  // Active-state derivation. The hooks.js reroute remaps
+  // public.jomcgi.dev/* → /public/* and private.jomcgi.dev/* → /private/*
+  // internally, but $page.url reflects the *browser* URL. So:
+  // - /notes (any host) → "notes"
+  // - any URL on public.jomcgi.dev → "home"
+  // - everything else → no active state
   let activeRoute = $derived.by(() => {
+    const host = $page.url.hostname;
     const path = $page.url.pathname;
     if (path === "/notes" || path.startsWith("/notes/")) return "notes";
-    if (path === "/public" || path.startsWith("/public/")) return "home";
+    if (host.startsWith("public.")) return "home";
     return "";
   });
 </script>

--- a/projects/monolith/frontend/vite.config.js
+++ b/projects/monolith/frontend/vite.config.js
@@ -10,7 +10,13 @@ export default defineConfig({
     // The runtime image ships only the SvelteKit `build/` output — there is
     // no node_modules. Any package imported by SSR-rendered code must be
     // bundled into the server chunks, not externalized.
-    noExternal: ["@dagrejs/dagre"],
+    noExternal: [
+      "@dagrejs/dagre",
+      "d3-force",
+      "d3-quadtree",
+      "d3-selection",
+      "d3-zoom",
+    ],
   },
   server: {
     proxy: {


### PR DESCRIPTION
Three bugs from the /notes rollout:

## 1. /notes 500 — d3-zoom not found at SSR runtime
`vite.config.js` already had `ssr.noExternal: ["@dagrejs/dagre"]` because the runtime image ships only `build/`, no `node_modules`. d3 packages were missing from that list, so they got externalized and crashed at first SSR render. Added all four to `noExternal`.

## 2. HOME → public.jomcgi.dev/public 404s
`hooks.js`'s reroute hook maps `public.jomcgi.dev/foo` → `/public/foo` internally. So `public.jomcgi.dev/public` reroutes to `/public/public` (no such route). Switched to bare `https://public.jomcgi.dev/`.

## 3. HOME not highlighted on the public homepage
`$page.url.pathname` reflects the *browser* URL (`/`), not the post-reroute internal path (`/public`). Detection switched to `hostname.startsWith("public.")` so any public-tier URL highlights HOME.

## Test plan

- [ ] CI green
- [ ] After deploy: `https://private.jomcgi.dev/notes` renders without 500
- [ ] After deploy: clicking HOME from /notes lands on `https://public.jomcgi.dev/` (no extra path segment)
- [ ] After deploy: HOME is underlined as active on the public homepage

🤖 Generated with [Claude Code](https://claude.com/claude-code)