### PR TITLE
feat(lakehouse): worker apko image wrapping the Temporal worker entrypoint (IMG-WORKER)

### DIFF
--- a/bazel/images/BUILD
+++ b/bazel/images/BUILD
@@ -51,6 +51,7 @@ multirun(
         "//projects/grimoire/frontend:image.push",
         "//projects/grimoire/ws-gateway:image.push",
         "//projects/hikes/update_forecast:update_image.push",
+        "//projects/lakehouse/image:image.push",
         "//projects/monolith/chart:chart.push",
         "//projects/monolith/frontend:image.push",
         "//projects/monolith/obsidian-image:image.push",

--- a/docs/plans/event-sourced-impl-status/IMG-WORKER.md
+++ b/docs/plans/event-sourced-impl-status/IMG-WORKER.md
@@ -1,0 +1,63 @@
+# IMG-WORKER — projects/lakehouse/image (Temporal worker apko image)
+
+**Unit:** IMG-WORKER (Wavefront 3)
+**ADR:** [agents/015 — Temporal Orchestration Substrate](../../decisions/agents/015-temporal-orchestration-substrate.md) §"Worker pools, not the orchestrator"
+**Branch:** `feat/lakehouse-img-worker`
+**Classification:** purely-additive — one new dir `projects/lakehouse/image/` plus a
+one-line insert into the auto-generated `bazel/images/BUILD` push list (exactly
+what `//bazel/images:generate-push-all` would emit; pre-applied so the FIRST CI
+run pushes the image and the format check sees no diff).
+
+## What shipped
+
+`projects/lakehouse/image/BUILD` — a single `py3_image` target, modeled
+field-for-field on the monolith `image` target:
+
+- `name = "image"`, `binary = "//projects/lakehouse/orchestrator/workflows:worker_main"`
+  (the W3-PREP entrypoint, `python -m projects.lakehouse.orchestrator.workflows.run`,
+  reads `TASK_QUEUE`).
+- `multiarch_tars = ["@claude_code//:tar"]` — bundles the Claude Code CLI (same as
+  the monolith backend image) so the gap-drain `run_research_session` activity can
+  invoke the existing harness. Dual-arch via the macro's `_amd64`/`_arm64` split.
+- `repository = "ghcr.io/jomcgi/homelab/projects/lakehouse/worker"`.
+- `env`:
+  - `PYTHONPATH = "/projects/lakehouse/orchestrator/workflows/worker_main.runfiles/_main"`
+    — the macro's auto-computed workspace root. `run.py` uses absolute
+    `from projects.lakehouse.orchestrator...` imports that resolve from that root,
+    so (unlike the monolith, which adds its package dir for its `imports = ["."]`
+    layout) only the workspace root is needed. Set explicitly for clarity.
+  - `SSL_CERT_FILE = ".../worker_main.runfiles/_main/projects/lakehouse/orchestrator/workflows/.worker_main/lib/python3.13/site-packages/certifi/cacert.pem"`
+    — certifi bundle (certifi==2026.2.25 is in `bazel/requirements/all.txt`,
+    transitively pulled by temporalio/pyiceberg) for outbound HTTPS. Path follows
+    the monolith pattern: `{runfiles}/_main/{binary.package}/.{binary.name}/lib/python3.13/site-packages/certifi/cacert.pem`.
+- Non-root uid 65532 / dual-arch handled by the `py3_image` macro + `@python_base`.
+
+## Design decisions
+
+- **`main` intentionally omitted.** The macro only emits the supplementary
+  `_srcs` tar when `main` is set, and that tar references
+  `//projects/lakehouse/orchestrator/workflows:run.py` as a source-file label —
+  which is **package-private** (the hand-written `workflows/BUILD` has no
+  `exports_files`/`default_visibility`), so setting `main` cross-package would
+  fail with a visibility error. `worker_main` already carries `run.py` in its
+  runfiles (its glob `srcs` include it), so the tar is unnecessary. This mirrors
+  the only other cross-package `py3_image` in the repo
+  (`//projects/agent_platform/orchestrator/mcp:image`), which also omits `main`.
+
+## One artifact, many Deployments
+
+This is ONE image. Per-queue Deployments (Wavefront 4) set `TASK_QUEUE`
+(gap-drain / iceberg-builder / housekeeping); there is no separate orchestrator
+pod. KEDA scales each pool to queue depth.
+
+## Validation
+
+No local `bazel build` (Mac has no `workflows`-pool runner). Validated by:
+
+- Manually replaying the `generate-push-all.sh` awk against the new BUILD →
+  confirms it emits `//projects/lakehouse/image:image.push` (matches the
+  pre-inserted line in `bazel/images/BUILD`).
+- Field-by-field comparison against the monolith `image` target and the macro
+  signature in `//bazel/tools/oci:py3_image.bzl`.
+- CI "Push images" (`push_all`) + the macro's `image_config_test` are the real
+  validation.

--- a/projects/lakehouse/image/BUILD
+++ b/projects/lakehouse/image/BUILD
@@ -1,0 +1,42 @@
+# HAND-WRITTEN (py3_image is a custom macro; gazelle does not manage it).
+# Modeled field-for-field on the monolith `image` target (projects/monolith/BUILD).
+#
+# ONE worker image for the event-sourced lakehouse. The image wraps the shared
+# Temporal worker entrypoint (//projects/lakehouse/orchestrator/workflows:worker_main,
+# `python -m projects.lakehouse.orchestrator.workflows.run`). Per ADR 015
+# §"Worker pools, not the orchestrator", there is no single orchestrator pod:
+# many Deployments share THIS image, differentiated only by the TASK_QUEUE env
+# var (gap-drain / iceberg-builder / housekeeping). The per-queue Deployments
+# are Wavefront 4; this unit (IMG-WORKER) ships only the image artifact.
+load("//bazel/tools/oci:py3_image.bzl", "py3_image")
+
+py3_image(
+    name = "image",
+    binary = "//projects/lakehouse/orchestrator/workflows:worker_main",
+    env = {
+        # The macro already sets PYTHONPATH to the workspace root
+        # (worker_main.runfiles/_main). worker_main's run.py uses absolute
+        # `from projects.lakehouse.orchestrator...` imports that resolve from
+        # that root, so unlike the monolith (which adds its package dir for its
+        # `imports = ["."]` layout) we only need the workspace root. Set it
+        # explicitly so the runtime import path is obvious and self-documenting.
+        "PYTHONPATH": "/projects/lakehouse/orchestrator/workflows/worker_main.runfiles/_main",
+        # The minimal base image has no CA certificates; point OpenSSL at
+        # certifi's bundle so outbound HTTPS works (Temporal Cloud/NATS TLS,
+        # the Claude Code harness invoked by run_research_session, etc.).
+        # The venv dir is `.{binary_name}` inside the binary's package dir.
+        "SSL_CERT_FILE": "/projects/lakehouse/orchestrator/workflows/worker_main.runfiles/_main/projects/lakehouse/orchestrator/workflows/.worker_main/lib/python3.13/site-packages/certifi/cacert.pem",
+    },
+    # `main` is intentionally omitted (cross-package). The macro only emits the
+    # supplementary `_srcs` tar — and only needs to — when `main` is set; that
+    # tar would reference //projects/lakehouse/orchestrator/workflows:run.py as a
+    # source-file label, which is package-private. worker_main already carries
+    # run.py in its runfiles (its glob `srcs` include it), so the tar is
+    # unnecessary. This mirrors the only other cross-package py3_image in the
+    # repo (//projects/agent_platform/orchestrator/mcp:image), which likewise
+    # omits `main`.
+    # Bundle the Claude Code CLI (same as the monolith backend image) so the
+    # gap-drain `run_research_session` activity can invoke the existing harness.
+    multiarch_tars = ["@claude_code//:tar"],
+    repository = "ghcr.io/jomcgi/homelab/projects/lakehouse/worker",
+)


### PR DESCRIPTION
## IMG-WORKER (Wavefront 3) — event-sourced lakehouse

Adds `projects/lakehouse/image/` with a single `py3_image` target packaging the W3-PREP worker entrypoint `//projects/lakehouse/orchestrator/workflows:worker_main` (`python -m projects.lakehouse.orchestrator.workflows.run`, reads `TASK_QUEUE`).

Per ADR 015 §"Worker pools, not the orchestrator", this is **one** image; the per-queue Deployments (Wavefront 4) differ only by `TASK_QUEUE` (gap-drain / iceberg-builder / housekeeping). There is no separate orchestrator pod.

### The `py3_image` target
Modeled field-for-field on the monolith `image` target:
- `binary = "//projects/lakehouse/orchestrator/workflows:worker_main"`
- `multiarch_tars = ["@claude_code//:tar"]` — bundles the Claude Code CLI (same as the monolith backend) so the gap-drain `run_research_session` activity can invoke the harness. Dual-arch handled by the macro.
- `repository = "ghcr.io/jomcgi/homelab/projects/lakehouse/worker"`
- `env.PYTHONPATH = "/projects/lakehouse/orchestrator/workflows/worker_main.runfiles/_main"` — the macro's workspace root; `run.py`'s absolute `projects.lakehouse.*` imports resolve from there.
- `env.SSL_CERT_FILE` → certifi bundle in the `.worker_main` venv (`certifi==2026.2.25` is in the lock, pulled transitively by temporalio/pyiceberg) for outbound HTTPS.
- Non-root uid 65532 + dual-arch via the macro / `@python_base`.

### `main` intentionally omitted (cross-package)
Setting `main` would make the macro emit a `_srcs` tar referencing `//projects/lakehouse/orchestrator/workflows:run.py` as a **package-private** source-file label → visibility error. `worker_main` already carries `run.py` in its runfiles (glob `srcs`), so the tar is unnecessary. Mirrors the only other cross-package `py3_image` in the repo (`//projects/agent_platform/orchestrator/mcp:image`), which also omits `main`.

### Push-list
Pre-inserted `//projects/lakehouse/image:image.push` into the auto-generated `bazel/images/BUILD` (verified it's exactly what `generate-push-all.sh` would emit) so the first CI run pushes the image and the format check sees no diff.

### Validation
No local `bazel build` (Mac has no `workflows`-pool runner). CI "Push images" (`push_all`) + the macro's `image_config_test` are the real validation.

Status note: `docs/plans/event-sourced-impl-status/IMG-WORKER.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)