### PR TITLE
fix(knowledge): edit_note preserves frontmatter + gap state-class CHECK

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.85.0
+version: 0.86.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/migrations/20260530000000_gaps_state_class_combo.sql
+++ b/projects/monolith/chart/migrations/20260530000000_gaps_state_class_combo.sql
@@ -1,0 +1,34 @@
+-- knowledge.gaps: enforce valid (state, gap_class) combinations.
+--
+-- Without this CHECK, two independent constraints (gaps_state_check and
+-- gaps_gap_class_check) admit any cross-product of state x gap_class,
+-- including combinations the lifecycle should never produce. Tonight's
+-- audit found 231 rows in (state='classified', gap_class='external') --
+-- per the classifier docs, external/internal/hybrid gaps move to
+-- in_review after classification; only parked gaps go to 'classified'
+-- terminal state. Those 231 rows were a historical drift, cleaned up
+-- in the bulk gap re-classification pass.
+--
+-- This constraint prevents recurrence: any UPDATE/INSERT that produces
+-- an invalid combo will now fail loudly with a CHECK violation.
+--
+-- 'discovered' is treated as wildcard because the classifier's frontmatter
+-- edits to gap_class and state are sequential text replacements, not a
+-- single atomic update. There is a brief window where the file has
+-- gap_class set but state still 'discovered' before the second edit
+-- lands; the reconciler may persist that intermediate state. Allowing
+-- (discovered, *) tolerates the race.
+--
+-- SQLite ignores CHECK constraints, so unit-test fixtures will not
+-- exercise this. Real Postgres in CI and prod will.
+ALTER TABLE knowledge.gaps DROP CONSTRAINT IF EXISTS gaps_state_class_combo;
+ALTER TABLE knowledge.gaps ADD CONSTRAINT gaps_state_class_combo CHECK (
+  state = 'discovered'
+  OR (state = 'in_review' AND gap_class IN ('external', 'internal', 'hybrid'))
+  OR (state IN ('researching', 'researched', 'verified', 'consolidated')
+      AND gap_class = 'external')
+  OR (state IN ('committed', 'rejected')
+      AND gap_class IN ('external', 'internal', 'hybrid'))
+  OR (state = 'parked' AND gap_class = 'parked')
+  OR (state = 'classified' AND gap_class = 'parked')
+);

--- a/projects/monolith/chart/migrations/atlas.sum
+++ b/projects/monolith/chart/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:XAqBxO4s7t3Tfa2MqlTqZzDh1pNBW8Tanv/8o/gNpM8=
+h1:0pMmfkLL5cd6rfFLshaGtWrUJl4wpnMdIH1ct1ZHipo=
 20260330000000_initial_schema.sql h1:J2futpSW0nJAIRR7nR7ssT7LwXIYrvRI+PkHb5Y4tLI=
 20260403000000_chat_schema.sql h1:pERUFC0vzM95etRuzp43XzkCV7lBCzrrtY5Mk7aF3CA=
 20260404000000_chat_attachments.sql h1:tv+Fdbr1rQC5nzUxfaBC0O6fu2OMGgLWf+YNg1WQXi4=
@@ -26,3 +26,4 @@ h1:XAqBxO4s7t3Tfa2MqlTqZzDh1pNBW8Tanv/8o/gNpM8=
 20260523000000_review_verification_columns.sql h1:wYVDUpVQCsS+++LHEo5p9t08zX+5o+al65A1Tz5rMKs=
 20260523120000_review_soft_delete.sql h1:lAYba7MzvHDO+/ob+CUPGmnwu5tYUh+fWf6TEvH8vVY=
 20260524000000_gate_external_research.sql h1:+PavvmK2LurjiKBrXucFNoZg7XnV7Buq/QpMXVhI6HE=
+20260530000000_gaps_state_class_combo.sql h1:5xds/70HjdD+YL1IAgzgGiRCMpXyeVt/JShx49GBr9g=

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.85.0
+      targetRevision: 0.86.0
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/knowledge/mcp.py
+++ b/projects/monolith/knowledge/mcp.py
@@ -99,6 +99,7 @@ async def create_note(
     source: str | None = None,
     tags: list[str] | None = None,
     type: str | None = None,
+    visibility: str | None = None,
 ) -> dict:
     """Create a new knowledge note in the vault.
 
@@ -111,9 +112,14 @@ async def create_note(
         source: Optional source URL or reference.
         tags: Optional list of tags.
         type: Optional note type (e.g. "concept", "paper").
+        visibility: Optional public or private. Atoms without visibility
+            land in the review queue. Set explicitly to avoid that.
     """
     if not content or not content.strip():
         return {"error": "content must not be empty"}
