### PR TITLE
feat(buck2): bazel parity II - push rules (oci_push/helm_push) + stamping

### DIFF
--- a/tools/buck2/examples/rust-service/BUCK
+++ b/tools/buck2/examples/rust-service/BUCK
@@ -46,4 +46,3 @@ helm_chart(
     # Create :chart.push (helm push to the OCI charts repo).
     publish = True,
 )
-

--- a/tools/buck2/examples/rust-service/BUCK
+++ b/tools/buck2/examples/rust-service/BUCK
@@ -43,4 +43,7 @@ helm_chart(
     deps = [":image"],
     # Digest-pin the deployed image's repository@digest into values.yaml.
     images = {"image": ":image.info"},
+    # Create :chart.push (helm push to the OCI charts repo).
+    publish = True,
 )
+

--- a/tools/buck2/helm/defs.bzl
+++ b/tools/buck2/helm/defs.bzl
@@ -46,7 +46,36 @@ helm_images_values = rule(
     },
 )
 
-def helm_chart(name, srcs, deps = [], images = None, lint = True, visibility = ["PUBLIC"], **kwargs):
+def _helm_push_impl(ctx: AnalysisContext) -> list[Provider]:
+    chart = ctx.attrs.chart[DefaultInfo].default_outputs[0]
+    sh = ctx.actions.write(
+        "helm_push.sh",
+        "\n".join([
+            "#!/usr/bin/env bash",
+            "set -euo pipefail",
+            "HELM=\"$1\"; CHART=\"$2\"; REPO=\"$3\"",
+            "echo \"pushing $CHART -> $REPO\" >&2",
+            "\"$HELM\" push \"$CHART\" \"$REPO\"",
+        ]),
+        is_executable = True,
+    )
+    return [
+        DefaultInfo(),
+        RunInfo(args = cmd_args([sh, ctx.attrs._helm[RunInfo], chart, ctx.attrs.repository])),
+    ]
+
+# Runnable: `buck2 run <chart>.push` pushes the packaged chart .tgz to an OCI
+# registry (helm push). Mirrors bazel/helm's helm_push.
+helm_push = rule(
+    impl = _helm_push_impl,
+    attrs = {
+        "chart": attrs.dep(),
+        "repository": attrs.string(),
+        "_helm": attrs.exec_dep(default = _HELM, providers = [RunInfo]),
+    },
+)
+
+def helm_chart(name, srcs, deps = [], images = None, lint = True, publish = False, repository = "oci://ghcr.io/jomcgi/homelab/charts", visibility = ["PUBLIC"], **kwargs):
     """Package a Helm chart into a `.tgz`.
 
     Args:
@@ -55,6 +84,8 @@ def helm_chart(name, srcs, deps = [], images = None, lint = True, visibility = [
       deps: targets the chart depends on (e.g. an oci_image) — built, not packaged.
       images: {yaml-path: image `.info` label} — digest-pinned into values.yaml.
       lint: also create a `<name>.lint` target running `helm lint`.
+      publish: also create a `<name>.push` runnable (`helm push` to `repository`).
+      repository: OCI repository to publish the chart to.
       visibility: target visibility.
     """
     overlay_srcs = []
