### PR TITLE
feat(monolith): full-bleed ships map with breadcrumb chip

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.97.1
+version: 0.98.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.97.1
+      targetRevision: 0.98.0
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/lib/public/components/ships/ShipsMap.svelte
+++ b/projects/monolith/frontend/src/lib/public/components/ships/ShipsMap.svelte
@@ -393,12 +393,14 @@
 <div class="map-wrap">
   <div class="map" bind:this={mapContainer}></div>
 
-  <div class="map-chip">
-    <span class="chip-name">Ships</span>
+  <nav class="map-chip" aria-label="Breadcrumb">
+    <a class="chip-home" href="https://jomcgi.dev/">jomcgi.dev</a>
+    <span class="chip-sep">/</span>
+    <span class="chip-name">ships</span>
     <span class="chip-sep">/</span>
     <span class="chip-live">live</span>
     <span class="chip-dot" aria-hidden="true"></span>
-  </div>
+  </nav>
 
   <div class="legend card-hard">
     <p class="eyebrow legend-title">Vessel type</p>
@@ -482,6 +484,17 @@
     font-weight: 700;
     letter-spacing: 0.1em;
     text-transform: uppercase;
+  }
+
+  .chip-home {
+    color: var(--ink);
+    text-decoration: underline;
+    text-underline-offset: 2px;
+    text-decoration-thickness: 1.5px;
+  }
+
+  .chip-home:hover {
+    color: var(--coral);
   }
 
   .chip-sep {

--- a/projects/monolith/frontend/src/routes/public/app/ships/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/ships/+page.svelte
@@ -6,33 +6,13 @@
   let { data } = $props();
 
   let vessels = $derived(data.snapshot?.vessels ?? []);
-  let count = $derived(data.snapshot?.count ?? vessels.length);
-
-  // "updated Ns ago": reset the clock each time a fresh snapshot lands, then
-  // tick a counter so the chip reads live without re-running the load.
-  let lastUpdated = $state(Date.now());
-  let secondsAgo = $state(0);
-
-  // data is a fresh object on every invalidateAll, so referencing it here
-  // re-runs the effect when the server load returns new vessels.
-  $effect(() => {
-    void data.snapshot;
-    lastUpdated = Date.now();
-    secondsAgo = 0;
-  });
 
   onMount(() => {
     // Live updates: re-run the SSR load on a timer. The browser hits the same
     // page route, which re-fetches the snapshot server-side. No client-side
     // call to /api/ships/* ever happens.
     const refresh = setInterval(() => invalidateAll(), 120_000);
-    const tick = setInterval(() => {
-      secondsAgo = Math.round((Date.now() - lastUpdated) / 1000);
-    }, 1000);
-    return () => {
-      clearInterval(refresh);
-      clearInterval(tick);
-    };
+    return () => clearInterval(refresh);
   });
 </script>
 
@@ -45,103 +25,32 @@
 </svelte:head>
 
 <div class="ships-page">
-  <header class="ships-head wrap">
-    <div class="ships-head-text">
-      <p class="eyebrow">Live AIS</p>
-      <h1 class="ships-title display">Ships</h1>
-      <p class="ships-sub">
-        Vessel positions, dead-reckoned between two-minute snapshots.
-      </p>
-    </div>
-    <div class="ships-status" aria-live="polite">
-      <span class="ships-dot" aria-hidden="true"></span>
-      <span class="ships-status-label">
-        {count} vessels &middot; updated {secondsAgo}s ago
-      </span>
-    </div>
-  </header>
-
-  <div class="ships-stage">
-    <ShipsMap {vessels} />
-  </div>
+  <!-- The visual heading is the breadcrumb chip inside ShipsMap; keep a real
+       (visually hidden) h1 so the page still has a heading for SEO + a11y. -->
+  <h1 class="sr-only">Live ships, AIS vessel tracker</h1>
+  <ShipsMap {vessels} />
 </div>
 
 <style>
+  /* Full-bleed: the map fills everything under the global nav, edge to edge.
+     ShipsMap's .map-wrap is absolutely positioned, so this is its containing
+     block. */
   .ships-page {
-    display: flex;
-    flex-direction: column;
+    position: relative;
     height: calc(100vh - 48px);
     background: var(--cream);
     color: var(--ink);
   }
 
-  .ships-head {
-    display: flex;
-    align-items: flex-end;
-    justify-content: space-between;
-    gap: 24px;
-    padding-top: 24px;
-    padding-bottom: 20px;
-    flex-wrap: wrap;
-  }
-
-  .ships-title {
-    font-size: clamp(40px, 7vw, 72px);
-    margin: 4px 0 6px;
-  }
-
-  .ships-sub {
-    font-family: var(--mono);
-    font-size: 13px;
-    color: var(--ink-3);
-    letter-spacing: 0.02em;
-  }
-
-  .ships-status {
-    display: inline-flex;
-    align-items: center;
-    gap: 10px;
-    padding: 10px 14px;
-    background: var(--paper);
-    border: 2px solid var(--ink);
-    box-shadow: var(--shadow-hard-sm);
-    font-family: var(--mono);
-    font-size: 12px;
-    font-weight: 600;
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
+  .sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0 0 0 0);
     white-space: nowrap;
-  }
-
-  .ships-dot {
-    width: 10px;
-    height: 10px;
-    border-radius: 999px;
-    background: var(--green);
-    border: 1px solid var(--ink);
-    animation: ships-pulse 1.6s ease-in-out infinite;
-  }
-
-  @keyframes ships-pulse {
-    0%,
-    100% {
-      opacity: 1;
-    }
-    50% {
-      opacity: 0.35;
-    }
-  }
-
-  .ships-stage {
-    flex: 1;
-    position: relative;
-    min-height: 0;
-    border-top: 2px solid var(--ink);
-  }
-
-  @media (prefers-reduced-motion: reduce) {
-    .ships-dot {
-      animation: none;
-    }
+    border: 0;
   }
 </style>


### PR DESCRIPTION
## What

Restructures the `/app/ships` top per the requested layout: drop the header band, let the map run edge-to-edge under the global nav, and replace the old "Ships / live" overlay with a breadcrumb chip.

- **Removed:** the header band (eyebrow "Live AIS" + "Ships" title + subtitle + the "N vessels · updated Ns ago" status pill).
- **Map is now full-bleed**, fills `calc(100vh - 48px)` edge to edge. `.ships-page` is the positioning context for the map overlay.
- **Breadcrumb chip** (top-left, existing hard-border style): `jomcgi.dev / ships / live ●`, with `jomcgi.dev` linking to the apex. The pulsing `live ●` dot still signals liveness.
- **Accessibility/SEO:** the visible h1 is replaced by a visually-hidden `.sr-only` h1 so the page keeps a heading.

## Note

The "N vessels · updated Ns ago" readout was dropped along with the band, matching the mockup. Easy to re-add as a small corner chip if wanted. Live refresh (re-running the SSR load every 120s) is unchanged.

Frontend-only; deploys via Image Updater. Chart pre-bumped to `0.98.0` in this PR to avoid the chart-version-bot push-back race.

🤖 Generated with [Claude Code](https://claude.com/claude-code)