### PR TITLE
feat(monolith): serve note bodies from Postgres (ADR 006 Phase 2)

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.136.0
+version: 0.136.1
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.135.0
+version: 0.136.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.136.0
+      targetRevision: 0.136.1
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.135.0
+      targetRevision: 0.136.0
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/knowledge/mcp.py
+++ b/projects/monolith/knowledge/mcp.py
@@ -71,8 +71,9 @@ async def search_knowledge(
 async def get_note(note_id: str) -> dict:
     """Retrieve a knowledge note by its stable ID.
 
-    Returns note metadata (title, type, tags), the full markdown
-    content read from the vault, and all outgoing graph edges.
+    Returns note metadata (title, type, tags), the markdown body (the
+    authored body from Postgres, with the vault file as a fallback), and
+    all outgoing graph edges.
 
     Args:
         note_id: The stable note identifier (e.g. "attention-is-all-you-need").
@@ -84,12 +85,14 @@ async def get_note(note_id: str) -> dict:
             return {"error": f"note not found: {note_id}"}
 
         vault_root = Path(os.environ.get(VAULT_ROOT_ENV, DEFAULT_VAULT_ROOT)).resolve()
-        resolved = (vault_root / note["path"]).resolve()
-        if not resolved.is_relative_to(vault_root) or not resolved.is_file():
+        body = notes_module.resolve_note_body(
+            note.get("content"), vault_root, note["path"]
+        )
+        if body is None:
             return {"error": f"vault file missing for {note_id}"}
 
         edges = store.get_note_links(note_id)
-        return {**note, "content": resolved.read_text(), "edges": edges}
+        return {**note, "content": body, "edges": edges}
 
 
 @mcp.tool

--- a/projects/monolith/knowledge/notes.py
+++ b/projects/monolith/knowledge/notes.py
@@ -27,6 +27,7 @@ import yaml
 from sqlmodel import Session, select
 
 from knowledge import frontmatter
+from knowledge import wikilinks
 from knowledge.models import Note
 
 logger = logging.getLogger(__name__)
@@ -62,32 +63,53 @@ def _get_note_or_raise(session: Session, note_id: str) -> Note:
     return note
 
 
+def resolve_note_body(content: str | None, vault_root: Path, path: str) -> str | None:
+    """Return a note's markdown body, preferring the Postgres ``content``
+    column (the ADR 006 body of record) and falling back to the on-disk
+    vault file while pre-existing rows may still carry NULL content (the
+    one-shot reconciler backfill is in progress).
+
+    The returned body is frontmatter- and ``## Links``-section-stripped in
+    both paths so callers get a stable shape regardless of source: the
+    column already holds the authored body, and the disk fallback parses
+    and strips to match. Returns ``None`` when content is NULL and the file
+    is missing or escapes the vault root, so callers can map that to their
+    own not-found / empty response.
+    """
+    if content is not None:
+        return content
+    resolved = (vault_root / path).resolve()
+    if not resolved.is_relative_to(vault_root) or not resolved.is_file():
+        return None
+    try:
+        raw = resolved.read_text()
+    except OSError:
+        return None
+    try:
+        _, body = frontmatter.parse(raw)
+    except frontmatter.FrontmatterError:
+        # Body still useful even if frontmatter is broken; fall back to raw.
+        return raw
+    return wikilinks.strip_links_section(body)
+
+
 def _read_note_snippet(vault_root: Path, note: Note) -> str:
     """Return the first ~100 lines of ``note``'s body, capped at 8 KiB.
 
-    Reads the vault file and strips frontmatter. Missing / unreadable
-    files return an empty string — review-queue listing is best-effort
-    metadata and must never break on a partial vault. The line+byte cap
-    is sized to give the audit UI enough context to evaluate a note
-    in-place without surfacing the entire body.
+    Prefers the Postgres ``content`` column (ADR 006), falling back to the
+    vault file. Missing / unreadable files return an empty string —
+    review-queue listing is best-effort metadata and must never break on a
+    partial vault. The line+byte cap is sized to give the audit UI enough
+    context to evaluate a note in-place without surfacing the entire body.
     """
-    try:
-        resolved = (vault_root / note.path).resolve()
-        if not resolved.is_relative_to(vault_root) or not resolved.is_file():
-            return ""
-        raw = resolved.read_text()
-    except OSError:
+    body = resolve_note_body(note.content, vault_root, note.path)
+    if body is None:
         logger.warning(
             "notes._read_note_snippet: failed to read %s for note_id=%r",
             note.path,
             note.note_id,
         )
         return ""
-    try:
-        _, body = frontmatter.parse(raw)
-    except frontmatter.FrontmatterError:
-        # Body still useful even if frontmatter is broken; fall back to raw.
-        body = raw
     head = "\n".join(body.lstrip().splitlines()[:_SNIPPET_MAX_LINES])
     # Byte cap as a backstop: a single very long line shouldn't blow
     # the payload past what the review UI can render comfortably.

--- a/projects/monolith/knowledge/notes_test.py
+++ b/projects/monolith/knowledge/notes_test.py
@@ -27,6 +27,7 @@ from knowledge.notes import (
     _serialize_frontmatter,
     _trash_filename,
     _write_note_visibility_frontmatter,
+    resolve_note_body,
 )
 
 
@@ -47,6 +48,7 @@ def _make_note(
     source: str | None = None,
     deleted_at: datetime | None = None,
     updated_at: datetime | None = None,
+    content: str | None = None,
 ) -> Note:
     """Return an *unsaved* Note for testing pure helpers that don't need a DB."""
     return Note(
@@ -54,6 +56,7 @@ def _make_note(
         path=path or f"{note_id}.md",
         title=title,
         content_hash=f"hash-{note_id}",
+        content=content,
         type=type_,
         visibility=visibility,  # type: ignore[arg-type]
         visibility_verified=visibility_verified,
@@ -91,7 +94,55 @@ def _write_vault_note(
 # ---------------------------------------------------------------------------
 
 
+class TestResolveNoteBody:
+    """ADR 006 Phase 2: prefer the Postgres content column, fall back to disk."""
+
+    def test_prefers_content_column_without_disk_access(self, tmp_path: Path) -> None:
+        # No file on disk; content must come from the column.
+        body = resolve_note_body("from the column", tmp_path, "nope.md")
+        assert body == "from the column"
+
+    def test_falls_back_to_disk_when_content_none(self, tmp_path: Path) -> None:
+        _write_vault_note(tmp_path, "note.md", body="disk body")
+        body = resolve_note_body(None, tmp_path, "note.md")
+        assert body is not None
+        assert "disk body" in body
+        # Frontmatter is stripped on the disk path.
+        assert "visibility" not in body
+
+    def test_disk_fallback_strips_links_section(self, tmp_path: Path) -> None:
+        (tmp_path / "n.md").write_text(
+            "---\nid: n\ntitle: N\n---\nReal body.\n\n## Links\n\n- Up: [[x]]\n"
+        )
+        body = resolve_note_body(None, tmp_path, "n.md")
+        assert body is not None
+        assert "Real body." in body
+        assert "## Links" not in body
+
+    def test_returns_none_when_content_none_and_file_missing(
+        self, tmp_path: Path
+    ) -> None:
+        assert resolve_note_body(None, tmp_path, "ghost.md") is None
+
+    def test_returns_none_on_path_escape(self, tmp_path: Path) -> None:
+        assert resolve_note_body(None, tmp_path, "../escape.md") is None
+
+    def test_empty_string_content_is_served_not_fallback(
+        self, tmp_path: Path
+    ) -> None:
+        # An empty body is a legitimate value, distinct from NULL — it must
+        # not trigger the disk fallback.
+        _write_vault_note(tmp_path, "e.md", body="should not be read")
+        assert resolve_note_body("", tmp_path, "e.md") == ""
+
+
 class TestReadNoteSnippet:
+    def test_uses_content_column_when_present(self, tmp_path: Path) -> None:
+        # No disk file; the snippet must be sourced from the column.
+        note = _make_note(path="col.md", content="Body from Postgres.")
+        snippet = _read_note_snippet(tmp_path, note)
+        assert "Body from Postgres." in snippet
+
     def test_returns_body_without_frontmatter(self, tmp_path: Path) -> None:
         note = _make_note(path="note.md")
         _write_vault_note(

--- a/projects/monolith/knowledge/notes_test.py
+++ b/projects/monolith/knowledge/notes_test.py
@@ -127,9 +127,7 @@ class TestResolveNoteBody:
     def test_returns_none_on_path_escape(self, tmp_path: Path) -> None:
         assert resolve_note_body(None, tmp_path, "../escape.md") is None
 
-    def test_empty_string_content_is_served_not_fallback(
-        self, tmp_path: Path
-    ) -> None:
+    def test_empty_string_content_is_served_not_fallback(self, tmp_path: Path) -> None:
         # An empty body is a legitimate value, distinct from NULL — it must
         # not trigger the disk fallback.
         _write_vault_note(tmp_path, "e.md", body="should not be read")

--- a/projects/monolith/knowledge/router.py
+++ b/projects/monolith/knowledge/router.py
@@ -48,6 +48,7 @@ from knowledge.notes import (
     delete_note,
     list_notes_for_review,
     reset_note_visibility,
+    resolve_note_body,
     set_note_visibility,
     undelete_note,
     verify_note_visibility,
@@ -304,18 +305,17 @@ def get_public_note(
         logger.info("public.note.404 note_id=%s reason=%s", note_id, reason)
         raise HTTPException(status_code=404, detail="Not Found")
 
-    # Load the body from the vault. Reuse the same path-traversal guard
-    # the private GET /notes/{id} uses so a malformed path can't escape
-    # the vault root.
+    # Load the body, preferring the Postgres content column (ADR 006) and
+    # falling back to the vault file. resolve_note_body reuses the same
+    # path-traversal guard the private GET /notes/{id} uses so a malformed
+    # path can't escape the vault root.
     vault_root = _get_vault_root()
-    resolved = (vault_root / note.path).resolve()
-    if not resolved.is_relative_to(vault_root) or not resolved.is_file():
+    body = resolve_note_body(note.content, vault_root, note.path)
+    if body is None:
         # Same identical 404 — don't leak that the DB row exists but
         # the file is missing/escaped.
         logger.info("public.note.404 note_id=%s reason=vault_file_missing", note_id)
         raise HTTPException(status_code=404, detail="Not Found")
-    raw = resolved.read_text()
-    _, body = frontmatter.parse(raw)
 
     # Slugified ids of every non-public note. ``sanitize_public_body``
     # slugifies wikilink display text via ``visibility._slugify`` and
@@ -385,12 +385,12 @@ def get_knowledge_note(
         raise HTTPException(status_code=404, detail="note not found")
 
     vault_root = _get_vault_root()
-    resolved = (vault_root / note["path"]).resolve()
-    if not resolved.is_relative_to(vault_root) or not resolved.is_file():
+    body = resolve_note_body(note.get("content"), vault_root, note["path"])
+    if body is None:
         raise HTTPException(status_code=404, detail="vault file missing")
 
     edges = store.get_note_links(note_id)
-    return {**note, "content": resolved.read_text(), "edges": edges}
+    return {**note, "content": body, "edges": edges}
 
 
 @router.delete("/notes/{note_id}")

--- a/projects/monolith/knowledge/store.py
+++ b/projects/monolith/knowledge/store.py
@@ -347,11 +347,16 @@ class KnowledgeStore:
         return results
 
     def get_note_by_id(self, note_id: str) -> dict | None:
-        """Fetch lightweight note metadata by stable ``note_id``.
+        """Fetch note metadata plus the authoritative ``content`` body by
+        stable ``note_id``.
 
         Returns ``None`` if no note matches. Used by the knowledge search
-        overlay's preview pane (ADR 003) to resolve a selected result to
-        its displayable metadata without re-running the vector query.
+        overlay's preview pane (ADR 003) and the note GET endpoints to
+        resolve a selected result to its displayable metadata and body
+        without re-running the vector query. ``content`` is the ADR 006
+        body of record and may be ``None`` for rows the one-shot backfill
+        has not reached yet (callers fall back to disk via
+        :func:`knowledge.notes.resolve_note_body`).
         """
         row = self.session.execute(
             select(
@@ -360,6 +365,7 @@ class KnowledgeStore:
                 Note.path,
                 Note.type,
                 Note.tags,
+                Note.content,
             )
             .where(Note.note_id == note_id)
             .where(Note.deleted_at.is_(None))
@@ -373,6 +379,7 @@ class KnowledgeStore:
             "path": row.path,
             "type": row.type,
             "tags": list(row.tags or []),
+            "content": row.content,
         }
 
     def get_graph(self) -> dict:

--- a/projects/monolith/knowledge/store_test.py
+++ b/projects/monolith/knowledge/store_test.py
@@ -88,6 +88,7 @@ def _upsert(
     metadata=None,
     n_chunks=1,
     links=None,
+    content=None,
 ):
     metadata = metadata or _meta(title=title)
     store.upsert_note(
@@ -99,6 +100,7 @@ def _upsert(
         chunks=_chunks(n_chunks),
         vectors=_vecs(n_chunks),
         links=links or [],
+        content=content,
     )
 
 
@@ -509,7 +511,22 @@ class TestGetNoteById:
             "path": "folder/note.md",
             "type": "paper",
             "tags": ["x"],
+            "content": None,
         }
+
+    def test_returns_content_when_set(self, store):
+        # ADR 006: get_note_by_id surfaces the authoritative body column.
+        _upsert(
+            store,
+            note_id="n2",
+            path="folder/n2.md",
+            title="N2",
+            metadata=_meta(title="N2", type="atom"),
+            content="The authored body.",
+        )
+        got = store.get_note_by_id("n2")
+        assert got is not None
+        assert got["content"] == "The authored body."
 
     def test_returns_none_when_missing(self, store):
         assert store.get_note_by_id("nope") is None


### PR DESCRIPTION
## ADR 006, Phase 2: serve note bodies from Postgres

Second phase of [ADR 006](https://github.com/jomcgi/homelab/blob/main/docs/decisions/platform/006-obsidian-decommission-postgres-interim.md) (plan: `docs/plans/2026-06-13-obsidian-decommission-plan.md`). Phase 1 made `knowledge.notes.content` the body of record; this switches the **read paths** off the vault filesystem onto that column.

### What changed

- **New `resolve_note_body(content, vault_root, path)` helper** (`notes.py`): prefers the `content` column and falls back to parsing the on-disk file while pre-existing rows may still have NULL content (one-shot backfill in progress). Returns a frontmatter- and `## Links`-section-stripped body in both paths, so callers get a stable shape regardless of source.
- **Converted read sites** to the helper: `get_note` (MCP), `get_knowledge_note` and `get_public_note` (HTTP), and the review-queue snippet (`_read_note_snippet`).
- **`get_note_by_id`** now selects and returns `content`.

### Why this is rendering-equivalent

The frontend `NotePanel` already strips YAML frontmatter and the generated `## Links` section client-side (`trimNoteBody`), and the public body gets the same treatment. Serving the body-only `content` column is therefore equivalent to the previous "read full file, trim client-side" behavior across the private panel, public notes, and review queue. The `## Links` section is regenerable from frontmatter edges (the graph/edges already carry that data), so it is intentionally excluded from the body of record.

### Safety / fallback

`resolve_note_body` keeps the same path-traversal guard the endpoints used before. Until the backfill finishes, any NULL-content row transparently falls back to disk, so there is no window where bodies disappear. Obsidian remains the editing surface and safety net.

### Not in this phase

`edit_note` (MCP + HTTP) still reads disk because it rebuilds the whole file to write back — that moves to Postgres in Phase 3 (write paths), along with dual-write.

### Tests

- New `TestResolveNoteBody`: column-preferred, disk fallback, Links-section stripping on fallback, missing-file and path-escape -> None, empty-string content served (not treated as NULL).
- `_read_note_snippet` sourced from the column when present.
- Existing read-path tests (mock notes without a `content` key) continue to exercise the disk-fallback path via `note.get("content")`.

https://claude.ai/code/session_01QHNVzzuvxSqH636tyLr3g8

---
_Generated by [Claude Code](https://claude.ai/code/session_01QHNVzzuvxSqH636tyLr3g8)_