### PR TITLE
fix(lakehouse): pytz for DuckDB tz-timestamp fetch (Quack /search)

### DIFF
--- a/projects/lakehouse/duckdb_query/BUILD
+++ b/projects/lakehouse/duckdb_query/BUILD
@@ -20,6 +20,12 @@ py_library(
     deps = [
         "@pip//certifi",
         "@pip//duckdb",
+        # DuckDB's Python client imports pytz LAZILY when converting a
+        # TIMESTAMP WITH TIME ZONE column (note_events.occurred_at, tz=UTC) to a
+        # Python datetime on fetch — e.g. Quack's `SELECT *` /search. The minimal
+        # image has no pytz, so the fetch raises "No module named 'pytz'".
+        # `# keep`: no static import for gazelle to see.
+        "@pip//pytz",  # keep
     ],
 )
 


### PR DESCRIPTION
Quack /search 500'd with "Required module 'pytz' failed to import". DuckDB's Python client uses pytz to convert a TIMESTAMP WITH TIME ZONE column (note_events.occurred_at, tz=UTC) to a Python datetime on fetch, and /search does SELECT *. Add @pip//pytz (in the lock) as a # keep dep on duckdb_query.

tzdata covered the write side (zoneinfo); pytz covers the DuckDB→Python read side. This is the last fetch-path gap — the casted VSS query already returns _processed notes at the data layer; this makes Quack's HTTP /search return them too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)