### PR TITLE
chore(lakehouse): bump chart 0.2.2 -> 0.2.3 (roll incremental export)

### DIFF
--- a/projects/lakehouse/chart/Chart.yaml
+++ b/projects/lakehouse/chart/Chart.yaml
@@ -6,5 +6,5 @@ description: >-
   callers), and the NATS->Iceberg/serving dispatchers. ADRs agents/015 (Temporal
   worker pools) and platform/004 (Iceberg lakehouse + hot-swap Quack serving).
 type: application
-version: 0.2.2
+version: 0.2.3
 appVersion: "0.1.0"

--- a/projects/lakehouse/deploy/application.yaml
+++ b/projects/lakehouse/deploy/application.yaml
@@ -18,7 +18,7 @@ spec:
     # path at HEAD) is what makes the merge of new images actually roll the pods.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: lakehouse
-      targetRevision: 0.2.2
+      targetRevision: 0.2.3
       helm:
         releaseName: lakehouse
         # The chart's packaged values.yaml (with pinned image tags) is the base;


### PR DESCRIPTION
Rolls #2444 (incremental note-change export) into the cluster. That PR changed worker code only, so the chart pin must be refreshed: bumping the version makes CI republish with `helm_images_values` re-pinning the post-#2444 worker image, and ArgoCD rolls the pods (workers then register the `note-export` schedule on boot). `targetRevision` bumped in lockstep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)