### PR TITLE
feat(monolith): store chat attachment bytes in SeaweedFS, not Postgres

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.133.0
+version: 0.133.1
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.133.1
+version: 0.133.2
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/migrations/20260614120000_chat_blobs_data_nullable.sql
+++ b/projects/monolith/chart/migrations/20260614120000_chat_blobs_data_nullable.sql
@@ -1,0 +1,6 @@
+-- Make chat.blobs.data nullable. Raw attachment bytes now live in SeaweedFS
+-- object storage (s3://<CHAT_BLOB_S3_BUCKET>/blobs/<sha256>), written by
+-- chat.store._blob_s3_put. New blobs store NULL here. Existing rows keep their
+-- bytes until a manual out-of-band export to SeaweedFS, after which a follow-up
+-- migration drops the column entirely.
+ALTER TABLE chat.blobs ALTER COLUMN data DROP NOT NULL;

--- a/projects/monolith/chart/migrations/atlas.sum
+++ b/projects/monolith/chart/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:erYbK5suS31+LqrRO/Z6AdoicxphNMl/WW79GY4Wyzg=
+h1:g93V7UYRgEgXV96UweIWhTTSNVuAeKDbHugie6uJO1A=
 20260330000000_initial_schema.sql h1:J2futpSW0nJAIRR7nR7ssT7LwXIYrvRI+PkHb5Y4tLI=
 20260403000000_chat_schema.sql h1:pERUFC0vzM95etRuzp43XzkCV7lBCzrrtY5Mk7aF3CA=
 20260404000000_chat_attachments.sql h1:tv+Fdbr1rQC5nzUxfaBC0O6fu2OMGgLWf+YNg1WQXi4=
@@ -38,3 +38,4 @@ h1:erYbK5suS31+LqrRO/Z6AdoicxphNMl/WW79GY4Wyzg=
 20260613000060_stars_climatology.sql h1:iHhd80/ZuZYw+77h9wJxQR2wvUny+MUqkLv6Tsis/qA=
 20260614000010_stars_v2_site_hours.sql h1:ZoC3kzKNSgyDoEDLO4M9rk4CL2TekRXzbbmSoK3QNBc=
 20260614000020_stars_v2_accumulators.sql h1:Al0nCReLo8Y5234WWoRpLgZnar6z4e+HTUeR00NSKGk=
+20260614120000_chat_blobs_data_nullable.sql h1:lTPA223wK0DrJTzu2jlOPW5Ni8w87wK2NcAo8YAUfa8=

--- a/projects/monolith/chart/templates/deployment.yaml
+++ b/projects/monolith/chart/templates/deployment.yaml
@@ -167,6 +167,12 @@ spec:
               value: {{ .Values.stars.gridKey | quote }}
             - name: STARS_CLIMATOLOGY_S3_KEY
               value: {{ .Values.stars.climatologyKey | quote }}
+            {{- if .Values.chat }}
+            # Chat attachment blob store reuses the shared SeaweedFS S3 endpoint/
+            # creds above (emitted under the stars block, which is always set).
+            - name: CHAT_BLOB_S3_BUCKET
+              value: {{ .Values.chat.blobBucket | quote }}
+            {{- end }}
             {{- end }}
           livenessProbe:
             httpGet:

--- a/projects/monolith/chart/values.yaml
+++ b/projects/monolith/chart/values.yaml
@@ -132,6 +132,12 @@ stars:
   s3AccessKeyId: "duckdb"
   s3SecretAccessKey: "duckdb"
 
+# Chat: Discord attachment bytes are stored in SeaweedFS (content-addressed at
+# blobs/<sha256>) rather than inline in Postgres. Reuses the shared SeaweedFS S3
+# endpoint/creds emitted alongside the stars block.
+chat:
+  blobBucket: "chat"
+
 cfIngress:
   private:
     enabled: true

--- a/projects/monolith/chat/models.py
+++ b/projects/monolith/chat/models.py
@@ -38,7 +38,10 @@ class Blob(SQLModel, table=True):
     __table_args__ = {"schema": "chat", "extend_existing": True}
 
     sha256: str = Field(primary_key=True, max_length=64)
-    data: bytes
+    # Raw bytes now live in SeaweedFS object storage at s3://<bucket>/blobs/<sha256>
+    # (written by chat.store). This column is retained nullable during the
+    # transition; a follow-up migration drops it once existing rows are exported.
+    data: bytes | None = Field(default=None)
     content_type: str
     description: str = Field(default="")
 

--- a/projects/monolith/chat/store.py
+++ b/projects/monolith/chat/store.py
@@ -2,6 +2,7 @@
 
 import hashlib
 import logging
+import os
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 
@@ -20,6 +21,54 @@ from chat.models import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _blob_s3_put(sha256: str, data: bytes, content_type: str) -> bool:
+    """Best-effort upload of a content-addressed attachment blob to SeaweedFS.
+
+    Stored at ``s3://<CHAT_BLOB_S3_BUCKET>/blobs/<sha256>``. Content-addressed,
+    so writes are idempotent and dedup for free. Mirrors stars.grid._s3_client:
+    dummy creds (SeaweedFS auth is disabled cluster-wide), path-style addressing,
+    scheme prepended to the endpoint. The bucket is auto-created on first write.
+
+    The caller treats failures as non-fatal: blob bytes are write-only today
+    (no read path consumes them), so an upload miss is at worst an archival gap,
+    never a chat-breaking error.
+    """
+    import boto3
+    from botocore.config import Config
+    from botocore.exceptions import ClientError
+
+    bucket = os.environ.get("CHAT_BLOB_S3_BUCKET", "")
+    endpoint = os.environ.get("SEAWEEDFS_S3_ENDPOINT", "")
+    if not bucket or not endpoint:
+        logger.warning("chat blob S3 not configured; skipping upload of %s", sha256)
+        return False
+    if not endpoint.startswith(("http://", "https://")):
+        endpoint = "http://" + endpoint
+    # Scheme guaranteed by the guard above; inline nosemgrep clears the pre-commit
+    # boto3-endpoint-url-missing-scheme hook (the Bazel main_semgrep_test, which
+    # ignores nosemgrep, is covered by exclude_rules in projects/monolith/BUILD).
+    client = boto3.client(  # nosemgrep
+        "s3",
+        endpoint_url=endpoint,
+        aws_access_key_id=os.environ.get("S3_ACCESS_KEY_ID", "duckdb"),
+        aws_secret_access_key=os.environ.get("S3_SECRET_ACCESS_KEY", "duckdb"),
+        config=Config(s3={"addressing_style": "path"}),
+    )
+    key = f"blobs/{sha256}"
+    try:
+        client.put_object(Bucket=bucket, Key=key, Body=data, ContentType=content_type)
+    except ClientError as exc:
+        code = exc.response.get("Error", {}).get("Code", "")
+        if code in ("NoSuchBucket", "404"):
+            client.create_bucket(Bucket=bucket)
+            client.put_object(
+                Bucket=bucket, Key=key, Body=data, ContentType=content_type
+            )
+        else:
+            raise
+    return True
 
 
 @dataclass
@@ -83,10 +132,17 @@ class MessageStore:
                     sha = hashlib.sha256(a["data"]).hexdigest()
                     existing_blob = self.session.get(Blob, sha)
                     if not existing_blob:
+                        # Raw bytes go to SeaweedFS (content-addressed); the row
+                        # keeps only metadata. Upload failure is non-fatal (bytes
+                        # have no read path), so log and store the row regardless.
+                        try:
+                            _blob_s3_put(sha, a["data"], a["content_type"])
+                        except Exception:
+                            logger.exception("chat blob S3 upload failed for %s", sha)
                         self.session.add(
                             Blob(
                                 sha256=sha,
-                                data=a["data"],
+                                data=None,
                                 content_type=a["content_type"],
                                 description=a.get("description", ""),
                             )

--- a/projects/monolith/chat/store_attachments_test.py
+++ b/projects/monolith/chat/store_attachments_test.py
@@ -241,7 +241,9 @@ class TestSaveMessageWithAttachmentsAdditional:
         assert saved_att is not None
         saved_blob = session.get(Blob, saved_att.blob_sha256)
         assert saved_blob is not None
-        assert saved_blob.data == raw_bytes
+        # Bytes now go to SeaweedFS (S3 unconfigured in tests, so not uploaded);
+        # the row persists with a NULL data column.
+        assert saved_blob.data is None
 
 
 # ---------------------------------------------------------------------------
@@ -324,4 +326,4 @@ class TestBlobDeduplication:
         # Only one blob row exists
         all_blobs = session.exec(select(Blob)).all()
         assert len(all_blobs) == 1
-        assert all_blobs[0].data == shared_data
+        assert all_blobs[0].data is None  # bytes now in SeaweedFS

--- a/projects/monolith/chat/store_blob_test.py
+++ b/projects/monolith/chat/store_blob_test.py
@@ -5,7 +5,7 @@ import hashlib
 import pytest
 from sqlmodel import Session, SQLModel, create_engine
 from sqlmodel.pool import StaticPool
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 from chat.models import Blob
 from chat.store import MessageStore
@@ -71,7 +71,7 @@ class TestGetBlobHappyPath:
         assert result is not None
         assert isinstance(result, Blob)
         assert result.sha256 == sha
-        assert result.data == image_data
+        assert result.data is None  # bytes now in SeaweedFS, not the data column
         assert result.description == "A test image"
         assert result.content_type == "image/png"
 
@@ -128,3 +128,34 @@ class TestGetBlobMissPath:
 
         result = store.get_blob(wrong_sha)
         assert result is None
+
+
+class TestBlobBytesRoutedToSeaweedFS:
+    @pytest.mark.asyncio
+    async def test_save_uploads_bytes_to_s3_and_nulls_column(self, store):
+        """Saving a new attachment uploads bytes to SeaweedFS and NULLs data."""
+        image_data = b"\x89PNG\r\n\x1a\nrouted"
+        sha = hashlib.sha256(image_data).hexdigest()
+
+        with patch("chat.store._blob_s3_put", return_value=True) as put:
+            await store.save_message(
+                discord_message_id="blob-s3-1",
+                channel_id="ch1",
+                user_id="u1",
+                username="Alice",
+                content="img",
+                is_bot=False,
+                attachments=[
+                    {
+                        "data": image_data,
+                        "content_type": "image/png",
+                        "filename": "x.png",
+                        "description": "d",
+                    }
+                ],
+            )
+
+        put.assert_called_once_with(sha, image_data, "image/png")
+        blob = store.get_blob(sha)
+        assert blob is not None
+        assert blob.data is None

--- a/projects/monolith/chat/store_flush_blob_test.py
+++ b/projects/monolith/chat/store_flush_blob_test.py
@@ -233,7 +233,8 @@ class TestBlobFlushBeforeAttachment:
 
         blob = session.get(Blob, expected_sha)
         assert blob is not None, "Blob must exist after save_message()"
-        assert blob.data == raw_data, "Blob data must be preserved exactly"
+        # Flush still happens; bytes now live in SeaweedFS so data is NULL.
+        assert blob.data is None
 
         atts = session.exec(
             select(Attachment).where(Attachment.message_id == msg.id)
@@ -341,4 +342,4 @@ class TestBlobFlushBeforeAttachment:
         att, blob = result[msg.id][0]
         assert att.blob_sha256 == expected_sha
         assert blob.sha256 == expected_sha
-        assert blob.data == raw_data
+        assert blob.data is None  # bytes now in SeaweedFS

--- a/projects/monolith/chat/store_test.py
+++ b/projects/monolith/chat/store_test.py
@@ -129,7 +129,7 @@ class TestSaveMessageWithAttachments:
         blob = session.get(Blob, saved[0].blob_sha256)
         assert blob is not None
         assert blob.description == "A cat"
-        assert blob.data == b"\x89PNG"
+        assert blob.data is None  # bytes now in SeaweedFS
 
     @pytest.mark.asyncio
     async def test_embeds_combined_text_and_descriptions(self, store):

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.133.1
+      targetRevision: 0.133.2
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.133.0
+      targetRevision: 0.133.1
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/e2e/e2e_test.py
+++ b/projects/monolith/e2e/e2e_test.py
@@ -6,11 +6,11 @@ Tests run against real PostgreSQL 16 + pgvector. External services
 
 import pytest
 from pydantic_ai.messages import ToolCallPart
+from sqlalchemy import text
 
 
 def test_postgres_is_running(pg):
     """Smoke test: PostgreSQL is reachable and has pgvector."""
-    from sqlalchemy import text
     from sqlmodel import create_engine
 
     engine = create_engine(pg.url)
@@ -267,7 +267,9 @@ class TestMessageStore:
         att, blob = pairs[0]
         assert att.filename == "photo.jpg"
         assert blob.content_type == "image/jpeg"
-        assert blob.data == b"blob-data-for-join-test"
+        # Bytes now live in SeaweedFS (S3 unset in e2e env, so not uploaded);
+        # the row persists with a NULL data column.
+        assert blob.data is None
 
     @pytest.mark.asyncio
     async def test_upsert_summary_insert_and_update(self, store):


### PR DESCRIPTION
## Why

`chat.blobs.data` stored Discord attachment bytes inline as `BYTEA`, ~250 MB of `monolith-pg` for 235 images. The bytes are **write-only**, no read path consumes them (the dedup cache keys on `sha256` and uses the vision `description`; the vision model is fed freshly-downloaded bytes). So they belong in object storage.

## Changes

- `chat.store._blob_s3_put` uploads new blobs to SeaweedFS at content-addressed key `blobs/<sha256>` (idempotent, free dedup), auto-creating the `chat` bucket. Reuses the shared `SEAWEEDFS_S3_ENDPOINT` + creds. **Upload failure is non-fatal** (bytes have no read path), logged, row still stored.
- `chat.blobs` row keeps its metadata (`sha256`/`content_type`/`description`); `data` is `NULL` for new rows. Migration drops the `NOT NULL` constraint.
- chart: `CHAT_BLOB_S3_BUCKET` env + `chat.blobBucket` value; chart `0.133.0` → `0.133.1`.
- Tests updated (rows persist with `data IS NULL`); added a test asserting bytes route to `_blob_s3_put`.

## Follow-ups (intentional, separate)

1. **Manual export** of the existing 235 blob rows' bytes to the `chat` bucket (owner does this out-of-band; bucket already created).
2. **Drop the `data` column** migration once export is verified (reclaims the ~250 MB).
3. Bucket provisioning is currently out-of-band (`weed shell`); the COSI ADR will formalize declarative provisioning + lifecycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)