### PR TITLE
feat(monolith): public layout pass + indexed_at + nav fix

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.75.0
+version: 0.76.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.76.0
+version: 0.76.1
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/migrations/20260522000000_knowledge_notes_public_layout_columns.sql
+++ b/projects/monolith/chart/migrations/20260522000000_knowledge_notes_public_layout_columns.sql
@@ -1,0 +1,18 @@
+-- knowledge.notes: add a separate force-directed layout pass for the
+-- public-only subgraph.
+--
+-- The existing layout_x/layout_y columns are computed by the gardener
+-- across the full graph (public + private). When the public API filters
+-- to visibility='public' the surviving nodes keep their global positions,
+-- which leaves visible "holes" where private clusters used to anchor
+-- the layout. The new columns hold positions computed over the public
+-- subset alone so the public /notes page renders a dense, intentional
+-- layout instead of a sparse ghost of the full graph.
+--
+-- Both columns are nullable. The next reconcile cycle populates them;
+-- until then, get_public_graph falls back to layout_x/layout_y via
+-- COALESCE so deploys never serve a blank canvas.
+
+ALTER TABLE knowledge.notes
+    ADD COLUMN layout_x_public DOUBLE PRECISION,
+    ADD COLUMN layout_y_public DOUBLE PRECISION;

--- a/projects/monolith/chart/migrations/atlas.sum
+++ b/projects/monolith/chart/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:ReBe4WJ/ttG6lak6HK4GpcO0RiyOyDP2HD7KUsJXULQ=
+h1:L1E9+BD86SA5oi9Ia2cJ993PRpr+IgHkAqnDCRtZiuQ=
 20260330000000_initial_schema.sql h1:J2futpSW0nJAIRR7nR7ssT7LwXIYrvRI+PkHb5Y4tLI=
 20260403000000_chat_schema.sql h1:pERUFC0vzM95etRuzp43XzkCV7lBCzrrtY5Mk7aF3CA=
 20260404000000_chat_attachments.sql h1:tv+Fdbr1rQC5nzUxfaBC0O6fu2OMGgLWf+YNg1WQXi4=
@@ -22,3 +22,4 @@ h1:ReBe4WJ/ttG6lak6HK4GpcO0RiyOyDP2HD7KUsJXULQ=
 20260506000000_knowledge_notes_layout_columns.sql h1:RzegpcFnYfeRKXVXdCosHAUWgFaWBbCr6cJwrQPGN9s=
 20260507120000_agent_tables.sql h1:4qwbdgPxJhF7t0sPWbMi9B59aYPECnybb9k9HeiU5+U=
 20260508000000_knowledge_notes_visibility.sql h1:VdONxBqXQJrc8uxN2IvO6s1gTLSdfmxcBg3z1jhV1lA=
+20260522000000_knowledge_notes_public_layout_columns.sql h1:UIKms5VUlxrTwoBGV7ReSyV4FJX0ohEpnDRwQ1c3VCQ=

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.75.0
+      targetRevision: 0.76.0
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.76.0
+      targetRevision: 0.76.1
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/lib/public/components/Nav.svelte
+++ b/projects/monolith/frontend/src/lib/public/components/Nav.svelte
@@ -2,9 +2,15 @@
   /** @type {{ route?: string }} */
   let { route = "home" } = $props();
 
