### PR TITLE
feat(monolith): serve note bodies from Postgres (ADR 006 Phase 2)

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.135.0
+version: 0.136.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.135.0
+      targetRevision: 0.136.0
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/knowledge/mcp.py
+++ b/projects/monolith/knowledge/mcp.py
@@ -24,6 +24,7 @@ from knowledge.gaps import answer_gap as _answer_gap
 from knowledge.gaps import approve_gap as _approve_gap
 from knowledge.gaps import list_review_queue, split_csv
 from knowledge.gardener import _slugify
+from knowledge.notes import resolve_note_body
 from knowledge.service import DEFAULT_VAULT_ROOT, VAULT_ROOT_ENV
 from knowledge.store import KnowledgeStore
 from shared.embedding import EmbeddingClient
@@ -72,7 +73,9 @@ async def get_note(note_id: str) -> dict:
     """Retrieve a knowledge note by its stable ID.
 
     Returns note metadata (title, type, tags), the full markdown
-    content read from the vault, and all outgoing graph edges.
+    body (authoritative ``knowledge.notes.content`` in Postgres, with a
+    vault fallback during the ADR 006 Phase 1 backfill), and all
+    outgoing graph edges.
 
     Args:
         note_id: The stable note identifier (e.g. "attention-is-all-you-need").
@@ -83,13 +86,15 @@ async def get_note(note_id: str) -> dict:
         if note is None:
             return {"error": f"note not found: {note_id}"}
 
+        # ADR 006 Phase 2: body of record is Postgres ``content``; the vault
+        # read is a fallback only while the Phase 1 backfill is in flight.
         vault_root = Path(os.environ.get(VAULT_ROOT_ENV, DEFAULT_VAULT_ROOT)).resolve()
-        resolved = (vault_root / note["path"]).resolve()
-        if not resolved.is_relative_to(vault_root) or not resolved.is_file():
+        body = resolve_note_body(note.get("content"), note["path"], vault_root)
+        if body is None:
             return {"error": f"vault file missing for {note_id}"}
 
         edges = store.get_note_links(note_id)
-        return {**note, "content": resolved.read_text(), "edges": edges}
+        return {**note, "content": body, "edges": edges}
 
 
 @mcp.tool

--- a/projects/monolith/knowledge/mcp_test.py
+++ b/projects/monolith/knowledge/mcp_test.py
@@ -142,6 +142,29 @@ class TestGetNote:
         assert result["edges"] == []
 
     @pytest.mark.asyncio
+    async def test_serves_content_from_db_without_disk(self, tmp_path, monkeypatch):
+        """ADR 006 Phase 2: body comes from Postgres, no vault file read."""
+        vault_dir = tmp_path / "vault"
+        vault_dir.mkdir()  # empty — proves the read does not touch disk
+        monkeypatch.setenv("VAULT_ROOT", str(vault_dir))
+
+        mock_session = MagicMock()
+        with (
+            patch("knowledge.mcp.Session", return_value=mock_session),
+            patch("knowledge.mcp.get_engine"),
+            patch("knowledge.mcp.KnowledgeStore") as MockStore,
+        ):
+            MockStore.return_value.get_note_by_id.return_value = {
+                **SAMPLE_NOTE,
+                "content": "# From Postgres\n\nNo disk read needed.",
+            }
+            MockStore.return_value.get_note_links.return_value = []
+            result = await get_note("n1")
+
+        assert result["content"] == "# From Postgres\n\nNo disk read needed."
+        assert result["edges"] == []
+
+    @pytest.mark.asyncio
     async def test_missing_note_returns_error(self):
         mock_session = MagicMock()
         with (

--- a/projects/monolith/knowledge/notes.py
+++ b/projects/monolith/knowledge/notes.py
@@ -62,32 +62,52 @@ def _get_note_or_raise(session: Session, note_id: str) -> Note:
     return note
 
 
+def resolve_note_body(content: str | None, path: str, vault_root: Path) -> str | None:
+    """Resolve a note's markdown body, preferring Postgres ``content``.
+
+    ADR 006 Phase 2: ``knowledge.notes.content`` is the authoritative
+    body (frontmatter and the generated ``## Links`` section already
+    stripped by the reconciler). Legacy rows whose Phase 1 backfill has
+    not completed yet may still have ``content IS NULL``; for those, fall
+    back to reading the vault file and stripping its frontmatter. Returns
+    ``None`` when neither source yields a body (missing or path-escaping
+    file) so callers can 404.
+    """
+    if content is not None:
+        return content
+    try:
+        resolved = (vault_root / path).resolve()
+        if not resolved.is_relative_to(vault_root) or not resolved.is_file():
+            return None
+        raw = resolved.read_text()
+    except OSError:
+        return None
+    try:
+        _, body = frontmatter.parse(raw)
+    except frontmatter.FrontmatterError:
+        # Body still useful even if frontmatter is broken; fall back to raw.
+        body = raw
+    return body
+
+
 def _read_note_snippet(vault_root: Path, note: Note) -> str:
     """Return the first ~100 lines of ``note``'s body, capped at 8 KiB.
 
