### PR TITLE
feat(knowledge): tune FA2 to reduce node overlap (node_size halo + sr=5/g=0.1/ll=false)

### DIFF
--- a/docs/plans/2026-05-06-kg-server-side-layout-design.md
+++ b/docs/plans/2026-05-06-kg-server-side-layout-design.md
@@ -367,8 +367,8 @@ new dep) plus a structural split:**
    gardener cycles for the orphan subset — even better than the soft
    stability we have for the connected core.
 
-**Final tuned parameters (from preview-script iteration on the real
-graph):**
+**Initial parameters (from preview-script iteration on the real
+graph; superseded by the tuning round below):**
 
 | Knob                   | Value | Rationale                                              |
 | ---------------------- | ----- | ------------------------------------------------------ |
@@ -384,6 +384,29 @@ graph):**
 edges. With a 5-min reconcile cadence that's 5% overhead. If we ever
 move to a faster reconcile cadence the right knob to turn down is
 `max_iter` (50 should be acceptable, 25 likely fine).
+
+### Tuning iteration after deploy (2026-05-06)
+
+After the first prod rollout, dense atom clusters showed visibly
+overlapping nodes — the cluster was internally well-shaped but
+individual atoms were stacking on top of each other. A second
+preview-script iteration round on the live graph dialed in:
+
+| Knob              | Before | After | Rationale                                                                                                                                       |
+| ----------------- | ------ | ----- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| `scaling_ratio`   | 2.0    | 5.0   | More pairwise repulsion to break up clumps                                                                                                      |
+| `gravity`         | 0.5    | 0.1   | Less center-pull, more radial spread                                                                                                            |
+| `linlog`          | True   | False | Linear attraction; `linlog` packs dense regions tighter, exactly the failure mode we're fixing                                                  |
+| `node_size_scale` | —      | 0.005 | NEW — passes a per-node halo dict to FA2 (`node_size=`), giving each node a degree-scaled collision-avoidance radius (the d3 `collide` analog). |
+
+The halo radius per node is `scale * (1 + log2(1 + degree))` — leaves
+get the base radius, hubs get a slightly larger personal-space bubble
+that keeps long-tail atoms from piling on top of high-degree centers.
+Setting `node_size_scale=0` is allowed and skips halo dict construction
+entirely (opt-out path for cheap layouts on tiny test fixtures).
+
+`core_fraction`, `ring_radius_fraction`, `max_iter`, and `seed` were
+unchanged.
 
 **Why FA2 over the other paths considered:**
 

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.72.2
+version: 0.72.3
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/templates/deployment.yaml
+++ b/projects/monolith/chart/templates/deployment.yaml
@@ -118,6 +118,8 @@ spec:
               value: {{ .Values.knowledge.layout.coreFraction | quote }}
             - name: KNOWLEDGE_LAYOUT_RING_RADIUS_FRACTION
               value: {{ .Values.knowledge.layout.ringRadiusFraction | quote }}
+            - name: KNOWLEDGE_LAYOUT_NODE_SIZE_SCALE
+              value: {{ .Values.knowledge.layout.nodeSizeScale | quote }}
             - name: KNOWLEDGE_LAYOUT_SEED
               value: {{ .Values.knowledge.layout.seed | quote }}
             {{- if .Values.knowledge.gitRemote }}

--- a/projects/monolith/chart/values.yaml
+++ b/projects/monolith/chart/values.yaml
@@ -85,13 +85,14 @@ knowledge:
       limits:
         memory: "384Mi"
   layout:
-    scalingRatio: 2.0
-    gravity: 0.5
+    scalingRatio: 5.0
+    gravity: 0.1
     maxIter: 100
-    linlog: true
+    linlog: false
     coreFraction: 0.99
     ringRadiusFraction: 0.995
     seed: 42
+    nodeSizeScale: 0.005
 
 chat:
   enabled: false

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.72.2
+      targetRevision: 0.72.3
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/knowledge/layout.py
+++ b/projects/monolith/knowledge/layout.py
@@ -70,12 +70,13 @@ def _is_truthy(value: str) -> bool:
 
 @dataclass(frozen=True, slots=True)
 class LayoutParams:
-    scaling_ratio: float = 2.0
-    gravity: float = 0.5
+    scaling_ratio: float = 5.0
+    gravity: float = 0.1
     max_iter: int = 100
-    linlog: bool = True
+    linlog: bool = False
     core_fraction: float = 0.99
     ring_radius_fraction: float = 0.995
