### PR TITLE
fix(lakehouse): http:// scheme for boto3 serving-artifact upload

### DIFF
--- a/projects/lakehouse/orchestrator/workflows/build_serving.py
+++ b/projects/lakehouse/orchestrator/workflows/build_serving.py
@@ -276,6 +276,12 @@ def _s3_client():
     from botocore.config import Config
 
     endpoint = os.environ.get("SEAWEEDFS_S3_ENDPOINT", DEFAULT_S3_ENDPOINT)
+    # The chart injects a scheme-less host:port (shared with DuckDB's httpfs,
+    # which derives the scheme from USE_SSL). boto3 requires a scheme on
+    # endpoint_url and raises "Invalid endpoint" otherwise; SeaweedFS S3 is
+    # plaintext HTTP, so prefix http:// when absent.
+    if not endpoint.startswith(("http://", "https://")):
+        endpoint = "http://" + endpoint
     return boto3.client(
         "s3",
         endpoint_url=endpoint,

--- a/projects/lakehouse/orchestrator/workflows/build_serving_test.py
+++ b/projects/lakehouse/orchestrator/workflows/build_serving_test.py
@@ -192,3 +192,24 @@ def test_s3_client_uses_path_style_and_env_endpoint() -> None:
     assert created["kwargs"]["endpoint_url"] == "http://sw:8333"
     cfg = created["kwargs"]["config"]
     assert cfg.s3["addressing_style"] == "path"
+
+
+def test_s3_client_prefixes_http_for_scheme_less_endpoint() -> None:
+    """The chart injects a scheme-less host:port (shared with DuckDB); boto3
+    needs a scheme on endpoint_url, so _s3_client prefixes http://."""
+    created = {}
+
+    fake_boto3 = MagicMock()
+    fake_boto3.client.side_effect = lambda service, **kw: (
+        created.update(kw) or MagicMock()
+    )
+
+    with (
+        patch.dict(
+            "os.environ", {"SEAWEEDFS_S3_ENDPOINT": "sw-gateway:8333"}, clear=False
+        ),
+        patch.dict("sys.modules", {"boto3": fake_boto3}),
+    ):
+        mod._s3_client()
+
+    assert created["endpoint_url"] == "http://sw-gateway:8333"


### PR DESCRIPTION
Last serving-leg gap: BuildServingArtifactWorkflow builds the chunks table + FLOAT[1024] HNSW index over 3431 real chunk rows, then fails uploading because _s3_client passed the chart's scheme-less SEAWEEDFS_S3_ENDPOINT to boto3 (ValueError: Invalid endpoint). Prefix http:// when no scheme (same as iceberg.catalog; SeaweedFS is plaintext). AWS_REQUEST_CHECKSUM_CALCULATION already keeps boto3 PUTs plain-bodied.

After merge: re-run serving build → artifact in s3://warehouse/serving/ → query Quack (criterion 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)