-    Reads the vault file and strips frontmatter. Missing / unreadable
-    files return an empty string — review-queue listing is best-effort
-    metadata and must never break on a partial vault. The line+byte cap
-    is sized to give the audit UI enough context to evaluate a note
-    in-place without surfacing the entire body.
+    Prefers the authoritative Postgres ``content`` (ADR 006 Phase 2) and
+    falls back to the vault file while any row's backfill is pending.
+    Missing / unreadable bodies return an empty string — review-queue
+    listing is best-effort metadata and must never break on a partial
+    vault. The line+byte cap is sized to give the audit UI enough context
+    to evaluate a note in-place without surfacing the entire body.
     """
-    try:
-        resolved = (vault_root / note.path).resolve()
-        if not resolved.is_relative_to(vault_root) or not resolved.is_file():
-            return ""
-        raw = resolved.read_text()
-    except OSError:
+    body = resolve_note_body(note.content, note.path, vault_root)
+    if body is None:
         logger.warning(
             "notes._read_note_snippet: failed to read %s for note_id=%r",
             note.path,
             note.note_id,
         )
         return ""
-    try:
-        _, body = frontmatter.parse(raw)
-    except frontmatter.FrontmatterError:
-        # Body still useful even if frontmatter is broken; fall back to raw.
-        body = raw
     head = "\n".join(body.lstrip().splitlines()[:_SNIPPET_MAX_LINES])
     # Byte cap as a backstop: a single very long line shouldn't blow
     # the payload past what the review UI can render comfortably.

--- a/projects/monolith/knowledge/notes_test.py
+++ b/projects/monolith/knowledge/notes_test.py
@@ -27,6 +27,7 @@ from knowledge.notes import (
     _serialize_frontmatter,
     _trash_filename,
     _write_note_visibility_frontmatter,
+    resolve_note_body,
 )
 
 
@@ -157,6 +158,48 @@ class TestReadNoteSnippet:
         (tmp_path / "plain.md").write_text("plain text\nno frontmatter\n")
         snippet = _read_note_snippet(tmp_path, note)
         assert "plain text" in snippet
+
+    def test_prefers_db_content_over_disk(self, tmp_path: Path) -> None:
+        """ADR 006 Phase 2: snippet comes from Postgres ``content``."""
+        note = _make_note(path="db.md")
+        note.content = "Body straight from Postgres."
+        # No file written — the snippet must still resolve from content.
+        snippet = _read_note_snippet(tmp_path, note)
+        assert "Body straight from Postgres." in snippet
+
+
+# ---------------------------------------------------------------------------
+# resolve_note_body
+# ---------------------------------------------------------------------------
+
+
+class TestResolveNoteBody:
+    def test_returns_content_when_present(self, tmp_path: Path) -> None:
+        # Disk holds something different to prove content wins.
+        (tmp_path / "n.md").write_text("from disk")
+        body = resolve_note_body("from postgres", "n.md", tmp_path)
+        assert body == "from postgres"
+
+    def test_falls_back_to_disk_when_content_none(self, tmp_path: Path) -> None:
+        (tmp_path / "n.md").write_text("---\nvisibility: public\n---\n\nfrom disk\n")
+        body = resolve_note_body(None, "n.md", tmp_path)
+        assert body is not None
+        assert "from disk" in body
+        assert "visibility" not in body  # frontmatter stripped on fallback
+
+    def test_returns_none_when_content_none_and_file_missing(
+        self, tmp_path: Path
+    ) -> None:
+        assert resolve_note_body(None, "ghost.md", tmp_path) is None
+
+    def test_returns_none_on_path_traversal(self, tmp_path: Path) -> None:
+        (tmp_path.parent / "escape.md").write_text("secret")
+        assert resolve_note_body(None, "../escape.md", tmp_path) is None
+
+    def test_empty_string_content_is_served(self, tmp_path: Path) -> None:
+        # An empty body is a valid value, not a reason to hit disk.
+        (tmp_path / "n.md").write_text("disk fallback should not run")
+        assert resolve_note_body("", "n.md", tmp_path) == ""
 
 
 # ---------------------------------------------------------------------------

--- a/projects/monolith/knowledge/router.py
+++ b/projects/monolith/knowledge/router.py
@@ -48,6 +48,7 @@ from knowledge.notes import (
     delete_note,
     list_notes_for_review,
     reset_note_visibility,
+    resolve_note_body,
     set_note_visibility,
     undelete_note,
     verify_note_visibility,
@@ -304,18 +305,17 @@ def get_public_note(
         logger.info("public.note.404 note_id=%s reason=%s", note_id, reason)
         raise HTTPException(status_code=404, detail="Not Found")
 
-    # Load the body from the vault. Reuse the same path-traversal guard
-    # the private GET /notes/{id} uses so a malformed path can't escape
-    # the vault root.
+    # ADR 006 Phase 2: body of record is Postgres ``content``. The vault
+    # read is a fallback only while the Phase 1 backfill is in flight, and
+    # ``resolve_note_body`` keeps the same path-traversal guard so a
+    # malformed path can't escape the vault root.
     vault_root = _get_vault_root()
-    resolved = (vault_root / note.path).resolve()
-    if not resolved.is_relative_to(vault_root) or not resolved.is_file():
+    body = resolve_note_body(note.content, note.path, vault_root)
+    if body is None:
         # Same identical 404 — don't leak that the DB row exists but
-        # the file is missing/escaped.
+        # the body is unavailable.
         logger.info("public.note.404 note_id=%s reason=vault_file_missing", note_id)
         raise HTTPException(status_code=404, detail="Not Found")
-    raw = resolved.read_text()
-    _, body = frontmatter.parse(raw)
 
     # Slugified ids of every non-public note. ``sanitize_public_body``
     # slugifies wikilink display text via ``visibility._slugify`` and
@@ -384,13 +384,15 @@ def get_knowledge_note(
     if note is None:
         raise HTTPException(status_code=404, detail="note not found")
 
+    # ADR 006 Phase 2: body of record is Postgres ``content``; the vault
+    # read is a fallback only while the Phase 1 backfill is in flight.
     vault_root = _get_vault_root()
-    resolved = (vault_root / note["path"]).resolve()
-    if not resolved.is_relative_to(vault_root) or not resolved.is_file():
+    body = resolve_note_body(note.get("content"), note["path"], vault_root)
+    if body is None:
         raise HTTPException(status_code=404, detail="vault file missing")
 
     edges = store.get_note_links(note_id)
-    return {**note, "content": resolved.read_text(), "edges": edges}
+    return {**note, "content": body, "edges": edges}
 
 
 @router.delete("/notes/{note_id}")

--- a/projects/monolith/knowledge/router_test.py
+++ b/projects/monolith/knowledge/router_test.py
@@ -230,6 +230,31 @@ class TestGetNoteEndpoint:
         assert body["tags"] == ["ml", "transformers"]
         assert body["content"] == "# Attention\n\nSelf-attention mechanism."
 
+    def test_serves_content_from_db_without_disk(
+        self, tmp_path, fake_session, monkeypatch
+    ):
+        """ADR 006 Phase 2: body is served from Postgres, no vault file."""
+        vault_dir = tmp_path / "vault"
+        vault_dir.mkdir()  # intentionally empty — no note file on disk
+        monkeypatch.setenv(VAULT_ROOT_ENV, str(vault_dir))
+
+        app.dependency_overrides[get_session] = lambda: fake_session
+        try:
+            c = TestClient(app, raise_server_exceptions=False)
+            with patch("knowledge.router.KnowledgeStore") as MockStore:
+                MockStore.return_value.get_note_by_id.return_value = {
+                    **SAMPLE_NOTE,
+                    "content": "# From Postgres\n\nNo disk read needed.",
+                }
+                MockStore.return_value.get_note_links.return_value = []
+                r = c.get("/api/knowledge/notes/n1")
+        finally:
+            app.dependency_overrides.clear()
+
+        assert r.status_code == 200
+        body = r.json()
+        assert body["content"] == "# From Postgres\n\nNo disk read needed."
+
     def test_missing_note_returns_404(self, note_client):
         """get_note_by_id returns None -> 404 'note not found'."""
         with patch("knowledge.router.KnowledgeStore") as MockStore:

--- a/projects/monolith/knowledge/store.py
+++ b/projects/monolith/knowledge/store.py
@@ -347,11 +347,13 @@ class KnowledgeStore:
         return results
 
     def get_note_by_id(self, note_id: str) -> dict | None:
-        """Fetch lightweight note metadata by stable ``note_id``.
+        """Fetch note metadata plus its body by stable ``note_id``.
 
-        Returns ``None`` if no note matches. Used by the knowledge search
-        overlay's preview pane (ADR 003) to resolve a selected result to
-        its displayable metadata without re-running the vector query.
+        Returns ``None`` if no note matches. Includes the authoritative
+        ``content`` (ADR 006) so note-detail readers can serve the body
+        from Postgres; ``content`` is ``None`` for rows whose Phase 1
+        backfill has not run yet, in which case callers fall back to the
+        vault file. Used by the note-detail and MCP ``get_note`` paths.
         """
         row = self.session.execute(
             select(
@@ -360,6 +362,7 @@ class KnowledgeStore:
                 Note.path,
                 Note.type,
                 Note.tags,
+                Note.content,
             )
             .where(Note.note_id == note_id)
             .where(Note.deleted_at.is_(None))
@@ -373,6 +376,7 @@ class KnowledgeStore:
             "path": row.path,
             "type": row.type,
             "tags": list(row.tags or []),
+            "content": row.content,
         }
 
     def get_graph(self) -> dict:

