### PR TITLE
fix(monolith): grant public_reader read access to dr_jobs schema

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.6.5
+version: 0.6.6
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.6.5
+      targetRevision: 0.6.6
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.155.0
+version: 0.156.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/migrations/20260618000000_dr_jobs_public_reader_grant.sql
+++ b/projects/monolith/chart/migrations/20260618000000_dr_jobs_public_reader_grant.sql
@@ -1,0 +1,13 @@
+-- Grant public_reader read access to dr_jobs (ADR 004 security/004). The /app/dr-jobs
+-- page is served by the public tier (monolith-public), which reads monolith-pg-ro as
+-- public_reader. The dr_jobs schema shipped (20260616130000_dr_jobs_schema.sql) without
+-- this grant, so every public-tier request 500'd with "permission denied for schema
+-- dr_jobs" and the SSR turned that into a 503. NHS Scotland vacancies are wholly public
+-- data, so dr_jobs joins hikes/ships/stars as a directly-readable schema (no public_api
+-- view needed). ALTER DEFAULT PRIVILEGES covers tables a future migration adds here so
+-- the grant does not silently rot. See 20260617000000_public_reader_role.sql.
+
+GRANT USAGE ON SCHEMA dr_jobs TO public_reader;
+GRANT SELECT ON ALL TABLES IN SCHEMA dr_jobs TO public_reader;
+ALTER DEFAULT PRIVILEGES IN SCHEMA dr_jobs
+    GRANT SELECT ON TABLES TO public_reader;

--- a/projects/monolith/chart/migrations/atlas.sum
+++ b/projects/monolith/chart/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:XAzJTgb9ujFS2/06v45qb4UKJL1Ps+jeItEY0r/s5EY=
+h1:UHM6K/0XclExcHtM76EVFOcHolWszDe5sGWJp1U7LQM=
 20260330000000_initial_schema.sql h1:J2futpSW0nJAIRR7nR7ssT7LwXIYrvRI+PkHb5Y4tLI=
 20260403000000_chat_schema.sql h1:pERUFC0vzM95etRuzp43XzkCV7lBCzrrtY5Mk7aF3CA=
 20260404000000_chat_attachments.sql h1:tv+Fdbr1rQC5nzUxfaBC0O6fu2OMGgLWf+YNg1WQXi4=
@@ -50,3 +50,4 @@ h1:XAzJTgb9ujFS2/06v45qb4UKJL1Ps+jeItEY0r/s5EY=
 20260617010000_observability_snapshots.sql h1:n7A5V/Hi0fDA2CcMpjx+abtIEPzIQw2y29HjttjN0Kw=
 20260617020000_public_api_knowledge_views.sql h1:u8hrvPXyEy13O8myQseybPSjcXNGshZcm7ccS+QikSA=
 20260617030000_chat_public.sql h1:9vsb9816XJqzHosczMkk6ry7DJDUxuHlwth7d6nDAO0=
+20260618000000_dr_jobs_public_reader_grant.sql h1:vGn4asj4xkcbL5fUdSHIlb6MbrMVAF4k5URBqS+nB+4=

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.155.0
+      targetRevision: 0.156.0
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/public_reader_grants_test.py
+++ b/projects/monolith/public_reader_grants_test.py
@@ -59,7 +59,12 @@ def test_public_reader_can_read_public_datasets(pg):
         with Session(engine) as session:
             session.execute(text("SET ROLE public_reader"))
             # A granted SELECT on each wholly-public dataset must not raise.
-            for table in ("ships.vessels", "stars.sites", "hikes.walks"):
+            for table in (
+                "ships.vessels",
+                "stars.sites",
+                "hikes.walks",
+                "dr_jobs.nhs_vacancies",
+            ):
                 session.execute(text(f"SELECT count(*) FROM {table}"))
     finally:
         engine.dispose()


### PR DESCRIPTION
## Problem

`/app/dr-jobs` returns **503** ("the server hit a rough patch / dr-jobs listings unavailable").

## Root cause

The page is served by the public tier (`monolith-public`), which reads `monolith-pg-ro` as the least-privilege `public_reader` role. The `dr_jobs` schema shipped (PR #2646/#2647) without a `public_reader` grant, so the public backend's `select(Vacancy)` against `dr_jobs.nhs_vacancies` failed:

```
psycopg.errors.InsufficientPrivilege: permission denied for schema dr_jobs
FROM dr_jobs.nhs_vacancies
```

The SSR `+page.server.js` load turns any non-2xx backend response into `error(503, ...)`, which is the page users saw. The `monolith` (private) tier and the daily scrape were healthy throughout; only the public read path was broken.

## Fix

NHS Scotland vacancies are wholly public data, so `dr_jobs` joins `hikes`/`ships`/`stars` as a directly-readable schema (no `public_api` view needed). New migration grants `public_reader`:

- `USAGE` on schema `dr_jobs`
- `SELECT` on all tables in `dr_jobs`
- `ALTER DEFAULT PRIVILEGES` so a future table in the schema does not silently rot the grant

Extends `public_reader_grants_test.py` to assert `dr_jobs.nhs_vacancies` is readable as `public_reader`. Bumps chart `0.155.0 -> 0.156.0` (Chart.yaml + application.yaml) so the migration deploys; `atlas.sum` regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)