### PR TITLE
fix(setup): authenticate crane to ghcr.io before bootstrap

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.64.0
+version: 0.65.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.64.0
+      targetRevision: 0.65.0
       helm:
         releaseName: monolith
         valueFiles:

--- a/tools/setup-cloud-env.sh
+++ b/tools/setup-cloud-env.sh
@@ -7,8 +7,9 @@
 # Required env vars (read at Claude Code session time, not by this script):
 #   BUILDBUDDY_API_KEY  - for the BuildBuddy MCP server (defined in .mcp.json)
 #
-# Optional env vars used by this script:
-#   GITHUB_TOKEN        - if set, used to authenticate the gh CLI
+# Required env vars (also used by this script):
+#   GITHUB_TOKEN        - authenticates crane to ghcr.io (needed to pull the
+#                         private tools image) and the gh CLI
 
 set -euo pipefail
 
@@ -57,19 +58,32 @@ else
 fi
 
 # ---------------------------------------------------------------------------
-# 3. Pull vendored tools (helm, prettier, gofumpt, ruff, etc.)
+# 3. Authenticate crane to ghcr.io (required to pull the private tools image)
+# ---------------------------------------------------------------------------
+if [[ -n "${GITHUB_TOKEN:-}" ]]; then
+	echo "==> Authenticating crane to ghcr.io"
+	echo "$GITHUB_TOKEN" | crane auth login ghcr.io --username x-access-token --password-stdin
+elif crane auth get ghcr.io >/dev/null 2>&1; then
+	echo "==> crane already authenticated to ghcr.io"
+else
+	echo "WARNING: \$GITHUB_TOKEN is not set and crane has no cached ghcr.io credentials."
+	echo "         bootstrap.sh may fail if the tools image is private."
+fi
+
+# ---------------------------------------------------------------------------
+# 4. Pull vendored tools (helm, prettier, gofumpt, ruff, etc.)
 # ---------------------------------------------------------------------------
 echo "==> Running ./bootstrap.sh"
 ./bootstrap.sh
 
 # ---------------------------------------------------------------------------
-# 4. direnv allow (per-path approval — required for .envrc to load)
+# 5. direnv allow (per-path approval — required for .envrc to load)
 # ---------------------------------------------------------------------------
 echo "==> direnv allow"
 direnv allow .
 
 # ---------------------------------------------------------------------------
-# 5. gh CLI auth (if GITHUB_TOKEN is set and not already authenticated)
+# 6. gh CLI auth (if GITHUB_TOKEN is set and not already authenticated)
 # ---------------------------------------------------------------------------
 if command -v gh >/dev/null 2>&1; then
 	if gh auth status >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary

- Adds a `crane auth login ghcr.io` step using `$GITHUB_TOKEN` before `bootstrap.sh` runs, since the tools image is private and requires authentication
- Falls back gracefully if crane already has cached credentials
- Emits a clear warning (rather than a cryptic crane error) if `GITHUB_TOKEN` is unset and no cached credentials exist
- Clarifies in the script header that `GITHUB_TOKEN` is required, not optional

## Test plan

- [ ] Set `GITHUB_TOKEN` in env, run `tools/setup-cloud-env.sh` on a fresh Linux machine — crane should authenticate and `bootstrap.sh` should pull the tools image successfully
- [ ] Run script a second time — all steps should skip as already-done (idempotent)
- [ ] Run without `GITHUB_TOKEN` set — script should print the warning and then fail at `bootstrap.sh` with the existing crane error (no regression vs before)

https://claude.ai/code/session_01E2MicTz2bKE4nVHVm9ACE4

---
_Generated by [Claude Code](https://claude.ai/code/session_01E2MicTz2bKE4nVHVm9ACE4)_


<img width="429" height="138" alt="image" src="https://github.com/user-attachments/assets/fa0cc219-14e8-4d09-9093-90ef5d8759ff" />
