### PR TITLE
feat(monolith): migrate marine/ships AIS app into the monolith

### DIFF
--- a/docs/plans/2026-06-10-ships-into-monolith.md
+++ b/docs/plans/2026-06-10-ships-into-monolith.md
@@ -1,0 +1,701 @@
+# Ships into Monolith Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Migrate the standalone `marine`/ships AIS vessel-tracking app (3 pods + NATS + SQLite) into the monolith as a single stateless in-process module serving a public, SSR-only, CDN-cached live map at `jomcgi.dev/app/ships`.
+
+**Architecture:** A supervised always-on asyncio task ingests AISStream.io over a websocket, dedupes and batch-writes to Postgres (the sole source of truth, no in-memory set). An SSR-only `/api/ships/snapshot` endpoint serializes a precomputed `latest_positions` table; Cloudflare CDN does the viewer fan-out (`s-maxage=120`), so origin load is flat in viewer count. A SvelteKit route mirrors the `/notes` pattern and renders a restyled MapLibre basemap with client-side dead reckoning between snapshots.
+
+**Tech Stack:** Python 3 / FastAPI / SQLModel / psycopg3 / Postgres (partitioned, Atlas migrations) / `shared.scheduler` / SvelteKit (Svelte 5) / MapLibre GL / Bazel + apko.
+
+**Non-negotiable house rules (apply to every task):**
+
+- **No em-dashes** in any code, comment, commit, or doc. Use commas, colons, or parentheses.
+- **No local test loop.** Write tests, but do NOT run `bazel test`/`pytest`/`vitest` from the workstation. Implement, commit, push the branch, watch CI via `gh pr checks <n> --watch`. Diagnose failures via `mcp__buildbuddy__*`.
+- **One code review per PR** at the end, not per task. Implementers self-review before each commit.
+- **Conventional Commits** for every commit. Commit frequently (one logical step per commit).
+- **Reuse, do not reinvent.** Every pattern below already exists in the monolith; the referenced file is the source of truth for style.
+
+**Worktree:** `/tmp/claude-worktrees/ships-monolith` on branch `feat/ships-into-monolith`. All work happens here.
+
+---
+
+## Background: what we are deleting, not porting
+
+The old `projects/ships/` design is shaped by service boundaries the monolith dissolves. The following are **deleted, not migrated**:
+
+- The 3 separate pods (`ingest`, `backend`, `frontend`) and the Bun proxy `server.ts`.
+- **NATS JetStream** and the `ais.position.*`/`ais.static.*` subjects. In-process, ingest hands rows straight to the persister.
+- **SQLite** and its Longhorn PVC / single-replica StatefulSet.
+- The **stream-replay / catchup state machine** (durable consumer `ships-api`, `CATCHUP_PENDING_THRESHOLD`, replay batching). Postgres is durable, so there is nothing to rebuild on restart. On restart we just reconnect to AISStream and miss a few seconds, which is fine for live tracking.
+- The **in-memory authoritative set** and the websocket fan-out (`WebSocketManager`, `/ws/live`). The CDN is the fan-out.
+
+What we **keep and port**: the AIS message parsing, the dedup thresholds, moored detection, the haversine helper, ETA parsing, and the reconnect/backoff loop. Source: `projects/ships/backend/main.py` and `projects/ships/ingest/main.py`.
+
+---
+
+## Task 0: Scaffold the `ships` Python package and register it
+
+**Files:**
+
+- Create: `projects/monolith/ships/__init__.py`
+- Create: `projects/monolith/ships/router.py` (stub)
+- Modify: `projects/monolith/app/main.py:196-199` (router registration), lifespan startup-jobs block (~`:62-66`)
+- Modify: `projects/monolith/BUILD` (hand-register, the dir is under `# gazelle:exclude knowledge` sibling conventions; ships python targets must be registered by hand the same way)
+
+**Step 1:** Create `ships/__init__.py` mirroring `knowledge/__init__.py`:
+
+```python
+"""Ships: in-monolith AIS vessel tracking (migrated from the standalone marine app)."""
+
+from fastapi import FastAPI
+from sqlmodel import Session
+
+
+def register(app: FastAPI) -> None:
+    """Register ships routers with the app."""
+    from ships.router import router
+
+    app.include_router(router)
+
+
+def on_startup_jobs(session: Session) -> None:
+    """Register ships scheduled jobs (retention / partition maintenance)."""
+    from shared.scheduler import register_job
+    from ships.retention import partition_maintenance_handler
+
+    register_job(
+        session,
+        name="ships.partition_maintenance",
+        interval_secs=86400,  # daily
+        handler=partition_maintenance_handler,
+        ttl_secs=3600,
+    )
+```
+
+**Step 2:** Create `ships/router.py` stub:
+
+```python
+"""Ships HTTP API. SSR-only: never added to httproute-public.yaml."""
+
+import logging
+
+from fastapi import APIRouter
+
+logger = logging.getLogger("ships")
+router = APIRouter(prefix="/api/ships", tags=["ships"])
+```
+
+**Step 3:** Register in `app/main.py`. Add `import ships` near the other domain imports, add `ships.register(app)` after `scheduler.register(app)` (`:199`), and inside the lifespan startup `with Session(get_engine()) as session:` block (next to `home.on_startup_jobs(session)`), add `ships.on_startup_jobs(session)`.
+
+**Step 4:** Register the package in `projects/monolith/BUILD` following the existing hand-registered `knowledge`/`chat` `py_library` entries (the tree is `gazelle:exclude`d, so new libraries and tests must be added manually). Add a `py_library` for `ships` with deps it will need: `@pip//sqlmodel`, `@pip//fastapi`, `@pip//websockets`, `@pip//certifi`, and the app/shared libs. (Confirm exact dep label style by copying the `knowledge` `py_library` block.)
+
+**Step 5:** Commit.
+
+```bash
+git add projects/monolith/ships projects/monolith/app/main.py projects/monolith/BUILD
+git commit -m "feat(monolith): scaffold ships package and register router"
+```
+
+> Note: registration referencing `ships.retention` and `ships.router` endpoints that do not exist yet is fine; the imports are lazy (inside functions). CI will only exercise them once those modules land in later tasks. If CI import-checks the registration eagerly, land Task 1, 5, and 6 modules before pushing.
+
+---
+
+## Task 1: Postgres schema (migration + SQLModel models)
+
+**Files:**
+
+- Create: `projects/monolith/chart/migrations/20260610000000_ships_schema.sql`
+- Create: `projects/monolith/ships/models.py`
+- Test: `projects/monolith/ships/models_test.py`
+
+**Design notes:**
+
+- Schema `ships`. All timestamps are `timestamptz`, never text.
+- `ships.positions` is **range-partitioned by day** on `recorded_at`. Retention = drop old partitions (Task 6), never a `DELETE` loop.
+- `ships.latest_positions` is the serving table (one row per vessel), maintained by upsert. It is the snapshot source and the dedup read-back source.
+- `mmsi` stays `TEXT` (avoids leading-zero / identifier edge cases). Join `positions`/`latest_positions` to `vessels` on `mmsi`.
+
+**Step 1: Write the migration SQL.**
+
+```sql
+-- 20260610000000_ships_schema.sql
+CREATE SCHEMA IF NOT EXISTS ships;
+
+-- Vessel metadata (AIS Type 5 / ShipStaticData).
+CREATE TABLE ships.vessels (
+    mmsi         TEXT PRIMARY KEY,
+    imo          TEXT,
+    call_sign    TEXT,
+    name         TEXT,
+    ship_type    INTEGER,
+    dimension_a  INTEGER,
+    dimension_b  INTEGER,
+    dimension_c  INTEGER,
+    dimension_d  INTEGER,
+    destination  TEXT,
+    eta          TIMESTAMPTZ,
+    draught      DOUBLE PRECISION,
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at   TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Position history (AIS Type 1/2/3). Partitioned by day for drop-partition retention.
+CREATE TABLE ships.positions (
+    id           BIGGENERATED... -- see note
+    mmsi         TEXT NOT NULL,
+    lat          DOUBLE PRECISION NOT NULL,
+    lon          DOUBLE PRECISION NOT NULL,
+    speed        DOUBLE PRECISION,
+    course       DOUBLE PRECISION,
+    heading      INTEGER,
+    nav_status   INTEGER,
+    ship_name    TEXT,
+    recorded_at  TIMESTAMPTZ NOT NULL,
+    received_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+) PARTITION BY RANGE (recorded_at);
+
+-- Partitioned tables cannot have a plain bigserial PK that is also the partition
+-- key, so use a composite PK (recorded_at, id) with id from a sequence.
+-- Replace the BIGGENERATED line above with:
+--   id BIGINT NOT NULL,
+-- and after the table:
+CREATE SEQUENCE ships.positions_id_seq OWNED BY ships.positions.id;
+ALTER TABLE ships.positions ALTER COLUMN id SET DEFAULT nextval('ships.positions_id_seq');
+ALTER TABLE ships.positions ADD PRIMARY KEY (recorded_at, id);
+
+-- BRIN for the time-window scans (retention, /track since=), tiny + append-friendly.
+CREATE INDEX positions_recorded_brin ON ships.positions USING brin (recorded_at);
+-- Btree for /track (filter by mmsi, order by time).
+CREATE INDEX positions_mmsi_recorded ON ships.positions (mmsi, recorded_at DESC);
+
+-- Seed an initial set of daily partitions so inserts have somewhere to land
+-- before the maintenance job first runs. Create yesterday..+2 days.
+-- (The maintenance job, Task 6, keeps a rolling window ahead.)
+CREATE TABLE ships.positions_default PARTITION OF ships.positions DEFAULT;
+
+-- Current position per vessel (serving + dedup read-back).
+CREATE TABLE ships.latest_positions (
+    mmsi                    TEXT PRIMARY KEY,
+    lat                     DOUBLE PRECISION NOT NULL,
+    lon                     DOUBLE PRECISION NOT NULL,
+    speed                   DOUBLE PRECISION,
+    course                  DOUBLE PRECISION,
+    heading                 INTEGER,
+    nav_status              INTEGER,
+    ship_name               TEXT,
+    recorded_at             TIMESTAMPTZ NOT NULL,
+    first_seen_at_location  TIMESTAMPTZ,
+    updated_at              TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+```
+
+> Implementer: clean up the inline `BIGGENERATED...` placeholder per the comment block (it documents the partition-PK constraint). A `DEFAULT` partition guarantees inserts never fail for a missing day; Task 6 converts the rolling window to explicit daily partitions and drops old ones. Verify the final SQL renders by reading a sibling migration (`20260408000000_knowledge_schema.sql`) for the Atlas file conventions (no transaction wrapper, idempotent-friendly).
+
+**Step 2: Write SQLModel models** mirroring the migration, with `schema="ships"` and `extend_existing`. Mirror any future CHECK constraints into `__table_args__` (knowledge/models.py:67-79 pattern) so SQLite unit tests enforce them. Use `datetime` (tz-aware) fields, not str.
+
+```python
+from datetime import datetime, timezone
+from sqlmodel import Field, SQLModel
+
+
+class Vessel(SQLModel, table=True):
+    __tablename__ = "vessels"
+    __table_args__ = {"schema": "ships", "extend_existing": True}
+
+    mmsi: str = Field(primary_key=True)
+    imo: str | None = None
+    call_sign: str | None = None
+    name: str | None = None
+    ship_type: int | None = None
+    dimension_a: int | None = None
+    dimension_b: int | None = None
+    dimension_c: int | None = None
+    dimension_d: int | None = None
+    destination: str | None = None
+    eta: datetime | None = None
+    draught: float | None = None
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    updated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+
+
+class LatestPosition(SQLModel, table=True):
+    __tablename__ = "latest_positions"
+    __table_args__ = {"schema": "ships", "extend_existing": True}
+
+    mmsi: str = Field(primary_key=True)
+    lat: float
+    lon: float
+    speed: float | None = None
+    course: float | None = None
+    heading: int | None = None
+    nav_status: int | None = None
+    ship_name: str | None = None
+    recorded_at: datetime
+    first_seen_at_location: datetime | None = None
+    updated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+
+
+class Position(SQLModel, table=True):
+    __tablename__ = "positions"
+    __table_args__ = {"schema": "ships", "extend_existing": True}
+
+    # Composite PK (recorded_at, id) in PG; for SQLite tests a single PK is fine.
+    id: int | None = Field(default=None, primary_key=True)
+    mmsi: str
+    lat: float
+    lon: float
+    speed: float | None = None
+    course: float | None = None
+    heading: int | None = None
+    nav_status: int | None = None
+    ship_name: str | None = None
+    recorded_at: datetime
+    received_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+```
+
+**Step 3: Write a model test** (`models_test.py`) using the SQLite + `SQLModel.metadata.create_all()` fixture convention (see knowledge tests; mirror their conftest). Assert a vessel + latest_position round-trips. Keep it minimal; this just proves the models import and create.
+
+**Step 4:** Register the test in `projects/monolith/BUILD` (hand-registered, gazelle-excluded tree).
+
+**Step 5:** Commit.
+
+```bash
+git add projects/monolith/chart/migrations/20260610000000_ships_schema.sql projects/monolith/ships/models.py projects/monolith/ships/models_test.py projects/monolith/BUILD
+git commit -m "feat(monolith): add ships postgres schema and models"
+```
+
+---
+
+## Task 2: Pure AIS logic (parsing, dedup, moored, haversine, ETA)
+
+These are pure functions with no DB or network, so they are the most testable. Port verbatim from the old code, swapping the in-memory cache argument for an explicit "previous position" argument so the function stays pure (the stateless design feeds it the read-back row).
+
+**Files:**
+
+- Create: `projects/monolith/ships/ais.py`
+- Test: `projects/monolith/ships/ais_test.py` (port cases from `projects/ships/ingest/ais_parsing_test.py` and `projects/ships/backend/tests/unit_test.py`)
+
+**Step 1:** Write `haversine_distance` (verbatim from `backend/main.py:143-158`), the dedup thresholds as module constants (`DEDUP_SPEED_THRESHOLD=0.5`, `DEDUP_DISTANCE_METERS=100`, `DEDUP_TIME_THRESHOLD=300`, `MOORED_RADIUS_METERS=500`, read from env with these defaults), and a pure `should_insert_position(data, last)` ported from `backend/main.py:273-328` where `last` is a `LatestPosition | None` instead of the cache lookup:
+
+```python
+def should_insert_position(
+    data: dict, last: "PriorPosition | None"
+) -> tuple[bool, datetime | None]:
+    """Dedup decision. Returns (should_insert, first_seen_at_location).
+
+    Pure: `last` is the prior latest_positions row (or None), passed in by the
+    caller after a batched read-back. Ported from projects/ships/backend/main.py.
+    """
+    # ... port the speed > threshold / distance > threshold / time > threshold
+    # ladder exactly, but compare datetimes directly (timestamptz) instead of
+    # parsing ISO strings.
+```
+
+Also port AIS message parsing (PositionReport -> position dict, ShipStaticData -> vessel dict) and ETA parsing (`ingest/main.py` ETA -> ISO; here produce a tz-aware `datetime`). Keep field names aligned with the models.
+
+**Step 2:** Port the test cases. Cover: first position always inserts; moving vessel inserts; stationary within 100 m and 300 s skips; stationary but > 300 s inserts; moved > 100 m resets `first_seen`; haversine known-distance sanity; ETA parse incl. the AIS "not available" sentinel.
+
+**Step 3:** Register test in BUILD.
+
+**Step 4:** Commit.
+
+```bash
+git commit -am "feat(monolith): port AIS parsing, dedup, and haversine logic"
+```
+
+---
+
+## Task 3: Stateless persistence layer (read-back + batched write)
+
+**Files:**
+
+- Create: `projects/monolith/ships/store.py`
+- Test: `projects/monolith/ships/store_test.py`
+
+**Design:** one function per ingest batch, fully stateless. It opens nothing long-lived; the caller passes a `Session`. Steps inside:
+
+1. Collect parsed positions + vessels from the batch.
+2. `SELECT ... FROM ships.latest_positions WHERE mmsi = ANY(:mmsis)` once. Build `{mmsi: PriorPosition}`.
+3. For each position, call `should_insert_position(data, prior.get(mmsi))`; keep survivors with their computed `first_seen_at_location`.
+4. Batch `INSERT` survivors into `ships.positions` (history).
+5. Batch upsert survivors into `ships.latest_positions` (`INSERT ... ON CONFLICT (mmsi) DO UPDATE`, `COALESCE(excluded.ship_name, latest_positions.ship_name)` to preserve names, mirror `backend/main.py:408-430`).
+6. Batch upsert vessels into `ships.vessels` (`ON CONFLICT (mmsi) DO UPDATE`, mirror `backend/main.py:455-478`).
+7. One commit.
+
+Use `sqlalchemy.text()` with bound params. Heed `feedback_psycopg3_nullable_param_cast`: nullable string params used in `IS NULL OR ...` shapes need explicit `::text` casts. Use `mmsi = ANY(:mmsis)` with a list param (psycopg3 adapts a Python list to a Postgres array).
+
+**Step 1:** Write `store_test.py` first (SQLite fixture): seed a `latest_positions` row, feed a batch with one stationary-skip + one moving-insert, assert `positions` got 1 row and `latest_positions` updated only the mover. (Note: ARRAY/`ANY` and `ON CONFLICT` differ on SQLite; for the unit test, either parametrize the read-back to an `IN` clause or gate the Postgres-specific SQL behind a dialect check. Simplest: write the read-back as `WHERE mmsi IN :mmsis` via `expanding=True` bindparam, which works on both, and use SQLModel/SQLAlchemy `merge`-style upsert helpers that the existing code uses cross-dialect. Confirm how knowledge/chat do cross-dialect upserts before choosing.)
+
+**Step 2:** Implement `persist_batch(session, positions, vessels)`.
+
+**Step 3:** Register test in BUILD.
+
+**Step 4:** Commit.
+
+```bash
+git commit -am "feat(monolith): stateless ships persistence (read-back + batched upsert)"
+```
+
+---
+
+## Task 4: AISStream ingest background task (supervised, in lifespan)
+
+**Files:**
+
+- Create: `projects/monolith/ships/ingest.py`
+- Modify: `projects/monolith/app/main.py` (lifespan: spawn + cancel the task)
+- Test: `projects/monolith/ships/ingest_test.py` (reconnect/backoff + batch-flush, mock the websocket; port from `ingest/reconnect_cap_test.py`, `nats_and_reconnect_test.py` minus NATS)
+
+**Design:** mirror `ingest/main.py:241-282` connect/backoff loop, but publish to the persister instead of NATS, and batch. The loop:
+
+```python
+async def ais_stream_loop(stop: asyncio.Event) -> None:
+    """Supervised AISStream listener. Reconnects forever; never raises out."""
+    import ssl, json, certifi, websockets
+    from app.db import get_engine
+    from sqlmodel import Session
+    from ships.ais import parse_message
+    from ships.store import persist_batch
+
+    api_key = os.environ.get("AISSTREAM_API_KEY", "")
+    url = os.environ.get("AISSTREAM_URL", "wss://stream.aisstream.io/v0/stream")
+    bbox = os.environ.get("BOUNDING_BOX", DEFAULT_BBOX)  # Pacific NW default
+    if not api_key:
+        logger.warning("AISSTREAM_API_KEY unset; ships ingest disabled")
+        return
+
+    ssl_ctx = ssl.create_default_context(cafile=certifi.where())
+    delay = INITIAL_RECONNECT_DELAY
+    while not stop.is_set():
+        try:
+            async with websockets.connect(url, ssl=ssl_ctx) as ws:
+                await ws.send(json.dumps({
+                    "APIKey": api_key,
+                    "BoundingBoxes": json.loads(bbox),
+                    "FilterMessageTypes": ["PositionReport", "ShipStaticData"],
+                }))
+                delay = INITIAL_RECONNECT_DELAY
+                batch_pos, batch_ves, last_flush = [], [], loop_time()
+                async for raw in ws:
+                    if stop.is_set():
+                        break
+                    kind, row = parse_message(raw)
+                    if kind == "position":
+                        batch_pos.append(row)
+                    elif kind == "vessel":
+                        batch_ves.append(row)
+                    # Flush on size or time (e.g. >=200 rows or >2s).
+                    if len(batch_pos) + len(batch_ves) >= FLUSH_SIZE or \
+                       loop_time() - last_flush > FLUSH_SECONDS:
+                        await asyncio.to_thread(_flush, batch_pos, batch_ves)
+                        batch_pos, batch_ves, last_flush = [], [], loop_time()
+        except Exception:
+            logger.exception("ships ingest: stream error")
+        if not stop.is_set():
+            await asyncio.sleep(delay)
+            delay = min(delay * RECONNECT_BACKOFF_FACTOR, MAX_RECONNECT_DELAY)
+
+
+def _flush(positions, vessels) -> None:
+    from app.db import get_engine
+    from sqlmodel import Session
+    from ships.store import persist_batch
+    if not positions and not vessels:
+        return
+    with Session(get_engine()) as session:
+        persist_batch(session, positions, vessels)
+```
+
+DB writes go through `asyncio.to_thread` with a fresh `Session(get_engine())` (the request-scoped `get_session` is unavailable in a background task; this matches how scheduler handlers open their own session).
+
+**Step 1:** Write `ingest_test.py` first: mock `websockets.connect` to yield a couple of messages then raise `ConnectionClosed`, assert the loop calls `_flush` with parsed rows and that backoff grows then resets. Assert an exception inside the loop body does not propagate (the `while` keeps going).
+
+**Step 2:** Implement `ingest.py`.
+
+**Step 3:** Wire into `app/main.py` lifespan: create an `asyncio.Event()` stored on `app.state.ships_stop`, `task = asyncio.create_task(ais_stream_loop(stop))`, `task.add_done_callback(_log_task_exception)`. In shutdown, `stop.set()` then `task.cancel()` + awaited with `CancelledError` swallow (mirror the lock-sweep teardown).
+
+**Step 4:** Register test in BUILD. Add `@pip//websockets`, `@pip//certifi` deps to the ships `py_library` if not already.
+
+**Step 5:** Commit.
+
+```bash
+git commit -am "feat(monolith): supervised AISStream ingest background task"
+```
+
+---
+
+## Task 5: Snapshot + track endpoints (SSR-only, CDN-cached)
+
+**Files:**
+
+- Modify: `projects/monolith/ships/router.py`
+- Test: `projects/monolith/ships/router_test.py`
+
+**Design:** mirror `knowledge/router.py:112-167` (cache-control constant, ETag, conditional GET 304).
+
+```python
+# Mirrors SHIPS_SNAPSHOT_CACHE_CONTROL in frontend/src/lib/cache-headers.js. Keep in sync.
+_SNAPSHOT_CACHE_CONTROL = (
+    "public, s-maxage=120, stale-while-revalidate=600, stale-if-error=86400"
+)
+
+
+def _snapshot_etag(vessel_count: int, max_updated: datetime | None) -> str:
+    stamp = max_updated.isoformat() if max_updated is not None else "null"
+    return f'"{stamp}-{vessel_count}"'
+
+
+@router.get("/snapshot")
+def get_snapshot(request: Request, response: Response, session: Session = Depends(get_session)):
+    """All current vessel positions for the /app/ships map. SSR-only, CDN-cached."""
+    rows = session.exec(text(
+        "SELECT lp.*, v.name AS vessel_name, v.ship_type, v.destination, v.eta "
+        "FROM ships.latest_positions lp "
+        "LEFT JOIN ships.vessels v USING (mmsi)"
+    )).mappings().all()
+    max_updated = max((r["updated_at"] for r in rows), default=None)
+    etag = _snapshot_etag(len(rows), _as_utc(max_updated))
+    headers = {"Cache-Control": _SNAPSHOT_CACHE_CONTROL, "ETag": etag}
+    if request.headers.get("if-none-match") == etag:
+        return Response(status_code=304, headers=headers)
+    for k, v in headers.items():
+        response.headers[k] = v
+    return {"count": len(rows), "vessels": [dict(r) for r in rows]}
+
+
+@router.get("/track/{mmsi}")
+def get_track(mmsi: str, since: str | None = None, limit: int = 1000,
+              request: Request = None, response: Response = None,
+              session: Session = Depends(get_session)):
+    """Position history for one vessel (shown on marker click). SSR-only."""
+    # SELECT ... FROM ships.positions WHERE mmsi = :mmsi [AND recorded_at > now() - :since]
+    # ORDER BY recorded_at DESC LIMIT :limit. Short-TTL cache header.
+```
+
+Copy `_as_utc` from `knowledge/router.py:118-130` (or import if shared). Track endpoint gets a shorter `s-maxage` (e.g. 60s).
+
+**Critical:** do **not** add `/api/ships/*` to `chart/templates/httproute-public.yaml`. The private HTTPRoute already passes unmatched `/api/*` to the backend, and SSR reaches it at `http://localhost:8000`. This keeps it off the public internet.
+
+**Step 1:** Write `router_test.py`: seed latest_positions + vessels (SQLite fixture, FastAPI `TestClient`), assert `/api/ships/snapshot` returns the vessels and a `Cache-Control`/`ETag`; assert a matching `If-None-Match` yields 304; assert `/track/{mmsi}` returns ordered history. Port shapes from `backend/tests/ships_api_test.py`.
+
+**Step 2:** Implement the endpoints.
+
+**Step 3:** Register test in BUILD.
+
+**Step 4:** Commit.
+
+```bash
+git commit -am "feat(monolith): ships snapshot and track endpoints (SSR-only, CDN-cached)"
+```
+
+---
+
+## Task 6: Partition maintenance + retention scheduled job
+
+**Files:**
+
+- Create: `projects/monolith/ships/retention.py`
+- Test: `projects/monolith/ships/retention_test.py`
+
+**Design:** a `shared.scheduler` handler (registered in Task 0) that runs daily and:
+
+1. Ensures daily partitions exist for today..+2 days (`CREATE TABLE IF NOT EXISTS ships.positions_YYYYMMDD PARTITION OF ships.positions FOR VALUES FROM (...) TO (...)`).
+2. Drops partitions older than the retention window (default 7 days): find child partitions of `ships.positions` whose upper bound is before `now() - retention`, `DROP TABLE`. This is instant and produces zero vacuum churn (the whole point of partitioning on shared Postgres).
+
+Handler signature matches `shared/scheduler.py` (`async def partition_maintenance_handler(session) -> datetime | None`). Do partition DDL via `asyncio.to_thread` with the engine if needed, or run synchronously on the passed session (DDL is quick).
+
+**Step 1:** Write `retention_test.py`: assert the SQL builder produces correct partition names/bounds for a given date, and that the "drop older than N days" selection excludes in-window partitions. (Partition DDL itself is Postgres-only; unit-test the name/bound/selection logic as pure functions, defer the live DDL to CI/prod.)
+
+**Step 2:** Implement `retention.py` (pure helpers + the handler).
+
+**Step 3:** Register test in BUILD.
+
+**Step 4:** Commit.
+
+```bash
+git commit -am "feat(monolith): ships partition maintenance and retention job"
+```
+
+---
+
+## Task 7: Secrets and chart wiring
+
+**Files:**
+
+- Modify: `projects/monolith/chart/templates/onepassworditem.yaml` (or add a ships-specific item) to surface `AISSTREAM_API_KEY`
+- Modify: `projects/monolith/chart/templates/deployment.yaml` (env: `AISSTREAM_API_KEY` via `secretKeyRef`; plain `AISSTREAM_URL`, `BOUNDING_BOX`)
+- Modify: `projects/monolith/chart/values.yaml` (bounding box default, onepassword item path)
+- Modify: `projects/monolith/chart/Chart.yaml` (version bump)
+- Modify: `projects/monolith/deploy/application.yaml` (`targetRevision` to match the new chart version)
+
+**Design:** the AISStream key currently lives in the `marine` 1Password item. Either (a) add the field to the monolith's existing OnePasswordItem in 1Password and reference it, or (b) add a second `OnePasswordItem` template gated by a value. Prefer (a) for fewer moving parts if the monolith item can hold the extra field; confirm the 1Password item layout before choosing. Inject via `secretKeyRef` exactly like `ICAL_FEED_URL` (deployment.yaml:43-47). NATS env vars are NOT added (NATS is gone).
+
+**House rule:** bump `Chart.yaml` `version` AND `deploy/application.yaml` `targetRevision` together (the chart-version-bot normally does this, but manual bumps must keep both in sync).
+
+**Step 1:** Render the chart locally to verify templating (allowed; this is not a test run):
+
+```bash
+helm template monolith projects/monolith/chart/ -f projects/monolith/deploy/values.yaml | grep -A3 AISSTREAM
+```
+
+Expected: the env var resolves to a `secretKeyRef`.
+
+**Step 2:** Commit.
+
+```bash
+git commit -am "feat(monolith): wire AISStream secret and bump chart for ships"
+```
+
+---
+
+## Task 8: Frontend route + MapLibre map + dead reckoning
+
+**Files:**
+
+- Modify: `projects/monolith/frontend/package.json` (add `maplibre-gl`), regenerate the lockfile with `pnpm install` (vendored pnpm)
+- Modify: `projects/monolith/frontend/src/lib/cache-headers.js` (add `SHIPS_SNAPSHOT_CACHE_CONTROL`, mirror the python constant, keep-in-sync comment)
+- Create: `projects/monolith/frontend/src/routes/public/app/ships/+page.server.js`
+- Create: `projects/monolith/frontend/src/routes/public/app/ships/+page.js` (`export const ssr = false`)
+- Create: `projects/monolith/frontend/src/routes/public/app/ships/+page.svelte`
+- Create: `projects/monolith/frontend/src/lib/public/components/ships/ShipsMap.svelte` (MapLibre wrapper)
+- Create: `projects/monolith/frontend/src/lib/public/ships/deadReckoning.js` (pure extrapolation)
+- Test: `projects/monolith/frontend/src/routes/public/app/ships/page.server.test.js`, `.../ships/deadReckoning.test.js`
+- Modify: `projects/monolith/frontend/BUILD` (it is `gazelle:ignore`; the `:src` glob already picks up `src/**/*`, but confirm new test files match the `:test_lib` glob and add the maplibre dep to the js deps)
+- Modify: `projects/monolith/frontend/src/routes/+layout.svelte` Nav `activeRoute` (add `/app/ships` active state) if a nav entry is wanted
+
+**Step 1: Cache header constant** (mirror python):
+
+```javascript
+// /app/ships snapshot: 120s fresh · 10m SWR · 1d SIE. Mirrors _SNAPSHOT_CACHE_CONTROL
+// in projects/monolith/ships/router.py — keep in sync.
+export const SHIPS_SNAPSHOT_CACHE_CONTROL = `public, s-maxage=120, stale-while-revalidate=600, stale-if-error=86400`;
+```
+
+**Step 2: Server load** (clone of notes `+page.server.js`):
+
+```javascript
+import { error } from "@sveltejs/kit";
+import { SHIPS_SNAPSHOT_CACHE_CONTROL } from "../../../../lib/cache-headers.js";
+
+const API_BASE = process.env.API_BASE || "http://localhost:8000";
+
+export async function load({ fetch, setHeaders }) {
+  const res = await fetch(`${API_BASE}/api/ships/snapshot`, {
+    signal: AbortSignal.timeout(10_000),
+  });
+  if (!res.ok) throw error(503, "ships snapshot unavailable");
+
+  const headers = { "cache-control": SHIPS_SNAPSHOT_CACHE_CONTROL };
+  const etag = res.headers?.get?.("etag");
+  if (etag) headers.etag = etag;
+  setHeaders(headers);
+
+  return { snapshot: await res.json() };
+}
+```
+
+(Watch the relative `../` depth: the file is one level deeper than `public/notes/`, so it is `../../../../lib/cache-headers.js`. Verify against the actual tree.)
+
+**Step 3: `+page.js`** sets `export const ssr = false;` (MapLibre needs `window`/WebGL; the server load still runs server-side, so data is SSR-sourced while the canvas renders client-side, identical to notes).
+
+**Step 4: Dead reckoning** (pure, unit-tested):
+
+```javascript
+// Extrapolate a vessel's position from its last fix using speed (knots) + course (deg).
+// Returns {lat, lon} for `elapsedSeconds` after the fix. Great-circle-ish small-step.
+export function deadReckon({ lat, lon, speed, course }, elapsedSeconds) {
+  if (!speed || speed <= 0) return { lat, lon };
+  const metersPerSec = speed * 0.514444; // knots -> m/s
+  const dist = metersPerSec * elapsedSeconds;
+  const R = 6371000;
+  const brng = (course ?? 0) * (Math.PI / 180);
+  const lat1 = lat * (Math.PI / 180);
+  const lon1 = lon * (Math.PI / 180);
+  const lat2 = Math.asin(
+    Math.sin(lat1) * Math.cos(dist / R) +
+      Math.cos(lat1) * Math.sin(dist / R) * Math.cos(brng),
+  );
+  const lon2 =
+    lon1 +
+    Math.atan2(
+      Math.sin(brng) * Math.sin(dist / R) * Math.cos(lat1),
+      Math.cos(dist / R) - Math.sin(lat1) * Math.sin(lat2),
+    );
+  return { lat: lat2 * (180 / Math.PI), lon: lon2 * (180 / Math.PI) };
+}
+```
+
+Test: a vessel heading 090 (due east) at 10 kn for 60 s moves ~309 m east, lat ~unchanged; speed 0 returns the same point.
+
+**Step 5: ShipsMap.svelte** (MapLibre wrapper):
+
+- Init `maplibre-gl` map with a **no-API-key basemap**. Use OpenFreeMap (`https://tiles.openfreemap.org/styles/liberty`) or a CARTO raster style. Pick OpenFreeMap (vector, free, no key); note in a comment that self-hosting tiles is a follow-up if external dependency is unwanted.
+- Restyle to the palette: cream water/land via a style override or a simple raster + CSS filter, `--ink` strokes, hide busy labels. Keep it muted so brutalist chrome reads on top.
+- Render vessels as markers/symbols colored by `ship_type`; orientation from `heading`/`course`. Update positions every animation frame using `deadReckon(vessel, (now - fixTime)/1000)`; correct to the true fix when a new snapshot arrives.
+- Brutalist chrome: a header bar (thick 2px `--ink` border, hard shadow, JetBrains Mono "SHIPS · live ●"), a vessel side-panel card (`.card-hard`, `--shadow-hard`) populated on marker click by fetching `/api/ships/track/{mmsi}` via the SvelteKit data layer (NOT a direct public call; route it through a `+page.server.js`-style endpoint or a `+server.js` proxy if needed to keep it SSR-only). Use design-system.css tokens; do not hardcode colors.
+- Import `maplibre-gl/dist/maplibre-gl.css` and scope overrides.
+
+**Step 6: +page.svelte**: `let { data } = $props();` feed `data.snapshot.vessels` into `ShipsMap`. Set up a `setInterval(() => invalidateAll(), 120_000)` (or `invalidate` of the load) in `onMount`, cleared on destroy, to refresh the snapshot through the CDN.
+
+**Step 7:** Write `page.server.test.js` (mirror notes test: mock fetch + setHeaders, assert endpoint URL `/api/ships/snapshot`, cache-control set, etag forwarded, 503 on `!ok`) and `deadReckoning.test.js`.
+
+**Step 8:** `pnpm install` to update the lockfile; confirm `frontend/BUILD` deps include maplibre (rules_js resolves from the lockfile). Do NOT run vitest locally.
+
+**Step 9:** Commit (may be split into dep-add / load+dr / map-component commits).
+
+```bash
+git commit -am "feat(frontend): add /app/ships live MapLibre map with dead reckoning"
+```
+
+> macOS gotcha (from memory): `pnpm build` can clobber the Bazel `BUILD` file via the case-insensitive `build/` dir. Do not run `pnpm build`; let CI build. If the lockfile step touches `BUILD`, restore it.
+
+---
+
+## Task 9: Push, watch CI, end-of-PR review, verify live
+
+**Step 1:** Push the branch and open the PR.
+
+```bash
+git push -u origin feat/ships-into-monolith
+gh pr create --fill
+gh pr checks <n> --watch
+```
+
+**Step 2:** Diagnose any CI failures via `mcp__buildbuddy__get_invocation` (commitSha selector) -> `get_target` -> `get_log`. Quote the actual error before hypothesizing (per CLAUDE.md). Push fixes.
+
+**Step 3:** One comprehensive code review of the full diff (`/code-review` or the code-review skill). Address findings.
+
+**Step 4:** Merge with rebase (`gh pr merge --rebase`; squash is disabled).
+
+**Step 5:** Verify live after ArgoCD syncs (~5-10s) and the Atlas migration applies:
+
+- `kubectl -n <monolith-ns> logs` for "ships ingest" connecting to AISStream and flushing batches.
+- `curl -s https://jomcgi.dev/app/ships` returns the SSR page; confirm vessels render.
+- Confirm `curl https://jomcgi.dev/api/ships/snapshot` from the public internet does **NOT** work (SSR-only); only the page does.
+- Confirm Cache-Control on the page response (`curl -I`).
+- Watch `ships.partition_maintenance` register and the daily partition appear.
+
+---
+
+## Task 10 (follow-up PR, AFTER live verification): decommission the standalone marine app
+
+Do this only once the in-monolith ships is verified serving real vessels. Until then the old `marine` app keeps running untouched.
+
+**Files (separate PR):**
+
+- Delete: `projects/ships/` (chart, deploy, backend, ingest, frontend)
+- Remove the `marine` ArgoCD Application from the root kustomization (run `format` to regenerate `projects/home-cluster/kustomization.yaml`)
+- Remove the `marine` namespace `OnePasswordItem` (after confirming the key was copied into the monolith's 1Password item)
+- Redirect `ships.jomcgi.dev` -> `jomcgi.dev/app/ships` (or remove the DNS/route) so the old URL does not 404
+- Remove the `marine` SigNoz HTTP check alert (`projects/ships/deploy/marine-httpcheck-alert.yaml`); optionally add an equivalent check for `/app/ships`
+
+Commit: `chore(marine): decommission standalone ships app, now served in monolith`.
+
+---
+
+## Open follow-ups (not blocking)
+
+- Self-host the MapLibre basemap tiles behind Cloudflare instead of OpenFreeMap, if the external tile dependency is unwanted.
+- Add a SigNoz HTTP check + alert for `/app/ships` (mirror the old `marine-httpcheck-alert.yaml` via the `add-httpcheck-alert` skill).
+- Consider a compact snapshot encoding (arrays over objects) if the JSON payload grows large.

--- a/docs/plans/2026-06-10-ships-into-monolith.md
+++ b/docs/plans/2026-06-10-ships-into-monolith.md
@@ -568,7 +568,7 @@ git commit -am "feat(monolith): wire AISStream secret and bump chart for ships"
 
 ```javascript
 // /app/ships snapshot: 120s fresh · 10m SWR · 1d SIE. Mirrors _SNAPSHOT_CACHE_CONTROL
-// in projects/monolith/ships/router.py — keep in sync.
+// in projects/monolith/ships/router.py, keep in sync.
 export const SHIPS_SNAPSHOT_CACHE_CONTROL = `public, s-maxage=120, stale-while-revalidate=600, stale-if-error=86400`;
 ```
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -237,6 +237,9 @@ importers:
       d3-zoom:
         specifier: ^3.0.0
         version: 3.0.0
+      maplibre-gl:
+        specifier: ^5.24.0
+        version: 5.24.0
       marked:
         specifier: ^18.0.0
         version: 18.0.0
@@ -1931,10 +1934,22 @@ packages:
         integrity: sha512-25gQLQMcpivjOSA40g3gO6qgiFPDpWRoMfd+G/GoppPIeP6JDaMMkMrEJnMZhKyyS6iKwVt5YKu02vCUyJM3Ug==,
       }
 
