### PR TITLE
feat(monolith): knowledge MCP tools for the remote-routine gardener (4c-1)

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.142.1
+version: 0.142.2
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.142.1
+      targetRevision: 0.142.2
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/knowledge/mcp.py
+++ b/projects/monolith/knowledge/mcp.py
@@ -14,7 +14,7 @@ import os
 from pathlib import Path
 
 import yaml
-from sqlmodel import Session
+from sqlmodel import Session, select
 
 from app.db import get_engine
 from app.mcp_app import mcp
@@ -23,8 +23,9 @@ from knowledge import notes as notes_module
 from knowledge.gaps import answer_gap as _answer_gap
 from knowledge.gaps import approve_gap as _approve_gap
 from knowledge.gaps import list_review_queue, split_csv
-from knowledge.gardener import _slugify
-from knowledge.indexing import index_note_best_effort
+from knowledge.gardener import GARDENER_VERSION, _slugify
+from knowledge.indexing import index_note_best_effort, index_note_from_raw
+from knowledge.models import AtomRawProvenance, RawInput
 from knowledge.notes import resolve_note_body
 from knowledge.service import DEFAULT_VAULT_ROOT, VAULT_ROOT_ENV
 from knowledge.store import KnowledgeStore
@@ -472,3 +473,262 @@ async def approve_research_gap(gap_id: int) -> dict:
             return _approve_gap(session, gap_id, vault_root)
         except ValueError as exc:
             return {"error": str(exc)}
