### PR TITLE
docs: update references to retired argocd/signoz/longhorn subdomains

### DIFF
--- a/.claude/skills/add-httpcheck-alert/SKILL.md
+++ b/.claude/skills/add-httpcheck-alert/SKILL.md
@@ -222,7 +222,7 @@ Creates: `projects/todo/deploy/todo-httpcheck-alert.yaml`
 ### Example 2: Service with Custom Namespace
 
 ```
-/add-httpcheck-alert signoz https://signoz.jomcgi.dev signoz
+/add-httpcheck-alert signoz https://private.jomcgi.dev/app/signoz signoz
 ```
 
 Creates: `projects/signoz/deploy/signoz-httpcheck-alert.yaml`

--- a/docs/observability-alerting.md
+++ b/docs/observability-alerting.md
@@ -140,7 +140,7 @@ Monitor service availability via the OTel httpcheck receiver. Pattern: `max(http
 | Service          | URL                                       | Location                                      |
 | ---------------- | ----------------------------------------- | --------------------------------------------- |
 | ArgoCD           | `https://private.jomcgi.dev/app/argocd/healthz` | `projects/platform/argocd/`                   |
-| Longhorn         | `https://longhorn.jomcgi.dev`             | `projects/platform/longhorn/`                 |
+| Longhorn         | `https://private.jomcgi.dev/app/longhorn/` | `projects/platform/longhorn/`                 |
 | SigNoz           | `https://private.jomcgi.dev/app/signoz`   | `projects/platform/signoz/`                   |
 | hikes.jomcgi.dev | `https://hikes.jomcgi.dev`                | `projects/platform/signoz/`                   |
 | jomcgi.dev       | `https://jomcgi.dev`                      | `projects/platform/signoz/`                   |

--- a/projects/platform/argocd/values-cluster.yaml
+++ b/projects/platform/argocd/values-cluster.yaml
@@ -1,5 +1,5 @@
 # Path-based private ingress: https://private.jomcgi.dev/app/argocd
-# Replaces the static tunnel route at argocd.jomcgi.dev (kept during transition).
+# Replaced the former argocd.jomcgi.dev tunnel route (retired in PR #2534).
 cfIngress:
   enabled: true
   tier: trusted

--- a/projects/platform/longhorn/templates/httproute.yaml
+++ b/projects/platform/longhorn/templates/httproute.yaml
@@ -8,9 +8,10 @@ browser is at a trailing-slash URL. The redirect route below handles the
 bare /app/longhorn case, which would otherwise resolve relative URLs
 against /app/ and fall through to the monolith catch-all.
 
-If anything still breaks (community reports on subpath setups are mixed),
-delete this file; the static tunnel route at longhorn.jomcgi.dev stays
-authoritative until this path is proven.
+This path is the authoritative route (verified working); the former
+longhorn.jomcgi.dev tunnel route was retired in PR #2534. If a future
+Longhorn upgrade breaks subpath asset/websocket handling, reverting this
+file plus the tunnel route is the fallback.
 */}}
 {{- if .Values.cfIngress.enabled }}
 {{- $routeParams := dict

--- a/projects/platform/longhorn/values-prod.yaml
+++ b/projects/platform/longhorn/values-prod.yaml
@@ -2,8 +2,8 @@
 # Wraps upstream chart configuration
 
 # Path-based private ingress: https://private.jomcgi.dev/app/longhorn
-# Experimental (see templates/httproute.yaml); longhorn.jomcgi.dev remains
-# the authoritative route until this is proven to work.
+# This is the authoritative route; the former longhorn.jomcgi.dev tunnel route
+# was retired in PR #2534. See templates/httproute.yaml for the prefix handling.
 cfIngress:
   enabled: true
   tier: trusted

--- a/projects/platform/signoz/values-prod.yaml
+++ b/projects/platform/signoz/values-prod.yaml
@@ -1,6 +1,6 @@
 # Path-based private ingress: https://private.jomcgi.dev/app/signoz
-# The old signoz.jomcgi.dev hostname stops working once the base path below
-# is set, because SigNoz serves all routes under the prefix.
+# SigNoz serves all routes under the base path below, so it cannot also serve
+# at a bare hostname; the former signoz.jomcgi.dev route was retired in PR #2534.
 cfIngress:
   enabled: true
   tier: trusted

--- a/projects/trips/backend/README.md
+++ b/projects/trips/backend/README.md
@@ -434,7 +434,7 @@ Instrumented with OpenTelemetry (auto-injected by Kyverno):
 - Elevation API calls
 - WebSocket connections
 
-View in SigNoz: https://signoz.jomcgi.dev
+View in SigNoz: https://private.jomcgi.dev/app/signoz
 
 ### Logs
 


### PR DESCRIPTION
Tidies the doc/comment references left over after #2534 retired the argocd/signoz/longhorn Cloudflare Tunnel routes. Points them at the path-based URLs and removes the stale 'kept during transition' / 'remains authoritative until proven' language now that the cutover is complete.

- `docs/observability-alerting.md` — Longhorn synthetic-check URL → `/app/longhorn/`
- `projects/trips/backend/README.md` — SigNoz link → `/app/signoz`
- `add-httpcheck-alert` SKILL.md — example command URL
- argocd/longhorn/signoz chart comments — reflect that the subdomains are retired

Comment- and doc-only; no rendered manifest change (verified). Historical `docs/plans/*` and ADRs left as point-in-time records.

🤖 Generated with [Claude Code](https://claude.com/claude-code)