### PR TITLE
fix(lakehouse): bundle DuckDB extensions in image (no runtime download)

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -385,4 +385,65 @@ multiarch_http_file(
     binary_name = "claude",
 )
 
+# DuckDB extensions bundled into the lakehouse worker + quack images so they
+# never download at runtime. The minimal hardened image has no system CA bundle
+# DuckDB's extension installer can find (it uses its own HTTPS stack, not
+# OpenSSL/$SSL_CERT_FILE), so the runtime INSTALL from extensions.duckdb.org
+# fails SSL verification. Bundling the signed .duckdb_extension.gz binaries (and
+# LOAD-ing them from a local path) sidesteps the network entirely — DuckDB still
+# verifies the embedded signature on LOAD. Pinned to DuckDB 1.5.3, matching the
+# @pip//duckdb wheel. The genrule in multiarch_http_file gzip-wraps the tar
+# layer; the .gz payload lands verbatim at /opt/duckdb_ext/ and is gunzipped to
+# /tmp by duckdb_query.load_extensions at startup.
+# URL pattern: https://extensions.duckdb.org/v1.5.3/{linux_amd64,linux_arm64}/<ext>.duckdb_extension.gz
+multiarch_http_file(
+    name = "duckdb_ext_httpfs",
+    amd64_sha256 = "e33a4085f04b84bcbb25c27dec3a821731e4d2476b93cfc84aa46c963098b882",
+    amd64_url = "https://extensions.duckdb.org/v1.5.3/linux_amd64/httpfs.duckdb_extension.gz",
+    arm64_sha256 = "bde75aadc4ebf9edb4b9fecf4aac6025f35fdae56116b2673b0b4990242c3a02",
+    arm64_url = "https://extensions.duckdb.org/v1.5.3/linux_arm64/httpfs.duckdb_extension.gz",
+    binary_name = "httpfs.duckdb_extension.gz",
+    package_dir = "/opt/duckdb_ext",
+)
+
+multiarch_http_file(
+    name = "duckdb_ext_iceberg",
+    amd64_sha256 = "f011e851a635b9f0deabbd3c39800d80f28fb64075495bbee7b2b2dbb003fb5f",
+    amd64_url = "https://extensions.duckdb.org/v1.5.3/linux_amd64/iceberg.duckdb_extension.gz",
+    arm64_sha256 = "4d869567d4e23b86a78388faf5e1fc2c1b9197be66cf51231ab9193ee8e3b22c",
+    arm64_url = "https://extensions.duckdb.org/v1.5.3/linux_arm64/iceberg.duckdb_extension.gz",
+    binary_name = "iceberg.duckdb_extension.gz",
+    package_dir = "/opt/duckdb_ext",
+)
+
+multiarch_http_file(
+    name = "duckdb_ext_vss",
+    amd64_sha256 = "ef2c977241623a5240b95543bb6905e7106574662ac5729ee9785f08c2ebb9c4",
+    amd64_url = "https://extensions.duckdb.org/v1.5.3/linux_amd64/vss.duckdb_extension.gz",
+    arm64_sha256 = "10adb395d8f279e0204b1208a7f1861e61c4d566b0816ea5d4c48ccf4b96cdc6",
+    arm64_url = "https://extensions.duckdb.org/v1.5.3/linux_arm64/vss.duckdb_extension.gz",
+    binary_name = "vss.duckdb_extension.gz",
+    package_dir = "/opt/duckdb_ext",
+)
+
+multiarch_http_file(
+    name = "duckdb_ext_avro",
+    amd64_sha256 = "5eb32503dec69526fca96c3fa381b3c0e2ce7881c6a88dfa04e5fba0ca26ab80",
+    amd64_url = "https://extensions.duckdb.org/v1.5.3/linux_amd64/avro.duckdb_extension.gz",
+    arm64_sha256 = "dcd28c0f227b714e524d6d7eae79db7d14a10029303faed6fce71cdcbb81e08d",
+    arm64_url = "https://extensions.duckdb.org/v1.5.3/linux_arm64/avro.duckdb_extension.gz",
+    binary_name = "avro.duckdb_extension.gz",
+    package_dir = "/opt/duckdb_ext",
+)
+
+multiarch_http_file(
+    name = "duckdb_ext_parquet",
+    amd64_sha256 = "993380466638a09cd14e25b68c7fec3f4bd697c16a35af2452aee9f8c8c65f87",
+    amd64_url = "https://extensions.duckdb.org/v1.5.3/linux_amd64/parquet.duckdb_extension.gz",
+    arm64_sha256 = "31debdb5e8aac3e66e1d1d0c9103865c1b18b1c460f17c1048ba2e3b73ea028f",
+    arm64_url = "https://extensions.duckdb.org/v1.5.3/linux_arm64/parquet.duckdb_extension.gz",
+    binary_name = "parquet.duckdb_extension.gz",
+    package_dir = "/opt/duckdb_ext",
+)
+
 bazel_dep(name = "rules_pkg", version = "1.1.0")

