### PR TITLE
feat(monolith): add public notes graph page at public.jomcgi.dev/notes

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.74.4
+version: 0.75.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.74.4
+      targetRevision: 0.75.0
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/lib/components/notes/NotePanel.svelte
+++ b/projects/monolith/frontend/src/lib/components/notes/NotePanel.svelte
@@ -2,7 +2,14 @@
   import { renderMarkdown } from "./markdown.js";
   import { colorFor, labelFor } from "./clusters.js";
 
-  let { selectedId, nodes, edges, onSelect, onClose } = $props();
+  let {
+    selectedId,
+    nodes,
+    edges,
+    onSelect,
+    onClose,
+    apiBase = "/api/knowledge/notes",
+  } = $props();
 
   let byId = $derived(new Map(nodes.map((n) => [n.id, n])));
   let titleMap = $derived(
@@ -77,12 +84,15 @@
     loading = true;
     error = "";
     body = "";
-    fetch(`/api/knowledge/notes/${encodeURIComponent(selectedId)}`, {
+    fetch(`${apiBase}/${encodeURIComponent(selectedId)}`, {
       signal: controller.signal,
     })
       .then((r) => (r.ok ? r.json() : Promise.reject(new Error("fetch failed"))))
       .then((data) => {
-        body = data.content ?? "";
+        // Private endpoint returns `content` (raw markdown incl. frontmatter,
+        // trimmed client-side); public endpoint returns `body` (already
+        // stripped + wikilink-sanitized server-side). Accept either.
+        body = data.content ?? data.body ?? "";
       })
       .catch((e) => {
         if (e.name !== "AbortError") error = "couldn't load note body";

--- a/projects/monolith/frontend/src/routes/public/notes/+page.js
+++ b/projects/monolith/frontend/src/routes/public/notes/+page.js
@@ -1,0 +1,4 @@
+// Same as private/notes: the page is a canvas-driven force graph, so
+// SSR adds latency without UX value and avoids Svelte 5 hydration
+// issues with d3-mounted components.
+export const ssr = false;

--- a/projects/monolith/frontend/src/routes/public/notes/+page.server.js
+++ b/projects/monolith/frontend/src/routes/public/notes/+page.server.js
@@ -1,0 +1,25 @@
+import { error } from "@sveltejs/kit";
+import { NOTES_PAGE_CACHE_CONTROL } from "../../../lib/cache-headers.js";
+
+const API_BASE = process.env.API_BASE || "http://localhost:8000";
+
+// Mirrors private/notes/+page.server.js, but hits the visibility-filtered
+// public endpoint. The backend enforces `visibility = 'public'` on both
+// nodes and edges (both-ends-public), so we just pass the payload through.
+export async function load({ fetch, setHeaders }) {
+  const res = await fetch(`${API_BASE}/api/knowledge/public/graph`, {
+    signal: AbortSignal.timeout(10_000),
+  });
+  if (!res.ok) {
+    throw error(503, "graph unavailable");
+  }
+
+  const headers = { "cache-control": NOTES_PAGE_CACHE_CONTROL };
+  const etag = res.headers?.get?.("etag");
+  if (etag) headers.etag = etag;
+  const lastModified = res.headers?.get?.("last-modified");
+  if (lastModified) headers["last-modified"] = lastModified;
+  setHeaders(headers);
+
+  return { graph: await res.json() };
+}

--- a/projects/monolith/frontend/src/routes/public/notes/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/notes/+page.svelte
@@ -7,19 +7,11 @@
 
   let { data } = $props();
 
-  // The server filters nodes by type (see GRAPH_NOTE_TYPES in store.py).
-  // We just pass through what arrives — no client-side filter needed.
   let nodes = $derived(data.graph.nodes);
   let edges = $derived(data.graph.edges);
   let indexedAt = $derived(data.graph.indexed_at);
-
-  // Degree is supplied per-node by the server (graph payload).
   let nodesWithDegree = $derived(nodes);
 
-  // activeClusters is initialised from the *initial* graph (a one-time
-  // snapshot), then mutated locally as the user toggles. Reading data
-  // (a $props value) inside $state() captures cleanly; reading a
-  // $derived inside $state() trips state_referenced_locally.
   let activeClusters = $state(
     new Set(data.graph.nodes.map((n) => n.type).filter(Boolean)),
   );
@@ -75,7 +67,7 @@
       {edges}
       onSelect={selectNode}
       onClose={() => (selectedId = null)}
-      apiBase="/api/knowledge/notes"
+      apiBase="/api/knowledge/public/notes"
     />
   </div>
 </div>

--- a/projects/monolith/frontend/src/routes/public/notes/page.server.test.js
+++ b/projects/monolith/frontend/src/routes/public/notes/page.server.test.js
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi } from "vitest";
+import { load } from "./+page.server.js";
+
+function makeHeaders(map = {}) {
+  const lower = Object.fromEntries(
+    Object.entries(map).map(([k, v]) => [k.toLowerCase(), v]),
+  );
+  return { get: (name) => lower[name.toLowerCase()] ?? null };
+}
+
+describe("/public/notes load", () => {
+  it("hits the visibility-filtered public graph endpoint", async () => {
+    const setHeaders = vi.fn();
+    const fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      headers: makeHeaders(),
+      json: async () => ({ nodes: [], edges: [], indexed_at: null }),
+    });
+
+    await load({ fetch, setHeaders });
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    const url = fetch.mock.calls[0][0];
+    expect(url).toMatch(/\/api\/knowledge\/public\/graph$/);
+    // Belt-and-braces: must NEVER fall back to the unfiltered private endpoint
+    // — that would leak private nodes onto public.jomcgi.dev.
+    expect(url).not.toMatch(/\/api\/knowledge\/graph$/);
+  });
+
+  it("sets a 1h s-maxage cache-control header", async () => {
+    const setHeaders = vi.fn();
+    const fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      headers: makeHeaders(),
+      json: async () => ({ nodes: [], edges: [], indexed_at: null }),
+    });
+
+    const result = await load({ fetch, setHeaders });
+
+    expect(setHeaders).toHaveBeenCalledWith(
+      expect.objectContaining({
+        "cache-control": expect.stringContaining("s-maxage=3600"),
+      }),
+    );
+    expect(result.graph).toEqual({ nodes: [], edges: [], indexed_at: null });
+  });
+
+  it("forwards ETag and Last-Modified from the API response", async () => {
+    const setHeaders = vi.fn();
+    const fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      headers: makeHeaders({
+        ETag: '"abc-3"',
+        "Last-Modified": "Mon, 27 Apr 2026 12:00:00 GMT",
+      }),
+      json: async () => ({ nodes: [], edges: [], indexed_at: null }),
+    });
+
+    await load({ fetch, setHeaders });
+
+    expect(setHeaders).toHaveBeenCalledWith(
+      expect.objectContaining({
+        etag: '"abc-3"',
+        "last-modified": "Mon, 27 Apr 2026 12:00:00 GMT",
+      }),
+    );
+  });
+
+  it("omits ETag and Last-Modified when the API does not return them", async () => {
+    const setHeaders = vi.fn();
+    const fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      headers: makeHeaders(),
+      json: async () => ({ nodes: [], edges: [], indexed_at: null }),
+    });
+
+    await load({ fetch, setHeaders });
+
+    const headers = setHeaders.mock.calls[0][0];
+    expect(headers).not.toHaveProperty("etag");
+    expect(headers).not.toHaveProperty("last-modified");
+  });
+
+  it("throws a 503 when the backend fetch fails", async () => {
+    const setHeaders = vi.fn();
+    const fetch = vi.fn().mockResolvedValue({ ok: false, status: 502 });
+
+    await expect(load({ fetch, setHeaders })).rejects.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

V2 of the public knowledge surface (V1 was the backend wiring + visibility column). Adds the SvelteKit page at `public.jomcgi.dev/notes` that renders the visibility-filtered force graph and slide-out note panel.

- New route `src/routes/public/notes/` — server loader hits `/api/knowledge/public/graph`, SSR off (same reason as `/private/notes`: canvas-driven d3 force graph)
- `NotePanel.svelte` now takes an `apiBase` prop (default `/api/knowledge/notes` preserves private behaviour) and accepts both `content` (private endpoint) and `body` (public endpoint, server-sanitized)
- Belt-and-braces: ingress already gates `/api/knowledge/public/*` only; backend enforces `visibility = 'public'`; this PR adds a unit-test assertion that the SvelteKit loader URL must NOT match the unfiltered `/graph` endpoint

## Test plan

- [ ] CI: `page.server.test.js` passes (load hits `/public/graph`, cache headers forwarded, 503 on backend failure)
- [ ] After merge: `curl https://public.jomcgi.dev/notes` returns the page HTML
- [ ] After merge: click a node → `NotePanel` fetches `/api/knowledge/public/notes/{id}` and renders sanitized body
- [ ] After merge: confirm private notes are NOT in the graph (cross-check node count against `/api/knowledge/public/graph`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)