### PR TITLE
fix(semgrep): switch require-readiness-probe to languages: generic

### DIFF
--- a/bazel/semgrep/rules/kubernetes/require-readiness-probe.yaml
+++ b/bazel/semgrep/rules/kubernetes/require-readiness-probe.yaml
@@ -17,7 +17,12 @@ rules:
       the application is ready to serve requests. This causes failed requests
       during rolling updates and cold starts. Add a `readinessProbe` that
       checks application health (e.g. an HTTP /healthz endpoint).
-    languages: [yaml]
+    # languages: [generic] (spacegrep) is required here because Helm templates
+    # contain {{ }} directives that make them invalid YAML. The YAML parser
+    # silently bails on these files so the rule never fires in yaml mode.
+    # The pattern structure (pattern + same-scope pattern-not) is compatible
+    # with spacegrep — both combinators are evaluated within the containers: region.
+    languages: [generic]
     severity: WARNING
     metadata:
       category: correctness

--- a/bazel/semgrep/tests/fixtures/require-readiness-probe.yaml
+++ b/bazel/semgrep/tests/fixtures/require-readiness-probe.yaml
@@ -1,4 +1,7 @@
 # Tests for require-readiness-probe rule.
+# The rule uses languages: [generic] (spacegrep). In generic mode the finding
+# is anchored at the `containers:` token, so # ruleid: annotations must appear
+# on the line immediately before `containers:`.
 ---
 # ok: container has readinessProbe
 apiVersion: v1
@@ -17,12 +20,12 @@ spec:
         periodSeconds: 10
 
 ---
-# ruleid: require-readiness-probe
 apiVersion: v1
 kind: Pod
 metadata:
   name: bad-pod
 spec:
+# ruleid: require-readiness-probe
   containers:
     - name: app
       image: myapp:latest
@@ -33,3 +36,41 @@ spec:
         httpGet:
           path: /healthz
           port: 8080
+
+---
+# Helm template syntax test: the rule must fire even when {{ }} directives are
+# present (YAML parser would reject this file; generic mode handles it fine).
+{{- if .Values.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "service.fullname" . }}
+spec:
+  template:
+    spec:
+# ruleid: require-readiness-probe
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          ports:
+            - containerPort: {{ .Values.service.port }}
+{{- end }}
+
+---
+# ok: Helm template with readinessProbe present
+{{- if .Values.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "service.fullname" . }}
+spec:
+  template:
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: {{ .Values.service.port }}
+{{- end }}


### PR DESCRIPTION
## Summary

- Switch `languages: [yaml]` → `languages: [generic]` (spacegrep) so the rule fires on Helm templates containing `{{ }}` directives that break the YAML parser
- Pattern structure (`pattern` + same-scope `pattern-not` inside `containers:`) is fully compatible with spacegrep
- Update fixture: move `# ruleid:` annotations to the line immediately before `containers:` (generic mode anchors findings at the first matched token)
- Add Helm template fixture blocks with `{{ }}` directives to verify the fix

## Root cause

In `languages: [yaml]` mode, semgrep's YAML parser silently bails when it encounters `{{ }}` Helm directives, so the rule never fired on real chart templates. Same class of bug as PR #2319.

🤖 Generated with [Claude Code](https://claude.com/claude-code)