### PR TITLE
test(monolith): assert exc_info=False in cluster counts error path

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.69.0
+version: 0.69.1
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.69.0
+      targetRevision: 0.69.1
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/home/observability/stats_test.py
+++ b/projects/monolith/home/observability/stats_test.py
@@ -211,11 +211,16 @@ async def test_cluster_counts_handles_k8s_errors():
     mock_client.count_pods = AsyncMock(return_value=10)
     mock_client.count_deployments = AsyncMock(return_value=5)
     mock_client.count_argocd_applications = AsyncMock(return_value=2)
-    mock_client.aggregate_node_resources = AsyncMock(
-        side_effect=Exception("metrics-server unreachable")
-    )
+    # Keep a reference to the exception so we can verify it is forwarded to logger.warning
+    # as a positional arg (not as exc_info=), which is the correct pattern outside an
+    # except block.
+    resources_error = Exception("metrics-server unreachable")
+    mock_client.aggregate_node_resources = AsyncMock(side_effect=resources_error)
 
-    with patch("home.observability.stats.KubernetesClient", return_value=mock_client):
+    with (
+        patch("home.observability.stats.KubernetesClient", return_value=mock_client),
+        patch("home.observability.stats.logger") as mock_logger,
+    ):
         result = await stats._query_cluster_counts()
 
     assert result["nodes"] == 0  # failed, falls back to 0
@@ -223,6 +228,15 @@ async def test_cluster_counts_handles_k8s_errors():
     # When aggregate_node_resources fails, the resource keys are simply absent.
     assert "cpu_used_cores" not in result
     assert "memory_used_gb" not in result
+    # Regression guard: exc_info must be False (not the exception object).
+    # Passing an Exception instance as exc_info outside an except block is a bug —
+    # the original code had exc_info=resources which was wrong; it was fixed to
+    # exc_info=False. This assertion ensures that regression cannot silently creep back.
+    mock_logger.warning.assert_called_once_with(
+        "Node resource aggregation failed: %s",
+        resources_error,
+        exc_info=False,
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Enhances `test_cluster_counts_handles_k8s_errors` in `stats_test.py` to guard against a specific logging bug that was recently fixed.
- The bug: `exc_info=resources` was passed to `logger.warning` outside an `except` block — an `Exception` object was used where `True`/`False`/a tuple is expected. It was corrected to `exc_info=False`.
- The new assertion patches `home.observability.stats.logger`, captures the `warning` call, and asserts it was invoked with `("Node resource aggregation failed: %s", resources_error, exc_info=False)` — ensuring the regression cannot creep back silently.

## Changes

- `projects/monolith/home/observability/stats_test.py`: stored the exception in a named variable `resources_error`, added `patch("home.observability.stats.logger")` to the existing context manager, added `mock_logger.warning.assert_called_once_with(...)` with `exc_info=False`.

## Test plan

- [ ] CI `bazel test //...` passes — specifically `//projects/monolith/home/observability:stats_test`
- [ ] The assertion would **fail** if `exc_info=False` were reverted to `exc_info=resources` in `stats.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)