+
+    if visibility is not None and visibility not in ("public", "private"):
+        return {"error": (f"visibility must be public or private, got {visibility!r}")}
 
     if title is None:
         title = content.strip()[:60]
@@ -125,6 +131,8 @@ async def create_note(
         fm["tags"] = tags
     if type:
         fm["type"] = type
+    if visibility:
+        fm["visibility"] = visibility
 
     file_content = "---\n" + yaml.dump(fm, default_flow_style=False) + "---\n" + content
 
@@ -147,18 +155,27 @@ async def edit_note(
     content: str | None = None,
     title: str | None = None,
     tags: list[str] | None = None,
+    visibility: str | None = None,
 ) -> dict:
     """Edit an existing knowledge note.
 
     Looks up the note by ID, merges the provided fields into the
-    existing frontmatter, and writes the updated file back.
+    existing frontmatter, and writes the updated file back. All
+    pre-existing frontmatter fields (visibility, source_tier, aliases,
+    edges, created/updated timestamps, custom extras) are preserved
+    on rewrite -- only the fields passed explicitly are modified.
 
     Args:
         note_id: The stable note identifier.
         content: New markdown body (replaces existing body if provided).
         title: New title (updates frontmatter if provided).
         tags: New tags list (updates frontmatter if provided).
+        visibility: Optional public or private. When None, the
+            existing visibility (if any) is preserved on rewrite.
     """
+    if visibility is not None and visibility not in ("public", "private"):
+        return {"error": (f"visibility must be public or private, got {visibility!r}")}
+
     with Session(get_engine()) as session:
         store = KnowledgeStore(session)
         note = store.get_note_by_id(note_id)
@@ -179,7 +196,13 @@ async def edit_note(
             parsed.tags = tags
         if content is not None:
             body = content
+        if visibility is not None:
+            parsed.visibility = visibility
 
+        # Mirrors router.edit_note's field list so every frontmatter field the
+        # parser knows about gets re-emitted. Drift between this list and the
+        # HTTP edit_note is the bug that silently nulled visibility on
+        # thousands of notes before this fix landed.
         fm_dict: dict[str, object] = {}
         if parsed.note_id:
             fm_dict["id"] = parsed.note_id
@@ -189,6 +212,8 @@ async def edit_note(
             fm_dict["type"] = parsed.type
         if parsed.status:
             fm_dict["status"] = parsed.status
+        if parsed.visibility is not None:
+            fm_dict["visibility"] = parsed.visibility
         if parsed.source:
             fm_dict["source"] = parsed.source
         if parsed.tags:
@@ -197,6 +222,10 @@ async def edit_note(
             fm_dict["aliases"] = parsed.aliases
         if parsed.edges:
             fm_dict["edges"] = parsed.edges
+        if parsed.created is not None:
+            fm_dict["created"] = parsed.created.isoformat()
+        if parsed.updated is not None:
+            fm_dict["updated"] = parsed.updated.isoformat()
         if parsed.extra:
             fm_dict.update(parsed.extra)
 

--- a/projects/monolith/knowledge/mcp_test.py
+++ b/projects/monolith/knowledge/mcp_test.py
@@ -231,6 +231,30 @@ class TestCreateNoteTool:
         text = created.read_text()
         assert "title: Short body" in text
 
+    @pytest.mark.asyncio
+    async def test_visibility_arg_writes_frontmatter(self, tmp_path, monkeypatch):
+        vault_dir = tmp_path / "vault"
+        vault_dir.mkdir()
+        monkeypatch.setenv("VAULT_ROOT", str(vault_dir))
+
+        result = await create_note(
+            content="An atom about service mesh.",
+            title="Linkerd mTLS",
+            visibility="public",
+        )
+
+        text = (vault_dir / result["path"]).read_text()
+        assert "visibility: public" in text
+
+    @pytest.mark.asyncio
+    async def test_rejects_invalid_visibility(self, tmp_path, monkeypatch):
+        vault_dir = tmp_path / "vault"
+        vault_dir.mkdir()
+        monkeypatch.setenv("VAULT_ROOT", str(vault_dir))
+
+        result = await create_note(content="body", visibility="weird-value")
+        assert "error" in result
+
 
 class TestEditNoteTool:
     """Tests for the edit_note MCP tool."""
@@ -291,6 +315,65 @@ class TestEditNoteTool:
             }
             result = await edit_note("n1", content="x")
 
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    async def test_preserves_existing_visibility(self, tmp_path, monkeypatch):
+        """Title-only edit must not drop visibility from frontmatter.
+
+        Regression guard for the bug that nulled visibility on thousands of
+        notes prior to this fix. Mirror the file shape that the gardener
+        emits (id + title + type + visibility) and confirm the rewrite
+        keeps the visibility line.
+        """
+        vault_dir = tmp_path / "vault"
+        vault_dir.mkdir()
+        note_file = vault_dir / "papers" / "attention.md"
+        note_file.parent.mkdir(parents=True)
+        note_file.write_text(
+            "---\nid: n1\ntitle: Original\ntype: atom\nvisibility: public\n---\nOld body"
+        )
+
+        monkeypatch.setenv("VAULT_ROOT", str(vault_dir))
+
+        mock_session = MagicMock()
+        with (
+            patch("knowledge.mcp.Session", return_value=mock_session),
+            patch("knowledge.mcp.get_engine"),
+            patch("knowledge.mcp.KnowledgeStore") as MockStore,
+        ):
+            MockStore.return_value.get_note_by_id.return_value = SAMPLE_NOTE
+            await edit_note("n1", title="Updated Title")
+
+        text = note_file.read_text()
+        assert "visibility: public" in text
+        assert "title: Updated Title" in text
+
+    @pytest.mark.asyncio
+    async def test_sets_visibility_when_passed(self, tmp_path, monkeypatch):
+        """Explicit visibility arg writes the field even if missing before."""
+        vault_dir = tmp_path / "vault"
+        vault_dir.mkdir()
+        note_file = vault_dir / "papers" / "attention.md"
+        note_file.parent.mkdir(parents=True)
+        note_file.write_text("---\nid: n1\ntitle: Original\n---\nOld body")
+
+        monkeypatch.setenv("VAULT_ROOT", str(vault_dir))
+
+        mock_session = MagicMock()
+        with (
+            patch("knowledge.mcp.Session", return_value=mock_session),
+            patch("knowledge.mcp.get_engine"),
+            patch("knowledge.mcp.KnowledgeStore") as MockStore,
+        ):
+            MockStore.return_value.get_note_by_id.return_value = SAMPLE_NOTE
+            await edit_note("n1", visibility="private")
+
+        assert "visibility: private" in note_file.read_text()
+
+    @pytest.mark.asyncio
+    async def test_rejects_invalid_visibility(self, tmp_path, monkeypatch):
+        result = await edit_note("n1", visibility="weird")
         assert "error" in result
 
 


### PR DESCRIPTION
## Summary

Two related fixes that close the silent-failure gaps surfaced by tonight's audit work:

- **MCP `edit_note` was silently dropping `visibility`** (and `created`, `updated`) on every rewrite. The fm_dict reassembly omitted any frontmatter field the tool's parameter list didn't explicitly cover. This is the root cause behind tonight's discovery that 3,225 atoms (74% of corpus) had null visibility despite earlier bulk classification: the subagents called `edit_note` to set visibility, the tool accepted the call and dropped the field, the reconciler propagated the null to DB, and the public graph silently shrank.
- **No CHECK constraint enforced valid (state, gap_class) combos.** The two independent column-level constraints admitted the cross-product, so the wrong-state combo `(classified, external)` was reachable. 231 such rows had accumulated by tonight and got cleaned up in the bulk re-classification pass.

## Commit 1: `fix(knowledge): preserve frontmatter on MCP edit_note + accept visibility`

- `edit_note` now mirrors `router.edit_note`'s exact field list when reassembling frontmatter (visibility, source, source_tier, aliases, edges, created, updated, extra)
- Both `edit_note` and `create_note` accept a new `visibility` parameter (validated against public/private)
- A comment block flags the drift risk so future readers see why this list must stay in sync with the HTTP version
- 5 new tests in `mcp_test.py` — one is the regression guard against tonight's exact failure mode (mirror the gardener's emit shape and assert visibility survives a title-only edit)

## Commit 2: `feat(knowledge): add CHECK constraint on gap (state, gap_class) combos`

- Atlas migration `20260530000000_gaps_state_class_combo.sql`
- Enumerates each valid pair per the classifier's documented lifecycle
- `discovered` is wildcard because the classifier's frontmatter edits to `gap_class` and `state` are sequential, not atomic; the reconciler may briefly persist the intermediate state
- Added as `VALID` (no NOT VALID stage) since tonight's cleanup left no bad rows

## Test plan

- [ ] CI green (`gh pr checks --watch`)
- [ ] After merge + rollout: any new gap classifier run that produced the bad combo would fail with CHECK violation (visible in monolith logs)
- [ ] Subsequent `edit_note(title="X")` calls on any note with visibility set preserve the visibility line

🤖 Generated with [Claude Code](https://claude.com/claude-code)