### PR TITLE
docs(trips): fix nginx routing description in README

### DIFF
--- a/projects/trips/README.md
+++ b/projects/trips/README.md
@@ -8,7 +8,7 @@ Photo-based GPS trip logging with elevation enrichment.
 | -------------- | ------------------------------------------------------------------------------------------ |
 | **backend**    | FastAPI server that replays trip data from NATS JetStream and serves REST + WebSocket APIs |
 | **frontend**   | Timeline view with day-by-day maps and per-day elevation stats (ascent, descent, min/max)  |
-| **nginx**      | Reverse-proxy routing layer — terminates external traffic and routes requests to the backend API or imgproxy |
+| **nginx**      | Reverse-proxy routing layer — routes incoming requests to the backend API, imgproxy (resized images), or SeaweedFS (full-resolution images) |
 | **imgproxy**   | Image resizing and processing service — serves optimised trip photos on demand              |
 | **tools**      | CLI tools for trip data management — six sub-directories: `publish-trip-images` (image ingestion with EXIF extraction), `backfill-elevation` (replays NATS points and enriches with elevation data), `delete-trip-points` (publishes tombstone messages to delete points), `publish-gap-route` (parses KML files to fill route gaps), `detect-wildlife` (wildlife detection inference + GoPro camera control), `elevation` (elevation API client library) |
 | **chart**      | Helm chart for Kubernetes deployment                                                       |


### PR DESCRIPTION
## Summary

- The `nginx` component in the trips stack routes to **three** backends (API, imgproxy, SeaweedFS), but the README only mentioned two (API, imgproxy)
- Removed the misleading "terminates external traffic" phrasing — nginx is a ClusterIP service that receives traffic from the cluster gateway layer, not directly from external connections

## Root cause

The `/trips/full/` path routes directly to SeaweedFS (full-resolution images without resizing), while imgproxy handles all resized variants (`/trips/thumb/`, `/trips/display/`, `/trips/preview/`, `/trips/gallery/`). This SeaweedFS routing leg was missing from the README description.

## Test plan
- [ ] README reads accurately against `chart/templates/nginx-configmap.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)