### PR TITLE
fix(seaweedfs): revert filer.s3 createBuckets (flipped cluster S3 to auth-enforced)

### DIFF
--- a/projects/platform/seaweedfs/values.yaml
+++ b/projects/platform/seaweedfs/values.yaml
@@ -122,19 +122,13 @@ seaweedfs:
       limits:
         cpu: 500m
         memory: 512Mi
-    # Declarative bucket provisioning. The chart's post-install bucket-hook Job
-    # is gated on filer.s3.* (NOT the standalone s3 component below), so the
-    # createBuckets list and its enabling flag must live here. Enabling filer.s3
-    # also runs an embedded S3 listener on the filer pod, but the canonical
-    # seaweedfs-s3 Service still selects only the standalone s3 component
-    # (its selector keys on component=s3), so clients are unaffected. Buckets
-    # live in the shared filer metadata, so monolith-trips is visible via the
-    # standalone s3 endpoint that imgproxy uses.
-    s3:
-      enabled: true
-      createBuckets:
-        - name: monolith-trips
-          anonymousRead: true
+    # NOTE: do NOT add `s3: { createBuckets: ... }` under filer here. The chart's
+    # bucket-hook runs `s3.configure --user anonymous`, which writes an identity
+    # into the shared filer metadata and flips the whole cluster S3 from
+    # auth-disabled (the open mode every service relies on with duckdb/anonymous
+    # keys) to auth-enforced, breaking chat blobs, stars grid, knowledge raws,
+    # and imgproxy with InvalidAccessKeyId. Provision buckets out-of-band via
+    # `weed shell s3.bucket.create` instead. (Incident 2026-06-19.)
 
   s3:
     enabled: true


### PR DESCRIPTION
## Incident (2026-06-19)
The trips migration added `filer.s3.createBuckets` to provision `monolith-trips`. On the post-merge ArgoCD sync, the chart's bucket-hook ran `s3.configure --user anonymous`, which wrote an identity into the shared SeaweedFS filer metadata and **flipped cluster-wide S3 from auth-disabled (open) to auth-enforced**. Every service using `duckdb`/`anonymous`/`any` keys (chat blobs, stars grid, knowledge raws, the new imgproxy) started failing with `InvalidAccessKeyId`.

## Recovery (already done, manually)
- Cleared the identity: `weed shell s3.configure -user anonymous -delete -apply`.
- Restarted the standalone `seaweedfs-s3` pod so it reloaded the now-empty identity list and reverted to open mode. Verified S3 reads work again with the keys services use.

## This change
Removes the `filer.s3` createBuckets block so a future seaweedfs sync does not re-run the hook and re-break S3. The `monolith-trips` bucket is created out-of-band via `weed shell s3.bucket.create` (already done). GitOps bucket provisioning on this cluster needs COSI or an approach that does not enable S3 auth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)