### PR TITLE
docs(trips): remove nginx/imgproxy rows from component table

### DIFF
--- a/projects/trips/README.md
+++ b/projects/trips/README.md
@@ -8,8 +8,6 @@ Photo-based GPS trip logging with elevation enrichment.
 | -------------- | ------------------------------------------------------------------------------------------ |
 | **backend**    | FastAPI server that replays trip data from NATS JetStream and serves REST + WebSocket APIs |
 | **frontend**   | Timeline view with day-by-day maps and per-day elevation stats (ascent, descent, min/max) — deployed as a Cloudflare Pages app (not part of the Helm chart) |
-| **nginx**      | Reverse-proxy routing layer — routes incoming requests to the backend API, imgproxy (resized images), or SeaweedFS (full-resolution images) |
-| **imgproxy**   | Image resizing and processing service — serves optimised trip photos on demand              |
 | **tools**      | CLI tools for trip data management — six sub-directories: `publish-trip-images` (image ingestion with EXIF extraction), `backfill-elevation` (replays NATS points and enriches with elevation data), `delete-trip-points` (publishes tombstone messages to delete points), `publish-gap-route` (parses KML files to fill route gaps), `detect-wildlife` (wildlife detection inference + GoPro camera control), `elevation` (elevation API client library) |
-| **chart**      | Helm chart for Kubernetes deployment                                                       |
+| **chart**      | Helm chart for Kubernetes deployment — includes nginx reverse-proxy and imgproxy templates |
 | **deploy**     | ArgoCD Application, kustomization, and cluster-specific values                             |


### PR DESCRIPTION
## Summary

- Removes the `nginx` and `imgproxy` rows from the component table in `projects/trips/README.md`
- These are Helm chart templates (`chart/templates/nginx-deployment.yaml`, `nginx-configmap.yaml`, `imgproxy-deployment.yaml`), not top-level source directories — listing them implied `projects/trips/nginx/` and `projects/trips/imgproxy/` exist, which they don't
- Updates the `chart` row description to: _"Helm chart for Kubernetes deployment — includes nginx reverse-proxy and imgproxy templates"_

## Test plan

- [x] Verify `projects/trips/nginx/` and `projects/trips/imgproxy/` do not exist
- [x] Verify nginx/imgproxy templates exist under `projects/trips/chart/templates/`
- [x] README renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)