### PR TITLE
docs(adr): reframe FastMonolith boundary as runtime context

### DIFF
--- a/docs/decisions/services/010-fastmonolith-modular-framework.md
+++ b/docs/decisions/services/010-fastmonolith-modular-framework.md
@@ -9,64 +9,65 @@
 
 ## Problem
 
-The monolith is already a modular monolith by convention: each domain (`hikes`, `ships`, `stars`, `knowledge`, `home`, `chat`, `scheduler`, `agent`) is a package exposing `register(app)` and `on_startup_jobs(session)`, sharing only `shared/` and `app/`, with `app/architecture_test.py` enforcing some of those rules at test time. The conventions work, but they are conventions. Three things nothing structural prevents today:
+The monolith is already a modular monolith by convention: each domain (`hikes`, `ships`, `stars`, `knowledge`, `home`, `chat`, `scheduler`, `agent`) is a package exposing `register(app)` and `on_startup_jobs(session)`, sharing only `shared/` and `app/`, with `app/architecture_test.py` enforcing some of those rules at test time. The conventions work, but they are conventions. Three gaps:
 
-1. **Shared data.** Every domain reads and writes the same Postgres schema with the same credentials. A bug (or a compromise) in one domain can read or corrupt another's rows. The only real confidentiality boundary in the system, the one ADR 004 leans on, is database permissions, and today every domain has the same ones.
-2. **Cross-domain reach.** `chat` imports `knowledge`'s store directly. Nothing stops a domain depending on another's internals.
-3. **Deployment leakage.** [ADR 004](../security/004-public-read-only-service-isolation.md) decided to split the anonymous public surface into a separate read-only artifact, but as written it is a one-off: a second hand-authored entrypoint with a hand-maintained list of "public routers," guarded by a hand-rolled import-check test. ADR 004 itself flags the failure mode:
+1. **Shared data, shared credentials.** Every domain reads and writes the same Postgres schema as the same role. A bug or compromise in one domain can read or corrupt another's rows. Database permissions are the only real confidentiality control in the system (the one ADR 004 leans on), and today every domain has identical ones.
+2. **Cross-domain reach.** `chat` imports `knowledge`'s store directly. Nothing marks where one domain's surface ends and another's begins, so coupling accretes silently.
+3. **One bespoke composition.** [ADR 004](../security/004-public-read-only-service-isolation.md) decided to run a separate read-only public surface alongside the private monolith. Done as a one-off, that means two hand-authored entrypoints with two copies of the composition glue (lifespan, scheduler loop, OTel, MCP mount, DB engine, the `register()` sequence), which drift, and a hand-maintained list of which routers are "public."
 
-   > Shared-code refactor accidentally pulls private modules into the public artifact... add a build/import check (or test) asserting private modules are absent from `main_public`.
-
-That guard rots, and two entrypoints means two copies of the composition glue (lifespan, scheduler loop, OTel, MCP mount, DB engine, the `register()` sequence) that silently drift.
-
-We want each boundary to be a property of the data model, the build graph, and the type system, not of a reviewer remembering a convention; the wiring written once and reused by every deployment; and each domain independently buildable and testable, even though prod runs them composed.
+We want domain isolation to be structural (each domain owns its data, with an explicit interface for the rare cross-domain call), the public/private separation to be enforced by the runtime's actual capabilities rather than by remembering a convention, and the composition wiring written once and reused by both deployments.
 
 ---
 
 ## Decision
 
-Extract a small in-repo framework, **FastMonolith** (`projects/monolith/framework/`), that makes "compose a deployable binary from privilege-typed, data-isolated domain modules" a first-class operation enforced at three layers. ADR 004's public/private split becomes one instance of the general pattern.
+Extract a small in-repo framework, **FastMonolith** (`projects/monolith/framework/`), that composes the monolith into per-tier binaries from data-isolated domain modules. The design rests on two boundaries plus a thin composition layer.
 
-**Layer 1 (load-bearing): per-domain data isolation.** Each domain owns its own Postgres schema (`hikes`, `ships`, `knowledge`, ...). Grants are per role and per tier: a domain's role gets DML on its own schema only; the `public_reader` role (ADR 004) gets `SELECT` on public schemas and public views and nothing else. This is the strongest boundary because it is the only one that stops a process from *reading another domain's rows* regardless of code: Bazel visibility stops accidental imports, but only Postgres grants stop data access. It is therefore **step one** of the work, ahead of any code split. Because per-domain schemas make cross-domain data access impossible by default, the legitimate cross-domain reads that exist today (`chat` -> `knowledge`) must go through a **domain public interface** (`<domain>/api.py`), never another schema or another domain's internals.
+**Boundary 1: per-domain data isolation (the decoupling).** Each domain owns its own Postgres schema (`hikes`, `ships`, `knowledge`, ...). This is primarily a Postgres-side change, and the payoff is much less coupling: a domain can only touch its own tables, so the accidental shared-table dependencies that accrete today become impossible. Existing cross-domain data reads (`chat` -> `knowledge`) become the **exception, not the norm**, done only for convenience (saving a network hop) and only through that domain's published interface, never another schema.
 
