### PR TITLE
fix(knowledge): delete gap stub on terminal research dispositions

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.70.0
+version: 0.70.1
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.70.0
+      targetRevision: 0.70.1
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/knowledge/research_end_to_end_test.py
+++ b/projects/monolith/knowledge/research_end_to_end_test.py
@@ -83,6 +83,25 @@ def _read_frontmatter(path: Path) -> dict:
     return yaml.safe_load(fm)
 
 
+def _write_stub(vault_root: Path, slug: str) -> Path:
+    """Mirror of the gardener's stub write so terminal-disposition tests can
+    assert the handler removes the stub (and breaks the reconcile-revert
+    loop)."""
+    stub_dir = vault_root / "_researching"
+    stub_dir.mkdir(parents=True, exist_ok=True)
+    stub = stub_dir / f"{slug}.md"
+    stub.write_text(
+        "---\n"
+        f"id: {slug}\n"
+        f"title: {slug}\n"
+        "type: gap\n"
+        "status: classified\n"
+        "gap_class: external\n"
+        "---\n"
+    )
+    return stub
+
+
 @pytest.mark.asyncio
 async def test_e2e_research_disposition_writes_raw_and_marks_committed(
     session: Session, tmp_path: Path
@@ -201,11 +220,12 @@ async def test_e2e_research_disposition_empty_claims_quarantines_and_bumps(
 
 
 @pytest.mark.asyncio
-async def test_e2e_personal_disposition_flips_gap_class_no_vault_file(
+async def test_e2e_personal_disposition_flips_gap_class_and_removes_stub(
     session: Session, tmp_path: Path
 ) -> None:
-    """personal: gap_class -> internal, no vault files written."""
+    """personal: gap_class -> internal, stub deleted, no other vault writes."""
     gap = _make_gap(session, term="my-private-project", note_id="my-private-project")
+    stub = _write_stub(tmp_path, "my-private-project")
 
     result = ResearchResult(
         disposition="personal",
@@ -224,16 +244,18 @@ async def test_e2e_personal_disposition_flips_gap_class_no_vault_file(
     assert gap.state == "classified"
     assert gap.research_attempts == 0  # personal does NOT burn an attempt
 
+    assert not stub.exists()
     assert not (tmp_path / "_inbox").exists()
     assert not (tmp_path / "_failed_research").exists()
 
 
 @pytest.mark.asyncio
-async def test_e2e_discard_disposition_parks_gap_no_vault_file(
+async def test_e2e_discard_disposition_parks_gap_and_removes_stub(
     session: Session, tmp_path: Path
 ) -> None:
-    """discard: gap parked, no vault files written."""
+    """discard: gap parked, stub deleted, no other vault writes."""
     gap = _make_gap(session, term="fooo", note_id="fooo")
+    stub = _write_stub(tmp_path, "fooo")
 
     result = ResearchResult(
         disposition="discard",
@@ -251,5 +273,6 @@ async def test_e2e_discard_disposition_parks_gap_no_vault_file(
     assert gap.state == "parked"
     assert gap.research_attempts == 0  # discard does NOT burn an attempt
 
+    assert not stub.exists()
     assert not (tmp_path / "_inbox").exists()
     assert not (tmp_path / "_failed_research").exists()

--- a/projects/monolith/knowledge/research_handler.py
+++ b/projects/monolith/knowledge/research_handler.py
@@ -7,14 +7,22 @@ optionally researches), routes per disposition.
   - ``research`` + non-empty post-filter claims: write the research raw,
     state -> "committed".
   - ``research`` + empty post-filter claims (everything failed citation
-    check): quarantine the draft, bump ``research_attempts``, park at
-    >= RESEARCH_PARK_THRESHOLD.
+    check): quarantine the draft, bump ``research_attempts``. Below
+    threshold the stub is left in place so the next tick retries; at
+    threshold the gap is parked and the stub is deleted.
   - ``personal``: gap_class flips to ``internal``, state stays
-    ``classified`` (no vault file). Sonnet caught a mis-classification.
-  - ``discard``: gap_class flips to ``parked``, state -> ``parked`` (no
-    vault file). Sonnet decided this isn't worth researching at all.
+    ``classified``. Sonnet caught a mis-classification. The stub is
+    deleted -- if the term reappears in another note, the gardener
+    will queue a fresh stub for re-classification.
+  - ``discard``: gap_class flips to ``parked``, state -> ``parked``.
+    Sonnet decided this isn't worth researching at all. Stub deleted.
   - Infra failures (claude subprocess timeout / non-zero exit / parse
     error) revert state without burning a research attempt.
+
+Stubs MUST be deleted on every terminal disposition: the reconciler
+projects ``_researching/<slug>.md`` frontmatter into the Gap row on
+every cycle, so a stub left at ``status: classified`` reverts the DB
+back to ``classified`` and the gap is re-picked indefinitely.
 
 Triage is a refinement of the upstream ``gap_classifier``, not a
 replacement -- the classifier's "external" candidates flow into here,
@@ -29,6 +37,7 @@ from pathlib import Path
 
 from sqlmodel import Session, select
 
+from knowledge.gap_stubs import RESEARCHING_DIR
 from knowledge.models import Gap
 from knowledge.research_agent import AGENT_MODEL, ResearchResult, run_research
 from knowledge.research_writer import quarantine, write_research_raw
@@ -37,6 +46,22 @@ logger = logging.getLogger(__name__)
 
 RESEARCH_BATCH_SIZE = 3
 RESEARCH_PARK_THRESHOLD = 3
+
+
+def _delete_stub(vault_root: Path, slug: str) -> None:
+    # The reconciler projects _researching/<slug>.md frontmatter into the
+    # Gap row on every cycle. If we leave the stub at status=classified
+    # after the handler flipped the DB row to a terminal state, the next
+    # reconciler tick reverts state -> classified and the gap gets
+    # re-picked next research tick. This caused the same five gaps to be
+    # re-researched ~every 5 minutes for days. Removing the stub stops
+    # the projection; the orphan Gap row is harmless (the SELECT filters
+    # state='classified', which the row no longer is).
+    stub = vault_root / RESEARCHING_DIR / f"{slug}.md"
+    try:
+        stub.unlink()
+    except FileNotFoundError:
+        pass
 
 
 async def research_gaps_handler(*, session: Session, vault_root: Path) -> None:
@@ -130,6 +155,7 @@ async def _process_one(*, session: Session, gap: Gap, vault_root: Path) -> None:
         gap.gap_class = "internal"
         gap.state = "classified"
         session.commit()
+        _delete_stub(vault_root, gap.note_id)
         logger.info(
             "knowledge.research-gaps: %s -> personal (gap_class=internal); reason=%s",
             gap.term,
@@ -141,6 +167,7 @@ async def _process_one(*, session: Session, gap: Gap, vault_root: Path) -> None:
         gap.gap_class = "parked"
         gap.state = "parked"
         session.commit()
+        _delete_stub(vault_root, gap.note_id)
         logger.info(
             "knowledge.research-gaps: %s -> discard (gap_class=parked); reason=%s",
             gap.term,
@@ -178,6 +205,8 @@ async def _process_one(*, session: Session, gap: Gap, vault_root: Path) -> None:
         gap.research_attempts = attempt
         gap.state = "parked" if attempt >= RESEARCH_PARK_THRESHOLD else "classified"
         session.commit()
+        if gap.state == "parked":
+            _delete_stub(vault_root, gap.note_id)
         logger.info(
             "knowledge.research-gaps: rejected %s (attempt=%d, state=%s)",
             gap.term,

--- a/projects/monolith/knowledge/research_handler_test.py
+++ b/projects/monolith/knowledge/research_handler_test.py
@@ -3,13 +3,18 @@
 Mocks ``run_research`` directly (the single boundary). Exercises:
   - happy path (research disposition with surviving claims)
   - infra failure (RuntimeError from run_research)
-  - personal disposition (gap_class flip, no file)
-  - discard disposition (gap parked, no file)
-  - all-claims-dropped quarantine (research disposition, empty post-filter claims)
-  - park-at-threshold after repeated quarantines
+  - personal disposition (gap_class flip, stub removed)
+  - discard disposition (gap parked, stub removed)
+  - all-claims-dropped quarantine below threshold (stub kept for retry)
+  - park-at-threshold after repeated quarantines (stub removed)
   - race-lost (state already changed before lock)
   - stuck-row recovery sweep
   - privacy guard (non-external gap skipped after lock)
+
+Stub-removal assertions guard against the reconcile-revert loop where
+a stub left at ``status: classified`` causes the reconciler to overwrite
+the handler's terminal-state DB write on its next cycle, so the same
+gap gets researched indefinitely.
 """
 
 from __future__ import annotations
@@ -82,6 +87,23 @@ def _make_gap(
     return gap
 
 
+def _write_stub(vault_root: Path, slug: str) -> Path:
+    """Write a minimal classified gap stub at _researching/<slug>.md."""
+    stub_dir = vault_root / "_researching"
+    stub_dir.mkdir(parents=True, exist_ok=True)
+    stub = stub_dir / f"{slug}.md"
+    stub.write_text(
+        "---\n"
+        f"id: {slug}\n"
+        f"title: {slug}\n"
+        "type: gap\n"
+        "status: classified\n"
+        "gap_class: external\n"
+        "---\n"
+    )
+    return stub
+
+
 def _research_result_with_claims() -> ResearchResult:
     note = ResearchNote(
         summary="Linkerd uses mTLS for service-to-service auth.",
@@ -135,10 +157,11 @@ async def test_research_disposition_writes_raw_and_marks_committed(
 
 
 @pytest.mark.asyncio
-async def test_personal_disposition_flips_gap_class_no_file(
+async def test_personal_disposition_flips_gap_class_and_removes_stub(
     session: Session, tmp_path: Path
 ) -> None:
     gap = _make_gap(session)
+    stub = _write_stub(tmp_path, "linkerd-mtls")
 
     personal = ResearchResult(
         disposition="personal",
@@ -156,15 +179,42 @@ async def test_personal_disposition_flips_gap_class_no_file(
     assert gap.gap_class == "internal"
     assert gap.state == "classified"
     assert gap.research_attempts == 0  # not bumped
+    assert not stub.exists()  # reconciler can no longer revert the DB row
     assert not (tmp_path / "_inbox").exists()
     assert not (tmp_path / "_failed_research").exists()
 
 
 @pytest.mark.asyncio
-async def test_discard_disposition_parks_gap_no_file(
+async def test_personal_disposition_tolerates_missing_stub(
+    session: Session, tmp_path: Path
+) -> None:
+    """Stub deletion is idempotent: a missing stub is not an error."""
+    gap = _make_gap(session)
+    # Deliberately do NOT write a stub.
+
+    personal = ResearchResult(
+        disposition="personal",
+        reason="term appears only in journal-style notes",
+        sources=(SourceEntry(tool="Glob", ref="glob:**/*.md"),),
+    )
+
+    with patch(
+        "knowledge.research_handler.run_research",
+        AsyncMock(return_value=personal),
+    ):
+        await research_gaps_handler(session=session, vault_root=tmp_path)
+
+    session.refresh(gap)
+    assert gap.gap_class == "internal"
+    assert gap.state == "classified"
+
+
+@pytest.mark.asyncio
+async def test_discard_disposition_parks_gap_and_removes_stub(
     session: Session, tmp_path: Path
 ) -> None:
     gap = _make_gap(session)
+    stub = _write_stub(tmp_path, "linkerd-mtls")
 
     discard = ResearchResult(
         disposition="discard",
@@ -181,15 +231,18 @@ async def test_discard_disposition_parks_gap_no_file(
     assert gap.gap_class == "parked"
     assert gap.state == "parked"
     assert gap.research_attempts == 0  # not bumped
+    assert not stub.exists()
     assert not (tmp_path / "_inbox").exists()
     assert not (tmp_path / "_failed_research").exists()
 
 
 @pytest.mark.asyncio
-async def test_all_claims_dropped_quarantines_and_bumps_attempts(
+async def test_all_claims_dropped_quarantines_and_keeps_stub_below_threshold(
     session: Session, tmp_path: Path
 ) -> None:
+    """Below threshold the stub stays so the next tick retries the gap."""
     gap = _make_gap(session)
+    stub = _write_stub(tmp_path, "linkerd-mtls")
 
     with patch(
         "knowledge.research_handler.run_research",
@@ -200,15 +253,17 @@ async def test_all_claims_dropped_quarantines_and_bumps_attempts(
     session.refresh(gap)
     assert gap.research_attempts == 1
     assert gap.state == "classified"  # below threshold
+    assert stub.exists()  # retained for the next research tick
     assert (tmp_path / "_failed_research" / "linkerd-mtls-1.md").exists()
     assert not (tmp_path / "_inbox" / "research" / "linkerd-mtls.md").exists()
 
 
 @pytest.mark.asyncio
-async def test_quarantine_at_threshold_parks_gap(
+async def test_quarantine_at_threshold_parks_gap_and_removes_stub(
     session: Session, tmp_path: Path
 ) -> None:
     gap = _make_gap(session, research_attempts=RESEARCH_PARK_THRESHOLD - 1)
+    stub = _write_stub(tmp_path, "linkerd-mtls")
 
     with patch(
         "knowledge.research_handler.run_research",
@@ -219,6 +274,7 @@ async def test_quarantine_at_threshold_parks_gap(
     session.refresh(gap)
     assert gap.research_attempts == RESEARCH_PARK_THRESHOLD
     assert gap.state == "parked"
+    assert not stub.exists()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- The research handler's `discard`/`personal`/threshold-quarantine paths were updating the DB row to a terminal state but leaving the `_researching/<slug>.md` stub at `status: classified`. The reconciler projects stub frontmatter into the Gap row on every cycle, so it reverted state → `classified` and the gap got re-picked next research tick.
- Concrete symptom on prod: 5 external gaps whose atoms already exist in `_processed/` (Postgres, Thanos, Foster Provost, Tom Fawcett, "data quality at source") were being re-researched every ~5 minutes for days, every run dispositioning to `discard`. ~50% of all stubs in `_researching/` (447/874) had their atom already in `_processed/` — once the loop is broken, the cleanup script will sweep them.
- Fix: delete the stub on every terminal disposition. Sub-threshold quarantine still keeps the stub since that case is meant to retry on the next tick.

## Test plan
- [x] Updated `research_handler_test.py` to write a stub before invoking the handler and assert the stub is removed on `discard`, `personal`, and threshold-quarantine.
- [x] Added `test_personal_disposition_tolerates_missing_stub` to verify the unlink is idempotent (no error if the stub is already gone — guards against future calls in code paths that may not have written one).
- [x] Updated `test_all_claims_dropped_quarantines_and_keeps_stub_below_threshold` to assert the stub is *retained* below threshold.
- [x] Updated the e2e tests with the same shape.
- [x] Manually verified locally: 692 external + 102 internal + 72 hybrid + 8 parked stubs in `_researching/`, log evidence of the loop in `kubectl logs ... -c backend` showing the same 5 terms re-researched every tick.

## Follow-up (manual, post-merge)
After this is deployed and the pod is in steady state, run a one-shot cleanup against the live vault to delete the existing 447 phantom stubs whose atoms already live in `_processed/`. The vault-backup job (every 15min) will commit and push the deletes. Approximate command:
```
cd ~/Documents/jomcgi
for stub in _researching/*.md; do
  slug=\$(basename "\$stub" .md)
  [ -f "_processed/\${slug}.md" ] && rm "\$stub"
done
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)