### PR TITLE
feat(stars): live twilight floor (-10 deg) for the midsummer no-dark weeks

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.138.0
+version: 0.139.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.138.0
+      targetRevision: 0.139.0
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/lib/public/components/stars/StarsMap.svelte
+++ b/projects/monolith/frontend/src/lib/public/components/stars/StarsMap.svelte
@@ -19,11 +19,17 @@
   // body renders. `heatVisible` toggles between the point markers and the
   // box-cell heatmap: when on, the circle markers hide and each site renders as
   // a coloured grid cell (ADR 009, mirroring /app/ships' fill-layer heatmap).
+  // `darknessMode` ("astronomical"|"twilight"|"none") is the page-level live
+  // darkness state. In "twilight" (the ~7-week midsummer window where Scotland
+  // gets no true dark) every site's clear_dark_hours is zero, so the live
+  // marker/cell value falls back to the wider clear_twilight_hours so the map
+  // still has a meaningful field to colour. LIVE only; ignored in historical.
   let {
     sites = [],
     activeNights = new Set(),
     nowMs = Date.now(),
     mode = "live",
+    darknessMode = "astronomical",
     heatVisible = false,
   } = $props();
 
@@ -162,6 +168,16 @@
     }),
   );
 
+  // Honest title for the live windows table: "clear dark hours" only when every
+  // shown hour is true dark (sun < -12). In the midsummer twilight fallback some
+  // or all hours are twilight-only, so the wider "clear windows" reads true. An
+  // older payload without per-hour `dark` flags (undefined) is treated as dark,
+  // keeping the original label.
+  let windowsAllDark = $derived(cardHours.every((h) => h.dark !== false));
+  let windowsTitle = $derived(
+    windowsAllDark ? "Upcoming clear dark hours" : "Upcoming clear windows",
+  );
+
   let mapsLink = $derived(
     selected
       ? `https://www.google.com/maps/search/?api=1&query=${selected.lat},${selected.lon}`
@@ -181,6 +197,14 @@
   function fmtSymbol(symbol) {
     // met.no symbol codes like "clearsky_night" -> "clearsky night".
     return symbol ? symbol.replace(/_/g, " ") : "n/a";
+  }
+
+  // Sun elevation as a signed whole-degree label (e.g. "-13 deg"), or "" when
+  // the payload predates the per-hour elevation field.
+  function fmtElev(deg) {
+    return typeof deg === "number" && Number.isFinite(deg)
+      ? `${Math.round(deg)} deg`
+      : "";
   }
 
   function fmtCoord(lat, lon) {
@@ -224,17 +248,23 @@
     };
   }
 
