### PR TITLE
feat(semgrep): add cfingress-rewrite-needs-slash-redirect rule

### DIFF
--- a/bazel/semgrep/rules/BUILD
+++ b/bazel/semgrep/rules/BUILD
@@ -400,6 +400,22 @@ semgrep_test(
     tags = ["semgrep"],
 )
 
+# cfingress-rewrite-needs-slash-redirect uses languages: [generic] scoped to
+# **/templates/httproute.yaml. Wired to its own annotation fixture independently
+# of yaml_rules_test (which scans yaml_fixtures, excluding this fixture).
+filegroup(
+    name = "cfingress_rewrite_needs_slash_redirect_rule",
+    srcs = ["yaml/cfingress-rewrite-needs-slash-redirect.yaml"],
+)
+
+semgrep_test(
+    name = "cfingress_rewrite_needs_slash_redirect_test",
+    srcs = ["//bazel/semgrep/tests:cfingress_rewrite_needs_slash_redirect_fixtures"],
+    env = {"SEMGREP_TEST_MODE": "1"},
+    rules = [":cfingress_rewrite_needs_slash_redirect_rule"],
+    tags = ["semgrep"],
+)
+
 # css-import-after-rules uses languages: [generic] scoped to **/*.css.
 # Wired to its own .css annotation fixture independently of generic_rules_test
 # (which only scans no-stale-repo-paths fixtures).

--- a/bazel/semgrep/rules/yaml/cfingress-rewrite-needs-slash-redirect.yaml
+++ b/bazel/semgrep/rules/yaml/cfingress-rewrite-needs-slash-redirect.yaml
@@ -1,0 +1,38 @@
+rules:
+  - id: cfingress-rewrite-needs-slash-redirect
+    languages: [generic]
+    severity: WARNING
+    message: >-
+      cf-ingress.httproute is called with "rewritePrefix" "/" but this template
+      has no companion slash-redirect rule. Without the redirect, visiting the
+      bare path prefix (e.g. /app/myservice instead of /app/myservice/) causes
+      the browser URL to stay at /app/myservice, and any relative asset or API
+      URLs emitted by the UI resolve against /app/ (the parent) instead of
+      /app/myservice/. Add a RequestRedirect HTTPRoute for the bare prefix
+      (see longhorn/templates/httproute.yaml for the pattern), or suppress with
+      a nosemgrep comment if the service uses a basehref mechanism that makes
+      the redirect unnecessary (e.g. ArgoCD with server.basehref injects
+      <base href="..."> into index.html, so no redirect is needed).
+    metadata:
+      category: correctness
+      subcategory: helm
+      confidence: HIGH
+      likelihood: MEDIUM
+      impact: MEDIUM
+      technology: [helm, kubernetes, gateway-api]
+    paths:
+      include:
+        - "**/templates/httproute.yaml"
+    # languages: [generic] (spacegrep) is required here because Helm templates
+    # contain {{ }} directives that make them invalid YAML. The primary pattern
+    # anchors at "rewritePrefix" "/" and the trailing ... extends the match
+    # forward to the end of the file so pattern-not can find RequestRedirect
+    # anywhere after the rewritePrefix declaration.
+    patterns:
+      - pattern: |
+          "rewritePrefix" "/"
+          ...
+      - pattern-not: |
+          "rewritePrefix" "/"
+          ...
+          RequestRedirect

