### PR TITLE
feat(knowledge): inline KEEP/SKIP rubric in gap classifier prompt

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.86.1
+version: 0.86.2
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.86.2
+version: 0.86.3
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.86.0
+version: 0.86.1
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.86.0
+      targetRevision: 0.86.1
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.86.1
+      targetRevision: 0.86.2
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.86.2
+      targetRevision: 0.86.3
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/knowledge/gap_classifier.py
+++ b/projects/monolith/knowledge/gap_classifier.py
@@ -24,11 +24,41 @@ import time
 from dataclasses import dataclass
 from pathlib import Path
 
+from knowledge.profile import (
+    RELEVANCE_EMPLOYER_CARVE_OUTS,
+    RELEVANCE_KEEP,
+    RELEVANCE_SKIP,
+)
+
 logger = logging.getLogger(__name__)
 
-CLASSIFIER_VERSION = "opus-4-7@v3"
+# v4 inlines the RELEVANCE_KEEP / RELEVANCE_SKIP rubric from profile.py so
+# the classifier parks SKIP-category terms (pop culture, religious history,
+# vendor marketing, etc.) on first classification instead of letting them
+# through as external. The night-of-2026-05-29 audit caught 428 such gaps
+# that the v3 prompt had wrongly marked external -- v4 closes that gap by
+# giving the classifier the same rubric Joe uses for manual triage.
+CLASSIFIER_VERSION = "opus-4-7@v4"
 
 _CLASSIFY_TIMEOUT_SECS = 300  # 5 minutes per batch — generous for N=10 stubs
