### PR TITLE
feat(hikes): normalize forecast storage to typed walk_hours with hourly TTL

### DIFF
--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -2167,6 +2167,17 @@ py_test(
 )
 
 py_test(
+    name = "hikes_jobs_test",
+    srcs = ["hikes/jobs_test.py"],
+    imports = ["."],
+    deps = [
+        ":monolith_backend",
+        "@pip//pytest",
+        "@pip//sqlmodel",
+    ],
+)
+
+py_test(
     name = "ships_heat_test",
     srcs = ["ships/heat_test.py"],
     imports = ["."],

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.127.0
+version: 0.127.1
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.126.3
+version: 0.127.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/migrations/20260613000020_hikes_walk_hours.sql
+++ b/projects/monolith/chart/migrations/20260613000020_hikes_walk_hours.sql
@@ -25,5 +25,28 @@ CREATE TABLE hikes.walk_hours (
 
 CREATE INDEX idx_hikes_walk_hours_time ON hikes.walk_hours (hour_time);
 
+-- Backfill the existing JSONB windows into typed rows BEFORE dropping the
+-- column, so a deploy does not blank /app/hikes until the next 2-hourly
+-- refresh (the refresh job keeps its stored next_run_at across the rollout, so
+-- the gap would otherwise be up to ~2 h). Each windows element is a
+-- [ts_unix, temp_c, precip_mm, wind_kmh, cloud_pct] tuple; windows_updated_at
+-- carries over as fetched_at so freshness (the list ETag/generated_at) survives
+-- the migration. ON CONFLICT guards against any duplicate hour in a stored
+-- array. This transforms rows already in Postgres, so the migration file stays
+-- tiny (well under the 256 KiB migrations-ConfigMap annotation cap).
+INSERT INTO hikes.walk_hours
+    (walk_uuid, hour_time, temp_c, precip_mm, wind_kmh, cloud_pct, fetched_at)
+SELECT
+    w.uuid,
+    to_timestamp((e->>0)::double precision),
+    (e->>1)::double precision,
+    (e->>2)::double precision,
+    (e->>3)::double precision,
+    (e->>4)::double precision,
+    COALESCE(w.windows_updated_at, now())
+FROM hikes.walks w
+CROSS JOIN LATERAL jsonb_array_elements(w.windows) AS e
+ON CONFLICT (walk_uuid, hour_time) DO NOTHING;
+
 ALTER TABLE hikes.walks DROP COLUMN windows;
 ALTER TABLE hikes.walks DROP COLUMN windows_updated_at;

--- a/projects/monolith/chart/migrations/20260613000020_hikes_walk_hours.sql
+++ b/projects/monolith/chart/migrations/20260613000020_hikes_walk_hours.sql
@@ -1,0 +1,29 @@
+-- hikes typed forecast hours: replace the JSONB windows tuple-array on
+-- hikes.walks with a typed, hour-keyed table mirroring stars.site_hours.
+--
+-- walk_hours : one row per walk-hour, keyed by (walk_uuid, hour_time). The
+--              6-hourly forecast job wholesale-replaces a walk's rows; the
+--              hourly prune job and both read endpoints drop hours once their
+--              clock hour ends (shared.forecast_freshness.top_of_hour). This
+--              stops elapsed hours leaking between the 2-hourly refreshes the
+--              old JSONB array allowed.
+--
+-- The old windows / windows_updated_at columns on hikes.walks are dropped:
+-- freshness now derives from max(walk_hours.fetched_at), so the marker column
+-- is redundant.
+
+CREATE TABLE hikes.walk_hours (
+    walk_uuid   TEXT NOT NULL,
+    hour_time   TIMESTAMPTZ NOT NULL,
+    temp_c      DOUBLE PRECISION NOT NULL,
+    precip_mm   DOUBLE PRECISION NOT NULL,
+    wind_kmh    DOUBLE PRECISION NOT NULL,
+    cloud_pct   DOUBLE PRECISION NOT NULL,
+    fetched_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (walk_uuid, hour_time)
+);
+
+CREATE INDEX idx_hikes_walk_hours_time ON hikes.walk_hours (hour_time);
+
+ALTER TABLE hikes.walks DROP COLUMN windows;
+ALTER TABLE hikes.walks DROP COLUMN windows_updated_at;

--- a/projects/monolith/chart/migrations/atlas.sum
+++ b/projects/monolith/chart/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:WH3hTT+fjFo6fX9Nt2Zg1jFjGZKxTYL6fQCckEGH4KQ=
+h1:F1JZqBioY+rz9fFPEyn4yBg9DEMDTUsenNJU0XqoiNI=
 20260330000000_initial_schema.sql h1:J2futpSW0nJAIRR7nR7ssT7LwXIYrvRI+PkHb5Y4tLI=
 20260403000000_chat_schema.sql h1:pERUFC0vzM95etRuzp43XzkCV7lBCzrrtY5Mk7aF3CA=
 20260404000000_chat_attachments.sql h1:tv+Fdbr1rQC5nzUxfaBC0O6fu2OMGgLWf+YNg1WQXi4=
@@ -31,4 +31,4 @@ h1:WH3hTT+fjFo6fX9Nt2Zg1jFjGZKxTYL6fQCckEGH4KQ=
 20260611000000_ships_heat_cells.sql h1:k3TYgAMF/TSXFcJoHtJlc9Or/NP2C3L97nEo2UpDdlk=
 20260613000000_hikes_schema.sql h1:I3wFdg/TMhLmFDKr81gPoIAIMe58j8ekriZrVvymsyw=
 20260613000010_stars_schema.sql h1:JoKjmwNkR27a/+uj4PaNhN/DHjXmZXocHC9q7ZA9FXw=
-20260613000020_hikes_walk_hours.sql h1:kFToTNoMFtEKNXa8hbgq6H/qLkOVqMu6szuuu3xFoVE=
+20260613000020_hikes_walk_hours.sql h1:WKm0YYkAh+9F5MlloiNw6rbNAvaTFkyDF4j2q2/Vz/g=

--- a/projects/monolith/chart/migrations/atlas.sum
+++ b/projects/monolith/chart/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:JYbhI2XDEgsjYN/0GKdSIHbUMneqHHHe0VPh3BKWGUM=
+h1:WH3hTT+fjFo6fX9Nt2Zg1jFjGZKxTYL6fQCckEGH4KQ=
 20260330000000_initial_schema.sql h1:J2futpSW0nJAIRR7nR7ssT7LwXIYrvRI+PkHb5Y4tLI=
 20260403000000_chat_schema.sql h1:pERUFC0vzM95etRuzp43XzkCV7lBCzrrtY5Mk7aF3CA=
 20260404000000_chat_attachments.sql h1:tv+Fdbr1rQC5nzUxfaBC0O6fu2OMGgLWf+YNg1WQXi4=
@@ -31,3 +31,4 @@ h1:JYbhI2XDEgsjYN/0GKdSIHbUMneqHHHe0VPh3BKWGUM=
 20260611000000_ships_heat_cells.sql h1:k3TYgAMF/TSXFcJoHtJlc9Or/NP2C3L97nEo2UpDdlk=
 20260613000000_hikes_schema.sql h1:I3wFdg/TMhLmFDKr81gPoIAIMe58j8ekriZrVvymsyw=
 20260613000010_stars_schema.sql h1:JoKjmwNkR27a/+uj4PaNhN/DHjXmZXocHC9q7ZA9FXw=
+20260613000020_hikes_walk_hours.sql h1:kFToTNoMFtEKNXa8hbgq6H/qLkOVqMu6szuuu3xFoVE=

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.127.0
+      targetRevision: 0.127.1
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.126.3
+      targetRevision: 0.127.0
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/hikes/__init__.py
+++ b/projects/monolith/hikes/__init__.py
@@ -12,9 +12,13 @@ def register(app: FastAPI) -> None:
 
 
 def on_startup_jobs(session: Session) -> None:
-    """Register hikes scheduled jobs (scrape + forecast refresh)."""
+    """Register hikes scheduled jobs (scrape + forecast refresh + hourly prune)."""
     from shared.scheduler import register_job
-    from hikes.jobs import refresh_forecasts_handler, scrape_walks_handler
+    from hikes.jobs import (
+        prune_windows_handler,
+        refresh_forecasts_handler,
+        scrape_walks_handler,
+    )
 
     register_job(
         session,
@@ -32,4 +36,14 @@ def on_startup_jobs(session: Session) -> None:
         interval_secs=2 * 3600,
         handler=refresh_forecasts_handler,
         ttl_secs=1800,
+    )
+    register_job(
+        session,
+        name="hikes.prune_windows",
+        # Hourly housekeeping: drop walk_hours whose clock hour has elapsed so
+        # the table does not grow unbounded between the slower refreshes. The
+        # read endpoints filter defensively regardless (top_of_hour cutoff).
+        interval_secs=3600,
+        handler=prune_windows_handler,
+        ttl_secs=300,
     )

--- a/projects/monolith/hikes/jobs.py
+++ b/projects/monolith/hikes/jobs.py
@@ -13,12 +13,13 @@ import logging
 from datetime import datetime, timezone
 
 import httpx
-from sqlmodel import Session, select
+from sqlmodel import Session, delete, select
 
 from hikes import models
 from hikes.forecast import fetch_all_windows
 from hikes.walkhighlands import Walk as ScrapedWalk
 from hikes.walkhighlands import fetch_all_walks
+from shared.forecast_freshness import top_of_hour
 
 logger = logging.getLogger("hikes")
 
@@ -31,9 +32,9 @@ FORECAST_TIMEOUT_SECS = 30.0
 def _persist_walks(walks: list[ScrapedWalk]) -> tuple[int, int]:
     """Upsert scraped walks in a fresh session. Returns (new, updated).
 
-    Upserts only the scraped columns plus scraped_at; windows and
-    windows_updated_at belong to the forecast job and are never touched here.
-    Runs off the event loop via asyncio.to_thread.
+    Upserts only the scraped columns plus scraped_at; the typed walk_hours
+    rows belong to the forecast job and are never touched here. Runs off the
+    event loop via asyncio.to_thread.
     """
     from app.db import get_engine
 
@@ -118,34 +119,88 @@ def _load_coords() -> list[tuple[str, float, float]]:
         )
 
 
-def _persist_windows(windows_by_uuid: dict[str, list], now: datetime) -> int:
-    """Write recomputed windows in a fresh session. Returns total window count.
+def _write_walk_hours(
+    session: Session, windows_by_uuid: dict[str, list], now: datetime
+) -> int:
+    """Wholesale-replace walk_hours rows for every fetched walk. Returns rows written.
 
-    Walks absent from windows_by_uuid keep their previous windows (the caller
-    only includes walks whose forecast fetch and computation both succeeded).
+    One bulk delete of the fetched walks' existing hours, then one add_all of
+    the new typed rows, so there is no per-iteration session.add. Walks absent
+    from ``windows_by_uuid`` (failed fetch) are untouched: stale beats empty.
+    A walk present with an empty window list correctly ends up with no hours
+    (its fetch succeeded but yielded nothing viable).
+
+    Each window tuple is [ts_unix, temp_c, precip_mm, wind_kmh, cloud_pct] as
+    emitted by hikes.forecast.compute_windows; the unix timestamp becomes the
+    tz-aware UTC hour_time.
+    """
+    walk_uuids = list(windows_by_uuid.keys())
+    session.execute(
+        delete(models.WalkHour).where(models.WalkHour.walk_uuid.in_(walk_uuids))
+    )
+    new_rows = [
+        models.WalkHour(
+            walk_uuid=walk_uuid,
+            hour_time=datetime.fromtimestamp(window[0], tz=timezone.utc),
+            temp_c=window[1],
+            precip_mm=window[2],
+            wind_kmh=window[3],
+            cloud_pct=window[4],
+            fetched_at=now,
+        )
+        for walk_uuid, windows in windows_by_uuid.items()
+        for window in windows
+    ]
+    session.add_all(new_rows)
+    return len(new_rows)
+
+
+def _persist_windows(windows_by_uuid: dict[str, list], now: datetime) -> int:
+    """Write recomputed hours in a fresh session. Returns total hour count."""
+    from app.db import get_engine
+
+    with Session(get_engine()) as session:
+        written = _write_walk_hours(session, windows_by_uuid, now)
+        session.commit()
+    return written
+
+
+def _prune_elapsed(session: Session) -> int:
+    """Delete walk_hours whose clock hour has elapsed. Returns rows deleted.
+
+    The cutoff is the top of the current UTC clock hour: rows whose hour_time is
+    strictly before it have elapsed. cutoff is tz-aware UTC, so the comparison
+    stays tz-aware against the TIMESTAMPTZ column.
+    """
+    cutoff = top_of_hour()
+    result = session.execute(
+        delete(models.WalkHour).where(models.WalkHour.hour_time < cutoff)
+    )
+    return result.rowcount or 0
+
+
+def _run_prune() -> int:
+    """Prune elapsed hours in a fresh session (runs off the event loop).
+
+    Commits only when rows were actually deleted, so a quiet hour is a no-op
+    transaction; fetched_at is never touched (the prune only deletes).
     """
     from app.db import get_engine
 
-    total_windows = 0
     with Session(get_engine()) as session:
-        for walk_uuid, windows in windows_by_uuid.items():
-            walk = session.get(models.Walk, walk_uuid)
-            if walk is None:
-                continue
-            walk.windows = windows
-            walk.windows_updated_at = now
-            total_windows += len(windows)
-        session.commit()
-    return total_windows
+        deleted = _prune_elapsed(session)
+        if deleted:
+            session.commit()
+    return deleted
 
 
 async def refresh_forecasts_handler(session: Session) -> datetime | None:
     """6-hourly met.no refresh: recompute viable hiking windows per walk.
 
-    Loads the coordinate corpus, runs the whole network phase, then updates
-    windows and windows_updated_at in one transaction. Walks whose fetch or
-    window computation failed are absent from the result dict and keep their
-    previous windows (stale beats empty).
+    Loads the coordinate corpus, runs the whole network phase, then
+    wholesale-replaces each fetched walk's typed walk_hours rows in one
+    transaction. Walks whose fetch or window computation failed are absent from
+    the result dict and keep their previous hours (stale beats empty).
     """
     coords = await asyncio.to_thread(_load_coords)
     if not coords:
@@ -156,11 +211,18 @@ async def refresh_forecasts_handler(session: Session) -> datetime | None:
     async with httpx.AsyncClient(timeout=FORECAST_TIMEOUT_SECS) as client:
         windows_by_uuid = await fetch_all_windows(client, coords, now)
 
-    total_windows = await asyncio.to_thread(_persist_windows, windows_by_uuid, now)
+    total_hours = await asyncio.to_thread(_persist_windows, windows_by_uuid, now)
     logger.info(
-        "hikes forecast: %d walks, %d forecasts fetched, %d viable windows",
+        "hikes forecast: %d walks, %d forecasts fetched, %d viable hours",
         len(coords),
         len(windows_by_uuid),
-        total_windows,
+        total_hours,
     )
+    return None
+
+
+async def prune_windows_handler(session: Session) -> datetime | None:
+    """Drop elapsed hours hourly (housekeeping; the read endpoints also filter)."""
+    deleted = await asyncio.to_thread(_run_prune)
+    logger.info("hikes prune_windows: deleted %d elapsed rows", deleted)
     return None

--- a/projects/monolith/hikes/jobs_test.py
+++ b/projects/monolith/hikes/jobs_test.py
@@ -1,0 +1,160 @@
+"""Unit tests for hikes.jobs DB cores on SQLite.
+
+Uses SQLModel.metadata.create_all (no migrations), mirroring stars/jobs_test.
+The async handlers delegate their DB work to synchronous cores
+(_write_walk_hours, _prune_elapsed) via asyncio.to_thread with a fresh engine
+session; the cores take an explicit session so they are testable against the
+in-memory fixture. The thin async wrappers are not unit tested here.
+
+Window tuples are [ts_unix_seconds, temp_c, precip_mm, wind_kmh, cloud_pct],
+exactly what hikes.forecast.compute_windows emits and what _write_walk_hours
+maps into typed WalkHour rows.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlmodel import Session, SQLModel, create_engine, select
+from sqlmodel.pool import StaticPool
+
+import hikes.jobs as jobs
+from hikes.models import WalkHour
+from shared.forecast_freshness import top_of_hour
+
+
+@pytest.fixture(name="session")
+def session_fixture():
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    original_schemas = {}
+    for table in SQLModel.metadata.tables.values():
+        if table.schema is not None:
+            original_schemas[table.name] = table.schema
+            table.schema = None
+    try:
+        SQLModel.metadata.create_all(engine)
+        with Session(engine) as session:
+            yield session
+    finally:
+        for table in SQLModel.metadata.tables.values():
+            if table.name in original_schemas:
+                table.schema = original_schemas[table.name]
+
+
+def _utc(dt):
+    """Coerce a loaded datetime to UTC-aware (SQLite returns naive values)."""
+    return dt if dt.tzinfo is not None else dt.replace(tzinfo=timezone.utc)
+
+
+def _ts(dt: datetime) -> int:
+    return int(dt.timestamp())
+
+
+def _seed_hour(session, walk_uuid, hour_time, temp_c=10.0):
+    session.add(
+        WalkHour(
+            walk_uuid=walk_uuid,
+            hour_time=hour_time,
+            temp_c=temp_c,
+            precip_mm=0.0,
+            wind_kmh=12.0,
+            cloud_pct=40.0,
+        )
+    )
+
+
+def test_write_walk_hours_inserts_rows_for_each_walk(session):
+    h1 = datetime(2026, 6, 13, 23, tzinfo=timezone.utc)
+    h2 = datetime(2026, 6, 13, 22, tzinfo=timezone.utc)
+    windows_by_uuid = {
+        "walk-a": [[_ts(h1), 12.5, 0, 14, 40]],
+        "walk-b": [[_ts(h2), 11.0, 0.5, 18, 55], [_ts(h1), 10.0, 0, 20, 60]],
+    }
+    now = datetime(2026, 6, 13, 21, tzinfo=timezone.utc)
+
+    written = jobs._write_walk_hours(session, windows_by_uuid, now)
+    session.commit()
+    assert written == 3
+
+    rows = session.exec(select(WalkHour)).all()
+    assert len(rows) == 3
+
+    a = session.get(WalkHour, ("walk-a", h1))
+    assert a is not None
+    assert a.temp_c == 12.5
+    assert a.wind_kmh == 14
+    # A single shared fetched_at is stamped across the whole run.
+    assert len({r.fetched_at for r in rows}) == 1
+
+
+def test_write_walk_hours_leaves_unfetched_walks_untouched(session):
+    # Stale beats empty: the bulk delete only targets fetched walk uuids, so a
+    # walk absent from the windows map keeps its previous rows.
+    kept = datetime(2026, 6, 13, 21, tzinfo=timezone.utc)
+    _seed_hour(session, "X", kept, temp_c=8.0)
+    session.commit()
+
+    now = datetime(2026, 6, 13, 22, tzinfo=timezone.utc)
+    new = datetime(2026, 6, 13, 23, tzinfo=timezone.utc)
+    jobs._write_walk_hours(session, {"A": [[_ts(new), 9.0, 0, 10, 30]]}, now)
+    session.commit()
+
+    survivor = session.get(WalkHour, ("X", kept))
+    assert survivor is not None
+    assert survivor.temp_c == 8.0
+    assert session.get(WalkHour, ("A", new)) is not None
+
+
+def test_write_walk_hours_replaces_walk_rows_wholesale(session):
+    old_a = datetime(2026, 6, 13, 20, tzinfo=timezone.utc)
+    old_b = datetime(2026, 6, 13, 21, tzinfo=timezone.utc)
+    _seed_hour(session, "A", old_a, temp_c=1.0)
+    _seed_hour(session, "A", old_b, temp_c=2.0)
+    session.commit()
+
+    now = datetime(2026, 6, 13, 22, tzinfo=timezone.utc)
+    new_a = datetime(2026, 6, 13, 23, tzinfo=timezone.utc)
+    new_b = datetime(2026, 6, 14, 0, tzinfo=timezone.utc)
+    windows_by_uuid = {
+        "A": [[_ts(new_a), 12.5, 0, 14, 40], [_ts(new_b), 11.0, 0, 16, 50]]
+    }
+    jobs._write_walk_hours(session, windows_by_uuid, now)
+    session.commit()
+
+    rows = session.exec(select(WalkHour).where(WalkHour.walk_uuid == "A")).all()
+    assert {_utc(r.hour_time) for r in rows} == {new_a, new_b}
+
+
+def test_write_walk_hours_empty_list_clears_a_fetched_walk(session):
+    # A walk present with an empty window list (fetch succeeded, nothing viable)
+    # has its stale rows removed and gains none.
+    old = datetime(2026, 6, 13, 20, tzinfo=timezone.utc)
+    _seed_hour(session, "A", old)
+    session.commit()
+
+    now = datetime(2026, 6, 13, 22, tzinfo=timezone.utc)
+    written = jobs._write_walk_hours(session, {"A": []}, now)
+    session.commit()
+    assert written == 0
+    assert session.exec(select(WalkHour).where(WalkHour.walk_uuid == "A")).all() == []
+
+
+def test_prune_elapsed_drops_only_elapsed_hours(session):
+    cutoff = top_of_hour(datetime.now(timezone.utc))
+    past_a = cutoff - timedelta(hours=3)
+    past_b = cutoff - timedelta(hours=1)
+    current = cutoff
+    future = cutoff + timedelta(hours=2)
+    for i, h in enumerate((past_a, past_b, current, future)):
+        _seed_hour(session, f"walk-{i}", h)
+    session.commit()
+
+    deleted = jobs._prune_elapsed(session)
+    session.commit()
+    assert deleted == 2
+
+    remaining = {_utc(r.hour_time) for r in session.exec(select(WalkHour)).all()}
+    assert remaining == {current, future}

--- a/projects/monolith/hikes/models.py
+++ b/projects/monolith/hikes/models.py
@@ -1,21 +1,19 @@
 """SQLModel definitions for the hikes schema (WalkHighlands walk corpus).
 
-Mirrors chart/migrations/20260613000000_hikes_schema.sql. One row per walk,
-keyed by the uuid5-of-coordinates identity from the original scraper. The
-windows column holds compact viable-window tuples
-([timestamp, temp_c, precip_mm, wind_kmh, cloud_pct]) replaced wholesale by
-the forecast job.
+Mirrors chart/migrations/20260613000000_hikes_schema.sql (walks) and
+20260613000020_hikes_walk_hours.sql (walk_hours).
+
+- ``Walk``: one row per walk, keyed by the uuid5-of-coordinates identity from
+  the original scraper.
+- ``WalkHour``: one row per walk-hour, keyed by (walk_uuid, hour_time), holding
+  the viable-window weather fields the forecast job computes. Replaces the old
+  JSONB ``windows`` tuple-array on walks. The hourly prune job and the read
+  endpoints drop hours once their clock hour ends.
 """
 
 from datetime import datetime, timezone
 
-from sqlalchemy import JSON, Column
-from sqlalchemy.dialects.postgresql import JSONB
 from sqlmodel import Field, SQLModel
-
-# Postgres uses JSONB (matching the migration); SQLite falls back to JSON so
-# the in-memory test fixture can create the table.
-_JSONB = JSONB().with_variant(JSON(), "sqlite")
 
 
 class Walk(SQLModel, table=True):  # nosemgrep: sqlmodel-datetime-without-factory
@@ -31,7 +29,18 @@ class Walk(SQLModel, table=True):  # nosemgrep: sqlmodel-datetime-without-factor
     summary: str = Field(default="")
     latitude: float
     longitude: float
-    windows: list = Field(default_factory=list, sa_column=Column(_JSONB))
-    windows_updated_at: datetime | None = Field(default=None)
     scraped_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+
+
+class WalkHour(SQLModel, table=True):  # nosemgrep: sqlmodel-datetime-without-factory
+    __tablename__ = "walk_hours"
+    __table_args__ = {"schema": "hikes", "extend_existing": True}
+
+    walk_uuid: str = Field(primary_key=True)
+    hour_time: datetime = Field(primary_key=True)
+    temp_c: float
+    precip_mm: float
+    wind_kmh: float
+    cloud_pct: float
+    fetched_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))