+
+
+# ---------------------------------------------------------------------------
+# Gardener decomposition tools (ADR 006 Phase 4c)
+#
+# The gardener is moving from an in-pod subprocess to a remote claude.ai
+# routine that drives decomposition over these MCP tools. New atoms are
+# FILELESS: written to Postgres only (no _processed file), because the
+# reconciler permanently defers without an Obsidian sidecar.
+# ---------------------------------------------------------------------------
+
+_ATOM_TYPES = frozenset({"atom", "fact", "active"})
+_VISIBILITIES = frozenset({"public", "private"})
+_ACTIVE_STATUSES = frozenset({"active", "someday", "blocked"})
+_ACTIVE_SIZES = frozenset({"small", "medium", "large", "unknown"})
+
+
+@mcp.tool
+async def list_raws_needing_decomposition(limit: int = 10) -> dict:
+    """List raw inputs the gardener still needs to decompose, fresh first.
+
+    Mirrors the in-pod gardener work queue: tier 1 is fresh raws with no
+    current-version provenance, tier 2 is retriable failed raws under the
+    retry ceiling. Use ``get_raw`` to read a raw body, then ``create_atom``
+    to emit atoms and ``record_provenance`` to close out raws that yield no
+    new notes or that fail.
+
+    Args:
+        limit: Maximum raws to return (default 10, clamped to 1 through 50).
+    """
+    limit = max(1, min(limit, 50))
+    with Session(get_engine()) as session:
+        raws = KnowledgeStore(session).raws_needing_decomposition(limit)
+        out = []
+        for raw in raws:
+            meta, _ = frontmatter.parse(raw.content)
+            title = meta.title or (raw.content.strip()[:60] or raw.raw_id)
+            out.append(
+                {
+                    "raw_id": raw.raw_id,
+                    "title": title,
+                    "source": raw.source,
+                    "created_at": raw.created_at,
+                }
+            )
+    return {"raws": out}
+
+
+@mcp.tool
+async def get_raw(raw_id: str) -> dict:
+    """Read a raw input markdown content by its ``raw_id``.
+
+    Returns the body the gardener should decompose into atoms. Reads
+    Postgres ``knowledge.raw_inputs.content`` for now, an S3 read replaces
+    this in ADR 006 Phase 4d.
+
+    Args:
+        raw_id: The stable raw input identifier.
+    """
+    with Session(get_engine()) as session:
+        row = session.exec(select(RawInput).where(RawInput.raw_id == raw_id)).first()
+        if row is None:
+            return {"error": f"raw not found: {raw_id}"}
+        return {"raw_id": row.raw_id, "content": row.content, "source": row.source}
+
+
+@mcp.tool
+async def create_atom(
+    title: str,
+    body: str,
+    type: str,
+    visibility: str,
+    tags: list[str] | None = None,
+    aliases: list[str] | None = None,
+    edges: dict[str, list[str]] | None = None,
+    derived_from_raw: str | None = None,
+    status: str | None = None,
+    size: str | None = None,
+    due: str | None = None,
+    blocked_by: list[str] | None = None,
+) -> dict:
+    """Create a new knowledge atom, fileless, indexed straight into Postgres.
+
+    Validates the atom schema, slugifies the title into a stable ``note_id``
+    (resolving DB collisions with a numeric suffix), serializes frontmatter,
+    and indexes the note synchronously. When ``derived_from_raw`` resolves
+    to a raw input, an ``AtomRawProvenance`` row links the atom to its raw.
+
+    Validation failures return an error message and write nothing.
+
+    Args:
+        title: Human-readable note title (required).
+        body: Markdown body of the atom (required).
+        type: One of atom, fact, or active.
+        visibility: One of public or private.
+        tags: Optional list of tags.
+        aliases: Optional list of aliases.
+        edges: Optional typed edges, e.g. a derives_from list of note ids.
+        derived_from_raw: Optional raw_id to record provenance against.
+        status: Required for type active. One of active, someday, blocked.
+        size: Required for type active. One of small, medium, large, unknown.
+        due: Optional ISO due date (active notes only).
+        blocked_by: Optional list of blocking note_ids (active notes only).
+    """
+    if type not in _ATOM_TYPES:
+        return {"error": f"type must be one of atom, fact, active, got {type!r}"}
+    if visibility not in _VISIBILITIES:
+        return {"error": f"visibility must be public or private, got {visibility!r}"}
+    if type == "active":
+        if status not in _ACTIVE_STATUSES:
+            return {
+                "error": (
+                    "type=active requires status in active, someday, blocked, "
+                    f"got {status!r}"
+                )
+            }
+        if size not in _ACTIVE_SIZES:
+            return {
+                "error": (
+                    "type=active requires size in small, medium, large, unknown, "
+                    f"got {size!r}"
+                )
+            }
+    if edges:
+        for edge_type in edges:
+            if edge_type not in frontmatter._KNOWN_EDGE_TYPES:
+                valid = ", ".join(sorted(frontmatter._KNOWN_EDGE_TYPES))
+                return {
+                    "error": f"invalid edge type {edge_type!r}: must be one of {valid}"
+                }
+
+    with Session(get_engine()) as session:
+        store = KnowledgeStore(session)
+
+        # Resolve a unique note_id against the DB (fileless: no filesystem
+        # collision check). The slug stem becomes the stable id.
+        base = _slugify(title)
+        note_id = base
+        counter = 1
+        while store.get_note_by_id(note_id) is not None:
+            note_id = f"{base}-{counter}"
+            counter += 1
+
+        fm_dict: dict[str, object] = {
+            "id": note_id,
+            "title": title,
+            "type": type,
+            "visibility": visibility,
+        }
+        if derived_from_raw is not None:
+            fm_dict["derived_from_raw"] = derived_from_raw
+        if tags:
+            fm_dict["tags"] = list(tags)
+        if aliases:
+            fm_dict["aliases"] = list(aliases)
+        if edges:
+            fm_dict["edges"] = {k: list(v) for k, v in edges.items()}
+        if type == "active":
+            fm_dict["status"] = status
+            fm_dict["size"] = size
+            if due is not None:
+                fm_dict["due"] = due
+            if blocked_by:
+                fm_dict["blocked_by"] = list(blocked_by)
+
+        fm_str = yaml.dump(fm_dict, default_flow_style=False, sort_keys=False)
+        raw = f"---\n{fm_str}---\n\n{body.strip()}\n"
+
+        await index_note_from_raw(
+            store,
+            EmbeddingClient(),
+            note_id=note_id,
+            rel_path=f"_processed/{note_id}.md",
+            raw=raw,
+        )
+
+        result: dict = {"note_id": note_id}
+        if derived_from_raw is not None:
+            raw_row = session.exec(
+                select(RawInput).where(RawInput.raw_id == derived_from_raw)
+            ).first()
+            if raw_row is None:
+                result["warning"] = (
+                    f"derived_from_raw {derived_from_raw!r} not found, "
+                    "provenance not recorded"
+                )
+            else:
+                session.add(
+                    AtomRawProvenance(
+                        raw_fk=raw_row.id,
+                        derived_note_id=note_id,
+                        gardener_version=GARDENER_VERSION,
+                    )
+                )
+                session.commit()
+
+    return result
+
+
+@mcp.tool
+async def record_provenance(
+    raw_id: str,
+    outcome: str,
+    error: str | None = None,
+) -> dict:
+    """Record a sentinel or failure provenance row for a decomposed raw.
+
+    Closes out a raw that the gardener processed but that produced no new
+    atoms (no-new-notes), or that failed (failed). A failed outcome
+    increments ``retry_count`` on the existing failure row (or inserts one
+    with ``retry_count=1``), so the retry ceiling in
+    ``raws_needing_decomposition`` is respected.
+
+    Args:
+        raw_id: The raw input that was processed.
+        outcome: Either no-new-notes or failed.
+        error: Optional error detail (only stored for a failed outcome).
+    """
+    if outcome not in ("no-new-notes", "failed"):
+        return {"error": f"outcome must be no-new-notes or failed, got {outcome!r}"}
+
+    with Session(get_engine()) as session:
+        row = session.exec(select(RawInput).where(RawInput.raw_id == raw_id)).first()
+        if row is None:
+            return {"error": f"raw not found: {raw_id}"}
+
+        if outcome == "no-new-notes":
+            session.add(
+                AtomRawProvenance(
+                    raw_fk=row.id,
+                    derived_note_id="no-new-notes",
+                    gardener_version=GARDENER_VERSION,
+                )
+            )
+        else:
+            existing = session.exec(
+                select(AtomRawProvenance).where(
+                    AtomRawProvenance.raw_fk == row.id,
+                    AtomRawProvenance.derived_note_id == "failed",
+                )
+            ).first()
+            if existing is not None:
+                existing.retry_count += 1
+                existing.error = (error or "")[:500]
+                existing.gardener_version = GARDENER_VERSION
+                session.add(existing)
+            else:
+                session.add(
+                    AtomRawProvenance(
+                        raw_fk=row.id,
+                        derived_note_id="failed",
+                        gardener_version=GARDENER_VERSION,
+                        error=(error or "")[:500],
+                        retry_count=1,
+                    )
+                )
+        session.commit()
+
+    return {"recorded": outcome, "raw_id": raw_id}

