### PR TITLE
feat(buck2): bazel-rule parity — OciImageInfo, helm digest-pinning, chart validation

### DIFF
--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -229,6 +229,11 @@ actions:
           # Prefer RE for every action that can run remotely (so Rust links on the
           # RE container); apko genrules opt out (network) and run on the runner.
           export BUCK_PREFER_REMOTE=true
+          # The BuildBuddy runner can reuse a VM snapshot carrying a stale buck2
+          # daemon whose buck-out was reset between runs, which aborts the build
+          # with "Failed to stat buck-out/v2: ENOENT". Kill any leftover daemon so
+          # we always start fresh.
+          /tmp/buck2 killall 2>/dev/null || true
           /tmp/buck2 --version
           /tmp/buck2 build //tools/buck2/...
           /tmp/buck2 test  //tools/buck2/...

--- a/tools/buck2/bin/BUCK
+++ b/tools/buck2/bin/BUCK
@@ -86,6 +86,26 @@ pinned_cli(
     },
 )
 
+# -- kubeconform — validate rendered manifests vs K8s API schemas (yannh/kubeconform)
+_KCF_V = "v0.8.0"
+_KCF_URL = "https://github.com/yannh/kubeconform/releases/download/{v}/kubeconform-{a}.tar.gz"
+
+pinned_cli(
+    name = "kubeconform",
+    binary = "kubeconform",
+    archive = "tar_root",
+    urls = {
+        "darwin-arm64": _KCF_URL.format(v = _KCF_V, a = "darwin-arm64"),
+        "linux-amd64": _KCF_URL.format(v = _KCF_V, a = "linux-amd64"),
+        "linux-arm64": _KCF_URL.format(v = _KCF_V, a = "linux-arm64"),
+    },
+    shas = {
+        "darwin-arm64": "f84f4dfbebf4a6b0b230385fa065a39ea35e02608c2b50d025dcf64775a69d67",
+        "linux-amd64": "9bc2bffbf71f261128533edaf912153948b7ff238f9a531ae6d34466ec287883",
+        "linux-arm64": "1f53fc8e81258197a35e8603054162a5af1de8c5af13746c71ab680d9534ed87",
+    },
+)
+
 # -- yq — YAML query/merge, single binary (mikefarah/yq) -----------------------
 _YQ_V = "v4.53.3"
 _YQ_URL = "https://github.com/mikefarah/yq/releases/download/{v}/yq_{a}"

--- a/tools/buck2/examples/rust-service/BUCK
+++ b/tools/buck2/examples/rust-service/BUCK
@@ -32,6 +32,7 @@ oci_image(
     name = "image",
     base = ":base",
     layers = [":server_layer"],
+    repository = "ghcr.io/jomcgi/homelab/rust-service",
 )
 
 # A basic Helm chart that deploys the rust image. `deps = [":image"]` makes the
@@ -40,4 +41,6 @@ helm_chart(
     name = "chart",
     srcs = glob(["chart/**"]),
     deps = [":image"],
+    # Digest-pin the deployed image's repository@digest into values.yaml.
+    images = {"image": ":image.info"},
 )

--- a/tools/buck2/examples/rust-service/chart/templates/deployment.yaml
+++ b/tools/buck2/examples/rust-service/chart/templates/deployment.yaml
@@ -20,4 +20,6 @@ spec:
         runAsGroup: 65532
       containers:
         - name: server
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          # Digest-pinned when helm_chart(images=...) injects .image.digest;
+          # falls back to the tag otherwise (lint/template with default values).
+          image: "{{ .Values.image.repository }}{{ if .Values.image.digest }}@{{ .Values.image.digest }}{{ else }}:{{ .Values.image.tag }}{{ end }}"

--- a/tools/buck2/helm/defs.bzl
+++ b/tools/buck2/helm/defs.bzl
@@ -1,30 +1,82 @@
-"""Minimal Helm chart packaging — wraps the pinned `helm`.
+"""Minimal Helm chart packaging — wraps the pinned `helm`/`yq`.
 
 `helm_chart` stages a chart (files under a `chart/` dir) and runs `helm package`
 to produce a versioned `.tgz`. `deps` (e.g. an oci_image) are built but not
