### PR TITLE
perf(hikes): slim the corpus payload, fetch windows per-walk on demand

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.117.0
+version: 0.118.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.117.0
+      targetRevision: 0.118.0
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/lib/public/components/hikes/HikesMap.svelte
+++ b/projects/monolith/frontend/src/lib/public/components/hikes/HikesMap.svelte
@@ -69,7 +69,34 @@
   // uuid -> walk row, so a marker click can recover the full record.
   const index = new Map();
 
-  let selected = $state(null); // selected walk object, or null
+  let selected = $state(null); // selected walk (light list row), or null
+  // The light corpus omits summary + hourly windows; the card fetches them per
+  // walk on selection from /app/hikes/walk/{uuid}. detail = {summary, windows}.
+  let selectedDetail = $state(null);
+  let detailLoading = $state(false);
+  let detailError = $state(false);
+  // Guards against an out-of-order resolution: a fast second click must win.
+  let detailToken = 0;
+
+  async function selectWalk(walk) {
+    selected = walk;
+    selectedDetail = null;
+    detailError = false;
+    detailLoading = true;
+    const token = ++detailToken;
+    try {
+      const res = await fetch(`/app/hikes/walk/${encodeURIComponent(walk.uuid)}`);
+      if (!res.ok) throw new Error(`status ${res.status}`);
+      const detail = await res.json();
+      if (token !== detailToken) return; // a newer selection superseded this one
+      selectedDetail = detail;
+    } catch {
+      if (token !== detailToken) return;
+      detailError = true;
+    } finally {
+      if (token === detailToken) detailLoading = false;
+    }
+  }
 
   function emptyFC() {
     return { type: "FeatureCollection", features: [] };
@@ -140,19 +167,24 @@
     pushData();
     fitToWalks();
     // If the open card's walk fell out of the filtered set, close it.
-    if (selected && !index.has(selected.uuid)) selected = null;
+    if (selected && !index.has(selected.uuid)) closeCard();
   }
 
   function closeCard() {
     selected = null;
+    selectedDetail = null;
+    detailError = false;
+    detailLoading = false;
+    detailToken++; // invalidate any in-flight detail fetch
   }
 
