### PR TITLE
perf(notes): cache graph view 1h with ETag/304 revalidation

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.66.6
+version: 0.66.7
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.66.7
+version: 0.66.8
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.66.7
+      targetRevision: 0.66.8
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.66.6
+      targetRevision: 0.66.7
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/lib/cache-headers.js
+++ b/projects/monolith/frontend/src/lib/cache-headers.js
@@ -1,5 +1,10 @@
+const ONE_HOUR = 3_600;
 const ONE_DAY = 86_400;
 const ONE_YEAR = 31_536_000;
 
 // 60s fresh · 24h SWR (background refresh) · 1y SIE (cluster-down resilience)
 export const PAGE_CACHE_CONTROL = `public, s-maxage=60, stale-while-revalidate=${ONE_DAY}, stale-if-error=${ONE_YEAR}`;
+
+// /notes graph: gardener mutates on a schedule, so 1h freshness is fine. Mirrors
+// _GRAPH_CACHE_CONTROL in projects/monolith/knowledge/router.py — keep in sync.
+export const NOTES_PAGE_CACHE_CONTROL = `public, s-maxage=${ONE_HOUR}, stale-while-revalidate=${ONE_DAY}, stale-if-error=${ONE_YEAR}`;

--- a/projects/monolith/frontend/src/routes/private/notes/+page.server.js
+++ b/projects/monolith/frontend/src/routes/private/notes/+page.server.js
@@ -1,15 +1,22 @@
 import { error } from "@sveltejs/kit";
-import { PAGE_CACHE_CONTROL } from "../../../lib/cache-headers.js";
+import { NOTES_PAGE_CACHE_CONTROL } from "../../../lib/cache-headers.js";
 
 const API_BASE = process.env.API_BASE || "http://localhost:8000";
 
 export async function load({ fetch, setHeaders }) {
-  setHeaders({ "cache-control": PAGE_CACHE_CONTROL });
   const res = await fetch(`${API_BASE}/api/knowledge/graph`, {
     signal: AbortSignal.timeout(10_000),
   });
   if (!res.ok) {
     throw error(503, "graph unavailable");
   }
+
+  const headers = { "cache-control": NOTES_PAGE_CACHE_CONTROL };
+  const etag = res.headers?.get?.("etag");
+  if (etag) headers.etag = etag;
+  const lastModified = res.headers?.get?.("last-modified");
+  if (lastModified) headers["last-modified"] = lastModified;
+  setHeaders(headers);
+
   return { graph: await res.json() };
 }

--- a/projects/monolith/frontend/src/routes/private/notes/page.server.test.js
+++ b/projects/monolith/frontend/src/routes/private/notes/page.server.test.js
@@ -1,11 +1,19 @@
 import { describe, it, expect, vi } from "vitest";
 import { load } from "./+page.server.js";
 
