### PR TITLE
feat(inference): switch local LLM to Qwen3.6-35B-A3B MoE (int4-mixed)

### DIFF
--- a/projects/agent_platform/inference/deploy/Chart.yaml
+++ b/projects/agent_platform/inference/deploy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: inference
 description: A Helm chart for LLM inference (llama.cpp and vLLM backends)
 type: application
-version: 2.5.2
+version: 2.5.3
 appVersion: "b5270"
 keywords:
   - llm

--- a/projects/agent_platform/inference/deploy/values-prod.yaml
+++ b/projects/agent_platform/inference/deploy/values-prod.yaml
@@ -11,8 +11,9 @@ image:
 imagePullSecret:
   enabled: true
 
-# Official Qwen3.6 chat template from Qwen/Qwen3.6-27B tokenizer_config.json.
-# Required because the quantized model (lorbus AutoRound) strips it.
+# Official Qwen3.6 chat template (qwen3_coder <function=...> tool-call format),
+# shared across the Qwen3.6 family — verified identical for Qwen3.6-35B-A3B.
+# Required because the AutoRound INT4 quant strips the template from the repo.
 server:
   chatTemplate: |
     {%- set image_count = namespace(value=0) %}
@@ -172,11 +173,23 @@ server:
 
 modelVolume:
   enabled: true
-  reference: "ghcr.io/jomcgi/models/qwen/qwen3.6-27b:lorbus-qwen3.6-27b-int4-autoround"
+  # Qwen3.6-35B-A3B MoE (~3B active) replacing the 27B hybrid (~27B active): at our
+  # batch=1 workload (Discord/summarize) decode is bandwidth-bound on active params,
+  # so this is a large per-call latency win. int4-mixed AutoRound keeps the router/
+  # gate + embeddings at higher precision (better MoE quality) with experts at INT4.
+  # Pushed to ghcr out-of-band via `hf2oci copy Intel/Qwen3.6-35B-A3B-int4-mixed-AutoRound
+  # -r ghcr.io/jomcgi/models`, so this references the resolved ghcr ref directly
+  # (matching the prior 27B convention).
+  reference: "ghcr.io/jomcgi/models/qwen/qwen3.6-35b-a3b:intel-qwen3.6-35b-a3b-int4-mixed-autoround"
   mountPath: "/model-image"
 
 vllm:
-  maxModelLen: 49152
+  # 32768 (was 49152): 35B-A3B int4-mixed weights are ~21-22GB resident (MoE keeps
+  # all experts loaded; mixed precision adds ~2GB over plain INT4), leaving thin KV
+  # headroom on a 24GB card. If load OOMs, add --enforce-eager (frees ~1-2GB of
+  # CUDA-graph capture) before lowering ctx further; raise back toward 49152 only
+  # after confirming KV headroom in the vLLM startup logs.
+  maxModelLen: 32768
   gpuMemoryUtilization: 0.95
   dtype: "auto"
   extraArgs:


### PR DESCRIPTION
## What

Switches the `inference` service's local LLM from the **Qwen3.6-27B hybrid** (~27B active) to the **Qwen3.6-35B-A3B MoE** (~3B active), served on vLLM via Intel's **int4-mixed AutoRound** quant.

## Why

Workload is mostly individual calls (Discord replies, summarize) — **batch=1, latency-sensitive**. At batch=1 decode is memory-bandwidth bound on *active* params, so ~3B (MoE) vs ~27B (dense hybrid) is a large single-call latency win. On the 24GB 4090, 4-bit is the only precision that fits (FP8 of a 35B is ~35GB).

**Why int4-mixed (not plain INT4):** MoE quantizes worse than dense at a uniform low bit-width — each expert is small and only ~3B params are active to average out rounding error. The mixed variant keeps the router/gate + embeddings + `lm_head` at higher precision (tiny in size, high in leverage) while experts stay INT4, for a meaningful quality gain at ~2GB more VRAM.

## How it reaches ghcr

Pushed out-of-band with `hf2oci copy Intel/Qwen3.6-35B-A3B-int4-mixed-AutoRound -r ghcr.io/jomcgi/models` (public repo, no token needed), resolving to `ghcr.io/jomcgi/models/qwen/qwen3.6-35b-a3b:intel-qwen3.6-35b-a3b-int4-mixed-autoround`. The volume then references that ghcr ref directly — matching the prior 27B convention. **Merge only after the push completes** (the ghcr image must exist, or the pod ImagePullBackOffs — the oci-model-cache webhook only gates `hf.co/…` refs, not ghcr refs).

## Changes
- `values-prod.yaml`: `modelVolume.reference` → the resolved ghcr ref above
- `values-prod.yaml`: `maxModelLen` `49152` → `32768`
- `Chart.yaml`: `2.5.2` → `2.5.3`

## Unchanged on purpose
- **Tool/reasoning surface**: 35B-A3B uses the same `qwen3_coder` `<function=…>` format and `qwen3` reasoning parser (verified vs the HF model card), so the hand-injected chat template and parser flags carry over verbatim.
- **`--served-model-name qwen3.6-27b`**: kept as a stable API alias to avoid churning the 6 monolith call sites + tests; honest rename is a follow-up.

## Risk / verification (post-merge)
- **VRAM is the main risk** — int4-mixed weights are ~21-22GB resident on a 24GB card, tighter than plain INT4. If the pod OOMs on load, add `--enforce-eager` (frees ~1-2GB of CUDA-graph capture); raise `maxModelLen` back toward 49152 only after confirming KV headroom in vLLM startup logs.
- **Quality**: A3B (3B active) reasons below the 27B dense; mixed precision narrows the gap and the chat/summarize bar is modest.
- After ArgoCD syncs: confirm the pod loads + serves, and a sample Discord/summarize call works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)