### PR TITLE
feat(semgrep): add no-deprecated-api-subdomain rule and fix trips docs

### DIFF
--- a/bazel/semgrep/rules/BUILD
+++ b/bazel/semgrep/rules/BUILD
@@ -230,6 +230,22 @@ semgrep_test(
     tags = ["semgrep"],
 )
 
+# no-deprecated-api-subdomain uses languages: [generic] scoped to projects/**/*.md.
+# This test wires the rule to its colocated annotation fixture independently of
+# generic_rules_test (which only scans no-stale-repo-paths fixtures).
+filegroup(
+    name = "no_deprecated_api_subdomain_rule",
+    srcs = ["generic/no-deprecated-api-subdomain.yaml"],
+)
+
+semgrep_test(
+    name = "no_deprecated_api_subdomain_test",
+    srcs = ["generic/no-deprecated-api-subdomain.txt"],
+    env = {"SEMGREP_TEST_MODE": "1"},
+    rules = [":no_deprecated_api_subdomain_rule"],
+    tags = ["semgrep"],
+)
+
 semgrep_test(
     name = "shell_rules_test",
     srcs = glob(["shell/*.bash"]),

--- a/bazel/semgrep/rules/generic/no-deprecated-api-subdomain.txt
+++ b/bazel/semgrep/rules/generic/no-deprecated-api-subdomain.txt
@@ -1,0 +1,39 @@
+# Test fixtures for the no-deprecated-api-subdomain semgrep rule.
+#
+# Annotations:
+#   # ruleid: no-deprecated-api-subdomain  — the next non-annotation line MUST be flagged
+#   # ok: no-deprecated-api-subdomain      — the next non-annotation line MUST NOT be flagged
+
+## Positive examples (should be flagged)
+
+A deprecated trips API subdomain in a curl example:
+
+# ruleid: no-deprecated-api-subdomain
+curl -X POST https://trips-api.jomcgi.dev/api/images
+
+A deprecated ships API subdomain in a config comment:
+
+# ruleid: no-deprecated-api-subdomain
+SHIPS_URL=https://ships-api.jomcgi.dev
+
+## Negative examples (should not be flagged)
+
+Direct service subdomain (current pattern):
+
+# ok: no-deprecated-api-subdomain
+https://trips.jomcgi.dev
+
+API gateway routing (current pattern):
+
+# ok: no-deprecated-api-subdomain
+https://api.jomcgi.dev/trips
+
+Top-level domain only:
+
+# ok: no-deprecated-api-subdomain
+jomcgi.dev
+
+A non-api subdomain:
+
+# ok: no-deprecated-api-subdomain
+https://ships.jomcgi.dev/api/v1/routes

--- a/bazel/semgrep/rules/generic/no-deprecated-api-subdomain.yaml
+++ b/bazel/semgrep/rules/generic/no-deprecated-api-subdomain.yaml
@@ -1,0 +1,22 @@
+rules:
+  - id: no-deprecated-api-subdomain
+    languages: [generic]
+    severity: WARNING
+    message: >-
+      Found a reference to a deprecated *-api.jomcgi.dev subdomain. Services now
+      use direct subdomains (e.g. ships.jomcgi.dev) or api-gateway routing
+      (e.g. api.jomcgi.dev/<service>). Update this URL to the current pattern.
+    metadata:
+      category: maintainability
+      subcategory: url-deprecation
+      confidence: HIGH
+      likelihood: MEDIUM
+      impact: LOW
+      description: >-
+        Detects deprecated *-api.jomcgi.dev subdomain references in project
+        documentation. Use direct service subdomains (e.g. ships.jomcgi.dev)
+        or the API gateway (api.jomcgi.dev/<service>) instead.
+    paths:
+      include:
+        - "projects/**/*.md"
+    pattern-regex: '\w+-api\.jomcgi\.dev'

--- a/bazel/semgrep/tests/BUILD
+++ b/bazel/semgrep/tests/BUILD
@@ -13,6 +13,7 @@ filegroup(
             "fixtures/fastapi-bare-tuple-return.yaml",
             "fixtures/logger-exc-info-non-boolean.yaml",
             "fixtures/no-create-extension-sql.yaml",
+            "fixtures/no-deprecated-api-subdomain.yaml",
             "fixtures/no-discarded-json-marshal.yaml",
             "fixtures/no-shared-preload-libraries-cnpg.yaml",
             "fixtures/no-unquoted-helm-range-args.yaml",

--- a/bazel/semgrep/tests/fixtures/no-deprecated-api-subdomain.yaml
+++ b/bazel/semgrep/tests/fixtures/no-deprecated-api-subdomain.yaml
@@ -1,0 +1,48 @@
+# Reference fixture for the no-deprecated-api-subdomain semgrep rule.
+# This file documents ok/bad patterns for human review.
+# The actual semgrep test fixture is bazel/semgrep/rules/generic/no-deprecated-api-subdomain.txt.
+#
+# Background: The homelab previously exposed services at *-api.jomcgi.dev subdomains
+# (e.g. trips-api.jomcgi.dev, ships-api.jomcgi.dev). These have been replaced by
+# direct service subdomains (e.g. trips.jomcgi.dev) or api-gateway routing
+# (e.g. api.jomcgi.dev/trips). Documentation referencing the old pattern should
+# be updated to avoid misleading consumers.
+
+examples:
+  bad:
+    - description: >-
+        deprecated trips API subdomain in a curl example — should use
+        api.jomcgi.dev/trips instead
+      code: |
+        curl -X POST https://trips-api.jomcgi.dev/api/images \
+          -H "CF-Access-Client-Id: $ID" \
+          -F "file=@image.jpg"
+
+    - description: >-
+        deprecated trips API subdomain in an environment variable — should use
+        api.jomcgi.dev/trips
+      code: |
+        TRIPS_API_URL=https://trips-api.jomcgi.dev
+
+    - description: >-
+        deprecated ships API subdomain referenced in a Cloudflare Access
+        application config
+      code: |
+        Create Cloudflare Access application for ships-api.jomcgi.dev/api/routes
+
+  ok:
+    - description: direct service subdomain — current pattern
+      code: |
+        https://trips.jomcgi.dev
+
+    - description: api-gateway routing — current pattern
+      code: |
+        TRIPS_API_URL=https://api.jomcgi.dev/trips
+
+    - description: top-level domain without a service prefix
+      code: |
+        jomcgi.dev
+
+    - description: non-api service subdomain
+      code: |
+        curl https://ships.jomcgi.dev/api/v1/routes

--- a/projects/trips/tools/publish-trip-images/api-migration.md
+++ b/projects/trips/tools/publish-trip-images/api-migration.md
@@ -114,7 +114,7 @@ gantt
 
 ### Phase 2: Cloudflare Access
 
-- [ ] Create Cloudflare Access application for `trips-api.jomcgi.dev/api/images`
+- [ ] Create Cloudflare Access application for `api.jomcgi.dev/trips/api/images`
 - [ ] Create service token for local client
 - [ ] Test auth flow with curl
 
@@ -153,7 +153,7 @@ SEAWEEDFS_SECRET_KEY=...
 ### Client (local)
 
 ```bash
-TRIPS_API_URL=https://trips-api.jomcgi.dev
+TRIPS_API_URL=https://api.jomcgi.dev/trips
 CF_ACCESS_CLIENT_ID=<from cloudflare>
 CF_ACCESS_CLIENT_SECRET=<from cloudflare>
 ```
@@ -167,7 +167,7 @@ curl -X POST http://localhost:8000/api/images \
   -F "file=@/path/to/image.jpg"
 
 # Test with Cloudflare Access (production)
-curl -X POST https://trips-api.jomcgi.dev/api/images \
+curl -X POST https://api.jomcgi.dev/trips/api/images \
   -H "CF-Access-Client-Id: $CF_ACCESS_CLIENT_ID" \
   -H "CF-Access-Client-Secret: $CF_ACCESS_CLIENT_SECRET" \
   -H "X-Image-Source: gopro" \


### PR DESCRIPTION
## Summary

- Adds semgrep rule `no-deprecated-api-subdomain` (`language: generic`, scoped to `projects/**/*.md`, severity `WARNING`) that flags deprecated `*-api.jomcgi.dev` subdomain URLs — services now use direct subdomains (e.g. `ships.jomcgi.dev`) or api-gateway routing (`api.jomcgi.dev/<service>`)
- Adds annotated test fixture at `bazel/semgrep/rules/generic/no-deprecated-api-subdomain.txt` with `# ruleid:` / `# ok:` comments
- Adds reference fixture at `bazel/semgrep/tests/fixtures/no-deprecated-api-subdomain.yaml` documenting bad/ok patterns
- Excludes reference fixture from `yaml_fixtures` glob in `bazel/semgrep/tests/BUILD` (same pattern as `logger-exc-info-non-boolean.yaml`)
- Wires `no_deprecated_api_subdomain_test` target in `bazel/semgrep/rules/BUILD`
- Fixes 3 remaining `trips-api.jomcgi.dev` references in `projects/trips/tools/publish-trip-images/api-migration.md` → `api.jomcgi.dev/trips`

## Test plan

- [ ] CI passes `bazel test //...`
- [ ] `no_deprecated_api_subdomain_test` builds and passes (SEMGREP_TEST_MODE=1 skips with warning, exits 0)
- [ ] `yaml_rules_test` still passes — new fixture excluded from glob
- [ ] `generic_rules_test` still passes — new rule in `generic/` filegroup, no-stale-repo-paths.md fixture has no deprecated API subdomain patterns
- [ ] No `trips-api.jomcgi.dev` occurrences remain in `projects/**/*.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)