### PR TITLE
feat(lakehouse): workflows package scaffold [W3-PREP]

### DIFF
--- a/docs/plans/event-sourced-impl-status/W3-PREP.md
+++ b/docs/plans/event-sourced-impl-status/W3-PREP.md
@@ -1,0 +1,54 @@
+# W3-PREP — workflows package scaffold (Wavefront-3 prerequisite)
+
+**Unit:** W3-PREP (orchestrator-authored, serialized before the Wavefront-3 fan-out)
+**Classification:** [manual-review] — one existing-file edit (`orchestrator/BUILD` directive).
+
+## Why this exists (not a plan unit)
+
+The plan puts each workflow in its own file under `orchestrator/workflows/<id>.py`
+with pkgutil discovery and "no shared registration list." But gazelle generates
+**one BUILD per directory** (one `py_test` per `*_test.py`), so five parallel
+workflow units would each regenerate `workflows/BUILD` and collide. This unit
+creates the shared seam **once** so the workflow units are genuinely conflict-free.
+
+## What shipped (all new files except one directive edit)
+
+- `orchestrator/workflows/__init__.py` — pkgutil loader: `discover_workflows()` /
+  `discover_activities()` walk this package's modules and read each module's
+  `WORKFLOWS` / `ACTIVITIES` attributes. No shared list to edit.
+- `orchestrator/workflows/run.py` — worker entrypoint
+  (`python -m projects.lakehouse.orchestrator.workflows.run`): reads `TASK_QUEUE`,
+  discovers workflows/activities, runs `orchestrator.worker.run_worker`. The
+  Wavefront-3 worker image uses this as its command. (Note: `worker.py` is NOT
+  modified — discovery lives in this new module, so the merged W2 worker skeleton
+  and its tests stay untouched.)
+- `orchestrator/workflows/BUILD` — **hand-written, gazelle-excluded**, glob-based:
+  `py_library workflows` (glob srcs), `py_venv_binary worker_main` (main=run.py),
+  one glob'd `py_test workflows_test`, and `semgrep_test`. `deps` is a **superset**
+  covering every lakehouse workflow (events, nats_client, iceberg, duckdb_query,
+  orchestrator + @pip temporalio/pyiceberg/pyarrow/duckdb/psycopg/pydantic).
+- `orchestrator/workflows/loader_test.py` — hermetic loader tests.
+- `orchestrator/BUILD` — added `# gazelle:exclude workflows` (the one existing-file
+  edit) so gazelle leaves the hand-written `workflows/BUILD` alone.
+
+## Convention for Wavefront-3 workflow units (READ THIS)
+
+Each workflow unit adds, under `orchestrator/workflows/`, **exactly**:
+
+- `<workflow_id>.py` exporting module-level `WORKFLOWS = [...]` (the
+  `@temporalio.workflow.defn` classes) and optional `ACTIVITIES = [...]`.
+- `<workflow_id>_test.py` (hermetic).
+
+**Touch NO BUILD file** — the globs pick the new files up and `deps` already covers
+them. If a workflow genuinely needs a dep not in the `_WORKFLOW_DEPS` superset,
+STOP and flag it (it's a serialized `workflows/BUILD` edit, not a parallel-safe change).
+gazelle does not run here, so no `# gazelle:resolve` directives are needed — deps
+are explicit `@pip//...` labels.
+
+## Deviations / notes
+
+- Skipped the `gazelle_python.yaml` manifest regen (risky `bazel run`, huge diff).
+  Because `workflows/` is gazelle-excluded with hand-written explicit `@pip//`
+  deps, gazelle's stale module manifest is irrelevant here.
+- Workflows are flat files (per the plan), not subpackages — the glob'd BUILD makes
+  that conflict-free without subpackage nesting.

--- a/projects/lakehouse/orchestrator/BUILD
+++ b/projects/lakehouse/orchestrator/BUILD
@@ -19,6 +19,12 @@ load("//bazel/tools/pytest:defs.bzl", "py_test")
 # gazelle:resolve py temporalio.client @pip//temporalio
 # gazelle:resolve py temporalio.worker @pip//temporalio
 
+# The `workflows/` subpackage is hand-managed (glob-based BUILD) so the parallel
+# Wavefront-3 workflow units can drop one `<id>.py` file each with NO BUILD edit
+# (conflict-free). Exclude it from gazelle so it isn't rewritten into per-file
+# targets that would collide across those units.
+# gazelle:exclude workflows
+
 py_library(
     name = "orchestrator",
     srcs = [

--- a/projects/lakehouse/orchestrator/workflows/BUILD
+++ b/projects/lakehouse/orchestrator/workflows/BUILD
@@ -27,7 +27,10 @@ _WORKFLOW_DEPS = [
 
 py_library(
     name = "workflows",
-    srcs = glob(["**/*.py"], exclude = ["**/*_test.py"]),
+    srcs = glob(
+        ["**/*.py"],
+        exclude = ["**/*_test.py"],
+    ),
     visibility = ["//:__subpackages__"],
     deps = _WORKFLOW_DEPS,
 )
@@ -37,7 +40,10 @@ py_library(
 # differentiated only by the TASK_QUEUE env var.
 py_venv_binary(
     name = "worker_main",
-    srcs = glob(["**/*.py"], exclude = ["**/*_test.py"]),
+    srcs = glob(
+        ["**/*.py"],
+        exclude = ["**/*_test.py"],
+    ),
     main = "run.py",
     visibility = ["//:__subpackages__"],
     deps = _WORKFLOW_DEPS,

--- a/projects/lakehouse/orchestrator/workflows/BUILD
+++ b/projects/lakehouse/orchestrator/workflows/BUILD
@@ -1,0 +1,61 @@
+# HAND-WRITTEN, gazelle-excluded (see `# gazelle:exclude workflows` in
+# projects/lakehouse/orchestrator/BUILD). This package is the conflict-free seam
+# for Wavefront-3 workflow units: each drops ONE `<workflow_id>.py` file here
+# (exporting module-level WORKFLOWS / ACTIVITIES) plus a `<workflow_id>_test.py`,
+# and touches NO BUILD file — the globs below pick them up automatically and the
+# loader (__init__.py) + run.py discover them at runtime. `deps` is a superset
+# covering every lakehouse workflow so a new file needs no dep edit here.
+load("@aspect_rules_py//py:defs.bzl", "py_library")
+load("@aspect_rules_py//py/private/py_venv:defs.bzl", "py_venv_binary")
+load("//bazel/semgrep/defs:defs.bzl", "semgrep_test")
+load("//bazel/tools/pytest:defs.bzl", "py_test")
+
+_WORKFLOW_DEPS = [
+    "//projects/lakehouse/events",
+    "//projects/lakehouse/nats_client",
+    "//projects/lakehouse/iceberg",
+    "//projects/lakehouse/duckdb_query",
+    "//projects/lakehouse/orchestrator",
+    "@pip//temporalio",
+    "@pip//pyiceberg",
+    "@pip//pyarrow",
+    "@pip//duckdb",
+    "@pip//psycopg",
+    "@pip//psycopg_binary",
+    "@pip//pydantic",
+]
+
+py_library(
+    name = "workflows",
+    srcs = glob(["**/*.py"], exclude = ["**/*_test.py"]),
+    visibility = ["//:__subpackages__"],
+    deps = _WORKFLOW_DEPS,
+)
+
+# Worker entrypoint binary: `python -m projects.lakehouse.orchestrator.workflows.run`.
+# The Wavefront-3 worker apko image wraps this; many Deployments share it,
+# differentiated only by the TASK_QUEUE env var.
+py_venv_binary(
+    name = "worker_main",
+    srcs = glob(["**/*.py"], exclude = ["**/*_test.py"]),
+    main = "run.py",
+    visibility = ["//:__subpackages__"],
+    deps = _WORKFLOW_DEPS,
+)
+
+# One glob'd test target (not one-per-file) so adding a workflow test requires
+# no edit here — keeping parallel workflow units conflict-free.
+py_test(
+    name = "workflows_test",
+    srcs = glob(["**/*_test.py"]),
+    deps = [
+        ":workflows",
+        "@pip//pytest",
+    ] + _WORKFLOW_DEPS,
+)
+
+semgrep_test(
+    name = "workflows_semgrep_test",
+    srcs = glob(["**/*.py"]),
+    rules = ["//bazel/semgrep/rules:python_rules"],
+)

--- a/projects/lakehouse/orchestrator/workflows/__init__.py
+++ b/projects/lakehouse/orchestrator/workflows/__init__.py
@@ -1,0 +1,53 @@
+"""Auto-discovery loader for lakehouse Temporal workflows (ADR agents/015).
+
+Each workflow module dropped under this package exports module-level
+``WORKFLOWS`` (a list of ``@temporalio.workflow.defn`` classes) and an optional
+``ACTIVITIES`` (a list of activity callables). New workflows = a new file here;
+the worker entrypoint (:mod:`projects.lakehouse.orchestrator.workflows.run`)
+discovers them through this loader, so there is **no shared registration list**
+to edit — that's what keeps the per-workflow Wavefront-3 units conflict-free.
+
+The loader itself imports neither ``temporalio`` nor the workflow modules'
+heavy deps at definition time beyond ``importlib``; it just walks the package
+and reads the modules' ``WORKFLOWS``/``ACTIVITIES`` attributes.
+"""
+
+from __future__ import annotations
+
+import importlib
+import pkgutil
+from types import ModuleType
+
+# Modules in this package that are NOT workflow modules.
+_NON_WORKFLOW_MODULES = {"run"}
+
+
+def _iter_workflow_modules() -> list[ModuleType]:
+    """Import and return every workflow module in this package."""
+    modules: list[ModuleType] = []
+    for info in pkgutil.iter_modules(__path__, prefix=__name__ + "."):
+        leaf = info.name.rsplit(".", 1)[-1]
+        if (
+            leaf.startswith("_")
+            or leaf.endswith("_test")
+            or leaf in _NON_WORKFLOW_MODULES
+        ):
+            continue
+        modules.append(importlib.import_module(info.name))
+    return modules
+
+
+def discover_workflows() -> list[type]:
+    """Collect all ``@workflow.defn`` classes exported by workflow modules."""
+    found: list[type] = []
+    for module in _iter_workflow_modules():
+        found.extend(getattr(module, "WORKFLOWS", ()))
+    return found
+
+
+def discover_activities() -> list[object]:
+    """Collect all activity callables exported by workflow modules."""
+    found: list[object] = []
+    for module in _iter_workflow_modules():
+        found.extend(getattr(module, "ACTIVITIES", ()))
+    return found

--- a/projects/lakehouse/orchestrator/workflows/loader_test.py
+++ b/projects/lakehouse/orchestrator/workflows/loader_test.py
@@ -1,0 +1,19 @@
+"""Tests for the workflow auto-discovery loader (hermetic — no Temporal)."""
+
+from __future__ import annotations
+
+import pytest
+
+from projects.lakehouse.orchestrator import workflows as wf
+
+
+@pytest.mark.parametrize("fn", [wf.discover_workflows, wf.discover_activities])
+def test_discovery_returns_list(fn) -> None:
+    # Always a list — empty at scaffold time, populated as workflow modules
+    # (each exporting WORKFLOWS/ACTIVITIES) are added by later units.
+    assert isinstance(fn(), list)
+
+
+def test_entrypoint_module_excluded_from_discovery() -> None:
+    # The 'run' entrypoint must never be treated as a workflow module.
+    assert "run" in wf._NON_WORKFLOW_MODULES

--- a/projects/lakehouse/orchestrator/workflows/run.py
+++ b/projects/lakehouse/orchestrator/workflows/run.py
@@ -1,0 +1,39 @@
+"""Worker entrypoint — discover + run all lakehouse workflows for ``$TASK_QUEUE``.
+
+    python -m projects.lakehouse.orchestrator.workflows.run
+
+Reads ``TASK_QUEUE`` from the environment, discovers every workflow/activity
+registered under :mod:`projects.lakehouse.orchestrator.workflows` via the
+package loader, and runs a Temporal worker against that queue. One image, many
+Deployments differentiated only by ``TASK_QUEUE`` (ADR 015 §"Worker pools, not
+the orchestrator"). The Wavefront-3 worker image (``projects/lakehouse/image``)
+uses this module as its command.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+
+from projects.lakehouse.orchestrator.worker import run_worker
+from projects.lakehouse.orchestrator.workflows import (
+    discover_activities,
+    discover_workflows,
+)
+
+
+def _main() -> None:
+    task_queue = os.environ.get("TASK_QUEUE")
+    if not task_queue:
+        raise SystemExit("TASK_QUEUE environment variable is required")
+    asyncio.run(
+        run_worker(
+            task_queue,
+            workflows=discover_workflows(),
+            activities=discover_activities(),
+        )
+    )
+
+
+if __name__ == "__main__":
+    _main()


### PR DESCRIPTION
## W3-PREP — serialized Wavefront-3 prerequisite

Creates the shared `orchestrator/workflows/` seam **once** so the parallel Wavefront-3 workflow units are conflict-free:
- `workflows/__init__.py` — pkgutil loader (`discover_workflows`/`discover_activities`, reads each module's `WORKFLOWS`/`ACTIVITIES`).
- `workflows/run.py` — worker entrypoint (`python -m projects.lakehouse.orchestrator.workflows.run`), reused by the W3 worker image. `worker.py` left untouched.
- `workflows/BUILD` — **hand-written, gazelle-excluded, glob-based** so each workflow unit drops one `<id>.py` with zero BUILD edits; `deps` is a superset of all lakehouse workflow deps.
- `orchestrator/BUILD` — one directive added: `# gazelle:exclude workflows`.

[manual-review]: one existing-file edit (the gazelle directive); everything else new. Validates the glob BUILD before the workflow fan-out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)