### PR TITLE
feat(monolith): self-contained stars domain at /app/stars

### DIFF
--- a/docs/plans/2026-06-13-stars-into-monolith.md
+++ b/docs/plans/2026-06-13-stars-into-monolith.md
@@ -1,228 +1,124 @@
-# Stars into Monolith Implementation Plan (Option A: hybrid)
+# Stars into Monolith Implementation Plan (self-contained, typed storage)
 
-> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task.
 
-**Goal:** Give the `stargazer` dark-sky pipeline a public face inside the monolith: a `stars` domain that ingests the pipeline's ranked output into Postgres on a schedule and serves a neobrutalist map of stargazing sites at `jomcgi.dev/app/stars`. The geospatial pipeline itself stays exactly where it is.
+> **Supersedes** the earlier "Option A: hybrid" version of this file. The hybrid
+> approach (keep the stargazer CronJob + NGINX alive, pull `/best` JSON over the
+> cluster network) was rejected. The monolith is now the source of truth: it
+> fetches MET Norway itself, scores it, and owns typed rows in Postgres. The
+> stargazer geospatial pipeline is not a runtime dependency and is retired in a
+> later, separate PR.
 
-**Architecture (Option A, hybrid):** The stargazer CronJob (every 6 hours, `stargazer` namespace, Longhorn PVC) is **untouched**. Its existing in-cluster NGINX API, which serves `best_locations.json` at `/best`, becomes the internal handoff interface. A monolith `shared.scheduler` job (`stars.ingest_sites`, every 3 hours) pulls that JSON over the cluster network and wholesale-replaces a small `stars.sites` table. One SSR-only `/api/stars/sites` endpoint serializes the table; Cloudflare CDN does the viewer fan-out. A SvelteKit route at `/app/stars` renders a MapLibre map of sites colored by astronomy score, with a per-site panel of the best upcoming dark-sky hours.
+**Goal:** Serve a neobrutalist dark-sky map at `jomcgi.dev/app/stars` from a self-contained `stars` domain in the monolith, with an explicit per-hour TTL so it never serves a forecast window that has already elapsed.
 
-**Why hybrid, not full absorption:** the pipeline's deps (rasterio, geopandas, osmium) would balloon the monolith image, and its 2Gi+ memory spikes do not belong in the API pod. The pipeline keeps its CronJob and PVC; the monolith only ever touches a few-hundred-KB JSON.
+**Architecture:** The monolith fetches MET Norway forecasts directly for a curated seed list of ~30 Scottish dark-sky sites, scores each dark hour for astronomy suitability, and stores **all** future qualifying hours in a typed `stars.site_hours` table (one row per site-hour; static site metadata stays in `seed.py` and is joined in at read time). Freshness has two layers sharing one cutoff (the top of the current clock hour): an **hourly prune job** (`DELETE WHERE hour_time < top_of_hour()`, indexed housekeeping) and a **read-time filter** in the endpoint (`WHERE hour_time >= top_of_hour()`, the correctness backstop) that also folds the current hour into the ETag so the CDN turns over hourly. The read endpoint is SSR-only and CDN-cached per ADR 002.
 
-**Tech Stack:** Python 3 / FastAPI / SQLModel / psycopg3 / Postgres (Atlas migrations) / `shared.scheduler` / httpx / SvelteKit (Svelte 5) / MapLibre GL / Bazel + apko.
+**Tech Stack:** Python 3 / FastAPI / SQLModel / psycopg3 / Postgres (Atlas migrations) / `shared.scheduler` / `httpx` / `astral` / pydantic / SvelteKit (Svelte 5) / MapLibre GL / Bazel + apko.
 
-**Reference implementation:** the `ships` domain (`projects/monolith/ships/*`, `frontend/src/routes/public/app/ships/*`) and, once merged, the `hikes` domain from `docs/plans/2026-06-13-hikes-into-monolith.md`. Hikes lands first; reuse its shapes.
+**Reference implementations:**
 
-**Non-negotiable house rules (apply to every task):**
+- hikes: `projects/monolith/hikes/{models,jobs,router,forecast,__init__}.py`, migration `chart/migrations/20260613000000_hikes_schema.sql`, frontend `frontend/src/routes/public/app/hikes/*`.
+- ships: `projects/monolith/ships/router.py` (ETag + conditional-GET shape), `ShipsMap.svelte` (MapLibre).
+- scheduler: `projects/monolith/shared/scheduler.py`: `register_job(session, *, name, interval_secs, handler, ttl_secs=1200)`. Fixed-interval (not cron); a handler may return a datetime to override `next_run_at`; handlers may be sync (pure DB) or async (network).
+- Reusable verbatim from `origin/feat/stars-domain` (`git show <ref>:<path>`): `stars/scoring.py` + `scoring_test.py` (pure, stargazer parity) and `stars/seed.py` (the 30 sites). Strip em-dashes from copied docstrings. Discard that branch's `models.py`, `router.py`, `service.py` storage, and its `refresh_runs` migration; reuse only the fetch + score logic.
 
-- **No em-dashes** in any code, comment, commit, or doc. Use commas, colons, or parentheses.
-- **No local test loop.** Write tests, but do NOT run `bazel test`/`pytest`/`vitest` from the workstation. Implement, commit, push the branch, watch CI via `gh pr checks <n> --watch`. Diagnose failures via `mcp__buildbuddy__*`.
-- **One code review per PR** at the end, not per task. Implementers self-review before each commit.
-- **Conventional Commits** for every commit. Commit frequently (one logical step per commit).
-- **No hardcoded `.svc.cluster.local` URLs in code defaults.** The stargazer API URL is injected via `values.yaml` env var; the code default is empty and the job no-ops with a warning when unset (semgrep enforces the URL rule).
+**Non-negotiable house rules (every task):**
 
-**Worktree:** `/tmp/claude-worktrees/stars-monolith` on branch `feat/stars-into-monolith`.
+- **No em-dashes** anywhere (code, comments, commits, docs). Commas, colons, parentheses, or split the sentence.
+- **No local test loop:** no `bazel test` / `pytest` / `vitest` / `pnpm build` from the workstation. Implement, commit, push, watch CI via `gh pr checks <n> --watch`; diagnose via `mcp__buildbuddy__*`, quoting the actual error first. `helm template` render is allowed (not a test).
+- **One code review per PR** at the end, not per task. Self-review before each commit.
+- **Conventional Commits**, one logical step per commit.
+- New monolith test/binary targets are **hand-registered** in `projects/monolith/BUILD` (gazelle will not add them; copy the `hikes`/`ships` blocks).
+- No hardcoded `.svc.cluster.local` URLs in code defaults; no manual `@sha256:` digests.
+- Test fixtures use SQLite + `create_all` (not migrations); mirror any CHECK constraints in `__table_args__`.
+- Chart bumps touch `chart/Chart.yaml` version AND `deploy/application.yaml` `targetRevision` in the same commit.
 
----
-
-## Background: what changes where
-
-**Untouched:** everything under `projects/stargazer/` backend code, the CronJob, the PVC, the NGINX api deployment and its in-cluster Service, the pipeline schedule, the `stargazer` namespace.
-
-**Source of truth for the data contract:** `projects/stargazer/backend/weather.py` `output_best_locations()`. The JSON at NGINX `/best` is a ranked array of:
-
-```json
-{
-  "id": "<point id>",
-  "coordinates": {"lat": 57.1, "lon": -4.7},
-  "altitude_m": 312,
-  "lp_zone": "dark",
-  "best_hours": [
-    {"time": "...", "score": 92.5, "cloud_area_fraction": 5, "relative_humidity": 60,
-     "wind_speed": 2.1, "air_temperature": 4.0, "dew_spread": 3.1,
-     "air_pressure": 1021.0, "symbol": "clearsky_night"}
-  ],
-  "best_score": 92.5
-}
-```
-
-(`best_hours` is capped at 5 per site, all hours have score >= 80, sites are sorted by `best_score` desc.)
-
-**Retired (follow-up PR, Task 6):** the public HTTPRoute exposing `api.jomcgi.dev/stargazer`. The NGINX api stays for in-cluster handoff only.
+**Worktree:** `/tmp/claude-worktrees/stars-monolith` on branch `feat/stars-into-monolith` (created off `origin/main`). Note: main HEAD already has an "APPS" dropdown in the public nav for `/app/*`; add a `/app/stars` entry to it.
 
 ---
 
-## Task 0: Scaffold the `stars` Python package and register it
+## Data contract
 
-**Files:**
+MET Norway `locationforecast/2.0/complete` returns `properties.timeseries[]`, each with `data.instant.details` (`cloud_area_fraction`, `relative_humidity`, `fog_area_fraction`, `wind_speed`, `air_temperature`, `dew_point_temperature`, `air_pressure_at_sea_level`) and `data.next_1_hours.summary.symbol_code`. An hour qualifies if the sun is at/below nautical twilight (astral elevation <= -12 deg) AND `score >= STARS_MIN_DISPLAY_SCORE` (default 60). `dew_spread = air_temperature - dew_point_temperature`. **Store every qualifying future hour** (not a global top-N; that breaks pruning). MET requires a descriptive User-Agent with contact info (generic UA returns 403); mirror hikes. Egress to `api.met.no` is already proven by hikes, so no new NetworkPolicy / Linkerd allowance is needed.
 
-- Create: `projects/monolith/stars/__init__.py`
-- Create: `projects/monolith/stars/router.py` (stub)
-- Modify: `projects/monolith/app/main.py` (add `import stars`; `stars.register(app)` after the other `*.register(app)` calls around `:220`; `stars.on_startup_jobs(session)` next to `ships.on_startup_jobs(session)` around `:68`)
-- Modify: `projects/monolith/BUILD` (hand-registered tree; copy the `ships`/`hikes` blocks)
-
-```python
-def on_startup_jobs(session: Session) -> None:
-    """Register the stargazer ingest job."""
-    from shared.scheduler import register_job
-    from stars.jobs import ingest_sites_handler
-
-    register_job(
-        session,
-        name="stars.ingest_sites",
-        interval_secs=3 * 3600,  # pipeline refreshes 6-hourly; 3h halves worst-case staleness
-        handler=ingest_sites_handler,
-        ttl_secs=600,
-    )
-```
-
-Commit: `feat(monolith): scaffold stars package and register router`
-
----
-
-## Task 1: Postgres schema (migration + SQLModel model)
-
-**Files:**
-
-- Create: `projects/monolith/chart/migrations/20260613000002_stars_schema.sql` (timestamp must sort after the hikes migrations if both are in flight)
-- Create: `projects/monolith/stars/models.py`
-- Test: `projects/monolith/stars/models_test.py`
-
-**Design:** one table mirroring the `/best` entry shape. `best_hours` stays JSONB (the serving endpoint returns sites whole; no per-hour queries). The table is wholesale-replaced each ingest, so no updated-at bookkeeping per row beyond `fetched_at`.
+## Schema
 
 ```sql
 CREATE SCHEMA IF NOT EXISTS stars;
-
-CREATE TABLE stars.sites (
-    id           TEXT PRIMARY KEY,
-    lat          DOUBLE PRECISION NOT NULL,
-    lon          DOUBLE PRECISION NOT NULL,
-    altitude_m   DOUBLE PRECISION NOT NULL DEFAULT 0,
-    lp_zone      TEXT NOT NULL DEFAULT 'unknown',
-    best_score   DOUBLE PRECISION NOT NULL,
-    best_hours   JSONB NOT NULL DEFAULT '[]'::jsonb,
-    fetched_at   TIMESTAMPTZ NOT NULL DEFAULT now()
+CREATE TABLE stars.site_hours (
+    site_id     TEXT NOT NULL,
+    hour_time   TIMESTAMPTZ NOT NULL,
+    score       DOUBLE PRECISION NOT NULL,
+    cloud_area_fraction DOUBLE PRECISION NOT NULL,
+    relative_humidity   DOUBLE PRECISION NOT NULL,
+    wind_speed          DOUBLE PRECISION NOT NULL,
+    air_temperature     DOUBLE PRECISION NOT NULL,
+    dew_spread          DOUBLE PRECISION NOT NULL,
+    symbol      TEXT NOT NULL DEFAULT '',
+    fetched_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (site_id, hour_time)
 );
-
-CREATE INDEX sites_best_score ON stars.sites (best_score DESC);
+CREATE INDEX idx_stars_site_hours_time  ON stars.site_hours (hour_time);
+CREATE INDEX idx_stars_site_hours_score ON stars.site_hours (score DESC);
 ```
 
-SQLModel model follows `ships/models.py` conventions (`schema="stars"`, `extend_existing`, tz-aware datetimes, JSON column via the same approach hikes uses so SQLite tests work). Model test: round-trip one site through a SQLite `create_all` fixture.
-
-Commit: `feat(monolith): add stars postgres schema and model`
+Migration filename `chart/migrations/20260613000010_stars_schema.sql` (sorts after hikes). Do not hand-edit `atlas.sum`.
 
 ---
 
-## Task 2: Ingest job (pull `/best` from the stargazer api)
+## Task 0: Shared top-of-hour cutoff
 
-**Files:**
+**Files:** create `projects/monolith/shared/forecast_freshness.py` + `_test.py`; register lib + test in `projects/monolith/BUILD`.
+`top_of_hour(now: datetime | None = None) -> datetime` returns the start of the current UTC clock hour. Tests: truncation, default-now path. (This is the single shared cutoff stars uses now and the future hikes-typed PR will reuse.)
+Commit: `feat(monolith): shared top-of-hour forecast TTL cutoff`
 
-- Create: `projects/monolith/stars/jobs.py`
-- Test: `projects/monolith/stars/jobs_test.py`
+## Task 1: Scaffold the stars package and register jobs
 
-**Design:**
+**Files:** create `stars/__init__.py`, `stars/router.py` (stub); modify `app/main.py` (`import stars`; `stars.register(app)` ~`:222`; `stars.on_startup_jobs(session)` ~`:69`); modify `projects/monolith/BUILD` (copy the hikes block for `stars/**/*.py`).
+`on_startup_jobs` registers `stars.refresh` (`interval_secs=3*3600`, `ttl_secs=900`, async `refresh_handler`) and `stars.prune_hours` (`interval_secs=3600`, `ttl_secs=300`, sync `prune_hours_handler`).
+Commit: `feat(monolith): scaffold stars package and register jobs`
 
-- Config: `STARGAZER_API_URL` read via `envOr`-style lookup with **no default**. Unset means log a warning once and return (the job is a no-op until the chart wires the env var; this is the house rule for service URLs).
-- Fetch `f"{base_url}/best"` with `httpx` (10s timeout). Validate the payload with a small pydantic row model mirroring the contract above; skip malformed entries with a logged count rather than failing the batch.
-- Empty or non-200 responses: log and keep the existing rows (stale beats empty; the pipeline may be mid-run).
-- Write path: in one transaction, `DELETE FROM stars.sites` then bulk insert the validated rows with a shared `fetched_at`. The set is small (a Scotland-wide 5 km grid filtered to score >= 80 sites), so wholesale replace is simpler and correct; site ids drift as the grid and weather change, so upsert-and-prune buys nothing.
-- Network phase completes before any session use (same handler shape as hikes/ships).
+## Task 2: Schema migration + SQLModel model
 
-**Tests:** mock httpx; assert happy path replaces rows, malformed entries are skipped, empty/error responses leave existing rows untouched, unset URL no-ops.
+**Files:** create the migration above; create `stars/models.py` (`SiteHour`, `schema="stars"`, `extend_existing`, tz-aware datetimes, PK `(site_id, hour_time)`); test `stars/models_test.py` (SQLite `create_all` round-trip); register in BUILD.
+Commit: `feat(monolith): add stars site_hours schema and model`
 
-Commit: `feat(monolith): stars ingest job pulling stargazer best locations`
+## Task 3: Port scoring + seed
 
----
+**Files:** copy `stars/scoring.py`, `stars/scoring_test.py`, `stars/seed.py` verbatim from `origin/feat/stars-domain` (strip em-dashes); add `stars/seed_test.py` (unique ids, lat in [54,61], lon in [-8,0], non-empty `lp_zone`); register tests in BUILD.
+Commit: `feat(monolith): port stars scoring and dark-sky seed list`
 
-## Task 3: `/api/stars/sites` endpoint (SSR-only, CDN-cached)
+## Task 4: Forecast fetch + refresh job
 
-**Files:**
+**Files:** create `stars/forecast.py` (bounded-concurrency MET fetch with UA + `sleep(1/rate)`; `score_location` keeps ALL qualifying hours sorted by time) and `stars/jobs.py` `refresh_handler` (network first with no session held; per successfully fetched site delete its rows and insert new scored hours with a shared `fetched_at`; failed fetches leave existing rows, stale beats empty; fully empty result is a logged no-op); tests `forecast_test.py` (astral/httpx mocked) + `jobs_test.py` (monkeypatch `fetch_all`); register in BUILD.
+Commit: `feat(monolith): stars refresh job fetching and scoring met.no`
 
-- Modify: `projects/monolith/stars/router.py`
-- Test: `projects/monolith/stars/router_test.py`
+## Task 5: Hourly prune job
 
-**Design:** clone `ships/router.py` `get_snapshot`: cache-control constant, ETag from `(count, max(fetched_at))`, conditional GET 304. Payload `{count, fetched_at, sites: [...]}` ordered by `best_score` desc. Cache header: `public, s-maxage=1800, stale-while-revalidate=3600, stale-if-error=86400`.
+**Files:** add `prune_hours_handler` to `stars/jobs.py`: `session.exec(delete(SiteHour).where(SiteHour.hour_time < top_of_hour()))`, commit only if rows deleted, do not touch `fetched_at`; test in `jobs_test.py` with rows straddling the current hour.
+Commit: `feat(monolith): hourly prune of elapsed stars hours`
 
-**Critical:** do **not** add `/api/stars/*` to `chart/templates/httproute-public.yaml`. SSR reaches it at `http://localhost:8000` (same rule as ships and hikes).
+## Task 6: /api/stars/sites endpoint
 
-**Tests:** SQLite fixture + `TestClient`; assert ordering, headers, 304.
+**Files:** flesh out `stars/router.py`; test `stars/router_test.py`.
+Select rows `WHERE hour_time >= top_of_hour(now)`; group by `site_id`; join static metadata from `seed.py`; per site `best_score = max(score)`, `best_hours = top-8 by score`; drop sites with no future hours; sort sites by `best_score` desc. ETag `f'"v1-{top_of_hour(now).isoformat()}-{max_fetched}-{count}"'`; honor `If-None-Match` -> 304. `Cache-Control: public, max-age=0, s-maxage=1800, stale-while-revalidate=3600, stale-if-error=86400`. CRITICAL: do NOT add `/api/stars/*` to `chart/templates/httproute-public.yaml` (SSR-only at `http://localhost:8000`). Tests: ordering, past-hours-omitted, header present, 304 on ETag, empty-table shape.
+Commit: `feat(monolith): stars sites endpoint with per-hour read filter`
 
-Commit: `feat(monolith): stars sites endpoint (SSR-only, CDN-cached)`
+## Task 7: Frontend /app/stars
 
