### PR TITLE
fix(monolith): expose /api/knowledge/public on the public ingress

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.74.1
+version: 0.74.2
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/templates/httproute-public.yaml
+++ b/projects/monolith/chart/templates/httproute-public.yaml
@@ -20,6 +20,18 @@ spec:
       backendRefs:
         - name: {{ include "monolith.fullname" . }}
           port: {{ .Values.cfIngress.public.servicePort | int }}
+    # Public knowledge API — narrowly scoped to /api/knowledge/public/* so we
+    # never expose the unfiltered /api/knowledge/{notes,gaps,dead-letter,…}
+    # surface on the public hostname. The backend itself enforces the same
+    # filter via knowledge.visibility.public_notes_filter; this is the
+    # ingress-layer belt-and-braces.
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /api/knowledge/public
+      backendRefs:
+        - name: {{ include "monolith.fullname" . }}
+          port: {{ .Values.service.apiPort | int }}
     # Everything else — SvelteKit reroute hook maps to /public/ internally
     - matches:
         - path:

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.74.1
+      targetRevision: 0.74.2
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
## Summary

Follow-up to #2298 / #2303. The FastAPI public endpoint exists and works (verified via in-cluster port-forward), but the public HTTPRoute had no rule routing `/api/knowledge/public/*` to the backend, so browser requests to `https://public.jomcgi.dev/api/knowledge/public/graph` fell through to the SvelteKit catch-all and returned SvelteKit's 404 HTML page.

Adds one narrowly-scoped rule to `httproute-public.yaml` mirroring the private route's `/api/knowledge` rule, but scoped to `/api/knowledge/public` only — never `/api/knowledge` broadly, since that would also expose `/notes/{id}`, `/dead-letter`, `/ingest`, and other admin-only endpoints on the public hostname.

Belt-and-braces: the backend already enforces visibility filtering via `knowledge.visibility.public_notes_filter`. This is the ingress-layer guard.

## Test plan

- [ ] CI green
- [ ] After merge: `curl https://public.jomcgi.dev/api/knowledge/public/graph` returns 200
- [ ] `curl https://public.jomcgi.dev/api/knowledge/notes/<any>` still 404 (not exposed)