### PR TITLE
docs(hikes): fix deployment-health.spec.js description in README

### DIFF
--- a/projects/hikes/README.md
+++ b/projects/hikes/README.md
@@ -57,7 +57,7 @@ User preferences are persisted to `localStorage`. The app has no server-side com
 
 - `app-functionality.spec.js` — tests walk filtering and UI behaviour; mocks `bundle.brotli` responses
 - `coordinates.spec.js` — tests coordinate parsing and haversine logic; mocks `bundle.brotli` responses
-- `deployment-health.spec.js` — tests the live deployment health endpoint; mocks `bundle.brotli` responses
+- `deployment-health.spec.js` — tests page load, asset availability, and form behaviour against the local Playwright server; mocks `bundle.brotli` responses
 
 Playwright starts its own HTTP server on port **33999** (`python3 -m http.server 33999 --directory public`) rather than reusing any externally running server. `mock-data.spec.js` is excluded from the default run.
 


### PR DESCRIPTION
## Summary

- `deployment-health.spec.js` was described as testing "the live deployment health endpoint"
- In reality the spec only runs against the local Playwright HTTP server on port 33999 (started by `playwright.config.js`); no production or staging URL is contacted
- Corrected the bullet point to accurately reflect what the test covers

## Source

Identified during a README accuracy audit (gist: https://gist.github.com/jomcgi/80a606679ff45ef89fac2eb60add6aa9).

🤖 Generated with [Claude Code](https://claude.com/claude-code)