### PR TITLE
feat(frontend): stars Live/Historical heatmap toggle + month picker

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.130.3
+version: 0.130.4
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.130.3
+      targetRevision: 0.130.4
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/lib/cache-headers.js
+++ b/projects/monolith/frontend/src/lib/cache-headers.js
@@ -44,3 +44,11 @@ export const HIKES_WALKS_CACHE_CONTROL =
 // _SITES_CACHE_CONTROL in projects/monolith/stars/router.py, keep in sync.
 export const STARS_SITES_CACHE_CONTROL =
   "public, max-age=0, s-maxage=1800, stale-while-revalidate=3600, stale-if-error=86400";
+
+// /app/stars history: per-month accumulated stats, banked by the hourly prune.
+// The numbers only grow as hours elapse, so the same 30 min fresh / 1 h SWR
+// window the live sites use is plenty. The history endpoint in router.py reuses
+// _SITES_CACHE_CONTROL, so this is the byte-for-byte same string; kept as its
+// own constant so the proxy reads intentionally and the two can diverge later.
+export const STARS_HISTORY_CACHE_CONTROL =
+  "public, max-age=0, s-maxage=1800, stale-while-revalidate=3600, stale-if-error=86400";

--- a/projects/monolith/frontend/src/lib/public/components/stars/StarsMap.svelte
+++ b/projects/monolith/frontend/src/lib/public/components/stars/StarsMap.svelte
@@ -1,15 +1,25 @@
 <script>
   import { onMount } from "svelte";
   import "maplibre-gl/dist/maplibre-gl.css";
+  import { relativeMax, heatWeightExpression } from "$lib/public/stars/heat.js";
 
-  // `sites` is the curated dark-sky list to plot; clicking a dot opens the
-  // detail card. `activeNights` is the set of selected night keys (evening
-  // dates) from the parent's night filter: a marker is coloured by the best
-  // score it reaches across those nights, and drops off the map when none of
-  // its hours fall on a selected night. `nowMs` is a coarse clock signal from
-  // the parent so the card can drop hours that have already elapsed between
-  // SSR loads.
-  let { sites = [], activeNights = new Set(), nowMs = Date.now() } = $props();
+  // `sites` is the list to plot; clicking a dot opens the detail card. In LIVE
+  // mode the rows carry per-night scores + best upcoming hours; in HISTORICAL
+  // mode they carry accumulated `sum_q` + component averages (ADR 008).
+  // `activeNights` is the set of selected night keys from the parent's night
+  // filter (LIVE only): a marker is coloured by the best score it reaches across
+  // those nights, and drops off the map when none of its hours fall on a
+  // selected night. `nowMs` is a coarse clock signal so the card can drop hours
+  // that have already elapsed between SSR loads. `mode` ("live"|"historical")
+  // switches how each feature's heat + marker value is derived and which card
+  // body renders. `heatVisible` toggles the heatmap layer.
+  let {
+    sites = [],
+    activeNights = new Set(),
+    nowMs = Date.now(),
+    mode = "live",
+    heatVisible = false,
+  } = $props();
 
   // OpenFreeMap needs no API key (same hosted liberty style as /app/ships and
   // /app/hikes, so the maps read as siblings). The liberty style ships light and
@@ -17,23 +27,48 @@
   // the subject, not the chrome.
   const BASEMAP_STYLE = "https://tiles.openfreemap.org/styles/liberty";
 
-  // Score buckets: muted (poor) -> blue (fair) -> violet (prime). Hardcoded in
+  // Marker buckets: muted (poor) -> blue (fair) -> violet (prime). Hardcoded in
   // JS (a data-viz ramp, not a design-system surface), tuned to read on the
   // light basemap; the prime stop is the funky violet that also marks Stars in
-  // the nav. Mirrors how HikesMap keeps its EFFORT_RAMP stops in JS and renders
-  // the legend swatches via inline style attributes.
+  // the nav. Mirrors how HikesMap keeps its EFFORT_RAMP stops in JS.
   //
-  // Boundaries follow the ADR 007 continuous quality Q = D x C x W: an ideal
-  // winter night reaches ~90+, while summer's best (sun never far below the
-  // horizon) tops out around 30-50, so the buckets break at 35 / 65.
+  // LIVE: boundaries follow the ADR 007 continuous quality Q = D x C x W (an
+  // ideal winter night reaches ~90+, summer tops out ~30-50, so 35 / 65). The
+  // marker's `score` property is the absolute live quality there. HISTORICAL:
+  // the `score` property is instead a RELATIVE percentile (heat / max-heat *
+  // 100), so the same 35 / 65 break reads as low / medium / high thirds of the
+  // realized-quality spread, and the legend relabels accordingly.
   const SCORE_BUCKETS = [
     { key: "low", label: "< 35", color: "#94a3b8" }, // muted slate
     { key: "mid", label: "35-65", color: "#3b82f6" }, // blue
     { key: "high", label: "65+", color: "#7c3aed" }, // violet (prime)
   ];
 
