### PR TITLE
feat(monolith): index note edits into Postgres on write (ADR 006 Phase 3)

### DIFF
--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -1915,6 +1915,17 @@ py_test(
 )
 
 py_test(
+    name = "knowledge_indexing_test",
+    srcs = ["knowledge/indexing_test.py"],
+    imports = ["."],
+    deps = [
+        ":monolith_backend",
+        "@pip//pytest",
+        "@pip//pytest_asyncio",
+    ],
+)
+
+py_test(
     name = "knowledge_wikilinks_test",
     srcs = ["knowledge/wikilinks_test.py"],
     imports = ["."],

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.139.2
+version: 0.139.3
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.139.2
+      targetRevision: 0.139.3
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/knowledge/indexing.py
+++ b/projects/monolith/knowledge/indexing.py
@@ -1,0 +1,125 @@
+"""Shared note-indexing pipeline (ADR 006 Phase 3).
+
+Chunk + embed + link-extract + upsert for a note body. Lifted out of the
+reconciler so the create/edit write paths can index synchronously into
+Postgres on every write, rather than waiting for the reconciler's next
+vault scan. The reconciler calls :func:`index_parsed_note` for its
+normal-note branch so both paths share one code path and cannot drift.
+
+The body of record is ``knowledge.notes.content``; chunks + embeddings
+back pgvector search. ``upsert_note`` persists all of it in one committed
+transaction, so a successful call leaves the note fully indexed.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+from pathlib import Path
+from typing import Protocol
+
+from knowledge import frontmatter, links, wikilinks
+from knowledge.frontmatter import ParsedFrontmatter
+from knowledge.store import KnowledgeStore
+from shared.chunker import chunk_markdown
+
+logger = logging.getLogger(__name__)
+
+
+class _Embedder(Protocol):
+    async def embed_batch(self, texts: list[str]) -> list[list[float]]: ...
+
+
+async def index_parsed_note(
+    store: KnowledgeStore,
+    embed_client: _Embedder,
+    *,
+    note_id: str,
+    rel_path: str,
+    content_hash: str,
+    title: str,
+    meta: ParsedFrontmatter,
+    authored_body: str,
+) -> None:
+    """Chunk, embed, extract links, and upsert a non-gap note.
+
+    ``authored_body`` must already have the generated ``## Links`` section
+    stripped (the reconciler does this before calling). Mirrors the
+    reconciler's normal-note indexing exactly; gap stubs are handled by the
+    reconciler's own branch and never reach here.
+    """
+    chunks = chunk_markdown(authored_body)
+    if not chunks:
+        chunks = [{"index": 0, "section_header": "", "text": authored_body or title}]
+    vectors = await embed_client.embed_batch([c["text"] for c in chunks])
+    note_links = links.extract(authored_body)
+    store.upsert_note(
+        note_id=note_id,
+        path=rel_path,
+        content_hash=content_hash,
+        title=title,
+        metadata=meta,
+        chunks=chunks,
+        vectors=vectors,
+        links=note_links,
+        content=authored_body,
+    )
+
+
+async def index_note_from_raw(
+    store: KnowledgeStore,
+    embed_client: _Embedder,
+    *,
+    note_id: str,
+    rel_path: str,
+    raw: str,
+) -> None:
+    """Parse a raw markdown file and index it under ``note_id``.
+
+    Used by the write paths, which already hold the full file content and
+    a stable ``note_id`` (the existing id for edits, the collision-resolved
+    filename stem for creates). Computes the content hash from ``raw`` so it
+    matches what the reconciler would compute for the same bytes on disk.
+    """
+    meta, body = frontmatter.parse(raw)
+    title = meta.title or Path(rel_path).stem
+    content_hash = hashlib.sha256(raw.encode("utf-8")).hexdigest()
+    authored_body = wikilinks.strip_links_section(body)
+    await index_parsed_note(
+        store,
+        embed_client,
+        note_id=note_id,
+        rel_path=rel_path,
+        content_hash=content_hash,
+        title=title,
+        meta=meta,
+        authored_body=authored_body,
+    )
+
+
+async def index_note_best_effort(
+    store: KnowledgeStore,
+    embed_client: _Embedder,
+    *,
+    note_id: str,
+    rel_path: str,
+    raw: str,
+) -> bool:
+    """Index on a write path, swallowing failures.
+
+    Returns ``True`` on success. On any error (e.g. the embedder being
+    unreachable) it logs and returns ``False``: the disk file is already
+    written, so the reconciler will index it on its next scan. A flaky
+    embedder must never fail a user's save.
+    """
+    try:
+        await index_note_from_raw(
+            store, embed_client, note_id=note_id, rel_path=rel_path, raw=raw
+        )
+        return True
+    except Exception:  # noqa: BLE001 — best-effort; reconciler is the fallback
+        logger.exception(
+            "knowledge: synchronous index failed for %s; reconciler will retry",
+            rel_path,
+        )
+        return False

--- a/projects/monolith/knowledge/indexing_test.py
+++ b/projects/monolith/knowledge/indexing_test.py
@@ -1,0 +1,115 @@
+"""Unit tests for knowledge.indexing (ADR 006 Phase 3).
+
+The shared chunk/embed/upsert pipeline used by both the reconciler and the
+write paths. Store + embedder are mocked; chunking, link extraction, and
+frontmatter parsing run for real.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from knowledge.frontmatter import ParsedFrontmatter
+from knowledge.indexing import (
+    index_note_best_effort,
+    index_note_from_raw,
+    index_parsed_note,
+)
+
+
+def _embed() -> AsyncMock:
+    client = AsyncMock()
+    client.embed_batch.side_effect = lambda texts: [[0.1] * 1024 for _ in texts]
+    return client
+
+
+class TestIndexParsedNote:
+    @pytest.mark.asyncio
+    async def test_embeds_chunks_and_upserts_with_body(self):
+        store = MagicMock()
+        embed = _embed()
+        meta = ParsedFrontmatter(title="My Note")
+        await index_parsed_note(
+            store,
+            embed,
+            note_id="my-note",
+            rel_path="_processed/my-note.md",
+            content_hash="h1",
+            title="My Note",
+            meta=meta,
+            authored_body="# Heading\n\nBody text.",
+        )
+        embed.embed_batch.assert_awaited_once()
+        store.upsert_note.assert_called_once()
+        kwargs = store.upsert_note.call_args.kwargs
+        assert kwargs["note_id"] == "my-note"
+        assert kwargs["content"] == "# Heading\n\nBody text."
+        assert kwargs["content_hash"] == "h1"
+        # One vector per chunk.
+        assert len(kwargs["vectors"]) == len(kwargs["chunks"])
+
+    @pytest.mark.asyncio
+    async def test_empty_body_still_embeds_one_chunk(self):
+        store = MagicMock()
+        embed = _embed()
+        await index_parsed_note(
+            store,
+            embed,
+            note_id="empty",
+            rel_path="empty.md",
+            content_hash="h",
+            title="Empty",
+            meta=ParsedFrontmatter(title="Empty"),
+            authored_body="",
+        )
+        kwargs = store.upsert_note.call_args.kwargs
+        # Falls back to a single chunk seeded with the title so search has
+        # something to match and the row is never chunk-less.
+        assert len(kwargs["chunks"]) == 1
+        assert kwargs["chunks"][0]["text"] == "Empty"
+
+
+class TestIndexNoteFromRaw:
+    @pytest.mark.asyncio
+    async def test_parses_strips_and_hashes(self):
+        store = MagicMock()
+        embed = _embed()
+        raw = "---\nid: my-note\ntitle: My Note\n---\n\n# Heading\n\nBody text.\n"
+        await index_note_from_raw(
+            store, embed, note_id="my-note", rel_path="_processed/my-note.md", raw=raw
+        )
+        kwargs = store.upsert_note.call_args.kwargs
+        assert kwargs["note_id"] == "my-note"
+        assert kwargs["content_hash"] == hashlib.sha256(raw.encode("utf-8")).hexdigest()
+        # Frontmatter stripped from the stored body.
+        assert "title:" not in kwargs["content"]
+        assert "Body text." in kwargs["content"]
+
+
+class TestIndexNoteBestEffort:
+    @pytest.mark.asyncio
+    async def test_returns_true_and_indexes_on_success(self):
+        store = MagicMock()
+        embed = _embed()
+        raw = "---\nid: n\ntitle: N\n---\n\nbody\n"
+        ok = await index_note_best_effort(
+            store, embed, note_id="n", rel_path="n.md", raw=raw
+        )
+        assert ok is True
+        store.upsert_note.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_swallows_embed_failure_and_returns_false(self):
+        store = MagicMock()
+        embed = AsyncMock()
+        embed.embed_batch.side_effect = RuntimeError("embedder down")
+        raw = "---\nid: n\ntitle: N\n---\n\nbody\n"
+        # Must not raise — a flaky embedder cannot fail a user's save.
+        ok = await index_note_best_effort(
+            store, embed, note_id="n", rel_path="n.md", raw=raw
+        )
+        assert ok is False
+        store.upsert_note.assert_not_called()

--- a/projects/monolith/knowledge/mcp.py
+++ b/projects/monolith/knowledge/mcp.py
@@ -24,6 +24,7 @@ from knowledge.gaps import answer_gap as _answer_gap
 from knowledge.gaps import approve_gap as _approve_gap
 from knowledge.gaps import list_review_queue, split_csv
 from knowledge.gardener import _slugify
+from knowledge.indexing import index_note_best_effort
 from knowledge.notes import resolve_note_body
 from knowledge.service import DEFAULT_VAULT_ROOT, VAULT_ROOT_ENV
 from knowledge.store import KnowledgeStore
@@ -238,6 +239,15 @@ async def edit_note(
             "---\n" + yaml.dump(fm_dict, default_flow_style=False) + "---\n" + body
         )
         resolved.write_text(file_content)
+        # ADR 006 Phase 3: re-index synchronously into Postgres; the disk
+        # write above is the safety net.
+        await index_note_best_effort(
+            store,
+            EmbeddingClient(),
+            note_id=note_id,
+            rel_path=note["path"],
+            raw=file_content,
+        )
         return {"path": note["path"], "note_id": note_id}
 
 

--- a/projects/monolith/knowledge/mcp_test.py
+++ b/projects/monolith/knowledge/mcp_test.py
@@ -296,6 +296,7 @@ class TestEditNoteTool:
         with (
             patch("knowledge.mcp.Session", return_value=mock_session),
             patch("knowledge.mcp.get_engine"),
+            patch("knowledge.mcp.EmbeddingClient", return_value=AsyncMock()),
             patch("knowledge.mcp.KnowledgeStore") as MockStore,
         ):
             MockStore.return_value.get_note_by_id.return_value = SAMPLE_NOTE
@@ -306,6 +307,33 @@ class TestEditNoteTool:
         assert "title: Updated Title" in text
         assert "New body" in text
         assert "Old body" not in text
+
+    @pytest.mark.asyncio
+    async def test_reindexes_into_postgres(self, tmp_path, monkeypatch):
+        """ADR 006 Phase 3: an edit re-indexes synchronously via upsert_note."""
+        vault_dir = tmp_path / "vault"
+        vault_dir.mkdir()
+        note_file = vault_dir / "papers" / "attention.md"
+        note_file.parent.mkdir(parents=True)
+        note_file.write_text("---\nid: n1\ntitle: Original\n---\nOld body")
+        monkeypatch.setenv("VAULT_ROOT", str(vault_dir))
+
+        embed = AsyncMock()
+        embed.embed_batch.side_effect = lambda texts: [[0.1] * 1024 for _ in texts]
+        mock_session = MagicMock()
+        with (
+            patch("knowledge.mcp.Session", return_value=mock_session),
+            patch("knowledge.mcp.get_engine"),
+            patch("knowledge.mcp.EmbeddingClient", return_value=embed),
+            patch("knowledge.mcp.KnowledgeStore") as MockStore,
+        ):
+            MockStore.return_value.get_note_by_id.return_value = SAMPLE_NOTE
+            await edit_note("n1", content="Fresh body")
+
+        MockStore.return_value.upsert_note.assert_called_once()
+        kwargs = MockStore.return_value.upsert_note.call_args.kwargs
+        assert kwargs["note_id"] == "n1"
+        assert "Fresh body" in kwargs["content"]
 
     @pytest.mark.asyncio
     async def test_not_found_returns_error(self):
@@ -363,6 +391,7 @@ class TestEditNoteTool:
         with (
             patch("knowledge.mcp.Session", return_value=mock_session),
             patch("knowledge.mcp.get_engine"),
+            patch("knowledge.mcp.EmbeddingClient", return_value=AsyncMock()),
             patch("knowledge.mcp.KnowledgeStore") as MockStore,
         ):
             MockStore.return_value.get_note_by_id.return_value = SAMPLE_NOTE
@@ -387,6 +416,7 @@ class TestEditNoteTool:
         with (
             patch("knowledge.mcp.Session", return_value=mock_session),
             patch("knowledge.mcp.get_engine"),
+            patch("knowledge.mcp.EmbeddingClient", return_value=AsyncMock()),
             patch("knowledge.mcp.KnowledgeStore") as MockStore,
         ):
             MockStore.return_value.get_note_by_id.return_value = SAMPLE_NOTE

--- a/projects/monolith/knowledge/notes_crud_test.py
+++ b/projects/monolith/knowledge/notes_crud_test.py
@@ -1,7 +1,7 @@
 """Unit tests for knowledge notes CRUD endpoints."""
 
 from datetime import datetime, timezone
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 import yaml
@@ -12,6 +12,7 @@ from sqlmodel.pool import StaticPool
 from app.db import get_session
 from app.main import app
 from knowledge.models import Note
+from knowledge.router import get_embedding_client
 from knowledge.service import VAULT_ROOT_ENV
 
 
@@ -21,10 +22,23 @@ def fake_session():
 
 
 @pytest.fixture()
-def client(fake_session, tmp_path, monkeypatch):
-    """TestClient with overridden session and a temp vault root."""
+def fake_embed_client():
+    """Embedding client whose embed_batch returns deterministic vectors.
+
+    ADR 006 Phase 3: edit_note re-indexes synchronously, so the write-path
+    tests need the embedder overridden to avoid a real network call.
+    """
+    client = AsyncMock()
+    client.embed_batch.side_effect = lambda texts: [[0.1] * 1024 for _ in texts]
+    return client
+
+
+@pytest.fixture()
+def client(fake_session, fake_embed_client, tmp_path, monkeypatch):
+    """TestClient with overridden session, embedder, and a temp vault root."""
     monkeypatch.setenv(VAULT_ROOT_ENV, str(tmp_path))
     app.dependency_overrides[get_session] = lambda: fake_session
+    app.dependency_overrides[get_embedding_client] = lambda: fake_embed_client
     yield TestClient(app, raise_server_exceptions=False)
     app.dependency_overrides.clear()
 
@@ -59,10 +73,11 @@ def real_session():
 
 
 @pytest.fixture()
-def db_client(real_session, tmp_path, monkeypatch):
+def db_client(real_session, fake_embed_client, tmp_path, monkeypatch):
     """TestClient backed by a real session — used by the soft-delete tests."""
     monkeypatch.setenv(VAULT_ROOT_ENV, str(tmp_path))
     app.dependency_overrides[get_session] = lambda: real_session
+    app.dependency_overrides[get_embedding_client] = lambda: fake_embed_client
     yield TestClient(app, raise_server_exceptions=False)
     app.dependency_overrides.clear()
 

--- a/projects/monolith/knowledge/reconciler.py
+++ b/projects/monolith/knowledge/reconciler.py
@@ -15,11 +15,11 @@ from typing import Protocol
 from sqlalchemy import text
 from sqlmodel import Session, select
 
-from knowledge import frontmatter, links, wikilinks
+from knowledge import frontmatter, wikilinks
 from knowledge.frontmatter import FrontmatterError, ParsedFrontmatter
+from knowledge.indexing import index_parsed_note
 from knowledge.models import Gap
 from knowledge.store import KnowledgeStore
-from shared.chunker import chunk_markdown
 
 logger = logging.getLogger("monolith.knowledge.reconciler")
 
@@ -375,24 +375,17 @@ class Reconciler:
                     "knowledge: vault read-only, skipping links sync for %s", rel_path
                 )
 
