### PR TITLE
fix(semgrep): extend no-inline-stdlib-import to test files

### DIFF
--- a/bazel/semgrep/rules/python/no-inline-stdlib-import.yaml
+++ b/bazel/semgrep/rules/python/no-inline-stdlib-import.yaml
@@ -17,10 +17,6 @@ rules:
       and make the code harder to audit.
     languages: [python]
     severity: WARNING
-    paths:
-      exclude:
-        - "*_test.py"
-        - "**/tests/**"
     metadata:
       category: maintainability
       subcategory: imports


### PR DESCRIPTION
## Summary

- Removes the `*_test.py` and `**/tests/**` exclusions from `no-inline-stdlib-import`
- Inline stdlib imports are equally harmful in tests (per-call overhead, hidden deps, BUILD auditability)
- Verified no existing `*_test.py` files have inline stdlib imports that would produce new findings

## Background

Commit `99646b0` had to **manually** move inline `import os` calls out of function bodies in `tag_rotation_test.py` — the fix was required by hand precisely because the rule excluded `*_test.py`. The exclusion was never justified: the same concerns (per-call overhead, dependency auditability, hidden dependencies) apply equally in test code.

Removing the exclusion means CI will now catch future regressions automatically.

Grep confirms zero inline stdlib imports currently exist in any `*_test.py` or `tests/` file, so no new findings will be produced.

## Test plan

- [ ] `no-inline-stdlib-import` rule now applies to test files
- [ ] Grep of `*_test.py` files shows zero existing violations
- [ ] CI `schedules_test_semgrep_test` and all other `*_test.py` semgrep targets pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)