### PR TITLE
fix(monolith): expand Postgres PVC 2Gi -> 50Gi to clear disk-full outage

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.132.1
+version: 0.132.2
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.132.1
+      targetRevision: 0.132.2
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/deploy/values.yaml
+++ b/projects/monolith/deploy/values.yaml
@@ -16,7 +16,7 @@ frontend:
 postgres:
   instances: 1
   storage:
-    size: 2Gi
+    size: 50Gi
 
 onepassword:
   enabled: true


### PR DESCRIPTION
## Problem

jomcgi.dev apps are intermittently 503ing. Root cause: the CNPG `monolith-pg` cluster filled its **2Gi** Longhorn PVC and is down.

- Cluster status: `Not enough disk space`
- `monolith-pg-1` log: `Detected low-disk space condition, avoid starting the instance` (CNPG pre-flight WAL check refuses to start Postgres)
- `monolith-pg-1`: CrashLoopBackOff (single-instance cluster, no failover)
- Monolith backend: `psycopg.OperationalError: connection to server ... failed: server closed the connection unexpectedly` on every DB request -> 503s

Likely triggered by the 2026-06-13 ERA5 climatology + stars box-cell heatmap backfill.

## Fix

Raise `postgres.storage.size` 2Gi -> 50Gi in `deploy/values.yaml`. Longhorn has `allowVolumeExpansion=true` and the volume is thin-provisioned (`numberOfReplicas=3`), so CNPG expands the PVC online and Postgres restarts once free space is available. Chart version + targetRevision bumped 0.132.1 -> 0.132.2 per repo convention.

## Verification after merge

1. ArgoCD syncs, CNPG patches the PVC, Longhorn resizes the filesystem online.
2. `kubectl get cluster -n monolith monolith-pg` returns Healthy, `monolith-pg-1` 2/2 Running.
3. jomcgi.dev DB-backed routes return 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)