### PR TITLE
feat(monolith): version-controlled claude.ai routines

### DIFF
--- a/.claude/skills/update-claude-routines/SKILL.md
+++ b/.claude/skills/update-claude-routines/SKILL.md
@@ -1,0 +1,187 @@
+---
+name: update-claude-routines
+description: Reconcile claude.ai scheduled-agent routines from version-controlled YAML in projects/monolith/claude_routines/. Resolves environment and mcp_connectors names against live claude.ai state at sync time. Invoke via /update-claude-routines, or use when the user has edited a routine YAML, asks to sync scheduled remote agents, or asks how the homelab's routine schema works.
+---
+
+# /update-claude-routines
+
+This skill keeps the user's claude.ai scheduled-agent routines in sync with the
+YAML definitions checked into `projects/monolith/claude_routines/`. The repo is
+the source of truth; running this skill brings live claude.ai state into
+alignment.
+
+## When to invoke
+
+- User types `/update-claude-routines` (optionally with a routine name as arg
+  to reconcile just that one routine)
+- User edits a file under `projects/monolith/claude_routines/`
+- User asks to sync, push, deploy, or reconcile scheduled remote agents
+- User asks "what's the schema for these YAMLs?" or "how do routine YAMLs work?"
+
+## What the YAMLs look like
+
+Each routine is one file at `projects/monolith/claude_routines/<slug>.yaml`.
+Full JSON Schema lives at `projects/monolith/claude_routines/schema.json` —
+prefer to read that for the authoritative spec. Summary:
+
+```yaml
+name: Backlog Audit (every 6h) # required; human-readable, used as the lookup key
+schedule: # required; pick one of cron or run_once_at
+  cron: "0 */6 * * *" # 5-field cron in UTC; minimum interval 1h
+  # run_once_at: "2026-05-23T15:00:00Z"  # RFC3339 UTC, future-dated
+enabled: true # default true
+model: claude-haiku-4-5-20251001 # pinned snapshot OR family alias (claude-haiku-4-5)
+environment: Default # NAME, not env_id (see Resolution rules)
+sources: # repos the agent's git workspace clones; optional
+  - https://github.com/jomcgi/homelab
+allowed_tools: [] # NOTE: API silently overrides [] with preset:default
+mcp_connectors: # short NAMES, not UUIDs (see Resolution rules)
+  - homelab
+prompt: | # required; the user-message content the routine fires with
+  ...
+```
+
+## Resolution rules — names → IDs at sync time
+
+The repo is deliberately UUID-free. Two fields are resolved from short names to
+account-specific IDs at sync time:
+
+### `environment` → `environment_id`
+
+| Name      | env_id                         | Notes                   |
+| --------- | ------------------------------ | ----------------------- |
+| `Default` | `env_011CUPNj26sqQQ9rLLJ6fZ7v` | Standard sandbox        |
+| `Unsafe`  | `env_011CUy9XmpTNSeNNCD1FDLWo` | Elevated; use sparingly |
+
+If the user adds a new environment, update this table.
+
+### `mcp_connectors[i]` (string) → full `{connector_uuid, name, url}` object
+
+Current connectors connected on the user's claude.ai account:
+
+| Short name        | connector_uuid                         | URL                                         |
+| ----------------- | -------------------------------------- | ------------------------------------------- |
+| `homelab`         | `c1cf153a-5323-43aa-9a3a-c01e08998732` | `https://mcp.jomcgi.dev/mcp`                |
+| `Google-Drive`    | `5080f8ce-2d1b-45c9-abeb-b0029012cc5b` | `https://drivemcp.googleapis.com/mcp/v1`    |
+| `Google-Calendar` | `b10484c4-1f11-439f-b1fe-c0918d15dbcc` | `https://calendarmcp.googleapis.com/mcp/v1` |
+| `Gmail`           | `c45373a8-c26e-436b-9285-5b747e0dcc77` | `https://gmailmcp.googleapis.com/mcp/v1`    |
+
+If the user adds or removes a connector via https://claude.ai/customize/connectors,
+update this table. If a YAML references a connector name not in this table,
+fail with a clear message linking the user to that URL.
+
+The `name` field passed to the API must match `[a-zA-Z0-9_-]+` (no dots, no
+spaces). The short names above already conform.
+
+## Workflow
+
+1. **Load tools.** RemoteTrigger is a deferred tool — call
+   `ToolSearch` with `select:RemoteTrigger` to load it.
+
+2. **Find the YAMLs.** Glob `projects/monolith/claude_routines/*.yaml`. If the
+   user supplied a routine name as an arg (e.g. `/update-claude-routines backlog-audit`),
+   filter to that one file. Otherwise reconcile all.
+
+3. **Read each YAML.** Parse it with the user's YAML library of choice (just
+   Read the file and parse in-context — no need for a script).
+
+4. **Validate.** Read `projects/monolith/claude_routines/schema.json` and
+   confirm each YAML conforms. On failure, print the JSON Schema error path
+   (e.g., `mcp_connectors[0]: must be a string`) and exit before any
+   RemoteTrigger calls.
+
+5. **Resolve names.** For each YAML:
+   - Replace `environment: <name>` with `environment_id: <env_id>` from the
+     table above. Fail with a clear message if the name is unknown.
+   - Replace each `mcp_connectors[i]` short name with the full
+     `{connector_uuid, name, url}` object from the table above. Fail with a
+     link to https://claude.ai/customize/connectors if any name is unknown.
+
+6. **Build the API body.** Each YAML maps to a `RemoteTrigger create`/`update`
+   body. Generate a fresh lowercase v4 UUID for `events[0].data.uuid`. The
+   prompt content goes in `events[0].data.message.content`.
+
+   The full body shape (matching the /schedule skill):
+
+   ```json
+   {
+     "name": "...",
+     "cron_expression": "..." OR "run_once_at": "...",
+     "enabled": true,
+     "job_config": {
+       "ccr": {
+         "environment_id": "...",
+         "session_context": {
+           "model": "...",
+           "sources": [{"git_repository": {"url": "..."}}],
+           "allowed_tools": []
+         },
+         "events": [{"data": {
+           "uuid": "<fresh v4>",
+           "session_id": "",
+           "type": "user",
+           "parent_tool_use_id": null,
+           "message": {"role": "user", "content": "<prompt>"}
+         }}]
+       }
+     },
+     "mcp_connections": [{"connector_uuid": "...", "name": "...", "url": "..."}]
+   }
+   ```
+
+7. **Reconcile.** For each YAML:
+   - Call `RemoteTrigger` action `list` to get all existing routines.
+   - Find the routine with matching `name`. If none, call `action: create`
+     with the body. If one exists, call `action: update` with `trigger_id`
+     set to the existing one's `id` and `body` containing only the changed
+     fields (partial update — pass the full body if computing the diff is
+     awkward, the API tolerates it).
+
+8. **Warn about orphans.** Any claude.ai routine whose name does NOT appear
+   in any YAML is an orphan. Print its name and ID, but DO NOT delete it —
+   claude.ai routines can only be removed via the web UI
+   (https://claude.ai/code/routines). Direct the user there if they want to
+   prune.
+
+9. **Print a summary.** Format like:
+
+   ```
+   Reconciliation summary:
+     Created:    1  (new-routine-name)
+     Updated:    1  (Backlog Audit (every 6h))
+     Unchanged:  0
+     Orphans:    0
+   ```
+
+   For created/updated routines, include the trigger ID and the claude.ai URL:
+   `https://claude.ai/code/routines/<trigger_id>`.
+
+## Errors and edge cases
+
+- **YAML schema failure** → print the JSON path of the bad field, exit before
+  any API calls. Idempotency: nothing partially-applied.
+- **Unknown `environment` name** → "Environment 'X' is not in the known list
+  ({Default, Unsafe}). Add it to this skill's resolution table if you've
+  registered a new environment in claude.ai."
+- **Unknown `mcp_connector` name** → "Connector 'X' is not connected on this
+  account. Connect it at https://claude.ai/customize/connectors and update
+  this skill's resolution table."
+- **`run_once_at` in the past** → "run_once_at is in the past
+  (<timestamp>). Update the YAML or remove the field."
+- **RemoteTrigger 4xx** → print the response body verbatim and exit. Common
+  causes: `name` collision (a routine with the same name was created
+  out-of-band), invalid cron, expired claude.ai session.
+- **API silently overrides `allowed_tools: []`** → expected behavior. Don't
+  treat the override in the response as drift; the textual constraints in
+  the routine's prompt are what actually limit tool use.
+
+## Notes
+
+- The reconciler is **always read-then-write**, never delete. Source-of-truth
+  drift (YAML removed from repo, routine still in claude.ai) surfaces as
+  orphans and requires manual cleanup.
+- Top-of-hour cron expressions get a few minutes of server-side jitter
+  (Anthropic's anti-thundering-herd). Don't treat this as drift.
+- Prefer pinned model snapshots (`claude-haiku-4-5-20251001`) over family
+  aliases (`claude-haiku-4-5`) for autonomous routines — the alias auto-tracks
+  the latest snapshot, which can change behavior under the user.

--- a/.claude/skills/update-claude-routines/SKILL.md
+++ b/.claude/skills/update-claude-routines/SKILL.md
@@ -79,29 +79,42 @@ spaces). The short names above already conform.
    `ToolSearch` with `select:RemoteTrigger` to load it.
 
 2. **Find the YAMLs.** Glob `projects/monolith/claude_routines/*.yaml`. If the
-   user supplied a routine name as an arg (e.g. `/update-claude-routines backlog-audit`),
-   filter to that one file. Otherwise reconcile all.
+   user supplied a routine slug as an arg (e.g.
+   `/update-claude-routines backlog-audit`), filter to that one file. If no
+   YAML matches the slug, print "No YAML in projects/monolith/claude_routines/
+   has slug '<arg>'. Available: <list of slugs>." and exit (no partial-apply).
+   Otherwise reconcile all.
 
-3. **Read each YAML.** Parse it with the user's YAML library of choice (just
-   Read the file and parse in-context — no need for a script).
+3. **Read each YAML.** Parse in-context — just Read the file and reason about
+   its structure; no Python or external script needed. Note that `prompt: |`
+   (YAML literal block) PRESERVES the trailing newline of the prompt content
+   and the API stores it verbatim — relevant if anyone ever adds a diff-based
+   equality check.
 
