### PR TITLE
docs(adr): revise ADR 006 Phase 4 to a tool-based gardener

### DIFF
--- a/docs/decisions/platform/006-obsidian-decommission-postgres-interim.md
+++ b/docs/decisions/platform/006-obsidian-decommission-postgres-interim.md
@@ -40,22 +40,24 @@ Make **Postgres the source of truth for note bodies** and **a monolith-served no
 
 1. **Body in Postgres.** Add an authoritative `content` column to `knowledge.notes`. `get_note` stops reading the filesystem; the web app and MCP tools read and write `content` directly. One-shot backfill of existing `_processed/` bodies from disk (raws are already in `knowledge.raw_inputs`).
 2. **Notes web UI.** A markdown read/write surface in the monolith (list, search, edit, wikilink and graph navigation reusing the existing search API and `layout_x/y`), reachable through Cloudflare Access exactly as the `homelab` CLI is today. This replaces the Obsidian app for both desktop and mobile (browser).
-3. **Gardener without a vault filesystem.** The gardener keeps its Claude-Code-with-files ergonomics by materializing only its working set into a per-run temp directory from Postgres, letting the subprocess edit files there, and writing results back to `knowledge.notes`. The vault stops being a durable, externally-mutated filesystem.
-4. **Retire Obsidian plumbing.** Remove the `headless-sync` sidecar and the durable `/vault` volume, cancel the Obsidian Sync subscription, and switch the deploy to `RollingUpdate`. Capture paths that previously relied on Obsidian mobile (quick capture) move to the already-built `ingest_queue`, `web_share`, `insert_api`, and Discord-mirror paths, plus a capture box in the web UI.
-5. **Backup.** Replace the git-push `knowledge.vault-backup` job with CNPG WAL/PITR (already configured) plus an optional periodic markdown export to a read-only git mirror, preserving a human-readable audit trail.
+3. **Gardener via schema-enforced tools, not a filesystem.** The gardener's Claude Code subprocess stops reading and writing `_processed/*.md`. Instead it operates through a `knowledge` Typer CLI grounded in the monolith's own store: `search`, `get`, `create-atom`, `edit`, `patch-edges`, and `get-raw`. The CLI is a thin veneer over the same `KnowledgeStore` + `knowledge.indexing` code the HTTP API and MCP tools use, so there is exactly one validated implementation of every operation. Atom/fact/active schemas are enforced at the CLI argument boundary, so a malformed atom is rejected with a correctable error instead of the prompt begging the model to quote its YAML. This removes the materialize-to-tmpdir step entirely: there is no working set to stage because the subprocess queries live Postgres on each call. (Originally specified as a per-run tmpdir materialized from Postgres; superseded 2026-06-14 by this tool-based approach, which is simpler and folds in schema enforcement.)
+4. **Raws as ground truth in object storage.** The immutable, content-addressed raw captures move out of `knowledge.raw_inputs.content` (Postgres) into SeaweedFS at `s3://knowledge-raws/<sha256>`, with the bucket provisioned via COSI per [ADR 007](007-seaweedfs-bucket-provisioning-cosi.md) (`deletionPolicy: Retain`, no TTL, content-addressed). `raw_inputs` keeps metadata plus the content-hash key; the gardener reads a raw via `get-raw`. This keeps the hot Postgres lean (raws are the bulk of the bytes and are never query targets), mirroring the `chat.blobs` BYTEA -> SeaweedFS migration. Sequenced after the tool-based gardener (Phase 4b).
+5. **Retire Obsidian plumbing.** Remove the `headless-sync` sidecar and the durable `/vault` volume, cancel the Obsidian Sync subscription, and switch the deploy to `RollingUpdate`. Capture paths that previously relied on Obsidian mobile (quick capture) move to the already-built `ingest_queue`, `web_share`, `insert_api`, and Discord-mirror paths, plus a capture box in the web UI.
+6. **Backup.** Replace the git-push `knowledge.vault-backup` job with CNPG WAL/PITR (already configured) plus an optional periodic markdown export to a read-only git mirror, preserving a human-readable audit trail.
 
 Postgres is the **destination** for note bodies, not an interim (the lakehouse this ADR originally preceded was withdrawn on 2026-06-14). Web-app data access still sits behind the thin `KnowledgeStore` interface, kept for testability and a clean read-path seam rather than as a hedge toward a future serving layer.
 
