### PR TITLE
feat(routines): daily-digest skill + scheduled routine

### DIFF
--- a/.claude/skills/daily-digest/SKILL.md
+++ b/.claude/skills/daily-digest/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: daily-digest
+description: >
+  Produce a prioritised digest of outstanding work, things you started but
+  have not finished, by scanning open ADRs, plans, and pull requests, then
+  post it to Discord. Use when the user asks "what should I follow through
+  on", "what's outstanding", "daily digest", or when the daily-digest
+  routine fires.
+---
+
+# Daily Digest: what to follow through on
+
+Scans three sources of in-flight work, ranks them by how close they are to
+"done but dropped", and posts a single Discord message. The framing is
+**follow-through**: surface the things Joe started and has not finished, not
+a generic backlog of everything that could ever be done.
+
+Run interactively with `/daily-digest`, or let the
+`projects/monolith/claude_routines/daily-digest.yaml` routine fire it on a
+schedule.
+
+## Sources
+
+| Source    | Where                                     | Signal of "outstanding"                                              |
+| --------- | ----------------------------------------- | ------------------------------------------------------------------- |
+| **PRs**   | `gh pr list` (authored by Joe + review)   | open PRs that need an action from Joe to move forward                |
+| **Plans** | `docs/plans/*.md`                          | unchecked `- [ ]` tasks remaining in an implementation plan          |
+| **ADRs**  | `docs/decisions/<category>/*.md`           | `**Status:** Draft` (a decision still owed)                          |
+
+This skill is read-only. It never edits ADRs/plans, never pushes, never
+touches PRs. Its only side effect is one Discord message.
+
+## Workflow
+
+### 1. Gather pull requests
+
+```bash
+# PRs Joe opened that are still open
+gh pr list --author "@me" --state open \
+  --json number,title,url,isDraft,reviewDecision,mergeable,statusCheckRollup,updatedAt
+
+# PRs waiting on Joe's review
+gh pr list --search "review-requested:@me state:open" \
+  --json number,title,url,updatedAt
+```
+
+If `gh` is not authenticated or returns an error, do not fail the whole
+digest: skip the PR section, note "PRs unavailable" once, and continue with
+plans and ADRs.
+
+### 2. Gather plans with remaining work
+
+Scan `docs/plans/*.md` for files that still contain unchecked checkboxes
+(`- [ ]`). For each, capture the plan title (first `#` heading), the count of
+remaining vs total tasks, and the file's date prefix. Newer plans with many
+unchecked tasks rank higher; a plan that is almost entirely checked is nearly
+done and ranks lower.
+
+Plans with **no** checkboxes carry no completion signal: skip them rather than
+guess. If a plan looks stale (old date, but unchecked), a quick
+`git log -1 --format=%cr -- <plan>` tells you how recently it was touched, use
+that to decide whether it is genuinely live.
+
+### 3. Gather draft ADRs
+
+Find ADRs whose header line reads `**Status:** Draft`:
+
+```bash
+grep -rl "^\*\*Status:\*\* Draft" docs/decisions/
+```
+
+A Draft ADR is a decision Joe still owes, distinct from implementation work.
+
+### 4. Rank
+
+Sort into priority tiers. The tier, not a numeric score, is what gets
+surfaced, so keep the buckets sharp:
+
+| Tier              | What lands here                                                                                  |
+| ----------------- | ----------------------------------------------------------------------------------------------- |
+| **P0 - finish**   | Open PR that is approved + mergeable but unmerged, OR failing CI, OR has review comments awaiting a reply. Almost done, one step from shipping. |
+| **P1 - in flight**| Plan with several unchecked tasks (an initiative actively underway); your own draft PRs.         |
+| **P2 - decide**   | Draft ADRs; plans whose only remainder is open questions.                                        |
+| **P3 - review**   | PRs requesting Joe's review.                                                                     |
+
+Within a tier, sort by most-recently-updated first. Cap the whole digest at
+~12 items; if more remain, append a `+N more` line per truncated tier.
+
+### 5. Post to Discord
+
+Call `mcp__homelab__monolith-monolith-agent-notify` **once** with a markdown
+message. Keep it under Discord's 2000-character limit. Shape:
+
+```
+**Daily digest, follow-through, <YYYY-MM-DD>**
+
+**P0 finish**
+- #123 Fix trace sampling, CI red on //projects/signoz, <url>
+- #119 Auth health check, approved + mergeable, just needs merge, <url>
+
+**P1 in flight**
+- Hikes into monolith, 4/11 tasks left, docs/plans/2026-06-13-hikes-into-monolith.md
+- #130 (draft) Per-PR preview envs, <url>
+
+**P2 decide**
+- ADR draft: NATS canonical event stream, docs/decisions/agents/016-...md
+
+**P3 review**
+- #131 Bump rules_apko, review requested, <url>
+```
+
+Set `level`:
+- `warn` if anything in P0 has been red/blocked for more than a couple of days,
+- otherwise `info`.
+
+If every source comes back empty (no open PRs, no plans with remaining tasks,
+no draft ADRs), post a single one-line `info`: "Daily digest: nothing
+outstanding, all clear." Do not stay silent, the absence of work is itself
+useful signal for a daily cadence.
+
+## Constraints
+
+- Read-only. No edits, commits, pushes, or PR mutations.
+- One Discord message per run. Never spam multiple notifies.
+- Prefer `gh` and local file reads; this skill needs no cluster access.
+- If a data source errors, degrade gracefully and report the rest, do not
+  abort the digest.

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.141.0
+version: 0.142.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/claude_routines/daily-digest.yaml
+++ b/projects/monolith/claude_routines/daily-digest.yaml
@@ -1,0 +1,45 @@
+# yaml-language-server: $schema=./schema.json
+name: Daily Digest (follow-through)
+schedule:
+  cron: "0 7 * * *"
+enabled: true
+model: claude-sonnet-4-6
+environment: Default
+sources:
+  - https://github.com/jomcgi/homelab
+allowed_tools: []
+mcp_connectors:
+  - homelab
+prompt: |
+  Produce a prioritised daily digest of outstanding work and post it to
+  Discord. The framing is follow-through: what has Joe started but not
+  finished, what should he carry through. Read-only: never edit files,
+  commit, push, or mutate any PR.
+
+  Follow the `daily-digest` skill in this repo
+  (.claude/skills/daily-digest/SKILL.md) for the full method. In brief:
+
+  1. PRs: `gh pr list --author "@me" --state open` plus PRs with
+     `review-requested:@me`. If `gh` errors, skip PRs and note it once.
+  2. Plans: scan `docs/plans/*.md` for files with remaining `- [ ]` tasks.
+  3. ADRs: `grep -rl "^\*\*Status:\*\* Draft" docs/decisions/`.
+
+  Rank into tiers, P0 finish (PR approved+mergeable, or CI red, or a review
+  reply owed), P1 in flight (plans with unchecked tasks, your draft PRs),
+  P2 decide (Draft ADRs), P3 review (PRs requesting your review). Within a
+  tier sort by most-recently-updated. Cap at ~12 items with "+N more" per
+  truncated tier.
+
+  Post once with `mcp__homelab__monolith-monolith-agent-notify`:
+    - message: the ranked markdown digest, under 2000 characters, headed
+      "Daily digest, follow-through, <YYYY-MM-DD>".
+    - level: "warn" if any P0 item has been red or blocked for more than a
+      couple of days, else "info".
+
+  If every source is empty, post one info line: "Daily digest: nothing
+  outstanding, all clear." Do not stay silent on an empty result.
+
+  Constraints:
+    - Read-only. No edits, commits, pushes, or PR mutations.
+    - Exactly one Discord notify per run.
+    - If one source errors, report the rest, do not abort the digest.

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.141.0
+      targetRevision: 0.142.0
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
## What

