### PR TITLE
test(lakehouse): cover _s3_client scheme-guard and _resolve_knowledge_db_url

### DIFF
--- a/projects/lakehouse/orchestrator/workflows/build_serving_test.py
+++ b/projects/lakehouse/orchestrator/workflows/build_serving_test.py
@@ -225,3 +225,25 @@ def test_s3_client_prefixes_http_for_scheme_less_endpoint() -> None:
         mod._s3_client()
 
     assert created["endpoint_url"] == "http://sw-gateway:8333"
+
+
+def test_s3_client_https_endpoint_passes_through_unchanged() -> None:
+    """An existing ``https://`` endpoint must reach boto3 without modification."""
+    created = {}
+
+    fake_boto3 = MagicMock()
+    fake_boto3.client.side_effect = lambda service, **kw: (
+        created.update(kw) or MagicMock()
+    )
+
+    with (
+        patch.dict(
+            "os.environ",
+            {"SEAWEEDFS_S3_ENDPOINT": "https://s3.example.com"},
+            clear=False,
+        ),
+        patch.dict("sys.modules", {"boto3": fake_boto3}),
+    ):
+        mod._s3_client()
+
+    assert created["endpoint_url"] == "https://s3.example.com"

--- a/projects/lakehouse/orchestrator/workflows/export_note_changes_test.py
+++ b/projects/lakehouse/orchestrator/workflows/export_note_changes_test.py
@@ -159,8 +159,7 @@ def test_knowledge_db_url_normalizes_psycopg_dialect():
         clear=True,
     ):
         assert (
-            enc._resolve_knowledge_db_url()
-            == "postgresql://app:pw@host:5432/monolith"
+            enc._resolve_knowledge_db_url() == "postgresql://app:pw@host:5432/monolith"
         )
 
 

--- a/projects/lakehouse/orchestrator/workflows/export_note_changes_test.py
+++ b/projects/lakehouse/orchestrator/workflows/export_note_changes_test.py
@@ -13,6 +13,8 @@ from contextlib import contextmanager
 from datetime import datetime, timedelta, timezone
 from unittest.mock import patch
 
+import pytest
+
 import temporalio.workflow
 
 import projects.lakehouse.orchestrator.workflows.export_note_changes as enc
@@ -133,6 +135,40 @@ def _chunk_row(note_fk, idx, embedding=None):
 
 
 # --- URL helpers ----------------------------------------------------------
+
+
+def test_knowledge_db_url_missing_raises_runtime_error():
+    """Missing DATABASE_URL must raise RuntimeError (not KeyError or AttributeError)."""
+    with patch.dict(enc.os.environ, {}, clear=True):
+        with pytest.raises(RuntimeError, match="DATABASE_URL"):
+            enc._resolve_knowledge_db_url()
+
+
+def test_knowledge_db_url_blank_raises_runtime_error():
+    """A blank (whitespace-only) DATABASE_URL must also raise RuntimeError."""
+    with patch.dict(enc.os.environ, {"DATABASE_URL": "   "}, clear=True):
+        with pytest.raises(RuntimeError, match="DATABASE_URL"):
+            enc._resolve_knowledge_db_url()
+
+
+def test_knowledge_db_url_normalizes_psycopg_dialect():
+    """``postgresql+psycopg://`` dialect must be normalised to ``postgresql://``."""
+    with patch.dict(
+        enc.os.environ,
+        {"DATABASE_URL": "postgresql+psycopg://app:pw@host:5432/monolith"},
+        clear=True,
+    ):
+        assert (
+            enc._resolve_knowledge_db_url()
+            == "postgresql://app:pw@host:5432/monolith"
+        )
+
+
+def test_knowledge_db_url_plain_postgresql_passes_through():
+    """A ``postgresql://`` URL must pass through unchanged."""
+    url = "postgresql://app:pw@host:5432/monolith"
+    with patch.dict(enc.os.environ, {"DATABASE_URL": url}, clear=True):
+        assert enc._resolve_knowledge_db_url() == url
 
 
 def test_lakehouse_db_url_swaps_db_and_normalizes_dialect():

--- a/projects/lakehouse/orchestrator/workflows/tag_rotation_test.py
+++ b/projects/lakehouse/orchestrator/workflows/tag_rotation_test.py
@@ -10,6 +10,7 @@ constant instead.
 
 from __future__ import annotations
 
+import os
 from datetime import timedelta
 from unittest.mock import patch
 
