### PR TITLE
docs(adr): CLI multi-platform distribution via native execution platforms

### DIFF
--- a/docs/decisions/index.md
+++ b/docs/decisions/index.md
@@ -69,3 +69,7 @@ ADRs document significant architectural decisions and their context.
 | [002 - Service Deployment Tooling](tooling/002-service-deployment-tooling.md) | Copier template to scaffold new services, eliminating per-service boilerplate           |
 | [003 - Spec-First CLI and Skills](tooling/003-spec-first-cli-and-skills.md)   | OpenAPI as source of truth; CLI commands and Claude skills are derived                  |
 | [004 - OCaml Rules for Semgrep](tooling/004-ocaml-rules-for-semgrep.md)       | Scale the custom bazel/ocaml ruleset (not obazl); ppx first, per-arch native toolchains |
+| [005 - tOyCaml Demonstrator](tooling/005-toycaml-demonstrator.md)             | Engine-shaped demonstrator exercising the ruleset before Semgrep lands                  |
+| [006 - Multi-arch OCaml Toolchains](tooling/006-extensible-multiarch-ocaml-toolchains.md) | Data-driven arch registry; per-arch toolchain registration gated on pool verification |
+| [007 - OCaml BUILD Generation](tooling/007-ocaml-build-file-generation-gazelle.md) | Gazelle-based BUILD file generation for OCaml sources                              |
+| [008 - CLI Multi-platform Distribution](tooling/008-cli-multiplatform-distribution.md) | One Bazel graph, native execution platforms (cloud arm64, self-hosted darwin); no cross-compilation, QEMU, or wasm |

--- a/docs/decisions/tooling/006-extensible-multiarch-ocaml-toolchains.md
+++ b/docs/decisions/tooling/006-extensible-multiarch-ocaml-toolchains.md
@@ -87,6 +87,11 @@ trivial `uname -m` on the existing executor.
 
 1. The exact BuildBuddy execution-property key(s) for arch routing (`Arch`, and
    any pool selector) -- resolved against executor docs + the probe at Phase 7.
+   **Update 2026-06-12:** pool availability is resolved. BuildBuddy launched
+   autoscaled cloud linux/arm64 executors on 2026-01-15 (`Arch: arm64`), so
+   Phase 7 needs no self-hosted pool; see
+   [ADR 008](008-cli-multiplatform-distribution.md) for the verified findings
+   and the extension of this model to CLI distribution (including darwin).
 2. Whether a production deployment would want additional arches beyond
    linux x86_64/aarch64 (the registry makes this a one-line answer when known).
 

