### PR TITLE
fix(stars): fall back to best_score when a payload has no night data

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.130.0
+version: 0.130.1
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.130.0
+      targetRevision: 0.130.1
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/lib/public/components/stars/StarsMap.svelte
+++ b/projects/monolith/frontend/src/lib/public/components/stars/StarsMap.svelte
@@ -111,13 +111,17 @@
     };
   }
 
-  // Best score this site reaches across the currently selected nights, or null
-  // when none of its hours fall on an active night (so it drops off the map,
-  // mirroring how the ships type filter hides deselected vessels). With every
-  // night selected this equals best_score, so the default view is unchanged.
+  // Best score this site reaches across the currently selected nights. Falls
+  // back to best_score (always present) when the payload carries no per-night
+  // data, so an older build or a CDN-cached pre-feature response never blanks
+  // the map; with night data and "All" selected this still equals best_score.
+  // A single selected night returns null for sites with no window then, so they
+  // drop off the map (the actual filter).
   function effectiveScore(site) {
-    if (!activeNights || activeNights.size === 0) return null;
-    const ns = site.night_scores || {};
+    const ns = site.night_scores;
+    if (!ns || !activeNights || activeNights.size === 0) {
+      return site.best_score ?? null;
+    }
     let best = null;
     for (const night of activeNights) {
       const s = ns[night];


### PR DESCRIPTION
## Problem

After #2571 shipped, the `/app/stars` map rendered **empty** (no site markers) and the night picker was **missing**, even though the header still showed "301 dark-sky sites · best score 40".

Root cause: the new night-aware marker colouring (`effectiveScore`) hard-depended on the new `night_scores` field. The `/app/stars` pages are `ssr=false` and fetch their data from a CDN-cached `__data.json` endpoint (`s-maxage=1800, stale-while-revalidate=3600`). The SvelteKit client fetches the `?x-sveltekit-invalidated` variant, which was still serving a **stale, pre-feature payload** with only `best_score`/`best_hours` and no `night_scores`/`nights`. The new frontend JS then coloured every marker `null` (blank map), and the absent `nights` list hid the picker.

The deployed backend is correct (a fresh, uncached `__data.json` carries `night_scores` for all 301 sites plus 8 `nights`); this is purely a frontend fragility against a payload that lacks the new fields.

## Fix

`effectiveScore` now falls back to `best_score` (always present) when `night_scores` is absent or no night set is active, so an older build, a deploy skew, or a CDN-cached pre-feature response never blanks the map. With night data present and "All" selected the result is unchanged (equals `best_score`); a single selected night still returns `null` for sites with no window that night, so the per-night filter behaves as before.

The stale CDN entry self-heals at the next hour boundary anyway (the ETag folds in the clock hour, forcing revalidation), but this removes the class of bug for good.

https://claude.ai/code/session_01V2w7wigNdZscKTdusUopJr

---
_Generated by [Claude Code](https://claude.ai/code/session_01V2w7wigNdZscKTdusUopJr)_