### PR TITLE
feat(knowledge): visibility labels and public API surface (V1)

### DIFF
--- a/docs/plans/2026-05-07-public-notes-visibility-design.md
+++ b/docs/plans/2026-05-07-public-notes-visibility-design.md
@@ -1,0 +1,395 @@
+# Public Notes — Visibility Labels & Public Surface
+
+**Date:** 2026-05-07
+**Status:** Design approved; implementation plan to follow.
+**Author:** Joe + Claude (brainstorming session)
+
+## Goal
+
+Add a `visibility: public | private` label to every note so a strict, opt-in
+subset of the knowledge graph can be exposed on the public website without
+leaking PII about Joe, his colleagues, his job search, or his personal life.
+
+The vault stays canonical. The DB mirrors visibility for cheap filtered
+queries. The labelling is LLM-driven from a shared, precise criteria block.
+Defaults are conservative: anything unlabelled is treated as private.
+
+## Phasing
+
+- **V1 — Backend wiring (this design).**
+  Schema + frontmatter + reconciler + prompt updates + public API + two
+  vault-mutation scripts (mechanical add, then LLM backfill). No frontend
+  changes; the existing private notes page is untouched.
+- **V2 — Public notes page (separate plan).** SvelteKit page under
+  `routes/public/notes/` consuming the V1 public API.
+- **V3 — Public chat (separate plan).** KG-animated chat backed by qwen,
+  with strict rate limits on the public surface.
+
+## Locked-in decisions
+
+| Decision                              | Choice                                                                         | Rationale                                                                                                          |
+| ------------------------------------- | ------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------ |
+| Source of truth                       | Frontmatter canonical, DB column mirrors                                       | Vault stays self-describing; SQL filtering stays cheap; same shape as `status`.                                    |
+| State space                           | Binary `public \| private`, null = private                                     | Keeps prompts and routes simple. `needs_review` deferred unless classifier confidence proves to be a real problem. |
+| Public render of `[[private-target]]` | Strip wikilink to plain text; drop the edge from the public graph              | Renderer-side stripping; bracket text leak accepted (low likelihood of acute PII inside link names).               |
+| Migration                             | Phase 1 mechanical-add (idempotent), then Phase 2 LLM backfill (single commit) | Phase 1 unblocks all backend code work; Phase 2 yields a single revertable vault diff.                             |
+| Backfill report                       | Written outside the working tree (e.g. `/tmp/`)                                | Rationales quote note content; never committed.                                                                    |
+| Public API namespace                  | `/api/knowledge/public/...`                                                    | Cache + auth divergence is obvious from the URL.                                                                   |
+
+## Data model
+
+### Migration
+
+`chart/migrations/YYYYMMDDHHMMSS_knowledge_notes_visibility.sql`:
+
+```sql
+ALTER TABLE knowledge.notes
+  ADD COLUMN visibility text NULL;
+
+ALTER TABLE knowledge.notes
+  ADD CONSTRAINT notes_visibility_chk
+  CHECK (visibility IS NULL OR visibility IN ('public', 'private'));
+
+CREATE INDEX notes_visibility_idx
+  ON knowledge.notes (visibility)
+  WHERE visibility = 'public';
+```
+
+Partial index because the public set is the small, hot read path; private/null
+reads do not need it.
+
+### `Note` SQLModel (`projects/monolith/knowledge/models.py`)
+
+```python
+Visibility = Literal["public", "private"]
+
+class Note(SQLModel, table=True):
+    ...
+    visibility: Visibility | None = Field(
+        default=None, sa_column=Column(String, nullable=True)
+    )
+```
+
+### Frontmatter parser (`projects/monolith/knowledge/frontmatter.py`)
+
+- Add `"visibility"` to `_PROMOTED_KEYS`.
+- Add `visibility: str | None = None` to `ParsedFrontmatter`.
+- `meta.visibility = _str_or_none(data.get("visibility"))` in `_build`.
+- Validate value is `public` / `private` / empty; **warn-and-treat-as-null** on
+  anything else. Never fail the parse — bad classifier output must not break
+  ingest.
+
+### Reconciler / store
+
+Wherever `status` is written from `ParsedFrontmatter` to `Note` in
+`store.py`, write `visibility` the same way. Frontmatter-canonical means every
+reconcile resyncs the DB from disk.
+
+### Coalescing rule
+
+Codified once in `knowledge/visibility.py`:
+
+```python
+def effective_visibility(note: Note) -> Literal["public", "private"]:
+    return note.visibility or "private"
+```
+
+Never inlined elsewhere — flipping the default later is a one-line change.
+
+## Visibility criteria (the load-bearing artifact)
+
+Lives in a new module `projects/monolith/knowledge/visibility.py` and is
+imported by every prompt that emits frontmatter and by the backfill script.
+Single source of truth — drift is the most common way these things go wrong.
+
+```python
+VISIBILITY_CRITERIA = """\
+## Visibility (REQUIRED frontmatter field)
+
+Every note MUST set `visibility: public` or `visibility: private`.
+This controls whether the note appears on Joe's public website.
+
+Default to `private` whenever you are uncertain.
+
+Mark `public` when the note is about:
+- General engineering concepts, principles, heuristics (DORA, Conway's Law,
+  blameless postmortems, etc.) — anything you'd find in a textbook, blog,
+  or conference talk.
+- Skills, technologies, or methods covered in Joe's public CV / GitHub /
+  conference talks.
+- Verifiable facts about external systems, libraries, protocols, or tools.
+- Book / paper / talk summaries when the source is publicly available.
+
+Mark `private` when the note involves any of:
+- Names of current or former colleagues, managers, reports, or interviewers.
+- Specific employers in non-public ways: project codenames, internal
+  architecture, compensation, performance reviews, hiring decisions.
+- Job-search activity: interview prep, comp negotiation, target companies,
+  reasons-for-leaving, offer comparisons.
+- Personal life: family, finances, health, relationships, legal matters,
+  living situation.
+- Critiques or hot takes about identifiable people or companies that
+  aren't already in Joe's public writing.
+- Active tasks, daily/weekly journals, blockers — anything operational
+  about Joe's current work.
+
+Edge cases:
+- An atom about a generally-applicable pattern that includes a
+  workplace-specific example: rewrite the example out and mark public,
+  OR keep the example and mark private. Do not mark public with the
+  example intact.
+- A fact about an external library mentioned during a private incident:
+  the fact is public, the incident framing is private — split into two
+  notes if needed.
+
+When in doubt: `private`.
+"""
+```
+
+## Prompt updates
+
+- **Gardener atom prompt** (`gardener.py` `_CLAUDE_PROMPT_HEADER`) — append
+  `VISIBILITY_CRITERIA`; add `visibility: public|private` to the required
+  frontmatter template, before `tags:`.
+- **Gardener distill prompt** (`_DISTILL_PROMPT`) — same: append criteria, add
+  `visibility:` to the required-fields list. Distilled task notes will
+  usually steer to `private`.
+- **Research writer** (`research_writer.py` `write_research_raw`) — set
+  `"visibility": "public"` directly in the frontmatter dict for `type:
+research` raws. The downstream gardener still re-classifies during
+  decomposition; this is a hint, not a guarantee.
+- **Manual edit endpoint** (`router.py` `PUT /api/knowledge/notes/{id}`) — no
+  code change; frontmatter passes through. Add one round-trip test to
+  guarantee the field survives.
+
+**Not changed:** the gap-classifier prompt (`gap_classifier.py`). It emits
+`external | internal | hybrid | parked` for _gaps_, a different axis from
+visibility. Conflating the two is the bug recorded in
+`memory/project_kg_gap_drain.md`.
+
+## Vault migration scripts
+
+Both live under `projects/monolith/knowledge/tools/` as Bazel `py_binary`
+targets. Both operate on the vault filesystem only — no DB writes; the
+reconciler picks up the resulting frontmatter changes on its next pass.
+
+### Phase 1 — `add_visibility_field` (mechanical, no LLM)
+
+```
+bazel run //projects/monolith/knowledge/tools:add_visibility_field -- \
+  --vault-root /path/to/vault --dirs _processed
+```
+
+- Walks configured dirs (default `_processed`).
+- For each `.md`: parse via `frontmatter.parse()`. If `visibility` already
+  present, skip. Otherwise insert `visibility:` (empty) into the YAML block,
+  preserving existing key order. Atomic temp-file + rename.
+- Insertion uses an in-place line edit on the raw frontmatter block (not a
+  full `yaml.dump` round-trip) so the diff stays small and auditable.
+- Idempotent.
+- Single commit on the vault repo when done.
+- **Unblocks all backend code work** — schema, parser, public routes can
+  land in parallel before Phase 2 runs.
+
+### Phase 2 — `classify_visibility_backfill` (LLM, single commit)
+
+```
+bazel run //projects/monolith/knowledge/tools:classify_visibility_backfill -- \
+  --vault-root /path/to/vault --report /tmp/visibility-report.json
+```
+
+- Walks `_processed/`, finds notes with null/empty `visibility`.
+- One LLM call per note via the `claude` CLI subprocess (per
+  `memory/feedback_claude_cli_subprocess_for_tos.md` — never the Anthropic
+  SDK). Prompt = `VISIBILITY_CRITERIA` + the note's title + tags + body.
+  Strict JSON-mode response: `{"visibility": "public"|"private",
+"rationale": "..."}`.
+- Parse failure / non-zero exit / timeout → leave the file unchanged, log
+  the failure in the report, default to `private` only if the script is
+  forced to set a value (it is not — the file just stays unlabelled and
+  the next run picks it up).
+- Internally batched with concurrency cap for crash recovery; **no per-batch
+  commits**. All label changes accumulate on disk; Joe commits the entire
+  labelled vault in one commit.
+- Report path is required and must be **outside the repo working tree**
+  (script enforces; refuses to write inside the repo). Recommended:
+  `/tmp/visibility-report.json`.
+- Resumable: re-running picks up only the still-unlabelled notes.
+
+**Revert plan:** `git revert <backfill-sha>` on the vault repo rolls back
+every label; tune criteria; re-run.
+
+## Public API surface
+
+Two new endpoints in `projects/monolith/knowledge/router.py`, mounted under
+`/api/knowledge/public/...`. Separate namespace (vs query-param filtering on
+existing routes) so:
+
+- Cache headers diverge cleanly (public can cache much longer at the edge).
+- Authn middleware can be added to the non-`/public/` routes without
+  touching these.
+- The URL itself documents what is exposed externally.
+
+### `GET /api/knowledge/public/graph`
+
+- Same JSON shape as `GET /api/knowledge/graph`, filtered.
+- Nodes: `WHERE COALESCE(visibility, 'private') = 'public'`.
+- Edges (`note_links`): both endpoints public — single SQL join on `notes`
+  for `src` and `target`. The partial index does work here.
+- Stub / gap nodes: excluded entirely (they leak the existence of
+  unresolved private wikilinks).
+- Cache: `public, s-maxage=3600, stale-while-revalidate=86400,
+stale-if-error=31536000` (mirroring the existing `_GRAPH_CACHE_CONTROL`).
+- ETag: derived from `(public_node_count, max(indexed_at) over public)`
+  (mirrors `_graph_etag`).
+
+### `GET /api/knowledge/public/notes/{note_id}`
+
+- 200 with sanitized body for public notes.
+- **404 (identical response) for both "doesn't exist" and "exists but
+  private"** — never expose existence.
+- Body sanitization (server-side, before serialization):
+  - Find every `[[...]]` wikilink in the body.
+  - Resolve targets via the existing slug + alias lookup.
+  - If target is private OR unresolved (gap), strip the wikilink to plain
+    text — keep the bracket contents minus the brackets. Bracket-text leak
+    accepted in the design.
+  - Implementation: `sanitize_public_body(body, private_target_ids)` in
+    `visibility.py`, fully unit-testable with no DB.
+- Up-front per-request query: `SELECT note_id FROM notes WHERE
+COALESCE(visibility, 'private') = 'private'` → in-memory check during
+  sanitization. Acceptable for V1; can target by linked-id later if it
+  shows up in profiling.
+- Response payload: same shape as the private endpoint minus internal-only
+  fields. Audit before merge to confirm no `extra` JSONB blob leaks.
+
+### Helper module — `projects/monolith/knowledge/visibility.py`
+
+- `VISIBILITY_CRITERIA` — the prompt block above.
+- `effective_visibility(note) -> Literal["public", "private"]` — coalescing.
+- `sanitize_public_body(body, private_target_ids) -> str` — wikilink
+  stripper.
+- `public_graph_filter()` — SQLAlchemy clause / SQL fragment for the join
+  filter.
+
+Public routes call **only** into this helper for the visibility gate; no
+scattered `if visibility == 'public'` checks anywhere else in the codebase.
+
+### Not exposed publicly in V1
+
+- `GET /api/knowledge/search` — embedding-driven; needs visibility-aware
+  chunk filtering and rate limits. Defer to V3 (chat).
+- `GET /gaps`, `/dead-letter`, `/notes/.../edit`, `/ingest`,
+  `POST /notes` — internal/admin.
+
+### Auth posture
+
+- Public routes: no auth, behind Cloudflare per repo convention. Standard
+  edge rate limits.
+- Existing private routes: unchanged. This change introduces no new authn
+  and modifies no existing authn — it only exposes a strictly narrower,
+  filtered subset under a new prefix.
+
+## Testing
+
+All tests land in the V1 PR. Per repo CLAUDE.md, no local test loop —
+implement, commit (Conventional Commits), push the PR branch, monitor via
+`gh pr checks <n> --watch`, iterate via `mcp__buildbuddy__*` on failures.
+
+### Unit
+
+- `frontmatter_test.py` — visibility parsed, validated, warn-don't-fail on
+  bad values (`visibility: yellow` → null + warning); round-trips through
+  `_PROMOTED_KEYS`.
+- `visibility_test.py` (new) — `effective_visibility` coalescing,
+  `sanitize_public_body` for: no links, link to public, link to private,
+  link to unresolved gap, multiple links per line, malformed `[[...]]`.
+- `store_test.py` — reconciler writes `visibility` column from frontmatter
+  on upsert; null frontmatter → null column.
+- `models_test.py` — `Visibility` Literal accepts `public` / `private` /
+  None, rejects others (assert via raw insert against the SQL CHECK).
+
+### Router
+
+- `GET /api/knowledge/public/graph`: only public nodes, only doubly-public
+  edges, no stub/gap nodes, ETag stable across calls, ETag changes when
+  the public set mutates, cache-control header correct.
+- `GET /api/knowledge/public/notes/{id}`: 200 + sanitized body for public,
+  identical 404 for missing and for existing-but-private, no internal
+  `extra` fields leak.
+- Conftest fixture seeds: `pub-A → pub-B` (kept), `pub-A → priv-X` (edge
+  dropped + body wikilink stripped), `priv-Y → pub-A` (entire edge dropped
+  — `priv-Y` not in public graph), gap node (excluded entirely).
+
+### Migration
+
+Existing migration test pattern in `chart/migrations/` — apply check,
+partial index assertion, CHECK constraint round-trip via raw SQL.
+
+### Scripts
+
+- `add_visibility_field_test.py` — idempotent (second run is a no-op),
+  skips already-keyed files, atomic write (mid-run failure does not
+  truncate), parse failure logs + skips.
+- `classify_visibility_backfill_test.py` — mocks `claude` subprocess;
+  strict JSON parse; refuses to write report path inside the working
+  tree; resumability (re-run skips already-labelled).
+
+## Rollout
+
+```
+PR1 (single PR, all V1 code, merges to main)
+  ├─ SQL migration + chart version bump (Chart.yaml + deploy/application.yaml targetRevision)
+  ├─ Note model + Visibility literal
+  ├─ Frontmatter parser changes
+  ├─ Reconciler / store write path
+  ├─ visibility.py: criteria + helpers + sanitizer
+  ├─ Public routes (graph + note-by-id)
+  ├─ Prompt updates (gardener atom + distill, research_writer)
+  ├─ Phase-1 script (add_visibility_field)
+  ├─ Phase-2 script (classify_visibility_backfill)
+  └─ All tests above
+   ↓ merges; ArgoCD syncs; public endpoints live but return empty
+   ↓ (no notes are explicitly public yet)
+
+Phase-1 vault commit (Joe, locally)
+  └─ bazel run //...:add_visibility_field — single commit to vault repo, push
+   ↓ reconciler picks up; DB column populated with nulls; serves as private
+
+Phase-2 vault commit (Joe, locally; whenever)
+  └─ bazel run //...:classify_visibility_backfill — single commit to vault, push
+   ↓ reconciler updates DB; public endpoints start returning content
+   ↓ smoke-test: curl /api/knowledge/public/graph and /api/knowledge/public/notes/<known-public>
+
+V2 (separate plan): SvelteKit page under routes/public/notes/
+V3 (separate plan): chat surface backed by qwen + KG animation
+```
+
+## Operational details
+
+- **Chart version bump:** PR1 modifies `chart/migrations/`, so `Chart.yaml`
+  and `deploy/application.yaml` `targetRevision` must both be bumped (per
+  `feedback_chart_version_bumps.md`). The chart-version-bot will handle
+  this if missed, but the implementer should do it explicitly.
+- **Observability:** public endpoints emit one structured log line per
+  request — `public.graph.served`, `public.note.404` (with internal-only
+  reason: `not_found` vs `private_gated`), `public.note.served`. Useful
+  when an alarming-looking `404_private_gated` rate spikes (= classifier
+  retagged a popular note private).
+- **No RBAC changes:** endpoints only read the DB; no cluster resource
+  reads.
+- **No image-updater changes:** no new images.
+- **Revert path:** revert PR1 → migration's `ADD COLUMN` rolls back via
+  existing migration tooling, partial index goes with it. If Phase 2
+  produces bad labels, `git revert` the vault commit, tune criteria,
+  re-run.
+
+## Out of scope for V1
+
+- Frontend page (V2).
+- Public chat / search / embeddings (V3).
+- Visibility-aware preview while editing in Obsidian.
+- `needs_review` intermediate state — only revisit if classifier
+  confidence proves to be a real problem in the backfill report.
+- Re-classification of already-labelled notes (backfill is null-only).
+- Per-chunk visibility (chunks inherit from parent note).

