### PR TITLE
docs(stargazer): remove stale webServer key from deploy values

### DIFF
--- a/projects/stargazer/deploy/values.yaml
+++ b/projects/stargazer/deploy/values.yaml
@@ -40,10 +40,6 @@ api:
     hostname: api.jomcgi.dev
     # Path prefix for stargazer API
     pathPrefix: /stargazer
-# Enable web server for dev
-webServer:
-  enabled: true
-  replicas: 1
 # Enable test data until CronJob runs successfully
 testData:
   enabled: true


### PR DESCRIPTION
## Summary

- `deploy/values.yaml` had a `webServer.enabled: true` block with no corresponding chart template
- The chart only implements `cronjob.yaml` and `deployment-api.yaml`; there is no webserver deployment template
- The key was silently ignored by Helm; removed it to eliminate dead configuration

## Test plan

- [ ] `helm template` on the chart with these values produces no unexpected resources

🤖 Generated with [Claude Code](https://claude.com/claude-code)