### PR TITLE
feat(stars): history CERRA-only, slimmer payload, year-long cache, live markers-only

### DIFF
--- a/docs/decisions/services/008-stars-live-historical-heatmaps.md
+++ b/docs/decisions/services/008-stars-live-historical-heatmaps.md
@@ -1,9 +1,18 @@
 # ADR 008: Stars live and historical heatmaps via month-bucketed accumulate-at-drop
 
 **Author:** Joe McGinley
-**Status:** Accepted
+**Status:** Superseded (in part) by [009-stars-era5-climatology-backfill](009-stars-era5-climatology-backfill.md)
 **Created:** 2026-06-13
 **Supersedes:** the heatmap section of [007-stars-quality-model-and-heatmap](007-stars-quality-model-and-heatmap.md) (its quality model `Q = D x C x W` still stands)
+
+> **Status note (superseded in part):** the live bank-at-prune accumulator
+> (`stars.site_month_stats`) described below has been retired. The ERA5/CERRA
+> climatology backfill (ADR 009) gives a complete, immediate multi-year seasonal
+> picture, which made the slow-filling live accumulator redundant: the historical
+> layer now reads `stars.site_month_climatology` alone, the `site_month_stats`
+> table is dropped, and the hourly prune only deletes elapsed forecast hours (it
+> no longer banks). The two-layer live/historical UX and the clear-dark metric
+> below are unchanged; only the source of the historical counts moved.
 
 ---
 

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.137.0
+version: 0.138.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/migrations/20260615000010_stars_drop_site_month_stats.sql
+++ b/projects/monolith/chart/migrations/20260615000010_stars_drop_site_month_stats.sql
@@ -1,0 +1,5 @@
+-- Stars v2 cleanup: retire the live bank-at-prune accumulator. The historical
+-- layer now comes entirely from stars.site_month_climatology (ERA5/CERRA
+-- backfill, ADR 009), so the per-site live accumulator is redundant and the
+-- prune only deletes elapsed forecast hours. Drop the now-unused table.
+DROP TABLE IF EXISTS stars.site_month_stats;

--- a/projects/monolith/chart/migrations/atlas.sum
+++ b/projects/monolith/chart/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:0EJS5CiHFZLjUzdF6Fvsl/pfO9dpur8GrfymRgcZFmo=
+h1:OA4TEb5ZpudpbthRU2ToB3SPF+TfYipmdzkFJS6lP0s=
 20260330000000_initial_schema.sql h1:J2futpSW0nJAIRR7nR7ssT7LwXIYrvRI+PkHb5Y4tLI=
 20260403000000_chat_schema.sql h1:pERUFC0vzM95etRuzp43XzkCV7lBCzrrtY5Mk7aF3CA=
 20260404000000_chat_attachments.sql h1:tv+Fdbr1rQC5nzUxfaBC0O6fu2OMGgLWf+YNg1WQXi4=
@@ -42,3 +42,4 @@ h1:0EJS5CiHFZLjUzdF6Fvsl/pfO9dpur8GrfymRgcZFmo=
 20260614120000_chat_blobs_data_nullable.sql h1:8FJeODc17x+BerRkKiHoq7HqUywCu3bGcDjQuUe/vVM=
 20260614130000_chat_blobs_drop_data.sql h1:5Aoo3uIAYRlX5xnYs2FLN5NSVhfA8aJ15eojlOjrwj0=
 20260614140000_ships_heat_cells_historical.sql h1:JeK7W/HdlkWzbX6/pX8CcougHAPZ9KVtcYM8iuk4H8w=
+20260615000010_stars_drop_site_month_stats.sql h1:gxTQRiohpF7zxz/WGiqv+aLKg2T4ZJK7Kf+vgYmtEMI=

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.137.0
+      targetRevision: 0.138.0
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/lib/cache-headers.js
+++ b/projects/monolith/frontend/src/lib/cache-headers.js
@@ -45,10 +45,11 @@ export const HIKES_WALKS_CACHE_CONTROL =
 export const STARS_SITES_CACHE_CONTROL =
   "public, max-age=0, s-maxage=1800, stale-while-revalidate=3600, stale-if-error=86400";
 
-// /app/stars history: per-month accumulated stats, banked by the hourly prune.
-// The numbers only grow as hours elapse, so the same 30 min fresh / 1 h SWR
-// window the live sites use is plenty. The history endpoint in router.py reuses
-// _SITES_CACHE_CONTROL, so this is the byte-for-byte same string; kept as its
-// own constant so the proxy reads intentionally and the two can diverge later.
+// /app/stars history (the bulk month layer and the per-site 12-month breakdown):
+// immutable between reloads, the bytes change only when the ~yearly ERA5/CERRA
+// climatology reload runs (ADR 009), whose runbook purges the Cloudflare cache
+// for /app/stars/history* right after. So cache it at the edge for a year and
+// invalidate explicitly. Mirrors _HISTORY_CACHE_CONTROL in
+// projects/monolith/stars/router.py, keep in sync.
 export const STARS_HISTORY_CACHE_CONTROL =
-  "public, max-age=0, s-maxage=1800, stale-while-revalidate=3600, stale-if-error=86400";
+  "public, max-age=0, s-maxage=31536000, stale-while-revalidate=604800, stale-if-error=604800";

--- a/projects/monolith/frontend/src/lib/public/components/stars/StarsMap.svelte
+++ b/projects/monolith/frontend/src/lib/public/components/stars/StarsMap.svelte
@@ -5,9 +5,11 @@
 
   // `sites` is the list to plot; clicking a dot opens the detail card. In LIVE
   // mode the rows carry per-night scores + upcoming clear-dark hours; in
-  // HISTORICAL mode they carry banked clear-dark-hour counts (clear_dark_hours /
-  // dark_hours / clear_rate) plus a per-month {1..12} breakdown for the card
-  // graph (stars v2 metric).
+  // HISTORICAL mode they carry clear-dark-hour counts (clear_dark_hours /
+  // dark_hours / clear_rate) for the selected view. The per-month {1..12}
+  // breakdown for the card graph is no longer in the bulk payload: it is fetched
+  // lazily per site from /app/stars/history/site/{id} when a history card opens
+  // (stars v2 metric).
   // `activeNights` is the set of selected night keys from the parent's night
   // filter (LIVE only): a marker is coloured by the best score it reaches across
   // those nights, and drops off the map when none of its hours fall on a
@@ -98,6 +100,37 @@
   const index = new Map();
 
   let selected = $state(null); // selected site row, or null
+
+  // Historical per-site month breakdown, fetched lazily when a history card opens
+  // (the bulk /history payload no longer carries the per-month map). Cached per
+  // site id so re-opening a card is instant. `cardMonths` is the {1..12} map for
+  // the currently open site; null means none open or the fetch is in flight,
+  // which the card renders as a tiny loading state.
+  const monthsCache = new Map();
+  let cardMonths = $state(null);
+
+  async function loadSiteMonths(siteId) {
+    if (monthsCache.has(siteId)) {
+      cardMonths = monthsCache.get(siteId);
+      return;
+    }
+    cardMonths = null;
+    try {
+      const res = await fetch(
+        `/app/stars/history/site/${encodeURIComponent(siteId)}`,
+      );
+      if (!res.ok) throw new Error(`history site ${res.status}`);
+      const payload = await res.json();
+      const months = payload?.months ?? {};
+      monthsCache.set(siteId, months);
+      // Only apply if the card has not moved to another site meanwhile.
+      if (selected && selected.id === siteId) cardMonths = months;
+    } catch {
+      // Fall back to an empty map so the chart renders as all-zero rather than
+      // hanging on the loading state.
+      if (selected && selected.id === siteId) cardMonths = {};
+    }
+  }
 
   // The legend follows what is actually drawn. The field is always a relative
   // clear-dark-hour percentile, so it reads low/medium/high either way: the cell
