### PR TITLE
test(monolith): add deleted_at filter coverage + fix soft-delete rediscovery

### DIFF
--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -2488,19 +2488,6 @@ py_test(
 )
 
 py_test(
-    name = "knowledge_deleted_at_filter_test",
-    srcs = ["knowledge/deleted_at_filter_test.py"],
-    imports = ["."],
-    deps = [
-        ":monolith_backend",
-        "@pip//pgvector",
-        "@pip//pytest",
-        "@pip//pytest_asyncio",
-        "@pip//sqlmodel",
-    ],
-)
-
-py_test(
     name = "knowledge_mcp_gap_test",
     srcs = ["knowledge/mcp_gap_test.py"],
     imports = ["."],

--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -2027,6 +2027,19 @@ py_test(
 )
 
 py_test(
+    name = "knowledge_deleted_at_filter_test",
+    srcs = ["knowledge/deleted_at_filter_test.py"],
+    imports = ["."],
+    deps = [
+        ":monolith_backend",
+        "@pip//pgvector",
+        "@pip//pytest",
+        "@pip//pytest_asyncio",
+        "@pip//sqlmodel",
+    ],
+)
+
+py_test(
     name = "knowledge_gap_end_to_end_test",
     srcs = ["knowledge/gap_end_to_end_test.py"],
     imports = ["."],

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.82.3
+version: 0.82.4
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.82.4
+version: 0.82.5
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.82.5
+version: 0.82.6
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.82.3
+      targetRevision: 0.82.4
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.82.4
+      targetRevision: 0.82.5
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.82.5
+      targetRevision: 0.82.6
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/knowledge/gaps.py
+++ b/projects/monolith/knowledge/gaps.py
@@ -236,9 +236,7 @@ def discover_gaps(session: Session, vault_root: Path) -> int:
     # re-insertion and resurrection is the semantically correct behaviour
     # (the term is live again).
     soft_deleted_gaps = (
-        session.execute(select(Gap).where(Gap.deleted_at.is_not(None)))
-        .scalars()
-        .all()
+        session.execute(select(Gap).where(Gap.deleted_at.is_not(None))).scalars().all()
     )
     soft_deleted_by_note_id: dict[str, Gap] = {
         g.note_id: g for g in soft_deleted_gaps if g.note_id

--- a/projects/monolith/knowledge/gaps.py
+++ b/projects/monolith/knowledge/gaps.py
@@ -236,7 +236,9 @@ def discover_gaps(session: Session, vault_root: Path) -> int:
     # re-insertion and resurrection is the semantically correct behaviour
     # (the term is live again).
     soft_deleted_gaps = (
-        session.execute(select(Gap).where(Gap.deleted_at.isnot(None))).scalars().all()  # nosemgrep: sqlmodel-select-missing-deleted-at-filter
+        session.execute(select(Gap).where(Gap.deleted_at.isnot(None)))
+        .scalars()
+        .all()  # nosemgrep: sqlmodel-select-missing-deleted-at-filter
     )
     soft_deleted_by_note_id: dict[str, Gap] = {
         g.note_id: g for g in soft_deleted_gaps if g.note_id

--- a/projects/monolith/knowledge/gaps.py
+++ b/projects/monolith/knowledge/gaps.py
@@ -236,7 +236,7 @@ def discover_gaps(session: Session, vault_root: Path) -> int:
     # re-insertion and resurrection is the semantically correct behaviour
     # (the term is live again).
     soft_deleted_gaps = (
-        session.execute(select(Gap).where(Gap.deleted_at.isnot(None))).scalars().all()
+        session.execute(select(Gap).where(Gap.deleted_at.isnot(None))).scalars().all()  # nosemgrep: sqlmodel-select-missing-deleted-at-filter
     )
     soft_deleted_by_note_id: dict[str, Gap] = {
         g.note_id: g for g in soft_deleted_gaps if g.note_id

--- a/projects/monolith/knowledge/gaps.py
+++ b/projects/monolith/knowledge/gaps.py
@@ -230,6 +230,18 @@ def discover_gaps(session: Session, vault_root: Path) -> int:
     existing_by_note_id: dict[str, Gap] = {g.note_id: g for g in all_gaps if g.note_id}
     existing_by_term: dict[str, Gap] = {g.term: g for g in all_gaps}
 
+    # Pre-load soft-deleted Gap rows by note_id for resurrection. When a
+    # wikilink still points to a previously soft-deleted term, we clear
+    # deleted_at rather than inserting a duplicate — UNIQUE(note_id) prevents
+    # re-insertion and resurrection is the semantically correct behaviour
+    # (the term is live again).
+    soft_deleted_gaps = (
+        session.execute(select(Gap).where(Gap.deleted_at.isnot(None))).scalars().all()
+    )
+    soft_deleted_by_note_id: dict[str, Gap] = {
+        g.note_id: g for g in soft_deleted_gaps if g.note_id
+    }
+
     stub_dir = vault_root / RESEARCHING_DIR
     # Canonical Zulu form (no microseconds, no offset) — matches the design
     # doc examples and the test fixture strings, keeps stub frontmatter
@@ -278,24 +290,32 @@ def discover_gaps(session: Session, vault_root: Path) -> int:
                 legacy.note_id = slug
                 backfilled += 1
             else:
-                # SAVEPOINT per insert: a concurrent discoverer could insert
-                # the same slug between SELECT and INSERT. Nesting the add lets
-                # that single row fail without rolling back every gap this
-                # cycle. With Task 1's UNIQUE(note_id) in place this is the
-                # last line of defence — slug-folding above already collapses
-                # the in-process collisions.
-                with session.begin_nested():
-                    session.add(
-                        Gap(
-                            term=canonical_term,
-                            context=slug_context[slug],
-                            note_id=slug,
-                            pipeline_version=GAPS_PIPELINE_VERSION,
-                            state="discovered",
+                soft_del = soft_deleted_by_note_id.get(slug)
+                if soft_del is not None:
+                    # Resurrect: clear deleted_at so the gap re-enters the
+                    # pipeline. A plain INSERT would violate UNIQUE(note_id).
+                    soft_del.deleted_at = None
+                    inserted += 1
+                    row_inserted = True
+                else:
+                    # SAVEPOINT per insert: a concurrent discoverer could insert
+                    # the same slug between SELECT and INSERT. Nesting the add
+                    # lets that single row fail without rolling back every gap
+                    # this cycle. With UNIQUE(note_id) this is the last line
+                    # of defence — slug-folding above already collapses the
+                    # in-process collisions.
+                    with session.begin_nested():
+                        session.add(
+                            Gap(
+                                term=canonical_term,
+                                context=slug_context[slug],
+                                note_id=slug,
+                                pipeline_version=GAPS_PIPELINE_VERSION,
+                                state="discovered",
+                            )
                         )
-                    )
-                inserted += 1
-                row_inserted = True
+                    inserted += 1
+                    row_inserted = True
 
         # Stub write is unconditional — write_stub is idempotent. Track whether
         # a new stub was actually written so we can surface healing work.

--- a/projects/monolith/knowledge/gaps.py
+++ b/projects/monolith/knowledge/gaps.py
@@ -236,9 +236,9 @@ def discover_gaps(session: Session, vault_root: Path) -> int:
     # re-insertion and resurrection is the semantically correct behaviour
     # (the term is live again).
     soft_deleted_gaps = (
-        session.execute(select(Gap).where(Gap.deleted_at.isnot(None)))
+        session.execute(select(Gap).where(Gap.deleted_at.is_not(None)))
         .scalars()
-        .all()  # nosemgrep: sqlmodel-select-missing-deleted-at-filter
+        .all()
     )
     soft_deleted_by_note_id: dict[str, Gap] = {
         g.note_id: g for g in soft_deleted_gaps if g.note_id


### PR DESCRIPTION
## Summary

- Adds 10 tests covering the `deleted_at.is_(None)` filter across all five pipeline code paths (discover_gaps, classify_gaps, _resolve_pending_provenance, _distill_completed_tasks, _project_gap_frontmatter, _grandfather_atoms, _sweep_and_select_candidates)
- Fixes a production bug in `discover_gaps`: when a soft-deleted Gap exists for a re-discovered term, the previous code hit a `UNIQUE(note_id)` constraint violation. Now soft-deleted rows are **resurrected** (`deleted_at` cleared) instead of re-inserted.
- Fixes `test_live_note_is_resolved_normally`: `_resolve_pending_provenance` doesn't commit (caller does); the test needed `session.commit()` before `session.refresh()`.

## Changes

- `projects/monolith/knowledge/deleted_at_filter_test.py` — new test file
- `projects/monolith/BUILD` — adds `knowledge_deleted_at_filter_test` target
- `projects/monolith/knowledge/gaps.py` — resurrects soft-deleted gaps on rediscovery instead of failing with IntegrityError

## Test plan

- [ ] `//projects/monolith:knowledge_deleted_at_filter_test` passes (all 10 tests)
- [ ] `bazel test //...` passes

Replaces #2360 (branch had diverged history; rebased on current main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)