### PR TITLE
feat(trips): scrubber day view + same-origin /img images

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.14.4
+version: 0.15.0
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/chart/templates/httproute-public.yaml
+++ b/projects/monolith-public/chart/templates/httproute-public.yaml
@@ -27,6 +27,22 @@ spec:
           port: {{ .Values.frontend.service.port | int }}
       timeouts:
         request: 60s
+    # /img/ -> imgproxy. This is a DELIBERATE, narrow exception to the otherwise
+    # frontend-only routing: imgproxy is read-only and tightly locked down
+    # (IMGPROXY_ALLOWED_SOURCES pins it to the monolith-trips bucket,
+    # IMGPROXY_ONLY_PRESETS caps it to the named resize presets), so exposing it
+    # same-origin replaces the old img.jomcgi.dev tunnel without widening the
+    # attack surface. No URLRewrite: imgproxy serves under /img via
+    # IMGPROXY_PATH_PREFIX, so the /img prefix is forwarded as-is.
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /img/
+      backendRefs:
+        - name: {{ include "monolith-public.fullname" . }}-imgproxy
+          port: {{ .Values.imgproxy.service.port | int }}
+      timeouts:
+        request: 60s
     # NO /api rule: the public backend is never internet-reachable. Every
     # backend read is server-side (SSR +page.server.js or a frontend +server.js
     # proxy, e.g. /notes/body/<id>, ships/stars heat/track), so the browser only

--- a/projects/monolith-public/chart/templates/imgproxy.yaml
+++ b/projects/monolith-public/chart/templates/imgproxy.yaml
@@ -1,15 +1,16 @@
 # imgproxy: on-the-fly image resizing/optimization for trip photos, serving
 # image BYTES (not a JSON API) from the monolith-trips SeaweedFS bucket. It is
-# reached directly by the Cloudflare tunnel at img.jomcgi.dev (cloudflared in
-# envoy-gateway-system, meshed), NOT through the envoy gateway / public
-# HTTPRoute. The Deployment and Service are rendered from the homelab-library
+# served same-origin under /img on the public hostname: the public HTTPRoute
+# (httproute-public.yaml) forwards /img/ to this Service, and imgproxy runs with
+# IMGPROXY_PATH_PREFIX=/img. The old img.jomcgi.dev Cloudflare-tunnel route is
+# retired. The Deployment and Service are rendered from the homelab-library
 # helpers (same as the web/frontend components), so it lives in the meshed
 # monolith-public namespace.
 #
 # Meshing notes: the namespace label auto-injects the Linkerd proxy. No Server
 # in linkerd-policy.yaml selects this component's port, so the cluster's
 # defaultInboundPolicy (all-unauthenticated) governs inbound and the meshed
-# cloudflared tunnel can reach it over mTLS. imgproxy's only egress is the
+# envoy gateway can reach it over mTLS. imgproxy's only egress is the
 # in-cluster seaweedfs-s3 endpoint, which is cluster-network traffic and so is
 # not blocked by the namespace EgressNetwork deny.
 #

--- a/projects/monolith-public/chart/values.yaml
+++ b/projects/monolith-public/chart/values.yaml
@@ -361,7 +361,9 @@ frontend:
 # "imgproxy" component consumed by the homelab-library deployment/service
 # helpers. On-the-fly image resizing/optimization for trip photos, fetching
 # sources from the monolith-trips SeaweedFS bucket and serving optimized image
-# bytes at img.jomcgi.dev (via the Cloudflare tunnel, not the envoy gateway).
+# bytes same-origin under /img on the public hostname (the public HTTPRoute
+# forwards /img/ here; IMGPROXY_PATH_PREFIX=/img strips the prefix internally).
+# The old img.jomcgi.dev Cloudflare-tunnel route is retired.
 # Uses an UPSTREAM public image (darthsim/imgproxy), so the tag is a plain
 # literal here and is NOT pinned by the Bazel helm_images_values pipeline (which
 # only rewrites the Bazel-built web/frontend images). The pod inherits the
@@ -395,6 +397,13 @@ imgproxy:
   env:
     - name: IMGPROXY_BIND
       value: ":8080"
