### PR TITLE
ci(semgrep): add no-em-dash rule and Claude hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -174,6 +174,11 @@
             "type": "command",
             "command": "$CLAUDE_PROJECT_DIR/bazel/tools/hooks/check-generated-file-edit.sh",
             "timeout": 10
+          },
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/bazel/tools/hooks/check-em-dash.sh",
+            "timeout": 10
           }
         ]
       }

--- a/bazel/semgrep/rules/BUILD
+++ b/bazel/semgrep/rules/BUILD
@@ -188,6 +188,22 @@ semgrep_test(
     tags = ["semgrep"],
 )
 
+# no-em-dash uses languages: [generic] so its fixture is a YAML file.
+# This test wires the rule to its annotation fixture independently of
+# generic_rules_test (which only scans no-stale-repo-paths fixtures).
+filegroup(
+    name = "no_em_dash_rule",
+    srcs = ["generic/no-em-dash.yaml"],
+)
+
+semgrep_test(
+    name = "no_em_dash_test",
+    srcs = ["//bazel/semgrep/tests:no_em_dash_fixtures"],
+    env = {"SEMGREP_TEST_MODE": "1"},
+    rules = [":no_em_dash_rule"],
+    tags = ["semgrep"],
+)
+
 # no-generic-test-filename uses languages: [generic] so its fixture is a Python file.
 # This test wires the rule to its annotation fixture independently of
 # generic_rules_test (which only scans no-stale-repo-paths fixtures).

--- a/bazel/semgrep/rules/generic/no-em-dash.yaml
+++ b/bazel/semgrep/rules/generic/no-em-dash.yaml
@@ -1,0 +1,30 @@
+rules:
+  - id: no-em-dash
+    languages: [generic]
+    severity: WARNING
+    paths:
+      include:
+        - "**/*.js"
+        - "**/*.py"
+        - "**/*.go"
+        - "**/*.md"
+        - "**/*.svelte"
+        - "**/*.bzl"
+        - "**/*.yaml"
+      exclude:
+        - "bazel/semgrep/tests/fixtures/**"  # test fixtures contain intentional em-dashes for rule validation
+        - "bazel/ocaml/examples/hello/testdata/**"  # OCaml golden file that legitimately contains an em-dash
+    message: >-
+      Em-dash found. Use a comma, colon, parentheses, or split the sentence
+      (see CLAUDE.md Writing Style).
+    metadata:
+      category: style
+      subcategory: punctuation
+      confidence: HIGH
+      likelihood: LOW
+      impact: LOW
+      description: >-
+        Detects the em-dash character (U+2014) in source files. The CLAUDE.md
+        writing style guide forbids em-dashes in new content. Use a comma,
+        colon, or parentheses instead, or split the sentence.
+    pattern-regex: '\u2014'

