### PR TITLE
fix(public-site): calm CV highlighting, widen text, fix sticker shadow seam

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.91.1
+version: 0.91.2
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.91.1
+      targetRevision: 0.91.2
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/lib/public/components/Sticker.svelte
+++ b/projects/monolith/frontend/src/lib/public/components/Sticker.svelte
@@ -13,7 +13,7 @@
 
 <span
   class="sticker {className}"
-  style:background={color}
+  style:background-color={color}
   style:transform="rotate({rotate}deg)"
 >
   {@render children()}
@@ -29,7 +29,13 @@
     text-transform: uppercase;
     padding: 8px 14px;
     border: 2px solid var(--ink);
-    box-shadow: 3px 3px 0 var(--ink);
+    /* The fill must not paint under the border: on a rotated element the
+       border's outer antialiasing blends with the fill, leaving a colored
+       hairline between border and shadow. drop-shadow (vs box-shadow) traces
+       the rotated silhouette exactly, so the shadow meets the border with no
+       seam or stepped corner. */
+    background-clip: padding-box;
+    filter: drop-shadow(3px 3px 0 var(--ink));
     white-space: nowrap;
     color: var(--ink);
   }

--- a/projects/monolith/frontend/src/routes/public/cv/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/cv/+page.svelte
@@ -17,8 +17,11 @@
 
   // Minimal inline-markdown tokenizer. The CV bullets carry just two markdown
   // constructs from cv.md — **emphasis** and [text](url) — so a focused
-  // tokenizer beats pulling in a full markdown dependency. Emphasis renders as
-  // a coral-underlined metric; links render as inline anchors.
+  // tokenizer beats pulling in a full markdown dependency. Emphasis splits two
+  // ways: a digit-bearing token mid-sentence is a metric (the only coral on
+  // the page); everything else — including the lead-in phrase that opens a
+  // bullet — renders as a plain bold run-in heading. Links render as inline
+  // anchors.
   function tokenize(text) {
     const tokens = [];
     const re = /\*\*(.+?)\*\*|\[(.+?)\]\((.+?)\)/g;
@@ -29,7 +32,8 @@
         tokens.push({ type: "text", text: text.slice(last, m.index) });
       }
       if (m[1] !== undefined) {
-        tokens.push({ type: "em", text: m[1] });
+        const isMetric = /\d/.test(m[1]) && m.index > 0;
+        tokens.push({ type: isMetric ? "em" : "lead", text: m[1] });
       } else {
         tokens.push({ type: "link", text: m[2], href: m[3] });
       }
