### PR TITLE
feat(trips): sign imgproxy URLs server-side (retire unsigned /unsafe)

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.15.1
+version: 0.16.0
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/chart/templates/imgproxy.yaml
+++ b/projects/monolith-public/chart/templates/imgproxy.yaml
@@ -14,9 +14,10 @@
 # in-cluster seaweedfs-s3 endpoint, which is cluster-network traffic and so is
 # not blocked by the namespace EgressNetwork deny.
 #
-# Security boundary: IMGPROXY_ALLOWED_SOURCES locks every request to
-# s3://monolith-trips/, which is what makes IMGPROXY_ALLOW_INSECURE_URLS (unsigned
-# URLs) safe. Per the resource-sizing convention this sets a CPU request but NO
+# Security boundary: URLs are HMAC-signed (IMGPROXY_KEY/SALT synced from
+# 1Password), so imgproxy only serves paths the frontend SSR signer produced;
+# IMGPROXY_ALLOWED_SOURCES additionally locks every request to s3://monolith-trips/
+# as defense in depth. Per the resource-sizing convention this sets a CPU request but NO
 # CPU limit (image decode is bursty CPU-bound work; a limit only throttles it)
 # and pins memory request == limit.
 {{- include "homelab.deployment" (dict "context" . "component" "imgproxy") }}

--- a/projects/monolith-public/chart/templates/onepassworditem-trips-imgproxy-signing.yaml
+++ b/projects/monolith-public/chart/templates/onepassworditem-trips-imgproxy-signing.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.imgproxySigning.onepassword.itemPath }}
+# Syncs the trips imgproxy URL-signing item (k8s-homelab/trips-imgproxy-signing)
+# into an Opaque Secret. The 1Password operator maps each field label to a Secret
+# data key verbatim, so the fields IMGPROXY_KEY / IMGPROXY_SALT surface as Secret
+# keys of the same names. BOTH the imgproxy component (to verify request
+# signatures) and the frontend SSR component (to sign /img URLs server-side)
+# reference these via secretKeyRef; the secret never reaches the browser. The
+# synced Secret name equals metadata.name (.Values.imgproxySigning.secretName).
+apiVersion: onepassword.com/v1
+kind: OnePasswordItem
+metadata:
+  name: {{ .Values.imgproxySigning.secretName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "monolith-public.labels" . | nindent 4 }}
+spec:
+  itemPath: {{ .Values.imgproxySigning.onepassword.itemPath | quote }}
+{{- end }}

--- a/projects/monolith-public/chart/values.yaml
+++ b/projects/monolith-public/chart/values.yaml
@@ -153,6 +153,23 @@ turnstile:
   onepassword:
     itemPath: ""
 
+# imgproxy URL signing (trip images). imgproxy validates an HMAC-SHA256 signature
+# on every /img request; only URLs the SSR signer (frontend
+# lib/server/trips-img.js) produces are accepted, so the unsigned /unsafe/ path is
+# retired. The KEY and SALT are hex-encoded random bytes synced from the
+# trips-imgproxy-signing 1Password item into an Opaque Secret (keys IMGPROXY_KEY /
+# IMGPROXY_SALT, mapped from the field labels). BOTH the imgproxy component (to
+# verify) and the frontend SSR component (to sign) reference this Secret via
+# secretKeyRef; the secret MUST NEVER be handed to the browser. onepassword.itemPath
+# is set in deploy/values.yaml and left empty here so a bare `helm template` does
+# not emit a OnePasswordItem with a null path.
+imgproxySigning:
+  # Name of the Opaque Secret the OnePasswordItem syncs the signing fields into.
+  # Backend (imgproxy) and frontend secretKeyRefs reference this name.
+  secretName: monolith-public-imgproxy-signing
+  onepassword:
+    itemPath: ""
+
 # "web" component consumed by the homelab-library deployment/service helpers.
 web:
   enabled: true
@@ -293,7 +310,9 @@ web:
 # "frontend" component (ADR 004 Phase 5d): the public-only SvelteKit SSR
 # renderer, built from the private-route-free source tree. It is a separate
 # meshed pod that server-renders the public pages and calls the backend "web"
-# component over in-cluster mTLS via API_BASE. It carries no secrets.
+# component over in-cluster mTLS via API_BASE. Its only secret is the imgproxy
+# URL signing key (IMGPROXY_KEY/SALT below): the SSR signer pre-signs /img URLs
+# server-side so the secret never reaches the browser.
 frontend:
   enabled: true
   replicas: 1
@@ -319,10 +338,13 @@ frontend:
       tcpSocket: true
       initialDelaySeconds: 3
       periodSeconds: 5
