### PR TITLE
fix(ships): collapse map attribution on styledata, not one-shot idle

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.107.4
+version: 0.107.5
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.107.5
+version: 0.107.6
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.107.5
+      targetRevision: 0.107.6
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.107.4
+      targetRevision: 0.107.5
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/lib/public/components/ships/ShipsMap.svelte
+++ b/projects/monolith/frontend/src/lib/public/components/ships/ShipsMap.svelte
@@ -466,17 +466,31 @@
       );
 
       // MapLibre's compact AttributionControl opens itself (a <details> with
-      // the `open` attribute + `maplibregl-compact-show` class) once the
-      // style's attributions populate, so it starts as a full-width credit bar
-      // and only shrinks to the "i" after the first pan. Collapse it up front by
-      // mirroring what MapLibre's own _updateCompactMinimize does on pan. A
-      // one-shot pass on `idle` (after the sources have loaded and it has opened
-      // itself) is enough; the button's own click still toggles it back open.
-      map.once("idle", () => {
+      // the `open` attribute + `maplibregl-compact-show` class) every time the
+      // style's attributions (re)populate, so it keeps wanting to render as a
+      // full-width credit bar. The old fix stripped that once on `idle`, but a
+      // live ships map never reliably idles: vessel dead-reckoning rewrites the
+      // source ~4x/sec and tiles keep streaming, so on a real session `idle`
+      // may never fire and the bar is left expanded (and on narrow/edge layouts
+      // that wide bar is what spills past the corner). Collapse it on every
+      // attribution update instead, so it never paints expanded, and stop once
+      // the user taps the button open themselves (their click sets `open`,
+      // which we then leave alone so the required OSM credits stay readable).
+      let userOpenedAttrib = false;
+      const collapseAttrib = () => {
+        if (userOpenedAttrib) return;
         const attrib = mapContainer.querySelector(".maplibregl-ctrl-attrib");
         attrib?.removeAttribute("open");
         attrib?.classList.remove("maplibregl-compact-show");
+      };
+      mapContainer.addEventListener("click", (e) => {
+        if (e.target.closest(".maplibregl-ctrl-attrib-button")) {
+          userOpenedAttrib = true;
+        }
       });
+      map.on("styledata", collapseAttrib);
+      map.on("sourcedata", collapseAttrib);
+      collapseAttrib();
 
       map.on("load", () => {
         pal = palette();
@@ -684,13 +698,15 @@
      wasn't worth the muting, so the markers and heat ramp now sit on the full
      basemap. */
 
-  /* The bottom-right stack (zoom + the collapsed attribution "i") sits at the
-     map's bottom edge, where on phones the home-indicator safe area was
-     clipping the lowest control offscreen. Lift the whole corner above the
-     inset so nothing hides behind it. Falls back to 0 on devices without a
-     safe area. */
+  /* The bottom-right stack (zoom + the collapsed attribution "i") sits in the
+     map's corner, where a device safe area can clip the controls offscreen:
+     the home-indicator inset on the bottom, and on a notched device held in
+     landscape the rounded-corner/notch inset on the right. Inset the whole
+     corner past both so nothing hides behind them. Falls back to 0 on devices
+     without a safe area. */
   .map :global(.maplibregl-ctrl-bottom-right) {
     bottom: env(safe-area-inset-bottom, 0);
+    right: env(safe-area-inset-right, 0);
   }
 
   /* Drop the group container entirely so each +/- button is its own square

--- a/projects/monolith/frontend/src/lib/public/components/ships/ShipsMap.svelte
+++ b/projects/monolith/frontend/src/lib/public/components/ships/ShipsMap.svelte
@@ -746,9 +746,18 @@
 
   /* Compact attribution: a single square "i" toggle that matches the zoom
      controls stacked above it, rather than MapLibre's default round white pill.
-     The required OSM/OpenMapTiles credits expand on tap. */
+     The required OSM/OpenMapTiles credits expand on tap.
+
+     The "i" button is `position: absolute; top: 0` inside this container, so the
+     container has to stay tall enough to hold it: MapLibre's default min-height
+     does that, but a previous `min-height: 0` collapsed the box to ~4px and the
+     24px button then overflowed *below* it. Because this control is anchored to
+     the map's bottom edge, that overflow fell off the bottom of the viewport and
+     clipped the lower ~10px of the "i". Match the container to the button (24px,
+     vertical padding zeroed for a clean square) so the button is fully held. */
   .map :global(.maplibregl-ctrl-attrib.maplibregl-compact) {
-    min-height: 0;
+    min-height: 24px;
+    padding-block: 0;
     background: transparent;
     box-shadow: none;
   }


### PR DESCRIPTION
## Problem

The map attribution control auto-hides jankily on the live ships UI, and the bottom-right zoom/attribution stack can clip off the right edge on real devices.

## Root cause

MapLibre's compact `AttributionControl` auto-opens as a full-width credit bar every time the style attributions repopulate. The previous fix (`7e5eff3b0`) stripped that open state **once on `idle`**. But a live ships map never reliably idles, vessel dead-reckoning rewrites the GeoJSON source ~4x/sec and tiles keep streaming, so on a real session `idle` fires seconds late or not at all. The bar is then left expanded, and the eventual collapse reads as a janky jump.

## Fix

- Collapse the attribution on every `styledata`/`sourcedata` instead of a one-shot `idle`, so it never paints expanded. Measured in a Playwright/WebKit harness that mimics the live `setData` churn: collapses at **~130ms vs ~1.1s** on the idle path, and stays collapsed through continuous source updates.
- Stop collapsing once the user taps the button open (their click sets `open`), so the required OSM/OpenMapTiles credits stay reachable.
- Honor `safe-area-inset-right` on the bottom-right control stack (it already lifts above `safe-area-inset-bottom`), so a notched device held in landscape can't clip the controls behind the rounded-corner inset.

## Verification

Reproduced the old-vs-new collapse timing under simulated live source churn with Playwright (Chromium + WebKit, desktop + mobile). Note: the right-edge clip itself did not reproduce in any headless engine/profile (controls measured 10px inside the edge everywhere), so the `safe-area-inset-right` change is defensive; the attribution-collapse timing fix is the verified behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)