### PR TITLE
feat(lakehouse): wire Wavefront 1 infra into platform GitOps root

### DIFF
--- a/projects/platform/kustomization.yaml
+++ b/projects/platform/kustomization.yaml
@@ -9,12 +9,18 @@ resources:
   - ./cloudnative-pg/deploy
   - ./cloudflare-gateway # Envoy Gateway + Gateway API + Cloudflare Tunnel; CRDs must be before linkerd
   - ./coredns
+  - ./keda
   - ./kyverno
   - ./linkerd
   - ./longhorn
+  - ./nack # NATS JetStream controller; must reconcile before nats-streams (Stream CRDs)
   - ./nats
+  - ./nats-streams
   - ./nvidia-gpu-operator
   - ./opentelemetry-operator
   - ./seaweedfs
   - ./signoz
   - ./signoz-addons # Must be after signoz
+  - ./temporal # Event-sourced lakehouse (ADR 015); sync-wave 2, needs temporal-databases first
+  - ./temporal-databases # CNPG Database CRs for temporal + temporal_visibility; sync-wave 1
+  - ./warehouse-bucket # SeaweedFS warehouse bucket for the Iceberg lakehouse (platform/004)


### PR DESCRIPTION
## Wavefront 1 wiring (activation)

Adds the six Wavefront 1 Applications to `projects/platform/kustomization.yaml`, making ArgoCD sync them:

`keda` · `nack` · `nats-streams` · `temporal` · `temporal-databases` · `warehouse-bucket`

Each component shipped as a pure-new-file PR (#2387–#2391, auto-merged, conflict-free). This is the single serialized wiring edit. No `generate-home-cluster.sh` regen needed — the root kustomization references the `projects/platform` aggregator wholesale.

**Deploy ordering** (via sync-wave annotations in each Application):
- wave 1: `temporal-databases` (CNPG Database CRs), `keda`, `nack`, `warehouse-bucket`
- wave 2: `temporal` (needs its DBs), `nats-streams` (needs nack's Stream CRDs)

### Manual prerequisites before Temporal goes healthy
1. **Restore the kube API tunnel** (for live verification at the gate).
2. **Populate 1Password** item `vaults/k8s-homelab/items/temporal-pg` with field `password` = the current `monolith-pg` `app` password (`kubectl -n monolith get secret monolith-pg-app -o jsonpath='{.data.password}' | base64 -d`). Until then the Temporal pods will wait/crashloop on the missing secret — expected, not a failure.

Validated locally: `kubectl kustomize projects/platform/` renders 20 Applications, no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)