--- a/projects/monolith/hikes/models_test.py
+++ b/projects/monolith/hikes/models_test.py
@@ -1,15 +1,15 @@
-"""Unit tests for hikes.models: round-trip Walk on SQLite.
+"""Unit tests for hikes.models: round-trip Walk + WalkHour on SQLite.
 
-Uses SQLModel.metadata.create_all (no migrations), mirroring the ships tests.
+Uses SQLModel.metadata.create_all (no migrations), mirroring the ships/stars tests.
 """
 
 from datetime import datetime, timezone
 
 import pytest
-from sqlmodel import Session, SQLModel, create_engine
+from sqlmodel import Session, SQLModel, create_engine, select
 from sqlmodel.pool import StaticPool
 
-from hikes.models import Walk
+from hikes.models import Walk, WalkHour
 
 
 @pytest.fixture(name="session")
@@ -35,7 +35,6 @@ def session_fixture():
 
 
 def test_walk_roundtrip(session):
-    windows_updated = datetime(2026, 6, 13, 12, 0, 0, tzinfo=timezone.utc)
     walk = Walk(
         uuid="3f2504e0-4f89-51d3-9a0c-0305e82c3301",
         name="Ben Lomond",
@@ -46,8 +45,6 @@ def test_walk_roundtrip(session):
         summary="A classic ascent of Scotland's most southerly Munro.",
         latitude=56.19,
         longitude=-4.633,
-        windows=[[1750000000, 12.5, 0, 14, 40]],
-        windows_updated_at=windows_updated,
     )
     session.add(walk)
     session.commit()
@@ -62,6 +59,59 @@ def test_walk_roundtrip(session):
     assert loaded.summary == "A classic ascent of Scotland's most southerly Munro."
     assert loaded.latitude == 56.19
     assert loaded.longitude == -4.633
-    assert loaded.windows == [[1750000000, 12.5, 0, 14, 40]]
     assert isinstance(loaded.scraped_at, datetime)
     assert isinstance(loaded.created_at, datetime)
+
+
+def test_walk_hour_roundtrip(session):
+    hour = datetime(2026, 6, 13, 12, 0, 0, tzinfo=timezone.utc)
+    row = WalkHour(
+        walk_uuid="3f2504e0-4f89-51d3-9a0c-0305e82c3301",
+        hour_time=hour,
+        temp_c=12.5,
+        precip_mm=0.0,
+        wind_kmh=14.0,
+        cloud_pct=40.0,
+    )
+    session.add(row)
+    session.commit()
+
+    loaded = session.get(WalkHour, ("3f2504e0-4f89-51d3-9a0c-0305e82c3301", hour))
+    assert loaded is not None
+    assert loaded.temp_c == 12.5
+    assert loaded.precip_mm == 0.0
+    assert loaded.wind_kmh == 14.0
+    assert loaded.cloud_pct == 40.0
+    # SQLite returns naive datetimes (no tz-aware type), so assert the type
+    # only, not tzinfo, matching stars/models_test. Production is Postgres
+    # TIMESTAMPTZ, where the value round-trips tz-aware.
+    assert isinstance(loaded.fetched_at, datetime)
+
+
+def test_walk_hour_composite_key_same_walk_different_hours(session):
+    hour_a = datetime(2026, 6, 13, 12, 0, 0, tzinfo=timezone.utc)
+    hour_b = datetime(2026, 6, 13, 13, 0, 0, tzinfo=timezone.utc)
+    common = {
+        "walk_uuid": "3f2504e0-4f89-51d3-9a0c-0305e82c3301",
+        "temp_c": 12.5,
+        "precip_mm": 0.0,
+        "wind_kmh": 14.0,
+        "cloud_pct": 40.0,
+    }
+    session.add(WalkHour(hour_time=hour_a, **common))
+    session.add(WalkHour(hour_time=hour_b, **common))
+    session.commit()
+
+    rows = session.exec(
+        select(WalkHour).where(
+            WalkHour.walk_uuid == "3f2504e0-4f89-51d3-9a0c-0305e82c3301"
+        )
+    ).all()
+    assert len(rows) == 2
+    loaded = {
+        r.hour_time
+        if r.hour_time.tzinfo is not None
+        else r.hour_time.replace(tzinfo=timezone.utc)
+        for r in rows
+    }
+    assert loaded == {hour_a, hour_b}

--- a/projects/monolith/hikes/router.py
+++ b/projects/monolith/hikes/router.py
@@ -12,7 +12,9 @@ Two read endpoints back the /app/hikes walk planner:
 
 Reached only from SvelteKit SSR (``http://localhost:8000`` in the same pod);
 the /app/hikes page is the public surface and the CDN fans out to viewers.
-Conditional GETs short-circuit with a 304 via ETag.
+Conditional GETs on the list short-circuit with a 304 via its ETag; the detail
+endpoint is CDN-cached without an ETag, and the client drops any already-started
+hour by absolute timestamp, so a momentarily stale detail never shows past hours.
 
 The read-time hour filter (``hour_time >= top_of_hour(now)``) is the source of
 truth for "future windows": both endpoints query the typed walk_hours table and

--- a/projects/monolith/hikes/router.py
+++ b/projects/monolith/hikes/router.py
@@ -13,6 +13,12 @@ Two read endpoints back the /app/hikes walk planner:
 Reached only from SvelteKit SSR (``http://localhost:8000`` in the same pod);
 the /app/hikes page is the public surface and the CDN fans out to viewers.
 Conditional GETs short-circuit with a 304 via ETag.
+
+The read-time hour filter (``hour_time >= top_of_hour(now)``) is the source of
+truth for "future windows": both endpoints query the typed walk_hours table and
+never trust it to be already pruned. The hourly prune job is housekeeping only,
+so a stale row that has not been pruned yet is still excluded here. The list
+ETag folds the cutoff in (see _walks_etag) so the CDN turns over hourly.
 """
 
 from __future__ import annotations
