### PR TITLE
fix(lakehouse): pyiceberg S3 writes to SeaweedFS (http scheme + disable aws-chunked checksum)

### DIFF
--- a/projects/lakehouse/chart/Chart.yaml
+++ b/projects/lakehouse/chart/Chart.yaml
@@ -6,5 +6,5 @@ description: >-
   NATS->Iceberg/serving dispatchers. ADRs agents/015 (Temporal worker pools) and
   platform/004 (Iceberg lakehouse + hot-swap Quack serving).
 type: application
-version: 0.1.1
+version: 0.1.2
 appVersion: "0.1.0"

--- a/projects/lakehouse/chart/templates/_helpers.tpl
+++ b/projects/lakehouse/chart/templates/_helpers.tpl
@@ -55,6 +55,17 @@ Usage:
 # /tmp emptyDir every pod mounts, so httpfs/iceberg/vss INSTALL/LOAD works.
 - name: HOME
   value: /tmp
+# pyiceberg's S3 FileIO uses pyarrow's AWS C++ SDK, which now defaults to adding
+# a streaming trailing checksum (aws-chunked / STREAMING-UNSIGNED-PAYLOAD-TRAILER)
+# on PUT. SeaweedFS does NOT decode that framing — it persists the literal chunk
+# headers ("88C\r\n{...}\r\n...chunk-signature\r\n\r\n") into the object body,
+# corrupting every metadata.json / data file pyiceberg writes (SeaweedFS #6847,
+# #6583). Force the SDK back to the pre-checksum behaviour so PUTs are plain.
+# DuckDB/httpfs and boto3 are unaffected; the vars are harmless for them.
+- name: AWS_REQUEST_CHECKSUM_CALCULATION
+  value: when_required
+- name: AWS_RESPONSE_CHECKSUM_VALIDATION
+  value: when_required
 {{- end -}}
 
 {{/*

--- a/projects/lakehouse/iceberg/catalog.py
+++ b/projects/lakehouse/iceberg/catalog.py
@@ -137,6 +137,16 @@ def catalog_config(env: Mapping[str, str] | None = None) -> dict[str, str]:
     env = os.environ if env is None else env
 
     endpoint = env.get("SEAWEEDFS_S3_ENDPOINT", DEFAULT_S3_ENDPOINT)
+    # pyiceberg hands ``s3.endpoint`` straight to pyarrow's S3FileSystem as
+    # ``endpoint_override`` with NO ``scheme`` kwarg, so pyarrow defaults to
+    # https. SeaweedFS S3 is plaintext HTTP, so a scheme-less endpoint triggers a
+    # TLS handshake against an HTTP server ("SSL routines::wrong version number").
+    # pyarrow honours a scheme embedded in endpoint_override, so ensure http://
+    # is present. The chart injects a scheme-less host:port shared with DuckDB
+    # (whose httpfs derives the scheme from USE_SSL instead), so the normalisation
+    # has to live here rather than in the shared env value.
+    if not endpoint.startswith(("http://", "https://")):
+        endpoint = "http://" + endpoint
     warehouse = env.get("ICEBERG_WAREHOUSE", DEFAULT_WAREHOUSE)
     catalog_uri = _catalog_uri(env)
     access_key = env.get("S3_ACCESS_KEY_ID", "")

--- a/projects/lakehouse/iceberg/catalog_test.py
+++ b/projects/lakehouse/iceberg/catalog_test.py
@@ -116,3 +116,29 @@ def test_sqlite_fallback_when_no_database_url():
     cfg = catalog_config(env={})
     assert cfg["type"] == "sql"
     assert cfg["uri"].startswith("sqlite://")
+
+
+def test_scheme_less_endpoint_gets_http_prefix():
+    """A scheme-less endpoint (the chart's shared host:port) is prefixed with
+    http:// — pyiceberg hands it to pyarrow which would otherwise default to
+    https and fail the TLS handshake against plaintext SeaweedFS."""
+    cfg = catalog_config(
+        env={"SEAWEEDFS_S3_ENDPOINT": "seaweedfs-s3.seaweedfs.svc.cluster.local:8333"}
+    )
+    assert cfg["s3.endpoint"] == "http://seaweedfs-s3.seaweedfs.svc.cluster.local:8333"
+
+
+def test_explicit_scheme_endpoint_is_preserved():
+    """An endpoint that already carries a scheme is left untouched (either scheme)."""
+    assert (
+        catalog_config(env={"SEAWEEDFS_S3_ENDPOINT": "https://s3.example:9000"})[
+            "s3.endpoint"
+        ]
+        == "https://s3.example:9000"
+    )
+    assert (
+        catalog_config(env={"SEAWEEDFS_S3_ENDPOINT": "http://s3.example:9000"})[
+            "s3.endpoint"
+        ]
+        == "http://s3.example:9000"
+    )

--- a/projects/lakehouse/iceberg/catalog_test.py
+++ b/projects/lakehouse/iceberg/catalog_test.py
@@ -121,11 +121,11 @@ def test_sqlite_fallback_when_no_database_url():
 def test_scheme_less_endpoint_gets_http_prefix():
     """A scheme-less endpoint (the chart's shared host:port) is prefixed with
     http:// — pyiceberg hands it to pyarrow which would otherwise default to
-    https and fail the TLS handshake against plaintext SeaweedFS."""
-    cfg = catalog_config(
-        env={"SEAWEEDFS_S3_ENDPOINT": "seaweedfs-s3.seaweedfs.svc.cluster.local:8333"}
-    )
-    assert cfg["s3.endpoint"] == "http://seaweedfs-s3.seaweedfs.svc.cluster.local:8333"
+    https and fail the TLS handshake against plaintext SeaweedFS. (A generic
+    host:port is used here rather than the real in-cluster service name so the
+    no-hardcoded-k8s-service-url lint stays happy.)"""
+    cfg = catalog_config(env={"SEAWEEDFS_S3_ENDPOINT": "s3-gateway:8333"})
+    assert cfg["s3.endpoint"] == "http://s3-gateway:8333"
 
 
 def test_explicit_scheme_endpoint_is_preserved():


### PR DESCRIPTION
## Problem

The NATS→Iceberg write reached S3 but every pyiceberg write was failing/corrupting against SeaweedFS — two stacked issues, both verified live in-cluster:

1. **TLS against a plaintext endpoint.** `catalog_config` passed a scheme-less `s3.endpoint`; pyiceberg hands it to pyarrow's `S3FileSystem` as `endpoint_override` with no `scheme` kwarg, so pyarrow defaults to **https**. SeaweedFS S3 is plaintext HTTP → `SSL routines::wrong version number`. (DuckDB works because httpfs derives the scheme from `USE_SSL false`.)

2. **`aws-chunked` framing persisted into objects.** pyarrow's AWS C++ SDK now defaults to a streaming trailing checksum (`STREAMING-UNSIGNED-PAYLOAD-TRAILER`). SeaweedFS doesn't decode it and stores the literal chunk framing — `88C\r\n{...}\r\n…chunk-signature\r\n\r\n` — so every written `metadata.json`/data file is invalid JSON (`TableMetadataWrapper … json_invalid`). Known SeaweedFS issue ([#6847](https://github.com/seaweedfs/seaweedfs/issues/6847), [#6583](https://github.com/seaweedfs/seaweedfs/issues/6583)).

## Fix

1. `catalog.py`: prepend `http://` to the endpoint when scheme-less (pyarrow honours a scheme embedded in `endpoint_override`). Leaves the DuckDB path's scheme-less value untouched.
2. `sharedEnv`: `AWS_REQUEST_CHECKSUM_CALCULATION` / `AWS_RESPONSE_CHECKSUM_VALIDATION = when_required` on all worker pods → plain-bodied PUTs.

**Verified in-cluster**: a pyarrow PUT to SeaweedFS with these env vars + `http://` endpoint, read back raw via boto3, returns byte-identical content (`CLEAN=True`). Tests added for the endpoint normalization. chart `0.1.1`→`0.1.2`.

## After merge

Re-trigger the commit workflow → `note_events` is created with clean metadata + data → `BuildServingArtifactWorkflow` → query Quack (criterion 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)