### PR TITLE
fix(git-hooks): stop post-rewrite-format aborting on unbound $1

### DIFF
--- a/bazel/tools/git/post-rewrite-format.sh
+++ b/bazel/tools/git/post-rewrite-format.sh
@@ -3,7 +3,10 @@
 # Installed via: pre-commit install --hook-type post-rewrite
 set -euo pipefail
 
-command="$1" # "rebase" or "amend"
+# "rebase" or "amend". Default to empty so `set -u` does not abort the hook
+# when git or pre-commit invokes it without the positional arg (the non-rebase
+# guard below then exits cleanly).
+command="${1:-}"
 
 # Only run after rebase (amend already triggers pre-commit)
 if [ "$command" != "rebase" ]; then


### PR DESCRIPTION
## What

One-line fix to `bazel/tools/git/post-rewrite-format.sh`: `command="$1"` becomes `command="${1:-}"`.

## Why

The hook runs under `set -euo pipefail`. When git or pre-commit invokes the post-rewrite hook without forwarding the positional arg, `command="$1"` aborts with `$1: unbound variable` (exit 1), printing an error after every rebase/amend:

```
post-rewrite-format.sh: line 6: $1: unbound variable
```

It is non-blocking (the rewrite has already completed), but it is noise on every rebase. Defaulting to empty lets the existing non-rebase guard (`if [ "$command" != "rebase" ]; then exit 0`) handle it cleanly.

## Verification

```
$ bash post-rewrite-format.sh        # no arg
exit=0
$ bash post-rewrite-format.sh amend  # non-rebase
exit=0
```
Previously the no-arg case exited 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)