### PR TITLE
feat(monolith): file-less raw ingestion (ADR 006 Phase 4c-4)

### DIFF
--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -2905,8 +2905,22 @@ py_test(
     imports = ["."],
     deps = [
         ":monolith_backend",
+        "@pip//pgvector",
         "@pip//pytest",
         "@pip//pytest_asyncio",
+        "@pip//sqlalchemy",
+        "@pip//sqlmodel",
+    ],
+)
+
+py_test(
+    name = "knowledge_raw_store_test",
+    srcs = ["knowledge/raw_store_test.py"],
+    imports = ["."],
+    deps = [
+        ":monolith_backend",
+        "@pip//boto3",
+        "@pip//pytest",
     ],
 )
 

--- a/projects/monolith/app/integration_test.py
+++ b/projects/monolith/app/integration_test.py
@@ -118,15 +118,15 @@ def test_get_schedule_today_returns_list(client):
 
 
 def test_post_note_returns_201(client, tmp_path, monkeypatch):
-    """POST /api/knowledge/notes with content → 201 and file written to vault."""
+    """POST /api/knowledge/notes with content -> 201 and a raw_inputs row (file-less)."""
     monkeypatch.setenv("VAULT_ROOT", str(tmp_path))
     response = client.post(
         "/api/knowledge/notes",
         json={"content": "test note", "title": "Test Note"},
     )
     assert response.status_code == 201
-    path = response.json().get("path", "")
-    assert path.endswith(".md")
+    raw_id = response.json().get("raw_id", "")
+    assert len(raw_id) == 64  # sha256 hex content hash
 
 
 def test_post_note_empty_content_returns_400(client, tmp_path, monkeypatch):

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.143.1
+version: 0.143.2
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.143.0
+version: 0.143.1
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.143.0
+      targetRevision: 0.143.1
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.143.1
+      targetRevision: 0.143.2
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/e2e/e2e_test.py
+++ b/projects/monolith/e2e/e2e_test.py
@@ -40,15 +40,15 @@ class TestHealthz:
 
 class TestNotesAPI:
     def test_create_note(self, client, tmp_path, monkeypatch):
-        """POST returns 201 and writes file to vault."""
+        """POST returns 201 and ingests a raw_inputs row (file-less, ADR 006)."""
         monkeypatch.setenv("VAULT_ROOT", str(tmp_path))
         response = client.post(
             "/api/knowledge/notes",
             json={"content": "Test fleeting note", "title": "Test Note"},
         )
         assert response.status_code == 201
-        path = response.json().get("path", "")
-        assert path.endswith(".md")
+        raw_id = response.json().get("raw_id", "")
+        assert len(raw_id) == 64  # sha256 hex content hash
 
     def test_empty_content_returns_400(self, client, tmp_path, monkeypatch):
         """Empty content returns 400."""

--- a/projects/monolith/knowledge/ingest_queue.py
+++ b/projects/monolith/knowledge/ingest_queue.py
@@ -4,19 +4,19 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import os
 import re
 from datetime import datetime, timezone
-from pathlib import Path
 from urllib.parse import parse_qs, urlparse
 
 import trafilatura
 from sqlalchemy import Column, String, text
 from sqlalchemy.engine import Engine
-from sqlmodel import Field, Session, SQLModel
+from sqlmodel import Field, Session, SQLModel, select
 from youtube_transcript_api import YouTubeTranscriptApi
 
-from knowledge.raw_paths import compute_raw_id, raw_target_path
+from knowledge.models import RawInput
+from knowledge.raw_paths import compute_raw_id
+from knowledge.raw_store import upload_raw
 
 logger = logging.getLogger("monolith.knowledge.ingest_queue")
 
@@ -136,35 +136,41 @@ def _claim_one(session: Session) -> IngestQueueItem | None:
     return IngestQueueItem.model_validate(dict(result._mapping))
 
 
-def _write_raw_md(
+def ingest_raw(
+    session: Session,
     *,
-    vault_root: Path,
-    title: str,
-    body: str,
-    source_type: str,
-    original_url: str,
-    now: datetime,
-) -> Path:
-    """Write fetched content as a raw markdown file under _raw/."""
-    content = (
-        f"---\n"
-        f'title: "{title}"\n'
-        f"source: {source_type}\n"
-        f"original_url: {original_url}\n"
-        f"---\n\n"
-        f"{body}\n"
-    )
+    content: str,
+    source: str,
+    original_url: str | None = None,
+    extra: dict | None = None,
+) -> RawInput:
+    """Persist raw content directly to knowledge.raw_inputs + S3 (no files).
+
+    Content-addressed and idempotent: the ``raw_id`` is the sha256 of the
+    content, so re-ingesting identical content returns the existing row without
+    a duplicate insert or re-upload. The markdown body is uploaded to
+    ``s3://knowledge/raws/<raw_id>.md``; the row's ``path`` is a synthetic
+    stable value (no real file) since the model requires it non-null + unique.
+    """
     raw_id = compute_raw_id(content)
