### PR TITLE
chore(claude): use $CLAUDE_PROJECT_DIR for hook script paths

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -51,12 +51,12 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bazel/tools/git/check-stale-pr.sh",
+            "command": "$CLAUDE_PROJECT_DIR/bazel/tools/git/check-stale-pr.sh",
             "timeout": 10
           },
           {
             "type": "command",
-            "command": "bazel/tools/hooks/prefer-bb-remote.sh",
+            "command": "$CLAUDE_PROJECT_DIR/bazel/tools/hooks/prefer-bb-remote.sh",
             "timeout": 5
           }
         ]
@@ -66,37 +66,37 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bazel/tools/hooks/pretooluse-write-edit.sh",
+            "command": "$CLAUDE_PROJECT_DIR/bazel/tools/hooks/pretooluse-write-edit.sh",
             "timeout": 10
           },
           {
             "type": "command",
-            "command": "bazel/tools/hooks/check-unnecessary-chart-bump.sh",
+            "command": "$CLAUDE_PROJECT_DIR/bazel/tools/hooks/check-unnecessary-chart-bump.sh",
             "timeout": 10
           },
           {
             "type": "command",
-            "command": "bazel/tools/hooks/check-python-file-shadows-package.sh",
+            "command": "$CLAUDE_PROJECT_DIR/bazel/tools/hooks/check-python-file-shadows-package.sh",
             "timeout": 10
           },
           {
             "type": "command",
-            "command": "bazel/tools/hooks/check-bdd-shared-testing-dep.sh",
+            "command": "$CLAUDE_PROJECT_DIR/bazel/tools/hooks/check-bdd-shared-testing-dep.sh",
             "timeout": 10
           },
           {
             "type": "command",
-            "command": "bazel/tools/hooks/check-deployment-component-label.sh",
+            "command": "$CLAUDE_PROJECT_DIR/bazel/tools/hooks/check-deployment-component-label.sh",
             "timeout": 10
           },
           {
             "type": "command",
-            "command": "bazel/tools/hooks/check-hardcoded-model-subprocess.sh",
+            "command": "$CLAUDE_PROJECT_DIR/bazel/tools/hooks/check-hardcoded-model-subprocess.sh",
             "timeout": 10
           },
           {
             "type": "command",
-            "command": "bazel/tools/hooks/check-allowed-tools-prompt-sync.sh",
+            "command": "$CLAUDE_PROJECT_DIR/bazel/tools/hooks/check-allowed-tools-prompt-sync.sh",
             "timeout": 10
           }
         ]


### PR DESCRIPTION
## Summary
- All `.claude/settings.json` `PreToolUse` hooks were configured with relative paths like `bazel/tools/git/check-stale-pr.sh`, so when Claude Code invoked them with a CWD other than the repo root they failed with `/bin/sh: ...: No such file or directory`. The errors were non-blocking but printed on every `Bash`/`Write`/`Edit` call, drowning real tool output in noise.
- Switched all 9 hook commands to `$CLAUDE_PROJECT_DIR/bazel/tools/...`. The shell that runs the hook expands the env var at execution time, so resolution no longer depends on whatever CWD the harness happened to be in.

## Test plan
- [x] Verified the same Bash tool call after the patch (locally) no longer emits `PreToolUse:Bash hook error` lines.
- [ ] CI passes on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)