### PR TITLE
fix(monolith): unblock asyncio loop in gardener + sane probe timeouts

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.72.3
+version: 0.72.4
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/templates/deployment.yaml
+++ b/projects/monolith/chart/templates/deployment.yaml
@@ -143,12 +143,22 @@ spec:
               port: api
             initialDelaySeconds: 5
             periodSeconds: 10
+            # K8s default `timeoutSeconds: 1` is unreasonable for a
+            # Python web server: any GC pause or kernel-scheduler hiccup
+            # trips it. 5s is conservative for /healthz, which is a
+            # synchronous handler returning a static dict (no DB, no
+            # work). 6 failures in a row (60s) before restart absorbs
+            # transient event-loop blips without losing the ability to
+            # recover a genuinely wedged process.
+            timeoutSeconds: 5
+            failureThreshold: 6
           readinessProbe:
             httpGet:
               path: /healthz
               port: api
             initialDelaySeconds: 3
             periodSeconds: 5
+            timeoutSeconds: 3
           {{- if .Values.knowledge.enabled }}
           volumeMounts:
             # Writable: the backend reconciler injects generated

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.72.3
+      targetRevision: 0.72.4
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/knowledge/gardener.py
+++ b/projects/monolith/knowledge/gardener.py
@@ -347,7 +347,18 @@ class Gardener:
         return fresh + retriable
 
     async def run(self) -> GardenStats:
-        """Run one gardening cycle: resolve pending → move → reconcile → decompose."""
+        """Run one gardening cycle: resolve pending → move → reconcile → decompose.
+
+        All sync helpers (DB scans, filesystem walks, slug-folding loops)
+        run on a worker thread via ``asyncio.to_thread`` so the event loop
+        stays free for the FastAPI ``/healthz`` probe and other API
+        requests. Without this, a single tick can hold the loop for
+        seconds-to-minutes; the K8s liveness probe (default
+        ``timeoutSeconds: 1``) would then fire and the pod would restart
+        mid-cycle. The Claude subprocess calls (``_ingest_one`` and
+        ``_distill_completed_tasks``) are already async via
+        ``asyncio.create_subprocess_exec`` and yield naturally.
+        """
         from knowledge.raw_ingest import move_phase, reconcile_raw_phase
 
         # Run every cycle: the Gardener instance is reconstructed per scheduled
@@ -359,7 +370,7 @@ class Gardener:
         try:
             from knowledge.gap_stubs import dedupe_stub_frontmatter
 
-            cleaned = dedupe_stub_frontmatter(self.vault_root)
+            cleaned = await asyncio.to_thread(dedupe_stub_frontmatter, self.vault_root)
             if cleaned:
                 logger.info(
                     "knowledge.garden: deduped %d stub frontmatters",
@@ -370,21 +381,25 @@ class Gardener:
                 "knowledge.garden: stub frontmatter dedup failed (non-fatal)"
             )
 
-        resolved_count = self._resolve_pending_provenance()
+        resolved_count = await asyncio.to_thread(self._resolve_pending_provenance)
         if resolved_count and self.session is not None:
             self.session.commit()
 
         now = datetime.now(timezone.utc)
-        move_stats = move_phase(vault_root=self.vault_root, now=now)
+        move_stats = await asyncio.to_thread(
+            move_phase, vault_root=self.vault_root, now=now
+        )
 
         reconcile_stats = None
         if self.session is not None:
