### PR TITLE
fix(lakehouse): in-cluster-only quack access (disable cfIngress) + real /search latency

### DIFF
--- a/docs/plans/event-sourced-impl-status/FINAL.md
+++ b/docs/plans/event-sourced-impl-status/FINAL.md
@@ -57,7 +57,7 @@ Iceberg on SeaweedFS  s3://warehouse/  (note_events / gap_events tables)
 s3://warehouse/serving/notes-vN.duckdb  (DuckDB + VSS HNSW, state=building)
    │  events.serving.artifact-ready  →  TagRotationWorkflow (5min grace, keep-last-24)
    ▼
-Quack pods (2×, in-RAM .duckdb, ATTACH OR REPLACE hot-swap)  →  Cloudflare CDN  →  query
+Quack pods (2×, in-RAM .duckdb, ATTACH OR REPLACE hot-swap)  →  in-cluster SSR callers (direct Service DNS, no public domain)
 ```
 
 - **Code home:** standalone `projects/lakehouse/` project (gate-ratified Option A) —
@@ -203,23 +203,25 @@ constant, so the optimiser rewrites `ORDER BY array_distance(...) LIMIT k` into 
 O(rows), the gap widens with corpus growth, so ~10 ms is a floor on the win, not a
 ceiling.
 
-**End-to-end (Quack HTTP `/search`):** on the **deployed post-fix image** (#2437),
-an authenticated `/search` (k=10, 1024-dim) returns HTTP 200 with 10 correctly-
-shaped `note_events` rows from the current artifact — the inlined-literal HNSW path
-is confirmed working in production. A clean end-to-end **latency** number was **not
-captured**: the CDN path (`quack.jomcgi.dev`) wasn't routing, and the only available
-route was `kubectl port-forward` over the (chronically flapping) remote API tunnel,
-whose ~0.8–2 s round-trip is pure transport and swamps the query — not representative
-of in-cluster latency. The representative figure is the engine-level **~10 ms** row
-above (the shipped query plan); a true in-cluster `/search` (engine + intra-mesh HTTP)
-is single-digit-to-low-tens of ms. For reference, the pre-fix image measured **~84 ms
-p50** end-to-end on the brute-force path.
+**End-to-end (Quack HTTP `/search`, in-cluster):** the read path is accessed
+**in-cluster only** — SSR callers hit the quack Service directly over cluster DNS
+(`lakehouse-quack.lakehouse.svc.cluster.local:8080`); there is **no public domain**
+(`cfIngress` is disabled). Measured from a one-off pod in the `lakehouse` namespace
+hitting the Service directly (k=10, 1024-dim, deployed post-fix image): HTTP 200,
+10 correct `note_events` rows, **~15 ms warm** (steady-state 14.5–16.2 ms; the
+first call is ~0.7 s cold while the connection opens and DuckDB faults the artifact
+pages / HNSW index into cache). That ~15 ms = the engine-level **~10 ms** HNSW row
+above + ~5 ms HTTP/serialization — the operative SSR-path latency (keep-alive
+connections + a hot artifact; the cold hit only recurs right after a hot-swap). For
+reference, the pre-fix image measured **~84 ms p50** on the brute-force path.
 
-**Takeaway:** point and aggregate reads are already single-digit-millisecond; the
-vector path is the one that matters for scale, and the HNSW fix moves it from a
-linear scan to an index scan. To capture a representative end-to-end `/search`
-latency, measure in-cluster (a sidecar/pod curl or the CDN once it's routing), not
-through a laptop port-forward.
+> Note: a `kubectl port-forward` from a workstation measured ~0.8–2 s for the same
+> call — that figure is ~60× inflated by API-server-proxy + remote-tunnel transport
+> and is **not** representative. Latency must be measured in-cluster, on the SSR path.
+
+**Takeaway:** point and aggregate reads are already single-digit-millisecond, and
+the vector path — the one that matters for scale — is ~15 ms in-cluster now that the
+HNSW fix moved it from a linear scan to an index scan.
 
 ---
 

--- a/projects/lakehouse/chart/Chart.yaml
+++ b/projects/lakehouse/chart/Chart.yaml
@@ -2,9 +2,9 @@ apiVersion: v2
 name: lakehouse
 description: >-
   Event-sourced lakehouse worker pools (Temporal task-queue Deployments + KEDA
-  autoscalers), the hot-swap Quack serving layer fronted by Cloudflare, and the
-  NATS->Iceberg/serving dispatchers. ADRs agents/015 (Temporal worker pools) and
-  platform/004 (Iceberg lakehouse + hot-swap Quack serving).
+  autoscalers), the hot-swap Quack serving layer (accessed in-cluster by SSR
+  callers), and the NATS->Iceberg/serving dispatchers. ADRs agents/015 (Temporal
+  worker pools) and platform/004 (Iceberg lakehouse + hot-swap Quack serving).
 type: application
-version: 0.2.1
+version: 0.2.2
 appVersion: "0.1.0"

--- a/projects/lakehouse/deploy/application.yaml
+++ b/projects/lakehouse/deploy/application.yaml
@@ -18,7 +18,7 @@ spec:
     # path at HEAD) is what makes the merge of new images actually roll the pods.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: lakehouse
-      targetRevision: 0.2.1
+      targetRevision: 0.2.2
       helm:
         releaseName: lakehouse
         # The chart's packaged values.yaml (with pinned image tags) is the base;

--- a/projects/lakehouse/deploy/values.yaml
+++ b/projects/lakehouse/deploy/values.yaml
@@ -15,10 +15,14 @@ worker:
 quack:
   image:
     pullPolicy: Always
-  # Front the read path with Cloudflare CDN once the public hostname is live.
+  # No public ingress: the read path is accessed IN-CLUSTER ONLY — SSR callers
+  # (e.g. the monolith) hit the quack Service directly over cluster DNS
+  # (lakehouse-quack.lakehouse.svc.cluster.local:8080). We deliberately do NOT
+  # expose quack via the public quack.jomcgi.dev domain, so cfIngress stays at the
+  # chart default (disabled) and no Gateway HTTPRoute is rendered. The in-cluster
+  # Service is independent of cfIngress, so this does not affect SSR access.
   cfIngress:
-    enabled: true
-    hostname: quack.jomcgi.dev
+    enabled: false
   queryToken:
     # MANUAL PREREQUISITE: 1Password item with a QUACK_QUERY_TOKEN field.
     onepasswordItemPath: vaults/k8s-homelab/items/lakehouse-quack-query-token


### PR DESCRIPTION
Corrects a drift from the agreed access model: the quack read path is **in-cluster only** — SSR callers (e.g. the monolith) hit the Service directly over cluster DNS (`lakehouse-quack.lakehouse.svc.cluster.local:8080`), **not** the public `quack.jomcgi.dev` domain. The deploy overlay was still enabling the Cloudflare Gateway route.

## Changes
- **`deploy/values.yaml`**: `cfIngress.enabled: true → false` (back to the chart default). `cfIngress` only gates `quack-httproute.yaml` (the public Gateway route); the in-cluster `Service` is a separate template (`quack-service.yaml`), so **SSR access is unaffected** — ArgoCD just prunes the now-unused public HTTPRoute.
- **`Chart.yaml`**: `0.2.1 → 0.2.2`; description "fronted by Cloudflare" → "accessed in-cluster by SSR callers". `application.yaml` `targetRevision` kept in sync at `0.2.2`.
- **`FINAL.md`**: fix the CDN framing (architecture diagram + benchmark) to the in-cluster SSR path, and record the **real** end-to-end `/search` latency.

## Real in-cluster `/search` latency (measured from a one-off pod hitting the Service directly)
```
cold first call ~0.7 s   (connection open + DuckDB page/HNSW warm-up)
warm steady     ~15 ms   (14.5–16.2 ms)  = engine ~10 ms HNSW + ~5 ms HTTP
```
HTTP 200, 10 correct `note_events` rows. The earlier ~0.8–2 s `port-forward` figure was ~60× inflated by API-server-proxy + remote-tunnel transport — flagged in the doc as non-representative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)