### PR TITLE
feat(monolith): add ships.heat_cells table (heatmap stage 1)

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.102.1
+version: 0.103.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/migrations/20260611000000_ships_heat_cells.sql
+++ b/projects/monolith/chart/migrations/20260611000000_ships_heat_cells.sql
@@ -1,0 +1,21 @@
+-- ships.heat_cells: precomputed traffic-density rollup for the /app/ships heatmap.
+--
+-- One row per occupied ~500m grid cell, holding the count of position fixes that
+-- fell in that cell over the trailing retention window. Recomputed in full from
+-- ships.positions by an hourly scheduled rollup (ships.heat_rollup). positions is
+-- the 7-day partitioned source of truth; this table just caches the aggregate so
+-- the map can be served cheaply (the live GROUP BY over millions of rows is too
+-- heavy to run per request).
+--
+-- The cell index is floor(lat / 0.005) x floor(lon / 0.0075), a ~500m square at
+-- the Salish Sea latitude (~48N, where a degree of longitude is shorter than a
+-- degree of latitude). The serving layer reconstructs each cell's polygon as
+-- [lat_bin*step_lat, lon_bin*step_lon] .. [+step_lat, +step_lon].
+
+CREATE TABLE ships.heat_cells (
+    lat_bin      INTEGER NOT NULL,
+    lon_bin      INTEGER NOT NULL,
+    count        INTEGER NOT NULL,
+    computed_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (lat_bin, lon_bin)
+);

--- a/projects/monolith/chart/migrations/atlas.sum
+++ b/projects/monolith/chart/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:ZfbzjIlgGHFHB51p19feyV8dea7UTYel36E4r69lGok=
+h1:vbBC0fvCXJw9OSZXS3yOsIjb+kVHwYkopThyfEx7okQ=
 20260330000000_initial_schema.sql h1:J2futpSW0nJAIRR7nR7ssT7LwXIYrvRI+PkHb5Y4tLI=
 20260403000000_chat_schema.sql h1:pERUFC0vzM95etRuzp43XzkCV7lBCzrrtY5Mk7aF3CA=
 20260404000000_chat_attachments.sql h1:tv+Fdbr1rQC5nzUxfaBC0O6fu2OMGgLWf+YNg1WQXi4=
@@ -28,3 +28,4 @@ h1:ZfbzjIlgGHFHB51p19feyV8dea7UTYel36E4r69lGok=
 20260524000000_gate_external_research.sql h1:+PavvmK2LurjiKBrXucFNoZg7XnV7Buq/QpMXVhI6HE=
 20260530000000_gaps_state_class_combo.sql h1:5xds/70HjdD+YL1IAgzgGiRCMpXyeVt/JShx49GBr9g=
 20260610000000_ships_schema.sql h1:Ja7g3S4yJxKhscRMUUqg+hg0kAWVRoHeUkKxkZoPxSQ=
+20260611000000_ships_heat_cells.sql h1:k3TYgAMF/TSXFcJoHtJlc9Or/NP2C3L97nEo2UpDdlk=

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.102.1
+      targetRevision: 0.103.0
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
Stage 1 (schema) of the `/app/ships` traffic-density heatmap. Shipping the migration first so it deploys and I can verify the real rollup against the table before wiring the job/API/frontend.

## What
- New `ships.heat_cells` table: one row per occupied ~500m grid cell (`floor(lat/0.005)` × `floor(lon/0.0075)`) with a position-fix `count` + `computed_at`. PK `(lat_bin, lon_bin)`.
- Regenerated `atlas.sum` (`atlas migrate hash`); `atlas migrate validate` passes.

## Why this shape
Validated the rollup aggregate against live `ships.positions` first:
- **~9,017 occupied cells**, 53k positions, **27ms** query.
- Counts heavily skewed: p50=2, p90=9, p99=80, max=620.
- Hot cells land on real anchorages (Elliott Bay `47.66,-122.39`; Burrard Inlet; Anacortes) and a fast-ferry lane near Vancouver, exactly the structure worth mapping.

`ships.positions` is the 7-day partitioned source; this table caches the aggregate so the map serves cheaply (the live GROUP BY is too heavy per request).

## Next stages (separate PRs)
2. Hourly rollup job (`ships.heat_rollup`) + `GET /api/ships/heat`.
3. Frontend WebGL fill layer + Vessels/Heat toggle + brutalist color ramp.

Chart bumped to `0.103.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)