-4. **Validate.** Read `projects/monolith/claude_routines/schema.json` and
-   confirm each YAML conforms. On failure, print the JSON Schema error path
-   (e.g., `mcp_connectors[0]: must be a string`) and exit before any
-   RemoteTrigger calls.
+4. **Validate against schema.json.** Read
+   `projects/monolith/claude_routines/schema.json` and confirm each YAML
+   conforms. Validation is **by inspection** — there's no JSON Schema library
+   to invoke in-context; compare YAML fields against the schema's `required`,
+   `type`, `enum`, and `pattern` constraints and surface mismatches. On
+   failure, print the JSON path of the bad field and exit BEFORE any
+   RemoteTrigger calls. Idempotency: nothing partially applied.
 
-5. **Resolve names.** For each YAML:
-   - Replace `environment: <name>` with `environment_id: <env_id>` from the
+5. **Resolve names → IDs.** For each YAML:
+   - Replace `environment: <name>` with `environment_id: <env_id>` using the
      table above. Fail with a clear message if the name is unknown.
    - Replace each `mcp_connectors[i]` short name with the full
-     `{connector_uuid, name, url}` object from the table above. Fail with a
+     `{connector_uuid, name, url}` object using the table above. Fail with a
      link to https://claude.ai/customize/connectors if any name is unknown.
 
