### PR TITLE
test(semgrep): add dedicated test target for no-session-in-to-thread rule

### DIFF
--- a/bazel/semgrep/rules/BUILD
+++ b/bazel/semgrep/rules/BUILD
@@ -311,3 +311,19 @@ semgrep_test(
     rules = [":claude_print_missing_permission_mode_rule"],
     tags = ["semgrep"],
 )
+
+# no-session-in-to-thread uses languages: [python] so its fixture is a YAML file.
+# This test wires the rule to its annotation fixture independently of python_rules_test
+# (which scans python/*.py sources and does not include YAML-annotated fixtures).
+filegroup(
+    name = "no_session_in_to_thread_rule",
+    srcs = ["python/no-session-in-to-thread.yaml"],
+)
+
+semgrep_test(
+    name = "no_session_in_to_thread_test",
+    srcs = ["//bazel/semgrep/tests:no_session_in_to_thread_fixtures"],
+    env = {"SEMGREP_TEST_MODE": "1"},
+    rules = [":no_session_in_to_thread_rule"],
+    tags = ["semgrep"],
+)

--- a/bazel/semgrep/tests/BUILD
+++ b/bazel/semgrep/tests/BUILD
@@ -87,6 +87,13 @@ filegroup(
     srcs = ["fixtures/claude-print-missing-permission-mode.yaml"],
 )
 
+# Fixture for the no-session-in-to-thread rule (languages: python).
+# Referenced by //bazel/semgrep/rules:no_session_in_to_thread_test.
+filegroup(
+    name = "no_session_in_to_thread_fixtures",
+    srcs = ["fixtures/no-session-in-to-thread.yaml"],
+)
+
 # Fixtures for kubernetes rules (require-readiness-probe, require-resource-limits, etc.).
 # Referenced by //bazel/semgrep/rules:kubernetes_rules_test.
 # New rule fixtures should be added here as they are created.


### PR DESCRIPTION
## Summary

- Adds `no_session_in_to_thread_fixtures` filegroup in `bazel/semgrep/tests/BUILD` exposing the existing fixture (already excluded from `yaml_fixtures`)
- Adds `no_session_in_to_thread_rule` filegroup in `bazel/semgrep/rules/BUILD` for `python/no-session-in-to-thread.yaml`
- Adds `no_session_in_to_thread_test` `semgrep_test` target wiring the rule to the fixture, following the same pattern as `claude_print_missing_permission_mode_test`, `sql_rules_test`, and `no_unquoted_helm_range_args_test`

## Test plan

- [ ] CI `bazel test //...` passes with the new `no_session_in_to_thread_test` target running under the `semgrep` tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)