### PR TITLE
fix(chat): resolve @-mentions in get_user_summary by user_id

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.91.0
+version: 0.91.1
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chat/agent.py
+++ b/projects/monolith/chat/agent.py
@@ -217,6 +217,23 @@ def create_agent(base_url: str | None = None) -> Agent[ChatDeps]:
     ) -> str:
         """Get user activity summaries. Call with no username to list all available users. Call with a username to get their full summary."""
         deps = ctx.deps
+        # Discord @-mentions arrive as {'type': 'user_id', 'id': '...'} rather
+        # than a name string. Resolve them by the stable user_id — mirroring
+        # search_history — so a mention reaches the summary keyed on that ID
+        # instead of falling through to the "list everyone" branch.
+        if isinstance(username, dict) and username.get("type") == "user_id":
+            raw_id = username.get("id")
+            if raw_id is not None:
+                summary = deps.store.get_user_summary_by_user_id(
+                    deps.channel_id, str(raw_id)
+                )
+                if not summary:
+                    return f"No summary available for user {raw_id}."
+                return (
+                    f"Summary for {summary.username} "
+                    f"(updated {summary.updated_at.strftime('%Y-%m-%d')}):\n"
+                    f"{summary.summary}"
+                )
         username = _coerce_username(username)
         if not username:
             summaries = deps.store.list_user_summaries(deps.channel_id)

