### PR TITLE
feat(lakehouse): activate Wavefront 4 (deploy workers/quack/dispatchers)

### DIFF
--- a/projects/lakehouse/kustomization.yaml
+++ b/projects/lakehouse/kustomization.yaml
@@ -1,11 +1,10 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-# Aggregator for the event-sourced lakehouse. INTENTIONALLY EMPTY this wavefront:
-# the W4 chart (./deploy) is AUTHOR-ONLY and must stay inert until the
-# orchestrator verifies Wavefront-1 live, then wires it by adding `- ./deploy`
-# here. Keeping this aggregator (rather than letting the home-cluster generator
-# auto-discover ./deploy directly) is what keeps the lakehouse Application
-# unsynced: the root references `projects/lakehouse`, which currently resolves to
-# nothing, so ArgoCD never creates the Application.
-resources: []
+# Aggregator for the event-sourced lakehouse. ACTIVATED: Wavefront 1 was verified
+# healthy live (Temporal/KEDA/NATS/SeaweedFS + temporal DBs), so the W4 chart is
+# wired in. ArgoCD's root app (`canada`) → this aggregator → creates the
+# `lakehouse` Application, which deploys the worker pools, Quack server, and
+# dispatchers into the `lakehouse` namespace.
+resources:
+  - ./deploy


### PR DESCRIPTION
W1 verified healthy live (Temporal Running, KEDA, NATS streams, temporal DBs, warehouse bucket; orchestrator/cluster_agents/monolith untouched). Flip `projects/lakehouse/kustomization.yaml` from empty aggregator to `- ./deploy` → ArgoCD deploys the lakehouse chart (3 worker pools + KEDA scalers, Quack 2x + Service/HTTPRoute, dispatchers 2x) into the `lakehouse` namespace. Kyverno clones `lakehouse-pg` for the housekeeping worker's backfill.