### PR TITLE
fix(semgrep): switch require-resource-limits to languages: generic

### DIFF
--- a/bazel/semgrep/rules/kubernetes/require-resource-limits.yaml
+++ b/bazel/semgrep/rules/kubernetes/require-resource-limits.yaml
@@ -18,7 +18,13 @@ rules:
       limits a single misbehaving container can consume all available CPU/memory
       on the node, causing OOMKills for other workloads. Define at minimum a
       memory limit. CPU limits are optional but recommended.
-    languages: [yaml]
+    # languages: [generic] (spacegrep) is required here because Helm templates
+    # contain {{ }} directives that make them invalid YAML. The YAML parser
+    # silently bails on these files so the rule never fires in yaml mode.
+    # The pattern structure (pattern + same-scope pattern-not inside containers:)
+    # is compatible with spacegrep — both combinators are evaluated within the
+    # containers: region, and multi-level ... nesting is handled correctly.
+    languages: [generic]
     severity: WARNING
     metadata:
       category: correctness

--- a/bazel/semgrep/tests/fixtures/require-resource-limits.yaml
+++ b/bazel/semgrep/tests/fixtures/require-resource-limits.yaml
@@ -1,4 +1,7 @@
 # Tests for require-resource-limits rule.
+# The rule uses languages: [generic] (spacegrep). In generic mode the finding
+# is anchored at the `containers:` token, so # ruleid: annotations must appear
+# on the line immediately before `containers:`.
 ---
 # ok: container has resource limits
 apiVersion: v1
@@ -18,24 +21,24 @@ spec:
           cpu: "500m"
 
 ---
-# ruleid: require-resource-limits
 apiVersion: v1
 kind: Pod
 metadata:
   name: bad-no-resources
 spec:
+# ruleid: require-resource-limits
   containers:
     - name: app
       image: myapp:latest
       # no resources block at all
 
 ---
-# ruleid: require-resource-limits
 apiVersion: v1
 kind: Pod
 metadata:
   name: bad-requests-only
 spec:
+# ruleid: require-resource-limits
   containers:
     - name: app
       image: myapp:latest
@@ -43,3 +46,42 @@ spec:
         requests:
           memory: "128Mi"
         # limits block missing
+
+---
+# Helm template syntax test: the rule must fire even when {{ }} directives are
+# present (YAML parser would reject this file; generic mode handles it fine).
+{{- if .Values.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "service.fullname" . }}
+spec:
+  template:
+    spec:
+# ruleid: require-resource-limits
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          ports:
+            - containerPort: {{ .Values.service.port }}
+{{- end }}
+
+---
+# ok: Helm template with resource limits present
+{{- if .Values.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "service.fullname" . }}
+spec:
+  template:
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          resources:
+            requests:
+              memory: "128Mi"
+            limits:
+              memory: "512Mi"
+{{- end }}


### PR DESCRIPTION
## Summary

- Switch `languages: [yaml]` → `languages: [generic]` (spacegrep) so the rule fires on Helm templates containing `{{ }}` directives that break the YAML parser
- Pattern structure (`pattern` + same-scope `pattern-not` inside `containers:` with multi-level `...` nesting for `resources.limits`) is fully compatible with spacegrep
- Update fixture: move `# ruleid:` annotations to the line immediately before `containers:` (generic mode anchors findings at the first matched token)
- Add Helm template fixture blocks with `{{ }}` directives to verify the fix

## Root cause

In `languages: [yaml]` mode, semgrep's YAML parser silently bails when it encounters `{{ }}` Helm directives, so the rule never fired on real chart templates. Same class of bug as PR #2319.

🤖 Generated with [Claude Code](https://claude.com/claude-code)