### PR TITLE
ci(semgrep): flag SQLAlchemy Session passed to asyncio.to_thread

### DIFF
--- a/bazel/semgrep/rules/python/no-session-in-to-thread.yaml
+++ b/bazel/semgrep/rules/python/no-session-in-to-thread.yaml
@@ -1,0 +1,40 @@
+rules:
+  - id: no-session-in-to-thread
+    patterns:
+      - pattern: asyncio.to_thread($FN, ..., $SESSION, ...)
+      - metavariable-regex:
+          metavariable: $SESSION
+          regex: ^session$
+    message: >-
+      `$SESSION` (a SQLAlchemy Session) is passed directly into
+      `asyncio.to_thread(...)`. SQLAlchemy Sessions are NOT thread-safe: sharing
+      one between the event loop and a worker thread causes data races, identity-map
+      corruption, and hard-to-reproduce transaction errors.
+
+      Pass `engine` (or `session.get_bind()`) instead and create a new Session
+      inside the threaded function:
+
+        def _sync_fn(engine, ...):
+            with Session(engine) as session:
+                ...
+
+        await asyncio.to_thread(_sync_fn, engine, ...)
+
+      See PR #2297 for the canonical precedent in this codebase.
+    languages: [python]
+    severity: WARNING
+    metadata:
+      category: correctness
+      subcategory: thread-safety
+      cwe: ["CWE-362: Concurrent Execution using Shared Resource with Improper Synchronization"]
+      confidence: HIGH
+      likelihood: HIGH
+      impact: HIGH
+      technology: [python, asyncio, sqlalchemy, sqlmodel]
+      description: >-
+        SQLAlchemy Session passed to asyncio.to_thread — Sessions are not
+        thread-safe and must not be shared between the event loop and worker
+        threads.
+    paths:
+      include:
+        - "projects/**/*.py"

--- a/bazel/semgrep/rules/python/no_session_in_to_thread.py
+++ b/bazel/semgrep/rules/python/no_session_in_to_thread.py
@@ -1,0 +1,71 @@
+# Tests for no-session-in-to-thread rule.
+# SQLAlchemy Sessions are not thread-safe and must not be passed to
+# asyncio.to_thread(). Pass engine (or session.get_bind()) instead and
+# create a new Session inside the threaded function. See PR #2297.
+import asyncio
+
+from sqlalchemy.orm import Session
+
+
+# ruleid: no-session-in-to-thread
+async def bad_session_first_extra_arg(engine, session):
+    result = await asyncio.to_thread(sync_read, session)
+    return result
+
+
+# ruleid: no-session-in-to-thread
+async def bad_session_with_extra_args(engine, session, item_id):
+    result = await asyncio.to_thread(sync_read, item_id, session)
+    return result
+
+
+# ruleid: no-session-in-to-thread
+async def bad_session_trailing(engine, session, item_id, limit):
+    result = await asyncio.to_thread(sync_query, item_id, limit, session)
+    return result
+
+
+# ok: engine passed instead of session — caller creates Session inside thread
+async def ok_engine_passed(engine, item_id):
+    result = await asyncio.to_thread(sync_read_with_engine, engine, item_id)
+    return result
+
+
+# ok: db_session variable name does not match ^session$ regex
+async def ok_db_session_name(engine, db_session, item_id):
+    result = await asyncio.to_thread(sync_read, db_session, item_id)
+    return result
+
+
+# ok: no asyncio.to_thread call
+async def ok_no_to_thread(engine, session, item_id):
+    with Session(engine) as s:
+        return s.get(MyModel, item_id)
+
+
+# ok: session used in event loop, not passed to thread
+async def ok_session_not_passed(engine, session):
+    objs = session.query(MyModel).all()
+    result = await asyncio.to_thread(cpu_bound_work, objs)
+    return result
+
+
+def sync_read(session, item_id=None):
+    return session.query(MyModel).first()
+
+
+def sync_read_with_engine(engine, item_id):
+    with Session(engine) as session:
+        return session.get(MyModel, item_id)
+
+
+def sync_query(item_id, limit, session):
+    return session.query(MyModel).limit(limit).all()
+
+
+def cpu_bound_work(objs):
+    return [o.value for o in objs]
+
+
+class MyModel:
+    pass