-6. **Build the API body.** Each YAML maps to a `RemoteTrigger create`/`update`
-   body. Generate a fresh lowercase v4 UUID for `events[0].data.uuid`. The
-   prompt content goes in `events[0].data.message.content`.
+6. **Build the API body.** Generate a fresh lowercase v4 UUID for
+   `events[0].data.uuid` — yes, even on UPDATE. The API replaces the prior
+   UUID without observable churn (verified empirically); preserving the
+   existing UUID via `RemoteTrigger get` is optional and not load-bearing.
+   The prompt content from the YAML goes in `events[0].data.message.content`
+   verbatim.
 
-   The full body shape (matching the /schedule skill):
+   Always send the **full body** — never a partial update. See step 7c on the
+   always-update rule.
 
    ```json
    {
@@ -129,21 +142,55 @@ spaces). The short names above already conform.
    }
    ```
 
-7. **Reconcile.** For each YAML:
-   - Call `RemoteTrigger` action `list` to get all existing routines.
-   - Find the routine with matching `name`. If none, call `action: create`
-     with the body. If one exists, call `action: update` with `trigger_id`
-     set to the existing one's `id` and `body` containing only the changed
-     fields (partial update — pass the full body if computing the diff is
-     awkward, the API tolerates it).
+   The `allowed_tools: []` in the body is silently replaced by the API with
+   a 17-item preset list at write time (see Notes); send `[]` anyway — don't
+   try to pre-populate.
 
