### PR TITLE
refactor(knowledge): typed gap-lifecycle exceptions (TODO A) + correct stale gap-notes comment

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.13.0
+version: 0.12.4
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.13.0
+      targetRevision: 0.12.4
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.166.4
+version: 0.167.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.167.0
+version: 0.167.1
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.167.0
+      targetRevision: 0.167.1
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.166.4
+      targetRevision: 0.167.0
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/knowledge/gap_review_endpoints_test.py
+++ b/projects/monolith/knowledge/gap_review_endpoints_test.py
@@ -18,8 +18,16 @@ from sqlmodel.pool import StaticPool
 
 from knowledge.gaps import (
     GAPS_PIPELINE_VERSION,
+    GapAnswerInvalidError,
+    GapError,
+    GapNotDeletedError,
+    GapNotFoundError,
+    GapWrongStateError,
     answer_gap,
     list_gaps_for_review,
+    reject_gap,
+    set_gap_class,
+    undelete_gap,
 )
 from knowledge.models import Gap, Note
 
@@ -663,3 +671,77 @@ class TestGapReviewQueueDictShape:
         assert r.status_code == 200
         item = r.json().get("gaps", [])[0]
         assert item["referenced_by_count"] == 2
+
+
+# ---------------------------------------------------------------------------
+# Typed gap-lifecycle errors (the class -> HTTP status contract)
+# ---------------------------------------------------------------------------
+
+
+class TestTypedGapErrors:
+    """Lock the typed-exception contract that ``_map_gap_error`` maps by class.
+
+    The gap functions raise ``GapError`` subclasses carrying a ``status_code``;
+    the router maps by class instead of matching error substrings. All subclass
+    ``ValueError`` so the MCP tools' ``except ValueError`` keeps working.
+    """
+
+    def test_all_subclass_value_error(self):
+        for cls in (
+            GapError,
+            GapNotFoundError,
+            GapWrongStateError,
+            GapNotDeletedError,
+            GapAnswerInvalidError,
+        ):
+            assert issubclass(cls, ValueError)
+
+    def test_status_codes(self):
+        assert GapError.status_code == 400
+        assert GapNotFoundError.status_code == 404
+        assert GapWrongStateError.status_code == 409
+        assert GapNotDeletedError.status_code == 409
+        assert GapAnswerInvalidError.status_code == 400
+
+    def test_unknown_gap_raises_not_found(self, session):
+        with pytest.raises(GapNotFoundError):
+            reject_gap(session, 999999)
+
+    def test_wrong_state_raises_wrong_state(self, session):
+        gap = _make_gap(session, term="Foo", state="rejected")
+        with pytest.raises(GapWrongStateError):
+            reject_gap(session, gap.id)
+
+    def test_invalid_gap_class_raises_gap_error(self, session):
+        gap = _make_gap(session, term="Bar", state="discovered", gap_class=None)
+        with pytest.raises(GapError) as exc_info:
+            set_gap_class(session, gap.id, "bogus")
+        # The base class (400), not a more specific subclass.
+        assert type(exc_info.value) is GapError
+
+    def test_undelete_live_gap_raises_not_deleted(self, session):
+        gap = _make_gap(session, term="Baz", state="in_review")
+        with pytest.raises(GapNotDeletedError):
+            undelete_gap(session, gap.id)
+
+    @pytest.mark.asyncio
+    async def test_answer_with_frontmatter_terminator_raises_answer_invalid(
+        self, session
+    ):
+        gap = _make_gap(session, term="Qux", state="in_review", gap_class="internal")
+        with pytest.raises(GapAnswerInvalidError):
+            await answer_gap(session, gap.id, "before\n---\nafter")
+
+    def test_map_gap_error_maps_each_class_to_its_status(self):
+        from knowledge.router import _map_gap_error
+
+        cases = [
+            (GapNotFoundError("x"), 404),
+            (GapWrongStateError("x"), 409),
+            (GapNotDeletedError("x"), 409),
+            (GapAnswerInvalidError("x"), 400),
+            (GapError("x"), 400),
+            (ValueError("untyped"), 400),  # non-GapError falls back to 400
+        ]
+        for exc, expected in cases:
+            assert _map_gap_error(exc).status_code == expected

--- a/projects/monolith/knowledge/gaps.py
+++ b/projects/monolith/knowledge/gaps.py
@@ -39,6 +39,47 @@ from knowledge.models import Gap, Note, NoteLink
 
 logger = logging.getLogger(__name__)
 
