### PR TITLE
feat(knowledge): enable discardable-gap rewrite + tombstone

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.67.0
+version: 0.67.1
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/templates/deployment.yaml
+++ b/projects/monolith/chart/templates/deployment.yaml
@@ -102,6 +102,10 @@ spec:
             {{- if .Values.knowledge.enabled }}
             - name: VAULT_ROOT
               value: {{ .Values.knowledge.vault.mountPath }}
+            {{- if .Values.knowledge.gaps.rewriteDiscardable }}
+            - name: KNOWLEDGE_GAPS_REWRITE_DISCARDABLE
+              value: "1"
+            {{- end }}
             {{- if .Values.knowledge.gitRemote }}
             - name: VAULT_GIT_REMOTE
               value: {{ .Values.knowledge.gitRemote | quote }}

--- a/projects/monolith/chart/values.yaml
+++ b/projects/monolith/chart/values.yaml
@@ -61,6 +61,12 @@ clickhouse:
 knowledge:
   enabled: false
   gitRemote: ""
+  gaps:
+    # When true, the gardener rewrites [[X]] -> bare text in source notes
+    # whose stub is marked `triaged: discardable`, then tombstones the gap
+    # row + stub once no references remain. Off by default — opt-in per
+    # cluster.
+    rewriteDiscardable: false
   headlessSync:
     image:
       repository: ghcr.io/jomcgi/homelab/projects/monolith/obsidian-image

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.67.0
+      targetRevision: 0.67.1
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/deploy/values.yaml
+++ b/projects/monolith/deploy/values.yaml
@@ -72,6 +72,8 @@ cfIngress:
 knowledge:
   enabled: true
   gitRemote: "https://github.com/jomcgi/obsidian-vault.git"
+  gaps:
+    rewriteDiscardable: true
   headlessSync:
     vaultName: "jomcgi"
   onepassword:


### PR DESCRIPTION
## Summary

- Sets `KNOWLEDGE_GAPS_REWRITE_DISCARDABLE=1` on the monolith backend to flip on Phase A of the work merged in #2246
- Chart `values.yaml` adds `knowledge.gaps.rewriteDiscardable` (default `false`) so the chart stays safe for any consumer; deploy `values.yaml` opts in for this cluster
- Chart 0.67.0 → 0.67.1 with matching `targetRevision`

Most recent dry-run on this cluster reported `rewrites_dryrun=1413` across 662 discardable stubs (and `tombstoned=55` already firing safely). After this lands, the next gardener cycle should report `rewrites_applied=1413` and the cycle after should tombstone the bulk of the 662.

## Test plan

- [x] `helm template` confirms `KNOWLEDGE_GAPS_REWRITE_DISCARDABLE: "1"` renders into the backend container env
- [x] Chart default keeps `rewriteDiscardable: false` so non-homelab consumers don't accidentally rewrite vault content
- [ ] Watch the next gardener cycle's `gaps.discover_gaps:` log line — expect `rewrites_applied` ≈ `rewrites_dryrun` from before
- [ ] Spot-check a few rewritten source notes via `git status` in the obsidian-vault repo