### PR TITLE
feat(monolith): add Loom changelog notifier

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.88.1
+version: 0.89.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.88.1
+      targetRevision: 0.89.0
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/deploy/values.yaml
+++ b/projects/monolith/deploy/values.yaml
@@ -112,6 +112,15 @@ chat:
       embedColor: "0x2ECC71"
       intervalHours: 1
       roastChance: 0.1
+    - name: "loom"
+      channelId: "1512815661531795618"
+      githubRepo: "rsJames-ttrpg/loom"
+      prompt: "professional"
+      embedTitle: "Loom"
+      embedColor: "0x2ECC71"
+      intervalHours: 1
+      commitFilter: "^(feat)(\\(.+?\\))?!?:\\s"
+      roastChance: 0.1
   onepassword:
     itemPath: "vaults/k8s-homelab/items/discord-bot"
 


### PR DESCRIPTION
## What

Adds a Discord changelog notifier for the private repo **rsJames-ttrpg/loom**, posting `feat:` commit summaries to the new server's channel (`1512815661531795618`).

Config mirrors the existing `homelab` entry:
- `prompt: professional`, `roastChance: 0.1`
- `commitFilter: ^feat...` (release-style updates only)
- `intervalHours: 1`, `embedColor: 0x2ECC71`, `embedTitle: "Loom"`

## Files

- `projects/monolith/deploy/values.yaml` — new `chat.changelogs` entry
- `projects/monolith/chart/Chart.yaml` — `0.88.1 → 0.89.0`
- `projects/monolith/deploy/application.yaml` — `targetRevision 0.88.1 → 0.89.0` (kept in lockstep so ArgoCD pulls the new chart)

## Verification

- Repo visibility: **private** — confirmed the bot's in-cluster `GITHUB_TOKEN` (1Password `discord-bot` item) returns **HTTP 200** on `repos/rsJames-ttrpg/loom`, so polling will succeed (no access change needed).
- Server ID not required — the notifier targets only `channelId`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)