### PR TITLE
chore(ingress): retire argocd/signoz/longhorn subdomain tunnel routes

### DIFF
--- a/projects/platform/cloudflare-gateway/Chart.yaml
+++ b/projects/platform/cloudflare-gateway/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cloudflare-gateway
 description: Cloudflare ingress stack - Envoy Gateway control plane, Gateway API resources, and Cloudflare Tunnel
 type: application
-version: 1.0.0
+version: 1.0.1
 appVersion: "v1.3.2"
 
 dependencies:

--- a/projects/platform/cloudflare-gateway/values-prod.yaml
+++ b/projects/platform/cloudflare-gateway/values-prod.yaml
@@ -27,12 +27,10 @@ tunnel:
 
   ingress:
     routes:
-      - hostname: argocd.jomcgi.dev
-        service: http://argocd-server.argocd.svc.cluster.local:80
-      - hostname: longhorn.jomcgi.dev
-        service: http://longhorn-frontend.longhorn.svc.cluster.local:80
-      - hostname: signoz.jomcgi.dev
-        service: http://signoz.signoz.svc.cluster.local:8080
+      # argocd, longhorn, and signoz retired: they now serve under
+      # private.jomcgi.dev/app/<app> via the cloudflare-ingress gateway
+      # (HTTPRoutes in each chart). Their old subdomains fall through to
+      # catchAll, which has no matching gateway route, so they stop resolving.
       - hostname: img.jomcgi.dev
         service: http://trips-nginx.trips.svc.cluster.local:80
       - hostname: grimoire.jomcgi.dev

--- a/projects/platform/longhorn/Chart.yaml
+++ b/projects/platform/longhorn/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: longhorn
 description: Longhorn distributed block storage system for Kubernetes
 type: application
-version: 1.0.0
+version: 1.0.1
 appVersion: "1.8.1"
 
 dependencies:

--- a/projects/platform/longhorn/longhorn-httpcheck-alert.yaml
+++ b/projects/platform/longhorn/longhorn-httpcheck-alert.yaml
@@ -26,7 +26,7 @@ data:
         "environment": "production"
       },
       "annotations": {
-        "summary": "Longhorn at longhorn.jomcgi.dev is unreachable",
+        "summary": "Longhorn at private.jomcgi.dev/app/longhorn is unreachable",
         "description": "HTTP health check has failed 5 consecutive times over 10 minutes. This could indicate the service is down or Cloudflare auth is failing (3xx redirect)."
       },
       "condition": {
@@ -46,7 +46,7 @@ data:
                   }
                 ],
                 "filter": {
-                  "expression": "http.url = 'https://longhorn.jomcgi.dev'"
+                  "expression": "http.url = 'https://private.jomcgi.dev/app/longhorn/'"
                 },
                 "groupBy": [],
                 "order": [],

--- a/projects/platform/signoz/Chart.yaml
+++ b/projects/platform/signoz/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: signoz
 description: A Helm chart wrapper for SigNoz
 type: application
-version: 0.1.1
+version: 0.1.2
 appVersion: "0.128.0"
 dependencies:
   - name: signoz

--- a/projects/platform/signoz/values-prod.yaml
+++ b/projects/platform/signoz/values-prod.yaml
@@ -97,8 +97,9 @@ k8s-infra:
               headers:
                 CF-Access-Client-Id: "${env:CF_ACCESS_CLIENT_ID}"
                 CF-Access-Client-Secret: "${env:CF_ACCESS_CLIENT_SECRET}"
-            # Storage management - Longhorn
-            - endpoint: https://longhorn.jomcgi.dev
+            # Storage management - Longhorn (path-based; trailing slash avoids
+            # the bare-prefix 301 to /app/longhorn/)
+            - endpoint: https://private.jomcgi.dev/app/longhorn/
               method: GET
               headers:
                 CF-Access-Client-Id: "${env:CF_ACCESS_CLIENT_ID}"


### PR DESCRIPTION
Final cleanup of the ADR-002 path migration (#2525, #2530), now that all three apps are verified working under `private.jomcgi.dev/app/<app>`.

## Changes

- **`cloudflare-gateway/values-prod.yaml`**: remove the `argocd.jomcgi.dev`, `longhorn.jomcgi.dev`, and `signoz.jomcgi.dev` tunnel routes. They fall through to `catchAll` (cloudflare-ingress), which has no matching gateway route, so the old subdomains stop resolving.
- **`signoz/values-prod.yaml`**: migrate Longhorn's httpcheck probe to `https://private.jomcgi.dev/app/longhorn/` (trailing slash avoids the bare-prefix 301). ArgoCD/SigNoz probes were already moved in #2525.
- **`longhorn-httpcheck-alert.yaml`**: alert expression + summary updated to the new path.

## Out of scope (not in git)

- **DNS**: the retired subdomains' CNAMEs live in Cloudflare, not the repo. Delete `argocd`/`signoz`/`longhorn` records there separately.
- **ArgoCD MCP**: registered at runtime in Context Forge (its `servers:` list in the `mcp-servers` chart is commented out), so it is removed/reconfigured in Context Forge, not here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)