### PR TITLE
feat(monolith): Phase 5b - public_reader LOGIN role + DB credential

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.148.2
+version: 0.148.3
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/templates/cnpg-cluster.yaml
+++ b/projects/monolith/chart/templates/cnpg-cluster.yaml
@@ -26,14 +26,25 @@ spec:
   # migrations) is what can CREATE the public_reader role. Its table/schema GRANTs
   # live in chart/migrations/20260617000000_public_reader_role.sql; CNPG does not
   # manage privileges. public_reader is the read-only identity for the Phase 5
-  # anonymous public service (ADR 004 security/004). It stays NOLOGIN here: no
-  # service consumes it yet, so a login credential (client-cert preferred) is added
-  # in Phase 5.
+  # anonymous public service (ADR 004 security/004).
+  #
+  # Phase 5b: the role is now LOGIN, with its password set by CNPG from the
+  # basic-auth secret below. CNPG's passwordSecret requires a
+  # kubernetes.io/basic-auth secret (keys: username, password) labelled
+  # cnpg.io/reload, which the 1Password operator (Opaque only) cannot emit, so
+  # the secret is created out-of-band from the 1Password item
+  # k8s-homelab/public-reader-db. See deploy/public-reader-secret.md
+  # to (re)create it. The public service reads the SAME 1Password item via its
+  # own OnePasswordItem (Opaque is fine there); both stay consistent because the
+  # 1Password item is the single source of truth. This credential is low-value:
+  # read-only, public data only, scoped by the public_api views.
   managed:
     roles:
       - name: public_reader
         ensure: present
-        login: false
+        login: true
+        passwordSecret:
+          name: monolith-pg-public-reader
         comment: "Read-only public surface (ADR 004); GRANTs in Atlas migration"
   # Hosts the monolith database (plus the default postgres maintenance db);
   # the temporal/temporal_visibility/lakehouse databases were decommissioned

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.148.2
+      targetRevision: 0.148.3
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/deploy/public-reader-secret.md
+++ b/projects/monolith/deploy/public-reader-secret.md
@@ -1,0 +1,40 @@
+# public_reader DB credential (ADR 004, Phase 5b)
+
+The anonymous public service connects to `monolith-pg-ro` as the read-only
+`public_reader` role. CNPG sets that role's password from a
+`kubernetes.io/basic-auth` secret named `monolith-pg-public-reader` (referenced
+by `passwordSecret` in `chart/templates/cnpg-cluster.yaml`).
+
+## Why this secret is created out-of-band
+
+CNPG's `managed.roles[].passwordSecret` requires a `kubernetes.io/basic-auth`
+secret (keys `username` + `password`) labelled `cnpg.io/reload`. The 1Password
+operator emits only `Opaque` secrets and the `OnePasswordItem` CRD cannot set the
+secret type or labels, so this one secret cannot be synced declaratively.
+
+The password's single source of truth is the 1Password item
+`k8s-homelab/public-reader-db`. The public service itself reads that same item
+through its own `OnePasswordItem` (Opaque is fine there), so both stay
+consistent. This is the only manual step; everything else is GitOps.
+
+The credential is low-value by design: read-only, public data only, scoped by
+the `public_api` views (Phase 2 + 5a').
+
+## (Re)create the secret
+
+Requires a logged-in `op` CLI and a kubectl context on the cluster. Idempotent.
+
+```sh
+PW="$(op read 'op://k8s-homelab/public-reader-db/password')"
+kubectl delete secret monolith-pg-public-reader -n monolith --ignore-not-found
+kubectl create secret generic monolith-pg-public-reader -n monolith \
+  --type=kubernetes.io/basic-auth \
+  --from-literal=username=public_reader \
+  --from-literal=password="$PW"
+kubectl label secret monolith-pg-public-reader -n monolith cnpg.io/reload=true
+```
+
+If the 1Password item is ever lost, recreate it with a fresh generated password
+(`op item create --category=login --vault=k8s-homelab --title=public-reader-db
+--generate-password='letters,digits,32' username=public_reader`) and re-run the
+block above so CNPG resets the role password to match.


### PR DESCRIPTION
## Phase 5b: public_reader login credential

Part of the monolith modularity program (ADR 004). The public service (Phase 5c) connects to the `monolith-pg-ro` read replica as `public_reader`. This makes that role a usable login identity.

### Changes
- `chart/templates/cnpg-cluster.yaml`: `public_reader` managed role flips to `login: true` with `passwordSecret: monolith-pg-public-reader`. CNPG sets the role password from that secret.
- `deploy/public-reader-secret.md`: documents the one out-of-band secret and how to (re)create it.

### Why one secret is out-of-band
CNPG's `passwordSecret` requires a `kubernetes.io/basic-auth` secret (keys `username`+`password`) labelled `cnpg.io/reload`. The 1Password operator emits only `Opaque` secrets and the `OnePasswordItem` CRD cannot set the type/labels, so this secret cannot be synced declaratively. The password's source of truth is the 1Password item `k8s-homelab/public-reader-db`; the public service (5c) reads the same item via its own `OnePasswordItem` (Opaque is fine there), so both stay consistent.

### Already provisioned in-cluster (this PR is the declarative half)
- 1Password item `k8s-homelab/public-reader-db` (username, 32-char password, server/port/database, full uri).
- Secret `monolith/monolith-pg-public-reader` (basic-auth, `cnpg.io/reload=true`) created from it, so CNPG can set the password the moment this chart syncs.

### Credential posture
Low-value by design: read-only, public data only, scoped by the `public_api` views (Phase 2 + 5a'). Not a high-value application secret.

🤖 Generated with [Claude Code](https://claude.com/claude-code)