+  // Heatmap colour ramp (transparent -> cool -> warm), keyed on heatmap-density.
+  // Like ShipsMap's HEAT_STOPS these are JS map-paint colours, not design tokens:
+  // a saturated plasma scale that stays vivid on the light/green basemap. The
+  // densest clusters bloom red, the sparse fringe fades to transparent blue.
+  const HEATMAP_COLOR = [
+    "interpolate",
+    ["linear"],
+    ["heatmap-density"],
+    0,
+    "rgba(59, 130, 246, 0)",
+    0.15,
+    "rgba(59, 130, 246, 0.45)", // cool blue
+    0.4,
+    "rgba(124, 58, 237, 0.7)", // violet
+    0.65,
+    "rgba(214, 31, 156, 0.8)", // magenta
+    0.85,
+    "rgba(255, 106, 0, 0.9)", // orange
+    1,
+    "rgba(255, 42, 31, 0.95)", // hot red (densest)
+  ];
+
   const SOURCE_ID = "sites";
   const LAYER_ID = "sites";
+  const HEAT_LAYER_ID = "sites-heat";
 
   let maplibregl; // loaded lazily in onMount (browser-only module)
   let mapContainer; // bound <div>
@@ -41,14 +76,37 @@
   let layerReady = false;
   let didFit = false;
 
+  // The relative-normalization ceiling for the current feature set, restamped on
+  // every pushData. Drives both the historical marker percentile and the
+  // heatmap-weight rescale, so the field re-normalizes as mode/night/month
+  // changes. Defaults to the live score ceiling.
+  let currentMaxHeat = 100;
+
   // site id -> site row, so a marker click can recover the full record.
   const index = new Map();
 
   let selected = $state(null); // selected site row, or null
 
+  // Mode-aware legend: LIVE shows the absolute score buckets; HISTORICAL relabels
+  // the same colours as relative low/medium/high (the heat field is normalized,
+  // so an absolute number would mislead).
+  let legendTitle = $derived(
+    mode === "historical" ? "Realized quality" : "Best score",
+  );
+  let legendItems = $derived(
+    mode === "historical"
+      ? [
+          { key: "low", label: "Low", color: SCORE_BUCKETS[0].color },
+          { key: "mid", label: "Medium", color: SCORE_BUCKETS[1].color },
+          { key: "high", label: "High", color: SCORE_BUCKETS[2].color },
+        ]
+      : SCORE_BUCKETS,
+  );
+
   // The selected site's hours, dropping any that have already elapsed (the hour
