### PR TITLE
feat(lakehouse): domain event envelope + publish helpers (LIB-EVENTS)

### DIFF
--- a/docs/plans/event-sourced-impl-status/LIB-EVENTS.md
+++ b/docs/plans/event-sourced-impl-status/LIB-EVENTS.md
@@ -1,0 +1,86 @@
+# LIB-EVENTS — projects/lakehouse/events (domain event envelope + publish)
+
+**Unit:** LIB-EVENTS (Wavefront 2 library unit)
+**ADR:** [agents/017 — Domain Event Schema and Tombstone Semantics](../../decisions/agents/017-domain-event-schema.md)
+**Branch:** `feat/lakehouse-lib-events`
+**Classification:** purely-additive — only new files under `projects/lakehouse/events/`.
+
+## What shipped
+
+`projects/lakehouse/events/`:
+
+- `__init__.py` — public surface re-exporting the envelope, publish, and
+  versioning helpers (`from projects.lakehouse.events import EventEnvelope, ...`).
+- `envelope.py` — Pydantic v2 `EventEnvelope` with the exact ADR-017 field set
+  (`schema_version=1` default, `entity_type`, `entity_id`, `event_type`,
+  `event_version`, `event_id`, `occurred_at`, `producer`, `payload`,
+  optional `correlation_id` / `caused_by`). `EventType` Literal of the five
+  universal types. `new_event_id()` (inline UUIDv7), `nats_msg_id()`,
+  `build_envelope()` convenience constructor.
+- `publish.py` — `Publisher` `typing.Protocol` (DI seam, no nats_client import),
+  `SUBJECT_BY_ENTITY` map, `subject_for()`, `async publish_event()`.
+- `versioning.py` — `next_event_version(conn, entity_type, entity_id)` atomic
+  upsert allocator + `CREATE_TABLE_SQL` for `lakehouse_event_versions`.
+- `registry/__init__.py` — `pkgutil.iter_modules` auto-discovery loader exposing
+  `SCHEMAS: dict[str, dict]` (+ `payload_model()` lookup helper).
+- `registry/gap.py`, `registry/note.py` — Pydantic payload models with
+  module-level `register(SCHEMAS)` hooks.
+- Tests: `envelope_test.py`, `publish_test.py`, `versioning_test.py`,
+  `registry/registry_test.py` (27 tests, all green locally).
+- `BUILD` (events) + `registry/BUILD` — best-effort; gazelle (ci-format-bot)
+  normalizes and adds `semgrep_test` targets on the PR branch.
+
+## Key decisions
+
+- **DI publish design.** `publish.py` defines a structural `Publisher` Protocol
+  (`@runtime_checkable`) and never imports `projects.lakehouse.nats_client`. The
+  parallel LIB-NATS JetStream wrapper satisfies it by duck typing, so the two
+  units have **zero import edge** in either direction and ship independently.
+  `publish_event` serializes via `model_dump_json()`, derives the subject
+  (explicit arg → `subject_for`), and passes `{entity_id}-v{version}` as both
+  `msg_id` and the `Nats-Msg-Id` header (ADR-017 idempotency layer 1).
+- **UUIDv7 impl (no new dep).** `new_event_id()` builds an RFC-9562 UUIDv7 from a
+  48-bit Unix-ms timestamp prefix + `os.urandom(10)`, sets the version nibble
+  (`0b0111`) and variant bits (`0b10`), and formats the hyphenated 36-char hex.
+  Time-prefixed → k-sortable / roughly time-ordered for trace correlation;
+  strict per-entity ordering comes from `event_version`, not the id. Python
+  3.11's `uuid` has no `uuid7`, so the inline impl avoids depending on stdlib
+  version or a new pip dep.
+- **Versioning via single atomic upsert.** `INSERT ... ON CONFLICT ... DO UPDATE
+SET version = version + 1 RETURNING version` is race-free on both Postgres and
+  sqlite ≥ 3.35 (tests use in-memory sqlite). `next_event_version` does **not**
+  commit — it joins the producer's event-generation transaction. The
+  `lakehouse_event_versions` table is created by a **deferred migration** (not
+  this unit); `CREATE_TABLE_SQL` is exported for that migration and for tests.
+- **Registry auto-discovery.** New event families = drop a module into
+  `registry/` with a `register(SCHEMAS)` hook; no central list to edit. The
+  loader skips `_*` and `*_test` modules so the test module in `registry/`
+  (globbed into the test target's runfiles) never registers a spurious entity.
+
+## Deviations from ADR 017
+
+- **`event_type` is `str`, not the `EventType` Literal, on the model.** ADR 017
+  explicitly allows domain-specific event types (e.g. gap-only `escalated`)
+  alongside the five universal ones. Typing the field as `str` lets those
+  validate; `EventType` is exported separately for the common typed path.
+- **`extra="forbid"` on the envelope, `extra="allow"` on payloads.** The
+  envelope rejects unknown top-level fields (typos fail fast); payloads tolerate
+  extra keys per the ADR's additive schema-evolution rule.
+- No other deviations. Field set matches the ADR-017 table exactly.
+
+## Deferred / out of scope
+
+- The `lakehouse_event_versions` migration (table DDL ships here as
+  `CREATE_TABLE_SQL`; the actual migration is a later unit).
+- Concrete NATS publishing (LIB-NATS unit provides the `Publisher` impl).
+- `edge` payload registry module — `edge` has a subject mapping but no payload
+  schema yet (no concrete use case; ADR open question #2 on cross-entity events).
+- Embedding-length enforcement on `NoteChunk.embedding` (documented as 1024-dim
+  voyage-4-nano, not validated, to tolerate a future model swap without a
+  schema_version bump).
+
+## Verification
+
+Ran `PYTHONPATH=. python3 -m pytest projects/lakehouse/events/` locally
+(system python3 + pydantic 2.12): **27 passed**. Imports clean; registry
+auto-discovers `gap` + `note`. Authoritative test run is CI (`bazel test`).

--- a/projects/lakehouse/events/BUILD
+++ b/projects/lakehouse/events/BUILD
@@ -19,7 +19,6 @@ py_test(
     srcs = ["envelope_test.py"],
     deps = [
         ":events",
-        "@pip//pydantic",
         "@pip//pytest",
     ],
 )
@@ -63,5 +62,23 @@ semgrep_test(
 semgrep_test(
     name = "__init___semgrep_test",
     srcs = ["__init__.py"],
+    rules = ["//bazel/semgrep/rules:python_rules"],
+)
+
+semgrep_test(
+    name = "envelope_test_semgrep_test",
+    srcs = ["envelope_test.py"],
+    rules = ["//bazel/semgrep/rules:python_rules"],
+)
+
+semgrep_test(
+    name = "publish_test_semgrep_test",
+    srcs = ["publish_test.py"],
+    rules = ["//bazel/semgrep/rules:python_rules"],
+)
+
+semgrep_test(
+    name = "versioning_test_semgrep_test",
+    srcs = ["versioning_test.py"],
     rules = ["//bazel/semgrep/rules:python_rules"],
 )

--- a/projects/lakehouse/events/BUILD
+++ b/projects/lakehouse/events/BUILD
@@ -1,0 +1,67 @@
+load("@aspect_rules_py//py:defs.bzl", "py_library")
+load("//bazel/semgrep/defs:defs.bzl", "semgrep_test")
+load("//bazel/tools/pytest:defs.bzl", "py_test")
+
+py_library(
+    name = "events",
+    srcs = [
+        "__init__.py",
+        "envelope.py",
+        "publish.py",
+        "versioning.py",
+    ],
+    visibility = ["//:__subpackages__"],
+    deps = ["@pip//pydantic"],
+)
+
+py_test(
+    name = "envelope_test",
+    srcs = ["envelope_test.py"],
+    deps = [
+        ":events",
+        "@pip//pydantic",
+        "@pip//pytest",
+    ],
+)
+
+py_test(
+    name = "publish_test",
+    srcs = ["publish_test.py"],
+    deps = [
+        ":events",
+        "@pip//pytest",
+    ],
+)
+
+py_test(
+    name = "versioning_test",
+    srcs = ["versioning_test.py"],
+    deps = [
+        ":events",
+        "@pip//pytest",
+    ],
+)
+
+semgrep_test(
+    name = "envelope_semgrep_test",
+    srcs = ["envelope.py"],
+    rules = ["//bazel/semgrep/rules:python_rules"],
+)
+
+semgrep_test(
+    name = "publish_semgrep_test",
+    srcs = ["publish.py"],
+    rules = ["//bazel/semgrep/rules:python_rules"],
+)
+
+semgrep_test(
+    name = "versioning_semgrep_test",
+    srcs = ["versioning.py"],
+    rules = ["//bazel/semgrep/rules:python_rules"],
+)
+
+semgrep_test(
+    name = "__init___semgrep_test",
+    srcs = ["__init__.py"],
+    rules = ["//bazel/semgrep/rules:python_rules"],
+)

--- a/projects/lakehouse/events/__init__.py
+++ b/projects/lakehouse/events/__init__.py
@@ -1,0 +1,48 @@
+"""Domain event envelope + publish helpers (ADR agents/017).
+
+The canonical event schema for the event-sourced lakehouse. Every cross-component
+state change is a versioned :class:`~projects.lakehouse.events.envelope.EventEnvelope`
+published to a NATS subject. Consumers interpret events by ``event_type``; producers
+never mutate state implicitly (tombstones are first-class events).
+
+Public surface::
+
+    from projects.lakehouse.events import (
+        EventEnvelope, EventType, build_envelope, new_event_id, nats_msg_id,
+        Publisher, publish_event, subject_for, SUBJECT_BY_ENTITY,
+        next_event_version, CREATE_TABLE_SQL,
+    )
+
+The payload schema registry (``projects.lakehouse.events.registry``) maps
+``entity_type -> {event_type -> payload model}`` and auto-discovers new event
+families by dropping a module into ``registry/``.
+"""
+
+from projects.lakehouse.events.envelope import (
+    EventEnvelope,
+    EventType,
+    build_envelope,
+    nats_msg_id,
+    new_event_id,
+)
+from projects.lakehouse.events.publish import (
+    SUBJECT_BY_ENTITY,
+    Publisher,
+    publish_event,
+    subject_for,
+)
+from projects.lakehouse.events.versioning import CREATE_TABLE_SQL, next_event_version
+
+__all__ = [
+    "EventEnvelope",
+    "EventType",
+    "build_envelope",
+    "nats_msg_id",
+    "new_event_id",
+    "Publisher",
+    "publish_event",
+    "subject_for",
+    "SUBJECT_BY_ENTITY",
+    "next_event_version",
+    "CREATE_TABLE_SQL",
+]

--- a/projects/lakehouse/events/envelope.py
+++ b/projects/lakehouse/events/envelope.py
@@ -1,0 +1,129 @@
+"""The canonical domain event envelope (ADR agents/017).
+
+A single system-wide envelope wraps every cross-component state change. The
+fields here mirror the ADR-017 spec exactly; see that ADR for the rationale
+behind each field, the entity lifecycle state machine, and tombstone semantics.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from datetime import datetime, timezone
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+# Universal event types per ADR 017. Entity-specific types (e.g. a gap-only
+# ``escalated``) are allowed by the spec but the envelope keeps the universal
+# set as a Literal for type-checking the common path. ``event_type`` on the
+# model is a plain ``str`` so domain-specific values still validate.
+EventType = Literal["created", "updated", "processed", "failed", "tombstoned"]
+
+
+def new_event_id() -> str:
+    """Generate a UUIDv7 (RFC 9562) as a 36-char hyphenated hex string.
+
+    UUIDv7 layout (128 bits)::
+
+        unix_ts_ms (48) | ver=0b0111 (4) | rand_a (12)
+        | var=0b10 (2)  | rand_b (62)
+
+    The 48-bit Unix-millisecond timestamp prefix makes IDs k-sortable by
+    creation time, which is exactly what ADR 017 wants for trace correlation
+    and roughly-ordered scans. Randomness comes from ``os.urandom`` so we add
+    no new dependency. Within the same millisecond, ordering is random (not
+    strictly monotonic) — per-entity strict ordering is provided separately by
+    ``event_version`` (see :mod:`projects.lakehouse.events.versioning`).
+    """
+    unix_ts_ms = int(time.time() * 1000) & 0xFFFFFFFFFFFF  # low 48 bits
+    rand = os.urandom(10)  # 80 bits of randomness; we use 74 of them
+
+    b = bytearray(16)
+    # 48-bit big-endian millisecond timestamp.
+    b[0] = (unix_ts_ms >> 40) & 0xFF
+    b[1] = (unix_ts_ms >> 32) & 0xFF
+    b[2] = (unix_ts_ms >> 24) & 0xFF
+    b[3] = (unix_ts_ms >> 16) & 0xFF
+    b[4] = (unix_ts_ms >> 8) & 0xFF
+    b[5] = unix_ts_ms & 0xFF
+    # Version nibble 0b0111 in the high nibble of byte 6, rand_a in the rest.
+    b[6] = 0x70 | (rand[0] & 0x0F)
+    b[7] = rand[1]
+    # Variant 0b10 in the high bits of byte 8, rand_b fills the remainder.
+    b[8] = 0x80 | (rand[2] & 0x3F)
+    b[9] = rand[3]
+    b[10:16] = rand[4:10]
+
+    h = b.hex()
+    return f"{h[0:8]}-{h[8:12]}-{h[12:16]}-{h[16:20]}-{h[20:32]}"
+
+
+def nats_msg_id(entity_id: str, event_version: int) -> str:
+    """JetStream dedup key for an event: ``{entity_id}-v{event_version}``.
+
+    Published in the ``Nats-Msg-Id`` header so a duplicate publish of the same
+    per-entity version is silently dropped inside the JetStream dedup window
+    (ADR 017, idempotency layer 1).
+    """
+    return f"{entity_id}-v{event_version}"
+
+
+class EventEnvelope(BaseModel):
+    """The ADR-017 domain event envelope.
+
+    Field set is exactly the ADR-017 table; ``correlation_id`` and ``caused_by``
+    are the only optional fields. ``schema_version`` defaults to ``1`` (this
+    ADR). Extra payload keys are tolerated by consumers per the additive schema
+    evolution rules, but the envelope itself forbids unknown top-level fields so
+    typos surface immediately.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = 1
+    entity_type: str
+    entity_id: str
+    event_type: str
+    event_version: int
+    event_id: str
+    occurred_at: datetime
+    producer: str
+    payload: dict
+    correlation_id: str | None = None
+    caused_by: str | None = None
+
+
+def build_envelope(
+    *,
+    entity_type: str,
+    entity_id: str,
+    event_type: str,
+    event_version: int,
+    producer: str,
+    payload: dict | None = None,
+    schema_version: int = 1,
+    event_id: str | None = None,
+    occurred_at: datetime | None = None,
+    correlation_id: str | None = None,
+    caused_by: str | None = None,
+) -> EventEnvelope:
+    """Construct an :class:`EventEnvelope`, filling sensible defaults.
+
+    ``event_id`` defaults to a fresh UUIDv7 (:func:`new_event_id`) and
+    ``occurred_at`` to the current UTC wall clock. Callers that compute these
+    upstream (e.g. for deterministic replay) may pass them explicitly.
+    """
+    return EventEnvelope(
+        schema_version=schema_version,
+        entity_type=entity_type,
+        entity_id=entity_id,
+        event_type=event_type,
+        event_version=event_version,
+        event_id=event_id or new_event_id(),
+        occurred_at=occurred_at or datetime.now(timezone.utc),
+        producer=producer,
+        payload=payload if payload is not None else {},
+        correlation_id=correlation_id,
+        caused_by=caused_by,
+    )

--- a/projects/lakehouse/events/envelope_test.py
+++ b/projects/lakehouse/events/envelope_test.py
@@ -1,0 +1,129 @@
+"""Unit tests for the domain event envelope (ADR agents/017)."""
+
+from __future__ import annotations
+
+import json
+import re
+from datetime import datetime, timezone
+
+import pytest
+
+from projects.lakehouse.events.envelope import (
+    EventEnvelope,
+    build_envelope,
+    nats_msg_id,
+    new_event_id,
+)
+
+_UUID_RE = re.compile(r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$")
+
+
+def _sample() -> EventEnvelope:
+    return build_envelope(
+        entity_type="gap",
+        entity_id="gap-42",
+        event_type="created",
+        event_version=1,
+        producer="monolith.gardener",
+        payload={"topic": "x", "context": {"k": "v"}},
+    )
+
+
+def test_build_envelope_fills_defaults():
+    env = _sample()
+    assert env.schema_version == 1
+    assert env.event_id  # auto-filled UUIDv7
+    assert _UUID_RE.match(env.event_id)
+    assert env.occurred_at.tzinfo is not None  # tz-aware UTC default
+    assert env.correlation_id is None
+    assert env.caused_by is None
+
+
+def test_envelope_round_trips_json():
+    env = _sample()
+    raw = env.model_dump_json()
+    decoded = json.loads(raw)
+    # Every ADR-017 field is present in the serialized form.
+    assert set(decoded) == {
+        "schema_version",
+        "entity_type",
+        "entity_id",
+        "event_type",
+        "event_version",
+        "event_id",
+        "occurred_at",
+        "producer",
+        "payload",
+        "correlation_id",
+        "caused_by",
+    }
+    rebuilt = EventEnvelope.model_validate_json(raw)
+    assert rebuilt == env
+
+
+def test_envelope_forbids_unknown_fields():
+    with pytest.raises(Exception):
+        EventEnvelope(
+            entity_type="gap",
+            entity_id="gap-1",
+            event_type="created",
+            event_version=1,
+            event_id=new_event_id(),
+            occurred_at=datetime.now(timezone.utc),
+            producer="p",
+            payload={},
+            bogus_field="nope",
+        )
+
+
+def test_explicit_event_id_and_occurred_at_preserved():
+    eid = new_event_id()
+    ts = datetime(2026, 5, 30, 12, 0, 0, tzinfo=timezone.utc)
+    env = build_envelope(
+        entity_type="note",
+        entity_id="note-7",
+        event_type="updated",
+        event_version=3,
+        producer="lakehouse.backfill",
+        payload={},
+        event_id=eid,
+        occurred_at=ts,
+        correlation_id="trace-abc",
+        caused_by="evt-upstream",
+    )
+    assert env.event_id == eid
+    assert env.occurred_at == ts
+    assert env.correlation_id == "trace-abc"
+    assert env.caused_by == "evt-upstream"
+
+
+def test_nats_msg_id_format():
+    assert nats_msg_id("gap-42", 1) == "gap-42-v1"
+    assert nats_msg_id("note-7", 12) == "note-7-v12"
+
+
+def test_new_event_id_is_valid_uuid_shape():
+    eid = new_event_id()
+    assert _UUID_RE.match(eid)
+    # Version nibble must be 7 (UUIDv7): char at index 14 of the hyphenated form.
+    assert eid[14] == "7"
+    # Variant: first hex digit of the 4th group is 8, 9, a, or b.
+    assert eid[19] in "89ab"
+
+
+def test_new_event_id_unique():
+    ids = {new_event_id() for _ in range(5000)}
+    assert len(ids) == 5000
+
+
+def test_new_event_id_roughly_time_ordered():
+    # IDs minted later have a >= timestamp prefix (k-sortable). Compare the
+    # 48-bit ms prefix across two batches separated by a tiny real delay.
+    import time
+
+    first = new_event_id()
+    time.sleep(0.01)
+    later = new_event_id()
+    first_prefix = first.replace("-", "")[:12]
+    later_prefix = later.replace("-", "")[:12]
+    assert later_prefix >= first_prefix

--- a/projects/lakehouse/events/publish.py
+++ b/projects/lakehouse/events/publish.py
@@ -1,0 +1,81 @@
+"""Transport-agnostic event publishing (ADR agents/017 + agents/016).
+
+This module deliberately does **not** import the NATS client. The concrete
+JetStream wrapper lives in the sibling ``projects.lakehouse.nats_client`` unit;
+to stay independent of it (these units ship in parallel) we depend only on a
+structural :class:`Publisher` protocol. The NATS wrapper satisfies the protocol
+by duck typing — no inheritance, no import edge in either direction.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+from projects.lakehouse.events.envelope import EventEnvelope, nats_msg_id
+
+# entity_type -> NATS subject. Matches the ADR-016 ``events.knowledge.*``
+# subject hierarchy. New entity types add an entry here (and a registry module).
+SUBJECT_BY_ENTITY: dict[str, str] = {
+    "gap": "events.knowledge.gap",
+    "note": "events.knowledge.note",
+    "edge": "events.knowledge.edge",
+}
+
+
+@runtime_checkable
+class Publisher(Protocol):
+    """Anything that can publish raw bytes to a NATS subject.
+
+    The ``projects.lakehouse.nats_client`` JetStream wrapper implements this.
+    ``msg_id`` populates the JetStream ``Nats-Msg-Id`` dedup key; ``headers``
+    carries that and any additional NATS headers.
+    """
+
+    async def publish(
+        self,
+        subject: str,
+        payload: bytes,
+        *,
+        msg_id: str | None = None,
+        headers: dict | None = None,
+    ) -> None: ...
+
+
+def subject_for(envelope: EventEnvelope) -> str:
+    """Resolve the NATS subject for ``envelope`` from its ``entity_type``.
+
+    Raises :class:`KeyError` for an unknown entity type so a missing subject
+    mapping fails loudly at publish time rather than silently routing nowhere.
+    """
+    try:
+        return SUBJECT_BY_ENTITY[envelope.entity_type]
+    except KeyError as exc:
+        raise KeyError(
+            f"no NATS subject mapped for entity_type={envelope.entity_type!r}; "
+            f"add it to SUBJECT_BY_ENTITY"
+        ) from exc
+
+
+async def publish_event(
+    publisher: Publisher,
+    envelope: EventEnvelope,
+    *,
+    subject: str | None = None,
+) -> None:
+    """Serialize ``envelope`` to JSON bytes and publish it via ``publisher``.
+
+    Subject is the explicit ``subject`` argument or, if omitted, derived from
+    the envelope's ``entity_type`` via :func:`subject_for`. The JetStream dedup
+    key (``{entity_id}-v{event_version}``) is passed both as ``msg_id`` and in
+    the ``Nats-Msg-Id`` header so the transport dedups duplicate publishes
+    (ADR 017 idempotency layer 1).
+    """
+    resolved_subject = subject if subject is not None else subject_for(envelope)
+    msg_id = nats_msg_id(envelope.entity_id, envelope.event_version)
+    payload = envelope.model_dump_json().encode("utf-8")
+    await publisher.publish(
+        resolved_subject,
+        payload,
+        msg_id=msg_id,
+        headers={"Nats-Msg-Id": msg_id},
+    )

--- a/projects/lakehouse/events/publish_test.py
+++ b/projects/lakehouse/events/publish_test.py
@@ -1,0 +1,119 @@
+"""Unit tests for transport-agnostic event publishing (ADR agents/017).
+
+Async paths are driven with ``asyncio.run`` rather than the pytest-asyncio
+plugin so the test is fully hermetic and self-contained (no conftest /
+asyncio_mode dependency).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+
+from projects.lakehouse.events.envelope import build_envelope
+from projects.lakehouse.events.publish import (
+    SUBJECT_BY_ENTITY,
+    Publisher,
+    publish_event,
+    subject_for,
+)
+
+
+class FakePublisher:
+    """Captures the args of the most recent publish call."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    async def publish(
+        self,
+        subject: str,
+        payload: bytes,
+        *,
+        msg_id: str | None = None,
+        headers: dict | None = None,
+    ) -> None:
+        self.calls.append(
+            {
+                "subject": subject,
+                "payload": payload,
+                "msg_id": msg_id,
+                "headers": headers,
+            }
+        )
+
+
+def test_fake_publisher_satisfies_protocol():
+    # Structural typing: the fake duck-types the Publisher protocol.
+    assert isinstance(FakePublisher(), Publisher)
+
+
+def test_subject_for_known_entities():
+    for entity_type, subject in SUBJECT_BY_ENTITY.items():
+        env = build_envelope(
+            entity_type=entity_type,
+            entity_id="x-1",
+            event_type="created",
+            event_version=1,
+            producer="p",
+            payload={},
+        )
+        assert subject_for(env) == subject
+
+
+def test_subject_for_unknown_entity_raises():
+    env = build_envelope(
+        entity_type="unknown",
+        entity_id="x-1",
+        event_type="created",
+        event_version=1,
+        producer="p",
+        payload={},
+    )
+    with pytest.raises(KeyError):
+        subject_for(env)
+
+
+def test_publish_event_derives_subject_and_msg_id():
+    pub = FakePublisher()
+    env = build_envelope(
+        entity_type="gap",
+        entity_id="gap-42",
+        event_type="created",
+        event_version=3,
+        producer="monolith.gardener",
+        payload={"topic": "t"},
+    )
+
+    asyncio.run(publish_event(pub, env))
+
+    assert len(pub.calls) == 1
+    call = pub.calls[0]
+    assert call["subject"] == "events.knowledge.gap"
+    assert call["msg_id"] == "gap-42-v3"
+    assert call["headers"] == {"Nats-Msg-Id": "gap-42-v3"}
+    # Payload is the JSON-serialized envelope.
+    decoded = json.loads(call["payload"].decode("utf-8"))
+    assert decoded["entity_id"] == "gap-42"
+    assert decoded["event_version"] == 3
+    assert decoded["payload"] == {"topic": "t"}
+
+
+def test_publish_event_subject_override():
+    pub = FakePublisher()
+    env = build_envelope(
+        entity_type="gap",
+        entity_id="gap-42",
+        event_type="created",
+        event_version=1,
+        producer="p",
+        payload={},
+    )
+
+    asyncio.run(publish_event(pub, env, subject="events.custom.override"))
+
+    assert pub.calls[0]["subject"] == "events.custom.override"
+    # msg_id still derives from the envelope, not the subject.
+    assert pub.calls[0]["msg_id"] == "gap-42-v1"

--- a/projects/lakehouse/events/registry/BUILD
+++ b/projects/lakehouse/events/registry/BUILD
@@ -19,7 +19,6 @@ py_test(
     deps = [
         ":registry",
         "@pip//pydantic",
-        "@pip//pytest",
     ],
 )
 
@@ -38,5 +37,11 @@ semgrep_test(
 semgrep_test(
     name = "__init___semgrep_test",
     srcs = ["__init__.py"],
+    rules = ["//bazel/semgrep/rules:python_rules"],
+)
+
+semgrep_test(
+    name = "registry_test_semgrep_test",
+    srcs = ["registry_test.py"],
     rules = ["//bazel/semgrep/rules:python_rules"],
 )

--- a/projects/lakehouse/events/registry/BUILD
+++ b/projects/lakehouse/events/registry/BUILD
@@ -1,0 +1,42 @@
+load("@aspect_rules_py//py:defs.bzl", "py_library")
+load("//bazel/semgrep/defs:defs.bzl", "semgrep_test")
+load("//bazel/tools/pytest:defs.bzl", "py_test")
+
+py_library(
+    name = "registry",
+    srcs = [
+        "__init__.py",
+        "gap.py",
+        "note.py",
+    ],
+    visibility = ["//:__subpackages__"],
+    deps = ["@pip//pydantic"],
+)
+
+py_test(
+    name = "registry_test",
+    srcs = ["registry_test.py"],
+    deps = [
+        ":registry",
+        "@pip//pydantic",
+        "@pip//pytest",
+    ],
+)
+
+semgrep_test(
+    name = "gap_semgrep_test",
+    srcs = ["gap.py"],
+    rules = ["//bazel/semgrep/rules:python_rules"],
+)
+
+semgrep_test(
+    name = "note_semgrep_test",
+    srcs = ["note.py"],
+    rules = ["//bazel/semgrep/rules:python_rules"],
+)
+
+semgrep_test(
+    name = "__init___semgrep_test",
+    srcs = ["__init__.py"],
+    rules = ["//bazel/semgrep/rules:python_rules"],
+)

--- a/projects/lakehouse/events/registry/BUILD
+++ b/projects/lakehouse/events/registry/BUILD
@@ -19,6 +19,7 @@ py_test(
     deps = [
         ":registry",
         "@pip//pydantic",
+        "@pip//pytest",
     ],
 )
 

--- a/projects/lakehouse/events/registry/__init__.py
+++ b/projects/lakehouse/events/registry/__init__.py
@@ -1,0 +1,54 @@
+"""Payload schema registry with module auto-discovery (ADR agents/017).
+
+Maps ``entity_type -> {event_type -> payload model}``. Adding a new event family
+is "drop a module into this package" — there is no central list to edit. At
+import time the loader walks every sibling submodule with
+:func:`pkgutil.iter_modules`, imports it, and lets each module register its
+payload models into the shared :data:`SCHEMAS` dict via a module-level
+``register(SCHEMAS)`` hook.
+
+A module contributes schemas by defining::
+
+    def register(schemas: dict) -> None:
+        schemas.setdefault("gap", {})["created"] = GapCreatedPayload
+
+The loader is idempotent — re-import is a no-op because Python caches modules
+and ``register`` overwrites the same keys.
+"""
+
+from __future__ import annotations
+
+import importlib
+import pkgutil
+from typing import Any
+
+# entity_type -> {event_type -> pydantic payload model class}
+SCHEMAS: dict[str, dict[str, Any]] = {}
+
+
+def _load() -> None:
+    """Import every submodule of this package and run its ``register`` hook."""
+    for module_info in pkgutil.iter_modules(__path__):
+        if module_info.name.startswith("_"):
+            continue
+        if module_info.name.endswith("_test"):
+            # Don't import test modules during normal registry loading.
+            continue
+        module = importlib.import_module(f"{__name__}.{module_info.name}")
+        register = getattr(module, "register", None)
+        if callable(register):
+            register(SCHEMAS)
+
+
+def payload_model(entity_type: str, event_type: str) -> Any | None:
+    """Return the registered payload model for ``(entity_type, event_type)``.
+
+    Returns ``None`` when no model is registered — consumers tolerate unknown
+    event types per the ADR-017 additive schema rules.
+    """
+    return SCHEMAS.get(entity_type, {}).get(event_type)
+
+
+_load()
+
+__all__ = ["SCHEMAS", "payload_model"]

--- a/projects/lakehouse/events/registry/gap.py
+++ b/projects/lakehouse/events/registry/gap.py
@@ -1,0 +1,65 @@
+"""Gap-event payload schemas (entity_type ``gap``).
+
+Mirrors what the gap-drain pipeline publishes onto ``events.knowledge.gap``.
+The gap lifecycle (states, classes) follows the existing knowledge-graph gap
+pipeline; these payloads carry just enough for consumers/projections without
+inlining the full gap record.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict
+
+# Gap classification (epistemic kind), per the gap pipeline. ``internal`` and
+# ``hybrid`` gaps wait for human review; ``external`` gaps auto-research.
+GapClass = str  # "external" | "internal" | "hybrid"
+
+# Gap workflow state, per the gap pipeline scheduler.
+GapState = str  # e.g. "new" | "researching" | "in_review" | "answered" | "dropped"
+
+
+class GapCreatedPayload(BaseModel):
+    """Payload for a ``gap`` ``created`` event."""
+
+    model_config = ConfigDict(extra="allow")
+
+    topic: str
+    gap_class: GapClass
+    state: GapState
+    context: dict[str, Any] | None = None
+
+
+class GapUpdatedPayload(BaseModel):
+    """Payload for a ``gap`` ``updated`` event (state transition / re-class)."""
+
+    model_config = ConfigDict(extra="allow")
+
+    topic: str | None = None
+    gap_class: GapClass | None = None
+    state: GapState
+    context: dict[str, Any] | None = None
+
+
+class GapTombstonedPayload(BaseModel):
+    """Payload for a ``gap`` ``tombstoned`` event.
+
+    Per ADR 017, a tombstone references the entity and a redacted reason; it
+    does not carry the data being forgotten.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    reason: str | None = None
+
+
+def register(schemas: dict[str, dict]) -> None:
+    """Register gap payload models into the shared SCHEMAS dict."""
+    schemas.setdefault("gap", {}).update(
+        {
+            "created": GapCreatedPayload,
+            "updated": GapUpdatedPayload,
+            "tombstoned": GapTombstonedPayload,
+        }
+    )

--- a/projects/lakehouse/events/registry/note.py
+++ b/projects/lakehouse/events/registry/note.py
@@ -1,0 +1,78 @@
+"""Note-event payload schemas (entity_type ``note``).
+
+Mirrors what the Wavefront-5 backfill will publish onto
+``events.knowledge.note``: the note record plus its chunked, embedded content.
+Embeddings are 1024-dim ``voyage-4-nano`` vectors.
+
+Note text and embeddings are sensitive KG content (ADR 017 §Security) — these
+payloads are the same sensitivity tier as the knowledge graph itself.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+# voyage-4-nano embedding dimensionality.
+EMBEDDING_DIM = 1024
+
+
+class NoteChunk(BaseModel):
+    """One embedded chunk of a note's body."""
+
+    model_config = ConfigDict(extra="allow")
+
+    chunk_index: int
+    section_header: str | None = None
+    chunk_text: str
+    # 1024-dim voyage-4-nano vector. Length is documented, not enforced, so the
+    # schema tolerates a future embedding-model swap without a version bump.
+    embedding: list[float]
+
+
+class NoteCreatedPayload(BaseModel):
+    """Payload for a ``note`` ``created`` event.
+
+    Carries note metadata plus the full set of embedded chunks. ``content_hash``
+    lets consumers dedup / detect no-op republishes of unchanged note bodies.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    note_id: str
+    path: str
+    title: str
+    content_hash: str
+    type: str
+    status: str
+    visibility: str
+    tags: list[str] = Field(default_factory=list)
+    aliases: list[str] = Field(default_factory=list)
+    chunks: list[NoteChunk] = Field(default_factory=list)
+
+
+class NoteUpdatedPayload(NoteCreatedPayload):
+    """Payload for a ``note`` ``updated`` event — same shape as created."""
+
+
+class NoteTombstonedPayload(BaseModel):
+    """Payload for a ``note`` ``tombstoned`` event.
+
+    References the note and a redacted reason only; does not carry the note
+    body or embeddings being forgotten (ADR 017 §Security, RTBF).
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    note_id: str
+    reason: str | None = None
+
+
+def register(schemas: dict[str, dict]) -> None:
+    """Register note payload models into the shared SCHEMAS dict."""
+    schemas.setdefault("note", {}).update(
+        {
+            "created": NoteCreatedPayload,
+            "updated": NoteUpdatedPayload,
+            "tombstoned": NoteTombstonedPayload,
+        }
+    )

--- a/projects/lakehouse/events/registry/registry_test.py
+++ b/projects/lakehouse/events/registry/registry_test.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from pydantic import BaseModel
+import pytest
+from pydantic import BaseModel, ValidationError
 
 from projects.lakehouse.events import registry
 from projects.lakehouse.events.registry import SCHEMAS, payload_model
@@ -57,6 +58,12 @@ def test_gap_created_payload_validates():
     assert p.topic == "t"
     assert p.gap_class == "external"
     assert p.state == "new"
+
+
+def test_gap_created_payload_requires_topic():
+    # ``topic`` is required; omitting it raises a pydantic ValidationError.
+    with pytest.raises(ValidationError):
+        GapCreatedPayload(gap_class="external", state="new")
 
 
 def test_note_created_payload_with_chunks():

--- a/projects/lakehouse/events/registry/registry_test.py
+++ b/projects/lakehouse/events/registry/registry_test.py
@@ -1,0 +1,82 @@
+"""Unit tests for the auto-discovering payload schema registry (ADR agents/017)."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+from projects.lakehouse.events import registry
+from projects.lakehouse.events.registry import SCHEMAS, payload_model
+from projects.lakehouse.events.registry.gap import GapCreatedPayload
+from projects.lakehouse.events.registry.note import NoteChunk, NoteCreatedPayload
+
+
+def test_loader_discovers_gap_and_note():
+    # Both registry modules were auto-imported and registered their entities.
+    assert "gap" in SCHEMAS
+    assert "note" in SCHEMAS
+
+
+def test_gap_schemas_populated():
+    assert SCHEMAS["gap"]["created"] is GapCreatedPayload
+    assert "updated" in SCHEMAS["gap"]
+    assert "tombstoned" in SCHEMAS["gap"]
+
+
+def test_note_schemas_populated():
+    assert SCHEMAS["note"]["created"] is NoteCreatedPayload
+    assert issubclass(SCHEMAS["note"]["created"], BaseModel)
+
+
+def test_payload_model_lookup():
+    assert payload_model("gap", "created") is GapCreatedPayload
+    assert payload_model("note", "created") is NoteCreatedPayload
+
+
+def test_payload_model_unknown_returns_none():
+    assert payload_model("gap", "does-not-exist") is None
+    assert payload_model("unknown-entity", "created") is None
+
+
+def test_reload_is_idempotent():
+    before = {et: dict(types) for et, types in SCHEMAS.items()}
+    registry._load()
+    after = {et: dict(types) for et, types in SCHEMAS.items()}
+    assert before.keys() == after.keys()
+    for et in before:
+        assert before[et] == after[et]
+
+
+def test_test_modules_not_registered_as_entities():
+    # The loader skips ``*_test`` modules, so this test module's import never
+    # pollutes SCHEMAS with a spurious entity type.
+    assert "registry_test" not in SCHEMAS
+
+
+def test_gap_created_payload_validates():
+    p = GapCreatedPayload(topic="t", gap_class="external", state="new")
+    assert p.topic == "t"
+    assert p.gap_class == "external"
+    assert p.state == "new"
+
+
+def test_note_created_payload_with_chunks():
+    chunk = NoteChunk(
+        chunk_index=0,
+        section_header="Intro",
+        chunk_text="hello",
+        embedding=[0.0] * 1024,
+    )
+    note = NoteCreatedPayload(
+        note_id="n1",
+        path="notes/n1.md",
+        title="N1",
+        content_hash="abc",
+        type="reference",
+        status="published",
+        visibility="public",
+        tags=["a", "b"],
+        aliases=["alt"],
+        chunks=[chunk],
+    )
+    assert len(note.chunks) == 1
+    assert len(note.chunks[0].embedding) == 1024

--- a/projects/lakehouse/events/versioning.py
+++ b/projects/lakehouse/events/versioning.py
@@ -1,0 +1,68 @@
+"""Per-entity monotonic event versioning (ADR agents/017).
+
+``event_version`` is monotonic per ``(entity_type, entity_id)`` and is the
+producer's responsibility (ADR 017). This module provides an atomic upsert
+allocator backed by a single counter table. It accepts any PEP 249 DB-API
+connection — the production path uses Postgres; tests use in-memory sqlite3.
+
+The ``lakehouse_event_versions`` table is created by a **deferred migration**
+(not in this unit). :data:`CREATE_TABLE_SQL` is exported so tests (and that
+later migration) can stand the table up; production code must not create it
+ad hoc.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# DDL for the counter table. The composite primary key gives one row per
+# entity instance; ``version`` is the highest version allocated so far.
+# Plain ANSI types so the same DDL works on both Postgres and sqlite3.
+CREATE_TABLE_SQL = """
+CREATE TABLE IF NOT EXISTS lakehouse_event_versions (
+    entity_type text NOT NULL,
+    entity_id   text NOT NULL,
+    version     int  NOT NULL,
+    PRIMARY KEY (entity_type, entity_id)
+)
+""".strip()
+
+# Atomic allocate-next: insert v1 on first sight, otherwise bump the existing
+# counter, returning the value assigned to this call. ON CONFLICT ... RETURNING
+# is supported by both Postgres and modern sqlite3 (>= 3.35), so a single
+# statement is race-free under either backend.
+_UPSERT_SQL = """
+INSERT INTO lakehouse_event_versions (entity_type, entity_id, version)
+VALUES (?, ?, 1)
+ON CONFLICT (entity_type, entity_id)
+DO UPDATE SET version = lakehouse_event_versions.version + 1
+RETURNING version
+""".strip()
+
+
+def next_event_version(conn: Any, entity_type: str, entity_id: str) -> int:
+    """Allocate and return the next monotonic version for an entity.
+
+    First call for a given ``(entity_type, entity_id)`` returns ``1``; each
+    subsequent call returns the prior value plus one. Distinct entities have
+    independent counters. The allocation is a single atomic upsert, so two
+    concurrent producers cannot be handed the same version.
+
+    ``conn`` is a DB-API connection (e.g. ``sqlite3.Connection`` or a psycopg
+    connection). The caller owns the surrounding transaction; this function
+    does not commit so the version allocation can join the producer's
+    event-generation transaction (ADR 017: transactional event generation
+    guarantees order).
+    """
+    cur = conn.cursor()
+    try:
+        cur.execute(_UPSERT_SQL, (entity_type, entity_id))
+        row = cur.fetchone()
+        if row is None:  # pragma: no cover - defensive; RETURNING always yields a row
+            raise RuntimeError(
+                "next_event_version: upsert returned no row; backend may not "
+                "support INSERT ... ON CONFLICT ... RETURNING"
+            )
+        return int(row[0])
+    finally:
+        cur.close()

--- a/projects/lakehouse/events/versioning_test.py
+++ b/projects/lakehouse/events/versioning_test.py
@@ -1,0 +1,52 @@
+"""Unit tests for per-entity monotonic event versioning (ADR agents/017).
+
+Uses an in-memory sqlite3 DB, which supports ``INSERT ... ON CONFLICT ...
+RETURNING`` (sqlite >= 3.35) — the same statement runs against Postgres in
+production.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+from projects.lakehouse.events.versioning import CREATE_TABLE_SQL, next_event_version
+
+
+@pytest.fixture
+def conn():
+    c = sqlite3.connect(":memory:")
+    c.execute(CREATE_TABLE_SQL)
+    yield c
+    c.close()
+
+
+def test_first_call_returns_one(conn):
+    assert next_event_version(conn, "gap", "gap-1") == 1
+
+
+def test_monotonic_increment(conn):
+    assert next_event_version(conn, "gap", "gap-1") == 1
+    assert next_event_version(conn, "gap", "gap-1") == 2
+    assert next_event_version(conn, "gap", "gap-1") == 3
+
+
+def test_distinct_entities_independent(conn):
+    assert next_event_version(conn, "gap", "gap-1") == 1
+    assert next_event_version(conn, "gap", "gap-2") == 1
+    assert next_event_version(conn, "gap", "gap-1") == 2
+    assert next_event_version(conn, "gap", "gap-2") == 2
+
+
+def test_distinct_entity_types_independent(conn):
+    # Same entity_id under different entity_type are separate counters.
+    assert next_event_version(conn, "gap", "x-1") == 1
+    assert next_event_version(conn, "note", "x-1") == 1
+    assert next_event_version(conn, "gap", "x-1") == 2
+
+
+def test_create_table_sql_is_idempotent(conn):
+    # Re-running the DDL must not error (IF NOT EXISTS).
+    conn.execute(CREATE_TABLE_SQL)
+    assert next_event_version(conn, "gap", "gap-1") == 1


### PR DESCRIPTION
Wavefront-2 unit **LIB-EVENTS** — the canonical domain event schema for the event-sourced lakehouse, per [ADR agents/017](docs/decisions/agents/017-domain-event-schema.md).

## What this adds (purely additive — only new files under `projects/lakehouse/events/`)

- **`envelope.py`** — Pydantic v2 `EventEnvelope` with the exact ADR-017 field set; inline RFC-9562 UUIDv7 `new_event_id()`; `nats_msg_id()`; `build_envelope()` convenience constructor; `EventType` Literal.
- **`publish.py`** — transport-agnostic `Publisher` `typing.Protocol` (DI seam, **no** `nats_client` import), `SUBJECT_BY_ENTITY`, `subject_for()`, `async publish_event()` setting the `Nats-Msg-Id` dedup header.
- **`versioning.py`** — `next_event_version()` atomic-upsert per-entity monotonic allocator + `CREATE_TABLE_SQL` (table created by a deferred migration, not this unit).
- **`registry/`** — `pkgutil` auto-discovery loader exposing `SCHEMAS`; `gap` + `note` payload models via module-level `register()` hooks.
- Per-module pytest tests (27, green locally on pydantic 2.x).

## Key decisions

- **Dependency injection** keeps this unit independent of the parallel LIB-NATS unit: the NATS JetStream wrapper satisfies the `Publisher` protocol by duck typing, so there is zero import edge in either direction.
- **Inline UUIDv7** (48-bit ms prefix + `os.urandom`, version/variant bits set) — k-sortable IDs with no new pip dep; strict per-entity ordering comes from `event_version`.
- **Registry auto-discovery** — new event families = drop a module into `registry/`; loader skips `*_test`/`_*` modules.

## Deviations from ADR 017

- `event_type` is `str` on the model (not the `EventType` Literal) so ADR-permitted domain-specific types validate.
- Envelope `extra="forbid"`; payloads `extra="allow"` (additive schema rule).

BUILD files are best-effort; `ci-format-bot`'s gazelle will normalize them and add `semgrep_test` targets on this branch.

Status note: `docs/plans/event-sourced-impl-status/LIB-EVENTS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)