+    # Serve under /img so the public HTTPRoute can forward /img/ here without a
+    # rewrite. imgproxy strips this prefix before parsing the processing path.
+    # MUST match the IMG_BASE in
+    # projects/monolith/frontend/src/lib/trips/images.js and the /img/ HTTPRoute
+    # rule in templates/httproute-public.yaml.
+    - name: IMGPROXY_PATH_PREFIX
+      value: "/img"
     - name: IMGPROXY_USE_S3
       value: "true"
     - name: IMGPROXY_S3_ENDPOINT

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.14.4
+      targetRevision: 0.15.0
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.170.3
+version: 0.171.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.170.3
+      targetRevision: 0.171.0
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/lib/public/components/trips/DayMap.svelte
+++ b/projects/monolith/frontend/src/lib/public/components/trips/DayMap.svelte
@@ -6,15 +6,27 @@
   // photo location. Interactive (pan/zoom). Follows the ShipsMap pattern
   // (lazy maplibre import, GeoJSON sources + layers).
   //
+  // `current` is the scrubber's selected photo index: the matching marker is
+  // highlighted (a larger ring on the `day-photo-current` layer) and the map
+  // eases to its coordinates. Clicking any marker calls onPhotoClick(i) so the
+  // page can set `current`.
+  //
   // TODO(trips): the old React DayMap drove a per-photo marker + terrain
   // hillshade lit from the sun position at the photo's timestamp. That solar /
   // bearing panel is dropped in this port; photos are shown as static markers.
-  let { points = [], photos = [], dayColor = "#2563eb", onPhotoClick } = $props();
+  let {
+    points = [],
+    photos = [],
+    dayColor = "#2563eb",
+    current = 0,
+    onPhotoClick,
+  } = $props();
 
   const BASEMAP_STYLE = "https://tiles.openfreemap.org/styles/liberty";
 
   let mapContainer;
   let map = null;
+  let mapReady = $state(false);
 
   function geoPoints() {
     return points.filter((p) => p.lat != null && p.lng != null);
@@ -30,6 +42,37 @@
       [Math.max(...lngs), Math.max(...lats)],
     ];
   }
+
+  // Coordinates of the photo at index `i`, or null if it has no GPS fix.
+  function photoCoords(i) {
+    const p = photos[i];
+    if (!p || p.lat == null || p.lng == null) return null;
+    return [p.lng, p.lat];
+  }
+
+  // Keep the highlight layer + camera in sync with the scrubber's `current`.
+  // Guarded on mapReady so it no-ops until the sources/layers exist.
+  $effect(() => {
+    const i = current;
+    if (!mapReady || !map) return;
+    const coords = photoCoords(i);
+    const src = map.getSource("day-photo-current");
+    if (src) {
+      src.setData({
+        type: "FeatureCollection",
+        features: coords
+          ? [
+              {
+                type: "Feature",
+                properties: { photoIndex: i },
+                geometry: { type: "Point", coordinates: coords },
+              },
+            ]
+          : [],
+      });
+    }
+    if (coords) map.easeTo({ center: coords, duration: 500 });
+  });
 
   onMount(() => {
     let destroyed = false;
@@ -71,8 +114,8 @@
         }
 
         // Carry each photo's index in the `photos` array so a marker click can
-        // open that exact photo in the page-level lightbox. `photos` is the same
-        // array the grid and PhotoViewer use, so the indices line up.
+        // set that exact photo as the scrubber's current index. `photos` is the
+        // same array the scrubber/elevation use, so the indices line up.
         const photoFeatures = photos
           .map((p, i) => ({ p, i }))
           .filter(({ p }) => p.lat != null && p.lng != null)
@@ -98,6 +141,24 @@
             },
           });
 
+          // Highlight layer for the current photo: a larger ring drawn on top of
+          // the base markers. Driven by the $effect above via its own source.
+          map.addSource("day-photo-current", {
+            type: "geojson",
+            data: { type: "FeatureCollection", features: [] },
+          });
+          map.addLayer({
+            id: "day-photo-current",
+            type: "circle",
+            source: "day-photo-current",
+            paint: {
+              "circle-radius": 9,
+              "circle-color": dayColor,
+              "circle-stroke-color": "#ffffff",
+              "circle-stroke-width": 3,
+            },
+          });
+
           map.on("click", "day-photos", (e) => {
             const i = e.features?.[0]?.properties?.photoIndex;
             if (i != null) onPhotoClick?.(i);
@@ -109,11 +170,16 @@
             map.getCanvas().style.cursor = "";
           });
         }
