### PR TITLE
fix(public-site): drop filler role/domain counts from CV band headers

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.91.6
+version: 0.91.7
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.91.6
+      targetRevision: 0.91.7
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/routes/public/cv/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/cv/+page.svelte
@@ -101,7 +101,9 @@
   <div class="band-head">
     <span class="band-num mono">{num}</span>
     <span class="band-title mono">{title}</span>
-    <span class="band-meta mono">{meta}</span>
+    {#if meta}
+      <span class="band-meta mono">{meta}</span>
+    {/if}
   </div>
 {/snippet}
 
@@ -160,7 +162,7 @@
   <!-- ═══ Work experience (paper) ═══ -->
   <section class="band band--paper reveal">
     <div class="wrap-narrow">
-      {@render bandHead("01", "Work Experience", `${jobs.length} Roles`)}
+      {@render bandHead("01", "Work Experience")}
       <div class="jobs">
         {#each jobs as job}
           <article class="job">
@@ -225,7 +227,7 @@
   <!-- ═══ Technical expertise (paper) ═══ -->
   <section class="band band--paper reveal">
     <div class="wrap-narrow">
-      {@render bandHead("03", "Technical Expertise", `${skills.length} Domains`)}
+      {@render bandHead("03", "Technical Expertise")}
       <div class="skills">
         {#each skills as cat}
           <div class="skill-cat">


### PR DESCRIPTION
## What

Removes the `6 Roles` and `8 Domains` meta labels from the CV page band headers (bands 01 and 03). These were derived counts (`jobs.length` / `skills.length`) that carried no real signal, a role tally can even read as job-hopping. Band 02's descriptive `Homelab` label stays.

## How

- Made `meta` optional in the `bandHead` snippet, guarded its `<span>` with `{#if meta}` so an omitted meta leaves no empty element.
- Dropped the meta argument from the Work Experience and Technical Expertise band heads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)