### PR TITLE
fix(knowledge): slugify wikilink target before existing-notes lookup

### DIFF
--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -1951,6 +1951,19 @@ py_test(
 )
 
 py_test(
+    name = "knowledge_gap_slug_resolution_test",
+    srcs = ["knowledge/gap_slug_resolution_test.py"],
+    imports = ["."],
+    deps = [
+        ":monolith_backend",
+        "@pip//pgvector",
+        "@pip//pytest",
+        "@pip//sqlalchemy",
+        "@pip//sqlmodel",
+    ],
+)
+
+py_test(
     name = "knowledge_research_agent_test",
     srcs = ["knowledge/research_agent_test.py"],
     imports = ["."],

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.72.0
+version: 0.72.1
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.72.0
+      targetRevision: 0.72.1
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/knowledge/gap_slug_resolution_test.py
+++ b/projects/monolith/knowledge/gap_slug_resolution_test.py
@@ -1,0 +1,148 @@
+"""Regression tests for the wikilink-target slug resolution in
+``knowledge.gaps.discover_gaps``.
+
+``links.extract`` writes ``NoteLink.target_id`` as the raw wikilink text
+(e.g. ``"Steve Krug"``), while ``existing_note_ids`` is built from
+``Note.note_id`` slugs (``"steve-krug"``) plus slugified aliases. The
+membership check in Phase 1 must slugify the target before comparing,
+otherwise ``[[Title Case]]`` wikilinks to existing slug-named notes
+create false-positive Gap rows -- the loop that previously sent
+~10 already-resolved terms per tick to Sonnet for nothing.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from sqlmodel import Session, SQLModel, create_engine, select
+from sqlmodel.pool import StaticPool
+
+from knowledge.gap_stubs import RESEARCHING_DIR
+from knowledge.gaps import discover_gaps
+from knowledge.models import Gap, Note, NoteLink
+
+
+@pytest.fixture(name="session")
+def session_fixture():
+    """In-memory SQLite session; strips Postgres schema names so DDL works."""
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    original_schemas: dict[str, str] = {}
+    for table in SQLModel.metadata.tables.values():
+        if table.schema is not None:
+            original_schemas[table.name] = table.schema
+            table.schema = None
+    try:
+        SQLModel.metadata.create_all(engine)
+        with Session(engine) as session:
+            yield session
+    finally:
+        for table in SQLModel.metadata.tables.values():
+            if table.name in original_schemas:
+                table.schema = original_schemas[table.name]
+
+
+def _make_atom(
+    session: Session,
+    note_id: str,
+    *,
+    title: str | None = None,
+    aliases: list[str] | None = None,
+) -> Note:
+    note = Note(
+        note_id=note_id,
+        path=f"_processed/{note_id}.md",
+        title=title or note_id,
+        content_hash=f"hash-{note_id}",
+        type="atom",
+        aliases=aliases or [],
+    )
+    session.add(note)
+    session.commit()
+    session.refresh(note)
+    return note
+
+
+def _add_body_link(session: Session, *, src_fk: int, target_id: str) -> None:
+    session.add(
+        NoteLink(
+            src_note_fk=src_fk,
+            target_id=target_id,
+            target_title=target_id,
+            kind="link",
+            edge_type=None,
+        )
+    )
+    session.commit()
+
+
+def test_raw_wikilink_resolves_to_existing_slug_note(
+    session: Session, tmp_path: Path
+) -> None:
+    """A ``[[Title Case]]`` wikilink to a note with ``note_id="title-case"``
+    must NOT produce a Gap row.
+
+    Pre-fix: the lookup compared raw wikilink text to slugs and almost
+    always missed, queueing the gap. Post-fix: ``_slugify(target_id)`` on
+    the lookup side resolves the wikilink.
+    """
+    _make_atom(session, "steve-krug", title="Steve Krug")
+    src = _make_atom(session, "src", title="Source")
+    # Target stored in raw form, as ``links.extract`` emits it.
+    _add_body_link(session, src_fk=src.id, target_id="Steve Krug")
+
+    discover_gaps(session, tmp_path)
+
+    rows = session.execute(select(Gap)).scalars().all()
+    assert rows == [], (
+        "Expected no Gap (resolves to existing 'steve-krug'), got: "
+        f"{[(r.term, r.note_id) for r in rows]}"
+    )
+    assert not (tmp_path / RESEARCHING_DIR / "steve-krug.md").exists(), (
+        "stub must not be written for a resolvable wikilink"
+    )
+
+
+def test_raw_wikilink_resolves_via_existing_alias(
+    session: Session, tmp_path: Path
+) -> None:
+    """``[[Bayes' Theorem]]`` should resolve to a canonical atom that
+    carries ``Bayes' Theorem`` in its aliases, even though the wikilink
+    text doesn't slug-match the canonical ``note_id``.
+    """
+    _make_atom(
+        session,
+        "thomas-bayes-rule",
+        title="Thomas Bayes' Rule",
+        aliases=["Bayes' Theorem"],
+    )
+    src = _make_atom(session, "src", title="Source")
+    _add_body_link(session, src_fk=src.id, target_id="Bayes' Theorem")
+
+    discover_gaps(session, tmp_path)
+
+    rows = session.execute(select(Gap)).scalars().all()
+    assert rows == [], (
+        "Expected no Gap (resolves via alias), got: "
+        f"{[(r.term, r.note_id) for r in rows]}"
+    )
+
+
+def test_raw_wikilink_with_no_match_still_creates_gap(
+    session: Session, tmp_path: Path
+) -> None:
+    """Sanity check: when the slugified wikilink doesn't match any existing
+    note or alias, the gap is correctly created."""
+    src = _make_atom(session, "src", title="Source")
+    _add_body_link(session, src_fk=src.id, target_id="Genuinely Novel Term")
+
+    discover_gaps(session, tmp_path)
+
+    rows = session.execute(select(Gap)).scalars().all()
+    assert len(rows) == 1
+    assert rows[0].term == "Genuinely Novel Term"
+    assert rows[0].note_id == "genuinely-novel-term"

--- a/projects/monolith/knowledge/gaps.py
+++ b/projects/monolith/knowledge/gaps.py
@@ -182,11 +182,23 @@ def discover_gaps(session: Session, vault_root: Path) -> int:
 
     # Phase 1: accumulate per-term breadcrumbs. One term can be referenced
     # by many source notes; the stub's referenced_by reflects that.
+    #
+    # ``NoteLink.target_id`` is the raw wikilink text (``Steve Krug``),
+    # while ``existing_note_ids`` is a set of slugs (``steve-krug``) plus
+    # slugified aliases. Slugify the target before the membership check
+    # so a wikilink to an existing note resolves correctly regardless of
+    # casing, spaces, or punctuation. Without this, every ``[[Title Case
+    # Term]]`` to a `_processed/<slug>.md` note creates a Gap row that
+    # only Sonnet's filesystem inspection can later catch and discard --
+    # one full Sonnet call per duplicate that should never have been
+    # queued. ``referenced_by`` is still keyed by the raw target so the
+    # downstream slug-fold (Phase 2) preserves the canonical wikilink
+    # text for ``slug_canonical_term``.
     referenced_by: dict[str, set[str]] = {}
     contexts: dict[str, str] = {}
     for row in link_rows:
         target_id = row.target_id
-        if target_id in existing_note_ids:
+        if _slugify(target_id) in existing_note_ids:
             continue
         referenced_by.setdefault(target_id, set()).add(row.note_id)
         # First-writer wins for context — legacy breadcrumb; the stub's


### PR DESCRIPTION
## Summary

The gardener's existence-check (`gaps.discover_gaps` Phase 1) compared **raw wikilink text** to a set of **slugs**, so it almost always missed. Every `[[Title Case Term]]` to a note with `note_id="title-case"` produced a false-positive Gap row that only Sonnet's filesystem inspection (deep inside the research subprocess) could later catch and discard.

One-line fix: `_slugify(target_id)` on the lookup side. `referenced_by` stays keyed by raw target so the downstream slug-fold in Phase 2 preserves canonical wikilink text.

## Why this matters

This is the **root cause** of the treadmill we observed in https://github.com/jomcgi/homelab/pull/2283 — and the reason useful research throughput was being eaten by ~10 wasted Sonnet calls per tick. The discardable-rewrite path from #2283 cleans up wikilinks for stubs that already exist; this PR prevents the same situation from recurring with new wikilinks.

## Test plan
- [x] New `gap_slug_resolution_test.py` (separate file because semgrep `no-generic-test-filename` blocks adding tests to `*gaps*_test.py`):
  - `test_raw_wikilink_resolves_to_existing_slug_note` — pre-fix this fails, post-fix passes
  - `test_raw_wikilink_resolves_via_existing_alias` — covers the alias-slugification path
  - `test_raw_wikilink_with_no_match_still_creates_gap` — sanity check that genuinely-new terms still produce gaps
- [x] Existing `gaps_test.py` tests use slug-form `target_id`s (`"gone-concept"`, etc.) which slugify to themselves — no breakage
- [x] BUILD entry added for the new py_test target
- [ ] BuildBuddy CI on this PR
- [ ] After deploy: watch for **discard-rate dropping** in `knowledge.research_handler` logs — most current discards are upstream-resolvable, so they should stop happening at all rather than be caught + parked

## Notes

- `KNOWLEDGE_GAPS_REWRITE_DISCARDABLE=1` is already live (commit `b1967bd4d`), so the markers PR #2283 writes will still rewrite source brackets when the gardener happens to encounter the marked terms in a source-note processing cycle.
- The pre-Sonnet `Path.exists()` guard I floated as a "follow-up" is now mooted by this fix — duplicates won't be created at gap-creation time, so the research handler never sees them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)