### PR TITLE
chore(monolith): also exclude test_*.py from source globs

### DIFF
--- a/bazel/semgrep/rules/bazel/py-glob-missing-tests-exclude.build
+++ b/bazel/semgrep/rules/bazel/py-glob-missing-tests-exclude.build
@@ -37,7 +37,10 @@ py_venv_binary(
     main = "main.py",
     srcs = glob(
         ["**/*.py"],
-        exclude = ["*/tests/**", "*_test.py"],
+        # Exclude both pytest naming conventions:
+        # - *_test.py (sibling-of-source convention)
+        # - test_*.py (pytest default convention)
+        exclude = ["*/tests/**", "**/*_test.py", "**/test_*.py"],
     ),
 )
 

--- a/bazel/semgrep/rules/bazel/py-glob-missing-tests-exclude.yaml
+++ b/bazel/semgrep/rules/bazel/py-glob-missing-tests-exclude.yaml
@@ -4,10 +4,14 @@ rules:
     severity: WARNING
     message: >-
       py_library or py_venv_binary uses glob(["**/*.py"]) without excluding
-      test directories. Add exclude=["*/tests/**"] to prevent conftest.py and
-      fixture files from being bundled into the production library target.
-      This was the root cause in commit 61fcaa4 where domain tests/conftest.py
-      files were inadvertently included in monolith_backend.
+      test directories. Add exclude=["*/tests/**", "**/*_test.py",
+      "**/test_*.py"] to keep conftest.py, fixtures, and test files out of
+      the production library target. Both pytest naming conventions
+      (sibling-style *_test.py AND default test_*.py) must be excluded --
+      missing the latter caused a 217-target test cascade on PR #2349 when
+      one broken assertion in a test_*.py file auto-collected into every
+      downstream test target's runfiles. Root cause for tests/conftest.py
+      bundling: commit 61fcaa4.
     metadata:
       category: correctness
     paths:

--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -41,7 +41,12 @@ py_venv_binary(
             "shared/**/*.py",
         ],
         exclude = [
+            # pytest discovers both *_test.py (sibling convention) and
+            # test_*.py (its default). Exclude both so that any test
+            # file in these source trees stays out of the production
+            # binary AND out of downstream test targets' runfiles.
             "**/*_test.py",
+            "**/test_*.py",
             "*/tests/**/*.py",
             "shared/testing/**/*.py",
         ],
@@ -89,7 +94,13 @@ py_library(
             "shared/**/*.py",
         ],
         exclude = [
+            # pytest discovers both *_test.py (sibling convention) and
+            # test_*.py (its default). Exclude both so a broken test in
+            # one knowledge/*.py file does not cascade across every
+            # downstream test target that depends on this library
+            # (per the 217-target cascade on PR #2349).
             "**/*_test.py",
+            "**/test_*.py",
             "*/tests/**/*.py",
             "shared/testing/**/*.py",
         ],

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.79.2
+version: 0.79.3
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.79.2
+      targetRevision: 0.79.3
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
## Summary

The existing exclude in monolith's `py_venv_binary(main)` and `py_library(monolith_backend)` caught `*_test.py` (the sibling-of-source naming this repo uses), but not `test_*.py` (pytest's default naming).

PR #2349 hit a 217-target test cascade because one broken test file named `test_models_verification.py` slipped through the glob, got pulled into `:monolith_backend`'s runfiles, and was auto-collected by pytest inside every downstream test target that depends on the backend. One broken assertion → ~110 test targets reporting failure.

This PR adds `**/test_*.py` to both exclude lists with an inline comment naming both conventions, and updates the `py-glob-missing-tests-exclude` semgrep rule message + fixture to recommend both patterns so future BUILD authors get the full guidance from the lint.

## Test plan

- [ ] CI green
- [ ] No production code path that legitimately needs a `test_*.py` file (search confirms none exist)
- [ ] Future PRs that add a `test_*.py` file in `knowledge/`, `chat/`, etc. don't trigger cross-target test cascades

🤖 Generated with [Claude Code](https://claude.com/claude-code)