### PR TITLE
fix(argocd): ignore kubectl restartedAt annotation on Deployments

### DIFF
--- a/projects/platform/argocd/Chart.yaml
+++ b/projects/platform/argocd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: argocd
 description: local argocd
 type: application
-version: 0.1.3
+version: 0.1.4
 appVersion: "2.13.2"
 dependencies:
   - name: argo-cd

--- a/projects/platform/argocd/values.yaml
+++ b/projects/platform/argocd/values.yaml
@@ -19,12 +19,19 @@ argo-cd:
       # injected fields cluster-wide, keyed by field rather than by a name list,
       # so any real change to other Deployment fields still surfaces.
       # Policy: projects/platform/kyverno/templates/otel-injection-policy.yaml.
+      #
+      # Also ignore kubectl.kubernetes.io/restartedAt: it is written by
+      # `kubectl rollout restart`, never appears in a chart, and otherwise leaves
+      # any manually-restarted Deployment permanently OutOfSync (e.g. monolith
+      # carried one from an April restart). The "/" in the annotation key is
+      # JSON-Pointer-escaped as "~1".
       resource.customizations.ignoreDifferences.apps_Deployment: |
         jqPathExpressions:
           - '.spec.template.spec.containers[].env[]? | select(.name | startswith("OTEL_"))'
           - '.spec.template.spec.initContainers[]?.env[]? | select(.name | startswith("OTEL_"))'
         jsonPointers:
           - /spec/template/metadata/annotations/otel.injected-by
+          - /spec/template/metadata/annotations/kubectl.kubernetes.io~1restartedAt
     rbac:
       policy.csv: |
         p, mcp-agent, applications, *, */*, allow


### PR DESCRIPTION
## What

Extends the global `apps_Deployment` `ignoreDifferences` (added in #2564) to also ignore the `kubectl.kubernetes.io/restartedAt` pod-template annotation.

## Why

After #2564 (OTEL env/annotation) and #2567 (the apiVersion wedge fix) landed, `monolith` was *still* OutOfSync on a second chart-absent field: `kubectl.kubernetes.io/restartedAt`, written by a `kubectl rollout restart` back in April. That annotation never appears in a chart, so ArgoCD will always flag a manually-restarted Deployment as drift.

Verified the OTEL jqPathExpression genuinely matches the live injected env (`OTEL_EXPORTER_OTLP_*` across all three monolith containers), and that `restartedAt` is the only remaining chart-absent field, so this is the last piece.

## How

```yaml
jsonPointers:
  - /spec/template/metadata/annotations/otel.injected-by
  - /spec/template/metadata/annotations/kubectl.kubernetes.io~1restartedAt   # new
```

(`/` in the annotation key is JSON-Pointer-escaped as `~1`.) Cluster-wide, so any manually-restarted Deployment stays Synced. Chart bumped `0.1.3 -> 0.1.4`. Verified via `helm template`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)