### PR TITLE
fix(monolith): grant RBAC for metrics.k8s.io nodes + log exc_info

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.66.3
+version: 0.66.4
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/templates/rbac.yaml
+++ b/projects/monolith/chart/templates/rbac.yaml
@@ -14,6 +14,9 @@ rules:
   - apiGroups: ["argoproj.io"]
     resources: ["applications"]
     verbs: ["list", "get"]
+  - apiGroups: ["metrics.k8s.io"]
+    resources: ["nodes"]
+    verbs: ["list"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.66.3
+      targetRevision: 0.66.4
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/home/observability/stats.py
+++ b/projects/monolith/home/observability/stats.py
@@ -109,7 +109,9 @@ async def _query_cluster_counts() -> dict:
                 }
             )
         else:
-            logger.warning("Node resource aggregation failed: %s", resources)
+            logger.warning(
+                "Node resource aggregation failed: %s", resources, exc_info=resources
+            )
         return result
     finally:
         await k8s.close()


### PR DESCRIPTION
## Summary
- Add `metrics.k8s.io` `nodes` `list` to the monolith ClusterRole. The `/home` stats endpoint calls `list_cluster_custom_object(group="metrics.k8s.io", version="v1beta1", plural="nodes")` to aggregate cluster CPU/memory, but only `nodes` in the core API group was granted — Kubernetes treats those as distinct RBAC subjects, so the call returned 403 and the cluster panel silently dropped CPU/memory.
- Pass `exc_info=resources` to the existing `logger.warning` so future failures include a traceback rather than just the kubernetes `ApiException` string.
- Bump chart `0.66.3 → 0.66.4` and matching `targetRevision`.

## Test plan
- [x] `helm template monolith projects/monolith/chart/ -f projects/monolith/deploy/values.yaml --show-only templates/rbac.yaml` renders the new rule
- [ ] CI passes
- [ ] After merge: ArgoCD auto-syncs, `kubectl auth can-i list nodes.metrics.k8s.io --as=system:serviceaccount:monolith:monolith` returns `yes`
- [ ] `/home` cluster panel shows CPU/memory once cache TTL (60s) expires

🤖 Generated with [Claude Code](https://claude.com/claude-code)