### PR TITLE
fix(knowledge): run layout pass off the asyncio loop

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.72.9
+version: 0.72.10
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.72.9
+      targetRevision: 0.72.10
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/knowledge/layout_test.py
+++ b/projects/monolith/knowledge/layout_test.py
@@ -210,6 +210,40 @@ class TestComputeLayout:
                     f"{ids[i]} and {ids[j]} overlap: distance={d}, min={2 * r}"
                 )
 
+    def test_compute_layout_handles_coincident_priors(self):
+        """Two nodes seeded at exactly the same point are pushed apart.
+
+        FA2 with identical prior positions can produce coincident output
+        centers; the vectorized collide pass must invent a finite push
+        direction (rather than dividing by zero) and separate them. This
+        exercises the ``d2 == 0`` branch in :func:`_resolve_overlaps`.
+        """
+        nodes = [
+            _node("a", 0.0, 0.0),
+            _node("b", 0.0, 0.0),
+            _node("c", 0.0, 0.0),
+        ]
+        edges = [EdgeRef("a", "b"), EdgeRef("b", "c"), EdgeRef("a", "c")]
+        params = LayoutParams(seed=42)
+
+        positions = compute_layout(nodes, edges, params)
+
+        assert set(positions.keys()) == {"a", "b", "c"}
+        assert _all_finite(positions)
+        # The collide pass should have separated all pairs by at least the
+        # sum of their render radii (degree=2 for every node here).
+        r = _expected_radius(2)
+        eps = 1e-6
+        ids = list(positions)
+        for i in range(len(ids)):
+            for j in range(i + 1, len(ids)):
+                xa, ya = positions[ids[i]]
+                xb, yb = positions[ids[j]]
+                d = math.hypot(xa - xb, ya - yb)
+                assert d >= 2 * r - eps, (
+                    f"{ids[i]} and {ids[j]} overlap: distance={d}, min={2 * r}"
+                )
+
 
 class TestLayoutParamsValidation:
     def test_validates_positive_max_iter(self):

--- a/projects/monolith/knowledge/layout_test.py
+++ b/projects/monolith/knowledge/layout_test.py
@@ -210,40 +210,6 @@ class TestComputeLayout:
                     f"{ids[i]} and {ids[j]} overlap: distance={d}, min={2 * r}"
                 )
 
-    def test_compute_layout_handles_coincident_priors(self):
-        """Two nodes seeded at exactly the same point are pushed apart.
-
-        FA2 with identical prior positions can produce coincident output
-        centers; the vectorized collide pass must invent a finite push
-        direction (rather than dividing by zero) and separate them. This
-        exercises the ``d2 == 0`` branch in :func:`_resolve_overlaps`.
-        """
-        nodes = [
-            _node("a", 0.0, 0.0),
-            _node("b", 0.0, 0.0),
-            _node("c", 0.0, 0.0),
-        ]
-        edges = [EdgeRef("a", "b"), EdgeRef("b", "c"), EdgeRef("a", "c")]
-        params = LayoutParams(seed=42)
-
-        positions = compute_layout(nodes, edges, params)
-
-        assert set(positions.keys()) == {"a", "b", "c"}
-        assert _all_finite(positions)
-        # The collide pass should have separated all pairs by at least the
-        # sum of their render radii (degree=2 for every node here).
-        r = _expected_radius(2)
-        eps = 1e-6
-        ids = list(positions)
-        for i in range(len(ids)):
-            for j in range(i + 1, len(ids)):
-                xa, ya = positions[ids[i]]
-                xb, yb = positions[ids[j]]
-                d = math.hypot(xa - xb, ya - yb)
-                assert d >= 2 * r - eps, (
-                    f"{ids[i]} and {ids[j]} overlap: distance={d}, min={2 * r}"
-                )
-
 
 class TestLayoutParamsValidation:
     def test_validates_positive_max_iter(self):

--- a/projects/monolith/knowledge/service.py
+++ b/projects/monolith/knowledge/service.py
@@ -10,9 +10,9 @@ from pathlib import Path
 from dulwich import porcelain
 
 from sqlalchemy import select, update
