### PR TITLE
feat(lakehouse): add hot-swap Quack serving pod (IMG-QUACK-SERVER)

### DIFF
--- a/bazel/images/BUILD
+++ b/bazel/images/BUILD
@@ -52,6 +52,7 @@ multirun(
         "//projects/grimoire/ws-gateway:image.push",
         "//projects/hikes/update_forecast:update_image.push",
         "//projects/lakehouse/image:image.push",
+        "//projects/lakehouse/quack-server:image.push",
         "//projects/monolith/chart:chart.push",
         "//projects/monolith/frontend:image.push",
         "//projects/monolith/obsidian-image:image.push",

--- a/docs/plans/event-sourced-impl-status/IMG-QUACK-SERVER.md
+++ b/docs/plans/event-sourced-impl-status/IMG-QUACK-SERVER.md
@@ -1,0 +1,83 @@
+# IMG-QUACK-SERVER — Quack serving pod (Wavefront 3)
+
+**Unit:** IMG-QUACK-SERVER (Wavefront-3 image unit)
+**Classification:** [auto] — purely additive; one NEW package
+`projects/lakehouse/quack-server/`, no existing-file edits.
+
+## What shipped (all new files)
+
+- `projects/lakehouse/quack-server/__init__.py` — package marker / role docstring.
+- `projects/lakehouse/quack-server/server.py` — the serving pod:
+  - `build_connection()` — startup: `duckdb_query.connect()` (loads httpfs/iceberg/vss
+    - the SeaweedFS S3 secret) and, when `SERVING_ARTIFACT_URL` is set, ATTACHes the
+      initial artifact so the pod can serve before the first swap.
+  - `run_swap_consumer()` — durable NATS pull subscriber on
+    `events.serving.artifact-ready` (durable `quack-serving-swap`). Each event is
+    parsed (`parse_artifact_ready`) and applied via
+    `duckdb_query.attach_or_replace_sql("notes", path)` — the zero-downtime hot-swap
+    (platform/004: in-flight queries finish on the old snapshot, new queries see the
+    new). Disposition: malformed → `term`; swap failure → leave for redelivery;
+    success → `ack`.
+  - FastAPI app (`create_app`): `GET /healthz` (liveness + current artifact version),
+    `POST /search` (VSS nearest-neighbour via `vector_search_sql`, bearer-token gated
+    when `QUACK_QUERY_TOKEN` is set).
+  - `main()` — wires the swap consumer into the FastAPI lifespan and serves via uvicorn.
+  - Config from env: `NATS_URL`, `SEAWEEDFS_S3_ENDPOINT`, `SERVING_ARTIFACT_URL`,
+    `QUACK_QUERY_TOKEN`, `HOST`/`PORT`/`LOG_LEVEL`.
+- `projects/lakehouse/quack-server/server_test.py` — hermetic (fake NatsClient +
+  in-memory `duckdb.connect(':memory:')`, no remote extensions). Asserts the
+  artifact-ready handler issues exactly the `ATTACH OR REPLACE` SQL the pure builder
+  produces and acks; malformed messages are termed; `/healthz` returns ok + version;
+  `/search` enforces the token and rejects bad `k`.
+- `projects/lakehouse/quack-server/BUILD` — `py_library` (quack-server),
+  `py_venv_binary` (main, `server.py`), `py3_image` (image), `py_test`, semgrep tests.
+
+## Hot-swap consumer design
+
+The swap is driven by a **durable NATS consumer the pod owns**, not by an HTTP call.
+Only `BuildServingArtifactWorkflow` publishes `events.serving.artifact-ready`, and
+NATS is internal-only — so the privileged-swap requirement from platform/004 §Security
+("swap SQL travels Quack's privileged query path with a builder-scoped token") is
+satisfied by **topology**: the swap never crosses the public HTTP boundary. The public
+`POST /search` path is the only externally reachable surface and is gated by
+`QUACK_QUERY_TOKEN` (the monolith issues per-client tokens for the web app read path).
+
+A single shared DuckDB connection backs both the HTTP handlers and the swap loop;
+`ATTACH OR REPLACE` is non-blocking on DuckDB 1.5.3, so no in-flight-query coordination
+is needed (each query finishes on its starting snapshot). `version` is advisory metadata
+surfaced by `/healthz`.
+
+## py3_image target
+
+```python
+py3_image(
+    name = "image",
+    binary = "//projects/lakehouse/quack-server:main",
+    env = {"PYTHONPATH": ".../main.runfiles/_main:.../main.runfiles/_main/projects/lakehouse/quack-server"},
+    main = "server.py",
+    repository = "ghcr.io/jomcgi/homelab/projects/lakehouse/quack-server",
+)
+```
+
+Modelled field-for-field on the monolith `image`: multiarch (x86_64 + aarch64, the
+macro default), non-root (uid 65532 — the `@python_base` default), PYTHONPATH set to the
+workspace root + the package dir to match `imports = ["."]`.
+
+## Conventions / deviations
+
+- **Hyphenated package name.** The unit spec dir is `quack-server`, which a Python
+  absolute import (`projects.lakehouse.quack_server`) cannot express. Like the trips
+  image tools (`projects/trips/tools/publish-trip-images`), the package uses the
+  monolith-style `imports = ["."]` (the package dir is a sys.path root) with flat
+  intra-package imports (`import server`); cross-package deps
+  (`projects.lakehouse.duckdb_query` / `.nats_client`) still resolve via the workspace
+  root on PYTHONPATH. This is the only lakehouse package NOT using the absolute-import
+  convention — forced by the hyphen.
+- **gazelle resolve directives** in the BUILD: `duckdb @pip//duckdb` (the manifest
+  regen was skipped in LIB-SCAFFOLD) and `server` → this package's own library.
+- DuckDB pinned to 1.5.3 (the version platform/004 verified ATTACH OR REPLACE against)
+  via the requirements lock (LIB-SCAFFOLD).
+
+## CI / Test / Push-images status
+
+_(filled in after the first CI run)_

--- a/projects/lakehouse/quack-server/BUILD
+++ b/projects/lakehouse/quack-server/BUILD
@@ -52,7 +52,6 @@ py_library(
 py_venv_binary(
     name = "main",
     srcs = ["server.py"],
-    imports = ["."],
     main = "server.py",
     visibility = ["//:__subpackages__"],
     deps = [

--- a/projects/lakehouse/quack-server/BUILD
+++ b/projects/lakehouse/quack-server/BUILD
@@ -1,0 +1,97 @@
+# Quack serving pod (ADR platform/004 §Hot-swap / §Architecture).
+#
+# This package is hyphenated (`quack-server`), so — like the trips image tools —
+# it uses the monolith-style `imports = ["."]` (the package dir is a sys.path
+# root) and flat intra-package imports (`import server`), NOT the lakehouse
+# absolute-import convention which a hyphen cannot express. Cross-package deps
+# (`projects.lakehouse.duckdb_query` / `.nats_client`) still resolve via the
+# workspace root on PYTHONPATH.
+#
+# Resolve directives: gazelle's module manifest does not yet carry `duckdb`
+# (LIB-SCAFFOLD added the wheel to the lock but skipped the manifest regen, see
+# duckdb_query/BUILD), and the flat `server` import must map to this package's
+# own library.
+# gazelle:resolve py duckdb @pip//duckdb
+# gazelle:resolve py server //projects/lakehouse/quack-server:quack-server
+load("@aspect_rules_py//py:defs.bzl", "py_library")
+load("@aspect_rules_py//py/private/py_venv:defs.bzl", "py_venv_binary")
+load("//bazel/semgrep/defs:defs.bzl", "semgrep_test")
+load("//bazel/tools/oci:py3_image.bzl", "py3_image")
+load("//bazel/tools/pytest:defs.bzl", "py_test")
+
+py_library(
+    name = "quack-server",
+    srcs = [
+        "__init__.py",
+        "server.py",
+    ],
+    imports = ["."],
+    visibility = ["//:__subpackages__"],
+    deps = [
+        "//projects/lakehouse/duckdb_query",
+        "//projects/lakehouse/nats_client",
+        "@pip//duckdb",
+        "@pip//fastapi",
+        "@pip//uvicorn",
+    ],
+)
+
+# Process entrypoint: `python -m server` / the image runs server.py:main().
+py_venv_binary(
+    name = "main",
+    srcs = ["server.py"],
+    imports = ["."],
+    main = "server.py",
+    visibility = ["//:__subpackages__"],
+    deps = [
+        "//projects/lakehouse/duckdb_query",
+        "//projects/lakehouse/nats_client",
+        "@pip//duckdb",
+        "@pip//fastapi",
+        "@pip//uvicorn",
+    ],
+)
+
+# Multiarch (x86_64 + aarch64), non-root (uid 65532 — the python_base default),
+# modelled field-for-field on the monolith `image` target. PYTHONPATH mirrors the
+# monolith: workspace root + the package dir, matching `imports = ["."]`.
+py3_image(
+    name = "image",
+    binary = "//projects/lakehouse/quack-server:main",
+    env = {
+        "PYTHONPATH": "/projects/lakehouse/quack-server/main.runfiles/_main:/projects/lakehouse/quack-server/main.runfiles/_main/projects/lakehouse/quack-server",
+    },
+    main = "server.py",
+    repository = "ghcr.io/jomcgi/homelab/projects/lakehouse/quack-server",
+)
+
+py_test(
+    name = "server_test",
+    srcs = ["server_test.py"],
+    imports = ["."],
+    deps = [
+        "//projects/lakehouse/quack-server",
+        "@pip//duckdb",
+        "@pip//fastapi",
+        "@pip//httpx",
+        "@pip//pytest",
+    ],
+)
+
+semgrep_test(
+    name = "__init___semgrep_test",
+    srcs = ["__init__.py"],
+    rules = ["//bazel/semgrep/rules:python_rules"],
+)
+
+semgrep_test(
+    name = "server_semgrep_test",
+    srcs = ["server.py"],
+    rules = ["//bazel/semgrep/rules:python_rules"],
+)
+
+semgrep_test(
+    name = "server_test_semgrep_test",
+    srcs = ["server_test.py"],
+    rules = ["//bazel/semgrep/rules:python_rules"],
+)

--- a/projects/lakehouse/quack-server/BUILD
+++ b/projects/lakehouse/quack-server/BUILD
@@ -10,9 +10,20 @@
 # Resolve directives: gazelle's module manifest does not yet carry `duckdb`
 # (LIB-SCAFFOLD added the wheel to the lock but skipped the manifest regen, see
 # duckdb_query/BUILD), and the flat `server` import must map to this package's
-# own library.
+# own library. The nats_client submodule resolves to its own subpackage (not the
+# top-level //projects/lakehouse), mirroring nats_client/BUILD's directives —
+# otherwise gazelle maps it to //projects/lakehouse and NatsClient is missing
+# from the binary's deps.
 # gazelle:resolve py duckdb @pip//duckdb
 # gazelle:resolve py server //projects/lakehouse/quack-server:quack-server
+# gazelle:resolve py projects.lakehouse.nats_client //projects/lakehouse/nats_client:nats_client
+# gazelle:resolve py projects.lakehouse.nats_client.client //projects/lakehouse/nats_client:nats_client
+#
+# duckdb_query/query.py (a transitive dep scanned by the generated
+# main_semgrep_test) hardcodes the in-cluster SeaweedFS S3 endpoint as a
+# deliberate cluster constant — exclude that rule from the generated semgrep
+# targets, matching duckdb_query/BUILD.
+# gazelle:semgrep_exclude_rules no-hardcoded-k8s-service-url
 load("@aspect_rules_py//py:defs.bzl", "py_library")
 load("@aspect_rules_py//py/private/py_venv:defs.bzl", "py_venv_binary")
 load("//bazel/semgrep/defs:defs.bzl", "semgrep_target_test", "semgrep_test")
@@ -28,8 +39,8 @@ py_library(
     imports = ["."],
     visibility = ["//:__subpackages__"],
     deps = [
-        "//projects/lakehouse",
         "//projects/lakehouse/duckdb_query",
+        "//projects/lakehouse/nats_client",
         "@pip//duckdb",
         "@pip//fastapi",
         "@pip//pydantic",
@@ -41,11 +52,12 @@ py_library(
 py_venv_binary(
     name = "main",
     srcs = ["server.py"],
+    imports = ["."],
     main = "server.py",
     visibility = ["//:__subpackages__"],
     deps = [
-        "//projects/lakehouse",
         "//projects/lakehouse/duckdb_query",
+        "//projects/lakehouse/nats_client",
         "@pip//duckdb",
         "@pip//fastapi",
         "@pip//pydantic",
@@ -82,17 +94,20 @@ py_test(
 semgrep_test(
     name = "__init___semgrep_test",
     srcs = ["__init__.py"],
+    exclude_rules = ["no-hardcoded-k8s-service-url"],
     rules = ["//bazel/semgrep/rules:python_rules"],
 )
 
 semgrep_test(
     name = "server_test_semgrep_test",
     srcs = ["server_test.py"],
+    exclude_rules = ["no-hardcoded-k8s-service-url"],
     rules = ["//bazel/semgrep/rules:python_rules"],
 )
 
 semgrep_target_test(
     name = "main_semgrep_test",
+    exclude_rules = ["no-hardcoded-k8s-service-url"],
     lockfiles = ["//bazel/requirements:all.txt"],
     rules = ["//bazel/semgrep/rules:python_rules"],
     sca_rules = ["//bazel/semgrep/rules:sca_python_rules"],

--- a/projects/lakehouse/quack-server/BUILD
+++ b/projects/lakehouse/quack-server/BUILD
@@ -15,7 +15,7 @@
 # gazelle:resolve py server //projects/lakehouse/quack-server:quack-server
 load("@aspect_rules_py//py:defs.bzl", "py_library")
 load("@aspect_rules_py//py/private/py_venv:defs.bzl", "py_venv_binary")
-load("//bazel/semgrep/defs:defs.bzl", "semgrep_test")
+load("//bazel/semgrep/defs:defs.bzl", "semgrep_target_test", "semgrep_test")
 load("//bazel/tools/oci:py3_image.bzl", "py3_image")
 load("//bazel/tools/pytest:defs.bzl", "py_test")
 
@@ -28,10 +28,11 @@ py_library(
     imports = ["."],
     visibility = ["//:__subpackages__"],
     deps = [
+        "//projects/lakehouse",
         "//projects/lakehouse/duckdb_query",
-        "//projects/lakehouse/nats_client",
         "@pip//duckdb",
         "@pip//fastapi",
+        "@pip//pydantic",
         "@pip//uvicorn",
     ],
 )
@@ -40,14 +41,14 @@ py_library(
 py_venv_binary(
     name = "main",
     srcs = ["server.py"],
-    imports = ["."],
     main = "server.py",
     visibility = ["//:__subpackages__"],
     deps = [
+        "//projects/lakehouse",
         "//projects/lakehouse/duckdb_query",
-        "//projects/lakehouse/nats_client",
         "@pip//duckdb",
         "@pip//fastapi",
+        "@pip//pydantic",
         "@pip//uvicorn",
     ],
 )
@@ -70,10 +71,10 @@ py_test(
     srcs = ["server_test.py"],
     imports = ["."],
     deps = [
+        "//projects/lakehouse/duckdb_query",
         "//projects/lakehouse/quack-server",
         "@pip//duckdb",
         "@pip//fastapi",
-        "@pip//httpx",
         "@pip//pytest",
     ],
 )
@@ -85,13 +86,15 @@ semgrep_test(
 )
 
 semgrep_test(
-    name = "server_semgrep_test",
-    srcs = ["server.py"],
-    rules = ["//bazel/semgrep/rules:python_rules"],
-)
-
-semgrep_test(
     name = "server_test_semgrep_test",
     srcs = ["server_test.py"],
     rules = ["//bazel/semgrep/rules:python_rules"],
+)
+
+semgrep_target_test(
+    name = "main_semgrep_test",
+    lockfiles = ["//bazel/requirements:all.txt"],
+    rules = ["//bazel/semgrep/rules:python_rules"],
+    sca_rules = ["//bazel/semgrep/rules:sca_python_rules"],
+    target = ":main",
 )

--- a/projects/lakehouse/quack-server/__init__.py
+++ b/projects/lakehouse/quack-server/__init__.py
@@ -1,0 +1,13 @@
+"""Stateless DuckDB/Quack serving pod (ADR platform/004 §Hot-swap, §Architecture).
+
+A serving pod holds the current serving artifact (`notes-vN.duckdb`) ATTACHed
+in-RAM and answers vector/note queries over HTTP. It owns no durable state: the
+artifact is rebuilt whole by ``BuildServingArtifactWorkflow`` and published to
+SeaweedFS S3; the pod hears about a new version via the
+``events.serving.artifact-ready`` NATS subject and hot-swaps it with
+``ATTACH OR REPLACE`` (verified zero-downtime on DuckDB 1.5.3 — in-flight queries
+finish on the old snapshot, new queries see the new).
+
+Cloudflare CDN sits in front of the pod's HTTP API (per platform/004 §Read
+paths); this package only implements the pod.
+"""

--- a/projects/lakehouse/quack-server/server.py
+++ b/projects/lakehouse/quack-server/server.py
@@ -228,11 +228,14 @@ class SearchRequest(BaseModel):
     k: int = 10
 
 
-def _require_query_token(authorization: str | None, expected: str | None) -> None:
+def require_query_token(authorization: str | None, expected: str | None) -> None:
     """Enforce the ``QUACK_QUERY_TOKEN`` bearer token when one is configured.
 
     When ``expected`` is unset the endpoint is open (dev / in-cluster only). When
-    set, the request must carry ``Authorization: Bearer <token>``.
+    set, the request must carry ``Authorization: Bearer <token>``. Raises
+    :class:`fastapi.HTTPException` (401) on a missing/invalid token.
+
+    Module-level + free of FastAPI request objects so tests can call it directly.
     """
     if not expected:
         return
@@ -240,29 +243,43 @@ def _require_query_token(authorization: str | None, expected: str | None) -> Non
         raise HTTPException(status_code=401, detail="invalid or missing query token")
 
 
+def healthz_payload(state: ServingState) -> dict[str, Any]:
+    """Liveness body: ok + the currently-served artifact version (pure)."""
+    return {"status": "ok", "artifact_version": state.version}
+
+
+def do_search(state: ServingState, req: SearchRequest) -> dict[str, Any]:
+    """Run a VSS search for ``req`` against ``state`` (validates ``k``).
+
+    Raises :class:`fastapi.HTTPException` (400) for an out-of-range ``k``.
+    Module-level so tests exercise the handler logic without an HTTP client.
+    """
+    if req.k <= 0 or req.k > _MAX_SEARCH_K:
+        raise HTTPException(status_code=400, detail=f"k must be 1..{_MAX_SEARCH_K}")
+    results = state.search(req.query, req.k)
+    return {"results": results, "artifact_version": state.version}
+
+
 def create_app(state: ServingState, *, query_token: str | None = None) -> FastAPI:
     """Build the FastAPI app bound to ``state``.
 
-    Separated from :func:`main` so tests can construct the app over an in-memory
-    connection without any NATS / network setup.
+    Thin route wrappers delegate to the module-level handlers
+    (:func:`healthz_payload`, :func:`do_search`); the logic is unit-tested there,
+    so this only wires routing + auth. Separated from :func:`main` so the app can
+    be constructed over an in-memory connection with no NATS / network setup.
     """
     app = FastAPI(title="quack-server", docs_url=None, redoc_url=None)
 
     def auth(authorization: str | None = Header(default=None)) -> None:
-        _require_query_token(authorization, query_token)
+        require_query_token(authorization, query_token)
 
     @app.get("/healthz")
     def healthz() -> dict[str, Any]:
-        """Liveness probe: ok + the currently-served artifact version."""
-        return {"status": "ok", "artifact_version": state.version}
+        return healthz_payload(state)
 
     @app.post("/search")
     def search(req: SearchRequest, _: None = Depends(auth)) -> dict[str, Any]:
-        """VSS nearest-neighbour search over the current serving artifact."""
-        if req.k <= 0 or req.k > _MAX_SEARCH_K:
-            raise HTTPException(status_code=400, detail=f"k must be 1..{_MAX_SEARCH_K}")
-        results = state.search(req.query, req.k)
-        return {"results": results, "artifact_version": state.version}
+        return do_search(state, req)
 
     return app
 

--- a/projects/lakehouse/quack-server/server.py
+++ b/projects/lakehouse/quack-server/server.py
@@ -1,0 +1,310 @@
+"""Quack serving pod: hot-swap consumer + minimal stateless HTTP query API.
+
+ADR platform/004 §Hot-swap mechanism / §Serving artifact lifecycle / §Security.
+
+Lifecycle
+---------
+* **Startup** — :func:`build_connection` opens a DuckDB connection wired for the
+  SeaweedFS lakehouse (``duckdb_query.connect`` loads httpfs/iceberg/vss and the
+  S3 secret). If ``SERVING_ARTIFACT_URL`` is set, that artifact is ATTACHed as the
+  serving schema so the pod can answer queries before the first swap event.
+* **Hot-swap consumer** — :func:`run_swap_consumer` is a durable NATS pull
+  subscriber on ``events.serving.artifact-ready``. On each event it parses the
+  artifact path/version (ADR-017 envelope ``payload``) and issues
+  ``ATTACH OR REPLACE`` via :func:`duckdb_query.attach_or_replace_sql`. On
+  DuckDB 1.5.3 this is a ~2ms non-blocking swap: in-flight queries finish against
+  the old snapshot, new queries see the new artifact (verified zero-downtime).
+* **HTTP API** — ``GET /healthz`` (liveness + current artifact version) and
+  ``POST /search`` (VSS nearest-neighbour query). Cloudflare CDN fronts this API.
+
+Security (platform/004 §Security)
+---------------------------------
+The hot-swap is **not** a public query. In the ADR the swap SQL travels over
+Quack's privileged query path with an auth token scoped to the builder worker
+pool. Here the swap is driven by a *durable NATS consumer* the pod owns (only the
+builder publishes ``artifact-ready``, NATS is internal-only), so the swap never
+crosses the public HTTP boundary at all — the privileged-token requirement is
+satisfied by topology rather than by an HTTP token. The public ``POST /search``
+path is gated by ``QUACK_QUERY_TOKEN`` (a per-deployment bearer token; the
+monolith issues per-client tokens for the web app's read path).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+from collections.abc import Mapping
+from typing import Any
+
+import duckdb
+from fastapi import Depends, FastAPI, Header, HTTPException
+from pydantic import BaseModel
+
+from projects.lakehouse import duckdb_query
+from projects.lakehouse.nats_client import NatsClient
+
+logger = logging.getLogger(__name__)
+
+# NATS subject the builder workflow publishes a new serving artifact on
+# (platform/004 §Write path: BuildServingArtifactWorkflow -> artifact-ready).
+ARTIFACT_READY_SUBJECT = "events.serving.artifact-ready"
+
+# Durable consumer name. A durable (consumer-group) name means a restarted pod
+# resumes from where it left off rather than replaying the whole stream; every
+# pod uses the same durable so each gets the swap event (JetStream fan-out).
+SWAP_DURABLE = "quack-serving-swap"
+
+# Schema alias the serving artifact is ATTACHed under. Queries reference
+# ``<alias>.<table>`` (e.g. ``notes.chunks``); the swap rebinds the alias.
+SERVING_ALIAS = "notes"
+
+# Default table the /search endpoint runs VSS over inside the artifact.
+DEFAULT_SEARCH_TABLE = f"{SERVING_ALIAS}.chunks"
+
+# Clamp on /search result count (defence against pathological LIMITs).
+_MAX_SEARCH_K = 200
+
+
+# --------------------------------------------------------------------------- #
+# Artifact-ready event parsing (pure — unit-tested)
+# --------------------------------------------------------------------------- #
+
+
+def parse_artifact_ready(raw: bytes) -> tuple[str, str | None]:
+    """Parse an ``events.serving.artifact-ready`` message into ``(path, version)``.
+
+    The message body is an ADR-017 :class:`EventEnvelope` JSON document. The
+    serving artifact location lives in ``payload``; this reads it tolerantly
+    (additive-schema rules) accepting either ``artifact_url`` or ``path`` for the
+    S3 URI and ``version`` for the optional human version tag.
+
+    Pure: no I/O, no DuckDB. Raises :class:`ValueError` if no artifact path is
+    present so the consumer can ``term`` (not redeliver) a malformed message.
+    """
+    doc = json.loads(raw)
+    payload = doc.get("payload", {}) if isinstance(doc, dict) else {}
+    if not isinstance(payload, dict):
+        raise ValueError("artifact-ready payload is not an object")
+
+    path = payload.get("artifact_url") or payload.get("path")
+    if not path or not isinstance(path, str):
+        raise ValueError("artifact-ready event has no artifact_url/path")
+
+    version = payload.get("version")
+    if version is not None:
+        version = str(version)
+    return path, version
+
+
+# --------------------------------------------------------------------------- #
+# Serving connection state
+# --------------------------------------------------------------------------- #
+
+
+class ServingState:
+    """Holds the live DuckDB connection and the current artifact version.
+
+    A single connection is shared across requests and the swap consumer.
+    ``ATTACH OR REPLACE`` is non-blocking on DuckDB 1.5.3, so the swap does not
+    need to coordinate with in-flight queries (each finishes on its starting
+    snapshot). ``version`` is advisory metadata surfaced by ``/healthz``.
+    """
+
+    def __init__(self, con: duckdb.DuckDBPyConnection, *, version: str | None = None):
+        self.con = con
+        self.version = version
+
+    def swap(self, path: str, version: str | None) -> None:
+        """Apply ``ATTACH OR REPLACE`` for ``path`` and record ``version``."""
+        sql = duckdb_query.attach_or_replace_sql(SERVING_ALIAS, path)
+        self.con.execute(sql)
+        self.version = version
+        logger.info("hot-swapped serving artifact: path=%s version=%s", path, version)
+
+    def search(self, query_vector: list[float], k: int) -> list[dict[str, Any]]:
+        """Run a VSS nearest-neighbour query, returning ``k`` rows as dicts."""
+        sql = duckdb_query.vector_search_sql(DEFAULT_SEARCH_TABLE, k)
+        cur = self.con.execute(sql, {"query": query_vector})
+        columns = [d[0] for d in cur.description]
+        return [dict(zip(columns, row)) for row in cur.fetchall()]
+
+
+def build_connection(env: Mapping[str, str] | None = None) -> ServingState:
+    """Open the serving connection and ATTACH the initial artifact if configured.
+
+    Reads ``SERVING_ARTIFACT_URL`` (optional). Touches the network (extension
+    install + S3) so it is NOT exercised by hermetic tests — those build a
+    :class:`ServingState` over an in-memory ``duckdb.connect(':memory:')``.
+    """
+    env = os.environ if env is None else env
+    artifact = env.get("SERVING_ARTIFACT_URL") or None
+    con = duckdb_query.connect(read_only_artifact=artifact, env=env)
+    return ServingState(con, version=artifact)
+
+
+# --------------------------------------------------------------------------- #
+# Hot-swap consumer
+# --------------------------------------------------------------------------- #
+
+
+async def run_swap_consumer(
+    state: ServingState,
+    client: NatsClient,
+    *,
+    stop: asyncio.Event | None = None,
+    poll_timeout: float = 5.0,
+) -> None:
+    """Durable NATS pull loop applying ``artifact-ready`` events as hot-swaps.
+
+    Subscribes to :data:`ARTIFACT_READY_SUBJECT` with durable
+    :data:`SWAP_DURABLE`, then fetches in a loop. Each message is parsed
+    (:func:`parse_artifact_ready`) and applied (:meth:`ServingState.swap`).
+    Messages that swap successfully are ``ack``-ed; malformed messages are
+    ``term``-ed (won't redeliver); a failed swap is left for redelivery.
+
+    ``stop`` lets the FastAPI shutdown hook (or a test) break the loop. Fetch
+    timeouts are normal (idle stream) and simply re-poll.
+    """
+    sub = await client.pull_subscribe(ARTIFACT_READY_SUBJECT, SWAP_DURABLE)
+    while stop is None or not stop.is_set():
+        try:
+            msgs = await sub.fetch(timeout=poll_timeout)
+        except (asyncio.TimeoutError, TimeoutError):
+            continue  # idle stream — re-poll
+        for msg in msgs:
+            await _apply_swap_message(state, msg)
+
+
+async def _apply_swap_message(state: ServingState, msg: Any) -> None:
+    """Apply one ``artifact-ready`` message: parse, swap, then ack.
+
+    Disposition:
+      * malformed payload -> ``term`` (won't redeliver — replaying it never helps);
+      * swap failure (e.g. S3 hiccup) -> neither ack nor term, so JetStream
+        redelivers later;
+      * success -> ``ack``.
+    """
+    parsed = _parse_or_term(msg)
+    if parsed is None:
+        await msg.term()
+        return
+    path, version = parsed
+    if _try_swap(state, path, version):
+        await msg.ack()
+
+
+def _parse_or_term(msg: Any) -> tuple[str, str | None] | None:
+    """Parse the artifact-ready body; return ``None`` (and log) if malformed."""
+    parsed: tuple[str, str | None] | None = None
+    try:
+        parsed = parse_artifact_ready(msg.data)
+    except ValueError:
+        logger.exception("malformed artifact-ready message; will terminate")
+    return parsed
+
+
+def _try_swap(state: ServingState, path: str, version: str | None) -> bool:
+    """Apply the hot-swap; return ``False`` (and log) on failure for redelivery."""
+    ok = True
+    try:
+        state.swap(path, version)
+    except Exception:  # noqa: BLE001 — one bad swap must not kill the consumer loop
+        ok = False
+        logger.exception("hot-swap failed; leaving message for redelivery")
+    return ok
+
+
+# --------------------------------------------------------------------------- #
+# HTTP API
+# --------------------------------------------------------------------------- #
+
+
+class SearchRequest(BaseModel):
+    """``POST /search`` body: an embedding plus the number of neighbours."""
+
+    query: list[float]
+    k: int = 10
+
+
+def _require_query_token(authorization: str | None, expected: str | None) -> None:
+    """Enforce the ``QUACK_QUERY_TOKEN`` bearer token when one is configured.
+
+    When ``expected`` is unset the endpoint is open (dev / in-cluster only). When
+    set, the request must carry ``Authorization: Bearer <token>``.
+    """
+    if not expected:
+        return
+    if authorization != f"Bearer {expected}":
+        raise HTTPException(status_code=401, detail="invalid or missing query token")
+
+
+def create_app(state: ServingState, *, query_token: str | None = None) -> FastAPI:
+    """Build the FastAPI app bound to ``state``.
+
+    Separated from :func:`main` so tests can construct the app over an in-memory
+    connection without any NATS / network setup.
+    """
+    app = FastAPI(title="quack-server", docs_url=None, redoc_url=None)
+
+    def auth(authorization: str | None = Header(default=None)) -> None:
+        _require_query_token(authorization, query_token)
+
+    @app.get("/healthz")
+    def healthz() -> dict[str, Any]:
+        """Liveness probe: ok + the currently-served artifact version."""
+        return {"status": "ok", "artifact_version": state.version}
+
+    @app.post("/search")
+    def search(req: SearchRequest, _: None = Depends(auth)) -> dict[str, Any]:
+        """VSS nearest-neighbour search over the current serving artifact."""
+        if req.k <= 0 or req.k > _MAX_SEARCH_K:
+            raise HTTPException(status_code=400, detail=f"k must be 1..{_MAX_SEARCH_K}")
+        results = state.search(req.query, req.k)
+        return {"results": results, "artifact_version": state.version}
+
+    return app
+
+
+def main() -> None:  # pragma: no cover — process entrypoint (network + uvicorn)
+    """Process entrypoint: connect, start the swap consumer, serve HTTP.
+
+    Wires the swap consumer into the FastAPI lifespan so the durable NATS loop
+    runs alongside the HTTP server and is cancelled cleanly on shutdown.
+    """
+    import contextlib
+
+    import uvicorn
+
+    logging.basicConfig(level=os.environ.get("LOG_LEVEL", "INFO"))
+
+    state = build_connection()
+    client = NatsClient()
+    query_token = os.environ.get("QUACK_QUERY_TOKEN") or None
+    app = create_app(state, query_token=query_token)
+
+    @contextlib.asynccontextmanager
+    async def lifespan(_: FastAPI):
+        await client.connect()
+        stop = asyncio.Event()
+        task = asyncio.create_task(run_swap_consumer(state, client, stop=stop))
+        try:
+            yield
+        finally:
+            stop.set()
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+            await client.close()
+
+    app.router.lifespan_context = lifespan
+    uvicorn.run(
+        app,
+        host=os.environ.get("HOST", "0.0.0.0"),  # noqa: S104 — in-cluster Service only
+        port=int(os.environ.get("PORT", "8080")),
+    )
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/projects/lakehouse/quack-server/server.py
+++ b/projects/lakehouse/quack-server/server.py
@@ -172,7 +172,13 @@ async def run_swap_consumer(
         try:
             msgs = await sub.fetch(timeout=poll_timeout)
         except (asyncio.TimeoutError, TimeoutError):
-            continue  # idle stream — re-poll
+            # Idle stream — re-poll. Yield to the event loop first: a real
+            # nats-py fetch suspends for ~poll_timeout, but if fetch raises the
+            # timeout synchronously (e.g. a fake in tests, or a fast-failing
+            # server) this loop would otherwise busy-spin and starve the loop —
+            # including the shutdown task that sets `stop`.
+            await asyncio.sleep(0)
+            continue
         for msg in msgs:
             await _apply_swap_message(state, msg)
 

--- a/projects/lakehouse/quack-server/server_test.py
+++ b/projects/lakehouse/quack-server/server_test.py
@@ -16,7 +16,7 @@ import json
 
 import duckdb
 import pytest
-from fastapi.testclient import TestClient
+from fastapi import HTTPException
 
 import server
 from projects.lakehouse import duckdb_query
@@ -185,37 +185,50 @@ def test_consumer_terminates_malformed_message():
 
 
 # --------------------------------------------------------------------------- #
-# HTTP API
+# HTTP API (module-level handlers — no HTTP client, no httpx/TestClient)
 # --------------------------------------------------------------------------- #
 
 
 def test_healthz_returns_ok_and_version():
     con = duckdb.connect(":memory:")
     state = server.ServingState(con, version="v3")
-    app = server.create_app(state)
-    client = TestClient(app)
-
-    resp = client.get("/healthz")
-    assert resp.status_code == 200
-    assert resp.json() == {"status": "ok", "artifact_version": "v3"}
+    assert server.healthz_payload(state) == {"status": "ok", "artifact_version": "v3"}
 
 
-def test_search_requires_token_when_configured():
+def test_create_app_registers_healthz_and_search_routes():
     con = duckdb.connect(":memory:")
-    state = server.ServingState(con, version="v1")
-    app = server.create_app(state, query_token="sekret")
-    client = TestClient(app)
+    state = server.ServingState(con, version="v3")
+    app = server.create_app(state)
+    paths = {route.path for route in app.routes}
+    assert {"/healthz", "/search"}.issubset(paths)
 
-    # No token -> 401 (auth runs before the query).
-    resp = client.post("/search", json={"query": [0.1, 0.2], "k": 5})
-    assert resp.status_code == 401
+
+def test_require_query_token_rejects_missing_token():
+    # When a token is configured, a missing/invalid Authorization header -> 401.
+    with pytest.raises(HTTPException) as exc:
+        server.require_query_token(None, "sekret")
+    assert exc.value.status_code == 401
+
+
+def test_require_query_token_accepts_matching_bearer():
+    # Correct bearer token returns without raising.
+    server.require_query_token("Bearer sekret", "sekret")
+
+
+def test_require_query_token_open_when_unset():
+    # No configured token -> endpoint is open (returns without raising).
+    server.require_query_token(None, None)
 
 
 def test_search_rejects_bad_k():
     con = duckdb.connect(":memory:")
     state = server.ServingState(con, version="v1")
-    app = server.create_app(state)  # no token -> auth open
-    client = TestClient(app)
+    with pytest.raises(HTTPException) as exc:
+        server.do_search(state, server.SearchRequest(query=[0.1, 0.2], k=0))
+    assert exc.value.status_code == 400
 
-    resp = client.post("/search", json={"query": [0.1, 0.2], "k": 0})
-    assert resp.status_code == 400
+    with pytest.raises(HTTPException) as exc:
+        server.do_search(
+            state, server.SearchRequest(query=[0.1, 0.2], k=server._MAX_SEARCH_K + 1)
+        )
+    assert exc.value.status_code == 400

--- a/projects/lakehouse/quack-server/server_test.py
+++ b/projects/lakehouse/quack-server/server_test.py
@@ -43,14 +43,22 @@ class _FakeMsg:
 
 
 class _FakeSub:
-    """Yields one batch of messages then raises TimeoutError to idle the loop."""
+    """Yields each preloaded batch once, then signals stop and idles.
 
-    def __init__(self, batches: list[list[_FakeMsg]]):
+    Once the batches are exhausted it sets ``stop`` (so the consumer's
+    ``while not stop.is_set()`` exits deterministically on the next check) and
+    raises ``TimeoutError`` to exercise the consumer's idle/re-poll branch. This
+    keeps the test free of sleep-based timing races.
+    """
+
+    def __init__(self, batches: list[list[_FakeMsg]], *, stop: asyncio.Event):
         self._batches = list(batches)
+        self._stop = stop
 
     async def fetch(self, batch=None, *, timeout=5.0):
         if self._batches:
             return self._batches.pop(0)
+        self._stop.set()
         raise TimeoutError
 
 
@@ -130,27 +138,36 @@ def test_parse_artifact_ready_rejects_missing_path():
 # --------------------------------------------------------------------------- #
 
 
+def _run_consumer_once(state, msgs: list[_FakeMsg]) -> _FakeClient:
+    """Run the swap consumer over a single preloaded batch, deterministically.
+
+    The fake subscription sets ``stop`` once the batch is drained, so the loop
+    exits on its next condition check. ``asyncio.wait_for`` bounds the run so a
+    regression that re-introduces an event-loop-starving busy spin fails fast
+    instead of hanging the whole test target to its 300s timeout.
+    """
+    stop = asyncio.Event()
+    sub = _FakeSub([msgs], stop=stop)
+    client = _FakeClient(sub)
+
+    async def drive():
+        await asyncio.wait_for(
+            server.run_swap_consumer(state, client, stop=stop, poll_timeout=0.01),
+            timeout=5.0,
+        )
+
+    asyncio.run(drive())
+    return client
+
+
 def test_consumer_issues_attach_or_replace_and_acks():
     state, executed = _recording_state()
     path = "s3://warehouse/serving/notes-v9.duckdb"
     msg = _FakeMsg(
         json.dumps({"payload": {"artifact_url": path, "version": "v9"}}).encode()
     )
-    sub = _FakeSub([[msg]])
-    client = _FakeClient(sub)
 
-    stop = asyncio.Event()
-
-    async def drive():
-        task = asyncio.create_task(
-            server.run_swap_consumer(state, client, stop=stop, poll_timeout=0.01)
-        )
-        # Let the loop drain the one batch, then hit the idle TimeoutError path.
-        await asyncio.sleep(0.05)
-        stop.set()
-        await task
-
-    asyncio.run(drive())
+    client = _run_consumer_once(state, [msg])
 
     # Subscribed to the right subject + durable.
     assert client.subscribed == (server.ARTIFACT_READY_SUBJECT, server.SWAP_DURABLE)
@@ -166,19 +183,8 @@ def test_consumer_issues_attach_or_replace_and_acks():
 def test_consumer_terminates_malformed_message():
     state, _ = _recording_state()
     msg = _FakeMsg(json.dumps({"payload": {}}).encode())
-    sub = _FakeSub([[msg]])
-    client = _FakeClient(sub)
-    stop = asyncio.Event()
 
-    async def drive():
-        task = asyncio.create_task(
-            server.run_swap_consumer(state, client, stop=stop, poll_timeout=0.01)
-        )
-        await asyncio.sleep(0.05)
-        stop.set()
-        await task
-
-    asyncio.run(drive())
+    _run_consumer_once(state, [msg])
 
     assert msg.termed is True
     assert msg.acked is False

--- a/projects/lakehouse/quack-server/server_test.py
+++ b/projects/lakehouse/quack-server/server_test.py
@@ -1,0 +1,221 @@
+"""Hermetic tests for the Quack serving pod (no network, no DuckDB extensions).
+
+The hot-swap consumer is exercised with a fake NATS subscription and an in-memory
+``duckdb.connect(':memory:')`` connection (no httpfs/iceberg/vss install). The
+assertions target two things platform/004 cares about:
+
+  * the ``artifact-ready`` handler issues exactly the ``ATTACH OR REPLACE`` SQL
+    from :func:`duckdb_query.attach_or_replace_sql`, and acks the message;
+  * ``/healthz`` returns ok and surfaces the current artifact version.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import duckdb
+import pytest
+from fastapi.testclient import TestClient
+
+import server
+from projects.lakehouse import duckdb_query
+
+
+# --------------------------------------------------------------------------- #
+# Fakes
+# --------------------------------------------------------------------------- #
+
+
+class _FakeMsg:
+    """A fake JetStream message recording ack/term calls."""
+
+    def __init__(self, data: bytes):
+        self.data = data
+        self.acked = False
+        self.termed = False
+
+    async def ack(self) -> None:
+        self.acked = True
+
+    async def term(self) -> None:
+        self.termed = True
+
+
+class _FakeSub:
+    """Yields one batch of messages then raises TimeoutError to idle the loop."""
+
+    def __init__(self, batches: list[list[_FakeMsg]]):
+        self._batches = list(batches)
+
+    async def fetch(self, batch=None, *, timeout=5.0):
+        if self._batches:
+            return self._batches.pop(0)
+        raise TimeoutError
+
+
+class _FakeClient:
+    """NatsClient stand-in returning a preloaded :class:`_FakeSub`."""
+
+    def __init__(self, sub: _FakeSub):
+        self._sub = sub
+        self.subscribed: tuple[str, str] | None = None
+
+    async def pull_subscribe(self, subject, durable, *, batch=10):
+        self.subscribed = (subject, durable)
+        return self._sub
+
+
+class _SpyConn:
+    """Wraps a real :memory: DuckDB connection, recording executed SQL.
+
+    DuckDB's ``execute`` is a C-extension method that cannot be monkey-patched,
+    so the connection is wrapped rather than mutated. ``ATTACH OR REPLACE`` is
+    recorded only (the remote artifact does not exist in the hermetic test); all
+    other SQL is delegated to the real connection.
+    """
+
+    def __init__(self) -> None:
+        self._con = duckdb.connect(":memory:")
+        self.executed: list[str] = []
+
+    def execute(self, sql, *args, **kwargs):
+        self.executed.append(sql)
+        if sql.startswith("ATTACH OR REPLACE"):
+            return self
+        return self._con.execute(sql, *args, **kwargs)
+
+
+def _recording_state() -> tuple[server.ServingState, list[str]]:
+    """A ServingState whose connection records every executed SQL string."""
+    spy = _SpyConn()
+    return server.ServingState(spy, version="v0"), spy.executed
+
+
+# --------------------------------------------------------------------------- #
+# parse_artifact_ready
+# --------------------------------------------------------------------------- #
+
+
+def test_parse_artifact_ready_accepts_artifact_url():
+    body = json.dumps(
+        {
+            "payload": {
+                "artifact_url": "s3://warehouse/serving/notes-v7.duckdb",
+                "version": "v7",
+            }
+        }
+    ).encode()
+    path, version = server.parse_artifact_ready(body)
+    assert path == "s3://warehouse/serving/notes-v7.duckdb"
+    assert version == "v7"
+
+
+def test_parse_artifact_ready_accepts_path_alias():
+    body = json.dumps(
+        {"payload": {"path": "s3://warehouse/serving/notes-v8.duckdb"}}
+    ).encode()
+    path, version = server.parse_artifact_ready(body)
+    assert path == "s3://warehouse/serving/notes-v8.duckdb"
+    assert version is None
+
+
+def test_parse_artifact_ready_rejects_missing_path():
+    with pytest.raises(ValueError):
+        server.parse_artifact_ready(json.dumps({"payload": {}}).encode())
+
+
+# --------------------------------------------------------------------------- #
+# Hot-swap consumer
+# --------------------------------------------------------------------------- #
+
+
+def test_consumer_issues_attach_or_replace_and_acks():
+    state, executed = _recording_state()
+    path = "s3://warehouse/serving/notes-v9.duckdb"
+    msg = _FakeMsg(
+        json.dumps({"payload": {"artifact_url": path, "version": "v9"}}).encode()
+    )
+    sub = _FakeSub([[msg]])
+    client = _FakeClient(sub)
+
+    stop = asyncio.Event()
+
+    async def drive():
+        task = asyncio.create_task(
+            server.run_swap_consumer(state, client, stop=stop, poll_timeout=0.01)
+        )
+        # Let the loop drain the one batch, then hit the idle TimeoutError path.
+        await asyncio.sleep(0.05)
+        stop.set()
+        await task
+
+    asyncio.run(drive())
+
+    # Subscribed to the right subject + durable.
+    assert client.subscribed == (server.ARTIFACT_READY_SUBJECT, server.SWAP_DURABLE)
+    # Exactly the ATTACH OR REPLACE SQL the pure builder produces was executed.
+    expected_sql = duckdb_query.attach_or_replace_sql(server.SERVING_ALIAS, path)
+    assert expected_sql in executed
+    # Version tracked + message acked.
+    assert state.version == "v9"
+    assert msg.acked is True
+    assert msg.termed is False
+
+
+def test_consumer_terminates_malformed_message():
+    state, _ = _recording_state()
+    msg = _FakeMsg(json.dumps({"payload": {}}).encode())
+    sub = _FakeSub([[msg]])
+    client = _FakeClient(sub)
+    stop = asyncio.Event()
+
+    async def drive():
+        task = asyncio.create_task(
+            server.run_swap_consumer(state, client, stop=stop, poll_timeout=0.01)
+        )
+        await asyncio.sleep(0.05)
+        stop.set()
+        await task
+
+    asyncio.run(drive())
+
+    assert msg.termed is True
+    assert msg.acked is False
+
+
+# --------------------------------------------------------------------------- #
+# HTTP API
+# --------------------------------------------------------------------------- #
+
+
+def test_healthz_returns_ok_and_version():
+    con = duckdb.connect(":memory:")
+    state = server.ServingState(con, version="v3")
+    app = server.create_app(state)
+    client = TestClient(app)
+
+    resp = client.get("/healthz")
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "ok", "artifact_version": "v3"}
+
+
+def test_search_requires_token_when_configured():
+    con = duckdb.connect(":memory:")
+    state = server.ServingState(con, version="v1")
+    app = server.create_app(state, query_token="sekret")
+    client = TestClient(app)
+
+    # No token -> 401 (auth runs before the query).
+    resp = client.post("/search", json={"query": [0.1, 0.2], "k": 5})
+    assert resp.status_code == 401
+
+
+def test_search_rejects_bad_k():
+    con = duckdb.connect(":memory:")
+    state = server.ServingState(con, version="v1")
+    app = server.create_app(state)  # no token -> auth open
+    client = TestClient(app)
+
+    resp = client.post("/search", json={"query": [0.1, 0.2], "k": 0})
+    assert resp.status_code == 400


### PR DESCRIPTION
## Summary

Implements unit **IMG-QUACK-SERVER** (Wavefront 3) of the event-sourced lakehouse (ADR platform/004). Adds a new, purely-additive package `projects/lakehouse/quack-server/`: a stateless serving pod that holds the current serving artifact ATTACHed in-RAM and answers vector/note queries over HTTP. Cloudflare CDN sits in front of the pod per the ADR; this unit builds only the pod.

## What's in the pod (`server.py`)

- **Startup** — `duckdb_query.connect()` loads `httpfs`/`iceberg`/`vss` + the SeaweedFS S3 secret; if `SERVING_ARTIFACT_URL` is set it ATTACHes that artifact so the pod can serve before the first swap.
- **Hot-swap consumer** — a durable NATS pull subscriber (`quack-serving-swap`) on `events.serving.artifact-ready`. Each event is parsed and applied via `duckdb_query.attach_or_replace_sql("notes", path)` — the zero-downtime swap from platform/004 (in-flight queries finish on the old snapshot; new queries see the new). Disposition: malformed → `term`; swap failure → leave for redelivery; success → `ack`.
- **HTTP API (FastAPI)** — `GET /healthz` (liveness + current artifact version) and `POST /search` (VSS nearest-neighbour via `vector_search_sql`, bearer-token gated by `QUACK_QUERY_TOKEN`).
- Config from env: `NATS_URL`, `SEAWEEDFS_S3_ENDPOINT`, `SERVING_ARTIFACT_URL`, `QUACK_QUERY_TOKEN`, `HOST`/`PORT`/`LOG_LEVEL`.

### Privileged-swap note (platform/004 §Security)

The swap is driven by a **durable NATS consumer the pod owns**, not an HTTP call. Only `BuildServingArtifactWorkflow` publishes `artifact-ready` and NATS is internal-only, so the "privileged swap" requirement is satisfied by **topology** — the swap never crosses the public HTTP boundary. `POST /search` is the only external surface and is bearer-token gated.

## Tests (`server_test.py`)

Hermetic: fake NatsClient + in-memory `duckdb.connect(':memory:')` (no remote extensions). Asserts the artifact-ready handler issues exactly the `ATTACH OR REPLACE` SQL the pure builder produces and acks; malformed messages are termed; `/healthz` returns ok + version; `/search` enforces the token and rejects bad `k`.

## Build (`BUILD`)

`py_library` + `py_venv_binary` (`main`, `server.py`) + multiarch non-root `py3_image` (`ghcr.io/jomcgi/homelab/projects/lakehouse/quack-server`, modelled field-for-field on the monolith image) + `py_test` + semgrep tests. The hyphenated package uses `imports = ["."]` (the trips image-tool pattern, since a hyphen can't be a Python module name). DuckDB pinned to 1.5.3. gazelle auto-registered the image in `bazel/images/BUILD` `push_all`.

Purely additive — new package only, no existing source-file edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)