### PR TITLE
feat(lakehouse): incremental note-change export (add/update/soft-delete)

### DIFF
--- a/projects/lakehouse/orchestrator/schedules/BUILD
+++ b/projects/lakehouse/orchestrator/schedules/BUILD
@@ -21,6 +21,7 @@ py_library(
         "build_serving.py",
         "gap_drain_sweep.py",
         "iceberg_batch.py",
+        "note_export.py",
         "tag_rotation.py",
     ],
     visibility = ["//:__subpackages__"],
@@ -56,6 +57,12 @@ semgrep_test(
 semgrep_test(
     name = "iceberg_batch_semgrep_test",
     srcs = ["iceberg_batch.py"],
+    rules = ["//bazel/semgrep/rules:python_rules"],
+)
+
+semgrep_test(
+    name = "note_export_semgrep_test",
+    srcs = ["note_export.py"],
     rules = ["//bazel/semgrep/rules:python_rules"],
 )
 

--- a/projects/lakehouse/orchestrator/schedules/note_export.py
+++ b/projects/lakehouse/orchestrator/schedules/note_export.py
@@ -1,0 +1,49 @@
+"""Schedule: incrementally forward changed notes to the event log.
+
+Drives :class:`ExportNoteChangesWorkflow` on the ``housekeeping`` task queue once
+a day to forward note adds/updates/soft-deletes since the watermark (the bootstrap
+backfill seeds history; this keeps the lakehouse fresh afterwards).
+
+Two properties make a *scheduled* cadence safe here:
+
+* ``overlap=SKIP`` — if a run is still draining when the next tick fires, skip the
+  tick rather than queue a pile-up. Combined with the workflow's stable id this
+  guarantees runs never interleave, so the watermark read -> emit -> advance
+  sequence is effectively single-threaded (no lost or duplicated deltas).
+* the export is idempotent (source-derived ``event_version`` + deduped serving
+  fold), so even a skipped/retried run can't corrupt the served view.
+
+Daily is plenty given the corpus churn; bumping to hourly is a one-line cron
+change (it's a cheap read-only PG sweep). References the workflow by type-name
+string so this module stays independent of the workflow unit.
+"""
+
+from __future__ import annotations
+
+import temporalio.client
+
+from projects.lakehouse.orchestrator import TaskQueue
+from projects.lakehouse.orchestrator.schedules import ScheduleDefinition
+
+WORKFLOW_TYPE = "ExportNoteChangesWorkflow"
+SCHEDULE_ID = "note-export"
+# Daily at 04:17 UTC — staggered off the hour to avoid colliding with other
+# daily housekeeping jobs.
+CRON = "17 4 * * *"
+
+SCHEDULES = [
+    ScheduleDefinition(
+        schedule_id=SCHEDULE_ID,
+        schedule=temporalio.client.Schedule(
+            action=temporalio.client.ScheduleActionStartWorkflow(
+                WORKFLOW_TYPE,
+                id=SCHEDULE_ID,
+                task_queue=TaskQueue.HOUSEKEEPING.value,
+            ),
+            spec=temporalio.client.ScheduleSpec(cron_expressions=[CRON]),
+            policy=temporalio.client.SchedulePolicy(
+                overlap=temporalio.client.ScheduleOverlapPolicy.SKIP,
+            ),
+        ),
+    ),
+]

--- a/projects/lakehouse/orchestrator/schedules/schedules_test.py
+++ b/projects/lakehouse/orchestrator/schedules/schedules_test.py
@@ -30,6 +30,7 @@ _EXPECTED = {
         TaskQueue.HOUSEKEEPING.value,
     ),
     "tag-rotation": ("TagRotationWorkflow", TaskQueue.HOUSEKEEPING.value),
+    "note-export": ("ExportNoteChangesWorkflow", TaskQueue.HOUSEKEEPING.value),
 }
 
 
@@ -41,7 +42,7 @@ def test_all_schedules_returns_list() -> None:
     assert isinstance(sched.all_schedules(), list)
 
 
-def test_discovers_all_four_schedules() -> None:
+def test_discovers_all_schedules() -> None:
     found = _by_id()
     assert set(found) == set(_EXPECTED)
     # No duplicate schedule IDs across modules.
@@ -77,6 +78,15 @@ def test_cron_schedules_use_expected_expressions() -> None:
         "*/15 * * * *"
     ]
     assert found["tag-rotation"].schedule.spec.cron_expressions == ["*/15 * * * *"]
+    assert found["note-export"].schedule.spec.cron_expressions == ["17 4 * * *"]
+
+
+def test_note_export_uses_skip_overlap() -> None:
+    # The incremental export advances a watermark; overlapping runs could double-
+    # emit or race the advance. overlap=SKIP guarantees runs never interleave.
+    policy = _by_id()["note-export"].schedule.policy
+    assert policy is not None
+    assert policy.overlap == temporalio.client.ScheduleOverlapPolicy.SKIP
 
 
 def test_iceberg_batch_uses_interval_spec() -> None:
@@ -157,16 +167,31 @@ def test_tag_rotation_module_constants() -> None:
     assert tag_rotation.CRON == "*/15 * * * *"
 
 
+def test_note_export_module_constants() -> None:
+    from projects.lakehouse.orchestrator.schedules import note_export
+
+    assert note_export.WORKFLOW_TYPE == "ExportNoteChangesWorkflow"
+    assert note_export.SCHEDULE_ID == "note-export"
+    assert note_export.CRON == "17 4 * * *"
+
+
 def test_each_module_exports_exactly_one_schedule() -> None:
     """Each schedule module exports a SCHEDULES list with exactly one entry."""
     from projects.lakehouse.orchestrator.schedules import (
         build_serving,
         gap_drain_sweep,
         iceberg_batch,
+        note_export,
         tag_rotation,
     )
 