-    target = raw_target_path(
-        vault_root=vault_root,
+    existing = session.exec(select(RawInput).where(RawInput.raw_id == raw_id)).first()
+    if existing is not None:
+        return existing
+
+    upload_raw(raw_id, content)
+    raw = RawInput(
         raw_id=raw_id,
-        title=title,
-        created_at=now,
+        path=f"raws/{raw_id}.md",
+        source=source,
+        content=content,
+        content_hash=raw_id,
+        original_path=original_url,
+        extra=extra or {},
     )
-    target.parent.mkdir(parents=True, exist_ok=True)
-    target.write_text(content, encoding="utf-8")
-    logger.info("ingest_queue: wrote %s", target)
-    return target
+    session.add(raw)
+    session.commit()
+    logger.info("ingest_queue: ingested raw %s (source=%s)", raw_id, source)
+    return raw
 
 
 async def ingest_handler(session: Session) -> datetime | None:
@@ -174,8 +180,6 @@ async def ingest_handler(session: Session) -> datetime | None:
         return None
 
     engine = session.get_bind()
-    vault_root = Path(os.environ.get("VAULT_ROOT", "/vault"))
-    now = datetime.now(timezone.utc)
 
     try:
         if item.source_type == "youtube":
@@ -185,13 +189,19 @@ async def ingest_handler(session: Session) -> datetime | None:
         else:
             raise ValueError(f"unknown source_type: {item.source_type}")
 
-        _write_raw_md(
-            vault_root=vault_root,
-            title=title,
-            body=body,
-            source_type=item.source_type,
+        content = (
+            f"---\n"
+            f'title: "{title}"\n'
+            f"source: {item.source_type}\n"
+            f"original_url: {item.url}\n"
+            f"---\n\n"
+            f"{body}\n"
+        )
+        ingest_raw(
+            session,
+            content=content,
+            source=item.source_type,
             original_url=item.url,
-            now=now,
         )
 
         await asyncio.to_thread(_mark_queue_done, engine, item.id)

--- a/projects/monolith/knowledge/ingest_queue_extra_test.py
+++ b/projects/monolith/knowledge/ingest_queue_extra_test.py
@@ -1,4 +1,4 @@
-"""Extra unit tests for ingest_queue: _extract_video_id, _write_raw_md, ingest_handler.
+"""Extra unit tests for ingest_queue: _extract_video_id, ingest_handler.
 
 Covers edge cases and paths not exercised by ingest_queue_test.py:
 
@@ -8,21 +8,15 @@ _extract_video_id:
   - query param fallback (v= in arbitrary position)
   - invalid URL raises ValueError
 
-_write_raw_md:
-  - writes correct frontmatter (title, source, original_url) and body
-  - file is created under _raw/ and parent dirs are created
-
 ingest_handler:
   - empty queue returns None without touching session
-  - successful youtube ingest calls fetcher + write + commit
-  - successful webpage ingest calls fetcher + write + commit
+  - successful youtube ingest calls fetcher + ingest_raw + commit
+  - successful webpage ingest calls fetcher + ingest_raw + commit
   - failed fetch triggers rollback + failed-status update + commit
 """
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
-from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -30,7 +24,6 @@ import pytest
 from knowledge.ingest_queue import (
     IngestQueueItem,
     _extract_video_id,
-    _write_raw_md,
     ingest_handler,
 )
 
@@ -82,86 +75,6 @@ class TestExtractVideoId:
         """Empty string raises ValueError."""
         with pytest.raises(ValueError, match="cannot extract video ID"):
             _extract_video_id("")
-
-
-# ---------------------------------------------------------------------------
-# _write_raw_md
-# ---------------------------------------------------------------------------
-
-
-class TestWriteRawMd:
-    _NOW = datetime(2026, 4, 11, 12, 0, 0, tzinfo=timezone.utc)
-
-    def _call(self, vault_root, **kw):
-        kwargs = dict(
-            vault_root=vault_root,
-            title="Test Title",
-            body="Body content here.",
-            source_type="youtube",
-            original_url="https://youtube.com/watch?v=abc123",
-            now=self._NOW,
-        )
-        kwargs.update(kw)
-        return _write_raw_md(**kwargs)
-
-    def test_returns_path_object(self, tmp_path):
-        result = self._call(tmp_path)
-        assert isinstance(result, Path)
-
-    def test_file_exists_after_write(self, tmp_path):
-        result = self._call(tmp_path)
-        assert result.exists()
-
-    def test_file_is_under_raw_directory(self, tmp_path):
-        result = self._call(tmp_path)
-        assert str(result).startswith(str(tmp_path / "_raw"))
-
-    def test_creates_parent_directories(self, tmp_path):
-        """Parent dirs under _raw/ are created even if they don't exist."""
-        result = self._call(tmp_path)
-        assert result.parent.is_dir()
-        assert (tmp_path / "_raw").is_dir()
-
-    def test_frontmatter_contains_title(self, tmp_path):
-        result = self._call(tmp_path, title="My Video Title")
-        content = result.read_text(encoding="utf-8")
-        assert 'title: "My Video Title"' in content
-
-    def test_frontmatter_contains_source_type(self, tmp_path):
-        result = self._call(tmp_path, source_type="webpage")
-        content = result.read_text(encoding="utf-8")
-        assert "source: webpage" in content
-
-    def test_frontmatter_contains_original_url(self, tmp_path):
-        url = "https://example.com/some/article"
-        result = self._call(tmp_path, original_url=url)
-        content = result.read_text(encoding="utf-8")
-        assert f"original_url: {url}" in content
-
-    def test_body_written_after_frontmatter(self, tmp_path):
-        result = self._call(tmp_path, body="This is the transcript body.")
-        content = result.read_text(encoding="utf-8")
-        assert "This is the transcript body." in content
-
-    def test_frontmatter_delimited_by_triple_dash(self, tmp_path):
-        result = self._call(tmp_path)
-        content = result.read_text(encoding="utf-8")
-        # Standard YAML frontmatter block
-        assert content.startswith("---\n")
-        # Second --- closes the block
-        assert "\n---\n" in content
-
-    def test_same_content_same_path(self, tmp_path):
-        """Deterministic: same inputs produce the same output path."""
-        path1 = self._call(tmp_path, title="Stable", body="Content")
-        path2 = self._call(
-            tmp_path,
-            title="Stable",
-            body="Content",
-            source_type="youtube",
-            original_url="https://youtube.com/watch?v=abc123",
-        )
-        assert path1 == path2
 
 
 # ---------------------------------------------------------------------------
@@ -226,9 +139,7 @@ class TestIngestHandler:
         with (
             patch("knowledge.ingest_queue._claim_one", return_value=item),
             patch("knowledge.ingest_queue.fetch_youtube_transcript", mock_fetch),
-            patch(
-                "knowledge.ingest_queue._write_raw_md", return_value=tmp_path / "out.md"
-            ),
+            patch("knowledge.ingest_queue.ingest_raw"),
             patch.dict("os.environ", {"VAULT_ROOT": str(tmp_path)}),
         ):
             await ingest_handler(session)
@@ -245,9 +156,7 @@ class TestIngestHandler:
                 "knowledge.ingest_queue.fetch_youtube_transcript",
                 AsyncMock(return_value=("Title", "body")),
             ),
-            patch(
-                "knowledge.ingest_queue._write_raw_md", return_value=tmp_path / "out.md"
-            ),
+            patch("knowledge.ingest_queue.ingest_raw"),
             patch.dict("os.environ", {"VAULT_ROOT": str(tmp_path)}),
         ):
             result = await ingest_handler(session)