--- a/projects/monolith/knowledge/store_test.py
+++ b/projects/monolith/knowledge/store_test.py
@@ -88,6 +88,7 @@ def _upsert(
     metadata=None,
     n_chunks=1,
     links=None,
+    content=None,
 ):
     metadata = metadata or _meta(title=title)
     store.upsert_note(
@@ -99,6 +100,7 @@ def _upsert(
         chunks=_chunks(n_chunks),
         vectors=_vecs(n_chunks),
         links=links or [],
+        content=content,
     )
 
 
@@ -509,7 +511,22 @@ class TestGetNoteById:
             "path": "folder/note.md",
             "type": "paper",
             "tags": ["x"],
+            "content": None,
         }
+
+    def test_returns_content_when_set(self, store):
+        """ADR 006: get_note_by_id surfaces the authoritative body."""
+        _upsert(
+            store,
+            note_id="n2",
+            path="folder/n2.md",
+            title="With Body",
+            metadata=_meta(title="With Body"),
+            content="# Heading\n\nThe authoritative body.",
+        )
+        got = store.get_note_by_id("n2")
+        assert got is not None
+        assert got["content"] == "# Heading\n\nThe authoritative body."
 
     def test_returns_none_when_missing(self, store):
         assert store.get_note_by_id("nope") is None


