### PR TITLE
ci: authenticate Docker Hub pulls to avoid anonymous 429 rate-limit

### DIFF
--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -88,6 +88,15 @@ actions:
             echo "Skipping automated commit from $AUTHOR"
             exit 0
           fi
+
+          # Authenticate Docker Hub so rules_oci base-image manifest fetches
+          # (ubuntu, osgeo/gdal, python_base, ...) are not subject to the
+          # anonymous ~100-pull/6h quota, which 429s and aborts the build.
+          # DOCKERHUB_USERNAME / DOCKERHUB_TOKEN set in BuildBuddy Settings → Secrets.
+          if [ -n "$DOCKERHUB_TOKEN" ]; then
+            echo "$DOCKERHUB_TOKEN" | docker login docker.io -u "$DOCKERHUB_USERNAME" --password-stdin
+          fi
+
           bazel test //... --config=ci --deleted_packages=bazel/tools/python --test_tag_filters=-external
 
           # OCaml multi-arch shard (ADR 006/008): the example/test ladder again,
@@ -142,6 +151,15 @@ actions:
 
           # GHCR_TOKEN set in BuildBuddy Settings → Secrets
           echo "$GHCR_TOKEN" | docker login ghcr.io -u jomcgi --password-stdin
+
+          # Authenticate Docker Hub too: rules_oci base-image fetches (ubuntu,
+          # osgeo/gdal, python_base, ...) hit the anonymous ~100-pull/6h quota
+          # and 429 without this. DOCKERHUB_USERNAME / DOCKERHUB_TOKEN set in
+          # BuildBuddy Settings → Secrets.
+          if [ -n "$DOCKERHUB_TOKEN" ]; then
+            echo "$DOCKERHUB_TOKEN" | docker login docker.io -u "$DOCKERHUB_USERNAME" --password-stdin
+          fi
+
           bazel run //bazel/images:push_all --config=ci --stamp
 
   # Push pages — runs on main only, in parallel with Test and Push images


### PR DESCRIPTION
## Fix recurring CI 429s on base-image fetches

The `Test` and `Push images` actions have been failing at analysis with `429 Too Many Requests` while `rules_oci` fetches base-image manifests from Docker Hub (`ubuntu`, `osgeo/gdal`, `python_base`). These are anonymous pulls subject to Docker Hub's ~100-pull/6h quota, which a burst of CI runs drains, blocking all image-building CI cluster-wide (failures rotate across unrelated projects: agent_platform, stargazer).

`Push images` already authenticates to **ghcr.io** but never **docker.io**, and `Test` does no docker login at all.

### Change
Adds a guarded `docker login docker.io` to the `Test` and `Push images` actions. `rules_oci` reads `~/.docker/config.json` (which `docker login` writes), so this authenticates the repository-rule fetches. The `if [ -n "$DOCKERHUB_TOKEN" ]` guard makes the step a no-op if the secret is unset, so it never hard-fails.

### Required secrets (BuildBuddy Settings → Secrets)
- `DOCKERHUB_USERNAME` — the Docker Hub account username
- `DOCKERHUB_TOKEN` — a Docker Hub access token (read-only / public-repo scope is enough; authenticated pulls get a much higher quota)

Once those are set, this PR's own CI run exercises the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)