### PR TITLE
test(lakehouse): add missing coverage for dispatchers, registry, tables, and schedules

### DIFF
--- a/projects/lakehouse/dispatchers/BUILD
+++ b/projects/lakehouse/dispatchers/BUILD
@@ -87,6 +87,7 @@ py_test(
     deps = [
         ":dispatchers",
         "//projects/lakehouse/events",
+        "//projects/lakehouse/orchestrator",
         "@pip//pytest",
         "@pip//temporalio",
     ],

--- a/projects/lakehouse/dispatchers/dispatchers_test.py
+++ b/projects/lakehouse/dispatchers/dispatchers_test.py
@@ -375,7 +375,9 @@ def test_artifact_ready_logs_path_fallback(caplog):
         producer="lakehouse.build_serving",
         payload={"path": "/data/serving/v6.duckdb", "version": "v6"},
     )
-    with caplog.at_level(logging.INFO, logger="projects.lakehouse.dispatchers.artifact_ready"):
+    with caplog.at_level(
+        logging.INFO, logger="projects.lakehouse.dispatchers.artifact_ready"
+    ):
         asyncio.run(artifact_ready.handle_artifact_ready(envelope, client))
 
     assert "/data/serving/v6.duckdb" in caplog.text
@@ -395,7 +397,9 @@ def test_artifact_ready_logs_empty_payload(caplog):
         producer="lakehouse.build_serving",
         payload={},
     )
-    with caplog.at_level(logging.INFO, logger="projects.lakehouse.dispatchers.artifact_ready"):
+    with caplog.at_level(
+        logging.INFO, logger="projects.lakehouse.dispatchers.artifact_ready"
+    ):
         asyncio.run(artifact_ready.handle_artifact_ready(envelope, client))
 
     assert "artifact-empty" in caplog.text

--- a/projects/lakehouse/dispatchers/dispatchers_test.py
+++ b/projects/lakehouse/dispatchers/dispatchers_test.py
@@ -9,6 +9,7 @@ Coroutines are driven with ``asyncio.run``. The only real Temporal symbol used i
 from __future__ import annotations
 
 import asyncio
+import logging
 
 import pytest
 from temporalio.exceptions import WorkflowAlreadyStartedError
@@ -364,8 +365,6 @@ def test_artifact_ready_module_constants():
 
 def test_artifact_ready_logs_path_fallback(caplog):
     """handle_artifact_ready falls back to 'path' when 'artifact_url' is absent."""
