### PR TITLE
fix(argocd): restore apiVersion on the private HTTPRoute manifest

### DIFF
--- a/projects/platform/argocd/Chart.yaml
+++ b/projects/platform/argocd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: argocd
 description: local argocd
 type: application
-version: 0.1.2
+version: 0.1.3
 appVersion: "2.13.2"
 dependencies:
   - name: argo-cd

--- a/projects/platform/argocd/templates/httproute.yaml
+++ b/projects/platform/argocd/templates/httproute.yaml
@@ -25,7 +25,7 @@ updated to include /app/argocd.
   "gateway" .Values.cfIngress.gateway
 }}
 # nosemgrep: cfingress-rewrite-needs-slash-redirect
-{{- $_ := set $routeParams "rewritePrefix" "/" }}
+{{ $_ := set $routeParams "rewritePrefix" "/" }}
 {{- include "cf-ingress.httproute" $routeParams }}
 ---
 {{- include "cf-ingress.security-policy" (dict "name" "argocd-private") }}


### PR DESCRIPTION
## What

A one-character Helm whitespace fix that restores the missing `apiVersion` on the `argocd-private` HTTPRoute.

## Root cause

`projects/platform/argocd/templates/httproute.yaml` rendered the HTTPRoute **without an `apiVersion`**:

```
# nosemgrep: cfingress-rewrite-needs-slash-redirect
{{- $_ := set $routeParams "rewritePrefix" "/" }}   <- left-trim ate the comment's newline
{{- include "cf-ingress.httproute" $routeParams }}  <- starts with apiVersion: ...
```

The `{{-` on the `set` line trimmed the newline after the `# nosemgrep` comment, so the include's first line (`apiVersion: gateway.networking.k8s.io/v1`) was glued onto the comment line and swallowed by the `#`. The rendered doc began at `kind: HTTPRoute` with no `apiVersion`.

## Impact

ArgoCD tracked the resource with an **empty group/version**, so the self-managed `argocd` Application wedged on `ComparisonError: ... groupVersion shouldn't be empty`. With the comparison broken, ArgoCD could not apply *any* new config to itself, including the OTEL `ignoreDifferences` from #2564. (The live HTTPRoute kept working because it was applied back when the template was correct.) Only the `argocd` app was affected — other cf-ingress users were unaffected because this construct is unique to this template.

## Fix

Drop the left-trim on the `set` line (`{{-` -> `{{`) so the `# nosemgrep` comment keeps its own line. The nosemgrep stays immediately before `rewritePrefix` (the rule anchors there per `bazel/semgrep/tests/fixtures/cfingress-rewrite-needs-slash-redirect.yaml`), and the rendered manifest regains its `apiVersion`.

## Verification

`helm template` now renders:

```
# nosemgrep: cfingress-rewrite-needs-slash-redirect
apiVersion: gateway.networking.k8s.io/v1
kind: HTTPRoute
```

Local semgrep pre-commit passed (suppression still active). Chart bumped `0.1.2 -> 0.1.3`. After merge, the `argocd` app needs a hard refresh to re-render the corrected manifest and clear the wedge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)