### PR TITLE
docs(stargazer): document backend/api.py in README

### DIFF
--- a/projects/stargazer/README.md
+++ b/projects/stargazer/README.md
@@ -10,7 +10,7 @@ Multi-phase pipeline: light pollution atlas + OSM road data to identify dark zon
 
 | Component   | Description |
 | ----------- | ----------- |
-| **backend** | Pipeline that combines light pollution data, OSM roads, and weather forecasts (`weather.py` handles met.no forecast API calls) |
+| **backend** | Pipeline that combines light pollution data, OSM roads, and weather forecasts (`weather.py` handles met.no forecast API calls). Also contains `api.py`, a stdlib Python HTTP server (`/health`, `/api/locations`, `/api/best`) that was used during development; the deployed API uses NGINX instead (see `chart/templates/deployment-api.yaml`) |
 | **tests**   | Additional unit tests for the backend pipeline (separate from tests co-located in `backend/`) |
 | **chart**   | Helm chart with CronJob and optional NGINX API server templates (controlled by `api.enabled` flag) |
 | **deploy**  | ArgoCD Application, kustomization, and cluster-specific values (enables API server via `api.enabled: true`) |


### PR DESCRIPTION
## Summary

- `backend/api.py` is a stdlib Python HTTP server (`/health`, `/api/locations`, `/api/best`) that exists in the backend directory but was undocumented in the README
- The deployed API uses NGINX (not `api.py`); `api.py` was written during development and superseded by the NGINX approach
- Added a note to the `backend` component row explaining the file and its relationship to the deployed API

## Changes

`projects/stargazer/README.md`: Expanded the `backend` component description to mention `api.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)