### PR TITLE
feat(monolith): public_reader read-only role + public views (ADR 004 Phase 2)

### DIFF
--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -3212,6 +3212,13 @@ bdd_test(
     ],
 )
 
+# Real-Postgres test: asserts the public_reader role's GRANTs isolate private rows
+# (ADR 004). Uses the bdd_test harness for the pg fixture + applied migrations.
+bdd_test(
+    name = "public_reader_grants_test",
+    srcs = ["public_reader_grants_test.py"],
+)
+
 bdd_test(
     name = "home_bdd_playwright_test",
     timeout = "long",

--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -13,6 +13,9 @@
 # gazelle:exclude stars
 # gazelle:exclude trips
 # gazelle:exclude dr_jobs
+# Hand-written bdd_test target (needs the real-Postgres harness), so keep gazelle
+# from generating a conflicting py_test for it.
+# gazelle:exclude public_reader_grants_test.py
 # gazelle:semgrep_exclude_rules avoid-sqlalchemy-text,sqlmodel-datetime-without-factory,tainted-fastapi-http-request-httpx,tainted-path-traversal-stdlib-fastapi
 load("@aspect_rules_py//py:defs.bzl", "py_library")
 load("@aspect_rules_py//py/private/py_venv:defs.bzl", "py_venv_binary")

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.145.0
+version: 0.145.1
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.144.10
+version: 0.145.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/migrations/20260617000000_public_reader_role.sql
+++ b/projects/monolith/chart/migrations/20260617000000_public_reader_role.sql
@@ -1,0 +1,50 @@
+-- public_reader: least-privilege read-only role for the Phase 5 anonymous public
+-- service (ADR 004 security/004). Confidentiality is enforced here at the database
+-- layer, not just at ingress: the role can read the wholly-public datasets (hikes,
+-- ships, stars) and a public-only view over knowledge notes, and nothing else. It
+-- is never granted the knowledge, chat, home, scheduler, claude_agent, trips, or
+-- todo schemas.
+--
+-- Role creation: in production the role is created by CNPG (spec.managed.roles,
+-- which runs as a superuser), because the Atlas migration runs as the `app` role,
+-- which owns the schemas but lacks CREATEROLE. The DO block below is a no-op in
+-- production (the role already exists); it is here so the CNPG-less test Postgres
+-- (which applies every migration as a superuser) creates the role and can exercise
+-- these GRANTs. The GRANTs run as `app`, which owns every object granted.
+
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'public_reader') THEN
+        CREATE ROLE public_reader NOLOGIN;
+    END IF;
+END $$;
+
+-- Wholly-public datasets: read directly. ALTER DEFAULT PRIVILEGES covers tables a
+-- future migration adds to these schemas, so the grant does not silently rot.
+GRANT USAGE ON SCHEMA hikes, ships, stars TO public_reader;
+GRANT SELECT ON ALL TABLES IN SCHEMA hikes, ships, stars TO public_reader;
+ALTER DEFAULT PRIVILEGES IN SCHEMA hikes, ships, stars
+    GRANT SELECT ON TABLES TO public_reader;
+
+-- Knowledge is private by default. Expose only public, non-deleted notes through a
+-- view. The view is NOT security_invoker, so it reads knowledge.notes with the view
+-- owner's privileges, while public_reader gets SELECT only on the view and no access
+-- to the knowledge schema. Private rows are therefore unreachable, and a public note
+-- whose visibility flips to private disappears from the view immediately.
+CREATE SCHEMA IF NOT EXISTS public_api;
+GRANT USAGE ON SCHEMA public_api TO public_reader;
+
+CREATE VIEW public_api.knowledge_notes AS
+    SELECT
+        note_id,
+        title,
+        type,
+        content,
+        indexed_at,
+        COALESCE(layout_x_public, layout_x) AS layout_x,
+        COALESCE(layout_y_public, layout_y) AS layout_y
+    FROM knowledge.notes
+    WHERE visibility = 'public'
+      AND deleted_at IS NULL;
+
+GRANT SELECT ON public_api.knowledge_notes TO public_reader;

