### PR TITLE
fix(trips): imgproxy probes at /img/health (PATH_PREFIX crash-loop)

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.15.0
+version: 0.15.1
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/chart/values.yaml
+++ b/projects/monolith-public/chart/values.yaml
@@ -383,14 +383,18 @@ imgproxy:
   # selects this port, so the meshed cloudflared tunnel reaches it.
   podAnnotations:
     linkerd.io/inject: enabled
-  # imgproxy serves /health (the library probe default), so no path override.
+  # IMGPROXY_PATH_PREFIX=/img moves EVERY route (including the health endpoint)
+  # under /img, so the probes must hit /img/health, not the library default
+  # /health (which now 404s and would crash-loop the pod on liveness failure).
   probes:
     liveness:
+      path: /img/health
       initialDelaySeconds: 5
       periodSeconds: 10
       timeoutSeconds: 5
       failureThreshold: 6
     readiness:
+      path: /img/health
       initialDelaySeconds: 3
       periodSeconds: 5
       timeoutSeconds: 3

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.15.0
+      targetRevision: 0.15.1
       helm:
         releaseName: monolith-public
         valueFiles:


### PR DESCRIPTION
IMGPROXY_PATH_PREFIX=/img (added for same-origin /img serving) moves every imgproxy route, including /health, under /img. The k8s probes still hit /health -> 404 -> liveness kills the pod -> CrashLoopBackOff, so the new imgproxy never becomes ready and /img/ 404s. Point liveness+readiness at /img/health. monolith-public 0.15.0 -> 0.15.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)