### PR TITLE
fix(monolith): report honest RSS memory in cluster gauge, not working set

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.144.6
+version: 0.144.7
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/templates/rbac.yaml
+++ b/projects/monolith/chart/templates/rbac.yaml
@@ -8,6 +8,11 @@ rules:
   - apiGroups: [""]
     resources: ["nodes", "pods"]
     verbs: ["list"]
+  # nodes/proxy lets the stats endpoint reach each kubelet's Summary API
+  # (/stats/summary) for honest rssBytes memory usage, not just working set.
+  - apiGroups: [""]
+    resources: ["nodes/proxy"]
+    verbs: ["get"]
   - apiGroups: ["apps"]
     resources: ["deployments"]
     verbs: ["list"]

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.144.6
+      targetRevision: 0.144.7
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/shared/kubernetes.py
+++ b/projects/monolith/shared/kubernetes.py
@@ -7,6 +7,7 @@ observability MCP tooling — keep the interface minimal and read-only.
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 
 from kubernetes_asyncio import client, config
@@ -111,11 +112,41 @@ class KubernetesClient:
             return None
         return result.get("status")
 
+    async def _node_rss_bytes(self, v1: "client.CoreV1Api", node: str) -> float | None:
+        """Anonymous resident memory for one node, from the kubelet Summary API.
+
+        Returns node.memory.rssBytes from /stats/summary, or None when the
+        summary (or the rssBytes field) is unavailable so the caller can fall
+        back. rssBytes excludes ALL file-backed page cache, unlike the
+        metrics-server "working set" which counts active page cache (e.g. the
+        multi-GB model-weight file reads on the GPU node) and overstates real
+        memory consumption by tens of GiB.
+        """
+        try:
+            raw = await v1.connect_get_node_proxy_with_path(
+                name=node, path="stats/summary"
+            )
+            data = json.loads(raw) if isinstance(raw, str) else raw
+            rss = (data.get("node", {}).get("memory", {}) or {}).get("rssBytes")
+            return float(rss) if rss is not None else None
+        except Exception:
+            logger.warning(
+                "kubelet summary unavailable for node %s; falling back to "
+                "working-set memory",
+                node,
+                exc_info=False,
+            )
+            return None
+
     async def aggregate_node_resources(self) -> dict[str, float]:
-        """Sum CPU and memory across all nodes from the metrics API.
+        """Sum CPU and memory across all nodes.
 
         Returns cores and bytes. Capacity comes from node.status.allocatable
