### PR TITLE
fix(monolith): vibrant Other color + outlier-robust map bounds

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.102.0
+version: 0.102.1
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.102.0
+      targetRevision: 0.102.1
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/lib/public/components/ships/ShipsMap.svelte
+++ b/projects/monolith/frontend/src/lib/public/components/ships/ShipsMap.svelte
@@ -53,7 +53,7 @@
     tanker: "#ff564a", // coral-red
     hsc: "#ffcb1f", // golden
     special: "#35cb5b", // spring green
-    unknown: "#404a5c", // clean slate (was a muddy brown-gray)
+    unknown: "#8b6fe8", // periwinkle violet (completes the spectrum)
   };
 
   // Vessel-type filter. Each legend box toggles whether that ITU band shows on
@@ -216,6 +216,25 @@
     if (src) src.setData(buildFeatures());
   }
 
+  // AIS sentinels: lat 91 / lon 181 mean "position not available"; (0, 0) is
+  // null island. Drop these so they neither plot nor blow out the bounds.
+  function validLatLon(lat, lon) {
+    if (lat == null || lon == null) return false;
+    if (Math.abs(lat) > 90 || Math.abs(lon) > 180) return false;
+    if (lat === 0 && lon === 0) return false;
+    return true;
+  }
+
+  // Linear-interpolated quantile over a pre-sorted array.
+  function quantile(sorted, q) {
+    const pos = (sorted.length - 1) * q;
+    const base = Math.floor(pos);
+    const next = sorted[base + 1];
+    return next === undefined
+      ? sorted[base]
+      : sorted[base] + (pos - base) * (next - sorted[base]);
+  }
+
   // Reset fleet state to snapshot truth whenever a new snapshot arrives, then
   // repaint. `vessels` is a fresh array on every invalidateAll.
   function syncVessels() {
@@ -223,7 +242,7 @@
 
     const seen = new Set();
     for (const v of vessels) {
-      if (v.lat == null || v.lon == null) continue;
+      if (!validLatLon(v.lat, v.lon)) continue;
       const id = String(v.mmsi);
       seen.add(id);
       fleet.set(id, {
@@ -244,14 +263,23 @@
     pushData();
 
     if (!didFit && seen.size > 0) {
-      const b = new maplibregl.LngLatBounds();
-      let any = false;
+      const lats = [];
+      const lons = [];
       for (const v of vessels) {
-        if (v.lat == null || v.lon == null) continue;
-        b.extend([v.lon, v.lat]);
-        any = true;
+        if (!validLatLon(v.lat, v.lon)) continue;
+        lats.push(v.lat);
+        lons.push(v.lon);
       }
-      if (any) {
+      if (lats.length) {
+        lats.sort((a, b) => a - b);
+        lons.sort((a, b) => a - b);
+        // Frame the 1st-99th percentile so a few outliers (a vessel reporting
+        // a far-off position) can't blow out the zoom to the whole globe.
+        const q = 0.01;
+        const b = new maplibregl.LngLatBounds(
+          [quantile(lons, q), quantile(lats, q)],
+          [quantile(lons, 1 - q), quantile(lats, 1 - q)],
+        );
         map.fitBounds(b, { padding: 64, maxZoom: 9, duration: 0 });
         didFit = true;
       }


### PR DESCRIPTION
## 1. "Other" color
Was a muddy slate `#404a5c`. Now a **periwinkle violet `#8b6fe8`** that completes the spectrum (blue/cyan/red/yellow/green + violet) and stays distinct from the other five.

## 2. Map bounds blow-out
`fitBounds` spanned **every** vessel, so a single outlier (a bad or far AIS position) zoomed the initial view out to the whole globe (the Australia-centered frame).

- **Drop invalid positions** from both the markers and the bounds: null island `(0,0)` and AIS "not available" sentinels (`lat 91` / `lon 181`).
- **Frame the 1st-99th percentile** of positions so a few stragglers can't dictate the zoom. Verified: 99 Pacific NW vessels + 1 Australia outlier → 1st-pct lat `46.2` (frames the cluster, ignores the outlier). Works for the interim Pacific NW feed and a future global one alike.

Frontend-only; Image Updater deploys. Chart pre-bumped to `0.102.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)