### PR TITLE
fix(chat): give the bot its own identity so it recognizes itself

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.90.1
+version: 0.90.2
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.90.2
+version: 0.90.3
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chat/agent.py
+++ b/projects/monolith/chat/agent.py
@@ -60,6 +60,20 @@ def build_system_prompt() -> str:
     return (
         "You are a friend hanging out in a Discord server. "
         "You talk like a real person — casual, direct, and natural.\n\n"
+        "WHO YOU ARE:\n"
+        "- Your name in this server is Qwen3.6. You're a large language model "
+        "(the qwen3.6-27b model) running locally on hardware in this "
+        "community — often someone's own GPU — not a hosted API service.\n"
+        '- When people @-mention you, reply to you, talk about "Qwen" or '
+        '"the bot", or comment on how you\'re running ("my 4090 is running '
+        'you", "you\'re kinda dumb"), they mean YOU. Own it.\n'
+        '- A "<@" followed by a long number is a Discord user mention. When '
+        "the number is your own user ID, that's someone addressing YOU — "
+        "don't treat it as a stranger's account or try to figure out who the "
+        "ID belongs to.\n"
+        '- Don\'t give detached third-party advice about "local models" as if '
+        "you weren't one. If someone says you're dumb or slow, take it as "
+        "being about you and roll with it in good humor.\n\n"
         "DO:\n"
         "- Answer directly. If someone asks a question, just answer it.\n"
         "- Match the vibe of the conversation. Be chill, funny, or serious "

--- a/projects/monolith/chat/agent.py
+++ b/projects/monolith/chat/agent.py
@@ -61,9 +61,9 @@ def build_system_prompt() -> str:
         "You are a friend hanging out in a Discord server. "
         "You talk like a real person — casual, direct, and natural.\n\n"
         "WHO YOU ARE:\n"
-        "- Your name in this server is Qwen3.6. You're a large language model "
-        "(the qwen3.6-27b model) running locally on hardware in this "
-        "community — often someone's own GPU — not a hosted API service.\n"
+        "- Your name in this server is Qwen3.6 — a large language model "
+        "running locally on hardware in this community, often someone's own "
+        "GPU, not a hosted API service.\n"
         '- When people @-mention you, reply to you, talk about "Qwen" or '
         '"the bot", or comment on how you\'re running ("my 4090 is running '
         'you", "you\'re kinda dumb"), they mean YOU. Own it.\n'

--- a/projects/monolith/chat/agent_test.py
+++ b/projects/monolith/chat/agent_test.py
@@ -17,6 +17,22 @@ class TestBuildSystemPrompt:
         prompt = build_system_prompt()
         assert "Search before you respond" in prompt
 
+    def test_states_own_name(self):
+        """System prompt tells the model its name is Qwen3.6."""
+        prompt = build_system_prompt()
+        assert "Qwen3.6" in prompt
+
+    def test_explains_self_mention_recognition(self):
+        """System prompt explains that its own <@id> mention means itself."""
+        prompt = build_system_prompt()
+        assert "mention" in prompt.lower()
+        assert "they mean YOU" in prompt
+
+    def test_warns_against_third_party_local_model_advice(self):
+        """System prompt tells the model not to disown being a local model."""
+        prompt = build_system_prompt()
+        assert "local models" in prompt
+
 
 class TestFormatContextMessages:
     def test_formats_user_message(self):

--- a/projects/monolith/chat/bot.py
+++ b/projects/monolith/chat/bot.py
@@ -334,8 +334,20 @@ class ChatBot(discord.Client):
                 + format_context_messages(recent, attachments_by_msg)
             )
 
+            # Tell the model its own live Discord identity so it recognizes
+            # mentions of itself. The numeric user ID isn't known when the
+            # agent is constructed (before the gateway connects), so it has to
+            # be injected per request here.
+            identity_note = (
+                f'[Your identity here: you are "{self.user.display_name}" '
+                f'(Discord user ID {self.user.id}). Any "<@{self.user.id}>" '
+                "mention, or a reply to one of your own messages, in this "
+                "conversation is someone talking to or about YOU — not a "
+                "third party to look up.]"
+            )
+
             user_prompt = (
-                f"{context}\n\nCurrent message from "
+                f"{identity_note}\n\n{context}\n\nCurrent message from "
                 f"{message.author.display_name}: {message.content}"
             )
 