--- a/docs/plans/2026-05-07-public-notes-visibility-v1-plan.md
+++ b/docs/plans/2026-05-07-public-notes-visibility-v1-plan.md
@@ -1,0 +1,1598 @@
+# Public Notes — Visibility Labels & Public Surface (V1) — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a binary `visibility: public | private` label to every note, expose a strictly filtered public knowledge-graph + note API at `/api/knowledge/public/...`, and ship two vault-mutation scripts (mechanical add + LLM backfill).
+
+**Architecture:** Frontmatter is canonical (the vault); a nullable `visibility` column on `knowledge.notes` mirrors it (null is treated as private). A new `knowledge/visibility.py` module owns the load-bearing artifacts: the criteria prompt block, the coalescing rule, the wikilink sanitizer, and the SQL filter. Two new public endpoints reuse the existing graph/note serializers but route through that single helper. Vault scripts under `knowledge/tools/` migrate disk state in two phases — schema-first (mechanical), values-second (LLM).
+
+**Tech Stack:** Python 3.12, FastAPI, SQLModel + SQLAlchemy, PostgreSQL (Atlas migrations), Bazel + aspect_rules_py, the `claude` CLI subprocess (per `memory/feedback_claude_cli_subprocess_for_tos.md` — never the Anthropic SDK).
+
+**Design doc:** `docs/plans/2026-05-07-public-notes-visibility-design.md` — read it first for full context.
+
+---
+
+## Plan-wide notes
+
+- **No local test loop.** Per `CLAUDE.md`, do not run `bazel test` from the workstation. Each task ends with `git commit`. Verification is the **single PR's CI run** at the end of the plan. The `format` command (vendored, in-direnv) updates BUILD files via gazelle and must be run before every commit that adds a new `.py` file.
+- **Single PR.** All 14 tasks land on the `feat/public-notes-visibility` branch (already created), one PR opened in Task 14.
+- **Code review cadence:** per repo convention, **one** comprehensive code review at end-of-PR, not per-task. Implementer subagents self-review; no per-task reviewer dispatch.
+- **Conventional Commits.** A `commit-msg` hook enforces format. Use `feat`, `fix`, `docs`, `test`, `refactor`, `chore`.
+- **Worktree:** all work happens in `/tmp/claude-worktrees/public-notes-visibility` on branch `feat/public-notes-visibility`.
+- **Frontend untouched.** V2 (SvelteKit page) is a separate plan.
+
+---
+
+## Task 1 — Schema migration
+
+**Files:**
+
+- Create: `projects/monolith/chart/migrations/20260507000000_knowledge_notes_visibility.sql`
+- Modify (auto): `projects/monolith/chart/migrations/atlas.sum` (pre-commit hook regenerates)
+
+**Step 1: Write the migration**
+
+Create `projects/monolith/chart/migrations/20260507000000_knowledge_notes_visibility.sql`:
+
+```sql
+-- Add visibility label so notes can be selectively exposed via the
+-- /api/knowledge/public/* surface. NULL is treated as private at
+-- serving time; an explicit value is required to expose a note.
+ALTER TABLE knowledge.notes
+  ADD COLUMN visibility text NULL;
+
+ALTER TABLE knowledge.notes
+  ADD CONSTRAINT notes_visibility_chk
+  CHECK (visibility IS NULL OR visibility IN ('public', 'private'));
+
+-- Partial index: public set is the small, hot read path; private/null
+-- reads do not need the index.
+CREATE INDEX notes_visibility_idx
+  ON knowledge.notes (visibility)
+  WHERE visibility = 'public';
+```
+
+**Step 2: Run formatter (regenerates `atlas.sum`)**
+
+```bash
+format
+```
+
+The pre-commit hook `Update Atlas migration checksums` will refresh `atlas.sum`. If the hook is not configured, `atlas migrate hash` does the same.
+
+**Step 3: Commit**
+
+```bash
+git add projects/monolith/chart/migrations/20260507000000_knowledge_notes_visibility.sql \
+        projects/monolith/chart/migrations/atlas.sum
+git commit -m "feat(knowledge): add visibility column to notes"
+```
+
+---
+
+## Task 2 — Note model: add `Visibility` literal + `visibility` field
+
+**Files:**
+
+- Modify: `projects/monolith/knowledge/models.py:30-44` (add Literal next to `GapClass`)
+- Modify: `projects/monolith/knowledge/models.py:54-75` (add field to `Note`)
+- Test: `projects/monolith/knowledge/models_test.py` (extend)
+
+**Step 1: Write the failing test**
+
+Add to `projects/monolith/knowledge/models_test.py`:
+
+```python
+def test_note_visibility_accepts_public_private_or_none():
+    Note(note_id="a", path="a.md", title="A", content_hash="h", visibility="public")
+    Note(note_id="b", path="b.md", title="B", content_hash="h", visibility="private")
+    Note(note_id="c", path="c.md", title="C", content_hash="h", visibility=None)
+
+
+def test_note_visibility_rejected_at_db_constraint(db_session):
+    """The Literal is type-only; the SQL CHECK is what enforces at write time.
+
+    Insert a bogus value via raw SQL and assert the constraint fires.
+    """
+    from sqlalchemy import text
+    from sqlalchemy.exc import IntegrityError
+
+    with pytest.raises(IntegrityError):
+        db_session.execute(
+            text(
+                "INSERT INTO knowledge.notes "
+                "(note_id, path, title, content_hash, visibility) "
+                "VALUES (:id, :p, :t, :h, :v)"
+            ),
+            {"id": "x", "p": "x.md", "t": "X", "h": "h", "v": "yellow"},
+        )
+        db_session.flush()
+```
+
+**Step 2: Modify the model**
+
+In `projects/monolith/knowledge/models.py`, after `GapState = Literal[...]`:
+
+```python
+# Mirror of the CHECK constraint in
+# chart/migrations/20260507000000_knowledge_notes_visibility.sql - keep in sync.
+Visibility = Literal["public", "private"]
+```
+
+In the `Note` class definition, after the `status` field:
+
+```python
+    visibility: Visibility | None = Field(
+        default=None, sa_column=Column(String, nullable=True)
+    )
+```
+
+**Step 3: Commit**
+
+```bash
+git add projects/monolith/knowledge/models.py projects/monolith/knowledge/models_test.py
+git commit -m "feat(knowledge): add visibility field to Note model"
+```
+
+---
+
+## Task 3 — `visibility.py` helper module
+
+**Files:**
+
+- Create: `projects/monolith/knowledge/visibility.py`
+- Create: `projects/monolith/knowledge/visibility_test.py`
+
+This module is the single source of truth for the criteria prompt, the coalescing rule, the wikilink sanitizer, and the SQL filter. Public routes call only into this — no scattered `if visibility == 'public'` checks.
+
+**Step 1: Write the failing tests**
+
+Create `projects/monolith/knowledge/visibility_test.py`:
+
+```python
+"""Tests for the visibility helper: coalescing, sanitisation, SQL filter."""
+
+from __future__ import annotations
+
+import pytest
+
+from knowledge.visibility import (
+    VISIBILITY_CRITERIA,
+    effective_visibility,
+    sanitize_public_body,
+)
+
+
+class _StubNote:
+    def __init__(self, visibility: str | None) -> None:
+        self.visibility = visibility
+
+
+def test_effective_visibility_public():
+    assert effective_visibility(_StubNote("public")) == "public"
+
+
+def test_effective_visibility_private():
+    assert effective_visibility(_StubNote("private")) == "private"
+
+
+def test_effective_visibility_null_defaults_private():
+    assert effective_visibility(_StubNote(None)) == "private"
+
+
+def test_effective_visibility_unknown_defaults_private():
+    """Defensive: a leaked-through bad value still defaults to private."""
+    assert effective_visibility(_StubNote("yellow")) == "private"
+
+
+def test_sanitize_no_links_passthrough():
+    body = "Plain text with no wikilinks."
+    assert sanitize_public_body(body, private_target_ids=set()) == body
+
+
+def test_sanitize_link_to_public_kept():
+    body = "See [[dora-metrics]] for the four key metrics."
+    assert sanitize_public_body(body, private_target_ids=set()) == body
+
+
+def test_sanitize_link_to_private_stripped_to_text():
+    body = "Discussed with [[Some Colleague]] yesterday."
+    out = sanitize_public_body(body, private_target_ids={"some-colleague"})
+    assert out == "Discussed with Some Colleague yesterday."
+
+
+def test_sanitize_link_to_unresolved_gap_stripped_to_text():
+    """Unresolved targets (gaps) are treated as private — no link."""
+    body = "The [[Mystery Concept]] is still being researched."
+    out = sanitize_public_body(
+        body, private_target_ids={"mystery-concept"}
+    )
+    assert out == "The Mystery Concept is still being researched."
+
+
+def test_sanitize_multiple_links_per_line():
+    body = "Both [[dora-metrics]] and [[Private Topic]] matter."
+    out = sanitize_public_body(body, private_target_ids={"private-topic"})
+    assert out == "Both [[dora-metrics]] and Private Topic matter."
+
+
+def test_sanitize_malformed_brackets_left_alone():
+    """We only strip well-formed [[X]] — partial brackets are not links."""
+    body = "[ [not a link] ] and [[ok]] and [unfinished"
+    out = sanitize_public_body(body, private_target_ids=set())
+    assert "[[ok]]" in out
+    assert "[unfinished" in out
+
+
+def test_criteria_text_present():
+    """Smoke check — every prompt that imports this string must keep it."""
+    assert "visibility: public" in VISIBILITY_CRITERIA
+    assert "When in doubt: `private`." in VISIBILITY_CRITERIA
+```
+
+Add a `py_test` entry for `visibility_test` in `projects/monolith/BUILD` (gazelle/`format` will normally do this, but visibility_test depends on `:monolith_backend` so confirm after running `format`).
+
+**Step 2: Implement `visibility.py`**
+
+Create `projects/monolith/knowledge/visibility.py`:
+
+```python
+"""Visibility helper: criteria, coalescing rule, wikilink sanitiser, SQL filter.
+
+All knowledge-pipeline code that needs to reason about public vs private
+content imports from here. Drift between the criteria the LLM sees and
+the criteria the routes enforce is the most common way these systems leak.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Iterable, Literal
+
+from sqlalchemy import or_
+from sqlalchemy.sql import ColumnElement
+
+from knowledge.models import Note
+
+VISIBILITY_CRITERIA = """\
+## Visibility (REQUIRED frontmatter field)
+
+Every note MUST set `visibility: public` or `visibility: private`.
+This controls whether the note appears on Joe's public website.
+
+Default to `private` whenever you are uncertain.
+
+Mark `public` when the note is about:
+- General engineering concepts, principles, heuristics (DORA, Conway's Law,
+  blameless postmortems, etc.) — anything you'd find in a textbook, blog,
+  or conference talk.
+- Skills, technologies, or methods covered in Joe's public CV / GitHub /
+  conference talks.
+- Verifiable facts about external systems, libraries, protocols, or tools.
+- Book / paper / talk summaries when the source is publicly available.
+
+Mark `private` when the note involves any of:
+- Names of current or former colleagues, managers, reports, or interviewers.
+- Specific employers in non-public ways: project codenames, internal
+  architecture, compensation, performance reviews, hiring decisions.
+- Job-search activity: interview prep, comp negotiation, target companies,
+  reasons-for-leaving, offer comparisons.
+- Personal life: family, finances, health, relationships, legal matters,
+  living situation.
+- Critiques or hot takes about identifiable people or companies that
+  aren't already in Joe's public writing.
+- Active tasks, daily/weekly journals, blockers — anything operational
+  about Joe's current work.
+
+Edge cases:
+- An atom about a generally-applicable pattern that includes a
+  workplace-specific example: rewrite the example out and mark public,
+  OR keep the example and mark private. Do not mark public with the
+  example intact.
+- A fact about an external library mentioned during a private incident:
+  the fact is public, the incident framing is private — split into two
+  notes if needed.
+
+When in doubt: `private`.
+"""
+
+EffectiveVisibility = Literal["public", "private"]
+
+_VALID = {"public", "private"}
+
+# A wikilink is a [[target]] possibly containing a |alias suffix that
+# we ignore for resolution. We resolve to a slug by lowercasing and
+# normalising spaces — same convention as gardener / gap_classifier.
+_WIKILINK_RE = re.compile(r"\[\[([^\[\]\n|]+)(?:\|[^\[\]\n]+)?\]\]")
+_SLUG_RE = re.compile(r"[^a-z0-9]+")
+
+
+def effective_visibility(note: Note | object) -> EffectiveVisibility:
+    """Return the public-or-private decision for a note.
+
+    Null and unknown values both fall to ``private`` so a misconfigured
+    or malformed value never accidentally exposes content.
+    """
+    raw = getattr(note, "visibility", None)
+    if raw in _VALID:
+        return raw  # type: ignore[return-value]
+    return "private"
+
+
+def _slugify(text: str) -> str:
+    return _SLUG_RE.sub("-", text.strip().lower()).strip("-")
+
+
+def sanitize_public_body(body: str, private_target_ids: Iterable[str]) -> str:
+    """Strip every wikilink whose target is in ``private_target_ids``.
+
+    Strip = replace ``[[Foo Bar]]`` with ``Foo Bar``. Bracket text is not
+    redacted — the design accepts that wikilink display text may contain
+    weak signals (the loud leak is the *graph edge*, which the public
+    graph endpoint already filters out).
+
+    Wikilinks whose target is NOT in ``private_target_ids`` are left
+    untouched so the frontend renderer can still resolve them to public
+    notes.
+    """
+    private = {p for p in private_target_ids}
+
+    def _replace(match: re.Match[str]) -> str:
+        display = match.group(1)
+        slug = _slugify(display)
+        if slug in private:
+            return display
+        return match.group(0)
+
+    return _WIKILINK_RE.sub(_replace, body)
+
+
+def public_notes_filter() -> ColumnElement[bool]:
+    """SQLAlchemy clause selecting only public notes.
+
+    Use ``Note.visibility == 'public'`` rather than ``COALESCE(..., 'private')``
+    so the partial index ``notes_visibility_idx`` is selected by the planner.
+    """
+    return Note.visibility == "public"
+```
+
+**Step 3: Run formatter to update BUILD**
+
+```bash
+format
+```
+
+`format` runs gazelle, which adds a `py_test` entry for `visibility_test` to `projects/monolith/BUILD`. Confirm `:monolith_backend` is in its `deps` list — gazelle uses Python imports to wire deps; the test imports from `knowledge`, which is part of the bundled `:monolith_backend` library glob.
+
+**Step 4: Commit**
+
+```bash
+git add projects/monolith/knowledge/visibility.py \
+        projects/monolith/knowledge/visibility_test.py \
+        projects/monolith/BUILD
+git commit -m "feat(knowledge): add visibility helper module"
+```
+
+---
+
+## Task 4 — Frontmatter parser: promote `visibility`
+
+**Files:**
+
+- Modify: `projects/monolith/knowledge/frontmatter.py:56-67` (add to `_PROMOTED_KEYS`)
+- Modify: `projects/monolith/knowledge/frontmatter.py:82-94` (add to `ParsedFrontmatter`)
+- Modify: `projects/monolith/knowledge/frontmatter.py:133-146` (project in `_build`)
+- Test: `projects/monolith/knowledge/frontmatter_test.py` (extend)
+
+**Step 1: Write failing tests**
+
+Add to `frontmatter_test.py`:
+
+```python
+def test_visibility_public_parsed():
+    raw = "---\nid: a\ntitle: A\nvisibility: public\n---\nbody"
+    meta, body = frontmatter.parse(raw)
+    assert meta.visibility == "public"
+
+
+def test_visibility_private_parsed():
+    raw = "---\nid: a\ntitle: A\nvisibility: private\n---\nbody"
+    meta, _ = frontmatter.parse(raw)
+    assert meta.visibility == "private"
+
+
+def test_visibility_missing_is_none():
+    raw = "---\nid: a\ntitle: A\n---\nbody"
+    meta, _ = frontmatter.parse(raw)
+    assert meta.visibility is None
+
+
+def test_visibility_empty_string_is_none():
+    raw = "---\nid: a\ntitle: A\nvisibility:\n---\nbody"
+    meta, _ = frontmatter.parse(raw)
+    assert meta.visibility is None
+
+
+def test_visibility_unknown_value_warns_and_nulls(caplog):
+    """Bad classifier output must not break ingest — warn, treat as null."""
+    raw = "---\nid: a\ntitle: A\nvisibility: yellow\n---\nbody"
+    with caplog.at_level("WARNING", logger="monolith.knowledge.frontmatter"):
+        meta, _ = frontmatter.parse(raw)
+    assert meta.visibility is None
+    assert any("visibility" in r.message.lower() for r in caplog.records)
+```
+
+**Step 2: Implement parser changes**
+
+In `projects/monolith/knowledge/frontmatter.py`:
+
+1. Add `"visibility"` to `_PROMOTED_KEYS` (the set at line 56).
+2. Add to `ParsedFrontmatter` (at line 82):
+
+```python
+    visibility: str | None = None
+```
+
+3. In `_build` (line 133), after `meta.status = ...`:
+
+```python
+    raw_visibility = _str_or_none(data.get("visibility"))
+    if raw_visibility in (None, "public", "private"):
+        meta.visibility = raw_visibility
+    else:
+        logger.warning(
+            "frontmatter visibility has unknown value %r — treating as null",
+            raw_visibility,
+        )
+        meta.visibility = None
+```
+
+**Step 3: Commit**
+
+```bash
+git add projects/monolith/knowledge/frontmatter.py \
+        projects/monolith/knowledge/frontmatter_test.py
+git commit -m "feat(knowledge): promote visibility into frontmatter parser"
+```
+
+---
+
+## Task 5 — Reconciler / store: persist `visibility` column
+
+**Files:**
+
+- Modify: `projects/monolith/knowledge/store.py` (the upsert path that writes `status` from `ParsedFrontmatter`)
+- Test: `projects/monolith/knowledge/store_test.py` (extend)
+
+**Step 1: Locate the upsert path**
+
+Find every place `status=parsed.status` (or equivalent) is passed into `Note(...)` or an UPDATE. There is at least one such path in `store.py` (note creation/update from frontmatter). Treat `visibility` identically.
+
+**Step 2: Write failing tests**
+
+Add to `store_test.py`:
+
+```python
+def test_upsert_writes_visibility_public(db_session):
+    parsed = ParsedFrontmatter(note_id="vis-pub", title="VP", visibility="public")
+    upsert_note_from_frontmatter(db_session, path="vp.md",
+                                 content_hash="h", parsed=parsed, body="x")
+    note = db_session.exec(select(Note).where(Note.note_id == "vis-pub")).one()
+    assert note.visibility == "public"
+
+
+def test_upsert_writes_visibility_private(db_session):
+    parsed = ParsedFrontmatter(note_id="vis-priv", title="VPr", visibility="private")
+    upsert_note_from_frontmatter(db_session, path="vpr.md",
+                                 content_hash="h", parsed=parsed, body="x")
+    note = db_session.exec(select(Note).where(Note.note_id == "vis-priv")).one()
+    assert note.visibility == "private"
+
+
+def test_upsert_null_visibility_writes_null(db_session):
+    parsed = ParsedFrontmatter(note_id="vis-null", title="VN", visibility=None)
+    upsert_note_from_frontmatter(db_session, path="vn.md",
+                                 content_hash="h", parsed=parsed, body="x")
+    note = db_session.exec(select(Note).where(Note.note_id == "vis-null")).one()
+    assert note.visibility is None
+```
+
+(Adjust function names to match the actual upsert API in `store.py`.)
+
+**Step 3: Wire `visibility` through**
+
+Add `visibility=parsed.visibility` to every `Note(...)` constructor and every UPDATE-path field assignment that already sets `status`. The reconcile pass must rewrite the column on every run (frontmatter is canonical).
+
+**Step 4: Commit**
+
+```bash
+git add projects/monolith/knowledge/store.py projects/monolith/knowledge/store_test.py
+git commit -m "feat(knowledge): persist visibility from frontmatter on upsert"
+```
+
+---
+
+## Task 6 — Manual edit endpoint: round-trip test only
+
+**Files:**
+
+- Test: `projects/monolith/knowledge/router_test.py` (extend)
+
+No production code changes. The `PUT /api/knowledge/notes/{id}` path passes frontmatter through the parser → store flow already covered by tasks 4-5. The test guards against future regressions where a refactor accidentally drops the field.
+
+**Step 1: Write the round-trip test**
+
+```python
+def test_put_note_round_trips_visibility(client, db_session, vault_root):
+    # Create the note with visibility: public
+    seed_note(db_session, vault_root, note_id="rt", visibility="public",
+              body="Round trip test.")
+
+    # Edit body via PUT, leaving frontmatter intact
+    res = client.put("/api/knowledge/notes/rt", json={"body": "edited body."})
+    assert res.status_code == 200
+
+    note = db_session.exec(select(Note).where(Note.note_id == "rt")).one()
+    assert note.visibility == "public"
+
+    # Now flip visibility via a frontmatter-rewriting PUT
+    res = client.put("/api/knowledge/notes/rt", json={
+        "body": "edited body.",
+        "frontmatter": {"visibility": "private"},
+    })
+    assert res.status_code == 200
+
+    note = db_session.exec(select(Note).where(Note.note_id == "rt")).one()
+    assert note.visibility == "private"
+```
+
+(Adjust to the actual PUT contract — read `router.py:188-251` and `notes_crud_test.py` for the existing shape.)
+
+**Step 2: Commit**
+
+```bash
+git add projects/monolith/knowledge/router_test.py
+git commit -m "test(knowledge): assert visibility round-trips through PUT note"
+```
+
+---
+
+## Task 7 — Public graph endpoint
+
+**Files:**
+
+- Modify: `projects/monolith/knowledge/router.py` (add new route, reuse existing graph helpers)
+- Test: `projects/monolith/knowledge/router_test.py` (extend)
+
+**Step 1: Write failing tests**
+
+Add to `router_test.py`:
+
+```python
+def test_public_graph_only_public_nodes(client, db_session, vault_root):
+    seed_note(db_session, vault_root, note_id="pub-A", visibility="public")
+    seed_note(db_session, vault_root, note_id="pub-B", visibility="public")
+    seed_note(db_session, vault_root, note_id="priv-X", visibility="private")
+    seed_note(db_session, vault_root, note_id="null-Y", visibility=None)
+    seed_link(db_session, src="pub-A", target="pub-B")
+    seed_link(db_session, src="pub-A", target="priv-X")
+    seed_link(db_session, src="null-Y", target="pub-B")
+
+    res = client.get("/api/knowledge/public/graph")
+    assert res.status_code == 200
+    body = res.json()
+
+    node_ids = {n["id"] for n in body["nodes"]}
+    assert node_ids == {"pub-A", "pub-B"}
+
+    edge_pairs = {(e["source"], e["target"]) for e in body["edges"]}
+    assert edge_pairs == {("pub-A", "pub-B")}
+
+
+def test_public_graph_excludes_gap_stubs(client, db_session, vault_root):
+    seed_note(db_session, vault_root, note_id="pub-A", visibility="public")
+    seed_gap(db_session, term="UnresolvedThing", note_id="unresolved-thing")
+
+    res = client.get("/api/knowledge/public/graph")
+    body = res.json()
+    assert "unresolved-thing" not in {n["id"] for n in body["nodes"]}
+
+
+def test_public_graph_cache_headers(client, db_session, vault_root):
+    seed_note(db_session, vault_root, note_id="pub-A", visibility="public")
+    res = client.get("/api/knowledge/public/graph")
+    cc = res.headers.get("cache-control", "")
+    assert "s-maxage=3600" in cc
+    assert "stale-while-revalidate=86400" in cc
+
+
+def test_public_graph_etag_changes_when_public_set_mutates(
+    client, db_session, vault_root
+):
+    seed_note(db_session, vault_root, note_id="pub-A", visibility="public")
+    etag_a = client.get("/api/knowledge/public/graph").headers["etag"]
+    seed_note(db_session, vault_root, note_id="pub-B", visibility="public")
+    etag_b = client.get("/api/knowledge/public/graph").headers["etag"]
+    assert etag_a != etag_b
+```
+
+**Step 2: Implement the endpoint**
+
+Add to `router.py` near `get_graph` (line 116):
+
+```python
+@router.get("/public/graph")
+def get_public_graph(
+    response: Response,
+    session: Session = Depends(get_db_session),
+) -> dict:
+    """Public-only knowledge graph: only public nodes, only doubly-public edges."""
+    nodes_q = select(Note).where(public_notes_filter())
+    public_notes = session.exec(nodes_q).all()
+
+    public_ids = {n.note_id for n in public_notes}
+    if not public_ids:
+        nodes, edges = [], []
+        indexed_at = None
+    else:
+        # Reuse existing serialiser; filter edges to doubly-public.
+        nodes = [_serialize_node(n) for n in public_notes]
+        link_q = (
+            select(NoteLink)
+            .join(Note, Note.id == NoteLink.src_note_fk)
+            .where(public_notes_filter())
+            .where(NoteLink.target_id.in_(public_ids))
+        )
+        edges = [_serialize_edge(l) for l in session.exec(link_q).all()]
+        indexed_at = max((n.indexed_at for n in public_notes), default=None)
+
+    response.headers["cache-control"] = _GRAPH_CACHE_CONTROL
+    response.headers["etag"] = _graph_etag(len(public_notes), indexed_at)
+    if indexed_at is not None:
+        response.headers["last-modified"] = _as_utc(indexed_at).strftime(
+            "%a, %d %b %Y %H:%M:%S GMT"
+        )
+    logger.info(
+        "public.graph.served nodes=%d edges=%d", len(nodes), len(edges)
+    )
+    return {"nodes": nodes, "edges": edges}
+```
+
+Reuse the **existing** serialisers (`_serialize_node`, `_serialize_edge`, or whatever `get_graph` already uses) — do not duplicate. Read `router.py:116-145` and copy the same shape minus the visibility filter.
+
+Import `from knowledge.visibility import public_notes_filter`.
+
+**Step 3: Commit**
+
+```bash
+git add projects/monolith/knowledge/router.py projects/monolith/knowledge/router_test.py
+git commit -m "feat(knowledge): add GET /api/knowledge/public/graph"
+```
+
+---
+
+## Task 8 — Public note endpoint
+
+**Files:**
+
+- Modify: `projects/monolith/knowledge/router.py` (add `GET /public/notes/{note_id}`)
+- Test: `projects/monolith/knowledge/router_test.py` (extend)
+
+**Step 1: Write failing tests**
+
+```python
+def test_public_note_200_for_public(client, db_session, vault_root):
+    seed_note(db_session, vault_root, note_id="pub-A", visibility="public",
+              body="Hello [[pub-B]] world.")
+    seed_note(db_session, vault_root, note_id="pub-B", visibility="public")
+    res = client.get("/api/knowledge/public/notes/pub-A")
+    assert res.status_code == 200
+    body = res.json()
+    # Public-target wikilink left intact for frontend resolution
+    assert "[[pub-B]]" in body["body"]
+
+
+def test_public_note_404_for_missing(client):
+    res = client.get("/api/knowledge/public/notes/does-not-exist")
+    assert res.status_code == 404
+
+
+def test_public_note_404_for_private_same_response_shape(
+    client, db_session, vault_root
+):
+    seed_note(db_session, vault_root, note_id="priv-X", visibility="private")
+    res_priv = client.get("/api/knowledge/public/notes/priv-X")
+    res_miss = client.get("/api/knowledge/public/notes/does-not-exist")
+    assert res_priv.status_code == 404
+    assert res_miss.status_code == 404
+    assert res_priv.json() == res_miss.json()
+
+
+def test_public_note_strips_private_wikilinks_from_body(
+    client, db_session, vault_root
+):
+    seed_note(db_session, vault_root, note_id="pub-A", visibility="public",
+              body="See [[pub-B]] and avoid [[Some Colleague]].")
+    seed_note(db_session, vault_root, note_id="pub-B", visibility="public")
+    seed_note(db_session, vault_root, note_id="some-colleague",
+              visibility="private")
+
+    res = client.get("/api/knowledge/public/notes/pub-A")
+    assert res.status_code == 200
+    body = res.json()["body"]
+    assert "[[pub-B]]" in body
+    assert "[[Some Colleague]]" not in body
+    assert "Some Colleague" in body  # bracket text is preserved
+
+
+def test_public_note_response_excludes_internal_fields(
+    client, db_session, vault_root
+):
+    seed_note(db_session, vault_root, note_id="pub-A", visibility="public",
+              extra={"internal_only": "secret"})
+    res = client.get("/api/knowledge/public/notes/pub-A")
+    body = res.json()
+    assert "extra" not in body
+    assert "secret" not in str(body)
+```
+
+**Step 2: Implement the endpoint**
+
+Add to `router.py`:
+
+```python
+@router.get("/public/notes/{note_id}")
+def get_public_note(
+    note_id: str,
+    session: Session = Depends(get_db_session),
+) -> dict:
+    note = session.exec(select(Note).where(Note.note_id == note_id)).one_or_none()
+    if note is None or effective_visibility(note) != "public":
+        # Identical 404 for missing and private — never expose existence.
+        reason = "not_found" if note is None else "private_gated"
+        logger.info("public.note.404 note_id=%s reason=%s", note_id, reason)
+        raise HTTPException(status_code=404, detail="Not Found")
+
+    private_ids = {
+        n.note_id
+        for n in session.exec(
+            select(Note).where(
+                or_(Note.visibility != "public", Note.visibility.is_(None))
+            )
+        ).all()
+    }
+
+    body = sanitize_public_body(_load_note_body(note), private_ids)
+    logger.info("public.note.served note_id=%s", note_id)
+    return {
+        "note_id": note.note_id,
+        "title": note.title,
+        "tags": list(note.tags),
+        "aliases": list(note.aliases),
+        "indexed_at": _as_utc(note.indexed_at).isoformat()
+            if note.indexed_at else None,
+        "body": body,
+    }
+```
+
+Imports:
+
+```python
+from knowledge.visibility import effective_visibility, sanitize_public_body
+from sqlalchemy import or_
+```
+
+**Step 3: Commit**
+
+```bash
+git add projects/monolith/knowledge/router.py projects/monolith/knowledge/router_test.py
+git commit -m "feat(knowledge): add GET /api/knowledge/public/notes/{id}"
+```
+
+---
+
+## Task 9 — Gardener atom prompt: append visibility criteria
+
+**Files:**
+
+- Modify: `projects/monolith/knowledge/gardener.py:31-144` (`_CLAUDE_PROMPT_HEADER`)
+- Test: extend an existing `gardener_test.py` or `mcp_test.py`
+
+**Step 1: Write the failing test**
+
+```python
+def test_gardener_prompt_includes_visibility_criteria():
+    from knowledge.gardener import _CLAUDE_PROMPT_HEADER
+    from knowledge.visibility import VISIBILITY_CRITERIA
+    rendered = _CLAUDE_PROMPT_HEADER.format(
+        raw_id="r", raw_file_path="x", processed_root="p", title="t"
+    )
+    assert "visibility: public|private" in rendered
+    # criteria must be appended verbatim — drift = leak
+    assert VISIBILITY_CRITERIA.strip() in rendered
+```
+
+**Step 2: Modify the prompt**
+
+Two changes to `_CLAUDE_PROMPT_HEADER` (line 31):
+
+1. In the frontmatter template (line 60-69), add the `visibility` line **before** `tags`:
+
+```
+visibility: public|private   # REQUIRED — see criteria below
+```
+
+2. Append `\n\n` + `VISIBILITY_CRITERIA` to the prompt body (just before the trailing `Title: {title}`).
+
+Implementation: introduce a module-level format-string constant rather than inlining, so the substitution is mechanical:
+
+```python
+from knowledge.visibility import VISIBILITY_CRITERIA
+
+_CLAUDE_PROMPT_HEADER = """\
+... existing content ...
+
+{VISIBILITY_CRITERIA}
+
+Title: {title}
+
+""".replace("{VISIBILITY_CRITERIA}", VISIBILITY_CRITERIA)
+```
+
+Or — simpler and more explicit — manually paste the criteria block into the prompt, but assert by import in tests so any future drift is caught.
+
+**Step 3: Commit**
+
+```bash
+git add projects/monolith/knowledge/gardener.py projects/monolith/knowledge/gardener_test.py
+git commit -m "feat(knowledge): require visibility in gardener atom prompt"
+```
+
+---
+
+## Task 10 — Gardener distill prompt: append visibility criteria
+
+**Files:**
+
+- Modify: `projects/monolith/knowledge/gardener.py:146-178` (`_DISTILL_PROMPT`)
+- Test: extend `gardener_distill_test.py`
+
+**Step 1: Write the failing test**
+
+```python
+def test_distill_prompt_includes_visibility_criteria():
+    from knowledge.gardener import _DISTILL_PROMPT
+    from knowledge.visibility import VISIBILITY_CRITERIA
+    rendered = _DISTILL_PROMPT.format(note_id="n", note_path="x",
+                                      processed_root="p", title="t")
+    assert "visibility:" in rendered
+    assert VISIBILITY_CRITERIA.strip() in rendered
+```
+
+**Step 2: Modify `_DISTILL_PROMPT`**
+
+Add `visibility: public|private` to the required-fields list in step 5 (line 157-159), and append `VISIBILITY_CRITERIA` before the trailing `Title: {title}`.
+
+**Step 3: Commit**
+
+```bash
+git add projects/monolith/knowledge/gardener.py \
+        projects/monolith/knowledge/gardener_distill_test.py
+git commit -m "feat(knowledge): require visibility in gardener distill prompt"
+```
+
+---
+
+## Task 11 — Research writer: set `visibility: public`
+
+**Files:**
+
+- Modify: `projects/monolith/knowledge/research_writer.py:61-71` (the `fm` dict in `write_research_raw`)
+- Test: `projects/monolith/knowledge/research_writer_test.py`
+
+**Step 1: Write the failing test**
+
+```python
+def test_research_raw_sets_visibility_public(tmp_path):
+    out_path = write_research_raw(
+        vault_root=tmp_path, slug="dora-metrics",
+        title="DORA Metrics", summary="...",
+        supported_claims=[], sources=[],
+        agent_model="m", researched_at="2026-05-07",
+    )
+    text = out_path.read_text()
+    assert "visibility: public" in text
+
+
+def test_failed_research_does_not_set_visibility(tmp_path):
+    """Quarantined drafts are forensic; visibility is irrelevant."""
+    out_path = quarantine(
+        vault_root=tmp_path, slug="bad", attempt=1, summary="...",
+        pre_filter_claims=[], sources=[],
+        agent_model="m", researched_at="2026-05-07",
+    )
+    assert "visibility" not in out_path.read_text()
+```
+
+**Step 2: Modify `write_research_raw`**
+
+Add to the `fm` dict (line 61):
+
+```python
+        "visibility": "public",
+```
+
+Place it after `"type": "research"` so the order in the resulting YAML stays readable.
+
+Do not modify `quarantine` — failed_research notes never reach the public surface.
+
+**Step 3: Commit**
+
+```bash
+git add projects/monolith/knowledge/research_writer.py \
+        projects/monolith/knowledge/research_writer_test.py
+git commit -m "feat(knowledge): mark research raws visibility: public"
+```
+
+---
+
+## Task 12 — Phase-1 script: `add_visibility_field`
+
+**Files:**
+
+- Create: `projects/monolith/knowledge/tools/add_visibility_field.py`
+- Create: `projects/monolith/knowledge/tools/add_visibility_field_test.py`
+
+**Step 1: Write failing tests**
+
+```python
+"""Tests for the mechanical Phase-1 visibility field injector."""
+
+from pathlib import Path
+
+from knowledge.tools.add_visibility_field import run
+
+
+def _write(p: Path, body: str) -> None:
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(body)
+
+
+def test_inserts_visibility_into_files_lacking_it(tmp_path):
+    note = tmp_path / "_processed/foo.md"
+    _write(note, "---\nid: foo\ntitle: Foo\n---\nbody\n")
+    stats = run(vault_root=tmp_path, dirs=["_processed"])
+    assert stats.added == 1
+    assert "visibility:\n" in note.read_text()
+
+
+def test_skips_files_already_with_visibility(tmp_path):
+    note = tmp_path / "_processed/bar.md"
+    _write(note, "---\nid: bar\ntitle: Bar\nvisibility: public\n---\nbody\n")
+    before = note.read_text()
+    stats = run(vault_root=tmp_path, dirs=["_processed"])
+    assert stats.added == 0
+    assert stats.already_set == 1
+    assert note.read_text() == before  # byte-stable
+
+
+def test_idempotent_second_run(tmp_path):
+    note = tmp_path / "_processed/baz.md"
+    _write(note, "---\nid: baz\ntitle: Baz\n---\nbody\n")
+    run(vault_root=tmp_path, dirs=["_processed"])
+    after_first = note.read_text()
+    run(vault_root=tmp_path, dirs=["_processed"])
+    assert note.read_text() == after_first
+
+
+def test_skips_files_with_no_frontmatter(tmp_path):
+    note = tmp_path / "_processed/raw.md"
+    _write(note, "Just a body, no frontmatter.\n")
+    stats = run(vault_root=tmp_path, dirs=["_processed"])
+    assert stats.added == 0
+    assert stats.parse_skipped == 1
+
+
+def test_skips_files_with_unparseable_frontmatter(tmp_path):
+    note = tmp_path / "_processed/broken.md"
+    _write(note, "---\nthis: is: not: yaml\n---\nbody\n")
+    stats = run(vault_root=tmp_path, dirs=["_processed"])
+    assert stats.parse_skipped == 1
+
+
+def test_atomic_write_does_not_truncate_on_failure(tmp_path, monkeypatch):
+    note = tmp_path / "_processed/atomic.md"
+    _write(note, "---\nid: a\n---\nbody\n")
+
+    def boom(*args, **kwargs):
+        raise OSError("boom")
+
+    monkeypatch.setattr("os.replace", boom)
+    try:
+        run(vault_root=tmp_path, dirs=["_processed"])
+    except OSError:
+        pass
+    # Original file is intact
+    assert "id: a" in note.read_text()
+```
+
+**Step 2: Implement the script**
+
+```python
+"""Phase-1 mechanical injection of `visibility:` into existing note frontmatter.
+
+Idempotent. No LLM calls. No DB writes. Walks the configured vault dirs,
+inserts `visibility:` (empty value) into every .md file that lacks the
+key. The resulting frontmatter is parsed by the reconciler on its next
+pass and persists null in the DB column — which the serving layer
+treats as private.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+import yaml
+
+from knowledge import frontmatter
+
+logger = logging.getLogger("monolith.knowledge.tools.add_visibility_field")
+
+_FRONTMATTER_RE = re.compile(r"^---\n(.*?)\n---\n", re.DOTALL)
+
+
+@dataclass
+class Stats:
+    added: int = 0
+    already_set: int = 0
+    parse_skipped: int = 0
+
+
+def _insert_visibility_line(block: str) -> str:
+    """Insert `visibility:` after `id:` (or at the top if no id)."""
+    lines = block.splitlines()
+    insert_at = 0
+    for i, line in enumerate(lines):
+        if line.startswith("id:"):
+            insert_at = i + 1
+            break
+    lines.insert(insert_at, "visibility:")
+    return "\n".join(lines)
+
+
+def _process_file(path: Path) -> str | None:
+    """Return the new file content, or None if no change is needed."""
+    raw = path.read_text()
+    match = _FRONTMATTER_RE.match(raw)
+    if not match:
+        return "PARSE_SKIP"
+
+    block = match.group(1)
+    try:
+        meta, _ = frontmatter.parse(raw)
+    except frontmatter.FrontmatterError as exc:
+        logger.warning("parse failure for %s: %s — skipping", path, exc)
+        return "PARSE_SKIP"
+
+    if "visibility" in {line.split(":", 1)[0].strip() for line in block.splitlines()}:
+        return None
+
+    new_block = _insert_visibility_line(block)
+    return raw[: match.start()] + f"---\n{new_block}\n---\n" + raw[match.end() :]
+
+
+def _atomic_write(path: Path, content: str) -> None:
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(content)
+    os.replace(tmp, path)
+
+
+def run(*, vault_root: Path, dirs: list[str]) -> Stats:
+    stats = Stats()
+    for d in dirs:
+        for md in (vault_root / d).rglob("*.md"):
+            outcome = _process_file(md)
+            if outcome == "PARSE_SKIP":
+                stats.parse_skipped += 1
+                continue
+            if outcome is None:
+                stats.already_set += 1
+                continue
+            _atomic_write(md, outcome)
+            stats.added += 1
+    return stats
+
+
+def main() -> int:
+    logging.basicConfig(level=logging.INFO)
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--vault-root", type=Path, required=True)
+    parser.add_argument("--dirs", nargs="+", default=["_processed"])
+    args = parser.parse_args()
+    stats = run(vault_root=args.vault_root, dirs=args.dirs)
+    print(f"added={stats.added} already_set={stats.already_set} "
+          f"parse_skipped={stats.parse_skipped}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+The script lives under `projects/monolith/knowledge/tools/`. Gazelle (via `format`) wires it into the `:monolith_backend` glob automatically since the parent BUILD globs `knowledge/**/*.py`. Wire it as a `py_venv_binary` in `projects/monolith/BUILD` if a separate `bazel run` target is desired — model on the existing `:main` binary at the top of that BUILD.
+
+**Step 3: Run formatter**
+
+```bash
+format
+```
+
+**Step 4: Commit**
+
+```bash
+git add projects/monolith/knowledge/tools/add_visibility_field.py \
+        projects/monolith/knowledge/tools/add_visibility_field_test.py \
+        projects/monolith/BUILD
+git commit -m "feat(knowledge): add Phase-1 visibility field injector"
+```
+
+---
+
+## Task 13 — Phase-2 script: `classify_visibility_backfill`
+
+**Files:**
+
+- Create: `projects/monolith/knowledge/tools/classify_visibility_backfill.py`
+- Create: `projects/monolith/knowledge/tools/classify_visibility_backfill_test.py`
+
+The script shells out to the `claude` CLI (per `memory/feedback_claude_cli_subprocess_for_tos.md`). Tests mock the subprocess — never call the real CLI.
+
+**Step 1: Write failing tests**
+
+```python
+"""Tests for the LLM-driven Phase-2 visibility backfill."""
+
+import json
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from knowledge.tools.classify_visibility_backfill import (
+    BackfillError,
+    classify_one,
+    run,
+)
+
+
+def _seed_note(p: Path, slug: str, visibility: str | None = None) -> Path:
+    fm = f"---\nid: {slug}\ntitle: {slug}\n"
+    if visibility is not None:
+        fm += f"visibility: {visibility}\n"
+    else:
+        fm += "visibility:\n"
+    fm += "---\nbody for {slug}.\n"
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(fm.format(slug=slug))
+    return p
+
+
+@pytest.fixture
+def vault(tmp_path):
+    _seed_note(tmp_path / "_processed/a.md", "a", visibility=None)
+    _seed_note(tmp_path / "_processed/b.md", "b", visibility="public")
+    _seed_note(tmp_path / "_processed/c.md", "c", visibility=None)
+    return tmp_path
+
+
+def test_refuses_report_path_inside_repo(vault):
+    with pytest.raises(BackfillError, match="outside the repo"):
+        run(vault_root=vault, report=vault / "out.json", batch_size=1,
+            run_one_for_test=lambda body: ("private", "test"))
+
+
+def test_skips_already_labelled_notes(vault):
+    calls = []
+
+    def fake(body):
+        calls.append(body)
+        return "public", "ok"
+
+    run(vault_root=vault, report=Path("/tmp/r.json"), batch_size=2,
+        run_one_for_test=fake)
+    # b.md is already "public" — skip; only a + c go through classifier
+    assert len(calls) == 2
+
+
+def test_writes_decision_back_to_frontmatter(vault):
+    def fake(body):
+        return "public", "looks public"
+
+    run(vault_root=vault, report=Path("/tmp/r.json"), batch_size=1,
+        run_one_for_test=fake)
+    a = (vault / "_processed/a.md").read_text()
+    assert "visibility: public" in a
+
+
+def test_strict_json_parse_failure_leaves_file_unchanged(vault, tmp_path):
+    def bad(body):
+        raise BackfillError("invalid JSON")
+
+    run(vault_root=vault, report=Path("/tmp/r.json"), batch_size=1,
+        run_one_for_test=bad)
+    # a.md still has visibility: (empty)
+    a = (vault / "_processed/a.md").read_text()
+    assert "visibility:\n" in a or "visibility: \n" in a
+
+
+def test_resumable_after_partial_run(vault):
+    # First run: only handle a (a → public)
+    def fake_a(body):
+        return "public", "ok"
+
+    run(vault_root=vault, report=Path("/tmp/r.json"), batch_size=1,
+        run_one_for_test=fake_a, max_files=1)
+
+    # Second run: c is the only remaining unlabelled
+    seen = []
+    def fake_c(body):
+        seen.append(body)
+        return "private", "ok"
+    run(vault_root=vault, report=Path("/tmp/r.json"), batch_size=1,
+        run_one_for_test=fake_c)
+    assert len(seen) == 1
+
+
+@patch("subprocess.run")
+def test_classify_one_parses_strict_json(mock_run):
+    mock_run.return_value = subprocess.CompletedProcess(
+        args=[], returncode=0,
+        stdout=json.dumps({"visibility": "public", "rationale": "concept"}),
+        stderr="",
+    )
+    decision, rationale = classify_one(body="body", title="t")
+    assert decision == "public"
+    assert rationale == "concept"
+
+
+@patch("subprocess.run")
+def test_classify_one_rejects_unknown_decision(mock_run):
+    mock_run.return_value = subprocess.CompletedProcess(
+        args=[], returncode=0,
+        stdout=json.dumps({"visibility": "yellow", "rationale": "x"}),
+        stderr="",
+    )
+    with pytest.raises(BackfillError):
+        classify_one(body="body", title="t")
+```
+
+**Step 2: Implement the script**
+
+```python
+"""Phase-2 backfill: classify every unlabelled note via the `claude` CLI.
+
+The script writes ``visibility: public`` or ``visibility: private`` into
+each note's frontmatter via in-place line replacement (no full YAML
+round-trip). Per `memory/feedback_claude_cli_subprocess_for_tos.md`, we
+shell out to the `claude` CLI rather than the Anthropic SDK.
+
+Resumable: re-running picks up only still-unlabelled notes. Crash
+recovery is implicit — partial work is on disk.
+
+Report: a JSON file written OUTSIDE the repo (the script refuses
+report paths inside the working tree). Rationales quote note content
+and must not be committed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import re
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Callable
+
+from knowledge import frontmatter
+from knowledge.visibility import VISIBILITY_CRITERIA
+
+logger = logging.getLogger(
+    "monolith.knowledge.tools.classify_visibility_backfill"
+)
+
+_FRONTMATTER_RE = re.compile(r"^(---\n)(.*?)(\n---\n)", re.DOTALL)
+_VISIBILITY_LINE_RE = re.compile(r"^visibility:.*$", re.MULTILINE)
+
+
+class BackfillError(Exception):
+    """Raised when the classifier output cannot be safely applied."""
+
+
+@dataclass
+class _ReportEntry:
+    note_id: str
+    decision: str | None
+    rationale: str | None
+    error: str | None = None
+
+
+@dataclass
+class _Report:
+    entries: list[_ReportEntry] = field(default_factory=list)
+
+
+def _check_report_path_outside_repo(report: Path) -> None:
+    cwd = Path.cwd().resolve()
+    try:
+        report.resolve().relative_to(cwd)
+    except ValueError:
+        return  # outside cwd — good
+    raise BackfillError(
+        f"refusing to write report at {report} — must be outside the repo "
+        "working tree (rationales quote note content; never commit)"
+    )
+
+
+def classify_one(*, body: str, title: str) -> tuple[str, str]:
+    """Single LLM call via the `claude` CLI subprocess. Returns (decision, rationale)."""
+    prompt = (
+        f"{VISIBILITY_CRITERIA}\n\n"
+        f"Title: {title}\n\nBody:\n{body}\n\n"
+        "Respond with strict JSON:\n"
+        '{"visibility": "public" | "private", "rationale": "<one sentence>"}\n'
+    )
+    proc = subprocess.run(
+        ["claude", "--print", "--output-format", "json"],
+        input=prompt, capture_output=True, text=True, timeout=120,
+    )
+    if proc.returncode != 0:
+        raise BackfillError(
+            f"claude exit={proc.returncode} stderr={proc.stderr[:200]!r}"
+        )
+    try:
+        # `claude --output-format json` wraps the response; the actual
+        # answer is in the .result field. Adjust if the CLI shape differs.
+        outer = json.loads(proc.stdout)
+        text = outer.get("result", proc.stdout)
+        parsed = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise BackfillError(f"non-JSON output: {exc}") from exc
+
+    decision = parsed.get("visibility")
+    rationale = parsed.get("rationale", "")
+    if decision not in {"public", "private"}:
+        raise BackfillError(f"invalid decision {decision!r}")
+    return decision, str(rationale)
+
+
+def _replace_visibility_line(content: str, value: str) -> str:
+    match = _FRONTMATTER_RE.match(content)
+    if not match:
+        raise BackfillError("note has no frontmatter")
+    head, block, tail = match.group(1), match.group(2), match.group(3)
+    if _VISIBILITY_LINE_RE.search(block):
+        new_block = _VISIBILITY_LINE_RE.sub(f"visibility: {value}", block)
+    else:
+        new_block = block + f"\nvisibility: {value}"
+    return head + new_block + tail + content[match.end() :]
+
+
+def _atomic_write(path: Path, content: str) -> None:
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(content)
+    os.replace(tmp, path)
+
+
+def _is_unlabelled(meta: frontmatter.ParsedFrontmatter) -> bool:
+    return meta.visibility in (None, "")
+
+
+def run(
+    *,
+    vault_root: Path,
+    report: Path,
+    batch_size: int = 50,
+    run_one_for_test: Callable[[str], tuple[str, str]] | None = None,
+    max_files: int | None = None,
+) -> _Report:
+    """Walk vault and classify every unlabelled note. ``run_one_for_test``
+    is a seam used by tests — production passes None and we use ``classify_one``.
+    """
+    _check_report_path_outside_repo(report)
+    rep = _Report()
+
+    files = sorted((vault_root / "_processed").rglob("*.md"))
+    processed = 0
+    for path in files:
+        if max_files is not None and processed >= max_files:
+            break
+        raw = path.read_text()
+        try:
+            meta, body = frontmatter.parse(raw)
+        except frontmatter.FrontmatterError:
+            rep.entries.append(_ReportEntry(
+                note_id=path.stem, decision=None, rationale=None,
+                error="frontmatter parse failure",
+            ))
+            continue
+        if not _is_unlabelled(meta):
+            continue
+
+        try:
+            if run_one_for_test is not None:
+                decision, rationale = run_one_for_test(body)
+            else:
+                decision, rationale = classify_one(body=body, title=meta.title or path.stem)
+        except BackfillError as exc:
+            rep.entries.append(_ReportEntry(
+                note_id=path.stem, decision=None, rationale=None,
+                error=str(exc),
+            ))
+            continue
+
+        new = _replace_visibility_line(raw, decision)
+        _atomic_write(path, new)
+        rep.entries.append(_ReportEntry(
+            note_id=path.stem, decision=decision, rationale=rationale,
+        ))
+        processed += 1
+
+    report.write_text(json.dumps(
+        [e.__dict__ for e in rep.entries], indent=2,
+    ))
+    return rep
+
+
+def main() -> int:
+    logging.basicConfig(level=logging.INFO)
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--vault-root", type=Path, required=True)
+    parser.add_argument(
+        "--report", type=Path, required=True,
+        help="must be outside the repo working tree",
+    )
+    parser.add_argument("--batch-size", type=int, default=50)
+    args = parser.parse_args()
+    rep = run(vault_root=args.vault_root, report=args.report,
+              batch_size=args.batch_size)
+    classified = sum(1 for e in rep.entries if e.decision)
+    errored = sum(1 for e in rep.entries if e.error)
+    print(f"classified={classified} errored={errored} report={args.report}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+**Step 3: Run formatter**
+
+```bash
+format
+```
+
+**Step 4: Commit**
+
+```bash
+git add projects/monolith/knowledge/tools/classify_visibility_backfill.py \
+        projects/monolith/knowledge/tools/classify_visibility_backfill_test.py \
+        projects/monolith/BUILD
+git commit -m "feat(knowledge): add Phase-2 visibility backfill classifier"
+```
+
+---
+
+## Task 14 — Chart bump, observability log lines, open PR
+
+**Files:**
+
+- Modify: `projects/monolith/chart/Chart.yaml` (bump version)
+- Modify: `projects/monolith/deploy/application.yaml` (matching `targetRevision`)
+
+**Step 1: Bump chart version**
+
+Per `memory/feedback_chart_version_bumps.md`. Read both files, increment patch version in both.
+
+**Step 2: Verify observability log lines from Tasks 7-8 are wired**
+
+Confirm:
+
+- `public.graph.served nodes=N edges=M`
+- `public.note.404 note_id=X reason={not_found|private_gated}`
+- `public.note.served note_id=X`
+
+These were added in Tasks 7-8; this step is just a final grep:
+
+```bash
+grep -n "public.graph.served\|public.note.404\|public.note.served" \
+    projects/monolith/knowledge/router.py
+```
+
+All three should appear.
+
+**Step 3: Commit**
+
+```bash
+git add projects/monolith/chart/Chart.yaml projects/monolith/deploy/application.yaml
+git commit -m "chore(monolith): bump chart version for visibility schema"
+```
+
+**Step 4: Push and open PR**
+
+```bash
+git push -u origin feat/public-notes-visibility
+
+gh pr create --title "feat(knowledge): visibility labels and public API surface (V1)" --body "$(cat <<'EOF'
+## Summary
+
+V1 of public notes — a binary `visibility: public | private` label on every
+note plus a strictly filtered public API at `/api/knowledge/public/...`.
+Frontend (V2) and chat (V3) are separate plans.
+
+Frontmatter is canonical; the DB column mirrors it; null is treated as
+private. The new `knowledge/visibility.py` module owns the criteria
+prompt, the coalescing rule, the wikilink sanitiser, and the SQL filter.
+Public routes call only into that helper.
+
+Two vault-mutation scripts ship under `knowledge/tools/`:
+- `add_visibility_field` — Phase 1, mechanical, no LLM, idempotent.
+- `classify_visibility_backfill` — Phase 2, LLM via `claude` CLI, single-commit.
+
+Design doc: `docs/plans/2026-05-07-public-notes-visibility-design.md`
+Plan doc: `docs/plans/2026-05-07-public-notes-visibility-v1-plan.md`
+
+## Test plan
+
+- [ ] CI green
+- [ ] Migration applies cleanly in CI's ephemeral DB
+- [ ] `format` produced no further BUILD changes
+- [ ] Public endpoints exist; private routes unchanged
+- [ ] Phase-1 / Phase-2 scripts import and `--help` parses
+
+## Rollout (post-merge)
+
+1. Run Phase 1 script against vault; commit + push.
+2. Wait for reconciler to populate the column with nulls.
+3. Run Phase 2 script (single `bazel run`, single vault commit, `/tmp/`-bound report).
+4. Smoke-test public endpoints.
+EOF
+)"
+```
+
+**Step 5: Watch CI**
+
+```bash
+gh pr checks <number> --watch
+```
+
+If failures, diagnose via `mcp__buildbuddy__get_invocation` (use `commitSha` selector) → `get_target` → `get_log`. **Quote the actual assertion error verbatim** before hypothesising — never blame infra without a real test failure first.
+
+---
+
+## Acceptance criteria
+
+CI green on the PR with all of the following:
+
+- `notes.visibility` column exists with CHECK constraint and partial index.
+- `Note.visibility` field is `Visibility | None`.
+- `frontmatter.parse()` recognises `visibility:` and warns-but-doesn't-fail on bad values.
+- Reconciler writes the column from frontmatter on every upsert.
+- `knowledge/visibility.py` exports `VISIBILITY_CRITERIA`, `effective_visibility`, `sanitize_public_body`, `public_notes_filter`.
+- Gardener atom prompt + distill prompt include the criteria block; tests assert this.
+- `research_writer` sets `visibility: public` on research raws.
+- `GET /api/knowledge/public/graph` returns only public nodes + doubly-public edges, has correct cache headers + ETag.
+- `GET /api/knowledge/public/notes/{id}` returns 200 for public, identical 404 for missing/private, body sanitised.
+- Phase 1 script: idempotent, atomic, parse-failure-tolerant.
+- Phase 2 script: refuses report inside repo, resumable, mocked-subprocess tests pass.
+- Chart + targetRevision bumped.

--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -1834,6 +1834,16 @@ py_test(
 )
 
 py_test(
+    name = "knowledge_visibility_test",
+    srcs = ["knowledge/visibility_test.py"],
+    imports = ["."],
+    deps = [
+        ":monolith_backend",
+        "@pip//pytest",
+    ],
+)
+
+py_test(
     name = "knowledge_gardener_test",
     srcs = ["knowledge/gardener_test.py"],
     imports = ["."],

--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -66,6 +66,22 @@ py_venv_binary(
     deps = [":monolith_backend"],
 )
 
+# Phase-2 vault-mutation script: classify every unlabelled note via the
+# `claude` CLI subprocess and write the decision back into frontmatter.
+# Run via `bazel run`:
+#   bazel run //projects/monolith:classify_visibility_backfill -- \
+#       --vault-root /path/to/vault --report /tmp/visibility-report.json
+# The report path MUST be outside the repo working tree — rationales
+# quote note content and must never be committed.
+py_venv_binary(
+    name = "classify_visibility_backfill",
+    srcs = ["knowledge/tools/classify_visibility_backfill.py"],
+    imports = ["."],
+    main = "knowledge/tools/classify_visibility_backfill.py",
+    visibility = ["//:__subpackages__"],
+    deps = [":monolith_backend"],
+)
+
 py_library(
     name = "monolith_backend",
     srcs = glob(
@@ -1859,6 +1875,16 @@ py_test(
 py_test(
     name = "knowledge_tools_add_visibility_field_test",
     srcs = ["knowledge/tools/add_visibility_field_test.py"],
+    imports = ["."],
+    deps = [
+        ":monolith_backend",
+        "@pip//pytest",
+    ],
+)
+
+py_test(
+    name = "knowledge_tools_classify_visibility_backfill_test",
+    srcs = ["knowledge/tools/classify_visibility_backfill_test.py"],
     imports = ["."],
     deps = [
         ":monolith_backend",

--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -53,6 +53,19 @@ py_venv_binary(
     deps = [":monolith_backend"],  # keep
 )
 
+# Phase-1 vault-mutation script: walk a vault and inject `visibility:` lines
+# into note frontmatter that lacks the key. Run via `bazel run`:
+#   bazel run //projects/monolith:add_visibility_field -- \
+#       --vault-root /path/to/vault --dirs _processed
+py_venv_binary(
+    name = "add_visibility_field",
+    srcs = ["knowledge/tools/add_visibility_field.py"],
+    imports = ["."],
+    main = "knowledge/tools/add_visibility_field.py",
+    visibility = ["//:__subpackages__"],
+    deps = [":monolith_backend"],
+)
+
 py_library(
     name = "monolith_backend",
     srcs = glob(
@@ -1836,6 +1849,16 @@ py_test(
 py_test(
     name = "knowledge_visibility_test",
     srcs = ["knowledge/visibility_test.py"],
+    imports = ["."],
+    deps = [
+        ":monolith_backend",
+        "@pip//pytest",
+    ],
+)
+
+py_test(
+    name = "knowledge_tools_add_visibility_field_test",
+    srcs = ["knowledge/tools/add_visibility_field_test.py"],
     imports = ["."],
     deps = [
         ":monolith_backend",

--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -59,11 +59,8 @@ py_venv_binary(
 #       --vault-root /path/to/vault --dirs _processed
 py_venv_binary(
     name = "add_visibility_field",
-    srcs = ["knowledge/tools/add_visibility_field.py"],
-    imports = ["."],
     main = "knowledge/tools/add_visibility_field.py",
     visibility = ["//:__subpackages__"],
-    deps = [":monolith_backend"],
 )
 
 # Phase-2 vault-mutation script: classify every unlabelled note via the
@@ -75,11 +72,8 @@ py_venv_binary(
 # quote note content and must never be committed.
 py_venv_binary(
     name = "classify_visibility_backfill",
-    srcs = ["knowledge/tools/classify_visibility_backfill.py"],
-    imports = ["."],
     main = "knowledge/tools/classify_visibility_backfill.py",
     visibility = ["//:__subpackages__"],
-    deps = [":monolith_backend"],
 )
 
 py_library(
@@ -2911,4 +2905,28 @@ py_test(
         "@pip//pytest",
         "@pip//pytest_asyncio",
     ],
+)
+
+semgrep_target_test(
+    name = "add_visibility_field_semgrep_test",
+    exclude_rules = [
+        "avoid-sqlalchemy-text",
+        "sqlmodel-datetime-without-factory",
+        "tainted-fastapi-http-request-httpx",
+        "tainted-path-traversal-stdlib-fastapi",
+    ],
+    rules = ["//bazel/semgrep/rules:python_rules"],
+    target = ":add_visibility_field",
+)
+
+semgrep_target_test(
+    name = "classify_visibility_backfill_semgrep_test",
+    exclude_rules = [
+        "avoid-sqlalchemy-text",
+        "sqlmodel-datetime-without-factory",
+        "tainted-fastapi-http-request-httpx",
+        "tainted-path-traversal-stdlib-fastapi",
+    ],
+    rules = ["//bazel/semgrep/rules:python_rules"],
+    target = ":classify_visibility_backfill",
 )

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.73.2
+version: 0.74.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/migrations/20260507000000_knowledge_notes_visibility.sql
+++ b/projects/monolith/chart/migrations/20260507000000_knowledge_notes_visibility.sql
@@ -1,0 +1,15 @@
+-- Add visibility label so notes can be selectively exposed via the
+-- /api/knowledge/public/* surface. NULL is treated as private at
+-- serving time; an explicit value is required to expose a note.
+ALTER TABLE knowledge.notes
+  ADD COLUMN visibility text NULL;
+
+ALTER TABLE knowledge.notes
+  ADD CONSTRAINT notes_visibility_chk
+  CHECK (visibility IS NULL OR visibility IN ('public', 'private'));
+
+-- Partial index: public set is the small, hot read path; private/null
+-- reads do not need the index.
+CREATE INDEX notes_visibility_idx
+  ON knowledge.notes (visibility)
+  WHERE visibility = 'public';

--- a/projects/monolith/chart/migrations/atlas.sum
+++ b/projects/monolith/chart/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:ASkXl5r8DxoK3NIZvp57PLgeoDbvJMdCrFT1R3QmH8o=
+h1:Ps8wyI+aPMoNddugYzH+Uyu+4dZ/KkUOqMPonH7Bm2A=
 20260330000000_initial_schema.sql h1:J2futpSW0nJAIRR7nR7ssT7LwXIYrvRI+PkHb5Y4tLI=
 20260403000000_chat_schema.sql h1:pERUFC0vzM95etRuzp43XzkCV7lBCzrrtY5Mk7aF3CA=
 20260404000000_chat_attachments.sql h1:tv+Fdbr1rQC5nzUxfaBC0O6fu2OMGgLWf+YNg1WQXi4=
@@ -20,4 +20,5 @@ h1:ASkXl5r8DxoK3NIZvp57PLgeoDbvJMdCrFT1R3QmH8o=
 20260425030000_knowledge_gaps_research_attempts.sql h1:aRmYysVgqThjJGiuI8qZPHnCtcO21666xNKayUN+lpI=
 20260425040000_knowledge_gaps_state_check_widen.sql h1:6NWOB+AVKMdGzLytpHAsV1CkTNN7f286idqR5wh87IE=
 20260506000000_knowledge_notes_layout_columns.sql h1:RzegpcFnYfeRKXVXdCosHAUWgFaWBbCr6cJwrQPGN9s=
-20260507120000_agent_tables.sql h1:4qwbdgPxJhF7t0sPWbMi9B59aYPECnybb9k9HeiU5+U=
+20260507000000_knowledge_notes_visibility.sql h1:uI7hC3tD4iajhaXOLjq0pi72o0QNcA+EhUtelRTpEE0=
+20260507120000_agent_tables.sql h1:+suMnYfML6T3+xhWSrSBh67F8lg7yL0qyrQhKdLrS1k=

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.73.2
+      targetRevision: 0.74.0
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/knowledge/frontmatter.py
+++ b/projects/monolith/knowledge/frontmatter.py
@@ -58,6 +58,7 @@ _PROMOTED_KEYS = {
     "title",
     "type",
     "status",
+    "visibility",
     "source",
     "tags",
     "aliases",
@@ -85,6 +86,7 @@ class ParsedFrontmatter:
     title: str | None = None
     type: str | None = None
     status: str | None = None
+    visibility: str | None = None
     source: str | None = None
     tags: list[str] = field(default_factory=list)
     aliases: list[str] = field(default_factory=list)
@@ -136,6 +138,15 @@ def _build(data: dict[str, Any]) -> ParsedFrontmatter:
     meta.title = _str_or_none(data.get("title"))
     meta.type = _str_or_none(data.get("type"))
     meta.status = _str_or_none(data.get("status"))
+    raw_visibility = _str_or_none(data.get("visibility"))
+    if raw_visibility in (None, "public", "private"):
+        meta.visibility = raw_visibility
+    else:
+        logger.warning(
+            "frontmatter visibility has unknown value %r — treating as null",
+            raw_visibility,
+        )
+        meta.visibility = None
     meta.source = _str_or_none(data.get("source"))
     meta.tags = _string_list(data.get("tags"))
     meta.aliases = _string_list(data.get("aliases"))

--- a/projects/monolith/knowledge/frontmatter_test.py
+++ b/projects/monolith/knowledge/frontmatter_test.py
@@ -164,6 +164,34 @@ class TestParse:
         meta, _ = parse(raw)
         assert meta.title == "ratio 3:1 works"
 
+    def test_visibility_public_parsed(self):
+        raw = "---\nid: a\ntitle: A\nvisibility: public\n---\nbody"
+        meta, _ = parse(raw)
+        assert meta.visibility == "public"
+
+    def test_visibility_private_parsed(self):
+        raw = "---\nid: a\ntitle: A\nvisibility: private\n---\nbody"
+        meta, _ = parse(raw)
+        assert meta.visibility == "private"
+
+    def test_visibility_missing_is_none(self):
+        raw = "---\nid: a\ntitle: A\n---\nbody"
+        meta, _ = parse(raw)
+        assert meta.visibility is None
+
+    def test_visibility_empty_string_is_none(self):
+        raw = "---\nid: a\ntitle: A\nvisibility:\n---\nbody"
+        meta, _ = parse(raw)
+        assert meta.visibility is None
+
+    def test_visibility_unknown_value_warns_and_nulls(self, caplog):
+        """Bad classifier output must not break ingest — warn, treat as null."""
+        raw = "---\nid: a\ntitle: A\nvisibility: yellow\n---\nbody"
+        with caplog.at_level("WARNING", logger="monolith.knowledge.frontmatter"):
+            meta, _ = parse(raw)
+        assert meta.visibility is None
+        assert any("visibility" in r.message.lower() for r in caplog.records)
+
     def test_nested_edges_not_broken_by_sanitizer(self):
         raw = (
             "---\n"

--- a/projects/monolith/knowledge/gardener.py
+++ b/projects/monolith/knowledge/gardener.py
@@ -17,6 +17,7 @@ from sqlmodel import Session, select
 
 from knowledge import frontmatter
 from knowledge.models import AtomRawProvenance, Note, RawInput
+from knowledge.visibility import VISIBILITY_CRITERIA
 
 logger = logging.getLogger("monolith.knowledge.gardener")
 
@@ -63,6 +64,7 @@ title: "<concise title — MUST be quoted if it contains a colon>"
 aliases: [<optional list of alternative wikilink forms — see Aliases section below>]
 type: atom|fact|active
 derived_from_raw: {raw_id}
+visibility: public|private   # REQUIRED — see criteria below
 tags: [optional]
 edges:
   derives_from: [source-slug]   # allowed edge types: derives_from | refines | generalizes | related | contradicts | supersedes
@@ -139,9 +141,11 @@ prefer that exact slug as the link target. If it doesn't exist, write
 the natural title-cased form — the gap-classifier and aliases system
 handle resolution.
 
+{VISIBILITY_CRITERIA}
+
 Title: {title}
 
-"""
+""".replace("{VISIBILITY_CRITERIA}", VISIBILITY_CRITERIA)
 
 _DISTILL_PROMPT = """\
 You are a knowledge gardener. A task has been completed. Extract any reusable

