### PR TITLE
fix(ingress): argocd rootpath for working UI, signoz bare-prefix redirect

### DIFF
--- a/projects/platform/argocd/Chart.yaml
+++ b/projects/platform/argocd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: argocd
 description: local argocd
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: "2.13.2"
 dependencies:
   - name: argo-cd

--- a/projects/platform/argocd/templates/httproute.yaml
+++ b/projects/platform/argocd/templates/httproute.yaml
@@ -1,10 +1,18 @@
 {{- /*
 Path-based private ingress: https://private.jomcgi.dev/app/argocd
 
-Envoy strips the /app/argocd prefix (URLRewrite), so argocd-server keeps
-serving at /. The matching server.basehref in values-cluster.yaml makes the
-UI reference its assets under the prefix. In-cluster API clients
-(argocd-mcp, bots hitting argocd-server.argocd.svc) are unaffected.
+The gateway forwards the full /app/argocd prefix intact (no URLRewrite):
+argocd-server runs with server.rootpath=/app/argocd (values-cluster.yaml),
+so it serves the UI, API, and websockets under the prefix and rewrites the
+index.html base href to /app/argocd/. basehref alone with a stripped prefix
+did not rewrite the base href in v3.x, leaving the UI blank.
+
+Trade-off: rootpath moves the API off / as well, so in-cluster clients must
+use the prefix (e.g. http://argocd-server.argocd.svc/app/argocd/api/...).
+The monolith reads ArgoCD via the Kubernetes API (Application CRs) and
+Image Updater runs in kubernetes application-API mode, so neither is
+affected; the runtime-registered argocd-mcp server needs its base URL
+updated to include /app/argocd.
 */}}
 {{- if .Values.cfIngress.enabled }}
 {{- $routeParams := dict
@@ -12,7 +20,6 @@ UI reference its assets under the prefix. In-cluster API clients
   "tier" .Values.cfIngress.tier
   "hostname" .Values.cfIngress.hostname
   "pathPrefix" .Values.cfIngress.pathPrefix
-  "rewritePrefix" "/"
   "serviceName" .Values.cfIngress.serviceName
   "servicePort" .Values.cfIngress.servicePort
   "gateway" .Values.cfIngress.gateway

--- a/projects/platform/argocd/values-cluster.yaml
+++ b/projects/platform/argocd/values-cluster.yaml
@@ -22,10 +22,16 @@ argo-cd:
     params:
       # Run server in insecure mode (behind Cloudflare Tunnel HTTPS termination)
       server.insecure: "true"
-      # UI is served from private.jomcgi.dev/app/argocd. The gateway strips
-      # the prefix before proxying, so only basehref is set (not rootpath):
-      # the API keeps serving at / for in-cluster clients like argocd-mcp.
+      # UI is served from private.jomcgi.dev/app/argocd. The gateway forwards
+      # the prefix intact (no strip), so rootpath makes argocd-server handle
+      # the subpath end to end (UI, API, websockets) and rewrite the index
+      # base href to /app/argocd/. basehref alone with a stripped prefix did
+      # not rewrite the base href in v3.x, leaving the UI blank. rootpath
+      # also moves the API off /, so in-cluster clients must use the prefix;
+      # the monolith reads ArgoCD via the K8s API and Image Updater runs in
+      # kubernetes application-API mode, so neither is affected.
       server.basehref: "/app/argocd"
+      server.rootpath: "/app/argocd"
       otlp.address: "signoz-otel-collector.signoz.svc.cluster.local:4317"
   # Enable metrics endpoints for all ArgoCD components
   # These expose Prometheus metrics including argocd_app_info for health/sync status

--- a/projects/platform/signoz/Chart.yaml
+++ b/projects/platform/signoz/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: signoz
 description: A Helm chart wrapper for SigNoz
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: "0.128.0"
 dependencies:
   - name: signoz

--- a/projects/platform/signoz/templates/httproute.yaml
+++ b/projects/platform/signoz/templates/httproute.yaml
@@ -19,5 +19,34 @@ http://signoz.signoz.svc.cluster.local:8080/app/signoz/api/v1/rules.
 }}
 {{- include "cf-ingress.httproute" $routeParams }}
 ---
+# Redirect the bare prefix to the trailing-slash form. Hitting /app/signoz
+# without the slash makes SigNoz 301 to / (root), which on private.jomcgi.dev
+# lands on the monolith. This gateway redirect catches the bare prefix first,
+# mirroring the longhorn-private-slash-redirect route.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: signoz-private-slash-redirect
+  labels:
+    ingress-tier: {{ .Values.cfIngress.tier }}
+spec:
+  parentRefs:
+    - name: {{ .Values.cfIngress.gateway.name }}
+      namespace: {{ .Values.cfIngress.gateway.namespace }}
+  hostnames:
+    - {{ .Values.cfIngress.hostname | quote }}
+  rules:
+    - matches:
+        - path:
+            type: Exact
+            value: {{ .Values.cfIngress.pathPrefix }}
+      filters:
+        - type: RequestRedirect
+          requestRedirect:
+            path:
+              type: ReplaceFullPath
+              replaceFullPath: {{ .Values.cfIngress.pathPrefix }}/
+            statusCode: 301
+---
 {{- include "cf-ingress.security-policy" (dict "name" "signoz-private") }}
 {{- end }}


### PR DESCRIPTION
Follow-up to #2525. Two of the three migrated apps were broken when tested live; this fixes both. Longhorn already works.

## ArgoCD: blank page -> `server.rootpath`

The UI rendered a blank page. With the gateway stripping `/app/argocd` and only `server.basehref` set, argocd-server v3.1.6 did **not** rewrite the `index.html` base href (verified in-cluster: served `<base href="/">`). Its asset URLs are relative, so they resolved to `private.jomcgi.dev/main.*.js`, fell through to the monolith `/` catch-all, and the JS never loaded.

Fix: set `server.rootpath: /app/argocd` (alongside `basehref`) and stop stripping the prefix at the gateway (drop `rewritePrefix` so the cf-ingress library omits the `URLRewrite` filter). argocd-server now handles the subpath end to end (UI, API, websockets) and rewrites the base href to `/app/argocd/`.

**Trade-off (accepted):** `rootpath` moves the API off `/` too. Blast radius was checked:
- monolith reads ArgoCD via the **K8s API** (`argoproj.io/applications` CRs), not the HTTP server. Unaffected.
- ArgoCD Image Updater runs in **kubernetes** application-API mode (no `argocd-server` address in its config). Unaffected.
- The runtime-registered **argocd-mcp** server (Context Forge, not in git) needs its base URL updated to include `/app/argocd`. Manual follow-up.
- `argocd` CLI: `--grpc-web-root-path /app/argocd` (already noted in #2525).

Safety: argocd-server is `RollingUpdate` with `maxUnavailable` effectively 0 over 2 replicas. If `rootpath` were to relocate `/healthz` and break the readiness probe, new pods just never go Ready and the old (API-working) pods keep serving. No outage; fix-forward.

## SigNoz: redirected to monolith root -> slash-redirect route

Hitting `/app/signoz` without a trailing slash makes SigNoz `301 -> /` (verified in-cluster), which on `private.jomcgi.dev` lands on the monolith. Add a gateway slash-redirect (`Exact /app/signoz -> 301 /app/signoz/`), mirroring the existing `longhorn-private-slash-redirect`. SigNoz already serves correctly at `/app/signoz/` (`<base href="/app/signoz/">`, 200).

## Not in this PR

ArgoCD v3.1 reached EOL 2026-05-06; the version upgrade (toward chart 9.x) is deliberately deferred to its own reviewed PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)