### PR TITLE
feat(semgrep): add meta-rule no-yaml-language-in-helm-templates

### DIFF
--- a/bazel/semgrep/rules/yaml/no-yaml-language-in-helm-templates.yaml
+++ b/bazel/semgrep/rules/yaml/no-yaml-language-in-helm-templates.yaml
@@ -1,0 +1,35 @@
+rules:
+  - id: no-yaml-language-in-helm-templates
+    languages: [yaml]
+    severity: ERROR
+    message: >-
+      This semgrep rule uses `languages: [yaml]` but its `paths.include`
+      targets `**/chart/templates/**`. Helm templates contain `{{ }}` directives
+      that make them invalid YAML — the YAML parser silently bails on those files
+      and the rule never fires on real chart templates. Switch to
+      `languages: [generic]` (spacegrep) and adapt patterns as needed. See PR
+      #2319 for the conversion pattern.
+    metadata:
+      category: correctness
+      subcategory: semgrep
+      confidence: HIGH
+      likelihood: HIGH
+      impact: HIGH
+      technology: [semgrep, helm]
+      description: >-
+        Detects semgrep rules that combine languages: [yaml] with a chart/templates
+        path filter — a combination that silently never fires on real Helm chart files.
+    paths:
+      include:
+        - "bazel/semgrep/rules/**/*.yaml"
+    patterns:
+      - pattern: |
+          languages:
+            - yaml
+      - pattern: |
+          paths:
+            include:
+              - $PATH
+      - metavariable-regex:
+          metavariable: $PATH
+          regex: '.*chart/templates.*'

--- a/bazel/semgrep/tests/fixtures/no-yaml-language-in-helm-templates.yaml
+++ b/bazel/semgrep/tests/fixtures/no-yaml-language-in-helm-templates.yaml
@@ -1,0 +1,64 @@
+# Tests for no-yaml-language-in-helm-templates rule.
+# Flags semgrep rule files that combine languages: [yaml] with a paths.include
+# entry targeting chart/templates — such rules silently never fire on Helm
+# template files because the YAML parser bails on {{ }} directives.
+#
+# In yaml-mode semgrep tests, # ruleid: annotations appear at the start of
+# the document (right after ---), before the first key.
+---
+# ruleid: no-yaml-language-in-helm-templates
+rules:
+  - id: bad-yaml-helm-rule
+    languages: [yaml]
+    severity: WARNING
+    message: "some message"
+    paths:
+      include:
+        - "**/chart/templates/**"
+    pattern: "foo: bar"
+
+---
+# ruleid: no-yaml-language-in-helm-templates
+rules:
+  - id: bad-yaml-helm-rule-kubernetes-subdir
+    languages: [yaml]
+    severity: ERROR
+    message: "some message"
+    paths:
+      include:
+        - "**/chart/templates/deployment.yaml"
+    patterns:
+      - pattern: "foo: bar"
+
+---
+# ok: no-yaml-language-in-helm-templates — uses languages: [generic] for chart templates
+rules:
+  - id: ok-generic-helm-rule
+    languages: [generic]
+    severity: WARNING
+    message: "some message"
+    paths:
+      include:
+        - "**/chart/templates/**"
+    pattern: "foo: bar"
+
+---
+# ok: no-yaml-language-in-helm-templates — uses languages: [yaml] but not for chart templates
+rules:
+  - id: ok-yaml-non-chart-rule
+    languages: [yaml]
+    severity: WARNING
+    message: "some message"
+    paths:
+      include:
+        - "**/*.yaml"
+    pattern: "foo: bar"
+
+---
+# ok: no-yaml-language-in-helm-templates — no paths restriction, not targeting charts
+rules:
+  - id: ok-yaml-no-paths-rule
+    languages: [yaml]
+    severity: WARNING
+    message: "some message"
+    pattern: "foo: bar"


### PR DESCRIPTION
## Summary

- Adds a new semgrep rule `no-yaml-language-in-helm-templates` that flags any semgrep rule YAML file combining `languages: [yaml]` with a `paths.include` entry targeting `chart/templates`
- Prevents this class of silent-miss bug from recurring — new rules with the broken combination will be caught in CI
- Rule lives in `bazel/semgrep/rules/yaml/` and is automatically included in `yaml_rules_test`
- Test fixture covers 2 bad cases and 3 good cases (generic mode, non-chart path, no paths)

## Background

PR #2319 fixed `no-httproute-rule-without-timeout` by switching from `languages: [yaml]` to `languages: [generic]`. Six other rules had the same bug. The companion PRs fix 5 of them; `require-fsgroup-with-pvc` is documented as intentionally exempt (spacegrep structural incompatibility). This meta-rule ensures no new rules fall into the same trap.

The meta-rule will itself flag `require-fsgroup-with-pvc` in production scans, serving as a persistent reminder that the rule needs a safe redesign path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)