### PR TITLE
feat(semgrep): add temporal-schedule-missing-overlap-policy rule

### DIFF
--- a/bazel/semgrep/rules/python/temporal-schedule-missing-overlap-policy.py
+++ b/bazel/semgrep/rules/python/temporal-schedule-missing-overlap-policy.py
@@ -1,0 +1,52 @@
+# Tests for temporal-schedule-missing-overlap-policy rule.
+# Positive cases (violations) have `# ruleid:` on the line above the call.
+# Negative cases (ok) have `# ok:` on the line above the call.
+#
+# Background: SchedulePolicy.overlap defaults to UNSPECIFIED when not set,
+# which lets Temporal pick any policy — in practice this can allow concurrent
+# runs. Watermark-advancing workflows (e.g. note-export) require SKIP so that
+# a new tick never races an in-progress run. Always pass overlap= explicitly.
+
+import temporalio.client
+from temporalio.client import ScheduleOverlapPolicy, SchedulePolicy
+
+
+# --- Violations (should be flagged) ---
+
+
+# ruleid: temporal-schedule-missing-overlap-policy
+temporalio.client.SchedulePolicy()
+
+# ruleid: temporal-schedule-missing-overlap-policy
+temporalio.client.SchedulePolicy(
+    catchup_window=None,
+)
+
+# ruleid: temporal-schedule-missing-overlap-policy
+SchedulePolicy()
+
+# ruleid: temporal-schedule-missing-overlap-policy
+SchedulePolicy(catchup_window=None)
+
+
+# --- OK cases (should not be flagged) ---
+
+# ok: explicit overlap= present on qualified form
+temporalio.client.SchedulePolicy(
+    overlap=temporalio.client.ScheduleOverlapPolicy.SKIP,
+)
+
+# ok: explicit overlap= with other kwargs on qualified form
+temporalio.client.SchedulePolicy(
+    overlap=temporalio.client.ScheduleOverlapPolicy.SKIP,
+    catchup_window=None,
+)
+
+# ok: explicit overlap= on unqualified form
+SchedulePolicy(overlap=ScheduleOverlapPolicy.BUFFER_ONE)
+
+# ok: explicit overlap= with other kwargs on unqualified form
+SchedulePolicy(
+    overlap=ScheduleOverlapPolicy.SKIP,
+    catchup_window=None,
+)

--- a/bazel/semgrep/rules/python/temporal-schedule-missing-overlap-policy.yaml
+++ b/bazel/semgrep/rules/python/temporal-schedule-missing-overlap-policy.yaml
@@ -1,0 +1,28 @@
+rules:
+  - id: temporal-schedule-missing-overlap-policy
+    patterns:
+      - pattern-either:
+          - pattern: temporalio.client.SchedulePolicy(...)
+          - pattern: SchedulePolicy(...)
+      - pattern-not: temporalio.client.SchedulePolicy(..., overlap=..., ...)
+      - pattern-not: SchedulePolicy(..., overlap=..., ...)
+    message: >
+      SchedulePolicy without explicit overlap= defaults to UNSPECIFIED, allowing
+      overlapping runs — set overlap to SKIP, BUFFER_ONE, etc. to prevent data
+      corruption in watermark-advancing workflows.
+    languages: [python]
+    severity: WARNING
+    paths:
+      include:
+        - "projects/lakehouse/orchestrator/schedules/*.py"
+    metadata:
+      category: correctness
+      subcategory: temporal
+      confidence: HIGH
+      likelihood: MEDIUM
+      impact: HIGH
+      technology: [python, temporal]
+      description: >
+        SchedulePolicy missing explicit overlap= — defaults to UNSPECIFIED which
+        allows concurrent runs; use SKIP or BUFFER_ONE to prevent data corruption
+        in watermark-advancing workflows


### PR DESCRIPTION
## Summary

- Adds a new semgrep rule `temporal-schedule-missing-overlap-policy` that flags `SchedulePolicy(...)` calls without an explicit `overlap=` kwarg
- Covers both qualified (`temporalio.client.SchedulePolicy(...)`) and unqualified (`SchedulePolicy(...)`) call forms
- Scoped to `projects/lakehouse/orchestrator/schedules/*.py` — where all Temporal schedule definitions live
- Includes a paired `.py` fixture documenting the bad/ok patterns

## Background

`SchedulePolicy.overlap` defaults to `UNSPECIFIED` when omitted. Any future edit that adds `SchedulePolicy(catchup_window=...)` without also specifying `overlap=` silently loses the SKIP guarantee, allowing overlapping runs to race the watermark-advance or tag-pointer state machine. Only `note_export.py` was explicit; the other 4 schedule files omit `policy=` entirely and are safe today but one future addition could break them.

Identified in the PR #2435–#2449 audit.

## Test plan

- [ ] New rule YAML validates (picked up by `python_rules` filegroup via glob)
- [ ] Fixture `.py` documents bad/ok patterns for human review
- [ ] CI `python_rules_test` (SEMGREP_TEST_MODE=1, always skip) unaffected
- [ ] Existing schedule `semgrep_test` targets will enforce the rule against the real schedule files

🤖 Generated with [Claude Code](https://claude.com/claude-code)