----
-
-## Task 4: Frontend route `/app/stars` (dark-sky map, neobrutalist)
-
-**Files:**
-
-- Create: `projects/monolith/frontend/src/routes/public/app/stars/+page.server.js` (clone ships': fetch `/api/stars/sites`, forward ETag, set `STARS_SITES_CACHE_CONTROL`)
-- Create: `projects/monolith/frontend/src/routes/public/app/stars/+page.js` (`export const ssr = false;`)
-- Create: `projects/monolith/frontend/src/routes/public/app/stars/+page.svelte`
-- Create: `projects/monolith/frontend/src/lib/public/components/stars/StarsMap.svelte`
-- Modify: `projects/monolith/frontend/src/lib/cache-headers.js` (add `STARS_SITES_CACHE_CONTROL`, keep-in-sync comment)
-- Tests: `page.server.test.js` (clone ships'), plus a pure-module test for any score-bucketing/formatting helpers
-
-**Design:**
-
-- **Map:** MapLibre per `ShipsMap.svelte`, centered on Scotland. This page earns a **dark variant** of the basemap restyle (a dark-sky map should be dark); keep chrome tokens from `design-system.css` so it still reads as a sibling of ships/hikes. Site markers colored by `best_score` buckets (for example 80-85 / 85-92 / 92+), sized or ringed by `lp_zone`.
-- **Site panel:** clicking a marker opens a hard-shadow card: coordinates, altitude, light-pollution zone, and a table of the best hours (local time, score, cloud %, temperature, dew spread, weather symbol). Include an "open in maps" link for navigation since these are literally places to drive to.
-- **Header bar:** "STARS · n dark-sky sites · best score s" with the `fetched_at` age. If the table is empty (pipeline outage or all-cloudy week), render an honest empty state ("no viewing windows above score 80 in the next 72h") rather than a blank map.
-- Snapshot refresh: `setInterval(invalidateAll, 30 * 60_000)` cleared on destroy.
-
+**Files:** create `frontend/src/routes/public/app/stars/{+page.server.js,+page.js,+page.svelte}` and `frontend/src/lib/public/components/stars/StarsMap.svelte` (clone hikes route + ShipsMap, DARK basemap variant, MapLibre centered on Scotland ~`[-4.2,57.0]` zoom 6, markers by `best_score` bucket, hard-shadow site panel with best-hours table + "open in maps" link, header with `fetched_at` age, honest empty state, `setInterval(invalidateAll, 30*60000)` + `nowMs` tick cleared on destroy); modify `frontend/src/lib/cache-headers.js` (add `STARS_SITES_CACHE_CONTROL`, keep-in-sync comment); add a `/app/stars` entry to the public nav APPS dropdown (grep `app/hikes|app/ships` under `frontend/src`); test `page.server.test.js` (clone hikes). Do NOT run `pnpm build`.
 Commit: `feat(frontend): add /app/stars dark-sky map`
 
-> Do not run `pnpm build` (BUILD-clobbering gotcha); let CI build.
+## Task 8: Chart wiring + version bump
 
----
+**Files:** modify `chart/templates/deployment.yaml` (`STARS_USER_AGENT` + optional `STARS_RATE_LIMIT`, `STARS_MIN_DISPLAY_SCORE` from values), `chart/values.yaml` (defaults; real UA contact), bump `chart/Chart.yaml` + `deploy/application.yaml` `targetRevision` same commit. Render-check with `helm template`.
+Commit: `feat(monolith): wire stars env vars and bump chart`
 
-## Task 5: Chart wiring (env var + bump)
+## Task 9: PR push, CI, review, merge, verify
 
-**Files:**
+Push, open PR, `gh pr checks <n> --watch`, diagnose via `mcp__buildbuddy__*` (commitSha selector -> get_target -> get_log). One comprehensive code review of the full diff. Merge `--rebase`. Verify live: trigger `stars.refresh` (table populates, log shows MET fetch); `curl -sI https://jomcgi.dev/app/stars` shows Cache-Control and renders; `/api/stars/sites` not publicly reachable; trigger `stars.prune_hours`.
 
-- Modify: `projects/monolith/chart/templates/deployment.yaml` (plain env `STARGAZER_API_URL` from values)
-- Modify: `projects/monolith/chart/values.yaml` (empty default) and `projects/monolith/deploy/values.yaml` (the real in-cluster URL)
-- Modify: `projects/monolith/chart/Chart.yaml` + `projects/monolith/deploy/application.yaml` (version bump + `targetRevision`, same commit)
+## Out of scope
 
-**Determining the URL:** the stargazer api Service is templated by the homelab-library helper (`projects/stargazer/chart/templates/service-api.yaml`, component `api`). Render it to get the exact name:
-
-```bash
-helm template stargazer projects/stargazer/chart/ -f projects/stargazer/deploy/values.yaml | grep -B2 -A8 "kind: Service"
-```
-
-Then set `STARGAZER_API_URL: http://<rendered-service-name>.stargazer.svc.cluster.local` in `deploy/values.yaml` (port per the rendered Service). No secrets are involved.
-
-Also verify network reachability assumptions: monolith and stargazer are different namespaces; if Linkerd policy or NetworkPolicies restrict cross-namespace traffic, add the needed allowance in the stargazer chart values rather than widening anything cluster-wide.
-
-Render check: `helm template monolith projects/monolith/chart/ -f projects/monolith/deploy/values.yaml | grep -A2 STARGAZER_API_URL`.
-
-Commit: `feat(monolith): wire stargazer api url and bump chart for stars`
-
----
-
-## Task 6: Push, watch CI, end-of-PR review, verify live
-
-1. Push `feat/stars-into-monolith`, open the PR, `gh pr checks <n> --watch`; diagnose via `mcp__buildbuddy__*`, quoting actual errors first.
-2. One comprehensive code review of the full diff; address findings.
-3. Merge with `gh pr merge --rebase`.
-4. Verify live after ArgoCD syncs and the migration applies:
-   - Trigger `stars.ingest_sites` via the scheduler skill; confirm `stars.sites` populates and the job log shows the fetch from the stargazer service.
-   - `curl -s https://jomcgi.dev/app/stars` renders sites; `curl -I` shows Cache-Control; `/api/stars/sites` is NOT publicly reachable.
-   - Confirm the page survives an empty table (check the empty state by eye or by timing before first ingest).
-
----
-
-## Task 7 (follow-up PR, AFTER live verification): retire the public stargazer route
-
-Only once `/app/stars` is verified live:
-
-- Modify: `projects/stargazer/deploy/values.yaml` to disable the public HTTPRoute (`httproute.enabled: false` or equivalent). The NGINX api Deployment + Service **stay** (they are the ingest handoff).
-- Remove any DNS or Cloudflare config pointing `api.jomcgi.dev/stargazer` at the cluster, or redirect it to `https://jomcgi.dev/app/stars`.
-- Commit: `chore(stargazer): retire public api route, served via /app/stars`.
-
----
-
-## Open follow-ups (not blocking)
-
-- A SigNoz HTTP check + alert for `/app/stars` via the `add-httpcheck-alert` skill.
-- Ingest `forecasts_scored.json` (`/locations`) too if the page later wants the full sub-80 heatmap rather than only ranked sites.
-- A "notify me when a 90+ night is forecast nearby" hook into the monolith notification hub; the data is already in Postgres.
-- Longer term: replace the NGINX handoff with the pipeline writing to Postgres directly, but only if the NGINX layer actually causes trouble; today it is the cheapest stable contract.
+- Hikes TTL / typed-storage normalization (owner does it in a separate PR; reuses `top_of_hour`).
+- Retiring the standalone stargazer pipeline (separate follow-up after `/app/stars` is verified live).

--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -2078,6 +2078,27 @@ py_test(
 )
 
 py_test(
+    name = "stars_scoring_test",
+    srcs = ["stars/scoring_test.py"],
+    imports = ["."],
+    deps = [
+        ":monolith_backend",
+        "@pip//pydantic",
+        "@pip//pytest",
+    ],
+)
+
+py_test(
+    name = "stars_seed_test",
+    srcs = ["stars/seed_test.py"],
+    imports = ["."],
+    deps = [
+        ":monolith_backend",
+        "@pip//pytest",
+    ],
+)
+
+py_test(
     name = "hikes_walkhighlands_test",
     srcs = ["hikes/walkhighlands_test.py"],
     imports = ["."],

--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -10,6 +10,7 @@
 # gazelle:exclude shared
 # gazelle:exclude ships
 # gazelle:exclude hikes
+# gazelle:exclude stars
 # gazelle:semgrep_exclude_rules avoid-sqlalchemy-text,sqlmodel-datetime-without-factory,tainted-fastapi-http-request-httpx,tainted-path-traversal-stdlib-fastapi
 load("@aspect_bazel_lib//lib:tar.bzl", "tar")
 load("@aspect_rules_py//py:defs.bzl", "py_library")
@@ -43,6 +44,7 @@ py_venv_binary(
             "shared/**/*.py",
             "ships/**/*.py",
             "hikes/**/*.py",
+            "stars/**/*.py",
         ],
         exclude = [
             # pytest discovers both *_test.py (sibling convention) and
@@ -98,6 +100,7 @@ py_library(
             "shared/**/*.py",
             "ships/**/*.py",
             "hikes/**/*.py",
+            "stars/**/*.py",
         ],
         exclude = [
             # pytest discovers both *_test.py (sibling convention) and

--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -1788,6 +1788,16 @@ py_test(
 )
 
 py_test(
+    name = "shared_forecast_freshness_test",
+    srcs = ["shared/forecast_freshness_test.py"],
+    imports = ["."],
+    deps = [
+        ":monolith_backend",
+        "@pip//pytest",
+    ],
+)
+
+py_test(
     name = "shared_chunker_test",
     srcs = ["shared/chunker_test.py"],
     imports = ["."],

--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -116,6 +116,7 @@ py_library(
     ),  # keep
     visibility = ["//:__subpackages__"],
     deps = [
+        "@pip//astral",
         "@pip//beautifulsoup4",
         "@pip//certifi",
         "@pip//discord_py",
@@ -2095,6 +2096,27 @@ py_test(
     deps = [
         ":monolith_backend",
         "@pip//pytest",
+    ],
+)
+
+py_test(
+    name = "stars_forecast_test",
+    srcs = ["stars/forecast_test.py"],
+    imports = ["."],
+    deps = [
+        ":monolith_backend",
+        "@pip//pytest",
+    ],
+)
+
+py_test(
+    name = "stars_jobs_test",
+    srcs = ["stars/jobs_test.py"],
+    imports = ["."],
+    deps = [
+        ":monolith_backend",
+        "@pip//pytest",
+        "@pip//sqlmodel",
     ],
 )
 

--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -2067,6 +2067,17 @@ py_test(
 )
 
 py_test(
+    name = "stars_models_test",
+    srcs = ["stars/models_test.py"],
+    imports = ["."],
+    deps = [
+        ":monolith_backend",
+        "@pip//pytest",
+        "@pip//sqlmodel",
+    ],
+)
+
+py_test(
     name = "hikes_walkhighlands_test",
     srcs = ["hikes/walkhighlands_test.py"],
     imports = ["."],

--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -2121,6 +2121,19 @@ py_test(
 )
 
 py_test(
+    name = "stars_router_test",
+    srcs = ["stars/router_test.py"],
+    imports = ["."],
+    deps = [
+        ":monolith_backend",
+        "@pip//fastapi",
+        "@pip//httpx",
+        "@pip//pytest",
+        "@pip//sqlmodel",
+    ],
+)
+
+py_test(
     name = "hikes_walkhighlands_test",
     srcs = ["hikes/walkhighlands_test.py"],
     imports = ["."],

--- a/projects/monolith/CLAUDE.md
+++ b/projects/monolith/CLAUDE.md
@@ -1,0 +1,50 @@
+# CLAUDE.md - monolith
+
+Scoped guidance for `projects/monolith`. The repo-root `CLAUDE.md` still applies.
+
+## Scheduled job handlers must not block the event loop
+
+Handlers registered with `shared.scheduler.register_job` have the signature
+`async def handler(session: Session) -> datetime | None` and are **awaited on the
+scheduler's event loop**. The monolith uses synchronous SQLModel sessions, so
+calling a sync Session method (`session.add` / `exec` / `execute` / `commit` /
+`get`) directly inside an `async def` blocks every coroutine on the loop,
+including `/healthz`, for the duration of the query. Semgrep
+`no-sync-session-in-async-def` fails CI on this; the rule is enforcing a real
+production concern, not a style nit.
+
+The established pattern (see `hikes/jobs.py`, `ships/retention.py`):
+
+1. Do all network I/O in the async handler with `await` first.
+2. Delegate **all** Session I/O to a worker thread:
+   `await asyncio.to_thread(_sync_helper, data)`.
+3. The sync helper opens its **own** fresh session and commits:
+   ```python
+   def _sync_helper(data) -> int:
+       from app.db import get_engine
+       with Session(get_engine()) as session:
+           ...  # sync DB work
+           session.commit()
+   ```
+   Pass plain data into `to_thread`, **never** the scheduler's `session` argument
+   (semgrep `no-session-in-to-thread` blocks that, and a session is not safe to
+   use across threads).
+4. Keep the DB logic in a sync core that takes an explicit `session` parameter
+   so the SQLite `create_all` test fixtures can drive it directly; the async
+   wrapper (network + `to_thread`) stays thin and is not unit tested.
+5. Do not `session.add` in a loop (semgrep `session-add-in-loop`): build the
+   rows and `session.add_all(...)` once, or mutate `session.get`-tracked rows
+   and let them flush on `commit`.
+
+## Test fixtures use SQLite; datetimes come back naive
+
+Model/endpoint tests use SQLite + `SQLModel.metadata.create_all` (not
+migrations). SQLite has no tz-aware type, so a `TIMESTAMPTZ` column round-trips
+as a **naive** datetime in tests, while production (Postgres) is tz-aware.
+
+- Assert `isinstance(value, datetime)`, not `value.tzinfo is not None`.
+- When comparing loaded datetimes for equality (sets, `==`), coerce first:
+  `dt if dt.tzinfo else dt.replace(tzinfo=timezone.utc)`.
+- Serialize datetimes through an `_as_utc`/`_iso` helper (see `ships/router.py`)
+  so JSON output and ETags are offset-consistent across SQLite tests and
+  Postgres prod.

--- a/projects/monolith/app/main.py
+++ b/projects/monolith/app/main.py
@@ -16,6 +16,7 @@ import home
 import knowledge
 import scheduler
 import ships
+import stars
 from home.observability.router import warm_cache, warm_stats_cache
 
 configure_logging()
@@ -68,6 +69,7 @@ async def lifespan(app: FastAPI):
         home.on_startup_jobs(session)
         ships.on_startup_jobs(session)
         hikes.on_startup_jobs(session)
+        stars.on_startup_jobs(session)
 
     # Start Discord bot + chat jobs if configured
     bot = None
@@ -221,6 +223,7 @@ knowledge.register(app)
 scheduler.register(app)
 ships.register(app)
 hikes.register(app)
+stars.register(app)
 app.mount("/mcp", _mcp_app)
 
 

--- a/projects/monolith/app/main_vault_sync_test.py
+++ b/projects/monolith/app/main_vault_sync_test.py
@@ -23,6 +23,7 @@ async def test_lifespan_calls_clone_vault():
         patch("home.on_startup_jobs"),
         patch("ships.on_startup_jobs"),
         patch("hikes.on_startup_jobs"),
+        patch("stars.on_startup_jobs"),
     ):
         from app.main import lifespan, app
 

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.126.0
+version: 0.126.1
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.125.0
+version: 0.126.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.126.1
+version: 0.126.2
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/migrations/20260613000010_stars_schema.sql
+++ b/projects/monolith/chart/migrations/20260613000010_stars_schema.sql
@@ -1,0 +1,23 @@
+-- Stars domain: curated dark-sky sites' future viewing windows.
+-- One row per site-hour. Static site metadata (name/lat/lon/altitude/lp_zone)
+-- lives in stars/seed.py and is joined in at read time. The hourly prune job and
+-- the read endpoint both drop hours once their clock hour ends.
+
+CREATE SCHEMA IF NOT EXISTS stars;
+
+CREATE TABLE stars.site_hours (
+    site_id     TEXT NOT NULL,
+    hour_time   TIMESTAMPTZ NOT NULL,
+    score       DOUBLE PRECISION NOT NULL,
+    cloud_area_fraction DOUBLE PRECISION NOT NULL,
+    relative_humidity   DOUBLE PRECISION NOT NULL,
+    wind_speed          DOUBLE PRECISION NOT NULL,
+    air_temperature     DOUBLE PRECISION NOT NULL,
+    dew_spread          DOUBLE PRECISION NOT NULL,
+    symbol      TEXT NOT NULL DEFAULT '',
+    fetched_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (site_id, hour_time)
+);
+
+CREATE INDEX idx_stars_site_hours_time  ON stars.site_hours (hour_time);
+CREATE INDEX idx_stars_site_hours_score ON stars.site_hours (score DESC);

--- a/projects/monolith/chart/migrations/atlas.sum
+++ b/projects/monolith/chart/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:Z7COhtYWd7KHwWzPkhT0qoWcZVkLUpb3/yoWBtY6nsQ=
+h1:JYbhI2XDEgsjYN/0GKdSIHbUMneqHHHe0VPh3BKWGUM=
 20260330000000_initial_schema.sql h1:J2futpSW0nJAIRR7nR7ssT7LwXIYrvRI+PkHb5Y4tLI=
 20260403000000_chat_schema.sql h1:pERUFC0vzM95etRuzp43XzkCV7lBCzrrtY5Mk7aF3CA=
 20260404000000_chat_attachments.sql h1:tv+Fdbr1rQC5nzUxfaBC0O6fu2OMGgLWf+YNg1WQXi4=
@@ -30,3 +30,4 @@ h1:Z7COhtYWd7KHwWzPkhT0qoWcZVkLUpb3/yoWBtY6nsQ=
 20260610000000_ships_schema.sql h1:Ja7g3S4yJxKhscRMUUqg+hg0kAWVRoHeUkKxkZoPxSQ=
 20260611000000_ships_heat_cells.sql h1:k3TYgAMF/TSXFcJoHtJlc9Or/NP2C3L97nEo2UpDdlk=
 20260613000000_hikes_schema.sql h1:I3wFdg/TMhLmFDKr81gPoIAIMe58j8ekriZrVvymsyw=
+20260613000010_stars_schema.sql h1:JoKjmwNkR27a/+uj4PaNhN/DHjXmZXocHC9q7ZA9FXw=

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.126.0
+      targetRevision: 0.126.1
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.126.1
+      targetRevision: 0.126.2
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.125.0
+      targetRevision: 0.126.0
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/lib/cache-headers.js
+++ b/projects/monolith/frontend/src/lib/cache-headers.js
@@ -38,3 +38,9 @@ export const SHIPS_HEAT_CACHE_CONTROL =
 // projects/monolith/hikes/router.py, keep in sync.
 export const HIKES_WALKS_CACHE_CONTROL =
   "public, max-age=0, s-maxage=1800, stale-while-revalidate=3600, stale-if-error=86400";
+
+// /app/stars sites: the refresh job runs 3-hourly and elapsed hours are pruned
+// hourly, so 30 min edge freshness with a 1 h SWR window is plenty. Mirrors
+// _SITES_CACHE_CONTROL in projects/monolith/stars/router.py, keep in sync.
+export const STARS_SITES_CACHE_CONTROL =
+  "public, max-age=0, s-maxage=1800, stale-while-revalidate=3600, stale-if-error=86400";

--- a/projects/monolith/frontend/src/lib/public/components/Nav.svelte
+++ b/projects/monolith/frontend/src/lib/public/components/Nav.svelte
@@ -43,6 +43,12 @@
       desc: "Live AIS vessel tracker",
       href: "/app/ships",
     },
+    {
+      slug: "stars",
+      label: "Stars",
+      desc: "Scotland dark-sky planner",
+      href: "/app/stars",
+    },
   ];
 
   const appsActive = $derived(apps.some((a) => a.slug === route));
@@ -165,6 +171,21 @@
                             stroke-width="1.8"
                             stroke-linecap="round"
                             stroke-linejoin="round"
+                          />
+                        </svg>
+                      {:else if app.slug === "stars"}
+                        <svg width="22" height="22" viewBox="0 0 24 24">
+                          <path
+                            d="M12 2 L14 9 L21 11 L14 13 L12 20 L10 13 L3 11 L10 9 Z"
+                            fill="none"
+                            stroke="currentColor"
+                            stroke-width="1.8"
+                            stroke-linejoin="round"
+                          />
+                          <path
+                            d="M18.5 3 L19 5 L21 5.5 L19 6 L18.5 8 L18 6 L16 5.5 L18 5 Z"
+                            fill="currentColor"
+                            stroke="none"
                           />
                         </svg>
                       {/if}

--- a/projects/monolith/frontend/src/lib/public/components/stars/StarsMap.svelte
+++ b/projects/monolith/frontend/src/lib/public/components/stars/StarsMap.svelte
@@ -1,0 +1,655 @@
+<script>
+  import { onMount } from "svelte";
+  import "maplibre-gl/dist/maplibre-gl.css";
+
+  // `sites` is the curated dark-sky list to plot; clicking a dot opens the
+  // detail card. `nowMs` is a coarse clock signal from the parent so the card
+  // can drop hours that have already elapsed between SSR loads.
+  let { sites = [], nowMs = Date.now() } = $props();
+
+  // OpenFreeMap needs no API key (same hosted liberty style as /app/ships and
+  // /app/hikes, so the maps read as siblings). The liberty style ships light,
+  // so we recolor its land/water/label layers to a night palette on load (see
+  // darkenBasemap): dark skies want a dark map.
+  const BASEMAP_STYLE = "https://tiles.openfreemap.org/styles/liberty";
+
+  // Night-sky basemap recolor. Defined in JS (not the design tokens, which are
+  // a light cream palette) so the map reads dark; mirrors how ShipsMap keeps
+  // its vivid marker colors in JS rather than in a <style> block. This is a map
+  // paint surface, not chrome, so the svelte-hardcoded-color rule does not
+  // apply here (the same surface ShipsMap uses for VESSEL_COLORS).
+  const NIGHT = {
+    land: "#0c1020", // near-black navy land base + background
+    water: "#05070f", // darker water so coastlines still read
+    line: "#1b2138", // roads / boundaries, dimmed right down
+    label: "#8893b0", // muted slate place labels
+    labelHalo: "#05070f", // dark halo keeps labels legible on the dark map
+  };
+
+  // Score buckets: muted (poor) -> sky-blue (fair) -> gold (prime). Hardcoded
+  // in JS (a data-viz ramp, not a design-system surface), chosen to rhyme with
+  // the --blue and --accent tokens. Mirrors how HikesMap keeps its EFFORT_RAMP
+  // stops in JS and renders the legend swatches via inline style attributes.
+  const SCORE_BUCKETS = [
+    { key: "low", label: "< 70", color: "#5b678c" }, // muted slate-blue
+    { key: "mid", label: "70-85", color: "#5fb9f2" }, // sky blue (~--blue)
+    { key: "high", label: "85+", color: "#ffd23f" }, // bright gold (~--accent)
+  ];
+
+  const SOURCE_ID = "sites";
+  const LAYER_ID = "sites";
+
+  let maplibregl; // loaded lazily in onMount (browser-only module)
+  let mapContainer; // bound <div>
+  let map = null;
+  let layerReady = false;
+  let didFit = false;
+
+  // site id -> site row, so a marker click can recover the full record.
+  const index = new Map();
+
+  let selected = $state(null); // selected site row, or null
+
+  // The selected site's hours, dropping any that have already elapsed (the hour
+  // is over once nowMs passes its end). The endpoint already prunes past hours
+  // server-side; this just keeps a long-open page honest between refreshes.
+  let cardHours = $derived(
+    (selected?.best_hours ?? []).filter((h) => {
+      const t = Date.parse(h.time);
+      return Number.isNaN(t) ? true : t + 3_600_000 > nowMs;
+    }),
+  );
+
+  let mapsLink = $derived(
+    selected
+      ? `https://www.google.com/maps/search/?api=1&query=${selected.lat},${selected.lon}`
+      : null,
+  );
+
+  function fmtTime(iso) {
+    const d = new Date(iso);
+    return d.toLocaleTimeString("en-GB", {
+      weekday: "short",
+      hour: "2-digit",
+      minute: "2-digit",
+      timeZone: "Europe/London",
+    });
+  }
+
+  function fmtSymbol(symbol) {
+    // met.no symbol codes like "clearsky_night" -> "clearsky night".
+    return symbol ? symbol.replace(/_/g, " ") : "n/a";
+  }
+
+  function fmtCoord(lat, lon) {
+    const ns = lat >= 0 ? "N" : "S";
+    const ew = lon >= 0 ? "E" : "W";
+    return `${Math.abs(lat).toFixed(3)}°${ns}, ${Math.abs(lon).toFixed(3)}°${ew}`;
+  }
+
+  function selectSite(site) {
+    selected = site;
+  }
+
+  function closeCard() {
+    selected = null;
+  }
+
+  function emptyFC() {
+    return { type: "FeatureCollection", features: [] };
+  }
+
+  function validLatLon(lat, lon) {
+    if (lat == null || lon == null) return false;
+    if (Math.abs(lat) > 90 || Math.abs(lon) > 180) return false;
+    if (lat === 0 && lon === 0) return false;
+    return true;
+  }
+
+  // Marker stroke comes from the design tokens (paper), a light ring that lifts
+  // every dot off the near-black basemap regardless of its score colour.
+  function palette() {
+    const s = getComputedStyle(document.documentElement);
+    return {
+      paper: s.getPropertyValue("--paper").trim(),
+    };
+  }
+
+  function buildFeatures() {
+    const features = [];
+    for (const site of sites) {
+      if (!validLatLon(site.lat, site.lon)) continue;
+      features.push({
+        type: "Feature",
+        id: site.id,
+        geometry: { type: "Point", coordinates: [site.lon, site.lat] },
+        properties: { id: site.id, score: site.best_score ?? 0 },
+      });
+    }
+    return { type: "FeatureCollection", features };
+  }
+
+  function pushData() {
+    const src = map?.getSource(SOURCE_ID);
+    if (src) src.setData(buildFeatures());
+  }
+
+  function fitToSites() {
+    const pts = sites.filter((s) => validLatLon(s.lat, s.lon));
+    if (didFit || !pts.length) return;
+    const b = new maplibregl.LngLatBounds();
+    for (const s of pts) b.extend([s.lon, s.lat]);
+    map.fitBounds(b, { padding: 64, maxZoom: 8, duration: 0 });
+    didFit = true;
+  }
+
+  function syncSites() {
+    if (!map || !layerReady) return;
+    index.clear();
+    for (const s of sites) index.set(s.id, s);
+    pushData();
+    fitToSites();
+    // If the open card's site fell out of the set, close it.
+    if (selected && !index.has(selected.id)) closeCard();
+  }
+
+  // Recolor the (light) liberty basemap to the night palette. Iterate the
+  // style's own layers so it survives upstream style tweaks; wrap each set in a
+  // try/catch because some layers (e.g. fill-pattern) don't carry the property
+  // we set, and we'd rather skip those than abort the whole restyle.
+  function darkenBasemap() {
+    const layers = map.getStyle()?.layers ?? [];
+    for (const layer of layers) {
+      const { id, type } = layer;
+      try {
+        if (type === "background") {
+          map.setPaintProperty(id, "background-color", NIGHT.land);
+        } else if (type === "fill") {
+          const water = /water|sea|ocean|lake|river|bay/i.test(id);
+          map.setPaintProperty(id, "fill-color", water ? NIGHT.water : NIGHT.land);
+          map.setPaintProperty(id, "fill-outline-color", NIGHT.line);
+        } else if (type === "line") {
+          map.setPaintProperty(id, "line-color", NIGHT.line);
+        } else if (type === "symbol") {
+          map.setPaintProperty(id, "text-color", NIGHT.label);
+          map.setPaintProperty(id, "text-halo-color", NIGHT.labelHalo);
+        }
+      } catch {
+        // Layer doesn't carry this property; leave it as the style shipped it.
+      }
+    }
+  }
+
+  // Repaint whenever the site set changes.
+  $effect(() => {
+    void sites;
+    if (map && layerReady) syncSites();
+  });
+
+  onMount(() => {
+    let cleanup = () => {};
+    let destroyed = false;
+
+    (async () => {
+      maplibregl = (await import("maplibre-gl")).default;
+      if (destroyed) return;
+
+      map = new maplibregl.Map({
+        container: mapContainer,
+        style: BASEMAP_STYLE,
+        // Scotland: every curated dark-sky site is up north, so frame there
+        // until the first fitBounds lands.
+        center: [-4.2, 57.0],
+        zoom: 6,
+        attributionControl: { compact: true },
+      });
+      map.addControl(
+        new maplibregl.NavigationControl({ showCompass: false }),
+        "bottom-right",
+      );
+
+      // Collapse the compact attribution on every update so it never paints as
+      // a full-width credit bar; leave it alone once the user taps it open.
+      // Same handling as ShipsMap / HikesMap.
+      let userOpenedAttrib = false;
+      const collapseAttrib = () => {
+        if (userOpenedAttrib) return;
+        const attrib = mapContainer.querySelector(".maplibregl-ctrl-attrib");
+        attrib?.removeAttribute("open");
+        attrib?.classList.remove("maplibregl-compact-show");
+      };
+      mapContainer.addEventListener("click", (e) => {
+        if (e.target.closest(".maplibregl-ctrl-attrib-button")) {
+          userOpenedAttrib = true;
+        }
+      });
+      map.on("styledata", collapseAttrib);
+      map.on("sourcedata", collapseAttrib);
+      collapseAttrib();
+
+      map.on("load", () => {
+        const pal = palette();
+        darkenBasemap();
+
+        map.addSource(SOURCE_ID, { type: "geojson", data: emptyFC() });
+        map.addLayer({
+          id: LAYER_ID,
+          type: "circle",
+          source: SOURCE_ID,
+          paint: {
+            // Fill by best score: muted slate -> sky blue -> gold, stepped at
+            // the 70 / 85 bucket boundaries. Paper stroke keeps every dot
+            // legible on the dark basemap; better sites read a touch larger.
+            "circle-color": [
+              "step",
+              ["get", "score"],
+              SCORE_BUCKETS[0].color,
+              70,
+              SCORE_BUCKETS[1].color,
+              85,
+              SCORE_BUCKETS[2].color,
+            ],
+            "circle-radius": [
+              "interpolate",
+              ["linear"],
+              ["get", "score"],
+              0,
+              5,
+              100,
+              11,
+            ],
+            "circle-stroke-width": 1.5,
+            "circle-stroke-color": pal.paper,
+          },
+        });
+        layerReady = true;
+
+        map.on("click", LAYER_ID, (e) => {
+          const f = e.features?.[0];
+          if (!f) return;
+          const site = index.get(f.properties.id);
+          if (site) selectSite(site);
+        });
+        map.on("mouseenter", LAYER_ID, () => {
+          map.getCanvas().style.cursor = "pointer";
+        });
+        map.on("mouseleave", LAYER_ID, () => {
+          map.getCanvas().style.cursor = "";
+        });
+
+        syncSites();
+      });
+
+      cleanup = () => {
+        index.clear();
+        map?.remove();
+        map = null;
+        layerReady = false;
+        didFit = false;
+      };
+    })();
+
+    return () => {
+      destroyed = true;
+      cleanup();
+    };
+  });
+</script>
+
+<div class="map-wrap" class:panel-open={selected}>
+  <div class="map" bind:this={mapContainer}></div>
+
+  {#if selected}
+    <aside class="card">
+      <button class="card-close" onclick={closeCard} aria-label="Close site card"
+        >&times;</button
+      >
+      <h2 class="card-name">{selected.name}</h2>
+      <dl class="card-stats">
+        <div>
+          <dt>Coordinates</dt>
+          <dd>{fmtCoord(selected.lat, selected.lon)}</dd>
+        </div>
+        <div><dt>Altitude</dt><dd>{selected.altitude_m} m</dd></div>
+        <div><dt>LP zone</dt><dd>{selected.lp_zone}</dd></div>
+      </dl>
+
+      {#if cardHours.length}
+        <p class="eyebrow card-windows-title">Best upcoming hours</p>
+        <table class="card-windows">
+          <thead>
+            <tr>
+              <th>Time</th>
+              <th>Score</th>
+              <th>Cloud</th>
+              <th>Temp</th>
+              <th>Dew</th>
+              <th>Sky</th>
+            </tr>
+          </thead>
+          <tbody>
+            {#each cardHours as h (h.time)}
+              <tr>
+                <td>{fmtTime(h.time)}</td>
+                <td>{Math.round(h.score)}</td>
+                <td>{Math.round(h.cloud_area_fraction)}%</td>
+                <td>{Math.round(h.air_temperature)}C</td>
+                <td>{h.dew_spread?.toFixed(1)}</td>
+                <td>{fmtSymbol(h.symbol)}</td>
+              </tr>
+            {/each}
+          </tbody>
+        </table>
+      {:else}
+        <p class="card-empty">No upcoming viewing hours for this site.</p>
+      {/if}
+
+      <a class="card-link" href={mapsLink} target="_blank" rel="noopener"
+        >Open in maps<span class="card-link-arrow" aria-hidden="true">&nearr;</span></a
+      >
+    </aside>
+  {/if}
+
+  <!-- Score legend: the colour buckets that tint the dots. -->
+  <div class="legend">
+    <span class="legend-title">Best score</span>
+    <ul class="legend-list">
+      {#each SCORE_BUCKETS as b (b.key)}
+        <li>
+          <span class="legend-sw" style="background: {b.color}"></span>{b.label}
+        </li>
+      {/each}
+    </ul>
+  </div>
+</div>
+
+<style>
+  .map-wrap {
+    position: absolute;
+    inset: 0;
+    overflow: hidden;
+    /* Dark base behind the map while tiles stream in (the page sits on --ink
+       too); --ink is the darkest design token, so the load flash matches the
+       night basemap rather than flashing cream. */
+    background: var(--ink);
+  }
+
+  .map {
+    position: absolute;
+    inset: 0;
+  }
+
+  /* Inset the bottom-right control stack past device safe areas (same reasons
+     as ShipsMap / HikesMap: home indicator + landscape notch). */
+  .map :global(.maplibregl-ctrl-bottom-right) {
+    bottom: env(safe-area-inset-bottom, 0);
+    right: env(safe-area-inset-right, 0);
+  }
+
+  /* Each zoom button is its own square that lifts off (neobrutalist), matching
+     the ships + hikes maps and the homepage buttons. */
+  .map :global(.maplibregl-ctrl-group) {
+    border: none;
+    border-radius: 0;
+    background: transparent;
+    box-shadow: none;
+    overflow: visible;
+  }
+
+  .map :global(.maplibregl-ctrl-group button) {
+    border: 2px solid var(--ink);
+    background: var(--paper);
+    transition:
+      transform 110ms ease,
+      box-shadow 110ms ease;
+  }
+
+  .map :global(.maplibregl-ctrl-group button + button) {
+    margin-top: 6px;
+  }
+
+  .map :global(.maplibregl-ctrl-group button:hover),
+  .map :global(.maplibregl-ctrl-group button:focus-visible),
+  .map :global(.maplibregl-ctrl-group button:active) {
+    transform: translate(-2px, -2px);
+    box-shadow: 2px 2px 0 var(--ink);
+    background: var(--paper);
+    position: relative;
+    z-index: 1;
+  }
+
+  /* Compact attribution: a single square "i" toggle matching the zoom stack. */
+  .map :global(.maplibregl-ctrl-attrib.maplibregl-compact) {
+    min-height: 24px;
+    padding-block: 0;
+    background: transparent;
+    box-shadow: none;
+  }
+
+  .map :global(.maplibregl-ctrl-attrib-button) {
+    width: 24px;
+    height: 24px;
+    border: 2px solid var(--ink);
+    border-radius: 0;
+    background-color: var(--paper);
+  }
+
+  .map :global(.maplibregl-ctrl-attrib.maplibregl-compact-show) {
+    background: var(--paper);
+    border: 2px solid var(--ink);
+    border-radius: 0;
+  }
+
+  .map :global(.maplibregl-ctrl-attrib-inner) {
+    font-family: var(--mono);
+    font-size: 10px;
+  }
+
+  /* Site detail card: a flat sharp-bordered paper overlay, top-right and clear
+     of the global app chrome (matches the hikes + ships overlays). */
+  .card {
+    position: absolute;
+    top: 16px;
+    right: 16px;
+    width: 340px;
+    max-width: calc(100% - 32px);
+    max-height: calc(100% - 32px);
+    overflow-y: auto;
+    padding: 18px;
+    background: var(--paper);
+    border: 2px solid var(--ink);
+    box-shadow: var(--shadow-hard);
+  }
+
+  .card-close {
+    position: absolute;
+    top: 8px;
+    right: 10px;
+    background: none;
+    border: none;
+    font-family: var(--mono);
+    font-size: 22px;
+    line-height: 1;
+    cursor: pointer;
+    color: var(--ink);
+  }
+
+  .card-name {
+    font-family: var(--serif);
+    font-size: 26px;
+    line-height: 1.05;
+    margin: 2px 28px 12px 0;
+    word-break: break-word;
+  }
+
+  .card-stats {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    gap: 10px 12px;
+    margin-bottom: 14px;
+    padding: 10px 12px;
+    background: var(--cream);
+    border: 2px solid var(--ink);
+  }
+
+  .card-stats > div {
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+  }
+
+  .card-stats dt {
+    font-family: var(--mono);
+    font-size: 10px;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--ink-2);
+  }
+
+  .card-stats dd {
+    font-family: var(--mono);
+    font-size: 14px;
+    font-weight: 700;
+  }
+
+  /* Highlighted header bar so the table reads as the answer, not a faint grey
+     eyebrow (overrides .eyebrow's muted colour). */
+  .card-windows-title {
+    display: inline-block;
+    margin: 0 0 10px;
+    padding: 4px 8px;
+    background: var(--accent);
+    color: var(--ink);
+    border: 2px solid var(--ink);
+  }
+
+  .card-windows {
+    width: 100%;
+    border-collapse: collapse;
+    font-family: var(--mono);
+    font-size: 11px;
+    margin-bottom: 14px;
+  }
+
+  .card-windows th {
+    text-align: left;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    color: var(--ink-3);
+    border-bottom: 2px solid var(--ink);
+    padding: 4px 6px 4px 0;
+  }
+
+  .card-windows td {
+    padding: 4px 6px 4px 0;
+    border-bottom: 1px dashed var(--rule-2);
+  }
+
+  .card-empty {
+    font-family: var(--mono);
+    font-size: 11px;
+    color: var(--ink-3);
+    margin-bottom: 14px;
+  }
+
+  .card-link {
+    display: inline-block;
+    font-family: var(--mono);
+    font-size: 12px;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    color: var(--ink);
+    text-decoration: underline;
+    text-decoration-color: var(--blue);
+    text-decoration-thickness: 2px;
+    text-decoration-skip-ink: none;
+    text-underline-offset: 3px;
+    transition: background 140ms ease;
+  }
+
+  .card-link:hover,
+  .card-link:focus-visible {
+    background: linear-gradient(transparent 62%, var(--accent) 62%);
+    text-decoration-color: var(--ink);
+  }
+
+  .card-link-arrow {
+    font-size: 0.85em;
+    margin-left: 2px;
+  }
+
+  /* Score legend, bottom-left, clear of the bottom-right zoom + attribution. */
+  .legend {
+    position: absolute;
+    left: 16px;
+    bottom: 16px;
+    z-index: 4;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    padding: 10px 12px;
+    background: var(--paper);
+    border: 2px solid var(--ink);
+    font-family: var(--mono);
+  }
+
+  .legend-title {
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--ink-2);
+  }
+
+  .legend-list {
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.02em;
+    color: var(--ink);
+  }
+
+  .legend-list li {
+    display: flex;
+    align-items: center;
+    gap: 7px;
+  }
+
+  .legend-sw {
+    width: 13px;
+    height: 13px;
+    border: 1.5px solid var(--ink);
+    flex: none;
+  }
+
+  @media (max-width: 640px) {
+    /* On phones the card is a bottom sheet, so the legend would collide with
+       it; drop the legend there (the colours stay self-evident). */
+    .legend {
+      display: none;
+    }
+
+    /* The card becomes a bottom sheet so the map keeps the upper screen. */
+    .card {
+      top: auto;
+      bottom: 0;
+      left: 0;
+      right: 0;
+      width: auto;
+      max-width: none;
+      max-height: 72vh;
+      border-width: 2px 0 0;
+      box-shadow: none;
+      padding: 20px 18px calc(20px + env(safe-area-inset-bottom));
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .map :global(.maplibregl-ctrl-group button) {
+      transition: none;
+    }
+  }
+</style>

--- a/projects/monolith/frontend/src/routes/public/app/stars/+page.js
+++ b/projects/monolith/frontend/src/routes/public/app/stars/+page.js
@@ -1,0 +1,5 @@
+// MapLibre needs window/WebGL, so render the page client-side only. The
+// +page.server.js load still runs server-side regardless, so the sites data
+// stays SSR-sourced (the browser never touches /api/stars/*). Same pattern as
+// /app/hikes and /app/ships.
+export const ssr = false;

--- a/projects/monolith/frontend/src/routes/public/app/stars/+page.server.js
+++ b/projects/monolith/frontend/src/routes/public/app/stars/+page.server.js
@@ -1,0 +1,31 @@
+import { error } from "@sveltejs/kit";
+// Relative (not $lib): vitest loads this module directly and its plain node
+// config does not resolve the SvelteKit $lib alias. stars sits at the same
+// depth as ships/hikes (routes/public/app/stars), hence four ../ segments to
+// reach src/lib/. Mirrors hikes/+page.server.js.
+import { STARS_SITES_CACHE_CONTROL } from "../../../../lib/cache-headers.js";
+
+const API_BASE = process.env.API_BASE || "http://localhost:8000";
+
+// SSR-only: the browser never calls /api/stars/* directly (that surface is not
+// exposed publicly). This load runs server-side in the same pod and the CDN
+// fans the result out to viewers. Live updates come from re-running this load
+// on a 30 min timer (invalidateAll) in the page, not from a client-side poll
+// (the refresh job runs 3-hourly).
+export async function load({ fetch, setHeaders }) {
+  const res = await fetch(`${API_BASE}/api/stars/sites`, {
+    signal: AbortSignal.timeout(10_000),
+  });
+  if (!res.ok) {
+    throw error(503, "stars sites unavailable");
+  }
+
+  const headers = { "cache-control": STARS_SITES_CACHE_CONTROL };
+  const etag = res.headers?.get?.("etag");
+  if (etag) headers.etag = etag;
+  const lastModified = res.headers?.get?.("last-modified");
+  if (lastModified) headers["last-modified"] = lastModified;
+  setHeaders(headers);
+
+  return { snapshot: await res.json() };
+}

--- a/projects/monolith/frontend/src/routes/public/app/stars/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/stars/+page.svelte
@@ -1,0 +1,216 @@
+<script>
+  import { onMount } from "svelte";
+  import { invalidateAll } from "$app/navigation";
+  import StarsMap from "$lib/public/components/stars/StarsMap.svelte";
+
+  let { data } = $props();
+
+  let sites = $derived(data.snapshot?.sites ?? []);
+  let count = $derived(data.snapshot?.count ?? 0);
+  // sites is already sorted by best_score descending, so the head is the best.
+  let topScore = $derived(
+    sites.length ? Math.round(sites[0].best_score ?? 0) : null,
+  );
+
+  // A coarse "current time" signal: it advances the "updated Xm ago" label and
+  // lets StarsMap drop hours that elapse on a long-open page (see the tick in
+  // onMount).
+  let nowMs = $state(Date.now());
+
+  // Relative age of the snapshot, mirroring the homepage's formatAgo (a local
+  // helper, not a shared export). Parameterized on nowMs so it ticks.
+  function formatAgo(iso, now) {
+    const then = Date.parse(iso);
+    if (!Number.isFinite(then)) return null;
+    const minutes = Math.max(0, Math.round((now - then) / 60_000));
+    if (minutes < 60) return `${minutes}m`;
+    const hours = Math.round(minutes / 60);
+    if (hours < 48) return `${hours}h`;
+    return `${Math.round(hours / 24)}d`;
+  }
+
+  let agoLabel = $derived(formatAgo(data.snapshot?.fetched_at, nowMs));
+
+  onMount(() => {
+    // Live updates: re-run the SSR load every 30 min (the refresh job runs
+    // 3-hourly). Same pattern as /app/hikes.
+    const refresh = setInterval(() => {
+      nowMs = Date.now();
+      invalidateAll();
+    }, 30 * 60_000);
+    // Lower-frequency tick so the age label advances and elapsed hours drop out
+    // of the open card without waiting for the data refetch; nothing here needs
+    // sub-minute resolution.
+    const clockTick = setInterval(() => (nowMs = Date.now()), 5 * 60_000);
+    return () => {
+      clearInterval(refresh);
+      clearInterval(clockTick);
+    };
+  });
+</script>
+
+<svelte:head>
+  <title>Dark-sky stargazing map, Scotland viewing windows</title>
+  <meta
+    name="description"
+    content="A map of curated Scottish dark-sky sites scored by upcoming viewing windows from the met.no forecast."
+  />
+</svelte:head>
+
+<div class="stars-page">
+  <h1 class="sr-only">Dark-sky stargazing map, Scotland viewing windows</h1>
+
+  <StarsMap {sites} {nowMs} />
+
+  <!-- Floating header: breadcrumb + headline stats, top-left clear of the map
+       chrome (mirrors the hikes control head). -->
+  <div class="controls">
+    <div class="panel control-head">
+      <div class="crumb-row">
+        <nav class="crumb" aria-label="Breadcrumb">
+          <a class="crumb-home" href="https://jomcgi.dev/"
+            >jomcgi.dev<span class="crumb-arrow" aria-hidden="true">&nearr;</span
+            ></a
+          >
+          <span class="crumb-sep">/</span>
+          <span class="crumb-name">stars</span>
+        </nav>
+        <p class="stats">
+          {count} dark-sky sites{#if topScore != null}
+            &middot; best score {topScore}{/if}{#if agoLabel}
+            &middot; updated {agoLabel} ago{/if}
+        </p>
+      </div>
+    </div>
+
+    {#if count === 0}
+      <div class="panel empty-state" role="status">
+        No viewing windows above score 60 in the next few nights. Check back
+        after the next forecast refresh.
+      </div>
+    {/if}
+  </div>
+</div>
+
+<style>
+  /* Full-bleed, map-first (same shell as /app/ships + /app/hikes): the map owns
+     the viewport and every control floats over it. StarsMap's .map-wrap is
+     absolutely positioned, so this is its containing block. --ink is the dark
+     base so the load flash matches the night basemap, not a cream flash. */
+  .stars-page {
+    position: relative;
+    height: 100vh;
+    height: 100dvh;
+    overflow: hidden;
+    background: var(--ink);
+    color: var(--ink);
+  }
+
+  .sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0 0 0 0);
+    white-space: nowrap;
+    border: 0;
+  }
+
+  /* Floating control stack, top-left, clear of the map's own chrome. */
+  .controls {
+    position: absolute;
+    top: 16px;
+    left: 16px;
+    z-index: 5;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    width: min(420px, calc(100% - 32px));
+  }
+
+  /* Flat sharp-bordered overlay, matching the ships + hikes map overlays:
+     paper bg, 2px ink border, no border-radius. */
+  .panel {
+    background: var(--paper);
+    border: 2px solid var(--ink);
+    padding: 12px;
+  }
+
+  .control-head {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
+
+  .crumb-row {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 8px 14px;
+    flex-wrap: wrap;
+  }
+
+  .crumb {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    font-family: var(--mono);
+    font-size: 12px;
+    font-weight: 700;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+  }
+
+  .crumb-home {
+    color: var(--ink);
+    text-decoration: underline;
+    text-decoration-color: var(--blue);
+    text-decoration-thickness: 2px;
+    text-decoration-skip-ink: none;
+    text-underline-offset: 2px;
+    padding: 0 2px;
+    transition: background 140ms ease;
+  }
+
+  .crumb-home:hover,
+  .crumb-home:focus-visible {
+    background: linear-gradient(transparent 56%, var(--accent) 56%);
+    text-decoration-color: var(--ink);
+  }
+
+  .crumb-arrow {
+    font-size: 0.85em;
+    margin-left: 1px;
+  }
+
+  .crumb-sep {
+    color: var(--ink-3);
+  }
+
+  .stats {
+    font-family: var(--mono);
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    color: var(--ink-2);
+  }
+
+  .empty-state {
+    font-family: var(--mono);
+    font-size: 12px;
+    line-height: 1.5;
+    letter-spacing: 0.02em;
+    color: var(--ink-2);
+  }
+
+  @media (max-width: 640px) {
+    .controls {
+      top: 12px;
+      left: 12px;
+      width: calc(100% - 24px);
+    }
+  }
+</style>

--- a/projects/monolith/frontend/src/routes/public/app/stars/page.server.test.js
+++ b/projects/monolith/frontend/src/routes/public/app/stars/page.server.test.js
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi } from "vitest";
+import { load } from "./+page.server.js";
+import { STARS_SITES_CACHE_CONTROL } from "../../../../lib/cache-headers.js";
+
+function makeHeaders(map = {}) {
+  const lower = Object.fromEntries(
+    Object.entries(map).map(([k, v]) => [k.toLowerCase(), v]),
+  );
+  return { get: (name) => lower[name.toLowerCase()] ?? null };
+}
+
+const SNAPSHOT = { sites: [], count: 0, total_sites: 30, fetched_at: null };
+
+describe("/public/app/stars load", () => {
+  it("hits the SSR-only stars sites endpoint", async () => {
+    const setHeaders = vi.fn();
+    const fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      headers: makeHeaders(),
+      json: async () => SNAPSHOT,
+    });
+
+    await load({ fetch, setHeaders });
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    const url = fetch.mock.calls[0][0];
+    expect(url).toMatch(/\/api\/stars\/sites$/);
+  });
+
+  it("sets the shared sites cache-control header", async () => {
+    const setHeaders = vi.fn();
+    const fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      headers: makeHeaders(),
+      json: async () => SNAPSHOT,
+    });
+
+    const result = await load({ fetch, setHeaders });
+
+    expect(setHeaders).toHaveBeenCalledWith(
+      expect.objectContaining({
+        "cache-control": STARS_SITES_CACHE_CONTROL,
+      }),
+    );
+    // Byte-for-byte mirror of _SITES_CACHE_CONTROL in stars/router.py.
+    expect(STARS_SITES_CACHE_CONTROL).toBe(
+      "public, max-age=0, s-maxage=1800, stale-while-revalidate=3600, stale-if-error=86400",
+    );
+    expect(result.snapshot).toEqual(SNAPSHOT);
+  });
+
+  it("forwards ETag and Last-Modified from the API response", async () => {
+    const setHeaders = vi.fn();
+    const fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      headers: makeHeaders({
+        ETag: '"v1-2026-06-13T21:00:00+00:00-none-0"',
+        "Last-Modified": "Fri, 13 Jun 2026 21:00:00 GMT",
+      }),
+      json: async () => SNAPSHOT,
+    });
+
+    await load({ fetch, setHeaders });
+
+    expect(setHeaders).toHaveBeenCalledWith(
+      expect.objectContaining({
+        etag: '"v1-2026-06-13T21:00:00+00:00-none-0"',
+        "last-modified": "Fri, 13 Jun 2026 21:00:00 GMT",
+      }),
+    );
+  });
+
+  it("omits ETag and Last-Modified when the API does not return them", async () => {
+    const setHeaders = vi.fn();
+    const fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      headers: makeHeaders(),
+      json: async () => SNAPSHOT,
+    });
+
+    await load({ fetch, setHeaders });
+
+    const headers = setHeaders.mock.calls[0][0];
+    expect(headers).not.toHaveProperty("etag");
+    expect(headers).not.toHaveProperty("last-modified");
+  });
+
+  it("throws a 503 when the backend fetch fails", async () => {
+    const setHeaders = vi.fn();
+    const fetch = vi.fn().mockResolvedValue({ ok: false, status: 502 });
+
+    await expect(load({ fetch, setHeaders })).rejects.toThrow();
+  });
+});

--- a/projects/monolith/shared/forecast_freshness.py
+++ b/projects/monolith/shared/forecast_freshness.py
@@ -1,0 +1,22 @@
+"""Shared per-hour TTL cutoff for forecast-style hour entries.
+
+The stars domain (and a future hikes change) stores hour-keyed forecast rows
+and treats each entry as valid only for the duration of its clock hour. An
+entry is dropped once the next hour begins. The cutoff is the top of the
+current UTC clock hour: keep entries whose hour_time >= top_of_hour(), drop
+the rest. Centralised here so the refresh job, the prune job, and the read
+endpoint all agree on the same boundary.
+"""
+
+from datetime import datetime, timezone
+
+
+def top_of_hour(now: datetime | None = None) -> datetime:
+    """Return the start of the current UTC clock hour.
+
+    Truncates minute, second, and microsecond to 0 and keeps tzinfo as UTC.
+    If ``now`` is None, uses datetime.now(timezone.utc).
+    """
+    if now is None:
+        now = datetime.now(timezone.utc)
+    return now.replace(minute=0, second=0, microsecond=0)

--- a/projects/monolith/shared/forecast_freshness_test.py
+++ b/projects/monolith/shared/forecast_freshness_test.py
@@ -1,0 +1,34 @@
+"""Unit tests for shared.forecast_freshness.top_of_hour."""
+
+from datetime import datetime, timezone
+
+from shared.forecast_freshness import top_of_hour
+
+
+def test_truncates_mid_hour_to_top_of_hour():
+    mid = datetime(2026, 6, 13, 14, 37, 42, 123456, tzinfo=timezone.utc)
+    result = top_of_hour(mid)
+    assert result == datetime(2026, 6, 13, 14, 0, 0, 0, tzinfo=timezone.utc)
+    assert result.minute == 0
+    assert result.second == 0
+    assert result.microsecond == 0
+    assert result.tzinfo == timezone.utc
+
+
+def test_none_uses_current_utc_time():
+    result = top_of_hour(None)
+    assert result.minute == 0
+    assert result.second == 0
+    assert result.microsecond == 0
+    assert result.tzinfo == timezone.utc
+
+
+def test_already_on_the_hour_is_unchanged():
+    on_hour = datetime(2026, 6, 13, 9, 0, 0, 0, tzinfo=timezone.utc)
+    assert top_of_hour(on_hour) == on_hour
+
+
+def test_idempotent():
+    mid = datetime(2026, 6, 13, 14, 37, 42, 123456, tzinfo=timezone.utc)
+    once = top_of_hour(mid)
+    assert top_of_hour(once) == once

--- a/projects/monolith/stars/__init__.py
+++ b/projects/monolith/stars/__init__.py
@@ -1,0 +1,36 @@
+"""Stars domain: best dark-sky viewing windows for ~30 curated Scottish sites.
+
+Self-contained: a scheduled job fetches MET Norway forecasts directly, scores
+each dark hour, and stores all future qualifying hours in Postgres
+(stars.site_hours). An hourly prune drops elapsed hours; the read endpoint
+filters defensively and is the source of truth. No external pipeline at runtime.
+"""
+
+from fastapi import FastAPI
+from sqlmodel import Session
+
+
+def register(app: FastAPI) -> None:
+    from stars.router import router
+
+    app.include_router(router)
+
+
+def on_startup_jobs(session: Session) -> None:
+    from shared.scheduler import register_job
+    from stars.jobs import prune_hours_handler, refresh_handler
+
+    register_job(
+        session,
+        name="stars.refresh",
+        interval_secs=3 * 3600,
+        handler=refresh_handler,
+        ttl_secs=900,
+    )
+    register_job(
+        session,
+        name="stars.prune_hours",
+        interval_secs=3600,
+        handler=prune_hours_handler,
+        ttl_secs=300,
+    )

--- a/projects/monolith/stars/forecast.py
+++ b/projects/monolith/stars/forecast.py
@@ -1,0 +1,122 @@
+"""MET Norway fetch + astronomy scoring for the stars seed sites."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from datetime import datetime
+
+import httpx
+from astral import LocationInfo
+from astral.sun import elevation
+
+from stars.scoring import WeatherData, calculate_astronomy_score
+from stars.seed import SCOTLAND_DARK_SKY_LOCATIONS, SeedLocation
+
+logger = logging.getLogger("monolith.stars.forecast")
+
+MET_NORWAY_URL = "https://api.met.no/weatherapi/locationforecast/2.0/complete"
+USER_AGENT = os.environ.get(
+    "STARS_USER_AGENT", "jomcgi-homelab-stars/1.0 https://jomcgi.dev"
+)
+RATE_LIMIT_PER_SEC = int(os.environ.get("STARS_RATE_LIMIT", "15"))
+MIN_DISPLAY_SCORE = int(os.environ.get("STARS_MIN_DISPLAY_SCORE", "60"))
+NAUTICAL_TWILIGHT_DEG = -12.0
+HTTP_TIMEOUT = 30.0
+
+
+def score_location(loc: SeedLocation, forecast: dict) -> list[dict]:
+    """All qualifying dark hours for one site, sorted by time ascending.
+
+    Each returned dict matches the stars.site_hours columns (minus site_id /
+    fetched_at, which the job sets): time, score, cloud_area_fraction,
+    relative_humidity, wind_speed, air_temperature, dew_spread, symbol.
+    """
+    observer = LocationInfo(latitude=loc["lat"], longitude=loc["lon"]).observer
+    hours: list[dict] = []
+    for entry in forecast.get("properties", {}).get("timeseries", []):
+        time_str = entry.get("time", "")
+        try:
+            t = datetime.fromisoformat(time_str.replace("Z", "+00:00"))
+        except ValueError:
+            continue
+        try:
+            if elevation(observer, t) > NAUTICAL_TWILIGHT_DEG:
+                continue
+        except Exception:  # pragma: no cover - astral edge cases
+            continue
+        instant = entry.get("data", {}).get("instant", {}).get("details", {})
+        next_1h = entry.get("data", {}).get("next_1_hours", {})
+        try:
+            weather = WeatherData(
+                cloud_area_fraction=instant.get("cloud_area_fraction", 100),
+                relative_humidity=instant.get("relative_humidity", 100),
+                fog_area_fraction=instant.get("fog_area_fraction", 0),
+                wind_speed=instant.get("wind_speed", 0),
+                air_temperature=instant.get("air_temperature", 10),
+                dew_point_temperature=instant.get("dew_point_temperature", 5),
+                air_pressure_at_sea_level=instant.get(
+                    "air_pressure_at_sea_level", 1013.25
+                ),
+            )
+        except Exception:
+            continue
+        score = calculate_astronomy_score(weather)
+        if score < MIN_DISPLAY_SCORE:
+            continue
+        hours.append(
+            {
+                "time": time_str,
+                "score": round(score, 1),
+                "cloud_area_fraction": weather.cloud_area_fraction,
+                "relative_humidity": weather.relative_humidity,
+                "wind_speed": weather.wind_speed,
+                "air_temperature": weather.air_temperature,
+                "dew_spread": round(
+                    weather.air_temperature - weather.dew_point_temperature, 1
+                ),
+                "symbol": next_1h.get("summary", {}).get("symbol_code", ""),
+            }
+        )
+    hours.sort(key=lambda h: h["time"])
+    return hours
+
+
+async def _fetch_and_score(
+    client: httpx.AsyncClient, loc: SeedLocation
+) -> tuple[str, list[dict] | None]:
+    """Fetch + score one site. None means the fetch failed (keep stale rows)."""
+    try:
+        resp = await client.get(
+            MET_NORWAY_URL,
+            params={
+                "lat": loc["lat"],
+                "lon": loc["lon"],
+                "altitude": loc["altitude_m"],
+            },
+            headers={"User-Agent": USER_AGENT},
+            timeout=HTTP_TIMEOUT,
+        )
+        resp.raise_for_status()
+    except httpx.HTTPError as exc:
+        logger.warning("stars forecast fetch failed for %s: %s", loc["id"], exc)
+        return loc["id"], None
+    return loc["id"], score_location(loc, resp.json())
+
+
+async def fetch_all() -> dict[str, list[dict]]:
+    """Map site id -> scored future hours, for sites that fetched successfully."""
+    semaphore = asyncio.Semaphore(RATE_LIMIT_PER_SEC)
+    async with httpx.AsyncClient(timeout=httpx.Timeout(HTTP_TIMEOUT)) as client:
+
+        async def _bounded(loc: SeedLocation):
+            async with semaphore:
+                result = await _fetch_and_score(client, loc)
+                await asyncio.sleep(1.0 / RATE_LIMIT_PER_SEC)  # stay under MET 20/s
+                return result
+
+        results = await asyncio.gather(
+            *(_bounded(loc) for loc in SCOTLAND_DARK_SKY_LOCATIONS)
+        )
+    return {sid: hours for sid, hours in results if hours is not None}

--- a/projects/monolith/stars/forecast.py
+++ b/projects/monolith/stars/forecast.py
@@ -44,7 +44,8 @@ def score_location(loc: SeedLocation, forecast: dict) -> list[dict]:
         try:
             if elevation(observer, t) > NAUTICAL_TWILIGHT_DEG:
                 continue
-        except Exception:  # pragma: no cover - astral edge cases
+        except Exception as exc:  # pragma: no cover - astral edge cases
+            logger.debug("astral elevation failed for %s at %s: %s", loc["id"], t, exc)
             continue
         instant = entry.get("data", {}).get("instant", {}).get("details", {})
         next_1h = entry.get("data", {}).get("next_1_hours", {})
@@ -60,7 +61,8 @@ def score_location(loc: SeedLocation, forecast: dict) -> list[dict]:
                     "air_pressure_at_sea_level", 1013.25
                 ),
             )
-        except Exception:
+        except Exception as exc:
+            logger.debug("skip malformed weather entry at %s: %s", time_str, exc)
             continue
         score = calculate_astronomy_score(weather)
         if score < MIN_DISPLAY_SCORE:

--- a/projects/monolith/stars/forecast_test.py
+++ b/projects/monolith/stars/forecast_test.py
@@ -1,0 +1,108 @@
+"""Unit tests for stars.forecast.score_location.
+
+elevation() is monkeypatched per entry so the dark/daylight gate is fully
+deterministic and independent of the real ephemeris. The qualifying-hour
+shape and ascending sort are asserted directly.
+"""
+
+import stars.forecast as forecast
+from stars.seed import SeedLocation
+
+_LOC: SeedLocation = {
+    "id": "test-site",
+    "name": "Test Site",
+    "lat": 57.0,
+    "lon": -4.0,
+    "altitude_m": 100,
+    "lp_zone": "1a",
+}
+
+# Sun elevation (degrees) keyed by the UTC hour of the timeseries entry.
+# Hours 22, 23, 0 are below nautical twilight (dark); hour 12 is daytime.
+_ELEV_BY_HOUR = {22: -20.0, 23: -20.0, 0: -20.0, 12: 30.0}
+
+
+def _fake_elevation(observer, t):
+    return _ELEV_BY_HOUR[t.hour]
+
+
+def _instant(cloud, humidity, wind, temp, dew, pressure=1013.25, fog=0):
+    return {
+        "data": {
+            "instant": {
+                "details": {
+                    "cloud_area_fraction": cloud,
+                    "relative_humidity": humidity,
+                    "fog_area_fraction": fog,
+                    "wind_speed": wind,
+                    "air_temperature": temp,
+                    "dew_point_temperature": dew,
+                    "air_pressure_at_sea_level": pressure,
+                }
+            },
+            "next_1_hours": {"summary": {"symbol_code": "clearsky_night"}},
+        }
+    }
+
+
+def _forecast():
+    # Deliberately out of time order so the ascending sort is exercised.
+    return {
+        "properties": {
+            "timeseries": [
+                # dark + clear -> qualifies (score 100)
+                {"time": "2026-06-13T23:00:00Z", **_instant(5, 55, 2, 8, 2)},
+                # dark + heavily clouded -> score < 60, dropped
+                {"time": "2026-06-14T00:00:00Z", **_instant(100, 90, 2, 8, 7)},
+                # daytime (sun up) -> dropped before scoring
+                {"time": "2026-06-13T12:00:00Z", **_instant(0, 40, 1, 12, 2)},
+                # dark + clear, earlier hour -> qualifies, must sort first
+                {"time": "2026-06-13T22:00:00Z", **_instant(5, 55, 2, 8, 2)},
+            ]
+        }
+    }
+
+
+_EXPECTED_KEYS = {
+    "time",
+    "score",
+    "cloud_area_fraction",
+    "relative_humidity",
+    "wind_speed",
+    "air_temperature",
+    "dew_spread",
+    "symbol",
+}
+
+
+def test_score_location_keeps_only_qualifying_hours_sorted(monkeypatch):
+    monkeypatch.setattr(forecast, "elevation", _fake_elevation)
+
+    hours = forecast.score_location(_LOC, _forecast())
+
+    # Two dark+clear hours qualify; the cloudy and daytime hours are dropped.
+    assert [h["time"] for h in hours] == [
+        "2026-06-13T22:00:00Z",
+        "2026-06-13T23:00:00Z",
+    ]
+    for h in hours:
+        assert set(h.keys()) == _EXPECTED_KEYS
+    first = hours[0]
+    assert first["score"] == 100.0
+    assert first["cloud_area_fraction"] == 5
+    assert first["relative_humidity"] == 55
+    assert first["wind_speed"] == 2
+    assert first["air_temperature"] == 8
+    assert first["dew_spread"] == 6.0
+    assert first["symbol"] == "clearsky_night"
+
+
+def test_score_location_empty_forecast_returns_empty(monkeypatch):
+    monkeypatch.setattr(forecast, "elevation", _fake_elevation)
+    assert forecast.score_location(_LOC, {}) == []
+
+
+def test_score_location_garbage_forecast_returns_empty(monkeypatch):
+    monkeypatch.setattr(forecast, "elevation", _fake_elevation)
+    garbage = {"properties": {"timeseries": [{"time": "not-a-timestamp"}]}}
+    assert forecast.score_location(_LOC, garbage) == []

--- a/projects/monolith/stars/jobs.py
+++ b/projects/monolith/stars/jobs.py
@@ -1,0 +1,11 @@
+"""Stars scheduled job handlers (refresh + prune). Fleshed out in later tasks."""
+
+from sqlmodel import Session
+
+
+async def refresh_handler(session: Session) -> None:  # implemented in a later task
+    raise NotImplementedError
+
+
+def prune_hours_handler(session: Session) -> None:  # implemented in a later task
+    raise NotImplementedError

--- a/projects/monolith/stars/jobs.py
+++ b/projects/monolith/stars/jobs.py
@@ -16,6 +16,7 @@ from datetime import datetime, timezone
 
 from sqlmodel import Session, delete
 
+from shared.forecast_freshness import top_of_hour
 from stars.forecast import fetch_all
 from stars.models import SiteHour
 from stars.seed import SCOTLAND_DARK_SKY_LOCATIONS
@@ -67,7 +68,15 @@ async def refresh_handler(session: Session) -> datetime | None:
     return None
 
 
-async def prune_hours_handler(
-    session: Session,
-) -> datetime | None:  # implemented in a later task
-    raise NotImplementedError
+async def prune_hours_handler(session: Session) -> datetime | None:
+    """Drop elapsed hours (housekeeping; the read endpoint also filters).
+
+    The cutoff is the top of the current UTC clock hour: rows whose hour_time
+    is strictly before it have elapsed and are removed. fetched_at is never
+    touched. cutoff is tz-aware UTC, so the comparison stays tz-aware.
+    """
+    cutoff = top_of_hour()
+    result = session.execute(delete(SiteHour).where(SiteHour.hour_time < cutoff))
+    session.commit()
+    logger.info("stars.prune_hours: deleted %s elapsed rows", result.rowcount)
+    return None

--- a/projects/monolith/stars/jobs.py
+++ b/projects/monolith/stars/jobs.py
@@ -1,11 +1,73 @@
-"""Stars scheduled job handlers (refresh + prune). Fleshed out in later tasks."""
+"""Stars scheduled job handlers (refresh + prune).
 
-from sqlmodel import Session
+refresh_handler runs the met.no fetch + astronomy scoring for every seed site
+and wholesale-replaces that site's site_hours rows. prune_hours_handler drops
+hours once their clock hour has elapsed. Both follow the scheduler contract
+(async def returning ``datetime | None``) and the network-before-session
+ordering used by hikes.jobs: the whole network phase runs first via httpx
+async, then the synchronous SQLModel I/O runs inline in the same coroutine.
+The Session is never handed to a worker thread (no-session-in-to-thread).
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+
+from sqlmodel import Session, delete
+
+from stars.forecast import fetch_all
+from stars.models import SiteHour
+from stars.seed import SCOTLAND_DARK_SKY_LOCATIONS
+
+logger = logging.getLogger("monolith.stars.jobs")
+
+_BY_ID = {loc["id"]: loc for loc in SCOTLAND_DARK_SKY_LOCATIONS}
 
 
-async def refresh_handler(session: Session) -> None:  # implemented in a later task
-    raise NotImplementedError
+async def refresh_handler(session: Session) -> datetime | None:
+    """Refresh per-site dark-hour forecasts from met.no.
+
+    Fetch + score every seed site first (no session work during the network
+    phase). Then, for each site that fetched successfully, wholesale-replace its
+    rows: delete the site's existing hours and insert one row per scored hour.
+    Sites whose fetch failed are absent from ``scored`` and keep their previous
+    rows (stale beats empty). A total fetch failure writes nothing.
+    """
+    scored = await fetch_all()
+    if not scored:
+        logger.warning("stars.refresh: empty fetch, keeping existing rows")
+        return None
+
+    fetched_at = datetime.now(timezone.utc)
+    for site_id, hours in scored.items():
+        session.execute(delete(SiteHour).where(SiteHour.site_id == site_id))
+        for h in hours:
+            hour_time = datetime.fromisoformat(h["time"].replace("Z", "+00:00"))
+            session.add(
+                SiteHour(
+                    site_id=site_id,
+                    hour_time=hour_time,
+                    score=h["score"],
+                    cloud_area_fraction=h["cloud_area_fraction"],
+                    relative_humidity=h["relative_humidity"],
+                    wind_speed=h["wind_speed"],
+                    air_temperature=h["air_temperature"],
+                    dew_spread=h["dew_spread"],
+                    symbol=h["symbol"],
+                    fetched_at=fetched_at,
+                )
+            )
+    session.commit()
+    logger.info(
+        "stars.refresh ok: refreshed %d/%d sites",
+        len(scored),
+        len(SCOTLAND_DARK_SKY_LOCATIONS),
+    )
+    return None
 
 
-def prune_hours_handler(session: Session) -> None:  # implemented in a later task
+async def prune_hours_handler(
+    session: Session,
+) -> datetime | None:  # implemented in a later task
     raise NotImplementedError

--- a/projects/monolith/stars/jobs.py
+++ b/projects/monolith/stars/jobs.py
@@ -1,16 +1,17 @@
 """Stars scheduled job handlers (refresh + prune).
 
 refresh_handler runs the met.no fetch + astronomy scoring for every seed site
-and wholesale-replaces that site's site_hours rows. prune_hours_handler drops
-hours once their clock hour has elapsed. Both follow the scheduler contract
-(async def returning ``datetime | None``) and the network-before-session
-ordering used by hikes.jobs: the whole network phase runs first via httpx
-async, then the synchronous SQLModel I/O runs inline in the same coroutine.
-The Session is never handed to a worker thread (no-session-in-to-thread).
+and wholesale-replaces site_hours rows. prune_hours_handler drops hours once
+their clock hour has elapsed. In both, the network phase runs in the async
+handler and the synchronous Session I/O is delegated to a worker thread
+(asyncio.to_thread) so it never blocks the event loop, mirroring hikes.jobs and
+ships.retention. The scheduler passes a session, but the DB work uses its own
+fresh session inside the thread.
 """
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from datetime import datetime, timezone
 
@@ -23,45 +24,85 @@ from stars.seed import SCOTLAND_DARK_SKY_LOCATIONS
 
 logger = logging.getLogger("monolith.stars.jobs")
 
-_BY_ID = {loc["id"]: loc for loc in SCOTLAND_DARK_SKY_LOCATIONS}
+
+def _write_sites(session: Session, scored: dict[str, list[dict]], now: datetime) -> int:
+    """Wholesale-replace rows for every fetched site. Returns rows written.
+
+    One bulk delete of the fetched sites' existing rows, then one add_all of the
+    new rows, so there is no per-iteration session.add. Sites absent from
+    ``scored`` (failed fetch) are untouched: stale beats empty.
+    """
+    site_ids = list(scored.keys())
+    session.execute(delete(SiteHour).where(SiteHour.site_id.in_(site_ids)))
+    new_rows = [
+        SiteHour(
+            site_id=site_id,
+            hour_time=datetime.fromisoformat(h["time"].replace("Z", "+00:00")),
+            score=h["score"],
+            cloud_area_fraction=h["cloud_area_fraction"],
+            relative_humidity=h["relative_humidity"],
+            wind_speed=h["wind_speed"],
+            air_temperature=h["air_temperature"],
+            dew_spread=h["dew_spread"],
+            symbol=h["symbol"],
+            fetched_at=now,
+        )
+        for site_id, hours in scored.items()
+        for h in hours
+    ]
+    session.add_all(new_rows)
+    return len(new_rows)
+
+
+def _persist_sites(scored: dict[str, list[dict]]) -> int:
+    """Write scored sites in a fresh session (runs off the event loop)."""
+    from app.db import get_engine
+
+    now = datetime.now(timezone.utc)
+    with Session(get_engine()) as session:
+        written = _write_sites(session, scored, now)
+        session.commit()
+    return written
+
+
+def _prune_elapsed(session: Session) -> int:
+    """Delete rows whose clock hour has elapsed. Returns rows deleted.
+
+    The cutoff is the top of the current UTC clock hour: rows whose hour_time is
+    strictly before it have elapsed. cutoff is tz-aware UTC, so the comparison
+    stays tz-aware against the TIMESTAMPTZ column.
+    """
+    cutoff = top_of_hour()
+    result = session.execute(delete(SiteHour).where(SiteHour.hour_time < cutoff))
+    return result.rowcount or 0
+
+
+def _run_prune() -> int:
+    """Prune elapsed hours in a fresh session (runs off the event loop)."""
+    from app.db import get_engine
+
+    with Session(get_engine()) as session:
+        deleted = _prune_elapsed(session)
+        session.commit()
+    return deleted
 
 
 async def refresh_handler(session: Session) -> datetime | None:
     """Refresh per-site dark-hour forecasts from met.no.
 
-    Fetch + score every seed site first (no session work during the network
-    phase). Then, for each site that fetched successfully, wholesale-replace its
-    rows: delete the site's existing hours and insert one row per scored hour.
-    Sites whose fetch failed are absent from ``scored`` and keep their previous
-    rows (stale beats empty). A total fetch failure writes nothing.
+    The network fetch + scoring runs first in the async handler; the synchronous
+    write is delegated to a worker thread with its own session. Sites whose fetch
+    failed keep their previous rows (stale beats empty); a total fetch failure
+    writes nothing.
     """
     scored = await fetch_all()
     if not scored:
         logger.warning("stars.refresh: empty fetch, keeping existing rows")
         return None
-
-    fetched_at = datetime.now(timezone.utc)
-    for site_id, hours in scored.items():
-        session.execute(delete(SiteHour).where(SiteHour.site_id == site_id))
-        for h in hours:
-            hour_time = datetime.fromisoformat(h["time"].replace("Z", "+00:00"))
-            session.add(
-                SiteHour(
-                    site_id=site_id,
-                    hour_time=hour_time,
-                    score=h["score"],
-                    cloud_area_fraction=h["cloud_area_fraction"],
-                    relative_humidity=h["relative_humidity"],
-                    wind_speed=h["wind_speed"],
-                    air_temperature=h["air_temperature"],
-                    dew_spread=h["dew_spread"],
-                    symbol=h["symbol"],
-                    fetched_at=fetched_at,
-                )
-            )
-    session.commit()
+    written = await asyncio.to_thread(_persist_sites, scored)
     logger.info(
-        "stars.refresh ok: refreshed %d/%d sites",
+        "stars.refresh ok: %d hours across %d/%d sites",
+        written,
         len(scored),
         len(SCOTLAND_DARK_SKY_LOCATIONS),
     )
@@ -69,14 +110,7 @@ async def refresh_handler(session: Session) -> datetime | None:
 
 
 async def prune_hours_handler(session: Session) -> datetime | None:
-    """Drop elapsed hours (housekeeping; the read endpoint also filters).
-
-    The cutoff is the top of the current UTC clock hour: rows whose hour_time
-    is strictly before it have elapsed and are removed. fetched_at is never
-    touched. cutoff is tz-aware UTC, so the comparison stays tz-aware.
-    """
-    cutoff = top_of_hour()
-    result = session.execute(delete(SiteHour).where(SiteHour.hour_time < cutoff))
-    session.commit()
-    logger.info("stars.prune_hours: deleted %s elapsed rows", result.rowcount)
+    """Drop elapsed hours (housekeeping; the read endpoint also filters)."""
+    deleted = await asyncio.to_thread(_run_prune)
+    logger.info("stars.prune_hours: deleted %d elapsed rows", deleted)
     return None

--- a/projects/monolith/stars/jobs_test.py
+++ b/projects/monolith/stars/jobs_test.py
@@ -1,9 +1,11 @@
-"""Unit tests for stars.jobs.refresh_handler on SQLite.
+"""Unit tests for stars.jobs DB cores on SQLite.
 
 Uses SQLModel.metadata.create_all (no migrations), mirroring stars/models_test.
-fetch_all is monkeypatched so no network call is made. The async handler is
-driven with asyncio.run inside a synchronous test, so no pytest-asyncio marker
-or plugin dependency is required.
+The async handlers delegate their DB work to synchronous cores (_write_sites,
+_prune_elapsed) via asyncio.to_thread with a fresh engine session, mirroring
+hikes.jobs / ships.retention. The cores take an explicit session so they are
+testable against the in-memory fixture; the thin async wrappers are not unit
+tested here (only the empty-fetch guard is, by monkeypatching the persist step).
 """
 
 import asyncio
@@ -53,14 +55,23 @@ def _hour(time_str, score=80.0):
     }
 
 
-def _patch_fetch_all(monkeypatch, scored):
-    async def _fake_fetch_all():
-        return scored
+def _seed_hour(session, site_id, hour_time, symbol="clearsky_night", score=70.0):
+    session.add(
+        SiteHour(
+            site_id=site_id,
+            hour_time=hour_time,
+            score=score,
+            cloud_area_fraction=10.0,
+            relative_humidity=60.0,
+            wind_speed=3.0,
+            air_temperature=8.0,
+            dew_spread=5.0,
+            symbol=symbol,
+        )
+    )
 
-    monkeypatch.setattr(jobs, "fetch_all", _fake_fetch_all)
 
-
-def test_refresh_inserts_rows_for_each_site(monkeypatch, session):
+def test_write_sites_inserts_rows_for_each_site(session):
     scored = {
         "galloway-forest": [_hour("2026-06-13T23:00:00Z", 90.0)],
         "tiree": [
@@ -68,10 +79,11 @@ def test_refresh_inserts_rows_for_each_site(monkeypatch, session):
             _hour("2026-06-13T23:00:00Z", 72.0),
         ],
     }
-    _patch_fetch_all(monkeypatch, scored)
+    now = datetime(2026, 6, 13, 21, tzinfo=timezone.utc)
 
-    result = asyncio.run(jobs.refresh_handler(session))
-    assert result is None
+    written = jobs._write_sites(session, scored, now)
+    session.commit()
+    assert written == 3
 
     rows = session.exec(select(SiteHour)).all()
     assert len(rows) == 3
@@ -81,102 +93,58 @@ def test_refresh_inserts_rows_for_each_site(monkeypatch, session):
         ("galloway-forest", datetime(2026, 6, 13, 23, tzinfo=timezone.utc)),
     )
     assert gf is not None
-    assert gf.site_id == "galloway-forest"
     assert gf.score == 90.0
-    assert gf.hour_time == datetime(2026, 6, 13, 23, tzinfo=timezone.utc)
-    assert gf.hour_time.tzinfo is not None
-    assert gf.fetched_at is not None
-    assert gf.fetched_at.tzinfo is not None
-
     # A single shared fetched_at is stamped across the whole run.
     assert len({r.fetched_at for r in rows}) == 1
 
 
-def test_refresh_empty_fetch_keeps_existing_rows(monkeypatch, session):
-    hour = datetime(2026, 6, 13, 21, tzinfo=timezone.utc)
-    session.add(
-        SiteHour(
-            site_id="X",
-            hour_time=hour,
-            score=88.0,
-            cloud_area_fraction=5.0,
-            relative_humidity=50.0,
-            wind_speed=2.0,
-            air_temperature=9.0,
-            dew_spread=6.0,
-            symbol="clearsky_night",
-        )
-    )
+def test_write_sites_leaves_unfetched_sites_untouched(session):
+    # Stale beats empty: the bulk delete only targets fetched site ids, so a
+    # site absent from the scored map keeps its previous rows.
+    kept = datetime(2026, 6, 13, 21, tzinfo=timezone.utc)
+    _seed_hour(session, "X", kept, symbol="old", score=88.0)
     session.commit()
 
-    _patch_fetch_all(monkeypatch, {})
+    now = datetime(2026, 6, 13, 22, tzinfo=timezone.utc)
+    jobs._write_sites(session, {"A": [_hour("2026-06-13T23:00:00Z", 90.0)]}, now)
+    session.commit()
 
-    result = asyncio.run(jobs.refresh_handler(session))
-    assert result is None
-
-    survivor = session.get(SiteHour, ("X", hour))
+    survivor = session.get(SiteHour, ("X", kept))
     assert survivor is not None
     assert survivor.score == 88.0
+    assert (
+        session.get(SiteHour, ("A", datetime(2026, 6, 13, 23, tzinfo=timezone.utc)))
+        is not None
+    )
 
 
-def test_refresh_replaces_site_rows_wholesale(monkeypatch, session):
+def test_write_sites_replaces_site_rows_wholesale(session):
     old_a = datetime(2026, 6, 13, 20, tzinfo=timezone.utc)
     old_b = datetime(2026, 6, 13, 21, tzinfo=timezone.utc)
-    for h in (old_a, old_b):
-        session.add(
-            SiteHour(
-                site_id="A",
-                hour_time=h,
-                score=50.0,
-                cloud_area_fraction=40.0,
-                relative_humidity=70.0,
-                wind_speed=4.0,
-                air_temperature=7.0,
-                dew_spread=4.0,
-                symbol="stale",
-            )
-        )
+    _seed_hour(session, "A", old_a, symbol="stale", score=50.0)
+    _seed_hour(session, "A", old_b, symbol="stale", score=50.0)
     session.commit()
 
+    now = datetime(2026, 6, 13, 22, tzinfo=timezone.utc)
     scored = {
         "A": [
             _hour("2026-06-13T23:00:00Z", 90.0),
             _hour("2026-06-14T00:00:00Z", 85.0),
         ]
     }
-    _patch_fetch_all(monkeypatch, scored)
-
-    asyncio.run(jobs.refresh_handler(session))
+    jobs._write_sites(session, scored, now)
+    session.commit()
 
     rows = session.exec(select(SiteHour).where(SiteHour.site_id == "A")).all()
     assert {r.hour_time for r in rows} == {
         datetime(2026, 6, 13, 23, tzinfo=timezone.utc),
         datetime(2026, 6, 14, 0, tzinfo=timezone.utc),
     }
-    # The stale rows are gone.
-    assert old_a not in {r.hour_time for r in rows}
     assert all(r.symbol == "clearsky_night" for r in rows)
 
 
-def _seed_hour(session, site_id, hour_time):
-    session.add(
-        SiteHour(
-            site_id=site_id,
-            hour_time=hour_time,
-            score=70.0,
-            cloud_area_fraction=10.0,
-            relative_humidity=60.0,
-            wind_speed=3.0,
-            air_temperature=8.0,
-            dew_spread=5.0,
-            symbol="clearsky_night",
-        )
-    )
-
-
-def test_prune_drops_only_elapsed_hours(session):
+def test_prune_elapsed_drops_only_elapsed_hours(session):
     cutoff = top_of_hour(datetime.now(timezone.utc))
-    # Two elapsed hours (strictly before the cutoff) and two current/future.
     past_a = cutoff - timedelta(hours=3)
     past_b = cutoff - timedelta(hours=1)
     current = cutoff
@@ -185,8 +153,29 @@ def test_prune_drops_only_elapsed_hours(session):
         _seed_hour(session, f"site-{i}", h)
     session.commit()
 
-    result = asyncio.run(jobs.prune_hours_handler(session))
-    assert result is None
+    deleted = jobs._prune_elapsed(session)
+    session.commit()
+    assert deleted == 2
 
     remaining = {r.hour_time for r in session.exec(select(SiteHour)).all()}
     assert remaining == {current, future}
+
+
+def test_refresh_handler_empty_fetch_is_noop(monkeypatch):
+    # When the fetch returns nothing, the handler must not touch the DB at all.
+    async def _empty_fetch():
+        return {}
+
+    called = False
+
+    def _should_not_run(scored):  # pragma: no cover - asserted not called
+        nonlocal called
+        called = True
+        return 0
+
+    monkeypatch.setattr(jobs, "fetch_all", _empty_fetch)
+    monkeypatch.setattr(jobs, "_persist_sites", _should_not_run)
+
+    result = asyncio.run(jobs.refresh_handler(None))
+    assert result is None
+    assert called is False

--- a/projects/monolith/stars/jobs_test.py
+++ b/projects/monolith/stars/jobs_test.py
@@ -42,6 +42,11 @@ def session_fixture():
                 table.schema = original_schemas[table.name]
 
 
+def _utc(dt):
+    """Coerce a loaded datetime to UTC-aware (SQLite returns naive values)."""
+    return dt if dt.tzinfo is not None else dt.replace(tzinfo=timezone.utc)
+
+
 def _hour(time_str, score=80.0):
     return {
         "time": time_str,
@@ -136,7 +141,7 @@ def test_write_sites_replaces_site_rows_wholesale(session):
     session.commit()
 
     rows = session.exec(select(SiteHour).where(SiteHour.site_id == "A")).all()
-    assert {r.hour_time for r in rows} == {
+    assert {_utc(r.hour_time) for r in rows} == {
         datetime(2026, 6, 13, 23, tzinfo=timezone.utc),
         datetime(2026, 6, 14, 0, tzinfo=timezone.utc),
     }
@@ -157,7 +162,7 @@ def test_prune_elapsed_drops_only_elapsed_hours(session):
     session.commit()
     assert deleted == 2
 
-    remaining = {r.hour_time for r in session.exec(select(SiteHour)).all()}
+    remaining = {_utc(r.hour_time) for r in session.exec(select(SiteHour)).all()}
     assert remaining == {current, future}
 
 

--- a/projects/monolith/stars/jobs_test.py
+++ b/projects/monolith/stars/jobs_test.py
@@ -1,0 +1,157 @@
+"""Unit tests for stars.jobs.refresh_handler on SQLite.
+
+Uses SQLModel.metadata.create_all (no migrations), mirroring stars/models_test.
+fetch_all is monkeypatched so no network call is made. The async handler is
+driven with asyncio.run inside a synchronous test, so no pytest-asyncio marker
+or plugin dependency is required.
+"""
+
+import asyncio
+from datetime import datetime, timezone
+
+import pytest
+from sqlmodel import Session, SQLModel, create_engine, select
+from sqlmodel.pool import StaticPool
+
+import stars.jobs as jobs
+from stars.models import SiteHour
+
+
+@pytest.fixture(name="session")
+def session_fixture():
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    original_schemas = {}
+    for table in SQLModel.metadata.tables.values():
+        if table.schema is not None:
+            original_schemas[table.name] = table.schema
+            table.schema = None
+    try:
+        SQLModel.metadata.create_all(engine)
+        with Session(engine) as session:
+            yield session
+    finally:
+        for table in SQLModel.metadata.tables.values():
+            if table.name in original_schemas:
+                table.schema = original_schemas[table.name]
+
+
+def _hour(time_str, score=80.0):
+    return {
+        "time": time_str,
+        "score": score,
+        "cloud_area_fraction": 10.0,
+        "relative_humidity": 60.0,
+        "wind_speed": 3.0,
+        "air_temperature": 8.0,
+        "dew_spread": 5.0,
+        "symbol": "clearsky_night",
+    }
+
+
+def _patch_fetch_all(monkeypatch, scored):
+    async def _fake_fetch_all():
+        return scored
+
+    monkeypatch.setattr(jobs, "fetch_all", _fake_fetch_all)
+
+
+def test_refresh_inserts_rows_for_each_site(monkeypatch, session):
+    scored = {
+        "galloway-forest": [_hour("2026-06-13T23:00:00Z", 90.0)],
+        "tiree": [
+            _hour("2026-06-13T22:00:00Z", 75.0),
+            _hour("2026-06-13T23:00:00Z", 72.0),
+        ],
+    }
+    _patch_fetch_all(monkeypatch, scored)
+
+    result = asyncio.run(jobs.refresh_handler(session))
+    assert result is None
+
+    rows = session.exec(select(SiteHour)).all()
+    assert len(rows) == 3
+
+    gf = session.get(
+        SiteHour,
+        ("galloway-forest", datetime(2026, 6, 13, 23, tzinfo=timezone.utc)),
+    )
+    assert gf is not None
+    assert gf.site_id == "galloway-forest"
+    assert gf.score == 90.0
+    assert gf.hour_time == datetime(2026, 6, 13, 23, tzinfo=timezone.utc)
+    assert gf.hour_time.tzinfo is not None
+    assert gf.fetched_at is not None
+    assert gf.fetched_at.tzinfo is not None
+
+    # A single shared fetched_at is stamped across the whole run.
+    assert len({r.fetched_at for r in rows}) == 1
+
+
+def test_refresh_empty_fetch_keeps_existing_rows(monkeypatch, session):
+    hour = datetime(2026, 6, 13, 21, tzinfo=timezone.utc)
+    session.add(
+        SiteHour(
+            site_id="X",
+            hour_time=hour,
+            score=88.0,
+            cloud_area_fraction=5.0,
+            relative_humidity=50.0,
+            wind_speed=2.0,
+            air_temperature=9.0,
+            dew_spread=6.0,
+            symbol="clearsky_night",
+        )
+    )
+    session.commit()
+
+    _patch_fetch_all(monkeypatch, {})
+
+    result = asyncio.run(jobs.refresh_handler(session))
+    assert result is None
+
+    survivor = session.get(SiteHour, ("X", hour))
+    assert survivor is not None
+    assert survivor.score == 88.0
+
+
+def test_refresh_replaces_site_rows_wholesale(monkeypatch, session):
+    old_a = datetime(2026, 6, 13, 20, tzinfo=timezone.utc)
+    old_b = datetime(2026, 6, 13, 21, tzinfo=timezone.utc)
+    for h in (old_a, old_b):
+        session.add(
+            SiteHour(
+                site_id="A",
+                hour_time=h,
+                score=50.0,
+                cloud_area_fraction=40.0,
+                relative_humidity=70.0,
+                wind_speed=4.0,
+                air_temperature=7.0,
+                dew_spread=4.0,
+                symbol="stale",
+            )
+        )
+    session.commit()
+
+    scored = {
+        "A": [
+            _hour("2026-06-13T23:00:00Z", 90.0),
+            _hour("2026-06-14T00:00:00Z", 85.0),
+        ]
+    }
+    _patch_fetch_all(monkeypatch, scored)
+
+    asyncio.run(jobs.refresh_handler(session))
+
+    rows = session.exec(select(SiteHour).where(SiteHour.site_id == "A")).all()
+    assert {r.hour_time for r in rows} == {
+        datetime(2026, 6, 13, 23, tzinfo=timezone.utc),
+        datetime(2026, 6, 14, 0, tzinfo=timezone.utc),
+    }
+    # The stale rows are gone.
+    assert old_a not in {r.hour_time for r in rows}
+    assert all(r.symbol == "clearsky_night" for r in rows)

--- a/projects/monolith/stars/jobs_test.py
+++ b/projects/monolith/stars/jobs_test.py
@@ -7,13 +7,14 @@ or plugin dependency is required.
 """
 
 import asyncio
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 import pytest
 from sqlmodel import Session, SQLModel, create_engine, select
 from sqlmodel.pool import StaticPool
 
 import stars.jobs as jobs
+from shared.forecast_freshness import top_of_hour
 from stars.models import SiteHour
 
 
@@ -155,3 +156,37 @@ def test_refresh_replaces_site_rows_wholesale(monkeypatch, session):
     # The stale rows are gone.
     assert old_a not in {r.hour_time for r in rows}
     assert all(r.symbol == "clearsky_night" for r in rows)
+
+
+def _seed_hour(session, site_id, hour_time):
+    session.add(
+        SiteHour(
+            site_id=site_id,
+            hour_time=hour_time,
+            score=70.0,
+            cloud_area_fraction=10.0,
+            relative_humidity=60.0,
+            wind_speed=3.0,
+            air_temperature=8.0,
+            dew_spread=5.0,
+            symbol="clearsky_night",
+        )
+    )
+
+
+def test_prune_drops_only_elapsed_hours(session):
+    cutoff = top_of_hour(datetime.now(timezone.utc))
+    # Two elapsed hours (strictly before the cutoff) and two current/future.
+    past_a = cutoff - timedelta(hours=3)
+    past_b = cutoff - timedelta(hours=1)
+    current = cutoff
+    future = cutoff + timedelta(hours=2)
+    for i, h in enumerate((past_a, past_b, current, future)):
+        _seed_hour(session, f"site-{i}", h)
+    session.commit()
+
+    result = asyncio.run(jobs.prune_hours_handler(session))
+    assert result is None
+
+    remaining = {r.hour_time for r in session.exec(select(SiteHour)).all()}
+    assert remaining == {current, future}

--- a/projects/monolith/stars/models.py
+++ b/projects/monolith/stars/models.py
@@ -1,0 +1,27 @@
+"""SQLModel definitions for the stars schema (curated dark-sky viewing windows).
+
+Mirrors chart/migrations/20260613000010_stars_schema.sql. One row per site-hour,
+keyed by (site_id, hour_time). Static site metadata (name/lat/lon/altitude/lp_zone)
+lives in stars/seed.py and is joined in at read time. The hourly prune job and the
+read endpoint both drop hours once their clock hour ends.
+"""
+
+from datetime import datetime, timezone
+
+from sqlmodel import Field, SQLModel
+
+
+class SiteHour(SQLModel, table=True):  # nosemgrep: sqlmodel-datetime-without-factory
+    __tablename__ = "site_hours"
+    __table_args__ = {"schema": "stars", "extend_existing": True}
+
+    site_id: str = Field(primary_key=True)
+    hour_time: datetime = Field(primary_key=True)
+    score: float
+    cloud_area_fraction: float
+    relative_humidity: float
+    wind_speed: float
+    air_temperature: float
+    dew_spread: float
+    symbol: str = ""
+    fetched_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))

