### PR TITLE
chore(monolith): bump backend memory to 3Gi req+lim

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.68.2
+version: 0.68.3
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.68.2
+      targetRevision: 0.68.3
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/deploy/values.yaml
+++ b/projects/monolith/deploy/values.yaml
@@ -5,10 +5,10 @@ backend:
   otelEndpoint: "http://signoz-k8s-infra-otel-agent.signoz.svc.cluster.local:4318/v1/traces"
   resources:
     requests:
-      memory: "256Mi"
+      memory: "3Gi"
       cpu: "10m"
     limits:
-      memory: "512Mi"
+      memory: "3Gi"
 
 frontend:
   otelCollectorUrl: "http://signoz-k8s-infra-otel-agent.signoz.svc.cluster.local:4318"


### PR DESCRIPTION
## Summary

The discardable-rewrite cycle (#2246/#2247/#2250) creates a brief embedding-burst spike: when Phase A rewrites N source notes, the next reconcile re-ingests them and the embedder processes ~10K chunks in one batch. The current 256Mi/512Mi req/lim is OOMKilling the pod mid-burst (exit 137), which leaves stale scheduler locks and stalls the convergence loop.

## Evidence

Pre-restart log of the most recent crash:
- `gaps.discover_gaps: rewrites_applied=76`
- `reconciler: upserted=1218`
- `generating index: 10643/10665`  ← OOMKilled here
- `Last State: Terminated, Reason: OOMKilled, Exit Code: 137`

## Why 3Gi

Covers the burst with substantial headroom. Drops back to baseline (~few hundred MiB) once the discardable backlog drains and per-cycle work returns to normal volume.

## Follow-up (separate PR)

Make the embedder process chunks in bounded batches with progress flushing, so a 10K-chunk reingest doesn't try to allocate them all at once. Once that lands we can drop the limit back to 1Gi-ish.

## Test plan

- [x] `helm template ...` renders `memory: 3Gi` for both requests and limits on the backend container
- [x] Chart.yaml + targetRevision bumped to 0.68.3 in lockstep