### PR TITLE
docs: ADR + plan for per-PR preview environments

### DIFF
--- a/docs/decisions/index.md
+++ b/docs/decisions/index.md
@@ -45,6 +45,7 @@ ADRs document significant architectural decisions and their context.
 | [002 - CDN-Cached Data Fetching](platform/002-cdn-cached-data-fetching.md)                                     | Public JSON endpoints cache at the Cloudflare edge; clients poll cached         |
 | [003 - CDN Cache Rule Scoped to `public.jomcgi.dev`](platform/003-cdn-cache-hostname-rule.md)                  | Scope CDN cache rule to public.jomcgi.dev (supersedes 002 partially)            |
 | [004 - Iceberg-on-SeaweedFS Lakehouse with Hot-Swap Quack Serving](platform/004-iceberg-lakehouse-hot-swap.md) | Event-sourced lakehouse; NATS → Iceberg → Quack hot-swap; partially evolves 001 |
+| [005 - Per-PR Preview Environments](platform/005-per-pr-preview-environments.md)                               | Ephemeral monolith previews: CoW Postgres clone, muted side effects, ApplicationSet PR generator |
 
 ## Security
 

--- a/docs/decisions/platform/005-per-pr-preview-environments.md
+++ b/docs/decisions/platform/005-per-pr-preview-environments.md
@@ -1,0 +1,135 @@
+# ADR 005: Per-PR Preview Environments for the Monolith
+
+**Author:** Joe McGinley
+**Status:** Draft
+**Created:** 2026-06-12
+**Relates to:** [ADR 001: Obsidian Vault Monolith Migration](001-obsidian-vault-monolith-migration.md), [Networking ADR 002: Path-Based Ingress Tiers](../networking/002-path-based-ingress-tiers.md)
+
+---
+
+## Problem
+
+Testing a monolith change today means merging to `main` and watching it roll out, or running pieces locally without the real cluster, database, ingress, and CNPG-managed secrets around them. There is no way to exercise a branch end to end, against realistic data, before it lands. We want a preview environment per open PR so a change can be clicked through at a stable URL before merge.
+
+Three properties make this non-trivial for the monolith specifically:
+
+1. **Postgres.** A useful preview needs realistic data, but we will not copy the whole database per PR, and we must never let a preview's writes touch prod data.
+2. **Side effects.** The monolith runs a Postgres-backed scheduler loop (gardener, changelog poller, vault git-push, ships maintenance) and a Discord bot. A second live instance sharing the same Discord token and doing the same scheduled work would double-reply in channels and duplicate expensive jobs.
+3. **Exposure.** The app's routes assume absolute paths (`/_app/*`, `/api/*`) and the public/private split is by hostname today. Previews must be reachable (by the developer and by Claude Code on the web) without exposing them publicly.
+
+---
+
+## Decision
+
+Ship ephemeral, label-gated preview environments driven by an **ArgoCD ApplicationSet pull-request generator**. For each opted-in open PR, ArgoCD templates one monolith Application that deploys the already-built PR image alongside a copy-on-write clone of the production database, muted of all scheduled and external side effects, behind a wildcard subdomain protected by Cloudflare Access.
+
+### 1. Postgres: copy-on-write clone, not a logical copy
+
+We clone production Postgres per preview at the **storage layer**, where copy-on-write already lives:
+
+- Production `monolith-pg` (CNPG) gains a **volume-snapshot backup** configuration. CNPG takes consistent online snapshots through the CSI `VolumeSnapshot` API, which Longhorn implements as block-level copy-on-write.
+- Each preview templates a small CNPG `Cluster` (`monolith-pg-pr-<n>`) that bootstraps via `bootstrap.recovery` from that snapshot. Longhorn provisions the clone copy-on-write: zero blocks copied up front, full prod data present, and every write in the preview is copy-on-write into private blocks, so prod is never mutated.
+
+This is the literal "separate the read path from the write path" idea, resolved at the block layer: unchanged blocks are physically shared with prod (reads), changed blocks are private to the preview (writes). It is also genuinely zero-copy: no data is duplicated until a preview writes.
+
+The cost is not disk, Longhorn handles that, it is that **two Postgres engines cannot mount the same data directory**, so each clone runs its own Postgres pod (512Mi request / 1Gi limit). On a single node that pod budget is the real constraint, so previews are **capped at 3 concurrent** and each clone runs `instances: 1`.
+
+A clone is a **point-in-time fork** taken when the preview is created, not live prod data. That staleness is the correct trade for an isolated preview.
+
+### 2. Side effects: one `PR_ENV` flag mutes the scheduler and the bot
+
+Rather than gate side effects piecemeal (the current model, where several scheduled jobs run unconditionally), add a single `PR_ENV=true` value that, at startup:
+
+- **does not start the scheduler loop** (`shared/scheduler.py`), which is the origin of all periodic work, and
+- **does not start the Discord bot** (`app/main.py`), which is the origin of all outbound chat.
+
+Killing those two startup points removes every duplicate job and every double Discord reply in one move: a preview has no bot connection and no scheduler tick. The preview's own cloned database keeps its scheduler/lock tables isolated as belt-and-suspenders, but the loop simply never runs.
+
+### 3. Exposure: wildcard subdomain behind Cloudflare Access
+
+Previews are served at **`<n>.pr.jomcgi.dev`** (wildcard DNS + wildcard origin cert), one clean origin per PR. A subdomain avoids the path-rewriting that `pr.jomcgi.dev/<n>/...` would force on an app full of absolute asset and API paths.
+
+The entire `*.pr.jomcgi.dev` wildcard sits behind a single **Cloudflare Access** policy (trusted tier), so previews are never publicly indexed and carry real cloned data safely. Each preview exposes the full (private-tier) route set, since the developer behind Access wants to exercise everything; we do not replicate the public/private hostname split per PR.
+
+Claude Code on the web and CI reach previews through a **Cloudflare Access service token** (`CF-Access-Client-Id` / `CF-Access-Client-Secret`) added to the wildcard policy and provided as a secret, which is the supported machine-access path rather than an IP bypass.
+
+### 4. Orchestration: ApplicationSet PR generator, label-gated
+
+An ArgoCD `ApplicationSet` with the GitHub **pull-request generator** enumerates open PRs and templates one Application each, auto-deleting when the PR closes (lifecycle handled for us). The generated Application is parameterised by PR number, branch, and head SHA, and overrides Helm values for `PR_ENV=true`, the hostname, the per-PR CNPG clone, and minimal replicas/resources.
+
+Because this is a monorepo, the generator cannot filter by changed path, so previews are **opt-in by the `preview` label**: the generator only templates labelled PRs. CI adds the `preview` label automatically when a PR's diff touches `projects/monolith/**`, so monolith PRs get previews without manual action while the label still bounds the count and gives an explicit opt-out. Previews run in the shared `monolith` namespace, so each preview's CNPG clone exposes its own `-app` DSN secret to its pod with no cross-namespace secret syncing.
+
+---
+
+## Architecture
+
+```mermaid
+graph TD
+    PR[Open PR with preview label] --> AS[ArgoCD ApplicationSet<br/>pull-request generator]
+    AS -->|templates per PR| APP[Application monolith-pr-n]
+    APP --> POD[Monolith pods<br/>PR_ENV=true: no scheduler, no bot]
+    APP --> SNAP[CNPG Cluster monolith-pg-pr-n]
+    PROD[(monolith-pg prod)] -->|volume-snapshot backup| VS[CSI VolumeSnapshot<br/>Longhorn CoW]
+    VS -->|bootstrap.recovery| SNAP
+    POD -->|DSN from -app secret| SNAP
+    CI[CI: diff touches projects/monolith/**] -->|adds 'preview' label| PR
+    Internet -->|n.pr.jomcgi.dev| CFA[Cloudflare Access<br/>wildcard policy]
+    CFA --> POD
+    Claude[Claude Code web / CI] -->|CF Access service token| CFA
+```
+
+---
+
+## Implementation
+
+See the companion plan: [`docs/plans/2026-06-12-per-pr-preview-environments-plan.md`](../../plans/2026-06-12-per-pr-preview-environments-plan.md). High-level phases:
+
+- [ ] **Phase 1: Mute side effects.** Add `PR_ENV` plumbing; gate the scheduler loop and Discord bot startup on it. (Pure app change, independently testable.)
+- [ ] **Phase 2: CoW Postgres.** Add volume-snapshot backup config to `monolith-pg`; parameterise the chart to optionally template a per-PR CNPG clone bootstrapped from a snapshot.
+- [ ] **Phase 3: Ingress.** Wildcard DNS + origin cert for `*.pr.jomcgi.dev`; per-PR HTTPRoute; Cloudflare Access policy over the wildcard; mint and wire the service token.
+- [ ] **Phase 4: Orchestration.** ApplicationSet PR generator scoped by the `preview` label, with the value overrides above and a concurrency cap of 3.
+- [ ] **Phase 5: CI labelling.** Add a CI step that applies the `preview` label when a PR diff touches `projects/monolith/**`.
+
+---
+
+## Security
+
+- **Previews are not public.** The whole `*.pr.jomcgi.dev` wildcard is behind one Cloudflare Access policy. Cloned prod data only ever reaches an authenticated session or the service token, never the open internet.
+- **No prod data mutation.** Copy-on-write isolation means a preview physically cannot write back to production blocks. The snapshot is read-once at bootstrap.
+- **No duplicated outbound actions.** `PR_ENV=true` means a preview holds no Discord connection and runs no scheduler, so it cannot post, push to the vault git remote, or fire any scheduled job.
+- **Service token scope.** The Cloudflare Access service token is limited to the `*.pr.jomcgi.dev` wildcard policy and carries no other access. It is stored as a secret, not committed.
+- Follows the baseline in `docs/security.md`. The new surface is the preview wildcard, mitigated by mandatory Access on it.
+
+---
+
+## Risks
+
+| Risk                                                              | Likelihood | Impact | Mitigation                                                                                              |
+| ----------------------------------------------------------------- | ---------- | ------ | ------------------------------------------------------------------------------------------------------ |
+| Per-PR Postgres pods exhaust single-node memory                   | Medium     | High   | Hard cap of 3 concurrent previews; `instances: 1` per clone; label-gated opt-in bounds the count       |
+| A preview still emits a side effect (missed code path)            | Low        | High   | Gate at the two startup points (scheduler loop, bot), not per job; cloned DB also isolates lock tables |
+| Snapshot taken from a busy prod volume is inconsistent            | Low        | Medium | Use CNPG's native volume-snapshot backup, which fences/checkpoints for a consistent online snapshot     |
+| Cloned prod data exposed if Access misconfigured                  | Low        | High   | Single wildcard Access policy applied before any preview route exists; CI check that the policy is live |
+| Stale preview clusters linger after PR close                      | Low        | Medium | ApplicationSet PR generator deletes the Application (and its CNPG clone) on PR close                    |
+| Service token leaks                                               | Low        | Medium | Token scoped only to the preview wildcard; rotate via Cloudflare; stored as a secret                   |
+
+---
+
+## Open Questions
+
+1. **Snapshot freshness.** Bootstrap each preview from an on-demand snapshot at PR-open (freshest, slightly slower create) versus the latest periodic backup snapshot (faster create, staler). Leaning on-demand at create time.
+2. **Frontend base URL.** Confirm the SvelteKit build needs no per-preview base path given the subdomain origin (expected, since paths stay absolute). Verify against `private.jomcgi.dev` behaviour.
+3. **Migrations on a clone.** A clone already carries prod's applied migrations, so the Atlas init job should be a no-op on the clone, but a PR that adds a migration must apply the new one. Confirm the Atlas init job runs forward-only against the clone cleanly.
+
+---
+
+## References
+
+| Resource                                                                                                          | Relevance                                              |
+| ---------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
+| [CNPG: Recovery from a Volume Snapshot](https://cloudnative-pg.io/documentation/current/recovery/)               | `bootstrap.recovery` from a CSI VolumeSnapshot         |
+| [CNPG: Backup with Volume Snapshots](https://cloudnative-pg.io/documentation/current/backup_volumesnapshot/)     | Consistent online snapshot backups on the prod cluster |
+| [Longhorn CSI Snapshot Support](https://longhorn.io/docs/latest/snapshots-and-backups/csi-snapshot-support/)     | Block-level copy-on-write snapshots and clones         |
+| [ArgoCD ApplicationSet Pull Request Generator](https://argo-cd.readthedocs.io/en/stable/operator-manual/applicationset/Generators-Pull-Request/) | Per-PR Application templating and label filtering      |
+| [Cloudflare Access Service Tokens](https://developers.cloudflare.com/cloudflare-one/identity/service-tokens/)    | Machine access through an Access policy                |
+| [Networking ADR 002: Path-Based Ingress Tiers](../networking/002-path-based-ingress-tiers.md)                    | Existing hostname/tier ingress model previews build on |

--- a/docs/plans/2026-06-12-per-pr-preview-environments-plan.md
+++ b/docs/plans/2026-06-12-per-pr-preview-environments-plan.md
@@ -1,0 +1,184 @@
+# Per-PR Preview Environments Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Give the monolith an ephemeral preview environment per opted-in open PR, reachable at `<n>.pr.jomcgi.dev`, running the already-built PR image against a copy-on-write clone of production Postgres, with all scheduled and external side effects muted.
+
+**Decision record:** [ADR Platform 005: Per-PR Preview Environments](../decisions/platform/005-per-pr-preview-environments.md). Read it first; this plan implements it.
+
+**Architecture (one paragraph):** An ArgoCD `ApplicationSet` pull-request generator templates one monolith `Application` per open PR carrying the `preview` label. Each Application deploys the monolith image tagged with the PR branch/SHA (already pushed by CI) with `PR_ENV=true`, which skips the scheduler loop and the Discord bot at startup. Each preview also templates a small CNPG `Cluster` that bootstraps copy-on-write from a Longhorn volume snapshot of production `monolith-pg`, so the preview has full prod data with isolated writes and zero up-front copy. The wildcard `*.pr.jomcgi.dev` sits behind one Cloudflare Access policy; Claude Code web and CI reach it via a service token. Previews run in the shared `monolith` namespace, capped at 3 concurrent, and are auto-deleted on PR close.
+
+**Tech stack:** CNPG (volume-snapshot backup + `bootstrap.recovery`), Longhorn CSI snapshots, ArgoCD ApplicationSet, Cloudflare Access service tokens, Gateway API HTTPRoute, the monolith Helm chart, Python/FastAPI startup.
+
+**Non-negotiable house rules (apply to every task):**
+
+- **No em-dashes** in any code, comment, commit, or doc. Use commas, colons, or parentheses.
+- **No local test loop.** Write tests, but do NOT run `bazel test`/`pytest`/`vitest` from the workstation. Implement, commit, push, watch CI via `gh pr checks <n> --watch`. Diagnose failures via `mcp__buildbuddy__*`.
+- **One code review per PR** at the end, not per task. Implementers self-review before each commit.
+- **Conventional Commits** for every commit (one logical step per commit).
+- **GitOps only.** No `kubectl apply/patch/edit`. Change Git; ArgoCD syncs.
+- **Chart version bumps** update both `chart/Chart.yaml` and `deploy/application.yaml` `targetRevision`.
+
+**Branch:** `claude/per-pr-environments-monolith-fhbdlg`.
+
+**Sequencing:** Phases are ordered so each is independently shippable and verifiable. Phase 1 (mute side effects) has zero prod-deploy risk and unblocks everything. Phases 2-5 can each be a separate PR if preferred; this plan keeps them as tasks under one feature.
+
+---
+
+## Phase 1: Mute side effects with a single `PR_ENV` flag
+
+The two startup points that produce every periodic and external action are the scheduler loop and the Discord bot. Gate both on one flag.
+
+### Task 1.1: Plumb `PR_ENV` into config
+
+**Files:**
+
+- Modify: monolith config/settings module (wherever env is read; same pattern as `DISCORD_BOT_TOKEN`).
+- Modify: `projects/monolith/chart/values.yaml` (add `prEnv: false`), `projects/monolith/chart/templates/deployment.yaml` (set `PR_ENV` env from `.Values.prEnv`).
+
+**Steps:**
+
+1. Read `PR_ENV` as a boolean (truthy on `"true"/"1"`), default false, in the same place other env flags are parsed.
+2. Surface it as `settings.pr_env` (or the module's idiom) so both the scheduler and bot startup can read one value.
+3. Wire `prEnv` through the chart: `values.yaml` default `false`, deployment template emits `- name: PR_ENV` `value: {{ .Values.prEnv | quote }}`.
+
+### Task 1.2: Skip the scheduler loop when `PR_ENV`
+
+**Files:** Modify: `projects/monolith/app/main.py` lifespan startup (the block that launches `run_scheduler_loop`), `projects/monolith/shared/scheduler.py` if a cleaner guard belongs there.
+
+**Steps:**
+
+1. In the lifespan startup, wrap the scheduler-loop launch in `if not settings.pr_env:`.
+2. Log a single clear line at startup when skipped: `scheduler loop disabled (PR_ENV)`.
+3. Add a unit test asserting the loop task is not created when `PR_ENV=true` (test the startup wiring, do not run the loop).
+
+### Task 1.3: Skip the Discord bot when `PR_ENV`
+
+**Files:** Modify: `projects/monolith/app/main.py:~74` (the `if DISCORD_BOT_TOKEN` bot start).
+
+**Steps:**
+
+1. Change the bot-start condition to also require `not settings.pr_env` (`if discord_token and not settings.pr_env:`).
+2. Log `discord bot disabled (PR_ENV)` when skipped.
+3. Unit test: bot is not started when `PR_ENV=true` even if a token is present.
+
+**Phase 1 done when:** with `PR_ENV=true`, startup logs both "disabled" lines, no scheduler task is scheduled, and no Discord connection is attempted. Verified on the preview once Phase 4 lands; unit-tested here.
+
+---
+
+## Phase 2: Copy-on-write Postgres clone
+
+### Task 2.1: Enable volume-snapshot backups on production `monolith-pg`
+
+**Files:** Modify: `projects/monolith/chart/templates/cnpg-cluster.yaml`, `projects/monolith/chart/values.yaml`.
+
+**Steps:**
+
+1. Confirm a Longhorn `VolumeSnapshotClass` exists (or add one under `projects/platform/longhorn/`). CNPG needs a CSI snapshot class to target.
+2. Add `backup.volumeSnapshot` configuration to the `monolith-pg` Cluster spec referencing that snapshot class, plus a `ScheduledBackup` (or document on-demand snapshot creation) per the ADR's open question on freshness. Default to on-demand at preview create; a periodic schedule is acceptable as a fallback.
+3. Keep this gated so production behaviour is unchanged except gaining snapshot capability.
+
+### Task 2.2: Parameterise the chart to template a per-PR CNPG clone
+
+**Files:** Modify: `projects/monolith/chart/templates/cnpg-cluster.yaml` (or a new `cnpg-cluster-preview.yaml`), `projects/monolith/chart/values.yaml`.
+
+**Steps:**
+
+1. Add chart values: `preview.enabled` (bool), `preview.id` (PR number), `preview.snapshotName` (source VolumeSnapshot).
+2. When `preview.enabled`, render a `Cluster` named `monolith-pg-pr-<id>` with `instances: 1`, minimal resources, and `bootstrap.recovery` from `volumeSnapshots` pointing at `preview.snapshotName`. Do NOT render the prod cluster in preview mode.
+3. Ensure the app `DATABASE_URL` resolves to the clone's `-app` secret (`monolith-pg-pr-<id>-app`) when `preview.enabled`. The deployment template already reads `monolith-pg-app`; make the secret name derive from the cluster name so prod and preview both work.
+4. Confirm the Atlas migration init job runs forward-only against the clone (the clone already has prod's applied migrations; only new PR migrations should apply).
+
+**Phase 2 done when:** `helm template` with `preview.enabled=true preview.id=123 preview.snapshotName=...` renders a CNPG clone cluster and a deployment whose `DATABASE_URL` points at the clone's secret, and renders the prod cluster when `preview.enabled=false`.
+
+---
+
+## Phase 3: Wildcard ingress + Cloudflare Access
+
+### Task 3.1: Wildcard DNS and origin cert for `*.pr.jomcgi.dev`
+
+**Files:** Modify: the Cloudflare gateway / tunnel config (wherever `private.jomcgi.dev` is configured), external-dns annotations.
+
+**Steps:**
+
+1. Add a tunnel route / wildcard hostname for `*.pr.jomcgi.dev` to the cloudflared gateway config.
+2. Provision a wildcard origin certificate (or confirm the existing cert covers `*.pr.jomcgi.dev`).
+3. Add the wildcard CNAME via the external-dns annotation pattern used for the existing hosts.
+
+### Task 3.2: Per-preview HTTPRoute
+
+**Files:** Modify: `projects/monolith/chart/templates/httproute-private.yaml` or add `httproute-preview.yaml`; `projects/monolith/chart/values.yaml`.
+
+**Steps:**
+
+1. When `preview.enabled`, render an HTTPRoute on hostname `<preview.id>.pr.jomcgi.dev` exposing the full (private-tier) route set to the monolith service.
+2. Reuse the existing private-route path set (assets, `/api/*`, chat). No public-tier narrowing for previews.
+
+### Task 3.3: Cloudflare Access policy + service token
+
+**Files:** Wherever Cloudflare Access policies are declared for `private.jomcgi.dev` (Access app config / Terraform / dashboard-managed reference).
+
+**Steps:**
+
+1. Add an Access application/policy covering `*.pr.jomcgi.dev` (trusted, same identity as private tier).
+2. Create a service token scoped to that policy. Store the client id/secret as a secret (1Password item, same pattern as other monolith secrets) for Claude Code web and CI.
+3. Document how to supply `CF-Access-Client-Id`/`CF-Access-Client-Secret` to a preview HTTP client.
+
+**Phase 3 done when:** `<n>.pr.jomcgi.dev` resolves, terminates behind Access, and a request bearing the service-token headers reaches the monolith service.
+
+---
+
+## Phase 4: ApplicationSet PR generator
+
+### Task 4.1: ApplicationSet manifest
+
+**Files:** Create: `projects/monolith/deploy/applicationset-preview.yaml`; modify: `projects/monolith/deploy/kustomization.yaml` to include it; run `format` to regenerate the home-cluster root.
+
+**Steps:**
+
+1. Define an `ApplicationSet` with a `pullRequest.github` generator: owner `jomcgi`, repo `homelab`, `labels: [preview]`, a sane `requeueAfterSeconds`, and token from the existing GitHub credentials secret used by ArgoCD.
+2. Template the Application: name `monolith-pr-{{.number}}`, namespace `monolith`, the monolith chart source (same OCI chart + `$values` pattern as `application.yaml`), with Helm value overrides:
+   - `prEnv: true`
+   - `preview.enabled: true`, `preview.id: {{.number}}`, `preview.snapshotName: <prod snapshot>`
+   - image tag `{{.branch}}` (or `{{.head_sha}}`) for backend and frontend
+   - hostname `{{.number}}.pr.jomcgi.dev`
+   - minimal replicas/resources
+3. Add a concurrency guard: cap at 3 previews. If ApplicationSet has no native cap, rely on the `preview` label being the gate and document the cap as a labelling-side limit (enforced in Phase 5).
+4. Enable auto-prune/self-heal and `preserveResourcesOnDeletion: false` so closing a PR removes the Application and its CNPG clone.
+
+**Phase 4 done when:** labelling a test PR `preview` causes ArgoCD to create `monolith-pr-<n>`; removing the label or closing the PR deletes it.
+
+---
+
+## Phase 5: CI auto-labelling + concurrency cap
+
+### Task 5.1: Label monolith PRs and enforce the cap
+
+**Files:** Modify: `buildbuddy.yaml` (or the appropriate CI workflow step).
+
+**Steps:**
+
+1. Add a CI step that, on PR events, checks whether the diff touches `projects/monolith/**`.
+2. If it does and fewer than 3 previews are currently active, add the `preview` label; otherwise post a single comment that the preview cap is reached and skip labelling.
+3. Ensure removing the label (manual opt-out) tears the preview down via the generator.
+
+**Phase 5 done when:** opening a monolith PR auto-applies `preview` (up to the cap) and a non-monolith PR does not get a preview.
+
+---
+
+## End-of-plan verification (on CI, on a real preview)
+
+1. Open a throwaway monolith PR; confirm CI labels it `preview` and ArgoCD creates `monolith-pr-<n>` + `monolith-pg-pr-<n>`.
+2. Hit `<n>.pr.jomcgi.dev` with the service token; confirm the app serves and reads cloned prod data.
+3. Confirm preview logs show "scheduler loop disabled (PR_ENV)" and "discord bot disabled (PR_ENV)", and that no Discord message was posted and no scheduled job ran.
+4. Write to the preview (create a note/task); confirm prod is unaffected.
+5. Close the PR; confirm the Application and the CNPG clone are deleted and the pod budget is reclaimed.
+6. One comprehensive code review of the full diff before merge.
+
+---
+
+## Out of scope
+
+- App-level primary/replica read-write splitting on prod. The copy-on-write clone is the read/write separation for previews; prod read-routing is a separate HA concern.
+- Per-preview public-tier route narrowing. Previews expose the full trusted route set behind Access.
+- True storage-disaggregated Postgres branching (Neon-style). Longhorn CoW snapshots cover the need without re-platforming off CNPG.

--- a/projects/websites/docs.jomcgi.dev/.vitepress/adr-sidebar.json
+++ b/projects/websites/docs.jomcgi.dev/.vitepress/adr-sidebar.json
@@ -120,6 +120,10 @@
       {
         "text": "004 - Iceberg-on-SeaweedFS Lakehouse with Hot-Swap Quack Serving",
         "link": "/docs/decisions/platform/004-iceberg-lakehouse-hot-swap"
+      },
+      {
+        "text": "005 - Per-PR Preview Environments",
+        "link": "/docs/decisions/platform/005-per-pr-preview-environments"
       }
     ]
   },


### PR DESCRIPTION
## What

Design-only PR: an ADR and an implementation plan for **ephemeral per-PR preview environments** for the monolith, so a branch can be exercised end to end (real cluster, DB, ingress, secrets) before it merges.

- `docs/decisions/platform/005-per-pr-preview-environments.md` (ADR, Draft)
- `docs/plans/2026-06-12-per-pr-preview-environments-plan.md` (implementation plan)
- `docs/decisions/index.md` (index entry)

No code or manifests change here. Implementation lands in follow-up PRs per the plan's phases.

## The design

**Postgres, copy-on-write.** Clone prod at the storage layer, where CoW already lives: production `monolith-pg` gains CNPG volume-snapshot backups (Longhorn implements CSI snapshots as block-level CoW), and each preview bootstraps a small CNPG cluster via `bootstrap.recovery` from that snapshot. Zero blocks copied up front, full prod data, and every preview write is CoW into private blocks so prod is never touched. This is the literal read-path / write-path split, resolved at the block layer. The cost is one Postgres pod per clone (two engines can't mount one data dir), so previews are capped at **3 concurrent**.

**Side effects, one flag.** `PR_ENV=true` skips the two startup points that produce all periodic and external behaviour, the scheduler loop and the Discord bot. No duplicate expensive jobs, no double Discord replies.

**Exposure.** Wildcard subdomain `<n>.pr.jomcgi.dev` (clean origin, no path rewriting) behind a single Cloudflare Access policy, so previews are never public despite carrying cloned data. Claude Code on the web and CI reach them via a Cloudflare Access **service token**.

**Orchestration.** An ArgoCD ApplicationSet **pull-request generator** templates one Application per open PR carrying a `preview` label and auto-deletes it on close. Because the monorepo can't be path-filtered in the generator, CI applies the `preview` label when a PR diff touches `projects/monolith/**`, which also enforces the 3-preview cap.

## Implementation phases (see plan)

1. Mute side effects (`PR_ENV` flag) — pure app change, zero deploy risk
2. CoW Postgres (snapshot backups + per-PR clone)
3. Wildcard ingress + Cloudflare Access + service token
4. ApplicationSet PR generator
5. CI auto-labelling + concurrency cap

## Open questions captured in the ADR

- On-demand vs periodic snapshot freshness
- Atlas migration behaviour against a clone (forward-only)
- SvelteKit base URL under the subdomain origin (expected no-op)

Review wanted on the **approach** before implementation starts.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RYgzjXBDUBK9eZJQrrJYha)_