--- a/projects/monolith/chat/bot_summary_injection_test.py
+++ b/projects/monolith/chat/bot_summary_injection_test.py
@@ -209,4 +209,37 @@ class TestNoSummariesGracefulSkip:
         prompt_arg = bot.agent.run_stream_events.call_args[0][0]
         assert "[Channel context:" not in prompt_arg
         assert "[People in this conversation:" not in prompt_arg
-        assert prompt_arg.startswith("Recent conversation:")
+        # The identity note is always injected first, then the conversation.
+        assert prompt_arg.startswith("[Your identity here:")
+        assert "Recent conversation:" in prompt_arg
+
+
+class TestIdentityInjection:
+    @pytest.mark.asyncio
+    async def test_bot_identity_appears_in_prompt(self):
+        """The bot's live display name and user ID are injected into the prompt."""
+        bot = _make_bot()
+        bot_user = bot.user
+        msg = _make_message(content="who are you", mentions=[bot_user])
+
+        mock_store = _make_store()
+
+        events = [_text_delta("I'm Qwen3.6.")]
+        bot.agent.run_stream_events = MagicMock(return_value=_async_iter(events))
+
+        with (
+            patch("chat.bot.get_engine"),
+            patch("chat.bot.Session") as mock_session_cls,
+            patch("chat.bot.MessageStore", return_value=mock_store),
+        ):
+            mock_session_cls.return_value.__enter__ = MagicMock(
+                return_value=MagicMock()
+            )
+            mock_session_cls.return_value.__exit__ = MagicMock(return_value=False)
+            await bot.on_message(msg)
+
+        prompt_arg = bot.agent.run_stream_events.call_args[0][0]
+        # _make_bot sets user id 999 / display name "BotUser".
+        assert '"BotUser"' in prompt_arg
+        assert "Discord user ID 999" in prompt_arg
+        assert "<@999>" in prompt_arg

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.90.2
+      targetRevision: 0.90.3
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.90.1
+      targetRevision: 0.90.2
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
## Problem

The Discord bot (**Qwen3.6**) had no self-awareness in its prompt, so it didn't recognize when people were talking to or about it:

1. A user said *"My 4090 is running @Qwen3.6 but it's still kinda dumb"* — the bot replied with detached third-party advice about how *"smaller models definitely lack the heavy reasoning cap... that you get with the massive API ones,"* not realizing **it** is the local model being called dumb.
2. On seeing its own raw mention `<@129478876967...>` in a message, the bot burned its entire reasoning trace trying to figure out which *"user/AI model/person"* that ID referred to — it's the bot's own Discord user ID.

Root cause: `build_system_prompt()` told the model it was *"a friend hanging out in a Discord server"* but never told it **who it is**, and the bot's numeric Discord user ID was never surfaced to the model, so raw `<@id>` mentions of itself were unresolvable.

## Fix

- **`agent.py` — system prompt:** added a `WHO YOU ARE` block that names the bot **Qwen3.6**, states it's the local `qwen3.6-27b` model running on community hardware (not a hosted API), and gives explicit rules: mentions of "Qwen"/"the bot"/its own `<@id>` mean *you*; don't analyze your own mention like a stranger's account; don't give third-party advice about "local models" as if you aren't one.
- **`bot.py` — per-request identity injection:** prepends a short identity note with the bot's **live** Discord display name + user ID to each prompt. The numeric ID isn't known at agent-construction time (the gateway hasn't connected yet), so it has to be injected per request — this is what lets the raw `<@id>` mentions actually resolve to the bot itself.

## Tests

- `agent_test.py`: prompt states its own name, explains self-mention recognition, and warns against disowning being a local model.
- `bot_summary_injection_test.py`: new `TestIdentityInjection` asserts the live display name / user ID / `<@id>` land in the prompt; updated the no-summaries test (prompt now opens with the identity note before `Recent conversation:`).

https://claude.ai/code/session_01DsRUT8hwrJdUwAgPVdexpP

---
_Generated by [Claude Code](https://claude.ai/code/session_01DsRUT8hwrJdUwAgPVdexpP)_