--- a/projects/monolith/chart/migrations/atlas.sum
+++ b/projects/monolith/chart/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:BNd2cU6RuSz4/VDX0RZo/ag61R49sMVhEhkD0wY2P0k=
+h1:DbBkKtWmH1iaDyixfmLvtdtu1bHx5qCDm9jGe1xsz1E=
 20260330000000_initial_schema.sql h1:J2futpSW0nJAIRR7nR7ssT7LwXIYrvRI+PkHb5Y4tLI=
 20260403000000_chat_schema.sql h1:pERUFC0vzM95etRuzp43XzkCV7lBCzrrtY5Mk7aF3CA=
 20260404000000_chat_attachments.sql h1:tv+Fdbr1rQC5nzUxfaBC0O6fu2OMGgLWf+YNg1WQXi4=
@@ -46,3 +46,4 @@ h1:BNd2cU6RuSz4/VDX0RZo/ag61R49sMVhEhkD0wY2P0k=
 20260615120000_trips_schema.sql h1:yN+REAy71uuXowKKwhPdBh61zJ0zbdb6Oe6eszzbcK0=
 20260616120000_drop_raw_inputs_content.sql h1:qqk/jqkPbF7Ivb5CJOfbZVpiOEBrt8s48LCpHqAvS/Y=
 20260616130000_dr_jobs_schema.sql h1:lGsOevT79e9N0UJPW4h10MMPGk9xYl3rquNi5FKZiMQ=
+20260617000000_public_reader_role.sql h1:+NzD4qGXVY9INroepjCrzXcyMf4Krma35Z2tpDvLkpU=

--- a/projects/monolith/chart/templates/cnpg-cluster.yaml
+++ b/projects/monolith/chart/templates/cnpg-cluster.yaml
@@ -22,6 +22,19 @@ spec:
       - name: vector
         image:
           reference: {{ .Values.postgres.pgvector.image }}
+  # Declarative roles. CNPG runs as a superuser, so it (not the app-role Atlas
+  # migrations) is what can CREATE the public_reader role. Its table/schema GRANTs
+  # live in chart/migrations/20260617000000_public_reader_role.sql; CNPG does not
+  # manage privileges. public_reader is the read-only identity for the Phase 5
+  # anonymous public service (ADR 004 security/004). It stays NOLOGIN here: no
+  # service consumes it yet, so a login credential (client-cert preferred) is added
+  # in Phase 5.
+  managed:
+    roles:
+      - name: public_reader
+        ensure: present
+        login: false
+        comment: "Read-only public surface (ADR 004); GRANTs in Atlas migration"
   # Hosts five databases (monolith, temporal, temporal_visibility,
   # lakehouse, postgres); Temporal is connection-heavy. The prior 256Mi
   # limit OOMKilled the instance 359 times. 1Gi limit with shared_buffers

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.145.0
+      targetRevision: 0.145.1
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.144.10
+      targetRevision: 0.145.0
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/public_reader_grants_test.py
+++ b/projects/monolith/public_reader_grants_test.py
@@ -1,0 +1,65 @@
+"""Phase 2 (ADR 004 security/004): public_reader is a least-privilege read role.
+
+Exercises the GRANTs from chart/migrations/20260617000000_public_reader_role.sql
+against a real Postgres (the `pg` fixture applies every migration), using SET ROLE
+so no login credential is needed. The point of the role is confidentiality at the
+database layer: private rows must be unreachable even with full query access.
+"""
+
+import pytest
+from sqlmodel import Session, create_engine, text
+
+
+def _seed_notes(engine) -> None:
+    with Session(engine) as session:
+        session.execute(
+            text(
+                """
+                INSERT INTO knowledge.notes
+                    (note_id, path, title, content_hash, content, visibility)
+                VALUES
+                    ('pubnote', 'pubnote.md', 'Public', 'h1', 'public body', 'public'),
+                    ('privnote', 'privnote.md', 'Private', 'h2', 'secret body', 'private')
+                ON CONFLICT (note_id) DO NOTHING
+                """
+            )
+        )
+        session.commit()
+
+
+def test_public_reader_view_exposes_only_public_notes(pg):
+    engine = create_engine(pg.url)
+    _seed_notes(engine)
+    try:
+        with Session(engine) as session:
+            session.execute(text("SET ROLE public_reader"))
+            rows = session.execute(
+                text("SELECT note_id FROM public_api.knowledge_notes ORDER BY note_id")
+            ).all()
+            assert [r[0] for r in rows] == ["pubnote"]
+    finally:
+        engine.dispose()
+
+
+def test_public_reader_denied_on_private_knowledge_table(pg):
+    engine = create_engine(pg.url)
+    try:
+        with Session(engine) as session:
+            session.execute(text("SET ROLE public_reader"))
+            with pytest.raises(Exception) as exc:
+                session.execute(text("SELECT note_id FROM knowledge.notes")).all()
+            assert "permission denied" in str(exc.value).lower()
+    finally:
+        engine.dispose()
+
+
+def test_public_reader_can_read_public_datasets(pg):
+    engine = create_engine(pg.url)
+    try:
+        with Session(engine) as session:
+            session.execute(text("SET ROLE public_reader"))
+            # A granted SELECT on each wholly-public dataset must not raise.
+            for table in ("ships.vessels", "stars.sites", "hikes.walks"):
+                session.execute(text(f"SELECT count(*) FROM {table}"))
+    finally:
+        engine.dispose()


