### PR TITLE
fix(monolith-public): explainer popover closes on outside-click/Esc + no shadow

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.11.12
+version: 0.11.13
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.11.12
+      targetRevision: 0.11.13
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.164.0
+version: 0.164.1
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.164.0
+      targetRevision: 0.164.1
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/routes/public/app/notes/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/notes/+page.svelte
@@ -53,6 +53,29 @@
     view = "chat";
   }
 
+  // ── "how does this work?" explainer ──────────────────────────────
+  // A controlled <details> popover (bind:open). Native <details> never closes on
+  // an outside click or Esc, so while it is open we attach document listeners
+  // that close it when the visitor clicks outside the disclosure or hits Escape.
+  // The effect only runs while open, so there is no idle global listener.
+  let explainerOpen = $state(false);
+  let explainerEl = $state();
+  $effect(() => {
+    if (!explainerOpen) return;
+    const onDocClick = (e) => {
+      if (explainerEl && !explainerEl.contains(e.target)) explainerOpen = false;
+    };
+    const onKey = (e) => {
+      if (e.key === "Escape") explainerOpen = false;
+    };
+    document.addEventListener("click", onDocClick);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("click", onDocClick);
+      document.removeEventListener("keydown", onKey);
+    };
+  });
+
   // ── admission / session ──────────────────────────────────────────
   let admitted = $state(false);
 
@@ -370,7 +393,7 @@
       </button>
     </div>
 
-    <details class="explainer">
+    <details class="explainer" bind:open={explainerOpen} bind:this={explainerEl}>
       <summary class="explainer-summary">
         <span class="explainer-mark" aria-hidden="true">+</span>
         <span class="explainer-eyebrow">HOW DOES THIS WORK?</span>
@@ -811,7 +834,6 @@
     padding: 14px 16px;
     background: var(--paper);
     border: 2px solid var(--ink);
-    box-shadow: var(--shadow-hard);
   }
   .explainer-body p {
     font-size: 12px;


### PR DESCRIPTION
The `/app/notes` "HOW DOES THIS WORK?" disclosure:

- **Closes on outside-click and Escape.** It is now a controlled `<details>` (`bind:open`); while open it attaches `document` click + keydown listeners that close it when the visitor clicks outside the disclosure or hits Esc. Native `<details>` does neither. The effect only runs while open, so there is no idle global listener, and the inside-click guard means clicking the summary or selecting body text never closes it unexpectedly.
- **No shadow.** Drops the expanded popover's hard shadow to match the flattened ticker/graph chrome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)