### PR TITLE
style(ships): use vibrant plasma ramp for density heatmap

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.106.0
+version: 0.106.1
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.106.0
+      targetRevision: 0.106.1
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/lib/public/components/ships/ShipsMap.svelte
+++ b/projects/monolith/frontend/src/lib/public/components/ships/ShipsMap.svelte
@@ -96,13 +96,16 @@
 
   // Neo-brutalist stepped ramp, tuned to the distinct-mover counts measured on
   // live data (p50=1, p90=3, p99=10, max~22): quiet water -> busy lanes.
+  // Fully saturated plasma scale (vivid violet through magenta and rose to
+  // orange/red). Deliberately skips green and pale blue so even the quiet-water
+  // low end stays vibrant against the green-and-beige basemap when zoomed out.
   const HEAT_STOPS = [
-    { at: 1, color: "#6fc2ff", label: "1-2" },
-    { at: 3, color: "#14c4a9", label: "3-5" },
-    { at: 6, color: "#35cb5b", label: "6-9" },
-    { at: 10, color: "#ffcb1f", label: "10-14" },
-    { at: 15, color: "#ff564a", label: "15-19" },
-    { at: 20, color: "#b3261e", label: "20+" },
+    { at: 1, color: "#6a00f4", label: "1-2" }, // vivid violet
+    { at: 3, color: "#b5179e", label: "3-5" }, // magenta
+    { at: 6, color: "#e5006d", label: "6-9" }, // rose
+    { at: 10, color: "#ff5400", label: "10-14" }, // vivid orange
+    { at: 15, color: "#ff2d2d", label: "15-19" }, // red
+    { at: 20, color: "#c1121f", label: "20+" }, // deep red
   ];
   const HEAT_FILL_COLOR = [
     "step",


### PR DESCRIPTION
## What

Swaps the ship traffic-density heatmap ramp from the old blue/green/yellow/red scale to a fully saturated **plasma** scale (vivid violet to deep red).

| Step | Old | New |
| --- | --- | --- |
| 1-2 | `#6fc2ff` pale blue | `#6a00f4` vivid violet |
| 3-5 | `#14c4a9` aqua-mint | `#b5179e` magenta |
| 6-9 | `#35cb5b` spring green | `#e5006d` rose |
| 10-14 | `#ffcb1f` golden | `#ff5400` vivid orange |
| 15-19 | `#ff564a` coral-red | `#ff2d2d` red |
| 20+ | `#b3261e` deep red | `#c1121f` deep red |

## Why

The old low end (pale blue plus two greens) sat right on top of the green-and-beige basemap, so quiet lanes washed out and blended in when zoomed out. The new ramp deliberately skips green and pale blue, keeping every density step vibrant from one end to the other.

## Scope

- Single change to `HEAT_STOPS` in `ShipsMap.svelte`.
- The map fill layer and the on-screen legend both render from `HEAT_STOPS`, so they update together with no further edits.
- The separate `VESSEL_COLORS` marker palette is untouched.

https://claude.ai/code/session_01GDJnV3G9iti25eBtjAzrhj

---
_Generated by [Claude Code](https://claude.ai/code/session_01GDJnV3G9iti25eBtjAzrhj)_