+  // NOTES is a same-host relative URL so it resolves to
+  // public.jomcgi.dev/notes from the public homepage and to
+  // private.jomcgi.dev/notes from the private dashboard, without
+  // bouncing public visitors into the auth-gated private surface.
+  // Other links are cross-host by design — HOME always points at the
+  // public site, ENGINEERING and CV live on the apex domain.
   const items = [
     { slug: "home", label: "HOME", href: "https://public.jomcgi.dev/" },
-    { slug: "notes", label: "NOTES", href: "https://private.jomcgi.dev/notes" },
+    { slug: "notes", label: "NOTES", href: "/notes" },
     {
       slug: "engineering",
       label: "ENGINEERING",

--- a/projects/monolith/knowledge/models.py
+++ b/projects/monolith/knowledge/models.py
@@ -90,6 +90,14 @@ class Note(SQLModel, table=True):  # nosemgrep: sqlmodel-datetime-without-factor
     indexed_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     layout_x: float | None = None
     layout_y: float | None = None
+    # Force-directed layout positions computed over the public-visibility
+    # subgraph only — used by GET /knowledge/public/graph so the public
+    # /notes page renders a dense layout instead of inheriting the full
+    # graph's positions (which leave visible holes where private clusters
+    # used to anchor). Populated by a separate gardener layout pass; the
+    # public endpoint COALESCEs back to layout_x/y until the first pass.
+    layout_x_public: float | None = None
+    layout_y_public: float | None = None
 
 
 class Chunk(SQLModel, table=True):

--- a/projects/monolith/knowledge/router.py
+++ b/projects/monolith/knowledge/router.py
@@ -23,7 +23,7 @@ from typing import Literal
 import yaml
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response
 from pydantic import BaseModel
-from sqlalchemy import or_
+from sqlalchemy import func, or_
 from sqlmodel import Session, select
 
 from app.db import get_session
@@ -170,8 +170,14 @@ def get_public_graph(
             Note.title,
             Note.type,
             Note.indexed_at,
-            Note.layout_x,
-            Note.layout_y,
+            # Prefer public-only layout positions (computed over the public
+            # subgraph by knowledge.service._run_public_layout_pass); fall
+            # back to the full-graph positions if the public pass hasn't
+            # populated this row yet, so a fresh deploy never serves NULL
+            # coords. Same shape consumed by /private/notes — keep both as
+            # nullable in the response, the client handles either.
+            func.coalesce(Note.layout_x_public, Note.layout_x).label("x"),
+            func.coalesce(Note.layout_y_public, Note.layout_y).label("y"),
         )
         .where(public_notes_filter())
         .where(Note.type.in_(list(GRAPH_NOTE_TYPES)))
@@ -222,8 +228,8 @@ def get_public_graph(
             "title": row.title,
             "type": row.type,
             "degree": degree_by_note_id.get(row.note_id, 0),
-            "x": row.layout_x,
-            "y": row.layout_y,
+            "x": row.x,
+            "y": row.y,
         }
         for row in public_note_rows
     ]
@@ -242,7 +248,14 @@ def get_public_graph(
     for key, value in headers.items():
         response.headers[key] = value
     logger.info("public.graph.served nodes=%d edges=%d", len(nodes), len(edges))
-    return {"nodes": nodes, "edges": edges}
+    return {
+        "nodes": nodes,
+        "edges": edges,
+        # Mirrors get_graph's response — StatusBar in the SvelteKit page
+        # reads this to display "indexed Xm ago". Previously omitted so
+        # the public page showed "indexed —" while the private one didn't.
+        "indexed_at": indexed_at.isoformat() if indexed_at is not None else None,
+    }
 
 
 @router.get("/public/notes/{note_id}")

--- a/projects/monolith/knowledge/router_test.py
+++ b/projects/monolith/knowledge/router_test.py
@@ -4,7 +4,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
-from sqlmodel import Session, SQLModel, create_engine
+from sqlmodel import Session, SQLModel, create_engine, select
 from sqlmodel.pool import StaticPool
 
 from app.db import get_session

--- a/projects/monolith/knowledge/router_test.py
+++ b/projects/monolith/knowledge/router_test.py
@@ -947,6 +947,140 @@ class TestPublicGraphEndpoint:
 
         assert etag_a != etag_b
 
+    def test_public_graph_returns_indexed_at_in_body(self, real_session):
+        """StatusBar in the SvelteKit page reads data.graph.indexed_at;
+        the public endpoint previously emitted Last-Modified but omitted
+        the field from the JSON body, so the public /notes page showed
+        no indexed-at timestamp."""
+        store = KnowledgeStore(real_session)
+        _upsert(
+            store,
+            note_id="pub-A",
+            path="pub-a.md",
+            content_hash="h-pa",
+            title="Pub A",
+            metadata=_meta(title="Pub A", type="atom", visibility="public"),
+            n_chunks=0,
+        )
+
+        app.dependency_overrides[get_session] = lambda: real_session
+        try:
+            c = TestClient(app, raise_server_exceptions=False)
+            res = c.get("/api/knowledge/public/graph")
+        finally:
+            app.dependency_overrides.clear()
+
+        body = res.json()
+        assert "indexed_at" in body
+        # ISO 8601 string (the actual instant is non-deterministic, set
+        # at upsert time — just assert the field is populated and
+        # roundtrips through fromisoformat).
+        from datetime import datetime as _dt
+
+        parsed = _dt.fromisoformat(body["indexed_at"])
+        assert parsed.tzinfo is not None  # always UTC-aware
+
+    def test_public_graph_indexed_at_null_when_no_public_notes(self, real_session):
+        """Empty public set → indexed_at is JSON null (not missing), so
+        the frontend can treat it as a known absence."""
+        store = KnowledgeStore(real_session)
+        _upsert(
+            store,
+            note_id="priv-X",
+            path="priv-x.md",
+            content_hash="h-px",
+            title="Priv X",
+            metadata=_meta(title="Priv X", type="atom", visibility="private"),
+            n_chunks=0,
+        )
+
+        app.dependency_overrides[get_session] = lambda: real_session
+        try:
+            c = TestClient(app, raise_server_exceptions=False)
+            res = c.get("/api/knowledge/public/graph")
+        finally:
+            app.dependency_overrides.clear()
+
+        body = res.json()
+        assert body["nodes"] == []
+        assert body["indexed_at"] is None
+
+    def test_public_graph_prefers_public_layout_columns(self, real_session):
+        """When layout_x_public/y_public are set, the endpoint returns
+        them in preference to the full-graph layout_x/y."""
+        from knowledge.models import Note
+
+        store = KnowledgeStore(real_session)
+        _upsert(
+            store,
+            note_id="pub-A",
+            path="pub-a.md",
+            content_hash="h-pa",
+            title="Pub A",
+            metadata=_meta(title="Pub A", type="atom", visibility="public"),
+            n_chunks=0,
+        )
+        # Seed both columns with distinguishable values; endpoint must
+        # serve the *_public values.
+        note = real_session.scalars(select(Note).where(Note.note_id == "pub-A")).one()
+        note.layout_x = 0.1
+        note.layout_y = 0.2
+        note.layout_x_public = 0.7
+        note.layout_y_public = 0.8
+        real_session.add(note)
+        real_session.commit()
+
+        app.dependency_overrides[get_session] = lambda: real_session
+        try:
+            c = TestClient(app, raise_server_exceptions=False)
+            res = c.get("/api/knowledge/public/graph")
+        finally:
+            app.dependency_overrides.clear()
+
+        body = res.json()
+        nodes = body["nodes"]
+        assert len(nodes) == 1
+        assert nodes[0]["x"] == 0.7
+        assert nodes[0]["y"] == 0.8
+
+    def test_public_graph_falls_back_to_full_layout_when_public_null(
+        self, real_session
+    ):
+        """First-deploy safety: when the public layout pass hasn't yet
+        populated the new columns, the endpoint must serve the full-graph
+        layout via COALESCE so /notes doesn't render blank."""
+        from knowledge.models import Note
+
+        store = KnowledgeStore(real_session)
+        _upsert(
+            store,
+            note_id="pub-A",
+            path="pub-a.md",
+            content_hash="h-pa",
+            title="Pub A",
+            metadata=_meta(title="Pub A", type="atom", visibility="public"),
+            n_chunks=0,
+        )
+        note = real_session.scalars(select(Note).where(Note.note_id == "pub-A")).one()
+        note.layout_x = 0.1
+        note.layout_y = 0.2
+        # layout_x_public/y_public left NULL — simulates pre-first-pass.
+        real_session.add(note)
+        real_session.commit()
+
+        app.dependency_overrides[get_session] = lambda: real_session
+        try:
+            c = TestClient(app, raise_server_exceptions=False)
+            res = c.get("/api/knowledge/public/graph")
+        finally:
+            app.dependency_overrides.clear()
+
+        body = res.json()
+        nodes = body["nodes"]
+        assert len(nodes) == 1
+        assert nodes[0]["x"] == 0.1
+        assert nodes[0]["y"] == 0.2
+
 
 def _seed_public_note_file(
     vault_dir,

--- a/projects/monolith/knowledge/service.py
+++ b/projects/monolith/knowledge/service.py
@@ -18,6 +18,7 @@ from knowledge.layout import EdgeRef, LayoutParams, NodePos, compute_layout
 from knowledge.models import Note, NoteLink
 from knowledge.reconciler import Reconciler
 from knowledge.store import KnowledgeStore
+from knowledge.visibility import public_notes_filter
 from shared.embedding import EmbeddingClient
 
 logger = logging.getLogger(__name__)
@@ -241,6 +242,71 @@ def _run_layout_pass(engine: Engine) -> tuple[int, int, int]:
         return len(nodes), len(edges), len(positions)
 
 
+def _run_public_layout_pass(engine: Engine) -> tuple[int, int, int]:
+    """Compute layout positions for the public-visibility subgraph only.
+
+    Mirrors :func:`_run_layout_pass` but restricts to ``visibility = 'public'``
+    notes and persists positions to ``layout_x_public`` / ``layout_y_public``.
+    The full-graph layout (``layout_x`` / ``layout_y``) is unchanged — the
+    two passes are independent so the private notes page continues to render
+    from its existing positions regardless of which finishes first.
+
+    Edge filter mirrors :func:`get_public_graph`: both endpoints must
+    resolve to a public note (source via the SQL filter on ``Note``, target
+    via the slug→canonical resolution against the public-only id set).
+    """
+    params = LayoutParams.from_env()
+
+    with Session(engine) as session:
+        note_rows = session.execute(
+            select(
+                Note.id,
+                Note.note_id,
+                Note.layout_x_public,
+                Note.layout_y_public,
+            ).where(public_notes_filter())
+        ).all()
+        fk_to_note_id: dict[int, str] = {r.id: r.note_id for r in note_rows}
+        nodes = [
+            NodePos(id=r.note_id, prior_x=r.layout_x_public, prior_y=r.layout_y_public)
+            for r in note_rows
+        ]
+
+        if not nodes:
+            return 0, 0, 0
+
+        edge_rows = session.execute(
+            select(NoteLink.src_note_fk, NoteLink.target_id)
+            .join(Note, NoteLink.src_note_fk == Note.id)
+            .where(public_notes_filter())
+        ).all()
+        note_id_set = set(fk_to_note_id.values())
+        slug_to_note_id = {_slugify(nid): nid for nid in note_id_set}
+        edges: list[EdgeRef] = []
+        for r in edge_rows:
+            if r.src_note_fk not in fk_to_note_id:
+                continue
+            canonical_target = slug_to_note_id.get(_slugify(r.target_id))
+            if canonical_target is None:
+                continue
+            edges.append(
+                EdgeRef(source=fk_to_note_id[r.src_note_fk], target=canonical_target)
+            )
+
+        positions = compute_layout(nodes, edges, params)
+
+        if positions:
+            for note_id, (x, y) in positions.items():
+                session.execute(
+                    update(Note)
+                    .where(Note.note_id == note_id)
+                    .values(layout_x_public=x, layout_y_public=y)
+                )
+            session.commit()
+
+        return len(nodes), len(edges), len(positions)
+
+
 async def reconcile_handler(session: Session) -> datetime | None:
     """Scheduler handler: run the knowledge vault reconciler."""
     if not _vault_sync_ready():
@@ -290,6 +356,30 @@ async def reconcile_handler(session: Session) -> datetime | None:
                 "edge_count": edge_count,
                 "positioned": positioned,
                 "duration_ms": int((time.perf_counter() - start) * 1000),
+            },
+        )
+
+    # Public-only layout pass: independent of the full-graph pass so the
+    # private notes page never loses its layout if the public pass fails,
+    # and vice versa. Runs sequentially on a worker thread for the same
+    # event-loop-blocking reason as the full pass.
+    public_start = time.perf_counter()
+    try:
+        (
+            public_node_count,
+            public_edge_count,
+            public_positioned,
+        ) = await asyncio.to_thread(_run_public_layout_pass, session.get_bind())
+    except Exception:  # noqa: BLE001 — same isolation rule as the full-graph pass
+        logger.exception("knowledge.layout: public pass failed")
+    else:
+        logger.info(
+            "knowledge.layout: public pass succeeded",
+            extra={
+                "node_count": public_node_count,
+                "edge_count": public_edge_count,
+                "positioned": public_positioned,
+                "duration_ms": int((time.perf_counter() - public_start) * 1000),
             },
         )
 

--- a/projects/monolith/knowledge/service_test.py
+++ b/projects/monolith/knowledge/service_test.py
@@ -873,6 +873,107 @@ class TestReconcileHandlerLayout:
         assert notes[0].layout_x is None
         assert notes[0].layout_y is None
 
+    @pytest.mark.asyncio
+    async def test_reconcile_handler_populates_public_layout_positions(
+        self, monkeypatch, tmp_path, session, fake_embed_client
+    ):
+        """Only public notes get layout_x_public/y_public; private stay NULL.
+
+        Mirrors the full-graph layout assertion above. The public pass
+        runs over visibility='public' only, so private notes must keep
+        NULL public coords even though they have full-graph coords.
+        """
+        from knowledge.models import Note
+
+        monkeypatch.setenv("VAULT_ROOT", str(tmp_path))
+        self._setup_vault(tmp_path)
+        self._write_note(
+            tmp_path,
+            "pub.md",
+            "---\nid: pub\ntitle: Pub\nvisibility: public\n---\n[[priv]] and [[pub2]].",
+        )
+        self._write_note(
+            tmp_path,
+            "pub2.md",
+            "---\nid: pub2\ntitle: Pub2\nvisibility: public\n---\n[[pub]].",
+        )
+        self._write_note(
+            tmp_path,
+            "priv.md",
+            "---\nid: priv\ntitle: Priv\nvisibility: private\n---\nBody.",
+        )
+
+        with patch("knowledge.service.EmbeddingClient", return_value=fake_embed_client):
+            await service.reconcile_handler(session)
+
+        notes = {n.note_id: n for n in session.scalars(select(Note))}
+        assert set(notes) == {"pub", "pub2", "priv"}
+        # Public notes get public-layout positions (in addition to the
+        # full-graph ones every note gets).
+        for nid in ("pub", "pub2"):
+            assert notes[nid].layout_x_public is not None, (
+                f"{nid} missing layout_x_public"
+            )
+            assert notes[nid].layout_y_public is not None, (
+                f"{nid} missing layout_y_public"
+            )
+            assert math.isfinite(notes[nid].layout_x_public)
+            assert math.isfinite(notes[nid].layout_y_public)
+        # Private note: no public layout (the pass filtered it out).
+        assert notes["priv"].layout_x_public is None
+        assert notes["priv"].layout_y_public is None
+
+    @pytest.mark.asyncio
+    async def test_reconcile_handler_public_layout_failure_isolated(
+        self, monkeypatch, tmp_path, session, fake_embed_client, caplog
+    ):
+        """Public layout failure must not affect full-graph layout or upserts.
+
+        Patches ``_run_public_layout_pass`` to raise; the full-graph
+        pass still runs and populates layout_x/layout_y, and the
+        reconciler upsert is committed.
+        """
+        from knowledge.models import Note
+
+        monkeypatch.setenv("VAULT_ROOT", str(tmp_path))
+        self._setup_vault(tmp_path)
+        self._write_note(
+            tmp_path,
+            "a.md",
+            "---\nid: a\ntitle: A\nvisibility: public\n---\nLinks to [[b]].",
+        )
+        self._write_note(
+            tmp_path,
+            "b.md",
+            "---\nid: b\ntitle: B\nvisibility: public\n---\nBack to [[a]].",
+        )
+
+        def boom(_engine):
+            raise RuntimeError("boom")
+
+        monkeypatch.setattr("knowledge.service._run_public_layout_pass", boom)
+
+        with (
+            patch("knowledge.service.EmbeddingClient", return_value=fake_embed_client),
+            caplog.at_level(logging.ERROR, logger="knowledge.service"),
+        ):
+            result = await service.reconcile_handler(session)
+
+        assert result is None
+        assert any(
+            "knowledge.layout: public pass failed" in r.message for r in caplog.records
+        )
+        notes = list(session.scalars(select(Note)))
+        assert len(notes) == 2
+        # Full-graph layout still ran successfully.
+        for note in notes:
+            assert note.layout_x is not None
+            assert note.layout_y is not None
+        # Public layout failed, so public coords are NULL.
+        for note in notes:
+            assert note.layout_x_public is None
+            assert note.layout_y_public is None
+
     # Note: the "preserves positions across no-op cycles" integration
     # test was removed because FA2 doesn't reach a stable equilibrium
     # on the 2-node-connected fixture used here — both per-node drift


### PR DESCRIPTION
## Summary

Three follow-ups to PR #2342 (public notes graph page), bundled because they all touch the same surface:

### 1. Dedicated public-graph layout pass
- New columns: `knowledge.notes.layout_x_public`, `layout_y_public` (nullable float8, migration `20260522000000_knowledge_notes_public_layout_columns.sql`)
- New gardener pass: `knowledge.service._run_public_layout_pass` runs immediately after the existing `_run_layout_pass`, on a worker thread, over the `visibility='public'` subgraph only
- Endpoint: `get_public_graph` selects `COALESCE(layout_x_public, layout_x)` so the period between deploy and first reconcile cycle never serves blank coords
- Failure isolation: a public-layout exception is logged separately and can't take down the full-graph pass (or vice versa)

### 2. `indexed_at` in /public/graph response body
- The endpoint previously computed it and emitted `Last-Modified` but omitted it from the JSON. StatusBar on the public /notes page showed no timestamp.
- New response shape: `{nodes, edges, indexed_at}` — same as `/graph`

### 3. Nav `/notes` link is now relative
- `Nav.svelte` NOTES href changed from `https://private.jomcgi.dev/notes` to `/notes`
- On `public.jomcgi.dev` the link now stays on the public surface instead of bouncing visitors into the auth-gated private site
- HOME / ENGINEERING / CV stay absolute (they're intentionally cross-host)

## Test plan

- [ ] CI: 3 new service tests pass (public-pass populates new columns, public-pass failure isolated, full-pass still completes when public errors)
- [ ] CI: 3 new router tests pass (indexed_at in body, indexed_at null when no public notes, COALESCE fallback to layout_x/y, prefer public columns when set)
- [ ] After merge + reconcile (~5min): `curl https://public.jomcgi.dev/api/knowledge/public/graph` body contains `indexed_at`
- [ ] After merge + reconcile: rendered graph is denser (no large empty arc)
- [ ] After merge: `public.jomcgi.dev/` NOTES link goes to `public.jomcgi.dev/notes` (not private)

🤖 Generated with [Claude Code](https://claude.com/claude-code)