### PR TITLE
fix(trips): clickable map markers + shared lightbox, imgproxy presets-only, cache tuning

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.14.2
+version: 0.14.3
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.14.3
+version: 0.14.4
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/chart/values.yaml
+++ b/projects/monolith-public/chart/values.yaml
@@ -414,6 +414,16 @@ imgproxy:
     # request to the monolith-trips bucket.
     - name: IMGPROXY_ALLOW_INSECURE_URLS
       value: "true"
+    # Named presets are the ONLY processing options allowed (ONLY_PRESETS below).
+    # This caps imgproxy to the exact sizes the trips frontend requests instead
+    # of serving arbitrary resizes of the bucket. The names here MUST match the
+    # PRESETS set in projects/monolith/frontend/src/lib/trips/images.js.
+    - name: IMGPROXY_PRESETS
+      value: "thumb=resize:fit:300:300/quality:85,gallery=resize:fit:600:600/quality:88,preview=resize:fit:1200:1200/quality:90,display=resize:fit:1920:1080/quality:92,full=quality:95"
+    # Reject any URL whose processing options are not one of the named presets
+    # above. Combined with ALLOWED_SOURCES this is the resize allow-list.
+    - name: IMGPROXY_ONLY_PRESETS
+      value: "true"
     - name: IMGPROXY_QUALITY
       value: "90"
     - name: IMGPROXY_FORMAT_QUALITY

--- a/projects/monolith-public/chart/values.yaml
+++ b/projects/monolith-public/chart/values.yaml
@@ -424,6 +424,11 @@ imgproxy:
     # above. Combined with ALLOWED_SOURCES this is the resize allow-list.
     - name: IMGPROXY_ONLY_PRESETS
       value: "true"
+    # Images are content-addressed (img_<sha256>.jpg), so a URL is immutable: a
+    # changed photo gets a new key. Cache for a year (this is imgproxy's current
+    # default; pin it so it survives any future default change).
+    - name: IMGPROXY_TTL
+      value: "31536000"
     - name: IMGPROXY_QUALITY
       value: "90"
     - name: IMGPROXY_FORMAT_QUALITY

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.14.2
+      targetRevision: 0.14.3
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.14.3
+      targetRevision: 0.14.4
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.170.2
+version: 0.170.3
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.170.2
+      targetRevision: 0.170.3
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/lib/cache-headers.js
+++ b/projects/monolith/frontend/src/lib/cache-headers.js
@@ -89,8 +89,11 @@ export const STARS_SITES_CACHE_CONTROL =
 export const STARS_HISTORY_CACHE_CONTROL =
   "public, max-age=0, s-maxage=31536000, stale-while-revalidate=604800, stale-if-error=604800";
 
-// /app/trips pages (the trip index + per-trip metadata and points): trip content
-// changes rarely (a backfill run at most), so a short browser TTL with a long
-// CDN TTL keeps the SSR pages snappy while a reload picks up fresh data within a
-// day. Mirrors _CACHE in projects/monolith/trips/read_router.py, keep in sync.
-export const TRIPS_CACHE_CONTROL = "public, max-age=300, s-maxage=86400";
+// /app/trips pages (the trip index + per-trip metadata and points). Trip content
+// is edited in place (title, cover, the occasional backfill), so a short CDN TTL
+// matters: a 24h edge cache made edits invisible for a day and required a manual
+// Cloudflare purge. 5 min CDN with stale-while-revalidate keeps the SSR pages
+// snappy (CDN offload) while edits propagate within minutes without a purge.
+// Mirrors _CACHE in projects/monolith/trips/read_router.py, keep in sync.
+export const TRIPS_CACHE_CONTROL =
+  "public, max-age=60, s-maxage=300, stale-while-revalidate=3600";

--- a/projects/monolith/frontend/src/lib/public/components/trips/DayMap.svelte
+++ b/projects/monolith/frontend/src/lib/public/components/trips/DayMap.svelte
@@ -9,7 +9,7 @@
   // TODO(trips): the old React DayMap drove a per-photo marker + terrain
   // hillshade lit from the sun position at the photo's timestamp. That solar /
   // bearing panel is dropped in this port; photos are shown as static markers.
