### PR TITLE
fix(knowledge): slug-normalize wikilink targets in graph edge filter

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.72.4
+version: 0.72.5
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.72.4
+      targetRevision: 0.72.5
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/knowledge/service.py
+++ b/projects/monolith/knowledge/service.py
@@ -11,6 +11,7 @@ from dulwich import porcelain
 from sqlalchemy import select, update
 from sqlmodel import Session
 
+from knowledge.gardener import _slugify
 from knowledge.layout import EdgeRef, LayoutParams, NodePos, compute_layout
 from knowledge.models import Note, NoteLink
 from knowledge.reconciler import Reconciler
@@ -201,11 +202,23 @@ def _run_layout_pass(session: Session) -> tuple[int, int, int]:
 
     edge_rows = session.execute(select(NoteLink.src_note_fk, NoteLink.target_id)).all()
     note_id_set = set(fk_to_note_id.values())
-    edges = [
-        EdgeRef(source=fk_to_note_id[r.src_note_fk], target=r.target_id)
-        for r in edge_rows
-        if r.src_note_fk in fk_to_note_id and r.target_id in note_id_set
-    ]
+    # Mirror ``KnowledgeStore.get_graph``'s slug-normalize-then-resolve
+    # logic. Body wikilinks store ``target_id`` as raw user-typed text
+    # (``"Steve Krug"``); gap stubs and ``_processed`` notes carry
+    # ``note_id`` in slug form. Without this normalization FA2 treats
+    # gap edges as missing, the gap nodes are classified as orphans by
+    # ``compute_layout``, and they drift to the perimeter ring.
+    slug_to_note_id = {_slugify(nid): nid for nid in note_id_set}
+    edges: list[EdgeRef] = []
+    for r in edge_rows:
+        if r.src_note_fk not in fk_to_note_id:
+            continue
+        canonical_target = slug_to_note_id.get(_slugify(r.target_id))
+        if canonical_target is None:
+            continue
+        edges.append(
+            EdgeRef(source=fk_to_note_id[r.src_note_fk], target=canonical_target)
+        )
 
     positions = compute_layout(nodes, edges, params)
 

--- a/projects/monolith/knowledge/store.py
+++ b/projects/monolith/knowledge/store.py
@@ -10,6 +10,7 @@ from sqlalchemy.orm.attributes import flag_modified
 from sqlmodel import Session, delete, select
 
 from knowledge.frontmatter import ParsedFrontmatter
+from knowledge.gardener import _slugify
 from knowledge.links import Link
 from knowledge.models import Chunk, Gap, Note, NoteLink
 from shared.chunker import Chunk as ChunkPayload
@@ -350,10 +351,17 @@ class KnowledgeStore:
         of truth so server-computed ``degree`` matches the visible-edge
         count the user sees.
 
-        Edges with unresolved or filtered-out targets (target_id pointing
-        to a string that doesn't match any in-set note's note_id) are
-        dropped — gap-promoted wikilinks survive as edges into
-        ``type='gap'`` nodes.
+        Edges with unresolved targets are dropped — no phantom edges.
+        Targets are resolved by slugifying ``NoteLink.target_id`` (which
+        stores the raw user-typed wikilink text, e.g. ``"Steve Krug"``)
+        and matching against the slugified ``note_id`` of each visible
+        note. This is the same normalization ``gaps.discover_gaps`` uses
+        when promoting unresolved wikilinks into ``type='gap'`` stubs, so
+        a wikilink ``[[Steve Krug]]`` consistently resolves to the gap at
+        ``_researching/steve-krug.md`` instead of being treated as an
+        unresolved string. The edge's ``target`` field is rewritten to
+        the canonical ``note_id`` so it joins cleanly with the
+        corresponding node on the frontend.
 
         Each node payload also ships server-computed ``degree`` (count of
         incident visible edges) and persisted ``x`` / ``y`` layout
@@ -370,12 +378,15 @@ class KnowledgeStore:
             )
         ).all()
         # Filter out notes whose type isn't in the graph set BEFORE we
-        # build note_ids — that way the existing edge filter
-        # (``row.target in note_ids``) automatically drops edges that
-        # point at filtered-out neighbours, keeping degree counts
-        # coherent with the visible edges.
+        # build note_ids — that way the edge filter automatically drops
+        # edges that point at filtered-out neighbours, keeping degree
+        # counts coherent with the visible edges.
         note_rows = [row for row in all_note_rows if row.type in GRAPH_NOTE_TYPES]
         note_ids = {row.note_id for row in note_rows}
+        # Map each visible note's slug back to its canonical note_id so a
+        # title-form wikilink (``"Steve Krug"``) resolves to the same node
+        # as its slug-form counterpart (``"steve-krug"``).
+        slug_to_note_id = {_slugify(nid): nid for nid in note_ids}
 
         link_rows = self.session.execute(
             select(
@@ -386,16 +397,21 @@ class KnowledgeStore:
             ).join(Note, NoteLink.src_note_fk == Note.id)
         ).all()
 
