### PR TITLE
docs(trips): replace vague tools description with named sub-directories

### DIFF
--- a/projects/trips/README.md
+++ b/projects/trips/README.md
@@ -8,6 +8,6 @@ Photo-based GPS trip logging with elevation enrichment.
 | ------------ | ------------------------------------------------------------------------------------------ |
 | **backend**  | FastAPI server that replays trip data from NATS JetStream and serves REST + WebSocket APIs |
 | **frontend** | Timeline view with day-by-day maps and per-day elevation stats (ascent, descent, min/max)  |
-| **tools**    | CLI tools for image ingestion with EXIF extraction, elevation enrichment, trip point management, KML route import, wildlife detection inference (`detect-wildlife`), and GoPro camera control |
+| **tools**    | CLI tools for trip data management — six sub-directories: `publish-trip-images` (image ingestion with EXIF extraction), `backfill-elevation` (replays NATS points and enriches with elevation data), `delete-trip-points` (publishes tombstone messages to delete points), `publish-gap-route` (parses KML files to fill route gaps), `detect-wildlife` (wildlife detection inference + GoPro camera control), `elevation` (elevation API client library) |
 | **chart**    | Helm chart for Kubernetes deployment                                                       |
 | **deploy**   | ArgoCD Application, kustomization, and cluster-specific values                             |


### PR DESCRIPTION
## Summary

- **tools**: Replaced the vague run-on description with a precise inline list naming all 6 tool sub-directories: `publish-trip-images`, `backfill-elevation`, `delete-trip-points`, `publish-gap-route`, `detect-wildlife`, and `elevation`, each with a concise purpose description

## Test plan

- [ ] README renders correctly on GitHub
- [ ] All 6 tool directories exist under `projects/trips/tools/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)