### PR TITLE
feat(knowledge): add daily DB-vs-file visibility drift detector

### DIFF
--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -1878,6 +1878,16 @@ py_test(
 )
 
 py_test(
+    name = "knowledge_drift_detector_test",
+    srcs = ["knowledge/drift_detector_test.py"],
+    imports = ["."],
+    deps = [
+        ":monolith_backend",
+        "@pip//pytest",
+    ],
+)
+
+py_test(
     name = "knowledge_profile_test",
     srcs = ["knowledge/profile_test.py"],
     imports = ["."],

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.85.0
+version: 0.86.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.85.0
+      targetRevision: 0.86.0
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/knowledge/drift_detector.py
+++ b/projects/monolith/knowledge/drift_detector.py
@@ -1,0 +1,156 @@
+"""Visibility drift detector: compare DB visibility column vs file frontmatter.
+
+Background: today's audit found 3225 atoms with null DB visibility despite
+earlier bulk classification work. The root cause was MCP edit_note silently
+dropping the visibility field on rewrite (fixed in PR #2380). This module
+is the defensive read-side counterpart that detects any future drift between
+file frontmatter and the DB column.
+
+Why drift can still happen even with the write-side fix:
+- Direct file edits (Joe-via-Obsidian, manual cleanup scripts) update the
+  file without going through the API
+- The reconciler is hash-based and only reprocesses files whose content
+  hash changed; in the brief window between an edit and the next
+  reconciler tick the DB and file disagree
+- Any future MCP/API write tool with a similar field-list bug
+
+The detector logs drift cases and emits a count via the standard logging
+path. There is no auto-healing -- a human reviews the warnings and decides
+whether to re-run set_note_visibility or repair the file.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+
+from sqlmodel import Session, select
+
+from knowledge import frontmatter
+from knowledge.models import Note
+from knowledge.service import DEFAULT_VAULT_ROOT, VAULT_ROOT_ENV
+
+logger = logging.getLogger(__name__)
+
+
+_MAX_SAMPLE_CASES = 100
+_MAX_LOGGED_CASES = 50
+
+
+@dataclass(frozen=True)
+class DriftCase:
+    note_id: str
+    path: str
+    db_visibility: str | None
+    file_visibility: str | None
+
+
+@dataclass(frozen=True)
+class DriftStats:
+    checked: int
+    drift_count: int
+    missing_files: int
+    parse_failures: int
+    drift_cases: tuple[DriftCase, ...] = field(default_factory=tuple)
+
+
+def detect_visibility_drift(session: Session, vault_root: Path) -> DriftStats:
+    """Scan all non-deleted notes and compare DB visibility vs file frontmatter.
+
+    For each note (excluding soft-deleted rows):
+    - DB visibility is read from the Note.visibility column
+    - File visibility is parsed from the frontmatter at vault_root/note.path
+    - A mismatch including the NULL/set asymmetry counts as drift
+
+    Returns a DriftStats with a bounded sample of drift cases. The total
+    count covers all drift; the cases tuple is capped at _MAX_SAMPLE_CASES
+    so a pathological scenario does not blow up memory or log buffers.
+    """
+    notes = list(session.scalars(select(Note).where(Note.deleted_at.is_(None))))
+
+    checked = 0
+    missing_files = 0
+    parse_failures = 0
+    total_drift = 0
+    sample_cases: list[DriftCase] = []
+
+    for note in notes:
+        file_path = vault_root / note.path
+        if not file_path.is_file():
+            missing_files += 1
+            continue
+
+        try:
+            raw = file_path.read_text()
+            parsed, _body = frontmatter.parse(raw)
+        except Exception:
+            # Malformed frontmatter is the reconciler's problem to surface;
+            # we just count it and move on with a single-line log so the
+            # drift sweep does not silently mask a parse regression.
+            logger.warning("knowledge.drift_detector: parse failed for %s", note.path)
+            parse_failures += 1
+            continue
+
+        checked += 1
+        if note.visibility != parsed.visibility:
+            total_drift += 1
+            if len(sample_cases) < _MAX_SAMPLE_CASES:
+                sample_cases.append(
+                    DriftCase(
+                        note_id=note.note_id,
+                        path=note.path,
+                        db_visibility=note.visibility,
+                        file_visibility=parsed.visibility,
+                    )
+                )
+
+    return DriftStats(
+        checked=checked,
+        drift_count=total_drift,
+        missing_files=missing_files,
+        parse_failures=parse_failures,
+        drift_cases=tuple(sample_cases),
+    )
+
+
+async def detect_drift_handler(session: Session) -> datetime | None:
+    """Scheduler handler: scan for visibility drift and log results.
+
+    Logs a one-line summary plus up to _MAX_LOGGED_CASES detail lines so
+    operators can spot regressions. Emits no exception even on partial
+    failure -- the next tick retries from scratch.
+    """
+    vault_root_str = os.environ.get(VAULT_ROOT_ENV, DEFAULT_VAULT_ROOT)
+    vault_root = Path(vault_root_str)
+    if not vault_root.is_dir():
+        logger.warning("knowledge.drift_detector: vault root missing: %s", vault_root)
+        return None
+
+    stats = detect_visibility_drift(session, vault_root)
+    logger.info(
+        "knowledge.drift_detector: checked=%d drift=%d missing=%d parse_fail=%d",
+        stats.checked,
+        stats.drift_count,
+        stats.missing_files,
+        stats.parse_failures,
+    )
+    for case in stats.drift_cases[:_MAX_LOGGED_CASES]:
+        logger.warning(
+            "knowledge.drift_detector: %s db=%s file=%s path=%s",
+            case.note_id,
+            case.db_visibility,
+            case.file_visibility,
+            case.path,
+        )
+    return None
+
+
+__all__ = [
+    "DriftCase",
+    "DriftStats",
+    "detect_visibility_drift",
+    "detect_drift_handler",
+]

--- a/projects/monolith/knowledge/drift_detector_test.py
+++ b/projects/monolith/knowledge/drift_detector_test.py
@@ -1,0 +1,201 @@
+"""Tests for knowledge.drift_detector."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+from sqlmodel import Session, SQLModel, create_engine
+from sqlmodel.pool import StaticPool
+
+from knowledge.drift_detector import (
+    DriftCase,
+    DriftStats,
+    detect_visibility_drift,
+)
+from knowledge.models import Note
+
+
+@pytest.fixture(name="session")
+def session_fixture():
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    original_schemas = {}
+    for table in SQLModel.metadata.tables.values():
+        if table.schema is not None:
+            original_schemas[table.name] = table.schema
+            table.schema = None
+    SQLModel.metadata.create_all(engine)
+    with Session(engine) as session:
+        yield session
+    for table in SQLModel.metadata.tables.values():
+        if table.name in original_schemas:
+            table.schema = original_schemas[table.name]
+
+
+def _make_note(
+    note_id: str,
+    path: str,
+    visibility: str | None = None,
+) -> Note:
+    return Note(
+        note_id=note_id,
+        path=path,
+        title=note_id,
+        type="atom",
+        content_hash="dummyhash",
+        visibility=visibility,
+        indexed_at=datetime.now(timezone.utc),
+    )
+
+
+def _write_atom(
+    vault_root: Path,
+    note_id: str,
+    visibility: str | None,
+) -> None:
+    file_path = vault_root / "_processed" / f"{note_id}.md"
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+    fm_lines = [f"id: {note_id}", f"title: {note_id}", "type: atom"]
+    if visibility is not None:
+        fm_lines.append(f"visibility: {visibility}")
+    file_path.write_text(
+        "---\n" + "\n".join(fm_lines) + "\n---\n\nbody for " + note_id + "\n"
+    )
+
+
+def test_no_drift_when_all_match(session, tmp_path):
+    """Both DB and file have the same visibility -> no drift cases."""
+    session.add(_make_note("a", "_processed/a.md", "public"))
+    session.add(_make_note("b", "_processed/b.md", "private"))
+    session.add(_make_note("c", "_processed/c.md", None))
+    session.commit()
+
+    _write_atom(tmp_path, "a", "public")
+    _write_atom(tmp_path, "b", "private")
+    _write_atom(tmp_path, "c", None)
+
+    stats = detect_visibility_drift(session, tmp_path)
+
+    assert stats.checked == 3
+    assert stats.drift_count == 0
+    assert stats.drift_cases == ()
+
+
+def test_drift_when_db_null_file_set(session, tmp_path):
+    """DB has NULL, file has visibility set -> drift case."""
+    session.add(_make_note("a", "_processed/a.md", None))
+    session.commit()
+    _write_atom(tmp_path, "a", "public")
+
+    stats = detect_visibility_drift(session, tmp_path)
+
+    assert stats.checked == 1
+    assert stats.drift_count == 1
+    assert len(stats.drift_cases) == 1
+    case = stats.drift_cases[0]
+    assert case.note_id == "a"
+    assert case.db_visibility is None
+    assert case.file_visibility == "public"
+
+
+def test_drift_when_db_set_file_null(session, tmp_path):
+    """DB has visibility, file has none -> drift case.
+
+    This is the exact failure mode the MCP edit_note bug produced:
+    file gets rewritten without visibility, DB still carries the old
+    value until reconciler propagates the null. Detector should catch
+    the gap.
+    """
+    session.add(_make_note("a", "_processed/a.md", "public"))
+    session.commit()
+    _write_atom(tmp_path, "a", None)
+
+    stats = detect_visibility_drift(session, tmp_path)
+
+    assert stats.drift_count == 1
+    case = stats.drift_cases[0]
+    assert case.db_visibility == "public"
+    assert case.file_visibility is None
+
+
+def test_drift_when_different_values(session, tmp_path):
+    """DB and file disagree on the value -> drift case."""
+    session.add(_make_note("a", "_processed/a.md", "public"))
+    session.commit()
+    _write_atom(tmp_path, "a", "private")
+
+    stats = detect_visibility_drift(session, tmp_path)
+
+    assert stats.drift_count == 1
+    case = stats.drift_cases[0]
+    assert case.db_visibility == "public"
+    assert case.file_visibility == "private"
+
+
+def test_missing_files_counted(session, tmp_path):
+    """Note row exists but the file is gone -> missing_files counter."""
+    session.add(_make_note("a", "_processed/ghost.md", "public"))
+    session.commit()
+
+    stats = detect_visibility_drift(session, tmp_path)
+
+    assert stats.checked == 0
+    assert stats.missing_files == 1
+    assert stats.drift_count == 0
+
+
+def test_parse_failure_counted(session, tmp_path):
+    """File present but unparseable frontmatter -> parse_failures counter."""
+    session.add(_make_note("a", "_processed/a.md", "public"))
+    session.commit()
+
+    bad_file = tmp_path / "_processed" / "a.md"
+    bad_file.parent.mkdir(parents=True, exist_ok=True)
+    bad_file.write_text("---\nthis: is: not: valid: yaml: : :\n---\nbody\n")
+
+    stats = detect_visibility_drift(session, tmp_path)
+
+    # Either parses with empty visibility (drift) or fails (parse_failures).
+    # Both outcomes are acceptable -- the contract is that we do not
+    # crash. Total signal across the two buckets covers the case.
+    assert stats.parse_failures + stats.drift_count >= 1
+
+
+def test_drift_cases_capped_at_sample_limit(session, tmp_path):
+    """Even with 200 drift cases the sample tuple stays bounded.
+
+    Protects against memory/log blow-up if every note in the vault drifts
+    at once (e.g. a future schema migration sets visibility to NULL on a
+    large slice).
+    """
+    notes = []
+    for i in range(150):
+        nid = f"n{i:03d}"
+        notes.append(_make_note(nid, f"_processed/{nid}.md", "public"))
+        _write_atom(tmp_path, nid, "private")
+    session.add_all(notes)
+    session.commit()
+
+    stats = detect_visibility_drift(session, tmp_path)
+
+    assert stats.drift_count == 150
+    assert len(stats.drift_cases) == 100
+
+
+def test_deleted_notes_skipped(session, tmp_path):
+    """Soft-deleted notes are not scanned even if their files still exist."""
+    deleted = _make_note("a", "_processed/a.md", "public")
+    deleted.deleted_at = datetime.now(timezone.utc)
+    session.add(deleted)
+    session.commit()
+    _write_atom(tmp_path, "a", "private")
+
+    stats = detect_visibility_drift(session, tmp_path)
+
+    assert stats.checked == 0
+    assert stats.drift_count == 0

--- a/projects/monolith/knowledge/service.py
+++ b/projects/monolith/knowledge/service.py
@@ -51,6 +51,12 @@ _RESEARCH_TTL_SECS = (
     # expires rather than racing against the in-flight run.
     1200
 )
+# Drift detector compares DB visibility column vs file frontmatter for
+# every non-deleted note. Daily cadence: drift is rare and a full scan
+# of ~5000 notes runs in well under a minute, so once a day catches
+# regressions without burning cycles.
+_DRIFT_INTERVAL_SECS = 86400
+_DRIFT_TTL_SECS = 600  # 10min ceiling on a single scan
 _GIT_READY_SENTINEL = ".git-ready"
 _SYNC_READY_SENTINEL = ".sync-ready"
 _GIT_AUTHOR = b"vault-backup <vault-backup@monolith.local>"
@@ -599,6 +605,16 @@ def on_startup(session: Session) -> None:
         interval_secs=_RESEARCH_INTERVAL_SECS,
         handler=research_gaps_handler,
         ttl_secs=_RESEARCH_TTL_SECS,
+    )
+
+    from knowledge.drift_detector import detect_drift_handler
+
+    register_job(
+        session,
+        name="knowledge.detect-drift",
+        interval_secs=_DRIFT_INTERVAL_SECS,
+        handler=detect_drift_handler,
+        ttl_secs=_DRIFT_TTL_SECS,
     )
 
     # One-shot stub reconciliation for the v2 gating migration. Cheap