+
+        // Signal the $effect that sources/layers exist; it then renders the
+        // initial highlight + centers on the current photo.
+        mapReady = true;
       });
 
       cleanup = () => {
         map?.remove();
         map = null;
+        mapReady = false;
       };
     })();
 

--- a/projects/monolith/frontend/src/lib/public/components/trips/ElevationChart.svelte
+++ b/projects/monolith/frontend/src/lib/public/components/trips/ElevationChart.svelte
@@ -1,12 +1,19 @@
 <script>
   // Filled-area elevation sparkline. `series` is an already-sampled array of
   // elevations (see lib/trips/trip.js elevationSeries). Pure SVG, no deps.
+  // `cursor` (optional) is a 0..1 fraction along the route; when set, a vertical
+  // line is drawn at that x position to track the scrubber's current photo.
+  // `cursorColor` lets the page tint it to the day colour. The viewBox uses
+  // preserveAspectRatio="none" (the area path is x-stretched), so the cursor is
+  // a vertical line only: a circle would render as a distorted ellipse.
   let {
     series = [],
     height = 28,
     min = null,
     max = null,
     color = "var(--ink)",
+    cursor = null,
+    cursorColor = "var(--ink)",
   } = $props();
 
   const lo = $derived(min ?? (series.length ? Math.min(...series) : 0));
@@ -24,6 +31,11 @@
     d += `L 100 ${height} Z`;
     return d;
   });
