### PR TITLE
docs(ships): fix README inaccuracies in component descriptions

### DIFF
--- a/projects/ships/README.md
+++ b/projects/ships/README.md
@@ -4,13 +4,13 @@ Real-time AIS vessel tracking with a MapLibre GL frontend.
 
 ## Overview
 
-| Component    | Description                                                       |
-| ------------ | ----------------------------------------------------------------- |
-| **ingest**   | Streams AIS position reports from AISstream.io via WebSocket      |
-| **backend**  | REST + WebSocket API over SQLite with moored-vessel deduplication |
-| **frontend** | MapLibre GL map with live vessel positions, types, and courses    |
-| **chart**    | Helm chart for Kubernetes deployment                              |
-| **deploy**   | ArgoCD Application, kustomization, and cluster-specific values    |
+| Component    | Description                                                                                                                                                                                                  |
+| ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **ingest**   | Streams AIS position reports from AISstream.io via WebSocket, filters by a configurable bounding box, and publishes positions to NATS JetStream                                                              |
+| **backend**  | REST + WebSocket API over SQLite with stationary-vessel deduplication (speed < 0.5 kn, distance < 100 m); replays the NATS stream on startup to build its SQLite DB and subscribes for live updates          |
+| **frontend** | React/Vite SPA served by a Bun-based proxy server (server.ts) that forwards API and WebSocket requests to the backend; renders a MapLibre GL map with live vessel positions, types, and courses              |
+| **chart**    | Helm chart for Kubernetes deployment                                                                                                                                                                         |
+| **deploy**   | ArgoCD Application, kustomization, and cluster-specific values                                                                                                                                               |
 
 Detailed component documentation exists in [backend/README.md](backend/README.md), [ingest/README.md](ingest/README.md), and [chart/README.md](chart/README.md).
 


### PR DESCRIPTION
## Summary

- Fixes **stationary-vessel deduplication** wording (was "moored-vessel") — the code deduplicates on speed threshold (< 0.5 kn) and distance (< 100 m), not mooring status
- Adds **NATS JetStream** to the architecture: ingest publishes positions to the stream; backend replays on startup to build its SQLite DB and subscribes for live updates
- Updates **frontend** description: React/Vite SPA served by a Bun-based proxy server (`server.ts`) that forwards API and WebSocket requests to the backend (MapLibre GL map detail retained)
- Notes configurable **bounding box filtering** in the ingest description

The other four project READMEs (agent_platform, hikes, stargazer, trips) were audited and are accurate — no changes needed.

## Test plan
- [ ] Verify table renders correctly in GitHub markdown preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)