### PR TITLE
perf: un-throttle trips-imgproxy and argocd repo-server CPU

### DIFF
--- a/projects/platform/argocd/values-cluster.yaml
+++ b/projects/platform/argocd/values-cluster.yaml
@@ -73,12 +73,15 @@ argo-cd:
       prometheus.io/port: "8083"
   repoServer:
     replicas: 2
+    # CPU limit raised 125m -> 1000m: manifest generation (helm template /
+    # kustomize build) is CPU-bound and gates every ArgoCD sync; it was throttled
+    # ~22% with p99 ~3.7s (max 34s) over 22k GenerateManifest calls.
     resources:
       requests:
         cpu: 25m
         memory: 128Mi
       limits:
-        cpu: 125m
+        cpu: 1000m
         memory: 512Mi
     livenessProbe:
       timeoutSeconds: 5

--- a/projects/trips/chart/Chart.yaml
+++ b/projects/trips/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: trips
 description: Yukon Trip Tracker - image hosting and live updates
 type: application
-version: 1.1.0
+version: 1.1.1
 appVersion: "1.0.0"
 annotations:
   org.opencontainers.image.source: "https://github.com/jomcgi/homelab"

--- a/projects/trips/chart/values.yaml
+++ b/projects/trips/chart/values.yaml
@@ -75,13 +75,17 @@ imgproxy:
       value: "false"
     - name: IMGPROXY_ALLOW_INSECURE_URLS
       value: "true"
+  # imgproxy decodes and resizes full-size trip photos on the fly, this is
+  # CPU-bound work. The old req=limit=10m (Guaranteed, ~1% of a core, no burst)
+  # throttled every resize. Burstable with a real ceiling; memory raised so the
+  # higher throughput can decode large source images without OOM.
   resources:
     requests:
-      cpu: 10m
-      memory: 75Mi
+      cpu: 100m
+      memory: 128Mi
     limits:
-      cpu: 10m
-      memory: 75Mi
+      cpu: "2"
+      memory: 512Mi
 
 # nginx routing configuration
 nginx:


### PR DESCRIPTION
Second round of throttle right-sizing (follow-up to #2699), from cAdvisor throttle counters + SigNoz trace latency. Both are CPU-bound workloads pinned at tiny limits while the cluster runs ~90% CPU-idle.

| Workload | Change | Evidence |
|---|---|---|
| trips imgproxy | CPU `req=limit=10m` → req 100m / limit **2 cores** (Burstable); mem 75Mi → 512Mi | image resizing throttled at ~1% of a core; was Guaranteed so it couldn't even burst |
| argocd repoServer | CPU limit `125m` → **1000m** | `GenerateManifest` throttled ~22%, p99 ~3.7s, max 34s over 22k calls; gates every ArgoCD sync |

imgproxy memory raised alongside CPU because the higher resize throughput means more concurrent large-image decodes. Bumps trips chart 1.1.0 → 1.1.1 (git-`HEAD` sourced; argocd is an upstream-wrapper values change, no bump).

**Not included:** api-gateway collector (still ~88% throttled even at 500m) is slated for deprecation, so left as-is per the owner.

The `monolith search_knowledge` p95 ~13.7s latency is a separate, deeper investigation (the RAG path emits no child spans, so it needs instrumentation before optimizing), tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)