### PR TITLE
fix(argocd): ignore only the two Kyverno-injected OTEL env vars

### DIFF
--- a/projects/platform/argocd/Chart.yaml
+++ b/projects/platform/argocd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: argocd
 description: local argocd
 type: application
-version: 0.1.4
+version: 0.1.5
 appVersion: "2.13.2"
 dependencies:
   - name: argo-cd

--- a/projects/platform/argocd/values.yaml
+++ b/projects/platform/argocd/values.yaml
@@ -12,12 +12,14 @@ argo-cd:
     cm:
       accounts.mcp-agent: apiKey
       # Kyverno's inject-otel-env-vars ClusterPolicy mutates every Deployment at
-      # admission to add the OTEL_EXPORTER_OTLP_* env vars (and an
-      # otel.injected-by pod-template annotation). ArgoCD renders charts without
-      # those injected fields, so it permanently reports such Deployments as
-      # OutOfSync (Healthy, but the noise hides genuine drift). Ignore exactly the
-      # injected fields cluster-wide, keyed by field rather than by a name list,
-      # so any real change to other Deployment fields still surfaces.
+      # admission to add the otel.injected-by annotation and exactly two env
+      # vars: OTEL_EXPORTER_OTLP_ENDPOINT and OTEL_EXPORTER_OTLP_PROTOCOL. ArgoCD
+      # renders charts without those, so affected Deployments sit permanently
+      # OutOfSync (Healthy, but the noise hides genuine drift). Ignore EXACTLY the
+      # two injected names, not all OTEL_* : charts define their own OTEL vars
+      # (e.g. monolith sets OTEL_EXPORTER_OTLP_TRACES_ENDPOINT and
+      # OTEL_COLLECTOR_HTTP_URL), and a startswith("OTEL_") match would strip
+      # those from the live side too and manufacture a fresh diff.
       # Policy: projects/platform/kyverno/templates/otel-injection-policy.yaml.
       #
       # Also ignore kubectl.kubernetes.io/restartedAt: it is written by
@@ -27,8 +29,8 @@ argo-cd:
       # JSON-Pointer-escaped as "~1".
       resource.customizations.ignoreDifferences.apps_Deployment: |
         jqPathExpressions:
-          - '.spec.template.spec.containers[].env[]? | select(.name | startswith("OTEL_"))'
-          - '.spec.template.spec.initContainers[]?.env[]? | select(.name | startswith("OTEL_"))'
+          - '.spec.template.spec.containers[].env[]? | select(.name == "OTEL_EXPORTER_OTLP_ENDPOINT" or .name == "OTEL_EXPORTER_OTLP_PROTOCOL")'
+          - '.spec.template.spec.initContainers[]?.env[]? | select(.name == "OTEL_EXPORTER_OTLP_ENDPOINT" or .name == "OTEL_EXPORTER_OTLP_PROTOCOL")'
         jsonPointers:
           - /spec/template/metadata/annotations/otel.injected-by
           - /spec/template/metadata/annotations/kubectl.kubernetes.io~1restartedAt


### PR DESCRIPTION
## What

Narrows the `apps_Deployment` `ignoreDifferences` env match from `startswith("OTEL_")` to the two exact names Kyverno actually injects.

## Why

#2564 used `select(.name | startswith("OTEL_"))`, assuming all `OTEL_*` env on a Deployment was Kyverno-injected. It is not: the monolith chart defines its own `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` (backend) and `OTEL_COLLECTOR_HTTP_URL` (frontend). The broad match stripped those from the **live** side during normalization, so live appeared to *lack* env vars the target has, and `monolith` stayed OutOfSync (now target-only instead of live-only).

The ArgoCD managed-resources normalized diff showed exactly this:
```
container backend:  target-only env = [OTEL_EXPORTER_OTLP_TRACES_ENDPOINT]
container frontend: target-only env = [OTEL_COLLECTOR_HTTP_URL]
```
And the `inject-otel-env-vars` policy's mutate list injects exactly:
```
OTEL_EXPORTER_OTLP_ENDPOINT, OTEL_EXPORTER_OTLP_PROTOCOL
```

## How

```yaml
jqPathExpressions:
  - '... .env[]? | select(.name == "OTEL_EXPORTER_OTLP_ENDPOINT" or .name == "OTEL_EXPORTER_OTLP_PROTOCOL")'
```
Matches only the injected pair, leaving chart-defined OTEL vars untouched on both sides. Verified the jq matches exactly the 6 injected entries (2 × 3 containers) on the live monolith Deployment and none of the chart's. Annotation ignores (`otel.injected-by`, `restartedAt`) unchanged. Chart bumped `0.1.4 -> 0.1.5`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)