### PR TITLE
chore(claude): drop coderabbit plugin, raise skill listing budget

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -107,7 +107,7 @@
     "frontend-design@claude-plugins-official": true,
     "github@claude-plugins-official": true,
     "playwright@claude-plugins-official": true,
-    "coderabbit@claude-plugins-official": true,
     "impeccable@impeccable": true
-  }
+  },
+  "skillListingBudgetFraction": 0.02
 }

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.72.5
+version: 0.72.6
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.72.5
+      targetRevision: 0.72.6
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
## Summary
- Remove `coderabbit@claude-plugins-official` from `enabledPlugins` in `.claude/settings.json` — already locally disabled with a stale install record, was causing `/doctor` to flag "Plugin not cached at (not recorded)" every session.
- Add `skillListingBudgetFraction: 0.02` (doubled from the default `0.01`). With 17+ enabled plugins, `/doctor` reports ~32 skill descriptions being truncated from listings to fit the 1% budget. Doubling recovers most/all of them at ~3k extra tokens of context per session.

`skillListingBudgetFraction` is undocumented in the public Claude Code settings reference but appears in `/doctor` output as a tunable, and Claude Code merges project-scoped settings with user-global config, so placing it here lets it travel with the repo.

## Test plan
- [ ] CI green
- [ ] After merge, pull main locally, run `/doctor` — expect zero plugin errors and the skill-truncation warning to either disappear or show fewer drops.
- [ ] Run `/status` to confirm the new fraction is active.

🤖 Generated with [Claude Code](https://claude.com/claude-code)