### PR TITLE
fix(kyverno): append injected OTEL env vars instead of prepending

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.130.1
+version: 0.130.2
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.130.1
+      targetRevision: 0.130.2
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/platform/kyverno/Chart.yaml
+++ b/projects/platform/kyverno/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kyverno
 description: Kyverno policy engine with ClusterPolicies for GHCR secret management
 type: application
-version: 1.0.3
+version: 1.0.4
 appVersion: "3.5.2"
 
 dependencies:

--- a/projects/platform/kyverno/templates/otel-injection-policy.yaml
+++ b/projects/platform/kyverno/templates/otel-injection-policy.yaml
@@ -19,11 +19,50 @@ metadata:
     policies.kyverno.io/description: |
       Automatically injects OTEL environment variables into all workloads
       for cluster-wide observability. ENABLED BY DEFAULT.
+
+      The env vars are APPENDED to each container's env list (json6902 add to
+      env/-), not strategic-merge-merged. Strategic merge prepends new env
+      entries, which shifts every chart-defined env var down by two and makes
+      ArgoCD (which diffs env positionally) report the workload permanently
+      OutOfSync even with an ignoreDifferences for the injected names. Appending
+      keeps the chart's env at its original indices so a by-name ignore lines up
+      and the workload stays Synced. The append rule is idempotent (skips a
+      container that already carries OTEL_EXPORTER_OTLP_ENDPOINT) and skips
+      containers with no env (nothing to instrument; keeps the env/- path valid).
 spec:
   background: {{ .Values.otelInjection.background }}
   validationFailureAction: Audit
   rules:
-  - name: add-otel-config-deployments
+  - name: add-otel-annotation-deployments
+    skipBackgroundRequests: true
+    match:
+      any:
+      - resources:
+          kinds:
+          {{- range .Values.otelInjection.targetKinds }}
+          - {{ . }}
+          {{- end }}
+    exclude:
+      any:
+      # Exclude system namespaces
+      - resources:
+          namespaces:
+          {{- range .Values.otelInjection.excludeNamespaces }}
+          - {{ . }}
+          {{- end }}
+      # Explicit opt-out only
+      - resources:
+          selector:
+            matchLabels:
+              otel.instrumentation: "disabled"
+    mutate:
+      patchStrategicMerge:
+        spec:
+          template:
+            metadata:
+              annotations:
+                otel.injected-by: "kyverno/inject-otel-env-vars"
+  - name: add-otel-env-deployments
     skipBackgroundRequests: true
     match:
       any:
@@ -51,18 +90,29 @@ spec:
         name: otel-config
         namespace: {{ .Release.Namespace }}
     mutate:
-      patchStrategicMerge:
-        spec:
-          template:
-            metadata:
-              annotations:
-                otel.injected-by: "kyverno/inject-otel-env-vars"
-            spec:
-              containers:
-              - (name): "*"
-                env:
-                - name: OTEL_EXPORTER_OTLP_ENDPOINT
-                  value: "{{ `{{ otelConfig.data.endpoint }}` }}"
-                - name: OTEL_EXPORTER_OTLP_PROTOCOL
-                  value: "{{ `{{ otelConfig.data.protocol }}` }}"
+      foreach:
+      - list: "request.object.spec.template.spec.containers"
+        preconditions:
+          all:
+          # Only containers that already declare env: nothing to instrument
+          # otherwise, and it keeps the json6902 env/- append path valid.
+          - key: "{{ `{{ length(element.env || '') }}` }}"
+            operator: GreaterThan
+            value: 0
+          # Idempotent: skip a container that already carries the injected var so
+          # a re-admission of an already-injected object does not duplicate it.
+          - key: OTEL_EXPORTER_OTLP_ENDPOINT
+            operator: AnyNotIn
+            value: "{{ `{{ element.env[].name }}` }}"
+        patchesJson6902: |-
+          - op: add
+            path: "/spec/template/spec/containers/{{ `{{ elementIndex }}` }}/env/-"
+            value:
+              name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: "{{ `{{ otelConfig.data.endpoint }}` }}"
+          - op: add
+            path: "/spec/template/spec/containers/{{ `{{ elementIndex }}` }}/env/-"
+            value:
+              name: OTEL_EXPORTER_OTLP_PROTOCOL
+              value: "{{ `{{ otelConfig.data.protocol }}` }}"
 {{- end }}


### PR DESCRIPTION
## What

Changes the `inject-otel-env-vars` ClusterPolicy to **append** the two OTEL env vars to each container's `env` (json6902 `add` to `env/-`) instead of `patchStrategicMerge` (which prepends).

## Why

Root cause of the persistent `monolith` (and `nats-box`) `OutOfSync`. Strategic-merge env injection **prepends** `OTEL_EXPORTER_OTLP_ENDPOINT` / `_PROTOCOL` at positions 0-1, shifting every chart-defined env var down by two. ArgoCD diffs env arrays **positionally**, so the shift makes the whole array mismatch. An element-level `ignoreDifferences` for the injected names (PRs #2564/#2570) can match the *set* but cannot realign a *shifted* array, so the workload stays OutOfSync.

Appending keeps the chart's env at its original indices, so the existing by-name ArgoCD ignore lines up and the workload reports Synced.

## How

- Split into two rules: annotation injection stays `patchStrategicMerge` (ordering is irrelevant for an annotation); env injection becomes `foreach` over containers + `patchesJson6902` appending to `/spec/template/spec/containers/{{ elementIndex }}/env/-`.
- **Idempotent**: precondition skips a container that already carries `OTEL_EXPORTER_OTLP_ENDPOINT`, so re-admission of an already-injected object never duplicates.
- **Safe on env-less containers**: precondition requires `length(element.env) > 0`, which also keeps the `env/-` path valid. (Behavior change: a container with zero env vars is no longer injected; such a container is not OTEL-instrumented anyway.)
- `validationFailureAction` stays `Audit`, so even a mutate miss never blocks admission.

## Testing / rollout

Kyverno mutation only runs at admission, so it cannot be exercised by `helm template`; I verified the rendered ClusterPolicy is syntactically correct (escaping resolves to proper Kyverno vars, `foreach` + `env/-` append, both preconditions). **Post-merge verification on-cluster** (will do after deploy):
1. New/synced Deployments get the two OTEL vars **appended** (last in the env list), exactly once.
2. No duplicate OTEL vars on re-admission.
3. Deployments still admit (Audit, but confirm no policy errors).
4. `monolith` reaches Synced once ArgoCD re-syncs it through admission.

Existing pods keep their prepended vars until their next admission (ArgoCD sync / rollout); `monolith` self-corrects on its next sync since ArgoCD applies OTEL-free desired and the new policy appends. Chart `1.0.3 -> 1.0.4`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)