### PR TITLE
style(monolith): white dr-jobs masthead + highlight-not-raise dropdown

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.144.5
+version: 0.144.6
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.144.5
+      targetRevision: 0.144.6
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/lib/public/components/BrutalistSelect.svelte
+++ b/projects/monolith/frontend/src/lib/public/components/BrutalistSelect.svelte
@@ -220,21 +220,20 @@
     border: 2px solid var(--ink);
     color: var(--ink);
     cursor: pointer;
-    transition:
-      transform 110ms ease,
-      box-shadow 110ms ease;
+    transition: background 110ms ease;
   }
 
+  /* A select EXPANDS, so highlight it (accent fill) rather than lifting it off
+     the page; a raised/shadowed box reads as "floats above", contradicting the
+     list that drops below. Mirrors the .open "anchored, not lifted" intent. */
   .bsel-trigger:hover {
-    transform: translate(-2px, -2px);
-    box-shadow: 2px 2px 0 var(--ink);
+    background: var(--accent);
   }
 
-  /* Brutalist focus: a hard offset stack, not the OS blue glow. */
+  /* Brutalist focus: the accent highlight, not the OS blue glow. */
   .bsel-trigger:focus-visible {
     outline: none;
-    transform: translate(-2px, -2px);
-    box-shadow: 2px 2px 0 var(--ink);
+    background: var(--accent);
   }
 
   /* Open: keep the box "pressed in" (no lift) so it reads as anchored to the

--- a/projects/monolith/frontend/src/routes/public/app/dr-jobs/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/dr-jobs/+page.svelte
@@ -255,13 +255,13 @@
     border: 2px solid var(--ink);
   }
 
-  /* Warm-tinted masthead, separated from the white row body by a 2px rule. */
+  /* Masthead: same white paper as the rows (no cream-on-cream tint), set off
+     from the row body only by the 2px rule. */
   .board-head {
     display: flex;
     flex-direction: column;
     gap: 9px;
     padding: 12px 14px;
-    background: var(--bg-elev);
     border-bottom: 2px solid var(--ink);
   }
 


### PR DESCRIPTION
Design review on the ledger redesign:

- **Cream-on-cream**: the `--bg-elev` masthead tint muddied against the page cream and the cream-filled select. Flattened the masthead to plain white paper (one clean sheet, set off from rows by the 2px rule).
- **Dropdown affordance**: a `<select>` expands *downward*, so a raised/shadowed hover (which reads as "floats above") is the wrong signal. `BrutalistSelect` now **highlights** (accent fill) on hover/focus instead of lifting. This matches the component's own `.open` comment ("anchored, not lifted") and also improves the hikes/stars location dropdowns.

CSS only. Chart 0.144.5 -> 0.144.6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)