### PR TITLE
feat(platform): node-local ingress traffic shaper (CAKE) for the AI node

### DIFF
--- a/projects/platform/node-traffic-shaper/README.md
+++ b/projects/platform/node-traffic-shaper/README.md
@@ -1,0 +1,94 @@
+# node-traffic-shaper
+
+Caps **inbound** bandwidth on a node's uplink with [CAKE](https://www.bufferbloat.net/projects/codel/wiki/Cake/)
+so a bulk download cannot starve latency-sensitive control-plane traffic.
+
+## Why this exists
+
+On the AI node, pulling model weights saturates the 1GbE uplink. Two sources:
+
+1. **Container/image-volume pulls** done by `containerd` (the `oci-model-cache`
+   operator delivers weights as OCI image volumes). These land in the **host**
+   network namespace, so they cannot be shaped by per-pod CNI bandwidth
+   annotations or by any in-pod limiter.
+2. The `hf2oci` copy Job's download from HuggingFace.
+
+The only enforcement point that catches **both** (plus any future workload) is
+the physical uplink. `containerd` has no bytes/sec download limit, so shaping has
+to happen at the NIC with `tc`. CAKE's per-flow fairness is the part that matters:
+during a saturating pull, etcd / kubelet / SSH keep their share instead of
+grinding to a halt.
+
+## Why node-local (not a DaemonSet / GitOps)
+
+Only the AI node pulls large images, so cluster-wide fan-out is unnecessary. A
+node-local systemd unit gives reboot persistence without the apko-image + Helm
+chart + ArgoCD machinery a DaemonSet would need. Trade-off: if the node is
+reprovisioned, reinstall the unit (see below). If other nodes start pulling
+weights, promote this to a privileged DaemonSet (the uplink auto-detect,
+`sch_cake`/`ifb` availability, and semgrep exclusions all carry over).
+
+## Files
+
+| File                          | Installed to           | Purpose                                |
+| ----------------------------- | ---------------------- | -------------------------------------- |
+| `node-traffic-shaper.sh`      | `/usr/local/sbin/`     | Idempotent apply (ifb redirect + CAKE) |
+| `node-traffic-shaper-down.sh` | `/usr/local/sbin/`     | Teardown / revert                      |
+| `node-traffic-shaper.service` | `/etc/systemd/system/` | Re-applies on every boot               |
+
+The apply script auto-detects the default-route interface, so it is correct on
+any node regardless of NIC name (`enp1s0` / `enp2s0` / `enp12s0` across this
+cluster). Tune the ceiling with `BANDWIDTH=` (default `940mbit`).
+
+## Install (interactive sudo required)
+
+Stage the three files to the node, then:
+
+```bash
+sudo install -m 0755 /tmp/node-traffic-shaper.sh      /usr/local/sbin/node-traffic-shaper.sh
+sudo install -m 0755 /tmp/node-traffic-shaper-down.sh /usr/local/sbin/node-traffic-shaper-down.sh
+sudo install -m 0644 /tmp/node-traffic-shaper.service /etc/systemd/system/node-traffic-shaper.service
+sudo systemctl daemon-reload
+```
+
+## First apply, safely (dead-man revert)
+
+CAKE applied correctly does not blackhole traffic, but a bad `tc` change can lock
+you out of SSH. Apply under a 120s auto-revert so a mistake self-heals. Run it
+detached so it survives the SSH session dropping:
+
+```bash
+sudo nohup bash -c '
+  /usr/local/sbin/node-traffic-shaper.sh
+  sleep 120
+  [ -f /tmp/keep-shaper ] || /usr/local/sbin/node-traffic-shaper-down.sh
+' &>/tmp/shaper.log &
+```
+
+Confirm SSH still works and shaping is live, then lock it in:
+
+```bash
+tc -s qdisc show dev ifb0          # expect: cake ... bandwidth 940Mbit
+sudo touch /tmp/keep-shaper        # cancels the auto-revert
+sudo systemctl enable --now node-traffic-shaper   # persist across reboots
+```
+
+## Verify under load
+
+While a model pull is running:
+
+```bash
+tc -s qdisc show dev ifb0          # drops/marks accrue on the bulk flow
+```
+
+Control-plane traffic (etcd, kubelet, SSH) should stay responsive.
+
+## Remove
+
+```bash
+sudo systemctl disable --now node-traffic-shaper
+sudo rm -f /etc/systemd/system/node-traffic-shaper.service \
+           /usr/local/sbin/node-traffic-shaper.sh \
+           /usr/local/sbin/node-traffic-shaper-down.sh
+sudo systemctl daemon-reload
+```

--- a/projects/platform/node-traffic-shaper/node-traffic-shaper-down.sh
+++ b/projects/platform/node-traffic-shaper/node-traffic-shaper-down.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Tear down the shaping installed by node-traffic-shaper.sh. Used as the systemd
+# ExecStop and available for manual revert. Best-effort: never fails.
+set -uo pipefail
+
+IFB="ifb0"
+IFACE="$(ip route show default | awk '/default/{print $5; exit}')"
+
+[ -n "${IFACE:-}" ] && tc qdisc del dev "$IFACE" ingress 2>/dev/null || true
+tc qdisc del dev "$IFB" root 2>/dev/null || true
+ip link set dev "$IFB" down 2>/dev/null || true
+
+echo "node-traffic-shaper: removed shaping"