-    import logging
-
     client = FakeTemporalClient()
     envelope = build_envelope(
         entity_type="serving-artifact",
@@ -386,8 +385,6 @@ def test_artifact_ready_logs_path_fallback(caplog):
 
 def test_artifact_ready_logs_empty_payload(caplog):
     """handle_artifact_ready handles an empty payload dict without error."""
-    import logging
-
     client = FakeTemporalClient()
     envelope = build_envelope(
         entity_type="serving-artifact",

--- a/projects/lakehouse/dispatchers/dispatchers_test.py
+++ b/projects/lakehouse/dispatchers/dispatchers_test.py
@@ -350,3 +350,147 @@ def test_run_no_dispatchers_is_a_noop():
     # No dispatchers -> no subscriptions, returns immediately.
     asyncio.run(run.run(dispatchers=[], nats_client=nats, temporal_client=client))
     assert nats.subscribed == []
+
+
+# --- artifact_ready module constants --------------------------------------
+
+
+def test_artifact_ready_module_constants():
+    assert artifact_ready.SUBJECT == "events.serving.artifact-ready"
+    assert artifact_ready.DURABLE == "artifact-ready-dispatcher"
+    # The DURABLE must not collide with quack-server's swap durable.
+    assert artifact_ready.DURABLE != "quack-serving-swap"
+
+
+def test_artifact_ready_logs_path_fallback(caplog):
+    """handle_artifact_ready falls back to 'path' when 'artifact_url' is absent."""
+    import logging
+
+    client = FakeTemporalClient()
+    envelope = build_envelope(
+        entity_type="serving-artifact",
+        entity_id="artifact-2026-05-31",
+        event_type="created",
+        event_version=1,
+        producer="lakehouse.build_serving",
+        payload={"path": "/data/serving/v6.duckdb", "version": "v6"},
+    )
+    with caplog.at_level(logging.INFO, logger="projects.lakehouse.dispatchers.artifact_ready"):
+        asyncio.run(artifact_ready.handle_artifact_ready(envelope, client))
+
+    assert "/data/serving/v6.duckdb" in caplog.text
+    assert client.calls == []  # still a stub — no workflow started
+
+
+def test_artifact_ready_logs_empty_payload(caplog):
+    """handle_artifact_ready handles an empty payload dict without error."""
+    import logging
+
+    client = FakeTemporalClient()
+    envelope = build_envelope(
+        entity_type="serving-artifact",
+        entity_id="artifact-empty",
+        event_type="created",
+        event_version=1,
+        producer="lakehouse.build_serving",
+        payload={},
+    )
+    with caplog.at_level(logging.INFO, logger="projects.lakehouse.dispatchers.artifact_ready"):
+        asyncio.run(artifact_ready.handle_artifact_ready(envelope, client))
+
+    assert "artifact-empty" in caplog.text
+    assert client.calls == []
+
+
+# --- gap_ready module constants -------------------------------------------
+
+
+def test_gap_ready_module_constants():
+    from projects.lakehouse.orchestrator import TaskQueue
+
+    assert gap_ready.SUBJECT == "events.knowledge.gap"
+    assert gap_ready.DURABLE == "gap-drain-dispatcher"
+    assert gap_ready.TRIGGER_EVENT_TYPE == "created"
+    assert gap_ready.WORKFLOW_TYPE == "GapDrainWorkflow"
+    assert gap_ready.TASK_QUEUE == TaskQueue.GAP_DRAIN.value  # "gap-drain"
+    assert gap_ready.WORKFLOW_ID_PREFIX == "gap-drain-"
+
+
+# --- run module constants -------------------------------------------------
+
+
+def test_run_poll_timeout_constant():
+    assert run.POLL_TIMEOUT == 5.0
+
+
+# --- run_dispatcher_loop (direct) -----------------------------------------
+
+
+def test_run_dispatcher_loop_dispatches_batch_and_acks():
+    """run_dispatcher_loop processes a single batch then idles."""
+    gap_d = gap_ready.DISPATCHERS[0]
+    msg = FakeMsg(_raw(_gap_envelope("55", "created")))
+    sub = FakeSubscription([[msg]])
+    client = FakeTemporalClient()
+
+    async def drive():
+        stop = asyncio.Event()
+        task = asyncio.create_task(
+            run.run_dispatcher_loop(gap_d, sub, client, stop=stop)
+        )
+        for _ in range(10):
+            await asyncio.sleep(0)
+        stop.set()
+        await asyncio.wait_for(task, timeout=2.0)
+
+    asyncio.run(drive())
+
+    assert msg.acked is True
+    assert client.calls[0]["kwargs"]["id"] == "gap-drain-55"
+
+
+def test_run_dispatcher_loop_stops_when_stop_event_set():
+    """The loop exits cleanly once the stop asyncio.Event is set."""
+    gap_d = gap_ready.DISPATCHERS[0]
+    # Empty subscription — no messages. Loop must still exit when stop is set.
+    sub = FakeSubscription([])
+    client = FakeTemporalClient()
+
+    async def drive():
+        stop = asyncio.Event()
+        task = asyncio.create_task(
+            run.run_dispatcher_loop(gap_d, sub, client, stop=stop)
+        )
+        # Yield a few times, then signal stop.
+        for _ in range(3):
+            await asyncio.sleep(0)
+        stop.set()
+        await asyncio.wait_for(task, timeout=2.0)
+
+    # Must complete without hanging.
+    asyncio.run(drive())
+
+
+def test_run_dispatcher_loop_timeout_does_not_break_loop():
+    """TimeoutError on fetch is a normal idle-stream condition — loop continues."""
+    gap_d = gap_ready.DISPATCHERS[0]
+    good = FakeMsg(_raw(_gap_envelope("77", "created")))
+    # First fetch returns a message; second and subsequent raise TimeoutError.
+    sub = FakeSubscription([[good]])
+    client = FakeTemporalClient()
+
+    async def drive():
+        stop = asyncio.Event()
+        task = asyncio.create_task(
+            run.run_dispatcher_loop(gap_d, sub, client, stop=stop)
+        )
+        for _ in range(10):
+            await asyncio.sleep(0)
+        stop.set()
+        await asyncio.wait_for(task, timeout=2.0)
+
+    asyncio.run(drive())
+
+    # The valid message before the timeouts was still processed.
+    assert good.acked is True
+    assert client.calls[0]["kwargs"]["id"] == "gap-drain-77"

--- a/projects/lakehouse/events/registry/registry_test.py
+++ b/projects/lakehouse/events/registry/registry_test.py
@@ -87,3 +87,196 @@ def test_note_created_payload_with_chunks():
     )
     assert len(note.chunks) == 1
     assert len(note.chunks[0].embedding) == 1024
+
+
+# --- GapUpdatedPayload ---------------------------------------------------
+
+
+def test_gap_updated_payload_requires_state():
+    from projects.lakehouse.events.registry.gap import GapUpdatedPayload
+
+    with pytest.raises(ValidationError):
+        GapUpdatedPayload()  # state is required
+
+
+def test_gap_updated_payload_optional_fields():
+    from projects.lakehouse.events.registry.gap import GapUpdatedPayload
+
+    # topic, gap_class, and context are optional.
+    p = GapUpdatedPayload(state="answered")
+    assert p.state == "answered"
+    assert p.topic is None
+    assert p.gap_class is None
+    assert p.context is None
+
+
+def test_gap_updated_payload_with_all_fields():
+    from projects.lakehouse.events.registry.gap import GapUpdatedPayload
+
+    p = GapUpdatedPayload(
+        topic="epistemology",
+        gap_class="external",
+        state="researching",
+        context={"source": "web"},
+    )
+    assert p.topic == "epistemology"
+    assert p.state == "researching"
+    assert p.context == {"source": "web"}
+
+
+# --- GapTombstonedPayload ------------------------------------------------
+
+
+def test_gap_tombstoned_payload_no_required_fields():
+    from projects.lakehouse.events.registry.gap import GapTombstonedPayload
+
+    # Tombstone has no required fields — entity_id lives in the envelope.
+    p = GapTombstonedPayload()
+    assert p.reason is None
+
+
+def test_gap_tombstoned_payload_reason():
+    from projects.lakehouse.events.registry.gap import GapTombstonedPayload
+
+    p = GapTombstonedPayload(reason="duplicate")
+    assert p.reason == "duplicate"
+
+
+def test_gap_schemas_has_all_three_event_types():
+    assert set(SCHEMAS["gap"]) >= {"created", "updated", "tombstoned"}
+
+
+# --- NoteUpdatedPayload --------------------------------------------------
+
+
+def test_note_updated_payload_is_subclass_of_created():
+    from projects.lakehouse.events.registry.note import NoteUpdatedPayload
+
+    assert issubclass(NoteUpdatedPayload, NoteCreatedPayload)
+
+
+def test_note_updated_payload_validates():
+    from projects.lakehouse.events.registry.note import NoteUpdatedPayload
+
+    p = NoteUpdatedPayload(
+        note_id="n2",
+        path="notes/n2.md",
+        title="N2",
+        content_hash="def",
+        type="permanent",
+        status="draft",
+        visibility="private",
+    )
+    assert p.note_id == "n2"
+    assert p.tags == []
+
+
+# --- NoteTombstonedPayload -----------------------------------------------
+
+
+def test_note_tombstoned_payload_requires_note_id():
+    from projects.lakehouse.events.registry.note import NoteTombstonedPayload
+
+    with pytest.raises(ValidationError):
+        NoteTombstonedPayload()  # note_id is required
+
+
+def test_note_tombstoned_payload_reason_optional():
+    from projects.lakehouse.events.registry.note import NoteTombstonedPayload
+
+    p = NoteTombstonedPayload(note_id="n3")
+    assert p.note_id == "n3"
+    assert p.reason is None
+
+
+def test_note_tombstoned_payload_with_reason():
+    from projects.lakehouse.events.registry.note import NoteTombstonedPayload
+
+    p = NoteTombstonedPayload(note_id="n4", reason="RTBF request")
+    assert p.reason == "RTBF request"
+
+
+def test_note_schemas_has_all_event_types():
+    assert set(SCHEMAS["note"]) >= {"created", "updated", "tombstoned"}
+
+
+# --- NoteChunk edge cases ------------------------------------------------
+
+
+def test_note_chunk_section_header_optional():
+    chunk = NoteChunk(chunk_index=1, chunk_text="body text", embedding=[0.1])
+    assert chunk.section_header is None
+
+
+def test_note_chunk_requires_chunk_text():
+    with pytest.raises(ValidationError):
+        NoteChunk(chunk_index=0, embedding=[0.0])  # chunk_text required
+
+
+# --- NoteCreatedPayload defaults -----------------------------------------
+
+
+def test_note_created_payload_defaults_to_empty_lists():
+    p = NoteCreatedPayload(
+        note_id="n5",
+        path="notes/n5.md",
+        title="N5",
+        content_hash="ghi",
+        type="fleeting",
+        status="published",
+        visibility="public",
+    )
+    assert p.tags == []
+    assert p.aliases == []
+    assert p.chunks == []
+
+
+# --- EMBEDDING_DIM constant ----------------------------------------------
+
+
+def test_embedding_dim_constant():
+    from projects.lakehouse.events.registry.note import EMBEDDING_DIM
+
+    assert EMBEDDING_DIM == 1024
+
+
+# --- register() called directly ------------------------------------------
+
+
+def test_gap_register_populates_fresh_dict():
+    from projects.lakehouse.events.registry.gap import (
+        GapCreatedPayload,
+        GapTombstonedPayload,
+        GapUpdatedPayload,
+        register,
+    )
+
+    fresh: dict = {}
+    register(fresh)
+    assert fresh["gap"]["created"] is GapCreatedPayload
+    assert fresh["gap"]["updated"] is GapUpdatedPayload
+    assert fresh["gap"]["tombstoned"] is GapTombstonedPayload
+
+
+def test_note_register_populates_fresh_dict():
+    from projects.lakehouse.events.registry.note import (
+        NoteCreatedPayload,
+        NoteTombstonedPayload,
+        NoteUpdatedPayload,
+        register,
+    )
+
+    fresh: dict = {}
+    register(fresh)
+    assert fresh["note"]["created"] is NoteCreatedPayload
+    assert fresh["note"]["updated"] is NoteUpdatedPayload
+    assert fresh["note"]["tombstoned"] is NoteTombstonedPayload
+
+
+def test_gap_register_is_idempotent():
+    from projects.lakehouse.events.registry.gap import GapCreatedPayload, register
+
+    d: dict = {}
+    register(d)
+    register(d)  # second call must not raise or duplicate keys
+    assert d["gap"]["created"] is GapCreatedPayload

--- a/projects/lakehouse/iceberg/tables_test.py
+++ b/projects/lakehouse/iceberg/tables_test.py
@@ -98,3 +98,61 @@ def test_unique_field_ids_per_schema():
     for name, schema in TABLES.items():
         ids = [f.field_id for f in schema.fields]
         assert len(ids) == len(set(ids)), f"{name} has duplicate top-level field IDs"
+
+
+# --- TABLE_NAME constants ------------------------------------------------
+
+
+def test_table_names_match_registry_keys():
+    """The TABLE_NAME string in each module must equal its key in TABLES."""
+    from projects.lakehouse.iceberg.tables import gap_events, note_events
+
+    assert gap_events.TABLE_NAME == "gap_events"
+    assert note_events.TABLE_NAME == "note_events"
+    assert gap_events.TABLE_NAME in TABLES
+    assert note_events.TABLE_NAME in TABLES
+
+
+# --- per-table field required/optional flags ----------------------------
+
+
+def test_note_events_note_id_is_required():
+    """``note_id`` is required=True in note_events (it's the note's own PK
+    column, distinct from the envelope's ``entity_id``)."""
+    by_name = {f.name: f for f in TABLES["note_events"].fields}
+    assert by_name["note_id"].required is True
+
+
+def test_gap_events_payload_fields_are_optional():
+    """Gap payload columns (topic, gap_class, state) are optional — a tombstone
+    row for a gap carries no payload, so they must allow NULL."""
+    by_name = {f.name: f for f in TABLES["gap_events"].fields}
+    for col in ("topic", "gap_class", "state"):
+        assert by_name[col].required is False, f"{col} should be optional"
+
+
+def test_note_events_chunk_fields_are_optional():
+    """Per-chunk columns are optional — a metadata-only note event (no chunks)
+    produces a single row with these columns null."""
+    by_name = {f.name: f for f in TABLES["note_events"].fields}
+    for col in ("chunk_text", "chunk_index", "section_header"):
+        assert by_name[col].required is False, f"{col} should be optional"
+
+
+# --- list element IDs uniqueness -----------------------------------------
+
+
+def test_note_events_list_element_ids_do_not_clash_with_field_ids():
+    """The list element IDs (101, 102, 103) must be distinct from every
+    top-level field ID in the schema (1–23)."""
+    from pyiceberg.types import ListType
+
+    schema = TABLES["note_events"]
+    top_ids = {f.field_id for f in schema.fields}
+    for f in schema.fields:
+        if isinstance(f.field_type, ListType):
+            elem_id = f.field_type.element_id
+            assert elem_id not in top_ids, (
+                f"List element ID {elem_id} on field '{f.name}' clashes with a "
+                f"top-level field ID"
+            )

--- a/projects/lakehouse/orchestrator/schedules/schedules_test.py
+++ b/projects/lakehouse/orchestrator/schedules/schedules_test.py
@@ -119,3 +119,56 @@ def test_register_schedules_propagates_unexpected_errors() -> None:
 
     with pytest.raises(RuntimeError, match="boom"):
         asyncio.run(sched.register_schedules(client))
+
+
+# --- per-module constants ------------------------------------------------
+
+
+def test_build_serving_module_constants() -> None:
+    from projects.lakehouse.orchestrator.schedules import build_serving
+
+    assert build_serving.WORKFLOW_TYPE == "BuildServingArtifactWorkflow"
+    assert build_serving.SCHEDULE_ID == "build-serving-artifact"
+    assert build_serving.CRON == "*/15 * * * *"
+
+
+def test_gap_drain_sweep_module_constants() -> None:
+    from projects.lakehouse.orchestrator.schedules import gap_drain_sweep
+
+    assert gap_drain_sweep.WORKFLOW_TYPE == "GapDrainSweepWorkflow"
+    assert gap_drain_sweep.SCHEDULE_ID == "gap-drain-sweep"
+    assert gap_drain_sweep.CRON == "*/5 * * * *"
+
+
+def test_iceberg_batch_module_constants() -> None:
+    from datetime import timedelta
+
+    from projects.lakehouse.orchestrator.schedules import iceberg_batch
+
+    assert iceberg_batch.WORKFLOW_TYPE == "IcebergBatchCommitWorkflow"
+    assert iceberg_batch.SCHEDULE_ID == "iceberg-batch-commit"
+    assert iceberg_batch.INTERVAL == timedelta(seconds=90)
+
+
+def test_tag_rotation_module_constants() -> None:
+    from projects.lakehouse.orchestrator.schedules import tag_rotation
+
+    assert tag_rotation.WORKFLOW_TYPE == "TagRotationWorkflow"
+    assert tag_rotation.SCHEDULE_ID == "tag-rotation"
+    assert tag_rotation.CRON == "*/15 * * * *"
+
+
+def test_each_module_exports_exactly_one_schedule() -> None:
+    """Each schedule module exports a SCHEDULES list with exactly one entry."""
+    from projects.lakehouse.orchestrator.schedules import (
+        build_serving,
+        gap_drain_sweep,
+        iceberg_batch,
+        tag_rotation,
+    )
+
+    for mod in (build_serving, gap_drain_sweep, iceberg_batch, tag_rotation):
+        schedules = getattr(mod, "SCHEDULES", None)
+        assert schedules is not None, f"{mod.__name__} missing SCHEDULES"
+        assert len(schedules) == 1, f"{mod.__name__} should export exactly one schedule"
+        assert isinstance(schedules[0], sched.ScheduleDefinition)

--- a/projects/lakehouse/orchestrator/schedules/schedules_test.py
+++ b/projects/lakehouse/orchestrator/schedules/schedules_test.py
@@ -169,5 +169,7 @@ def test_each_module_exports_exactly_one_schedule() -> None:
     for mod in (build_serving, gap_drain_sweep, iceberg_batch, tag_rotation):
         mod_schedules = getattr(mod, "SCHEDULES", None)
         assert mod_schedules is not None, f"{mod.__name__} missing SCHEDULES"
-        assert len(mod_schedules) == 1, f"{mod.__name__} should export exactly one schedule"
+        assert len(mod_schedules) == 1, (
+            f"{mod.__name__} should export exactly one schedule"
+        )
         assert isinstance(mod_schedules[0], sched.ScheduleDefinition)

--- a/projects/lakehouse/orchestrator/schedules/schedules_test.py
+++ b/projects/lakehouse/orchestrator/schedules/schedules_test.py
@@ -9,6 +9,7 @@ Discovery and spec-shape assertions never connect to a server.
 from __future__ import annotations
 
 import asyncio
+from datetime import timedelta
 from unittest import mock
 
 import pytest
@@ -141,8 +142,6 @@ def test_gap_drain_sweep_module_constants() -> None:
 
 
 def test_iceberg_batch_module_constants() -> None:
-    from datetime import timedelta
-
     from projects.lakehouse.orchestrator.schedules import iceberg_batch
 
     assert iceberg_batch.WORKFLOW_TYPE == "IcebergBatchCommitWorkflow"
@@ -168,7 +167,7 @@ def test_each_module_exports_exactly_one_schedule() -> None:
     )
 
     for mod in (build_serving, gap_drain_sweep, iceberg_batch, tag_rotation):