-8. **Warn about orphans.** Any claude.ai routine whose name does NOT appear
-   in any YAML is an orphan. Print its name and ID, but DO NOT delete it —
-   claude.ai routines can only be removed via the web UI
+7. **Reconcile.** For each YAML:
+
+   a. **Get the current state.** Call `RemoteTrigger` action `list`. The
+   response shape is `{data: [<trigger>...], has_more: bool}`. If
+   `has_more` is true the response is paginated; the API does not yet
+   expose a documented cursor, so treat any `has_more: true` as a
+   "should-not-happen" error — print loudly and stop without mutating.
+   (A user with >~50 routines is the only realistic trigger; revisit
+   when it actually happens.)
+
+   b. **Match by name.** Each item in `data` is a bare trigger object — NOT
+   wrapped in `{trigger: ...}`. That wrapper appears only on `get`,
+   `create`, and `update` responses. The YAML's `name` field is compared
+   verbatim against each `data[i].name` — exact string match, spaces and
+   parentheses preserved, no case folding, no slugification.
+
+   c. **Decide create vs update — and always update on match.** If no
+   trigger matches: call `action: create` with the full body from step
+   6 (no `trigger_id`). If a trigger matches: call `action: update` with
+   `trigger_id` set to that trigger's `id`, passing the full body.
+
+   **Do not compute a diff to skip the update.** Diffing is brittle for
+   at least four reasons:
+   - the API overrides `allowed_tools` (your `[]` becomes a 17-item list),
+   - the server jitters `next_run_at` and `updated_at`,
+   - YAML `prompt: |` keeps a trailing newline that the API stores verbatim,
+   - `creator.display_name` and `permitted_tools` are returned but are
+     not sendable fields.
+
+   Always update when name matches. The API is idempotent for repeated
+   full-body writes with the same content. Cost: one API call per
+   routine per run.
+
+   d. **Read the response.** Both `create` and `update` wrap the result as
+   `{trigger: {<full trigger object>}}`. Pull `trigger.id` for
+   reporting; pull `trigger.next_run_at` to confirm the schedule was
+   accepted.
+
+8. **Warn about orphans.** Any trigger in `list.data` whose `name` does
+   NOT appear in any YAML is an orphan. Print its name and ID, but DO NOT
+   delete it — claude.ai routines can only be removed via the web UI
    (https://claude.ai/code/routines). Direct the user there if they want to
    prune.
 
-9. **Print a summary.** Format like:
+9. **Print a summary — always, even on zero-change runs.** Format:
 
    ```
    Reconciliation summary:
@@ -153,27 +200,36 @@ spaces). The short names above already conform.
      Orphans:    0
    ```
 
-   For created/updated routines, include the trigger ID and the claude.ai URL:
-   `https://claude.ai/code/routines/<trigger_id>`.
+   For created/updated routines include the trigger ID and the claude.ai
+   URL: `https://claude.ai/code/routines/<trigger_id>`. With the
+   always-update rule from step 7c, `Unchanged` will usually be 0 — that's
+   expected, not a bug. The column exists for a future diff-based skip.
 
 ## Errors and edge cases
 
-- **YAML schema failure** → print the JSON path of the bad field, exit before
-  any API calls. Idempotency: nothing partially-applied.
-- **Unknown `environment` name** → "Environment 'X' is not in the known list
-  ({Default, Unsafe}). Add it to this skill's resolution table if you've
-  registered a new environment in claude.ai."
-- **Unknown `mcp_connector` name** → "Connector 'X' is not connected on this
-  account. Connect it at https://claude.ai/customize/connectors and update
-  this skill's resolution table."
+- **YAML schema failure** → print the JSON path of the bad field, exit
+  before any API calls. Idempotency: nothing partially applied.
+- **Unknown `environment` name** → "Environment 'X' is not in the known
+  list ({Default, Unsafe}). Add it to this skill's resolution table if you
+  have registered a new environment in claude.ai."
+- **Unknown `mcp_connector` name** → "Connector 'X' is not connected on
+  this account. Connect it at https://claude.ai/customize/connectors and
+  update this skill's resolution table."
 - **`run_once_at` in the past** → "run_once_at is in the past
   (<timestamp>). Update the YAML or remove the field."
-- **RemoteTrigger 4xx** → print the response body verbatim and exit. Common
-  causes: `name` collision (a routine with the same name was created
-  out-of-band), invalid cron, expired claude.ai session.
-- **API silently overrides `allowed_tools: []`** → expected behavior. Don't
-  treat the override in the response as drift; the textual constraints in
-  the routine's prompt are what actually limit tool use.
+- **RemoteTrigger 4xx** → print the response body verbatim and exit.
+  Common causes: invalid cron, expired claude.ai session, malformed `name`
+  on `mcp_connections` (must match `[A-Za-z0-9_-]+`; no dots or spaces).
+- **`list` returns `has_more: true`** → pagination is not yet supported in
+  this skill. Print a warning ("paginated routine list not supported;
+  reconcile may be incomplete") and stop without mutating.
+- **API silently replaces `allowed_tools: []`** → expected; do not treat
+  the override in the response as drift. The textual constraints in the
+  prompt are what actually limit tool use.
+- **`permitted_tools: []` on `mcp_connections` in responses** → not a
+  sendable field. Omit on send; the API will populate the field with `[]`
+  unprompted.
+- **Slug arg doesn't match any YAML** → see step 2's exit behavior.
 
 ## Notes
 
@@ -185,3 +241,23 @@ spaces). The short names above already conform.
 - Prefer pinned model snapshots (`claude-haiku-4-5-20251001`) over family
   aliases (`claude-haiku-4-5`) for autonomous routines — the alias auto-tracks
   the latest snapshot, which can change behavior under the user.
+- **`allowed_tools` override (verified)** — when you send `"allowed_tools": []`
+  the API stores this exact list on the routine:
+  ```
+  preset:default, Task, Bash, Glob, Grep, Read, Edit, MultiEdit, Write,
+  NotebookEdit, WebFetch, TodoWrite, WebSearch, BashOutput, KillBash,
+  Skill, Tmux, Monitor, SendUserFile, REPL
+  ```
+  That is the actual tool surface the routine has at runtime. If you need a
+  narrower surface, enforce it via the prompt — there's no server-side way.
+- **Response envelope asymmetry** — `list` returns trigger objects bare
+  inside `data: [...]`; `get`, `create`, and `update` wrap their single
+  trigger as `{trigger: {...}}`. Don't mix the two when post-processing.
+- **`creator.display_name`** appears on `get`/`create`/`update` responses
+  but is omitted from `list` items. Cosmetic only; don't depend on it for
+  matching.
+- **Routines that have already fired** carry `last_fired_at` plus an
+  advanced `next_run_at`. This is _runtime state_, not drift from the YAML.
+- The `data[i]` items on a `list` response include the full `job_config`
+  and `mcp_connections` — there is no follow-up `get` needed for matching
+  or to read fields. Save the API call.

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.76.2
+version: 0.77.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/claude_routines/README.md
+++ b/projects/monolith/claude_routines/README.md
@@ -1,0 +1,55 @@
+# Claude.ai Routines (source of truth)
+
+Version-controlled definitions of the user's claude.ai scheduled-agent
+**routines** (a.k.a. Claude Code Routines / remote triggers). Each
+`*.yaml` file in this directory is one routine. claude.ai is the _runtime_
+state; this directory is the _intent_ state. Drift is reconciled by running
+the `/update-claude-routines` skill.
+
+## Files
+
+| Path                    | Purpose                                                                                  |
+| ----------------------- | ---------------------------------------------------------------------------------------- |
+| `schema.json`           | JSON Schema for routine YAMLs. IDEs (e.g. VSCode + YAML extension) can validate on save. |
+| `<slug>.yaml`           | One routine per file. The `name` field is the lookup key when reconciling.               |
+| `README.md` (this file) | Pointer to the schema + skill.                                                           |
+
+The reconciliation logic lives in the
+[`update-claude-routines` skill](../../../.claude/skills/update-claude-routines/SKILL.md) —
+it explains the schema, the name → ID resolution rules for `environment` and
+`mcp_connectors`, the workflow, and the error modes.
+
+## Adding a routine
+
+1. Copy an existing YAML (e.g. `backlog-audit.yaml`) and edit `name`, `schedule`,
+   `prompt`, and any other relevant fields.
+2. Validate against `schema.json` — your IDE will do this automatically if the
+   first line of the YAML is the `yaml-language-server` schema directive shown
+   in the existing files.
+3. PR + merge.
+4. In a Claude Code session, run `/update-claude-routines` (or
+   `/update-claude-routines <slug>` to reconcile just that one). The skill
+   creates or updates the claude.ai routine to match.
+
+## Editing a routine
+
+Same as adding — change the YAML, PR, merge, run `/update-claude-routines`.
+The skill matches existing claude.ai routines by `name`, so renaming a routine
+in YAML _creates a new one in claude.ai_; the old one becomes an orphan that
+must be deleted manually via https://claude.ai/code/routines.
+
+## Removing a routine
+
+Delete the YAML, PR, merge. The skill will report the corresponding claude.ai
+routine as an orphan but **will not delete it** — deletion is only possible via
+the web UI at https://claude.ai/code/routines. This is intentional: routines
+carry execution history (`last_run_at`, `ended_reason`) that a silent delete
+would lose.
+
+## No UUIDs in this directory
+
+By design — UUIDs (env_ids, connector UUIDs) are account-specific runtime
+identifiers, not configuration. Routine YAMLs reference `environment` and
+`mcp_connectors` by short name; the skill resolves to IDs at sync time using
+the current tables in its SKILL.md. If the user adds a new environment or
+connects a new connector, update the skill's resolution tables in the same PR.

--- a/projects/monolith/claude_routines/backlog-audit.yaml
+++ b/projects/monolith/claude_routines/backlog-audit.yaml
@@ -1,0 +1,34 @@
+# yaml-language-server: $schema=./schema.json
+name: Backlog Audit (every 6h)
+schedule:
+  cron: "0 */6 * * *"
+enabled: true
+model: claude-haiku-4-5-20251001
+environment: Default
+sources:
+  - https://github.com/jomcgi/homelab
+allowed_tools: []
+mcp_connectors:
+  - homelab
+prompt: |
+  Read-only homelab backlog audit. Post a Discord alert if work is due.
+  Never execute, claim, complete, or investigate jobs.
+
+  1. Call `mcp__homelab__monolith-monolith-agent-list-routine-jobs`
+     with `{"due_only": true}`.
+
+  2. If `jobs` is empty: exit silently. Do nothing else.
+
+  3. If `jobs` is non-empty, call `mcp__homelab__monolith-monolith-agent-notify`
+     once with:
+       - message: markdown list of each job's name, routine_kind, and how
+         overdue it is (current time minus next_run_at, e.g. "2h 14m overdue").
+         Cap at 10 entries; if there are more, append a "+N more" line.
+       - level: "warn" if any job is >6h overdue, else "info"
+     Then exit.
+
+  Constraints:
+    - Do not call claim-routine-job, complete-routine-job, or any mutating tool.
+    - Do not investigate, fix, or execute any job.
+    - Do not call local tools (Bash, Read, etc.) — pure MCP only.
+    - If the first MCP call fails, exit without retry.

--- a/projects/monolith/claude_routines/schema.json
+++ b/projects/monolith/claude_routines/schema.json
@@ -1,0 +1,89 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/jomcgi/homelab/projects/monolith/claude_routines/schema.json",
+  "title": "Claude.ai routine definition",
+  "description": "Declarative spec for one scheduled claude.ai remote agent (routine). Resolution of `environment` and `mcp_connectors` names to claude.ai IDs happens at sync time via the /update-claude-routines skill — UUIDs and URLs do not appear in this file.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["name", "schedule", "model", "environment", "prompt"],
+  "properties": {
+    "name": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Human-readable routine name. Used as the lookup key when reconciling — must be unique across the user's claude.ai routines."
+    },
+    "schedule": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Exactly one of `cron` (recurring) or `run_once_at` (one-shot).",
+      "oneOf": [
+        {
+          "required": ["cron"],
+          "properties": {
+            "cron": {
+              "type": "string",
+              "description": "5-field cron expression in UTC. Minimum interval is 1 hour; sub-hourly expressions are rejected by the API.",
+              "pattern": "^[0-9*/,-]+( +[0-9*/,-]+){4}$"
+            }
+          }
+        },
+        {
+          "required": ["run_once_at"],
+          "properties": {
+            "run_once_at": {
+              "type": "string",
+              "format": "date-time",
+              "description": "RFC3339 UTC timestamp. Must be in the future at sync time; past timestamps are rejected by the API."
+            }
+          }
+        }
+      ]
+    },
+    "enabled": {
+      "type": "boolean",
+      "default": true,
+      "description": "Whether the routine fires on schedule. Default true."
+    },
+    "model": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Claude model ID. Prefer pinned snapshots (e.g. claude-haiku-4-5-20251001) for autonomous routines so behavior doesn't shift under you. Family aliases (e.g. claude-haiku-4-5) auto-track the latest snapshot."
+    },
+    "environment": {
+      "type": "string",
+      "enum": ["Default", "Unsafe"],
+      "description": "Claude.ai environment NAME. Resolved to env_id at sync time. Pattern-rejection of UUID-shaped values via enum.",
+      "not": {
+        "pattern": "^env_[A-Za-z0-9]+$"
+      }
+    },
+    "sources": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "format": "uri",
+        "pattern": "^https://"
+      },
+      "description": "Git repositories cloned into the routine's workspace. Optional."
+    },
+    "allowed_tools": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Local-tool allowlist. NOTE: the claude.ai API silently overrides an empty list with preset:default, so this field is not actually restrictive. Rely on prompt-level constraints if you need a narrow tool surface."
+    },
+    "mcp_connectors": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "pattern": "^[A-Za-z0-9_-]+$",
+        "description": "Short connector name from the user's claude.ai account. Must match [A-Za-z0-9_-]+ (the same constraint the API places on mcp_connections.name). Resolved to {connector_uuid, name, url} at sync time."
+      },
+      "description": "MCP connectors to attach to the routine, referenced by short name. Resolution table lives in the /update-claude-routines skill."
+    },
+    "prompt": {
+      "type": "string",
+      "minLength": 1,
+      "description": "The user-message content the routine fires with. Self-contained — the agent starts with zero context from prior sessions."
+    }
+  }
+}

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.76.2
+      targetRevision: 0.77.0
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
## Summary

