### PR TITLE
feat(monolith-frontend): brutalist review page + dedup races

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.80.0
+version: 0.81.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.80.0
+      targetRevision: 0.81.0
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/lib/global.css
+++ b/projects/monolith/frontend/src/lib/global.css
@@ -1,3 +1,14 @@
+/* ── Shared design tokens (canonical source) ──────────────────────
+ * @import MUST be at the very top of the file. The CSS spec requires
+ * @import rules before any other rules; PostCSS / vite silently strip
+ * @import statements that come after other declarations, which causes
+ * the shared tokens (--yellow, --border-heavy, --coral, --cream,
+ * --font-mono, etc.) to never load. That manifests as headings using
+ * the browser's serif fallback (because font-family: var(--font-mono)
+ * resolves to nothing) and brutalist borders/badges going invisible.
+ */
+@import "../../../../websites/shared/tokens.css";
+
 /* ── Reset ──────────────────────────────────── */
 *,
 *::before,
@@ -27,9 +38,6 @@ a {
   color: inherit;
   text-decoration: none;
 }
-
-/* ── Shared design tokens (canonical source) ── */
-@import "../../../../websites/shared/tokens.css";
 
 /* ── Private-only intermediate aliases ──────── */
 /*

--- a/projects/monolith/frontend/src/lib/private/components/ModeToggle.svelte
+++ b/projects/monolith/frontend/src/lib/private/components/ModeToggle.svelte
@@ -24,17 +24,18 @@
 </div>
 
 <style>
-  /* Brutalist tablist: explicit mono + hover/active underline that
-     mirrors Nav.svelte's coral underline pattern, so this toggle reads
-     as a sibling of the site nav rather than a custom widget. */
+  /* Brutalist tablist: chunky stamp blocks instead of subtle underlines.
+     Active = filled cream block with 2px border and offset shadow (looks
+     like a sticker). Hover = inactive button gets an outline preview of
+     the same frame so the click target advertises itself. */
 
   .toggle {
     display: inline-flex;
-    gap: 0.25rem;
+    gap: 0.6rem;
+    align-items: center;
   }
 
   .toggle button {
-    position: relative;
     font-family: var(--font-mono);
     font-size: 0.8rem;
     font-weight: 700;
@@ -42,34 +43,29 @@
     letter-spacing: 0.14em;
     color: var(--fg-tertiary);
     background: transparent;
-    border: none;
-    padding: 0.5rem 0.75rem;
+    border: 2px solid transparent;
+    padding: 0.4rem 0.65rem;
     cursor: pointer;
+    transform: translate(0, 0);
+    transition:
+      transform 0.08s ease,
+      box-shadow 0.08s ease,
+      background 0.08s ease,
+      color 0.08s ease,
+      border-color 0.08s ease;
   }
 
