### PR TITLE
style(monolith): make /app/dr-jobs pop with the content-page palette

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.144.1
+version: 0.144.2
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.144.1
+      targetRevision: 0.144.2
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/routes/public/app/dr-jobs/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/dr-jobs/+page.svelte
@@ -245,10 +245,14 @@
     border: 0;
   }
 
-  /* Flat, sharp-bordered paper panels, matching the ships/hikes overlays. */
+  /* Chunky paper panels: 2px ink border, 8px radius, hard offset shadow, the
+     same "pop" the home/cv/engineering content pages use (not the deliberately
+     flat map overlays on /app/hikes + /app/ships). */
   .panel {
     background: var(--paper);
     border: 2px solid var(--ink);
+    border-radius: var(--radius);
+    box-shadow: var(--shadow-hard);
     padding: 14px;
   }
 
@@ -333,6 +337,9 @@
   .toggle {
     display: inline-flex;
     border: 2px solid var(--ink);
+    border-radius: var(--radius);
+    overflow: hidden;
+    box-shadow: var(--shadow-hard-sm);
   }
 
   .seg {
@@ -390,10 +397,21 @@
     align-items: stretch;
     justify-content: space-between;
     gap: 14px;
+    transition:
+      transform 120ms ease,
+      box-shadow 120ms ease;
+  }
+
+  /* Brutalist lift: slide up-left to reveal a bigger offset shadow, the same
+     interaction as the engineering rail links. */
+  .card:hover {
+    transform: translate(-2px, -2px);
+    box-shadow: 6px 6px 0 var(--ink);
   }
 
   .card.past {
     opacity: 0.72;
+    box-shadow: var(--shadow-hard-sm);
   }
 
   .card-main {
@@ -415,18 +433,20 @@
     font-weight: 700;
     letter-spacing: 0.06em;
     text-transform: uppercase;
-    padding: 2px 6px;
+    padding: 2px 8px;
     border: 1.5px solid var(--ink);
+    border-radius: 999px;
   }
 
+  /* Full-palette status pops, like the engineering page tags: green = fresh,
+     coral = urgency. Ink text on both for contrast against the bright fills. */
   .badge.new {
-    background: var(--accent);
+    background: var(--green);
   }
 
   .badge.soon {
-    background: var(--blue);
-    color: var(--paper);
-    border-color: var(--blue);
+    background: var(--coral);
+    color: var(--ink);
   }
 
   .badge.ref {
@@ -490,7 +510,7 @@
   }
 
   .close-rel.urgent {
-    color: var(--blue);
+    color: var(--coral);
     opacity: 1;
     font-weight: 700;
   }


### PR DESCRIPTION
Follow-up to #2646. The MVP used the flat map-overlay style (2px border, no shadow, yellow/blue only) copied from /app/hikes + /app/ships. Since dr-jobs is a scrollable content page like /cv and /engineering, this adopts their fuller "pop" treatment from the design system:

- **8px rounded corners + hard offset shadows** (`--shadow-hard` = `4px 4px 0 ink`) on panels and cards.
- **Hover lift**: cards `translate(-2px, -2px)` and grow the shadow, the same interaction as the engineering rail links.
- **Full-palette pill badges**: New = `--green`, Closing soon = `--coral` (was muted blue).
- **Coral closing-date urgency** for posts closing within 7 days.

CSS-only; no backend change. Chart 0.144.1 -> 0.144.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)