### PR TITLE
fix: /notes hydration crash and /private home null-safety

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.66.2
+version: 0.66.3
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.66.2
+      targetRevision: 0.66.3
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/lib/components/notes/KnowledgeGraph.svelte
+++ b/projects/monolith/frontend/src/lib/components/notes/KnowledgeGraph.svelte
@@ -6,7 +6,7 @@
   // surface — search box, legend, side panel, and status bar live in
   // sibling components and drive this one via props/events.
 
-  import { onMount, onDestroy, createEventDispatcher } from "svelte";
+  import { onMount, onDestroy } from "svelte";
   import {
     forceSimulation,
     forceLink,
@@ -38,9 +38,10 @@
     selectedId = null,
     searchTerm = "",
     activeClusters = new Set(),
+    onNodeClick = () => {},
+    onNodeHover = () => {},
+    onZoom = () => {},
   } = $props();
-
-  const dispatch = createEventDispatcher();
 
   // Force-sim tuning lifted from the prototype.
   const CFG = {
@@ -542,8 +543,7 @@
       if (n !== hovered) {
         hovered = n;
         overNode = !!n;
-        dispatch(
-          "nodeHover",
+        onNodeHover(
           n ? { id: n.id, title: n.title } : { id: null, title: null },
         );
         render();
@@ -554,9 +554,9 @@
   function handleMouseUp(e) {
     if (mouseDownAt && !didMove) {
       if (mouseDownAt.node) {
-        dispatch("nodeClick", { id: mouseDownAt.node.id });
+        onNodeClick({ id: mouseDownAt.node.id });
       } else if (e.target === canvas) {
-        dispatch("nodeClick", { id: null });
+        onNodeClick({ id: null });
       }
     }
     mouseDownAt = null;
@@ -567,7 +567,7 @@
     if (hovered) {
       hovered = null;
       overNode = false;
-      dispatch("nodeHover", { id: null, title: null });
+      onNodeHover({ id: null, title: null });
       render();
     }
   }
@@ -626,7 +626,7 @@
       })
       .on("zoom", (e) => {
         transform = e.transform;
-        dispatch("zoom", transform.k);
+        onZoom(transform.k);
         if (e.sourceEvent && e.sourceEvent.type === "mousemove") {
           panning = true;
         }

--- a/projects/monolith/frontend/src/routes/private/+page.svelte
+++ b/projects/monolith/frontend/src/routes/private/+page.svelte
@@ -315,14 +315,26 @@
   });
 
   // ── Todo ─────────────────────────────────────
+  // /api/home was removed in the 2026-04-17 Home-module refactor; the
+  // backend now returns 404. Until this page is re-pointed at the
+  // knowledge.tasks endpoint, fall back to sane defaults when data.todo
+  // isn't shaped right so SSR doesn't crash with "cannot read .task".
   // svelte-ignore state_referenced_locally
-  let goal = $state(data.todo.weekly.task);
+  let goal = $state(data.todo?.weekly?.task ?? "");
   // svelte-ignore state_referenced_locally
-  let goalDone = $state(data.todo.weekly.done);
+  let goalDone = $state(data.todo?.weekly?.done ?? false);
   // svelte-ignore state_referenced_locally
-  let daily = $state(data.todo.daily.map((d) => d.task));
+  let daily = $state(
+    Array.isArray(data.todo?.daily)
+      ? data.todo.daily.map((d) => d.task ?? "")
+      : ["", "", ""],
+  );
   // svelte-ignore state_referenced_locally
-  let dailyDone = $state(data.todo.daily.map((d) => d.done));
+  let dailyDone = $state(
+    Array.isArray(data.todo?.daily)
+      ? data.todo.daily.map((d) => d.done ?? false)
+      : [false, false, false],
+  );
   let editing = $state(false);
 
   let goalRef = $state(null);

--- a/projects/monolith/frontend/src/routes/private/notes/+page.svelte
+++ b/projects/monolith/frontend/src/routes/private/notes/+page.svelte
@@ -59,9 +59,9 @@
       {selectedId}
       {searchTerm}
       {activeClusters}
-      on:nodeClick={(e) => selectNode(e.detail.id)}
-      on:nodeHover={(e) => (hoverTitle = e.detail.title ?? "—")}
-      on:zoom={(e) => (zoom = e.detail)}
+      onNodeClick={(e) => selectNode(e.id)}
+      onNodeHover={(e) => (hoverTitle = e.title ?? "—")}
+      onZoom={(k) => (zoom = k)}
     />
 
     <GraphSearch value={searchTerm} onChange={(v) => (searchTerm = v)} />


### PR DESCRIPTION
Two production bugs from the latest deploy:

## 1. /notes hydration error (`Cannot read properties of null (reading 'r')`)
`KnowledgeGraph.svelte` used `createEventDispatcher`, which is deprecated in Svelte 5 and produces subtle hydration mismatches in prod builds. Converted to callback props (`onNodeClick` / `onNodeHover` / `onZoom`) — the idiomatic Svelte 5 pattern. Consumer in `+page.svelte` updated to pass them as props instead of `on:event` directives.

## 2. /private home `[500] GET /` (`Cannot read properties of undefined (reading 'task')`)
Pre-existing bug surfaced by the new shared Nav. The frontend loader fetches `/api/home`, but that endpoint was removed in commit 64f49cf6f (`refactor(monolith): remove Home module, replaced by knowledge tasks`, 2026-04-17). Backend now returns 404; `data.todo` is `{detail: "Not Found"}`, not the expected shape, so `data.todo.weekly.task` throws.

Added optional-chaining + array guards so the page renders sane defaults instead of crashing. Proper fix is to repoint the loader at `/api/knowledge/tasks` — out of scope here, deferred per prior user direction ("we can totally ignore the private/home page rn. That will be a future refactor").

## Test plan

- [ ] CI green
- [ ] After deploy: `https://private.jomcgi.dev/notes` hydrates without console errors
- [ ] After deploy: `https://private.jomcgi.dev/` renders the capture page (with empty todos) instead of 500
- [ ] After deploy: clicking nodes / hovering on /notes still works (callbacks wired)

🤖 Generated with [Claude Code](https://claude.com/claude-code)