### PR TITLE
feat(lakehouse): PG-backed shared Iceberg catalog (Iceberg→Quack serving leg)

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -385,4 +385,65 @@ multiarch_http_file(
     binary_name = "claude",
 )
 
+# DuckDB extensions bundled into the lakehouse worker + quack images so they
+# never download at runtime. The minimal hardened image has no system CA bundle
+# DuckDB's extension installer can find (it uses its own HTTPS stack, not
+# OpenSSL/$SSL_CERT_FILE), so the runtime INSTALL from extensions.duckdb.org
+# fails SSL verification. Bundling the signed .duckdb_extension.gz binaries (and
+# LOAD-ing them from a local path) sidesteps the network entirely — DuckDB still
+# verifies the embedded signature on LOAD. Pinned to DuckDB 1.5.3, matching the
+# @pip//duckdb wheel. The genrule in multiarch_http_file gzip-wraps the tar
+# layer; the .gz payload lands verbatim at /opt/duckdb_ext/ and is gunzipped to
+# /tmp by duckdb_query.load_extensions at startup.
+# URL pattern: https://extensions.duckdb.org/v1.5.3/{linux_amd64,linux_arm64}/<ext>.duckdb_extension.gz
+multiarch_http_file(
+    name = "duckdb_ext_httpfs",
+    amd64_sha256 = "e33a4085f04b84bcbb25c27dec3a821731e4d2476b93cfc84aa46c963098b882",
+    amd64_url = "https://extensions.duckdb.org/v1.5.3/linux_amd64/httpfs.duckdb_extension.gz",
+    arm64_sha256 = "bde75aadc4ebf9edb4b9fecf4aac6025f35fdae56116b2673b0b4990242c3a02",
+    arm64_url = "https://extensions.duckdb.org/v1.5.3/linux_arm64/httpfs.duckdb_extension.gz",
+    binary_name = "httpfs.duckdb_extension.gz",
+    package_dir = "/opt/duckdb_ext",
+)
+
+multiarch_http_file(
+    name = "duckdb_ext_iceberg",
+    amd64_sha256 = "f011e851a635b9f0deabbd3c39800d80f28fb64075495bbee7b2b2dbb003fb5f",
+    amd64_url = "https://extensions.duckdb.org/v1.5.3/linux_amd64/iceberg.duckdb_extension.gz",
+    arm64_sha256 = "4d869567d4e23b86a78388faf5e1fc2c1b9197be66cf51231ab9193ee8e3b22c",
+    arm64_url = "https://extensions.duckdb.org/v1.5.3/linux_arm64/iceberg.duckdb_extension.gz",
+    binary_name = "iceberg.duckdb_extension.gz",
+    package_dir = "/opt/duckdb_ext",
+)
+
+multiarch_http_file(
+    name = "duckdb_ext_vss",
+    amd64_sha256 = "ef2c977241623a5240b95543bb6905e7106574662ac5729ee9785f08c2ebb9c4",
+    amd64_url = "https://extensions.duckdb.org/v1.5.3/linux_amd64/vss.duckdb_extension.gz",
+    arm64_sha256 = "10adb395d8f279e0204b1208a7f1861e61c4d566b0816ea5d4c48ccf4b96cdc6",
+    arm64_url = "https://extensions.duckdb.org/v1.5.3/linux_arm64/vss.duckdb_extension.gz",
+    binary_name = "vss.duckdb_extension.gz",
+    package_dir = "/opt/duckdb_ext",
+)
+
+multiarch_http_file(
+    name = "duckdb_ext_avro",
+    amd64_sha256 = "5eb32503dec69526fca96c3fa381b3c0e2ce7881c6a88dfa04e5fba0ca26ab80",
+    amd64_url = "https://extensions.duckdb.org/v1.5.3/linux_amd64/avro.duckdb_extension.gz",
+    arm64_sha256 = "dcd28c0f227b714e524d6d7eae79db7d14a10029303faed6fce71cdcbb81e08d",
+    arm64_url = "https://extensions.duckdb.org/v1.5.3/linux_arm64/avro.duckdb_extension.gz",
+    binary_name = "avro.duckdb_extension.gz",
+    package_dir = "/opt/duckdb_ext",
+)
+
+multiarch_http_file(
+    name = "duckdb_ext_parquet",
+    amd64_sha256 = "993380466638a09cd14e25b68c7fec3f4bd697c16a35af2452aee9f8c8c65f87",
+    amd64_url = "https://extensions.duckdb.org/v1.5.3/linux_amd64/parquet.duckdb_extension.gz",
+    arm64_sha256 = "31debdb5e8aac3e66e1d1d0c9103865c1b18b1c460f17c1048ba2e3b73ea028f",
+    arm64_url = "https://extensions.duckdb.org/v1.5.3/linux_arm64/parquet.duckdb_extension.gz",
+    binary_name = "parquet.duckdb_extension.gz",
+    package_dir = "/opt/duckdb_ext",
+)
+
 bazel_dep(name = "rules_pkg", version = "1.1.0")