@@ -268,9 +177,7 @@ class TestIngestHandler:
                 "knowledge.ingest_queue.fetch_youtube_transcript",
                 AsyncMock(return_value=("Title", "body")),
             ),
-            patch(
-                "knowledge.ingest_queue._write_raw_md", return_value=tmp_path / "out.md"
-            ),
+            patch("knowledge.ingest_queue.ingest_raw"),
             patch.dict("os.environ", {"VAULT_ROOT": str(tmp_path)}),
         ):
             await ingest_handler(session)
@@ -288,9 +195,7 @@ class TestIngestHandler:
         with (
             patch("knowledge.ingest_queue._claim_one", return_value=item),
             patch("knowledge.ingest_queue.fetch_webpage", mock_fetch),
-            patch(
-                "knowledge.ingest_queue._write_raw_md", return_value=tmp_path / "out.md"
-            ),
+            patch("knowledge.ingest_queue.ingest_raw"),
             patch.dict("os.environ", {"VAULT_ROOT": str(tmp_path)}),
         ):
             await ingest_handler(session)
@@ -307,9 +212,7 @@ class TestIngestHandler:
                 "knowledge.ingest_queue.fetch_webpage",
                 AsyncMock(return_value=("Title", "body")),
             ),
-            patch(
-                "knowledge.ingest_queue._write_raw_md", return_value=tmp_path / "out.md"
-            ),
+            patch("knowledge.ingest_queue.ingest_raw"),
             patch.dict("os.environ", {"VAULT_ROOT": str(tmp_path)}),
         ):
             result = await ingest_handler(session)
