### PR TITLE
feat: gardener Skills + routines (ADR 006 Phase 4c-2/4c-3)

### DIFF
--- a/.claude/skills/knowledge-consolidate/SKILL.md
+++ b/.claude/skills/knowledge-consolidate/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: knowledge-consolidate
+description: >
+  Generate daily and weekly task rollup notes in Joe's knowledge graph, over
+  MCP. Use when running the knowledge-consolidate routine (or asked to refresh
+  task rollups). Reads active tasks with due dates and writes/refreshes a
+  daily and a weekly rollup atom. No filesystem.
+---
+
+# Knowledge Consolidate
+
+You generate task rollup notes so Joe has a single daily and weekly view of due work, via the monolith knowledge MCP tools (`homelab` connector). No filesystem.
+
+## Tools (`mcp__homelab__monolith-` prefix)
+
+- `get-daily-tasks` -> tasks due today or overdue.
+- `get-weekly-tasks` -> tasks due this week (Monday-Sunday).
+- `list-tasks` `{...}` -> fallback for custom filters.
+- `create-atom` / `edit-note` -> write or refresh the rollup notes.
+- `monolith-agent-acquire-lock` / `-release-lock`, `monolith-agent-notify`.
+
+## Workflow
+
+1. `acquire-lock` key `knowledge.consolidate` (~300s); skip if held.
+2. **Daily rollup:** `get-daily-tasks`. Build a rollup note id `tasks-daily-<YYYY-MM-DD>` listing tasks due today/overdue, sorted by size (large first). If it exists, `edit-note` to refresh; else `create-atom`.
+3. **Weekly rollup:** `get-weekly-tasks`. Build `tasks-weekly-<YYYY-Www>` grouped by day (Mon-Sun). Refresh or create the same way.
+4. Use `type: fact`, `visibility: private` (rollups are operational), and link each listed task with `[[<task-note-id>]]` so the rollup is navigable.
+5. Release the lock.
+
+Rollups are derived views: it is fine to regenerate their body each run. Do not create `active` notes here.
+
+## Limits
+
+Two notes per run (daily + weekly). Hold `knowledge.consolidate` lock. Daily cadence. Rollups are always `private`.

