### PR TITLE
chore(monolith): bump chart version to 0.72.7

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.72.6
+version: 0.72.7
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.72.6
+      targetRevision: 0.72.7
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
chart-version-bot bumped to 0.72.6 in \`2a481dc64\` *before* the layout-v2 code merge (\`b02b70cd0\`) landed. The OCI chart at 0.72.6 was therefore built without the new layout code; ArgoCD pulls 0.72.6 and gets the old chart. Bot didn't auto-bump after \`b02b70cd0\` because the version field hadn't changed.

Manual bump to force a fresh chart push with the layout-v2 code.