### PR TITLE
fix: clean up Turnstile widget on unmount (public chat gate broken)

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.11.0
+version: 0.11.1
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.11.0
+      targetRevision: 0.11.1
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.161.0
+version: 0.161.1
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.161.0
+      targetRevision: 0.161.1
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/lib/public/components/TurnstileGate.svelte
+++ b/projects/monolith/frontend/src/lib/public/components/TurnstileGate.svelte
@@ -29,6 +29,13 @@
   // admitted (session cookie set); "error" = admission rejected.
   let status = $state(null);
   let widgetEl;
+  // The id Turnstile returns from render(). Tracked so we render exactly once
+  // per mount and can remove() the widget on unmount, keeping Turnstile's global
+  // widget registry clean. Without this, an unmount (NEW CHAT re-gating, or SPA
+  // navigation back to this page) orphans the widget and the next render fails
+  // with "Cannot find Widget", so the solve callback never fires and no session
+  // is ever created.
+  let widgetId = null;
 
   async function onSolve(token) {
     status = "verifying";
@@ -47,7 +54,10 @@
 
   function renderWidget() {
     if (!window.turnstile || !widgetEl || !siteKey) return;
-    window.turnstile.render(widgetEl, {
+    // Render at most once per mount. A second render() on the same element is
+    // what triggers the "widget already rendered" / orphan errors.
+    if (widgetId !== null) return;
+    widgetId = window.turnstile.render(widgetEl, {
       sitekey: siteKey,
       callback: onSolve,
       "error-callback": () => {
@@ -56,11 +66,23 @@
     });
   }
 
+  function removeWidget() {
+    if (widgetId !== null && window.turnstile) {
+      try {
+        window.turnstile.remove(widgetId);
+      } catch {
+        // Widget already gone; nothing to clean up.
+      }
+    }
+    widgetId = null;
+  }
+
   onMount(() => {
-    if (!siteKey) return;
+    if (!siteKey) return undefined;
     if (window.turnstile) {
       renderWidget();
-      return;
+      // Still remove the widget on unmount so the registry stays clean.
+      return removeWidget;
     }
     // Load the challenge script once, then render when it is ready.
     let script = document.querySelector(`script[src="${SCRIPT_SRC}"]`);
@@ -72,7 +94,10 @@
       document.head.appendChild(script);
     }
     script.addEventListener("load", renderWidget);
-    return () => script.removeEventListener("load", renderWidget);
+    return () => {
+      script.removeEventListener("load", renderWidget);
+      removeWidget();
+    };
   });
 </script>
 


### PR DESCRIPTION
## Public chat send does nothing (prod fix)

Console: `[Cloudflare Turnstile] Cannot find Widget ... consider using turnstile.remove()`.

`TurnstileGate.svelte` called `turnstile.render()` but never stored the widget id, never called `turnstile.remove()` on unmount, and had no render-once guard. On unmount/remount (NEW CHAT re-gating, or SPA navigation back to /app/notes) Turnstile orphaned the widget, the new render failed, the solve callback never fired, no session was created, and **send silently did nothing**. The full-screen rewrite changed the mount pattern and exposed it.

Fix: capture the id from `turnstile.render()`, render exactly once per mount, and `turnstile.remove(id)` in the onMount cleanup so the global widget registry stays clean across mounts.

Frontend-only; no migration. monolith-public 0.11.0 -> 0.11.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)