### PR TITLE
feat(hooks): warn when image.tag set in OCI-pinned chart deploy overlay

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -148,6 +148,11 @@
             "type": "command",
             "command": "$CLAUDE_PROJECT_DIR/bazel/tools/hooks/check-classifier-version-bump.sh",
             "timeout": 10
+          },
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/bazel/tools/hooks/check-oci-values-image-tag.sh",
+            "timeout": 10
           }
         ]
       }

--- a/bazel/tools/hooks/check-oci-values-image-tag.sh
+++ b/bazel/tools/hooks/check-oci-values-image-tag.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+# PreToolUse hook: warn when setting image.tag in a deploy overlay for an
+# OCI-pinned chart.
+#
+# OCI-published charts (those with `publish = True` in chart/BUILD) have
+# digest-pinned images baked in by helm_images_values at build time.  The
+# deploy/values.yaml overlay is applied AFTER that base (Helm valueFiles are
+# last-wins), so any `tag:` set here silently overrides the pinned digest and
+# the container image becomes unpinned again.
+#
+# Input: JSON on stdin from Claude Code hook system
+# Exit 0: allow (warnings emitted on stderr — advisory only)
+# Exit 2: block (not used)
+
+set -euo pipefail
+
+INPUT=$(cat)
+
+# Only trigger on projects/*/deploy/values.yaml edits
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
+if [[ -z "$FILE_PATH" ]]; then
+	exit 0
+fi
+
+if [[ "$FILE_PATH" != */projects/*/deploy/values.yaml ]]; then
+	exit 0
+fi
+
+# Derive the service root: projects/<service>
+# FILE_PATH looks like .../projects/<service>/deploy/values.yaml
+DEPLOY_DIR=$(dirname "$FILE_PATH")
+SERVICE_DIR=$(dirname "$DEPLOY_DIR")
+CHART_BUILD="$SERVICE_DIR/chart/BUILD"
+
+# Only apply this check if the chart is OCI-published
+if [[ ! -f "$CHART_BUILD" ]]; then
+	exit 0
+fi
+if ! grep -q 'publish = True' "$CHART_BUILD" 2>/dev/null; then
+	exit 0
+fi
+
+# Get the content being written/edited
+TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty')
+if [[ "$TOOL_NAME" == "Edit" ]]; then
+	NEW_CONTENT=$(echo "$INPUT" | jq -r '.tool_input.new_string // empty')
+else
+	NEW_CONTENT=$(echo "$INPUT" | jq -r '.tool_input.content // empty')
+fi
+
+if [[ -z "$NEW_CONTENT" ]]; then
+	exit 0
+fi
+
+# Detect tag: appearing under an image: block via awk.
+# Tracks indentation: when a line ends with "image:", record its indent depth.
+# On subsequent lines at a greater indent level, look for "tag:".
+HAS_TAG=$(echo "$NEW_CONTENT" | awk '
+  /image:[[:space:]]*$/ {
+    img_line = $0
+    sub(/[^[:space:]].*/, "", img_line)
+    img_indent = length(img_line)
+    in_image = 1
+    next
+  }
+  in_image {
+    if (/^[[:space:]]*$/) next
+    curr_line = $0
+    sub(/[^[:space:]].*/, "", curr_line)
+    curr_indent = length(curr_line)
+    if (curr_indent > img_indent) {
+      if (/[[:space:]]tag:/) { print "yes"; exit }
+    } else {
+      in_image = 0
+    }
+  }
+' || true)
+
+if [[ "$HAS_TAG" == "yes" ]]; then
+	SERVICE_NAME=$(basename "$SERVICE_DIR")
+	cat >&2 <<-EOF
+		WARNING: Setting image.tag in a deploy overlay for an OCI-pinned chart
+		silently un-pins digest pinning.
+
+		Service: $SERVICE_NAME
+		File:    $FILE_PATH
+
+		The chart at $CHART_BUILD has publish = True, which means the OCI
+		chart ships with digest-pinned image tags baked in by helm_images_values
+		at CI build time.
+
+		Helm applies valueFiles last-wins: the deploy/values.yaml overlay is
+		layered on top of the packaged chart values, so any image.tag set here
+		overrides the pinned digest and the image becomes unpinned.
+
+		Remove the image.tag line(s) from the overlay.  Only pullPolicy and
+		other non-tag fields should appear under image: in the deploy overlay.
+
+		If you intentionally want to pin a specific tag (e.g. for a rollback),
+		proceed — but be aware this disables automatic digest pinning.
+	EOF
+fi
+
+exit 0


### PR DESCRIPTION
## Summary

- Adds `bazel/tools/hooks/check-oci-values-image-tag.sh` PreToolUse hook
- Triggers on Write/Edit to `projects/*/deploy/values.yaml`
- When the service's `chart/BUILD` has `publish = True` (OCI-published, digest-pinned chart), scans incoming content for a `tag:` key nested under an `image:` block
- Emits a `WARNING` to stderr explaining that Helm `valueFiles` are last-wins, so setting `image.tag` in the deploy overlay silently overrides the baked-in digest pin
- Advisory only (always exits 0)
- Registered in `.claude/settings.json` under the `Write|Edit` matcher

## Why

OCI-published charts (`publish = True` in `chart/BUILD`) ship with digest-pinned images baked in by `helm_images_values` at CI build time. The deploy overlay is applied after that base by ArgoCD's `valueFiles`, so any `image.tag` in the overlay overwrites the pinned digest. The lakehouse values.yaml already has a comment warning about this. This hook catches it at write time before it lands in a commit.

## Test plan

- [ ] CI passes (`bazel test //...`)
- [ ] Hook script is executable and parses stdin JSON correctly
- [ ] No-op when file path doesn't match pattern
- [ ] No-op when chart BUILD lacks `publish = True`
- [ ] Warns when `tag:` appears under `image:` block in overlay content

🤖 Generated with [Claude Code](https://claude.com/claude-code)