--- a/projects/monolith/stars/models_test.py
+++ b/projects/monolith/stars/models_test.py
@@ -1,0 +1,108 @@
+"""Unit tests for stars.models: round-trip SiteHour on SQLite.
+
+Uses SQLModel.metadata.create_all (no migrations), mirroring the hikes tests.
+"""
+
+from datetime import datetime, timezone
+
+import pytest
+from sqlmodel import Session, SQLModel, create_engine, select
+from sqlmodel.pool import StaticPool
+
+from stars.models import SiteHour
+
+
+@pytest.fixture(name="session")
+def session_fixture():
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    original_schemas = {}
+    for table in SQLModel.metadata.tables.values():
+        if table.schema is not None:
+            original_schemas[table.name] = table.schema
+            table.schema = None
+    try:
+        SQLModel.metadata.create_all(engine)
+        with Session(engine) as session:
+            yield session
+    finally:
+        for table in SQLModel.metadata.tables.values():
+            if table.name in original_schemas:
+                table.schema = original_schemas[table.name]
+
+
+def test_site_hour_roundtrip(session):
+    hour = datetime(2026, 6, 13, 22, 0, 0, tzinfo=timezone.utc)
+    row = SiteHour(
+        site_id="galloway-forest",
+        hour_time=hour,
+        score=87.5,
+        cloud_area_fraction=10.0,
+        relative_humidity=60.0,
+        wind_speed=3.0,
+        air_temperature=8.0,
+        dew_spread=5.0,
+        symbol="clearsky_night",
+    )
+    session.add(row)
+    session.commit()
+
+    loaded = session.get(SiteHour, ("galloway-forest", hour))
+    assert loaded is not None
+    assert loaded.site_id == "galloway-forest"
+    assert loaded.score == 87.5
+    assert loaded.cloud_area_fraction == 10.0
+    assert loaded.relative_humidity == 60.0
+    assert loaded.wind_speed == 3.0
+    assert loaded.air_temperature == 8.0
+    assert loaded.dew_spread == 5.0
+    assert loaded.symbol == "clearsky_night"
+    assert isinstance(loaded.fetched_at, datetime)
+    assert loaded.fetched_at.tzinfo is not None
+    assert loaded.fetched_at.utcoffset() is not None
+
+
+def test_default_symbol_is_empty(session):
+    hour = datetime(2026, 6, 13, 23, 0, 0, tzinfo=timezone.utc)
+    row = SiteHour(
+        site_id="tiree",
+        hour_time=hour,
+        score=70.0,
+        cloud_area_fraction=20.0,
+        relative_humidity=65.0,
+        wind_speed=4.0,
+        air_temperature=9.0,
+        dew_spread=4.0,
+    )
+    session.add(row)
+    session.commit()
+
+    loaded = session.get(SiteHour, ("tiree", hour))
+    assert loaded is not None
+    assert loaded.symbol == ""
+
+
+def test_composite_primary_key_same_site_different_hours(session):
+    hour_a = datetime(2026, 6, 13, 22, 0, 0, tzinfo=timezone.utc)
+    hour_b = datetime(2026, 6, 13, 23, 0, 0, tzinfo=timezone.utc)
+    common = {
+        "site_id": "iona",
+        "score": 80.0,
+        "cloud_area_fraction": 15.0,
+        "relative_humidity": 62.0,
+        "wind_speed": 2.0,
+        "air_temperature": 7.0,
+        "dew_spread": 6.0,
+    }
+    session.add(SiteHour(hour_time=hour_a, **common))
+    session.add(SiteHour(hour_time=hour_b, **common))
+    session.commit()
+
+    rows = session.exec(
+        select(SiteHour).where(SiteHour.site_id == "iona")
+    ).all()
+    assert len(rows) == 2
+    assert {r.hour_time for r in rows} == {hour_a, hour_b}