-  // Stats + window rows for the selected walk's card. Windows are grouped by
-  // UK-local day. We show the day the user filtered to (the parent's
-  // selectedDay chip) when this walk has windows on it, so clicking a marker
-  // that survived a "Saturday" filter shows Saturday's rows. Otherwise we fall
-  // back to the earliest day with a future window.
-  let cardDays = $derived(selected ? groupWindowsByDay(selected) : {});
+  // Window rows for the selected walk's card, grouped by UK-local day. Windows
+  // come from the per-walk detail fetch (selectedDetail), not the light list.
+  // We show the day the user filtered to (the parent's selectedDay chip) when
+  // this walk has windows on it, so clicking a marker that survived a
+  // "Saturday" filter shows Saturday's rows. Otherwise we fall back to the
+  // earliest day with a future window.
+  let cardDays = $derived(selectedDetail ? groupWindowsByDay(selectedDetail) : {});
   let cardDayKeys = $derived(Object.keys(cardDays).sort());
   let cardDayKey = $derived(
     selectedDay && cardDays[selectedDay]?.length
@@ -266,7 +298,7 @@
           const f = e.features?.[0];
           if (!f) return;
           const walk = index.get(f.properties.uuid);
-          if (walk) selected = walk;
+          if (walk) selectWalk(walk);
         });
         map.on("mouseenter", LAYER_ID, () => {
           map.getCanvas().style.cursor = "pointer";
@@ -314,11 +346,15 @@
         <div><dt>Ascent</dt><dd>{selected.ascent_m} m</dd></div>
         <div><dt>Duration</dt><dd>{fmtDuration(selected.duration_h)}</dd></div>
       </dl>
-      {#if selected.summary}
-        <p class="card-summary">{selected.summary}</p>
+      {#if selectedDetail?.summary}
+        <p class="card-summary">{selectedDetail.summary}</p>
       {/if}
 
-      {#if cardRows.length}
+      {#if detailLoading}
+        <p class="card-empty">Loading forecast…</p>
+      {:else if detailError}
+        <p class="card-empty">Couldn't load the forecast. Try again.</p>
+      {:else if cardRows.length}
         <p class="eyebrow card-windows-title">Next viable: {cardDayLabel}</p>
         <table class="card-windows">
           <thead>

--- a/projects/monolith/frontend/src/routes/public/app/hikes/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/hikes/+page.svelte
@@ -5,9 +5,7 @@
   import {
     filterWalksByCharacteristics,
     filterWalksByLocation,
-    groupWindowsByDay,
     upcomingUkDays,
-    viableInNextDays,
   } from "$lib/public/hikes/filters.js";
 
   let { data } = $props();
@@ -163,15 +161,17 @@
       );
     }
     if (selectedDay != null) {
-      result = result.filter(
-        (w) => (groupWindowsByDay(w)[selectedDay]?.length ?? 0) > 0,
-      );
+      // viable_days is the server-computed set of UK days with a viable window;
+      // membership is a cheap O(1) check, no hourly windows to re-parse.
+      result = result.filter((w) => w.viable_days?.includes(selectedDay));
     }
     return result;
   });
 
+  // Today's UK-local day key (first chip of the rolling strip).
+  let todayKey = $derived(upcomingUkDays(1, new Date(nowMs))[0]);
   let viableTodayCount = $derived(
-    walks.filter((w) => viableInNextDays(w, 1, new Date(nowMs))).length,
+    walks.filter((w) => w.viable_days?.includes(todayKey)).length,
   );
 
   // A hidden (collapsed) numeric filter is active, so the toggle can show a dot.

--- a/projects/monolith/frontend/src/routes/public/app/hikes/walk/[uuid]/+server.js
+++ b/projects/monolith/frontend/src/routes/public/app/hikes/walk/[uuid]/+server.js
@@ -1,0 +1,23 @@
+import { error, json } from "@sveltejs/kit";
+import { HIKES_WALKS_CACHE_CONTROL } from "$lib/cache-headers.js";
+
+const API_BASE = process.env.API_BASE || "http://localhost:8000";
+
+// Same-origin proxy for one walk's detail (summary + hourly windows). The map
+// calls this site route (/app/hikes/walk/{uuid}) on marker click; the fetch to
+// /api/hikes/* happens server-side here, keeping that private surface off the
+// browser. Mirrors ships/track/[mmsi]/+server.js. The light corpus list omits
+// windows, so this is what fills the selected-walk card.
+export async function GET({ params, fetch }) {
+  const res = await fetch(
+    `${API_BASE}/api/hikes/walks/${encodeURIComponent(params.uuid)}`,
+    { signal: AbortSignal.timeout(10_000) },
+  );
+  if (!res.ok) {
+    throw error(res.status === 404 ? 404 : 503, "hike detail unavailable");
+  }
+
+  return json(await res.json(), {
+    headers: { "cache-control": HIKES_WALKS_CACHE_CONTROL },
+  });
+}

--- a/projects/monolith/hikes/router.py
+++ b/projects/monolith/hikes/router.py
@@ -1,9 +1,14 @@
 """Hikes HTTP API. SSR-only: never added to httproute-public.yaml.
 
-One read endpoint backs the /app/hikes walk planner:
+Two read endpoints back the /app/hikes walk planner:
 
-- ``GET /api/hikes/walks``, the whole walk corpus with viable weather
-  windows, for the initial page render.
+- ``GET /api/hikes/walks``, the whole walk corpus as a LIGHT list (stats,
+  coordinates, and the set of viable UK-local days), for the map + filters.
+  Deliberately omits the hour-by-hour ``windows`` and the prose ``summary``:
+  shipping ~49 hourly tuples for all ~1600 walks was ~3 MB, and the map and
+  day filter only need "which days is this walk viable".
+- ``GET /api/hikes/walks/{uuid}``, the per-walk detail (``summary`` +
+  hourly ``windows``) the selected-walk card fetches on demand.
 
 Reached only from SvelteKit SSR (``http://localhost:8000`` in the same pod);
 the /app/hikes page is the public surface and the CDN fans out to viewers.
@@ -14,8 +19,9 @@ from __future__ import annotations
 
 import logging
 from datetime import datetime, timezone
+from zoneinfo import ZoneInfo
 
-from fastapi import APIRouter, Depends, Request, Response
+from fastapi import APIRouter, Depends, HTTPException, Request, Response
 from sqlmodel import Session, select
 
 from app.db import get_session
@@ -25,11 +31,35 @@ logger = logging.getLogger("hikes")
 
 router = APIRouter(prefix="/api/hikes", tags=["hikes"])
 
+# Walks are in Scotland, so viable-day bucketing uses the UK civil calendar (the
+# frontend day strip does the same in the browser). tzdata is present in the
+# image (home.schedule already relies on zoneinfo server-side).
+_UK_TZ = ZoneInfo("Europe/London")
+
 # Forecasts refresh 6-hourly, so 30 min fresh with a 1 h SWR window is plenty.
 # Mirrors HIKES_WALKS_CACHE_CONTROL in frontend/src/lib/cache-headers.js, keep in sync.
 _WALKS_CACHE_CONTROL = (
     "public, s-maxage=1800, stale-while-revalidate=3600, stale-if-error=86400"
 )
+
+
+def _viable_days(windows: list | None) -> list[str]:
+    """Distinct UK-local calendar days (YYYY-MM-DD) that carry a viable window.
+
+    Window tuples are [ts_seconds, ...]; ts is unix UTC. We emit ABSOLUTE dates
+    (not "next 7 days") so the value is independent of when it was computed and
+    stays correct in a CDN cache across midnight; the client intersects them
+    with its own rolling 7-day strip.
+    """
+    days: set[str] = set()
+    for window in windows or []:
+        try:
+            ts = window[0]
+        except (TypeError, IndexError, KeyError):
+            continue
+        local = datetime.fromtimestamp(ts, tz=timezone.utc).astimezone(_UK_TZ)
+        days.add(local.date().isoformat())
+    return sorted(days)
 
 
 def _as_utc(value: datetime | None) -> datetime | None:
@@ -87,10 +117,11 @@ def get_walks(
                 "distance_km": walk.distance_km,
                 "ascent_m": walk.ascent_m,
                 "duration_h": walk.duration_h,
-                "summary": walk.summary,
                 "latitude": walk.latitude,
                 "longitude": walk.longitude,
-                "windows": walk.windows,
+                # Light: the days this walk is viable, not the hourly windows.
+                # The card fetches windows + summary from /walks/{uuid}.
+                "viable_days": _viable_days(walk.windows),
             }
         )
 
@@ -106,4 +137,27 @@ def get_walks(
         "count": len(walks),
         "generated_at": _iso(max_updated),
         "walks": walks,
+    }
+
+
+@router.get("/walks/{uuid}")
+def get_walk_detail(
+    uuid: str,
+    response: Response,
+    session: Session = Depends(get_session),
+):
+    """Per-walk detail (summary + hourly windows) for the selected-walk card.
+
+    Split out of the list so the corpus stays light; fetched on demand when a
+    marker is clicked. SSR-only, CDN-cached the same as the list.
+    """
+    walk = session.get(Walk, uuid)
+    if walk is None:
+        raise HTTPException(status_code=404, detail="walk not found")
+
+    response.headers["Cache-Control"] = _WALKS_CACHE_CONTROL
+    return {
+        "uuid": walk.uuid,
+        "summary": walk.summary,
+        "windows": walk.windows,
     }

--- a/projects/monolith/hikes/router_test.py
+++ b/projects/monolith/hikes/router_test.py
@@ -35,7 +35,10 @@ def _uk_days(windows):
     uk = ZoneInfo("Europe/London")
     return sorted(
         {
-            datetime.fromtimestamp(w[0], tz=timezone.utc).astimezone(uk).date().isoformat()
+            datetime.fromtimestamp(w[0], tz=timezone.utc)
+            .astimezone(uk)
+            .date()
+            .isoformat()
             for w in windows
         }
     )

--- a/projects/monolith/hikes/router_test.py
+++ b/projects/monolith/hikes/router_test.py
@@ -8,6 +8,7 @@ that mounts only the hikes router, mirroring the schema-stripping +
 from __future__ import annotations
 
 from datetime import datetime, timezone
+from zoneinfo import ZoneInfo
 
 import pytest
 from fastapi import FastAPI
@@ -27,6 +28,17 @@ WINDOWS = [
     [1750582800, 14, 0, 12, 40],
     [1750586400, 15, 0, 18, 55],
 ]
+
+
+def _uk_days(windows):
+    """Expected viable_days for a window set, mirroring router._viable_days."""
+    uk = ZoneInfo("Europe/London")
+    return sorted(
+        {
+            datetime.fromtimestamp(w[0], tz=timezone.utc).astimezone(uk).date().isoformat()
+            for w in windows
+        }
+    )
 
 
 @pytest.fixture(name="session")
@@ -114,15 +126,17 @@ class TestWalks:
         assert ben["distance_km"] == 11.0
         assert ben["ascent_m"] == 920
         assert ben["duration_h"] == 5.5
-        assert ben["summary"] == "A steep but rewarding Munro above Loch Lomond."
         assert ben["latitude"] == 56.2734
         assert ben["longitude"] == -4.7521
-        # The windows list comes through intact.
-        assert ben["windows"] == WINDOWS
+        # The light list carries viable_days, not the hourly windows or summary
+        # (those move to the per-walk detail endpoint).
+        assert ben["viable_days"] == _uk_days(WINDOWS)
+        assert "windows" not in ben
+        assert "summary" not in ben
 
-        # The walk without a forecast has empty windows.
+        # The walk without a forecast has no viable days.
         an_teallach = body["walks"][0]
-        assert an_teallach["windows"] == []
+        assert an_teallach["viable_days"] == []
 
     def test_cache_and_etag_headers(self, client, session):
         _seed_walks(session)
@@ -147,3 +161,20 @@ class TestWalks:
         r = client.get("/api/hikes/walks")
         assert r.status_code == 200
         assert r.json() == {"count": 0, "generated_at": None, "walks": []}
+
+
+class TestWalkDetail:
+    def test_detail_returns_summary_and_windows(self, client, session):
+        _seed_walks(session)
+        r = client.get("/api/hikes/walks/aaaaaaaa-0000-5000-8000-000000000001")
+        assert r.status_code == 200
+        body = r.json()
+        assert body["uuid"] == "aaaaaaaa-0000-5000-8000-000000000001"
+        assert body["summary"] == "A steep but rewarding Munro above Loch Lomond."
+        assert body["windows"] == WINDOWS
+        assert r.headers["Cache-Control"]
+
+    def test_detail_404_for_unknown_uuid(self, client, session):
+        _seed_walks(session)
+        r = client.get("/api/hikes/walks/does-not-exist")
+        assert r.status_code == 404


### PR DESCRIPTION
## Why
The `/app/hikes` initial payload was **~3 MB**: the list shipped every walk's hour-by-hour forecast `windows` (~49 tuples × ~1,600 walks = 2.4 MB) plus prose `summary` (0.4 MB), and the client re-parsed all of it on every filter interaction. But the map + day filter only need *which days a walk is viable*; the hourly detail and summary are only used in the selected-walk card.

Confirmed beforehand: filtering is 100% client-side (no API calls on clicks); the only network was the initial 3 MB load + a 30-min refetch.

## What
- **Backend:** `GET /api/hikes/walks` returns a **light** list (stats, coords, and a server-computed `viable_days` set of UK-local `YYYY-MM-DD` strings); new `GET /api/hikes/walks/{uuid}` returns the per-walk `summary` + `windows`. `viable_days` are absolute dates so the value stays CDN-cache-correct across midnight; the client intersects them with its rolling 7-day strip. (tzdata is in the image — `home.schedule` already uses server-side `zoneinfo`.)
- **Frontend:** a same-origin proxy `app/hikes/walk/[uuid]/+server.js` (mirrors ships `track/[mmsi]`) lets the card fetch one walk's detail on click, with a brief loading state. Day filter + "viable today" are now O(1) `viable_days` membership checks, not window re-bucketing.

Payload ~3 MB → ~0.3 MB; filtering no longer touches hourly data.

Chart 0.117.0 → 0.118.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)