-        edges = [
-            {
-                "source": row.source,
-                "target": row.target,
-                "kind": row.kind,
-                "edge_type": row.edge_type,
-            }
-            for row in link_rows
-            if row.source in note_ids and row.target in note_ids
-        ]
+        edges: list[dict] = []
+        for row in link_rows:
+            if row.source not in note_ids:
+                continue
+            canonical_target = slug_to_note_id.get(_slugify(row.target))
+            if canonical_target is None:
+                continue
+            edges.append(
+                {
+                    "source": row.source,
+                    "target": canonical_target,
+                    "kind": row.kind,
+                    "edge_type": row.edge_type,
+                }
+            )
 
         # Compute degree from the response edges so server-side semantics
         # match exactly what the client used to compute (increment both

--- a/projects/monolith/knowledge/store_test.py
+++ b/projects/monolith/knowledge/store_test.py
@@ -581,6 +581,68 @@ def test_get_graph_drops_edges_with_unresolved_targets(session):
     assert result["edges"] == []
 
 
+def test_get_graph_resolves_title_form_wikilink_to_slug_note_id(session):
+    # Body wikilinks land in NoteLink.target_id as the user-typed text
+    # (``"Steve Krug"``), but gap stubs (and most _processed notes)
+    # store note_id in slug form (``"steve-krug"``). The graph endpoint
+    # must slug-normalize before the membership check, otherwise inbound
+    # edges to gap nodes are silently dropped — they render as orphans
+    # on the canvas perimeter.
+    store = KnowledgeStore(session)
+    _upsert(
+        store,
+        note_id="src",
+        path="src.md",
+        content_hash="h-src",
+        title="Source",
+        metadata=_meta(title="Source", type="atom"),
+        links=[Link(target="Steve Krug", display=None)],
+    )
+    _upsert(
+        store,
+        note_id="steve-krug",
+        path="_researching/steve-krug.md",
+        content_hash="h-gap",
+        title="Steve Krug",
+        metadata=_meta(title="Steve Krug", type="gap"),
+    )
+
+    result = store.get_graph()
+
+    edges = result["edges"]
+    assert len(edges) == 1
+    edge = edges[0]
+    assert edge["source"] == "src"
+    # Edge target is rewritten to the canonical slug so it joins
+    # cleanly with the corresponding node id on the frontend.
+    assert edge["target"] == "steve-krug"
+    by_id = {n["id"]: n for n in result["nodes"]}
+    assert by_id["src"]["degree"] == 1
+    assert by_id["steve-krug"]["degree"] == 1
+
+
+def test_get_graph_drops_title_form_wikilink_with_no_matching_slug(session):
+    # Negative companion to the title-form resolution test: when the
+    # slugified target still doesn't match any visible note, the edge
+    # is dropped — slug normalization must not invent phantom edges.
+    store = KnowledgeStore(session)
+    _upsert(
+        store,
+        note_id="src",
+        path="src.md",
+        content_hash="h-src",
+        title="Source",
+        metadata=_meta(title="Source", type="atom"),
+        # No note with note_id="steve-krug" exists.
+        links=[Link(target="Steve Krug", display=None)],
+    )
+
+    result = store.get_graph()
+
+    assert any(n["id"] == "src" for n in result["nodes"])
+    assert result["edges"] == []
+
+
 def test_get_graph_returns_empty_for_empty_session(session):
     store = KnowledgeStore(session)
 


### PR DESCRIPTION
## Summary

- `KnowledgeStore.get_graph` and the layout pass were comparing raw `NoteLink.target_id` (user-typed wikilink text, e.g. `"Steve Krug"`) against a set of slug-form `note_id`s (`"steve-krug"`), so every inbound edge to a gap stub was silently dropped. Gap nodes appeared on the canvas but with no adjacency; FA2 classified them as orphans and the orphan-ring branch yeeted them to the perimeter.
- Fix: slugify both sides of the membership check (same `_slugify` helper `gaps.discover_gaps` already uses to resolve unresolved wikilinks into stubs) and rewrite the returned edge's `target` to the canonical `note_id` so degree counts and frontend node-id joins stay coherent.
- No phantom edges: when the slugified target still doesn't match any visible note, the edge is dropped — same invariant as before, just less strict on casing.

## Test plan

- [ ] CI green on BuildBuddy
- [ ] Positive regression: `Link(target="Steve Krug")` → `Note(note_id="steve-krug", type="gap")` produces edge with `target="steve-krug"`, degree=1 on both endpoints
- [ ] Negative regression: title-form target with no matching slug stays dropped (no phantom edges)
- [ ] Existing `test_get_graph_drops_edges_with_unresolved_targets` still green (slug "nonexistent" still doesn't match)
- [ ] After deploy, observe gap nodes appearing inside the FA2 core (not on the orphan ring) at the next reconcile cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)