### PR TITLE
fix(semgrep): document require-fsgroup-with-pvc helm template limitation

### DIFF
--- a/bazel/semgrep/rules/kubernetes/require-fsgroup-with-pvc.yaml
+++ b/bazel/semgrep/rules/kubernetes/require-fsgroup-with-pvc.yaml
@@ -16,6 +16,17 @@ rules:
       `fsGroup: 65532` in `spec.template.spec.securityContext`. Without it, the
       volume is owned by root and the container will fail with a permission denied
       error. Add `fsGroup: 65532` to your `podSecurityContext` values.
+    # NOTE: This rule intentionally keeps languages: [yaml] rather than [generic].
+    # The pattern-not checks for securityContext.fsGroup which is a sibling key to
+    # volumes: in the pod spec (not nested inside volumes:). In spacegrep's generic
+    # mode, pattern-not is evaluated within the anchor region only (the volumes: block),
+    # where fsGroup never appears — so the pattern-not would always be satisfied,
+    # producing a false positive on every correctly-configured PVC deployment.
+    #
+    # Consequence: this rule is a Helm template blind spot. The YAML parser silently
+    # bails on {{ }} directives, so the rule never fires on chart templates. The
+    # no-yaml-language-in-helm-template-rule meta-rule flags this for future
+    # redesign once a safe conversion path is identified.
     languages: [yaml]
     severity: ERROR
     metadata:

--- a/bazel/semgrep/tests/fixtures/require-fsgroup-with-pvc.yaml
+++ b/bazel/semgrep/tests/fixtures/require-fsgroup-with-pvc.yaml
@@ -1,4 +1,15 @@
 # Tests for require-fsgroup-with-pvc rule.
+# NOTE: This rule uses languages: [yaml] and is intentionally NOT converted to
+# languages: [generic]. The pattern-not checks for securityContext.fsGroup which
+# is a sibling key to volumes: (never nested inside it). In spacegrep generic mode,
+# pattern-not is evaluated within the anchor region only — fsGroup never appears
+# inside volumes:, so the pattern-not would always be satisfied on every PVC
+# volume, producing a false positive on every correctly-configured deployment.
+#
+# Helm template blind spot: this rule will not fire on Helm templates that contain
+# {{ }} directives because the YAML parser silently bails on those files.
+# The no-yaml-language-in-helm-template-rule meta-rule flags this rule for future
+# redesign once a safe conversion strategy is identified.
 ---
 # ok: PVC volume with fsGroup set in podSecurityContext
 apiVersion: apps/v1


### PR DESCRIPTION
## Summary

- Documents why `require-fsgroup-with-pvc` intentionally keeps `languages: [yaml]` rather than converting to `languages: [generic]`
- Adds detailed comments to both the rule and test fixture explaining the incompatibility

## Why not generic mode?

The rule's `pattern-not` checks for `securityContext.fsGroup` which is a **sibling key** to `volumes:` in the pod spec — it never appears inside the `volumes:` block. In spacegrep's generic mode, `pattern-not` is evaluated within the anchor region only (the `volumes:` block), so `fsGroup` would never be found there, meaning the `pattern-not` would always be satisfied and the rule would fire on **every PVC deployment** including correctly-configured ones → false positive on every good deployment.

The trade-off: the rule is a Helm template blind spot (the YAML parser bails on `{{ }}`-containing files). The companion PR adds the `no-yaml-language-in-helm-templates` meta-rule which flags this for future redesign.

🤖 Generated with [Claude Code](https://claude.com/claude-code)