### PR TITLE
fix: retry Turnstile siteverify (egress flake), white graph bg

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.11.6
+version: 0.11.7
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.11.6
+      targetRevision: 0.11.7
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.162.1
+version: 0.162.2
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chat_public/turnstile.py
+++ b/projects/monolith/chat_public/turnstile.py
@@ -17,6 +17,7 @@ non-2xx, malformed body) is treated as a failure, never a pass.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import os
 from dataclasses import dataclass
@@ -32,9 +33,28 @@ SITEVERIFY_URL = "https://challenges.cloudflare.com/turnstile/v0/siteverify"
 # production always injects it from the cloudflare-turnstile OnePasswordItem.
 SECRET_KEY = os.environ.get("TURNSTILE_SECRET_KEY", "")
 
-# A siteverify round-trip is a small JSON POST; keep the timeout short so a slow
-# or unreachable Cloudflare fails closed quickly rather than hanging admission.
-_TIMEOUT_SECONDS = float(os.environ.get("TURNSTILE_TIMEOUT_SECONDS", "5"))
+# Per-attempt timeout. The connect leg is the flaky one (the Linkerd egress
+# proxy establishing the off-cluster connection to Cloudflare), so it gets a
+# more generous budget than the read.
+_TIMEOUT = httpx.Timeout(
+    float(os.environ.get("TURNSTILE_TIMEOUT_SECONDS", "6")),
+    connect=float(os.environ.get("TURNSTILE_CONNECT_TIMEOUT_SECONDS", "8")),
+)
+
+# Retry transient connect/network failures: the off-cluster egress to Cloudflare
+# is occasionally slow to establish and a single attempt fails closed with a
+# ConnectError, which blocks admission. A ConnectError means the request never
+# reached Cloudflare, so the token was NOT consumed and retrying is safe.
+_VERIFY_ATTEMPTS = int(os.environ.get("TURNSTILE_VERIFY_ATTEMPTS", "3"))
+_RETRYABLE_ERRORS = (
+    httpx.ConnectError,
+    httpx.ConnectTimeout,
+    httpx.ReadTimeout,
+    httpx.PoolTimeout,
+    httpx.WriteError,
+    httpx.RemoteProtocolError,
+    httpx.NetworkError,
+)
 
 
 @dataclass(frozen=True)
@@ -85,19 +105,41 @@ async def siteverify(token: str | None, remoteip: str | None = None) -> Turnstil
     if remoteip:
         data["remoteip"] = remoteip
 
-    try:
-        async with httpx.AsyncClient(timeout=_TIMEOUT_SECONDS) as client:
-            resp = await client.post(SITEVERIFY_URL, data=data)
-            resp.raise_for_status()
-            body = resp.json()
-    except (httpx.HTTPError, ValueError) as exc:
-        # Fail closed: a verification we cannot complete is not a pass.
-        logger.warning("chat_public.turnstile.verify_error err=%s", type(exc).__name__)
-        return TurnstileResult(
-            success=False,
-            outcome="failed",
-            error_codes=("verify-unreachable",),
-        )
+    body = None
+    for attempt in range(_VERIFY_ATTEMPTS):
+        try:
+            async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
+                resp = await client.post(SITEVERIFY_URL, data=data)
+                resp.raise_for_status()
+                body = resp.json()
+            break
+        except _RETRYABLE_ERRORS as exc:
+            # Transient egress failure; the request did not reach Cloudflare, so
+            # the token is unspent and we can retry safely.
+            if attempt + 1 < _VERIFY_ATTEMPTS:
+                await asyncio.sleep(0.3 * (attempt + 1))
+                continue
+            logger.warning(
+                "chat_public.turnstile.verify_error err=%s attempts=%d",
+                type(exc).__name__,
+                attempt + 1,
+            )
+            return TurnstileResult(
+                success=False,
+                outcome="failed",
+                error_codes=("verify-unreachable",),
+            )
+        except (httpx.HTTPError, ValueError) as exc:
+            # Non-retryable (a real 4xx/5xx from Cloudflare or a malformed body):
+            # fail closed without retrying.
+            logger.warning(
+                "chat_public.turnstile.verify_error err=%s", type(exc).__name__
+            )
+            return TurnstileResult(
+                success=False,
+                outcome="failed",
+                error_codes=("verify-unreachable",),
+            )
 
     success = bool(body.get("success"))
     return TurnstileResult(

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.162.1
+      targetRevision: 0.162.2
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/lib/public/chat/GraphView.svelte
+++ b/projects/monolith/frontend/src/lib/public/chat/GraphView.svelte
@@ -151,7 +151,7 @@
 <style>
   .graph-view {
     border: 2px solid var(--ink);
-    background: var(--bg);
+    background: var(--paper);
     display: flex;
     flex-direction: column;
     overflow: hidden;
@@ -257,6 +257,12 @@
   .graph-view :global(.legend),
   .graph-view :global(.panel) {
     box-shadow: none;
+  }
+  /* Whiten the graph canvas: the shared stage is a cream parchment that reads as
+     cream-on-cream against the page. Scoped so the private notes graph keeps its
+     parchment. */
+  .graph-view :global(.stage) {
+    background: var(--paper);
   }
 
   @media (max-width: 640px) {


### PR DESCRIPTION
Two live fixes:
1. **Admission failing ('Success!' widget but 'Verification failed')**: the backend siteverify call to challenges.cloudflare.com intermittently ConnectErrors through the Linkerd egress and we failed closed on the first attempt. Now retries transient connect/network errors (token is unspent on a ConnectError, so safe) with a more generous connect timeout.
2. **Graph cream-on-cream**: whiten the graph view container + the shared cream stage canvas, scoped so the private notes graph keeps its parchment.

monolith-public bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)