### PR TITLE
docs(trips): clarify GoPro control is inside detect-wildlife

### DIFF
--- a/projects/trips/README.md
+++ b/projects/trips/README.md
@@ -8,6 +8,6 @@ Photo-based GPS trip logging with elevation enrichment.
 | ------------ | ------------------------------------------------------------------------------------------ |
 | **backend**  | FastAPI server that replays trip data from NATS JetStream and serves REST + WebSocket APIs |
 | **frontend** | Timeline view with day-by-day maps and per-day elevation stats (ascent, descent, min/max)  |
-| **tools**    | CLI tools for image ingestion with EXIF extraction, elevation enrichment, trip point management, KML route import, wildlife detection inference (`detect-wildlife`), and GoPro camera control |
+| **tools**    | CLI tools for image ingestion with EXIF extraction, elevation enrichment, trip point management, KML route import, and wildlife detection with GoPro camera control (`detect-wildlife`) |
 | **chart**    | Helm chart for Kubernetes deployment                                                       |
 | **deploy**   | ArgoCD Application, kustomization, and cluster-specific values                             |


### PR DESCRIPTION
## Summary

- Corrects the `tools` row description in `projects/trips/README.md`
- GoPro camera control is implemented **inside** `detect-wildlife/main.py` (imports `open_gopro`, instantiates `WiredGoPro`), not as a separate standalone tool
- Previous wording listed "GoPro camera control" after the `(detect-wildlife)` parenthetical, implying it was a separate tool

## Test plan
- [ ] README renders correctly on GitHub
- [ ] Description accurately reflects that GoPro control is part of `detect-wildlife`

🤖 Generated with [Claude Code](https://claude.com/claude-code)