-| Aspect                  | Today (Obsidian)                     | Decided (Postgres, destination)                         |
-| ----------------------- | ------------------------------------ | ------------------------------------------------------- |
-| **Editing surface**     | Obsidian app + paid Sync             | Monolith notes web UI (Cloudflare Access)               |
-| **Note body of record** | `/vault/_processed/*.md` on disk     | `knowledge.notes.content` in Postgres                   |
-| **Search**              | pgvector on `chunks`                 | pgvector on `chunks` (unchanged)                        |
-| **Gardener I/O**        | Claude Code against durable `/vault` | Claude Code against per-run tmpdir, results to Postgres |
-| **Sync sidecar**        | `headless-sync` (Obsidian Sync)      | none                                                    |
-| **Vault volume**        | durable emptyDir/PVC, single replica | none; `RollingUpdate`, N replicas                       |
-| **Backup**              | git push of `/vault`                 | CNPG WAL + optional markdown git export                 |
-| **Third-party egress**  | Obsidian cloud                       | none                                                    |
+| Aspect                  | Today (Obsidian)                                     | Decided (Postgres, destination)                                             |
+| ----------------------- | ---------------------------------------------------- | --------------------------------------------------------------------------- |
+| **Editing surface**     | Obsidian app + paid Sync                             | Monolith notes web UI (Cloudflare Access)                                   |
+| **Note body of record** | `/vault/_processed/*.md` on disk                     | `knowledge.notes.content` in Postgres                                       |
+| **Raw ground truth**    | `/vault/_raw/*.md` + `raw_inputs.content` (Postgres) | `s3://knowledge-raws/<sha256>` (SeaweedFS, COSI)                            |
+| **Search**              | pgvector on `chunks`                                 | pgvector on `chunks` (unchanged)                                            |
+| **Gardener I/O**        | Claude Code against durable `/vault`                 | Claude Code via schema-enforced `knowledge` CLI -> Postgres (no filesystem) |
+| **Sync sidecar**        | `headless-sync` (Obsidian Sync)                      | none                                                                        |
+| **Vault volume**        | durable emptyDir/PVC, single replica                 | none; `RollingUpdate`, N replicas                                           |
+| **Backup**              | git push of `/vault`                                 | CNPG WAL + optional markdown git export                                     |
+| **Third-party egress**  | Obsidian cloud                                       | none                                                                        |
 
 ---
 
@@ -74,17 +76,17 @@ graph TB
     IQ -->|raw markdown| PG
 
     subgraph Gardener["knowledge.garden (scheduled)"]
-      MAT["materialize working set -> tmpdir"] --> CC["Claude Code (Read/Write/Edit)"]
-      CC --> WB["write results back"]
+      CC["Claude Code subprocess"] -->|search / get / create-atom / edit / patch-edges| CLI["knowledge Typer CLI"]
+      CC -->|get-raw| CLI
     end
-    PG -->|raws + context| MAT
-    WB -->|upsert notes / edges / gaps| PG
+    CLI -->|same KnowledgeStore + indexing| PG
+    RAW[("SeaweedFS<br/>s3://knowledge-raws/&lt;sha256&gt;")] -->|get-raw| CLI
 
     PG -->|CNPG WAL / PITR| BK["backups"]
     PG -.->|optional periodic export| GIT["read-only markdown git mirror"]
 ```
 
-The only components that change are the ones Obsidian touched: the editing surface (new web UI), the body-of-record (now `knowledge.notes.content`), and the gardener's file I/O (now a per-run tmpdir). Chunking, embedding, pgvector search, edges, gaps, graph layout, and the scheduler are unchanged.
+The only components that change are the ones Obsidian touched: the editing surface (new web UI), the body-of-record (now `knowledge.notes.content`), the raw ground truth (now `s3://knowledge-raws` via COSI), and the gardener's I/O (now the schema-enforced `knowledge` CLI, no filesystem). Chunking, embedding, pgvector search, edges, gaps, graph layout, and the scheduler are unchanged.
 
 ---
 
@@ -111,13 +113,13 @@ Baseline per `docs/security.md`. Deviations and notes:
 
 ## Risks
 
