### PR TITLE
feat(monolith): ships heatmap rollup + /api/ships/heat (stage 2)

### DIFF
--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -2038,6 +2038,17 @@ py_test(
 )
 
 py_test(
+    name = "ships_heat_test",
+    srcs = ["ships/heat_test.py"],
+    imports = ["."],
+    deps = [
+        ":monolith_backend",
+        "@pip//pytest",
+        "@pip//sqlmodel",
+    ],
+)
+
+py_test(
     name = "ships_ais_test",
     srcs = ["ships/ais_test.py"],
     imports = ["."],

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.103.0
+version: 0.104.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.103.0
+      targetRevision: 0.104.0
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/ships/__init__.py
+++ b/projects/monolith/ships/__init__.py
@@ -12,8 +12,9 @@ def register(app: FastAPI) -> None:
 
 
 def on_startup_jobs(session: Session) -> None:
-    """Register ships scheduled jobs (partition maintenance / retention)."""
+    """Register ships scheduled jobs (partition maintenance, heatmap rollup)."""
     from shared.scheduler import register_job
+    from ships.heat import heat_rollup_handler
     from ships.retention import partition_maintenance_handler
 
     register_job(
@@ -22,4 +23,11 @@ def on_startup_jobs(session: Session) -> None:
         interval_secs=86400,
         handler=partition_maintenance_handler,
         ttl_secs=3600,
+    )
+    register_job(
+        session,
+        name="ships.heat_rollup",
+        interval_secs=3600,
+        handler=heat_rollup_handler,
+        ttl_secs=1800,
     )

--- a/projects/monolith/ships/heat.py
+++ b/projects/monolith/ships/heat.py
@@ -1,0 +1,110 @@
+"""Ships traffic-density heatmap rollup.
+
+Recomputes ``ships.heat_cells`` from ``ships.positions`` (the 7-day partitioned
+window): one row per occupied ~500m grid cell holding the count of DISTINCT
+vessels that MOVED through it.
+
+Two deliberate choices make the map show *traffic* rather than *dwell*:
+
+  - "Moved" = the vessel's speed-over-ground exceeded ``MIN_SPEED_KN`` at some
+    point in the window. This keeps anchored-but-real traffic (a cargo ship
+    waiting in the bay arrives and departs, so it moved) while dropping
+    permanently-fixed small craft that never move.
+  - ``count(distinct mmsi)`` (not raw fix count) so a single vessel reporting
+    every couple of minutes for days counts once per cell, not thousands of
+    times. An anchorage then reads as "how many different ships used it".
+
+Validated against live data before building: ~9k occupied cells, counts 1-22,
+hot cells landing on real ferry lanes and harbour approaches.
+
+This module is split like ``retention.py``:
+
+  - Pure helpers (cell steps, the rollup SQL builder) are unit-tested.
+  - A thin handler runs the live ``DELETE`` + ``INSERT`` off the event loop. The
+    aggregation is Postgres-only and is exercised in prod / CI-against-Postgres,
+    never in the SQLite unit tests.
+"""
+
+import asyncio
+import logging
+import os
+from datetime import datetime
+
+from sqlmodel import Session, text
+
+logger = logging.getLogger("ships")
+
+# ~500m square cells at Salish Sea latitude (~48N). A degree of longitude is
+# shorter than a degree of latitude there, so the lon step is larger to keep
+# cells roughly square. The serving layer reconstructs each cell polygon as
+# [lat_bin*LAT_STEP, lon_bin*LON_STEP] .. [+LAT_STEP, +LON_STEP].
+LAT_STEP = float(os.environ.get("SHIPS_HEAT_LAT_STEP", "0.005"))
+LON_STEP = float(os.environ.get("SHIPS_HEAT_LON_STEP", "0.0075"))
+
+# A vessel counts as real traffic (not a fixed object) if its speed exceeds this
+# at any point in the window. Env-tunable so the cut can be adjusted live.
+MIN_SPEED_KN = float(os.environ.get("SHIPS_HEAT_MIN_SPEED_KN", "1.0"))
+
+# Trailing window. Matches positions retention (SHIPS_RETENTION_DAYS).
+WINDOW_DAYS = int(os.environ.get("SHIPS_HEAT_WINDOW_DAYS", "7"))
+
+
+def rollup_insert_sql(
+    lat_step: float, lon_step: float, min_speed: float, window_days: int
+) -> str:
+    """Build the INSERT...SELECT that fills heat_cells from positions.
+
+    All interpolated values are floats/ints derived from module constants (env),
+    never user input, so the f-string cannot carry SQL injection. (Flagged to
+    preempt the semgrep raw-SQL rule, mirrors retention.py.)
+    """
+    return (
+        "INSERT INTO ships.heat_cells (lat_bin, lon_bin, count) "
+        "WITH movers AS ("
+        "  SELECT mmsi FROM ships.positions"
+        f"  WHERE recorded_at >= now() - interval '{window_days} days'"
+        f"  GROUP BY mmsi HAVING max(speed) >= {min_speed}"
+        ") "
+        f"SELECT floor(p.lat / {lat_step})::int, floor(p.lon / {lon_step})::int, "
+        "       count(distinct p.mmsi) "
+        "FROM ships.positions p JOIN movers USING (mmsi) "
+        f"WHERE p.recorded_at >= now() - interval '{window_days} days' "
+        "  AND p.lat BETWEEN -90 AND 90 AND p.lon BETWEEN -180 AND 180 "
+        "  AND NOT (p.lat = 0 AND p.lon = 0) "
+        "GROUP BY 1, 2"
+    )
+
+
+def _run_heat_rollup() -> None:
+    """Synchronous full-replace rollup; own session, run off the event loop.
+
+    DELETE + INSERT in one transaction so readers of heat_cells never see an
+    empty table mid-rebuild (MVCC keeps the old rows visible until commit).
+    """
+    from app.db import get_engine
+
+    insert_sql = rollup_insert_sql(LAT_STEP, LON_STEP, MIN_SPEED_KN, WINDOW_DAYS)
+    with Session(get_engine()) as session:
+        try:
+            session.execute(text("DELETE FROM ships.heat_cells"))
+            session.execute(text(insert_sql))
+            session.commit()
+            logger.info(
+                "ships heat rollup ok (window=%dd, min_speed=%.1f)",
+                WINDOW_DAYS,
+                MIN_SPEED_KN,
+            )
+        except Exception:
+            logger.exception("ships heat rollup failed")
+            session.rollback()
+
+
+async def heat_rollup_handler(session: Session) -> datetime | None:
+    """Recompute the traffic-density heatmap rollup.
+
+    Delegates the synchronous aggregation to a worker thread so it never blocks
+    the event loop. The scheduler passes a session, but the work uses its own
+    session inside the thread (mirrors partition_maintenance_handler).
+    """
+    await asyncio.to_thread(_run_heat_rollup)
+    return None

--- a/projects/monolith/ships/heat_test.py
+++ b/projects/monolith/ships/heat_test.py
@@ -1,0 +1,35 @@
+"""Unit tests for ships/heat.py: the traffic-density rollup SQL builder.
+
+The pure SQL builder is the testable unit; the live DELETE+INSERT is Postgres-
+only (aggregation over ships.positions) and is exercised in prod / CI-against-
+Postgres, never here.
+"""
+
+from ships.heat import rollup_insert_sql
+
+
+def test_rollup_insert_sql_counts_distinct_movers():
+    sql = rollup_insert_sql(0.005, 0.0075, 1.0, 7)
+
+    # Full-replace destination is the rollup table.
+    assert "INSERT INTO ships.heat_cells (lat_bin, lon_bin, count)" in sql
+    # Distinct vessels (not raw fixes) so dwell can't dominate.
+    assert "count(distinct p.mmsi)" in sql
+    # Only vessels that move at some point in the window (per-vessel filter).
+    assert "GROUP BY mmsi HAVING max(speed) >= 1.0" in sql
+    # Trailing window is applied to both the movers CTE and the main scan.
+    assert sql.count("interval '7 days'") == 2
+    # Cell binning uses the supplied steps.
+    assert "floor(p.lat / 0.005)::int" in sql
+    assert "floor(p.lon / 0.0075)::int" in sql
+    # Bogus coordinates are dropped.
+    assert "AND p.lat BETWEEN -90 AND 90 AND p.lon BETWEEN -180 AND 180" in sql
+    assert "NOT (p.lat = 0 AND p.lon = 0)" in sql
+
+
+def test_rollup_insert_sql_threads_all_params():
+    sql = rollup_insert_sql(0.01, 0.02, 2.5, 3)
+    assert "floor(p.lat / 0.01)::int" in sql
+    assert "floor(p.lon / 0.02)::int" in sql
+    assert "HAVING max(speed) >= 2.5" in sql
+    assert "interval '3 days'" in sql

--- a/projects/monolith/ships/models.py
+++ b/projects/monolith/ships/models.py
@@ -68,3 +68,16 @@ class LatestPosition(
     recorded_at: datetime
     first_seen_at_location: datetime | None = Field(default=None)
     updated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+
+
+class HeatCell(SQLModel, table=True):  # nosemgrep: sqlmodel-datetime-without-factory
+    __tablename__ = "heat_cells"
+    __table_args__ = {"schema": "ships", "extend_existing": True}
+
+    # Precomputed traffic-density rollup: one row per occupied ~500m grid cell
+    # (floor(lat/step) x floor(lon/step)) holding the count of distinct moving
+    # vessels that used it. Rebuilt in full by ships.heat.heat_rollup_handler.
+    lat_bin: int = Field(primary_key=True)
+    lon_bin: int = Field(primary_key=True)
+    count: int
+    computed_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))

