### PR TITLE
feat(hooks): add check-semgrep-rule-has-fixture PreToolUse hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -118,6 +118,11 @@
             "type": "command",
             "command": "$CLAUDE_PROJECT_DIR/bazel/tools/hooks/check-public-route-visibility-filter.sh",
             "timeout": 10
+          },
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/bazel/tools/hooks/check-semgrep-rule-has-fixture.sh",
+            "timeout": 10
           }
         ]
       }

--- a/bazel/tools/hooks/BUILD
+++ b/bazel/tools/hooks/BUILD
@@ -45,3 +45,9 @@ sh_test(
     srcs = ["check-public-route-visibility-filter_test.sh"],
     data = [":check-public-route-visibility-filter.sh"],
 )
+
+sh_test(
+    name = "check_semgrep_rule_has_fixture_test",
+    srcs = ["check-semgrep-rule-has-fixture_test.sh"],
+    data = [":check-semgrep-rule-has-fixture.sh"],
+)

--- a/bazel/tools/hooks/check-semgrep-rule-has-fixture.sh
+++ b/bazel/tools/hooks/check-semgrep-rule-has-fixture.sh
@@ -49,7 +49,7 @@ has_non_yaml_fixture() {
 }
 
 # Check 1: central fixtures dir — any extension (including .yaml)
-if compgen -G "${FIXTURES_DIR}/${STEM}."'*' > /dev/null 2>&1; then
+if compgen -G "${FIXTURES_DIR}/${STEM}."'*' >/dev/null 2>&1; then
 	exit 0
 fi
 

