### PR TITLE
feat(stars): order best hours chronologically and add a night filter

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.129.0
+version: 0.130.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.128.0
+version: 0.129.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.127.6
+version: 0.128.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.128.0
+      targetRevision: 0.129.0
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.127.6
+      targetRevision: 0.128.0
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.129.0
+      targetRevision: 0.130.0
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/lib/public/components/stars/StarsMap.svelte
+++ b/projects/monolith/frontend/src/lib/public/components/stars/StarsMap.svelte
@@ -3,9 +3,13 @@
   import "maplibre-gl/dist/maplibre-gl.css";
 
   // `sites` is the curated dark-sky list to plot; clicking a dot opens the
-  // detail card. `nowMs` is a coarse clock signal from the parent so the card
-  // can drop hours that have already elapsed between SSR loads.
-  let { sites = [], nowMs = Date.now() } = $props();
+  // detail card. `activeNights` is the set of selected night keys (evening
+  // dates) from the parent's night filter: a marker is coloured by the best
+  // score it reaches across those nights, and drops off the map when none of
+  // its hours fall on a selected night. `nowMs` is a coarse clock signal from
+  // the parent so the card can drop hours that have already elapsed between
+  // SSR loads.
+  let { sites = [], activeNights = new Set(), nowMs = Date.now() } = $props();
 
   // OpenFreeMap needs no API key (same hosted liberty style as /app/ships and
   // /app/hikes, so the maps read as siblings). The liberty style ships light and
@@ -107,15 +111,32 @@
     };
   }
 
+  // Best score this site reaches across the currently selected nights, or null
+  // when none of its hours fall on an active night (so it drops off the map,
+  // mirroring how the ships type filter hides deselected vessels). With every
+  // night selected this equals best_score, so the default view is unchanged.
+  function effectiveScore(site) {
+    if (!activeNights || activeNights.size === 0) return null;
+    const ns = site.night_scores || {};
+    let best = null;
+    for (const night of activeNights) {
+      const s = ns[night];
+      if (s != null && (best === null || s > best)) best = s;
+    }
+    return best;
+  }
+
   function buildFeatures() {
     const features = [];
     for (const site of sites) {
       if (!validLatLon(site.lat, site.lon)) continue;
+      const score = effectiveScore(site);
+      if (score === null) continue;
       features.push({
         type: "Feature",
         id: site.id,
         geometry: { type: "Point", coordinates: [site.lon, site.lat] },
-        properties: { id: site.id, score: site.best_score ?? 0 },
+        properties: { id: site.id, score },
       });
     }
     return { type: "FeatureCollection", features };
@@ -149,6 +170,13 @@
   $effect(() => {
     void sites;
     if (map && layerReady) syncSites();
+  });
+
+  // Recolour/refilter the markers when the night selection changes. setData
+  // alone (no refit) keeps the viewport put while the dots restyle.
+  $effect(() => {
+    void activeNights;
+    if (map && layerReady) pushData();
   });
 
   onMount(() => {

--- a/projects/monolith/frontend/src/routes/public/app/stars/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/stars/+page.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { onMount, untrack } from "svelte";
+  import { onMount } from "svelte";
   import { invalidateAll } from "$app/navigation";
   import StarsMap from "$lib/public/components/stars/StarsMap.svelte";
 
@@ -8,35 +8,27 @@
   let sites = $derived(data.snapshot?.sites ?? []);
   let count = $derived(data.snapshot?.count ?? 0);
 
-  // Night-filter chips (like the ships vessel-type legend): each night the
-  // forecast covers is a toggle, and StarsMap recolours every marker by the
-  // best score it reaches across the selected nights. `nights` is the sorted
-  // union of evening dates (YYYY-MM-DD) the API returns.
+  // Night picker: "I'm free Saturday, show me the map for Saturday night." One
+  // chip per viewing night plus an "All" reset; picking a night filters the map
+  // to that night and StarsMap recolours each marker by the score it reaches
+  // then. `nights` is the sorted union of evening dates (YYYY-MM-DD) the API
+  // returns.
   let nights = $derived(data.snapshot?.nights ?? []);
-  // Seeded all-on from the initial payload so SSR and first paint render every
-  // chip selected; the effect below then reconciles it across SSR refreshes.
-  let activeNights = $state(new Set(data.snapshot?.nights ?? []));
-  // Plain (non-reactive) mirror of the last night set we reconciled against, so
-  // the effect below only re-runs off `nights`, never off its own writes.
-  let knownNights = new Set();
+  let selectedNight = $state("all"); // "all" or a night key
 
-  // Keep the selection in step with each SSR refresh: new nights default to on,
-  // nights that fall off the horizon drop out, and the user's toggles survive
-  // the 30 min refresh. A full turnover (or first load) starts all-on.
-  $effect(() => {
-    const incoming = new Set(nights);
-    untrack(() => {
-      let next;
-      if (knownNights.size === 0) {
-        next = new Set(incoming);
-      } else {
-        next = new Set([...activeNights].filter((n) => incoming.has(n)));
-        for (const n of incoming) if (!knownNights.has(n)) next.add(n);
-      }
-      knownNights = incoming;
-      activeNights = next;
-    });
-  });
+  // Fall back to "all" if the chosen night has dropped off the forecast horizon
+  // on an SSR refresh (it elapsed). Derived, so there is no effect to loop on.
+  let effectiveNight = $derived(
+    selectedNight !== "all" && nights.includes(selectedNight)
+      ? selectedNight
+      : "all",
+  );
+
+  // The nights the map scores against: every night for "all", else just the
+  // chosen one. StarsMap takes the max score across this set per marker.
+  let activeNights = $derived(
+    effectiveNight === "all" ? new Set(nights) : new Set([effectiveNight]),
+  );
 
   // Format a night key (the evening date) into a short "Sat 14" chip label.
   // Noon UTC keeps the weekday/day from rolling across the date line when
@@ -51,12 +43,8 @@
     });
   }
 
