### PR TITLE
fix: explainer + on the left, flatten graph view shadows

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.11.5
+version: 0.11.6
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.11.5
+      targetRevision: 0.11.6
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.162.0
+version: 0.162.1
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.162.0
+      targetRevision: 0.162.1
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/lib/public/chat/GraphView.svelte
+++ b/projects/monolith/frontend/src/lib/public/chat/GraphView.svelte
@@ -152,7 +152,6 @@
   .graph-view {
     border: 2px solid var(--ink);
     background: var(--bg);
-    box-shadow: var(--shadow-hard-lg);
     display: flex;
     flex-direction: column;
     overflow: hidden;
@@ -249,7 +248,15 @@
     border: 2px solid var(--ink);
     background: var(--accent);
     cursor: pointer;
-    box-shadow: var(--shadow-hard-sm);
+  }
+
+  /* Flatten the reused graph chrome within this view (the shared components
+     carry a hard 4px offset shadow); scoped here so the private notes graph is
+     untouched and NotePanel does not need editing. */
+  .graph-view :global(.search),
+  .graph-view :global(.legend),
+  .graph-view :global(.panel) {
+    box-shadow: none;
   }
 
   @media (max-width: 640px) {

--- a/projects/monolith/frontend/src/routes/public/app/notes/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/notes/+page.svelte
@@ -222,9 +222,9 @@
        than buried at the bottom. -->
   <details class="explainer">
     <summary class="explainer-summary">
+      <span class="explainer-mark" aria-hidden="true">+</span>
       <span class="explainer-eyebrow">HOW DOES THIS WORK?</span>
       <span class="explainer-hint">An open model on my own cluster, no tools.</span>
-      <span class="explainer-mark" aria-hidden="true">+</span>
     </summary>
     <div class="explainer-body">
       <p>
@@ -490,9 +490,9 @@
     white-space: nowrap;
   }
   .explainer-mark {
-    margin-left: auto;
     font-size: 18px;
     line-height: 1;
+    color: var(--ink-3);
     transition: transform 150ms ease;
   }
   .explainer[open] .explainer-mark {


### PR DESCRIPTION
Explainer disclosure mark moved from the far-right of the full-width banner to the left beside the heading. Graph view flattened: removed its own hard shadows and the reused search/legend/note-panel shadows (scoped :global so the private graph + NotePanel are untouched). monolith-public bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)