@@ -25,7 +31,8 @@ from fastapi import APIRouter, Depends, HTTPException, Request, Response
 from sqlmodel import Session, select
 
 from app.db import get_session
-from hikes.models import Walk
+from hikes.models import Walk, WalkHour
+from shared.forecast_freshness import top_of_hour
 
 logger = logging.getLogger("hikes")
 
@@ -41,25 +48,6 @@ _UK_TZ = ZoneInfo("Europe/London")
 # (see the note in cache-headers.js). Mirrors HIKES_WALKS_CACHE_CONTROL in
 # frontend/src/lib/cache-headers.js, keep in sync.
 _WALKS_CACHE_CONTROL = "public, max-age=0, s-maxage=1800, stale-while-revalidate=3600, stale-if-error=86400"
-
-
-def _viable_days(windows: list | None) -> list[str]:
-    """Distinct UK-local calendar days (YYYY-MM-DD) that carry a viable window.
-
-    Window tuples are [ts_seconds, ...]; ts is unix UTC. We emit ABSOLUTE dates
-    (not "next 7 days") so the value is independent of when it was computed and
-    stays correct in a CDN cache across midnight; the client intersects them
-    with its own rolling 7-day strip.
-    """
-    days: set[str] = set()
-    for window in windows or []:
-        try:
-            ts = window[0]
-        except (TypeError, IndexError, KeyError):
-            continue
-        local = datetime.fromtimestamp(ts, tz=timezone.utc).astimezone(_UK_TZ)
-        days.add(local.date().isoformat())
-    return sorted(days)
 
 
 def _as_utc(value: datetime | None) -> datetime | None:
