### PR TITLE
docs(stargazer): fix README inaccuracies around DEM support

### DIFF
--- a/projects/stargazer/README.md
+++ b/projects/stargazer/README.md
@@ -4,11 +4,13 @@ Finds the best stargazing spots in Scotland for the next 72 hours.
 
 ## Overview
 
-Multi-phase pipeline: light pollution atlas + OSM road data + DEM (Digital Elevation Model) data to identify dark zones near roads, scored by weather forecast. The backend runs as a scheduled CronJob (every 6 hours). An optional NGINX API server serves the results — disabled by default (`api.enabled: false` in chart defaults) and enabled in the cluster deploy values.
+Multi-phase pipeline: light pollution atlas + OSM road data to identify dark zones near roads, scored by weather forecast. The backend runs as a scheduled CronJob (every 6 hours). An optional NGINX API server serves the results — disabled by default (`api.enabled: false` in chart defaults) and enabled in the cluster deploy values.
+
+> **Note:** DEM (Digital Elevation Model / elevation) support is planned but not yet implemented. The pipeline currently uses `altitude_m = 0` for all locations. See [implementation.md](implementation.md) for planned tasks T4 and T8.
 
 | Component   | Description |
 | ----------- | ----------- |
-| **backend** | Pipeline that combines light pollution data, OSM roads, DEM elevation data, and weather forecasts (`weather.py` handles met.no forecast API calls) |
+| **backend** | Pipeline that combines light pollution data, OSM roads, and weather forecasts (`weather.py` handles met.no forecast API calls) |
 | **tests**   | Additional unit tests for the backend pipeline (separate from tests co-located in `backend/`) |
 | **chart**   | Helm chart with CronJob and optional NGINX API server templates (controlled by `api.enabled` flag) |
 | **deploy**  | ArgoCD Application, kustomization, and cluster-specific values (enables API server via `api.enabled: true`) |


### PR DESCRIPTION
## Summary

- Removes DEM (Digital Elevation Model) from the active pipeline description — `acquisition.download_dem()` is an unimplemented stub with a `# TODO: Implement SRTM tile fetching` comment that creates only an empty directory
- Adds a callout note clarifying that elevation support is planned (tasks T4/T8 in `implementation.md`) but not yet implemented, and that `altitude_m = 0` is used as the current fallback for all locations
- Updates the backend component table row to remove the incorrect "DEM elevation data" claim

## Test plan

- [ ] README accurately reflects current code behaviour (`altitude_m = 0` for all points)
- [ ] Note links correctly to `implementation.md` for planned tasks

🤖 Generated with [Claude Code](https://claude.com/claude-code)