### PR TITLE
feat(semgrep): add svelte-hardcoded-color-in-style rule

### DIFF
--- a/bazel/semgrep/rules/BUILD
+++ b/bazel/semgrep/rules/BUILD
@@ -391,3 +391,19 @@ semgrep_test(
     rules = [":sveltekit_form_action_unvalidated_path_rule"],
     tags = ["semgrep"],
 )
+
+# svelte-hardcoded-color-in-style uses languages: [generic] scoped to **/*.svelte.
+# Wired to its own .svelte annotation fixture independently of typescript_rules_test
+# (which only scans *.ts fixtures).
+filegroup(
+    name = "svelte_hardcoded_color_in_style_rule",
+    srcs = ["typescript/svelte-hardcoded-color-in-style.yaml"],
+)
+
+semgrep_test(
+    name = "svelte_hardcoded_color_in_style_test",
+    srcs = ["//bazel/semgrep/tests:svelte_hardcoded_color_in_style_fixtures"],
+    env = {"SEMGREP_TEST_MODE": "1"},
+    rules = [":svelte_hardcoded_color_in_style_rule"],
+    tags = ["semgrep"],
+)

--- a/bazel/semgrep/rules/typescript/svelte-hardcoded-color-in-style.yaml
+++ b/bazel/semgrep/rules/typescript/svelte-hardcoded-color-in-style.yaml
@@ -1,0 +1,27 @@
+rules:
+  - id: svelte-hardcoded-color-in-style
+    languages: [generic]
+    severity: WARNING
+    paths:
+      include:
+        - "**/*.svelte"
+    message: >-
+      Hex color literal found in a Svelte file. Hard-coded colors bypass the
+      CSS token system (tokens.css / var(--token)) and silently fall out of
+      sync when the design palette changes. Replace hex values with the
+      appropriate CSS custom property: e.g., `color: #141414` →
+      `color: var(--fg)`, `background: #f1ebdc` → `background: var(--bg)`.
+      See PR #2342 where three hardcoded hex colors were left after a palette
+      refactor and had to be fixed separately.
+    metadata:
+      category: maintainability
+      subcategory: design-tokens
+      confidence: HIGH
+      likelihood: MEDIUM
+      impact: LOW
+      technology: [svelte, css, postcss]
+      description: >-
+        Detects hard-coded CSS hex color literals inside Svelte files.
+        They bypass the CSS custom-property token system and drift silently
+        when the design palette is updated.
+    pattern-regex: ':\s*#[0-9a-fA-F]{3,8}\b'

--- a/bazel/semgrep/tests/BUILD
+++ b/bazel/semgrep/tests/BUILD
@@ -60,6 +60,13 @@ filegroup(
     srcs = ["fixtures/no-create-event-dispatcher-runes.svelte"],
 )
 
+# Fixture for the svelte-hardcoded-color-in-style rule (languages: generic, paths: **/*.svelte).
+# Referenced by //bazel/semgrep/rules:svelte_hardcoded_color_in_style_test.
+filegroup(
+    name = "svelte_hardcoded_color_in_style_fixtures",
+    srcs = ["fixtures/svelte-hardcoded-color-in-style.svelte"],
+)
+
 # Fixture for the no-stale-repo-paths rule (languages: generic).
 # Referenced by //bazel/semgrep/rules:generic_rules_test.
 filegroup(

--- a/bazel/semgrep/tests/fixtures/svelte-hardcoded-color-in-style.svelte
+++ b/bazel/semgrep/tests/fixtures/svelte-hardcoded-color-in-style.svelte
@@ -1,0 +1,58 @@
+<!-- Test fixtures for the svelte-hardcoded-color-in-style semgrep rule.
+
+Annotations:
+  ruleid: svelte-hardcoded-color-in-style   — the next non-annotation line MUST be flagged
+  ok: svelte-hardcoded-color-in-style       — the next non-annotation line MUST NOT be flagged
+-->
+
+<script>
+  // Script section — no CSS, so no color flags here.
+  const label = "hello";
+</script>
+
+<template>
+  <!-- Template section: hex in href anchors should not fire -->
+  <!-- ok: svelte-hardcoded-color-in-style -->
+  <a href="#section-1">Jump</a>
+  <!-- ok: svelte-hardcoded-color-in-style -->
+  <p>Some text with #hashtag mention</p>
+</template>
+
+<style>
+  /* Positive cases — hard-coded hex colors that bypass design tokens */
+
+  /* ruleid: svelte-hardcoded-color-in-style */
+  background: #f1ebdc;
+
+  /* ruleid: svelte-hardcoded-color-in-style */
+  color: #141414;
+
+  /* ruleid: svelte-hardcoded-color-in-style */
+  border-color: #aabbcc;
+
+  /* ruleid: svelte-hardcoded-color-in-style */
+  fill: #fff;
+
+  /* ruleid: svelte-hardcoded-color-in-style */
+  stroke: #123456ab;
+
+  /* Negative cases — using CSS custom properties (correct pattern) */
+
+  /* ok: svelte-hardcoded-color-in-style */
+  background: var(--bg);
+
+  /* ok: svelte-hardcoded-color-in-style */
+  color: var(--fg);
+
+  /* ok: svelte-hardcoded-color-in-style */
+  border-color: var(--border);
+
+  /* ok: svelte-hardcoded-color-in-style */
+  font-family: var(--font-mono);
+
+  /* ok: svelte-hardcoded-color-in-style */
+  background: inherit;
+
+  /* ok: svelte-hardcoded-color-in-style */
+  color: transparent;
+</style>


### PR DESCRIPTION
## Summary

Adds a new semgrep rule `svelte-hardcoded-color-in-style` (WARNING) that catches hard-coded CSS hex color literals in Svelte files.

**Problem identified in PR #2342 review:** Three hex colors were introduced after a palette refactor — `background: #f1ebdc`, `color: #141414`, `font-family: "JetBrains Mono"` — none using the existing CSS custom properties (`var(--bg)`, `var(--fg)`, `var(--font-mono)`) from `tokens.css`. The `css-import-after-rules` rule was introduced for the same root cause; this catches the downstream symptom.

## Changes

- `bazel/semgrep/rules/typescript/svelte-hardcoded-color-in-style.yaml` — new rule
- `bazel/semgrep/tests/fixtures/svelte-hardcoded-color-in-style.svelte` — annotated fixture
- `bazel/semgrep/tests/BUILD` — fixture filegroup
- `bazel/semgrep/rules/BUILD` — test target

## Pattern

```yaml
pattern-regex: ':\s*#[0-9a-fA-F]{3,8}\b'
paths:
  include: ["**/*.svelte"]
```

Matches CSS property values with hex colors (`: #rrggbb`) in any `.svelte` file. Severity WARNING — nudge, not a hard block, since legacy one-off values may be intentional.

## Test plan

- [ ] `//bazel/semgrep/rules:svelte_hardcoded_color_in_style_test` passes
- [ ] `bazel test //...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)