### PR TITLE
feat(lakehouse): add Temporal schedule definitions (WF-SCHEDULES)

### DIFF
--- a/docs/plans/event-sourced-impl-status/WF-SCHEDULES.md
+++ b/docs/plans/event-sourced-impl-status/WF-SCHEDULES.md
@@ -1,0 +1,70 @@
+# WF-SCHEDULES — Temporal schedule definitions (Wavefront 3)
+
+**Unit:** WF-SCHEDULES (Wavefront-3 fan-out)
+**Branch / PR:** `feat/lakehouse-wf-schedules`
+**Classification:** [auto] — all-new gazelle-managed package; no shared-file edits.
+
+## What shipped
+
+New package `projects/lakehouse/orchestrator/schedules/` (the unit owns the whole
+dir, so its hand-written `BUILD` is not a cross-unit conflict):
+
+- `__init__.py` — pkgutil loader + idempotent registration helper:
+  - `ScheduleDefinition(schedule_id, schedule)` — frozen dataclass; `schedule` is
+    a `temporalio.client.Schedule`.
+  - `all_schedules() -> list[ScheduleDefinition]` — walks this package via
+    `pkgutil.iter_modules`, aggregating each submodule's module-level `SCHEDULES`
+    list. New schedule = new file, **no shared list to edit** (conflict-free,
+    mirrors the `workflows` loader).
+  - `register_schedules(client, *, namespace="default")` — async; for each
+    discovered definition calls `client.create_schedule(id, schedule)`, swallowing
+    `temporalio.client.ScheduleAlreadyRunningError`. Called from monolith/worker
+    startup in Wavefront 5. (`temporalio` imported lazily inside the function so
+    the hermetic loader stays import-light.)
+- One file per schedule (each exports `SCHEDULES = [ScheduleDefinition(...)]`):
+  - `gap_drain_sweep.py`, `iceberg_batch.py`, `build_serving.py`, `tag_rotation.py`.
+- `schedules_test.py` — hermetic: discovery of all four, per-spec workflow
+  type-name / cadence / task queue, and `register_schedules` against a mocked
+  client (create-per-spec, AlreadyRunning swallowed, unexpected errors propagate).
+- `BUILD` — hand-written following the sibling `orchestrator`/`events` gazelle
+  pattern (`py_library` globbing all non-test srcs, one `py_test`, one
+  `semgrep_test` per source). Includes the proven `# gazelle:resolve py
+temporalio @pip//temporalio` (+ `.client`) directives because the generated
+  module manifest (`bazel/tools/python/gazelle_python.yaml`) was never regenerated
+  to include `temporalio` (same situation the W2/orchestrator package documents).
+
+## The four schedules
+
+| Schedule ID              | Workflow type-name             | Cadence             | Task queue        |
+| ------------------------ | ------------------------------ | ------------------- | ----------------- |
+| `gap-drain-sweep`        | `GapDrainSweepWorkflow`        | cron `*/5 * * * *`  | `gap-drain`       |
+| `iceberg-batch-commit`   | `IcebergBatchCommitWorkflow`   | interval 90s        | `iceberg-builder` |
+| `build-serving-artifact` | `BuildServingArtifactWorkflow` | cron `*/15 * * * *` | `housekeeping`    |
+| `tag-rotation`           | `TagRotationWorkflow`          | cron `*/15 * * * *` | `housekeeping`    |
+
+Iceberg batch commit uses an interval (`ScheduleIntervalSpec(every=90s)`) rather
+than cron — sub-minute granularity isn't expressible in 5-field cron, and 90s
+matches the "every 1-2 min" batch-commit intent. The other three use
+`ScheduleSpec(cron_expressions=[...])`.
+
+## Idempotency
+
+Workflows are referenced **by type-name string**
+(`ScheduleActionStartWorkflow(workflow="GapDrainSweepWorkflow", ...)`), so this
+package imports neither the workflow classes nor the parallel WF-STORAGE /
+WF-DOMAIN units. `register_schedules` is idempotent because `create_schedule`
+raises `ScheduleAlreadyRunningError` when a schedule ID already exists (created on
+a prior boot); the helper catches and skips it, so re-running registration on
+every startup is a no-op for already-registered schedules. Unexpected errors
+propagate.
+
+## Deviations / notes
+
+- The standalone `gazelle` binary in the dev-tools cache did not emit a BUILD for
+  the new dir locally (it lacks the repo's full Python gazelle config, which is
+  CI-only under `//bazel/tools/python`). BUILD was hand-written to the exact
+  sibling pattern; ci-format-bot will normalize it on the PR if needed.
+- `register_schedules` accepts `namespace` for surface symmetry and logs it;
+  Temporal has no per-call namespace override on `create_schedule`, so the
+  schedule is created in whatever namespace the `client` is connected to (callers
+  connect the client to the target namespace).

