### PR TITLE
feat(semgrep): add css-import-after-rules to catch silent PostCSS stripping

### DIFF
--- a/bazel/semgrep/rules/BUILD
+++ b/bazel/semgrep/rules/BUILD
@@ -343,3 +343,19 @@ semgrep_test(
     rules = [":sveltekit_public_route_fetches_private_knowledge_api_rule"],
     tags = ["semgrep"],
 )
+
+# css-import-after-rules uses languages: [generic] scoped to **/*.css.
+# Wired to its own .css annotation fixture independently of generic_rules_test
+# (which only scans no-stale-repo-paths fixtures).
+filegroup(
+    name = "css_import_after_rules_rule",
+    srcs = ["generic/css-import-after-rules.yaml"],
+)
+
+semgrep_test(
+    name = "css_import_after_rules_test",
+    srcs = ["//bazel/semgrep/tests:css_import_after_rules_fixtures"],
+    env = {"SEMGREP_TEST_MODE": "1"},
+    rules = [":css_import_after_rules_rule"],
+    tags = ["semgrep"],
+)

--- a/bazel/semgrep/rules/generic/css-import-after-rules.yaml
+++ b/bazel/semgrep/rules/generic/css-import-after-rules.yaml
@@ -1,0 +1,26 @@
+rules:
+  - id: css-import-after-rules
+    languages: [generic]
+    severity: WARNING
+    paths:
+      include:
+        - "**/*.css"
+    message: >-
+      @import found after a CSS rule block. The CSS specification requires all
+      @import statements to appear before any other rules; PostCSS and Vite
+      silently strip late @imports, causing design tokens or resets to vanish
+      at build time. Move all @import statements to the top of the file, before
+      any selector blocks. (This bug was fixed in PR #2353 where global.css
+      had `@import tokens.css` after the reset block.)
+    metadata:
+      category: correctness
+      subcategory: css
+      confidence: HIGH
+      likelihood: HIGH
+      impact: MEDIUM
+      technology: [css, postcss, vite]
+      description: >-
+        Detects @import statements that appear after a CSS rule block (a closing
+        brace). PostCSS/Vite silently strip late @imports per CSS spec, causing
+        design tokens to vanish at build time.
+    pattern-regex: '}\s*\n\s*@import'

--- a/bazel/semgrep/tests/BUILD
+++ b/bazel/semgrep/tests/BUILD
@@ -102,6 +102,13 @@ filegroup(
     srcs = ["fixtures/no-session-in-to-thread.yaml"],
 )
 
+# Fixture for the css-import-after-rules rule (languages: generic, paths: **/*.css).
+# Referenced by //bazel/semgrep/rules:css_import_after_rules_test.
+filegroup(
+    name = "css_import_after_rules_fixtures",
+    srcs = ["fixtures/css-import-after-rules.css"],
+)
+
 # Fixtures for kubernetes rules (require-readiness-probe, require-resource-limits, etc.).
 # Referenced by //bazel/semgrep/rules:kubernetes_rules_test.
 # New rule fixtures should be added here as they are created.

--- a/bazel/semgrep/tests/fixtures/css-import-after-rules.css
+++ b/bazel/semgrep/tests/fixtures/css-import-after-rules.css
@@ -1,0 +1,29 @@
+/* Test fixtures for the css-import-after-rules semgrep rule.
+ *
+ * Annotations:
+ *   /* ruleid: css-import-after-rules */  — match starts on the next non-annotation line
+ *   /* ok: css-import-after-rules */      — the next non-annotation line must NOT be flagged
+ */
+
+/* GOOD: @import before any CSS rules — PostCSS/Vite processes these correctly */
+@import 'tokens.css';
+@import url('reset.css');
+
+:root {
+  --color-bg: #fff;
+  --color-text: #333;
+}
+
+/* ok: css-import-after-rules */
+body { font-family: sans-serif; }
+
+h1 {
+  font-size: 2rem;
+}
+
+/* BAD: @import after a CSS rule block — PostCSS/Vite silently strips it.
+ * Reproduces the bug fixed in PR #2353 (global.css had @import tokens.css
+ * after the reset block, causing design tokens to vanish). */
+/* ruleid: css-import-after-rules */
+body { margin: 0; padding: 0; }
+@import 'tokens.css';


### PR DESCRIPTION
## Summary

- Adds `bazel/semgrep/rules/generic/css-import-after-rules.yaml` — a `generic`-language rule (scoped to `**/*.css`) that detects `@import` statements appearing after a CSS rule block (`}`)
- PostCSS and Vite silently strip late `@import`s per CSS spec, causing design tokens to vanish at build time; this was the bug fixed in PR #2353 where `global.css` had `@import tokens.css` after the reset block
- Uses `pattern-regex: '}\s*\n\s*@import'` to detect the closing brace immediately before an `@import`
- Adds annotated test fixture `bazel/semgrep/tests/fixtures/css-import-after-rules.css` with BAD (import after rule) and GOOD (import before rules) examples
- Registers `css_import_after_rules_rule` filegroup and `css_import_after_rules_test` semgrep_test in `rules/BUILD`, plus fixture filegroup in `tests/BUILD`

## Test plan

- [ ] `bazel test //bazel/semgrep/rules:css_import_after_rules_test` passes (CI)
- [ ] BAD fixture line annotated with `/* ruleid: css-import-after-rules */` is flagged
- [ ] GOOD fixture line annotated with `/* ok: css-import-after-rules */` is not flagged

🤖 Generated with [Claude Code](https://claude.com/claude-code)