### PR DESCRIPTION
Phase 2 of the monolith modularity program (plan: \`docs/plans/2026-06-16-monolith-modularity.md\`; rationale: ADR 004 security/004). Additive, no behavior change to existing paths.

## What
Establishes the **confidentiality boundary** for the future anonymous public service (Phase 5) at the database layer.

- **`public_reader` role** created declaratively by CNPG (\`spec.managed.roles\`). CNPG runs as superuser, which is required: the Atlas migration runs as \`app\`, which lacks \`CREATEROLE\`. Stays \`NOLOGIN\` (no consumer yet); the login credential (client-cert preferred) lands in Phase 5.
- **GRANTs** (Atlas migration, run as \`app\` which owns the objects): \`SELECT\` on the wholly-public \`hikes\`/\`ships\`/\`stars\` schemas (+ \`ALTER DEFAULT PRIVILEGES\` so future tables stay covered), and \`SELECT\` on a new \`public_api.knowledge_notes\` view. Never grants \`knowledge\`/\`chat\`/\`home\`/\`scheduler\`/\`claude_agent\`/\`trips\`/\`todo\`.
- **\`public_api.knowledge_notes\`** exposes only \`visibility = 'public'\`, non-deleted notes. The view is owned by \`app\` and is not \`security_invoker\`, so \`public_reader\` reads public rows through it without any access to the \`knowledge\` schema. Private rows are unreachable by database permission, not application logic.
- **GRANT isolation test** (\`public_reader_grants_test.py\`, real Postgres via the \`bdd_test\` harness): asserts \`public_reader\` sees only public notes through the view, is **denied** on \`knowledge.notes\`, and can read the public datasets, via \`SET ROLE\` (no credential needed).

## Notes
- The migration's \`DO\`-block \`CREATE ROLE IF NOT EXISTS\` is a no-op in prod (CNPG already made the role); it exists so the CNPG-less CI Postgres (which applies migrations as superuser) can create the role and exercise the grants.
- No body sanitization at the DB layer: a public note's body is public; only graph edges to private notes are filtered, which stays app-side. Confirmed with Joe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)