### PR TITLE
docs(hikes): fix README inaccuracies found during audit

### DIFF
--- a/projects/hikes/README.md
+++ b/projects/hikes/README.md
@@ -56,8 +56,8 @@ User preferences are persisted to `localStorage`. The app has no server-side com
 **Playwright tests** live in `frontend/tests/` and are configured in `playwright.config.js`. The default `npm test` run includes three spec files:
 
 - `app-functionality.spec.js` — tests walk filtering and UI behaviour; mocks `bundle.brotli` responses
-- `coordinates.spec.js` — tests coordinate parsing and haversine logic; does not mock the bundle
-- `deployment-health.spec.js` — tests the live deployment health endpoint; does not mock the bundle
+- `coordinates.spec.js` — tests coordinate parsing and haversine logic; mocks `bundle.brotli` responses
+- `deployment-health.spec.js` — tests the live deployment health endpoint; mocks `bundle.brotli` responses
 
 Playwright starts its own HTTP server on port **33999** (`python3 -m http.server 33999 --directory public`) rather than reusing any externally running server. `mock-data.spec.js` is excluded from the default run.
 


### PR DESCRIPTION
## Summary

- `coordinates.spec.js` was described as "does not mock the bundle" but actually intercepts `bundle.brotli` via `page.route()` in a `beforeEach` hook
- `deployment-health.spec.js` was described as "does not mock the bundle" but also intercepts `bundle.brotli` via `page.route()` and additionally injects a mock `window.BrotliDecompress` via `addInitScript`

Both descriptions updated to "mocks \`bundle.brotli\` responses" to match actual behaviour.

Found during a README accuracy audit across all 5 project READMEs.

## Test plan
- [ ] README diff reviewed for correctness
- [ ] No code changes — docs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)