### PR TITLE
fix(lakehouse): SQLAlchemy runtime dep for iceberg SqlCatalog (unblocks NATS→Iceberg write)

### DIFF
--- a/projects/lakehouse/iceberg/BUILD
+++ b/projects/lakehouse/iceberg/BUILD
@@ -29,6 +29,17 @@ py_library(
     deps = [
         "@pip//pyarrow",
         "@pip//pyiceberg",
+        # pyiceberg's SqlCatalog imports SQLAlchemy + the psycopg driver LAZILY
+        # (only when a catalog is actually loaded), so gazelle cannot see them
+        # from the `import pyiceberg` statements and would otherwise omit them —
+        # leaving the worker venv without SQLAlchemy and crashing every catalog
+        # load with "No module named 'sqlalchemy'". `# keep` pins them as runtime
+        # deps so load_warehouse_catalog() can open the PG-backed catalog
+        # (postgresql+psycopg dialect). SQLAlchemy 2.0.x ships the psycopg-v3
+        # dialect; psycopg_binary supplies libpq for the minimal image.
+        "@pip//psycopg",  # keep
+        "@pip//psycopg_binary",  # keep
+        "@pip//sqlalchemy",  # keep
     ],
 )
 


### PR DESCRIPTION
## Root cause (a latent bug surfaced by the PG-catalog work)

`pyiceberg`'s `SqlCatalog` imports **SQLAlchemy** (and the psycopg driver) *lazily* — only when a catalog is loaded. So gazelle never saw them from the `import pyiceberg` statements and left them out of the `iceberg` `py_library` deps. The worker venv had no SQLAlchemy, and every `load_warehouse_catalog()` crashed:

```
ModuleNotFoundError: No module named 'sqlalchemy'
pyiceberg.exceptions.NotInstalledError: SQLAlchemy support not installed
```

This had been **silently breaking the NATS→Iceberg write all along**: the dispatcher ACKs the NATS message when it *starts* `IcebergBatchCommitWorkflow`, so the SqlCatalog failure showed up only as a workflow-level error, not a NATS redelivery. The warehouse bucket was empty the whole time — **verified via boto3: `WAREHOUSE_OBJECT_COUNT=0`** — despite earlier "completed"-looking observations. It also blocks the new PG-backed catalog read in `build_serving`.

The 100 backfilled `_processed` events are safe in NATS (infinite retention), so no data is lost — a re-backfill replays them once the writer works.

## Fix

Pin `@pip//sqlalchemy` (2.0.48, already in the lock — ships the `postgresql+psycopg` v3 dialect) plus `@pip//psycopg` / `@pip//psycopg_binary` as `# keep` runtime deps on the iceberg `py_library`, so they're in the worker closure. `# keep` prevents gazelle from pruning them (no matching import). **No lock change** — purely wiring existing wheels into the dependency graph.

## Verification (post-merge)

1. Restart iceberg-builder (KEDA scale-up on re-backfill) + housekeeping on the new `worker:main`.
2. Re-run `BackfillFromProcessedNotesWorkflow` → events replay from NATS → writer commits `note_events` to the PG `lakehouse` catalog + S3.
3. `BuildServingArtifactWorkflow` → serving `.duckdb`.
4. Query Quack for a `_processed` note (criterion 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)