### PR TITLE
feat(monolith): in-pod knowledge Typer CLI (ADR 006 Phase 4a-i)

### DIFF
--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -146,6 +146,7 @@ py_library(
         "@pip//sqlmodel",
         "@pip//timelength",
         "@pip//trafilatura",
+        "@pip//typer",
         "@pip//tzdata",
         "@pip//uvicorn",
         "@pip//websockets",
@@ -170,9 +171,13 @@ py_library(
 
 tar(
     name = "knowledge_tools_tar",
-    srcs = ["knowledge/tools/knowledge-search"],
+    srcs = [
+        "knowledge/tools/knowledge",
+        "knowledge/tools/knowledge-search",
+    ],
     mtree = [
         "./usr/local/bin/knowledge-search type=file content=$(execpath knowledge/tools/knowledge-search) mode=0755 uid=0 gid=0",
+        "./usr/local/bin/knowledge type=file content=$(execpath knowledge/tools/knowledge) mode=0755 uid=0 gid=0",
     ],
 )
 
@@ -2555,6 +2560,17 @@ py_test(
         ":monolith_backend",
         "@pip//pytest",
         "@pip//pytest_asyncio",
+    ],
+)
+
+py_test(
+    name = "knowledge_cli_test",
+    srcs = ["knowledge/cli_test.py"],
+    imports = ["."],
+    deps = [
+        ":monolith_backend",
+        "@pip//pytest",
+        "@pip//typer",
     ],
 )
 

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.139.4
+version: 0.139.5
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.139.4
+      targetRevision: 0.139.5
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/knowledge/cli.py
+++ b/projects/monolith/knowledge/cli.py
@@ -1,0 +1,442 @@
+"""In-pod Typer CLI for the knowledge gardener (ADR 006 Phase 4a).
+
+Replaces the gardener subprocess's Read/Write/Edit on ``/vault/_processed``
+with create/edit/search commands grounded in the monolith's own store, so
+every atom is created or mutated through one validated, synchronously
+indexed path.
+
+Runs INSIDE the monolith pod against ``DATABASE_URL`` (exactly like the
+``knowledge-search`` script): each command opens its own engine + session,
+embeds via :class:`shared.embedding.EmbeddingClient`, and indexes through
+:func:`knowledge.indexing.index_note_from_raw` (chunk + embed + link-extract
++ upsert, committed). Indexing is async, so each command wraps the coroutine
+in ``asyncio.run`` (Typer commands are sync).
+
+The write commands DUAL-WRITE: a ``_processed/<slug>.md`` file on disk plus a
+synchronous index into Postgres. The disk file is a safety net through Phase
+5: the reconciler deletes notes whose file is missing, and Obsidian sync
+still reads the files.
+
+Output discipline: stdout carries the machine-usable result (JSON for
+search/get, raw markdown for get-raw, the note_id string for the write
+commands). All diagnostics and errors go to stderr. Exit codes: 0 ok,
+1 not-found/runtime, 2 validation.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import math
+import os
+import sys
+from enum import Enum
+from pathlib import Path
+from typing import Annotated, Optional
+
+import typer
+import yaml
+
+from knowledge import frontmatter
+from knowledge.gardener import GARDENER_VERSION, _slugify
+from knowledge.indexing import index_note_from_raw
+from knowledge.models import AtomRawProvenance, RawInput
+from knowledge.notes import _serialize_frontmatter
+from knowledge.store import KnowledgeStore
+from shared.embedding import EmbeddingClient
+from sqlmodel import Session, create_engine, select
+
+app = typer.Typer(
+    name="knowledge",
+    help="In-pod knowledge gardener: search, read, and create/edit atoms.",
+)
+
+
+class AtomType(str, Enum):
+    atom = "atom"
+    fact = "fact"
+    active = "active"
+
+
+class Visibility(str, Enum):
+    public = "public"
+    private = "private"
+
+
+class Status(str, Enum):
+    active = "active"
+    someday = "someday"
+    blocked = "blocked"
+
+
+class Size(str, Enum):
+    small = "small"
+    medium = "medium"
+    large = "large"
+    unknown = "unknown"
+
+
+def _engine():
+    """Open a SQLModel engine from ``DATABASE_URL`` or exit 1 to stderr."""
+    db_url = os.environ.get("DATABASE_URL")
+    if not db_url:
+        typer.echo("knowledge: DATABASE_URL not set", err=True)
+        raise typer.Exit(1)
+    return create_engine(db_url)
+
+
+def _vault_root() -> Path:
+    return Path(os.environ.get("VAULT_ROOT", "/vault"))
+
+
+def _read_body(body: str) -> str:
+    """Resolve a ``--body`` value, reading stdin when it is ``-``."""
+    if body == "-":
+        return sys.stdin.read()
+    return body
+
+
+def _parse_edges(edge_strs: list[str]) -> dict[str, list[str]]:
+    """Parse ``type:target-slug`` edge specs into an ``{type: [targets]}`` map.
+
+    Raises ``ValueError`` (mapped to exit 2 by callers) on a malformed spec
+    or an unknown edge type. Targets are de-duplicated, preserving order.
+    """
+    edges: dict[str, list[str]] = {}
+    for spec in edge_strs:
+        if ":" not in spec:
+            raise ValueError(f"invalid edge {spec!r}: expected 'type:target-slug'")
+        edge_type, _, target = spec.partition(":")
+        edge_type = edge_type.strip()
+        target = target.strip()
+        if edge_type not in frontmatter._KNOWN_EDGE_TYPES:
+            valid = ", ".join(sorted(frontmatter._KNOWN_EDGE_TYPES))
+            raise ValueError(f"invalid edge type {edge_type!r}: must be one of {valid}")
+        if not target:
+            raise ValueError(f"invalid edge {spec!r}: empty target")
+        edges.setdefault(edge_type, [])
+        if target not in edges[edge_type]:
+            edges[edge_type].append(target)
+    return edges
+
+
+def _edges_or_exit(edge_strs: list[str]) -> dict[str, list[str]]:
+    try:
+        return _parse_edges(edge_strs)
+    except ValueError as exc:
+        typer.echo(f"knowledge: {exc}", err=True)
+        raise typer.Exit(2) from exc
+
+
+@app.command()
+def search(
+    query: Annotated[str, typer.Argument(help="Natural-language search query")],
+    limit: Annotated[int, typer.Option("--limit", help="Max results")] = 5,
+) -> None:
+    """Semantic search over the notes graph; prints a JSON array to stdout."""
+    engine = _engine()
+    embed_client = EmbeddingClient()
+    embedding = asyncio.run(embed_client.embed(query))
+    with Session(engine) as session:
+        results = KnowledgeStore(session).search_notes(
+            query_embedding=embedding, limit=limit
+        )
+    # Drop NaN/inf scores so the JSON stays valid and downstream-parseable
+    # (mirrors knowledge-search's finite-score filter).
+    safe = [
+        r
+        for r in results
+        if isinstance(r.get("score"), (int, float)) and math.isfinite(r["score"])
+    ]
+    typer.echo(json.dumps(safe))
+
+
+@app.command()
+def get(
+    note_id: Annotated[str, typer.Argument(help="Stable note_id")],
+) -> None:
+    """Print a note's metadata, body, and edges as JSON to stdout."""
+    engine = _engine()
+    with Session(engine) as session:
+        store = KnowledgeStore(session)
+        note = store.get_note_by_id(note_id)
+        if note is None:
+            typer.echo(f"knowledge: note not found: {note_id}", err=True)
+            raise typer.Exit(1)
+        edges = store.get_note_links(note_id)
+    out = {
+        "note_id": note["note_id"],
+        "title": note["title"],
+        "type": note.get("type"),
+        "tags": note.get("tags", []),
+        "content": note.get("content"),
+        "edges": edges,
+    }
+    typer.echo(json.dumps(out))
+
+
+@app.command(name="get-raw")
+def get_raw(
+    raw_id: Annotated[str, typer.Argument(help="raw_inputs.raw_id")],
+) -> None:
+    """Print a raw input's markdown content (not JSON) to stdout."""
+    engine = _engine()
+    with Session(engine) as session:
+        row = session.exec(select(RawInput).where(RawInput.raw_id == raw_id)).first()
+    if row is None:
+        typer.echo(f"knowledge: raw not found: {raw_id}", err=True)
+        raise typer.Exit(1)
+    typer.echo(row.content)
+
+
+@app.command(name="create-atom")
+def create_atom(
+    title: Annotated[str, typer.Option("--title", help="Note title (required)")],
+    body: Annotated[
+        str, typer.Option("--body", help="Body markdown, or '-' to read stdin")
+    ],
+    note_type: Annotated[AtomType, typer.Option("--type", help="atom | fact | active")],
+    visibility: Annotated[
+        Visibility, typer.Option("--visibility", help="public | private")
+    ],
+    tags: Annotated[list[str], typer.Option("--tags", help="Tag (repeatable)")] = [],
+    aliases: Annotated[
+        list[str], typer.Option("--aliases", help="Alias (repeatable)")
+    ] = [],
+    edge: Annotated[
+        list[str],
+        typer.Option("--edge", help="Typed edge 'type:target-slug' (repeatable)"),
+    ] = [],
+    derived_from_raw: Annotated[
+        Optional[str],
+        typer.Option("--derived-from-raw", help="raw_id for provenance"),
+    ] = None,
+    status: Annotated[
+        Optional[Status],
+        typer.Option("--status", help="active-only: active | someday | blocked"),
+    ] = None,
+    size: Annotated[
+        Optional[Size],
+        typer.Option("--size", help="active-only: small | medium | large | unknown"),
+    ] = None,
+    due: Annotated[
+        Optional[str], typer.Option("--due", help="active-only: ISO due date")
+    ] = None,
+    blocked_by: Annotated[
+        list[str],
+        typer.Option("--blocked-by", help="active-only: blocking note_id (repeatable)"),
+    ] = [],
+) -> None:
+    """Create a new atom: validate, dual-write the file, and index it.
+
+    On success prints the resolved note_id to stdout. Validation failures
+    (bad edge, active without status/size) print a correctable message to
+    stderr and exit 2.
+    """
+    # Schema enforcement before any side effects. type/visibility are
+    # required by Typer; active notes additionally require status AND size.
+    if note_type is AtomType.active and (status is None or size is None):
+        typer.echo(
+            "knowledge: type=active requires --status and --size",
+            err=True,
+        )
+        raise typer.Exit(2)
+    edges = _edges_or_exit(edge)
+
+    # Resolve the filename collision under _processed/ the same way
+    # router.create_note does; the resolved stem becomes the note_id.
+    vault_root = _vault_root()
+    processed = vault_root / "_processed"
+    slug = _slugify(title)
+    filename = f"{slug}.md"
+    dest = processed / filename
+    counter = 1
+    while dest.exists():
+        filename = f"{slug}-{counter}.md"
+        dest = processed / filename
+        counter += 1
+    note_id = dest.stem
+    rel_path = f"_processed/{filename}"
+
+    fm_dict: dict = {
+        "id": note_id,
+        "title": title,
+        "type": note_type.value,
+        "visibility": visibility.value,
+    }
+    if derived_from_raw is not None:
+        fm_dict["derived_from_raw"] = derived_from_raw
+    if tags:
+        fm_dict["tags"] = list(tags)
+    if aliases:
+        fm_dict["aliases"] = list(aliases)
+    if edges:
+        fm_dict["edges"] = edges
+    if note_type is AtomType.active:
+        fm_dict["status"] = status.value
+        fm_dict["size"] = size.value
+        if due is not None:
+            fm_dict["due"] = due
+        if blocked_by:
+            fm_dict["blocked_by"] = list(blocked_by)
+
+    fm_str = yaml.dump(fm_dict, default_flow_style=False, sort_keys=False)
+    file_content = f"---\n{fm_str}---\n\n{_read_body(body).strip()}\n"
+
+    processed.mkdir(parents=True, exist_ok=True)
+    dest.write_text(file_content)
+
+    engine = _engine()
+    embed_client = EmbeddingClient()
+    with Session(engine) as session:
+        store = KnowledgeStore(session)
+        asyncio.run(
+            index_note_from_raw(
+                store,
+                embed_client,
+                note_id=note_id,
+                rel_path=rel_path,
+                raw=file_content,
+            )
+        )
+        if derived_from_raw is not None:
+            raw_row = session.exec(
+                select(RawInput).where(RawInput.raw_id == derived_from_raw)
+            ).first()
+            if raw_row is None:
+                typer.echo(
+                    f"knowledge: warning: derived-from-raw {derived_from_raw!r} "
+                    "not found, skipping provenance",
+                    err=True,
+                )
+            else:
+                session.add(
+                    AtomRawProvenance(
+                        raw_fk=raw_row.id,
+                        derived_note_id=note_id,
+                        gardener_version=GARDENER_VERSION,
+                    )
+                )
+                session.commit()
+
+    typer.echo(note_id)
+
+
+def _apply_edit(
+    note_id: str,
+    *,
+    body: str | None,
+    title: str | None,
+    tags: list[str],
+    visibility: Visibility | None,
+    edge_strs: list[str],
+) -> str:
+    """Shared load + merge + dual-write + re-index path for edit/patch-edges.
+
+    Reads the existing ``_processed`` file (the note's path from the store),
+    merges only the provided fields into the parsed frontmatter (preserving
+    aliases, edges, created/updated, and any extras), unions in new edges,
+    re-serializes, writes the file, and re-indexes under the existing id.
+    Returns the note_id on success.
+    """
+    new_edges = _edges_or_exit(edge_strs)
+    engine = _engine()
+    embed_client = EmbeddingClient()
+    vault_root = _vault_root()
+    with Session(engine) as session:
+        store = KnowledgeStore(session)
+        note = store.get_note_by_id(note_id)
+        if note is None:
+            typer.echo(f"knowledge: note not found: {note_id}", err=True)
+            raise typer.Exit(1)
+
+        rel_path = note["path"]
+        resolved = vault_root / rel_path
+        parsed, note_body = frontmatter.parse(resolved.read_text())
+
+        if title is not None:
+            parsed.title = title
+        if tags:
+            parsed.tags = list(tags)
+        if visibility is not None:
+            parsed.visibility = visibility.value
+        if body is not None:
+            note_body = _read_body(body).strip()
+
+        # Union new edges into the existing edges map, preserving order.
+        for edge_type, targets in new_edges.items():
+            existing = parsed.edges.setdefault(edge_type, [])
+            for target in targets:
+                if target not in existing:
+                    existing.append(target)
+
+        file_content = _serialize_frontmatter(parsed, note_body)
+        resolved.write_text(file_content)
+
+        existing_id = note["note_id"]
+        asyncio.run(
+            index_note_from_raw(
+                store,
+                embed_client,
+                note_id=existing_id,
+                rel_path=rel_path,
+                raw=file_content,
+            )
+        )
+    return existing_id
+
+
+@app.command()
+def edit(
+    note_id: Annotated[str, typer.Argument(help="Stable note_id")],
+    body: Annotated[
+        Optional[str], typer.Option("--body", help="New body, or '-' to read stdin")
+    ] = None,
+    title: Annotated[Optional[str], typer.Option("--title", help="New title")] = None,
+    tags: Annotated[
+        list[str], typer.Option("--tags", help="Replace tags (repeatable)")
+    ] = [],
+    visibility: Annotated[
+        Optional[Visibility], typer.Option("--visibility", help="public | private")
+    ] = None,
+    edge: Annotated[
+        list[str],
+        typer.Option(
+            "--edge", "--add-edge", help="Merge edge 'type:target-slug' (repeatable)"
+        ),
+    ] = [],
+) -> None:
+    """Edit a note's frontmatter/body in place, then re-index. Prints note_id."""
+    result_id = _apply_edit(
+        note_id,
+        body=body,
+        title=title,
+        tags=tags,
+        visibility=visibility,
+        edge_strs=edge,
+    )
+    typer.echo(result_id)
+
+
+@app.command(name="patch-edges")
+def patch_edges(
+    note_id: Annotated[str, typer.Argument(help="Stable note_id")],
+    edge: Annotated[
+        list[str],
+        typer.Option("--edge", help="Add edge 'type:target-slug' (repeatable)"),
+    ] = [],
+) -> None:
+    """Add typed edges to a note (union with existing), re-index. Prints note_id."""
+    result_id = _apply_edit(
+        note_id,
+        body=None,
+        title=None,
+        tags=[],
+        visibility=None,
+        edge_strs=edge,
+    )
+    typer.echo(result_id)
+
+
+if __name__ == "__main__":
+    app()

--- a/projects/monolith/knowledge/cli_test.py
+++ b/projects/monolith/knowledge/cli_test.py
@@ -1,0 +1,380 @@
+"""Unit tests for the in-pod knowledge gardener CLI (ADR 006 Phase 4a).
+
+Store, embedder, indexing, engine, and Session are all mocked: no real DB,
+network, or embedder is touched. The disk dual-write runs for real against a
+``tmp_path`` vault so collision resolution and frontmatter round-trips are
+exercised end to end.
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from knowledge import frontmatter
+from knowledge.cli import app
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+@pytest.fixture
+def env(tmp_path, monkeypatch):
+    """Set DATABASE_URL + VAULT_ROOT and return the vault root path."""
+    monkeypatch.setenv("DATABASE_URL", "postgresql://test/db")
+    monkeypatch.setenv("VAULT_ROOT", str(tmp_path))
+    (tmp_path / "_processed").mkdir()
+    return tmp_path
+
+
+@pytest.fixture
+def mocks():
+    """Patch the engine/session/store/embedder/indexing seams."""
+    with (
+        patch("knowledge.cli.create_engine") as create_engine,
+        patch("knowledge.cli.Session") as session_cls,
+        patch("knowledge.cli.KnowledgeStore") as store_cls,
+        patch("knowledge.cli.EmbeddingClient") as embed_cls,
+        patch("knowledge.cli.index_note_from_raw", new_callable=AsyncMock) as index,
+    ):
+        session = MagicMock()
+        session_cls.return_value.__enter__.return_value = session
+        session_cls.return_value.__exit__.return_value = False
+
+        store = MagicMock()
+        store_cls.return_value = store
+
+        embed = MagicMock()
+        embed.embed = AsyncMock(return_value=[0.1] * 8)
+        embed_cls.return_value = embed
+
+        yield SimpleNamespace(
+            create_engine=create_engine,
+            session=session,
+            store=store,
+            embed=embed,
+            index=index,
+        )
+
+
+class TestSearch:
+    def test_returns_json_array_and_filters_non_finite(self, runner, env, mocks):
+        mocks.store.search_notes.return_value = [
+            {"note_id": "n1", "title": "T1", "path": "p1", "score": 0.91},
+            {"note_id": "n2", "title": "T2", "path": "p2", "score": float("nan")},
+        ]
+        result = runner.invoke(app, ["search", "hello world", "--limit", "3"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert [d["note_id"] for d in data] == ["n1"]
+        _, kwargs = mocks.store.search_notes.call_args
+        assert kwargs["limit"] == 3
+
+
+class TestGet:
+    def test_found(self, runner, env, mocks):
+        mocks.store.get_note_by_id.return_value = {
+            "note_id": "foo",
+            "title": "Foo",
+            "path": "_processed/foo.md",
+            "type": "atom",
+            "tags": ["a"],
+            "content": "Body of foo.",
+        }
+        mocks.store.get_note_links.return_value = [
+            {"target_id": "bar", "kind": "edge", "edge_type": "related"}
+        ]
+        result = runner.invoke(app, ["get", "foo"])
+        assert result.exit_code == 0
+        out = json.loads(result.output)
+        assert out["note_id"] == "foo"
+        assert out["content"] == "Body of foo."
+        assert out["edges"][0]["edge_type"] == "related"
+
+    def test_not_found_exits_1(self, runner, env, mocks):
+        mocks.store.get_note_by_id.return_value = None
+        result = runner.invoke(app, ["get", "missing"])
+        assert result.exit_code == 1
+        assert "not found" in result.output
+
+
+class TestGetRaw:
+    def test_found_prints_content(self, runner, env, mocks):
+        mocks.session.exec.return_value.first.return_value = SimpleNamespace(
+            content="# raw markdown\nbody"
+        )
+        result = runner.invoke(app, ["get-raw", "raw-123"])
+        assert result.exit_code == 0
+        assert "# raw markdown" in result.output
+
+    def test_missing_exits_1(self, runner, env, mocks):
+        mocks.session.exec.return_value.first.return_value = None
+        result = runner.invoke(app, ["get-raw", "raw-nope"])
+        assert result.exit_code == 1
+        assert "not found" in result.output
+
+
+class TestCreateAtom:
+    def test_happy_path(self, runner, env, mocks):
+        result = runner.invoke(
+            app,
+            [
+                "create-atom",
+                "--title",
+                "My Atom",
+                "--body",
+                "Hello body content",
+                "--type",
+                "atom",
+                "--visibility",
+                "public",
+                "--tags",
+                "alpha",
+            ],
+        )
+        assert result.exit_code == 0
+        assert result.output.strip() == "my-atom"
+
+        note_file = env / "_processed" / "my-atom.md"
+        assert note_file.exists()
+        assert "Hello body content" in note_file.read_text()
+
+        mocks.index.assert_called_once()
+        _, kwargs = mocks.index.call_args
+        assert kwargs["note_id"] == "my-atom"
+        assert kwargs["rel_path"] == "_processed/my-atom.md"
+        assert "Hello body content" in kwargs["raw"]
+        assert "visibility: public" in kwargs["raw"]
+
+    def test_body_from_stdin(self, runner, env, mocks):
+        result = runner.invoke(
+            app,
+            [
+                "create-atom",
+                "--title",
+                "Stdin Atom",
+                "--body",
+                "-",
+                "--type",
+                "fact",
+                "--visibility",
+                "private",
+            ],
+            input="piped body text",
+        )
+        assert result.exit_code == 0
+        _, kwargs = mocks.index.call_args
+        assert "piped body text" in kwargs["raw"]
+
+    def test_missing_visibility_exits_2(self, runner, env, mocks):
+        result = runner.invoke(
+            app,
+            [
+                "create-atom",
+                "--title",
+                "No Vis",
+                "--body",
+                "x",
+                "--type",
+                "atom",
+            ],
+        )
+        assert result.exit_code == 2
+        mocks.index.assert_not_called()
+
+    def test_active_without_status_size_exits_2(self, runner, env, mocks):
+        result = runner.invoke(
+            app,
+            [
+                "create-atom",
+                "--title",
+                "A Task",
+                "--body",
+                "do the thing",
+                "--type",
+                "active",
+                "--visibility",
+                "public",
+            ],
+        )
+        assert result.exit_code == 2
+        assert "requires --status and --size" in result.output
+        mocks.index.assert_not_called()
+
+    def test_active_with_status_size_ok(self, runner, env, mocks):
+        result = runner.invoke(
+            app,
+            [
+                "create-atom",
+                "--title",
+                "Real Task",
+                "--body",
+                "do it",
+                "--type",
+                "active",
+                "--visibility",
+                "public",
+                "--status",
+                "active",
+                "--size",
+                "small",
+            ],
+        )
+        assert result.exit_code == 0
+        _, kwargs = mocks.index.call_args
+        assert "status: active" in kwargs["raw"]
+        assert "size: small" in kwargs["raw"]
+
+    def test_bad_edge_format_exits_2(self, runner, env, mocks):
+        result = runner.invoke(
+            app,
+            [
+                "create-atom",
+                "--title",
+                "Edgy",
+                "--body",
+                "x",
+                "--type",
+                "atom",
+                "--visibility",
+                "public",
+                "--edge",
+                "bogustype:target",
+            ],
+        )
+        assert result.exit_code == 2
+        assert "invalid edge type" in result.output
+        mocks.index.assert_not_called()
+
+    def test_valid_edge_serialized(self, runner, env, mocks):
+        result = runner.invoke(
+            app,
+            [
+                "create-atom",
+                "--title",
+                "Linked",
+                "--body",
+                "x",
+                "--type",
+                "atom",
+                "--visibility",
+                "public",
+                "--edge",
+                "derives_from:source-note",
+            ],
+        )
+        assert result.exit_code == 0
+        _, kwargs = mocks.index.call_args
+        parsed, _ = frontmatter.parse(kwargs["raw"])
+        assert parsed.edges["derives_from"] == ["source-note"]
+
+    def test_collision_appends_suffix(self, runner, env, mocks):
+        (env / "_processed" / "my-atom.md").write_text("---\nid: my-atom\n---\n\nx\n")
+        result = runner.invoke(
+            app,
+            [
+                "create-atom",
+                "--title",
+                "My Atom",
+                "--body",
+                "second one",
+                "--type",
+                "atom",
+                "--visibility",
+                "public",
+            ],
+        )
+        assert result.exit_code == 0
+        assert result.output.strip() == "my-atom-1"
+        assert (env / "_processed" / "my-atom-1.md").exists()
+        _, kwargs = mocks.index.call_args
+        assert kwargs["note_id"] == "my-atom-1"
+
+    def test_provenance_row_added_when_raw_found(self, runner, env, mocks):
+        mocks.session.exec.return_value.first.return_value = SimpleNamespace(id=42)
+        result = runner.invoke(
+            app,
+            [
+                "create-atom",
+                "--title",
+                "Derived",
+                "--body",
+                "x",
+                "--type",
+                "atom",
+                "--visibility",
+                "public",
+                "--derived-from-raw",
+                "raw-7",
+            ],
+        )
+        assert result.exit_code == 0
+        assert mocks.session.add.called
+        assert mocks.session.commit.called
+
+
+class TestEdit:
+    def _seed(self, env) -> None:
+        (env / "_processed" / "foo.md").write_text(
+            "---\nid: foo\ntitle: Old Title\ntype: atom\n"
+            "aliases:\n- legacy\n---\n\nOriginal body.\n"
+        )
+
+    def test_merges_title_and_reindexes(self, runner, env, mocks):
+        self._seed(env)
+        mocks.store.get_note_by_id.return_value = {
+            "note_id": "foo",
+            "path": "_processed/foo.md",
+            "title": "Old Title",
+            "type": "atom",
+            "tags": [],
+            "content": "Original body.",
+        }
+        result = runner.invoke(app, ["edit", "foo", "--title", "New Title"])
+        assert result.exit_code == 0
+        assert result.output.strip() == "foo"
+
+        on_disk = (env / "_processed" / "foo.md").read_text()
+        assert "New Title" in on_disk
+        # Pre-existing aliases must be preserved through the merge.
+        assert "legacy" in on_disk
+
+        mocks.index.assert_called_once()
+        _, kwargs = mocks.index.call_args
+        assert kwargs["note_id"] == "foo"
+        assert "New Title" in kwargs["raw"]
+
+    def test_not_found_exits_1(self, runner, env, mocks):
+        mocks.store.get_note_by_id.return_value = None
+        result = runner.invoke(app, ["edit", "ghost", "--title", "X"])
+        assert result.exit_code == 1
+        assert "not found" in result.output
+
+
+class TestPatchEdges:
+    def test_unions_edges(self, runner, env, mocks):
+        (env / "_processed" / "bar.md").write_text(
+            "---\nid: bar\ntitle: Bar\ntype: atom\n"
+            "edges:\n  related:\n  - existing-a\n---\n\nbody\n"
+        )
+        mocks.store.get_note_by_id.return_value = {
+            "note_id": "bar",
+            "path": "_processed/bar.md",
+            "title": "Bar",
+            "type": "atom",
+            "tags": [],
+            "content": "body",
+        }
+        result = runner.invoke(app, ["patch-edges", "bar", "--edge", "related:new-b"])
+        assert result.exit_code == 0
+        assert result.output.strip() == "bar"
+
+        _, kwargs = mocks.index.call_args
+        parsed, _ = frontmatter.parse(kwargs["raw"])
+        assert parsed.edges["related"] == ["existing-a", "new-b"]

--- a/projects/monolith/knowledge/tools/knowledge
+++ b/projects/monolith/knowledge/tools/knowledge
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+"""Entrypoint for the in-pod knowledge gardener CLI (ADR 006 Phase 4a).
+
+A thin launcher so the gardener subprocess (and operators) can invoke
+``knowledge <verb>`` from /usr/local/bin. All logic lives in
+``knowledge.cli``; this only forwards to the Typer app.
+"""
+
+from knowledge.cli import app
+
+if __name__ == "__main__":
+    app()


### PR DESCRIPTION
## ADR 006 Phase 4a-i: the gardener's tool surface

First half of the [revised Phase 4](https://github.com/jomcgi/homelab/blob/main/docs/decisions/platform/006-obsidian-decommission-postgres-interim.md) (tool-based gardener). Adds a `knowledge` Typer CLI grounded in the monolith's own store, so atoms are created/edited/searched through **one validated, synchronously-indexed path** instead of Read/Write/Edit on the vault filesystem. The gardener prompt rewrite onto these verbs is Phase 4a-ii (next PR); this CLI is independently usable.

### Why a CLI (not a tmpdir)
The gardener subprocess discovers and edits notes mid-run via search, so the working set is unknowable up front, killing the "materialize a tmpdir" approach. Operating through Postgres-backed tools dissolves that and moves frontmatter validation to a typed boundary.

### Commands (`knowledge/cli.py`)
- `search` / `get` / `get-raw` — reads.
- `create-atom` / `edit` / `patch-edges` — writes. **Dual-write**: they write the `_processed/<slug>.md` file (the reconciler/Obsidian safety net through Phase 5, since the reconciler deletes notes whose file vanished) **and** index synchronously via `knowledge.indexing.index_note_from_raw`.

### Schema enforcement (the point)
`--type`/`--visibility` are required enums; `type=active` requires `--status`+`--size`; `--edge` specs are validated against the known edge types. Malformed input exits 2 with a correctable message instead of the prompt begging the model to quote its YAML. `create-atom` records `atom_raw_provenance` when `--derived-from-raw` is given.

### Grounding
The CLI is a thin veneer over the same `KnowledgeStore` + `knowledge.indexing` the HTTP API and MCP use; it runs in-pod against `DATABASE_URL` exactly like the existing `knowledge-search` script, and is baked to `/usr/local/bin/knowledge`.

### Tests
`knowledge_cli_test` (15 hermetic CliRunner tests): search JSON + NaN filter; get/get-raw found+missing; create-atom happy/stdin/active/edge-serialization/provenance + the three exit-2 validations + collision suffix; edit merge+preserve-aliases; patch-edges union.

🤖 Generated with [Claude Code](https://claude.com/claude-code)