@@ -383,9 +286,7 @@ class TestIngestHandler:
                 "knowledge.ingest_queue.fetch_webpage",
                 AsyncMock(return_value=("Title", "body")),
             ),
-            patch(
-                "knowledge.ingest_queue._write_raw_md", return_value=tmp_path / "out.md"
-            ),
+            patch("knowledge.ingest_queue.ingest_raw"),
             patch.dict("os.environ", {"VAULT_ROOT": str(tmp_path)}),
         ):
             result = await ingest_handler(session)

--- a/projects/monolith/knowledge/ingest_queue_test.py
+++ b/projects/monolith/knowledge/ingest_queue_test.py
@@ -1,13 +1,20 @@
 """Tests for the URL ingest queue."""
 
 import pytest
-from unittest.mock import patch, MagicMock
+from unittest.mock import AsyncMock, patch, MagicMock
+
+from sqlmodel import Session, SQLModel, create_engine, select
+from sqlmodel.pool import StaticPool
 
 from knowledge.ingest_queue import (
     IngestQueueItem,
     fetch_youtube_transcript,
     fetch_webpage,
+    ingest_handler,
+    ingest_raw,
 )
+from knowledge.models import RawInput
+from knowledge.raw_paths import compute_raw_id
 
 
 def test_ingest_queue_item_defaults():
@@ -72,3 +79,100 @@ async def test_fetch_webpage_handles_no_content():
         mock_traf.extract.return_value = None
         with pytest.raises(RuntimeError, match="no content extracted"):
             await fetch_webpage("https://example.com/empty")
+
+
+@pytest.fixture()
+def db_session():
+    """Real SQLite session with schema= overrides stripped for create_all().
+
+    Mirrors notes_crud_test.real_session: the knowledge tables declare a
+    Postgres schema, which SQLite can't honour, so strip and restore them.
+    """
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    original_schemas = {}
+    for table in SQLModel.metadata.tables.values():
+        if table.schema is not None:
+            original_schemas[table.name] = table.schema
+            table.schema = None
+    try:
+        SQLModel.metadata.create_all(engine)
+        with Session(engine) as s:
+            yield s
+    finally:
+        for table in SQLModel.metadata.tables.values():
+            if table.name in original_schemas:
+                table.schema = original_schemas[table.name]
+
+
+class TestIngestRaw:
+    """ingest_raw: fileless raw_inputs + S3 insert (ADR 006 Phase 4c-4)."""
+
+    def test_inserts_raw_input_and_uploads(self, db_session):
+        content = "---\ntitle: Hello\n---\n\nBody\n"
+        with patch("knowledge.ingest_queue.upload_raw") as mock_upload:
+            raw = ingest_raw(
+                db_session,
+                content=content,
+                source="capture",
+                original_url="https://example.com",
+            )
+
+        expected_id = compute_raw_id(content)
+        assert raw.raw_id == expected_id
+        assert raw.content_hash == expected_id
+        assert raw.path == f"raws/{expected_id}.md"
+        assert raw.source == "capture"
+        assert raw.original_path == "https://example.com"
+        assert raw.content == content
+        mock_upload.assert_called_once_with(expected_id, content)
+
+        rows = db_session.exec(select(RawInput)).all()
+        assert len(rows) == 1
+        assert rows[0].raw_id == expected_id
+
+    def test_dedup_returns_existing_no_duplicate(self, db_session):
+        content = "same content"
+        with patch("knowledge.ingest_queue.upload_raw") as mock_upload:
+            first = ingest_raw(db_session, content=content, source="capture")
+            second = ingest_raw(db_session, content=content, source="capture")
+
+        assert first.id == second.id
+        # Upload only happens on the first (novel) insert.
+        assert mock_upload.call_count == 1
+        rows = db_session.exec(select(RawInput)).all()
+        assert len(rows) == 1
+
+
+@pytest.mark.asyncio
+async def test_ingest_handler_calls_ingest_raw_with_built_content():
+    """ingest_handler fetches, assembles frontmatter+body, and calls ingest_raw."""
+    item = IngestQueueItem(url="https://example.com/article", source_type="webpage")
+    item.id = 7
+    session = MagicMock()
+
+    with (
+        patch("knowledge.ingest_queue._claim_one", return_value=item),
+        patch(
+            "knowledge.ingest_queue.fetch_webpage",
+            new=AsyncMock(return_value=("Page Title", "page body")),
+        ),
+        patch("knowledge.ingest_queue.ingest_raw") as mock_ingest,
+        patch(
+            "knowledge.ingest_queue._mark_queue_done", return_value=None
+        ) as mock_done,
+    ):
+        await ingest_handler(session)
+
+    mock_ingest.assert_called_once()
+    kwargs = mock_ingest.call_args.kwargs
+    assert kwargs["source"] == "webpage"
+    assert kwargs["original_url"] == "https://example.com/article"
+    content = kwargs["content"]
+    assert 'title: "Page Title"' in content
+    assert "source: webpage" in content
+    assert "page body" in content
+    mock_done.assert_called_once()

