### PR TITLE
feat(monolith): /app/dr-jobs NHS Scotland anaesthetics vacancy aggregator

### DIFF
--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -12,6 +12,7 @@
 # gazelle:exclude hikes
 # gazelle:exclude stars
 # gazelle:exclude trips
+# gazelle:exclude dr_jobs
 # gazelle:semgrep_exclude_rules avoid-sqlalchemy-text,sqlmodel-datetime-without-factory,tainted-fastapi-http-request-httpx,tainted-path-traversal-stdlib-fastapi
 load("@aspect_rules_py//py:defs.bzl", "py_library")
 load("@aspect_rules_py//py/private/py_venv:defs.bzl", "py_venv_binary")
@@ -46,6 +47,7 @@ py_venv_binary(
             "hikes/**/*.py",
             "stars/**/*.py",
             "trips/**/*.py",
+            "dr_jobs/**/*.py",
         ],
         exclude = [
             # pytest discovers both *_test.py (sibling convention) and
@@ -107,6 +109,7 @@ py_library(
             "hikes/**/*.py",
             "stars/**/*.py",
             "trips/**/*.py",
+            "dr_jobs/**/*.py",
         ],
         exclude = [
             # pytest discovers both *_test.py (sibling convention) and
@@ -2180,6 +2183,53 @@ py_test(
     deps = [
         ":monolith_backend",
         "@pip//pytest",
+    ],
+)
+
+py_test(
+    name = "dr_jobs_models_test",
+    srcs = ["dr_jobs/models_test.py"],
+    imports = ["."],
+    deps = [
+        ":monolith_backend",
+        "@pip//pytest",
+        "@pip//sqlmodel",
+    ],
+)
+
+py_test(
+    name = "dr_jobs_scraper_test",
+    srcs = ["dr_jobs/scraper_test.py"],
+    imports = ["."],
+    deps = [
+        ":monolith_backend",
+        "@pip//httpx",
+        "@pip//pytest",
+        "@pip//pytest_asyncio",
+    ],
+)
+
+py_test(
+    name = "dr_jobs_router_test",
+    srcs = ["dr_jobs/router_test.py"],
+    imports = ["."],
+    deps = [
+        ":monolith_backend",
+        "@pip//fastapi",
+        "@pip//httpx",
+        "@pip//pytest",
+        "@pip//sqlmodel",
+    ],
+)
+
+py_test(
+    name = "dr_jobs_jobs_test",
+    srcs = ["dr_jobs/jobs_test.py"],
+    imports = ["."],
+    deps = [
+        ":monolith_backend",
+        "@pip//pytest",
+        "@pip//sqlmodel",
     ],
 )
 

--- a/projects/monolith/app/main.py
+++ b/projects/monolith/app/main.py
@@ -11,6 +11,7 @@ from fastapi.staticfiles import StaticFiles
 
 from app.log import configure_logging
 import chat
+import dr_jobs
 import hikes
 import home
 import knowledge
@@ -70,6 +71,7 @@ async def lifespan(app: FastAPI):
         ships.on_startup_jobs(session)
         hikes.on_startup_jobs(session)
         stars.on_startup_jobs(session)
+        dr_jobs.on_startup_jobs(session)
 
     # Start Discord bot + chat jobs if configured
     bot = None
@@ -224,6 +226,7 @@ scheduler.register(app)
 ships.register(app)
 hikes.register(app)
 stars.register(app)
+dr_jobs.register(app)
 app.mount("/mcp", _mcp_app)
 
 

--- a/projects/monolith/app/main_vault_sync_test.py
+++ b/projects/monolith/app/main_vault_sync_test.py
@@ -24,6 +24,7 @@ async def test_lifespan_calls_clone_vault():
         patch("ships.on_startup_jobs"),
         patch("hikes.on_startup_jobs"),
         patch("stars.on_startup_jobs"),
+        patch("dr_jobs.on_startup_jobs"),
     ):
         from app.main import lifespan, app
 

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.143.5
+version: 0.144.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.144.0
+version: 0.144.1
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/migrations/20260616130000_dr_jobs_schema.sql
+++ b/projects/monolith/chart/migrations/20260616130000_dr_jobs_schema.sql
@@ -1,0 +1,30 @@
+-- dr_jobs schema: NHS Scotland (apply.jobs.scot.nhs.uk) vacancy aggregator.
+--
+-- nhs_vacancies : one row per JobTrain vacancy, keyed by the numeric JobId.
+--   The daily scrape (dr_jobs.scrape_nhs) upserts the structured JSON-LD
+--   fields and stamps last_seen_at. Rows are never deleted: the live view
+--   filters on last_seen_at + closing_date, the history view shows the rest.
+--   The filter scope (keyword + salary bands) lives in the scraper, not here.
+
+CREATE SCHEMA IF NOT EXISTS dr_jobs;
+
+CREATE TABLE dr_jobs.nhs_vacancies (
+    job_id              TEXT PRIMARY KEY,
+    reference           TEXT NOT NULL DEFAULT '',
+    title               TEXT NOT NULL,
+    employment_type     TEXT NOT NULL DEFAULT '',
+    salary_band         TEXT NOT NULL DEFAULT '',
+    salary_text         TEXT NOT NULL DEFAULT '',
+    town                TEXT NOT NULL DEFAULT '',
+    postcode            TEXT NOT NULL DEFAULT '',
+    region              TEXT NOT NULL DEFAULT '',
+    posted_date         DATE,
+    closing_date        DATE,
+    url                 TEXT NOT NULL,
+    first_seen_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+    last_seen_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
+    scraped_at          TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_nhs_vacancies_closing ON dr_jobs.nhs_vacancies (closing_date);
+CREATE INDEX idx_nhs_vacancies_last_seen ON dr_jobs.nhs_vacancies (last_seen_at DESC);

--- a/projects/monolith/chart/migrations/atlas.sum
+++ b/projects/monolith/chart/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:DzYCq5++PEYk2Br2c+BeHfRpR/b3g8p5wnum8vXZnvE=
+h1:BNd2cU6RuSz4/VDX0RZo/ag61R49sMVhEhkD0wY2P0k=
 20260330000000_initial_schema.sql h1:J2futpSW0nJAIRR7nR7ssT7LwXIYrvRI+PkHb5Y4tLI=
 20260403000000_chat_schema.sql h1:pERUFC0vzM95etRuzp43XzkCV7lBCzrrtY5Mk7aF3CA=
 20260404000000_chat_attachments.sql h1:tv+Fdbr1rQC5nzUxfaBC0O6fu2OMGgLWf+YNg1WQXi4=
@@ -45,3 +45,4 @@ h1:DzYCq5++PEYk2Br2c+BeHfRpR/b3g8p5wnum8vXZnvE=
 20260615000020_knowledge_notes_content_column.sql h1:b4MUb3rORQg42bRQ/jVy54YIKn8cx46nO202F54DWMY=
 20260615120000_trips_schema.sql h1:yN+REAy71uuXowKKwhPdBh61zJ0zbdb6Oe6eszzbcK0=
 20260616120000_drop_raw_inputs_content.sql h1:qqk/jqkPbF7Ivb5CJOfbZVpiOEBrt8s48LCpHqAvS/Y=
+20260616130000_dr_jobs_schema.sql h1:lGsOevT79e9N0UJPW4h10MMPGk9xYl3rquNi5FKZiMQ=

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.143.5
+      targetRevision: 0.144.0
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.144.0
+      targetRevision: 0.144.1
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/deploy/values.yaml
+++ b/projects/monolith/deploy/values.yaml
@@ -143,5 +143,6 @@ agent:
     defaultChannelId: "1501965852969402517"
     allowedChannelIds:
       - "1501965852969402517"
+      - "1516663194699960382" # dr-jobs new-vacancy digest
   signoz:
     url: "http://signoz.signoz.svc.cluster.local:8080/app/signoz"

--- a/projects/monolith/dr_jobs/__init__.py
+++ b/projects/monolith/dr_jobs/__init__.py
@@ -1,0 +1,32 @@
+"""dr_jobs: in-monolith NHS Scotland vacancy aggregator (/app/dr-jobs).
+
+Scrapes apply.jobs.scot.nhs.uk daily for anaesthetics-consultant posts and
+serves them as a live/history listing table. Same shape as the hikes domain:
+a scheduled scrape job upserts a Postgres table, an SSR-only read endpoint backs
+the page, and the CDN fans the result out.
+"""
+
+from fastapi import FastAPI
+from sqlmodel import Session
+
+
+def register(app: FastAPI) -> None:
+    """Register the dr_jobs router with the app."""
+    from dr_jobs.router import router
+
+    app.include_router(router)
+
+
+def on_startup_jobs(session: Session) -> None:
+    """Register the daily NHS Scotland scrape job."""
+    from shared.scheduler import register_job
+
+    from dr_jobs.jobs import scrape_nhs_handler
+
+    register_job(
+        session,
+        name="dr_jobs.scrape_nhs",
+        interval_secs=86400,  # daily; NHS consultant posts turn over slowly
+        handler=scrape_nhs_handler,
+        ttl_secs=3600,  # generous: each run fetches a heavy detail page per job
+    )

--- a/projects/monolith/dr_jobs/jobs.py
+++ b/projects/monolith/dr_jobs/jobs.py
@@ -1,0 +1,190 @@
+"""Scheduled job handler for the dr_jobs domain.
+
+scrape_nhs_handler runs the daily NHS Scotland vacancy scrape. The network
+phase runs in the async handler and the synchronous Session upsert is delegated
+to a worker thread (asyncio.to_thread) so it never blocks the scheduler event
+loop, mirroring hikes.scrape_walks_handler. The scheduler passes a session, but
+the DB work uses its own session inside the thread.
+
+When the upsert inserts genuinely new vacancies (and the run was not the initial
+seed of an empty table), the handler posts a one-message Discord digest to the
+dr-jobs channel so the partner is pinged the day a post appears.
+"""
+
+import asyncio
+import logging
+import os
+from datetime import date, datetime, timezone
+
+import httpx
+
+from dr_jobs import models
+from dr_jobs.scraper import fetch_vacancies
+
+logger = logging.getLogger("dr_jobs")
+
+# Client-level ceiling; per-request timeouts in scraper.py are tighter.
+SCRAPE_TIMEOUT_SECS = 60.0
+
+# Discord channel for the new-jobs digest (same server as the monolith bot).
+# Must be present in MONOLITH_AGENT_DISCORD_ALLOWED_CHANNEL_IDS (see
+# deploy/values.yaml agent.discord.allowedChannelIds) or notify() rejects it.
+DISCORD_CHANNEL_ID = os.environ.get("DR_JOBS_DISCORD_CHANNEL_ID", "1516663194699960382")
+
+# Cap the digest so a large batch (or first real scrape after a long gap) cannot
+# blow past Discord's 2000-char message limit.
+_DIGEST_MAX_LISTED = 12
+
+_MONTHS = (
+    "Jan",
+    "Feb",
+    "Mar",
+    "Apr",
+    "May",
+    "Jun",
+    "Jul",
+    "Aug",
+    "Sep",
+    "Oct",
+    "Nov",
+    "Dec",
+)
+
+# Vacancy dict keys that map straight onto Vacancy columns (timestamps excluded:
+# the upsert manages first_seen_at / last_seen_at / scraped_at itself).
+_FIELDS = (
+    "reference",
+    "title",
+    "employment_type",
+    "salary_band",
+    "salary_text",
+    "town",
+    "postcode",
+    "region",
+    "posted_date",
+    "closing_date",
+    "url",
+)
+
+
+def _persist(vacancies: list[dict]) -> tuple[list[dict], int, bool]:
+    """Upsert scraped vacancies in a fresh session.
+
+    Returns (new_vacancies, updated_count, was_seed). new_vacancies is the list
+    of dicts that were inserted (used for the Discord digest); was_seed is True
+    when the table was empty before this run, so the caller suppresses the
+    digest on the initial backfill.
+
+    Option A lifecycle: insert unseen JobIds (stamping first_seen_at), refresh
+    every field plus last_seen_at on seen ones, and never delete. A vacancy that
+    has dropped off the site simply stops having last_seen_at advanced, so the
+    read endpoint ages it out of the live view. Runs off the event loop via
+    asyncio.to_thread.
+    """
+    from sqlmodel import Session, func, select
+
+    from app.db import get_engine
+
+    now = datetime.now(timezone.utc)
+    new_vacancies: list[dict] = []
+    new_rows: list[models.Vacancy] = []
+    updated = 0
+    with Session(get_engine()) as session:
+        pre_count = session.exec(select(func.count()).select_from(models.Vacancy)).one()
+        was_seed = pre_count == 0
+        for vac in vacancies:
+            existing = session.get(models.Vacancy, vac["job_id"])
+            if existing is None:
+                new_vacancies.append(vac)
+                new_rows.append(
+                    models.Vacancy(
+                        **vac,
+                        first_seen_at=now,
+                        last_seen_at=now,
+                        scraped_at=now,
+                    )
+                )
+                continue
+            for field in _FIELDS:
+                setattr(existing, field, vac[field])
+            existing.last_seen_at = now
+            existing.scraped_at = now
+            updated += 1
+            # session.get rows are tracked; attribute writes flush on commit
+            # without a session.add in the loop.
+
+        if new_rows:
+            session.add_all(new_rows)
+        session.commit()
+    return new_vacancies, updated, was_seed
+
+
+def _fmt_closing(value: date | None) -> str:
+    """'12 Jul' for a date, or 'no closing date'."""
+    if value is None:
+        return "no closing date"
+    return f"{value.day} {_MONTHS[value.month - 1]}"
+
+
+def build_digest(new_vacancies: list[dict]) -> str:
+    """Format the Discord digest for newly-seen vacancies (no em-dashes)."""
+    n = len(new_vacancies)
+    plural = "s" if n != 1 else ""
+    lines = [f"\U0001fa7a {n} new NHS Scotland anaesthetics consultant job{plural}:"]
+    for vac in new_vacancies[:_DIGEST_MAX_LISTED]:
+        where = vac.get("town") or "location TBC"
+        lines.append(
+            f"• {vac['title'].strip()} · {where}, "
+            f"closes {_fmt_closing(vac.get('closing_date'))}"
+        )
+    if n > _DIGEST_MAX_LISTED:
+        lines.append(f"...and {n - _DIGEST_MAX_LISTED} more")
+    lines.append("https://jomcgi.dev/app/dr-jobs")
+    return "\n".join(lines)
+
+
+async def _send_digest(new_vacancies: list[dict]) -> None:
+    """Post the new-jobs digest to Discord. Never raises (a notify failure must
+    not fail an otherwise-successful scrape)."""
+    try:
+        from agent.notify import notify
+
+        await notify(build_digest(new_vacancies), channel=DISCORD_CHANNEL_ID)
+    except Exception:  # noqa: BLE001 - best-effort side channel
+        logger.warning("dr_jobs: failed to post new-jobs Discord digest", exc_info=True)
+
+
+async def scrape_nhs_handler(session) -> datetime | None:
+    """Daily NHS Scotland scrape: full network phase, then one upsert pass.
+
+    If the scrape produced nothing (transient site outage), keep the existing
+    rows and write nothing, so the live view degrades to "stale" rather than
+    "empty".
+    """
+    async with httpx.AsyncClient(
+        follow_redirects=True, timeout=SCRAPE_TIMEOUT_SECS
+    ) as client:
+        vacancies, stats = await fetch_vacancies(client)
+
+    if not vacancies:
+        logger.error(
+            "dr_jobs scrape: zero vacancies, keeping existing rows (stats: %s)",
+            stats,
+        )
+        return None
+
+    new_vacancies, updated, was_seed = await asyncio.to_thread(_persist, vacancies)
+    logger.info(
+        "dr_jobs scrape: upserted %d vacancies (%d new, %d updated) seed=%s stats=%s",
+        len(vacancies),
+        len(new_vacancies),
+        updated,
+        was_seed,
+        stats,
+    )
+
+    # Suppress the digest on the initial backfill (every row is "new" then).
+    if new_vacancies and not was_seed:
+        await _send_digest(new_vacancies)
+
+    return None

--- a/projects/monolith/dr_jobs/jobs_test.py
+++ b/projects/monolith/dr_jobs/jobs_test.py
@@ -1,0 +1,112 @@
+"""Unit tests for dr_jobs.jobs.
+
+build_digest is pure (no DB/network). _persist is exercised against in-memory
+SQLite by monkeypatching app.db.get_engine to the test engine (it opens its own
+session from get_engine, mirroring hikes._persist_walks). Asserts the Option A
+lifecycle: seed suppression, insert vs update accounting, and that an unseen
+JobId is what counts as "new".
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+from sqlmodel import Session, SQLModel, create_engine, select
+from sqlmodel.pool import StaticPool
+
+import app.db as app_db
+import dr_jobs.jobs as jobs
+from dr_jobs.models import Vacancy
+
+
+@pytest.fixture(name="engine")
+def engine_fixture(monkeypatch):
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    original_schemas = {}
+    for table in SQLModel.metadata.tables.values():
+        if table.schema is not None:
+            original_schemas[table.name] = table.schema
+            table.schema = None
+    try:
+        SQLModel.metadata.create_all(engine)
+        # _persist opens Session(get_engine()); point it at the test engine.
+        monkeypatch.setattr(app_db, "get_engine", lambda: engine)
+        yield engine
+    finally:
+        for table in SQLModel.metadata.tables.values():
+            if table.name in original_schemas:
+                table.schema = original_schemas[table.name]
+
+
+def _vac(job_id, title="PS1 - Consultant Anaesthetist", closing=date(2026, 7, 12)):
+    return {
+        "job_id": job_id,
+        "reference": "PS1",
+        "title": title,
+        "employment_type": "Permanent",
+        "salary_band": "Consultant",
+        "salary_text": "Consultant (£111,430 - £148,064)",
+        "town": "Elgin",
+        "postcode": "IV30 1SN",
+        "region": "",
+        "posted_date": date(2026, 6, 10),
+        "closing_date": closing,
+        "url": f"https://apply.jobs.scot.nhs.uk/Job/JobDetail?JobId={job_id}",
+    }
+
+
+class TestPersist:
+    def test_seed_run_inserts_but_flags_seed(self, engine):
+        new, updated, was_seed = jobs._persist([_vac("A"), _vac("B")])
+        assert was_seed is True  # table was empty
+        assert {v["job_id"] for v in new} == {"A", "B"}
+        assert updated == 0
+        with Session(engine) as s:
+            assert len(s.exec(select(Vacancy)).all()) == 2
+
+    def test_second_run_detects_new_and_updates(self, engine):
+        jobs._persist([_vac("A")])  # seed
+        new, updated, was_seed = jobs._persist(
+            [_vac("A", title="PS1 - Consultant Anaesthetist (amended)"), _vac("B")]
+        )
+        assert was_seed is False
+        assert [v["job_id"] for v in new] == ["B"]  # only B is unseen
+        assert updated == 1  # A refreshed
+        with Session(engine) as s:
+            a = s.get(Vacancy, "A")
+            assert a.title.endswith("(amended)")
+
+    def test_first_seen_preserved_on_update(self, engine):
+        jobs._persist([_vac("A")])
+        with Session(engine) as s:
+            first_seen = s.get(Vacancy, "A").first_seen_at
+        jobs._persist([_vac("A")])
+        with Session(engine) as s:
+            assert s.get(Vacancy, "A").first_seen_at == first_seen
+
+
+class TestBuildDigest:
+    def test_lists_jobs_with_count_and_link(self):
+        msg = jobs.build_digest([_vac("A", title="Consultant Anaesthetist")])
+        assert "1 new NHS Scotland anaesthetics consultant job:" in msg
+        assert "• Consultant Anaesthetist · Elgin, closes 12 Jul" in msg
+        assert "https://jomcgi.dev/app/dr-jobs" in msg
+
+    def test_plural_and_no_em_dash(self):
+        msg = jobs.build_digest([_vac("A"), _vac("B")])
+        assert "2 new NHS Scotland anaesthetics consultant jobs:" in msg
+        assert "—" not in msg  # never an em-dash (house style)
+
+    def test_caps_long_batches(self):
+        many = [_vac(str(i), title=f"Job {i}") for i in range(20)]
+        msg = jobs.build_digest(many)
+        assert "...and 8 more" in msg
+
+    def test_missing_closing_date(self):
+        msg = jobs.build_digest([_vac("A", closing=None)])
+        assert "no closing date" in msg

--- a/projects/monolith/dr_jobs/models.py
+++ b/projects/monolith/dr_jobs/models.py
@@ -1,0 +1,38 @@
+"""SQLModel definitions for the dr_jobs schema (NHS Scotland vacancy aggregator).
+
+Mirrors chart/migrations/20260616130000_dr_jobs_schema.sql.
+
+One row per NHS JobTrain vacancy on apply.jobs.scot.nhs.uk, keyed by the numeric
+JobId from the listing. The daily scrape upserts the structured JSON-LD fields
+and stamps last_seen_at. Rows are never deleted (Option A lifecycle): a closed
+posting drops out of the live view (which filters on last_seen_at + closing_date)
+but stays queryable for the history view.
+"""
+
+from datetime import date, datetime, timezone
+
+from sqlmodel import Field, SQLModel
+
+
+class Vacancy(SQLModel, table=True):  # nosemgrep: sqlmodel-datetime-without-factory
+    __tablename__ = "nhs_vacancies"
+    __table_args__ = {"schema": "dr_jobs", "extend_existing": True}
+
+    # The numeric JobTrain JobId (e.g. "256437"); stable across re-scrapes.
+    job_id: str = Field(primary_key=True)
+    # Leading board reference parsed from the title (e.g. "PS246039"); "" if none.
+    reference: str = Field(default="")
+    title: str
+    employment_type: str = Field(default="")
+    # Salary band name ("Consultant" / "Locum Consultant") split off salary_text.
+    salary_band: str = Field(default="")
+    salary_text: str = Field(default="")
+    town: str = Field(default="")
+    postcode: str = Field(default="")
+    region: str = Field(default="")
+    posted_date: date | None = None
+    closing_date: date | None = None
+    url: str
+    first_seen_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    last_seen_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    scraped_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))

--- a/projects/monolith/dr_jobs/models_test.py
+++ b/projects/monolith/dr_jobs/models_test.py
@@ -1,0 +1,85 @@
+"""Unit tests for dr_jobs/models.py on SQLite (create_all, no migrations).
+
+Mirrors hikes/models_test: strip the Postgres-only schema= override so
+SQLModel.metadata.create_all() lands the table in SQLite's default schema, then
+round-trip a row.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+
+import pytest
+from sqlmodel import Session, SQLModel, create_engine
+from sqlmodel.pool import StaticPool
+
+from dr_jobs.models import Vacancy
+
+
+@pytest.fixture(name="session")
+def session_fixture():
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    original_schemas = {}
+    for table in SQLModel.metadata.tables.values():
+        if table.schema is not None:
+            original_schemas[table.name] = table.schema
+            table.schema = None
+    try:
+        SQLModel.metadata.create_all(engine)
+        with Session(engine) as session:
+            yield session
+    finally:
+        for table in SQLModel.metadata.tables.values():
+            if table.name in original_schemas:
+                table.schema = original_schemas[table.name]
+
+
+def test_round_trip(session: Session):
+    now = datetime.now(timezone.utc)
+    session.add(
+        Vacancy(
+            job_id="256437",
+            reference="PS246039",
+            title="PS246039 - Consultant Anaesthetist",
+            employment_type="Permanent",
+            salary_band="Consultant",
+            salary_text="Consultant (£111,430 - £148,064)",
+            town="Elgin",
+            postcode="IV30 1SN",
+            posted_date=date(2026, 6, 10),
+            closing_date=date(2026, 7, 12),
+            url="https://apply.jobs.scot.nhs.uk/Job/JobDetail?JobId=256437",
+            first_seen_at=now,
+            last_seen_at=now,
+            scraped_at=now,
+        )
+    )
+    session.commit()
+
+    row = session.get(Vacancy, "256437")
+    assert row is not None
+    assert row.reference == "PS246039"
+    assert row.salary_band == "Consultant"
+    assert row.closing_date == date(2026, 7, 12)
+    assert isinstance(row.first_seen_at, datetime)
+
+
+def test_defaults(session: Session):
+    # Optional text fields default to "", dates to None.
+    session.add(
+        Vacancy(
+            job_id="1",
+            title="Consultant in Paediatric Anaesthesia",
+            url="https://example.invalid/Job/JobDetail?JobId=1",
+        )
+    )
+    session.commit()
+    row = session.get(Vacancy, "1")
+    assert row.reference == ""
+    assert row.salary_band == ""
+    assert row.posted_date is None
+    assert row.closing_date is None

--- a/projects/monolith/dr_jobs/router.py
+++ b/projects/monolith/dr_jobs/router.py
@@ -1,0 +1,145 @@
+"""dr_jobs HTTP API. SSR-only: never added to httproute-public.yaml.
+
+One read endpoint backs the /app/dr-jobs listing:
+
+- ``GET /api/dr-jobs/listings`` returns every scraped vacancy with a server
+  computed ``is_live`` flag. Live = seen in the most recent scrape (last_seen_at
+  within LIVE_GRACE) AND not past its closing date; everything else is history.
+  The page renders both from one payload and toggles between them client-side,
+  so the History button needs no second request.
+
+Reached only from SvelteKit SSR (``http://localhost:8000`` in the same pod); the
+/app/dr-jobs page is the public surface and the CDN fans the result out. The
+ETag folds in the day so the live/history split turns over at midnight even when
+no scrape has run, and conditional GETs short-circuit with a 304.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import date, datetime, timedelta, timezone
+
+from fastapi import APIRouter, Depends, Request, Response
+from sqlmodel import Session, select
+
+from app.db import get_session
+from dr_jobs.models import Vacancy
+
+logger = logging.getLogger("dr_jobs")
+
+router = APIRouter(prefix="/api/dr-jobs", tags=["dr_jobs"])
+
+# A vacancy counts as "live" if it was seen within this window of the last
+# scrape. The scrape runs daily, so 36 h tolerates a single missed/late run
+# before a post ages out of the live view; a longer gap correctly demotes it.
+LIVE_GRACE = timedelta(hours=36)
+
+# Scrape runs daily, so 30 min edge freshness with a 1 h SWR window is plenty.
+# Mirrors DR_JOBS_LISTINGS_CACHE_CONTROL in
+# frontend/src/lib/cache-headers.js, keep in sync.
+_LISTINGS_CACHE_CONTROL = "public, max-age=0, s-maxage=1800, stale-while-revalidate=3600, stale-if-error=86400"
+
+# Bump when the listings response SHAPE changes (fields added/removed/renamed),
+# so a shape-only code deploy busts every client's data-derived ETag.
+_LISTINGS_SCHEMA_VERSION = "v1"
+
+
+def _as_utc(value: datetime | None) -> datetime | None:
+    """Coerce a datetime to tz-aware UTC.
+
+    Postgres returns tz-aware values; SQLite (tests) can return naive ones even
+    though we always write tz-aware UTC. Treat naive as UTC so ETag stamps and
+    the live cutoff comparison stay stable across both backends.
+    """
+    if value is None:
+        return None
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+def _is_live(row: Vacancy, cutoff: datetime, today: date) -> bool:
+    """Live = seen in the latest scrape AND not past its closing date."""
+    last_seen = _as_utc(row.last_seen_at)
+    if last_seen is None or last_seen < cutoff:
+        return False
+    return row.closing_date is None or row.closing_date >= today
+
+
+def _listings_etag(count: int, today: date, max_seen: datetime | None) -> str:
+    """Stable ETag: schema token + day (live/history rolls at midnight) + the
+    freshest last_seen_at (busts on a scrape) + row count (busts on add/drop)."""
+    stamp = max_seen.isoformat() if max_seen is not None else "null"
+    return f'"{_LISTINGS_SCHEMA_VERSION}-{today.isoformat()}-{stamp}-{count}"'
+
+
+def _serialize(row: Vacancy, is_live: bool) -> dict:
+    return {
+        "job_id": row.job_id,
+        "reference": row.reference,
+        "title": row.title,
+        "employment_type": row.employment_type,
+        "salary_band": row.salary_band,
+        "salary_text": row.salary_text,
+        "town": row.town,
+        "postcode": row.postcode,
+        "region": row.region,
+        "posted_date": row.posted_date.isoformat() if row.posted_date else None,
+        "closing_date": row.closing_date.isoformat() if row.closing_date else None,
+        "url": row.url,
+        "first_seen_at": _as_utc(row.first_seen_at).isoformat()
+        if row.first_seen_at
+        else None,
+        "is_live": is_live,
+    }
+
+
+@router.get("/listings")
+def get_listings(
+    request: Request,
+    response: Response,
+    session: Session = Depends(get_session),
+):
+    """Every scraped vacancy with an is_live flag. SSR-only, CDN-cached.
+
+    Live rows sort by soonest closing first (what the partner acts on); history
+    rows sort by most-recently closed first. The single payload carries both so
+    the page's Live/History toggle is purely client-side.
+    """
+    now = datetime.now(timezone.utc)
+    today = now.date()
+    cutoff = now - LIVE_GRACE
+
+    rows = session.exec(select(Vacancy)).all()
+
+    max_seen: datetime | None = None
+    for row in rows:
+        seen = _as_utc(row.last_seen_at)
+        if seen is not None and (max_seen is None or seen > max_seen):
+            max_seen = seen
+
+    live: list[dict] = []
+    history: list[dict] = []
+    for row in rows:
+        live_flag = _is_live(row, cutoff, today)
+        (live if live_flag else history).append(_serialize(row, live_flag))
+
+    # Soonest-closing first for live; most-recently-closing first for history.
+    # date.max/min keep null closing dates out of the way at each end.
+    live.sort(key=lambda j: j["closing_date"] or date.max.isoformat())
+    history.sort(key=lambda j: j["closing_date"] or date.min.isoformat(), reverse=True)
+    jobs = live + history
+
+    etag = _listings_etag(len(jobs), today, max_seen)
+    headers = {"Cache-Control": _LISTINGS_CACHE_CONTROL, "ETag": etag}
+    if request.headers.get("if-none-match") == etag:
+        return Response(status_code=304, headers=headers)
+
+    for key, value in headers.items():
+        response.headers[key] = value
+    return {
+        "count": len(jobs),
+        "live_count": len(live),
+        "generated_at": max_seen.isoformat() if max_seen is not None else None,
+        "jobs": jobs,
+    }

--- a/projects/monolith/dr_jobs/router_test.py
+++ b/projects/monolith/dr_jobs/router_test.py
@@ -1,0 +1,143 @@
+"""Unit tests for dr_jobs/router.py: /api/dr-jobs/listings.
+
+In-memory SQLite seeded with live, closed, and aged-out rows, mounted on a
+minimal FastAPI app via app.dependency_overrides[get_session], mirroring
+hikes/router_test. Asserts the server-computed is_live split, the live/history
+ordering, and the ETag/304 path.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta, timezone
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlmodel import Session, SQLModel, create_engine
+from sqlmodel.pool import StaticPool
+
+from app.db import get_session
+from dr_jobs.models import Vacancy
+from dr_jobs.router import router
+
+NOW = datetime.now(timezone.utc)
+TODAY = NOW.date()
+STALE_SEEN = NOW - timedelta(hours=48)  # older than LIVE_GRACE (36h)
+
+
+@pytest.fixture(name="session")
+def session_fixture():
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    original_schemas = {}
+    for table in SQLModel.metadata.tables.values():
+        if table.schema is not None:
+            original_schemas[table.name] = table.schema
+            table.schema = None
+    try:
+        SQLModel.metadata.create_all(engine)
+        with Session(engine) as session:
+            yield session
+    finally:
+        for table in SQLModel.metadata.tables.values():
+            if table.name in original_schemas:
+                table.schema = original_schemas[table.name]
+
+
+@pytest.fixture(name="client")
+def client_fixture(session):
+    app = FastAPI()
+    app.include_router(router)
+    app.dependency_overrides[get_session] = lambda: session
+    yield TestClient(app)
+    app.dependency_overrides.clear()
+
+
+def _vac(job_id, *, title, closing, last_seen=NOW, town="Elgin"):
+    return Vacancy(
+        job_id=job_id,
+        title=title,
+        town=town,
+        closing_date=closing,
+        url=f"https://apply.jobs.scot.nhs.uk/Job/JobDetail?JobId={job_id}",
+        first_seen_at=NOW,
+        last_seen_at=last_seen,
+        scraped_at=last_seen,
+    )
+
+
+def _seed(session):
+    # Live: seen now, closes in the future (soonest first after sort).
+    session.add(_vac("A", title="Live soon", closing=TODAY + timedelta(days=2)))
+    session.add(_vac("B", title="Live later", closing=TODAY + timedelta(days=20)))
+    # History: seen now but past its closing date.
+    session.add(_vac("C", title="Closed", closing=TODAY - timedelta(days=3)))
+    # History: still open but not seen in the last scrape (aged out).
+    session.add(
+        _vac(
+            "D", title="Stale", closing=TODAY + timedelta(days=5), last_seen=STALE_SEEN
+        )
+    )
+    session.commit()
+
+
+class TestListings:
+    def test_split_and_ordering(self, client, session):
+        _seed(session)
+        body = client.get("/api/dr-jobs/listings").json()
+        assert body["count"] == 4
+        assert body["live_count"] == 2
+
+        ids = [j["job_id"] for j in body["jobs"]]
+        # Live first (soonest closing: A before B), then history.
+        assert ids[:2] == ["A", "B"]
+        assert set(ids[2:]) == {"C", "D"}
+
+        flags = {j["job_id"]: j["is_live"] for j in body["jobs"]}
+        assert flags == {"A": True, "B": True, "C": False, "D": False}
+
+    def test_serialized_fields(self, client, session):
+        _seed(session)
+        body = client.get("/api/dr-jobs/listings").json()
+        a = next(j for j in body["jobs"] if j["job_id"] == "A")
+        assert a["title"] == "Live soon"
+        assert a["closing_date"] == (TODAY + timedelta(days=2)).isoformat()
+        assert a["url"].endswith("JobId=A")
+        assert a["is_live"] is True
+
+    def test_cache_and_etag_headers(self, client, session):
+        _seed(session)
+        r = client.get("/api/dr-jobs/listings")
+        assert r.status_code == 200
+        assert (
+            r.headers["Cache-Control"]
+            == "public, max-age=0, s-maxage=1800, stale-while-revalidate=3600, stale-if-error=86400"
+        )
+        assert r.headers["ETag"].startswith(f'"v1-{TODAY.isoformat()}-')
+
+    def test_conditional_get_returns_304(self, client, session):
+        _seed(session)
+        etag = client.get("/api/dr-jobs/listings").headers["ETag"]
+        second = client.get("/api/dr-jobs/listings", headers={"If-None-Match": etag})
+        assert second.status_code == 304
+        assert second.headers["ETag"] == etag
+
+    def test_empty(self, client):
+        body = client.get("/api/dr-jobs/listings").json()
+        assert body == {
+            "count": 0,
+            "live_count": 0,
+            "generated_at": None,
+            "jobs": [],
+        }
+
+    def test_null_closing_date_is_live_when_recently_seen(self, client, session):
+        session.add(_vac("E", title="No closing", closing=None))
+        session.commit()
+        body = client.get("/api/dr-jobs/listings").json()
+        assert body["live_count"] == 1
+        assert body["jobs"][0]["is_live"] is True
+        assert body["jobs"][0]["closing_date"] is None

--- a/projects/monolith/dr_jobs/scraper.py
+++ b/projects/monolith/dr_jobs/scraper.py
@@ -1,0 +1,206 @@
+"""Scrape NHS Scotland anaesthetics-consultant vacancies from apply.jobs.scot.nhs.uk.
+
+The JobTrain site is a two-tier scrape:
+
+- ``GET /Home/_JobCard?what=<kw>&Salary=<bands>&Skip=<n>`` is the AJAX list
+  endpoint the vacancies page itself calls. It returns a partial HTML fragment
+  of job cards (``data-jobId`` attributes) plus a ``totalMatchRecords`` hidden
+  input for pagination. No auth, no antiforgery token, no reCAPTCHA on GET.
+- ``GET /Job/JobDetail?JobId=<id>`` carries a schema.org ``JobPosting`` JSON-LD
+  block (published for Google Jobs indexing). We parse the structured fields
+  from there rather than scraping presentational HTML, so a cosmetic redesign
+  of the site does not break us.
+
+The pure parse helpers (parse_job_ids, parse_detail) take HTML strings so the
+unit tests can exercise them against fixtures with no network. fetch_vacancies
+orchestrates the network phase and never raises: it logs and counts failures in
+the stats dict and returns whatever it managed to gather, mirroring the
+hikes/ships scrape handlers (a transient outage must not wipe the corpus).
+"""
+
+from __future__ import annotations
+
+import html as ihtml
+import json
+import logging
+import os
+import re
+from datetime import date
+
+import httpx
+
+logger = logging.getLogger("dr_jobs")
+
+BASE_URL = "https://apply.jobs.scot.nhs.uk"
+
+# Filter scope. Defaults match the partner's saved search: keyword "anaesth"
+# across the two consultant salary bands (52 = Consultant, 63 = Locum
+# Consultant) from the site's Salary multiselect. Overridable via env without a
+# redeploy of code, only a values bump.
+DEFAULT_WHAT = os.environ.get("DR_JOBS_WHAT", "anaesth")
+DEFAULT_SALARY = os.environ.get("DR_JOBS_SALARY", "52,63")
+
+# The list endpoint pages 12 cards at a time (pageSize in vacancies.js). MAX_SKIP
+# is a safety bound so a malformed totalMatchRecords cannot loop forever; the
+# anaesthetics-consultant search returns well under a page in practice.
+PAGE_SIZE = 12
+MAX_SKIP = 600
+
+# Per-request timeouts; the client-level timeout in the handler is the ceiling.
+LIST_TIMEOUT_SECS = 15.0
+DETAIL_TIMEOUT_SECS = 20.0
+
+# The site treats these as AJAX/browser requests; mirror what vacancies.js sends.
+_HEADERS = {
+    "User-Agent": (
+        "Mozilla/5.0 (compatible; dr-jobs-aggregator/1.0; "
+        "+https://jomcgi.dev/app/dr-jobs)"
+    ),
+    "X-Requested-With": "XMLHttpRequest",
+}
+
+_JOB_ID_RE = re.compile(r'data-jobId="(\d+)"')
+_TOTAL_RE = re.compile(r'id="totalMatchRecords"\s+value="(\d+)"')
+_JSONLD_RE = re.compile(
+    r'<script[^>]*type=["\']application/ld\+json["\'][^>]*>(.*?)</script>',
+    re.DOTALL,
+)
+# Leading board reference code in a title, e.g. "PS246039 - Consultant ...".
+_REF_RE = re.compile(r"^\s*([A-Z]{2,}\d[\w-]*)\b")
+
+
+def parse_job_ids(list_html: str) -> tuple[list[str], int | None]:
+    """Parse the _JobCard fragment: ordered unique JobIds and the match total.
+
+    Returns (ids, total). total is None if the hidden input is absent (treated
+    by the caller as "stop paginating").
+    """
+    ids: list[str] = []
+    for jid in _JOB_ID_RE.findall(list_html):
+        if jid not in ids:
+            ids.append(jid)
+    m = _TOTAL_RE.search(list_html)
+    total = int(m.group(1)) if m else None
+    return ids, total
+
+
+def _parse_iso_date(value: str | None) -> date | None:
+    """Parse an ISO date or datetime prefix (validThrough is '...T00:00')."""
+    if not value:
+        return None
+    try:
+        return date.fromisoformat(value.strip()[:10])
+    except ValueError:
+        return None
+
+
+def parse_detail(detail_html: str, job_id: str, url: str) -> dict | None:
+    """Extract a vacancy dict from a JobDetail page's JSON-LD JobPosting block.
+
+    Returns None if no parseable JobPosting is present (the caller counts it as
+    a detail error and skips). Salary and title are HTML-unescaped (the JSON-LD
+    carries entities like &#xA3; for the pound sign).
+    """
+    m = _JSONLD_RE.search(detail_html)
+    if not m:
+        return None
+    try:
+        data = json.loads(m.group(1))
+    except (json.JSONDecodeError, TypeError):
+        return None
+    if not isinstance(data, dict) or data.get("@type") != "JobPosting":
+        return None
+
+    title = ihtml.unescape((data.get("title") or "").strip())
+    if not title:
+        return None
+    salary_text = ihtml.unescape((data.get("baseSalary") or "").strip())
+    # "Consultant (£111,430 - £148,064)" -> "Consultant"; bare text -> itself.
+    salary_band = salary_text.split(" (", 1)[0].strip()
+
+    ref_match = _REF_RE.match(title)
+    reference = ref_match.group(1) if ref_match else ""
+
+    loc = data.get("jobLocation") or {}
+    address = loc.get("address") if isinstance(loc, dict) else {}
+    address = address if isinstance(address, dict) else {}
+
+    return {
+        "job_id": job_id,
+        "reference": reference,
+        "title": title,
+        "employment_type": (data.get("employmentType") or "").strip(),
+        "salary_band": salary_band,
+        "salary_text": salary_text,
+        "town": (address.get("addressLocality") or "").strip(),
+        "postcode": (address.get("postalCode") or "").strip(),
+        "region": (address.get("addressRegion") or "").strip(),
+        "posted_date": _parse_iso_date(data.get("datePosted")),
+        "closing_date": _parse_iso_date(data.get("validThrough")),
+        "url": url,
+    }
+
+
+async def _list_job_ids(
+    client: httpx.AsyncClient, what: str, salary: str, stats: dict
+) -> list[str]:
+    """Page through _JobCard collecting every matching JobId (dedup, in order)."""
+    job_ids: list[str] = []
+    skip = 0
+    while skip <= MAX_SKIP:
+        params = {"what": what, "Salary": salary, "Skip": skip}
+        try:
+            resp = await client.get(
+                f"{BASE_URL}/Home/_JobCard",
+                params=params,
+                headers=_HEADERS,
+                timeout=LIST_TIMEOUT_SECS,
+            )
+            resp.raise_for_status()
+        except httpx.HTTPError as exc:
+            logger.error("dr_jobs list fetch failed at skip=%d: %s", skip, exc)
+            stats["list_err"] += 1
+            break
+        ids, total = parse_job_ids(resp.text)
+        before = len(job_ids)
+        job_ids.extend(jid for jid in ids if jid not in job_ids)
+        skip += PAGE_SIZE
+        # Stop when we've covered the reported total, the page was empty, or a
+        # page added nothing new (defensive against a stuck pager).
+        if not ids or len(job_ids) == before or total is None or skip >= total:
+            break
+    return job_ids
+
+
+async def fetch_vacancies(
+    client: httpx.AsyncClient,
+    what: str = DEFAULT_WHAT,
+    salary: str = DEFAULT_SALARY,
+) -> tuple[list[dict], dict]:
+    """Fetch and parse every matching vacancy. Never raises.
+
+    Returns (vacancies, stats). stats counts list/detail errors so the handler
+    can log a health summary and decide whether the run produced anything.
+    """
+    stats = {"listed": 0, "detail_ok": 0, "detail_err": 0, "list_err": 0}
+    job_ids = await _list_job_ids(client, what, salary, stats)
+    stats["listed"] = len(job_ids)
+
+    vacancies: list[dict] = []
+    for job_id in job_ids:
+        url = f"{BASE_URL}/Job/JobDetail?JobId={job_id}"
+        try:
+            resp = await client.get(url, headers=_HEADERS, timeout=DETAIL_TIMEOUT_SECS)
+            resp.raise_for_status()
+        except httpx.HTTPError as exc:
+            logger.warning("dr_jobs detail fetch failed for %s: %s", job_id, exc)
+            stats["detail_err"] += 1
+            continue
+        vac = parse_detail(resp.text, job_id, url)
+        if vac is None:
+            logger.warning("dr_jobs detail parse yielded nothing for %s", job_id)
+            stats["detail_err"] += 1
+            continue
+        vacancies.append(vac)
+        stats["detail_ok"] += 1
+    return vacancies, stats

--- a/projects/monolith/dr_jobs/scraper_test.py
+++ b/projects/monolith/dr_jobs/scraper_test.py
@@ -1,0 +1,158 @@
+"""Unit tests for dr_jobs/scraper.py.
+
+The pure parse helpers (parse_job_ids, parse_detail) run against inline HTML
+fixtures shaped like the real apply.jobs.scot.nhs.uk responses. fetch_vacancies
+runs against an httpx.MockTransport so the two-tier list -> detail flow is
+exercised end to end with no network.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+import httpx
+import pytest
+
+from dr_jobs import scraper
+
+# A _JobCard fragment with two job cards and the match-total hidden input.
+LIST_HTML = """
+<input type="hidden" id="totalCurrentRecords" value="2">
+<input type="hidden" id="totalMatchRecords" value="2">
+<div class="job-card" data-jobId="256437"></div>
+<a href="/Job/JobDetail?JobId=256437">PS246039 - Consultant Anaesthetist</a>
+<div class="job-card" data-jobId="259286"></div>
+<a href="/Job/JobDetail?JobId=259286">CI248883 - Fixed Term Consultant Anaesthetist</a>
+"""
+
+# A JobDetail page carrying a schema.org JobPosting JSON-LD block. &#xA3; is the
+# literal HTML entity the site emits for the pound sign.
+DETAIL_HTML_TEMPLATE = """
+<html><head>
+<script type="application/ld+json">
+{{"@context":"https://schema.org","@type":"JobPosting",
+"title":"{title}","datePosted":"{posted}","validThrough":"{closing}T00:00",
+"employmentType":"{etype}",
+"hiringOrganization":{{"@type":"Organization","name":"NHS Scotland"}},
+"jobLocation":{{"@type":"Place","address":{{"@type":"PostalAddress",
+"addressLocality":"{town}","addressRegion":"","postalCode":"{postcode}",
+"addressCountry":"GB"}}}},
+"baseSalary":"{salary}"}}
+</script>
+</head><body></body></html>
+"""
+
+
+def _detail(**kw) -> str:
+    base = {
+        "title": "PS246039 - Consultant Anaesthetist ",
+        "posted": "2026-06-10",
+        "closing": "2026-07-12",
+        "etype": "Permanent",
+        "town": "Elgin",
+        "postcode": "IV30 1SN",
+        "salary": "Consultant (&#xA3;111,430 - &#xA3;148,064)",
+    }
+    base.update(kw)
+    return DETAIL_HTML_TEMPLATE.format(**base)
+
+
+class TestParseJobIds:
+    def test_extracts_ordered_unique_ids_and_total(self):
+        ids, total = scraper.parse_job_ids(LIST_HTML)
+        assert ids == ["256437", "259286"]
+        assert total == 2
+
+    def test_dedupes_repeated_ids(self):
+        html = '<div data-jobId="1"></div><div data-jobId="1"></div><div data-jobId="2"></div>'
+        ids, total = scraper.parse_job_ids(html)
+        assert ids == ["1", "2"]
+        assert total is None  # no totalMatchRecords input
+
+
+class TestParseDetail:
+    def test_full_parse(self):
+        vac = scraper.parse_detail(_detail(), "256437", "https://x/JobId=256437")
+        assert vac == {
+            "job_id": "256437",
+            "reference": "PS246039",
+            "title": "PS246039 - Consultant Anaesthetist",
+            "employment_type": "Permanent",
+            "salary_band": "Consultant",
+            "salary_text": "Consultant (£111,430 - £148,064)",
+            "town": "Elgin",
+            "postcode": "IV30 1SN",
+            "region": "",
+            "posted_date": date(2026, 6, 10),
+            "closing_date": date(2026, 7, 12),
+            "url": "https://x/JobId=256437",
+        }
+
+    def test_locum_band_split(self):
+        vac = scraper.parse_detail(
+            _detail(salary="Locum Consultant (&#xA3;111,430 - &#xA3;148,064)"),
+            "1",
+            "u",
+        )
+        assert vac["salary_band"] == "Locum Consultant"
+
+    def test_title_without_reference(self):
+        vac = scraper.parse_detail(
+            _detail(title="Consultant in Paediatric Anaesthesia"), "1", "u"
+        )
+        assert vac["reference"] == ""
+        assert vac["title"] == "Consultant in Paediatric Anaesthesia"
+
+    def test_no_jsonld_returns_none(self):
+        assert scraper.parse_detail("<html>no ld json</html>", "1", "u") is None
+
+    def test_non_jobposting_returns_none(self):
+        html = '<script type="application/ld+json">{"@type":"WebSite"}</script>'
+        assert scraper.parse_detail(html, "1", "u") is None
+
+
+@pytest.mark.asyncio
+async def test_fetch_vacancies_end_to_end():
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/Home/_JobCard":
+            return httpx.Response(200, text=LIST_HTML)
+        if request.url.path == "/Job/JobDetail":
+            job_id = request.url.params.get("JobId")
+            title = (
+                "PS246039 - Consultant Anaesthetist "
+                if job_id == "256437"
+                else "CI248883 - Fixed Term Consultant Anaesthetist "
+            )
+            return httpx.Response(200, text=_detail(title=title, etype="Fixed-term"))
+        return httpx.Response(404)
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(
+        transport=transport, timeout=httpx.Timeout(30.0)
+    ) as client:
+        vacancies, stats = await scraper.fetch_vacancies(client)
+
+    assert stats["listed"] == 2
+    assert stats["detail_ok"] == 2
+    assert stats["detail_err"] == 0
+    assert [v["job_id"] for v in vacancies] == ["256437", "259286"]
+    assert vacancies[0]["reference"] == "PS246039"
+
+
+@pytest.mark.asyncio
+async def test_fetch_vacancies_counts_detail_errors():
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/Home/_JobCard":
+            return httpx.Response(200, text=LIST_HTML)
+        # Both detail pages 500: the run lists 2 but parses 0.
+        return httpx.Response(500, text="boom")
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(
+        transport=transport, timeout=httpx.Timeout(30.0)
+    ) as client:
+        vacancies, stats = await scraper.fetch_vacancies(client)
+
+    assert vacancies == []
+    assert stats["listed"] == 2
+    assert stats["detail_err"] == 2

--- a/projects/monolith/frontend/src/lib/cache-headers.js
+++ b/projects/monolith/frontend/src/lib/cache-headers.js
@@ -39,6 +39,12 @@ export const SHIPS_HEAT_CACHE_CONTROL =
 export const HIKES_WALKS_CACHE_CONTROL =
   "public, max-age=0, s-maxage=1800, stale-while-revalidate=3600, stale-if-error=86400";
 
+// /app/dr-jobs listings: the NHS scrape runs daily, so 30 min edge freshness
+// with a 1 h SWR window is plenty. Mirrors _LISTINGS_CACHE_CONTROL in
+// projects/monolith/dr_jobs/router.py, keep in sync.
+export const DR_JOBS_LISTINGS_CACHE_CONTROL =
+  "public, max-age=0, s-maxage=1800, stale-while-revalidate=3600, stale-if-error=86400";
+
 // /app/stars sites: the refresh job runs 3-hourly and elapsed hours are pruned
 // hourly, so 30 min edge freshness with a 1 h SWR window is plenty. Mirrors
 // _SITES_CACHE_CONTROL in projects/monolith/stars/router.py, keep in sync.

--- a/projects/monolith/frontend/src/lib/public/components/Nav.svelte
+++ b/projects/monolith/frontend/src/lib/public/components/Nav.svelte
@@ -49,6 +49,12 @@
       desc: "Scotland dark-sky planner",
       href: "/app/stars",
     },
+    {
+      slug: "dr-jobs",
+      label: "Dr Jobs",
+      desc: "NHS Scotland anaesthetics consultant posts",
+      href: "/app/dr-jobs",
+    },
   ];
 
   const appsActive = $derived(apps.some((a) => a.slug === route));

--- a/projects/monolith/frontend/src/routes/public/app/dr-jobs/+page.server.js
+++ b/projects/monolith/frontend/src/routes/public/app/dr-jobs/+page.server.js
@@ -1,0 +1,29 @@
+import { error } from "@sveltejs/kit";
+// Relative (not $lib): vitest loads this module directly and its plain node
+// config does not resolve the SvelteKit $lib alias. dr-jobs sits at the same
+// depth as hikes (routes/public/app/dr-jobs), hence four ../ segments to reach
+// src/lib/. Mirrors hikes/+page.server.js.
+import { DR_JOBS_LISTINGS_CACHE_CONTROL } from "../../../../lib/cache-headers.js";
+
+const API_BASE = process.env.API_BASE || "http://localhost:8000";
+
+// SSR-only: the browser never calls /api/dr-jobs/* directly (that surface is not
+// exposed publicly). This load runs server-side in the same pod and the CDN
+// fans the result out to viewers. Live updates come from re-running this load on
+// a timer (invalidateAll) in the page; the scrape runs daily, so the table
+// barely changes between loads.
+export async function load({ fetch, setHeaders }) {
+  const res = await fetch(`${API_BASE}/api/dr-jobs/listings`, {
+    signal: AbortSignal.timeout(10_000),
+  });
+  if (!res.ok) {
+    throw error(503, "dr-jobs listings unavailable");
+  }
+
+  const headers = { "cache-control": DR_JOBS_LISTINGS_CACHE_CONTROL };
+  const etag = res.headers?.get?.("etag");
+  if (etag) headers.etag = etag;
+  setHeaders(headers);
+
+  return { listings: await res.json() };
+}

--- a/projects/monolith/frontend/src/routes/public/app/dr-jobs/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/dr-jobs/+page.svelte
@@ -1,0 +1,514 @@
+<script>
+  import { onMount } from "svelte";
+  import { invalidateAll } from "$app/navigation";
+  import BrutalistSelect from "$lib/public/components/BrutalistSelect.svelte";
+
+  let { data } = $props();
+
+  const jobs = $derived(data.listings?.jobs ?? []);
+  const liveJobs = $derived(jobs.filter((j) => j.is_live));
+  const historyJobs = $derived(jobs.filter((j) => !j.is_live));
+
+  // Live by default; the History button reveals closed/expired posts (Option A
+  // lifecycle keeps them, so this needs no second request).
+  let view = $state("live");
+  let town = $state("");
+
+  const bucket = $derived(view === "live" ? liveJobs : historyJobs);
+
+  // Town options for the current bucket, alphabetised, with an "all" sentinel.
+  const townOptions = $derived([
+    { value: "", label: "All locations" },
+    ...[...new Set(bucket.map((j) => j.town).filter(Boolean))]
+      .sort((a, b) => a.localeCompare(b))
+      .map((t) => ({ value: t, label: t })),
+  ]);
+
+  const visible = $derived(
+    town ? bucket.filter((j) => j.town === town) : bucket,
+  );
+
+  // Reset the town filter when the option leaves the new bucket (e.g. toggling
+  // to History where that town has no posts), so the table never goes blank.
+  $effect(() => {
+    if (town && !bucket.some((j) => j.town === town)) town = "";
+  });
+
+  const MONTHS = [
+    "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+    "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
+  ];
+
+  function fmtDate(iso) {
+    if (!iso) return "—";
+    const [y, m, d] = iso.split("-").map(Number);
+    if (!y || !m || !d) return "—";
+    return `${d} ${MONTHS[m - 1]} ${y}`;
+  }
+
+  // Whole days from today (UTC) to an ISO date; negative once past.
+  function daysUntil(iso) {
+    if (!iso) return null;
+    const [y, m, d] = iso.split("-").map(Number);
+    if (!y) return null;
+    const then = Date.UTC(y, m - 1, d);
+    const now = new Date();
+    const today = Date.UTC(
+      now.getUTCFullYear(),
+      now.getUTCMonth(),
+      now.getUTCDate(),
+    );
+    return Math.round((then - today) / 86_400_000);
+  }
+
+  function closesLabel(iso) {
+    const n = daysUntil(iso);
+    if (n === null) return "";
+    if (n < 0) return "closed";
+    if (n === 0) return "today";
+    if (n === 1) return "1 day left";
+    return `${n} days left`;
+  }
+
+  const isClosingSoon = (iso) => {
+    const n = daysUntil(iso);
+    return n !== null && n >= 0 && n <= 7;
+  };
+
+  // "New" badge: first seen by the scraper within the last week.
+  function isNew(j) {
+    if (!j.first_seen_at) return false;
+    const seen = Date.parse(j.first_seen_at);
+    return Number.isFinite(seen) && Date.now() - seen < 7 * 86_400_000;
+  }
+
+  // Drop the leading "REF - " from the display title (the reference shows as its
+  // own chip), falling back to the raw title if stripping leaves nothing.
+  function cleanTitle(j) {
+    if (j.reference && j.title.startsWith(j.reference)) {
+      const rest = j.title
+        .slice(j.reference.length)
+        .replace(/^\s*[-–]\s*/, "")
+        .trim();
+      if (rest) return rest;
+    }
+    return j.title;
+  }
+
+  onMount(() => {
+    // The scrape is daily, so a slow refresh is plenty; this keeps an open tab
+    // from drifting if it sits for hours. Re-runs the SSR load (no client poll).
+    const refresh = setInterval(() => invalidateAll(), 30 * 60_000);
+    return () => clearInterval(refresh);
+  });
+</script>
+
+<svelte:head>
+  <title>NHS Scotland anaesthetics consultant jobs</title>
+  <meta
+    name="description"
+    content="Aggregated NHS Scotland consultant and locum consultant anaesthetics vacancies, refreshed daily from apply.jobs.scot.nhs.uk."
+  />
+</svelte:head>
+
+<div class="jobs-page">
+  <h1 class="sr-only">NHS Scotland anaesthetics consultant vacancies</h1>
+
+  <header class="head panel">
+    <div class="crumb-row">
+      <nav class="crumb" aria-label="Breadcrumb">
+        <a class="crumb-home" href="https://jomcgi.dev/"
+          >jomcgi.dev<span class="crumb-arrow" aria-hidden="true">&nearr;</span></a
+        >
+        <span class="crumb-sep">/</span>
+        <span class="crumb-name">dr-jobs</span>
+      </nav>
+      <p class="stats">
+        {liveJobs.length} live &middot; {historyJobs.length} past
+      </p>
+    </div>
+
+    <p class="lede">
+      NHS Scotland consultant &amp; locum consultant anaesthetics posts, scraped
+      daily from
+      <a href="https://apply.jobs.scot.nhs.uk/Home/Job" rel="external"
+        >apply.jobs.scot.nhs.uk</a
+      >.
+    </p>
+
+    <div class="controls">
+      <div class="toggle" role="group" aria-label="Show live or past jobs">
+        <button
+          class="seg"
+          class:active={view === "live"}
+          aria-pressed={view === "live"}
+          onclick={() => (view = "live")}
+        >
+          Live ({liveJobs.length})
+        </button>
+        <button
+          class="seg"
+          class:active={view === "history"}
+          aria-pressed={view === "history"}
+          onclick={() => (view = "history")}
+        >
+          History ({historyJobs.length})
+        </button>
+      </div>
+
+      <div class="field">
+        <span class="field-label" id="town-label">Location</span>
+        <BrutalistSelect
+          options={townOptions}
+          bind:value={town}
+          label="Filter by location"
+          id="dr-jobs-town"
+        />
+      </div>
+    </div>
+  </header>
+
+  {#if visible.length === 0}
+    <p class="empty panel">
+      {#if view === "live"}
+        No live anaesthetics consultant posts right now. Try History for recent
+        listings.
+      {:else}
+        No past listings recorded yet.
+      {/if}
+    </p>
+  {:else}
+    <ul class="cards">
+      {#each visible as j (j.job_id)}
+        <li class="card panel" class:past={!j.is_live}>
+          <div class="card-main">
+            <div class="badges">
+              {#if j.is_live && isNew(j)}
+                <span class="badge new">New</span>
+              {/if}
+              {#if j.is_live && isClosingSoon(j.closing_date)}
+                <span class="badge soon">Closing soon</span>
+              {/if}
+              {#if j.reference}
+                <span class="badge ref">{j.reference}</span>
+              {/if}
+            </div>
+            <a class="title" href={j.url} target="_blank" rel="noopener">
+              {cleanTitle(j)}
+            </a>
+            <p class="meta">
+              {#if j.town}<span>{j.town}{j.postcode ? ` ${j.postcode}` : ""}</span
+                >{/if}
+              {#if j.employment_type}<span class="dot">&middot;</span><span
+                  >{j.employment_type}</span
+                >{/if}
+              {#if j.salary_band}<span class="dot">&middot;</span><span
+                  >{j.salary_band}</span
+                >{/if}
+            </p>
+          </div>
+          <div class="card-side">
+            <span class="close-date">{fmtDate(j.closing_date)}</span>
+            <span class="close-rel" class:urgent={isClosingSoon(j.closing_date)}>
+              {closesLabel(j.closing_date)}
+            </span>
+          </div>
+        </li>
+      {/each}
+    </ul>
+  {/if}
+</div>
+
+<style>
+  .jobs-page {
+    min-height: 100vh;
+    min-height: 100dvh;
+    background: var(--cream);
+    color: var(--ink);
+    padding: 16px;
+    max-width: 860px;
+    margin: 0 auto;
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+  }
+
+  .sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0 0 0 0);
+    white-space: nowrap;
+    border: 0;
+  }
+
+  /* Flat, sharp-bordered paper panels, matching the ships/hikes overlays. */
+  .panel {
+    background: var(--paper);
+    border: 2px solid var(--ink);
+    padding: 14px;
+  }
+
+  .head {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  .crumb-row {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 8px 14px;
+    flex-wrap: wrap;
+  }
+
+  .crumb {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    font-family: var(--mono);
+    font-size: 12px;
+    font-weight: 700;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+  }
+
+  .crumb-home {
+    color: var(--ink);
+    text-decoration: underline;
+    text-decoration-color: var(--blue);
+    text-decoration-thickness: 2px;
+    text-underline-offset: 2px;
+    padding: 0 2px;
+    transition: background 140ms ease;
+  }
+
+  .crumb-home:hover,
+  .crumb-home:focus-visible {
+    background: linear-gradient(transparent 56%, var(--accent) 56%);
+    text-decoration-color: var(--ink);
+  }
+
+  .crumb-arrow {
+    font-size: 0.85em;
+  }
+
+  .crumb-sep,
+  .crumb-name {
+    color: var(--ink);
+  }
+
+  .stats {
+    font-family: var(--mono);
+    font-size: 12px;
+    font-weight: 700;
+    letter-spacing: 0.06em;
+    margin: 0;
+  }
+
+  .lede {
+    margin: 0;
+    font-size: 14px;
+    line-height: 1.5;
+  }
+
+  .lede a {
+    color: var(--ink);
+    text-decoration: underline;
+    text-decoration-color: var(--blue);
+    text-decoration-thickness: 2px;
+  }
+
+  .controls {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: flex-end;
+    gap: 12px;
+  }
+
+  .toggle {
+    display: inline-flex;
+    border: 2px solid var(--ink);
+  }
+
+  .seg {
+    font-family: var(--mono);
+    font-size: 12px;
+    font-weight: 700;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    padding: 8px 14px;
+    background: var(--paper);
+    color: var(--ink);
+    border: 0;
+    cursor: pointer;
+    transition: background 120ms ease;
+  }
+
+  .seg + .seg {
+    border-left: 2px solid var(--ink);
+  }
+
+  .seg.active {
+    background: var(--accent);
+  }
+
+  .seg:hover:not(.active) {
+    background: var(--cream);
+  }
+
+  .field {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    min-width: 180px;
+  }
+
+  .field-label {
+    font-family: var(--mono);
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+
+  .cards {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
+
+  .card {
+    display: flex;
+    align-items: stretch;
+    justify-content: space-between;
+    gap: 14px;
+  }
+
+  .card.past {
+    opacity: 0.72;
+  }
+
+  .card-main {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    min-width: 0;
+  }
+
+  .badges {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+  }
+
+  .badge {
+    font-family: var(--mono);
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    padding: 2px 6px;
+    border: 1.5px solid var(--ink);
+  }
+
+  .badge.new {
+    background: var(--accent);
+  }
+
+  .badge.soon {
+    background: var(--blue);
+    color: var(--paper);
+    border-color: var(--blue);
+  }
+
+  .badge.ref {
+    background: transparent;
+    color: var(--ink);
+  }
+
+  .title {
+    font-size: 16px;
+    font-weight: 700;
+    line-height: 1.3;
+    color: var(--ink);
+    text-decoration: underline;
+    text-decoration-color: var(--blue);
+    text-decoration-thickness: 2px;
+    text-underline-offset: 2px;
+  }
+
+  .title:hover,
+  .title:focus-visible {
+    background: linear-gradient(transparent 60%, var(--accent) 60%);
+    text-decoration-color: var(--ink);
+  }
+
+  .meta {
+    margin: 0;
+    font-size: 13px;
+    color: var(--ink);
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    align-items: baseline;
+  }
+
+  .meta .dot {
+    opacity: 0.5;
+  }
+
+  .card-side {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    justify-content: center;
+    gap: 2px;
+    text-align: right;
+    white-space: nowrap;
+    flex-shrink: 0;
+  }
+
+  .close-date {
+    font-family: var(--mono);
+    font-size: 13px;
+    font-weight: 700;
+  }
+
+  .close-rel {
+    font-family: var(--mono);
+    font-size: 11px;
+    letter-spacing: 0.04em;
+    opacity: 0.7;
+  }
+
+  .close-rel.urgent {
+    color: var(--blue);
+    opacity: 1;
+    font-weight: 700;
+  }
+
+  .empty {
+    font-size: 14px;
+    line-height: 1.5;
+  }
+
+  @media (max-width: 540px) {
+    .card {
+      flex-direction: column;
+    }
+    .card-side {
+      align-items: flex-start;
+      text-align: left;
+      flex-direction: row;
+      gap: 8px;
+    }
+  }
+</style>


### PR DESCRIPTION
## What

A new in-monolith app at **/app/dr-jobs** that aggregates NHS Scotland (apply.jobs.scot.nhs.uk) **consultant + locum consultant anaesthetics** vacancies, refreshed daily, with a live/history table and a Discord ping when new posts appear.

Built for a partner's job search (the saved filter: keyword `anaesth`, salary bands Consultant + Locum Consultant).

## How (mirrors the hikes domain)

- **Scraper** (`dr_jobs/scraper.py`): two-tier scrape with no auth/reCAPTCHA. The JobTrain AJAX list endpoint `/Home/_JobCard?what=anaesth&Salary=52,63` yields matching JobIds; each `/Job/JobDetail` page carries a schema.org `JobPosting` JSON-LD block we parse for structured fields (title, board/town, postcode, dates, salary). Parsing the JSON-LD (published for Google Jobs) rather than presentational HTML keeps us resilient to cosmetic redesigns. Pure parse helpers are unit-tested against real captured markup.
- **Schedule + lifecycle** (`dr_jobs/jobs.py`): daily `dr_jobs.scrape_nhs` job. Network phase async, upsert delegated to `asyncio.to_thread`. **Option A lifecycle**: upsert keyed on JobId, stamp `last_seen_at`, never delete. Closed/removed posts age out of the live view but stay in history.
- **Read API** (`dr_jobs/router.py`): `GET /api/dr-jobs/listings`, SSR-only, CDN-cached with ETag/304. Computes `is_live` (seen in last scrape AND not past closing date) server-side; one payload carries live + history.
- **Frontend**: `/app/dr-jobs` SvelteKit table with a Live/History toggle and a location filter, built from the neo-brutalist house tokens. Plus a Nav launcher entry.
- **Discord**: on a non-seed scrape that inserts new posts, posts a one-message digest to channel `1516663194699960382` (added to the agent notify allow-list). Seed run is suppressed so the first scrape does not dump the whole backlog.

## Verification

- Pure parsers run against **real** captured NHS HTML: all 6 current matches found, every field extracted.
- `atlas migrate hash` + `validate` pass; `helm template` renders clean (migration in ConfigMap, channel in allow-list env).
- Unit tests: scraper parse + MockTransport flow, router live/history split + ETag/304, model round-trip, persist seed-suppression + digest formatting.
- Chart `0.143.5` -> `0.144.0` (Chart.yaml + application.yaml in sync).

🤖 Generated with [Claude Code](https://claude.com/claude-code)