-        schedules = getattr(mod, "SCHEDULES", None)
-        assert schedules is not None, f"{mod.__name__} missing SCHEDULES"
-        assert len(schedules) == 1, f"{mod.__name__} should export exactly one schedule"
-        assert isinstance(schedules[0], sched.ScheduleDefinition)
+        mod_schedules = getattr(mod, "SCHEDULES", None)
+        assert mod_schedules is not None, f"{mod.__name__} missing SCHEDULES"
+        assert len(mod_schedules) == 1, f"{mod.__name__} should export exactly one schedule"
+        assert isinstance(mod_schedules[0], sched.ScheduleDefinition)


### PR DESCRIPTION
## Summary

Extends the four existing lakehouse test suites to cover all 11 modules added in commits affb65c..7720426. All tests are hermetic (no NATS, Temporal, or Iceberg servers).

- **dispatchers/dispatchers_test.py** (+9 tests): `artifact_ready` SUBJECT/DURABLE constants, `path`-fallback payload logging, empty-payload safety; `gap_ready` module constants (SUBJECT, DURABLE, TRIGGER_EVENT_TYPE, WORKFLOW_TYPE, TASK_QUEUE, WORKFLOW_ID_PREFIX); `run.POLL_TIMEOUT` constant; `run_dispatcher_loop` exercised directly — dispatches batch, honours stop event, and tolerates TimeoutError idle polls
- **events/registry/registry_test.py** (+18 tests): `GapUpdatedPayload` (state required, optional fields), `GapTombstonedPayload` (no required fields), `NoteUpdatedPayload` (subclass check), `NoteTombstonedPayload` (note_id required), `NoteChunk` with optional `section_header`, `NoteCreatedPayload` empty-list defaults, `EMBEDDING_DIM` constant, `register()` called directly on a fresh dict + idempotency
- **iceberg/tables_test.py** (+6 tests): `TABLE_NAME` constants match TABLES registry keys; `note_id` required in note_events; gap payload columns (topic, gap_class, state) optional; note chunk columns optional; list element IDs 101/102/103 don't clash with top-level field IDs
- **orchestrator/schedules/schedules_test.py** (+5 tests): WORKFLOW_TYPE, SCHEDULE_ID, CRON/INTERVAL constants for all four schedule modules; each module exports exactly one `ScheduleDefinition`

## Test plan

- [ ] CI: `bazel test //projects/lakehouse/dispatchers:dispatchers_test`
- [ ] CI: `bazel test //projects/lakehouse/events/registry:registry_test`
- [ ] CI: `bazel test //projects/lakehouse/iceberg:tables_test`
- [ ] CI: `bazel test //projects/lakehouse/orchestrator/schedules:schedules_test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)