### PR TITLE
fix(lakehouse): clone monolith-pg credential via Kyverno (drop 1Password round-trip)

### DIFF
--- a/projects/lakehouse/chart/templates/workers/housekeeping-worker-deployment.yaml
+++ b/projects/lakehouse/chart/templates/workers/housekeeping-worker-deployment.yaml
@@ -3,8 +3,9 @@
 # workflow. min=1 max=2 (ScaledObject owns replicas, so it is not set here).
 #
 # Backfill reads monolith-pg READ-ONLY via DATABASE_URL, injected from the
-# 1Password-synced `-pg` Secret (key `uri`). Only this pool gets DATABASE_URL,
-# and only when the PG 1Password item is configured.
+# `<fullname>-pg` Secret (key `uri`) that Kyverno clones from
+# monolith/monolith-pg-app into this namespace (clone-monolith-pg-app policy).
+# Only this pool gets DATABASE_URL, and only when .Values.pg.enabled is true.
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -42,7 +43,11 @@ spec:
             {{- if .Values.onepassword.s3.itemPath }}
             {{- include "lakehouse.s3Env" . | nindent 12 }}
             {{- end }}
-            {{- if .Values.onepassword.pg.itemPath }}
+            {{- if .Values.pg.enabled }}
+            # READ-ONLY monolith-pg URI for the backfill. The `<fullname>-pg`
+            # Secret is cloned from monolith/monolith-pg-app into this namespace
+            # by the Kyverno ClusterPolicy `clone-monolith-pg-app` (key `uri`) --
+            # no 1Password round-trip for the cluster-generated credential.
             - name: DATABASE_URL
               valueFrom:
                 secretKeyRef:

--- a/projects/lakehouse/chart/values.yaml
+++ b/projects/lakehouse/chart/values.yaml
@@ -159,10 +159,19 @@ dispatchers:
 # dummy (duckdb/duckdb); wired through 1Password so enabling auth later is a
 # values change, not a template change.
 # ---------------------------------------------------------------------------
+
+# Postgres backfill credential. When enabled, the housekeeping worker gets
+# DATABASE_URL (READ-ONLY) from the `<fullname>-pg` Secret that the Kyverno
+# ClusterPolicy `clone-monolith-pg-app` clones from monolith/monolith-pg-app
+# (key `uri`) into this namespace — no 1Password item, no manual step. Enable
+# in deploy/ once the lakehouse namespace exists (Kyverno backfills it).
+pg:
+  enabled: false
+
 onepassword:
   pg:
-    # Empty => no OnePasswordItem rendered and the housekeeping worker omits
-    # DATABASE_URL (backfill disabled). Set in deploy/ to enable PG backfill.
+    # DEPRECATED for PG: superseded by the Kyverno clone above. Leave empty.
+    # (Kept so the legacy OnePasswordItem template stays inert, not removed.)
     itemPath: ""
   s3:
     # Empty => no OnePasswordItem rendered; pods fall back to DuckDB's dummy

--- a/projects/lakehouse/deploy/values.yaml
+++ b/projects/lakehouse/deploy/values.yaml
@@ -24,15 +24,15 @@ dispatchers:
   image:
     tag: main
 
-onepassword:
-  pg:
-    # MANUAL PREREQUISITE: 1Password item with a `uri` field = a libpq postgres
-    # URL built from user `app`, the CNPG-generated monolith-pg `app` password,
-    # host monolith-pg-rw.monolith.svc.cluster.local, port 5432, db monolith.
-    # Used read-only by the backfill.
-    itemPath: vaults/k8s-homelab/items/lakehouse-pg
-  s3:
-    # MANUAL PREREQUISITE: 1Password item with S3_ACCESS_KEY_ID /
-    # S3_SECRET_ACCESS_KEY fields (dummy duckdb/duckdb fine while SeaweedFS S3
-    # auth is disabled).
-    itemPath: vaults/k8s-homelab/items/lakehouse-s3
+# PG backfill credential is cloned by Kyverno (clone-monolith-pg-app) from
+# monolith/monolith-pg-app into the lakehouse ns as `<fullname>-pg` (key `uri`)
+# — no 1Password round-trip for the cluster-generated credential. Just enable
+# the housekeeping worker's DATABASE_URL wiring.
+pg:
+  enabled: true
+
+# No `onepassword:` overrides here: the PG credential is Kyverno-cloned (not a
+# 1Password item) and S3 falls back to DuckDB dummies (SeaweedFS auth off). The
+# chart defaults leave both itemPaths unset so their OnePasswordItems don't
+# render. (Omitted rather than set to "" — empty deploy itemPaths are a flagged
+# correctness smell, no-empty-1password-itempath.)