--- a/projects/monolith/knowledge/gardener.py
+++ b/projects/monolith/knowledge/gardener.py
@@ -160,6 +160,7 @@ Steps:
 4. If the task was routine with no notable learnings, create no new notes.
 5. Each new note must have YAML frontmatter with:
    - id, title, type (atom or fact), tags
+   - visibility: public|private   # REQUIRED — see criteria below
    - edges: derives_from: [{note_id}]
 6. Do NOT create a new active/task note. Only create atom or fact notes.
 
@@ -176,9 +177,11 @@ words ("the team", "production"), multi-clause phrases, and the atom's
 own title. If a target already exists at `{processed_root}/<slug>.md`,
 prefer that slug; otherwise write the natural title-cased form.
 
+{VISIBILITY_CRITERIA}
+
 Title: {title}
 
-"""
+""".replace("{VISIBILITY_CRITERIA}", VISIBILITY_CRITERIA)
 
 _CLAUDE_TIMEOUT_SECS = 900
 

--- a/projects/monolith/knowledge/gardener_distill_test.py
+++ b/projects/monolith/knowledge/gardener_distill_test.py
@@ -8,8 +8,26 @@ import pytest
 from sqlmodel import Session, SQLModel, create_engine, select
 from sqlmodel.pool import StaticPool
 