--- a/projects/monolith/knowledge/mcp_test.py
+++ b/projects/monolith/knowledge/mcp_test.py
@@ -2,18 +2,25 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from knowledge.gardener import GARDENER_VERSION
+from knowledge.models import AtomRawProvenance
 from knowledge.mcp import (
+    create_atom,
     create_note,
     delete_note,
     edit_note,
     get_daily_tasks,
     get_note,
+    get_raw,
     get_weekly_tasks,
+    list_raws_needing_decomposition,
     list_tasks,
+    record_provenance,
     search_knowledge,
     search_tasks,
     update_task,
@@ -687,3 +694,341 @@ class TestGetWeeklyTasks:
 
         assert len(result["tasks"]) == 1
         MockStore.return_value.list_tasks_weekly.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Gardener decomposition tool tests (ADR 006 Phase 4c)
+# ---------------------------------------------------------------------------
+
+
+def _result(value):
+    """Wrap a value as a SQLModel exec(...) result whose .first() returns it."""
+    r = MagicMock()
+    r.first.return_value = value
+    return r
+
+
+class TestListRawsNeedingDecomposition:
+    """Tests for the list_raws_needing_decomposition MCP tool."""
+
+    @pytest.mark.asyncio
+    async def test_returns_raws(self):
+        fake_raw = SimpleNamespace(
+            raw_id="r1",
+            content="---\ntitle: My Raw\n---\nbody text",
+            source="discord",
+            created_at="2026-01-01",
+        )
+        mock_session = MagicMock()
+        with (
+            patch("knowledge.mcp.Session", return_value=mock_session),
+            patch("knowledge.mcp.get_engine"),
+            patch("knowledge.mcp.KnowledgeStore") as MockStore,
+        ):
+            MockStore.return_value.raws_needing_decomposition.return_value = [fake_raw]
+            result = await list_raws_needing_decomposition()
+
+        assert result["raws"] == [
+            {
+                "raw_id": "r1",
+                "title": "My Raw",
+                "source": "discord",
+                "created_at": "2026-01-01",
+            }
+        ]
+
+    @pytest.mark.asyncio
+    async def test_clamps_limit(self):
+        mock_session = MagicMock()
+        with (
+            patch("knowledge.mcp.Session", return_value=mock_session),
+            patch("knowledge.mcp.get_engine"),
+            patch("knowledge.mcp.KnowledgeStore") as MockStore,
+        ):
+            MockStore.return_value.raws_needing_decomposition.return_value = []
+            await list_raws_needing_decomposition(limit=999)
+
+            MockStore.return_value.raws_needing_decomposition.assert_called_once_with(
+                50
+            )
+
+
+class TestGetRaw:
+    """Tests for the get_raw MCP tool."""
+
+    @pytest.mark.asyncio
+    async def test_found(self):
+        row = SimpleNamespace(raw_id="r1", content="hello world", source="discord")
+        mock_session = MagicMock()
+        mock_session.__enter__.return_value = mock_session
+        mock_session.exec.return_value.first.return_value = row
+        with (
+            patch("knowledge.mcp.Session", return_value=mock_session),
+            patch("knowledge.mcp.get_engine"),
+        ):
+            result = await get_raw("r1")
+
+        assert result == {
+            "raw_id": "r1",
+            "content": "hello world",
+            "source": "discord",
+        }
+
+    @pytest.mark.asyncio
+    async def test_missing(self):
+        mock_session = MagicMock()
+        mock_session.__enter__.return_value = mock_session
+        mock_session.exec.return_value.first.return_value = None
+        with (
+            patch("knowledge.mcp.Session", return_value=mock_session),
+            patch("knowledge.mcp.get_engine"),
+        ):
+            result = await get_raw("nope")
+
+        assert "error" in result
+        assert "nope" in result["error"]
+
+
+class TestCreateAtom:
+    """Tests for the create_atom MCP tool."""
+
+    @pytest.mark.asyncio
+    async def test_happy_path(self):
+        mock_session = MagicMock()
+        mock_session.__enter__.return_value = mock_session
+        index = AsyncMock()
+        with (
+            patch("knowledge.mcp.Session", return_value=mock_session),
+            patch("knowledge.mcp.get_engine"),
+            patch("knowledge.mcp.EmbeddingClient", return_value=AsyncMock()),
+            patch("knowledge.mcp.index_note_from_raw", index),
+            patch("knowledge.mcp.KnowledgeStore") as MockStore,
+        ):
+            MockStore.return_value.get_note_by_id.return_value = None
+            result = await create_atom(
+                title="My Atom",
+                body="The body.",
+                type="atom",
+                visibility="public",
+                tags=["x"],
+            )
+
+        assert result == {"note_id": "my-atom"}
+        index.assert_awaited_once()
+        kwargs = index.call_args.kwargs
+        assert kwargs["note_id"] == "my-atom"
+        assert "visibility: public" in kwargs["raw"]
+        assert "The body." in kwargs["raw"]
+
+    @pytest.mark.asyncio
+    async def test_rejects_bad_type(self):
+        index = AsyncMock()
+        with patch("knowledge.mcp.index_note_from_raw", index):
+            result = await create_atom(
+                title="x", body="y", type="bogus", visibility="public"
+            )
+
+        assert "error" in result
+        index.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_rejects_bad_visibility(self):
+        index = AsyncMock()
+        with patch("knowledge.mcp.index_note_from_raw", index):
+            result = await create_atom(
+                title="x", body="y", type="atom", visibility="secret"
+            )
+
+        assert "error" in result
+        index.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_active_requires_status_and_size(self):
+        index = AsyncMock()
+        with patch("knowledge.mcp.index_note_from_raw", index):
+            result = await create_atom(
+                title="x", body="y", type="active", visibility="public"
+            )
+
+        assert "error" in result
+        index.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_active_with_status_and_size_ok(self):
+        mock_session = MagicMock()
+        mock_session.__enter__.return_value = mock_session
+        index = AsyncMock()
+        with (
+            patch("knowledge.mcp.Session", return_value=mock_session),
+            patch("knowledge.mcp.get_engine"),
+            patch("knowledge.mcp.EmbeddingClient", return_value=AsyncMock()),
+            patch("knowledge.mcp.index_note_from_raw", index),
+            patch("knowledge.mcp.KnowledgeStore") as MockStore,
+        ):
+            MockStore.return_value.get_note_by_id.return_value = None
+            result = await create_atom(
+                title="Do The Thing",
+                body="task body",
+                type="active",
+                visibility="private",
+                status="active",
+                size="small",
+            )
+
+        assert result == {"note_id": "do-the-thing"}
+        kwargs = index.call_args.kwargs
+        assert "status: active" in kwargs["raw"]
+        assert "size: small" in kwargs["raw"]
+
+    @pytest.mark.asyncio
+    async def test_rejects_bad_edge_type(self):
+        index = AsyncMock()
+        with patch("knowledge.mcp.index_note_from_raw", index):
+            result = await create_atom(
+                title="x",
+                body="y",
+                type="atom",
+                visibility="public",
+                edges={"not_a_real_edge": ["target"]},
+            )
+
+        assert "error" in result
+        index.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_collision_appends_suffix(self):
+        mock_session = MagicMock()
+        mock_session.__enter__.return_value = mock_session
+        index = AsyncMock()
+
+        def gnb(note_id):
+            return SAMPLE_NOTE if note_id == "my-atom" else None
+
+        with (
+            patch("knowledge.mcp.Session", return_value=mock_session),
+            patch("knowledge.mcp.get_engine"),
+            patch("knowledge.mcp.EmbeddingClient", return_value=AsyncMock()),
+            patch("knowledge.mcp.index_note_from_raw", index),
+            patch("knowledge.mcp.KnowledgeStore") as MockStore,
+        ):
+            MockStore.return_value.get_note_by_id.side_effect = gnb
+            result = await create_atom(
+                title="My Atom", body="b", type="atom", visibility="public"
+            )
+
+        assert result == {"note_id": "my-atom-1"}
+        assert index.call_args.kwargs["note_id"] == "my-atom-1"
+
+    @pytest.mark.asyncio
+    async def test_records_provenance_when_raw_resolves(self):
+        mock_session = MagicMock()
+        mock_session.__enter__.return_value = mock_session
+        mock_session.exec.return_value.first.return_value = SimpleNamespace(id=7)
+        index = AsyncMock()
+        with (
+            patch("knowledge.mcp.Session", return_value=mock_session),
+            patch("knowledge.mcp.get_engine"),
+            patch("knowledge.mcp.EmbeddingClient", return_value=AsyncMock()),
+            patch("knowledge.mcp.index_note_from_raw", index),
+            patch("knowledge.mcp.KnowledgeStore") as MockStore,
+        ):
+            MockStore.return_value.get_note_by_id.return_value = None
+            result = await create_atom(
+                title="My Atom",
+                body="b",
+                type="atom",
+                visibility="public",
+                derived_from_raw="r1",
+            )
+
+        assert result == {"note_id": "my-atom"}
+        added = mock_session.add.call_args.args[0]
+        assert isinstance(added, AtomRawProvenance)
+        assert added.raw_fk == 7
+        assert added.derived_note_id == "my-atom"
+        assert added.gardener_version == GARDENER_VERSION
+        mock_session.commit.assert_called_once()
+
+
+class TestRecordProvenance:
+    """Tests for the record_provenance MCP tool."""
+
+    @pytest.mark.asyncio
+    async def test_rejects_bad_outcome(self):
+        result = await record_provenance("r1", "weird")
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    async def test_raw_missing(self):
+        mock_session = MagicMock()
+        mock_session.__enter__.return_value = mock_session
+        mock_session.exec.return_value.first.return_value = None
+        with (
+            patch("knowledge.mcp.Session", return_value=mock_session),
+            patch("knowledge.mcp.get_engine"),
+        ):
+            result = await record_provenance("nope", "no-new-notes")
+
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    async def test_no_new_notes(self):
+        mock_session = MagicMock()
+        mock_session.__enter__.return_value = mock_session
+        mock_session.exec.return_value.first.return_value = SimpleNamespace(id=3)
+        with (
+            patch("knowledge.mcp.Session", return_value=mock_session),
+            patch("knowledge.mcp.get_engine"),
+        ):
+            result = await record_provenance("r1", "no-new-notes")
+
+        assert result == {"recorded": "no-new-notes", "raw_id": "r1"}
+        added = mock_session.add.call_args.args[0]
+        assert isinstance(added, AtomRawProvenance)
+        assert added.raw_fk == 3
+        assert added.derived_note_id == "no-new-notes"
+        mock_session.commit.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_failed_inserts_new_row(self):
+        mock_session = MagicMock()
+        mock_session.__enter__.return_value = mock_session
+        mock_session.exec.side_effect = [
+            _result(SimpleNamespace(id=4)),
+            _result(None),
+        ]
+        with (
+            patch("knowledge.mcp.Session", return_value=mock_session),
+            patch("knowledge.mcp.get_engine"),
+        ):
+            result = await record_provenance("r1", "failed", error="boom")
+
+        assert result == {"recorded": "failed", "raw_id": "r1"}
+        added = mock_session.add.call_args.args[0]
+        assert isinstance(added, AtomRawProvenance)
+        assert added.derived_note_id == "failed"
+        assert added.retry_count == 1
+        assert added.error == "boom"
+        mock_session.commit.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_failed_increments_existing_row(self):
+        existing = SimpleNamespace(retry_count=2, error=None, gardener_version="old")
+        mock_session = MagicMock()
+        mock_session.__enter__.return_value = mock_session
+        mock_session.exec.side_effect = [
+            _result(SimpleNamespace(id=5)),
+            _result(existing),
+        ]
+        with (
+            patch("knowledge.mcp.Session", return_value=mock_session),
+            patch("knowledge.mcp.get_engine"),
+        ):
+            result = await record_provenance("r1", "failed", error="again")
+
+        assert result == {"recorded": "failed", "raw_id": "r1"}
+        assert existing.retry_count == 3
+        assert existing.error == "again"
+        assert existing.gardener_version == GARDENER_VERSION
+        mock_session.add.assert_called_once_with(existing)
+        mock_session.commit.assert_called_once()

--- a/projects/monolith/knowledge/store.py
+++ b/projects/monolith/knowledge/store.py
@@ -5,14 +5,14 @@ from __future__ import annotations
 import logging
 from datetime import date, datetime, timedelta, timezone
 
-from sqlalchemy import func
+from sqlalchemy import func, not_, or_
 from sqlalchemy.orm.attributes import flag_modified
 from sqlmodel import Session, delete, select
 
 from knowledge.frontmatter import ParsedFrontmatter
-from knowledge.gardener import _slugify
+from knowledge.gardener import GARDENER_VERSION, Gardener, _slugify
 from knowledge.links import Link
-from knowledge.models import Chunk, Gap, Note, NoteLink
+from knowledge.models import AtomRawProvenance, Chunk, Gap, Note, NoteLink, RawInput
 from shared.chunker import Chunk as ChunkPayload
 
 logger = logging.getLogger(__name__)
@@ -770,3 +770,74 @@ class KnowledgeStore:
             "resolved_at": gap.resolved_at,
             "pipeline_version": gap.pipeline_version,
         }