### PR DESCRIPTION
## ADR 006, Phase 2: note reads off disk

Second phase of [ADR 006](https://github.com/jomcgi/homelab/blob/main/docs/decisions/platform/006-obsidian-decommission-postgres-interim.md) per the merged plan. Phase 1 (#2593) made `knowledge.notes.content` the authoritative body; this phase switches the **read paths** to serve from Postgres, keeping a disk fallback until the Phase 1 backfill nulls are gone.

### What changed
- **`store.get_note_by_id`** now selects and returns `content`.
- **New `knowledge.notes.resolve_note_body(content, path, vault_root)`** — prefers Postgres `content`, falls back to reading + frontmatter-stripping the vault file, sharing the path-traversal guard. Returns `None` when neither source yields a body so callers 404.
- **Readers migrated:** router `get_knowledge_note` + `get_public_note`, mcp `get_note`, and the review-queue snippet reader.

### Backward compatibility
Body-only content (frontmatter + `## Links` stripped) is safe: the frontend already strips both client-side (`renderNote`, `cleanNoteContent`), so the response-shape change is a no-op for rendering. No frontend change needed (UI rework is Phase 5).

### Scope note (deviation from plan)
The plan listed the two `edit_note` "reads" in Phase 2. They are deferred to **Phase 3** (write paths): `edit_note` is a read-modify-write that re-emits frontmatter, so migrating only its read half would leave a half-migrated edit path. Phase 3 owns the edit rewrite, so the whole flow moves together.

### Tests
Added DB-served coverage (router, mcp, snippet) and direct `resolve_note_body` unit tests (content wins, disk fallback strips frontmatter, missing/traversal -> None, empty-string body served not re-read). Existing tests pass unchanged via the fallback path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)