+
+# ---------------------------------------------------------------------------
+# Typed gap-lifecycle errors
+#
+# Each carries the HTTP ``status_code`` its router endpoint should surface, so
+# ``knowledge.router._map_gap_error`` maps by class instead of matching error
+# substrings. All subclass ``ValueError`` so existing callers that ``except
+# ValueError`` (the MCP tools return ``str(exc)``) keep working unchanged.
+# ---------------------------------------------------------------------------
+
+
+class GapError(ValueError):
+    """Base for gap-lifecycle errors. Maps to HTTP 400 unless overridden."""
+
+    status_code = 400
+
+
+class GapNotFoundError(GapError):
+    """No gap with the given id (or it is soft-deleted on a write path)."""
+
+    status_code = 404
+
+
+class GapWrongStateError(GapError):
+    """The gap is not in the state the requested transition requires."""
+
+    status_code = 409
+
+
+class GapNotDeletedError(GapError):
+    """``undelete`` was called on a gap that is not soft-deleted."""
+
+    status_code = 409
+
+
+class GapAnswerInvalidError(GapError):
+    """The supplied answer text is invalid (e.g. a frontmatter terminator)."""
+
+    status_code = 400
+
+
 GAPS_PIPELINE_VERSION = "gaps@v1"
 
 
@@ -472,7 +513,7 @@ def list_gaps_for_review(
             .limit(limit)
         )
     else:
-        raise ValueError(f"unknown review-queue mode: {mode!r}")
+        raise GapError(f"unknown review-queue mode: {mode!r}")
 
     rows = session.execute(stmt).scalars().all()
     return [_gap_to_dict(gap, session=session) for gap in rows]
@@ -493,16 +534,16 @@ def list_review_queue(session: Session) -> list[dict]:
 
 
 def _get_gap_or_raise(session: Session, gap_id: int) -> Gap:
-    """Load a Gap by id or raise ValueError. Shared by reject/verify/reopen.
+    """Load a Gap by id or raise :class:`GapNotFoundError`. Shared by
+    reject/verify/reopen.
 
-    Mirrors :func:`answer_gap`'s error contract — the router layer maps
-    ``"Gap not found"`` substrings to HTTP 404. Soft-deleted gaps
+    The router maps :class:`GapNotFoundError` to HTTP 404. Soft-deleted gaps
     (``deleted_at IS NOT NULL``) are treated as not-found so write paths
     can't mutate them; use :func:`undelete_gap` to restore first.
     """
     gap = session.get(Gap, gap_id)
     if gap is None or gap.deleted_at is not None:
-        raise ValueError(f"Gap not found: id={gap_id}")
+        raise GapNotFoundError(f"Gap not found: id={gap_id}")
     return gap
 
 
@@ -518,7 +559,7 @@ def reject_gap(session: Session, gap_id: int) -> dict:
     """
     gap = _get_gap_or_raise(session, gap_id)
     if gap.state != "in_review":
