### PR TITLE
docs(agent_platform): fix umbrella chart description in README

### DIFF
--- a/projects/agent_platform/README.md
+++ b/projects/agent_platform/README.md
@@ -17,5 +17,5 @@ See [docs/agents.md](../../docs/agents.md) for the full architecture.
 | **goose_agent**          | Goose agent container and configuration |
 | **inference**            | On-cluster LLM inference and embedding inference (model configured per environment) |
 | **vllm**                 | Alternative LLM serving backend (full Helm chart with templates and vendored dependencies in `vllm/deploy/` — not wired to ArgoCD) |
-| **chart**                | Umbrella Helm chart for all agent platform components |
+| **chart**                | Umbrella Helm chart bundling orchestrator, sandboxes, MCP servers, and NATS (`cluster_agents`, `inference`, and `api_gateway` have separate ArgoCD Applications) |
 | **deploy**               | ArgoCD Application, kustomization, and cluster-specific values |


### PR DESCRIPTION
## Summary

- Corrects the `chart` row description in `projects/agent_platform/README.md`
- The umbrella chart bundles **5 subcharts**: orchestrator, sandboxes (goose-sandboxes), MCP servers, NATS, and agent-sandbox
- `cluster_agents`, `inference`, and `api_gateway` each have separate ArgoCD Applications and are **not** part of this umbrella chart
- Previous wording "Umbrella Helm chart for all agent platform components" was misleading

## Test plan
- [ ] README renders correctly on GitHub
- [ ] Chart description matches `chart/Chart.yaml` dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)