+    node_size_scale: float = 0.005
     seed: int = 42
 
     def __post_init__(self) -> None:
@@ -99,6 +100,12 @@ class LayoutParams:
             raise ValueError(
                 f"ring_radius_fraction must be in (0, 1], got {self.ring_radius_fraction}"
             )
+        # node_size_scale may legitimately be 0 (no halo / no collision-avoidance).
+        # Disallow negatives and non-finite values.
+        if not (self.node_size_scale >= 0 and math.isfinite(self.node_size_scale)):
+            raise ValueError(
+                f"node_size_scale must be non-negative and finite, got {self.node_size_scale}"
+            )
         if self.core_fraction > self.ring_radius_fraction:
             raise ValueError(
                 f"core_fraction ({self.core_fraction}) must be <= "
@@ -115,14 +122,15 @@ class LayoutParams:
         """
         env = environ if environ is not None else os.environ
         return cls(
-            scaling_ratio=float(env.get("KNOWLEDGE_LAYOUT_SCALING_RATIO", "2.0")),
-            gravity=float(env.get("KNOWLEDGE_LAYOUT_GRAVITY", "0.5")),
+            scaling_ratio=float(env.get("KNOWLEDGE_LAYOUT_SCALING_RATIO", "5.0")),
+            gravity=float(env.get("KNOWLEDGE_LAYOUT_GRAVITY", "0.1")),
             max_iter=int(env.get("KNOWLEDGE_LAYOUT_MAX_ITER", "100")),
-            linlog=_is_truthy(env.get("KNOWLEDGE_LAYOUT_LINLOG", "true")),
+            linlog=_is_truthy(env.get("KNOWLEDGE_LAYOUT_LINLOG", "false")),
             core_fraction=float(env.get("KNOWLEDGE_LAYOUT_CORE_FRACTION", "0.99")),
             ring_radius_fraction=float(
                 env.get("KNOWLEDGE_LAYOUT_RING_RADIUS_FRACTION", "0.995")
             ),
+            node_size_scale=float(env.get("KNOWLEDGE_LAYOUT_NODE_SIZE_SCALE", "0.005")),
             seed=int(env.get("KNOWLEDGE_LAYOUT_SEED", "42")),
         )
 
@@ -197,15 +205,31 @@ def compute_layout(
             and math.isfinite(n.prior_y)
         }
 
-        raw = nx.forceatlas2_layout(
-            g,
-            pos=prior or None,
-            max_iter=params.max_iter,
-            scaling_ratio=params.scaling_ratio,
-            gravity=params.gravity,
-            linlog=params.linlog,
-            seed=params.seed,
-        )
+        kwargs: dict = {
+            "pos": prior or None,
+            "max_iter": params.max_iter,
+            "scaling_ratio": params.scaling_ratio,
+            "gravity": params.gravity,
+            "linlog": params.linlog,
+            "seed": params.seed,
+        }
+        # When node_size_scale > 0, pass a per-node halo radius dict to FA2
+        # for collision-avoidance (analogous to d3-force's `collide`). The
+        # halo grows logarithmically with degree, so high-degree hubs claim
+        # a slightly larger personal-space bubble than leaf nodes. Skip the
+        # dict construction entirely when scale=0 — the param is opt-out.
+        if params.node_size_scale > 0:
+            degrees = {n.id: 0 for n in connected}
+            for e in edges:
+                if e.source in degrees:
+                    degrees[e.source] += 1
+                if e.target in degrees:
+                    degrees[e.target] += 1
+            kwargs["node_size"] = {
+                nid: params.node_size_scale * (1 + math.log2(1 + degrees.get(nid, 0)))
+                for nid in connected_ids
+            }
+        raw = nx.forceatlas2_layout(g, **kwargs)
 
         # Find FA2's bounding box across finite outputs and post-scale to
         # fill `core_fraction` of the unit canvas. Skip the rescale entirely

--- a/projects/monolith/knowledge/layout_test.py
+++ b/projects/monolith/knowledge/layout_test.py
@@ -223,6 +223,29 @@ class TestComputeLayout:
         r = math.hypot(x, y)
         assert abs(r - params.ring_radius_fraction) < 1e-9
 
+    def test_compute_layout_with_node_size_scale_changes_output(self):
+        """node_size_scale must be plumbed through to FA2 — same graph with
+        scale=0 vs scale>0 yields different positions, proving the halo dict
+        actually reaches the layout call.
+        """
+        nodes = [_node(nid) for nid in ("a", "b", "c", "d", "e")]
+        edges = [
+            EdgeRef("a", "b"),
+            EdgeRef("a", "c"),
+            EdgeRef("a", "d"),
+            EdgeRef("a", "e"),
+            EdgeRef("b", "c"),
+        ]
+
+        no_halo = compute_layout(
+            nodes, edges, LayoutParams(node_size_scale=0.0, seed=42)
+        )
+        with_halo = compute_layout(
+            nodes, edges, LayoutParams(node_size_scale=0.01, seed=42)
+        )
+
+        assert no_halo != with_halo
+
 
 class TestLayoutParamsValidation:
     def test_validates_positive_max_iter(self):
@@ -276,16 +299,30 @@ class TestLayoutParamsValidation:
         with pytest.raises(ValueError, match="must be <= ring_radius_fraction"):
             LayoutParams(core_fraction=0.95, ring_radius_fraction=0.5)
 
+    def test_node_size_scale_zero_is_allowed(self):
+        # node_size_scale=0 means "no halo" — must construct without raising.
+        params = LayoutParams(node_size_scale=0.0)
+        assert params.node_size_scale == 0.0
+
+    def test_node_size_scale_validates_negative(self):
+        with pytest.raises(ValueError, match="non-negative"):
+            LayoutParams(node_size_scale=-0.001)
+
+    def test_node_size_scale_validates_finite(self):
+        with pytest.raises(ValueError, match="non-negative and finite"):
+            LayoutParams(node_size_scale=float("inf"))
+
 
 class TestLayoutParamsFromEnv:
     def test_uses_defaults_when_env_empty(self):
         params = LayoutParams.from_env({})
-        assert params.scaling_ratio == 2.0
-        assert params.gravity == 0.5
+        assert params.scaling_ratio == 5.0
+        assert params.gravity == 0.1
         assert params.max_iter == 100
-        assert params.linlog is True
+        assert params.linlog is False
         assert params.core_fraction == 0.99
         assert params.ring_radius_fraction == 0.995
+        assert params.node_size_scale == 0.005
         assert params.seed == 42
 
     def test_reads_overrides_from_env(self):
@@ -294,18 +331,20 @@ class TestLayoutParamsFromEnv:
                 "KNOWLEDGE_LAYOUT_SCALING_RATIO": "3.5",
                 "KNOWLEDGE_LAYOUT_GRAVITY": "1.0",
                 "KNOWLEDGE_LAYOUT_MAX_ITER": "200",
-                "KNOWLEDGE_LAYOUT_LINLOG": "0",
+                "KNOWLEDGE_LAYOUT_LINLOG": "1",
                 "KNOWLEDGE_LAYOUT_CORE_FRACTION": "0.8",
                 "KNOWLEDGE_LAYOUT_RING_RADIUS_FRACTION": "0.9",
+                "KNOWLEDGE_LAYOUT_NODE_SIZE_SCALE": "0.01",
                 "KNOWLEDGE_LAYOUT_SEED": "7",
             }
         )
         assert params.scaling_ratio == 3.5
         assert params.gravity == 1.0
         assert params.max_iter == 200
-        assert params.linlog is False
+        assert params.linlog is True
         assert params.core_fraction == 0.8
         assert params.ring_radius_fraction == 0.9
+        assert params.node_size_scale == 0.01
         assert params.seed == 7
 
     @pytest.mark.parametrize("truthy", ["1", "true", "TRUE", "True", "yes", "YES"])
@@ -327,3 +366,5 @@ class TestLayoutParamsFromEnv:
             LayoutParams.from_env({"KNOWLEDGE_LAYOUT_CORE_FRACTION": "2.0"})
         with pytest.raises(ValueError):
             LayoutParams.from_env({"KNOWLEDGE_LAYOUT_RING_RADIUS_FRACTION": "0"})
+        with pytest.raises(ValueError):
+            LayoutParams.from_env({"KNOWLEDGE_LAYOUT_NODE_SIZE_SCALE": "-0.001"})

--- a/projects/monolith/scripts/preview-layout.py
+++ b/projects/monolith/scripts/preview-layout.py
@@ -14,12 +14,13 @@ orphan ring on the canvas perimeter at ``--ring-radius-fraction``.
 Usage:
     python preview-layout.py \\
         --snapshot graph.json \\
-        --scaling-ratio 2.0 \\
-        --gravity 0.5 \\
+        --scaling-ratio 5.0 \\
+        --gravity 0.1 \\
         --max-iter 100 \\
-        --linlog \\
+        --no-linlog \\
         --core-fraction 0.99 \\
         --ring-radius-fraction 0.995 \\
+        --node-size-scale 0.005 \\
         --seed 42 \\
         --out preview.html
 
@@ -51,15 +52,15 @@ def main(argv: list[str] | None = None) -> int:
         required=True,
         help="Path to a graph JSON snapshot ({nodes:[...], edges:[...]}).",
     )
-    parser.add_argument("--scaling-ratio", type=float, default=2.0)
-    parser.add_argument("--gravity", type=float, default=0.5)
+    parser.add_argument("--scaling-ratio", type=float, default=5.0)
+    parser.add_argument("--gravity", type=float, default=0.1)
     parser.add_argument("--max-iter", type=int, default=100)
     parser.add_argument(
         "--linlog",
         dest="linlog",
         action="store_true",
-        default=True,
-        help="Enable FA2 logarithmic attraction (default: on).",
+        default=False,
+        help="Enable FA2 logarithmic attraction (default: off).",
     )
     parser.add_argument(
         "--no-linlog",
@@ -69,6 +70,12 @@ def main(argv: list[str] | None = None) -> int:
     )
     parser.add_argument("--core-fraction", type=float, default=0.99)
     parser.add_argument("--ring-radius-fraction", type=float, default=0.995)
+    parser.add_argument(
+        "--node-size-scale",
+        type=float,
+        default=0.005,
+        help="FA2 collision-avoidance halo per-node, scaled by node degree (0 disables).",
+    )
     parser.add_argument("--seed", type=int, default=42)
     parser.add_argument(
         "--out",
@@ -95,6 +102,7 @@ def main(argv: list[str] | None = None) -> int:
         linlog=args.linlog,
         core_fraction=args.core_fraction,
         ring_radius_fraction=args.ring_radius_fraction,
+        node_size_scale=args.node_size_scale,
         seed=args.seed,
     )
     positions = compute_layout(nodes, edges, params)
@@ -126,7 +134,7 @@ def _render_html(
         f"layout preview (sr={params.scaling_ratio}, g={params.gravity}, "
         f"it={params.max_iter}, ll={params.linlog}, "
         f"core={params.core_fraction}, ring={params.ring_radius_fraction}, "
-        f"seed={params.seed})"
+        f"nss={params.node_size_scale}, seed={params.seed})"
     )
     return f"""<!doctype html>
 <html><head><meta charset="utf-8"><title>{title}</title></head>

--- a/projects/monolith/scripts/preview_layout_test.py
+++ b/projects/monolith/scripts/preview_layout_test.py
@@ -146,6 +146,8 @@ def test_preview_layout_passes_params_to_compute_layout(tmp_path, monkeypatch):
             "0.8",
             "--ring-radius-fraction",
             "0.9",
+            "--node-size-scale",
+            "0.01",
             "--seed",
             "7",
             "--out",
@@ -160,4 +162,5 @@ def test_preview_layout_passes_params_to_compute_layout(tmp_path, monkeypatch):
     assert p.linlog is False
     assert p.core_fraction == 0.8
     assert p.ring_radius_fraction == 0.9
+    assert p.node_size_scale == 0.01
     assert p.seed == 7


### PR DESCRIPTION
## Summary

Follow-up to #2284. Post-deploy on the real ~2900-node graph, the original FA2 tuning produced visible overlap in dense atom clusters. Iterated locally via the preview script and landed on:

- **`scaling_ratio: 2.0 → 5.0`** — more pairwise repulsion to break up clumps
- **`gravity: 0.5 → 0.1`** — less center pull, more spread
- **`linlog: true → false`** — linlog actively packed dense regions tighter (logarithmic attraction grows much faster than linear at short distances), exactly the failure mode the user reported
- **`node_size_scale: 0.005`** (NEW) — adds a per-node halo to FA2 (the d3 \`forceCollide\` analog); halo radius scales by \`log2(1+degree)\` so hub nodes claim slightly more breathing room than leaves

Helm chart bumped 0.72.2 → 0.72.3.

## Test plan

- [ ] CI green on push
- [ ] Manual: confirm reduced overlap on \`/private/notes\` after rollout
- [ ] SigNoz: verify \`knowledge.layout: pass succeeded\` log fires on the next reconcile cycle post-deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)