### PR TITLE
docs(lakehouse): fix image/ module path in README

### DIFF
--- a/projects/lakehouse/README.md
+++ b/projects/lakehouse/README.md
@@ -22,7 +22,7 @@ NATS JetStream  ->  Temporal workflows  ->  Iceberg on SeaweedFS  ->  DuckDB / Q
 | `iceberg/`          | PyIceberg writer helpers; per-domain `tables/`                         | 2         |
 | `duckdb_query/`     | DuckDB + iceberg-extension query helpers                               | 2         |
 | `dispatchers/`      | NATS → Temporal workflow dispatchers                                   | 4         |
-| `image/`            | apko worker image (`python -m projects.lakehouse.orchestrator.worker`) | 3         |
+| `image/`            | apko worker image (`python -m projects.lakehouse.orchestrator.workflows.run`) | 3         |
 | `quack-server/`     | apko DuckDB/Quack serving image                                        | 3         |
 | `chart/`, `deploy/` | Path-based Helm chart + ArgoCD Application                             | 4         |
 


### PR DESCRIPTION
## Summary

- Corrects the `image/` row in the Layout table: the worker image runs `python -m projects.lakehouse.orchestrator.workflows.run`, not `python -m projects.lakehouse.orchestrator.worker`
- The `image/BUILD` file binds to `orchestrator/workflows:worker_main` → `run.py`; the skeleton `orchestrator/worker.py` has a stale self-documenting comment that was reflected in the README

## Test plan

- [x] README diff verified against `projects/lakehouse/image/BUILD` and `projects/lakehouse/orchestrator/workflows/run.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)