### PR TITLE
fix(ships): start the map zoomed in on the fleet core

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.107.6
+version: 0.107.7
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.107.6
+      targetRevision: 0.107.7
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/lib/public/components/ships/ShipsMap.svelte
+++ b/projects/monolith/frontend/src/lib/public/components/ships/ShipsMap.svelte
@@ -361,14 +361,21 @@
       if (lats.length) {
         lats.sort((a, b) => a - b);
         lons.sort((a, b) => a - b);
-        // Frame the 1st-99th percentile so a few outliers (a vessel reporting
-        // a far-off position) can't blow out the zoom to the whole globe.
-        const q = 0.01;
+        // Frame the dense core of the fleet (5th-95th percentile) rather than
+        // its full spread: the AIS feed is regionally clustered, so a handful
+        // of near-outliers would otherwise pull the bounds wide and leave the
+        // screen mostly empty water. Trimming to the core lets the initial fit
+        // land on where the vessels actually are; the outliers still render as
+        // markers, reachable by panning/zooming out.
+        const q = 0.05;
         const b = new maplibregl.LngLatBounds(
           [quantile(lons, q), quantile(lats, q)],
           [quantile(lons, 1 - q), quantile(lats, 1 - q)],
         );
-        map.fitBounds(b, { padding: 64, maxZoom: 9, duration: 0 });
+        // maxZoom 12 (was 9) lets a tight cluster fill the viewport instead of
+        // being capped far out; fitBounds only reaches it when the core really
+        // is that small, so a wider fleet still frames naturally.
+        map.fitBounds(b, { padding: 48, maxZoom: 12, duration: 0 });
         didFit = true;
       }
     }


### PR DESCRIPTION
## What

The live ships map (`/app/ships`) opened far too zoomed out, leaving most of the screen as empty water. On mobile this read as a big blank space above the fleet (see the Slack report: "Can this start more zoomed in?").

## Why

The initial `fitBounds` had two things working against a tight frame:

1. It framed the 1st-99th percentile of vessel positions (`q = 0.01`). With a regionally clustered AIS feed, a few near-outliers (a vessel reporting a far-off fix) pulled the bounds wide.
2. It capped the zoom at `maxZoom: 9`, so even a small dense cluster could not zoom in enough to fill the viewport.

Together, the map opened way out with the fleet a tiny clump in a sea of empty basemap.

## Change

- Frame the 5th-95th percentile core of the fleet instead of the near-full spread, so the fit lands on where the vessels actually are.
- Raise the cap to `maxZoom: 12` so a tight cluster fills the viewport. `fitBounds` only reaches the cap when the core really is that small, so a genuinely wide fleet still frames naturally.
- Trim padding `64 -> 48` to give the cluster a touch more room.

Outliers still render as markers and remain reachable by panning / zooming out. Single-file tweak in `ShipsMap.svelte`; no component tests assert on these values.

https://claude.ai/code/session_01MzU3xjaF77squXCz447hWK