### PR TITLE
feat(monolith): drop unused chat.blobs.data column (bytes now in SeaweedFS)

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.133.2
+version: 0.133.3
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/migrations/20260614130000_chat_blobs_drop_data.sql
+++ b/projects/monolith/chart/migrations/20260614130000_chat_blobs_drop_data.sql
@@ -1,0 +1,9 @@
+-- Drop chat.blobs.data permanently. Raw attachment bytes now live in SeaweedFS
+-- object storage (s3://<CHAT_BLOB_S3_BUCKET>/blobs/<sha256>), written by
+-- chat.store._blob_s3_put. All 363 pre-existing rows were exported to SeaweedFS
+-- and verified out-of-band, so the column is no longer read or written and can
+-- be removed. The row now holds only metadata (sha256, content_type,
+-- description). Note: dropping the column reclaims it logically, but a manual
+-- VACUUM FULL chat.blobs is still required to return the TOAST space to the
+-- volume.
+ALTER TABLE chat.blobs DROP COLUMN data;

--- a/projects/monolith/chart/migrations/atlas.sum
+++ b/projects/monolith/chart/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:g93V7UYRgEgXV96UweIWhTTSNVuAeKDbHugie6uJO1A=
+h1:p4E5JKtPnxxViE0tp3OIThKnvUaYplLF8c22tcnaz5o=
 20260330000000_initial_schema.sql h1:J2futpSW0nJAIRR7nR7ssT7LwXIYrvRI+PkHb5Y4tLI=
 20260403000000_chat_schema.sql h1:pERUFC0vzM95etRuzp43XzkCV7lBCzrrtY5Mk7aF3CA=
 20260404000000_chat_attachments.sql h1:tv+Fdbr1rQC5nzUxfaBC0O6fu2OMGgLWf+YNg1WQXi4=
@@ -39,3 +39,4 @@ h1:g93V7UYRgEgXV96UweIWhTTSNVuAeKDbHugie6uJO1A=
 20260614000010_stars_v2_site_hours.sql h1:ZoC3kzKNSgyDoEDLO4M9rk4CL2TekRXzbbmSoK3QNBc=
 20260614000020_stars_v2_accumulators.sql h1:Al0nCReLo8Y5234WWoRpLgZnar6z4e+HTUeR00NSKGk=
 20260614120000_chat_blobs_data_nullable.sql h1:lTPA223wK0DrJTzu2jlOPW5Ni8w87wK2NcAo8YAUfa8=
+20260614130000_chat_blobs_drop_data.sql h1:GKbcKD3/dowWeSS8qk5ticicyMcM/gHNzWksomDECnk=

--- a/projects/monolith/chat/agent_helper_functions_test.py
+++ b/projects/monolith/chat/agent_helper_functions_test.py
@@ -298,7 +298,6 @@ class TestFormatContextMessagesAttachments:
                     Attachment(id=1, message_id=5, blob_sha256="aaa", filename="a.png"),
                     Blob(
                         sha256="aaa",
-                        data=b"",
                         content_type="image/png",
                         description="A dog",
                     ),
@@ -307,7 +306,6 @@ class TestFormatContextMessagesAttachments:
                     Attachment(id=2, message_id=5, blob_sha256="bbb", filename="b.png"),
                     Blob(
                         sha256="bbb",
-                        data=b"",
                         content_type="image/png",
                         description="A cat",
                     ),
@@ -341,7 +339,6 @@ class TestFormatContextMessagesAttachments:
                     Attachment(id=1, message_id=7, blob_sha256="ccc", filename="c.png"),
                     Blob(
                         sha256="ccc",
-                        data=b"",
                         content_type="image/png",
                         description="Sunset",
                     ),

--- a/projects/monolith/chat/agent_test.py
+++ b/projects/monolith/chat/agent_test.py
@@ -92,7 +92,6 @@ class TestFormatContextMessages:
                     ),
                     Blob(
                         sha256="abc123",
-                        data=b"",
                         content_type="image/png",
                         description="A cat on a keyboard",
                     ),

--- a/projects/monolith/chat/models.py
+++ b/projects/monolith/chat/models.py
@@ -38,10 +38,8 @@ class Blob(SQLModel, table=True):
     __table_args__ = {"schema": "chat", "extend_existing": True}
 
     sha256: str = Field(primary_key=True, max_length=64)
-    # Raw bytes now live in SeaweedFS object storage at s3://<bucket>/blobs/<sha256>
-    # (written by chat.store). This column is retained nullable during the
-    # transition; a follow-up migration drops it once existing rows are exported.
-    data: bytes | None = Field(default=None)
+    # Raw bytes live in SeaweedFS object storage at s3://<bucket>/blobs/<sha256>
+    # (written by chat.store). The row holds only metadata.
     content_type: str
     description: str = Field(default="")
 

