### PR TITLE
feat(monolith): full-screen ships app, no nav, polished chip + zoom

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.98.0
+version: 0.99.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.98.0
+      targetRevision: 0.99.0
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/lib/public/components/ships/ShipsMap.svelte
+++ b/projects/monolith/frontend/src/lib/public/components/ships/ShipsMap.svelte
@@ -394,7 +394,9 @@
   <div class="map" bind:this={mapContainer}></div>
 
   <nav class="map-chip" aria-label="Breadcrumb">
-    <a class="chip-home" href="https://jomcgi.dev/">jomcgi.dev</a>
+    <a class="chip-home" href="https://jomcgi.dev/"
+      >jomcgi.dev<span class="chip-home-arrow" aria-hidden="true">↗</span></a
+    >
     <span class="chip-sep">/</span>
     <span class="chip-name">ships</span>
     <span class="chip-sep">/</span>
@@ -465,7 +467,26 @@
   .map :global(.maplibregl-ctrl-group) {
     border: 2px solid var(--ink);
     border-radius: 0;
+    /* No shadow on the group; each button lifts and casts its own shadow on
+       hover (see below), so the controls feel pressable rather than static. */
+  }
+
+  .map :global(.maplibregl-ctrl-group button) {
+    transition:
+      transform 110ms ease,
+      box-shadow 110ms ease;
+  }
+
+  .map :global(.maplibregl-ctrl-group button:hover) {
+    transform: translate(-1px, -1px);
     box-shadow: var(--shadow-hard-sm);
+    position: relative;
+    z-index: 1; /* lift the shadow above the adjacent button */
+  }
+
+  .map :global(.maplibregl-ctrl-group button:active) {
+    transform: translate(0, 0);
+    box-shadow: none; /* pressed back down */
   }
 
   .map-chip {
@@ -478,7 +499,6 @@
     padding: 8px 12px;
     background: var(--paper);
     border: 2px solid var(--ink);
-    box-shadow: var(--shadow-hard);
     font-family: var(--mono);
     font-size: 12px;
     font-weight: 700;
@@ -486,15 +506,33 @@
     text-transform: uppercase;
   }
 
+  /* The home crumb is a real link out to the apex: underlined by default with
+     a small click-through arrow, and on hover/focus it gets the CV's
+     highlighter-marker treatment (bold + accent swipe) to read as "selected". */
   .chip-home {
     color: var(--ink);
     text-decoration: underline;
-    text-underline-offset: 2px;
+    text-decoration-color: var(--blue);
     text-decoration-thickness: 1.5px;
+    text-underline-offset: 2px;
+    padding: 0 2px;
+    -webkit-box-decoration-break: clone;
+    box-decoration-break: clone;
+    transition:
+      background 140ms ease,
+      text-decoration-color 140ms ease;
   }
 
-  .chip-home:hover {
-    color: var(--coral);
+  .chip-home:hover,
+  .chip-home:focus-visible {
+    background: linear-gradient(transparent 56%, var(--accent) 56%);
+    text-decoration-color: var(--ink);
+  }
+
+  .chip-home-arrow {
+    margin-left: 1px;
+    font-size: 0.85em;
+    vertical-align: 0.08em;
   }
 
   .chip-sep {
@@ -657,6 +695,9 @@
   @media (prefers-reduced-motion: reduce) {
     .chip-dot {
       animation: none;
+    }
+    .map :global(.maplibregl-ctrl-group button) {
+      transition: none;
     }
   }
 </style>

--- a/projects/monolith/frontend/src/routes/+layout.svelte
+++ b/projects/monolith/frontend/src/routes/+layout.svelte
@@ -7,6 +7,14 @@
 
   let isPrivate = $derived($page.url.hostname.startsWith("private."));
 
+  // Apps under /app/* are full-screen experiences (e.g. the live ships map)
+  // that render their own chrome, so the site nav is suppressed for them. The
+  // hooks.js reroute keeps the browser path un-prefixed, but match the
+  // /public|/private prefixes too in case a route is hit directly.
+  let hideNav = $derived(
+    /^\/(public\/|private\/)?app\//.test($page.url.pathname),
+  );
+
   // Active-state derivation. The hooks.js reroute remaps
   // public.jomcgi.dev/* → /public/* and private.jomcgi.dev/* → /private/*
   // internally, but $page.url reflects the *browser* URL. So:
@@ -30,6 +38,8 @@
   });
 </script>
 
-<Nav route={activeRoute} {isPrivate} />
+{#if !hideNav}
+  <Nav route={activeRoute} {isPrivate} />
+{/if}
 
 {@render children()}

--- a/projects/monolith/frontend/src/routes/public/app/ships/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/ships/+page.svelte
@@ -37,7 +37,12 @@
      block. */
   .ships-page {
     position: relative;
-    height: calc(100vh - 48px);
+    /* No site nav on /app/* routes, so the map owns the whole viewport.
+       100dvh tracks the dynamic viewport (mobile browser chrome) so the
+       bottom-anchored legend never falls off-screen. 100vh is the fallback. */
+    height: 100vh;
+    height: 100dvh;
+    overflow: hidden;
     background: var(--cream);
     color: var(--ink);
   }


### PR DESCRIPTION
## What

Follow-ups on the ships app layout.

### Full-screen / viewport
- **Hide the site nav on `/app/*` routes.** Apps are full-screen experiences with their own chrome; generalized in the root layout via a path test (`/app/`, plus `/public|/private` prefixes for direct hits).
- **Ships page fills `100dvh`** instead of `calc(100vh - 48px)`. The nav was padding-sized (~50px), not 48px, so the old math overflowed the viewport, clipping the bottom-anchored legend and adding a scrollbar. With no nav, the map owns the whole dynamic viewport (`dvh` also handles mobile browser chrome).

### Chip + controls polish
- **Drop the chip drop-shadow** (wasn't adding much).
- **Click-through arrow** (`↗`) on `jomcgi.dev`, and on hover/focus the link gets the CV's highlighter-marker treatment (bold + accent swipe) to read as selected.
- **Zoom controls:** remove the group shadow; each button now lifts (`translate(-1px,-1px)`) and casts its own hard shadow on hover, pressing back down on `:active`. Disabled under `prefers-reduced-motion`.

Frontend-only; deploys via Image Updater. Chart pre-bumped to `0.99.0` to avoid the chart-version-bot push-back race.

🤖 Generated with [Claude Code](https://claude.com/claude-code)