### PR TITLE
perf(knowledge): run research-gaps job once per day

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.74.2
+version: 0.74.3
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.74.2
+      targetRevision: 0.74.3
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/knowledge/service.py
+++ b/projects/monolith/knowledge/service.py
@@ -41,7 +41,7 @@ _CLASSIFY_INTERVAL_SECS = 60  # 1-minute tick
 # risking a second replica racing Edit calls on the same stubs.
 _CLASSIFY_TTL_SECS = 360  # 300s subprocess timeout + 60s headroom
 _CLASSIFY_BATCH_SIZE = 10
-_RESEARCH_INTERVAL_SECS = 300
+_RESEARCH_INTERVAL_SECS = 86400  # once per day
 _RESEARCH_TTL_SECS = (
     1200  # 20min lock-lease (Sonnet research runs can be slow with web tools)
 )

--- a/projects/monolith/knowledge/service_test.py
+++ b/projects/monolith/knowledge/service_test.py
@@ -611,7 +611,7 @@ class TestClassifyGapsHandler:
         )
 
     def test_on_startup_registers_research_gaps_job(self, session):
-        """Startup registers knowledge.research-gaps with a 5-minute tick."""
+        """Startup registers knowledge.research-gaps with a daily tick."""
         from knowledge.service import on_startup
         from shared.scheduler import ScheduledJob
         from sqlmodel import select
@@ -621,7 +621,7 @@ class TestClassifyGapsHandler:
         job = session.execute(
             select(ScheduledJob).where(ScheduledJob.name == "knowledge.research-gaps")
         ).scalar_one()
-        assert job.interval_secs == 300
+        assert job.interval_secs == 86400
         assert job.ttl_secs == 1200  # was 600
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Bump `_RESEARCH_INTERVAL_SECS` from 300s (every 5 min) to 86400s (once per day) in `projects/monolith/knowledge/service.py` to cut Sonnet token spend on the `knowledge.research-gaps` job.
- Update the matching assertion + docstring in `service_test.py`.

## Context
The job processes up to 10 external/classified gaps per tick using the Sonnet research agent with web tools — running it every 5 minutes was burning tokens disproportionately for a backfill workload.

`shared.scheduler.register_job` upserts and updates `interval_secs` on the existing DB row while preserving `next_run_at`, so on the next monolith rollout the schedule will switch to daily without an extra immediate run. `_RESEARCH_TTL_SECS` (1200s lock-lease) is unchanged — still appropriate for an individual tick that may run several Sonnet calls.

## Test plan
- [ ] BuildBuddy CI green (covers the updated `test_on_startup_registers_research_gaps_job` assertion)
- [ ] After rollout, confirm via the `scheduler` skill that the `knowledge.research-gaps` row shows `interval_secs=86400`

---
_Generated by [Claude Code](https://claude.ai/code/session_01PaJrZvJi2uZFtKt1GYgXAn)_