--- a/projects/monolith/chat/agent_tool_execution_test.py
+++ b/projects/monolith/chat/agent_tool_execution_test.py
@@ -5,6 +5,7 @@ using pydantic_ai's FunctionModel, which lets us control what the LLM
 "requests" and then verify what the tool returns.
 """
 
+from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -153,7 +154,6 @@ class TestSearchHistoryWithResults:
     @pytest.mark.asyncio
     async def test_returns_formatted_messages_when_results_exist(self):
         """search_history returns formatted context when store returns messages."""
-        from datetime import datetime, timezone
 
         from chat.models import Message
 
@@ -299,7 +299,6 @@ class TestGetUserSummaryListMode:
     @pytest.mark.asyncio
     async def test_returns_user_list_when_no_username(self):
         """get_user_summary returns a list of users when called with no username."""
-        from datetime import datetime, timezone
 
         from chat.models import UserChannelSummary
 
@@ -516,7 +515,6 @@ class TestGetUserSummaryFound:
     @pytest.mark.asyncio
     async def test_returns_formatted_summary_when_found(self):
         """get_user_summary returns a formatted string with username and summary text."""
-        from datetime import datetime, timezone
 
         from chat.models import UserChannelSummary
 
@@ -571,7 +569,6 @@ class TestGetUserSummaryFound:
     @pytest.mark.asyncio
     async def test_get_user_summary_called_with_channel_and_username(self):
         """get_user_summary passes channel_id and username to store.get_user_summary."""
-        from datetime import datetime, timezone
 
         from chat.models import UserChannelSummary
 
@@ -598,3 +595,113 @@ class TestGetUserSummaryFound:
         )
 
         store.get_user_summary.assert_called_once_with("my-chan", "alice")
+
+
+# ---------------------------------------------------------------------------
+# get_user_summary — Discord @-mention dict resolves by user_id
+# ---------------------------------------------------------------------------
+
+
+class TestGetUserSummaryMention:
+    @pytest.mark.asyncio
+    async def test_mention_dict_resolves_summary_by_user_id(self):
+        """A {'type': 'user_id'} mention is looked up by user_id, not username."""
+
+        from chat.models import UserChannelSummary
+
+        embed_client = AsyncMock()
+        store = MagicMock()
+
+        summary_obj = UserChannelSummary(
+            channel_id="ch1",
+            user_id="98146497454960640",
+            username="𝔲𝔤𝔩𝔶𝔟𝔬𝔶",
+            summary="uglyboy critiques tech ecosystems through cynical pragmatism.",
+            last_message_id=10,
+            updated_at=datetime(2026, 5, 27, tzinfo=timezone.utc),
+        )
+        store.get_user_summary_by_user_id.return_value = summary_obj
+
+        deps = _make_deps(store, embed_client)
+        agent = create_agent(base_url="http://fake:8080")
+
+        tool_return_captured = []
+
+        def model_func(messages, info):  # type: ignore[type-arg]
+            for msg in messages:
+                if hasattr(msg, "parts"):
+                    for part in msg.parts:
+                        if isinstance(part, ToolReturnPart):
+                            tool_return_captured.append(part.content)
+                            return ModelResponse(parts=[TextPart("done")])
+            return ModelResponse(
+                parts=[
+                    ToolCallPart(
+                        tool_name="get_user_summary",
+                        args={
+                            "username": {
+                                "type": "user_id",
+                                "id": "98146497454960640",
+                            }
+                        },
+                        tool_call_id="call-1",
+                    )
+                ]
+            )
+
+        await agent.run(
+            "what do your notes say about @uglyboy",
+            model=FunctionModel(model_func),
+            deps=deps,
+        )
+
+        # Resolved by the stable id, never by the mutable display name.
+        store.get_user_summary_by_user_id.assert_called_once_with(
+            "ch1", "98146497454960640"
+        )
+        store.get_user_summary.assert_not_called()
+        store.list_user_summaries.assert_not_called()
+        assert len(tool_return_captured) == 1
+        result = tool_return_captured[0]
+        assert "critiques tech ecosystems" in result
+        assert "𝔲𝔤𝔩𝔶𝔟𝔬𝔶" in result
+
+    @pytest.mark.asyncio
+    async def test_mention_dict_reports_no_summary_when_absent(self):
+        """An unknown mentioned user_id returns a 'no summary' message, not a list."""
+        embed_client = AsyncMock()
+        store = MagicMock()
+        store.get_user_summary_by_user_id.return_value = None
+
+        deps = _make_deps(store, embed_client)
+        agent = create_agent(base_url="http://fake:8080")
+
+        tool_return_captured = []
+
+        def model_func(messages, info):  # type: ignore[type-arg]
+            for msg in messages:
+                if hasattr(msg, "parts"):
+                    for part in msg.parts:
+                        if isinstance(part, ToolReturnPart):
+                            tool_return_captured.append(part.content)
+                            return ModelResponse(parts=[TextPart("done")])
+            return ModelResponse(
+                parts=[
+                    ToolCallPart(
+                        tool_name="get_user_summary",
+                        args={"username": {"type": "user_id", "id": "404"}},
+                        tool_call_id="call-1",
+                    )
+                ]
+            )
+
+        await agent.run(
+            "what about @nobody",
+            model=FunctionModel(model_func),
+            deps=deps,
+        )
+
+        store.get_user_summary_by_user_id.assert_called_once_with("ch1", "404")
+        store.list_user_summaries.assert_not_called()
+        assert len(tool_return_captured) == 1
+        assert "404" in tool_return_captured[0]

--- a/projects/monolith/chat/store.py
+++ b/projects/monolith/chat/store.py
@@ -242,6 +242,23 @@ class MessageStore:
         )
         return self.session.exec(stmt).first()
 
+    def get_user_summary_by_user_id(
+        self, channel_id: str, user_id: str
+    ) -> UserChannelSummary | None:
+        """Return the rolling summary for a user_id in a channel, or None.
+
+        Looks up by the stable Discord user_id rather than the mutable display
+        name. This is the canonical key — the table's unique constraint is on
+        (channel_id, user_id) — and it survives nickname changes and exotic
+        display names (e.g. Unicode "fraktur" nicks that never equal their
+        ASCII spelling).
+        """
+        stmt = select(UserChannelSummary).where(
+            UserChannelSummary.channel_id == channel_id,
+            UserChannelSummary.user_id == user_id,
+        )
+        return self.session.exec(stmt).first()
+
     def upsert_summary(
         self,
         channel_id: str,

--- a/projects/monolith/chat/store_summary_test.py
+++ b/projects/monolith/chat/store_summary_test.py
@@ -82,6 +82,43 @@ class TestGetUserSummary:
         assert result is None
 
 
+class TestGetUserSummaryByUserId:
+    def test_returns_summary_for_known_user_id(self, store, session):
+        """get_user_summary_by_user_id resolves by the stable user_id."""
+        session.add(
+            UserChannelSummary(
+                channel_id="ch1",
+                user_id="98146497454960640",
+                username="𝔲𝔤𝔩𝔶𝔟𝔬𝔶",
+                summary="uglyboy critiques tech ecosystems.",
+                last_message_id=1,
+            )
+        )
+        session.commit()
+        result = store.get_user_summary_by_user_id("ch1", "98146497454960640")
+        assert result is not None
+        assert result.username == "𝔲𝔤𝔩𝔶𝔟𝔬𝔶"
+        assert "critiques" in result.summary
+
+    def test_returns_none_for_unknown_user_id(self, store):
+        """get_user_summary_by_user_id returns None when the id is absent."""
+        assert store.get_user_summary_by_user_id("ch1", "404") is None
+
+    def test_scoped_to_channel(self, store, session):
+        """get_user_summary_by_user_id only matches within the given channel."""
+        session.add(
+            UserChannelSummary(
+                channel_id="ch1",
+                user_id="u1",
+                username="Alice",
+                summary="Alice summary.",
+                last_message_id=1,
+            )
+        )
+        session.commit()
+        assert store.get_user_summary_by_user_id("ch2", "u1") is None
+
+
 class TestListUserSummaries:
     def test_returns_all_summaries_for_channel(self, store, session):
         """list_user_summaries returns all summaries in the channel."""

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.91.0
+      targetRevision: 0.91.1
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
## Problem

Asked *"what do your notes say about @𝔲𝔤𝔩𝔶𝔟𝔬𝔶"*, the Discord bot replied **"I don't have any specific notes attached to that ID"** — despite a fully populated record existing for that user (Discord ID `98146497454960640`, summaries across multiple channels through 2026-05-27).

The KG / chat store was **not** the problem. Semantic search returns the profile for both the plain `uglyboy` and the raw Unicode-fraktur `𝔲𝔤𝔩𝔶𝔟𝔬𝔶` query. The failure was in the bot's `get_user_summary` tool.

## Root cause

A Discord `@-mention` reaches the tool as a dict — `{'type': 'user_id', 'id': '98146497454960640'}` — not a name string. `get_user_summary` only ran `_coerce_username`, which extracts `username`/`name`/`display_name` keys. The mention dict has none of those, so it coerced to `None`, and the tool fell into its **"no username → list every user"** branch — never retrieving the mentioned person's summary. The model, handed a bare user list, then confabulated "no notes attached to that ID."

The sibling tool `search_history` already decodes this exact mention shape and resolves it to a `user_id`; `get_user_summary` had simply drifted out of sync.

## Fix

- `get_user_summary` now detects the `{'type': 'user_id'}` mention dict and looks the summary up by the **stable `user_id`** — mirroring `search_history`. The plain-string and list-mode paths are unchanged.
- Adds `MessageStore.get_user_summary_by_user_id(channel_id, user_id)`, querying the table's canonical key (`UserChannelSummary`'s unique constraint is `(channel_id, user_id)`). This is robust to nickname changes and exotic display names (e.g. fraktur nicks that never equal their ASCII spelling).

## Why user_id, not username

The display name is mutable and non-unique — the same human appears as both `𝔲𝔤𝔩𝔶𝔟𝔬𝔶` and `uglyboy`. The `user_id` is the canonical, stable key. Routing mentions through it closes the whole class of "name doesn't match what's stored" misses.

## Tests

- `store_summary_test.py::TestGetUserSummaryByUserId` — lookup by id, miss, channel scoping (uses a fraktur username in the fixture).
- `agent_tool_execution_test.py::TestGetUserSummaryMention` — drives the tool with a mention dict via `FunctionModel`; asserts it resolves by `user_id`, never touches `get_user_summary`/`list_user_summaries`, and returns the summary; plus an absent-id case that reports "no summary" rather than dumping the user list.
- Also hoisted the file's pre-existing inline `datetime` imports to module level to satisfy the `no-inline-stdlib-import` semgrep rule.

## Known follow-up (not in scope)

The plain-text-name path (`get_user_summary("uglyboy")`) still does an exact `username` match, so an ASCII spelling won't find a fraktur-stored row. The @-mention path — the actual trigger here — is fixed. A future change could route the name path through `find_user_id_by_username` for alias tolerance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)