### PR TITLE
fix(monolith): remove semicolons from agent.mcp docstrings

### DIFF
--- a/projects/monolith/agent/mcp.py
+++ b/projects/monolith/agent/mcp.py
@@ -74,7 +74,7 @@ def _serialize_dead_letter(row: dict) -> dict:
 async def monolith_agent_acquire_lock(key: str, holder: str, ttl_secs: int) -> dict:
     """Acquire an opportunistic TTL lock keyed by ``key``.
 
-    Steals expired locks; refuses live ones. Returns ``acquired=False``
+    Steals expired locks but refuses live ones. Returns ``acquired=False``
     when another holder has the key with a still-live TTL.
     """
     result = locks.acquire(key, holder, ttl_secs)
@@ -123,8 +123,8 @@ async def monolith_agent_notify(
 ) -> dict:
     """Post a Discord message via the in-process bot.
 
-    Defaults to the homelab channel from settings; ``channel``, if
-    specified, must be in the configured allow-list.
+    Defaults to the homelab channel from settings. The ``channel`` arg,
+    if specified, must be in the configured allow-list.
     """
     return await notify_mod.notify(message, level=level, channel=channel)
 

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.73.0
+version: 0.73.1
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.73.0
+      targetRevision: 0.73.1
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
## Summary

Context Forge (in-cluster MCP gateway) rejects tool descriptions containing \`;\` as a sanitization policy. Discovery silently dropped 2 of 16 agent tools (\`acquire_lock\` and \`notify\`) on this rule. Their docstrings had semicolons.

Server-side monolith was fine all along — \`mcp.client.sse\` against the live pod returned all 16 tools. The 14/16 split was at the gateway layer.

## Changes

Two one-line rephrases:
- \`acquire_lock\`: \"Steals expired locks**;** refuses live ones\" → \"Steals expired locks **but** refuses live ones\"
- \`notify\`: \"Defaults to the homelab channel from settings**;** \\\`channel\\\`, if specified...\" → \"Defaults to the homelab channel from settings**.** The \\\`channel\\\` arg, if specified...\"

No code logic changes.

## Test plan

- [ ] CI green
- [ ] After merge: re-add monolith server in Context Forge admin (or wait for next discovery refresh) → all 16 agent tools appear in tools table
- [ ] Claude.ai connector palette shows \`monolith-agent-notify\` and \`monolith-agent-acquire-lock\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)