--- a/projects/monolith/stars/models_test.py
+++ b/projects/monolith/stars/models_test.py
@@ -104,4 +104,11 @@ def test_composite_primary_key_same_site_different_hours(session):
 
     rows = session.exec(select(SiteHour).where(SiteHour.site_id == "iona")).all()
     assert len(rows) == 2
-    assert {r.hour_time for r in rows} == {hour_a, hour_b}
+    # SQLite returns naive datetimes; coerce to UTC-aware before comparing.
+    loaded = {
+        r.hour_time
+        if r.hour_time.tzinfo is not None
+        else r.hour_time.replace(tzinfo=timezone.utc)
+        for r in rows
+    }
+    assert loaded == {hour_a, hour_b}

--- a/projects/monolith/stars/models_test.py
+++ b/projects/monolith/stars/models_test.py
@@ -60,9 +60,10 @@ def test_site_hour_roundtrip(session):
     assert loaded.air_temperature == 8.0
     assert loaded.dew_spread == 5.0
     assert loaded.symbol == "clearsky_night"
+    # SQLite returns naive datetimes (no tz-aware type), so assert the type
+    # only, not tzinfo, matching hikes/models_test. Production is Postgres
+    # TIMESTAMPTZ, where the value round-trips tz-aware.
     assert isinstance(loaded.fetched_at, datetime)
