### PR TITLE
fix(ships): tidy mobile map header overlap and attribution

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.107.0
+version: 0.107.1
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.107.0
+      targetRevision: 0.107.1
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/lib/public/components/ships/ShipsMap.svelte
+++ b/projects/monolith/frontend/src/lib/public/components/ships/ShipsMap.svelte
@@ -457,7 +457,12 @@
         style: BASEMAP_STYLE,
         center: [0, 30],
         zoom: 1.4,
-        attributionControl: true,
+        // Collapse the OSM/OpenMapTiles attribution into a compact "i" button
+        // instead of letting the full credit line sprawl across the bottom of
+        // the map (especially cramped on mobile). compact:true keeps it closed
+        // by default at any viewport width; tapping the button still reveals
+        // the required credits.
+        attributionControl: { compact: true },
       });
       map.addControl(
         new maplibregl.NavigationControl({ showCompass: false }),
@@ -578,7 +583,7 @@
     >
     <span class="chip-sep">/</span>
     <span class="chip-name">ships</span>
-    <span class="chip-sep">/</span>
+    <span class="chip-sep chip-sep-live">/</span>
     <span class="chip-live">live</span>
     <span class="chip-dot" aria-hidden="true"></span>
   </nav>
@@ -712,6 +717,34 @@
     background: var(--paper);
     position: relative;
     z-index: 1;
+  }
+
+  /* Compact attribution: a single square "i" toggle that matches the zoom
+     controls stacked above it, rather than MapLibre's default round white pill.
+     The required OSM/OpenMapTiles credits expand on tap. */
+  .map :global(.maplibregl-ctrl-attrib.maplibregl-compact) {
+    min-height: 0;
+    background: transparent;
+    box-shadow: none;
+  }
+
+  .map :global(.maplibregl-ctrl-attrib-button) {
+    width: 24px;
+    height: 24px;
+    border: 2px solid var(--ink);
+    border-radius: 0;
+    background-color: var(--paper);
+  }
+
+  .map :global(.maplibregl-ctrl-attrib.maplibregl-compact-show) {
+    background: var(--paper);
+    border: 2px solid var(--ink);
+    border-radius: 0;
+  }
+
+  .map :global(.maplibregl-ctrl-attrib-inner) {
+    font-family: var(--mono);
+    font-size: 10px;
   }
 
   .map-chip {
@@ -993,6 +1026,15 @@
       gap: 6px;
       padding: 7px 9px;
       font-size: 11px;
+    }
+
+    /* On a phone the chip and the (larger) mode toggle share the top row and
+       collide right where "live" meets "Vessels". Drop the redundant "/ live"
+       text: the pulsing green dot already signals live, and losing those
+       characters gives the toggle clear room beside the chip. */
+    .chip-sep-live,
+    .chip-live {
+      display: none;
     }
 
     /* The primary control on mobile: bigger buttons, bigger touch targets. */


### PR DESCRIPTION
## What

Two small mobile polish fixes for the live ships map (`/app/ships`), from feedback on the new mobile view.

### 1. Top header overlap

On a phone the breadcrumb chip (`jomcgi.dev / ships / live`) and the larger `Vessels / Heat` toggle both sit on the top row (left vs right) and collide right where `live` meets `Vessels`. The fix drops the redundant `/ live` text on narrow viewports. The pulsing green dot already signals "live", and reclaiming those characters gives the toggle clear room beside the chip. Desktop is unchanged.

### 2. MapLibre attribution sprawl

The full `MapLibre | OpenFreeMap © OpenMapTiles Data from OpenStreetMap` credit line was sprawling along the bottom of the map. Attribution is a licensing requirement, so rather than remove it, this collapses it into MapLibre's compact `ⓘ` button (`attributionControl: { compact: true }`) and styles that button to match the neo-brutalist zoom controls stacked above it (square, ink border, paper fill). The required credits still expand on tap.

## Testing

CSS/markup-only change to one Svelte component. No test assertions reference the changed config or markup. Verified the diff renders the same desktop layout; mobile behavior to confirm on the PR preview.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HmCz2LDick2bri9Vg1iMTp)_