### PR TITLE
fix(frontend): white fill for secondary CV buttons

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.94.1
+version: 0.94.2
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.94.1
+      targetRevision: 0.94.2
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/lib/public/styles/design-system.css
+++ b/projects/monolith/frontend/src/lib/public/styles/design-system.css
@@ -138,7 +138,10 @@ ul {
 }
 
 .btn-secondary {
-  background: transparent;
+  /* White fill, not transparent: on the cream page a transparent button
+     reads as "cream on cream" and disappears. Paper lifts it off the
+     background while keeping the flat-ink border language. */
+  background: var(--paper);
 }
 
 .btn:hover {


### PR DESCRIPTION
## What

Secondary CV contact buttons (`LINKEDIN`, `GITHUB`) used `background: transparent`, which on the cream page (`--cream` #f3ede1) rendered as "cream on cream" and made them visually disappear next to the blue primary email button.

Switch `.btn-secondary` to `var(--paper)` (white) so the buttons lift cleanly off the cream background while keeping the flat 2px ink border and hard-shadow hover language. White already anchors the cards in this design system, so it stays on-brand.

Bumps monolith chart `0.94.1` → `0.94.2` (Chart.yaml + application.yaml targetRevision in sync).

## Before / after

- Before: cream-filled secondary buttons blend into the cream page.
- After: white-filled secondary buttons read as distinct, bordered chips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)