### PR TITLE
fix(semgrep): switch require-cnpg-cluster-resources to languages: generic

### DIFF
--- a/bazel/semgrep/rules/kubernetes/require-cnpg-cluster-resources.yaml
+++ b/bazel/semgrep/rules/kubernetes/require-cnpg-cluster-resources.yaml
@@ -16,7 +16,13 @@ rules:
                 memory: ...
     message: >
       CNPG Cluster missing resources.requests.memory — pods may be OOM-killed without memory requests.
-    languages: [yaml]
+    # languages: [generic] (spacegrep) is required here because Helm templates
+    # contain {{ }} directives that make them invalid YAML. The YAML parser
+    # silently bails on these files so the rule never fires in yaml mode.
+    # The pattern structure (pattern-inside + pattern + same-scope pattern-not
+    # inside spec:) is compatible with spacegrep — all three combinators are
+    # supported in generic mode.
+    languages: [generic]
     severity: WARNING
     metadata:
       category: correctness

--- a/bazel/semgrep/tests/fixtures/require-cnpg-cluster-resources.yaml
+++ b/bazel/semgrep/tests/fixtures/require-cnpg-cluster-resources.yaml
@@ -1,6 +1,10 @@
 # Tests for require-cnpg-cluster-resources rule.
 # CNPG Cluster CRDs must declare spec.resources.requests.memory to prevent
 # pods from being OOM-killed when the node is under memory pressure.
+#
+# The rule uses languages: [generic] (spacegrep). In generic mode the finding
+# is anchored at the `spec:` token, so # ruleid: annotations must appear on
+# the line immediately before `spec:`.
 ---
 # ok: require-cnpg-cluster-resources — has resources.requests.memory
 apiVersion: postgresql.cnpg.io/v1
@@ -43,20 +47,20 @@ spec:
           image: myapp:latest
 
 ---
-# ruleid: require-cnpg-cluster-resources
 apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
 metadata:
   name: missing-all-resources
+# ruleid: require-cnpg-cluster-resources
 spec:
   instances: 3
 
 ---
-# ruleid: require-cnpg-cluster-resources
 apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
 metadata:
   name: missing-requests-memory
+# ruleid: require-cnpg-cluster-resources
 spec:
   instances: 3
   resources:
@@ -64,13 +68,42 @@ spec:
       memory: "2Gi"
 
 ---
-# ruleid: require-cnpg-cluster-resources
 apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
 metadata:
   name: has-requests-cpu-but-not-memory
+# ruleid: require-cnpg-cluster-resources
 spec:
   instances: 3
   resources:
     requests:
       cpu: "500m"
+
+---
+# Helm template syntax test: the rule must fire even when {{ }} directives are
+# present (YAML parser would reject this file; generic mode handles it fine).
+{{- if .Values.postgresql.enabled }}
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: {{ include "service.fullname" . }}-pg
+# ruleid: require-cnpg-cluster-resources
+spec:
+  instances: {{ .Values.postgresql.instances }}
+  storage:
+    size: {{ .Values.postgresql.storage.size }}
+{{- end }}
+
+---
+# ok: Helm template with resources.requests.memory present
+{{- if .Values.postgresql.enabled }}
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: {{ include "service.fullname" . }}-pg
+spec:
+  instances: {{ .Values.postgresql.instances }}
+  resources:
+    requests:
+      memory: {{ .Values.postgresql.resources.requests.memory | quote }}
+{{- end }}


### PR DESCRIPTION
## Summary

- Switch `languages: [yaml]` → `languages: [generic]` (spacegrep) so the rule fires on Helm templates containing `{{ }}` directives that break the YAML parser
- Pattern structure (`pattern-inside` + `pattern` + same-scope `pattern-not` inside `spec:`) is fully compatible with spacegrep — all three combinators are supported in generic mode
- Update fixture: move `# ruleid:` annotations to the line immediately before `spec:` (generic mode anchors findings at the inner `pattern:` match)
- Add Helm template fixture blocks with `{{ }}` directives to verify the fix

## Root cause

In `languages: [yaml]` mode, semgrep's YAML parser silently bails when it encounters `{{ }}` Helm directives, so the rule never fired on real chart templates. Same class of bug as PR #2319.

🤖 Generated with [Claude Code](https://claude.com/claude-code)