### PR TITLE
fix(monolith): stars map field and card derive from one window list

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.140.3
+version: 0.140.4
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.140.3
+      targetRevision: 0.140.4
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/lib/public/components/stars/StarsMap.svelte
+++ b/projects/monolith/frontend/src/lib/public/components/stars/StarsMap.svelte
@@ -1,7 +1,12 @@
 <script>
   import { onMount } from "svelte";
   import "maplibre-gl/dist/maplibre-gl.css";
-  import { relativeMax, monthBars } from "$lib/public/stars/heat.js";
+  import {
+    relativeMax,
+    monthBars,
+    liveWindows,
+    nightKey,
+  } from "$lib/public/stars/heat.js";
 
   // `sites` is the list to plot; clicking a dot opens the detail card. In LIVE
   // mode the rows carry per-night scores + upcoming clear-dark hours; in
@@ -85,6 +90,11 @@
   // (ShipsMap uses 0.9 over water; stars cells sit on land so go a touch lower).
   const CELL_FILL_OPACITY = 0.72;
 
+  // How many upcoming windows the detail card lists at once. best_hours ships
+  // more than this (see _DISPLAY_HOURS server-side) so the elapsed-filtered list
+  // still fills the card through a night as the earliest hours drop off.
+  const CARD_HOURS = 8;
+
   const SOURCE_ID = "sites"; // point features -> circle markers
   const LAYER_ID = "sites";
   const CELL_SOURCE = "sites-cells"; // square polygons -> fill heatmap
@@ -157,16 +167,11 @@
         ],
   );
 
-  // The selected site's hours, dropping any that have already elapsed (the hour
-  // is over once nowMs passes its end). LIVE only; historical rows carry no
-  // best_hours. The endpoint already prunes past hours server-side; this just
-  // keeps a long-open page honest between refreshes.
-  let cardHours = $derived(
-    (selected?.best_hours ?? []).filter((h) => {
-      const t = Date.parse(h.time);
-      return Number.isNaN(t) ? true : t + 3_600_000 > nowMs;
-    }),
-  );
+  // The selected site's upcoming windows for the card list: the same elapsed-
+  // filtered best_hours the map field is derived from (so a coloured cell always
+  // has card rows), capped at the handful the card shows at once. LIVE only;
+  // historical rows carry no best_hours.
+  let cardHours = $derived(liveWindows(selected, nowMs).slice(0, CARD_HOURS));
 
   // Group the live windows by London-local day so the list shows each day once
   // (a rowspan label) with its hours beneath, rather than repeating "Mon, Mon,
@@ -269,28 +274,32 @@
     };
   }
 