-**Layer 2: build-graph boundary.** Each domain becomes its own Bazel `py_library` with two visibility tiers: `:<domain>_api` (a narrow, stable interface, widely visible) and `:<domain>` (internals, restricted to the domain's own targets, its tests, and the binaries). Cross-domain dependencies may only target `:_api`. The two production deployments are two `py_venv_binary` targets with different `deps`: the public binary lists only `tier=PUBLIC` libraries, so private domain code is *physically absent* from the public artifact, not merely unrouted. A `bazel cquery` test asserts the public binary's transitive closure contains no `tier=PRIVATE` library, replacing ADR 004's fragile import-check with a structural one a refactor cannot defeat.
+**Boundary 2: the runtime security context (the public/private separation).** What actually keeps the anonymous public surface safe is not which code is compiled in, it is what the running process can do:
 
-**Layer 3: runtime composition contract.** Each domain exports a `Module`: a frozen dataclass declaring `name`, `tier` (`PUBLIC`/`PRIVATE`), `schema`, its `register(app)` callable, and what it needs from the host (scheduled jobs, secrets, ClickHouse, MCP tool registration). A single `build_app(profile, modules)` function owns the FastAPI app, the combined lifespan, the scheduler loop, OTel, the MCP mount, and the database engine. It is the *only* place that wiring lives. `build_app` validates that every module's tier and required capabilities are permitted by the binary's `Profile` (a `PRIVATE` module in the public profile is a startup error) and binds the engine to the profile's role, so a module cannot open its own connection or reach a schema it was not granted.
+- The **public** runtime is injected with **no secrets or tokens**, and connects to Postgres as a **read-only role granted `SELECT` on public schemas and views only** (the `public_reader` role / read replica from ADR 004).
+- The **private** runtime gets the full secret set and a read-write role.
 
-Two cross-cutting concerns are resolved by the framework owning the shared machinery and composing it per binary, rather than forking it into each domain:
+Because the boundary is the credential set and the database grants, **code crossover between tiers is acceptable**: even if shared or private code is linked into the public binary, it is inert without tokens and cannot read private rows without the grant. We therefore do **not** build a build-graph exclusion test; isolation is a property of the deployment's capabilities, which hold regardless of code presence. The route surface still stays clean because the public binary only composes the public modules, so private routes are never registered (linked code != served routes).
 
-- **Scheduler.** The scheduler stays shared framework code, but the loop is started per binary and scans only the jobs of the modules composed into that binary. The public binary registers no jobs and runs no loop; a single-domain binary runs a loop over just that domain. Job rows are private-tier and isolated, but the loop is *not* duplicated into every domain. This keeps the working SKIP-LOCKED design and avoids re-introducing the duplication the framework exists to remove.
-- **MCP.** The framework owns one MCP server instance. `build_app` aggregates each composed module's optional `register_mcp` onto that single instance and mounts it once. "One MCP server, all tooling" is preserved, and it stays independently deployable because the aggregation is over whatever modules are present. MCP is a private-tier capability; the public binary mounts no MCP surface. A tool that needs another domain calls that domain's `api.py`, not its internals.
+**Composition: a thin `build_app(profile, modules)` shared by both binaries.** Each domain exports a `Module`: a frozen dataclass declaring `name`, `tier` (`PUBLIC`/`PRIVATE`), its owning `schema`, its `register(app)` callable, and what it needs from the host (scheduled jobs, secrets, ClickHouse, MCP). A single `build_app` owns the FastAPI app, the combined lifespan, the scheduler loop, OTel, the MCP mount, and the database engine, the only place that wiring lives. It binds the engine to the profile's role and validates that a module's declared needs (secrets, tier) fit the profile, so a public binary cannot be handed secrets it should not have. There are **two `py_venv_binary` targets** (`main_public`, `main_private`) composing different module sets; per-domain `py_library` targets exist for build/test modularity, not as a security wall.
 
-A domain that legitimately serves both tiers (today only `knowledge`) splits into `<domain>_core` (shared models/logic, no routes) plus `<domain>_public` and `<domain>_private` modules, keeping "module to tier" total.
+**`<domain>/api.py` is the cross-domain contract, designed to become a network API.** The only legal way for one domain to call another is its `api.py`. Every function there must be shaped like a future HTTP endpoint: serializable inputs and outputs (Pydantic models / plain data), no `Session` or ORM objects crossing the boundary. The in-process call today and a network call tomorrow then have identical signatures, so `api.py` is exactly the seam where a domain could later be cut out into its own deployable service. This single contract covers all cross-domain needs: `chat` -> `knowledge`, cross-domain MCP tools, anything.
+
+Two cross-cutting concerns stay shared framework code composed per binary, not forked into each domain:
+
+- **Scheduler.** The SKIP-LOCKED loop stays in `framework/`, but **job rows live per-domain**: each domain owns its scheduler tables in its own schema, and the loop, started once per binary, scans the composed domains' job tables. The public binary registers no jobs and runs no loop. This keeps domains isolated on the Postgres side without duplicating the loop.
+- **MCP.** The framework owns one MCP server instance; `build_app` aggregates each composed module's optional `register_mcp` onto it and mounts it once. "One MCP server, all tooling" is preserved; a standalone domain still exposes one server with just its tools. MCP is private-tier; the public binary mounts none.
+
+A domain that serves both tiers (today only `knowledge`) splits into `<domain>_core` (shared models/logic, no routes) plus `<domain>_public` and `<domain>_private` modules.
 
 | Aspect | Today | Decided (FastMonolith) |
 | ------ | ----- | ---------------------- |
-| Domain data | Shared schema, shared credentials | Per-domain schema, per-tier grants (Layer 1) |
-| Cross-domain access | Direct internal imports (`chat` -> `knowledge`) | Through `<domain>/api.py` only |
-| Module boundary | Convention + partial test | Per-domain `py_library`, split `:_api` / internals visibility |
-| Public/private exclusion | Hand-maintained router list + import-check test | Disjoint binary `deps`; private code absent from public artifact |
-| Privilege model | Implicit (which router got imported) | Explicit `tier` on each `Module`, validated by `build_app` |
-| Composition glue | One bespoke `main.py` (would be duplicated per ADR 004) | One `build_app`, reused by every binary |
-| Scheduler | One global loop over one jobs table | Shared loop composed per binary; jobs isolated, private-tier |
+| Domain data | Shared schema, shared role | Per-domain schema; each domain owns its tables |
+| Public/private separation | Ingress path match + backend filter | Runtime capability: no secrets + read-only public-only grant |
+| Code crossover between tiers | N/A | Acceptable; not relied on for security |
+| Cross-domain access | Direct internal imports | Exception, via `<domain>/api.py` (endpoint-shaped) only |
+| Composition glue | One bespoke `main.py` | One thin `build_app`, reused by both binaries |
+| Binaries | One | `main_public` + `main_private`, different module sets |
+| Scheduler | One global loop over one jobs table | Shared loop composed per binary; per-domain job tables |
 | MCP | Shared instance, import-side-effect registration | Framework-owned instance, `build_app` aggregates per module |
-| Individual deployability | Not possible | Any module set composes a binary (used for isolated CI) |
-| Boundary enforcement | Reviewer + runtime test | DB grants + `bazel cquery` test + `build_app` validation |
+| Individual deployability | Not possible | Any module set composes a binary; `api.py` is the cut point |
 
-This is deliberately *not* a heavyweight framework: no base classes domains inherit from, no DI container, no plugin auto-discovery. A module is plain data plus callables; the framework is a composition function plus Bazel visibility plus a schema-per-domain migration convention. The value is owning the wiring once and making the build graph and the database the enforcement.
+This is deliberately *not* a heavyweight framework: no base classes, no DI container, no plugin auto-discovery. A module is plain data plus callables; the framework is a thin composition function plus a schema-per-domain convention plus the `api.py` contract.
 
 ---
 
 ## Architecture
 
-### Three enforcement layers
+### The two boundaries
 
 ```mermaid
 graph TD
-    A[Layer 1: per-domain Postgres schema + per-tier grants] -->|process cannot read another domain's rows| B[Confidentiality, the load-bearing boundary]
-    C[Layer 2: per-domain py_library, split :_api / internals visibility] -->|cross-domain only via :_api; private libs absent from public binary| D[Code isolation + compile-time exclusion]
-    E[Layer 3: build_app validates tier + binds engine to profile role] -->|PRIVATE module in PUBLIC profile is a startup error| F[Runtime defense in depth]
-    G[bazel cquery test on public dep closure] -->|fails CI if a PRIVATE lib appears| D
+    A[Per-domain Postgres schema] -->|a domain can only touch its own tables| B[Decoupling: cross-domain access is the exception, via api.py]
+    C[Runtime security context per binary] -->|public: no secrets + read-only public-only grant| D[Public/private separation, independent of linked code]
+    E[Thin build_app, two binaries] -->|public composes only public modules| F[Private routes never registered on public]
 ```
 
 ### Composition model
@@ -96,42 +97,42 @@ graph TD
 
 ### Relationship to ADR 004
 
-FastMonolith does not change ADR 004's security model; it is the mechanism that implements it generically.
+FastMonolith implements ADR 004's public/private split as a reusable framework and keeps its decided security controls; it does not modify ADR 004.
 
 | ADR 004 control | FastMonolith expression |
 | --------------- | ----------------------- |
-| Separate composition `main_public.py` | `build_app(PUBLIC_PROFILE, public_modules)` |
-| Private routers absent from the binary | Public binary `deps` exclude `tier=PRIVATE` libraries |
-| "Add a build/import check" guard | `bazel cquery` test on the public binary's transitive deps |
-| `public_reader` role + public views | Per-domain schemas + per-tier grants (Layer 1); `PUBLIC_PROFILE` binds the engine to that role |
-| Read-only, no secrets | Profile declares the allowed secret set; `build_app` rejects modules needing more |
+| Separate public composition | `main_public = build_app(PUBLIC_PROFILE, public_modules)`, sharing one `build_app` with the private binary |
+| `public_reader` role + public views + read replica | `PUBLIC_PROFILE` binds the engine to that role/endpoint; per-domain schemas are what the grants are scoped to |
+| Public surface holds no secrets | `PUBLIC_PROFILE` injects no secrets; `build_app` rejects a module that requires any |
+| NetworkPolicy, SLO rollup job | Unchanged, consumed as decided |
 
-The Postgres read replica, NetworkPolicy, and SLO rollup job remain exactly as ADR 004 decided. FastMonolith generalizes the application and data layers so the split is structural rather than a bespoke second entrypoint.
+The one difference in emphasis: ADR 004 frames artifact separation as the mechanism that "removes the failure mode," and suggested a build/import check to keep private modules out of the public binary. FastMonolith instead treats the **runtime capability set (no secrets + read-only public-only grant) as the load-bearing control**, so it keeps the two-binary split for cleanliness but does not add the build-graph exclusion test, and tolerates code crossover. ADR 004's role, grant, replica, and NetworkPolicy layers all still hold under this framing.
 
 ---
 
 ## Alternatives Considered
 
-- **Keep ADR 004's bespoke `main_public.py` (no framework).** Rejected: duplicates the composition glue, rests the exclusion guarantee on a hand-maintained router list, and gives future domains no reusable path.
-- **Runtime feature flags / `PUBLIC_MODE` on one binary.** Rejected (as ADR 004 did): private code and secrets still ship in the artifact, so isolation becomes a config that can be set wrong.
-- **Code boundaries first, data isolation last.** Rejected: the data grant boundary is the only one that enforces confidentiality, so it leads. Splitting code while every domain still shares one schema and one credential set would ship the appearance of isolation without the substance.
-- **Separate database per domain (not schemas).** Rejected as too heavy: the CNPG cluster already hosts five databases; per-domain *schemas* with per-role grants give the same row/column isolation with far less operational cost. Revisit only if a domain must survive another's database being down.
-- **Scheduler loop forked into each domain.** Rejected: re-introduces the duplicated infra the framework exists to remove. The loop is shared framework code composed per binary; only the job *rows* are isolated.
-- **Per-domain MCP servers aggregated by a gateway.** Rejected for the in-process case: the goal is one MCP server exposing all tooling. The framework aggregates module `register_mcp` onto a single instance; a domain deployed standalone still exposes one server with just its tools.
-- **A heavyweight framework (base class, DI container, auto-discovery).** Rejected: re-couples every domain to the framework, the opposite of the goal, and over-engineered for a homelab.
-- **One production chart per domain.** Rejected as scope: prod runs the composed public and private binaries. Individual deployability is retained as a build/test capability.
+- **One image, `PROFILE` env, deployed twice.** Viable under the runtime-context framing (security would still come from secrets + grants), but two explicit binaries keep the composed surface obvious and were the chosen shape.
+- **Build-graph exclusion test (`bazel cquery` that private code is absent from the public binary).** Rejected as the security control: the boundary is the runtime capability set, not artifact contents. Code crossover is acceptable, so the test would add machinery without being the thing that keeps data safe.
+- **Code boundaries first, data isolation last.** Rejected: per-domain schemas are the decoupling that everything else builds on, so they lead.
+- **Separate database per domain (not schemas).** Rejected as too heavy: the CNPG cluster already hosts several databases; per-domain schemas with per-role grants give the isolation at far less cost.
+- **Scheduler loop forked into each domain.** Rejected: re-introduces the duplicated infra the framework removes. The loop is shared and composed per binary; only the job rows are per-domain.
+- **Per-domain MCP servers behind a gateway.** Rejected for the in-process case: the goal is one server exposing all tooling; `build_app` aggregates module tools onto a single instance.
+- **A heavyweight framework (base class, DI container, auto-discovery).** Rejected: re-couples every domain to the framework, the opposite of the goal.
+- **One production chart per domain.** Rejected as scope: prod runs the two composed binaries. Per-domain deployability is a build/test capability, with `api.py` as the eventual cut point.
 
 ---
 
 ## Security
 
-Builds on the `docs/security.md` baseline and inherits [ADR 004](../security/004-public-read-only-service-isolation.md)'s four-layer model. FastMonolith strengthens the data and build layers:
+Builds on the `docs/security.md` baseline and ADR 004. The load-bearing controls for the public/private boundary are runtime, not build-time:
 
-- **Confidentiality is database-enforced per domain.** Per-domain schemas plus per-tier grants mean a process can only read the schemas its role was granted. The public role sees public schemas and views only; a compromised domain cannot read another's rows even within the private binary.
-- **Compile-time exclusion is structural.** A `bazel cquery` test fails CI if any `tier=PRIVATE` library enters the public binary's closure, converting ADR 004's "remember to keep private modules out" into a build invariant.
-- **Defense in depth at startup.** `build_app` independently validates module tier and required secrets against the profile, and binds the engine to the profile's role, so even a mis-specified `deps` list cannot boot a public binary with private capabilities or broader grants.
-- **Cross-domain access is narrowed.** Only `<domain>/api.py` is cross-domain-visible; internals and schemas are not, so the attack surface between domains is an explicit, reviewable interface.
-- No deviations from `docs/security.md`; this ADR tightens the data, build, and runtime layers for the highest-risk surface.
+- **No secrets in the public runtime.** The public deployment is injected with no tokens or credentials; `build_app` rejects a public-profile module that declares a secret requirement.
+- **Read-only, public-only database grant.** The public runtime connects as a read-only role with `SELECT` on public schemas and views only (ADR 004's `public_reader` on the replica). It cannot write, and cannot read private rows, by database permission.
+- **Per-domain schemas scope the grants.** Because each domain owns a schema, grants are expressed per domain and per tier, making "what can the public role see" auditable.
+- **Code crossover is explicitly tolerated.** Private or shared code linked into the public binary is inert without tokens or grants, so isolation does not depend on proving code absence.
+- **Cross-domain access is an explicit, reviewable interface.** `<domain>/api.py` is the only cross-domain seam, endpoint-shaped and serializable.
+- No deviations from `docs/security.md`.
 
 ---
 
@@ -139,22 +140,20 @@ Builds on the `docs/security.md` baseline and inherits [ADR 004](../security/004
 
 | Risk | Likelihood | Impact | Mitigation |
 | ---- | ---------- | ------ | ---------- |
-| Per-domain schema migration is invasive (moving existing tables) | High | High | Lead with it as step one against the primary, one domain at a time, each verified by CI; tables move by schema rename, not data copy |
-| Cross-domain coupling surfaces late (e.g. undiscovered `chat`/`knowledge` reads) | Medium | Medium | Per-domain grants make every such read fail loudly during step one, forcing each onto `<domain>/api.py` before the code split |
-| `bazel cquery` boundary test is flaky or hard to express | Low | Medium | Tier is a tag on each `py_library`; prototype the query first, fall back to an aspect collecting a `TierInfo` provider |
-| Scheduler composition regresses the working SKIP-LOCKED loop | Medium | High | Keep the loop in `framework/` unchanged; only scope which jobs it scans by composed module. Cover with the existing scheduler tests plus a composition test |
-| `knowledge` `_core` leaks private logic into the public path | Medium | High | `_core` holds models and pure helpers only; per-tier grants remain the database-enforced backstop, so a leak still cannot read private rows as `public_reader` |
-| Framework abstraction ossifies | Low | Medium | Keep `Module` plain data and `build_app` thin; domains keep full control of routers, jobs, and their `api.py` |
+| Per-domain schema migration is invasive (moving existing tables) | High | High | Lead with it as step one, one domain at a time, each verified by CI; tables move by `SET SCHEMA` rename, not data copy |
+| Cross-domain coupling surfaces late | Medium | Medium | Per-domain grants make every cross-domain read fail loudly during step one, forcing each onto an `api.py` function |
+| `api.py` contracts drift from being endpoint-shaped (leak `Session`/ORM objects) | Medium | Medium | Lint/architecture test that `api.py` signatures are serializable; review treats `api.py` as a public API |
+| Code crossover lulls into shipping a secret-dependent path on public | Low | High | `build_app` validates the public profile injects no secrets and the role is read-only; a path needing either fails fast |
+| Scheduler composition regresses the working SKIP-LOCKED loop | Medium | High | Keep the loop in `framework/` unchanged; only scope which per-domain job tables it scans. Cover with existing scheduler tests plus a composition test |
+| `knowledge` `_core` leaks private logic into the public path | Medium | Medium | `_core` holds models and pure helpers only; the read-only public-only grant remains the backstop, so a leak still cannot read private rows |
 
 ---
 
 ## Open Questions
 
-1. **Scheduler jobs table layout.** One framework-owned `scheduler` schema granted private-only (simpler loop), or a jobs table per domain schema (cleanest isolation, loop does a UNION over composed schemas). Lean to the former since scheduling is inherently private-tier.
-2. **Cross-domain MCP tool placement.** A tool spanning domains is registered by one module but calls others via `api.py`. Confirm whether such tools live in the owning domain's module or in a thin composition-level `agent` module that may depend on multiple `:_api` targets.
-3. **Tier as a Bazel tag vs. a provider.** Whether `tier=PUBLIC|PRIVATE` is a `tags` entry keyed on by `cquery`, or a `TierInfo` provider via a thin macro. Decide when prototyping the boundary test.
-4. **`home/observability` tiering.** It serves a public main page (precomputed snapshots per ADR 004) and private detail. Confirm whether it splits like `knowledge` or collapses to a thin `home_public` reading only snapshot tables.
-5. **Schema ownership of shared reference data.** Any table read by several domains (if any exist beyond `knowledge` notes) needs an owning schema and an `api.py`; inventory during step one.
+1. **`home/observability` tiering.** It serves a public main page (precomputed snapshots per ADR 004) and private detail. Confirm whether it splits like `knowledge` or collapses to a thin `home_public` reading only snapshot tables.
+2. **Shared reference data ownership.** Any table read by several domains needs an owning schema and an `api.py`; inventory during step one.
+3. **`api.py` enforcement mechanism.** Whether the "serializable, endpoint-shaped" contract is enforced by an architecture test, a lint, or convention plus review.
 
 ---
 
@@ -162,10 +161,10 @@ Builds on the `docs/security.md` baseline and inherits [ADR 004](../security/004
 
 | Resource | Relevance |
 | -------- | --------- |
-| [ADR 004: Public Read-Only Service Isolation](../security/004-public-read-only-service-isolation.md) | The security model FastMonolith implements generically |
+| [ADR 004: Public Read-Only Service Isolation](../security/004-public-read-only-service-isolation.md) | The public/private security model FastMonolith implements as a framework |
 | [ADR 002: Path-Based Ingress Tiers](../networking/002-path-based-ingress-tiers.md) | Public/private tier and hostname scheme the binaries sit behind |
 | `projects/monolith/app/main.py` | The composition glue `build_app` extracts and replaces |
 | `projects/monolith/app/mcp_app.py` | The single MCP instance `build_app` takes ownership of |
 | `projects/monolith/shared/scheduler.py` | The SKIP-LOCKED scheduler loop composed per binary |
-| `projects/monolith/app/architecture_test.py` | Existing convention enforcement FastMonolith makes structural |
-| [aspect_rules_py `py_library` / `py_venv_binary`](https://github.com/aspect-build/rules_py) | Build-graph mechanism for per-domain libraries and per-binary deps |
+| `projects/monolith/app/architecture_test.py` | Existing convention enforcement FastMonolith extends |
+| [aspect_rules_py `py_library` / `py_venv_binary`](https://github.com/aspect-build/rules_py) | Build-graph mechanism for per-domain libraries and the two binaries |

--- a/docs/plans/2026-06-15-fastmonolith-framework-design.md
+++ b/docs/plans/2026-06-15-fastmonolith-framework-design.md
@@ -1,19 +1,18 @@
 # FastMonolith Framework — Implementation Design
 
-**Date:** 2026-06-15
+**Date:** 2026-06-15 (revised 2026-06-16)
 **ADR:** [services/010-fastmonolith-modular-framework](../decisions/services/010-fastmonolith-modular-framework.md)
 **Builds on:** [security/004-public-read-only-service-isolation](../decisions/security/004-public-read-only-service-isolation.md)
-**Branch:** `claude/monolith-framework-design-3wnz1w`
 
 ---
 
 ## Scope
 
-Extract a small in-repo framework (`projects/monolith/framework/`) that composes deployable FastAPI binaries from privilege-typed, data-isolated domain modules, and use it to ship ADR 004's public/private split as the first consumer. Three enforcement layers, led by data isolation:
+Extract a small in-repo framework (`projects/monolith/framework/`) that composes the monolith into two per-tier binaries from data-isolated domain modules, and use it to ship ADR 004's public/private split. The design rests on two boundaries plus a thin composition layer:
 
-1. **Data** — per-domain Postgres schema, per-tier grants (the load-bearing boundary; step one).
-2. **Build** — per-domain Bazel `py_library` with split `:_api` / internals visibility; disjoint binary `deps`.
-3. **Runtime** — one `build_app(profile, modules)` owning all wiring; composes scheduler and MCP per binary.
+1. **Data isolation**: per-domain Postgres schema (the decoupling; step one).
+2. **Runtime security context**: the public binary runs with no secrets and a read-only public-only DB grant (the public/private boundary). Code crossover between tiers is tolerated, so there is no build-graph exclusion test.
+3. **Composition**: one thin `build_app(profile, modules)` shared by `main_public` and `main_private`; scheduler and MCP composed per binary; `<domain>/api.py` as the endpoint-shaped cross-domain contract.
 
 Out of scope: per-domain production charts, separate databases per domain, any change to ADR 004's replica / NetworkPolicy / rollup decisions (consumed as-is).
 
@@ -21,7 +20,7 @@ Out of scope: per-domain production charts, separate databases per domain, any c
 
 `framework/` is intentionally tiny. Three concepts.
 
-### `Profile` — what a binary is allowed to do
+### `Profile`: what a binary's runtime can do
 
 ```python
 class Tier(enum.Enum):
@@ -34,7 +33,7 @@ class Profile:
     db_endpoint_env: str          # "DATABASE_URL" (private) / "DATABASE_RO_URL" (public)
     db_role: str                  # "monolith_app" / "public_reader"
     db_read_only: bool            # public: True -> engine sets default_transaction_read_only
-    allowed_secrets: frozenset[str]
+    allowed_secrets: frozenset[str]   # public: empty
     clickhouse_enabled: bool
     mcp_enabled: bool
 
@@ -42,7 +41,9 @@ PRIVATE_PROFILE = Profile(Tier.PRIVATE, "DATABASE_URL", "monolith_app", False, A
 PUBLIC_PROFILE  = Profile(Tier.PUBLIC,  "DATABASE_RO_URL", "public_reader", True, frozenset(), False, False)
 ```
 
-### `Module` — what a domain provides
+The profile is the runtime boundary: `PUBLIC_PROFILE` carries no secrets and a read-only role. The deployment reinforces it (the public pod simply does not mount the secret env / OnePasswordItems), so even linked private code has nothing to use.
+
+### `Module`: what a domain provides
 
 ```python
 @dataclasses.dataclass(frozen=True)
@@ -57,15 +58,15 @@ class Module:
     requires_clickhouse: bool = False
 ```
 
-Each domain exports `MODULE = Module(...)`, reusing its existing `register` / `on_startup_jobs` as the callables, so the wrapper is thin. Cross-domain logic is reached only through `<domain>/api.py`.
+Each domain exports `MODULE = Module(...)`, reusing its existing `register` / `on_startup_jobs`, so the wrapper is thin. Cross-domain logic is reached only through `<domain>/api.py`.
 
-### `build_app(profile, modules)` — the one composition root
+### `build_app(profile, modules)`: the one composition root
 
 Owns everything `app/main.py` does today, once:
 
 ```python
 def build_app(profile: Profile, modules: Sequence[Module]) -> FastAPI:
-    _validate(profile, modules)               # tier, secrets, capability checks (raises on mismatch)
+    _validate(profile, modules)               # secrets/capability checks (raises on mismatch)
     engine = _make_engine(profile)            # endpoint + role + read_only from the profile
     mcp = _new_mcp() if profile.mcp_enabled else None
     lifespan = _build_lifespan(profile, modules, engine, mcp)   # scheduler loop (composed), jobs, bot, ingest
@@ -82,9 +83,9 @@ def build_app(profile: Profile, modules: Sequence[Module]) -> FastAPI:
     return app
 ```
 
-`_validate` raises if a module's `tier` is incompatible with the profile, if `requires_secrets` is not a subset of `profile.allowed_secrets`, or if a module needs ClickHouse/MCP the profile disables. The scheduler loop started in `_build_lifespan` scans only the jobs registered by the composed modules; the public binary registers none and runs no loop.
+`_validate` raises if `requires_secrets` is not a subset of `profile.allowed_secrets`, or if a module needs ClickHouse/MCP the profile disables, so a public binary fails fast rather than silently shipping a path that needs a secret it does not have. The scheduler loop in `_build_lifespan` scans only the job tables of the composed modules; the public binary registers none and runs no loop.
 
-The entrypoints become trivial and duplication-free:
+The entrypoints are trivial and duplication-free:
 
 ```python
 # app/main_private.py
@@ -93,67 +94,79 @@ app = build_app(PRIVATE_PROFILE, ALL_MODULES)
 app = build_app(PUBLIC_PROFILE, PUBLIC_MODULES)
 ```
 
-## Data isolation (Layer 1, step one)
+`PUBLIC_MODULES` composes only public modules, so private routes are never registered on the public binary even though shared/private code may be transitively linked.
 
-The substantive, load-bearing work. Each domain gets a Postgres schema and per-tier grants, landed against the primary before any code split.
+## Boundary 1: data isolation (step one)
 
-- **Schemas:** `hikes`, `ships`, `stars`, `knowledge`, `home`, `chat`, `scheduler`. Existing tables move into their owning schema by `ALTER TABLE ... SET SCHEMA` (rename, not data copy), in Atlas migrations on the primary.
-- **Grants:** `monolith_app` gets DML on all private + public schemas. `public_reader` (ADR 004) gets `SELECT` only on `hikes`, `ships`, `stars`, the `home` snapshot tables, and the `knowledge_public` view. No other grants; default-deny via `REVOKE ALL` then explicit grants.
-- **Cross-domain reads become loud failures.** Once `knowledge` tables are out of the default schema, `chat`'s direct store access fails until it goes through `knowledge/api.py`. That is the point: the grant boundary surfaces every cross-domain coupling during step one.
-- **Scheduler jobs** live in the `scheduler` schema, granted to `monolith_app` only (never `public_reader`). Open question 1 in the ADR: one shared jobs table vs. per-domain job tables; default is the shared `scheduler` schema for a simpler loop.
+The substantive, decoupling work. Each domain gets a Postgres schema and per-tier grants, landed against the primary before any code split.
 
-This step delivers real isolation inside the existing single binary, independent of the public/private split.
+- **Schemas:** `hikes`, `ships`, `stars`, `knowledge`, `home`, `chat`. Existing tables move into their owning schema by `ALTER TABLE ... SET SCHEMA` (rename, not data copy), in Atlas migrations on the primary.
+- **Per-domain scheduler tables:** each domain that schedules work owns its `*_jobs` table in its own schema (not one global jobs table). The shared loop scans the composed domains' job tables.
+- **Grants:** `monolith_app` gets DML on all schemas. `public_reader` (ADR 004) gets `SELECT` only on `hikes`, `ships`, `stars`, the `home` snapshot tables, and the `knowledge_public` view. Default-deny via `REVOKE ALL` then explicit grants. No scheduler tables for `public_reader`.
+- **Cross-domain reads become loud failures.** Once `knowledge` tables leave the default schema, `chat`'s direct store access fails until it goes through `knowledge/api.py`. That is the point: the grant boundary surfaces every cross-domain coupling here, at step one.
 
-## Bazel layout (Layer 2)
+This delivers real isolation inside the existing single binary, independent of the public/private split.
+
+## Boundary 2: runtime security context
+
+The public/private separation lives in the deployment, not the build:
+
+- The public Deployment injects **no secrets** (no `DISCORD_BOT_TOKEN`, `GITHUB_TOKEN`, `CLICKHOUSE_*`, `VAULT_*`, etc.) and points `DATABASE_RO_URL` at `monolith-pg-ro` as `public_reader`.
+- `PUBLIC_PROFILE` makes the engine read-only and `allowed_secrets` empty, so any module needing a secret fails `build_app` validation.
+- Therefore code crossover is safe: shared or private code linked into the public binary is inert without tokens and cannot read private rows without the grant. **No `cquery` exclusion test is built**: artifact contents are not the boundary.
+
+## `<domain>/api.py`: the cross-domain contract
+
+The only legal cross-domain seam, designed to become a network API:
+
+- Inputs and outputs are serializable (Pydantic models / plain data); no `Session` or ORM objects cross the boundary.
+- Signatures are identical whether called in-process (today, for convenience / saving a hop) or over HTTP (after a future domain extraction), so `api.py` is the cut point for making a domain its own service.
+- Covers every cross-domain need: `chat` -> `knowledge`, cross-domain MCP tools, etc. Cross-domain access is the exception, not the norm.
+
+## Bazel layout
+
+Per-domain `py_library` targets for build/test modularity (not a security wall):
 
 ```
 projects/monolith/
   framework/BUILD            # py_library "framework" (Profile, Module, build_app), wide visibility
-  hikes/BUILD                # "hikes_api" (wide vis); "hikes" internals (restricted), tags=["tier=public"]
-  ships/BUILD                # "ships_api"; "ships" tags=["tier=public"]
-  stars/BUILD                # "stars_api"; "stars" tags=["tier=public"]
-  knowledge/BUILD            # "knowledge_core"; "knowledge_api"; "knowledge_public" (public); "knowledge_private" (private)
-  home/BUILD                 # "home_public" (public); "home_private" (private)
-  chat/BUILD                 # "chat_api"; "chat" tags=["tier=private"]  (deps may include //...:knowledge_api)
-  scheduler/BUILD            # "scheduler" tags=["tier=private"]
-  agent/BUILD                # "agent" tags=["tier=private"]
+  hikes/BUILD                # "hikes_api" (wide vis); "hikes" internals
+  ships/BUILD ; stars/BUILD  # same shape
+  knowledge/BUILD            # "knowledge_core"; "knowledge_api"; "knowledge_public"; "knowledge_private"
+  home/BUILD                 # "home_public"; "home_private"
+  chat/BUILD                 # "chat_api"; "chat"  (deps may include //...:knowledge_api)
+  scheduler/BUILD ; agent/BUILD
   app/BUILD                  # py_venv_binary "main_private" (deps = all); "main_public" (deps = public only)
 ```
 
-Each domain's internals `py_library` restricts `visibility` to its own targets, its tests, and `//projects/monolith/app:*`; the `:_api` target is widely visible. Cross-domain deps may only reference `:_api`. `framework` and `shared` keep broad visibility.
-
-### Boundary test
-
-A `py_test`/`sh_test` runs `bazel cquery 'deps(//projects/monolith/app:main_public)'` and asserts no dep carries `tier=private`. Prototype the `tags` + cquery approach first; fall back to a `TierInfo` provider aspect if tags prove brittle (ADR open question 3).
+Cross-domain deps reference only `:_api`. Visibility keeps coupling honest (a domain's internals are not widely visible), but it is hygiene, not the security control, so it is not backed by a build-graph exclusion test.
 
 ## Testing both routes
 
 - **Per-domain** (existing `py_test` per domain): unchanged, now against the isolated `py_library`.
 - **`main_private_test.py`**: full route surface present; engine read-write.
-- **`main_public_test.py`**: only public route prefixes; representative private routes 404; `app.state.engine` read-only; no `/mcp` mount; `build_app(PUBLIC_PROFILE, [a_private_module])` raises.
-- **Boundary `cquery` test**: private libraries absent from the public binary's closure.
-- **Data grant test**: as `public_reader`, asserting a private table/row is not selectable (ADR 004's mandated test, now per-schema).
-- **`architecture_test.py`** extended: every domain exports a `MODULE` with a valid `Tier` and `schema`; cross-domain imports target only `:_api`; existing prefix checks retained.
+- **`main_public_test.py`**: only public route prefixes; representative private routes 404; `app.state.engine` read-only; no `/mcp` mount; `build_app(PUBLIC_PROFILE, [module_requiring_a_secret])` raises.
+- **Data grant test**: as `public_reader`, assert a private table/row is not selectable and writes are rejected (ADR 004's mandated test, now per-schema). This is the test that proves the boundary.
+- **`architecture_test.py`** extended: every domain exports a `MODULE` with a valid `Tier` and `schema`; cross-domain imports target only `:_api`; `api.py` signatures are serializable; existing prefix checks retained.
 
 ## Migration sequence
 
 Each step is independently shippable and CI-verified; the single private binary keeps working until the last step.
 
-1. **Per-domain schemas + grants (Layer 1).** Atlas migrations moving each domain's tables into its schema, per-tier grants, `public_reader` scoped to public schemas/views. Repoint each domain's queries to its schema. Resolve every cross-domain read onto a temporary `api.py`. Ship inside the existing binary; this is the load-bearing change.
+1. **Per-domain schemas + grants + per-domain scheduler tables (Boundary 1).** Atlas migrations moving each domain's tables into its schema, per-tier grants, `public_reader` scoped to public schemas/views. Repoint queries. Resolve every cross-domain read onto an `api.py` function. Ship inside the existing binary; this is the load-bearing change.
 2. **Introduce the framework, behavior-preserving.** Add `framework/` (`Profile`, `Module`, `build_app`). Rewrite `app/main.py` as `build_app(PRIVATE_PROFILE, ALL_MODULES)`. One binary still; verify the rendered app, scheduler, and MCP surface are identical.
-3. **Formalize `<domain>/api.py` + module objects.** Each domain exports `MODULE` and a stable `api.py`; extend `architecture_test.py`.
-4. **Split per-domain `py_library` targets (Layer 2)** with tier tags and split `:_api` / internals visibility. Bulk of the `BUILD` churn; domain by domain.
+3. **Formalize `<domain>/api.py` + module objects.** Each domain exports `MODULE` and a stable, serializable `api.py`; extend `architecture_test.py`.
+4. **Split per-domain `py_library` targets** with `:_api` / internals visibility. Domain by domain.
 5. **Split `knowledge`** into `knowledge_core` + `knowledge_public` + `knowledge_private`; resolve `home` into `home_public` / `home_private`.
-6. **Add `main_public`.** New entrypoint, `py_venv_binary`, apko image, public SvelteKit dist. Add the `cquery` boundary test and `main_public_test`.
-7. **Wire the public deployment (ADR 004 deliverables).** Point `PUBLIC_PROFILE` at `monolith-pg-ro` as `public_reader`; default-deny NetworkPolicy egress; SLO rollup job feeding `home_public`. Second Deployment in the chart for the public binary (one chart, two binaries).
-8. **Cleanup.** Rename `app/main.py` -> `app/main_private.py` if desired; document the module + `api.py` pattern for new domains in `docs/services.md` / `docs/contributing.md`.
+6. **Add `main_public`.** New entrypoint, `py_venv_binary`, apko image, public SvelteKit dist. Add `main_public_test`.
+7. **Wire the public deployment (ADR 004 deliverables).** Public Deployment with no secrets; `PUBLIC_PROFILE` at `monolith-pg-ro` as `public_reader`; default-deny NetworkPolicy egress; SLO rollup job feeding `home_public`. Second Deployment in the chart (one chart, two binaries).
+8. **Cleanup.** Rename `app/main.py` -> `app/main_private.py` if desired; document the module + `api.py` pattern in `docs/services.md` / `docs/contributing.md`.
 
 ## Open questions (carried from the ADR)
 
-1. Scheduler jobs: one shared `scheduler` schema vs. per-domain job tables.
-2. Cross-domain MCP tool placement: owning module vs. a thin composition-level `agent` module depending on multiple `:_api` targets.
-3. Tier as Bazel `tags` + cquery vs. a `TierInfo` provider aspect.
-4. `home/observability` split shape.
+1. `home/observability` split shape (full `_core`/`_public`/`_private` vs. a thin `home_public` reading only snapshot tables).
+2. Shared reference-data ownership: any table read by several domains needs an owning schema and an `api.py`; inventory during step one.
+3. `api.py` enforcement: architecture test vs. lint vs. convention plus review.
 
 ## References
 


### PR DESCRIPTION
## What

Follow-up to #2614 (merged). Revises the FastMonolith ADR + design doc to reflect the agreed reframe from discussion.

## The reframe

The previous draft made the **build-graph (code exclusion)** the headline security control. We agreed the actual boundary is the **runtime capability set**, so:

- **Public/private separation = runtime context**, not artifact contents: the public binary is injected with **no secrets** and connects as a **read-only role granted `SELECT` on public schemas/views only**. Because that is the boundary, **code crossover between tiers is tolerated** and the `bazel cquery` exclusion test is **dropped**.
- **Per-domain Postgres schemas** are the decoupling (the Postgres-side change that gets us "less coupling"). Cross-domain access is the **exception, for convenience**, only via a domain interface.
- **`<domain>/api.py` is the cross-domain contract, shaped to become a network API** (serializable in/out, no `Session`/ORM objects), so it is also the future service-extraction seam.
- **Per-domain scheduler tables** (reversing the earlier shared-schema default); the SKIP-LOCKED loop stays shared framework code composed per binary.
- **Two binaries** (`main_public` / `main_private`) retained for cleanliness; per-domain `py_library` targets are for modularity, not a security wall.
- **ADR 004 left unchanged**; ADR 010 notes only the difference in emphasis (runtime controls load-bearing vs. artifact separation).

## Status

ADR remains **Draft**. Docs only, no code. Per your call, auto-merge will be enabled so this lands once CI is green.

https://claude.ai/code/session_01UayEhC4xpJcQWAKaqwSAGL

---
_Generated by [Claude Code](https://claude.ai/code/session_01UayEhC4xpJcQWAKaqwSAGL)_