-  .toggle button::after {
-    content: "";
-    position: absolute;
-    left: 0.75rem;
-    right: 0.75rem;
-    bottom: 0.2rem;
-    height: 2px;
-    background: var(--coral);
-    transform: scaleX(0);
-    transition: transform 160ms ease;
-  }
-
-  .toggle button:hover::after {
-    transform: scaleX(1);
+  .toggle button:hover:not(.active) {
+    color: var(--fg);
+    border-color: var(--fg);
+    transform: translate(-2px, -2px);
+    box-shadow: 4px 4px 0 0 var(--fg);
   }
 
   .toggle button.active {
     color: var(--fg);
-  }
-
-  .toggle button.active::after {
-    background: var(--fg);
-    transform: scaleX(1);
+    background: var(--cream);
+    border-color: var(--fg);
   }
 
   .toggle button:focus-visible {

--- a/projects/monolith/frontend/src/lib/private/components/ReviewCard.svelte
+++ b/projects/monolith/frontend/src/lib/private/components/ReviewCard.svelte
@@ -149,20 +149,21 @@
 
   <div class="actions">
     {#if mode === "pending"}
-      <button class="action" onclick={() => onDecide("yes")}>
+      <button class="action action--keep" onclick={() => onDecide("yes")}>
         {tab === "gaps" ? "Keep (y)" : "Public (y)"}
       </button>
-      <button class="action" onclick={() => onDecide("no")}>
+      <button class="action action--reject" onclick={() => onDecide("no")}>
         {tab === "gaps" ? "Reject (n)" : "Private (n)"}
       </button>
     {:else}
-      <button class="action" onclick={() => onDecide("yes")}>Agree (y)</button>
+      <button class="action action--agree" onclick={() => onDecide("yes")}
+        >Agree (y)</button
+      >
       <button class="action" onclick={() => onDecide("no")}>Flip (n)</button>
       <button class="action" onclick={() => onDecide("skip")}>Skip (s)</button>
-      <button
-        class="action action--danger"
-        onclick={() => onDecide("delete")}
-      >Delete (d)</button>
+      <button class="action action--danger" onclick={() => onDecide("delete")}
+        >Delete (d)</button
+      >
     {/if}
   </div>
 </article>
@@ -178,12 +179,17 @@
   .card {
     border: var(--border-heavy);
     background: var(--bg);
-    padding: 1.5rem 1.75rem;
+    padding: 1.25rem 1.5rem;
     font-family: var(--font-mono);
     color: var(--fg);
     display: flex;
     flex-direction: column;
-    gap: 1.25rem;
+    gap: 1rem;
+    /* Single-screen layout: fill the parent's remaining height so the
+       review surface fits in one viewport. Body subpanels scroll
+       internally; actions stay pinned at the bottom. */
+    flex: 1 1 auto;
+    min-height: 0;
   }
 
   /* ── Header strip ─────────────────────────────────────────────── */
@@ -195,6 +201,7 @@
     gap: 1rem;
     padding-bottom: 1rem;
     border-bottom: var(--border-heavy);
+    flex-shrink: 0;
   }
 
   .card-tab {
@@ -210,8 +217,12 @@
     white-space: nowrap;
   }
 
+  /* Aligns with the knowledge graph cluster palette:
+       --cluster-gap   = coral
+       --cluster-paper = green (used for notes here)
+     so a gap card visually rhymes with a gap node in the graph. */
   .card-tab--gap {
-    background: var(--yellow);
+    background: var(--coral);
   }
 
   .card-tab--note {
@@ -322,13 +333,24 @@
 
   /* ── Body subpanel (snippet / stub / answer) ──────────────────── */
 
+  /* The LAST card-body (which is always the big one -- snippet or stub)
+     flex-grows so the card fills available vertical space. Earlier
+     bodies (a captured answer above the stub for gaps) stay
+     natural-sized and DO NOT shrink -- otherwise their inner <pre>
+     overflows the box and visually bleeds into the next subpanel. */
   .card-body {
     display: flex;
     flex-direction: column;
-    gap: 0.6rem;
+    gap: 0.5rem;
     border: var(--border-heavy);
     background: var(--bg);
-    padding: 1rem 1.25rem;
+    padding: 0.85rem 1rem;
+    flex-shrink: 0;
+  }
+
+  .card-body:last-of-type {
+    flex: 1 1 auto;
+    min-height: 0;
   }
 
   .body-label {
@@ -338,11 +360,16 @@
     text-transform: uppercase;
     letter-spacing: 0.14em;
     color: var(--fg);
+    background: var(--cream);
+    padding: 0.25rem 0.55rem;
+    border: 2px solid var(--fg);
+    align-self: flex-start;
   }
 
   .body-scroll {
     position: relative;
-    max-height: 28rem;
+    flex: 1 1 auto;
+    min-height: 0;
     overflow: auto;
     scrollbar-width: thin;
     scrollbar-color: var(--fg) transparent;
@@ -371,9 +398,9 @@
   .actions {
     display: flex;
     gap: 0.75rem;
-    margin-top: 0.5rem;
     justify-content: flex-end;
     flex-wrap: wrap;
+    flex-shrink: 0;
   }
 
   .action {
@@ -387,14 +414,22 @@
     border: 2px solid var(--fg);
     padding: 0.55rem 1rem;
     cursor: pointer;
+    /* Flat-by-default, pop-on-hover: button lifts up-left and casts a
+       hard offset shadow; on active it lands flat again. */
+    transform: translate(0, 0);
     transition:
-      background 0.1s ease,
-      color 0.1s ease;
+      transform 0.08s ease,
+      box-shadow 0.08s ease;
   }
 
   .action:hover {
-    background: var(--fg);
-    color: var(--bg);
+    transform: translate(-2px, -2px);
+    box-shadow: 4px 4px 0 0 var(--fg);
+  }
+
+  .action:active {
+    transform: translate(0, 0);
+    box-shadow: 0 0 0 0 var(--fg);
   }
 
   .action:focus-visible {
@@ -402,12 +437,20 @@
     outline-offset: 2px;
   }
 
-  .action--danger {
+  /* Variant fills -- semantically coloured per cluster palette. */
+  .action--keep {
+    background: var(--yellow);
+  }
+
+  .action--reject {
     background: var(--coral);
   }
 
-  .action--danger:hover {
-    background: var(--fg);
-    color: var(--coral);
+  .action--agree {
+    background: var(--green);
+  }
+
+  .action--danger {
+    background: var(--coral);
   }
 </style>

--- a/projects/monolith/frontend/src/routes/private/review/+page.server.js
+++ b/projects/monolith/frontend/src/routes/private/review/+page.server.js
@@ -49,6 +49,23 @@ function isAllowedPath(path) {
   return typeof path === "string" && path.startsWith("/api/knowledge/");
 }
 
+// FastAPI errors come back as {"detail": "<message>"} JSON. Pull the
+// human string out so the client error banner shows
+//   "cannot verify note_id='patricia-selinger': visibility is unset"
+// instead of the raw JSON envelope. Falls back to the raw text on any
+// parse failure so we never lose information.
+async function readError(res) {
+  const text = await res.text();
+  try {
+    const body = JSON.parse(text);
+    if (body && typeof body.detail === "string") return body.detail;
+    if (body && typeof body.error === "string") return body.error;
+  } catch {
+    /* not JSON -- fall through */
+  }
+  return text;
+}
+
 export const actions = {
   // decide: POST to the monolith with no body — used for every endpoint
   // except notes' set-visibility (which needs a JSON body).
@@ -65,7 +82,7 @@ export const actions = {
     if (!res.ok) {
       // Surface the upstream status verbatim so the client can branch on
       // 404 (item was soft-deleted in another tab) without parsing text.
-      return fail(res.status, { error: await res.text() });
+      return fail(res.status, { error: await readError(res) });
     }
     return { ok: true };
   },
@@ -88,7 +105,7 @@ export const actions = {
       signal: AbortSignal.timeout(10_000),
     });
     if (!res.ok) {
-      return fail(res.status, { error: await res.text() });
+      return fail(res.status, { error: await readError(res) });
     }
     return { ok: true };
   },
@@ -108,7 +125,7 @@ export const actions = {
       signal: AbortSignal.timeout(10_000),
     });
     if (!res.ok) {
-      return fail(res.status, { error: await res.text() });
+      return fail(res.status, { error: await readError(res) });
     }
     return { ok: true };
   },
@@ -128,7 +145,7 @@ export const actions = {
       signal: AbortSignal.timeout(10_000),
     });
     if (!res.ok) {
-      return fail(res.status, { error: await res.text() });
+      return fail(res.status, { error: await readError(res) });
     }
     return { ok: true };
   },

--- a/projects/monolith/frontend/src/routes/private/review/+page.svelte
+++ b/projects/monolith/frontend/src/routes/private/review/+page.svelte
@@ -8,9 +8,18 @@
 
   let { data } = $props();
 
-  // Card index within the current queue. Reset on tab/mode change or refetch.
+  // Cursor for j/k navigation + skip. y/n/delete do NOT touch this --
+  // they add the item's id to `processedIds` so the visible list
+  // shrinks and the next item slides into place automatically.
   let index = $state(0);
   let pendingError = $state(null);
+
+  // Items the user has acted on (y/n/delete) in this session. We filter
+  // these out of data.items so a slow backend round-trip can't make a
+  // verified item reappear after invalidateAll(). When tab/mode changes
+  // or invalidateAll completes, this set is reconciled against the new
+  // data.items so stale ids drop out.
+  let processedIds = $state(new Set());
 
   // Active undo toast — null when no recent deletion. Shape:
   //   { tab, id, label, key } where key is a monotonic counter so the
@@ -19,33 +28,44 @@
   let tombstone = $state(null);
   let toastCounter = 0;
 
-  let current = $derived(data.items[index]);
+  // Items the user has NOT yet acted on. The user sees this filtered
+  // list; index points into it. When y/n/delete fires, the acted item
+  // moves to processedIds, this list shrinks by 1, and current
+  // advances automatically without an explicit index++.
+  let visibleItems = $derived(
+    data.items.filter((it) => !processedIds.has(String(it.id))),
+  );
+  let current = $derived(visibleItems[index]);
 
-  // If the queue shrinks (e.g. after invalidateAll refetch with fewer items),
-  // clamp the index so `current` doesn't go undefined while items remain.
+  // Keep index in range when the visible list shrinks (action removes
+  // an item, invalidate returns fewer items, etc.).
   $effect(() => {
-    if (data.items.length === 0) {
+    if (visibleItems.length === 0) {
       if (index !== 0) index = 0;
       return;
     }
-    if (index > data.items.length - 1) {
-      index = 0;
+    if (index > visibleItems.length - 1) {
+      index = Math.max(0, visibleItems.length - 1);
     }
   });
+
+  function resetSession() {
+    index = 0;
+    pendingError = null;
+    processedIds = new Set();
+  }
 
   function setTab(t) {
     const url = new URL($page.url);
     url.searchParams.set("tab", t);
-    index = 0;
-    pendingError = null;
+    resetSession();
     goto(url, { replaceState: true, invalidateAll: true });
   }
 
   function setMode(m) {
     const url = new URL($page.url);
     url.searchParams.set("mode", m);
-    index = 0;
-    pendingError = null;
+    resetSession();
     goto(url, { replaceState: true, invalidateAll: true });
   }
 
@@ -103,12 +123,29 @@
     return `Deleted ${noun} "${trimmed}"`;
   }
 
+  // j/k preview navigation -- doesn't process anything. Bounded by
+  // visibleItems length so we never land on an undefined card.
   function advance() {
-    if (index < data.items.length - 1) index++;
+    if (index < visibleItems.length - 1) index++;
   }
 
   function back() {
     if (index > 0) index--;
+  }
+
+  // Add an item id to processedIds (= "this is no longer visible to me
+  // in this session"). Returns a rollback closure that removes it again
+  // on failure.
+  function markProcessed(id) {
+    const key = String(id);
+    const next = new Set(processedIds);
+    next.add(key);
+    processedIds = next;
+    return () => {
+      const rollback = new Set(processedIds);
+      rollback.delete(key);
+      processedIds = rollback;
+    };
   }
 
   // Apart from `delete`, every action POSTs to a /verify, /reject,
@@ -133,15 +170,17 @@
       return;
     }
 
-    const { path, body } = endpointFor(data.tab, data.mode, action, current);
+    const target = current;
+    const { path, body } = endpointFor(data.tab, data.mode, action, target);
 
     // Any further decision clears the previous undo toast — the user has
     // moved on, and stale tombstones are confusing.
     tombstone = null;
 
-    // Optimistic UI: advance immediately, roll back on failure.
-    const prevIndex = index;
-    advance();
+    // Optimistic: hide the item from the visible queue immediately.
+    // Next item slides into `current` via the derived store. Rollback
+    // restores the item if the backend rejects.
+    const rollback = markProcessed(target.id);
 
     const formData = new FormData();
     formData.set("path", path);
@@ -155,37 +194,38 @@
       });
       const result = deserialize(await res.text());
       if (result.type === "failure" || result.type === "error") {
-        // 404 from a decide path means the row was already soft-deleted
-        // (likely from another window). Silently advance — no error UI.
+        // 404 from a decide path means the row was already gone in
+        // another tab; keep it processed-and-hidden, no error UI.
         if (result.status === 404) {
           pendingError = null;
         } else {
-          index = prevIndex;
+          rollback();
           pendingError = result.data?.error ?? "Decide failed";
           return;
         }
       } else {
         pendingError = null;
       }
