### PR TITLE
fix(monolith): stars card close button in flow, drop card shadow

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.139.2
+version: 0.139.3
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.139.2
+      targetRevision: 0.139.3
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/lib/public/components/stars/StarsMap.svelte
+++ b/projects/monolith/frontend/src/lib/public/components/stars/StarsMap.svelte
@@ -611,10 +611,17 @@
 
   {#if selected}
     <aside class="card">
-      <button class="card-close" onclick={closeCard} aria-label="Close site card"
-        >&times;</button
-      >
-      <h2 class="card-name">{selected.name}</h2>
+      <!-- Header keeps the close control in normal flow (right-aligned via
+           margin-left:auto) so it always reserves its own height and can never
+           overlap the stats box, with or without a site name (grid sites have
+           none, which is why the absolutely-positioned button used to collide
+           with the cream stats box). -->
+      <header class="card-head">
+        {#if selected.name}<h2 class="card-name">{selected.name}</h2>{/if}
+        <button class="card-close" onclick={closeCard} aria-label="Close site card"
+          >&times;</button
+        >
+      </header>
 
       {#if mode === "historical"}
         <!-- Historical body: the clear-dark-hour count for the selected view
@@ -851,7 +858,15 @@
     padding: 18px;
     background: var(--paper);
     border: 2px solid var(--ink);
-    box-shadow: var(--shadow-hard);
+  }
+
+  /* Header row: site name (when present) on the left, close control pushed to
+     the right. Reserves the button's height in flow so content sits clear. */
+  .card-head {
+    display: flex;
+    align-items: flex-start;
+    gap: 12px;
+    margin-bottom: 12px;
   }
 
   /* Close control: a bordered paper square matching the map's zoom/attribution
@@ -859,9 +874,8 @@
      tap target. Lifts with the neobrutalist translate + hard shadow, flipping to
      the accent on hover/press. */
   .card-close {
-    position: absolute;
-    top: 10px;
-    right: 10px;
+    flex: 0 0 auto;
+    margin-left: auto;
     display: flex;
     align-items: center;
     justify-content: center;
@@ -893,10 +907,11 @@
   }
 
   .card-name {
+    flex: 1 1 auto;
     font-family: var(--serif);
     font-size: 26px;
     line-height: 1.05;
-    margin: 2px 48px 12px 0;
+    margin: 0;
     word-break: break-word;
   }
 


### PR DESCRIPTION
## What

On `/app/stars`, the detail card's close (×) button was made larger (40px) for mobile tap targets, but as an `position: absolute` element it overlapped the cream stats box: grid sites have no `name`, so the title `<h2>` collapsed to zero height and the stats box slid up directly under the button.

## Fix

- Move the close button into a flex header row (`.card-head`), right-aligned via `margin-left: auto`, so it reserves its own height in flow and can never overlap content, with or without a site name. The 40px tap target is preserved.
- Drop the default `box-shadow: var(--shadow-hard)` on `.card`: the hard shadow added visual noise to the popout with no affordance value (the legend already has no shadow; the button keeps its hover/press lift).

Chart bumped 0.139.2 -> 0.139.3 (Chart.yaml + application.yaml targetRevision).

## Verification

Renders correctly in both modes (live "Upcoming clear windows" and historical "Clear dark hours by month"). Visual change only, no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)