### PR TITLE
docs(stargazer): fix README — optional NGINX API, 6h schedule, weather.py

### DIFF
--- a/projects/stargazer/README.md
+++ b/projects/stargazer/README.md
@@ -4,14 +4,14 @@ Finds the best stargazing spots in Scotland for the next 72 hours.
 
 ## Overview
 
-Multi-phase pipeline: light pollution atlas + OSM road data + DEM (Digital Elevation Model) data to identify dark zones near roads, scored by weather forecast. The backend runs as a scheduled CronJob with a separate NGINX API server for serving results.
+Multi-phase pipeline: light pollution atlas + OSM road data + DEM (Digital Elevation Model) data to identify dark zones near roads, scored by weather forecast. The backend runs as a scheduled CronJob (every 6 hours). An optional NGINX API server serves the results — disabled by default (`api.enabled: false` in chart defaults) and enabled in the cluster deploy values.
 
 | Component   | Description |
 | ----------- | ----------- |
-| **backend** | Pipeline that combines light pollution data, OSM roads, DEM elevation data, and weather forecasts |
+| **backend** | Pipeline that combines light pollution data, OSM roads, DEM elevation data, and weather forecasts (`weather.py` handles met.no forecast API calls) |
 | **tests**   | Additional unit tests for the backend pipeline (separate from tests co-located in `backend/`) |
-| **chart**   | Helm chart with CronJob and NGINX API server templates |
-| **deploy**  | ArgoCD Application, kustomization, and cluster-specific values |
+| **chart**   | Helm chart with CronJob and optional NGINX API server templates (controlled by `api.enabled` flag) |
+| **deploy**  | ArgoCD Application, kustomization, and cluster-specific values (enables API server via `api.enabled: true`) |
 
 ## Documentation
 


### PR DESCRIPTION
## Summary

- **API server is optional, not always-on:** README implied the NGINX API server is always deployed alongside the CronJob; clarified it is disabled by default (`api.enabled: false` in chart `values.yaml`) and enabled in the cluster deploy values
- **CronJob schedule:** Added "every 6 hours" (`0 */6 * * *`) to the overview description
- **weather.py module:** Noted in the backend row that `weather.py` handles met.no forecast API calls

## Test plan

- [ ] Verify `projects/stargazer/chart/values.yaml` has `api.enabled: false`
- [ ] Verify `projects/stargazer/deploy/values.yaml` has `api.enabled: true`
- [ ] Verify `projects/stargazer/chart/values.yaml` schedule is `"0 */6 * * *"`
- [ ] Verify `projects/stargazer/backend/weather.py` exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)