### PR TITLE
fix(monolith): make stars card "Open in maps" a full-width tap target

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.139.0
+version: 0.139.1
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.139.0
+      targetRevision: 0.139.1
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/lib/public/components/stars/StarsMap.svelte
+++ b/projects/monolith/frontend/src/lib/public/components/stars/StarsMap.svelte
@@ -1014,30 +1014,51 @@
     margin: 4px 0 12px;
   }
 
+  /* Primary action: a full-width filled button rather than a thin underlined
+     link, so it is a comfortable tap target (>=44px tall) on the mobile bottom
+     sheet and reads as the card's main action. Lifts on press with the same
+     neobrutalist translate + hard shadow as the night/month chips. */
   .card-link {
-    display: inline-block;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    width: 100%;
+    min-height: 44px;
+    padding: 12px 14px;
+    background: var(--ink);
+    color: var(--paper);
+    border: 2px solid var(--ink);
     font-family: var(--mono);
     font-size: 12px;
     font-weight: 700;
-    letter-spacing: 0.04em;
-    color: var(--ink);
-    text-decoration: underline;
-    text-decoration-color: var(--blue);
-    text-decoration-thickness: 2px;
-    text-decoration-skip-ink: none;
-    text-underline-offset: 3px;
-    transition: background 140ms ease;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    text-decoration: none;
+    text-align: center;
+    cursor: pointer;
+    transition:
+      transform 110ms ease,
+      box-shadow 110ms ease,
+      background 110ms ease,
+      color 110ms ease;
   }
 
   .card-link:hover,
   .card-link:focus-visible {
-    background: linear-gradient(transparent 62%, var(--accent) 62%);
-    text-decoration-color: var(--ink);
+    transform: translate(-2px, -2px);
+    box-shadow: 2px 2px 0 var(--ink);
+    background: var(--accent);
+    color: var(--ink);
+  }
+
+  .card-link:active {
+    transform: translate(-1px, -1px);
+    box-shadow: 1px 1px 0 var(--ink);
   }
 
   .card-link-arrow {
     font-size: 0.85em;
-    margin-left: 2px;
   }
 
   /* Marker legend, bottom-left, clear of the bottom-right zoom + attribution. */

--- a/projects/monolith/frontend/src/lib/public/components/stars/StarsMap.svelte
+++ b/projects/monolith/frontend/src/lib/public/components/stars/StarsMap.svelte
@@ -854,24 +854,38 @@
     box-shadow: var(--shadow-hard);
   }
 
+  /* Close control: a full 44px square hit area (the glyph stays visually small
+     but the tap target meets the touch-size floor), sat in the top-right corner.
+     Lifts to the accent on hover/press so the affordance is obvious. */
   .card-close {
     position: absolute;
-    top: 8px;
-    right: 10px;
+    top: 4px;
+    right: 4px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 44px;
+    height: 44px;
     background: none;
     border: none;
     font-family: var(--mono);
-    font-size: 22px;
+    font-size: 24px;
     line-height: 1;
     cursor: pointer;
     color: var(--ink);
+    transition: background 110ms ease;
+  }
+
+  .card-close:hover,
+  .card-close:focus-visible {
+    background: var(--accent);
   }
 
   .card-name {
     font-family: var(--serif);
     font-size: 26px;
     line-height: 1.05;
-    margin: 2px 28px 12px 0;
+    margin: 2px 44px 12px 0;
     word-break: break-word;
   }
 


### PR DESCRIPTION
## What

On the `/app/stars` site detail card, the "Open in maps" action was a thin underlined text link. In the mobile bottom-sheet layout (see the reported screenshot) it is an awkward tap target, easy to miss.

This promotes it to a full-width filled button:

- `display: flex`, full width, `min-height: 44px` so it meets the standard touch-target size on phones.
- Filled ink-on-paper with a 2px ink border, matching the neobrutalist night/month chips.
- Standard press lift (translate + hard shadow) on hover/focus/active, flipping to the accent fill on hover for affordance.
- Centred label + arrow via flex gap (drops the old `margin-left` hack).

Reads as the card's primary action on desktop too, not just a fix for mobile.

## Scope

CSS-only change in `StarsMap.svelte`; no markup, behaviour, or data changes. The link still opens Google Maps at the site's lat/lon in a new tab.

https://claude.ai/code/session_01WVxrmBSPDsK2P9coMAGAAi

---
_Generated by [Claude Code](https://claude.ai/code/session_01WVxrmBSPDsK2P9coMAGAAi)_