-        raise ValueError(
+        raise GapWrongStateError(
             f"Gap id={gap_id} is in state={gap.state!r}, expected 'in_review'"
         )
 
@@ -564,7 +605,7 @@ def reopen_gap(session: Session, gap_id: int) -> dict:
     """
     gap = _get_gap_or_raise(session, gap_id)
     if gap.state not in _TERMINAL_GAP_STATES:
-        raise ValueError(
+        raise GapWrongStateError(
             f"Gap id={gap_id} is in state={gap.state!r}, expected one of "
             f"{list(_TERMINAL_GAP_STATES)}"
         )
@@ -604,10 +645,10 @@ def set_gap_class(session: Session, gap_id: int, gap_class: str) -> dict:
             classified or in flight).
     """
     if gap_class not in _VALID_GAP_CLASSES:
-        raise ValueError(f"invalid gap_class: {gap_class!r}")
+        raise GapError(f"invalid gap_class: {gap_class!r}")
     gap = _get_gap_or_raise(session, gap_id)
     if gap.state != "discovered":
-        raise ValueError(
+        raise GapWrongStateError(
             f"Gap id={gap_id} is in state={gap.state!r}, expected 'discovered'"
         )
 
@@ -663,9 +704,9 @@ def _load_gap_for_answer(session: Session, gap_id: int) -> Gap:
     """
     gap = session.get(Gap, gap_id)
     if gap is None or gap.deleted_at is not None:
-        raise ValueError(f"Gap not found: id={gap_id}")
+        raise GapNotFoundError(f"Gap not found: id={gap_id}")
     if gap.state != "in_review":
-        raise ValueError(
+        raise GapWrongStateError(
             f"Gap id={gap_id} is in state={gap.state!r}, expected 'in_review'"
         )
     return gap
@@ -750,7 +791,7 @@ async def answer_gap(
     """
     gap = _load_gap_for_answer(session, gap_id)
     if "\n---\n" in f"\n{answer}\n":
-        raise ValueError(
+        raise GapAnswerInvalidError(
             "answer may not contain a frontmatter terminator ('---' on its own line)"
         )
 
@@ -797,7 +838,7 @@ def delete_gap(session: Session, gap_id: int) -> dict:
     # Bypass _get_gap_or_raise's deleted-as-404 to make delete idempotent.
     gap = session.get(Gap, gap_id)
     if gap is None:
-        raise ValueError(f"Gap not found: id={gap_id}")
+        raise GapNotFoundError(f"Gap not found: id={gap_id}")
     if gap.deleted_at is not None:
         return _gap_to_dict(gap, session=session)
 
@@ -822,9 +863,9 @@ def undelete_gap(session: Session, gap_id: int) -> dict:
     # Bypass _get_gap_or_raise's deleted-as-404 so we can find the row.
     gap = session.get(Gap, gap_id)
     if gap is None:
-        raise ValueError(f"Gap not found: id={gap_id}")
+        raise GapNotFoundError(f"Gap not found: id={gap_id}")
     if gap.deleted_at is None:
-        raise ValueError(f"Gap id={gap_id} is not deleted")
+        raise GapNotDeletedError(f"Gap id={gap_id} is not deleted")
 
     gap.deleted_at = None
     session.add(gap)

--- a/projects/monolith/knowledge/router.py
+++ b/projects/monolith/knowledge/router.py
@@ -14,7 +14,6 @@ can override it with a deterministic fake via ``app.dependency_overrides``.
 from __future__ import annotations
 
 import logging
-import re
 from email.utils import format_datetime
 from typing import Literal
 
@@ -25,6 +24,7 @@ from sqlmodel import Session, select
 
 from app.db import get_session
 from knowledge.gaps import (
+    GapError,
     answer_gap,
     delete_gap,
     list_gaps_for_review,
@@ -400,29 +400,16 @@ def get_review_queue_endpoint(
 
 
 def _map_gap_error(exc: ValueError) -> HTTPException:
-    """Map a :class:`ValueError` from a gap function to an HTTP error.
+    """Map a gap-lifecycle error to an HTTP error by exception class.
 
-    Centralises the string-prefix mapping so reject/verify/reopen/answer
-    all surface the same status codes. The post-MVP TODO on
-    ``answer_gap_endpoint`` (typed exceptions) applies here too — once
-    gaps.py raises typed errors, this helper collapses to an
-    ``isinstance`` dispatch.
+    ``knowledge.gaps`` raises typed :class:`~knowledge.gaps.GapError`
+    subclasses, each carrying the ``status_code`` its endpoint should
+    surface (404 not-found, 409 wrong-state / not-deleted, 400 otherwise).
+    A bare ``ValueError`` that is not a ``GapError`` (should not occur from
+    the gap layer) falls back to 400.
     """
-    msg = str(exc)
-    if "Gap not found" in msg:
-        return HTTPException(status_code=404, detail=msg)
-    if "is not deleted" in msg:
-        # Calling undelete on a live row is a UI bug, not "not found"
-        # — surface a distinct 409 so the frontend can react sensibly.
-        return HTTPException(status_code=409, detail=msg)
-    if re.search(
-        r"\bexpected\b", msg
-    ):  # "expected 'in_review'" / "expected one of [...]"
-        # \b word boundary so "unexpected" (substring) doesn't false-match.
-        return HTTPException(status_code=409, detail=msg)
-    if "frontmatter terminator" in msg:
-        return HTTPException(status_code=400, detail=msg)
-    return HTTPException(status_code=400, detail=msg)
+    status_code = exc.status_code if isinstance(exc, GapError) else 400
+    return HTTPException(status_code=status_code, detail=str(exc))
 
 
 @router.post("/gaps/{gap_id}/answer")
@@ -435,10 +422,6 @@ async def answer_gap_endpoint(
     try:
         return await answer_gap(session, gap_id, data.answer)
     except ValueError as exc:
-        # TODO(post-mvp): refactor gaps.py to raise typed exceptions
-        # (GapNotFoundError, GapWrongStateError, GapAnswerRejectedError) so this
-        # error mapping isn't coupled to specific string messages. The router
-        # should map by exception class, not str(exc) substring.
         raise _map_gap_error(exc) from exc
 
 

--- a/projects/monolith/knowledge/router_test.py
+++ b/projects/monolith/knowledge/router_test.py
@@ -11,6 +11,11 @@ from sqlmodel.pool import StaticPool
 from app.db import get_session
 from app.main import app
 from knowledge.frontmatter import ParsedFrontmatter
+from knowledge.gaps import (
+    GapAnswerInvalidError,
+    GapNotFoundError,
+    GapWrongStateError,
+)
 from knowledge.links import Link
 from knowledge.public_models import PublicNote, PublicNoteLink
 from knowledge.router import get_embedding_client
@@ -563,9 +568,9 @@ class TestAnswerGapEndpoint:
             assert args[2] == "my answer text"
 
     def test_gap_not_found_returns_404(self, note_client):
-        """ValueError containing 'Gap not found' maps to HTTP 404."""
+        """GapNotFoundError maps to HTTP 404."""
         with patch("knowledge.router.answer_gap") as mock_answer:
-            mock_answer.side_effect = ValueError("Gap not found: id=9999")
+            mock_answer.side_effect = GapNotFoundError("Gap not found: id=9999")
             r = note_client.post(
                 "/api/knowledge/gaps/9999/answer",
                 json={"answer": "anything"},
@@ -575,9 +580,9 @@ class TestAnswerGapEndpoint:
         assert "Gap not found" in r.json().get("detail", "")
 
     def test_wrong_state_returns_409(self, note_client):
-        """ValueError containing 'expected in_review' maps to HTTP 409."""
+        """GapWrongStateError maps to HTTP 409."""
         with patch("knowledge.router.answer_gap") as mock_answer:
-            mock_answer.side_effect = ValueError(
+            mock_answer.side_effect = GapWrongStateError(
                 "Gap 1 is in state 'discovered', expected 'in_review'"
             )
             r = note_client.post(
@@ -589,9 +594,9 @@ class TestAnswerGapEndpoint:
         assert "expected 'in_review'" in r.json().get("detail", "")
 
     def test_frontmatter_terminator_returns_400(self, note_client):
-        """ValueError containing 'frontmatter terminator' maps to HTTP 400."""
+        """GapAnswerInvalidError (frontmatter terminator) maps to HTTP 400."""
         with patch("knowledge.router.answer_gap") as mock_answer:
-            mock_answer.side_effect = ValueError(
+            mock_answer.side_effect = GapAnswerInvalidError(
                 "Answer contains a frontmatter terminator (---)"
             )
             r = note_client.post(

--- a/projects/monolith/knowledge/store.py
+++ b/projects/monolith/knowledge/store.py
@@ -466,8 +466,12 @@ class KnowledgeStore:
 
         # Orphans (no edges) carry no graph information; we filter them
         # out so the layout step doesn't waste effort and the renderer
-        # doesn't show floating dots. The 506 unlinked gap notes
-        # observed in prod are a separate data bug — see followup TODO.
+        # doesn't show floating dots. Most orphans are legacy vault-era
+        # type='gap' stub notes: the fileless discover_gaps no longer
+        # creates stub notes (gaps live in knowledge.gaps now), so the
+        # pre-migration stubs whose term is no longer wikilinked anywhere
+        # have nothing pointing at them. Filtering them here is correct;
+        # purging the vestigial stubs is tracked separately.
         connected_note_ids = set(degree_by_note_id)
         connected_note_rows = [
             row for row in note_rows if row.note_id in connected_note_ids


### PR DESCRIPTION
Resolves the two knowledge TODOs flagged in the codebase review.

## TODO A — typed gap exceptions (done)
`router.py:_map_gap_error` mapped `ValueError` to HTTP status by matching error **substrings** (`"Gap not found"`, `\bexpected\b`, etc.). This replaces that with a typed `GapError` hierarchy in `gaps.py`:

- `GapNotFoundError` (404), `GapWrongStateError` (409), `GapNotDeletedError` (409), `GapAnswerInvalidError` (400), base `GapError` (400) — each carries its `status_code`.
- `_map_gap_error` collapses to a one-line class dispatch (drops the regex + the now-unused `re` import).
- All subclass `ValueError`, so the MCP tools' `except ValueError` keep returning `str(exc)` unchanged. Messages and HTTP codes are preserved → existing endpoint tests still pass. Adds a contract test locking the class→status mapping.

## TODO B — the "506 unlinked gap notes" comment (corrected; data purge deferred)
Investigated against prod: the `type='gap'` notes are **legacy vault-era stubs**. The fileless `discover_gaps` no longer creates stub notes (gaps live in `knowledge.gaps`), so the pre-migration stubs are vestigial. The count has dropped from 506 to ~96 truly-unlinked, and `get_graph`'s orphan filter already handles them correctly. This PR corrects the stale comment. **The actual data purge is a separate decision** (it would remove ~1071 still-linked legacy stubs from the private graph) — raised with Joe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)