--- a/projects/monolith/knowledge/notes_crud_test.py
+++ b/projects/monolith/knowledge/notes_crud_test.py
@@ -83,36 +83,38 @@ def db_client(real_session, fake_embed_client, tmp_path, monkeypatch):
 
 
 class TestCreateNote:
-    """Tests for POST /api/knowledge/notes."""
+    """Tests for POST /api/knowledge/notes (fileless: raw_inputs + S3, ADR 006)."""
 
-    def test_create_note_writes_file(self, client, tmp_path):
-        """POST with content+title returns 201 and writes file with frontmatter."""
-        r = client.post(
-            "/api/knowledge/notes",
-            json={
-                "content": "This is my note content.",
-                "title": "My Test Note",
-                "source": "manual",
-                "tags": ["test", "example"],
-                "type": "note",
-            },
-        )
+    def test_create_note_returns_raw_id_and_calls_ingest_raw(self, client):
+        """POST returns 201 with {raw_id} and inserts a raw via ingest_raw."""
+        with patch("knowledge.router.ingest_raw") as mock_ingest:
+            mock_ingest.return_value = MagicMock(raw_id="deadbeef")
+            r = client.post(
+                "/api/knowledge/notes",
+                json={
+                    "content": "This is my note content.",
+                    "title": "My Test Note",
+                    "source": "manual",
+                    "tags": ["test", "example"],
+                    "type": "note",
+                },
+            )
 
         assert r.status_code == 201
-        body = r.json()
-        path = body.get("path", "")
-        assert path.endswith(".md")
+        assert r.json() == {"raw_id": "deadbeef"}
 
-        written = (tmp_path / path).read_text()
-        # Parse frontmatter (between --- delimiters)
-        parts = written.split("---\n")
-        assert len(parts) >= 3, f"Expected frontmatter delimiters, got: {written}"
+        mock_ingest.assert_called_once()
+        kwargs = mock_ingest.call_args.kwargs
+        assert kwargs["source"] == "manual"
+        content = kwargs["content"]
+        # Frontmatter + body assembled from the request fields.
+        parts = content.split("---\n")
+        assert len(parts) >= 3, f"Expected frontmatter delimiters, got: {content}"
         fm = yaml.safe_load(parts[1])
         assert fm["title"] == "My Test Note"
         assert fm["source"] == "manual"
         assert fm["tags"] == ["test", "example"]
         assert fm["type"] == "note"
-        # Content follows the frontmatter
         assert "This is my note content." in parts[2]
 
     def test_create_note_content_required(self, client):
@@ -132,35 +134,32 @@ class TestCreateNote:
         assert r.status_code == 400
         assert "content" in r.json().get("detail", "").lower()
 
-    def test_create_note_generates_title_from_content(self, client, tmp_path):
+    def test_create_note_generates_title_from_content(self, client):
         """POST without title uses first 60 chars of content as title."""
         content = "A short note about something interesting"
-        r = client.post(
-            "/api/knowledge/notes",
-            json={"content": content},
-        )
+        with patch("knowledge.router.ingest_raw") as mock_ingest:
+            mock_ingest.return_value = MagicMock(raw_id="abc123")
+            r = client.post(
+                "/api/knowledge/notes",
+                json={"content": content},
+            )
 
         assert r.status_code == 201
-        path = r.json().get("path", "")
-        written = (tmp_path / path).read_text()
-        parts = written.split("---\n")
-        fm = yaml.safe_load(parts[1])
+        built = mock_ingest.call_args.kwargs["content"]
+        fm = yaml.safe_load(built.split("---\n")[1])
         assert fm["title"] == content[:60]
 
