### PR TITLE
feat(public-site): neo-brutalist design polish

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.90.4
+version: 0.91.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.90.4
+      targetRevision: 0.91.0
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/lib/public/components/Footer.svelte
+++ b/projects/monolith/frontend/src/lib/public/components/Footer.svelte
@@ -46,7 +46,7 @@
 
 <style>
   .footer {
-    background: #fff;
+    background: var(--paper);
     border-top: 2px solid var(--ink);
     padding: 80px 0 60px;
     position: relative;
@@ -56,6 +56,9 @@
   .footer-content {
     max-width: 900px;
     text-align: center;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
   }
 
   .footer-headline {
@@ -77,11 +80,12 @@
   }
 
 
+  /* Off-axis on purpose: the sticker hangs left of the centered headline. */
   :global(.footer-sticker) {
     display: inline-block;
     font-size: 14px;
     margin-bottom: 24px;
-    margin-right: 680px;
+    align-self: flex-start;
   }
 
   .deco {
@@ -107,7 +111,7 @@
 
   @media (max-width: 768px) {
     :global(.footer-sticker) {
-      margin-right: 0;
+      align-self: center;
     }
     .footer {
       text-align: center;
@@ -117,6 +121,13 @@
     }
     .deco {
       display: none;
+    }
+    .deco-star {
+      display: block;
+      width: 40px;
+      height: 40px;
+      top: 16px;
+      right: 16px;
     }
   }
 </style>

--- a/projects/monolith/frontend/src/lib/public/components/Marquee.svelte
+++ b/projects/monolith/frontend/src/lib/public/components/Marquee.svelte
@@ -25,7 +25,7 @@
   .marquee {
     background: var(--accent);
     color: var(--ink);
-    border-bottom: 1.5px solid var(--ink);
+    border-bottom: 2px solid var(--ink);
     overflow: hidden;
     font-family: var(--mono);
     font-size: 13px;

--- a/projects/monolith/frontend/src/lib/public/components/dag/DagRenderer.svelte
+++ b/projects/monolith/frontend/src/lib/public/components/dag/DagRenderer.svelte
@@ -165,9 +165,17 @@
     {@const gy = grp.bounds.minY}
     {@const gw = grp.bounds.maxX - grp.bounds.minX}
     {@const gh = grp.bounds.maxY - grp.bounds.minY}
-    {@const sw = isSelected ? 2.5 : 1.5}
+    {@const sw = isSelected ? 3 : 2}
     {@const isActive = active === grp.id}
     <g class="dag-group" style:opacity={hi ? 1 : 0.15} style:transition="opacity 0.4s ease">
+      <!-- Base fill lifts groups off the cream background -->
+      {#if c.groupFill !== "none"}
+        <rect
+          x={gx} y={gy}
+          width={gw} height={gh}
+          fill={c.groupFill}
+        />
+      {/if}
       <!-- Group fill on hover/select -->
       {#if isActive}
         <rect
@@ -217,13 +225,13 @@
         x1={e.p1.x} y1={e.p1.y}
         x2={e.p2.x} y2={e.p2.y}
         stroke={c.edge}
-        stroke-width="1.5"
+        stroke-width="2"
       />
       {#if e.fwdArrow}
-        <path d={e.fwdArrow} fill="none" stroke={c.arrow} stroke-width="1.5" />
+        <path d={e.fwdArrow} fill="none" stroke={c.arrow} stroke-width="2" />
       {/if}
       {#if e.revArrow}
-        <path d={e.revArrow} fill="none" stroke={c.arrow} stroke-width="1.5" />
+        <path d={e.revArrow} fill="none" stroke={c.arrow} stroke-width="2" />
       {/if}
     </g>
   {/each}
@@ -242,6 +250,12 @@
         : "var(--green, #4ade80)"}
     {#if pos}
       <g class="dag-node" style:opacity={hi ? 1 : 0.15} style:transition="opacity 0.4s ease">
+        <!-- Hard offset shadow — the sticker motif carried into the DAG -->
+        <rect
+          x={pos.x - w / 2 + 3} y={pos.y - h / 2 + 3}
+          width={w} height={h}
+          fill={c.ink}
+        />
         <rect
           x={pos.x - w / 2} y={pos.y - h / 2}
           width={w} height={h}

--- a/projects/monolith/frontend/src/lib/public/styles/design-system.css
+++ b/projects/monolith/frontend/src/lib/public/styles/design-system.css
@@ -27,15 +27,14 @@
   --mono: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
 
   /* ── Spacing / Radius ────────────────────── */
-  --radius: 14px;
-  --radius-lg: 22px;
+  --radius: 8px;
+  --radius-lg: 12px;
 
   /* ── Shadows ─────────────────────────────── */
-  --shadow-sm: 0 1px 0 rgba(10, 10, 10, 0.06), 0 1px 2px rgba(10, 10, 10, 0.04);
-  --shadow-md:
-    0 4px 14px rgba(10, 10, 10, 0.06), 0 1px 2px rgba(10, 10, 10, 0.04);
-  --shadow-lg:
-    0 20px 50px -18px rgba(10, 10, 10, 0.25), 0 4px 14px rgba(10, 10, 10, 0.06);
+  /* Hard offsets only — soft blurred shadows break the flat ink language. */
+  --shadow-hard-sm: 2px 2px 0 var(--ink);
+  --shadow-hard: 4px 4px 0 var(--ink);
+  --shadow-hard-lg: 6px 6px 0 var(--ink);
 }
 
 /* ── Reset ──────────────────────────────── */
@@ -151,16 +150,17 @@ ul {
 /* ── Cards (hard shadow) ───────────────── */
 .card-hard {
   background: var(--paper);
-  border: 1.5px solid var(--ink);
+  border: 2px solid var(--ink);
   border-radius: var(--radius);
+  box-shadow: var(--shadow-hard);
   transition:
     transform 180ms ease,
     box-shadow 180ms ease;
 }
 
 .card-hard:hover {
-  transform: translate(-4px, -4px);
-  box-shadow: 4px 4px 0 var(--ink);
+  transform: translate(-2px, -2px);
+  box-shadow: var(--shadow-hard-lg);
 }
 
 /* ── Ticker / Marquee ──────────────────── */

--- a/projects/monolith/frontend/src/routes/public/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/+page.svelte
@@ -135,10 +135,10 @@
   >
 
   <div class="wrap hero-content">
-    <h1 class="hero-headline">ten years ago i was underwriting policies<br />and winning insurance hackathons.<br />now i'm building production grade infra<br />for weekend side quests and keeping<br /><a href="https://semgrep.dev" class="hero-mono">semgrep</a> online.</h1>
+    <h1 class="hero-headline">ten years ago i was underwriting policies and winning insurance hackathons. now i'm building <span class="hl hl-yellow">production grade infra</span> for weekend side quests and keeping <a href="https://semgrep.dev" class="hero-mono">semgrep</a> online.</h1>
     <div class="hero-cta-row">
       <a href="#homelab" class="btn btn-primary">SEE MY HOMELAB <span class="btn-arr">→</span></a>
-      <a href="#homelab" class="btn btn-secondary">TALK TO MY NOTES</a>
+      <a href="/notes" class="btn btn-secondary">TALK TO MY NOTES</a>
     </div>
     <Sticker color="var(--coral)" rotate={-5} class="sticker-hero">← BUILT THIS SITE TOO</Sticker>
   </div>
@@ -162,14 +162,15 @@
   <svg class="deco deco-bio-circle" width="24" height="24" viewBox="0 0 24 24"
     ><circle cx="12" cy="12" r="10" fill="none" stroke="var(--ink)" stroke-width="2" /></svg
   >
-  <Sticker color="var(--paper)" rotate={-3} class="sticker-bio">A LITTLE ABOUT ME</Sticker>
-
   <div class="wrap bio-content">
-    <p class="bio-sub">
-      I'm Joe, from Scotland, living in Vancouver.<br />
-      Monorepo enthusiast. Lover of <a href="https://brutalistwebsites.com/" class="bio-link">brutalist websites</a>.<br />
-      Care<em>mad</em> about developer experience.
-    </p>
+    <div class="bio-left">
+      <Sticker color="var(--paper)" rotate={-3} class="sticker-bio">A LITTLE ABOUT ME</Sticker>
+      <p class="bio-sub">
+        I'm Joe, from Scotland, living in Vancouver.<br />
+        Monorepo enthusiast. Lover of <a href="https://brutalistwebsites.com/" class="bio-link">brutalist websites</a>.<br />
+        Care<em>mad</em> about developer experience.
+      </p>
+    </div>
     <h2 class="bio-headline">Boring infrastructure<br />is a feature.</h2>
   </div>
 </section>
@@ -196,7 +197,7 @@
     padding: 88px 0 96px;
     position: relative;
     overflow: hidden;
-    border-bottom: 1px solid var(--ink);
+    border-bottom: 2px solid var(--ink);
   }
 
   .hero-content {
@@ -207,12 +208,17 @@
 
   .hero-headline {
     font-family: var(--mono);
-    font-weight: 400;
+    font-weight: 700;
     font-size: clamp(20px, 2.6vw, 38px);
-    line-height: 1.45;
+    line-height: 1.4;
     letter-spacing: -0.01em;
     margin: 0 0 44px;
+    max-width: 46ch;
+    text-wrap: balance;
     color: var(--ink);
+    /* .hl's ::before sits at z-index -1 — isolate so it stays above the
+       section background instead of vanishing behind it. */
+    isolation: isolate;
   }
 
   .hero-mono {
@@ -321,7 +327,7 @@
   /* ── Bio panel ───────────────────────────── */
   .bio-panel {
     background: var(--accent);
-    border-bottom: 1px solid var(--ink);
+    border-bottom: 2px solid var(--ink);
     padding: 56px 0;
     position: relative;
     overflow: hidden;
@@ -362,19 +368,14 @@
     text-decoration-color: var(--coral);
   }
 
-  :global(.sticker-bio) {
-    position: absolute;
-    top: 40px;
-    left: 6%;
+  .bio-left {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 22px;
   }
 
   /* ── Responsive ──────────────────────────── */
-  @media (max-width: 1900px) {
-    :global(.sticker-bio) {
-      display: none !important;
-    }
-  }
-
   @media (max-width: 1100px) {
     .bio-content {
       grid-template-columns: 1fr;
@@ -396,8 +397,23 @@
     :global(.sticker-hero) {
       display: none !important;
     }
+    /* Keep one signature shape per band on mobile so the shape language
+       survives small screens; the rest would collide with text. */
     .deco {
       display: none;
+    }
+    .deco-star {
+      display: block;
+      width: 34px;
+      height: 34px;
+      top: 10px;
+      right: 12px;
+    }
+    .deco-bio-squiggle {
+      display: block;
+      width: 56px;
+      top: 14px;
+      right: 14px;
     }
   }
 </style>

--- a/projects/monolith/frontend/src/routes/public/HomepageTopology.svelte
+++ b/projects/monolith/frontend/src/routes/public/HomepageTopology.svelte
@@ -142,7 +142,7 @@
     groupLabel: "var(--ink)",
     edge: "var(--ink)",
     arrow: "var(--ink)",
-    groupFill: "none",
+    groupFill: "var(--paper)",
     selectedFill: "var(--accent)",
   };
 </script>
@@ -151,7 +151,17 @@
 
 <section class="topology-section" id="homelab">
   <div class="topology-wrap" class:split={!!focusedNode}>
-    <h2 class="topology-title">Homelab</h2>
+    <div class="topology-head">
+      <div>
+        <p class="eyebrow">Live from the cluster · click a node</p>
+        <h2 class="topology-title">Homelab</h2>
+      </div>
+      <div class="topology-legend mono" aria-label="Node status legend">
+        <span class="legend-item"><i class="legend-dot legend-ok"></i>Healthy</span>
+        <span class="legend-item"><i class="legend-dot legend-warn"></i>Warning</span>
+        <span class="legend-item"><i class="legend-dot legend-bad"></i>Degraded</span>
+      </div>
+    </div>
 
     <div class="topology-body" class:split-body={!!focusedNode}>
       <div class="dag-pane">
@@ -203,6 +213,15 @@
     padding: 0 32px;
   }
 
+  .topology-head {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-end;
+    gap: 16px;
+    flex-wrap: wrap;
+    margin-bottom: 12px;
+  }
+
   .topology-title {
     font-family: var(--mono);
     font-size: clamp(22px, 2.4vw, 32px);
@@ -210,7 +229,47 @@
     text-transform: uppercase;
     letter-spacing: 0.06em;
     color: var(--ink);
-    margin: 0 0 12px;
+    margin: 4px 0 0;
+  }
+
+  .topology-legend {
+    display: flex;
+    gap: 14px;
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--ink-2);
+    border: 2px solid var(--ink);
+    background: var(--paper);
+    box-shadow: var(--shadow-hard-sm);
+    padding: 8px 12px;
+  }
+
+  .legend-item {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+  }
+
+  .legend-dot {
+    width: 9px;
+    height: 9px;
+    border-radius: 999px;
+    border: 1.5px solid var(--ink);
+    display: inline-block;
+  }
+
+  .legend-ok {
+    background: var(--green);
+  }
+
+  .legend-warn {
+    background: var(--accent);
+  }
+
+  .legend-bad {
+    background: var(--coral);
   }
 
   .topology-empty {

--- a/projects/monolith/frontend/src/routes/public/cv/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/cv/+page.svelte
@@ -1,7 +1,19 @@
 <script>
   import { onMount } from "svelte";
   import { Footer, Sticker, Marquee } from "$lib/public/components";
-  import { contact, name, summary, jobs, projects, skills } from "./cv-data.js";
+  import {
+    contact,
+    name,
+    tagline,
+    summary,
+    jobs,
+    earlierCareer,
+    personalIntro,
+    projects,
+    collabAside,
+    collabProjects,
+    skills,
+  } from "./cv-data.js";
 
   // Minimal inline-markdown tokenizer. The CV bullets carry just two markdown
   // constructs from cv.md — **emphasis** and [text](url) — so a focused
@@ -33,9 +45,9 @@
   // chip grid of section 03). Keeping these distinct avoids showing the same
   // list twice; the marquee is a signature, the chips are the reference.
   const MARQUEE_ITEMS = [
-    "Senior Platform Engineer",
-    "Reliability",
-    "Observability",
+    "Senior Platform Engineer @ Semgrep",
+    "AWS / EKS",
+    "eBPF & Cilium",
     "Distributed Systems",
     "OpenTelemetry Contributor",
     "K3S Homelab",
@@ -66,7 +78,7 @@
   <title>Joe McGinley — CV</title>
   <meta
     name="description"
-    content="Joe McGinley — Senior Platform Engineer. GCP · Kubernetes · Go · Python · Reliability & Observability."
+    content="Joe McGinley — Senior Platform Engineer @ Semgrep. AWS · EKS · Kubernetes · eBPF · Reliability & Observability."
   />
 </svelte:head>
 
@@ -118,7 +130,7 @@
     <div class="wrap-narrow hero-content">
       <p class="eyebrow">Curriculum Vitae</p>
       <h1 class="cv-name display">{name}</h1>
-      <p class="cv-tagline mono">Senior Platform Engineer · GCP · Kubernetes · Reliability</p>
+      <p class="cv-tagline mono">{tagline}</p>
       <div class="cv-contacts">
         <a class="btn btn-primary" href={`mailto:${contact.email}`}>{contact.email}</a>
         <a class="btn btn-secondary" href={contact.linkedin.href} target="_blank" rel="noreferrer"
@@ -156,13 +168,40 @@
               </div>
               <span class="job-dates mono">{job.dates}</span>
             </div>
-            <ul class="bullets">
-              {#each job.bullets as bullet}
-                <li>{@render inline(bullet)}</li>
+            {#if job.blurb}
+              <p class="job-blurb">{@render inline(job.blurb)}</p>
+            {/if}
+            {#if job.bullets}
+              <ul class="bullets">
+                {#each job.bullets as bullet}
+                  <li>{@render inline(bullet)}</li>
+                {/each}
+              </ul>
+            {/if}
+            {#if job.highlights}
+              {#each job.highlights as highlight}
+                <div class="highlight">
+                  <h4 class="highlight-title mono">{highlight.title}</h4>
+                  {#if highlight.kicker}
+                    <p class="highlight-kicker">{highlight.kicker}</p>
+                  {/if}
+                  {#if highlight.intro}
+                    <p class="highlight-intro">{@render inline(highlight.intro)}</p>
+                  {/if}
+                  <ul class="bullets">
+                    {#each highlight.bullets as bullet}
+                      <li>{@render inline(bullet)}</li>
+                    {/each}
+                  </ul>
+                </div>
               {/each}
-            </ul>
+            {/if}
           </article>
         {/each}
+      </div>
+      <div class="earlier">
+        <p class="eyebrow">Earlier Career</p>
+        <p class="earlier-text">{@render inline(earlierCareer)}</p>
       </div>
     </div>
   </section>
@@ -170,9 +209,16 @@
   <!-- ═══ Personal projects (cream) ═══ -->
   <section class="band band--cream reveal">
     <div class="wrap-narrow">
-      {@render bandHead("02", "Personal Projects", "Homelab")}
+      {@render bandHead("02", "Personal Engineering", "Homelab")}
+      <p class="section-intro">{@render inline(personalIntro)}</p>
       <ul class="bullets bullets--lg">
         {#each projects as project}
+          <li>{@render inline(project)}</li>
+        {/each}
+      </ul>
+      <p class="section-intro section-aside">{collabAside}</p>
+      <ul class="bullets bullets--lg">
+        {#each collabProjects as project}
           <li>{@render inline(project)}</li>
         {/each}
       </ul>
@@ -409,6 +455,90 @@
     padding: 7px 12px;
     border: 2px solid var(--ink);
     box-shadow: 3px 3px 0 var(--ink);
+  }
+
+  /* ── Role blurb + named project subsections ─ */
+  .job-blurb {
+    font-family: var(--sans);
+    font-size: 16px;
+    line-height: 1.55;
+    color: var(--ink-2);
+    margin: 0 0 18px 23px;
+    max-width: 72ch;
+  }
+  .highlight {
+    margin: 0 0 22px 23px;
+  }
+  .highlight:last-child {
+    margin-bottom: 0;
+  }
+  .highlight-title {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 13px;
+    font-weight: 700;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--ink);
+    margin-bottom: 6px;
+  }
+  .highlight-title::before {
+    content: "";
+    width: 10px;
+    height: 10px;
+    background: var(--accent);
+    border: 2px solid var(--ink);
+    flex-shrink: 0;
+  }
+  .highlight-kicker {
+    font-family: var(--sans);
+    font-size: 15px;
+    font-weight: 600;
+    line-height: 1.45;
+    color: var(--ink);
+    margin: 0 0 8px;
+    max-width: 72ch;
+  }
+  .highlight-intro {
+    font-family: var(--sans);
+    font-size: 14px;
+    line-height: 1.55;
+    color: var(--ink-3);
+    margin: 0 0 12px;
+    max-width: 72ch;
+  }
+  .highlight .bullets {
+    margin-left: 0;
+  }
+
+  /* ── Earlier career footnote ──────────────── */
+  .earlier {
+    margin-top: 28px;
+    padding-top: 22px;
+    border-top: 2px solid var(--rule);
+  }
+  .earlier-text {
+    font-family: var(--sans);
+    font-size: 15px;
+    line-height: 1.55;
+    color: var(--ink-2);
+    max-width: 72ch;
+    margin-top: 8px;
+  }
+
+  /* ── Section intro / aside lines ──────────── */
+  .section-intro {
+    font-family: var(--sans);
+    font-size: 16px;
+    line-height: 1.55;
+    color: var(--ink-2);
+    margin: 0 0 20px;
+    max-width: 72ch;
+  }
+  .section-aside {
+    margin-top: 24px;
+    color: var(--ink-3);
   }
 
   /* ── Bullets ──────────────────────────────── */

--- a/projects/monolith/frontend/src/routes/public/cv/cv-data.js
+++ b/projects/monolith/frontend/src/routes/public/cv/cv-data.js
@@ -1,7 +1,8 @@
-// CV content — transcribed verbatim from the canonical markdown CV
-// (projects/websites/jomcgi.dev/src/assets/cv.md). Bullet strings keep the
-// markdown inline syntax (**bold**, [text](url)); the page renders them via the
-// tiny tokenizer in +page.svelte rather than pulling in a markdown dependency.
+// CV content — transcribed from the canonical public CV maintained in the
+// private cv repo (public/cv.md there; only the public/ variant is ever
+// mirrored here). Bullet strings keep the markdown inline syntax (**bold**,
+// [text](url)); the page renders them via the tiny tokenizer in +page.svelte
+// rather than pulling in a markdown dependency.
 
 export const contact = {
   email: "joe@jomcgi.dev",
@@ -15,128 +16,150 @@ export const contact = {
 
 export const name = "Joe McGinley";
 
+export const tagline =
+  "Senior Platform Engineer @ Semgrep · AWS / EKS · Kubernetes · eBPF";
+
 export const summary =
-  "As a Senior Platform Engineer, I build and operate reliable, cost-effective distributed systems, primarily using GCP and Kubernetes. I thrive on improving performance and stability, having drastically cut processing times (**weeks down to minutes**), reduced costs by up to **89%**, and eliminated recurring SLA violations. My approach relies on pragmatic automation, leveraging OpenTelemetry for deep system insights, and robust system design, especially for critical data platforms.";
+  "I run Kubernetes hands-on: from ingress to eBPF, controllers and all the CRDs in between. Caremad about developer & user experience.";
 
 export const jobs = [
+  // Current role stays deliberately scope-level: what the job is, not a
+  // case-study of recent wins. The deep, metric-framed writeups live on
+  // past roles only; the full current-role story stays in the PDF CV that
+  // gets handed out directly.
+  {
+    company: "Semgrep",
+    title: "Senior Platform Engineer",
+    dates: "May 2025 – Present",
+    blurb:
+      "AWS / EKS / Kubernetes platform across 25 clusters for an AppSec SaaS serving large enterprise customers.",
+    bullets: [
+      "Run scan execution on Argo Workflows at scale: long-lived, latency-critical workloads held inside the control plane's etcd and apiserver limits.",
+      "Migrated the org's ingress off deprecated ingress-nginx to Envoy Gateway on the Kubernetes Gateway API, with Cilium as the eBPF CNI and Linkerd as the L7 mesh.",
+      "Built per-customer infrastructure cost attribution: usage metered at the kernel with eBPF, reconciled to the AWS bill.",
+    ],
+  },
   {
     company: "BenchSci",
-    title: "Senior Software Engineer II (Promoted Oct 2023)",
-    dates: "Oct 2022 – Present",
-    bullets: [
-      "Stabilized a critical, frequently failing product, reducing incident Time-to-Resolve (TTR) by **40%** and eliminating recurring SLA violations, by leading a cross-functional Root Cause Analysis (RCA) squad to produce an RCA playbook and a backlog of automated tests and reliability improvements for service owners.",
-      "Reduced core document processing time from **weeks to minutes** by designing and building a scalable (25m+ docs) distributed event processing framework (Kubernetes/GKE), engineered for high resilience, scaling to cloud quota limits, and scaling to zero for cost efficiency enabling an **89%** reduction in processing costs.",
-      "Optimized transactional write throughput for our primary **10TB** Postgres database utilizing PGvector (HNSW), enabling significantly faster ingestion of customer data while balancing high-performance reads under strict infrastructure scaling constraints.",
-      "Managed and performance-tuned a large-scale Neo4j knowledge graph, optimizing complex query performance and data ingestion pipelines for essential company insights.",
-      "Reduced incident Time-to-Identify (TTI) from **94 to 23 minutes** and cut false alerts by **15%** by driving company-wide OpenTelemetry adoption, creating a unified observability standard (logs, metrics, traces) and centralizing monitoring/alerting.",
-      "Implemented an SLO framework translating business needs into measurable reliability targets, designed for low-friction developer adoption, guiding data-informed prioritization and clearly communicating essential non-functional requirements.",
-      "Increased data release stability from bi-weekly failures to **>30 days** uptime using automated recovery and OpenTelemetry, allowing developers to ship features faster with reduced risk to users.",
-      "Cut critical Postgres processing time by **55%** (to **9 hrs**) via tuning and scaling, enabling a faster release cadence and improving core software delivery performance metrics.",
-      "Served as the go-to expert for data orchestration, resolving complex cross-team workflow challenges and ensuring successful platform adoption.",
+    title: "Senior Software Engineer / SSE2",
+    dates: "Oct 2022 – May 2025",
+    blurb:
+      "Pharma R&D SaaS. Three years removing complexity for other engineers — making the hard infra path the easy one, with business value as the byproduct. Promoted to SSE2 within 12 months.",
+    highlights: [
+      {
+        title: "Event-Driven Data Platform",
+        kicker: "Weeks to minutes, $644 → $69 per 2.5M docs",
+        intro:
+          "BenchSci turns 25M+ scientific papers into structured biomedical knowledge via NER, LLM extraction, and knowledge-graph linking. Document processing was a weekly batch with pipeline-granularity caching: freshness capped what product could ship, and unchanged work was reprocessed every cycle.",
+        bullets: [
+          "**Rebuilt it event-driven on GKE** — per-document events, per-document caching, scale-to-zero; only changed docs reprocess. Processing collapsed weeks → minutes, cost dropped **$644 → $69 per 2.5M docs (−89%)**, scaling to **100K+ concurrent documents** with the full **25M+ corpus** reprocessable on demand.",
+          "**Made it the path of least resistance** — for the ML researchers who used it, adoption was a decorator and a Python function; the framework owned deployment, event semantics, the message log, and live data testing. **~200 engineers adopted it** as the data platform's canonical foundation.",
+        ],
+      },
+      {
+        title: "Also at BenchSci",
+        bullets: [
+          "**OpenTelemetry org-wide adoption** — every team was rolling their own logs, metrics, and tracing. I drove the company-wide OTel rollout: logs, metrics, and traces out of the box, one standard, one place to look. Incident **time-to-identify (TTI) dropped from 94 to 23 minutes (−75%)**; false-alert volume down 15%.",
+          "**GPU inference at cloud-quota limits** — ran in-pod L4 inference for **~50 in-house ML models** (paper extraction, entity enrichment, vision ML) inside the same event-driven pipeline, autoscaling across regions against a **~25K L4-GPU quota** — bursting onto spot capacity when available — with each document's work colocated in-region to avoid cross-region transfer.",
+          "**RCA squad lead** — post-incident process was bespoke per team. I authored the company RCA playbook and led a cross-functional squad through it. **40% time-to-resolution reduction**; recurring SLA violations eliminated.",
+        ],
+      },
     ],
   },
   {
     company: "Ensono",
-    title: "Platform Engineering Consultant",
+    title: "Platform Engineering Consultant (contract)",
     dates: "May 2022 – Oct 2022",
-    bullets: [
-      "Architected and delivered a greenfield data platform on Google Cloud (GCP) for a major hotel chain, enabling self-service analytics for diverse stakeholders from HQ to individual hotel GMs.",
-      "Engineered data ingestion and processing pipelines using Cloud Composer (Airflow), integrating robust data quality checks to ensure data integrity and reliability.",
-      "Improved platform resilience and data availability through targeted architectural enhancements and operational best practices, supporting critical business decision-making.",
-    ],
+    blurb:
+      "Greenfield GCP data platform for a hotel chain; Cloud Composer pipelines, IaC, BigQuery modeling.",
   },
   {
     company: "Hometree",
     title: "Senior Platform Engineer",
     dates: "Sep 2021 – May 2022",
-    bullets: [
-      "Optimized production database ER models to improve data access efficiency and simplify application development integration.",
-      "Enhanced the resilience and operational reliability of a legacy data platform through targeted improvements and implementing engineering best practices.",
-      "Modernized data modeling and transformation using DBT/BigQuery, increasing data consistency and visibility across the business.",
-      "Provided data engineering guidance to Full Stack teams, enhancing data handling within core applications.",
-    ],
+    blurb:
+      "DBT / BigQuery modernization for a UK home-warranty business; ER model optimization; resilience work on a legacy platform.",
   },
   {
     company: "AXA",
     title: "Senior Platform Engineer",
     dates: "Jan 2021 – Sep 2021",
-    bullets: [
-      "Designed robust batch and streaming ETL architectures enabling scalable data processing on Azure.",
-      "Implemented automated infrastructure provisioning (Terraform) and deployment pipelines (CI/CD with Azure DevOps), improving platform stability and deployment velocity.",
-      "Deployed key data services and infrastructure, including systems supporting ML applications that drove significant cost savings (e.g., **40%** CAC reduction).",
-      "Consulted cross-functionally on data platform projects, influencing technical direction and implementation standards.",
-    ],
+    blurb:
+      "Azure ETL + Terraform IaC; ML infrastructure that contributed to a **40% reduction in customer acquisition cost**.",
   },
   {
     company: "Sky",
     title: "Platform Engineer",
     dates: "Feb 2020 – Jan 2021",
-    bullets: [
-      "Executed the migration of a core on-premise data platform to GCP, improving system scalability and unlocking new data exploration avenues.",
-      "Designed and maintained robust, fault-tolerant ETL processes, increasing the resilience and reliability of critical data pipelines.",
-      "Advanced team technical skills by mentoring engineers and analysts on development standards and new technologies.",
-    ],
+    blurb:
+      "Led an on-prem → GCP migration; mentored junior engineers. Role eliminated in COVID restructuring.",
   },
 ];
 
+export const earlierCareer =
+  "**Chubb (2018–2020)** — account servicing for multinational corporate insurance. Automated the majority of regional account-servicing admin and won two UK-wide hackathons (incl. an ML fraud classifier taken to production) — the start of the pivot into engineering.";
+
+export const personalIntro =
+  "All of this runs on a bare-metal K3s cluster I operate at home, GitOps-deployed. Source: [github.com/jomcgi/homelab](https://github.com/jomcgi/homelab).";
+
 export const projects = [
-  "Actively contributing code and performing peer reviews for the OpenTelemetry project ([opentelemetry-python](https://github.com/open-telemetry/opentelemetry-python), [opentelemetry-python-contrib](https://github.com/open-telemetry/opentelemetry-python-contrib)).",
-  "Designed and operate a bare-metal Kubernetes cluster (K3s) as a practical environment for reliability engineering experimentation.",
-  "Centralized observability using the OpenTelemetry Collector to process diverse signals (traces, metrics, logs from cluster/apps, GitHub webhook -> Otel traces); data forwarded to Grafana Cloud and Honeycomb for analysis, alerting, and SLO tracking.",
-  "Automated infrastructure and deployments using GitOps CI/CD principles, ensuring high availability awareness through layered monitoring: Uptime Kuma for on-site checks/alerts, backed by a GCP uptime check with SMS alerting monitoring the primary monitoring service itself.",
+  "**OCI Model Cache Operator** ([projects/operators/oci-model-cache](https://github.com/jomcgi/homelab/tree/main/projects/operators/oci-model-cache)) — Go operator + ModelCache CRD + admission webhook that streams HuggingFace models into an OCI registry and rewrites pod volume refs at admission, so pods mount models like container images. Sealed-interface Go state machines make invalid phase transitions a compile error.",
+  "**Self-hosted agent platform** ([projects/agent_platform](https://github.com/jomcgi/homelab/tree/main/projects/agent_platform)) — vLLM inference, an MCP gateway, a sandboxed-execution orchestrator, and scheduled Claude routines running autonomous platform maintenance over a Postgres + pgvector knowledge graph.",
+  "**Platform plumbing** — four custom Bazel rulesets (notably rules_helm, and a rules_semgrep that extracts the scan engine from its PyPI wheels for hermetic **30s-vs-2min** diff scans); Argo CD GitOps; Envoy Gateway / Gateway API ingress behind a Cloudflare Tunnel (no open ports); Linkerd, Kyverno, 1Password Operator, self-hosted SigNoz.",
+];
+
+export const collabAside =
+  "Separately, a collaborative project (not part of the homelab):";
+
+export const collabProjects = [
+  '**loom** (in progress, with a collaborator under the weave-hand org — repo currently private, to be open-sourced) — a data platform built on one bet: **operating a governed, typed-object platform should scale sub-linearly with your data and your org** — a new dataset, domain, or transform adds no new system to run. Built clean-sheet in **Rust**, treating data governance as a safety property: an LLM-assisted STPA hazard analysis where "unsafe" means a governance violation, not a crash.',
 ];
 
 export const skills = [
   {
-    label: "Cloud & Infrastructure",
+    label: "Stack",
     items: [
-      "Google Cloud Platform (GCP)",
+      "AWS (EKS, S3)",
+      "GCP (GKE, BigQuery, Pub/Sub)",
       "Azure",
-      "Kubernetes (GKE)",
+      "Kubernetes",
+      "eBPF",
+      "Cilium",
+      "Linkerd",
+      "Gateway API",
+      "Argo CD",
       "Terraform",
-      "Infrastructure-as-Code (IaC)",
+      "Bazel",
     ],
   },
   {
-    label: "Reliability Engineering",
+    label: "Data & Observability",
     items: [
-      "SLO Definition & Implementation",
-      "Incident Management & Post-mortems",
-      "Monitoring & Alerting",
-      "Chaos Engineering",
-    ],
-  },
-  {
-    label: "Observability",
-    items: [
-      "OpenTelemetry (OTel)",
+      "Snowflake",
+      "SQLMesh",
+      "dbt",
+      "Postgres (PGvector/HNSW)",
+      "Neo4j",
+      "Iceberg",
+      "OpenTelemetry",
       "Prometheus",
       "Grafana",
-      "Distributed Tracing",
-      "Structured Logging",
+      "SigNoz",
+      "Honeycomb",
     ],
   },
   {
-    label: "Development",
+    label: "Languages & AI Infra",
     items: [
       "Go",
       "Python",
-      "Event-Driven Architecture",
-      "Microservices",
-      "API Design (REST)",
-    ],
-  },
-  {
-    label: "Databases & Data Systems",
-    items: [
-      "Postgres (incl. PGvector tuning)",
-      "Neo4j",
-      "BigQuery",
-      "Data Modeling",
-      "Database Optimization",
-      "Cloud Pub/Sub",
-      "ETL/Data Pipeline Design",
-      "Data Orchestration (Airflow/Composer)",
+      "Rust",
+      "SQL",
+      "Starlark",
+      "vLLM",
+      "MCP",
+      "Agent orchestration",
+      "Claude Code",
     ],
   },
 ];


### PR DESCRIPTION
## Summary

Acts on a design critique of public.jomcgi.dev (palette untouched), plus refreshes stale page copy while in here:

**Design language**
- All ink borders normalized to 2px (hero/bio rules were 1px, cards/marquee 1.5px)
- Soft blurred `--shadow-*` tokens (unused) replaced with hard offsets; `.card-hard` carries its offset shadow at rest
- Topology section brutalized: hard offset shadows on DAG nodes, 2px edges/arrows, paper group fills, eyebrow ("live from the cluster · click a node") + status legend
- Hero: weight 700, natural wrap + `text-wrap: balance`, `.hl` yellow highlight on "production grade infra"
- Bug fix: TALK TO MY NOTES pointed at `#homelab` instead of `/notes`
- Stickers: bio sticker into flow (was `display:none` under 1900px), footer sticker drops its `margin-right: 680px` magic number; one deco per band survives mobile

**Content**
- Refresh page copy that had drifted out of date; the CV page gains blurb/bullet/highlight rendering per role

Includes the monolith chart bump (0.91.0).

## Test plan
- [ ] CI green (svelte build + vitest)
- [ ] Verify homepage hero wrap at 1440/768/390 after deploy
- [ ] Verify topology node shadows + legend render against live SLO data
- [ ] Verify /cv renders all roles + subsections

🤖 Generated with [Claude Code](https://claude.com/claude-code)