### PR TITLE
docs: document Discord notify tool for alerting from a session

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -139,6 +139,7 @@ For everything else, use `kubectl`. SigNoz observability (historical logs/traces
 | **BuildBuddy CI**    | `mcp__buildbuddy__get_invocation` (selectors: `invocationId` or `commitSha`) → `get_target` → `get_action` → `get_log`. `get_file_range` reads byte ranges from CAS blob URIs in build events (16 MiB max). |
 | **Observability** (logs/traces/metrics/dashboards/alerts) | SigNoz UI at `private.jomcgi.dev/app/signoz`. No MCP by default; running `projects/platform/signoz-addons/signoz-mcp-wrapper.sh` locally exposes `signoz-*` tools (search-logs, search-traces-by-service, list-dashboards, list-alerts, etc.). |
 | **Agent jobs**       | `monolith-monolith-agent-list-routine-jobs`, `monolith-monolith-agent-trigger-routine-job`, `monolith-monolith-agent-trigger-job`                                                                           |
+| **Alert / message Joe** | `monolith-monolith-agent-notify` posts a Discord message via the in-process bot (args: `message`, optional `level` of `info`/`warn`/`error`, optional `channel` from the allow-list). Defaults to the homelab channel. This is the way to reach Joe from a session (a finished long task, a blocked decision, a heads-up). Outbound only: it cannot read or list channels. Be sparing, one clear message, not a play-by-play. |
 
 ## Kubernetes Operations (kubectl)
 


### PR DESCRIPTION
Adds a row to the Cluster Investigation table in the root `CLAUDE.md` documenting `monolith-monolith-agent-notify` as the way to alert Joe from a session (Discord, via the in-process bot).

Covers: the args (`message`, optional `level`, optional `channel`), the default homelab channel, that it's outbound-only (cannot read/list channels), and a note to be sparing.

Confirmed working this session: a test message posted successfully to the default homelab channel.

Docs-only change.

https://claude.ai/code/session_01WVxrmBSPDsK2P9coMAGAAi

---
_Generated by [Claude Code](https://claude.ai/code/session_01WVxrmBSPDsK2P9coMAGAAi)_