### PR DESCRIPTION
## Summary

New `knowledge.drift_detector` module that compares DB `visibility` column vs file frontmatter `visibility` field for every non-deleted note. Drift cases are logged at WARNING level; the scan runs as a daily scheduled job via the standard `register_job` pattern.

Read-side complement to PR #2380 (MCP `edit_note` field-list bug). The write-side fix prevents the specific silent-null failure mode tonight's audit surfaced. This detector catches any future drift from:

- Direct file edits via Obsidian-sync or manual cleanup scripts that bypass the API
- The reconciler's hash-based diff that may briefly persist a file-DB disagreement between an edit and the next reconciler tick
- Any future MCP/API write path with a similar field-list bug

## Design choices

- **Detection only, no auto-healing.** Auto-healing would mask the underlying bug. A human reviews the warning log and decides whether to re-run `set_note_visibility` or repair the file.
- **Drift sample capped at 100 cases** to bound memory and log buffers even if a pathological scenario produces 1000s of mismatches.
- **Daily cadence (86400s).** Drift is rare and a full ~5000-note scan runs in under a minute; once a day catches regressions without burning cycles.
- **10-min TTL** gives ample headroom above the expected sub-minute runtime.

## Tests (8 cases)

- No-drift baseline (file + DB agree on public/private/null)
- Three mismatch shapes (db-null + file-set, db-set + file-null, different values)
- Missing-file handling (note row exists, file deleted)
- Parse-failure tolerance (unparseable frontmatter logs + counts)
- Sample cap bounds (150 drift cases produce 100-entry sample)
- Soft-deleted notes are skipped (defensive pattern from PR #2370)

## Test plan

- [ ] CI green (`gh pr checks --watch`)
- [ ] After merge + rollout: SigNoz captures the `knowledge.drift_detector` info line in monolith logs; drift count should be 0 in steady state. Any non-zero needs investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)