+
+
+def _format_relevance_keep() -> str:
+    """Render RELEVANCE_KEEP as bullet text for the classifier prompt."""
+    return "\n".join(
+        f"- **{row['domain']}**: {row['signals']}" for row in RELEVANCE_KEEP
+    )
+
+
+def _format_relevance_skip() -> str:
+    """Render RELEVANCE_SKIP as bullet text for the classifier prompt."""
+    return "\n".join(
+        f"- **{row['category']}**: {row['examples']}" for row in RELEVANCE_SKIP
+    )
+
+
+_RELEVANCE_KEEP_TEXT = _format_relevance_keep()
+_RELEVANCE_SKIP_TEXT = _format_relevance_skip()
 
 
 _CLASSIFIER_PROMPT = """\
@@ -48,6 +78,33 @@ Obsidian vault — into four classes.
   user's specific setup is personal.
 - **parked**: queryable but not worth current budget. Example: highly
   niche terms, project-specific jargon that may never be revisited.
+
+## Relevance rubric (Joe's profile)
+
+The four-class decision must consider BOTH whether a term is publicly
+researchable AND whether it falls in a KEEP or SKIP domain per Joe's
+relevance profile. If the term clearly matches a SKIP category,
+classify it as `parked` even though it is publicly researchable --
+the research budget should not be spent on out-of-domain content.
+
+### KEEP domains -- worth research budget (verdict tends `external`)
+
+{relevance_keep}
+
+### SKIP categories -- NOT worth research budget (verdict: `parked`)
+
+{relevance_skip}
+
+### Carve-outs
+
+{carve_outs}
+
+A term that clearly fits a KEEP domain and is publicly researchable
+should be `external`. A term in a KEEP domain that requires Joe's
+specific annotation (his configuration, his project context) is
+`hybrid`. A term that is publicly researchable but matches SKIP is
+`parked`. A term that only Joe can resolve (named friend, his
+journal, his specific decision) is `internal`.
 
 ## Rules
 
@@ -149,6 +206,9 @@ async def classify_stubs(
     prompt = _CLASSIFIER_PROMPT.format(
         classifier_version=CLASSIFIER_VERSION,
         stub_list=stub_list,
+        relevance_keep=_RELEVANCE_KEEP_TEXT,
+        relevance_skip=_RELEVANCE_SKIP_TEXT,
+        carve_outs=RELEVANCE_EMPLOYER_CARVE_OUTS,
     )
 
     start = time.monotonic()

--- a/projects/monolith/knowledge/gap_classifier_test.py
+++ b/projects/monolith/knowledge/gap_classifier_test.py
@@ -179,12 +179,66 @@ def test_classifier_prompt_explicitly_forbids_appending_duplicate_keys():
     # Sanity: ensure the .format() placeholders are still intact and the prompt
     # still substitutes cleanly. Catches stray `{` / `}` accidentally introduced
     # to the prompt body.
+    from knowledge.gap_classifier import (
+        _RELEVANCE_KEEP_TEXT,
+        _RELEVANCE_SKIP_TEXT,
+    )
+    from knowledge.profile import RELEVANCE_EMPLOYER_CARVE_OUTS
+
     rendered = _CLASSIFIER_PROMPT.format(
         classifier_version=CLASSIFIER_VERSION,
         stub_list="- /tmp/example.md",
+        relevance_keep=_RELEVANCE_KEEP_TEXT,
+        relevance_skip=_RELEVANCE_SKIP_TEXT,
+        carve_outs=RELEVANCE_EMPLOYER_CARVE_OUTS,
     )
     assert CLASSIFIER_VERSION in rendered
     assert "/tmp/example.md" in rendered
+
+
+def test_classifier_prompt_inlines_relevance_rubric():
+    """Drift detector for the profile.py -> classifier prompt wiring.
+
+    PR #2378 promoted Joe's relevance rubric to typed Python constants;
+    this test pins that those constants actually reach the classifier
+    prompt rendered at runtime. If anyone refactors the .format() call
+    site without passing the rubric, the prompt would silently revert
+    to the v3 four-class-only shape and SKIP-category gaps would once
+    again leak through as external.
+    """
+    from knowledge.gap_classifier import (
+        _RELEVANCE_KEEP_TEXT,
+        _RELEVANCE_SKIP_TEXT,
+    )
+    from knowledge.profile import (
+        RELEVANCE_EMPLOYER_CARVE_OUTS,
+        RELEVANCE_KEEP,
+        RELEVANCE_SKIP,
+    )
+
+    rendered = _CLASSIFIER_PROMPT.format(
+        classifier_version=CLASSIFIER_VERSION,
+        stub_list="- /tmp/example.md",
+        relevance_keep=_RELEVANCE_KEEP_TEXT,
+        relevance_skip=_RELEVANCE_SKIP_TEXT,
+        carve_outs=RELEVANCE_EMPLOYER_CARVE_OUTS,
+    )
+
+    # A sample of KEEP domains and SKIP categories should appear verbatim.
+    assert RELEVANCE_KEEP[0]["domain"] in rendered, (
+        "first KEEP domain missing from rendered prompt"
+    )
+    assert RELEVANCE_SKIP[0]["category"] in rendered, (
+        "first SKIP category missing from rendered prompt"
+    )
+    assert RELEVANCE_EMPLOYER_CARVE_OUTS in rendered, (
+        "carve-out paragraph missing from rendered prompt"
+    )
+    # The explanatory framing that ties the rubric to the four-class decision
+    # must survive prompt edits -- this is the load-bearing instruction.
+    assert "matches SKIP" in rendered or "matches a SKIP" in rendered, (
+        "prompt must instruct that SKIP-matching terms get parked"
+    )
 
 
 def test_classifier_prompt_routes_internal_hybrid_external_to_in_review():

--- a/projects/monolith/knowledge/gap_classifier_test.py
+++ b/projects/monolith/knowledge/gap_classifier_test.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 import pytest
 
+from knowledge.profile import RELEVANCE_EMPLOYER_CARVE_OUTS
 from knowledge.gap_classifier import (
     _CLASSIFIER_PROMPT,
     _RELEVANCE_KEEP_TEXT,

--- a/projects/monolith/knowledge/gap_classifier_test.py
+++ b/projects/monolith/knowledge/gap_classifier_test.py
@@ -317,7 +317,7 @@ def test_classifier_prompt_includes_person_public_peer_subclassification():
         "public-figure examples must be present so the rubric is concrete "
         "for the LLM (abstract definitions alone get misapplied)"
     )
-    assert CLASSIFIER_VERSION == "opus-4-7@v3", (
+    assert CLASSIFIER_VERSION == "opus-4-7@v4", (
         "version bump propagates into stub frontmatter so future-Joe can "
         "query for which classifier produced which atom"
     )

--- a/projects/monolith/knowledge/gap_classifier_test.py
+++ b/projects/monolith/knowledge/gap_classifier_test.py
@@ -10,6 +10,8 @@ import pytest
 
 from knowledge.gap_classifier import (
     _CLASSIFIER_PROMPT,
+    _RELEVANCE_KEEP_TEXT,
+    _RELEVANCE_SKIP_TEXT,
     CLASSIFIER_VERSION,
     ClassifyStats,
     classify_stubs,
@@ -258,6 +260,9 @@ def test_classifier_prompt_routes_internal_hybrid_external_to_in_review():
     rendered = _CLASSIFIER_PROMPT.format(
         classifier_version=CLASSIFIER_VERSION,
         stub_list="- /tmp/example.md",
+        relevance_keep=_RELEVANCE_KEEP_TEXT,
+        relevance_skip=_RELEVANCE_SKIP_TEXT,
+        carve_outs=RELEVANCE_EMPLOYER_CARVE_OUTS,
     )
 
     # Both terminal-ish statuses must be reachable from the prompt:
@@ -301,6 +306,9 @@ def test_classifier_prompt_includes_person_public_peer_subclassification():
     rendered = _CLASSIFIER_PROMPT.format(
         classifier_version=CLASSIFIER_VERSION,
         stub_list="- /tmp/example.md",
+        relevance_keep=_RELEVANCE_KEEP_TEXT,
+        relevance_skip=_RELEVANCE_SKIP_TEXT,
+        carve_outs=RELEVANCE_EMPLOYER_CARVE_OUTS,
     )
     assert "person:public" in rendered, "v3 must teach the person:public sub-tag"
     assert "person:peer" in rendered, "v3 must teach the person:peer sub-tag"


### PR DESCRIPTION
## Summary

The OLD gap classifier prompt only had the 4-class rubric (external/internal/hybrid/parked); it had **no notion of which terms were worth the research budget**. So whenever a wikilink pointed at a SKIP-category topic (pop culture, religious history, vendor trivia, Hearthstone Battlegrounds, FDR-era political stubs, etc.), it got marked `external` and entered the research pipeline.

Tonight's audit found **428 such gaps** that should have been parked on first classification. The bulk re-classification pass cleaned them up via SQL; this PR closes the root cause so future runs do not produce them.

## How

PR #2378 promoted Joe's relevance rubric to typed Python constants in `profile.py`. This PR wires those constants into the classifier prompt:

- Imports `RELEVANCE_KEEP`, `RELEVANCE_SKIP`, `RELEVANCE_EMPLOYER_CARVE_OUTS`
- Renders KEEP and SKIP as bullet lists once at module load time
- Injects the rendered text via three new prompt placeholders (`{relevance_keep}`, `{relevance_skip}`, `{carve_outs}`)
- Updates both `.format()` call sites

The new prompt section explains the join between the four-class rubric and the relevance rubric:

> A term that fits a KEEP domain and is publicly researchable → `external`. A term in a KEEP domain that needs Joe's annotation → `hybrid`. A term that is publicly researchable but matches SKIP → `parked`. A term that only Joe can resolve → `internal`.

`CLASSIFIER_VERSION` bumped to `opus-4-7@v4` so downstream consumers can distinguish rubric-aware classifications from the v3 four-class-only ones. **No migration needed** — the classifier overwrites `classifier_version` every run, so v3-stamped stubs get re-classified at v4 on their next tick.

## Tests

- `test_classifier_prompt_inlines_relevance_rubric` (new): drift detector pinning the profile.py → prompt wiring. If a future refactor drops the rubric placeholders from the `.format()` call, this test fails before the regression reaches prod.
- Existing prompt assertions updated to pass the new placeholders.

## Test plan

- [ ] CI green (`gh pr checks --watch`)
- [ ] After merge + rollout: next classifier tick produces v4-stamped classifications; spot-check that any SKIP-category term recently emitted now lands in `parked` rather than `in_review/external`

🤖 Generated with [Claude Code](https://claude.com/claude-code)