### PR TITLE
feat(trips): add monolith trips schema and S3 EXIF backfill

### DIFF
--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -3463,6 +3463,10 @@ py_venv_binary(
 semgrep_target_test(
     name = "trips_backfill_semgrep_test",
     exclude_rules = [
+        # main.py guards the SeaweedFS endpoint with a scheme check, but
+        # semgrep-core ignores the inline # nosemgrep (mirrors :main). The
+        # # keep stops gazelle from dropping it back to the file directive set.
+        "boto3-endpoint-url-missing-scheme",  # keep
         # trips.models uses datetime fields for the migration's TIMESTAMPTZ
         # columns; semgrep-core ignores the inline # nosemgrep (mirrors :main).
         "sqlmodel-datetime-without-factory",

--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -11,6 +11,7 @@
 # gazelle:exclude ships
 # gazelle:exclude hikes
 # gazelle:exclude stars
+# gazelle:exclude trips
 # gazelle:semgrep_exclude_rules avoid-sqlalchemy-text,sqlmodel-datetime-without-factory,tainted-fastapi-http-request-httpx,tainted-path-traversal-stdlib-fastapi
 load("@aspect_bazel_lib//lib:tar.bzl", "tar")
 load("@aspect_rules_py//py:defs.bzl", "py_library")
@@ -45,6 +46,7 @@ py_venv_binary(
             "ships/**/*.py",
             "hikes/**/*.py",
             "stars/**/*.py",
+            "trips/**/*.py",
         ],
         exclude = [
             # pytest discovers both *_test.py (sibling convention) and
@@ -57,6 +59,8 @@ py_venv_binary(
             "shared/testing/**/*.py",
             # Offline grid generator: run by hand, not part of the runtime image.
             "stars/grid_gen/**",
+            # Run-by-hand S3->Postgres backfill, not part of the runtime image.
+            "trips/backfill/**",
         ],
     ),  # keep
     data = [":frontend_dist"],
@@ -103,6 +107,7 @@ py_library(
             "ships/**/*.py",
             "hikes/**/*.py",
             "stars/**/*.py",
+            "trips/**/*.py",
         ],
         exclude = [
             # pytest discovers both *_test.py (sibling convention) and
@@ -116,6 +121,8 @@ py_library(
             "shared/testing/**/*.py",
             # Offline grid generator: run by hand, not part of the runtime image.
             "stars/grid_gen/**",
+            # Run-by-hand S3->Postgres backfill, not part of the runtime image.
+            "trips/backfill/**",
         ],
     ),  # keep
     visibility = ["//:__subpackages__"],
@@ -3415,4 +3422,87 @@ semgrep_target_test(
     ],
     rules = ["//bazel/semgrep/rules:python_rules"],
     target = ":classify_visibility_backfill",
+)
+
+# Run-by-hand backfill: re-derive trips.points from S3 image EXIF (+ optional
+# KML gap route and NRCan elevation) and upsert into Postgres. Not part of the
+# server image (excluded from the :main / :monolith_backend globs above).
+#   bazel run //projects/monolith:trips_backfill -- run --slug <slug> ...
+py_library(
+    name = "trips_backfill_lib",
+    srcs = glob(
+        ["trips/**/*.py"],
+        exclude = ["trips/**/*_test.py"],
+    ),
+    imports = ["."],
+    visibility = ["//:__subpackages__"],
+    deps = [
+        "@pip//boto3",
+        "@pip//botocore",
+        "@pip//defusedxml",
+        "@pip//httpx",
+        "@pip//pillow",
+        "@pip//pyyaml",
+        "@pip//sqlalchemy",
+        "@pip//sqlmodel",
+        "@pip//typer",
+        "@pip//tzdata",
+    ],
+)
+
+py_venv_binary(
+    name = "trips_backfill",
+    srcs = glob(
+        ["trips/**/*.py"],
+        exclude = ["trips/**/*_test.py"],
+    ),
+    imports = ["."],
+    main = "trips/backfill/main.py",
+    visibility = ["//:__subpackages__"],
+    deps = [":trips_backfill_lib"],
+)
+
+semgrep_target_test(
+    name = "trips_backfill_semgrep_test",
+    exclude_rules = [
+        # main.py guards the SeaweedFS endpoint with a scheme check; semgrep-core
+        # does not honour the inline # nosemgrep, so exclude here (mirrors :main).
+        "boto3-endpoint-url-missing-scheme",
+        # trips.models uses datetime fields for the migration's TIMESTAMPTZ
+        # columns; semgrep-core ignores the inline # nosemgrep (mirrors :main).
+        "sqlmodel-datetime-without-factory",
+    ],
+    rules = ["//bazel/semgrep/rules:python_rules"],
+    target = ":trips_backfill",
+)
+
+py_test(
+    name = "trips_models_test",
+    srcs = ["trips/models_test.py"],
+    imports = ["."],
+    deps = [
+        ":monolith_backend",
+        "@pip//pytest",
+        "@pip//sqlmodel",
+    ],
+)
+
+py_test(
+    name = "trips_backfill_transform_test",
+    srcs = ["trips/backfill/transform_test.py"],
+    imports = ["."],
+    deps = [
+        ":trips_backfill_lib",
+        "@pip//pytest",
+    ],
+)
+
+py_test(
+    name = "trips_backfill_exif_test",
+    srcs = ["trips/backfill/exif_test.py"],
+    imports = ["."],
+    deps = [
+        ":trips_backfill_lib",
+        "@pip//pytest",
+    ],
 )

--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -3456,21 +3456,19 @@ py_venv_binary(
         ["trips/**/*.py"],
         exclude = ["trips/**/*_test.py"],
     ),
-    imports = ["."],
     main = "trips/backfill/main.py",
     visibility = ["//:__subpackages__"],
-    deps = [":trips_backfill_lib"],
 )
 
 semgrep_target_test(
     name = "trips_backfill_semgrep_test",
     exclude_rules = [
-        # main.py guards the SeaweedFS endpoint with a scheme check; semgrep-core
-        # does not honour the inline # nosemgrep, so exclude here (mirrors :main).
-        "boto3-endpoint-url-missing-scheme",
         # trips.models uses datetime fields for the migration's TIMESTAMPTZ
         # columns; semgrep-core ignores the inline # nosemgrep (mirrors :main).
         "sqlmodel-datetime-without-factory",
+        "avoid-sqlalchemy-text",
+        "tainted-fastapi-http-request-httpx",
+        "tainted-path-traversal-stdlib-fastapi",
     ],
     rules = ["//bazel/semgrep/rules:python_rules"],
     target = ":trips_backfill",

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.140.1
+version: 0.140.2
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.140.0
+version: 0.140.1
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.139.9
+version: 0.140.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/migrations/20260615120000_trips_schema.sql
+++ b/projects/monolith/chart/migrations/20260615120000_trips_schema.sql
@@ -1,0 +1,56 @@
+-- trips schema: road-trip photo journeys, ported from the standalone
+-- trips.jomcgi.dev service into the monolith (/app/trips, SSR).
+--
+-- trips  : one row per trip, holding the display metadata that used to live
+--          in the frontend config.yaml (title/subtitle, per-day labels,
+--          highlights, manual stats). days/highlights/stats are JSONB so the
+--          shape can evolve without a migration per field.
+-- points : one row per map point, keyed by (trip_slug, id). Mirrors the old
+--          NATS TripPoint: GPS, capture time, the S3 image key, source, tags,
+--          elevation (NRCan CDEM) and the camera EXIF/optics fields. Points
+--          with image NULL are route-only "gap" points used to draw the
+--          driving line between photos.
+--
+-- Points are re-derived from image EXIF in the `trips` S3 bucket by the local
+-- backfill (projects/monolith/trips/backfill); the monolith never writes here
+-- at runtime.
+
+CREATE SCHEMA IF NOT EXISTS trips;
+
+CREATE TABLE trips.trips (
+    slug          TEXT PRIMARY KEY,
+    title         TEXT NOT NULL,
+    short_title   TEXT,
+    subtitle      TEXT,
+    -- IANA zone the camera-local EXIF timestamps are interpreted in when the
+    -- backfill converts them to the tz-aware taken_at below.
+    timezone      TEXT NOT NULL DEFAULT 'America/Vancouver',
+    default_image TEXT,
+    default_zoom  INTEGER,
+    days          JSONB NOT NULL DEFAULT '{}'::jsonb,
+    highlights    JSONB NOT NULL DEFAULT '[]'::jsonb,
+    stats         JSONB NOT NULL DEFAULT '{}'::jsonb,
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE trips.points (
+    trip_slug         TEXT NOT NULL REFERENCES trips.trips (slug) ON DELETE CASCADE,
+    id                TEXT NOT NULL,
+    lat               DOUBLE PRECISION NOT NULL,
+    lng               DOUBLE PRECISION NOT NULL,
+    taken_at          TIMESTAMPTZ NOT NULL,
+    image             TEXT,
+    source            TEXT NOT NULL DEFAULT 'gopro',
+    tags              TEXT[] NOT NULL DEFAULT '{}',
+    elevation         DOUBLE PRECISION,
+    light_value       DOUBLE PRECISION,
+    iso               INTEGER,
+    shutter_speed     TEXT,
+    aperture          DOUBLE PRECISION,
+    focal_length_35mm INTEGER,
+    created_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (trip_slug, id)
+);
+
+-- Read path renders points in capture order per trip.
+CREATE INDEX idx_trips_points_trip_taken ON trips.points (trip_slug, taken_at);

--- a/projects/monolith/chart/migrations/atlas.sum
+++ b/projects/monolith/chart/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:2UeHbMSVs4CQdAYIX5NQ/zZJzFL8kEp3In5LC7VEJBc=
+h1:CL7hSFVjDihr5Qls4zuH2J5doEBEUXhrhNJP3DahyG4=
 20260330000000_initial_schema.sql h1:J2futpSW0nJAIRR7nR7ssT7LwXIYrvRI+PkHb5Y4tLI=
 20260403000000_chat_schema.sql h1:pERUFC0vzM95etRuzp43XzkCV7lBCzrrtY5Mk7aF3CA=
 20260404000000_chat_attachments.sql h1:tv+Fdbr1rQC5nzUxfaBC0O6fu2OMGgLWf+YNg1WQXi4=
@@ -43,3 +43,4 @@ h1:2UeHbMSVs4CQdAYIX5NQ/zZJzFL8kEp3In5LC7VEJBc=
 20260614140000_ships_heat_cells_historical.sql h1:EsJugdv91D++HoaJYGs1Mk2aw48bEfvymr0ZD64yURU=
 20260615000010_stars_drop_site_month_stats.sql h1:2kcpcspJX0faiL3sA6UjNH6fq3VoyHltiLZt/+DNAg4=
 20260615000020_knowledge_notes_content_column.sql h1:b4MUb3rORQg42bRQ/jVy54YIKn8cx46nO202F54DWMY=
+20260615120000_trips_schema.sql h1:yN+REAy71uuXowKKwhPdBh61zJ0zbdb6Oe6eszzbcK0=

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.139.9
+      targetRevision: 0.140.0
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.140.0
+      targetRevision: 0.140.1
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.140.1
+      targetRevision: 0.140.2
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/trips/__init__.py
+++ b/projects/monolith/trips/__init__.py
@@ -1,0 +1,7 @@
+"""trips: road-trip photo journeys, served SSR at /app/trips.
+
+This package currently holds the Postgres-backed data model (models.py) and a
+local, run-by-hand backfill (backfill/) that re-derives points from image EXIF
+in the `trips` S3 bucket. The SSR router and scheduled jobs land in later
+phases of the migration off the standalone trips.jomcgi.dev service.
+"""

--- a/projects/monolith/trips/backfill/__init__.py
+++ b/projects/monolith/trips/backfill/__init__.py
@@ -1,0 +1,8 @@
+"""Local, run-by-hand backfill that populates the trips Postgres schema.
+
+Re-derives points from image EXIF in the `trips` S3 (SeaweedFS) bucket,
+optionally adds route-only "gap" points from KML directions and elevation from
+the NRCan CDEM API, then upserts into trips.trips / trips.points. Run via
+`bazel run //projects/monolith:trips_backfill -- ...` against a port-forwarded
+SeaweedFS + Postgres; it is not part of the monolith server image.
+"""

--- a/projects/monolith/trips/backfill/exif.py
+++ b/projects/monolith/trips/backfill/exif.py
@@ -1,0 +1,140 @@
+"""EXIF extraction for the trips backfill.
+
+Ported from projects/trips/tools/publish-trip-images so the monolith backfill
+re-derives the same GPS / timestamp / optics fields the old NATS pipeline
+produced, without depending on the (soon-to-be-retired) standalone service.
+
+``extract_exif`` does PIL file I/O; the numeric helpers are pure and unit
+tested directly.
+"""
+
+import logging
+import math
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+
+from PIL import Image
+from PIL.ExifTags import GPSTAGS, TAGS
+
+logger = logging.getLogger("trips.backfill")
+
+
+@dataclass
+class Optics:
+    """Camera exposure data from EXIF."""
+
+    light_value: float | None = None  # Exposure Value (EV)
+    iso: int | None = None
+    shutter_speed: str | None = None  # e.g. "1/240"
+    aperture: float | None = None  # f-number
+    focal_length_35mm: int | None = None
+
+    def is_empty(self) -> bool:
+        return not any(
+            (
+                self.light_value,
+                self.iso,
+                self.shutter_speed,
+                self.aperture,
+                self.focal_length_35mm,
+            )
+        )
+
+
+def gps_info(exif_gps: dict) -> dict:
+    """Map raw GPSInfo tag ids to their names."""
+    return {GPSTAGS.get(key, key): val for key, val in exif_gps.items()}
+
+
+def dms_to_decimal(dms: tuple, ref: str) -> float:
+    """Convert GPS coordinates from degrees/minutes/seconds to decimal."""
+    degrees, minutes, seconds = dms
+    decimal = float(degrees) + float(minutes) / 60 + float(seconds) / 3600
+    if ref in ("S", "W"):
+        decimal = -decimal
+    return decimal
+
+
+def light_value(
+    aperture: float | None, shutter_time: float | None, iso: int | None
+) -> float | None:
+    """Exposure Value from the exposure triangle.
+
+    LV = log2(N^2 / t) - log2(ISO / 100), N=aperture, t=shutter seconds.
+    """
+    if aperture is None or shutter_time is None or iso is None:
+        return None
+    if aperture <= 0 or shutter_time <= 0 or iso <= 0:
+        return None
+    try:
+        lv = math.log2((aperture**2) / shutter_time) - math.log2(iso / 100)
+        return round(lv, 1)
+    except (ValueError, ZeroDivisionError):
+        return None
+
+
+def format_shutter_speed(exposure_time: float | None) -> str | None:
+    """Format exposure time as a readable shutter string (0.004166.. -> '1/240')."""
+    if exposure_time is None or exposure_time <= 0:
+        return None
+    if exposure_time >= 1:
+        return f"{exposure_time:.1f}s"
+    return f"1/{round(1 / exposure_time)}"
+
+
+def extract_exif(
+    image_path: Path,
+) -> tuple[float | None, float | None, str | None, Optics | None]:
+    """Extract (lat, lng, camera-local ISO timestamp, optics) from an image."""
+    try:
+        img = Image.open(image_path)
+        raw = img._getexif()
+        if not raw:
+            return None, None, None, None
+
+        exif = {TAGS.get(tag_id, tag_id): value for tag_id, value in raw.items()}
+
+        lat = lng = timestamp = None
+
+        if "GPSInfo" in exif:
+            gps = gps_info(exif["GPSInfo"])
+            if "GPSLatitude" in gps and "GPSLongitude" in gps:
+                lat = dms_to_decimal(gps["GPSLatitude"], gps.get("GPSLatitudeRef", "N"))
+                lng = dms_to_decimal(
+                    gps["GPSLongitude"], gps.get("GPSLongitudeRef", "E")
+                )
+
+        # EXIF time is camera-local (no tz); the backfill localizes it later.
+        for tag in ("DateTimeOriginal", "DateTime"):
+            if tag in exif:
+                timestamp = datetime.strptime(
+                    exif[tag], "%Y:%m:%d %H:%M:%S"
+                ).isoformat()
+                break
+
+        optics = Optics()
+        iso_raw = exif.get("ISOSpeedRatings")
+        if iso_raw:
+            optics.iso = int(iso_raw[0] if isinstance(iso_raw, tuple) else iso_raw)
+
+        fnumber = exif.get("FNumber")
+        if fnumber:
+            optics.aperture = round(float(fnumber), 1)
+
+        exposure = exif.get("ExposureTime")
+        exposure_f = None
+        if exposure:
+            exposure_f = float(exposure)
+            optics.shutter_speed = format_shutter_speed(exposure_f)
+
+        focal_35 = exif.get("FocalLengthIn35mmFilm")
+        if focal_35:
+            optics.focal_length_35mm = int(focal_35)
+
+        optics.light_value = light_value(optics.aperture, exposure_f, optics.iso)
+
+        return lat, lng, timestamp, (None if optics.is_empty() else optics)
+    except Exception as exc:  # noqa: BLE001 - best-effort EXIF, log and skip
+        logger.warning("could not extract EXIF from %s: %s", image_path, exc)
+        return None, None, None, None

--- a/projects/monolith/trips/backfill/exif_test.py
+++ b/projects/monolith/trips/backfill/exif_test.py
@@ -1,0 +1,33 @@
+"""Unit tests for the pure numeric helpers in trips.backfill.exif."""
+
+from trips.backfill import exif
+
+
+def test_dms_to_decimal_north_east():
+    # 50 deg 40' 28.2" N -> ~50.6745
+    assert round(exif.dms_to_decimal((50, 40, 28.2), "N"), 4) == 50.6745
+
+
+def test_dms_to_decimal_south_west_negative():
+    assert exif.dms_to_decimal((120, 0, 0), "W") == -120.0
+    assert exif.dms_to_decimal((30, 0, 0), "S") == -30.0
+
+
+def test_light_value():
+    # f/2.5, 1/240s, ISO 393 -> ~8.6 EV
+    assert exif.light_value(2.5, 1 / 240, 393) == 8.6
+    assert exif.light_value(None, 1 / 240, 393) is None
+    assert exif.light_value(2.5, 0, 393) is None
+
+
+def test_format_shutter_speed():
+    assert exif.format_shutter_speed(1 / 240) == "1/240"
+    assert exif.format_shutter_speed(2.0) == "2.0s"
+    assert exif.format_shutter_speed(0) is None
+    assert exif.format_shutter_speed(None) is None
+
+
+def test_optics_is_empty():
+    assert exif.Optics().is_empty()
+    assert not exif.Optics(iso=393).is_empty()
+    assert not exif.Optics(light_value=8.6).is_empty()

--- a/projects/monolith/trips/backfill/main.py
+++ b/projects/monolith/trips/backfill/main.py
@@ -1,0 +1,295 @@
+"""Local backfill CLI: re-derive trips Postgres rows from S3 image EXIF.
+
+Run by hand against a port-forwarded SeaweedFS + Postgres, e.g.:
+
+    bazel run //projects/monolith:trips_backfill -- run \\
+        --slug 2025-liard-hot-springs \\
+        --config projects/trips/frontend/public/trips/2025-liard-hot-springs/config.yaml \\
+        --endpoint http://localhost:8333 \\
+        --database-url postgresql://postgres@localhost:5432/monolith \\
+        --kml van-to-kamloops.kml --kml-start 2025-01-03T10:28:00
+
+It lists the `trips` bucket, extracts GPS/timestamp/optics EXIF from each image,
+optionally adds route-only gap points from KML directions and elevation from the
+NRCan CDEM API, then replaces trips.points for the trip (and upserts the
+trips.trips metadata row from config.yaml). Idempotent: re-running rebuilds.
+"""
+
+import asyncio
+import logging
+import tempfile
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Annotated
+
+import boto3
+import httpx
+import typer
+import yaml
+from botocore.config import Config
+from sqlalchemy import delete
+from sqlmodel import Session, create_engine
+
+from trips.backfill import exif, transform
+from trips.models import Trip, TripPoint
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger("trips.backfill")
+
+app = typer.Typer(help="Backfill the trips Postgres schema from S3 image EXIF.")
+
+DEFAULT_BUCKET = "trips"
+ELEVATION_API = "https://geogratis.gc.ca/services/elevation/cdem/altitude"
+_IMAGE_EXTS = {".jpg", ".jpeg", ".png", ".heic", ".heif"}
+
+
+def make_engine(database_url: str):
+    """Create an engine, rewriting the scheme for psycopg v3 (see app/db.py)."""
+    url = database_url.replace("postgresql://", "postgresql+psycopg://", 1)
+    return create_engine(url)
+
+
+def get_s3_client(endpoint: str):
+    """S3 client for SeaweedFS (auth disabled in-cluster)."""
+    # Guard against a scheme-less endpoint (semgrep boto3-endpoint-url-missing-scheme).
+    if not endpoint.startswith(("http://", "https://")):
+        endpoint = f"http://{endpoint}"
+    return boto3.client(
+        "s3",
+        endpoint_url=endpoint,
+        aws_access_key_id="any",
+        aws_secret_access_key="any",
+        config=Config(signature_version="s3v4"),
+        region_name="us-east-1",
+    )
+
+
+def list_image_keys(s3, bucket: str) -> list[str]:
+    """List image object keys in the bucket (paginated)."""
+    keys: list[str] = []
+    token = None
+    while True:
+        kwargs = {"Bucket": bucket, "MaxKeys": 1000}
+        if token:
+            kwargs["ContinuationToken"] = token
+        resp = s3.list_objects_v2(**kwargs)
+        for obj in resp.get("Contents", []):
+            if Path(obj["Key"]).suffix.lower() in _IMAGE_EXTS:
+                keys.append(obj["Key"])
+        if not resp.get("IsTruncated"):
+            return keys
+        token = resp["NextContinuationToken"]
+
+
+def _extract_photo_points(
+    s3, bucket: str, keys: list[str], tmp_dir: Path, concurrency: int
+) -> list[dict]:
+    """Download images, pull EXIF, return photo point dicts (GPS only)."""
+
+    def work(key: str):
+        local = tmp_dir / Path(key).name
+        try:
+            s3.download_file(bucket, key, str(local))
+            lat, lng, ts, optics = exif.extract_exif(local)
+            return key, lat, lng, ts, optics
+        except Exception as exc:  # noqa: BLE001 - skip unreadable objects
+            logger.warning("failed to process %s: %s", key, exc)
+            return key, None, None, None, None
+        finally:
+            local.unlink(missing_ok=True)
+
+    points: list[dict] = []
+    with ThreadPoolExecutor(max_workers=concurrency) as pool:
+        for future in as_completed(pool.submit(work, k) for k in keys):
+            key, lat, lng, ts, optics = future.result()
+            if lat is None or lng is None:
+                continue  # no GPS -> not a map point
+            if not transform.is_valid_coordinates(lat, lng):
+                continue
+            points.append(
+                {
+                    "key": key,
+                    "lat": round(lat, 5),
+                    "lng": round(lng, 5),
+                    "timestamp": ts,
+                    "optics": optics,
+                }
+            )
+    return points
+
+
+async def _fetch_elevations(
+    coords: list[tuple[float, float]], concurrency: int
+) -> dict[tuple[float, float], float | None]:
+    """Fetch NRCan CDEM elevations, deduped by rounded coordinate."""
+    unique = sorted({(round(la, 5), round(ln, 5)) for la, ln in coords})
+    sem = asyncio.Semaphore(concurrency)
+    out: dict[tuple[float, float], float | None] = {}
+
+    async with httpx.AsyncClient(timeout=10.0) as client:
+
+        async def one(lat: float, lng: float):
+            async with sem:
+                try:
+                    resp = await client.get(
+                        ELEVATION_API, params={"lat": lat, "lon": lng}
+                    )
+                    out[(lat, lng)] = (
+                        resp.json().get("altitude") if resp.status_code == 200 else None
+                    )
+                except Exception:  # noqa: BLE001 - best effort, leave as None
+                    out[(lat, lng)] = None
+
+        await asyncio.gather(*(one(la, ln) for la, ln in unique))
+    return out
+
+
+def _load_trip_row(slug: str, config_path: Path, tz: str) -> Trip:
+    """Build the trips.trips row from a frontend config.yaml."""
+    data = yaml.safe_load(config_path.read_text()) or {}
+    trip = data.get("trip", {})
+    timeline = data.get("timeline", {})
+    days = {str(k): v for k, v in (data.get("days") or {}).items()}
+    return Trip(
+        slug=slug,
+        title=trip.get("title", slug),
+        short_title=trip.get("short_title"),
+        subtitle=trip.get("subtitle"),
+        timezone=tz,
+        default_image=timeline.get("default_image"),
+        default_zoom=timeline.get("default_zoom"),
+        days=days,
+        highlights=data.get("highlights") or [],
+        stats=data.get("stats") or {},
+    )
+
+
+@app.command()
+def run(
+    slug: Annotated[str, typer.Option(help="Trip slug, e.g. 2025-liard-hot-springs")],
+    config: Annotated[
+        Path | None,
+        typer.Option(help="frontend config.yaml to upsert the trips.trips row"),
+    ] = None,
+    bucket: Annotated[str, typer.Option(help="S3 bucket")] = DEFAULT_BUCKET,
+    endpoint: Annotated[
+        str, typer.Option(help="SeaweedFS S3 endpoint")
+    ] = "http://localhost:8333",
+    database_url: Annotated[
+        str,
+        typer.Option(
+            envvar="DATABASE_URL", help="Postgres URL (defaults to $DATABASE_URL)"
+        ),
+    ] = "postgresql://postgres@localhost:5432/monolith",
+    source: Annotated[str, typer.Option(help="Image source tag")] = "gopro",
+    tz: Annotated[
+        str, typer.Option("--timezone", help="IANA zone for EXIF timestamps")
+    ] = "America/Vancouver",
+    kml: Annotated[
+        list[Path] | None, typer.Option(help="KML route file(s) for gap points")
+    ] = None,
+    kml_start: Annotated[
+        list[str] | None,
+        typer.Option(help="ISO start time per --kml (parallel order)"),
+    ] = None,
+    kml_max_points: Annotated[
+        int, typer.Option(help="Max gap points sampled per KML")
+    ] = 100,
+    elevation: Annotated[
+        bool, typer.Option(help="Fetch elevation from NRCan CDEM")
+    ] = True,
+    concurrency: Annotated[int, typer.Option(help="Parallel downloads/requests")] = 10,
+    dry_run: Annotated[
+        bool, typer.Option("--dry-run", "-n", help="Compute only, don't write")
+    ] = False,
+) -> None:
+    """Rebuild trips.points (and optionally trips.trips) for one trip."""
+    now = datetime.now(timezone.utc)
+    s3 = get_s3_client(endpoint)
+
+    print(f"Listing s3://{bucket} ...")
+    keys = list_image_keys(s3, bucket)
+    print(f"Found {len(keys)} images")
+
+    with tempfile.TemporaryDirectory(prefix="trips-backfill-") as tmp:
+        photo = _extract_photo_points(s3, bucket, keys, Path(tmp), concurrency)
+    print(f"Extracted {len(photo)} photo points with GPS")
+
+    # Route-only gap points from KML directions.
+    gap: list[dict] = []
+    kml_files = list(kml or [])
+    starts = list(kml_start or [])
+    if kml_files and len(starts) != len(kml_files):
+        raise typer.BadParameter("--kml-start must be given once per --kml")
+    for path, start in zip(kml_files, starts):
+        coords = transform.parse_kml_coordinates(path.read_text())
+        coords = transform.sample_coordinates(coords, kml_max_points)
+        gap.extend(transform.gap_points(coords, datetime.fromisoformat(start), tz))
+    if gap:
+        print(f"Built {len(gap)} gap points from {len(kml_files)} KML route(s)")
+
+    # Elevation enrichment (photo + gap).
+    elevations: dict[tuple[float, float], float | None] = {}
+    if elevation:
+        coords = [(p["lat"], p["lng"]) for p in photo] + [
+            (p["lat"], p["lng"]) for p in gap
+        ]
+        print(f"Fetching elevation for {len(coords)} points ...")
+        elevations = asyncio.run(_fetch_elevations(coords, concurrency))
+        resolved = sum(1 for v in elevations.values() if v is not None)
+        print(f"Elevation: {resolved}/{len(elevations)} unique coords resolved")
+
+    rows: list[TripPoint] = []
+    for p in photo:
+        o: exif.Optics | None = p["optics"]
+        rows.append(
+            TripPoint(
+                trip_slug=slug,
+                id=transform.point_id_from_image_key(p["key"]),
+                lat=p["lat"],
+                lng=p["lng"],
+                taken_at=transform.localize(p["timestamp"], tz, now),
+                image=p["key"],
+                source=source,
+                tags=[],
+                elevation=elevations.get((p["lat"], p["lng"])),
+                light_value=o.light_value if o else None,
+                iso=o.iso if o else None,
+                shutter_speed=o.shutter_speed if o else None,
+                aperture=o.aperture if o else None,
+                focal_length_35mm=o.focal_length_35mm if o else None,
+            )
+        )
+    for g in gap:
+        rows.append(
+            TripPoint(
+                trip_slug=slug,
+                id=g["id"],
+                lat=g["lat"],
+                lng=g["lng"],
+                taken_at=g["taken_at"],
+                image=None,
+                source=g["source"],
+                tags=g["tags"],
+                elevation=elevations.get((g["lat"], g["lng"])),
+            )
+        )
+
+    print(f"Prepared {len(rows)} total points for trip {slug}")
+    if dry_run:
+        print("[DRY RUN] no database writes")
+        return
+
+    engine = make_engine(database_url)
+    with Session(engine) as session:
+        if config is not None:
+            session.merge(_load_trip_row(slug, config, tz))
+        session.execute(delete(TripPoint).where(TripPoint.trip_slug == slug))
+        session.add_all(rows)
+        session.commit()
+    print(f"Wrote {len(rows)} points for {slug}")
+
+
+if __name__ == "__main__":
+    app()

--- a/projects/monolith/trips/backfill/main.py
+++ b/projects/monolith/trips/backfill/main.py
@@ -157,7 +157,7 @@ def _load_trip_row(slug: str, config_path: Path, tz: str) -> Trip:
         title=trip.get("title", slug),
         short_title=trip.get("short_title"),
         subtitle=trip.get("subtitle"),
-        timezone=tz,
+        tz=tz,
         default_image=timeline.get("default_image"),
         default_zoom=timeline.get("default_zoom"),
         days=days,

--- a/projects/monolith/trips/backfill/main.py
+++ b/projects/monolith/trips/backfill/main.py
@@ -138,7 +138,8 @@ async def _fetch_elevations(
                     out[(lat, lng)] = (
                         resp.json().get("altitude") if resp.status_code == 200 else None
                     )
-                except Exception:  # noqa: BLE001 - best effort, leave as None
+                except Exception as exc:  # noqa: BLE001 - best effort, leave as None
+                    logger.debug("elevation fetch failed for %s,%s: %s", lat, lng, exc)
                     out[(lat, lng)] = None
 
         await asyncio.gather(*(one(la, ln) for la, ln in unique))

--- a/projects/monolith/trips/backfill/transform.py
+++ b/projects/monolith/trips/backfill/transform.py
@@ -1,0 +1,110 @@
+"""Pure transforms for the trips backfill.
+
+No network/disk I/O so these are unit tested directly; main.py wires them to
+S3, the elevation API and Postgres. Deterministic id namespaces match the
+original publish-* tools so re-derived rows keep stable ids.
+"""
+
+import uuid
+from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
+
+import defusedxml.ElementTree as ET
+
+GAP_KEY_NAMESPACE = uuid.UUID("b2c3d4e5-f6a7-8901-bcde-f23456789012")
+
+_KML_NS = {"kml": "http://www.opengis.net/kml/2.2"}
+
+
+def is_valid_coordinates(lat: float, lng: float) -> bool:
+    """Reject null island (0, 0) and out-of-range coordinates."""
+    if lat == 0.0 and lng == 0.0:
+        return False
+    return -90 <= lat <= 90 and -180 <= lng <= 180
+
+
+def point_id_from_image_key(image_key: str) -> str:
+    """Deterministic point id from an S3 image key.
+
+    Mirrors the old NATS pipeline: 'img_2d30f3c65619.jpg' -> '2d30f3c65619'.
+    """
+    return image_key.replace("img_", "").rsplit(".", 1)[0]
+
+
+def gap_point_id(lat: float, lng: float, timestamp: str) -> str:
+    """Deterministic id for a route-only gap point."""
+    identity = f"gap:{lat:.5f}:{lng:.5f}:{timestamp}"
+    return f"gap_{uuid.uuid5(GAP_KEY_NAMESPACE, identity).hex[:12]}"
+
+
+def localize(naive_iso: str | None, tz: str, fallback: datetime) -> datetime:
+    """Interpret a naive camera-local ISO timestamp in ``tz`` as tz-aware.
+
+    Falls back to ``fallback`` (already tz-aware) when the timestamp is missing
+    or unparseable.
+    """
+    zone = ZoneInfo(tz)
+    if not naive_iso:
+        return fallback
+    try:
+        parsed = datetime.fromisoformat(naive_iso)
+    except ValueError:
+        return fallback
+    if parsed.tzinfo is not None:
+        return parsed
+    return parsed.replace(tzinfo=zone)
+
+
+def parse_kml_coordinates(kml_text: str) -> list[tuple[float, float]]:
+    """Extract (lat, lng) tuples from the LineStrings in a KML document."""
+    root = ET.fromstring(kml_text)
+    coords: list[tuple[float, float]] = []
+    for linestring in root.findall(".//kml:LineString/kml:coordinates", _KML_NS):
+        if not linestring.text:
+            continue
+        for token in linestring.text.strip().split():
+            parts = token.split(",")
+            if len(parts) >= 2:
+                lng, lat = float(parts[0]), float(parts[1])
+                coords.append((lat, lng))
+    return coords
+
+
+def sample_coordinates(
+    coords: list[tuple[float, float]], max_points: int
+) -> list[tuple[float, float]]:
+    """Uniformly thin a coordinate list while keeping its shape and endpoints."""
+    if max_points <= 0 or len(coords) <= max_points:
+        return list(coords)
+    step = len(coords) / max_points
+    sampled = [coords[int(i * step)] for i in range(max_points)]
+    if sampled[-1] != coords[-1]:
+        sampled.append(coords[-1])
+    return sampled
+
+
+def gap_points(
+    coords: list[tuple[float, float]], start: datetime, tz: str
+) -> list[dict]:
+    """Build route-only gap point dicts from a sampled coordinate list.
+
+    Timestamps are sequential milliseconds after ``start`` (naive, camera-local)
+    purely for ordering; ``start`` is localized via ``tz``.
+    """
+    points = []
+    for i, (lat, lng) in enumerate(coords):
+        if not is_valid_coordinates(lat, lng):
+            continue
+        ts = (start + timedelta(milliseconds=i)).isoformat()
+        points.append(
+            {
+                "id": gap_point_id(lat, lng, ts),
+                "lat": round(lat, 5),
+                "lng": round(lng, 5),
+                "taken_at": localize(ts, tz, start.replace(tzinfo=ZoneInfo(tz))),
+                "image": None,
+                "source": "gap",
+                "tags": ["gap", "car"],
+            }
+        )
+    return points

--- a/projects/monolith/trips/backfill/transform_test.py
+++ b/projects/monolith/trips/backfill/transform_test.py
@@ -1,0 +1,92 @@
+"""Unit tests for trips.backfill.transform (pure, no I/O)."""
+
+from datetime import datetime, timezone
+from zoneinfo import ZoneInfo
+
+from trips.backfill import transform
+
+_KML = """<?xml version="1.0" encoding="UTF-8"?>
+<kml xmlns="http://www.opengis.net/kml/2.2">
+  <Document><Placemark><LineString><coordinates>
+    -123.1,49.2,0 -120.3,50.6,0 -118.0,52.9,0
+  </coordinates></LineString></Placemark></Document>
+</kml>"""
+
+
+def test_is_valid_coordinates():
+    assert transform.is_valid_coordinates(49.2, -123.1)
+    assert not transform.is_valid_coordinates(0.0, 0.0)  # null island
+    assert not transform.is_valid_coordinates(91.0, 0.0)
+    assert not transform.is_valid_coordinates(0.0, 181.0)
+
+
+def test_point_id_from_image_key():
+    assert transform.point_id_from_image_key("img_2d30f3c65619.jpg") == "2d30f3c65619"
+    assert transform.point_id_from_image_key("img_abc123.png") == "abc123"
+
+
+def test_gap_point_id_is_deterministic():
+    a = transform.gap_point_id(50.6, -120.3, "2025-01-03T10:28:00")
+    b = transform.gap_point_id(50.6, -120.3, "2025-01-03T10:28:00")
+    assert a == b
+    assert a.startswith("gap_")
+    assert a != transform.gap_point_id(50.7, -120.3, "2025-01-03T10:28:00")
+
+
+def test_localize_naive_applies_zone():
+    fallback = datetime(2000, 1, 1, tzinfo=timezone.utc)
+    out = transform.localize("2025-01-03T18:30:00", "America/Vancouver", fallback)
+    assert out.tzinfo == ZoneInfo("America/Vancouver")
+    assert out.hour == 18
+    # 18:30 PST is 02:30 UTC next day.
+    assert out.astimezone(timezone.utc).hour == 2
+
+
+def test_localize_missing_uses_fallback():
+    fallback = datetime(2000, 1, 1, tzinfo=timezone.utc)
+    assert transform.localize(None, "America/Vancouver", fallback) == fallback
+    assert transform.localize("not-a-date", "America/Vancouver", fallback) == fallback
+
+
+def test_localize_passes_through_aware():
+    fallback = datetime(2000, 1, 1, tzinfo=timezone.utc)
+    out = transform.localize("2025-01-03T18:30:00+00:00", "America/Vancouver", fallback)
+    assert out == datetime(2025, 1, 3, 18, 30, tzinfo=timezone.utc)
+
+
+def test_parse_kml_coordinates():
+    coords = transform.parse_kml_coordinates(_KML)
+    assert coords == [(49.2, -123.1), (50.6, -120.3), (52.9, -118.0)]
+
+
+def test_sample_coordinates_keeps_endpoints():
+    coords = [(float(i), 0.0) for i in range(100)]
+    sampled = transform.sample_coordinates(coords, 10)
+    assert len(sampled) <= 11
+    assert sampled[0] == (0.0, 0.0)
+    assert sampled[-1] == (99.0, 0.0)
+    # No thinning needed when already under the cap.
+    assert transform.sample_coordinates(coords[:5], 10) == coords[:5]
+
+
+def test_gap_points_shape():
+    coords = [(49.2, -123.1), (50.6, -120.3)]
+    start = datetime(2025, 1, 3, 10, 28, 0)
+    pts = transform.gap_points(coords, start, "America/Vancouver")
+    assert len(pts) == 2
+    first = pts[0]
+    assert first["image"] is None
+    assert first["source"] == "gap"
+    assert first["tags"] == ["gap", "car"]
+    assert first["taken_at"].tzinfo == ZoneInfo("America/Vancouver")
+    # ids are deterministic and ordered timestamps differ.
+    assert pts[0]["id"] != pts[1]["id"]
+    assert pts[1]["taken_at"] > pts[0]["taken_at"]
+
+
+def test_gap_points_skips_invalid():
+    pts = transform.gap_points(
+        [(0.0, 0.0), (50.6, -120.3)], datetime(2025, 1, 3, 10, 28, 0), "UTC"
+    )
+    assert len(pts) == 1
+    assert pts[0]["lat"] == 50.6

--- a/projects/monolith/trips/models.py
+++ b/projects/monolith/trips/models.py
@@ -1,0 +1,68 @@
+"""SQLModel definitions for the trips schema.
+
+Mirrors chart/migrations/20260615120000_trips_schema.sql:
+
+- ``Trip``: one row per trip, keyed by ``slug``. Holds the display metadata
+  that used to live in the frontend config.yaml (title/subtitle, the per-day
+  labels, highlights and manual stats). days/highlights/stats are JSON blobs so
+  the shape can evolve without a migration per field.
+- ``TripPoint``: one row per map point, keyed by (trip_slug, id). Mirrors the
+  old NATS TripPoint: GPS, capture time, the S3 image key, source, tags,
+  elevation and the camera EXIF/optics fields. ``image`` is NULL for route-only
+  "gap" points used to draw the driving line between photos.
+
+Postgres uses JSONB / TEXT[]; the SQLite variants let SQLModel.metadata
+.create_all() build the tables for the in-memory unit-test fixtures.
+"""
+
+from datetime import datetime, timezone
+from typing import Any
+
+from sqlalchemy import JSON, Column, String
+from sqlalchemy.dialects.postgresql import ARRAY as PG_ARRAY
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlmodel import Field, SQLModel
+
+# Postgres-native types with SQLite fallbacks (mirrors knowledge/models.py).
+_JSONB = JSONB().with_variant(JSON(), "sqlite")
+_STRING_ARRAY = PG_ARRAY(String).with_variant(JSON(), "sqlite")
+
+
+class Trip(SQLModel, table=True):  # nosemgrep: sqlmodel-datetime-without-factory
+    __tablename__ = "trips"
+    __table_args__ = {"schema": "trips", "extend_existing": True}
+
+    slug: str = Field(primary_key=True)
+    title: str
+    short_title: str | None = None
+    subtitle: str | None = None
+    # IANA zone the camera-local EXIF timestamps are interpreted in when the
+    # backfill converts them to the tz-aware TripPoint.taken_at.
+    timezone: str = "America/Vancouver"
+    default_image: str | None = None
+    default_zoom: int | None = None
+    days: dict[str, Any] = Field(default_factory=dict, sa_column=Column(_JSONB))
+    highlights: list[Any] = Field(default_factory=list, sa_column=Column(_JSONB))
+    stats: dict[str, Any] = Field(default_factory=dict, sa_column=Column(_JSONB))
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+
+
+class TripPoint(SQLModel, table=True):  # nosemgrep: sqlmodel-datetime-without-factory
+    __tablename__ = "points"
+    __table_args__ = {"schema": "trips", "extend_existing": True}
+
+    trip_slug: str = Field(primary_key=True)
+    id: str = Field(primary_key=True)
+    lat: float
+    lng: float
+    taken_at: datetime
+    image: str | None = None
+    source: str = "gopro"
+    tags: list[str] = Field(default_factory=list, sa_column=Column(_STRING_ARRAY))
+    elevation: float | None = None
+    light_value: float | None = None
+    iso: int | None = None
+    shutter_speed: str | None = None
+    aperture: float | None = None
+    focal_length_35mm: int | None = None
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))

--- a/projects/monolith/trips/models.py
+++ b/projects/monolith/trips/models.py
@@ -15,11 +15,7 @@ Postgres uses JSONB / TEXT[]; the SQLite variants let SQLModel.metadata
 .create_all() build the tables for the in-memory unit-test fixtures.
 """
 
-# Import datetime's timezone under an alias so the `timezone` model field
-# (mapping the trips.trips.timezone column) does not shadow the module name
-# (semgrep python-shadow-module-import).
-from datetime import datetime
-from datetime import timezone as dt_timezone
+from datetime import datetime, timezone
 from typing import Any
 
 from sqlalchemy import JSON, Column, String
@@ -41,14 +37,19 @@ class Trip(SQLModel, table=True):  # nosemgrep: sqlmodel-datetime-without-factor
     short_title: str | None = None
     subtitle: str | None = None
     # IANA zone the camera-local EXIF timestamps are interpreted in when the
-    # backfill converts them to the tz-aware TripPoint.taken_at.
-    timezone: str = "America/Vancouver"
+    # backfill converts them to the tz-aware TripPoint.taken_at. Attribute named
+    # `tz` (not `timezone`) to avoid shadowing the datetime.timezone import
+    # (semgrep python-shadow-module-import); the DB column stays `timezone`.
+    tz: str = Field(
+        default="America/Vancouver",
+        sa_column=Column("timezone", String, nullable=False),
+    )
     default_image: str | None = None
     default_zoom: int | None = None
     days: dict[str, Any] = Field(default_factory=dict, sa_column=Column(_JSONB))
     highlights: list[Any] = Field(default_factory=list, sa_column=Column(_JSONB))
     stats: dict[str, Any] = Field(default_factory=dict, sa_column=Column(_JSONB))
-    created_at: datetime = Field(default_factory=lambda: datetime.now(dt_timezone.utc))
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
 
 
 class TripPoint(SQLModel, table=True):  # nosemgrep: sqlmodel-datetime-without-factory
@@ -69,4 +70,4 @@ class TripPoint(SQLModel, table=True):  # nosemgrep: sqlmodel-datetime-without-f
     shutter_speed: str | None = None
     aperture: float | None = None
     focal_length_35mm: int | None = None
-    created_at: datetime = Field(default_factory=lambda: datetime.now(dt_timezone.utc))
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))

--- a/projects/monolith/trips/models.py
+++ b/projects/monolith/trips/models.py
@@ -15,7 +15,11 @@ Postgres uses JSONB / TEXT[]; the SQLite variants let SQLModel.metadata
 .create_all() build the tables for the in-memory unit-test fixtures.
 """
 
-from datetime import datetime, timezone
+# Import datetime's timezone under an alias so the `timezone` model field
+# (mapping the trips.trips.timezone column) does not shadow the module name
+# (semgrep python-shadow-module-import).
+from datetime import datetime
+from datetime import timezone as dt_timezone
 from typing import Any
 
 from sqlalchemy import JSON, Column, String
@@ -44,7 +48,7 @@ class Trip(SQLModel, table=True):  # nosemgrep: sqlmodel-datetime-without-factor
     days: dict[str, Any] = Field(default_factory=dict, sa_column=Column(_JSONB))
     highlights: list[Any] = Field(default_factory=list, sa_column=Column(_JSONB))
     stats: dict[str, Any] = Field(default_factory=dict, sa_column=Column(_JSONB))
-    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    created_at: datetime = Field(default_factory=lambda: datetime.now(dt_timezone.utc))
 
 
 class TripPoint(SQLModel, table=True):  # nosemgrep: sqlmodel-datetime-without-factory
@@ -65,4 +69,4 @@ class TripPoint(SQLModel, table=True):  # nosemgrep: sqlmodel-datetime-without-f
     shutter_speed: str | None = None
     aperture: float | None = None
     focal_length_35mm: int | None = None
-    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    created_at: datetime = Field(default_factory=lambda: datetime.now(dt_timezone.utc))

--- a/projects/monolith/trips/models_test.py
+++ b/projects/monolith/trips/models_test.py
@@ -56,7 +56,7 @@ def test_trip_roundtrip(session):
     assert loaded.title == "WINTER ROAD TRIP"
     assert loaded.short_title == "Liard"
     # Default timezone applies when not set explicitly.
-    assert loaded.timezone == "America/Vancouver"
+    assert loaded.tz == "America/Vancouver"
     assert loaded.default_zoom == 4
     assert loaded.days["1"]["label"] == "VAN -> KAMLOOPS"
     assert loaded.highlights[0]["id"] == "liard-hotsprings"

--- a/projects/monolith/trips/models_test.py
+++ b/projects/monolith/trips/models_test.py
@@ -1,0 +1,122 @@
+"""Unit tests for trips.models: round-trip Trip + TripPoint on SQLite.
+
+Uses SQLModel.metadata.create_all (no migrations), mirroring the hikes/ships/
+stars model tests. The schema-stripping fixture lets the schema-qualified
+tables build on SQLite.
+"""
+
+from datetime import datetime, timezone
+
+import pytest
+from sqlmodel import Session, SQLModel, create_engine, select
+from sqlmodel.pool import StaticPool
+
+from trips.models import Trip, TripPoint
+
+
+@pytest.fixture(name="session")
+def session_fixture():
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    original_schemas = {}
+    for table in SQLModel.metadata.tables.values():
+        if table.schema is not None:
+            original_schemas[table.name] = table.schema
+            table.schema = None
+    try:
+        SQLModel.metadata.create_all(engine)
+        with Session(engine) as session:
+            yield session
+    finally:
+        for table in SQLModel.metadata.tables.values():
+            if table.name in original_schemas:
+                table.schema = original_schemas[table.name]
+
+
+def test_trip_roundtrip(session):
+    trip = Trip(
+        slug="2025-liard-hot-springs",
+        title="WINTER ROAD TRIP",
+        short_title="Liard",
+        subtitle="Vancouver -> Yukon -> Vancouver",
+        default_image="img_2d30f3c65619",
+        default_zoom=4,
+        days={"1": {"label": "VAN -> KAMLOOPS", "notes": "The beginning"}},
+        highlights=[{"id": "liard-hotsprings", "type": "hotspring", "day": 6}],
+        stats={"coldest_temp": -34},
+    )
+    session.add(trip)
+    session.commit()
+
+    loaded = session.get(Trip, "2025-liard-hot-springs")
+    assert loaded is not None
+    assert loaded.title == "WINTER ROAD TRIP"
+    assert loaded.short_title == "Liard"
+    # Default timezone applies when not set explicitly.
+    assert loaded.timezone == "America/Vancouver"
+    assert loaded.default_zoom == 4
+    assert loaded.days["1"]["label"] == "VAN -> KAMLOOPS"
+    assert loaded.highlights[0]["id"] == "liard-hotsprings"
+    assert loaded.stats["coldest_temp"] == -34
+    assert isinstance(loaded.created_at, datetime)
+
+
+def test_trip_point_roundtrip_with_optics(session):
+    taken = datetime(2025, 1, 3, 18, 30, 0, tzinfo=timezone.utc)
+    point = TripPoint(
+        trip_slug="2025-liard-hot-springs",
+        id="2d30f3c65619",
+        lat=50.6745,
+        lng=-120.3273,
+        taken_at=taken,
+        image="img_2d30f3c65619.jpg",
+        source="camera",
+        tags=["car", "hotspring"],
+        elevation=345.0,
+        light_value=8.6,
+        iso=393,
+        shutter_speed="1/240",
+        aperture=2.5,
+        focal_length_35mm=16,
+    )
+    session.add(point)
+    session.commit()
+
+    loaded = session.get(TripPoint, ("2025-liard-hot-springs", "2d30f3c65619"))
+    assert loaded is not None
+    assert loaded.lat == 50.6745
+    assert loaded.lng == -120.3273
+    assert loaded.image == "img_2d30f3c65619.jpg"
+    assert loaded.source == "camera"
+    assert loaded.tags == ["car", "hotspring"]
+    assert loaded.elevation == 345.0
+    assert loaded.light_value == 8.6
+    assert loaded.iso == 393
+    assert loaded.shutter_speed == "1/240"
+    assert loaded.aperture == 2.5
+    assert loaded.focal_length_35mm == 16
+    # SQLite returns naive datetimes; production is Postgres TIMESTAMPTZ.
+    assert isinstance(loaded.taken_at, datetime)
+
+
+def test_trip_point_gap_has_no_image(session):
+    gap = TripPoint(
+        trip_slug="2025-liard-hot-springs",
+        id="gap_aabbccddeeff",
+        lat=51.0,
+        lng=-121.0,
+        taken_at=datetime(2025, 1, 3, 10, 28, 0, tzinfo=timezone.utc),
+        source="gap",
+        tags=["gap", "car"],
+    )
+    session.add(gap)
+    session.commit()
+
+    rows = session.exec(select(TripPoint).where(TripPoint.source == "gap")).all()
+    assert len(rows) == 1
+    assert rows[0].image is None
+    assert rows[0].elevation is None
+    assert rows[0].tags == ["gap", "car"]


### PR DESCRIPTION
Begins migrating the standalone `trips.jomcgi.dev` service into the monolith (target: SSR at `/app/trips`, neo-brutalist styling). This first step lands the Postgres data model and the local replay tooling. The SSR frontend, read endpoints, and image routing follow in later phases. The standalone service keeps running until the monolith version reaches parity.

## What's here

**Migration** `chart/migrations/20260615120000_trips_schema.sql` (`trips` schema):
- `trips.trips`: one row per trip, holding the display metadata that lived in the frontend `config.yaml` (title/subtitle, per-day labels, highlights, manual stats as JSONB), plus a `timezone` used to interpret camera-local EXIF times.
- `trips.points`: one row per map point, keyed by `(trip_slug, id)`. Mirrors the old NATS `TripPoint`: GPS, capture time, S3 image key, source, tags, elevation, and EXIF/optics. `image` is NULL for route-only "gap" points.
- `atlas.sum` regenerated with the pinned atlas v1.1.0 (`atlas migrate validate` passes; only the new entry + total line change).

**Model** `trips/models.py`: SQLModel `Trip` and `TripPoint` mirroring the migration, with JSONB / `TEXT[]` SQLite variants so the in-memory unit-test fixtures build.

**Backfill** `trips/backfill/`: run-by-hand CLI (decided: run locally, not a deployed job) that lists the `trips` S3 bucket, re-derives points from image EXIF, optionally adds route-only gap points from KML directions and elevation from the NRCan CDEM API, then replaces `trips.points` for a trip and upserts the `trips.trips` metadata row from `config.yaml`. Pure transform/EXIF helpers are unit tested; S3/HTTP/DB I/O lives in `main.py`. Excluded from the server image (like `stars/grid_gen`).

```
bazel run //projects/monolith:trips_backfill -- run \
  --slug 2025-liard-hot-springs \
  --config projects/trips/frontend/public/trips/2025-liard-hot-springs/config.yaml \
  --endpoint http://localhost:8333 \
  --database-url postgresql://postgres@localhost:5432/monolith \
  --kml van-to-kamloops.kml --kml-start 2025-01-03T10:28:00
```

## Notes
- "Replay from S3" is implemented as re-deriving photo points from image EXIF. Route geometry (gap points) and elevation are not in EXIF, so the backfill folds in the existing KML-route and NRCan-elevation enrichment, matching today's data.
- Local verification: 18 new unit tests pass (pure helpers + SQLite round-trip), `ruff check` clean, `atlas migrate validate` OK.

## Scope (this PR)
Schema migrations complete and the backfill script is ready to run. Out of scope (later phases): SSR pages, `/api/trips` read endpoints, image serving through the site, and decommissioning the standalone service.

https://claude.ai/code/session_019ZzwJ2KRdVUDcsGyjGAgHd

---
_Generated by [Claude Code](https://claude.ai/code/session_019ZzwJ2KRdVUDcsGyjGAgHd)_