### PR TITLE
feat(buck2): bazel parity III - argocd_app

### DIFF
--- a/tools/buck2/examples/rust-service/BUCK
+++ b/tools/buck2/examples/rust-service/BUCK
@@ -1,5 +1,5 @@
 load("//tools/buck2/apko:defs.bzl", "apko_image")
-load("//tools/buck2/helm:defs.bzl", "helm_chart")
+load("//tools/buck2/helm:defs.bzl", "argocd_app", "helm_chart")
 load("//tools/buck2/oci:defs.bzl", "oci_image", "tar_layer")
 
 # Basic Rust service built with buck2's `rust_binary` (the same primitive loom
@@ -45,4 +45,14 @@ helm_chart(
     images = {"image": ":image.info"},
     # Create :chart.push (helm push to the OCI charts repo).
     publish = True,
+)
+
+# ArgoCD Application that deploys the published chart.
+argocd_app(
+    name = "app",
+    app_name = "rust-service",
+    release_name = "rust-service",
+    chart = "rust-service",
+    target_revision = "0.1.0",
+    namespace = "rust-service",
 )

--- a/tools/buck2/helm/defs.bzl
+++ b/tools/buck2/helm/defs.bzl
@@ -75,6 +75,57 @@ helm_push = rule(
     },
 )
 
+_ARGOCD_APP_TEMPLATE = """apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: {name}
+  namespace: argocd
+spec:
+  source:
+    repoURL: {repo}
+    chart: {chart}
+    targetRevision: {rev}
+    helm:
+      releaseName: {release}
+  destination:
+    server: {server}
+    namespace: {ns}
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+"""
+
+def _argocd_app_impl(ctx: AnalysisContext) -> list[Provider]:
+    content = _ARGOCD_APP_TEMPLATE.format(
+        name = ctx.attrs.app_name or ctx.label.name,
+        repo = ctx.attrs.chart_repo,
+        chart = ctx.attrs.chart,
+        rev = ctx.attrs.target_revision,
+        release = ctx.attrs.release_name or ctx.attrs.app_name or ctx.label.name,
+        server = ctx.attrs.dest_server,
+        ns = ctx.attrs.namespace,
+    )
+    out = ctx.actions.write("application.yaml", content)
+    return [DefaultInfo(default_output = out)]
+
+# Generates an ArgoCD Application that deploys the chart published to an OCI repo
+# (chart + targetRevision), mirroring bazel/helm's argocd_app / deploy manifests.
+argocd_app = rule(
+    impl = _argocd_app_impl,
+    attrs = {
+        "chart": attrs.string(),  # chart name in the OCI repo
+        "target_revision": attrs.string(),  # chart version
+        "namespace": attrs.string(default = "default"),
+        "release_name": attrs.string(default = ""),
+        "app_name": attrs.string(default = ""),  # Application metadata.name (defaults to target name)
+        "chart_repo": attrs.string(default = "ghcr.io/jomcgi/homelab/charts"),
+        "dest_server": attrs.string(default = "https://kubernetes.default.svc"),
+    },
+)
+
 def helm_chart(name, srcs, deps = [], images = None, lint = True, publish = False, repository = "oci://ghcr.io/jomcgi/homelab/charts", visibility = ["PUBLIC"], **kwargs):
     """Package a Helm chart into a `.tgz`.
 


### PR DESCRIPTION
Third parity slice: `argocd_app`, the analogue of `bazel/helm`'s argocd_app / deploy manifests.

## What
- **`argocd_app`** generates an ArgoCD `Application` that deploys the published OCI chart (chart + targetRevision + helm releaseName + destination + syncPolicy with automated prune/selfHeal + CreateNamespace). This is the deploy-wiring piece (what ArgoCD watches).
- Example `:app` for the rust-service chart.

Chart render + K8s schema validation is already covered by `helm_chart` `.validate` (helm template + kubeconform) from parity I.

## Verified
- `:app` builds locally and emits a valid `kind: Application` YAML.

## Remaining parity (follow-ups)
- multi-arch `oci_image_index` (needs aarch64 Rust cross-link); semgrep policy on rendered manifests; live `argocd diff`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)