-| Risk                                                      | Likelihood | Impact | Mitigation                                                                                                   |
-| --------------------------------------------------------- | ---------- | ------ | ------------------------------------------------------------------------------------------------------------ |
-| Web UI is real net-new work                               | High       | Medium | Reuse the existing `/private/notes` graph + search API; ship editor + capture incrementally (plan Phase 5)   |
-| Gardener tmpdir materialization loses or mis-writes notes | Medium     | High   | Write-back is an explicit upsert keyed on `note_id` + `content_hash`; keep a markdown git export as recovery |
-| Loss of Obsidian mobile capture ergonomics                | Medium     | Medium | Web UI capture box plus existing `ingest_queue`/`web_share`/Discord paths; validate before cutting Sync      |
-| Processed-note body backfill from disk is incomplete      | Low        | High   | One-shot reconcile diffs `content_hash` against disk; run before removing the vault volume                   |
-| pgvector load grows on the shared CNPG cluster            | Low        | Medium | Unchanged from today; monitor via SigNoz, bump CNPG resources if needed                                      |
+| Risk                                                 | Likelihood | Impact | Mitigation                                                                                                                                                                                         |
+| ---------------------------------------------------- | ---------- | ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Web UI is real net-new work                          | High       | Medium | Reuse the existing `/private/notes` graph + search API; ship editor + capture incrementally (plan Phase 5)                                                                                         |
+| Gardener atom writes are malformed or lose data      | Medium     | High   | The `create-atom`/`edit` CLI validates the schema and goes through the shared `knowledge.indexing` upsert (atomic, committed); raws stay immutable in object storage so any atom can be re-derived |
+| Loss of Obsidian mobile capture ergonomics           | Medium     | Medium | Web UI capture box plus existing `ingest_queue`/`web_share`/Discord paths; validate before cutting Sync                                                                                            |
+| Processed-note body backfill from disk is incomplete | Low        | High   | One-shot reconcile diffs `content_hash` against disk; run before removing the vault volume                                                                                                         |
+| pgvector load grows on the shared CNPG cluster       | Low        | Medium | Unchanged from today; monitor via SigNoz, bump CNPG resources if needed                                                                                                                            |
 
 ---
 
@@ -130,10 +132,11 @@ Baseline per `docs/security.md`. Deviations and notes:
 
 ## References
 
-| Resource                                                                                 | Relevance                                                      |
-| ---------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
-| [001 — Obsidian Vault Migration into Monolith](001-obsidian-vault-monolith-migration.md) | Superseded: it kept Obsidian Sync via TigerFS                  |
-| [004 — Iceberg-on-SeaweedFS Lakehouse](004-iceberg-lakehouse-hot-swap.md)                | Superseded (KG storage domain); lakehouse withdrawn 2026-06-14 |
-| `projects/monolith/knowledge/`                                                           | Gardener, store, router, MCP tools being adapted               |
-| `projects/monolith/chart/migrations/20260408000000_knowledge_schema.sql`                 | `knowledge.notes` schema gaining a `content` column            |
-| `projects/monolith/chart/templates/cnpg-cluster.yaml`                                    | CNPG cluster + pgvector hosting the body of record             |
+| Resource                                                                                  | Relevance                                                      |
+| ----------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
+| [001 — Obsidian Vault Migration into Monolith](001-obsidian-vault-monolith-migration.md)  | Superseded: it kept Obsidian Sync via TigerFS                  |
+| [004 — Iceberg-on-SeaweedFS Lakehouse](004-iceberg-lakehouse-hot-swap.md)                 | Superseded (KG storage domain); lakehouse withdrawn 2026-06-14 |
+| [007 — SeaweedFS bucket provisioning via COSI](007-seaweedfs-bucket-provisioning-cosi.md) | How the `knowledge-raws` bucket is provisioned (Phase 4b)      |
+| `projects/monolith/knowledge/`                                                            | Gardener, store, router, MCP tools, and the `knowledge` CLI    |
+| `projects/monolith/chart/migrations/20260408000000_knowledge_schema.sql`                  | `knowledge.notes` schema gaining a `content` column            |
+| `projects/monolith/chart/templates/cnpg-cluster.yaml`                                     | CNPG cluster + pgvector hosting the body of record             |

--- a/docs/plans/2026-06-13-obsidian-decommission-plan.md
+++ b/docs/plans/2026-06-13-obsidian-decommission-plan.md
@@ -63,14 +63,22 @@ Keep writing the disk file **too** (dual-write) so Obsidian Sync and the reconci
 
 **Verify:** CI green; create/edit via web API, confirm row + chunks update and (still) a disk file appears.
 
-## Phase 4 — Gardener without a durable vault FS
+## Phase 4 — Gardener via schema-enforced tools (revised 2026-06-14)
 
-Repoint the gardener's Claude Code subprocess from the durable `/vault` to a **per-run tmpdir** materialized from Postgres:
+Originally specified as a per-run tmpdir materialized from Postgres. Superseded by a **tool-based gardener**: the subprocess never touches a filesystem, it operates through a `knowledge` Typer CLI grounded in the monolith store. This dissolves the materialization problem (the subprocess discovers and edits notes mid-run via `knowledge-search`, so the working set is unknowable up front) and folds in schema enforcement. Split into two independently shippable sub-phases.
 