+function makeHeaders(map = {}) {
+  const lower = Object.fromEntries(
+    Object.entries(map).map(([k, v]) => [k.toLowerCase(), v]),
+  );
+  return { get: (name) => lower[name.toLowerCase()] ?? null };
+}
+
 describe("/notes load", () => {
-  it("fetches the graph and sets the cache-control header", async () => {
+  it("fetches the graph and sets a 1h s-maxage cache-control header", async () => {
     const setHeaders = vi.fn();
     const fetch = vi.fn().mockResolvedValue({
       ok: true,
+      headers: makeHeaders(),
       json: async () => ({ nodes: [], edges: [], indexed_at: null }),
     });
 
@@ -13,10 +21,46 @@ describe("/notes load", () => {
 
     expect(setHeaders).toHaveBeenCalledWith(
       expect.objectContaining({
-        "cache-control": expect.stringContaining("s-maxage="),
+        "cache-control": expect.stringContaining("s-maxage=3600"),
       }),
     );
     expect(result.graph).toEqual({ nodes: [], edges: [], indexed_at: null });
+  });
+
+  it("forwards ETag and Last-Modified from the API response", async () => {
+    const setHeaders = vi.fn();
+    const fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      headers: makeHeaders({
+        ETag: '"abc-3"',
+        "Last-Modified": "Mon, 27 Apr 2026 12:00:00 GMT",
+      }),
+      json: async () => ({ nodes: [], edges: [], indexed_at: null }),
+    });
+
+    await load({ fetch, setHeaders });
+
+    expect(setHeaders).toHaveBeenCalledWith(
+      expect.objectContaining({
+        etag: '"abc-3"',
+        "last-modified": "Mon, 27 Apr 2026 12:00:00 GMT",
+      }),
+    );
+  });
+
+  it("omits ETag header when the API does not return one", async () => {
+    const setHeaders = vi.fn();
+    const fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      headers: makeHeaders(),
+      json: async () => ({ nodes: [], edges: [], indexed_at: null }),
+    });
+
+    await load({ fetch, setHeaders });
+
+    const headers = setHeaders.mock.calls[0][0];
+    expect(headers).not.toHaveProperty("etag");
+    expect(headers).not.toHaveProperty("last-modified");
   });
 
   it("throws a 503 when the backend fetch fails", async () => {

--- a/projects/monolith/knowledge/router.py
+++ b/projects/monolith/knowledge/router.py
@@ -15,11 +15,12 @@ from __future__ import annotations
 
 import logging
 import os
+from email.utils import format_datetime
 from pathlib import Path
 from typing import Literal
 
 import yaml
-from fastapi import APIRouter, Depends, HTTPException, Query, Response
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response
 from pydantic import BaseModel
 from sqlmodel import Session, select
 
@@ -80,24 +81,48 @@ async def search_knowledge(
     return {"results": results}
 
 
-# Mirrors PAGE_CACHE_CONTROL in projects/monolith/frontend/src/lib/cache-headers.js — keep in sync.
+# Mirrors NOTES_PAGE_CACHE_CONTROL in projects/monolith/frontend/src/lib/cache-headers.js — keep in sync.
 _GRAPH_CACHE_CONTROL = (
-    "public, s-maxage=60, stale-while-revalidate=86400, stale-if-error=31536000"
+    "public, s-maxage=3600, stale-while-revalidate=86400, stale-if-error=31536000"
 )
+
+
+def _graph_etag(graph: dict) -> str:
+    """Stable ETag for a graph payload.
+
+    Combines max(indexed_at) with node count so deletions invalidate even
+    when the surviving notes' timestamps don't move.
+    """
+    indexed_at = graph.get("indexed_at")
+    stamp = indexed_at.isoformat() if indexed_at is not None else "null"
+    return f'"{stamp}-{len(graph["nodes"])}"'
 
 
 @router.get("/graph")
 def get_graph(
+    request: Request,
     response: Response,
     session: Session = Depends(get_session),
-) -> dict:
+):
     """Return the full knowledge graph for the /notes visualisation.
 
     Heavily CDN-cached: the gardener mutates the graph on a schedule, so
-    60s freshness with 24h SWR is generous and saves repeated DB hits.
+    1h freshness with 24h SWR is generous and saves repeated DB hits.
+    Conditional GETs short-circuit with 304 via ETag/Last-Modified.
     """
-    response.headers["Cache-Control"] = _GRAPH_CACHE_CONTROL
-    return KnowledgeStore(session).get_graph()
+    graph = KnowledgeStore(session).get_graph()
+    etag = _graph_etag(graph)
+    headers = {"Cache-Control": _GRAPH_CACHE_CONTROL, "ETag": etag}
+    indexed_at = graph.get("indexed_at")
+    if indexed_at is not None:
+        headers["Last-Modified"] = format_datetime(indexed_at, usegmt=True)
+
+    if request.headers.get("if-none-match") == etag:
+        return Response(status_code=304, headers=headers)
+
+    for key, value in headers.items():
+        response.headers[key] = value
+    return graph
 
 
 @router.get("/notes/{note_id}")

--- a/projects/monolith/knowledge/router.py
+++ b/projects/monolith/knowledge/router.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import logging
 import os
+from datetime import datetime, timezone
 from email.utils import format_datetime
 from pathlib import Path
 from typing import Literal
@@ -87,15 +88,29 @@ _GRAPH_CACHE_CONTROL = (
 )
 
 
-def _graph_etag(graph: dict) -> str:
+def _as_utc(value: datetime | None) -> datetime | None:
+    """Coerce a datetime to tz-aware UTC.
+
+    Postgres returns tz-aware values; SQLite (used in tests) can return
+    naive ones even though we always write tz-aware UTC. Treat naive
+    datetimes as UTC so downstream formatters and ETag stamps are stable
+    across both backends.
+    """
+    if value is None:
+        return None
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+def _graph_etag(node_count: int, indexed_at: datetime | None) -> str:
     """Stable ETag for a graph payload.
 
     Combines max(indexed_at) with node count so deletions invalidate even
     when the surviving notes' timestamps don't move.
     """
-    indexed_at = graph.get("indexed_at")
     stamp = indexed_at.isoformat() if indexed_at is not None else "null"
-    return f'"{stamp}-{len(graph["nodes"])}"'
+    return f'"{stamp}-{node_count}"'
 
 
 @router.get("/graph")
@@ -111,9 +126,9 @@ def get_graph(
     Conditional GETs short-circuit with 304 via ETag/Last-Modified.
     """
     graph = KnowledgeStore(session).get_graph()
-    etag = _graph_etag(graph)
+    indexed_at = _as_utc(graph.get("indexed_at"))
+    etag = _graph_etag(len(graph["nodes"]), indexed_at)
     headers = {"Cache-Control": _GRAPH_CACHE_CONTROL, "ETag": etag}
-    indexed_at = graph.get("indexed_at")
     if indexed_at is not None:
         headers["Last-Modified"] = format_datetime(indexed_at, usegmt=True)
 

--- a/projects/monolith/knowledge/router_test.py
+++ b/projects/monolith/knowledge/router_test.py
@@ -745,6 +745,36 @@ class TestGraphEndpoint:
 
         cache_control = response.headers["cache-control"]
         assert "public" in cache_control
-        assert "s-maxage=" in cache_control
+        assert "s-maxage=3600" in cache_control
         assert "stale-while-revalidate=" in cache_control
         assert "stale-if-error=" in cache_control
+
+        # Conditional GET prerequisites: a stable ETag and a Last-Modified.
+        assert response.headers["etag"]
+        assert response.headers["last-modified"]
+
+    def test_graph_endpoint_returns_304_on_matching_if_none_match(self, real_session):
+        store = KnowledgeStore(real_session)
+        _upsert(
+            store,
+            note_id="id-a",
+            path="a.md",
+            content_hash="h-a",
+            title="A",
+            metadata=_meta(title="A", type="atom"),
+            n_chunks=0,
+        )
+
+        app.dependency_overrides[get_session] = lambda: real_session
+        try:
+            c = TestClient(app, raise_server_exceptions=False)
+            first = c.get("/api/knowledge/graph")
+            etag = first.headers["etag"]
+            second = c.get("/api/knowledge/graph", headers={"If-None-Match": etag})
+        finally:
+            app.dependency_overrides.clear()
+
+        assert second.status_code == 304
+        assert second.content == b""
+        assert second.headers["etag"] == etag
+        assert "s-maxage=3600" in second.headers["cache-control"]


### PR DESCRIPTION
## Summary

- Bumps `/api/knowledge/graph` CDN freshness from `s-maxage=60` to `s-maxage=3600` so Cloudflare holds the rendered graph for an hour. SWR/SIE windows are unchanged, so the safety net is intact.
- Adds an `ETag` (and `Last-Modified`) derived from the graph's `max(indexed_at)` plus node count, so conditional GETs short-circuit with `304 Not Modified` instead of re-serializing the full payload. Node count is included to invalidate when notes are deleted (since deletions don't move the surviving rows' timestamps).
- Splits a `NOTES_PAGE_CACHE_CONTROL` constant out of the shared `PAGE_CACHE_CONTROL` so the public landing page keeps its 60s freshness window. The notes page also forwards the API's `ETag`/`Last-Modified` headers so the SvelteKit data response can be revalidated by the browser back-button as well.
- Per-note fetches via `/api/knowledge/notes/{note_id}` are unchanged — they remain the live freshness path for individual notes while the graph itself is heavily cached.
- Bumps `Chart.yaml` to `0.66.7` and `application.yaml` `targetRevision` to match.

## Test plan

- [ ] CI green on `bazel test //...` (unit tests for both router.py ETag/304 behaviour and the SvelteKit page load)
- [ ] After ArgoCD rolls 0.66.7: `curl -i https://<host>/api/knowledge/graph` returns `Cache-Control: ... s-maxage=3600 ...` plus `ETag:` and `Last-Modified:` headers
- [ ] Repeating the call with `If-None-Match: <etag>` returns `304` with empty body
- [ ] DevTools network panel for `/notes` page shows `cache-control: ... s-maxage=3600 ...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)