+
+    def raws_needing_decomposition(self, limit: int = 10) -> list[RawInput]:
+        """Return raws the gardener still needs to decompose, fresh first.
+
+        Lifts the exact tiering from ``Gardener._raws_needing_decomposition``
+        so the remote claude.ai routine (ADR 006 Phase 4c) sees the same work
+        queue the in-pod gardener used to.
+
+        Tier 1 (fresh): no current-version or pre-migration provenance at all.
+        Tier 2 (retriable): have a ``derived_note_id='failed'`` provenance row
+        with ``retry_count < Gardener._MAX_RETRIES`` and no successful
+        current-version provenance.
+
+        Returns ``(fresh + retriable)[:limit]``, preserving tier order.
+        """
+        # Subquery: raw_fk values that have current-version or pre-migration
+        # provenance (i.e. successfully handled or grandfathered).
+        handled_subq = (
+            select(AtomRawProvenance.raw_fk)
+            .where(AtomRawProvenance.raw_fk.is_not(None))
+            .where(
+                or_(
+                    AtomRawProvenance.gardener_version == GARDENER_VERSION,
+                    AtomRawProvenance.gardener_version == "pre-migration",
+                )
+            )
+            .where(
+                or_(
+                    AtomRawProvenance.derived_note_id.is_(None),
+                    AtomRawProvenance.derived_note_id != "failed",
+                )
+            )
+            .subquery()
+        )
+
+        # Subquery: raw_fk values that have a "failed" provenance row
+        # (regardless of retry_count: filtered in tier 2).
+        failed_subq = (
+            select(AtomRawProvenance.raw_fk)
+            .where(AtomRawProvenance.raw_fk.is_not(None))
+            .where(AtomRawProvenance.derived_note_id == "failed")
+            .subquery()
+        )
+
+        # Tier 1: fresh raws, not handled AND not failed.
+        fresh_stmt = (
+            select(RawInput)
+            .where(not_(RawInput.id.in_(select(handled_subq.c.raw_fk))))
+            .where(not_(RawInput.id.in_(select(failed_subq.c.raw_fk))))
+            .order_by(RawInput.created_at.asc().nullslast(), RawInput.id.asc())
+        )
+        fresh = list(self.session.exec(fresh_stmt).all())
+
+        # Tier 2: retriable failed raws have a "failed" row with
+        # retry_count < _MAX_RETRIES and no successful current-version prov.
+        retriable_subq = (
+            select(AtomRawProvenance.raw_fk)
+            .where(AtomRawProvenance.raw_fk.is_not(None))
+            .where(AtomRawProvenance.derived_note_id == "failed")
+            .where(AtomRawProvenance.retry_count < Gardener._MAX_RETRIES)
+            .subquery()
+        )
+        retriable_stmt = (
+            select(RawInput)
+            .where(RawInput.id.in_(select(retriable_subq.c.raw_fk)))
+            .where(not_(RawInput.id.in_(select(handled_subq.c.raw_fk))))
+            .order_by(RawInput.created_at.asc().nullslast(), RawInput.id.asc())
+        )
+        retriable = list(self.session.exec(retriable_stmt).all())
+
+        return (fresh + retriable)[:limit]