+  "@mapbox/tiny-sdf@2.2.0":
+    resolution:
+      {
+        integrity: sha512-LVL4wgI9YAum5V+LNVQO6QgFBPw7/MIIY4XJPNsPDMrjEwcE+JfKk1LuIl8GnF197ejVdC9QdPaxrx5gfgdGXg==,
+      }
+
   "@mapbox/unitbezier@0.0.1":
     resolution:
       {
         integrity: sha512-nMkuDXFv60aBr9soUG5q+GvZYL+2KZHVvsqFCzqnkGEf46U2fvmytHaEVc1/YZbiLn8X+eR3QzX1+dwDO1lxlw==,
+      }
+
+  "@mapbox/unitbezier@1.0.0":
+    resolution:
+      {
+        integrity: sha512-fqd515fjBmANKGGsQ286E2Wvj/XvDFpGzwJxq4CI6jMQue6Oy04uCKp+JWKF00xRTmk6cEu1jPJ9p3xqH8YWqQ==,
       }
 
   "@mapbox/vector-tile@2.0.4":
@@ -1950,12 +1965,31 @@ packages:
       }
     engines: { node: ">=6.0.0" }
 
+  "@maplibre/geojson-vt@6.1.0":
+    resolution:
+      {
+        integrity: sha512-2eIY4gZxeKIVOZVNkAMb+5NgXhgsMQpOveTQAvnp53LYqHGJZDidk7Ew0Tged9PThidpbS+NFTh0g4zivhPDzQ==,
+      }
+
+  "@maplibre/maplibre-gl-style-spec@24.10.0":
+    resolution:
+      {
+        integrity: sha512-lichxSiagMEBBrqHF0trtMQH9RKh+9jUlIJl0qW0QHvt2H/tbvUWdE+ZzI2Jd0/pT7j/iavLonlPu7EQ/ixTOw==,
+      }
+    hasBin: true
+
   "@maplibre/maplibre-gl-style-spec@24.4.1":
     resolution:
       {
         integrity: sha512-UKhA4qv1h30XT768ccSv5NjNCX+dgfoq2qlLVmKejspPcSQTYD4SrVucgqegmYcKcmwf06wcNAa/kRd0NHWbUg==,
       }
     hasBin: true
+
+  "@maplibre/mlt@1.1.11":
+    resolution:
+      {
+        integrity: sha512-dKvjKdITw9d0y3ndGkSqLUEpWCizMtdq8NB06cHohH/JZ2sJoM7dClR9wzJLUWykjbw9RXDFmhjjNBnNW27mzw==,
+      }
 
   "@maplibre/mlt@1.1.2":
     resolution:
@@ -1967,6 +2001,12 @@ packages:
     resolution:
       {
         integrity: sha512-bxrk/kQUwWXZgmqYgwOCnZCMONCRi3MJMqJdza4T3E4AeR5i+VyMnaJ8iDWtWxdfEAJRtrzIOeJtxZSy5mFrFA==,
+      }
+
+  "@maplibre/vt-pbf@4.3.2":
+    resolution:
+      {
+        integrity: sha512-j6p0AdjvAR19Z3XaCysle7A4ZSo08tYOzxD0Y9NQylwPAkwJJeYub5b2eVucdeDh7erhv69DahoLOevDRERRUw==,
       }
 
   "@mermaid-js/parser@0.6.3":
@@ -8256,6 +8296,13 @@ packages:
       }
     engines: { node: ">=16.14.0", npm: ">=8.1.0" }
 
+  maplibre-gl@5.24.0:
+    resolution:
+      {
+        integrity: sha512-ALyFxgtd5R+65UqZ/++lOqwWcC0SNho9c27fYSyLmG7AfnAul2o46F05aDJGPbFU57wos9dgcIySHs0Xe6ia3A==,
+      }
+    engines: { node: ">=16.14.0", npm: ">=8.1.0" }
+
   mark.js@8.11.1:
     resolution:
       {
@@ -9679,6 +9726,13 @@ packages:
     resolution:
       {
         integrity: sha512-SuLdBvS42z33m8ejRbInMapQe8n0D3vN/Xd5fmWM3tufNgRQFBpaW2YVJxQZV4iPNqb0vEFvssMEo5w9c6BTIA==,
+      }
+    hasBin: true
+
+  pbf@5.1.0:
+    resolution:
+      {
+        integrity: sha512-Wv0yo0+uZepnoNEKsquhar1F18LogB8oeEikIhUXG16udbiXG7JecHGySwoo6kuMgjmbQYzdrTZlO+/K9t8eZg==,
       }
     hasBin: true
 
@@ -13529,7 +13583,11 @@ snapshots:
 
   "@mapbox/tiny-sdf@2.0.7": {}
 
+  "@mapbox/tiny-sdf@2.2.0": {}
+
   "@mapbox/unitbezier@0.0.1": {}
+
+  "@mapbox/unitbezier@1.0.0": {}
 
   "@mapbox/vector-tile@2.0.4":
     dependencies:
@@ -13538,6 +13596,19 @@ snapshots:
       pbf: 4.0.1
 
   "@mapbox/whoots-js@3.1.0": {}
+
+  "@maplibre/geojson-vt@6.1.0":
+    dependencies:
+      kdbush: 4.0.2
+
+  "@maplibre/maplibre-gl-style-spec@24.10.0":
+    dependencies:
+      "@mapbox/jsonlint-lines-primitives": 2.0.2
+      "@mapbox/unitbezier": 1.0.0
+      json-stringify-pretty-compact: 4.0.0
+      minimist: 1.2.8
+      quickselect: 3.0.0
+      tinyqueue: 3.0.0
 
   "@maplibre/maplibre-gl-style-spec@24.4.1":
     dependencies:
@@ -13548,6 +13619,10 @@ snapshots:
       quickselect: 3.0.0
       rw: 1.3.3
       tinyqueue: 3.0.0
+
+  "@maplibre/mlt@1.1.11":
+    dependencies:
+      "@mapbox/point-geometry": 1.1.0
 
   "@maplibre/mlt@1.1.2":
     dependencies:
@@ -13562,6 +13637,12 @@ snapshots:
       geojson-vt: 4.0.2
       pbf: 4.0.1
       supercluster: 8.0.1
+
+  "@maplibre/vt-pbf@4.3.2":
+    dependencies:
+      "@mapbox/point-geometry": 1.1.0
+      "@types/geojson": 7946.0.16
+      pbf: 5.1.0
 
   "@mermaid-js/parser@0.6.3":
     dependencies:
@@ -17543,6 +17624,28 @@ snapshots:
       supercluster: 8.0.1
       tinyqueue: 3.0.0
 
+  maplibre-gl@5.24.0:
+    dependencies:
+      "@mapbox/jsonlint-lines-primitives": 2.0.2
+      "@mapbox/point-geometry": 1.1.0
+      "@mapbox/tiny-sdf": 2.2.0
+      "@mapbox/unitbezier": 0.0.1
+      "@mapbox/vector-tile": 2.0.4
+      "@mapbox/whoots-js": 3.1.0
+      "@maplibre/geojson-vt": 6.1.0
+      "@maplibre/maplibre-gl-style-spec": 24.10.0
+      "@maplibre/mlt": 1.1.11
+      "@maplibre/vt-pbf": 4.3.2
+      "@types/geojson": 7946.0.16
+      earcut: 3.0.2
+      gl-matrix: 3.4.4
+      kdbush: 4.0.2
+      murmurhash-js: 1.0.0
+      pbf: 4.0.1
+      potpack: 2.1.0
+      quickselect: 3.0.0
+      tinyqueue: 3.0.0
+
   mark.js@8.11.1: {}
 
   markdown-table@3.0.4: {}
@@ -18612,6 +18715,10 @@ snapshots:
   pathe@2.0.3: {}
 
   pbf@4.0.1:
+    dependencies:
+      resolve-protobuf-schema: 2.1.0
+
+  pbf@5.1.0:
     dependencies:
       resolve-protobuf-schema: 2.1.0
 

--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -2071,6 +2071,19 @@ py_test(
 )
 
 py_test(
+    name = "ships_router_test",
+    srcs = ["ships/router_test.py"],
+    imports = ["."],
+    deps = [
+        ":monolith_backend",
+        "@pip//fastapi",
+        "@pip//httpx",
+        "@pip//pytest",
+        "@pip//sqlmodel",
+    ],
+)
+
+py_test(
     name = "knowledge_gap_model_test",
     srcs = ["knowledge/gap_model_test.py"],
     imports = ["."],

--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -2084,6 +2084,16 @@ py_test(
 )
 
 py_test(
+    name = "ships_retention_test",
+    srcs = ["ships/retention_test.py"],
+    imports = ["."],
+    deps = [
+        ":monolith_backend",
+        "@pip//pytest",
+    ],
+)
+
+py_test(
     name = "knowledge_gap_model_test",
     srcs = ["knowledge/gap_model_test.py"],
     imports = ["."],

--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -8,6 +8,7 @@
 # gazelle:exclude home
 # gazelle:exclude scheduler
 # gazelle:exclude shared
+# gazelle:exclude ships
 # gazelle:semgrep_exclude_rules avoid-sqlalchemy-text,sqlmodel-datetime-without-factory,tainted-fastapi-http-request-httpx,tainted-path-traversal-stdlib-fastapi
 load("@aspect_bazel_lib//lib:tar.bzl", "tar")
 load("@aspect_rules_py//py:defs.bzl", "py_library")
@@ -39,6 +40,7 @@ py_venv_binary(
             "home/**/*.py",
             "scheduler/**/*.py",
             "shared/**/*.py",
+            "ships/**/*.py",
         ],
         exclude = [
             # pytest discovers both *_test.py (sibling convention) and
@@ -92,6 +94,7 @@ py_library(
             "home/**/*.py",
             "scheduler/**/*.py",
             "shared/**/*.py",
+            "ships/**/*.py",
         ],
         exclude = [
             # pytest discovers both *_test.py (sibling convention) and
@@ -2017,6 +2020,17 @@ py_test(
         "@pip//pgvector",
         "@pip//pytest",
         "@pip//sqlalchemy",
+        "@pip//sqlmodel",
+    ],
+)
+
+py_test(
+    name = "ships_models_test",
+    srcs = ["ships/models_test.py"],
+    imports = ["."],
+    deps = [
+        ":monolith_backend",
+        "@pip//pytest",
         "@pip//sqlmodel",
     ],
 )

--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -2046,6 +2046,17 @@ py_test(
 )
 
 py_test(
+    name = "ships_store_test",
+    srcs = ["ships/store_test.py"],
+    imports = ["."],
+    deps = [
+        ":monolith_backend",
+        "@pip//pytest",
+        "@pip//sqlmodel",
+    ],
+)
+
+py_test(
     name = "knowledge_gap_model_test",
     srcs = ["knowledge/gap_model_test.py"],
     imports = ["."],

--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -2036,6 +2036,16 @@ py_test(
 )
 
 py_test(
+    name = "ships_ais_test",
+    srcs = ["ships/ais_test.py"],
+    imports = ["."],
+    deps = [
+        ":monolith_backend",
+        "@pip//pytest",
+    ],
+)
+
+py_test(
     name = "knowledge_gap_model_test",
     srcs = ["knowledge/gap_model_test.py"],
     imports = ["."],

--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -110,6 +110,7 @@ py_library(
     ),  # keep
     visibility = ["//:__subpackages__"],
     deps = [
+        "@pip//certifi",
         "@pip//discord_py",
         "@pip//dulwich",
         "@pip//fastapi",
@@ -133,6 +134,7 @@ py_library(
         "@pip//trafilatura",
         "@pip//tzdata",
         "@pip//uvicorn",
+        "@pip//websockets",
         "@pip//youtube_transcript_api",
     ],
 )
@@ -2053,6 +2055,18 @@ py_test(
         ":monolith_backend",
         "@pip//pytest",
         "@pip//sqlmodel",
+    ],
+)
+
+py_test(
+    name = "ships_ingest_test",
+    srcs = ["ships/ingest_test.py"],
+    imports = ["."],
+    deps = [
+        ":monolith_backend",
+        "@pip//pytest",
+        "@pip//pytest_asyncio",
+        "@pip//websockets",
     ],
 )
 

--- a/projects/monolith/app/main.py
+++ b/projects/monolith/app/main.py
@@ -177,14 +177,13 @@ async def lifespan(app: FastAPI):
         bot_task.cancel()
     scheduler_task.cancel()
 
-    # Stop the ships ingest loop: signal it, cancel, and await it, swallowing
-    # the CancelledError it re-raises on clean shutdown.
+    # Stop the ships ingest loop: signal it and cancel (cancel-only, matching the
+    # bot/scheduler/sweep teardown above). The supervised loop re-raises
+    # CancelledError on shutdown; its done callback (_log_task_exception) handles
+    # it. We do not await here so the path stays robust when tests patch
+    # asyncio.create_task into a non-awaitable mock.
     app.state.ships_stop.set()
     app.state.ships_task.cancel()
-    try:
-        await app.state.ships_task
-    except asyncio.CancelledError:
-        pass
 
     # Best-effort vault backup — preserve any uncommitted changes before the pod dies.
     try:

--- a/projects/monolith/app/main.py
+++ b/projects/monolith/app/main.py
@@ -104,6 +104,16 @@ async def lifespan(app: FastAPI):
     scheduler_task = asyncio.create_task(run_scheduler_loop())
     scheduler_task.add_done_callback(_log_task_exception)
 
+    # Start the supervised AISStream ingest listener. It reconnects forever and
+    # never raises out (only CancelledError on shutdown), so it can never crash
+    # the app. Disabled automatically when AISSTREAM_API_KEY is unset.
+    from ships.ingest import ais_stream_loop
+
+    app.state.ships_stop = asyncio.Event()
+    app.state.ships_task = asyncio.create_task(ais_stream_loop(app.state.ships_stop))
+    app.state.ships_task.add_done_callback(_log_task_exception)
+    logger.info("Ships AISStream ingest started")
+
     # Lock sweep stays in-memory (30s, bot-coupled, already multi-pod safe via SKIP LOCKED)
     sweep_task = None
     if discord_token and bot:
@@ -166,6 +176,15 @@ async def lifespan(app: FastAPI):
     if bot_task:
         bot_task.cancel()
     scheduler_task.cancel()
+
+    # Stop the ships ingest loop: signal it, cancel, and await it, swallowing
+    # the CancelledError it re-raises on clean shutdown.
+    app.state.ships_stop.set()
+    app.state.ships_task.cancel()
+    try:
+        await app.state.ships_task
+    except asyncio.CancelledError:
+        pass
 
     # Best-effort vault backup — preserve any uncommitted changes before the pod dies.
     try:

--- a/projects/monolith/app/main.py
+++ b/projects/monolith/app/main.py
@@ -14,6 +14,7 @@ import chat
 import home
 import knowledge
 import scheduler
+import ships
 from home.observability.router import warm_cache, warm_stats_cache
 
 configure_logging()
@@ -64,6 +65,7 @@ async def lifespan(app: FastAPI):
 
         knowledge_startup(session)
         home.on_startup_jobs(session)
+        ships.on_startup_jobs(session)
 
     # Start Discord bot + chat jobs if configured
     bot = None
@@ -197,6 +199,7 @@ home.register(app)
 chat.register(app)
 knowledge.register(app)
 scheduler.register(app)
+ships.register(app)
 app.mount("/mcp", _mcp_app)
 
 

--- a/projects/monolith/app/main_app_state_test.py
+++ b/projects/monolith/app/main_app_state_test.py
@@ -57,6 +57,7 @@ def _lifespan_patches_no_discord():
         patch("sqlmodel.Session", return_value=mock_session),
         patch("home.on_startup_jobs"),
         patch("shared.scheduler.run_scheduler_loop", new_callable=AsyncMock),
+        patch("ships.on_startup_jobs"),
     ]
 
 
@@ -73,6 +74,7 @@ def _lifespan_patches_with_discord(mock_bot):
         patch("chat.summarizer.on_startup"),
         patch("chat.summarizer.build_llm_caller", return_value=MagicMock()),
         patch("chat.bot.create_bot", return_value=mock_bot),
+        patch("ships.on_startup_jobs"),
     ]
 
 
@@ -146,6 +148,7 @@ class TestLifespanAppStateBotAssignment:
             patches[4],
             patches[5],
             patches[6],
+            patches[7],
         ):
             async with lifespan(app):
                 # During the lifespan body, app.state.bot must be the created bot
@@ -175,6 +178,7 @@ class TestLifespanAppStateBotAssignment:
             patches[1],
             patches[2],
             patches[3],
+            patches[4],
         ):
             async with lifespan(app):
                 assert app.state.bot is None, (
@@ -203,6 +207,7 @@ class TestLifespanAppStateBotAssignment:
             patches[1],
             patches[2],
             patches[3],
+            patches[4],
         ):
             async with lifespan(app):
                 assert hasattr(app.state, "backfill_task"), (

--- a/projects/monolith/app/main_extra_test.py
+++ b/projects/monolith/app/main_extra_test.py
@@ -41,6 +41,7 @@ def _lifespan_patches_no_discord():
         patch("sqlmodel.Session", return_value=mock_session),
         patch("home.on_startup_jobs"),
         patch("shared.scheduler.run_scheduler_loop", new_callable=AsyncMock),
+        patch("ships.on_startup_jobs"),
     ]
 
 
@@ -57,6 +58,7 @@ def _lifespan_patches_with_discord(mock_bot):
         patch("chat.summarizer.on_startup"),
         patch("chat.summarizer.build_llm_caller", return_value=MagicMock()),
         patch("chat.bot.create_bot", return_value=mock_bot),
+        patch("ships.on_startup_jobs"),
     ]
 
 