--- a/bazel/semgrep/tests/BUILD
+++ b/bazel/semgrep/tests/BUILD
@@ -9,6 +9,7 @@ filegroup(
         # Exclude Go-rule reference fixtures that are not tested against yaml_rules.
         # Exclude SQL/generic and kubernetes-specific fixtures that are tested separately.
         exclude = [
+            "fixtures/no-em-dash.yaml",
             "fixtures/boto3-endpoint-url-missing-scheme.yaml",
             "fixtures/claude-print-missing-permission-mode.yaml",
             "fixtures/duckdb-bound-param-in-array-distance.yaml",
@@ -74,6 +75,13 @@ filegroup(
 filegroup(
     name = "no_stale_repo_paths_fixtures",
     srcs = ["fixtures/no-stale-repo-paths.md"],
+)
+
+# Fixture for the no-em-dash rule (languages: generic).
+# Referenced by //bazel/semgrep/rules:no_em_dash_test.
+filegroup(
+    name = "no_em_dash_fixtures",
+    srcs = ["fixtures/no-em-dash.yaml"],
 )
 
 # Fixture for the no-create-extension-sql rule (languages: generic, paths: **/migrations/*.sql).

--- a/bazel/semgrep/tests/fixtures/no-em-dash.yaml
+++ b/bazel/semgrep/tests/fixtures/no-em-dash.yaml
@@ -1,0 +1,10 @@
+# Tests for the no-em-dash semgrep rule.
+# ruleid: annotation means the next non-comment line MUST be flagged.
+# ok: annotation means the next non-comment line MUST NOT be flagged.
+---
+# ruleid: no-em-dash
+description: "Platform engineering — from ingress to eBPF"
+
+---
+# ok: no-em-dash
+description: "Platform engineering: from ingress to eBPF"

--- a/bazel/tools/hooks/check-em-dash.sh
+++ b/bazel/tools/hooks/check-em-dash.sh
@@ -29,8 +29,8 @@ if [[ -z "$NEW_CONTENT" ]]; then
 fi
 
 # Check for the em-dash character (U+2014, UTF-8: 0xE2 0x80 0x94)
-if echo "$NEW_CONTENT" | grep -qP '\x{2014}' 2>/dev/null || \
-   echo "$NEW_CONTENT" | grep -qF $'\xe2\x80\x94'; then
+if echo "$NEW_CONTENT" | grep -qP '\x{2014}' 2>/dev/null ||
+	echo "$NEW_CONTENT" | grep -qF $'\xe2\x80\x94'; then
 	FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
 	cat >&2 <<-'EOF'
 		WARNING: Em-dash (U+2014) found in content being written.

--- a/bazel/tools/hooks/check-em-dash.sh
+++ b/bazel/tools/hooks/check-em-dash.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+# PreToolUse hook: warn when content being written or edited contains an em-dash
+# (U+2014).
+#
+# The CLAUDE.md Writing Style section forbids em-dashes in new content. Use a
+# comma, colon, parentheses, or split the sentence instead.
+#
+# This hook is advisory only. It emits a WARNING on stderr and exits 0 so the
+# write/edit is not blocked.
+#
+# Input: JSON on stdin from Claude Code hook system
+# Exit 0: allow (warnings emitted on stderr, advisory only)
+# Exit 2: block (not used)
+
+set -euo pipefail
+
+INPUT=$(cat)
+
+# Get the content being written/edited
+TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty')
+if [[ "$TOOL_NAME" == "Edit" ]]; then
+	NEW_CONTENT=$(echo "$INPUT" | jq -r '.tool_input.new_string // empty')
+else
+	NEW_CONTENT=$(echo "$INPUT" | jq -r '.tool_input.content // empty')
+fi
+
+if [[ -z "$NEW_CONTENT" ]]; then
+	exit 0
+fi
+
+# Check for the em-dash character (U+2014, UTF-8: 0xE2 0x80 0x94)
+if echo "$NEW_CONTENT" | grep -qP '\x{2014}' 2>/dev/null || \
+   echo "$NEW_CONTENT" | grep -qF $'\xe2\x80\x94'; then
+	FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
+	cat >&2 <<-'EOF'
+		WARNING: Em-dash (U+2014) found in content being written.
+	EOF
+	cat >&2 <<-EOF
+		File: ${FILE_PATH:-<unknown>}
+	EOF
+	cat >&2 <<-'EOF'
+
+		The CLAUDE.md Writing Style guide forbids em-dashes in new content.
+		Replace each em-dash with a comma, colon, parentheses, or split the
+		sentence instead. For example:
+
+		  Before: "The service (complex) handles auth."
+		  Use:    comma, colon, or parentheses (see CLAUDE.md Writing Style).
+
+		This is advisory only. The write will proceed, but please revise the
+		content before committing.
+	EOF
+fi
+
+exit 0


### PR DESCRIPTION
## Summary

- Adds `bazel/semgrep/rules/generic/no-em-dash.yaml`: a generic-language semgrep rule that flags the em-dash character (U+2014) in `.js`, `.py`, `.go`, `.md`, `.svelte`, `.bzl`, and `.yaml` files. Excludes test fixtures and the OCaml golden file that legitimately contains an em-dash.
- Adds `bazel/semgrep/tests/fixtures/no-em-dash.yaml`: annotated fixture with one bad (flagged) and one ok (not flagged) example. Excluded from `yaml_fixtures` since it is a generic-rule fixture.
- Adds `bazel/tools/hooks/check-em-dash.sh`: advisory `PreToolUse` hook for `Write|Edit` that warns on stderr when written content contains U+2014. Exits 0 (non-blocking).
- Registers the hook in `.claude/settings.json` under the `Write|Edit` matcher.
- Wires the rule and fixture together in `bazel/semgrep/rules/BUILD` with a `no_em_dash_test` target.

## Test plan

- [ ] CI `no_em_dash_test` semgrep target passes (fixture annotation check: bad line flagged, ok line clean).
- [ ] `yaml_rules_test` continues to pass (fixture excluded from `yaml_fixtures`).
- [ ] `generic_rules_test` continues to pass (no change to `no_stale_repo_paths_fixtures`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)