### PR TITLE
fix(public-site): fold loom into projects list with repo's Foundry framing

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.91.3
+version: 0.91.4
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.91.3
+      targetRevision: 0.91.4
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/routes/public/cv/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/cv/+page.svelte
@@ -10,8 +10,6 @@
     earlierCareer,
     personalIntro,
     projects,
-    collabAside,
-    collabProjects,
     skills,
   } from "./cv-data.js";
 
@@ -218,12 +216,6 @@
       <p class="section-intro">{@render inline(personalIntro)}</p>
       <ul class="bullets bullets--lg">
         {#each projects as project}
-          <li>{@render inline(project)}</li>
-        {/each}
-      </ul>
-      <p class="section-intro section-aside">{collabAside}</p>
-      <ul class="bullets bullets--lg">
-        {#each collabProjects as project}
           <li>{@render inline(project)}</li>
         {/each}
       </ul>
@@ -535,10 +527,6 @@
     line-height: 1.55;
     color: var(--ink-2);
     margin: 0 0 20px;
-  }
-  .section-aside {
-    margin-top: 24px;
-    color: var(--ink-3);
   }
 
   /* ── Bullets ──────────────────────────────── */

--- a/projects/monolith/frontend/src/routes/public/cv/cv-data.js
+++ b/projects/monolith/frontend/src/routes/public/cv/cv-data.js
@@ -106,13 +106,7 @@ export const projects = [
   "**OCI Model Cache Operator** ([projects/operators/oci-model-cache](https://github.com/jomcgi/homelab/tree/main/projects/operators/oci-model-cache)): a Go operator that streams HuggingFace models into an OCI registry and rewrites pod volumes at admission, so pods mount models like container images. Sealed-interface state machines make invalid phase transitions a compile error.",
   "**Self-hosted agent platform** ([projects/agent_platform](https://github.com/jomcgi/homelab/tree/main/projects/agent_platform)): vLLM inference, an MCP gateway, a sandboxed-execution orchestrator, and scheduled Claude routines running autonomous platform maintenance over a Postgres + pgvector knowledge graph.",
   "**Platform plumbing**: four custom Bazel rulesets, notably rules_helm and a rules_semgrep that extracts the scan engine from its PyPI wheels and cuts hermetic diff scans **from 2 minutes to 30 seconds**; Argo CD GitOps; Envoy Gateway / Gateway API ingress behind a Cloudflare Tunnel (no open ports); Linkerd, Kyverno, 1Password Operator, self-hosted SigNoz.",
-];
-
-export const collabAside =
-  "Separately, a collaborative project (in progress, private for now):";
-
-export const collabProjects = [
-  "**loom**: a **Rust** data platform built on one bet: **it should scale sub-linearly with your data and your org**. A new dataset, domain, or transform adds no new system to run.",
+  "**loom**: an open-source take on **Palantir Foundry** — a typed-object data platform with built-in lineage and governance, on a **Rust** + DataFusion + DuckLake core. Postgres is the only stateful coordinator, so a new dataset, domain, or transform adds **no new system to run**.",
 ];
 
 export const skills = [


### PR DESCRIPTION
Replaces the loom CV bullet's abstract sub-linear-scaling pitch with the framing from loom's own README — an open-source take on Palantir Foundry on a Rust + DataFusion + DuckLake core, with Postgres as the only stateful coordinator. The "no new system to run" line stays, now as a consequence of that design rather than a slogan.

Also removes the "Separately, a collaborative project (in progress, private for now)" aside and folds loom into the main projects list, deleting the now-unused `collabAside`/`collabProjects` exports and the orphaned `.section-aside` CSS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)