-  let { points = [], photos = [], dayColor = "#2563eb" } = $props();
+  let { points = [], photos = [], dayColor = "#2563eb", onPhotoClick } = $props();
 
   const BASEMAP_STYLE = "https://tiles.openfreemap.org/styles/liberty";
 
@@ -70,11 +70,15 @@
           });
         }
 
+        // Carry each photo's index in the `photos` array so a marker click can
+        // open that exact photo in the page-level lightbox. `photos` is the same
+        // array the grid and PhotoViewer use, so the indices line up.
         const photoFeatures = photos
-          .filter((p) => p.lat != null && p.lng != null)
-          .map((p) => ({
+          .map((p, i) => ({ p, i }))
+          .filter(({ p }) => p.lat != null && p.lng != null)
+          .map(({ p, i }) => ({
             type: "Feature",
-            properties: {},
+            properties: { photoIndex: i },
             geometry: { type: "Point", coordinates: [p.lng, p.lat] },
           }));
         if (photoFeatures.length) {
@@ -92,6 +96,17 @@
               "circle-stroke-color": "#ffffff",
               "circle-stroke-width": 2,
             },
+          });
+
+          map.on("click", "day-photos", (e) => {
+            const i = e.features?.[0]?.properties?.photoIndex;
+            if (i != null) onPhotoClick?.(i);
+          });
+          map.on("mouseenter", "day-photos", () => {
+            map.getCanvas().style.cursor = "pointer";
+          });
+          map.on("mouseleave", "day-photos", () => {
+            map.getCanvas().style.cursor = "";
           });
         }
       });

--- a/projects/monolith/frontend/src/lib/public/components/trips/PhotoGrid.svelte
+++ b/projects/monolith/frontend/src/lib/public/components/trips/PhotoGrid.svelte
@@ -1,24 +1,15 @@
 <script>
   import { imgUrl } from "$lib/trips/images.js";
-  import PhotoViewer from "./PhotoViewer.svelte";
 
