### PR TITLE
fix(monolith): point loom changelog at weave-hand/loom org

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.90.0
+version: 0.90.1
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.90.0
+      targetRevision: 0.90.1
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/deploy/values.yaml
+++ b/projects/monolith/deploy/values.yaml
@@ -114,7 +114,7 @@ chat:
       roastChance: 0.1
     - name: "loom"
       channelId: "1512815661531795618"
-      githubRepo: "rsJames-ttrpg/loom"
+      githubRepo: "weave-hand/loom"
       prompt: "professional"
       embedTitle: "Loom"
       embedColor: "0x2ECC71"


### PR DESCRIPTION
## What

Update the `loom` changelog notifier's `githubRepo` from `rsJames-ttrpg/loom` to `weave-hand/loom`, following the repo's transfer to the `weave-hand` org.

## Why this is a fix, not cosmetic

The notifier fetches commits via `httpx.AsyncClient` with the default `follow_redirects=False` (`projects/monolith/chat/changelog.py:176`). When a GitHub repo is transferred, the API returns a **301** from the old path. Because we don't follow it:

- `resp.raise_for_status()` doesn't raise (301 is not 4xx/5xx), and
- `resp.json()` returns the redirect envelope (`{"message": "Moved Permanently", ...}`) instead of a commits array,

which then breaks in `_summarize_with_qwen`'s `for c in commits` loop. So the job would start erroring on the stale `rsJames-ttrpg/loom` ref rather than transparently following the move.

## Scope

Values-only change. ArgoCD reads `deploy/values.yaml` live from git `HEAD` (the monolith Application's `$values` source), so this takes effect on the next sync.

## Please confirm

I used exactly `weave-hand/loom` as given. Worth a quick check that this matches the actual GitHub URL slug (org names are case/hyphen-sensitive) — a typo here fails the same way as the stale ref.

https://claude.ai/code/session_01Bud44BKRiRkFrVcseBycQa

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bud44BKRiRkFrVcseBycQa)_