### PR TITLE
fix(lakehouse): parse occurred_at to datetime for pyarrow timestamp column

### DIFF
--- a/projects/lakehouse/orchestrator/workflows/iceberg_batch.py
+++ b/projects/lakehouse/orchestrator/workflows/iceberg_batch.py
@@ -35,7 +35,7 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass, field
-from datetime import timedelta
+from datetime import datetime, timedelta
 
 import temporalio.activity
 import temporalio.workflow
@@ -109,10 +109,17 @@ def _envelope_to_row(envelope: dict) -> dict:
     table; the ``payload`` dict's keys are spread into the payload columns. Keys
     the target table's schema doesn't declare are dropped by
     ``writer.rows_to_arrow`` (``pa.Table.from_pylist`` ignores extras), so a
-    superset payload is safe. ``occurred_at`` is left as the envelope's ISO
-    string; pyarrow casts it to the table's timestamptz column.
+    superset payload is safe. ``occurred_at`` arrives as an ISO-8601 string (the
+    envelope is dumped with ``mode="json"``) and is parsed to a timezone-aware
+    ``datetime`` here: pyarrow's ``timestamp[us, tz=UTC]`` column does NOT
+    auto-parse ISO strings — ``Table.from_pylist`` reads the string as an epoch
+    int and fails with "object of type 'str' cannot be converted to int".
     """
     payload = envelope.get("payload") or {}
+    occurred_at = envelope.get("occurred_at")
+    if isinstance(occurred_at, str):
+        # datetime.fromisoformat handles the trailing 'Z' on Python 3.11+.
+        occurred_at = datetime.fromisoformat(occurred_at)
     row = {
         "schema_version": envelope.get("schema_version"),
         "entity_type": envelope.get("entity_type"),
@@ -120,7 +127,7 @@ def _envelope_to_row(envelope: dict) -> dict:
         "event_type": envelope.get("event_type"),
         "event_version": envelope.get("event_version"),
         "event_id": envelope.get("event_id"),
-        "occurred_at": envelope.get("occurred_at"),
+        "occurred_at": occurred_at,
         "producer": envelope.get("producer"),
         "correlation_id": envelope.get("correlation_id"),
         "caused_by": envelope.get("caused_by"),

--- a/projects/lakehouse/orchestrator/workflows/iceberg_batch_test.py
+++ b/projects/lakehouse/orchestrator/workflows/iceberg_batch_test.py
@@ -10,6 +10,7 @@ because it downloads a server binary.
 from __future__ import annotations
 
 import json
+from datetime import datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -91,6 +92,9 @@ def test_envelope_to_row_spreads_payload_and_envelope() -> None:
     assert row["note_id"] == "n1"
     assert row["title"] == "t"
     assert row["embedding"] == [0.1, 0.2]
+    # occurred_at is parsed from the ISO string to a datetime so pyarrow's
+    # timestamptz column accepts it (from_pylist won't parse ISO strings).
+    assert isinstance(row["occurred_at"], datetime)
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Problem

With the SeaweedFS S3 write fixed (#2425), `IcebergBatchCommitWorkflow` got further — `create_table` wrote clean metadata — but `append` failed in `rows_to_arrow`:

```
pyarrow.lib.ArrowTypeError: object of type <class 'str'> cannot be converted to int
  at append_events -> rows_to_arrow -> pa.Table.from_pylist(rows, schema=arrow_schema)
```

Pinpointed (via a real NATS event peeked in-cluster) to **`occurred_at`**: `_envelope_to_row` left it as the envelope's ISO-8601 string, but the arrow column is `timestamp[us, tz=UTC]`. `from_pylist` doesn't parse ISO strings into timestamps — it reads the string as an epoch int and fails.

## Fix

Parse `occurred_at` to a tz-aware `datetime` in `_envelope_to_row` (`fromisoformat`, module-level import to satisfy `no-inline-stdlib-import`). **Verified in-cluster**: a real note event now converts to a 23-column arrow table with a proper `timestamp[us, tz=UTC]` `occurred_at`. Added a test assertion.

## After merge

Restart the worker → re-run the commit → `note_events` data lands in S3 → `BuildServingArtifactWorkflow` → query Quack (criterion 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)