-      // Refill the queue when we're near the end.
-      if (data.items.length - index <= 3) {
+      // Refill the visible queue when we're near the end. processedIds
+      // persists across the refetch so any items the backend hasn't
+      // committed yet stay hidden until the next setTab/setMode reset.
+      if (visibleItems.length <= 3) {
         await invalidateAll();
-        index = 0;
       }
     } catch (e) {
-      index = prevIndex;
+      rollback();
       pendingError = e?.message ?? String(e);
     }
   }
 
   async function handleDelete() {
     const target = current;
-    const prevIndex = index;
+    if (!target) return;
     const path = deletePathFor(data.tab, target);
     const label = tombstoneLabel(data.tab, target);
 
-    // Optimistic advance + arm the undo toast immediately.
-    advance();
+    // Optimistic: hide the card + arm the undo toast immediately.
+    const rollback = markProcessed(target.id);
     toastCounter += 1;
     tombstone = {
       tab: data.tab,
@@ -208,19 +248,18 @@
         // hit Undo if they meant to keep it (undelete is idempotent on
         // the backend in the unknown-id case it'll just 404 silently).
         if (result.status !== 404) {
-          index = prevIndex;
+          rollback();
           tombstone = null;
           pendingError = result.data?.error ?? "Delete failed";
           return;
         }
       }
       pendingError = null;
-      if (data.items.length - index <= 3) {
+      if (visibleItems.length <= 3) {
         await invalidateAll();
-        index = 0;
       }
     } catch (e) {
-      index = prevIndex;
+      rollback();
       tombstone = null;
       pendingError = e?.message ?? String(e);
     }
@@ -229,9 +268,12 @@
   async function handleUndo() {
     if (!tombstone) return;
     const t = tombstone;
-    // Optimistically dismiss the toast; if the call fails we'll re-arm
-    // it with an error label.
+    // Optimistically dismiss the toast and unhide the item from the
+    // visible queue so a successful undo immediately brings it back.
     tombstone = null;
+    const restored = new Set(processedIds);
+    restored.delete(String(t.id));
+    processedIds = restored;
 
     const formData = new FormData();
     formData.set("path", undeletePathFor(t.tab, t.id));
@@ -248,6 +290,8 @@
         // 409: gap was not deleted (idempotency edge). Treat both as
         // best-effort and surface a quiet inline error.
         pendingError = result.data?.error ?? "Undo failed";
+        // Re-hide the item; the visible queue should match server truth.
+        markProcessed(t.id);
         return;
       }
       pendingError = null;
@@ -255,6 +299,7 @@
       await invalidateAll();
     } catch (e) {
       pendingError = e?.message ?? String(e);
+      markProcessed(t.id);
     }
   }
 