-    def test_create_note_collision_appends_suffix(self, client, tmp_path):
-        """POST with title that collides gets a -1 suffix."""
-        # Pre-create the file at the expected slug path
-        (tmp_path / "my-note.md").write_text("existing")
-
-        r = client.post(
-            "/api/knowledge/notes",
-            json={"content": "New content", "title": "My Note"},
-        )
+    def test_create_note_defaults_source_to_capture(self, client):
+        """POST without source defaults the raw source to 'capture'."""
+        with patch("knowledge.router.ingest_raw") as mock_ingest:
+            mock_ingest.return_value = MagicMock(raw_id="xyz")
+            r = client.post(
+                "/api/knowledge/notes",
+                json={"content": "no source given"},
+            )
 
         assert r.status_code == 201
-        path = r.json().get("path", "")
-        assert path == "my-note-1.md"
-        assert (tmp_path / path).exists()
+        assert mock_ingest.call_args.kwargs["source"] == "capture"
 
 
 def _insert_note(session: Session, *, note_id: str, path: str) -> Note:

--- a/projects/monolith/knowledge/raw_store.py
+++ b/projects/monolith/knowledge/raw_store.py
@@ -1,0 +1,113 @@
+"""S3 storage for raw ingest content (ADR 006 Phase 4c-4).
+
+Raw markdown content is stored content-addressed at
+``s3://knowledge/raws/<content_hash>.md`` on the SeaweedFS S3 gateway, with the
+``knowledge.raw_inputs`` row holding the metadata. This replaces the old
+file-based ``_raw/`` drop that relied on the (now offline) gardener move phase
+to mirror files into Postgres.
+
+The S3 client mirrors stars.grid._s3_client / chat.store._blob_s3_put: dummy
+creds (SeaweedFS auth is disabled cluster-wide, but boto3 needs some value),
+path-style addressing (SeaweedFS only supports it), and a scheme prefixed onto
+the scheme-less endpoint the chart injects. When ``SEAWEEDFS_S3_ENDPOINT`` is
+unset/empty (tests, local dev) the helpers no-op with a logged warning rather
+than guessing a cluster URL.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+logger = logging.getLogger("monolith.knowledge.raw_store")
+
+RAW_BUCKET = "knowledge"
+
+
+def _raw_key(content_hash: str) -> str:
+    """S3 object key for a raw input keyed by its content hash."""
+    return f"raws/{content_hash}.md"
+
+
+def _s3_client():
+    """boto3 S3 client pointed at the SeaweedFS S3 gateway, or None.
+
+    Returns None (logging a warning) when ``SEAWEEDFS_S3_ENDPOINT`` is
+    unset/empty so tests and local dev no-op cleanly. Mirrors
+    stars.grid._s3_client: dummy creds, path-style addressing, scheme prefixed
+    onto the scheme-less host:port the chart injects.
+    """
+    import boto3
+    from botocore.config import Config
+
+    endpoint = os.environ.get("SEAWEEDFS_S3_ENDPOINT", "")
+    if not endpoint:
+        logger.warning("knowledge raw S3 not configured; skipping S3 access")
+        return None
+    if not endpoint.startswith(("http://", "https://")):
+        endpoint = "http://" + endpoint
+    # Scheme guaranteed by the guard above; inline nosemgrep clears the
+    # pre-commit boto3-endpoint-url-missing-scheme hook (the Bazel
+    # main_semgrep_test, which ignores nosemgrep, is covered by exclude_rules
+    # in projects/monolith/BUILD).
+    return boto3.client(  # nosemgrep
+        "s3",
+        endpoint_url=endpoint,
+        aws_access_key_id=os.environ.get("S3_ACCESS_KEY_ID", "duckdb"),
+        aws_secret_access_key=os.environ.get("S3_SECRET_ACCESS_KEY", "duckdb"),
+        region_name=os.environ.get("AWS_REGION", "us-east-1"),
+        config=Config(s3={"addressing_style": "path"}),
+    )
+
+
+def upload_raw(content_hash: str, content: str) -> None:
+    """Upload raw content to S3, idempotently. No-ops when S3 is unconfigured.
+
+    Content-addressed, so a key that already exists (head_object hit) is left
+    untouched. The bucket is auto-created on first write.
+    """
+    from botocore.exceptions import ClientError
+
+    client = _s3_client()
+    if client is None:
+        return
+    key = _raw_key(content_hash)
+    try:
+        client.head_object(Bucket=RAW_BUCKET, Key=key)
+        return
+    except ClientError as exc:
+        code = exc.response.get("Error", {}).get("Code", "")
+        if code not in ("404", "NoSuchKey", "NoSuchBucket", "NotFound"):
+            raise
+    body = content.encode("utf-8")
+    try:
+        client.put_object(
+            Bucket=RAW_BUCKET, Key=key, Body=body, ContentType="text/markdown"
+        )
+    except ClientError as exc:
+        code = exc.response.get("Error", {}).get("Code", "")
+        if code in ("NoSuchBucket", "404"):
+            client.create_bucket(Bucket=RAW_BUCKET)
+            client.put_object(
+                Bucket=RAW_BUCKET, Key=key, Body=body, ContentType="text/markdown"
+            )
+        else:
+            raise
+
+
+def fetch_raw(content_hash: str) -> str | None:
+    """Fetch raw content from S3 by content hash, or None if missing/unconfigured."""
+    from botocore.exceptions import ClientError
+
+    client = _s3_client()
+    if client is None:
+        return None
+    key = _raw_key(content_hash)
+    try:
+        resp = client.get_object(Bucket=RAW_BUCKET, Key=key)
+    except ClientError as exc:
+        code = exc.response.get("Error", {}).get("Code", "")
+        if code in ("404", "NoSuchKey", "NoSuchBucket", "NotFound"):
+            return None
+        raise
+    return resp["Body"].read().decode("utf-8")

--- a/projects/monolith/knowledge/raw_store_test.py
+++ b/projects/monolith/knowledge/raw_store_test.py
@@ -1,0 +1,80 @@
+"""Unit tests for knowledge.raw_store (fileless raw S3 storage, ADR 006)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from botocore.exceptions import ClientError
+
+from knowledge.raw_store import RAW_BUCKET, _raw_key, fetch_raw, upload_raw
+
+
+def _client_error(code: str) -> ClientError:
+    return ClientError({"Error": {"Code": code}}, "Op")
+
+
+def test_raw_key_is_content_addressed():
+    assert _raw_key("abc123") == "raws/abc123.md"
+
+
+class TestUploadRaw:
+    def test_noop_when_no_s3_client(self):
+        """Unconfigured S3 (no client) is a clean no-op, not an error."""
+        with patch("knowledge.raw_store._s3_client", return_value=None):
+            # Should not raise.
+            upload_raw("hash1", "content")
+
+    def test_idempotent_head_hit_skips_put(self):
+        """An existing object (head_object succeeds) is not re-uploaded."""
+        client = MagicMock()
+        client.head_object.return_value = {}
+        with patch("knowledge.raw_store._s3_client", return_value=client):
+            upload_raw("hash1", "content")
+        client.head_object.assert_called_once_with(
+            Bucket=RAW_BUCKET, Key="raws/hash1.md"
+        )
+        client.put_object.assert_not_called()
+
+    def test_puts_when_head_misses(self):
+        """A missing object (head 404) triggers a put_object."""
+        client = MagicMock()
+        client.head_object.side_effect = _client_error("404")
+        with patch("knowledge.raw_store._s3_client", return_value=client):
+            upload_raw("hash2", "the body")
+        client.put_object.assert_called_once_with(
+            Bucket=RAW_BUCKET,
+            Key="raws/hash2.md",
+            Body=b"the body",
+            ContentType="text/markdown",
+        )
+
+    def test_creates_bucket_when_missing(self):
+        """A NoSuchBucket on put triggers create_bucket + retry."""
+        client = MagicMock()
+        client.head_object.side_effect = _client_error("NoSuchBucket")
+        client.put_object.side_effect = [_client_error("NoSuchBucket"), None]
+        with patch("knowledge.raw_store._s3_client", return_value=client):
+            upload_raw("hash3", "body")
+        client.create_bucket.assert_called_once_with(Bucket=RAW_BUCKET)
+        assert client.put_object.call_count == 2
+
+
+class TestFetchRaw:
+    def test_returns_none_when_no_client(self):
+        with patch("knowledge.raw_store._s3_client", return_value=None):
+            assert fetch_raw("hash1") is None
+
+    def test_returns_decoded_content(self):
+        client = MagicMock()
+        client.get_object.return_value = {"Body": MagicMock(read=lambda: b"hello")}
+        with patch("knowledge.raw_store._s3_client", return_value=client):
+            assert fetch_raw("hash1") == "hello"
+        client.get_object.assert_called_once_with(
+            Bucket=RAW_BUCKET, Key="raws/hash1.md"
+        )
+
+    def test_returns_none_on_missing_key(self):
+        client = MagicMock()
+        client.get_object.side_effect = _client_error("NoSuchKey")
+        with patch("knowledge.raw_store._s3_client", return_value=client):
+            assert fetch_raw("missing") is None