-  function toggleNight(key) {
-    // Reassign (not mutate) so the $state Set re-renders the chips + map.
-    const next = new Set(activeNights);
-    if (next.has(key)) next.delete(key);
-    else next.add(key);
-    activeNights = next;
+  function selectNight(key) {
+    selectedNight = key;
   }
   // sites is already sorted by best_score descending, so the head is the best.
   let topScore = $derived(
@@ -136,15 +124,24 @@
 
     {#if nights.length > 1}
       <div class="panel night-filter">
-        <p class="filter-title">Nights</p>
+        <p class="filter-title">Free on a night?</p>
         <div class="night-chips">
+          <button
+            type="button"
+            class="night-chip"
+            class:is-off={effectiveNight !== "all"}
+            aria-pressed={effectiveNight === "all"}
+            onclick={() => selectNight("all")}
+          >
+            All
+          </button>
           {#each nights as night (night)}
             <button
               type="button"
               class="night-chip"
-              class:is-off={!activeNights.has(night)}
-              aria-pressed={activeNights.has(night)}
-              onclick={() => toggleNight(night)}
+              class:is-off={effectiveNight !== night}
+              aria-pressed={effectiveNight === night}
+              onclick={() => selectNight(night)}
             >
               {nightLabel(night)}
             </button>

--- a/projects/monolith/frontend/src/routes/public/app/stars/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/stars/+page.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { onMount } from "svelte";
+  import { onMount, untrack } from "svelte";
   import { invalidateAll } from "$app/navigation";
   import StarsMap from "$lib/public/components/stars/StarsMap.svelte";
 
@@ -7,6 +7,57 @@
 
   let sites = $derived(data.snapshot?.sites ?? []);
   let count = $derived(data.snapshot?.count ?? 0);
+
+  // Night-filter chips (like the ships vessel-type legend): each night the
+  // forecast covers is a toggle, and StarsMap recolours every marker by the
+  // best score it reaches across the selected nights. `nights` is the sorted
+  // union of evening dates (YYYY-MM-DD) the API returns.
+  let nights = $derived(data.snapshot?.nights ?? []);
+  // Seeded all-on from the initial payload so SSR and first paint render every
+  // chip selected; the effect below then reconciles it across SSR refreshes.
+  let activeNights = $state(new Set(data.snapshot?.nights ?? []));
+  // Plain (non-reactive) mirror of the last night set we reconciled against, so
+  // the effect below only re-runs off `nights`, never off its own writes.
+  let knownNights = new Set();
+
+  // Keep the selection in step with each SSR refresh: new nights default to on,
+  // nights that fall off the horizon drop out, and the user's toggles survive
+  // the 30 min refresh. A full turnover (or first load) starts all-on.
+  $effect(() => {
+    const incoming = new Set(nights);
+    untrack(() => {
+      let next;
+      if (knownNights.size === 0) {
+        next = new Set(incoming);
+      } else {
+        next = new Set([...activeNights].filter((n) => incoming.has(n)));
+        for (const n of incoming) if (!knownNights.has(n)) next.add(n);
+      }
+      knownNights = incoming;
+      activeNights = next;
+    });
+  });
+
+  // Format a night key (the evening date) into a short "Sat 14" chip label.
+  // Noon UTC keeps the weekday/day from rolling across the date line when
+  // rendered in UK local time.
+  function nightLabel(key) {
+    const [y, m, d] = key.split("-").map(Number);
+    const dt = new Date(Date.UTC(y, m - 1, d, 12));
+    return dt.toLocaleDateString("en-GB", {
+      weekday: "short",
+      day: "numeric",
+      timeZone: "Europe/London",
+    });
+  }
+
+  function toggleNight(key) {
+    // Reassign (not mutate) so the $state Set re-renders the chips + map.
+    const next = new Set(activeNights);
+    if (next.has(key)) next.delete(key);
+    else next.add(key);
+    activeNights = next;
+  }
   // sites is already sorted by best_score descending, so the head is the best.
   let topScore = $derived(
     sites.length ? Math.round(sites[0].best_score ?? 0) : null,
@@ -60,7 +111,7 @@
 <div class="stars-page">
   <h1 class="sr-only">Dark-sky stargazing map, Scotland viewing windows</h1>
 
-  <StarsMap {sites} {nowMs} />
+  <StarsMap {sites} {activeNights} {nowMs} />
 
   <!-- Floating header: breadcrumb + headline stats, top-left clear of the map
        chrome (mirrors the hikes control head). -->
@@ -82,6 +133,25 @@
         </p>
       </div>
     </div>
+
+    {#if nights.length > 1}
+      <div class="panel night-filter">
+        <p class="filter-title">Nights</p>
+        <div class="night-chips">
+          {#each nights as night (night)}
+            <button
+              type="button"
+              class="night-chip"
+              class:is-off={!activeNights.has(night)}
+              aria-pressed={activeNights.has(night)}
+              onclick={() => toggleNight(night)}
+            >
+              {nightLabel(night)}
+            </button>
+          {/each}
+        </div>
+      </div>
+    {/if}
 
     {#if count === 0}
       <div class="panel empty-state" role="status">
@@ -204,6 +274,60 @@
     line-height: 1.5;
     letter-spacing: 0.02em;
     color: var(--ink-2);
+  }
+
+  /* Night-filter chips: a wrapped row of toggles, styled like the ships type
+     filter (bordered mono boxes; the off state dims but stays clickable). */
+  .filter-title {
+    font-family: var(--mono);
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--ink-2);
+    margin: 0 0 8px;
+  }
+
+  .night-chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+  }
+
+  .night-chip {
+    padding: 5px 9px;
+    background: var(--ink);
+    color: var(--paper);
+    border: 2px solid var(--ink);
+    font-family: var(--mono);
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    cursor: pointer;
+    transition:
+      transform 110ms ease,
+      box-shadow 110ms ease,
+      opacity 110ms ease,
+      background 110ms ease;
+  }
+
+  .night-chip:hover,
+  .night-chip:focus-visible {
+    transform: translate(-2px, -2px);
+    box-shadow: 2px 2px 0 var(--ink);
+  }
+
+  .night-chip:active {
+    transform: translate(-1px, -1px);
+    box-shadow: 1px 1px 0 var(--ink);
+  }
+
+  /* Deselected nights invert to paper + dim, so the active set reads at a
+     glance while staying clickable to re-enable. */
+  .night-chip.is-off {
+    background: var(--paper);
+    color: var(--ink);
+    opacity: 0.45;
   }
 
   @media (max-width: 640px) {

--- a/projects/monolith/frontend/src/routes/public/app/stars/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/stars/+page.svelte
@@ -15,6 +15,7 @@
   // returns.
   let nights = $derived(data.snapshot?.nights ?? []);
   let selectedNight = $state("all"); // "all" or a night key
+  let filterOpen = $state(false); // the night box is collapsed until tapped
 
   // Fall back to "all" if the chosen night has dropped off the forecast horizon
   // on an SSR refresh (it elapsed). Derived, so there is no effect to loop on.
@@ -45,6 +46,7 @@
 
   function selectNight(key) {
     selectedNight = key;
+    filterOpen = false; // collapse back to the summary once a night is picked
   }
   // sites is already sorted by best_score descending, so the head is the best.
   let topScore = $derived(
@@ -124,29 +126,46 @@
 
     {#if nights.length > 1}
       <div class="panel night-filter">
-        <p class="filter-title">Free on a night?</p>
-        <div class="night-chips">
-          <button
-            type="button"
-            class="night-chip"
-            class:is-off={effectiveNight !== "all"}
-            aria-pressed={effectiveNight === "all"}
-            onclick={() => selectNight("all")}
+        <button
+          type="button"
+          class="filter-toggle"
+          aria-expanded={filterOpen}
+          onclick={() => (filterOpen = !filterOpen)}
+        >
+          <span class="filter-label">Night</span>
+          <span class="filter-current"
+            >{effectiveNight === "all"
+              ? "All nights"
+              : nightLabel(effectiveNight)}</span
           >
-            All
-          </button>
-          {#each nights as night (night)}
+          <span class="filter-caret" class:open={filterOpen} aria-hidden="true"
+            >&#9662;</span
+          >
+        </button>
+        {#if filterOpen}
+          <div class="night-chips">
             <button
               type="button"
-              class="night-chip"
-              class:is-off={effectiveNight !== night}
-              aria-pressed={effectiveNight === night}
-              onclick={() => selectNight(night)}
+              class="night-chip night-chip-all"
+              class:is-off={effectiveNight !== "all"}
+              aria-pressed={effectiveNight === "all"}
+              onclick={() => selectNight("all")}
             >
-              {nightLabel(night)}
+              All nights
             </button>
-          {/each}
-        </div>
+            {#each nights as night (night)}
+              <button
+                type="button"
+                class="night-chip"
+                class:is-off={effectiveNight !== night}
+                aria-pressed={effectiveNight === night}
+                onclick={() => selectNight(night)}
+              >
+                {nightLabel(night)}
+              </button>
+            {/each}
+          </div>
+        {/if}
       </div>
     {/if}
 
@@ -273,26 +292,62 @@
     color: var(--ink-2);
   }
 
-  /* Night-filter chips: a wrapped row of toggles, styled like the ships type
-     filter (bordered mono boxes; the off state dims but stays clickable). */
-  .filter-title {
+  /* Night filter: a collapsed summary row that expands on click into a two-up
+     grid of night chips, so it stays out of the way until you reach for it. */
+  .night-filter {
+    padding: 0;
+  }
+
+  .filter-toggle {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    width: 100%;
+    padding: 10px 12px;
+    background: var(--paper);
+    border: none;
+    cursor: pointer;
     font-family: var(--mono);
+    color: var(--ink);
+  }
+
+  .filter-label {
     font-size: 10px;
     font-weight: 700;
     letter-spacing: 0.1em;
     text-transform: uppercase;
     color: var(--ink-2);
-    margin: 0 0 8px;
   }
 
+  .filter-current {
+    margin-left: auto;
+    font-size: 12px;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+  }
+
+  .filter-caret {
+    font-size: 11px;
+    color: var(--ink-2);
+    transition: transform 140ms ease;
+  }
+
+  .filter-caret.open {
+    transform: rotate(180deg);
+  }
+
+  /* Two-column grid of chips, revealed below the summary when expanded; the top
+     rule separates it from the toggle row. */
   .night-chips {
-    display: flex;
-    flex-wrap: wrap;
+    display: grid;
+    grid-template-columns: 1fr 1fr;
     gap: 6px;
+    padding: 10px 12px 12px;
+    border-top: 2px solid var(--ink);
   }
 
   .night-chip {
-    padding: 5px 9px;
+    padding: 6px 9px;
     background: var(--ink);
     color: var(--paper);
     border: 2px solid var(--ink);
@@ -300,6 +355,7 @@
     font-size: 11px;
     font-weight: 700;
     letter-spacing: 0.04em;
+    text-align: center;
     cursor: pointer;
     transition:
       transform 110ms ease,
@@ -319,12 +375,17 @@
     box-shadow: 1px 1px 0 var(--ink);
   }
 
-  /* Deselected nights invert to paper + dim, so the active set reads at a
-     glance while staying clickable to re-enable. */
+  /* The picked night is the filled chip; the rest invert to paper + dim so the
+     current selection reads at a glance while staying tappable. */
   .night-chip.is-off {
     background: var(--paper);
     color: var(--ink);
-    opacity: 0.45;
+    opacity: 0.55;
+  }
+
+  /* The reset spans the full width above the per-night grid. */
+  .night-chip-all {
+    grid-column: 1 / -1;
   }
 
   @media (max-width: 640px) {

--- a/projects/monolith/stars/router.py
+++ b/projects/monolith/stars/router.py
@@ -24,7 +24,8 @@ been pruned yet is still excluded here.
 from __future__ import annotations
 
 import logging
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
+from zoneinfo import ZoneInfo
 
 from fastapi import APIRouter, Depends, Request, Response
 from sqlmodel import Session, select
@@ -40,6 +41,14 @@ router = APIRouter(prefix="/api/stars", tags=["stars"])
 # Cap each site's hour list to the top N by score, so the payload stays light
 # even with a multi-day forecast horizon.
 _DISPLAY_HOURS = 8
+
+# Dark hours run across midnight, so a viewing "night" is not a calendar day.
+# We label each night by its evening date in UK local time: shifting the local
+# clock back 12 h folds an evening and the following pre-dawn hours into one
+# night key, so the map's night filter groups hours the way a stargazer thinks
+# about them (one outing = one night).
+_LONDON = ZoneInfo("Europe/London")
+_NIGHT_SHIFT = timedelta(hours=12)
 
 # Forecasts refresh hourly, so 30 min edge freshness with a 1 h SWR window is
 # plenty; max-age=0 makes the browser revalidate rather than hold a stale copy.
@@ -67,6 +76,19 @@ def _iso(value: datetime | None) -> str | None:
     """ISO-8601 string in UTC, or None. Keeps the JSON consistent across backends."""
     coerced = _as_utc(value)
     return coerced.isoformat() if coerced is not None else None
+
+
+def _night_key(hour_time: datetime) -> str:
+    """ISO date (YYYY-MM-DD) of the night a dark hour belongs to.
+
+    A night runs from one evening into the next morning, so labelling by the
+    calendar date would split a single outing at midnight. Convert to UK local
+    time and shift back 12 h before taking the date: evening hours keep their
+    own date and pre-dawn hours fold back onto the evening that opened the
+    night. The frontend formats this key into the chip label.
+    """
+    local = _as_utc(hour_time).astimezone(_LONDON)
+    return (local - _NIGHT_SHIFT).date().isoformat()
 
 
 @router.get("/sites")
@@ -108,6 +130,19 @@ def get_sites(
             continue
 
         best_score = max(h.score for h in hours)
+
+        # Per-night best score, so the map's night filter can recolour each
+        # marker by the quality it can reach on the selected night(s).
+        night_scores: dict[str, float] = {}
+        for h in hours:
+            key = _night_key(h.hour_time)
+            if key not in night_scores or h.score > night_scores[key]:
+                night_scores[key] = h.score
+
+        # Select the best N hours by score (the windows worth showing), then
+        # display them in chronological order: a planner reads the night top to
+        # bottom, so the card must run by time, not by score.
+        top_hours = sorted(hours, key=lambda h: h.score, reverse=True)[:_DISPLAY_HOURS]
         best_hours = [
             {
                 "time": _iso(h.hour_time),
@@ -119,7 +154,7 @@ def get_sites(
                 "dew_spread": h.dew_spread,
                 "symbol": h.symbol,
             }
-            for h in sorted(hours, key=lambda h: h.score, reverse=True)[:_DISPLAY_HOURS]
+            for h in sorted(top_hours, key=lambda h: h.hour_time)
         ]
         sites.append(
             {
@@ -131,10 +166,16 @@ def get_sites(
                 "lp_zone": meta.lp_zone,
                 "best_score": best_score,
                 "best_hours": best_hours,
+                "night_scores": night_scores,
             }
         )
 
     sites.sort(key=lambda s: s["best_score"], reverse=True)
+
+    # Union of nights present across all sites, ascending, so the frontend can
+    # render one stable row of night-filter chips (a site missing a night just
+    # has no score for it).
+    nights = sorted({key for s in sites for key in s["night_scores"]})
 
     # The ETag folds in the current clock hour so the CDN turns over hourly even
     # when fetched_at has not changed: as hours fall past the cutoff the payload
@@ -155,5 +196,6 @@ def get_sites(
         "sites": sites,
         "count": len(sites),
         "total_sites": len(by_id),
+        "nights": nights,
         "fetched_at": _iso(max_fetched),
     }

--- a/projects/monolith/stars/router_test.py
+++ b/projects/monolith/stars/router_test.py
@@ -181,6 +181,7 @@ class TestSites:
             "sites": [],
             "count": 0,
             "total_sites": 0,
+            "nights": [],
             "fetched_at": None,
         }
 
@@ -212,6 +213,47 @@ class TestSites:
         best_hours = body["sites"][0]["best_hours"]
         assert len(best_hours) == 8
         scores = [h["score"] for h in best_hours]
-        # Sorted descending, and exactly the 8 highest (0.11 .. 0.04).
-        assert scores == sorted(scores, reverse=True)
-        assert scores == [0.11, 0.10, 0.09, 0.08, 0.07, 0.06, 0.05, 0.04]
+        # Selection is the 8 highest scores (offsets 5..12, scores 0.04..0.11).
+        assert set(scores) == {0.11, 0.10, 0.09, 0.08, 0.07, 0.06, 0.05, 0.04}
+
+    def test_best_hours_in_chronological_order(self, client, session):
+        # Hours arrive scored out of time order; the card must read by time, so
+        # the response sorts the selected hours ascending by hour_time.
+        _seed_site(session, "galloway-forest")
+        session.add(_hour("galloway-forest", 1, 0.3))
+        session.add(_hour("galloway-forest", 2, 0.9))
+        session.add(_hour("galloway-forest", 3, 0.5))
+        session.commit()
+
+        r = client.get("/api/stars/sites")
+        assert r.status_code == 200
+        body = r.json()
+        times = [h["time"] for h in body["sites"][0]["best_hours"]]
+        assert times == sorted(times)
+        assert times == [
+            (CUTOFF + timedelta(hours=1)).isoformat(),
+            (CUTOFF + timedelta(hours=2)).isoformat(),
+            (CUTOFF + timedelta(hours=3)).isoformat(),
+        ]
+
+    def test_night_scores_and_nights(self, client, session):
+        # Two nights' worth of hours: each site exposes the best score per night
+        # (keyed by the evening date), and the response lists the union of
+        # nights ascending for the filter chips.
+        _seed_site(session, "galloway-forest")
+        # Offsets chosen relative to a fixed cutoff so both nights are covered
+        # regardless of when the suite runs.
+        session.add(_hour("galloway-forest", 1, 0.4))
+        session.add(_hour("galloway-forest", 2, 0.8))
+        session.add(_hour("galloway-forest", 26, 0.6))
+        session.commit()
+
+        r = client.get("/api/stars/sites")
+        assert r.status_code == 200
+        body = r.json()
+        night_scores = body["sites"][0]["night_scores"]
+        # Each night maps to the best score reached that night.
+        assert max(night_scores.values()) == 0.8
+        # Top-level nights is the sorted union of the per-site night keys.
+        assert body["nights"] == sorted(set(night_scores))
+        assert body["nights"] == sorted(body["nights"])


### PR DESCRIPTION
## What

Two changes to the `/app/stars` dark-sky planner, both visible in the site detail card / map:

### 1. Order the "best upcoming hours" chronologically

The card selected the top 8 hours **by score** but also rendered them in score order, so the times read out of sequence (Mon 01:00, Sun 01:00, Tue 01:00, ...). We now keep the same top-8-by-score selection (those are the windows worth showing) and then sort the displayed hours by time, so the card runs top to bottom in clock order the way a planner reads a night.

### 2. Night filter (like the ships type filter)

A row of night toggle chips over the map. Each chip is one viewing night; toggling recolours every site marker by the best score it can reach across the selected nights, and a site with no hours on any selected night drops off the map (mirroring how deselecting a vessel type hides those ships).

- **API** (`stars/router.py`): each site now returns `night_scores` (best score per night), and the response returns the sorted union of `nights`. A "night" is keyed by its evening date in UK local time, with pre-dawn hours folded back onto the night that opened them (a 12 h shift), so one outing is one chip rather than splitting at midnight.
- **Page** (`+page.svelte`): owns the active-night set, renders the chips, and reconciles the selection across the 30 min SSR refresh (new nights default on, elapsed nights drop out, user toggles persist).
- **Map** (`StarsMap.svelte`): consumes the active set, recolouring/filtering markers via `setData` (no refit, so the viewport stays put). With every night selected the view is identical to before.

## Tests

`stars/router_test.py`: updated the cap test (selection unchanged, order is now chronological) and the empty-table shape (now includes `nights`), plus new cases for chronological ordering and for `night_scores` / the top-level `nights` union.

Svelte formatting is left to CI's format-bot (no local svelte prettier plugin in this environment); ruff format/check pass on the Python changes.

https://claude.ai/code/session_01V2w7wigNdZscKTdusUopJr

---
_Generated by [Claude Code](https://claude.ai/code/session_01V2w7wigNdZscKTdusUopJr)_