@@ -183,8 +184,6 @@ def test_s3_client_schemeless_endpoint_prefixes_http() -> None:
     The chart injects host:port without a scheme (shared with DuckDB's httpfs);
     boto3 raises "Invalid endpoint" when no scheme is present.
     """
-    import os
-
     created: dict = {}
     with (
         patch.dict(os.environ, {"SEAWEEDFS_S3_ENDPOINT": "minio:9000"}, clear=False),
@@ -197,8 +196,6 @@ def test_s3_client_schemeless_endpoint_prefixes_http() -> None:
 
 def test_s3_client_http_endpoint_passes_through_unchanged() -> None:
     """An existing ``http://`` endpoint must reach boto3 without modification."""
-    import os
-
     created: dict = {}
     with (
         patch.dict(
@@ -215,8 +212,6 @@ def test_s3_client_http_endpoint_passes_through_unchanged() -> None:
 
 def test_s3_client_https_endpoint_passes_through_unchanged() -> None:
     """An existing ``https://`` endpoint must reach boto3 without modification."""
-    import os
-
     created: dict = {}
     with (
         patch.dict(

--- a/projects/lakehouse/orchestrator/workflows/tag_rotation_test.py
+++ b/projects/lakehouse/orchestrator/workflows/tag_rotation_test.py
@@ -159,3 +159,73 @@ async def test_rotate_tags_promote_only_no_others() -> None:
     assert result.demoted == {}
     assert result.cleaned == []
     assert s3.states["serving/notes-v1.duckdb"] == "current"
+
+
+# --------------------------------------------------------------------------- #
+# _s3_client() scheme-guard (lines 99-102)
+# --------------------------------------------------------------------------- #
+
+
+def _fake_boto3_capturing(created: dict):
+    """Return a fake boto3 module whose .client() records call kwargs in ``created``."""
+    from unittest.mock import MagicMock
+
+    fake = MagicMock()
+    fake.client.side_effect = lambda svc, **kw: (
+        created.update({"service": svc, **kw}) or MagicMock()
+    )
+    return fake
+
+
+def test_s3_client_schemeless_endpoint_prefixes_http() -> None:
+    """A scheme-less endpoint (e.g. ``minio:9000``) must get ``http://`` prepended.
+
+    The chart injects host:port without a scheme (shared with DuckDB's httpfs);
+    boto3 raises "Invalid endpoint" when no scheme is present.
+    """
+    import os
+
+    created: dict = {}
+    with (
+        patch.dict(os.environ, {"SEAWEEDFS_S3_ENDPOINT": "minio:9000"}, clear=False),
+        patch.dict("sys.modules", {"boto3": _fake_boto3_capturing(created)}),
+    ):
+        mod._s3_client()
+
+    assert created["endpoint_url"] == "http://minio:9000"
+
+
+def test_s3_client_http_endpoint_passes_through_unchanged() -> None:
+    """An existing ``http://`` endpoint must reach boto3 without modification."""
+    import os
+
+    created: dict = {}
+    with (
+        patch.dict(
+            os.environ,
+            {"SEAWEEDFS_S3_ENDPOINT": "http://seaweedfs:8333"},
+            clear=False,
+        ),
+        patch.dict("sys.modules", {"boto3": _fake_boto3_capturing(created)}),
+    ):
+        mod._s3_client()
+
+    assert created["endpoint_url"] == "http://seaweedfs:8333"
+
+
+def test_s3_client_https_endpoint_passes_through_unchanged() -> None:
+    """An existing ``https://`` endpoint must reach boto3 without modification."""
+    import os
+
+    created: dict = {}
+    with (
+        patch.dict(
+            os.environ,
+            {"SEAWEEDFS_S3_ENDPOINT": "https://s3.example.com"},
+            clear=False,
+        ),
+        patch.dict("sys.modules", {"boto3": _fake_boto3_capturing(created)}),
+    ):
+        mod._s3_client()
+
+    assert created["endpoint_url"] == "https://s3.example.com"


### PR DESCRIPTION
## Summary

Closes two coverage gaps identified in commits `7720426..8175240`:

- **`tag_rotation._s3_client()` scheme-guard** (lines 99-102): 3 new tests covering scheme-less endpoint gets `http://` prefix, `http://` passes through, `https://` passes through
- **`export_note_changes._resolve_knowledge_db_url()`**: 4 new tests covering missing `DATABASE_URL` raises `RuntimeError`, blank value raises `RuntimeError`, `postgresql+psycopg://` is normalised to `postgresql://`, and plain `postgresql://` passes through unchanged
- **`build_serving._s3_client()`** (identical guard): 1 new test for `https://` passthrough (scheme-less already had a test; `http://` already covered by existing path-style test)

## Test plan

- [ ] `bazel test //projects/lakehouse/orchestrator/workflows:workflows_test` passes (CI)
- [ ] All 8 new test functions collected and green
- [ ] No existing tests broken

🤖 Generated with [Claude Code](https://claude.com/claude-code)