### PR TITLE
feat(knowledge): plug research-handler discards into discardable rewrite path

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.71.0
+version: 0.72.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.71.0
+      targetRevision: 0.72.0
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/knowledge/models.py
+++ b/projects/monolith/knowledge/models.py
@@ -34,10 +34,12 @@ GapState = Literal[
     "discovered",
     "classified",
     "in_review",
+    "researching",
     "researched",
     "verified",
     "consolidated",
     "committed",
+    "parked",
     "rejected",
 ]
 

--- a/projects/monolith/knowledge/reconciler.py
+++ b/projects/monolith/knowledge/reconciler.py
@@ -32,10 +32,12 @@ _VALID_GAP_STATES = frozenset(
         "discovered",
         "classified",
         "in_review",
+        "researching",
         "researched",
         "verified",
         "consolidated",
         "committed",
+        "parked",
         "rejected",
     }
 )

--- a/projects/monolith/knowledge/research_end_to_end_test.py
+++ b/projects/monolith/knowledge/research_end_to_end_test.py
@@ -250,10 +250,11 @@ async def test_e2e_personal_disposition_flips_gap_class_and_removes_stub(
 
 
 @pytest.mark.asyncio
-async def test_e2e_discard_disposition_parks_gap_and_removes_stub(
+async def test_e2e_discard_disposition_parks_gap_and_marks_stub_discardable(
     session: Session, tmp_path: Path
 ) -> None:
-    """discard: gap parked, stub deleted, no other vault writes."""
+    """discard: gap parked, stub marked ``triaged: discardable`` so the
+    next gardener tick can rewrite source wikilinks. No other vault writes."""
     gap = _make_gap(session, term="fooo", note_id="fooo")
     stub = _write_stub(tmp_path, "fooo")
 
@@ -273,6 +274,13 @@ async def test_e2e_discard_disposition_parks_gap_and_removes_stub(
     assert gap.state == "parked"
     assert gap.research_attempts == 0  # discard does NOT burn an attempt
 
-    assert not stub.exists()
+    assert stub.exists()
+    import yaml as _yaml
+
+    fm = _yaml.safe_load(stub.read_text().split("---\n", 2)[1])
+    assert fm["triaged"] == "discardable"
+    assert fm["status"] == "parked"
+    assert fm["gap_class"] == "parked"
+
     assert not (tmp_path / "_inbox").exists()
     assert not (tmp_path / "_failed_research").exists()

--- a/projects/monolith/knowledge/research_handler.py
+++ b/projects/monolith/knowledge/research_handler.py
@@ -37,6 +37,7 @@ import traceback
 from datetime import datetime, timezone
 from pathlib import Path
 
+import yaml
 from sqlalchemy.engine import Engine
 from sqlmodel import Session, select
 
@@ -53,19 +54,65 @@ RESEARCH_PARK_THRESHOLD = 3
 
 
 def _delete_stub(vault_root: Path, slug: str) -> None:
-    # The reconciler projects _researching/<slug>.md frontmatter into the
-    # Gap row on every cycle. If we leave the stub at status=classified
-    # after the handler flipped the DB row to a terminal state, the next
-    # reconciler tick reverts state -> classified and the gap gets
-    # re-picked next research tick. This caused the same five gaps to be
-    # re-researched ~every 5 minutes for days. Removing the stub stops
-    # the projection; the orphan Gap row is harmless (the SELECT filters
-    # state='classified', which the row no longer is).
+    # Used by the personal/quarantine paths where we want the gardener
+    # to be free to recreate the stub if the term reappears. The reconciler
+    # projects stub frontmatter into the Gap row on every cycle, so leaving
+    # a stub at status=classified after the handler flipped the DB row to a
+    # terminal state would cause the next reconciler tick to revert state
+    # -> classified and the gap would be re-picked next research tick.
+    # Removing the stub stops the projection.
     stub = vault_root / RESEARCHING_DIR / f"{slug}.md"
     try:
         stub.unlink()
     except FileNotFoundError:
         pass
+
+
+def _mark_stub_discardable(vault_root: Path, slug: str) -> None:
+    """Mark the stub as ``triaged: discardable`` so the gardener can
+    rewrite source wikilinks on its next tick.
+
+    Without this, every Sonnet ``discard`` is a treadmill: the gap row
+    ends up parked, gets cleaned up, and then the gardener re-discovers
+    the same wikilink in source notes and creates a new stub. Marking
+    the stub plugs ``research_handler`` into the existing Phase A
+    discardable-rewrite path in ``gaps.discover_gaps`` (gated by
+    ``KNOWLEDGE_GAPS_REWRITE_DISCARDABLE``; default off = dry-run that
+    just logs ``rewrites_dryrun=N``).
+
+    Also overwrites ``status`` and ``gap_class`` to ``parked`` so the
+    next reconciler tick projects matching values onto the Gap row
+    instead of reverting it to the classifier's earlier classified+external
+    state. ``parked`` is in the migration's CHECK list and in the
+    reconciler's ``_VALID_GAP_STATES`` (also extended in this commit).
+
+    Idempotent: missing stub is a no-op; an already-marked stub is left
+    alone to avoid mtime churn.
+    """
+    stub = vault_root / RESEARCHING_DIR / f"{slug}.md"
+    try:
+        text = stub.read_text()
+    except FileNotFoundError:
+        return
+    if not text.startswith("---\n"):
+        return
+    parts = text.split("---\n", 2)
+    if len(parts) < 3:
+        return
+    meta = yaml.safe_load(parts[1])
+    if not isinstance(meta, dict):
+        return
+    if (
+        meta.get("triaged") == "discardable"
+        and meta.get("status") == "parked"
+        and meta.get("gap_class") == "parked"
+    ):
+        return  # already marked — skip the write to keep mtime stable.
+    meta["triaged"] = "discardable"
+    meta["status"] = "parked"
+    meta["gap_class"] = "parked"
+    fm_str = yaml.dump(meta, default_flow_style=False, sort_keys=False)
+    stub.write_text(f"---\n{fm_str}---\n{parts[2]}")
 
 
 async def research_gaps_handler(*, session: Session, vault_root: Path) -> None:
@@ -241,7 +288,7 @@ async def _process_one(*, session: Session, gap: Gap, vault_root: Path) -> None:
         gap.gap_class = "parked"
         gap.state = "parked"
         session.commit()
-        _delete_stub(vault_root, gap.note_id)
+        _mark_stub_discardable(vault_root, gap.note_id)
         logger.info(
             "knowledge.research-gaps: %s -> discard (gap_class=parked); reason=%s",
             gap.term,

--- a/projects/monolith/knowledge/research_handler_test.py
+++ b/projects/monolith/knowledge/research_handler_test.py
@@ -213,9 +213,16 @@ async def test_personal_disposition_tolerates_missing_stub(
 
 
 @pytest.mark.asyncio
-async def test_discard_disposition_parks_gap_and_removes_stub(
+async def test_discard_disposition_parks_gap_and_marks_stub_discardable(
     session: Session, tmp_path: Path
 ) -> None:
+    """Discards plug into the Phase A discardable-rewrite path.
+
+    The stub must stay in place with ``triaged: discardable`` so the next
+    gardener tick sees it and (eventually) rewrites source wikilinks.
+    Status and gap_class are set to ``parked`` so the reconciler projects
+    matching values onto the Gap row instead of reverting it.
+    """
     gap = _make_gap(session)
     stub = _write_stub(tmp_path, "linkerd-mtls")
 
@@ -234,9 +241,78 @@ async def test_discard_disposition_parks_gap_and_removes_stub(
     assert gap.gap_class == "parked"
     assert gap.state == "parked"
     assert gap.research_attempts == 0  # not bumped
-    assert not stub.exists()
+    assert stub.exists(), "stub must remain so the gardener can pick up the marker"
+
+    import yaml as _yaml
+
+    parts = stub.read_text().split("---\n", 2)
+    fm = _yaml.safe_load(parts[1])
+    assert fm["triaged"] == "discardable"
+    assert fm["status"] == "parked"
+    assert fm["gap_class"] == "parked"
+
     assert not (tmp_path / "_inbox").exists()
     assert not (tmp_path / "_failed_research").exists()
+
+
+@pytest.mark.asyncio
+async def test_discard_disposition_tolerates_missing_stub(
+    session: Session, tmp_path: Path
+) -> None:
+    """Marker write is idempotent: missing stub is not an error."""
+    gap = _make_gap(session)
+    # Deliberately do NOT write a stub.
+
+    discard = ResearchResult(
+        disposition="discard",
+        reason="not worth tracking",
+    )
+
+    with patch(
+        "knowledge.research_handler.run_research",
+        AsyncMock(return_value=discard),
+    ):
+        await research_gaps_handler(session=session, vault_root=tmp_path)
+
+    session.refresh(gap)
+    assert gap.state == "parked"
+    assert gap.gap_class == "parked"
+    assert not (tmp_path / "_researching" / "linkerd-mtls.md").exists()
+
+
+@pytest.mark.asyncio
+async def test_discard_marker_is_idempotent_on_already_marked_stub(
+    session: Session, tmp_path: Path
+) -> None:
+    """Re-discarding an already-marked stub doesn't churn the file's mtime."""
+    gap = _make_gap(session)
+    stub = _write_stub(tmp_path, "linkerd-mtls")
+
+    # Pre-mark the stub as if a previous discard had already run.
+    import yaml as _yaml
+
+    parts = stub.read_text().split("---\n", 2)
+    fm = _yaml.safe_load(parts[1])
+    fm["triaged"] = "discardable"
+    fm["status"] = "parked"
+    fm["gap_class"] = "parked"
+    stub.write_text(f"---\n{_yaml.dump(fm, sort_keys=False)}---\n{parts[2]}")
+    pre_mtime = stub.stat().st_mtime_ns
+
+    discard = ResearchResult(
+        disposition="discard",
+        reason="duplicate gap",
+    )
+
+    with patch(
+        "knowledge.research_handler.run_research",
+        AsyncMock(return_value=discard),
+    ):
+        await research_gaps_handler(session=session, vault_root=tmp_path)
+
+    assert stub.stat().st_mtime_ns == pre_mtime, (
+        "already-marked stub must not be rewritten"
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Replaces `_delete_stub` in the research handler's `discard` branch with a new `_mark_stub_discardable` helper that writes `triaged: discardable` (plus `status=parked`, `gap_class=parked`) into the stub frontmatter. The next gardener tick sees the marker and (eventually) rewrites source `[[wikilinks]]` to bare text via the existing Phase A `_rewrite_sources` path in `gaps.discover_gaps`.
- Extends `_VALID_GAP_STATES` (in `reconciler.py`) and the `GapState` `Literal` (in `models.py`) to include `parked` and `researching`. The DB CHECK constraint admitted both since migration `20260425040000_knowledge_gaps_state_check_widen`, but the Python view was stale.

## Why
Live observation of the research-gaps job over multiple ticks shows ~95% of Sonnet's discards are for terms that already have a `_processed/<slug>.md` note. The discard correctly parks the gap row, but the `[[wikilinks]]` in source notes stay intact, so the gardener re-discovers the same term on its next tick and queues a fresh stub. Net inflow: ~228 new gaps/hour. Net useful research: ~12 commits/hour. The classified backlog stays pinned at ~500 because inflow ≈ duplicate outflow.

The rewrite path that breaks this loop already exists (see `gap_discardable_rewrite_test.py`) and is sitting idle behind `KNOWLEDGE_GAPS_REWRITE_DISCARDABLE`. Until now nothing wrote the `triaged: discardable` marker, so the path never fired.

## Two-PR rollout
This PR is **safe to merge** because the env flag still defaults to off — `_rewrite_sources` runs in dry-run mode. We'll see `rewrites_dryrun=N` log lines from the gardener within a few ticks of deploy. **Once we've validated the dry-run counts**, a tiny follow-up PR flips `KNOWLEDGE_GAPS_REWRITE_DISCARDABLE=true` in deploy values to perform the writes.

## Why personal/quarantine paths are unchanged
Those terms might still be valuable to research later (personal goes to user review; quarantine just means Sonnet failed 3x), so stripping their wikilinks at the source would lose context. They keep using `_delete_stub`, leaving the gardener free to recreate stubs if the term reappears.

## Test plan
- [x] Updated `test_discard_disposition_parks_gap_and_marks_stub_discardable` to assert the marker is present and the stub stays
- [x] Added `test_discard_disposition_tolerates_missing_stub` (idempotency on no-stub)
- [x] Added `test_discard_marker_is_idempotent_on_already_marked_stub` (no mtime churn on re-discard)
- [x] Updated e2e test `test_e2e_discard_disposition_parks_gap_and_marks_stub_discardable`
- [x] No reconciler tests rely on `parked`/`researching` being rejected as invalid (greppped)
- [ ] BuildBuddy CI on this PR
- [ ] After deploy: watch gardener log for `rewrites_dryrun=N` — N should match the rate of Sonnet discards

🤖 Generated with [Claude Code](https://claude.com/claude-code)