### PR TITLE
feat(hooks): add check-public-route-visibility-filter hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -113,6 +113,11 @@
             "type": "command",
             "command": "$CLAUDE_PROJECT_DIR/bazel/tools/hooks/check-constant-change-test-grep.sh",
             "timeout": 10
+          },
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/bazel/tools/hooks/check-public-route-visibility-filter.sh",
+            "timeout": 10
           }
         ]
       }

--- a/bazel/tools/hooks/BUILD
+++ b/bazel/tools/hooks/BUILD
@@ -39,3 +39,9 @@ sh_test(
     srcs = ["check-constant-change-test-grep_test.sh"],
     data = [":check-constant-change-test-grep.sh"],
 )
+
+sh_test(
+    name = "check_public_route_visibility_filter_test",
+    srcs = ["check-public-route-visibility-filter_test.sh"],
+    data = [":check-public-route-visibility-filter.sh"],
+)

--- a/bazel/tools/hooks/check-public-route-visibility-filter.sh
+++ b/bazel/tools/hooks/check-public-route-visibility-filter.sh
@@ -1,0 +1,125 @@
+#!/bin/bash
+# PreToolUse hook: warn when writing a /public/ route to knowledge/router.py
+# without referencing public_notes_filter() or effective_visibility().
+#
+# Background: PR #2298 established that every /public/ route querying Note
+# must call public_notes_filter() or effective_visibility() to avoid
+# leaking non-public notes. A bare .where() without these helpers silently
+# returns private notes to unauthenticated callers.
+#
+# This hook fires on Write|Edit when:
+#   1. The file path matches **/knowledge/router.py
+#   2. The new content introduces a route decorator containing "/public/"
+#   3. The function body immediately following that decorator does NOT
+#      reference public_notes_filter or effective_visibility
+#
+# Input: JSON on stdin from Claude Code hook system
+# Exit 0: allow (warnings emitted on stderr — advisory only)
+# Exit 2: block (not used)
+
+set -euo pipefail
+
+INPUT=$(cat)
+
+# Only check knowledge/router.py
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
+if [[ -z "$FILE_PATH" ]]; then
+	exit 0
+fi
+if [[ "$FILE_PATH" != */knowledge/router.py ]]; then
+	exit 0
+fi
+
+# Get the content being written (Write tool) or the replacement string (Edit tool)
+NEW_CONTENT=$(echo "$INPUT" | jq -r '.tool_input.new_string // .tool_input.content // empty')
+if [[ -z "$NEW_CONTENT" ]]; then
+	exit 0
+fi
+
+# Only relevant if a /public/ route is present
+if ! echo "$NEW_CONTENT" | grep -qE '@router\.(get|post|put|patch|delete)\([^)]*['"'"'"/]public/'; then
+	exit 0
+fi
+
+# Use Python to find /public/ route functions that lack the required filter call.
+# Content is passed via HOOK_CONTENT env var to avoid stdin/heredoc conflicts.
+WARNINGS=$(
+	HOOK_CONTENT="$NEW_CONTENT" python3 - "$FILE_PATH" <<'PYTHON'
+import os
+import re
+import sys
+
+file_path = sys.argv[1]
+content = os.environ['HOOK_CONTENT']
+
+REQUIRED = ('public_notes_filter', 'effective_visibility')
+
+# Split content into lines for processing.
+lines = content.splitlines()
+
+warnings = []
+i = 0
+while i < len(lines):
+    line = lines[i]
+    # Detect a route decorator that includes /public/
+    if re.search(r'@router\.(get|post|put|patch|delete)\([^)]*[\'"/]public/', line):
+        decorator_line = i + 1  # 1-based for display
+        # Collect the function body: skip any additional decorator lines, then
+        # grab lines until the next top-level def/class or end of content.
+        j = i + 1
+        # Skip additional decorators (lines starting with @)
+        while j < len(lines) and lines[j].lstrip().startswith('@'):
+            j += 1
+        # j should now be the 'def ...' line
+        func_start = j
+        j += 1
+        func_lines = [lines[func_start]] if func_start < len(lines) else []
+        # Collect indented body lines
+        while j < len(lines):
+            l = lines[j]
+            # Stop at next top-level definition (non-empty, non-indented)
+            if l and not l[0].isspace() and not l.startswith('#'):
+                break
+            func_lines.append(l)
+            j += 1
+
+        func_body = '\n'.join(func_lines)
+
+        # Check if either required helper is referenced
+        has_filter = any(req in func_body for req in REQUIRED)
+        if not has_filter:
+            # Extract route path for the warning message
+            route_match = re.search(r'[\'"]([^\'"]*public[^\'"]*)[\'"]', line)
+            route_path = route_match.group(1) if route_match else line.strip()
+            warnings.append(
+                f'  - Route at line {decorator_line}: {route_path!r}'
+            )
+
+    i += 1
+
+for w in warnings:
+    print(w)
+PYTHON
+)
+
+if [[ -n "$WARNINGS" ]]; then
+	cat >&2 <<-EOF
+		WARNING: /public/ route in knowledge/router.py missing visibility filter.
+
+		File: $FILE_PATH
+
+		Every route under /public/ that queries Note must call either
+		public_notes_filter() or effective_visibility() to prevent leaking
+		non-public notes to unauthenticated callers (PR #2298).
+
+		Routes missing visibility guard:
+		$WARNINGS
+
+		Fix: add public_notes_filter() to the .where() clause, e.g.:
+		  session.execute(select(Note).where(public_notes_filter()))
+		or check note visibility before returning:
+		  if effective_visibility(note) != "public": raise HTTPException(404)
+	EOF
+fi
+
+exit 0

--- a/bazel/tools/hooks/check-public-route-visibility-filter_test.sh
+++ b/bazel/tools/hooks/check-public-route-visibility-filter_test.sh
@@ -1,0 +1,245 @@
+#!/usr/bin/env bash
+# Unit tests for check-public-route-visibility-filter.sh PreToolUse hook.
+#
+# The hook:
+#   - Reads JSON from stdin with .tool_input.file_path and .tool_input.content
+#     (Write) or .tool_input.new_string (Edit)
+#   - Exits 0 always (warning-only, never blocks)
+#   - Emits a WARNING on stderr when knowledge/router.py adds a /public/ route
+#     whose function body does not call public_notes_filter or effective_visibility
+#   - Skips non-router files, non-public routes, and routes that already call
+#     the required helpers
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Locate hook from Bazel runfiles
+# ---------------------------------------------------------------------------
+HOOK_REL="bazel/tools/hooks/check-public-route-visibility-filter.sh"
+HOOK=""
+for candidate in \
+	"${RUNFILES_DIR:-}/_main/${HOOK_REL}" \
+	"${TEST_SRCDIR:-}/_main/${HOOK_REL}" \
+	"${BASH_SOURCE[0]%/*}/check-public-route-visibility-filter.sh"; do
+	if [[ -f "$candidate" ]]; then
+		HOOK="$candidate"
+		break
+	fi
+done
+if [[ -z "$HOOK" ]]; then
+	echo "ERROR: cannot locate check-public-route-visibility-filter.sh in runfiles" >&2
+	exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Install a minimal jq stub so the hook runs in the hermetic sandbox.
+# The hook uses:
+#   jq -r '.tool_input.file_path // empty'
+#   jq -r '.tool_input.new_string // .tool_input.content // empty'
+# ---------------------------------------------------------------------------
+mkdir -p "${TEST_TMPDIR}/bin"
+cat >"${TEST_TMPDIR}/bin/jq" <<'JQ_STUB'
+#!/usr/bin/env python3
+"""Minimal jq stub covering expressions used by check-public-route-visibility-filter.sh."""
+import json, sys
+
+args = sys.argv[1:]
+raw = False
+if args and args[0] == "-r":
+    raw = True
+    args = args[1:]
+
+expr = args[0] if args else "."
+data = json.load(sys.stdin)
+
+def jq_eval(obj, expr):
+    """Evaluate '.a.b // .c.d // empty' style expressions."""
+    for alt in expr.split("//"):
+        alt = alt.strip()
+        if alt == "empty":
+            return None
+        keys = [k for k in alt.lstrip(".").split(".") if k]
+        val = obj
+        try:
+            for k in keys:
+                val = val[k] if isinstance(val, dict) else None
+                if val is None:
+                    break
+        except (KeyError, TypeError):
+            val = None
+        if val is not None:
+            return val
+    return None
+
+result = jq_eval(data, expr)
+if result is None:
+    pass  # empty — print nothing
+elif raw:
+    print(result)
+else:
+    print(json.dumps(result))
+JQ_STUB
+chmod +x "${TEST_TMPDIR}/bin/jq"
+export PATH="${TEST_TMPDIR}/bin:${PATH}"
+
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
+PASS=0
+FAIL=0
+
+run_test() {
+	local name="$1"
+	local input_json="$2"
+	local want_exit="$3"      # expected exit code (always 0 for this hook)
+	local want_stderr_re="$4" # regex that must match stderr (empty = no output expected)
+
+	local stderr_out
+	local got_exit=0
+	stderr_out=$(printf '%s' "$input_json" | bash "$HOOK" 2>&1 >/dev/null) || got_exit=$?
+
+	local ok=true
+
+	if [[ "$got_exit" -ne "$want_exit" ]]; then
+		echo "FAIL [$name]: exit $got_exit, want $want_exit"
+		ok=false
+	fi
+
+	if [[ -n "$want_stderr_re" ]]; then
+		if ! echo "$stderr_out" | grep -qE "$want_stderr_re"; then
+			echo "FAIL [$name]: stderr $(printf '%q' "$stderr_out") did not match /$want_stderr_re/"
+			ok=false
+		fi
+	else
+		if [[ -n "$stderr_out" ]]; then
+			echo "FAIL [$name]: unexpected stderr: $(printf '%q' "$stderr_out")"
+			ok=false
+		fi
+	fi
+
+	if $ok; then
+		echo "PASS [$name]"
+		PASS=$((PASS + 1))
+	else
+		FAIL=$((FAIL + 1))
+	fi
+}
+
+# Build JSON inputs using Python (guaranteed available in the hermetic Bazel sandbox).
+make_json() {
+	local fp="$1" key="$2" val="$3"
+	python3 - "$fp" "$key" "$val" <<'PY'
+import json, sys
+fp, key, val = sys.argv[1], sys.argv[2], sys.argv[3]
+print(json.dumps({"tool_input": {"file_path": fp, key: val}}))
+PY
+}
+
+ROUTER_PATH="/workspace/homelab/projects/monolith/knowledge/router.py"
+
+# ---------------------------------------------------------------------------
+# Content fixtures
+# ---------------------------------------------------------------------------
+
+# /public/ route WITHOUT either visibility helper → should warn
+BAD_CONTENT='@router.get("/public/feed")
+def get_public_feed(session: Session = Depends(get_session)):
+    """Return recent public notes."""
+    rows = session.execute(select(Note).where(Note.type == "atom")).all()
+    return [r.note_id for r in rows]
+'
+
+# /public/ route WITH public_notes_filter → OK
+GOOD_FILTER_CONTENT='@router.get("/public/feed")
+def get_public_feed(session: Session = Depends(get_session)):
+    """Return recent public notes."""
+    rows = session.execute(
+        select(Note).where(public_notes_filter())
+    ).all()
+    return [r.note_id for r in rows]
+'
+
+# /public/ route WITH effective_visibility → OK
+GOOD_EFFECTIVE_CONTENT='@router.get("/public/notes/{note_id}")
+def get_public_note(note_id: str, session: Session = Depends(get_session)):
+    """Return a note iff public."""
+    note = session.get(Note, note_id)
+    if note is None or effective_visibility(note) != "public":
+        raise HTTPException(404)
+    return note
+'
+
+# Non-public route (no /public/ in path) → should NOT warn
+NON_PUBLIC_CONTENT='@router.get("/internal/notes")
+def get_notes(session: Session = Depends(get_session)):
+    """Internal listing, auth required."""
+    rows = session.execute(select(Note)).all()
+    return rows
+'
+
+# Route with /public/ but double-guarded by both helpers → OK
+BOTH_HELPERS_CONTENT='@router.get("/public/graph")
+def get_public_graph(session: Session = Depends(get_session)):
+    notes = session.execute(select(Note).where(public_notes_filter())).all()
+    filtered = [n for n in notes if effective_visibility(n) == "public"]
+    return filtered
+'
+
+# ---------------------------------------------------------------------------
+# Test cases
+# ---------------------------------------------------------------------------
+
+# 1. /public/ route missing visibility guard → warns
+run_test "missing_visibility_filter_warns" \
+	"$(make_json "$ROUTER_PATH" "content" "$BAD_CONTENT")" \
+	0 "WARNING.*visibility filter"
+
+# 2. /public/ route with public_notes_filter → no warning
+run_test "has_public_notes_filter_ok" \
+	"$(make_json "$ROUTER_PATH" "content" "$GOOD_FILTER_CONTENT")" \
+	0 ""
+
+# 3. /public/ route with effective_visibility → no warning
+run_test "has_effective_visibility_ok" \
+	"$(make_json "$ROUTER_PATH" "content" "$GOOD_EFFECTIVE_CONTENT")" \
+	0 ""
+
+# 4. Non-public route → no warning
+run_test "non_public_route_skipped" \
+	"$(make_json "$ROUTER_PATH" "content" "$NON_PUBLIC_CONTENT")" \
+	0 ""
+
+# 5. Wrong file path → no warning (hook skips non-knowledge/router.py)
+run_test "wrong_file_skipped" \
+	"$(make_json "/workspace/homelab/projects/monolith/other/router.py" "content" "$BAD_CONTENT")" \
+	0 ""
+
+# 6. Edit tool (new_string) missing filter → warns
+run_test "edit_tool_missing_filter_warns" \
+	"$(make_json "$ROUTER_PATH" "new_string" "$BAD_CONTENT")" \
+	0 "WARNING"
+
+# 7. Route with both helpers → no warning
+run_test "both_helpers_ok" \
+	"$(make_json "$ROUTER_PATH" "content" "$BOTH_HELPERS_CONTENT")" \
+	0 ""
+
+# 8. Empty JSON → no crash, no warning
+run_test "empty_json_allowed" \
+	'{}' \
+	0 ""
+
+# 9. Empty content → no warning
+run_test "empty_content_skipped" \
+	"$(make_json "$ROUTER_PATH" "content" "")" \
+	0 ""
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+echo "Results: ${PASS} passed, ${FAIL} failed"
+if [[ "$FAIL" -gt 0 ]]; then
+	exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

- Adds `bazel/tools/hooks/check-public-route-visibility-filter.sh` — fires on Write|Edit when target matches `**/knowledge/router.py`; detects `/public/` route decorators whose function body omits `public_notes_filter()` or `effective_visibility()` and emits an advisory WARNING on stderr (exit 0)
- Registers the hook in `.claude/settings.json` under the existing Write|Edit PreToolUse hooks array
- Adds 9-case `sh_test` and corresponding BUILD target

**Background:** PR #2298 established that every `/public/` route querying Note must call `public_notes_filter()` or `effective_visibility()`. A bare `.where()` without these helpers silently returns private notes to unauthenticated callers.

## Test plan

- [ ] CI passes `//bazel/tools/hooks:check_public_route_visibility_filter_test`
- [ ] Hook fires (WARNING) when writing a `/public/` route to `knowledge/router.py` without a visibility guard
- [ ] Hook is silent for routes that already call `public_notes_filter()` or `effective_visibility()`
- [ ] Hook is silent for non-`knowledge/router.py` files

🤖 Generated with [Claude Code](https://claude.com/claude-code)