### PR TITLE
fix(lakehouse): DuckDB ca_cert_file=certifi for extension SSL download

### DIFF
--- a/projects/lakehouse/duckdb_query/BUILD
+++ b/projects/lakehouse/duckdb_query/BUILD
@@ -8,6 +8,7 @@ load("//bazel/tools/pytest:defs.bzl", "py_test")
 # the requirements lock but did not regenerate the manifest), so resolve it
 # locally here to keep this unit independent of the shared manifest.
 # gazelle:resolve py duckdb @pip//duckdb
+# gazelle:resolve py certifi @pip//certifi
 
 py_library(
     name = "duckdb_query",
@@ -16,7 +17,10 @@ py_library(
         "query.py",
     ],
     visibility = ["//:__subpackages__"],
-    deps = ["@pip//duckdb"],
+    deps = [
+        "@pip//certifi",
+        "@pip//duckdb",
+    ],
 )
 
 py_test(

--- a/projects/lakehouse/duckdb_query/query.py
+++ b/projects/lakehouse/duckdb_query/query.py
@@ -179,6 +179,13 @@ def connect(
     # emptyDir every lakehouse pod mounts).
     duckdb_home = (env or os.environ).get("DUCKDB_HOME", "/tmp")
     con = duckdb.connect(config={"home_directory": duckdb_home})
+    # The minimal hardened image has no system CA bundle DuckDB can find, so the
+    # HTTPS extension download from extensions.duckdb.org fails SSL verification
+    # ("Problem with the SSL CA cert"). DuckDB uses its own `ca_cert_file` (not
+    # OpenSSL/$SSL_CERT_FILE); point it at certifi's bundle (a hard dep).
+    import certifi
+
+    con.execute(f"SET ca_cert_file = '{certifi.where()}'")
     load_extensions(con)
     con.execute(s3_secret_sql(env))
     if read_only_artifact is not None:


### PR DESCRIPTION
After the home_directory fix, DuckDB `INSTALL` cleared the FS error but failed SSL: `Failed to download extension iceberg ... Problem with the SSL CA cert`. The hardened image has no CA bundle DuckDB can find, and DuckDB uses its own `ca_cert_file`. Point it at certifi's bundle (hard dep) before load_extensions. Rebuilds quack + worker; both need it (quack serving + build_serving).