### PR TITLE
fix(monolith): add HTTPRoute timeouts and fix semgrep rule language

### DIFF
--- a/bazel/semgrep/rules/yaml/no-httproute-rule-without-timeout.yaml
+++ b/bazel/semgrep/rules/yaml/no-httproute-rule-without-timeout.yaml
@@ -1,6 +1,6 @@
 rules:
   - id: no-httproute-rule-without-timeout
-    languages: [yaml]
+    languages: [generic]
     severity: WARNING
     message: >-
       HTTPRoute rule has `backendRefs` but no `timeouts` section. Envoy's

--- a/bazel/semgrep/tests/fixtures/no-httproute-rule-without-timeout.yaml
+++ b/bazel/semgrep/tests/fixtures/no-httproute-rule-without-timeout.yaml
@@ -2,13 +2,18 @@
 # HTTPRoute rules with backendRefs must declare a timeouts section so that
 # Envoy's default 15-second timeout does not silently drop long-running
 # requests (streaming, uploads, LLM inference, etc.).
+#
+# The rule uses languages: [generic] (spacegrep) rather than languages: [yaml]
+# because real chart templates contain {{ }} Helm directives that break the YAML
+# parser. In generic mode the finding is anchored at the `rules:` token, so
+# # ruleid: annotations must appear on the line immediately before `rules:`.
 ---
-# ruleid: no-httproute-rule-without-timeout
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: my-service
 spec:
+# ruleid: no-httproute-rule-without-timeout
   rules:
     - matches:
         - path:
@@ -19,12 +24,12 @@ spec:
           port: 8080
 
 ---
-# ruleid: no-httproute-rule-without-timeout
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: api-route
 spec:
+# ruleid: no-httproute-rule-without-timeout
   rules:
     - matches:
         - path:
@@ -34,6 +39,26 @@ spec:
         - name: api-service
           port: 80
           weight: 100
+
+---
+# Helm template syntax test: the rule must fire even when {{ }} directives are
+# present (YAML parser would reject this file; generic mode handles it fine).
+{{- if .Values.cfIngress.public.enabled }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "service.fullname" . }}-public
+spec:
+# ruleid: no-httproute-rule-without-timeout
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: {{ include "service.fullname" . }}
+          port: {{ .Values.service.port | int }}
+{{- end }}
 
 ---
 # ok: no-httproute-rule-without-timeout — timeouts section present after backendRefs
@@ -89,3 +114,23 @@ spec:
       backendRefs:
         - name: reverse-service
           port: 9090
+
+---
+# ok: no-httproute-rule-without-timeout — Helm template with explicit timeouts
+{{- if .Values.cfIngress.public.enabled }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "service.fullname" . }}-public
+spec:
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: {{ include "service.fullname" . }}
+          port: {{ .Values.service.port | int }}
+      timeouts:
+        request: 60s
+{{- end }}

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.74.3
+version: 0.74.4
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/templates/httproute-public.yaml
+++ b/projects/monolith/chart/templates/httproute-public.yaml
@@ -20,6 +20,8 @@ spec:
       backendRefs:
         - name: {{ include "monolith.fullname" . }}
           port: {{ .Values.cfIngress.public.servicePort | int }}
+      timeouts:
+        request: 60s
     # Public knowledge API — narrowly scoped to /api/knowledge/public/* so we
     # never expose the unfiltered /api/knowledge/{notes,gaps,dead-letter,…}
     # surface on the public hostname. The backend itself enforces the same
@@ -32,6 +34,8 @@ spec:
       backendRefs:
         - name: {{ include "monolith.fullname" . }}
           port: {{ .Values.service.apiPort | int }}
+      timeouts:
+        request: 30s
     # Everything else — SvelteKit reroute hook maps to /public/ internally
     - matches:
         - path:
@@ -40,6 +44,8 @@ spec:
       backendRefs:
         - name: {{ include "monolith.fullname" . }}
           port: {{ .Values.cfIngress.public.servicePort | int }}
+      timeouts:
+        request: 60s
 ---
 {{- $rlParams := dict
   "name" (printf "%s-public" (include "monolith.fullname" .))

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.74.3
+      targetRevision: 0.74.4
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
## Summary

- **Add explicit `timeouts` blocks** to all 3 rules in `httproute-public.yaml` (/_app/ and / → 60s for SvelteKit; /api/knowledge/public → 30s for the API). Without these, Envoy's default 15s timeout silently drops long SSR renders and streaming responses.
- **Fix `no-httproute-rule-without-timeout` semgrep rule** (`languages: [yaml]` → `languages: [generic]`): Helm templates contain `{{ include "..." . }}` directives that make them invalid YAML — the YAML parser bailed out silently so the rule never fired on any real chart file. The `generic` (spacegrep) engine pattern-matches raw text, handling Helm directives as opaque tokens.
- **Update test fixture** to move `# ruleid:` annotations immediately above `rules:` (spacegrep anchors findings at the matched text, not the document root) and add a Helm template syntax test case to prove the rule works on actual chart files.
- **Bump chart** `0.74.3 → 0.74.4` and sync `application.yaml` `targetRevision`.

## Root cause

The semgrep rule was broken in two ways that masked each other:
1. `languages: [yaml]` fails silently on Helm templates (invalid YAML) → rule never fires on real files
2. Test fixture used pure YAML (no `{{ }}`), so the YAML parser succeeded and tests passed — giving false confidence the rule was working

## Test plan

- [ ] `yaml_rules_test` semgrep test passes with updated fixture annotations and Helm template test cases
- [ ] `helm template` on the monolith chart renders valid HTTPRoute with `timeouts` on all 3 rules
- [ ] Chart version and `targetRevision` are in sync at `0.74.4`

🤖 Generated with [Claude Code](https://claude.com/claude-code)