--- a/projects/lakehouse/duckdb_query/__init__.py
+++ b/projects/lakehouse/duckdb_query/__init__.py
@@ -14,9 +14,10 @@ Design split (important for hermetic CI):
   * **Pure SQL builders** (``s3_secret_sql``, ``attach_or_replace_sql``,
     ``vector_search_sql``) return SQL strings and touch no network — these are
     what the unit tests exercise.
-  * **Network/extension-touching helpers** (``load_extensions``, ``connect`` with
-    a remote artifact) install/load DuckDB extensions, which download from the
-    internet at runtime. These are kept out of the default test path.
+  * **Extension/S3-touching helpers** (``load_extensions``, ``connect`` with a
+    remote artifact) LOAD the signed DuckDB extensions bundled into the image at
+    ``/opt/duckdb_ext`` (no network) and read S3. These are kept out of the
+    default test path so hermetic CI never touches the on-disk bundle.
 
 SeaweedFS S3 auth is currently disabled, so the configured KEY_ID/SECRET may be
 dummy values; the secret is still required for the DuckDB ``httpfs`` S3 layer to

--- a/projects/lakehouse/duckdb_query/query.py
+++ b/projects/lakehouse/duckdb_query/query.py
@@ -5,10 +5,11 @@ The module is intentionally split into two layers:
   * **Pure SQL string builders** — ``s3_secret_sql``, ``attach_or_replace_sql`` and
     ``vector_search_sql``. They have no side effects, touch no network, and are the
     unit-tested surface.
-  * **Network / extension-touching helpers** — ``load_extensions`` (``INSTALL``/``LOAD``
-    of ``httpfs``/``iceberg``/``vss``, which download from the internet at runtime) and
-    ``connect`` (which calls ``load_extensions`` and configures the S3 secret). These
-    are kept out of the default test path so the hermetic CI never reaches the network.
+  * **Extension / S3-touching helpers** — ``load_extensions`` (``LOAD`` of the signed
+    extension binaries bundled into the image at ``/opt/duckdb_ext`` — gunzipped to a
+    writable dir, no network) and ``connect`` (which calls ``load_extensions`` and
+    configures the S3 secret). These are kept out of the default test path so the
+    hermetic CI never touches the on-disk bundle.
 
 DuckDB version is pinned to 1.5.3 (the version platform/004 verified for the
 ``ATTACH OR REPLACE`` hot-swap semantics).
