### PR TITLE
docs(trips): correct backend component description

### DIFF
--- a/projects/trips/README.md
+++ b/projects/trips/README.md
@@ -6,7 +6,7 @@ Photo-based GPS trip logging with elevation enrichment.
 
 | Component      | Description                                                                                |
 | -------------- | ------------------------------------------------------------------------------------------ |
-| **backend**    | FastAPI server that replays trip data from NATS JetStream and serves REST + WebSocket APIs; includes image upload endpoints (`UploadFile`) for ingesting trip photos |
+| **backend**    | FastAPI server that replays trip data from NATS JetStream and serves REST + WebSocket APIs (`GET /api/points`, `GET /api/points/{id}`, `GET /api/stats`, `GET /health`, `WS /ws/live`); image ingestion is handled by the `publish-trip-images` CLI tool, not the backend |
 | **frontend**   | Timeline view with day-by-day maps and per-day elevation stats (ascent, descent, min/max), plus a `TripSummaryPage` with a full-trip overview and multi-day map — deployed as a Cloudflare Pages app (not part of the Helm chart) |
 | **tools**      | CLI tools for trip data management — six sub-directories: `publish-trip-images` (image ingestion with EXIF extraction), `backfill-elevation` (replays NATS points and enriches with elevation data), `delete-trip-points` (publishes tombstone messages to delete points), `publish-gap-route` (parses KML files to fill route gaps), `detect-wildlife` (wildlife detection inference + GoPro camera control), `elevation` (elevation API client library) |
 | **chart**      | Helm chart for Kubernetes deployment — includes nginx reverse-proxy and imgproxy templates |


### PR DESCRIPTION
## Summary

- The trips `backend` README description incorrectly claimed the FastAPI server "includes image upload endpoints (`UploadFile`) for ingesting trip photos"
- Verified: `UploadFile` is imported in `main.py` but is unused — no upload endpoints exist in the backend (`@app.post` is never used)
- The backend only serves: `GET /api/points`, `GET /api/points/{id}`, `GET /api/stats`, `GET /health`, `WS /ws/live`
- Image ingestion is handled by the `publish-trip-images` CLI tool (scans a directory, extracts EXIF, uploads to SeaweedFS, publishes to NATS) — not the backend API

## Test plan

- [x] Read `projects/trips/backend/main.py` in full — confirmed no upload endpoints
- [x] Verified `UploadFile`, `File`, `Header` imports are unused
- [x] Verified `projects/trips/tools/publish-trip-images/main.py` is the correct home for image ingestion

🤖 Generated with [Claude Code](https://claude.com/claude-code)