### PR TITLE
feat(semgrep): add sveltekit-public-route-fetches-private-knowledge-api rule

### DIFF
--- a/bazel/semgrep/rules/BUILD
+++ b/bazel/semgrep/rules/BUILD
@@ -327,3 +327,19 @@ semgrep_test(
     rules = [":no_session_in_to_thread_rule"],
     tags = ["semgrep"],
 )
+
+# sveltekit-public-route-fetches-private-knowledge-api uses languages: [generic] scoped to
+# **/routes/public/**/*page.server.*. Wired to its own .js annotation fixture independently of
+# typescript_rules_test (which only scans *.ts fixtures).
+filegroup(
+    name = "sveltekit_public_route_fetches_private_knowledge_api_rule",
+    srcs = ["typescript/sveltekit-public-route-fetches-private-knowledge-api.yaml"],
+)
+
+semgrep_test(
+    name = "sveltekit_public_route_fetches_private_knowledge_api_test",
+    srcs = ["//bazel/semgrep/tests:sveltekit_public_route_fetches_private_knowledge_api_fixtures"],
+    env = {"SEMGREP_TEST_MODE": "1"},
+    rules = [":sveltekit_public_route_fetches_private_knowledge_api_rule"],
+    tags = ["semgrep"],
+)

--- a/bazel/semgrep/rules/typescript/sveltekit-public-route-fetches-private-knowledge-api.yaml
+++ b/bazel/semgrep/rules/typescript/sveltekit-public-route-fetches-private-knowledge-api.yaml
@@ -1,0 +1,25 @@
+rules:
+  - id: sveltekit-public-route-fetches-private-knowledge-api
+    languages: [generic]
+    severity: ERROR
+    paths:
+      include:
+        - "**/routes/public/**/*page.server.*"
+    message: >-
+      Files under routes/public/ must use the visibility-filtered
+      /api/knowledge/public/ endpoints, not the private /api/knowledge/ ones.
+      Fetching private endpoints from a public route leaks private notes to
+      unauthenticated users. Replace /api/knowledge/graph with
+      /api/knowledge/public/graph and /api/knowledge/notes/ with
+      /api/knowledge/public/notes/.
+    metadata:
+      category: security
+      subcategory: data-exposure
+      confidence: HIGH
+      likelihood: HIGH
+      impact: HIGH
+      technology: [sveltekit, typescript, javascript]
+      description: Public SvelteKit route fetching private knowledge API endpoint
+    pattern-either:
+      - pattern-regex: '\/api\/knowledge\/graph'
+      - pattern-regex: '\/api\/knowledge\/notes'

--- a/bazel/semgrep/tests/BUILD
+++ b/bazel/semgrep/tests/BUILD
@@ -38,6 +38,13 @@ filegroup(
     srcs = glob(["fixtures/*.ts"]),
 )
 