--- a/docs/decisions/tooling/008-cli-multiplatform-distribution.md
+++ b/docs/decisions/tooling/008-cli-multiplatform-distribution.md
@@ -1,0 +1,147 @@
+# ADR 008: CLI multi-platform distribution via native execution platforms
+
+**Author:** Joe McGinley
+**Status:** Accepted
+**Created:** 2026-06-12
+**Refines:** [ADR 006](006-extensible-multiarch-ocaml-toolchains.md) (extends its per-arch model to CLI distribution and resolves its pool-availability question)
+
+---
+
+## Problem
+
+The OCaml ruleset (ADR 004/005/006) will eventually produce a user-distributed
+CLI (Semgrep-derived), not just cluster images. That changes the target matrix:
+linux x86_64/arm64, macOS arm64 (must-have within a year), possibly macOS
+x86_64 and Windows later. ADR 006 fixed the per-arch mechanism for the cluster
+but left distribution unaddressed, and the obvious gap was uncomfortable: OCaml
+appeared to force "Bazel for linux plus a separate non-Bazel mac lane", a
+fragmented release story.
+
+Deep research (June 2026, multi-source with 3-vote adversarial verification of
+the load-bearing claims) re-examined the strategy space: upstream OCaml
+cross-compilation, cross tooling, wasm, QEMU emulation, and how peer OCaml
+CLIs actually ship. This ADR records the verified findings and the decided
+direction.
+
+## Decision
+
+**One Bazel graph, multiple native execution platforms, all scheduled through
+BuildBuddy.** The build definition stays singular; only the execution platform
+varies per target platform.
+
+| Target | Execution | Notes |
+| --- | --- | --- |
+| linux x86_64 | BuildBuddy cloud executors (today's pool) | unchanged |
+| linux arm64 | BuildBuddy **cloud** arm64 executors (`Arch: arm64`) | cloud pool exists since 2026-01-15, un-gating ADR 006's Phase 7 with zero infra on our side |
+| macOS arm64 | **Self-hosted BuildBuddy darwin executor on genuine Apple hardware** | EC2 Mac dedicated host or a rack Mac mini; choice deferred to implementation. Release-lane platform (nightly/tag builds), not per-PR CI |
+| Windows | Out of scope until demand exists | semgrep's native MinGW-on-windows-runner pipeline is a proven template for our exact C-stub stack when needed |
+
+Supporting decisions:
+
+- **Post-5.4 consolidation option (not a prerequisite):** vanilla OCaml 5.4+
+  can build a linux-x86_64 to linux-arm64 cross compiler (upstream CI-tested).
+  Once our pin moves to 5.4 (semgrep upstream is moving before EoY), linux
+  arm64 *builds* can consolidate onto the amd64 pool, keeping a small arm64
+  test shard. This restores the single-pool uniformity the rest of the repo
+  already has (Go cross-compiles via transitions; apko assembles prebuilt
+  apks), and is a contained optimization on top of this decision.
+- **Distribution layer:** musl-static linux binaries (the dune/unison pattern)
+  rather than a glibc/manylinux matrix; GitHub artifact attestations on
+  release tarballs (the dune pattern).
+- **macOS is structurally different from linux arm64, and the plan accepts
+  that.** A compile target is CPU + OS + ABI/libc, not an architecture. The
+  aarch64 code generator is shared, but darwin means Mach-O + ld64 + mandatory
+  code signing, and compiling/linking against libSystem and the Apple SDK,
+  which the Xcode EULA ties to Apple hardware. That licensing fact, not a
+  technical gap, is why no clean linux-to-macOS toolchain exists in any
+  language ecosystem and why mac capacity means Apple hardware (which EC2 Mac
+  provides legitimately).
+
+## Architecture
+
+```mermaid
+graph TD
+    G[One Bazel graph<br/>same //...:cli targets] --> S[BuildBuddy scheduler]
+    S --> A[Cloud pool<br/>linux amd64]
+    S --> B[Cloud pool<br/>linux arm64<br/>since 2026-01]
+    S --> C[Self-hosted darwin executor<br/>EC2 Mac or rack Mac mini<br/>release lane only]
+    A --> R[Release artifacts<br/>musl-static linux, mac arm64<br/>+ attestations]
+    B --> R
+    C --> R
+```
+
+## Verified findings
+
+Load-bearing claims were adversarially verified (3 independent votes each,
+primary sources):
+
+| Finding | Status |
+| --- | --- |
+| BuildBuddy launched autoscaled cloud linux/arm64 RBE executors 2026-01-15; darwin/windows executors remain self-hosted only | 3/3 confirmed |
+| Upstream OCaml CI cross-builds linux-x86_64 to aarch64-linux-gnu (plus mingw64, Android); no darwin target | 3/3 confirmed |
+| The simplified cross machinery (PR #13526) ships in **5.4.0+**, not vanilla 5.3 (the "5.3 cross compiler" demo used backports) | 2/3 corrected the 5.3 claim |
+| No publicly available linux-to-macOS toolchain for OCaml 5.x exists (osxcross-based repos frozen at 4.14; the zig attempt died at link errors and was abandoned) | confirmed (softened from "none working": one company privately crosses a 5.2 backport to macOS, host unspecified) |
+| QEMU user-mode emulation: 5-20x slowdown on compiler workloads, documented Bazel breakage, no production RBE-under-QEMU precedent | confirmed |
+| wasm_of_ocaml is mature for JS hosts (~2x native; Jane Street production) but the standalone WASI runtime is still an unmerged PR; C stubs are hand-written glue; semgrep retired its JS/wasm Windows path in favor of native | 3/3 confirmed |
+| Every peer OCaml CLI (semgrep, dune, flow, unison, infer, ocamlformat) ships from native runners per OS/arch; none cross-compile; semgrep's arm64 wheels build on Depot native arm builders (QEMU as enabled fallback only) | confirmed (one secondary-source detail corrected) |
+| semgrep ships native Windows since Fall 2025: native windows-2022 runner + MinGW-w64 + opam, keeping PCRE2 and tree-sitter as native DLLs | confirmed |
+
+## Alternatives Considered
+
+- **linux-to-macOS cross-compilation:** no public OCaml 5 toolchain, the one
+  serious attempt (zig cc) abandoned at link errors, and the Apple SDK is
+  EULA-bound to Apple hardware. Dead for the planning horizon.
+- **QEMU emulation for foreign arches:** 5-20x on compiler-heavy work plus
+  documented Bazel breakage. Even semgrep keeps it only as a fallback.
+- **wasm distribution:** Node-shaped today (no merged WASI runtime), manual C
+  stub glue, and the closest peer retired this approach. Retained as a future
+  browser/playground option only.
+- **A GitHub-Actions-only release lane outside Bazel:** loses hermeticity,
+  RBE caching, and the single build definition; this fragmentation concern is
+  what prompted the research.
+- **Dropping macOS:** fails the stated must-have.
+
+## Security
+
+Baseline per `docs/security.md`. New surface: a self-hosted darwin executor
+joins the build plane; its BuildBuddy API key should be scoped to that
+executor role and the host treated as release infrastructure (patched,
+access-controlled). Release artifacts gain GitHub artifact attestations.
+Distributing macOS binaries will eventually require Apple Developer ID
+signing/notarization (Gatekeeper); that pipeline is deliberately out of scope
+here and tracked as an open question.
+
+## Risks
+
+| Risk | Likelihood | Impact | Mitigation |
+| --- | --- | --- | --- |
+| EC2 Mac economics (24h minimum dedicated-host billing) make the mac lane expensive if treated as always-on CI | Medium | Low | Release-lane only; scheduled allocate/build/release automation, or a rack Mac mini (no minimum, one-time cost) |
+| Darwin executor is a pet (macOS updates, Xcode CLT, executor upgrades) | High | Low | One host, release-lane only; AMI/snapshot the known-good image |
+| BuildBuddy cloud mac RBE turns out to exist and we built self-hosted unnecessarily | Low | Low | Ask BuildBuddy before provisioning; architecture is identical either way |
+| 5.4 pin bump slips (cross consolidation deferred indefinitely) | Medium | Low | Consolidation is an optimization; the arm64 cloud pool path works on 5.3 today |
+| macOS signing/notarization blocks first mac release | Medium | Medium | Resolve the Developer ID question before announcing mac support |
+
+## Open Questions
+
+1. EC2 Mac dedicated host vs rack Mac mini for the darwin executor (ops/cost
+   preference; swappable later).
+2. Apple Developer ID signing + notarization pipeline for distributed mac
+   binaries.
+3. Whether/when Windows demand justifies replicating semgrep's MinGW pipeline.
+
+## References
+
+| Resource | Relevance |
+| --- | --- |
+| [BuildBuddy: Remote Builds on linux/arm64](https://www.buildbuddy.io/blog/arm64-support/) | cloud arm64 executors (2026-01-15) |
+| [BuildBuddy RBE platforms docs](https://www.buildbuddy.io/docs/rbe-platforms/) | `Arch` exec_property; darwin self-hosted only |
+| [ocaml/ocaml build-cross.yml](https://github.com/ocaml/ocaml/blob/trunk/.github/workflows/build-cross.yml) | upstream-tested cross targets |
+| [ocaml/ocaml PR #13526](https://github.com/ocaml/ocaml/pull/13526) | cross-compiler build simplification (5.4.0) |
+| [discuss: OCaml 5.3 cross compiler](https://discuss.ocaml.org/t/building-an-ocaml-cross-compiler-with-ocaml-5-3/15918) | 5.3 needs backports |
+| [discuss: zig as OCaml cross compiler](https://discuss.ocaml.org/t/early-work-experimenting-with-zig-as-a-cross-compiler-for-ocaml/16151) | linux-to-darwin attempt abandoned |
+| [semgrep v1.100.0 release workflows](https://github.com/semgrep/semgrep/tree/v1.100.0/.github/workflows) | peer pipeline: native runners per platform |
+| [semgrep windows.libsonnet](https://github.com/semgrep/semgrep/blob/develop/.github/workflows/libs/windows.libsonnet) | native Windows MinGW template (our C-stub stack) |
+| [Tarides: wasm_of_ocaml optimisations (2026-02)](https://tarides.com/blog/2026-02-11-announcing-new-wasm-of-ocaml-optimisations/) | WASI still an open PR |
+| [dune binary-distribution](https://github.com/ocaml-dune/binary-distribution) | musl-static + attestation distribution pattern |
+| [uber/hermetic_cc_toolchain](https://github.com/uber/hermetic_cc_toolchain) | zig cc for the C half of future cross consolidation |
+| `docs/decisions/tooling/006-extensible-multiarch-ocaml-toolchains.md` | the per-arch mechanism this extends |

--- a/projects/websites/docs.jomcgi.dev/.vitepress/adr-sidebar.json
+++ b/projects/websites/docs.jomcgi.dev/.vitepress/adr-sidebar.json
@@ -1,1 +1,218 @@
-[{"text":"Agents","collapsed":true,"items":[{"text":"001 - Self-Hosted Autonomous Coding Agents via OpenHands","link":"/docs/decisions/agents/001-background-agents"},{"text":"002 - Kubernetes-Native OpenHands Sandboxes via agent-sandbox","link":"/docs/decisions/agents/002-openhands-agent-sandbox"},{"text":"003 - MCP Context Forge as Agent Tool Gateway","link":"/docs/decisions/agents/003-context-forge"},{"text":"004 - Autonomous Coding Agents","link":"/docs/decisions/agents/004-autonomous-agents"},{"text":"005 - Role-Based MCP Access","link":"/docs/decisions/agents/005-role-based-mcp-access"},{"text":"006 - OIDC Authentication for MCP Gateway","link":"/docs/decisions/agents/006-oidc-auth-mcp-gateway"},{"text":"007 - Agent Run Orchestration Service","link":"/docs/decisions/agents/007-agent-orchestrator"},{"text":"008 - Cluster Patrol Loop Resilience","link":"/docs/decisions/agents/008-cluster-patrol-loop-resilience"},{"text":"009 - Automated Test Generation Bots","link":"/docs/decisions/agents/009-automated-test-generation"},{"text":"010 - Recipe-Driven Agent Registry","link":"/docs/decisions/agents/010-recipe-driven-agent-registry"},{"text":"011 - Agent MCP v1 Follow-ons and Deferred Self-Improvement Loop","link":"/docs/decisions/agents/011-agent-mcp-v1-followons"},{"text":"011 - Cloudflare Managed OAuth for MCP Gateway","link":"/docs/decisions/agents/011-cloudflare-managed-oauth"},{"text":"012 - Knowledge Gardener Two-Tier Model Pipeline","link":"/docs/decisions/agents/012-knowledge-gardener-model-pipeline"},{"text":"013 - Knowledge Gardener Gemma4-Only Pipeline","link":"/docs/decisions/agents/013-knowledge-gardener-gemma4-only"},{"text":"014 - AX + Substrate as the Agent Runtime Substrate","link":"/docs/decisions/agents/014-ax-substrate-agent-runtime"},{"text":"015 - Temporal as the Orchestration Substrate","link":"/docs/decisions/agents/015-temporal-orchestration-substrate"},{"text":"016 - NATS as the Canonical Event Stream","link":"/docs/decisions/agents/016-nats-canonical-event-stream"},{"text":"017 - Domain Event Schema and Tombstone Semantics","link":"/docs/decisions/agents/017-domain-event-schema"}]},{"text":"Docs","collapsed":true,"items":[{"text":"001 - Static Documentation Site for docs.jomcgi.dev","link":"/docs/decisions/docs/001-static-docs-site"}]},{"text":"Networking","collapsed":true,"items":[{"text":"001 - Reduce Cloudflare Operator Scope via Envoy Gateway","link":"/docs/decisions/networking/001-cloudflare-envoy-gateway"},{"text":"002 - Path-Based Ingress Tiers with Automatic DNS","link":"/docs/decisions/networking/002-path-based-ingress-tiers"}]},{"text":"Platform","collapsed":true,"items":[{"text":"001 - Migrate Obsidian Vault into Monolith with TigerFS","link":"/docs/decisions/platform/001-obsidian-vault-monolith-migration"},{"text":"002 - CDN-Cached Data Fetching for Monolith Public Routes","link":"/docs/decisions/platform/002-cdn-cached-data-fetching"},{"text":"003 - CDN Cache Rule Scoped to `public.jomcgi.dev`","link":"/docs/decisions/platform/003-cdn-cache-hostname-rule"},{"text":"004 - Iceberg-on-SeaweedFS Lakehouse with Hot-Swap Quack Serving","link":"/docs/decisions/platform/004-iceberg-lakehouse-hot-swap"}]},{"text":"Repo","collapsed":true,"items":[{"text":"001 - Monorepo Structure & Dotfile Housekeeping","link":"/docs/decisions/repo/001-monorepo-structure-and-dotfile-housekeeping"}]},{"text":"Security","collapsed":true,"items":[{"text":"001 - Hermetic Semgrep via Bazel","link":"/docs/decisions/security/001-bazel-semgrep"},{"text":"002 - RL-Finetuned Model for Security-Incident-Driven Semgrep Rule Generation","link":"/docs/decisions/security/002-semgrep-rule-generation-rl"},{"text":"003 - gVisor RuntimeClass for Agent Sandboxes","link":"/docs/decisions/security/003-gvisor-runtime-class"}]},{"text":"Services","collapsed":true,"items":[{"text":"001 - Discord History Backfill","link":"/docs/decisions/services/001-discord-history-backfill"},{"text":"002 - Discord Chat Automation & Reactivity","link":"/docs/decisions/services/002-discord-chat-automation"},{"text":"003 - Knowledge Search Overlay","link":"/docs/decisions/services/003-knowledge-search-overlay"},{"text":"004 - D&D Sourcebook Knowledge Graph Integration","link":"/docs/decisions/services/004-dnd-sourcebook-knowledge-integration"},{"text":"005 - Repo Markdown Knowledge Graph Sync via OCI Volume","link":"/docs/decisions/services/005-repo-docs-knowledge-sync"}]},{"text":"Tooling","collapsed":true,"items":[{"text":"001 - OCI-Based Tool Distribution","link":"/docs/decisions/tooling/001-oci-tool-distribution"},{"text":"002 - Service Deployment Tooling","link":"/docs/decisions/tooling/002-service-deployment-tooling"},{"text":"003 - Spec-First CLI and Skills","link":"/docs/decisions/tooling/003-spec-first-cli-and-skills"},{"text":"004 - Scale the custom OCaml ruleset toward Semgrep Pro","link":"/docs/decisions/tooling/004-ocaml-rules-for-semgrep"},{"text":"005 - tOyCaml -- a representative demonstrator for the OCaml ruleset","link":"/docs/decisions/tooling/005-toycaml-demonstrator"},{"text":"006 - Extensible multi-arch OCaml toolchains","link":"/docs/decisions/tooling/006-extensible-multiarch-ocaml-toolchains"},{"text":"007 - OCaml first-party BUILD generation via Gazelle","link":"/docs/decisions/tooling/007-ocaml-build-file-generation-gazelle"}]}]
+[
+  {
+    "text": "Agents",
+    "collapsed": true,
+    "items": [
+      {
+        "text": "001 - Self-Hosted Autonomous Coding Agents via OpenHands",
+        "link": "/docs/decisions/agents/001-background-agents"
+      },
+      {
+        "text": "002 - Kubernetes-Native OpenHands Sandboxes via agent-sandbox",
+        "link": "/docs/decisions/agents/002-openhands-agent-sandbox"
+      },
+      {
+        "text": "003 - MCP Context Forge as Agent Tool Gateway",
+        "link": "/docs/decisions/agents/003-context-forge"
+      },
+      {
+        "text": "004 - Autonomous Coding Agents",
+        "link": "/docs/decisions/agents/004-autonomous-agents"
+      },
+      {
+        "text": "005 - Role-Based MCP Access",
+        "link": "/docs/decisions/agents/005-role-based-mcp-access"
+      },
+      {
+        "text": "006 - OIDC Authentication for MCP Gateway",
+        "link": "/docs/decisions/agents/006-oidc-auth-mcp-gateway"
+      },
+      {
+        "text": "007 - Agent Run Orchestration Service",
+        "link": "/docs/decisions/agents/007-agent-orchestrator"
+      },
+      {
+        "text": "008 - Cluster Patrol Loop Resilience",
+        "link": "/docs/decisions/agents/008-cluster-patrol-loop-resilience"
+      },
+      {
+        "text": "009 - Automated Test Generation Bots",
+        "link": "/docs/decisions/agents/009-automated-test-generation"
+      },
+      {
+        "text": "010 - Recipe-Driven Agent Registry",
+        "link": "/docs/decisions/agents/010-recipe-driven-agent-registry"
+      },
+      {
+        "text": "011 - Agent MCP v1 Follow-ons and Deferred Self-Improvement Loop",
+        "link": "/docs/decisions/agents/011-agent-mcp-v1-followons"
+      },
+      {
+        "text": "011 - Cloudflare Managed OAuth for MCP Gateway",
+        "link": "/docs/decisions/agents/011-cloudflare-managed-oauth"
+      },
+      {
+        "text": "012 - Knowledge Gardener Two-Tier Model Pipeline",
+        "link": "/docs/decisions/agents/012-knowledge-gardener-model-pipeline"
+      },
+      {
+        "text": "013 - Knowledge Gardener Gemma4-Only Pipeline",
+        "link": "/docs/decisions/agents/013-knowledge-gardener-gemma4-only"
+      },
+      {
+        "text": "014 - AX + Substrate as the Agent Runtime Substrate",
+        "link": "/docs/decisions/agents/014-ax-substrate-agent-runtime"
+      },
+      {
+        "text": "015 - Temporal as the Orchestration Substrate",
+        "link": "/docs/decisions/agents/015-temporal-orchestration-substrate"
+      },
+      {
+        "text": "016 - NATS as the Canonical Event Stream",
+        "link": "/docs/decisions/agents/016-nats-canonical-event-stream"
+      },
+      {
+        "text": "017 - Domain Event Schema and Tombstone Semantics",
+        "link": "/docs/decisions/agents/017-domain-event-schema"
+      }
+    ]
+  },
+  {
+    "text": "Docs",
+    "collapsed": true,
+    "items": [
+      {
+        "text": "001 - Static Documentation Site for docs.jomcgi.dev",
+        "link": "/docs/decisions/docs/001-static-docs-site"
+      }
+    ]
+  },
+  {
+    "text": "Networking",
+    "collapsed": true,
+    "items": [
+      {
+        "text": "001 - Reduce Cloudflare Operator Scope via Envoy Gateway",
+        "link": "/docs/decisions/networking/001-cloudflare-envoy-gateway"
+      },
+      {
+        "text": "002 - Path-Based Ingress Tiers with Automatic DNS",
+        "link": "/docs/decisions/networking/002-path-based-ingress-tiers"
+      }
+    ]
+  },
+  {
+    "text": "Platform",
+    "collapsed": true,
+    "items": [
+      {
+        "text": "001 - Migrate Obsidian Vault into Monolith with TigerFS",
+        "link": "/docs/decisions/platform/001-obsidian-vault-monolith-migration"
+      },
+      {
+        "text": "002 - CDN-Cached Data Fetching for Monolith Public Routes",
+        "link": "/docs/decisions/platform/002-cdn-cached-data-fetching"
+      },
+      {
+        "text": "003 - CDN Cache Rule Scoped to `public.jomcgi.dev`",
+        "link": "/docs/decisions/platform/003-cdn-cache-hostname-rule"
+      },
+      {
+        "text": "004 - Iceberg-on-SeaweedFS Lakehouse with Hot-Swap Quack Serving",
+        "link": "/docs/decisions/platform/004-iceberg-lakehouse-hot-swap"
+      }
+    ]
+  },
+  {
+    "text": "Repo",
+    "collapsed": true,
+    "items": [
+      {
+        "text": "001 - Monorepo Structure & Dotfile Housekeeping",
+        "link": "/docs/decisions/repo/001-monorepo-structure-and-dotfile-housekeeping"
+      }
+    ]
+  },
+  {
+    "text": "Security",
+    "collapsed": true,
+    "items": [
+      {
+        "text": "001 - Hermetic Semgrep via Bazel",
+        "link": "/docs/decisions/security/001-bazel-semgrep"
+      },
+      {
+        "text": "002 - RL-Finetuned Model for Security-Incident-Driven Semgrep Rule Generation",
+        "link": "/docs/decisions/security/002-semgrep-rule-generation-rl"
+      },
+      {
+        "text": "003 - gVisor RuntimeClass for Agent Sandboxes",
+        "link": "/docs/decisions/security/003-gvisor-runtime-class"
+      }
+    ]
+  },
+  {
+    "text": "Services",
+    "collapsed": true,
+    "items": [
+      {
+        "text": "001 - Discord History Backfill",
+        "link": "/docs/decisions/services/001-discord-history-backfill"
+      },
+      {
+        "text": "002 - Discord Chat Automation & Reactivity",
+        "link": "/docs/decisions/services/002-discord-chat-automation"
+      },
+      {
+        "text": "003 - Knowledge Search Overlay",
+        "link": "/docs/decisions/services/003-knowledge-search-overlay"
+      },
+      {
+        "text": "004 - D&D Sourcebook Knowledge Graph Integration",
+        "link": "/docs/decisions/services/004-dnd-sourcebook-knowledge-integration"
+      },
+      {
+        "text": "005 - Repo Markdown Knowledge Graph Sync via OCI Volume",
+        "link": "/docs/decisions/services/005-repo-docs-knowledge-sync"
+      }
+    ]
+  },
+  {
+    "text": "Tooling",
+    "collapsed": true,
+    "items": [
+      {
+        "text": "001 - OCI-Based Tool Distribution",
+        "link": "/docs/decisions/tooling/001-oci-tool-distribution"
+      },
+      {
+        "text": "002 - Service Deployment Tooling",
+        "link": "/docs/decisions/tooling/002-service-deployment-tooling"
+      },
+      {
+        "text": "003 - Spec-First CLI and Skills",
+        "link": "/docs/decisions/tooling/003-spec-first-cli-and-skills"
+      },
+      {
+        "text": "004 - Scale the custom OCaml ruleset toward Semgrep Pro",
+        "link": "/docs/decisions/tooling/004-ocaml-rules-for-semgrep"
+      },
+      {
+        "text": "005 - tOyCaml -- a representative demonstrator for the OCaml ruleset",
+        "link": "/docs/decisions/tooling/005-toycaml-demonstrator"
+      },
+      {
+        "text": "006 - Extensible multi-arch OCaml toolchains",
+        "link": "/docs/decisions/tooling/006-extensible-multiarch-ocaml-toolchains"
+      },
+      {
+        "text": "007 - OCaml first-party BUILD generation via Gazelle",
+        "link": "/docs/decisions/tooling/007-ocaml-build-file-generation-gazelle"
+      },
+      {
+        "text": "008 - CLI multi-platform distribution via native execution platforms",
+        "link": "/docs/decisions/tooling/008-cli-multiplatform-distribution"
+      }
+    ]
+  }
+]


### PR DESCRIPTION
Records the multi-platform CLI distribution research and decision as ADR 008 (tooling), following the deep-research session on cross-compilation strategies.

## What's in here

- **ADR 008: CLI multi-platform distribution via native execution platforms.** One Bazel graph executed on native platforms through BuildBuddy: linux x86_64 (today's pool), linux arm64 (BuildBuddy cloud arm64 executors, launched 2026-01-15, which un-gates ADR 006's Phase 7 with zero infra), macOS arm64 (self-hosted darwin BuildBuddy executor on genuine Apple hardware, EC2 Mac or rack Mac mini, release lane only). Cross-to-macOS, QEMU emulation, and wasm distribution are rejected with cited, adversarially verified evidence. Post-5.4 cross consolidation for linux arm64 is noted as a contained future optimization (semgrep upstream moves to OCaml 5.4 before EoY).
- **ADR 006 amendment**: resolves its pool-availability open question with a pointer to ADR 008.
- **Decisions index**: brings the tooling section current (005 through 008 were missing or new).

## Evidence quality

Load-bearing claims went through 3-vote adversarial verification against primary sources (BuildBuddy blog/docs, ocaml/ocaml build-cross.yml and PR #13526, semgrep release workflows at v1.100.0 and develop, Tarides wasm posts, GitHub changelog). Two initially-reported details were corrected by verification and are recorded in their corrected form: vanilla cross needs OCaml 5.4+ (not 5.3), and semgrep's arm64 QEMU fallback is enabled (not disabled).

https://claude.ai/code/session_01J4SPkjboMjCnamWky7hbxb

---
_Generated by [Claude Code](https://claude.ai/code/session_01J4SPkjboMjCnamWky7hbxb)_