--- a/projects/monolith/chat/models_test.py
+++ b/projects/monolith/chat/models_test.py
@@ -179,29 +179,26 @@ class TestBlobModel:
         columns = {c.name for c in Blob.__table__.columns}
         expected = {
             "sha256",
-            "data",
             "content_type",
             "description",
         }
         assert expected == columns
 
     def test_blob_construction(self):
-        """Blob can be constructed with all fields."""
+        """Blob can be constructed with all metadata fields."""
         blob = Blob(
             sha256="deadbeef" * 8,
-            data=b"\x89PNG",
             content_type="image/png",
             description="A photo of a cat",
         )
+        assert blob.sha256 == "deadbeef" * 8
         assert blob.content_type == "image/png"
-        assert blob.data == b"\x89PNG"
         assert blob.description == "A photo of a cat"
 
     def test_blob_description_defaults_empty(self):
         """Blob.description defaults to empty string."""
         blob = Blob(
             sha256="abcd1234" * 8,
-            data=b"",
             content_type="image/gif",
         )
         assert blob.description == ""

--- a/projects/monolith/chat/store.py
+++ b/projects/monolith/chat/store.py
@@ -142,7 +142,6 @@ class MessageStore:
                         self.session.add(
                             Blob(
                                 sha256=sha,
-                                data=None,
                                 content_type=a["content_type"],
                                 description=a.get("description", ""),
                             )

--- a/projects/monolith/chat/store_attachments_test.py
+++ b/projects/monolith/chat/store_attachments_test.py
@@ -1,5 +1,6 @@
 """Additional tests for get_attachments() edge cases and save_message() with attachments."""
 
+import hashlib
 from unittest.mock import AsyncMock
 
 import pytest
@@ -215,8 +216,8 @@ class TestSaveMessageWithAttachmentsAdditional:
         assert len(saved) == 0
 
     @pytest.mark.asyncio
-    async def test_blob_data_is_preserved_exactly(self, store, session):
-        """save_message() stores attachment bytes in the Blob without modification."""
+    async def test_blob_sha256_is_content_address(self, store, session):
+        """save_message() content-addresses the Blob by the sha256 of the bytes."""
         raw_bytes = b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR"
         msg = await store.save_message(
             discord_message_id="bytes_check",
@@ -241,9 +242,8 @@ class TestSaveMessageWithAttachmentsAdditional:
         assert saved_att is not None
         saved_blob = session.get(Blob, saved_att.blob_sha256)
         assert saved_blob is not None
-        # Bytes now go to SeaweedFS (S3 unconfigured in tests, so not uploaded);
-        # the row persists with a NULL data column.
-        assert saved_blob.data is None
+        # Bytes now live in SeaweedFS; the row is keyed by the content hash.
+        assert saved_blob.sha256 == hashlib.sha256(raw_bytes).hexdigest()
 
 
 # ---------------------------------------------------------------------------
@@ -326,4 +326,3 @@ class TestBlobDeduplication:
         # Only one blob row exists
         all_blobs = session.exec(select(Blob)).all()
         assert len(all_blobs) == 1
-        assert all_blobs[0].data is None  # bytes now in SeaweedFS

--- a/projects/monolith/chat/store_blob_test.py
+++ b/projects/monolith/chat/store_blob_test.py
@@ -71,7 +71,6 @@ class TestGetBlobHappyPath:
         assert result is not None
         assert isinstance(result, Blob)
         assert result.sha256 == sha
-        assert result.data is None  # bytes now in SeaweedFS, not the data column
         assert result.description == "A test image"
         assert result.content_type == "image/png"
 
@@ -82,7 +81,6 @@ class TestGetBlobHappyPath:
 
         blob = Blob(
             sha256=sha,
-            data=raw,
             content_type="image/jpeg",
             description="A direct blob",
         )
@@ -93,7 +91,7 @@ class TestGetBlobHappyPath:
 
         assert result is not None
         assert result.sha256 == sha
-        assert result.data == raw
+        assert result.content_type == "image/jpeg"
         assert result.description == "A direct blob"
 
 
@@ -119,7 +117,6 @@ class TestGetBlobMissPath:
         session.add(
             Blob(
                 sha256=correct_sha,
-                data=raw,
                 content_type="image/png",
                 description="real blob",
             )
@@ -132,8 +129,8 @@ class TestGetBlobMissPath:
 
 class TestBlobBytesRoutedToSeaweedFS:
     @pytest.mark.asyncio
-    async def test_save_uploads_bytes_to_s3_and_nulls_column(self, store):
-        """Saving a new attachment uploads bytes to SeaweedFS and NULLs data."""
+    async def test_save_uploads_bytes_to_s3_and_keeps_metadata_row(self, store):
+        """Saving a new attachment uploads bytes to SeaweedFS and keeps the metadata row."""
         image_data = b"\x89PNG\r\n\x1a\nrouted"
         sha = hashlib.sha256(image_data).hexdigest()
 
@@ -158,4 +155,4 @@ class TestBlobBytesRoutedToSeaweedFS:
         put.assert_called_once_with(sha, image_data, "image/png")
         blob = store.get_blob(sha)
         assert blob is not None
-        assert blob.data is None
+        assert blob.sha256 == sha

--- a/projects/monolith/chat/store_flush_blob_test.py
+++ b/projects/monolith/chat/store_flush_blob_test.py
@@ -233,8 +233,6 @@ class TestBlobFlushBeforeAttachment:
 
         blob = session.get(Blob, expected_sha)
         assert blob is not None, "Blob must exist after save_message()"
-        # Flush still happens; bytes now live in SeaweedFS so data is NULL.
-        assert blob.data is None
 
         atts = session.exec(
             select(Attachment).where(Attachment.message_id == msg.id)
@@ -258,7 +256,6 @@ class TestBlobFlushBeforeAttachment:
         session.add(
             Blob(
                 sha256=sha,
-                data=raw_data,
                 content_type="image/gif",
                 description="Pre-existing",
             )
@@ -342,4 +339,3 @@ class TestBlobFlushBeforeAttachment:
         att, blob = result[msg.id][0]
         assert att.blob_sha256 == expected_sha
         assert blob.sha256 == expected_sha
-        assert blob.data is None  # bytes now in SeaweedFS

--- a/projects/monolith/chat/store_test.py
+++ b/projects/monolith/chat/store_test.py
@@ -129,7 +129,6 @@ class TestSaveMessageWithAttachments:
         blob = session.get(Blob, saved[0].blob_sha256)
         assert blob is not None
         assert blob.description == "A cat"
-        assert blob.data is None  # bytes now in SeaweedFS
 
     @pytest.mark.asyncio
     async def test_embeds_combined_text_and_descriptions(self, store):

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.133.2
+      targetRevision: 0.133.3
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/e2e/e2e_test.py
+++ b/projects/monolith/e2e/e2e_test.py
@@ -267,9 +267,6 @@ class TestMessageStore:
         att, blob = pairs[0]
         assert att.filename == "photo.jpg"
         assert blob.content_type == "image/jpeg"
-        # Bytes now live in SeaweedFS (S3 unset in e2e env, so not uploaded);
-        # the row persists with a NULL data column.
-        assert blob.data is None
 
     @pytest.mark.asyncio
     async def test_upsert_summary_insert_and_update(self, store):


### PR DESCRIPTION
## Summary

Chat attachment bytes were moved to SeaweedFS object storage in PR #2599 (merged + deployed). All 363 pre-existing `chat.blobs` rows were exported to S3 and verified (363/363), so the `data` column is no longer read or written. This PR permanently drops it.

## Changes

- New Atlas migration `20260614130000_chat_blobs_drop_data.sql`: `ALTER TABLE chat.blobs DROP COLUMN data;` (atlas.sum auto-updated by the pre-commit hook).
- Remove the `data: bytes | None` field from the `Blob` SQLModel (keeps `sha256`, `content_type`, `description`).
- Drop the `data=None` kwarg from the `Blob(...)` construction in `chat.store.save_messages`; the `_blob_s3_put(...)` upload path is unchanged.
- Fix all tests that referenced the removed field: drop `data=` kwargs from `Blob(...)` constructions and remove `blob.data` / `result.data` assertions. Where removing an assertion left a test vacuous, repurposed it to assert the content-addressed `sha256` / metadata (`content_type`, `description`) instead. Renamed two now-misleading tests (`test_blob_data_is_preserved_exactly` -> `test_blob_sha256_is_content_address`, `test_save_uploads_bytes_to_s3_and_nulls_column` -> `..._keeps_metadata_row`).
- Bump chart version `0.133.2` -> `0.133.3` (`Chart.yaml` + `deploy/application.yaml` `targetRevision`, kept in sync).

## Notes

- Bytes verified in SeaweedFS: 363/363.
- This drop reclaims the column logically, but a `VACUUM FULL chat.blobs` is still needed out-of-band to return the ~250MB of TOAST space to the volume.
- Base branch was already at chart `0.133.2` (from the merged PR #2599), so this bumps to `0.133.3` rather than the `0.133.1 -> 0.133.2` in the original task note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)