--- a/projects/monolith/knowledge/router.py
+++ b/projects/monolith/knowledge/router.py
@@ -42,7 +42,7 @@ from knowledge.gaps import (
 )
 from knowledge.gardener import Gardener, _slugify
 from knowledge.indexing import index_note_best_effort
-from knowledge.ingest_queue import IngestQueueItem
+from knowledge.ingest_queue import IngestQueueItem, ingest_raw
 from knowledge.models import AtomRawProvenance, Note, NoteLink, RawInput
 from knowledge.notes import (
     _note_to_review_dict,
@@ -549,16 +549,19 @@ class CreateNoteRequest(BaseModel):
 
 
 @router.post("/notes", status_code=201)
-def create_note(data: CreateNoteRequest) -> dict:
-    """Capture a new markdown note as a vault-root drop.
+def create_note(
+    data: CreateNoteRequest,
+    session: Session = Depends(get_session),
+) -> dict:
+    """Capture a new markdown note straight into the raw-input pipeline.
 
-    This is a capture path, not direct graph-note creation: the drop is
-    swept into ``_raw/`` by ``raw_ingest`` and decomposed into ``_processed``
-    atoms by the gardener, so its content reaches Postgres via
-    ``raw_inputs`` (and the resulting atoms via the reconciler). It is
-    therefore intentionally NOT indexed into ``knowledge.notes`` here — only
-    ``edit_note``, which mutates an existing ``_processed`` note, indexes
-    synchronously (ADR 006 Phase 3).
+    This is a capture path, not direct graph-note creation: the frontmatter +
+    body is inserted as a ``knowledge.raw_inputs`` row (with the markdown body
+    uploaded to ``s3://knowledge/raws/<raw_id>.md``), no files. The gardener
+    routine later decomposes it into ``_processed`` atoms, so its content
+    reaches the graph via the gardener. It is therefore intentionally NOT
+    indexed into ``knowledge.notes`` here. Only ``edit_note``, which mutates an
+    existing ``_processed`` note, indexes synchronously (ADR 006 Phase 3).
     """
     content = data.content.strip()
     if not content:
@@ -578,22 +581,8 @@ def create_note(data: CreateNoteRequest) -> dict:
     fm_str = yaml.dump(fm_dict, default_flow_style=False, sort_keys=False)
     file_content = f"---\n{fm_str}---\n\n{content}\n"
 
-    vault_root = _get_vault_root()
-    slug = _slugify(title)
-    filename = f"{slug}.md"
-
-    # Handle collisions
-    dest = vault_root / filename
-    counter = 1
-    while dest.exists():
-        filename = f"{slug}-{counter}.md"
-        dest = vault_root / filename
-        counter += 1
-
-    dest.write_text(
-        file_content
-    )  # nosemgrep: tainted-path-traversal-stdlib-fastapi (dest always confined to vault_root via / operator)
-    return {"path": filename}
+    raw = ingest_raw(session, content=file_content, source=data.source or "capture")
+    return {"raw_id": raw.raw_id}
 
 
 @router.get("/dead-letter")


### PR DESCRIPTION
Ingestion writes `knowledge.raw_inputs` + `s3://knowledge/raws/<hash>.md` **directly**, no vault files. The old `_raw/` drop relied on the gardener's `move_phase`/`reconcile_raw_phase` to mirror files into Postgres, but the gardener is offline, so URL-ingested files were landing in the ephemeral `_raw/` and never reaching the DB.

- `knowledge/raw_store.py`: content-addressed S3 helpers (mirrors `stars.grid._s3_client`; no-op when `SEAWEEDFS_S3_ENDPOINT` unset). `upload_raw` idempotent; `fetch_raw` ready for the later `get_raw`->S3 switch.
- `ingest_queue.ingest_raw(...)`: sha256 `raw_id`, dedup, S3 upload + `RawInput` insert. `ingest_handler` (URL queue) uses it; `_write_raw_md` deleted.
- `router.create_note` (capture endpoint): inserts a `raw_inputs` row + S3 object instead of a vault drop; returns `{raw_id}` (no frontend consumer of the old `{path}`).

`raw_ingest.py` + the gardener's move/reconcile calls retire with the gardener in 4c-5. Tests + BUILD targets added. Builds on 4c-1/4c-2/4c-3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)