Adds a **daily digest** that surfaces a prioritised list of outstanding work, the things you started but have not finished, and posts it to Discord.

Two pieces, matching the request for "a schedule & skill":

1. **Skill** `.claude/skills/daily-digest/SKILL.md` — the methodology. Scans three sources and ranks them by follow-through priority:
   - **PRs** (`gh pr list`): your open PRs + PRs requesting your review
   - **Plans** (`docs/plans/*.md`): files with remaining `- [ ]` tasks
   - **ADRs** (`docs/decisions/`): `Status: Draft` (a decision still owed)
2. **Routine** `projects/monolith/claude_routines/daily-digest.yaml` — a claude.ai scheduled agent that fires the skill **daily at 07:00 UTC** and posts via `monolith-agent-notify`.

## Prioritisation

| Tier | Lands here |
| ---- | ---------- |
| P0 finish | PR approved + mergeable but unmerged, or CI red, or a review reply owed |
| P1 in flight | plans with unchecked tasks, your draft PRs |
| P2 decide | Draft ADRs |
| P3 review | PRs requesting your review |

Read-only throughout: the only side effect is one Discord message per run. Degrades gracefully if `gh` is unavailable (skips PRs, still reports plans + ADRs). On an empty result it posts "nothing outstanding, all clear" rather than going silent.

## Activate

The routine YAML is intent state. After merge, run `/update-claude-routines` to sync it to claude.ai.

## Defaults worth a look
- **Schedule:** 07:00 UTC daily, change the `cron` in the YAML if you want a different time.
- **Model:** `claude-sonnet-4-6` (prioritisation needs more judgement than the haiku backlog-audit routine).

https://claude.ai/code/session_01Fr6NAUwcG6pCDwRhCxkRoo

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fr6NAUwcG6pCDwRhCxkRoo)_