### PR TITLE
fix(kyverno): admission-controller Secret RBAC for clone-monolith-pg-app

### DIFF
--- a/projects/platform/kyverno/templates/clone-monolith-pg-secret-policy.yaml
+++ b/projects/platform/kyverno/templates/clone-monolith-pg-secret-policy.yaml
@@ -59,13 +59,17 @@ spec:
           namespace: monolith
           name: monolith-pg-app
 ---
-# Kyverno 3.x restricts the background controller's Secret access by default.
-# Grant get/list/watch on the source + create/update/delete on the clones via an
-# aggregated ClusterRole (the documented mechanism for clone-generate of Secrets).
+# Kyverno 3.x restricts both controllers' Secret access by default. The
+# BACKGROUND controller does the actual clone (needs get/list/watch on the
+# source + create/update/delete on the clones). The ADMISSION controller
+# validates the generate rule at policy-admission time and rejects the policy
+# unless it ALSO has get/list on Secrets ("kyverno-admission-controller requires
+# permissions list,get for resource v1/Secret"). Grant each via its matching
+# aggregation label (least privilege: admission is read-only).
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: kyverno:clone-monolith-pg-secret
+  name: kyverno:clone-monolith-pg-secret-background
   labels:
     app.kubernetes.io/part-of: kyverno
     rbac.kyverno.io/aggregate-to-background-controller: "true"
@@ -81,3 +85,20 @@ rules:
       - create
       - update
       - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kyverno:clone-monolith-pg-secret-admission
+  labels:
+    app.kubernetes.io/part-of: kyverno
+    rbac.kyverno.io/aggregate-to-admission-controller: "true"
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+      - list
+      - watch


### PR DESCRIPTION
The clone-monolith-pg-app ClusterPolicy was rejected by Kyverno's validate-policy webhook: `kyverno-admission-controller requires permissions list,get for resource v1/Secret`. Kyverno 3.x requires BOTH the background controller (does the clone) and the admission controller (validates the generate rule) to have Secret access. Adds a second aggregated ClusterRole (read-only get/list/watch) for the admission controller. Unblocks the temporal-pg / lakehouse-pg clone → Temporal can start.