### PR TITLE
test(gardener): assert WebSearch and WebFetch in allowedTools

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.68.4
+version: 0.68.5
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.68.4
+      targetRevision: 0.68.5
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/knowledge/gardener_test.py
+++ b/projects/monolith/knowledge/gardener_test.py
@@ -372,6 +372,8 @@ class TestIngestOneClaude:
         allowed_tools = args[allowed_idx + 1]
         assert "Bash" in allowed_tools
         assert "Write" in allowed_tools
+        assert "WebSearch" in allowed_tools
+        assert "WebFetch" in allowed_tools
         assert kwargs.get("cwd") == vault
         assert kwargs.get("env", {}).get("HOME") == "/tmp"
 


### PR DESCRIPTION
## Summary

- Adds two assertions to `test_spawns_claude_with_correct_flags` in `gardener_test.py`
- Asserts that `WebSearch` and `WebFetch` are present in the `--allowedTools` value passed to the `claude` subprocess
- Guards against accidentally dropping the web tools added in commit `97378bc9` that close the research pipeline loop

## Test plan

- [ ] CI passes `bazel test //projects/monolith/...` (existing test now also validates WebSearch/WebFetch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)