--- a/projects/platform/kyverno/templates/clone-monolith-pg-secret-policy.yaml
+++ b/projects/platform/kyverno/templates/clone-monolith-pg-secret-policy.yaml
@@ -1,0 +1,83 @@
+# Cross-namespace replication of the CNPG-generated Postgres `app` credential.
+#
+# CNPG writes the `app` password into Secret `monolith-pg-app` in the `monolith`
+# namespace. The Temporal cluster (ns `temporal`) and the lakehouse backfill
+# worker (ns `lakehouse`) need it, but K8s Secrets are namespace-scoped. Rather
+# than launder a cluster-generated secret through 1Password by hand, Kyverno
+# clones it into the target namespaces and keeps it in sync (synchronize: true)
+# if CNPG ever rotates it. Triggered on namespace creation; generateExisting
+# also backfills the namespace if it already exists.
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: clone-monolith-pg-app
+  annotations:
+    policies.kyverno.io/title: Clone monolith-pg-app into temporal + lakehouse
+    policies.kyverno.io/category: Secret Management
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/description: |
+      Replicates the CNPG-generated monolith-pg `app` credential Secret into the
+      temporal and lakehouse namespaces (synchronized), so no manual 1Password
+      round-trip is needed for cluster-generated Postgres credentials.
+spec:
+  background: true
+  rules:
+    - name: clone-to-temporal
+      match:
+        any:
+          - resources:
+              kinds:
+                - Namespace
+              names:
+                - temporal
+      generate:
+        apiVersion: v1
+        kind: Secret
+        name: temporal-pg
+        namespace: temporal
+        synchronize: true
+        generateExisting: true
+        clone:
+          namespace: monolith
+          name: monolith-pg-app
+    - name: clone-to-lakehouse
+      match:
+        any:
+          - resources:
+              kinds:
+                - Namespace
+              names:
+                - lakehouse
+      generate:
+        apiVersion: v1
+        kind: Secret
+        name: lakehouse-pg
+        namespace: lakehouse
+        synchronize: true
+        generateExisting: true
+        clone:
+          namespace: monolith
+          name: monolith-pg-app
+---
+# Kyverno 3.x restricts the background controller's Secret access by default.
+# Grant get/list/watch on the source + create/update/delete on the clones via an
+# aggregated ClusterRole (the documented mechanism for clone-generate of Secrets).
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kyverno:clone-monolith-pg-secret
+  labels:
+    app.kubernetes.io/part-of: kyverno
+    rbac.kyverno.io/aggregate-to-background-controller: "true"
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - delete

--- a/projects/platform/temporal/values.yaml
+++ b/projects/platform/temporal/values.yaml
@@ -260,21 +260,11 @@ temporal:
   # (`helm test`-only; not needed for GitOps.)
 
   # ---------------------------------------------------------------------------
-  # Cross-namespace Postgres credential: the CNPG `app` password lives in secret
-  # `monolith-pg-app` in the `monolith` ns. We materialise it into a `temporal-pg`
-  # Secret in THIS namespace via the 1Password Operator. The `temporal-pg`
-  # 1Password item is a MANUAL PREREQUISITE (see status note) -- populate it with
-  # the current monolith-pg `app` password under a `password` field.
+  # Cross-namespace Postgres credential: the CNPG `app` password lives in Secret
+  # `monolith-pg-app` (ns `monolith`). It is cloned into THIS namespace as the
+  # `temporal-pg` Secret by the Kyverno ClusterPolicy `clone-monolith-pg-app`
+  # (projects/platform/kyverno/templates/clone-monolith-pg-secret-policy.yaml)
+  # with synchronize:true -- no manual 1Password step, auto-resyncs on rotation.
+  # `existingSecret: temporal-pg` above consumes it (key `password`).
   # ---------------------------------------------------------------------------
-  extraObjects:
-    - |
-      apiVersion: onepassword.com/v1
-      kind: OnePasswordItem
-      metadata:
-        name: temporal-pg
-        namespace: {{ .Release.Namespace }}
-        labels:
-          app.kubernetes.io/part-of: shared-infrastructure
-          app.kubernetes.io/managed-by: temporal
-      spec:
-        itemPath: vaults/k8s-homelab/items/temporal-pg
+  extraObjects: []


### PR DESCRIPTION
Per review: copying the CNPG-generated `app` password into 1Password just to sync it back into another namespace is a pointless round-trip. Replace with a Kyverno `generate`+`clone`+`synchronize` ClusterPolicy that replicates `monolith/monolith-pg-app` into the `temporal` and `lakehouse` namespaces automatically — no manual step, auto-resyncs on rotation — plus the aggregated RBAC Kyverno 3.x requires to clone Secrets.

- **temporal**: drops the `temporal-pg` OnePasswordItem; `existingSecret: temporal-pg` consumes the cloned Secret.
- **lakehouse**: `DATABASE_URL` gated on `.Values.pg.enabled` from the cloned `lakehouse-pg` Secret (key `uri`); S3 falls back to DuckDB dummies (SeaweedFS auth off). Only the quack query token stays a OnePasswordItem (minted, not cluster-generated).

Eliminates both PG manual-prerequisite steps. Validated: kubectl dry-run on policy; helm template temporal (0 OnePasswordItems) + lakehouse (DATABASE_URL→lakehouse-pg.uri); semgrep clean.