@@ -16,7 +17,9 @@ DuckDB version is pinned to 1.5.3 (the version platform/004 verified for the
 
 from __future__ import annotations
 
+import gzip
 import os
+import shutil
 from collections.abc import Mapping
 
 import duckdb
@@ -46,11 +49,26 @@ _S3_REGION = "us-east-1"
 # Secret name used for the SeaweedFS S3 endpoint inside a DuckDB connection.
 _S3_SECRET_NAME = "seaweedfs"
 
-# DuckDB extensions needed for the lakehouse read/serving paths.
+# DuckDB extensions needed for the lakehouse read/serving paths. These are
+# bundled into the worker + quack images at _BUNDLED_EXT_DIR (see MODULE.bazel's
+# duckdb_ext_* multiarch_http_file rules) and LOAD-ed from a local path so the
+# hardened image never downloads them — DuckDB still verifies the embedded
+# signature on LOAD.
+#
+# ORDER MATTERS: with no installer to auto-resolve transitive extensions, each
+# must be LOAD-ed after its dependencies. avro + parquet are iceberg's readers,
+# so they precede iceberg.
+#   avro    — Avro decoder used by iceberg's manifest reads
+#   parquet — Parquet reader used by iceberg data files
 #   httpfs  — direct S3 reads against SeaweedFS
 #   iceberg — read Iceberg tables (workflow read path: warehouse.knowledge.*)
 #   vss     — HNSW vector search over the serving artifact's embedding column
-_EXTENSIONS = ("httpfs", "iceberg", "vss")
+_EXTENSIONS = ("avro", "parquet", "httpfs", "iceberg", "vss")
+
+# Where the multiarch_http_file tars place the signed .duckdb_extension.gz files
+# in the image rootfs (read-only at runtime). load_extensions gunzips each into a
+# writable scratch dir before LOAD-ing it.
+_BUNDLED_EXT_DIR = "/opt/duckdb_ext"
 
 
 # --------------------------------------------------------------------------- #
@@ -133,21 +151,40 @@ def vector_search_sql(table: str, k: int) -> str:
 
 
 # --------------------------------------------------------------------------- #
-# Network / extension-touching helpers (NOT exercised by hermetic tests)
+# Extension / S3-touching helpers (NOT exercised by hermetic tests)
 # --------------------------------------------------------------------------- #
 
 
-def load_extensions(con: duckdb.DuckDBPyConnection) -> None:
-    """``INSTALL`` + ``LOAD`` the lakehouse DuckDB extensions on ``con``.
+def load_extensions(
+    con: duckdb.DuckDBPyConnection,
+    *,
+    env: Mapping[str, str] | None = None,
+) -> None:
+    """``LOAD`` the lakehouse DuckDB extensions from the in-image bundle on ``con``.
 
-    Installs ``httpfs``, ``iceberg`` and ``vss``. The first ``INSTALL`` of each
-    downloads the extension binary from the DuckDB extension repository over the
-    network, so this MUST NOT be called from hermetic CI tests — it is deliberately
-    factored out of the pure builders for exactly that reason.
+    The signed extension binaries (``avro``, ``parquet``, ``httpfs``, ``iceberg``,
+    ``vss``) are baked into the image at ``_BUNDLED_EXT_DIR`` as gzipped
+    ``.duckdb_extension.gz`` files (see MODULE.bazel's ``duckdb_ext_*``
+    ``multiarch_http_file`` rules). The image rootfs is read-only, so each is
+    gunzipped once into a writable scratch dir (``$DUCKDB_HOME/duckdb_ext``,
+    default ``/tmp/duckdb_ext``) and then ``LOAD``-ed by absolute path.
+
+    No ``INSTALL`` and no network: ``LOAD '<path>'`` verifies the extension's
+    embedded signature locally, so the hardened image — which has no CA bundle
+    DuckDB's extension installer could use — never reaches extensions.duckdb.org.
+    Because it reads the on-disk bundle, this MUST NOT be called from hermetic CI
+    tests; it is deliberately factored out of the pure builders for that reason.
     """
+    env = os.environ if env is None else env
+    runtime_dir = os.path.join(env.get("DUCKDB_HOME", "/tmp"), "duckdb_ext")
+    os.makedirs(runtime_dir, exist_ok=True)
     for ext in _EXTENSIONS:
-        con.execute(f"INSTALL {ext};")
-        con.execute(f"LOAD {ext};")
+        gz_path = os.path.join(_BUNDLED_EXT_DIR, f"{ext}.duckdb_extension.gz")
+        ext_path = os.path.join(runtime_dir, f"{ext}.duckdb_extension")
+        if not os.path.exists(ext_path):
+            with gzip.open(gz_path, "rb") as src, open(ext_path, "wb") as dst:
+                shutil.copyfileobj(src, dst)
+        con.execute(f"LOAD '{ext_path}';")
 
 
 def connect(
@@ -159,34 +196,37 @@ def connect(
 
     Steps performed:
       1. ``duckdb.connect()`` (in-memory base connection).
-      2. ``load_extensions`` — installs/loads httpfs, iceberg, vss (network on first
-         install).
+      2. ``load_extensions`` — LOADs the bundled httpfs, iceberg, vss, avro, parquet
+         extensions from the in-image bundle (no network; see ``load_extensions``).
       3. Runs ``s3_secret_sql(env)`` so subsequent ``s3://`` reads authenticate
          against SeaweedFS.
       4. If ``read_only_artifact`` is given, ``ATTACH OR REPLACE`` it as schema
          ``notes`` (the hot-swap pattern from platform/004 §hot-swap). The path may be
          an ``s3://warehouse/serving/notes-vN.duckdb`` URI or a local ``.duckdb`` file.
 
-    Because steps 2-4 touch the network (extension download, S3 reads), this function
-    is **not** invoked by the unit tests. Tests exercise the pure builders and an
+    Because steps 2-4 touch the filesystem bundle and S3, this function is **not**
+    invoked by the unit tests. Tests exercise the pure builders and an
     extension-free ``duckdb.connect(':memory:')`` smoke check instead.
     """
-    # DuckDB downloads extensions under <home_directory>/.duckdb. It derives
-    # home_directory from the passwd home of the running uid (NOT the $HOME env),
-    # which for the non-root container user (65532) is "/" on a read-only
-    # rootfs => INSTALL fails with 'Failed to create directory "/.duckdb"'.
-    # Point home_directory at a writable dir (DUCKDB_HOME, default /tmp — the
-    # emptyDir every lakehouse pod mounts).
+    # DuckDB derives its home_directory from the passwd home of the running uid
+    # (NOT the $HOME env), which for the non-root container user (65532) is "/"
+    # on a read-only rootfs. Several DuckDB operations create <home>/.duckdb
+    # (settings, temp), which would fail with 'Failed to create directory
+    # "/.duckdb"'. Point home_directory at a writable dir (DUCKDB_HOME, default
+    # /tmp — the emptyDir every lakehouse pod mounts). Extensions are LOAD-ed from
+    # the bundle (load_extensions), not installed here, so this no longer governs
+    # extension downloads — it just keeps DuckDB's home writable.
     duckdb_home = (env or os.environ).get("DUCKDB_HOME", "/tmp")
     con = duckdb.connect(config={"home_directory": duckdb_home})
-    # The minimal hardened image has no system CA bundle DuckDB can find, so the
-    # HTTPS extension download from extensions.duckdb.org fails SSL verification
-    # ("Problem with the SSL CA cert"). DuckDB uses its own `ca_cert_file` (not
-    # OpenSSL/$SSL_CERT_FILE); point it at certifi's bundle (a hard dep).
+    # SeaweedFS S3 is plaintext (USE_SSL false) and extensions LOAD from the local
+    # bundle, so no CA bundle is needed for the lakehouse paths. Set DuckDB's own
+    # `ca_cert_file` (distinct from OpenSSL/$SSL_CERT_FILE) at certifi's bundle
+    # defensively, so any future HTTPS httpfs read (e.g. an external S3) verifies
+    # against a real trust store rather than failing on the empty system store.
     import certifi
 
     con.execute(f"SET ca_cert_file = '{certifi.where()}'")
-    load_extensions(con)
+    load_extensions(con, env=env)
     con.execute(s3_secret_sql(env))
     if read_only_artifact is not None:
         con.execute(attach_or_replace_sql("notes", read_only_artifact))

--- a/projects/lakehouse/image/BUILD
+++ b/projects/lakehouse/image/BUILD
@@ -36,7 +36,18 @@ py3_image(
     # repo (//projects/agent_platform/orchestrator/mcp:image), which likewise
     # omits `main`.
     # Bundle the Claude Code CLI (same as the monolith backend image) so the
-    # gap-drain `run_research_session` activity can invoke the existing harness.
-    multiarch_tars = ["@claude_code//:tar"],
+    # gap-drain `run_research_session` activity can invoke the existing harness,
+    # plus the signed DuckDB extensions (httpfs/iceberg/vss/avro/parquet) so the
+    # iceberg-builder + read paths LOAD them from /opt/duckdb_ext/ rather than
+    # downloading at runtime — the hardened image has no CA bundle DuckDB's
+    # extension installer can use. See MODULE.bazel and duckdb_query.load_extensions.
+    multiarch_tars = [
+        "@claude_code//:tar",
+        "@duckdb_ext_avro//:tar",
+        "@duckdb_ext_httpfs//:tar",
+        "@duckdb_ext_iceberg//:tar",
+        "@duckdb_ext_parquet//:tar",
+        "@duckdb_ext_vss//:tar",
+    ],
     repository = "ghcr.io/jomcgi/homelab/projects/lakehouse/worker",
 )

--- a/projects/lakehouse/quack-server/BUILD
+++ b/projects/lakehouse/quack-server/BUILD
@@ -74,6 +74,19 @@ py3_image(
         "PYTHONPATH": "/projects/lakehouse/quack-server/main.runfiles/_main:/projects/lakehouse/quack-server/main.runfiles/_main/projects/lakehouse/quack-server",
     },
     main = "server.py",
+    # Bundle the signed DuckDB extensions so the serving connection LOADs them
+    # from /opt/duckdb_ext/ instead of downloading at runtime (the hardened image
+    # has no CA bundle DuckDB's extension installer can use). Quack only strictly
+    # needs httpfs (S3 reads) + vss (HNSW search), but load_extensions loads the
+    # full set; bundling all five keeps the worker and quack images consistent.
+    # See MODULE.bazel and duckdb_query.load_extensions.
+    multiarch_tars = [
+        "@duckdb_ext_avro//:tar",
+        "@duckdb_ext_httpfs//:tar",
+        "@duckdb_ext_iceberg//:tar",
+        "@duckdb_ext_parquet//:tar",
+        "@duckdb_ext_vss//:tar",
+    ],
     repository = "ghcr.io/jomcgi/homelab/projects/lakehouse/quack-server",
 )
 


