### PR TITLE
feat(hikes): neo-brutalist Near dropdown

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.131.2
+version: 0.132.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.131.2
+      targetRevision: 0.132.0
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/lib/public/components/BrutalistSelect.svelte
+++ b/projects/monolith/frontend/src/lib/public/components/BrutalistSelect.svelte
@@ -1,0 +1,331 @@
+<script>
+  // A custom select styled to the MotherDuck-brutalist house language: a native
+  // <select> can render its closed box with CSS but the OPEN option list is OS
+  // chrome (rounded, gradient, system font) with no styling hooks, so we rebuild
+  // the control. That means re-implementing what the native element gives for
+  // free: the WAI-ARIA select-only combobox pattern (focus stays on the trigger,
+  // a roving aria-activedescendant highlights options), full keyboard nav,
+  // type-ahead, and click-outside. Anything less would be less usable than the
+  // <select> it replaces.
+  //
+  // Props:
+  //   options  -> [{ value, label }]
+  //   value    -> bindable selected value (matches an option.value)
+  //   onchange -> called after the value changes (parity with <select onchange>)
+  //   label    -> accessible name for the listbox
+  //   id       -> base id for stable option ids (aria-activedescendant)
+  let {
+    options = [],
+    value = $bindable(""),
+    onchange = () => {},
+    label = "Select",
+    id = "brutalist-select",
+  } = $props();
+
+  let open = $state(false);
+  // Index of the keyboard-highlighted option while open (the roving focus). -1
+  // means "none yet"; opening seeds it to the current selection.
+  let activeIndex = $state(-1);
+
+  let rootEl;
+  let listEl;
+
+  let selectedIndex = $derived(options.findIndex((o) => o.value === value));
+  let selectedLabel = $derived(
+    selectedIndex >= 0 ? options[selectedIndex].label : "",
+  );
+
+  const optionId = (i) => `${id}-opt-${i}`;
+
+  function openList() {
+    open = true;
+    // Seed the highlight on the current selection so arrow keys move from there.
+    activeIndex = selectedIndex >= 0 ? selectedIndex : 0;
+  }
+
+  function closeList() {
+    open = false;
+    activeIndex = -1;
+  }
+
+  function commit(i) {
+    if (i < 0 || i >= options.length) return;
+    const next = options[i].value;
+    const changed = next !== value;
+    value = next;
+    closeList();
+    // Mirror native <select>: onchange fires only when the value actually moves.
+    if (changed) onchange();
+  }
+
+  // Scroll the highlighted option into view when arrowing through a long list
+  // (the region list overflows its max-height).
+  $effect(() => {
+    if (!open || activeIndex < 0 || !listEl) return;
+    const el = listEl.querySelector(`#${CSS.escape(optionId(activeIndex))}`);
+    el?.scrollIntoView({ block: "nearest" });
+  });
+
+  // Type-ahead: native selects let you jump by typing a prefix. Accumulate
+  // keystrokes within a short window and match option labels.
+  let typeBuffer = "";
+  let typeTimer = null;
+  function typeAhead(char) {
+    typeBuffer += char.toLowerCase();
+    clearTimeout(typeTimer);
+    typeTimer = setTimeout(() => (typeBuffer = ""), 600);
+    const from = (open ? activeIndex : selectedIndex) + 1;
+    // Search wrapping from just after the current position so repeated presses
+    // cycle through same-letter matches.
+    for (let k = 0; k < options.length; k++) {
+      const i = (from + k) % options.length;
+      if (options[i].label.toLowerCase().startsWith(typeBuffer)) {
+        if (open) activeIndex = i;
+        else commit(i);
+        return;
+      }
+    }
+  }
+
+  function onTriggerKeydown(e) {
+    switch (e.key) {
+      case "ArrowDown":
+      case "ArrowUp":
+      case "Enter":
+      case " ":
+        e.preventDefault();
+        if (!open) openList();
+        else if (e.key === "Enter" || e.key === " ") commit(activeIndex);
+        else activeIndex = clampMove(e.key === "ArrowDown" ? 1 : -1);
+        break;
+      case "Home":
+        if (open) {
+          e.preventDefault();
+          activeIndex = 0;
+        }
+        break;
+      case "End":
+        if (open) {
+          e.preventDefault();
+          activeIndex = options.length - 1;
+        }
+        break;
+      case "Escape":
+        if (open) {
+          e.preventDefault();
+          closeList();
+        }
+        break;
+      case "Tab":
+        // Let focus leave naturally, but don't strand an open popup behind it.
+        if (open) closeList();
+        break;
+      default:
+        // Single printable char -> type-ahead.
+        if (e.key.length === 1 && !e.metaKey && !e.ctrlKey && !e.altKey) {
+          e.preventDefault();
+          if (!open) openList();
+          typeAhead(e.key);
+        }
+    }
+  }
+
+  function clampMove(delta) {
+    const n = options.length;
+    if (n === 0) return -1;
+    const start = activeIndex < 0 ? selectedIndex : activeIndex;
+    return Math.max(0, Math.min(n - 1, (start < 0 ? 0 : start) + delta));
+  }
+
+  function onWindowPointerDown(e) {
+    if (open && rootEl && !rootEl.contains(e.target)) closeList();
+  }
+</script>
+
+<svelte:window onpointerdown={onWindowPointerDown} />
+
+<div class="bsel" bind:this={rootEl}>
+  <button
+    type="button"
+    class="bsel-trigger"
+    class:open
+    role="combobox"
+    aria-haspopup="listbox"
+    aria-expanded={open}
+    aria-controls={`${id}-listbox`}
+    aria-activedescendant={open && activeIndex >= 0
+      ? optionId(activeIndex)
+      : undefined}
+    aria-label={label}
+    onclick={() => (open ? closeList() : openList())}
+    onkeydown={onTriggerKeydown}
+  >
+    <span class="bsel-value">{selectedLabel}</span>
+    <span class="bsel-caret" aria-hidden="true">{open ? "▴" : "▾"}</span>
+  </button>
+
+  {#if open}
+    <ul
+      class="bsel-list"
+      id={`${id}-listbox`}
+      role="listbox"
+      aria-label={label}
+      bind:this={listEl}
+      tabindex="-1"
+    >
+      {#each options as opt, i (opt.value)}
+        <li
+          id={optionId(i)}
+          class="bsel-option"
+          class:active={i === activeIndex}
+          class:selected={opt.value === value}
+          role="option"
+          aria-selected={opt.value === value}
+          onpointerenter={() => (activeIndex = i)}
+          onpointerdown={(e) => {
+            e.preventDefault();
+            commit(i);
+          }}
+        >
+          {#if opt.value === value}
+            <span class="bsel-tick" aria-hidden="true">▸</span>
+          {:else}
+            <span class="bsel-tick bsel-tick-empty" aria-hidden="true"></span>
+          {/if}
+          <span class="bsel-label">{opt.label}</span>
+        </li>
+      {/each}
+    </ul>
+  {/if}
+</div>
+
+<style>
+  .bsel {
+    position: relative;
+    width: 100%;
+  }
+
+  /* Closed control: same flat sharp box as .field input/select had. */
+  .bsel-trigger {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    width: 100%;
+    font-family: var(--mono);
+    font-size: 13px;
+    text-align: left;
+    padding: 7px 8px;
+    background: var(--cream);
+    border: 2px solid var(--ink);
+    color: var(--ink);
+    cursor: pointer;
+    transition:
+      transform 110ms ease,
+      box-shadow 110ms ease;
+  }
+
+  .bsel-trigger:hover {
+    transform: translate(-2px, -2px);
+    box-shadow: 2px 2px 0 var(--ink);
+  }
+
+  /* Brutalist focus: a hard offset stack, not the OS blue glow. */
+  .bsel-trigger:focus-visible {
+    outline: none;
+    transform: translate(-2px, -2px);
+    box-shadow: 2px 2px 0 var(--ink);
+  }
+
+  /* Open: keep the box "pressed in" (no lift) so it reads as anchored to the
+     list dropping below it. */
+  .bsel-trigger.open {
+    transform: none;
+    box-shadow: none;
+    background: var(--ink);
+    color: var(--paper);
+  }
+
+  .bsel-value {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .bsel-caret {
+    flex: none;
+    font-size: 10px;
+  }
+
+  /* The open list: a stacked brutalist card. 2px ink border + hard offset
+     shadow, no radius, no gradient. Overlaps the trigger's bottom border by
+     2px (margin-top: -2px) so the two borders fuse into one continuous edge. */
+  .bsel-list {
+    position: absolute;
+    top: 100%;
+    left: 0;
+    right: 0;
+    margin: -2px 0 0;
+    padding: 0;
+    list-style: none;
+    z-index: 20;
+    max-height: 280px;
+    overflow-y: auto;
+    background: var(--paper);
+    border: 2px solid var(--ink);
+    box-shadow: 4px 4px 0 var(--ink);
+  }
+
+  .bsel-option {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-family: var(--mono);
+    font-size: 13px;
+    letter-spacing: 0.02em;
+    padding: 7px 9px;
+    color: var(--ink);
+    cursor: pointer;
+    border-bottom: 1px solid var(--cream);
+  }
+
+  .bsel-option:last-child {
+    border-bottom: none;
+  }
+
+  /* Keyboard highlight and pointer hover share the ink-inversion used by
+     .day-chip.active / .more-toggle.on, so highlight reads the same everywhere. */
+  .bsel-option.active {
+    background: var(--ink);
+    color: var(--paper);
+  }
+
+  /* Selected (but not highlighted) option: yellow accent marker bar, the only
+     spot the brand accent appears among these controls. */
+  .bsel-option.selected:not(.active) {
+    background: var(--accent);
+  }
+
+  .bsel-tick {
+    flex: none;
+    width: 0.7em;
+    font-size: 11px;
+    line-height: 1;
+  }
+
+  .bsel-tick-empty {
+    visibility: hidden;
+  }
+
+  .bsel-label {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .bsel-trigger {
+      transition: none;
+    }
+  }
+</style>

--- a/projects/monolith/frontend/src/routes/public/app/hikes/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/hikes/+page.svelte
@@ -2,6 +2,7 @@
   import { onMount } from "svelte";
   import { invalidateAll } from "$app/navigation";
   import HikesMap from "$lib/public/components/hikes/HikesMap.svelte";
+  import BrutalistSelect from "$lib/public/components/BrutalistSelect.svelte";
   import {
     filterWalksByCharacteristics,
     filterWalksByLocation,
@@ -35,6 +36,13 @@
     { key: "torridon", label: "Wester Ross", lat: 57.5841, lon: -5.5325 },
   ];
   const GEO_SENTINEL = "__me__";
+  // Flat option list for the brutalist "Near" dropdown: the two specials first,
+  // then the density-ordered region presets.
+  const NEAR_OPTIONS = [
+    { value: "", label: "Anywhere" },
+    { value: GEO_SENTINEL, label: "My location" },
+    ...HIKE_LOCATIONS.map((l) => ({ value: l.key, label: l.label })),
+  ];
   // Fixed radius for a region preset. The presets already pick a coarse area, so
   // a single generous radius beats a fiddly per-use input (regions span tens of
   // km; this captures the cluster without spilling into the next one).
@@ -253,16 +261,16 @@
         </p>
       </div>
 
-      <label class="field near-field"
-        >Near
-        <select bind:value={nearKey} onchange={onNearChange}>
-          <option value="">Anywhere</option>
-          <option value={GEO_SENTINEL}>My location</option>
-          {#each HIKE_LOCATIONS as loc (loc.key)}
-            <option value={loc.key}>{loc.label}</option>
-          {/each}
-        </select>
-      </label>
+      <div class="field near-field">
+        <span class="field-label" id="near-label">Near</span>
+        <BrutalistSelect
+          id="near"
+          label="Near"
+          options={NEAR_OPTIONS}
+          bind:value={nearKey}
+          onchange={onNearChange}
+        />
+      </div>
       {#if geoError}
         <p class="geo-error" role="alert">{geoError}</p>
       {/if}
@@ -538,8 +546,7 @@
     color: var(--ink-3);
   }
 
-  .field input,
-  .field select {
+  .field input {
     font-family: var(--mono);
     font-size: 13px;
     padding: 7px 8px;


### PR DESCRIPTION
## What

Replaces the native \`<select>\` "NEAR" dropdown on \`/app/hikes\` with a custom **BrutalistSelect** component, so the *open* option list matches the MotherDuck-brutalist house language instead of falling back to OS chrome.

### Why

The native \`<select>\` styled its closed box fine, but the open menu is browser-rendered (rounded panel, soft gradient, system font, macOS checkmark, blue focus glow) with no CSS hooks. The only way to control the open list cross-browser is to rebuild the control.

### Design

- Trigger + absolutely-positioned listbox using existing tokens: 2px ink border, \`--cream\`/\`--paper\`, JetBrains Mono.
- Highlight uses the same ink-inversion as \`.day-chip.active\` / \`.more-toggle.on\`.
- Open panel gets a \`4px 4px 0\` hard offset shadow (stacked-card look), no radius/gradient.
- Selected row carries the \`--accent\` yellow marker bar (first appearance of the brand accent among these controls).
- Brutalist focus: hard offset stack replaces the OS blue glow.

### Accessibility

Reimplements what the native control gave for free, so the custom one is not a downgrade:
- WAI-ARIA select-only combobox: \`role="combobox"\`/\`listbox\`/\`option\`, roving \`aria-activedescendant\` with focus held on the trigger.
- Keyboard: Arrow/Home/End/Enter/Space/Escape, plus type-ahead.
- Click-outside (and Tab) to dismiss.

The page keeps its existing \`nearKey\` binding and \`onNearChange\` geolocation path unchanged; \`onchange\` fires only when the value actually moves, matching native semantics.

### Reusable

Lives at \`src/lib/public/components/BrutalistSelect.svelte\` (\`options\` / bindable \`value\` / \`onchange\`) so it's the house dropdown pattern going forward; this page is currently the only \`<select>\` in the frontend.

## Test

No local svelte test/format loop in this repo (\`.svelte\` is excluded from the prettier pipeline). Verifying via CI on the pushed branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)