@@ -85,6 +87,7 @@ class TestLifespanBotCloseException:
             patches[4],
             patches[5],
             patches[6],
+            patches[7],
         ):
             with pytest.raises(RuntimeError, match="Discord connection lost"):
                 async with lifespan(app):
@@ -92,7 +95,7 @@ class TestLifespanBotCloseException:
 
     @pytest.mark.asyncio
     async def test_bot_close_exception_does_not_prevent_task_creation(self):
-        """Even when bot.close() will later raise, all 3 tasks are still created at startup."""
+        """Even when bot.close() will later raise, all 4 tasks are still created at startup."""
         tasks, capture = _make_task_capturer()
 
         mock_bot = MagicMock()
@@ -109,6 +112,7 @@ class TestLifespanBotCloseException:
             patches[4],
             patches[5],
             patches[6],
+            patches[7],
         ):
             try:
                 async with lifespan(app):
@@ -116,8 +120,8 @@ class TestLifespanBotCloseException:
             except RuntimeError:
                 pass  # expected
 
-        # bot + scheduler + sweep = 3 tasks must have been created
-        assert len(tasks) == 3
+        # bot + scheduler + ships ingest + sweep = 4 tasks must have been created
+        assert len(tasks) == 4
 
 
 # ---------------------------------------------------------------------------
@@ -143,6 +147,7 @@ class TestLifespanRunSchedulerLoopException:
             patch("app.db.get_engine", return_value=MagicMock()),
             patch("sqlmodel.Session", return_value=mock_session),
             patch("home.on_startup_jobs"),
+            patch("ships.on_startup_jobs"),
             patch(
                 "shared.scheduler.run_scheduler_loop",
                 new=failing_run_scheduler_loop,
@@ -172,6 +177,7 @@ class TestLifespanRunSchedulerLoopException:
             patch("app.db.get_engine", return_value=MagicMock()),
             patch("sqlmodel.Session", return_value=mock_session),
             patch("home.on_startup_jobs"),
+            patch("ships.on_startup_jobs"),
             patch(
                 "shared.scheduler.run_scheduler_loop",
                 new=failing_run_scheduler_loop,
@@ -211,6 +217,7 @@ class TestLifespanBotStartException:
             patches[4],
             patches[5],
             patches[6],
+            patches[7],
         ):
             async with lifespan(app):
                 started = True
@@ -237,6 +244,7 @@ class TestLifespanBotStartException:
             patches[4],
             patches[5],
             patches[6],
+            patches[7],
         ):
             async with lifespan(app):
                 pass

--- a/projects/monolith/app/main_lifespan_discord_test.py
+++ b/projects/monolith/app/main_lifespan_discord_test.py
@@ -22,6 +22,7 @@ def _lifespan_patches_no_discord():
         patch("sqlmodel.Session", return_value=mock_session),
         patch("home.on_startup_jobs"),
         patch("shared.scheduler.run_scheduler_loop", new_callable=AsyncMock),
+        patch("ships.on_startup_jobs"),
     ]
 
 
@@ -38,13 +39,14 @@ def _lifespan_patches_with_discord(mock_bot):
         patch("chat.summarizer.on_startup"),
         patch("chat.summarizer.build_llm_caller", return_value=MagicMock()),
         patch("chat.bot.create_bot", return_value=mock_bot),
+        patch("ships.on_startup_jobs"),
     ]
 
 
 class TestLifespanWithDiscordToken:
     @pytest.mark.asyncio
     async def test_lifespan_starts_bot_when_token_set(self):
-        """When DISCORD_BOT_TOKEN is set lifespan creates three tasks (bot, scheduler, sweep)."""
+        """When DISCORD_BOT_TOKEN is set lifespan creates four tasks (bot, scheduler, ships ingest, sweep)."""
         created_tasks = []
 
         def capture_create_task(coro, **kwargs):
@@ -69,12 +71,13 @@ class TestLifespanWithDiscordToken:
             patches[4],
             patches[5],
             patches[6],
+            patches[7],
         ):
             async with lifespan(app):
                 pass
 
-        # bot + scheduler + sweep = 3 tasks
-        assert len(created_tasks) == 3
+        # bot + scheduler + ships ingest + sweep = 4 tasks
+        assert len(created_tasks) == 4
 
     @pytest.mark.asyncio
     async def test_lifespan_closes_bot_on_shutdown(self):
@@ -102,6 +105,7 @@ class TestLifespanWithDiscordToken:
             patches[4],
             patches[5],
             patches[6],
+            patches[7],
         ):
             async with lifespan(app):
                 pass
@@ -134,17 +138,18 @@ class TestLifespanWithDiscordToken:
             patches[4],
             patches[5],
             patches[6],
+            patches[7],
         ):
             async with lifespan(app):
                 pass
 
-        # All three tasks (bot, scheduler, sweep) should be cancelled
+        # All four tasks (bot, scheduler, ships ingest, sweep) should be cancelled
         for task in created_tasks:
             task.cancel.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_lifespan_no_bot_task_when_token_empty(self):
-        """When DISCORD_BOT_TOKEN is absent lifespan creates exactly 1 task (scheduler)."""
+        """When DISCORD_BOT_TOKEN is absent lifespan creates exactly 2 tasks (scheduler, ships ingest)."""
         created_tasks = []
 
         def capture_create_task(coro, **kwargs):
@@ -167,11 +172,12 @@ class TestLifespanWithDiscordToken:
             patches[1],
             patches[2],
             patches[3],
+            patches[4],
         ):
             async with lifespan(app):
                 pass
 
-        assert len(created_tasks) == 1
+        assert len(created_tasks) == 2
 
 
 @pytest.mark.asyncio
@@ -193,6 +199,7 @@ async def test_lifespan_calls_tracer_provider_shutdown_on_exit():
         patches[1],
         patches[2],
         patches[3],
+        patches[4],
     ):
         async with lifespan(app):
             mock_tracer_provider.shutdown.assert_not_called()

--- a/projects/monolith/app/main_lock_sweep_test.py
+++ b/projects/monolith/app/main_lock_sweep_test.py
@@ -57,6 +57,7 @@ def _lifespan_patches_with_discord(mock_bot):
         patch("chat.summarizer.on_startup"),
         patch("chat.summarizer.build_llm_caller", return_value=MagicMock()),
         patch("chat.bot.create_bot", return_value=mock_bot),
+        patch("ships.on_startup_jobs"),
     ]
 
 
@@ -70,14 +71,15 @@ def _lifespan_patches_no_discord():
         patch("sqlmodel.Session", return_value=mock_session),
         patch("home.on_startup_jobs"),
         patch("shared.scheduler.run_scheduler_loop", new_callable=AsyncMock),
+        patch("ships.on_startup_jobs"),
     ]
 
 
 def _capture_sweep_coro():
-    """Capture the _lock_sweep_loop coroutine (task 3) without closing it.
+    """Capture the _lock_sweep_loop coroutine (task 4) without closing it.
 
     Task order when DISCORD_BOT_TOKEN is set:
-      1=bot, 2=scheduler, 3=sweep
+      1=bot, 2=scheduler, 3=ships ingest, 4=sweep
     """
     mock_bot = MagicMock()
     mock_bot.close = AsyncMock()
@@ -89,7 +91,7 @@ def _capture_sweep_coro():
     def capture_create_task(coro, **kwargs):
         task_counter[0] += 1
         t = MagicMock()
-        if task_counter[0] == 3:
+        if task_counter[0] == 4:
             coros.append(coro)  # preserve — do NOT close
         else:
             if hasattr(coro, "close"):
@@ -125,7 +127,7 @@ class TestSweepTaskRegistration:
     async def test_sweep_task_registers_done_callback_with_log_task_exception(self):
         """When DISCORD_BOT_TOKEN is set, sweep_task.add_done_callback(_log_task_exception) is called.
 
