### PR TITLE
feat(ocaml): close the semgrep_core closure with the yaml ctypes-stubgen slice

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -103,6 +103,7 @@ use_repo(
     "ocaml_cppo",
     "ocaml_csexp",
     "ocaml_cstruct",
+    "ocaml_ctypes",
     "ocaml_digestif",
     "ocaml_domain_local_await",
     "ocaml_dune_configurator",
@@ -113,6 +114,7 @@ use_repo(
     "ocaml_fpath",
     "ocaml_hex",
     "ocaml_hmap",
+    "ocaml_integers",
     "ocaml_logs",
     "ocaml_lwt",
     "ocaml_lwt_dllist",
@@ -163,6 +165,7 @@ use_repo(
     "ocaml_uri",
     "ocaml_uuidm",
     "ocaml_visitors",
+    "ocaml_yaml",
     "ocaml_yojson",
 )
 

--- a/bazel/ocaml/README.md
+++ b/bazel/ocaml/README.md
@@ -216,7 +216,12 @@ no_preprocessing | future_syntax | (pps ...))` — future_syntax is the
   here: warning flags only, and linux-glibc feature pins -- plus
   ocaml_intrinsics_kernel and base, the Jane Street ladder's foundation:
   base's random_repr/shadow_stdlib codegen runs against the sysroot tar and
-  its mpopcnt probe pins to the portable fallback), and for packages
+  its mpopcnt probe pins to the portable fallback; integers and ctypes,
+  whose `install_c_headers`/`c_names` spellings and configurator probe are
+  not modeled -- ctypes' probe runs in a genrule via the lwt discover mold;
+  and yaml, the first two-stage ctypes stubgen package, vendored libyaml as
+  a cc_library plus a compile-and-run stubgen genrule -- see
+  semgrep_src/README.md's yaml dispatch), and for packages
   that are not dune projects at all, where there is nothing to translate
   (cmdliner and logs build with b0/topkg; their flat module layouts make the
   overrides one ocaml_library per findlib name). Overrides still

--- a/bazel/ocaml/examples/opam_ladder/BUILD
+++ b/bazel/ocaml/examples/opam_ladder/BUILD
@@ -147,6 +147,14 @@ build_test(
         # on the 5.3 sysroot).
         "@ocaml_base64//:base64",
         "@ocaml_base64//:base64_rfc2045",
+        # Phase 8 yaml slice: the ctypes closure src/core's yaml dep rides
+        # on. integers/ctypes use c_srcs (not cc_library), so they build on
+        # both arch shards; ctypes_primitives.ml comes from the real
+        # configurator probe run on the default pool (the lwt_features
+        # mold), identical output on both LP64 little-endian platforms.
+        "@ocaml_integers//:integers",
+        "@ocaml_ctypes//:ctypes",
+        "@ocaml_ctypes//:ctypes_stubs",
     ],
 )
 
@@ -198,5 +206,10 @@ build_test(
         "@semgrep_src//:semgrep_core_sca",
         "@semgrep_src//:git_wrapper",
         "@semgrep_src//:semgrep_core_target",
+        # Phase 8 yaml slice: ocaml-yaml links the vendored libyaml
+        # cc_library, hence the cc bucket; src/core (the closure this slice
+        # closes) reaches it AND commons' pcre.
+        "@ocaml_yaml//:yaml",
+        "@semgrep_src//:semgrep_core",
     ],
 )

--- a/bazel/ocaml/opam/lock.json
+++ b/bazel/ocaml/opam/lock.json
@@ -1086,6 +1086,46 @@
       "ppx_runtime": {
         "visitors.ppx": ["visitors.runtime"]
       }
+    },
+    {
+      "name": "integers",
+      "version": "0.8.0",
+      "repo": "ocaml_integers",
+      "url": "https://github.com/yallop/ocaml-integers/archive/0.8.0.tar.gz",
+      "sha256": "04a1a6d5cc1ecfd3f354a83caed27e59995bb26adec64d88193ccc36268929fa",
+      "strip_prefix": "ocaml-integers-0.8.0",
+      "type": "tar.gz",
+      "libs": {
+        "integers": "integers"
+      },
+      "override": true
+    },
+    {
+      "name": "ctypes",
+      "version": "0.24.0",
+      "repo": "ocaml_ctypes",
+      "url": "https://github.com/yallop/ocaml-ctypes/archive/refs/tags/0.24.0.tar.gz",
+      "sha256": "249c5604c8554659761a7282db4ad200aa8c0fdc408cdb53102bd70feeb51955",
+      "strip_prefix": "ocaml-ctypes-0.24.0",
+      "type": "tar.gz",
+      "libs": {
+        "ctypes": "ctypes",
+        "ctypes.stubs": "ctypes_stubs"
+      },
+      "override": true
+    },
+    {
+      "name": "yaml",
+      "version": "3.2.0",
+      "repo": "ocaml_yaml",
+      "url": "https://github.com/avsm/ocaml-yaml/releases/download/v3.2.0/yaml-3.2.0.tbz",
+      "sha256": "c50d2aca28b9f966792b71e1603351e5d24eda4dfd3e4453fbd50366a3a08227",
+      "strip_prefix": "yaml-3.2.0",
+      "type": "tar.bz2",
+      "libs": {
+        "yaml": "yaml"
+      },
+      "override": true
     }
   ]
 }

--- a/bazel/ocaml/opam/overrides/ctypes/BUILD.tpl
+++ b/bazel/ocaml/opam/overrides/ctypes/BUILD.tpl
@@ -1,0 +1,102 @@
+# Override BUILD for ctypes (installed by extension.bzl).
+#
+# Why an override: src/ctypes/dune generates ctypes_primitives.ml with a
+# dune-configurator probe (../configure/gen_c_primitives.exe) and copies
+# ocaml_integers.h out of the installed integers package
+# (%{lib:integers:ocaml_integers.h}); neither rule shape is modeled.
+#
+# The probe compiles C snippets to read sizeof/alignof/format strings for
+# every C primitive. Unlike parmap's (whose two outputs are pinned), the
+# generated file is ~130 lines, so the real probe runs in a genrule via the
+# lwt.unix discover mold: built with our rules, run on the executor against
+# the staged sysroot with dune's .dune/configurator.v2 protocol hand-written.
+# The output is identical on this ruleset's two platforms (linux x86_64 and
+# aarch64 are both little-endian LP64; long double is 16/16 on both), so the
+# default-pool run serves both arch shards, exactly like lwt_features.
+#
+# ctypes.stubs is a plain second library. ctypes-foreign (libffi) and
+# ctypes.top stay unbuilt: yaml's stubgen path needs only ctypes + stubs.
+load("@homelab//bazel/ocaml:defs.bzl", "ocaml_binary", "ocaml_library")
+
+_SYSROOT = "@homelab//bazel/ocaml/toolchain:ocaml_compiler"
+
+ocaml_binary(
+    name = "gen_c_primitives",
+    srcs = ["src/configure/gen_c_primitives.ml"],
+    deps = ["@ocaml_dune_configurator//:configurator"],
+)
+
+genrule(
+    name = "ctypes_primitives_ml",
+    srcs = [_SYSROOT],
+    outs = ["ctypes_primitives.ml"],
+    cmd = """
+set -e
+export LC_ALL=C
+T=$$(mktemp -d) && tar -xf $(location %s) -C $$T
+G=$$(realpath $(location :gen_c_primitives))
+B=$$(mktemp -d) && mkdir -p $$B/.dune
+OC=$$T/bin/ocamlc.opt
+# .dune/configurator.v2: csexp of ((ocamlc <path>) (ocaml_config_vars ((k v)...)))
+{
+    printf '((6:ocamlc%%d:%%s)(17:ocaml_config_vars(' $${#OC} "$$OC"
+    OCAMLLIB=$$T/lib/ocaml "$$OC" -config | while IFS=: read -r k v; do
+        v="$${v# }"
+        printf '(%%d:%%s%%d:%%s)' $${#k} "$$k" $${#v} "$$v"
+    done
+    printf ')))'
+} > $$B/.dune/configurator.v2
+W=$$(mktemp -d)
+(cd $$W && INSIDE_DUNE=$$B OCAMLLIB=$$T/lib/ocaml PATH=$$T/bin:$$PATH "$$G") > $@
+""" % _SYSROOT,
+    tools = [":gen_c_primitives"],
+)
+
+# ctypes' dune copies the installed integers header next to its own sources
+# (and installs it); the cstubs C headers include it as "ocaml_integers.h".
+genrule(
+    name = "ocaml_integers_h",
+    srcs = ["@ocaml_integers//:src/ocaml_integers.h"],
+    outs = ["ocaml_integers.h"],
+    cmd = "cp $(location @ocaml_integers//:src/ocaml_integers.h) $@",
+)
+
+# The headers ctypes installs, for consumers that compile generated cstubs C
+# outside this package (yaml's stubgen genrules stage these by basename).
+filegroup(
+    name = "c_headers",
+    srcs = glob(["src/ctypes/*.h"]) + [":ocaml_integers_h"],
+    visibility = ["//visibility:public"],
+)
+
+ocaml_library(
+    name = "ctypes",
+    srcs = glob([
+        "src/ctypes/*.ml",
+        "src/ctypes/*.mli",
+    ]) + [":ctypes_primitives_ml"],
+    c_headers = glob(["src/ctypes/*.h"]) + [":ocaml_integers_h"],
+    c_srcs = [
+        "src/ctypes/complex_stubs.c",
+        "src/ctypes/ctypes_bigarrays.c",
+        "src/ctypes/ctypes_roots.c",
+        "src/ctypes/ldouble_stubs.c",
+        "src/ctypes/managed_buffer_stubs.c",
+        "src/ctypes/posix_types_stubs.c",
+        "src/ctypes/raw_pointer_stubs.c",
+        "src/ctypes/type_info_stubs.c",
+    ],
+    visibility = ["//visibility:public"],
+    deps = ["@ocaml_integers//:integers"],
+)
+
+ocaml_library(
+    name = "ctypes_stubs",
+    srcs = glob([
+        "src/cstubs/*.ml",
+        "src/cstubs/*.mli",
+    ]),
+    opam_deps = ["str"],
+    visibility = ["//visibility:public"],
+    deps = [":ctypes"],
+)

--- a/bazel/ocaml/opam/overrides/integers/BUILD.tpl
+++ b/bazel/ocaml/opam/overrides/integers/BUILD.tpl
@@ -1,0 +1,28 @@
+# Override BUILD for integers (installed by extension.bzl).
+#
+# Why an override: the dune stanza uses (install_c_headers ocaml_integers) and
+# (c_names unsigned_stubs), the pre-foreign_stubs spelling for C stubs, which
+# dune2bazel does not model. The build itself is one flat library: the stub
+# compiles via c_srcs and the header stages via c_headers (the parmap shape).
+#
+# ocaml_integers.h is exported because ctypes' dune copies it next to its own
+# sources (%{lib:integers:ocaml_integers.h}) and installs it; the ctypes
+# override reproduces that copy.
+#
+# integers.top (toplevel pretty printers, byte-only over compiler-libs) stays
+# unbuilt: nothing in the universe names it.
+load("@homelab//bazel/ocaml:defs.bzl", "ocaml_library")
+
+exports_files(["src/ocaml_integers.h"])
+
+ocaml_library(
+    name = "integers",
+    srcs = glob([
+        "src/*.ml",
+        "src/*.mli",
+    ]),
+    c_headers = ["src/ocaml_integers.h"],
+    c_srcs = ["src/unsigned_stubs.c"],
+    visibility = ["//visibility:public"],
+    deps = ["@ocaml_stdlib_shims//:stdlib_shims"],
+)

--- a/bazel/ocaml/opam/overrides/yaml/BUILD.tpl
+++ b/bazel/ocaml/opam/overrides/yaml/BUILD.tpl
@@ -1,0 +1,201 @@
+# Override BUILD for yaml (installed by extension.bzl).
+#
+# Why an override: ocaml-yaml is a two-stage ctypes stubgen package -- the
+# README's "yaml scoping" dispatch in bazel/ocaml/semgrep_src/README.md,
+# measured against this tarball's dune files. The pieces:
+#
+#   1. vendor/: the vendored libyaml C sources as a cc_library (the pcre2-c
+#      pattern), compiled -DHAVE_CONFIG_H against the checked-in config.h.
+#      Upstream's per-object rules + ocamlmklib archive collapse into one
+#      cc_library; dumper.c stays out exactly as upstream's dune leaves it.
+#   2. config/discover.ml's two probe outputs are pinned (the parmap
+#      pattern): `cflags` is provably ocamlopt_cflags on the linux sysroot
+#      ("-O2 -fno-strict-aliasing -fwrapv", inlined into yaml_c's copts;
+#      the ppc64/msvc branches are dead here) and `ctypes-cflags` is just
+#      -I<installed ctypes headers>, which here is the staged
+#      @ocaml_ctypes//:c_headers dir.
+#   3. yaml.bindings.types / yaml.bindings: plain libraries over
+#      ctypes.stubs + ctypes (no codegen).
+#   4. stage one (compile-AND-RUN): run ffi_types_stubgen.exe to emit C,
+#      compile that C with the executor's gcc against the staged ctypes
+#      headers + vendor/yaml.h + the sysroot's lib/ocaml (dune's
+#      %{ocaml_where}), run the result to emit g.ml for yaml.types. One
+#      genrule, two process generations.
+#   5. stage two: ffi_stubgen.exe -ml -> g.ml and -c -> yaml_stubs.c for
+#      yaml.ffi (pure prints, no C compile inside the genrule).
+#   6. yaml (lib/): plain library over yaml.ffi. yaml.unix and yaml-sexp
+#      stay unbuilt (src/core names only `yaml`).
+#
+# Both stubgen binaries and the stage-one genrule run on the default pool
+# (the yojson ocamllex precedent: the genrule stages the unconstrained
+# sysroot). Their outputs are arch-independent for this ruleset's two
+# platforms: linux x86_64 and aarch64 are both little-endian LP64, so
+# libyaml's struct layouts and enum values agree. The cc_library keeps the
+# whole package in CI's cc bucket (no-arm64) regardless.
+load("@homelab//bazel/ocaml:defs.bzl", "ocaml_binary", "ocaml_library")
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+_SYSROOT = "@homelab//bazel/ocaml/toolchain:ocaml_compiler"
+
+_CTYPES_HEADERS = "@ocaml_ctypes//:c_headers"
+
+# The root dune's (env ...) flags, applied by dune to every library here.
+_ENV_WFLAGS = [
+    "-w",
+    "-9-27-32-34",
+]
+
+cc_library(
+    name = "yaml_c",
+    srcs = [
+        "vendor/api.c",
+        "vendor/config.h",
+        "vendor/emitter.c",
+        "vendor/loader.c",
+        "vendor/parser.c",
+        "vendor/reader.c",
+        "vendor/scanner.c",
+        "vendor/writer.c",
+        "vendor/yaml_private.h",
+    ],
+    hdrs = ["vendor/yaml.h"],
+    copts = [
+        "-DHAVE_CONFIG_H",
+        "-O2",
+        "-fno-strict-aliasing",
+        "-fwrapv",
+        "-w",
+    ],
+    includes = ["vendor"],
+)
+
+ocaml_library(
+    name = "yaml_bindings_types",
+    srcs = [
+        "types/bindings/yaml_bindings_types.ml",
+        "types/bindings/yaml_bindings_types.mli",
+    ],
+    ocamlopt_flags = _ENV_WFLAGS,
+    wrapped = True,
+    deps = [
+        "@ocaml_ctypes//:ctypes",
+        "@ocaml_ctypes//:ctypes_stubs",
+    ],
+)
+
+ocaml_binary(
+    name = "ffi_types_stubgen",
+    srcs = ["types/stubgen/ffi_types_stubgen.ml"],
+    deps = [":yaml_bindings_types"],
+)
+
+# Stage one: the compile-AND-RUN genrule. ffi_types_stubgen.exe prints a C
+# program; building THAT (against the ctypes headers, vendor/yaml.h, and the
+# sysroot's caml/ headers) and running it prints g.ml for yaml.types.
+genrule(
+    name = "yaml_types_g_ml",
+    srcs = [
+        "vendor/yaml.h",
+        _SYSROOT,
+        _CTYPES_HEADERS,
+    ],
+    outs = ["types/lib/g.ml"],
+    cmd = """
+set -e
+T=$$(mktemp -d) && tar -xf $(location %s) -C $$T
+G=$$(realpath $(location :ffi_types_stubgen))
+H=$$(mktemp -d)
+cp $(location vendor/yaml.h) $$H/
+for h in $(locations %s); do cp $$h $$H/; done
+W=$$(mktemp -d)
+"$$G" > $$W/ffi_ml_types_stubgen.c
+gcc $$W/ffi_ml_types_stubgen.c -I $$H -I $$T/lib/ocaml -o $$W/gen
+$$W/gen > $@
+""" % (_SYSROOT, _CTYPES_HEADERS),
+    tools = [":ffi_types_stubgen"],
+)
+
+ocaml_library(
+    name = "yaml_types",
+    srcs = [
+        "types/lib/m.ml",
+        ":yaml_types_g_ml",
+    ],
+    ocamlopt_flags = _ENV_WFLAGS,
+    wrapped = True,
+    deps = [
+        ":yaml_bindings_types",
+        "@ocaml_ctypes//:ctypes",
+        "@ocaml_ctypes//:ctypes_stubs",
+    ],
+)
+
+ocaml_library(
+    name = "yaml_bindings",
+    srcs = ["ffi/bindings/yaml_bindings.ml"],
+    ocamlopt_flags = _ENV_WFLAGS,
+    wrapped = True,
+    deps = [
+        ":yaml_types",
+        "@ocaml_ctypes//:ctypes",
+        "@ocaml_ctypes//:ctypes_stubs",
+    ],
+)
+
+ocaml_binary(
+    name = "ffi_stubgen",
+    srcs = ["ffi/stubgen/ffi_stubgen.ml"],
+    deps = [
+        ":yaml_bindings",
+        ":yaml_types",
+    ],
+)
+
+# Stage two: plain prints (Cstubs.write_ml / write_c), no C compile here.
+genrule(
+    name = "yaml_ffi_g_ml",
+    outs = ["ffi/lib/g.ml"],
+    cmd = "$(location :ffi_stubgen) -ml > $@",
+    tools = [":ffi_stubgen"],
+)
+
+genrule(
+    name = "yaml_stubs_c",
+    outs = ["yaml_stubs.c"],
+    cmd = "$(location :ffi_stubgen) -c > $@",
+    tools = [":ffi_stubgen"],
+)
+
+# The generated yaml_stubs.c quote-includes "ctypes_cstubs_internals.h" (the
+# ctypes header set stages by basename next to it) and angle-includes
+# <yaml.h>, which resolves through yaml_c's exported vendor/ include dir.
+ocaml_library(
+    name = "yaml_ffi",
+    srcs = [
+        "ffi/lib/m.ml",
+        ":yaml_ffi_g_ml",
+    ],
+    c_headers = [_CTYPES_HEADERS],
+    c_srcs = [":yaml_stubs_c"],
+    cc_deps = [":yaml_c"],
+    ocamlopt_flags = _ENV_WFLAGS,
+    wrapped = True,
+    deps = [
+        ":yaml_bindings",
+        ":yaml_types",
+        "@ocaml_ctypes//:ctypes",
+        "@ocaml_ctypes//:ctypes_stubs",
+    ],
+)
+
+ocaml_library(
+    name = "yaml",
+    srcs = glob([
+        "lib/*.ml",
+        "lib/*.mli",
+    ]),
+    ocamlopt_flags = _ENV_WFLAGS,
+    visibility = ["//visibility:public"],
+    wrapped = True,
+    deps = [":yaml_ffi"],
+)

--- a/bazel/ocaml/semgrep_src/README.md
+++ b/bazel/ocaml/semgrep_src/README.md
@@ -39,6 +39,7 @@ model rejects loudly at fetch time.
 | `src/sca`                      | `:semgrep_core_sca`        | Dependency.ml{,i} overlays strip the unreferenced Alcotest.testable value (kind_testable), keeping alcotest out of the lock                                                                            |
 | `libs/git_wrapper`             | `:git_wrapper`             | dune overlay drops ocaml-git; Git_wrapper.ml{,i} overlays swap the functor types for concrete digestif-backed equivalents and fail loudly in the object-store walkers (dispatch below)                 |
 | `src/target`                   | `:semgrep_core_target`     | dune overlay adds git_wrapper (Origin/Target reference it; upstream reached it transitively through lib_parsing, whose overlay measured it out); the `(env ...)` block is inert                        |
+| `src/core`                     | `:semgrep_core`            | translated as-is; the semgrep_core closure's keystone. yaml was the only name that gated it (dispatch below); the `(env ...)` -w 30 block is inert (warnings are not errors here); tests/ has its own dune and stays out via the non-recursive glob                                              |
 
 ## libs/commons rejection dispatch
 
@@ -186,52 +187,90 @@ though two existing entries had to bump (next table).
 | `Atdgen_runtime.Yojson_extra` (interfaces codegen) | lock bump: atd 2.16.0 -> 3.0.1. The checked-in `_j` codegen calls the 3.x runtime (semgrep-interfaces.opam floors atdgen >= 3.0.1; semgrep.opam >= 3.0.0); the override grows a `*.mll` glob for the runtime's new ocamllex modules, everything else transfers                      |
 | atdgen-runtime 3.0.1 floors `yojson >= 3.0.0`    | lock bump: yojson 2.2.2 -> 3.0.0. The lib/ tree and build structure are identical (the only dune delta drops the inert `(libraries seq)`); the mucppo override transfers unchanged. ppx_deriving_yojson 3.10.0's runtime floor is yojson >= 1.6.0, still satisfied                  |
 
-## yaml scoping (NOT landed; gates src/core)
+## yaml closure dispatch (the slice that closed semgrep_core)
 
-`src/core` names `yaml` (semgrep.opam floor >= 3.2.0); everything else in
-its stanza resolves today (visitors.ppx, commons.ppx, ppx_telemetry,
-sexplib, uri, uuidm, semgrep_core_rule, semgrep_core_target). ocaml-yaml
-3.2.0 is NOT the lwt.unix/parmap mold: it is a two-stage **ctypes stubgen**
-package. Lock `ctypes` + `integers` (+ whatever closure `--verify` pulls;
-yaml's opam also names dune-configurator and bos, both already locked)
-before touching yaml itself.
+`src/core` named `yaml` (semgrep.opam floor >= 3.2.0); everything else in
+its stanza already resolved. ocaml-yaml 3.2.0 is a two-stage **ctypes
+stubgen** package, landed as three lock entries:
 
-Expected override shape (`opam/overrides/yaml/BUILD.tpl`), measured against
-the 3.2.0 tarball's dune files; the genrules follow the lwt.unix discover
-mold (stage the sysroot tar, run on the executor) but compile-and-run a
-generated C program instead of just running an OCaml probe:
+| piece                                       | dispatch                                                                                                                                                                                                                                                                                                          |
+| ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `integers` 0.8.0                            | lock, override: `(install_c_headers ...)` + `(c_names ...)` (the pre-foreign_stubs stub spelling) are not modeled; one flat library, the parmap c_srcs shape. integers.top (byte-only toplevel printers) stays unbuilt                                                                                            |
+| `ctypes` 0.24.0                             | lock, override: ctypes_primitives.ml comes from a dune-configurator probe and ocaml_integers.h from a `%{lib:integers:...}` copy rule. The probe RUNS in a genrule (the lwt.unix discover mold) instead of being pinned like parmap's: its output is ~130 generated lines, and it is provably identical on both platforms (linux x86_64/aarch64 are little-endian LP64; long double is 16/16 on both). ctypes.stubs is a plain second library; ctypes-foreign (libffi) and ctypes.top stay unbuilt |
+| ctypes' `bigarray` dep                      | inert: Bigarray is stdlib on OCaml 5.3, no archive or flag needed (verified in the harness)                                                                                                                                                                                                                       |
+| `bigarray-compat`                           | never materialized: ctypes 0.24.0 dropped it (the scoping pass predicted it "likely"); opam resolution for yaml 3.2.0 pulls exactly ctypes + integers                                                                                                                                                             |
+| `yaml` 3.2.0                                | lock, override: the six-piece dispatch below, landed as recorded                                                                                                                                                                                                                                                  |
 
-1. `vendor/` (`yaml.c`): the vendored libyaml C sources as `c_srcs` on an
-   ocaml_library (or a cc_library via cc_deps, the pcre2 pattern); upstream
-   compiles them with `-DHAVE_CONFIG_H` against its checked-in config.h and
-   archives via ocamlmklib (`foreign_archives yaml_c_stubs`).
-2. `config/ctypes-cflags`: dune-configurator probe; provably constant on
-   the linux sysroot (it emits include paths for ctypes' installed headers),
-   so the override pins its output the way parmap's probes are pinned.
+The yaml override (`opam/overrides/yaml/BUILD.tpl`), as landed:
+
+1. `vendor/` (`yaml.c`): the vendored libyaml C sources as a **cc_library**
+   via cc_deps (the pcre2-c pattern won over c_srcs: stage one needs the
+   header dir as a plain `-I`, and the stub compile needs `<yaml.h>` to
+   resolve through an exported include dir), compiled `-DHAVE_CONFIG_H`
+   against the checked-in config.h. dumper.c stays out, as upstream's dune
+   leaves it.
+2. `config/discover.ml`'s outputs are pinned (the parmap pattern):
+   `cflags` is ocamlopt_cflags ("-O2 -fno-strict-aliasing -fwrapv", inlined
+   into yaml_c's copts; the ppc64/msvc branches are dead) and
+   `ctypes-cflags` is -I<installed ctypes headers>, which here is the
+   staged `@ocaml_ctypes//:c_headers` filegroup.
 3. `yaml.bindings.types`, `yaml.bindings`: plain ocaml_libraries over
-   ctypes.stubs + ctypes (translate or hand-write; no codegen).
-4. types/stubgen, stage one (the compile-AND-RUN genrule): build
-   `ffi_types_stubgen.exe` (ocaml_binary over yaml.bindings.types), run it
-   to emit `ffi_ml_types_stubgen.c`, compile that C with the executor's cc
-   against `vendor/` headers + the pinned ctypes-cflags + the sysroot's
-   `lib/ocaml` (dune's `%{ocaml_where}`), run the resulting binary to emit
-   `g.ml` for `yaml.types`. One genrule, two process generations.
-5. ffi/stubgen, stage two: build `ffi_stubgen.exe` (over yaml.bindings +
-   yaml.types), run `-ml` -> `g.ml` and `-c` -> `yaml_stubs.c` for
-   `yaml.ffi` (whose dune carries `(modules g m)` -- complete once the
-   generated g.ml joins, so the translator feature covers it if translated;
-   the foreign_stubs C file keeps this an override regardless).
-6. `yaml` (lib/): plain library over yaml.ffi; `yaml.unix` stays unbuilt
-   (src/core names only `yaml`).
+   ctypes.stubs + ctypes (hand-written in the override; no codegen).
+4. types/stubgen, stage one (the compile-AND-RUN genrule): run
+   `ffi_types_stubgen.exe` to emit C, compile that C with the executor's
+   gcc against the staged ctypes headers + vendor/yaml.h + the sysroot's
+   `lib/ocaml` (dune's `%{ocaml_where}`), run the result to emit `g.ml`
+   for `yaml.types`. One genrule, two process generations.
+5. ffi/stubgen, stage two: `ffi_stubgen.exe -ml` -> `g.ml` and `-c` ->
+   `yaml_stubs.c` for `yaml.ffi` (pure prints, no C compile in the
+   genrule). The generated C quote-includes "ctypes_cstubs_internals.h"
+   (staged by basename via c_headers) and angle-includes `<yaml.h>`
+   (resolved through yaml_c's exported vendor/ dir).
+6. `yaml` (lib/): plain library over yaml.ffi; `yaml.unix` and `yaml-sexp`
+   stay unbuilt (src/core names only `yaml`).
 
-Both stubgen binaries are exec-config tools running on the default pool, so
-the genrules reference the unconstrained `toolchain:ocaml_compiler` exactly
-like yojson's ocamllex run (see bazel/ocaml/README.md, multi-arch notes).
+Both stubgen binaries are exec-config tools running on the default pool, and
+the stage-one genrule references the unconstrained `toolchain:ocaml_compiler`
+exactly like yojson's ocamllex run (see bazel/ocaml/README.md, multi-arch
+notes); g.ml's constants (libyaml struct sizes/offsets, enum values) agree
+between the two LP64 platforms. integers/ctypes use c_srcs, not cc_library,
+so they live in the both-arch `ladder_builds`; yaml's cc_library puts it
+(and src/core, which also reaches commons' pcre) in `ladder_builds_cc`.
 
-## Next slice dispatch (toward semgrep-core, NOT landed)
+The whole stack was pre-validated in the local harness: every override
+recipe replayed through the real driver (including both stubgen genrules),
+an e2e binary parsed and re-emitted YAML through the driver-built chain,
+and src/core compiled with its full composed ppx driver against it.
 
-The Go chain's consumer is `src/parsing` (Parse_target/Parse_pattern), whose
-dune names `semgrep_core` plus every other language parser. With this
-slice's seven dirs in, the remaining semgrep_core closure is exactly
-`src/core` <- yaml (section above). After src/core: src/parsing and the
-per-language parser matrix, each its own scoping pass.
+## src/parsing scoping (recorded, NOT landed)
+
+`src/parsing` (Parse_target/Parse_pattern; `semgrep.parsing`, dune name
+`semgrep_parsing`) is the next consumer: its stanza names `semgrep_core`
+plus essentially the whole parser matrix. Its two `Parsing_stats.atd`
+atdgen rule pairs match the translated rule shape, and its pps line
+(ppx_profiling, ppx_deriving.show, telemetry.ppx) already resolves. The
+`(libraries ...)` decompose as:
+
+| group                                                                                  | dispatch                                                                                                                                                                                                                                                                                          |
+| -------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `pcre`, `base`, `uri`                                                                  | in the lock                                                                                                                                                                                                                                                                                       |
+| `commons`, `git_wrapper`, `paths`, `lib_parsing`, `process_limits`, `spacegrep`, `parallelism`, `semgrep_core` | internal, translated                                                                                                                                                                                                                                                                              |
+| `parser_go.tree_sitter` / `.ast_generic`, `parser_javascript.ast`                      | internal, translated (the Go chain + JS AST)                                                                                                                                                                                                                                                      |
+| `fast_json` (libs/fast_json)                                                           | internal, new dir: lib_parsing + paths + yojson + ast_generic, pure, no pps surprises. Cheapest first landing                                                                                                                                                                                     |
+| `semgrep.typing` (src/typing)                                                          | internal, new dir: commons + lib_parsing + parallelism + semgrep_core + ppx_deriving.runtime. Cheap                                                                                                                                                                                               |
+| `parser_yaml.ast/.parser/.ast_generic` (languages/yaml/)                               | internal, new dirs: the first yaml-lock consumers outside src/core (parser names `yaml` directly)                                                                                                                                                                                                 |
+| `pfff_lang_GENERIC_analyze` (src/analyzing)                                            | internal, new dir: names `semgrep.il`, pulling src/il (its own scoping look)                                                                                                                                                                                                                      |
+| `semgrep.prefiltering` (src/prefiltering)                                              | internal, new dir: two more atdgen rule pairs (translated shape)                                                                                                                                                                                                                                  |
+| `semgrep_targeting` (src/targeting)                                                    | internal, new dir, the first NEW external since yaml: `ppx_blob` in pps (needs a lock entry) plus `(preprocessor_deps (file default.semgrepignore))`, which the translator does not model -- expect a translator feature or an override-style dispatch                                            |
+| `pfff-lang_GENERIC-naming` (src/naming)                                                | internal, new dir: commons + ast_generic + semgrep.core + semgrep.typing + parser_javascript.ast                                                                                                                                                                                                  |
+| `ojsonnet` (libs/ojsonnet)                                                             | internal, new dir: names `parser_jsonnet.tree_sitter`, so the jsonnet grammar must stamp into the lock first (the tree-sitter-go pattern)                                                                                                                                                         |
+| tree-sitter language chains (python, cpp, php, ocaml, typescript, scala, bash, dockerfile, java, jsonnet, terraform, ruby, ql, lisp) | each needs its grammar stamped from the submodule commit + the ast/tree-sitter/generic dirs translated; bash's grammar is already locked. scala's path is `recursive_descent` (plain OCaml, no grammar)                                                                                            |
+| direct-to-generic parsers (dart, cairo, solidity, csharp, rust, lua, kotlin, swift, julia, r, hack, fga, html, promql, protobuf, move_on_sui, move_on_aptos, circom) | `.ast_generic`-only names, but most wrap a tree-sitter CST under the hood -- scope each dir before assuming it is grammar-free                                                                                                                                                                    |
+| `parser_*.menhir` (go, ocaml, python, cpp, php, javascript, json)                      | the wrinkle: the legacy menhir parsers are named DIRECTLY in src/parsing's stanza, so "menhir parsers stay out" requires either landing them or measuring them out per dir. parser_json.menhir (which itself depends on parser_javascript.menhir) is the JSON path Parse_target actually uses, so the JSON menhir chain likely must land; the rest are overlay candidates after an ocamldep measurement |
+
+Suggested landing order: fast_json + typing (cheap, no new externals); the
+languages/yaml trio (validates the yaml lock from a second consumer);
+src/il + analyzing; prefiltering; targeting (ppx_blob lock +
+preprocessor_deps dispatch); naming; ojsonnet + the jsonnet grammar; then
+the per-language matrix in waves; the menhir question last, measured, with
+src/parsing itself closing the slice.

--- a/bazel/ocaml/semgrep_src/source.bzl
+++ b/bazel/ocaml/semgrep_src/source.bzl
@@ -70,6 +70,11 @@ SEMGREP_SRC_DIRS = [
     # overlays/libs/git_wrapper/ and README).
     "libs/git_wrapper",
     "src/target",
+    # The semgrep_core closure closes: yaml (the one name that gated it)
+    # rides the lock via the two-stage ctypes stubgen override. The (env ...)
+    # block is inert; the tests/ subdir has its own dune and stays out via
+    # the non-recursive glob.
+    "src/core",
 ]
 
 SEMGREP_LIBS = {
@@ -112,6 +117,8 @@ SEMGREP_LIBS = {
     "semgrep_core_sca": ":semgrep_core_sca",
     "semgrep.target": ":semgrep_core_target",
     "semgrep_core_target": ":semgrep_core_target",
+    "semgrep.core": ":semgrep_core",
+    "semgrep_core": ":semgrep_core",
 }
 
 OVERLAYS = [


### PR DESCRIPTION
## What

Closes the `semgrep_core` closure: `src/core` joins the translated frontier, gated until now on `yaml` (the one unresolved name in its stanza).

### Lock: ctypes + integers + yaml

- **integers 0.8.0** (override): `(install_c_headers ...)` + `(c_names ...)` are not modeled by the translator; one flat library with the parmap `c_srcs` shape. `integers.top` stays unbuilt.
- **ctypes 0.24.0** (override): `ctypes_primitives.ml` comes from the real `gen_c_primitives` configurator probe run in a genrule (the lwt.unix discover mold, `INSIDE_DUNE` protocol hand-written) rather than pinned: the output is ~130 generated lines and provably identical on linux x86_64/aarch64 (both little-endian LP64, long double 16/16). `ctypes.stubs` is a plain second library; ctypes-foreign (libffi) stays out, per the recorded dispatch. The `bigarray` dep is inert on the 5.3 stdlib.
- **yaml 3.2.0** (override): the six-piece two-stage ctypes-stubgen dispatch recorded in `semgrep_src/README.md`, landed as recorded: vendored libyaml as a `cc_library` (the pcre2-c pattern, `-DHAVE_CONFIG_H` against its checked-in config.h), both discover probe outputs pinned (the parmap pattern), plain bindings libraries, the stage-one compile-AND-RUN stubgen genrule (run stubgen to emit C, gcc it against staged ctypes headers + vendor + the sysroot's `lib/ocaml`, run that to emit `g.ml`), stage-two `-ml`/`-c` prints, and `yaml` over `yaml.ffi`. `yaml.unix` stays unbuilt.

opam resolution cross-checked: `yaml.3.2.0` pulls exactly ctypes 0.24.0 + integers 0.8.0 (ctypes 0.24.0 dropped `bigarray-compat`, so the predicted extra entry never materialized).

### src/core

Translates as-is (the `(env ...)` -w 30 block is inert; tests/ stays out via the non-recursive glob). `SEMGREP_LIBS` keys both `semgrep.core` and `semgrep_core`. Ladder placement: integers/ctypes in the both-arch `ladder_builds` (`c_srcs` only, no cc_library); yaml + src/core in `ladder_builds_cc` (the vendored libyaml cc_library, plus commons' pcre).

### Recorded, not landed

The `src/parsing` scoping dispatch joins the README: the parser-matrix decomposition with per-group dispatch and a suggested landing order, the `ppx_blob` + `(preprocessor_deps ...)` gap in src/targeting, and the `parser_json.menhir` wrinkle (named directly in the stanza, and the JSON path Parse_target actually uses).

## Validation

Pre-validated in the local harness (fresh container, recipe per the session notes): every override recipe replayed through the real driver including both stubgen genrules; an e2e binary parsed and re-emitted YAML through the driver-built integers -> ctypes -> libyaml chain; `src/core` compiled with its full composed ppx driver (visitors.ppx + commons.ppx + ppx_telemetry + deriving set) against the driver-built yaml. CI on this branch is the authoritative check.

https://claude.ai/code/session_01TJf1QGtM1TdWTyYxhnknCK

---
_Generated by [Claude Code](https://claude.ai/code/session_01TJf1QGtM1TdWTyYxhnknCK)_