@@ -83,26 +71,62 @@ def _iso(value: datetime | None) -> str | None:
     return coerced.isoformat() if coerced is not None else None
 
 
+def _viable_days(hours: list[datetime]) -> list[str]:
+    """Distinct UK-local calendar days (YYYY-MM-DD) covered by the given hours.
+
+    We emit ABSOLUTE dates (not "next 7 days") so the value is independent of
+    when it was computed and stays correct in a CDN cache across midnight; the
+    client intersects them with its own rolling 7-day strip.
+    """
+    days: set[str] = set()
+    for hour_time in hours:
+        coerced = _as_utc(hour_time)
+        if coerced is None:
+            continue
+        days.add(coerced.astimezone(_UK_TZ).date().isoformat())
+    return sorted(days)
+
+
+def _window_tuple(row: WalkHour) -> list:
+    """Reassemble the compact wire tuple from a typed walk_hours row.
+
+    The client reads windows as [ts_unix_seconds, temp_c, precip_mm, wind_kmh,
+    cloud_pct] tuples (see frontend hikes/filters.js). Storage is normalised to
+    typed rows, but the wire format is unchanged, so the frontend needs no edit.
+    wind_kmh and cloud_pct were integers in the legacy tuple, so cast them back
+    from the DOUBLE PRECISION columns; temp_c/precip_mm stay as stored.
+    """
+    coerced = _as_utc(row.hour_time)
+    return [
+        int(coerced.timestamp()),
+        row.temp_c,
+        row.precip_mm,
+        int(row.wind_kmh),
+        int(row.cloud_pct),
+    ]
+
+
 # Bump whenever the /walks response SHAPE changes (fields added/removed/renamed).