@@ -85,6 +89,7 @@
 {#snippet inline(text)}
   {#each tokenize(text) as tok}
     {#if tok.type === "em"}<span class="metric">{tok.text}</span
+      >{:else if tok.type === "lead"}<span class="lead">{tok.text}</span
       >{:else if tok.type === "link"}<a
         class="inline-link"
         href={tok.href}
@@ -464,7 +469,6 @@
     line-height: 1.55;
     color: var(--ink-2);
     margin: 0 0 18px 23px;
-    max-width: 72ch;
   }
   .highlight {
     margin: 0 0 22px 23px;
@@ -498,7 +502,6 @@
     line-height: 1.45;
     color: var(--ink);
     margin: 0 0 8px;
-    max-width: 72ch;
   }
   .highlight-intro {
     font-family: var(--sans);
@@ -506,7 +509,6 @@
     line-height: 1.55;
     color: var(--ink-3);
     margin: 0 0 12px;
-    max-width: 72ch;
   }
   .highlight .bullets {
     margin-left: 0;
@@ -523,7 +525,6 @@
     font-size: 15px;
     line-height: 1.55;
     color: var(--ink-2);
-    max-width: 72ch;
     margin-top: 8px;
   }
 
@@ -534,7 +535,6 @@
     line-height: 1.55;
     color: var(--ink-2);
     margin: 0 0 20px;
-    max-width: 72ch;
   }
   .section-aside {
     margin-top: 24px;
@@ -571,6 +571,13 @@
     color: var(--ink);
     font-size: 15px;
     font-weight: 700;
+  }
+
+  /* Bullet lead-ins are run-in headings: bold ink, no marker. Coral is
+     reserved for .metric below, so the eye can find the numbers. */
+  .lead {
+    font-weight: 700;
+    color: var(--ink);
   }
 
   /* Metrics are the ONLY coral on the page — coral means "this is the number

--- a/projects/monolith/frontend/src/routes/public/cv/cv-data.js
+++ b/projects/monolith/frontend/src/routes/public/cv/cv-data.js
@@ -52,7 +52,7 @@ export const jobs = [
         intro:
           "BenchSci turns 25M+ scientific papers into structured biomedical knowledge via NER, LLM extraction, and knowledge-graph linking. Document processing was a weekly batch with pipeline-granularity caching: freshness capped what product could ship, and unchanged work was reprocessed every cycle.",
         bullets: [
-          "**Rebuilt it event-driven on GKE** — per-document events, per-document caching, scale-to-zero; only changed docs reprocess. Processing collapsed weeks → minutes, cost dropped **$644 → $69 per 2.5M docs (−89%)**, scaling to **100K+ concurrent documents** with the full **25M+ corpus** reprocessable on demand.",
+          "**Rebuilt it event-driven on GKE** — per-document events, per-document caching, scale-to-zero; only changed docs reprocess. Processing collapsed weeks → minutes, cost dropped **$644 → $69 per 2.5M docs (−89%)**, scaling to 100K+ concurrent documents with the full 25M+ corpus reprocessable on demand.",
           "**Made it the path of least resistance** — for the ML researchers who used it, adoption was a decorator and a Python function; the framework owned deployment, event semantics, the message log, and live data testing. **~200 engineers adopted it** as the data platform's canonical foundation.",
         ],
       },
@@ -60,7 +60,7 @@ export const jobs = [
         title: "Also at BenchSci",
         bullets: [
           "**OpenTelemetry org-wide adoption** — every team was rolling their own logs, metrics, and tracing. I drove the company-wide OTel rollout: logs, metrics, and traces out of the box, one standard, one place to look. Incident **time-to-identify (TTI) dropped from 94 to 23 minutes (−75%)**; false-alert volume down 15%.",
-          "**GPU inference at cloud-quota limits** — ran in-pod L4 inference for **~50 in-house ML models** (paper extraction, entity enrichment, vision ML) inside the same event-driven pipeline, autoscaling across regions against a **~25K L4-GPU quota** — bursting onto spot capacity when available — with each document's work colocated in-region to avoid cross-region transfer.",
+          "**GPU inference at cloud-quota limits** — ran in-pod L4 inference for ~50 in-house ML models (paper extraction, entity enrichment, vision ML) inside the same event-driven pipeline, autoscaling across regions against a **~25K L4-GPU quota** — bursting onto spot capacity when available — with each document's work colocated in-region to avoid cross-region transfer.",
           "**RCA squad lead** — post-incident process was bespoke per team. I authored the company RCA playbook and led a cross-functional squad through it. **40% time-to-resolution reduction**; recurring SLA violations eliminated.",
         ],
       },


### PR DESCRIPTION
Design feedback round 2 on the CV page + footer sticker:

- **Over-highlighting** — bullet lead-ins now render as bold-ink run-in headings; coral is reserved for digit-bearing metric tokens mid-sentence. Also trimmed secondary metrics (corpus size, model count) so each bullet carries at most one coral mark.
- **Narrow text** — dropped the `72ch` caps on blurbs/intros/kickers; short sentences were wrapping inside an 880px column that bullets already fill edge-to-edge.
- **Sticker shadow artifacts** — `background-clip: padding-box` stops the coral fill bleeding under the rotated border's antialiasing (the faint red hairline), and `filter: drop-shadow()` replaces `box-shadow` so the shadow traces the rotated silhouette with no seam or stepped corner.

Verified by rendering the page locally (vite dev + headless Chrome screenshots).

Includes monolith chart bump to 0.91.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)