-        chunks = chunk_markdown(authored_body)
-        if not chunks:
-            chunks = [
-                {"index": 0, "section_header": "", "text": authored_body or title}
-            ]
-        vectors = await self.embed_client.embed_batch([c["text"] for c in chunks])
-        note_links = links.extract(authored_body)
-
-        self.store.upsert_note(
+        # ADR 006 Phase 3: the chunk/embed/upsert step is shared with the
+        # write paths via knowledge.indexing so both index identically.
+        await index_parsed_note(
+            self.store,
+            self.embed_client,
             note_id=note_id,
-            path=rel_path,
+            rel_path=rel_path,
             content_hash=content_hash,
             title=title,
-            metadata=meta,
-            chunks=chunks,
-            vectors=vectors,
-            links=note_links,
-            content=authored_body,
+            meta=meta,
+            authored_body=authored_body,
         )
         return True
 

--- a/projects/monolith/knowledge/router.py
+++ b/projects/monolith/knowledge/router.py
@@ -41,6 +41,7 @@ from knowledge.gaps import (
     verify_gap,
 )
 from knowledge.gardener import Gardener, _slugify
+from knowledge.indexing import index_note_best_effort
 from knowledge.ingest_queue import IngestQueueItem
 from knowledge.models import AtomRawProvenance, Note, NoteLink, RawInput
 from knowledge.notes import (
@@ -443,12 +444,13 @@ def undelete_note_endpoint(
 
 
 @router.put("/notes/{note_id}")
-def edit_note(
+async def edit_note(
     note_id: str,
     data: EditNoteRequest,
     session: Session = Depends(get_session),
+    embed_client: EmbeddingClient = Depends(get_embedding_client),
 ) -> dict:
-    """Update an existing note's frontmatter and/or body in the vault."""
+    """Update an existing note's frontmatter and/or body, then re-index."""
     store = KnowledgeStore(session)
     note = store.get_note_by_id(note_id)
     if note is None:
@@ -502,6 +504,15 @@ def edit_note(
         file_content
     )  # nosemgrep: tainted-path-traversal-stdlib-fastapi (guarded by is_relative_to check above)
 
+    # ADR 006 Phase 3: re-index synchronously so the edit is searchable and
+    # the body of record is current. Disk write above is the safety net.
+    await index_note_best_effort(
+        store,
+        embed_client,
+        note_id=note_id,
+        rel_path=note["path"],
+        raw=file_content,
+    )
     return {"path": note["path"], "note_id": note_id}
 
 
@@ -539,7 +550,16 @@ class CreateNoteRequest(BaseModel):
 
 @router.post("/notes", status_code=201)
 def create_note(data: CreateNoteRequest) -> dict:
-    """Create a new markdown note in the vault with YAML frontmatter."""
+    """Capture a new markdown note as a vault-root drop.
+
+    This is a capture path, not direct graph-note creation: the drop is
+    swept into ``_raw/`` by ``raw_ingest`` and decomposed into ``_processed``
+    atoms by the gardener, so its content reaches Postgres via
+    ``raw_inputs`` (and the resulting atoms via the reconciler). It is
+    therefore intentionally NOT indexed into ``knowledge.notes`` here — only
+    ``edit_note``, which mutates an existing ``_processed`` note, indexes
+    synchronously (ADR 006 Phase 3).
+    """
     content = data.content.strip()
     if not content:
         raise HTTPException(status_code=400, detail="content must not be empty")


### PR DESCRIPTION
## ADR 006, Phase 3: write paths index into Postgres

Builds on Phase 1 (#2593, body column) and Phase 2 (#2604, reads off disk). This phase makes **edits index synchronously into Postgres** so a change is searchable and the body of record is current immediately, instead of waiting for the reconciler's next vault scan.

### What changed
- **New `knowledge/indexing.py`** — `index_parsed_note` (chunk + embed + link-extract + upsert) and `index_note_from_raw`, plus `index_note_best_effort` which swallows embedder failures so a flaky embedder never fails a user's save (the reconciler stays the fallback indexer).
- **Reconciler refactor** — `_ingest_one`'s normal-note branch now calls `index_parsed_note`, so the reconciler and the write paths share one code path and can't drift. Gap-stub handling and link sync stay in the reconciler.
- **`router.edit_note` + `mcp.edit_note`** — re-index synchronously after the disk dual-write (the disk file remains the Obsidian/reconciler safety net through Phase 5). Both endpoints are now `async`.

### Scope decision: create vs edit
`create_note` is **intentionally not indexed here**. It is a vault-root *capture* swept into `_raw/` by `raw_ingest` and decomposed into `_processed/` atoms by the gardener, so its content already reaches Postgres via `raw_inputs`. Directly indexing it would create a phantom `knowledge.notes` row with an immediately-stale path that duplicates the gardener's atoms. `delete_note` is already DB-driven (soft-delete).

### Resilience
`upsert_note` commits atomically; `index_note_best_effort` catches embedder failures, logs, and returns False, leaving the disk file for the reconciler to index later (i.e. today's behavior). A save never fails on a flaky embedder.

### Tests
New `knowledge_indexing_test` target (unit tests for all three indexing fns incl. the embedder-failure path). mcp + notes_crud edit tests override the embedder to avoid real network calls and assert the re-index `upsert_note`. Reconciler tests unchanged (the shared fn re-raises, preserving the rollback-on-embed-failure behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)