### PR TITLE
feat(monolith-public): add externally-assertable /health route

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.6.6
+version: 0.6.7
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.6.7
+version: 0.6.8
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.6.7
+      targetRevision: 0.6.8
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.6.6
+      targetRevision: 0.6.7
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/app/main_public.py
+++ b/projects/monolith/app/main_public.py
@@ -14,6 +14,8 @@ query private tables today and will 500 as ``public_reader`` until Phase 5a'.
 
 from __future__ import annotations
 
+import logging
+
 import chat_public
 import dr_jobs
 import hikes
@@ -21,10 +23,15 @@ import home
 import knowledge
 import ships
 import stars
+from app.db import get_engine
 from app.log import configure_logging
 from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+from sqlmodel import Session, text
 
 configure_logging()
+
+logger = logging.getLogger("monolith_public")
 
 app = FastAPI(title="Monolith Public")
 
@@ -39,6 +46,27 @@ chat_public.register_public(app)
 
 @app.get("/healthz")
 def healthz():
+    return {"status": "ok"}
+
+
+@app.get("/api/health")
+def api_health():
+    """Deep health for the public tier, reached via the frontend /health proxy.
+
+    The backend is never internet-reachable, so the externally assertable signal
+    is jomcgi.dev/health, which proxies here in-cluster. Unlike /healthz (process
+    up only), this runs SELECT 1 to confirm the read replica is reachable and the
+    public_reader role can execute a query, the class of failure that left the
+    process green while /app/dr-jobs 503'd. Returns a clean 503 rather than
+    raising, so a DB outage logs once per probe instead of a traceback, and the
+    frontend gets a machine-readable status either way.
+    """
+    try:
+        with Session(get_engine()) as session:
+            session.execute(text("SELECT 1"))
+    except Exception:
+        logger.exception("public health check failed")
+        return JSONResponse({"status": "unhealthy"}, status_code=503)
     return {"status": "ok"}
 
 

--- a/projects/monolith/app/main_public_routes_test.py
+++ b/projects/monolith/app/main_public_routes_test.py
@@ -59,6 +59,10 @@ def test_healthz_present():
     assert "/healthz" in _paths()
 
 
+def test_api_health_present():
+    assert "/api/health" in _paths()
+
+
 # Deny-by-default allowlist: every route on the public app must fall under one
 # of these prefixes. Unlike the negative assertions below (which forbid the
 # private prefixes we know about today), this catches a future domain mounted
