### PR TITLE
fix(monolith): raise monolith-pg memory to stop OOMKill loop

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.96.3
+version: 0.96.4
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/templates/cnpg-cluster.yaml
+++ b/projects/monolith/chart/templates/cnpg-cluster.yaml
@@ -16,18 +16,23 @@ spec:
     {{- end }}
   postgresql:
     parameters:
-      shared_buffers: "64MB"
-      effective_cache_size: "128MB"
+      shared_buffers: "256MB"
+      effective_cache_size: "768MB"
     extensions:
       - name: vector
         image:
           reference: {{ .Values.postgres.pgvector.image }}
+  # Hosts five databases (monolith, temporal, temporal_visibility,
+  # lakehouse, postgres); Temporal is connection-heavy. The prior 256Mi
+  # limit OOMKilled the instance 359 times. 1Gi limit with shared_buffers
+  # at 256MB (25% of limit) gives headroom for the working set plus
+  # per-connection work_mem.
   resources:
     requests:
-      memory: "128Mi"
-      cpu: "10m"
+      memory: "512Mi"
+      cpu: "50m"
     limits:
-      memory: "256Mi"
+      memory: "1Gi"
   bootstrap:
     initdb:
       database: monolith

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.96.3
+      targetRevision: 0.96.4
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
## Problem

`monolith-pg` (CNPG) had been **OOMKilled 359 times** (exit 137), latest at 20:13 UTC. The instance hosts five databases, `monolith` (728MB), `temporal` (205MB), `temporal_visibility` (141MB), `lakehouse`, `postgres`, but was capped at a **256Mi** memory limit. Temporal's connection-heavy workload kept the working set (~241Mi live) against the ceiling, so any spike tripped the kernel OOM killer and CNPG just restarted it, over and over.

Discovered while checking resource usage after the ships deploy. The ships tables are **not** the cause (`positions_20260611` ≈ 4.7MB, `vessels` ≈ 216KB); this is a pre-existing undersize shared across all five DBs.

## Fix

In `chart/templates/cnpg-cluster.yaml`:
- memory limit `256Mi` -> `1Gi`, requests `128Mi` -> `512Mi`, cpu request `10m` -> `50m`
- `shared_buffers` `64MB` -> `256MB` (25% of the new limit)
- `effective_cache_size` `128MB` -> `768MB`

Chart `0.96.3` -> `0.96.4` + matching `targetRevision`.

## Note

CNPG applies memory/param changes via a rolling restart of the instance (single-instance cluster, so a brief blip). Expected and safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)