+# Fixture for the sveltekit-public-route-fetches-private-knowledge-api rule (languages: generic).
+# Referenced by //bazel/semgrep/rules:sveltekit_public_route_fetches_private_knowledge_api_test.
+filegroup(
+    name = "sveltekit_public_route_fetches_private_knowledge_api_fixtures",
+    srcs = ["fixtures/sveltekit-public-route-fetches-private-knowledge-api.js"],
+)
+
 # Fixture for the no-create-event-dispatcher-runes rule (languages: generic, paths: projects/**/*.svelte).
 # Referenced by //bazel/semgrep/rules:no_create_event_dispatcher_runes_test.
 filegroup(

--- a/bazel/semgrep/tests/fixtures/sveltekit-public-route-fetches-private-knowledge-api.js
+++ b/bazel/semgrep/tests/fixtures/sveltekit-public-route-fetches-private-knowledge-api.js
@@ -8,11 +8,15 @@
 
 // Bare graph endpoint:
 // ruleid: sveltekit-public-route-fetches-private-knowledge-api
-const res = await fetch('/api/knowledge/graph', { signal: AbortSignal.timeout(5000) });
+const res = await fetch("/api/knowledge/graph", {
+  signal: AbortSignal.timeout(5000),
+});
 
 // Notes endpoint without public prefix:
 // ruleid: sveltekit-public-route-fetches-private-knowledge-api
-const notes = await fetch('/api/knowledge/notes/recent', { signal: AbortSignal.timeout(5000) });
+const notes = await fetch("/api/knowledge/notes/recent", {
+  signal: AbortSignal.timeout(5000),
+});
 
 // Double-quoted graph endpoint:
 // ruleid: sveltekit-public-route-fetches-private-knowledge-api
@@ -21,10 +25,14 @@ const data = await fetch("/api/knowledge/graph");
 // Negative examples — safe calls using the visibility-filtered public endpoints
 
 // ok: sveltekit-public-route-fetches-private-knowledge-api
-const pubGraph = await fetch('/api/knowledge/public/graph', { signal: AbortSignal.timeout(5000) });
+const pubGraph = await fetch("/api/knowledge/public/graph", {
+  signal: AbortSignal.timeout(5000),
+});
 
 // ok: sveltekit-public-route-fetches-private-knowledge-api
-const pubNotes = await fetch('/api/knowledge/public/notes/recent', { signal: AbortSignal.timeout(5000) });
+const pubNotes = await fetch("/api/knowledge/public/notes/recent", {
+  signal: AbortSignal.timeout(5000),
+});
 
 // ok: sveltekit-public-route-fetches-private-knowledge-api
 const pubData = await fetch("/api/knowledge/public/graph");

--- a/bazel/semgrep/tests/fixtures/sveltekit-public-route-fetches-private-knowledge-api.js
+++ b/bazel/semgrep/tests/fixtures/sveltekit-public-route-fetches-private-knowledge-api.js
@@ -1,0 +1,30 @@
+// Test fixtures for the sveltekit-public-route-fetches-private-knowledge-api semgrep rule.
+//
+// Annotations:
+//   // ruleid: sveltekit-public-route-fetches-private-knowledge-api  — the next non-annotation line MUST be flagged
+//   // ok: sveltekit-public-route-fetches-private-knowledge-api      — the next non-annotation line MUST NOT be flagged
+
+// Positive examples — fetching private knowledge API endpoints (should be flagged)
+
+// Bare graph endpoint:
+// ruleid: sveltekit-public-route-fetches-private-knowledge-api
+const res = await fetch('/api/knowledge/graph', { signal: AbortSignal.timeout(5000) });
+
+// Notes endpoint without public prefix:
+// ruleid: sveltekit-public-route-fetches-private-knowledge-api
+const notes = await fetch('/api/knowledge/notes/recent', { signal: AbortSignal.timeout(5000) });
+
+// Double-quoted graph endpoint:
+// ruleid: sveltekit-public-route-fetches-private-knowledge-api
+const data = await fetch("/api/knowledge/graph");
+
+// Negative examples — safe calls using the visibility-filtered public endpoints
+
+// ok: sveltekit-public-route-fetches-private-knowledge-api
+const pubGraph = await fetch('/api/knowledge/public/graph', { signal: AbortSignal.timeout(5000) });
+
+// ok: sveltekit-public-route-fetches-private-knowledge-api
+const pubNotes = await fetch('/api/knowledge/public/notes/recent', { signal: AbortSignal.timeout(5000) });
+
+// ok: sveltekit-public-route-fetches-private-knowledge-api
+const pubData = await fetch("/api/knowledge/public/graph");


### PR DESCRIPTION
## Summary

- Adds a new semgrep rule `sveltekit-public-route-fetches-private-knowledge-api` that catches `+page.server.js` files under `routes/public/` fetching private knowledge API endpoints
- Rule uses `languages: [generic]` with `paths.include` scoped to `**/routes/public/**/*page.server.*`
- Two `pattern-regex` alternatives: one for `/api/knowledge/graph` (exact), one for `/api/knowledge/notes` — both flag the unfiltered private endpoints
- Adds annotated test fixture `sveltekit-public-route-fetches-private-knowledge-api.js` with positive (bad) and negative (ok) examples
- Wires fixture + rule to a dedicated `semgrep_test` target in `//bazel/semgrep/rules`

## Test plan

- [ ] CI `sveltekit_public_route_fetches_private_knowledge_api_test` passes — semgrep correctly flags `/api/knowledge/graph` and `/api/knowledge/notes` fetch calls while allowing `/api/knowledge/public/graph` and `/api/knowledge/public/notes`
- [ ] `typescript_rules_test` continues to pass (new `.yaml` rule is automatically picked up by `glob(["typescript/*.yaml"])`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)