### PR DESCRIPTION
First build step of the MCP-routine gardener ([ADR 006 Phase 4c](https://github.com/jomcgi/homelab/blob/main/docs/plans/2026-06-16-mcp-routine-gardener-plan.md)). Adds the MCP tools a remote claude.ai routine needs to decompose raws into atoms over MCP, no in-pod subprocess, no filesystem.

### Tools
- `store.raws_needing_decomposition(limit)` — lifts the fresh + retriable-failed tiering from `gardener._raws_needing_decomposition`.
- `list_raws_needing_decomposition`, `get_raw` — the gardener's read side.
- `create_atom` — **fileless**: validates the atom schema **server-side** (type, visibility, `active`->status+size, edge types), resolves `note_id` collisions against the DB, indexes straight into Postgres via `index_note_from_raw`. Records `AtomRawProvenance` when `derived_from_raw` resolves. (The reconciler defers permanently post-Obsidian, so a fileless atom is never pruned.)
- `record_provenance` — the `no-new-notes` sentinel + `failed`/retry-increment rows, preserving the retry ceiling.

### Why this is stronger than the old gardener
Atom schema is now enforced at the **MCP boundary**, malformed atoms are rejected with a correctable error, not just hoped for in a prompt.

### Tests
16 cases across the 4 tools: validation failures (bad type/visibility, missing status+size for active, bad edge), DB collision suffixing, provenance recording, sentinel/failed-increment.

### Notes
- `create_atom` docstrings kept free of `;`/`|` (Context Forge drops tools whose descriptions contain them).
- Deferred: `patch_edges` + fileless `edit_note` (need frontmatter reconstruction from DB columns); next steps are the Skills + routine YAMLs (4c-2/4c-3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)