### PR TITLE
fix(knowledge): add _discord to gardener._EXCLUDED_DIRS + drift-detector test

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.83.0
+version: 0.83.1
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.83.0
+      targetRevision: 0.83.1
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/knowledge/gardener.py
+++ b/projects/monolith/knowledge/gardener.py
@@ -29,6 +29,13 @@ _EXCLUDED_DIRS = {
     # Skipping the directory prevents the gardener from re-ingesting
     # trashed notes as fresh raws on the next discover tick.
     "_trash",
+    # _discord/ holds per-user and per-channel summary mirrors written
+    # by chat/vault_export.py. Those files are explicitly NOT meant for
+    # KG ingest — see vault_export.py's module docstring. Without this
+    # exclusion, the gardener walks the directory and queues every
+    # mirror file for decomposition, flooding the KG with channel ×
+    # user × cycle noise. Kept in sync with raw_ingest._EXCLUDED_TOP_LEVEL.
+    "_discord",
     ".obsidian",
     ".trash",
 }

--- a/projects/monolith/knowledge/raw_ingest_test.py
+++ b/projects/monolith/knowledge/raw_ingest_test.py
@@ -231,6 +231,31 @@ def test_infer_source_research_does_not_override_explicit_meta_source():
     assert _infer_source("manual", ("_inbox", "research", "x.md")) == "manual"
 
 
+def test_excluded_top_level_and_excluded_dirs_stay_in_sync():
+    """Drift detector: raw_ingest._EXCLUDED_TOP_LEVEL and gardener._EXCLUDED_DIRS
+    must contain the same set of directories.
+
+    Both scanners walk the vault root and skip the same set of managed/private
+    directories. A directory added to one but not the other will be processed
+    by one pipeline and silently ignored by the other, causing inconsistencies
+    (e.g. PR #2370 added _discord/ to _EXCLUDED_TOP_LEVEL but missed
+    _EXCLUDED_DIRS, so the gardener still walked _discord/).
+
+    Known alias: raw_ingest uses the RAW_ROOT_NAME constant (== "_raw") while
+    gardener uses the literal "_raw". Both resolve to the same string, so the
+    sets compare equal without any normalization.
+    """
+    from knowledge import raw_ingest
+    from knowledge.gardener import _EXCLUDED_DIRS
+
+    assert raw_ingest._EXCLUDED_TOP_LEVEL == _EXCLUDED_DIRS, (
+        "raw_ingest._EXCLUDED_TOP_LEVEL and gardener._EXCLUDED_DIRS are out of sync.\n"
+        f"  Only in _EXCLUDED_TOP_LEVEL: {raw_ingest._EXCLUDED_TOP_LEVEL - _EXCLUDED_DIRS}\n"
+        f"  Only in _EXCLUDED_DIRS: {_EXCLUDED_DIRS - raw_ingest._EXCLUDED_TOP_LEVEL}\n"
+        "Add the missing entry to both sets and update this test's docstring."
+    )
+
+
 def test_excluded_top_level_contains_discord_to_match_vault_export_intent():
     """Drift detector: _discord/ must be excluded from move_phase.
 


### PR DESCRIPTION
## Summary

- **Bug fix**: `gardener._EXCLUDED_DIRS` was missing `_discord`, so the gardener walked `_discord/` and queued vault_export.py mirror files for decomposition (PR #2370 added `_discord` to `raw_ingest._EXCLUDED_TOP_LEVEL` but missed the gardener set)
- **Drift detector**: New test `test_excluded_top_level_and_excluded_dirs_stay_in_sync` asserts both exclusion sets stay equal, catching future desyncs at CI time
- **Chart bump**: 0.83.0 → 0.83.1 (required since gardener.py changed)

## Changes

- `projects/monolith/knowledge/gardener.py`: Add `_discord` to `_EXCLUDED_DIRS` with a comment matching the style in `raw_ingest.py`, referencing `vault_export.py`'s intent
- `projects/monolith/knowledge/raw_ingest_test.py`: Add `test_excluded_top_level_and_excluded_dirs_stay_in_sync` — imports both sets, asserts equality, documents the known alias (`RAW_ROOT_NAME` = `"_raw"`)
- `projects/monolith/chart/Chart.yaml` + `deploy/application.yaml`: version 0.83.1

## Test plan

- [ ] `test_excluded_top_level_and_excluded_dirs_stay_in_sync` passes with the `_discord` fix in place
- [ ] `test_excluded_top_level_contains_discord_to_match_vault_export_intent` (pre-existing) still passes
- [ ] CI green (`bazel test //...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)