### PR TITLE
ci(semgrep): flag overly broad public API prefixes in HTTPRoutes

### DIFF
--- a/bazel/semgrep/rules/yaml/no-broad-public-api-prefix.yaml
+++ b/bazel/semgrep/rules/yaml/no-broad-public-api-prefix.yaml
@@ -1,0 +1,29 @@
+rules:
+  - id: no-broad-public-api-prefix
+    languages: [yaml]
+    severity: WARNING
+    message: >-
+      Public HTTPRoute PathPrefix is too broad and risks exposing private API
+      surfaces. Prefixes like `/api` or `/api/knowledge` will forward every
+      request under that namespace — including unauthenticated endpoints that
+      were never meant to be publicly reachable. Narrow the prefix to the exact
+      public sub-path (e.g. `/api/knowledge/public`) as described in PR #2304's
+      belt-and-braces pattern: the ingress rule should mirror the same scope
+      enforced by the backend's visibility filter.
+    metadata:
+      category: security
+      subcategory: gateway-api
+      confidence: HIGH
+      likelihood: HIGH
+      impact: HIGH
+      technology: [helm, kubernetes, gateway-api]
+    paths:
+      include:
+        - "**/chart/templates/httproute-public*"
+    patterns:
+      - pattern: |
+          type: PathPrefix
+          value: $VALUE
+      - metavariable-regex:
+          metavariable: $VALUE
+          regex: '^/api(/[^/]+)?$'

--- a/bazel/semgrep/tests/fixtures/no-broad-public-api-prefix.yaml
+++ b/bazel/semgrep/tests/fixtures/no-broad-public-api-prefix.yaml
@@ -1,0 +1,133 @@
+# Tests for no-broad-public-api-prefix rule.
+# Public HTTPRoute PathPrefix values of /api or /api/<single-segment> are too
+# broad and risk exposing private endpoints. Prefixes must be scoped to at
+# least three segments (e.g. /api/knowledge/public) to be safe on a public
+# hostname.
+---
+# Broad /api prefix — flags entire API namespace as public.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: too-broad-api
+spec:
+  rules:
+    - matches:
+        - path:
+            # ruleid: no-broad-public-api-prefix
+            type: PathPrefix
+            value: /api
+      backendRefs:
+        - name: my-service
+          port: 8080
+      timeouts:
+        request: 30s
+
+---
+# /api/knowledge is still too broad — exposes notes, gaps, dead-letter, etc.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: too-broad-knowledge
+spec:
+  rules:
+    - matches:
+        - path:
+            # ruleid: no-broad-public-api-prefix
+            type: PathPrefix
+            value: /api/knowledge
+      backendRefs:
+        - name: my-service
+          port: 8080
+      timeouts:
+        request: 30s
+
+---
+# /api/users is still only two segments — too broad for a public route.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: too-broad-users
+spec:
+  rules:
+    - matches:
+        - path:
+            # ruleid: no-broad-public-api-prefix
+            type: PathPrefix
+            value: /api/users
+      backendRefs:
+        - name: my-service
+          port: 8080
+      timeouts:
+        request: 30s
+
+---
+# ok: no-broad-public-api-prefix — /api/knowledge/public is narrowly scoped (3 segments).
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: narrowly-scoped-knowledge
+spec:
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /api/knowledge/public
+      backendRefs:
+        - name: my-service
+          port: 8080
+      timeouts:
+        request: 30s
+
+---
+# ok: no-broad-public-api-prefix — root prefix / is not an /api path.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: root-prefix
+spec:
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: my-service
+          port: 8080
+      timeouts:
+        request: 30s
+
+---
+# ok: no-broad-public-api-prefix — /_app/ prefix for SvelteKit assets is not an /api path.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: app-assets
+spec:
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /_app/
+      backendRefs:
+        - name: my-service
+          port: 8080
+      timeouts:
+        request: 30s
+
+---
+# ok: no-broad-public-api-prefix — /api/v1/health/live is 4 segments, sufficiently scoped.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: deep-health-route
+spec:
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /api/v1/health/live
+      backendRefs:
+        - name: my-service
+          port: 8080
+      timeouts:
+        request: 30s


### PR DESCRIPTION
## Summary

- Adds `bazel/semgrep/rules/yaml/no-broad-public-api-prefix.yaml` — new semgrep WARNING/security rule that flags PathPrefix values of `/api` or `/api/<single-segment>` in public HTTPRoute templates
- Adds `bazel/semgrep/tests/fixtures/no-broad-public-api-prefix.yaml` with 3 positive (should flag) and 4 negative (should not flag) test cases
- No BUILD changes required — both files are auto-discovered by existing `glob()` calls

## Background

PR #2304 showed that adding `/api/knowledge` as a PathPrefix to a public HTTPRoute would expose private endpoints (notes, gaps, dead-letter, etc.). The correct pattern is a narrowly scoped prefix like `/api/knowledge/public` — three or more path segments. This rule enforces that at write time for all `**/chart/templates/httproute-public*` files.

## Test plan

- [ ] `bazel test //bazel/semgrep/rules:yaml_rules_test` — verifies 3 `ruleid` annotations fire and 4 `ok` annotations are clean
- [ ] CI semgrep scan passes on `projects/monolith/chart/templates/httproute-public.yaml` (already uses `/api/knowledge/public`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)