@@ -78,6 +82,9 @@ ALLOWED_PREFIXES = (
     # from the internet.
     "/internal/chat",
     "/healthz",
+    # Deep health probe (DB reachable + public_reader can query). Reached via the
+    # frontend /health same-origin proxy; not a private surface.
+    "/api/health",
     "/openapi.json",
     "/docs",
     "/redoc",

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.156.0
+version: 0.157.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.157.0
+version: 0.157.1
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.157.0
+      targetRevision: 0.157.1
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.156.0
+      targetRevision: 0.157.0
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/lib/cache-headers.js
+++ b/projects/monolith/frontend/src/lib/cache-headers.js
@@ -25,6 +25,15 @@ export function versionedEtag(dataEtag) {
 // 60s fresh · 24h SWR (background refresh) · 1y SIE (cluster-down resilience)
 export const PAGE_CACHE_CONTROL = `public, s-maxage=60, stale-while-revalidate=${ONE_DAY}, stale-if-error=${ONE_YEAR}`;
 
+// /health probe: deliberately the inverse of the data caches above. A 60s edge
+// cache caps origin load at ~1 req/min, but health MUST surface a real outage,
+// so there is NO stale-if-error (it would serve a stale 200 while the origin is
+// down) and NO stale-while-revalidate (it would mask a fresh transition to
+// unhealthy for a cycle). Only the 200 is cached; the frontend leaves the header
+// off the 503 path so failures are never cached. 60s detection lag is fine: this
+// is a personal service with no SLA.
+export const HEALTH_CACHE_CONTROL = "public, max-age=0, s-maxage=60";
+
 // /notes graph: gardener mutates on a schedule, so 1h freshness is fine. Mirrors
 // _GRAPH_CACHE_CONTROL in projects/monolith/knowledge/router.py — keep in sync.
 export const NOTES_PAGE_CACHE_CONTROL = `public, s-maxage=${ONE_HOUR}, stale-while-revalidate=${ONE_DAY}, stale-if-error=${ONE_YEAR}`;

--- a/projects/monolith/frontend/src/routes/public/health/+server.js
+++ b/projects/monolith/frontend/src/routes/public/health/+server.js
@@ -1,0 +1,36 @@
+import { json } from "@sveltejs/kit";
+import { HEALTH_CACHE_CONTROL } from "$lib/cache-headers.js";
+
+const API_BASE = process.env.API_BASE || "http://localhost:8000";
+
+// External health probe for the public tier (jomcgi.dev/health). Machine-readable
+// JSON, not a page. The gateway routes only to this frontend, so this same-origin
+// route is the only externally reachable health surface; it proxies server-side to
+// the backend's deep check (read replica reachable + public_reader can query),
+// keeping the /api surface off the browser. Success is edge-cached for 60s
+// (HEALTH_CACHE_CONTROL) to cap origin load at ~1 req/min; the 503 path sets no
+// cache header so failures are never cached and an outage surfaces within a cycle.
+export async function GET({ fetch }) {
+  let res;
+  try {
+    res = await fetch(`${API_BASE}/api/health`, {
+      signal: AbortSignal.timeout(5_000),
+    });
+  } catch {
+    return json(
+      { status: "unhealthy", reason: "backend unreachable" },
+      { status: 503 },
+    );
+  }
+
+  if (!res.ok) {
+    return json(
+      { status: "unhealthy", backendStatus: res.status },
+      { status: 503 },
+    );
+  }
+
+  return json(await res.json(), {
+    headers: { "cache-control": HEALTH_CACHE_CONTROL },
+  });
+}

--- a/projects/monolith/frontend/src/routes/public/health/+server.js
+++ b/projects/monolith/frontend/src/routes/public/health/+server.js
@@ -1,5 +1,9 @@
 import { json } from "@sveltejs/kit";
-import { HEALTH_CACHE_CONTROL } from "$lib/cache-headers.js";
+// Relative (not $lib): vitest loads this module directly via server.test.js and
+// its plain node config does not resolve the SvelteKit $lib alias. Mirrors the
+// dr-jobs +page.server.js note. From routes/public/health/ that is three ../ to
+// reach src/lib/.
+import { HEALTH_CACHE_CONTROL } from "../../../lib/cache-headers.js";
 
 const API_BASE = process.env.API_BASE || "http://localhost:8000";
 

--- a/projects/monolith/frontend/src/routes/public/health/server.test.js
+++ b/projects/monolith/frontend/src/routes/public/health/server.test.js
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi } from "vitest";
+import { GET } from "./+server.js";
+import { HEALTH_CACHE_CONTROL } from "../../../lib/cache-headers.js";
+
+describe("/public/health GET", () => {
+  it("proxies to the backend deep health endpoint", async () => {
+    const fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ status: "ok" }),
+    });
+
+    const res = await GET({ fetch });
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(fetch.mock.calls[0][0]).toMatch(/\/api\/health$/);
+    expect(res.status).toBe(200);
+  });
+
+  it("caches only the healthy response (60s edge, no stale-if-error)", async () => {
+    const fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ status: "ok" }),
+    });
+
+    const res = await GET({ fetch });
+
+    expect(res.headers.get("cache-control")).toBe(HEALTH_CACHE_CONTROL);
+    expect(HEALTH_CACHE_CONTROL).not.toContain("stale-if-error");
+    expect(HEALTH_CACHE_CONTROL).not.toContain("stale-while-revalidate");
+  });
+
+  it("returns an uncached 503 when the backend reports unhealthy", async () => {
+    const fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 503,
+      json: async () => ({ status: "unhealthy" }),
+    });
+
+    const res = await GET({ fetch });
+
+    expect(res.status).toBe(503);
+    expect(res.headers.get("cache-control")).toBeNull();
+  });
+
+  it("returns an uncached 503 when the backend is unreachable", async () => {
+    const fetch = vi.fn().mockRejectedValue(new Error("connection refused"));
+
+    const res = await GET({ fetch });
+
+    expect(res.status).toBe(503);
+    expect(res.headers.get("cache-control")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Why

Follow-up to the dr-jobs 503 (PR #2677). That outage showed a process-up signal isn't enough: the public tier's `/healthz` was green while the `public_reader` DB path was broken. This adds a health route that reaches through to the database, so the public tier's health can be asserted from outside the cluster.

## What

- **Backend** (`main_public`): `GET /api/health` runs `SELECT 1` as `public_reader` to confirm the read replica is reachable and the role can execute a query. Returns a clean `503` (not a raised 500) on failure, so a DB outage logs once per probe instead of a traceback.
- **Frontend**: `GET /health` (`+server.js`) at `jomcgi.dev/health`. The gateway routes solely to the frontend (the backend is never internet-reachable), so this same-origin route is the only externally reachable health surface; it proxies server-side to the backend deep check, keeping `/api` off the browser. Returns machine-readable JSON.
- **Caching** (`HEALTH_CACHE_CONTROL = public, max-age=0, s-maxage=60`): the `200` is edge-cached 60s to cap origin load at ~1 req/min. Deliberately the inverse of the data caches: **no `stale-if-error`** (would serve a stale 200 while origin is down) and **no `stale-while-revalidate`** (would mask a fresh transition to unhealthy). Failures set no cache header, so they're never cached. Detection lag ≤60s, fine for a personal service with no SLA.

## Tests

- Extends the public route-table allowlist + adds a presence assertion in `main_public_routes_test.py`.
- New frontend `server.test.js`: proxy target, cache-on-success-only, and both failure paths (backend 503, backend unreachable).

## Scope

Public tier only (per request: the private tier is single-user). No HTTPRoute change needed: `/health` rides the existing catch-all `/` rule to the frontend; `/api/health` stays backend-internal. Chart `monolith-public` bumped `0.6.6 -> 0.6.7`.

## Verify after merge

`curl -s -o /dev/null -w "%{http_code}\n" https://jomcgi.dev/health` should return `200` with body `{"status":"ok"}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)