### PR TITLE
fix(hooks): widen OCI image-tag check to cover values-prod.yaml overlays

### DIFF
--- a/bazel/tools/hooks/check-oci-values-image-tag.sh
+++ b/bazel/tools/hooks/check-oci-values-image-tag.sh
@@ -22,7 +22,7 @@ if [[ -z "$FILE_PATH" ]]; then
 	exit 0
 fi
 
-if [[ "$FILE_PATH" != */projects/*/deploy/values.yaml ]]; then
+if [[ "$FILE_PATH" != */projects/*/deploy/values*.yaml ]]; then
 	exit 0
 fi
 


### PR DESCRIPTION
## Summary

- Changes the glob in `check-oci-values-image-tag.sh` line 25 from `*/projects/*/deploy/values.yaml` to `*/projects/*/deploy/values*.yaml`
- This ensures the hook also fires for `values-prod.yaml` and any other overlay files alongside the base `values.yaml`

## Test plan
- [ ] Hook logic unchanged — only the file path filter is widened
- [ ] Existing `values.yaml` files still trigger the check
- [ ] `values-prod.yaml` overlays now also trigger the check

🤖 Generated with [Claude Code](https://claude.com/claude-code)