--- a/bazel/semgrep/tests/BUILD
+++ b/bazel/semgrep/tests/BUILD
@@ -15,6 +15,7 @@ filegroup(
             "fixtures/no-create-extension-sql.yaml",
             "fixtures/no-deprecated-api-subdomain.yaml",
             "fixtures/no-discarded-json-marshal.yaml",
+            "fixtures/no-session-in-to-thread.yaml",
             "fixtures/no-shared-preload-libraries-cnpg.yaml",
             "fixtures/no-unquoted-helm-range-args.yaml",
             "fixtures/python-shadow-module-import.yaml",

--- a/bazel/semgrep/tests/fixtures/no-session-in-to-thread.yaml
+++ b/bazel/semgrep/tests/fixtures/no-session-in-to-thread.yaml
@@ -1,0 +1,45 @@
+# Reference fixture for the no-session-in-to-thread semgrep rule.
+# This file documents ok/bad patterns for human review.
+# The actual semgrep test fixture is bazel/semgrep/rules/python/no_session_in_to_thread.py.
+#
+# Background: SQLAlchemy Sessions maintain an identity map and a connection
+# that are not safe to share across OS threads. Passing a Session to
+# asyncio.to_thread() runs the threaded function in the ThreadPoolExecutor
+# while the event loop continues; if any other coroutine uses the same
+# Session concurrently the result is data races and identity-map corruption.
+# See PR #2297 for the canonical fix pattern in this codebase.
+
+examples:
+  bad:
+    - description: >-
+        session passed as second arg to asyncio.to_thread — the threaded
+        function and the event loop may both use the Session concurrently
+      code: |
+        result = await asyncio.to_thread(sync_read, session)
+
+    - description: session passed after other positional args
+      code: |
+        result = await asyncio.to_thread(sync_query, item_id, limit, session)
+
+  ok:
+    - description: engine passed instead — new Session created inside the thread
+      code: |
+        async def handler(engine, item_id):
+            result = await asyncio.to_thread(_sync_read, engine, item_id)
+
+        def _sync_read(engine, item_id):
+            with Session(engine) as session:
+                return session.get(MyModel, item_id)
+
+    - description: session.get_bind() passed — new Session created inside the thread
+      code: |
+        result = await asyncio.to_thread(_sync_fn, session.get_bind())
+
+    - description: variable named db_session — does not match the ^session$ regex
+      code: |
+        result = await asyncio.to_thread(sync_fn, db_session, item_id)
+
+    - description: session used in event-loop coroutine, not passed to thread
+      code: |
+        objs = session.query(MyModel).all()
+        result = await asyncio.to_thread(cpu_bound_work, objs)


### PR DESCRIPTION
## Summary

- Adds `bazel/semgrep/rules/python/no-session-in-to-thread.yaml` — flags `asyncio.to_thread($FN, ..., $SESSION, ...)` where `$SESSION` matches `session`
- Message explains that SQLAlchemy Session is not thread-safe and recommends passing `engine` (or `session.get_bind()`) and creating a new Session inside the threaded function, citing PR #2297 as precedent
- Severity: WARNING, category: correctness, paths: `projects/**/*.py`
- Includes colocated annotation test fixture `no_session_in_to_thread.py` for `python_rules_test` with `# ruleid:` / `# ok:` annotations
- Includes documentation fixture `bazel/semgrep/tests/fixtures/no-session-in-to-thread.yaml`
- Updates `bazel/semgrep/tests/BUILD` to exclude the doc fixture from `yaml_fixtures` (it is not a yaml-language semgrep test)

## Test plan

- [ ] `bazel test //bazel/semgrep/rules:python_rules_test` passes in CI
- [ ] Rule fires on `asyncio.to_thread(fn, session)` and `asyncio.to_thread(fn, x, session)` patterns
- [ ] Rule is silent when `engine` is passed, when variable is named `db_session`, and when session is used in the event loop but not passed to the thread

🤖 Generated with [Claude Code](https://claude.com/claude-code)