-  // is over once nowMs passes its end). The endpoint already prunes past hours
-  // server-side; this just keeps a long-open page honest between refreshes.
+  // is over once nowMs passes its end). LIVE only; historical rows carry no
+  // best_hours. The endpoint already prunes past hours server-side; this just
+  // keeps a long-open page honest between refreshes.
   let cardHours = $derived(
     (selected?.best_hours ?? []).filter((h) => {
       const t = Date.parse(h.time);
@@ -116,7 +174,7 @@
   // data, so an older build or a CDN-cached pre-feature response never blanks
   // the map; with night data and "All" selected this still equals best_score.
   // A single selected night returns null for sites with no window then, so they
-  // drop off the map (the actual filter).
+  // drop off the map (the actual filter). LIVE only.
   function effectiveScore(site) {
     const ns = site.night_scores;
     if (!ns || !activeNights || activeNights.size === 0) {
@@ -130,25 +188,70 @@
     return best;
   }
 
+  // The raw heat value for a site in the current mode: LIVE = the per-night
+  // score (the value the marker already colours by), HISTORICAL = the
+  // accumulated quality-weighted frequency sum_q. null drops the site (LIVE: no
+  // window on the selected night; HISTORICAL: missing/zero stat).
+  function rawHeat(site) {
+    if (mode === "historical") {
+      const q = site.sum_q;
+      return typeof q === "number" && q > 0 ? q : null;
+    }
+    return effectiveScore(site);
+  }
+
   function buildFeatures() {
-    const features = [];
+    // First pass: collect each plotted site's raw heat; second pass: normalize.
+    const raw = [];
     for (const site of sites) {
       if (!validLatLon(site.lat, site.lon)) continue;
-      const score = effectiveScore(site);
-      if (score === null) continue;
-      features.push({
-        type: "Feature",
-        id: site.id,
-        geometry: { type: "Point", coordinates: [site.lon, site.lat] },
-        properties: { id: site.id, score },
-      });
+      const heat = rawHeat(site);
+      if (heat === null) continue;
+      raw.push({ site, heat });
     }
+    // Relative ceiling: the densest point reaches full weight regardless of the
+    // field's absolute scale (live 0..100 vs historical sum_q). Restamped here so
+    // the heatmap-weight expression in pushData rescales to whatever is in view.
+    currentMaxHeat = relativeMax(raw.map((r) => r.heat));
+
+    const features = raw.map(({ site, heat }) => ({
+      type: "Feature",
+      id: site.id,
+      geometry: { type: "Point", coordinates: [site.lon, site.lat] },
+      properties: {
+        id: site.id,
+        heat,
+        // Marker colour/size value: absolute live score, or a 0..100 relative
+        // percentile in historical so the shared 35 / 65 buckets read as thirds.
+        score:
+          mode === "historical" ? (100 * heat) / currentMaxHeat : heat,
+      },
+    }));
     return { type: "FeatureCollection", features };
   }
 
   function pushData() {
     const src = map?.getSource(SOURCE_ID);
-    if (src) src.setData(buildFeatures());
+    if (!src) return;
+    src.setData(buildFeatures());
+    // Re-normalize the heatmap weight to the current ceiling so the field
+    // rescales as data/mode changes (ADR 008: colour normalizes relatively).
+    if (map.getLayer(HEAT_LAYER_ID)) {
+      map.setPaintProperty(
+        HEAT_LAYER_ID,
+        "heatmap-weight",
+        heatWeightExpression(currentMaxHeat),
+      );
+    }
+  }
+
+  function applyHeatVisibility() {
+    if (!map || !map.getLayer(HEAT_LAYER_ID)) return;
+    map.setLayoutProperty(
+      HEAT_LAYER_ID,
+      "visibility",
+      heatVisible ? "visible" : "none",
+    );
   }
 
   function fitToSites() {
@@ -181,6 +284,22 @@
   $effect(() => {
     void activeNights;
     if (map && layerReady) pushData();
+  });
+
+  // Mode flip (live <-> historical) swaps what each feature means, so rebuild the
+  // data and drop any open card (its row shape belongs to the other mode).
+  $effect(() => {
+    void mode;
+    if (map && layerReady) {
+      closeCard();
+      pushData();
+    }
+  });
+
+  // Show/hide the heatmap layer when the parent toggles it.
+  $effect(() => {
+    void heatVisible;
+    if (map && layerReady) applyHeatVisibility();
   });
 
   onMount(() => {
@@ -228,15 +347,64 @@
         const pal = palette();
 
         map.addSource(SOURCE_ID, { type: "geojson", data: emptyFC() });
+
+        // Heatmap first, so it sits BENEATH the circle markers (which stay on
+        // top and clickable). Weighted by each feature's `heat`, normalized
+        // relatively in pushData; hidden until the parent toggles it on.
+        map.addLayer({
+          id: HEAT_LAYER_ID,
+          type: "heatmap",
+          source: SOURCE_ID,
+          layout: { visibility: heatVisible ? "visible" : "none" },
+          paint: {
+            "heatmap-weight": heatWeightExpression(currentMaxHeat),
+            // Lift the whole field as you zoom in so sparse points still bloom.
+            "heatmap-intensity": [
+              "interpolate",
+              ["linear"],
+              ["zoom"],
+              5,
+              1,
+              11,
+              3,
+            ],
+            "heatmap-color": HEATMAP_COLOR,
+            // Generous radius: only ~30 sites span Scotland, so each needs a
+            // wide bloom to read as heat rather than a fuzzy dot. Grows with
+            // zoom so clusters stay coherent.
+            "heatmap-radius": [
+              "interpolate",
+              ["linear"],
+              ["zoom"],
+              5,
+              22,
+              8,
+              45,
+              11,
+              70,
+            ],
+            // Fade slightly as you zoom in so the markers take over up close.
+            "heatmap-opacity": [
+              "interpolate",
+              ["linear"],
+              ["zoom"],
+              5,
+              0.9,
+              10,
+              0.6,
+            ],
+          },
+        });
+
         map.addLayer({
           id: LAYER_ID,
           type: "circle",
           source: SOURCE_ID,
           paint: {
-            // Fill by best score: muted slate -> blue -> violet, stepped at
-            // the 35 / 65 bucket boundaries (ADR 007 continuous quality). Ink
-            // stroke keeps every dot legible on the light basemap; better sites
-            // read a touch larger.
+            // Fill by the marker `score` value (absolute live quality, or a
+            // 0..100 relative percentile in historical), stepped at the 35 / 65
+            // bucket boundaries. Ink stroke keeps every dot legible on the light
+            // basemap; better sites read a touch larger.
             "circle-color": [
               "step",
               ["get", "score"],
@@ -302,43 +470,75 @@
         >&times;</button
       >
       <h2 class="card-name">{selected.name}</h2>
-      <dl class="card-stats">
-        <div>
-          <dt>Coordinates</dt>
-          <dd>{fmtCoord(selected.lat, selected.lon)}</dd>
-        </div>
-        <div><dt>Altitude</dt><dd>{selected.altitude_m} m</dd></div>
-        <div><dt>LP zone</dt><dd>{selected.lp_zone}</dd></div>
-      </dl>
 
-      {#if cardHours.length}
-        <p class="eyebrow card-windows-title">Best upcoming hours</p>
-        <table class="card-windows">
-          <thead>
-            <tr>
-              <th>Time</th>
-              <th>Score</th>
-              <th>Cloud</th>
-              <th>Temp</th>
-              <th>Dew</th>
-              <th>Sky</th>
-            </tr>
-          </thead>
-          <tbody>
-            {#each cardHours as h (h.time)}
-              <tr>
-                <td>{fmtTime(h.time)}</td>
-                <td>{Math.round(h.score)}</td>
-                <td>{Math.round(h.cloud_area_fraction)}%</td>
-                <td>{Math.round(h.air_temperature)}C</td>
-                <td>{h.dew_spread?.toFixed(1)}</td>
-                <td>{fmtSymbol(h.symbol)}</td>
-              </tr>
-            {/each}
-          </tbody>
-        </table>
+      {#if mode === "historical"}
+        <!-- Historical body: accumulated realized quality for the month, plus
+             the darkness/clarity decomposition (ADR 008). No hourly windows. -->
+        <dl class="card-stats">
+          <div>
+            <dt>Coordinates</dt>
+            <dd>{fmtCoord(selected.lat, selected.lon)}</dd>
+          </div>
+          <div>
+            <dt>Realized quality</dt>
+            <dd>{Math.round(selected.sum_q ?? 0)}</dd>
+          </div>
+          <div>
+            <dt>Hours banked</dt>
+            <dd>{selected.window_count ?? 0}</dd>
+          </div>
+          <div>
+            <dt>Avg darkness</dt>
+            <dd>{(selected.avg_darkness ?? 0).toFixed(1)}</dd>
+          </div>
+          <div>
+            <dt>Avg clarity</dt>
+            <dd>{(selected.avg_clarity ?? 0).toFixed(1)}</dd>
+          </div>
+        </dl>
+        <p class="card-empty">
+          Quality-weighted frequency accumulated as forecast hours elapsed this
+          month. Higher means more, clearer dark hours banked here.
+        </p>
       {:else}
-        <p class="card-empty">No upcoming viewing hours for this site.</p>
+        <dl class="card-stats">
+          <div>
+            <dt>Coordinates</dt>
+            <dd>{fmtCoord(selected.lat, selected.lon)}</dd>
+          </div>
+          <div><dt>Altitude</dt><dd>{selected.altitude_m} m</dd></div>
+          <div><dt>LP zone</dt><dd>{selected.lp_zone}</dd></div>
+        </dl>
+
+        {#if cardHours.length}
+          <p class="eyebrow card-windows-title">Best upcoming hours</p>
+          <table class="card-windows">
+            <thead>
+              <tr>
+                <th>Time</th>
+                <th>Score</th>
+                <th>Cloud</th>
+                <th>Temp</th>
+                <th>Dew</th>
+                <th>Sky</th>
+              </tr>
+            </thead>
+            <tbody>
+              {#each cardHours as h (h.time)}
+                <tr>
+                  <td>{fmtTime(h.time)}</td>
+                  <td>{Math.round(h.score)}</td>
+                  <td>{Math.round(h.cloud_area_fraction)}%</td>
+                  <td>{Math.round(h.air_temperature)}C</td>
+                  <td>{h.dew_spread?.toFixed(1)}</td>
+                  <td>{fmtSymbol(h.symbol)}</td>
+                </tr>
+              {/each}
+            </tbody>
+          </table>
+        {:else}
+          <p class="card-empty">No upcoming viewing hours for this site.</p>
+        {/if}
       {/if}
 
       <a class="card-link" href={mapsLink} target="_blank" rel="noopener"
@@ -347,11 +547,11 @@
     </aside>
   {/if}
 
-  <!-- Score legend: the colour buckets that tint the dots. -->
+  <!-- Marker legend: the colour buckets that tint the dots (mode-aware). -->
   <div class="legend">
-    <span class="legend-title">Best score</span>
+    <span class="legend-title">{legendTitle}</span>
     <ul class="legend-list">
-      {#each SCORE_BUCKETS as b (b.key)}
+      {#each legendItems as b (b.key)}
         <li>
           <span class="legend-sw" style="background: {b.color}"></span>{b.label}
         </li>
@@ -545,6 +745,7 @@
   .card-empty {
     font-family: var(--mono);
     font-size: 11px;
+    line-height: 1.5;
     color: var(--ink-3);
     margin-bottom: 14px;
   }
@@ -575,7 +776,7 @@
     margin-left: 2px;
   }
 
-  /* Score legend, bottom-left, clear of the bottom-right zoom + attribution. */
+  /* Marker legend, bottom-left, clear of the bottom-right zoom + attribution. */
   .legend {
     position: absolute;
     left: 16px;

--- a/projects/monolith/frontend/src/lib/public/stars/heat.js
+++ b/projects/monolith/frontend/src/lib/public/stars/heat.js
@@ -1,0 +1,71 @@
+// Pure helpers for the /app/stars heatmap layer and the historical month
+// picker. Kept out of StarsMap.svelte so they stay unit-testable without a DOM
+// or MapLibre (mirrors ships/deadReckoning.js, hikes/filters.js).
+
+// Full month-of-year names, indexed 1..12 (index 0 is a pad so month numbers
+// read directly). The historical layer buckets by month-of-year (ADR 008), so
+// the picker and header label by name, not by a year-month.
+export const MONTH_LABELS = [
+  "",
+  "January",
+  "February",
+  "March",
+  "April",
+  "May",
+  "June",
+  "July",
+  "August",
+  "September",
+  "October",
+  "November",
+  "December",
+];
+
+// Short three-letter chip labels (Jan..Dec), indexed 1..12 to match.
+export const MONTH_SHORT = [
+  "",
+  "Jan",
+  "Feb",
+  "Mar",
+  "Apr",
+  "May",
+  "Jun",
+  "Jul",
+  "Aug",
+  "Sep",
+  "Oct",
+  "Nov",
+  "Dec",
+];
+
+// Full month name for a 1..12 number, or "" for anything out of range.
+export function monthLabel(month) {
+  return MONTH_LABELS[month] ?? "";
+}
+
+// Short month name for a 1..12 number, or "" for anything out of range.
+export function monthShort(month) {
+  return MONTH_SHORT[month] ?? "";
+}
+
+// The relative normalization floor: the largest heat value across the current
+// features, but never below `floor` (default 1) so an all-zero or single-point
+// set still yields a strictly ascending interpolate domain (MapLibre rejects a
+// stop list whose inputs are not increasing, which 0..0 would be). The heatmap
+// rescales to whatever data is in view, so switching mode/month re-derives this.
+export function relativeMax(values, floor = 1) {
+  let max = floor;
+  for (const v of values) {
+    if (typeof v === "number" && Number.isFinite(v) && v > max) max = v;
+  }
+  return max;
+}
+
+// MapLibre `heatmap-weight` expression that maps each feature's `heat` property
+// linearly from 0..max onto 0..1, so the densest point reaches full weight
+// regardless of the field's absolute scale (live score 0..100 vs historical
+// sum_q, which can be much larger). Recomputed and re-applied whenever the data
+// changes.
+export function heatWeightExpression(max) {
+  return ["interpolate", ["linear"], ["get", "heat"], 0, 0, max, 1];
+}

--- a/projects/monolith/frontend/src/lib/public/stars/heat.test.js
+++ b/projects/monolith/frontend/src/lib/public/stars/heat.test.js
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "vitest";
+import {
+  monthLabel,
+  monthShort,
+  relativeMax,
+  heatWeightExpression,
+} from "./heat.js";
+
+describe("monthLabel / monthShort", () => {
+  it("maps 1..12 to month names", () => {
+    expect(monthLabel(1)).toBe("January");
+    expect(monthLabel(12)).toBe("December");
+    expect(monthShort(1)).toBe("Jan");
+    expect(monthShort(6)).toBe("Jun");
+  });
+
+  it("returns empty string for out-of-range months", () => {
+    expect(monthLabel(0)).toBe("");
+    expect(monthLabel(13)).toBe("");
+    expect(monthShort(99)).toBe("");
+  });
+});
+
+describe("relativeMax", () => {
+  it("returns the largest finite value", () => {
+    expect(relativeMax([3, 1, 42, 7])).toBe(42);
+  });
+
+  it("never drops below the floor (default 1) so the domain stays ascending", () => {
+    expect(relativeMax([])).toBe(1);
+    expect(relativeMax([0, 0, 0])).toBe(1);
+    expect(relativeMax([0.2, 0.5])).toBe(1);
+  });
+
+  it("honours a custom floor", () => {
+    expect(relativeMax([2, 3], 10)).toBe(10);
+    expect(relativeMax([20, 3], 10)).toBe(20);
+  });
+
+  it("ignores non-finite values", () => {
+    expect(relativeMax([NaN, Infinity, 5, null, "x"])).toBe(5);
+  });
+});
+
+describe("heatWeightExpression", () => {
+  it("builds an interpolate from 0..max onto 0..1", () => {
+    expect(heatWeightExpression(80)).toEqual([
+      "interpolate",
+      ["linear"],
+      ["get", "heat"],
+      0,
+      0,
+      80,
+      1,
+    ]);
+  });
+});

--- a/projects/monolith/frontend/src/routes/public/app/stars/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/stars/+page.svelte
@@ -2,20 +2,32 @@
   import { onMount } from "svelte";
   import { invalidateAll } from "$app/navigation";
   import StarsMap from "$lib/public/components/stars/StarsMap.svelte";
+  import { monthLabel, monthShort } from "$lib/public/stars/heat.js";
 
   let { data } = $props();
 
   let sites = $derived(data.snapshot?.sites ?? []);
   let count = $derived(data.snapshot?.count ?? 0);
 
-  // Night picker: "I'm free Saturday, show me the map for Saturday night." One
-  // chip per viewing night plus an "All" reset; picking a night filters the map
-  // to that night and StarsMap recolours each marker by the score it reaches
-  // then. `nights` is the sorted union of evening dates (YYYY-MM-DD) the API
-  // returns.
+  // Mode: LIVE = the upcoming-forecast layer (per-night quality); HISTORICAL =
+  // the month-bucketed accumulated quality layer (ADR 008). The toggle swaps the
+  // map's data source, the time control (night picker vs month picker), and the
+  // heat field StarsMap weights by.
+  let mode = $state("live");
+
+  // Heat layer: in LIVE it is an optional overlay (markers-first by default, the
+  // shipped look), so it is off until toggled; in HISTORICAL it is the point of
+  // the layer, so it is always on. StarsMap reads the resolved value.
+  let showHeat = $state(false);
+  let heatOn = $derived(mode === "historical" ? true : showHeat);
+
+  // Night picker (LIVE): "I'm free Saturday, show me the map for Saturday night."
+  // One chip per viewing night plus an "All" reset; picking a night filters the
+  // map to that night and StarsMap recolours each marker by the score it reaches
+  // then. `nights` is the sorted union of evening dates the API returns.
   let nights = $derived(data.snapshot?.nights ?? []);
   let selectedNight = $state("all"); // "all" or a night key
-  let filterOpen = $state(false); // the night box is collapsed until tapped
+  let nightOpen = $state(false); // the night box is collapsed until tapped
 
   // Fall back to "all" if the chosen night has dropped off the forecast horizon
   // on an SSR refresh (it elapsed). Derived, so there is no effect to loop on.
@@ -46,8 +58,76 @@
 
   function selectNight(key) {
     selectedNight = key;
-    filterOpen = false; // collapse back to the summary once a night is picked
+    nightOpen = false; // collapse back to the summary once a night is picked
   }
+
+  // Month picker (HISTORICAL): one chip per month-of-year, defaulting to the
+  // current UTC month (the accumulator buckets by month-of-year, not year-month,
+  // so the picker is a fixed Jan..Dec, ADR 008).
+  const MONTHS = Array.from({ length: 12 }, (_, i) => i + 1);
+  let selectedMonth = $state(new Date().getUTCMonth() + 1);
+  let monthOpen = $state(false);
+
+  function selectMonth(m) {
+    selectedMonth = m;
+    monthOpen = false;
+  }
+
+  // Historical data, fetched through the SSR-only same-origin proxy
+  // (/app/stars/history/<month>) so the browser never touches /api/stars/*.
+  // Cached per month so re-selecting a month is instant.
+  const historyCache = new Map();
+  let historyData = $state(null); // last loaded {month, sites, count}
+  let historyLoading = $state(false);
+  let historyError = $state(false);
+
+  async function loadMonth(m) {
+    if (historyCache.has(m)) {
+      historyData = historyCache.get(m);
+      historyError = false;
+      return;
+    }
+    historyLoading = true;
+    historyError = false;
+    try {
+      const res = await fetch(`/app/stars/history/${m}`);
+      if (!res.ok) throw new Error(`history ${res.status}`);
+      const payload = await res.json();
+      historyCache.set(m, payload);
+      // Only apply if the user has not moved on while the fetch was in flight.
+      if (mode === "historical" && selectedMonth === m) {
+        historyData = payload;
+      }
+    } catch {
+      if (mode === "historical" && selectedMonth === m) historyError = true;
+    } finally {
+      historyLoading = false;
+    }
+  }
+
+  // Load (or re-use) the selected month whenever we are in historical mode or the
+  // month changes. Reads mode + selectedMonth, so it re-runs on either; it does
+  // not read the history state it writes, so there is no loop.
+  $effect(() => {
+    if (mode === "historical") loadMonth(selectedMonth);
+  });
+
+  function setMode(next) {
+    if (next === mode) return;
+    mode = next;
+    if (next === "live") showHeat = false; // back to markers-first live default
+  }
+
+  // The site set the map plots: live snapshot, or the loaded month's sites.
+  let mapSites = $derived(mode === "live" ? sites : (historyData?.sites ?? []));
+
+  // Whether the loaded history matches the currently selected month (guards the
+  // header + empty state from showing stale counts during a month switch).
+  let histReady = $derived(
+    !!historyData && historyData.month === selectedMonth,
+  );
+  let histCount = $derived(histReady ? historyData.count : 0);
+
   // sites is already sorted by best_score descending, so the head is the best.
   let topScore = $derived(
     sites.length ? Math.round(sites[0].best_score ?? 0) : null,
@@ -94,14 +174,14 @@
   <title>Dark-sky stargazing map, Scotland viewing windows</title>
   <meta
     name="description"
-    content="A map of curated Scottish dark-sky sites scored by upcoming viewing windows from the met.no forecast."
+    content="A map of curated Scottish dark-sky sites scored by upcoming viewing windows from the met.no forecast, with a historical realized-quality layer by month."
   />
 </svelte:head>
 
 <div class="stars-page">
   <h1 class="sr-only">Dark-sky stargazing map, Scotland viewing windows</h1>
 
-  <StarsMap {sites} {activeNights} {nowMs} />
+  <StarsMap sites={mapSites} {activeNights} {nowMs} {mode} heatVisible={heatOn} />
 
   <!-- Floating header: breadcrumb + headline stats, top-left clear of the map
        chrome (mirrors the hikes control head). -->
@@ -116,64 +196,158 @@
           <span class="crumb-sep">/</span>
           <span class="crumb-name">stars</span>
         </nav>
-        <p class="stats">
-          {count} dark-sky sites{#if topScore != null}
-            &middot; best score {topScore}{/if}{#if agoLabel}
-            &middot; updated {agoLabel} ago{/if}
-        </p>
+        {#if mode === "historical"}
+          <p class="stats">
+            {histCount}
+            {histCount === 1 ? "site" : "sites"} with history in {monthLabel(
+              selectedMonth,
+            )}
+          </p>
+        {:else}
+          <p class="stats">
+            {count} dark-sky sites{#if topScore != null}
+              &middot; best score {topScore}{/if}{#if agoLabel}
+              &middot; updated {agoLabel} ago{/if}
+          </p>
+        {/if}
       </div>
     </div>
 
-    {#if nights.length > 1}
-      <div class="panel night-filter">
+    <!-- Mode toggle: LIVE forecast vs HISTORICAL realized-quality (ADR 008). -->
+    <div class="panel mode-toggle" role="group" aria-label="Map mode">
+      <button
+        type="button"
+        class="seg"
+        class:is-active={mode === "live"}
+        aria-pressed={mode === "live"}
+        onclick={() => setMode("live")}
+      >
+        Live
+      </button>
+      <button
+        type="button"
+        class="seg"
+        class:is-active={mode === "historical"}
+        aria-pressed={mode === "historical"}
+        onclick={() => setMode("historical")}
+      >
+        Historical
+      </button>
+    </div>
+
+    {#if mode === "live"}
+      <!-- Heat overlay switch (live only): historical forces heat on. -->
+      <button
+        type="button"
+        class="panel heat-switch"
+        class:is-on={showHeat}
+        aria-pressed={showHeat}
+        onclick={() => (showHeat = !showHeat)}
+      >
+        <span class="heat-label">Heatmap</span>
+        <span class="heat-state">{showHeat ? "On" : "Off"}</span>
+      </button>
+
+      {#if nights.length > 1}
+        <div class="panel night-filter">
+          <button
+            type="button"
+            class="filter-toggle"
+            aria-expanded={nightOpen}
+            onclick={() => (nightOpen = !nightOpen)}
+          >
+            <span class="filter-label">Night</span>
+            <span class="filter-current"
+              >{effectiveNight === "all"
+                ? "All nights"
+                : nightLabel(effectiveNight)}</span
+            >
+            <span class="filter-caret" class:open={nightOpen} aria-hidden="true"
+              >&#9662;</span
+            >
+          </button>
+          {#if nightOpen}
+            <div class="night-chips">
+              <button
+                type="button"
+                class="night-chip night-chip-all"
+                class:is-off={effectiveNight !== "all"}
+                aria-pressed={effectiveNight === "all"}
+                onclick={() => selectNight("all")}
+              >
+                All nights
+              </button>
+              {#each nights as night (night)}
+                <button
+                  type="button"
+                  class="night-chip"
+                  class:is-off={effectiveNight !== night}
+                  aria-pressed={effectiveNight === night}
+                  onclick={() => selectNight(night)}
+                >
+                  {nightLabel(night)}
+                </button>
+              {/each}
+            </div>
+          {/if}
+        </div>
+      {/if}
+
+      {#if count === 0}
+        <div class="panel empty-state" role="status">
+          No dark-sky windows in the next few nights. Check back after the next
+          forecast refresh.
+        </div>
+      {/if}
+    {:else}
+      <!-- Month picker (historical): a collapsed summary that expands into a
+           four-up grid of month chips, mirroring the night picker. -->
+      <div class="panel month-filter">
         <button
           type="button"
           class="filter-toggle"
-          aria-expanded={filterOpen}
-          onclick={() => (filterOpen = !filterOpen)}
+          aria-expanded={monthOpen}
+          onclick={() => (monthOpen = !monthOpen)}
         >
-          <span class="filter-label">Night</span>
-          <span class="filter-current"
-            >{effectiveNight === "all"
-              ? "All nights"
-              : nightLabel(effectiveNight)}</span
-          >
-          <span class="filter-caret" class:open={filterOpen} aria-hidden="true"
+          <span class="filter-label">Month</span>
+          <span class="filter-current">{monthLabel(selectedMonth)}</span>
+          <span class="filter-caret" class:open={monthOpen} aria-hidden="true"
             >&#9662;</span
           >
         </button>
-        {#if filterOpen}
-          <div class="night-chips">
-            <button
-              type="button"
-              class="night-chip night-chip-all"
-              class:is-off={effectiveNight !== "all"}
-              aria-pressed={effectiveNight === "all"}
-              onclick={() => selectNight("all")}
-            >
-              All nights
-            </button>
-            {#each nights as night (night)}
+        {#if monthOpen}
+          <div class="month-chips">
+            {#each MONTHS as m (m)}
               <button
                 type="button"
-                class="night-chip"
-                class:is-off={effectiveNight !== night}
-                aria-pressed={effectiveNight === night}
-                onclick={() => selectNight(night)}
+                class="month-chip"
+                class:is-off={selectedMonth !== m}
+                aria-pressed={selectedMonth === m}
+                onclick={() => selectMonth(m)}
               >
-                {nightLabel(night)}
+                {monthShort(m)}
               </button>
             {/each}
           </div>
         {/if}
       </div>
-    {/if}
 
-    {#if count === 0}
-      <div class="panel empty-state" role="status">
-        No dark-sky windows in the next few nights. Check back after the next
-        forecast refresh.
-      </div>
+      {#if historyError}
+        <div class="panel empty-state" role="status">
+          Historical data is unavailable right now. Try another month or check
+          back shortly.
+        </div>
+      {:else if historyLoading && !histReady}
+        <div class="panel empty-state" role="status">
+          Loading {monthLabel(selectedMonth)} history&hellip;
+        </div>
+      {:else if histReady && histCount === 0}
+        <div class="panel empty-state" role="status">
+          Historical data is still accumulating for {monthLabel(selectedMonth)}.
+          Quality banks as forecast hours elapse, so this layer fills over the
+          coming weeks.
+        </div>
+      {/if}
     {/if}
   </div>
 </div>
@@ -292,9 +466,83 @@
     color: var(--ink-2);
   }
 
-  /* Night filter: a collapsed summary row that expands on click into a two-up
-     grid of night chips, so it stays out of the way until you reach for it. */
-  .night-filter {
+  /* Mode toggle: two equal segments, the active one filled ink-on-paper, the
+     other inverted, sharing one border (neobrutalist segmented control). */
+  .mode-toggle {
+    display: flex;
+    padding: 0;
+    overflow: hidden;
+  }
+
+  .seg {
+    flex: 1;
+    padding: 10px 12px;
+    background: var(--paper);
+    color: var(--ink);
+    border: none;
+    cursor: pointer;
+    font-family: var(--mono);
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    transition: background 110ms ease;
+  }
+
+  .seg + .seg {
+    border-left: 2px solid var(--ink);
+  }
+
+  .seg.is-active {
+    background: var(--ink);
+    color: var(--paper);
+  }
+
+  .seg:not(.is-active):hover,
+  .seg:not(.is-active):focus-visible {
+    background: var(--cream);
+  }
+
+  /* Heat switch: a single full-width pill mirroring the filter toggle row; fills
+     accent when on so it reads as engaged. */
+  .heat-switch {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    cursor: pointer;
+    font-family: var(--mono);
+    text-align: left;
+    transition: background 110ms ease;
+  }
+
+  .heat-label {
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--ink-2);
+  }
+
+  .heat-state {
+    margin-left: auto;
+    font-size: 12px;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+  }
+
+  .heat-switch.is-on {
+    background: var(--accent);
+  }
+
+  .heat-switch.is-on .heat-label,
+  .heat-switch.is-on .heat-state {
+    color: var(--ink);
+  }
+
+  /* Time filters (night + month): a collapsed summary row that expands on click
+     into a grid of chips, so it stays out of the way until reached for. */
+  .night-filter,
+  .month-filter {
     padding: 0;
   }
 
@@ -336,8 +584,8 @@
     transform: rotate(180deg);
   }
 
-  /* Two-column grid of chips, revealed below the summary when expanded; the top
-     rule separates it from the toggle row. */
+  /* Grid of chips, revealed below the summary when expanded; the top rule
+     separates it from the toggle row. Nights are two-up, months four-up. */
   .night-chips {
     display: grid;
     grid-template-columns: 1fr 1fr;
@@ -346,7 +594,16 @@
     border-top: 2px solid var(--ink);
   }
 
-  .night-chip {
+  .month-chips {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 6px;
+    padding: 10px 12px 12px;
+    border-top: 2px solid var(--ink);
+  }
+
+  .night-chip,
+  .month-chip {
     padding: 6px 9px;
     background: var(--ink);
     color: var(--paper);
@@ -365,25 +622,29 @@
   }
 
   .night-chip:hover,
-  .night-chip:focus-visible {
+  .night-chip:focus-visible,
+  .month-chip:hover,
+  .month-chip:focus-visible {
     transform: translate(-2px, -2px);
     box-shadow: 2px 2px 0 var(--ink);
   }
 
-  .night-chip:active {
+  .night-chip:active,
+  .month-chip:active {
     transform: translate(-1px, -1px);
     box-shadow: 1px 1px 0 var(--ink);
   }
 
-  /* The picked night is the filled chip; the rest invert to paper + dim so the
-     current selection reads at a glance while staying tappable. */
-  .night-chip.is-off {
+  /* The picked chip is filled; the rest invert to paper + dim so the current
+     selection reads at a glance while staying tappable. */
+  .night-chip.is-off,
+  .month-chip.is-off {
     background: var(--paper);
     color: var(--ink);
     opacity: 0.55;
   }
 
-  /* The reset spans the full width above the per-night grid. */
+  /* The night reset spans the full width above the per-night grid. */
   .night-chip-all {
     grid-column: 1 / -1;
   }

--- a/projects/monolith/frontend/src/routes/public/app/stars/history/[month]/+server.js
+++ b/projects/monolith/frontend/src/routes/public/app/stars/history/[month]/+server.js
@@ -1,0 +1,26 @@
+import { error, json } from "@sveltejs/kit";
+import { STARS_HISTORY_CACHE_CONTROL } from "$lib/cache-headers.js";
+
+const API_BASE = process.env.API_BASE || "http://localhost:8000";
+
+// Same-origin proxy for the historical heatmap layer (ADR 008). The page calls
+// this site route (/app/stars/history/{month}) when it switches to Historical
+// mode or the month changes; the fetch to /api/stars/history happens here,
+// server-side in the same pod, keeping that private surface off the browser.
+// Mirrors hikes/walk/[uuid]/+server.js. `month` is 1..12; the API clamps and
+// defaults internally, so an out-of-range value still returns a (possibly
+// empty) payload rather than 4xx.
+export async function GET({ params, fetch }) {
+  const month = Number(params.month);
+  const res = await fetch(
+    `${API_BASE}/api/stars/history?month=${encodeURIComponent(month)}`,
+    { signal: AbortSignal.timeout(10_000) },
+  );
+  if (!res.ok) {
+    throw error(503, "stars history unavailable");
+  }
+
+  return json(await res.json(), {
+    headers: { "cache-control": STARS_HISTORY_CACHE_CONTROL },
+  });
+}


### PR DESCRIPTION
The user-facing piece of ADR 008: `/app/stars` gets a **Live / Historical** mode toggle, a MapLibre **heatmap layer**, and a **month picker** (historical), reusing the existing night picker.

- **Live**: markers (as shipped) + a Heatmap on/off pill; heat weighted by the selected night's score.
- **Historical**: heatmap forced on, weighted by `sum_q` from `/api/stars/history?month=` (via a new SSR-only `history/[month]/+server.js` proxy); month picker defaults to the current month; honest "still accumulating" empty state.
- Heat weight is **relative-normalized** (rescales per mode/night/month); markers stay clickable on top.

Historical is sparse until the live accumulator fills / the ERA5 climatology backfill (ADR 009) lands. Heat paint (radius/intensity/opacity) is reasoned-not-rendered, may want a tweak once live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)