-  // Contact-sheet grid of a day's photos. Clicking a tile opens the lightbox.
-  // Self-contained: owns the lightbox open/index state.
-  let { photos = [], tz = "UTC" } = $props();
-
-  let open = $state(false);
-  let index = $state(0);
-
-  function show(i) {
-    index = i;
-    open = true;
-  }
+  // Contact-sheet grid of a day's photos. Clicking a tile calls onOpen(i); the
+  // lightbox itself is owned by the page so the map and grid share one viewer.
+  let { photos = [], onOpen = () => {} } = $props();
 </script>
 
 {#if photos.length}
   <div class="grid">
     {#each photos as photo, i (photo.id)}
-      <button class="tile" onclick={() => show(i)} aria-label={`Open photo ${i + 1}`}>
+      <button class="tile" onclick={() => onOpen(i)} aria-label={`Open photo ${i + 1}`}>
         <img
           src={imgUrl(photo.image, "gallery")}
           alt={`Photo ${i + 1}`}
@@ -30,16 +21,6 @@
   </div>
 {:else}
   <p class="empty">No photos for this day.</p>
-{/if}
-
-{#if open}
-  <PhotoViewer
-    {photos}
-    {index}
-    {tz}
-    onIndex={(i) => (index = i)}
-    onClose={() => (open = false)}
-  />
 {/if}
 
 <style>

--- a/projects/monolith/frontend/src/lib/trips/images.js
+++ b/projects/monolith/frontend/src/lib/trips/images.js
@@ -5,15 +5,14 @@
 // `image` value (the S3 object key for that photo).
 const IMG_BASE = "https://img.jomcgi.dev";
 
-const PRESETS = {
-  thumb: "rs:fit:300:300/q:85",
-  display: "rs:fit:1920:1080/q:92",
-  preview: "rs:fit:1200:1200/q:90",
-  gallery: "rs:fit:600:600/q:88",
+// imgproxy is locked to named presets (IMGPROXY_ONLY_PRESETS); these names must
+// match IMGPROXY_PRESETS in the monolith-public chart.
+const PRESETS = new Set(["thumb", "gallery", "preview", "display", "full"]);
+
+export const imgUrl = (key, preset = "gallery") => {
+  const p = PRESETS.has(preset) ? preset : "gallery";
+  return `${IMG_BASE}/unsafe/${p}/plain/s3://monolith-trips/${key}`;
 };
 
-export const imgUrl = (key, preset) =>
-  `${IMG_BASE}/unsafe/${PRESETS[preset]}/plain/s3://monolith-trips/${key}`;
-
 export const fullUrl = (key) =>
-  `${IMG_BASE}/unsafe/plain/s3://monolith-trips/${key}`;
+  `${IMG_BASE}/unsafe/full/plain/s3://monolith-trips/${key}`;

--- a/projects/monolith/frontend/src/lib/trips/images.test.js
+++ b/projects/monolith/frontend/src/lib/trips/images.test.js
@@ -2,26 +2,36 @@ import { describe, it, expect } from "vitest";
 import { imgUrl, fullUrl } from "./images.js";
 
 describe("trips image helpers", () => {
-  it("builds a preset-resized imgproxy URL from an object key", () => {
+  it("builds a named-preset imgproxy URL from an object key", () => {
     expect(imgUrl("img_abc.jpg", "thumb")).toBe(
-      "https://img.jomcgi.dev/unsafe/rs:fit:300:300/q:85/plain/s3://monolith-trips/img_abc.jpg",
+      "https://img.jomcgi.dev/unsafe/thumb/plain/s3://monolith-trips/img_abc.jpg",
     );
     expect(imgUrl("img_abc.jpg", "gallery")).toBe(
-      "https://img.jomcgi.dev/unsafe/rs:fit:600:600/q:88/plain/s3://monolith-trips/img_abc.jpg",
+      "https://img.jomcgi.dev/unsafe/gallery/plain/s3://monolith-trips/img_abc.jpg",
     );
   });
 
-  it("exposes all four presets", () => {
-    for (const preset of ["thumb", "display", "preview", "gallery"]) {
+  it("exposes all named presets", () => {
+    for (const preset of ["thumb", "gallery", "preview", "display", "full"]) {
       const url = imgUrl("k", preset);
-      expect(url).toContain("/unsafe/");
-      expect(url).toContain("/plain/s3://monolith-trips/k");
+      expect(url).toBe(
+        `https://img.jomcgi.dev/unsafe/${preset}/plain/s3://monolith-trips/k`,
+      );
     }
   });
 
-  it("builds a full-resolution URL with no resize preset", () => {
+  it("falls back to the gallery preset for an unknown name", () => {
+    expect(imgUrl("k", "nope")).toBe(
+      "https://img.jomcgi.dev/unsafe/gallery/plain/s3://monolith-trips/k",
+    );
+    expect(imgUrl("k")).toBe(
+      "https://img.jomcgi.dev/unsafe/gallery/plain/s3://monolith-trips/k",
+    );
+  });
+
+  it("builds a full-resolution URL via the full preset", () => {
     expect(fullUrl("img_abc.jpg")).toBe(
-      "https://img.jomcgi.dev/unsafe/plain/s3://monolith-trips/img_abc.jpg",
+      "https://img.jomcgi.dev/unsafe/full/plain/s3://monolith-trips/img_abc.jpg",
     );
   });
 });

--- a/projects/monolith/frontend/src/routes/public/app/trips/[slug]/day/[day]/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/trips/[slug]/day/[day]/+page.svelte
@@ -3,6 +3,7 @@
   import DayMap from "$lib/public/components/trips/DayMap.svelte";
   import DayStats from "$lib/public/components/trips/DayStats.svelte";
   import PhotoGrid from "$lib/public/components/trips/PhotoGrid.svelte";
+  import PhotoViewer from "$lib/public/components/trips/PhotoViewer.svelte";
   import ElevationChart from "$lib/public/components/trips/ElevationChart.svelte";
   import {
     groupByDay,
@@ -23,6 +24,17 @@
   const photos = $derived(day ? photosOf(day.points) : []);
   const label = $derived(dayLabel(trip?.days, dayNumber));
   const dayStats = $derived(day ? { ...day, photoCount: photos.length } : null);
+
+  // One lightbox shared by the map markers and the photo grid. -1 = closed.
+  // The map and grid both index into the same `photos` array, so opening photo
+  // i is unambiguous.
+  let viewerIndex = $state(-1);
+  function openPhoto(i) {
+    viewerIndex = i;
+  }
+  function closePhoto() {
+    viewerIndex = -1;
+  }
 </script>
 
 <svelte:head>
@@ -38,7 +50,7 @@
     <DayNav slug={trip.slug} {dayNumber} {totalDays} {label} dayColor={color} />
 
     <div class="map-box">
-      <DayMap points={day.points} {photos} dayColor={color} />
+      <DayMap points={day.points} {photos} dayColor={color} onPhotoClick={openPhoto} />
     </div>
 
     <DayStats stats={dayStats} dayColor={color} />
@@ -58,8 +70,18 @@
 
     <section class="photos">
       <p class="eyebrow">{photos.length} photo{photos.length === 1 ? "" : "s"}</p>
-      <PhotoGrid {photos} tz={trip?.tz} />
+      <PhotoGrid {photos} onOpen={openPhoto} />
     </section>
+  {/if}
+
+  {#if viewerIndex >= 0}
+    <PhotoViewer
+      {photos}
+      index={viewerIndex}
+      tz={trip?.tz}
+      onIndex={(i) => (viewerIndex = i)}
+      onClose={closePhoto}
+    />
   {/if}
 </div>
 

--- a/projects/monolith/frontend/src/routes/public/app/trips/[slug]/layout.server.test.js
+++ b/projects/monolith/frontend/src/routes/public/app/trips/[slug]/layout.server.test.js
@@ -47,7 +47,9 @@ describe("/public/app/trips/[slug] layout load", () => {
       expect.objectContaining({ "cache-control": TRIPS_CACHE_CONTROL }),
     );
     // Byte-for-byte mirror of _CACHE in trips/read_router.py.
-    expect(TRIPS_CACHE_CONTROL).toBe("public, max-age=300, s-maxage=86400");
+    expect(TRIPS_CACHE_CONTROL).toBe(
+      "public, max-age=60, s-maxage=300, stale-while-revalidate=3600",
+    );
   });
 
   it("throws a 404 when the trip does not exist", async () => {

--- a/projects/monolith/trips/read_router.py
+++ b/projects/monolith/trips/read_router.py
@@ -28,7 +28,7 @@ router = APIRouter(prefix="/api/trips", tags=["trips"])
 # Trip content changes rarely (a backfill run at most), so a short browser TTL
 # with a long CDN TTL keeps the SSR pages snappy while letting a reload pick up
 # fresh data within a day.
-_CACHE = "public, max-age=300, s-maxage=86400"
+_CACHE = "public, max-age=60, s-maxage=300, stale-while-revalidate=3600"
 
 
 @router.get("/trips")


### PR DESCRIPTION
Follow-up to the trips migration, fixing interactivity lost in the React->Svelte port and hardening/tuning the image layer.

## Changes
- **Map markers clickable** (the main regression): lifted the photo lightbox to the day page; both `DayMap` markers and `PhotoGrid` tiles now open the same `PhotoViewer` (with flip-through). Markers carry a `photoIndex` into the shared `photos` array.
- **imgproxy presets-only**: added `IMGPROXY_PRESETS` (thumb/gallery/preview/display/full) + `IMGPROXY_ONLY_PRESETS=true`. Combined with the existing `ALLOWED_SOURCES=s3://monolith-trips/` lock, the public surface is now exactly: 5 fixed sizes, of public trip photos, nothing else. Arbitrary `rs:fit:NNN:NNN` requests are rejected. `images.js` now builds preset-name URLs.
- **Page cache 24h -> 5min** (`TRIPS_CACHE_CONTROL`, + matching `read_router._CACHE`): trip pages are edited in place (title/cover), so a 24h edge cache made edits invisible for a day. Now ~5min with stale-while-revalidate.
- **Image cache pinned to 1 year** (`IMGPROXY_TTL=31536000`): images are content-addressed and immutable, so cache them effectively forever.
- Imageless gap/route points already filtered out of the grid (confirmed; fixes the broken "Photo 1" tile).

monolith-public chart 0.14.2 -> 0.14.4.

## ONE-TIME action after deploy (Joe)
The current trip page is still in the OLD 24h CF cache with old `rs:fit` image URLs; once `ONLY_PRESETS` is live those URLs 404. **Purge the Cloudflare cache for `jomcgi.dev/app/trips/*` once** after this deploys, that clears the stale HTML (showing the new title/cover/interactivity) and the new 5-min TTL keeps things fresh from then on. (No CF API token in-cluster, so this is a dashboard action.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)