-  // Upcoming clear-dark-hour count this site reaches across the currently
-  // selected nights. Falls back to the site-level clear_dark_hours when the
-  // payload carries no per-night map (older build / CDN-cached response), so the
-  // map never blanks. With a single selected night, sites with no clear-dark
-  // hours that night return null and drop off the map (the night filter). LIVE
-  // only. night_clear_dark only holds nights with >= 1 clear-dark hour, so a
-  // missing key is correctly treated as zero (dropped under a single night).
+  // Upcoming clear-hour count this site reaches across the currently selected
+  // nights. Normally this is the clear-DARK count; in the midsummer "twilight"
+  // darkness mode (no true dark anywhere) it falls back to the wider clear-
+  // TWILIGHT count so the live field is not uniformly zero. Falls back to the
+  // site-level total when the payload carries no per-night map (older build /
+  // CDN-cached response), so the map never blanks. With a single selected night,
+  // sites with no qualifying hours that night return null and drop off the map
+  // (the night filter). LIVE only. The per-night maps only hold nights with >= 1
+  // qualifying hour, so a missing key is correctly treated as zero.
   function effectiveClearDark(site) {
-    const nd = site.night_clear_dark;
+    const twilight = darknessMode === "twilight";
+    const nd = twilight ? site.night_clear_twilight : site.night_clear_dark;
+    const total = twilight
+      ? (site.clear_twilight_hours ?? site.clear_dark_hours)
+      : site.clear_dark_hours;
     if (!nd || !activeNights || activeNights.size === 0) {
-      return site.clear_dark_hours ?? null;
+      return total ?? null;
     }
     let best = null;
     for (const night of activeNights) {
@@ -406,6 +436,13 @@
   $effect(() => {
     void activeNights;
     if (map && layerReady) pushData();
+  });
+
+  // Recolour when the page flips between dark and twilight darkness modes: the
+  // live field then derives from a different per-site count (dark vs twilight).
+  $effect(() => {
+    void darknessMode;
+    if (map && layerReady && mode === "live") pushData();
   });
 
   // Mode flip (live <-> historical) swaps what each feature means, so rebuild the
@@ -662,11 +699,12 @@
         </dl>
 
         {#if cardHours.length}
-          <p class="eyebrow card-windows-title">Upcoming clear dark hours</p>
+          <p class="eyebrow card-windows-title">{windowsTitle}</p>
           <table class="card-windows">
             <thead>
               <tr>
                 <th>Time</th>
+                <th>Phase</th>
                 <th>Cloud</th>
                 <th>Temp</th>
                 <th>Sky</th>
@@ -676,6 +714,18 @@
               {#each cardHours as h (h.time)}
                 <tr>
                   <td>{fmtTime(h.time)}</td>
+                  <td>
+                    <!-- True dark (sun < -12) vs twilight-only fallback
+                         (-12 .. -10), with the sun elevation so the window is
+                         honestly marked. `dark` undefined (older payload) reads
+                         as dark. -->
+                    <span class="phase" class:is-twilight={h.dark === false}
+                      >{h.dark === false ? "Twilight" : "Dark"}</span
+                    >
+                    {#if fmtElev(h.sun_elevation_deg)}
+                      <span class="phase-elev">{fmtElev(h.sun_elevation_deg)}</span>
+                    {/if}
+                  </td>
                   <td>{Math.round(h.cloud_area_fraction)}%</td>
                   <td>{Math.round(h.air_temperature)}C</td>
                   <td>{fmtSymbol(h.symbol)}</td>
@@ -684,7 +734,7 @@
             </tbody>
           </table>
         {:else}
-          <p class="card-empty">No upcoming clear dark hours for this site.</p>
+          <p class="card-empty">No upcoming clear windows for this site.</p>
         {/if}
       {/if}
 
@@ -887,6 +937,25 @@
   .card-windows td {
     padding: 4px 6px 4px 0;
     border-bottom: 1px dashed var(--rule-2);
+  }
+
+  /* Phase tag: true-dark windows read in ink, twilight-fallback windows in the
+     muted ink so the eye trusts the dark ones first. The sun elevation sits
+     under the tag, dimmer still, so the column stays narrow. */
+  .phase {
+    display: block;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+  }
+
+  .phase.is-twilight {
+    color: var(--ink-3);
+  }
+
+  .phase-elev {
+    display: block;
+    font-size: 10px;
+    color: var(--ink-3);
   }
 
   /* 12-month clear-dark-hours bar chart: a flat SVG block sitting in the card,

--- a/projects/monolith/frontend/src/routes/public/app/stars/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/stars/+page.svelte
@@ -9,6 +9,16 @@
   let sites = $derived(data.snapshot?.sites ?? []);
   let count = $derived(data.snapshot?.count ?? 0);
 
+  // Page-level darkness mode from the live snapshot (stars twilight fallback):
+  //   "astronomical" - true dark (sun < -12) is available somewhere tonight;
+  //   "twilight"     - no true dark anywhere, only the -10 deg twilight floor;
+  //   "none"         - not even twilight (deep midsummer in the far north).
+  // For ~7 weeks each midsummer Scotland has no astronomical darkness, so this
+  // drives the disclaimer and tells StarsMap to colour by the twilight count.
+  // Defaults to "astronomical" so an older/cached payload without the field
+  // behaves exactly as before (no disclaimer, dark-hour colouring).
+  let darkness = $derived(data.snapshot?.darkness ?? "astronomical");
+
   // Mode: LIVE = the upcoming-forecast layer (per-night quality), markers only;
   // HISTORICAL = the month-bucketed clear-dark-hours layer (stars v2), the
   // box-cell heatmap. The toggle swaps the map's data source, the time control
@@ -192,7 +202,14 @@
 <div class="stars-page">
   <h1 class="sr-only">Dark-sky stargazing map, Scotland viewing windows</h1>
 
-  <StarsMap sites={mapSites} {activeNights} {nowMs} {mode} heatVisible={heatOn} />
+  <StarsMap
+    sites={mapSites}
+    {activeNights}
+    {nowMs}
+    {mode}
+    darknessMode={darkness}
+    heatVisible={heatOn}
+  />
 
   <!-- Floating header: breadcrumb + headline stats, top-left clear of the map
        chrome (mirrors the hikes control head). -->
@@ -290,7 +307,23 @@
         </div>
       {/if}
 
-      {#if count === 0}
+      <!-- Summer twilight disclaimer: for ~7 weeks each midsummer Scotland gets
+           no astronomical darkness, so the live layer falls back to the darkest
+           twilight windows (down to -10 deg) and says so. -->
+      {#if darkness === "none"}
+        <div class="panel disclaimer" role="status">
+          No usable stargazing windows in Scotland this week: right now the summer
+          sky never gets dark enough, even for twilight. Astronomical darkness
+          returns by August.
+        </div>
+      {:else if darkness === "twilight"}
+        <div class="panel disclaimer" role="status">
+          No astronomical darkness in Scotland right now (it returns by August).
+          Showing the darkest twilight windows instead, best in the south.
+        </div>
+      {/if}
+
+      {#if count === 0 && darkness === "astronomical"}
         <div class="panel empty-state" role="status">
           No dark-sky windows in the next few nights. Check back after the next
           forecast refresh.
@@ -469,6 +502,18 @@
     line-height: 1.5;
     letter-spacing: 0.02em;
     color: var(--ink-2);
+  }
+
+  /* Summer twilight disclaimer: same mono read as the empty state, lifted with a
+     thick accent left edge so it registers as a heads-up, not an error. */
+  .disclaimer {
+    font-family: var(--mono);
+    font-size: 12px;
+    line-height: 1.5;
+    letter-spacing: 0.02em;
+    color: var(--ink);
+    border-left-width: 8px;
+    border-left-color: var(--accent);
   }
 
   /* Mode toggle: two equal segments, the active one filled ink-on-paper, the

--- a/projects/monolith/stars/forecast.py
+++ b/projects/monolith/stars/forecast.py
@@ -16,7 +16,7 @@ import httpx
 from astral import LocationInfo
 from astral.sun import elevation
 
-from stars.scoring import CLEAR_CLOUD_MAX_PCT, is_dark_hour
+from stars.scoring import CLEAR_CLOUD_MAX_PCT, is_dark_hour, is_twilight_hour
 
 logger = logging.getLogger("monolith.stars.forecast")
 
@@ -29,18 +29,21 @@ HTTP_TIMEOUT = 30.0
 
 
 def score_location(loc: dict, forecast: dict) -> list[dict]:
-    """All dark hours for one site, sorted by time ascending (stars v2).
+    """All twilight-or-darker hours for one site, sorted by time ascending (v2).
 
-    Every dark hour (sun below -12 deg, nautical) is kept and tagged with
-    ``is_clear`` (cloud < 10%); the clear-dark hours are the windows worth
-    showing. Hours that are not dark (daylight or only civil twilight) are
-    dropped. Unlike v1, a dark-but-cloudy hour is no longer dropped: it is kept
-    with ``is_clear`` False so the prune can still count it toward dark_hours
-    (the clarity-rate denominator).
+    Every hour with the sun below the -10 deg twilight floor is kept and tagged
+    with ``is_clear`` (cloud < 10%) and ``dark`` (sun < -12 deg, true nautical
+    dark). The gate is the twilight floor, not the dark threshold, so the LIVE
+    layer still has windows to surface during the ~7-week midsummer stretch when
+    Scotland gets no astronomical darkness at all; ``dark`` distinguishes the
+    true-dark hours from the twilight-only fallback. Hours brighter than -10
+    (daylight or shallower twilight) are dropped. A kept-but-cloudy hour is not
+    dropped: it is kept with ``is_clear`` False so the read path can still count
+    it toward the dark/twilight denominators.
 
     Each returned dict carries the fields the job and the read path need (minus
     site_id / fetched_at, which the job sets): time, sun_elevation_deg,
-    cloud_area_fraction, air_temperature, dew_spread, symbol, is_clear.
+    cloud_area_fraction, air_temperature, dew_spread, symbol, is_clear, dark.
     """
     observer = LocationInfo(latitude=loc["lat"], longitude=loc["lon"]).observer
     hours: list[dict] = []
@@ -55,8 +58,8 @@ def score_location(loc: dict, forecast: dict) -> list[dict]:
         except Exception as exc:  # pragma: no cover - astral edge cases
             logger.debug("astral elevation failed for %s at %s: %s", loc["id"], t, exc)
             continue
-        if not is_dark_hour(e):
-            continue  # daylight / not yet nautically dark
+        if not is_twilight_hour(e):
+            continue  # daylight / brighter than the -10 deg twilight floor
         instant = entry.get("data", {}).get("instant", {}).get("details", {})
         next_1h = entry.get("data", {}).get("next_1_hours", {})
         # Missing cloud defaults to overcast (100) so an absent reading counts as
@@ -73,6 +76,10 @@ def score_location(loc: dict, forecast: dict) -> list[dict]:
                 "dew_spread": round(air_temperature - dew_point, 1),
                 "symbol": next_1h.get("summary", {}).get("symbol_code", ""),
                 "is_clear": cloud < CLEAR_CLOUD_MAX_PCT,
+                # True nautical dark (sun < -12), vs a twilight-only fallback
+                # hour (-12 <= sun < -10). The read path recomputes this from
+                # sun_elevation_deg, but emitting it keeps the dict honest.
+                "dark": is_dark_hour(e),
             }
         )
     hours.sort(key=lambda h: h["time"])

--- a/projects/monolith/stars/forecast_test.py
+++ b/projects/monolith/stars/forecast_test.py
@@ -1,10 +1,11 @@
 """Unit tests for stars.forecast.score_location (stars v2).
 
-elevation() is monkeypatched per entry so the dark/daylight gate is fully
+elevation() is monkeypatched per entry so the twilight/daylight gate is fully
 deterministic and independent of the real ephemeris. score_location keeps every
-dark hour (sun below -12 deg) and tags each with is_clear (cloud < 10%); only
-daytime / not-dark hours are dropped. A dark-but-cloudy hour is kept (is_clear
-False) so the prune can still count it toward dark_hours.
+hour below the -10 deg twilight floor (the summer fallback), tags each with
+is_clear (cloud < 10%) and dark (sun < -12, true nautical dark); only hours
+brighter than -10 are dropped. A kept-but-cloudy hour is retained (is_clear
+False) so the read path can still count it toward the denominators.
 """
 
 import stars.forecast as forecast
@@ -67,6 +68,7 @@ _EXPECTED_KEYS = {
     "dew_spread",
     "symbol",
     "is_clear",
+    "dark",
 }
 
 
@@ -94,11 +96,50 @@ def test_score_location_keeps_all_dark_hours_sorted(monkeypatch):
     # 5% cloud under the 10% threshold -> clear.
     assert first["is_clear"] is True
 
+    # Deep-dark hours (sun -20) are flagged dark.
+    assert first["dark"] is True
+
     # The fully-clouded dark hour is retained but flagged not-clear.
     cloudy = hours[2]
     assert cloudy["time"] == "2026-06-14T00:00:00Z"
     assert cloudy["cloud_area_fraction"] == 100
     assert cloudy["is_clear"] is False
+    assert cloudy["dark"] is True
+
+
+def test_score_location_keeps_twilight_drops_below_floor(monkeypatch):
+    # The summer fallback: with no true dark, hours between the -10 floor and the
+    # -12 dark threshold are kept (dark=False); a true-dark hour is dark=True; an
+    # hour shallower than -10 is dropped entirely.
+    elev_by_hour = {
+        21: -9.0,  # shallower than the -10 floor -> dropped
+        22: -11.0,  # twilight: kept, dark=False
+        23: -13.0,  # true dark: kept, dark=True
+    }
+    monkeypatch.setattr(forecast, "elevation", lambda observer, t: elev_by_hour[t.hour])
+    fc = {
+        "properties": {
+            "timeseries": [
+                {"time": "2026-06-21T21:00:00Z", **_instant(5, 8, 2)},
+                {"time": "2026-06-21T22:00:00Z", **_instant(5, 8, 2)},
+                {"time": "2026-06-21T23:00:00Z", **_instant(5, 8, 2)},
+            ]
+        }
+    }
+    hours = forecast.score_location(_LOC, fc)
+
+    # The -9 hour is gone; the twilight and dark hours survive, sorted ascending.
+    assert [h["time"] for h in hours] == [
+        "2026-06-21T22:00:00Z",
+        "2026-06-21T23:00:00Z",
+    ]
+    twilight, dark = hours
+    assert twilight["sun_elevation_deg"] == -11.0
+    assert twilight["dark"] is False
+    # Still clear (cloud 5%), just not true dark.
+    assert twilight["is_clear"] is True
+    assert dark["sun_elevation_deg"] == -13.0
+    assert dark["dark"] is True
 
 
 def test_score_location_cloud_boundary_is_not_clear(monkeypatch):

--- a/projects/monolith/stars/router.py
+++ b/projects/monolith/stars/router.py
@@ -17,6 +17,14 @@ cloud < 10%), not the old continuous quality Q = darkness x cloud x weather.
 ``clear_dark_hours`` is the count of upcoming clear-dark hours and drives the map
 ordering and marker colour on the live layer.
 
+For ~7 weeks each midsummer Scotland gets no astronomical darkness (the sun never
+drops past -12 deg), which would leave the live layer empty. The /sites endpoint
+adds a twilight fallback: it also reports ``clear_twilight_hours`` (clear hours
+down to a -10 deg floor) and a page-level ``darkness`` mode (astronomical /
+twilight / none) so the frontend can surface the darkest available windows with a
+disclaimer instead of showing nothing. The strict -12 metric and the historical
+climatology are unchanged; this only widens the live layer's fallback.
+
 Reached only from SvelteKit SSR (``http://localhost:8000`` in the same pod);
 the /app/stars page is the public surface and the CDN fans out to viewers, per
 ADR 002. Conditional GETs short-circuit with a 304 via ETag.
@@ -39,7 +47,7 @@ from sqlmodel import Session, select
 from app.db import get_session
 from shared.forecast_freshness import top_of_hour
 from stars.models import Site, SiteHour, SiteMonthClimatology
-from stars.scoring import is_clear_dark_hour
+from stars.scoring import CLEAR_CLOUD_MAX_PCT, is_dark_hour, is_twilight_hour
 
 logger = logging.getLogger("stars")
 
@@ -137,6 +145,15 @@ def get_sites(
             max_fetched = row.fetched_at
         by_site.setdefault(row.site_id, []).append(row)
 
+    # Track, across all sites, whether any site has a true-dark hour (sun < -12,
+    # cloud-independent) and whether any kept hour exists at all (< -10). These
+    # drive the page-level ``darkness`` mode: astronomical dark is available,
+    # only twilight is available, or nothing is. Midsummer in Scotland the dark
+    # set is empty for ~7 weeks, so the twilight fallback is what keeps the live
+    # layer useful.
+    any_dark_hour = False
+    any_twilight_hour = False
+
     sites = []
     for site_id, hours in by_site.items():
         meta = by_id.get(site_id)
@@ -147,25 +164,49 @@ def get_sites(
             logger.debug("stars: skipping unknown site_id %s", site_id)
             continue
 
-        # The clear-dark hours among the upcoming dark hours are the windows
-        # worth showing; their count is the live headline metric.
-        clear_hours = [
+        # Clear hours split two ways. clear-DARK (sun < -12 AND cloud < 10) is
+        # the unchanged headline metric and drives ranking + history. clear-
+        # TWILIGHT (sun < -10 AND cloud < 10) is the wider summer fallback: every
+        # clear-dark hour is also a clear-twilight hour, so the twilight count is
+        # always >= the dark count. In a normal (dark) night they are equal; only
+        # in the midsummer no-true-dark window does twilight exceed dark.
+        clear_twilight = [
             h
             for h in hours
-            if is_clear_dark_hour(h.sun_elevation_deg, h.cloud_area_fraction)
+            if is_twilight_hour(h.sun_elevation_deg)
+            and h.cloud_area_fraction < CLEAR_CLOUD_MAX_PCT
         ]
+        clear_hours = [h for h in clear_twilight if is_dark_hour(h.sun_elevation_deg)]
         clear_dark_hours = len(clear_hours)
+        clear_twilight_hours = len(clear_twilight)
 
-        # Per-night count of clear-dark hours, so the map's night filter can
-        # recolour each marker by how many clear-dark hours the selected
-        # night(s) hold.
+        # Feed the page-level darkness mode. The elevation checks are cloud-
+        # independent on purpose: "is there any astronomical darkness (or any
+        # twilight) at all tonight" is a sky-geometry question, not a cloud one.
+        # Every kept row is already below the -10 floor, but check explicitly so
+        # the mode stays correct even against unexpected rows.
+        if any(is_dark_hour(h.sun_elevation_deg) for h in hours):
+            any_dark_hour = True
+        if any(is_twilight_hour(h.sun_elevation_deg) for h in hours):
+            any_twilight_hour = True
+
+        # Per-night counts so the map's night filter can recolour each marker by
+        # how many clear hours the selected night(s) hold. We keep both a
+        # clear-dark and a clear-twilight breakdown so the night filter still
+        # works in twilight mode (when every clear-dark count is zero).
         night_clear_dark: dict[str, int] = {}
         for h in clear_hours:
             key = _night_key(h.hour_time)
             night_clear_dark[key] = night_clear_dark.get(key, 0) + 1
+        night_clear_twilight: dict[str, int] = {}
+        for h in clear_twilight:
+            key = _night_key(h.hour_time)
+            night_clear_twilight[key] = night_clear_twilight.get(key, 0) + 1
 
-        # Display the upcoming clear-dark hours in chronological order, capped:
-        # a planner reads the night top to bottom.
+        # Display the upcoming clear windows in chronological order, capped: a
+        # planner reads the night top to bottom. We show the clear-twilight set
+        # (the superset) and tag each hour ``dark`` so the card can label true
+        # dark vs twilight-fallback windows, with the sun elevation alongside.
         best_hours = [
             {
                 "time": _iso(h.hour_time),
@@ -173,8 +214,10 @@ def get_sites(
                 "air_temperature": h.air_temperature,
                 "dew_spread": h.dew_spread,
                 "symbol": h.symbol,
+                "sun_elevation_deg": h.sun_elevation_deg,
+                "dark": is_dark_hour(h.sun_elevation_deg),
             }
-            for h in sorted(clear_hours, key=lambda h: h.hour_time)[:_DISPLAY_HOURS]
+            for h in sorted(clear_twilight, key=lambda h: h.hour_time)[:_DISPLAY_HOURS]
         ]
         sites.append(
             {
@@ -185,17 +228,42 @@ def get_sites(
                 "altitude_m": meta.altitude_m,
                 "lp_zone": meta.lp_zone,
                 "clear_dark_hours": clear_dark_hours,
+                "clear_twilight_hours": clear_twilight_hours,
                 "best_hours": best_hours,
                 "night_clear_dark": night_clear_dark,
+                "night_clear_twilight": night_clear_twilight,
             }
         )
 
-    sites.sort(key=lambda s: s["clear_dark_hours"], reverse=True)
+    # Sort by clear-dark first, then clear-twilight: in a normal night this is
+    # just the dark ordering, but in the midsummer twilight window (every
+    # clear_dark_hours == 0) the twilight count breaks the tie so the ranking is
+    # still meaningful (best windows in the darker south float to the top).
+    sites.sort(
+        key=lambda s: (s["clear_dark_hours"], s["clear_twilight_hours"]),
+        reverse=True,
+    )
+
+    # Page-level darkness mode, driving the frontend disclaimer:
+    #   "astronomical" - at least one site has a true-dark hour (sun < -12);
+    #   "twilight"     - no true dark anywhere, but some twilight windows exist;
+    #   "none"         - not even twilight (deep midsummer in the far north).
+    if any_dark_hour:
+        darkness = "astronomical"
+    elif any_twilight_hour:
+        darkness = "twilight"
+    else:
+        darkness = "none"
 
     # Union of nights present across all sites, ascending, so the frontend can
     # render one stable row of night-filter chips (a site missing a night just
-    # has no clear-dark hours for it).
-    nights = sorted({key for s in sites for key in s["night_clear_dark"]})
+    # has no qualifying hours for it). In twilight mode the dark per-night maps
+    # are all empty, so key the chips off the twilight breakdown the map colours
+    # by; otherwise this is the unchanged clear-dark night set.
+    night_field = (
+        "night_clear_twilight" if darkness == "twilight" else "night_clear_dark"
+    )
+    nights = sorted({key for s in sites for key in s[night_field]})
 
     # The ETag folds in the current clock hour so the CDN turns over hourly even
     # when fetched_at has not changed: as hours fall past the cutoff the payload
@@ -203,7 +271,8 @@ def get_sites(
     max_fetched_utc = _as_utc(max_fetched)
     etag = (
         f'"v2-{cutoff.isoformat()}-'
-        f'{max_fetched_utc.isoformat() if max_fetched_utc else "none"}-{len(sites)}"'
+        f"{max_fetched_utc.isoformat() if max_fetched_utc else 'none'}-"
+        f'{len(sites)}-{darkness}"'
     )
     headers = {"Cache-Control": _SITES_CACHE_CONTROL, "ETag": etag}
 
@@ -217,6 +286,7 @@ def get_sites(
         "count": len(sites),
         "total_sites": len(by_id),
         "nights": nights,
+        "darkness": darkness,
         "fetched_at": _iso(max_fetched),
     }
 

--- a/projects/monolith/stars/router_test.py
+++ b/projects/monolith/stars/router_test.py
@@ -195,7 +195,8 @@ class TestSites:
         assert second.content == b""
 
     def test_empty_table(self, client):
-        # No sites and no hours: total_sites reflects the empty stars.sites table.
+        # No sites and no hours: total_sites reflects the empty stars.sites table,
+        # and with no kept hours at all the darkness mode is "none".
         r = client.get("/api/stars/sites")
         assert r.status_code == 200
         assert r.json() == {
@@ -203,6 +204,7 @@ class TestSites:
             "count": 0,
             "total_sites": 0,
             "nights": [],
+            "darkness": "none",
             "fetched_at": None,
         }
 
@@ -279,6 +281,73 @@ class TestSites:
         # Top-level nights is the sorted union of the per-site night keys.
         assert body["nights"] == sorted(set(night_clear_dark))
         assert body["nights"] == sorted(body["nights"])
+
+    def test_clear_twilight_at_least_clear_dark_and_dark_flag(self, client, session):
+        # A clear true-dark hour (sun -18) plus a clear twilight-only hour
+        # (sun -11). Twilight is the superset: clear_twilight_hours (2) >=
+        # clear_dark_hours (1). best_hours carries both, each tagged dark.
+        _seed_site(session, "galloway-forest")
+        session.add(_hour("galloway-forest", 1, sun=-18.0))
+        session.add(_hour("galloway-forest", 2, sun=-11.0))
+        session.commit()
+
+        r = client.get("/api/stars/sites")
+        assert r.status_code == 200
+        body = r.json()
+        site = body["sites"][0]
+        assert site["clear_dark_hours"] == 1
+        assert site["clear_twilight_hours"] == 2
+        assert site["clear_twilight_hours"] >= site["clear_dark_hours"]
+        # best_hours shows the full clear-twilight superset, sorted by time, each
+        # tagged dark (true at -18, false at -11) with its sun elevation.
+        flags = {h["time"]: h["dark"] for h in site["best_hours"]}
+        assert flags[(CUTOFF + timedelta(hours=1)).isoformat()] is True
+        assert flags[(CUTOFF + timedelta(hours=2)).isoformat()] is False
+        assert all("sun_elevation_deg" in h for h in site["best_hours"])
+
+    def test_darkness_astronomical_when_any_dark_hour(self, client, session):
+        # Any upcoming true-dark hour (sun < -12) anywhere puts the page in
+        # astronomical mode, regardless of cloud (a dark-but-cloudy hour counts).
+        _seed_site(session, "galloway-forest")
+        session.add(_hour("galloway-forest", 1, sun=-13.0, cloud=80.0))
+        session.commit()
+
+        r = client.get("/api/stars/sites")
+        assert r.status_code == 200
+        body = r.json()
+        assert body["darkness"] == "astronomical"
+
+    def test_darkness_twilight_when_only_twilight_hours(self, client, session):
+        # Midsummer: no hour reaches -12, but some are below the -10 floor. The
+        # page falls back to twilight; clear_dark is zero while clear_twilight
+        # carries the windows.
+        _seed_site(session, "galloway-forest")
+        session.add(_hour("galloway-forest", 1, sun=-11.0))
+        session.add(_hour("galloway-forest", 2, sun=-10.5))
+        session.commit()
+
+        r = client.get("/api/stars/sites")
+        assert r.status_code == 200
+        body = r.json()
+        assert body["darkness"] == "twilight"
+        site = body["sites"][0]
+        assert site["clear_dark_hours"] == 0
+        assert site["clear_twilight_hours"] == 2
+        # In twilight mode the night chips key off the twilight breakdown.
+        assert body["nights"] == sorted(set(site["night_clear_twilight"]))
+
+    def test_darkness_none_when_no_kept_hours(self, client, session):
+        # A site exists but only has past hours -> no kept rows at all -> the
+        # page reports darkness "none" (not even twilight is available).
+        _seed_site(session, "galloway-forest")
+        session.add(_hour("galloway-forest", -1, sun=-18.0))
+        session.commit()
+
+        r = client.get("/api/stars/sites")
+        assert r.status_code == 200
+        body = r.json()
+        assert body["count"] == 0
+        assert body["darkness"] == "none"
 
 
 class TestHistory:

--- a/projects/monolith/stars/scoring.py
+++ b/projects/monolith/stars/scoring.py
@@ -14,11 +14,32 @@ dark_hours). The same thresholds are replicated by the offline ERA5 backfill
 NAUTICAL_DARK_DEG = -12.0  # sun below this = "dark" for the clear-dark metric
 CLEAR_CLOUD_MAX_PCT = 10.0  # cloud cover (%) strictly below this = "clear"
 
+# Summer fallback floor for the LIVE layer only. For ~7 weeks each midsummer
+# Scotland gets no astronomical darkness (the sun never sinks past -12 deg), so
+# the strict dark metric leaves the live forecast empty. -10 deg is mid-nautical
+# twilight: the brighter constellations and planets are still visible, so it is
+# the honest floor for "darkest available window" when true dark is out of
+# reach. Below -10 (e.g. far-north midsummer where the sun only reaches ~-8) we
+# show nothing. The strict -12 dark metric is unchanged for ranking and history;
+# this only widens what the live layer is allowed to surface.
+TWILIGHT_FLOOR_DEG = -10.0
+
 
 def is_dark_hour(sun_elevation_deg: float) -> bool:
     """True when the sun is far enough below the horizon to count as a dark hour
     (nautical/astronomical), the denominator for the clear-dark rate."""
     return sun_elevation_deg < NAUTICAL_DARK_DEG
+
+
+def is_twilight_hour(sun_elevation_deg: float) -> bool:
+    """True when the sun is below the -10 deg twilight floor: the widest window
+    the LIVE layer will surface as a usable (if not fully dark) stargazing hour.
+
+    Strictly weaker than is_dark_hour: a dark hour (sun < -12) is always also a
+    twilight hour (sun < -10), so dark windows are a subset of twilight windows.
+    Used only as the live summer fallback; the dark (-12) metric still drives
+    ranking and the historical climatology."""
+    return sun_elevation_deg < TWILIGHT_FLOOR_DEG
 
 
 def is_clear_dark_hour(sun_elevation_deg: float, cloud_area_fraction: float) -> bool:

--- a/projects/monolith/stars/scoring_test.py
+++ b/projects/monolith/stars/scoring_test.py
@@ -3,14 +3,17 @@
 from stars.scoring import (
     CLEAR_CLOUD_MAX_PCT,
     NAUTICAL_DARK_DEG,
+    TWILIGHT_FLOOR_DEG,
     is_clear_dark_hour,
     is_dark_hour,
+    is_twilight_hour,
 )
 
 
 def test_thresholds_are_the_contract_values():
     assert NAUTICAL_DARK_DEG == -12.0
     assert CLEAR_CLOUD_MAX_PCT == 10.0
+    assert TWILIGHT_FLOOR_DEG == -10.0
 
 
 class TestIsDarkHour:
@@ -29,6 +32,35 @@ class TestIsDarkHour:
 
     def test_daytime_is_not_dark(self):
         assert is_dark_hour(0.0) is False
+
+
+class TestIsTwilightHour:
+    def test_exactly_minus_10_is_not_twilight(self):
+        # Strictly below -10, so the boundary itself does not count.
+        assert is_twilight_hour(-10.0) is False
+
+    def test_just_below_minus_10_is_twilight(self):
+        assert is_twilight_hour(-10.01) is True
+
+    def test_shallower_than_floor_is_not_twilight(self):
+        # Far-north midsummer, sun only reaches ~-8: nothing usable.
+        assert is_twilight_hour(-8.0) is False
+
+    def test_daytime_is_not_twilight(self):
+        assert is_twilight_hour(0.0) is False
+
+    def test_dark_implies_twilight(self):
+        # Every true-dark hour (sun < -12) is also a twilight hour (sun < -10):
+        # dark windows are a strict subset of twilight windows.
+        for sun in (-12.01, -13.0, -18.0, -30.0):
+            assert is_dark_hour(sun) is True
+            assert is_twilight_hour(sun) is True
+
+    def test_between_floor_and_dark_is_twilight_only(self):
+        # -12 <= sun < -10: twilight-only fallback, not true dark.
+        for sun in (-10.5, -11.0, -11.99):
+            assert is_twilight_hour(sun) is True
+            assert is_dark_hour(sun) is False
 
 
 class TestIsClearDarkHour:


### PR DESCRIPTION
For ~7 weeks each midsummer Scotland has no astronomical darkness (sun never reaches -12 deg), so the live forecast layer is currently empty and useless. This adds a graceful, honest fallback.

## What
The strict -12 deg metric (history, ranking, the CERRA climatology) is untouched. The LIVE forecast now:
- Keeps hours down to a fixed -10 deg floor (mid-nautical twilight, brighter constellations + planets visible), each tagged `dark` (true < -12).
- `/sites` adds `clear_twilight_hours` (>= `clear_dark_hours`) and a top-level `darkness` flag: `astronomical` (a true-dark hour exists), `twilight` (only -10..-12 hours), or `none` (nothing below -10, far-north midsummer).
- Live page shows a disclaimer when there's no true darkness ("returns by August, showing the darkest twilight windows, best in the south"), colours markers by the twilight count in that mode, and the card labels each hour Dark/Twilight with its sun elevation.

Below -10 deg (far-north midsummer, sun only ~-8) the map stays empty, geographically honest. Why -10: nautical twilight where brighter stars/constellations are genuinely visible; below -6 (civil) only planets/Moon.

The `dark` flag is recomputed at read time from the stored `sun_elevation_deg`, so no schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)