-  // Upcoming clear-hour count this site reaches across the currently selected
-  // nights. Normally this is the clear-DARK count; in the midsummer "twilight"
-  // darkness mode (no true dark anywhere) it falls back to the wider clear-
-  // TWILIGHT count so the live field is not uniformly zero. Falls back to the
-  // site-level total when the payload carries no per-night map (older build /
-  // CDN-cached response), so the map never blanks. With a single selected night,
-  // sites with no qualifying hours that night return null and drop off the map
-  // (the night filter). LIVE only. The per-night maps only hold nights with >= 1
-  // qualifying hour, so a missing key is correctly treated as zero.
+  // Upcoming clear-window count this site reaches across the currently selected
+  // nights, derived from the same best_hours array the card lists (so a coloured
+  // cell always has card rows). In astronomical mode only true-dark hours count
+  // toward the field; in the midsummer "twilight" mode the whole clear-twilight
+  // superset counts so the field is not uniformly zero. Hours with no `dark`
+  // flag (older payload) count as dark, preserving prior behaviour. With one or
+  // more selected nights the site takes its best single night's count; a site
+  // with no qualifying windows on the active nights returns null and drops off
+  // the map (the night filter). LIVE only.
   function effectiveClearDark(site) {
-    const twilight = darknessMode === "twilight";
-    const nd = twilight ? site.night_clear_twilight : site.night_clear_dark;
-    const total = twilight
-      ? (site.clear_twilight_hours ?? site.clear_dark_hours)
-      : site.clear_dark_hours;
-    if (!nd || !activeNights || activeNights.size === 0) {
-      return total ?? null;
+    const darkOnly = darknessMode !== "twilight";
+    const wins = liveWindows(site, nowMs).filter(
+      (h) => !darkOnly || h.dark !== false,
+    );
+    if (!activeNights || activeNights.size === 0) {
+      return wins.length || null;
+    }
+    const perNight = new Map();
+    for (const h of wins) {
+      const night = nightKey(h.time);
+      if (!activeNights.has(night)) continue;
+      perNight.set(night, (perNight.get(night) ?? 0) + 1);
     }
     let best = null;
-    for (const night of activeNights) {
-      const c = nd[night];
-      if (c != null && (best === null || c > best)) best = c;
+    for (const c of perNight.values()) {
+      if (best === null || c > best) best = c;
     }
     return best;
   }
@@ -463,6 +472,15 @@
   // live field then derives from a different per-site count (dark vs twilight).
   $effect(() => {
     void darknessMode;
+    if (map && layerReady && mode === "live") pushData();
+  });
+
+  // Recolour as the clock advances: the live field elapsed-filters best_hours,
+  // so a tick can drop a site whose last window has just passed. Keeps the
+  // markers in step with the card (which re-derives on nowMs), so a coloured
+  // cell never outlives its windows. LIVE only.
+  $effect(() => {
+    void nowMs;
     if (map && layerReady && mode === "live") pushData();
   });
 

--- a/projects/monolith/frontend/src/lib/public/stars/heat.js
+++ b/projects/monolith/frontend/src/lib/public/stars/heat.js
@@ -95,3 +95,58 @@ export function relativeMax(values, floor = 1) {
 export function heatWeightExpression(max) {
   return ["interpolate", ["linear"], ["get", "heat"], 0, 0, max, 1];
 }
+
+const HOUR_MS = 3_600_000;
+
+// A forecast hour is still "upcoming" until the end of its clock hour (its start
+// + 1 h) is in the future. Mirrors the server's read-time prune, applied on the
+// client so a long-open page drops hours that elapse between data refreshes.
+// `iso` carries a UTC offset, so Date.parse yields an absolute instant: this is
+// timezone-safe regardless of the viewer's locale (Vancouver or otherwise). An
+// unparseable time is kept rather than silently dropped.
+export function isUpcoming(iso, nowMs) {
+  const t = Date.parse(iso);
+  return Number.isNaN(t) ? true : t + HOUR_MS > nowMs;
+}
+
+const NIGHT_SHIFT_MS = 12 * HOUR_MS;
+
+// The viewing-night key (YYYY-MM-DD) an hour belongs to, matching the server's
+// retired _night_key. A night runs from one evening into the next morning, so
+// shifting the instant back 12 h and taking its UK-local date folds the evening
+// and the following pre-dawn hours onto one key (one outing = one night).
+export function nightKey(iso) {
+  const ms = Date.parse(iso);
+  if (Number.isNaN(ms)) return null;
+  return new Date(ms - NIGHT_SHIFT_MS).toLocaleDateString("en-CA", {
+    timeZone: "Europe/London",
+  });
+}
+
+// A site's upcoming clear windows (the live layer): best_hours with already-
+// elapsed hours dropped. This is the clear-twilight superset the card lists; the
+// map field filters it further by darkness mode (see the component). Shared by
+// the map field, the night buckets and the card so a coloured cell always has
+// card rows. Returns a new array, never mutates the input.
+export function liveWindows(site, nowMs) {
+  return (site?.best_hours ?? []).filter((h) => isUpcoming(h.time, nowMs));
+}
+
+// The sorted union of upcoming viewing-night keys across all sites, for the
+// night-filter chips. Derived from the same windows the map colours by, so a
+// fully-elapsed night drops out and a chip can never offer a night with no
+// selectable windows. In astronomical mode only true-dark windows seed a night;
+// in the midsummer twilight fallback every clear-twilight window does. Hours with
+// no `dark` flag (older payload) count as dark, preserving prior behaviour.
+export function starsNights(sites, darkness, nowMs) {
+  const darkOnly = darkness !== "twilight";
+  const keys = new Set();
+  for (const site of sites ?? []) {
+    for (const h of liveWindows(site, nowMs)) {
+      if (darkOnly && h.dark === false) continue;
+      const key = nightKey(h.time);
+      if (key) keys.add(key);
+    }
+  }
+  return [...keys].sort();
+}

--- a/projects/monolith/frontend/src/lib/public/stars/heat.test.js
+++ b/projects/monolith/frontend/src/lib/public/stars/heat.test.js
@@ -5,6 +5,10 @@ import {
   monthBars,
   relativeMax,
   heatWeightExpression,
+  isUpcoming,
+  nightKey,
+  liveWindows,
+  starsNights,
 } from "./heat.js";
 
 describe("monthLabel / monthShort", () => {
@@ -92,5 +96,107 @@ describe("heatWeightExpression", () => {
       80,
       1,
     ]);
+  });
+});
+
+const NOW = Date.parse("2026-06-16T02:04:00Z");
+
+describe("isUpcoming", () => {
+  it("drops an hour once its clock hour has fully elapsed", () => {
+    // Starts 01:00, ends 02:00, which is before now (02:04): elapsed.
+    expect(isUpcoming("2026-06-16T01:00:00+00:00", NOW)).toBe(false);
+  });
+
+  it("keeps the in-progress hour and any future hour", () => {
+    // Starts 02:00, ends 03:00 > now: still upcoming.
+    expect(isUpcoming("2026-06-16T02:00:00+00:00", NOW)).toBe(true);
+    expect(isUpcoming("2026-06-16T05:00:00+00:00", NOW)).toBe(true);
+  });
+
+  it("is timezone-safe: an offset-bearing string parses as an absolute instant", () => {
+    // 03:00+01:00 == 02:00Z, in progress at 02:04Z.
+    expect(isUpcoming("2026-06-16T03:00:00+01:00", NOW)).toBe(true);
+  });
+
+  it("keeps an unparseable time rather than silently dropping it", () => {
+    expect(isUpcoming("not-a-date", NOW)).toBe(true);
+  });
+});
+
+describe("nightKey", () => {
+  it("folds pre-dawn hours back onto the evening that opened the night", () => {
+    // 01:00Z and the prior 22:00Z belong to the same viewing night.
+    expect(nightKey("2026-06-16T01:00:00+00:00")).toBe("2026-06-15");
+    expect(nightKey("2026-06-15T22:00:00+00:00")).toBe("2026-06-15");
+  });
+
+  it("rolls to the next night once past midday UK time", () => {
+    expect(nightKey("2026-06-16T12:00:00+00:00")).toBe("2026-06-16");
+  });
+
+  it("returns null for an unparseable time", () => {
+    expect(nightKey("nope")).toBe(null);
+  });
+});
+
+describe("liveWindows", () => {
+  const site = {
+    best_hours: [
+      { time: "2026-06-16T00:00:00+00:00", dark: true }, // elapsed
+      { time: "2026-06-16T03:00:00+00:00", dark: true }, // future dark
+      { time: "2026-06-17T01:00:00+00:00", dark: false }, // future twilight-only
+    ],
+  };
+
+  it("drops elapsed hours and keeps the clear-twilight superset (dark + twilight)", () => {
+    const wins = liveWindows(site, NOW);
+    expect(wins.map((h) => h.time)).toEqual([
+      "2026-06-16T03:00:00+00:00",
+      "2026-06-17T01:00:00+00:00",
+    ]);
+  });
+
+  it("tolerates a missing site / best_hours", () => {
+    expect(liveWindows(null, NOW)).toEqual([]);
+    expect(liveWindows({}, NOW)).toEqual([]);
+  });
+});
+
+describe("starsNights", () => {
+  const sites = [
+    {
+      best_hours: [
+        { time: "2026-06-16T00:00:00+00:00", dark: true }, // elapsed -> ignored
+        { time: "2026-06-16T03:00:00+00:00", dark: true }, // night 2026-06-15
+        { time: "2026-06-17T01:00:00+00:00", dark: false }, // night 2026-06-16, twilight
+      ],
+    },
+    {
+      best_hours: [
+        { time: "2026-06-16T04:00:00+00:00", dark: true }, // night 2026-06-15 (dupe)
+      ],
+    },
+  ];
+
+  it("unions upcoming nights from true-dark windows in astronomical mode", () => {
+    // The twilight-only window's night is excluded; the duplicate night folds.
+    expect(starsNights(sites, "astronomical", NOW)).toEqual(["2026-06-15"]);
+  });
+
+  it("includes twilight windows' nights in twilight mode", () => {
+    expect(starsNights(sites, "twilight", NOW)).toEqual([
+      "2026-06-15",
+      "2026-06-16",
+    ]);
+  });
+
+  it("treats hours with no dark flag as dark (older payload)", () => {
+    const legacy = [{ best_hours: [{ time: "2026-06-16T03:00:00+00:00" }] }];
+    expect(starsNights(legacy, "astronomical", NOW)).toEqual(["2026-06-15"]);
+  });
+
+  it("returns an empty list for no sites", () => {
+    expect(starsNights([], "twilight", NOW)).toEqual([]);
+    expect(starsNights(undefined, "twilight", NOW)).toEqual([]);
   });
 });

--- a/projects/monolith/frontend/src/routes/public/app/stars/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/stars/+page.svelte
@@ -2,9 +2,15 @@
   import { onMount } from "svelte";
   import { invalidateAll } from "$app/navigation";
   import StarsMap from "$lib/public/components/stars/StarsMap.svelte";
-  import { monthLabel, monthShort } from "$lib/public/stars/heat.js";
+  import { monthLabel, monthShort, starsNights } from "$lib/public/stars/heat.js";
 
   let { data } = $props();
+
+  // A coarse "current time" signal: it advances the "updated Xm ago" label, the
+  // night-chip set, and StarsMap dropping hours that elapse on a long-open page
+  // (see the tick in onMount). Declared up top so the derivations below can read
+  // it.
+  let nowMs = $state(Date.now());
 
   let sites = $derived(data.snapshot?.sites ?? []);
   let count = $derived(data.snapshot?.count ?? 0);
@@ -35,8 +41,12 @@
   // Night picker (LIVE): "I'm free Saturday, show me the map for Saturday night."
   // One chip per viewing night plus an "All" reset; picking a night filters the
   // map to that night and StarsMap recolours each marker by the score it reaches
-  // then. `nights` is the sorted union of evening dates the API returns.
-  let nights = $derived(data.snapshot?.nights ?? []);
+  // then. `nights` is the sorted union of upcoming evening dates, derived from
+  // the same windows the map colours by (and re-derived as nowMs advances, so a
+  // fully-elapsed night drops its chip). Empty unless we are in live mode.
+  let nights = $derived(
+    mode === "live" ? starsNights(sites, darkness, nowMs) : [],
+  );
   let selectedNight = $state("all"); // "all" or a night key
   let nightOpen = $state(false); // the night box is collapsed until tapped
 
@@ -156,11 +166,6 @@
   let topClearDark = $derived(
     sites.length ? Math.round(sites[0].clear_dark_hours ?? 0) : null,
   );
-
-  // A coarse "current time" signal: it advances the "updated Xm ago" label and
-  // lets StarsMap drop hours that elapse on a long-open page (see the tick in
-  // onMount).
-  let nowMs = $state(Date.now());
 
   // Relative age of the snapshot, mirroring the homepage's formatAgo (a local
   // helper, not a shared export). Parameterized on nowMs so it ticks.

--- a/projects/monolith/stars/router.py
+++ b/projects/monolith/stars/router.py
@@ -38,8 +38,7 @@ been pruned yet is still excluded here.
 from __future__ import annotations
 
 import logging
-from datetime import datetime, timedelta, timezone
-from zoneinfo import ZoneInfo
+from datetime import datetime, timezone
 
 from fastapi import APIRouter, Depends, Query, Request, Response
 from sqlmodel import Session, select
@@ -53,17 +52,13 @@ logger = logging.getLogger("stars")
 
 router = APIRouter(prefix="/api/stars", tags=["stars"])
 
-# Cap each site's displayed hour list, so the payload stays light even with a
-# multi-day forecast horizon. clear_dark_hours still reports the full count.
-_DISPLAY_HOURS = 8
-
-# Dark hours run across midnight, so a viewing "night" is not a calendar day.
-# We label each night by its evening date in UK local time: shifting the local
-# clock back 12 h folds an evening and the following pre-dawn hours into one
-# night key, so the map's night filter groups hours the way a stargazer thinks
-# about them (one outing = one night).
-_LONDON = ZoneInfo("Europe/London")
-_NIGHT_SHIFT = timedelta(hours=12)
+# Cap each site's upcoming-window list. 25 is well above the ~8 the card shows at
+# once: the surplus is headroom so the client can drop already-elapsed hours and
+# still have future windows to list through a night. The map field, the night
+# buckets and the card all derive from this one array client-side, so a coloured
+# cell can never disagree with an empty card. clear_dark_hours /
+# clear_twilight_hours still report the full counts for ranking.
+_DISPLAY_HOURS = 25
 
 # Forecasts refresh hourly, so 30 min edge freshness with a 1 h SWR window is
 # plenty; max-age=0 makes the browser revalidate rather than hold a stale copy.
@@ -102,19 +97,6 @@ def _iso(value: datetime | None) -> str | None:
     """ISO-8601 string in UTC, or None. Keeps the JSON consistent across backends."""
     coerced = _as_utc(value)
     return coerced.isoformat() if coerced is not None else None
-
-
-def _night_key(hour_time: datetime) -> str:
-    """ISO date (YYYY-MM-DD) of the night a dark hour belongs to.
-
-    A night runs from one evening into the next morning, so labelling by the
-    calendar date would split a single outing at midnight. Convert to UK local
-    time and shift back 12 h before taking the date: evening hours keep their
-    own date and pre-dawn hours fold back onto the evening that opened the
-    night. The frontend formats this key into the chip label.
-    """
-    local = _as_utc(hour_time).astimezone(_LONDON)
-    return (local - _NIGHT_SHIFT).date().isoformat()
 
 
 @router.get("/sites")
@@ -190,31 +172,19 @@ def get_sites(
         if any(is_twilight_hour(h.sun_elevation_deg) for h in hours):
             any_twilight_hour = True
 
-        # Per-night counts so the map's night filter can recolour each marker by
-        # how many clear hours the selected night(s) hold. We keep both a
-        # clear-dark and a clear-twilight breakdown so the night filter still
-        # works in twilight mode (when every clear-dark count is zero).
-        night_clear_dark: dict[str, int] = {}
-        for h in clear_hours:
-            key = _night_key(h.hour_time)
-            night_clear_dark[key] = night_clear_dark.get(key, 0) + 1
-        night_clear_twilight: dict[str, int] = {}
-        for h in clear_twilight:
-            key = _night_key(h.hour_time)
-            night_clear_twilight[key] = night_clear_twilight.get(key, 0) + 1
-
-        # Display the upcoming clear windows in chronological order, capped: a
-        # planner reads the night top to bottom. We show the clear-twilight set
-        # (the superset) and tag each hour ``dark`` so the card can label true
-        # dark vs twilight-fallback windows, with the sun elevation alongside.
+        # The site's upcoming clear windows in chronological order, capped at
+        # _DISPLAY_HOURS. This is the clear-twilight superset, each hour tagged
+        # ``dark`` (true nautical dark, sun < -12) vs a twilight-only fallback
+        # hour. The live map field, the night-filter buckets and the card list
+        # all derive from this one array on the client, so the marker colour and
+        # the card can never disagree; the cap is the headroom that keeps the
+        # card from emptying mid-night as the earliest hours elapse. Only the
+        # fields the card renders are emitted (time / cloud / dark); the count
+        # headlines above carry the magnitudes.
         best_hours = [
             {
                 "time": _iso(h.hour_time),
                 "cloud_area_fraction": h.cloud_area_fraction,
-                "air_temperature": h.air_temperature,
-                "dew_spread": h.dew_spread,
-                "symbol": h.symbol,
-                "sun_elevation_deg": h.sun_elevation_deg,
                 "dark": is_dark_hour(h.sun_elevation_deg),
             }
             for h in sorted(clear_twilight, key=lambda h: h.hour_time)[:_DISPLAY_HOURS]
@@ -230,8 +200,6 @@ def get_sites(
                 "clear_dark_hours": clear_dark_hours,
                 "clear_twilight_hours": clear_twilight_hours,
                 "best_hours": best_hours,
-                "night_clear_dark": night_clear_dark,
-                "night_clear_twilight": night_clear_twilight,
             }
         )
 
@@ -255,16 +223,6 @@ def get_sites(
     else:
         darkness = "none"
 
-    # Union of nights present across all sites, ascending, so the frontend can
-    # render one stable row of night-filter chips (a site missing a night just
-    # has no qualifying hours for it). In twilight mode the dark per-night maps
-    # are all empty, so key the chips off the twilight breakdown the map colours
-    # by; otherwise this is the unchanged clear-dark night set.
-    night_field = (
-        "night_clear_twilight" if darkness == "twilight" else "night_clear_dark"
-    )
-    nights = sorted({key for s in sites for key in s[night_field]})
-
     # The ETag folds in the current clock hour so the CDN turns over hourly even
     # when fetched_at has not changed: as hours fall past the cutoff the payload
     # shrinks, and the cutoff token forces a revalidation at each hour boundary.
@@ -285,7 +243,6 @@ def get_sites(
         "sites": sites,
         "count": len(sites),
         "total_sites": len(by_id),
-        "nights": nights,
         "darkness": darkness,
         "fetched_at": _iso(max_fetched),
     }

--- a/projects/monolith/stars/router_test.py
+++ b/projects/monolith/stars/router_test.py
@@ -203,7 +203,6 @@ class TestSites:
             "sites": [],
             "count": 0,
             "total_sites": 0,
-            "nights": [],
             "darkness": "none",
             "fetched_at": None,
         }
@@ -221,11 +220,12 @@ class TestSites:
         assert body["count"] == 1
         assert body["total_sites"] == 2
 
-    def test_best_hours_capped_at_eight(self, client, session):
-        # 12 future clear-dark hours; the count reports all 12 but the displayed
-        # list is capped at the earliest 8 by time.
+    def test_best_hours_capped_at_display_limit(self, client, session):
+        # 30 future clear-dark hours; the count reports all 30 but the displayed
+        # list is capped at the earliest 25 by time. The surplus over the ~8 the
+        # card shows is the headroom the client filters down from as hours elapse.
         _seed_site(session, "galloway-forest")
-        session.add_all([_hour("galloway-forest", i + 1) for i in range(12)])
+        session.add_all([_hour("galloway-forest", i + 1) for i in range(30)])
         session.commit()
 
         r = client.get("/api/stars/sites")
@@ -233,11 +233,11 @@ class TestSites:
         body = r.json()
         assert body["count"] == 1
         site = body["sites"][0]
-        assert site["clear_dark_hours"] == 12
+        assert site["clear_dark_hours"] == 30
         best_hours = site["best_hours"]
-        assert len(best_hours) == 8
-        # The earliest 8 hours by time (offsets 1..8).
-        expected = [(CUTOFF + timedelta(hours=i + 1)).isoformat() for i in range(8)]
+        assert len(best_hours) == 25
+        # The earliest 25 hours by time (offsets 1..25).
+        expected = [(CUTOFF + timedelta(hours=i + 1)).isoformat() for i in range(25)]
         assert [h["time"] for h in best_hours] == expected
 
     def test_best_hours_in_chronological_order(self, client, session):
@@ -260,10 +260,12 @@ class TestSites:
             (CUTOFF + timedelta(hours=3)).isoformat(),
         ]
 
-    def test_night_clear_dark_and_nights(self, client, session):
-        # Two nights' worth of clear-dark hours: each site exposes the per-night
-        # clear-dark count (keyed by the evening date), and the response lists
-        # the union of nights ascending for the filter chips.
+    def test_multi_night_hours_all_in_best_hours(self, client, session):
+        # Two nights' worth of clear-dark hours are all carried in best_hours
+        # (within the display cap), so the client can bucket them by night for
+        # the filter chips. The per-night maps and the top-level nights union are
+        # no longer computed server-side (the client derives them from these
+        # windows), so the payload carries neither.
         _seed_site(session, "galloway-forest")
         # Offsets chosen relative to a fixed cutoff so both nights are covered
         # regardless of when the suite runs.
@@ -275,12 +277,13 @@ class TestSites:
         r = client.get("/api/stars/sites")
         assert r.status_code == 200
         body = r.json()
-        night_clear_dark = body["sites"][0]["night_clear_dark"]
-        # The per-night counts sum to the site's total clear-dark hours.
-        assert sum(night_clear_dark.values()) == 3
-        # Top-level nights is the sorted union of the per-site night keys.
-        assert body["nights"] == sorted(set(night_clear_dark))
-        assert body["nights"] == sorted(body["nights"])
+        site = body["sites"][0]
+        assert site["clear_dark_hours"] == 3
+        assert len(site["best_hours"]) == 3
+        # The server no longer emits per-night maps or a nights union.
+        assert "night_clear_dark" not in site
+        assert "night_clear_twilight" not in site
+        assert "nights" not in body
 
     def test_clear_twilight_at_least_clear_dark_and_dark_flag(self, client, session):
         # A clear true-dark hour (sun -18) plus a clear twilight-only hour
@@ -299,11 +302,15 @@ class TestSites:
         assert site["clear_twilight_hours"] == 2
         assert site["clear_twilight_hours"] >= site["clear_dark_hours"]
         # best_hours shows the full clear-twilight superset, sorted by time, each
-        # tagged dark (true at -18, false at -11) with its sun elevation.
+        # tagged dark (true at -18, false at -11).
         flags = {h["time"]: h["dark"] for h in site["best_hours"]}
         assert flags[(CUTOFF + timedelta(hours=1)).isoformat()] is True
         assert flags[(CUTOFF + timedelta(hours=2)).isoformat()] is False
-        assert all("sun_elevation_deg" in h for h in site["best_hours"])
+        # Each window carries only the fields the card renders: time, cloud, dark.
+        assert all(
+            set(h) == {"time", "cloud_area_fraction", "dark"}
+            for h in site["best_hours"]
+        )
 
     def test_darkness_astronomical_when_any_dark_hour(self, client, session):
         # Any upcoming true-dark hour (sun < -12) anywhere puts the page in
@@ -333,8 +340,6 @@ class TestSites:
         site = body["sites"][0]
         assert site["clear_dark_hours"] == 0
         assert site["clear_twilight_hours"] == 2
-        # In twilight mode the night chips key off the twilight breakdown.
-        assert body["nights"] == sorted(set(site["night_clear_twilight"]))
 
     def test_darkness_none_when_no_kept_hours(self, client, session):
         # A site exists but only has past hours -> no kept rows at all -> the


### PR DESCRIPTION
## Problem

On the live `/app/stars` map a cell could show as a colored "has clear windows" site, but clicking it showed "No upcoming clear windows for this site." The grid and the detail card disagreed.

Root cause: the two were computed from different things and re-filtered differently.

- The **cell color** came from a fetch-time count (`clear_twilight_hours` / the per-night maps), which was never re-checked against the wall clock.
- The **card list** re-filtered `best_hours` against the live clock to drop elapsed hours.

So once a site's only near-term window elapsed, the count stayed positive (cell colored) while the card emptied. This was most visible on marginal far-north sites near the solstice, where the sun barely dips to the `-10°` twilight floor for roughly one hour around 01:00 local: that single window passes and the card empties while the snapshot count still shows it. (A viewer in a far-west timezone makes it look like daytime, but it is Scotland's clock that matters.)

