### PR TITLE
fix(semgrep): switch no-hardcoded-k8s-url-in-helm-env to languages: generic

### DIFF
--- a/bazel/semgrep/rules/yaml/no-hardcoded-k8s-url-in-helm-env.yaml
+++ b/bazel/semgrep/rules/yaml/no-hardcoded-k8s-url-in-helm-env.yaml
@@ -1,6 +1,6 @@
 rules:
   - id: no-hardcoded-k8s-url-in-helm-env
-    languages: [yaml]
+    languages: [generic]
     severity: WARNING
     message: >-
       Hardcoded Kubernetes in-cluster service URL in a Helm template env var
@@ -18,10 +18,9 @@ rules:
     paths:
       include:
         - "**/chart/templates/**"
-    patterns:
-      - pattern: |
-          - name: $NAME
-            value: $URL
-      - metavariable-regex:
-          metavariable: $URL
-          regex: '.*\.svc\.cluster\.local.*'
+    # languages: [generic] (spacegrep) is required here because Helm templates
+    # contain {{ }} directives that make them invalid YAML. The YAML parser
+    # silently bails on these files and the rule never fires in yaml mode.
+    # pattern-regex is used because spacegrep tokenises "http" and ":" separately,
+    # breaking metavariable-regex capture of full unquoted URLs.
+    pattern-regex: 'value:[ \t]+"?[^"{\n]*\.svc\.cluster\.local'

--- a/bazel/semgrep/tests/fixtures/no-hardcoded-k8s-url-in-helm-env.yaml
+++ b/bazel/semgrep/tests/fixtures/no-hardcoded-k8s-url-in-helm-env.yaml
@@ -1,19 +1,23 @@
 # Tests for no-hardcoded-k8s-url-in-helm-env rule.
 # Helm template env vars must not hardcode .svc.cluster.local URLs — inject
 # via values.yaml so operators can override without editing the chart template.
+#
+# The rule uses languages: [generic] (spacegrep) with pattern-regex. In generic
+# mode the finding is anchored at the `value:` token, so # ruleid: annotations
+# must appear on the line immediately before `value:`.
 ---
-# ruleid: no-hardcoded-k8s-url-in-helm-env
 - name: CLICKHOUSE_URL
+  # ruleid: no-hardcoded-k8s-url-in-helm-env
   value: http://chi-signoz-clickhouse.signoz.svc.cluster.local:8123
 
 ---
-# ruleid: no-hardcoded-k8s-url-in-helm-env
 - name: OTEL_EXPORTER_OTLP_ENDPOINT
+  # ruleid: no-hardcoded-k8s-url-in-helm-env
   value: "http://signoz-otel-collector.signoz.svc.cluster.local:4317"
 
 ---
-# ruleid: no-hardcoded-k8s-url-in-helm-env
 - name: DATABASE_URL
+  # ruleid: no-hardcoded-k8s-url-in-helm-env
   value: 'postgres://user:pass@my-db.default.svc.cluster.local:5432/mydb'
 
 ---
@@ -38,3 +42,19 @@
 # ok: no-hardcoded-k8s-url-in-helm-env — localhost is not a cluster-local service URL
 - name: METRICS_ADDR
   value: http://localhost:9090
+
+---
+# Helm template syntax test: the rule must fire even when {{ }} directives are
+# present (YAML parser would reject this file; generic mode handles it fine).
+{{- if .Values.otel.enabled }}
+- name: OTEL_ENDPOINT
+  # ruleid: no-hardcoded-k8s-url-in-helm-env
+  value: http://my-otel-collector.monitoring.svc.cluster.local:4317
+{{- end }}
+
+---
+# ok: no-hardcoded-k8s-url-in-helm-env — Helm template with value from values.yaml
+{{- if .Values.otel.enabled }}
+- name: OTEL_ENDPOINT
+  value: {{ .Values.otel.endpoint | quote }}
+{{- end }}


### PR DESCRIPTION
## Summary

- Switch `languages: [yaml]` → `languages: [generic]` (spacegrep) so the rule fires on Helm templates containing `{{ }}` directives that break the YAML parser
- Replace `patterns+metavariable-regex` with `pattern-regex` — spacegrep tokenises `http` and `:` separately, so `$URL` only captures `http` rather than the full URL
- Update fixture: move `# ruleid:` annotations to the line immediately before `value:` (generic mode anchors findings at `value:`)
- Add a Helm template fixture block with `{{ }}` directives to verify the fix

## Root cause

In `languages: [yaml]` mode, semgrep's YAML parser silently bails when it encounters `{{ }}` Helm directives, so the rule never fired on real chart templates. Diagnosed in the same class of issues as PR #2319.

🤖 Generated with [Claude Code](https://claude.com/claude-code)