-- `knowledge/gardener.py:261-277` (`vault_root`/`processed_root`), `:786` (`cwd=self.vault_root`), `:920-984` (before/after glob + read-back): materialize only the working set (target raws + relevant `_processed` notes pulled from `knowledge.notes.content`) into `tempfile.mkdtemp()`, set `cwd` there, diff new/changed files after the run, and `upsert_note` results back to Postgres keyed on `note_id` + `content_hash`.
-- The vault-wide reconciler scan becomes redundant for gardener output once writes go through `upsert_note`; keep it running until Phase 6 as the consistency net.
+### Phase 4a — `knowledge` Typer CLI + tool-based gardener
 
-**Verify:** CI green; trigger `knowledge.garden` (scheduler skill / `monolith-agent-trigger-job`), confirm new atoms land in Postgres with no durable-vault dependency.
+- **New `knowledge/cli.py`**: a Typer app exposing `search`, `get`, `create-atom`, `edit`, `patch-edges`, `get-raw`. Thin veneer over `KnowledgeStore` + `knowledge.indexing` (the same code the HTTP API and MCP use); opens a DB session in-process exactly as `knowledge/tools/knowledge-search` does today. Register a console-script/shim and bake into the image alongside `knowledge-search` (`BUILD:173-175` pattern).
+- **Schema enforcement**: Pydantic models for `atom` / `fact` / `active` (active requires `status` + `size`; edges typed; `visibility` required). `create-atom` validates and, on failure, prints a correctable error the subprocess can act on. `create-atom`/`edit` go through `index_note_from_raw`/`index_parsed_note` (chunk + embed + upsert, committed) and record `atom_raw_provenance`.
+- **Gardener rewrite** (`knowledge/gardener.py`): drop `cwd=vault_root`, the before/after `_processed` glob, and the disk read-back. Rewrite `_CLAUDE_PROMPT_HEADER` to instruct the subprocess to use the `knowledge` CLI verbs instead of Read/Write/Edit + filesystem paths. Provenance is recorded from the `create-atom` return (note ids), not from globbed files.
+- **Verify:** CI green; trigger `knowledge.garden`, confirm new atoms land in Postgres with no `_processed` filesystem writes; malformed-atom rejection exercised in tests.
+
+### Phase 4b — Raws to SeaweedFS via COSI (sequenced after 4a)
+
+- Provision a `knowledge-raws` bucket via a COSI `BucketClaim` in `projects/monolith/deploy/` per [ADR 007](../decisions/platform/007-seaweedfs-bucket-provisioning-cosi.md) (`deletionPolicy: Retain`, content-addressed, no TTL).
+- Move raw content from `knowledge.raw_inputs.content` (Postgres) to `s3://knowledge-raws/<sha256>`, mirroring the `chat.blobs` migration (nullable -> backfill/export -> drop column -> `VACUUM FULL`). `raw_inputs` keeps metadata + the content-hash key. `get-raw` reads from S3.
+- **Verify:** CI green; `raw_inputs.content` dropped; gardener `get-raw` serves from SeaweedFS; Postgres size reclaimed.
 
 ## Phase 5 — Notes web UI (editor + search)
 

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.139.3
+version: 0.139.4
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.139.3
+      targetRevision: 0.139.4
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
Revises ADR 006 Phase 4 from the per-run-tmpdir gardener to a **schema-enforced `knowledge` Typer CLI grounded in the monolith store**, and splits the plan's Phase 4 into 4a (CLI + gardener rewrite) and 4b (raws to SeaweedFS/COSI).

### Why
The gardener subprocess discovers and edits existing notes mid-run via `knowledge-search`, so the working set is unknowable up front, which made "materialize the working set into a tmpdir" a chicken-and-egg problem. Operating through Postgres-backed tools (`search`/`get`/`create-atom`/`edit`/`patch-edges`/`get-raw`) dissolves that and moves frontmatter validation from prompt admonitions to a typed argument boundary. The CLI is a thin veneer over the same `KnowledgeStore` + `knowledge.indexing` the HTTP API and MCP already use, so there's one validated implementation.

### Changes
- **ADR 006**: rewrite Decision item 3 (tools, not tmpdir); add item 4 (raws to `s3://knowledge-raws` via COSI per ADR 007); update comparison table, architecture diagram, gardener risk row, references.
- **Plan**: split Phase 4 into 4a (Typer CLI + gardener rewrite) and 4b (raws to SeaweedFS/COSI).

ADR 007 (COSI bucket provisioning, Accepted 2026-06-14) already covers the bucket mechanism and is referenced rather than duplicated.

Companion to merged #2593/#2604/#2607 (Phases 1-3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)