### PR TITLE
feat(knowledge): notes RAG chat backed by in-cluster Qwen

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.85.0
+version: 0.86.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.85.0
+      targetRevision: 0.86.0
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/lib/components/notes/NotesChat.svelte
+++ b/projects/monolith/frontend/src/lib/components/notes/NotesChat.svelte
@@ -1,0 +1,434 @@
+<script>
+  /**
+   * Collapsible RAG chat panel for the notes knowledge graph.
+   *
+   * Props:
+   *   apiBase  – backend chat endpoint prefix (e.g. "/api/knowledge/public")
+   *   isPublic – true for the public page (shows rate-limit badge and notice)
+   */
+  let { apiBase = "/api/knowledge", isPublic = false } = $props();
+
+  // ── state ───────────────────────────────────────────────────────────
+  let open = $state(false);
+  let question = $state("");
+  let messages = $state(/** @type {Array<{role:string,text:string,error?:boolean}>} */ ([]));
+  let streaming = $state(false);
+  let inputRef = $state(null);
+
+  // Rate-limit tracking (public endpoint exposes headers).
+  let rlRemaining = $state(null); // null = unknown
+  let rlLimit = $state(null);
+  let rlReset = $state(null); // epoch seconds
+  let rateLimited = $state(false);
+  let retryIn = $state(0);
+
+  $effect(() => {
+    if (open && inputRef) inputRef.focus();
+  });
+
+  function toggle() {
+    open = !open;
+  }
+
+  function formatReset(epoch) {
+    if (!epoch) return "";
+    const diff = Math.max(0, Math.ceil(epoch - Date.now() / 1000));
+    if (diff === 0) return "now";
+    return `${diff}s`;
+  }
+
+  function remainingLabel() {
+    if (!isPublic || rlLimit === null) return null;
+    return `${rlRemaining ?? "?"}/${rlLimit} req/min`;
+  }
+
+  async function submit(e) {
+    e.preventDefault();
+    const q = question.trim();
+    if (!q || streaming) return;
+
+    question = "";
+    messages = [...messages, { role: "user", text: q }];
+    streaming = true;
+    rateLimited = false;
+
+    const assistantIdx = messages.length;
+    messages = [...messages, { role: "assistant", text: "" }];
+
+    try {
+      const res = await fetch(`${apiBase}/chat`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ question: q }),
+      });
+
+      // Parse rate-limit headers (present on both 200 and 429).
+      if (isPublic) {
+        const limit = res.headers.get("X-RateLimit-Limit");
+        const remaining = res.headers.get("X-RateLimit-Remaining");
+        const reset = res.headers.get("X-RateLimit-Reset");
+        if (limit) rlLimit = parseInt(limit);
+        if (remaining) rlRemaining = parseInt(remaining);
+        if (reset) rlReset = parseInt(reset);
+      }
+
+      if (res.status === 429) {
+        const body = await res.json();
+        rateLimited = true;
+        retryIn = body.retry_after ?? 60;
+        messages = messages.map((m, i) =>
+          i === assistantIdx
+            ? { role: "assistant", text: body.message ?? "Rate limited.", error: true }
+            : m,
+        );
+        streaming = false;
+        return;
+      }
+
+      if (!res.ok) {
+        throw new Error(`HTTP ${res.status}`);
+      }
+
+      const reader = res.body.getReader();
+      const decoder = new TextDecoder();
+      let buf = "";
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        buf += decoder.decode(value, { stream: true });
+        const lines = buf.split("\n");
+        buf = lines.pop() ?? "";
+        for (const line of lines) {
+          if (!line.startsWith("data:")) continue;
+          const raw = line.slice(5).trim();
+          if (!raw) continue;
+          try {
+            const evt = JSON.parse(raw);
+            if (evt.type === "text_chunk") {
+              messages = messages.map((m, i) =>
+                i === assistantIdx ? { ...m, text: m.text + evt.text } : m,
+              );
+            } else if (evt.type === "error") {
+              messages = messages.map((m, i) =>
+                i === assistantIdx
+                  ? { ...m, text: evt.message ?? "Error from inference.", error: true }
+                  : m,
+              );
+            }
+          } catch {
+            // malformed chunk — ignore
+          }
+        }
+      }
+    } catch (err) {
+      messages = messages.map((m, i) =>
+        i === assistantIdx ? { ...m, text: "Connection error.", error: true } : m,
+      );
+    } finally {
+      streaming = false;
+    }
+  }
+
+  function onKeydown(e) {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      submit(e);
+    }
+  }
+</script>
+
+<!-- ── Toggle button ─────────────────────────────────────────────── -->
+<button
+  class="chat-toggle"
+  class:open
+  onclick={toggle}
+  aria-label={open ? "Close notes chat" : "Ask the notes"}
+  aria-expanded={open}
+>
+  <span class="toggle-label">
+    {open ? "✕ CLOSE" : "ASK THE NOTES"}
+  </span>
+  {#if isPublic && rlLimit !== null && !open}
+    <span class="rl-badge">{rlRemaining ?? rlLimit}/{rlLimit}</span>
+  {/if}
+</button>
+
+<!-- ── Chat panel ────────────────────────────────────────────────── -->
+{#if open}
+  <div class="chat-panel" role="complementary" aria-label="Notes chat">
+    <div class="chat-header">
+      <span class="eyebrow">ASK THE NOTES</span>
+      {#if isPublic}
+        <span class="rl-notice" title="Running on Joe's in-cluster GPU — rate limited to {rlLimit ?? 5} req/min to prevent abuse">
+          ⚡ in-cluster · {rlLimit ?? 5} req/min
+          {#if rlRemaining !== null}
+            · {rlRemaining} left
+            {#if rlReset}· resets {formatReset(rlReset)}{/if}
+          {/if}
+        </span>
+      {/if}
+    </div>
+
+    <div class="chat-messages" aria-live="polite">
+      {#if messages.length === 0}
+        <p class="chat-empty">Ask anything about these notes.</p>
+      {/if}
+      {#each messages as msg}
+        <div class="msg msg-{msg.role}" class:error={msg.error}>
+          <span class="msg-role">{msg.role === "user" ? "YOU" : "NOTES"}</span>
+          <span class="msg-text">{msg.text}</span>
+          {#if msg.role === "assistant" && streaming && !msg.text}
+            <span class="cursor">▋</span>
+          {/if}
+        </div>
+      {/each}
+    </div>
+
+    {#if rateLimited}
+      <div class="rate-limit-banner">
+        ⏸ Rate limited — this runs on Joe's homelab GPU.
+        Retry in {retryIn}s.
+        <span class="rl-explain">
+          Intentionally throttled at {rlLimit ?? 5} req/min to prevent abuse on shared in-cluster infra.
+        </span>
+      </div>
+    {/if}
+
+    <form class="chat-input-row" onsubmit={submit}>
+      <textarea
+        bind:this={inputRef}
+        bind:value={question}
+        onkeydown={onKeydown}
+        placeholder="Ask a question…"
+        rows="2"
+        disabled={streaming}
+        aria-label="Your question"
+      ></textarea>
+      <button type="submit" class="send-btn" disabled={streaming || !question.trim()}>
+        {streaming ? "…" : "→"}
+      </button>
+    </form>
+  </div>
+{/if}
+
+<style>
+  /* ── Toggle button ────────────────────────────────────────────── */
+  .chat-toggle {
+    position: absolute;
+    bottom: 20px;
+    right: 20px;
+    z-index: 10;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    background: #ffde01;
+    border: 1.5px solid #141414;
+    box-shadow: 4px 4px 0 #141414;
+    font-family: "JetBrains Mono", ui-monospace, "SF Mono", monospace;
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: #141414;
+    padding: 8px 14px;
+    cursor: pointer;
+    transition:
+      transform 100ms ease,
+      box-shadow 100ms ease;
+  }
+
+  .chat-toggle:hover {
+    transform: translate(-2px, -2px);
+    box-shadow: 6px 6px 0 #141414;
+  }
+
+  .chat-toggle:active {
+    transform: none;
+    box-shadow: 2px 2px 0 #141414;
+  }
+
+  .chat-toggle.open {
+    background: #f1ebdc;
+  }
+
+  .rl-badge {
+    background: #141414;
+    color: #ffde01;
+    font-size: 9px;
+    padding: 1px 5px;
+    letter-spacing: 0.08em;
+  }
+
+  /* ── Chat panel ──────────────────────────────────────────────── */
+  .chat-panel {
+    position: absolute;
+    bottom: 64px;
+    right: 20px;
+    z-index: 10;
+    width: 380px;
+    max-width: calc(100vw - 40px);
+    background: #ffffff;
+    border: 1.5px solid #141414;
+    box-shadow: 6px 6px 0 #141414;
+    display: flex;
+    flex-direction: column;
+    font-family: "JetBrains Mono", ui-monospace, "SF Mono", monospace;
+    font-size: 12px;
+    color: #141414;
+    max-height: 60vh;
+  }
+
+  .chat-header {
+    display: flex;
+    align-items: baseline;
+    gap: 10px;
+    flex-wrap: wrap;
+    padding: 8px 12px 6px;
+    border-bottom: 1.5px solid #141414;
+    background: #f1ebdc;
+  }
+
+  .eyebrow {
+    font-size: 9px;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: #6b6658;
+    flex-shrink: 0;
+  }
+
+  .rl-notice {
+    font-size: 9px;
+    letter-spacing: 0.06em;
+    color: #6b6658;
+    flex: 1;
+    text-align: right;
+    cursor: help;
+  }
+
+  /* ── Messages ─────────────────────────────────────────────────── */
+  .chat-messages {
+    flex: 1;
+    overflow-y: auto;
+    padding: 10px 12px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    scrollbar-width: thin;
+    scrollbar-color: #ddd5c3 transparent;
+  }
+
+  .chat-empty {
+    color: #8a857a;
+    font-size: 11px;
+    letter-spacing: 0.04em;
+    text-align: center;
+    margin-top: 12px;
+  }
+
+  .msg {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+
+  .msg-role {
+    font-size: 8px;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: #8a857a;
+  }
+
+  .msg-user .msg-role {
+    color: #141414;
+  }
+
+  .msg-text {
+    white-space: pre-wrap;
+    word-break: break-word;
+    line-height: 1.5;
+    font-size: 12px;
+  }
+
+  .msg.error .msg-text {
+    color: #ff7169;
+  }
+
+  .cursor {
+    display: inline-block;
+    animation: blink 900ms step-end infinite;
+  }
+
+  @keyframes blink {
+    50% { opacity: 0; }
+  }
+
+  /* ── Rate-limit banner ─────────────────────────────────────────── */
+  .rate-limit-banner {
+    padding: 8px 12px;
+    background: #fff3cd;
+    border-top: 1.5px solid #141414;
+    font-size: 10px;
+    line-height: 1.5;
+    color: #141414;
+  }
+
+  .rl-explain {
+    display: block;
+    color: #6b6658;
+    margin-top: 2px;
+    font-size: 9px;
+    letter-spacing: 0.04em;
+  }
+
+  /* ── Input row ─────────────────────────────────────────────────── */
+  .chat-input-row {
+    display: flex;
+    gap: 0;
+    border-top: 1.5px solid #141414;
+  }
+
+  textarea {
+    flex: 1;
+    border: none;
+    outline: none;
+    resize: none;
+    padding: 8px 10px;
+    font-family: inherit;
+    font-size: 12px;
+    background: #f8f6f0;
+    color: #141414;
+    caret-color: #ff7169;
+    line-height: 1.5;
+  }
+
+  textarea::placeholder {
+    color: rgba(20, 20, 20, 0.32);
+  }
+
+  textarea:disabled {
+    opacity: 0.6;
+  }
+
+  .send-btn {
+    width: 40px;
+    border: none;
+    border-left: 1.5px solid #141414;
+    background: #141414;
+    color: #ffde01;
+    font-family: inherit;
+    font-size: 16px;
+    cursor: pointer;
+    transition: background 100ms ease;
+    flex-shrink: 0;
+  }
+
+  .send-btn:hover:not(:disabled) {
+    background: #2a2824;
+  }
+
+  .send-btn:disabled {
+    background: #8a857a;
+    cursor: not-allowed;
+  }
+</style>

--- a/projects/monolith/frontend/src/routes/private/notes/+page.svelte
+++ b/projects/monolith/frontend/src/routes/private/notes/+page.svelte
@@ -4,6 +4,7 @@
   import GraphLegend from "$lib/components/notes/GraphLegend.svelte";
   import GraphSearch from "$lib/components/notes/GraphSearch.svelte";
   import StatusBar from "$lib/components/notes/StatusBar.svelte";
+  import NotesChat from "$lib/components/notes/NotesChat.svelte";
 
   let { data } = $props();
 
@@ -77,6 +78,7 @@
       onClose={() => (selectedId = null)}
       apiBase="/api/knowledge/notes"
     />
+    <NotesChat apiBase="/api/knowledge" isPublic={false} />
   </div>
 </div>
 

--- a/projects/monolith/frontend/src/routes/public/notes/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/notes/+page.svelte
@@ -4,6 +4,7 @@
   import GraphLegend from "$lib/components/notes/GraphLegend.svelte";
   import GraphSearch from "$lib/components/notes/GraphSearch.svelte";
   import StatusBar from "$lib/components/notes/StatusBar.svelte";
+  import NotesChat from "$lib/components/notes/NotesChat.svelte";
 
   let { data } = $props();
 
@@ -69,6 +70,7 @@
       onClose={() => (selectedId = null)}
       apiBase="/api/knowledge/public/notes"
     />
+    <NotesChat apiBase="/api/knowledge/public" isPublic={true} />
   </div>
 </div>
 

--- a/projects/monolith/knowledge/chat.py
+++ b/projects/monolith/knowledge/chat.py
@@ -137,7 +137,9 @@ async def stream_chat_response(
             async with client.stream("POST", url, json=payload) as resp:
                 if resp.status_code != 200:
                     body = await resp.aread()
-                    logger.error("notes_chat: upstream %d %s", resp.status_code, body[:200])
+                    logger.error(
+                        "notes_chat: upstream %d %s", resp.status_code, body[:200]
+                    )
                     yield 'data: {"type":"error","message":"inference unavailable"}\n\n'
                     return
 
@@ -155,7 +157,7 @@ async def stream_chat_response(
                         delta = obj["choices"][0]["delta"]
                         text = delta.get("content") or ""
                         if text:
-                            yield f'data: {json.dumps({"type": "text_chunk", "text": text})}\n\n'
+                            yield f"data: {json.dumps({'type': 'text_chunk', 'text': text})}\n\n"
                     except Exception:
                         pass
 

--- a/projects/monolith/knowledge/chat.py
+++ b/projects/monolith/knowledge/chat.py
@@ -1,0 +1,168 @@
+"""Notes chat: RAG over public (or all) notes streamed from in-cluster Qwen.
+
+Rate limiting for the public endpoint: a per-IP token bucket that allows
+RATE_LIMIT_RPM requests per minute with a burst equal to RATE_LIMIT_BURST.
+Limit state lives in-process; across multiple replicas each pod enforces
+independently (fine for homelab abuse-prevention, not accounting-grade).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import time
+from typing import AsyncIterator
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+# Public endpoint rate limit: 5 req/min per IP, burst up to 5.
+RATE_LIMIT_RPM = int(os.environ.get("PUBLIC_CHAT_RATE_LIMIT_RPM", "5"))
+RATE_LIMIT_BURST = int(os.environ.get("PUBLIC_CHAT_RATE_LIMIT_BURST", "5"))
+
+# vLLM / llama.cpp endpoint (OpenAI-compatible).
+LLAMA_CPP_URL = os.environ.get("LLAMA_CPP_URL", "")
+MODEL_NAME = os.environ.get("NOTES_CHAT_MODEL", "qwen3.6-27b")
+MAX_CONTEXT_NOTES = 6
+MAX_TOKENS = 512
+
+_SYSTEM_PROMPT = (
+    "You are a concise assistant that answers questions about Joe's personal knowledge base. "
+    "You are given a selection of relevant note snippets as context. "
+    "Answer only from the provided context. If the context does not contain enough information "
+    "to answer confidently, say so. Keep answers short and precise — this is a knowledge lookup, "
+    "not a chat. Do not invent facts not supported by the notes."
+)
+
+
+class _Bucket:
+    """Token bucket for one IP address."""
+
+    __slots__ = ("tokens", "last_refill", "_lock")
+
+    def __init__(self) -> None:
+        self.tokens: float = float(RATE_LIMIT_BURST)
+        self.last_refill: float = time.monotonic()
+        self._lock = asyncio.Lock()
+
+    async def consume(self) -> tuple[bool, int, float]:
+        """Try to consume one token.
+
+        Returns (allowed, remaining, reset_at_epoch).
+        reset_at_epoch is the wall-clock second when the bucket will be full.
+        """
+        async with self._lock:
+            now = time.monotonic()
+            elapsed = now - self.last_refill
+            refill = elapsed * (RATE_LIMIT_RPM / 60.0)
+            self.tokens = min(float(RATE_LIMIT_BURST), self.tokens + refill)
+            self.last_refill = now
+
+            remaining_tokens = max(0, int(self.tokens) - 1)
+            seconds_to_full = (RATE_LIMIT_BURST - self.tokens) / (RATE_LIMIT_RPM / 60.0)
+            reset_at = time.time() + max(0.0, seconds_to_full)
+
+            if self.tokens >= 1:
+                self.tokens -= 1
+                return True, remaining_tokens, reset_at
+            return False, 0, reset_at
+
+
+class PublicNotesRateLimiter:
+    """Per-IP token-bucket rate limiter for the public chat endpoint."""
+
+    def __init__(self) -> None:
+        self._buckets: dict[str, _Bucket] = {}
+        self._lock = asyncio.Lock()
+
+    async def check(self, ip: str) -> tuple[bool, int, float]:
+        """Return (allowed, remaining, reset_epoch) for the given IP."""
+        async with self._lock:
+            if ip not in self._buckets:
+                self._buckets[ip] = _Bucket()
+        return await self._buckets[ip].consume()
+
+
+# Module-level singleton shared across requests.
+public_limiter = PublicNotesRateLimiter()
+
+
+def _build_context(results: list[dict]) -> str:
+    """Format top search results as a context block for the LLM."""
+    parts = []
+    for r in results[:MAX_CONTEXT_NOTES]:
+        title = r.get("title", "untitled")
+        snippet = r.get("snippet", "").strip()
+        section = r.get("section", "")
+        if section:
+            parts.append(f"## {title} — {section}\n{snippet}")
+        else:
+            parts.append(f"## {title}\n{snippet}")
+    return "\n\n".join(parts)
+
+
+async def stream_chat_response(
+    question: str,
+    context: str,
+    base_url: str | None = None,
+) -> AsyncIterator[str]:
+    """Yield SSE text lines streaming the Qwen answer.
+
+    Each yielded string is a complete SSE line (``data: {...}\\n\\n``).
+    Yields a terminal ``data: [DONE]\\n\\n`` when the stream ends.
+    """
+    url = (base_url or LLAMA_CPP_URL).rstrip("/") + "/v1/chat/completions"
+
+    messages = [
+        {"role": "system", "content": _SYSTEM_PROMPT},
+        {
+            "role": "user",
+            "content": f"Context from notes:\n\n{context}\n\nQuestion: {question}",
+        },
+    ]
+
+    payload = {
+        "model": MODEL_NAME,
+        "messages": messages,
+        "stream": True,
+        "max_tokens": MAX_TOKENS,
+        # Disable thinking to keep latency acceptable for a web UI.
+        "chat_template_kwargs": {"enable_thinking": False},
+    }
+
+    try:
+        async with httpx.AsyncClient(timeout=60.0) as client:
+            async with client.stream("POST", url, json=payload) as resp:
+                if resp.status_code != 200:
+                    body = await resp.aread()
+                    logger.error("notes_chat: upstream %d %s", resp.status_code, body[:200])
+                    yield 'data: {"type":"error","message":"inference unavailable"}\n\n'
+                    return
+
+                async for line in resp.aiter_lines():
+                    if not line.startswith("data:"):
+                        continue
+                    chunk = line[5:].strip()
+                    if chunk == "[DONE]":
+                        break
+                    # Parse delta content and re-emit as our own event shape.
+                    try:
+                        import json
+
+                        obj = json.loads(chunk)
+                        delta = obj["choices"][0]["delta"]
+                        text = delta.get("content") or ""
+                        if text:
+                            yield f'data: {json.dumps({"type": "text_chunk", "text": text})}\n\n'
+                    except Exception:
+                        pass
+
+        yield 'data: {"type":"done"}\n\n'
+    except httpx.TimeoutException:
+        logger.warning("notes_chat: upstream timeout")
+        yield 'data: {"type":"error","message":"inference timed out"}\n\n'
+    except Exception:
+        logger.exception("notes_chat: unexpected error")
+        yield 'data: {"type":"error","message":"internal error"}\n\n'

--- a/projects/monolith/knowledge/chat_test.py
+++ b/projects/monolith/knowledge/chat_test.py
@@ -35,8 +35,7 @@ class TestBuildContext:
 
     def test_caps_at_max_context_notes(self):
         results = [
-            {"title": f"Note {i}", "snippet": "x", "section": ""}
-            for i in range(10)
+            {"title": f"Note {i}", "snippet": "x", "section": ""} for i in range(10)
         ]
         ctx = _build_context(results)
         # Only MAX_CONTEXT_NOTES (6) should appear.
@@ -121,9 +120,7 @@ def _client_with_overrides():
 class TestPublicChatEndpoint:
     def test_short_question_returns_400(self, _client_with_overrides):
         client, *_ = _client_with_overrides
-        res = client.post(
-            "/api/knowledge/public/chat", json={"question": "hi"}
-        )
+        res = client.post("/api/knowledge/public/chat", json={"question": "hi"})
         assert res.status_code == 400
 
     def test_rate_limit_headers_present_on_success(self, _client_with_overrides):
@@ -139,9 +136,7 @@ class TestPublicChatEndpoint:
             patch("knowledge.router.stream_chat_response", side_effect=_fake_stream),
             patch("knowledge.router.public_limiter") as mock_limiter,
         ):
-            mock_limiter.check = AsyncMock(
-                return_value=(True, 4, time.time() + 60)
-            )
+            mock_limiter.check = AsyncMock(return_value=(True, 4, time.time() + 60))
             res = client.post(
                 "/api/knowledge/public/chat",
                 json={"question": "what are transformers?"},
@@ -154,9 +149,7 @@ class TestPublicChatEndpoint:
         client, *_ = _client_with_overrides
 
         with patch("knowledge.router.public_limiter") as mock_limiter:
-            mock_limiter.check = AsyncMock(
-                return_value=(False, 0, time.time() + 30)
-            )
+            mock_limiter.check = AsyncMock(return_value=(False, 0, time.time() + 30))
             res = client.post(
                 "/api/knowledge/public/chat",
                 json={"question": "what are transformers?"},

--- a/projects/monolith/knowledge/chat_test.py
+++ b/projects/monolith/knowledge/chat_test.py
@@ -1,0 +1,168 @@
+"""Tests for knowledge/chat.py — rate limiter and stream helper."""
+
+import asyncio
+import json
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.db import get_session
+from app.main import app
+from knowledge.chat import PublicNotesRateLimiter, _build_context
+from knowledge.router import get_embedding_client
+
+
+# ── _build_context ──────────────────────────────────────────────────
+
+
+class TestBuildContext:
+    def test_includes_title_and_snippet(self):
+        results = [
+            {"title": "Foo", "snippet": "bar baz", "section": ""},
+        ]
+        ctx = _build_context(results)
+        assert "Foo" in ctx
+        assert "bar baz" in ctx
+
+    def test_section_appended_when_present(self):
+        results = [
+            {"title": "T", "snippet": "body", "section": "## Intro"},
+        ]
+        ctx = _build_context(results)
+        assert "## Intro" in ctx
+
+    def test_caps_at_max_context_notes(self):
+        results = [
+            {"title": f"Note {i}", "snippet": "x", "section": ""}
+            for i in range(10)
+        ]
+        ctx = _build_context(results)
+        # Only MAX_CONTEXT_NOTES (6) should appear.
+        assert ctx.count("## Note") == 0  # sections absent
+        assert ctx.count("Note ") == 6
+
+    def test_empty_results(self):
+        assert _build_context([]) == ""
+
+
+# ── PublicNotesRateLimiter ──────────────────────────────────────────
+
+
+class TestPublicNotesRateLimiter:
+    def test_first_request_allowed(self):
+        limiter = PublicNotesRateLimiter()
+        allowed, remaining, reset_epoch = asyncio.run(limiter.check("1.2.3.4"))
+        assert allowed is True
+        assert reset_epoch > time.time()
+
+    def test_exhausting_burst_blocks(self):
+        from knowledge.chat import RATE_LIMIT_BURST
+
+        limiter = PublicNotesRateLimiter()
+        ip = "10.0.0.1"
+
+        async def _drain():
+            results = []
+            for _ in range(RATE_LIMIT_BURST + 2):
+                results.append(await limiter.check(ip))
+            return results
+
+        results = asyncio.run(_drain())
+        allowed_flags = [r[0] for r in results]
+        # First BURST requests should be allowed.
+        assert all(allowed_flags[:RATE_LIMIT_BURST])
+        # At least the last one must be blocked.
+        assert not allowed_flags[-1]
+
+    def test_different_ips_independent(self):
+        limiter = PublicNotesRateLimiter()
+
+        async def _check():
+            a = await limiter.check("1.1.1.1")
+            b = await limiter.check("2.2.2.2")
+            return a, b
+
+        (a_allowed, *_), (b_allowed, *_) = asyncio.run(_check())
+        assert a_allowed
+        assert b_allowed
+
+
+# ── /api/knowledge/public/chat endpoint ────────────────────────────
+
+FAKE_EMBEDDING = [0.1] * 1024
+FAKE_RESULTS = [
+    {
+        "note_id": "n1",
+        "title": "Attention",
+        "snippet": "transformers replace recurrence",
+        "section": "## Architecture",
+        "score": 0.9,
+    }
+]
+
+
+@pytest.fixture()
+def _client_with_overrides():
+    fake_embed = AsyncMock()
+    fake_embed.embed.return_value = FAKE_EMBEDDING
+    fake_session = MagicMock()
+
+    app.dependency_overrides[get_session] = lambda: fake_session
+    app.dependency_overrides[get_embedding_client] = lambda: fake_embed
+
+    with TestClient(app, raise_server_exceptions=False) as c:
+        yield c, fake_session, fake_embed
+
+    app.dependency_overrides.clear()
+
+
+class TestPublicChatEndpoint:
+    def test_short_question_returns_400(self, _client_with_overrides):
+        client, *_ = _client_with_overrides
+        res = client.post(
+            "/api/knowledge/public/chat", json={"question": "hi"}
+        )
+        assert res.status_code == 400
+
+    def test_rate_limit_headers_present_on_success(self, _client_with_overrides):
+        client, fake_session, _ = _client_with_overrides
+        store_mock = MagicMock()
+        store_mock.search_notes_with_context.return_value = []
+
+        async def _fake_stream(*_a, **_kw):
+            yield 'data: {"type":"done"}\n\n'
+
+        with (
+            patch("knowledge.router.KnowledgeStore", return_value=store_mock),
+            patch("knowledge.router.stream_chat_response", side_effect=_fake_stream),
+            patch("knowledge.router.public_limiter") as mock_limiter,
+        ):
+            mock_limiter.check = AsyncMock(
+                return_value=(True, 4, time.time() + 60)
+            )
+            res = client.post(
+                "/api/knowledge/public/chat",
+                json={"question": "what are transformers?"},
+            )
+
+        assert res.status_code == 200
+        assert "x-ratelimit-limit" in res.headers
+
+    def test_rate_limited_returns_429(self, _client_with_overrides):
+        client, *_ = _client_with_overrides
+
+        with patch("knowledge.router.public_limiter") as mock_limiter:
+            mock_limiter.check = AsyncMock(
+                return_value=(False, 0, time.time() + 30)
+            )
+            res = client.post(
+                "/api/knowledge/public/chat",
+                json={"question": "what are transformers?"},
+            )
+
+        assert res.status_code == 429
+        body = res.json()
+        assert body["error"] == "rate_limited"
+        assert "x-ratelimit-limit" in res.headers

--- a/projects/monolith/knowledge/router.py
+++ b/projects/monolith/knowledge/router.py
@@ -14,6 +14,7 @@ can override it with a deterministic fake via ``app.dependency_overrides``.
 from __future__ import annotations
 
 import logging
+import math
 import os
 import re
 from datetime import datetime, timezone
@@ -23,12 +24,20 @@ from typing import Literal
 
 import yaml
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response
+from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 from sqlalchemy import func, or_
 from sqlmodel import Session, select
 
 from app.db import get_session
 from knowledge import frontmatter
+from knowledge.chat import (
+    MAX_CONTEXT_NOTES,
+    RATE_LIMIT_RPM,
+    _build_context,
+    public_limiter,
+    stream_chat_response,
+)
 from knowledge.gaps import (
     answer_gap,
     approve_gap,
@@ -870,3 +879,122 @@ def reset_note_visibility_endpoint(
     except ValueError as exc:
         raise _map_note_error(exc) from exc
     return _note_to_review_dict(note, vault_root)
+
+
+# ── Notes chat ──────────────────────────────────────────────────────────────
+
+
+class ChatRequest(BaseModel):
+    question: str
+
+
+def _rate_limit_headers(remaining: int, reset_epoch: float) -> dict[str, str]:
+    return {
+        "X-RateLimit-Limit": str(RATE_LIMIT_RPM),
+        "X-RateLimit-Remaining": str(remaining),
+        "X-RateLimit-Reset": str(math.ceil(reset_epoch)),
+        "Cache-Control": "no-store",
+    }
+
+
+@router.post("/public/chat")
+async def public_notes_chat(
+    body: ChatRequest,
+    request: Request,
+    session: Session = Depends(get_session),
+    embed_client: EmbeddingClient = Depends(get_embedding_client),
+) -> StreamingResponse:
+    """RAG chat over public notes only, rate-limited per IP.
+
+    Streams Server-Sent Events with ``{"type": "text_chunk", "text": "..."}``
+    events and a terminal ``{"type": "done"}``.
+
+    Rate limit headers (``X-RateLimit-*``) are set on the response.
+    When the limit is exceeded returns 429 with a JSON body instead of a stream.
+    """
+    ip = request.client.host if request.client else "unknown"
+    allowed, remaining, reset_epoch = await public_limiter.check(ip)
+
+    headers = _rate_limit_headers(remaining, reset_epoch)
+
+    if not allowed:
+        import json
+
+        reset_in = max(0, math.ceil(reset_epoch - __import__("time").time()))
+        body_bytes = json.dumps(
+            {
+                "error": "rate_limited",
+                "message": f"Public chat is rate-limited to {RATE_LIMIT_RPM} req/min on in-cluster infra. "
+                f"Retry in {reset_in}s.",
+                "retry_after": reset_in,
+            }
+        ).encode()
+        return Response(
+            content=body_bytes,
+            status_code=429,
+            media_type="application/json",
+            headers=headers,
+        )
+
+    if len(body.question.strip()) < 3:
+        raise HTTPException(400, "question too short")
+
+    try:
+        vector = await embed_client.embed(body.question)
+    except Exception:
+        logger.exception("public_notes_chat: embedding failed")
+        raise HTTPException(503, "embedding unavailable")
+
+    results = KnowledgeStore(session).search_notes_with_context(
+        query_embedding=vector,
+        limit=MAX_CONTEXT_NOTES,
+        public_only=True,
+    )
+    context = _build_context(results)
+
+    async def _generate():
+        async for chunk in stream_chat_response(body.question, context):
+            yield chunk
+
+    return StreamingResponse(
+        _generate(),
+        media_type="text/event-stream",
+        headers=headers,
+    )
+
+
+@router.post("/chat")
+async def private_notes_chat(
+    body: ChatRequest,
+    session: Session = Depends(get_session),
+    embed_client: EmbeddingClient = Depends(get_embedding_client),
+) -> StreamingResponse:
+    """RAG chat over all notes (public + private).
+
+    Protected by Cloudflare Access at the ingress level; no app-level
+    rate limit applied here.
+    """
+    if len(body.question.strip()) < 3:
+        raise HTTPException(400, "question too short")
+
+    try:
+        vector = await embed_client.embed(body.question)
+    except Exception:
+        logger.exception("private_notes_chat: embedding failed")
+        raise HTTPException(503, "embedding unavailable")
+
+    results = KnowledgeStore(session).search_notes_with_context(
+        query_embedding=vector,
+        limit=MAX_CONTEXT_NOTES,
+    )
+    context = _build_context(results)
+
+    async def _generate():
+        async for chunk in stream_chat_response(body.question, context):
+            yield chunk
+
+    return StreamingResponse(
+        _generate(),
+        media_type="text/event-stream",
+        headers={"Cache-Control": "no-store"},
+    )

--- a/projects/monolith/knowledge/store.py
+++ b/projects/monolith/knowledge/store.py
@@ -213,6 +213,7 @@ class KnowledgeStore:
         query_embedding: list[float],
         limit: int = 20,
         type_filter: str | None = None,
+        public_only: bool = False,
     ) -> list[dict]:
         """Semantic search returning type, tags, best chunk section + snippet.
 
@@ -254,6 +255,8 @@ class KnowledgeStore:
         )
         if type_filter is not None:
             notes_stmt = notes_stmt.where(Note.type == type_filter)
+        if public_only:
+            notes_stmt = notes_stmt.where(Note.visibility == "public")
 
         note_rows = self.session.execute(notes_stmt).all()
         if not note_rows:

--- a/projects/monolith/knowledge/store_test.py
+++ b/projects/monolith/knowledge/store_test.py
@@ -488,6 +488,30 @@ class TestSearchNotesWithContext:
         assert results[0]["note_id"] == "n1"
         assert results[0]["type"] == "paper"
 
+    def test_public_only_excludes_private_notes(self):
+        _upsert(
+            self.store,
+            note_id="pub",
+            path="pub.md",
+            title="Public Note",
+            metadata=_meta(title="Public Note", visibility="public"),
+            n_chunks=1,
+        )
+        _upsert(
+            self.store,
+            note_id="priv",
+            path="priv.md",
+            title="Private Note",
+            metadata=_meta(title="Private Note", visibility="private"),
+            n_chunks=1,
+        )
+        results = self.store.search_notes_with_context(
+            query_embedding=[0.0] * 1024, public_only=True
+        )
+        ids = {r["note_id"] for r in results}
+        assert "pub" in ids
+        assert "priv" not in ids
+
     def test_empty_db_returns_empty_list(self):
         results = self.store.search_notes_with_context(query_embedding=[0.0] * 1024)
         assert results == []


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **New `POST /api/knowledge/public/chat`** — RAG chat over public notes only, rate-limited to 5 req/min per IP via an in-process token bucket. Returns SSE stream of Qwen3.6-27B answer grounded in the top-6 semantically similar public note snippets.
- **New `POST /api/knowledge/chat`** — same but over all notes (public + private), no app-level rate limit (Cloudflare Access / ingress protects it).
- **`NotesChat.svelte`** — collapsible bottom-right panel on both `/notes` pages. Matches the existing brutalist design: yellow hard-shadow toggle button, mono font, ink borders. On the public page it shows a persistent `⚡ in-cluster · 5 req/min` badge and, when rate-limited, a clear banner explaining the intentional throttle on shared homelab GPU infra.
- **`knowledge/store.py`** — added `public_only: bool = False` to `search_notes_with_context` so the public endpoint filters at the SQL level (not post-hoc).
- **`knowledge/chat.py`** — `PublicNotesRateLimiter` (per-IP token bucket), `stream_chat_response()` (OpenAI-compat SSE to vLLM).
- Tests cover: rate limiter exhaustion, 429 response shape, rate-limit headers, `public_only` SQL filter.

## Public-page rate limit behaviour

| Header | Value |
|---|---|
| `X-RateLimit-Limit` | 5 (configurable via `PUBLIC_CHAT_RATE_LIMIT_RPM`) |
| `X-RateLimit-Remaining` | tokens left this minute |
| `X-RateLimit-Reset` | epoch second of next full refill |

When exhausted: HTTP 429 + JSON `{"error":"rate_limited","message":"...","retry_after":N}` + on-page banner.

## Test plan

- [ ] CI green (rate limiter unit tests, router endpoint tests, store `public_only` test)
- [ ] On public notes page: "ASK THE NOTES" button appears bottom-right
- [ ] Click → panel expands with `⚡ in-cluster · 5 req/min` notice in header
- [ ] Ask a question → streams Qwen answer grounded in note snippets
- [ ] After 5 requests in a minute → 429 banner appears with retry countdown
- [ ] Private notes page: same panel without rate-limit badge, answers include private notes

https://claude.ai/code/session_018LiNk3ASMjotuftVsx889M
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_018LiNk3ASMjotuftVsx889M)_