-    assert loaded.fetched_at.tzinfo is not None
-    assert loaded.fetched_at.utcoffset() is not None
 
 
 def test_default_symbol_is_empty(session):

--- a/projects/monolith/stars/models_test.py
+++ b/projects/monolith/stars/models_test.py
@@ -101,8 +101,6 @@ def test_composite_primary_key_same_site_different_hours(session):
     session.add(SiteHour(hour_time=hour_b, **common))
     session.commit()
 
-    rows = session.exec(
-        select(SiteHour).where(SiteHour.site_id == "iona")
-    ).all()
+    rows = session.exec(select(SiteHour).where(SiteHour.site_id == "iona")).all()
     assert len(rows) == 2
     assert {r.hour_time for r in rows} == {hour_a, hour_b}

--- a/projects/monolith/stars/router.py
+++ b/projects/monolith/stars/router.py
@@ -1,3 +1,152 @@
-from fastapi import APIRouter
+"""Stars HTTP API. SSR-only: never added to httproute-public.yaml.
+
+One read endpoint backs the /app/stars dark-sky planner:
+
+- ``GET /api/stars/sites``, every curated Scotland dark-sky site joined with
+  its best upcoming viewing hours, for the site list + detail cards.
+
+Reached only from SvelteKit SSR (``http://localhost:8000`` in the same pod);
+the /app/stars page is the public surface and the CDN fans out to viewers, per
+ADR 002. Conditional GETs short-circuit with a 304 via ETag.
+
+The read-time hour filter (``hour_time >= top_of_hour(now)``) is the source of
+truth for "future windows": the endpoint never trusts the table to be already
+pruned. The hourly prune job is housekeeping only, so a stale row that has not
+been pruned yet is still excluded here.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, Depends, Request, Response
+from sqlmodel import Session, select
+
+from app.db import get_session
+from shared.forecast_freshness import top_of_hour
+from stars.models import SiteHour
+from stars.seed import SCOTLAND_DARK_SKY_LOCATIONS
+
+logger = logging.getLogger("stars")
 
 router = APIRouter(prefix="/api/stars", tags=["stars"])
+
+# Static site metadata, keyed by site id, joined into each row group at read time.
+_BY_ID = {loc["id"]: loc for loc in SCOTLAND_DARK_SKY_LOCATIONS}
+
+# Cap each site's hour list to the top N by score, so the payload stays light
+# even with a multi-day forecast horizon.
+_DISPLAY_HOURS = 8
+
+# Forecasts refresh hourly, so 30 min edge freshness with a 1 h SWR window is
+# plenty; max-age=0 makes the browser revalidate rather than hold a stale copy.
+# Mirrors STARS_SITES_CACHE_CONTROL in frontend/src/lib/cache-headers.js if/when
+# that constant is added; keep in sync.
+_SITES_CACHE_CONTROL = "public, max-age=0, s-maxage=1800, stale-while-revalidate=3600, stale-if-error=86400"
+
+
+def _as_utc(value: datetime | None) -> datetime | None:
+    """Coerce a datetime to tz-aware UTC.
+
+    Postgres returns tz-aware values; SQLite (used in tests) can return
+    naive ones even though we always write tz-aware UTC. Treat naive
+    datetimes as UTC so downstream formatters and ETag stamps are stable
+    across both backends.
+    """
+    if value is None:
+        return None
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+def _iso(value: datetime | None) -> str | None:
+    """ISO-8601 string in UTC, or None. Keeps the JSON consistent across backends."""
+    coerced = _as_utc(value)
+    return coerced.isoformat() if coerced is not None else None
+
+
+@router.get("/sites")
+def get_sites(
+    request: Request,
+    response: Response,
+    session: Session = Depends(get_session),
+):
+    """All curated dark-sky sites with their best upcoming hours. SSR-only, CDN-cached."""
+    now = datetime.now(timezone.utc)
+    cutoff = top_of_hour(now)
+
+    # Read-time correctness filter: only hours at or after the current clock
+    # hour. The prune job is best-effort housekeeping; the endpoint must not
+    # trust the table to be already pruned.
+    rows = session.exec(select(SiteHour).where(SiteHour.hour_time >= cutoff)).all()
+
+    by_site: dict[str, list[SiteHour]] = {}
+    max_fetched: datetime | None = None
+    for row in rows:
+        if row.fetched_at is not None and (
+            max_fetched is None or row.fetched_at > max_fetched
+        ):
+            max_fetched = row.fetched_at
+        by_site.setdefault(row.site_id, []).append(row)
+
+    sites = []
+    for site_id, hours in by_site.items():
+        meta = _BY_ID.get(site_id)
+        if meta is None:
+            # Defensive: the refresh job only writes seed ids, so this should
+            # not happen. Skip rather than emit a site with no metadata.
+            logger.debug("stars: skipping unknown site_id %s", site_id)
+            continue
+
+        best_score = max(h.score for h in hours)
+        best_hours = [
+            {
+                "time": _iso(h.hour_time),
+                "score": h.score,
+                "cloud_area_fraction": h.cloud_area_fraction,
+                "relative_humidity": h.relative_humidity,
+                "wind_speed": h.wind_speed,
+                "air_temperature": h.air_temperature,
+                "dew_spread": h.dew_spread,
+                "symbol": h.symbol,
+            }
+            for h in sorted(hours, key=lambda h: h.score, reverse=True)[:_DISPLAY_HOURS]
+        ]
+        sites.append(
+            {
+                "id": meta["id"],
+                "name": meta["name"],
+                "lat": meta["lat"],
+                "lon": meta["lon"],
+                "altitude_m": meta["altitude_m"],
+                "lp_zone": meta["lp_zone"],
+                "best_score": best_score,
+                "best_hours": best_hours,
+            }
+        )
+
+    sites.sort(key=lambda s: s["best_score"], reverse=True)
+
+    # The ETag folds in the current clock hour so the CDN turns over hourly even
+    # when fetched_at has not changed: as hours fall past the cutoff the payload
+    # shrinks, and the cutoff token forces a revalidation at each hour boundary.
+    max_fetched_utc = _as_utc(max_fetched)
+    etag = (
+        f'"v1-{cutoff.isoformat()}-'
+        f'{max_fetched_utc.isoformat() if max_fetched_utc else "none"}-{len(sites)}"'
+    )
+    headers = {"Cache-Control": _SITES_CACHE_CONTROL, "ETag": etag}
+
+    if request.headers.get("if-none-match") == etag:
+        return Response(status_code=304, headers=headers)
+
+    for key, value in headers.items():
+        response.headers[key] = value
+    return {
+        "sites": sites,
+        "count": len(sites),
+        "total_sites": len(SCOTLAND_DARK_SKY_LOCATIONS),
+        "fetched_at": _iso(max_fetched),
+    }

--- a/projects/monolith/stars/router.py
+++ b/projects/monolith/stars/router.py
@@ -1,0 +1,3 @@
+from fastapi import APIRouter
+
+router = APIRouter(prefix="/api/stars", tags=["stars"])

--- a/projects/monolith/stars/router_test.py
+++ b/projects/monolith/stars/router_test.py
@@ -1,0 +1,175 @@
+"""Unit tests for stars/router.py: /api/stars/sites.
+
+Uses an in-memory SQLite DB seeded with real seed ids and a minimal FastAPI app
+that mounts only the stars router, mirroring the schema-stripping +
+``app.dependency_overrides[get_session]`` pattern in ``ships/router_test.py``
+and ``hikes/router_test.py``.
+
+Timestamps are computed relative to ``top_of_hour(datetime.now(timezone.utc))``
+so the read-time ``hour_time >= cutoff`` filter behaves the same regardless of
+when the suite runs (no hour-boundary flakiness).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlmodel import Session, SQLModel, create_engine
+from sqlmodel.pool import StaticPool
+
+from app.db import get_session
+from shared.forecast_freshness import top_of_hour
+from stars.models import SiteHour
+from stars.router import _SITES_CACHE_CONTROL, router
+from stars.seed import SCOTLAND_DARK_SKY_LOCATIONS
+
+CUTOFF = top_of_hour(datetime.now(timezone.utc))
+FETCHED = CUTOFF - timedelta(minutes=10)
+
+
+@pytest.fixture(name="session")
+def session_fixture():
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    # SQLite can't span schemas, so strip the Postgres-only schema= overrides so
+    # SQLModel.metadata.create_all() lands every table in the default schema.
+    original_schemas = {}
+    for table in SQLModel.metadata.tables.values():
+        if table.schema is not None:
+            original_schemas[table.name] = table.schema
+            table.schema = None
+    try:
+        SQLModel.metadata.create_all(engine)
+        with Session(engine) as session:
+            yield session
+    finally:
+        for table in SQLModel.metadata.tables.values():
+            if table.name in original_schemas:
+                table.schema = original_schemas[table.name]
+
+
+@pytest.fixture(name="client")
+def client_fixture(session):
+    app = FastAPI()
+    app.include_router(router)
+    app.dependency_overrides[get_session] = lambda: session
+    yield TestClient(app)
+    app.dependency_overrides.clear()
+
+
+def _hour(
+    site_id: str,
+    offset_hours: int,
+    score: float,
+) -> SiteHour:
+    """A SiteHour for ``site_id`` at cutoff + offset_hours, with a given score."""
+    return SiteHour(
+        site_id=site_id,
+        hour_time=CUTOFF + timedelta(hours=offset_hours),
+        score=score,
+        cloud_area_fraction=10.0,
+        relative_humidity=70.0,
+        wind_speed=3.0,
+        air_temperature=8.0,
+        dew_spread=2.0,
+        symbol="clearsky_night",
+        fetched_at=FETCHED,
+    )
+
+
+class TestSites:
+    def test_ordering_by_best_score(self, client, session):
+        # galloway-forest peaks at 0.9; tomintoul peaks at 0.5.
+        session.add(_hour("galloway-forest", 1, 0.7))
+        session.add(_hour("galloway-forest", 2, 0.9))
+        session.add(_hour("tomintoul", 1, 0.5))
+        session.add(_hour("tomintoul", 2, 0.3))
+        session.commit()
+
+        r = client.get("/api/stars/sites")
+        assert r.status_code == 200
+        body = r.json()
+        assert body["count"] == 2
+        ids = [s["id"] for s in body["sites"]]
+        assert ids == ["galloway-forest", "tomintoul"]
+        assert body["sites"][0]["best_score"] == 0.9
+        # Metadata is joined in from the seed list.
+        assert body["sites"][0]["name"] == "Galloway Forest Park"
+        assert body["sites"][0]["lp_zone"] == "1a"
+
+    def test_past_hours_omitted(self, client, session):
+        # galloway-forest has only past hours -> excluded entirely.
+        session.add(_hour("galloway-forest", -1, 0.9))
+        session.add(_hour("galloway-forest", -2, 0.8))
+        # tomintoul has a mix: only its future hours come back.
+        session.add(_hour("tomintoul", -1, 0.95))
+        session.add(_hour("tomintoul", 1, 0.4))
+        session.add(_hour("tomintoul", 2, 0.6))
+        session.commit()
+
+        r = client.get("/api/stars/sites")
+        assert r.status_code == 200
+        body = r.json()
+        assert body["count"] == 1
+        assert [s["id"] for s in body["sites"]] == ["tomintoul"]
+        tomintoul = body["sites"][0]
+        # Only the two future hours; the past hour (and its higher score) is gone.
+        assert len(tomintoul["best_hours"]) == 2
+        assert tomintoul["best_score"] == 0.6
+        future_times = {
+            (CUTOFF + timedelta(hours=1)).isoformat(),
+            (CUTOFF + timedelta(hours=2)).isoformat(),
+        }
+        assert {h["time"] for h in tomintoul["best_hours"]} == future_times
+
+    def test_cache_and_etag_headers(self, client, session):
+        session.add(_hour("galloway-forest", 1, 0.7))
+        session.commit()
+        r = client.get("/api/stars/sites")
+        assert r.status_code == 200
+        assert r.headers["Cache-Control"] == _SITES_CACHE_CONTROL
+        assert r.headers["ETag"]
+
+    def test_conditional_get_returns_304(self, client, session):
+        session.add(_hour("galloway-forest", 1, 0.7))
+        session.commit()
+        first = client.get("/api/stars/sites")
+        etag = first.headers["ETag"]
+        second = client.get("/api/stars/sites", headers={"If-None-Match": etag})
+        assert second.status_code == 304
+        assert second.headers["ETag"] == etag
+        assert second.headers["Cache-Control"]
+        assert second.content == b""
+
+    def test_empty_table(self, client):
+        r = client.get("/api/stars/sites")
+        assert r.status_code == 200
+        assert r.json() == {
+            "sites": [],
+            "count": 0,
+            "total_sites": len(SCOTLAND_DARK_SKY_LOCATIONS),
+            "fetched_at": None,
+        }
+
+    def test_best_hours_capped_at_eight(self, client, session):
+        # 12 future hours with ascending scores; expect the top 8 by score.
+        for i in range(12):
+            session.add(_hour("galloway-forest", i + 1, score=i / 100.0))
+        session.commit()
+
+        r = client.get("/api/stars/sites")
+        assert r.status_code == 200
+        body = r.json()
+        assert body["count"] == 1
+        best_hours = body["sites"][0]["best_hours"]
+        assert len(best_hours) == 8
+        scores = [h["score"] for h in best_hours]
+        # Sorted descending, and exactly the 8 highest (0.11 .. 0.04).
+        assert scores == sorted(scores, reverse=True)
+        assert scores == [0.11, 0.10, 0.09, 0.08, 0.07, 0.06, 0.05, 0.04]

