### PR TITLE
fix(lakehouse): explode chunks into per-chunk rows + cast embedding to FLOAT[N]

### DIFF
--- a/projects/lakehouse/orchestrator/workflows/build_serving.py
+++ b/projects/lakehouse/orchestrator/workflows/build_serving.py
@@ -73,6 +73,15 @@ ICEBERG_NAMESPACE = "knowledge"
 SERVING_SCHEMA = "main"
 SERVING_TABLE = "chunks"
 
+# Embedding dimensionality of the knowledge corpus (the monolith's embedding
+# model). The note_events ``embedding`` column is an Iceberg ``list<float>`` →
+# DuckDB reads it as a variable-length ``FLOAT[]``, but a VSS HNSW index requires
+# a fixed-size ``FLOAT[N]`` key. The chunks-build CAST pins it to this N so the
+# index can be created. All live embeddings share this dimension (single model);
+# a row of a different length would fail the CAST loudly rather than silently
+# corrupt the index.
+EMBEDDING_DIM = 1024
+
 # Serving-artifact-ready event (platform/004 §hot-swap trigger). Published on an
 # explicit subject — NOT one of the events.knowledge.* entity subjects — so it is
 # routed to the Quack swap consumer, not back into the Iceberg drainer.
@@ -128,7 +137,7 @@ current_rows AS (
       ON e.note_id = l.note_id
      AND e.event_version = l.max_version
 )
-SELECT *
+SELECT * EXCLUDE (embedding), CAST(embedding AS FLOAT[{embedding_dim}]) AS embedding
 FROM current_rows
 WHERE event_type <> 'tombstoned'
   AND embedding IS NOT NULL;
@@ -200,6 +209,7 @@ async def build_artifact(version: int) -> BuildResult:
                 schema=f"artifact.{SERVING_SCHEMA}",
                 table=SERVING_TABLE,
                 source_uri=source_uri,
+                embedding_dim=EMBEDDING_DIM,
             )
             con.execute(build_chunks)
             con.execute(

--- a/projects/lakehouse/orchestrator/workflows/build_serving_test.py
+++ b/projects/lakehouse/orchestrator/workflows/build_serving_test.py
@@ -53,6 +53,7 @@ def test_build_chunks_sql_applies_current_version_filter() -> None:
         schema="artifact.main",
         table="chunks",
         source_uri="s3://warehouse/knowledge/note_events",
+        embedding_dim=1024,
     )
     # Latest-version fold: MAX(event_version) per note_id, joined back.
     assert "MAX(event_version)" in sql
@@ -63,6 +64,9 @@ def test_build_chunks_sql_applies_current_version_filter() -> None:
     assert "embedding IS NOT NULL" in sql
     # Reads the Iceberg snapshot, not a raw parquet path.
     assert "iceberg_scan('s3://warehouse/knowledge/note_events')" in sql
+    # embedding is cast from variable FLOAT[] to fixed FLOAT[N] so the HNSW
+    # index can be built over it.
+    assert "CAST(embedding AS FLOAT[1024])" in sql
 
 
 def test_build_hnsw_sql_indexes_embedding() -> None:

--- a/projects/lakehouse/orchestrator/workflows/iceberg_batch.py
+++ b/projects/lakehouse/orchestrator/workflows/iceberg_batch.py
@@ -102,25 +102,37 @@ class DrainResult:
     empty: bool = False
 
 
-def _envelope_to_row(envelope: dict) -> dict:
-    """Flatten an :class:`EventEnvelope` dict into an Iceberg row dict.
+def _envelope_to_rows(envelope: dict) -> list[dict]:
+    """Flatten an :class:`EventEnvelope` dict into one or more Iceberg row dicts.
 
     Envelope fields map 1:1 to the envelope columns shared by every ``*_events``
