### PR TITLE
fix(seaweedfs): raise filer memory to 2Gi (OOM crash-loop took down cluster S3)

### DIFF
--- a/projects/platform/seaweedfs/values.yaml
+++ b/projects/platform/seaweedfs/values.yaml
@@ -118,10 +118,14 @@ seaweedfs:
     resources:
       requests:
         cpu: 100m
-        memory: 128Mi
+        # The filer loads the whole metadata tree into memory on cold start. At
+        # 512Mi it OOM-crash-looped (exit 137) after a restart, taking down all
+        # cluster S3 (chat blobs, stars grid, knowledge raws, imgproxy). Give it
+        # burst headroom for the cold-load spike. (Incident 2026-06-19.)
+        memory: 768Mi
       limits:
         cpu: 500m
-        memory: 512Mi
+        memory: 2Gi
     # NOTE: do NOT add `s3: { createBuckets: ... }` under filer here. The chart's
     # bucket-hook runs `s3.configure --user anonymous`, which writes an identity
     # into the shared filer metadata and flips the whole cluster S3 from


### PR DESCRIPTION
## Incident (2026-06-19, follow-up to #2709)
After the filer.s3 toggle restarts, the SeaweedFS filer began **OOM-crash-looping** (exit 137) at its 512Mi memory limit: it loads the entire metadata tree into memory on cold start, which spikes past 512Mi. With the filer down, ALL cluster S3 was unavailable (chat blobs, stars grid, knowledge raws, imgproxy, trips).

## Recovery (already done, manually)
- Disabled ArgoCD self-heal on the seaweedfs app (it was reverting the emergency bump) and `kubectl set resources statefulset/seaweedfs-filer --limits=memory=2Gi --requests=memory=768Mi`. Filer stabilized; buckets back.
- **Self-heal must be re-enabled after this merges** so live matches git.

## This change
Raises the filer memory request 128Mi -> 768Mi and limit 512Mi -> 2Gi so the cold-load spike fits. Makes the emergency bump durable (otherwise ArgoCD reverts to 512Mi and re-OOMs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)