### PR TITLE
fix(lakehouse): drop invalid -replication flag wedging warehouse-bucket Job

### DIFF
--- a/projects/platform/warehouse-bucket/job.yaml
+++ b/projects/platform/warehouse-bucket/job.yaml
@@ -94,9 +94,13 @@ spec:
                 exit 0
               fi
 
-              echo "Creating bucket '${BUCKET}' (replication=000, single-node)..."
-              # replication 000 = no replication; rack-aware deferred until multi-node.
-              echo "s3.bucket.create -name ${BUCKET} -replication 000" \
+              echo "Creating bucket '${BUCKET}' (single-node, default replication)..."
+              # NOTE: SeaweedFS 3.73 `s3.bucket.create` only accepts `-name`
+              # (no `-replication` flag — passing it errors with "flag provided
+              # but not defined"). Replication is a cluster/volume-level setting
+              # here, not per-bucket via this command; rack-aware replication
+              # (ADR platform/004 risks) is deferred until multi-node anyway.
+              echo "s3.bucket.create -name ${BUCKET}" \
                 | weed shell -master "${MASTER}"
 
               echo "Verifying bucket '${BUCKET}' exists..."


### PR DESCRIPTION
The `warehouse-bucket-create` Job passed `-replication 000` to SeaweedFS 3.73 `s3.bucket.create`, which only accepts `-name` → 'flag provided but not defined' → Job errored → it's a PreSync hook inlined into the root `canada` app-of-apps, so it blocked ALL of Wavefront 1 from deploying. Drop the flag (replication is cluster/volume-level, not per-bucket). Verified against the live Job's error log.