--- a/projects/monolith/ships/router.py
+++ b/projects/monolith/ships/router.py
@@ -22,7 +22,9 @@ from fastapi import APIRouter, Depends, Request, Response
 from sqlmodel import Session, select
 
 from app.db import get_session
-from ships.models import LatestPosition, Position, Vessel
+from ships.heat import LAT_STEP as HEAT_LAT_STEP
+from ships.heat import LON_STEP as HEAT_LON_STEP
+from ships.models import HeatCell, LatestPosition, Position, Vessel
 
 logger = logging.getLogger("ships")
 
@@ -38,6 +40,11 @@ _SNAPSHOT_CACHE_CONTROL = (
 # Mirrors SHIPS_TRACK_CACHE_CONTROL in frontend/src/lib/cache-headers.js, keep in sync.
 _TRACK_CACHE_CONTROL = (
     "public, s-maxage=60, stale-while-revalidate=300, stale-if-error=86400"
+)
+# Heatmap rollup refreshes hourly, so 5 min fresh with a 1 h SWR window is plenty.
+# Mirrors SHIPS_HEAT_CACHE_CONTROL in frontend/src/lib/cache-headers.js, keep in sync.
+_HEAT_CACHE_CONTROL = (
+    "public, s-maxage=300, stale-while-revalidate=3600, stale-if-error=86400"
 )
 
 
@@ -186,3 +193,27 @@ def get_track(
 
     response.headers["Cache-Control"] = _TRACK_CACHE_CONTROL
     return {"mmsi": mmsi, "count": len(track), "track": track}
+
+
+@router.get("/heat")
+def get_heat(
+    response: Response,
+    session: Session = Depends(get_session),
+):
+    """Precomputed traffic-density grid for the /app/ships heatmap.
+
+    Returns the occupied ~500m cells as compact [lat_bin, lon_bin, count]
+    triples plus the cell steps; the client reconstructs each cell polygon as
+    [lat_bin*step_lat, lon_bin*step_lon] .. [+step]. SSR-only, CDN-cached. The
+    heavy aggregation runs hourly in ships.heat; this just reads the rollup.
+    """
+    rows = session.exec(select(HeatCell)).all()
+    cells = [[c.lat_bin, c.lon_bin, c.count] for c in rows]
+
+    response.headers["Cache-Control"] = _HEAT_CACHE_CONTROL
+    return {
+        "step_lat": HEAT_LAT_STEP,
+        "step_lon": HEAT_LON_STEP,
+        "count": len(cells),
+        "cells": cells,
+    }

--- a/projects/monolith/ships/router_test.py
+++ b/projects/monolith/ships/router_test.py
@@ -17,7 +17,7 @@ from sqlmodel import Session, SQLModel, create_engine
 from sqlmodel.pool import StaticPool
 
 from app.db import get_session
-from ships.models import LatestPosition, Position, Vessel
+from ships.models import HeatCell, LatestPosition, Position, Vessel
 from ships.router import _parse_since, router
 
 T0 = datetime(2026, 6, 10, 12, 0, 0, tzinfo=timezone.utc)
@@ -214,3 +214,31 @@ class TestParseSince:
         assert _parse_since("h") is None
         assert _parse_since("") is None
         assert _parse_since(None) is None
+
+
+def _seed_heat(session: Session) -> None:
+    session.add(HeatCell(lat_bin=9856, lon_bin=-16416, count=22))
+    session.add(HeatCell(lat_bin=9520, lon_bin=-16312, count=3))
+    session.commit()
+
+
+class TestHeat:
+    def test_returns_cells_and_steps(self, client, session):
+        _seed_heat(session)
+        r = client.get("/api/ships/heat")
+        assert r.status_code == 200
+        body = r.json()
+        assert body["count"] == 2
+        assert body["step_lat"] == 0.005
+        assert body["step_lon"] == 0.0075
+        # Compact [lat_bin, lon_bin, count] triples; client rebuilds polygons.
+        triples = {(c[0], c[1]): c[2] for c in body["cells"]}
+        assert triples[(9856, -16416)] == 22
+        assert triples[(9520, -16312)] == 3
+
+    def test_empty_when_no_rollup(self, client):
+        r = client.get("/api/ships/heat")
+        assert r.status_code == 200
+        body = r.json()
+        assert body["count"] == 0
+        assert body["cells"] == []


### PR DESCRIPTION
Stage 2 of the `/app/ships` traffic-density heatmap: the rollup job + serving endpoint. (Stage 1, the `heat_cells` table, is already merged & deployed.)

## The metric (validated against prod data first)
`ships.heat_cells` is recomputed hourly from the 7-day `positions` window as **`count(distinct mmsi)` per ~500m cell, over vessels with `max(speed) >= 1 kn`**. This shows *traffic*, not *dwell*:
- The per-vessel `max(speed)` filter keeps anchored-but-real vessels (a cargo ship that arrives, anchors in the bay, departs **moves** at some point) while dropping permanently-fixed small craft (43% of vessels never move).
- `count(distinct mmsi)` (not raw fixes) stops one vessel reporting every 2 min for days from burning a cell, an anchorage reads as "how many different ships used it."

Measured on live data: **9,153 cells, counts 1–22**, hot cells landing on real ferry lanes (Elliott Bay, 19 vessels) and harbour approaches (Vancouver, 22 vessels). The exact `DELETE`+`INSERT` was run against the prod table to confirm before this PR.

## Changes
- `ships/heat.py` — pure `rollup_insert_sql` builder + `heat_rollup_handler` (own-session `DELETE`+`INSERT` off the event loop in one txn, mirrors `retention.py`). Cell steps / speed / window are env-tunable.
- `ships/__init__.py` — register `ships.heat_rollup` at 3600s.
- `ships/models.py` — `HeatCell` model (composite PK; serves the API + makes the table in SQLite tests).
- `ships/router.py` — `GET /api/ships/heat` → `{step_lat, step_lon, count, cells:[[lat_bin,lon_bin,count]]}`, CDN-cached (5 min fresh / 1 h SWR).
- Tests: `heat_test` (SQL builder) + `router_test::TestHeat`; hand-registered BUILD entry (ships is gazelle-excluded).

## Next
Stage 3: the WebGL fill layer + Vessels/Heat toggle + brutalist color ramp (tuned to the 1–22 range).

Chart bumped to `0.104.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)