### PR TITLE
chore(monolith): take the knowledge gardener offline for the ADR 006 transition

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.139.5
+version: 0.139.6
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.139.5
+      targetRevision: 0.139.6
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/deploy/values.yaml
+++ b/projects/monolith/deploy/values.yaml
@@ -124,8 +124,14 @@ chat:
   onepassword:
     itemPath: "vaults/k8s-homelab/items/discord-bot"
 
+# Taken offline 2026-06-14 for the ADR 006 Phase 4 transition: with the
+# gardener paused, the raw export / file moves can be done as a controlled
+# one-off, and the gardener stays down until the CLI-based version (Phase 4a-ii)
+# is ready. Dropping the token makes garden_handler() skip cleanly (it logs a
+# warning and returns when CLAUDE_CODE_OAUTH_TOKEN is absent). Re-enable by
+# flipping this back to true.
 gardener:
-  enabled: true
+  enabled: false
   onepassword:
     itemPath: "vaults/k8s-homelab/items/litellm-claude-auth"
 


### PR DESCRIPTION
Sets `gardener.enabled=false` so `CLAUDE_CODE_OAUTH_TOKEN` is no longer injected. `garden_handler()` then skips cleanly each scheduler tick (it logs a warning and returns when the token is absent, `service.py:158`), so no `claude` subprocess runs and no failed-provenance churn accrues.

### Why
Pauses LLM decomposition while we do the ADR 006 Phase 4 data migration (confirm note bodies are in Postgres, move raws to SeaweedFS) as a controlled one-off, and keeps the gardener down until the CLI-based rewrite (Phase 4a-ii) lands. Fully reversible: flip back to `true`.

Follows Phases 1-3 + the `knowledge` CLI (#2616), all merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)