### PR TITLE
feat(cv): update summary snippet

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.108.0
+version: 0.108.1
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.107.7
+version: 0.108.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.107.7
+      targetRevision: 0.108.0
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.108.0
+      targetRevision: 0.108.1
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/routes/public/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/+page.svelte
@@ -164,8 +164,9 @@
     <div class="bio-left">
       <Sticker color="var(--paper)" rotate={-3} class="sticker-bio">A LITTLE ABOUT ME</Sticker>
       <p class="bio-sub">
-        Mostly I build infrastructure and abstractions so that other engineers don't have to think about it - Kubernetes, eBPF, and everything in between.<br />
-        Care<em>mad</em> about developer and user experience.
+        I'm Joe, from Scotland, living in Vancouver.<br />
+        Monorepo enthusiast. Lover of <a href="https://brutalistwebsites.com/" class="bio-link">brutalist websites</a>.<br />
+        Care<em>mad</em> about developer experience.
       </p>
     </div>
     <h2 class="bio-headline">Boring infrastructure<br />is a feature.</h2>

--- a/projects/monolith/frontend/src/routes/public/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/+page.svelte
@@ -164,9 +164,8 @@
     <div class="bio-left">
       <Sticker color="var(--paper)" rotate={-3} class="sticker-bio">A LITTLE ABOUT ME</Sticker>
       <p class="bio-sub">
-        I'm Joe, from Scotland, living in Vancouver.<br />
-        Monorepo enthusiast. Lover of <a href="https://brutalistwebsites.com/" class="bio-link">brutalist websites</a>.<br />
-        Care<em>mad</em> about developer experience.
+        Mostly I build infrastructure and abstractions so that other engineers don't have to think about it - Kubernetes, eBPF, and everything in between.<br />
+        Care<em>mad</em> about developer and user experience.
       </p>
     </div>
     <h2 class="bio-headline">Boring infrastructure<br />is a feature.</h2>

--- a/projects/monolith/frontend/src/routes/public/cv/cv-data.js
+++ b/projects/monolith/frontend/src/routes/public/cv/cv-data.js
@@ -20,7 +20,7 @@ export const tagline =
   "Senior Platform Engineer @ Semgrep · AWS / EKS · Kubernetes · eBPF";
 
 export const summary =
-  "I run Kubernetes hands-on: from ingress to eBPF, controllers and all the CRDs in between. Caremad about developer & user experience.";
+  "Mostly I build infrastructure and abstractions so that other engineers don't have to think about it - Kubernetes, eBPF, and everything in between. Caremad about developer and user experience.";
 
 export const jobs = [
   // Current role stays deliberately scope-level: what the job is, not a


### PR DESCRIPTION
Updates the CV summary line with new wording that better captures the infrastructure/abstractions angle.

Before: "I run Kubernetes hands-on: from ingress to eBPF, controllers and all the CRDs in between. Caremad about developer & user experience."

After: "Mostly I build infrastructure and abstractions so that other engineers don't have to think about it - Kubernetes, eBPF, and everything in between. Caremad about developer and user experience."