+
+  // Clamp the cursor fraction to [0,1] and map to an x in 0..100 viewBox units.
+  const cursorX = $derived(
+    cursor == null ? null : Math.max(0, Math.min(1, cursor)) * 100,
+  );
 </script>
 
 {#if path}
@@ -34,5 +46,16 @@
     aria-hidden="true"
   >
     <path d={path} fill={color} fill-opacity="0.85" />
+    {#if cursorX != null}
+      <line
+        x1={cursorX}
+        y1="0"
+        x2={cursorX}
+        y2={height}
+        stroke={cursorColor}
+        stroke-width="1.5"
+        vector-effect="non-scaling-stroke"
+      />
+    {/if}
   </svg>
 {/if}

--- a/projects/monolith/frontend/src/lib/public/components/trips/PhotoViewer.svelte
+++ b/projects/monolith/frontend/src/lib/public/components/trips/PhotoViewer.svelte
@@ -1,6 +1,6 @@
 <script>
   import { onMount } from "svelte";
-  import { fullUrl } from "$lib/trips/images.js";
+  import { imgUrl } from "$lib/trips/images.js";
 
   // Fullscreen lightbox for a list of photo points. Controlled: the parent owns
   // `index` and reacts to onIndex / onClose. Keyboard: left/right navigate,
@@ -54,7 +54,7 @@
     {/if}
 
     <figure class="frame">
-      <img src={fullUrl(photo.image)} alt={`Photo ${index + 1} of ${photos.length}`} />
+      <img src={imgUrl(photo.image, "display")} alt={`Photo ${index + 1} of ${photos.length}`} />
       <figcaption>
         <span class="count">{index + 1} / {photos.length}</span>
         {#if photo.taken_at}<span>{fmtTime(photo.taken_at)}</span>{/if}

--- a/projects/monolith/frontend/src/lib/trips/images.js
+++ b/projects/monolith/frontend/src/lib/trips/images.js
@@ -1,9 +1,11 @@
 // imgproxy URL helpers for the /app/trips pages. Originals live in the
-// monolith-trips SeaweedFS bucket; imgproxy resizes them on the fly and serves
-// from img.jomcgi.dev (absolute, cross-origin <img>, no CORS needed). The
-// presets mirror the sizes the old trips frontend used. `key` is the TripPoint
-// `image` value (the S3 object key for that photo).
-const IMG_BASE = "https://img.jomcgi.dev";
+// monolith-trips SeaweedFS bucket; imgproxy resizes them on the fly. It is now
+// served same-origin under /img by the monolith-public HTTPRoute (imgproxy runs
+// with IMGPROXY_PATH_PREFIX=/img), so these are relative URLs (no cross-origin,
+// no CORS, no separate img.jomcgi.dev tunnel). The presets mirror the sizes the
+// old trips frontend used. `key` is the TripPoint `image` value (the S3 object
+// key for that photo).
+const IMG_BASE = "/img";
 
 // imgproxy is locked to named presets (IMGPROXY_ONLY_PRESETS); these names must
 // match IMGPROXY_PRESETS in the monolith-public chart.

--- a/projects/monolith/frontend/src/lib/trips/images.test.js
+++ b/projects/monolith/frontend/src/lib/trips/images.test.js
@@ -2,36 +2,32 @@ import { describe, it, expect } from "vitest";
 import { imgUrl, fullUrl } from "./images.js";
 
 describe("trips image helpers", () => {
-  it("builds a named-preset imgproxy URL from an object key", () => {
+  it("builds a same-origin named-preset imgproxy URL from an object key", () => {
     expect(imgUrl("img_abc.jpg", "thumb")).toBe(
-      "https://img.jomcgi.dev/unsafe/thumb/plain/s3://monolith-trips/img_abc.jpg",
+      "/img/unsafe/thumb/plain/s3://monolith-trips/img_abc.jpg",
     );
     expect(imgUrl("img_abc.jpg", "gallery")).toBe(
-      "https://img.jomcgi.dev/unsafe/gallery/plain/s3://monolith-trips/img_abc.jpg",
+      "/img/unsafe/gallery/plain/s3://monolith-trips/img_abc.jpg",
     );
   });
 
   it("exposes all named presets", () => {
     for (const preset of ["thumb", "gallery", "preview", "display", "full"]) {
       const url = imgUrl("k", preset);
-      expect(url).toBe(
-        `https://img.jomcgi.dev/unsafe/${preset}/plain/s3://monolith-trips/k`,
-      );
+      expect(url).toBe(`/img/unsafe/${preset}/plain/s3://monolith-trips/k`);
     }
   });
 
   it("falls back to the gallery preset for an unknown name", () => {
     expect(imgUrl("k", "nope")).toBe(
-      "https://img.jomcgi.dev/unsafe/gallery/plain/s3://monolith-trips/k",
+      "/img/unsafe/gallery/plain/s3://monolith-trips/k",
     );
-    expect(imgUrl("k")).toBe(
-      "https://img.jomcgi.dev/unsafe/gallery/plain/s3://monolith-trips/k",
-    );
+    expect(imgUrl("k")).toBe("/img/unsafe/gallery/plain/s3://monolith-trips/k");
   });
 
   it("builds a full-resolution URL via the full preset", () => {
     expect(fullUrl("img_abc.jpg")).toBe(
-      "https://img.jomcgi.dev/unsafe/full/plain/s3://monolith-trips/img_abc.jpg",
+      "/img/unsafe/full/plain/s3://monolith-trips/img_abc.jpg",
     );
   });
 });

--- a/projects/monolith/frontend/src/lib/trips/trip.js
+++ b/projects/monolith/frontend/src/lib/trips/trip.js
@@ -160,6 +160,14 @@ export function dayPhotos(dayPoints) {
   return (dayPoints || []).filter((p) => p.image);
 }
 
+// Clamp a scrubber index into [0, count-1] (returns 0 when there are no items).
+// Pure so the day-page scrubber's prev/next + keyboard stepping is unit-testable
+// without a Svelte render harness.
+export function clampIndex(i, count) {
+  if (!count || count < 1) return 0;
+  return Math.max(0, Math.min(count - 1, i));
+}
+
 // Sampled elevation series for a sparkline (caps point count).
 export function elevationSeries(points, maxPoints = 60) {
   const elevs = (points || []).map((p) => p.elevation).filter((e) => e != null);

--- a/projects/monolith/frontend/src/lib/trips/trip.test.js
+++ b/projects/monolith/frontend/src/lib/trips/trip.test.js
@@ -6,6 +6,7 @@ import {
   dayLabel,
   dayPhotos,
   routeDistanceKm,
+  clampIndex,
 } from "./trip.js";
 
 // Two days in America/Vancouver (UTC-8 in winter): the 23:30 local point of
@@ -81,5 +82,23 @@ describe("dayLabel + dayPhotos", () => {
   });
   it("dayPhotos keeps only image-bearing points", () => {
     expect(dayPhotos(POINTS).map((p) => p.id)).toEqual(["a", "c"]);
+  });
+});
+
+describe("clampIndex (scrubber stepping)", () => {
+  it("advances and steps back within range", () => {
+    // Mirrors the day-page step(): current + delta, clamped to the photo count.
+    expect(clampIndex(0 + 1, 3)).toBe(1);
+    expect(clampIndex(1 + 1, 3)).toBe(2);
+    expect(clampIndex(2 - 1, 3)).toBe(1);
+  });
+  it("clamps at both ends instead of wrapping", () => {
+    expect(clampIndex(-1, 3)).toBe(0);
+    expect(clampIndex(2 + 1, 3)).toBe(2);
+    expect(clampIndex(99, 3)).toBe(2);
+  });
+  it("returns 0 when there are no photos", () => {
+    expect(clampIndex(0, 0)).toBe(0);
+    expect(clampIndex(5, 0)).toBe(0);
   });
 });

--- a/projects/monolith/frontend/src/routes/public/app/trips/[slug]/day/[day]/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/trips/[slug]/day/[day]/+page.svelte
@@ -2,15 +2,15 @@
   import DayNav from "$lib/public/components/trips/DayNav.svelte";
   import DayMap from "$lib/public/components/trips/DayMap.svelte";
   import DayStats from "$lib/public/components/trips/DayStats.svelte";
-  import PhotoGrid from "$lib/public/components/trips/PhotoGrid.svelte";
-  import PhotoViewer from "$lib/public/components/trips/PhotoViewer.svelte";
   import ElevationChart from "$lib/public/components/trips/ElevationChart.svelte";
+  import { imgUrl } from "$lib/trips/images.js";
   import {
     groupByDay,
     dayColor,
     dayLabel,
     dayPhotos as photosOf,
     elevationSeries,
+    clampIndex,
   } from "$lib/trips/trip.js";
 
   let { data } = $props();
@@ -24,17 +24,70 @@
   const photos = $derived(day ? photosOf(day.points) : []);
   const label = $derived(dayLabel(trip?.days, dayNumber));
   const dayStats = $derived(day ? { ...day, photoCount: photos.length } : null);
+  const series = $derived(day ? elevationSeries(day.points, 120) : []);
 
-  // One lightbox shared by the map markers and the photo grid. -1 = closed.
-  // The map and grid both index into the same `photos` array, so opening photo
-  // i is unambiguous.
-  let viewerIndex = $state(-1);
-  function openPhoto(i) {
-    viewerIndex = i;
+  // Scrubber state: the index of the "current" photo. The map highlights and
+  // centers this photo, the elevation cursor tracks its route position, and the
+  // right-hand panel shows it at display size. Clamped to the photo count.
+  let current = $state(0);
+
+  // Reset to the first photo whenever the day changes (SvelteKit reuses this
+  // component across [day] navigations, so $state(0) alone would persist a stale
+  // index). Also keeps `current` in range if the photo list shrinks.
+  $effect(() => {
+    const _ = dayNumber;
+    current = 0;
+  });
+  $effect(() => {
+    if (current > photos.length - 1) current = clampIndex(current, photos.length);
+  });
+
+  const photo = $derived(photos[current] ?? null);
+
+  function step(delta) {
+    if (!photos.length) return;
+    current = clampIndex(current + delta, photos.length);
   }
-  function closePhoto() {
-    viewerIndex = -1;
+
+  // Cursor fraction (0..1) along the elevation x-axis. The elevation chart is
+  // sampled over every point in the day; map the current photo to its position
+  // in that point sequence so the cursor tracks where the photo sits along the
+  // route. Approximate (photo points are a subset of all points) but tracking.
+  const cursorFraction = $derived.by(() => {
+    if (!photo || !day || day.points.length < 2) return null;
+    const idx = day.points.indexOf(photo);
+    if (idx < 0) return null;
+    return idx / (day.points.length - 1);
+  });
+
+  function fmtTime(iso) {
+    if (!iso) return "";
+    try {
+      return new Date(iso).toLocaleString("en-CA", {
+        timeZone: trip?.tz || "UTC",
+        month: "short",
+        day: "numeric",
+        hour: "2-digit",
+        minute: "2-digit",
+      });
+    } catch {
+      return "";
+    }
   }
+
+  // Arrow keys step through photos. No scroll-jacking: keyboard + buttons only.
+  $effect(() => {
+    const onKey = (e) => {
+      if (!photos.length) return;
+      if (e.key === "ArrowLeft") {
+        step(-1);
+      } else if (e.key === "ArrowRight") {
+        step(1);
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  });
 </script>
 
 <svelte:head>
@@ -49,55 +102,163 @@
   {:else}
     <DayNav slug={trip.slug} {dayNumber} {totalDays} {label} dayColor={color} />
 
-    <div class="map-box">
-      <DayMap points={day.points} {photos} dayColor={color} onPhotoClick={openPhoto} />
-    </div>
+    <div class="scrubber">
+      <section class="map-box" aria-label="Day route map">
+        <DayMap
+          points={day.points}
+          {photos}
+          dayColor={color}
+          {current}
+          onPhotoClick={(i) => (current = i)}
+        />
+      </section>
 
-    <DayStats stats={dayStats} dayColor={color} />
+      <section class="stats-box">
+        <p class="eyebrow">Day stats</p>
+        <DayStats stats={dayStats} dayColor={color} />
+      </section>
+
+      <section class="photo-box" style={`--day:${color}`}>
+        <p class="eyebrow">
+          Photo {photos.length ? current + 1 : 0} / {photos.length}
+        </p>
+        {#if photo}
+          <figure class="frame">
+            <img
+              src={imgUrl(photo.image, "display")}
+              alt={`Photo ${current + 1} of ${photos.length}`}
+              decoding="async"
+            />
+            <figcaption>
+              {#if photo.taken_at}<span>{fmtTime(photo.taken_at)}</span>{/if}
+              {#if photo.focal_length_35mm}<span>{photo.focal_length_35mm}mm</span>{/if}
+              {#if photo.aperture}<span>&fnof;/{photo.aperture}</span>{/if}
+              {#if photo.iso}<span>ISO {photo.iso}</span>{/if}
+              {#if photo.shutter_speed}<span>{photo.shutter_speed}</span>{/if}
+              {#if photo.elevation != null}<span>{Math.round(photo.elevation)}m</span>{/if}
+            </figcaption>
+          </figure>
+          <div class="controls">
+            <button
+              class="step"
+              onclick={() => step(-1)}
+              disabled={current === 0}
+              aria-label="Previous photo"
+            >
+              &larr; Prev
+            </button>
+            <button
+              class="step"
+              onclick={() => step(1)}
+              disabled={current >= photos.length - 1}
+              aria-label="Next photo"
+            >
+              Next &rarr;
+            </button>
+          </div>
+        {:else}
+          <p class="empty">No photos for this day.</p>
+        {/if}
+      </section>
+    </div>
 
     {#if dayStats.hasElevation}
       <section class="profile">
         <p class="eyebrow">Elevation profile</p>
         <div class="chart">
           <ElevationChart
-            series={elevationSeries(day.points, 120)}
+            {series}
             height={90}
             {color}
+            cursor={cursorFraction}
+            cursorColor={color}
           />
         </div>
       </section>
     {/if}
-
-    <section class="photos">
-      <p class="eyebrow">{photos.length} photo{photos.length === 1 ? "" : "s"}</p>
-      <PhotoGrid {photos} onOpen={openPhoto} />
-    </section>
-  {/if}
-
-  {#if viewerIndex >= 0}
-    <PhotoViewer
-      {photos}
-      index={viewerIndex}
-      tz={trip?.tz}
-      onIndex={(i) => (viewerIndex = i)}
-      onClose={closePhoto}
-    />
   {/if}
 </div>
 
 <style>
   .page {
-    max-width: 1100px;
+    max-width: 1280px;
     margin: 0 auto;
     padding: 24px 24px 64px;
     background: var(--cream);
     color: var(--ink);
     min-height: 100vh;
   }
+  .scrubber {
+    display: grid;
+    grid-template-columns: 1.1fr 0.9fr 1.3fr;
+    grid-template-areas: "map stats photo";
+    gap: 20px;
+    align-items: start;
+  }
   .map-box {
+    grid-area: map;
     border: 2px solid var(--ink);
-    height: 280px;
-    margin-bottom: 24px;
+    height: 420px;
+  }
+  .stats-box {
+    grid-area: stats;
+  }
+  .photo-box {
+    grid-area: photo;
+  }
+  .frame {
+    margin: 0;
+    border: 2px solid var(--ink);
+    background: var(--ink);
+    display: flex;
+    flex-direction: column;
+  }
+  .frame img {
+    width: 100%;
+    max-height: 460px;
+    object-fit: contain;
+    display: block;
+    background: var(--ink);
+  }
+  figcaption {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px 16px;
+    padding: 10px 12px;
+    font-family: var(--mono);
+    font-size: 11px;
+    letter-spacing: 0.04em;
+    color: var(--paper);
+    border-top: 2px solid var(--day);
+  }
+  .controls {
+    display: flex;
+    gap: 0;
+    margin-top: 12px;
+  }
+  .step {
+    flex: 1;
+    font-family: var(--mono);
+    font-size: 12px;
+    font-weight: 700;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--ink);
+    border: 2px solid var(--ink);
+    background: var(--paper);
+    padding: 10px 14px;
+    cursor: pointer;
+  }
+  .step + .step {
+    border-left: none;
+  }
+  .step:hover:not(:disabled) {
+    background: var(--ink);
+    color: var(--paper);
+  }
+  .step:disabled {
+    opacity: 0.35;
+    cursor: default;
   }
   .profile {
     margin-top: 28px;
@@ -106,9 +267,6 @@
     border: 2px solid var(--ink);
     background: var(--paper);
     padding: 12px 14px;
-  }
-  .photos {
-    margin-top: 28px;
   }
   .eyebrow {
     font-family: var(--mono);
@@ -119,11 +277,29 @@
     color: var(--ink-3);
     margin: 0 0 12px;
   }
+  .empty {
+    font-family: var(--mono);
+    font-size: 12px;
+    color: var(--ink-3);
+  }
   .missing {
     font-family: var(--mono);
     color: var(--ink-3);
   }
   .missing a {
     color: var(--ink);
+  }
+  /* Narrow screens: stack map, photo, stats (in that order), then elevation. */
+  @media (max-width: 900px) {
+    .scrubber {
+      grid-template-columns: 1fr;
+      grid-template-areas:
+        "map"
+        "photo"
+        "stats";
+    }
+    .map-box {
+      height: 300px;
+    }
   }
 </style>

--- a/projects/platform/cloudflare-gateway/values-prod.yaml
+++ b/projects/platform/cloudflare-gateway/values-prod.yaml
@@ -31,11 +31,6 @@ tunnel:
       # private.jomcgi.dev/app/<app> via the cloudflare-ingress gateway
       # (HTTPRoutes in each chart). Their old subdomains fall through to
       # catchAll, which has no matching gateway route, so they stop resolving.
-      # Trip images: imgproxy resizes/optimizes photos from the monolith-trips
-      # SeaweedFS bucket on the fly. Lives in the monolith-public chart (meshed
-      # public tier); the tunnel reaches it directly, not via the envoy gateway.
-      - hostname: img.jomcgi.dev
-        service: http://monolith-public-imgproxy.monolith-public.svc.cluster.local:8080
       - hostname: grimoire.jomcgi.dev
         service: http://grimoire-frontend.grimoire.svc.cluster.local:8080
       - hostname: api.jomcgi.dev


### PR DESCRIPTION
Rebuilds the trips day view to match the original UX and fixes the image-serving layer.

## Day view = interactive scrubber
Replaces the thumbnail grid + lightbox with: **map left / stats middle / current photo right**, elevation strip below. Step through the day's photos with **Left/Right arrows + prev/next buttons**; the map marker highlights + centers on the current photo and the elevation cursor tracks its position. Clicking a map marker jumps to that photo. Responsive (stacks on narrow screens).

## Image fixes
- On-screen photos use the **`display` preset (~400KB)**, never `full` (6.5MB) - fixes the slow/blank lightbox.
- Images now served **same-origin at `jomcgi.dev/img/`** (HTTPRoute /img/ -> imgproxy + `IMGPROXY_PATH_PREFIX=/img`); the `img.jomcgi.dev` subdomain is retired.

monolith-public chart 0.14.4 -> 0.15.0.

Note: signed image URLs are a follow-up PR (server-side signing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)