-    table; the ``payload`` dict's keys are spread into the payload columns. Keys
-    the target table's schema doesn't declare are dropped by
-    ``writer.rows_to_arrow`` (``pa.Table.from_pylist`` ignores extras), so a
-    superset payload is safe. ``occurred_at`` arrives as an ISO-8601 string (the
-    envelope is dumped with ``mode="json"``) and is parsed to a timezone-aware
-    ``datetime`` here: pyarrow's ``timestamp[us, tz=UTC]`` column does NOT
-    auto-parse ISO strings — ``Table.from_pylist`` reads the string as an epoch
-    int and fails with "object of type 'str' cannot be converted to int".
+    table; the payload's note-level keys spread into the payload columns. Keys the
+    target schema doesn't declare are dropped by ``writer.rows_to_arrow``
+    (``pa.Table.from_pylist`` ignores extras), so a superset payload is safe.
+
+    EXPLOSION: the ``note_events`` schema is flat *per chunk* — ``embedding``,
+    ``chunk_text``, ``chunk_index`` and ``section_header`` are columns, not a
+    nested list — but a ``NoteCreated`` payload carries its chunks as a nested
+    ``chunks`` list. This therefore emits **one row per chunk**, repeating the
+    note-level columns, and lifts each chunk's fields up to the flat columns.
+    Without the explode ``from_pylist`` silently drops the nested ``chunks`` list
+    and every chunk column lands NULL, leaving the serving build with zero
+    indexable vectors. A payload with no ``chunks`` (gap_events, or a chunkless
+    note) yields a single row with null chunk columns.
+
+    ``occurred_at`` arrives as an ISO-8601 string (the envelope is dumped with
+    ``mode="json"``) and is parsed to a timezone-aware ``datetime``: pyarrow's
+    ``timestamp[us, tz=UTC]`` column does NOT auto-parse ISO strings —
+    ``from_pylist`` reads the string as an epoch int and fails with "object of
+    type 'str' cannot be converted to int".
     """
-    payload = envelope.get("payload") or {}
+    payload = dict(envelope.get("payload") or {})
+    chunks = payload.pop("chunks", None) or []
     occurred_at = envelope.get("occurred_at")
     if isinstance(occurred_at, str):
         # datetime.fromisoformat handles the trailing 'Z' on Python 3.11+.
         occurred_at = datetime.fromisoformat(occurred_at)
-    row = {
+    base = {
         "schema_version": envelope.get("schema_version"),
         "entity_type": envelope.get("entity_type"),
         "entity_id": envelope.get("entity_id"),
@@ -132,10 +144,19 @@ def _envelope_to_row(envelope: dict) -> dict:
         "correlation_id": envelope.get("correlation_id"),
         "caused_by": envelope.get("caused_by"),
     }
-    # Spread payload columns (note_id, path, embedding, topic, gap_class, ...).
-    # rows_to_arrow drops any key not in the target schema.
-    row.update(payload)
-    return row
+    # Note-level payload columns (note_id, path, title, ... — chunks popped out).
+    base.update(payload)
+    if not chunks:
+        return [base]
+    rows = []
+    for chunk in chunks:
+        row = dict(base)
+        row["chunk_index"] = chunk.get("chunk_index")
+        row["section_header"] = chunk.get("section_header")
+        row["chunk_text"] = chunk.get("chunk_text")
+        row["embedding"] = chunk.get("embedding")
+        rows.append(row)
+    return rows
 
 
 def _load_or_create_table(catalog, namespace: str, table_name: str):
@@ -221,8 +242,9 @@ async def drain_and_commit() -> DrainResult:
                 # a redelivering message that ops can investigate.
                 skipped += 1
                 continue
-            rows_by_table.setdefault(table, []).append(
-                _envelope_to_row(envelope.model_dump(mode="json"))
+            # One event explodes into one row per chunk (see _envelope_to_rows).
+            rows_by_table.setdefault(table, []).extend(
+                _envelope_to_rows(envelope.model_dump(mode="json"))
             )
             msgs_by_table.setdefault(table, []).append(msg)
 

--- a/projects/lakehouse/orchestrator/workflows/iceberg_batch_test.py
+++ b/projects/lakehouse/orchestrator/workflows/iceberg_batch_test.py
@@ -81,9 +81,12 @@ def test_table_by_entity_matches_publish_subjects() -> None:
         assert entity_type in SUBJECT_BY_ENTITY
 
 
-def test_envelope_to_row_spreads_payload_and_envelope() -> None:
+def test_envelope_to_rows_spreads_payload_and_envelope() -> None:
     env = _note_envelope()
-    row = mod._envelope_to_row(json.loads(env.model_dump_json()))
+    rows = mod._envelope_to_rows(json.loads(env.model_dump_json()))
+    # A chunkless payload yields exactly one row.
+    assert len(rows) == 1
+    row = rows[0]
     # Envelope columns present.
     assert row["entity_type"] == "note"
     assert row["entity_id"] == "n1"
@@ -95,6 +98,47 @@ def test_envelope_to_row_spreads_payload_and_envelope() -> None:
     # occurred_at is parsed from the ISO string to a datetime so pyarrow's
     # timestamptz column accepts it (from_pylist won't parse ISO strings).
     assert isinstance(row["occurred_at"], datetime)
+
+
+def test_envelope_to_rows_explodes_chunks() -> None:
+    """A NoteCreated payload carries chunks as a nested list; the flat note_events
+    schema is per-chunk, so each chunk becomes its own row with the note-level
+    columns repeated and the chunk's fields lifted to the flat columns."""
+    env = build_envelope(
+        entity_type="note",
+        entity_id="n2",
+        event_type="created",
+        event_version=3,
+        producer="test",
+        payload={
+            "note_id": "n2",
+            "path": "_processed/x.md",
+            "title": "X",
+            "chunks": [
+                {
+                    "chunk_index": 0,
+                    "section_header": "Intro",
+                    "chunk_text": "hello",
+                    "embedding": [0.1, 0.2],
+                },
+                {
+                    "chunk_index": 1,
+                    "section_header": "Body",
+                    "chunk_text": "world",
+                    "embedding": [0.3, 0.4],
+                },
+            ],
+        },
+    )
+    rows = mod._envelope_to_rows(json.loads(env.model_dump_json()))
+    assert len(rows) == 2
+    # Note-level columns repeated; the nested chunks list is NOT a column.
+    assert all(r["note_id"] == "n2" and r["path"] == "_processed/x.md" for r in rows)
+    assert all("chunks" not in r for r in rows)
+    # Each chunk's fields are lifted to the flat per-chunk columns.
+    assert [r["chunk_index"] for r in rows] == [0, 1]
+    assert [r["embedding"] for r in rows] == [[0.1, 0.2], [0.3, 0.4]]
+    assert [r["chunk_text"] for r in rows] == ["hello", "world"]
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Problem