### PR DESCRIPTION
## Problem

Quack (and the iceberg-builder worker) crash-loop on startup: the hardened minimal image has no system CA bundle DuckDB's extension installer can use, so the runtime `INSTALL` from `extensions.duckdb.org` fails SSL verification:

```
Failed to download extension "iceberg" at URL ".../iceberg.duckdb_extension.gz"
(ERROR Problem with the SSL CA cert (path? access rights?))
```

DuckDB's extension installer uses its **own** HTTPS stack (not OpenSSL / `$SSL_CERT_FILE`), and ignores the `ca_cert_file` setting we tried, so the CA fix didn't take. This is the last leg blocking the Iceberg→Quack serving path (criterion 3 of the lakehouse goal).

## Fix

Bundle the signed DuckDB 1.5.3 extensions into both the worker and quack images and `LOAD` them from a local path — no network, no CA dependency. `LOAD '<path>'` still verifies the extension's embedded signature locally.

- **MODULE.bazel** — five `multiarch_http_file` rules (`duckdb_ext_{httpfs,iceberg,vss,avro,parquet}`), per-arch (amd64+arm64), sha256-pinned, placing the `.duckdb_extension.gz` at `/opt/duckdb_ext`.
- **image/BUILD + quack-server/BUILD** — add the five `:tar`s to `multiarch_tars`.
- **duckdb_query/query.py** — `load_extensions` gunzips each bundled `.gz` into `$DUCKDB_HOME/duckdb_ext` (writable, default `/tmp`) once, then `LOAD '<path>'`. `avro`+`parquet` load before `iceberg` (no installer to auto-resolve transitive extensions).

`certifi`/`ca_cert_file` and `home_directory=/tmp` are retained defensively (the worker's `SSL_CERT_FILE` env depends on `certifi` in its venv) — they're now no-ops for extension loading.

## Verification (post-merge)

1. Restart quack + housekeeping worker → confirm no `Failed to download extension` / no crash-loop.
2. Trigger `BuildServingArtifactWorkflow` → serving `.duckdb` lands in `s3://warehouse/serving/`.
3. Query Quack for one of the 100 backfilled `_processed` notes (criterion 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)