### PR TITLE
docs(mcp): add missing _helpers.tpl to directory layout

### DIFF
--- a/projects/mcp/README.md
+++ b/projects/mcp/README.md
@@ -19,6 +19,7 @@ projects/mcp/
     │   ├── Chart.yaml          # Chart metadata; declares mcp-stack + homelab-library deps
     │   ├── values.yaml         # Chart defaults (most feature flags off, auth config)
     │   └── templates/
+    │       ├── _helpers.tpl        # Helm named template helpers
     │       ├── httproute.yaml      # Gateway API HTTPRoute for mcp.jomcgi.dev
     │       ├── networkpolicy.yaml  # Cross-namespace ingress policy (disabled; see below)
     │       └── onepassworditem.yaml # 1Password secret sync (JWT_SECRET_KEY, etc.)


### PR DESCRIPTION
## Summary

- The `chart/templates/` directory contains `_helpers.tpl` but it was omitted from the README directory tree
- Added `_helpers.tpl` alongside the other three template files in the documented layout

## Test plan

- [ ] README accurately reflects the 4 files present in `context-forge-gateway/chart/templates/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)