--- a/bazel/semgrep/tests/BUILD
+++ b/bazel/semgrep/tests/BUILD
@@ -20,6 +20,7 @@ filegroup(
             "fixtures/no-discarded-json-marshal.yaml",
             "fixtures/no-session-in-to-thread.yaml",
             "fixtures/no-shared-preload-libraries-cnpg.yaml",
+            "fixtures/cfingress-rewrite-needs-slash-redirect.yaml",
             "fixtures/no-unquoted-helm-range-args.yaml",
             "fixtures/python-shadow-module-import.yaml",
             "fixtures/require-cnpg-cluster-resources.yaml",
@@ -151,6 +152,16 @@ filegroup(
 
 # Fixtures for kubernetes rules (require-readiness-probe, require-resource-limits, etc.).
 # Referenced by //bazel/semgrep/rules:kubernetes_rules_test.
+# Fixture for the cfingress-rewrite-needs-slash-redirect rule (languages: generic,
+# paths: **/templates/httproute.yaml). Excluded from yaml_fixtures because the rule
+# uses a forward-scanning pattern-not that requires the ok and bad cases to be ordered
+# carefully, and it targets template files rather than plain YAML.
+# Referenced by //bazel/semgrep/rules:cfingress_rewrite_needs_slash_redirect_test.
+filegroup(
+    name = "cfingress_rewrite_needs_slash_redirect_fixtures",
+    srcs = ["fixtures/cfingress-rewrite-needs-slash-redirect.yaml"],
+)
+
 # New rule fixtures should be added here as they are created.
 filegroup(
     name = "kubernetes_yaml_fixtures",

--- a/bazel/semgrep/tests/fixtures/cfingress-rewrite-needs-slash-redirect.yaml
+++ b/bazel/semgrep/tests/fixtures/cfingress-rewrite-needs-slash-redirect.yaml
@@ -1,0 +1,65 @@
+# Tests for cfingress-rewrite-needs-slash-redirect rule.
+# cf-ingress.httproute calls with "rewritePrefix" "/" must have a companion
+# RequestRedirect rule for the bare prefix. Without it, relative asset URLs
+# in the UI resolve against the wrong base path.
+#
+# The rule uses languages: [generic] (spacegrep). The primary pattern anchors
+# at "rewritePrefix" "/" and uses ... to scan forward; pattern-not checks if
+# RequestRedirect appears after it. Because of this forward-scan semantics, ok
+# cases must appear BEFORE bad cases in this fixture so that the ok-case
+# RequestRedirect does not suppress the bad-case findings.
+#
+# In generic mode the finding is anchored at the "rewritePrefix" "/" tokens, so
+# # ruleid: annotations must appear on the line immediately before "rewritePrefix".
+
+---
+# ok: cfingress-rewrite-needs-slash-redirect -- companion RequestRedirect is present after rewritePrefix
+{{- if .Values.cfIngress.enabled }}
+{{- $routeParams := dict
+  "name" "my-service-private"
+  "tier" .Values.cfIngress.tier
+  "hostname" .Values.cfIngress.hostname
+  "pathPrefix" .Values.cfIngress.pathPrefix
+  "rewritePrefix" "/"
+  "serviceName" .Values.cfIngress.serviceName
+  "servicePort" .Values.cfIngress.servicePort
+  "gateway" .Values.cfIngress.gateway
+}}
+{{- include "cf-ingress.httproute" $routeParams }}
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: my-service-private-slash-redirect
+spec:
+  rules:
+    - matches:
+        - path:
+            type: Exact
+            value: {{ .Values.cfIngress.pathPrefix }}
+      filters:
+        - type: RequestRedirect
+          requestRedirect:
+            path:
+              type: ReplaceFullPath
+              replaceFullPath: {{ .Values.cfIngress.pathPrefix }}/
+            statusCode: 301
+{{- end }}
+
+---
+# Bad case: rewritePrefix "/" with no RequestRedirect anywhere after it.
+# The annotation must be on the line immediately before "rewritePrefix" "/".
+{{- if .Values.cfIngress.enabled }}
+{{- $routeParams := dict
+  "name" "bad-service-private"
+  "tier" .Values.cfIngress.tier
+  "hostname" .Values.cfIngress.hostname
+  "pathPrefix" .Values.cfIngress.pathPrefix
+# ruleid: cfingress-rewrite-needs-slash-redirect
+  "rewritePrefix" "/"
+  "serviceName" .Values.cfIngress.serviceName
+  "servicePort" .Values.cfIngress.servicePort
+  "gateway" .Values.cfIngress.gateway
+}}
+{{- include "cf-ingress.httproute" $routeParams }}
+{{- end }}

--- a/projects/platform/argocd/templates/httproute.yaml
+++ b/projects/platform/argocd/templates/httproute.yaml
@@ -12,11 +12,12 @@ UI reference its assets under the prefix. In-cluster API clients
   "tier" .Values.cfIngress.tier
   "hostname" .Values.cfIngress.hostname
   "pathPrefix" .Values.cfIngress.pathPrefix
-  "rewritePrefix" "/"
   "serviceName" .Values.cfIngress.serviceName
   "servicePort" .Values.cfIngress.servicePort
   "gateway" .Values.cfIngress.gateway
 }}
+# nosemgrep: cfingress-rewrite-needs-slash-redirect
+{{- $_ := set $routeParams "rewritePrefix" "/" }}
 {{- include "cf-ingress.httproute" $routeParams }}
 ---
 {{- include "cf-ingress.security-policy" (dict "name" "argocd-private") }}


### PR DESCRIPTION
## Summary

- Adds semgrep rule `cfingress-rewrite-needs-slash-redirect` that flags `**/templates/httproute.yaml` files using `cf-ingress.httproute` with `rewritePrefix "/"` but no companion `RequestRedirect` rule
- Uses `languages: [generic]` (spacegrep) since real Helm templates contain `{{ }}` directives that break the YAML parser
- Pattern scans forward from `"rewritePrefix" "/"` to find `RequestRedirect`; fires only when it is absent
- Adds test fixture with ok case (companion present) before bad case (no redirect), matching the forward-scan semantics
- Adds a `nosemgrep` comment to ArgoCD's `httproute.yaml`: ArgoCD uses `server.basehref` to inject `<base href="/app/argocd">` into `index.html`, making the slash-redirect unnecessary for this basehref-aware SPA (confirmed by upstream analysis in gist 617689673970baad097c9f39c080fc37)
- Longhorn already has the companion redirect and will not fire
- BUILD files updated to exclude the fixture from `yaml_fixtures` and wire a dedicated test target

## Test plan

- [ ] CI passes (`bazel test //...`) -- all semgrep test targets skip in `SEMGREP_TEST_MODE=1`
- [ ] Longhorn's `httproute.yaml` does NOT produce a finding (has `RequestRedirect`)
- [ ] ArgoCD's `httproute.yaml` is suppressed via `nosemgrep` annotation
- [ ] Any new service adding `"rewritePrefix" "/"` without a companion redirect will be flagged by Semgrep Cloud Platform

🤖 Generated with [Claude Code](https://claude.com/claude-code)