### PR TITLE
docs(trips): fix README — pnpm→npm, TripSummaryPage, image upload, alert

### DIFF
--- a/projects/trips/README.md
+++ b/projects/trips/README.md
@@ -6,8 +6,8 @@ Photo-based GPS trip logging with elevation enrichment.
 
 | Component      | Description                                                                                |
 | -------------- | ------------------------------------------------------------------------------------------ |
-| **backend**    | FastAPI server that replays trip data from NATS JetStream and serves REST + WebSocket APIs |
-| **frontend**   | Timeline view with day-by-day maps and per-day elevation stats (ascent, descent, min/max) — deployed as a Cloudflare Pages app (not part of the Helm chart) |
+| **backend**    | FastAPI server that replays trip data from NATS JetStream and serves REST + WebSocket APIs; includes image upload endpoints (`UploadFile`) for ingesting trip photos |
+| **frontend**   | Timeline view with day-by-day maps and per-day elevation stats (ascent, descent, min/max), plus a `TripSummaryPage` with a full-trip overview and multi-day map — deployed as a Cloudflare Pages app (not part of the Helm chart) |
 | **tools**      | CLI tools for trip data management — six sub-directories: `publish-trip-images` (image ingestion with EXIF extraction), `backfill-elevation` (replays NATS points and enriches with elevation data), `delete-trip-points` (publishes tombstone messages to delete points), `publish-gap-route` (parses KML files to fill route gaps), `detect-wildlife` (wildlife detection inference + GoPro camera control), `elevation` (elevation API client library) |
 | **chart**      | Helm chart for Kubernetes deployment — includes nginx reverse-proxy and imgproxy templates |
-| **deploy**     | ArgoCD Application, kustomization, and cluster-specific values                             |
+| **deploy**     | ArgoCD Application, kustomization, cluster-specific values, and SigNoz HTTP health check alert for imgproxy (`img-httpcheck-alert.yaml`) |

--- a/projects/trips/frontend/README.md
+++ b/projects/trips/frontend/README.md
@@ -20,10 +20,10 @@ Interactive trip viewer for exploring travel routes and photos.
 
 ```bash
 # Install dependencies
-pnpm install
+npm install
 
 # Start dev server
-pnpm dev
+npm run dev
 ```
 
 The app connects to the trips API (`api.jomcgi.dev/trips`) for photo and route data.


### PR DESCRIPTION
## Summary

- **frontend/README.md:** Replace `pnpm install`/`pnpm dev` with `npm install`/`npm run dev` — the project has `package-lock.json` (npm), not `pnpm-lock.yaml`
- **README.md backend row:** Add mention of image upload endpoints (FastAPI `UploadFile`) for ingesting trip photos
- **README.md frontend row:** Add `TripSummaryPage` (full-trip overview with multi-day map) to the page list
- **README.md deploy row:** Add `img-httpcheck-alert.yaml` (SigNoz HTTP health check alert for imgproxy)

## Test plan

- [ ] Verify `projects/trips/frontend/package-lock.json` exists (not `pnpm-lock.yaml`)
- [ ] Verify `UploadFile` import in `projects/trips/backend/main.py`
- [ ] Verify `projects/trips/frontend/src/pages/TripSummaryPage.jsx` exists
- [ ] Verify `projects/trips/deploy/img-httpcheck-alert.yaml` exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)