+from sqlalchemy.engine import Engine
 from sqlmodel import Session
 
-from app.db import get_engine
 from knowledge.gardener import _slugify
 from knowledge.layout import EdgeRef, LayoutParams, NodePos, compute_layout
 from knowledge.models import Note, NoteLink
@@ -179,20 +179,23 @@ async def garden_handler(session: Session) -> datetime | None:
     return None
 
 
-def _run_layout_pass() -> tuple[int, int, int]:
+def _run_layout_pass(engine: Engine) -> tuple[int, int, int]:
     """Compute layout positions for the current graph and persist them.
 
-    Opens its own DB session so the work can be dispatched onto a worker
-    thread via ``asyncio.to_thread`` without sharing SQLAlchemy state
-    with the caller's loop-thread session. Mirrors
-    ``KnowledgeStore.get_graph``'s edge filter (only edges where both
-    endpoints map to known note_ids) so positions and degrees stay
-    coherent with what the API ships. Caller is responsible for
-    catching exceptions and translating them to structured log events.
+    Opens its own SQLAlchemy session bound to the caller-supplied engine
+    so the work can be dispatched onto a worker thread via
+    ``asyncio.to_thread`` without sharing the loop-thread session.
+    Engines are thread-safe (the connection pool lives on them); sessions
+    are not, which is why the caller passes ``session.get_bind()``
+    instead of the session itself. Mirrors ``KnowledgeStore.get_graph``'s
+    edge filter (only edges where both endpoints map to known note_ids)
+    so positions and degrees stay coherent with what the API ships.
+    Caller is responsible for catching exceptions and translating them
+    to structured log events.
     """
     params = LayoutParams.from_env()
 
-    with Session(get_engine()) as session:
+    with Session(engine) as session:
         note_rows = session.execute(
             select(Note.id, Note.note_id, Note.layout_x, Note.layout_y)
         ).all()
@@ -270,11 +273,13 @@ async def reconcile_handler(session: Session) -> datetime | None:
     # CPU-bound (FA2 + the hard-collide pass); running it on the asyncio
     # loop blocked uvicorn for >20s on the live graph and tripped the
     # ``/healthz`` liveness probe, which surfaced as 5xx on the notes
-    # page. ``_run_layout_pass`` opens its own SQLAlchemy session so no
-    # session is shared across threads.
+    # page. ``_run_layout_pass`` opens its own SQLAlchemy session bound
+    # to the caller's engine — engines are thread-safe, sessions are not.
     start = time.perf_counter()
     try:
-        node_count, edge_count, positioned = await asyncio.to_thread(_run_layout_pass)
+        node_count, edge_count, positioned = await asyncio.to_thread(
+            _run_layout_pass, session.get_bind()
+        )
     except Exception:  # noqa: BLE001 — layout failure must not affect reconcile result
         logger.exception("knowledge.layout: pass failed")
     else:

--- a/projects/monolith/knowledge/service.py
+++ b/projects/monolith/knowledge/service.py
@@ -1,5 +1,6 @@
 """Startup hook that registers the knowledge scheduled jobs."""
 
+import asyncio
 import logging
 import os
 import time
@@ -11,6 +12,7 @@ from dulwich import porcelain
 from sqlalchemy import select, update
 from sqlmodel import Session
 
+from app.db import get_engine
 from knowledge.gardener import _slugify
 from knowledge.layout import EdgeRef, LayoutParams, NodePos, compute_layout
 from knowledge.models import Note, NoteLink
@@ -177,61 +179,63 @@ async def garden_handler(session: Session) -> datetime | None:
     return None
 
 
