### PR TITLE
feat(monolith): scrape dr-jobs hourly instead of daily

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.144.3
+version: 0.144.4
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.144.3
+      targetRevision: 0.144.4
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/dr_jobs/__init__.py
+++ b/projects/monolith/dr_jobs/__init__.py
@@ -26,7 +26,15 @@ def on_startup_jobs(session: Session) -> None:
     register_job(
         session,
         name="dr_jobs.scrape_nhs",
-        interval_secs=86400,  # daily; NHS consultant posts turn over slowly
+        # Hourly: the scrape is cheap (one list call + ~one heavy detail page
+        # per matching job, a handful today) and JobTrain tolerates it easily.
+        # Hourly gets a new post (and its Discord ping) in front of the partner
+        # within the hour instead of up to a day, and dedup means re-seen jobs
+        # only bump last_seen_at, so a faster cadence never re-pings.
+        interval_secs=3600,
         handler=scrape_nhs_handler,
-        ttl_secs=3600,  # generous: each run fetches a heavy detail page per job
+        # A run fetches a few heavy detail pages but finishes in well under a
+        # minute; 10 min frees the lock promptly if a pod dies mid-scrape
+        # without ever overlapping the hourly tick.
+        ttl_secs=600,
     )


### PR DESCRIPTION
Bumps the `dr_jobs.scrape_nhs` cadence from daily to hourly. The scrape is one list call plus ~one heavy detail page per matching job (a handful today), so hourly is still trivially gentle on JobTrain. It gets a new post and its Discord ping in front of the partner within the hour instead of up to a day; dedup (upsert keyed on JobId) means re-seen jobs only bump `last_seen_at`, so the faster cadence never re-pings. Lock TTL 3600->600 so a pod dying mid-run frees the lock before the next hourly tick.

Chart 0.144.3 -> 0.144.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)