### PR TITLE
test(stargazer): assert timeout=300 in preprocessing subprocess calls

### DIFF
--- a/projects/stargazer/backend/preprocessing_test.py
+++ b/projects/stargazer/backend/preprocessing_test.py
@@ -178,6 +178,17 @@ class TestGeoreferenceRaster:
         for call in mock_run.call_args_list:
             assert call.kwargs.get("check") is True
 
+    def test_timeout_300_passed_to_subprocess_run(self, tmp_path: Path):
+        settings = make_settings(tmp_path)
+        (settings.raw_dir / "Europe2024.png").touch()
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            georeference_raster(settings)
+
+        for call in mock_run.call_args_list:
+            assert call.kwargs.get("timeout") == 300
+
     def test_returns_scotland_tif_path(self, tmp_path: Path):
         settings = make_settings(tmp_path)
         (settings.raw_dir / "Europe2024.png").touch()
@@ -351,6 +362,25 @@ class TestExtractRoads:
 
         cmd = mock_run.call_args[0][0]
         assert "GeoJSON" in cmd
+
+    def test_timeout_300_passed_to_subprocess_run(self, tmp_path: Path):
+        settings = make_settings(tmp_path)
+        (settings.raw_dir / "scotland-latest.osm.pbf").touch()
+
+        with (
+            patch("osmium.BackReferenceWriter") as mock_writer,
+            patch("osmium.FileProcessor", return_value=[]),
+            patch("subprocess.run") as mock_run,
+        ):
+            mock_writer_inst = MagicMock()
+            mock_writer.return_value = mock_writer_inst
+            mock_writer_inst.__enter__ = MagicMock()
+            mock_writer_inst.__exit__ = MagicMock(return_value=False)
+            mock_run.return_value = MagicMock(returncode=0)
+
+            extract_roads(settings)
+
+        assert mock_run.call_args.kwargs.get("timeout") == 300
 
     def test_returns_geojson_path(self, tmp_path: Path):
         settings = make_settings(tmp_path)


### PR DESCRIPTION
## Summary

- Adds `TestGeoreferenceRaster.test_timeout_300_passed_to_subprocess_run` — iterates all `subprocess.run` calls made by `georeference_raster()` (gdal_translate + gdalwarp) and asserts each carries `timeout=300`
- Adds `TestExtractRoads.test_timeout_300_passed_to_subprocess_run` — asserts the ogr2ogr `subprocess.run` call in `extract_roads()` carries `timeout=300`

Both tests follow the exact same mock pattern as the existing `test_check_true_passed_to_subprocess_run` test and cover the `timeout=300` kwarg added in commit `8f4bb1be` that previously had no test assertions.

## Test plan
- [ ] CI passes `bazel test //projects/stargazer/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)