@@ -346,16 +391,11 @@
 
     <ModeToggle mode={data.mode} onChange={setMode} />
 
-    <div class="legend" aria-hidden="true">
-      <kbd>j</kbd>/<kbd>k</kbd> nav
-      · <kbd>y</kbd>/<kbd>n</kbd> decide
-      {#if data.mode === "audit"}
-        · <kbd>s</kbd> skip
-        · <kbd>d</kbd> delete
-      {/if}
-      · <kbd>Tab</kbd> tab
-      · <kbd>m</kbd> mode
-    </div>
+    {#if visibleItems.length}
+      <span class="counter" aria-label="Queue position"
+        >{index + 1} / {visibleItems.length}</span
+      >
+    {/if}
   </header>
 
   {#if pendingError}
@@ -381,7 +421,6 @@
       mode={data.mode}
       onDecide={handleDecide}
     />
-    <footer class="counter">{index + 1} / {data.items.length}</footer>
   {/if}
 </section>
 
@@ -401,83 +440,81 @@
      the active-tab underline mirrors Nav.svelte's coral-on-hover /
      black-on-active so this page reads as a sibling of the site nav. */
 
+  /* Single-screen layout: the whole review surface fits in one viewport
+     so the user can power through items without scrolling. The Card
+     flex-grows to fill remaining height; its body subpanels scroll
+     internally when content overflows. */
   .review {
-    padding: 2.5rem 2.75rem;
+    padding: 1.5rem 2.5rem 1.5rem;
     font-family: var(--font-mono);
     color: var(--fg);
     background: var(--bg);
-    min-height: calc(100vh - 4rem);
+    height: calc(100vh - 4rem); /* 4rem reserves the site Nav header */
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    overflow: hidden;
   }
 
   .bar {
     display: flex;
-    gap: 2rem;
+    gap: 1.5rem;
     align-items: center;
-    margin-bottom: 1.75rem;
-    padding-bottom: 1rem;
+    padding-bottom: 0.75rem;
     border-bottom: var(--border-heavy);
+    flex-shrink: 0;
   }
 
+  /* Flat-by-default, pop-on-hover. Active tab is a filled yellow block
+     that sits flat (already chosen, no need to advertise interactivity);
+     inactive tabs gain a border + offset shadow on hover. */
   .tabs {
     display: inline-flex;
-    gap: 0.25rem;
+    gap: 0.6rem;
+    align-items: center;
   }
 
   .tabs button {
-    position: relative;
     font-family: var(--font-mono);
-    font-size: 0.8rem;
+    font-size: 0.85rem;
     font-weight: 700;
     text-transform: uppercase;
     letter-spacing: 0.14em;
     color: var(--fg-tertiary);
     background: transparent;
-    border: none;
-    padding: 0.5rem 0.75rem;
+    border: 2px solid transparent;
+    padding: 0.45rem 0.75rem;
     cursor: pointer;
+    transform: translate(0, 0);
+    transition:
+      transform 0.08s ease,
+      box-shadow 0.08s ease,
+      background 0.08s ease,
+      color 0.08s ease,
+      border-color 0.08s ease;
   }
 
-  .tabs button::after {
-    content: "";
-    position: absolute;
-    left: 0.75rem;
-    right: 0.75rem;
-    bottom: 0.2rem;
-    height: 2px;
-    background: var(--coral);
-    transform: scaleX(0);
-    transition: transform 160ms ease;
-  }
-
-  .tabs button:hover::after {
-    transform: scaleX(1);
+  .tabs button:hover:not(.active) {
+    color: var(--fg);
+    border-color: var(--fg);
+    transform: translate(-2px, -2px);
+    box-shadow: 4px 4px 0 0 var(--fg);
   }
 
   .tabs button.active {
     color: var(--fg);
+    background: var(--yellow);
+    border-color: var(--fg);
   }
 
-  .tabs button.active::after {
-    background: var(--fg);
-    transform: scaleX(1);
-  }
-
-  .legend {
+  .counter {
     margin-left: auto;
     font-family: var(--font-mono);
-    font-size: 0.75rem;
-    color: var(--fg);
-    letter-spacing: 0.04em;
-  }
-
-  .legend kbd {
-    font-family: var(--font-mono);
-    font-size: 0.72rem;
+    font-size: 0.85rem;
     font-weight: 700;
-    padding: 0.1rem 0.4rem;
-    border: 2px solid var(--fg);
     color: var(--fg);
-    background: var(--bg);
+    letter-spacing: 0.08em;
+    font-variant-numeric: tabular-nums;
   }
 
   .banner {
@@ -504,15 +541,6 @@
     cursor: pointer;
     padding: 0 0.25rem;
     font-weight: 700;
-  }
-
-  .counter {
-    font-family: var(--font-mono);
-    font-size: 0.8rem;
-    color: var(--fg);
-    letter-spacing: 0.04em;
-    margin-top: 1.25rem;
-    font-variant-numeric: tabular-nums;
   }
 
   .error {


### PR DESCRIPTION
## Summary

Iteration on `/private/review` after the first brutalist PR landed flat-looking and was missing things the live UX needed. Five files, three real bug fixes plus the visual rework.

## Bug fixes

- **`global.css`**: The `@import` of `tokens.css` was on line 32, AFTER the reset rules. Per the CSS spec `@import` must come before any other rules; PostCSS / vite silently strips out-of-place imports. Result: `--yellow`, `--coral`, `--border-heavy`, `--font-mono` etc. were never loaded site-wide, and every heading inherited the browser's serif fallback. Moving `@import` to the top of the file fixes the entire site.
- **`+page.svelte` (optimistic dedup)**: Rapid `y` keypresses fired backend POSTs in parallel; the near-end `invalidateAll()` could refetch before the writes committed, so the new list re-included items the user had just processed (visible as "items repeating" mid-session). Replaced index-based optimistic UI with a `processedIds: Set<id>` that filters `data.items` client-side. Items the user acts on this session stay hidden across refetches even if the backend hasn't caught up.
- **`+page.server.js`**: FastAPI errors come back as `{"detail": "..."}` and were being surfaced as the raw JSON envelope in the error banner. Added `readError()` to extract `.detail` (or `.error` for the form-action format) before `fail()`.

## Design iteration

- **`ReviewCard`**: 2px solid black borders (`--border-heavy`), pure white bg, hard corners, explicit `var(--font-mono)` on every element. Cluster-aligned type badges: GAP = `--cluster-gap` (coral), NOTE = `--cluster-paper` (green). Action buttons semantically coloured: Keep = yellow, Reject/Delete = coral, Agree = green. Body-label stamps. Flat-by-default sticker buttons that pop up-left + cast a 4px hard offset shadow on hover, flat on press.
- **`ModeToggle` / page tabs**: filled stamp blocks for active state (cream for mode, yellow for tab) with no shadow when chosen; inactive buttons pop-out on hover only.
- **Single-screen layout**: page is `height: 100vh - 4rem` with flex column. Card flex-grows, last body subpanel grows to fill, snippet scrolls internally. No more page-level scrolling.
- Earlier card-body subpanels (Answer above Stub) are `flex-shrink: 0` so their inner `<pre>` cannot bleed into the next box.
- Keyboard legend removed; queue counter moved to the bar.

## Test plan

- [ ] CI green
- [ ] private.jomcgi.dev/review: title is monospace, GAP badge is coral, NOTE badge is green, action buttons have coloured fills
- [ ] Buttons pop up-left with shadow on hover, flat on click
- [ ] Burst-pressing `y` no longer repeats items
- [ ] Error banner shows readable text, not raw JSON
- [ ] No page-level scrollbar — card fills viewport, body subpanel scrolls internally

🤖 Generated with [Claude Code](https://claude.com/claude-code)