### PR TITLE
docs(trips): add nginx and imgproxy to component table

### DIFF
--- a/projects/trips/README.md
+++ b/projects/trips/README.md
@@ -4,10 +4,12 @@ Photo-based GPS trip logging with elevation enrichment.
 
 ## Overview
 
-| Component    | Description                                                                                |
-| ------------ | ------------------------------------------------------------------------------------------ |
-| **backend**  | FastAPI server that replays trip data from NATS JetStream and serves REST + WebSocket APIs |
-| **frontend** | Timeline view with day-by-day maps and per-day elevation stats (ascent, descent, min/max)  |
-| **tools**    | CLI tools for trip data management — six sub-directories: `publish-trip-images` (image ingestion with EXIF extraction), `backfill-elevation` (replays NATS points and enriches with elevation data), `delete-trip-points` (publishes tombstone messages to delete points), `publish-gap-route` (parses KML files to fill route gaps), `detect-wildlife` (wildlife detection inference + GoPro camera control), `elevation` (elevation API client library) |
-| **chart**    | Helm chart for Kubernetes deployment                                                       |
-| **deploy**   | ArgoCD Application, kustomization, and cluster-specific values                             |
+| Component      | Description                                                                                |
+| -------------- | ------------------------------------------------------------------------------------------ |
+| **backend**    | FastAPI server that replays trip data from NATS JetStream and serves REST + WebSocket APIs |
+| **frontend**   | Timeline view with day-by-day maps and per-day elevation stats (ascent, descent, min/max)  |
+| **nginx**      | Reverse-proxy routing layer — terminates external traffic and routes requests to the backend API or imgproxy |
+| **imgproxy**   | Image resizing and processing service — serves optimised trip photos on demand              |
+| **tools**      | CLI tools for trip data management — six sub-directories: `publish-trip-images` (image ingestion with EXIF extraction), `backfill-elevation` (replays NATS points and enriches with elevation data), `delete-trip-points` (publishes tombstone messages to delete points), `publish-gap-route` (parses KML files to fill route gaps), `detect-wildlife` (wildlife detection inference + GoPro camera control), `elevation` (elevation API client library) |
+| **chart**      | Helm chart for Kubernetes deployment                                                       |
+| **deploy**     | ArgoCD Application, kustomization, and cluster-specific values                             |


### PR DESCRIPTION
## Summary

- Adds `nginx` (reverse-proxy routing layer) and `imgproxy` (image resizing service) to the top-level component table
- Both are distinct Kubernetes `Deployment` resources in the Helm chart but were absent from the README overview
- The `chart/README.md` already documented them; this brings the top-level README in sync

Fixes: replaces conflicting PR #2271 (branch had diverged from main)