-def _run_layout_pass(session: Session) -> tuple[int, int, int]:
+def _run_layout_pass() -> tuple[int, int, int]:
     """Compute layout positions for the current graph and persist them.
 
-    Commits via the passed-in session. Caller MUST commit any prior
-    uncommitted state first — see reconcile_handler's pre-layout
-    ``session.commit()``. Otherwise the reconciler upserts and the
-    layout writes share a transaction, and a layout failure would roll
-    back the upserts too. Caller is also responsible for catching
-    exceptions and translating them to structured log events. Mirrors
+    Opens its own DB session so the work can be dispatched onto a worker
+    thread via ``asyncio.to_thread`` without sharing SQLAlchemy state
+    with the caller's loop-thread session. Mirrors
     ``KnowledgeStore.get_graph``'s edge filter (only edges where both
     endpoints map to known note_ids) so positions and degrees stay
-    coherent with what the API ships.
+    coherent with what the API ships. Caller is responsible for
+    catching exceptions and translating them to structured log events.
     """
     params = LayoutParams.from_env()
 
-    note_rows = session.execute(
-        select(Note.id, Note.note_id, Note.layout_x, Note.layout_y)
-    ).all()
-    fk_to_note_id: dict[int, str] = {r.id: r.note_id for r in note_rows}
-    nodes = [
-        NodePos(id=r.note_id, prior_x=r.layout_x, prior_y=r.layout_y) for r in note_rows
-    ]
+    with Session(get_engine()) as session:
+        note_rows = session.execute(
+            select(Note.id, Note.note_id, Note.layout_x, Note.layout_y)
+        ).all()
+        fk_to_note_id: dict[int, str] = {r.id: r.note_id for r in note_rows}
+        nodes = [
+            NodePos(id=r.note_id, prior_x=r.layout_x, prior_y=r.layout_y)
+            for r in note_rows
+        ]
 
-    edge_rows = session.execute(select(NoteLink.src_note_fk, NoteLink.target_id)).all()
-    note_id_set = set(fk_to_note_id.values())
-    # Mirror ``KnowledgeStore.get_graph``'s slug-normalize-then-resolve
-    # logic. Body wikilinks store ``target_id`` as raw user-typed text
-    # (``"Steve Krug"``); gap stubs and ``_processed`` notes carry
-    # ``note_id`` in slug form. Without this normalization FA2 treats
-    # gap edges as missing and the gap nodes get no position from
-    # ``compute_layout`` (the API then drops them as orphans).
-    slug_to_note_id = {_slugify(nid): nid for nid in note_id_set}
-    edges: list[EdgeRef] = []
-    for r in edge_rows:
-        if r.src_note_fk not in fk_to_note_id:
-            continue
-        canonical_target = slug_to_note_id.get(_slugify(r.target_id))
-        if canonical_target is None:
-            continue
-        edges.append(
-            EdgeRef(source=fk_to_note_id[r.src_note_fk], target=canonical_target)
-        )
-
-    positions = compute_layout(nodes, edges, params)
-
-    if positions:
-        for note_id, (x, y) in positions.items():
-            session.execute(
-                update(Note)
-                .where(Note.note_id == note_id)
-                .values(layout_x=x, layout_y=y)
+        edge_rows = session.execute(
+            select(NoteLink.src_note_fk, NoteLink.target_id)
+        ).all()
+        note_id_set = set(fk_to_note_id.values())
+        # Mirror ``KnowledgeStore.get_graph``'s slug-normalize-then-resolve
+        # logic. Body wikilinks store ``target_id`` as raw user-typed text
+        # (``"Steve Krug"``); gap stubs and ``_processed`` notes carry
+        # ``note_id`` in slug form. Without this normalization FA2 treats
+        # gap edges as missing and the gap nodes get no position from
+        # ``compute_layout`` (the API then drops them as orphans).
+        slug_to_note_id = {_slugify(nid): nid for nid in note_id_set}
+        edges: list[EdgeRef] = []
+        for r in edge_rows:
+            if r.src_note_fk not in fk_to_note_id:
+                continue
+            canonical_target = slug_to_note_id.get(_slugify(r.target_id))
+            if canonical_target is None:
+                continue
+            edges.append(
+                EdgeRef(source=fk_to_note_id[r.src_note_fk], target=canonical_target)
             )
-        session.commit()
 
-    return len(nodes), len(edges), len(positions)
+        positions = compute_layout(nodes, edges, params)
+
+        if positions:
+            for note_id, (x, y) in positions.items():
+                session.execute(
+                    update(Note)
+                    .where(Note.note_id == note_id)
+                    .values(layout_x=x, layout_y=y)
+                )
+            session.commit()
+
+        return len(nodes), len(edges), len(positions)
 
 
 async def reconcile_handler(session: Session) -> datetime | None:
@@ -257,16 +261,21 @@ async def reconcile_handler(session: Session) -> datetime | None:
         },
     )
 
