### PR TITLE
fix(knowledge): route internal/hybrid gaps to status=in_review

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.70.1
+version: 0.70.2
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.70.1
+      targetRevision: 0.70.2
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/knowledge/gap_classifier.py
+++ b/projects/monolith/knowledge/gap_classifier.py
@@ -64,9 +64,14 @@ Obsidian vault — into four classes.
   replace it — do not add a new line. YAML requires unique top-level
   keys; appending a duplicate key produces an ugly stub even when YAML
   parsers tolerate it. Example:
-  - find: `status: discovered` → replace with: `status: classified`
   - find: `gap_class: null` → replace with one of: `gap_class: external`
     | `gap_class: internal` | `gap_class: hybrid` | `gap_class: parked`
+  - find: `status: discovered` → replace with the status that matches
+    the class you just chose:
+      - `status: classified` for `gap_class: external` or `parked`
+        (external flows into the research pipeline; parked is terminal)
+      - `status: in_review` for `gap_class: internal` or `hybrid`
+        (these surface in the user's review queue for them to answer)
   - find: `classified_at: null` → replace with the current ISO timestamp
     (UTC, e.g. `classified_at: '2026-04-25T08:00:00Z'`)
   - find: `classifier_version: null` → replace with

--- a/projects/monolith/knowledge/gap_classifier_test.py
+++ b/projects/monolith/knowledge/gap_classifier_test.py
@@ -185,3 +185,36 @@ def test_classifier_prompt_explicitly_forbids_appending_duplicate_keys():
     )
     assert CLASSIFIER_VERSION in rendered
     assert "/tmp/example.md" in rendered
+
+
+def test_classifier_prompt_routes_internal_and_hybrid_to_in_review():
+    """Drift detector: internal/hybrid must transition to in_review, not classified.
+
+    Without this the review queue (which filters state == 'in_review')
+    is silently always empty — the bug fixed by this commit. The
+    research handler only consumes external+classified, so leaving
+    internal/hybrid at status: classified strands them with no consumer.
+    """
+    rendered = _CLASSIFIER_PROMPT.format(
+        classifier_version=CLASSIFIER_VERSION,
+        stub_list="- /tmp/example.md",
+    )
+    # Both terminal statuses for the discovered → classified/in_review
+    # transition must be reachable from the prompt.
+    assert "status: classified" in rendered, (
+        "prompt must still produce status: classified for external/parked"
+    )
+    assert "status: in_review" in rendered, (
+        "prompt must produce status: in_review for internal/hybrid so the "
+        "review queue surfaces them for the user to answer"
+    )
+    # The routing must be explicit — both class names appear within the
+    # short window after `status: in_review` so Sonnet can't reasonably
+    # misroute. 200 chars covers the bullet line plus its parenthetical.
+    after_in_review = rendered.split("status: in_review", 1)[1][:200]
+    assert "internal" in after_in_review, (
+        "in_review branch must name the internal class explicitly"
+    )
+    assert "hybrid" in after_in_review, (
+        "in_review branch must name the hybrid class explicitly"
+    )


### PR DESCRIPTION
## Summary
- The classifier prompt unconditionally wrote `status: classified` for every gap class. The reconciler projects status → `Gap.state` verbatim, and the only consumer of internal/hybrid gaps (`list_review_queue`, MCP `monolith-get-review-queue`) filters `state == 'in_review'`. Net effect: 67 internal+hybrid gaps were stranded at `state='classified'` with no consumer — review queue always empty.
- Make status assignment conditional on the class chosen:
  - `external` / `parked` → `status: classified` (external flows into the research pipeline; parked is terminal)
  - `internal` / `hybrid` → `status: in_review` (these surface for the user to answer)
- Existing review/answer surface (HTTP `/gaps/review-queue` + `/gaps/{id}/answer`, MCP `monolith-get-review-queue` + `monolith-answer-gap`) already gates on `state='in_review'`, so once the prompt produces that state the queue starts populating with no other code changes needed.

## Test plan
- [x] Added `test_classifier_prompt_routes_internal_and_hybrid_to_in_review` asserting both `status: classified` and `status: in_review` are reachable from the rendered prompt, and that the `in_review` branch explicitly names both `internal` and `hybrid` within a 200-char window so a future rewrite can't silently revert the routing.
- [x] Existing `test_classifier_prompt_explicitly_forbids_appending_duplicate_keys` still passes (the find-and-replace discipline + YAML uniqueness rationale are unchanged).
- [x] Manually rendered the prompt and verified the new sub-list reads cleanly.

## Follow-up (manual, post-deploy)
The 67 stubs already on disk at `gap_class: internal|hybrid, status: classified` won't be re-classified (the classifier only picks up stubs where `gap_class is None`). Backfill them after deploy via the obsidian sidecar — rewrite frontmatter `status: classified` → `status: in_review` for those slugs. The reconciler projects to DB `state='in_review'` on its next 5-min tick, no SQL needed (mirrors the cluster-side approach used in #2278).

🤖 Generated with [Claude Code](https://claude.com/claude-code)