### PR TITLE
fix(monolith): bypass subdomain reroute for /otel/

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.68.0
+version: 0.68.1
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.68.0
+      targetRevision: 0.68.1
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/hooks.js
+++ b/projects/monolith/frontend/src/hooks.js
@@ -12,8 +12,17 @@ const DOMAIN_PREFIX_MAP = {
   "private.": "/private",
 };
 
+// Top-level routes that intentionally live outside /public and /private.
+// The browser OTEL exporter posts to same-origin /otel/v1/traces and the
+// handler proxies to the cluster-internal SigNoz collector, so it must
+// not be swept under a subdomain prefix.
+const PASSTHROUGH_PREFIXES = ["/otel/"];
+
 /** @type {import('@sveltejs/kit').Reroute} */
 export function reroute({ url }) {
+  if (PASSTHROUGH_PREFIXES.some((p) => url.pathname.startsWith(p))) {
+    return;
+  }
   for (const [domain, prefix] of Object.entries(DOMAIN_PREFIX_MAP)) {
     if (
       url.hostname.startsWith(domain) &&

--- a/projects/monolith/frontend/src/hooks.test.js
+++ b/projects/monolith/frontend/src/hooks.test.js
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import { reroute } from "./hooks.js";
+
+function url(hostname, pathname) {
+  return new URL(`https://${hostname}${pathname}`);
+}
+
+describe("reroute", () => {
+  it("rewrites public.* paths under /public", () => {
+    expect(reroute({ url: url("public.jomcgi.dev", "/slos") })).toBe(
+      "/public/slos",
+    );
+  });
+
+  it("rewrites private.* paths under /private", () => {
+    expect(reroute({ url: url("private.jomcgi.dev", "/notes") })).toBe(
+      "/private/notes",
+    );
+  });
+
+  it("leaves /otel/* alone on subdomain hosts so browser spans reach the proxy", () => {
+    expect(
+      reroute({ url: url("public.jomcgi.dev", "/otel/v1/traces") }),
+    ).toBeUndefined();
+    expect(
+      reroute({ url: url("private.jomcgi.dev", "/otel/v1/traces") }),
+    ).toBeUndefined();
+  });
+
+  it("leaves already-prefixed paths alone", () => {
+    expect(
+      reroute({ url: url("public.jomcgi.dev", "/public/slos") }),
+    ).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- The browser OTEL exporter posts to `${origin}/otel/v1/traces`, which the SvelteKit reroute hook in `frontend/src/hooks.js` was silently rewriting to `/public/otel/v1/traces` (or `/private/...`) on the subdomain hosts — there is no route there, so the SSR server returned **404** for every span batch.
- A same-origin proxy at `frontend/src/routes/otel/v1/traces/+server.js` already exists and forwards to the cluster-internal SigNoz collector via `OTEL_COLLECTOR_HTTP_URL`. It just never received the traffic because the reroute happened first.
- Fix: add a `PASSTHROUGH_PREFIXES = ["/otel/"]` list and early-return from `reroute` when the request path starts with one of them. Adds a small `hooks.test.js` covering the reroute behaviour and the new passthrough.

This keeps OTEL same-origin only — there is no public OTEL endpoint exposed; the browser still goes through the SSR proxy and the proxy talks to the cluster-internal collector.

The 404s regressed in `9438f9b68` ("unify domain-to-route rerouting in SvelteKit hooks") which moved the public/private rewrite from the gateway into the hook; the gateway used to leave `/otel/*` untouched.

## Test plan
- [x] `prettier` clean on both files
- [ ] CI runs `vitest` on `hooks.test.js` and the existing frontend suites
- [ ] After merge: in browser devtools, confirm `POST /otel/v1/traces` returns `200` (or `204` if `OTEL_COLLECTOR_HTTP_URL` is unset on the env) instead of `404`
- [ ] Confirm `monolith-frontend` service spans appear in SigNoz

🤖 Generated with [Claude Code](https://claude.com/claude-code)