### PR TITLE
feat(lakehouse): NATS->Temporal dispatchers + image [SVC-DISPATCHERS]

### DIFF
--- a/bazel/images/BUILD
+++ b/bazel/images/BUILD
@@ -51,6 +51,7 @@ multirun(
         "//projects/grimoire/frontend:image.push",
         "//projects/grimoire/ws-gateway:image.push",
         "//projects/hikes/update_forecast:update_image.push",
+        "//projects/lakehouse/dispatchers:image.push",
         "//projects/lakehouse/image:image.push",
         "//projects/lakehouse/quack-server:image.push",
         "//projects/monolith/chart:chart.push",

--- a/docs/plans/event-sourced-impl-status/SVC-DISPATCHERS.md
+++ b/docs/plans/event-sourced-impl-status/SVC-DISPATCHERS.md
@@ -1,0 +1,109 @@
+# SVC-DISPATCHERS — NATS -> Temporal workflow dispatchers + image
+
+**Unit:** SVC-DISPATCHERS (Wavefront 4)
+**ADR:** [agents/016 — NATS as Canonical Event Stream](../../decisions/agents/016-nats-canonical-event-stream.md) §"Workflow dispatchers" · [agents/017 — Domain Event Schema](../../decisions/agents/017-domain-event-schema.md) · [agents/015 — Temporal Orchestration Substrate](../../decisions/agents/015-temporal-orchestration-substrate.md)
+**Branch:** `feat/lakehouse-w4-dispatchers`
+**Classification:** purely-additive — one new dir `projects/lakehouse/dispatchers/` plus a one-line insert into the auto-generated `bazel/images/BUILD` push list (exactly what `//bazel/images:generate-push-all` emits; pre-applied so the FIRST CI run pushes the image and the format check sees no diff).
+**Scope:** AUTHOR-ONLY. Nothing is wired to a Deployment by this unit; the dispatcher Deployment lives in the sibling W4-CHART unit (which references this image by repo string). The gap dispatcher is a **shadow / parallel** definition — production cutover from the live orchestrator is out of scope (see SCOPE GUARD below).
+
+## What shipped
+
+A `monolith-dispatchers`-style process (ADR 016 §"Workflow dispatchers": small
+adapters translating NATS events into `start_workflow` calls).
+
+- `projects/lakehouse/dispatchers/__init__.py` — the `Dispatcher` dataclass
+  (`subject`, `durable`, async `handle(envelope, temporal_client)`, optional
+  `event_type` filter) + a `pkgutil.iter_modules` loader exposing
+  `all_dispatchers()` that aggregates each submodule's module-level `DISPATCHERS`
+  list. **New dispatcher = a new file, no shared-list edit** — mirrors the
+  `orchestrator.workflows` / `orchestrator.schedules` loaders.
+- `projects/lakehouse/dispatchers/gap_ready.py` — `DISPATCHERS` entry for subject
+  `events.knowledge.gap`, filter `event_type == "created"`. Handler starts
+  `GapDrainWorkflow` (referenced by **type-name string**, never imported) with
+  deterministic ID `gap-drain-{entity_id}` on task queue `gap-drain`, swallowing
+  `WorkflowAlreadyStartedError` as an idempotent no-op.
+- `projects/lakehouse/dispatchers/artifact_ready.py` — `DISPATCHERS` entry for
+  subject `events.serving.artifact-ready`. **Minimal stub** (logs only): the
+  quack-server pod already self-subscribes to this subject and performs its own
+  `ATTACH OR REPLACE` (`quack-server/server.py:run_swap_consumer`, durable
+  `quack-serving-swap`), so this is a secondary/optional reaction hook with a
+  **distinct durable** (`artifact-ready-dispatcher`) so JetStream fans out to both
+  consumers independently. Deliberately does NOT start a swap workflow (no
+  double-swap).
+- `projects/lakehouse/dispatchers/run.py` — entrypoint
+  (`python -m projects.lakehouse.dispatchers.run`). Connects `NatsClient` +
+  Temporal (`orchestrator.client.get_client`), opens a durable pull consumer per
+  dispatcher, and polls all in a graceful loop. Message disposition mirrors the
+  quack consumer: malformed envelope -> `term`; filtered-out event -> `ack`;
+  handler success -> `ack`; handler raises -> left un-acked for JetStream
+  redelivery (the per-subscription loop logs and continues so one bad message
+  can't kill the loop).
+- `projects/lakehouse/dispatchers/BUILD` — `py_library` (gazelle-managed) +
+  `py_venv_binary` (`name = "main"`, `main = run.py`) + hand-written `py3_image`
+  (`repository = "ghcr.io/jomcgi/homelab/projects/lakehouse/dispatchers"`,
+  multiarch, non-root 65532, PYTHONPATH = workspace root, modeled on
+  `projects/lakehouse/image`) + `py_test` + semgrep targets.
+- `projects/lakehouse/dispatchers/dispatchers_test.py` — hermetic tests
+  (fakes for NATS client/subscription/message + Temporal client).
+- `bazel/images/BUILD` — `//projects/lakehouse/dispatchers:image.push` inserted
+  into the sorted `push_all` list (auto-generated; pre-applied).
+
+## gap_ready dispatch design
+
+1. Producer publishes a `gap` `created` event to `events.knowledge.gap`
+   (ADR-017 envelope, `Nats-Msg-Id = {entity_id}-v{event_version}`).
+2. The run loop's durable pull consumer (`gap-drain-dispatcher`) fetches it,
+   decodes it to an `EventEnvelope`, applies the dispatcher's `event_type ==
+"created"` filter (`updated`/`processed`/`tombstoned` are acked + ignored).
+3. `handle_gap_created` calls
+   `temporal_client.start_workflow("GapDrainWorkflow", envelope.payload,
+id="gap-drain-{entity_id}", task_queue="gap-drain")`.
+4. If a drain for that gap is already running, Temporal raises
+   `WorkflowAlreadyStartedError`, which is **swallowed** — the three independent
+   trigger paths (this dispatcher / cron sweep / manual) converge on one
+   deterministic workflow ID; whichever fires first wins (ADR 015 §"Workflow
+   identity = work identity").
+5. On success the message is acked. Net effect: at-least-once NATS delivery +
+   workflow-ID dedup = exactly-once workflow start.
+
+The workflow is referenced by **type-name string** (no import of the workflow
+class), so the dispatcher carries no workflow/activity dependency and stays a
+~30-line adapter (ADR 016).
+
+### Note on the `temporalio` exception path
+
+The spec phrases this as `temporalio.client.WorkflowAlreadyStartedError`, but in
+the pinned `temporalio==1.27.2` the symbol is **not** re-exported from
+`temporalio.client` — it lives in `temporalio.exceptions` (same as the W3
+`gap_drain` workflow's import). The handler imports it from there; verified
+against the pinned wheel.
+
+## SCOPE GUARD (deliberate — production cutover is a FOLLOW-UP, not this run)
+
+The gap dispatcher is a **parallel / shadow** definition, reacting to (and
+triggering) the W3 shadow `GapDrainWorkflow`. Production gap dispatch still flows
+through the existing live orchestrator (`projects/agent_platform/orchestrator` /
+`knowledge/research_handler`). Wiring this NATS->Temporal path as the production
+gap pipeline — and deploying the dispatcher pod (W4-CHART) — is a deliberate
+follow-up unit. Nothing here competes with the live pipeline.
+
+## Validation
+
+No local `bazel test` (Mac has no `workflows`-pool runner). Validated by:
+
+- **Hermetic test run in a throwaway venv** with the _pinned_ `temporalio==1.27.2`
+  - `pydantic` + `nats-py`: **19/19 passed**. Asserts gap-created event ->
+    `start_workflow("GapDrainWorkflow", id="gap-drain-<id>", task_queue="gap-drain")`,
+    `WorkflowAlreadyStartedError` swallowed, `all_dispatchers()` discovers both,
+    event_type filter, artifact-ready stub never touches Temporal, malformed -> term,
+    handler-error -> redelivery, end-to-end run() wiring with fakes.
+- `ruff check` + `ruff format --check`: clean.
+- Push-list insert position confirmed via `LC_ALL=C sort` (matches what
+  `generate-push-all.sh` emits).
+- CI "Test and push" (`bazel test //...` + image push on main) + the `py3_image`
+  macro's `image_config_test` are the real validation.
+
+## Status
+
+- Implementation: complete
+- CI / Test / Push-images: <!-- filled in post-merge -->

--- a/projects/lakehouse/dispatchers/BUILD
+++ b/projects/lakehouse/dispatchers/BUILD
@@ -1,0 +1,122 @@
+load("@aspect_rules_py//py:defs.bzl", "py_library")
+load("@aspect_rules_py//py/private/py_venv:defs.bzl", "py_venv_binary")
+load("//bazel/semgrep/defs:defs.bzl", "semgrep_target_test", "semgrep_test")
+load("//bazel/tools/oci:py3_image.bzl", "py3_image")
+load("//bazel/tools/pytest:defs.bzl", "py_test")
+
+# NATS -> Temporal workflow dispatchers (ADR agents/016). Small adapters that
+# subscribe to NATS subjects and translate domain events into Temporal
+# `start_workflow` calls. New dispatcher = a new `<id>.py` file exporting a
+# module-level `DISPATCHERS` list; the package loader (`all_dispatchers()`)
+# aggregates them, so adding one needs NO shared-list edit.
+#
+# `temporalio` is in the pip lock (LIB-SCAFFOLD) but the generated gazelle module
+# manifest (bazel/tools/python/gazelle_python.yaml, GENERATED / content-checked)
+# was not regenerated to include it, so gazelle can't auto-resolve
+# `import temporalio`. Resolve it explicitly here — the documented escape hatch,
+# matching orchestrator/BUILD.
+# gazelle:resolve py temporalio @pip//temporalio
+# gazelle:resolve py temporalio.client @pip//temporalio
+
+py_library(
+    name = "dispatchers",
+    srcs = [
+        "__init__.py",
+        "artifact_ready.py",
+        "gap_ready.py",
+        "run.py",
+    ],
+    visibility = ["//:__subpackages__"],
+    deps = [
+        "//projects/lakehouse/events",
+        "//projects/lakehouse/nats_client",
+        "//projects/lakehouse/orchestrator",
+        "@pip//temporalio",
+    ],
+)
+
+# Process entrypoint: `python -m projects.lakehouse.dispatchers.run`. The image
+# runs run.py:_main(). One process subscribes to every discovered dispatcher's
+# subject (there is no per-subject pod — ADR 016 Open Q2 "one dispatcher service
+# handling many subscriptions").
+py_venv_binary(
+    name = "main",
+    srcs = ["run.py"],
+    main = "run.py",
+    visibility = ["//:__subpackages__"],
+    deps = [
+        ":dispatchers",
+        "//projects/lakehouse/events",
+        "//projects/lakehouse/nats_client",
+        "//projects/lakehouse/orchestrator",
+        "@pip//temporalio",
+    ],
+)
+
+# Multiarch (x86_64 + aarch64), non-root (uid 65532 — the python_base default),
+# modeled field-for-field on the lakehouse worker image
+# (//projects/lakehouse/image). run.py uses absolute
+# `from projects.lakehouse.dispatchers...` imports that resolve from the
+# workspace root, so PYTHONPATH is just the macro's auto-computed workspace root
+# (no per-package dir needed, unlike the hyphenated quack-server package).
+# SSL_CERT_FILE points OpenSSL at certifi's bundle (the minimal base has no CA
+# certs) so outbound TLS to Temporal/NATS works.
+py3_image(
+    name = "image",
+    binary = "//projects/lakehouse/dispatchers:main",
+    env = {
+        "PYTHONPATH": "/projects/lakehouse/dispatchers/main.runfiles/_main",
+        "SSL_CERT_FILE": "/projects/lakehouse/dispatchers/main.runfiles/_main/projects/lakehouse/dispatchers/.main/lib/python3.13/site-packages/certifi/cacert.pem",
+    },
+    main = "run.py",
+    repository = "ghcr.io/jomcgi/homelab/projects/lakehouse/dispatchers",
+)
+
+py_test(
+    name = "dispatchers_test",
+    srcs = ["dispatchers_test.py"],
+    deps = [
+        ":dispatchers",
+        "//projects/lakehouse/events",
+        "@pip//pytest",
+        "@pip//temporalio",
+    ],
+)
+
+semgrep_target_test(
+    name = "main_semgrep_test",
+    lockfiles = ["//bazel/requirements:all.txt"],
+    rules = ["//bazel/semgrep/rules:python_rules"],
+    sca_rules = ["//bazel/semgrep/rules:sca_python_rules"],
+    target = ":main",
+)
+
+semgrep_test(
+    name = "__init___semgrep_test",
+    srcs = ["__init__.py"],
+    rules = ["//bazel/semgrep/rules:python_rules"],
+)
+
+semgrep_test(
+    name = "artifact_ready_semgrep_test",
+    srcs = ["artifact_ready.py"],
+    rules = ["//bazel/semgrep/rules:python_rules"],
+)
+
+semgrep_test(
+    name = "gap_ready_semgrep_test",
+    srcs = ["gap_ready.py"],
+    rules = ["//bazel/semgrep/rules:python_rules"],
+)
+
+semgrep_test(
+    name = "run_semgrep_test",
+    srcs = ["run.py"],
+    rules = ["//bazel/semgrep/rules:python_rules"],
+)
+
+semgrep_test(
+    name = "dispatchers_test_semgrep_test",
+    srcs = ["dispatchers_test.py"],
+    rules = ["//bazel/semgrep/rules:python_rules"],
+)

--- a/projects/lakehouse/dispatchers/BUILD
+++ b/projects/lakehouse/dispatchers/BUILD
@@ -78,6 +78,8 @@ py_test(
     deps = [
         ":dispatchers",
         "//projects/lakehouse/events",
+        "//projects/lakehouse/nats_client",
+        "//projects/lakehouse/orchestrator",
         "@pip//pytest",
         "@pip//temporalio",
     ],

--- a/projects/lakehouse/dispatchers/BUILD
+++ b/projects/lakehouse/dispatchers/BUILD
@@ -28,8 +28,8 @@ py_library(
     ],
     visibility = ["//:__subpackages__"],
     deps = [
+        "//projects/lakehouse",
         "//projects/lakehouse/events",
-        "//projects/lakehouse/nats_client",
         "//projects/lakehouse/orchestrator",
         "@pip//temporalio",
     ],
@@ -46,8 +46,8 @@ py_venv_binary(
     visibility = ["//:__subpackages__"],
     deps = [
         ":dispatchers",
+        "//projects/lakehouse",
         "//projects/lakehouse/events",
-        "//projects/lakehouse/nats_client",
         "//projects/lakehouse/orchestrator",
         "@pip//temporalio",
     ],
@@ -89,30 +89,6 @@ semgrep_target_test(
     rules = ["//bazel/semgrep/rules:python_rules"],
     sca_rules = ["//bazel/semgrep/rules:sca_python_rules"],
     target = ":main",
-)
-
-semgrep_test(
-    name = "__init___semgrep_test",
-    srcs = ["__init__.py"],
-    rules = ["//bazel/semgrep/rules:python_rules"],
-)
-
-semgrep_test(
-    name = "artifact_ready_semgrep_test",
-    srcs = ["artifact_ready.py"],
-    rules = ["//bazel/semgrep/rules:python_rules"],
-)
-
-semgrep_test(
-    name = "gap_ready_semgrep_test",
-    srcs = ["gap_ready.py"],
-    rules = ["//bazel/semgrep/rules:python_rules"],
-)
-
-semgrep_test(
-    name = "run_semgrep_test",
-    srcs = ["run.py"],
-    rules = ["//bazel/semgrep/rules:python_rules"],
 )
 
 semgrep_test(

--- a/projects/lakehouse/dispatchers/BUILD
+++ b/projects/lakehouse/dispatchers/BUILD
@@ -17,6 +17,15 @@ load("//bazel/tools/pytest:defs.bzl", "py_test")
 # matching orchestrator/BUILD.
 # gazelle:resolve py temporalio @pip//temporalio
 # gazelle:resolve py temporalio.client @pip//temporalio
+#
+# Force `projects.lakehouse.nats_client` to resolve to its own subpackage target
+# rather than the parent //projects/lakehouse (which carries only the top-level
+# __init__.py, NOT the nats_client submodule). Without this, gazelle maps
+# `from projects.lakehouse.nats_client import NatsClient` (in run.py) to
+# //projects/lakehouse and NatsClient is missing from the binary/test runfiles
+# (ModuleNotFoundError at runtime). Mirrors nats_client/BUILD + quack-server/BUILD.
+# gazelle:resolve py projects.lakehouse.nats_client //projects/lakehouse/nats_client:nats_client
+# gazelle:resolve py projects.lakehouse.nats_client.client //projects/lakehouse/nats_client:nats_client
 
 py_library(
     name = "dispatchers",
@@ -28,8 +37,8 @@ py_library(
     ],
     visibility = ["//:__subpackages__"],
     deps = [
-        "//projects/lakehouse",
         "//projects/lakehouse/events",
+        "//projects/lakehouse/nats_client",
         "//projects/lakehouse/orchestrator",
         "@pip//temporalio",
     ],
@@ -46,8 +55,8 @@ py_venv_binary(
     visibility = ["//:__subpackages__"],
     deps = [
         ":dispatchers",
-        "//projects/lakehouse",
         "//projects/lakehouse/events",
+        "//projects/lakehouse/nats_client",
         "//projects/lakehouse/orchestrator",
         "@pip//temporalio",
     ],

--- a/projects/lakehouse/dispatchers/BUILD
+++ b/projects/lakehouse/dispatchers/BUILD
@@ -87,8 +87,6 @@ py_test(
     deps = [
         ":dispatchers",
         "//projects/lakehouse/events",
-        "//projects/lakehouse/nats_client",
-        "//projects/lakehouse/orchestrator",
         "@pip//pytest",
         "@pip//temporalio",
     ],

--- a/projects/lakehouse/dispatchers/__init__.py
+++ b/projects/lakehouse/dispatchers/__init__.py
@@ -1,0 +1,119 @@
+"""NATS -> Temporal workflow dispatchers (ADR agents/016 §"Workflow dispatchers").
+
+Dispatchers are the small adapters that turn canonical NATS events
+(ADR 017 :class:`~projects.lakehouse.events.envelope.EventEnvelope`) into
+Temporal ``start_workflow`` calls. ADR 016 §Proposal: "Workflow dispatchers are
+small adapters (~30 lines each) that translate NATS events into ``start_workflow``
+calls with deterministic IDs." The producer never references Temporal; the
+consumer never references the producer.
+
+Auto-discovery
+--------------
+Each dispatcher module dropped under this package exports a module-level
+``DISPATCHERS`` list of :class:`Dispatcher`. New dispatcher = a new file; the
+entrypoint (:mod:`projects.lakehouse.dispatchers.run`) discovers them through
+:func:`all_dispatchers`, so there is **no shared registration list** to edit —
+mirroring the ``orchestrator.workflows`` / ``orchestrator.schedules`` loaders and
+keeping per-dispatcher units conflict-free.
+
+A :class:`Dispatcher` carries:
+
+* ``subject`` — the NATS subject to subscribe to (``events.{domain}.{type}``);
+* ``durable`` — the durable (consumer-group) name so a restarted pod resumes
+  from where it left off;
+* ``handle`` — an ``async (envelope, temporal_client) -> None`` callable that
+  reacts to one event (typically a ``start_workflow`` with a deterministic ID).
+
+``handle`` takes the **decoded** :class:`EventEnvelope` (the run loop parses the
+raw message once and applies the dispatcher's own ``event_type`` filter), plus a
+``temporalio.client.Client``. Handlers stay independent of the workflow classes
+they trigger: ADR 016 references workflows by **type-name string**, never by
+import, so a dispatcher pulls in no workflow/activity deps.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import importlib
+import pkgutil
+from collections.abc import Awaitable, Callable
+from types import ModuleType
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    import temporalio.client
+
+    from projects.lakehouse.events.envelope import EventEnvelope
+
+    # An event handler: react to one decoded envelope using a Temporal client.
+    Handler = Callable[[EventEnvelope, "temporalio.client.Client"], Awaitable[None]]
+else:  # at runtime the alias is only used for annotations, kept loose.
+    Handler = Callable[..., Awaitable[None]]
+
+
+@dataclasses.dataclass(frozen=True)
+class Dispatcher:
+    """One NATS-subject -> Temporal-workflow adapter.
+
+    ``handle`` is typed loosely enough that importing this module (and running
+    the hermetic loader tests) never forces a ``temporalio`` import at
+    module-definition time. The submodules that build the actual handlers import
+    ``temporalio`` themselves when they need its exception types.
+
+    Attributes:
+        subject: NATS subject to subscribe to (e.g. ``events.knowledge.gap``).
+        durable: Durable consumer (consumer-group) name; a restarted pod resumes
+            from the durable's position rather than replaying the whole stream.
+        handle: ``async (envelope, temporal_client) -> None`` reacting to one
+            event. The run loop only calls it for events this dispatcher cares
+            about (see ``event_type``).
+        event_type: Optional ADR-017 ``event_type`` filter. When set, the run
+            loop dispatches only events whose ``event_type`` matches; when
+            ``None`` the handler sees every event on ``subject``.
+    """
+
+    subject: str
+    durable: str
+    handle: Handler
+    event_type: str | None = None
+
+    def matches(self, envelope: Any) -> bool:
+        """Whether ``envelope`` should be handed to :attr:`handle`.
+
+        Applies the optional ``event_type`` filter (ADR 017 §"Per-consumer
+        interpretation": consumers subscribe to a subject, then filter by
+        ``event_type``). With no filter, every event on the subject matches.
+        """
+        if self.event_type is None:
+            return True
+        return getattr(envelope, "event_type", None) == self.event_type
+
+
+def _iter_dispatcher_modules() -> list[ModuleType]:
+    """Import and return every dispatcher module in this package.
+
+    Skips private modules, test modules, and the ``run`` entrypoint — none of
+    those export ``DISPATCHERS``.
+    """
+    modules: list[ModuleType] = []
+    for info in pkgutil.iter_modules(__path__, prefix=__name__ + "."):
+        leaf = info.name.rsplit(".", 1)[-1]
+        if leaf.startswith("_") or leaf.endswith("_test") or leaf == "run":
+            continue
+        modules.append(importlib.import_module(info.name))
+    return modules
+
+
+def all_dispatchers() -> list[Dispatcher]:
+    """Aggregate the ``DISPATCHERS`` list exported by every dispatcher module."""
+    found: list[Dispatcher] = []
+    for module in _iter_dispatcher_modules():
+        found.extend(getattr(module, "DISPATCHERS", ()))
+    return found
+
+
+__all__ = [
+    "Dispatcher",
+    "Handler",
+    "all_dispatchers",
+]

--- a/projects/lakehouse/dispatchers/artifact_ready.py
+++ b/projects/lakehouse/dispatchers/artifact_ready.py
@@ -1,0 +1,86 @@
+"""Artifact-ready dispatcher: a secondary reaction hook on ``events.serving.artifact-ready``.
+
+ADR 016 §"Per-consumer interpretation": multiple consumers can subscribe to the
+same subject and interpret events differently. This dispatcher is the **optional,
+secondary** reaction to a new serving artifact.
+
+Why this is a stub (read before adding logic here)
+---------------------------------------------------
+The quack-server pod **already self-subscribes** to ``events.serving.artifact-ready``
+and performs its own ``ATTACH OR REPLACE`` hot-swap directly
+(``projects/lakehouse/quack-server/server.py`` :func:`run_swap_consumer`, durable
+``quack-serving-swap``). The primary artifact->serving swap is therefore owned by
+quack itself, by topology — it does **not** go through Temporal or this dispatcher.
+
+To avoid double-swapping we deliberately do **not** start a swap workflow here.
+This dispatcher exists as a clearly-documented seam for *other* reactions to a new
+artifact (metrics, notifications, an Iceberg snapshot hook, ...) that a later unit
+might want without touching the producer or quack. Today it is a minimal
+observability stub: it logs the artifact-ready event. Its own **distinct** durable
+(``artifact-ready-dispatcher``, not quack's ``quack-serving-swap``) means JetStream
+fans the event out to both consumers independently — the stub's ack never affects
+quack's swap.
+
+This dispatcher reacts to **all** ``event_type`` values on the subject (no
+filter) because "an artifact is ready" is itself the event; there is no
+``created`` vs ``updated`` distinction for the serving stub to care about yet.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from projects.lakehouse.dispatchers import Dispatcher
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    import temporalio.client
+
+    from projects.lakehouse.events.envelope import EventEnvelope
+
+logger = logging.getLogger(__name__)
+
+# Subject the builder workflow publishes a new serving artifact on. Kept as a
+# local constant (rather than imported from quack-server, which is a hyphenated
+# binary package with no importable module name) but deliberately identical to
+# quack-server's ARTIFACT_READY_SUBJECT.
+SUBJECT = "events.serving.artifact-ready"
+
+# DISTINCT durable from quack-server's ``quack-serving-swap`` — JetStream treats
+# each durable as an independent consumer group, so this hook and quack's swap
+# each receive the event and ack independently. Sharing the durable would steal
+# deliveries from quack and break the hot-swap.
+DURABLE = "artifact-ready-dispatcher"
+
+
+async def handle_artifact_ready(
+    envelope: EventEnvelope,
+    temporal_client: temporalio.client.Client,
+) -> None:
+    """Secondary reaction to an artifact-ready event (stub: log only).
+
+    Deliberately does **not** start a swap workflow: quack-server owns the
+    primary ATTACH-OR-REPLACE swap via its own self-subscription (see module
+    docstring). ``temporal_client`` is part of the handler contract (every
+    dispatcher gets one) and is intentionally unused here — a future reaction
+    (e.g. a metrics or snapshot workflow) would start it via this client.
+    """
+    payload = getattr(envelope, "payload", {}) or {}
+    artifact = payload.get("artifact_url") or payload.get("path")
+    logger.info(
+        "artifact-ready (secondary hook): entity_id=%s version=%s artifact=%s "
+        "(quack-server performs the authoritative hot-swap)",
+        getattr(envelope, "entity_id", None),
+        payload.get("version"),
+        artifact,
+    )
+
+
+DISPATCHERS = [
+    Dispatcher(
+        subject=SUBJECT,
+        durable=DURABLE,
+        handle=handle_artifact_ready,
+        event_type=None,  # react to every event on the subject
+    ),
+]

--- a/projects/lakehouse/dispatchers/dispatchers_test.py
+++ b/projects/lakehouse/dispatchers/dispatchers_test.py
@@ -1,0 +1,352 @@
+"""Hermetic tests for the NATS -> Temporal dispatchers (ADR agents/016).
+
+No NATS server, no Temporal server, no network: the NATS client, its pull
+subscriptions, the Temporal client, and individual NATS messages are all fakes.
+Coroutines are driven with ``asyncio.run``. The only real Temporal symbol used is
+``WorkflowAlreadyStartedError`` (an exception type, cheap to construct).
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from temporalio.exceptions import WorkflowAlreadyStartedError
+
+from projects.lakehouse.dispatchers import Dispatcher, all_dispatchers
+from projects.lakehouse.dispatchers import artifact_ready, gap_ready, run
+from projects.lakehouse.events.envelope import EventEnvelope, build_envelope
+
+
+# --- fakes ----------------------------------------------------------------
+
+
+class FakeTemporalClient:
+    """Records ``start_workflow`` calls; can be told to raise AlreadyStarted."""
+
+    def __init__(self, *, raise_already_started: bool = False) -> None:
+        self.calls: list[dict] = []
+        self._raise_already_started = raise_already_started
+
+    async def start_workflow(self, workflow, *args, **kwargs):
+        self.calls.append({"workflow": workflow, "args": args, "kwargs": kwargs})
+        if self._raise_already_started:
+            raise WorkflowAlreadyStartedError(kwargs.get("id", "?"), str(workflow))
+        return object()  # a fake WorkflowHandle
+
+
+class FakeMsg:
+    """A NATS message that records its ack/term disposition."""
+
+    def __init__(self, data: bytes) -> None:
+        self.data = data
+        self.acked = False
+        self.termed = False
+
+    async def ack(self) -> None:
+        self.acked = True
+
+    async def term(self) -> None:
+        self.termed = True
+
+
+class FakeSubscription:
+    """Yields one canned batch of messages, then only times out.
+
+    Mirrors a durable pull subscription's ``fetch``: the first call returns the
+    batch; subsequent calls raise ``TimeoutError`` (idle stream) so the run loop
+    re-polls until ``stop`` is set.
+    """
+
+    def __init__(self, batches: list[list[FakeMsg]]) -> None:
+        self._batches = list(batches)
+
+    async def fetch(self, batch=None, *, timeout=None):
+        if self._batches:
+            return self._batches.pop(0)
+        raise TimeoutError
+
+
+class FakeNatsClient:
+    """Hands out pre-seeded subscriptions keyed by ``(subject, durable)``."""
+
+    def __init__(self, subs: dict[tuple[str, str], FakeSubscription]) -> None:
+        self._subs = subs
+        self.subscribed: list[tuple[str, str]] = []
+        self.connected = False
+        self.closed = False
+
+    async def connect(self) -> None:
+        self.connected = True
+
+    async def pull_subscribe(self, subject, durable, *, batch=10):
+        self.subscribed.append((subject, durable))
+        return self._subs[(subject, durable)]
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+# --- helpers --------------------------------------------------------------
+
+
+def _gap_envelope(entity_id: str = "42", event_type: str = "created") -> EventEnvelope:
+    return build_envelope(
+        entity_type="gap",
+        entity_id=entity_id,
+        event_type=event_type,
+        event_version=1,
+        producer="monolith.gardener",
+        payload={"term": "wong-zakai", "context": "ctx"},
+    )
+
+
+def _raw(envelope: EventEnvelope) -> bytes:
+    return envelope.model_dump_json().encode("utf-8")
+
+
+# --- discovery (all_dispatchers) ------------------------------------------
+
+
+def test_all_dispatchers_discovers_both():
+    found = all_dispatchers()
+    subjects = {d.subject for d in found}
+    assert "events.knowledge.gap" in subjects
+    assert "events.serving.artifact-ready" in subjects
+    # Exactly the two dispatcher modules' single entries each.
+    assert len(found) == 2
+    assert all(isinstance(d, Dispatcher) for d in found)
+
+
+def test_discovered_dispatchers_have_distinct_durables():
+    durables = [d.durable for d in all_dispatchers()]
+    assert len(durables) == len(set(durables)), "durables must be unique"
+    # artifact-ready must NOT collide with quack-server's swap durable.
+    assert "quack-serving-swap" not in durables
+
+
+# --- gap_ready dispatcher --------------------------------------------------
+
+
+def test_gap_ready_dispatcher_shape():
+    (d,) = gap_ready.DISPATCHERS
+    assert d.subject == "events.knowledge.gap"
+    assert d.durable == "gap-drain-dispatcher"
+    assert d.event_type == "created"
+
+
+def test_gap_ready_starts_workflow_with_deterministic_id():
+    client = FakeTemporalClient()
+    envelope = _gap_envelope("42")
+    asyncio.run(gap_ready.handle_gap_created(envelope, client))
+
+    assert len(client.calls) == 1
+    call = client.calls[0]
+    # Workflow referenced by type-name STRING (not the class).
+    assert call["workflow"] == "GapDrainWorkflow"
+    assert call["kwargs"]["id"] == "gap-drain-42"
+    assert call["kwargs"]["task_queue"] == "gap-drain"
+    # Event payload forwarded as the workflow arg.
+    assert call["args"][0] == envelope.payload
+
+
+def test_gap_ready_swallows_already_started():
+    client = FakeTemporalClient(raise_already_started=True)
+    # Must not raise — WorkflowAlreadyStartedError is an idempotent no-op.
+    asyncio.run(gap_ready.handle_gap_created(_gap_envelope("7"), client))
+    assert client.calls[0]["kwargs"]["id"] == "gap-drain-7"
+
+
+def test_workflow_id_for_is_deterministic():
+    assert gap_ready.workflow_id_for("42") == "gap-drain-42"
+    assert gap_ready.workflow_id_for("42") == gap_ready.workflow_id_for("42")
+
+
+# --- artifact_ready dispatcher (stub) -------------------------------------
+
+
+def test_artifact_ready_dispatcher_shape():
+    (d,) = artifact_ready.DISPATCHERS
+    assert d.subject == "events.serving.artifact-ready"
+    assert d.durable == "artifact-ready-dispatcher"
+    # No event_type filter — reacts to every event on the subject.
+    assert d.event_type is None
+
+
+def test_artifact_ready_stub_does_not_touch_temporal():
+    client = FakeTemporalClient()
+    envelope = build_envelope(
+        entity_type="serving-artifact",
+        entity_id="artifact-2026-05-30",
+        event_type="created",
+        event_version=1,
+        producer="lakehouse.build_serving",
+        payload={"artifact_url": "s3://warehouse/serving/v5.duckdb", "version": "v5"},
+    )
+    asyncio.run(artifact_ready.handle_artifact_ready(envelope, client))
+    # Stub must NOT start a workflow — quack-server owns the authoritative swap.
+    assert client.calls == []
+
+
+# --- Dispatcher.matches (event_type filter) -------------------------------
+
+
+def test_matches_filters_by_event_type():
+    (d,) = gap_ready.DISPATCHERS
+    assert d.matches(_gap_envelope("1", "created")) is True
+    assert d.matches(_gap_envelope("1", "updated")) is False
+    assert d.matches(_gap_envelope("1", "tombstoned")) is False
+
+
+def test_matches_no_filter_accepts_everything():
+    (d,) = artifact_ready.DISPATCHERS
+    assert d.matches(_gap_envelope("1", "created")) is True
+    assert d.matches(_gap_envelope("1", "anything")) is True
+
+
+# --- run.decode_envelope --------------------------------------------------
+
+
+def test_decode_envelope_roundtrips():
+    envelope = _gap_envelope("99")
+    decoded = run.decode_envelope(_raw(envelope))
+    assert decoded.entity_id == "99"
+    assert decoded.event_type == "created"
+    assert decoded.payload == envelope.payload
+
+
+def test_decode_envelope_rejects_malformed():
+    with pytest.raises(Exception):
+        run.decode_envelope(b"not json at all")
+
+
+# --- run.dispatch_message disposition -------------------------------------
+
+
+def test_dispatch_message_created_event_starts_and_acks():
+    (d,) = gap_ready.DISPATCHERS
+    client = FakeTemporalClient()
+    msg = FakeMsg(_raw(_gap_envelope("42", "created")))
+    asyncio.run(run.dispatch_message(d, msg, client))
+
+    assert msg.acked is True
+    assert msg.termed is False
+    assert client.calls[0]["kwargs"]["id"] == "gap-drain-42"
+
+
+def test_dispatch_message_filtered_event_acks_without_dispatch():
+    (d,) = gap_ready.DISPATCHERS
+    client = FakeTemporalClient()
+    msg = FakeMsg(_raw(_gap_envelope("42", "updated")))  # not "created"
+    asyncio.run(run.dispatch_message(d, msg, client))
+
+    assert msg.acked is True  # filtered-out events are acked, not redelivered
+    assert client.calls == []  # handler never invoked
+
+
+def test_dispatch_message_malformed_is_termed():
+    (d,) = gap_ready.DISPATCHERS
+    client = FakeTemporalClient()
+    msg = FakeMsg(b"{not valid json")
+    asyncio.run(run.dispatch_message(d, msg, client))
+
+    assert msg.termed is True
+    assert msg.acked is False
+    assert client.calls == []
+
+
+def test_dispatch_message_handler_error_leaves_for_redelivery():
+    async def boom(envelope, temporal_client):
+        raise RuntimeError("handler blew up")
+
+    d = Dispatcher(
+        subject="events.knowledge.gap",
+        durable="x",
+        handle=boom,
+        event_type="created",
+    )
+    client = FakeTemporalClient()
+    msg = FakeMsg(_raw(_gap_envelope("42", "created")))
+    # dispatch_message re-raises; the loop is what swallows + logs.
+    with pytest.raises(RuntimeError, match="handler blew up"):
+        asyncio.run(run.dispatch_message(d, msg, client))
+    assert msg.acked is False  # un-acked -> JetStream redelivers
+    assert msg.termed is False
+
+
+# --- run.run wiring (end-to-end, fakes) -----------------------------------
+
+
+def test_run_wires_subscriptions_and_dispatches():
+    gap_d = gap_ready.DISPATCHERS[0]
+    created = FakeMsg(_raw(_gap_envelope("42", "created")))
+    sub = FakeSubscription([[created]])
+    nats = FakeNatsClient({(gap_d.subject, gap_d.durable): sub})
+    client = FakeTemporalClient()
+
+    async def drive():
+        stop = asyncio.Event()
+        task = asyncio.create_task(
+            run.run(
+                dispatchers=[gap_d],
+                nats_client=nats,
+                temporal_client=client,
+                stop=stop,
+                # tiny poll timeout via the loop default is fine; FakeSubscription
+                # raises TimeoutError after the first batch.
+            )
+        )
+        # Let the loop fetch the batch + dispatch, then re-poll (idle) at least
+        # once before stopping.
+        for _ in range(5):
+            await asyncio.sleep(0)
+        stop.set()
+        await asyncio.wait_for(task, timeout=2.0)
+
+    asyncio.run(drive())
+
+    assert (gap_d.subject, gap_d.durable) in nats.subscribed
+    assert created.acked is True
+    assert client.calls[0]["kwargs"]["id"] == "gap-drain-42"
+    # Injected NATS client is NOT closed by run() (caller owns its lifecycle).
+    assert nats.closed is False
+
+
+def test_run_handler_error_does_not_kill_loop():
+    gap_d = gap_ready.DISPATCHERS[0]
+    # First message is malformed (termed), second is a valid created event that
+    # must still be dispatched — proving one bad message doesn't kill the loop.
+    bad = FakeMsg(b"garbage")
+    good = FakeMsg(_raw(_gap_envelope("7", "created")))
+    sub = FakeSubscription([[bad, good]])
+    nats = FakeNatsClient({(gap_d.subject, gap_d.durable): sub})
+    client = FakeTemporalClient()
+
+    async def drive():
+        stop = asyncio.Event()
+        task = asyncio.create_task(
+            run.run(
+                dispatchers=[gap_d],
+                nats_client=nats,
+                temporal_client=client,
+                stop=stop,
+            )
+        )
+        for _ in range(5):
+            await asyncio.sleep(0)
+        stop.set()
+        await asyncio.wait_for(task, timeout=2.0)
+
+    asyncio.run(drive())
+
+    assert bad.termed is True
+    assert good.acked is True
+    assert client.calls[0]["kwargs"]["id"] == "gap-drain-7"
+
+
+def test_run_no_dispatchers_is_a_noop():
+    nats = FakeNatsClient({})
+    client = FakeTemporalClient()
+    # No dispatchers -> no subscriptions, returns immediately.
+    asyncio.run(run.run(dispatchers=[], nats_client=nats, temporal_client=client))
+    assert nats.subscribed == []

--- a/projects/lakehouse/dispatchers/gap_ready.py
+++ b/projects/lakehouse/dispatchers/gap_ready.py
@@ -1,0 +1,129 @@
+"""Gap-ready dispatcher: ``events.knowledge.gap`` ``created`` -> ``GapDrainWorkflow``.
+
+ADR 016 §Architecture / ADR 017 §"Per-consumer interpretation": the gap-drain
+dispatcher subscribes to ``events.knowledge.gap`` and filters ``event_type ==
+"created"``. On a gap-created event it starts the per-gap drain workflow with the
+deterministic ID ``gap-drain-{entity_id}`` on the ``gap-drain`` task queue,
+swallowing :class:`temporalio.exceptions.WorkflowAlreadyStartedError` as an
+idempotent no-op (ADR 015 §"Workflow identity = work identity": event / cron
+sweep / manual triggers all converge on one execution; whichever fires first
+wins, the rest are silent no-ops).
+
+The workflow is referenced by **type-name string** (``"GapDrainWorkflow"``), never
+imported — exactly as ADR 016 prescribes for dispatchers and mirroring the
+``orchestrator.schedules.gap_drain_sweep`` schedule. This keeps the dispatcher a
+~30-line adapter with no workflow/activity dependency edge.
+
+SCOPE GUARD — shadow / parallel definition
+-------------------------------------------
+Like the W3 ``orchestrator.workflows.gap_drain`` shadow workflow this dispatcher
+reacts to, this is a **parallel definition only**. Production gap dispatch still
+flows through the existing live orchestrator
+(``projects/agent_platform/orchestrator`` / ``knowledge/research_handler``).
+Cutting the production gap pipeline over to this NATS->Temporal path is a
+deliberate follow-up unit, **out of scope for this run** — nothing here is wired
+to a Deployment by this unit (the dispatcher Deployment lives in the sibling
+W4-CHART unit and the cutover is later still).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from projects.lakehouse.dispatchers import Dispatcher
+from projects.lakehouse.events.publish import SUBJECT_BY_ENTITY
+from projects.lakehouse.orchestrator import TaskQueue
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    import temporalio.client
+
+    from projects.lakehouse.events.envelope import EventEnvelope
+
+logger = logging.getLogger(__name__)
+
+# Subject + durable consumer for the gap stream. Subject comes from the events
+# package's canonical entity->subject map (single source of truth, ADR 016
+# §"Per-subject topology") so the dispatcher and producers can never drift.
+SUBJECT = SUBJECT_BY_ENTITY["gap"]  # "events.knowledge.gap"
+DURABLE = "gap-drain-dispatcher"
+
+# Only react to gap *creation* (ADR 017 §"Per-consumer interpretation": the
+# gap-drain dispatcher filters event_type == "created"). updated/processed/
+# tombstoned events on the same subject are ignored by this consumer.
+TRIGGER_EVENT_TYPE = "created"
+
+# Referenced by type-name string, never imported (ADR 016). Matches the W3
+# `@workflow.defn class GapDrainWorkflow` registered in
+# projects.lakehouse.orchestrator.workflows.gap_drain.
+WORKFLOW_TYPE = "GapDrainWorkflow"
+
+# Task queue the per-gap drain workflow runs on (ADR 015 worker pools).
+TASK_QUEUE = TaskQueue.GAP_DRAIN.value  # "gap-drain"
+
+# Deterministic per-gap workflow ID prefix (ADR 015 §"Workflow identity = work
+# identity"). Mirrors orchestrator.workflows.gap_drain.WORKFLOW_ID_PREFIX, kept
+# local so the dispatcher needs no import edge to the workflow module.
+WORKFLOW_ID_PREFIX = "gap-drain-"
+
+
+def workflow_id_for(entity_id: str) -> str:
+    """Deterministic workflow ID for a gap's drain workflow: ``gap-drain-{id}``."""
+    return f"{WORKFLOW_ID_PREFIX}{entity_id}"
+
+
+async def handle_gap_created(
+    envelope: EventEnvelope,
+    temporal_client: temporalio.client.Client,
+) -> None:
+    """Start ``GapDrainWorkflow`` for a gap-created event (idempotent).
+
+    The run loop has already applied the ``event_type == "created"`` filter, so
+    every call here is a genuine gap-creation. Starts the workflow by type-name
+    string with the deterministic ID ``gap-drain-{entity_id}`` on the
+    ``gap-drain`` task queue. A re-delivered or duplicate event collapses onto
+    the existing execution via :class:`WorkflowAlreadyStartedError`, which is
+    swallowed (ADR 015 idempotent dispatch).
+
+    The gap context (term/class/etc.) is **not** reconstructed here: the
+    dispatcher's job per ADR 016 is the translation hop, not gap business logic.
+    The shadow ``GapDrainWorkflow`` reads the gap row itself; the workflow input
+    is the gap id wrapped in the workflow's expected payload shape, kept minimal
+    and forwarded from the event payload when present.
+    """
+    # Imported lazily so importing this dispatcher module (and the hermetic
+    # loader tests) never requires temporalio to be importable at definition
+    # time — only invoking the handler does. The exception lives in
+    # temporalio.exceptions (temporalio.client does NOT re-export it in 1.27.x);
+    # this is the same symbol the W3 gap_drain workflow imports.
+    from temporalio.exceptions import WorkflowAlreadyStartedError
+
+    entity_id = envelope.entity_id
+    wf_id = workflow_id_for(entity_id)
+    try:
+        await temporal_client.start_workflow(
+            WORKFLOW_TYPE,
+            envelope.payload,
+            id=wf_id,
+            task_queue=TASK_QUEUE,
+        )
+        logger.info(
+            "dispatched %s id=%s task_queue=%s (gap-created event_id=%s)",
+            WORKFLOW_TYPE,
+            wf_id,
+            TASK_QUEUE,
+            getattr(envelope, "event_id", None),
+        )
+    except WorkflowAlreadyStartedError:
+        # A drain for this gap is already running — idempotent no-op (ADR 015).
+        logger.debug("%s id=%s already started; idempotent no-op", WORKFLOW_TYPE, wf_id)
+
+
+DISPATCHERS = [
+    Dispatcher(
+        subject=SUBJECT,
+        durable=DURABLE,
+        handle=handle_gap_created,
+        event_type=TRIGGER_EVENT_TYPE,
+    ),
+]

--- a/projects/lakehouse/dispatchers/run.py
+++ b/projects/lakehouse/dispatchers/run.py
@@ -1,0 +1,183 @@
+"""Dispatcher process entrypoint (ADR agents/016 §"Workflow dispatchers").
+
+    python -m projects.lakehouse.dispatchers.run
+
+One ``monolith-dispatchers``-style process that subscribes to every discovered
+dispatcher's NATS subject and translates events into Temporal ``start_workflow``
+calls. Per ADR 016, dispatchers are small adapters; this module is the shared
+plumbing they run inside:
+
+* connect a :class:`~projects.lakehouse.nats_client.NatsClient` and a Temporal
+  ``temporalio.client.Client`` (``orchestrator.client.get_client``);
+* for each :class:`~projects.lakehouse.dispatchers.Dispatcher`, open a durable
+  (consumer-group) pull subscription on its subject;
+* poll all subscriptions in a graceful loop, decode each message into an
+  ADR-017 :class:`EventEnvelope`, apply the dispatcher's ``event_type`` filter,
+  and invoke its ``handle(envelope, temporal_client)``.
+
+Message disposition mirrors quack-server's swap consumer:
+  * malformed payload (un-decodable envelope) -> ``term`` (redelivery never helps);
+  * handler raises -> neither ack nor term, so JetStream redelivers later;
+  * handled (or filtered out) -> ``ack``.
+
+This is AUTHOR-ONLY scaffolding for this unit: the per-dispatcher Deployment that
+runs this entrypoint lives in the sibling W4-CHART unit; nothing here is wired to
+production by this run.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from typing import TYPE_CHECKING, Any
+
+from projects.lakehouse.dispatchers import Dispatcher, all_dispatchers
+from projects.lakehouse.events.envelope import EventEnvelope
+from projects.lakehouse.nats_client import NatsClient
+from projects.lakehouse.orchestrator.client import get_client
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    import temporalio.client
+
+logger = logging.getLogger(__name__)
+
+# How long a single pull fetch blocks before returning empty (idle stream). A
+# timeout is normal and simply re-polls; kept short so a stop signal is observed
+# promptly across all subscriptions.
+POLL_TIMEOUT = 5.0
+
+
+def decode_envelope(raw: bytes) -> EventEnvelope:
+    """Decode a raw NATS message body into an ADR-017 :class:`EventEnvelope`.
+
+    Pure (no I/O) so the dispatch logic is unit-testable without NATS. Raises
+    (``pydantic.ValidationError`` / ``ValueError`` from bad JSON) on a malformed
+    body so the caller can ``term`` the message.
+    """
+    return EventEnvelope.model_validate_json(raw)
+
+
+async def dispatch_message(
+    dispatcher: Dispatcher,
+    msg: Any,
+    temporal_client: temporalio.client.Client,
+) -> None:
+    """Decode, filter, and handle one message for ``dispatcher``; then dispose.
+
+    Disposition:
+      * malformed envelope -> ``term`` (won't redeliver);
+      * event filtered out by the dispatcher's ``event_type`` -> ``ack`` (it is
+        correctly handled by being ignored — redelivery would never help);
+      * handler success -> ``ack``;
+      * handler raises -> neither ack nor term, leaving JetStream to redeliver.
+    """
+    try:
+        envelope = decode_envelope(msg.data)
+    except Exception:  # noqa: BLE001 — any decode failure is terminal for this msg
+        logger.exception(
+            "malformed event on %s; terminating message", dispatcher.subject
+        )
+        await msg.term()
+        return
+
+    if not dispatcher.matches(envelope):
+        # Not this dispatcher's event_type — ack so it isn't redelivered.
+        await msg.ack()
+        return
+
+    # Handler success -> ack. A raised handler is intentionally NOT caught here
+    # so the message is left un-acked for JetStream redelivery (at-least-once);
+    # the per-subscription loop guards against one bad message killing the loop.
+    await dispatcher.handle(envelope, temporal_client)
+    await msg.ack()
+
+
+async def run_dispatcher_loop(
+    dispatcher: Dispatcher,
+    subscription: Any,
+    temporal_client: temporalio.client.Client,
+    *,
+    stop: asyncio.Event | None = None,
+    poll_timeout: float = POLL_TIMEOUT,
+) -> None:
+    """Poll one dispatcher's durable subscription until ``stop`` is set.
+
+    Fetch timeouts (idle stream) are normal and re-poll. A handler that raises is
+    logged and the next poll continues — one bad event must not kill the loop
+    (the un-acked message is redelivered by JetStream).
+    """
+    while stop is None or not stop.is_set():
+        try:
+            msgs = await subscription.fetch(timeout=poll_timeout)
+        except (asyncio.TimeoutError, TimeoutError):
+            # Idle stream. Yield to the loop first so a synchronously-raising
+            # fake fetch (tests / fast-failing server) can't busy-spin and
+            # starve the shutdown task — same guard as quack-server's consumer.
+            await asyncio.sleep(0)
+            continue
+        for msg in msgs:
+            try:
+                await dispatch_message(dispatcher, msg, temporal_client)
+            except Exception:  # noqa: BLE001 — keep the loop alive on handler error
+                logger.exception(
+                    "dispatch failed on %s; leaving message for redelivery",
+                    dispatcher.subject,
+                )
+
+
+async def run(
+    *,
+    dispatchers: list[Dispatcher] | None = None,
+    nats_client: NatsClient | None = None,
+    temporal_client: temporalio.client.Client | None = None,
+    stop: asyncio.Event | None = None,
+) -> None:
+    """Wire up every dispatcher and run their poll loops concurrently.
+
+    Connects NATS + Temporal when clients aren't injected (tests inject fakes),
+    opens a durable pull subscription per dispatcher, and runs each loop as a
+    task until ``stop`` is set (or forever). Cleans up the NATS connection on
+    exit. ``dispatchers`` defaults to :func:`all_dispatchers`.
+    """
+    discovered = all_dispatchers() if dispatchers is None else dispatchers
+
+    nc = NatsClient() if nats_client is None else nats_client
+    own_nats = nats_client is None
+    if own_nats:
+        await nc.connect()
+
+    client = await get_client() if temporal_client is None else temporal_client
+
+    try:
+        tasks: list[asyncio.Task] = []
+        for dispatcher in discovered:
+            subscription = await nc.pull_subscribe(
+                dispatcher.subject, dispatcher.durable
+            )
+            logger.info(
+                "subscribed dispatcher subject=%s durable=%s event_type=%s",
+                dispatcher.subject,
+                dispatcher.durable,
+                dispatcher.event_type,
+            )
+            tasks.append(
+                asyncio.create_task(
+                    run_dispatcher_loop(dispatcher, subscription, client, stop=stop)
+                )
+            )
+        if tasks:
+            await asyncio.gather(*tasks)
+    finally:
+        if own_nats:
+            await nc.close()
+
+
+def _main() -> None:  # pragma: no cover — process entrypoint (network)
+    """Console entrypoint: discover dispatchers and run their loops forever."""
+    logging.basicConfig(level=os.environ.get("LOG_LEVEL", "INFO"))
+    asyncio.run(run())
+
+
+if __name__ == "__main__":  # pragma: no cover
+    _main()


### PR DESCRIPTION
## SVC-DISPATCHERS (Wavefront 4) — NATS -> Temporal workflow dispatchers + image

Implements ADR [agents/016](docs/decisions/agents/016-nats-canonical-event-stream.md) §"Workflow dispatchers": small adapters that subscribe to NATS subjects and translate domain events (ADR [017](docs/decisions/agents/017-domain-event-schema.md) envelope) into Temporal `start_workflow` calls (ADR [015](docs/decisions/agents/015-temporal-orchestration-substrate.md) deterministic IDs).

### What shipped — new dir `projects/lakehouse/dispatchers/`
- **`__init__.py`** — `Dispatcher` dataclass (`subject`, `durable`, async `handle(envelope, temporal_client)`, optional `event_type` filter) + `pkgutil.iter_modules` loader `all_dispatchers()`. New dispatcher = a new file, **no shared list**.
- **`gap_ready.py`** — subject `events.knowledge.gap`, filter `event_type == "created"`; starts `GapDrainWorkflow` (referenced by **type-name string**, never imported) with deterministic id `gap-drain-{entity_id}` on task queue `gap-drain`, swallowing `WorkflowAlreadyStartedError` (idempotent no-op).
- **`artifact_ready.py`** — subject `events.serving.artifact-ready`, **minimal stub** (logs only) with a **distinct durable** (`artifact-ready-dispatcher`). quack-server already self-subscribes and performs the authoritative `ATTACH OR REPLACE` swap, so this is a secondary reaction hook — no double-swap.
- **`run.py`** — entrypoint (`python -m projects.lakehouse.dispatchers.run`): connects `NatsClient` + Temporal `get_client`, durable pull consumer per dispatcher, graceful loop (malformed -> term, filtered-out -> ack, success -> ack, handler error -> redelivery).
- **`BUILD`** — `py_library` + `py_venv_binary` (`main = run.py`) + multiarch non-root (65532) `py3_image` (`ghcr.io/jomcgi/homelab/projects/lakehouse/dispatchers`) + `py_test` + semgrep.
- **`bazel/images/BUILD`** — one-line push-list insert (auto-generated; pre-applied so the first CI run pushes the image, format sees no diff).

### Scope
**AUTHOR-ONLY: nothing deploys this run.** Nothing is wired to a Deployment here — the dispatcher Deployment lives in the sibling **W4-CHART** unit (references this image by repo string). The gap dispatcher is a **shadow / parallel** definition reacting to the W3 shadow `GapDrainWorkflow`; **production cutover from the live orchestrator is out of scope** (deliberate follow-up).

### Tests
Hermetic (fakes for NATS client/subscription/message + Temporal client). Validated locally in a throwaway venv with the pinned `temporalio==1.27.2`: **19/19 passed**. `ruff` clean. CI `bazel test //...` + image push are the real validation.

Note: the pinned `temporalio==1.27.2` exposes `WorkflowAlreadyStartedError` from `temporalio.exceptions` (not re-exported by `temporalio.client`); the handler imports it from there, matching the W3 `gap_drain` workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)