### PR TITLE
fix(nav): remove dr-jobs from apps dropdown

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.144.6
+version: 0.144.7
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.144.6
+      targetRevision: 0.144.7
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/lib/public/components/Nav.svelte
+++ b/projects/monolith/frontend/src/lib/public/components/Nav.svelte
@@ -49,12 +49,6 @@
       desc: "Scotland dark-sky planner",
       href: "/app/stars",
     },
-    {
-      slug: "dr-jobs",
-      label: "Dr Jobs",
-      desc: "NHS Scotland anaesthetics consultant posts",
-      href: "/app/dr-jobs",
-    },
   ];
 
   const appsActive = $derived(apps.some((a) => a.slug === route));


### PR DESCRIPTION
## Summary

Removes the **Dr Jobs** entry from the public APPS dropdown in the shared nav. It's a private app intended only for Joe's partner and shouldn't be advertised in the menu.

The `/app/dr-jobs` route itself stays intact and directly accessible, so the link still works for anyone with it.

## Changes

- Drop the `dr-jobs` item from the `apps` array in `Nav.svelte`. No dr-jobs-specific styles existed, so nothing else to clean up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FUnNw3Y1jdmqhoG963X1Lx)_