### PR TITLE
chore(opentelemetry-operator): drop Instrumentation CRs for deleted namespaces

### DIFF
--- a/projects/platform/opentelemetry-operator/Chart.yaml
+++ b/projects/platform/opentelemetry-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: opentelemetry-operator
 description: OpenTelemetry Operator with auto-instrumentation for Python, Node.js, and Go
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: "0.145.0"
 dependencies:
   - name: opentelemetry-operator

--- a/projects/platform/opentelemetry-operator/values-prod.yaml
+++ b/projects/platform/opentelemetry-operator/values-prod.yaml
@@ -9,17 +9,14 @@ instrumentation:
   go:
     enabled: true
     endpoint: http://signoz-k8s-infra-otel-agent.signoz.svc.cluster.local:4318
-  # Namespaces to deploy Instrumentation CRs into
+  # Namespaces to deploy Instrumentation CRs into.
+  # Only live namespaces belong here: an entry for a deleted namespace leaves
+  # the app permanently OutOfSync (the CR can never be created).
   namespaces:
     # Production
     - trips
     - api-gateway
-    - mcp-servers
-    - todo
-    - agent-orchestrator
     - cluster-agents
     - monolith
     # Development
-    - grimoire
-    - marine
     - stargazer


### PR DESCRIPTION
## Problem

The `opentelemetry-operator` ArgoCD app has been permanently **OutOfSync** on 15 phantom `Instrumentation` resources. `instrumentation.namespaces` in `values-prod.yaml` declared CRs for five namespaces that no longer exist:

- `mcp-servers`, `todo`, `agent-orchestrator` (retired apps)
- `grimoire`, `marine` (decommissioned; marine moved into the monolith)

All five return `NotFound`, and none appear in the live `kubectl get instrumentation -A` output. The operator can't create an `Instrumentation` in a missing namespace, so ArgoCD reports them OutOfSync forever (3 languages x 5 namespaces = 15).

Found during a GitOps orphan audit (the sibling of the cluster memory-gauge fix in #2654).

## Fix

Keep only the live namespaces: `trips`, `api-gateway`, `cluster-agents`, `monolith`, `stargazer`. `helm template` now renders exactly 15 `Instrumentation` CRs across those 5 namespaces and zero dead ones. With the app's `prune: true`, this flips it back to Synced.

No functional change to instrumentation on live namespaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)