-        Task order: 1=bot, 2=scheduler, 3=sweep.
+        Task order: 1=bot, 2=scheduler, 3=ships ingest, 4=sweep.
         """
         mock_bot = MagicMock()
         mock_bot.close = AsyncMock()
@@ -137,7 +139,7 @@ class TestSweepTaskRegistration:
             if hasattr(coro, "close"):
                 coro.close()
             task_counter[0] += 1
-            if task_counter[0] == 3:
+            if task_counter[0] == 4:
                 return sweep_task_mock
             return MagicMock()
 
@@ -152,6 +154,7 @@ class TestSweepTaskRegistration:
             patches[4],
             patches[5],
             patches[6],
+            patches[7],
         ):
             async with lifespan(app):
                 pass
@@ -180,6 +183,7 @@ class TestSweepTaskRegistration:
             patches[4],
             patches[5],
             patches[6],
+            patches[7],
             patch("app.main.logger") as mock_logger,
         ):
             async with lifespan(app):
@@ -215,13 +219,14 @@ class TestSweepTaskRegistration:
             patches[1],
             patches[2],
             patches[3],
+            patches[4],
             patch("app.main.logger") as mock_logger,
         ):
             async with lifespan(app):
                 pass
 
-        # Only 1 task should be created (scheduler)
-        assert len(tasks_created) == 1
+        # 2 tasks should be created (scheduler + ships ingest)
+        assert len(tasks_created) == 2
         messages = [str(c) for c in mock_logger.info.call_args_list]
         assert not any("Message lock sweep started" in m for m in messages)
 
@@ -256,6 +261,7 @@ class TestLockSweepLoopNoExpiredLocks:
             patches[4],
             patches[5],
             patches[6],
+            patches[7],
         ):
             async with lifespan(app):
                 pass
@@ -310,6 +316,7 @@ class TestLockSweepLoopNoExpiredLocks:
             patches[4],
             patches[5],
             patches[6],
+            patches[7],
         ):
             async with lifespan(app):
                 pass
@@ -362,6 +369,7 @@ class TestLockSweepLoopNoExpiredLocks:
             patches[4],
             patches[5],
             patches[6],
+            patches[7],
         ):
             async with lifespan(app):
                 pass
@@ -418,6 +426,7 @@ class TestLockSweepLoopNoExpiredLocks:
             patches[4],
             patches[5],
             patches[6],
+            patches[7],
         ):
             async with lifespan(app):
                 pass
@@ -482,6 +491,7 @@ class TestLockSweepLoopWithExpiredLocks:
             patches[4],
             patches[5],
             patches[6],
+            patches[7],
         ):
             async with lifespan(app):
                 pass
@@ -540,6 +550,7 @@ class TestLockSweepLoopWithExpiredLocks:
             patches[4],
             patches[5],
             patches[6],
+            patches[7],
         ):
             async with lifespan(app):
                 pass
@@ -598,6 +609,7 @@ class TestLockSweepLoopWithExpiredLocks:
             patches[4],
             patches[5],
             patches[6],
+            patches[7],
         ):
             async with lifespan(app):
                 pass
@@ -659,6 +671,7 @@ class TestLockSweepLoopExceptionHandling:
             patches[4],
             patches[5],
             patches[6],
+            patches[7],
         ):
             async with lifespan(app):
                 pass
@@ -717,6 +730,7 @@ class TestLockSweepLoopExceptionHandling:
             patches[4],
             patches[5],
             patches[6],
+            patches[7],
         ):
             async with lifespan(app):
                 pass
@@ -772,6 +786,7 @@ class TestLockSweepLoopExceptionHandling:
             patches[4],
             patches[5],
             patches[6],
+            patches[7],
         ):
             async with lifespan(app):
                 pass

--- a/projects/monolith/app/main_sidecar_test.py
+++ b/projects/monolith/app/main_sidecar_test.py
@@ -63,6 +63,7 @@ def _lifespan_patches_with_discord(mock_bot):
         patch("chat.summarizer.on_startup"),
         patch("chat.summarizer.build_llm_caller", return_value=MagicMock()),
         patch("chat.bot.create_bot", return_value=mock_bot),
+        patch("ships.on_startup_jobs"),
     ]
 
 
@@ -76,6 +77,7 @@ def _lifespan_patches_no_discord():
         patch("sqlmodel.Session", return_value=mock_session),
         patch("home.on_startup_jobs"),
         patch("shared.scheduler.run_scheduler_loop", new_callable=AsyncMock),
+        patch("ships.on_startup_jobs"),
     ]
 
 
@@ -428,6 +430,7 @@ async def test_start_bot_when_ready_calls_wait_for_sidecar_before_bot_start():
         patches[4],
         patches[5],
         patches[6],
+        patches[7],
     ):
         async with lifespan(app):
             pass
@@ -469,11 +472,12 @@ async def test_start_bot_when_ready_not_scheduled_when_no_token():
         patches[1],
         patches[2],
         patches[3],
+        patches[4],
     ):
         async with lifespan(app):
             pass
 
-    # Only scheduler — no bot task
-    assert len(created_tasks) == 1, (
-        f"Expected 1 task without a bot token, got {len(created_tasks)}"
+    # Scheduler + ships ingest task (no bot task)
+    assert len(created_tasks) == 2, (
+        f"Expected 2 tasks without a bot token, got {len(created_tasks)}"
     )

--- a/projects/monolith/app/main_summary_edge_test.py
+++ b/projects/monolith/app/main_summary_edge_test.py
@@ -34,6 +34,7 @@ def _lifespan_patches_no_discord():
         patch("sqlmodel.Session", return_value=mock_session),
         patch("home.on_startup_jobs"),
         patch("shared.scheduler.run_scheduler_loop", new_callable=AsyncMock),
+        patch("ships.on_startup_jobs"),
     ]
 
 
@@ -67,6 +68,7 @@ class TestLifespanShutdownBackfillDone:
             patches[1],
             patches[2],
             patches[3],
+            patches[4],
         ):
             async with lifespan(app):
                 # Inject the already-done backfill task during the lifespan body
@@ -99,6 +101,7 @@ class TestLifespanShutdownBackfillDone:
             patches[1],
             patches[2],
             patches[3],
+            patches[4],
         ):
             async with lifespan(app):
                 app.state.backfill_task = backfill_mock

--- a/projects/monolith/app/main_summary_test.py
+++ b/projects/monolith/app/main_summary_test.py
@@ -53,6 +53,7 @@ def _lifespan_patches_with_discord(mock_bot):
         patch("chat.summarizer.on_startup"),
         patch("chat.summarizer.build_llm_caller", return_value=MagicMock()),
         patch("chat.bot.create_bot", return_value=mock_bot),
+        patch("ships.on_startup_jobs"),
     ]
 
 
@@ -66,6 +67,7 @@ def _lifespan_patches_no_discord():
         patch("sqlmodel.Session", return_value=mock_session),
         patch("home.on_startup_jobs"),
         patch("shared.scheduler.run_scheduler_loop", new_callable=AsyncMock),
+        patch("ships.on_startup_jobs"),
     ]
 
 
@@ -94,6 +96,7 @@ class TestChatStartupHook:
             patch("app.db.get_engine", return_value=MagicMock()),
             patch("sqlmodel.Session", return_value=mock_session),
             patch("home.on_startup_jobs"),
+            patch("ships.on_startup_jobs"),
             patch("shared.scheduler.run_scheduler_loop", new_callable=AsyncMock),
             patch("chat.summarizer.on_startup", mock_chat_startup),
             patch("chat.summarizer.build_llm_caller", return_value=MagicMock()),
@@ -132,17 +135,20 @@ class TestChatStartupHook:
             patches[4],
             patches[5],
             patches[6],
+            patches[7],
         ):
             async with lifespan(app):
                 pass
 
-        assert len(task_mocks) == 3
-        # Tasks: 0=bot, 1=scheduler, 2=sweep — all should have done callbacks
+        assert len(task_mocks) == 4
+        # Tasks: 0=bot, 1=scheduler, 2=ships ingest, 3=sweep, all have done callbacks
         bot_task = task_mocks[0]
         scheduler_task = task_mocks[1]
-        sweep_task = task_mocks[2]
+        ships_task = task_mocks[2]
+        sweep_task = task_mocks[3]
         bot_task.add_done_callback.assert_called_once_with(_log_task_exception)
         scheduler_task.add_done_callback.assert_called_once_with(_log_task_exception)
+        ships_task.add_done_callback.assert_called_once_with(_log_task_exception)
         sweep_task.add_done_callback.assert_called_once_with(_log_task_exception)
 
 
@@ -174,6 +180,7 @@ class TestSummaryLoopLogging:
             patch("app.db.get_engine", return_value=MagicMock()),
             patch("sqlmodel.Session", return_value=mock_session),
             patch("home.on_startup_jobs"),
+            patch("ships.on_startup_jobs"),
             patch("shared.scheduler.run_scheduler_loop", new_callable=AsyncMock),
         ):
             async with lifespan(app):

--- a/projects/monolith/app/main_test.py
+++ b/projects/monolith/app/main_test.py
@@ -155,12 +155,13 @@ def _lifespan_patches_no_discord():
         patch("sqlmodel.Session", return_value=mock_session),
         patch("home.on_startup_jobs"),
         patch("shared.scheduler.run_scheduler_loop", new_callable=AsyncMock),
+        patch("ships.on_startup_jobs"),
     ]
 
 
 @pytest.mark.asyncio
 async def test_lifespan_creates_one_background_task_on_startup():
-    """Lifespan creates exactly one asyncio task (scheduler_loop) on startup without discord."""
+    """Lifespan creates two asyncio tasks (scheduler_loop + ships ingest) on startup without discord."""
     from app.main import lifespan
 
     created_tasks = []
@@ -174,11 +175,11 @@ async def test_lifespan_creates_one_background_task_on_startup():
 
     patches = _lifespan_patches_no_discord()
     with patch("asyncio.create_task", side_effect=capture_create_task):
-        with patches[0], patches[1], patches[2], patches[3]:
+        with patches[0], patches[1], patches[2], patches[3], patches[4]:
             async with lifespan(app):
                 pass
 
-    assert len(created_tasks) == 1
+    assert len(created_tasks) == 2
 
 
 @pytest.mark.asyncio
@@ -197,11 +198,11 @@ async def test_lifespan_cancels_all_tasks_on_shutdown():
 
     patches = _lifespan_patches_no_discord()
     with patch("asyncio.create_task", side_effect=capture_create_task):
-        with patches[0], patches[1], patches[2], patches[3]:
+        with patches[0], patches[1], patches[2], patches[3], patches[4]:
             async with lifespan(app):
                 pass
 
-    assert len(mock_tasks) == 1
+    assert len(mock_tasks) == 2
     for task in mock_tasks:
         task.cancel.assert_called_once()
 
@@ -222,9 +223,9 @@ async def test_lifespan_no_tasks_cancelled_before_shutdown():
 
     patches = _lifespan_patches_no_discord()
     with patch("asyncio.create_task", side_effect=capture_create_task):
-        with patches[0], patches[1], patches[2], patches[3]:
+        with patches[0], patches[1], patches[2], patches[3], patches[4]:
             async with lifespan(app):
-                assert len(mock_tasks) == 1
+                assert len(mock_tasks) == 2
                 for task in mock_tasks:
                     task.cancel.assert_not_called()
 
@@ -256,9 +257,10 @@ async def test_lifespan_scheduler_task_is_run_scheduler_loop():
         ),
         patch("home.on_startup_jobs"),
         patch("shared.scheduler.run_scheduler_loop", mock_scheduler),
+        patch("ships.on_startup_jobs"),
     ]
     with patch("asyncio.create_task", side_effect=capture_create_task):
-        with patches[0], patches[1], patches[2], patches[3]:
+        with patches[0], patches[1], patches[2], patches[3], patches[4]:
             async with lifespan(app):
                 pass
 
@@ -350,7 +352,7 @@ async def test_lifespan_logs_monolith_started_on_startup():
 
     patches = _lifespan_patches_no_discord()
     with patch("asyncio.create_task", side_effect=capture_create_task):
-        with patches[0], patches[1], patches[2], patches[3]:
+        with patches[0], patches[1], patches[2], patches[3], patches[4]:
             with patch("app.main.logger") as mock_logger:
                 async with lifespan(app):
                     pass
@@ -373,7 +375,7 @@ async def test_lifespan_logs_shutting_down_on_exit():
 
     patches = _lifespan_patches_no_discord()
     with patch("asyncio.create_task", side_effect=capture_create_task):
-        with patches[0], patches[1], patches[2], patches[3]:
+        with patches[0], patches[1], patches[2], patches[3], patches[4]:
             with patch("app.main.logger") as mock_logger:
                 async with lifespan(app):
                     pass
@@ -402,6 +404,7 @@ def _lifespan_patches_with_discord(mock_bot):
         patch("chat.summarizer.on_startup"),
         patch("chat.summarizer.build_llm_caller", return_value=MagicMock()),
         patch("chat.bot.create_bot", return_value=mock_bot),
+        patch("ships.on_startup_jobs"),
     ]
 
 
@@ -420,7 +423,7 @@ async def test_lifespan_registers_done_callback_on_bot_task_when_token_set():
         if hasattr(coro, "close"):
             coro.close()
         task_counter[0] += 1
-        # Tasks created: 1=bot, 2=scheduler, 3=sweep
+        # Tasks created: 1=bot, 2=scheduler, 3=ships ingest, 4=sweep
         if task_counter[0] == 1:
             return bot_task_mock
         return MagicMock()
@@ -436,6 +439,7 @@ async def test_lifespan_registers_done_callback_on_bot_task_when_token_set():
                 patches[4],
                 patches[5],
                 patches[6],
+                patches[7],
             ):
                 async with lifespan(app):
                     pass
@@ -467,6 +471,7 @@ async def test_lifespan_logs_discord_bot_starting_when_token_set():
                 patches[4],
                 patches[5],
                 patches[6],
+                patches[7],
             ):
                 with patch("app.main.logger") as mock_logger:
                     async with lifespan(app):
@@ -480,7 +485,7 @@ async def test_lifespan_logs_discord_bot_starting_when_token_set():
 
 @pytest.mark.asyncio
 async def test_lifespan_creates_three_tasks_when_discord_token_set():
-    """When DISCORD_BOT_TOKEN is set, lifespan creates three tasks (bot, scheduler, sweep)."""
+    """When DISCORD_BOT_TOKEN is set, lifespan creates four tasks (bot, scheduler, ships ingest, sweep)."""
     from app.main import lifespan
 
     mock_bot = MagicMock()
@@ -506,11 +511,12 @@ async def test_lifespan_creates_three_tasks_when_discord_token_set():
                 patches[4],
                 patches[5],
                 patches[6],
+                patches[7],
             ):
                 async with lifespan(app):
                     pass
 
-    assert len(created_tasks) == 3
+    assert len(created_tasks) == 4
 
 
 @pytest.mark.asyncio
@@ -530,7 +536,7 @@ async def test_lifespan_does_not_log_discord_bot_starting_when_token_absent():
     patches = _lifespan_patches_no_discord()
     with patch.dict(os.environ, env_without_token, clear=True):
         with patch("asyncio.create_task", side_effect=capture_create_task):
-            with patches[0], patches[1], patches[2], patches[3]:
+            with patches[0], patches[1], patches[2], patches[3], patches[4]:
                 with patch("app.main.logger") as mock_logger:
                     async with lifespan(app):
                         pass

--- a/projects/monolith/app/main_vault_sync_test.py
+++ b/projects/monolith/app/main_vault_sync_test.py
@@ -21,6 +21,7 @@ async def test_lifespan_calls_clone_vault():
         patch("app.db.get_engine"),
         patch("knowledge.service.on_startup"),
         patch("home.on_startup_jobs"),
+        patch("ships.on_startup_jobs"),
     ):
         from app.main import lifespan, app
 

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.95.2
+version: 0.96.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.96.1
+version: 0.96.2
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.96.0
+version: 0.96.1
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.95.1
+version: 0.95.2
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/migrations/20260610000000_ships_schema.sql
+++ b/projects/monolith/chart/migrations/20260610000000_ships_schema.sql
@@ -1,0 +1,72 @@
+-- ships schema: AIS vessel tracking.
+--
+-- vessels          : static/voyage metadata, one row per MMSI
+-- positions        : partitioned position history (retention via drop-partition)
+-- latest_positions : serving + dedup read-back table, one row per MMSI
+--
+-- Postgres is the single source of truth (stateless serving, no in-memory set).
+
+CREATE SCHEMA IF NOT EXISTS ships;
+
+-- One row per vessel (keyed by MMSI). Holds the static + voyage-related fields
+-- that arrive on AIS type 5 messages and rarely change.
+CREATE TABLE ships.vessels (
+    mmsi         TEXT PRIMARY KEY,
+    imo          TEXT,
+    call_sign    TEXT,
+    name         TEXT,
+    ship_type    INTEGER,
+    dimension_a  INTEGER,
+    dimension_b  INTEGER,
+    dimension_c  INTEGER,
+    dimension_d  INTEGER,
+    destination  TEXT,
+    eta          TIMESTAMPTZ,
+    draught      DOUBLE PRECISION,
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at   TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Append-only position history, range-partitioned on recorded_at so old data
+-- can be dropped a partition at a time. A partitioned table's primary key must
+-- include the partition key, hence the composite (recorded_at, id).
+CREATE TABLE ships.positions (
+    id           BIGINT NOT NULL,
+    mmsi         TEXT NOT NULL,
+    lat          DOUBLE PRECISION NOT NULL,
+    lon          DOUBLE PRECISION NOT NULL,
+    speed        DOUBLE PRECISION,
+    course       DOUBLE PRECISION,
+    heading      INTEGER,
+    nav_status   INTEGER,
+    ship_name    TEXT,
+    recorded_at  TIMESTAMPTZ NOT NULL,
+    received_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (recorded_at, id)
+) PARTITION BY RANGE (recorded_at);
+
+CREATE SEQUENCE ships.positions_id_seq OWNED BY ships.positions.id;
+ALTER TABLE ships.positions ALTER COLUMN id SET DEFAULT nextval('ships.positions_id_seq');
+
+-- Catch-all partition so inserts never fail before the maintenance job creates
+-- per-period partitions.
+CREATE TABLE ships.positions_default PARTITION OF ships.positions DEFAULT;
+
+CREATE INDEX positions_recorded_brin ON ships.positions USING brin (recorded_at);
+CREATE INDEX positions_mmsi_recorded ON ships.positions (mmsi, recorded_at DESC);
+
+-- Serving + dedup read-back table: one row per MMSI holding the most recent
+-- position. Read on ingest to dedup, and read by the API to serve the map.
+CREATE TABLE ships.latest_positions (
+    mmsi                    TEXT PRIMARY KEY,
+    lat                     DOUBLE PRECISION NOT NULL,
+    lon                     DOUBLE PRECISION NOT NULL,
+    speed                   DOUBLE PRECISION,
+    course                  DOUBLE PRECISION,
+    heading                 INTEGER,
+    nav_status              INTEGER,
+    ship_name               TEXT,
+    recorded_at             TIMESTAMPTZ NOT NULL,
+    first_seen_at_location  TIMESTAMPTZ,
+    updated_at              TIMESTAMPTZ NOT NULL DEFAULT now()
+);

--- a/projects/monolith/chart/migrations/atlas.sum
+++ b/projects/monolith/chart/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:0pMmfkLL5cd6rfFLshaGtWrUJl4wpnMdIH1ct1ZHipo=
+h1:ZfbzjIlgGHFHB51p19feyV8dea7UTYel36E4r69lGok=
 20260330000000_initial_schema.sql h1:J2futpSW0nJAIRR7nR7ssT7LwXIYrvRI+PkHb5Y4tLI=
 20260403000000_chat_schema.sql h1:pERUFC0vzM95etRuzp43XzkCV7lBCzrrtY5Mk7aF3CA=
 20260404000000_chat_attachments.sql h1:tv+Fdbr1rQC5nzUxfaBC0O6fu2OMGgLWf+YNg1WQXi4=
@@ -27,3 +27,4 @@ h1:0pMmfkLL5cd6rfFLshaGtWrUJl4wpnMdIH1ct1ZHipo=
 20260523120000_review_soft_delete.sql h1:lAYba7MzvHDO+/ob+CUPGmnwu5tYUh+fWf6TEvH8vVY=
 20260524000000_gate_external_research.sql h1:+PavvmK2LurjiKBrXucFNoZg7XnV7Buq/QpMXVhI6HE=
 20260530000000_gaps_state_class_combo.sql h1:5xds/70HjdD+YL1IAgzgGiRCMpXyeVt/JShx49GBr9g=
+20260610000000_ships_schema.sql h1:Ja7g3S4yJxKhscRMUUqg+hg0kAWVRoHeUkKxkZoPxSQ=

--- a/projects/monolith/chart/templates/deployment.yaml
+++ b/projects/monolith/chart/templates/deployment.yaml
@@ -66,6 +66,15 @@ spec:
                   name: {{ include "monolith.fullname" . }}-clickhouse
                   key: PASSWORD
             {{- end }}
+            {{- if .Values.marine.enabled }}
+            - name: AISSTREAM_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "monolith.fullname" . }}-marine
+                  key: ais-stream-api-key
+            - name: BOUNDING_BOX
+              value: {{ .Values.marine.boundingBox | quote }}
+            {{- end }}
             - name: FRONTEND_HEALTH_URL
               value: "http://localhost:3000/"
             - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT

--- a/projects/monolith/chart/templates/onepassworditem-marine.yaml
+++ b/projects/monolith/chart/templates/onepassworditem-marine.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.marine.enabled }}
+apiVersion: onepassword.com/v1
+kind: OnePasswordItem
+metadata:
+  name: {{ include "monolith.fullname" . }}-marine
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "monolith.labels" . | nindent 4 }}
+spec:
+  itemPath: {{ .Values.marine.onepassword.itemPath | quote }}
+{{- end }}

--- a/projects/monolith/chart/values.yaml
+++ b/projects/monolith/chart/values.yaml
@@ -110,6 +110,16 @@ gardener:
   onepassword:
     itemPath: ""
 
+# Marine / AIS ship tracking: streams vessel positions from AISStream.io.
+# Reuses the existing 1Password "marine" vault item (shared with the legacy
+# standalone ships app) so the secret keeps materializing after that app is
+# decommissioned.
+marine:
+  enabled: true
+  onepassword:
+    itemPath: "vaults/k8s-homelab/items/marine"
+  boundingBox: "[[[46.876152, -129.552155], [51.413769, -121.213531]]]"
+
 cfIngress:
   private:
     enabled: true

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.95.1
+      targetRevision: 0.95.2
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.96.1
+      targetRevision: 0.96.2
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.96.0
+      targetRevision: 0.96.1
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.95.2
+      targetRevision: 0.96.0
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/BUILD
+++ b/projects/monolith/frontend/BUILD
@@ -39,6 +39,8 @@ js_library(
         ":node_modules/@dagrejs/dagre",
         # Runtime markdown rendering
         ":node_modules/marked",
+        # WebGL basemap for the /app/ships live vessel map
+        ":node_modules/maplibre-gl",
         # OpenTelemetry browser tracing
         ":node_modules/@opentelemetry/api",
         ":node_modules/@opentelemetry/sdk-trace-web",

--- a/projects/monolith/frontend/package.json
+++ b/projects/monolith/frontend/package.json
@@ -20,6 +20,7 @@
     "@opentelemetry/resources": "^1.30.0",
     "@opentelemetry/sdk-trace-web": "^1.30.0",
     "@opentelemetry/semantic-conventions": "^1.28.0",
+    "maplibre-gl": "^5.24.0",
     "marked": "^18.0.0",
     "roughjs": "^4.6.6"
   },

--- a/projects/monolith/frontend/src/lib/cache-headers.js
+++ b/projects/monolith/frontend/src/lib/cache-headers.js
@@ -8,3 +8,14 @@ export const PAGE_CACHE_CONTROL = `public, s-maxage=60, stale-while-revalidate=$
 // /notes graph: gardener mutates on a schedule, so 1h freshness is fine. Mirrors
 // _GRAPH_CACHE_CONTROL in projects/monolith/knowledge/router.py — keep in sync.
 export const NOTES_PAGE_CACHE_CONTROL = `public, s-maxage=${ONE_HOUR}, stale-while-revalidate=${ONE_DAY}, stale-if-error=${ONE_YEAR}`;
+
+// /app/ships snapshot: AIS positions refresh every ~2 min, so 120s freshness
+// with a 10 min SWR window keeps the CDN serving warm data between ingests.
+// Mirrors _SNAPSHOT_CACHE_CONTROL in projects/monolith/ships/router.py, keep in sync.
+export const SHIPS_SNAPSHOT_CACHE_CONTROL =
+  "public, s-maxage=120, stale-while-revalidate=600, stale-if-error=86400";
+
+// /app/ships track: one vessel's history, fetched on marker click. Mirrors
+// _TRACK_CACHE_CONTROL in projects/monolith/ships/router.py, keep in sync.
+export const SHIPS_TRACK_CACHE_CONTROL =
+  "public, s-maxage=60, stale-while-revalidate=300, stale-if-error=86400";

--- a/projects/monolith/frontend/src/lib/public/components/ships/ShipsMap.svelte
+++ b/projects/monolith/frontend/src/lib/public/components/ships/ShipsMap.svelte
@@ -1,0 +1,586 @@
+<script>
+  import { onMount } from "svelte";
+  import "maplibre-gl/dist/maplibre-gl.css";
+  import { deadReckon } from "$lib/public/ships/deadReckoning.js";
+
+  let { vessels = [] } = $props();
+
+  // OpenFreeMap needs no API key. Self-hosting the tiles + style is a
+  // follow-up; for now we point at the hosted liberty style and tint the
+  // canvas toward the cream palette with a CSS filter (see <style>).
+  const BASEMAP_STYLE = "https://tiles.openfreemap.org/styles/liberty";
+
+  // A fix older than this is almost certainly a vessel that stopped
+  // reporting; dead-reckoning it any further would fling the marker across
+  // the map, so clamp the extrapolation window.
+  const MAX_DR_SECONDS = 300;
+
+  let maplibregl; // loaded lazily in onMount (browser-only module)
+  let mapContainer; // bound <div>
+  let map = null;
+  let pal = null; // design-token palette, resolved once the map is up
+  let rafId = null;
+  let didFit = false;
+
+  // mmsi -> { marker, el, onClick, fixLat, fixLon, fixTimeMs, speed, course }
+  const markers = new Map();
+
+  let selected = $state(null); // selected vessel object (snapshot row)
+  let track = $state(null); // { mmsi, count, track } or null
+  let trackLoading = $state(false);
+
+  function emptyFC() {
+    return { type: "FeatureCollection", features: [] };
+  }
+
+  // Resolve palette from the design tokens so colors stay single-sourced in
+  // design-system.css rather than duplicated as hex literals here.
+  function palette() {
+    const s = getComputedStyle(document.documentElement);
+    const g = (name) => s.getPropertyValue(name).trim();
+    return {
+      passenger: g("--blue"),
+      cargo: g("--teal"),
+      tanker: g("--coral"),
+      hsc: g("--accent"),
+      special: g("--green"),
+      unknown: g("--ink-3"),
+      ink: g("--ink"),
+    };
+  }
+
+  // ITU AIS ship_type bands mapped onto the palette.
+  function shipBandColor(type, p) {
+    if (type == null) return p.unknown;
+    if (type >= 60 && type <= 69) return p.passenger;
+    if (type >= 70 && type <= 79) return p.cargo;
+    if (type >= 80 && type <= 89) return p.tanker;
+    if (type >= 40 && type <= 49) return p.hsc;
+    if (type >= 50 && type <= 59) return p.special;
+    return p.unknown;
+  }
+
+  function shipTypeLabel(type) {
+    if (type == null) return "Unknown";
+    if (type >= 60 && type <= 69) return "Passenger";
+    if (type >= 70 && type <= 79) return "Cargo";
+    if (type >= 80 && type <= 89) return "Tanker";
+    if (type >= 40 && type <= 49) return "High-speed craft";
+    if (type >= 50 && type <= 59) return "Special craft";
+    if (type >= 30 && type <= 39) return "Fishing / working";
+    return `Type ${type}`;
+  }
+
+  function fmtSpeed(s) {
+    return s == null ? "n/a" : `${s.toFixed(1)} kn`;
+  }
+
+  function fmtDeg(d) {
+    return d == null ? "n/a" : `${Math.round(d)}°`;
+  }
+
+  // Base time for extrapolation: the AIS message timestamp, not "now". The
+  // snapshot can be served from cache, so recorded_at is the real fix age.
+  function fixTimeMs(v) {
+    const t = Date.parse(v.recorded_at || v.updated_at || "");
+    return Number.isNaN(t) ? Date.now() : t;
+  }
+
+  function rotationOf(v) {
+    return v.heading ?? v.course ?? 0;
+  }
+
+  function makeMarkerEl() {
+    const el = document.createElement("div");
+    el.className = "ship-marker";
+    // fill = currentColor (set per-vessel via el.style.color); stroke pulls
+    // the ink token straight from the cascade so it is not hardcoded here.
+    el.innerHTML =
+      '<svg viewBox="0 0 20 20" width="22" height="22" aria-hidden="true">' +
+      '<path d="M10 1 L17 18 L10 14 L3 18 Z" fill="currentColor" ' +
+      'style="stroke: var(--ink); stroke-width: 1.5; stroke-linejoin: round;" />' +
+      "</svg>";
+    return el;
+  }
+
+  function syncMarkers() {
+    if (!map || !maplibregl) return;
+    if (!pal) pal = palette();
+
+    const seen = new Set();
+    for (const v of vessels) {
+      if (v.lat == null || v.lon == null) continue;
+      const id = String(v.mmsi);
+      seen.add(id);
+      const color = shipBandColor(v.ship_type, pal);
+      const rot = rotationOf(v);
+
+      let entry = markers.get(id);
+      if (!entry) {
+        const el = makeMarkerEl();
+        const marker = new maplibregl.Marker({
+          element: el,
+          rotation: rot,
+          rotationAlignment: "map",
+        })
+          .setLngLat([v.lon, v.lat])
+          .addTo(map);
+        entry = { marker, el, onClick: null };
+        markers.set(id, entry);
+      } else {
+        entry.marker.setRotation(rot);
+      }
+      entry.el.style.color = color;
+
+      // Rebind the click handler so it always closes over the latest row.
+      if (entry.onClick) entry.el.removeEventListener("click", entry.onClick);
+      entry.onClick = (e) => {
+        e.stopPropagation();
+        selectVessel(v);
+      };
+      entry.el.addEventListener("click", entry.onClick);
+
+      // Reset the dead-reckoning fix to snapshot truth.
+      entry.fixLat = v.lat;
+      entry.fixLon = v.lon;
+      entry.fixTimeMs = fixTimeMs(v);
+      entry.speed = v.speed;
+      entry.course = v.course;
+    }
+
+    // Drop vessels that fell out of the snapshot.
+    for (const [id, entry] of markers) {
+      if (seen.has(id)) continue;
+      if (entry.onClick) entry.el.removeEventListener("click", entry.onClick);
+      entry.marker.remove();
+      markers.delete(id);
+    }
+
+    if (!didFit && seen.size > 0) {
+      const b = new maplibregl.LngLatBounds();
+      let any = false;
+      for (const v of vessels) {
+        if (v.lat == null || v.lon == null) continue;
+        b.extend([v.lon, v.lat]);
+        any = true;
+      }
+      if (any) {
+        map.fitBounds(b, { padding: 64, maxZoom: 9, duration: 0 });
+        didFit = true;
+      }
+    }
+  }
+
+  function startLoop() {
+    const step = () => {
+      const now = Date.now();
+      for (const entry of markers.values()) {
+        const elapsed = Math.min(
+          (now - entry.fixTimeMs) / 1000,
+          MAX_DR_SECONDS,
+        );
+        const pos = deadReckon(
+          {
+            lat: entry.fixLat,
+            lon: entry.fixLon,
+            speed: entry.speed,
+            course: entry.course,
+          },
+          elapsed,
+        );
+        entry.marker.setLngLat([pos.lon, pos.lat]);
+      }
+      rafId = requestAnimationFrame(step);
+    };
+    rafId = requestAnimationFrame(step);
+  }
+
+  function drawTrack(points) {
+    const src = map?.getSource("ship-track");
+    if (!src) return;
+    const coordinates = (points || [])
+      .filter((p) => p.lon != null && p.lat != null)
+      .map((p) => [p.lon, p.lat]);
+    src.setData({
+      type: "Feature",
+      geometry: { type: "LineString", coordinates },
+      properties: {},
+    });
+  }
+
+  async function selectVessel(v) {
+    selected = v;
+    track = null;
+    trackLoading = true;
+    try {
+      // Same-origin site route, proxied to /api/ships/track/{mmsi} server-side
+      // by +server.js. The browser never touches the private API surface.
+      const res = await fetch(
+        `/app/ships/track/${encodeURIComponent(v.mmsi)}`,
+      );
+      if (res.ok) {
+        const body = await res.json();
+        track = body;
+        drawTrack(body.track);
+      }
+    } catch {
+      // Network blip: keep the panel open with snapshot fields, just no track.
+    } finally {
+      trackLoading = false;
+    }
+  }
+
+  function closePanel() {
+    selected = null;
+    track = null;
+    const src = map?.getSource("ship-track");
+    if (src) src.setData(emptyFC());
+  }
+
+  // Highlight the selected marker. Re-runs when `selected` changes.
+  $effect(() => {
+    const id = selected ? String(selected.mmsi) : null;
+    for (const [mmsi, entry] of markers) {
+      entry.el.classList.toggle("is-selected", mmsi === id);
+    }
+  });
+
+  // Reset markers to snapshot truth whenever a new snapshot arrives. `vessels`
+  // is a fresh array on every invalidateAll, so this fires on each live update.
+  $effect(() => {
+    void vessels;
+    if (map) syncMarkers();
+  });
+
+  onMount(() => {
+    let cleanup = () => {};
+    let destroyed = false;
+
+    (async () => {
+      maplibregl = (await import("maplibre-gl")).default;
+      if (destroyed) return;
+
+      map = new maplibregl.Map({
+        container: mapContainer,
+        style: BASEMAP_STYLE,
+        center: [0, 30],
+        zoom: 1.4,
+        attributionControl: true,
+      });
+      map.addControl(
+        new maplibregl.NavigationControl({ showCompass: false }),
+        "bottom-right",
+      );
+
+      map.on("load", () => {
+        pal = palette();
+        map.addSource("ship-track", { type: "geojson", data: emptyFC() });
+        map.addLayer({
+          id: "ship-track-line",
+          type: "line",
+          source: "ship-track",
+          layout: { "line-cap": "round", "line-join": "round" },
+          paint: {
+            "line-color": pal.ink,
+            "line-width": 2.5,
+            "line-dasharray": [1.5, 1],
+          },
+        });
+        syncMarkers();
+        startLoop();
+      });
+
+      cleanup = () => {
+        if (rafId) cancelAnimationFrame(rafId);
+        for (const entry of markers.values()) {
+          if (entry.onClick) entry.el.removeEventListener("click", entry.onClick);
+          entry.marker.remove();
+        }
+        markers.clear();
+        map?.remove();
+        map = null;
+      };
+    })();
+
+    return () => {
+      destroyed = true;
+      cleanup();
+    };
+  });
+</script>
+
+<div class="map-wrap">
+  <div class="map" bind:this={mapContainer}></div>
+
+  <div class="map-chip">
+    <span class="chip-name">Ships</span>
+    <span class="chip-sep">/</span>
+    <span class="chip-live">live</span>
+    <span class="chip-dot" aria-hidden="true"></span>
+  </div>
+
+  <div class="legend card-hard">
+    <p class="eyebrow legend-title">Vessel type</p>
+    <ul class="legend-list">
+      <li><span class="sw sw-passenger"></span>Passenger</li>
+      <li><span class="sw sw-cargo"></span>Cargo</li>
+      <li><span class="sw sw-tanker"></span>Tanker</li>
+      <li><span class="sw sw-hsc"></span>High-speed</li>
+      <li><span class="sw sw-special"></span>Special</li>
+      <li><span class="sw sw-unknown"></span>Other</li>
+    </ul>
+  </div>
+
+  {#if selected}
+    <aside class="panel card-hard">
+      <button class="panel-close" onclick={closePanel} aria-label="Close vessel panel"
+        >&times;</button
+      >
+      <p class="eyebrow">Vessel</p>
+      <h2 class="panel-name">
+        {selected.name || selected.ship_name || `MMSI ${selected.mmsi}`}
+      </h2>
+      <dl class="panel-rows">
+        <div><dt>MMSI</dt><dd>{selected.mmsi}</dd></div>
+        <div><dt>Type</dt><dd>{shipTypeLabel(selected.ship_type)}</dd></div>
+        <div><dt>Speed</dt><dd>{fmtSpeed(selected.speed)}</dd></div>
+        <div><dt>Course</dt><dd>{fmtDeg(selected.course)}</dd></div>
+        <div><dt>Heading</dt><dd>{fmtDeg(selected.heading)}</dd></div>
+        <div>
+          <dt>Destination</dt>
+          <dd>{selected.destination || "Unknown"}</dd>
+        </div>
+      </dl>
+      {#if trackLoading}
+        <p class="panel-meta">Loading track…</p>
+      {:else if track}
+        <p class="panel-meta">{track.count} track points</p>
+      {/if}
+    </aside>
+  {/if}
+</div>
+
+<style>
+  .map-wrap {
+    position: absolute;
+    inset: 0;
+    overflow: hidden;
+    background: var(--cream);
+  }
+
+  .map {
+    position: absolute;
+    inset: 0;
+  }
+
+  /* Push the basemap toward the warm cream/ink palette without restyling
+     every layer. Kept subtle so markers and chrome stay legible. */
+  .map :global(.maplibregl-canvas) {
+    filter: grayscale(0.4) sepia(0.12) brightness(1.02) contrast(0.96);
+  }
+
+  .map :global(.maplibregl-ctrl-group) {
+    border: 2px solid var(--ink);
+    border-radius: 0;
+    box-shadow: var(--shadow-hard-sm);
+  }
+
+  :global(.ship-marker) {
+    cursor: pointer;
+    line-height: 0;
+    filter: drop-shadow(1px 1px 0 var(--ink));
+    transition: transform 120ms ease;
+  }
+
+  :global(.ship-marker:hover) {
+    transform: scale(1.25);
+  }
+
+  :global(.ship-marker.is-selected) {
+    transform: scale(1.5);
+  }
+
+  .map-chip {
+    position: absolute;
+    top: 16px;
+    left: 16px;
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 12px;
+    background: var(--paper);
+    border: 2px solid var(--ink);
+    box-shadow: var(--shadow-hard);
+    font-family: var(--mono);
+    font-size: 12px;
+    font-weight: 700;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+  }
+
+  .chip-sep {
+    color: var(--ink-3);
+  }
+
+  .chip-dot {
+    width: 9px;
+    height: 9px;
+    border-radius: 999px;
+    background: var(--green);
+    border: 1px solid var(--ink);
+    animation: chip-pulse 1.6s ease-in-out infinite;
+  }
+
+  @keyframes chip-pulse {
+    0%,
+    100% {
+      opacity: 1;
+    }
+    50% {
+      opacity: 0.3;
+    }
+  }
+
+  .legend {
+    position: absolute;
+    bottom: 16px;
+    left: 16px;
+    padding: 12px 14px;
+    background: var(--paper);
+  }
+
+  .legend-title {
+    margin-bottom: 8px;
+  }
+
+  .legend-list {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 4px 14px;
+    font-family: var(--mono);
+    font-size: 11px;
+    letter-spacing: 0.04em;
+  }
+
+  .legend-list li {
+    display: flex;
+    align-items: center;
+    gap: 7px;
+  }
+
+  .sw {
+    width: 11px;
+    height: 11px;
+    border: 1.5px solid var(--ink);
+    flex: none;
+  }
+
+  .sw-passenger {
+    background: var(--blue);
+  }
+  .sw-cargo {
+    background: var(--teal);
+  }
+  .sw-tanker {
+    background: var(--coral);
+  }
+  .sw-hsc {
+    background: var(--accent);
+  }
+  .sw-special {
+    background: var(--green);
+  }
+  .sw-unknown {
+    background: var(--ink-3);
+  }
+
+  .panel {
+    position: absolute;
+    top: 16px;
+    right: 16px;
+    width: 280px;
+    max-width: calc(100% - 32px);
+    padding: 18px;
+    background: var(--paper);
+  }
+
+  .panel-close {
+    position: absolute;
+    top: 8px;
+    right: 10px;
+    background: none;
+    border: none;
+    font-family: var(--mono);
+    font-size: 22px;
+    line-height: 1;
+    cursor: pointer;
+    color: var(--ink);
+  }
+
+  .panel-name {
+    font-family: var(--serif);
+    font-size: 28px;
+    line-height: 1.05;
+    margin: 2px 0 14px;
+    word-break: break-word;
+  }
+
+  .panel-rows {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .panel-rows > div {
+    display: flex;
+    justify-content: space-between;
+    gap: 12px;
+    border-bottom: 1px dashed var(--rule-2);
+    padding-bottom: 6px;
+  }
+
+  .panel-rows dt {
+    font-family: var(--mono);
+    font-size: 10px;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--ink-3);
+  }
+
+  .panel-rows dd {
+    font-family: var(--mono);
+    font-size: 12px;
+    font-weight: 600;
+    text-align: right;
+  }
+
+  .panel-meta {
+    margin-top: 12px;
+    font-family: var(--mono);
+    font-size: 11px;
+    color: var(--ink-3);
+    letter-spacing: 0.04em;
+  }
+
+  @media (max-width: 640px) {
+    .legend {
+      display: none;
+    }
+    .panel {
+      top: auto;
+      bottom: 16px;
+      left: 16px;
+      right: 16px;
+      width: auto;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .chip-dot {
+      animation: none;
+    }
+    :global(.ship-marker) {
+      transition: none;
+    }
+  }
+</style>

--- a/projects/monolith/frontend/src/lib/public/ships/deadReckoning.js
+++ b/projects/monolith/frontend/src/lib/public/ships/deadReckoning.js
@@ -1,0 +1,21 @@
+// Extrapolate a vessel's position from its last fix using speed (knots) + course (deg).
+export function deadReckon({ lat, lon, speed, course }, elapsedSeconds) {
+  if (!speed || speed <= 0) return { lat, lon };
+  const metersPerSec = speed * 0.514444;
+  const dist = metersPerSec * elapsedSeconds;
+  const R = 6371000;
+  const brng = (course ?? 0) * (Math.PI / 180);
+  const lat1 = (lat * Math.PI) / 180;
+  const lon1 = (lon * Math.PI) / 180;
+  const lat2 = Math.asin(
+    Math.sin(lat1) * Math.cos(dist / R) +
+      Math.cos(lat1) * Math.sin(dist / R) * Math.cos(brng),
+  );
+  const lon2 =
+    lon1 +
+    Math.atan2(
+      Math.sin(brng) * Math.sin(dist / R) * Math.cos(lat1),
+      Math.cos(dist / R) - Math.sin(lat1) * Math.sin(lat2),
+    );
+  return { lat: (lat2 * 180) / Math.PI, lon: (lon2 * 180) / Math.PI };
+}

--- a/projects/monolith/frontend/src/lib/public/ships/deadReckoning.test.js
+++ b/projects/monolith/frontend/src/lib/public/ships/deadReckoning.test.js
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import { deadReckon } from "./deadReckoning.js";
+
+// One nautical mile per minute at 60 knots; at 10 knots over 60s a vessel
+// covers 10 kn * 0.514444 m/s/kn * 60 s ~= 308.7 m.
+const EXPECTED_M = 10 * 0.514444 * 60;
+
+// Meters per degree of longitude at the equator (cos(0) = 1).
+const M_PER_DEG_LON = (6371000 * Math.PI) / 180;
+
+describe("deadReckon", () => {
+  it("moves ~309 m due east on heading 090 at 10 kn for 60 s", () => {
+    const start = { lat: 0, lon: 0, speed: 10, course: 90 };
+    const next = deadReckon(start, 60);
+
+    // Latitude is essentially unchanged on a due-east heading.
+    expect(Math.abs(next.lat)).toBeLessThan(1e-6);
+    // Longitude increases (moving east).
+    expect(next.lon).toBeGreaterThan(0);
+
+    const movedM = next.lon * M_PER_DEG_LON;
+    expect(movedM).toBeGreaterThan(305);
+    expect(movedM).toBeLessThan(312);
+    expect(Math.abs(movedM - EXPECTED_M)).toBeLessThan(2);
+  });
+
+  it("returns the same point when speed is 0", () => {
+    const start = { lat: 51.5, lon: -0.12, speed: 0, course: 180 };
+    expect(deadReckon(start, 120)).toEqual({ lat: 51.5, lon: -0.12 });
+  });
+
+  it("returns the same point when speed is missing", () => {
+    const start = { lat: 51.5, lon: -0.12, course: 180 };
+    expect(deadReckon(start, 120)).toEqual({ lat: 51.5, lon: -0.12 });
+  });
+
+  it("treats an undefined course as 0 (due north)", () => {
+    const start = { lat: 0, lon: 0, speed: 10 };
+    const next = deadReckon(start, 60);
+
+    // Course defaults to 0 deg = north: latitude increases, longitude steady.
+    expect(next.lat).toBeGreaterThan(0);
+    expect(Math.abs(next.lon)).toBeLessThan(1e-6);
+
+    const movedM = (next.lat * Math.PI * 6371000) / 180;
+    expect(Math.abs(movedM - EXPECTED_M)).toBeLessThan(2);
+  });
+});

--- a/projects/monolith/frontend/src/routes/public/app/ships/+page.js
+++ b/projects/monolith/frontend/src/routes/public/app/ships/+page.js
@@ -1,0 +1,5 @@
+// MapLibre needs window/WebGL, so render the page client-side only. The
+// +page.server.js load still runs server-side regardless, so the snapshot
+// data stays SSR-sourced (the browser never touches /api/ships/*). Same
+// pattern as /notes.
+export const ssr = false;

--- a/projects/monolith/frontend/src/routes/public/app/ships/+page.server.js
+++ b/projects/monolith/frontend/src/routes/public/app/ships/+page.server.js
@@ -1,0 +1,30 @@
+import { error } from "@sveltejs/kit";
+// Relative (not $lib): vitest loads this module directly and its plain node
+// config does not resolve the SvelteKit $lib alias. ships is one level deeper
+// than /notes, hence four ../ segments. Mirrors how notes/+page.server.js
+// reaches the same file.
+import { SHIPS_SNAPSHOT_CACHE_CONTROL } from "../../../../lib/cache-headers.js";
+
+const API_BASE = process.env.API_BASE || "http://localhost:8000";
+
+// SSR-only: the browser never calls /api/ships/* directly (that surface is not
+// exposed publicly). This load runs server-side in the same pod and the CDN
+// fans the result out to viewers. Live updates come from re-running this load
+// on a ~120s timer (invalidateAll) in the page, not from a client-side poll.
+export async function load({ fetch, setHeaders }) {
+  const res = await fetch(`${API_BASE}/api/ships/snapshot`, {
+    signal: AbortSignal.timeout(10_000),
+  });
+  if (!res.ok) {
+    throw error(503, "ships snapshot unavailable");
+  }
+
+  const headers = { "cache-control": SHIPS_SNAPSHOT_CACHE_CONTROL };
+  const etag = res.headers?.get?.("etag");
+  if (etag) headers.etag = etag;
+  const lastModified = res.headers?.get?.("last-modified");
+  if (lastModified) headers["last-modified"] = lastModified;
+  setHeaders(headers);
+
+  return { snapshot: await res.json() };
+}

--- a/projects/monolith/frontend/src/routes/public/app/ships/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/ships/+page.svelte
@@ -1,0 +1,147 @@
+<script>
+  import { onMount } from "svelte";
+  import { invalidateAll } from "$app/navigation";
+  import ShipsMap from "$lib/public/components/ships/ShipsMap.svelte";
+
+  let { data } = $props();
+
+  let vessels = $derived(data.snapshot?.vessels ?? []);
+  let count = $derived(data.snapshot?.count ?? vessels.length);
+
+  // "updated Ns ago": reset the clock each time a fresh snapshot lands, then
+  // tick a counter so the chip reads live without re-running the load.
+  let lastUpdated = $state(Date.now());
+  let secondsAgo = $state(0);
+
+  // data is a fresh object on every invalidateAll, so referencing it here
+  // re-runs the effect when the server load returns new vessels.
+  $effect(() => {
+    void data.snapshot;
+    lastUpdated = Date.now();
+    secondsAgo = 0;
+  });
+
+  onMount(() => {
+    // Live updates: re-run the SSR load on a timer. The browser hits the same
+    // page route, which re-fetches the snapshot server-side. No client-side
+    // call to /api/ships/* ever happens.
+    const refresh = setInterval(() => invalidateAll(), 120_000);
+    const tick = setInterval(() => {
+      secondsAgo = Math.round((Date.now() - lastUpdated) / 1000);
+    }, 1000);
+    return () => {
+      clearInterval(refresh);
+      clearInterval(tick);
+    };
+  });
+</script>
+
+<svelte:head>
+  <title>Live ships, AIS vessel tracker</title>
+  <meta
+    name="description"
+    content="A live map of vessel positions from AIS, with client-side dead reckoning between snapshots."
+  />
+</svelte:head>
+
+<div class="ships-page">
+  <header class="ships-head wrap">
+    <div class="ships-head-text">
+      <p class="eyebrow">Live AIS</p>
+      <h1 class="ships-title display">Ships</h1>
+      <p class="ships-sub">
+        Vessel positions, dead-reckoned between two-minute snapshots.
+      </p>
+    </div>
+    <div class="ships-status" aria-live="polite">
+      <span class="ships-dot" aria-hidden="true"></span>
+      <span class="ships-status-label">
+        {count} vessels &middot; updated {secondsAgo}s ago
+      </span>
+    </div>
+  </header>
+
+  <div class="ships-stage">
+    <ShipsMap {vessels} />
+  </div>
+</div>
+
+<style>
+  .ships-page {
+    display: flex;
+    flex-direction: column;
+    height: calc(100vh - 48px);
+    background: var(--cream);
+    color: var(--ink);
+  }
+
+  .ships-head {
+    display: flex;
+    align-items: flex-end;
+    justify-content: space-between;
+    gap: 24px;
+    padding-top: 24px;
+    padding-bottom: 20px;
+    flex-wrap: wrap;
+  }
+
+  .ships-title {
+    font-size: clamp(40px, 7vw, 72px);
+    margin: 4px 0 6px;
+  }
+
+  .ships-sub {
+    font-family: var(--mono);
+    font-size: 13px;
+    color: var(--ink-3);
+    letter-spacing: 0.02em;
+  }
+
+  .ships-status {
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+    padding: 10px 14px;
+    background: var(--paper);
+    border: 2px solid var(--ink);
+    box-shadow: var(--shadow-hard-sm);
+    font-family: var(--mono);
+    font-size: 12px;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    white-space: nowrap;
+  }
+
+  .ships-dot {
+    width: 10px;
+    height: 10px;
+    border-radius: 999px;
+    background: var(--green);
+    border: 1px solid var(--ink);
+    animation: ships-pulse 1.6s ease-in-out infinite;
+  }
+
+  @keyframes ships-pulse {
+    0%,
+    100% {
+      opacity: 1;
+    }
+    50% {
+      opacity: 0.35;
+    }
+  }
+
+  .ships-stage {
+    flex: 1;
+    position: relative;
+    min-height: 0;
+    border-top: 2px solid var(--ink);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .ships-dot {
+      animation: none;
+    }
+  }
+</style>

--- a/projects/monolith/frontend/src/routes/public/app/ships/page.server.test.js
+++ b/projects/monolith/frontend/src/routes/public/app/ships/page.server.test.js
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi } from "vitest";
+import { load } from "./+page.server.js";
+import { SHIPS_SNAPSHOT_CACHE_CONTROL } from "../../../../lib/cache-headers.js";
+
+function makeHeaders(map = {}) {
+  const lower = Object.fromEntries(
+    Object.entries(map).map(([k, v]) => [k.toLowerCase(), v]),
+  );
+  return { get: (name) => lower[name.toLowerCase()] ?? null };
+}
+
+const SNAPSHOT = { count: 0, vessels: [] };
+
+describe("/public/app/ships load", () => {
+  it("hits the SSR-only ships snapshot endpoint", async () => {
+    const setHeaders = vi.fn();
+    const fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      headers: makeHeaders(),
+      json: async () => SNAPSHOT,
+    });
+
+    await load({ fetch, setHeaders });
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    const url = fetch.mock.calls[0][0];
+    expect(url).toMatch(/\/api\/ships\/snapshot$/);
+  });
+
+  it("sets the shared snapshot cache-control header", async () => {
+    const setHeaders = vi.fn();
+    const fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      headers: makeHeaders(),
+      json: async () => SNAPSHOT,
+    });
+
+    const result = await load({ fetch, setHeaders });
+
+    expect(setHeaders).toHaveBeenCalledWith(
+      expect.objectContaining({
+        "cache-control": SHIPS_SNAPSHOT_CACHE_CONTROL,
+      }),
+    );
+    // Byte-for-byte mirror of _SNAPSHOT_CACHE_CONTROL in ships/router.py.
+    expect(SHIPS_SNAPSHOT_CACHE_CONTROL).toBe(
+      "public, s-maxage=120, stale-while-revalidate=600, stale-if-error=86400",
+    );
+    expect(result.snapshot).toEqual(SNAPSHOT);
+  });
+
+  it("forwards ETag and Last-Modified from the API response", async () => {
+    const setHeaders = vi.fn();
+    const fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      headers: makeHeaders({
+        ETag: '"2026-06-10T00:00:00+00:00-3"',
+        "Last-Modified": "Wed, 10 Jun 2026 00:00:00 GMT",
+      }),
+      json: async () => SNAPSHOT,
+    });
+
+    await load({ fetch, setHeaders });
+
+    expect(setHeaders).toHaveBeenCalledWith(
+      expect.objectContaining({
+        etag: '"2026-06-10T00:00:00+00:00-3"',
+        "last-modified": "Wed, 10 Jun 2026 00:00:00 GMT",
+      }),
+    );
+  });
+
+  it("omits ETag and Last-Modified when the API does not return them", async () => {
+    const setHeaders = vi.fn();
+    const fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      headers: makeHeaders(),
+      json: async () => SNAPSHOT,
+    });
+
+    await load({ fetch, setHeaders });
+
+    const headers = setHeaders.mock.calls[0][0];
+    expect(headers).not.toHaveProperty("etag");
+    expect(headers).not.toHaveProperty("last-modified");
+  });
+
+  it("throws a 503 when the backend fetch fails", async () => {
+    const setHeaders = vi.fn();
+    const fetch = vi.fn().mockResolvedValue({ ok: false, status: 502 });
+
+    await expect(load({ fetch, setHeaders })).rejects.toThrow();
+  });
+});

--- a/projects/monolith/frontend/src/routes/public/app/ships/track/[mmsi]/+server.js
+++ b/projects/monolith/frontend/src/routes/public/app/ships/track/[mmsi]/+server.js
@@ -1,0 +1,21 @@
+import { error, json } from "@sveltejs/kit";
+import { SHIPS_TRACK_CACHE_CONTROL } from "$lib/cache-headers.js";
+
+const API_BASE = process.env.API_BASE || "http://localhost:8000";
+
+// Same-origin proxy for one vessel's track history. The map calls this site
+// route (/app/ships/track/{mmsi}) on marker click; the fetch to /api/ships/*
+// happens server-side here, keeping that private surface off the browser.
+export async function GET({ params, fetch }) {
+  const res = await fetch(
+    `${API_BASE}/api/ships/track/${encodeURIComponent(params.mmsi)}`,
+    { signal: AbortSignal.timeout(10_000) },
+  );
+  if (!res.ok) {
+    throw error(503, "ship track unavailable");
+  }
+
+  return json(await res.json(), {
+    headers: { "cache-control": SHIPS_TRACK_CACHE_CONTROL },
+  });
+}

--- a/projects/monolith/ships/__init__.py
+++ b/projects/monolith/ships/__init__.py
@@ -1,0 +1,25 @@
+"""Ships: in-monolith AIS vessel tracking (migrated from the standalone marine app)."""
+
+from fastapi import FastAPI
+from sqlmodel import Session
+
+
+def register(app: FastAPI) -> None:
+    """Register ships routers with the app."""
+    from ships.router import router
+
+    app.include_router(router)
+
+
+def on_startup_jobs(session: Session) -> None:
+    """Register ships scheduled jobs (partition maintenance / retention)."""
+    from shared.scheduler import register_job
+    from ships.retention import partition_maintenance_handler
+
+    register_job(
+        session,
+        name="ships.partition_maintenance",
+        interval_secs=86400,
+        handler=partition_maintenance_handler,
+        ttl_secs=3600,
+    )

--- a/projects/monolith/ships/ais.py
+++ b/projects/monolith/ships/ais.py
@@ -1,0 +1,306 @@
+"""Pure AIS logic: message parsing, deduplication, moored detection, haversine.
+
+Ported from the standalone marine app (projects/ships/ingest/main.py and
+projects/ships/backend/main.py). This module is intentionally side-effect free:
+no database, no network, no FastAPI. The stateless persister calls
+should_insert_position with the prior position it read back from Postgres, so
+deduplication stays pure (the prior position is passed in, never cached here).
+"""
+
+import json
+import logging
+import math
+import os
+import re
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+
+logger = logging.getLogger("ships")
+
+# Deduplication settings (read from env, same names/defaults as the old backend).
+# Skip a position if within this distance (meters) and speed below threshold.
+DEDUP_DISTANCE_METERS = float(os.getenv("DEDUP_DISTANCE_METERS", "100"))
+DEDUP_SPEED_THRESHOLD = float(os.getenv("DEDUP_SPEED_THRESHOLD", "0.5"))  # knots
+DEDUP_TIME_THRESHOLD = int(os.getenv("DEDUP_TIME_THRESHOLD", "300"))  # seconds
+
+# Moored detection settings.
+MOORED_RADIUS_METERS = float(os.getenv("MOORED_RADIUS_METERS", "500"))
+MOORED_MIN_DURATION_HOURS = float(os.getenv("MOORED_MIN_DURATION_HOURS", "1"))
+
+# AISStream sends time_utc in a Go-style layout, e.g.
+# "2024-01-15 10:00:00.000000000 +0000 UTC". ISO 8601 (the shape used in tests
+# and most upstreams) is tried first; this regex handles the Go fallback.
+_AIS_TIME_RE = re.compile(
+    r"^(?P<base>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})"
+    r"(?P<frac>\.\d+)?\s+(?P<offset>[+-]\d{4})(?:\s+\w+)?$"
+)
+
+
+def haversine_distance(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
+    """Calculate distance between two points in meters using Haversine formula."""
+    R = 6371000  # Earth's radius in meters
+
+    phi1 = math.radians(lat1)
+    phi2 = math.radians(lat2)
+    delta_phi = math.radians(lat2 - lat1)
+    delta_lambda = math.radians(lon2 - lon1)
+
+    a = (
+        math.sin(delta_phi / 2) ** 2
+        + math.cos(phi1) * math.cos(phi2) * math.sin(delta_lambda / 2) ** 2
+    )
+    c = 2 * math.atan2(math.sqrt(a), math.sqrt(1 - a))
+
+    return R * c
+
+
+@dataclass(frozen=True)
+class PriorPosition:
+    """Immutable snapshot of a vessel's prior position.
+
+    The persister builds this from a latest_positions row before calling
+    should_insert_position. All timestamps are tz-aware datetimes.
+    """
+
+    lat: float
+    lon: float
+    speed: float | None
+    recorded_at: datetime
+    first_seen_at_location: datetime | None
+
+
+def should_insert_position(
+    data: dict, last: PriorPosition | None
+) -> tuple[bool, datetime | None]:
+    """Decide whether a position should be inserted (deduplication logic).
+
+    Pure: the prior position is passed in as last (None means first sighting),
+    not read from any cache. Returns (should_insert, first_seen_at_location).
+
+    Ported from projects/ships/backend/main.py should_insert_position. The only
+    behavioural change: timestamps are tz-aware datetimes (data["recorded_at"]
+    and last.recorded_at) instead of ISO strings, so no fromisoformat parsing.
+    """
+    mmsi = data.get("mmsi")
+    if not mmsi:
+        return False, None
+
+    lat = data.get("lat", 0)
+    lon = data.get("lon", 0)
+    recorded_at = data.get("recorded_at")
+
+    if last is None:
+        return True, recorded_at  # First position for this vessel
+
+    # Always insert if speed is above threshold (vessel is moving).
+    speed = data.get("speed") or 0
+    if speed > DEDUP_SPEED_THRESHOLD:
+        # Check if moved significantly to reset first_seen.
+        distance = haversine_distance(last.lat, last.lon, lat, lon)
+        first_seen = (
+            last.first_seen_at_location
+            if distance <= MOORED_RADIUS_METERS
+            else recorded_at
+        )
+        return True, first_seen
+
+    # Calculate distance from last position.
+    distance = haversine_distance(last.lat, last.lon, lat, lon)
+
+    # Insert if moved more than threshold.
+    if distance > DEDUP_DISTANCE_METERS:
+        first_seen = (
+            last.first_seen_at_location
+            if distance <= MOORED_RADIUS_METERS
+            else recorded_at
+        )
+        return True, first_seen
+
+    # Check time since last update.
+    try:
+        time_diff = (recorded_at - last.recorded_at).total_seconds()
+
+        # Insert if enough time has passed (even for stationary vessels).
+        if time_diff > DEDUP_TIME_THRESHOLD:
+            # Still in same area, keep original first_seen.
+            return True, last.first_seen_at_location or recorded_at
+    except (ValueError, TypeError, AttributeError):
+        return True, recorded_at  # Insert if timestamp arithmetic fails
+
+    return False, None
+
+
+def parse_eta(eta: dict | None) -> datetime | None:
+    """Convert an AISStream ETA dict to a tz-aware datetime.
+
+    AIS ETA (per ITU-R M.1371-5) has no year, only Month, Day, Hour, Minute.
+    Unavailable values: Month=0, Day=0, Hour=24, Minute=60.
+
+    We infer the year: if the date is in the past, assume next year.
+
+    Ported from projects/ships/ingest/main.py format_eta, returning a datetime
+    instead of an ISO string (the Vessel.eta column is a datetime).
+    """
+    if not eta or not isinstance(eta, dict):
+        return None
+
+    month = eta.get("Month", 0)
+    day = eta.get("Day", 0)
+    hour = eta.get("Hour", 24)
+    minute = eta.get("Minute", 60)
+
+    # Month=0 or Day=0 means unavailable.
+    if month == 0 or day == 0:
+        return None
+
+    # Hour=24 or Minute=60 means unavailable, default to 00:00.
+    if hour == 24:
+        hour = 0
+    if minute == 60:
+        minute = 0
+
+    # Infer year: if date is in the past, use next year.
+    now = datetime.now(timezone.utc)
+    year = now.year
+
+    try:
+        eta_dt = datetime(year, month, day, hour, minute, tzinfo=timezone.utc)
+        if eta_dt < now:
+            eta_dt = datetime(year + 1, month, day, hour, minute, tzinfo=timezone.utc)
+        return eta_dt
+    except (ValueError, TypeError):
+        # Invalid date (e.g. Feb 30) or non-numeric field.
+        return None
+
+
+def _parse_ais_time(value: object) -> datetime | None:
+    """Parse an AISStream time_utc value into a tz-aware datetime, or None.
+
+    Tolerant: returns None on missing/invalid input rather than raising.
+    """
+    if not isinstance(value, str) or not value.strip():
+        return None
+    text = value.strip()
+
+    # ISO 8601 (e.g. "2024-01-15T10:00:00Z"), the shape used by test fixtures.
+    try:
+        return datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError:
+        pass
+
+    # AISStream Go-style layout (e.g. "2024-01-15 10:00:00.000000000 +0000 UTC").
+    match = _AIS_TIME_RE.match(text)
+    if not match:
+        return None
+    base = match.group("base")
+    frac = match.group("frac")
+    offset = match.group("offset")
+    try:
+        sign = -1 if offset[0] == "-" else 1
+        tz = timezone(
+            sign * timedelta(hours=int(offset[1:3]), minutes=int(offset[3:5]))
+        )
+        micros = int(round(float(frac) * 1_000_000)) if frac else 0
+        return datetime.strptime(base, "%Y-%m-%d %H:%M:%S").replace(
+            microsecond=micros, tzinfo=tz
+        )
+    except (ValueError, TypeError):
+        return None
+
+
+def _parse_position(
+    message: dict, mmsi: str, metadata: dict
+) -> tuple[str, dict] | tuple[None, None]:
+    """Build a position dict from a PositionReport message."""
+    position = (message.get("Message") or {}).get("PositionReport") or {}
+    if not position:
+        return None, None
+
+    lat = position.get("Latitude")
+    lon = position.get("Longitude")
+    # Skip if coordinates are invalid (mirrors the old ingest early return).
+    if lat is None or lon is None:
+        return None, None
+
+    data = {
+        "mmsi": mmsi,
+        "lat": lat,
+        "lon": lon,
+        "speed": position.get("Sog"),  # Speed over ground
+        "course": position.get("Cog"),  # Course over ground
+        "heading": position.get("TrueHeading"),
+        "nav_status": position.get("NavigationalStatus"),
+        "ship_name": (metadata.get("ShipName") or "").strip(),
+        "recorded_at": _parse_ais_time(metadata.get("time_utc")),
+    }
+    return "position", data
+
+
+def _parse_vessel(
+    message: dict, mmsi: str, metadata: dict
+) -> tuple[str, dict] | tuple[None, None]:
+    """Build a vessel dict from a ShipStaticData message."""
+    static = (message.get("Message") or {}).get("ShipStaticData") or {}
+    if not static:
+        return None, None
+
+    # Dimensions: A=bow, B=stern, C=port, D=starboard to reference point.
+    dimension = static.get("Dimension") or {}
+    imo = static.get("ImoNumber")
+
+    data = {
+        "mmsi": mmsi,
+        # The Vessel.imo column is a string; AISStream sends an int.
+        "imo": str(imo) if imo is not None else None,
+        "call_sign": (static.get("CallSign") or "").strip(),
+        "name": (static.get("Name") or "").strip()
+        or (metadata.get("ShipName") or "").strip(),
+        "ship_type": static.get("Type"),
+        "dimension_a": dimension.get("A"),
+        "dimension_b": dimension.get("B"),
+        "dimension_c": dimension.get("C"),
+        "dimension_d": dimension.get("D"),
+        "destination": (static.get("Destination") or "").strip(),
+        "eta": parse_eta(static.get("Eta")),
+        "draught": static.get("MaximumStaticDraught"),
+    }
+    return "vessel", data
+
+
+def parse_message(raw: str | bytes) -> tuple[str, dict] | tuple[None, None]:
+    """Parse a raw AISStream JSON message.
+
+    Returns ("position", {...}) for a PositionReport, ("vessel", {...}) for a
+    ShipStaticData, or (None, None) for any other type, missing MMSI, or parse
+    failure. Tolerant: invalid input never raises.
+
+    Combines the parsing in projects/ships/ingest/main.py (process_message,
+    _process_position_report, _process_static_data) with the position/vessel
+    routing the old backend did by NATS subject. The output dict keys line up
+    with the ships.models columns so the persister can insert them directly.
+    """
+    try:
+        message = json.loads(raw)
+    except (json.JSONDecodeError, TypeError, ValueError):
+        return None, None
+    if not isinstance(message, dict):
+        return None, None
+
+    metadata = message.get("MetaData")
+    if not isinstance(metadata, dict):
+        return None, None
+
+    mmsi = str(metadata.get("MMSI", ""))
+    if not mmsi:
+        return None, None
+
+    msg_type = message.get("MessageType")
+    try:
+        if msg_type == "PositionReport":
+            return _parse_position(message, mmsi, metadata)
+        if msg_type == "ShipStaticData":
+            return _parse_vessel(message, mmsi, metadata)
+    except (AttributeError, TypeError, ValueError):
+        return None, None
+
+    return None, None

--- a/projects/monolith/ships/ais_test.py
+++ b/projects/monolith/ships/ais_test.py
@@ -1,0 +1,375 @@
+"""Unit tests for ships.ais: haversine, deduplication, ETA, message parsing.
+
+Ported from the standalone marine app tests:
+- projects/ships/backend/tests/unit_test.py (haversine, should_insert_position)
+- projects/ships/ingest/ais_parsing_test.py (message parsing, ETA)
+
+These exercise pure logic only (no DB, no network). The deduplication function
+takes the prior position as an argument, so tests build PriorPosition directly.
+"""
+
+import json
+import math
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from ships.ais import (
+    PriorPosition,
+    haversine_distance,
+    parse_eta,
+    parse_message,
+    should_insert_position,
+)
+
+UTC = timezone.utc
+
+
+# ---------------------------------------------------------------------------
+# haversine_distance
+# ---------------------------------------------------------------------------
+
+
+class TestHaversineDistance:
+    def test_same_point_is_zero(self):
+        assert haversine_distance(0.0, 0.0, 0.0, 0.0) == 0.0
+
+    def test_london_to_paris_approx_343km(self):
+        d = haversine_distance(51.5074, -0.1278, 48.8566, 2.3522)
+        assert 330_000 < d < 360_000, f"Expected ~343 km, got {d:.0f} m"
+
+    def test_one_degree_latitude_approx_111km(self):
+        d = haversine_distance(0.0, 0.0, 1.0, 0.0)
+        assert 110_000 < d < 112_000, f"Expected ~111 km, got {d:.0f} m"
+
+    def test_short_distance_about_111m(self):
+        # 0.001 degree of latitude is roughly 111 m.
+        d = haversine_distance(0.0, 0.0, 0.001, 0.0)
+        assert 100 < d < 125
+
+    def test_return_type_is_float(self):
+        assert isinstance(haversine_distance(0.0, 0.0, 1.0, 1.0), float)
+
+    def test_uses_earth_radius_6371km(self):
+        d = haversine_distance(0.0, 0.0, 90.0, 0.0)
+        expected = math.pi / 2 * 6_371_000
+        assert abs(d - expected) < 1000
+
+
+# ---------------------------------------------------------------------------
+# should_insert_position (pure dedup ladder)
+# ---------------------------------------------------------------------------
+
+
+class TestShouldInsertPosition:
+    BASE = datetime(2024, 1, 1, 10, 0, 0, tzinfo=UTC)
+
+    def _prior(self, lat, lon, speed=0.0, recorded_at=None, first_seen=None):
+        ts = recorded_at or self.BASE
+        return PriorPosition(
+            lat=lat,
+            lon=lon,
+            speed=speed,
+            recorded_at=ts,
+            first_seen_at_location=first_seen or ts,
+        )
+
+    def test_no_mmsi_returns_false(self):
+        ok, fs = should_insert_position({"lat": 0.0, "lon": 0.0}, None)
+        assert ok is False
+        assert fs is None
+
+    def test_empty_mmsi_returns_false(self):
+        ok, _ = should_insert_position({"mmsi": "", "lat": 0.0, "lon": 0.0}, None)
+        assert ok is False
+
+    def test_first_position_always_inserted(self):
+        recorded = self.BASE
+        data = {
+            "mmsi": "123456789",
+            "lat": 51.5,
+            "lon": -0.1,
+            "speed": 0.0,
+            "recorded_at": recorded,
+        }
+        ok, fs = should_insert_position(data, None)
+        assert ok is True
+        assert fs == recorded
+
+    def test_moving_vessel_always_inserted(self):
+        """Speed > 0.5 knots always inserts."""
+        last = self._prior(51.5, -0.1, speed=0.0)
+        data = {
+            "mmsi": "123",
+            "lat": 51.5001,
+            "lon": -0.1,
+            "speed": 5.0,
+            "recorded_at": self.BASE + timedelta(minutes=1),
+        }
+        ok, _ = should_insert_position(data, last)
+        assert ok is True
+
+    def test_stationary_same_spot_within_time_threshold_skipped(self):
+        """Stationary, same spot, < 300 s elapsed: skip."""
+        last = self._prior(51.5, -0.1, speed=0.0, recorded_at=self.BASE)
+        data = {
+            "mmsi": "123",
+            "lat": 51.5,
+            "lon": -0.1,
+            "speed": 0.0,
+            "recorded_at": self.BASE + timedelta(seconds=60),
+        }
+        ok, fs = should_insert_position(data, last)
+        assert ok is False
+        assert fs is None
+
+    def test_stationary_same_spot_beyond_time_threshold_inserts_preserving_first_seen(
+        self,
+    ):
+        """Stationary, same spot, > 300 s elapsed: insert and keep first_seen."""
+        first_seen = datetime(2024, 1, 1, 8, 0, 0, tzinfo=UTC)
+        last = self._prior(
+            51.5, -0.1, speed=0.0, recorded_at=self.BASE, first_seen=first_seen
+        )
+        data = {
+            "mmsi": "123",
+            "lat": 51.5,
+            "lon": -0.1,
+            "speed": 0.0,
+            "recorded_at": self.BASE + timedelta(seconds=360),
+        }
+        ok, fs = should_insert_position(data, last)
+        assert ok is True
+        assert fs == first_seen
+
+    def test_moved_beyond_distance_within_moored_radius_preserves_first_seen(self):
+        """Moved > 100 m but within the 500 m moored radius: keep first_seen."""
+        first_seen = datetime(2024, 1, 1, 8, 0, 0, tzinfo=UTC)
+        last = self._prior(
+            51.5, -0.1, speed=0.0, recorded_at=self.BASE, first_seen=first_seen
+        )
+        # ~200 m north (0.0018 deg lat), still inside 500 m radius.
+        data = {
+            "mmsi": "123",
+            "lat": 51.5018,
+            "lon": -0.1,
+            "speed": 0.0,
+            "recorded_at": self.BASE + timedelta(seconds=60),
+        }
+        ok, fs = should_insert_position(data, last)
+        assert ok is True
+        assert fs == first_seen
+
+    def test_moved_beyond_moored_radius_resets_first_seen(self):
+        """Moved beyond the 500 m moored radius: reset first_seen to current time."""
+        first_seen = datetime(2024, 1, 1, 8, 0, 0, tzinfo=UTC)
+        last = self._prior(
+            51.5, -0.1, speed=0.0, recorded_at=self.BASE, first_seen=first_seen
+        )
+        recorded = self.BASE + timedelta(minutes=1)
+        # ~1.1 km north (0.01 deg lat), well beyond 500 m.
+        data = {
+            "mmsi": "123",
+            "lat": 51.51,
+            "lon": -0.1,
+            "speed": 0.0,
+            "recorded_at": recorded,
+        }
+        ok, fs = should_insert_position(data, last)
+        assert ok is True
+        assert fs == recorded
+
+    def test_none_speed_treated_as_zero(self):
+        last = self._prior(51.5, -0.1, speed=None, recorded_at=self.BASE)
+        data = {
+            "mmsi": "123",
+            "lat": 51.5,
+            "lon": -0.1,
+            "speed": None,
+            "recorded_at": self.BASE + timedelta(seconds=60),
+        }
+        ok, _ = should_insert_position(data, last)
+        # Within 100 m and 60 s: deduplicated.
+        assert ok is False
+
+
+# ---------------------------------------------------------------------------
+# parse_eta
+# ---------------------------------------------------------------------------
+
+
+class TestParseEta:
+    def test_valid_future_eta_returns_datetime(self):
+        # Pick a date guaranteed to be in the future this year (or next).
+        eta = parse_eta({"Month": 12, "Day": 31, "Hour": 23, "Minute": 59})
+        assert isinstance(eta, datetime)
+        assert eta.tzinfo is not None
+        assert eta.month == 12
+        assert eta.day == 31
+        assert eta.hour == 23
+        assert eta.minute == 59
+
+    def test_unavailable_month_returns_none(self):
+        assert parse_eta({"Month": 0, "Day": 1, "Hour": 12, "Minute": 0}) is None
+
+    def test_unavailable_day_returns_none(self):
+        assert parse_eta({"Month": 1, "Day": 0, "Hour": 12, "Minute": 0}) is None
+
+    def test_hour_24_minute_60_default_to_midnight(self):
+        eta = parse_eta({"Month": 6, "Day": 15, "Hour": 24, "Minute": 60})
+        assert eta is not None
+        assert eta.hour == 0
+        assert eta.minute == 0
+
+    def test_none_input_returns_none(self):
+        assert parse_eta(None) is None
+
+    def test_invalid_calendar_date_returns_none(self):
+        # February 30 does not exist.
+        assert parse_eta({"Month": 2, "Day": 30, "Hour": 12, "Minute": 0}) is None
+
+
+# ---------------------------------------------------------------------------
+# parse_message
+# ---------------------------------------------------------------------------
+
+
+class TestParseMessage:
+    def _position_message(self):
+        return json.dumps(
+            {
+                "MessageType": "PositionReport",
+                "MetaData": {
+                    "MMSI": "123456789",
+                    "time_utc": "2024-01-15T10:00:00Z",
+                    "ShipName": "  STAR VANCOUVER  ",
+                },
+                "Message": {
+                    "PositionReport": {
+                        "Latitude": 48.5,
+                        "Longitude": -123.4,
+                        "Sog": 10.0,
+                        "Cog": 180.0,
+                        "TrueHeading": 179,
+                        "NavigationalStatus": 0,
+                    }
+                },
+            }
+        )
+
+    def _static_message(self):
+        return json.dumps(
+            {
+                "MessageType": "ShipStaticData",
+                "MetaData": {
+                    "MMSI": "987654321",
+                    "time_utc": "2024-01-15T10:00:00Z",
+                    "ShipName": "FALLBACK",
+                },
+                "Message": {
+                    "ShipStaticData": {
+                        "ImoNumber": 9074729,
+                        "CallSign": "  ABCD  ",
+                        "Name": "  EVER GIVEN  ",
+                        "Type": 70,
+                        "Dimension": {"A": 200, "B": 100, "C": 20, "D": 30},
+                        "Destination": "  ROTTERDAM  ",
+                        "Eta": {"Month": 12, "Day": 31, "Hour": 12, "Minute": 0},
+                        "MaximumStaticDraught": 14.5,
+                    }
+                },
+            }
+        )
+
+    def test_position_report_parses_to_position_tuple(self):
+        kind, data = parse_message(self._position_message())
+        assert kind == "position"
+        assert data["mmsi"] == "123456789"
+        assert data["lat"] == 48.5
+        assert data["lon"] == -123.4
+        assert data["speed"] == 10.0
+        assert data["course"] == 180.0
+        assert data["heading"] == 179
+        assert data["nav_status"] == 0
+        # ShipName whitespace is stripped.
+        assert data["ship_name"] == "STAR VANCOUVER"
+
+    def test_position_recorded_at_is_tz_aware_datetime(self):
+        _, data = parse_message(self._position_message())
+        assert isinstance(data["recorded_at"], datetime)
+        assert data["recorded_at"].tzinfo is not None
+        assert data["recorded_at"] == datetime(2024, 1, 15, 10, 0, 0, tzinfo=UTC)
+
+    def test_position_accepts_bytes_input(self):
+        kind, data = parse_message(self._position_message().encode())
+        assert kind == "position"
+        assert data["mmsi"] == "123456789"
+
+    def test_position_missing_coordinates_returns_none(self):
+        raw = json.dumps(
+            {
+                "MessageType": "PositionReport",
+                "MetaData": {"MMSI": "123", "time_utc": "2024-01-15T10:00:00Z"},
+                "Message": {"PositionReport": {"Sog": 5.0}},
+            }
+        )
+        assert parse_message(raw) == (None, None)
+
+    def test_static_data_parses_to_vessel_tuple(self):
+        kind, data = parse_message(self._static_message())
+        assert kind == "vessel"
+        assert data["mmsi"] == "987654321"
+        # ImoNumber (int) is normalised to a string for the Vessel.imo column.
+        assert data["imo"] == "9074729"
+        assert data["call_sign"] == "ABCD"
+        assert data["name"] == "EVER GIVEN"
+        assert data["ship_type"] == 70
+        assert data["dimension_a"] == 200
+        assert data["dimension_d"] == 30
+        assert data["destination"] == "ROTTERDAM"
+        assert data["draught"] == 14.5
+
+    def test_static_data_eta_is_datetime(self):
+        _, data = parse_message(self._static_message())
+        assert isinstance(data["eta"], datetime)
+        assert data["eta"].month == 12
+        assert data["eta"].day == 31
+
+    def test_static_data_name_falls_back_to_metadata_ship_name(self):
+        raw = json.dumps(
+            {
+                "MessageType": "ShipStaticData",
+                "MetaData": {"MMSI": "111", "ShipName": "META NAME"},
+                "Message": {"ShipStaticData": {"Name": "   ", "Type": 70}},
+            }
+        )
+        kind, data = parse_message(raw)
+        assert kind == "vessel"
+        assert data["name"] == "META NAME"
+
+    def test_unknown_message_type_returns_none(self):
+        raw = json.dumps(
+            {
+                "MessageType": "SomethingElse",
+                "MetaData": {"MMSI": "123"},
+                "Message": {},
+            }
+        )
+        assert parse_message(raw) == (None, None)
+
+    def test_missing_mmsi_returns_none(self):
+        raw = json.dumps(
+            {
+                "MessageType": "PositionReport",
+                "MetaData": {"time_utc": "2024-01-15T10:00:00Z"},
+                "Message": {"PositionReport": {"Latitude": 1.0, "Longitude": 2.0}},
+            }
+        )
+        assert parse_message(raw) == (None, None)
+
+    def test_malformed_json_returns_none(self):
+        assert parse_message("{bad json}") == (None, None)
+        assert parse_message(b"") == (None, None)
+
+    def test_non_object_json_returns_none(self):
+        assert parse_message("[1, 2, 3]") == (None, None)

--- a/projects/monolith/ships/ingest.py
+++ b/projects/monolith/ships/ingest.py
@@ -1,0 +1,137 @@
+"""Supervised AISStream ingest background task.
+
+The only always-on networked component of the ships module. Holds a websocket
+to AISStream.io, parses each message via ships.ais.parse_message, batches the
+results, and flushes them through the stateless persister (ships.store) straight
+to Postgres. NATS is gone: this writes directly to the database.
+
+Ported from the standalone ingest pod (projects/ships/ingest/main.py,
+subscribe_to_aisstream), folded in-process. It runs inside the monolith's
+FastAPI lifespan and MUST NEVER crash the app: an AISStream hiccup or a parse
+error is swallowed and retried, never propagated. Only asyncio.CancelledError
+(clean shutdown) is allowed through.
+"""
+
+import asyncio
+import json
+import logging
+import os
+import ssl
+import time
+
+from ships.ais import parse_message
+
+logger = logging.getLogger("ships")
+
+# WebSocket reconnection settings (same names/defaults as the old ingest).
+INITIAL_RECONNECT_DELAY = 1.0
+MAX_RECONNECT_DELAY = 60.0
+RECONNECT_BACKOFF_FACTOR = 2.0
+
+# Batching: flush when the batch reaches this many rows, or this many seconds
+# have elapsed since the last flush, whichever comes first.
+FLUSH_SIZE = 200
+FLUSH_SECONDS = 2.0
+
+AISSTREAM_URL_DEFAULT = "wss://stream.aisstream.io/v0/stream"
+# Pacific Northwest coast, copied verbatim from the old ingest BOUNDING_BOX
+# default (projects/ships/ingest/main.py).
+DEFAULT_BOUNDING_BOX = "[[[46.876152, -129.552155], [51.413769, -121.213531]]]"
+
+
+def _now() -> float:
+    """Monotonic clock for the flush timer (never wall-clock)."""
+    return time.monotonic()
+
+
+async def ais_stream_loop(stop: asyncio.Event) -> None:
+    """Supervised AISStream listener. Reconnects forever; never raises out.
+
+    The only exception allowed to propagate is asyncio.CancelledError, so the
+    lifespan can cancel this task cleanly on shutdown. Every other error is
+    logged and retried with exponential backoff. The app can never be crashed
+    by an ingest failure.
+    """
+    import certifi
+    import websockets
+
+    api_key = os.environ.get("AISSTREAM_API_KEY", "")
+    if not api_key:
+        logger.warning("AISSTREAM_API_KEY unset; ships ingest disabled")
+        return
+    url = os.environ.get("AISSTREAM_URL", AISSTREAM_URL_DEFAULT)
+    bbox = os.environ.get("BOUNDING_BOX", DEFAULT_BOUNDING_BOX)
+    # certifi CA bundle: minimal container images ship no system CA store.
+    ssl_ctx = ssl.create_default_context(cafile=certifi.where())
+    delay = INITIAL_RECONNECT_DELAY
+
+    while not stop.is_set():
+        try:
+            logger.info("ships ingest: connecting to AISStream at %s", url)
+            async with websockets.connect(url, ssl=ssl_ctx) as ws:
+                await ws.send(
+                    json.dumps(
+                        {
+                            "APIKey": api_key,
+                            "BoundingBoxes": json.loads(bbox),
+                            "FilterMessageTypes": [
+                                "PositionReport",
+                                "ShipStaticData",
+                            ],
+                        }
+                    )
+                )
+                # Reset backoff once the connection (and subscription) succeed.
+                delay = INITIAL_RECONNECT_DELAY
+                positions: list[dict] = []
+                vessels: list[dict] = []
+                last_flush = _now()
+
+                async for raw in ws:
+                    if stop.is_set():
+                        break
+                    kind, row = parse_message(raw)
+                    if kind == "position":
+                        positions.append(row)
+                    elif kind == "vessel":
+                        vessels.append(row)
+                    if (
+                        len(positions) + len(vessels) >= FLUSH_SIZE
+                        or _now() - last_flush > FLUSH_SECONDS
+                    ):
+                        await asyncio.to_thread(_flush, positions, vessels)
+                        positions, vessels, last_flush = [], [], _now()
+
+                # Flush any remainder on a clean close.
+                if positions or vessels:
+                    await asyncio.to_thread(_flush, positions, vessels)
+        except asyncio.CancelledError:
+            # Let cancellation through for a clean shutdown.
+            raise
+        except Exception:
+            logger.exception("ships ingest: stream error")
+
+        if not stop.is_set():
+            await asyncio.sleep(delay)
+            delay = min(delay * RECONNECT_BACKOFF_FACTOR, MAX_RECONNECT_DELAY)
+
+
+def _flush(positions: list[dict], vessels: list[dict]) -> None:
+    """Synchronous DB write in a worker thread, with a fresh Session.
+
+    Background tasks open their own session; the request-scoped get_session is
+    not available here. A flush failure is logged and swallowed so the ingest
+    loop keeps running.
+    """
+    from sqlmodel import Session
+
+    from app.db import get_engine
+    from ships.store import persist_batch
+
+    if not positions and not vessels:
+        return
+    try:
+        with Session(get_engine()) as session:
+            persist_batch(session, list(positions), list(vessels))
+    except Exception:
+        logger.exception("ships ingest: flush failed")

--- a/projects/monolith/ships/ingest_test.py
+++ b/projects/monolith/ships/ingest_test.py
@@ -1,0 +1,251 @@
+"""Tests for the supervised AISStream ingest loop (ships.ingest).
+
+The ingest loop is the only always-on networked component of the ships module.
+These tests prove it:
+  1. parses messages and flushes the batch (here via the clean-close remainder),
+  2. backs off on reconnect and resets the delay after a success,
+  3. never propagates a loop-body exception (cannot crash the app),
+  4. disables itself (no connect) when AISSTREAM_API_KEY is unset.
+
+Every test sets the stop Event (usually inside a patched asyncio.sleep) so the
+supervised loop always terminates: no test makes a real network call or hangs.
+The websocket-mock approach mirrors projects/ships/ingest/reconnect_cap_test.py.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import ships.ingest as ingest
+from ships.ingest import (
+    INITIAL_RECONNECT_DELAY,
+    RECONNECT_BACKOFF_FACTOR,
+    ais_stream_loop,
+)
+
+
+# ---------------------------------------------------------------------------
+# Websocket mocks
+# ---------------------------------------------------------------------------
+
+
+class _ScriptedWS:
+    """Async-context-manager websocket that yields a fixed list of raw messages."""
+
+    def __init__(self, messages):
+        self._messages = list(messages)
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        return False
+
+    async def send(self, _msg):
+        pass
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if not self._messages:
+            raise StopAsyncIteration
+        return self._messages.pop(0)
+
+
+class _FailOnEnterWS:
+    """Websocket whose connect (__aenter__) always raises a generic error."""
+
+    async def __aenter__(self):
+        raise RuntimeError("connection refused")
+
+    async def __aexit__(self, *args):
+        return False
+
+
+class _RaiseDuringIterWS:
+    """Websocket that raises a generic exception inside the message loop body."""
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        return False
+
+    async def send(self, _msg):
+        pass
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        raise RuntimeError("boom inside the loop")
+
+
+def _position_raw(mmsi: int = 123456789) -> str:
+    return json.dumps(
+        {
+            "MessageType": "PositionReport",
+            "MetaData": {
+                "MMSI": mmsi,
+                "ShipName": "TEST",
+                "time_utc": "2024-01-15T10:00:00Z",
+            },
+            "Message": {
+                "PositionReport": {
+                    "Latitude": 48.0,
+                    "Longitude": -123.0,
+                    "Sog": 5.0,
+                    "Cog": 90.0,
+                    "TrueHeading": 91,
+                    "NavigationalStatus": 0,
+                }
+            },
+        }
+    )
+
+
+def _vessel_raw(mmsi: int = 123456789) -> str:
+    return json.dumps(
+        {
+            "MessageType": "ShipStaticData",
+            "MetaData": {
+                "MMSI": mmsi,
+                "ShipName": "TEST",
+                "time_utc": "2024-01-15T10:00:00Z",
+            },
+            "Message": {
+                "ShipStaticData": {
+                    "Name": "TEST",
+                    "Type": 70,
+                    "ImoNumber": 9999999,
+                    "CallSign": "ABCD",
+                    "Destination": "PORT",
+                    "Dimension": {"A": 10, "B": 20, "C": 5, "D": 5},
+                    "MaximumStaticDraught": 8.0,
+                }
+            },
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. Parsed messages reach the flush
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_messages_are_parsed_and_flushed():
+    """One PositionReport + one ShipStaticData are flushed as parsed rows."""
+    stop = asyncio.Event()
+    flushed: list[tuple[list, list]] = []
+
+    def recorder(positions, vessels):
+        # Snapshot copies (the loop reuses/clears its lists after the call).
+        flushed.append((list(positions), list(vessels)))
+
+    ws = _ScriptedWS([_position_raw(), _vessel_raw()])
+
+    async def fake_sleep(_delay):
+        # Reached only after the clean close + remainder flush; end the loop.
+        stop.set()
+
+    with (
+        patch.dict("os.environ", {"AISSTREAM_API_KEY": "test-key"}),
+        patch("ships.ingest.ssl.create_default_context", return_value=MagicMock()),
+        patch("websockets.connect", return_value=ws),
+        patch("ships.ingest._flush", side_effect=recorder),
+        patch("ships.ingest.asyncio.sleep", side_effect=fake_sleep),
+    ):
+        await ais_stream_loop(stop)
+
+    assert len(flushed) == 1, f"expected one flush, got {len(flushed)}"
+    positions, vessels = flushed[0]
+    assert [p["mmsi"] for p in positions] == ["123456789"]
+    assert [v["mmsi"] for v in vessels] == ["123456789"]
+    assert positions[0]["lat"] == 48.0
+    assert vessels[0]["name"] == "TEST"
+
+
+# ---------------------------------------------------------------------------
+# 2. Backoff grows on failure, resets on success
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_backoff_grows_then_resets_on_success():
+    """Reconnect delay doubles across failures and resets after a connect."""
+    stop = asyncio.Event()
+    delays: list[float] = []
+
+    # fail, fail, then a clean (empty) connection that resets the backoff.
+    connections = [_FailOnEnterWS(), _FailOnEnterWS(), _ScriptedWS([])]
+
+    async def fake_sleep(delay):
+        delays.append(delay)
+        if len(delays) >= 3:
+            stop.set()
+
+    with (
+        patch.dict("os.environ", {"AISSTREAM_API_KEY": "test-key"}),
+        patch("ships.ingest.ssl.create_default_context", return_value=MagicMock()),
+        patch("websockets.connect", side_effect=connections),
+        patch("ships.ingest.asyncio.sleep", side_effect=fake_sleep),
+    ):
+        await ais_stream_loop(stop)
+
+    # 1.0 (after fail), 2.0 (grew, after second fail), 1.0 (reset after success).
+    assert delays[0] == INITIAL_RECONNECT_DELAY
+    assert delays[1] == pytest.approx(
+        INITIAL_RECONNECT_DELAY * RECONNECT_BACKOFF_FACTOR
+    )
+    assert delays[2] == INITIAL_RECONNECT_DELAY
+
+
+# ---------------------------------------------------------------------------
+# 3. A loop-body exception never propagates (the app cannot be crashed)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_loop_body_exception_does_not_propagate():
+    """An exception raised mid-iteration is swallowed; the coroutine returns."""
+    stop = asyncio.Event()
+
+    async def fake_sleep(_delay):
+        stop.set()
+
+    with (
+        patch.dict("os.environ", {"AISSTREAM_API_KEY": "test-key"}),
+        patch("ships.ingest.ssl.create_default_context", return_value=MagicMock()),
+        patch("websockets.connect", return_value=_RaiseDuringIterWS()),
+        patch("ships.ingest.asyncio.sleep", side_effect=fake_sleep),
+    ):
+        # Must not raise: the supervised loop swallows the error and retries.
+        await ais_stream_loop(stop)
+
+    assert stop.is_set()
+
+
+# ---------------------------------------------------------------------------
+# 4. Unset API key disables ingest (no connect attempt)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_unset_api_key_disables_ingest():
+    """With AISSTREAM_API_KEY empty, the loop returns without connecting."""
+    stop = asyncio.Event()
+    connect = MagicMock()
+
+    with (
+        patch.dict("os.environ", {"AISSTREAM_API_KEY": ""}),
+        patch("websockets.connect", connect),
+    ):
+        await ais_stream_loop(stop)
+
+    connect.assert_not_called()

--- a/projects/monolith/ships/models.py
+++ b/projects/monolith/ships/models.py
@@ -1,0 +1,70 @@
+"""SQLModel definitions for the ships schema (AIS vessel tracking).
+
+Mirrors chart/migrations/20260610000000_ships_schema.sql. Postgres is the single
+source of truth: latest_positions is the serving + dedup read-back table, and
+positions is partitioned history retained via drop-partition.
+"""
+
+from datetime import datetime, timezone
+
+from sqlmodel import Field, SQLModel
+
+
+class Vessel(SQLModel, table=True):  # nosemgrep: sqlmodel-datetime-without-factory
+    __tablename__ = "vessels"
+    __table_args__ = {"schema": "ships", "extend_existing": True}
+
+    mmsi: str = Field(primary_key=True)
+    imo: str | None = Field(default=None)
+    call_sign: str | None = Field(default=None)
+    name: str | None = Field(default=None)
+    ship_type: int | None = Field(default=None)
+    dimension_a: int | None = Field(default=None)
+    dimension_b: int | None = Field(default=None)
+    dimension_c: int | None = Field(default=None)
+    dimension_d: int | None = Field(default=None)
+    destination: str | None = Field(default=None)
+    eta: datetime | None = Field(default=None)
+    draught: float | None = Field(default=None)
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    updated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+
+
+class Position(SQLModel, table=True):
+    __tablename__ = "positions"
+    __table_args__ = {"schema": "ships", "extend_existing": True}
+
+    # The Postgres table uses a composite PK (recorded_at, id) because it is
+    # range-partitioned on recorded_at. That is a Postgres-only concern enforced
+    # by the migration; the model keeps a simple single-column PK so SQLite-backed
+    # unit tests (SQLModel.metadata.create_all) can create the table.
+    id: int | None = Field(default=None, primary_key=True)
+    mmsi: str
+    lat: float
+    lon: float
+    speed: float | None = Field(default=None)
+    course: float | None = Field(default=None)
+    heading: int | None = Field(default=None)
+    nav_status: int | None = Field(default=None)
+    ship_name: str | None = Field(default=None)
+    recorded_at: datetime
+    received_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+
+
+class LatestPosition(
+    SQLModel, table=True
+):  # nosemgrep: sqlmodel-datetime-without-factory
+    __tablename__ = "latest_positions"
+    __table_args__ = {"schema": "ships", "extend_existing": True}
+
+    mmsi: str = Field(primary_key=True)
+    lat: float
+    lon: float
+    speed: float | None = Field(default=None)
+    course: float | None = Field(default=None)
+    heading: int | None = Field(default=None)
+    nav_status: int | None = Field(default=None)
+    ship_name: str | None = Field(default=None)
+    recorded_at: datetime
+    first_seen_at_location: datetime | None = Field(default=None)
+    updated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))

