### PR TITLE
feat(knowledge): parallelise research-gaps tick with asyncio.gather

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.70.2
+version: 0.71.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.70.2
+      targetRevision: 0.71.0
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/knowledge/research_handler.py
+++ b/projects/monolith/knowledge/research_handler.py
@@ -31,10 +31,13 @@ and Sonnet may downgrade them based on full vault context.
 
 from __future__ import annotations
 
+import asyncio
 import logging
+import traceback
 from datetime import datetime, timezone
 from pathlib import Path
 
+from sqlalchemy.engine import Engine
 from sqlmodel import Session, select
 
 from knowledge.gap_stubs import RESEARCHING_DIR
@@ -44,7 +47,8 @@ from knowledge.research_writer import quarantine, write_research_raw
 
 logger = logging.getLogger(__name__)
 
-RESEARCH_BATCH_SIZE = 3
+RESEARCH_BATCH_SIZE = 10
+RESEARCH_CONCURRENCY = 10
 RESEARCH_PARK_THRESHOLD = 3
 
 
@@ -65,7 +69,19 @@ def _delete_stub(vault_root: Path, slug: str) -> None:
 
 
 async def research_gaps_handler(*, session: Session, vault_root: Path) -> None:
-    """Run one tick of the external research pipeline."""
+    """Run one tick of the external research pipeline.
+
+    Fans out up to ``RESEARCH_CONCURRENCY`` gaps in parallel via
+    ``asyncio.gather``. Each task opens its own SQLAlchemy session from
+    the bound engine -- sync ``Session`` objects are not safe to share
+    across concurrently-awaiting tasks (the underlying psycopg
+    connection can be corrupted by interleaved execute() calls).
+
+    The passed-in ``session`` handles the recovery sweep + candidate
+    SELECT only; the parallel tasks never touch it.
+    """
+    engine = session.get_bind()
+
     # Recovery sweep: if the previous tick crashed mid-flight (between
     # the 'researching' lock and any terminal state assignment), the
     # row would be stuck forever -- the SELECT below filters
@@ -100,31 +116,89 @@ async def research_gaps_handler(*, session: Session, vault_root: Path) -> None:
         logger.info("knowledge.research-gaps: no candidates")
         return
 
-    for gap in candidates:
+    # Capture plain values up front so the parallel tasks don't depend
+    # on the original session staying open or on ORM lazy-loads.
+    gap_descriptors = [(gap.id, gap.term, gap.gap_class) for gap in candidates]
+
+    semaphore = asyncio.Semaphore(RESEARCH_CONCURRENCY)
+    results = await asyncio.gather(
+        *[
+            _claim_and_process(
+                engine=engine,
+                gap_id=gap_id,
+                term=term,
+                gap_class=gap_class,
+                vault_root=vault_root,
+                semaphore=semaphore,
+            )
+            for gap_id, term, gap_class in gap_descriptors
+        ],
+        return_exceptions=True,
+    )
+    # Per-gap try/except inside _process_one already reverts state on
+    # failure. Anything that escapes here is a bug; log loudly with the
+    # full traceback so we see it instead of silently dropping a sibling
+    # task's exception. (Can't use `exc_info=outcome` -- semgrep rule
+    # `logger-exc-info-non-boolean` flags plain-variable exc_info because
+    # the linter can't statically verify the value is an exception.)
+    for (gap_id, term, _), outcome in zip(gap_descriptors, results):
+        if isinstance(outcome, BaseException):
+            tb = "".join(
+                traceback.format_exception(
+                    type(outcome), outcome, outcome.__traceback__
+                )
+            )
+            logger.error(
+                "knowledge.research-gaps: unexpected exception for gap %s "
+                "(id=%d); other tasks unaffected:\n%s",
+                term,
+                gap_id,
+                tb,
+            )
+
+
+async def _claim_and_process(
+    *,
+    engine: Engine,
+    gap_id: int,
+    term: str,
+    gap_class: str | None,
+    vault_root: Path,
+    semaphore: asyncio.Semaphore,
+) -> None:
+    """Lock one gap row and dispatch it to ``_process_one``.
+
+    Each invocation runs on its own SQLAlchemy session (one connection
+    from the engine pool), bracketed by the semaphore so we never burst
+    above ``RESEARCH_CONCURRENCY`` open subprocesses.
+    """
+    async with semaphore:
         # Defense-in-depth privacy guard: even though the SELECT
         # filtered, re-assert before each Sonnet call. Cheap, prevents
         # future misroutes.
-        if gap.gap_class != "external":
+        if gap_class != "external":
             logger.warning(
-                "knowledge.research-gaps: skipping non-external gap %s", gap.term
+                "knowledge.research-gaps: skipping non-external gap %s", term
             )
-            continue
+            return
 
-        # Race-safe lock: only proceed if state still 'classified'.
-        result = session.execute(
-            Gap.__table__.update()
-            .where(Gap.id == gap.id, Gap.state == "classified")
-            .values(state="researching")
-        )
-        session.commit()
-        # NB: gap.state in-memory is now stale (still 'classified').
-        # The Core UPDATE bypassed the ORM identity map. Don't read
-        # gap.state below this point -- always assign explicitly.
-        if result.rowcount == 0:
-            logger.info("knowledge.research-gaps: race lost for %s", gap.term)
-            continue
+        with Session(engine) as task_session:
+            # Race-safe lock: only proceed if state still 'classified'.
+            result = task_session.execute(
+                Gap.__table__.update()
+                .where(Gap.id == gap_id, Gap.state == "classified")
+                .values(state="researching")
+            )
+            task_session.commit()
+            if result.rowcount == 0:
+                logger.info("knowledge.research-gaps: race lost for %s", term)
+                return
 