@@ -92,6 +123,14 @@ def helm_chart(name, srcs, deps = [], images = None, lint = True, visibility = [
         visibility = visibility,
         **kwargs
     )
+
+    if publish:
+        helm_push(
+            name = name + ".push",
+            chart = ":" + name,
+            repository = repository,
+            visibility = visibility,
+        )
 
     if lint:
         native.genrule(

--- a/tools/buck2/image_tags.sh
+++ b/tools/buck2/image_tags.sh
@@ -18,9 +18,9 @@ branch="${GITHUB_REF_NAME:-${GIT_BRANCH:-${BUILDKITE_BRANCH:-$(git rev-parse --a
 branch_tag="$(echo "${branch}" | tr '/' '-' | tr '[:upper:]' '[:lower:]')"
 
 if [ "${branch}" = "main" ]; then
-  image_tag="${base_tag}"
+	image_tag="${base_tag}"
 else
-  image_tag="dev-${base_tag}"
+	image_tag="dev-${base_tag}"
 fi
 
 echo "${image_tag} ${branch_tag}"

--- a/tools/buck2/image_tags.sh
+++ b/tools/buck2/image_tags.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Emit the image tags to push, space-separated, for the runtime-arg push flow:
+#
+#   buck2 run //path:image.push -- $(tools/buck2/image_tags.sh)
+#
+# This is the Buck2 analogue of bazel/tools/workspace_status.sh's STABLE_IMAGE_TAG
+# / STABLE_BRANCH_TAG (buck2 has no --stamp): the timestamped+sha tag plus the
+# sanitized branch. On non-main branches the timestamp tag is dev-prefixed so
+# ArgoCD Image Updater ignores it (matching the bazel side). Chart values pin by
+# digest (deterministic); these tags are human/registry-facing aliases.
+set -o errexit -o nounset -o pipefail
+
+git_short_sha="$(git rev-parse --short HEAD)"
+base_tag="$(date -u +"%Y.%m.%d.%H.%M.%S")-${git_short_sha}"
+
+# Branch from CI env (GitHub/BuildBuddy/etc.) or git, sanitized for tags.
+branch="${GITHUB_REF_NAME:-${GIT_BRANCH:-${BUILDKITE_BRANCH:-$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)}}}"
+branch_tag="$(echo "${branch}" | tr '/' '-' | tr '[:upper:]' '[:lower:]')"
+
+if [ "${branch}" = "main" ]; then
+  image_tag="${base_tag}"
+else
+  image_tag="dev-${base_tag}"
+fi
+
+echo "${image_tag} ${branch_tag}"

--- a/tools/buck2/oci/defs.bzl
+++ b/tools/buck2/oci/defs.bzl
@@ -12,6 +12,37 @@ base config so no separate mutate step is needed for the common case.
 load(":providers.bzl", "OciImageInfo")
 
 _REGCTL = "//tools/buck2/bin:regctl"
+_CRANE = "//tools/buck2/bin:crane"
+
+def _oci_push_impl(ctx: AnalysisContext) -> list[Provider]:
+    image = ctx.attrs.image[DefaultInfo].default_outputs[0]
+    sh = ctx.actions.write(
+        "oci_push.sh",
+        "\n".join([
+            "#!/usr/bin/env bash",
+            "set -euo pipefail",
+            "CRANE=\"$1\"; IMAGE=\"$2\"; REPO=\"$3\"; shift 3",
+            "if [ \"$#\" -eq 0 ]; then echo \"usage: buck2 run <target> -- <tag>...\" >&2; exit 2; fi",
+            "for t in \"$@\"; do echo \"pushing $REPO:$t\" >&2; \"$CRANE\" push \"$IMAGE\" \"$REPO:$t\"; done",
+        ]),
+        is_executable = True,
+    )
+    return [
+        DefaultInfo(),
+        RunInfo(args = cmd_args([sh, ctx.attrs._crane[RunInfo], image, ctx.attrs.repository])),
+    ]
+
+# Runnable: `buck2 run <image>.push -- <tag>...` pushes the image tar to its
+# repository at each runtime-supplied tag (via crane). Tags are runtime args (the
+# Buck2 runtime-arg analogue of bazel's stamped remote_tags); see image_tags.sh.
+oci_push = rule(
+    impl = _oci_push_impl,
+    attrs = {
+        "image": attrs.dep(),
+        "repository": attrs.string(),
+        "_crane": attrs.exec_dep(default = _CRANE, providers = [RunInfo]),
+    },
+)
 
 def _oci_image_info_impl(ctx: AnalysisContext) -> list[Provider]:
     image = ctx.attrs.image[DefaultInfo].default_outputs[0]
@@ -76,10 +107,16 @@ def oci_image(name, base, layers = [], platform = "linux/amd64", repository = No
     )
 
     # Expose OciImageInfo (repository + digest) for helm digest-pinning, like
-    # bazel's go_image/apko_image `.info` sub-target.
+    # bazel's go_image/apko_image `.info` sub-target, and a `.push` runnable.
     if repository:
         oci_image_info(
             name = name + ".info",
+            image = ":" + name,
+            repository = repository,
+            visibility = visibility,
+        )
+        oci_push(
+            name = name + ".push",
             image = ":" + name,
             repository = repository,
             visibility = visibility,


### PR DESCRIPTION
Second parity slice: image/chart **publishing**, matching `bazel/tools/oci` (`*.push`) and `bazel/helm` (`helm_push`, `helm_chart(publish=...)`).

## What
- **`oci_push`** - runnable that `crane push`es an image tar to its repository at **runtime-arg tags**; `oci_image` gains a `.push` sub-target.
- **`helm_push`** - runnable `helm push` of a packaged chart to an OCI repo; `helm_chart` gains `publish=` + `repository=` (default `oci://ghcr.io/jomcgi/homelab/charts`) creating `.push`.
- **`image_tags.sh`** - emits the `YYYY.MM.DD.HH.MM.SS-<sha>` + branch tags for the runtime-arg push (buck2 has no `--stamp`); the analogue of `bazel/tools/workspace_status.sh`. Usage: `buck2 run //path:image.push -- $(tools/buck2/image_tags.sh)`. Chart values stay digest-pinned (deterministic); these tags are registry-facing aliases.

## Verified
- `image_tags.sh` emits correct tags (dev-prefixed off main, branch sanitized).
- Push rules pass analysis; CI builds the runnables (actual push is a `buck2 run` release step, not a build check).

## Follow-ups
- `argocd_app` (render/diff/semgrep), `oci_image_index` multi-arch, semgrep policy on rendered manifests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)