### PR TITLE
fix(monolith): restore vessel marker color saturation

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.97.0
+version: 0.97.1
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.97.0
+      targetRevision: 0.97.1
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/lib/public/components/ships/ShipsMap.svelte
+++ b/projects/monolith/frontend/src/lib/public/components/ships/ShipsMap.svelte
@@ -127,8 +127,16 @@
       const ctx = canvas.getContext("2d");
       ctx.scale(px / 20, px / 20); // path authored in a 20x20 viewBox
       const path = new Path2D("M10 1 L17 18 L10 14 L3 18 Z");
+      // The basemap canvas wears a `grayscale(0.4)` CSS filter to warm the
+      // tiles toward the cream palette (see <style>). The vessel symbols now
+      // render inside that same canvas, so they get desaturated too. Boost the
+      // fill's saturation here so that after the canvas filter the markers land
+      // back at the legend's vividness. Applied to the fill only; the ink
+      // outline is reset to no filter so it stays dark.
+      ctx.filter = "saturate(1.75) brightness(1.04)";
       ctx.fillStyle = fill;
       ctx.fill(path);
+      ctx.filter = "none";
       ctx.lineWidth = 1.5;
       ctx.lineJoin = "round";
       ctx.strokeStyle = p.ink;


### PR DESCRIPTION
## Problem

After the DOM-marker → GPU-symbol-layer rewrite (#2496), the vessel arrows look dull/desaturated compared to the legend swatches of the same colors.

## Why

The basemap canvas carries a `filter: grayscale(0.4) sepia(0.12) ...` CSS warm-tint (to push the tiles toward the cream palette). The old DOM markers lived outside the canvas and were never filtered; the new symbol-layer markers render **inside** the canvas, so `grayscale(0.4)` strips ~40% of their saturation. The legend swatches are still DOM (unfiltered), hence the mismatch.

## Fix

Boost each icon fill's saturation when rasterizing (`ctx.filter = "saturate(1.75) brightness(1.04)"`) so that after the canvas filter the markers land back at the legend's vividness. Applied to the fill only; the ink outline is reset to no filter so it stays dark. Basemap treatment unchanged. `ctx.filter` degrades gracefully (markers just render at today's saturation) on browsers that don't support it.

Frontend-only; deploys via Image Updater.

🤖 Generated with [Claude Code](https://claude.com/claude-code)