### PR TITLE
feat: public chat (V3) Phase 2 — Turnstile admission, budgets, egress

### DIFF
--- a/projects/monolith-public/chart/BUILD
+++ b/projects/monolith-public/chart/BUILD
@@ -10,6 +10,16 @@ filegroup(
     visibility = ["//projects/monolith:__pkg__"],
 )
 
+# Guard (ADR 005): the Turnstile *secret* must stay in the backend ("web"); the
+# frontend may reference only the public site-key literal. The test asserting
+# this lives in the Python-native //projects/monolith package and reads this
+# chart's values.yaml via the filegroup below.
+filegroup(
+    name = "chart_values",
+    srcs = ["values.yaml"],
+    visibility = ["//projects/monolith:__pkg__"],
+)
+
 helm_chart(
     name = "chart",
     images = {

--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.6.3
+version: 0.6.4
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/chart/templates/linkerd-policy.yaml
+++ b/projects/monolith-public/chart/templates/linkerd-policy.yaml
@@ -30,6 +30,48 @@ metadata:
 spec:
   trafficPolicy: Deny
 ---
+# THE ONE SANCTIONED EGRESS WIDENING (ADR 005, Public Chat V3 Phase 2). REVIEW
+# THIS CAREFULLY.
+#
+# Public chat verifies Cloudflare Turnstile tokens by calling siteverify
+# (https://challenges.cloudflare.com/turnstile/v0/siteverify) from the backend.
+# That is the FIRST and ONLY off-cluster egress from this otherwise default-deny
+# namespace (the EgressNetwork above denies all external traffic). Without an
+# explicit allow the siteverify call is BLOCKED and no session can ever be
+# minted.
+#
+# The allow is a Gateway API TLSRoute (not HTTPRoute): the outbound call is TLS
+# to an external host, so Linkerd matches it by the SNI hostname in the
+# ClientHello. parentRefs binds it to the deny-all EgressNetwork; the single
+# hostname + port 443 scope means this opens challenges.cloudflare.com and
+# nothing else. An RCE in the public path still cannot reach any other internet
+# host. The CRD is served at gateway.networking.k8s.io/v1alpha2 and is present in
+# the cluster (tlsroutes.gateway.networking.k8s.io); Linkerd's policy controller
+# has RBAC over tlsroutes (see the linkerd-control-plane destination-rbac).
+#
+# If this single host ever needs to change, this is the only rule to touch; do
+# not broaden it to a wildcard.
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: TLSRoute
+metadata:
+  name: {{ include "monolith-public.fullname" . }}-allow-turnstile-egress
+  labels:
+    {{- include "monolith-public.labels" . | nindent 4 }}
+spec:
+  parentRefs:
+    - name: {{ include "monolith-public.fullname" . }}-deny-egress
+      kind: EgressNetwork
+      group: policy.linkerd.io
+      namespace: {{ .Release.Namespace }}
+      port: 443
+  hostnames:
+    - challenges.cloudflare.com
+  rules:
+    - backendRefs:
+        - name: {{ include "monolith-public.fullname" . }}-deny-egress
+          kind: EgressNetwork
+          group: policy.linkerd.io
+---
 # The Cloudflare/Envoy gateway identity. We authorize by mesh identity using a
 # wildcard over the gateway namespace's ServiceAccounts so the rule survives the
 # envoy data-plane SA's hash-suffixed name. The gateway is meshed, so its proxy

--- a/projects/monolith-public/chart/templates/onepassworditem.yaml
+++ b/projects/monolith-public/chart/templates/onepassworditem.yaml
@@ -35,3 +35,22 @@ metadata:
 spec:
   itemPath: {{ .Values.publicWriter.onepassword.itemPath | quote }}
 {{- end }}
+{{- if .Values.turnstile.onepassword.itemPath }}
+---
+# Syncs the Cloudflare Turnstile item (ADR 005 layer 1) into an Opaque Secret.
+# The 1Password operator maps each field label to a Secret data key verbatim, so
+# the fields SITE_KEY / SECRET_KEY / IP_HASH_SALT surface as Secret keys of the
+# same names. The backend "web" component references SECRET_KEY (siteverify) and
+# IP_HASH_SALT (ip_hash salt) via secretKeyRef; SITE_KEY is public and handed to
+# the frontend as a plain literal instead, so the frontend never touches this
+# Secret. The synced Secret name equals metadata.name (.Values.turnstile.secretName).
+apiVersion: onepassword.com/v1
+kind: OnePasswordItem
+metadata:
+  name: {{ .Values.turnstile.secretName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "monolith-public.labels" . | nindent 4 }}
+spec:
+  itemPath: {{ .Values.turnstile.onepassword.itemPath | quote }}
+{{- end }}

--- a/projects/monolith-public/chart/values.yaml
+++ b/projects/monolith-public/chart/values.yaml
@@ -91,6 +91,33 @@ chatPublic:
   maxSessionTokens: 32000
   # Session / cookie TTL in seconds (the SSR cookie maxAge mirrors this).
   sessionTtlSeconds: 1800
+  # Global circuit-breaker ceiling: max in-flight public message/inference calls
+  # at once (ADR 005 layer 2 backstop). Starts at 1, matching the Phase-3
+  # reserved-headroom semaphore intent; validate at load test. Mirrored as
+  # CHAT_PUBLIC_GLOBAL_MAX_CONCURRENT on web.env below.
+  globalMaxConcurrent: 1
+  # Turnstile siteverify HTTP timeout (seconds): keep short so a slow/unreachable
+  # Cloudflare fails closed quickly. Mirrored as TURNSTILE_TIMEOUT_SECONDS below.
+  turnstileTimeoutSeconds: 5
+
+# Cloudflare Turnstile admission (ADR 005 layer 1). The SECRET is backend-only:
+# siteverify runs in the "web" FastAPI binary, so TURNSTILE_SECRET_KEY (and the
+# IP-hash salt) are sourced via secretKeyRef from the OnePasswordItem synced
+# below; the frontend MUST NEVER reference this secret. The site KEY is public by
+# design (it only identifies the widget), so it is a plain values literal handed
+# to the frontend as TURNSTILE_SITE_KEY, not a secretKeyRef. onepassword.itemPath
+# is set in deploy/values.yaml and left empty here so a bare `helm template` does
+# not emit a OnePasswordItem with a null path.
+turnstile:
+  # Public Turnstile site key. SSOT for frontend.env TURNSTILE_SITE_KEY below
+  # (Helm values cannot self-reference, so the literal is repeated there).
+  siteKey: "0x4AAAAAADm59tvOGWo09IYc"
+  # Name of the Opaque Secret the OnePasswordItem syncs the Turnstile fields into
+  # (keys SITE_KEY / SECRET_KEY / IP_HASH_SALT, mapped from the 1Password field
+  # labels). Backend secretKeyRefs in web.env reference this name.
+  secretName: monolith-public-turnstile
+  onepassword:
+    itemPath: ""
 
 # "web" component consumed by the homelab-library deployment/service helpers.
 web:
@@ -147,9 +174,25 @@ web:
       value: "32000"
     - name: CHAT_PUBLIC_SESSION_TTL_SECONDS
       value: "1800"
-    # TODO(Phase 2): TURNSTILE_SECRET_KEY for siteverify, sourced from the
-    # OnePasswordItem vaults/k8s-homelab/items/cloudflare-turnstile (field
-    # SECRET_KEY). The secret lives in the backend only, never in the frontend.
+    - name: CHAT_PUBLIC_GLOBAL_MAX_CONCURRENT
+      value: "1"
+    # Turnstile siteverify (ADR 005 layer 1): the SECRET is backend-only. Sourced
+    # via secretKeyRef from the monolith-public-turnstile Secret (key SECRET_KEY),
+    # synced from the cloudflare-turnstile 1Password item. Never in the frontend.
+    - name: TURNSTILE_SECRET_KEY
+      valueFrom:
+        secretKeyRef:
+          name: monolith-public-turnstile
+          key: SECRET_KEY
+    - name: TURNSTILE_TIMEOUT_SECONDS
+      value: "5"
+    # Salt mixed into the stored ip_hash so it is not a bare sha256 of a guessable
+    # IP. Backend-only, from the same Turnstile 1Password item (key IP_HASH_SALT).
+    - name: CHAT_PUBLIC_IP_HASH_SALT
+      valueFrom:
+        secretKeyRef:
+          name: monolith-public-turnstile
+          key: IP_HASH_SALT
   # CPU request is sized so the HPA's per-container CPU utilization is a
   # meaningful signal (idle is ~1m). Memory request covers the FastAPI baseline
   # (~110Mi idle: SQLModel + psycopg + pgvector + the knowledge internals); the
@@ -213,10 +256,12 @@ frontend:
     # at this address over in-cluster mTLS (ADR 005, Phase 1).
     - name: CHAT_API_BASE
       value: "http://monolith-public-web:8000"
-    # TODO(Phase 2): TURNSTILE_SITE_KEY (public site key) for the SSR-rendered
-    # Turnstile widget, sourced from the OnePasswordItem
-    # vaults/k8s-homelab/items/cloudflare-turnstile (field SITE_KEY). The site
-    # key is public by design; the secret key stays on the backend only.
+    # Public Turnstile site key for the SSR-rendered widget (ADR 005 layer 1).
+    # PUBLIC by design (it only identifies the widget), so it is a plain literal,
+    # NOT a secretKeyRef: the frontend must never reference the Turnstile secret.
+    # Mirrors turnstile.siteKey above (Helm values cannot self-reference).
+    - name: TURNSTILE_SITE_KEY
+      value: "0x4AAAAAADm59tvOGWo09IYc"
     - name: OTEL_COLLECTOR_HTTP_URL
       value: "http://signoz-k8s-infra-otel-agent.signoz.svc.cluster.local:4318"
   # SSR Node needs more headroom than the read-only backend. CPU request sized

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.6.3
+      targetRevision: 0.6.4
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith-public/deploy/values.yaml
+++ b/projects/monolith-public/deploy/values.yaml
@@ -19,6 +19,14 @@ publicWriter:
   onepassword:
     itemPath: "vaults/k8s-homelab/items/public-writer-db"
 
+# Public chat Turnstile admission (ADR 005, Phase 2): sync the Cloudflare
+# Turnstile item into the monolith-public-turnstile Secret (keys SITE_KEY /
+# SECRET_KEY / IP_HASH_SALT). The backend uses SECRET_KEY + IP_HASH_SALT via
+# secretKeyRef; the public SITE_KEY is a values literal handed to the frontend.
+turnstile:
+  onepassword:
+    itemPath: "vaults/k8s-homelab/items/cloudflare-turnstile"
+
 # Phase 5e cutover: serve the public hostname from this isolated service.
 cfIngress:
   public:

--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -21,6 +21,7 @@
 # gazelle:exclude public_knowledge_views_test.py
 # gazelle:exclude chat_public_grants_test.py
 # gazelle:exclude public_httproute_chat_guard_test.py
+# gazelle:exclude public_turnstile_secret_isolation_test.py
 # gazelle:semgrep_exclude_rules avoid-sqlalchemy-text,sqlmodel-datetime-without-factory,tainted-fastapi-http-request-httpx,tainted-path-traversal-stdlib-fastapi
 load("@aspect_rules_py//py:defs.bzl", "py_library")
 load("@aspect_rules_py//py/private/py_venv:defs.bzl", "py_venv_binary")
@@ -2386,6 +2387,36 @@ py_test(
         "@pip//httpx",
         "@pip//pytest",
         "@pip//sqlmodel",
+    ],
+)
+
+# Hand-registered (chat_public is gazelle-excluded): Phase 2 admission + abuse
+# controls (Turnstile siteverify failure -> 403, global circuit-breaker shed via
+# the busy SSE event, salted ip_hash storage).
+py_test(
+    name = "chat_public_phase2_test",
+    srcs = ["chat_public/phase2_test.py"],
+    imports = ["."],
+    deps = [
+        ":monolith_public_backend",
+        "@pip//fastapi",
+        "@pip//httpx",
+        "@pip//pytest",
+        "@pip//sqlmodel",
+    ],
+)
+
+# Guard (ADR 005): the Turnstile secret stays in the backend; the frontend
+# carries only the public site-key literal. Reads the monolith-public chart's
+# values.yaml via a cross-package data dep (no Helm toolchain needed).
+py_test(
+    name = "public_turnstile_secret_isolation_test",
+    srcs = ["public_turnstile_secret_isolation_test.py"],
+    data = ["//projects/monolith-public/chart:chart_values"],
+    imports = ["."],
+    deps = [
+        "@pip//pytest",
+        "@pip//pyyaml",
     ],
 )
 

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.153.3
+version: 0.154.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chat_public/limits.py
+++ b/projects/monolith/chat_public/limits.py
@@ -13,7 +13,15 @@ the old value (per CLAUDE.md).
 
 from __future__ import annotations
 
+import contextlib
 import os
+import threading
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy import func
+from sqlmodel import Session, select
+
+from chat_public.models import ChatSession
 
 # --------------------------------------------------------------------------
 # Config knobs (ADR 005 / plan Phase 0 starting values). One place only.
@@ -35,12 +43,36 @@ MAX_SESSION_TOKENS = int(os.environ.get("CHAT_PUBLIC_MAX_SESSION_TOKENS", "32000
 # is treated as expired and cannot be used for another turn.
 SESSION_TTL_SECONDS = int(os.environ.get("CHAT_PUBLIC_SESSION_TTL_SECONDS", "1800"))
 
+# Per-IP session-mint cap: the most sessions one (hashed) client IP may create in
+# the trailing window below (ADR 005 layer 2, per-IP). This is the backend
+# counter that complements Envoy's per-IP rate limit, so one IP cannot mint
+# sessions without bound. The forwarded CF-Connecting-IP is trusted only because
+# the backend is structurally reachable solely from the SSR mesh identity (see
+# the -web Server + AuthorizationPolicy in the monolith-public linkerd-policy),
+# so no untrusted peer can spoof it.
+PER_IP_MINT_RATE = int(os.environ.get("CHAT_PUBLIC_PER_IP_MINT_RATE", "5"))
+
+# Trailing window for the per-IP mint cap, in seconds (default 1 hour).
+IP_MINT_WINDOW_SECONDS = int(
+    os.environ.get("CHAT_PUBLIC_IP_MINT_WINDOW_SECONDS", "3600")
+)
+
+# Global circuit-breaker ceiling: the maximum number of public message/inference
+# calls in flight across this process at once (ADR 005 layer 2, global backstop).
+# Default 1 matches the Phase-0 reserved-headroom semaphore intent (start at 1,
+# validate at load test). Over the ceiling the message path sheds with a "busy"
+# event rather than spending a slot.
+GLOBAL_MAX_CONCURRENT = int(os.environ.get("CHAT_PUBLIC_GLOBAL_MAX_CONCURRENT", "1"))
+
 
 class LimitExceeded(Exception):
-    """Raised when a public-chat budget is exceeded.
+    """Raised when a public-chat admission/budget control rejects a request.
 
-    ``code`` is a stable machine string the router maps to a 4xx status and a
-    "busy"/"limit" SSE event; ``message`` is a human-readable reason.
+    ``code`` is a stable machine string the router maps to an HTTP status and a
+    "busy"/"limit" SSE event; ``message`` is a human-readable reason. It covers
+    both the per-session budgets (char_cap / max_turns / max_session_tokens) and
+    the admission/shed controls (turnstile_failed / ip_mint_rate / busy), so the
+    router has one rejection channel.
     """
 
     def __init__(self, code: str, message: str) -> None:
@@ -74,3 +106,103 @@ def check_session_tokens(total_tokens: int) -> None:
             "max_session_tokens",
             f"This conversation has reached its {MAX_SESSION_TOKENS} token limit.",
         )
+
+
+def check_ip_mint_rate(db: Session, ip_hash: str | None) -> None:
+    """Reject session creation once a hashed IP has minted too many sessions.
+
+    Counts sessions already created with the same ``ip_hash`` inside the trailing
+    window and rejects over ``PER_IP_MINT_RATE``. The IP is keyed by its salted
+    hash only (the raw IP is never stored). A None ip_hash (no forwarded IP, e.g.
+    local dev) skips the check, since there is nothing to key on.
+    """
+    if not ip_hash:
+        return
+    window_start = datetime.now(timezone.utc) - timedelta(
+        seconds=IP_MINT_WINDOW_SECONDS
+    )
+    count = db.exec(
+        select(func.count())
+        .select_from(ChatSession)
+        .where(
+            ChatSession.ip_hash == ip_hash,
+            ChatSession.created_at >= window_start,
+        )
+    ).one()
+    if count >= PER_IP_MINT_RATE:
+        raise LimitExceeded(
+            "ip_mint_rate",
+            "Too many chat sessions from this network. Please try again later.",
+        )
+
+
+class _CircuitBreaker:
+    """An in-process counter of in-flight public message/inference calls.
+
+    ADR 005 layer 2 wants this global ceiling to be effective cluster-wide; a
+    process-local counter is the simplest thing that is correct for a single
+    replica and unit-testable now. Phase 3 wires the real reserved-headroom
+    semaphore in front of vLLM, at which point this becomes (or is replaced by)
+    the cluster-aware control. Deliberately NOT a Postgres-backed distributed
+    counter: that is over-engineering for the current single-replica shape.
+
+    A threading.Lock (not asyncio) is used because the Phase-2 message endpoint
+    is a sync FastAPI handler dispatched to the threadpool, so concurrent turns
+    run on different threads.
+    """
+
+    def __init__(self, limit: int) -> None:
+        self._limit = limit
+        self._inflight = 0
+        self._lock = threading.Lock()
+
+    def try_acquire(self) -> bool:
+        with self._lock:
+            if self._inflight >= self._limit:
+                return False
+            self._inflight += 1
+            return True
+
+    def release(self) -> None:
+        with self._lock:
+            if self._inflight > 0:
+                self._inflight -= 1
+
+    @property
+    def inflight(self) -> int:
+        with self._lock:
+            return self._inflight
+
+
+# Module-global breaker, sized from the env ceiling at import.
+_breaker = _CircuitBreaker(GLOBAL_MAX_CONCURRENT)
+
+
+def current_inflight() -> int:
+    """In-flight public call count, for observability and tests."""
+    return _breaker.inflight
+
+
+@contextlib.contextmanager
+def inflight_slot():
+    """Acquire a global in-flight slot for one public message/inference call.
+
+    Raises ``LimitExceeded("busy")`` when the global ceiling is already reached,
+    so the caller sheds the request without spending a slot. Releases the slot on
+    exit.
+
+    TODO(Phase 3): when the message path becomes async and streams real vLLM
+    tokens, the slot MUST be held for the whole generation (acquire before the
+    stream, release when it completes), not just while the handler builds the
+    response. In Phase 2 the canned reply is produced synchronously inside this
+    context, so holding it for the handler body is sufficient.
+    """
+    if not _breaker.try_acquire():
+        raise LimitExceeded(
+            "busy",
+            "Public chat is busy right now. Please try again in a moment.",
+        )
+    try:
+        yield
+    finally:
+        _breaker.release()

--- a/projects/monolith/chat_public/limits.py
+++ b/projects/monolith/chat_public/limits.py
@@ -16,12 +16,6 @@ from __future__ import annotations
 import contextlib
 import os
 import threading
-from datetime import datetime, timedelta, timezone
-
-from sqlalchemy import func
-from sqlmodel import Session, select
-
-from chat_public.models import ChatSession
 
 # --------------------------------------------------------------------------
 # Config knobs (ADR 005 / plan Phase 0 starting values). One place only.
@@ -43,19 +37,12 @@ MAX_SESSION_TOKENS = int(os.environ.get("CHAT_PUBLIC_MAX_SESSION_TOKENS", "32000
 # is treated as expired and cannot be used for another turn.
 SESSION_TTL_SECONDS = int(os.environ.get("CHAT_PUBLIC_SESSION_TTL_SECONDS", "1800"))
 
-# Per-IP session-mint cap: the most sessions one (hashed) client IP may create in
-# the trailing window below (ADR 005 layer 2, per-IP). This is the backend
-# counter that complements Envoy's per-IP rate limit, so one IP cannot mint
-# sessions without bound. The forwarded CF-Connecting-IP is trusted only because
-# the backend is structurally reachable solely from the SSR mesh identity (see
-# the -web Server + AuthorizationPolicy in the monolith-public linkerd-policy),
-# so no untrusted peer can spoof it.
-PER_IP_MINT_RATE = int(os.environ.get("CHAT_PUBLIC_PER_IP_MINT_RATE", "5"))
-
-# Trailing window for the per-IP mint cap, in seconds (default 1 hour).
-IP_MINT_WINDOW_SECONDS = int(
-    os.environ.get("CHAT_PUBLIC_IP_MINT_WINDOW_SECONDS", "3600")
-)
+# No per-IP session-mint cap: Turnstile is anonymous proof-of-humanity, not a
+# user identity, and a per-IP cap mostly penalises NAT-shared legitimate users
+# without stopping IP-rotating abusers. The real protections are aggregate (the
+# global circuit breaker below + the Phase 3 reserved-headroom semaphore) plus
+# the per-session budgets above. ip_hash is still stored (see sessions.py) for
+# reactive abuse forensics and targeted blocking, not a pre-emptive cap.
 
 # Global circuit-breaker ceiling: the maximum number of public message/inference
 # calls in flight across this process at once (ADR 005 layer 2, global backstop).
@@ -71,8 +58,8 @@ class LimitExceeded(Exception):
     ``code`` is a stable machine string the router maps to an HTTP status and a
     "busy"/"limit" SSE event; ``message`` is a human-readable reason. It covers
     both the per-session budgets (char_cap / max_turns / max_session_tokens) and
-    the admission/shed controls (turnstile_failed / ip_mint_rate / busy), so the
-    router has one rejection channel.
+    the admission/shed controls (turnstile_failed / busy), so the router has one
+    rejection channel.
     """
 
     def __init__(self, code: str, message: str) -> None:
@@ -105,34 +92,6 @@ def check_session_tokens(total_tokens: int) -> None:
         raise LimitExceeded(
             "max_session_tokens",
             f"This conversation has reached its {MAX_SESSION_TOKENS} token limit.",
-        )
-
-
-def check_ip_mint_rate(db: Session, ip_hash: str | None) -> None:
-    """Reject session creation once a hashed IP has minted too many sessions.
-
-    Counts sessions already created with the same ``ip_hash`` inside the trailing
-    window and rejects over ``PER_IP_MINT_RATE``. The IP is keyed by its salted
-    hash only (the raw IP is never stored). A None ip_hash (no forwarded IP, e.g.
-    local dev) skips the check, since there is nothing to key on.
-    """
-    if not ip_hash:
-        return
-    window_start = datetime.now(timezone.utc) - timedelta(
-        seconds=IP_MINT_WINDOW_SECONDS
-    )
-    count = db.exec(
-        select(func.count())
-        .select_from(ChatSession)
-        .where(
-            ChatSession.ip_hash == ip_hash,
-            ChatSession.created_at >= window_start,
-        )
-    ).one()
-    if count >= PER_IP_MINT_RATE:
-        raise LimitExceeded(
-            "ip_mint_rate",
-            "Too many chat sessions from this network. Please try again later.",
         )
 
 

--- a/projects/monolith/chat_public/phase2_test.py
+++ b/projects/monolith/chat_public/phase2_test.py
@@ -1,0 +1,183 @@
+"""Phase 2 unit tests for the public-chat backend (ADR 005).
+
+Covers the admission + abuse controls added in Phase 2:
+
+1. Turnstile siteverify failure rejects session creation with 403
+   ``turnstile_failed`` (real verify path: a non-empty TURNSTILE_SECRET_KEY plus
+   a mocked Cloudflare response of ``{"success": false}``).
+2. The global circuit breaker sheds a turn with the 200 ``busy`` SSE event when
+   the in-flight ceiling is occupied (and persists nothing).
+3. The forwarded client IP is stored only as a salted sha256 ``ip_hash``, never
+   the raw IP.
+
+Fast in-memory SQLite + TestClient, mirroring router_test.py (the chat_public
+models live on the Postgres-only ``chat_public`` schema, which SQLite cannot
+span, so the schema= overrides are stripped for the fixture).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlmodel import Session, SQLModel, create_engine, select
+from sqlmodel.pool import StaticPool
+
+from chat_public import limits, sessions, turnstile
+from chat_public.db import get_chat_session
+from chat_public.models import ChatMessage, ChatSession
+from chat_public.router import router
+
+
+@pytest.fixture(name="session")
+def session_fixture():
+    """In-memory SQLite session (schema-stripped for SQLite compat)."""
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    original_schemas = {}
+    for table in SQLModel.metadata.tables.values():
+        if table.schema is not None:
+            original_schemas[table.name] = table.schema
+            table.schema = None
+    try:
+        SQLModel.metadata.create_all(engine)
+        with Session(engine) as session:
+            yield session
+    finally:
+        for table in SQLModel.metadata.tables.values():
+            if table.name in original_schemas:
+                table.schema = original_schemas[table.name]
+
+
+@pytest.fixture(name="client")
+def client_fixture(session):
+    app = FastAPI()
+    app.include_router(router)
+    app.dependency_overrides[get_chat_session] = lambda: session
+    yield TestClient(app, raise_server_exceptions=False)
+    app.dependency_overrides.clear()
+
+
+def _parse_sse(text: str) -> list[dict]:
+    frames = []
+    for line in text.splitlines():
+        if line.startswith("data: "):
+            frames.append(json.loads(line[len("data: ") :]))
+    return frames
+
+
+class _FakeResponse:
+    """A minimal stand-in for an httpx.Response from Cloudflare siteverify."""
+
+    def __init__(self, payload: dict) -> None:
+        self._payload = payload
+
+    def raise_for_status(self) -> None:  # 2xx, nothing to raise
+        return None
+
+    def json(self) -> dict:
+        return self._payload
+
+
+class _FakeAsyncClient:
+    """Async-context-manager stand-in for httpx.AsyncClient.
+
+    Returns a fixed siteverify payload from ``post`` so the verify path runs
+    without any network IO (the egress TLSRoute is not exercised in unit tests).
+    """
+
+    payload: dict = {"success": False, "error-codes": ["invalid-input-response"]}
+
+    def __init__(self, *args, **kwargs) -> None:
+        pass
+
+    async def __aenter__(self) -> "_FakeAsyncClient":
+        return self
+
+    async def __aexit__(self, *args) -> bool:
+        return False
+
+    async def post(self, url, data=None) -> _FakeResponse:
+        return _FakeResponse(self.payload)
+
+
+# ---------------------------------------------------------------------------
+# 1. Turnstile siteverify failure -> 403 turnstile_failed
+# ---------------------------------------------------------------------------
+
+
+def test_siteverify_failure_rejects_session_with_403(client, session, monkeypatch):
+    # Force the real verify path: a non-empty secret skips the dev stub-accept.
+    monkeypatch.setattr(turnstile, "SECRET_KEY", "test-secret-key")
+    # Cloudflare returns success:false -> the challenge failed.
+    monkeypatch.setattr(turnstile.httpx, "AsyncClient", _FakeAsyncClient)
+
+    resp = client.post(
+        "/internal/chat/session",
+        json={"turnstile_token": "a-token-cloudflare-will-reject"},
+        headers={"CF-Connecting-IP": "203.0.113.7"},
+    )
+
+    assert resp.status_code == 403
+    body = resp.json()
+    assert body["detail"]["code"] == "turnstile_failed"
+    # No session row is opened on a failed challenge.
+    assert session.exec(select(ChatSession)).all() == []
+
+
+# ---------------------------------------------------------------------------
+# 2. Global circuit breaker sheds with the "busy" SSE event
+# ---------------------------------------------------------------------------
+
+
+def test_global_ceiling_sheds_with_busy_sse_event(client, session, monkeypatch):
+    # Occupy the entire ceiling: a breaker sized 0 sheds every turn.
+    monkeypatch.setattr(limits, "_breaker", limits._CircuitBreaker(0))
+
+    row = sessions.create_session(session)
+    resp = client.post(
+        "/internal/chat/message",
+        json={"session_id": row.id, "message": "hello"},
+    )
+
+    # Shed as a 200 SSE "busy" event (so it relays through the SSR passthrough),
+    # not a 4xx/5xx status.
+    assert resp.status_code == 200
+    assert resp.headers["content-type"].startswith("text/event-stream")
+    frames = _parse_sse(resp.text)
+    busy = next(f for f in frames if f["type"] == "busy")
+    assert busy["data"]["code"] == "busy"
+
+    # A shed turn is free: nothing persisted, counters untouched.
+    assert session.exec(select(ChatMessage)).all() == []
+    session.refresh(row)
+    assert row.turn_count == 0
+    assert row.total_tokens == 0
+
+
+# ---------------------------------------------------------------------------
+# 3. ip_hash is stored salted + hashed, never the raw IP
+# ---------------------------------------------------------------------------
+
+
+def test_ip_hash_stored_salted_not_raw(session, monkeypatch):
+    monkeypatch.setattr(sessions, "IP_HASH_SALT", "test-salt")
+    raw_ip = "203.0.113.7"
+
+    row = sessions.create_session(session, ip=raw_ip)
+
+    assert row.ip_hash is not None
+    # Never the raw IP, and not the unsalted digest either.
+    assert row.ip_hash != raw_ip
+    assert row.ip_hash != hashlib.sha256(raw_ip.encode("utf-8")).hexdigest()
+    # It is exactly the salted sha256 hex digest (64 lowercase hex chars).
+    expected = hashlib.sha256(("test-salt" + raw_ip).encode("utf-8")).hexdigest()
+    assert row.ip_hash == expected
+    assert len(row.ip_hash) == 64
+    assert all(c in "0123456789abcdef" for c in row.ip_hash)

--- a/projects/monolith/chat_public/router.py
+++ b/projects/monolith/chat_public/router.py
@@ -20,7 +20,7 @@ from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 from sqlmodel import Session
 
-from chat_public import limits, sessions
+from chat_public import limits, sessions, turnstile
 from chat_public.db import get_chat_session
 from chat_public.sse import SSEEmitter
 
@@ -45,8 +45,9 @@ def _estimate_tokens(text: str) -> int:
 
 
 class SessionCreateRequest(BaseModel):
-    # Turnstile token forwarded by SSR. Verification is stubbed in Phase 1
-    # (sessions.verify_turnstile), real siteverify in Phase 2.
+    # Turnstile token forwarded by SSR (the value the browser widget produced).
+    # Verified here via real siteverify (chat_public.turnstile.siteverify); no
+    # valid token, no session.
     turnstile_token: str | None = None
 
 
@@ -64,32 +65,63 @@ class MessageRequest(BaseModel):
 def _limit_status(code: str) -> int:
     """Map a LimitExceeded code to an HTTP status.
 
-    char_cap is malformed input (400); the budget ceilings are quota
-    exhaustion (429).
+    char_cap is malformed input (400); a failed challenge is forbidden (403);
+    the budget/rate ceilings are quota exhaustion (429).
     """
-    return 400 if code == "char_cap" else 429
+    if code == "char_cap":
+        return 400
+    if code == "turnstile_failed":
+        return 403
+    return 429
 
 
 @router.post("/session", response_model=SessionCreateResponse)
-def create_chat_session(
+async def create_chat_session(
     payload: SessionCreateRequest = Body(default_factory=SessionCreateRequest),
     db: Session = Depends(get_chat_session),
     cf_ipcountry: str | None = Header(default=None, alias="CF-IPCountry"),
+    cf_connecting_ip: str | None = Header(default=None, alias="CF-Connecting-IP"),
     user_agent: str | None = Header(default=None, alias="User-Agent"),
 ) -> SessionCreateResponse:
-    """Verify the (stubbed) Turnstile token and open a server-side session.
+    """Verify the Turnstile token and open a server-side session.
 
-    Returns the opaque session id; SSR stores it in an httpOnly cookie. The
-    row, not the cookie, is the authority for every later budget. The real
-    client IP (for hashing) is forwarded by SSR in Phase 2; Phase 1 stores only
-    coarse country and a user-agent hash.
+    Admission order: (1) siteverify the forwarded Turnstile token (no valid
+    token, no session); (2) enforce the per-IP session-mint cap on the forwarded
+    client IP, hashed. Only then is a row opened. Returns the opaque session id;
+    SSR stores it in an httpOnly cookie. The row, not the cookie, is the
+    authority for every later budget.
+
+    The real client IP arrives in the Cloudflare ``CF-Connecting-IP`` header,
+    forwarded by SSR. The backend trusts it because it is reachable ONLY from the
+    SSR mesh identity: the ``-web`` Linkerd Server + AuthorizationPolicy (see the
+    monolith-public linkerd-policy) authorize only the frontend ServiceAccount,
+    so any request reaching this handler came from SSR. The IP is stored only as
+    a salted hash, never raw.
     """
-    session = sessions.create_session(
-        db,
-        turnstile_token=payload.turnstile_token,
-        country=cf_ipcountry,
-        user_agent=user_agent,
-    )
+    result = await turnstile.siteverify(payload.turnstile_token, cf_connecting_ip)
+    if not result.success:
+        raise HTTPException(
+            status_code=_limit_status("turnstile_failed"),
+            detail={
+                "code": "turnstile_failed",
+                "message": "Challenge verification failed. Please try again.",
+            },
+        )
+
+    try:
+        session = sessions.create_session(
+            db,
+            turnstile_outcome=result.outcome,
+            ip=cf_connecting_ip,
+            country=cf_ipcountry,
+            user_agent=user_agent,
+        )
+    except limits.LimitExceeded as exc:
+        raise HTTPException(
+            status_code=_limit_status(exc.code),
+            detail={"code": exc.code, "message": exc.message},
+        ) from exc
+
     logger.info("chat_public.session.created turn_limit=%d", limits.MAX_TURNS)
     return SessionCreateResponse(session_id=session.id)
 
@@ -124,11 +156,34 @@ def post_chat_message(
             detail={"code": exc.code, "message": exc.message},
         ) from exc
 
-    # Persist the user message, then the canned assistant reply, then bump the
-    # per-session counters. All client-supplied history (if any) is ignored.
-    user_tokens = _estimate_tokens(payload.message)
+    # Global circuit breaker (ADR 005 layer 2): acquire an in-flight slot before
+    # spending any inference. Over the global ceiling the turn is shed with a
+    # "busy" SSE event and NOTHING is persisted (no user message, no counter
+    # bump), so a shed turn is free. The breaker is delivered as a 200 SSE event
+    # rather than a 4xx/5xx status so it flows through the SSR SSE passthrough
+    # unchanged (a non-2xx would be relayed as JSON, not a stream event).
+    try:
+        with limits.inflight_slot():
+            return _serve_turn(db, session, payload.message)
+    except limits.LimitExceeded as exc:
+        if exc.code != "busy":
+            raise
+        emitter = SSEEmitter()
+        emitter.emit("busy", {"code": "busy", "message": exc.message})
+        emitter.close()
+        logger.info("chat_public.message.shed reason=busy")
+        return StreamingResponse(emitter.stream(), media_type="text/event-stream")
+
+
+def _serve_turn(db: Session, session, message: str) -> StreamingResponse:
+    """Persist one turn and stream the (canned, Phase 2) assistant reply.
+
+    Runs while a global in-flight slot is held. All client-supplied history (if
+    any) is ignored; the session row is the sole transcript.
+    """
+    user_tokens = _estimate_tokens(message)
     sessions.append_message(
-        db, session, role="user", content=payload.message, tokens=user_tokens
+        db, session, role="user", content=message, tokens=user_tokens
     )
 
     reply = _CANNED_RESPONSE

--- a/projects/monolith/chat_public/router.py
+++ b/projects/monolith/chat_public/router.py
@@ -85,18 +85,18 @@ async def create_chat_session(
 ) -> SessionCreateResponse:
     """Verify the Turnstile token and open a server-side session.
 
-    Admission order: (1) siteverify the forwarded Turnstile token (no valid
-    token, no session); (2) enforce the per-IP session-mint cap on the forwarded
-    client IP, hashed. Only then is a row opened. Returns the opaque session id;
-    SSR stores it in an httpOnly cookie. The row, not the cookie, is the
-    authority for every later budget.
+    Admission: siteverify the forwarded Turnstile token (no valid token, no
+    session). Only then is a row opened. Returns the opaque session id; SSR
+    stores it in an httpOnly cookie. The row, not the cookie, is the authority
+    for every later budget.
 
     The real client IP arrives in the Cloudflare ``CF-Connecting-IP`` header,
-    forwarded by SSR. The backend trusts it because it is reachable ONLY from the
-    SSR mesh identity: the ``-web`` Linkerd Server + AuthorizationPolicy (see the
-    monolith-public linkerd-policy) authorize only the frontend ServiceAccount,
-    so any request reaching this handler came from SSR. The IP is stored only as
-    a salted hash, never raw.
+    forwarded by SSR, and is stored only as a salted hash for reactive abuse
+    forensics (there is no per-IP mint cap; see limits.py). The backend trusts
+    the header because it is reachable ONLY from the SSR mesh identity: the
+    ``-web`` Linkerd Server + AuthorizationPolicy (see the monolith-public
+    linkerd-policy) authorize only the frontend ServiceAccount, so any request
+    reaching this handler came from SSR.
     """
     result = await turnstile.siteverify(payload.turnstile_token, cf_connecting_ip)
     if not result.success:
@@ -108,20 +108,13 @@ async def create_chat_session(
             },
         )
 
-    try:
-        session = sessions.create_session(
-            db,
-            turnstile_outcome=result.outcome,
-            ip=cf_connecting_ip,
-            country=cf_ipcountry,
-            user_agent=user_agent,
-        )
-    except limits.LimitExceeded as exc:
-        raise HTTPException(
-            status_code=_limit_status(exc.code),
-            detail={"code": exc.code, "message": exc.message},
-        ) from exc
-
+    session = sessions.create_session(
+        db,
+        turnstile_outcome=result.outcome,
+        ip=cf_connecting_ip,
+        country=cf_ipcountry,
+        user_agent=user_agent,
+    )
     logger.info("chat_public.session.created turn_limit=%d", limits.MAX_TURNS)
     return SessionCreateResponse(session_id=session.id)
 

--- a/projects/monolith/chat_public/sessions.py
+++ b/projects/monolith/chat_public/sessions.py
@@ -64,16 +64,14 @@ def create_session(
 
     Turnstile siteverify runs in the router (it is async network IO, see
     chat_public.turnstile.siteverify); this function is only reached once the
-    challenge passed, and records the verified ``turnstile_outcome``. It enforces
-    the per-IP session-mint cap before inserting (raising limits.LimitExceeded on
-    breach) so one network cannot mint sessions without bound.
+    challenge passed, and records the verified ``turnstile_outcome``.
 
     The opaque id is generated server-side from a CSPRNG, so the client cannot
-    forge or guess one. The IP is stored only as a salted hash, never raw; that
-    same hash keys the per-IP mint cap.
+    forge or guess one. The IP is stored only as a salted hash, never raw.
     """
+    # ip_hash is retained for reactive abuse forensics and targeted blocking,
+    # not a pre-emptive per-IP cap (dropped: see limits.py rationale).
     ip_hash = hash_value(ip, IP_HASH_SALT)
-    limits.check_ip_mint_rate(db, ip_hash)
     session = ChatSession(
         id=secrets.token_urlsafe(32),
         ip_hash=ip_hash,

--- a/projects/monolith/chat_public/sessions.py
+++ b/projects/monolith/chat_public/sessions.py
@@ -11,6 +11,7 @@ transitions.
 from __future__ import annotations
 
 import hashlib
+import os
 import secrets
 from datetime import datetime, timedelta, timezone
 
@@ -18,6 +19,12 @@ from sqlmodel import Session, select
 
 from chat_public import limits
 from chat_public.models import ChatMessage, ChatSession
+
+# Optional salt mixed into the IP/user-agent hash so the stored pseudonym is not
+# a bare sha256 of a guessable value (an attacker cannot precompute a rainbow
+# table of IP hashes without the salt). No default: empty salt is acceptable for
+# dev/test; production injects one via CHAT_PUBLIC_IP_HASH_SALT.
+IP_HASH_SALT = os.environ.get("CHAT_PUBLIC_IP_HASH_SALT", "")
 
 
 def _utcnow() -> datetime:
@@ -33,50 +40,44 @@ def _as_utc(dt: datetime | None) -> datetime | None:
     return dt
 
 
-def hash_value(value: str | None) -> str | None:
+def hash_value(value: str | None, salt: str = "") -> str | None:
     """Hash an IP or user-agent for pseudonymous storage. Never store the raw.
 
     Returns None for an absent value so the column stays NULL rather than a
-    hash of the empty string.
+    hash of the empty string. An optional salt is prepended before hashing so the
+    stored pseudonym is not a bare sha256 of a guessable value.
     """
     if not value:
         return None
-    return hashlib.sha256(value.encode("utf-8")).hexdigest()
-
-
-def verify_turnstile(token: str | None, ip: str | None) -> bool:
-    """Verify a Cloudflare Turnstile token against siteverify.
-
-    Phase 1 seam: this is a stubbed-accept. The real siteverify call (with the
-    Turnstile secret from a OnePasswordItem, run in this FastAPI binary, never
-    in SSR) lands in Phase 2. Returning True here lets the session and limit
-    machinery be built and tested without the live challenge.
-
-    TODO(Phase 2): call https://challenges.cloudflare.com/turnstile/v0/siteverify
-    with the secret + token + remote IP and return its success flag; reject on
-    failure so no verified session is minted without a solved challenge.
-    """
-    return True
+    return hashlib.sha256((salt + value).encode("utf-8")).hexdigest()
 
 
 def create_session(
     db: Session,
     *,
-    turnstile_token: str | None = None,
+    turnstile_outcome: str = "passed",
     ip: str | None = None,
     country: str | None = None,
     user_agent: str | None = None,
 ) -> ChatSession:
-    """Verify the (stubbed) Turnstile token and open a server-side session row.
+    """Open a server-side session row for an already-admitted request.
+
+    Turnstile siteverify runs in the router (it is async network IO, see
+    chat_public.turnstile.siteverify); this function is only reached once the
+    challenge passed, and records the verified ``turnstile_outcome``. It enforces
+    the per-IP session-mint cap before inserting (raising limits.LimitExceeded on
+    breach) so one network cannot mint sessions without bound.
 
     The opaque id is generated server-side from a CSPRNG, so the client cannot
-    forge or guess one. Pseudonymous details are stored hashed.
+    forge or guess one. The IP is stored only as a salted hash, never raw; that
+    same hash keys the per-IP mint cap.
     """
-    outcome = "passed" if verify_turnstile(turnstile_token, ip) else "failed"
+    ip_hash = hash_value(ip, IP_HASH_SALT)
+    limits.check_ip_mint_rate(db, ip_hash)
     session = ChatSession(
         id=secrets.token_urlsafe(32),
-        ip_hash=hash_value(ip),
-        turnstile_outcome=outcome,
+        ip_hash=ip_hash,
+        turnstile_outcome=turnstile_outcome,
         country=country,
         user_agent_hash=hash_value(user_agent),
         status="active",

--- a/projects/monolith/chat_public/turnstile.py
+++ b/projects/monolith/chat_public/turnstile.py
@@ -1,0 +1,109 @@
+"""Cloudflare Turnstile siteverify for public-chat admission (ADR 005 layer 1).
+
+This is the admission challenge: no solved Turnstile token, no session. The
+siteverify call runs in THIS FastAPI binary (the Turnstile *secret* is a
+backend-only OnePasswordItem, never in SSR); SSR forwards only the user's token
+and the real client IP. The site key is public by design; the secret key is a
+verification-only credential.
+
+The call is the FIRST off-cluster egress from the public namespace. ADR 004 gives
+that namespace a default-deny Linkerd EgressNetwork, so this destination
+(challenges.cloudflare.com:443) is explicitly allowed by a single TLSRoute in
+projects/monolith-public/chart/templates/linkerd-policy.yaml. Nothing else opens.
+
+Fail-closed posture: any verification we cannot complete (network error, timeout,
+non-2xx, malformed body) is treated as a failure, never a pass.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+# Cloudflare's siteverify endpoint (the one sanctioned off-cluster egress).
+SITEVERIFY_URL = "https://challenges.cloudflare.com/turnstile/v0/siteverify"
+
+# Verification-only secret, backend-only. Unset in dev/test (see siteverify);
+# production always injects it from the cloudflare-turnstile OnePasswordItem.
+SECRET_KEY = os.environ.get("TURNSTILE_SECRET_KEY", "")
+
+# A siteverify round-trip is a small JSON POST; keep the timeout short so a slow
+# or unreachable Cloudflare fails closed quickly rather than hanging admission.
+_TIMEOUT_SECONDS = float(os.environ.get("TURNSTILE_TIMEOUT_SECONDS", "5"))
+
+
+@dataclass(frozen=True)
+class TurnstileResult:
+    """The outcome of a siteverify call.
+
+    ``success`` is the only admission decision. ``outcome`` is the stable string
+    persisted to ``sessions.turnstile_outcome`` (passed / failed / stub_accept).
+    The remaining fields are the diagnostic correlates Cloudflare returns; they
+    are not used as a security boundary, only for logging/forensics.
+    """
+
+    success: bool
+    outcome: str
+    error_codes: tuple[str, ...] = ()
+    action: str | None = None
+    hostname: str | None = None
+
+
+async def siteverify(token: str | None, remoteip: str | None = None) -> TurnstileResult:
+    """Verify a Turnstile token against Cloudflare's siteverify endpoint.
+
+    POSTs the form fields ``secret`` (env), ``response`` (the user token), and
+    ``remoteip`` (the forwarded client IP, when present). Returns a small result;
+    callers admit only when ``success`` is True.
+
+    Dev/test fallback: if ``TURNSTILE_SECRET_KEY`` is unset we stub-accept so
+    local dev and unit tests work without a live challenge. This branch is
+    clearly marked and never taken in production, where the secret is always set.
+    """
+    if not SECRET_KEY:
+        # Stubbed-accept fallback (dev/test only). Never reached in prod.
+        logger.warning(
+            "chat_public.turnstile.stub_accept TURNSTILE_SECRET_KEY unset; "
+            "accepting without a live challenge (dev/test only)"
+        )
+        return TurnstileResult(success=True, outcome="stub_accept")
+
+    if not token:
+        # No token to verify is a failed challenge, not an error.
+        return TurnstileResult(
+            success=False,
+            outcome="failed",
+            error_codes=("missing-input-response",),
+        )
+
+    data = {"secret": SECRET_KEY, "response": token}
+    if remoteip:
+        data["remoteip"] = remoteip
+
+    try:
+        async with httpx.AsyncClient(timeout=_TIMEOUT_SECONDS) as client:
+            resp = await client.post(SITEVERIFY_URL, data=data)
+            resp.raise_for_status()
+            body = resp.json()
+    except (httpx.HTTPError, ValueError) as exc:
+        # Fail closed: a verification we cannot complete is not a pass.
+        logger.warning("chat_public.turnstile.verify_error err=%s", type(exc).__name__)
+        return TurnstileResult(
+            success=False,
+            outcome="failed",
+            error_codes=("verify-unreachable",),
+        )
+
+    success = bool(body.get("success"))
+    return TurnstileResult(
+        success=success,
+        outcome="passed" if success else "failed",
+        error_codes=tuple(body.get("error-codes") or ()),
+        action=body.get("action"),
+        hostname=body.get("hostname"),
+    )

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.153.3
+      targetRevision: 0.154.0
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/lib/public/chat/admission.js
+++ b/projects/monolith/frontend/src/lib/public/chat/admission.js
@@ -1,0 +1,30 @@
+// Client-side admission helper for public chat (ADR 005, Phase 2).
+//
+// The browser never talks to the internal chat API: it POSTs the solved
+// Turnstile token to the same-origin SSR proxy (/chat/session, rerouted to
+// /public/chat/session), which forwards the token + CF-Connecting-IP to the
+// FastAPI backend, runs siteverify there, and sets the opaque httpOnly session
+// cookie. This module is the single, testable seam for that call so the Svelte
+// widget stays a thin shell around it.
+
+// Same-origin SSR proxy path (the reroute hook maps it to /public/chat/session).
+const SESSION_PROXY_PATH = "/chat/session";
+
+/**
+ * Exchange a solved Turnstile token for a server-side session.
+ *
+ * On success the SSR proxy sets the httpOnly `cps` cookie; the opaque id never
+ * reaches the browser, so this returns only an `ok` flag plus the HTTP status.
+ *
+ * @param {string} turnstileToken The token the Turnstile widget produced.
+ * @param {typeof fetch} [fetchImpl] Injectable fetch (defaults to global fetch).
+ * @returns {Promise<{ ok: boolean, status: number }>}
+ */
+export async function createChatSession(turnstileToken, fetchImpl = fetch) {
+  const resp = await fetchImpl(SESSION_PROXY_PATH, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ turnstile_token: turnstileToken }),
+  });
+  return { ok: resp.ok, status: resp.status };
+}

--- a/projects/monolith/frontend/src/lib/public/chat/admission.test.js
+++ b/projects/monolith/frontend/src/lib/public/chat/admission.test.js
@@ -1,0 +1,25 @@
+import { describe, it, expect, vi } from "vitest";
+import { createChatSession } from "./admission.js";
+
+describe("createChatSession", () => {
+  it("POSTs the turnstile token to the same-origin session proxy", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+
+    const result = await createChatSession("tok-abc", fetchImpl);
+
+    expect(result).toEqual({ ok: true, status: 200 });
+    const [url, init] = fetchImpl.mock.calls[0];
+    // Same-origin SSR proxy, not the internal chat API directly.
+    expect(url).toBe("/chat/session");
+    expect(init.method).toBe("POST");
+    expect(JSON.parse(init.body)).toEqual({ turnstile_token: "tok-abc" });
+  });
+
+  it("relays a failed admission as ok:false with the upstream status", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({ ok: false, status: 403 });
+
+    const result = await createChatSession("bad-token", fetchImpl);
+
+    expect(result).toEqual({ ok: false, status: 403 });
+  });
+});

--- a/projects/monolith/frontend/src/lib/public/components/TurnstileGate.svelte
+++ b/projects/monolith/frontend/src/lib/public/components/TurnstileGate.svelte
@@ -1,0 +1,105 @@
+<script>
+  /**
+   * Minimal Cloudflare Turnstile admission gate (ADR 005, Phase 2).
+   *
+   * The deliberate Phase 2 scope: render the challenge with the public site key,
+   * and on solve exchange the token for a server-side session via the SSR proxy.
+   * It carries NO chat UI: the neo-brutalist chat box / graph overlay is Phase 4,
+   * which restyles and places this gate. Keep this a thin shell around
+   * `createChatSession` (the testable admission seam).
+   *
+   * The site key is public by design; the Turnstile *secret* never leaves the
+   * FastAPI backend. The challenge script + iframe load from
+   * https://challenges.cloudflare.com (allowed: this app sets no CSP, see the
+   * Phase 2 notes).
+   *
+   * @type {{
+   *   siteKey: string,
+   *   onAdmitted?: () => void,
+   * }}
+   */
+  let { siteKey, onAdmitted } = $props();
+
+  import { onMount } from "svelte";
+  import { createChatSession } from "$lib/public/chat/admission.js";
+
+  const SCRIPT_SRC = "https://challenges.cloudflare.com/turnstile/v0/api.js";
+
+  // null = waiting for a solve; "verifying" = exchanging the token; "ready" =
+  // admitted (session cookie set); "error" = admission rejected.
+  let status = $state(null);
+  let widgetEl;
+
+  async function onSolve(token) {
+    status = "verifying";
+    try {
+      const { ok } = await createChatSession(token);
+      if (ok) {
+        status = "ready";
+        onAdmitted?.();
+      } else {
+        status = "error";
+      }
+    } catch {
+      status = "error";
+    }
+  }
+
+  function renderWidget() {
+    if (!window.turnstile || !widgetEl || !siteKey) return;
+    window.turnstile.render(widgetEl, {
+      sitekey: siteKey,
+      callback: onSolve,
+      "error-callback": () => {
+        status = "error";
+      },
+    });
+  }
+
+  onMount(() => {
+    if (!siteKey) return;
+    if (window.turnstile) {
+      renderWidget();
+      return;
+    }
+    // Load the challenge script once, then render when it is ready.
+    let script = document.querySelector(`script[src="${SCRIPT_SRC}"]`);
+    if (!script) {
+      script = document.createElement("script");
+      script.src = SCRIPT_SRC;
+      script.async = true;
+      script.defer = true;
+      document.head.appendChild(script);
+    }
+    script.addEventListener("load", renderWidget);
+    return () => script.removeEventListener("load", renderWidget);
+  });
+</script>
+
+{#if !siteKey}
+  <p class="turnstile-gate__note">Chat is unavailable right now.</p>
+{:else}
+  <div class="turnstile-gate">
+    <div bind:this={widgetEl} class="turnstile-gate__widget"></div>
+    {#if status === "verifying"}
+      <p class="turnstile-gate__note">Verifying…</p>
+    {:else if status === "error"}
+      <p class="turnstile-gate__note">
+        Verification failed. Please try again.
+      </p>
+    {/if}
+  </div>
+{/if}
+
+<style>
+  .turnstile-gate {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+  .turnstile-gate__note {
+    font-family: var(--mono);
+    font-size: 13px;
+    color: var(--ink);
+  }
+</style>

--- a/projects/monolith/frontend/src/lib/public/components/index.js
+++ b/projects/monolith/frontend/src/lib/public/components/index.js
@@ -5,3 +5,4 @@ export { default as Marquee } from "./Marquee.svelte";
 export { default as Stamp } from "./Stamp.svelte";
 export { default as Footer } from "./Footer.svelte";
 export { default as ScrollCta } from "./ScrollCta.svelte";
+export { default as TurnstileGate } from "./TurnstileGate.svelte";

--- a/projects/monolith/frontend/src/routes/public/chat/+page.server.js
+++ b/projects/monolith/frontend/src/routes/public/chat/+page.server.js
@@ -1,0 +1,12 @@
+// Expose the public Turnstile site key to the client (ADR 005, Phase 2).
+//
+// Consistent with how this app passes server config to the client elsewhere
+// (e.g. +page.server.js reading process.env.API_BASE): the SSR load reads the
+// site key from the environment and returns it in the page data. The site key
+// is PUBLIC by design (it identifies the widget, not a credential); the
+// Turnstile *secret* never enters the frontend, only the FastAPI backend.
+const TURNSTILE_SITE_KEY = process.env.TURNSTILE_SITE_KEY || "";
+
+export function load() {
+  return { turnstileSiteKey: TURNSTILE_SITE_KEY };
+}

--- a/projects/monolith/frontend/src/routes/public/chat/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/chat/+page.svelte
@@ -1,0 +1,38 @@
+<script>
+  // Minimal Phase 2 mount point for the public-chat admission gate (ADR 005).
+  // This proves the Turnstile -> session-cookie path end to end; the
+  // neo-brutalist chat box and graph overlay are Phase 4, which will restyle and
+  // place the gate (and add the message UI). Intentionally bare for now.
+  import TurnstileGate from "$lib/public/components/TurnstileGate.svelte";
+
+  let { data } = $props();
+  let admitted = $state(false);
+</script>
+
+<svelte:head>
+  <title>Chat · jomcgi.dev</title>
+  <meta name="robots" content="noindex" />
+</svelte:head>
+
+<main class="chat-shell">
+  <h1>Chat</h1>
+  {#if admitted}
+    <p>You're in. The chat experience lands in a later phase.</p>
+  {:else}
+    <p>Solve the challenge to start chatting.</p>
+    <TurnstileGate
+      siteKey={data.turnstileSiteKey}
+      onAdmitted={() => (admitted = true)}
+    />
+  {/if}
+</main>
+
+<style>
+  .chat-shell {
+    max-width: 640px;
+    margin: 0 auto;
+    padding: 48px 24px;
+    font-family: var(--mono);
+    color: var(--ink);
+  }
+</style>

--- a/projects/monolith/frontend/src/routes/public/chat/session/+server.js
+++ b/projects/monolith/frontend/src/routes/public/chat/session/+server.js
@@ -15,8 +15,9 @@ const SESSION_COOKIE = "cps";
 const SESSION_COOKIE_MAX_AGE = 1800;
 
 export async function POST({ request, cookies }) {
-  // Optional Turnstile token forwarded by the client. Phase 1 stub-accepts any
-  // or none; real siteverify (in the FastAPI backend) lands in Phase 2.
+  // Turnstile token forwarded by the client widget. The FastAPI backend runs
+  // siteverify (the Turnstile secret lives there, never in SSR); no valid
+  // token, no session (the backend returns 403 turnstile_failed).
   let turnstileToken = null;
   try {
     const body = await request.json();
@@ -24,18 +25,24 @@ export async function POST({ request, cookies }) {
       turnstileToken = body.turnstile_token;
     }
   } catch {
-    // A missing or empty body is fine in Phase 1.
+    // A missing or empty body falls through: the backend treats an absent token
+    // as a failed challenge in production (it only stub-accepts when its secret
+    // is unset, i.e. dev/test).
   }
 
-  // Forward coarse geo + user-agent for the backend's pseudonymous session row.
-  // TODO(Phase 2): also forward the Cloudflare CF-Connecting-IP so the backend
-  // can key its per-IP session-mint limiter. The backend trusts that header
-  // only on connections bearing SSR's Linkerd identity.
+  // Forward coarse geo + user-agent for the backend's pseudonymous session row,
+  // plus the real client IP from Cloudflare's CF-Connecting-IP header so the
+  // backend can salt-and-hash it (ip_hash, for reactive abuse forensics). The
+  // backend trusts CF-Connecting-IP only on connections bearing SSR's Linkerd
+  // identity (the -web Server + AuthorizationPolicy authorize only the frontend
+  // ServiceAccount), so a direct caller cannot spoof it.
   const headers = { "content-type": "application/json" };
   const country = request.headers.get("cf-ipcountry");
   if (country) headers["CF-IPCountry"] = country;
   const userAgent = request.headers.get("user-agent");
   if (userAgent) headers["User-Agent"] = userAgent;
+  const connectingIp = request.headers.get("cf-connecting-ip");
+  if (connectingIp) headers["CF-Connecting-IP"] = connectingIp;
 
   const resp = await fetch(`${CHAT_API_BASE}/internal/chat/session`, {
     method: "POST",

--- a/projects/monolith/frontend/src/routes/public/chat/session/server.test.js
+++ b/projects/monolith/frontend/src/routes/public/chat/session/server.test.js
@@ -44,7 +44,7 @@ describe("/public/chat/session POST", () => {
     expect(JSON.stringify(body)).not.toContain("opaque-session-id-123");
   });
 
-  it("forwards the turnstile token and coarse geo to the internal API", async () => {
+  it("forwards the turnstile token, coarse geo, and client IP to the internal API", async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,
       json: async () => ({ session_id: "sid" }),
@@ -53,7 +53,11 @@ describe("/public/chat/session POST", () => {
     const cookies = { set: vi.fn() };
     const request = {
       json: async () => ({ turnstile_token: "tok-abc" }),
-      headers: makeHeaders({ "cf-ipcountry": "GB", "user-agent": "UA/1" }),
+      headers: makeHeaders({
+        "cf-ipcountry": "GB",
+        "user-agent": "UA/1",
+        "cf-connecting-ip": "203.0.113.7",
+      }),
     };
 
     await POST({ request, cookies });
@@ -63,6 +67,24 @@ describe("/public/chat/session POST", () => {
     expect(JSON.parse(init.body)).toEqual({ turnstile_token: "tok-abc" });
     expect(init.headers["CF-IPCountry"]).toBe("GB");
     expect(init.headers["User-Agent"]).toBe("UA/1");
+    // The real client IP is forwarded so the backend can salt-and-hash it
+    // (ip_hash); the backend trusts this header only from SSR's mesh identity.
+    expect(init.headers["CF-Connecting-IP"]).toBe("203.0.113.7");
+  });
+
+  it("omits CF-Connecting-IP when the client IP header is absent", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ session_id: "sid" }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const cookies = { set: vi.fn() };
+    const request = { json: async () => ({}), headers: makeHeaders() };
+
+    await POST({ request, cookies });
+
+    const [, init] = fetchMock.mock.calls[0];
+    expect(init.headers["CF-Connecting-IP"]).toBeUndefined();
   });
 
   it("relays the upstream status when the internal API rejects", async () => {

--- a/projects/monolith/public_turnstile_secret_isolation_test.py
+++ b/projects/monolith/public_turnstile_secret_isolation_test.py
@@ -1,0 +1,103 @@
+"""Guard (ADR 005): the Turnstile secret stays in the backend, not the frontend.
+
+ADR 005 layer 1 / Security: siteverify runs in the FastAPI "web" binary and the
+Turnstile *secret* (and the ip-hash salt) live there only. The site *key* is
+public by design and is the only Turnstile value the SSR "frontend" component may
+carry, as a plain literal (never a secretKeyRef to the Turnstile secret object).
+
+This reads the monolith-public chart's values.yaml and fails CI if a future edit
+either drops the backend secretKeyRefs or leaks the Turnstile secret into the
+frontend. Reading values.yaml (not a rendered manifest) keeps the test free of a
+Helm toolchain; the env blocks are plain literals there.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import yaml
+
+TURNSTILE_SECRET_NAME = "monolith-public-turnstile"
+
+
+def _values_path() -> Path:
+    srcdir = os.environ.get("TEST_SRCDIR", "")
+    candidate = (
+        Path(srcdir)
+        / "_main"
+        / "projects"
+        / "monolith-public"
+        / "chart"
+        / "values.yaml"
+    )
+    if candidate.exists():
+        return candidate
+    # Fallback for a direct (non-bazel) run from the repo root.
+    here = (
+        Path(__file__).resolve().parent.parent
+        / "monolith-public"
+        / "chart"
+        / "values.yaml"
+    )
+    if here.exists():
+        return here
+    raise FileNotFoundError(
+        f"values.yaml not found at {candidate} or {here} (TEST_SRCDIR={srcdir!r})"
+    )
+
+
+def _load_values() -> dict:
+    return yaml.safe_load(_values_path().read_text())
+
+
+def _env_by_name(component: dict) -> dict:
+    return {entry["name"]: entry for entry in component.get("env", [])}
+
+
+def test_backend_references_turnstile_secret_via_secretkeyref():
+    """The "web" backend gets SECRET_KEY + IP_HASH_SALT from the synced Secret."""
+    values = _load_values()
+    web_env = _env_by_name(values["web"])
+
+    for var, key in (
+        ("TURNSTILE_SECRET_KEY", "SECRET_KEY"),
+        ("CHAT_PUBLIC_IP_HASH_SALT", "IP_HASH_SALT"),
+    ):
+        assert var in web_env, f"{var} missing from web.env"
+        ref = web_env[var].get("valueFrom", {}).get("secretKeyRef", {})
+        assert ref.get("name") == TURNSTILE_SECRET_NAME, f"{var} wrong secret"
+        assert ref.get("key") == key, f"{var} wrong secret key"
+
+    # The backend must NOT carry the public site key (it does not need it).
+    assert "TURNSTILE_SITE_KEY" not in web_env
+
+
+def test_frontend_carries_only_the_public_site_key_literal():
+    """The SSR frontend gets the public site key as a literal, never the secret."""
+    values = _load_values()
+    frontend_env = _env_by_name(values["frontend"])
+
+    # The site key is present as a plain literal value (no valueFrom).
+    assert "TURNSTILE_SITE_KEY" in frontend_env
+    site_key_entry = frontend_env["TURNSTILE_SITE_KEY"]
+    assert "valueFrom" not in site_key_entry, "site key must be a literal"
+    assert isinstance(site_key_entry.get("value"), str)
+    assert site_key_entry["value"], "site key literal must be non-empty"
+
+    # No frontend env entry may reference the Turnstile secret object, and the
+    # backend-only secret/salt vars must not appear in the frontend at all.
+    for name, entry in frontend_env.items():
+        ref = entry.get("valueFrom", {}).get("secretKeyRef", {})
+        assert ref.get("name") != TURNSTILE_SECRET_NAME, (
+            f"frontend env {name} references the Turnstile secret"
+        )
+    assert "TURNSTILE_SECRET_KEY" not in frontend_env
+    assert "CHAT_PUBLIC_IP_HASH_SALT" not in frontend_env
+
+
+def test_site_key_literal_matches_the_values_ssot():
+    """The frontend literal mirrors turnstile.siteKey (the documented SSOT)."""
+    values = _load_values()
+    frontend_env = _env_by_name(values["frontend"])
+    assert frontend_env["TURNSTILE_SITE_KEY"]["value"] == values["turnstile"]["siteKey"]


### PR DESCRIPTION
## Public Chat (V3) — Phase 2

Implements Phase 2 of `docs/plans/2026-06-16-public-chat-v3-plan.md` (ADR `security/005`): real Turnstile admission, server-side budgets, and the one sanctioned egress widening. Builds on Phase 1 (#2674, merged + live).

### What lands
- **Real Turnstile siteverify** in the FastAPI backend (`chat_public/turnstile.py`): async, **fail-closed** on any network/timeout/non-2xx/malformed response; stub-accepts only when `TURNSTILE_SECRET_KEY` is unset (dev/test). Secret stays in the backend, never SSR.
- **Egress allow (security-reviewed):** a single Linkerd `TLSRoute` (SNI `challenges.cloudflare.com:443`) attached to the namespace default-deny `EgressNetwork`. This is the first off-cluster egress from `monolith-public`; nothing else opens.
- **CF-Connecting-IP** forwarded SSR→backend (trusted because the `-web` Server/AuthorizationPolicy already restricts the backend to the frontend mesh identity); stored salted+hashed as `ip_hash`.
- **Global circuit breaker** (`CHAT_PUBLIC_GLOBAL_MAX_CONCURRENT`): sheds with a 200 `busy` SSE event so SSR relays it unbuffered.
- **Minimal Turnstile widget** (`TurnstileGate.svelte` + admission seam). The full neo-brutalist notes-page chat UI is Phase 4.
- **Wiring:** `cloudflare-turnstile` OnePasswordItem → `monolith-public-turnstile` secret; backend gets `SECRET_KEY` + `IP_HASH_SALT`; frontend gets the public `SITE_KEY` as a values literal (never references the secret). Chart 0.6.3→0.6.4.

### Design decisions (this PR)
- **Per-IP session-mint cap dropped.** Turnstile is anonymous proof-of-humanity, not a user identity; the protections that matter are aggregate (global ceiling + Phase 3 reserved-headroom semaphore) + per-session budgets + the existing Envoy edge per-IP limit. `ip_hash` retained for reactive forensics only.

### Security invariants
- Turnstile secret backend-only; frontend env carries only the public site key (asserted by `public_turnstile_secret_isolation_test`).
- siteverify fails closed; egress allow is a single SNI host.
- `ip_hash` stored salted, never raw IP.

### Out of scope
- Phase 3: vLLM wiring + reserved-headroom semaphore + compaction (the breaker is in-process for now; Phase 3 wires the real semaphore).
- Phase 4: retrieval + neo-brutalist notes-page UI + graph overlay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)