-  # No secrets. API_BASE points at the backend "web" Service (in-cluster).
+  # API_BASE points at the backend "web" Service (in-cluster).
   # OTEL_COLLECTOR_HTTP_URL lets the same-origin /otel proxy forward browser
   # traces to the in-cluster SigNoz collector (cross-namespace, in-cluster, so
-  # the EgressNetwork off-cluster deny does not apply).
+  # the EgressNetwork off-cluster deny does not apply). IMGPROXY_KEY/SALT are the
+  # only secrets: the SSR signer (lib/server/trips-img.js) reads them via
+  # $env/dynamic/private to sign /img URLs server-side and they never reach the
+  # browser ($lib/server is never client-bundled).
   env:
     - name: API_BASE
       value: "http://monolith-public-web:8000"
@@ -339,6 +361,21 @@ frontend:
       value: "0x4AAAAAADm59tvOGWo09IYc"
     - name: OTEL_COLLECTOR_HTTP_URL
       value: "http://signoz-k8s-infra-otel-agent.signoz.svc.cluster.local:4318"
+    # imgproxy URL signing secret (hex-encoded KEY/SALT), synced from 1Password
+    # via the imgproxy-signing OnePasswordItem. The SSR signer computes the same
+    # HMAC the imgproxy component validates. secretKeyRef name must equal
+    # imgproxySigning.secretName above (values.yaml is not re-templated, so this
+    # is a literal, like DATABASE_URL / the Turnstile refs).
+    - name: IMGPROXY_KEY
+      valueFrom:
+        secretKeyRef:
+          name: monolith-public-imgproxy-signing
+          key: IMGPROXY_KEY
+    - name: IMGPROXY_SALT
+      valueFrom:
+        secretKeyRef:
+          name: monolith-public-imgproxy-signing
+          key: IMGPROXY_SALT
   # SSR Node needs more headroom than the read-only backend. CPU request sized
   # for a meaningful HPA signal (Node SSR is CPU-bound under concurrent renders).
   # Memory request keeps headroom above the ~37Mi idle baseline for load spikes.
@@ -363,7 +400,8 @@ frontend:
 # sources from the monolith-trips SeaweedFS bucket and serving optimized image
 # bytes same-origin under /img on the public hostname (the public HTTPRoute
 # forwards /img/ here; IMGPROXY_PATH_PREFIX=/img strips the prefix internally).
-# The old img.jomcgi.dev Cloudflare-tunnel route is retired.
+# The old img.jomcgi.dev Cloudflare-tunnel route is retired. URLs are HMAC-signed
+# (IMGPROXY_KEY/SALT): only paths the frontend SSR signer produces are served.
 # Uses an UPSTREAM public image (darthsim/imgproxy), so the tag is a plain
 # literal here and is NOT pinned by the Bazel helm_images_values pipeline (which
 # only rewrites the Bazel-built web/frontend images). The pod inherits the
@@ -404,8 +442,8 @@ imgproxy:
     # Serve under /img so the public HTTPRoute can forward /img/ here without a
     # rewrite. imgproxy strips this prefix before parsing the processing path.
     # MUST match the IMG_BASE in
-    # projects/monolith/frontend/src/lib/trips/images.js and the /img/ HTTPRoute
-    # rule in templates/httproute-public.yaml.
+    # projects/monolith/frontend/src/lib/server/trips-img.js and the /img/
+    # HTTPRoute rule in templates/httproute-public.yaml.
     - name: IMGPROXY_PATH_PREFIX
       value: "/img"
     - name: IMGPROXY_USE_S3
@@ -418,15 +456,28 @@ imgproxy:
       value: "anonymous"
     - name: AWS_SECRET_ACCESS_KEY
       value: "anonymous"
-    # Lock imgproxy to the trips bucket. This is the security boundary that lets
-    # the unsigned-URL mode below be safe: imgproxy will only fetch sources under
-    # s3://monolith-trips/, never other buckets or arbitrary URLs.
+    # Lock imgproxy to the trips bucket: it will only fetch sources under
+    # s3://monolith-trips/, never other buckets or arbitrary URLs. Defense in
+    # depth alongside URL signing (IMGPROXY_KEY/SALT below) and the preset
+    # allow-list.
     - name: IMGPROXY_ALLOWED_SOURCES
       value: "s3://monolith-trips/"
