### PR TITLE
fix(monolith): declare favicon in the app shell to stop /favicon.ico 404

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.121.0
+version: 0.122.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.121.0
+      targetRevision: 0.122.0
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/app.html
+++ b/projects/monolith/frontend/src/app.html
@@ -3,6 +3,11 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <!-- Declared in the static shell (not just the layout) so it is present at
+         initial parse: the /app/* pages are ssr=false, so a layout-injected
+         icon arrives after hydration and the browser has already 404'd on the
+         default /favicon.ico. -->
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link


### PR DESCRIPTION
`favicon.svg` exists in `static/` and is linked from the public layout, but on `ssr=false` routes (`/app/ships`, `/app/hikes`) that link is injected after hydration, so the initial shell has no icon and the browser 404s on the default `/favicon.ico`. Declare the icon in `app.html` so it's present at first parse for every route.

(The "CSS preloaded but not used" console messages are benign Chrome hints from the `/app/*` pages inheriting the `public/` layout's CSS under `ssr=false` timing — left as-is.)

Chart 0.121.0 → 0.122.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)