### PR TITLE
test(hooks): add missing coverage for semgrep PreToolUse hook edge cases

### DIFF
--- a/bazel/tools/hooks/check-semgrep-helm-fixture-has-template-syntax_test.sh
+++ b/bazel/tools/hooks/check-semgrep-helm-fixture-has-template-syntax_test.sh
@@ -266,6 +266,33 @@ run_test "write_fixture_no_matching_rule_silent" \
 		'no helm syntax here')" \
 	0 ""
 
+# 10. Edit: existing file has no {{ AND new_string has no {{ → warns
+# This exercises the third Edit sub-path: file exists, no {{ on disk, no {{ in new_string.
+printf '# plain fixture, no helm syntax\nmatchLabels:\n  app: myapp\n' >"$FIXTURE_PATH"
+run_test "edit_existing_file_no_helm_syntax_new_string_no_helm_syntax_warns" \
+	"$(make_edit_json "$FIXTURE_PATH" \
+		'app: myapp' \
+		'app: newapp')" \
+	0 "WARNING.*require-component-label"
+rm -f "$FIXTURE_PATH"
+
+# 11. Edit: file does not exist AND new_string has no {{ → warns
+# Ensures the warning fires for brand-new fixtures written via Edit without helm syntax.
+run_test "edit_new_file_no_helm_syntax_warns" \
+	"$(make_edit_json "$FIXTURE_PATH" \
+		'' \
+		'matchLabels:
+  app: myapp')" \
+	0 "WARNING.*require-component-label"
+
+# 12. Edit: empty new_string (no content to check) → silent
+# The early-exit on empty FIXTURE_CONTENT prevents a false positive.
+run_test "edit_empty_new_string_silent" \
+	"$(make_edit_json "$FIXTURE_PATH" \
+		'app: myapp' \
+		'')" \
+	0 ""
+
 # ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------

--- a/bazel/tools/hooks/check-semgrep-rule-has-fixture_test.sh
+++ b/bazel/tools/hooks/check-semgrep-rule-has-fixture_test.sh
@@ -198,6 +198,27 @@ run_test "top_level_rules_file_silent" \
 	"$(make_json "$TOP_RULE")" \
 	0 ""
 
+# 9. Rule has a colocated .yaml sibling (e.g. another YAML rule or config) but
+# no non-yaml fixture. has_non_yaml_fixture filters .yaml files, so the
+# sibling must NOT satisfy Check 2 → warns.
+# This explicitly exercises the `[[ "$f" == *.yaml ]] && continue` branch.
+RULE_F="${FAKE_RULES}/kubernetes/no-yaml-only-fixture.yaml"
+touch "$RULE_F"
+touch "${FAKE_RULES}/kubernetes/no-yaml-only-fixture.config.yaml"
+# The .yaml sibling is filtered out by has_non_yaml_fixture; no non-yaml
+# fixture exists → WARNING expected.
+run_test "rule_colocated_yaml_only_fixture_warns" \
+	"$(make_json "$RULE_F")" \
+	0 "WARNING.*no-yaml-only-fixture"
+
+# 10. Rule whose stem has no dashes (STEM_UNDERSCORED == STEM) and no fixture → warns.
+# Check 3 is skipped because the stem contains no dashes; warning must still fire.
+RULE_G="${FAKE_RULES}/kubernetes/noprivileged.yaml"
+touch "$RULE_G"
+run_test "rule_no_dashes_in_stem_no_fixture_warns" \
+	"$(make_json "$RULE_G")" \
+	0 "WARNING.*noprivileged"
+
 # ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes the two **high-severity** coverage gaps identified in the post-merge review of `e719face..b2a187ed`:

### `check-semgrep-helm-fixture-has-template-syntax_test.sh` (+3 tests)
- **Test 10** – Edit where existing file has no `{{` AND `new_string` has no `{{` → the warning path for the Edit tool was entirely untested; this is the main gap
- **Test 11** – Edit where the file doesn't yet exist and `new_string` has no `{{` → same warning path for brand-new fixtures
- **Test 12** – Edit with empty `new_string` → exercises the empty-`FIXTURE_CONTENT` early-exit guard (lines 71-73)

### `check-semgrep-rule-has-fixture_test.sh` (+2 tests)
- **Test 9** – Rule with a colocated `.yaml`-only sibling → explicitly exercises the `[[ "$f" == *.yaml ]] && continue` branch inside `has_non_yaml_fixture` (never reached by any prior test)
- **Test 10** – Rule whose stem has no dashes (`STEM_UNDERSCORED == STEM`) and no fixture → confirms the warning fires when Check 3 is skipped entirely

No production code was modified.

## Test plan
- [ ] CI runs `bazel test //bazel/tools/hooks/...` and both `sh_test` targets pass with the new cases included

🤖 Generated with [Claude Code](https://claude.com/claude-code)