### PR TITLE
fix(lakehouse): RetryPolicy import + DuckDB HOME (backfill 0-events + Quack crash)

### DIFF
--- a/projects/lakehouse/chart/templates/_helpers.tpl
+++ b/projects/lakehouse/chart/templates/_helpers.tpl
@@ -50,6 +50,11 @@ Usage:
   value: {{ .Values.env.seaweedfsS3Endpoint | quote }}
 - name: ICEBERG_WAREHOUSE
   value: {{ .Values.env.icebergWarehouse | quote }}
+# DuckDB writes its extension cache to $HOME/.duckdb; the containers are
+# read-only-rootfs (HOME unset => /.duckdb fails). Point HOME at the writable
+# /tmp emptyDir every pod mounts, so httpfs/iceberg/vss INSTALL/LOAD works.
+- name: HOME
+  value: /tmp
 {{- end -}}
 
 {{/*

--- a/projects/lakehouse/chart/templates/quack/quack-deployment.yaml
+++ b/projects/lakehouse/chart/templates/quack/quack-deployment.yaml
@@ -39,6 +39,11 @@ spec:
               containerPort: {{ .Values.quack.port }}
               protocol: TCP
           env:
+            # DuckDB writes its extension cache to $HOME/.duckdb; this container
+            # is read-only-rootfs (HOME unset => /.duckdb fails). Point HOME at
+            # the writable /tmp emptyDir so httpfs/iceberg/vss INSTALL/LOAD works.
+            - name: HOME
+              value: /tmp
             - name: PORT
               value: {{ .Values.quack.port | quote }}
             {{- if .Values.quack.servingArtifactUrl }}

--- a/projects/lakehouse/orchestrator/workflows/backfill_processed_notes.py
+++ b/projects/lakehouse/orchestrator/workflows/backfill_processed_notes.py
@@ -38,6 +38,7 @@ from dataclasses import dataclass
 from datetime import timedelta
 
 from temporalio import activity, workflow
+from temporalio.common import RetryPolicy
 
 # Heavy / non-deterministic libraries are imported inside the workflow's
 # deterministic sandbox only through ``imports_passed_through`` so the SDK does
@@ -294,13 +295,13 @@ class BackfillFromProcessedNotesWorkflow:
         # Notes processed within THIS run segment; resets on continue_as_new.
         processed_this_run = 0
 
-        read_retry = workflow.RetryPolicy(
+        read_retry = RetryPolicy(
             initial_interval=timedelta(seconds=1),
             backoff_coefficient=2.0,
             maximum_interval=timedelta(minutes=1),
             maximum_attempts=5,
         )
-        publish_retry = workflow.RetryPolicy(
+        publish_retry = RetryPolicy(
             initial_interval=timedelta(seconds=1),
             backoff_coefficient=2.0,
             maximum_interval=timedelta(minutes=1),

--- a/projects/lakehouse/orchestrator/workflows/gap_drain.py
+++ b/projects/lakehouse/orchestrator/workflows/gap_drain.py
@@ -38,6 +38,7 @@ from dataclasses import dataclass, field
 from datetime import timedelta
 
 from temporalio import activity, workflow
+from temporalio.common import RetryPolicy
 from temporalio.exceptions import WorkflowAlreadyStartedError
 
 with workflow.unsafe.imports_passed_through():
@@ -250,7 +251,7 @@ class GapDrainWorkflow:
             gap_context,
             start_to_close_timeout=timedelta(hours=1),
             heartbeat_timeout=timedelta(minutes=10),
-            retry_policy=workflow.RetryPolicy(
+            retry_policy=RetryPolicy(
                 initial_interval=timedelta(seconds=5),
                 backoff_coefficient=2.0,
                 # Cap backoff at 1h+ for external-dependency outages
@@ -278,7 +279,7 @@ class GapDrainSweepWorkflow:
             find_ready_gaps,
             limit,
             start_to_close_timeout=timedelta(minutes=2),
-            retry_policy=workflow.RetryPolicy(
+            retry_policy=RetryPolicy(
                 initial_interval=timedelta(seconds=1),
                 backoff_coefficient=2.0,
                 maximum_interval=timedelta(minutes=1),


### PR DESCRIPTION
Two runtime bugs found driving the live backfill (hermetic tests missed them):

1. **backfill + gap_drain** used `workflow.RetryPolicy` (doesn't exist; it's `temporalio.common.RetryPolicy`) → `AttributeError` on every activation → backfill published **0 events**. Fixed the import (the other 3 workflows were already correct).
2. **DuckDB** `INSTALL` writes to `$HOME/.duckdb`; read-only-rootfs containers have HOME unset → `/.duckdb` IOException → **Quack CrashLoopBackOff** (and would crash build_serving). Set `HOME=/tmp` (writable emptyDir) in chart sharedEnv + quack deployment.

Rebuilds the worker image; chart env applies on sync. After merge: restart lakehouse pods to pull the fixed image + env, then re-run the backfill.