### PR TITLE
feat(lakehouse): SeaweedFS warehouse stale-artifact lifecycle policy [INFRA-SEAWEEDFS-LIFECYCLE]

### DIFF
--- a/docs/plans/event-sourced-impl-status/INFRA-SEAWEEDFS-LIFECYCLE.md
+++ b/docs/plans/event-sourced-impl-status/INFRA-SEAWEEDFS-LIFECYCLE.md
@@ -1,0 +1,121 @@
+# INFRA-SEAWEEDFS-LIFECYCLE — warehouse stale-artifact lifecycle policy
+
+Status: **author-only** (CI-validated, NOT wired into ArgoCD this run). Wiring
+into `projects/platform/kustomization.yaml` /
+`projects/home-cluster/kustomization.yaml` is **deferred to the orchestrator**
+(central wiring after merge), per the unit's "purely additive" constraint.
+
+## What shipped
+
+A new, additive ArgoCD Application `warehouse-lifecycle` that idempotently
+applies a stale-serving-artifact **expiry (lifecycle) policy** to the existing
+`warehouse` S3 bucket on the existing SeaweedFS deployment (ns `seaweedfs`).
+Nothing under `projects/platform/seaweedfs/` or
+`projects/platform/warehouse-bucket/` was touched.
+
+Files created (all new, in `projects/platform/warehouse-lifecycle/`):
+
+- `application.yaml` — `argoproj.io/v1alpha1` Application, name
+  `warehouse-lifecycle`, ns `argocd`, label
+  `app.kubernetes.io/part-of: shared-infrastructure`, annotation
+  `argocd.argoproj.io/sync-wave: "1"`. Plain kustomize/directory source (NO Helm
+  block): `repoURL https://github.com/jomcgi/homelab.git`,
+  `path projects/platform/warehouse-lifecycle`, `targetRevision HEAD`.
+  Destination ns `seaweedfs`. `syncPolicy.automated` prune + selfHeal,
+  `syncOptions: [CreateNamespace=true]`, retry limit 5.
+- `kustomization.yaml` — Kustomization, `resources: [job.yaml]`.
+- `job.yaml` — the idempotent lifecycle-apply Job (details below).
+
+## Lifecycle approach — PREFIX-based TTL (documented deviation from tag-filter)
+
+The unit spec preferred an S3 `PutBucketLifecycleConfiguration` rule with a
+`Filter` on tag `state=stale` + `Expiration: Days=1`. **That is not safe on the
+deployed SeaweedFS, so this unit took the spec-anticipated prefix-based
+fallback.** Research findings:
+
+- **Deployed version is SeaweedFS 3.73** (`appVersion` in
+  `projects/platform/seaweedfs/Chart.yaml`; the chart/values do not override the
+  image tag — same fact the sibling INFRA-SEAWEEDFS unit relied on).
+- **Reliable S3 lifecycle expiration is NOT available on 3.73.** Upstream
+  maintainer (chrislusf) states dependable lifecycle expiry only landed "around
+  4.26~" (seaweedfs#2745). On recent versions the S3-lifecycle age check is
+  buggy: seaweedfs#6619 reports a prefix-filtered 1-day rule that deleted **all**
+  matching objects regardless of age. Tag-filtered (`Filter.Tag`) expiry is even
+  less battle-tested than prefix. Putting an S3 lifecycle config on 3.73 would
+  therefore either silently no-op or risk mass-deletion of the durable
+  warehouse — neither acceptable.
+- **The version-stable native mechanism in 3.73 is `weed shell fs.configure`**,
+  which has a `-ttl` flag (verified present in the 3.73 source:
+  `weed/shell/command_fs_configure.go`, `String("ttl", ...)`, regex
+  `^[1-255][mhdwMy]$`) applied per `-locationPrefix` and persisted with `-apply`.
+  This sets a **filer-enforced, age-correct TTL** on a path. S3 buckets map to
+  filer path `/buckets/<bucket>/`, so the serving prefix is
+  `/buckets/warehouse/serving/`.
+
+So the policy is: `fs.configure -locationPrefix=/buckets/warehouse/serving/
+-ttl=1d -apply`. This is **prefix-based, not tag-based** — the exact fallback
+the unit spec allowed ("if tag-based filtering isn't supported … fall back to a
+prefix-based rule on `serving/` with documented caveat").
+
+### Freshness caveat
+
+A prefix TTL on `serving/` ages out the _current_ artifact after 1 day too, not
+just `state=stale` ones. This is fine because `BuildServingArtifactWorkflow`
+rewrites the current artifact every ~15 min (ADR platform/004), far inside the
+1-day window — the live artifact is continuously refreshed and only
+orphaned/stale objects actually age out. The build workflow's **keep-last-N=24**
+cleanup remains the belt-and-suspenders backstop (ADR platform/004 §"Serving
+artifact lifecycle"). When SeaweedFS is upgraded to >= ~4.26 this can be
+revisited and swapped for a true tag-filtered (`state=stale`) S3 lifecycle rule.
+
+## Idempotency & security
+
+Mirrors the sibling INFRA-SEAWEEDFS `warehouse-bucket` Job:
+
+- Same image `chrislusf/seaweedfs:3.73`, talks to
+  `seaweedfs-master.seaweedfs.svc.cluster.local:9333` via `weed shell`. No S3
+  credentials (S3 gateway `enableAuth: false`; `weed shell` talks to the master
+  directly over the cluster network).
+- **Idempotent**: `weed shell` is a command interpreter (cannot branch), so the
+  Job first reads the persisted config with a flag-less `fs.configure`
+  (simulation, no mutation), greps for the prefix + desired ttl, and only re-runs
+  with `-apply` if absent. Safe to re-run; ArgoCD recreates it each sync via
+  `argocd.argoproj.io/hook: PreSync` + `hook-delete-policy: BeforeHookCreation`
+  (avoids the "Job spec is immutable" selfHeal problem).
+  `ttlSecondsAfterFinished: 600` reaps the pod.
+- **Security**: non-root uid/gid 65532, `runAsNonRoot`,
+  `readOnlyRootFilesystem: true` (emptyDir at `/tmp`, `HOME=/tmp` for `weed`
+  scratch), `allowPrivilegeEscalation: false`, all capabilities dropped,
+  `seccompProfile: RuntimeDefault`, `automountServiceAccountToken: false` (no
+  K8s API calls). `restartPolicy: OnFailure`, `backoffLimit: 5`, minimal
+  resources (25m/32Mi req, 100m/64Mi lim). Linkerd-meshed namespace, NO
+  NetworkPolicies (per cluster rule).
+
+## ADR alignment
+
+- Implements ADR platform/004 §"Serving artifact lifecycle": "SeaweedFS
+  lifecycle deletes `state=stale` objects after 1 day" — realized here as a
+  1-day prefix TTL on `serving/` (deviation documented above), with keep-last-N
+  as the documented backstop.
+- §"One operational rule" (snapshot GC / Iceberg expiry outside the backup
+  window) concerns **Iceberg snapshot GC**, a separate workflow — out of scope
+  for this serving-artifact lifecycle unit; noted so it isn't conflated.
+
+## Deferred / follow-ups
+
+- **Central wiring** of this Application into
+  `projects/platform/kustomization.yaml` /
+  `projects/home-cluster/kustomization.yaml` — handled by the orchestrator after
+  merge (per unit constraints; this unit must not edit those files).
+- **Tag-filtered S3 lifecycle** (`state=stale`, Expiration Days=1) — revisit
+  after a SeaweedFS upgrade to >= ~4.26, where it becomes reliable.
+
+## Self-validation
+
+`kubectl kustomize projects/platform/warehouse-lifecycle/` renders cleanly
+(single Job manifest). All three files pass YAML lint. No Helm here. Nothing was
+applied to the cluster and `fs.configure` was NOT run against the live filer —
+author-only, per unit constraints. (Live kubectl re-confirmation of service
+names/ports was not performed; the verified discovery facts from the sibling
+unit were reused: `seaweedfs-master.seaweedfs:9333`, S3 auth disabled, image
+`chrislusf/seaweedfs:3.73`.)

--- a/projects/platform/warehouse-lifecycle/application.yaml
+++ b/projects/platform/warehouse-lifecycle/application.yaml
@@ -1,0 +1,48 @@
+# ArgoCD Application: warehouse-lifecycle
+#
+# Idempotently applies a stale-artifact lifecycle (expiry) policy to the
+# existing `warehouse` S3 bucket on the existing SeaweedFS deployment
+# (ns seaweedfs) for the event-sourced lakehouse (ADR platform/004,
+# "Serving artifact lifecycle"): old serving artifacts under serving/ are
+# expired ~1 day after they go stale.
+#
+# This is a plain kustomize/directory Application (NOT a Helm chart) — there is
+# no upstream chart for "set a bucket lifecycle". The policy is applied by an
+# idempotent Job (see job.yaml) that talks to the SeaweedFS master via
+# `weed shell`, mirroring the sibling INFRA-SEAWEEDFS warehouse-bucket unit.
+#
+# Additive unit INFRA-SEAWEEDFS-LIFECYCLE. Does not touch
+# projects/platform/seaweedfs/ or projects/platform/warehouse-bucket/.
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: warehouse-lifecycle
+  namespace: argocd
+  labels:
+    app.kubernetes.io/part-of: shared-infrastructure
+  annotations:
+    # Sync after SeaweedFS itself and after the warehouse bucket exists (both
+    # wave 1); the Job retries against the master until it is reachable, so
+    # ordering is best-effort.
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/jomcgi/homelab.git
+    path: projects/platform/warehouse-lifecycle
+    targetRevision: HEAD
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: seaweedfs
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m

--- a/projects/platform/warehouse-lifecycle/job.yaml
+++ b/projects/platform/warehouse-lifecycle/job.yaml
@@ -1,0 +1,156 @@
+# Idempotent Job: apply the stale-serving-artifact lifecycle (expiry) policy
+# to the `warehouse` S3 bucket on SeaweedFS.
+#
+# WHAT: expire old serving artifacts under serving/ ~1 day after they go stale,
+# per ADR platform/004 ("Serving artifact lifecycle": SeaweedFS lifecycle
+# deletes state=stale objects after 1 day, with the build workflow's
+# keep-last-N=24 as the belt-and-suspenders backstop).
+#
+# APPROACH (prefix-based TTL, NOT tag-based) — documented deviation:
+#   The unit spec preferred an S3 PutBucketLifecycleConfiguration rule with a
+#   Filter on tag state=stale + Expiration Days=1. The deployed SeaweedFS is
+#   **3.73** (appVersion of projects/platform/seaweedfs/Chart.yaml). On 3.73,
+#   reliable S3 lifecycle expiration is NOT available: upstream maintainer
+#   confirms dependable lifecycle expiry only landed "around 4.26~", and even on
+#   recent versions the S3-lifecycle age check is buggy (seaweedfs#6619 — a
+#   prefix-filtered 1-day rule deleted ALL matching objects regardless of age).
+#   Tag-filtered (Filter.Tag) expiry is even less battle-tested. Putting an S3
+#   lifecycle config on 3.73 would therefore either silently no-op or risk
+#   mass-deletion — neither acceptable for the durable warehouse.
+#
+#   The version-stable native mechanism in 3.73 is `weed shell fs.configure`,
+#   which has a `-ttl` flag (confirmed in the 3.73 source) applied per
+#   `-locationPrefix`. This sets a filer-enforced, age-correct TTL on a path.
+#   S3 buckets map to the filer path /buckets/<bucket>/, so the serving prefix
+#   is /buckets/warehouse/serving/. This is the exact prefix-based fallback the
+#   unit spec anticipated. It mirrors the sibling INFRA-SEAWEEDFS unit's
+#   `weed shell` style (same image, same master, no S3 credentials needed).
+#
+# FRESHNESS NUANCE: a prefix TTL on serving/ would also age out the *current*
+# artifact after 1 day — but BuildServingArtifactWorkflow rewrites the current
+# artifact every ~15 min (ADR platform/004), far inside the 1-day window, so the
+# live artifact is continuously refreshed and only orphaned/stale objects age
+# out. keep-last-N=24 in the build workflow remains the belt-and-suspenders
+# backstop. When SeaweedFS is upgraded to >= ~4.26, this can be revisited and
+# swapped for a true tag-filtered (state=stale) S3 lifecycle rule.
+#
+# IDEMPOTENCY: `weed shell` is a command interpreter, not a POSIX shell, so we
+# cannot branch inside it. Instead we first run `fs.configure` in *simulation*
+# mode (no -apply) for the serving prefix and grep its echoed config for the
+# desired ttl; only if the ttl is not already present do we re-run with -apply.
+# Safe to re-run — ArgoCD recreates this Job on every sync via the PreSync hook.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: warehouse-lifecycle-apply
+  namespace: seaweedfs
+  labels:
+    app.kubernetes.io/name: warehouse-lifecycle
+    app.kubernetes.io/part-of: shared-infrastructure
+  annotations:
+    # Run on every ArgoCD sync and recreate cleanly each time. PreSync keeps the
+    # policy applied before any downstream lakehouse component syncs.
+    argocd.argoproj.io/hook: PreSync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+spec:
+  backoffLimit: 5
+  # Reap the pod automatically a while after success to keep the namespace tidy.
+  ttlSecondsAfterFinished: 600
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: warehouse-lifecycle
+    spec:
+      restartPolicy: OnFailure
+      # This Job makes no Kubernetes API calls — only network calls to the
+      # SeaweedFS master — so it needs no ServiceAccount token.
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        fsGroup: 65532
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: apply-lifecycle
+          image: chrislusf/seaweedfs:3.73
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          env:
+            - name: MASTER
+              value: "seaweedfs-master.seaweedfs.svc.cluster.local:9333"
+            # S3 bucket <bucket> maps to filer path /buckets/<bucket>/; the
+            # serving artifacts live under serving/ inside the warehouse bucket.
+            - name: PREFIX
+              value: "/buckets/warehouse/serving/"
+            # 1d per ADR platform/004 ("deletes state=stale objects after 1 day").
+            - name: TTL
+              value: "1d"
+            # Give weed a writable scratch/home dir under the read-only root FS.
+            - name: HOME
+              value: "/tmp"
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -eu
+              echo "Waiting for SeaweedFS master at ${MASTER} ..."
+              i=0
+              until echo "cluster.check" | weed shell -master "${MASTER}" >/dev/null 2>&1; do
+                i=$((i + 1))
+                if [ "$i" -ge 30 ]; then
+                  echo "ERROR: master ${MASTER} not reachable after $i attempts" >&2
+                  exit 1
+                fi
+                echo "  master not ready yet (attempt $i); retrying in 5s..."
+                sleep 5
+              done
+
+              echo "Checking current filer config for prefix ${PREFIX} ..."
+              # `fs.configure` with no flags echoes the persisted filer
+              # configuration as text (one stanza per locationPrefix) without
+              # mutating anything. Read it and check whether our prefix already
+              # carries the desired ttl before deciding to apply.
+              CURRENT="$(echo "fs.configure" | weed shell -master "${MASTER}" 2>/dev/null || true)"
+              echo "----- current filer config -----"
+              echo "${CURRENT}"
+              echo "--------------------------------"
+
+              # The persisted config prints one stanza per locationPrefix. Look
+              # for our exact prefix together with the ttl value on the same
+              # stanza. SeaweedFS prints these as `location_prefix:"..." ttl:"1d"`
+              # (proto text) or as TOML-ish lines depending on version; match the
+              # prefix and ttl tolerantly anywhere in the output.
+              if printf '%s\n' "${CURRENT}" | grep -Fq "${PREFIX}" \
+                   && printf '%s\n' "${CURRENT}" | grep -Eq "ttl[^a-zA-Z0-9]+${TTL}([^0-9a-zA-Z]|\$)"; then
+                echo "Lifecycle ttl=${TTL} already configured for ${PREFIX}; nothing to do."
+                exit 0
+              fi
+
+              echo "Applying lifecycle ttl=${TTL} to ${PREFIX} ..."
+              echo "fs.configure -locationPrefix=${PREFIX} -ttl=${TTL} -apply" \
+                | weed shell -master "${MASTER}"
+
+              echo "Verifying lifecycle ttl=${TTL} on ${PREFIX} ..."
+              echo "fs.configure" | weed shell -master "${MASTER}" 2>/dev/null \
+                | grep -Fq "${PREFIX}"
+              echo "Lifecycle policy applied: ${PREFIX} ttl=${TTL}."
+          resources:
+            requests:
+              cpu: 25m
+              memory: 32Mi
+            limits:
+              cpu: 100m
+              memory: 64Mi
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}

--- a/projects/platform/warehouse-lifecycle/kustomization.yaml
+++ b/projects/platform/warehouse-lifecycle/kustomization.yaml
@@ -1,0 +1,10 @@
+# Kustomization for the warehouse-lifecycle ArgoCD Application.
+#
+# Plain kustomize (no Helm): a single idempotent Job that applies the
+# stale-serving-artifact expiry (lifecycle) policy to the existing `warehouse`
+# S3 bucket on the existing SeaweedFS deployment.
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - job.yaml


### PR DESCRIPTION
## Unit: INFRA-SEAWEEDFS-LIFECYCLE (Wavefront 4)

**AUTHOR-ONLY: CI-validated, NOT wired into ArgoCD this run.** Central wiring into `projects/platform/kustomization.yaml` / `projects/home-cluster/kustomization.yaml` is deferred to the orchestrator after merge, per the unit's purely-additive constraint.

### What this adds

A new, additive ArgoCD Application `warehouse-lifecycle` (new dir `projects/platform/warehouse-lifecycle/` only — no existing files modified) that idempotently applies a **1-day expiry policy** to the serving artifacts of the existing `warehouse` S3 bucket on SeaweedFS, per ADR platform/004 §"Serving artifact lifecycle".

Files (all new):
- `application.yaml` — Application `warehouse-lifecycle`, ns argocd, `part-of: shared-infrastructure`, sync-wave `1`, plain kustomize source `projects/platform/warehouse-lifecycle`, targetRevision HEAD, dest ns `seaweedfs`, automated prune+selfHeal, retry 5.
- `kustomization.yaml` — `resources: [job.yaml]`.
- `job.yaml` — idempotent lifecycle-apply Job.

### Lifecycle approach: PREFIX-based TTL (documented deviation from tag-filter)

The spec preferred a tag-filtered S3 `PutBucketLifecycleConfiguration` (`Filter` on `state=stale`, `Expiration Days=1`). **Not safe on the deployed SeaweedFS 3.73**:
- Upstream confirms reliable S3 lifecycle expiry only landed ~4.26+ (seaweedfs#2745).
- seaweedfs#6619: a prefix-filtered 1-day lifecycle rule mass-deleted **all** matching objects regardless of age (buggy age check). Tag-filtered expiry is even less tested.

Instead this uses the version-stable native mechanism: `weed shell fs.configure -locationPrefix=/buckets/warehouse/serving/ -ttl=1d -apply` (the `-ttl` flag is verified present in the 3.73 source). This is filer-enforced, age-correct, **prefix-based** — the exact fallback the spec allowed. The build workflow's keep-last-N=24 remains the belt-and-suspenders backstop. Revisit for a tag-filtered rule after a SeaweedFS upgrade to >= ~4.26.

**Freshness caveat:** a prefix TTL also ages the current artifact after 1 day, but `BuildServingArtifactWorkflow` rewrites it every ~15 min (far inside the window), so only orphaned/stale objects actually age out.

### Style / safety

Mirrors the sibling INFRA-SEAWEEDFS `warehouse-bucket` Job: image `chrislusf/seaweedfs:3.73`, `weed shell` against the master (no creds), idempotent (reads persisted config, applies only if absent), PreSync hook with `BeforeHookCreation` delete policy, non-root 65532, read-only rootfs, dropped caps, `automountServiceAccountToken: false`. Linkerd-meshed namespace, no NetworkPolicies.

### Self-validation

`kubectl kustomize projects/platform/warehouse-lifecycle/` renders cleanly (single Job manifest); all files YAML-lint. Nothing applied to the cluster.

Status note: `docs/plans/event-sourced-impl-status/INFRA-SEAWEEDFS-LIFECYCLE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)