### PR TITLE
feat(semgrep): add no-create-event-dispatcher-runes rule for Svelte 5

### DIFF
--- a/bazel/semgrep/rules/BUILD
+++ b/bazel/semgrep/rules/BUILD
@@ -158,6 +158,22 @@ semgrep_test(
     tags = ["semgrep"],
 )
 
+# no-create-event-dispatcher-runes uses languages: [generic] scoped to projects/**/*.svelte.
+# Wired to its own .svelte annotation fixture independently of typescript_rules_test
+# (which only scans *.ts fixtures).
+filegroup(
+    name = "no_create_event_dispatcher_runes_rule",
+    srcs = ["typescript/no-create-event-dispatcher-runes.yaml"],
+)
+
+semgrep_test(
+    name = "no_create_event_dispatcher_runes_test",
+    srcs = ["//bazel/semgrep/tests:no_create_event_dispatcher_runes_fixtures"],
+    env = {"SEMGREP_TEST_MODE": "1"},
+    rules = [":no_create_event_dispatcher_runes_rule"],
+    tags = ["semgrep"],
+)
+
 semgrep_test(
     name = "generic_rules_test",
     srcs = ["//bazel/semgrep/tests:no_stale_repo_paths_fixtures"],

--- a/bazel/semgrep/rules/typescript/no-create-event-dispatcher-runes.yaml
+++ b/bazel/semgrep/rules/typescript/no-create-event-dispatcher-runes.yaml
@@ -1,0 +1,22 @@
+rules:
+  - id: no-create-event-dispatcher-runes
+    languages: [generic]
+    severity: ERROR
+    paths:
+      include:
+        - "projects/**/*.svelte"
+    message: >-
+      createEventDispatcher is a Svelte 4 API. All components under
+      projects/**/*.svelte use Svelte 5 runes — replace with a callback
+      prop instead: `let { onEvent } = $props()` and call `onEvent(data)`
+      directly. Mixing createEventDispatcher with $props()/$state() will
+      cause runtime errors in Svelte 5.
+    metadata:
+      category: correctness
+      subcategory: svelte5-migration
+      confidence: HIGH
+      likelihood: HIGH
+      impact: HIGH
+      technology: [svelte, typescript]
+      description: createEventDispatcher import in a Svelte 5 runes component
+    pattern-regex: 'import\s*\{[^}]*createEventDispatcher[^}]*\}\s*from\s*[''"]svelte[''"]'

--- a/bazel/semgrep/tests/BUILD
+++ b/bazel/semgrep/tests/BUILD
@@ -37,6 +37,13 @@ filegroup(
     srcs = glob(["fixtures/*.ts"]),
 )
 
+# Fixture for the no-create-event-dispatcher-runes rule (languages: generic, paths: projects/**/*.svelte).
+# Referenced by //bazel/semgrep/rules:no_create_event_dispatcher_runes_test.
+filegroup(
+    name = "no_create_event_dispatcher_runes_fixtures",
+    srcs = ["fixtures/no-create-event-dispatcher-runes.svelte"],
+)
+
 # Fixture for the no-stale-repo-paths rule (languages: generic).
 # Referenced by //bazel/semgrep/rules:generic_rules_test.
 filegroup(

--- a/bazel/semgrep/tests/fixtures/no-create-event-dispatcher-runes.svelte
+++ b/bazel/semgrep/tests/fixtures/no-create-event-dispatcher-runes.svelte
@@ -1,0 +1,30 @@
+# Test fixtures for the no-create-event-dispatcher-runes semgrep rule.
+#
+# Annotations:
+#   # ruleid: no-create-event-dispatcher-runes  — the next non-annotation line MUST be flagged
+#   # ok: no-create-event-dispatcher-runes      — the next non-annotation line MUST NOT be flagged
+
+# Positive examples — createEventDispatcher in a runes file (should be flagged)
+
+# Bare named import:
+# ruleid: no-create-event-dispatcher-runes
+import { createEventDispatcher } from 'svelte';
+
+# Combined import alongside other Svelte exports:
+# ruleid: no-create-event-dispatcher-runes
+import { createEventDispatcher, onMount } from 'svelte';
+
+# Double-quoted module specifier:
+# ruleid: no-create-event-dispatcher-runes
+import { createEventDispatcher } from "svelte";
+
+# Negative examples — safe imports that must not be flagged
+
+# ok: no-create-event-dispatcher-runes
+import { onMount } from 'svelte';
+
+# ok: no-create-event-dispatcher-runes
+import { $state } from 'svelte/reactivity';
+
+# ok: no-create-event-dispatcher-runes
+import { createEventDispatcher } from 'svelte/legacy';


### PR DESCRIPTION
## Summary

- Adds semgrep rule `no-create-event-dispatcher-runes` that flags `createEventDispatcher` imports from `'svelte'` in any file under `projects/**/*.svelte`
- All 21 Svelte components in this repo already use Svelte 5 runes (`$props()`/`$state()`) — the rule guards against regression to the Svelte 4 dispatch API
- Includes `.svelte` annotation fixture with `ruleid`/`ok` cases covering named import, combined import, and safe alternatives
- BUILD wiring follows the established pattern for path-scoped generic rules (dedicated `filegroup` + `semgrep_test` with `SEMGREP_TEST_MODE=1`)

## Test plan

- [ ] `bazel test //bazel/semgrep/rules:no_create_event_dispatcher_runes_test` passes (SEMGREP_TEST_MODE=1 skips annotation verification but validates BUILD wiring)
- [ ] `bazel test //bazel/semgrep/rules:typescript_rules_test` passes (new rule YAML auto-included via `glob(["typescript/*.yaml"])`)
- [ ] Zero violations in the monolith frontend (confirmed by upstream research — all 21 Svelte files are clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)