-            reconcile_stats = reconcile_raw_phase(
-                vault_root=self.vault_root, session=self.session
+            reconcile_stats = await asyncio.to_thread(
+                reconcile_raw_phase,
+                vault_root=self.vault_root,
+                session=self.session,
             )
             self.session.commit()
 
-        raws = self._raws_needing_decomposition()
+        raws = await asyncio.to_thread(self._raws_needing_decomposition)
         if self.max_files_per_run > 0 and len(raws) > self.max_files_per_run:
             logger.info(
                 "gardener: %d raws need decomposition, capping to %d",
@@ -406,9 +421,9 @@ class Gardener:
         distilled, distill_failed = await self._distill_completed_tasks()
         failed += distill_failed
 
-        consolidated = self._consolidate_task_views()
+        consolidated = await asyncio.to_thread(self._consolidate_task_views)
 
-        gaps_discovered = self._discover_gaps()
+        gaps_discovered = await asyncio.to_thread(self._discover_gaps)
 
         stats = GardenStats(
             ingested=ingested,

--- a/projects/monolith/knowledge/reconciler.py
+++ b/projects/monolith/knowledge/reconciler.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import logging
 import re
@@ -92,13 +93,20 @@ class Reconciler:
         self.researching_root = self.vault_root / "_researching"
 
     async def run(self) -> ReconcileStats:
-        """Reconcile the vault. Returns a ReconcileStats breakdown."""
+        """Reconcile the vault. Returns a ReconcileStats breakdown.
+
+        The pre-loop helpers (`_pre_sync_links`, `get_indexed`, `_walk`)
+        are sync and walk the entire vault + scan the full Note table.
+        Run them on a worker thread via `asyncio.to_thread` so the
+        event loop stays free for `/healthz` and other API requests.
+        Same loop-unblock pattern as the gardener handler.
+        """
         # Sync ## Links sections across all processed notes before hash
         # comparison so that notes with missing or stale sections get
         # re-ingested in this cycle via the normal hash-change path.
-        self._pre_sync_links()
-        indexed = self.store.get_indexed()
-        on_disk = self._walk(previous_indexed=indexed)
+        await asyncio.to_thread(self._pre_sync_links)
+        indexed = await asyncio.to_thread(self.store.get_indexed)
+        on_disk = await asyncio.to_thread(self._walk, previous_indexed=indexed)
 
         to_upsert = sorted(
             path for path, h in on_disk.items() if indexed.get(path) != h


### PR DESCRIPTION
## Summary

Fixes the pod-restart-every-30-min issue. Two changes:

1. **`gardener.py`** — wrap all seven sync helpers in `Gardener.run()` (`dedupe_stub_frontmatter`, `_resolve_pending_provenance`, `move_phase`, `reconcile_raw_phase`, `_raws_needing_decomposition`, `_consolidate_task_views`, `_discover_gaps`) in `await asyncio.to_thread(...)`. The event loop stays free during the tick so `/healthz` (and other API requests) can be served promptly.

2. **`chart/templates/deployment.yaml`** — bump probe `timeoutSeconds` from K8s default `1s` to `5s` (liveness) / `3s` (readiness), and `failureThreshold` to `6` (60s of consecutive failures before restart). The `1s` default is unreasonable for any non-trivial Python process.

## Why both fixes together

They address the same incident from two angles. The `to_thread` wrap stops the loop from being blocked in the first place — but if some new sync hotspot appears in the future, the bumped probe timeouts will absorb the blip without tripping a restart. Defense in depth: prevent + tolerate.

## Why `to_thread` over async-native SQLAlchemy

Considered. The project has **zero** `AsyncSession` usage today, so going native would cascade through the entire knowledge handler stack — a multi-PR refactor. `to_thread` covers all blocking work uniformly (DB + filesystem + CPU-bound chunks), whereas async-native only covers DB. SQLAlchemy sync `Session` is safe under `to_thread` because each call awaits a single thread; the event loop never touches the session concurrently.

If we want to adopt async-native sessions later as part of broader knowledge-pipeline modernization, this PR doesn't lock that out — `to_thread` becomes a no-op once the inner code is async.

## Test plan
- [x] `Gardener.run()`'s async signature is unchanged — existing tests using `await gardener.run()` work unmodified
- [x] `garden_handler` in `service.py` still invokes `await gardener.run()` — no change
- [x] All wrapped functions are sync today; their behavior under `to_thread` is identical (just runs on a worker thread instead of the event loop)
- [x] Format check passes locally
- [ ] BuildBuddy CI on this PR
- [ ] After deploy: pod restart count should stop climbing; `kubectl get pod -n monolith -o jsonpath='{.items[*].status.containerStatuses[?(@.name=="backend")].restartCount}'` should plateau

🤖 Generated with [Claude Code](https://claude.com/claude-code)