-# The ETag is otherwise data-derived (max_updated + count), so a shape-only code
-# deploy leaves it unchanged: browsers revalidate, get a 304, and keep their
-# stale-shape body. Folding this token in means a shape change busts every
-# client's cache, so they pick up the new shape on the next revalidation rather
-# than staying broken until the underlying data happens to change.
+# The ETag is otherwise data-derived, so a shape-only code deploy would leave it
+# unchanged: browsers revalidate, get a 304, and keep their stale-shape body.
+# Folding this token in means a shape change busts every client's cache.
 # History: v2 = dropped hourly `windows` + `summary`, added `viable_days`.
-_WALKS_SCHEMA_VERSION = "v2"
+#          v3 = windows backed by typed walk_hours; ETag folds in the hourly
+#               top_of_hour cutoff so the CDN turns over each clock hour.
+_WALKS_SCHEMA_VERSION = "v3"
 
 
-def _walks_etag(walk_count: int, max_updated: datetime | None) -> str:
+def _walks_etag(walk_count: int, cutoff: datetime, max_fetched: datetime | None) -> str:
     """Stable ETag for the walks payload.
 
-    Combines a response-schema token with max(windows_updated_at) and the row
-    count, so the cache invalidates on a shape change (schema token), a data
-    refresh (timestamp), or a walk appearing/disappearing (count) even when no
-    surviving row's timestamp moves.
+    Combines the response-schema token, the current clock-hour cutoff, the
+    freshest walk_hours fetched_at, and the row count. The cutoff token turns
+    the cache over at each hour boundary (as hours fall past the cutoff the
+    viable_days sets shrink); fetched_at busts it on a forecast refresh; count
+    busts it when a walk appears or disappears.
     """