-        (what the scheduler can actually assign), not status.capacity.
+        (what the scheduler can actually assign), not status.capacity. CPU usage
+        comes from the metrics API. Memory "used" is anonymous RSS from the
+        kubelet Summary API (see _node_rss_bytes) rather than the metrics-server
+        working set, because working set includes reclaimable page cache and
+        wildly overstates real usage on nodes that mmap/read large files.
         """
         api = await self._ensure_client()
         v1 = client.CoreV1Api(api)
@@ -134,11 +165,23 @@ class KubernetesClient:
             cpu_cap += _parse_cpu(alloc.get("cpu", "0"))
             mem_cap += _parse_memory(alloc.get("memory", "0"))
 
-        cpu_used = mem_used = 0.0
+        # CPU usage and a per-node working-set fallback for memory.
+        cpu_used = 0.0
+        mem_ws_by_node: dict[str, float] = {}
         for item in metrics_resp.get("items", []):
             usage = item.get("usage", {})
             cpu_used += _parse_cpu(usage.get("cpu", "0"))
-            mem_used += _parse_memory(usage.get("memory", "0"))
+            name = item.get("metadata", {}).get("name", "")
+            mem_ws_by_node[name] = _parse_memory(usage.get("memory", "0"))
+
+        # Honest memory: kubelet rssBytes per node, fall back to working set on miss.
+        node_names = [n.metadata.name for n in nodes_resp.items]
+        rss_list = await asyncio.gather(
+            *(self._node_rss_bytes(v1, name) for name in node_names)
+        )
+        mem_used = 0.0
+        for name, rss in zip(node_names, rss_list):
+            mem_used += rss if rss is not None else mem_ws_by_node.get(name, 0.0)
 
         return {
             "cpu_used_cores": cpu_used,

--- a/projects/monolith/shared/kubernetes_test.py
+++ b/projects/monolith/shared/kubernetes_test.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -67,18 +68,31 @@ async def test_count_argocd_applications(k8s_client):
     assert count == 2
 
 
+def _node(name: str, allocatable: dict) -> MagicMock:
+    node = MagicMock()
+    node.metadata.name = name
+    node.status.allocatable = allocatable
+    return node
+
+
+def _summary_json(rss_mib: float) -> str:
+    """A minimal kubelet /stats/summary payload carrying node rssBytes."""
+    return json.dumps({"node": {"memory": {"rssBytes": rss_mib * 1024**2}}})
+
+
 @pytest.mark.asyncio
-async def test_aggregate_node_resources_sums_cpu_and_memory(k8s_client):
+async def test_aggregate_node_resources_uses_rss_not_working_set(k8s_client):
     mock_api = MagicMock()
     mock_v1 = MagicMock()
     mock_custom = MagicMock()
 
-    node_a = MagicMock()
-    node_a.status.allocatable = {"cpu": "16", "memory": "65536Mi"}
-    node_b = MagicMock()
-    node_b.status.allocatable = {"cpu": "8", "memory": "32768Mi"}
-    mock_v1.list_node = AsyncMock(return_value=MagicMock(items=[node_a, node_b]))
+    nodes = [
+        _node("node-a", {"cpu": "16", "memory": "65536Mi"}),
+        _node("node-b", {"cpu": "8", "memory": "32768Mi"}),
+    ]
+    mock_v1.list_node = AsyncMock(return_value=MagicMock(items=nodes))
 
+    # Metrics API reports inflated working-set memory (includes page cache).
     mock_custom.list_cluster_custom_object = AsyncMock(
         return_value={
             "items": [
@@ -94,6 +108,12 @@ async def test_aggregate_node_resources_sums_cpu_and_memory(k8s_client):
         }
     )
 
+    # Kubelet Summary API reports honest rssBytes (excludes page cache).
+    rss = {"node-a": 8192, "node-b": 4096}
+    mock_v1.connect_get_node_proxy_with_path = AsyncMock(
+        side_effect=lambda name, path: _summary_json(rss[name])
+    )
+
     with (
         patch("shared.kubernetes.config.load_incluster_config"),
         patch("shared.kubernetes.ApiClient", return_value=mock_api),
@@ -104,8 +124,57 @@ async def test_aggregate_node_resources_sums_cpu_and_memory(k8s_client):
 
     assert result["cpu_used_cores"] == pytest.approx(2.0)
     assert result["cpu_capacity_cores"] == pytest.approx(24.0)
-    assert result["memory_used_bytes"] == pytest.approx(30720 * 1024**2)
+    # Memory = rss sum (12288Mi), NOT the working-set sum (30720Mi).
+    assert result["memory_used_bytes"] == pytest.approx(12288 * 1024**2)
     assert result["memory_capacity_bytes"] == pytest.approx(98304 * 1024**2)
+
+
+@pytest.mark.asyncio
+async def test_aggregate_node_resources_falls_back_to_working_set(k8s_client):
+    """When the kubelet Summary API is unavailable, per-node memory falls back
+    to the metrics-server working-set value rather than dropping to zero."""
+    mock_api = MagicMock()
+    mock_v1 = MagicMock()
+    mock_custom = MagicMock()
+
+    nodes = [
+        _node("node-a", {"cpu": "16", "memory": "65536Mi"}),
+        _node("node-b", {"cpu": "8", "memory": "32768Mi"}),
+    ]
+    mock_v1.list_node = AsyncMock(return_value=MagicMock(items=nodes))
+    mock_custom.list_cluster_custom_object = AsyncMock(
+        return_value={
+            "items": [
+                {
+                    "metadata": {"name": "node-a"},
+                    "usage": {"cpu": "1500m", "memory": "20480Mi"},
+                },
+                {
+                    "metadata": {"name": "node-b"},
+                    "usage": {"cpu": "500m", "memory": "10240Mi"},
+                },
+            ]
+        }
+    )
+
+    # node-a summary fails (-> working set 20480Mi); node-b returns rss 4096Mi.
+    async def _proxy(name, path):
+        if name == "node-a":
+            raise RuntimeError("kubelet unreachable")
+        return _summary_json(4096)
+
+    mock_v1.connect_get_node_proxy_with_path = AsyncMock(side_effect=_proxy)
+
+    with (
+        patch("shared.kubernetes.config.load_incluster_config"),
+        patch("shared.kubernetes.ApiClient", return_value=mock_api),
+        patch("shared.kubernetes.client.CoreV1Api", return_value=mock_v1),
+        patch("shared.kubernetes.client.CustomObjectsApi", return_value=mock_custom),
+    ):
+        result = await k8s_client.aggregate_node_resources()
+
+    # 20480Mi (node-a working-set fallback) + 4096Mi (node-b rss) = 24576Mi.
+    assert result["memory_used_bytes"] == pytest.approx(24576 * 1024**2)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

The public cluster gauge (`/api/home/observability/stats` -> `+page.svelte` marquee) showed `mem: 71.5 / 98` while the cluster's real memory consumption was ~14 GiB. The gauge sourced memory "used" from the metrics-server API (`metrics.k8s.io/nodes`), which reports **working set** (`usage - inactive_file`). Working set counts *active* file-backed page cache as used.

On the GPU node, loading the Qwen model reads ~36 GiB of weight files off disk, populating active page cache that the cgroup attributes to the inference pod. Verified against `/proc/meminfo` on node-4: `MemAvailable` was 44.2 GiB (71% free), `AnonPages` 13.6 GiB, while `top`/working-set reported ~51 GiB "used". The weights themselves live in VRAM (23.8 of 24.5 GiB), entirely separate from host RAM accounting.

## Fix

Source memory "used" from each kubelet's Summary API (`/stats/summary`, `node.memory.rssBytes`) instead of the metrics-server working set. `rssBytes` is anonymous resident memory and excludes all page cache, so it can't be inflated by file reads. Empirically `rssBytes` (13.4 GiB) matched `/proc/meminfo` `AnonPages` (13.6 GiB) on node-4.

- CPU usage/capacity and memory capacity (allocatable) are unchanged.
- Per-node fallback to the metrics-server working-set value when the Summary API is unavailable (so a kubelet hiccup degrades gracefully instead of zeroing the gauge).
- Adds a `nodes/proxy` `get` rule to the ClusterRole. The Summary API is reachable only through the node proxy subresource; the prior `nodes: [list]` / `metrics.k8s.io/nodes: [list]` rules do not grant it. Without this the calls would 403 and silently fall back, so the RBAC is load-bearing.

## Tradeoff

`rssBytes` excludes ~3-4 GiB of non-reclaimable kernel/slab, so it slightly under-reports vs `free`'s "used" column (`total - MemAvailable`). The `MemAvailable`-based number would need node-exporter, which isn't deployed. RSS is the right "what processes actually hold" figure and removes the page-cache inflation.

## Tests

- `test_aggregate_node_resources_uses_rss_not_working_set` - asserts the gauge sums rss (12288Mi) not working set (30720Mi).
- `test_aggregate_node_resources_falls_back_to_working_set` - one node's Summary API fails; that node uses the working-set fallback while the other uses rss.

🤖 Generated with [Claude Code](https://claude.com/claude-code)