### PR TITLE
feat(monolith-public): right-size resources + CPU HPAs (burst to 3x)

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.3.1
+version: 0.4.0
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/chart/templates/hpa.yaml
+++ b/projects/monolith-public/chart/templates/hpa.yaml
@@ -1,0 +1,31 @@
+{{- range $component := list "web" "frontend" }}
+{{- $vals := index $.Values $component }}
+{{- if and $vals.enabled $vals.autoscaling $vals.autoscaling.enabled }}
+# HPA for the {{ $component }} component. Scales on the app container's CPU
+# (ContainerResource, GA in k8s 1.27+) so the linkerd-proxy sidecar's CPU does
+# not dilute the signal. CPU, not memory: Node/Python hold memory after a spike,
+# so a memory-based HPA would never scale back down.
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "monolith-public.fullname" $ }}-{{ $component }}
+  labels:
+    {{- include "monolith-public.labels" $ | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "monolith-public.fullname" $ }}-{{ $component }}
+  minReplicas: {{ $vals.autoscaling.minReplicas }}
+  maxReplicas: {{ $vals.autoscaling.maxReplicas }}
+  metrics:
+    - type: ContainerResource
+      containerResource:
+        name: cpu
+        container: {{ $component }}
+        target:
+          type: Utilization
+          averageUtilization: {{ $vals.autoscaling.targetCPUUtilizationPercentage }}
+---
+{{- end }}
+{{- end }}

--- a/projects/monolith-public/chart/values.yaml
+++ b/projects/monolith-public/chart/values.yaml
@@ -89,16 +89,27 @@ web:
         secretKeyRef:
           name: monolith-public-db
           key: uri
-  # Modest footprint: the public tier serves read-only cached snapshots.
+  # CPU request is sized so the HPA's per-container CPU utilization is a
+  # meaningful signal (idle is ~1m). Memory request covers the FastAPI baseline
+  # (~110Mi idle: SQLModel + psycopg + pgvector + the knowledge internals); the
+  # old 64Mi request was below actual. No CPU limit: let it burst (the HPA scales
+  # out on sustained CPU rather than throttling).
   resources:
     requests:
-      cpu: 25m
-      memory: 64Mi
+      cpu: 100m
+      memory: 160Mi
     limits:
-      memory: 256Mi
+      memory: 384Mi
   service:
     type: ClusterIP
     port: 8000
+  # HPA: steady moderate load sits ~30% on one pod; burst to 3 (CPU-based, since
+  # memory is sticky for Python and would never scale down).
+  autoscaling:
+    enabled: true
+    minReplicas: 1
+    maxReplicas: 3
+    targetCPUUtilizationPercentage: 60
 
 # "frontend" component (ADR 004 Phase 5d): the public-only SvelteKit SSR
 # renderer, built from the private-route-free source tree. It is a separate
@@ -138,16 +149,24 @@ frontend:
       value: "http://monolith-public-web:8000"
     - name: OTEL_COLLECTOR_HTTP_URL
       value: "http://signoz-k8s-infra-otel-agent.signoz.svc.cluster.local:4318"
-  # SSR Node needs more headroom than the read-only backend.
+  # SSR Node needs more headroom than the read-only backend. CPU request sized
+  # for a meaningful HPA signal (Node SSR is CPU-bound under concurrent renders).
+  # Memory request keeps headroom above the ~37Mi idle baseline for load spikes.
   resources:
     requests:
-      cpu: 25m
+      cpu: 100m
       memory: 128Mi
     limits:
       memory: 512Mi
   service:
     type: ClusterIP
     port: 3000
+  # HPA: steady moderate load sits ~30% on one pod; burst to 3 (CPU-based).
+  autoscaling:
+    enabled: true
+    minReplicas: 1
+    maxReplicas: 3
+    targetCPUUtilizationPercentage: 60
 
 # Public ingress (ADR 004 Phase 5e). Defaults off; enabled in deploy/values.yaml
 # for the cutover of the public hostname to this service. The frontend serves

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.3.1
+      targetRevision: 0.4.0
       helm:
         releaseName: monolith-public
         valueFiles:
@@ -21,6 +21,13 @@ spec:
   destination:
     server: https://kubernetes.default.svc
     namespace: monolith-public
+  # The HPA owns replica counts; without this, selfHeal would revert the
+  # Deployments to the chart's replicas and fight the autoscaler.
+  ignoreDifferences:
+    - group: apps
+      kind: Deployment
+      jsonPointers:
+        - /spec/replicas
   syncPolicy:
     automated:
       prune: true


### PR DESCRIPTION
## Right-size public pods + autoscaling

Idle usage on the public pods showed the backend at **111Mi** (above its 64Mi memory request) and CPU ~1m on everything.

### Right-size
- backend `web`: mem request `64Mi → 160Mi` (covers the ~110Mi FastAPI baseline), limit `256Mi → 384Mi`.
- both app containers: CPU request `25m → 100m` so the HPA's per-container CPU % is a meaningful signal (idle ~1%).
- frontend memory left at 128Mi/512Mi (Node SSR spikes under load).

### HPA (burst to 3x, ~30% steady on one pod)
- A `HorizontalPodAutoscaler` per component (web + frontend): min 1, max 3, CPU target 60%.
- **CPU, not memory**: Node/Python retain memory after a spike, so a memory-based HPA would scale up and never back down.
- Uses `ContainerResource` (GA in k8s 1.27; cluster is 1.35) targeting the **app** container so the linkerd-proxy's CPU doesn't dilute the signal.
- `ignoreDifferences` on Deployment `/spec/replicas` so ArgoCD selfHeal doesn't fight the autoscaler.

This is the cluster's first HPA. Verified renders cleanly (HPA `container:` matches the actual container names).

🤖 Generated with [Claude Code](https://claude.com/claude-code)