### PR TITLE
fix(ships): collapse map attribution to the compact button on load

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.107.1
+version: 0.107.2
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.107.1
+      targetRevision: 0.107.2
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/lib/public/components/ships/ShipsMap.svelte
+++ b/projects/monolith/frontend/src/lib/public/components/ships/ShipsMap.svelte
@@ -457,17 +457,31 @@
         style: BASEMAP_STYLE,
         center: [0, 30],
         zoom: 1.4,
-        // Collapse the OSM/OpenMapTiles attribution into a compact "i" button
+        // Render the OSM/OpenMapTiles attribution as a compact "i" button
         // instead of letting the full credit line sprawl across the bottom of
-        // the map (especially cramped on mobile). compact:true keeps it closed
-        // by default at any viewport width; tapping the button still reveals
-        // the required credits.
+        // the map (especially cramped on mobile). MapLibre opens this expanded
+        // on first paint and only minimizes it once the user pans, so we also
+        // collapse it up front below; tapping the button still reveals the
+        // required credits.
         attributionControl: { compact: true },
       });
       map.addControl(
         new maplibregl.NavigationControl({ showCompass: false }),
         "bottom-right",
       );
+
+      // MapLibre's compact AttributionControl opens itself (a <details> with
+      // the `open` attribute + `maplibregl-compact-show` class) once the
+      // style's attributions populate, so it starts as a full-width credit bar
+      // and only shrinks to the "i" after the first pan. Collapse it up front by
+      // mirroring what MapLibre's own _updateCompactMinimize does on pan. A
+      // one-shot pass on `idle` (after the sources have loaded and it has opened
+      // itself) is enough; the button's own click still toggles it back open.
+      map.once("idle", () => {
+        const attrib = mapContainer.querySelector(".maplibregl-ctrl-attrib");
+        attrib?.removeAttribute("open");
+        attrib?.classList.remove("maplibregl-compact-show");
+      });
 
       map.on("load", () => {
         pal = palette();


### PR DESCRIPTION
## What

Follow-up to #2514. That PR switched the ships map to `attributionControl: { compact: true }`, but the OpenMapTiles/OpenStreetMap credit bar was still showing full-width on load.

## Why

MapLibre GL JS v5's compact `AttributionControl` renders **expanded** on first paint: once the style's attributions populate it sets the container (a `<details>`) to `open` and adds `maplibregl-compact-show`. It only minimizes to the `ⓘ` button after the user first pans the map (`_updateCompactMinimize`). So on a fresh load, the credit line still sprawled along the bottom.

## Fix

After the map reaches `idle` (sources loaded, attribution populated), strip the open state once, mirroring exactly what MapLibre's own `_updateCompactMinimize` does on pan:

```js
map.once("idle", () => {
  const attrib = mapContainer.querySelector(".maplibregl-ctrl-attrib");
  attrib?.removeAttribute("open");
  attrib?.classList.remove("maplibregl-compact-show");
});
```

Once `maplibregl-compact` is present the control won't re-expand on its own, so the one-shot pass is sufficient. The credits remain one tap away via the `ⓘ` button, so licensing attribution is preserved.

## Testing

CSS/JS-only change to one Svelte component; no test assertions reference the attribution control. Chrome isn't provisioned for Playwright in this environment, so this was verified by reading the MapLibre v5.24 `AttributionControl` source rather than a live render. Worth a quick look on the PR preview / after deploy to confirm it starts collapsed.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HmCz2LDick2bri9Vg1iMTp)_