-    stamp = max_updated.isoformat() if max_updated is not None else "null"
-    return f'"{_WALKS_SCHEMA_VERSION}-{stamp}-{walk_count}"'
+    stamp = max_fetched.isoformat() if max_fetched is not None else "null"
+    return f'"{_WALKS_SCHEMA_VERSION}-{cutoff.isoformat()}-{stamp}-{walk_count}"'
 
 
 @router.get("/walks")
@@ -112,31 +136,46 @@ def get_walks(
     session: Session = Depends(get_session),
 ):
     """The whole walk corpus for the /app/hikes planner. SSR-only, CDN-cached."""
-    rows = session.exec(select(Walk).order_by(Walk.name)).all()
+    now = datetime.now(timezone.utc)
+    cutoff = top_of_hour(now)
 
-    walks = []
-    max_updated: datetime | None = None
-    for walk in rows:
-        updated = _as_utc(walk.windows_updated_at)
-        if updated is not None and (max_updated is None or updated > max_updated):
-            max_updated = updated
-        walks.append(
-            {
-                "uuid": walk.uuid,
-                "name": walk.name,
-                "url": walk.url,
-                "distance_km": walk.distance_km,
-                "ascent_m": walk.ascent_m,
-                "duration_h": walk.duration_h,
-                "latitude": walk.latitude,
-                "longitude": walk.longitude,
-                # Light: the days this walk is viable, not the hourly windows.
-                # The card fetches windows + summary from /walks/{uuid}.
-                "viable_days": _viable_days(walk.windows),
-            }
+    walk_rows = session.exec(select(Walk).order_by(Walk.name)).all()
+
+    # Read-time correctness filter: only hours at or after the current clock
+    # hour. The prune job is best-effort housekeeping; the endpoint must not
+    # trust the table to be already pruned.
+    hour_rows = session.exec(
+        select(WalkHour.walk_uuid, WalkHour.hour_time, WalkHour.fetched_at).where(
+            WalkHour.hour_time >= cutoff
         )
+    ).all()
 
-    etag = _walks_etag(len(walks), max_updated)
+    hours_by_walk: dict[str, list[datetime]] = {}
+    max_fetched: datetime | None = None
+    for walk_uuid, hour_time, fetched_at in hour_rows:
+        hours_by_walk.setdefault(walk_uuid, []).append(hour_time)
+        coerced = _as_utc(fetched_at)
+        if coerced is not None and (max_fetched is None or coerced > max_fetched):
+            max_fetched = coerced
+
+    walks = [
+        {
+            "uuid": walk.uuid,
+            "name": walk.name,
+            "url": walk.url,
+            "distance_km": walk.distance_km,
+            "ascent_m": walk.ascent_m,
+            "duration_h": walk.duration_h,
+            "latitude": walk.latitude,
+            "longitude": walk.longitude,
+            # Light: the days this walk is viable, not the hourly windows.
+            # The card fetches windows + summary from /walks/{uuid}.
+            "viable_days": _viable_days(hours_by_walk.get(walk.uuid, [])),
+        }
+        for walk in walk_rows
+    ]
+
+    etag = _walks_etag(len(walks), cutoff, max_fetched)
     headers = {"Cache-Control": _WALKS_CACHE_CONTROL, "ETag": etag}
 
     if request.headers.get("if-none-match") == etag:
@@ -146,7 +185,7 @@ def get_walks(
         response.headers[key] = value
     return {
         "count": len(walks),
-        "generated_at": _iso(max_updated),
+        "generated_at": _iso(max_fetched),
         "walks": walks,
     }
 
@@ -160,15 +199,24 @@ def get_walk_detail(
     """Per-walk detail (summary + hourly windows) for the selected-walk card.
 
     Split out of the list so the corpus stays light; fetched on demand when a
-    marker is clicked. SSR-only, CDN-cached the same as the list.
+    marker is clicked. SSR-only, CDN-cached the same as the list. Hours are
+    filtered to the current clock hour and reassembled into the wire tuples the
+    frontend expects.
     """
     walk = session.get(Walk, uuid)
     if walk is None:
         raise HTTPException(status_code=404, detail="walk not found")
 
+    cutoff = top_of_hour(datetime.now(timezone.utc))
+    hour_rows = session.exec(
+        select(WalkHour)
+        .where(WalkHour.walk_uuid == uuid, WalkHour.hour_time >= cutoff)
+        .order_by(WalkHour.hour_time)
+    ).all()
+
     response.headers["Cache-Control"] = _WALKS_CACHE_CONTROL
     return {
         "uuid": walk.uuid,
         "summary": walk.summary,
-        "windows": walk.windows,
+        "windows": [_window_tuple(row) for row in hour_rows],
     }

--- a/projects/monolith/hikes/router_test.py
+++ b/projects/monolith/hikes/router_test.py
@@ -1,13 +1,17 @@
-"""Unit tests for hikes/router.py: /api/hikes/walks.
+"""Unit tests for hikes/router.py: /api/hikes/walks (+ /{uuid} detail).
 
 Uses an in-memory SQLite DB seeded with real rows and a minimal FastAPI app
 that mounts only the hikes router, mirroring the schema-stripping +
-``app.dependency_overrides[get_session]`` pattern in ``ships/router_test.py``.
+``app.dependency_overrides[get_session]`` pattern in ``stars/router_test.py``.
+
+Hours are anchored on ``top_of_hour(now)`` so the read-time cutoff keeps the
+seeded "future" rows and drops the seeded "elapsed" one, the same way
+stars/router_test pins its timestamps to the cutoff.
 """
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from zoneinfo import ZoneInfo
 
 import pytest
@@ -17,31 +21,24 @@ from sqlmodel import Session, SQLModel, create_engine
 from sqlmodel.pool import StaticPool
 
 from app.db import get_session
-from hikes.models import Walk
+from hikes.models import Walk, WalkHour
 from hikes.router import router
+from shared.forecast_freshness import top_of_hour
 
-T0 = datetime(2026, 6, 12, 6, 0, 0, tzinfo=timezone.utc)
+CUTOFF = top_of_hour(datetime.now(timezone.utc))
+H1 = CUTOFF + timedelta(hours=1)
+H2 = CUTOFF + timedelta(hours=2)
+ELAPSED = CUTOFF - timedelta(hours=1)
+FETCHED = datetime(2026, 6, 12, 6, 0, 0, tzinfo=timezone.utc)
 
-# Window tuples are [unix_ts_seconds, temp_c, precip_mm, wind_kmh, cloud_pct],
-# matching what hikes.forecast.compute_windows emits and what the frontend reads.
-WINDOWS = [
-    [1750582800, 14, 0, 12, 40],
-    [1750586400, 15, 0, 18, 55],
-]
+BEN = "aaaaaaaa-0000-5000-8000-000000000001"
+TEALLACH = "aaaaaaaa-0000-5000-8000-000000000002"
 
 
-def _uk_days(windows):
-    """Expected viable_days for a window set, mirroring router._viable_days."""
+def _uk_days(*hours: datetime) -> list[str]:
+    """Expected viable_days for a set of hour_times, mirroring router._viable_days."""
     uk = ZoneInfo("Europe/London")
-    return sorted(
-        {
-            datetime.fromtimestamp(w[0], tz=timezone.utc)
-            .astimezone(uk)
-            .date()
-            .isoformat()
-            for w in windows
-        }
-    )
+    return sorted({h.astimezone(uk).date().isoformat() for h in hours})
 
 
 @pytest.fixture(name="session")
@@ -77,10 +74,25 @@ def client_fixture(session):
     app.dependency_overrides.clear()
 
 
+def _hour(
+    walk_uuid, hour_time, temp_c=12.5, precip_mm=0.0, wind_kmh=14.0, cloud_pct=40.0
+):
+    return WalkHour(
+        walk_uuid=walk_uuid,
+        hour_time=hour_time,
+        temp_c=temp_c,
+        precip_mm=precip_mm,
+        wind_kmh=wind_kmh,
+        cloud_pct=cloud_pct,
+        fetched_at=FETCHED,
+    )
+
+
 def _seed_walks(session: Session) -> None:
+    # Ben Vorlich has two future hours; An Teallach has no forecast at all.
     session.add(
         Walk(
-            uuid="aaaaaaaa-0000-5000-8000-000000000001",
+            uuid=BEN,
             name="Ben Vorlich from Ardlui",
             url="https://www.walkhighlands.co.uk/lochlomond/ben-vorlich-ardlui.shtml",
             distance_km=11.0,
@@ -89,13 +101,11 @@ def _seed_walks(session: Session) -> None:
             summary="A steep but rewarding Munro above Loch Lomond.",
             latitude=56.2734,
             longitude=-4.7521,
-            windows=WINDOWS,
-            windows_updated_at=T0,
         )
     )
     session.add(
         Walk(
-            uuid="aaaaaaaa-0000-5000-8000-000000000002",
+            uuid=TEALLACH,
             name="An Teallach circuit",
             url="https://www.walkhighlands.co.uk/torridon/an-teallach.shtml",
             distance_km=18.5,
@@ -106,6 +116,8 @@ def _seed_walks(session: Session) -> None:
             longitude=-5.2596,
         )
     )
+    session.add(_hour(BEN, H1))
+    session.add(_hour(BEN, H2, temp_c=15.0, wind_kmh=18.0, cloud_pct=55.0))
     session.commit()
 
 
@@ -116,7 +128,7 @@ class TestWalks:
         assert r.status_code == 200
         body = r.json()
         assert body["count"] == 2
-        assert body["generated_at"] == T0.isoformat()
+        assert body["generated_at"] == FETCHED.isoformat()
         assert len(body["walks"]) == 2
 
         # Ordered by name: "An Teallach circuit" before "Ben Vorlich from Ardlui".
@@ -124,7 +136,7 @@ class TestWalks:
         assert names == ["An Teallach circuit", "Ben Vorlich from Ardlui"]
 
         ben = body["walks"][1]
-        assert ben["uuid"] == "aaaaaaaa-0000-5000-8000-000000000001"
+        assert ben["uuid"] == BEN
         assert ben["url"].endswith("ben-vorlich-ardlui.shtml")
         assert ben["distance_km"] == 11.0
         assert ben["ascent_m"] == 920
@@ -132,14 +144,37 @@ class TestWalks:
         assert ben["latitude"] == 56.2734
         assert ben["longitude"] == -4.7521
         # The light list carries viable_days, not the hourly windows or summary
-        # (those move to the per-walk detail endpoint).
-        assert ben["viable_days"] == _uk_days(WINDOWS)
+        # (those live on the per-walk detail endpoint).
+        assert ben["viable_days"] == _uk_days(H1, H2)
         assert "windows" not in ben
         assert "summary" not in ben
 
         # The walk without a forecast has no viable days.
         an_teallach = body["walks"][0]
         assert an_teallach["viable_days"] == []
+
+    def test_elapsed_hours_excluded_from_viable_days(self, client, session):
+        # An hour below the clock-hour cutoff must not contribute a viable day,
+        # even though the prune job has not run.
+        session.add(
+            Walk(
+                uuid=BEN,
+                name="Ben Vorlich from Ardlui",
+                url="https://example.invalid/ben.shtml",
+                distance_km=11.0,
+                ascent_m=920,
+                duration_h=5.5,
+                summary="",
+                latitude=56.2734,
+                longitude=-4.7521,
+            )
+        )
+        session.add(_hour(BEN, ELAPSED))
+        session.add(_hour(BEN, H1))
+        session.commit()
+
+        body = client.get("/api/hikes/walks").json()
+        assert body["walks"][0]["viable_days"] == _uk_days(H1)
 
     def test_cache_and_etag_headers(self, client, session):
         _seed_walks(session)
@@ -149,7 +184,8 @@ class TestWalks:
             r.headers["Cache-Control"]
             == "public, max-age=0, s-maxage=1800, stale-while-revalidate=3600, stale-if-error=86400"
         )
-        assert r.headers["ETag"]
+        # v3 schema token plus the hourly cutoff are folded into the ETag.
+        assert r.headers["ETag"].startswith(f'"v3-{CUTOFF.isoformat()}-')
 
     def test_conditional_get_returns_304(self, client, session):
         _seed_walks(session)
@@ -169,13 +205,40 @@ class TestWalks:
 class TestWalkDetail:
     def test_detail_returns_summary_and_windows(self, client, session):
         _seed_walks(session)
-        r = client.get("/api/hikes/walks/aaaaaaaa-0000-5000-8000-000000000001")
+        r = client.get(f"/api/hikes/walks/{BEN}")
         assert r.status_code == 200
         body = r.json()
-        assert body["uuid"] == "aaaaaaaa-0000-5000-8000-000000000001"
+        assert body["uuid"] == BEN
         assert body["summary"] == "A steep but rewarding Munro above Loch Lomond."
-        assert body["windows"] == WINDOWS
+        # Hours reassembled into wire tuples, ordered by time. wind_kmh/cloud_pct
+        # come back as ints (legacy tuple shape); temp_c/precip_mm stay numeric.
+        assert body["windows"] == [
+            [int(H1.timestamp()), 12.5, 0.0, 14, 40],
+            [int(H2.timestamp()), 15.0, 0.0, 18, 55],
+        ]
         assert r.headers["Cache-Control"]
+
+    def test_detail_excludes_elapsed_hours(self, client, session):
+        session.add(
+            Walk(
+                uuid=BEN,
+                name="Ben Vorlich from Ardlui",
+                url="https://example.invalid/ben.shtml",
+                distance_km=11.0,
+                ascent_m=920,
+                duration_h=5.5,
+                summary="",
+                latitude=56.2734,
+                longitude=-4.7521,
+            )
+        )
+        session.add(_hour(BEN, ELAPSED))
+        session.add(_hour(BEN, H1))
+        session.commit()
+
+        body = client.get(f"/api/hikes/walks/{BEN}").json()
+        times = [w[0] for w in body["windows"]]
+        assert times == [int(H1.timestamp())]
 
     def test_detail_404_for_unknown_uuid(self, client, session):
         _seed_walks(session)


### PR DESCRIPTION
## What

Normalises the hikes domain's forecast storage to typed rows with a per-hour TTL, matching the stars domain (which landed `shared.forecast_freshness.top_of_hour()` this reuses).

Previously hikes stored forecast windows as a JSONB tuple array on `hikes.walks.windows`, and the router served whatever was in the array, so elapsed hours leaked between the 2-hourly refreshes.

## Changes

1. **Typed table.** New `hikes.walk_hours` (`walk_uuid`, `hour_time`, `temp_c`, `precip_mm`, `wind_kmh`, `cloud_pct`, `fetched_at`, PK `(walk_uuid, hour_time)`, index on `hour_time`), mirroring `stars.site_hours`. Migration drops `walks.windows` and `walks.windows_updated_at`; freshness now derives from `max(walk_hours.fetched_at)`. New `WalkHour` SQLModel + SQLite `create_all` round-trip test.
2. **Refresh handler** writes typed `walk_hours` rows (mapping the `[ts, temp, precip, wind, cloud]` tuples `compute_windows` still emits) instead of a JSONB array; failed fetches leave existing rows (stale beats empty), an empty-but-successful fetch clears the walk.
3. **New `hikes.prune_windows` job** (`interval_secs=3600`): deletes hours below `top_of_hour()`, commits only when rows were removed, never touches `fetched_at`. Mirrors `stars.prune_hours`.
4. **Read-time filter.** Both `/api/hikes/walks` (viable_days) and `/walks/{uuid}` (windows) query `hour_time >= top_of_hour(now)`, so elapsed hours never leak regardless of prune timing. The list ETag folds in `top_of_hour(now).isoformat()` and bumps to **v3** so the CDN cache turns over hourly.
5. **Frontend unchanged.** The detail endpoint reassembles typed rows into the existing `[ts, temp, precip, wind, cloud]` wire tuples, so `HikesMap`/`filters.js` and the 30-min `invalidateAll` + `nowMs` tick are untouched.

## Notes

- `atlas.sum` regenerated for the new migration (CI `atlas_sum_test` validates it).
- `hikes_jobs_test` hand-registered in `projects/monolith/BUILD` (`# gazelle:exclude hikes`).
- Chart bumped `0.126.2 -> 0.127.0` (`Chart.yaml` + `application.yaml` `targetRevision` in sync).

🤖 Generated with [Claude Code](https://claude.com/claude-code)