### PR TITLE
feat(hikes): green->red effort ramp and always-visible Near filter

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.116.0
+version: 0.117.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.116.0
+      targetRevision: 0.117.0
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/lib/public/components/hikes/HikesMap.svelte
+++ b/projects/monolith/frontend/src/lib/public/components/hikes/HikesMap.svelte
@@ -15,16 +15,18 @@
     maxima = { duration: 1, ascent: 1, distance: 1 },
   } = $props();
 
-  // Effort ramp, mirrors ShipsMap's HEAT_STOPS so the two maps read as siblings:
-  // violet (gentle) -> red (strenuous). Hardcoded hex like the ships heatmap
-  // (these are data-viz ramp stops, not design-system surface tokens).
+  // Effort ramp: the universal trail-difficulty convention, green (easy) ->
+  // red (hard), keeping the ships heat ramp's orange/red hot end so the two
+  // maps still rhyme. Green keeps the gentle majority (≈67% of the corpus)
+  // reading calm instead of alarming-hot. Hardcoded hex (data-viz ramp stops,
+  // not design-system surface tokens). Keep in sync with the .legend-bar
+  // gradient below.
   const EFFORT_RAMP = [
-    { at: 0.0, color: "#7b2ff7" }, // vivid violet, gentlest
-    { at: 0.2, color: "#d61f9c" }, // magenta
-    { at: 0.4, color: "#ff0a78" }, // hot rose
-    { at: 0.6, color: "#ff6a00" }, // vivid orange
-    { at: 0.8, color: "#ff2a1f" }, // bright red
-    { at: 1.0, color: "#ff0019" }, // pure vivid red, most strenuous
+    { at: 0.0, color: "#15a34a" }, // green, gentlest
+    { at: 0.25, color: "#84c91e" }, // lime
+    { at: 0.5, color: "#ffcb1f" }, // golden yellow
+    { at: 0.75, color: "#ff6a00" }, // orange (ships)
+    { at: 1.0, color: "#ff0019" }, // red (ships), most strenuous
   ];
 
   // Effort score in [0,1]: equal-weight blend of duration, ascent and distance,
@@ -615,11 +617,10 @@
     border: 2px solid var(--ink);
     background: linear-gradient(
       to right,
-      #7b2ff7,
-      #d61f9c,
-      #ff0a78,
+      #15a34a,
+      #84c91e,
+      #ffcb1f,
       #ff6a00,
-      #ff2a1f,
       #ff0019
     );
   }

--- a/projects/monolith/frontend/src/routes/public/app/hikes/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/hikes/+page.svelte
@@ -174,16 +174,10 @@
     walks.filter((w) => viableInNextDays(w, 1, new Date(nowMs))).length,
   );
 
-  // Any non-default filter active, so the toggle can show a dot while collapsed.
+  // A hidden (collapsed) numeric filter is active, so the toggle can show a dot.
+  // Near lives in the always-visible head, so it does not count here.
   let filtersActive = $derived(
-    !!(
-      minDuration ||
-      maxDuration ||
-      minDistance ||
-      maxDistance ||
-      maxAscent ||
-      nearKey
-    ),
+    !!(minDuration || maxDuration || minDistance || maxDistance || maxAscent),
   );
 
   function resetFilters() {
@@ -245,6 +239,20 @@
         </p>
       </div>
 
+      <label class="field near-field"
+        >Near
+        <select bind:value={nearKey} onchange={onNearChange}>
+          <option value="">Anywhere</option>
+          <option value={GEO_SENTINEL}>My location</option>
+          {#each HIKE_LOCATIONS as loc (loc.key)}
+            <option value={loc.key}>{loc.label}</option>
+          {/each}
+        </select>
+      </label>
+      {#if geoError}
+        <p class="geo-error" role="alert">{geoError}</p>
+      {/if}
+
       <div class="day-strip" role="group" aria-label="Filter by viable day">
         <button
           type="button"
@@ -280,20 +288,6 @@
 
     {#if filtersOpen}
       <div class="panel control-more">
-        <label class="field"
-          >Near
-          <select bind:value={nearKey} onchange={onNearChange}>
-            <option value="">Anywhere</option>
-            <option value={GEO_SENTINEL}>My location</option>
-            {#each HIKE_LOCATIONS as loc (loc.key)}
-              <option value={loc.key}>{loc.label}</option>
-            {/each}
-          </select>
-        </label>
-        {#if geoError}
-          <p class="geo-error" role="alert">{geoError}</p>
-        {/if}
-
         <div class="num-grid">
           <label class="field"
             >Min duration (h)


### PR DESCRIPTION
Review feedback on the effort-coloured map.

- **Effort ramp: violet→red → green→yellow→red.** The corpus is ~67% gentle walks, but the ships ramp's only calm colour is violet, so the large magenta band read as "hot" and everything looked hard. Switch to the universal trail-difficulty convention (green=easy → red=hard), keeping the ships orange/red hot end so the maps still rhyme. Gentle walks now read calm green.
- **Near dropdown is now visible by default** in the top panel (primary "jump to where the walks are" control); only the numeric duration/distance/ascent refinements stay behind the Filters toggle.

Chart 0.116.0 -> 0.117.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)