### PR TITLE
chore(routines): run daily digest at 05:00 PDT

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.142.0
+version: 0.142.1
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/claude_routines/daily-digest.yaml
+++ b/projects/monolith/claude_routines/daily-digest.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=./schema.json
 name: Daily Digest (follow-through)
 schedule:
-  cron: "0 7 * * *"
+  cron: "0 12 * * *" # 05:00 PDT (UTC-7); cron is UTC-only, so this is 04:00 once PST returns
 enabled: true
 model: claude-sonnet-4-6
 environment: Default

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.142.0
+      targetRevision: 0.142.1
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
Updates the `Daily Digest (follow-through)` routine to fire at **05:00 PDT** instead of 07:00 UTC.

`cron: "0 7 * * *"` → `cron: "0 12 * * *"`

PDT is UTC-7, so 05:00 PDT = 12:00 UTC.

## DST caveat

The routine `cron` field is UTC-only (no timezone support), so this is pinned to 12:00 UTC year-round. When the clocks fall back to PST (UTC-8) in November, 12:00 UTC becomes 04:00 local. Flagged inline in the YAML; bump the hour to `0 13 * * *` if you want it back at 05:00 during PST.

## Activation

After merge, sync to claude.ai from an interactive claude.ai Code session:

```
/update-claude-routines daily-digest
```

https://claude.ai/code/session_01Fr6NAUwcG6pCDwRhCxkRoo

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fr6NAUwcG6pCDwRhCxkRoo)_