### PR TITLE
fix(hikes): version the walks ETag so shape changes bust client caches

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.120.0
+version: 0.121.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.120.0
+      targetRevision: 0.121.0
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/hikes/router.py
+++ b/projects/monolith/hikes/router.py
@@ -83,15 +83,26 @@ def _iso(value: datetime | None) -> str | None:
     return coerced.isoformat() if coerced is not None else None
 
 
+# Bump whenever the /walks response SHAPE changes (fields added/removed/renamed).
+# The ETag is otherwise data-derived (max_updated + count), so a shape-only code
+# deploy leaves it unchanged: browsers revalidate, get a 304, and keep their
+# stale-shape body. Folding this token in means a shape change busts every
+# client's cache, so they pick up the new shape on the next revalidation rather
+# than staying broken until the underlying data happens to change.
+# History: v2 = dropped hourly `windows` + `summary`, added `viable_days`.
+_WALKS_SCHEMA_VERSION = "v2"
+
+
 def _walks_etag(walk_count: int, max_updated: datetime | None) -> str:
     """Stable ETag for the walks payload.
 
-    Combines max(windows_updated_at) with the row count so a walk appearing
-    or disappearing invalidates the cache even when no surviving row's
-    timestamp moves.
+    Combines a response-schema token with max(windows_updated_at) and the row
+    count, so the cache invalidates on a shape change (schema token), a data
+    refresh (timestamp), or a walk appearing/disappearing (count) even when no
+    surviving row's timestamp moves.
     """
     stamp = max_updated.isoformat() if max_updated is not None else "null"
-    return f'"{stamp}-{walk_count}"'
+    return f'"{_WALKS_SCHEMA_VERSION}-{stamp}-{walk_count}"'
 
 
 @router.get("/walks")


### PR DESCRIPTION
The walks ETag was purely data-derived (`max_updated-count`), so a **shape-only** deploy (dropping `windows`/`summary`, adding `viable_days`) left it unchanged. Browsers holding the old-shape payload revalidated, got a `304`, and kept the stale body → day strip broke ("0 viable today", no chips) until the forecast data next changed.

Fix: fold a `_WALKS_SCHEMA_VERSION` token into the ETag, bumped on shape changes (`v2` = the viable_days slim-down). Now a shape change invalidates every client's cache; combined with `max-age=0` (PR #2547), clients pick up the new shape on their next revalidation instead of staying stale.

Chart 0.120.0 → 0.121.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)