### PR TITLE
docs(agent_platform): fix cluster_agents and orchestrator descriptions

### DIFF
--- a/projects/agent_platform/README.md
+++ b/projects/agent_platform/README.md
@@ -10,9 +10,9 @@ See [docs/agents.md](../../docs/agents.md) for the full architecture.
 
 | Component                | Description |
 | ------------------------ | ----------- |
-| **orchestrator**         | Go service that dispatches agent jobs via NATS JetStream |
+| **orchestrator**         | Go service that dispatches agent jobs via NATS JetStream. Also contains an MCP server (`mcp/`), a React web UI (`ui/`), and a CLI runner (`cmd/runner/`) |
 | **sandboxes**            | Shell setup script for MCP profiles (`setup-mcp-profiles.sh`); Kubernetes sandbox pod definitions live in `chart/sandboxes/` and `chart/agent-sandbox/` |
-| **cluster_agents**       | Go service that monitors cluster health and runs autonomous improvement agents (patrol, escalator, PR fix, README freshness, test coverage, rules, `collector_alerts`, and `git_activity_gate`). `collector_alerts` monitors SigNoz alert rules; `git_activity_gate` gates autonomous agent runs on recent git activity. |
+| **cluster_agents**       | Go service that monitors cluster health and runs five autonomous improvement agents: `patrol` (escalates firing SigNoz alerts), `TestCoverageAgent`, `ReadmeFreshnessAgent`, `RulesAgent`, and `PRFixAgent`. Shared utilities: `AlertCollector` polls SigNoz for firing alerts (used by patrol); `GitActivityGate` gates improvement-agent runs on recent git activity; `Escalator` deduplicates findings and dispatches jobs to the orchestrator. |
 | **api_gateway**          | Nginx-based API gateway with route-based backend selection for api.jomcgi.dev. Has its own Helm chart and ArgoCD Application in `api_gateway/deploy/` (not part of the umbrella chart), with nginx reverse proxy, cluster-info sidecar, and SLO alerting templates. |
 | **goose_agent**          | Goose agent container and configuration. Includes 19 agent recipe YAML files in `image/recipes/` (deep-plan, code-fix, research, web-research, adr-writer, bazel, ci-debug, feature, pr-review, and more) and the apko container image definition in `image/`. |
 | **inference**            | On-cluster LLM inference and embedding inference (model configured per environment) |


### PR DESCRIPTION
## Summary

- **cluster_agents**: The previous description incorrectly listed `escalator`, `collector_alerts`, and `git_activity_gate` as agents alongside the actual registered agents. Fixed to clearly distinguish the five `Agent` interface implementations (`patrol`, `TestCoverageAgent`, `ReadmeFreshnessAgent`, `RulesAgent`, `PRFixAgent`) from the three shared utilities (`AlertCollector`, `GitActivityGate`, `Escalator`).
- **orchestrator**: Added the previously unmentioned `mcp/` (Python MCP server), `ui/` (React web UI), and `cmd/runner/` (CLI runner) subdirectories to the component description.

## Verification

Changes verified against `cluster_agents/main.go` (agents registered in `[]Agent{...}`) and `orchestrator/` directory structure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)