### PR TITLE
fix(inference): raise embedding ubatch/batch to 8192 + bump memory

### DIFF
--- a/projects/agent_platform/inference/deploy/Chart.yaml
+++ b/projects/agent_platform/inference/deploy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: inference
 description: A Helm chart for LLM inference (llama.cpp and vLLM backends)
 type: application
-version: 2.5.1
+version: 2.5.2
 appVersion: "b5270"
 keywords:
   - llm

--- a/projects/agent_platform/inference/deploy/values-prod.yaml
+++ b/projects/agent_platform/inference/deploy/values-prod.yaml
@@ -242,11 +242,19 @@ embeddings:
     cacheTypeV: "f16"
     threads: 4
     jinja: false
+    # Raise ubatch/batch from llama.cpp's 512-token default: in --embedding
+    # mode the whole input must fit in one physical batch, and the monolith
+    # chunker's `words * 1.3` estimator undercounts dense markdown (tables,
+    # code) — a "512-est" chunk can decode to ~700 real tokens and 500 out.
     extraArgs:
       - "--embedding"
       - "--alias"
       - "voyage-4-nano"
       - "--metrics"
+      - "--ubatch-size"
+      - "8192"
+      - "--batch-size"
+      - "8192"
   nodeSelector:
     kubernetes.io/hostname: node-4
   podAnnotations:
@@ -256,6 +264,6 @@ embeddings:
   resources:
     requests:
       cpu: 2
-      memory: "2Gi"
-    limits:
       memory: "4Gi"
+    limits:
+      memory: "8Gi"


### PR DESCRIPTION
## Summary

- Embedding ingest fails with HTTP 500 for markdown-heavy notes (e.g. `fifteen-properties-of-living-centers.md`) because llama.cpp's default `--ubatch-size 512` rejects inputs whose actual token count exceeds 512. The monolith chunker estimates `words * 1.3` which undercounts dense markdown — a "512-est" chunk decodes to ~700 real tokens.
- Set `--ubatch-size`/`--batch-size` to `ctxSize` (8192) on `inference-embeddings` so any chunk the model can hold is accepted at the batch layer.
- Bump embedding pod memory (req 2→4Gi, limit 4→8Gi) to absorb the larger working buffer; pod was steady-state at 83% of the old 4Gi limit.

Reproduced the 500 from inside the pod with the failing chunk: `"input (703 tokens) is too large to process. increase the physical batch size (current batch size: 512)"`.

## Test plan

- [x] `helm template` renders new args + resources cleanly
- [ ] CI green
- [ ] After deploy: `kubectl logs -n inference inference-embeddings-...` shows `--ubatch-size 8192` in startup line
- [ ] After deploy: re-run `kubectl exec` repro for the table chunk and confirm HTTP 200
- [ ] Next `knowledge.reconcile` run logs `failed=0` (or at least `fifteen-properties-of-living-centers.md` no longer fails)

🤖 Generated with [Claude Code](https://claude.com/claude-code)