### PR TITLE
docs: fix stale API URLs in ships and trips sub-READMEs

### DIFF
--- a/projects/ships/backend/README.md
+++ b/projects/ships/backend/README.md
@@ -144,7 +144,7 @@ Returns a flat list of vessels joined with their latest positions. Each entry co
 
 ```bash
 # Get all vessels
-curl https://ships-api.jomcgi.dev/api/vessels
+curl https://ships.jomcgi.dev/api/vessels
 ```
 
 ### GET /api/vessels/{mmsi}
@@ -186,7 +186,7 @@ Same flat structure as the vessels list, with additional computed fields for the
 **Example:**
 
 ```bash
-curl https://ships-api.jomcgi.dev/api/vessels/316001234
+curl https://ships.jomcgi.dev/api/vessels/316001234
 ```
 
 **Error responses:**
@@ -226,13 +226,13 @@ Get position history for a vessel.
 
 ```bash
 # Get all positions (last 7 days)
-curl https://ships-api.jomcgi.dev/api/vessels/316001234/track
+curl https://ships.jomcgi.dev/api/vessels/316001234/track
 
 # Get positions from last hour
-curl https://ships-api.jomcgi.dev/api/vessels/316001234/track?since=1h
+curl https://ships.jomcgi.dev/api/vessels/316001234/track?since=1h
 
 # Get last 100 positions
-curl https://ships-api.jomcgi.dev/api/vessels/316001234/track?limit=100
+curl https://ships.jomcgi.dev/api/vessels/316001234/track?limit=100
 ```
 
 ### WS /ws/live
@@ -286,7 +286,7 @@ Subsequently, batched position updates are broadcast as vessels move:
 **Example client:**
 
 ```javascript
-const ws = new WebSocket("wss://ships-api.jomcgi.dev/ws/live");
+const ws = new WebSocket("wss://ships.jomcgi.dev/ws/live");
 
 ws.onmessage = (event) => {
   const msg = JSON.parse(event.data);
@@ -452,7 +452,7 @@ Deployed via ArgoCD to Kubernetes cluster.
 
 - Helm chart: `projects/ships/chart/`
 - Overlay: `projects/ships/deploy/`
-- Service URL: https://ships-api.jomcgi.dev
+- Service URL: https://ships.jomcgi.dev
 
 **Persistent storage:**
 

--- a/projects/ships/chart/Chart.yaml
+++ b/projects/ships/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: marine
 description: Marine services - AIS vessel tracking and API
 type: application
-version: 0.3.48
+version: 0.3.49
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/ships/deploy/application.yaml
+++ b/projects/ships/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: marine
-      targetRevision: 0.3.48
+      targetRevision: 0.3.49
       helm:
         releaseName: marine
         valueFiles:

--- a/projects/trips/backend/README.md
+++ b/projects/trips/backend/README.md
@@ -72,7 +72,7 @@ MaxAge: 8760h # 365 days
 ### Connection
 
 ```javascript
-const ws = new WebSocket("wss://trips-api.jomcgi.dev/ws/live");
+const ws = new WebSocket("wss://api.jomcgi.dev/trips/ws/live");
 ```
 
 **Authentication:** None (public read-only endpoint)
@@ -155,7 +155,7 @@ pong
 ### Example Client
 
 ```javascript
-const ws = new WebSocket("wss://trips-api.jomcgi.dev/ws/live");
+const ws = new WebSocket("wss://api.jomcgi.dev/trips/ws/live");
 
 ws.onopen = () => {
   console.log("Connected to trip updates");
@@ -256,13 +256,13 @@ Get all trip points.
 
 ```bash
 # Get all points
-curl -H "X-API-Key: $TRIP_API_KEY" https://trips-api.jomcgi.dev/api/points
+curl -H "X-API-Key: $TRIP_API_KEY" https://api.jomcgi.dev/trips/api/points
 
 # Get first 100 points
-curl -H "X-API-Key: $TRIP_API_KEY" https://trips-api.jomcgi.dev/api/points?limit=100
+curl -H "X-API-Key: $TRIP_API_KEY" https://api.jomcgi.dev/trips/api/points?limit=100
 
 # Paginate: skip first 100, get next 100
-curl -H "X-API-Key: $TRIP_API_KEY" https://trips-api.jomcgi.dev/api/points?limit=100&offset=100
+curl -H "X-API-Key: $TRIP_API_KEY" https://api.jomcgi.dev/trips/api/points?limit=100&offset=100
 ```
 
 ### GET /api/points/{point_id}
@@ -416,7 +416,7 @@ Deployed via ArgoCD to Kubernetes cluster.
 
 - Helm chart: `projects/trips/chart/`
 - Overlay: `projects/trips/deploy/`
-- Service URL: https://trips-api.jomcgi.dev
+- Service URL: https://api.jomcgi.dev/trips
 
 **Dependencies:**
 

--- a/projects/trips/chart/README.md
+++ b/projects/trips/chart/README.md
@@ -10,7 +10,7 @@ A trip photo sharing platform that stores original images in SeaweedFS (S3-compa
 flowchart LR
     User[User] --> Nginx[Nginx\nRouter]
     Nginx -->|/trips/full/| SeaweedFS[SeaweedFS\nS3 Storage]
-    Nginx -->|/trips/thumb/\n/trips/display/\n/trips/gallery/| Imgproxy[imgproxy\nImage Resizer]
+    Nginx -->|/trips/thumb/\n/trips/display/\n/trips/preview/\n/trips/gallery/| Imgproxy[imgproxy\nImage Resizer]
     Imgproxy --> SeaweedFS
     Nginx -->|/trips/api/| API[Python API]
     Nginx -->|/trips/ws/| API


### PR DESCRIPTION
## Summary

Final README verification sweep found three inaccuracies in sub-READMEs that the initial audit missed:

- **`ships/backend/README.md`**: All example URLs used `ships-api.jomcgi.dev` which doesn't exist in the Cloudflare gateway config. The ships API is proxied through the Bun frontend server at `ships.jomcgi.dev/api/...` and `wss://ships.jomcgi.dev/ws/live`.
- **`trips/backend/README.md`**: All example URLs used `trips-api.jomcgi.dev` which is not a real public hostname. The trips API is routed through `api-gateway` at `api.jomcgi.dev/trips/...` (confirmed in `projects/agent_platform/api_gateway/deploy/templates/configmap.yaml`).
- **`trips/chart/README.md`**: The mermaid architecture diagram listed only three imgproxy routes (`/trips/thumb/`, `/trips/display/`, `/trips/gallery/`) but the nginx configmap actually defines four — the `/trips/preview/` (1200px) variant was missing.

## Test plan

- [x] Verified `ships-api.jomcgi.dev` does not appear in Cloudflare gateway config (`values-prod.yaml`)
- [x] Confirmed ships API is proxied via Bun `server.ts` at `ships.jomcgi.dev/api/` and `/ws/`
- [x] Confirmed trips API gateway routes `/trips/` → trips nginx in `configmap.yaml`
- [x] Confirmed all four imgproxy routes in `nginx-configmap.yaml`: thumb, display, preview, gallery

🤖 Generated with [Claude Code](https://claude.com/claude-code)