### PR TITLE
fix(hikes): only show day chips with forecast coverage; warm ships heat

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.118.0
+version: 0.119.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.118.0
+      targetRevision: 0.119.0
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/lib/public/components/ships/ShipsMap.svelte
+++ b/projects/monolith/frontend/src/lib/public/components/ships/ShipsMap.svelte
@@ -586,6 +586,16 @@
 
         syncVessels();
         startLoop();
+
+        // Warm the heat grid in the background so the first Heat toggle is
+        // instant. Still lazy (kept out of the initial payload), just fetched
+        // on idle after first paint instead of waiting for the toggle.
+        // loadHeat() is a no-op once cached, so the toggle handler stays correct.
+        if (typeof requestIdleCallback === "function") {
+          requestIdleCallback(() => loadHeat(), { timeout: 3000 });
+        } else {
+          setTimeout(() => loadHeat(), 1500);
+        }
       });
 
       cleanup = () => {

--- a/projects/monolith/frontend/src/routes/public/app/hikes/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/hikes/+page.svelte
@@ -100,7 +100,21 @@
     return Number.isNaN(n) ? fallback : n;
   }
 
-  let dayKeys = $derived(upcomingUkDays(DATE_HORIZON, new Date(nowMs)));
+  // The days any walk is actually viable on (union of viable_days across the
+  // corpus). met.no's compact forecast only carries hourly data for ~3 days, so
+  // the corpus only covers ~today..+2; without this the strip would render dead
+  // chips for days 4-7 that match no walk ("picking a day shows nothing").
+  let availableDays = $derived(
+    new Set(walks.flatMap((w) => w.viable_days ?? [])),
+  );
+
+  // The upcoming UK days that have forecast coverage: the rolling N-day strip
+  // intersected with days the data actually has. Every chip shown yields walks.
+  let dayKeys = $derived(
+    upcomingUkDays(DATE_HORIZON, new Date(nowMs)).filter((k) =>
+      availableDays.has(k),
+    ),
+  );
 
   function dayLabel(key) {
     // Noon UTC keeps the label on the intended UK calendar day across BST/GMT.


### PR DESCRIPTION
## Hikes: day filter "shows nothing"
The day strip rendered 7 chips, but met.no's compact forecast only carries **hourly** data (`next_1_hours`) for ~3 days, so `viable_days` only ever spans ~today..+2. The trailing chips matched no walk → "picking a day shows nothing." (Verified on the live payload: all 1,620 walks have `viable_days = [13,14,15]` only.)

Fix: render only the upcoming days that actually have coverage — intersect the rolling strip with the union of `viable_days` across the corpus. Bonus: this degrades gracefully against a **stale browser-cached payload** from the slim deploy (predating `viable_days`) — `availableDays` is empty, so only "Any day" shows instead of dead chips.

> Note: anyone still seeing the old broken state has the pre-slim data cached in their browser (Cloudflare injects a 1h Browser Cache TTL since our origin only sets `s-maxage`). It self-heals within ~1h / next forecast refresh / a hard refresh.

## Ships: faster first heat toggle
Warm the traffic heat grid on idle after first paint (still lazy — not in the initial payload) so the first Heat toggle is instant instead of waiting on the fetch + 23k-cell build.

Chart 0.118.0 → 0.119.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)