--- a/projects/monolith/stars/scoring.py
+++ b/projects/monolith/stars/scoring.py
@@ -1,0 +1,99 @@
+"""Astronomy suitability scoring for weather forecasts.
+
+Ported verbatim from projects/stargazer/backend/scoring.py: pure functions,
+no I/O, no external deps beyond pydantic. Behaviour parity is asserted by
+the corresponding scoring_test.py also ported from stargazer.
+"""
+
+from pydantic import BaseModel, Field
+
+
+class WeatherData(BaseModel):
+    """Weather data from MET Norway API."""
+
+    cloud_area_fraction: float = Field(ge=0, le=100)
+    relative_humidity: float = Field(ge=0, le=100)
+    fog_area_fraction: float = Field(default=0, ge=0, le=100)
+    wind_speed: float = Field(ge=0)
+    air_temperature: float
+    dew_point_temperature: float
+    air_pressure_at_sea_level: float = Field(default=1013.25)
+
+
+class ScoredForecast(BaseModel):
+    """Forecast with astronomy suitability score."""
+
+    time: str
+    score: float = Field(ge=0, le=100)
+    cloud_area_fraction: float
+    relative_humidity: float
+    fog_area_fraction: float
+    wind_speed: float
+    air_temperature: float
+    dew_spread: float
+    air_pressure: float
+    symbol: str = ""
+
+
+def calculate_astronomy_score(weather: WeatherData) -> float:
+    """Calculate astronomy suitability score (0-100).
+
+    Weights: cloud 50%, humidity 15%, fog 10%, wind 10%, dew 15%, pressure +0-10 bonus.
+    """
+    if weather.cloud_area_fraction < 20:
+        cloud_score = 100
+    elif weather.cloud_area_fraction < 50:
+        cloud_score = 100 - (weather.cloud_area_fraction - 20) * 1.67
+    else:
+        cloud_score = max(0, 50 - (weather.cloud_area_fraction - 50))
+
+    if weather.relative_humidity < 70:
+        humidity_score = 100
+    elif weather.relative_humidity < 85:
+        humidity_score = 100 - (weather.relative_humidity - 70) * 3.33
+    else:
+        humidity_score = max(0, 50 - (weather.relative_humidity - 85) * 3.33)
+
+    if weather.fog_area_fraction < 5:
+        fog_score = 100
+    elif weather.fog_area_fraction < 20:
+        fog_score = 100 - (weather.fog_area_fraction - 5) * 3.33
+    else:
+        fog_score = max(0, 50 - (weather.fog_area_fraction - 20) * 1.67)
+
+    if weather.wind_speed < 5:
+        wind_score = 100
+    elif weather.wind_speed < 10:
+        wind_score = 100 - (weather.wind_speed - 5) * 10
+    else:
+        wind_score = max(0, 50 - (weather.wind_speed - 10) * 5)
+
+    dew_spread = weather.air_temperature - weather.dew_point_temperature
+    if dew_spread > 5:
+        dew_score = 100
+    elif dew_spread > 2:
+        dew_score = 100 - (5 - dew_spread) * 16.67
+    else:
+        dew_score = max(0, 50 - (2 - dew_spread) * 25)
+
+    pressure_bonus = 0
+    if weather.air_pressure_at_sea_level > 1015:
+        pressure_bonus = min(10, (weather.air_pressure_at_sea_level - 1015) * 2)
+
+    weighted = (
+        cloud_score * 0.50
+        + humidity_score * 0.15
+        + fog_score * 0.10
+        + wind_score * 0.10
+        + dew_score * 0.15
+        + pressure_bonus
+    )
+    return min(100, max(0, weighted))
+
+
+def is_dark_enough(
+    sun_altitude: float,
+    astronomical_darkness_threshold: float = -18.0,
+) -> bool:
+    """Astronomical darkness: sun > 18° below horizon."""
+    return sun_altitude <= astronomical_darkness_threshold

