### PR TITLE
fix(keda): server-side apply so the 647 KiB ScaledJob CRD installs

### DIFF
--- a/projects/platform/keda/application.yaml
+++ b/projects/platform/keda/application.yaml
@@ -26,6 +26,10 @@ spec:
       selfHeal: true
     syncOptions:
       - CreateNamespace=true
+      # ScaledJob CRD renders to ~647 KiB; client-side apply blows the 256 KiB
+      # last-applied-configuration annotation cap and that one CRD silently fails
+      # to install, crash-looping keda-operator. Server-side apply skips the annotation.
+      - ServerSideApply=true
     retry:
       limit: 5
       backoff:


### PR DESCRIPTION
## Problem

`keda-operator` is crash-looping: **869 restarts**, exit code 1, on:
```
controller-runtime.source.Kind: no matches for kind "ScaledJob" in version "keda.sh/v1alpha1"
setup: problem running manager: failed to wait for scaledjob caches to sync ... timed out
```
The cluster has every KEDA CRD **except `scaledjobs.keda.sh`**. With ScaledJob missing, the operator can't sync its cache and dies, so KEDA autoscaling is effectively down.

## Root cause

The ScaledJob CRD renders to **~647 KiB**. ArgoCD's default **client-side apply** stores the whole object in the `kubectl.kubernetes.io/last-applied-configuration` annotation, hard-capped at **262144 bytes (256 KiB)**. The live ArgoCD condition:
```
CustomResourceDefinition "scaledjobs.keda.sh" is invalid: metadata.annotations: Too long:
may not be more than 262144 bytes (retried 5 times).
```
Only ScaledJob exceeds the cap; its five smaller sibling CRDs (≤23 KiB) all applied fine. This is the same failure mode CLAUDE.md documents for the monolith migrations ConfigMap, here on a CRD.

## Fix

Add `ServerSideApply=true` to the keda Application's `syncOptions` (server-side apply doesn't write that annotation). This matches the existing convention, cert-manager, kyverno, opentelemetry-operator, and cnpg all already set it; keda was the lone large-CRD app that didn't.

```diff
     syncOptions:
       - CreateNamespace=true
+      - ServerSideApply=true
```

On the next sync the CRD installs cleanly (it doesn't exist yet, so no annotation conflict to strip), and the crash-looping operator recovers on its next restart. `selfHeal: true` should re-trigger automatically; a hard refresh forces it if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)