### PR TITLE
feat(monolith): continuous stars quality score (ADR 007)

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.127.1
+version: 0.127.2
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/migrations/20260613000030_stars_sun_elevation.sql
+++ b/projects/monolith/chart/migrations/20260613000030_stars_sun_elevation.sql
@@ -1,0 +1,6 @@
+-- Stars domain: record the sun's elevation per site-hour.
+-- ADR 007 ranks dark hours by a continuous quality Q = D x C x W where the
+-- darkness factor D is derived from the sun elevation; storing the elevation
+-- lets the read side reason about how dark each hour actually was.
+
+ALTER TABLE stars.site_hours ADD COLUMN sun_elevation_deg DOUBLE PRECISION NOT NULL DEFAULT 0;

--- a/projects/monolith/chart/migrations/atlas.sum
+++ b/projects/monolith/chart/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:F1JZqBioY+rz9fFPEyn4yBg9DEMDTUsenNJU0XqoiNI=
+h1:bFTtp4Bx3jzBPieGw82SwG644fzdq6wNBpQO6Cy8geY=
 20260330000000_initial_schema.sql h1:J2futpSW0nJAIRR7nR7ssT7LwXIYrvRI+PkHb5Y4tLI=
 20260403000000_chat_schema.sql h1:pERUFC0vzM95etRuzp43XzkCV7lBCzrrtY5Mk7aF3CA=
 20260404000000_chat_attachments.sql h1:tv+Fdbr1rQC5nzUxfaBC0O6fu2OMGgLWf+YNg1WQXi4=
@@ -32,3 +32,4 @@ h1:F1JZqBioY+rz9fFPEyn4yBg9DEMDTUsenNJU0XqoiNI=
 20260613000000_hikes_schema.sql h1:I3wFdg/TMhLmFDKr81gPoIAIMe58j8ekriZrVvymsyw=
 20260613000010_stars_schema.sql h1:JoKjmwNkR27a/+uj4PaNhN/DHjXmZXocHC9q7ZA9FXw=
 20260613000020_hikes_walk_hours.sql h1:WKm0YYkAh+9F5MlloiNw6rbNAvaTFkyDF4j2q2/Vz/g=
+20260613000030_stars_sun_elevation.sql h1:KZFw4zfaRTVVvPeEXk/z/Ts1qtK7cMAxiW8EThPJA1I=

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.127.1
+      targetRevision: 0.127.2
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/lib/public/components/stars/StarsMap.svelte
+++ b/projects/monolith/frontend/src/lib/public/components/stars/StarsMap.svelte
@@ -18,10 +18,14 @@
   // light basemap; the prime stop is the funky violet that also marks Stars in
   // the nav. Mirrors how HikesMap keeps its EFFORT_RAMP stops in JS and renders
   // the legend swatches via inline style attributes.
+  //
+  // Boundaries follow the ADR 007 continuous quality Q = D x C x W: an ideal
+  // winter night reaches ~90+, while summer's best (sun never far below the
+  // horizon) tops out around 30-50, so the buckets break at 35 / 65.
   const SCORE_BUCKETS = [
-    { key: "low", label: "< 70", color: "#94a3b8" }, // muted slate
-    { key: "mid", label: "70-85", color: "#3b82f6" }, // blue
-    { key: "high", label: "85+", color: "#7c3aed" }, // violet (prime)
+    { key: "low", label: "< 35", color: "#94a3b8" }, // muted slate
+    { key: "mid", label: "35-65", color: "#3b82f6" }, // blue
+    { key: "high", label: "65+", color: "#7c3aed" }, // violet (prime)
   ];
 
   const SOURCE_ID = "sites";