Introduce `projects/monolith/claude_routines/` as the **source of truth** for the user's claude.ai scheduled-agent routines, paired with a new `.claude/skills/update-claude-routines` skill that handles reconciliation.

- **Each routine is one YAML file** under `projects/monolith/claude_routines/`. Schema: `schema.json` (IDE-validated via `yaml-language-server` directive).
- **No UUIDs in the repo.** Routines reference `environment` and `mcp_connectors` by short *name*; the skill resolves names → IDs at sync time using tables in its `SKILL.md`. Same pattern as K8s manifests referencing Services by name, not UID.
- **The skill is the bridge.** `/update-claude-routines` (with optional routine-name arg) reads YAMLs, validates against the schema, resolves names, lists existing claude.ai routines, and calls `RemoteTrigger` to create or update. Always read-then-write, never deletes; orphans (claude.ai routines without a corresponding YAML) are warned about but require manual cleanup via the claude.ai UI.

## Architectural shape

| Concern | Where it lives |
|---|---|
| Routine intent (cron, prompt, model, etc.) | `projects/monolith/claude_routines/*.yaml` |
| Schema | `projects/monolith/claude_routines/schema.json` |
| Reconciliation logic + name → ID resolution tables | `.claude/skills/update-claude-routines/SKILL.md` |
| Runtime state (last_run_at, next_run_at, ended_reason) | claude.ai API (not in repo) |

This separates *intent* (in git, reviewable) from *state* (in claude.ai, ephemeral) — mirroring the same pattern used by `claude_agent.routine_jobs` vs. `scheduler.scheduled_jobs` in the monolith.

## First routine

`backlog-audit.yaml` is the source-controlled twin of the live `Backlog Audit (every 6h)` routine (`trig_01NRshGL2j1m9nBaDFGeDJRs`), with one substantive change: the prompt now uses full `mcp__homelab__*` tool prefixes instead of bare suffixes. The first execution this morning showed the agent had to spend tokens discovering the prefix; pinning it in the prompt saves that on every future fire.

## Test plan

- [ ] Merge this PR.
- [ ] In a Claude Code session in this repo, run `/update-claude-routines`.
- [ ] Confirm the skill auto-loads correctly (description matching).
- [ ] Confirm it lists the existing routine, computes a diff (prompt change), and updates rather than creating a duplicate.
- [ ] Watch the next 11pm Vancouver / 06:00 UTC fire to confirm cleaner execution.
- [ ] After confirming the loop works, look for anything the skill missed and refine SKILL.md in a follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)