### PR TITLE
fix(knowledge): hide labels at default zoom; only show when actively zoomed in

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.72.7
+version: 0.72.8
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.72.7
+      targetRevision: 0.72.8
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/lib/components/notes/KnowledgeGraph.svelte
+++ b/projects/monolith/frontend/src/lib/components/notes/KnowledgeGraph.svelte
@@ -51,7 +51,14 @@
     hubBoost: 0.325,
     edgeOpacity: 0.16,
     edgeOpacityActive: 0.85,
-    labelMinZoom: 1.2,
+    // Labels turn on only when the user has actively zoomed in past
+    // any default-fit state. ``fitToBbox()`` caps initial zoom at 1.5×
+    // (see line ~548), so this threshold sits clearly above that —
+    // default page-load shows zero labels regardless of layout size,
+    // selection still gets a label always, search still labels its
+    // matches, and zooming in past 1.6× turns on the high-degree
+    // visible-node labels.
+    labelMinZoom: 1.6,
     labelMaxCount: 60,
   };
 


### PR DESCRIPTION
## Summary

User feedback: at default zoom, the canvas was cluttered with ~50 high-degree node labels even with no selection or search active. Bumped \`labelMinZoom\` from \`1.2\` to \`1.6\` — clearly above the \`fitToBbox\` cap of \`1.5x\` — so default page load reliably hides labels regardless of layout size.

Selection still labels the selected node + neighbors, search still labels matches, and zooming in past 1.6x re-enables the high-degree visible-node labels.

## Test plan

- [ ] CI green
- [ ] Manual: confirm \`/private/notes\` default-zoom shows zero labels
- [ ] Manual: clicking a node still highlights it + immediate neighbors
- [ ] Manual: searching still labels matching nodes
- [ ] Manual: scrolling/zooming in past 1.6x re-shows hub labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)