## Fix

Make the map field and the card read from **one** elapsed-filtered window array, with enough headroom that the card does not run dry mid-night when windows are available.

- **`stars/router.py`**: raise the `best_hours` cap `8 → 25` (headroom the client filters down from), slim each window to just the fields the card renders (`time` / `cloud_area_fraction` / `dark`, dropping `air_temperature` / `dew_spread` / `symbol` / `sun_elevation_deg`), and drop the server-computed per-night maps + `nights` union (now derived client-side). The slim windows roughly offset the larger cap, so payload stays flat.
- **`StarsMap.svelte`**: the marker/cell count and the card list both derive from `liveWindows()` (`best_hours` minus already-elapsed hours). Markers repaint as the clock ticks so a cell never outlives its windows.
- **`+page.svelte` / `heat.js`**: the night-filter chip union is derived from the same windows (`starsNights`), re-derived as the clock advances so a fully-elapsed night drops its chip.

Result: a colored cell always has card rows, by construction. In astronomical mode only true-dark hours feed the map field; in the midsummer twilight fallback the whole clear-twilight superset does (unchanged behavior). The strict `-12°` dark metric, ranking, and the historical climatology are untouched.

## Tests

- `heat.test.js`: new coverage for `isUpcoming`, `nightKey`, `liveWindows`, `starsNights` (including the timezone-safe instant parsing and the astronomical-vs-twilight night union).
- `router_test.py`: updated the cap test (`8 → 25`), the slim `best_hours` shape, and removed the now-client-side per-night/`nights` assertions.

Note: `.svelte` files are not prettier-formatted in this environment (no svelte plugin available locally); the CI format bot will normalize if needed.

https://claude.ai/code/session_01WZr1VyT9pbksf7a98MADLc

---
_Generated by [Claude Code](https://claude.ai/code/session_01WZr1VyT9pbksf7a98MADLc)_