--- a/projects/monolith/stars/scoring_test.py
+++ b/projects/monolith/stars/scoring_test.py
@@ -1,0 +1,310 @@
+"""Unit tests for stars.scoring (ported from projects/stargazer/backend/scoring_test.py)."""
+
+import pytest
+
+from stars.scoring import (
+    ScoredForecast,
+    WeatherData,
+    calculate_astronomy_score,
+    is_dark_enough,
+)
+
+
+class TestWeatherDataValidation:
+    def test_accepts_valid_data(self):
+        w = WeatherData(
+            cloud_area_fraction=10.0,
+            relative_humidity=60.0,
+            wind_speed=3.0,
+            air_temperature=10.0,
+            dew_point_temperature=5.0,
+        )
+        assert w.cloud_area_fraction == 10.0
+
+    def test_fog_defaults_to_zero(self):
+        w = WeatherData(
+            cloud_area_fraction=50.0,
+            relative_humidity=70.0,
+            wind_speed=5.0,
+            air_temperature=10.0,
+            dew_point_temperature=5.0,
+        )
+        assert w.fog_area_fraction == 0.0
+
+    def test_pressure_defaults_to_standard(self):
+        w = WeatherData(
+            cloud_area_fraction=50.0,
+            relative_humidity=70.0,
+            wind_speed=5.0,
+            air_temperature=10.0,
+            dew_point_temperature=5.0,
+        )
+        assert w.air_pressure_at_sea_level == 1013.25
+
+    def test_rejects_negative_cloud_fraction(self):
+        with pytest.raises(ValueError):
+            WeatherData(
+                cloud_area_fraction=-1.0,
+                relative_humidity=50.0,
+                wind_speed=5.0,
+                air_temperature=10.0,
+                dew_point_temperature=5.0,
+            )
+
+    def test_rejects_cloud_fraction_over_100(self):
+        with pytest.raises(ValueError):
+            WeatherData(
+                cloud_area_fraction=101.0,
+                relative_humidity=50.0,
+                wind_speed=5.0,
+                air_temperature=10.0,
+                dew_point_temperature=5.0,
+            )
+
+    def test_rejects_negative_humidity(self):
+        with pytest.raises(ValueError):
+            WeatherData(
+                cloud_area_fraction=50.0,
+                relative_humidity=-5.0,
+                wind_speed=5.0,
+                air_temperature=10.0,
+                dew_point_temperature=5.0,
+            )
+
+    def test_rejects_humidity_over_100(self):
+        with pytest.raises(ValueError):
+            WeatherData(
+                cloud_area_fraction=50.0,
+                relative_humidity=105.0,
+                wind_speed=5.0,
+                air_temperature=10.0,
+                dew_point_temperature=5.0,
+            )
+
+    def test_rejects_negative_wind_speed(self):
+        with pytest.raises(ValueError):
+            WeatherData(
+                cloud_area_fraction=50.0,
+                relative_humidity=50.0,
+                wind_speed=-1.0,
+                air_temperature=10.0,
+                dew_point_temperature=5.0,
+            )
+
+    def test_accepts_zero_wind_speed(self):
+        w = WeatherData(
+            cloud_area_fraction=50.0,
+            relative_humidity=50.0,
+            wind_speed=0.0,
+            air_temperature=10.0,
+            dew_point_temperature=5.0,
+        )
+        assert w.wind_speed == 0.0
+
+    def test_accepts_boundary_cloud_values(self):
+        w_clear = WeatherData(
+            cloud_area_fraction=0.0,
+            relative_humidity=50.0,
+            wind_speed=5.0,
+            air_temperature=10.0,
+            dew_point_temperature=5.0,
+        )
+        assert w_clear.cloud_area_fraction == 0.0
+
+        w_overcast = WeatherData(
+            cloud_area_fraction=100.0,
+            relative_humidity=50.0,
+            wind_speed=5.0,
+            air_temperature=10.0,
+            dew_point_temperature=5.0,
+        )
+        assert w_overcast.cloud_area_fraction == 100.0
+
+    def test_negative_temperature_is_valid(self):
+        w = WeatherData(
+            cloud_area_fraction=10.0,
+            relative_humidity=50.0,
+            wind_speed=3.0,
+            air_temperature=-10.0,
+            dew_point_temperature=-15.0,
+        )
+        assert w.air_temperature == -10.0
+
+
+class TestScoredForecastModel:
+    def test_accepts_valid_scored_forecast(self):
+        sf = ScoredForecast(
+            time="2024-01-15T22:00:00Z",
+            score=85.0,
+            cloud_area_fraction=10.0,
+            relative_humidity=60.0,
+            fog_area_fraction=0.0,
+            wind_speed=3.0,
+            air_temperature=8.0,
+            dew_spread=5.0,
+            air_pressure=1018.0,
+        )
+        assert sf.score == 85.0
+        assert sf.symbol == ""
+
+    def test_score_must_be_0_to_100(self):
+        with pytest.raises(ValueError):
+            ScoredForecast(
+                time="2024-01-15T22:00:00Z",
+                score=101.0,
+                cloud_area_fraction=10.0,
+                relative_humidity=60.0,
+                fog_area_fraction=0.0,
+                wind_speed=3.0,
+                air_temperature=8.0,
+                dew_spread=5.0,
+                air_pressure=1018.0,
+            )
+
+
+class TestCalculateAstronomyScore:
+    def _make_weather(self, **kwargs) -> WeatherData:
+        defaults = {
+            "cloud_area_fraction": 0.0,
+            "relative_humidity": 40.0,
+            "fog_area_fraction": 0.0,
+            "wind_speed": 2.0,
+            "air_temperature": 15.0,
+            "dew_point_temperature": 5.0,
+            "air_pressure_at_sea_level": 1030.0,
+        }
+        defaults.update(kwargs)
+        return WeatherData(**defaults)
+
+    def test_score_always_in_0_to_100_range(self):
+        worst = self._make_weather(
+            cloud_area_fraction=100.0,
+            relative_humidity=100.0,
+            fog_area_fraction=100.0,
+            wind_speed=100.0,
+            air_temperature=0.0,
+            dew_point_temperature=0.0,
+            air_pressure_at_sea_level=900.0,
+        )
+        assert 0.0 <= calculate_astronomy_score(worst) <= 100.0
+        best = self._make_weather()
+        assert 0.0 <= calculate_astronomy_score(best) <= 100.0
+
+    def test_ideal_conditions_score_near_100(self):
+        score = calculate_astronomy_score(self._make_weather())
+        assert score >= 95.0
+
+    def test_full_cloud_cover_penalises_heavily(self):
+        clear_score = calculate_astronomy_score(
+            self._make_weather(cloud_area_fraction=0.0)
+        )
+        cloudy_score = calculate_astronomy_score(
+            self._make_weather(cloud_area_fraction=100.0)
+        )
+        assert clear_score - cloudy_score >= 40.0
+
+    def test_high_humidity_penalises_score(self):
+        score_low = calculate_astronomy_score(
+            self._make_weather(relative_humidity=50.0)
+        )
+        score_high = calculate_astronomy_score(
+            self._make_weather(relative_humidity=95.0)
+        )
+        assert score_low > score_high
+
+    def test_calm_wind_better_than_strong_wind(self):
+        base = {
+            "cloud_area_fraction": 30.0,
+            "relative_humidity": 75.0,
+            "fog_area_fraction": 5.0,
+            "air_temperature": 10.0,
+            "dew_point_temperature": 7.0,
+            "air_pressure_at_sea_level": 1013.0,
+        }
+        calm = calculate_astronomy_score(self._make_weather(wind_speed=2.0, **base))
+        strong = calculate_astronomy_score(self._make_weather(wind_speed=20.0, **base))
+        assert calm > strong
+
+    def test_good_dew_spread_scores_higher(self):
+        good = self._make_weather(air_temperature=15.0, dew_point_temperature=5.0)
+        poor = self._make_weather(air_temperature=10.0, dew_point_temperature=9.5)
+        assert calculate_astronomy_score(good) > calculate_astronomy_score(poor)
+
+    def test_high_pressure_gives_bonus(self):
+        low_p = self._make_weather(
+            cloud_area_fraction=30.0, air_pressure_at_sea_level=1005.0
+        )
+        high_p = self._make_weather(
+            cloud_area_fraction=30.0, air_pressure_at_sea_level=1025.0
+        )
+        assert calculate_astronomy_score(high_p) > calculate_astronomy_score(low_p)
+
+    def test_pressure_bonus_capped_at_10(self):
+        moderate = self._make_weather(
+            cloud_area_fraction=50.0, air_pressure_at_sea_level=1020.0
+        )
+        extreme = self._make_weather(
+            cloud_area_fraction=50.0, air_pressure_at_sea_level=1100.0
+        )
+        assert calculate_astronomy_score(extreme) == pytest.approx(
+            calculate_astronomy_score(moderate), abs=0.1
+        )
+
+    def test_score_capped_at_100(self):
+        perfect = self._make_weather(air_pressure_at_sea_level=9999.0)
+        assert calculate_astronomy_score(perfect) <= 100.0
+
+    def test_score_clamped_at_0(self):
+        terrible = WeatherData(
+            cloud_area_fraction=100.0,
+            relative_humidity=100.0,
+            fog_area_fraction=100.0,
+            wind_speed=100.0,
+            air_temperature=0.0,
+            dew_point_temperature=10.0,
+            air_pressure_at_sea_level=900.0,
+        )
+        assert calculate_astronomy_score(terrible) >= 0.0
+
+    def test_weighted_average_components(self):
+        base = WeatherData(
+            cloud_area_fraction=0.0,
+            relative_humidity=40.0,
+            fog_area_fraction=0.0,
+            wind_speed=2.0,
+            air_temperature=15.0,
+            dew_point_temperature=5.0,
+            air_pressure_at_sea_level=1013.0,
+        )
+        all_cloud = WeatherData(
+            cloud_area_fraction=100.0,
+            relative_humidity=40.0,
+            fog_area_fraction=0.0,
+            wind_speed=2.0,
+            air_temperature=15.0,
+            dew_point_temperature=5.0,
+            air_pressure_at_sea_level=1013.0,
+        )
+        diff = calculate_astronomy_score(base) - calculate_astronomy_score(all_cloud)
+        assert 40.0 <= diff <= 60.0
+
+
+class TestIsDarkEnough:
+    def test_sun_at_minus_18_is_dark(self):
+        assert is_dark_enough(-18.0) is True
+
+    def test_sun_below_minus_18_is_dark(self):
+        assert is_dark_enough(-20.0) is True
+
+    def test_sun_just_above_threshold_is_not_dark(self):
+        assert is_dark_enough(-17.9) is False
+
+    def test_nautical_twilight_not_dark(self):
+        assert is_dark_enough(-12.0) is False
+
+    def test_daytime_not_dark(self):
+        assert is_dark_enough(0.0) is False
+
+    def test_custom_threshold_civil(self):
+        assert is_dark_enough(-6.0, astronomical_darkness_threshold=-6.0) is True
+        assert is_dark_enough(-5.9, astronomical_darkness_threshold=-6.0) is False

