### PR TITLE
fix(monolith): revalidate app data in-browser; 2-hourly hike forecast

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.119.0
+version: 0.120.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.119.0
+      targetRevision: 0.120.0
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/lib/cache-headers.js
+++ b/projects/monolith/frontend/src/lib/cache-headers.js
@@ -9,24 +9,32 @@ export const PAGE_CACHE_CONTROL = `public, s-maxage=60, stale-while-revalidate=$
 // _GRAPH_CACHE_CONTROL in projects/monolith/knowledge/router.py — keep in sync.
 export const NOTES_PAGE_CACHE_CONTROL = `public, s-maxage=${ONE_HOUR}, stale-while-revalidate=${ONE_DAY}, stale-if-error=${ONE_YEAR}`;
 
-// /app/ships snapshot: AIS positions refresh every ~2 min, so 120s freshness
-// with a 10 min SWR window keeps the CDN serving warm data between ingests.
+// These app data endpoints (SSR-fetched JSON) all carry `max-age=0` so the
+// BROWSER revalidates every load instead of holding a stale copy. Without an
+// explicit max-age, Cloudflare injects a zone Browser-Cache-TTL (~1 h), which
+// made the live ships map show hour-stale vessels and stranded /app/hikes on a
+// pre-deploy payload shape. The CDN still caches via `s-maxage`, and the ETag
+// makes browser revalidation a cheap 304 when nothing changed.
+
+// /app/ships snapshot: AIS positions refresh every ~2 min, so 120s edge
+// freshness with a 10 min SWR window keeps the CDN serving warm data between
+// ingests; max-age=0 keeps the browser from caching positions for an hour.
 // Mirrors _SNAPSHOT_CACHE_CONTROL in projects/monolith/ships/router.py, keep in sync.
 export const SHIPS_SNAPSHOT_CACHE_CONTROL =
-  "public, s-maxage=120, stale-while-revalidate=600, stale-if-error=86400";
+  "public, max-age=0, s-maxage=120, stale-while-revalidate=600, stale-if-error=86400";
 
 // /app/ships track: one vessel's history, fetched on marker click. Mirrors
 // _TRACK_CACHE_CONTROL in projects/monolith/ships/router.py, keep in sync.
 export const SHIPS_TRACK_CACHE_CONTROL =
-  "public, s-maxage=60, stale-while-revalidate=300, stale-if-error=86400";
+  "public, max-age=0, s-maxage=60, stale-while-revalidate=300, stale-if-error=86400";
 
 // /app/ships heat: traffic-density grid, rolled up hourly so 5 min fresh / 1 h
 // SWR. Mirrors _HEAT_CACHE_CONTROL in projects/monolith/ships/router.py, keep in sync.
 export const SHIPS_HEAT_CACHE_CONTROL =
-  "public, s-maxage=300, stale-while-revalidate=3600, stale-if-error=86400";
+  "public, max-age=0, s-maxage=300, stale-while-revalidate=3600, stale-if-error=86400";
 
-// /app/hikes walks: forecasts refresh 6-hourly, so 30 min fresh with a 1 h SWR
-// window is plenty. Mirrors _WALKS_CACHE_CONTROL in projects/monolith/hikes/router.py,
-// keep in sync.
+// /app/hikes walks: forecasts refresh 6-hourly, so 30 min edge freshness with a
+// 1 h SWR window is plenty. Mirrors _WALKS_CACHE_CONTROL in
+// projects/monolith/hikes/router.py, keep in sync.
 export const HIKES_WALKS_CACHE_CONTROL =
-  "public, s-maxage=1800, stale-while-revalidate=3600, stale-if-error=86400";
+  "public, max-age=0, s-maxage=1800, stale-while-revalidate=3600, stale-if-error=86400";

--- a/projects/monolith/frontend/src/routes/public/app/hikes/page.server.test.js
+++ b/projects/monolith/frontend/src/routes/public/app/hikes/page.server.test.js
@@ -44,7 +44,7 @@ describe("/public/app/hikes load", () => {
     );
     // Byte-for-byte mirror of _WALKS_CACHE_CONTROL in hikes/router.py.
     expect(HIKES_WALKS_CACHE_CONTROL).toBe(
-      "public, s-maxage=1800, stale-while-revalidate=3600, stale-if-error=86400",
+      "public, max-age=0, s-maxage=1800, stale-while-revalidate=3600, stale-if-error=86400",
     );
     expect(result.snapshot).toEqual(SNAPSHOT);
   });

--- a/projects/monolith/frontend/src/routes/public/app/ships/page.server.test.js
+++ b/projects/monolith/frontend/src/routes/public/app/ships/page.server.test.js
@@ -44,7 +44,7 @@ describe("/public/app/ships load", () => {
     );
     // Byte-for-byte mirror of _SNAPSHOT_CACHE_CONTROL in ships/router.py.
     expect(SHIPS_SNAPSHOT_CACHE_CONTROL).toBe(
-      "public, s-maxage=120, stale-while-revalidate=600, stale-if-error=86400",
+      "public, max-age=0, s-maxage=120, stale-while-revalidate=600, stale-if-error=86400",
     );
     expect(result.snapshot).toEqual(SNAPSHOT);
   });

--- a/projects/monolith/hikes/__init__.py
+++ b/projects/monolith/hikes/__init__.py
@@ -26,7 +26,10 @@ def on_startup_jobs(session: Session) -> None:
     register_job(
         session,
         name="hikes.refresh_forecasts",
-        interval_secs=6 * 3600,
+        # Every 2 h: met.no's multi-day forecast only re-runs a few times a day,
+        # so this hedges to catch a fresh model run within ~2 h without hammering
+        # met.no (hourly would re-fetch identical data ~20x/day for ~1600 walks).
+        interval_secs=2 * 3600,
         handler=refresh_forecasts_handler,
         ttl_secs=1800,
     )

--- a/projects/monolith/hikes/router.py
+++ b/projects/monolith/hikes/router.py
@@ -36,10 +36,12 @@ router = APIRouter(prefix="/api/hikes", tags=["hikes"])
 # image (home.schedule already relies on zoneinfo server-side).
 _UK_TZ = ZoneInfo("Europe/London")
 
-# Forecasts refresh 6-hourly, so 30 min fresh with a 1 h SWR window is plenty.
-# Mirrors HIKES_WALKS_CACHE_CONTROL in frontend/src/lib/cache-headers.js, keep in sync.
+# Forecasts refresh every 2 h, so 30 min edge freshness with a 1 h SWR window is
+# plenty; max-age=0 makes the browser revalidate rather than hold a stale copy
+# (see the note in cache-headers.js). Mirrors HIKES_WALKS_CACHE_CONTROL in
+# frontend/src/lib/cache-headers.js, keep in sync.
 _WALKS_CACHE_CONTROL = (
-    "public, s-maxage=1800, stale-while-revalidate=3600, stale-if-error=86400"
+    "public, max-age=0, s-maxage=1800, stale-while-revalidate=3600, stale-if-error=86400"
 )
 
 

--- a/projects/monolith/hikes/router.py
+++ b/projects/monolith/hikes/router.py
@@ -40,9 +40,7 @@ _UK_TZ = ZoneInfo("Europe/London")
 # plenty; max-age=0 makes the browser revalidate rather than hold a stale copy
 # (see the note in cache-headers.js). Mirrors HIKES_WALKS_CACHE_CONTROL in
 # frontend/src/lib/cache-headers.js, keep in sync.
-_WALKS_CACHE_CONTROL = (
-    "public, max-age=0, s-maxage=1800, stale-while-revalidate=3600, stale-if-error=86400"
-)
+_WALKS_CACHE_CONTROL = "public, max-age=0, s-maxage=1800, stale-while-revalidate=3600, stale-if-error=86400"
 
 
 def _viable_days(windows: list | None) -> list[str]:

--- a/projects/monolith/hikes/router_test.py
+++ b/projects/monolith/hikes/router_test.py
@@ -147,7 +147,7 @@ class TestWalks:
         assert r.status_code == 200
         assert (
             r.headers["Cache-Control"]
-            == "public, s-maxage=1800, stale-while-revalidate=3600, stale-if-error=86400"
+            == "public, max-age=0, s-maxage=1800, stale-while-revalidate=3600, stale-if-error=86400"
         )
         assert r.headers["ETag"]
 

--- a/projects/monolith/ships/router.py
+++ b/projects/monolith/ships/router.py
@@ -33,18 +33,20 @@ router = APIRouter(prefix="/api/ships", tags=["ships"])
 # Clamp the track limit so a crafted request can't pull an unbounded history.
 _MAX_TRACK_LIMIT = 5000
 
+# max-age=0 makes the browser revalidate rather than hold a stale copy for the
+# CDN's injected ~1 h browser TTL (see the note in cache-headers.js).
 # Mirrors SHIPS_SNAPSHOT_CACHE_CONTROL in frontend/src/lib/cache-headers.js, keep in sync.
 _SNAPSHOT_CACHE_CONTROL = (
-    "public, s-maxage=120, stale-while-revalidate=600, stale-if-error=86400"
+    "public, max-age=0, s-maxage=120, stale-while-revalidate=600, stale-if-error=86400"
 )
 # Mirrors SHIPS_TRACK_CACHE_CONTROL in frontend/src/lib/cache-headers.js, keep in sync.
 _TRACK_CACHE_CONTROL = (
-    "public, s-maxage=60, stale-while-revalidate=300, stale-if-error=86400"
+    "public, max-age=0, s-maxage=60, stale-while-revalidate=300, stale-if-error=86400"
 )
 # Heatmap rollup refreshes hourly, so 5 min fresh with a 1 h SWR window is plenty.
 # Mirrors SHIPS_HEAT_CACHE_CONTROL in frontend/src/lib/cache-headers.js, keep in sync.
 _HEAT_CACHE_CONTROL = (
-    "public, s-maxage=300, stale-while-revalidate=3600, stale-if-error=86400"
+    "public, max-age=0, s-maxage=300, stale-while-revalidate=3600, stale-if-error=86400"
 )
 
 

--- a/projects/monolith/ships/router_test.py
+++ b/projects/monolith/ships/router_test.py
@@ -119,7 +119,7 @@ class TestSnapshot:
         assert r.status_code == 200
         assert (
             r.headers["Cache-Control"]
-            == "public, s-maxage=120, stale-while-revalidate=600, stale-if-error=86400"
+            == "public, max-age=0, s-maxage=120, stale-while-revalidate=600, stale-if-error=86400"
         )
         assert r.headers["ETag"]
 
@@ -195,7 +195,7 @@ class TestTrack:
         r = client.get("/api/ships/track/316001234")
         assert (
             r.headers["Cache-Control"]
-            == "public, s-maxage=60, stale-while-revalidate=300, stale-if-error=86400"
+            == "public, max-age=0, s-maxage=60, stale-while-revalidate=300, stale-if-error=86400"
         )
 
 


### PR DESCRIPTION
## Cache headers (the fix for "cache shouldn't be that long")
The hikes + ships SSR data endpoints set only `s-maxage` (CDN), no `max-age`. Cloudflare then injects a zone **Browser-Cache-TTL (~1 h)**, so browsers held data for an hour: the "live" ships map showed hour-stale vessels despite a 120 s `s-maxage`, and `/app/hikes` stranded on the pre-slim payload shape.

Add **`max-age=0`** to the walks, ships snapshot, ships track, and ships heat cache-control (browser-facing `cache-headers.js` + mirrored `router.py` constants). Browsers now revalidate every load; the CDN still caches via `s-maxage`, and the existing ETag makes revalidation a cheap `304` when nothing changed.

## Forecast cadence
Run `hikes.refresh_forecasts` every **2 h** (was 6 h) — a hedge to catch a fresh met.no model run within ~2 h, without the ~20×/day redundant fetching for ~1,600 walks an hourly job would cause (met.no's multi-day forecast only re-runs a few times a day, and we don't yet send conditional requests).

Updated the hardcoded cache-control assertions in the hikes/ships router tests.

Chart 0.119.0 → 0.120.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)