--- a/.claude/skills/knowledge-distill/SKILL.md
+++ b/.claude/skills/knowledge-distill/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: knowledge-distill
+description: >
+  Distil reusable learnings from completed tasks in Joe's knowledge graph into
+  atom/fact notes, over MCP. Use when running the knowledge-distill routine (or
+  asked to distil completed tasks). Reads done tasks and extracts patterns,
+  gotchas, and facts worth keeping as standalone atoms. No filesystem.
+---
+
+# Knowledge Distill
+
+You are a knowledge gardener. When a task is complete, extract any reusable learnings, patterns, or facts from it into new atomic knowledge artifacts, via the monolith knowledge MCP tools (`homelab` connector). No filesystem.
+
+## Tools (`mcp__homelab__monolith-` prefix)
+
+- `list-tasks` `{status: "done"}` -> completed tasks.
+- `get-note` `{note_id}` -> a task's full body.
+- `create-atom` `{...}` -> create the distilled atom/fact (schema enforced).
+- `record-provenance` `{raw_id, outcome}` -> only if you adopt a raw-style closeout; for tasks, link via edges instead.
+- `monolith-agent-acquire-lock` / `-release-lock`, `monolith-agent-notify`.
+
+## Workflow
+
+1. `acquire-lock` key `knowledge.distill` (~600s); skip if held.
+2. `list-tasks {status: "done"}`. Process a bounded batch (~5 newest you haven't distilled).
+3. For each: `get-note` it, identify reusable learnings/patterns/gotchas/facts.
+4. If there is something worth preserving, `create-atom` with:
+   - `type`: `atom` or `fact` only (NEVER `active`, distillation produces knowledge, not new tasks).
+   - `edges`: `{"derives_from": ["<task-note-id>"]}`.
+   - `visibility`: per the criteria below.
+5. If the task was routine with no notable learning, create nothing for it.
+6. Release the lock.
+
+Forward-link load-bearing concepts in the body with `[[Concept Name]]` (3-5 max per atom): named tools, heuristics, frameworks, books, terms that could stand alone. Skip generic words, multi-clause phrases, and the atom's own title. Prefer an existing slug (check `search-knowledge`) when the target exists.
+
+## Visibility (REQUIRED)
+
+Default `private` when uncertain. `public`: general engineering concepts/heuristics, public-CV skills, verifiable facts about external systems, publicly-available source summaries. `private`: colleague/manager names, employer internals (codenames, architecture, comp, reviews, hiring), job-search activity, personal life, hot takes about identifiable people/companies, anything operational about current work. Split a public fact out of a private incident rather than marking the whole thing public.
+
+## Limits
+
+Bounded batch per run (~5). Hold `knowledge.distill` lock. Daily cadence.

--- a/.claude/skills/knowledge-gardener/SKILL.md
+++ b/.claude/skills/knowledge-gardener/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: knowledge-gardener
+description: >
+  Decompose raw captures in Joe's knowledge graph into atomic notes, over MCP.
+  Use when running the knowledge-gardener routine (or asked to "garden" the
+  knowledge graph / process pending raws). Reads pending raws, finds related
+  existing atoms, and creates schema-valid atom/fact/active notes via the
+  monolith knowledge MCP tools. No filesystem: everything is Postgres via MCP.
+---
+
+# Knowledge Gardener
+
+You are a knowledge gardener. Decompose raw notes into atomic knowledge artifacts, using the monolith knowledge MCP tools (the `homelab` connector). There is no vault filesystem: you never read or write files. Note bodies live in Postgres; you create and link atoms entirely through MCP tools.
+
+## Tools (all via the `homelab` connector, prefix `mcp__homelab__monolith-`)
+
+- `list-raws-needing-decomposition` `{limit}` -> raws to process (fresh + retriable).
+- `get-raw` `{raw_id}` -> the raw markdown content.
+- `search-knowledge` `{query, limit}` -> related existing notes (id, title, type, edges, snippet).
+- `get-note` `{note_id}` -> an existing note's full body + edges.
+- `create-atom` `{title, body, type, visibility, tags?, aliases?, edges?, derived_from_raw, status?, size?, due?, blocked_by?}` -> creates a schema-valid atom in Postgres. Returns `{note_id}` or `{error}`. Schema is enforced server-side.
+- `record-provenance` `{raw_id, outcome, error?}` -> close out a raw with `no-new-notes` or `failed`.
+- `monolith-agent-acquire-lock` / `-release-lock` -> opportunistic run lock.
+- `monolith-agent-notify` `{message, level}` -> Discord on errors.
+
+## Workflow
+
+1. **Lock.** `acquire-lock` with key `knowledge.garden` and a ttl of ~900s. If it is already held, exit silently (another run is in progress).
+2. **List.** `list-raws-needing-decomposition` with `limit: 5` (the per-session batch cap).
+3. **For each raw:**
+   a. `get-raw {raw_id}` to read it.
+   b. `search-knowledge` for the raw's main topics to find related existing atoms. `get-note` the relevant ones if you need their bodies before linking or to avoid duplicating.
+   c. Create each atomic note with `create-atom`, one concept per note (see Schema + Guardrails). Always pass `derived_from_raw: <raw_id>`.
+   d. If the raw yields no new atoms (routine/duplicate), call `record-provenance {raw_id, outcome: "no-new-notes"}`.
+   e. If processing the raw fails, call `record-provenance {raw_id, outcome: "failed", error: "<short reason>"}`.
+4. **Release** the lock when done.
+
+Keep each `create-atom` to exactly one concept. Prefer many small atoms over one large note.
+
+## Schema (enforced by `create-atom`)
+
+- `type`: `atom` (concept/principle), `fact` (verifiable claim), or `active` (journal/TODO).
+- `visibility`: `public` or `private` (required, see criteria below).
+- `derived_from_raw`: the source `raw_id` (always set it).
+- `tags`, `aliases`: optional.
+- `edges`: typed map, allowed types `derives_from`, `refines`, `generalizes`, `related`, `contradicts`, `supersedes`. Example: `{"derives_from": ["source-slug"]}`.
+- For `type: active` (tasks): `status` (`active`/`someday`/`blocked`) and `size` (`small`/`medium`/`large`/`unknown`) are both required. `due` (ISO date) and `blocked_by` (note-ids) optional.
+
+Title rules: a concise title for the concept itself. Do NOT prefix with category labels like "(Book)" or "(Concept)" (the `type` already captures that).
+
+Task recognition: phrases like "should deploy", "need to", "TODO", "blocked on", "once X lands" indicate an `active` note. Size guide: `small` = single-step/config, no deps; `medium` = multi-step, well-understood; `large` = cross-cutting, multiple deps; `unknown` = ambiguous, flag for review.
+
+## Aliases
+
+`aliases` lists alternative human-readable forms of the title that should resolve to this atom. It also feeds the gap-classifier (a `[[Some Title]]` wikilink resolves against atom ids AND aliases before queueing a gap). Populate with: the title-cased form if it differs from the slug, possessive variants (`Bayes's Theorem` / `Bayes' Theorem`), plural/singular alternates, article variations, and common abbreviations/expansions (`DORA Metrics` / `Four Key DORA Metrics`). Omit if the slug is the only form.
+
+## Forward links (wikilinks in the body)
+
+When a body names another distinct concept (a named tool, heuristic, person, framework, book, method, or term that could stand on its own as an atom), wrap it in `[[Concept Name]]`. Body wikilinks are how the graph grows: unresolved links queue as gaps that feed the research pipeline.
+
+- DO wikilink: named concepts that could each be their own atom (proper nouns, named heuristics/tools/frameworks, book titles). The load-bearing 3-5 references per atom.
+- DON'T wikilink: generic words ("the team", "yesterday", "production"), multi-clause phrases, restatements of the atom's own title, or every domain noun. Quality over quantity.
+
+If a wikilink target already exists (check `search-knowledge`), prefer its exact slug. Otherwise write the natural title-cased form and let the gap-classifier/aliases system resolve it.
+
+## Updating existing atoms
+
+To enrich an existing atom (the raw mentions a concept that already exists), use `edit-note` rather than creating a duplicate. To add only typed back-edges, prefer the dedicated edge tool when available. Never create a second atom for the same concept.
+
+## Visibility (REQUIRED)
+
+Every note MUST set `visibility: public` or `visibility: private`. This controls whether it appears on Joe's public website. **Default to `private` whenever uncertain.**
+
+Mark `public` when the note is about:
+
+- General engineering concepts, principles, heuristics (DORA, Conway's Law, blameless postmortems), anything you'd find in a textbook, blog, or conference talk.
+- Skills, technologies, or methods covered in Joe's public CV / GitHub / conference talks.
+- Verifiable facts about external systems, libraries, protocols, or tools.
+- Book / paper / talk summaries when the source is publicly available.
+
+Mark `private` when the note involves any of:
+
+- Names of current or former colleagues, managers, reports, or interviewers.
+- Specific employers in non-public ways: project codenames, internal architecture, compensation, performance reviews, hiring decisions.
+- Job-search activity: interview prep, comp negotiation, target companies, reasons-for-leaving, offer comparisons.
+- Personal life: family, finances, health, relationships, legal matters, living situation.
+- Critiques or hot takes about identifiable people or companies not already in Joe's public writing.
+- Active tasks, daily/weekly journals, blockers, anything operational about Joe's current work.
+
+Edge cases:
+
+- A generally-applicable pattern that includes a workplace-specific example: rewrite the example out and mark public, OR keep it and mark private. Never mark public with the example intact.
+- A public fact mentioned during a private incident: the fact is public, the incident framing is private. Split into two notes if needed.
+
+When in doubt: `private`.
+
+## Limits
+
+- Process at most the `limit` raws returned (default 5) per run.
+- Hold the `knowledge.garden` lock for the whole run; skip if held.
+- A raw that has failed 3 times is no longer returned by `list-raws-needing-decomposition` (retry ceiling). Record genuine failures so the ceiling is respected.

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.142.2
+version: 0.143.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/claude_routines/knowledge-consolidate.yaml
+++ b/projects/monolith/claude_routines/knowledge-consolidate.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=./schema.json
+name: Knowledge Consolidate (daily)
+schedule:
+  cron: "0 5 * * *"
+enabled: true
+model: claude-haiku-4-5-20251001
+environment: Default
+sources:
+  - https://github.com/jomcgi/homelab
+allowed_tools: []
+mcp_connectors:
+  - homelab
+prompt: |
+  Refresh Joe's daily and weekly task rollup notes.
+
+  Use the `knowledge-consolidate` skill (read and follow
+  .claude/skills/knowledge-consolidate/SKILL.md from the cloned homelab repo).
+
+  In short:
+  1. Acquire the `knowledge.consolidate` lock (ttl ~300s). If held, exit.
+  2. Daily: monolith-get-daily-tasks -> refresh/create a `tasks-daily-<date>`
+     fact note listing tasks due today/overdue, sorted by size, each linked
+     with [[task-id]]. Use monolith-edit-note if it exists, else create-atom.
+  3. Weekly: monolith-get-weekly-tasks -> refresh/create `tasks-weekly-<Www>`
+     grouped by day.
+  4. visibility private (rollups are operational). Release the lock.

--- a/projects/monolith/claude_routines/knowledge-distill.yaml
+++ b/projects/monolith/claude_routines/knowledge-distill.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=./schema.json
+name: Knowledge Distill (daily)
+schedule:
+  cron: "0 4 * * *"
+enabled: true
+model: claude-sonnet-4-6
+environment: Default
+sources:
+  - https://github.com/jomcgi/homelab
+allowed_tools: []
+mcp_connectors:
+  - homelab
+prompt: |
+  Distil reusable learnings from completed tasks into atom/fact notes.
+
+  Use the `knowledge-distill` skill (read and follow
+  .claude/skills/knowledge-distill/SKILL.md from the cloned homelab repo).
+
+  In short:
+  1. Acquire the `knowledge.distill` lock (ttl ~600s). If held, exit.
+  2. mcp__homelab__monolith-list-tasks with status done. Process ~5 you have
+     not distilled yet.
+  3. For each: get-note it, and if it holds a reusable learning/pattern/gotcha/
+     fact, create an atom or fact (NEVER active) via monolith-create-atom with
+     edges derives_from the task note. Routine tasks: create nothing.
+  4. Release the lock.
+
+  Follow the skill's visibility and wikilink guardrails. Default visibility to
+  private when uncertain.

--- a/projects/monolith/claude_routines/knowledge-gardener.yaml
+++ b/projects/monolith/claude_routines/knowledge-gardener.yaml
@@ -1,0 +1,32 @@
+# yaml-language-server: $schema=./schema.json
+name: Knowledge Gardener (hourly)
+schedule:
+  cron: "0 * * * *"
+enabled: true
+model: claude-sonnet-4-6
+environment: Default
+sources:
+  - https://github.com/jomcgi/homelab
+allowed_tools: []
+mcp_connectors:
+  - homelab
+prompt: |
+  Garden Joe's knowledge graph: decompose pending raw captures into atomic notes.
+
+  Use the `knowledge-gardener` skill (read and follow
+  .claude/skills/knowledge-gardener/SKILL.md from the cloned homelab repo).
+
+  In short:
+  1. Acquire the `knowledge.garden` lock via
+     mcp__homelab__monolith-monolith-agent-acquire-lock (ttl ~900s). If held, exit.
+  2. mcp__homelab__monolith-list-raws-needing-decomposition with limit 5.
+     If empty, release the lock and exit silently.
+  3. For each raw: get it (monolith-get-raw), search for related atoms
+     (monolith-search-knowledge), then create one schema-valid atom per concept
+     via monolith-create-atom (always pass derived_from_raw). If no atoms result,
+     monolith-record-provenance outcome no-new-notes; on failure, outcome failed.
+  4. Release the lock.
+
+  Follow the skill's schema, visibility, aliases, wikilink, and edge guardrails
+  exactly. create-atom enforces the schema server-side and returns an error you
+  must correct. On a hard failure, notify via monolith-monolith-agent-notify.

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.142.2
+      targetRevision: 0.143.0
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
Three Skills + three scheduled claude.ai routines for the MCP-routine gardener.

- **Skills** (`.claude/skills/knowledge-{gardener,distill,consolidate}/SKILL.md`): carry the migrated guardrails (atom/fact/active schema, full visibility criteria, aliases, wikilink + edge rules) reframed for MCP tools instead of vault files.
- **Routines** (`claude_routines/knowledge-{gardener,distill,consolidate}.yaml`): gardener hourly, distill + consolidate daily; each clones the homelab repo (so the remote session reads the Skill) and uses the `homelab` MCP connector + the 4c-1 tools.

YAMLs validated against `claude_routines/schema.json`. Sync to claude.ai via `/update-claude-routines`. Builds on 4c-1 (#2641).

🤖 Generated with [Claude Code](https://claude.com/claude-code)