### PR TITLE
test(monolith): regression-guard for Context Forge tool description validation

### DIFF
--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -2841,3 +2841,15 @@ py_test(
         "@pip//pytest_asyncio",
     ],
 )
+
+py_test(
+    name = "agent_mcp_description_compliance_test",
+    srcs = ["agent/mcp_description_compliance_test.py"],
+    imports = ["."],
+    deps = [
+        ":monolith_backend",
+        "@pip//fastmcp",
+        "@pip//pytest",
+        "@pip//pytest_asyncio",
+    ],
+)

--- a/projects/monolith/agent/mcp_description_compliance_test.py
+++ b/projects/monolith/agent/mcp_description_compliance_test.py
@@ -1,0 +1,63 @@
+"""Asserts every registered MCP tool description survives Context Forge sanitization.
+
+Context Forge (the in-cluster MCP gateway at
+``context-forge-gateway-mcp-stack-mcpgateway`` in namespace ``mcp``)
+runs a security validator on every tool description it discovers.
+Tools whose description contains any of the patterns below are
+silently dropped from the proxied surface, with only an ERROR log
+line in the gateway pod. The result is partial-discovery (e.g. 14 of
+16 tools visible to Claude.ai) that is invisible from monolith's side.
+
+This test asserts at CI time that no future MCP tool addition can
+sneak in a forbidden pattern and ship to production with silent
+discovery loss.
+
+Source of the rules (verified 2026-05-08 against the deployed gateway
+image): ``/app/mcpgateway/schemas.py`` ``ToolCreate.validate_description``
+plus ``MAX_DESCRIPTION_LENGTH`` from ``/app/mcpgateway/common/validators.py``.
+If Context Forge is upgraded and the rules change, update the
+``FORBIDDEN_PATTERNS`` and ``MAX_DESCRIPTION_LENGTH`` constants below.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+# From mcpgateway/schemas.py:436 — copied verbatim. Backticks are
+# explicitly allowed (commonly used for Markdown inline code).
+FORBIDDEN_PATTERNS = ["&&", ";", "||", "$(", "|", "> ", "< "]
+
+# From mcpgateway/common/validators.py — gateway default is 8192 (8KB).
+# Real cap could differ if the gateway is configured with a smaller
+# value, but we assert against the default; a smaller cap would
+# similarly catch over-long descriptions in CI.
+MAX_DESCRIPTION_LENGTH = 8192
+
+
+@pytest.mark.asyncio
+async def test_all_mcp_tool_descriptions_pass_context_forge_validation():
+    """Every registered tool's description must be Context Forge-safe."""
+    importlib.import_module("agent.mcp")
+    importlib.import_module("knowledge.mcp")
+    from app.mcp_app import mcp
+
+    tools = await mcp.list_tools()
+    violations: list[str] = []
+    for tool in tools:
+        desc = tool.description or ""
+        for pat in FORBIDDEN_PATTERNS:
+            if pat in desc:
+                violations.append(f"  {tool.name}: contains forbidden pattern {pat!r}")
+        if len(desc) > MAX_DESCRIPTION_LENGTH:
+            violations.append(
+                f"  {tool.name}: description too long "
+                f"({len(desc)} > {MAX_DESCRIPTION_LENGTH})"
+            )
+    assert not violations, (
+        "These MCP tool descriptions will be silently dropped by Context Forge:\n"
+        + "\n".join(violations)
+        + "\n\nFix: rephrase the docstring to avoid the listed pattern. "
+        "See feedback_context_forge_description_sanitization.md memory entry."
+    )

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.73.1
+version: 0.73.2
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.73.1
+      targetRevision: 0.73.2
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
## Summary

Adds an automated test that walks every registered MCP tool and asserts the description does not contain Context Forge's forbidden patterns (\`&&\`, \`;\`, \`||\`, \`\$(\`, \`|\`, \`> \`, \`< \`) or exceed the 8KB max description length.

This prevents the same regression that caused PR #2300: tools whose docstrings hit Context Forge's sanitizer get silently dropped from discovery, producing partial-tool surfaces visible to Claude.ai with no signal upstream.

## Source of the rules

Patterns lifted verbatim from \`/app/mcpgateway/schemas.py\` \`ToolCreate.validate_description\` in the deployed Context Forge gateway image (verified 2026-05-08). Constants documented in the test docstring; if Context Forge's policy expands, update \`FORBIDDEN_PATTERNS\` in the test.

## Test plan

- [ ] CI green on this PR
- [ ] Test fails fast on any future PR that introduces a forbidden character in a tool description

🤖 Generated with [Claude Code](https://claude.com/claude-code)