### PR TITLE
feat(monolith): postgres read replica (CNPG instances: 2) — ADR 004 Phase 3

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.145.1
+version: 0.146.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/templates/cnpg-cluster.yaml
+++ b/projects/monolith/chart/templates/cnpg-cluster.yaml
@@ -35,11 +35,12 @@ spec:
         ensure: present
         login: false
         comment: "Read-only public surface (ADR 004); GRANTs in Atlas migration"
-  # Hosts five databases (monolith, temporal, temporal_visibility,
-  # lakehouse, postgres); Temporal is connection-heavy. The prior 256Mi
-  # limit OOMKilled the instance 359 times. 1Gi limit with shared_buffers
-  # at 256MB (25% of limit) gives headroom for the working set plus
-  # per-connection work_mem.
+  # Hosts the monolith database (plus the default postgres maintenance db);
+  # the temporal/temporal_visibility/lakehouse databases were decommissioned
+  # 2026-06-14. The prior 256Mi limit OOMKilled the instance 359 times. 1Gi
+  # limit with shared_buffers at 256MB (25% of limit) gives headroom for the
+  # working set plus per-connection work_mem. Applies per instance, so the
+  # standby (instances: 2) gets the same budget.
   resources:
     requests:
       memory: "512Mi"

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.145.1
+      targetRevision: 0.146.0
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/deploy/values.yaml
+++ b/projects/monolith/deploy/values.yaml
@@ -14,7 +14,10 @@ frontend:
   otelCollectorUrl: "http://signoz-k8s-infra-otel-agent.signoz.svc.cluster.local:4318"
 
 postgres:
-  instances: 1
+  # Two instances: a primary (-rw) plus a hot standby (-ro) for the Phase 5
+  # public read-only service (ADR 004 security/004) and for availability. CNPG
+  # auto-creates the -ro / -r services and streams replication.
+  instances: 2
   storage:
     size: 50Gi
 


### PR DESCRIPTION
Phase 3 of the monolith modularity program (plan: \`docs/plans/2026-06-16-monolith-modularity.md\`; ADR 004 Layer 3).

## What
- \`postgres.instances: 1 -> 2\` in \`deploy/values.yaml\`. CNPG stands up a hot standby and auto-creates the \`monolith-pg-ro\` (read-only) and \`-r\` services with streaming replication.
- Fixed the stale \`cnpg-cluster.yaml\` comment (dropped the decommissioned temporal/lakehouse databases; noted the budget is per-instance).

Nothing reads \`-ro\` yet; the public service consumes it in Phase 5. This PR just stands up the standby + availability.

## Pre-flight (capacity)
Checked before bumping: \`monolith-pg-1\` uses **638Mi** of its 1Gi limit on node-3; no node is above **58%** memory (node-1 at 48%, ~5GB free). A second 1Gi-limit instance fits with anti-affinity. The historical 359 OOMKills were at the old 256Mi limit. Standby mirrors only \`monolith\`+\`postgres\` (temporal/lakehouse gone).

## Post-merge verification
Will confirm 2 ready instances, \`-ro\` endpoint resolves, and low replication lag after ArgoCD syncs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)