-        await _process_one(session=session, gap=gap, vault_root=vault_root)
+            # Re-fetch the gap in this session so _process_one's mutations
+            # are tracked by the ORM and committed against this connection.
+            gap = task_session.get(Gap, gap_id)
+            assert gap is not None, f"gap {gap_id} disappeared after lock"
+            await _process_one(session=task_session, gap=gap, vault_root=vault_root)
 
 
 async def _process_one(*, session: Session, gap: Gap, vault_root: Path) -> None:

--- a/projects/monolith/knowledge/research_handler_test.py
+++ b/projects/monolith/knowledge/research_handler_test.py
@@ -19,6 +19,7 @@ gap gets researched indefinitely.
 
 from __future__ import annotations
 
+import asyncio
 from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
@@ -34,6 +35,8 @@ from knowledge.research_agent import (
     SourceEntry,
 )
 from knowledge.research_handler import (
+    RESEARCH_BATCH_SIZE,
+    RESEARCH_CONCURRENCY,
     RESEARCH_PARK_THRESHOLD,
     research_gaps_handler,
 )
@@ -364,3 +367,51 @@ async def test_no_candidates_logs_and_returns(session: Session, tmp_path: Path) 
     with patch("knowledge.research_handler.run_research", runner):
         await research_gaps_handler(session=session, vault_root=tmp_path)
     runner.assert_not_awaited()
+
+
+def test_concurrency_constants_consistent() -> None:
+    """Batch size should not exceed concurrency, or the semaphore queues
+    work that we could just have gathered. Equal is the intended shape."""
+    assert RESEARCH_BATCH_SIZE <= RESEARCH_CONCURRENCY
+
+
+@pytest.mark.asyncio
+async def test_full_batch_processed_concurrently(
+    session: Session, tmp_path: Path
+) -> None:
+    """A tick with N gaps fans them all out via asyncio.gather and each
+    one reaches a terminal disposition.
+
+    Uses an asyncio.Event to verify concurrency: the mocked run_research
+    blocks until N parallel callers have entered, then releases all of
+    them. If the handler ran sequentially, only one caller would ever
+    enter at a time and the test would deadlock.
+    """
+    n = 5
+    gaps = [_make_gap(session, term=f"term-{i}", note_id=f"slug-{i}") for i in range(n)]
+
+    entered = asyncio.Event()
+    in_flight = 0
+
+    async def mocked_run_research(*, term: str, vault_root: Path) -> ResearchResult:
+        nonlocal in_flight
+        in_flight += 1
+        if in_flight >= n:
+            entered.set()
+        # Fail fast if the handler is sequential -- a 1s wait would
+        # multiply by N if serialized, but completes once if parallel.
+        await asyncio.wait_for(entered.wait(), timeout=2.0)
+        return _research_result_with_claims()
+
+    runner = AsyncMock(side_effect=mocked_run_research)
+    with patch("knowledge.research_handler.run_research", runner):
+        await research_gaps_handler(session=session, vault_root=tmp_path)
+    assert runner.await_count == n
+
+    for gap in gaps:
+        session.refresh(gap)
+        assert gap.state == "committed", f"{gap.term} was not committed"
+    # Every gap wrote its raw to a distinct slug -- no collision under
+    # parallel writes.
+    for i in range(n):
+        assert (tmp_path / "_inbox" / "research" / f"slug-{i}.md").exists()


### PR DESCRIPTION
## Summary
- Bumps `RESEARCH_BATCH_SIZE` 3 → 10 and adds `RESEARCH_CONCURRENCY = 10`; the per-tick `for gap in candidates` loop is replaced with `asyncio.gather` capped by an `asyncio.Semaphore`.
- Each parallel task opens its own SQLAlchemy session from the engine bound to the passed-in session — sync `Session` is not safe to share across concurrently-awaiting tasks (interleaved `execute()` corrupts the underlying psycopg connection).
- The race-safe `classified → researching` lock moves inside `_claim_and_process` so each task locks its own row. Recovery sweep, terminal-state writes, and stub-deletion logic are unchanged.

## Why this is safe
- **Connection pool**: SQLAlchemy default is `QueuePool(size=5, max_overflow=10) = 15`. We hold ≤10 connections during a tick, leaving headroom for the rest of the app. Other knowledge jobs run on separate ticks (`shared/scheduler.py` claims one per tick).
- **Pod memory**: current usage is 382Mi / 3Gi limit. 10 × ~150Mi/Sonnet subprocess = ~1.5Gi extra, still inside limit.
- **TTL**: `_RESEARCH_TTL_SECS = 1200` already had headroom; concurrent execution shrinks per-tick wall-clock, doesn't grow it.
- **Failure isolation**: `gather(..., return_exceptions=True)` so one task's bug can't cancel siblings; escapees are logged with a formatted traceback.
- **Vault writes**: each gap writes a distinct slug (`_inbox/research/<slug>.md`) — no collisions under parallel writes.

## Test plan
- [x] Added `test_full_batch_processed_concurrently` — uses `asyncio.Event` + `wait_for(timeout=2.0)` so a sequential handler would deadlock and fail. Verifies all N gaps reach `committed` and each writes its raw.
- [x] Existing single-gap tests should still pass — they use SQLite + `StaticPool` which lets `Session(engine)` per task share the same underlying connection (operations serialize in the event loop, deterministically).
- [ ] Watch BuildBuddy CI on this PR before merge.
- [ ] After deploy: monitor pod memory via `kubectl top pod -n monolith` for the first few ticks; bump request from 3Gi if we get close.
- [ ] After deploy: watch SigNoz for `knowledge.research-gaps` log volume — should see ~10× more `committed` lines per tick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)