### PR TITLE
fix(lakehouse): enable persistent HNSW for on-disk serving artifact

### DIFF
--- a/projects/lakehouse/duckdb_query/query.py
+++ b/projects/lakehouse/duckdb_query/query.py
@@ -227,6 +227,14 @@ def connect(
 
     con.execute(f"SET ca_cert_file = '{certifi.where()}'")
     load_extensions(con, env=env)
+    # The serving artifact persists a VSS HNSW index inside an on-disk .duckdb,
+    # and Quack ATTACHes that file to query it. Both the build (CREATE INDEX ...
+    # USING HNSW on the attached on-disk DB) and Quack's read require DuckDB's
+    # experimental persistent-HNSW flag — platform/004 §hot-swap deliberately
+    # ships a persistent HNSW serving artifact. Without it the index build raises
+    # "HNSW indexes can only be created in in-memory databases". Set after
+    # load_extensions since the vss extension registers this option.
+    con.execute("SET hnsw_enable_experimental_persistence = true;")
     con.execute(s3_secret_sql(env))
     if read_only_artifact is not None:
         con.execute(attach_or_replace_sql("notes", read_only_artifact))


### PR DESCRIPTION
## Problem

`BuildServingArtifactWorkflow` read `note_events` via the catalog + DuckDB and ran the current-version fold, then failed on the VSS index:

```
_duckdb.BinderException: HNSW indexes can only be created in in-memory databases,
or when 'hnsw_enable_experimental_persistence' is set to true.
```

The serving artifact is an **on-disk** `.duckdb` (platform/004 §hot-swap deliberately ships a persistent HNSW index), and Quack ATTACHes it to query — so both the build and Quack's read require DuckDB's experimental persistent-HNSW flag.

## Fix

Set `hnsw_enable_experimental_persistence = true` in `duckdb_query.connect` (after the vss extension loads). Covers both the build (CREATE INDEX) and Quack (read). **Verified in-cluster**: attaching an on-disk DB and creating a HNSW index succeeds with the flag.

## Progress so far

PG→NATS ✅, NATS→Iceberg ✅ (`note_events` has 3 parquet data files committed). This unblocks the serving build; then the Quack query closes criterion 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)