### PR TITLE
refactor(monolith): shrink public import closure for the pruned public image (5c-1)

### DIFF
--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -333,6 +333,16 @@ py_test(
 )
 
 py_test(
+    name = "main_public_imports_test",
+    srcs = ["app/main_public_imports_test.py"],
+    imports = ["."],
+    deps = [
+        ":monolith_backend",
+        "@pip//pytest",
+    ],
+)
+
+py_test(
     name = "integration_test",
     size = "medium",
     srcs = ["app/integration_test.py"],

--- a/projects/monolith/app/main_public_imports_test.py
+++ b/projects/monolith/app/main_public_imports_test.py
@@ -1,0 +1,98 @@
+"""Import-closure guard for the public app (ADR 004 Layer 1+4).
+
+The public service must ship a pruned image that does NOT contain the private
+write-path modules or the ClickHouse client/creds. This test imports
+``app.main_public`` in a FRESH subprocess (so module state leaked into
+``sys.modules`` by other tests in the same process cannot mask a regression) and
+asserts that none of the forbidden private modules ended up in the child's
+``sys.modules``.
+
+If this test fails, a module-level import somewhere in the public register chain
+re-introduced a private dependency: find the offending ``import`` and make it
+lazy (move it inside the function that needs it) rather than weakening the
+forbidden list below.
+
+``import pytest`` is intentional even though no fixtures are used: it keeps
+gazelle's dependency inference attaching ``@pip//pytest`` to this target.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+
+import pytest  # noqa: F401  (keeps the gazelle pytest dep; see module docstring)
+
+# Private surface that must never land in the public import closure. Each entry
+# is matched as a module name OR a dotted prefix (so "chat" also forbids
+# "chat.anything").
+FORBIDDEN_MODULES = [
+    # Private domains.
+    "chat",
+    "agent",
+    "scheduler",
+    # Private knowledge routers / write paths.
+    "knowledge.router",
+    "knowledge.tasks_router",
+    "knowledge.gaps",
+    "knowledge.ingest_queue",
+    "knowledge.mcp",
+    # Heavy knowledge write/maintenance internals this refactor removed from
+    # the public closure.
+    "knowledge.service",
+    "knowledge.reconciler",
+    "knowledge.layout",
+    # ClickHouse client + writer path + private home paths.
+    "home.observability.clickhouse",
+    "home.observability.slo",
+    "home.observability.topology_query",
+    "home.observability.rollup",
+    "home.observability.stats",
+    "home.schedule",
+]
+
+# Snippet run in the child: import the public app, then dump every loaded module
+# name as JSON on stdout so the parent can assert on the closure.
+_SNIPPET = (
+    "import app.main_public; import json, sys; print(json.dumps(list(sys.modules)))"
+)
+
+
+def _loaded_modules() -> set[str]:
+    """Import ``app.main_public`` in a fresh process; return its sys.modules."""
+    env = dict(os.environ)
+    # Propagate the test runner's import roots so the child can import ``app``
+    # regardless of how the Bazel py launcher set up the parent's sys.path.
+    env["PYTHONPATH"] = os.pathsep.join(p for p in sys.path if p) + (
+        os.pathsep + env["PYTHONPATH"] if env.get("PYTHONPATH") else ""
+    )
+    proc = subprocess.run(
+        [sys.executable, "-c", _SNIPPET],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert proc.returncode == 0, (
+        "child failed to import app.main_public:\n"
+        f"stdout={proc.stdout!r}\nstderr={proc.stderr!r}"
+    )
+    return set(json.loads(proc.stdout.strip().splitlines()[-1]))
+
+
+def test_public_import_closure_excludes_private_modules() -> None:
+    """No forbidden private module is present in the public import closure."""
+    loaded = _loaded_modules()
+    offenders = sorted(
+        forbidden
+        for forbidden in FORBIDDEN_MODULES
+        if forbidden in loaded
+        or any(m == forbidden or m.startswith(forbidden + ".") for m in loaded)
+    )
+    assert not offenders, (
+        "app.main_public pulled forbidden private modules into its import "
+        f"closure: {offenders}. Make the offending import lazy (move it inside "
+        "the function that needs it); do not weaken FORBIDDEN_MODULES."
+    )

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.148.3
+version: 0.148.4
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.148.3
+      targetRevision: 0.148.4
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/home/observability/rollup.py
+++ b/projects/monolith/home/observability/rollup.py
@@ -19,8 +19,8 @@ import logging
 from sqlmodel import Session, text
 
 from app.db import get_engine
-from home.observability.router import build_topology
 from home.observability.stats import build_stats
+from home.observability.topology_query import build_topology
 from scheduler.api import register_job
 
 logger = logging.getLogger(__name__)

--- a/projects/monolith/home/observability/router.py
+++ b/projects/monolith/home/observability/router.py
@@ -1,239 +1,25 @@
+"""Public, read-only observability endpoints (``/stats`` and ``/topology``).
+
+Both endpoints serve precomputed snapshot rows out of the ``observability``
+schema: they never touch ClickHouse or the K8s API, so this module stays free of
+the ClickHouse client, SLO math, and topology config. The writer that fills those
+snapshots (``build_topology``) lives in ``home.observability.topology_query`` and
+runs only on the private monolith via ``home.observability.rollup``. Keeping this
+split lets the public service mount these routes without the ClickHouse import
+closure (ADR 004 Layer 1+4).
+"""
+
 from __future__ import annotations
 
-import asyncio
 import logging
-import os
 
 from fastapi import APIRouter, Depends
 from sqlmodel import Session, text
 
 from app.db import get_session
-from home.observability.clickhouse import ClickHouseClient
-from home.observability.config import (
-    EdgeConfig,
-    GroupConfig,
-    NodeConfig,
-    TopologyConfig,
-)
-from home.observability.slo import (
-    aggregate_group,
-    compute_brief,
-    compute_budget,
-    compute_status,
-)
-from home.observability.topology_config import TOPOLOGY
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/api/home/observability", tags=["observability"])
-
-_ch_semaphore = asyncio.Semaphore(2)
-_CH_RETRIES = 1
-_CH_RETRY_DELAY = 1.0
-
-
-async def _ch_scalar(client: ClickHouseClient, query: str) -> float | None:
-    """Execute a scalar query with one retry on transient failure."""
-    for attempt in range(_CH_RETRIES + 1):
-        try:
-            async with _ch_semaphore:
-                return await client.query_scalar(query)
-        except Exception:
-            if attempt < _CH_RETRIES:
-                await asyncio.sleep(_CH_RETRY_DELAY)
-            else:
-                raise
-
-
-async def _ch_rows(client: ClickHouseClient, query: str) -> list[dict]:
-    """Execute a rows query with one retry on transient failure."""
-    for attempt in range(_CH_RETRIES + 1):
-        try:
-            async with _ch_semaphore:
-                return await client.query_rows(query)
-        except Exception:
-            if attempt < _CH_RETRIES:
-                await asyncio.sleep(_CH_RETRY_DELAY)
-            else:
-                raise
-
-
-async def _query_node(client: ClickHouseClient, node: NodeConfig) -> dict:
-    """Execute all queries for a single node and return topology JSON.
-
-    Acquires _ch_semaphore before each ClickHouse call to limit concurrent
-    queries and avoid ClickHouse OOM-killing under memory pressure.
-    """
-    result: dict = {
-        "id": node.id,
-        "label": node.label,
-        "tier": node.tier,
-        "description": node.description,
-    }
-    if node.group:
-        result["group"] = node.group
-    if node.ingress:
-        result["ingress"] = True
-
-    # SLO query
-    availability = None
-    if node.slo and node.slo.query:
-        try:
-            availability = await _ch_scalar(client, node.slo.query)
-        except Exception:
-            logger.exception("SLO query failed for %s", node.id)
-
-    if node.slo:
-        result["slo"] = {"target": node.slo.target, "current": availability}
-        if availability is not None:
-            result["status"] = compute_status(availability, node.slo.target)
-            result["budget"] = compute_budget(
-                availability, node.slo.target, node.slo.window_days
-            )
-        else:
-            result["status"] = "degraded"
-    else:
-        result["status"] = "healthy"
-
-    # Metric queries
-    metrics = []
-    for m in node.metrics:
-        if m.static is not None:
-            metrics.append({"k": m.key, "v": m.static})
-        elif m.query:
-            try:
-                val = await _ch_scalar(client, m.query)
-                suffix = m.unit or ""
-                v = f"{val}{suffix}" if val is not None else "—"
-                metrics.append({"k": m.key, "v": v})
-            except Exception:
-                logger.exception("Metric query failed for %s.%s", node.id, m.key)
-                metrics.append({"k": m.key, "v": "—"})
-    result["metrics"] = metrics
-
-    # Brief
-    metrics_dict = {m["k"]: m["v"] for m in metrics}
-    result["brief"] = compute_brief(availability, metrics_dict)
-
-    # Spark query
-    if node.spark:
-        try:
-            rows = await _ch_rows(client, node.spark.query)
-            result["spark"] = [r.get("value", 0) for r in rows]
-        except Exception:
-            logger.exception("Spark query failed for %s", node.id)
-
-    return result
-
-
-async def _query_edge(client: ClickHouseClient, edge: EdgeConfig) -> dict:
-    """Serialize an edge, running Linkerd metric queries if configured."""
-    result: dict = {"from": edge.source, "to": edge.target}
-    if edge.bidi:
-        result["bidi"] = True
-    if edge.linkerd is None:
-        return result
-    lk = edge.linkerd
-    try:
-        rps, latency, error_rate = await asyncio.gather(
-            _ch_scalar(client, lk.rps_query),
-            _ch_scalar(client, lk.latency_query),
-            _ch_scalar(client, lk.error_rate_query),
-            return_exceptions=True,
-        )
-        result["linkerd"] = {
-            "rps": rps if not isinstance(rps, Exception) else None,
-            "p99_ms": latency if not isinstance(latency, Exception) else None,
-            "error_pct": error_rate if not isinstance(error_rate, Exception) else None,
-        }
-    except Exception:
-        logger.exception(
-            "Linkerd edge query failed for %s->%s", edge.source, edge.target
-        )
-    return result
-
-
-async def build_topology() -> dict:
-    """Execute all queries and build the full topology response."""
-    cfg = TOPOLOGY
-    ch_url = os.environ.get("CLICKHOUSE_URL", "")
-    client = ClickHouseClient(
-        base_url=ch_url,
-        user=os.environ.get("CLICKHOUSE_USER", ""),
-        password=os.environ.get("CLICKHOUSE_PASSWORD", ""),
-    )
-
-    try:
-        # Query all nodes and edges in parallel
-        node_results, edge_results = await asyncio.gather(
-            asyncio.gather(
-                *[_query_node(client, n) for n in cfg.nodes],
-                return_exceptions=True,
-            ),
-            asyncio.gather(
-                *[_query_edge(client, e) for e in cfg.edges],
-                return_exceptions=True,
-            ),
-        )
-
-        # Build node lookup, handling exceptions
-        nodes = []
-        node_map: dict[str, dict] = {}
-        for i, r in enumerate(node_results):
-            if isinstance(r, Exception):
-                logger.error("Node %s failed: %s", cfg.nodes[i].id, r)
-                fallback = {
-                    "id": cfg.nodes[i].id,
-                    "label": cfg.nodes[i].label,
-                    "tier": cfg.nodes[i].tier,
-                    "description": cfg.nodes[i].description,
-                    "status": "degraded",
-                    "brief": "query error",
-                    "metrics": [],
-                }
-                if cfg.nodes[i].group:
-                    fallback["group"] = cfg.nodes[i].group
-                nodes.append(fallback)
-                node_map[cfg.nodes[i].id] = fallback
-            else:
-                nodes.append(r)
-                node_map[r["id"]] = r
-
-        # Aggregate groups
-        groups = []
-        for g in cfg.groups:
-            children = [node_map[cid] for cid in g.children if cid in node_map]
-            target = g.slo.target if g.slo else 99.0
-            window = g.slo.window_days if g.slo else 30
-            agg = aggregate_group(children, target, window)
-
-            group_result = {
-                "id": g.id,
-                "label": g.label,
-                "tier": g.tier,
-                "description": g.description,
-                "children": g.children,
-                **agg,
-            }
-            if g.ingress:
-                group_result["ingress"] = True
-            groups.append(group_result)
-
-        # Edges
-        edges = []
-        for i, r in enumerate(edge_results):
-            if isinstance(r, Exception):
-                e = cfg.edges[i]
-                logger.error("Edge %s->%s failed: %s", e.source, e.target, r)
-                edge: dict = {"from": e.source, "to": e.target}
-                if e.bidi:
-                    edge["bidi"] = True
-                edges.append(edge)
-            else:
-                edges.append(r)
-
-        return {"groups": groups, "nodes": nodes, "edges": edges}
-    finally:
-        await client.close()
 
 
 @router.get("/stats", tags=["stats"])

--- a/projects/monolith/home/observability/topology_query.py
+++ b/projects/monolith/home/observability/topology_query.py
@@ -1,0 +1,241 @@
+"""ClickHouse-backed topology builder (ADR 004 Layer 4 writer path).
+
+Holds ``build_topology`` and its ClickHouse helpers, split out of
+``home.observability.router`` so the public read endpoints (``/stats`` and
+``/topology``, which only read precomputed Postgres snapshots) do not drag the
+ClickHouse client, SLO math, and topology config into the public import closure.
+
+Only the private monolith calls this: ``home.observability.rollup`` invokes
+``build_topology`` on a schedule and upserts the payload into the
+``observability.topology_snapshot`` table that the read endpoints serve from.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+
+from home.observability.clickhouse import ClickHouseClient
+from home.observability.config import (
+    EdgeConfig,
+    NodeConfig,
+)
+from home.observability.slo import (
+    aggregate_group,
+    compute_brief,
+    compute_budget,
+    compute_status,
+)
+from home.observability.topology_config import TOPOLOGY
+
+logger = logging.getLogger(__name__)
+
+_ch_semaphore = asyncio.Semaphore(2)
+_CH_RETRIES = 1
+_CH_RETRY_DELAY = 1.0
+
+
+async def _ch_scalar(client: ClickHouseClient, query: str) -> float | None:
+    """Execute a scalar query with one retry on transient failure."""
+    for attempt in range(_CH_RETRIES + 1):
+        try:
+            async with _ch_semaphore:
+                return await client.query_scalar(query)
+        except Exception:
+            if attempt < _CH_RETRIES:
+                await asyncio.sleep(_CH_RETRY_DELAY)
+            else:
+                raise
+
+
+async def _ch_rows(client: ClickHouseClient, query: str) -> list[dict]:
+    """Execute a rows query with one retry on transient failure."""
+    for attempt in range(_CH_RETRIES + 1):
+        try:
+            async with _ch_semaphore:
+                return await client.query_rows(query)
+        except Exception:
+            if attempt < _CH_RETRIES:
+                await asyncio.sleep(_CH_RETRY_DELAY)
+            else:
+                raise
+
+
+async def _query_node(client: ClickHouseClient, node: NodeConfig) -> dict:
+    """Execute all queries for a single node and return topology JSON.
+
+    Acquires _ch_semaphore before each ClickHouse call to limit concurrent
+    queries and avoid ClickHouse OOM-killing under memory pressure.
+    """
+    result: dict = {
+        "id": node.id,
+        "label": node.label,
+        "tier": node.tier,
+        "description": node.description,
+    }
+    if node.group:
+        result["group"] = node.group
+    if node.ingress:
+        result["ingress"] = True
+
+    # SLO query
+    availability = None
+    if node.slo and node.slo.query:
+        try:
+            availability = await _ch_scalar(client, node.slo.query)
+        except Exception:
+            logger.exception("SLO query failed for %s", node.id)
+
+    if node.slo:
+        result["slo"] = {"target": node.slo.target, "current": availability}
+        if availability is not None:
+            result["status"] = compute_status(availability, node.slo.target)
+            result["budget"] = compute_budget(
+                availability, node.slo.target, node.slo.window_days
+            )
+        else:
+            result["status"] = "degraded"
+    else:
+        result["status"] = "healthy"
+
+    # Metric queries
+    metrics = []
+    for m in node.metrics:
+        if m.static is not None:
+            metrics.append({"k": m.key, "v": m.static})
+        elif m.query:
+            try:
+                val = await _ch_scalar(client, m.query)
+                suffix = m.unit or ""
+                v = f"{val}{suffix}" if val is not None else "—"
+                metrics.append({"k": m.key, "v": v})
+            except Exception:
+                logger.exception("Metric query failed for %s.%s", node.id, m.key)
+                metrics.append({"k": m.key, "v": "—"})
+    result["metrics"] = metrics
+
+    # Brief
+    metrics_dict = {m["k"]: m["v"] for m in metrics}
+    result["brief"] = compute_brief(availability, metrics_dict)
+
+    # Spark query
+    if node.spark:
+        try:
+            rows = await _ch_rows(client, node.spark.query)
+            result["spark"] = [r.get("value", 0) for r in rows]
+        except Exception:
+            logger.exception("Spark query failed for %s", node.id)
+
+    return result
+
+
+async def _query_edge(client: ClickHouseClient, edge: EdgeConfig) -> dict:
+    """Serialize an edge, running Linkerd metric queries if configured."""
+    result: dict = {"from": edge.source, "to": edge.target}
+    if edge.bidi:
+        result["bidi"] = True
+    if edge.linkerd is None:
+        return result
+    lk = edge.linkerd
+    try:
+        rps, latency, error_rate = await asyncio.gather(
+            _ch_scalar(client, lk.rps_query),
+            _ch_scalar(client, lk.latency_query),
+            _ch_scalar(client, lk.error_rate_query),
+            return_exceptions=True,
+        )
+        result["linkerd"] = {
+            "rps": rps if not isinstance(rps, Exception) else None,
+            "p99_ms": latency if not isinstance(latency, Exception) else None,
+            "error_pct": error_rate if not isinstance(error_rate, Exception) else None,
+        }
+    except Exception:
+        logger.exception(
+            "Linkerd edge query failed for %s->%s", edge.source, edge.target
+        )
+    return result
+
+
+async def build_topology() -> dict:
+    """Execute all queries and build the full topology response."""
+    cfg = TOPOLOGY
+    ch_url = os.environ.get("CLICKHOUSE_URL", "")
+    client = ClickHouseClient(
+        base_url=ch_url,
+        user=os.environ.get("CLICKHOUSE_USER", ""),
+        password=os.environ.get("CLICKHOUSE_PASSWORD", ""),
+    )
+
+    try:
+        # Query all nodes and edges in parallel
+        node_results, edge_results = await asyncio.gather(
+            asyncio.gather(
+                *[_query_node(client, n) for n in cfg.nodes],
+                return_exceptions=True,
+            ),
+            asyncio.gather(
+                *[_query_edge(client, e) for e in cfg.edges],
+                return_exceptions=True,
+            ),
+        )
+
+        # Build node lookup, handling exceptions
+        nodes = []
+        node_map: dict[str, dict] = {}
+        for i, r in enumerate(node_results):
+            if isinstance(r, Exception):
+                logger.error("Node %s failed: %s", cfg.nodes[i].id, r)
+                fallback = {
+                    "id": cfg.nodes[i].id,
+                    "label": cfg.nodes[i].label,
+                    "tier": cfg.nodes[i].tier,
+                    "description": cfg.nodes[i].description,
+                    "status": "degraded",
+                    "brief": "query error",
+                    "metrics": [],
+                }
+                if cfg.nodes[i].group:
+                    fallback["group"] = cfg.nodes[i].group
+                nodes.append(fallback)
+                node_map[cfg.nodes[i].id] = fallback
+            else:
+                nodes.append(r)
+                node_map[r["id"]] = r
+
+        # Aggregate groups
+        groups = []
+        for g in cfg.groups:
+            children = [node_map[cid] for cid in g.children if cid in node_map]
+            target = g.slo.target if g.slo else 99.0
+            window = g.slo.window_days if g.slo else 30
+            agg = aggregate_group(children, target, window)
+
+            group_result = {
+                "id": g.id,
+                "label": g.label,
+                "tier": g.tier,
+                "description": g.description,
+                "children": g.children,
+                **agg,
+            }
+            if g.ingress:
+                group_result["ingress"] = True
+            groups.append(group_result)
+
+        # Edges
+        edges = []
+        for i, r in enumerate(edge_results):
+            if isinstance(r, Exception):
+                e = cfg.edges[i]
+                logger.error("Edge %s->%s failed: %s", e.source, e.target, r)
+                edge: dict = {"from": e.source, "to": e.target}
+                if e.bidi:
+                    edge["bidi"] = True
+                edges.append(edge)
+            else:
+                edges.append(r)
+
+        return {"groups": groups, "nodes": nodes, "edges": edges}
+    finally:
+        await client.close()

--- a/projects/monolith/knowledge/notes.py
+++ b/projects/monolith/knowledge/notes.py
@@ -18,6 +18,7 @@ review UI can show context without a second round-trip per row.
 from __future__ import annotations
 
 import logging
+import os
 import shutil
 from datetime import datetime, timezone
 from pathlib import Path
@@ -30,6 +31,19 @@ from knowledge import frontmatter
 from knowledge.models import Note
 
 logger = logging.getLogger(__name__)
+
+# Vault-root resolution lives here (not in knowledge.service) so the light
+# public note path (knowledge.public_router) can resolve the vault root without
+# importing knowledge.service and its heavy write-path closure (reconciler,
+# layout, gap_stubs). knowledge.service re-exports these for back-compat.
+VAULT_ROOT_ENV = "VAULT_ROOT"
+DEFAULT_VAULT_ROOT = "/vault"
+
+
+def get_vault_root() -> Path:
+    """Resolve the vault root from the env (or default), as an absolute path."""
+    return Path(os.environ.get(VAULT_ROOT_ENV, DEFAULT_VAULT_ROOT)).resolve()
+
 
 # Snippet cap for the review-queue list calls. Was 200 chars when the
 # review page first shipped — too thin to evaluate a card in audit mode.

--- a/projects/monolith/knowledge/public_router.py
+++ b/projects/monolith/knowledge/public_router.py
@@ -24,9 +24,8 @@ from sqlmodel import Session, select
 from app.db import get_session
 from knowledge.gardener import _slugify
 from knowledge.http_cache import _as_utc, _graph_etag, _GRAPH_CACHE_CONTROL
-from knowledge.notes import resolve_note_body
+from knowledge.notes import get_vault_root, resolve_note_body
 from knowledge.public_models import PublicNote, PublicNoteLink
-from knowledge.service import get_vault_root
 from knowledge.store import GRAPH_NOTE_TYPES
 from knowledge.visibility import strip_private_wikilinks
 

--- a/projects/monolith/knowledge/router.py
+++ b/projects/monolith/knowledge/router.py
@@ -44,6 +44,7 @@ from knowledge.models import AtomRawProvenance, RawInput
 from knowledge.notes import (
     _note_to_review_dict,
     delete_note,
+    get_vault_root,
     list_notes_for_review,
     reset_note_visibility,
     resolve_note_body,
@@ -51,7 +52,6 @@ from knowledge.notes import (
     undelete_note,
     verify_note_visibility,
 )
-from knowledge.service import get_vault_root
 from knowledge.store import KnowledgeStore
 from shared.embedding import EmbeddingClient
 

--- a/projects/monolith/knowledge/service.py
+++ b/projects/monolith/knowledge/service.py
@@ -17,20 +17,22 @@ from knowledge.gap_stubs import RESEARCHING_DIR
 from knowledge.gardener import _slugify
 from knowledge.layout import EdgeRef, LayoutParams, NodePos, compute_layout
 from knowledge.models import Gap, Note, NoteLink
+
+# Vault-root helpers moved to knowledge.notes (light module) so the public note
+# path can resolve the vault root without importing this heavy module. Re-export
+# them here for back-compat: drift_detector, mcp, and several tests still do
+# `from knowledge.service import VAULT_ROOT_ENV` / `get_vault_root`.
+from knowledge.notes import (  # noqa: F401 (re-exported for back-compat)
+    DEFAULT_VAULT_ROOT,
+    VAULT_ROOT_ENV,
+    get_vault_root,
+)
 from knowledge.reconciler import Reconciler
 from knowledge.store import KnowledgeStore
 from knowledge.visibility import public_notes_filter
 from shared.embedding import EmbeddingClient
 
 logger = logging.getLogger(__name__)
-
-VAULT_ROOT_ENV = "VAULT_ROOT"
-DEFAULT_VAULT_ROOT = "/vault"
-
-
-def get_vault_root() -> Path:
-    """Resolve the vault root from the env (or default), as an absolute path."""
-    return Path(os.environ.get(VAULT_ROOT_ENV, DEFAULT_VAULT_ROOT)).resolve()
 
 
 # 5-minute reconcile cycle. _TTL_SECS is the lock-lease: a worker holding


### PR DESCRIPTION
## Phase 5c-1: shrink the public import closure

Prep for the pruned public-only image (ADR 004 Layer 1+4). Pure refactor, no behavior change for the private app. Splitting 5c into a low-risk refactor (this) + the packaging PR (5c-2) keeps the deploy-affecting change isolated.

### Refactors
- **ClickHouse out of the public read path.** `home/observability/router.py` kept `build_topology` + all ClickHouse helpers at module top, dragging the ClickHouse client/creds + slo/config into anything importing the observability router (including `main_public`). Moved the writer (`build_topology`, `_ch_*`, `_query_node/edge`) to a new `home/observability/topology_query.py`; `rollup.py` imports it from there. `router.py` now imports only fastapi/sqlmodel/app.db, so the public `/stats` + `/topology` snapshot endpoints carry no ClickHouse dependency.
- **knowledge.service out of the public note path.** `public_router` reached `knowledge.service` (which pulls reconciler/layout/gap_stubs) via `get_vault_root`. Moved the vault-root helpers (`VAULT_ROOT_ENV`, `DEFAULT_VAULT_ROOT`, `get_vault_root`) to the light `knowledge/notes.py`; `service.py` re-exports them for back-compat so existing callers/tests are untouched.

### Guard
- `app/main_public_imports_test.py`: imports `app.main_public` in a fresh subprocess and asserts the ADR 004 private surface is absent from `sys.modules`: `chat`, `agent`, `scheduler`, the private knowledge routers (`router`, `tasks_router`, `gaps`, `ingest_queue`, `mcp`), the heavy write/maintenance internals (`service`, `reconciler`, `layout`), and the observability writer/ClickHouse path (`clickhouse`, `slo`, `topology_query`, `rollup`, `stats`, `home.schedule`). This proves the closure is prunable and prevents regression.

5c-2 will build the pruned `main_public` binary + image + chart + un-meshed namespace + default-deny NetworkPolicy + ArgoCD app on top of this verified-clean closure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)