### PR TITLE
fix: match public-chat title-bar element sizes

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.11.7
+version: 0.11.8
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.11.7
+      targetRevision: 0.11.8
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.162.2
+version: 0.162.3
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.162.2
+      targetRevision: 0.162.3
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/routes/public/app/notes/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/notes/+page.svelte
@@ -588,9 +588,10 @@
     background: var(--blue);
   }
   .chat-box-status {
-    font-size: 10px;
-    letter-spacing: 0.1em;
-    padding: 2px 7px;
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0.14em;
+    padding: 3px 9px;
     border: 1.5px solid var(--ink);
     background: var(--paper);
   }
@@ -604,10 +605,10 @@
   }
   .bar-btn {
     font-family: var(--mono);
-    font-size: 10px;
+    font-size: 11px;
     font-weight: 700;
-    letter-spacing: 0.1em;
-    padding: 5px 11px;
+    letter-spacing: 0.14em;
+    padding: 3px 9px;
     border: 1.5px solid var(--ink);
     background: var(--paper);
     color: var(--ink);


### PR DESCRIPTION
SESSION OPEN / NEW CHAT were noticeably smaller than the PUBLIC CHAT tag; align font-size/weight/letter-spacing/padding so all three boxes match. monolith-public bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)