-    for mod in (build_serving, gap_drain_sweep, iceberg_batch, tag_rotation):
+    for mod in (
+        build_serving,
+        gap_drain_sweep,
+        iceberg_batch,
+        note_export,
+        tag_rotation,
+    ):
         mod_schedules = getattr(mod, "SCHEDULES", None)
         assert mod_schedules is not None, f"{mod.__name__} missing SCHEDULES"
         assert len(mod_schedules) == 1, (

--- a/projects/lakehouse/orchestrator/workflows/build_serving.py
+++ b/projects/lakehouse/orchestrator/workflows/build_serving.py
@@ -121,8 +121,18 @@ def _artifact_s3_uri(version: int) -> str:
 #
 # Built as a CTE chain so it reads as the fold it is:
 #   latest   -> the MAX(event_version) per note_id
-#   live     -> rows at that latest version whose latest event isn't tombstoned
-#   indexed  -> live rows that actually carry an embedding
+#   current  -> rows at that latest version
+#   deduped  -> ONE row per (note_id, event_version, chunk_index)
+#   (final)  -> deduped rows that aren't tombstoned and carry an embedding
+#
+# The dedup step is load-bearing: note_events is one row per chunk and is an
+# append-only, at-least-once log (NATS redelivery, the incremental export's
+# watermark re-scan margin, and re-runs of the bootstrap can all re-append the
+# SAME (note_id, event_version) more than once). Without deduping, every
+# duplicated chunk row would survive the MAX(event_version) join and be indexed
+# twice — duplicate vectors in the HNSW index and duplicate `/search` hits. We
+# keep the most-recently-emitted copy (occurred_at, then event_id as a stable
+# tiebreak) so the fold is idempotent to any duplicate delivery.
 _BUILD_CHUNKS_SQL = """
 CREATE TABLE {schema}.{table} AS
 WITH latest AS (
@@ -136,11 +146,33 @@ current_rows AS (
     JOIN latest l
       ON e.note_id = l.note_id
      AND e.event_version = l.max_version
+),
+deduped AS (
+    SELECT * EXCLUDE (_rn) FROM (
+        SELECT c.*,
+               ROW_NUMBER() OVER (
+                   PARTITION BY c.note_id, c.event_version, c.chunk_index
+                   ORDER BY c.occurred_at DESC, c.event_id DESC
+               ) AS _rn
+        FROM current_rows c
+    )
+    WHERE _rn = 1
 )
 SELECT * EXCLUDE (embedding), CAST(embedding AS FLOAT[{embedding_dim}]) AS embedding
-FROM current_rows
+FROM deduped
 WHERE event_type <> 'tombstoned'
-  AND embedding IS NOT NULL;
+  -- Drop the whole note if its latest revision includes a tombstone — even on an
+  -- (epoch-millis) version TIE between the delete and the prior content. This is
+  -- note-level, so it doesn't rely on the tombstone version strictly exceeding
+  -- the content version (the chunk rows live in different ROW_NUMBER partitions
+  -- from the chunk_index-NULL tombstone row, so the per-row filter alone can't
+  -- catch them on a tie).
+  AND note_id NOT IN (SELECT note_id FROM deduped WHERE event_type = 'tombstoned')
+  -- Only index rows carrying a full-width vector. A null or empty-list embedding
+  -- (e.g. a source chunk with no embedding) would otherwise reach the fixed-size
+  -- CAST AS FLOAT[N] and abort the ENTIRE build, not just that row.
+  AND embedding IS NOT NULL
+  AND len(embedding) = {embedding_dim};
 """
 
 # Build the HNSW index over the indexed chunks. array_distance is the metric
@@ -282,7 +314,11 @@ def _s3_client():
     # plaintext HTTP, so prefix http:// when absent.
     if not endpoint.startswith(("http://", "https://")):
         endpoint = "http://" + endpoint
-    return boto3.client(
+    # Scheme is guaranteed by the guard above; the Bazel semgrep_target_test
+    # already excludes boto3-endpoint-url-missing-scheme (workflows/BUILD), and
+    # the inline nosemgrep below clears the pre-commit hook (which doesn't read
+    # BUILD exclude_rules). Bare nosemgrep: this line has no other rule matches.
+    return boto3.client(  # nosemgrep
         "s3",
         endpoint_url=endpoint,
         aws_access_key_id=os.environ.get("S3_ACCESS_KEY_ID", "duckdb"),

--- a/projects/lakehouse/orchestrator/workflows/build_serving_test.py
+++ b/projects/lakehouse/orchestrator/workflows/build_serving_test.py
@@ -9,9 +9,9 @@ shape, the HNSW index build, the ``state=building`` tag on upload, and the
 
 from __future__ import annotations
 
+import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
-import pytest
 import temporalio.workflow
 
 from projects.lakehouse.orchestrator.workflows import build_serving as mod
@@ -58,10 +58,20 @@ def test_build_chunks_sql_applies_current_version_filter() -> None:
     # Latest-version fold: MAX(event_version) per note_id, joined back.
     assert "MAX(event_version)" in sql
     assert "GROUP BY note_id" in sql
-    # Drops tombstoned (deleted) notes — stale-vector mitigation.
+    # Idempotent to duplicate delivery: one row per (note_id, event_version,
+    # chunk_index), so a re-appended event (NATS redelivery / export re-scan /
+    # bootstrap re-run) can't double-index a chunk.
+    assert "ROW_NUMBER() OVER" in sql
+    assert "PARTITION BY c.note_id, c.event_version, c.chunk_index" in sql
+    # Drops tombstoned (deleted) notes — stale-vector mitigation. Note-level
+    # NOT IN so a deleted note is dropped even on a version tie, not just the
+    # tombstone row.
     assert "event_type <> 'tombstoned'" in sql
-    # Drops metadata-only rows with no vector.
+    assert "note_id NOT IN (SELECT note_id FROM deduped WHERE event_type" in sql
+    # Drops metadata-only rows with no vector, AND wrong-width vectors that would
+    # crash the fixed-size CAST and abort the whole build.
     assert "embedding IS NOT NULL" in sql
+    assert "len(embedding) = 1024" in sql
     # Reads the Iceberg snapshot, not a raw parquet path.
     assert "iceberg_scan('s3://warehouse/knowledge/note_events')" in sql
     # embedding is cast from variable FLOAT[] to fixed FLOAT[N] so the HNSW
@@ -81,8 +91,10 @@ def test_build_hnsw_sql_indexes_embedding() -> None:
 # --------------------------------------------------------------------------- #
 
 
-@pytest.mark.asyncio
-async def test_build_artifact_builds_indexes_tags_and_publishes() -> None:
+def test_build_artifact_builds_indexes_tags_and_publishes() -> None:
+    # Driven via asyncio.run (not @pytest.mark.asyncio) so it actually executes —
+    # the lakehouse test harness has no pytest-asyncio wired, so a marked async
+    # test would be collected but never awaited (pass-without-running).
     con = MagicMock()
     # rows_indexed query result
     con.execute.return_value.fetchone.return_value = (42,)
@@ -125,7 +137,7 @@ async def test_build_artifact_builds_indexes_tags_and_publishes() -> None:
         ),
         patch("builtins.open", fake_open),
     ):
-        result = await mod.build_artifact(123)
+        result = asyncio.run(mod.build_artifact(123))
 
     assert result.version == 123
     assert result.artifact_path == "s3://warehouse/serving/notes-v123.duckdb"

--- a/projects/lakehouse/orchestrator/workflows/export_note_changes.py
+++ b/projects/lakehouse/orchestrator/workflows/export_note_changes.py
@@ -1,0 +1,528 @@
+"""ExportNoteChangesWorkflow — incremental add/update/soft-delete forwarder.
+
+The bootstrap (:mod:`backfill_processed_notes`) seeds the event log from the
+whole ``_processed`` corpus once. This workflow keeps the lakehouse *fresh*
+afterwards by forwarding only what changed, so it can run on a cheap cadence
+(daily/hourly) instead of re-exporting everything.
+
+How it stays correct without hooking the filesystem (ADR 016/017):
+
+* **PG is the change chokepoint.** However a note's markdown is edited, the
+  monolith's ingest converges it into ``knowledge.notes``: it recomputes
+  ``content_hash``, re-embeds into ``knowledge.chunks``, and — atomically, in one
+  transaction (``store.upsert_note``) — stamps ``indexed_at = now()``. Unchanged
+  content is skipped, so ``indexed_at`` advances *iff* content actually changed.
+  Soft deletes stamp ``deleted_at = now()`` and keep the row. We therefore poll a
+  single monotonic per-row marker, ``change_at = GREATEST(indexed_at, deleted_at)``.
+* **One snapshot per read.** The note page and its chunks are read in a single
+  ``REPEATABLE READ`` transaction, so a concurrent upsert can never tear a note's
+  metadata from its embeddings — they were committed together and we see one
+  consistent snapshot.
+* **Source-derived, idempotent version.** ``event_version`` is the epoch-millis of
+  ``change_at`` (int64). It is a pure function of the source row, so an activity
+  retry or the watermark re-scan margin re-emits the *same* ``{note_id}-v{ms}``
+  dedup key — JetStream drops it inside the dedup window, and the serving fold
+  (now deduped per ``(note_id, event_version, chunk_index)``) collapses any copy
+  that slips past it. Monotonic per note, so the fold's ``MAX(event_version)``
+  always picks the latest revision; a tombstone (versioned on ``deleted_at``)
+  sorts after the content it supersedes.
+* **Watermark in the lakehouse DB.** A one-row ``export_state`` table (in the
+  lakehouse Postgres database that already backs the Iceberg catalog — never the
+  monolith's ``knowledge`` schema) records the high-water ``change_at``. Re-reads
+  start at ``watermark - margin`` so a transaction that committed late (below the
+  prior high-water mark) is caught next run; idempotency makes the overlap free.
+
+Scope: this forwards **adds, updates, and soft deletes**. *Hard* deletes
+(``store.delete_note`` physically removes the row) can't be forwarded — there is
+nothing left to read — and need a periodic reconcile pass (diff live PG note_ids
+against the served set, tombstone the difference). That's a documented follow-up.
+
+The schedule (``schedules/note_export``) runs this with ``overlap=SKIP`` and a
+stable workflow id, so runs never interleave and the watermark advance is
+effectively single-threaded.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from urllib.parse import urlsplit, urlunsplit
+
+from temporalio import activity, workflow
+from temporalio.common import RetryPolicy
+
+with workflow.unsafe.imports_passed_through():
+    from projects.lakehouse.events.envelope import build_envelope
+    from projects.lakehouse.events.publish import publish_event, subject_for
+    from projects.lakehouse.events.registry.note import (
+        NoteChunk,
+        NoteTombstonedPayload,
+        NoteUpdatedPayload,
+    )
+    from projects.lakehouse.nats_client.client import NatsClient
+
+# --- constants ------------------------------------------------------------
+
+ENTITY_TYPE = "note"
+PRODUCER = "lakehouse.export"
+# Watermark row key in lakehouse.export_state (one row per logical export).
+WATERMARK_NAME = "note-export"
+# Lakehouse catalog DB name (matches iceberg.catalog DEFAULT_CATALOG_DB); the
+# watermark lives here, not in the monolith's knowledge schema.
+DEFAULT_CATALOG_DB = "lakehouse"
+
+DEFAULT_BATCH_SIZE = 50
+# Re-scan window (seconds) below the stored watermark — covers transactions that
+# were assigned change_at = now() but committed after a prior run snapshotted,
+# so they'd otherwise sit invisibly under the high-water mark. Idempotency makes
+# re-reading this window harmless.
+DEFAULT_MARGIN_SECONDS = 300
+DEFAULT_CONTINUE_AS_NEW_THRESHOLD = 500
+
+
+@dataclass
+class ExportInput:
+    """Resumable input for the incremental export.
+
+    ``lower_bound`` (the fixed ``watermark - margin`` floor for this run) and the
+    keyset cursor ``(cursor_change_at, cursor_id)`` carry across
+    ``continue_as_new`` so a long delta paginates without re-reading. ``processed``
+    is the running total; ``last_change_at`` is the high-water ``change_at`` seen
+    so far, written back to the watermark when the run completes.
+    """
+
+    lower_bound: str | None = None
+    cursor_change_at: str | None = None
+    cursor_id: int = 0
+    processed: int = 0
+    last_change_at: str | None = None
+    batch_size: int = DEFAULT_BATCH_SIZE
+    margin_seconds: int = DEFAULT_MARGIN_SECONDS
+    continue_as_new_threshold: int = DEFAULT_CONTINUE_AS_NEW_THRESHOLD
+
+
+# --- db url helpers -------------------------------------------------------
+
+
+def _resolve_knowledge_db_url() -> str:
+    """Read ``DATABASE_URL`` (monolith-pg) as a plain libpq URL for psycopg."""
+    url = os.environ.get("DATABASE_URL")
+    if not url or not url.strip():
+        raise RuntimeError("DATABASE_URL is required for the note export")
+    return url.strip().replace("postgresql+psycopg://", "postgresql://", 1)
+
+
+def _resolve_lakehouse_db_url() -> str:
+    """Derive the lakehouse-DB libpq URL from ``DATABASE_URL``.
+
+    Reuses the monolith-pg credentials against the dedicated ``lakehouse``
+    database (``ICEBERG_CATALOG_DB``, default ``lakehouse``) — the same database
+    the Iceberg SqlCatalog uses — so the watermark never touches the monolith's
+    ``knowledge`` schema. Mirrors ``iceberg.catalog._catalog_uri`` but returns a
+    plain ``postgresql://`` URL psycopg.connect accepts.
+    """
+    base = _resolve_knowledge_db_url()
+    db = os.environ.get("ICEBERG_CATALOG_DB", DEFAULT_CATALOG_DB)
+    parts = urlsplit(base)
+    return urlunsplit(parts._replace(path=f"/{db}"))
+
+
+# --- activities -----------------------------------------------------------
+
+_CREATE_STATE_SQL = """
+CREATE TABLE IF NOT EXISTS export_state (
+    name       text PRIMARY KEY,
+    watermark  timestamptz NOT NULL,
+    updated_at timestamptz NOT NULL DEFAULT now()
+)
+""".strip()
+
+# Monotonic per-row change marker: the later of (re)index and soft-delete.
+_CHANGE_AT = "GREATEST(indexed_at, COALESCE(deleted_at, indexed_at))"
+
+# Corpus membership. A row belongs to the export if it is a live ``_processed``
+# note OR a soft-deleted note that WAS in ``_processed`` before the monolith's
+# ``delete_note`` rewrote its path to ``_trash/`` (it stashes the original in
+# ``pre_delete_path``). The pre_delete_path branch is load-bearing: a soft delete
+# stamps ``deleted_at`` *and* moves the path out of ``_processed/`` in the same
+# commit, so gating only on ``path LIKE '_processed/%'`` would silently never
+# emit a tombstone and the deleted note's vectors would stay indexed forever.
+# ``%%`` (parameterized queries only — psycopg3 unescapes to a single ``%``).
+_CORPUS_MEMBER = (
+    "((deleted_at IS NULL AND path LIKE '_processed/%%') "
+    "OR (deleted_at IS NOT NULL AND pre_delete_path LIKE '_processed/%%'))"
+)
+
+
+@activity.defn
+async def read_export_lower_bound(name: str, margin_seconds: int) -> str:
+    """Return the inclusive lower bound (ISO) for this run: ``watermark - margin``.
+
+    Ensures ``export_state`` exists. On first sight (no row), initializes the
+    watermark to the *current* max ``change_at`` in the corpus — i.e. it assumes
+    the one-shot bootstrap already seeded history, so the first incremental run is
+    a near-no-op rather than a redundant full re-export. (To force a full
+    re-export, ``UPDATE export_state SET watermark = '1970-01-01' WHERE name=…``.)
+    """
+    import psycopg
+
+    with psycopg.connect(_resolve_lakehouse_db_url()) as conn:
+        with conn.cursor() as cur:
+            cur.execute(_CREATE_STATE_SQL)
+            cur.execute(
+                "SELECT watermark FROM export_state WHERE name = %(name)s",
+                {"name": name},
+            )
+            row = cur.fetchone()
+            if row is not None:
+                watermark = row[0]
+            else:
+                # Initialize from the corpus's current high-water change_at.
+                with psycopg.connect(_resolve_knowledge_db_url()) as kconn:
+                    with kconn.cursor() as kcur:
+                        # No params on this execute, so psycopg3 does NOT unescape
+                        # %% -> % here; use single % directly. Mirrors _CORPUS_MEMBER
+                        # so the seed watermark accounts for soft-deletes too.
+                        kcur.execute(
+                            f"SELECT MAX({_CHANGE_AT}) FROM knowledge.notes "
+                            "WHERE (deleted_at IS NULL AND path LIKE '_processed/%') "
+                            "OR (deleted_at IS NOT NULL "
+                            "AND pre_delete_path LIKE '_processed/%')"
+                        )
+                        watermark = kcur.fetchone()[0] or datetime(
+                            1970, 1, 1, tzinfo=timezone.utc
+                        )
+                cur.execute(
+                    "INSERT INTO export_state (name, watermark) "
+                    "VALUES (%(name)s, %(watermark)s) "
+                    "ON CONFLICT (name) DO NOTHING",
+                    {"name": name, "watermark": watermark},
+                )
+        conn.commit()
+
+    lower = watermark - timedelta(seconds=margin_seconds)
+    return lower.isoformat()
+
+
+@activity.defn
+async def read_note_changes_batch(
+    lower_bound: str,
+    cursor_change_at: str | None,
+    cursor_id: int,
+    limit: int,
+) -> list[dict]:
+    """Read one keyset page of changed ``_processed`` notes since ``lower_bound``.
+
+    Single ``REPEATABLE READ`` snapshot: pages by ``(change_at, id)`` so the scan
+    is stable under concurrent inserts, then fetches chunks for the *live* notes
+    in the page in one round-trip. Soft-deleted notes (``deleted_at IS NOT NULL``)
+    are returned as tombstones (no body/embeddings — ADR 017 RTBF); live notes
+    carry their chunks. Each row is tagged with the ``event_type`` and the
+    source-derived ``event_version`` (epoch-millis of its ``change_at``).
+    """
+    import psycopg
+
+    cursor_ts = cursor_change_at if cursor_change_at is not None else lower_bound
+
+    ordered_pks: list[int] = []
+    live_ids: list[int] = []
+    by_pk: dict[int, dict] = {}
+
+    with psycopg.connect(_resolve_knowledge_db_url()) as conn:
+        # One snapshot for both queries so a note's metadata and its chunk
+        # embeddings (committed together by upsert_note) can't be torn apart.
+        conn.isolation_level = psycopg.IsolationLevel.REPEATABLE_READ
+        with conn.cursor() as cur:
+            cur.execute(
+                f"""
+                SELECT id, note_id, path, title, content_hash, type, status,
+                       visibility, tags, aliases, indexed_at, deleted_at,
+                       {_CHANGE_AT} AS change_at
+                FROM knowledge.notes
+                WHERE {_CORPUS_MEMBER}
+                  -- psycopg3 sends str params as text; cast so the comparison is
+                  -- timestamptz>timestamptz, not the missing timestamptz>text op.
+                  AND {_CHANGE_AT} > %(lower)s::timestamptz
+                  AND ({_CHANGE_AT}, id) > (%(cursor_ts)s::timestamptz, %(cursor_id)s)
+                ORDER BY change_at, id
+                LIMIT %(limit)s
+                """,
+                {
+                    "lower": lower_bound,
+                    "cursor_ts": cursor_ts,
+                    "cursor_id": cursor_id,
+                    "limit": limit,
+                },
+            )
+            for row in cur.fetchall():
+                (
+                    pk,
+                    note_id,
+                    path,
+                    title,
+                    content_hash,
+                    note_type,
+                    status,
+                    visibility,
+                    tags,
+                    aliases,
+                    indexed_at,
+                    deleted_at,
+                    change_at,
+                ) = row
+                ordered_pks.append(pk)
+                # event_version = epoch-millis of the change marker (int64).
+                version = int(change_at.timestamp() * 1000)
+                if deleted_at is not None:
+                    by_pk[pk] = {
+                        "note_id": note_id,
+                        "event_type": "tombstoned",
+                        "event_version": version,
+                        "change_at": change_at.isoformat(),
+                        "id": pk,
+                    }
+                else:
+                    live_ids.append(pk)
+                    by_pk[pk] = {
+                        "note_id": note_id,
+                        "path": path,
+                        "title": title or "",
+                        "content_hash": content_hash or "",
+                        "type": note_type or "",
+                        "status": status or "",
+                        "visibility": visibility or "",
+                        "tags": list(tags) if tags else [],
+                        "aliases": list(aliases) if aliases else [],
+                        "chunks": [],
+                        "event_type": "updated",
+                        "event_version": version,
+                        "change_at": change_at.isoformat(),
+                        "id": pk,
+                    }
+
+            if live_ids:
+                cur.execute(
+                    """
+                    SELECT note_fk, chunk_index, section_header,
+                           chunk_text, embedding::real[]
+                    FROM knowledge.chunks
+                    WHERE note_fk = ANY(%(ids)s)
+                    ORDER BY note_fk, chunk_index
+                    """,
+                    {"ids": live_ids},
+                )
+                for (
+                    note_fk,
+                    chunk_index,
+                    section_header,
+                    chunk_text,
+                    embedding,
+                ) in cur.fetchall():
+                    note = by_pk.get(note_fk)
+                    if note is None:
+                        continue
+                    note["chunks"].append(
+                        {
+                            "chunk_index": chunk_index,
+                            "section_header": section_header,
+                            "chunk_text": chunk_text or "",
+                            "embedding": (
+                                [float(x) for x in embedding] if embedding else []
+                            ),
+                        }
+                    )
+
+    # Return in the SQL's (change_at, id) order — trust the server's timestamptz
+    # ordering rather than re-deriving it from ISO strings (which would mis-sort
+    # under a non-UTC session timezone), so the workflow's batch[-1] cursor is
+    # always the true page maximum.
+    return [by_pk[pk] for pk in ordered_pks]
+
+
+@activity.defn
+async def publish_note_change_events(batch: list[dict]) -> int:
+    """Publish each changed note as its ``updated`` / ``tombstoned`` domain event.
+
+    Reuses the ADR-017 envelope + NATS publisher. ``event_type`` and
+    ``event_version`` come from the row (set by :func:`read_note_changes_batch`),
+    so the dedup key ``{note_id}-v{version}`` is source-derived and idempotent.
+    Tombstones carry only the note id (no body/embeddings).
+    """
+    if not batch:
+        return 0
+
+    nats_client = NatsClient()
+    await nats_client.connect()
+    published = 0
+    try:
+        for note in batch:
+            event_type = note["event_type"]
+            if event_type == "tombstoned":
+                payload = NoteTombstonedPayload(note_id=note["note_id"])
+            else:
+                chunks = [
+                    NoteChunk(
+                        chunk_index=chunk["chunk_index"],
+                        section_header=chunk.get("section_header"),
+                        chunk_text=chunk["chunk_text"],
+                        embedding=chunk.get("embedding", []),
+                    )
+                    for chunk in note.get("chunks", [])
+                ]
+                payload = NoteUpdatedPayload(
+                    note_id=note["note_id"],
+                    path=note["path"],
+                    title=note["title"],
+                    content_hash=note["content_hash"],
+                    type=note["type"],
+                    status=note["status"],
+                    visibility=note["visibility"],
+                    tags=note.get("tags", []),
+                    aliases=note.get("aliases", []),
+                    chunks=chunks,
+                )
+            envelope = build_envelope(
+                entity_type=ENTITY_TYPE,
+                entity_id=note["note_id"],
+                event_type=event_type,
+                event_version=note["event_version"],
+                producer=PRODUCER,
+                payload=payload.model_dump(),
+            )
+            await publish_event(nats_client, envelope, subject=subject_for(envelope))
+            published += 1
+    finally:
+        await nats_client.close()
+
+    return published
+
+
+@activity.defn
+async def advance_export_watermark(name: str, watermark: str) -> None:
+    """Set ``export_state.watermark`` to ``watermark`` (monotonically).
+
+    Uses ``GREATEST`` so a stale/replayed advance can never move the watermark
+    backwards. Called once per run after all batches publish, so a mid-run crash
+    leaves the watermark untouched and the next run safely re-reads (idempotent).
+    """
+    import psycopg
+
+    with psycopg.connect(_resolve_lakehouse_db_url()) as conn:
+        with conn.cursor() as cur:
+            cur.execute(_CREATE_STATE_SQL)
+            cur.execute(
+                """
+                INSERT INTO export_state (name, watermark)
+                VALUES (%(name)s, %(watermark)s::timestamptz)
+                ON CONFLICT (name) DO UPDATE
+                SET watermark = GREATEST(export_state.watermark, EXCLUDED.watermark),
+                    updated_at = now()
+                """,
+                {"name": name, "watermark": watermark},
+            )
+        conn.commit()
+
+
+# --- workflow -------------------------------------------------------------
+
+
+@workflow.defn
+class ExportNoteChangesWorkflow:
+    """Forward note adds/updates/soft-deletes changed since the watermark.
+
+    Resolves ``lower_bound = watermark - margin`` once, keyset-paginates the
+    changed set, publishes each page, and advances the watermark to the highest
+    ``change_at`` processed. ``continue_as_new`` keeps a large delta replay-cheap.
+    Returns the number of events forwarded across all segments.
+    """
+
+    @workflow.run
+    async def run(self, params: ExportInput | None = None) -> int:
+        params = params or ExportInput()
+
+        retry = RetryPolicy(
+            initial_interval=timedelta(seconds=1),
+            backoff_coefficient=2.0,
+            maximum_interval=timedelta(minutes=1),
+            maximum_attempts=5,
+        )
+
+        lower_bound = params.lower_bound
+        if lower_bound is None:
+            lower_bound = await workflow.execute_activity(
+                read_export_lower_bound,
+                args=[WATERMARK_NAME, params.margin_seconds],
+                start_to_close_timeout=timedelta(minutes=2),
+                retry_policy=retry,
+            )
+
+        cursor_change_at = params.cursor_change_at
+        cursor_id = params.cursor_id
+        processed = params.processed
+        last_change_at = params.last_change_at
+        processed_this_run = 0
+
+        while True:
+            batch = await workflow.execute_activity(
+                read_note_changes_batch,
+                args=[lower_bound, cursor_change_at, cursor_id, params.batch_size],
+                start_to_close_timeout=timedelta(minutes=5),
+                retry_policy=retry,
+            )
+            if not batch:
+                break
+
+            published = await workflow.execute_activity(
+                publish_note_change_events,
+                args=[batch],
+                start_to_close_timeout=timedelta(minutes=5),
+                retry_policy=retry,
+            )
+            processed += published
+            processed_this_run += published
+
+            # Advance the keyset cursor + high-water mark to the last (sorted) row.
+            cursor_change_at = batch[-1]["change_at"]
+            cursor_id = batch[-1]["id"]
+            last_change_at = cursor_change_at
+
+            if len(batch) < params.batch_size:
+                break
+
+            if processed_this_run >= params.continue_as_new_threshold:
+                workflow.continue_as_new(
+                    args=[
+                        ExportInput(
+                            lower_bound=lower_bound,
+                            cursor_change_at=cursor_change_at,
+                            cursor_id=cursor_id,
+                            processed=processed,
+                            last_change_at=last_change_at,
+                            batch_size=params.batch_size,
+                            margin_seconds=params.margin_seconds,
+                            continue_as_new_threshold=params.continue_as_new_threshold,
+                        )
+                    ]
+                )
+
+        # Persist progress only after the full delta is forwarded.
+        if last_change_at is not None:
+            await workflow.execute_activity(
+                advance_export_watermark,
+                args=[WATERMARK_NAME, last_change_at],
+                start_to_close_timeout=timedelta(minutes=2),
+                retry_policy=retry,
+            )
+
+        return processed
+
+
+# Auto-discovery exports (read by the workflows package loader).
+WORKFLOWS = [ExportNoteChangesWorkflow]
+ACTIVITIES = [
+    read_export_lower_bound,
+    read_note_changes_batch,
+    publish_note_change_events,
+    advance_export_watermark,
+]

--- a/projects/lakehouse/orchestrator/workflows/export_note_changes_test.py
+++ b/projects/lakehouse/orchestrator/workflows/export_note_changes_test.py
@@ -1,0 +1,402 @@
+"""Hermetic tests for the incremental note-export workflow.
+
+No Temporal server, no DB, no network: psycopg's ``connect`` is patched to a fake
+connection returning canned rows, the NATS client is a fake that captures
+publishes, and coroutines run via ``asyncio.run`` (no pytest-asyncio plugin).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from contextlib import contextmanager
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+
+import temporalio.workflow
+
+import projects.lakehouse.orchestrator.workflows.export_note_changes as enc
+from projects.lakehouse.orchestrator.workflows.export_note_changes import (
+    ACTIVITIES,
+    PRODUCER,
+    WORKFLOWS,
+    ExportNoteChangesWorkflow,
+    advance_export_watermark,
+    publish_note_change_events,
+    read_export_lower_bound,
+    read_note_changes_batch,
+)
+
+EMBEDDING_1024 = [0.001 * i for i in range(1024)]
+_T0 = datetime(2026, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
+_T1 = datetime(2026, 6, 1, 12, 5, 0, tzinfo=timezone.utc)
+
+
+# --- fakes ----------------------------------------------------------------
+
+
+class FakeCursor:
+    def __init__(self, note_rows, chunk_rows):
+        self._note_rows = note_rows
+        self._chunk_rows = chunk_rows
+        self._pending: list = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def execute(self, sql, params=None):
+        if "FROM knowledge.notes" in sql:
+            self._pending = list(self._note_rows)
+        elif "FROM knowledge.chunks" in sql:
+            self._pending = list(self._chunk_rows)
+        else:  # pragma: no cover - defensive
+            raise AssertionError(f"unexpected query: {sql}")
+
+    def fetchall(self):
+        return self._pending
+
+
+class FakeConn:
+    """Fake psycopg connection; accepts ``isolation_level`` assignment."""
+
+    def __init__(self, cursor):
+        self._cursor = cursor
+        self.isolation_level = None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def cursor(self):
+        return self._cursor
+
+
+@contextmanager
+def patched_psycopg(note_rows, chunk_rows):
+    import psycopg
+
+    fake = FakeConn(FakeCursor(note_rows, chunk_rows))
+    with (
+        patch.object(psycopg, "connect", return_value=fake),
+        patch.dict(
+            enc.os.environ,
+            {"DATABASE_URL": "postgresql://app:app@localhost:5432/monolith"},
+        ),
+    ):
+        yield fake
+
+
+class FakeNatsClient:
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+        self.connected = False
+        self.closed = False
+
+    async def connect(self) -> None:
+        self.connected = True
+
+    async def publish(self, subject, payload, *, msg_id=None, headers=None) -> None:
+        self.calls.append({"subject": subject, "payload": payload, "msg_id": msg_id})
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+def _note_row(pk, note_id, indexed_at, deleted_at=None):
+    # (id, note_id, path, title, content_hash, type, status, visibility,
+    #  tags, aliases, indexed_at, deleted_at, change_at)
+    change_at = max(indexed_at, deleted_at) if deleted_at else indexed_at
+    return (
+        pk,
+        note_id,
+        f"_processed/{note_id}.md",
+        f"Title {note_id}",
+        f"hash-{pk}",
+        "atom",
+        "active",
+        "public",
+        ["tag-a"],
+        [f"alias-{note_id}"],
+        indexed_at,
+        deleted_at,
+        change_at,
+    )
+
+
+def _chunk_row(note_fk, idx, embedding=None):
+    return (note_fk, idx, f"§{idx}", f"chunk {idx}", embedding or EMBEDDING_1024)
+
+
+# --- URL helpers ----------------------------------------------------------
+
+
+def test_lakehouse_db_url_swaps_db_and_normalizes_dialect():
+    with patch.dict(
+        enc.os.environ,
+        {"DATABASE_URL": "postgresql+psycopg://app:pw@host:5432/monolith"},
+        clear=True,
+    ):
+        assert (
+            enc._resolve_lakehouse_db_url() == "postgresql://app:pw@host:5432/lakehouse"
+        )
+
+
+def test_lakehouse_db_url_honors_catalog_db_override():
+    with patch.dict(
+        enc.os.environ,
+        {
+            "DATABASE_URL": "postgresql://app@host:5432/monolith",
+            "ICEBERG_CATALOG_DB": "lh2",
+        },
+        clear=True,
+    ):
+        assert enc._resolve_lakehouse_db_url() == "postgresql://app@host:5432/lh2"
+
+
+# --- read_note_changes_batch ---------------------------------------------
+
+
+def test_read_batch_emits_updated_with_chunks_and_epoch_version():
+    rows = [_note_row(1, "alpha", _T0)]
+    chunks = [_chunk_row(1, 0), _chunk_row(1, 1)]
+    with patched_psycopg(rows, chunks):
+        batch = asyncio.run(read_note_changes_batch("1970-01-01", None, 0, 50))
+
+    assert len(batch) == 1
+    note = batch[0]
+    assert note["event_type"] == "updated"
+    # event_version = epoch-millis of indexed_at (the change marker).
+    assert note["event_version"] == int(_T0.timestamp() * 1000)
+    assert note["note_id"] == "alpha"
+    assert len(note["chunks"]) == 2
+    assert note["chunks"][0]["embedding"] == EMBEDDING_1024
+
+
+def test_read_batch_emits_tombstone_for_soft_deleted_note():
+    # deleted_at set + later than indexed_at -> tombstone versioned on deleted_at,
+    # carrying NO chunks (RTBF: body/embeddings not forwarded).
+    rows = [_note_row(2, "gone", _T0, deleted_at=_T1)]
+    with patched_psycopg(rows, chunk_rows=[]):
+        batch = asyncio.run(read_note_changes_batch("1970-01-01", None, 0, 50))
+
+    assert len(batch) == 1
+    note = batch[0]
+    assert note["event_type"] == "tombstoned"
+    assert note["event_version"] == int(_T1.timestamp() * 1000)
+    assert "chunks" not in note
+
+
+def test_read_batch_sets_repeatable_read_snapshot():
+    import psycopg
+
+    rows = [_note_row(1, "alpha", _T0)]
+    with patched_psycopg(rows, [_chunk_row(1, 0)]) as conn:
+        asyncio.run(read_note_changes_batch("1970-01-01", None, 0, 50))
+    # The note + its chunks must be read in ONE snapshot so they can't be torn.
+    assert conn.isolation_level == psycopg.IsolationLevel.REPEATABLE_READ
+
+
+def test_read_batch_empty_returns_empty_list():
+    with patched_psycopg(note_rows=[], chunk_rows=[]):
+        assert asyncio.run(read_note_changes_batch("1970-01-01", None, 0, 50)) == []
+
+
+# --- publish_note_change_events ------------------------------------------
+
+
+def _updated_dict(note_id, version):
+    return {
+        "note_id": note_id,
+        "path": f"_processed/{note_id}.md",
+        "title": "T",
+        "content_hash": "h",
+        "type": "atom",
+        "status": "active",
+        "visibility": "public",
+        "tags": [],
+        "aliases": [],
+        "chunks": [
+            {
+                "chunk_index": 0,
+                "section_header": None,
+                "chunk_text": "c",
+                "embedding": EMBEDDING_1024,
+            }
+        ],
+        "event_type": "updated",
+        "event_version": version,
+    }
+
+
+def _tombstone_dict(note_id, version):
+    return {"note_id": note_id, "event_type": "tombstoned", "event_version": version}
+
+
+def test_publish_updated_carries_body_and_source_derived_msg_id():
+    fake = FakeNatsClient()
+    with patch.object(enc, "NatsClient", return_value=fake):
+        count = asyncio.run(
+            publish_note_change_events([_updated_dict("alpha", 1717243200000)])
+        )
+
+    assert count == 1
+    call = fake.calls[0]
+    assert call["msg_id"] == "alpha-v1717243200000"
+    body = json.loads(call["payload"])
+    assert body["event_type"] == "updated"
+    assert body["producer"] == PRODUCER
+    assert body["payload"]["chunks"][0]["embedding"] == EMBEDDING_1024
+    assert fake.closed is True
+
+
+def test_publish_tombstone_has_no_body_or_embeddings():
+    fake = FakeNatsClient()
+    with patch.object(enc, "NatsClient", return_value=fake):
+        asyncio.run(
+            publish_note_change_events([_tombstone_dict("gone", 1717243500000)])
+        )
+
+    body = json.loads(fake.calls[0]["payload"])
+    assert body["event_type"] == "tombstoned"
+    assert fake.calls[0]["msg_id"] == "gone-v1717243500000"
+    # Tombstone payload carries only the note id (+ optional reason) — no chunks.
+    assert "chunks" not in body["payload"]
+    assert body["payload"]["note_id"] == "gone"
+
+
+def test_publish_empty_batch_is_noop_no_connect():
+    fake = FakeNatsClient()
+    with patch.object(enc, "NatsClient", return_value=fake):
+        assert asyncio.run(publish_note_change_events([])) == 0
+    assert fake.connected is False
+
+
+# --- corpus membership (the soft-delete tombstone fix) -------------------
+
+
+def test_corpus_member_includes_pre_delete_path():
+    # The HIGH-severity fix: soft-delete rewrites path out of _processed/ into
+    # _trash/ while stashing the original in pre_delete_path. Membership MUST
+    # gate deleted rows on pre_delete_path, or no tombstone is ever emitted.
+    member = enc._CORPUS_MEMBER
+    assert "deleted_at IS NULL AND path LIKE '_processed/%%'" in member
+    assert "deleted_at IS NOT NULL AND pre_delete_path LIKE '_processed/%%'" in member
+
+
+# --- watermark activities (read_export_lower_bound / advance) -------------
+
+
+class _WmCursor:
+    """Routes the watermark/seed queries; records executed SQL."""
+
+    def __init__(self, watermark_row, max_change_at):
+        self._watermark_row = watermark_row  # None or (datetime,)
+        self._max_change_at = max_change_at  # datetime or None
+        self.executed: list[str] = []
+        self._last = None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def execute(self, sql, params=None):
+        self.executed.append(sql)
+        if "SELECT watermark FROM export_state" in sql:
+            self._last = self._watermark_row
+        elif "SELECT MAX(" in sql:
+            self._last = (self._max_change_at,)
+        else:  # CREATE TABLE / INSERT — no result row
+            self._last = None
+
+    def fetchone(self):
+        return self._last
+
+
+class _WmConn:
+    def __init__(self, cursor):
+        self._cursor = cursor
+        self.committed = False
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def cursor(self):
+        return self._cursor
+
+    def commit(self):
+        self.committed = True
+
+
+@contextmanager
+def _patched_wm(watermark_row, max_change_at):
+    import psycopg
+
+    conn = _WmConn(_WmCursor(watermark_row, max_change_at))
+    with (
+        patch.object(psycopg, "connect", return_value=conn),
+        patch.dict(
+            enc.os.environ,
+            {"DATABASE_URL": "postgresql://app:app@localhost:5432/monolith"},
+        ),
+    ):
+        yield conn
+
+
+def test_lower_bound_first_run_seeds_from_max_change_at():
+    # No watermark row yet -> seed from the corpus MAX(change_at) and return
+    # MAX - margin (assumes the bootstrap already covered history).
+    with _patched_wm(watermark_row=None, max_change_at=_T1) as conn:
+        lb = asyncio.run(read_export_lower_bound("note-export", 300))
+
+    assert lb == (_T1 - timedelta(seconds=300)).isoformat()
+    assert any("INSERT INTO export_state" in s for s in conn._cursor.executed)
+    assert conn.committed is True
+
+
+def test_lower_bound_uses_existing_watermark_minus_margin():
+    with _patched_wm(watermark_row=(_T1,), max_change_at=None) as conn:
+        lb = asyncio.run(read_export_lower_bound("note-export", 60))
+
+    assert lb == (_T1 - timedelta(seconds=60)).isoformat()
+    # Existing watermark -> no seed INSERT, no MAX query needed.
+    assert not any("INSERT INTO export_state" in s for s in conn._cursor.executed)
+    assert not any("SELECT MAX(" in s for s in conn._cursor.executed)
+
+
+def test_advance_watermark_upserts_monotonically_with_greatest():
+    with _patched_wm(watermark_row=None, max_change_at=None) as conn:
+        asyncio.run(advance_export_watermark("note-export", _T1.isoformat()))
+
+    joined = " ".join(conn._cursor.executed)
+    assert "INSERT INTO export_state" in joined
+    # GREATEST so a stale/replayed advance never moves the watermark backwards.
+    assert "GREATEST(export_state.watermark, EXCLUDED.watermark)" in joined
+    assert conn.committed is True
+
+
+# --- exports --------------------------------------------------------------
+
+
+def test_workflow_is_defn_and_exported():
+    assert ExportNoteChangesWorkflow in WORKFLOWS
+    assert temporalio.workflow._Definition.from_class(ExportNoteChangesWorkflow)
+
+
+def test_activities_exported():
+    names = {getattr(a, "__name__", "") for a in ACTIVITIES}
+    assert {
+        "read_export_lower_bound",
+        "read_note_changes_batch",
+        "publish_note_change_events",
+        "advance_export_watermark",
+    } <= names


### PR DESCRIPTION
Keeps the lakehouse fresh after the one-shot bootstrap, **hook-free** — it observes PG (`knowledge.notes`), the convergence point for every edit, rather than the filesystem. A daily watermark poll forwards adds/updates/soft-deletes as `created`/`updated`/`tombstoned` events that flow NATS → Iceberg → serving DuckDB.

## Design
- **`ExportNoteChangesWorkflow`** — keyset-paginates `(change_at, id)` where `change_at = GREATEST(indexed_at, deleted_at)`, in **one `REPEATABLE READ` snapshot** (a note's metadata + chunk embeddings — committed together by `upsert_note` — can't be torn apart). Watermark lives in the **lakehouse** PG DB (`export_state`, never the monolith `knowledge` schema); advanced once at the end (crash → re-read → safe).
- **`event_version = epoch-millis(change_at)`** — *source-derived*, so it's idempotent under Temporal activity retry and the watermark re-scan margin (same change → same `{note_id}-v{ms}` dedup key), and monotonic per note so the fold's `MAX` picks the latest revision.
- **`note-export` schedule** — daily, `overlap=SKIP` (runs never interleave → the watermark advance is single-threaded).
- **Idempotent serving fold** — `ROW_NUMBER` dedup per `(note_id, event_version, chunk_index)`, so at-least-once redelivery / re-scan / bootstrap re-runs can't double-index a chunk (also fixes a latent constant-`v1` dup bug).

## Reviewed adversarially (5-agent workflow); fixes applied
- **HIGH** — soft-delete rewrites `path` `_processed/`→`_trash/` (stashing the original in `pre_delete_path`), so gating only on `path LIKE '_processed/%'` would **never tombstone a deleted note** (stale vectors forever). Membership now gates deleted rows on `pre_delete_path`.
- **MED** — a tombstone tied at the same epoch-ms version as its content didn't win the fold; now a note is dropped if **any** max-version row is tombstoned (note-level `NOT IN`).
- **LOW** — an empty/wrong-width embedding would crash the fixed-size `CAST` for the *whole* build → fold also requires `len(embedding) = dim`.
- **LOW** — keyset cursor re-sorted pages by ISO string (mis-orders under a non-UTC session tz) → return in the SQL's `timestamptz` order.
- The two watermark activities are now tested; `build_serving`'s async test converted to `asyncio.run` so it actually executes.

## Scope / follow-up
Forwards **adds / updates / soft-deletes**. **Hard deletes** (`store.delete_note` physically removes the row) can't be forwarded — nothing left to read — and need a periodic **reconcile** pass (diff live PG note_ids vs the served set, tombstone the difference). Documented as a fast-follow.

No chart/deploy/image change — workers auto-discover the new workflow + schedule on next rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)