The serving build produced an **empty** artifact (0 indexable rows). Two stacked bugs in the embedding flow, both confirmed in-cluster:

1. **Chunk data dropped on write.** `_envelope_to_row` emitted one row per note event with the payload's `chunks` as a *nested* list. The `note_events` schema is flat *per chunk* (`embedding`/`chunk_text`/`chunk_index`/`section_header` are columns), so `pa.Table.from_pylist` silently dropped the nested list — verified: `note_events` had **1190 rows, 0 non-null embeddings**.
2. **HNSW needs fixed-size vectors.** `embedding` is an Iceberg `list<float>` → DuckDB reads it as variable `FLOAT[]`, but HNSW requires `FLOAT[N]`.

## Fix

1. `_envelope_to_row` → `_envelope_to_rows`: **explode** each event into one row per chunk, lifting chunk fields to the flat columns; `drain_and_commit` extends. Chunkless payloads (gap_events) → one row.
2. `build_serving` CASTs `embedding` to `FLOAT[EMBEDDING_DIM]` (1024) in the chunks build (`SELECT * EXCLUDE (embedding), CAST(...)`).

**Verified in-cluster**: real note events carry chunks with 1024-dim embeddings; the cast + HNSW build succeed. Tests updated (explode + cast).

## After merge

Reset `note_events` (drop the embeddingless rows), re-run backfill → per-chunk rows with embeddings → serving build → query Quack (criterion 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)