### PR TITLE
chore(monolith): tear out the Obsidian sidecar + vault git-sync (ADR 006)

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.139.8
+version: 0.139.9
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/obsidian_readiness_probe_test.sh
+++ b/projects/monolith/chart/obsidian_readiness_probe_test.sh
@@ -48,9 +48,12 @@ else
 	pass "obsidian container absent when knowledge.enabled=false (default)"
 fi
 
-# Render with knowledge enabled for remaining tests
+# Render with knowledge AND the obsidian sidecar enabled for the remaining
+# tests. As of ADR 006 the sidecar is opt-in (headlessSync.enabled defaults
+# false), so both flags are needed to render it.
 RENDERED=$("$HELM" template monolith "$CHART_TGZ" \
 	--set knowledge.enabled=true \
+	--set knowledge.headlessSync.enabled=true \
 	--set knowledge.headlessSync.vaultName=test-vault)
 
 # ---------------------------------------------------------------------------

--- a/projects/monolith/chart/templates/deployment.yaml
+++ b/projects/monolith/chart/templates/deployment.yaml
@@ -212,7 +212,7 @@ spec:
             {{- toYaml .Values.backend.resources | nindent 12 }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-        {{- if .Values.knowledge.enabled }}
+        {{- if and .Values.knowledge.enabled .Values.knowledge.headlessSync.enabled }}
         - name: obsidian
           image: "{{ .Values.knowledge.headlessSync.image.repository }}:{{ .Values.knowledge.headlessSync.image.tag }}"
           securityContext:

--- a/projects/monolith/chart/values.yaml
+++ b/projects/monolith/chart/values.yaml
@@ -68,6 +68,12 @@ knowledge:
     # cluster.
     rewriteDiscardable: false
   headlessSync:
+    # Obsidian headless-sync sidecar. Off by default (ADR 006): note bodies
+    # are authoritative in Postgres (knowledge.notes.content) and raws live in
+    # SeaweedFS, so the sidecar's slow full-vault download on every pod start
+    # is no longer needed. When false the reconciler permanently defers (its
+    # .sync-ready sentinel is never written), so no disk scan/prune runs.
+    enabled: false
     image:
       repository: ghcr.io/jomcgi/homelab/projects/monolith/obsidian-image
       tag: latest

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.139.8
+      targetRevision: 0.139.9
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/deploy/values.yaml
+++ b/projects/monolith/deploy/values.yaml
@@ -71,13 +71,15 @@ cfIngress:
 
 knowledge:
   enabled: true
-  gitRemote: "https://github.com/jomcgi/obsidian-vault.git"
+  # Obsidian + vault git-sync torn out 2026-06-15 (ADR 006). Note bodies are
+  # authoritative in Postgres (knowledge.notes.content, backfilled) and raws
+  # are exported to s3://knowledge-raws, so the slow per-rollout vault download
+  # is gone. gitRemote cleared -> clone_vault and vault-backup no-op;
+  # headlessSync.enabled is false in the chart so the obsidian sidecar is not
+  # rendered. Reversible: restore gitRemote + set headlessSync.enabled: true.
+  gitRemote: ""
   gaps:
     rewriteDiscardable: true
-  headlessSync:
-    vaultName: "jomcgi"
-  onepassword:
-    itemPath: "vaults/k8s-homelab/items/obsidian"
 
 dashboards:
   cnpg-overview:


### PR DESCRIPTION
The obsidian headless-sync sidecar downloads the **entire vault from Obsidian cloud before it goes Ready**, which wedged and slowed every pod rollout (observed live: new pods stuck at 3/4 for 7+ minutes on the obsidian readiness probe). It is no longer needed: note bodies are authoritative in `knowledge.notes.content` (backfilled, reads serve from Postgres with no disk dependency, proven against a nonexistent vault path), and raws are exported to `s3://knowledge-raws` (1737/1737, content-verified).

### Changes
- `deployment.yaml`: gate the obsidian sidecar on `knowledge.headlessSync.enabled` (additional to `knowledge.enabled`).
- chart values: `headlessSync.enabled` defaults `false`.
- deploy values: clear `gitRemote` (so `clone_vault` and the `vault-backup` git push no-op); drop the unused obsidian onepassword item + vaultName.

### Safe by construction
With no sidecar, the `.sync-ready` sentinel is never written, so `reconcile_handler` permanently defers and never runs its `indexed - on_disk` prune (which would otherwise delete the graph against an empty vault). `/vault` stays an emptyDir scratch for the write-path dual-write; reads come from Postgres. Reversible via the two values.

Render-verified: 0 obsidian containers, 0 `VAULT_GIT_REMOTE`, 0 obsidian-image refs.

### Follow-up (not blocking rollout speed)
Delete the `obsidian-image` build target + the knowledge `OnePasswordItem` template, and retire the reconciler disk scan (Phase 6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)