-from knowledge.gardener import GARDENER_VERSION, Gardener
+from knowledge.gardener import GARDENER_VERSION, Gardener, _DISTILL_PROMPT
 from knowledge.models import AtomRawProvenance, Note
+from knowledge.visibility import VISIBILITY_CRITERIA
+
+
+def test_distill_prompt_includes_visibility_criteria():
+    """The distill prompt must require a `visibility:` frontmatter field
+    and embed the verbatim criteria text from `knowledge.visibility`.
+
+    Distilled atoms come from completed task notes — typically workplace
+    specifics — so the criteria steer most outputs to `private`. Drift
+    between this prompt and the public-route filters is the primary leak
+    failure mode, hence the assertion on the imported constant.
+    """
+    rendered = _DISTILL_PROMPT.format(
+        note_id="n", note_path="x", processed_root="p", title="t"
+    )
+    assert "visibility:" in rendered
+    # criteria must be appended verbatim — drift = leak
+    assert VISIBILITY_CRITERIA.strip() in rendered
 
 
 @pytest.fixture(name="session")

--- a/projects/monolith/knowledge/gardener_test.py
+++ b/projects/monolith/knowledge/gardener_test.py
@@ -16,6 +16,23 @@ from knowledge.gardener import (
     _slugify,
     _split_frontmatter,
 )
