### PR TITLE
fix(monolith): keep the k8s API client out of the public image

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), un-meshed and pruned
 type: application
-version: 0.1.2
+version: 0.1.3
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.1.2
+      targetRevision: 0.1.3
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -244,6 +244,10 @@ _PUBLIC_PRUNE_EXCLUDE = [
     "home/observability/topology_query.py",
     "home/observability/rollup.py",
     "home/observability/stats.py",
+    # The K8s API client wrapper. Only stats.py (excluded above) uses it, so it
+    # is not in the public closure; keep the cluster-API client out of the
+    # public artifact entirely (ADR 004: public holds no cluster access).
+    "home/observability/kubernetes.py",
 ]
 
 py_library(

--- a/projects/monolith/app/main_public_imports_test.py
+++ b/projects/monolith/app/main_public_imports_test.py
@@ -51,6 +51,7 @@ FORBIDDEN_MODULES = [
     "home.observability.topology_query",
     "home.observability.rollup",
     "home.observability.stats",
+    "home.observability.kubernetes",
     "home.schedule",
     "home.schedule_router",
 ]

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.149.1
+version: 0.149.2
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.149.1
+      targetRevision: 0.149.2
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
Phase 5c-2 review follow-up (ADR 004). `home/observability/kubernetes.py` (the cluster-API client wrapper) was compiled into the pruned public library even though its only caller, `stats.py`, is already excluded, so it is not in `app.main_public`'s runtime closure. A security-isolation artifact should not carry a cluster-API client at all.

- Exclude the file from `:monolith_public_backend`'s pruned glob.
- Add `home.observability.kubernetes` to the `main_public_imports_test` forbidden list so a future accidental import fails CI.

No live exploit path existed (the public pod has no SA token and the NetworkPolicy blocks the API server), this is defense-in-depth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)