-    # Persist reconciler upserts before the layout step so layout failure
-    # can never roll back upsert state. The scheduler will commit again on
-    # return; the second commit is a no-op.
+    # Persist reconciler upserts before the layout step so the layout
+    # pass — which opens its own session in a worker thread — sees the
+    # upserts via the committed snapshot.
     session.commit()
 
+    # Dispatch the layout pass to a worker thread. ``compute_layout`` is
+    # CPU-bound (FA2 + the hard-collide pass); running it on the asyncio
+    # loop blocked uvicorn for >20s on the live graph and tripped the
+    # ``/healthz`` liveness probe, which surfaced as 5xx on the notes
+    # page. ``_run_layout_pass`` opens its own SQLAlchemy session so no
+    # session is shared across threads.
     start = time.perf_counter()
     try:
-        node_count, edge_count, positioned = _run_layout_pass(session)
+        node_count, edge_count, positioned = await asyncio.to_thread(_run_layout_pass)
     except Exception:  # noqa: BLE001 — layout failure must not affect reconcile result
-        session.rollback()  # clear any aborted txn so the scheduler's commit doesn't blow up
         logger.exception("knowledge.layout: pass failed")
     else:
         logger.info(

--- a/projects/monolith/knowledge/service_test.py
+++ b/projects/monolith/knowledge/service_test.py
@@ -831,7 +831,13 @@ class TestReconcileHandlerLayout:
     async def test_reconcile_handler_layout_failure_does_not_roll_back_upserts(
         self, monkeypatch, tmp_path, session, fake_embed_client, caplog
     ):
-        """Layout exception is caught; upsert state is preserved."""
+        """Layout exception is caught; reconcile upsert state is preserved.
+
+        ``_run_layout_pass`` runs on a worker thread with its own DB
+        session, so any failure inside it cannot poison the caller's
+        session. The handler still has to log the exception and return
+        cleanly so the scheduler treats the reconcile run as successful.
+        """
         from knowledge.models import Note
 
         monkeypatch.setenv("VAULT_ROOT", str(tmp_path))
@@ -842,7 +848,7 @@ class TestReconcileHandlerLayout:
             "---\nid: a\ntitle: A\n---\nBody.",
         )
 
-        def boom(_session):
+        def boom():
             raise RuntimeError("boom")
 
         # Patch at the import target — same module the handler resolves
@@ -864,68 +870,6 @@ class TestReconcileHandlerLayout:
         assert len(notes) == 1
         assert notes[0].note_id == "a"
         # And the layout pass didn't run, so positions are still None.
