### PR TITLE
docs(lakehouse): correct py3_image description in README

### DIFF
--- a/projects/lakehouse/README.md
+++ b/projects/lakehouse/README.md
@@ -22,8 +22,8 @@ NATS JetStream  ->  Temporal workflows  ->  Iceberg on SeaweedFS  ->  DuckDB / Q
 | `iceberg/`          | PyIceberg writer helpers; per-domain `tables/`                         | 2         |
 | `duckdb_query/`     | DuckDB + iceberg-extension query helpers                               | 2         |
 | `dispatchers/`      | NATS → Temporal workflow dispatchers                                   | 4         |
-| `image/`            | `py3_image` (rules_oci) worker image (`python -m projects.lakehouse.orchestrator.workflows.run`) | 3         |
-| `quack-server/`     | `py3_image` (rules_oci) DuckDB/Quack serving image                     | 3         |
+| `image/`            | `py3_image` (custom Bazel macro) worker image (`python -m projects.lakehouse.orchestrator.workflows.run`) | 3         |
+| `quack-server/`     | `py3_image` (custom Bazel macro) DuckDB/Quack serving image            | 3         |
 | `chart/`, `deploy/` | OCI-versioned Helm chart + ArgoCD Application                          | 4         |
 
 ## Conventions


### PR DESCRIPTION
## Summary

- The README layout table labeled `image/` and `quack-server/` as using `py3_image (rules_oci)`
- `py3_image` is a custom Bazel macro defined in `//bazel/tools/oci:py3_image.bzl`, not a direct `rules_oci` type
- The BUILD file itself notes: `# HAND-WRITTEN (py3_image is a custom macro; gazelle does not manage it)`
- Updated both rows to say `py3_image (custom Bazel macro)`

## Test plan

- [ ] README accurately describes the image build tooling

🤖 Generated with [Claude Code](https://claude.com/claude-code)