@@ -198,15 +202,16 @@
           source: SOURCE_ID,
           paint: {
             // Fill by best score: muted slate -> blue -> violet, stepped at
-            // the 70 / 85 bucket boundaries. Ink stroke keeps every dot
-            // legible on the light basemap; better sites read a touch larger.
+            // the 35 / 65 bucket boundaries (ADR 007 continuous quality). Ink
+            // stroke keeps every dot legible on the light basemap; better sites
+            // read a touch larger.
             "circle-color": [
               "step",
               ["get", "score"],
               SCORE_BUCKETS[0].color,
-              70,
+              35,
               SCORE_BUCKETS[1].color,
-              85,
+              65,
               SCORE_BUCKETS[2].color,
             ],
             "circle-radius": [

--- a/projects/monolith/frontend/src/routes/public/app/stars/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/stars/+page.svelte
@@ -85,8 +85,8 @@
 
     {#if count === 0}
       <div class="panel empty-state" role="status">
-        No viewing windows above score 60 in the next few nights. Check back
-        after the next forecast refresh.
+        No dark-sky windows in the next few nights. Check back after the next
+        forecast refresh.
       </div>
     {/if}
   </div>

--- a/projects/monolith/stars/forecast.py
+++ b/projects/monolith/stars/forecast.py
@@ -11,7 +11,7 @@ import httpx
 from astral import LocationInfo
 from astral.sun import elevation
 
-from stars.scoring import WeatherData, calculate_astronomy_score
+from stars.scoring import WeatherData, darkness_factor, quality_score
 from stars.seed import SCOTLAND_DARK_SKY_LOCATIONS, SeedLocation
 
 logger = logging.getLogger("monolith.stars.forecast")
@@ -21,17 +21,21 @@ USER_AGENT = os.environ.get(
     "STARS_USER_AGENT", "jomcgi-homelab-stars/1.0 https://jomcgi.dev"
 )
 RATE_LIMIT_PER_SEC = int(os.environ.get("STARS_RATE_LIMIT", "15"))
-MIN_DISPLAY_SCORE = int(os.environ.get("STARS_MIN_DISPLAY_SCORE", "60"))
-NAUTICAL_TWILIGHT_DEG = -12.0
 HTTP_TIMEOUT = 30.0
 
 
 def score_location(loc: SeedLocation, forecast: dict) -> list[dict]:
-    """All qualifying dark hours for one site, sorted by time ascending.
+    """All dark hours for one site ranked by quality, sorted by time ascending.
+
+    ADR 007: every civil-dark hour (sun below -6 deg) is kept and scored by the
+    continuous quality Q = D x C x W, so summer nights surface the best
+    available windows instead of going empty. Hours that are not dark, or are
+    dark but hopeless (Q == 0, e.g. fully clouded), are dropped.
 
     Each returned dict matches the stars.site_hours columns (minus site_id /
-    fetched_at, which the job sets): time, score, cloud_area_fraction,
-    relative_humidity, wind_speed, air_temperature, dew_spread, symbol.
+    fetched_at, which the job sets): time, score, sun_elevation_deg,
+    cloud_area_fraction, relative_humidity, wind_speed, air_temperature,
+    dew_spread, symbol.
     """
     observer = LocationInfo(latitude=loc["lat"], longitude=loc["lon"]).observer
     hours: list[dict] = []
@@ -42,11 +46,12 @@ def score_location(loc: SeedLocation, forecast: dict) -> list[dict]:
         except ValueError:
             continue
         try:
-            if elevation(observer, t) > NAUTICAL_TWILIGHT_DEG:
-                continue
+            e = elevation(observer, t)
         except Exception as exc:  # pragma: no cover - astral edge cases
             logger.debug("astral elevation failed for %s at %s: %s", loc["id"], t, exc)
             continue
+        if darkness_factor(e) <= 0.0:
+            continue  # daylight / brighter than civil twilight
         instant = entry.get("data", {}).get("instant", {}).get("details", {})
         next_1h = entry.get("data", {}).get("next_1_hours", {})
         try:
@@ -64,13 +69,14 @@ def score_location(loc: SeedLocation, forecast: dict) -> list[dict]:
         except Exception as exc:
             logger.debug("skip malformed weather entry at %s: %s", time_str, exc)
             continue
-        score = calculate_astronomy_score(weather)
-        if score < MIN_DISPLAY_SCORE:
-            continue
+        q = quality_score(weather, e)
+        if q <= 0.0:
+            continue  # dark but hopeless (e.g. fully clouded)
         hours.append(
             {
                 "time": time_str,
-                "score": round(score, 1),
+                "score": round(q, 1),
+                "sun_elevation_deg": round(e, 1),
                 "cloud_area_fraction": weather.cloud_area_fraction,
                 "relative_humidity": weather.relative_humidity,
                 "wind_speed": weather.wind_speed,

--- a/projects/monolith/stars/forecast_test.py
+++ b/projects/monolith/stars/forecast_test.py
@@ -1,8 +1,10 @@
 """Unit tests for stars.forecast.score_location.
 
 elevation() is monkeypatched per entry so the dark/daylight gate is fully
-deterministic and independent of the real ephemeris. The qualifying-hour
-shape and ascending sort are asserted directly.
+deterministic and independent of the real ephemeris. ADR 007: score_location
+keeps every civil-dark hour ranked by the continuous quality Q = D x C x W and
+drops daytime hours and dark-but-hopeless (Q == 0) hours. The qualifying-hour
+shape, recorded sun elevation, and ascending sort are asserted directly.
 """
 
 import stars.forecast as forecast
@@ -18,7 +20,7 @@ _LOC: SeedLocation = {
 }
 
 # Sun elevation (degrees) keyed by the UTC hour of the timeseries entry.
-# Hours 22, 23, 0 are below nautical twilight (dark); hour 12 is daytime.
+# Hours 22, 23, 0 are deep dark (below astronomical -18); hour 12 is daytime.
 _ELEV_BY_HOUR = {22: -20.0, 23: -20.0, 0: -20.0, 12: 30.0}
 
 
@@ -50,13 +52,13 @@ def _forecast():
     return {
         "properties": {
             "timeseries": [
-                # dark + clear -> qualifies (score 100)
+                # deep-dark + clear -> qualifies (Q == 100)
                 {"time": "2026-06-13T23:00:00Z", **_instant(5, 55, 2, 8, 2)},
-                # dark + heavily clouded -> score < 60, dropped
+                # dark but fully clouded -> Q == 0, dropped
                 {"time": "2026-06-14T00:00:00Z", **_instant(100, 90, 2, 8, 7)},
-                # daytime (sun up) -> dropped before scoring
+                # daytime (sun up, not dark) -> dropped before scoring
                 {"time": "2026-06-13T12:00:00Z", **_instant(0, 40, 1, 12, 2)},
-                # dark + clear, earlier hour -> qualifies, must sort first
+                # deep-dark + clear, earlier hour -> qualifies, must sort first
                 {"time": "2026-06-13T22:00:00Z", **_instant(5, 55, 2, 8, 2)},
             ]
         }
@@ -66,6 +68,7 @@ def _forecast():
 _EXPECTED_KEYS = {
     "time",
     "score",
+    "sun_elevation_deg",
     "cloud_area_fraction",
     "relative_humidity",
     "wind_speed",
@@ -80,7 +83,8 @@ def test_score_location_keeps_only_qualifying_hours_sorted(monkeypatch):
 
     hours = forecast.score_location(_LOC, _forecast())
 
-    # Two dark+clear hours qualify; the cloudy and daytime hours are dropped.
+    # Two deep-dark clear hours qualify; the fully-clouded (Q == 0) and daytime
+    # hours are dropped.
     assert [h["time"] for h in hours] == [
         "2026-06-13T22:00:00Z",
         "2026-06-13T23:00:00Z",
@@ -88,7 +92,10 @@ def test_score_location_keeps_only_qualifying_hours_sorted(monkeypatch):
     for h in hours:
         assert set(h.keys()) == _EXPECTED_KEYS
     first = hours[0]
+    # Deep dark (-20 -> darkness 1.0) + 5% cloud (under the 10% allowance) +
+    # ideal weather -> full quality.
     assert first["score"] == 100.0
+    assert first["sun_elevation_deg"] == -20.0
     assert first["cloud_area_fraction"] == 5
     assert first["relative_humidity"] == 55
     assert first["wind_speed"] == 2

--- a/projects/monolith/stars/jobs.py
+++ b/projects/monolith/stars/jobs.py
@@ -44,6 +44,7 @@ def _write_sites(session: Session, scored: dict[str, list[dict]], now: datetime)
             wind_speed=h["wind_speed"],
             air_temperature=h["air_temperature"],
             dew_spread=h["dew_spread"],
+            sun_elevation_deg=h["sun_elevation_deg"],
             symbol=h["symbol"],
             fetched_at=now,
         )

--- a/projects/monolith/stars/jobs_test.py
+++ b/projects/monolith/stars/jobs_test.py
@@ -51,6 +51,7 @@ def _hour(time_str, score=80.0):
     return {
         "time": time_str,
         "score": score,
+        "sun_elevation_deg": -18.5,
         "cloud_area_fraction": 10.0,
         "relative_humidity": 60.0,
         "wind_speed": 3.0,
@@ -99,6 +100,8 @@ def test_write_sites_inserts_rows_for_each_site(session):
     )
     assert gf is not None
     assert gf.score == 90.0
+    # The sun elevation written by the forecast flows through to the row.
+    assert gf.sun_elevation_deg == -18.5
     # A single shared fetched_at is stamped across the whole run.
     assert len({r.fetched_at for r in rows}) == 1
 

--- a/projects/monolith/stars/models.py
+++ b/projects/monolith/stars/models.py
@@ -23,5 +23,6 @@ class SiteHour(SQLModel, table=True):  # nosemgrep: sqlmodel-datetime-without-fa
     wind_speed: float
     air_temperature: float
     dew_spread: float
+    sun_elevation_deg: float = Field(default=0.0)
     symbol: str = ""
     fetched_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))

--- a/projects/monolith/stars/models_test.py
+++ b/projects/monolith/stars/models_test.py
@@ -45,6 +45,7 @@ def test_site_hour_roundtrip(session):
         wind_speed=3.0,
         air_temperature=8.0,
         dew_spread=5.0,
+        sun_elevation_deg=-18.5,
         symbol="clearsky_night",
     )
     session.add(row)
@@ -59,6 +60,7 @@ def test_site_hour_roundtrip(session):
     assert loaded.wind_speed == 3.0
     assert loaded.air_temperature == 8.0
     assert loaded.dew_spread == 5.0
+    assert loaded.sun_elevation_deg == -18.5
     assert loaded.symbol == "clearsky_night"
     # SQLite returns naive datetimes (no tz-aware type), so assert the type
     # only, not tzinfo, matching hikes/models_test. Production is Postgres

--- a/projects/monolith/stars/router.py
+++ b/projects/monolith/stars/router.py
@@ -5,6 +5,11 @@ One read endpoint backs the /app/stars dark-sky planner:
 - ``GET /api/stars/sites``, every curated Scotland dark-sky site joined with
   its best upcoming viewing hours, for the site list + detail cards.
 
+Each hour's ``score`` is the ADR 007 continuous stargazing quality (0..100,
+Q = darkness x cloud x weather), not the old additive astronomy score with a
+fixed display floor. ``best_score`` is the max quality across a site's future
+hours and drives the map ordering and marker colour.
+
 Reached only from SvelteKit SSR (``http://localhost:8000`` in the same pod);
 the /app/stars page is the public surface and the CDN fans out to viewers, per
 ADR 002. Conditional GETs short-circuit with a 304 via ETag.

--- a/projects/monolith/stars/scoring.py
+++ b/projects/monolith/stars/scoring.py
@@ -35,6 +35,44 @@ class ScoredForecast(BaseModel):
     symbol: str = ""
 
 
+def _humidity_score(weather: WeatherData) -> float:
+    """Relative-humidity sub-score (0-100). Lifted verbatim from the inline
+    humidity branch of calculate_astronomy_score; reused by weather_modifier."""
+    if weather.relative_humidity < 70:
+        return 100
+    if weather.relative_humidity < 85:
+        return 100 - (weather.relative_humidity - 70) * 3.33
+    return max(0, 50 - (weather.relative_humidity - 85) * 3.33)
+
+
+def _fog_score(weather: WeatherData) -> float:
+    """Fog sub-score (0-100). Lifted verbatim from the inline fog branch."""
+    if weather.fog_area_fraction < 5:
+        return 100
+    if weather.fog_area_fraction < 20:
+        return 100 - (weather.fog_area_fraction - 5) * 3.33
+    return max(0, 50 - (weather.fog_area_fraction - 20) * 1.67)
+
+
+def _wind_score(weather: WeatherData) -> float:
+    """Wind sub-score (0-100). Lifted verbatim from the inline wind branch."""
+    if weather.wind_speed < 5:
+        return 100
+    if weather.wind_speed < 10:
+        return 100 - (weather.wind_speed - 5) * 10
+    return max(0, 50 - (weather.wind_speed - 10) * 5)
+
+
+def _dew_score(weather: WeatherData) -> float:
+    """Dew-spread sub-score (0-100). Lifted verbatim from the inline dew branch."""
+    dew_spread = weather.air_temperature - weather.dew_point_temperature
+    if dew_spread > 5:
+        return 100
+    if dew_spread > 2:
+        return 100 - (5 - dew_spread) * 16.67
+    return max(0, 50 - (2 - dew_spread) * 25)
+
+
 def calculate_astronomy_score(weather: WeatherData) -> float:
     """Calculate astronomy suitability score (0-100).
 
@@ -47,34 +85,10 @@ def calculate_astronomy_score(weather: WeatherData) -> float:
     else:
         cloud_score = max(0, 50 - (weather.cloud_area_fraction - 50))
 
-    if weather.relative_humidity < 70:
-        humidity_score = 100
-    elif weather.relative_humidity < 85:
-        humidity_score = 100 - (weather.relative_humidity - 70) * 3.33
-    else:
-        humidity_score = max(0, 50 - (weather.relative_humidity - 85) * 3.33)
-
-    if weather.fog_area_fraction < 5:
-        fog_score = 100
-    elif weather.fog_area_fraction < 20:
-        fog_score = 100 - (weather.fog_area_fraction - 5) * 3.33
-    else:
-        fog_score = max(0, 50 - (weather.fog_area_fraction - 20) * 1.67)
-
-    if weather.wind_speed < 5:
-        wind_score = 100
-    elif weather.wind_speed < 10:
-        wind_score = 100 - (weather.wind_speed - 5) * 10
-    else:
-        wind_score = max(0, 50 - (weather.wind_speed - 10) * 5)
-
-    dew_spread = weather.air_temperature - weather.dew_point_temperature
-    if dew_spread > 5:
-        dew_score = 100
-    elif dew_spread > 2:
-        dew_score = 100 - (5 - dew_spread) * 16.67
-    else:
-        dew_score = max(0, 50 - (2 - dew_spread) * 25)
+    humidity_score = _humidity_score(weather)
+    fog_score = _fog_score(weather)
+    wind_score = _wind_score(weather)
+    dew_score = _dew_score(weather)
 
     pressure_bonus = 0
     if weather.air_pressure_at_sea_level > 1015:
@@ -89,6 +103,56 @@ def calculate_astronomy_score(weather: WeatherData) -> float:
         + pressure_bonus
     )
     return min(100, max(0, weighted))
+
+
+CIVIL_TWILIGHT_DEG = -6.0
+ASTRONOMICAL_DEG = -18.0
+CLOUD_FALLOFF_SPAN = 45.0  # cloud % beyond the darkness-scaled allowance at which the cloud factor reaches 0
+
+
+def darkness_factor(sun_elevation_deg: float) -> float:
+    """Continuous darkness 0..1: 0 at civil twilight (-6 deg), 1 at astronomical
+    darkness (-18 deg); nautical (-12 deg) lands at 0.5 (ADR 007)."""
+    if sun_elevation_deg >= CIVIL_TWILIGHT_DEG:
+        return 0.0
+    if sun_elevation_deg <= ASTRONOMICAL_DEG:
+        return 1.0
+    return (CIVIL_TWILIGHT_DEG - sun_elevation_deg) / (
+        CIVIL_TWILIGHT_DEG - ASTRONOMICAL_DEG
+    )
+
+
+def cloud_factor(cloud_area_fraction: float, darkness: float) -> float:
+    """Cloud 0..1 with a darkness-scaled allowance: full credit up to ~5% cloud
+    when only ok-dark and ~10% when very dark, then linear falloff (ADR 007).
+    Deeper darkness forgives more cloud."""
+    allowance = 5.0 + 5.0 * darkness
+    excess = max(0.0, cloud_area_fraction - allowance)
+    return max(0.0, 1.0 - excess / CLOUD_FALLOFF_SPAN)
+
+
+def weather_modifier(weather: WeatherData) -> float:
+    """Non-cloud weather (humidity, fog, wind, dew) folded into a 0.7..1.0
+    modifier so it nudges quality without overpowering the darkness/cloud core.
+    Reuses the same per-component sub-scores as calculate_astronomy_score."""
+    avg = (
+        _humidity_score(weather)
+        + _fog_score(weather)
+        + _wind_score(weather)
+        + _dew_score(weather)
+    ) / 4.0  # each is 0..100
+    return 0.7 + 0.3 * (avg / 100.0)
+
+
+def quality_score(weather: WeatherData, sun_elevation_deg: float) -> float:
+    """Continuous stargazing quality 0..100 = D x C x W (ADR 007). 0 when the
+    sky is not at least civil-dark."""
+    d = darkness_factor(sun_elevation_deg)
+    if d <= 0.0:
+        return 0.0
+    c = cloud_factor(weather.cloud_area_fraction, d)
+    w = weather_modifier(weather)
+    return d * c * w * 100.0
 
 
 def is_dark_enough(

--- a/projects/monolith/stars/scoring_test.py
+++ b/projects/monolith/stars/scoring_test.py
@@ -6,7 +6,11 @@ from stars.scoring import (
     ScoredForecast,
     WeatherData,
     calculate_astronomy_score,
+    cloud_factor,
+    darkness_factor,
     is_dark_enough,
+    quality_score,
+    weather_modifier,
 )
 
 
@@ -308,3 +312,100 @@ class TestIsDarkEnough:
     def test_custom_threshold_civil(self):
         assert is_dark_enough(-6.0, astronomical_darkness_threshold=-6.0) is True
         assert is_dark_enough(-5.9, astronomical_darkness_threshold=-6.0) is False
+
+
+class TestDarknessFactor:
+    def test_civil_twilight_is_zero(self):
+        assert darkness_factor(-6.0) == 0.0
+
+    def test_nautical_twilight_is_half(self):
+        assert darkness_factor(-12.0) == pytest.approx(0.5)
+
+    def test_astronomical_is_one(self):
+        assert darkness_factor(-18.0) == 1.0
+
+    def test_daytime_is_zero(self):
+        assert darkness_factor(0.0) == 0.0
+
+    def test_deep_dark_clamps_at_one(self):
+        assert darkness_factor(-30.0) == 1.0
+
+
+class TestCloudFactor:
+    def test_very_dark_full_credit_within_allowance(self):
+        # darkness=1 -> allowance 10; 8% cloud is under it, full credit.
+        assert cloud_factor(8.0, 1.0) == 1.0
+
+    def test_very_dark_reaches_zero_at_span(self):
+        # darkness=1 -> allowance 10; 55% cloud is allowance + 45 span -> 0.
+        assert cloud_factor(55.0, 1.0) == 0.0
+
+    def test_very_dark_midpoint(self):
+        # darkness=1 -> allowance 10; 32.5% cloud -> excess 22.5 / 45 -> 0.5.
+        assert cloud_factor(32.5, 1.0) == pytest.approx(0.5)
+
+    def test_ok_dark_full_credit_within_allowance(self):
+        # darkness=0.5 -> allowance 7.5; 4% cloud is under it, full credit.
+        assert cloud_factor(4.0, 0.5) == 1.0
+
+
+class TestWeatherModifier:
+    def _ideal(self) -> WeatherData:
+        return WeatherData(
+            cloud_area_fraction=0.0,
+            relative_humidity=40.0,
+            fog_area_fraction=0.0,
+            wind_speed=1.0,
+            air_temperature=5.0,
+            dew_point_temperature=-2.0,
+            air_pressure_at_sea_level=1020.0,
+        )
+
+    def _poor(self) -> WeatherData:
+        return WeatherData(
+            cloud_area_fraction=0.0,
+            relative_humidity=100.0,
+            fog_area_fraction=100.0,
+            wind_speed=100.0,
+            air_temperature=5.0,
+            dew_point_temperature=5.0,
+            air_pressure_at_sea_level=1000.0,
+        )
+
+    def test_within_bounds_ideal(self):
+        m = weather_modifier(self._ideal())
+        assert 0.7 <= m <= 1.0
+
+    def test_within_bounds_poor(self):
+        m = weather_modifier(self._poor())
+        assert 0.7 <= m <= 1.0
+
+    def test_ideal_is_full(self):
+        assert weather_modifier(self._ideal()) == pytest.approx(1.0)
+
+
+class TestQualityScore:
+    def _ideal(self, cloud: float = 0.0) -> WeatherData:
+        return WeatherData(
+            cloud_area_fraction=cloud,
+            relative_humidity=40.0,
+            fog_area_fraction=0.0,
+            wind_speed=1.0,
+            air_temperature=5.0,
+            dew_point_temperature=-2.0,
+            air_pressure_at_sea_level=1020.0,
+        )
+
+    def test_ideal_deep_dark_near_100(self):
+        assert quality_score(self._ideal(), -18.0) > 90.0
+
+    def test_ideal_nautical_near_50(self):
+        q = quality_score(self._ideal(), -12.0)
+        assert 45.0 < q < 55.0
+
+    def test_cloud_drags_quality_down(self):
+        q = quality_score(self._ideal(cloud=40.0), -18.0)
+        assert 25.0 < q < 45.0
+
+    def test_not_dark_is_zero(self):
+        assert quality_score(self._ideal(), -3.0) == 0.0


### PR DESCRIPTION
Implements ADR 007's continuous stargazing quality model on the existing ~30 curated stars sites. Replaces the hard darkness gate (sun <= -12) plus the additive astronomy-score >= 60 floor with a single continuous quality per forecast hour:

Q = D x C x W

- D (darkness): 0 at civil twilight (-6 deg), 0.5 at nautical (-12), 1 at astronomical (-18).
- C (cloud): darkness-scaled allowance (5% when ok-dark, 10% when very dark), then linear falloff over a 45-point span. Deeper darkness forgives more cloud.
- W (weather modifier): humidity/fog/wind/dew folded into a 0.7..1.0 nudge, reusing the same per-component sub-scores as calculate_astronomy_score.

All civil-dark hours are kept and ranked by Q, so summer surfaces "best available" instead of going empty. The sun elevation is now stored per hour.

## Changes
- scoring.py: extracted `_humidity_score`/`_fog_score`/`_wind_score`/`_dew_score` (verbatim) and refactored `calculate_astronomy_score` to call them (behaviour-preserving, parity suite unchanged). Added `darkness_factor`, `cloud_factor`, `weather_modifier`, `quality_score`.
- Migration `20260613000030_stars_sun_elevation.sql` + `SiteHour.sun_elevation_deg` + regenerated `atlas.sum`.
- forecast.py: keep-all-dark-hours ranked by Q, record `sun_elevation_deg`; removed `MIN_DISPLAY_SCORE` / `NAUTICAL_TWILIGHT_DEG`. jobs.py writes the new column.
- StarsMap.svelte: retuned `SCORE_BUCKETS` and step boundaries to 35 / 65 for the Q distribution. Empty-state copy reworded off the fixed score number.
- Chart bumped 0.127.1 -> 0.127.2 (Chart.yaml + application.yaml targetRevision).

## Worked examples the tests assert
- darkness_factor: -6 -> 0, -12 -> 0.5, -18 -> 1, 0 -> 0, -30 -> 1
- cloud_factor (darkness=1, allowance 10): 8% -> 1.0, 55% -> 0.0, 32.5% -> 0.5; (darkness=0.5, allowance 7.5): 4% -> 1.0
- quality_score (ideal weather): -18 -> 100 (>90), -12 -> 50 (45<q<55), -18 with 40% cloud -> 33.3 (25<q<45), -3 -> 0

Tests not run locally per repo workflow; relying on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)