### PR TITLE
docs(trips): add nginx and imgproxy to component table

### DIFF
--- a/projects/trips/README.md
+++ b/projects/trips/README.md
@@ -4,10 +4,12 @@ Photo-based GPS trip logging with elevation enrichment.
 
 ## Overview
 
-| Component    | Description                                                                                |
-| ------------ | ------------------------------------------------------------------------------------------ |
-| **backend**  | FastAPI server that replays trip data from NATS JetStream and serves REST + WebSocket APIs |
-| **frontend** | Timeline view with day-by-day maps and per-day elevation stats (ascent, descent, min/max)  |
-| **tools**    | CLI tools for image ingestion with EXIF extraction, elevation enrichment, trip point management, KML route import, and wildlife detection with GoPro camera control (`detect-wildlife`) |
-| **chart**    | Helm chart for Kubernetes deployment                                                       |
-| **deploy**   | ArgoCD Application, kustomization, and cluster-specific values                             |
+| Component      | Description                                                                                |
+| -------------- | ------------------------------------------------------------------------------------------ |
+| **backend**    | FastAPI server that replays trip data from NATS JetStream and serves REST + WebSocket APIs |
+| **frontend**   | Timeline view with day-by-day maps and per-day elevation stats (ascent, descent, min/max)  |
+| **nginx**      | Reverse-proxy routing layer — terminates external traffic and routes requests to the backend API or imgproxy |
+| **imgproxy**   | Image resizing and processing service — serves optimised trip photos on demand              |
+| **tools**      | CLI tools for image ingestion with EXIF extraction, elevation enrichment, trip point management, KML route import, and wildlife detection with GoPro camera control (`detect-wildlife`) |
+| **chart**      | Helm chart for Kubernetes deployment                                                       |
+| **deploy**     | ArgoCD Application, kustomization, and cluster-specific values                             |

--- a/projects/trips/README.md
+++ b/projects/trips/README.md
@@ -8,6 +8,6 @@ Photo-based GPS trip logging with elevation enrichment.
 | ------------ | ------------------------------------------------------------------------------------------ |
 | **backend**  | FastAPI server that replays trip data from NATS JetStream and serves REST + WebSocket APIs |
 | **frontend** | Timeline view with day-by-day maps and per-day elevation stats (ascent, descent, min/max)  |
-| **tools**    | CLI tools for image ingestion with EXIF extraction, elevation enrichment, trip point management, KML route import, wildlife detection inference (`detect-wildlife`), and GoPro camera control |
+| **tools**    | CLI tools for image ingestion with EXIF extraction, elevation enrichment, trip point management, KML route import, and wildlife detection with GoPro camera control (`detect-wildlife`) |
 | **chart**    | Helm chart for Kubernetes deployment                                                       |
 | **deploy**   | ArgoCD Application, kustomization, and cluster-specific values                             |


### PR DESCRIPTION
## Summary

- Adds **`nginx`** (reverse-proxy routing layer) and **`imgproxy`** (image resizing service) to the top-level component table
- Both have distinct Kubernetes `Deployment` resources in `chart/templates/` (`nginx-deployment.yaml`, `imgproxy-deployment.yaml`) and were omitted from the README overview

## Test plan
- [ ] Component table matches actual chart templates

🤖 Generated with [Claude Code](https://claude.com/claude-code)