--- a/bazel/tools/hooks/check-semgrep-rule-has-fixture.sh
+++ b/bazel/tools/hooks/check-semgrep-rule-has-fixture.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# PreToolUse hook: warn when writing/editing a semgrep rule YAML file that has
+# no corresponding test fixture.
+#
+# Fixtures can live in two places:
+#   1. bazel/semgrep/tests/fixtures/<rule-stem>.<ext>  (central fixtures dir)
+#   2. bazel/semgrep/rules/<subdir>/<rule-stem>.<ext>  (colocated, any non-yaml ext)
+#      Python fixtures use underscore naming: <rule_stem>.py
+#
+# Input: JSON on stdin from Claude Code hook system
+# Exit 0: allow (warnings emitted on stderr — advisory only)
+# Exit 2: block (not used)
+
+set -euo pipefail
+
+INPUT=$(cat)
+
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
+if [[ -z "$FILE_PATH" ]]; then
+	exit 0
+fi
+
+# Only check semgrep rule yaml files (bazel/semgrep/rules/<subdir>/<name>.yaml)
+if [[ "$FILE_PATH" != */bazel/semgrep/rules/*/*.yaml ]]; then
+	exit 0
+fi
+
+STEM=$(basename "$FILE_PATH" .yaml)
+RULE_DIR=$(dirname "$FILE_PATH")
+
+# Derive the project root (everything before /bazel/semgrep/)
+PROJECT_DIR=$(echo "$FILE_PATH" | sed 's|/bazel/semgrep/.*||')
+FIXTURES_DIR="${PROJECT_DIR}/bazel/semgrep/tests/fixtures"
+
+# Python colocated fixtures use underscores instead of dashes
+STEM_UNDERSCORED=$(echo "$STEM" | tr '-' '_')
+
+# Helper: check if any non-yaml file matches a glob prefix
+has_non_yaml_fixture() {
+	local prefix="$1"
+	local found=false
+	# Use a subshell with nullglob to safely iterate
+	while IFS= read -r f; do
+		[[ "$f" == *.yaml ]] && continue
+		found=true
+		break
+	done < <(compgen -G "${prefix}."'*' 2>/dev/null || true)
+	$found
+}
+
+# Check 1: central fixtures dir — any extension (including .yaml)
+if compgen -G "${FIXTURES_DIR}/${STEM}."'*' > /dev/null 2>&1; then
+	exit 0
+fi
+
+# Check 2: colocated fixture with dash-named stem (non-yaml)
+if has_non_yaml_fixture "${RULE_DIR}/${STEM}"; then
+	exit 0
+fi
+
+# Check 3: colocated fixture with underscore-named stem (Python convention)
+if [[ "$STEM_UNDERSCORED" != "$STEM" ]] && has_non_yaml_fixture "${RULE_DIR}/${STEM_UNDERSCORED}"; then
+	exit 0
+fi
+
+cat >&2 <<EOF
+WARNING: No test fixture found for semgrep rule '${STEM}'.
+
+Expected a fixture in one of:
+  ${FIXTURES_DIR}/${STEM}.<ext>
+  ${RULE_DIR}/${STEM}.<ext>  (colocated)
+  ${RULE_DIR}/${STEM_UNDERSCORED}.<ext>  (colocated, Python naming)
+
+Add a fixture file to validate the rule catches real violations.
+See bazel/semgrep/tests/fixtures/ for examples.
+
+File: ${FILE_PATH}
+EOF
+
+exit 0

--- a/bazel/tools/hooks/check-semgrep-rule-has-fixture_test.sh
+++ b/bazel/tools/hooks/check-semgrep-rule-has-fixture_test.sh
@@ -1,0 +1,209 @@
+#!/usr/bin/env bash
+# Unit tests for check-semgrep-rule-has-fixture.sh PreToolUse hook.
+#
+# The hook:
+#   - Reads JSON from stdin with .tool_input.file_path
+#   - Exits 0 always (warning-only, never blocks)
+#   - Emits a WARNING on stderr when a semgrep rule yaml has no fixture in
+#     either bazel/semgrep/tests/fixtures/ or colocated in the rule directory
+#   - Skips non-rule files (not under bazel/semgrep/rules/<subdir>/)
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Locate hook from Bazel runfiles
+# ---------------------------------------------------------------------------
+HOOK_REL="bazel/tools/hooks/check-semgrep-rule-has-fixture.sh"
+HOOK=""
+for candidate in \
+	"${RUNFILES_DIR:-}/_main/${HOOK_REL}" \
+	"${TEST_SRCDIR:-}/_main/${HOOK_REL}" \
+	"${BASH_SOURCE[0]%/*}/check-semgrep-rule-has-fixture.sh"; do
+	if [[ -f "$candidate" ]]; then
+		HOOK="$candidate"
+		break
+	fi
+done
+if [[ -z "$HOOK" ]]; then
+	echo "ERROR: cannot locate check-semgrep-rule-has-fixture.sh in runfiles" >&2
+	exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Install a minimal jq stub so the hook runs in the hermetic Bazel sandbox.
+# The hook uses:
+#   jq -r '.tool_input.file_path // empty'
+# ---------------------------------------------------------------------------
+mkdir -p "${TEST_TMPDIR}/bin"
+cat >"${TEST_TMPDIR}/bin/jq" <<'JQ_STUB'
+#!/usr/bin/env python3
+"""Minimal jq stub covering expressions used by check-semgrep-rule-has-fixture.sh."""
+import json, sys
+
+args = sys.argv[1:]
+raw = False
+if args and args[0] == "-r":
+    raw = True
+    args = args[1:]
+
+expr = args[0] if args else "."
+data = json.load(sys.stdin)
+
+def jq_eval(obj, expr):
+    """Evaluate '.a.b // .c.d // empty' style expressions."""
+    for alt in expr.split("//"):
+        alt = alt.strip()
+        if alt == "empty":
+            return None
+        keys = [k for k in alt.lstrip(".").split(".") if k]
+        val = obj
+        try:
+            for k in keys:
+                val = val[k] if isinstance(val, dict) else None
+                if val is None:
+                    break
+        except (KeyError, TypeError):
+            val = None
+        if val is not None:
+            return val
+    return None
+
+result = jq_eval(data, expr)
+if result is None:
+    pass  # empty — print nothing
+elif raw:
+    print(result)
+else:
+    print(json.dumps(result))
+JQ_STUB
+chmod +x "${TEST_TMPDIR}/bin/jq"
+export PATH="${TEST_TMPDIR}/bin:${PATH}"
+
+# ---------------------------------------------------------------------------
+# Set up a fake project directory tree that mirrors the real layout
+# ---------------------------------------------------------------------------
+FAKE_ROOT="${TEST_TMPDIR}/project"
+FAKE_RULES="${FAKE_ROOT}/bazel/semgrep/rules"
+FAKE_FIXTURES="${FAKE_ROOT}/bazel/semgrep/tests/fixtures"
+mkdir -p "${FAKE_RULES}/kubernetes" "${FAKE_RULES}/python" "${FAKE_RULES}/yaml" "${FAKE_FIXTURES}"
+
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
+PASS=0
+FAIL=0
+
+make_json() {
+	local fp="$1"
+	python3 - "$fp" <<'PY'
+import json, sys
+print(json.dumps({"tool_name": "Write", "tool_input": {"file_path": sys.argv[1], "content": "rules: []"}}))
+PY
+}
+
+run_test() {
+	local name="$1"
+	local input_json="$2"
+	local want_exit="$3"
+	local want_stderr_re="$4"
+
+	local stderr_out
+	local got_exit=0
+	stderr_out=$(printf '%s' "$input_json" | bash "$HOOK" 2>&1 >/dev/null) || got_exit=$?
+
+	local ok=true
+
+	if [[ "$got_exit" -ne "$want_exit" ]]; then
+		echo "FAIL [$name]: exit $got_exit, want $want_exit"
+		ok=false
+	fi
+
+	if [[ -n "$want_stderr_re" ]]; then
+		if ! echo "$stderr_out" | grep -qE "$want_stderr_re"; then
+			echo "FAIL [$name]: stderr $(printf '%q' "$stderr_out") did not match /$want_stderr_re/"
+			ok=false
+		fi
+	else
+		if [[ -n "$stderr_out" ]]; then
+			echo "FAIL [$name]: unexpected stderr: $(printf '%q' "$stderr_out")"
+			ok=false
+		fi
+	fi
+
+	if $ok; then
+		echo "PASS [$name]"
+		PASS=$((PASS + 1))
+	else
+		FAIL=$((FAIL + 1))
+	fi
+}
+
+# ---------------------------------------------------------------------------
+# Test cases
+# ---------------------------------------------------------------------------
+
+# 1. Rule has a fixture in tests/fixtures/ → silent
+RULE_A="${FAKE_RULES}/kubernetes/no-privileged.yaml"
+touch "$RULE_A"
+touch "${FAKE_FIXTURES}/no-privileged.yaml"
+run_test "rule_with_central_fixture_silent" \
+	"$(make_json "$RULE_A")" \
+	0 ""
+
+# 2. Rule has NO fixture anywhere → warns
+RULE_B="${FAKE_RULES}/kubernetes/no-orphan-resource.yaml"
+touch "$RULE_B"
+run_test "rule_without_fixture_warns" \
+	"$(make_json "$RULE_B")" \
+	0 "WARNING.*no-orphan-resource"
+
+# 3. Non-rule file (wrong path) → silent
+run_test "non_rule_file_silent" \
+	"$(make_json "${FAKE_ROOT}/projects/myapp/chart/templates/deployment.yaml")" \
+	0 ""
+
+# 4. Empty JSON → silent
+run_test "empty_json_silent" \
+	'{}' \
+	0 ""
+
+# 5. Rule has colocated non-yaml fixture (dash-named) → silent
+RULE_C="${FAKE_RULES}/yaml/no-httproute-timeout.yaml"
+touch "$RULE_C"
+touch "${FAKE_RULES}/yaml/no-httproute-timeout.txt"
+run_test "rule_with_colocated_fixture_silent" \
+	"$(make_json "$RULE_C")" \
+	0 ""
+
+# 6. Rule has colocated fixture with Python underscore naming → silent
+RULE_D="${FAKE_RULES}/python/session-add-in-loop.yaml"
+touch "$RULE_D"
+touch "${FAKE_RULES}/python/session_add_in_loop.py"
+run_test "rule_with_colocated_underscore_fixture_silent" \
+	"$(make_json "$RULE_D")" \
+	0 ""
+
+# 7. Rule has a central fixture with non-yaml extension → silent
+RULE_E="${FAKE_RULES}/yaml/no-unquoted-args.yaml"
+touch "$RULE_E"
+touch "${FAKE_FIXTURES}/no-unquoted-args.go"
+run_test "rule_with_central_non_yaml_fixture_silent" \
+	"$(make_json "$RULE_E")" \
+	0 ""
+
+# 8. File in rules/ top level (no subdir) — does NOT match the pattern → silent
+TOP_RULE="${FAKE_RULES}/no-top-level.yaml"
+touch "$TOP_RULE"
+run_test "top_level_rules_file_silent" \
+	"$(make_json "$TOP_RULE")" \
+	0 ""
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+echo "Results: ${PASS} passed, ${FAIL} failed"
+if [[ "$FAIL" -gt 0 ]]; then
+	exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

- Adds `bazel/tools/hooks/check-semgrep-rule-has-fixture.sh`: fires on Write|Edit when the file path matches `bazel/semgrep/rules/**/*.yaml`, checks for a fixture in `bazel/semgrep/tests/fixtures/` or colocated in the rule directory (including Python underscore-named variants), and emits an advisory WARNING on stderr if none is found
- Adds `bazel/tools/hooks/check-semgrep-rule-has-fixture_test.sh`: sh_test with 8 cases covering 8 scenarios (fixture found, no fixture warns, non-rule file silent, etc.)
- Registers the hook in `.claude/settings.json` under the Write|Edit matcher
- Adds BUILD target for the test

## Test plan

- [ ] CI passes `bazel test //bazel/tools/hooks:check_semgrep_rule_has_fixture_test`
- [ ] Hook is advisory-only: always exits 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)