--- a/projects/lakehouse/orchestrator/schedules/BUILD
+++ b/projects/lakehouse/orchestrator/schedules/BUILD
@@ -42,12 +42,6 @@ py_test(
 )
 
 semgrep_test(
-    name = "init_semgrep_test",
-    srcs = ["__init__.py"],
-    rules = ["//bazel/semgrep/rules:python_rules"],
-)
-
-semgrep_test(
     name = "build_serving_semgrep_test",
     srcs = ["build_serving.py"],
     rules = ["//bazel/semgrep/rules:python_rules"],
@@ -74,5 +68,11 @@ semgrep_test(
 semgrep_test(
     name = "schedules_test_semgrep_test",
     srcs = ["schedules_test.py"],
+    rules = ["//bazel/semgrep/rules:python_rules"],
+)
+
+semgrep_test(
+    name = "__init___semgrep_test",
+    srcs = ["__init__.py"],
     rules = ["//bazel/semgrep/rules:python_rules"],
 )

--- a/projects/lakehouse/orchestrator/schedules/BUILD
+++ b/projects/lakehouse/orchestrator/schedules/BUILD
@@ -1,0 +1,78 @@
+load("@aspect_rules_py//py:defs.bzl", "py_library")
+load("//bazel/semgrep/defs:defs.bzl", "semgrep_test")
+load("//bazel/tools/pytest:defs.bzl", "py_test")
+
+# Temporal schedule definitions (ADR agents/015 §"Scheduling unified with
+# execution"): one file per schedule exporting `SCHEDULES`, aggregated by the
+# pkgutil loader in __init__.py. ci-format-bot (gazelle) normalizes this file.
+#
+# The `temporalio` wheel is in the pip lock (added by LIB-SCAFFOLD) but the
+# generated gazelle module manifest (bazel/tools/python/gazelle_python.yaml,
+# GENERATED / DO NOT EDIT, content-checked) was not regenerated to include it,
+# so gazelle can't auto-resolve `import temporalio`. Resolve it explicitly here
+# (the documented escape hatch, also used by the sibling orchestrator package).
+# gazelle:resolve py temporalio @pip//temporalio
+# gazelle:resolve py temporalio.client @pip//temporalio
+
+py_library(
+    name = "schedules",
+    srcs = [
+        "__init__.py",
+        "build_serving.py",
+        "gap_drain_sweep.py",
+        "iceberg_batch.py",
+        "tag_rotation.py",
+    ],
+    visibility = ["//:__subpackages__"],
+    deps = [
+        "//projects/lakehouse/orchestrator",
+        "@pip//temporalio",
+    ],
+)
+
+py_test(
+    name = "schedules_test",
+    srcs = ["schedules_test.py"],
+    deps = [
+        ":schedules",
+        "//projects/lakehouse/orchestrator",
+        "@pip//pytest",
+        "@pip//temporalio",
+    ],
+)
+
+semgrep_test(
+    name = "init_semgrep_test",
+    srcs = ["__init__.py"],
+    rules = ["//bazel/semgrep/rules:python_rules"],
+)
+
+semgrep_test(
+    name = "build_serving_semgrep_test",
+    srcs = ["build_serving.py"],
+    rules = ["//bazel/semgrep/rules:python_rules"],
+)
+
+semgrep_test(
+    name = "gap_drain_sweep_semgrep_test",
+    srcs = ["gap_drain_sweep.py"],
+    rules = ["//bazel/semgrep/rules:python_rules"],
+)
+
+semgrep_test(
+    name = "iceberg_batch_semgrep_test",
+    srcs = ["iceberg_batch.py"],
+    rules = ["//bazel/semgrep/rules:python_rules"],
+)
+
+semgrep_test(
+    name = "tag_rotation_semgrep_test",
+    srcs = ["tag_rotation.py"],
+    rules = ["//bazel/semgrep/rules:python_rules"],
+)
+
+semgrep_test(
+    name = "schedules_test_semgrep_test",
+    srcs = ["schedules_test.py"],
+    rules = ["//bazel/semgrep/rules:python_rules"],
+)

--- a/projects/lakehouse/orchestrator/schedules/__init__.py
+++ b/projects/lakehouse/orchestrator/schedules/__init__.py
@@ -1,0 +1,114 @@
+"""Temporal schedule definitions for the lakehouse (ADR agents/015).
+
+ADR 015 §"Scheduling unified with execution": cron-style triggers become
+Temporal ``Schedule``s registered idempotently from startup, sharing the same
+Postgres persistence, retry policy, and UI as event-triggered workflows. The
+per-domain scheduler module shrinks to "register Temporal Schedules from a
+``SCHEDULES`` list at boot."
+
+Each schedule lives in its own module here exporting a module-level
+``SCHEDULES`` list of :class:`ScheduleDefinition`. New schedule = a new file;
+:func:`all_schedules` aggregates them via ``pkgutil`` discovery, so there is
+**no shared registration list** to edit (conflict-free, mirroring the
+``workflows`` loader). :func:`register_schedules` is called from monolith/worker
+startup (Wavefront 5) to idempotently create each schedule.
+
+Schedules reference their target workflow **by type-name string**
+(``ScheduleActionStartWorkflow(workflow="...")``), so this package does not
+import the workflow classes and stays independent of the parallel
+WF-STORAGE / WF-DOMAIN units.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import importlib
+import logging
+import pkgutil
+from types import ModuleType
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    import temporalio.client
+
+logger = logging.getLogger(__name__)
+
+
+@dataclasses.dataclass(frozen=True)
+class ScheduleDefinition:
+    """A single schedule: its stable ID plus the Temporal ``Schedule`` spec.
+
+    ``schedule`` is typed loosely (``object``) so importing this module — and
+    running the hermetic loader tests — never forces a ``temporalio`` import at
+    module-definition time when it isn't needed. The submodules that build the
+    actual specs import ``temporalio.client`` themselves.
+    """
+
+    schedule_id: str
+    schedule: object
+
+
+def _iter_schedule_modules() -> list[ModuleType]:
+    """Import and return every schedule module in this package."""
+    modules: list[ModuleType] = []
+    for info in pkgutil.iter_modules(__path__, prefix=__name__ + "."):
+        leaf = info.name.rsplit(".", 1)[-1]
+        if leaf.startswith("_") or leaf.endswith("_test"):
+            continue
+        modules.append(importlib.import_module(info.name))
+    return modules
+
+
+def all_schedules() -> list[ScheduleDefinition]:
+    """Aggregate the ``SCHEDULES`` list exported by every schedule module."""
+    found: list[ScheduleDefinition] = []
+    for module in _iter_schedule_modules():
+        found.extend(getattr(module, "SCHEDULES", ()))
+    return found
+
+
+async def register_schedules(
+    client: temporalio.client.Client,
+    *,
+    namespace: str = "default",
+) -> None:
+    """Idempotently create every discovered schedule on ``client``.
+
+    Called once from monolith/worker startup (Wavefront 5). For each
+    :class:`ScheduleDefinition`, calls ``client.create_schedule(id, schedule)``.
+    If a schedule with that ID already exists (a prior boot created it),
+    Temporal raises :class:`temporalio.client.ScheduleAlreadyRunningError`,
+    which is swallowed — that's what makes startup registration idempotent:
+    re-running it on every boot is a no-op for already-registered schedules.
+
+    ``namespace`` is accepted for symmetry with the rest of the orchestrator
+    surface and logged; the schedule is created in whatever namespace ``client``
+    is connected to (Temporal has no per-call namespace override on
+    ``create_schedule``), so callers should connect the client to ``namespace``.
+    """
+    # Imported lazily so module import (and the hermetic loader tests) don't
+    # require temporalio to be importable.
+    import temporalio.client
+
+    for definition in all_schedules():
+        try:
+            await client.create_schedule(definition.schedule_id, definition.schedule)
+            logger.info(
+                "registered Temporal schedule %s (namespace=%s)",
+                definition.schedule_id,
+                namespace,
+            )
+        except temporalio.client.ScheduleAlreadyRunningError:
+            # Already registered by a prior boot — idempotent no-op.
+            logger.debug(
+                "Temporal schedule %s already exists; skipping (namespace=%s)",
+                definition.schedule_id,
+                namespace,
+            )
+
+
+__all__ = [
+    "ScheduleDefinition",
+    "all_schedules",
+    "register_schedules",
+]

--- a/projects/lakehouse/orchestrator/schedules/build_serving.py
+++ b/projects/lakehouse/orchestrator/schedules/build_serving.py
@@ -1,0 +1,34 @@
+"""Schedule: rebuild serving artifacts from the lakehouse (ADR agents/015).
+
+Drives ``BuildServingArtifactWorkflow`` on the ``housekeeping`` task queue every
+15 minutes to refresh the query-serving artifacts derived from committed Iceberg
+data.
+
+References the workflow by **type-name string** so this module is independent of
+the WF-STORAGE / WF-DOMAIN units that define ``BuildServingArtifactWorkflow``.
+"""
+
+from __future__ import annotations
+
+import temporalio.client
+
+from projects.lakehouse.orchestrator import TaskQueue
+from projects.lakehouse.orchestrator.schedules import ScheduleDefinition
+
+WORKFLOW_TYPE = "BuildServingArtifactWorkflow"
+SCHEDULE_ID = "build-serving-artifact"
+CRON = "*/15 * * * *"
+
+SCHEDULES = [
+    ScheduleDefinition(
+        schedule_id=SCHEDULE_ID,
+        schedule=temporalio.client.Schedule(
+            action=temporalio.client.ScheduleActionStartWorkflow(
+                WORKFLOW_TYPE,
+                id=SCHEDULE_ID,
+                task_queue=TaskQueue.HOUSEKEEPING.value,
+            ),
+            spec=temporalio.client.ScheduleSpec(cron_expressions=[CRON]),
+        ),
+    ),
+]

--- a/projects/lakehouse/orchestrator/schedules/gap_drain_sweep.py
+++ b/projects/lakehouse/orchestrator/schedules/gap_drain_sweep.py
@@ -1,0 +1,34 @@
+"""Schedule: sweep the knowledge-gap drain queue (ADR agents/015).
+
+Periodically kicks the ``GapDrainSweepWorkflow`` to drain pending gaps onto the
+``gap-drain`` task queue. Cron every 5 minutes — matches the gap pipeline's
+existing scheduler cadence (the auto-research drain it replaces).
+
+References the workflow by **type-name string** so this module is independent of
+the WF-DOMAIN unit that defines ``GapDrainSweepWorkflow``.
+"""
+
+from __future__ import annotations
+
+import temporalio.client
+
+from projects.lakehouse.orchestrator import TaskQueue
+from projects.lakehouse.orchestrator.schedules import ScheduleDefinition
+
+WORKFLOW_TYPE = "GapDrainSweepWorkflow"
+SCHEDULE_ID = "gap-drain-sweep"
+CRON = "*/5 * * * *"
+
+SCHEDULES = [
+    ScheduleDefinition(
+        schedule_id=SCHEDULE_ID,
+        schedule=temporalio.client.Schedule(
+            action=temporalio.client.ScheduleActionStartWorkflow(
+                WORKFLOW_TYPE,
+                id=SCHEDULE_ID,
+                task_queue=TaskQueue.GAP_DRAIN.value,
+            ),
+            spec=temporalio.client.ScheduleSpec(cron_expressions=[CRON]),
+        ),
+    ),
+]

--- a/projects/lakehouse/orchestrator/schedules/iceberg_batch.py
+++ b/projects/lakehouse/orchestrator/schedules/iceberg_batch.py
@@ -1,0 +1,39 @@
+"""Schedule: commit buffered events to Iceberg (ADR agents/015).
+
+Drives ``IcebergBatchCommitWorkflow`` on the ``iceberg-builder`` task queue at a
+tight cadence so the lakehouse stays near-real-time. An interval (every 90s) is
+used rather than cron: sub-minute granularity isn't expressible in 5-field cron,
+and an interval matches the "every 1-2 min" batch-commit intent directly.
+
+References the workflow by **type-name string** so this module is independent of
+the WF-STORAGE unit that defines ``IcebergBatchCommitWorkflow``.
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+import temporalio.client
+
+from projects.lakehouse.orchestrator import TaskQueue
+from projects.lakehouse.orchestrator.schedules import ScheduleDefinition
+
+WORKFLOW_TYPE = "IcebergBatchCommitWorkflow"
+SCHEDULE_ID = "iceberg-batch-commit"
+INTERVAL = timedelta(seconds=90)
+
+SCHEDULES = [
+    ScheduleDefinition(
+        schedule_id=SCHEDULE_ID,
+        schedule=temporalio.client.Schedule(
+            action=temporalio.client.ScheduleActionStartWorkflow(
+                WORKFLOW_TYPE,
+                id=SCHEDULE_ID,
+                task_queue=TaskQueue.ICEBERG_BUILDER.value,
+            ),
+            spec=temporalio.client.ScheduleSpec(
+                intervals=[temporalio.client.ScheduleIntervalSpec(every=INTERVAL)],
+            ),
+        ),
+    ),
+]

--- a/projects/lakehouse/orchestrator/schedules/schedules_test.py
+++ b/projects/lakehouse/orchestrator/schedules/schedules_test.py
@@ -1,0 +1,121 @@
+"""Tests for the lakehouse Temporal schedule definitions (hermetic — no Temporal).
+
+Discovery and spec-shape assertions never connect to a server.
+``register_schedules`` is exercised against a mocked client: it must call
+``create_schedule`` once per discovered spec and swallow
+``ScheduleAlreadyRunningError`` so boot-time registration is idempotent.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest import mock
+
+import pytest
+import temporalio.client
+
+from projects.lakehouse.orchestrator import TaskQueue
+from projects.lakehouse.orchestrator import schedules as sched
+
+# Expected (schedule_id, workflow_type, task_queue) for each shipped module.
+_EXPECTED = {
+    "gap-drain-sweep": ("GapDrainSweepWorkflow", TaskQueue.GAP_DRAIN.value),
+    "iceberg-batch-commit": (
+        "IcebergBatchCommitWorkflow",
+        TaskQueue.ICEBERG_BUILDER.value,
+    ),
+    "build-serving-artifact": (
+        "BuildServingArtifactWorkflow",
+        TaskQueue.HOUSEKEEPING.value,
+    ),
+    "tag-rotation": ("TagRotationWorkflow", TaskQueue.HOUSEKEEPING.value),
+}
+
+
+def _by_id() -> dict[str, sched.ScheduleDefinition]:
+    return {d.schedule_id: d for d in sched.all_schedules()}
+
+
+def test_all_schedules_returns_list() -> None:
+    assert isinstance(sched.all_schedules(), list)
+
+
+def test_discovers_all_four_schedules() -> None:
+    found = _by_id()
+    assert set(found) == set(_EXPECTED)
+    # No duplicate schedule IDs across modules.
+    assert len(sched.all_schedules()) == len(_EXPECTED)
+
+
+def test_each_definition_is_a_schedule_definition() -> None:
+    for definition in sched.all_schedules():
+        assert isinstance(definition, sched.ScheduleDefinition)
+        assert isinstance(definition.schedule, temporalio.client.Schedule)
+
+
+@pytest.mark.parametrize(
+    ("schedule_id", "workflow_type", "task_queue"),
+    [(sid, wf, tq) for sid, (wf, tq) in _EXPECTED.items()],
+)
+def test_spec_targets_expected_workflow_and_queue(
+    schedule_id: str, workflow_type: str, task_queue: str
+) -> None:
+    definition = _by_id()[schedule_id]
+    action = definition.schedule.action
+    assert isinstance(action, temporalio.client.ScheduleActionStartWorkflow)
+    # Workflow referenced by type-name string (not an imported class).
+    assert action.workflow == workflow_type
+    assert action.task_queue == task_queue
+    assert action.id == schedule_id
+
+
+def test_cron_schedules_use_expected_expressions() -> None:
+    found = _by_id()
+    assert found["gap-drain-sweep"].schedule.spec.cron_expressions == ["*/5 * * * *"]
+    assert found["build-serving-artifact"].schedule.spec.cron_expressions == [
+        "*/15 * * * *"
+    ]
+    assert found["tag-rotation"].schedule.spec.cron_expressions == ["*/15 * * * *"]
+
+
+def test_iceberg_batch_uses_interval_spec() -> None:
+    spec = _by_id()["iceberg-batch-commit"].schedule.spec
+    # Interval-based (sub-minute cadence isn't expressible in 5-field cron).
+    assert not spec.cron_expressions
+    assert len(spec.intervals) == 1
+    assert spec.intervals[0].every.total_seconds() == 90
+
+
+def test_register_schedules_creates_each_spec() -> None:
+    client = mock.Mock()
+    client.create_schedule = mock.AsyncMock()
+
+    asyncio.run(sched.register_schedules(client))
+
+    created_ids = {call.args[0] for call in client.create_schedule.call_args_list}
+    assert created_ids == set(_EXPECTED)
+    assert client.create_schedule.await_count == len(_EXPECTED)
+    # Each call passes the corresponding Schedule object positionally.
+    for call in client.create_schedule.call_args_list:
+        assert isinstance(call.args[1], temporalio.client.Schedule)
+
+
+def test_register_schedules_swallows_already_running() -> None:
+    # Every create raises AlreadyRunning (schedules pre-exist from a prior boot);
+    # register_schedules must complete without propagating — that's idempotency.
+    client = mock.Mock()
+    client.create_schedule = mock.AsyncMock(
+        side_effect=temporalio.client.ScheduleAlreadyRunningError()
+    )
+
+    asyncio.run(sched.register_schedules(client))
+
+    assert client.create_schedule.await_count == len(_EXPECTED)
+
+
+def test_register_schedules_propagates_unexpected_errors() -> None:
+    client = mock.Mock()
+    client.create_schedule = mock.AsyncMock(side_effect=RuntimeError("boom"))
+
+    with pytest.raises(RuntimeError, match="boom"):
+        asyncio.run(sched.register_schedules(client))

--- a/projects/lakehouse/orchestrator/schedules/tag_rotation.py
+++ b/projects/lakehouse/orchestrator/schedules/tag_rotation.py
@@ -1,0 +1,34 @@
+"""Schedule: rotate serving tags onto freshly built artifacts (ADR agents/015).
+
+Drives ``TagRotationWorkflow`` on the ``housekeeping`` task queue every 15
+minutes — coupled to the ``build_serving`` cadence so the serving tag advances
+to the artifact a build cycle just produced.
+
+References the workflow by **type-name string** so this module is independent of
+the WF-DOMAIN unit that defines ``TagRotationWorkflow``.
+"""
+
+from __future__ import annotations
+
+import temporalio.client
+
+from projects.lakehouse.orchestrator import TaskQueue
+from projects.lakehouse.orchestrator.schedules import ScheduleDefinition
+
+WORKFLOW_TYPE = "TagRotationWorkflow"
+SCHEDULE_ID = "tag-rotation"
+CRON = "*/15 * * * *"
+
+SCHEDULES = [
+    ScheduleDefinition(
+        schedule_id=SCHEDULE_ID,
+        schedule=temporalio.client.Schedule(
+            action=temporalio.client.ScheduleActionStartWorkflow(
+                WORKFLOW_TYPE,
+                id=SCHEDULE_ID,
+                task_queue=TaskQueue.HOUSEKEEPING.value,
+            ),
+            spec=temporalio.client.ScheduleSpec(cron_expressions=[CRON]),
+        ),
+    ),
+]


### PR DESCRIPTION
## Summary

Wavefront-3 unit **WF-SCHEDULES** of the event-sourced lakehouse (ADR agents/015 §"Scheduling unified with execution"). Adds the new gazelle-managed package `projects/lakehouse/orchestrator/schedules/`: cron/interval triggers become Temporal `Schedule`s registered idempotently from startup, sharing the same Postgres persistence and UI as event-triggered workflows.

## The four schedules

| Schedule ID | Workflow type-name | Cadence | Task queue |
| --- | --- | --- | --- |
| `gap-drain-sweep` | `GapDrainSweepWorkflow` | cron `*/5 * * * *` | `gap-drain` |
| `iceberg-batch-commit` | `IcebergBatchCommitWorkflow` | interval 90s | `iceberg-builder` |
| `build-serving-artifact` | `BuildServingArtifactWorkflow` | cron `*/15 * * * *` | `housekeeping` |
| `tag-rotation` | `TagRotationWorkflow` | cron `*/15 * * * *` | `housekeeping` |

## Design

- `__init__.py`: `pkgutil` loader `all_schedules()` aggregates each submodule's module-level `SCHEDULES` list — new schedule = new file, no shared registration list (conflict-free, mirrors the `workflows` loader). Async `register_schedules(client, *, namespace="default")` idempotently calls `create_schedule` per spec and swallows `ScheduleAlreadyRunningError`; called from monolith/worker startup in Wavefront 5.
- Workflows referenced **by type-name string** (`ScheduleActionStartWorkflow(workflow="...")`) — no workflow-class imports, so independent of the parallel WF-STORAGE/WF-DOMAIN units.
- Iceberg batch commit uses `ScheduleIntervalSpec(every=90s)` (sub-minute cadence isn't expressible in 5-field cron); the others use `ScheduleSpec(cron_expressions=[...])`.
- Hand-written `BUILD` (unit owns the whole dir) following the sibling `orchestrator`/`events` gazelle pattern, with the proven `# gazelle:resolve py temporalio` workaround for the stale module manifest.

## Tests

`schedules_test.py` (hermetic, no Temporal connection): discovers all four schedules; asserts each spec's workflow type-name / cadence / task queue; exercises `register_schedules` against a mocked client (create-per-spec, `ScheduleAlreadyRunningError` swallowed, unexpected errors propagate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)