-packaged, so the chart target *depends on* the image it deploys — building the
-chart builds the image. This is the Buck2 counterpart to bazel/helm's helm_chart
-(digest-pinned image-value injection can be layered on later via helm values).
+packaged, so the chart target *depends on* the image it deploys. `images=` pins
+chart image references by digest (via `helm_images_values`, the Buck2 counterpart
+to bazel/helm's `helm_chart(images=...)` + `helm_images_values`). `lint=True`
+adds a `helm lint` validation target.
 """
 
-_HELM = "//tools/buck2/bin:helm"
+load("//tools/buck2/oci:providers.bzl", "OciImageInfo")
 
-def helm_chart(name, srcs, deps = [], visibility = ["PUBLIC"], **kwargs):
+_HELM = "//tools/buck2/bin:helm"
+_YQ = "//tools/buck2/bin:yq"
+_KUBECONFORM = "//tools/buck2/bin:kubeconform"
+
+def _helm_images_values_impl(ctx: AnalysisContext) -> list[Provider]:
+    out = ctx.actions.declare_output("images.yaml")
+
+    # Args: yq, out, then a (yaml-path, repository, digest-file) triple per image.
+    triples = []
+    for path, dep in ctx.attrs.images.items():
+        info = dep[OciImageInfo]
+        triples += [path, info.repository, info.digest]
+
+    # Build values like `<path>.repository: <repo>` / `<path>.digest: sha256:...`
+    # for each image (dot-paths become nested keys), digest read from its file.
+    script = (
+        'set -e; YQ="$1"; OUT="$2"; shift 2; echo "{}" > "$OUT"; ' +
+        'while [ "$#" -ge 3 ]; do P="$1"; R="$2"; DF="$3"; shift 3; D="$(cat "$DF")"; ' +
+        '"$YQ" -i ".${P}.repository = \\"$R\\" | .${P}.digest = \\"$D\\"" "$OUT"; done'
+    )
+    ctx.actions.run(
+        cmd_args(["bash", "-c", script, "_", ctx.attrs._yq[RunInfo], out.as_output()] + triples),
+        category = "helm_images_values",
+    )
+    return [DefaultInfo(default_output = out)]
+
+# Generates a values overlay pinning each image's repository + digest from its
+# OciImageInfo. Mirrors bazel/helm's helm_images_values.
+helm_images_values = rule(
+    impl = _helm_images_values_impl,
+    attrs = {
+        "images": attrs.dict(attrs.string(), attrs.dep(providers = [OciImageInfo])),
+        "_yq": attrs.exec_dep(default = _YQ, providers = [RunInfo]),
+    },
+)
+
+def helm_chart(name, srcs, deps = [], images = None, lint = True, visibility = ["PUBLIC"], **kwargs):
     """Package a Helm chart into a `.tgz`.
 
     Args:
       name: target name; output is the packaged chart `.tgz`.
       srcs: chart files under a `chart/` dir (e.g. glob(["chart/**"])).
       deps: targets the chart depends on (e.g. an oci_image) — built, not packaged.
+      images: {yaml-path: image `.info` label} — digest-pinned into values.yaml.
+      lint: also create a `<name>.lint` target running `helm lint`.
       visibility: target visibility.
     """
+    overlay_srcs = []
+    merge = ":"
+    if images:
+        helm_images_values(
+            name = name + ".images_values",
+            images = images,
+            visibility = visibility,
+        )
+        overlay_srcs = [":" + name + ".images_values"]
+
+        # Deep-merge the generated overlay into the staged chart's values.yaml.
+        merge = " && ".join([
+            "OV=\"\"; for f in $SRCS; do case \"$f\" in *images.yaml) OV=\"$f\" ;; esac; done",
+            "if [ -n \"$OV\" ]; then $(exe {yq}) eval-all -i 'select(fi==0) * select(fi==1)' \"$TMP/chart/values.yaml\" \"$OV\"; fi".format(yq = _YQ),
+        ])
+
     native.genrule(
         name = name,
-        srcs = srcs + deps,
+        srcs = srcs + overlay_srcs + deps,
         out = "chart.tgz",
-        # Stage only the files under `.../chart/` (preserving structure), skipping
-        # any deps, then `helm package`. Shell $-vars ($f/$rel/$d) are expanded by
-        # sh; buck2 only substitutes $SRCS/$TMP/$OUT and $(...) macros.
         cmd = " && ".join([
             "mkdir -p \"$TMP/chart\"",
             "for f in $SRCS; do " +
@@ -33,9 +85,51 @@ def helm_chart(name, srcs, deps = [], visibility = ["PUBLIC"], **kwargs):
             "case \"$rel\" in */*) d=\"${rel%/*}\" ;; *) d=\".\" ;; esac; " +
             "mkdir -p \"$TMP/chart/$d\"; cp \"$f\" \"$TMP/chart/$rel\"; " +
             "done",
+            merge,
             "$(exe {helm}) package \"$TMP/chart\" -d \"$TMP/out\" >/dev/null".format(helm = _HELM),
             "mv \"$TMP/out\"/*.tgz $OUT",
         ]),
         visibility = visibility,
         **kwargs
     )
+
+    if lint:
+        native.genrule(
+            name = name + ".lint",
+            srcs = srcs,
+            out = "lint.ok",
+            cmd = " && ".join([
+                "mkdir -p \"$TMP/chart\"",
+                "for f in $SRCS; do " +
+                "rel=\"${f##*/chart/}\"; " +
+                "case \"$rel\" in */*) d=\"${rel%/*}\" ;; *) d=\".\" ;; esac; " +
+                "mkdir -p \"$TMP/chart/$d\"; cp \"$f\" \"$TMP/chart/$rel\"; " +
+                "done",
+                "$(exe {helm}) lint \"$TMP/chart\" >/dev/null".format(helm = _HELM),
+                "touch $OUT",
+            ]),
+            visibility = visibility,
+        )
+
+        # Full validation: render with `helm template`, then check the manifests
+        # against Kubernetes API schemas with kubeconform (lint alone doesn't do
+        # schema validation). kubeconform fetches schemas over the network, so it
+        # runs locally (off RE) like apko.
+        native.genrule(
+            name = name + ".validate",
+            srcs = srcs,
+            out = "validate.ok",
+            cmd = " && ".join([
+                "mkdir -p \"$TMP/chart\"",
+                "for f in $SRCS; do " +
+                "rel=\"${f##*/chart/}\"; " +
+                "case \"$rel\" in */*) d=\"${rel%/*}\" ;; *) d=\".\" ;; esac; " +
+                "mkdir -p \"$TMP/chart/$d\"; cp \"$f\" \"$TMP/chart/$rel\"; " +
+                "done",
+                "$(exe {helm}) template validate \"$TMP/chart\" > \"$TMP/manifests.yaml\"".format(helm = _HELM),
+                "$(exe {kcf}) -strict -summary \"$TMP/manifests.yaml\"".format(kcf = _KUBECONFORM),
+                "touch $OUT",
+            ]),
+            labels = ["uses_undeclared_inputs"],
+            visibility = visibility,
+        )

--- a/tools/buck2/oci/defs.bzl
+++ b/tools/buck2/oci/defs.bzl
@@ -9,9 +9,44 @@ registry reference as its base. Image config (entrypoint etc.) is set on the apk
 base config so no separate mutate step is needed for the common case.
 """
 
+load(":providers.bzl", "OciImageInfo")
+
 _REGCTL = "//tools/buck2/bin:regctl"
 
-def oci_image(name, base, layers = [], platform = "linux/amd64", visibility = ["PUBLIC"], **kwargs):
+def _oci_image_info_impl(ctx: AnalysisContext) -> list[Provider]:
+    image = ctx.attrs.image[DefaultInfo].default_outputs[0]
+    digest = ctx.actions.declare_output("digest")
+
+    # The image tar is an OCI layout; the first sha256 in index.json is the
+    # (single-arch) manifest digest — i.e. the ref you'd pull as repo@sha256:...
+    ctx.actions.run(
+        cmd_args([
+            "bash",
+            "-c",
+            'set -e; D="$(mktemp -d)"; tar -xf "$1" -C "$D" index.json; grep -oE "sha256:[a-f0-9]{64}" "$D/index.json" | head -1 | tr -d "\\n" > "$2"',
+            "_",  # $0
+            image,
+            digest.as_output(),
+        ]),
+        category = "oci_digest",
+    )
+
+    return [
+        DefaultInfo(default_output = digest),
+        OciImageInfo(repository = ctx.attrs.repository, digest = digest),
+    ]
+
+# Exposes OciImageInfo (repository + content digest) for an image tar, so
+# helm_images_values can digest-pin the chart. Mirrors bazel's oci_image_info.
+oci_image_info = rule(
+    impl = _oci_image_info_impl,
+    attrs = {
+        "image": attrs.dep(),
+        "repository": attrs.string(),
+    },
+)
+
+def oci_image(name, base, layers = [], platform = "linux/amd64", repository = None, visibility = ["PUBLIC"], **kwargs):
     """Layer `layers` (filesystem tarballs) onto `base` (an OCI image tar).
 
     Args:
@@ -39,6 +74,16 @@ def oci_image(name, base, layers = [], platform = "linux/amd64", visibility = ["
         visibility = visibility,
         **kwargs
     )
+
+    # Expose OciImageInfo (repository + digest) for helm digest-pinning, like
+    # bazel's go_image/apko_image `.info` sub-target.
+    if repository:
+        oci_image_info(
+            name = name + ".info",
+            image = ":" + name,
+            repository = repository,
+            visibility = visibility,
+        )
 
 def tar_layer(name, binary, path, visibility = ["PUBLIC"], **kwargs):
     """Package a single executable `binary` target into a layer tar at `path`.

--- a/tools/buck2/oci/providers.bzl
+++ b/tools/buck2/oci/providers.bzl
@@ -1,0 +1,13 @@
+"""Providers for the buck2 OCI rules.
+
+Buck2 counterpart to bazel/tools/oci/providers.bzl's OciImageInfo. Carries the
+target registry repository and a file holding the image's content digest
+(sha256:...), so helm_images_values can pin chart image references by digest —
+the deterministic analogue of bazel's stamped-tag injection.
+"""
+
+OciImageInfo = provider(
+    # repository: str registry URL (e.g. "ghcr.io/jomcgi/homelab/rust-service")
+    # digest: artifact (a file containing "sha256:<hex>")
+    fields = ["repository", "digest"],
+)


### PR DESCRIPTION
First slice of bringing `tools/buck2` to parity with `bazel/helm` + `bazel/tools/oci`.

## What
- **`OciImageInfo` provider + `oci_image_info`** — extracts the image's content digest from the OCI tar; `oci_image` gains a `.info` sub-target (mirrors bazel's `.info`).
- **Helm digest-pinning** — `helm_images_values` builds a values overlay of `repository`+`digest` per image; `helm_chart(images={...})` deep-merges it into `values.yaml` (yq). The deployed image is pinned by `repository@digest` (deterministic — the Buck2 analogue of bazel's stamped-tag injection).
- **Chart validation beyond lint** (answering "is linting enough?" — it isn't): `helm_chart` now also emits `.validate`, which **renders** (`helm template`) and validates the manifests against **Kubernetes API schemas** (`kubeconform -strict`). `helm lint` only checks structure/syntax; this catches invalid K8s. Pinned `kubeconform v0.8.0`.

## Validation layers now
1. `helm lint` (structure/syntax) — `:chart.lint`
2. `helm template` render — inside `:chart.validate`
3. `kubeconform` schema validation — `:chart.validate`
(semgrep policy on manifests is a follow-up to match homelab's `semgrep_manifest_test`.)

## Verified
- `.lint` + `.validate` build green locally (helm lint + helm template | kubeconform with schemas fetched).
- Full chain (image → digest → chart) builds on BuildBuddy RE.

## Follow-ups (continuing parity)
- push rules (`apko_push`/`oci_push`, `helm_push`) + runtime-arg stamping; `argocd_app` (+ render/diff/semgrep); `helm_template_test`; `oci_image_index` multi-arch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)