### PR TITLE
fix(semgrep): switch no-broad-public-api-prefix to languages: generic

### DIFF
--- a/bazel/semgrep/rules/yaml/no-broad-public-api-prefix.yaml
+++ b/bazel/semgrep/rules/yaml/no-broad-public-api-prefix.yaml
@@ -1,6 +1,6 @@
 rules:
   - id: no-broad-public-api-prefix
-    languages: [yaml]
+    languages: [generic]
     severity: WARNING
     message: >-
       Public HTTPRoute PathPrefix is too broad and risks exposing private API
@@ -20,10 +20,11 @@ rules:
     paths:
       include:
         - "**/chart/templates/httproute-public*"
-    patterns:
-      - pattern: |
-          type: PathPrefix
-          value: $VALUE
-      - metavariable-regex:
-          metavariable: $VALUE
-          regex: '^/api(/[^/]+)?$'
+    # languages: [generic] (spacegrep) is required here because Helm templates
+    # contain {{ }} directives that make them invalid YAML. The YAML parser
+    # silently bails on these files so the rule never fires in yaml mode.
+    # pattern-regex replaces patterns+metavariable-regex because spacegrep
+    # tokenises "/" separately, breaking $VALUE capture for path strings.
+    # The regex matches type: PathPrefix followed by value: /api with at most
+    # one additional path segment — i.e. /api or /api/<single-segment>.
+    pattern-regex: 'type:\s+PathPrefix\n[ \t]+value:\s+/api(/[^/\n]+)?(\n|$)'

--- a/bazel/semgrep/tests/fixtures/no-broad-public-api-prefix.yaml
+++ b/bazel/semgrep/tests/fixtures/no-broad-public-api-prefix.yaml
@@ -3,6 +3,10 @@
 # broad and risk exposing private endpoints. Prefixes must be scoped to at
 # least three segments (e.g. /api/knowledge/public) to be safe on a public
 # hostname.
+#
+# The rule uses languages: [generic] (spacegrep) with pattern-regex. In generic
+# mode the finding is anchored at the `type:` token, so # ruleid: annotations
+# must appear on the line immediately before `type: PathPrefix`.
 ---
 # Broad /api prefix — flags entire API namespace as public.
 apiVersion: gateway.networking.k8s.io/v1
@@ -131,3 +135,41 @@ spec:
           port: 8080
       timeouts:
         request: 30s
+
+---
+# Helm template syntax test: the rule must fire even when {{ }} directives are
+# present (YAML parser would reject this file; generic mode handles it fine).
+{{- if .Values.cfIngress.public.enabled }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "service.fullname" . }}-public
+spec:
+  rules:
+    - matches:
+        - path:
+            # ruleid: no-broad-public-api-prefix
+            type: PathPrefix
+            value: /api
+      backendRefs:
+        - name: {{ include "service.fullname" . }}
+          port: {{ .Values.service.port | int }}
+{{- end }}
+
+---
+# ok: no-broad-public-api-prefix — Helm template with narrowly scoped prefix
+{{- if .Values.cfIngress.public.enabled }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "service.fullname" . }}-public
+spec:
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /api/knowledge/public
+      backendRefs:
+        - name: {{ include "service.fullname" . }}
+          port: {{ .Values.service.port | int }}
+{{- end }}


### PR DESCRIPTION
## Summary

- Switch `languages: [yaml]` → `languages: [generic]` (spacegrep) so the rule fires on Helm templates containing `{{ }}` directives that break the YAML parser
- Replace `patterns+metavariable-regex` with `pattern-regex` matching the `type: PathPrefix` / `value:` pair in one regex — spacegrep tokenises `/` separately, breaking `$VALUE` capture for path strings
- Annotation positions are unchanged (already on the line before `type:`)
- Add Helm template fixture blocks with `{{ }}` directives to verify the fix

## Root cause

In `languages: [yaml]` mode, semgrep's YAML parser silently bails when it encounters `{{ }}` Helm directives, so the rule never fired on real chart templates. Same class of bug as PR #2319.

🤖 Generated with [Claude Code](https://claude.com/claude-code)