+from knowledge.visibility import VISIBILITY_CRITERIA
+
+
+def test_gardener_prompt_includes_visibility_criteria():
+    """The atom-creation prompt must require a `visibility:` frontmatter field
+    and embed the verbatim criteria text from `knowledge.visibility`.
+
+    Drift between the criteria the LLM sees here and the criteria the public
+    routes / sanitizer enforce is the primary leakage failure mode for the
+    public-notes feature, so this test asserts on the imported constant.
+    """
+    rendered = _CLAUDE_PROMPT_HEADER.format(
+        raw_id="r", raw_file_path="x", processed_root="p", title="t"
+    )
+    assert "visibility: public|private" in rendered
+    # criteria must be appended verbatim — drift = leak
+    assert VISIBILITY_CRITERIA.strip() in rendered
 
 
 def _write(tmp_path: Path, rel: str, content: str) -> None:

--- a/projects/monolith/knowledge/models.py
+++ b/projects/monolith/knowledge/models.py
@@ -8,7 +8,7 @@ NoteId = NewType("NoteId", str)
 
 from pgvector.sqlalchemy import Vector
 from pydantic import field_validator
-from sqlalchemy import JSON, Column, Integer, String, UniqueConstraint
+from sqlalchemy import JSON, CheckConstraint, Column, Integer, String, UniqueConstraint
 from sqlalchemy.dialects.postgresql import ARRAY as PG_ARRAY
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlmodel import Field, SQLModel
@@ -43,6 +43,10 @@ GapState = Literal[
     "rejected",
 ]
 
+# Mirror of the CHECK constraint in
+# chart/migrations/20260507000000_knowledge_notes_visibility.sql - keep in sync.
+Visibility = Literal["public", "private"]
+
 # Postgres uses native TEXT[] for tags/aliases; SQLite falls back to JSON
 # so the in-memory test fixture can create the tables.
 _STRING_ARRAY = PG_ARRAY(String).with_variant(JSON(), "sqlite")
@@ -53,7 +57,17 @@ _JSONB = JSONB().with_variant(JSON(), "sqlite")
 
 class Note(SQLModel, table=True):  # nosemgrep: sqlmodel-datetime-without-factory
     __tablename__ = "notes"