-        assert notes[0].layout_x is None
-        assert notes[0].layout_y is None
-
-    @pytest.mark.asyncio
-    async def test_reconcile_handler_layout_failure_after_partial_writes_rolls_back(
-        self, monkeypatch, tmp_path, session, fake_embed_client, caplog
-    ):
-        """Layout that issues an UPDATE then raises must roll back cleanly.
-
-        Exercises the post-rollback contract: the layout pass writes one
-        Note row's layout_x/layout_y, then raises. Without
-        ``session.rollback()`` in the except branch, Postgres would mark
-        the txn aborted and the scheduler's subsequent ``_complete_job``
-        commit would raise ``PendingRollbackError`` — misattributing the
-        layout failure as a reconcile failure. With the rollback the
-        partial UPDATE is discarded and reconcile_handler returns
-        cleanly; the test note's layout_x/layout_y stay None.
-        """
-        from sqlalchemy import update
-
-        from knowledge.models import Note
-
-        monkeypatch.setenv("VAULT_ROOT", str(tmp_path))
-        self._setup_vault(tmp_path)
-        self._write_note(
-            tmp_path,
-            "a.md",
-            "---\nid: a\ntitle: A\n---\nBody.",
-        )
-
-        def boom_after_update(s):
-            # Issue a real UPDATE through the same session, then raise.
-            # Without rollback the next session.commit() (scheduler's)
-            # would surface PendingRollbackError under Postgres.
-            s.execute(
-                update(Note)
-                .where(Note.note_id == "a")
-                .values(layout_x=9.9, layout_y=8.8)
-            )
-            raise RuntimeError("boom-after-update")
-
-        monkeypatch.setattr("knowledge.service._run_layout_pass", boom_after_update)
-
-        with (
-            patch("knowledge.service.EmbeddingClient", return_value=fake_embed_client),
-            caplog.at_level(logging.ERROR, logger="knowledge.service"),
-        ):
-            result = await service.reconcile_handler(session)
-
-        # The handler returned cleanly and logged the failure.
-        assert result is None
-        assert any("knowledge.layout: pass failed" in r.message for r in caplog.records)
-
-        # A subsequent commit must succeed — i.e. the session is no
-        # longer in an aborted state. This is the key regression check:
-        # without the rollback, this commit would raise.
-        session.commit()
-
-        # Partial UPDATE was rolled back: layout positions stay None.
-        notes = list(session.scalars(select(Note)))
-        assert len(notes) == 1
-        assert notes[0].note_id == "a"
         assert notes[0].layout_x is None
         assert notes[0].layout_y is None
 

--- a/projects/monolith/knowledge/service_test.py
+++ b/projects/monolith/knowledge/service_test.py
@@ -848,7 +848,7 @@ class TestReconcileHandlerLayout:
             "---\nid: a\ntitle: A\n---\nBody.",
         )
 
-        def boom():
+        def boom(_engine):
             raise RuntimeError("boom")
 
         # Patch at the import target — same module the handler resolves


### PR DESCRIPTION
## Summary

- The reconcile handler called `_run_layout_pass` synchronously, running FA2 + the hard-collide pass on uvicorn's asyncio loop. On the live graph (~3.5k nodes) FA2 alone burned 10-15s of CPU, blocking `/healthz` long enough to trip the liveness probe; concurrent notes-page requests surfaced as 5xx at the ingress.
- Move the pass onto a worker thread via `asyncio.to_thread` and have it open its own SQLAlchemy session so no session is shared across threads.
- Layout algorithm is **unchanged** — `layout.py` is byte-identical to `main`. Benchmark on the live graph showed the Python collide loop completes in ~1s and a numpy rewrite was actually slower because per-cell array overhead loses to Python's short-circuit on already-spread points.

## Diagnostic evidence

The Discord heartbeat watchdog caught the loop blocked >20s with this traceback:

```
WARNING discord.gateway: Shard ID None heartbeat blocked for more than 20 seconds.
  File ".../knowledge/service.py", line 267, in reconcile_handler
    node_count, edge_count, positioned = _run_layout_pass(session)
  File ".../knowledge/layout.py", line 302, in compute_layout
    raw = nx.forceatlas2_layout(g, **kwargs)
```

…immediately followed by `Liveness probe failed: ... context deadline exceeded`. Pod had 1 restart in 82m, matching the bursty 5xx pattern (reconcile runs every 5 min, blocks for 10-20s).

## Test plan

- [ ] CI green on this branch
- [ ] After ArgoCD rolls the new pod, no `heartbeat blocked` warnings in `kubectl logs -n monolith deploy/monolith -c backend --since=20m`
- [ ] No new pod restarts across 2-3 reconcile cycles (~15 min)
- [ ] `knowledge.layout: pass succeeded` log lines still appear with reasonable `duration_ms`
- [ ] `/healthz` returns 200 within 1s even during a reconcile window
- [ ] Notes page returns 200 consistently (no bursty 5xx)

🤖 Generated with [Claude Code](https://claude.com/claude-code)