### PR TITLE
fix(frontend): heading hover becomes a highlighter swipe

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.95.0
+version: 0.95.1
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.95.0
+      targetRevision: 0.95.1
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/routes/public/engineering/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/engineering/+page.svelte
@@ -487,17 +487,28 @@
   }
 
   /* The heading itself is the repo link. Plain until hover, then a
-     hard underline + the arrow nudges, so it reads as text first and a
-     link on intent. */
+     highlighter swipe wipes in behind the text and the arrow nudges, so
+     it reads as text first and a link on intent. The band is a
+     background (not a border), so it sits behind the glyphs and never
+     floats below the serif descenders the way the old underline did. */
   .title-link {
     color: inherit;
     text-decoration: none;
-    border-bottom: 2px solid transparent;
-    transition: border-color 140ms ease;
+    background-image: linear-gradient(var(--accent), var(--accent));
+    background-repeat: no-repeat;
+    background-position: 0 78%;
+    background-size: 0% 0.4em;
+    transition: background-size 220ms ease;
   }
 
   .title-link:hover {
-    border-bottom-color: var(--ink);
+    background-size: 100% 0.4em;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .title-link {
+      transition: none;
+    }
   }
 
   .title-arrow {


### PR DESCRIPTION
## What

On the engineering page, each deep-dive section heading links to its repo. On hover the link turned a `border-bottom` solid ink. Because these are large serif display headings, that border floated well below the descenders and read as a heavy flat bar clear of the text (see before).

This swaps it for a **highlighter swipe**: an accent-yellow band (`--accent`) that wipes in left-to-right behind the glyphs. The highlight is a `background-image` (not a border), so it sits *on* the text rather than under it, sidestepping the descender gap entirely. The arrow nudge is unchanged.

```css
.title-link {
  background-image: linear-gradient(var(--accent), var(--accent));
  background-repeat: no-repeat;
  background-position: 0 78%;
  background-size: 0% 0.4em;          /* collapsed until hover */
  transition: background-size 220ms ease;
}
.title-link:hover { background-size: 100% 0.4em; }   /* wipes to full width */
```

Honours `prefers-reduced-motion` (drops the transition).

## Chart

Bumped monolith chart `0.95.0` -> `0.95.1` (Chart.yaml + application.yaml targetRevision in sync) so the frontend change rolls out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)