### PR TITLE
feat(monolith): Phase 5a - read-only public service entrypoint (main_public)

### DIFF
--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -319,6 +319,19 @@ py_test(
 )
 
 py_test(
+    name = "main_public_routes_test",
+    srcs = ["app/main_public_routes_test.py"],
+    imports = ["."],
+    deps = [
+        ":monolith_backend",
+        "@pip//fastapi",
+        "@pip//pytest",
+        "@pip//sqlmodel",
+        "@pip//tzdata",
+    ],
+)
+
+py_test(
     name = "integration_test",
     size = "medium",
     srcs = ["app/integration_test.py"],

--- a/projects/monolith/app/bdd_completeness_test.py
+++ b/projects/monolith/app/bdd_completeness_test.py
@@ -33,6 +33,9 @@ _PUBLIC_EXCLUSIONS: set[str] = {
     "home.register",
     "chat.register",
     "knowledge.register",
+    # register_public() is app wiring (Phase 5a public split), not a BDD route
+    "home.register_public",
+    "knowledge.register_public",
     # FastAPI class is re-exported by domains, not a domain function
     "home.FastAPI",
     "chat.FastAPI",

--- a/projects/monolith/app/main_public.py
+++ b/projects/monolith/app/main_public.py
@@ -1,0 +1,46 @@
+"""Public, read-only FastAPI entrypoint.
+
+A second, lean entrypoint that mounts ONLY the public, read-only route surface
+via each domain's ``register_public`` hook. It deliberately omits everything in
+``app.main`` that the public tier must never run: the Discord bot, the scheduler
+loop, AIS ingest, vault clone, the ``/mcp`` mount, OTEL background setup, and the
+SvelteKit static mount. There is no lifespan, so importing this module is cheap
+and side-effect-free (the route-table guard test relies on that).
+
+Phase 5a only stands up the code and a CI guard test; the public service is not
+deployed here (image/chart land in Phase 5c). The knowledge public routes still
+query private tables today and will 500 as ``public_reader`` until Phase 5a'.
+"""
+
+from __future__ import annotations
+
+import dr_jobs
+import hikes
+import home
+import knowledge
+import ships
+import stars
+from app.log import configure_logging
+from fastapi import FastAPI
+
+configure_logging()
+
+app = FastAPI(title="Monolith Public")
+
+ships.register_public(app)
+stars.register_public(app)
+hikes.register_public(app)
+dr_jobs.register_public(app)
+knowledge.register_public(app)
+home.register_public(app)
+
+
+@app.get("/healthz")
+def healthz():
+    return {"status": "ok"}
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(app, host="0.0.0.0", port=8000, log_level="warning")

--- a/projects/monolith/app/main_public_routes_test.py
+++ b/projects/monolith/app/main_public_routes_test.py
@@ -1,0 +1,118 @@
+"""Route-table guard for the public app.
+
+Asserts that ``app.main_public`` exposes ONLY the public, read-only route
+surface and ZERO private paths. This is a pure import + introspection test:
+it never starts the app or touches a database, so it stays fast and stable
+in CI.
+
+``import pytest`` is intentional even though no fixtures are used: it keeps
+gazelle's dependency inference attaching ``@pip//pytest`` to this target.
+"""
+
+from __future__ import annotations
+
+import pytest  # noqa: F401  (keeps the gazelle pytest dep; see module docstring)
+
+from app.main_public import app
+
+
+def _paths() -> set[str]:
+    return {r.path for r in app.routes if hasattr(r, "path")}
+
+
+# ---------------------------------------------------------------------------
+# Positive assertions: these public paths MUST be present.
+# ---------------------------------------------------------------------------
+
+REQUIRED_PATHS = [
+    "/api/knowledge/public/graph",
+    "/api/knowledge/public/notes/{note_id}",
+    "/api/home/observability/stats",
+    "/api/home/observability/topology",
+]
+
+# Prefixes for the wholly-public domains; at least one route per prefix must
+# be mounted. Mirrors each domain router's declared prefix.
+REQUIRED_PREFIXES = [
+    "/api/ships",
+    "/api/stars",
+    "/api/hikes",
+    "/api/dr-jobs",
+]
+
+
+def test_required_public_paths_present():
+    paths = _paths()
+    for required in REQUIRED_PATHS:
+        assert required in paths, f"expected public path {required!r} to be mounted"
+
+
+def test_each_public_domain_has_a_route():
+    paths = _paths()
+    for prefix in REQUIRED_PREFIXES:
+        assert any(p.startswith(prefix) for p in paths), (
+            f"expected at least one route under {prefix!r}"
+        )
+
+
+def test_healthz_present():
+    assert "/healthz" in _paths()
+
+
+# ---------------------------------------------------------------------------
+# Negative assertions: these private paths MUST be absent.
+# ---------------------------------------------------------------------------
+
+
+def test_no_mcp_mount():
+    paths = _paths()
+    assert not any(p.startswith("/mcp") for p in paths), (
+        "the public app must not mount /mcp"
+    )
+
+
+def test_only_public_knowledge_paths():
+    paths = _paths()
+    for p in paths:
+        if p.startswith("/api/knowledge"):
+            assert p.startswith("/api/knowledge/public"), (
+                f"private knowledge path {p!r} leaked into the public app"
+            )
+
+
+def test_only_observability_home_paths():
+    paths = _paths()
+    for p in paths:
+        if p.startswith("/api/home"):
+            assert p.startswith("/api/home/observability"), (
+                f"non-observability home path {p!r} leaked into the public app"
+            )
+
+
+def test_no_schedule_chat_scheduler_agent_paths():
+    paths = _paths()
+    forbidden_prefixes = [
+        "/api/home/schedule",
+        "/api/chat",
+        "/api/scheduler",
+        "/api/agent",
+        # knowledge tasks router is private
+        "/api/knowledge/tasks",
+    ]
+    for prefix in forbidden_prefixes:
+        leaked = [p for p in paths if p.startswith(prefix)]
+        assert not leaked, f"private paths under {prefix!r} leaked: {leaked}"
+
+
+def test_specific_private_knowledge_paths_absent():
+    paths = _paths()
+    explicitly_absent = [
+        "/api/knowledge/search",
+        "/api/knowledge/graph",
+        "/api/knowledge/notes/{note_id}",
+        "/api/knowledge/gaps",
+    ]
+    for path in explicitly_absent:
+        assert path not in paths, (
+            f"private knowledge path {path!r} must not be in the public app"
+        )

--- a/projects/monolith/app/main_public_routes_test.py
+++ b/projects/monolith/app/main_public_routes_test.py
@@ -59,6 +59,34 @@ def test_healthz_present():
     assert "/healthz" in _paths()
 
 
+# Deny-by-default allowlist: every route on the public app must fall under one
+# of these prefixes. Unlike the negative assertions below (which forbid the
+# private prefixes we know about today), this catches a future domain mounted
+# under an unexpected prefix, so a new private surface cannot silently leak
+# into the public artifact.
+ALLOWED_PREFIXES = (
+    "/api/ships",
+    "/api/stars",
+    "/api/hikes",
+    "/api/dr-jobs",
+    "/api/knowledge/public",
+    "/api/home/observability",
+    "/healthz",
+    "/openapi.json",
+    "/docs",
+    "/redoc",
+)
+
+
+def test_only_allowed_route_prefixes():
+    paths = _paths()
+    for p in paths:
+        assert p.startswith(ALLOWED_PREFIXES), (
+            f"path {p!r} is not in the public allowlist; "
+            "the public app must expose only public, read-only routes"
+        )
+
+
 # ---------------------------------------------------------------------------
 # Negative assertions: these private paths MUST be absent.
 # ---------------------------------------------------------------------------

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.148.0
+version: 0.148.1
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.147.2
+version: 0.148.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.147.2
+      targetRevision: 0.148.0
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.148.0
+      targetRevision: 0.148.1
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/dr_jobs/__init__.py
+++ b/projects/monolith/dr_jobs/__init__.py
@@ -17,6 +17,11 @@ def register(app: FastAPI) -> None:
     app.include_router(router)
 
 
+def register_public(app: FastAPI) -> None:
+    """dr_jobs is a wholly public, read-only domain: reuse register."""
+    register(app)
+
+
 def on_startup_jobs(session: Session) -> None:
     """Register the daily NHS Scotland scrape job."""
     from scheduler.api import register_job

--- a/projects/monolith/hikes/__init__.py
+++ b/projects/monolith/hikes/__init__.py
@@ -11,6 +11,11 @@ def register(app: FastAPI) -> None:
     app.include_router(router)
 
 
+def register_public(app: FastAPI) -> None:
+    """Hikes is a wholly public, read-only domain: reuse register."""
+    register(app)
+
+
 def on_startup_jobs(session: Session) -> None:
     """Register hikes scheduled jobs (scrape + forecast refresh + hourly prune)."""
     from scheduler.api import register_job

--- a/projects/monolith/home/__init__.py
+++ b/projects/monolith/home/__init__.py
@@ -11,6 +11,13 @@ def register(app: FastAPI) -> None:
     app.include_router(observability_router)
 
 
+def register_public(app: FastAPI) -> None:
+    """Register only the public, read-only home routes (observability stats/topology)."""
+    from home.observability.router import router as observability_router
+
+    app.include_router(observability_router)
+
+
 def on_startup_jobs(session) -> None:
     from scheduler.api import register_job
     from home.schedule import calendar_poll_handler

--- a/projects/monolith/knowledge/__init__.py
+++ b/projects/monolith/knowledge/__init__.py
@@ -13,13 +13,30 @@ from fastapi import FastAPI
 
 from knowledge.api import get_embedding_client, get_store, search_notes
 
-__all__ = ["register", "search_notes", "get_store", "get_embedding_client"]
+__all__ = [
+    "register",
+    "register_public",
+    "search_notes",
+    "get_store",
+    "get_embedding_client",
+]
 
 
 def register(app: FastAPI) -> None:
-    """Register knowledge domain routers with the app."""
+    """Register knowledge domain routers with the app (full private surface)."""
+    from knowledge.public_router import router as public_router
     from knowledge.router import router
     from knowledge.tasks_router import router as tasks_router
 
     app.include_router(router)
     app.include_router(tasks_router)
+    # Mount the public routes on the private app too so /api/knowledge/public/*
+    # keeps serving exactly as before the public split.
+    app.include_router(public_router)
+
+
+def register_public(app: FastAPI) -> None:
+    """Register only the public, read-only knowledge routes."""
+    from knowledge.public_router import router as public_router
+
+    app.include_router(public_router)

--- a/projects/monolith/knowledge/http_cache.py
+++ b/projects/monolith/knowledge/http_cache.py
@@ -1,0 +1,41 @@
+"""Shared HTTP caching helpers for knowledge graph endpoints.
+
+These helpers back the Cache-Control / ETag / Last-Modified behaviour for both
+the private graph route (``knowledge.router``) and the public graph route
+(``knowledge.public_router``). They live in this neutral module so the public
+router never has to import the private-route module to reuse them.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+# Mirrors NOTES_PAGE_CACHE_CONTROL in projects/monolith/frontend/src/lib/cache-headers.js — keep in sync.
+_GRAPH_CACHE_CONTROL = (
+    "public, s-maxage=3600, stale-while-revalidate=86400, stale-if-error=31536000"
+)
+
+
+def _as_utc(value: datetime | None) -> datetime | None:
+    """Coerce a datetime to tz-aware UTC.
+
+    Postgres returns tz-aware values; SQLite (used in tests) can return
+    naive ones even though we always write tz-aware UTC. Treat naive
+    datetimes as UTC so downstream formatters and ETag stamps are stable
+    across both backends.
+    """
+    if value is None:
+        return None
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+def _graph_etag(node_count: int, indexed_at: datetime | None) -> str:
+    """Stable ETag for a graph payload.
+
+    Combines max(indexed_at) with node count so deletions invalidate even
+    when the surviving notes' timestamps don't move.
+    """
+    stamp = indexed_at.isoformat() if indexed_at is not None else "null"
+    return f'"{stamp}-{node_count}"'

--- a/projects/monolith/knowledge/public_router.py
+++ b/projects/monolith/knowledge/public_router.py
@@ -1,0 +1,219 @@
+"""Public, read-only HTTP API for the knowledge graph.
+
+Holds the two public knowledge endpoints so they can be mounted on the
+public-only app (``app.main_public``) without pulling in the private-route
+module (``knowledge.router``):
+
+- ``GET /api/knowledge/public/graph`` — public-only graph (public nodes,
+  doubly-public edges).
+- ``GET /api/knowledge/public/notes/{note_id}`` — a single note iff its
+  effective visibility is ``public``.
+
+These handlers are also mounted on the private app (see ``knowledge.register``)
+so ``/api/knowledge/public/*`` behaves identically there.
+"""
+
+from __future__ import annotations
+
+import logging
+from email.utils import format_datetime
+
+from fastapi import APIRouter, Depends, HTTPException, Request, Response
+from sqlalchemy import func, or_
+from sqlmodel import Session, select
+
+from app.db import get_session
+from knowledge.gardener import _slugify
+from knowledge.http_cache import _as_utc, _graph_etag, _GRAPH_CACHE_CONTROL
+from knowledge.models import Note, NoteLink
+from knowledge.notes import resolve_note_body
+from knowledge.service import get_vault_root
+from knowledge.store import GRAPH_NOTE_TYPES
+from knowledge.visibility import (
+    effective_visibility,
+    public_notes_filter,
+    sanitize_public_body,
+)
+from knowledge.visibility import _slugify as _visibility_slugify
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/knowledge", tags=["knowledge"])
+
+
+@router.get("/public/graph")
+def get_public_graph(
+    request: Request,
+    response: Response,
+    session: Session = Depends(get_session),
+):
+    """Public-only knowledge graph: only public nodes, only doubly-public edges.
+
+    Mirrors :func:`get_graph` but applies ``public_notes_filter()`` to both
+    ends of every edge so a private note can never appear as a node *or* a
+    target. Same Cache-Control + ETag semantics so the CDN treats this
+    payload identically.
+    """
+    # Only public notes whose type is in the renderable graph set. Gap
+    # stubs (type='gap') with NULL visibility are excluded by the
+    # visibility filter alone, but this also keeps the type filter
+    # consistent with get_graph().
+    public_note_rows = session.execute(
+        select(
+            Note.note_id,
+            Note.title,
+            Note.type,
+            Note.indexed_at,
+            # Prefer public-only layout positions (computed over the public
+            # subgraph by knowledge.service._run_public_layout_pass); fall
+            # back to the full-graph positions if the public pass hasn't
+            # populated this row yet, so a fresh deploy never serves NULL
+            # coords. Same shape consumed by /private/notes — keep both as
+            # nullable in the response, the client handles either.
+            func.coalesce(Note.layout_x_public, Note.layout_x).label("x"),
+            func.coalesce(Note.layout_y_public, Note.layout_y).label("y"),
+        )
+        .where(public_notes_filter())
+        .where(Note.type.in_(list(GRAPH_NOTE_TYPES)))
+        .where(Note.deleted_at.is_(None))
+    ).all()
+
+    public_note_ids = {row.note_id for row in public_note_rows}
+    slug_to_note_id = {_slugify(nid): nid for nid in public_note_ids}
+
+    if public_note_ids:
+        # Single SQL join enforces both-ends-public: source side via the
+        # join filter, target side via the IN clause against the resolved
+        # public slug set (mirrors get_graph's slug→canonical resolution).
+        link_rows = session.execute(
+            select(
+                Note.note_id.label("source"),
+                NoteLink.target_id.label("target"),
+                NoteLink.kind,
+                NoteLink.edge_type,
+            )
+            .join(Note, NoteLink.src_note_fk == Note.id)
+            .where(public_notes_filter())
+            .where(Note.deleted_at.is_(None))
+        ).all()
+    else:
+        link_rows = []
+
+    edges: list[dict] = []
+    for row in link_rows:
+        canonical_target = slug_to_note_id.get(_slugify(row.target))
+        if canonical_target is None:
+            continue
+        edges.append(
+            {
+                "source": row.source,
+                "target": canonical_target,
+                "kind": row.kind,
+                "edge_type": row.edge_type,
+            }
+        )
+
+    degree_by_note_id: dict[str, int] = {}
+    for edge in edges:
+        degree_by_note_id[edge["source"]] = degree_by_note_id.get(edge["source"], 0) + 1
+        degree_by_note_id[edge["target"]] = degree_by_note_id.get(edge["target"], 0) + 1
+
+    nodes = [
+        {
+            "id": row.note_id,
+            "title": row.title,
+            "type": row.type,
+            "degree": degree_by_note_id.get(row.note_id, 0),
+            "x": row.x,
+            "y": row.y,
+        }
+        for row in public_note_rows
+    ]
+
+    indexed_at = _as_utc(
+        max((row.indexed_at for row in public_note_rows), default=None)
+    )
+    etag = _graph_etag(len(public_note_rows), indexed_at)
+    headers = {"Cache-Control": _GRAPH_CACHE_CONTROL, "ETag": etag}
+    if indexed_at is not None:
+        headers["Last-Modified"] = format_datetime(indexed_at, usegmt=True)
+
+    if request.headers.get("if-none-match") == etag:
+        return Response(status_code=304, headers=headers)
+
+    for key, value in headers.items():
+        response.headers[key] = value
+    logger.info("public.graph.served nodes=%d edges=%d", len(nodes), len(edges))
+    return {
+        "nodes": nodes,
+        "edges": edges,
+        # Mirrors get_graph's response — StatusBar in the SvelteKit page
+        # reads this to display "indexed Xm ago". Previously omitted so
+        # the public page showed "indexed —" while the private one didn't.
+        "indexed_at": indexed_at.isoformat() if indexed_at is not None else None,
+    }
+
+
+@router.get("/public/notes/{note_id}")
+def get_public_note(
+    note_id: str,
+    session: Session = Depends(get_session),
+) -> dict:
+    """Return a single note iff its effective visibility is ``public``.
+
+    The 404 response is identical for missing notes AND for notes that
+    exist but are private/null-visibility — the existence of a private
+    note must never be observable. Body wikilinks targeting private
+    notes are stripped to plain text via :func:`sanitize_public_body`;
+    wikilinks targeting public notes are left intact for the frontend
+    renderer to resolve.
+    """
+    note = session.exec(
+        select(Note).where(Note.note_id == note_id).where(Note.deleted_at.is_(None))
+    ).one_or_none()
+    if note is None or effective_visibility(note) != "public":
+        # Identical 404 for missing and private — never expose existence.
+        # The reason is logged but not surfaced in the response.
+        reason = "not_found" if note is None else "private_gated"
+        logger.info("public.note.404 note_id=%s reason=%s", note_id, reason)
+        raise HTTPException(status_code=404, detail="Not Found")
+
+    # ADR 006 Phase 2: body of record is Postgres ``content``. The vault
+    # read is a fallback only while the Phase 1 backfill is in flight, and
+    # ``resolve_note_body`` keeps the same path-traversal guard so a
+    # malformed path can't escape the vault root.
+    vault_root = get_vault_root()
+    body = resolve_note_body(note.content, note.path, vault_root)
+    if body is None:
+        # Same identical 404 — don't leak that the DB row exists but
+        # the body is unavailable.
+        logger.info("public.note.404 note_id=%s reason=vault_file_missing", note_id)
+        raise HTTPException(status_code=404, detail="Not Found")
+
+    # Slugified ids of every non-public note. ``sanitize_public_body``
+    # slugifies wikilink display text via ``visibility._slugify`` and
+    # drops the bracketing on any match — use the same helper here so
+    # the sets compare consistently. Note: ``or_(... != 'public', ...
+    # IS NULL)`` is required because in SQL ``NULL != 'public'`` is
+    # ``NULL``, not true, so a bare ``!=`` would silently leave NULL-
+    # visibility notes out of the private set.
+    private_slugs = {
+        _visibility_slugify(n.note_id)
+        for n in session.exec(
+            select(Note)
+            .where(or_(Note.visibility != "public", Note.visibility.is_(None)))
+            .where(Note.deleted_at.is_(None))
+        ).all()
+    }
+    sanitized = sanitize_public_body(body, private_slugs)
+
+    indexed_at = _as_utc(note.indexed_at)
+    logger.info("public.note.served note_id=%s", note_id)
+    return {
+        "note_id": note.note_id,
+        "title": note.title,
+        "tags": list(note.tags or []),
+        "aliases": list(note.aliases or []),
+        "indexed_at": indexed_at.isoformat() if indexed_at is not None else None,
+        "body": sanitized,
+    }

--- a/projects/monolith/knowledge/public_router.py
+++ b/projects/monolith/knowledge/public_router.py
@@ -4,9 +4,9 @@ Holds the two public knowledge endpoints so they can be mounted on the
 public-only app (``app.main_public``) without pulling in the private-route
 module (``knowledge.router``):
 
-- ``GET /api/knowledge/public/graph`` — public-only graph (public nodes,
+- ``GET /api/knowledge/public/graph``: public-only graph (public nodes,
   doubly-public edges).
-- ``GET /api/knowledge/public/notes/{note_id}`` — a single note iff its
+- ``GET /api/knowledge/public/notes/{note_id}``: a single note iff its
   effective visibility is ``public``.
 
 These handlers are also mounted on the private app (see ``knowledge.register``)
@@ -68,7 +68,7 @@ def get_public_graph(
             # subgraph by knowledge.service._run_public_layout_pass); fall
             # back to the full-graph positions if the public pass hasn't
             # populated this row yet, so a fresh deploy never serves NULL
-            # coords. Same shape consumed by /private/notes — keep both as
+            # coords. Same shape consumed by /private/notes, keep both as
             # nullable in the response, the client handles either.
             func.coalesce(Note.layout_x_public, Note.layout_x).label("x"),
             func.coalesce(Note.layout_y_public, Note.layout_y).label("y"),
@@ -147,9 +147,9 @@ def get_public_graph(
     return {
         "nodes": nodes,
         "edges": edges,
-        # Mirrors get_graph's response — StatusBar in the SvelteKit page
+        # Mirrors get_graph's response: the StatusBar in the SvelteKit page
         # reads this to display "indexed Xm ago". Previously omitted so
-        # the public page showed "indexed —" while the private one didn't.
+        # the public page showed no "indexed" stamp while the private one did.
         "indexed_at": indexed_at.isoformat() if indexed_at is not None else None,
     }
 
@@ -162,7 +162,7 @@ def get_public_note(
     """Return a single note iff its effective visibility is ``public``.
 
     The 404 response is identical for missing notes AND for notes that
-    exist but are private/null-visibility — the existence of a private
+    exist but are private/null-visibility, so the existence of a private
     note must never be observable. Body wikilinks targeting private
     notes are stripped to plain text via :func:`sanitize_public_body`;
     wikilinks targeting public notes are left intact for the frontend
@@ -172,7 +172,7 @@ def get_public_note(
         select(Note).where(Note.note_id == note_id).where(Note.deleted_at.is_(None))
     ).one_or_none()
     if note is None or effective_visibility(note) != "public":
-        # Identical 404 for missing and private — never expose existence.
+        # Identical 404 for missing and private: never expose existence.
         # The reason is logged but not surfaced in the response.
         reason = "not_found" if note is None else "private_gated"
         logger.info("public.note.404 note_id=%s reason=%s", note_id, reason)
@@ -185,14 +185,14 @@ def get_public_note(
     vault_root = get_vault_root()
     body = resolve_note_body(note.content, note.path, vault_root)
     if body is None:
-        # Same identical 404 — don't leak that the DB row exists but
+        # Same identical 404: don't leak that the DB row exists but
         # the body is unavailable.
         logger.info("public.note.404 note_id=%s reason=vault_file_missing", note_id)
         raise HTTPException(status_code=404, detail="Not Found")
 
     # Slugified ids of every non-public note. ``sanitize_public_body``
     # slugifies wikilink display text via ``visibility._slugify`` and
-    # drops the bracketing on any match — use the same helper here so
+    # drops the bracketing on any match; use the same helper here so
     # the sets compare consistently. Note: ``or_(... != 'public', ...
     # IS NULL)`` is required because in SQL ``NULL != 'public'`` is
     # ``NULL``, not true, so a bare ``!=`` would silently leave NULL-

--- a/projects/monolith/knowledge/router.py
+++ b/projects/monolith/knowledge/router.py
@@ -14,17 +14,13 @@ can override it with a deterministic fake via ``app.dependency_overrides``.
 from __future__ import annotations
 
 import logging
-import os
 import re
-from datetime import datetime, timezone
 from email.utils import format_datetime
-from pathlib import Path
 from typing import Literal
 
 import yaml
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response
 from pydantic import BaseModel
-from sqlalchemy import func, or_
 from sqlmodel import Session, select
 
 from app.db import get_session
@@ -40,10 +36,11 @@ from knowledge.gaps import (
     undelete_gap,
     verify_gap,
 )
-from knowledge.gardener import Gardener, _slugify
+from knowledge.gardener import Gardener
+from knowledge.http_cache import _as_utc, _graph_etag, _GRAPH_CACHE_CONTROL
 from knowledge.indexing import index_note_best_effort
 from knowledge.ingest_queue import IngestQueueItem, ingest_raw
-from knowledge.models import AtomRawProvenance, Note, NoteLink, RawInput
+from knowledge.models import AtomRawProvenance, RawInput
 from knowledge.notes import (
     _note_to_review_dict,
     delete_note,
@@ -54,14 +51,8 @@ from knowledge.notes import (
     undelete_note,
     verify_note_visibility,
 )
-from knowledge.service import DEFAULT_VAULT_ROOT, VAULT_ROOT_ENV
-from knowledge.store import GRAPH_NOTE_TYPES, KnowledgeStore
-from knowledge.visibility import (
-    effective_visibility,
-    public_notes_filter,
-    sanitize_public_body,
-)
-from knowledge.visibility import _slugify as _visibility_slugify
+from knowledge.service import get_vault_root
+from knowledge.store import KnowledgeStore
 from shared.embedding import EmbeddingClient
 
 logger = logging.getLogger(__name__)
@@ -76,11 +67,6 @@ def get_embedding_client() -> EmbeddingClient:
     to inject a deterministic fake.
     """
     return EmbeddingClient()
-
-
-def _get_vault_root() -> Path:
-    """Resolve the vault root from the env (or default), as an absolute path."""
-    return Path(os.environ.get(VAULT_ROOT_ENV, DEFAULT_VAULT_ROOT)).resolve()
 
 
 @router.get("/search")
@@ -111,37 +97,6 @@ async def search_knowledge(
     return {"results": results}
 
 
-# Mirrors NOTES_PAGE_CACHE_CONTROL in projects/monolith/frontend/src/lib/cache-headers.js — keep in sync.
-_GRAPH_CACHE_CONTROL = (
-    "public, s-maxage=3600, stale-while-revalidate=86400, stale-if-error=31536000"
-)
-
-
-def _as_utc(value: datetime | None) -> datetime | None:
-    """Coerce a datetime to tz-aware UTC.
-
-    Postgres returns tz-aware values; SQLite (used in tests) can return
-    naive ones even though we always write tz-aware UTC. Treat naive
-    datetimes as UTC so downstream formatters and ETag stamps are stable
-    across both backends.
-    """
-    if value is None:
-        return None
-    if value.tzinfo is None:
-        return value.replace(tzinfo=timezone.utc)
-    return value.astimezone(timezone.utc)
-
-
-def _graph_etag(node_count: int, indexed_at: datetime | None) -> str:
-    """Stable ETag for a graph payload.
-
-    Combines max(indexed_at) with node count so deletions invalidate even
-    when the surviving notes' timestamps don't move.
-    """
-    stamp = indexed_at.isoformat() if indexed_at is not None else "null"
-    return f'"{stamp}-{node_count}"'
-
-
 @router.get("/graph")
 def get_graph(
     request: Request,
@@ -169,184 +124,6 @@ def get_graph(
     return graph
 
 
-@router.get("/public/graph")
-def get_public_graph(
-    request: Request,
-    response: Response,
-    session: Session = Depends(get_session),
-):
-    """Public-only knowledge graph: only public nodes, only doubly-public edges.
-
-    Mirrors :func:`get_graph` but applies ``public_notes_filter()`` to both
-    ends of every edge so a private note can never appear as a node *or* a
-    target. Same Cache-Control + ETag semantics so the CDN treats this
-    payload identically.
-    """
-    # Only public notes whose type is in the renderable graph set. Gap
-    # stubs (type='gap') with NULL visibility are excluded by the
-    # visibility filter alone, but this also keeps the type filter
-    # consistent with get_graph().
-    public_note_rows = session.execute(
-        select(
-            Note.note_id,
-            Note.title,
-            Note.type,
-            Note.indexed_at,
-            # Prefer public-only layout positions (computed over the public
-            # subgraph by knowledge.service._run_public_layout_pass); fall
-            # back to the full-graph positions if the public pass hasn't
-            # populated this row yet, so a fresh deploy never serves NULL
-            # coords. Same shape consumed by /private/notes — keep both as
-            # nullable in the response, the client handles either.
-            func.coalesce(Note.layout_x_public, Note.layout_x).label("x"),
-            func.coalesce(Note.layout_y_public, Note.layout_y).label("y"),
-        )
-        .where(public_notes_filter())
-        .where(Note.type.in_(list(GRAPH_NOTE_TYPES)))
-        .where(Note.deleted_at.is_(None))
-    ).all()
-
-    public_note_ids = {row.note_id for row in public_note_rows}
-    slug_to_note_id = {_slugify(nid): nid for nid in public_note_ids}
-
-    if public_note_ids:
-        # Single SQL join enforces both-ends-public: source side via the
-        # join filter, target side via the IN clause against the resolved
-        # public slug set (mirrors get_graph's slug→canonical resolution).
-        link_rows = session.execute(
-            select(
-                Note.note_id.label("source"),
-                NoteLink.target_id.label("target"),
-                NoteLink.kind,
-                NoteLink.edge_type,
-            )
-            .join(Note, NoteLink.src_note_fk == Note.id)
-            .where(public_notes_filter())
-            .where(Note.deleted_at.is_(None))
-        ).all()
-    else:
-        link_rows = []
-
-    edges: list[dict] = []
-    for row in link_rows:
-        canonical_target = slug_to_note_id.get(_slugify(row.target))
-        if canonical_target is None:
-            continue
-        edges.append(
-            {
-                "source": row.source,
-                "target": canonical_target,
-                "kind": row.kind,
-                "edge_type": row.edge_type,
-            }
-        )
-
-    degree_by_note_id: dict[str, int] = {}
-    for edge in edges:
-        degree_by_note_id[edge["source"]] = degree_by_note_id.get(edge["source"], 0) + 1
-        degree_by_note_id[edge["target"]] = degree_by_note_id.get(edge["target"], 0) + 1
-
-    nodes = [
-        {
-            "id": row.note_id,
-            "title": row.title,
-            "type": row.type,
-            "degree": degree_by_note_id.get(row.note_id, 0),
-            "x": row.x,
-            "y": row.y,
-        }
-        for row in public_note_rows
-    ]
-
-    indexed_at = _as_utc(
-        max((row.indexed_at for row in public_note_rows), default=None)
-    )
-    etag = _graph_etag(len(public_note_rows), indexed_at)
-    headers = {"Cache-Control": _GRAPH_CACHE_CONTROL, "ETag": etag}
-    if indexed_at is not None:
-        headers["Last-Modified"] = format_datetime(indexed_at, usegmt=True)
-
-    if request.headers.get("if-none-match") == etag:
-        return Response(status_code=304, headers=headers)
-
-    for key, value in headers.items():
-        response.headers[key] = value
-    logger.info("public.graph.served nodes=%d edges=%d", len(nodes), len(edges))
-    return {
-        "nodes": nodes,
-        "edges": edges,
-        # Mirrors get_graph's response — StatusBar in the SvelteKit page
-        # reads this to display "indexed Xm ago". Previously omitted so
-        # the public page showed "indexed —" while the private one didn't.
-        "indexed_at": indexed_at.isoformat() if indexed_at is not None else None,
-    }
-
-
-@router.get("/public/notes/{note_id}")
-def get_public_note(
-    note_id: str,
-    session: Session = Depends(get_session),
-) -> dict:
-    """Return a single note iff its effective visibility is ``public``.
-
-    The 404 response is identical for missing notes AND for notes that
-    exist but are private/null-visibility — the existence of a private
-    note must never be observable. Body wikilinks targeting private
-    notes are stripped to plain text via :func:`sanitize_public_body`;
-    wikilinks targeting public notes are left intact for the frontend
-    renderer to resolve.
-    """
-    note = session.exec(
-        select(Note).where(Note.note_id == note_id).where(Note.deleted_at.is_(None))
-    ).one_or_none()
-    if note is None or effective_visibility(note) != "public":
-        # Identical 404 for missing and private — never expose existence.
-        # The reason is logged but not surfaced in the response.
-        reason = "not_found" if note is None else "private_gated"
-        logger.info("public.note.404 note_id=%s reason=%s", note_id, reason)
-        raise HTTPException(status_code=404, detail="Not Found")
-
-    # ADR 006 Phase 2: body of record is Postgres ``content``. The vault
-    # read is a fallback only while the Phase 1 backfill is in flight, and
-    # ``resolve_note_body`` keeps the same path-traversal guard so a
-    # malformed path can't escape the vault root.
-    vault_root = _get_vault_root()
-    body = resolve_note_body(note.content, note.path, vault_root)
-    if body is None:
-        # Same identical 404 — don't leak that the DB row exists but
-        # the body is unavailable.
-        logger.info("public.note.404 note_id=%s reason=vault_file_missing", note_id)
-        raise HTTPException(status_code=404, detail="Not Found")
-
-    # Slugified ids of every non-public note. ``sanitize_public_body``
-    # slugifies wikilink display text via ``visibility._slugify`` and
-    # drops the bracketing on any match — use the same helper here so
-    # the sets compare consistently. Note: ``or_(... != 'public', ...
-    # IS NULL)`` is required because in SQL ``NULL != 'public'`` is
-    # ``NULL``, not true, so a bare ``!=`` would silently leave NULL-
-    # visibility notes out of the private set.
-    private_slugs = {
-        _visibility_slugify(n.note_id)
-        for n in session.exec(
-            select(Note)
-            .where(or_(Note.visibility != "public", Note.visibility.is_(None)))
-            .where(Note.deleted_at.is_(None))
-        ).all()
-    }
-    sanitized = sanitize_public_body(body, private_slugs)
-
-    indexed_at = _as_utc(note.indexed_at)
-    logger.info("public.note.served note_id=%s", note_id)
-    return {
-        "note_id": note.note_id,
-        "title": note.title,
-        "tags": list(note.tags or []),
-        "aliases": list(note.aliases or []),
-        "indexed_at": indexed_at.isoformat() if indexed_at is not None else None,
-        "body": sanitized,
-    }
-
-
 @router.get("/notes/review-queue")
 def get_notes_review_queue_endpoint(
     mode: Literal["pending", "audit"] = Query(default="pending"),
@@ -367,7 +144,7 @@ def get_notes_review_queue_endpoint(
     ordering, ``GET /notes/review-queue`` would resolve to
     ``get_knowledge_note(note_id="review-queue")`` and 404.
     """
-    vault_root = _get_vault_root()
+    vault_root = get_vault_root()
     return {
         "notes": list_notes_for_review(
             session, mode=mode, limit=limit, vault_root=vault_root
@@ -387,7 +164,7 @@ def get_knowledge_note(
 
     # ADR 006 Phase 2: body of record is Postgres ``content``; the vault
     # read is a fallback only while the Phase 1 backfill is in flight.
-    vault_root = _get_vault_root()
+    vault_root = get_vault_root()
     body = resolve_note_body(note.get("content"), note["path"], vault_root)
     if body is None:
         raise HTTPException(status_code=404, detail="vault file missing")
@@ -414,7 +191,7 @@ def delete_note_endpoint(
     is now the standard review-dict payload (matching the other
     note-action endpoints), with ``deleted_at`` populated.
     """
-    vault_root = _get_vault_root()
+    vault_root = get_vault_root()
     try:
         note = delete_note(session, note_id, vault_root)
     except ValueError as exc:
@@ -435,7 +212,7 @@ def undelete_note_endpoint(
     Use the audit-mode review queue + delete action to land here in the
     first place.
     """
-    vault_root = _get_vault_root()
+    vault_root = get_vault_root()
     try:
         note = undelete_note(session, note_id, vault_root)
     except ValueError as exc:
@@ -456,7 +233,7 @@ async def edit_note(
     if note is None:
         raise HTTPException(status_code=404, detail="note not found")
 
-    vault_root = _get_vault_root()
+    vault_root = get_vault_root()
     resolved = (vault_root / note["path"]).resolve()
     if not resolved.is_relative_to(vault_root) or not resolved.is_file():
         raise HTTPException(status_code=404, detail="vault file missing")
@@ -680,7 +457,7 @@ def get_review_queue_endpoint(
     plus a ``stub_body`` read from ``_researching/<slug>.md`` so the
     audit UI can render in-place without a per-row round-trip.
     """
-    vault_root = _get_vault_root()
+    vault_root = get_vault_root()
     return {
         "gaps": list_gaps_for_review(
             session, mode=mode, limit=limit, vault_root=vault_root
@@ -721,7 +498,7 @@ def answer_gap_endpoint(
     session: Session = Depends(get_session),
 ) -> dict:
     """Commit a user answer for a gap and emit a personal-tier atom."""
-    vault_root = _get_vault_root()
+    vault_root = get_vault_root()
     try:
         return answer_gap(session, gap_id, data.answer, vault_root)
     except ValueError as exc:
@@ -738,7 +515,7 @@ def reject_gap_endpoint(
     session: Session = Depends(get_session),
 ) -> dict:
     """Reject a pending gap. Transitions in_review → rejected and tombstones the stub."""
-    vault_root = _get_vault_root()
+    vault_root = get_vault_root()
     try:
         return reject_gap(session, gap_id, vault_root)
     except ValueError as exc:
@@ -757,7 +534,7 @@ def approve_gap_endpoint(
     to ``classified`` so the next reconciler tick doesn't revert the
     Gap row. Only valid for ``gap_class='external'``.
     """
-    vault_root = _get_vault_root()
+    vault_root = get_vault_root()
     try:
         return approve_gap(session, gap_id, vault_root)
     except ValueError as exc:
@@ -794,7 +571,7 @@ def delete_gap_endpoint(
     session: Session = Depends(get_session),
 ) -> dict:
     """Soft-delete a gap. Hard-deletes the stub file; regenerable on undelete."""
-    vault_root = _get_vault_root()
+    vault_root = get_vault_root()
     try:
         return delete_gap(session, gap_id, vault_root)
     except ValueError as exc:
@@ -847,7 +624,7 @@ def set_note_visibility_endpoint(
     session: Session = Depends(get_session),
 ) -> dict:
     """Set ``visibility`` (public|private) and mark verified."""
-    vault_root = _get_vault_root()
+    vault_root = get_vault_root()
     try:
         note = set_note_visibility(session, note_id, data.visibility, vault_root)
     except ValueError as exc:
@@ -861,7 +638,7 @@ def verify_note_visibility_endpoint(
     session: Session = Depends(get_session),
 ) -> dict:
     """Mark ``visibility_verified=True``. 409 if visibility is unset."""
-    vault_root = _get_vault_root()
+    vault_root = get_vault_root()
     try:
         note = verify_note_visibility(session, note_id)
     except ValueError as exc:
@@ -875,7 +652,7 @@ def reset_note_visibility_endpoint(
     session: Session = Depends(get_session),
 ) -> dict:
     """Clear ``visibility`` and ``visibility_verified``. Sends back to pending."""
-    vault_root = _get_vault_root()
+    vault_root = get_vault_root()
     try:
         note = reset_note_visibility(session, note_id, vault_root)
     except ValueError as exc:

--- a/projects/monolith/knowledge/service.py
+++ b/projects/monolith/knowledge/service.py
@@ -26,6 +26,13 @@ logger = logging.getLogger(__name__)
 
 VAULT_ROOT_ENV = "VAULT_ROOT"
 DEFAULT_VAULT_ROOT = "/vault"
+
+
+def get_vault_root() -> Path:
+    """Resolve the vault root from the env (or default), as an absolute path."""
+    return Path(os.environ.get(VAULT_ROOT_ENV, DEFAULT_VAULT_ROOT)).resolve()
+
+
 # 5-minute reconcile cycle. _TTL_SECS is the lock-lease: a worker holding
 # the row past this is treated as crashed and the lock can be reclaimed.
 # We keep it generous (20m) so LLM-heavy handlers can finish without being

--- a/projects/monolith/ships/__init__.py
+++ b/projects/monolith/ships/__init__.py
@@ -11,6 +11,11 @@ def register(app: FastAPI) -> None:
     app.include_router(router)
 
 
+def register_public(app: FastAPI) -> None:
+    """Ships is a wholly public, read-only domain: reuse register."""
+    register(app)
+
+
 def on_startup_jobs(session: Session) -> None:
     """Register ships scheduled jobs (partition maintenance, heatmap rollup)."""
     from scheduler.api import register_job

--- a/projects/monolith/stars/__init__.py
+++ b/projects/monolith/stars/__init__.py
@@ -18,6 +18,11 @@ def register(app: FastAPI) -> None:
     app.include_router(router)
 
 
+def register_public(app: FastAPI) -> None:
+    """Stars is a wholly public, read-only domain: reuse register."""
+    register(app)
+
+
 def on_startup_jobs(session: Session) -> None:
     from scheduler.api import register_job
     from stars.grid import load_climatology_handler, load_grid_handler


### PR DESCRIPTION
## Phase 5a: separate read-only public service entrypoint

Part of the monolith modularity program (ADR 004, plan `docs/plans/2026-06-16-monolith-modularity.md`). Phases 1-4 are shipped; this is the first of the Phase 5 sub-PRs (5a).

Stands up a second FastAPI entrypoint `app/main_public.py` that mounts ONLY the public, read-only routes via a new `register_public(app)` hook per domain, plus a route-table guard test. No deployment in this PR (image/chart land in 5c); knowledge public routes still query private tables until 5a' repoints them to views.

### What this does
- `app/main_public.py`: lean `FastAPI(title="Monolith Public")`, no heavy lifespan (no Discord bot, scheduler loop, AIS ingest, vault clone, MCP, OTEL background setup), `/healthz`.
- `register_public(app)` hooks:
  - ships/stars/hikes/dr_jobs: wholly public, reuse `register`.
  - knowledge: mounts ONLY `/api/knowledge/public/graph` + `/api/knowledge/public/notes/{note_id}` via a new `knowledge/public_router.py`.
  - home: mounts ONLY `observability_router` (`/stats` + `/topology`); `schedule_router` stays private.
- `knowledge/public_router.py`: the two public handlers, moved verbatim. Does NOT import `knowledge.router`, so the private-route module stays out of the public import graph (isolation is structural, per ADR 004 Layer 1).
- `knowledge/http_cache.py` + `knowledge/service.get_vault_root()`: shared helpers hoisted into neutral modules so both the private router and the public router import them without coupling.
- Route-table guard test `app/main_public_routes_test.py`: asserts the public app exposes the expected public paths and ZERO private paths (no `/mcp`, no non-public `/api/knowledge/*`, no `/api/home/schedule`, no chat/scheduler/agent).

### Behavior preserved for the private app
`knowledge.register` still includes `public_router`, so `private.jomcgi.dev` serves `/api/knowledge/public/*` exactly as before. `app/main.py` is unchanged. The split is additive only.

### Security note
The public knowledge surface is intentionally ONLY `/public/graph` + `/public/notes/{id}`; `/search` and `/graph` return all notes and must never be mounted on the public artifact. The guard test enforces this at the route-table level.

🤖 Generated with [Claude Code](https://claude.com/claude-code)