@@ -391,6 +424,17 @@
     if (map && layerReady) applyHeatVisibility();
   });
 
+  // Lazy-load the open historical card's 12-month breakdown. Reads selected.id +
+  // mode; does not read the cardMonths state it writes, so there is no loop.
+  $effect(() => {
+    const id = selected?.id;
+    if (mode === "historical" && id) {
+      loadSiteMonths(id);
+    } else {
+      cardMonths = null;
+    }
+  });
+
   onMount(() => {
     let cleanup = () => {};
     let destroyed = false;
@@ -559,46 +603,53 @@
           </div>
         </dl>
 
-        {@const bars = monthBars(selected.months)}
         <p class="eyebrow card-windows-title">Clear dark hours by month</p>
-        <!-- Inline SVG bar chart (no charting dep): one bar per month-of-year,
-             height relative to the busiest month, the tallest bar(s) accented
-             and value-labelled. viewBox does the scaling so the CSS width keeps
-             it crisp. Mono labels + 2px ink strokes mirror the card chrome. -->
-        <svg
-          class="month-chart"
-          viewBox="0 0 264 112"
-          preserveAspectRatio="xMidYMid meet"
-          role="img"
-          aria-label="Clear dark hours for each month of the year"
-        >
-          <line x1="6" y1="86" x2="258" y2="86" class="chart-axis" />
-          {#each bars as bar (bar.month)}
-            {@const bw = 16}
-            {@const x = 8 + (bar.month - 1) * 20.8}
-            {@const h = bar.value > 0 ? Math.max(2, Math.round(bar.frac * 70)) : 0}
-            {#if h > 0}
-              <rect
-                {x}
-                y={86 - h}
-                width={bw}
-                height={h}
-                class="chart-bar"
-                class:is-max={bar.isMax}
-              />
-            {/if}
-            {#if bar.isMax && bar.value > 0}
-              <text x={x + bw / 2} y={86 - h - 4} class="chart-val"
-                >{bar.value}</text
+        {#if cardMonths}
+          {@const bars = monthBars(cardMonths)}
+          <!-- Inline SVG bar chart (no charting dep): one bar per month-of-year,
+               height relative to the busiest month, the tallest bar(s) accented
+               and value-labelled. viewBox does the scaling so the CSS width keeps
+               it crisp. Mono labels + 2px ink strokes mirror the card chrome. The
+               per-month data is lazy-fetched per site (cardMonths). -->
+          <svg
+            class="month-chart"
+            viewBox="0 0 264 112"
+            preserveAspectRatio="xMidYMid meet"
+            role="img"
+            aria-label="Clear dark hours for each month of the year"
+          >
+            <line x1="6" y1="86" x2="258" y2="86" class="chart-axis" />
+            {#each bars as bar (bar.month)}
+              {@const bw = 16}
+              {@const x = 8 + (bar.month - 1) * 20.8}
+              {@const h =
+                bar.value > 0 ? Math.max(2, Math.round(bar.frac * 70)) : 0}
+              {#if h > 0}
+                <rect
+                  {x}
+                  y={86 - h}
+                  width={bw}
+                  height={h}
+                  class="chart-bar"
+                  class:is-max={bar.isMax}
+                />
+              {/if}
+              {#if bar.isMax && bar.value > 0}
+                <text x={x + bw / 2} y={86 - h - 4} class="chart-val"
+                  >{bar.value}</text
+                >
+              {/if}
+              <text x={x + bw / 2} y={100} class="chart-tick">{bar.short[0]}</text
               >
-            {/if}
-            <text x={x + bw / 2} y={100} class="chart-tick">{bar.short[0]}</text>
-          {/each}
-        </svg>
+            {/each}
+          </svg>
+        {:else}
+          <p class="chart-loading">Loading monthly breakdown&hellip;</p>
+        {/if}
         <p class="card-empty">
-          Hours with the sun below -12 deg and under 10% cloud, banked as forecast
-          hours elapse and seeded from the ERA5 seasonal baseline. Taller bars are
-          the months this spot clears most.
+          Hours with the sun below -12 deg and under 10% cloud, from the ERA5
+          reanalysis seasonal baseline. Taller bars are the months this spot
+          clears most.
         </p>
       {:else}
         <dl class="card-stats">
@@ -884,6 +935,14 @@
     line-height: 1.5;
     color: var(--ink-3);
     margin-bottom: 14px;
+  }
+
+  /* Tiny loading line while the lazy per-site month breakdown fetches. */
+  .chart-loading {
+    font-family: var(--mono);
+    font-size: 11px;
+    color: var(--ink-3);
+    margin: 4px 0 12px;
   }
 
   .card-link {

--- a/projects/monolith/frontend/src/routes/public/app/stars/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/stars/+page.svelte
@@ -9,17 +9,15 @@
   let sites = $derived(data.snapshot?.sites ?? []);
   let count = $derived(data.snapshot?.count ?? 0);
 
-  // Mode: LIVE = the upcoming-forecast layer (per-night quality); HISTORICAL =
-  // the month-bucketed clear-dark-hours layer (stars v2). The toggle swaps the
-  // map's data source, the time control (night picker vs month picker), and the
-  // heat field StarsMap weights by.
+  // Mode: LIVE = the upcoming-forecast layer (per-night quality), markers only;
+  // HISTORICAL = the month-bucketed clear-dark-hours layer (stars v2), the
+  // box-cell heatmap. The toggle swaps the map's data source, the time control
+  // (night picker vs month picker), and whether the box-cell heatmap shows.
   let mode = $state("live");
 
-  // Heat layer: in LIVE it is an optional overlay (markers-first by default, the
-  // shipped look), so it is off until toggled; in HISTORICAL it is the point of
-  // the layer, so it is always on. StarsMap reads the resolved value.
-  let showHeat = $state(false);
-  let heatOn = $derived(mode === "historical" ? true : showHeat);
+  // The box-cell heatmap belongs to the historical layer only: LIVE is always
+  // markers, HISTORICAL is always the heatmap. StarsMap reads this resolved flag.
+  let heatOn = $derived(mode === "historical");
 
   // Night picker (LIVE): "I'm free Saturday, show me the map for Saturday night."
   // One chip per viewing night plus an "All" reset; picking a night filters the
@@ -128,7 +126,6 @@
   function setMode(next) {
     if (next === mode) return;
     mode = next;
-    if (next === "live") showHeat = false; // back to markers-first live default
   }
 
   // The site set the map plots: live snapshot, or the loaded month's sites.
@@ -248,18 +245,6 @@
     </div>
 
     {#if mode === "live"}
-      <!-- Heat overlay switch (live only): historical forces heat on. -->
-      <button
-        type="button"
-        class="panel heat-switch"
-        class:is-on={showHeat}
-        aria-pressed={showHeat}
-        onclick={() => (showHeat = !showHeat)}
-      >
-        <span class="heat-label">Heatmap</span>
-        <span class="heat-state">{showHeat ? "On" : "Off"}</span>
-      </button>
-
       {#if nights.length > 1}
         <div class="panel night-filter">
           <button
@@ -364,9 +349,8 @@
         </div>
       {:else if histReady && histCount === 0}
         <div class="panel empty-state" role="status">
-          No clear dark hours {historyScope} yet. The seasonal baseline fills from
-          the ERA5 backfill, and live clear-dark hours bank as forecast hours
-          elapse.
+          No clear dark hours {historyScope}. The seasonal baseline comes from the
+          ERA5 reanalysis backfill.
         </div>
       {/if}
     {/if}
@@ -522,42 +506,6 @@
   .seg:not(.is-active):hover,
   .seg:not(.is-active):focus-visible {
     background: var(--cream);
-  }
-
-  /* Heat switch: a single full-width pill mirroring the filter toggle row; fills
-     accent when on so it reads as engaged. */
-  .heat-switch {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    cursor: pointer;
-    font-family: var(--mono);
-    text-align: left;
-    transition: background 110ms ease;
-  }
-
-  .heat-label {
-    font-size: 10px;
-    font-weight: 700;
-    letter-spacing: 0.1em;
-    text-transform: uppercase;
-    color: var(--ink-2);
-  }
-
-  .heat-state {
-    margin-left: auto;
-    font-size: 12px;
-    font-weight: 700;
-    letter-spacing: 0.04em;
-  }
-
-  .heat-switch.is-on {
-    background: var(--accent);
-  }
-
-  .heat-switch.is-on .heat-label,
-  .heat-switch.is-on .heat-state {
-    color: var(--ink);
   }
 
   /* Time filters (night + month): a collapsed summary row that expands on click

--- a/projects/monolith/frontend/src/routes/public/app/stars/history/site/[id]/+server.js
+++ b/projects/monolith/frontend/src/routes/public/app/stars/history/site/[id]/+server.js
@@ -1,0 +1,24 @@
+import { error, json } from "@sveltejs/kit";
+import { STARS_HISTORY_CACHE_CONTROL } from "$lib/cache-headers.js";
+
+const API_BASE = process.env.API_BASE || "http://localhost:8000";
+
+// Same-origin proxy for one site's 12-month clear-dark-hours breakdown (ADR 009).
+// The historical detail card calls this site route
+// (/app/stars/history/site/{id}) lazily when it opens, since the bulk /history
+// payload no longer carries the per-month map; the fetch to
+// /api/stars/history/site/{id} happens here, server-side in the same pod, keeping
+// that private surface off the browser. Mirrors history/[month]/+server.js.
+export async function GET({ params, fetch }) {
+  const res = await fetch(
+    `${API_BASE}/api/stars/history/site/${encodeURIComponent(params.id)}`,
+    { signal: AbortSignal.timeout(10_000) },
+  );
+  if (!res.ok) {
+    throw error(503, "stars history unavailable");
+  }
+
+  return json(await res.json(), {
+    headers: { "cache-control": STARS_HISTORY_CACHE_CONTROL },
+  });
+}

--- a/projects/monolith/stars/grid.py
+++ b/projects/monolith/stars/grid.py
@@ -135,9 +135,9 @@ def _load_grid_sync() -> int:
         session.add_all(rows)
         # Clean orphaned forecast hours for sites no longer in the grid: the
         # add_all above autoflushes before the subquery runs, so this sees the
-        # new grid. site_month_stats orphans are intentionally left (ADR 008):
-        # the banked monthly history is worth keeping even if a grid point is
-        # dropped, and the table is bounded at 12 rows per site.
+        # new grid. site_month_climatology orphans are intentionally left: the
+        # seasonal history is worth keeping even if a grid point is dropped, and
+        # the table is bounded at 12 rows per site.
         # synchronize_session=False: the ORM evaluator cannot evaluate a notin_
         # subquery in Python, so issue the DELETE as SQL.
         session.execute(

--- a/projects/monolith/stars/grid_gen/backfill_cerra.py
+++ b/projects/monolith/stars/grid_gen/backfill_cerra.py
@@ -53,6 +53,13 @@ Reproduction runbook:
   kubectl port-forward -n seaweedfs svc/seaweedfs-s3 8333:8333 &
   curl -X PUT -T /tmp/climatology.json http://localhost:8333/stars/climatology.json
   homelab scheduler jobs run-now stars.load_climatology
+
+  # 5. Invalidate the CDN. /api/stars/history* is cached at the edge for a year
+  #    (immutable between reloads), so PURGE Cloudflare for the history paths
+  #    right after the load or the new climatology will not show until expiry.
+  #    Do this every reload (and after any /history response-shape change):
+  #    Cloudflare dashboard -> Caching -> Purge -> "https://jomcgi.dev/app/stars/history*"
+  #    (or the API: POST .../zones/<zone>/purge_cache with that prefix).
 """
 
 import argparse

--- a/projects/monolith/stars/jobs.py
+++ b/projects/monolith/stars/jobs.py
@@ -20,8 +20,7 @@ from sqlmodel import Session, delete, select
 
 from shared.forecast_freshness import top_of_hour
 from stars.forecast import fetch_all
-from stars.models import Site, SiteHour, SiteMonthStat
-from stars.scoring import is_clear_dark_hour
+from stars.models import Site, SiteHour
 
 logger = logging.getLogger("monolith.stars.jobs")
 
@@ -52,11 +51,8 @@ def _write_sites(session: Session, scored: dict[str, list[dict]], now: datetime)
     Deletes only hours at or after the current clock hour for the fetched sites,
     then add_all of the new (future) scored hours, so there is no per-iteration
     session.add. Elapsed rows (hour_time < top_of_hour) are intentionally left
-    in place: the hourly prune is the sole remover of elapsed hours and banks
-    them into stars.site_month_stats exactly once before deleting (ADR 008). A
-    wholesale delete here would drop those rows before the prune could bank
-    them. Sites absent from ``scored`` (failed fetch) are untouched: stale beats
-    empty.
+    in place for the hourly prune to delete, rather than wholesale-cleared here.
+    Sites absent from ``scored`` (failed fetch) are untouched: stale beats empty.
     """
     site_ids = list(scored.keys())
     cutoff = top_of_hour(now)
@@ -98,56 +94,21 @@ def _persist_sites(scored: dict[str, list[dict]]) -> int:
 
 
 def _prune_elapsed(session: Session) -> int:
-    """Bank then delete rows whose clock hour has elapsed. Returns rows deleted.
+    """Delete rows whose clock hour has elapsed. Returns rows deleted.
 
     The cutoff is the top of the current UTC clock hour: rows whose hour_time is
     strictly before it have elapsed. cutoff is tz-aware UTC, so the comparison
     stays tz-aware against the TIMESTAMPTZ column.
 
-    Exactly-once banking: this is the SOLE remover of elapsed hours, so each
-    elapsing hour is accumulated into stars.site_month_stats once, then deleted.
-    Every elapsing row is a dark hour (forecast keeps only sun < -12), so each
-    increments dark_hours; the subset that is also clear (cloud < 10%) increments
-    clear_dark_hours. The aggregation is done in Python (grouping by the hour's
-    month-of-year) rather than a Postgres ``extract()`` / ``ON CONFLICT`` upsert
-    so the same core is portable to the SQLite create_all test fixtures. The
-    elapsing set is small (one clock hour's worth), so the loop is cheap.
+    This is pure housekeeping. The historical layer no longer comes from a live
+    accumulator banked here: it comes entirely from the ERA5/CERRA climatology
+    (stars.site_month_climatology, ADR 009), so the prune just drops elapsed
+    forecast hours.
     """
     cutoff = top_of_hour()
-    elapsing = session.exec(select(SiteHour).where(SiteHour.hour_time < cutoff)).all()
-
-    # Accumulate the per-(site, month-of-year) clear-dark counts in memory.
-    buckets: dict[tuple[str, int], dict[str, int]] = {}
-    for row in elapsing:
-        key = (row.site_id, row.hour_time.month)
-        agg = buckets.setdefault(key, {"dark": 0, "clear": 0})
-        agg["dark"] += 1
-        if is_clear_dark_hour(row.sun_elevation_deg, row.cloud_area_fraction):
-            agg["clear"] += 1
-
-    # Bank each bucket: increment the existing month row in place, or add a new
-    # one. New rows are collected and add_all'd once (no session.add in a loop).
-    new_rows: list[SiteMonthStat] = []
-    for (site_id, month), agg in buckets.items():
-        stat = session.get(SiteMonthStat, (site_id, month))
-        if stat is None:
-            new_rows.append(
-                SiteMonthStat(
-                    site_id=site_id,
-                    month=month,
-                    dark_hours=agg["dark"],
-                    clear_dark_hours=agg["clear"],
-                )
-            )
-        else:
-            stat.dark_hours += agg["dark"]
-            stat.clear_dark_hours += agg["clear"]
-    if new_rows:
-        session.add_all(new_rows)
-
-    # synchronize_session=False: the rows were just loaded to bank them, so an
-    # in-Python evaluation of the predicate would compare the aware cutoff
-    # against SQLite's naive datetimes (in tests) and raise. Issue the SQL delete.
+    # synchronize_session=False: issue the DELETE as SQL rather than evaluating
+    # the predicate in Python, which would compare the aware cutoff against
+    # SQLite's naive datetimes (in tests) and raise.
     result = session.execute(
         delete(SiteHour)
         .where(SiteHour.hour_time < cutoff)

--- a/projects/monolith/stars/jobs_test.py
+++ b/projects/monolith/stars/jobs_test.py
@@ -17,7 +17,7 @@ from sqlmodel.pool import StaticPool
 
 import stars.jobs as jobs
 from shared.forecast_freshness import top_of_hour
-from stars.models import SiteHour, SiteMonthStat
+from stars.models import SiteHour
 
 
 @pytest.fixture(name="session")
@@ -134,9 +134,9 @@ def test_write_sites_leaves_unfetched_sites_untouched(session):
 
 
 def test_write_sites_replaces_future_only_keeps_elapsed(session):
-    # ADR 008: refresh replaces a fetched site's FUTURE hours only. An elapsed
-    # hour (< top_of_hour) survives the refresh so the prune can bank it; the
-    # stale future hour is replaced by the freshly scored future hours.
+    # Refresh replaces a fetched site's FUTURE hours only. An elapsed hour
+    # (< top_of_hour) survives the refresh and is left for the prune to delete;
+    # the stale future hour is replaced by the freshly scored future hours.
     elapsed = datetime(2026, 6, 13, 20, tzinfo=timezone.utc)
     stale_future = datetime(2026, 6, 13, 23, tzinfo=timezone.utc)
     _seed_hour(session, "A", elapsed, symbol="banked")
@@ -182,47 +182,36 @@ def test_prune_elapsed_drops_only_elapsed_hours(session):
     assert remaining == {current, future}
 
 
-def test_prune_banks_elapsed_into_month_stats(session):
-    # Elapsed dark hours are banked into site_month_stats (the right month
-    # bucket) before deletion: every elapsing row counts toward dark_hours, and
-    # the clear ones (cloud < 10%) toward clear_dark_hours.
+def test_prune_only_deletes_no_banking(session):
+    # The prune is pure housekeeping now: it deletes elapsed hours and writes no
+    # accumulator. The live bank-at-prune table (site_month_stats) was retired in
+    # favour of the ERA5/CERRA climatology (ADR 009), so the model is gone and the
+    # SQLite fixture never creates that table.
+    assert "site_month_stats" not in SQLModel.metadata.tables
+
     cutoff = top_of_hour(datetime.now(timezone.utc))
     h1 = cutoff - timedelta(hours=2)
     h2 = cutoff - timedelta(hours=3)
     future = cutoff + timedelta(hours=1)
-    # h1 is clear (5% cloud); h2 is dark but cloudy (50%).
     _seed_hour(session, "S", h1, cloud=5.0)
     _seed_hour(session, "S", h2, cloud=50.0)
-    # A future hour must be neither banked nor deleted.
     _seed_hour(session, "S", future, cloud=5.0)
     session.commit()
 
+    before = len(session.exec(select(SiteHour)).all())
     deleted = jobs._prune_elapsed(session)
     session.commit()
     assert deleted == 2
 
-    # Group the seeded elapsed hours by month exactly as the prune does, so the
-    # assertion holds even if the two hours straddle a month boundary.
-    expected: dict[int, dict[str, int]] = {}
-    for ht, clear in ((h1, True), (h2, False)):
-        agg = expected.setdefault(ht.month, {"dark": 0, "clear": 0})
-        agg["dark"] += 1
-        if clear:
-            agg["clear"] += 1
-    for month, agg in expected.items():
-        stat = session.get(SiteMonthStat, ("S", month))
-        assert stat is not None
-        assert stat.dark_hours == agg["dark"]
-        assert stat.clear_dark_hours == agg["clear"]
-
-    # The elapsed rows are deleted; only the future hour remains.
-    remaining = {_utc(r.hour_time) for r in session.exec(select(SiteHour)).all()}
-    assert remaining == {_utc(future)}
+    # The elapsed rows are deleted; only the future hour remains. The count drops
+    # by exactly the deleted rows, with nothing banked anywhere.
+    remaining = session.exec(select(SiteHour)).all()
+    assert len(remaining) == before - deleted == 1
+    assert {_utc(r.hour_time) for r in remaining} == {_utc(future)}
 
 
-def test_prune_rerun_does_not_double_count(session):
-    # The prune is the sole elapsed-remover and banks exactly once: a second run
-    # over an already-pruned table banks nothing more (no double-count).
+def test_prune_rerun_on_empty_table_is_noop(session):
+    # A second run over an already-pruned table deletes nothing more.
     cutoff = top_of_hour(datetime.now(timezone.utc))
     h1 = cutoff - timedelta(hours=2)
     _seed_hour(session, "S", h1, cloud=5.0)
@@ -230,39 +219,9 @@ def test_prune_rerun_does_not_double_count(session):
 
     assert jobs._prune_elapsed(session) == 1
     session.commit()
-    # Rows are gone, so the second prune finds nothing to bank or delete.
     assert jobs._prune_elapsed(session) == 0
     session.commit()
-
-    stat = session.get(SiteMonthStat, ("S", h1.month))
-    assert stat is not None
-    assert stat.dark_hours == 1
-    assert stat.clear_dark_hours == 1
-
-
-def test_prune_increments_existing_month_stat(session):
-    # Banking accumulates additively into an existing month row.
-    cutoff = top_of_hour(datetime.now(timezone.utc))
-    h1 = cutoff - timedelta(hours=2)
-    month = h1.month
-    session.add(
-        SiteMonthStat(
-            site_id="S",
-            month=month,
-            dark_hours=5,
-            clear_dark_hours=3,
-        )
-    )
-    _seed_hour(session, "S", h1, cloud=5.0)
-    session.commit()
-
-    assert jobs._prune_elapsed(session) == 1
-    session.commit()
-
-    stat = session.get(SiteMonthStat, ("S", month))
-    assert stat is not None
-    assert stat.dark_hours == 6
-    assert stat.clear_dark_hours == 4
+    assert session.exec(select(SiteHour)).all() == []
 
 
 def test_refresh_handler_empty_fetch_is_noop(monkeypatch):

--- a/projects/monolith/stars/models.py
+++ b/projects/monolith/stars/models.py
@@ -47,39 +47,18 @@ class SiteHour(SQLModel, table=True):  # nosemgrep: sqlmodel-datetime-without-fa
     fetched_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
 
 
-class SiteMonthStat(
-    SQLModel, table=True
-):  # nosemgrep: sqlmodel-datetime-without-factory
-    """Per-site, per-calendar-month accumulator of clear-dark hours (v2).
-
-    Banked by the hourly prune as forecast hours elapse: each elapsing dark hour
-    adds 1 to ``dark_hours`` and, when it is also clear (cloud < 10%), 1 to
-    ``clear_dark_hours``, in the row for its month-of-year (1-12). The table stays
-    bounded at 12 rows per site and builds a stable seasonal picture.
-    ``clear_dark_hours`` is the headline metric; ``clear_dark_hours / dark_hours``
-    is the clarity rate.
-    """
-
-    __tablename__ = "site_month_stats"
-    __table_args__ = {"schema": "stars", "extend_existing": True}
-
-    site_id: str = Field(primary_key=True)
-    month: int = Field(primary_key=True)
-    dark_hours: int = Field(default=0)
-    clear_dark_hours: int = Field(default=0)
-
-
 class SiteMonthClimatology(
     SQLModel, table=True
 ):  # nosemgrep: sqlmodel-datetime-without-factory
-    """Per-site, per-month-of-year ERA5 reanalysis backfill (v2).
+    """Per-site, per-month-of-year ERA5/CERRA reanalysis backfill (v2).
 
-    A long-run seasonal baseline computed offline from the ERA5 reanalysis and
-    ingested by the stars.load_climatology job from climatology.json on SeaweedFS.
-    Same clear-dark counts as ``SiteMonthStat`` (dark_hours + clear_dark_hours) so
-    /api/stars/history can compose the two by per-field addition: the climatology
-    pre-fills the heatmap before the live accumulator has banked enough elapsed
-    hours to be meaningful.
+    A long-run seasonal baseline computed offline from the ERA5/CERRA reanalysis
+    and ingested by the stars.load_climatology job from climatology.json on
+    SeaweedFS. ``dark_hours`` is the per-month-of-year (1-12) count of dark hours
+    (sun < -12 deg) and ``clear_dark_hours`` the subset that is also clear (cloud
+    < 10%); ``clear_dark_hours / dark_hours`` is the clarity rate. /api/stars/history
+    reads this table directly: it is the sole source of the historical layer now
+    that the live bank-at-prune accumulator has been retired (ADR 009).
     """
 
     __tablename__ = "site_month_climatology"

--- a/projects/monolith/stars/models_test.py
+++ b/projects/monolith/stars/models_test.py
@@ -9,7 +9,7 @@ import pytest
 from sqlmodel import Session, SQLModel, create_engine, select
 from sqlmodel.pool import StaticPool
 
-from stars.models import Site, SiteHour, SiteMonthClimatology, SiteMonthStat
+from stars.models import Site, SiteHour, SiteMonthClimatology
 
 
 @pytest.fixture(name="session")
@@ -126,46 +126,6 @@ def test_default_symbol_is_empty(session):
     assert loaded.wind_speed == 0.0
 
 
-def test_site_month_stat_roundtrip(session):
-    row = SiteMonthStat(
-        site_id="galloway-forest",
-        month=12,
-        dark_hours=47,
-        clear_dark_hours=18,
-    )
-    session.add(row)
-    session.commit()
-
-    loaded = session.get(SiteMonthStat, ("galloway-forest", 12))
-    assert loaded is not None
-    assert loaded.dark_hours == 47
-    assert loaded.clear_dark_hours == 18
-
-
-def test_site_month_stat_defaults(session):
-    # dark_hours and clear_dark_hours carry their column defaults.
-    row = SiteMonthStat(site_id="tiree", month=6)
-    session.add(row)
-    session.commit()
-
-    loaded = session.get(SiteMonthStat, ("tiree", 6))
-    assert loaded is not None
-    assert loaded.dark_hours == 0
-    assert loaded.clear_dark_hours == 0
-
-
-def test_site_month_stat_composite_pk_same_site_different_months(session):
-    common = {"site_id": "iona", "dark_hours": 5, "clear_dark_hours": 1}
-    session.add(SiteMonthStat(month=1, **common))
-    session.add(SiteMonthStat(month=2, **common))
-    session.commit()
-
-    rows = session.exec(
-        select(SiteMonthStat).where(SiteMonthStat.site_id == "iona")
-    ).all()
-    assert {r.month for r in rows} == {1, 2}
-
-
 def test_site_month_climatology_roundtrip(session):
     row = SiteMonthClimatology(
         site_id="scotland-0001",
@@ -192,6 +152,12 @@ def test_site_month_climatology_defaults(session):
     assert loaded is not None
     assert loaded.dark_hours == 0
     assert loaded.clear_dark_hours == 0
+
+
+def test_site_month_stats_table_is_gone():
+    # The live bank-at-prune accumulator was retired (ADR 009): history comes
+    # entirely from the climatology, so the model and its table no longer exist.
+    assert "site_month_stats" not in SQLModel.metadata.tables
 
 
 def test_composite_primary_key_same_site_different_hours(session):

--- a/projects/monolith/stars/router.py
+++ b/projects/monolith/stars/router.py
@@ -5,10 +5,12 @@ Two read endpoints back the /app/stars dark-sky planner:
 - ``GET /api/stars/sites``, every dark-sky site (from stars.sites, sourced from
   the light-pollution grid) joined with its upcoming clear-dark viewing hours,
   for the site list + detail cards (the live layer).
-- ``GET /api/stars/history``, per-site accumulated clear-dark hours for a
-  calendar month (from stars.site_month_stats, banked by the hourly prune as
-  forecast hours elapse, combined with the ERA5 climatology baseline), for the
-  historical heatmap layer.
+- ``GET /api/stars/history``, per-site clear-dark hours for a calendar month (or
+  the whole year) from the ERA5/CERRA climatology (stars.site_month_climatology,
+  ADR 009), for the historical heatmap layer.
+- ``GET /api/stars/history/site/{id}``, one site's 12-month clear-dark-hours
+  breakdown, fetched lazily when a history card opens (the bulk /history payload
+  no longer carries the per-month map).
 
 The stars v2 metric is a concrete count of clear dark hours (sun < -12 deg and
 cloud < 10%), not the old continuous quality Q = darkness x cloud x weather.
@@ -36,7 +38,7 @@ from sqlmodel import Session, select
 
 from app.db import get_session
 from shared.forecast_freshness import top_of_hour
-from stars.models import Site, SiteHour, SiteMonthClimatology, SiteMonthStat
+from stars.models import Site, SiteHour, SiteMonthClimatology
 from stars.scoring import is_clear_dark_hour
 
 logger = logging.getLogger("stars")
@@ -60,6 +62,17 @@ _NIGHT_SHIFT = timedelta(hours=12)
 # Mirrors STARS_SITES_CACHE_CONTROL in frontend/src/lib/cache-headers.js if/when
 # that constant is added; keep in sync.
 _SITES_CACHE_CONTROL = "public, max-age=0, s-maxage=1800, stale-while-revalidate=3600, stale-if-error=86400"
+
+# The historical layer is effectively IMMUTABLE between reloads: the bytes change
+# only when the (roughly yearly) ERA5/CERRA climatology reload runs, so cache it
+# at the edge for a year and invalidate explicitly. The reload is a manual op
+# (backfill_cerra.py -> upload -> stars.load_climatology), so its runbook purges
+# the Cloudflare cache for /app/stars/history* right after, the two always happen
+# together, so the cache can never be wrongly stale. max-age=0 keeps the browser
+# off a private stale copy so a CDN purge fully invalidates. NOTE: a code change
+# to the /history response shape also needs that same purge. Mirrors
+# STARS_HISTORY_CACHE_CONTROL in frontend/src/lib/cache-headers.js; keep in sync.
+_HISTORY_CACHE_CONTROL = "public, max-age=0, s-maxage=31536000, stale-while-revalidate=604800, stale-if-error=604800"
 
 
 def _as_utc(value: datetime | None) -> datetime | None:
@@ -220,44 +233,31 @@ def get_history(
         description="Month-of-year 1-12; 0 = all year (every month summed)",
     ),
 ):
-    """Per-site combined clear-dark hours for a month, or the whole year. SSR-only.
+    """Per-site historical clear-dark hours for a month, or the whole year. SSR-only.
 
-    The historical heatmap layer: each site's heat is the sum of the live
-    accumulator (stars.site_month_stats, banked by the hourly prune as forecast
-    hours elapse) and the ERA5 climatology backfill (stars.site_month_climatology,
-    a long-run seasonal baseline). The two tables carry identical clear-dark
-    counts, so they compose by per-field addition: ``dark_hours`` and
-    ``clear_dark_hours`` add, and ``clear_rate`` is the combined
-    clear_dark_hours over the combined dark_hours.
+    The historical heatmap layer reads the ERA5/CERRA climatology backfill
+    (stars.site_month_climatology, a long-run seasonal baseline ingested by
+    stars.load_climatology, ADR 009). The retired live bank-at-prune accumulator
+    no longer contributes: history is the climatology alone.
 
     ``month`` 1-12 filters the headline counts to that month-of-year; ``month`` 0
     is the all-year view (the default), which sums every month bucket per site.
-    Regardless of the selected view, each site carries a ``months`` map of all 12
-    months' clear_dark_hours (built from the UNFILTERED rows) so the frontend can
-    always draw a 12-bar seasonal graph.
 
-    A site is included if it appears in EITHER table for the selected view
-    (full-outer-join by site_id, done in Python). ``clear_dark_hours`` is the
-    headline heat metric. Sites with no metadata (dropped from the grid) or zero
-    dark hours in the selected view are omitted. Ordered by combined
-    ``clear_dark_hours`` descending. CDN-cached with the same headers as
-    ``/sites``; conditional GETs short-circuit with a 304.
+    Each site carries only its headline counts for the selected view
+    (``clear_dark_hours`` / ``dark_hours`` / ``clear_rate``). The per-month 12-bar
+    breakdown is fetched lazily per site from /history/site/{id} when a card opens,
+    so this bulk payload stays light. Sites with no metadata (dropped from the
+    grid) or zero dark hours in the selected view are omitted. Ordered by
+    ``clear_dark_hours`` descending. CDN-cached; conditional GETs short-circuit
+    with a 304.
     """
     by_id = {site.id: site for site in session.exec(select(Site)).all()}
 
-    # Read every month bucket from both accumulators once. A single pass builds
-    # two things: the per-site months map (always all 12 months, for the graph)
-    # and the selected-view headline counts (the chosen month, or all when 0).
-    live = session.exec(select(SiteMonthStat)).all()
-    climo = session.exec(select(SiteMonthClimatology)).all()
+    rows = session.exec(select(SiteMonthClimatology)).all()
 
-    # site_id -> {month: combined clear_dark_hours} for the 12-bar graph.
-    months_index: dict[str, dict[int, int]] = {}
-    # site_id -> {dark, clear} for the selected view (month, or all-year sum).
+    # site_id -> {dark, clear} for the selected view (a month, or the all-year sum).
     combined: dict[str, dict[str, int]] = {}
-    for row in (*live, *climo):
-        per_month = months_index.setdefault(row.site_id, {})
-        per_month[row.month] = per_month.get(row.month, 0) + row.clear_dark_hours
+    for row in rows:
         if month == 0 or row.month == month:
             agg = combined.setdefault(row.site_id, {"dark": 0, "clear": 0})
             agg["dark"] += row.dark_hours
@@ -267,8 +267,8 @@ def get_history(
     for site_id, agg in combined.items():
         meta = by_id.get(site_id)
         if meta is None:
-            # Orphans (a site dropped from the grid) are kept in both tables as
-            # historical record but have no metadata to render; skip them.
+            # Orphans (a site dropped from the grid) are kept in the climatology
+            # as historical record but have no metadata to render; skip them.
             logger.debug("stars.history: skipping unknown site_id %s", site_id)
             continue
         dark = agg["dark"]
@@ -277,7 +277,6 @@ def get_history(
             # No dark hours in the selected view: nothing to show, and the rate
             # would divide by zero.
             continue
-        per_month = months_index.get(site_id, {})
         sites.append(
             {
                 "id": meta.id,
@@ -287,22 +286,18 @@ def get_history(
                 "clear_dark_hours": clear,
                 "dark_hours": dark,
                 "clear_rate": clear / dark if dark else 0.0,
-                # All 12 months, zero-filled, so the frontend always has 12 bars
-                # regardless of the selected view.
-                "months": {mo: per_month.get(mo, 0) for mo in range(1, 13)},
             }
         )
 
     sites.sort(key=lambda s: s["clear_dark_hours"], reverse=True)
 
-    # The ETag folds in the selected month (0 = all year), the site count, the
-    # max combined clear_dark_hours and the total combined dark_hours: it turns
-    # over when EITHER the live prune banks more hours or the climatology
+    # The ETag folds in the selected month (0 = all year), the site count, the max
+    # clear_dark_hours and the total dark_hours: it turns over when the climatology
     # backfill reloads.
     max_clear = max((s["clear_dark_hours"] for s in sites), default=0)
     total_dark = sum(s["dark_hours"] for s in sites)
     etag = f'"v2-{month}-{len(sites)}-{max_clear}-{total_dark}"'
-    headers = {"Cache-Control": _SITES_CACHE_CONTROL, "ETag": etag}
+    headers = {"Cache-Control": _HISTORY_CACHE_CONTROL, "ETag": etag}
 
     if request.headers.get("if-none-match") == etag:
         return Response(status_code=304, headers=headers)
@@ -314,3 +309,41 @@ def get_history(
         "sites": sites,
         "count": len(sites),
     }
+
+
+@router.get("/history/site/{site_id}")
+def get_history_site(
+    site_id: str,
+    request: Request,
+    response: Response,
+    session: Session = Depends(get_session),
+):
+    """One site's 12-month clear-dark-hours breakdown. SSR-only, lazy per card.
+
+    Backs the historical detail card's 12-bar seasonal chart: the bulk /history
+    payload no longer carries the per-month map, so the card fetches this when it
+    opens. Reads the ERA5/CERRA climatology (stars.site_month_climatology, ADR
+    009). ``months`` is a {1..12: clear_dark_hours} map, zero-filled for any month
+    the site has no climatology row. CDN-cached like /history; conditional GETs
+    short-circuit with a 304.
+    """
+    rows = session.exec(
+        select(SiteMonthClimatology).where(SiteMonthClimatology.site_id == site_id)
+    ).all()
+    months = {mo: 0 for mo in range(1, 13)}
+    for row in rows:
+        if 1 <= row.month <= 12:
+            months[row.month] = row.clear_dark_hours
+
+    # The ETag folds in the site id and the year total: it turns over when the
+    # climatology backfill reloads.
+    total = sum(months.values())
+    etag = f'"v2-site-{site_id}-{total}"'
+    headers = {"Cache-Control": _HISTORY_CACHE_CONTROL, "ETag": etag}
+
+    if request.headers.get("if-none-match") == etag:
+        return Response(status_code=304, headers=headers)
+
+    for key, value in headers.items():
+        response.headers[key] = value
+    return {"site_id": site_id, "months": months}

--- a/projects/monolith/stars/router_test.py
+++ b/projects/monolith/stars/router_test.py
@@ -22,8 +22,8 @@ from sqlmodel.pool import StaticPool
 
 from app.db import get_session
 from shared.forecast_freshness import top_of_hour
-from stars.models import Site, SiteHour, SiteMonthClimatology, SiteMonthStat
-from stars.router import _SITES_CACHE_CONTROL, router
+from stars.models import Site, SiteHour, SiteMonthClimatology
+from stars.router import _HISTORY_CACHE_CONTROL, _SITES_CACHE_CONTROL, router
 
 CUTOFF = top_of_hour(datetime.now(timezone.utc))
 FETCHED = CUTOFF - timedelta(minutes=10)
@@ -282,16 +282,6 @@ class TestSites:
 
 
 class TestHistory:
-    def _seed_stat(self, session, site_id, month, dark_hours, clear_dark_hours):
-        session.add(
-            SiteMonthStat(
-                site_id=site_id,
-                month=month,
-                dark_hours=dark_hours,
-                clear_dark_hours=clear_dark_hours,
-            )
-        )
-
     def _seed_climo(self, session, site_id, month, dark_hours, clear_dark_hours):
         session.add(
             SiteMonthClimatology(
@@ -302,19 +292,15 @@ class TestHistory:
             )
         )
 
-    def test_month_filter_ordering_rate_and_months_map(self, client, session):
+    def test_month_filter_ordering_rate_no_months_in_bulk(self, client, session):
         _seed_site(session, "galloway-forest")
         _seed_site(session, "tomintoul")
-        # December: live accumulator plus ERA5 climatology backfill combine per
-        # field. galloway leads on combined clear_dark_hours.
-        self._seed_stat(session, "galloway-forest", 12, 40, 20)
-        self._seed_climo(session, "galloway-forest", 12, 10, 5)
-        self._seed_stat(session, "tomintoul", 12, 20, 4)
-        self._seed_climo(session, "tomintoul", 12, 5, 2)
-        # A different month is excluded from the headline counts but still feeds
-        # the (unfiltered) 12-month graph.
-        self._seed_stat(session, "tomintoul", 6, 5, 5)
-        self._seed_climo(session, "tomintoul", 6, 5, 5)
+        # December: the historical layer reads the ERA5/CERRA climatology only.
+        # galloway leads on clear_dark_hours.
+        self._seed_climo(session, "galloway-forest", 12, 50, 25)
+        self._seed_climo(session, "tomintoul", 12, 25, 6)
+        # A different month is excluded from the headline counts entirely.
+        self._seed_climo(session, "tomintoul", 6, 10, 10)
         session.commit()
 
         r = client.get("/api/stars/history", params={"month": 12})
@@ -323,56 +309,32 @@ class TestHistory:
         assert body["month"] == 12
         assert body["count"] == 2
         ids = [s["id"] for s in body["sites"]]
-        # Ordered by combined clear_dark_hours descending.
+        # Ordered by clear_dark_hours descending.
         assert ids == ["galloway-forest", "tomintoul"]
         gf = body["sites"][0]
-        # Combined counts: live + climatology.
-        assert gf["clear_dark_hours"] == 20 + 5
-        assert gf["dark_hours"] == 40 + 10
-        assert gf["clear_rate"] == pytest.approx((20 + 5) / (40 + 10))
+        assert gf["clear_dark_hours"] == 25
+        assert gf["dark_hours"] == 50
+        assert gf["clear_rate"] == pytest.approx(25 / 50)
         # Metadata joined from stars.sites.
         assert gf["name"] == "Galloway Forest Park"
         assert gf["lat"] == 55.083
-        # The months map is always 12 entries (string keys in JSON), zero-filled.
-        assert set(gf["months"].keys()) == {str(m) for m in range(1, 13)}
-        assert gf["months"]["12"] == 25
-        assert gf["months"]["6"] == 0
-        # tomintoul's June bucket (excluded from the headline) still shows in the
-        # unfiltered months map: 5 live + 5 climo clear-dark hours.
+        # The bulk payload is slim: no per-month map (it is fetched lazily per
+        # site from /history/site/{id}).
+        assert "months" not in gf
+        # tomintoul's December headline excludes its June bucket.
         tom = body["sites"][1]
-        assert tom["clear_dark_hours"] == 4 + 2
-        assert tom["months"]["12"] == 6
-        assert tom["months"]["6"] == 10
-
-    def test_site_present_only_in_climatology_is_included(self, client, session):
-        # A site with no live stats but an ERA5 backfill row still appears, with
-        # the climatology values standing in for the combined counts.
-        _seed_site(session, "galloway-forest")
-        _seed_site(session, "tomintoul")
-        self._seed_stat(session, "galloway-forest", 4, 20, 18)
-        self._seed_climo(session, "tomintoul", 4, 8, 5)
-        session.commit()
-
-        r = client.get("/api/stars/history", params={"month": 4})
-        assert r.status_code == 200
-        body = r.json()
-        assert {s["id"] for s in body["sites"]} == {"galloway-forest", "tomintoul"}
-        by_id = {s["id"]: s for s in body["sites"]}
-        tom = by_id["tomintoul"]
-        assert tom["clear_dark_hours"] == 5
-        assert tom["dark_hours"] == 8
-        assert tom["clear_rate"] == pytest.approx(5 / 8)
-        assert tom["months"]["4"] == 5
+        assert tom["clear_dark_hours"] == 6
+        assert "months" not in tom
 
     def test_default_is_all_year(self, client, session):
         # No month param -> all-year view (month 0): every month-of-year bucket
-        # for a site, across both tables, is summed into one combined row.
+        # for a site is summed into one row.
         _seed_site(session, "galloway-forest")
         _seed_site(session, "tomintoul")
-        self._seed_stat(session, "galloway-forest", 1, 10, 8)
-        self._seed_stat(session, "galloway-forest", 12, 20, 15)
+        self._seed_climo(session, "galloway-forest", 1, 10, 8)
+        self._seed_climo(session, "galloway-forest", 12, 20, 15)
         self._seed_climo(session, "galloway-forest", 6, 5, 4)
-        self._seed_stat(session, "tomintoul", 7, 8, 6)
+        self._seed_climo(session, "tomintoul", 7, 8, 6)
         session.commit()
 
         r = client.get("/api/stars/history")
@@ -380,20 +342,28 @@ class TestHistory:
         body = r.json()
         assert body["month"] == 0
         gf = next(s for s in body["sites"] if s["id"] == "galloway-forest")
-        # All three galloway rows (Jan + Dec live + Jun climo) fold into one.
+        # All three galloway rows (Jan + Dec + Jun) fold into one.
         assert gf["dark_hours"] == 10 + 20 + 5
         assert gf["clear_dark_hours"] == 8 + 15 + 4
-        # The months map still separates the per-month buckets.
-        assert gf["months"]["1"] == 8
-        assert gf["months"]["12"] == 15
-        assert gf["months"]["6"] == 4
-        # Ordered by combined clear_dark_hours desc: galloway (27) before tomintoul (6).
+        assert "months" not in gf
+        # Ordered by clear_dark_hours desc: galloway (27) before tomintoul (6).
         assert [s["id"] for s in body["sites"]] == ["galloway-forest", "tomintoul"]
 
-    def test_orphan_stat_without_site_is_skipped(self, client, session):
-        # A site_month_stats row whose site dropped from the grid has no
-        # metadata to render and is omitted.
-        self._seed_stat(session, "ghost", 12, 5, 4)
+    def test_clear_rate_guards_zero_dark(self, client, session):
+        # A site whose only climatology row has zero dark hours has no dark hours
+        # to show and would divide by zero, so it is omitted (never a NaN rate).
+        _seed_site(session, "galloway-forest")
+        self._seed_climo(session, "galloway-forest", 5, 0, 0)
+        session.commit()
+
+        r = client.get("/api/stars/history", params={"month": 5})
+        assert r.status_code == 200
+        assert r.json() == {"month": 5, "sites": [], "count": 0}
+
+    def test_orphan_climatology_without_site_is_skipped(self, client, session):
+        # A climatology row whose site dropped from the grid has no metadata to
+        # render and is omitted.
+        self._seed_climo(session, "ghost", 12, 5, 4)
         session.commit()
 
         r = client.get("/api/stars/history", params={"month": 12})
@@ -402,16 +372,19 @@ class TestHistory:
 
     def test_cache_and_etag_headers(self, client, session):
         _seed_site(session, "galloway-forest")
-        self._seed_stat(session, "galloway-forest", 12, 10, 5)
+        self._seed_climo(session, "galloway-forest", 12, 10, 5)
         session.commit()
         r = client.get("/api/stars/history", params={"month": 12})
         assert r.status_code == 200
-        assert r.headers["Cache-Control"] == _SITES_CACHE_CONTROL
+        # History caches longer than the live sites layer (it is effectively
+        # static between climatology reloads).
+        assert r.headers["Cache-Control"] == _HISTORY_CACHE_CONTROL
+        assert _HISTORY_CACHE_CONTROL != _SITES_CACHE_CONTROL
         assert r.headers["ETag"]
 
     def test_conditional_get_returns_304(self, client, session):
         _seed_site(session, "galloway-forest")
-        self._seed_stat(session, "galloway-forest", 12, 10, 5)
+        self._seed_climo(session, "galloway-forest", 12, 10, 5)
         session.commit()
         first = client.get("/api/stars/history", params={"month": 12})
         etag = first.headers["ETag"]
@@ -435,3 +408,64 @@ class TestHistory:
     def test_invalid_month_rejected(self, client):
         assert client.get("/api/stars/history", params={"month": 13}).status_code == 422
         assert client.get("/api/stars/history", params={"month": -1}).status_code == 422
+
+
+class TestHistorySite:
+    def _seed_climo(self, session, site_id, month, dark_hours, clear_dark_hours):
+        session.add(
+            SiteMonthClimatology(
+                site_id=site_id,
+                month=month,
+                dark_hours=dark_hours,
+                clear_dark_hours=clear_dark_hours,
+            )
+        )
+
+    def test_returns_zero_filled_12_month_map(self, client, session):
+        # The per-site breakdown is a {1..12: clear_dark_hours} map (string keys
+        # after JSON), zero-filled for months with no climatology row.
+        self._seed_climo(session, "galloway-forest", 1, 30, 8)
+        self._seed_climo(session, "galloway-forest", 12, 50, 25)
+        # A different site's rows must not bleed into this one.
+        self._seed_climo(session, "tomintoul", 6, 10, 9)
+        session.commit()
+
+        r = client.get("/api/stars/history/site/galloway-forest")
+        assert r.status_code == 200
+        body = r.json()
+        assert body["site_id"] == "galloway-forest"
+        months = body["months"]
+        assert set(months.keys()) == {str(m) for m in range(1, 13)}
+        assert months["1"] == 8
+        assert months["12"] == 25
+        assert months["6"] == 0
+
+    def test_unknown_site_returns_all_zero_map(self, client, session):
+        # A site with no climatology rows (or no metadata) still returns a valid
+        # all-zero 12-month map rather than 404, so the card chart renders empty.
+        r = client.get("/api/stars/history/site/ghost")
+        assert r.status_code == 200
+        body = r.json()
+        assert body["site_id"] == "ghost"
+        assert body["months"] == {str(m): 0 for m in range(1, 13)}
+
+    def test_cache_and_etag_headers(self, client, session):
+        self._seed_climo(session, "galloway-forest", 12, 10, 5)
+        session.commit()
+        r = client.get("/api/stars/history/site/galloway-forest")
+        assert r.status_code == 200
+        assert r.headers["Cache-Control"] == _HISTORY_CACHE_CONTROL
+        assert r.headers["ETag"]
+
+    def test_conditional_get_returns_304(self, client, session):
+        self._seed_climo(session, "galloway-forest", 12, 10, 5)
+        session.commit()
+        first = client.get("/api/stars/history/site/galloway-forest")
+        etag = first.headers["ETag"]
+        second = client.get(
+            "/api/stars/history/site/galloway-forest",
+            headers={"If-None-Match": etag},
+        )
+        assert second.status_code == 304
+        assert second.headers["ETag"] == etag
+        assert second.content == b""


### PR DESCRIPTION
Follow-up cleanup after the CERRA microclimate climatology went live.

## Why
With history now coming entirely from the CERRA climatology (`site_month_climatology`), the ADR-008 "bank-at-prune" live accumulator is redundant, it existed only to slowly build a climatology we now have. Removing it simplifies the data path, drops ~14k banked rows/hour of DB churn, and makes `/history` static, which unlocks aggressive caching to fix the cold-load slowness on the 14k-site map.

## What
- **Retire the live accumulator**: prune just deletes elapsed `site_hours` (no banking); drop `stars.site_month_stats` table + `SiteMonthStat` model (migration). ADR 008 marked superseded.
- **`/history` reads climatology only** (no live/climo join).
- **Slim payload**: the per-site 12-month `months` map is removed from the bulk response; a new `GET /api/stars/history/site/{id}` serves it, lazy-fetched only when a history card opens. Bulk `/history` drops from ~3.4MB to ~1MB.
- **Year-long edge cache**: history is immutable between the ~yearly reloads, so `s-maxage` goes from 6h to 1 year, invalidated by a Cloudflare purge step added to the `backfill_cerra` reload runbook (data reload + purge always happen together).
- **Live = markers-only**: removed the live heatmap toggle (a density heatmap of sparse, seasonal forecast hours made no sense); the box-cell heatmap stays for the historical layer.

Tests updated throughout (prune deletes-no-banking, history climo-only + no `months` in bulk, new per-site endpoint, model/table absence).

🤖 Generated with [Claude Code](https://claude.com/claude-code)