### PR TITLE
fix(argocd): ignore Kyverno-injected OTEL fields in Deployment diffs

### DIFF
--- a/projects/platform/argocd/Chart.yaml
+++ b/projects/platform/argocd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: argocd
 description: local argocd
 type: application
-version: 0.1.1
+version: 0.1.2
 appVersion: "2.13.2"
 dependencies:
   - name: argo-cd

--- a/projects/platform/argocd/values.yaml
+++ b/projects/platform/argocd/values.yaml
@@ -11,6 +11,20 @@ argo-cd:
   configs:
     cm:
       accounts.mcp-agent: apiKey
+      # Kyverno's inject-otel-env-vars ClusterPolicy mutates every Deployment at
+      # admission to add the OTEL_EXPORTER_OTLP_* env vars (and an
+      # otel.injected-by pod-template annotation). ArgoCD renders charts without
+      # those injected fields, so it permanently reports such Deployments as
+      # OutOfSync (Healthy, but the noise hides genuine drift). Ignore exactly the
+      # injected fields cluster-wide, keyed by field rather than by a name list,
+      # so any real change to other Deployment fields still surfaces.
+      # Policy: projects/platform/kyverno/templates/otel-injection-policy.yaml.
+      resource.customizations.ignoreDifferences.apps_Deployment: |
+        jqPathExpressions:
+          - '.spec.template.spec.containers[].env[]? | select(.name | startswith("OTEL_"))'
+          - '.spec.template.spec.initContainers[]?.env[]? | select(.name | startswith("OTEL_"))'
+        jsonPointers:
+          - /spec/template/metadata/annotations/otel.injected-by
     rbac:
       policy.csv: |
         p, mcp-agent, applications, *, */*, allow


### PR DESCRIPTION
## What

Adds a global `resource.customizations.ignoreDifferences.apps_Deployment` to the ArgoCD config so the Kyverno-injected OTEL fields stop showing as drift.

## Why

The `inject-otel-env-vars` ClusterPolicy (`projects/platform/kyverno/templates/otel-injection-policy.yaml`, ~209 days old) mutates **every** Deployment/StatefulSet/DaemonSet at admission to add:

- `OTEL_EXPORTER_OTLP_ENDPOINT` / `OTEL_EXPORTER_OTLP_PROTOCOL` / `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` env vars, and
- an `otel.injected-by: kyverno/inject-otel-env-vars` pod-template annotation.

ArgoCD renders charts from source without those injected fields, so it permanently reports affected Deployments as **OutOfSync** (still **Healthy**). Today `monolith` and `agent-platform-nats-box` are both stuck this way. The noise hides genuine drift.

`managedFieldsManagers: [kyverno]` does **not** work here: webhook mutations are attributed to the request's field manager, not Kyverno (the live object's managers are `kubectl-rollout` / `argocd-controller` / `k3s`), so the fix is keyed on the injected fields directly.

## How

```yaml
resource.customizations.ignoreDifferences.apps_Deployment: |
  jqPathExpressions:
    - '.spec.template.spec.containers[].env[]? | select(.name | startswith("OTEL_"))'
    - '.spec.template.spec.initContainers[]?.env[]? | select(.name | startswith("OTEL_"))'
  jsonPointers:
    - /spec/template/metadata/annotations/otel.injected-by
```

Scoped to exactly the injected fields, so any real change to other Deployment fields (image, replicas, non-OTEL env, resources) still surfaces as drift. Global (cluster-wide) rather than per-app because the policy is cluster-wide and the same drift will hit any future OTEL-injected app.

## Verification

- `helm template` renders the key well-formed into the `argocd-cm` ConfigMap data alongside the chart's preset `ignoreResourceUpdates.*` entries.
- Chart version bumped `0.1.1 -> 0.1.2`. The argocd app syncs from a git path at `targetRevision: HEAD` (not an OCI-pinned chart), so there is no `targetRevision` to keep in sync.

## Note

Unrelated to but discovered during the hikes `walk_hours` migration deploy. There is also a one-off stale `kubectl.kubernetes.io/restartedAt` annotation on the `monolith` Deployment from a manual `kubectl rollout restart` in April; if `monolith` does not go fully Synced after this lands, that residual annotation is the cause and can be cleared with a one-time sync or a small follow-up ignore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)