### PR TITLE
fix(public-site): drop em-dashes from CV copy, ban them in CLAUDE.md

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -32,6 +32,10 @@ Skip this for: one-line config fixes, typo corrections, mechanical renames, or w
 
 Output shape: "Option A (simplest): …; Option B: … — recommend A unless you want flexibility for X." Then pause.
 
+## Writing Style
+
+**Never use em-dashes (—) in anything you write**: site copy, CV content, docs, ADRs, commit messages, PR bodies, code comments. Use a comma, colon, parentheses, or split the sentence. Existing em-dashes in old files are grandfathered (don't churn files just to strip them), but never add new ones.
+
 ## Essential Commands
 
 ```bash

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.91.4
+version: 0.91.5
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.91.4
+      targetRevision: 0.91.5
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/routes/public/cv/cv-data.js
+++ b/projects/monolith/frontend/src/routes/public/cv/cv-data.js
@@ -1,4 +1,4 @@
-// CV content — transcribed from the canonical public CV maintained in the
+// CV content, transcribed from the canonical public CV maintained in the
 // private cv repo (public/cv.md there; only the public/ variant is ever
 // mirrored here). Bullet strings keep the markdown inline syntax (**bold**,
 // [text](url)); the page renders them via the tiny tokenizer in +page.svelte
@@ -106,7 +106,7 @@ export const projects = [
   "**OCI Model Cache Operator** ([projects/operators/oci-model-cache](https://github.com/jomcgi/homelab/tree/main/projects/operators/oci-model-cache)): a Go operator that streams HuggingFace models into an OCI registry and rewrites pod volumes at admission, so pods mount models like container images. Sealed-interface state machines make invalid phase transitions a compile error.",
   "**Self-hosted agent platform** ([projects/agent_platform](https://github.com/jomcgi/homelab/tree/main/projects/agent_platform)): vLLM inference, an MCP gateway, a sandboxed-execution orchestrator, and scheduled Claude routines running autonomous platform maintenance over a Postgres + pgvector knowledge graph.",
   "**Platform plumbing**: four custom Bazel rulesets, notably rules_helm and a rules_semgrep that extracts the scan engine from its PyPI wheels and cuts hermetic diff scans **from 2 minutes to 30 seconds**; Argo CD GitOps; Envoy Gateway / Gateway API ingress behind a Cloudflare Tunnel (no open ports); Linkerd, Kyverno, 1Password Operator, self-hosted SigNoz.",
-  "**loom**: an open-source take on **Palantir Foundry** — a typed-object data platform with built-in lineage and governance, on a **Rust** + DataFusion + DuckLake core. Postgres is the only stateful coordinator, so a new dataset, domain, or transform adds **no new system to run**.",
+  "**loom**: an open-source take on **Palantir Foundry**, a typed-object data platform with built-in lineage and governance, on a **Rust** + DataFusion + DuckLake core. Postgres is the only stateful coordinator, so a new dataset, domain, or transform adds **no new system to run**.",
 ];
 
 export const skills = [


### PR DESCRIPTION
Follow-up to #2474, which introduced an em-dash in the loom bullet. Rewrites it as a comma appositive and cleans the one in the cv-data.js header comment.

Also adds a Writing Style section to .claude/CLAUDE.md: never write em-dashes in new prose (site copy, docs, ADRs, commit messages, PR bodies, code comments); existing occurrences are grandfathered to avoid churn-only diffs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)