### PR TITLE
feat(semgrep): add sqlalchemy-ne-on-nullable-without-isnull rule

### DIFF
--- a/bazel/semgrep/rules/python/sqlalchemy-ne-on-nullable-without-isnull.py
+++ b/bazel/semgrep/rules/python/sqlalchemy-ne-on-nullable-without-isnull.py
@@ -1,0 +1,72 @@
+# Tests for sqlalchemy-ne-on-nullable-without-isnull rule.
+from sqlalchemy import or_, select
+
+
+# ruleid: sqlalchemy-ne-on-nullable-without-isnull
+def bad_visibility_ne(session):
+    return session.exec(select(Note).where(Note.visibility != "public")).all()
+
+
+# ruleid: sqlalchemy-ne-on-nullable-without-isnull
+def bad_status_ne(session):
+    return session.exec(select(Task).where(Task.status != "done")).all()
+
+
+# ruleid: sqlalchemy-ne-on-nullable-without-isnull
+def bad_edge_type_ne(session):
+    return session.exec(select(Edge).where(Edge.edge_type != "related")).all()
+
+
+# ruleid: sqlalchemy-ne-on-nullable-without-isnull
+def bad_gap_class_ne(session):
+    return session.exec(select(Gap).where(Gap.gap_class != "known")).all()
+
+
+# ruleid: sqlalchemy-ne-on-nullable-without-isnull
+def bad_visibility_chained_where(session):
+    return (
+        session.exec(
+            select(Note)
+            .where(Note.author == "alice")
+            .where(Note.visibility != "private")
+        ).all()
+    )
+
+
+# ok: visibility wrapped with or_ including .is_(None)
+def ok_visibility_with_isnull(session):
+    return session.exec(
+        select(Note).where(or_(Note.visibility != "public", Note.visibility.is_(None)))
+    ).all()
+
+
+# ok: status wrapped with or_ including .is_(None)
+def ok_status_with_isnull(session):
+    return session.exec(
+        select(Task).where(or_(Task.status != "done", Task.status.is_(None)))
+    ).all()
+
+
+# ok: edge_type wrapped with or_ including .is_(None)
+def ok_edge_type_with_isnull(session):
+    return session.exec(
+        select(Edge).where(or_(Edge.edge_type != "related", Edge.edge_type.is_(None)))
+    ).all()
+
+
+# ok: gap_class wrapped with or_ including .is_(None)
+def ok_gap_class_with_isnull(session):
+    return session.exec(
+        select(Gap).where(or_(Gap.gap_class != "known", Gap.gap_class.is_(None)))
+    ).all()
+
+
+# ok: non-nullable field (id) — not in the known-nullable list
+def ok_non_nullable_field(session):
+    return session.exec(select(Note).where(Note.id != 0)).all()
+
+
+# ok: equality check on a nullable field (== silently excludes NULLs too, but that
+# is a separate concern — this rule only targets !=)
+def ok_equality_check(session):
+    return session.exec(select(Note).where(Note.visibility == "public")).all()

--- a/bazel/semgrep/rules/python/sqlalchemy-ne-on-nullable-without-isnull.py
+++ b/bazel/semgrep/rules/python/sqlalchemy-ne-on-nullable-without-isnull.py
@@ -24,13 +24,9 @@ def bad_gap_class_ne(session):
 
 # ruleid: sqlalchemy-ne-on-nullable-without-isnull
 def bad_visibility_chained_where(session):
-    return (
-        session.exec(
-            select(Note)
-            .where(Note.author == "alice")
-            .where(Note.visibility != "private")
-        ).all()
-    )
+    return session.exec(
+        select(Note).where(Note.author == "alice").where(Note.visibility != "private")
+    ).all()
 
 
 # ok: visibility wrapped with or_ including .is_(None)

--- a/bazel/semgrep/rules/python/sqlalchemy-ne-on-nullable-without-isnull.yaml
+++ b/bazel/semgrep/rules/python/sqlalchemy-ne-on-nullable-without-isnull.yaml
@@ -1,0 +1,25 @@
+rules:
+  - id: sqlalchemy-ne-on-nullable-without-isnull
+    patterns:
+      - pattern: $STMT.where(..., $MODEL.$FIELD != $VAL, ...)
+      - metavariable-regex:
+          metavariable: $FIELD
+          regex: ^(visibility|status|edge_type|gap_class)$
+    message: >-
+      `$MODEL.$FIELD != $VAL` on a nullable column silently excludes NULL rows.
+      In SQL, `NULL != 'x'` evaluates to `NULL` (not `TRUE`), so rows where
+      `$FIELD` is NULL are silently dropped from the result set. Wrap with
+      `or_($MODEL.$FIELD != $VAL, $MODEL.$FIELD.is_(None))` to include them.
+    languages: [python]
+    severity: WARNING
+    metadata:
+      category: correctness
+      subcategory: orm
+      cwe: ["CWE-573: Improper Following of Specification by Caller"]
+      confidence: HIGH
+      likelihood: HIGH
+      impact: MEDIUM
+      technology: [python, sqlalchemy, sqlmodel]
+      description: >-
+        Bare != on a nullable SQLAlchemy column silently excludes NULL rows —
+        wrap with or_(..., Model.field.is_(None)) to include NULL-valued rows.


### PR DESCRIPTION
## Summary

- Adds new semgrep rule `sqlalchemy-ne-on-nullable-without-isnull` in `bazel/semgrep/rules/python/`
- Flags bare `!=` comparisons on known-nullable SQLAlchemy columns (`visibility`, `status`, `edge_type`, `gap_class`) inside `.where()` calls without an accompanying `or_(..., .is_(None))`
- In SQL, `NULL != 'x'` evaluates to `NULL` (not `TRUE`), silently excluding rows where the column is NULL — the correct pattern is `or_(Model.field != value, Model.field.is_(None))`
- Adds colocated Python test fixture with `# ruleid:` (5 bad cases) and `# ok:` (5 safe cases) annotations; picked up automatically by `python_rules_test` glob

Origin: PR #2298 router.py line 294 demonstrated the correct `or_(Note.visibility != "public", Note.visibility.is_(None))` fix; this rule prevents future regressions elsewhere.

## Test plan

- [ ] CI `python_rules_test` passes (semgrep fixture annotations match rule behaviour)
- [ ] No existing Python files are flagged (rule is scoped to the known-nullable field list)

🤖 Generated with [Claude Code](https://claude.com/claude-code)