### PR TITLE
feat(monolith): stars ERA5 climatology loader (ADR 009)

### DIFF
--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -2127,6 +2127,17 @@ py_test(
 )
 
 py_test(
+    name = "stars_climatology_test",
+    srcs = ["stars/climatology_test.py"],
+    imports = ["."],
+    deps = [
+        ":monolith_backend",
+        "@pip//pytest",
+        "@pip//sqlmodel",
+    ],
+)
+
+py_test(
     name = "stars_router_test",
     srcs = ["stars/router_test.py"],
     imports = ["."],

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.130.4
+version: 0.131.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.131.0
+version: 0.131.1
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/migrations/20260613000060_stars_climatology.sql
+++ b/projects/monolith/chart/migrations/20260613000060_stars_climatology.sql
@@ -1,0 +1,18 @@
+-- Stars ERA5 climatology backfill (ADR 009): a long-run seasonal baseline that
+-- pre-fills the historical heatmap before the live accumulator (site_month_stats,
+-- ADR 008) has banked enough elapsed forecast hours to be meaningful.
+--
+-- An offline step computes per-site, per-month-of-year sufficient stats from the
+-- ERA5 reanalysis and uploads climatology.json to SeaweedFS out-of-band. The
+-- stars.load_climatology job wholesale-replaces this table from that object, and
+-- /api/stars/history sums it with the live accumulator per site. Same shape as
+-- site_month_stats so the two compose by simple per-field addition.
+CREATE TABLE stars.site_month_climatology (
+    site_id      TEXT NOT NULL,
+    month        SMALLINT NOT NULL,
+    window_count INTEGER NOT NULL DEFAULT 0,
+    sum_q        DOUBLE PRECISION NOT NULL DEFAULT 0,
+    sum_darkness DOUBLE PRECISION NOT NULL DEFAULT 0,
+    sum_clarity  DOUBLE PRECISION NOT NULL DEFAULT 0,
+    PRIMARY KEY (site_id, month)
+);

--- a/projects/monolith/chart/migrations/atlas.sum
+++ b/projects/monolith/chart/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:uZI2ocZbSd95/BSbghc8n5SWKMEp/NbxFRBH79csfeE=
+h1:IvUniSDumRO6aG4YVbFYVAu6GFM6NgbrXEIg+dz3yLQ=
 20260330000000_initial_schema.sql h1:J2futpSW0nJAIRR7nR7ssT7LwXIYrvRI+PkHb5Y4tLI=
 20260403000000_chat_schema.sql h1:pERUFC0vzM95etRuzp43XzkCV7lBCzrrtY5Mk7aF3CA=
 20260404000000_chat_attachments.sql h1:tv+Fdbr1rQC5nzUxfaBC0O6fu2OMGgLWf+YNg1WQXi4=
@@ -35,3 +35,4 @@ h1:uZI2ocZbSd95/BSbghc8n5SWKMEp/NbxFRBH79csfeE=
 20260613000030_stars_sun_elevation.sql h1:KZFw4zfaRTVVvPeEXk/z/Ts1qtK7cMAxiW8EThPJA1I=
 20260613000040_stars_sites.sql h1:9y+8j63oMhAIUKrFZyCsfgfsmsoEtNxkUw+VRERpzlM=
 20260613000050_stars_history.sql h1:3TOUfWf/5ObXUfauw/zRnBUefirFRt4G4Gh6lTYc1Bc=
+20260613000060_stars_climatology.sql h1:iHhd80/ZuZYw+77h9wJxQR2wvUny+MUqkLv6Tsis/qA=

--- a/projects/monolith/chart/templates/deployment.yaml
+++ b/projects/monolith/chart/templates/deployment.yaml
@@ -165,6 +165,8 @@ spec:
               value: {{ .Values.stars.gridBucket | quote }}
             - name: STARS_GRID_S3_KEY
               value: {{ .Values.stars.gridKey | quote }}
+            - name: STARS_CLIMATOLOGY_S3_KEY
+              value: {{ .Values.stars.climatologyKey | quote }}
             {{- end }}
           livenessProbe:
             httpGet:

--- a/projects/monolith/chart/values.yaml
+++ b/projects/monolith/chart/values.yaml
@@ -128,6 +128,7 @@ stars:
   seaweedfsS3Endpoint: "http://seaweedfs-s3.seaweedfs.svc.cluster.local:8333"
   gridBucket: "stars"
   gridKey: "grid.json"
+  climatologyKey: "climatology.json"
   s3AccessKeyId: "duckdb"
   s3SecretAccessKey: "duckdb"
 

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.131.0
+      targetRevision: 0.131.1
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.130.4
+      targetRevision: 0.131.0
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/stars/__init__.py
+++ b/projects/monolith/stars/__init__.py
@@ -20,7 +20,7 @@ def register(app: FastAPI) -> None:
 
 def on_startup_jobs(session: Session) -> None:
     from shared.scheduler import register_job
-    from stars.grid import load_grid_handler
+    from stars.grid import load_climatology_handler, load_grid_handler
     from stars.jobs import prune_hours_handler, refresh_handler
 
     register_job(
@@ -28,6 +28,13 @@ def on_startup_jobs(session: Session) -> None:
         name="stars.load_grid",
         interval_secs=6 * 3600,
         handler=load_grid_handler,
+        ttl_secs=600,
+    )
+    register_job(
+        session,
+        name="stars.load_climatology",
+        interval_secs=24 * 3600,
+        handler=load_climatology_handler,
         ttl_secs=600,
     )
     register_job(

--- a/projects/monolith/stars/__init___test.py
+++ b/projects/monolith/stars/__init___test.py
@@ -23,25 +23,41 @@ def test_register_passes_router_to_include_router():
     assert args[0] is real_router
 
 
-def test_on_startup_jobs_calls_register_job_three_times():
-    """on_startup_jobs() calls register_job exactly three times."""
+def test_on_startup_jobs_calls_register_job_four_times():
+    """on_startup_jobs() calls register_job exactly four times."""
     import stars
 
     session = MagicMock()
     with patch("shared.scheduler.register_job") as mock_register:
         stars.on_startup_jobs(session)
-    assert mock_register.call_count == 3
+    assert mock_register.call_count == 4
 
 
 def test_on_startup_jobs_correct_names():
-    """on_startup_jobs() registers stars.load_grid, stars.refresh, and stars.prune_hours."""
+    """on_startup_jobs() registers the four stars scheduled jobs."""
     import stars
 
     session = MagicMock()
     with patch("shared.scheduler.register_job") as mock_register:
         stars.on_startup_jobs(session)
     names = {c[1]["name"] for c in mock_register.call_args_list}
-    assert names == {"stars.load_grid", "stars.refresh", "stars.prune_hours"}
+    assert names == {
+        "stars.load_grid",
+        "stars.load_climatology",
+        "stars.refresh",
+        "stars.prune_hours",
+    }
+
+
+def test_on_startup_jobs_load_climatology_interval():
+    """stars.load_climatology is registered with a 24-hour interval."""
+    import stars
+
+    session = MagicMock()
+    with patch("shared.scheduler.register_job") as mock_register:
+        stars.on_startup_jobs(session)
+    by_name = {c[1]["name"]: c[1] for c in mock_register.call_args_list}
+    assert by_name["stars.load_climatology"]["interval_secs"] == 24 * 3600
 
 
 def test_on_startup_jobs_passes_session_as_first_positional():

--- a/projects/monolith/stars/climatology_test.py
+++ b/projects/monolith/stars/climatology_test.py
@@ -1,0 +1,127 @@
+"""Unit tests for the stars ERA5 climatology ingest (ADR 009).
+
+Mirrors stars/grid_test: SQLModel.metadata.create_all on SQLite (no migrations),
+_fetch_climatology monkeypatched so the S3 layer is never exercised, and
+_load_climatology_sync's get_engine pointed at the in-memory engine so the
+wholesale-replace is asserted against a real session.
+"""
+
+import pytest
+from sqlmodel import Session, SQLModel, create_engine, select
+from sqlmodel.pool import StaticPool
+
+import stars.grid as grid
+from stars.models import SiteMonthClimatology
+
+
+@pytest.fixture(name="engine")
+def engine_fixture(monkeypatch):
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    original_schemas = {}
+    for table in SQLModel.metadata.tables.values():
+        if table.schema is not None:
+            original_schemas[table.name] = table.schema
+            table.schema = None
+    try:
+        SQLModel.metadata.create_all(engine)
+        # _load_climatology_sync opens its own Session(get_engine()); point it here.
+        import app.db as db
+
+        monkeypatch.setattr(db, "get_engine", lambda: engine)
+        yield engine
+    finally:
+        for table in SQLModel.metadata.tables.values():
+            if table.name in original_schemas:
+                table.schema = original_schemas[table.name]
+
+
+_CLIMO = [
+    {
+        "site_id": "scotland-0001",
+        "month": 3,
+        "window_count": 300,
+        "sum_q": 18180.0,
+        "sum_darkness": 210.5,
+        "sum_clarity": 250.1,
+    },
+    {
+        "site_id": "scotland-0002",
+        "month": 3,
+        "window_count": 120,
+        "sum_q": 6000.0,
+        "sum_darkness": 80.0,
+        "sum_clarity": 70.0,
+    },
+]
+
+
+def test_load_climatology_sync_upserts_rows(engine, monkeypatch):
+    monkeypatch.setattr(grid, "_fetch_climatology", lambda: [dict(r) for r in _CLIMO])
+
+    written = grid._load_climatology_sync()
+    assert written == 2
+
+    with Session(engine) as session:
+        rows = session.exec(select(SiteMonthClimatology)).all()
+        by_id = {r.site_id: r for r in rows}
+    assert set(by_id) == {"scotland-0001", "scotland-0002"}
+    assert by_id["scotland-0001"].month == 3
+    assert by_id["scotland-0001"].window_count == 300
+    assert by_id["scotland-0001"].sum_q == 18180.0
+    assert by_id["scotland-0001"].sum_darkness == 210.5
+    assert by_id["scotland-0001"].sum_clarity == 250.1
+
+
+def test_load_climatology_sync_replaces_existing_rows(engine, monkeypatch):
+    # A stale row not present in the new backfill must be removed (wholesale replace).
+    with Session(engine) as session:
+        session.add(
+            SiteMonthClimatology(site_id="stale", month=9, window_count=5, sum_q=10.0)
+        )
+        session.commit()
+
+    monkeypatch.setattr(grid, "_fetch_climatology", lambda: [dict(_CLIMO[0])])
+    written = grid._load_climatology_sync()
+    assert written == 1
+
+    with Session(engine) as session:
+        keys = {
+            (r.site_id, r.month)
+            for r in session.exec(select(SiteMonthClimatology)).all()
+        }
+    assert keys == {("scotland-0001", 3)}
+
+
+def test_load_climatology_sync_skips_malformed_rows(engine, monkeypatch):
+    payload = [
+        {"site_id": "good", "month": 6, "window_count": 1, "sum_q": 5.0},
+        {"site_id": "no-month"},  # missing month -> skipped
+        {"month": 6},  # missing site_id -> skipped
+        {"site_id": "bad-month", "month": 13},  # month out of range -> skipped
+        {"site_id": "non-numeric", "month": "abc"},  # unparseable month -> skipped
+        "not-a-dict",  # skipped
+    ]
+    monkeypatch.setattr(grid, "_fetch_climatology", lambda: payload)
+
+    written = grid._load_climatology_sync()
+    assert written == 1
+    with Session(engine) as session:
+        ids = {r.site_id for r in session.exec(select(SiteMonthClimatology)).all()}
+    assert ids == {"good"}
+
+
+def test_load_climatology_sync_empty_is_noop(engine, monkeypatch):
+    monkeypatch.setattr(grid, "_fetch_climatology", lambda: None)
+    assert grid._load_climatology_sync() == 0
+
+
+def test_fetch_climatology_unset_endpoint_returns_none(monkeypatch):
+    monkeypatch.delenv("SEAWEEDFS_S3_ENDPOINT", raising=False)
+    assert grid._fetch_climatology() is None
+
+    monkeypatch.setenv("SEAWEEDFS_S3_ENDPOINT", "   ")
+    assert grid._fetch_climatology() is None

--- a/projects/monolith/stars/grid.py
+++ b/projects/monolith/stars/grid.py
@@ -23,7 +23,7 @@ from datetime import datetime, timezone
 
 from sqlmodel import Session, delete, select
 
-from stars.models import Site, SiteHour
+from stars.models import Site, SiteHour, SiteMonthClimatology
 
 logger = logging.getLogger("monolith.stars.grid")
 
@@ -159,4 +159,113 @@ async def load_grid_handler(session: Session) -> datetime | None:
 
     count = await asyncio.to_thread(_load_grid_sync)
     logger.info("stars.load_grid: %d sites", count)
+    return None
+
+
+def _fetch_climatology() -> list[dict] | None:
+    """Read climatology.json from SeaweedFS; None on missing endpoint or any error.
+
+    The ERA5 backfill (ADR 009): an offline step uploads per-site, per-month-of-year
+    sufficient stats out-of-band. A missing/empty ``SEAWEEDFS_S3_ENDPOINT`` is the
+    expected state in environments without SeaweedFS (e.g. local dev): log a warning
+    and no-op rather than crash. Any S3/parse error is also swallowed to a warning
+    so a bad object never wedges the scheduler.
+    """
+    if not os.environ.get("SEAWEEDFS_S3_ENDPOINT", "").strip():
+        logger.warning("stars.load_climatology: SEAWEEDFS_S3_ENDPOINT unset, skipping")
+        return None
+    bucket = os.environ.get("STARS_GRID_S3_BUCKET", "stars")
+    key = os.environ.get("STARS_CLIMATOLOGY_S3_KEY", "climatology.json")
+    try:
+        s3 = _s3_client()
+        obj = s3.get_object(Bucket=bucket, Key=key)
+        body = obj["Body"].read()
+        data = json.loads(body)
+    except Exception as exc:
+        logger.warning(
+            "stars.load_climatology: failed to fetch %s/%s: %s", bucket, key, exc
+        )
+        return None
+    if not isinstance(data, list):
+        logger.warning(
+            "stars.load_climatology: climatology.json is not a JSON array, skipping"
+        )
+        return None
+    return data
+
+
+def _load_climatology_sync() -> int:
+    """Wholesale-replace stars.site_month_climatology from the backfill. Returns rows written.
+
+    Malformed rows (missing site_id/month, non-numeric stats, or month outside
+    1-12) are skipped with a logged count. The delete + add_all run in one
+    transaction so a failure leaves the prior table intact rather than truncating
+    it.
+    """
+    from app.db import get_engine
+
+    backfill = _fetch_climatology()
+    if not backfill:
+        return 0
+
+    rows: list[SiteMonthClimatology] = []
+    skipped = 0
+    for entry in backfill:
+        if not isinstance(entry, dict):
+            skipped += 1
+            continue
+        site_id = entry.get("site_id")
+        month = entry.get("month")
+        if site_id is None or month is None:
+            skipped += 1
+            continue
+        try:
+            month_int = int(month)
+            if not 1 <= month_int <= 12:
+                skipped += 1
+                continue
+            rows.append(
+                SiteMonthClimatology(
+                    site_id=str(site_id),
+                    month=month_int,
+                    window_count=int(entry.get("window_count") or 0),
+                    sum_q=float(entry.get("sum_q") or 0.0),
+                    sum_darkness=float(entry.get("sum_darkness") or 0.0),
+                    sum_clarity=float(entry.get("sum_clarity") or 0.0),
+                )
+            )
+        except (TypeError, ValueError):
+            skipped += 1
+            continue
+    if skipped:
+        logger.warning(
+            "stars.load_climatology: skipped %d malformed climatology rows", skipped
+        )
+    if not rows:
+        logger.warning(
+            "stars.load_climatology: no valid climatology rows, leaving table intact"
+        )
+        return 0
+
+    with Session(get_engine()) as session:
+        # synchronize_session=False: a wholesale clear before reload; there are
+        # no in-session objects to keep in sync, so skip the ORM evaluator.
+        session.execute(
+            delete(SiteMonthClimatology).execution_options(synchronize_session=False)
+        )
+        session.add_all(rows)
+        session.commit()
+    return len(rows)
+
+
+async def load_climatology_handler(session: Session) -> datetime | None:
+    """Ingest the ERA5 climatology backfill into stars.site_month_climatology.
+
+    The S3 fetch + DB write run together in a worker thread with their own fresh
+    session; this handler never touches the passed session on the event loop.
+    """
+    import asyncio
+
+    count = await asyncio.to_thread(_load_climatology_sync)
+    logger.info("stars.load_climatology: %d rows", count)
     return None

--- a/projects/monolith/stars/grid_gen/backfill_climatology.py
+++ b/projects/monolith/stars/grid_gen/backfill_climatology.py
@@ -1,0 +1,179 @@
+"""Offline ERA5 climatology backfill for the stars historical heatmap (ADR 009).
+
+Fetches ~5yr of hourly ERA5 (Open-Meteo archive) per grid point, scores each
+dark hour with the same Q = D x C x W model as the live pipeline, and aggregates
+sufficient statistics by month-of-year into climatology.json.
+
+Pure stdlib: NOAA solar elevation (so D matches astral within tolerance) and the
+Q-factor formulas replicated from projects/monolith/stars/scoring.py (KEEP IN
+SYNC). Output is uploaded to SeaweedFS (s3://stars/climatology.json) and ingested
+by the stars.load_climatology job into stars.site_month_climatology.
+"""
+
+import json
+import math
+import sys
+import time
+import urllib.parse
+import urllib.request
+from datetime import datetime
+
+ARCHIVE = "https://archive-api.open-meteo.com/v1/archive"
+START, END = "2021-01-01", "2025-12-31"
+CIVIL, ASTRO, CLOUD_SPAN = -6.0, -18.0, 45.0
+
+
+def sun_elevation_deg(lat, lon, dt):
+    """NOAA solar elevation (degrees) for a naive-UTC datetime."""
+    doy = dt.timetuple().tm_yday
+    hour = dt.hour + dt.minute / 60.0
+    g = 2 * math.pi / 365.0 * (doy - 1 + (hour - 12) / 24.0)
+    eqtime = 229.18 * (
+        0.000075
+        + 0.001868 * math.cos(g)
+        - 0.032077 * math.sin(g)
+        - 0.014615 * math.cos(2 * g)
+        - 0.040849 * math.sin(2 * g)
+    )
+    decl = (
+        0.006918
+        - 0.399912 * math.cos(g)
+        + 0.070257 * math.sin(g)
+        - 0.006758 * math.cos(2 * g)
+        + 0.000907 * math.sin(2 * g)
+        - 0.002697 * math.cos(3 * g)
+        + 0.00148 * math.sin(3 * g)
+    )
+    tst = hour * 60.0 + eqtime + 4.0 * lon  # true solar time (minutes), UTC
+    ha = math.radians(tst / 4.0 - 180.0)  # hour angle
+    latr = math.radians(lat)
+    cos_zen = math.sin(latr) * math.sin(decl) + math.cos(latr) * math.cos(
+        decl
+    ) * math.cos(ha)
+    cos_zen = max(-1.0, min(1.0, cos_zen))
+    return 90.0 - math.degrees(math.acos(cos_zen))
+
+
+def darkness_factor(e):
+    if e >= CIVIL:
+        return 0.0
+    if e <= ASTRO:
+        return 1.0
+    return (CIVIL - e) / (CIVIL - ASTRO)
+
+
+def cloud_factor(cloud, d):
+    allowance = 5.0 + 5.0 * d
+    return max(0.0, 1.0 - max(0.0, cloud - allowance) / CLOUD_SPAN)
+
+
+def _humidity_score(h):
+    if h < 70:
+        return 100.0
+    if h < 85:
+        return 100.0 - (h - 70) * 3.33
+    return max(0.0, 50.0 - (h - 85) * 3.33)
+
+
+def _wind_score(w):
+    if w < 5:
+        return 100.0
+    if w < 10:
+        return 100.0 - (w - 5) * 10.0
+    return max(0.0, 50.0 - (w - 10) * 5.0)
+
+
+def _dew_score(spread):
+    if spread > 5:
+        return 100.0
+    if spread > 2:
+        return 100.0 - (5 - spread) * 16.67
+    return max(0.0, 50.0 - (2 - spread) * 25.0)
+
+
+def weather_modifier(humidity, wind, dew_spread):
+    # fog has no ERA5 equivalent -> fog_score is 100 (matches the default path).
+    avg = (
+        _humidity_score(humidity) + 100.0 + _wind_score(wind) + _dew_score(dew_spread)
+    ) / 4.0
+    return 0.7 + 0.3 * (avg / 100.0)
+
+
+def score_point(lat, lon, hourly):
+    """Aggregate sufficient stats by month-of-year for one point's ERA5 series."""
+    times = hourly["time"]
+    cc = hourly["cloud_cover"]
+    temp = hourly["temperature_2m"]
+    rh = hourly["relative_humidity_2m"]
+    wind = hourly["wind_speed_10m"]
+    dew = hourly["dew_point_2m"]
+    by_month = {}  # month -> [count, sum_q, sum_d, sum_c]
+    for i, t in enumerate(times):
+        if cc[i] is None or temp[i] is None or dew[i] is None:
+            continue
+        dt = datetime.fromisoformat(t)  # naive UTC
+        d = darkness_factor(sun_elevation_deg(lat, lon, dt))
+        if d <= 0:
+            continue
+        c = cloud_factor(cc[i], d)
+        w = weather_modifier(rh[i] or 100, wind[i] or 0, temp[i] - dew[i])
+        q = d * c * w * 100.0
+        if q <= 0:
+            continue
+        b = by_month.setdefault(dt.month, [0, 0.0, 0.0, 0.0])
+        b[0] += 1
+        b[1] += q
+        b[2] += d
+        b[3] += c
+    return by_month
+
+
+def fetch(lat, lon):
+    qs = urllib.parse.urlencode(
+        {
+            "latitude": lat,
+            "longitude": lon,
+            "start_date": START,
+            "end_date": END,
+            "hourly": "cloud_cover,temperature_2m,relative_humidity_2m,wind_speed_10m,dew_point_2m",
+            "timezone": "UTC",
+            "wind_speed_unit": "ms",
+        }
+    )
+    for attempt in range(5):
+        try:
+            with urllib.request.urlopen(f"{ARCHIVE}?{qs}", timeout=60) as r:
+                return json.loads(r.read())["hourly"]
+        except Exception as exc:
+            wait = 5 * (attempt + 1)
+            print(f"  retry {attempt + 1} after {wait}s ({exc})", file=sys.stderr)
+            time.sleep(wait)
+    raise RuntimeError(f"failed to fetch {lat},{lon}")
+
+
+def main():
+    grid = json.load(open(sys.argv[1] if len(sys.argv) > 1 else "/tmp/grid_scot.json"))
+    limit = int(sys.argv[2]) if len(sys.argv) > 2 else len(grid)
+    out = []
+    for n, site in enumerate(grid[:limit]):
+        bm = score_point(site["lat"], site["lon"], fetch(site["lat"], site["lon"]))
+        for month, (cnt, sq, sd, sc) in bm.items():
+            out.append(
+                {
+                    "site_id": site["id"],
+                    "month": month,
+                    "window_count": cnt,
+                    "sum_q": round(sq, 3),
+                    "sum_darkness": round(sd, 3),
+                    "sum_clarity": round(sc, 3),
+                }
+            )
+        if n % 20 == 0:
+            print(f"  {n + 1}/{limit} points", file=sys.stderr)
+        time.sleep(1.0)  # be polite to Open-Meteo
+    json.dump(out, open("/tmp/climatology.json", "w"))
+    print(f"{limit} points -> {len(out)} (site,month) rows -> /tmp/climatology.json")
+
+
+if __name__ == "__main__":
+    main()

--- a/projects/monolith/stars/models.py
+++ b/projects/monolith/stars/models.py
@@ -68,3 +68,27 @@ class SiteMonthStat(
     sum_q: float = Field(default=0.0)
     sum_darkness: float = Field(default=0.0)
     sum_clarity: float = Field(default=0.0)
+
+
+class SiteMonthClimatology(
+    SQLModel, table=True
+):  # nosemgrep: sqlmodel-datetime-without-factory
+    """Per-site, per-month-of-year ERA5 reanalysis backfill (ADR 009).
+
+    A long-run seasonal baseline computed offline from the ERA5 reanalysis and
+    ingested by the stars.load_climatology job from climatology.json on SeaweedFS.
+    Same sufficient stats as ``SiteMonthStat`` (window_count + the sum_q /
+    sum_darkness / sum_clarity sums) so /api/stars/history can compose the two by
+    per-field addition: the climatology pre-fills the heatmap before the live
+    accumulator has banked enough elapsed hours to be meaningful.
+    """
+
+    __tablename__ = "site_month_climatology"
+    __table_args__ = {"schema": "stars", "extend_existing": True}
+
+    site_id: str = Field(primary_key=True)
+    month: int = Field(primary_key=True)
+    window_count: int = Field(default=0)
+    sum_q: float = Field(default=0.0)
+    sum_darkness: float = Field(default=0.0)
+    sum_clarity: float = Field(default=0.0)

--- a/projects/monolith/stars/models_test.py
+++ b/projects/monolith/stars/models_test.py
@@ -9,7 +9,7 @@ import pytest
 from sqlmodel import Session, SQLModel, create_engine, select
 from sqlmodel.pool import StaticPool
 
-from stars.models import Site, SiteHour, SiteMonthStat
+from stars.models import Site, SiteHour, SiteMonthClimatology, SiteMonthStat
 
 
 @pytest.fixture(name="session")
@@ -179,6 +179,40 @@ def test_site_month_stat_composite_pk_same_site_different_months(session):
         select(SiteMonthStat).where(SiteMonthStat.site_id == "iona")
     ).all()
     assert {r.month for r in rows} == {1, 2}
+
+
+def test_site_month_climatology_roundtrip(session):
+    row = SiteMonthClimatology(
+        site_id="scotland-0001",
+        month=3,
+        window_count=300,
+        sum_q=18180.0,
+        sum_darkness=210.5,
+        sum_clarity=250.1,
+    )
+    session.add(row)
+    session.commit()
+
+    loaded = session.get(SiteMonthClimatology, ("scotland-0001", 3))
+    assert loaded is not None
+    assert loaded.window_count == 300
+    assert loaded.sum_q == 18180.0
+    assert loaded.sum_darkness == 210.5
+    assert loaded.sum_clarity == 250.1
+
+
+def test_site_month_climatology_defaults(session):
+    # window_count and the sums carry their column defaults.
+    row = SiteMonthClimatology(site_id="scotland-0002", month=7)
+    session.add(row)
+    session.commit()
+
+    loaded = session.get(SiteMonthClimatology, ("scotland-0002", 7))
+    assert loaded is not None
+    assert loaded.window_count == 0
+    assert loaded.sum_q == 0.0
+    assert loaded.sum_darkness == 0.0
+    assert loaded.sum_clarity == 0.0
 
 
 def test_composite_primary_key_same_site_different_hours(session):

--- a/projects/monolith/stars/router.py
+++ b/projects/monolith/stars/router.py
@@ -35,7 +35,7 @@ from sqlmodel import Session, select
 
 from app.db import get_session
 from shared.forecast_freshness import top_of_hour
-from stars.models import Site, SiteHour, SiteMonthStat
+from stars.models import Site, SiteHour, SiteMonthClimatology, SiteMonthStat
 
 logger = logging.getLogger("stars")
 
@@ -213,33 +213,58 @@ def get_history(
         default=0, ge=0, le=12, description="Month-of-year 1-12; 0 = current UTC month"
     ),
 ):
-    """Per-site accumulated realized quality for a calendar month. SSR-only.
+    """Per-site combined realized quality for a calendar month. SSR-only.
 
-    The historical heatmap layer (ADR 008): for the selected month-of-year, each
-    site with banked stats reports its quality-weighted frequency ``sum_q`` (the
-    headline heat metric) plus the component decomposition (average darkness and
-    clarity over ``window_count`` hours). ``month`` defaults to the current UTC
-    month. Sites with no banked hours for the month are omitted (the layer is
-    sparse until it fills). Ordered by ``sum_q`` descending. CDN-cached with the
-    same headers as ``/sites``; conditional GETs short-circuit with a 304.
+    The historical heatmap layer (ADR 008 + 009): for the selected month-of-year,
+    each site's heat is the sum of the live accumulator (stars.site_month_stats,
+    banked by the hourly prune as forecast hours elapse) and the ERA5 climatology
+    backfill (stars.site_month_climatology, a long-run seasonal baseline). The two
+    tables carry identical sufficient stats, so they compose by per-field addition:
+    ``window_count``, ``sum_q``, ``sum_darkness`` and ``sum_clarity`` add, and the
+    averages are the combined component sums over the combined ``window_count``.
+
+    A site is included if it appears in EITHER table (full-outer-join by site_id,
+    done in Python). ``sum_q`` is the headline heat metric; ``avg_darkness`` /
+    ``avg_clarity`` give the decomposition. ``month`` defaults to the current UTC
+    month. Sites with no metadata (dropped from the grid) or a zero combined count
+    are omitted. Ordered by combined ``sum_q`` descending. CDN-cached with the same
+    headers as ``/sites``; conditional GETs short-circuit with a 304.
     """
     selected = month or datetime.now(timezone.utc).month
 
     by_id = {site.id: site for site in session.exec(select(Site)).all()}
-    stats = session.exec(
+    live = session.exec(
         select(SiteMonthStat).where(SiteMonthStat.month == selected)
     ).all()
+    climo = session.exec(
+        select(SiteMonthClimatology).where(SiteMonthClimatology.month == selected)
+    ).all()
+
+    # Full-outer-join the two accumulators by site_id, summing the sufficient
+    # stats per field. A site present in only one table contributes that table's
+    # values (the other side defaults to zero).
+    combined: dict[str, dict[str, float]] = {}
+    for row in (*live, *climo):
+        agg = combined.setdefault(
+            row.site_id,
+            {"window_count": 0, "sum_q": 0.0, "sum_darkness": 0.0, "sum_clarity": 0.0},
+        )
+        agg["window_count"] += row.window_count
+        agg["sum_q"] += row.sum_q
+        agg["sum_darkness"] += row.sum_darkness
+        agg["sum_clarity"] += row.sum_clarity
 
     sites = []
-    for stat in stats:
-        meta = by_id.get(stat.site_id)
+    for site_id, agg in combined.items():
+        meta = by_id.get(site_id)
         if meta is None:
-            # site_month_stats orphans (a site dropped from the grid) are kept
-            # as historical record but have no metadata to render; skip them.
-            logger.debug("stars.history: skipping unknown site_id %s", stat.site_id)
+            # Orphans (a site dropped from the grid) are kept in both tables as
+            # historical record but have no metadata to render; skip them.
+            logger.debug("stars.history: skipping unknown site_id %s", site_id)
             continue
-        if stat.window_count <= 0:
-            # Guard against a zero-count row producing a divide-by-zero average.
+        count = agg["window_count"]
+        if count <= 0:
+            # Guard against a zero combined count producing a divide-by-zero average.
             continue
         sites.append(
             {
@@ -247,19 +272,21 @@ def get_history(
                 "name": meta.name,
                 "lat": meta.lat,
                 "lon": meta.lon,
-                "sum_q": stat.sum_q,
-                "window_count": stat.window_count,
-                "avg_darkness": stat.sum_darkness / stat.window_count,
-                "avg_clarity": stat.sum_clarity / stat.window_count,
+                "sum_q": agg["sum_q"],
+                "window_count": count,
+                "avg_darkness": agg["sum_darkness"] / count,
+                "avg_clarity": agg["sum_clarity"] / count,
             }
         )
 
     sites.sort(key=lambda s: s["sum_q"], reverse=True)
 
-    # The ETag folds in the selected month, the site count, and the current max
-    # sum_q: as the prune banks more hours the max grows and the CDN turns over.
+    # The ETag folds in the selected month, the site count, the max combined
+    # sum_q and the total combined window_count: it turns over when EITHER the
+    # live prune banks more hours or the climatology backfill is reloaded.
     max_sum_q = max((s["sum_q"] for s in sites), default=0.0)
-    etag = f'"v1-{selected}-{len(sites)}-{max_sum_q}"'
+    total_count = sum(s["window_count"] for s in sites)
+    etag = f'"v2-{selected}-{len(sites)}-{max_sum_q}-{total_count}"'
     headers = {"Cache-Control": _SITES_CACHE_CONTROL, "ETag": etag}
 
     if request.headers.get("if-none-match") == etag:

--- a/projects/monolith/stars/router_test.py
+++ b/projects/monolith/stars/router_test.py
@@ -22,7 +22,7 @@ from sqlmodel.pool import StaticPool
 
 from app.db import get_session
 from shared.forecast_freshness import top_of_hour
-from stars.models import Site, SiteHour, SiteMonthStat
+from stars.models import Site, SiteHour, SiteMonthClimatology, SiteMonthStat
 from stars.router import _SITES_CACHE_CONTROL, router
 
 CUTOFF = top_of_hour(datetime.now(timezone.utc))
@@ -281,14 +281,39 @@ class TestHistory:
             )
         )
 
+    def _seed_climo(
+        self,
+        session,
+        site_id,
+        month,
+        window_count,
+        sum_q,
+        sum_darkness,
+        sum_clarity,
+    ):
+        session.add(
+            SiteMonthClimatology(
+                site_id=site_id,
+                month=month,
+                window_count=window_count,
+                sum_q=sum_q,
+                sum_darkness=sum_darkness,
+                sum_clarity=sum_clarity,
+            )
+        )
+
     def test_month_filter_ordering_and_derived_averages(self, client, session):
         _seed_site(session, "galloway-forest")
         _seed_site(session, "tomintoul")
-        # December stats: galloway leads on sum_q.
+        # December: live accumulator plus ERA5 climatology backfill combine per
+        # field. galloway leads on combined sum_q.
         self._seed_stat(session, "galloway-forest", 12, 40, 3200.0, 36.0, 30.0)
+        self._seed_climo(session, "galloway-forest", 12, 10, 800.0, 9.0, 6.0)
         self._seed_stat(session, "tomintoul", 12, 20, 1000.0, 14.0, 8.0)
-        # A different month must be excluded by the filter.
+        self._seed_climo(session, "tomintoul", 12, 5, 250.0, 3.0, 2.0)
+        # A different month must be excluded by the filter (both tables).
         self._seed_stat(session, "tomintoul", 6, 5, 5000.0, 4.0, 4.0)
+        self._seed_climo(session, "tomintoul", 6, 5, 5000.0, 4.0, 4.0)
         session.commit()
 
         r = client.get("/api/stars/history", params={"month": 12})
@@ -297,17 +322,38 @@ class TestHistory:
         assert body["month"] == 12
         assert body["count"] == 2
         ids = [s["id"] for s in body["sites"]]
-        # Ordered by sum_q descending.
+        # Ordered by combined sum_q descending.
         assert ids == ["galloway-forest", "tomintoul"]
         gf = body["sites"][0]
-        assert gf["sum_q"] == 3200.0
-        assert gf["window_count"] == 40
-        # Averages are the component sums over window_count.
-        assert gf["avg_darkness"] == pytest.approx(36.0 / 40)
-        assert gf["avg_clarity"] == pytest.approx(30.0 / 40)
+        # Combined sums: live + climatology.
+        assert gf["sum_q"] == pytest.approx(3200.0 + 800.0)
+        assert gf["window_count"] == 40 + 10
+        # Averages are the combined component sums over the combined window_count.
+        assert gf["avg_darkness"] == pytest.approx((36.0 + 9.0) / (40 + 10))
+        assert gf["avg_clarity"] == pytest.approx((30.0 + 6.0) / (40 + 10))
         # Metadata joined from stars.sites.
         assert gf["name"] == "Galloway Forest Park"
         assert gf["lat"] == 55.083
+
+    def test_site_present_only_in_climatology_is_included(self, client, session):
+        # A site with no live stats but an ERA5 backfill row still appears, with
+        # the climatology values standing in for the full combined stats.
+        _seed_site(session, "galloway-forest")
+        _seed_site(session, "tomintoul")
+        self._seed_stat(session, "galloway-forest", 4, 20, 1000.0, 18.0, 14.0)
+        self._seed_climo(session, "tomintoul", 4, 8, 400.0, 6.0, 5.0)
+        session.commit()
+
+        r = client.get("/api/stars/history", params={"month": 4})
+        assert r.status_code == 200
+        body = r.json()
+        assert {s["id"] for s in body["sites"]} == {"galloway-forest", "tomintoul"}
+        by_id = {s["id"]: s for s in body["sites"]}
+        tom = by_id["tomintoul"]
+        assert tom["sum_q"] == pytest.approx(400.0)
+        assert tom["window_count"] == 8
+        assert tom["avg_darkness"] == pytest.approx(6.0 / 8)
+        assert tom["avg_clarity"] == pytest.approx(5.0 / 8)
 
     def test_default_month_is_current_utc(self, client, session):
         current = datetime.now(timezone.utc).month


### PR DESCRIPTION
Ingestion + serving path for ADR 009 (stars historical climatology backfill).

- **`stars.site_month_climatology`** table + `SiteMonthClimatology` model (same sufficient-stats shape as the live `site_month_stats`).
- **`stars.load_climatology`** job (daily): boto3-fetches `climatology.json` from SeaweedFS and wholesale-replaces the table (mirrors `load_grid`).
- **`/api/stars/history`** now merges the live accumulator (`site_month_stats`) with the backfill (`site_month_climatology`) per site (full-outer by site_id, summed), so the historical heatmap shows climatology + recent realized quality combined.
- Offline **`grid_gen/backfill_climatology.py`** committed (excluded from the runtime image): fetches ~5yr hourly ERA5 from Open-Meteo, scores each dark hour with the same `Q=D×C×W` (pure-Python NOAA sun elevation + the scoring formulas), aggregates by month-of-year → `climatology.json`.

The `climatology.json` itself is uploaded to SeaweedFS out-of-band (a 306-point ERA5 fetch is running); the loader ingests it on its next run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)