### PR TITLE
fix(ci): prefix dev chart tag SHA with g for valid SemVer

### DIFF
--- a/bazel/helm/push.sh.tpl
+++ b/bazel/helm/push.sh.tpl
@@ -116,8 +116,12 @@ elif [[ "$CAN_VERSION" == "true" ]]; then
     echo "Chart version unchanged at ${CURRENT_VERSION}"
   fi
 
-  # Re-package chart with semver-compatible pre-release tag for OCI push (PRs use ephemeral tags)
-  DATESTAMP="0.0.0-dev.$(date -u '+%Y%m%d%H%M%S').$(cd "$WORKSPACE" && git rev-parse --short HEAD)"
+  # Re-package chart with semver-compatible pre-release tag for OCI push (PRs use ephemeral tags).
+  # Prefix the short SHA with `g` (git-describe convention) so it is always an
+  # alphanumeric SemVer pre-release identifier. An all-numeric short SHA with a
+  # leading zero (e.g. 00303542) would otherwise be parsed as a numeric identifier,
+  # which SemVer forbids from having leading zeroes, and Helm rejects the version.
+  DATESTAMP="0.0.0-dev.$(date -u '+%Y%m%d%H%M%S').g$(cd "$WORKSPACE" && git rev-parse --short HEAD)"
   WORK_DIR=$(mktemp -d)
   tar -xzf "$CHART_TGZ" -C "$WORK_DIR"
   CHART_NAME=$(ls "$WORK_DIR")


### PR DESCRIPTION
## Problem

The dev chart pre-release tag in `bazel/helm/push.sh.tpl` embeds the short commit SHA:

```sh
DATESTAMP="0.0.0-dev.$(date -u '+%Y%m%d%H%M%S').$(... git rev-parse --short HEAD)"
```

SemVer 2.0.0 forbids leading zeroes in a **numeric** pre-release identifier. When the short SHA happens to be all digits with a leading zero (e.g. `00303542`), the `dev.<timestamp>.00303542` pre-release parses `00303542` as a numeric identifier and Helm rejects the version:

```
Error: validation: chart.metadata.version "0.0.0-dev.20260616030629.00303542" is invalid
```

This failed the **Push images** step for every chart in the run (monolith, agent-platform, cluster-agents, oci-model-cache), since they all share this template. A SHA containing any hex letter (the common case) parses as an alphanumeric identifier, where the leading-zero rule does not apply, which is why this only surfaces on the ~0.2% of SHAs that are all-numeric with a leading zero.

## Fix

Prefix the short SHA with `g` (the `git describe` convention), so the identifier is always alphanumeric and never parsed as a number: `0.0.0-dev.<timestamp>.g00303542` is valid SemVer.

## Context

Surfaced on #2625, whose rebased HEAD happened to land the all-numeric SHA `00303542`. That PR's code was already green on its prior SHA; this is a latent tooling bug, kept as a separate PR to stay scoped.

https://claude.ai/code/session_01JBT6fyxboecSvmJCJpXLZX

---
_Generated by [Claude Code](https://claude.ai/code/session_01JBT6fyxboecSvmJCJpXLZX)_