### PR TITLE
feat(lakehouse): create SeaweedFS warehouse bucket [INFRA-SEAWEEDFS]

### DIFF
--- a/docs/plans/event-sourced-impl-status/INFRA-SEAWEEDFS.md
+++ b/docs/plans/event-sourced-impl-status/INFRA-SEAWEEDFS.md
@@ -1,0 +1,99 @@
+# INFRA-SEAWEEDFS — warehouse S3 bucket
+
+Status: **shipped** (PR open, auto-merge enabled). Wiring into the
+`projects/platform/kustomization.yaml` and `projects/home-cluster/kustomization.yaml`
+is **deferred to the orchestrator** (central wiring after merge), per the unit's
+"purely additive" constraint.
+
+## What shipped
+
+A new, additive ArgoCD Application `warehouse-bucket` that creates the
+`warehouse` S3 bucket on the **existing** SeaweedFS deployment (ns `seaweedfs`).
+Nothing under `projects/platform/seaweedfs/` was touched.
+
+Files created (all new):
+
+- `projects/platform/warehouse-bucket/application.yaml` — `argoproj.io/v1alpha1`
+  Application, name `warehouse-bucket`, ns `argocd`, label
+  `app.kubernetes.io/part-of: shared-infrastructure`, annotation
+  `argocd.argoproj.io/sync-wave: "1"`. Plain kustomize/directory source (NO Helm
+  block): `repoURL https://github.com/jomcgi/homelab.git`,
+  `path projects/platform/warehouse-bucket`, `targetRevision HEAD`. Destination
+  ns `seaweedfs`. `syncPolicy.automated` prune + selfHeal,
+  `syncOptions: [CreateNamespace=true]`, retry limit 5.
+- `projects/platform/warehouse-bucket/kustomization.yaml` — Kustomization,
+  `resources: [job.yaml]`.
+- `projects/platform/warehouse-bucket/job.yaml` — the idempotent bucket-creation
+  Job (details below).
+
+## Bucket-creation approach (option B: `weed shell`)
+
+Chose option B over the `aws` CLI (option A) because it is simpler:
+
+- **Reuses the same image the cluster already runs** — `chrislusf/seaweedfs:3.73`
+  (the deployed chart's appVersion; the repo values do not override the image
+  tag). No separate aws-cli image to pull, and `weed` is already on every node.
+- **No credentials needed.** The S3 gateway has `enableAuth: false` and `weed
+shell` talks straight to the master (`seaweedfs-master.seaweedfs.svc.cluster.local:9333`)
+  over the cluster network — no dummy AWS creds required.
+- Command surface: `s3.bucket.list` / `s3.bucket.create -name warehouse -replication 000`
+  piped into `weed shell -master <master>:9333`.
+
+(aws CLI option A was rejected only on simplicity grounds — it would have worked
+too, against `http://seaweedfs-s3.seaweedfs.svc.cluster.local:8333` with dummy
+creds and `s3 mb || true`.)
+
+## Idempotency
+
+`weed shell` is a command interpreter, not a POSIX shell, so it can't branch
+internally. The Job therefore:
+
+1. Waits for the master to be reachable (up to 30 × 5s) via `cluster.check`.
+2. Dumps `s3.bucket.list` and greps (whole-word, tolerant of the tree-style
+   listing's leading whitespace / trailing metadata) for `warehouse`. If present,
+   exits 0 — nothing to do.
+3. Otherwise runs `s3.bucket.create`, then re-lists to verify.
+
+Safe to re-run. The Job carries `argocd.argoproj.io/hook: PreSync` +
+`hook-delete-policy: BeforeHookCreation`, so ArgoCD recreates it cleanly on every
+sync (avoids the "Job spec is immutable" problem of a plain selfHeal'd Job) and
+keeps the bucket present before downstream lakehouse components sync.
+`ttlSecondsAfterFinished: 600` reaps the completed pod.
+
+Security: non-root uid/gid 65532, `runAsNonRoot`, `readOnlyRootFilesystem: true`
+(with an `emptyDir` at `/tmp` and `HOME=/tmp` for `weed`'s scratch),
+`allowPrivilegeEscalation: false`, all capabilities dropped, `seccompProfile:
+RuntimeDefault`, `automountServiceAccountToken: false` (the Job makes no
+Kubernetes API calls — only network calls to the master). `restartPolicy:
+OnFailure`, `backoffLimit: 5`, minimal resources (25m/32Mi req, 100m/64Mi lim).
+
+## Replication deviation (documented)
+
+ADR platform/004 (§risks) calls for rack-aware replication. The cluster is
+currently **single-node for SeaweedFS** (1 master replica, 1 volume replica per
+`projects/platform/seaweedfs/values.yaml`). True rack-aware replication requires
+**multiple volume servers**, which do not exist yet. The bucket is therefore
+created with **`-replication 000` (no replication)**, which is the correct,
+single-node-appropriate setting. **Rack-aware replication is deferred until the
+SeaweedFS deployment spans multiple volume servers** — at that point the bucket's
+replication policy (and the chart's `volume.replicas` / `defaultReplication`)
+should be revisited.
+
+## Deferred / follow-ups
+
+- **Central wiring** of this Application into `projects/platform/kustomization.yaml`
+  / `projects/home-cluster/kustomization.yaml` — handled by the orchestrator after
+  merge (per unit constraints; this unit must not edit those files).
+- **Rack-aware replication** — see deviation above; revisit on multi-node.
+- Buckets remain otherwise non-IaC-managed in the repo (existing `knowledge`,
+  `trips` buckets were created imperatively); this unit only IaC-manages
+  `warehouse`.
+
+## Self-validation
+
+`kubectl kustomize projects/platform/warehouse-bucket/` renders cleanly (single
+Job manifest). No Helm here. Manifest was NOT applied and `aws s3 mb` was NOT run
+against the cluster — author-only, per unit constraints. (Live kubectl reads to
+re-confirm service names/ports were unavailable this session — the cluster API
+was unreachable — so the verified discovery facts handed to the unit were used:
+`seaweedfs-master.seaweedfs:9333`, `seaweedfs-s3.seaweedfs:8333`, auth disabled.)

--- a/projects/platform/warehouse-bucket/application.yaml
+++ b/projects/platform/warehouse-bucket/application.yaml
@@ -1,0 +1,42 @@
+# ArgoCD Application: warehouse-bucket
+#
+# Idempotently creates the `warehouse` S3 bucket on the existing SeaweedFS
+# deployment (ns seaweedfs) for the event-sourced lakehouse (ADR platform/004).
+#
+# This is a plain kustomize/directory Application (NOT a Helm chart) — there is
+# no upstream chart for "make a bucket". The bucket is created by an idempotent
+# Job (see job.yaml) that talks to the SeaweedFS master via `weed shell`.
+#
+# Additive unit INFRA-SEAWEEDFS. Does not touch projects/platform/seaweedfs/.
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: warehouse-bucket
+  namespace: argocd
+  labels:
+    app.kubernetes.io/part-of: shared-infrastructure
+  annotations:
+    # Sync after SeaweedFS itself (which also lives in wave 1); the Job retries
+    # against the master until it is reachable, so ordering is best-effort.
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/jomcgi/homelab.git
+    path: projects/platform/warehouse-bucket
+    targetRevision: HEAD
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: seaweedfs
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m

--- a/projects/platform/warehouse-bucket/job.yaml
+++ b/projects/platform/warehouse-bucket/job.yaml
@@ -1,0 +1,118 @@
+# Idempotent Job: create the `warehouse` S3 bucket on SeaweedFS.
+#
+# Approach (option B): reuse the SAME image the cluster already runs
+# (chrislusf/seaweedfs:3.73, appVersion of the deployed chart) and drive the
+# master via `weed shell`. This avoids pulling a separate aws-cli image and
+# needs no S3 credentials — `enableAuth: false` on the S3 gateway and the
+# shell talks straight to the master over the cluster network.
+#
+# Idempotency: `weed shell` is a command interpreter, not a POSIX shell, so we
+# cannot branch inside it. Instead we first dump the bucket list with one
+# `weed shell` invocation, grep for `warehouse` at the POSIX-shell level, and
+# only run `s3.bucket.create` if the bucket is absent. This makes the Job safe
+# to re-run — ArgoCD recreates it on every sync via the PreSync hook below.
+#
+# Replication: created with `-replication 000` (no replication). The cluster is
+# single-node for SeaweedFS today (1 master / 1 volume replica), so true
+# rack-aware replication (ADR platform/004 risks) is NOT possible yet and is
+# DEFERRED until multiple volume servers exist. Documented deviation.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: warehouse-bucket-create
+  namespace: seaweedfs
+  labels:
+    app.kubernetes.io/name: warehouse-bucket
+    app.kubernetes.io/part-of: shared-infrastructure
+  annotations:
+    # Run on every ArgoCD sync and recreate cleanly each time. PreSync keeps the
+    # bucket present before any downstream lakehouse component syncs.
+    argocd.argoproj.io/hook: PreSync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+spec:
+  backoffLimit: 5
+  # Reap the pod automatically a while after success to keep the namespace tidy.
+  ttlSecondsAfterFinished: 600
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: warehouse-bucket
+    spec:
+      restartPolicy: OnFailure
+      # This Job makes no Kubernetes API calls — only network calls to the
+      # SeaweedFS master — so it needs no ServiceAccount token.
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        fsGroup: 65532
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: create-bucket
+          image: chrislusf/seaweedfs:3.73
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          env:
+            - name: MASTER
+              value: "seaweedfs-master.seaweedfs.svc.cluster.local:9333"
+            - name: BUCKET
+              value: "warehouse"
+            # Give weed a writable scratch/home dir under the read-only root FS.
+            - name: HOME
+              value: "/tmp"
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -eu
+              echo "Waiting for SeaweedFS master at ${MASTER} ..."
+              i=0
+              until echo "cluster.check" | weed shell -master "${MASTER}" >/dev/null 2>&1; do
+                i=$((i + 1))
+                if [ "$i" -ge 30 ]; then
+                  echo "ERROR: master ${MASTER} not reachable after $i attempts" >&2
+                  exit 1
+                fi
+                echo "  master not ready yet (attempt $i); retrying in 5s..."
+                sleep 5
+              done
+
+              echo "Listing existing buckets..."
+              # s3.bucket.list prints a tree-style listing (leading whitespace,
+              # trailing size/replication metadata), so match the bucket name as
+              # a whole word anywhere on a line rather than requiring an exact line.
+              if echo "s3.bucket.list" | weed shell -master "${MASTER}" 2>/dev/null \
+                   | grep -Eq "(^|[[:space:]/])${BUCKET}([[:space:]/]|\$)"; then
+                echo "Bucket '${BUCKET}' already exists; nothing to do."
+                exit 0
+              fi
+
+              echo "Creating bucket '${BUCKET}' (replication=000, single-node)..."
+              # replication 000 = no replication; rack-aware deferred until multi-node.
+              echo "s3.bucket.create -name ${BUCKET} -replication 000" \
+                | weed shell -master "${MASTER}"
+
+              echo "Verifying bucket '${BUCKET}' exists..."
+              echo "s3.bucket.list" | weed shell -master "${MASTER}" 2>/dev/null \
+                | grep -Eq "(^|[[:space:]/])${BUCKET}([[:space:]/]|\$)"
+              echo "Bucket '${BUCKET}' created."
+          resources:
+            requests:
+              cpu: 25m
+              memory: 32Mi
+            limits:
+              cpu: 100m
+              memory: 64Mi
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}

--- a/projects/platform/warehouse-bucket/kustomization.yaml
+++ b/projects/platform/warehouse-bucket/kustomization.yaml
@@ -1,0 +1,9 @@
+# Kustomization for the warehouse-bucket ArgoCD Application.
+#
+# Plain kustomize (no Helm): a single idempotent Job that creates the
+# `warehouse` S3 bucket on the existing SeaweedFS deployment.
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - job.yaml


### PR DESCRIPTION
## Unit INFRA-SEAWEEDFS — warehouse bucket

Part of the additive event-sourced lakehouse build (ADR platform/004). Creates the `warehouse` S3 bucket on the **existing** SeaweedFS deployment (ns `seaweedfs`).

### What this adds (purely additive — no existing file modified)

A new ArgoCD Application `warehouse-bucket` under `projects/platform/warehouse-bucket/`:

- `application.yaml` — `argoproj.io/v1alpha1` Application, ns `argocd`, label `part-of: shared-infrastructure`, sync-wave `1`. **Plain kustomize/directory source (no Helm block)** — there is no upstream chart for "make a bucket". Destination ns `seaweedfs`, automated prune+selfHeal, `CreateNamespace=true`, retry 5.
- `kustomization.yaml` — `resources: [job.yaml]`.
- `job.yaml` — idempotent bucket-creation Job (PreSync hook).

### Approach (option B: `weed shell`)

Reuses the **same image the cluster already runs** (`chrislusf/seaweedfs:3.73`) and drives the master (`seaweedfs-master.seaweedfs:9333`) via `weed shell`. No separate aws-cli image and **no S3 creds** (`enableAuth: false`). Idempotent — lists buckets, only creates if absent; the PreSync hook + `BeforeHookCreation` delete policy recreate it cleanly on every sync (avoids the immutable-Job-spec problem). Non-root uid 65532, read-only rootfs, no SA token, minimal resources, `restartPolicy: OnFailure`, `backoffLimit: 5`.

(Option A — aws CLI `s3 mb || true` against `seaweedfs-s3:8333` with dummy creds — would have worked too; rejected only on simplicity.)

### Replication deviation (documented)

ADR platform/004 (§risks) wants rack-aware replication, but SeaweedFS is **single-node today** (1 master / 1 volume replica). True rack-aware replication needs multiple volume servers. Bucket is created with **`-replication 000`** (single-node-appropriate); **rack-aware replication is deferred until multi-node**. See `docs/plans/event-sourced-impl-status/INFRA-SEAWEEDFS.md`.

### Wiring deferred

Wiring this Application into `projects/platform/kustomization.yaml` / `projects/home-cluster/kustomization.yaml` is **handled centrally by the orchestrator after merge** — this unit intentionally does not edit those files.

### Validation

`kubectl kustomize projects/platform/warehouse-bucket/` renders cleanly (single Job manifest). Manifest not applied; `aws s3 mb` not run against the cluster (author-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)