--- a/projects/platform/node-traffic-shaper/node-traffic-shaper.service
+++ b/projects/platform/node-traffic-shaper/node-traffic-shaper.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=Node ingress traffic shaper (CAKE on uplink)
+Documentation=https://github.com/jomcgi/homelab/tree/main/projects/platform/node-traffic-shaper
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+# Inbound ceiling. 940mbit on a 1GbE link keeps the queue inside CAKE (just under
+# line rate) so its per-flow fairness, not the dumb NIC/switch buffer, decides who
+# waits during a saturating pull.
+Environment=BANDWIDTH=940mbit
+ExecStart=/usr/local/sbin/node-traffic-shaper.sh
+ExecStop=/usr/local/sbin/node-traffic-shaper-down.sh
+
+[Install]
+WantedBy=multi-user.target

--- a/projects/platform/node-traffic-shaper/node-traffic-shaper.sh
+++ b/projects/platform/node-traffic-shaper/node-traffic-shaper.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# node-traffic-shaper: cap inbound bandwidth on a node's uplink with CAKE so a
+# bulk download (model-weight image pulls, hf2oci) cannot starve latency-sensitive
+# control-plane traffic (etcd, kubelet, SSH).
+#
+# Ingress cannot be shaped directly, so we redirect the uplink's ingress onto an
+# intermediate functional block (ifb0) and run CAKE on ifb0's egress. CAKE's
+# per-flow fairness is what protects control traffic during a saturating pull.
+#
+# Idempotent: safe to run repeatedly and on every boot. Auto-detects the
+# default-route interface so it works regardless of NIC name.
+set -euo pipefail
+
+BANDWIDTH="${BANDWIDTH:-940mbit}"
+IFB="ifb0"
+
+IFACE="$(ip route show default | awk '/default/{print $5; exit}')"
+if [ -z "${IFACE:-}" ]; then
+	echo "node-traffic-shaper: no default-route interface found" >&2
+	exit 1
+fi
+
+# Load modules (autoload via the ip/tc calls below covers the no-op case).
+modprobe ifb numifbs=1 2>/dev/null || true
+modprobe sch_cake 2>/dev/null || true
+
+# Intermediate functional block device, brought up once.
+if ! ip link show "$IFB" >/dev/null 2>&1; then
+	ip link add "$IFB" type ifb
+fi
+ip link set dev "$IFB" up
+
+# Redirect all uplink ingress onto ifb0. Clean del+add so reconciles never
+# accumulate duplicate redirect filters.
+tc qdisc del dev "$IFACE" ingress 2>/dev/null || true
+tc qdisc add dev "$IFACE" handle ffff: ingress
+tc filter add dev "$IFACE" parent ffff: protocol all u32 \
+	match u32 0 0 action mirred egress redirect dev "$IFB"
+
+# The actual shaper: CAKE on the redirected ingress, in ingress-accounting mode.
+tc qdisc replace dev "$IFB" root cake bandwidth "$BANDWIDTH" ingress
+
+echo "node-traffic-shaper: shaping ${IFACE} ingress -> ${IFB} @ ${BANDWIDTH}"


### PR DESCRIPTION
## What

Adds a node-local ingress traffic shaper for the AI node (node-4): a small `tc`/CAKE
apply script, a teardown script, a systemd unit (reboot persistence), and a runbook.

## Why

Pulling model weights saturates node-4's 1GbE uplink and starves control-plane
traffic (etcd, kubelet, SSH). Two sources, both unshapeable from above the host:

1. **containerd image-volume pulls** (the `oci-model-cache` operator delivers
   weights as OCI image volumes). These land in the host network namespace, so
   per-pod CNI bandwidth annotations and any in-pod limiter cannot see them.
2. The `hf2oci` copy Job's HuggingFace download.

`containerd` has no bytes/sec download limit, so the only enforcement point that
catches both (plus any future workload) is the physical uplink. CAKE's per-flow
fairness is what keeps control traffic alive during a saturating pull, not just
the ceiling.

## Why node-local, not a DaemonSet

Only node-4 pulls large images, so cluster-wide fan-out is unnecessary. A systemd
unit gives reboot persistence without the apko-image + Helm chart + ArgoCD wiring
a privileged DaemonSet needs. If other nodes start pulling weights, promote to a
DaemonSet (NIC auto-detect, `sch_cake`/`ifb` availability, and the semgrep
exclusion set all carry over).

## Deploy

Not wired into ArgoCD (no `deploy/kustomization.yaml`, so the home-cluster root
does not pick it up). Install is manual per the README runbook: stage the files,
apply under a 120s dead-man revert, verify, then `systemctl enable --now`.

Default ceiling: `BANDWIDTH=940mbit` (just under 1GbE line rate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)