### PR TITLE
feat(knowledge): bump research cadence 1day -> 15min

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.84.2
+version: 0.85.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.84.2
+      targetRevision: 0.85.0
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/knowledge/service.py
+++ b/projects/monolith/knowledge/service.py
@@ -43,9 +43,13 @@ _CLASSIFY_INTERVAL_SECS = 60  # 1-minute tick
 # risking a second replica racing Edit calls on the same stubs.
 _CLASSIFY_TTL_SECS = 360  # 300s subprocess timeout + 60s headroom
 _CLASSIFY_BATCH_SIZE = 10
-_RESEARCH_INTERVAL_SECS = 86400  # once per day
+_RESEARCH_INTERVAL_SECS = 900  # every 15 minutes
 _RESEARCH_TTL_SECS = (
-    1200  # 20min lock-lease (Sonnet research runs can be slow with web tools)
+    # 20min lock-lease (Sonnet research runs can be slow with web tools).
+    # Exceeds the 15min interval intentionally: if a research tick takes
+    # longer than the interval, the next tick simply waits until the lock
+    # expires rather than racing against the in-flight run.
+    1200
 )
 _GIT_READY_SENTINEL = ".git-ready"
 _SYNC_READY_SENTINEL = ".sync-ready"

--- a/projects/monolith/knowledge/service_test.py
+++ b/projects/monolith/knowledge/service_test.py
@@ -621,7 +621,7 @@ class TestClassifyGapsHandler:
         job = session.execute(
             select(ScheduledJob).where(ScheduledJob.name == "knowledge.research-gaps")
         ).scalar_one()
-        assert job.interval_secs == 86400
+        assert job.interval_secs == service._RESEARCH_INTERVAL_SECS
         assert job.ttl_secs == 1200  # was 600
 
     @pytest.mark.asyncio
@@ -819,7 +819,7 @@ class TestReconcileHandlerLayout:
         with patch("knowledge.service.EmbeddingClient", return_value=fake_embed_client):
             await service.reconcile_handler(session)
 
-        notes = list(session.scalars(select(Note)))
+        notes = list(session.scalars(select(Note).where(Note.deleted_at.is_(None))))
         assert len(notes) == 2
         for note in notes:
             assert note.layout_x is not None, f"{note.note_id} has no layout_x"
@@ -866,7 +866,7 @@ class TestReconcileHandlerLayout:
         # Failure was logged at ERROR via logger.exception.
         assert any("knowledge.layout: pass failed" in r.message for r in caplog.records)
         # The upsert was committed: the new note exists.
-        notes = list(session.scalars(select(Note)))
+        notes = list(session.scalars(select(Note).where(Note.deleted_at.is_(None))))
         assert len(notes) == 1
         assert notes[0].note_id == "a"
         # And the layout pass didn't run, so positions are still None.
@@ -906,7 +906,10 @@ class TestReconcileHandlerLayout:
         with patch("knowledge.service.EmbeddingClient", return_value=fake_embed_client):
             await service.reconcile_handler(session)
 
-        notes = {n.note_id: n for n in session.scalars(select(Note))}
+        notes = {
+            n.note_id: n
+            for n in session.scalars(select(Note).where(Note.deleted_at.is_(None)))
+        }
         assert set(notes) == {"pub", "pub2", "priv"}
         # Public notes get public-layout positions (in addition to the
         # full-graph ones every note gets).
@@ -963,7 +966,7 @@ class TestReconcileHandlerLayout:
         assert any(
             "knowledge.layout: public pass failed" in r.message for r in caplog.records
         )
-        notes = list(session.scalars(select(Note)))
+        notes = list(session.scalars(select(Note).where(Note.deleted_at.is_(None))))
         assert len(notes) == 2
         # Full-graph layout still ran successfully.
         for note in notes:


### PR DESCRIPTION
## Summary

Drops `_RESEARCH_INTERVAL_SECS` from 86400 (1 day) to 900 (15 min) so the external research scheduler ticks 96× more often, draining the calibrated queue materially faster.

## Why now

Tonight's gap re-classification pass parked 428 low-relevance gaps (Pop culture, religious/patristic, vendor trivia, etc.) and left 332 legitimately-external gaps in the `in_review` queue. With the queue now calibrated against `profile.py`'s rubric, faster cadence drains real research debt rather than burning tokens on Hearthstone.

## TTL relationship (important)

The 20min TTL (`_RESEARCH_TTL_SECS=1200`) intentionally stays above the new 15min interval. If a research tick runs long, the next tick simply waits for the lock to expire rather than racing against the in-flight Sonnet subprocess. Added a comment block explaining this non-obvious relationship.

## Scope creep disclosure

The pre-commit semgrep gate surfaced 4 pre-existing `sqlmodel-select-missing-deleted-at-filter` violations in `service_test.py` (lines 822, 869, 909, 966) whenever the file is touched. The rule doesn't honour `# nosemgrep`, so the only path forward was to fix them inline. All 4 are test-data-existence checks, not soft-delete behaviour tests, so the filter is a no-op for the assertions.

## Test plan

- [ ] CI green (`gh pr checks --watch`)
- [ ] After merge + rollout, confirm the `knowledge.research-gaps` ScheduledJob row in DB has `interval_secs=900`
- [ ] Watch `in_review/external` queue count drop materially over the next few hours

🤖 Generated with [Claude Code](https://claude.com/claude-code)