### PR TITLE
feat(kyverno): audit-only require resource requests in app namespaces

### DIFF
--- a/projects/platform/kyverno/templates/require-resources-policy.yaml
+++ b/projects/platform/kyverno/templates/require-resources-policy.yaml
@@ -1,0 +1,56 @@
+{{- if .Values.requireResources.enabled }}
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: require-resource-requests
+  annotations:
+    policies.kyverno.io/title: Require Resource Requests and Memory Limit
+    policies.kyverno.io/category: Resource Management
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/description: |
+      AUDIT-ONLY guardrail for first-party application namespaces. Every
+      container must declare CPU and memory requests and a memory limit.
+
+      A CPU LIMIT is intentionally NOT required: CPU limits cause CFS
+      throttling even on an idle node, which is the opposite of what we want.
+      The convention here is CPU requests (for fair scheduling) + memory
+      requests=limit (to bound the noisy-neighbour / OOM blast radius), with
+      CPU left burstable.
+
+      Scoped to the namespaces where we author Helm charts (see
+      requireResources.includeNamespaces), so it catches regressions in our own
+      services without touching vendor-managed operator namespaces. Audit mode:
+      violations surface as PolicyReports, nothing is rejected.
+spec:
+  background: {{ .Values.requireResources.background }}
+  validationFailureAction: Audit
+  rules:
+  - name: require-requests-and-mem-limit
+    match:
+      any:
+      - resources:
+          kinds:
+          {{- range .Values.requireResources.targetKinds }}
+          - {{ . }}
+          {{- end }}
+          namespaces:
+          {{- range .Values.requireResources.includeNamespaces }}
+          - {{ . }}
+          {{- end }}
+    validate:
+      message: >-
+        Every container must set resources.requests.cpu, resources.requests.memory
+        and resources.limits.memory (a CPU limit is intentionally not required, to
+        avoid CFS throttling).
+      pattern:
+        spec:
+          template:
+            spec:
+              containers:
+              - resources:
+                  requests:
+                    cpu: "?*"
+                    memory: "?*"
+                  limits:
+                    memory: "?*"
+{{- end }}

--- a/projects/platform/kyverno/values.yaml
+++ b/projects/platform/kyverno/values.yaml
@@ -35,6 +35,26 @@ linkerdInjection:
     # Observability (optional - can mesh these if desired)
     - signoz # SigNoz collector (avoid circular tracing)
 
+# Require resource requests + a memory limit (AUDIT-only) in first-party app
+# namespaces, so regressions in our own charts surface as PolicyReports. A CPU
+# limit is intentionally NOT required: CPU limits cause CFS throttling even on an
+# idle node. Scoped to namespaces where we author Helm charts; vendor/operator
+# namespaces are deliberately left out (they ship without resources and we don't
+# want to flag what we can't change).
+requireResources:
+  enabled: true
+  background: true # scan existing workloads too, not just new admissions
+  targetKinds:
+    - Deployment
+    - StatefulSet
+    - DaemonSet
+  includeNamespaces:
+    - monolith
+    - monolith-public
+    - trips
+    - agent-platform
+    - api-gateway
+
 kyverno:
   # Admission controller configuration
   admissionController:


### PR DESCRIPTION
Adds a Kyverno `ClusterPolicy` (**Audit** mode) requiring CPU+memory **requests** and a **memory limit** on Deployments/StatefulSets/DaemonSets in our first-party app namespaces: `monolith`, `monolith-public`, `trips`, `agent-platform`, `api-gateway`.

## Why this shape

From the coverage scan, ~30 of the 33 workloads missing requests/limits are **third-party operators** (gpu-operator, longhorn, cnpg, etc.), not our services. So the goal isn't to fix those (we can't sensibly mutate vendor pods), it's a **regression guardrail for our own charts**, catching the next "shipped with no requests" or "imgproxy pinned at 10m" before it lands.

Design choices:
- **No CPU limit required.** CPU limits cause CFS throttling even on an idle node, the exact problem the recent right-sizing PRs (#2699, #2705) undid. The convention enforced is CPU+mem requests + a mem limit, CPU left burstable.
- **Audit, not Enforce.** Surfaces violations as PolicyReports; rejects nothing (matches the cluster's existing Audit-mode Kyverno policies). `background: true` so it also scans existing workloads.
- **Scoped to our namespaces**, vendor/operator namespaces deliberately excluded.

HEAD-sourced platform app, no chart version bump. Verified the template renders via `helm template`.

Check results after sync with: `kubectl get policyreport -A` (or `clusterpolicyreport`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)