-    __table_args__ = {"schema": "knowledge", "extend_existing": True}
+    __table_args__ = (
+        # Mirrors the CHECK constraint in
+        # chart/migrations/20260507000000_knowledge_notes_visibility.sql.
+        # Declared on the model (in addition to the migration) so SQLite-backed
+        # unit tests using SQLModel.metadata.create_all() also enforce it.
+        CheckConstraint(
+            "visibility IS NULL OR visibility IN ('public', 'private')",
+            name="notes_visibility_chk",
+        ),
+        {"schema": "knowledge", "extend_existing": True},
+    )
 
     id: int | None = Field(default=None, primary_key=True)
     note_id: NoteId = Field(
@@ -64,6 +78,9 @@ class Note(SQLModel, table=True):  # nosemgrep: sqlmodel-datetime-without-factor
     content_hash: str
     type: str | None = None
     status: str | None = None
+    visibility: Visibility | None = Field(
+        default=None, sa_column=Column(String, nullable=True)
+    )
     source: str | None = None
     tags: list[str] = Field(default_factory=list, sa_column=Column(_STRING_ARRAY))
     aliases: list[str] = Field(default_factory=list, sa_column=Column(_STRING_ARRAY))

--- a/projects/monolith/knowledge/models_test.py
+++ b/projects/monolith/knowledge/models_test.py
@@ -313,6 +313,35 @@ def test_note_model_has_optional_layout_columns():
     assert note.layout_y == -0.2
 
 
+def test_note_visibility_accepts_public_private_or_none():
+    Note(note_id="a", path="a.md", title="A", content_hash="h", visibility="public")
+    Note(note_id="b", path="b.md", title="B", content_hash="h", visibility="private")
+    Note(note_id="c", path="c.md", title="C", content_hash="h", visibility=None)
+
+
+def test_note_visibility_rejected_at_db_constraint(session):
+    """The Literal is type-only; the SQL CHECK is what enforces at write time.
+
+    Insert a bogus value via raw SQL and assert the constraint fires. The
+    CheckConstraint is declared on the Note model so SQLModel.metadata.create_all
+    emits it for SQLite too — keeping this test honest in CI without needing a
+    real Postgres instance.
+    """
+    from sqlalchemy import text
+    from sqlalchemy.exc import IntegrityError
+
+    with pytest.raises(IntegrityError):
+        session.execute(
+            text(
+                "INSERT INTO notes "
+                "(note_id, path, title, content_hash, visibility) "
+                "VALUES (:id, :p, :t, :h, :v)"
+            ),
+            {"id": "x", "p": "x.md", "t": "X", "h": "h", "v": "yellow"},
+        )
+        session.flush()
+
+
 def test_gap_has_note_id_unique_constraint():
     """note_id is the projection-layer identity — must be UNIQUE in the schema."""
     from sqlalchemy import UniqueConstraint

--- a/projects/monolith/knowledge/notes_crud_test.py
+++ b/projects/monolith/knowledge/notes_crud_test.py
@@ -243,3 +243,56 @@ class TestEditNote:
 
         assert r.status_code == 404
         assert "vault file missing" in r.json().get("detail", "")
+
+    def test_edit_note_preserves_visibility_in_frontmatter(self, client, tmp_path):
+        """PUT must preserve visibility frontmatter on body/title rewrites.
+
+        Regression guard for the public-notes-visibility V1: the PUT endpoint
+        rewrites the file's frontmatter from the parsed metadata. If a future
+        refactor drops ``visibility`` from the re-serialized frontmatter, the
+        next reconciler pass will null the column on disk and silently leak
+        previously-public notes back to private (or vice versa). Tasks 4-5
+        wire ``visibility`` through the parser -> store flow; this test makes
+        sure the PUT round-trip doesn't undo that on every manual edit.
+        """
+        note_path = "rt.md"
+        original = (
+            "---\n"
+            "title: Round Trip\n"
+            "visibility: public\n"
+            "tags:\n"
+            "- demo\n"
+            "---\n"
+            "\n"
+            "Original body\n"
+        )
+        (tmp_path / note_path).write_text(original)
+
+        mock_note = {
+            "note_id": "rt",
+            "title": "Round Trip",
+            "path": note_path,
+            "type": "note",
+            "tags": ["demo"],
+        }
+
+        with patch("knowledge.router.KnowledgeStore") as MockStore:
+            MockStore.return_value.get_note_by_id.return_value = mock_note
+
+            r = client.put(
+                "/api/knowledge/notes/rt",
+                json={"content": "Edited body."},
+            )
+
+        assert r.status_code == 200
+
+        # Re-parse the rewritten file and assert the visibility key survived
+        # the round-trip through the PUT serializer.
+        written = (tmp_path / note_path).read_text()
+        parts = written.split("---\n")
+        assert len(parts) >= 3, f"Expected frontmatter delimiters, got: {written}"
+        fm = yaml.safe_load(parts[1])
+        assert fm.get("visibility") == "public", (
+            f"PUT dropped visibility from frontmatter; got fm={fm!r}"
+        )
+        assert "Edited body." in parts[2]

--- a/projects/monolith/knowledge/research_writer.py
+++ b/projects/monolith/knowledge/research_writer.py
@@ -60,6 +60,7 @@ def write_research_raw(
 
     fm = {
         "type": "research",
+        "visibility": "public",
         "id": slug,
         "title": f"Research note: {title}",
         "derived_from_gap": slug,

--- a/projects/monolith/knowledge/research_writer_test.py
+++ b/projects/monolith/knowledge/research_writer_test.py
@@ -130,3 +130,35 @@ def test_research_raw_path_format(tmp_path: Path) -> None:
     assert out.parent.name == "research"
     assert out.parent.parent.name == "_inbox"
     assert out.name == "thing.md"
+
+
+def test_research_raw_sets_visibility_public(tmp_path: Path) -> None:
+    out_path = write_research_raw(
+        vault_root=tmp_path,
+        slug="dora-metrics",
+        title="DORA Metrics",
+        summary="...",
+        supported_claims=[],
+        sources=[],
+        agent_model="sonnet",
+        researched_at="2026-05-07T12:00:00Z",
+    )
+    text = out_path.read_text()
+    assert "visibility: public" in text
+    fm = _read_fm(out_path)
+    assert fm["visibility"] == "public"
+
+
+def test_failed_research_does_not_set_visibility(tmp_path: Path) -> None:
+    """Quarantined drafts are forensic; visibility is irrelevant."""
+    out_path = quarantine(
+        vault_root=tmp_path,
+        slug="bad",
+        attempt=1,
+        summary="...",
+        pre_filter_claims=[],
+        sources=[],
+        agent_model="sonnet",
+        researched_at="2026-05-07T12:00:00Z",
+    )
+    assert "visibility" not in out_path.read_text()

--- a/projects/monolith/knowledge/router.py
+++ b/projects/monolith/knowledge/router.py
@@ -23,6 +23,7 @@ from typing import Literal
 import yaml
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response
 from pydantic import BaseModel
+from sqlalchemy import or_
 from sqlmodel import Session, select
 
 from app.db import get_session
@@ -33,7 +34,12 @@ from knowledge.ingest_queue import IngestQueueItem
 from knowledge.models import AtomRawProvenance, Note, NoteLink, RawInput
 from knowledge.service import DEFAULT_VAULT_ROOT, VAULT_ROOT_ENV
 from knowledge.store import GRAPH_NOTE_TYPES, KnowledgeStore
-from knowledge.visibility import public_notes_filter
+from knowledge.visibility import (
+    effective_visibility,
+    public_notes_filter,
+    sanitize_public_body,
+)
+from knowledge.visibility import _slugify as _visibility_slugify
 from shared.embedding import EmbeddingClient
 
 logger = logging.getLogger(__name__)
@@ -237,6 +243,70 @@ def get_public_graph(
         response.headers[key] = value
     logger.info("public.graph.served nodes=%d edges=%d", len(nodes), len(edges))
     return {"nodes": nodes, "edges": edges}
+
+
+@router.get("/public/notes/{note_id}")
+def get_public_note(
+    note_id: str,
+    session: Session = Depends(get_session),
+) -> dict:
+    """Return a single note iff its effective visibility is ``public``.
+
+    The 404 response is identical for missing notes AND for notes that
+    exist but are private/null-visibility — the existence of a private
+    note must never be observable. Body wikilinks targeting private
+    notes are stripped to plain text via :func:`sanitize_public_body`;
+    wikilinks targeting public notes are left intact for the frontend
+    renderer to resolve.
+    """
+    note = session.exec(select(Note).where(Note.note_id == note_id)).one_or_none()
+    if note is None or effective_visibility(note) != "public":
+        # Identical 404 for missing and private — never expose existence.
+        # The reason is logged but not surfaced in the response.
+        reason = "not_found" if note is None else "private_gated"
+        logger.info("public.note.404 note_id=%s reason=%s", note_id, reason)
+        raise HTTPException(status_code=404, detail="Not Found")
+
+    # Load the body from the vault. Reuse the same path-traversal guard
+    # the private GET /notes/{id} uses so a malformed path can't escape
+    # the vault root.
+    vault_root = _get_vault_root()
+    resolved = (vault_root / note.path).resolve()
+    if not resolved.is_relative_to(vault_root) or not resolved.is_file():
+        # Same identical 404 — don't leak that the DB row exists but
+        # the file is missing/escaped.
+        logger.info("public.note.404 note_id=%s reason=vault_file_missing", note_id)
+        raise HTTPException(status_code=404, detail="Not Found")
+    raw = resolved.read_text()
+    _, body = frontmatter.parse(raw)
+
+    # Slugified ids of every non-public note. ``sanitize_public_body``
+    # slugifies wikilink display text via ``visibility._slugify`` and
+    # drops the bracketing on any match — use the same helper here so
+    # the sets compare consistently. Note: ``or_(... != 'public', ...
+    # IS NULL)`` is required because in SQL ``NULL != 'public'`` is
+    # ``NULL``, not true, so a bare ``!=`` would silently leave NULL-
+    # visibility notes out of the private set.
+    private_slugs = {
+        _visibility_slugify(n.note_id)
+        for n in session.exec(
+            select(Note).where(
+                or_(Note.visibility != "public", Note.visibility.is_(None))
+            )
+        ).all()
+    }
+    sanitized = sanitize_public_body(body, private_slugs)
+
+    indexed_at = _as_utc(note.indexed_at)
+    logger.info("public.note.served note_id=%s", note_id)
+    return {
+        "note_id": note.note_id,
+        "title": note.title,
+        "tags": list(note.tags or []),
+        "aliases": list(note.aliases or []),
+        "indexed_at": indexed_at.isoformat() if indexed_at is not None else None,
+        "body": sanitized,
+    }
 
 
 @router.get("/notes/{note_id}")

--- a/projects/monolith/knowledge/router.py
+++ b/projects/monolith/knowledge/router.py
@@ -223,6 +223,8 @@ def edit_note(
         fm_dict["type"] = parsed.type
     if parsed.status is not None:
         fm_dict["status"] = parsed.status
+    if parsed.visibility is not None:
+        fm_dict["visibility"] = parsed.visibility
     if parsed.source is not None:
         fm_dict["source"] = parsed.source
     if parsed.tags:

--- a/projects/monolith/knowledge/router.py
+++ b/projects/monolith/knowledge/router.py
@@ -30,9 +30,10 @@ from knowledge import frontmatter
 from knowledge.gaps import answer_gap, list_review_queue, split_csv
 from knowledge.gardener import Gardener, _slugify
 from knowledge.ingest_queue import IngestQueueItem
-from knowledge.models import AtomRawProvenance, RawInput
+from knowledge.models import AtomRawProvenance, Note, NoteLink, RawInput
 from knowledge.service import DEFAULT_VAULT_ROOT, VAULT_ROOT_ENV
-from knowledge.store import KnowledgeStore
+from knowledge.store import GRAPH_NOTE_TYPES, KnowledgeStore
+from knowledge.visibility import public_notes_filter
 from shared.embedding import EmbeddingClient
 
 logger = logging.getLogger(__name__)
@@ -138,6 +139,104 @@ def get_graph(
     for key, value in headers.items():
         response.headers[key] = value
     return graph
+
+
+@router.get("/public/graph")
+def get_public_graph(
+    request: Request,
+    response: Response,
+    session: Session = Depends(get_session),
+):
+    """Public-only knowledge graph: only public nodes, only doubly-public edges.
+
+    Mirrors :func:`get_graph` but applies ``public_notes_filter()`` to both
+    ends of every edge so a private note can never appear as a node *or* a
+    target. Same Cache-Control + ETag semantics so the CDN treats this
+    payload identically.
+    """
+    # Only public notes whose type is in the renderable graph set. Gap
+    # stubs (type='gap') with NULL visibility are excluded by the
+    # visibility filter alone, but this also keeps the type filter
+    # consistent with get_graph().
+    public_note_rows = session.execute(
+        select(
+            Note.note_id,
+            Note.title,
+            Note.type,
+            Note.indexed_at,
+            Note.layout_x,
+            Note.layout_y,
+        )
+        .where(public_notes_filter())
+        .where(Note.type.in_(list(GRAPH_NOTE_TYPES)))
+    ).all()
+
+    public_note_ids = {row.note_id for row in public_note_rows}
+    slug_to_note_id = {_slugify(nid): nid for nid in public_note_ids}
+
+    if public_note_ids:
+        # Single SQL join enforces both-ends-public: source side via the
+        # join filter, target side via the IN clause against the resolved
+        # public slug set (mirrors get_graph's slug→canonical resolution).
+        link_rows = session.execute(
+            select(
+                Note.note_id.label("source"),
+                NoteLink.target_id.label("target"),
+                NoteLink.kind,
+                NoteLink.edge_type,
+            )
+            .join(Note, NoteLink.src_note_fk == Note.id)
+            .where(public_notes_filter())
+        ).all()
+    else:
+        link_rows = []
+
+    edges: list[dict] = []
+    for row in link_rows:
+        canonical_target = slug_to_note_id.get(_slugify(row.target))
+        if canonical_target is None:
+            continue
+        edges.append(
+            {
+                "source": row.source,
+                "target": canonical_target,
+                "kind": row.kind,
+                "edge_type": row.edge_type,
+            }
+        )
+
+    degree_by_note_id: dict[str, int] = {}
+    for edge in edges:
+        degree_by_note_id[edge["source"]] = degree_by_note_id.get(edge["source"], 0) + 1
+        degree_by_note_id[edge["target"]] = degree_by_note_id.get(edge["target"], 0) + 1
+
+    nodes = [
+        {
+            "id": row.note_id,
+            "title": row.title,
+            "type": row.type,
+            "degree": degree_by_note_id.get(row.note_id, 0),
+            "x": row.layout_x,
+            "y": row.layout_y,
+        }
+        for row in public_note_rows
+    ]
+
+    indexed_at = _as_utc(
+        max((row.indexed_at for row in public_note_rows), default=None)
+    )
+    etag = _graph_etag(len(public_note_rows), indexed_at)
+    headers = {"Cache-Control": _GRAPH_CACHE_CONTROL, "ETag": etag}
+    if indexed_at is not None:
+        headers["Last-Modified"] = format_datetime(indexed_at, usegmt=True)
+
+    if request.headers.get("if-none-match") == etag:
+        return Response(status_code=304, headers=headers)
+
+    for key, value in headers.items():
+        response.headers[key] = value
+    logger.info("public.graph.served nodes=%d edges=%d", len(nodes), len(edges))
+    return {"nodes": nodes, "edges": edges}
 
 
 @router.get("/notes/{note_id}")

--- a/projects/monolith/knowledge/router_test.py
+++ b/projects/monolith/knowledge/router_test.py
@@ -946,3 +946,229 @@ class TestPublicGraphEndpoint:
             app.dependency_overrides.clear()
 
         assert etag_a != etag_b
+
+
+def _seed_public_note_file(
+    vault_dir,
+    *,
+    note_id: str,
+    body: str,
+    filename: str | None = None,
+) -> str:
+    """Write a body file under ``vault_dir`` and return its relative path.
+
+    The endpoint loads the body from disk via ``vault_root / note.path``,
+    so tests that exercise the served body must materialise the file.
+    """
+    rel_path = filename or f"{note_id}.md"
+    dest = vault_dir / rel_path
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    # Wrap in a minimal frontmatter terminator so frontmatter.parse()
+    # treats the supplied text as the body. Without the terminator, the
+    # whole file is body — which is also fine but explicit is better.
+    dest.write_text(f"---\nid: {note_id}\n---\n\n{body}")
+    return rel_path
+
+
+class TestPublicNoteEndpoint:
+    """Tests for GET /api/knowledge/public/notes/{note_id}.
+
+    Strict-visibility per-note endpoint paired with /public/graph. Two
+    properties under explicit assertion:
+
+    1. Identical 404 response for missing AND for private notes — the
+       existence of a private note must never be observable.
+    2. Body wikilinks targeting private notes are stripped to plain
+       text via :func:`sanitize_public_body`; wikilinks targeting public
+       notes are left intact for the frontend to resolve.
+    """
+
+    def test_public_note_200_for_public(self, real_session, tmp_path, monkeypatch):
+        vault_dir = tmp_path / "vault"
+        vault_dir.mkdir()
+        path_a = _seed_public_note_file(
+            vault_dir, note_id="pub-A", body="Hello [[pub-B]] world."
+        )
+        path_b = _seed_public_note_file(vault_dir, note_id="pub-B", body="B body.")
+        monkeypatch.setenv(VAULT_ROOT_ENV, str(vault_dir))
+
+        store = KnowledgeStore(real_session)
+        _upsert(
+            store,
+            note_id="pub-A",
+            path=path_a,
+            content_hash="h-pa",
+            title="Pub A",
+            metadata=_meta(title="Pub A", type="atom", visibility="public"),
+            n_chunks=0,
+        )
+        _upsert(
+            store,
+            note_id="pub-B",
+            path=path_b,
+            content_hash="h-pb",
+            title="Pub B",
+            metadata=_meta(title="Pub B", type="atom", visibility="public"),
+            n_chunks=0,
+        )
+
+        app.dependency_overrides[get_session] = lambda: real_session
+        try:
+            c = TestClient(app, raise_server_exceptions=False)
+            res = c.get("/api/knowledge/public/notes/pub-A")
+        finally:
+            app.dependency_overrides.clear()
+
+        assert res.status_code == 200
+        body = res.json()
+        # Public-target wikilink left intact for the frontend to resolve.
+        assert "[[pub-B]]" in body["body"]
+
+    def test_public_note_404_for_missing(self, real_session, tmp_path, monkeypatch):
+        vault_dir = tmp_path / "vault"
+        vault_dir.mkdir()
+        monkeypatch.setenv(VAULT_ROOT_ENV, str(vault_dir))
+
+        app.dependency_overrides[get_session] = lambda: real_session
+        try:
+            c = TestClient(app, raise_server_exceptions=False)
+            res = c.get("/api/knowledge/public/notes/does-not-exist")
+        finally:
+            app.dependency_overrides.clear()
+
+        assert res.status_code == 404
+
+    def test_public_note_404_for_private_same_response_shape(
+        self, real_session, tmp_path, monkeypatch
+    ):
+        """Private and missing notes return byte-identical 404 payloads."""
+        vault_dir = tmp_path / "vault"
+        vault_dir.mkdir()
+        path_priv = _seed_public_note_file(vault_dir, note_id="priv-X", body="secret.")
+        monkeypatch.setenv(VAULT_ROOT_ENV, str(vault_dir))
+
+        store = KnowledgeStore(real_session)
+        _upsert(
+            store,
+            note_id="priv-X",
+            path=path_priv,
+            content_hash="h-px",
+            title="Priv X",
+            metadata=_meta(title="Priv X", type="atom", visibility="private"),
+            n_chunks=0,
+        )
+
+        app.dependency_overrides[get_session] = lambda: real_session
+        try:
+            c = TestClient(app, raise_server_exceptions=False)
+            res_priv = c.get("/api/knowledge/public/notes/priv-X")
+            res_miss = c.get("/api/knowledge/public/notes/does-not-exist")
+        finally:
+            app.dependency_overrides.clear()
+
+        assert res_priv.status_code == 404
+        assert res_miss.status_code == 404
+        # Identical body — never expose that priv-X exists.
+        assert res_priv.json() == res_miss.json()
+
+    def test_public_note_strips_private_wikilinks_from_body(
+        self, real_session, tmp_path, monkeypatch
+    ):
+        vault_dir = tmp_path / "vault"
+        vault_dir.mkdir()
+        path_a = _seed_public_note_file(
+            vault_dir,
+            note_id="pub-A",
+            body="See [[pub-B]] and avoid [[Some Colleague]].",
+        )
+        path_b = _seed_public_note_file(vault_dir, note_id="pub-B", body="B.")
+        path_priv = _seed_public_note_file(
+            vault_dir, note_id="some-colleague", body="private."
+        )
+        monkeypatch.setenv(VAULT_ROOT_ENV, str(vault_dir))
+
+        store = KnowledgeStore(real_session)
+        _upsert(
+            store,
+            note_id="pub-A",
+            path=path_a,
+            content_hash="h-pa",
+            title="Pub A",
+            metadata=_meta(title="Pub A", type="atom", visibility="public"),
+            n_chunks=0,
+        )
+        _upsert(
+            store,
+            note_id="pub-B",
+            path=path_b,
+            content_hash="h-pb",
+            title="Pub B",
+            metadata=_meta(title="Pub B", type="atom", visibility="public"),
+            n_chunks=0,
+        )
+        _upsert(
+            store,
+            note_id="some-colleague",
+            path=path_priv,
+            content_hash="h-sc",
+            title="Some Colleague",
+            metadata=_meta(title="Some Colleague", type="atom", visibility="private"),
+            n_chunks=0,
+        )
+
+        app.dependency_overrides[get_session] = lambda: real_session
+        try:
+            c = TestClient(app, raise_server_exceptions=False)
+            res = c.get("/api/knowledge/public/notes/pub-A")
+        finally:
+            app.dependency_overrides.clear()
+
+        assert res.status_code == 200
+        payload = res.json()
+        body = payload["body"]
+        assert "[[pub-B]]" in body
+        assert "[[Some Colleague]]" not in body
+        # Bracket text is preserved — sanitize_public_body strips the
+        # [[…]] wrapper but keeps the display text. See the design note
+        # in knowledge/visibility.py: the loud leak is the *graph edge*
+        # (already filtered by /public/graph), not the display string.
+        assert "Some Colleague" in body
+
+    def test_public_note_response_excludes_internal_fields(
+        self, real_session, tmp_path, monkeypatch
+    ):
+        """The ``extra`` JSONB blob (arbitrary system metadata) is never
+        serialized into the public response — we serialize an explicit
+        whitelist of fields, not ``**note.dict()``."""
+        vault_dir = tmp_path / "vault"
+        vault_dir.mkdir()
+        path_a = _seed_public_note_file(vault_dir, note_id="pub-A", body="Hello world.")
+        monkeypatch.setenv(VAULT_ROOT_ENV, str(vault_dir))
+
+        store = KnowledgeStore(real_session)
+        _upsert(
+            store,
+            note_id="pub-A",
+            path=path_a,
+            content_hash="h-pa",
+            title="Pub A",
+            metadata=_meta(
+                title="Pub A",
+                type="atom",
+                visibility="public",
+                extra={"internal_only": "secret"},
+            ),
+            n_chunks=0,
+        )
+
+        app.dependency_overrides[get_session] = lambda: real_session
+        try:
+            c = TestClient(app, raise_server_exceptions=False)
+            res = c.get("/api/knowledge/public/notes/pub-A")
+        finally:
+            app.dependency_overrides.clear()
+
+        assert res.status_code == 200
+        body = res.json()
+        assert "extra" not in body
+        assert "secret" not in str(body)

--- a/projects/monolith/knowledge/router_test.py
+++ b/projects/monolith/knowledge/router_test.py
@@ -778,3 +778,171 @@ class TestGraphEndpoint:
         assert second.content == b""
         assert second.headers["etag"] == etag
         assert "s-maxage=3600" in second.headers["cache-control"]
+
+
+class TestPublicGraphEndpoint:
+    """Tests for GET /api/knowledge/public/graph.
+
+    Strict-visibility variant of /graph: only ``visibility='public'`` notes
+    appear as nodes, and edges are kept only when *both* endpoints are
+    public. Mirrors the cache-header / ETag contract of the private graph
+    so the CDN behaves identically.
+    """
+
+    def test_public_graph_only_public_nodes(self, real_session):
+        """Private/null-visibility notes are excluded from nodes; private
+        targets are excluded from edges even when the source is public."""
+        store = KnowledgeStore(real_session)
+        # pub-A links to pub-B (kept) and to priv-X (dropped: target private).
+        _upsert(
+            store,
+            note_id="pub-A",
+            path="pub-a.md",
+            content_hash="h-pa",
+            title="Pub A",
+            metadata=_meta(title="Pub A", type="atom", visibility="public"),
+            n_chunks=0,
+            links=[
+                Link(target="pub-B", display=None),
+                Link(target="priv-X", display=None),
+            ],
+        )
+        _upsert(
+            store,
+            note_id="pub-B",
+            path="pub-b.md",
+            content_hash="h-pb",
+            title="Pub B",
+            metadata=_meta(title="Pub B", type="atom", visibility="public"),
+            n_chunks=0,
+        )
+        _upsert(
+            store,
+            note_id="priv-X",
+            path="priv-x.md",
+            content_hash="h-px",
+            title="Priv X",
+            metadata=_meta(title="Priv X", type="atom", visibility="private"),
+            n_chunks=0,
+        )
+        # null-Y links to pub-B but is itself null-visibility → both the
+        # node and the edge must be dropped.
+        _upsert(
+            store,
+            note_id="null-Y",
+            path="null-y.md",
+            content_hash="h-ny",
+            title="Null Y",
+            metadata=_meta(title="Null Y", type="atom", visibility=None),
+            n_chunks=0,
+            links=[Link(target="pub-B", display=None)],
+        )
+
+        app.dependency_overrides[get_session] = lambda: real_session
+        try:
+            c = TestClient(app, raise_server_exceptions=False)
+            res = c.get("/api/knowledge/public/graph")
+        finally:
+            app.dependency_overrides.clear()
+
+        assert res.status_code == 200
+        body = res.json()
+        node_ids = {n["id"] for n in body["nodes"]}
+        assert node_ids == {"pub-A", "pub-B"}
+        edge_pairs = {(e["source"], e["target"]) for e in body["edges"]}
+        assert edge_pairs == {("pub-A", "pub-B")}
+
+    def test_public_graph_excludes_gap_stubs(self, real_session):
+        """Gap stub notes (type='gap', visibility=NULL) never appear in
+        the public graph regardless of how they're linked."""
+        store = KnowledgeStore(real_session)
+        # Public note that wikilinks to an unresolved gap stub.
+        _upsert(
+            store,
+            note_id="pub-A",
+            path="pub-a.md",
+            content_hash="h-pa",
+            title="Pub A",
+            metadata=_meta(title="Pub A", type="atom", visibility="public"),
+            n_chunks=0,
+            links=[Link(target="UnresolvedThing", display=None)],
+        )
+        # The gap stub the gardener would create — auto-generated, no
+        # explicit visibility, type='gap'.
+        _upsert(
+            store,
+            note_id="unresolved-thing",
+            path="_researching/unresolved-thing.md",
+            content_hash="h-ut",
+            title="UnresolvedThing",
+            metadata=_meta(title="UnresolvedThing", type="gap", visibility=None),
+            n_chunks=0,
+        )
+
+        app.dependency_overrides[get_session] = lambda: real_session
+        try:
+            c = TestClient(app, raise_server_exceptions=False)
+            res = c.get("/api/knowledge/public/graph")
+        finally:
+            app.dependency_overrides.clear()
+
+        body = res.json()
+        node_ids = {n["id"] for n in body["nodes"]}
+        assert "unresolved-thing" not in node_ids
+
+    def test_public_graph_cache_headers(self, real_session):
+        """Public graph carries the same CDN cache directives as /graph."""
+        store = KnowledgeStore(real_session)
+        _upsert(
+            store,
+            note_id="pub-A",
+            path="pub-a.md",
+            content_hash="h-pa",
+            title="Pub A",
+            metadata=_meta(title="Pub A", type="atom", visibility="public"),
+            n_chunks=0,
+        )
+
+        app.dependency_overrides[get_session] = lambda: real_session
+        try:
+            c = TestClient(app, raise_server_exceptions=False)
+            res = c.get("/api/knowledge/public/graph")
+        finally:
+            app.dependency_overrides.clear()
+
+        cc = res.headers.get("cache-control", "")
+        assert "s-maxage=3600" in cc
+        assert "stale-while-revalidate=86400" in cc
+
+    def test_public_graph_etag_changes_when_public_set_mutates(self, real_session):
+        """Adding a new public note invalidates the ETag (node-count
+        component changes even if timestamps don't move enough)."""
+        store = KnowledgeStore(real_session)
+        _upsert(
+            store,
+            note_id="pub-A",
+            path="pub-a.md",
+            content_hash="h-pa",
+            title="Pub A",
+            metadata=_meta(title="Pub A", type="atom", visibility="public"),
+            n_chunks=0,
+        )
+
+        app.dependency_overrides[get_session] = lambda: real_session
+        try:
+            c = TestClient(app, raise_server_exceptions=False)
+            etag_a = c.get("/api/knowledge/public/graph").headers["etag"]
+            _upsert(
+                store,
+                note_id="pub-B",
+                path="pub-b.md",
+                content_hash="h-pb",
+                title="Pub B",
+                metadata=_meta(title="Pub B", type="atom", visibility="public"),
+                n_chunks=0,
+            )
+            etag_b = c.get("/api/knowledge/public/graph").headers["etag"]
+        finally:
+            app.dependency_overrides.clear()
+
+        assert etag_a != etag_b

--- a/projects/monolith/knowledge/store.py
+++ b/projects/monolith/knowledge/store.py
@@ -97,6 +97,7 @@ class KnowledgeStore:
                 content_hash=content_hash,
                 type=metadata.type,
                 status=metadata.status,
+                visibility=metadata.visibility,
                 source=metadata.source,
                 tags=metadata.tags,
                 aliases=metadata.aliases,

--- a/projects/monolith/knowledge/store_test.py
+++ b/projects/monolith/knowledge/store_test.py
@@ -191,6 +191,51 @@ class TestUpsertNote:
         assert by_kind["link"][0].target_title == "the b"
 
 
+class TestUpsertVisibility:
+    """``visibility`` from frontmatter must be persisted to the DB column.
+
+    The reconciler treats disk frontmatter as canonical, so every upsert
+    must rewrite this column — including back to NULL when the key is
+    removed.
+    """
+
+    def test_upsert_writes_visibility_public(self, store, session):
+        _upsert(
+            store,
+            note_id="vis-pub",
+            path="vp.md",
+            metadata=_meta(title="VP", visibility="public"),
+        )
+        note = session.execute(
+            select(Note).where(Note.note_id == "vis-pub")
+        ).scalar_one()
+        assert note.visibility == "public"
+
+    def test_upsert_writes_visibility_private(self, store, session):
+        _upsert(
+            store,
+            note_id="vis-priv",
+            path="vpr.md",
+            metadata=_meta(title="VPr", visibility="private"),
+        )
+        note = session.execute(
+            select(Note).where(Note.note_id == "vis-priv")
+        ).scalar_one()
+        assert note.visibility == "private"
+
+    def test_upsert_null_visibility_writes_null(self, store, session):
+        _upsert(
+            store,
+            note_id="vis-null",
+            path="vn.md",
+            metadata=_meta(title="VN", visibility=None),
+        )
+        note = session.execute(
+            select(Note).where(Note.note_id == "vis-null")
+        ).scalar_one()
+        assert note.visibility is None
+
+
 class TestUpsertAtomicity:
     def test_upsert_replace_is_atomic_on_mid_insert_failure(self, store, session):
         _upsert(

--- a/projects/monolith/knowledge/tools/__init__.py
+++ b/projects/monolith/knowledge/tools/__init__.py
@@ -1,0 +1,1 @@
+"""Vault-mutation tools for knowledge management (Phase-1, Phase-2 scripts)."""

--- a/projects/monolith/knowledge/tools/add_visibility_field.py
+++ b/projects/monolith/knowledge/tools/add_visibility_field.py
@@ -1,0 +1,104 @@
+"""Phase-1 mechanical injection of `visibility:` into existing note frontmatter.
+
+Idempotent. No LLM calls. No DB writes. Walks the configured vault dirs,
+inserts `visibility:` (empty value) into every .md file that lacks the
+key. The resulting frontmatter is parsed by the reconciler on its next
+pass and persists null in the DB column — which the serving layer
+treats as private.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+from knowledge import frontmatter
+
+logger = logging.getLogger("monolith.knowledge.tools.add_visibility_field")
+
+_FRONTMATTER_RE = re.compile(r"^---\n(.*?)\n---\n", re.DOTALL)
+
+
+@dataclass
+class Stats:
+    added: int = 0
+    already_set: int = 0
+    parse_skipped: int = 0
+
+
+def _insert_visibility_line(block: str) -> str:
+    """Insert `visibility:` after `id:` (or at the top if no id)."""
+    lines = block.splitlines()
+    insert_at = 0
+    for i, line in enumerate(lines):
+        if line.startswith("id:"):
+            insert_at = i + 1
+            break
+    lines.insert(insert_at, "visibility:")
+    return "\n".join(lines)
+
+
+def _process_file(path: Path) -> str | None:
+    """Return the new file content, or None if no change is needed."""
+    raw = path.read_text()
+    match = _FRONTMATTER_RE.match(raw)
+    if not match:
+        return "PARSE_SKIP"
+
+    block = match.group(1)
+    try:
+        meta, _ = frontmatter.parse(raw)
+    except frontmatter.FrontmatterError as exc:
+        logger.warning("parse failure for %s: %s — skipping", path, exc)
+        return "PARSE_SKIP"
+
+    if "visibility" in {line.split(":", 1)[0].strip() for line in block.splitlines()}:
+        return None
+
+    new_block = _insert_visibility_line(block)
+    return raw[: match.start()] + f"---\n{new_block}\n---\n" + raw[match.end() :]
+
+
+def _atomic_write(path: Path, content: str) -> None:
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(content)
+    os.replace(tmp, path)
+
+
+def run(*, vault_root: Path, dirs: list[str]) -> Stats:
+    stats = Stats()
+    for d in dirs:
+        for md in (vault_root / d).rglob("*.md"):
+            outcome = _process_file(md)
+            if outcome == "PARSE_SKIP":
+                stats.parse_skipped += 1
+                continue
+            if outcome is None:
+                stats.already_set += 1
+                continue
+            _atomic_write(md, outcome)
+            stats.added += 1
+    return stats
+
+
+def main() -> int:
+    logging.basicConfig(level=logging.INFO)
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--vault-root", type=Path, required=True)
+    parser.add_argument("--dirs", nargs="+", default=["_processed"])
+    args = parser.parse_args()
+    stats = run(vault_root=args.vault_root, dirs=args.dirs)
+    print(
+        f"added={stats.added} already_set={stats.already_set} "
+        f"parse_skipped={stats.parse_skipped}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/projects/monolith/knowledge/tools/add_visibility_field_test.py
+++ b/projects/monolith/knowledge/tools/add_visibility_field_test.py
@@ -47,7 +47,8 @@ def test_skips_files_with_no_frontmatter(tmp_path):
 
 def test_skips_files_with_unparseable_frontmatter(tmp_path):
     note = tmp_path / "_processed/broken.md"
-    _write(note, "---\nthis: is: not: yaml\n---\nbody\n")
+    # Unclosed flow collection — sanitizer doesn't touch this; yaml raises.
+    _write(note, "---\nfoo: [unclosed\n---\nbody\n")
     stats = run(vault_root=tmp_path, dirs=["_processed"])
     assert stats.parse_skipped == 1
 

--- a/projects/monolith/knowledge/tools/add_visibility_field_test.py
+++ b/projects/monolith/knowledge/tools/add_visibility_field_test.py
@@ -1,0 +1,68 @@
+"""Tests for the mechanical Phase-1 visibility field injector."""
+
+from pathlib import Path
+
+from knowledge.tools.add_visibility_field import run
+
+
+def _write(p: Path, body: str) -> None:
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(body)
+
+
+def test_inserts_visibility_into_files_lacking_it(tmp_path):
+    note = tmp_path / "_processed/foo.md"
+    _write(note, "---\nid: foo\ntitle: Foo\n---\nbody\n")
+    stats = run(vault_root=tmp_path, dirs=["_processed"])
+    assert stats.added == 1
+    assert "visibility:\n" in note.read_text()
+
+
+def test_skips_files_already_with_visibility(tmp_path):
+    note = tmp_path / "_processed/bar.md"
+    _write(note, "---\nid: bar\ntitle: Bar\nvisibility: public\n---\nbody\n")
+    before = note.read_text()
+    stats = run(vault_root=tmp_path, dirs=["_processed"])
+    assert stats.added == 0
+    assert stats.already_set == 1
+    assert note.read_text() == before  # byte-stable
+
+
+def test_idempotent_second_run(tmp_path):
+    note = tmp_path / "_processed/baz.md"
+    _write(note, "---\nid: baz\ntitle: Baz\n---\nbody\n")
+    run(vault_root=tmp_path, dirs=["_processed"])
+    after_first = note.read_text()
+    run(vault_root=tmp_path, dirs=["_processed"])
+    assert note.read_text() == after_first
+
+
+def test_skips_files_with_no_frontmatter(tmp_path):
+    note = tmp_path / "_processed/raw.md"
+    _write(note, "Just a body, no frontmatter.\n")
+    stats = run(vault_root=tmp_path, dirs=["_processed"])
+    assert stats.added == 0
+    assert stats.parse_skipped == 1
+
+
+def test_skips_files_with_unparseable_frontmatter(tmp_path):
+    note = tmp_path / "_processed/broken.md"
+    _write(note, "---\nthis: is: not: yaml\n---\nbody\n")
+    stats = run(vault_root=tmp_path, dirs=["_processed"])
+    assert stats.parse_skipped == 1
+
+
+def test_atomic_write_does_not_truncate_on_failure(tmp_path, monkeypatch):
+    note = tmp_path / "_processed/atomic.md"
+    _write(note, "---\nid: a\n---\nbody\n")
+
+    def boom(*args, **kwargs):
+        raise OSError("boom")
+
+    monkeypatch.setattr("os.replace", boom)
+    try:
+        run(vault_root=tmp_path, dirs=["_processed"])
+    except OSError:
+        pass
+    # Original file is intact
+    assert "id: a" in note.read_text()

--- a/projects/monolith/knowledge/tools/classify_visibility_backfill.py
+++ b/projects/monolith/knowledge/tools/classify_visibility_backfill.py
@@ -1,0 +1,245 @@
+"""Phase-2 backfill: classify every unlabelled note via the `claude` CLI.
+
+The script writes ``visibility: public`` or ``visibility: private`` into
+each note's frontmatter via in-place line replacement (no full YAML
+round-trip). Per ``memory/feedback_claude_cli_subprocess_for_tos.md``,
+we shell out to the ``claude`` CLI rather than the Anthropic SDK.
+
+Resumable: re-running picks up only still-unlabelled notes. Crash
+recovery is implicit — partial work is on disk.
+
+Report: a JSON file written OUTSIDE the repo (the script refuses
+report paths inside the working tree). Rationales quote note content
+and must not be committed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import re
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Callable
+
+from knowledge import frontmatter
+from knowledge.visibility import VISIBILITY_CRITERIA
+
+logger = logging.getLogger("monolith.knowledge.tools.classify_visibility_backfill")
+
+_FRONTMATTER_RE = re.compile(r"^(---\n)(.*?)(\n---\n)", re.DOTALL)
+_VISIBILITY_LINE_RE = re.compile(r"^visibility:.*$", re.MULTILINE)
+
+
+class BackfillError(Exception):
+    """Raised when the classifier output cannot be safely applied."""
+
+
+@dataclass
+class _ReportEntry:
+    note_id: str
+    decision: str | None
+    rationale: str | None
+    error: str | None = None
+
+
+@dataclass
+class _Report:
+    entries: list[_ReportEntry] = field(default_factory=list)
+
+
+def _find_repo_root() -> Path | None:
+    """Walk up from this file looking for a `.git` directory.
+
+    Returns the repo root, or ``None`` if no `.git` is found (e.g. running
+    from inside a Bazel runfiles tree). Callers should treat ``None`` as
+    "no repo to protect against" and skip the report-path check.
+    """
+    here = Path(__file__).resolve()
+    for ancestor in (here, *here.parents):
+        if (ancestor / ".git").exists():
+            return ancestor
+    return None
+
+
+def _check_report_path_outside_repo(report: Path, repo_root: Path | None) -> None:
+    """Raise ``BackfillError`` if ``report`` would land inside ``repo_root``.
+
+    Anchored to the actual repo root (detected via ``.git/``) rather than
+    ``Path.cwd()``, which is unreliable: pytest tmpdirs sit outside the
+    repo and would defeat a cwd-based check.
+    """
+    if repo_root is None:
+        return
+    try:
+        report.resolve().relative_to(repo_root.resolve())
+    except ValueError:
+        return  # outside the repo — safe
+    raise BackfillError(
+        f"refusing to write report at {report} — must be outside the repo "
+        "working tree (rationales quote note content; never commit)"
+    )
+
+
+def classify_one(*, body: str, title: str) -> tuple[str, str]:
+    """Single LLM call via the ``claude`` CLI subprocess.
+
+    Returns ``(decision, rationale)``. Raises ``BackfillError`` on any
+    failure mode (non-zero exit, non-JSON output, invalid decision).
+    """
+    prompt = (
+        f"{VISIBILITY_CRITERIA}\n\n"
+        f"Title: {title}\n\nBody:\n{body}\n\n"
+        "Respond with strict JSON:\n"
+        '{"visibility": "public" | "private", "rationale": "<one sentence>"}\n'
+    )
+    proc = subprocess.run(
+        ["claude", "--print", "--output-format", "json"],
+        input=prompt,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    if proc.returncode != 0:
+        raise BackfillError(
+            f"claude exit={proc.returncode} stderr={proc.stderr[:200]!r}"
+        )
+    try:
+        # `claude --output-format json` wraps the response; the actual
+        # answer is in the .result field. Adjust if the CLI shape differs.
+        outer = json.loads(proc.stdout)
+        text = outer.get("result", proc.stdout)
+        parsed = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise BackfillError(f"non-JSON output: {exc}") from exc
+
+    decision = parsed.get("visibility")
+    rationale = parsed.get("rationale", "")
+    if decision not in {"public", "private"}:
+        raise BackfillError(f"invalid decision {decision!r}")
+    return decision, str(rationale)
+
+
+def _replace_visibility_line(content: str, value: str) -> str:
+    match = _FRONTMATTER_RE.match(content)
+    if not match:
+        raise BackfillError("note has no frontmatter")
+    head, block, tail = match.group(1), match.group(2), match.group(3)
+    if _VISIBILITY_LINE_RE.search(block):
+        new_block = _VISIBILITY_LINE_RE.sub(f"visibility: {value}", block)
+    else:
+        new_block = block + f"\nvisibility: {value}"
+    return head + new_block + tail + content[match.end() :]
+
+
+def _atomic_write(path: Path, content: str) -> None:
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(content)
+    os.replace(tmp, path)
+
+
+def _is_unlabelled(meta: frontmatter.ParsedFrontmatter) -> bool:
+    return meta.visibility in (None, "")
+
+
+def run(
+    *,
+    vault_root: Path,
+    report: Path,
+    run_one_for_test: Callable[[str], tuple[str, str]] | None = None,
+    max_files: int | None = None,
+    _repo_root_for_test: Path | None = None,
+) -> _Report:
+    """Walk vault and classify every unlabelled note.
+
+    ``run_one_for_test`` is the seam tests use to avoid hitting the real
+    ``claude`` CLI; production passes ``None`` and we use ``classify_one``.
+    ``_repo_root_for_test`` overrides the ``.git``-based repo-root detection
+    so the report-path safety check is exercised under pytest tmpdirs (which
+    sit outside the worktree).
+    """
+    repo_root = (
+        _repo_root_for_test if _repo_root_for_test is not None else _find_repo_root()
+    )
+    _check_report_path_outside_repo(report, repo_root)
+
+    rep = _Report()
+
+    files = sorted((vault_root / "_processed").rglob("*.md"))
+    processed = 0
+    for path in files:
+        if max_files is not None and processed >= max_files:
+            break
+        raw = path.read_text()
+        try:
+            meta, body = frontmatter.parse(raw)
+        except frontmatter.FrontmatterError:
+            rep.entries.append(
+                _ReportEntry(
+                    note_id=path.stem,
+                    decision=None,
+                    rationale=None,
+                    error="frontmatter parse failure",
+                )
+            )
+            continue
+        if not _is_unlabelled(meta):
+            continue
+
+        try:
+            if run_one_for_test is not None:
+                decision, rationale = run_one_for_test(body)
+            else:
+                decision, rationale = classify_one(
+                    body=body, title=meta.title or path.stem
+                )
+        except BackfillError as exc:
+            rep.entries.append(
+                _ReportEntry(
+                    note_id=path.stem,
+                    decision=None,
+                    rationale=None,
+                    error=str(exc),
+                )
+            )
+            continue
+
+        new = _replace_visibility_line(raw, decision)
+        _atomic_write(path, new)
+        rep.entries.append(
+            _ReportEntry(
+                note_id=path.stem,
+                decision=decision,
+                rationale=rationale,
+            )
+        )
+        processed += 1
+
+    report.write_text(json.dumps([e.__dict__ for e in rep.entries], indent=2))
+    return rep
+
+
+def main() -> int:
+    logging.basicConfig(level=logging.INFO)
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--vault-root", type=Path, required=True)
+    parser.add_argument(
+        "--report",
+        type=Path,
+        required=True,
+        help="must be outside the repo working tree",
+    )
+    args = parser.parse_args()
+    rep = run(vault_root=args.vault_root, report=args.report)
+    classified = sum(1 for e in rep.entries if e.decision)
+    errored = sum(1 for e in rep.entries if e.error)
+    print(f"classified={classified} errored={errored} report={args.report}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/projects/monolith/knowledge/tools/classify_visibility_backfill_test.py
+++ b/projects/monolith/knowledge/tools/classify_visibility_backfill_test.py
@@ -1,0 +1,157 @@
+"""Tests for the LLM-driven Phase-2 visibility backfill."""
+
+import json
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from knowledge.tools.classify_visibility_backfill import (
+    BackfillError,
+    classify_one,
+    run,
+)
+
+
+def _seed_note(p: Path, slug: str, visibility: str | None = None) -> Path:
+    fm = f"---\nid: {slug}\ntitle: {slug}\n"
+    if visibility is not None:
+        fm += f"visibility: {visibility}\n"
+    else:
+        fm += "visibility:\n"
+    fm += f"---\nbody for {slug}.\n"
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(fm)
+    return p
+
+
+@pytest.fixture
+def vault(tmp_path):
+    _seed_note(tmp_path / "_processed/a.md", "a", visibility=None)
+    _seed_note(tmp_path / "_processed/b.md", "b", visibility="public")
+    _seed_note(tmp_path / "_processed/c.md", "c", visibility=None)
+    return tmp_path
+
+
+def test_refuses_report_path_inside_repo(vault):
+    # Anchor the safety check to the vault itself so a report path
+    # *inside* the vault triggers the refusal even though the vault is
+    # under pytest's tmpdir (which sits outside the actual git root).
+    with pytest.raises(BackfillError, match="outside the repo"):
+        run(
+            vault_root=vault,
+            report=vault / "out.json",
+            run_one_for_test=lambda body: ("private", "test"),
+            _repo_root_for_test=vault,
+        )
+
+
+def _report_outside_repo(tmp_path: Path, name: str) -> Path:
+    """Return a report path that is guaranteed outside the actual git repo.
+
+    pytest's ``tmp_path`` resolves under the OS tmp dir (e.g.
+    ``/private/var/folders/...``), which is outside the homelab worktree
+    regardless of where pytest is invoked from — so the script's safety
+    check accepts it without needing ``_repo_root_for_test``.
+    """
+    return tmp_path / name
+
+
+def test_skips_already_labelled_notes(vault, tmp_path):
+    calls = []
+
+    def fake(body):
+        calls.append(body)
+        return "public", "ok"
+
+    run(
+        vault_root=vault,
+        report=_report_outside_repo(tmp_path, "report-skip.json"),
+        run_one_for_test=fake,
+    )
+    # b.md is already "public" — skip; only a + c go through classifier.
+    assert len(calls) == 2
+
+
+def test_writes_decision_back_to_frontmatter(vault, tmp_path):
+    def fake(body):
+        return "public", "looks public"
+
+    run(
+        vault_root=vault,
+        report=_report_outside_repo(tmp_path, "report-write.json"),
+        run_one_for_test=fake,
+    )
+    a = (vault / "_processed/a.md").read_text()
+    assert "visibility: public" in a
+
+
+def test_strict_json_parse_failure_leaves_file_unchanged(vault, tmp_path):
+    def bad(body):
+        raise BackfillError("invalid JSON")
+
+    run(
+        vault_root=vault,
+        report=_report_outside_repo(tmp_path, "report-bad.json"),
+        run_one_for_test=bad,
+    )
+    a = (vault / "_processed/a.md").read_text()
+    # a.md still has the empty `visibility:` line untouched.
+    assert "visibility:\n" in a or "visibility: \n" in a
+
+
+def test_resumable_after_partial_run(vault, tmp_path):
+    # First run: only handle one file (a → public via max_files=1).
+    def fake_a(body):
+        return "public", "ok"
+
+    run(
+        vault_root=vault,
+        report=_report_outside_repo(tmp_path, "report-r1.json"),
+        run_one_for_test=fake_a,
+        max_files=1,
+    )
+
+    # Second run: c is the only remaining unlabelled note.
+    seen = []
+
+    def fake_c(body):
+        seen.append(body)
+        return "private", "ok"
+
+    run(
+        vault_root=vault,
+        report=_report_outside_repo(tmp_path, "report-r2.json"),
+        run_one_for_test=fake_c,
+    )
+    assert len(seen) == 1
+
+
+@patch("knowledge.tools.classify_visibility_backfill.subprocess.run")
+def test_classify_one_parses_strict_json(mock_run):
+    mock_run.return_value = subprocess.CompletedProcess(
+        args=[],
+        returncode=0,
+        stdout=json.dumps(
+            {"result": json.dumps({"visibility": "public", "rationale": "concept"})}
+        ),
+        stderr="",
+    )
+    decision, rationale = classify_one(body="body", title="t")
+    assert decision == "public"
+    assert rationale == "concept"
+
+
+@patch("knowledge.tools.classify_visibility_backfill.subprocess.run")
+def test_classify_one_rejects_unknown_decision(mock_run):
+    mock_run.return_value = subprocess.CompletedProcess(
+        args=[],
+        returncode=0,
+        stdout=json.dumps(
+            {"result": json.dumps({"visibility": "yellow", "rationale": "x"})}
+        ),
+        stderr="",
+    )
+    with pytest.raises(BackfillError):
+        classify_one(body="body", title="t")

--- a/projects/monolith/knowledge/visibility.py
+++ b/projects/monolith/knowledge/visibility.py
@@ -1,0 +1,116 @@
+"""Visibility helper: criteria, coalescing rule, wikilink sanitiser, SQL filter.
+
+All knowledge-pipeline code that needs to reason about public vs private
+content imports from here. Drift between the criteria the LLM sees and
+the criteria the routes enforce is the most common way these systems leak.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Iterable, Literal
+
+from sqlalchemy.sql import ColumnElement
+
+from knowledge.models import Note
+
+VISIBILITY_CRITERIA = """\
+## Visibility (REQUIRED frontmatter field)
+
+Every note MUST set `visibility: public` or `visibility: private`.
+This controls whether the note appears on Joe's public website.
+
+Default to `private` whenever you are uncertain.
+
+Mark `public` when the note is about:
+- General engineering concepts, principles, heuristics (DORA, Conway's Law,
+  blameless postmortems, etc.) — anything you'd find in a textbook, blog,
+  or conference talk.
+- Skills, technologies, or methods covered in Joe's public CV / GitHub /
+  conference talks.
+- Verifiable facts about external systems, libraries, protocols, or tools.
+- Book / paper / talk summaries when the source is publicly available.
+
+Mark `private` when the note involves any of:
+- Names of current or former colleagues, managers, reports, or interviewers.
+- Specific employers in non-public ways: project codenames, internal
+  architecture, compensation, performance reviews, hiring decisions.
+- Job-search activity: interview prep, comp negotiation, target companies,
+  reasons-for-leaving, offer comparisons.
+- Personal life: family, finances, health, relationships, legal matters,
+  living situation.
+- Critiques or hot takes about identifiable people or companies that
+  aren't already in Joe's public writing.
+- Active tasks, daily/weekly journals, blockers — anything operational
+  about Joe's current work.
+
+Edge cases:
+- An atom about a generally-applicable pattern that includes a
+  workplace-specific example: rewrite the example out and mark public,
+  OR keep the example and mark private. Do not mark public with the
+  example intact.
+- A fact about an external library mentioned during a private incident:
+  the fact is public, the incident framing is private — split into two
+  notes if needed.
+
+When in doubt: `private`.
+"""
+
+EffectiveVisibility = Literal["public", "private"]
+
+_VALID = {"public", "private"}
+
+# A wikilink is a [[target]] possibly containing a |alias suffix that
+# we ignore for resolution. We resolve to a slug by lowercasing and
+# normalising spaces — same convention as gardener / gap_classifier.
+_WIKILINK_RE = re.compile(r"\[\[([^\[\]\n|]+)(?:\|[^\[\]\n]+)?\]\]")
+_SLUG_RE = re.compile(r"[^a-z0-9]+")
+
+
+def effective_visibility(note: Note | object) -> EffectiveVisibility:
+    """Return the public-or-private decision for a note.
+
+    Null and unknown values both fall to ``private`` so a misconfigured
+    or malformed value never accidentally exposes content.
+    """
+    raw = getattr(note, "visibility", None)
+    if raw in _VALID:
+        return raw  # type: ignore[return-value]
+    return "private"
+
+
+def _slugify(text: str) -> str:
+    return _SLUG_RE.sub("-", text.strip().lower()).strip("-")
+
+
+def sanitize_public_body(body: str, private_target_ids: Iterable[str]) -> str:
+    """Strip every wikilink whose target is in ``private_target_ids``.
+
+    Strip = replace ``[[Foo Bar]]`` with ``Foo Bar``. Bracket text is not
+    redacted — the design accepts that wikilink display text may contain
+    weak signals (the loud leak is the *graph edge*, which the public
+    graph endpoint already filters out).
+
+    Wikilinks whose target is NOT in ``private_target_ids`` are left
+    untouched so the frontend renderer can still resolve them to public
+    notes.
+    """
+    private = {p for p in private_target_ids}
+
+    def _replace(match: re.Match[str]) -> str:
+        display = match.group(1)
+        slug = _slugify(display)
+        if slug in private:
+            return display
+        return match.group(0)
+
+    return _WIKILINK_RE.sub(_replace, body)
+
+
+def public_notes_filter() -> ColumnElement[bool]:
+    """SQLAlchemy clause selecting only public notes.
+
+    Use ``Note.visibility == 'public'`` rather than ``COALESCE(..., 'private')``
+    so the partial index ``notes_visibility_idx`` is selected by the planner.
+    """
+    return Note.visibility == "public"

--- a/projects/monolith/knowledge/visibility_test.py
+++ b/projects/monolith/knowledge/visibility_test.py
@@ -1,0 +1,76 @@
+"""Tests for the visibility helper: coalescing, sanitisation, SQL filter."""
+
+from __future__ import annotations
+
+import pytest
+
+from knowledge.visibility import (
+    VISIBILITY_CRITERIA,
+    effective_visibility,
+    sanitize_public_body,
+)
+
+
+class _StubNote:
+    def __init__(self, visibility: str | None) -> None:
+        self.visibility = visibility
+
+
+def test_effective_visibility_public():
+    assert effective_visibility(_StubNote("public")) == "public"
+
+
+def test_effective_visibility_private():
+    assert effective_visibility(_StubNote("private")) == "private"
+
+
+def test_effective_visibility_null_defaults_private():
+    assert effective_visibility(_StubNote(None)) == "private"
+
+
+def test_effective_visibility_unknown_defaults_private():
+    """Defensive: a leaked-through bad value still defaults to private."""
+    assert effective_visibility(_StubNote("yellow")) == "private"
+
+
+def test_sanitize_no_links_passthrough():
+    body = "Plain text with no wikilinks."
+    assert sanitize_public_body(body, private_target_ids=set()) == body
+
+
+def test_sanitize_link_to_public_kept():
+    body = "See [[dora-metrics]] for the four key metrics."
+    assert sanitize_public_body(body, private_target_ids=set()) == body
+
+
+def test_sanitize_link_to_private_stripped_to_text():
+    body = "Discussed with [[Some Colleague]] yesterday."
+    out = sanitize_public_body(body, private_target_ids={"some-colleague"})
+    assert out == "Discussed with Some Colleague yesterday."
+
+
+def test_sanitize_link_to_unresolved_gap_stripped_to_text():
+    """Unresolved targets (gaps) are treated as private — no link."""
+    body = "The [[Mystery Concept]] is still being researched."
+    out = sanitize_public_body(body, private_target_ids={"mystery-concept"})
+    assert out == "The Mystery Concept is still being researched."
+
+
+def test_sanitize_multiple_links_per_line():
+    body = "Both [[dora-metrics]] and [[Private Topic]] matter."
+    out = sanitize_public_body(body, private_target_ids={"private-topic"})
+    assert out == "Both [[dora-metrics]] and Private Topic matter."
+
+
+def test_sanitize_malformed_brackets_left_alone():
+    """We only strip well-formed [[X]] — partial brackets are not links."""
+    body = "[ [not a link] ] and [[ok]] and [unfinished"
+    out = sanitize_public_body(body, private_target_ids=set())
+    assert "[[ok]]" in out
+    assert "[unfinished" in out
+
+
+def test_criteria_text_present():
+    """Smoke check — every prompt that imports this string must keep it."""
+    assert "visibility: public" in VISIBILITY_CRITERIA
+    assert "When in doubt: `private`." in VISIBILITY_CRITERIA


### PR DESCRIPTION
## Summary

V1 of public notes — a binary `visibility: public | private` label on every
note plus a strictly filtered public API at `/api/knowledge/public/...`.
Frontend (V2) and chat (V3) are separate plans.

Frontmatter is canonical; the DB column mirrors it; null is treated as
private. The new `knowledge/visibility.py` module owns the criteria
prompt, the coalescing rule, the wikilink sanitiser, and the SQL filter.
Public routes call only into that helper.

Two vault-mutation scripts ship under `knowledge/tools/`:
- `add_visibility_field` — Phase 1, mechanical, no LLM, idempotent.
- `classify_visibility_backfill` — Phase 2, LLM via `claude` CLI, single-commit.

Design doc: `docs/plans/2026-05-07-public-notes-visibility-design.md`
Plan doc: `docs/plans/2026-05-07-public-notes-visibility-v1-plan.md`

## Test plan

- [ ] CI green
- [ ] Migration applies cleanly in CI's ephemeral DB
- [ ] `format` produced no further BUILD changes
- [ ] Public endpoints exist; private routes unchanged
- [ ] Phase-1 / Phase-2 scripts import and `--help` parses

## Rollout (post-merge)

1. Run Phase 1 script against vault; commit + push.
2. Wait for reconciler to populate the column with nulls.
3. Run Phase 2 script (single `bazel run`, single vault commit, `/tmp/`-bound report).
4. Smoke-test public endpoints.