--- a/projects/monolith/stars/seed.py
+++ b/projects/monolith/stars/seed.py
@@ -1,0 +1,276 @@
+"""Hand-curated dark-sky locations in Scotland.
+
+Replaces stargazer's geospatial pipeline (LP atlas + OSM roads + DEM → grid
+of ~500 sample points) with a curated seed list. The shape matches the
+original ``sample_points_enriched.geojson`` rows (id/lat/lon/altitude_m/lp_zone)
+plus a human-readable ``name`` so the UI can label results.
+
+Coverage targets the recognised dark-sky destinations: International Dark Sky
+Park designations (Galloway Forest, Tomintoul-Glenlivet), Dark Sky Communities
+(Coll), and well-known remote viewing spots across the Highlands, Islands,
+and Borders. ``lp_zone`` is the DJ Lorenz Light Pollution Atlas band (1a-3a
+covers natural-sky-dominant areas; 1a is the darkest).
+"""
+
+from typing import TypedDict
+
+
+class SeedLocation(TypedDict):
+    id: str
+    name: str
+    lat: float
+    lon: float
+    altitude_m: int
+    lp_zone: str
+
+
+SCOTLAND_DARK_SKY_LOCATIONS: list[SeedLocation] = [
+    # Galloway Forest: International Dark Sky Park (2009)
+    {
+        "id": "galloway-forest",
+        "name": "Galloway Forest Park",
+        "lat": 55.083,
+        "lon": -4.500,
+        "altitude_m": 110,
+        "lp_zone": "1a",
+    },
+    {
+        "id": "bruces-stone",
+        "name": "Bruce's Stone, Loch Trool",
+        "lat": 55.083,
+        "lon": -4.483,
+        "altitude_m": 130,
+        "lp_zone": "1a",
+    },
+    {
+        "id": "loch-doon",
+        "name": "Loch Doon",
+        "lat": 55.244,
+        "lon": -4.392,
+        "altitude_m": 240,
+        "lp_zone": "1b",
+    },
+    {
+        "id": "clatteringshaws",
+        "name": "Clatteringshaws Loch",
+        "lat": 55.063,
+        "lon": -4.290,
+        "altitude_m": 200,
+        "lp_zone": "1a",
+    },
+    # Cairngorms / Tomintoul-Glenlivet: International Dark Sky Park (2018)
+    {
+        "id": "tomintoul",
+        "name": "Tomintoul",
+        "lat": 57.249,
+        "lon": -3.371,
+        "altitude_m": 345,
+        "lp_zone": "1a",
+    },
+    {
+        "id": "glenlivet",
+        "name": "Glenlivet",
+        "lat": 57.349,
+        "lon": -3.302,
+        "altitude_m": 260,
+        "lp_zone": "1a",
+    },
+    {
+        "id": "glen-tanar",
+        "name": "Glen Tanar, Cairngorms",
+        "lat": 57.040,
+        "lon": -2.870,
+        "altitude_m": 220,
+        "lp_zone": "1b",
+    },
+    {
+        "id": "glenmore-forest",
+        "name": "Glenmore Forest, Cairngorms",
+        "lat": 57.166,
+        "lon": -3.690,
+        "altitude_m": 320,
+        "lp_zone": "1b",
+    },
+    {
+        "id": "loch-morlich",
+        "name": "Loch Morlich",
+        "lat": 57.166,
+        "lon": -3.706,
+        "altitude_m": 305,
+        "lp_zone": "1b",
+    },
+    # West Highlands
+    {
+        "id": "glen-affric",
+        "name": "Glen Affric",
+        "lat": 57.282,
+        "lon": -4.918,
+        "altitude_m": 250,
+        "lp_zone": "1a",
+    },
+    {
+        "id": "glen-coe",
+        "name": "Glen Coe",
+        "lat": 56.673,
+        "lon": -4.989,
+        "altitude_m": 100,
+        "lp_zone": "1b",
+    },
+    {
+        "id": "rannoch-moor",
+        "name": "Rannoch Moor",
+        "lat": 56.626,
+        "lon": -4.687,
+        "altitude_m": 320,
+        "lp_zone": "1a",
+    },
+    {
+        "id": "knoydart",
+        "name": "Knoydart",
+        "lat": 57.040,
+        "lon": -5.700,
+        "altitude_m": 50,
+        "lp_zone": "1a",
+    },
+    # Inner Hebrides
+    {
+        "id": "isle-of-coll",
+        "name": "Isle of Coll (Dark Sky Community)",
+        "lat": 56.620,
+        "lon": -6.550,
+        "altitude_m": 30,
+        "lp_zone": "1a",
+    },
+    {
+        "id": "tiree",
+        "name": "Tiree",
+        "lat": 56.504,
+        "lon": -6.880,
+        "altitude_m": 15,
+        "lp_zone": "1a",
+    },
+    {
+        "id": "mull-dervaig",
+        "name": "Mull (Dervaig)",
+        "lat": 56.589,
+        "lon": -6.182,
+        "altitude_m": 30,
+        "lp_zone": "1a",
+    },
+    {
+        "id": "iona",
+        "name": "Iona",
+        "lat": 56.330,
+        "lon": -6.396,
+        "altitude_m": 20,
+        "lp_zone": "1a",
+    },
+    {
+        "id": "skye-trotternish",
+        "name": "Skye (Trotternish)",
+        "lat": 57.580,
+        "lon": -6.180,
+        "altitude_m": 100,
+        "lp_zone": "1a",
+    },
+    # Outer Hebrides
+    {
+        "id": "north-uist",
+        "name": "North Uist",
+        "lat": 57.595,
+        "lon": -7.319,
+        "altitude_m": 20,
+        "lp_zone": "1a",
+    },
+    {
+        "id": "lewis-callanish",
+        "name": "Lewis (Callanish)",
+        "lat": 58.195,
+        "lon": -6.745,
+        "altitude_m": 30,
+        "lp_zone": "1a",
+    },
+    {
+        "id": "harris-luskentyre",
+        "name": "Harris (Luskentyre)",
+        "lat": 57.881,
+        "lon": -6.945,
+        "altitude_m": 10,
+        "lp_zone": "1a",
+    },
+    {
+        "id": "barra",
+        "name": "Barra",
+        "lat": 56.978,
+        "lon": -7.477,
+        "altitude_m": 15,
+        "lp_zone": "1a",
+    },
+    # Northern Highlands
+    {
+        "id": "assynt",
+        "name": "Assynt",
+        "lat": 58.158,
+        "lon": -5.066,
+        "altitude_m": 130,
+        "lp_zone": "1a",
+    },
+    {
+        "id": "cape-wrath",
+        "name": "Cape Wrath",
+        "lat": 58.552,
+        "lon": -4.957,
+        "altitude_m": 50,
+        "lp_zone": "1a",
+    },
+    {
+        "id": "dunnet-head",
+        "name": "Dunnet Head, Caithness",
+        "lat": 58.671,
+        "lon": -3.376,
+        "altitude_m": 100,
+        "lp_zone": "1a",
+    },
+    # Orkney + Shetland
+    {
+        "id": "orkney-birsay",
+        "name": "Orkney (Birsay)",
+        "lat": 59.130,
+        "lon": -3.279,
+        "altitude_m": 25,
+        "lp_zone": "1a",
+    },
+    {
+        "id": "orkney-hoy",
+        "name": "Orkney (Hoy)",
+        "lat": 58.851,
+        "lon": -3.297,
+        "altitude_m": 60,
+        "lp_zone": "1a",
+    },
+    {
+        "id": "shetland-mainland",
+        "name": "Shetland (South Mainland)",
+        "lat": 60.299,
+        "lon": -1.342,
+        "altitude_m": 30,
+        "lp_zone": "1a",
+    },
+    {
+        "id": "shetland-unst",
+        "name": "Unst, Shetland",
+        "lat": 60.756,
+        "lon": -0.831,
+        "altitude_m": 50,
+        "lp_zone": "1a",
+    },
+    # Borders / South-East
+    {
+        "id": "moffat",
+        "name": "Moffat (Dark Sky Town)",
+        "lat": 55.331,
+        "lon": -3.443,
+        "altitude_m": 110,
+        "lp_zone": "2a",
+    },
+]

--- a/projects/monolith/stars/seed_test.py
+++ b/projects/monolith/stars/seed_test.py
@@ -1,0 +1,27 @@
+"""Unit tests for stars.seed: structural invariants of the dark-sky seed list."""
+
+from stars.seed import SCOTLAND_DARK_SKY_LOCATIONS
+
+
+def test_has_at_least_25_locations():
+    assert len(SCOTLAND_DARK_SKY_LOCATIONS) >= 25
+
+
+def test_ids_are_unique():
+    ids = [loc["id"] for loc in SCOTLAND_DARK_SKY_LOCATIONS]
+    assert len(ids) == len(set(ids))
+
+
+def test_latitudes_within_scotland():
+    for loc in SCOTLAND_DARK_SKY_LOCATIONS:
+        assert 54 <= loc["lat"] <= 61, loc["id"]
+
+
+def test_longitudes_within_scotland():
+    for loc in SCOTLAND_DARK_SKY_LOCATIONS:
+        assert -8 <= loc["lon"] <= 0, loc["id"]
+
+
+def test_lp_zone_non_empty():
+    for loc in SCOTLAND_DARK_SKY_LOCATIONS:
+        assert loc["lp_zone"], loc["id"]


### PR DESCRIPTION
## What

A self-contained `stars` domain serving a dark-sky stargazing map at `jomcgi.dev/app/stars`.

The monolith fetches MET Norway forecasts directly for ~30 curated Scottish dark-sky sites (`stars/seed.py`), scores each dark hour for astronomy suitability (`stars/scoring.py`, ported from stargazer), and stores every future qualifying hour as a row in a typed Postgres table `stars.site_hours`. No dependency on the standalone stargazer pipeline at runtime (its geospatial half is dropped in favour of the curated seed list).

## Freshness / TTL

Per-hour TTL with one shared cutoff (`shared/forecast_freshness.py` `top_of_hour()`), applied in two layers:
- **Hourly prune job** (`stars.prune_hours`): `DELETE ... WHERE hour_time < top_of_hour()`. Housekeeping that keeps the table small and the ETag honest.
- **Read-time filter** in `GET /api/stars/sites`: `WHERE hour_time >= top_of_hour(now)`. The correctness backstop, so an elapsed hour is never served regardless of when the prune last ran. The ETag folds in the current hour so the CDN turns over hourly.

## Pieces

- Schema migration `20260613000010_stars_schema.sql` (`stars.site_hours`, typed columns, indexes, composite PK).
- `stars.refresh` job (every 3h): async fetch + score, per-site wholesale replace, stale-beats-empty on partial failure, no-op on total failure.
- `GET /api/stars/sites`: SSR-only, CDN-cached per ADR 002, grouped payload, ETag + conditional-GET 304.
- Frontend `/app/stars`: dark-recoloured MapLibre map, score-bucketed site markers, per-site detail cards with best upcoming hours, empty state, 30-min refresh; a `Stars` entry added to the public APPS nav.
- Chart bumped to 0.126.0 (+ `application.yaml` targetRevision).

## Notes

- Production is Postgres (`TIMESTAMPTZ`); SQLite appears only in test fixtures. Datetimes are coerced via the ships/hikes `_as_utc`/`_iso` helpers so JSON and ETags are offset-consistent across both.
- Hikes will adopt the same typed storage + TTL in a separate follow-up PR.
- Retiring the standalone stargazer pipeline is a separate follow-up after this is verified live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)