-    # Unsafe (unsigned) URL mode. Safe here because ALLOWED_SOURCES locks every
-    # request to the monolith-trips bucket.
-    - name: IMGPROXY_ALLOW_INSECURE_URLS
-      value: "true"
+    # Signed-URL mode. With IMGPROXY_KEY/SALT set, imgproxy REQUIRES a valid
+    # HMAC-SHA256 signature on every request (the unsigned /unsafe/ path is
+    # rejected), so only URLs the SSR signer (frontend lib/server/trips-img.js)
+    # produces are served. The KEY and SALT are hex-encoded secrets synced from
+    # the trips-imgproxy-signing 1Password item; sourced via secretKeyRef, never
+    # as a plaintext values literal, and the same secret the frontend signs with.
+    - name: IMGPROXY_KEY
+      valueFrom:
+        secretKeyRef:
+          name: monolith-public-imgproxy-signing
+          key: IMGPROXY_KEY
+    - name: IMGPROXY_SALT
+      valueFrom:
+        secretKeyRef:
+          name: monolith-public-imgproxy-signing
+          key: IMGPROXY_SALT
     # Named presets are the ONLY processing options allowed (ONLY_PRESETS below).
     # This caps imgproxy to the exact sizes the trips frontend requests instead
     # of serving arbitrary resizes of the bucket. The names here MUST match the

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.15.1
+      targetRevision: 0.16.0
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith-public/deploy/values.yaml
+++ b/projects/monolith-public/deploy/values.yaml
@@ -27,6 +27,13 @@ turnstile:
   onepassword:
     itemPath: "vaults/k8s-homelab/items/cloudflare-turnstile"
 
+# Trip image URL signing: sync the imgproxy KEY/SALT from 1Password into the
+# monolith-public-imgproxy-signing Secret (keys IMGPROXY_KEY / IMGPROXY_SALT).
+# Both the imgproxy and frontend components reference it via secretKeyRef.
+imgproxySigning:
+  onepassword:
+    itemPath: "vaults/k8s-homelab/items/trips-imgproxy-signing"
+
 # Phase 5e cutover: serve the public hostname from this isolated service.
 cfIngress:
   public:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.171.0