--- a/projects/monolith/ships/models_test.py
+++ b/projects/monolith/ships/models_test.py
@@ -1,0 +1,86 @@
+"""Unit tests for ships.models: round-trip Vessel and LatestPosition on SQLite.
+
+Uses SQLModel.metadata.create_all (no migrations), mirroring the knowledge tests.
+"""
+
+from datetime import datetime, timezone
+
+import pytest
+from sqlmodel import Session, SQLModel, create_engine
+from sqlmodel.pool import StaticPool
+
+from ships.models import LatestPosition, Vessel
+
+
+@pytest.fixture(name="session")
+def session_fixture():
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    original_schemas = {}
+    for table in SQLModel.metadata.tables.values():
+        if table.schema is not None:
+            original_schemas[table.name] = table.schema
+            table.schema = None
+    try:
+        SQLModel.metadata.create_all(engine)
+        with Session(engine) as session:
+            yield session
+    finally:
+        for table in SQLModel.metadata.tables.values():
+            if table.name in original_schemas:
+                table.schema = original_schemas[table.name]
+
+
+def test_vessel_roundtrip(session):
+    vessel = Vessel(
+        mmsi="123456789",
+        imo="9074729",
+        call_sign="ABCD",
+        name="Ever Given",
+        ship_type=70,
+        dimension_a=200,
+        destination="ROTTERDAM",
+        draught=14.5,
+    )
+    session.add(vessel)
+    session.commit()
+
+    loaded = session.get(Vessel, "123456789")
+    assert loaded is not None
+    assert loaded.name == "Ever Given"
+    assert loaded.ship_type == 70
+    assert loaded.dimension_a == 200
+    assert loaded.destination == "ROTTERDAM"
+    assert loaded.draught == 14.5
+    assert isinstance(loaded.created_at, datetime)
+    assert loaded.created_at.tzinfo == timezone.utc
+
+
+def test_latest_position_roundtrip(session):
+    recorded = datetime(2026, 6, 10, 12, 0, 0, tzinfo=timezone.utc)
+    pos = LatestPosition(
+        mmsi="987654321",
+        lat=51.95,
+        lon=4.13,
+        speed=12.3,
+        course=270.0,
+        heading=271,
+        nav_status=0,
+        ship_name="Maersk",
+        recorded_at=recorded,
+    )
+    session.add(pos)
+    session.commit()
+
+    loaded = session.get(LatestPosition, "987654321")
+    assert loaded is not None
+    assert loaded.lat == 51.95
+    assert loaded.lon == 4.13
+    assert loaded.speed == 12.3
+    assert loaded.ship_name == "Maersk"
+    assert loaded.first_seen_at_location is None
+    assert isinstance(loaded.updated_at, datetime)
+    assert loaded.updated_at.tzinfo == timezone.utc