--- a/projects/lakehouse/chart/Chart.yaml
+++ b/projects/lakehouse/chart/Chart.yaml
@@ -6,5 +6,5 @@ description: >-
   NATS->Iceberg/serving dispatchers. ADRs agents/015 (Temporal worker pools) and
   platform/004 (Iceberg lakehouse + hot-swap Quack serving).
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: "0.1.0"

--- a/projects/lakehouse/chart/templates/workers/iceberg-builder-worker-deployment.yaml
+++ b/projects/lakehouse/chart/templates/workers/iceberg-builder-worker-deployment.yaml
@@ -38,6 +38,19 @@ spec:
             {{- if .Values.onepassword.s3.itemPath }}
             {{- include "lakehouse.s3Env" . | nindent 12 }}
             {{- end }}
+            {{- if .Values.pg.enabled }}
+            # The iceberg-builder writes table pointers through the shared
+            # Iceberg SqlCatalog, which lives in the `lakehouse` PG database.
+            # The `<fullname>-pg` Secret (Kyverno-cloned from monolith-pg-app,
+            # key `uri`) authenticates as `app`; iceberg.catalog repoints it at
+            # the `lakehouse` database. Same credential as the housekeeping
+            # backfill — the catalog never touches the monolith notes tables.
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "lakehouse.fullname" . }}-pg
+                  key: uri
+            {{- end }}
           resources:
             {{- toYaml .Values.worker.resources | nindent 12 }}
           securityContext:

--- a/projects/lakehouse/duckdb_query/__init__.py
+++ b/projects/lakehouse/duckdb_query/__init__.py
@@ -14,9 +14,10 @@ Design split (important for hermetic CI):
   * **Pure SQL builders** (``s3_secret_sql``, ``attach_or_replace_sql``,
     ``vector_search_sql``) return SQL strings and touch no network — these are
     what the unit tests exercise.
-  * **Network/extension-touching helpers** (``load_extensions``, ``connect`` with
-    a remote artifact) install/load DuckDB extensions, which download from the
-    internet at runtime. These are kept out of the default test path.
+  * **Extension/S3-touching helpers** (``load_extensions``, ``connect`` with a
+    remote artifact) LOAD the signed DuckDB extensions bundled into the image at
+    ``/opt/duckdb_ext`` (no network) and read S3. These are kept out of the
+    default test path so hermetic CI never touches the on-disk bundle.
 
 SeaweedFS S3 auth is currently disabled, so the configured KEY_ID/SECRET may be
 dummy values; the secret is still required for the DuckDB ``httpfs`` S3 layer to

--- a/projects/lakehouse/duckdb_query/query.py
+++ b/projects/lakehouse/duckdb_query/query.py
@@ -5,10 +5,11 @@ The module is intentionally split into two layers:
   * **Pure SQL string builders** — ``s3_secret_sql``, ``attach_or_replace_sql`` and
     ``vector_search_sql``. They have no side effects, touch no network, and are the
     unit-tested surface.
-  * **Network / extension-touching helpers** — ``load_extensions`` (``INSTALL``/``LOAD``
-    of ``httpfs``/``iceberg``/``vss``, which download from the internet at runtime) and
-    ``connect`` (which calls ``load_extensions`` and configures the S3 secret). These
-    are kept out of the default test path so the hermetic CI never reaches the network.
+  * **Extension / S3-touching helpers** — ``load_extensions`` (``LOAD`` of the signed
+    extension binaries bundled into the image at ``/opt/duckdb_ext`` — gunzipped to a
+    writable dir, no network) and ``connect`` (which calls ``load_extensions`` and
+    configures the S3 secret). These are kept out of the default test path so the
+    hermetic CI never touches the on-disk bundle.
 
 DuckDB version is pinned to 1.5.3 (the version platform/004 verified for the
 ``ATTACH OR REPLACE`` hot-swap semantics).