+version: 0.172.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.171.0
+      targetRevision: 0.172.0
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/BUILD
+++ b/projects/monolith/frontend/BUILD
@@ -195,6 +195,9 @@ js_library(
         # Resolved by the $app/environment alias in vitest.config.js; lives
         # outside src/ so it never reaches the app bundle.
         "test/app-environment-stub.js",
+        # Resolved by the $env/dynamic/private alias in vitest.config.js; same
+        # rationale: lives outside src/ so it never reaches the app bundle.
+        "test/env-dynamic-private-stub.js",
     ],
     deps = [
         ":node_modules/vitest",

--- a/projects/monolith/frontend/src/lib/public/components/trips/PhotoGrid.svelte
+++ b/projects/monolith/frontend/src/lib/public/components/trips/PhotoGrid.svelte
@@ -1,8 +1,8 @@
 <script>
-  import { imgUrl } from "$lib/trips/images.js";
-
   // Contact-sheet grid of a day's photos. Clicking a tile calls onOpen(i); the
   // lightbox itself is owned by the page so the map and grid share one viewer.
+  // Each photo carries a pre-signed `imgGallery` URL (signed server-side in the
+  // trip [slug] layout load); this component never builds an imgproxy URL.
   let { photos = [], onOpen = () => {} } = $props();
 </script>
 
@@ -11,7 +11,7 @@
     {#each photos as photo, i (photo.id)}
       <button class="tile" onclick={() => onOpen(i)} aria-label={`Open photo ${i + 1}`}>
         <img
-          src={imgUrl(photo.image, "gallery")}
+          src={photo.imgGallery}
           alt={`Photo ${i + 1}`}
           loading="lazy"
           decoding="async"

--- a/projects/monolith/frontend/src/lib/public/components/trips/PhotoViewer.svelte
+++ b/projects/monolith/frontend/src/lib/public/components/trips/PhotoViewer.svelte
@@ -1,7 +1,8 @@
 <script>
   import { onMount } from "svelte";
-  import { imgUrl } from "$lib/trips/images.js";
 
+  // Each photo carries a pre-signed `imgDisplay` URL (signed server-side in the
+  // trip [slug] layout load); this component never builds an imgproxy URL.
   // Fullscreen lightbox for a list of photo points. Controlled: the parent owns
   // `index` and reacts to onIndex / onClose. Keyboard: left/right navigate,
   // Escape closes.
@@ -54,7 +55,7 @@
     {/if}
 
     <figure class="frame">
-      <img src={imgUrl(photo.image, "display")} alt={`Photo ${index + 1} of ${photos.length}`} />
+      <img src={photo.imgDisplay} alt={`Photo ${index + 1} of ${photos.length}`} />
       <figcaption>
         <span class="count">{index + 1} / {photos.length}</span>
         {#if photo.taken_at}<span>{fmtTime(photo.taken_at)}</span>{/if}

--- a/projects/monolith/frontend/src/lib/server/trips-img.js
+++ b/projects/monolith/frontend/src/lib/server/trips-img.js
@@ -1,0 +1,61 @@
+// Server-only imgproxy URL signer for the /app/trips pages. Lives under
+// $lib/server/** so SvelteKit guarantees it is NEVER bundled into the client:
+// the HMAC signing secret (IMGPROXY_KEY / IMGPROXY_SALT) must stay server-side.
+// The SSR loads pre-sign every image URL and pass the result as plain data, so
+// the browser only ever sees a finished `/img/<signature>/<preset>/plain/...`
+// URL and never the secret.
+//
+// imgproxy (monolith-public chart) runs with IMGPROXY_PATH_PREFIX=/img and, once
+// IMGPROXY_KEY/IMGPROXY_SALT are set, REQUIRES a valid signature on every
+// request (the old unsigned /unsafe/ path is retired). The signature is an
+// HMAC-SHA256 over the request path AFTER the /img prefix (imgproxy strips the
+// prefix before checking the signature).
+import { createHmac } from "node:crypto";
+import { env } from "$env/dynamic/private";
+import { PRESETS } from "../trips/images.js";
+
+const IMG_BASE = "/img";
+const S3_PREFIX = "s3://monolith-trips/";
+
+let warned = false;
+function warnUnsigned() {
+  if (warned) return;
+  warned = true;
+  // Local dev without the secret: fall back to unsigned URLs so the pages still
+  // render. In prod IMGPROXY_KEY/SALT are always injected (secretKeyRef), so
+  // this branch never runs there.
+  console.warn(
+    "[trips-img] IMGPROXY_KEY/IMGPROXY_SALT unset, falling back to unsigned /img/unsafe/ URLs (local dev only).",
+  );
+}
+
+// signature = base64url(HMAC_SHA256(key=hex(KEY), msg=hex(SALT) ++ utf8(path)))
+// with no padding. Node's "base64url" digest encoding already omits padding.
+function sign(path) {
+  const h = createHmac("sha256", Buffer.from(env.IMGPROXY_KEY, "hex"));
+  h.update(Buffer.from(env.IMGPROXY_SALT, "hex"));
+  h.update(path);
+  return h.digest("base64url");
+}
+
+// Build the signed (or, without a secret, unsigned) same-origin imgproxy URL for
+// one object key + named preset. `path` is everything after the signature and is
+// exactly what imgproxy signs once it has stripped the /img prefix.
+function build(key, preset) {
+  const p = PRESETS.has(preset) ? preset : "gallery";
+  const path = `/${p}/plain/${S3_PREFIX}${key}`;
+  if (!env.IMGPROXY_KEY || !env.IMGPROXY_SALT) {
+    warnUnsigned();
+    return `${IMG_BASE}/unsafe${path}`;
+  }
+  return `${IMG_BASE}/${sign(path)}${path}`;
+}
+
+// key is the TripPoint `image` value (the S3 object key for that photo).
+export function signedImgUrl(key, preset = "gallery") {
+  return build(key, preset);
+}
+
+export function signedFullUrl(key) {
+  return build(key, "full");
+}

--- a/projects/monolith/frontend/src/lib/server/trips-img.test.js
+++ b/projects/monolith/frontend/src/lib/server/trips-img.test.js
@@ -1,0 +1,92 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { createHmac } from "node:crypto";
+import { signedImgUrl, signedFullUrl } from "./trips-img.js";
+
+// Hex-encoded fake key/salt (the real ones are random bytes from 1Password).
+const KEY = "00112233445566778899aabbccddeeff"; // gitleaks:allow
+const SALT = "ffeeddccbbaa99887766554433221100"; // gitleaks:allow
+
+// Independent reference implementation of the imgproxy signature so the test
+// pins the exact bytes, not just the shape: HMAC-SHA256(key=hex(KEY)) over
+// hex(SALT) ++ utf8(path), base64url, no padding.
+function expectedSig(path, key, salt) {
+  const h = createHmac("sha256", Buffer.from(key, "hex"));
+  h.update(Buffer.from(salt, "hex"));
+  h.update(path);
+  return h.digest("base64url");
+}
+
+function setEnv(key, salt) {
+  if (key === undefined) delete process.env.IMGPROXY_KEY;
+  else process.env.IMGPROXY_KEY = key;
+  if (salt === undefined) delete process.env.IMGPROXY_SALT;
+  else process.env.IMGPROXY_SALT = salt;
+}
+
+describe("trips imgproxy URL signer", () => {
+  let savedKey;
+  let savedSalt;
+
+  beforeEach(() => {
+    savedKey = process.env.IMGPROXY_KEY;
+    savedSalt = process.env.IMGPROXY_SALT;
+  });
+  afterEach(() => {
+    setEnv(savedKey, savedSalt);
+  });
+
+  it("signs a known path to a stable signature", () => {
+    setEnv(KEY, SALT);
+    const path = "/display/plain/s3://monolith-trips/img_x.jpg";
+    const sig = expectedSig(path, KEY, SALT);
+    expect(signedImgUrl("img_x.jpg", "display")).toBe(`/img/${sig}${path}`);
+    // base64url, no padding, URL-safe alphabet only.
+    expect(sig).toMatch(/^[A-Za-z0-9_-]+$/);
+    expect(sig).not.toContain("=");
+  });
+
+  it("puts the /img prefix before the signature and the unprefixed path after", () => {
+    setEnv(KEY, SALT);
+    const url = signedImgUrl("img_abc.jpg", "gallery");
+    expect(url).toMatch(
+      /^\/img\/[A-Za-z0-9_-]+\/gallery\/plain\/s3:\/\/monolith-trips\/img_abc\.jpg$/,
+    );
+  });
+
+  it("falls back to the gallery preset for an unknown name", () => {
+    setEnv(KEY, SALT);
+    const path = "/gallery/plain/s3://monolith-trips/k";
+    expect(signedImgUrl("k", "nope")).toBe(
+      `/img/${expectedSig(path, KEY, SALT)}${path}`,
+    );
+    expect(signedImgUrl("k")).toBe(
+      `/img/${expectedSig(path, KEY, SALT)}${path}`,
+    );
+  });
+
+  it("signedFullUrl uses the full preset", () => {
+    setEnv(KEY, SALT);
+    const path = "/full/plain/s3://monolith-trips/img_abc.jpg";
+    expect(signedFullUrl("img_abc.jpg")).toBe(
+      `/img/${expectedSig(path, KEY, SALT)}${path}`,
+    );
+  });
+
+  it("produces different signatures for different keys", () => {
+    setEnv(KEY, SALT);
+    const a = signedImgUrl("k", "display");
+    setEnv("aabbccddeeff00112233445566778899", SALT); // gitleaks:allow
+    const b = signedImgUrl("k", "display");
+    expect(a).not.toBe(b);
+  });
+
+  it("falls back to an unsigned /unsafe/ URL when the secret is absent", () => {
+    setEnv(undefined, undefined);
+    expect(signedImgUrl("img_abc.jpg", "thumb")).toBe(
+      "/img/unsafe/thumb/plain/s3://monolith-trips/img_abc.jpg",
+    );
+    expect(signedFullUrl("img_abc.jpg")).toBe(
+      "/img/unsafe/full/plain/s3://monolith-trips/img_abc.jpg",
+    );
+  });
+});

--- a/projects/monolith/frontend/src/lib/trips/images.js
+++ b/projects/monolith/frontend/src/lib/trips/images.js
@@ -1,20 +1,17 @@
-// imgproxy URL helpers for the /app/trips pages. Originals live in the
-// monolith-trips SeaweedFS bucket; imgproxy resizes them on the fly. It is now
-// served same-origin under /img by the monolith-public HTTPRoute (imgproxy runs
-// with IMGPROXY_PATH_PREFIX=/img), so these are relative URLs (no cross-origin,
-// no CORS, no separate img.jomcgi.dev tunnel). The presets mirror the sizes the
-// old trips frontend used. `key` is the TripPoint `image` value (the S3 object
-// key for that photo).
-const IMG_BASE = "/img";
-
-// imgproxy is locked to named presets (IMGPROXY_ONLY_PRESETS); these names must
-// match IMGPROXY_PRESETS in the monolith-public chart.
-const PRESETS = new Set(["thumb", "gallery", "preview", "display", "full"]);
-
-export const imgUrl = (key, preset = "gallery") => {
-  const p = PRESETS.has(preset) ? preset : "gallery";
-  return `${IMG_BASE}/unsafe/${p}/plain/s3://monolith-trips/${key}`;
-};
-
-export const fullUrl = (key) =>
-  `${IMG_BASE}/unsafe/full/plain/s3://monolith-trips/${key}`;
+// Shared preset name list for the /app/trips imgproxy images. Originals live in
+// the monolith-trips SeaweedFS bucket; imgproxy resizes them on the fly and
+// serves them same-origin under /img (the monolith-public HTTPRoute forwards
+// /img/ to imgproxy, which runs with IMGPROXY_PATH_PREFIX=/img). URL building +
+// HMAC signing happens server-side in $lib/server/trips-img.js (the signing
+// secret must never reach the client); this module only holds the preset names
+// so the server signer and any caller share one source of truth.
+//
+// imgproxy is locked to these named presets (IMGPROXY_ONLY_PRESETS); the names
+// MUST match IMGPROXY_PRESETS in the monolith-public chart (chart/values.yaml).
+export const PRESETS = new Set([
+  "thumb",
+  "gallery",
+  "preview",
+  "display",
+  "full",
+]);

--- a/projects/monolith/frontend/src/lib/trips/images.test.js
+++ b/projects/monolith/frontend/src/lib/trips/images.test.js
@@ -1,33 +1,12 @@
 import { describe, it, expect } from "vitest";
-import { imgUrl, fullUrl } from "./images.js";
+import { PRESETS } from "./images.js";
 
-describe("trips image helpers", () => {
-  it("builds a same-origin named-preset imgproxy URL from an object key", () => {
-    expect(imgUrl("img_abc.jpg", "thumb")).toBe(
-      "/img/unsafe/thumb/plain/s3://monolith-trips/img_abc.jpg",
-    );
-    expect(imgUrl("img_abc.jpg", "gallery")).toBe(
-      "/img/unsafe/gallery/plain/s3://monolith-trips/img_abc.jpg",
-    );
-  });
-
-  it("exposes all named presets", () => {
+describe("trips image presets", () => {
+  it("exposes the named presets imgproxy is locked to", () => {
+    // Must match IMGPROXY_PRESETS in the monolith-public chart values.
     for (const preset of ["thumb", "gallery", "preview", "display", "full"]) {
-      const url = imgUrl("k", preset);
-      expect(url).toBe(`/img/unsafe/${preset}/plain/s3://monolith-trips/k`);
+      expect(PRESETS.has(preset)).toBe(true);
     }
-  });
-
-  it("falls back to the gallery preset for an unknown name", () => {
-    expect(imgUrl("k", "nope")).toBe(
-      "/img/unsafe/gallery/plain/s3://monolith-trips/k",
-    );
-    expect(imgUrl("k")).toBe("/img/unsafe/gallery/plain/s3://monolith-trips/k");
-  });
-
-  it("builds a full-resolution URL via the full preset", () => {
-    expect(fullUrl("img_abc.jpg")).toBe(
-      "/img/unsafe/full/plain/s3://monolith-trips/img_abc.jpg",
-    );
+    expect(PRESETS.size).toBe(5);
   });
 });

--- a/projects/monolith/frontend/src/routes/public/app/trips/+page.server.js
+++ b/projects/monolith/frontend/src/routes/public/app/trips/+page.server.js
@@ -7,6 +7,10 @@ import {
   TRIPS_CACHE_CONTROL,
   versionedEtag,
 } from "../../../../lib/cache-headers.js";
+// Server-only imgproxy URL signer (relative import: vitest loads this module
+// directly without the $lib alias). See [slug]/+layout.server.js for the same
+// pattern; the HMAC secret never leaves the server.
+import { signedImgUrl } from "../../../../lib/server/trips-img.js";
 
 // No URL fallback: API_BASE is injected via values.yaml in prod; a localhost
 // fallback would silently route to the wrong backend if the env var were missing
@@ -30,5 +34,13 @@ export async function load({ fetch, setHeaders }) {
   if (etag) headers.etag = etag;
   setHeaders(headers);
 
-  return { index: await res.json() };
+  // Pre-sign each trip cover server-side (gallery preset) into `coverUrl` so the
+  // index cards render a signed /img URL without ever touching the secret.
+  const index = await res.json();
+  const trips = (index.trips ?? []).map((t) =>
+    t.default_image
+      ? { ...t, coverUrl: signedImgUrl(t.default_image, "gallery") }
+      : t,
+  );
+  return { index: { ...index, trips } };
 }

--- a/projects/monolith/frontend/src/routes/public/app/trips/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/trips/+page.svelte
@@ -1,6 +1,6 @@
 <script>
-  import { imgUrl } from "$lib/trips/images.js";
-
+  // Image URLs are pre-signed server-side in +page.server.js (trip.coverUrl);
+  // the signing secret never reaches the client.
   let { data } = $props();
 
   const trips = $derived(data.index?.trips ?? []);
@@ -33,9 +33,9 @@
         <li>
           <a class="card" href={`/app/trips/${trip.slug}`}>
             <div class="thumb">
-              {#if trip.default_image}
+              {#if trip.coverUrl}
                 <img
-                  src={imgUrl(trip.default_image, "gallery")}
+                  src={trip.coverUrl}
                   alt={trip.title}
                   loading="lazy"
                   decoding="async"

--- a/projects/monolith/frontend/src/routes/public/app/trips/[slug]/+layout.server.js
+++ b/projects/monolith/frontend/src/routes/public/app/trips/[slug]/+layout.server.js
@@ -7,6 +7,12 @@ import {
   TRIPS_CACHE_CONTROL,
   versionedEtag,
 } from "../../../../../lib/cache-headers.js";
+// Server-only: signs imgproxy URLs with the HMAC secret. Relative (not $lib) so
+// vitest, which loads this module directly without the SvelteKit $lib alias, can
+// resolve it (the signer's $env/dynamic/private import is aliased in
+// vitest.config.js). $lib/server/** is never client-bundled, so the secret stays
+// server-side; we pre-sign here and hand the components finished URLs.
+import { signedImgUrl } from "../../../../../lib/server/trips-img.js";
 
 // No URL fallback: API_BASE is injected via values.yaml in prod; a localhost
 // fallback would silently route to the wrong backend if the env var were missing
@@ -35,5 +41,34 @@ export async function load({ params, fetch, setHeaders }) {
   setHeaders(headers);
 
   const { trip, points } = await res.json();
-  return { trip, points };
+
+  // Pre-sign every image URL server-side and attach it to the data. The day
+  // scrubber needs the `display` preset, the grids/timeline need `gallery`, so
+  // each image-bearing point carries both. Cover + highlight thumbs use
+  // `gallery`. Fields are only added when the source image exists, so trips /
+  // points without photos pass through unchanged.
+  const signedPoints = (points ?? []).map((p) =>
+    p.image
+      ? {
+          ...p,
+          imgDisplay: signedImgUrl(p.image, "display"),
+          imgGallery: signedImgUrl(p.image, "gallery"),
+        }
+      : p,
+  );
+
+  let signedTrip = trip;
+  if (trip) {
+    signedTrip = { ...trip };
+    if (trip.default_image) {
+      signedTrip.coverUrl = signedImgUrl(trip.default_image, "gallery");
+    }
+    if (Array.isArray(trip.highlights)) {
+      signedTrip.highlights = trip.highlights.map((h) =>
+        h.image ? { ...h, imgGallery: signedImgUrl(h.image, "gallery") } : h,
+      );
+    }
+  }
+
+  return { trip: signedTrip, points: signedPoints };
 }

--- a/projects/monolith/frontend/src/routes/public/app/trips/[slug]/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/trips/[slug]/+page.svelte
@@ -1,7 +1,6 @@
 <script>
   import TripMap from "$lib/public/components/trips/TripMap.svelte";
   import ElevationChart from "$lib/public/components/trips/ElevationChart.svelte";
-  import { imgUrl } from "$lib/trips/images.js";
   import {
     deriveTripStats,
     dayColor,
@@ -167,8 +166,8 @@ ${trkpts}
                   onmouseenter={() => (hoveredDay = (h.day ?? 1) - 1)}
                   onmouseleave={() => (hoveredDay = null)}
                 >
-                  {#if h.image}
-                    <img src={imgUrl(h.image, "gallery")} alt={h.title} loading="lazy" />
+                  {#if h.imgGallery}
+                    <img src={h.imgGallery} alt={h.title} loading="lazy" />
                   {:else}
                     <span class="hl-fill" aria-hidden="true"></span>
                   {/if}

--- a/projects/monolith/frontend/src/routes/public/app/trips/[slug]/day/[day]/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/trips/[slug]/day/[day]/+page.svelte
@@ -3,7 +3,6 @@
   import DayMap from "$lib/public/components/trips/DayMap.svelte";
   import DayStats from "$lib/public/components/trips/DayStats.svelte";
   import ElevationChart from "$lib/public/components/trips/ElevationChart.svelte";
-  import { imgUrl } from "$lib/trips/images.js";
   import {
     groupByDay,
     dayColor,
@@ -125,7 +124,7 @@
         {#if photo}
           <figure class="frame">
             <img
-              src={imgUrl(photo.image, "display")}
+              src={photo.imgDisplay}
               alt={`Photo ${current + 1} of ${photos.length}`}
               decoding="async"
             />

--- a/projects/monolith/frontend/src/routes/public/app/trips/[slug]/layout.server.test.js
+++ b/projects/monolith/frontend/src/routes/public/app/trips/[slug]/layout.server.test.js
@@ -67,4 +67,63 @@ describe("/public/app/trips/[slug] layout load", () => {
       load({ params: { slug: "2025-x" }, fetch, setHeaders }),
     ).rejects.toThrow();
   });
+
+  it("pre-signs image URLs onto points, the cover, and highlights", async () => {
+    // Clear the signing secret so the signer's deterministic unsigned /unsafe/
+    // fallback is exercised (the HMAC path is covered in lib/server/trips-img.test.js).
+    const savedKey = process.env.IMGPROXY_KEY;
+    const savedSalt = process.env.IMGPROXY_SALT;
+    delete process.env.IMGPROXY_KEY;
+    delete process.env.IMGPROXY_SALT;
+    try {
+      const payload = {
+        trip: {
+          slug: "2025-x",
+          title: "X",
+          default_image: "cover.jpg",
+          highlights: [
+            { id: 1, title: "H1", image: "h1.jpg" },
+            { id: 2, title: "no-photo" },
+          ],
+        },
+        points: [
+          { id: 1, image: "p1.jpg" },
+          { id: 2, lat: 1, lng: 2 },
+        ],
+      };
+      const fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        headers: makeHeaders(),
+        json: async () => payload,
+      });
+
+      const result = await load({
+        params: { slug: "2025-x" },
+        fetch,
+        setHeaders: vi.fn(),
+      });
+
+      expect(result.trip.coverUrl).toBe(
+        "/img/unsafe/gallery/plain/s3://monolith-trips/cover.jpg",
+      );
+      expect(result.trip.highlights[0].imgGallery).toBe(
+        "/img/unsafe/gallery/plain/s3://monolith-trips/h1.jpg",
+      );
+      expect(result.trip.highlights[1].imgGallery).toBeUndefined();
+      expect(result.points[0].imgDisplay).toBe(
+        "/img/unsafe/display/plain/s3://monolith-trips/p1.jpg",
+      );
+      expect(result.points[0].imgGallery).toBe(
+        "/img/unsafe/gallery/plain/s3://monolith-trips/p1.jpg",
+      );
+      // Image-less point passes through untouched.
+      expect(result.points[1].imgDisplay).toBeUndefined();
+    } finally {
+      if (savedKey === undefined) delete process.env.IMGPROXY_KEY;
+      else process.env.IMGPROXY_KEY = savedKey;
+      if (savedSalt === undefined) delete process.env.IMGPROXY_SALT;
+      else process.env.IMGPROXY_SALT = savedSalt;
+    }
+  });
 });

--- a/projects/monolith/frontend/test/env-dynamic-private-stub.js
+++ b/projects/monolith/frontend/test/env-dynamic-private-stub.js
@@ -1,0 +1,9 @@
+// Test stub for SvelteKit's `$env/dynamic/private` virtual module.
+//
+// The real module is injected by the SvelteKit build and reflects the server
+// process environment. Our vitest config is a bare node environment with no
+// SvelteKit plugin (see vitest.config.js), so the virtual specifier does not
+// resolve when lib/server/trips-img.js (and the trips server loads that import
+// it) are loaded directly. Exposing process.env lets tests set/clear
+// IMGPROXY_KEY / IMGPROXY_SALT to exercise the signed and unsigned paths.
+export const env = process.env;

--- a/projects/monolith/frontend/vitest.config.js
+++ b/projects/monolith/frontend/vitest.config.js
@@ -11,6 +11,13 @@ export default defineConfig({
       "$app/environment": fileURLToPath(
         new URL("./test/app-environment-stub.js", import.meta.url),
       ),
+      // Same reason for `$env/dynamic/private` (used by lib/server/trips-img.js
+      // and, transitively, the trips server loads). The real module is injected
+      // by SvelteKit at build time; the stub exposes process.env so tests can
+      // control IMGPROXY_KEY/SALT.
+      "$env/dynamic/private": fileURLToPath(
+        new URL("./test/env-dynamic-private-stub.js", import.meta.url),
+      ),
     },
   },
   test: {


### PR DESCRIPTION
Signs trip image URLs so only URLs our server generates work; retires unsigned `/unsafe` mode.

## How
- Server-only signer `lib/server/trips-img.js` (never client-bundled) reads `IMGPROXY_KEY`/`IMGPROXY_SALT` from `$env/dynamic/private` and builds `/img/<hmac-sig>/<preset>/plain/s3://monolith-trips/<key>`. The browser never sees the secret.
- The trips `+page.server.js` / `+layout.server.js` loads pre-sign each photo's `display`/`gallery` URL + covers/highlights and pass them as data; components consume the pre-signed fields (no client-side URL building).
- imgproxy: `IMGPROXY_KEY`/`IMGPROXY_SALT` via secretKeyRef, `IMGPROXY_ALLOW_INSECURE_URLS` removed (unsigned URLs now 403). Secret synced from 1Password (`trips-imgproxy-signing`, k8s-homelab) via a new OnePasswordItem; same secret injected into the public-frontend SSR pod so its signatures match.

**Signature format verified live**: against a throwaway imgproxy v3.25.0 with the real key/salt + PATH_PREFIX, a valid signed URL -> 200, tampered -> 403, unsigned -> 403.

monolith-public chart 0.15.1 -> 0.16.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)