### PR TITLE
feat(monolith-public): live GPU ticker + full-bleed notes ticker

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.11.11
+version: 0.11.12
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.11.11
+      targetRevision: 0.11.12
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.163.0
+version: 0.164.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.163.0
+      targetRevision: 0.164.0
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/routes/public/app/notes/+page.server.js
+++ b/projects/monolith/frontend/src/routes/public/app/notes/+page.server.js
@@ -7,6 +7,18 @@
 // switches to the graph view, so the initial chat load stays light.
 const TURNSTILE_SITE_KEY = process.env.TURNSTILE_SITE_KEY || "";
 
-export function load() {
-  return { turnstileSiteKey: TURNSTILE_SITE_KEY };
+export async function load({ fetch }) {
+  // Seed the live ticker's GPU readout with the cluster stats snapshot (the
+  // same payload the homepage renders), via the same-origin proxy. The page
+  // then polls it client-side. Fail-soft: the ticker falls back to its static
+  // readouts when stats are unavailable, so a stats hiccup never blocks chat.
+  let stats = null;
+  try {
+    const res = await fetch("/app/notes/stats");
+    if (res.ok) stats = await res.json();
+  } catch {
+    // leave stats null; the ticker degrades gracefully
+  }
+
+  return { turnstileSiteKey: TURNSTILE_SITE_KEY, stats };
 }

--- a/projects/monolith/frontend/src/routes/public/app/notes/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/notes/+page.svelte
@@ -10,6 +10,7 @@
   // Chat is the default view. A Chat | Graph toggle switches to the graph view,
   // which is LAZY: the heavy KnowledgeGraph component and its data are only
   // imported/fetched on the first switch, never on the initial chat load.
+  import { onMount } from "svelte";
   import TurnstileGate from "$lib/public/components/TurnstileGate.svelte";
   import { renderMarkdown } from "$lib/components/notes/markdown.js";
   import {
@@ -82,9 +83,11 @@
   // while a turn streams (chars received / 4 per token, over elapsed seconds),
   // settling to the last turn's rate when idle.
   //
-  // GPU hardware stats (temp / VRAM) are deliberately omitted: they need a
-  // metrics endpoint we do not expose yet. Wiring those into the ticker is a
-  // planned follow-up.
+  // GPU UTIL / VRAM come from the cluster stats snapshot (the same payload the
+  // homepage renders): SSR seeds `data.stats`, and we poll the same-origin
+  // /app/notes/stats proxy so the GPU readout stays live while a visitor sits on
+  // the page. No new backend endpoint, and the browser never calls the backend
+  // directly. When stats are unavailable the GPU items just drop out.
   const MODEL_NAME = "QWEN3.6-27B"; // CHAT_PUBLIC_MODEL = qwen3.6-27b
   const BOT_LABEL = "QWEN3.6 / LOCAL"; // model family + "runs on my cluster"
   const CONTEXT_WINDOW = 32768; // CHAT_PUBLIC_MODEL_WINDOW_TOKENS
@@ -100,6 +103,45 @@
   let tokPerSec = $state(0); // last computed decode rate
   let turnStart = 0; // performance.now() at turn start (plain, non-reactive)
 
+  // Live cluster stats (homepage GPU/system snapshot). SSR-seeded, then polled.
+  let liveStats = $state(data.stats ?? null);
+  onMount(() => {
+    let stopped = false;
+    const id = setInterval(async () => {
+      try {
+        const res = await fetch("/app/notes/stats");
+        if (!stopped && res.ok) liveStats = await res.json();
+      } catch {
+        // keep the last good value; the readout never goes blank on a blip
+      }
+    }, 20_000);
+    return () => {
+      stopped = true;
+      clearInterval(id);
+    };
+  });
+
+  // GPU readouts derived from the snapshot: utilization and VRAM used / total.
+  // Each item appears only when its field is present, so a partial snapshot
+  // (e.g. util known but frame buffer unavailable) still surfaces what it can.
+  const gpuItems = $derived.by(() => {
+    const g = liveStats?.gpu;
+    if (!g) return [];
+    const items = [];
+    if (typeof g.utilization_pct === "number") {
+      items.push(`GPU: ${Math.round(g.utilization_pct)}% UTIL`);
+    }
+    if (
+      typeof g.memory_used_gb === "number" &&
+      typeof g.memory_total_gb === "number"
+    ) {
+      items.push(
+        `VRAM: ${g.memory_used_gb.toFixed(0)} / ${g.memory_total_gb.toFixed(0)} GB`,
+      );
+    }
+    return items;
+  });
+
   function fmtCount(n) {
     // 1234 -> "1,234". Used for the KG note count and empty-state copy.
     return n.toLocaleString("en-US");
@@ -111,6 +153,7 @@
 
   const tickerItems = $derived([
     `MODEL: ${MODEL_NAME}`,
+    ...gpuItems,
     `CTX: ${fmtTokens(sessionTokens)} / ${CONTEXT_WINDOW / 1024}K`,
     `TOK/S: ${tokPerSec.toFixed(1)}`,
     `KG: ${fmtCount(PUBLIC_NOTE_COUNT)} NOTES`,
@@ -657,10 +700,17 @@
      translateX(-33.333%) gives a seamless loop. Coral dots separate segments. */
   .ticker {
     flex: none;
+    /* Full-bleed: span the whole viewport width edge to edge, escaping the app
+       shell's horizontal padding (incl. safe-area insets). For a flex child the
+       50% resolves against the parent's content width, so this margin collapses
+       to exactly -padding at every breakpoint. No shadow: just top/bottom rules
+       so the band reads as a clean stripe. */
+    width: 100vw;
+    margin-left: calc(50% - 50vw);
     background: var(--accent);
     color: var(--ink);
-    border: 2px solid var(--ink);
-    box-shadow: var(--shadow-hard-sm);
+    border-top: 2px solid var(--ink);
+    border-bottom: 2px solid var(--ink);
     overflow: hidden;
     font-size: 11px;
     font-weight: 700;
@@ -672,7 +722,7 @@
     gap: 36px;
     padding: 7px 0;
     width: max-content;
-    animation: ticker-scroll 42s linear infinite;
+    animation: ticker-scroll 28s linear infinite;
   }
   .ticker-item {
     display: inline-flex;

--- a/projects/monolith/frontend/src/routes/public/app/notes/page.server.test.js
+++ b/projects/monolith/frontend/src/routes/public/app/notes/page.server.test.js
@@ -8,12 +8,25 @@ describe("/public/app/notes load", () => {
     else process.env.TURNSTILE_SITE_KEY = original;
   });
 
-  it("exposes the public Turnstile site key and does not fetch the graph", () => {
-    // The graph is fetched lazily client-side (via /app/notes/graph) only when
-    // the visitor opens the graph view, so the page load stays light: it just
-    // hands the public site key to the chat gate. No `fetch` is provided here on
-    // purpose; the load must not call it.
-    const result = load();
+  it("exposes the public Turnstile site key and seeds the stats snapshot", async () => {
+    // The graph is still fetched lazily client-side; load only seeds the chat
+    // gate's site key plus the ticker's GPU/system snapshot from the same-origin
+    // /app/notes/stats proxy.
+    const fetch = async (url) => {
+      expect(url).toBe("/app/notes/stats");
+      return { ok: true, json: async () => ({ gpu: { utilization_pct: 42 } }) };
+    };
+    const result = await load({ fetch });
     expect(result).toHaveProperty("turnstileSiteKey");
+    expect(result.stats).toEqual({ gpu: { utilization_pct: 42 } });
+  });
+
+  it("degrades to null stats when the snapshot is unavailable", async () => {
+    // A stats hiccup must never block the chat: a non-ok response (or a throw)
+    // leaves stats null and the ticker falls back to its static readouts.
+    const fetch = async () => ({ ok: false });
+    const result = await load({ fetch });
+    expect(result).toHaveProperty("turnstileSiteKey");
+    expect(result.stats).toBeNull();
   });
 });

--- a/projects/monolith/frontend/src/routes/public/app/notes/stats/+server.js
+++ b/projects/monolith/frontend/src/routes/public/app/notes/stats/+server.js
@@ -1,0 +1,26 @@
+import { error, json } from "@sveltejs/kit";
+
+// The localhost fallback is the established convention across every public
+// proxy (ships/stars/notes/graph/body); prod sets API_BASE via values.yaml.
+// nosemgrep: sveltekit-server-hardcoded-api-base-fallback
+const API_BASE = process.env.API_BASE || "http://localhost:8000";
+
+// Same-origin proxy for the public cluster stats snapshot, the exact payload
+// the homepage renders (home/observability/stats). The notes ticker SSR-seeds
+// and then polls this for its live GPU readout, so the browser never calls the
+// backend directly (the gateway only routes to the frontend; mirrors the
+// graph/body +server.js proxies).
+//
+// The backend serves a precomputed snapshot row (no ClickHouse/K8s call per
+// request), so a short shared cache is plenty and shields it from poll storms.
+export async function GET({ fetch, setHeaders }) {
+  const res = await fetch(`${API_BASE}/api/home/observability/stats`, {
+    signal: AbortSignal.timeout(8_000),
+  });
+  if (!res.ok) {
+    throw error(503, "stats unavailable");
+  }
+
+  setHeaders({ "cache-control": "public, max-age=15" });
+  return json(await res.json());
+}


### PR DESCRIPTION
## What

Addresses three pieces of feedback on the `/app/notes` public chat ticker:

1. **Live GPU readout from existing homepage metrics.** The yellow ticker now shows real **GPU utilization** and **VRAM used / total**, read from the same precomputed cluster stats snapshot the homepage renders (`home/observability/stats`). No new backend endpoint: a same-origin `/app/notes/stats` proxy forwards to the already-public `/api/home/observability/stats`, SSR seeds the first value, and the page polls every 20s so the readout stays live. The backend stays off the internet (the gateway only routes to the frontend).
2. **Edge to edge, no shadow.** The ticker band is now full-bleed across the full viewport width via the `width: 100vw; margin-left: calc(50% - 50vw)` trick (self-corrects for the shell padding at every breakpoint, including safe-area insets), and drops its hard shadow for clean top/bottom rules.
3. **Faster scroll.** Marquee duration 42s -> 28s.

The KG note count stays the maintained public constant (not the snapshot's total-notes count, which includes private notes) so the grounding claim stays honest.

## Notes

- Fail-soft: a stats hiccup leaves the GPU items out and never blocks chat.
- `page.server.test.js` updated for the new async `load` (seeds stats, degrades to null).

🤖 Generated with [Claude Code](https://claude.com/claude-code)