### PR TITLE
docs(lakehouse): fix image build tool description in README

### DIFF
--- a/projects/lakehouse/README.md
+++ b/projects/lakehouse/README.md
@@ -22,8 +22,8 @@ NATS JetStream  ->  Temporal workflows  ->  Iceberg on SeaweedFS  ->  DuckDB / Q
 | `iceberg/`          | PyIceberg writer helpers; per-domain `tables/`                         | 2         |
 | `duckdb_query/`     | DuckDB + iceberg-extension query helpers                               | 2         |
 | `dispatchers/`      | NATS → Temporal workflow dispatchers                                   | 4         |
-| `image/`            | apko worker image (`python -m projects.lakehouse.orchestrator.workflows.run`) | 3         |
-| `quack-server/`     | apko DuckDB/Quack serving image                                        | 3         |
+| `image/`            | `py3_image` (rules_oci) worker image (`python -m projects.lakehouse.orchestrator.workflows.run`) | 3         |
+| `quack-server/`     | `py3_image` (rules_oci) DuckDB/Quack serving image                     | 3         |
 | `chart/`, `deploy/` | OCI-versioned Helm chart + ArgoCD Application                          | 4         |
 
 ## Conventions


### PR DESCRIPTION
## Summary

- `image/` and `quack-server/` were both described as "apko" images in the layout table
- Neither directory contains an `apko.yaml`; both use the `py3_image` macro (`rules_oci` + `aspect_rules_py`)
- Updated both table entries to name the actual build macro used

## Source

Identified during a README accuracy audit (gist: https://gist.github.com/jomcgi/80a606679ff45ef89fac2eb60add6aa9).

🤖 Generated with [Claude Code](https://claude.com/claude-code)