@@ -16,7 +17,9 @@ DuckDB version is pinned to 1.5.3 (the version platform/004 verified for the
 
 from __future__ import annotations
 
+import gzip
 import os
+import shutil
 from collections.abc import Mapping
 
 import duckdb
@@ -46,11 +49,26 @@ _S3_REGION = "us-east-1"
 # Secret name used for the SeaweedFS S3 endpoint inside a DuckDB connection.
 _S3_SECRET_NAME = "seaweedfs"
 
-# DuckDB extensions needed for the lakehouse read/serving paths.
+# DuckDB extensions needed for the lakehouse read/serving paths. These are
+# bundled into the worker + quack images at _BUNDLED_EXT_DIR (see MODULE.bazel's
+# duckdb_ext_* multiarch_http_file rules) and LOAD-ed from a local path so the
+# hardened image never downloads them — DuckDB still verifies the embedded
+# signature on LOAD.
+#
+# ORDER MATTERS: with no installer to auto-resolve transitive extensions, each
+# must be LOAD-ed after its dependencies. avro + parquet are iceberg's readers,
+# so they precede iceberg.
+#   avro    — Avro decoder used by iceberg's manifest reads
+#   parquet — Parquet reader used by iceberg data files
 #   httpfs  — direct S3 reads against SeaweedFS
 #   iceberg — read Iceberg tables (workflow read path: warehouse.knowledge.*)
 #   vss     — HNSW vector search over the serving artifact's embedding column
-_EXTENSIONS = ("httpfs", "iceberg", "vss")
+_EXTENSIONS = ("avro", "parquet", "httpfs", "iceberg", "vss")
+
+# Where the multiarch_http_file tars place the signed .duckdb_extension.gz files
+# in the image rootfs (read-only at runtime). load_extensions gunzips each into a
+# writable scratch dir before LOAD-ing it.
+_BUNDLED_EXT_DIR = "/opt/duckdb_ext"
 
 
 # --------------------------------------------------------------------------- #
@@ -133,21 +151,40 @@ def vector_search_sql(table: str, k: int) -> str:
 
 
 # --------------------------------------------------------------------------- #
-# Network / extension-touching helpers (NOT exercised by hermetic tests)
+# Extension / S3-touching helpers (NOT exercised by hermetic tests)
 # --------------------------------------------------------------------------- #
 
 
-def load_extensions(con: duckdb.DuckDBPyConnection) -> None:
-    """``INSTALL`` + ``LOAD`` the lakehouse DuckDB extensions on ``con``.
+def load_extensions(
+    con: duckdb.DuckDBPyConnection,
+    *,
+    env: Mapping[str, str] | None = None,
+) -> None:
+    """``LOAD`` the lakehouse DuckDB extensions from the in-image bundle on ``con``.
 
-    Installs ``httpfs``, ``iceberg`` and ``vss``. The first ``INSTALL`` of each
-    downloads the extension binary from the DuckDB extension repository over the
-    network, so this MUST NOT be called from hermetic CI tests — it is deliberately
-    factored out of the pure builders for exactly that reason.
+    The signed extension binaries (``avro``, ``parquet``, ``httpfs``, ``iceberg``,
+    ``vss``) are baked into the image at ``_BUNDLED_EXT_DIR`` as gzipped
+    ``.duckdb_extension.gz`` files (see MODULE.bazel's ``duckdb_ext_*``
+    ``multiarch_http_file`` rules). The image rootfs is read-only, so each is
+    gunzipped once into a writable scratch dir (``$DUCKDB_HOME/duckdb_ext``,
+    default ``/tmp/duckdb_ext``) and then ``LOAD``-ed by absolute path.
+
+    No ``INSTALL`` and no network: ``LOAD '<path>'`` verifies the extension's
+    embedded signature locally, so the hardened image — which has no CA bundle
+    DuckDB's extension installer could use — never reaches extensions.duckdb.org.
+    Because it reads the on-disk bundle, this MUST NOT be called from hermetic CI
+    tests; it is deliberately factored out of the pure builders for that reason.
     """
+    env = os.environ if env is None else env
+    runtime_dir = os.path.join(env.get("DUCKDB_HOME", "/tmp"), "duckdb_ext")
+    os.makedirs(runtime_dir, exist_ok=True)
     for ext in _EXTENSIONS:
-        con.execute(f"INSTALL {ext};")
-        con.execute(f"LOAD {ext};")
+        gz_path = os.path.join(_BUNDLED_EXT_DIR, f"{ext}.duckdb_extension.gz")
+        ext_path = os.path.join(runtime_dir, f"{ext}.duckdb_extension")
+        if not os.path.exists(ext_path):
+            with gzip.open(gz_path, "rb") as src, open(ext_path, "wb") as dst:
+                shutil.copyfileobj(src, dst)
+        con.execute(f"LOAD '{ext_path}';")
 
 
 def connect(
@@ -159,34 +196,37 @@ def connect(
 
     Steps performed:
       1. ``duckdb.connect()`` (in-memory base connection).
-      2. ``load_extensions`` — installs/loads httpfs, iceberg, vss (network on first
-         install).
+      2. ``load_extensions`` — LOADs the bundled httpfs, iceberg, vss, avro, parquet
+         extensions from the in-image bundle (no network; see ``load_extensions``).
       3. Runs ``s3_secret_sql(env)`` so subsequent ``s3://`` reads authenticate
          against SeaweedFS.
       4. If ``read_only_artifact`` is given, ``ATTACH OR REPLACE`` it as schema
          ``notes`` (the hot-swap pattern from platform/004 §hot-swap). The path may be
          an ``s3://warehouse/serving/notes-vN.duckdb`` URI or a local ``.duckdb`` file.
 
-    Because steps 2-4 touch the network (extension download, S3 reads), this function
-    is **not** invoked by the unit tests. Tests exercise the pure builders and an
+    Because steps 2-4 touch the filesystem bundle and S3, this function is **not**
+    invoked by the unit tests. Tests exercise the pure builders and an
     extension-free ``duckdb.connect(':memory:')`` smoke check instead.
     """
-    # DuckDB downloads extensions under <home_directory>/.duckdb. It derives
-    # home_directory from the passwd home of the running uid (NOT the $HOME env),
-    # which for the non-root container user (65532) is "/" on a read-only
-    # rootfs => INSTALL fails with 'Failed to create directory "/.duckdb"'.
-    # Point home_directory at a writable dir (DUCKDB_HOME, default /tmp — the
-    # emptyDir every lakehouse pod mounts).
+    # DuckDB derives its home_directory from the passwd home of the running uid
+    # (NOT the $HOME env), which for the non-root container user (65532) is "/"
+    # on a read-only rootfs. Several DuckDB operations create <home>/.duckdb
+    # (settings, temp), which would fail with 'Failed to create directory
+    # "/.duckdb"'. Point home_directory at a writable dir (DUCKDB_HOME, default
+    # /tmp — the emptyDir every lakehouse pod mounts). Extensions are LOAD-ed from
+    # the bundle (load_extensions), not installed here, so this no longer governs
+    # extension downloads — it just keeps DuckDB's home writable.
     duckdb_home = (env or os.environ).get("DUCKDB_HOME", "/tmp")
     con = duckdb.connect(config={"home_directory": duckdb_home})
-    # The minimal hardened image has no system CA bundle DuckDB can find, so the
-    # HTTPS extension download from extensions.duckdb.org fails SSL verification
-    # ("Problem with the SSL CA cert"). DuckDB uses its own `ca_cert_file` (not
-    # OpenSSL/$SSL_CERT_FILE); point it at certifi's bundle (a hard dep).
+    # SeaweedFS S3 is plaintext (USE_SSL false) and extensions LOAD from the local
+    # bundle, so no CA bundle is needed for the lakehouse paths. Set DuckDB's own
+    # `ca_cert_file` (distinct from OpenSSL/$SSL_CERT_FILE) at certifi's bundle
+    # defensively, so any future HTTPS httpfs read (e.g. an external S3) verifies
+    # against a real trust store rather than failing on the empty system store.
     import certifi
 
     con.execute(f"SET ca_cert_file = '{certifi.where()}'")
-    load_extensions(con)
+    load_extensions(con, env=env)
     con.execute(s3_secret_sql(env))
     if read_only_artifact is not None:
         con.execute(attach_or_replace_sql("notes", read_only_artifact))

--- a/projects/lakehouse/iceberg/catalog.py
+++ b/projects/lakehouse/iceberg/catalog.py
@@ -10,29 +10,38 @@ catalog service to operate or back up.
 PyIceberg 0.11.1 has **no Hadoop / pure-filesystem catalog** implementation. Its
 ``AVAILABLE_CATALOGS`` are ``rest``, ``hive``, ``glue``, ``dynamodb``, ``sql``,
 ``in-memory`` and ``bigquery``. The closest no-external-service option is
-``CatalogType.SQL`` (``SqlCatalog``) backed by a **SQLite** metadata database.
+``CatalogType.SQL`` (``SqlCatalog``), which works against any SQLAlchemy backend.
 
-We therefore use ``type="sql"`` with a SQLite URI on shared storage. The Iceberg
-*data* and *metadata* files (manifests, snapshots, ``vN.metadata.json``) still
-live immutably in the S3 warehouse exactly as platform/004 describes; only the
-small catalog index (namespace + table -> current-metadata-pointer) lives in the
-SQLite DB.
+We use ``type="sql"`` backed by **PostgreSQL** — a dedicated ``lakehouse``
+database on the existing monolith-pg CNPG cluster (a CNPG ``Database`` CRD; see
+projects/platform/temporal-databases/database-lakehouse.yaml). The Iceberg *data*
+and *metadata* files (manifests, snapshots, ``…metadata.json``) live immutably in
+the S3 warehouse exactly as platform/004 describes; only the small catalog index
+(namespace + table -> current-metadata-pointer) lives in Postgres.
 
-DEVIATION (follow-up for Wavefront 3): platform/004 says the catalog pointer
-lives *in the warehouse bucket*. With SqlCatalog the pointer lives in a SQLite
-file that must itself be on shared storage and included in the backup set (it is
-small — namespace + table rows). The backup section's "clone the bucket, have
-everything" guarantee is preserved only if the SQLite DB is co-located on the
-same SeaweedFS-backed volume (or itself rcloned). The batch-commit deployment
-(Wavefront 3) must mount the catalog DB on shared storage and add it to the
-backup cron, OR revisit once pyiceberg ships a filesystem catalog. Tracked as a
-platform/004 follow-up.
+Why Postgres, not the SQLite the first cut used: the pointer must be visible to
+*every* worker pod — the iceberg-builder writes table pointers; the housekeeping
+build_serving reads them to find the current snapshot. A pod-local SQLite file
+stranded the pointer on one pod's ephemeral ``/tmp`` (the cluster mounts no shared
+volume), so cross-pod reads failed. Postgres makes the catalog genuinely shared
+and durable. This resolves the prior "shared catalog" deviation; the credential
+is the cluster-generated monolith-pg ``app`` role (cloned in as ``lakehouse-pg``),
+pointed at the isolated ``lakehouse`` database so it never touches the monolith's
+notes/embedding tables.
+
+DEVIATION from platform/004 §"file-based catalog": the pointer lives in Postgres
+rather than *inside the warehouse bucket*, so a bucket-only ``rclone`` snapshot no
+longer captures the catalog. The catalog is instead covered by the CNPG cluster's
+own backup (the same PG that backs the monolith + Temporal), which is an existing,
+operated backup path — a net improvement over a hand-managed SQLite file. Revisit
+if pyiceberg ever ships a pure-filesystem catalog.
 """
 
 from __future__ import annotations
 
 import os
 from collections.abc import Mapping
+from urllib.parse import urlsplit, urlunsplit
 
 # Default S3 endpoint for the in-cluster SeaweedFS S3 gateway: the ``seaweedfs-s3``
 # Service in the ``seaweedfs`` namespace on port 8333, resolved through the usual
@@ -53,10 +62,56 @@ DEFAULT_S3_ENDPOINT = f"http://{_SVC_NAME}.{_SVC_NAMESPACE}.{_CLUSTER_DNS_SUFFIX
 DEFAULT_WAREHOUSE = "s3://warehouse/"
 DEFAULT_REGION = "us-east-1"
 
-# Catalog name + the SQLite metadata DB. The DB lives on shared storage so the
-# warehouse + catalog pointer back up together (see module docstring deviation).
+# Catalog name. The SqlCatalog pointer index (which metadata.json is current
+# per table) lives in PostgreSQL in the cluster — see ``_catalog_uri``. A
+# Postgres backend makes the pointer SHARED across every worker pod (the
+# iceberg-builder writes table pointers; the housekeeping build_serving reads
+# them), resolving the platform/004 "shared catalog" deviation that the old
+# pod-local SQLite file introduced. The SQLite URI below is only the fallback
+# for hermetic tests / local dev where no DATABASE_URL is injected.
 CATALOG_NAME = "warehouse"
-DEFAULT_CATALOG_URI = "sqlite:////warehouse/catalog/warehouse_catalog.db"
+DEFAULT_CATALOG_URI = "sqlite:////tmp/warehouse_catalog.db"
+
+# Dedicated PostgreSQL database (CNPG Database CRD, owner ``app``, on the
+# monolith-pg cluster — see projects/platform/temporal-databases/) that holds the
+# SqlCatalog metastore tables (``iceberg_tables`` / ``iceberg_namespace_properties``).
+# Isolated from the monolith app DB so the catalog never touches the notes/
+# embedding tables. Overridable via ICEBERG_CATALOG_DB.
+DEFAULT_CATALOG_DB = "lakehouse"
+
+
+def _catalog_uri(env: Mapping[str, str]) -> str:
+    """Resolve the SqlCatalog SQLAlchemy URI from ``env``.
+
+    Precedence:
+      1. ``ICEBERG_CATALOG_URI`` — an explicit override (used by tests and local
+         dev; e.g. a ``sqlite:///`` path).
+      2. Derived from ``DATABASE_URL`` — the cluster-generated monolith-pg
+         credential (cloned into this namespace as the ``lakehouse-pg`` Secret)
+         authenticates as the ``app`` role. We reuse those credentials but point
+         at the dedicated ``lakehouse`` database (``ICEBERG_CATALOG_DB``) so the
+         catalog's pointer index is shared across all worker pods. The driver is
+         forced to ``psycopg`` (v3 — the installed driver) for SQLAlchemy, and
+         the original query string (e.g. ``sslmode``) is preserved.
+      3. ``DEFAULT_CATALOG_URI`` — the SQLite fallback for hermetic tests.
+
+    Pure: parses strings only, no I/O.
+    """
+    explicit = env.get("ICEBERG_CATALOG_URI")
+    if explicit:
+        return explicit
+
+    database_url = env.get("DATABASE_URL")
+    if database_url:
+        catalog_db = env.get("ICEBERG_CATALOG_DB", DEFAULT_CATALOG_DB)
+        parts = urlsplit(database_url)
+        # Keep netloc (user:pass@host:port) + query (sslmode, etc.); swap the
+        # driver to psycopg v3 and the database to the dedicated catalog DB.
+        return urlunsplit(
+            parts._replace(scheme="postgresql+psycopg", path=f"/{catalog_db}")
+        )
+
+    return DEFAULT_CATALOG_URI
 
 
 def catalog_config(env: Mapping[str, str] | None = None) -> dict[str, str]:
@@ -70,7 +125,11 @@ def catalog_config(env: Mapping[str, str] | None = None) -> dict[str, str]:
 
       SEAWEEDFS_S3_ENDPOINT   S3 endpoint (default: in-cluster SeaweedFS gateway)
       ICEBERG_WAREHOUSE       warehouse root      (default: ``s3://warehouse/``)
-      ICEBERG_CATALOG_URI     SQLite metadata DB  (default: shared-storage path)
+      DATABASE_URL            monolith-pg URI; the catalog reuses its credentials
+                              against the ``lakehouse`` database (see _catalog_uri)
+      ICEBERG_CATALOG_URI     explicit catalog URI override (default: derived from
+                              DATABASE_URL, else the SQLite test fallback)
+      ICEBERG_CATALOG_DB      catalog database name when deriving (default: lakehouse)
       S3_ACCESS_KEY_ID        S3 access key       (default: ``""`` — auth off)
       S3_SECRET_ACCESS_KEY    S3 secret key       (default: ``""`` — auth off)
       AWS_REGION              S3 region           (default: ``us-east-1``)
@@ -79,15 +138,16 @@ def catalog_config(env: Mapping[str, str] | None = None) -> dict[str, str]:
 
     endpoint = env.get("SEAWEEDFS_S3_ENDPOINT", DEFAULT_S3_ENDPOINT)
     warehouse = env.get("ICEBERG_WAREHOUSE", DEFAULT_WAREHOUSE)
-    catalog_uri = env.get("ICEBERG_CATALOG_URI", DEFAULT_CATALOG_URI)
+    catalog_uri = _catalog_uri(env)
     access_key = env.get("S3_ACCESS_KEY_ID", "")
     secret_key = env.get("S3_SECRET_ACCESS_KEY", "")
     region = env.get("AWS_REGION", DEFAULT_REGION)
 
     return {
-        # SqlCatalog: no external metastore service; the pointer index lives in a
-        # SQLite DB on shared storage (see module docstring for the rationale +
-        # the platform/004 deviation this introduces).
+        # SqlCatalog: no external metastore service. In-cluster the pointer index
+        # lives in the shared `lakehouse` PostgreSQL database (see _catalog_uri),
+        # so every worker pod sees the same "current snapshot" pointer. type stays
+        # "sql" for both the PG and SQLite-fallback backends.
         "type": "sql",
         "uri": catalog_uri,
         "warehouse": warehouse,

--- a/projects/lakehouse/iceberg/catalog_test.py
+++ b/projects/lakehouse/iceberg/catalog_test.py
@@ -72,3 +72,47 @@ def test_config_is_all_strings():
 def test_required_keys_present(key):
     """Every key the catalog/FileIO relies on is always emitted."""
     assert key in catalog_config(env={})
+
+
+def test_catalog_uri_derived_from_database_url():
+    """With DATABASE_URL set (and no explicit override), the catalog URI reuses
+    those credentials but points at the dedicated `lakehouse` database with the
+    psycopg v3 driver — and preserves the query string (sslmode, etc.)."""
+    cfg = catalog_config(
+        env={
+            "DATABASE_URL": "postgresql://app:pw@monolith-pg-rw.monolith:5432/app?sslmode=require",
+        }
+    )
+    assert (
+        cfg["uri"]
+        == "postgresql+psycopg://app:pw@monolith-pg-rw.monolith:5432/lakehouse?sslmode=require"
+    )
+
+
+def test_explicit_catalog_uri_wins_over_database_url():
+    """An explicit ICEBERG_CATALOG_URI overrides the DATABASE_URL derivation."""
+    cfg = catalog_config(
+        env={
+            "ICEBERG_CATALOG_URI": "sqlite:////tmp/cat.db",
+            "DATABASE_URL": "postgresql://app:pw@host:5432/app",
+        }
+    )
+    assert cfg["uri"] == "sqlite:////tmp/cat.db"
+
+
+def test_catalog_db_name_is_overridable():
+    """ICEBERG_CATALOG_DB chooses the database when deriving from DATABASE_URL."""
+    cfg = catalog_config(
+        env={
+            "DATABASE_URL": "postgresql://app:pw@host:5432/app",
+            "ICEBERG_CATALOG_DB": "lakehouse_alt",
+        }
+    )
+    assert cfg["uri"] == "postgresql+psycopg://app:pw@host:5432/lakehouse_alt"
+
+
+def test_sqlite_fallback_when_no_database_url():
+    """No override and no DATABASE_URL -> the SQLite test fallback (type stays sql)."""
+    cfg = catalog_config(env={})
+    assert cfg["type"] == "sql"
+    assert cfg["uri"].startswith("sqlite://")

--- a/projects/lakehouse/image/BUILD
+++ b/projects/lakehouse/image/BUILD
@@ -36,7 +36,18 @@ py3_image(
     # repo (//projects/agent_platform/orchestrator/mcp:image), which likewise
     # omits `main`.
     # Bundle the Claude Code CLI (same as the monolith backend image) so the
-    # gap-drain `run_research_session` activity can invoke the existing harness.
-    multiarch_tars = ["@claude_code//:tar"],
+    # gap-drain `run_research_session` activity can invoke the existing harness,
+    # plus the signed DuckDB extensions (httpfs/iceberg/vss/avro/parquet) so the
+    # iceberg-builder + read paths LOAD them from /opt/duckdb_ext/ rather than
+    # downloading at runtime — the hardened image has no CA bundle DuckDB's
+    # extension installer can use. See MODULE.bazel and duckdb_query.load_extensions.
+    multiarch_tars = [
+        "@claude_code//:tar",
+        "@duckdb_ext_avro//:tar",
+        "@duckdb_ext_httpfs//:tar",
+        "@duckdb_ext_iceberg//:tar",
+        "@duckdb_ext_parquet//:tar",
+        "@duckdb_ext_vss//:tar",
+    ],
     repository = "ghcr.io/jomcgi/homelab/projects/lakehouse/worker",
 )

--- a/projects/lakehouse/orchestrator/workflows/build_serving.py
+++ b/projects/lakehouse/orchestrator/workflows/build_serving.py
@@ -167,10 +167,19 @@ async def build_artifact(version: int) -> BuildResult:
     from projects.lakehouse.duckdb_query.query import connect
     from projects.lakehouse.events.envelope import build_envelope
     from projects.lakehouse.events.publish import publish_event
+    from projects.lakehouse.iceberg.catalog import load_warehouse_catalog
     from projects.lakehouse.nats_client.client import NatsClient
 
     namespace = os.environ.get("ICEBERG_NAMESPACE", ICEBERG_NAMESPACE)
-    source_uri = f"s3://{SERVING_BUCKET}/{namespace}/{SOURCE_TABLE}"
+    # Resolve the *current* snapshot's metadata.json through the shared catalog
+    # rather than letting DuckDB guess the version from the table directory:
+    # DuckDB's iceberg version-guessing cannot parse PyIceberg SqlCatalog's
+    # metadata filenames, and the PG-backed catalog (shared across pods) is the
+    # source of truth for which snapshot is current. iceberg_scan reads the exact
+    # metadata.json path directly, so the build always reflects the latest commit.
+    catalog = load_warehouse_catalog()
+    table = catalog.load_table(f"{namespace}.{SOURCE_TABLE}")
+    source_uri = table.metadata_location
 
     artifact_uri = _artifact_s3_uri(version)
     artifact_key = _artifact_key(version)

--- a/projects/lakehouse/orchestrator/workflows/build_serving_test.py
+++ b/projects/lakehouse/orchestrator/workflows/build_serving_test.py
@@ -83,6 +83,14 @@ async def test_build_artifact_builds_indexes_tags_and_publishes() -> None:
     # rows_indexed query result
     con.execute.return_value.fetchone.return_value = (42,)
 
+    # The shared catalog resolves the current snapshot's metadata.json; the build
+    # iceberg_scans that exact path (no DuckDB version-guessing).
+    catalog = MagicMock()
+    metadata_location = (
+        "s3://warehouse/knowledge/note_events/metadata/00001-abc.metadata.json"
+    )
+    catalog.load_table.return_value.metadata_location = metadata_location
+
     s3 = MagicMock()
     nats_client = AsyncMock()
 
@@ -98,6 +106,10 @@ async def test_build_artifact_builds_indexes_tags_and_publishes() -> None:
 
     with (
         patch("projects.lakehouse.duckdb_query.query.connect", return_value=con),
+        patch(
+            "projects.lakehouse.iceberg.catalog.load_warehouse_catalog",
+            return_value=catalog,
+        ),
         patch.object(mod, "_s3_client", return_value=s3),
         patch(
             "projects.lakehouse.nats_client.client.NatsClient",
@@ -115,11 +127,17 @@ async def test_build_artifact_builds_indexes_tags_and_publishes() -> None:
     assert result.artifact_path == "s3://warehouse/serving/notes-v123.duckdb"
     assert result.rows_indexed == 42
 
-    # The DuckDB build ran the current-version-filter CREATE TABLE + HNSW index.
+    # Resolved the current snapshot via the shared catalog and iceberg_scanned
+    # that exact metadata.json path (not the table dir / version-guessing).
+    catalog.load_table.assert_called_once_with("knowledge.note_events")
+
+    # The DuckDB build ran the current-version-filter CREATE TABLE + HNSW index
+    # over the catalog-resolved metadata location.
     executed = " ".join(str(c.args[0]) for c in con.execute.call_args_list)
     assert "MAX(event_version)" in executed
     assert "USING HNSW (embedding)" in executed
     assert "event_type <> 'tombstoned'" in executed
+    assert metadata_location in executed
 
     # Uploaded with state=building tag (platform/004 lifecycle initial tag).
     s3.put_object.assert_called_once()

--- a/projects/lakehouse/quack-server/BUILD
+++ b/projects/lakehouse/quack-server/BUILD
@@ -74,6 +74,19 @@ py3_image(
         "PYTHONPATH": "/projects/lakehouse/quack-server/main.runfiles/_main:/projects/lakehouse/quack-server/main.runfiles/_main/projects/lakehouse/quack-server",
     },
     main = "server.py",
+    # Bundle the signed DuckDB extensions so the serving connection LOADs them
+    # from /opt/duckdb_ext/ instead of downloading at runtime (the hardened image
+    # has no CA bundle DuckDB's extension installer can use). Quack only strictly
+    # needs httpfs (S3 reads) + vss (HNSW search), but load_extensions loads the
+    # full set; bundling all five keeps the worker and quack images consistent.
+    # See MODULE.bazel and duckdb_query.load_extensions.
+    multiarch_tars = [
+        "@duckdb_ext_avro//:tar",
+        "@duckdb_ext_httpfs//:tar",
+        "@duckdb_ext_iceberg//:tar",
+        "@duckdb_ext_parquet//:tar",
+        "@duckdb_ext_vss//:tar",
+    ],
     repository = "ghcr.io/jomcgi/homelab/projects/lakehouse/quack-server",
 )
 

--- a/projects/platform/temporal-databases/database-lakehouse.yaml
+++ b/projects/platform/temporal-databases/database-lakehouse.yaml
@@ -1,0 +1,26 @@
+# Declarative CNPG Database for the lakehouse Iceberg catalog (PyIceberg
+# SqlCatalog). The catalog's pointer index (iceberg_tables /
+# iceberg_namespace_properties — "which metadata.json is current" per table)
+# lives here in Postgres so it is SHARED across all lakehouse worker pods (the
+# iceberg-builder writes pointers; the housekeeping build_serving reads them),
+# resolving the platform/004 "shared catalog" deviation that a pod-local SQLite
+# file introduced.
+#
+# Lives alongside the temporal databases because, like them, it is an additive
+# CNPG Database on the existing monolith-pg cluster (and must sit in the monolith
+# namespace next to that Cluster). Owner `app` — the same role the cluster-
+# generated monolith-pg credential (cloned into the lakehouse namespace as the
+# lakehouse-pg Secret) authenticates as, so those credentials can create the
+# catalog tables here. Additive: a NEW database, isolated from the monolith app
+# database; it does not touch the Cluster resource or the notes/embedding tables.
+apiVersion: postgresql.cnpg.io/v1
+kind: Database
+metadata:
+  name: lakehouse
+  namespace: monolith
+spec:
+  cluster:
+    name: monolith-pg
+  name: lakehouse
+  owner: app
+  ensure: present

--- a/projects/platform/temporal-databases/kustomization.yaml
+++ b/projects/platform/temporal-databases/kustomization.yaml
@@ -4,3 +4,4 @@ kind: Kustomization
 resources:
   - database-temporal.yaml
   - database-temporal-visibility.yaml
+  - database-lakehouse.yaml


### PR DESCRIPTION
## Problem

With the DuckDB extension bundling fixed (#2421), the serving-artifact build got further but still failed:

```
Could not guess Iceberg table version using 'none' compression
and format(s): 'v%s%s.metadata.json,%s%s.metadata.json'
```

Root cause is the **deferred "shared catalog" deviation** that `catalog.py` itself flagged:

- The PyIceberg `SqlCatalog` pointer ("which `metadata.json` is current") lived in a **pod-local SQLite file** on the iceberg-builder's ephemeral `/tmp` — the cluster mounts no shared volume.
- `build_serving` runs on a *different* pod (housekeeping queue) and can't see it, so it fell back to a raw `iceberg_scan(table_dir)`. DuckDB's version-guessing can't parse PyIceberg's metadata filenames → failure.

## Fix — move the catalog to Postgres (shared + durable)

- **New CNPG `Database` `lakehouse`** (owner `app`, on the existing `monolith-pg` cluster) holds the catalog's `iceberg_tables`/`iceberg_namespace_properties`. Isolated from the monolith app DB — never touches the notes/embedding tables.
- **`catalog._catalog_uri`** derives the catalog URI at runtime from the already-injected `DATABASE_URL`: same cloned `app` credentials, scheme → `postgresql+psycopg` (v3, already a dep), database → `lakehouse`. Falls back to SQLite when `DATABASE_URL` is absent, so **hermetic tests are unchanged**.
- **`build_serving`** resolves the current snapshot via the shared catalog (`load_table().metadata_location`) and `iceberg_scan`s that exact path — no version-guessing.
- **iceberg-builder pool** also gets `DATABASE_URL` (it writes pointers through the catalog; previously only housekeeping had it).
- chart `0.1.0` → `0.1.1`.

### Backup-story note (vs platform/004)

platform/004 wanted the pointer *inside the warehouse bucket* (bucket snapshot captures all). Postgres deviates from that literal but folds the catalog into the CNPG cluster's **existing, operated backup** (same PG behind the monolith + Temporal) — strictly more robust than a hand-managed SQLite file. Documented in `catalog.py`.

## Verification (post-merge)

1. CNPG creates the `lakehouse` database; restart iceberg-builder + housekeeping to pick up `DATABASE_URL` + the new catalog.
2. Re-run `BackfillFromProcessedNotesWorkflow` so the fresh PG catalog gets `note_events` from source.
3. `BuildServingArtifactWorkflow` → serving `.duckdb` in `s3://warehouse/serving/`.
4. Query Quack through the CDN for a backfilled `_processed` note (criterion 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)