### PR TITLE
fix(chat): resolve message subject from structured mention/reply data

### DIFF
--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -1440,6 +1440,20 @@ py_test(
 )
 
 py_test(
+    name = "chat_bot_subject_note_test",
+    srcs = ["chat/bot_subject_note_test.py"],
+    imports = ["."],
+    deps = [
+        ":monolith_backend",
+        "@pip//pgvector",
+        "@pip//pydantic_ai_slim",
+        "@pip//pytest",
+        "@pip//pytest_asyncio",
+        "@pip//sqlmodel",
+    ],
+)
+
+py_test(
     name = "chat_bot_attachment_download_test",
     srcs = ["chat/bot_attachment_download_test.py"],
     imports = ["."],

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.91.5
+version: 0.91.6
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chat/bot.py
+++ b/projects/monolith/chat/bot.py
@@ -76,6 +76,52 @@ def should_respond(message: discord.Message, bot_user: discord.User) -> bool:
     return False
 
 
+def format_subject_note(message: discord.Message, bot_user_id: int) -> str:
+    """State who the current message is about, from Discord's structured data.
+
+    Without this, the model has to infer the subject of a "who is this / what
+    are your notes on them" question by scanning the rendered conversation
+    history, where every past message still carries raw ``<@id>`` tokens. It
+    can grab a stale id from an earlier message instead of the person actually
+    being addressed. The triggering message's own @-mentions, and the author
+    of any message it is a reply to, are the authoritative targets, so we name
+    them explicitly with their numeric ids. Returns "" for plain chat with no
+    such target (the note is only added when there is something to resolve).
+    """
+    lines: list[str] = []
+
+    mentioned = [m for m in getattr(message, "mentions", []) if m.id != bot_user_id]
+    if mentioned:
+        lines.append(
+            "  - directly @-mentions: "
+            + ", ".join(f"{m.display_name} (Discord user ID {m.id})" for m in mentioned)
+        )
+
+    ref = getattr(message, "reference", None)
+    resolved = getattr(ref, "resolved", None) if ref is not None else None
+    if (
+        resolved is not None
+        and not isinstance(resolved, discord.DeletedReferencedMessage)
+        and getattr(resolved, "author", None) is not None
+        and resolved.author.id != bot_user_id
+    ):
+        author = resolved.author
+        lines.append(
+            "  - is a reply to a message from: "
+            f"{author.display_name} (Discord user ID {author.id})"
+        )
+
+    if not lines:
+        return ""
+
+    return (
+        "\n[Who this message is about. If it asks who someone is, or for your "
+        "notes or summary about a person, resolve it to these Discord user ids, "
+        "not to any mention that only appears in the conversation history "
+        "above:\n" + "\n".join(lines) + "]"
+    )
+
+
 async def download_image_attachments(
     attachments: list[discord.Attachment],
     vision_client: VisionClient,
@@ -346,9 +392,15 @@ class ChatBot(discord.Client):
                 "third party to look up.]"
             )
 
+            # Authoritative subject resolved from Discord's structured mention
+            # and reply data, so the model targets the right person rather than
+            # a stale "<@id>" scraped from the history above.
+            subject_note = format_subject_note(message, self.user.id)
+
             user_prompt = (
                 f"{identity_note}\n\n{context}\n\nCurrent message from "
                 f"{message.author.display_name}: {message.content}"
+                f"{subject_note}"
             )
 
             # Include current message images in prompt

--- a/projects/monolith/chat/bot_subject_note_test.py
+++ b/projects/monolith/chat/bot_subject_note_test.py
@@ -1,0 +1,202 @@
+"""Tests for format_subject_note + its injection into the agent prompt.
+
+format_subject_note resolves *who the current message is about* from Discord's
+structured mention/reply data, so the model targets the right person instead of
+scraping a stale "<@id>" out of the rendered conversation history. These tests
+cover the pure helper (mention, reply, exclusion, empty cases) and verify the
+note actually reaches the prompt passed to the agent.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pydantic_ai import PartDeltaEvent, TextPartDelta
+
+from chat.bot import ChatBot, format_subject_note
+
+
+def _user(uid: int, name: str) -> SimpleNamespace:
+    return SimpleNamespace(id=uid, display_name=name)
+
+
+def _reply_to(author: SimpleNamespace) -> SimpleNamespace:
+    """A message.reference whose resolved message was written by `author`."""
+    return SimpleNamespace(resolved=SimpleNamespace(author=author))
+
+
+def _msg(mentions=None, reference=None) -> SimpleNamespace:
+    return SimpleNamespace(mentions=mentions or [], reference=reference)
+
+
+BOT_ID = 999
+
+
+# ---------------------------------------------------------------------------
+# format_subject_note (pure helper)
+# ---------------------------------------------------------------------------
+
+
+class TestFormatSubjectNote:
+    def test_empty_for_plain_message(self):
+        """No mentions and no reply -> no subject note (plain chat)."""
+        assert format_subject_note(_msg(), BOT_ID) == ""
+
+    def test_mention_surfaces_id_and_name(self):
+        """A direct @-mention is named with its numeric id."""
+        note = format_subject_note(
+            _msg(mentions=[_user(98146497454960640, "𝔲𝔤𝔩𝔶𝔟𝔬𝔶")]), BOT_ID
+        )
+        assert "directly @-mentions" in note
+        assert "Discord user ID 98146497454960640" in note
+        assert "𝔲𝔤𝔩𝔶𝔟𝔬𝔶" in note
+
+    def test_excludes_the_bot_itself(self):
+        """A mention of the bot is dropped; only third parties remain."""
+        note = format_subject_note(
+            _msg(mentions=[_user(BOT_ID, "Qwen"), _user(42, "alice")]), BOT_ID
+        )
+        assert "Discord user ID 42" in note
+        assert str(BOT_ID) not in note
+        assert "Qwen" not in note
+
+    def test_mention_only_bot_yields_empty(self):
+        """If the only mention is the bot, there is no third-party subject."""
+        assert format_subject_note(_msg(mentions=[_user(BOT_ID, "Qwen")]), BOT_ID) == ""
+
+    def test_reply_target_author_surfaced(self):
+        """Replying to someone's message names that author as the subject."""
+        note = format_subject_note(_msg(reference=_reply_to(_user(555, "bob"))), BOT_ID)
+        assert "is a reply to a message from" in note
+        assert "Discord user ID 555" in note
+        assert "bob" in note
+
+    def test_reply_to_bot_is_ignored(self):
+        """A reply to the bot's own message is not a third-party subject."""
+        assert (
+            format_subject_note(
+                _msg(reference=_reply_to(_user(BOT_ID, "Qwen"))), BOT_ID
+            )
+            == ""
+        )
+
+    def test_mention_and_reply_both_listed(self):
+        """Both an @-mention and a reply target appear when both are present."""
+        note = format_subject_note(
+            _msg(
+                mentions=[_user(42, "alice")],
+                reference=_reply_to(_user(555, "bob")),
+            ),
+            BOT_ID,
+        )
+        assert "Discord user ID 42" in note
+        assert "Discord user ID 555" in note
+
+    def test_reply_with_no_author_ignored(self):
+        """A resolved reference lacking an author (e.g. deleted) is skipped."""
+        ref = SimpleNamespace(resolved=SimpleNamespace(author=None))
+        assert format_subject_note(_msg(reference=ref), BOT_ID) == ""
+
+    def test_history_only_mention_not_surfaced(self):
+        """Ids that exist only in history (not on the triggering message) are
+        never in the note: the helper reads structured fields, not text."""
+        note = format_subject_note(_msg(mentions=[_user(42, "alice")]), BOT_ID)
+        # An unrelated id that might appear in rendered history must not leak in.
+        assert "123456789012345678" not in note
+
+
+# ---------------------------------------------------------------------------
+# Injection into the agent prompt (wiring)
+# ---------------------------------------------------------------------------
+
+
+class _AsyncCtxManager:
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        return False
+
+
+async def _async_iter(events):
+    for e in events:
+        yield e
+
+
+def _make_bot(user_id: int = BOT_ID) -> ChatBot:
+    with (
+        patch("chat.bot.EmbeddingClient") as mock_ec,
+        patch("chat.bot.VisionClient"),
+        patch("chat.bot.create_agent") as mock_ca,
+    ):
+        mock_ec.return_value = AsyncMock()
+        mock_ca.return_value = MagicMock()
+        bot = ChatBot()
+    bot._connection = MagicMock()
+    bot._connection.user = MagicMock()
+    bot._connection.user.id = user_id
+    bot._connection.user.display_name = "Qwen"
+    return bot
+
+
+def _make_store():
+    store = AsyncMock()
+    store.save_message = AsyncMock()
+    store.get_recent = MagicMock(return_value=[])
+    store.get_attachments = MagicMock(return_value={})
+    store.get_channel_summary = MagicMock(return_value=None)
+    store.get_user_summaries_for_users = MagicMock(return_value=[])
+    store.acquire_lock = MagicMock(return_value=True)
+    store.mark_completed = MagicMock()
+    return store
+
+
+def _make_discord_message(mentions, reference=None) -> MagicMock:
+    msg = MagicMock()
+    msg.id = 1
+    msg.content = "what do your notes say about them"
+    msg.author.bot = False
+    msg.author.id = 42
+    msg.author.display_name = "asker"
+    msg.channel.id = 99
+    msg.channel.typing = MagicMock(return_value=_AsyncCtxManager())
+    msg.mentions = mentions
+    msg.reference = reference
+    msg.attachments = []
+    msg.embeds = []
+    sent = MagicMock(id=100)
+    sent.edit = AsyncMock()
+    msg.reply = AsyncMock(return_value=sent)
+    return msg
+
+
+async def _run(bot: ChatBot, msg: MagicMock, store) -> str:
+    bot.agent.run_stream_events = MagicMock(
+        return_value=_async_iter(
+            [PartDeltaEvent(index=0, delta=TextPartDelta(content_delta="ok"))]
+        )
+    )
+    with (
+        patch("chat.bot.get_engine"),
+        patch("chat.bot.Session") as mock_session_cls,
+        patch("chat.bot.MessageStore", return_value=store),
+    ):
+        mock_session_cls.return_value.__enter__ = MagicMock(return_value=MagicMock())
+        mock_session_cls.return_value.__exit__ = MagicMock(return_value=False)
+        await bot.on_message(msg)
+    return bot.agent.run_stream_events.call_args[0][0]
+
+
+class TestSubjectNoteInPrompt:
+    @pytest.mark.asyncio
+    async def test_mentioned_user_id_reaches_prompt(self):
+        """The mentioned user's id is stated authoritatively in the prompt."""
+        bot = _make_bot()
+        mentioned = MagicMock()
+        mentioned.id = 98146497454960640
+        mentioned.display_name = "𝔲𝔤𝔩𝔶𝔟𝔬𝔶"
+        msg = _make_discord_message(mentions=[bot.user, mentioned])
+        prompt = await _run(bot, msg, _make_store())
+
+        assert "Who this message is about" in prompt
+        assert "Discord user ID 98146497454960640" in prompt

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.91.5
+      targetRevision: 0.91.6
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
## Problem

After the `get_user_summary` mention-resolution fix (#2471), the bot resolved a *user_id* correctly but sometimes resolved the **wrong** user_id: asked "what do your notes say about @X", it would return a different person's notes.

Root cause is in how the prompt is assembled in `bot.py`. The model is handed a flat text blob:

```
[identity note]
[channel + people summaries]
Recent conversation:
[20 messages, each rendered "{username}: {msg.content}" with raw <@id> tokens intact]

Current message from {author}: {message.content}
```

Three things make it grab the wrong id:
1. **History carries raw `<@id>` tokens** (`format_context_messages` renders each message verbatim), so old mentions look like actionable ids.
2. **The current message is just one more text line**, not privileged over the 20 above it.
3. **The reply target is never in the prompt.** `should_respond` inspects `message.reference.resolved` only to decide *whether* to answer; the replied-to message and its author are never surfaced. So a reply to someone's message ("who is this guy") gives the model zero structured signal and it guesses from history.

## Fix

Discord already gives us the subject structurally. Add `format_subject_note(message, bot_user_id)`, which states it authoritatively in the prompt:

```
[Who this message is about. If it asks who someone is, or for your notes or
 summary about a person, resolve it to these Discord user ids, not to any
 mention that only appears in the conversation history above:
  - directly @-mentions: 𝔲𝔤𝔩𝔶𝔟𝔬𝔶 (Discord user ID 98146497454960640)
  - is a reply to a message from: <name> (Discord user ID ...)]
```

It lists the triggering message's own @-mentions and the author of any message it replies to, excludes the bot itself, and returns `""` for plain chat (no note added). Appended to the user prompt in `_stream_response`.

This is the "simplest approach" of the two considered: once the subject is stated authoritatively, the model has no reason to prefer a history id, so rewriting history rendering (the more invasive option) is unnecessary.

## Relationship to #2471

Complementary, not overlapping. #2471 made `get_user_summary` resolve a mention dict by `user_id`; this makes sure the **right** `user_id` reaches it. The tool from #2471 is untouched.

## Tests

`chat/bot_subject_note_test.py` (hand-registered in `projects/monolith/BUILD`, since `chat` is `gazelle:exclude`):
- Pure helper: mention surfaces id+name, bot excluded, mention-only-bot empty, reply-target author surfaced, reply-to-bot ignored, mention+reply both listed, no-author reference ignored, plain message empty.
- Wiring: a mentioned user's id reaches the prompt passed to the agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)