### PR TITLE
feat(lakehouse): publish chart as OCI + pin image digests

### DIFF
--- a/bazel/images/BUILD
+++ b/bazel/images/BUILD
@@ -51,6 +51,7 @@ multirun(
         "//projects/grimoire/frontend:image.push",
         "//projects/grimoire/ws-gateway:image.push",
         "//projects/hikes/update_forecast:update_image.push",
+        "//projects/lakehouse/chart:chart.push",
         "//projects/lakehouse/dispatchers:image.push",
         "//projects/lakehouse/image:image.push",
         "//projects/lakehouse/quack-server:image.push",

--- a/projects/lakehouse/chart/BUILD
+++ b/projects/lakehouse/chart/BUILD
@@ -9,18 +9,26 @@ load("//bazel/helm:defs.bzl", "helm_chart")
 # tell gazelle to leave them alone.
 #
 # Helm chart for the event-sourced lakehouse worker/quack/dispatcher Deployments
-# + KEDA scalers (ADRs agents/015, platform/004). AUTHOR-ONLY this wavefront:
-# CI-validated via helm_template_test / semgrep_manifest_test (see
-# ../deploy:lakehouse) but NOT published or wired into ArgoCD yet.
+# + KEDA scalers (ADRs agents/015, platform/004). Published as an OCI chart and
+# wired into ArgoCD (../deploy:lakehouse); CI-validated via helm_template_test /
+# semgrep_manifest_test.
 #
-# No `images=` pinning here: the dispatchers image is a sibling W4 unit not yet
-# built in this branch, and helm_images_values requires every referenced
-# image .info target to exist. The orchestrator adds image pinning when it wires
-# the chart (worker -> //projects/lakehouse/image:image.info, quack ->
-# //projects/lakehouse/quack-server:image.info, dispatchers -> its target).
+# `images=` + `publish=True` make CI (a) deep-merge each image's CI-stamped tag
+# into the packaged chart's values.yaml at build time (helm_images_values — the
+# OCI chart ships digest-pinned; never hand-edit `@sha256:` into values) and
+# (b) push the chart to ghcr.io/jomcgi/homelab/charts by its Chart.yaml version.
+# All three image `.info` targets now exist (worker / quack-server / dispatchers).
+# NOTE: ../deploy/values.yaml must NOT set `image.tag` or the git overlay clobbers
+# the pin (Helm valueFiles are last-wins over the packaged base).
 helm_chart(
     name = "chart",
+    images = {
+        "worker.image": "//projects/lakehouse/image:image.info",
+        "quack.image": "//projects/lakehouse/quack-server:image.info",
+        "dispatchers.image": "//projects/lakehouse/dispatchers:image.info",
+    },
     lint = False,
+    publish = True,
     # //projects/lakehouse:__subpackages__ so the separate deploy/ package's
     # argocd_app (which references //projects/lakehouse/chart:chart) can see the
     # chart filegroup; //overlays for the historical overlay rendering.

--- a/projects/lakehouse/chart/Chart.yaml
+++ b/projects/lakehouse/chart/Chart.yaml
@@ -6,5 +6,5 @@ description: >-
   NATS->Iceberg/serving dispatchers. ADRs agents/015 (Temporal worker pools) and
   platform/004 (Iceberg lakehouse + hot-swap Quack serving).
 type: application
-version: 0.1.2
+version: 0.2.0
 appVersion: "0.1.0"

--- a/projects/lakehouse/deploy/BUILD
+++ b/projects/lakehouse/deploy/BUILD
@@ -6,10 +6,14 @@ load("//bazel/helm:defs.bzl", "argocd_app")
 # this argocd_app without our semgrep_exclude_rules and would not fix the chart's
 # cross-package visibility, so we keep both BUILDs out of gazelle's hands.
 #
-# Path-based ArgoCD Application for the event-sourced lakehouse worker/quack/
-# dispatcher Deployments + KEDA scalers. Hand-written (not left to gazelle) so we
-# can carry semgrep_exclude_rules — gazelle's helm extension manages only chart/
-# chart_files/release_name/namespace/values_files/tags and preserves this attr.
+# OCI-sourced ArgoCD Application for the event-sourced lakehouse worker/quack/
+# dispatcher Deployments + KEDA scalers (application.yaml pulls the chart from
+# ghcr.io/jomcgi/homelab/charts by version). This argocd_app target only renders
+# the LOCAL chart for CI validation (helm_template_test / semgrep_manifest_test) —
+# chart/chart_files/values_files stay path-local regardless of how the deployed
+# Application sources the chart. Hand-written (not left to gazelle) so we can carry
+# semgrep_exclude_rules — gazelle's helm extension manages only chart/chart_files/
+# release_name/namespace/values_files/tags and preserves this attr.
 #
 # require-readiness-probe: the gap-drain / iceberg-builder / housekeeping worker
 # pods and the dispatcher pods are Temporal task-queue pollers / NATS consumers

--- a/projects/lakehouse/deploy/application.yaml
+++ b/projects/lakehouse/deploy/application.yaml
@@ -11,16 +11,25 @@ metadata:
     argocd.argoproj.io/sync-wave: "3"
 spec:
   project: default
-  source:
-    repoURL: https://github.com/jomcgi/homelab.git
-    path: projects/lakehouse/chart
-    targetRevision: HEAD
-    helm:
-      releaseName: lakehouse
-      valueFiles:
-        # Chart defaults, then environment-specific overrides from deploy/.
-        - values.yaml
-        - ../deploy/values.yaml
+  sources:
+    # Chart from the OCI registry (pushed by CI via Bazel helm_push), digest-pinned
+    # at build time by helm_images_values. targetRevision is the Chart.yaml semver;
+    # CI keeps it in sync on version bumps. Pulling by version (not the `:main`
+    # path at HEAD) is what makes the merge of new images actually roll the pods.
+    - repoURL: ghcr.io/jomcgi/homelab/charts
+      chart: lakehouse
+      targetRevision: 0.2.0
+      helm:
+        releaseName: lakehouse
+        # The chart's packaged values.yaml (with pinned image tags) is the base;
+        # this overlay adds environment-specific overrides — and must NOT set
+        # image.tag, or it would clobber the pin.
+        valueFiles:
+          - $values/projects/lakehouse/deploy/values.yaml
+    # Git repo, referenced as $values above, for the environment-specific overlay.
+    - repoURL: https://github.com/jomcgi/homelab.git
+      targetRevision: HEAD
+      ref: values
   destination:
     server: https://kubernetes.default.svc
     namespace: lakehouse

--- a/projects/lakehouse/deploy/values.yaml
+++ b/projects/lakehouse/deploy/values.yaml
@@ -1,21 +1,19 @@
-# Environment-specific overrides for the lakehouse chart (layered on top of
-# projects/lakehouse/chart/values.yaml). AUTHOR-ONLY this wavefront: the chart
-# is CI-validated but NOT wired into ArgoCD; the orchestrator enables it after
-# live Wavefront-1 verification. The 1Password itemPaths below are MANUAL
+# Environment-specific overrides for the lakehouse chart, layered on top of the
+# OCI chart's packaged values.yaml. The 1Password itemPaths below are MANUAL
 # PREREQUISITES -- the items must exist and be populated before the housekeeping
 # worker can read PG and before the Quack /search token is enforced.
 
-# Pin the worker/quack/dispatcher images to the live tag. The Bazel image
-# pipeline manages digest pinning at build time; leave repository defaults.
+# Image tags are deliberately NOT set here. The OCI chart is digest-pinned at
+# build time (helm_images_values bakes the CI-stamped tag into the packaged
+# values.yaml), and this overlay is applied AFTER that base (Helm valueFiles are
+# last-wins), so a `tag:` here would silently un-pin the images. Only pullPolicy
+# is overridden — Always re-pulls defensively on restart, harmless now that the
+# pinned tag is immutable.
 worker:
   image:
-    tag: main
-    # `main` is mutable (re-pushed each merge) and this path-based chart isn't
-    # digest-pinned, so Always ensures restarted pods pull CI rebuilds.
     pullPolicy: Always
 quack:
   image:
-    tag: main
     pullPolicy: Always
   # Front the read path with Cloudflare CDN once the public hostname is live.
   cfIngress:
@@ -26,7 +24,6 @@ quack:
     onepasswordItemPath: vaults/k8s-homelab/items/lakehouse-quack-query-token
 dispatchers:
   image:
-    tag: main
     pullPolicy: Always
 
 # PG backfill credential is cloned by Kyverno (clone-monolith-pg-app) from


### PR DESCRIPTION
The lakehouse chart tracked the floating `:main` tag via a **path-based** ArgoCD source with **no Image Updater and no digest pin**. ArgoCD only syncs on manifest changes, so a merge that rebuilt the worker/quack/dispatcher images never rolled the running pods — which is why #2435's serving fixes (HNSW, fan-out hot-swap, schedule seeding) merged but never deployed.

This wires the same digest-pinning + OCI-chart flow the **monolith** and **ships** charts use.

## Changes
- **`chart/BUILD`** — add `images = {worker, quack, dispatchers → :image.info}` + `publish = True`. CI now (a) deep-merges each image's CI-stamped tag into the packaged chart's `values.yaml` via `helm_images_values` (digest-pinned; never hand-edit `@sha256:`) and (b) pushes the chart to `ghcr.io/jomcgi/homelab/charts` by Chart.yaml version.
- **`deploy/application.yaml`** — path-based `source` → OCI `sources` (`chart: lakehouse`, `targetRevision: 0.2.0`) + a git `$values` source for the env overlay. Pulling **by version** is what makes a new image roll the pods.
- **`deploy/values.yaml`** — drop the `image.tag: main` overrides. The overlay is applied *after* the packaged (pinned) base and Helm valueFiles are last-wins, so a `tag:` here would silently un-pin. `pullPolicy` kept.
- **`Chart.yaml`** — `0.1.2 → 0.2.0`.
- **`bazel/images:push_all`** — regenerated (via `generate-push-all.sh`) to include `//projects/lakehouse/chart:chart.push`.

## Effect
After merge, CI publishes `lakehouse` `0.2.0` to OCI with pinned images, and ArgoCD rolls the pods onto the **post-#2435** build: HNSW engaged on `/search`, per-pod fan-out hot-swap (all replicas swap), and the four Temporal schedules registered. The empty `temporal schedule list` baseline should then flip.

## Verification plan (post-merge)
1. CI `push_all` publishes the OCI chart + images.
2. ArgoCD syncs lakehouse to `0.2.0`; Quack/worker pods roll to the pinned image.
3. `temporal schedule list` shows the 4 schedules; `/search` latency drops (HNSW); both Quack pods report the swapped artifact version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)