### PR TITLE
fix(monolith): stars live map uses box-cell heatmap, restyle card close

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.139.1
+version: 0.139.2
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.139.1
+      targetRevision: 0.139.2
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/lib/public/components/stars/StarsMap.svelte
+++ b/projects/monolith/frontend/src/lib/public/components/stars/StarsMap.svelte
@@ -854,38 +854,49 @@
     box-shadow: var(--shadow-hard);
   }
 
-  /* Close control: a full 44px square hit area (the glyph stays visually small
-     but the tap target meets the touch-size floor), sat in the top-right corner.
-     Lifts to the accent on hover/press so the affordance is obvious. */
+  /* Close control: a bordered paper square matching the map's zoom/attribution
+     chrome (a bare glyph read as a stray character), 40px so it stays an easy
+     tap target. Lifts with the neobrutalist translate + hard shadow, flipping to
+     the accent on hover/press. */
   .card-close {
     position: absolute;
-    top: 4px;
-    right: 4px;
+    top: 10px;
+    right: 10px;
     display: flex;
     align-items: center;
     justify-content: center;
-    width: 44px;
-    height: 44px;
-    background: none;
-    border: none;
+    width: 40px;
+    height: 40px;
+    background: var(--paper);
+    border: 2px solid var(--ink);
     font-family: var(--mono);
-    font-size: 24px;
+    font-size: 22px;
     line-height: 1;
     cursor: pointer;
     color: var(--ink);
-    transition: background 110ms ease;
+    transition:
+      transform 110ms ease,
+      box-shadow 110ms ease,
+      background 110ms ease;
   }
 
   .card-close:hover,
   .card-close:focus-visible {
+    transform: translate(-2px, -2px);
+    box-shadow: 2px 2px 0 var(--ink);
     background: var(--accent);
+  }
+
+  .card-close:active {
+    transform: translate(-1px, -1px);
+    box-shadow: 1px 1px 0 var(--ink);
   }
 
   .card-name {
     font-family: var(--serif);
     font-size: 26px;
     line-height: 1.05;
-    margin: 2px 44px 12px 0;
+    margin: 2px 48px 12px 0;
     word-break: break-word;
   }
 

--- a/projects/monolith/frontend/src/routes/public/app/stars/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/stars/+page.svelte
@@ -19,15 +19,18 @@
   // behaves exactly as before (no disclaimer, dark-hour colouring).
   let darkness = $derived(data.snapshot?.darkness ?? "astronomical");
 
-  // Mode: LIVE = the upcoming-forecast layer (per-night quality), markers only;
-  // HISTORICAL = the month-bucketed clear-dark-hours layer (stars v2), the
-  // box-cell heatmap. The toggle swaps the map's data source, the time control
-  // (night picker vs month picker), and whether the box-cell heatmap shows.
+  // Mode: LIVE = the upcoming-forecast layer (per-night quality); HISTORICAL =
+  // the month-bucketed clear-dark-hours layer (stars v2). Both render as the
+  // box-cell heatmap (see heatOn below). The toggle swaps the map's data source
+  // and the time control (night picker vs month picker).
   let mode = $state("live");
 
-  // The box-cell heatmap belongs to the historical layer only: LIVE is always
-  // markers, HISTORICAL is always the heatmap. StarsMap reads this resolved flag.
-  let heatOn = $derived(mode === "historical");
+  // Both layers render as the box-cell heatmap. The site grid is a dense ~4km
+  // mesh (thousands of sites), so plotting raw point markers piles them into
+  // unreadable blobs; the filled cells read cleanly at every zoom (ADR 009,
+  // mirroring /app/ships). StarsMap still opens the per-site card on a cell tap,
+  // so the live forecast windows table is unaffected. Always on, both modes.
+  const heatOn = true;
 
   // Night picker (LIVE): "I'm free Saturday, show me the map for Saturday night."
   // One chip per viewing night plus an "All" reset; picking a night filters the


### PR DESCRIPTION
Follow-up to #2610 from feedback on the two screenshots ("the x looks weird" + "now that we have a dense grid just rendering raw points is super ugly").

## Changes

**1. Live map renders as the box-cell heatmap**
The site grid is a dense ~4km mesh (thousands of sites). In LIVE mode the raw circle markers piled up into unreadable purple/black blobs. This switches the live layer to the same box-cell heatmap the historical layer already uses (`heatOn = true` for both modes), so the field reads cleanly at every zoom. The per-site detail card still opens on a cell tap, so the live forecast windows table is unaffected. Markers/heatmap mechanism in `StarsMap.svelte` is unchanged — only which one the page enables.

**2. Card close (×) restyled**
Every other control on the map (zoom +/−, the attribution "i") is a bordered paper square, so the bare × glyph read as a stray character. This makes it a bordered 40px paper square matching that chrome, with the standard neobrutalist press lift and accent hover. Keeps an easy tap target; widened the heading's right margin to clear it.

## Scope
CSS + one flag flip across `StarsMap.svelte` and the stars `+page.svelte`. No data, API, or markup-behaviour changes.

Note: I can't visually verify the rendered result from here (no branch dev server per the repo's no-local-test-loop setup), so a spot-check once it deploys would confirm the live heatmap and close button feel right.

https://claude.ai/code/session_01WVxrmBSPDsK2P9coMAGAAi

---
_Generated by [Claude Code](https://claude.ai/code/session_01WVxrmBSPDsK2P9coMAGAAi)_