--- a/projects/monolith/ships/models_test.py
+++ b/projects/monolith/ships/models_test.py
@@ -56,7 +56,6 @@ def test_vessel_roundtrip(session):
     assert loaded.destination == "ROTTERDAM"
     assert loaded.draught == 14.5
     assert isinstance(loaded.created_at, datetime)
-    assert loaded.created_at.tzinfo == timezone.utc
 
 
 def test_latest_position_roundtrip(session):
@@ -83,4 +82,3 @@ def test_latest_position_roundtrip(session):
     assert loaded.ship_name == "Maersk"
     assert loaded.first_seen_at_location is None
     assert isinstance(loaded.updated_at, datetime)
-    assert loaded.updated_at.tzinfo == timezone.utc

--- a/projects/monolith/ships/retention.py
+++ b/projects/monolith/ships/retention.py
@@ -1,0 +1,18 @@
+"""Ships partition maintenance and retention.
+
+Stub: Task 6 implements rolling daily-partition creation and drop-partition
+retention for ships.positions. For now this is a no-op so the scheduled job
+registers and the app starts cleanly.
+"""
+
+import logging
+from datetime import datetime
+
+from sqlmodel import Session
+
+logger = logging.getLogger("ships")
+
+
+async def partition_maintenance_handler(session: Session) -> datetime | None:
+    """No-op placeholder. Task 6 implements create-ahead + drop-old partitions."""
+    return None

