### PR TITLE
feat(hooks): warn on editing generated DO-NOT-EDIT files

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -169,6 +169,11 @@
             "type": "command",
             "command": "$CLAUDE_PROJECT_DIR/bazel/tools/hooks/check-asyncio-mark-build-dep.sh",
             "timeout": 10
+          },
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/bazel/tools/hooks/check-generated-file-edit.sh",
+            "timeout": 10
           }
         ]
       }

--- a/bazel/tools/hooks/check-generated-file-edit.sh
+++ b/bazel/tools/hooks/check-generated-file-edit.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# PreToolUse hook for Write|Edit operations.
+# Warns when editing a file that contains a "DO NOT EDIT" header in its first 5 lines.
+#
+# Input: JSON on stdin from Claude Code hook system
+# Exit 0: always (advisory only, never blocks)
+
+set -euo pipefail
+
+INPUT=$(cat)
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
+
+# No file path — nothing to check
+if [[ -z "$FILE_PATH" ]]; then
+	exit 0
+fi
+
+# File does not exist yet (new file) — nothing to check
+if [[ ! -f "$FILE_PATH" ]]; then
+	exit 0
+fi
+
+# Read the first 5 lines and check for "DO NOT EDIT" (case-insensitive)
+if head -n 5 "$FILE_PATH" | grep -qi "do not edit"; then
+	cat >&2 <<-EOF
+		WARNING: This file appears to be generated (contains DO NOT EDIT header).
+		Edit the source spec or template instead, then regenerate.
+		If you must edit this file directly, proceed with caution.
+		File: $FILE_PATH
+	EOF
+fi
+
+exit 0


### PR DESCRIPTION
## Summary

- Adds `bazel/tools/hooks/check-generated-file-edit.sh`: a PreToolUse hook that reads the first 5 lines of a file before Write or Edit, and emits an advisory warning on stderr if any line contains DO NOT EDIT (case-insensitive).
- Registers the new hook in `.claude/settings.json` under the existing `Write|Edit` matcher.

## Behavior

- New file (does not exist yet): silently exits 0.
- Existing file without a DO-NOT-EDIT header: silently exits 0.
- Existing file with a DO-NOT-EDIT header: prints a warning on stderr and exits 0 (never blocks).

## Test plan

- [ ] CI passes (bazel test //...)
- [ ] Manually verify the hook fires when editing a generated file

🤖 Generated with [Claude Code](https://claude.com/claude-code)