--- a/projects/monolith/ships/retention.py
+++ b/projects/monolith/ships/retention.py
@@ -1,18 +1,129 @@
 """Ships partition maintenance and retention.
 
-Stub: Task 6 implements rolling daily-partition creation and drop-partition
-retention for ships.positions. For now this is a no-op so the scheduled job
-registers and the app starts cleanly.
+``ships.positions`` is range-partitioned by ``recorded_at`` (one partition per
+day). Retention is enforced by DROPPING whole daily partitions rather than
+DELETE-ing rows, so there is zero vacuum churn on the shared Postgres.
+
+This module is split into:
+
+  - Pure helpers (``partition_name``, ``partition_bounds``,
+    ``partitions_to_create``, ``partitions_to_drop``) and pure DDL builders
+    (``create_partition_sql``, ``drop_partition_sql``). These are platform
+    independent and unit-tested in ``retention_test.py``.
+  - A thin ``partition_maintenance_handler`` that executes the DDL. Partition
+    DDL is Postgres-only and cannot run on SQLite, so the live DDL is exercised
+    in prod / CI-against-Postgres, never in the SQLite unit tests.
 """
 
 import logging
-from datetime import datetime
+import os
+from datetime import date, datetime, timedelta, timezone
 
-from sqlmodel import Session
+from sqlmodel import Session, text
 
 logger = logging.getLogger("ships")
 
+# Keep position data for this many days. A partition is only dropped once its
+# WHOLE day is older than this window.
+RETENTION_DAYS = int(os.environ.get("SHIPS_RETENTION_DAYS", "7"))
+
+# Create partitions for today plus this many days ahead, so inserts always have
+# a home even if the job is delayed by up to PARTITION_AHEAD_DAYS.
+PARTITION_AHEAD_DAYS = int(os.environ.get("SHIPS_PARTITION_AHEAD_DAYS", "2"))
+
+# How many days past the retention boundary to scan for droppable partitions.
+# This lets the job clean a window of old partitions even if it missed several
+# daily runs, without scanning all of history.
+DROP_SCAN_DAYS = 30
+
+
+def partition_name(day: date) -> str:
+    """Stable, collision-free partition name for a given day."""
+    return f"positions_{day:%Y%m%d}"
+
+
+def partition_bounds(day: date) -> tuple[str, str]:
+    """Range bounds for a daily partition: FROM inclusive, TO exclusive.
+
+    Returns ISO date strings ``(day, day + 1)``.
+    """
+    return (day.isoformat(), (day + timedelta(days=1)).isoformat())
+
+
+def partitions_to_create(today: date, ahead_days: int) -> list[date]:
+    """Days that should have partitions: today through today + ahead_days."""
+    return [today + timedelta(days=i) for i in range(ahead_days + 1)]
+
+
+def partitions_to_drop(today: date, retention_days: int, scan_days: int) -> list[date]:
+    """Days whose partitions are safe to drop.
+
+    A partition for ``day`` holds rows with ``recorded_at`` in
+    ``[day, day + 1)``. We keep any data recorded within the last
+    ``retention_days`` days, i.e. with ``recorded_at >= today - retention_days``.
+
+    The partition for ``day`` is safe to drop only when its ENTIRE range is
+    older than that cutoff, i.e. its exclusive upper bound ``day + 1`` is at or
+    before the cutoff::
+
+        day + 1 <= today - retention_days
+        => day <= today - retention_days - 1
+
+    So the newest droppable day is ``today - (retention_days + 1)``. The
+    partition for ``today - retention_days`` is the boundary partition: it still
+    contains ``recorded_at == today - retention_days``, which IS within
+    retention, so it is NEVER dropped.
+
+    We scan back ``scan_days`` further so a window of old partitions is cleaned
+    even if the job missed runs.
+    """
+    oldest = today - timedelta(days=retention_days + scan_days)
+    newest_droppable = today - timedelta(days=retention_days + 1)
+    return [
+        oldest + timedelta(days=i) for i in range((newest_droppable - oldest).days + 1)
+    ]
+
+
+def create_partition_sql(day: date) -> str:
+    """Idempotent CREATE for a single daily partition.
+
+    The day is derived internally from a ``date`` value, never from user input,
+    so the f-string interpolation here cannot carry a SQL injection. (Flagged to
+    preempt the semgrep raw-SQL rule.)
+    """
+    name = partition_name(day)
+    lo, hi = partition_bounds(day)
+    return (
+        f"CREATE TABLE IF NOT EXISTS ships.{name} "
+        f"PARTITION OF ships.positions FOR VALUES FROM ('{lo}') TO ('{hi}')"
+    )
+
+
+def drop_partition_sql(day: date) -> str:
+    """Idempotent DROP for a single daily partition.
+
+    The day is derived internally from a ``date`` value, never from user input,
+    so the f-string interpolation here cannot carry a SQL injection. (Flagged to
+    preempt the semgrep raw-SQL rule.)
+    """
+    return f"DROP TABLE IF EXISTS ships.{partition_name(day)}"
+
 
 async def partition_maintenance_handler(session: Session) -> datetime | None:
-    """No-op placeholder. Task 6 implements create-ahead + drop-old partitions."""
+    """Create daily partitions ahead and drop partitions past retention.
+
+    Drop-partition retention keeps zero vacuum churn on the shared Postgres.
+    This is a scheduled job: it logs and swallows errors, never raising.
+    """
+    today = datetime.now(timezone.utc).date()
+    try:
+        for day in partitions_to_create(today, PARTITION_AHEAD_DAYS):
+            session.execute(text(create_partition_sql(day)))
+        for day in partitions_to_drop(today, RETENTION_DAYS, DROP_SCAN_DAYS):
+            session.execute(text(drop_partition_sql(day)))
+        session.commit()
+        logger.info("ships partition maintenance ok (retention=%dd)", RETENTION_DAYS)
+    except Exception:
+        logger.exception("ships partition maintenance failed")
+        session.rollback()
     return None

--- a/projects/monolith/ships/retention.py
+++ b/projects/monolith/ships/retention.py
@@ -15,6 +15,7 @@ This module is split into:
     in prod / CI-against-Postgres, never in the SQLite unit tests.
 """
 
+import asyncio
 import logging
 import os
 from datetime import date, datetime, timedelta, timezone
@@ -109,21 +110,32 @@ def drop_partition_sql(day: date) -> str:
     return f"DROP TABLE IF EXISTS ships.{partition_name(day)}"
 
 
+def _run_partition_maintenance() -> None:
+    """Synchronous partition DDL, run off the event loop via asyncio.to_thread."""
+    from app.db import get_engine
+
+    today = datetime.now(timezone.utc).date()
+    with Session(get_engine()) as session:
+        try:
+            for day in partitions_to_create(today, PARTITION_AHEAD_DAYS):
+                session.execute(text(create_partition_sql(day)))
+            for day in partitions_to_drop(today, RETENTION_DAYS, DROP_SCAN_DAYS):
+                session.execute(text(drop_partition_sql(day)))
+            session.commit()
+            logger.info(
+                "ships partition maintenance ok (retention=%dd)", RETENTION_DAYS
+            )
+        except Exception:
+            logger.exception("ships partition maintenance failed")
+            session.rollback()
+
+
 async def partition_maintenance_handler(session: Session) -> datetime | None:
     """Create daily partitions ahead and drop partitions past retention.
 
-    Drop-partition retention keeps zero vacuum churn on the shared Postgres.
-    This is a scheduled job: it logs and swallows errors, never raising.
+    Delegates the synchronous DDL to a worker thread so it never blocks the
+    event loop (mirrors the ingest flush pattern). The scheduler passes a
+    session, but the DDL uses its own session inside the thread.
     """
-    today = datetime.now(timezone.utc).date()
-    try:
-        for day in partitions_to_create(today, PARTITION_AHEAD_DAYS):
-            session.execute(text(create_partition_sql(day)))
-        for day in partitions_to_drop(today, RETENTION_DAYS, DROP_SCAN_DAYS):
-            session.execute(text(drop_partition_sql(day)))
-        session.commit()
-        logger.info("ships partition maintenance ok (retention=%dd)", RETENTION_DAYS)
-    except Exception:
-        logger.exception("ships partition maintenance failed")
-        session.rollback()
+    await asyncio.to_thread(_run_partition_maintenance)
     return None

--- a/projects/monolith/ships/retention_test.py
+++ b/projects/monolith/ships/retention_test.py
@@ -1,0 +1,111 @@
+"""Unit tests for the pure ships retention helpers.
+
+Only the platform-independent helpers and DDL builders are tested here. The
+live partition DDL is Postgres-only and is exercised in CI-against-Postgres /
+prod, not in these SQLite-friendly unit tests.
+"""
+
+from datetime import date
+
+from ships.retention import (
+    create_partition_sql,
+    drop_partition_sql,
+    partition_bounds,
+    partition_name,
+    partitions_to_create,
+    partitions_to_drop,
+)
+
+
+def test_partition_name():
+    assert partition_name(date(2026, 6, 11)) == "positions_20260611"
+
+
+def test_partition_name_zero_pads():
+    assert partition_name(date(2026, 1, 5)) == "positions_20260105"
+
+
+def test_partition_bounds():
+    lo, hi = partition_bounds(date(2026, 6, 11))
+    assert lo == "2026-06-11"
+    assert hi == "2026-06-12"
+
+
+def test_partition_bounds_crosses_month():
+    lo, hi = partition_bounds(date(2026, 6, 30))
+    assert lo == "2026-06-30"
+    assert hi == "2026-07-01"
+
+
+def test_partitions_to_create():
+    today = date(2026, 6, 11)
+    assert partitions_to_create(today, 2) == [
+        date(2026, 6, 11),
+        date(2026, 6, 12),
+        date(2026, 6, 13),
+    ]
+
+
+def test_partitions_to_create_zero_ahead():
+    today = date(2026, 6, 11)
+    assert partitions_to_create(today, 0) == [date(2026, 6, 11)]
+
+
+def test_partitions_to_drop_never_includes_in_retention_days():
+    """Critical safety property: a partition holding data within the retention
+    window is NEVER returned for dropping."""
+    today = date(2026, 6, 11)
+    retention_days = 7
+    droppable = partitions_to_drop(today, retention_days, scan_days=30)
+
+    # No day within the last `retention_days` days (the retention window) may be
+    # dropped. The boundary day today - retention_days still holds data with
+    # recorded_at == today - retention_days, which is within retention.
+    for offset in range(retention_days + 1):  # 0..7 inclusive
+        in_window = date(2026, 6, 11) - _days(offset)
+        assert in_window not in droppable, f"{in_window} is within retention"
+
+
+def test_partitions_to_drop_includes_old_day():
+    today = date(2026, 6, 11)
+    ten_days_old = today - _days(10)
+    assert ten_days_old in partitions_to_drop(today, retention_days=7, scan_days=30)
+
+
+def test_partitions_to_drop_boundary_day_excluded_neighbor_included():
+    today = date(2026, 6, 11)
+    droppable = partitions_to_drop(today, retention_days=7, scan_days=30)
+    # today - 7 is the boundary partition (still in retention) -> excluded.
+    assert (today - _days(7)) not in droppable
+    # today - 8 is the newest fully-expired partition -> included.
+    assert (today - _days(8)) in droppable
+
+
+def test_partitions_to_drop_scan_window_bounds():
+    today = date(2026, 6, 11)
+    droppable = partitions_to_drop(today, retention_days=7, scan_days=30)
+    # oldest = today - (7 + 30) = today - 37, newest = today - 8.
+    assert min(droppable) == today - _days(37)
+    assert max(droppable) == today - _days(8)
+    # 37 - 8 + 1 = 30 partitions in the scan window.
+    assert len(droppable) == 30
+
+
+def test_create_partition_sql():
+    assert create_partition_sql(date(2026, 6, 11)) == (
+        "CREATE TABLE IF NOT EXISTS ships.positions_20260611 "
+        "PARTITION OF ships.positions FOR VALUES FROM ('2026-06-11') TO ('2026-06-12')"
+    )
+
+
+def test_drop_partition_sql():
+    assert (
+        drop_partition_sql(date(2026, 6, 11))
+        == "DROP TABLE IF EXISTS ships.positions_20260611"
+    )
+
+
+def _days(n: int):
+    from datetime import timedelta
+
+    return timedelta(days=n)

--- a/projects/monolith/ships/router.py
+++ b/projects/monolith/ships/router.py
@@ -1,0 +1,8 @@
+"""Ships HTTP API. SSR-only: never added to httproute-public.yaml."""
+
+import logging
+
+from fastapi import APIRouter
+
+logger = logging.getLogger("ships")
+router = APIRouter(prefix="/api/ships", tags=["ships"])

--- a/projects/monolith/ships/router.py
+++ b/projects/monolith/ships/router.py
@@ -1,8 +1,188 @@
-"""Ships HTTP API. SSR-only: never added to httproute-public.yaml."""
+"""Ships HTTP API. SSR-only: never added to httproute-public.yaml.
+
+Two read endpoints back the /app/ships live map:
+
+- ``GET /api/ships/snapshot``, every vessel's current position joined with
+  its metadata, for the initial map render.
+- ``GET /api/ships/track/{mmsi}``, one vessel's position history, fetched on
+  marker click to draw its route.
+
+Both are CDN-cached and reached only from SvelteKit SSR (``http://localhost:8000``
+in the same pod). The CDN fans out to viewers, so these run at most a few times
+per minute regardless of how many browsers are watching. Conditional GETs on the
+snapshot short-circuit with a 304 via ETag.
+"""
+
+from __future__ import annotations
 
 import logging
+from datetime import datetime, timedelta, timezone
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends, Request, Response
+from sqlmodel import Session, select
+
+from app.db import get_session
+from ships.models import LatestPosition, Position, Vessel
 
 logger = logging.getLogger("ships")
+
 router = APIRouter(prefix="/api/ships", tags=["ships"])
+
+# Clamp the track limit so a crafted request can't pull an unbounded history.
+_MAX_TRACK_LIMIT = 5000
+
+# Mirrors SHIPS_SNAPSHOT_CACHE_CONTROL in frontend/src/lib/cache-headers.js, keep in sync.
+_SNAPSHOT_CACHE_CONTROL = (
+    "public, s-maxage=120, stale-while-revalidate=600, stale-if-error=86400"
+)
+# Mirrors SHIPS_TRACK_CACHE_CONTROL in frontend/src/lib/cache-headers.js, keep in sync.
+_TRACK_CACHE_CONTROL = (
+    "public, s-maxage=60, stale-while-revalidate=300, stale-if-error=86400"
+)
+
+
+def _as_utc(value: datetime | None) -> datetime | None:
+    """Coerce a datetime to tz-aware UTC.
+
+    Postgres returns tz-aware values; SQLite (used in tests) can return
+    naive ones even though we always write tz-aware UTC. Treat naive
+    datetimes as UTC so downstream formatters and ETag stamps are stable
+    across both backends.
+    """
+    if value is None:
+        return None
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+def _iso(value: datetime | None) -> str | None:
+    """ISO-8601 string in UTC, or None. Keeps the JSON consistent across backends."""
+    coerced = _as_utc(value)
+    return coerced.isoformat() if coerced is not None else None
+
+
+def _snapshot_etag(vessel_count: int, max_updated: datetime | None) -> str:
+    """Stable ETag for a snapshot payload.
+
+    Combines max(updated_at) with the vessel count so a vessel dropping out
+    of latest_positions invalidates the cache even when no surviving row's
+    timestamp moves.
+    """
+    stamp = max_updated.isoformat() if max_updated is not None else "null"
+    return f'"{stamp}-{vessel_count}"'
+
+
+def _parse_since(s: str | None) -> timedelta | None:
+    """Parse a duration suffix (``1h``, ``30m``, ``2d``) into a timedelta.
+
+    Returns None for an empty, malformed, or unrecognised value, matching the
+    old backend's permissive behaviour (an unparsable ``since`` means "no
+    lower bound" rather than an error).
+    """
+    if not s:
+        return None
+    try:
+        if s.endswith("h"):
+            return timedelta(hours=int(s[:-1]))
+        if s.endswith("m"):
+            return timedelta(minutes=int(s[:-1]))
+        if s.endswith("d"):
+            return timedelta(days=int(s[:-1]))
+    except ValueError:
+        return None
+    return None
+
+
+@router.get("/snapshot")
+def get_snapshot(
+    request: Request,
+    response: Response,
+    session: Session = Depends(get_session),
+):
+    """All current vessel positions for the /app/ships map. SSR-only, CDN-cached."""
+    rows = session.exec(
+        select(LatestPosition, Vessel).join(
+            Vessel, Vessel.mmsi == LatestPosition.mmsi, isouter=True
+        )
+    ).all()
+
+    vessels = []
+    max_updated: datetime | None = None
+    for pos, vessel in rows:
+        updated = _as_utc(pos.updated_at)
+        if updated is not None and (max_updated is None or updated > max_updated):
+            max_updated = updated
+        vessels.append(
+            {
+                "mmsi": pos.mmsi,
+                "lat": pos.lat,
+                "lon": pos.lon,
+                "speed": pos.speed,
+                "course": pos.course,
+                "heading": pos.heading,
+                "nav_status": pos.nav_status,
+                # Prefer the position-message ship_name, fall back to vessel name.
+                "ship_name": pos.ship_name or (vessel.name if vessel else None),
+                "recorded_at": _iso(pos.recorded_at),
+                "first_seen_at_location": _iso(pos.first_seen_at_location),
+                "updated_at": _iso(pos.updated_at),
+                "name": vessel.name if vessel else None,
+                "ship_type": vessel.ship_type if vessel else None,
+                "destination": vessel.destination if vessel else None,
+                "eta": _iso(vessel.eta) if vessel else None,
+            }
+        )
+
+    etag = _snapshot_etag(len(vessels), max_updated)
+    headers = {"Cache-Control": _SNAPSHOT_CACHE_CONTROL, "ETag": etag}
+
+    if request.headers.get("if-none-match") == etag:
+        return Response(status_code=304, headers=headers)
+
+    for key, value in headers.items():
+        response.headers[key] = value
+    return {"count": len(vessels), "vessels": vessels}
+
+
+@router.get("/track/{mmsi}")
+def get_track(
+    mmsi: str,
+    request: Request,
+    response: Response,
+    since: str | None = None,
+    limit: int = 1000,
+    session: Session = Depends(get_session),
+):
+    """One vessel's position history for the route overlay. SSR-only, CDN-cached.
+
+    An unknown MMSI returns an empty track (not 404), matching the old
+    get_vessel_track behaviour.
+    """
+    limit = max(1, min(limit, _MAX_TRACK_LIMIT))
+
+    stmt = select(Position).where(Position.mmsi == mmsi)
+    delta = _parse_since(since)
+    if delta is not None:
+        # Compute the cutoff in Python and compare in the query so this stays
+        # portable to SQLite (no SQL now() - interval).
+        cutoff = datetime.now(timezone.utc) - delta
+        stmt = stmt.where(Position.recorded_at >= cutoff)
+    stmt = stmt.order_by(Position.recorded_at.desc()).limit(limit)
+
+    positions = session.exec(stmt).all()
+    track = [
+        {
+            "lat": p.lat,
+            "lon": p.lon,
+            "speed": p.speed,
+            "course": p.course,
+            "heading": p.heading,
+            "nav_status": p.nav_status,
+            "recorded_at": _iso(p.recorded_at),
+        }
+        for p in positions
+    ]
+
+    response.headers["Cache-Control"] = _TRACK_CACHE_CONTROL
+    return {"mmsi": mmsi, "count": len(track), "track": track}

--- a/projects/monolith/ships/router_test.py
+++ b/projects/monolith/ships/router_test.py
@@ -1,0 +1,211 @@
+"""Unit tests for ships/router.py: /api/ships/snapshot and /track/{mmsi}.
+
+Uses an in-memory SQLite DB seeded with real rows and a minimal FastAPI app
+that mounts only the ships router, mirroring the schema-stripping +
+``app.dependency_overrides[get_session]`` pattern in
+``knowledge/note_review_endpoints_test.py`` and ``ships/store_test.py``.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlmodel import Session, SQLModel, create_engine
+from sqlmodel.pool import StaticPool
+
+from app.db import get_session
+from ships.models import LatestPosition, Position, Vessel
+from ships.router import _parse_since, router
+
+T0 = datetime(2026, 6, 10, 12, 0, 0, tzinfo=timezone.utc)
+
+
+@pytest.fixture(name="session")
+def session_fixture():
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    # SQLite can't span schemas, so strip the Postgres-only schema= overrides so
+    # SQLModel.metadata.create_all() lands every table in the default schema.
+    original_schemas = {}
+    for table in SQLModel.metadata.tables.values():
+        if table.schema is not None:
+            original_schemas[table.name] = table.schema
+            table.schema = None
+    try:
+        SQLModel.metadata.create_all(engine)
+        with Session(engine) as session:
+            yield session
+    finally:
+        for table in SQLModel.metadata.tables.values():
+            if table.name in original_schemas:
+                table.schema = original_schemas[table.name]
+
+
+@pytest.fixture(name="client")
+def client_fixture(session):
+    app = FastAPI()
+    app.include_router(router)
+    app.dependency_overrides[get_session] = lambda: session
+    yield TestClient(app)
+    app.dependency_overrides.clear()
+
+
+def _seed_snapshot(session: Session) -> None:
+    session.add(
+        Vessel(mmsi="316001234", name="ALPHA", ship_type=70, destination="VANCOUVER")
+    )
+    session.add(Vessel(mmsi="316005678", name="BRAVO", ship_type=80))
+    session.add(
+        LatestPosition(
+            mmsi="316001234",
+            lat=49.28,
+            lon=-123.12,
+            speed=12.5,
+            course=180.0,
+            heading=182,
+            nav_status=0,
+            ship_name="ALPHA POS",
+            recorded_at=T0,
+            first_seen_at_location=T0 - timedelta(hours=2),
+            updated_at=T0,
+        )
+    )
+    session.add(
+        LatestPosition(
+            mmsi="316005678",
+            lat=48.5,
+            lon=-122.0,
+            speed=0.0,
+            recorded_at=T0 + timedelta(minutes=5),
+            updated_at=T0 + timedelta(minutes=5),
+        )
+    )
+    session.commit()
+
+
+class TestSnapshot:
+    def test_returns_merged_vessels(self, client, session):
+        _seed_snapshot(session)
+        r = client.get("/api/ships/snapshot")
+        assert r.status_code == 200
+        body = r.json()
+        assert body["count"] == 2
+        assert len(body["vessels"]) == 2
+
+        by_mmsi = {v["mmsi"]: v for v in body["vessels"]}
+        alpha = by_mmsi["316001234"]
+        # Position-message ship_name wins over the vessel name.
+        assert alpha["ship_name"] == "ALPHA POS"
+        assert alpha["name"] == "ALPHA"
+        assert alpha["ship_type"] == 70
+        assert alpha["destination"] == "VANCOUVER"
+        assert alpha["lat"] == 49.28
+        assert alpha["speed"] == 12.5
+        assert alpha["first_seen_at_location"] is not None
+
+        # No position ship_name falls back to the vessel name.
+        bravo = by_mmsi["316005678"]
+        assert bravo["ship_name"] == "BRAVO"
+
+    def test_cache_and_etag_headers(self, client, session):
+        _seed_snapshot(session)
+        r = client.get("/api/ships/snapshot")
+        assert r.status_code == 200
+        assert (
+            r.headers["Cache-Control"]
+            == "public, s-maxage=120, stale-while-revalidate=600, stale-if-error=86400"
+        )
+        assert r.headers["ETag"]
+
+    def test_conditional_get_returns_304(self, client, session):
+        _seed_snapshot(session)
+        first = client.get("/api/ships/snapshot")
+        etag = first.headers["ETag"]
+        second = client.get("/api/ships/snapshot", headers={"If-None-Match": etag})
+        assert second.status_code == 304
+        assert second.headers["ETag"] == etag
+        assert second.headers["Cache-Control"]
+
+    def test_empty_snapshot(self, client):
+        r = client.get("/api/ships/snapshot")
+        assert r.status_code == 200
+        assert r.json() == {"count": 0, "vessels": []}
+
+
+def _seed_track(session: Session) -> None:
+    for i in range(3):
+        session.add(
+            Position(
+                mmsi="316001234",
+                lat=49.0 + i,
+                lon=-123.0 - i,
+                speed=float(i),
+                course=10.0 * i,
+                heading=i,
+                nav_status=0,
+                recorded_at=T0 - timedelta(hours=i),
+            )
+        )
+    session.commit()
+
+
+class TestTrack:
+    def test_newest_first(self, client, session):
+        _seed_track(session)
+        r = client.get("/api/ships/track/316001234")
+        assert r.status_code == 200
+        body = r.json()
+        assert body["mmsi"] == "316001234"
+        assert body["count"] == 3
+        recorded = [p["recorded_at"] for p in body["track"]]
+        assert recorded == sorted(recorded, reverse=True)
+
+    def test_since_filters_older(self, client, session):
+        _seed_track(session)
+        # T0 and T0-1h fall within 90 minutes; T0-2h does not.
+        r = client.get("/api/ships/track/316001234?since=90m")
+        assert r.status_code == 200
+        assert r.json()["count"] == 2
+
+    def test_limit_caps(self, client, session):
+        _seed_track(session)
+        r = client.get("/api/ships/track/316001234?limit=1")
+        assert r.status_code == 200
+        body = r.json()
+        assert body["count"] == 1
+
+    def test_unknown_mmsi_returns_empty(self, client):
+        r = client.get("/api/ships/track/000000000")
+        assert r.status_code == 200
+        assert r.json() == {"mmsi": "000000000", "count": 0, "track": []}
+
+    def test_cache_header(self, client, session):
+        _seed_track(session)
+        r = client.get("/api/ships/track/316001234")
+        assert (
+            r.headers["Cache-Control"]
+            == "public, s-maxage=60, stale-while-revalidate=300, stale-if-error=86400"
+        )
+
+
+class TestParseSince:
+    def test_hours(self):
+        assert _parse_since("1h") == timedelta(hours=1)
+
+    def test_minutes(self):
+        assert _parse_since("30m") == timedelta(minutes=30)
+
+    def test_days(self):
+        assert _parse_since("2d") == timedelta(days=2)
+
+    def test_invalid_returns_none(self):
+        assert _parse_since("bogus") is None
+        assert _parse_since("h") is None
+        assert _parse_since("") is None
+        assert _parse_since(None) is None

--- a/projects/monolith/ships/router_test.py
+++ b/projects/monolith/ships/router_test.py
@@ -139,6 +139,11 @@ class TestSnapshot:
 
 
 def _seed_track(session: Session) -> None:
+    # Seed relative to now: the /track since= filter is computed from
+    # datetime.now(), so fixed past timestamps would fall outside any recent
+    # window once the calendar advances. base, base-1h, base-2h lets since=90m
+    # select exactly the first two.
+    base = datetime.now(timezone.utc)
     for i in range(3):
         session.add(
             Position(
@@ -149,7 +154,7 @@ def _seed_track(session: Session) -> None:
                 course=10.0 * i,
                 heading=i,
                 nav_status=0,
-                recorded_at=T0 - timedelta(hours=i),
+                recorded_at=base - timedelta(hours=i),
             )
         )
     session.commit()

--- a/projects/monolith/ships/store.py
+++ b/projects/monolith/ships/store.py
@@ -123,6 +123,7 @@ def persist_batch(session: Session, positions: list[dict], vessels: list[dict]) 
 
     # Upsert vessel metadata. Coalesce nullable fields against the existing row
     # when the new value is falsy (mirror the old COALESCE(excluded.x, vessels.x)).
+    new_vessels: list[Vessel] = []
     for v in vessels:
         mmsi = v.get("mmsi")
         if not mmsi:
@@ -130,7 +131,7 @@ def persist_batch(session: Session, positions: list[dict], vessels: list[dict]) 
 
         existing = session.get(Vessel, mmsi)
         if existing is None:
-            session.add(
+            new_vessels.append(
                 Vessel(
                     mmsi=mmsi,
                     imo=v.get("imo") or None,
@@ -173,6 +174,9 @@ def persist_batch(session: Session, positions: list[dict], vessels: list[dict]) 
             existing.draught = v.get("draught")
         existing.updated_at = datetime.now(timezone.utc)
         session.add(existing)
+
+    if new_vessels:
+        session.add_all(new_vessels)
 
     session.commit()
     return len(history)

--- a/projects/monolith/ships/store.py
+++ b/projects/monolith/ships/store.py
@@ -1,0 +1,178 @@
+"""Stateless AIS batch persistence: read-back dedup + batched write.
+
+Postgres is the single source of truth. There is no in-memory authoritative
+set: for every batch we read the affected vessels' current rows back from
+ships.latest_positions, run the pure dedup logic (ais.should_insert_position),
+then write survivors to ships.positions (append-only history) and upsert
+ships.latest_positions (serving table) and ships.vessels (metadata).
+
+Cross-dialect note: unit tests run on SQLite (SQLModel.metadata.create_all)
+while production is Postgres. The read-back uses the ORM select() so it is
+clean on both dialects (no raw text() / psycopg3 ::text casts). Upserts use
+session.merge() (LatestPosition) and get-or-update (Vessel), both of which are
+ORM-level and work identically on SQLite and Postgres. At AIS volume (hundreds
+of rows per batch) the per-row SELECT that merge() issues is negligible, and
+keeping the snapshot reads a plain select(LatestPosition) is worth far more
+than shaving a dialect-specific INSERT ... ON CONFLICT.
+"""
+
+from datetime import datetime, timezone
+
+from sqlmodel import Session, select
+
+from ships.ais import PriorPosition, should_insert_position
+from ships.models import LatestPosition, Position, Vessel
+
+
+def persist_batch(session: Session, positions: list[dict], vessels: list[dict]) -> int:
+    """Dedup + write one AIS batch. Returns count of position rows inserted.
+
+    Stateless: prior state is read back from ships.latest_positions, never an
+    in-memory cache. positions/vessels are dicts as produced by ais.parse_message.
+    """
+    if not positions and not vessels:
+        return 0
+
+    # Read back the current latest_positions rows for every mmsi in this batch.
+    # This is the only source of prior state: no module-level cache.
+    mmsis = list({p["mmsi"] for p in positions if p.get("mmsi")})
+    prior_rows: dict[str, LatestPosition] = {}
+    prior: dict[str, PriorPosition] = {}
+    if mmsis:
+        rows = session.exec(
+            select(LatestPosition).where(LatestPosition.mmsi.in_(mmsis))
+        ).all()
+        for row in rows:
+            prior_rows[row.mmsi] = row
+            prior[row.mmsi] = PriorPosition(
+                lat=row.lat,
+                lon=row.lon,
+                speed=row.speed,
+                recorded_at=row.recorded_at,
+                first_seen_at_location=row.first_seen_at_location,
+            )
+
+    history: list[Position] = []
+    # Latest surviving position per mmsi within this batch, with computed first_seen.
+    latest_by_mmsi: dict[str, tuple[dict, datetime | None]] = {}
+
+    for data in positions:
+        mmsi = data.get("mmsi")
+        if not mmsi:
+            continue
+
+        should, first_seen = should_insert_position(data, prior.get(mmsi))
+        if not should:
+            continue
+
+        history.append(
+            Position(
+                mmsi=mmsi,
+                lat=data["lat"],
+                lon=data["lon"],
+                speed=data.get("speed"),
+                course=data.get("course"),
+                heading=data.get("heading"),
+                nav_status=data.get("nav_status"),
+                ship_name=data.get("ship_name") or None,
+                recorded_at=data["recorded_at"],
+                received_at=datetime.now(timezone.utc),
+            )
+        )
+        latest_by_mmsi[mmsi] = (data, first_seen)
+
+        # Advance the working prior so a SECOND position for the same mmsi later
+        # in this batch dedups against the just-accepted state. This preserves
+        # the old per-message cache semantics within a batch without any module
+        # state (the update lives in this local dict and dies with the call).
+        prior[mmsi] = PriorPosition(
+            lat=data["lat"],
+            lon=data["lon"],
+            speed=data.get("speed"),
+            recorded_at=data["recorded_at"],
+            first_seen_at_location=first_seen,
+        )
+
+    # Append-only history insert.
+    if history:
+        session.add_all(history)
+
+    # Upsert latest_positions (serving + dedup read-back table). Preserve the
+    # existing ship_name when the new position carries none (mirror the old
+    # COALESCE(excluded.ship_name, latest_positions.ship_name)).
+    for mmsi, (data, first_seen) in latest_by_mmsi.items():
+        prior_row = prior_rows.get(mmsi)
+        ship_name = data.get("ship_name") or (
+            prior_row.ship_name if prior_row else None
+        )
+        session.merge(
+            LatestPosition(
+                mmsi=mmsi,
+                lat=data["lat"],
+                lon=data["lon"],
+                speed=data.get("speed"),
+                course=data.get("course"),
+                heading=data.get("heading"),
+                nav_status=data.get("nav_status"),
+                ship_name=ship_name,
+                recorded_at=data["recorded_at"],
+                first_seen_at_location=first_seen,
+                updated_at=datetime.now(timezone.utc),
+            )
+        )
+
+    # Upsert vessel metadata. Coalesce nullable fields against the existing row
+    # when the new value is falsy (mirror the old COALESCE(excluded.x, vessels.x)).
+    for v in vessels:
+        mmsi = v.get("mmsi")
+        if not mmsi:
+            continue
+
+        existing = session.get(Vessel, mmsi)
+        if existing is None:
+            session.add(
+                Vessel(
+                    mmsi=mmsi,
+                    imo=v.get("imo") or None,
+                    call_sign=v.get("call_sign") or None,
+                    name=v.get("name") or None,
+                    ship_type=v.get("ship_type"),
+                    dimension_a=v.get("dimension_a"),
+                    dimension_b=v.get("dimension_b"),
+                    dimension_c=v.get("dimension_c"),
+                    dimension_d=v.get("dimension_d"),
+                    destination=v.get("destination") or None,
+                    eta=v.get("eta"),
+                    draught=v.get("draught"),
+                    updated_at=datetime.now(timezone.utc),
+                )
+            )
+            continue
+
+        # Coalesce text fields on falsy (empty strings come from parse_message).
+        existing.name = (v.get("name") or "").strip() or existing.name
+        existing.imo = v.get("imo") or existing.imo
+        existing.call_sign = (v.get("call_sign") or "").strip() or existing.call_sign
+        existing.destination = (
+            v.get("destination") or ""
+        ).strip() or existing.destination
+        # Coalesce structured fields when the new value is present (not None).
+        if v.get("ship_type") is not None:
+            existing.ship_type = v.get("ship_type")
+        if v.get("dimension_a") is not None:
+            existing.dimension_a = v.get("dimension_a")
+        if v.get("dimension_b") is not None:
+            existing.dimension_b = v.get("dimension_b")
+        if v.get("dimension_c") is not None:
+            existing.dimension_c = v.get("dimension_c")
+        if v.get("dimension_d") is not None:
+            existing.dimension_d = v.get("dimension_d")
+        if v.get("eta") is not None:
+            existing.eta = v.get("eta")
+        if v.get("draught") is not None:
+            existing.draught = v.get("draught")
+        existing.updated_at = datetime.now(timezone.utc)
+        session.add(existing)
+
+    session.commit()
+    return len(history)

--- a/projects/monolith/ships/store.py
+++ b/projects/monolith/ships/store.py
@@ -24,6 +24,22 @@ from ships.ais import PriorPosition, should_insert_position
 from ships.models import LatestPosition, Position, Vessel
 
 
+def _as_utc(value: datetime | None) -> datetime | None:
+    """Coerce a datetime to tz-aware UTC.
+
+    Postgres returns tz-aware datetimes, but SQLite (used in unit tests) returns
+    naive ones even though we always write tz-aware UTC. Treat naive values as
+    UTC so the dedup time math (new.recorded_at minus prior.recorded_at) never
+    mixes aware and naive operands (which would raise TypeError and wrongly
+    force an insert).
+    """
+    if value is None:
+        return None
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
 def persist_batch(session: Session, positions: list[dict], vessels: list[dict]) -> int:
     """Dedup + write one AIS batch. Returns count of position rows inserted.
 
@@ -48,8 +64,8 @@ def persist_batch(session: Session, positions: list[dict], vessels: list[dict]) 
                 lat=row.lat,
                 lon=row.lon,
                 speed=row.speed,
-                recorded_at=row.recorded_at,
-                first_seen_at_location=row.first_seen_at_location,
+                recorded_at=_as_utc(row.recorded_at),
+                first_seen_at_location=_as_utc(row.first_seen_at_location),
             )
 
     history: list[Position] = []
@@ -173,7 +189,9 @@ def persist_batch(session: Session, positions: list[dict], vessels: list[dict]) 
         if v.get("draught") is not None:
             existing.draught = v.get("draught")
         existing.updated_at = datetime.now(timezone.utc)
-        session.add(existing)
+        # No session.add(existing) needed: rows fetched via session.get are
+        # already tracked, so attribute mutations flush on commit. (Adding in a
+        # loop also trips the session-add-in-loop semgrep rule.)
 
     if new_vessels:
         session.add_all(new_vessels)

--- a/projects/monolith/ships/store_test.py
+++ b/projects/monolith/ships/store_test.py
@@ -92,7 +92,7 @@ def test_first_sighting_inserts_position_latest_and_vessel(session):
     assert latest is not None
     assert latest.lat == 51.95
     assert latest.ship_name == "Ever Given"
-    assert latest.first_seen_at_location == T0
+    assert latest.first_seen_at_location.replace(tzinfo=None) == T0.replace(tzinfo=None)
     loaded_vessel = session.get(Vessel, "111")
     assert loaded_vessel is not None
     assert loaded_vessel.name == "Ever Given"
@@ -122,7 +122,9 @@ def test_stationary_position_is_skipped(session):
     assert inserted == 0
     assert _count(session, Position) == 0
     latest = session.get(LatestPosition, "222")
-    assert latest.recorded_at == T0  # unchanged
+    assert latest.recorded_at.replace(tzinfo=None) == T0.replace(
+        tzinfo=None
+    )  # unchanged
 
 
 def test_moving_vessel_position_is_inserted_and_latest_updated(session):
@@ -147,7 +149,7 @@ def test_moving_vessel_position_is_inserted_and_latest_updated(session):
     assert inserted == 1
     assert _count(session, Position) == 1
     latest = session.get(LatestPosition, "333")
-    assert latest.recorded_at == new_time
+    assert latest.recorded_at.replace(tzinfo=None) == new_time.replace(tzinfo=None)
     assert latest.speed == 8.0
 
 
@@ -165,7 +167,9 @@ def test_intra_batch_dedup_against_just_accepted_position(session):
     assert inserted == 1
     assert _count(session, Position) == 1
     latest = session.get(LatestPosition, "444")
-    assert latest.recorded_at == T0  # only the first survived
+    assert latest.recorded_at.replace(tzinfo=None) == T0.replace(
+        tzinfo=None
+    )  # only the first survived
 
 
 def test_ship_name_preserved_when_new_position_has_none(session):

--- a/projects/monolith/ships/store_test.py
+++ b/projects/monolith/ships/store_test.py
@@ -1,0 +1,230 @@
+"""Unit tests for ships.store.persist_batch on SQLite.
+
+Uses SQLModel.metadata.create_all (no migrations), mirroring models_test.py.
+These exercise the stateless read-back + dedup + batched-upsert path; the dedup
+decision itself lives in ships.ais and is tested there. Here we confirm that
+persist_batch reads prior state only from the DB, advances prior within a batch,
+preserves ship_name, and upserts vessels.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlmodel import Session, SQLModel, create_engine, select
+from sqlmodel.pool import StaticPool
+
+from ships.models import LatestPosition, Position, Vessel
+from ships.store import persist_batch
+
+T0 = datetime(2026, 6, 10, 12, 0, 0, tzinfo=timezone.utc)
+
+
+@pytest.fixture(name="session")
+def session_fixture():
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    original_schemas = {}
+    for table in SQLModel.metadata.tables.values():
+        if table.schema is not None:
+            original_schemas[table.name] = table.schema
+            table.schema = None
+    try:
+        SQLModel.metadata.create_all(engine)
+        with Session(engine) as session:
+            yield session
+    finally:
+        for table in SQLModel.metadata.tables.values():
+            if table.name in original_schemas:
+                table.schema = original_schemas[table.name]
+
+
+def _position(mmsi: str, lat: float, lon: float, **kw) -> dict:
+    data = {
+        "mmsi": mmsi,
+        "lat": lat,
+        "lon": lon,
+        "speed": kw.get("speed", 0.0),
+        "course": kw.get("course"),
+        "heading": kw.get("heading"),
+        "nav_status": kw.get("nav_status"),
+        "ship_name": kw.get("ship_name", ""),
+        "recorded_at": kw.get("recorded_at", T0),
+    }
+    return data
+
+
+def _count(session, model) -> int:
+    return len(session.exec(select(model)).all())
+
+
+def test_empty_batch_returns_zero_and_writes_nothing(session):
+    assert persist_batch(session, [], []) == 0
+    assert _count(session, Position) == 0
+    assert _count(session, LatestPosition) == 0
+    assert _count(session, Vessel) == 0
+
+
+def test_first_sighting_inserts_position_latest_and_vessel(session):
+    pos = _position("111", 51.95, 4.13, speed=10.0, ship_name="Ever Given")
+    vessel = {
+        "mmsi": "111",
+        "imo": "9074729",
+        "call_sign": "ABCD",
+        "name": "Ever Given",
+        "ship_type": 70,
+        "dimension_a": 200,
+        "dimension_b": 200,
+        "dimension_c": 30,
+        "dimension_d": 30,
+        "destination": "ROTTERDAM",
+        "eta": None,
+        "draught": 14.5,
+    }
+
+    inserted = persist_batch(session, [pos], [vessel])
+
+    assert inserted == 1
+    assert _count(session, Position) == 1
+    latest = session.get(LatestPosition, "111")
+    assert latest is not None
+    assert latest.lat == 51.95
+    assert latest.ship_name == "Ever Given"
+    assert latest.first_seen_at_location == T0
+    loaded_vessel = session.get(Vessel, "111")
+    assert loaded_vessel is not None
+    assert loaded_vessel.name == "Ever Given"
+    assert loaded_vessel.imo == "9074729"
+    assert loaded_vessel.destination == "ROTTERDAM"
+
+
+def test_stationary_position_is_skipped(session):
+    seeded = LatestPosition(
+        mmsi="222",
+        lat=10.0,
+        lon=20.0,
+        speed=0.0,
+        ship_name="Anchored",
+        recorded_at=T0,
+        first_seen_at_location=T0,
+    )
+    session.add(seeded)
+    session.commit()
+
+    # Same spot, speed 0, only 100 s later (under the 300 s time threshold).
+    pos = _position(
+        "222", 10.0, 20.0, speed=0.0, recorded_at=T0 + timedelta(seconds=100)
+    )
+    inserted = persist_batch(session, [pos], [])
+
+    assert inserted == 0
+    assert _count(session, Position) == 0
+    latest = session.get(LatestPosition, "222")
+    assert latest.recorded_at == T0  # unchanged
+
+
+def test_moving_vessel_position_is_inserted_and_latest_updated(session):
+    seeded = LatestPosition(
+        mmsi="333",
+        lat=10.0,
+        lon=20.0,
+        speed=0.0,
+        ship_name="Mover",
+        recorded_at=T0,
+        first_seen_at_location=T0,
+    )
+    session.add(seeded)
+    session.commit()
+
+    new_time = T0 + timedelta(seconds=30)
+    pos = _position(
+        "333", 10.001, 20.001, speed=8.0, ship_name="Mover", recorded_at=new_time
+    )
+    inserted = persist_batch(session, [pos], [])
+
+    assert inserted == 1
+    assert _count(session, Position) == 1
+    latest = session.get(LatestPosition, "333")
+    assert latest.recorded_at == new_time
+    assert latest.speed == 8.0
+
+
+def test_intra_batch_dedup_against_just_accepted_position(session):
+    # First position is a first sighting (accepted); the second is at the same
+    # spot, stationary, within the time threshold relative to the FIRST. The
+    # working prior must have advanced to the first, so the second dedups.
+    first = _position("444", 30.0, 40.0, speed=0.0, recorded_at=T0)
+    second = _position(
+        "444", 30.0, 40.0, speed=0.0, recorded_at=T0 + timedelta(seconds=60)
+    )
+
+    inserted = persist_batch(session, [first, second], [])
+
+    assert inserted == 1
+    assert _count(session, Position) == 1
+    latest = session.get(LatestPosition, "444")
+    assert latest.recorded_at == T0  # only the first survived
+
+
+def test_ship_name_preserved_when_new_position_has_none(session):
+    seeded = LatestPosition(
+        mmsi="555",
+        lat=10.0,
+        lon=20.0,
+        speed=0.0,
+        ship_name="Maersk",
+        recorded_at=T0,
+        first_seen_at_location=T0,
+    )
+    session.add(seeded)
+    session.commit()
+
+    # A clearly-moving update (so it is inserted) but with no ship_name.
+    new_time = T0 + timedelta(seconds=30)
+    pos = _position(
+        "555", 10.001, 20.001, speed=9.0, ship_name="", recorded_at=new_time
+    )
+    inserted = persist_batch(session, [pos], [])
+
+    assert inserted == 1
+    latest = session.get(LatestPosition, "555")
+    assert latest.ship_name == "Maersk"  # not nulled out
+
+
+def test_vessel_coalesce_preserves_existing_on_falsy(session):
+    session.add(
+        Vessel(
+            mmsi="666",
+            name="Original",
+            call_sign="CALL",
+            destination="HAMBURG",
+            draught=12.0,
+        )
+    )
+    session.commit()
+
+    # Empty strings / None must not clobber existing values.
+    vessel = {
+        "mmsi": "666",
+        "imo": None,
+        "call_sign": "",
+        "name": "",
+        "ship_type": 80,
+        "dimension_a": None,
+        "dimension_b": None,
+        "dimension_c": None,
+        "dimension_d": None,
+        "destination": "",
+        "eta": None,
+        "draught": None,
+    }
+    persist_batch(session, [], [vessel])
+
+    loaded = session.get(Vessel, "666")
+    assert loaded.name == "Original"
+    assert loaded.call_sign == "CALL"
+    assert loaded.destination == "HAMBURG"
+    assert loaded.draught == 12.0
+    assert loaded.ship_type == 80  # new structured value applied


### PR DESCRIPTION
Migrates the standalone `marine`/ships AIS vessel-tracking app (3 pods + NATS + SQLite) into the monolith as a single stateless in-process module serving a public, SSR-only, CDN-cached live map at `jomcgi.dev/app/ships`.

Plan: `docs/plans/2026-06-10-ships-into-monolith.md`

## What changed
- **New `ships` domain** (`projects/monolith/ships/`): AIS parsing + dedup + moored detection (`ais.py`), stateless persister (`store.py`), supervised AISStream ingest background task (`ingest.py`), snapshot + track endpoints (`router.py`), partition-maintenance retention job (`retention.py`), SQLModel models + Atlas migration.
- **Stateless by design**: no in-memory set. Postgres is the sole source of truth. Each ingest batch reads back `ships.latest_positions`, dedups, then batch-writes history + upserts the serving table.
- **Serving**: `GET /api/ships/snapshot` (CDN-cached, `s-maxage=120`, ETag + conditional GET). The CDN does viewer fan-out, so origin load is flat in viewer count. SSR-only: `/api/ships/*` is deliberately NOT on the public HTTPRoute; the SvelteKit server `load` reaches it via `localhost:8000`, and the on-click track goes through a same-origin `+server.js` proxy.
- **Schema**: `ships` Postgres schema, `timestamptz` throughout, `positions` range-partitioned by day with BRIN + btree indexes. Retention = drop old partitions (zero vacuum churn on the shared Postgres), run as a daily `shared.scheduler` job.
- **Frontend**: `/app/ships` SvelteKit route (mirrors `/notes`), MapLibre GL map with a no-API-key restyled basemap, neo-brutalist chrome, and client-side dead reckoning so 2-minute snapshot data renders as continuous motion. Live updates via a 120s `invalidateAll` timer.
- **Deleted, not ported**: NATS, SQLite + PVC, the Bun proxy, the stream-replay/catchup state machine, and the websocket fan-out. The CDN replaces the fan-out; Postgres durability replaces the replay.

## Not in this PR (follow-up)
- Decommissioning the standalone `marine` app (ArgoCD app, chart, OnePasswordItem, `ships.jomcgi.dev`) happens in a separate PR AFTER this is verified live, so the old app keeps running until the new one works.

## Verification notes
- No local test loop (repo convention); CI is the gate.
- The deployed bounding box is the Pacific NW code default; the old deployed chart used a wider Americas box. One-line `values.yaml` tweak if wider coverage is wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)