### PR TITLE
feat(trips): rich per-photo telemetry, dominant photo, neighbor preloading

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.16.1
+version: 0.17.0
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.16.1
+      targetRevision: 0.17.0
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.172.1
+version: 0.173.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.172.1
+      targetRevision: 0.173.0
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/lib/public/components/trips/DayMap.svelte
+++ b/projects/monolith/frontend/src/lib/public/components/trips/DayMap.svelte
@@ -11,14 +11,20 @@
   // eases to its coordinates. Clicking any marker calls onPhotoClick(i) so the
   // page can set `current`.
   //
-  // TODO(trips): the old React DayMap drove a per-photo marker + terrain
-  // hillshade lit from the sun position at the photo's timestamp. That solar /
-  // bearing panel is dropped in this port; photos are shown as static markers.
+  // `currentCoords` (optional) is the [lng, lat] for the current photo with the
+  // page's GPS interpolation already applied, so the highlight marker tracks
+  // photos that lack their own fix. Falls back to the photo's raw coordinates.
+  //
+  // Note: the old React DayMap also drove a terrain hillshade lit from the sun
+  // position at the photo's timestamp; that relighting needs a raster-DEM
+  // terrain source and is out of scope here. The solar/bearing readouts live in
+  // the telemetry panel instead.
   let {
     points = [],
     photos = [],
     dayColor = "#2563eb",
     current = 0,
+    currentCoords = null,
     onPhotoClick,
   } = $props();
 
@@ -51,11 +57,13 @@
   }
 
   // Keep the highlight layer + camera in sync with the scrubber's `current`.
-  // Guarded on mapReady so it no-ops until the sources/layers exist.
+  // Guarded on mapReady so it no-ops until the sources/layers exist. Prefers the
+  // page's interpolated `currentCoords` so the marker tracks fix-less photos.
   $effect(() => {
     const i = current;
+    const interp = currentCoords;
     if (!mapReady || !map) return;
-    const coords = photoCoords(i);
+    const coords = interp ?? photoCoords(i);
     const src = map.getSource("day-photo-current");
     if (src) {
       src.setData({

--- a/projects/monolith/frontend/src/lib/public/components/trips/DayStats.svelte
+++ b/projects/monolith/frontend/src/lib/public/components/trips/DayStats.svelte
@@ -18,6 +18,18 @@
         <span class="label">Descent</span>
         <span class="value down">-{stats.descent.toLocaleString()}<span class="unit">m</span></span>
       </div>
+      {#if stats.maxElevation != null}
+        <div class="cell">
+          <span class="label">High Point</span>
+          <span class="value">{stats.maxElevation.toLocaleString()}<span class="unit">m</span></span>
+        </div>
+      {/if}
+      {#if stats.minElevation != null}
+        <div class="cell">
+          <span class="label">Low Point</span>
+          <span class="value">{stats.minElevation.toLocaleString()}<span class="unit">m</span></span>
+        </div>
+      {/if}
     {/if}
     <div class="cell">
       <span class="label">Photos</span>

--- a/projects/monolith/frontend/src/lib/public/components/trips/DayTelemetry.svelte
+++ b/projects/monolith/frontend/src/lib/public/components/trips/DayTelemetry.svelte
@@ -1,0 +1,158 @@
+<script>
+  // Per-photo telemetry panel: the monospace "machine interface" readout that
+  // sat beside the photo in the old React day view (DataPanel). Each cell is a
+  // brutalist 2px-bordered box with a mono eyebrow label and a value. `t` is the
+  // object from lib/trips/telemetry.js photoTelemetry(); `index`/`total` drive
+  // the photo counter, `dayColor` tints the accent border.
+  import { formatCoord } from "$lib/trips/telemetry.js";
+
+  let { t = null, index = 0, total = 0, dayColor = "var(--ink)" } = $props();
+</script>
+
+{#if t}
+  <div class="telem" style={`--day:${dayColor}`}>
+    <div class="cell time">
+      <span class="label">Time</span>
+      <span class="clock">{t.time}<span class="period">{t.period}</span></span>
+    </div>
+
+    <div class="cell">
+      <span class="label">Solar</span>
+      <span class="value">{t.solarAltDeg != null ? `${Math.round(t.solarAltDeg)}°` : "--"}</span>
+      <span class="sub">{t.solarLabel}</span>
+    </div>
+
+    <div class="cell">
+      <span class="label">Light</span>
+      <span class="value sm">{t.light || "DARK"}</span>
+    </div>
+
+    <div class="cell">
+      <span class="label">EV</span>
+      <span class="value">{t.ev ?? "--"}</span>
+      <span class="sub">{t.evLabel}</span>
+    </div>
+
+    <div class="cell">
+      <span class="label">Elev</span>
+      <span class="value">{t.elevation != null ? Math.round(t.elevation) : "--"}<span class="unit">m</span></span>
+    </div>
+
+    <div class="cell">
+      <span class="label">Position</span>
+      <span class="coord">{formatCoord(t.lat, true)}</span>
+      <span class="coord">{formatCoord(t.lng, false)}</span>
+    </div>
+
+    <div class="cell">
+      <span class="label">Km</span>
+      <span class="value">{t.km ?? 0}<span class="unit">/{t.totalKm ?? 0}</span></span>
+    </div>
+
+    <div class="cell bearing">
+      <span class="label">Bearing</span>
+      <span class="arrow">{t.bearingArrow}</span>
+      <span class="sub">{t.bearing != null ? `${Math.round(t.bearing)}°` : "--"}</span>
+    </div>
+
+    <div class="cell optics">
+      <span class="label">Optics</span>
+      <span class="value sm">
+        {t.focalLength35mm != null ? `${t.focalLength35mm}mm` : "--"} &fnof;/{t.aperture ?? "--"}
+      </span>
+      <span class="sub">ISO {t.iso ?? "--"} · {t.shutterSpeed ?? "--"}</span>
+    </div>
+
+    <div class="cell">
+      <span class="label">Photo</span>
+      <span class="value">{total ? index + 1 : 0}<span class="unit">/{total}</span></span>
+    </div>
+  </div>
+{/if}
+
+<style>
+  .telem {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+    border: 2px solid var(--ink);
+    border-bottom: none;
+    font-family: var(--mono);
+  }
+  .cell {
+    display: flex;
+    flex-direction: column;
+    padding: 12px 14px;
+    border-bottom: 2px solid var(--ink);
+    border-right: 2px solid var(--ink);
+    background: var(--paper);
+    min-width: 0;
+  }
+  .label {
+    font-size: 9px;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--ink-3);
+    margin-bottom: 6px;
+  }
+  .value {
+    font-size: 20px;
+    font-weight: 900;
+    line-height: 1;
+    color: var(--ink);
+  }
+  .value.sm {
+    font-size: 13px;
+    font-weight: 700;
+  }
+  .unit {
+    font-size: 11px;
+    font-weight: 700;
+    color: var(--ink-3);
+    margin-left: 2px;
+  }
+  .sub {
+    font-size: 9px;
+    font-weight: 700;
+    letter-spacing: 0.06em;
+    color: var(--ink-3);
+    margin-top: 4px;
+  }
+  .coord {
+    font-size: 11px;
+    font-weight: 700;
+    line-height: 1.5;
+    color: var(--ink);
+  }
+  /* TIME: the dominant readout, spanning a touch wider with a big clock. */
+  .time {
+    border-top: 4px solid var(--day);
+    margin-top: -2px;
+  }
+  .clock {
+    font-size: 28px;
+    font-weight: 900;
+    line-height: 1;
+    color: var(--ink);
+  }
+  .period {
+    font-size: 12px;
+    font-weight: 700;
+    color: var(--ink-3);
+    margin-left: 4px;
+  }
+  .bearing .arrow {
+    font-size: 30px;
+    line-height: 1;
+    color: var(--ink);
+  }
+  .optics {
+    /* Optics text is long: let it claim two columns on wider grids. */
+    grid-column: span 2;
+  }
+  @media (max-width: 600px) {
+    .optics {
+      grid-column: span 1;
+    }
+  }
+</style>

--- a/projects/monolith/frontend/src/lib/public/components/trips/ElevationChart.svelte
+++ b/projects/monolith/frontend/src/lib/public/components/trips/ElevationChart.svelte
@@ -14,6 +14,7 @@
     color = "var(--ink)",
     cursor = null,
     cursorColor = "var(--ink)",
+    showMinMax = false,
   } = $props();
 
   const lo = $derived(min ?? (series.length ? Math.min(...series) : 0));
@@ -39,23 +40,51 @@
 </script>
 
 {#if path}
-  <svg
-    viewBox={`0 0 100 ${height}`}
-    preserveAspectRatio="none"
-    style={`width:100%;height:${height}px;display:block`}
-    aria-hidden="true"
-  >
-    <path d={path} fill={color} fill-opacity="0.85" />
-    {#if cursorX != null}
-      <line
-        x1={cursorX}
-        y1="0"
-        x2={cursorX}
-        y2={height}
-        stroke={cursorColor}
-        stroke-width="1.5"
-        vector-effect="non-scaling-stroke"
-      />
+  <div class="elev" style={`--h:${height}px`}>
+    <svg
+      viewBox={`0 0 100 ${height}`}
+      preserveAspectRatio="none"
+      style={`width:100%;height:${height}px;display:block`}
+      aria-hidden="true"
+    >
+      <path d={path} fill={color} fill-opacity="0.85" />
+      {#if cursorX != null}
+        <line
+          x1={cursorX}
+          y1="0"
+          x2={cursorX}
+          y2={height}
+          stroke={cursorColor}
+          stroke-width="1.5"
+          vector-effect="non-scaling-stroke"
+        />
+      {/if}
+    </svg>
+    {#if showMinMax}
+      <span class="tick top">{Math.round(hi)}m</span>
+      <span class="tick bottom">{Math.round(lo)}m</span>
     {/if}
-  </svg>
+  </div>
 {/if}
+
+<style>
+  .elev {
+    position: relative;
+  }
+  .tick {
+    position: absolute;
+    right: 2px;
+    font-family: var(--mono);
+    font-size: 9px;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    color: var(--ink-3);
+    pointer-events: none;
+  }
+  .tick.top {
+    top: 0;
+  }
+  .tick.bottom {
+    bottom: 0;
+  }
+</style>

--- a/projects/monolith/frontend/src/lib/trips/sun.js
+++ b/projects/monolith/frontend/src/lib/trips/sun.js
@@ -1,0 +1,115 @@
+// Minimal solar-position + sunset math, inlined rather than pulling in the
+// `suncalc` npm package (a new dep + lockfile churn for two functions is not
+// worth it). Ported from the public-domain SunCalc core
+// (https://github.com/mourner/suncalc, BSD-2-Clause) and trimmed to just the
+// two things the day-view telemetry needs: the sun's altitude at a moment, and
+// the day's sunset time. Pure and dependency free, so it is unit testable.
+//
+// Astronomy refs are the same as SunCalc: Astronomy Answers position formulae
+// (aa.quae.nl/en/reken/zonpositie.html).
+
+const PI = Math.PI;
+const rad = PI / 180;
+const dayMs = 1000 * 60 * 60 * 24;
+const J1970 = 2440588;
+const J2000 = 2451545;
+const e = rad * 23.4397; // obliquity of the Earth
+
+function toDays(date) {
+  return date.valueOf() / dayMs - 0.5 + J1970 - J2000;
+}
+
+function rightAscension(l, b) {
+  return Math.atan2(
+    Math.sin(l) * Math.cos(e) - Math.tan(b) * Math.sin(e),
+    Math.cos(l),
+  );
+}
+
+function declination(l, b) {
+  return Math.asin(
+    Math.sin(b) * Math.cos(e) + Math.cos(b) * Math.sin(e) * Math.sin(l),
+  );
+}
+
+function altitudeRad(H, phi, dec) {
+  return Math.asin(
+    Math.sin(phi) * Math.sin(dec) + Math.cos(phi) * Math.cos(dec) * Math.cos(H),
+  );
+}
+
+function siderealTime(d, lw) {
+  return rad * (280.16 + 360.9856235 * d) - lw;
+}
+
+function solarMeanAnomaly(d) {
+  return rad * (357.5291 + 0.98560028 * d);
+}
+
+function eclipticLongitude(M) {
+  const C =
+    rad *
+    (1.9148 * Math.sin(M) + 0.02 * Math.sin(2 * M) + 0.0003 * Math.sin(3 * M)); // equation of center
+  const P = rad * 102.9372; // perihelion of the Earth
+  return M + C + P + PI;
+}
+
+function sunCoords(d) {
+  const M = solarMeanAnomaly(d);
+  const L = eclipticLongitude(M);
+  return { dec: declination(L, 0), ra: rightAscension(L, 0) };
+}
+
+// Sun altitude (radians, negative below the horizon) at `date` for the given
+// latitude / longitude in degrees. Matches SunCalc.getPosition().altitude.
+export function sunAltitude(date, lat, lng) {
+  const lw = rad * -lng;
+  const phi = rad * lat;
+  const d = toDays(date);
+  const c = sunCoords(d);
+  const H = siderealTime(d, lw) - c.ra;
+  return altitudeRad(H, phi, c.dec);
+}
+
+// --- sunset time ---
+const J0 = 0.0009;
+
+function julianCycle(d, lw) {
+  return Math.round(d - J0 - lw / (2 * PI));
+}
+function approxTransit(Ht, lw, n) {
+  return J0 + (Ht + lw) / (2 * PI) + n;
+}
+function solarTransitJ(ds, M, L) {
+  return J2000 + ds + 0.0053 * Math.sin(M) - 0.0069 * Math.sin(2 * L);
+}
+function hourAngle(h, phi, d) {
+  return Math.acos(
+    (Math.sin(h) - Math.sin(phi) * Math.sin(d)) / (Math.cos(phi) * Math.cos(d)),
+  );
+}
+function fromJulian(j) {
+  return new Date((j + 0.5 - J1970) * dayMs);
+}
+
+// Sunset Date for the day containing `date` at the given location, or null when
+// the sun does not set (polar day / night: the hour-angle acos goes out of
+// domain and yields NaN). Matches SunCalc.getTimes().sunset (altitude -0.833°).
+export function sunsetTime(date, lat, lng) {
+  const lw = rad * -lng;
+  const phi = rad * lat;
+  const d = toDays(date);
+  const n = julianCycle(d, lw);
+  const ds = approxTransit(0, lw, n);
+  const M = solarMeanAnomaly(ds);
+  const L = eclipticLongitude(M);
+  const dec = declination(L, 0);
+
+  const h0 = -0.833 * rad; // standard sunset altitude
+  const w = hourAngle(h0, phi, dec);
+  if (Number.isNaN(w)) return null;
+  const a = approxTransit(w, lw, n);
+  const Jset = solarTransitJ(a, M, L);
+  const set = fromJulian(Jset);
+  return Number.isNaN(set.getTime()) ? null : set;
+}

--- a/projects/monolith/frontend/src/lib/trips/sun.test.js
+++ b/projects/monolith/frontend/src/lib/trips/sun.test.js
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import { sunAltitude, sunsetTime } from "./sun.js";
+
+const toDeg = (rad) => (rad * 180) / Math.PI;
+
+// Mid-latitude site in southern BC (lat 49, lng -123). At solar noon the sun's
+// altitude is roughly 90 - lat +/- the solar declination (+23.44deg at the June
+// solstice, -23.44deg at December), so these are physical sanity checks rather
+// than golden values copied from the suncalc package.
+describe("sunAltitude", () => {
+  it("is high near the summer-solstice solar noon", () => {
+    // 2025-06-21 19:12Z is ~12:12 PDT (UTC-7), close to local solar noon.
+    const alt = toDeg(sunAltitude(new Date("2025-06-21T19:12:00Z"), 49, -123));
+    expect(alt).toBeGreaterThan(55);
+    expect(alt).toBeLessThan(70);
+  });
+
+  it("is low near the winter-solstice solar noon", () => {
+    const alt = toDeg(sunAltitude(new Date("2025-12-21T20:12:00Z"), 49, -123));
+    expect(alt).toBeGreaterThan(10);
+    expect(alt).toBeLessThan(25);
+  });
+
+  it("is below the horizon at local midnight", () => {
+    // 2025-06-22T08:00Z is ~01:00 PDT.
+    const alt = toDeg(sunAltitude(new Date("2025-06-22T08:00:00Z"), 49, -123));
+    expect(alt).toBeLessThan(0);
+  });
+});
+
+describe("sunsetTime", () => {
+  it("returns a sunset after local noon at a mid-latitude site", () => {
+    const noon = new Date("2025-06-21T19:12:00Z");
+    const set = sunsetTime(noon, 49, -123);
+    expect(set).toBeInstanceOf(Date);
+    expect(set.getTime()).toBeGreaterThan(noon.getTime());
+  });
+
+  it("returns null in the polar day (sun never sets)", () => {
+    // 2025-06-21 at 80N: continuous daylight, no sunset.
+    expect(sunsetTime(new Date("2025-06-21T12:00:00Z"), 80, 0)).toBeNull();
+  });
+});

--- a/projects/monolith/frontend/src/lib/trips/telemetry.js
+++ b/projects/monolith/frontend/src/lib/trips/telemetry.js
@@ -1,0 +1,242 @@
+// Per-photo telemetry for the day-view scrubber: position, elevation, cumulative
+// distance, bearing, exposure and solar context for the currently selected
+// photo. Ported from the old React DayDetailPage's DataPanel / currentPhoto
+// computations so the SvelteKit page can derive the same readouts from the SSR
+// payload. Pure and dependency free (solar math is inlined in ./sun.js) so it is
+// unit testable without a Svelte render harness.
+
+import { sunAltitude, sunsetTime } from "./sun.js";
+
+function takenMs(p) {
+  if (!p?.taken_at) return null;
+  const t = new Date(p.taken_at).getTime();
+  return Number.isNaN(t) ? null : t;
+}
+
+// Great-circle distance in km between two {lat,lng} points (haversine).
+function haversineKm(a, b) {
+  if (a?.lat == null || b?.lat == null) return 0;
+  const R = 6371;
+  const dLat = ((b.lat - a.lat) * Math.PI) / 180;
+  const dLon = ((b.lng - a.lng) * Math.PI) / 180;
+  const s =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos((a.lat * Math.PI) / 180) *
+      Math.cos((b.lat * Math.PI) / 180) *
+      Math.sin(dLon / 2) ** 2;
+  return R * 2 * Math.atan2(Math.sqrt(s), Math.sqrt(1 - s));
+}
+
+// Interpolate {lat, lng, elevation} for a photo from the day's GPS track by
+// timestamp, used when the photo itself lacks a fix. Ported from the React
+// `currentPhoto` useMemo: walk the (time-ordered) track, linearly interpolate
+// between the points bracketing the photo's capture time, and clamp to the first
+// / last point outside the track's span. Returns the photo's own values when it
+// already has a fix or cannot be interpolated.
+export function interpolatePosition(photo, dayPoints) {
+  const out = {
+    lat: photo?.lat ?? null,
+    lng: photo?.lng ?? null,
+    elevation: photo?.elevation ?? null,
+  };
+  if (photo?.lat != null && photo?.lng != null) return out;
+
+  const photoTime = takenMs(photo);
+  if (photoTime == null || !dayPoints?.length) return out;
+
+  let prev = null;
+  for (const point of dayPoints) {
+    const pt = takenMs(point);
+    if (pt == null) continue;
+    if (pt >= photoTime) {
+      if (prev) {
+        const prevTime = takenMs(prev);
+        const t = (photoTime - prevTime) / (pt - prevTime);
+        return {
+          lat: prev.lat + (point.lat - prev.lat) * t,
+          lng: prev.lng + (point.lng - prev.lng) * t,
+          elevation:
+            prev.elevation != null && point.elevation != null
+              ? prev.elevation + (point.elevation - prev.elevation) * t
+              : (photo?.elevation ?? point.elevation ?? null),
+        };
+      }
+      // Photo precedes the first track point: clamp to it.
+      return {
+        lat: point.lat,
+        lng: point.lng,
+        elevation: point.elevation ?? out.elevation,
+      };
+    }
+    prev = point;
+  }
+  // Photo after the last track point: clamp to it.
+  if (prev) {
+    return {
+      lat: prev.lat,
+      lng: prev.lng,
+      elevation: prev.elevation ?? out.elevation,
+    };
+  }
+  return out;
+}
+
+// Compass bearing in degrees (0..360, 0 = north) of the track direction at the
+// photo's capture time: the heading of the first track segment whose end is at
+// or after the photo. Ported from the React `bearing` useMemo.
+export function bearingAt(dayPoints, photoTime) {
+  if (!dayPoints?.length || photoTime == null) return null;
+  let prev = null;
+  for (const point of dayPoints) {
+    const pt = takenMs(point);
+    if (pt != null && pt >= photoTime && prev) {
+      const lat1 = (prev.lat * Math.PI) / 180;
+      const lat2 = (point.lat * Math.PI) / 180;
+      const dLng = ((point.lng - prev.lng) * Math.PI) / 180;
+      const y = Math.sin(dLng) * Math.cos(lat2);
+      const x =
+        Math.cos(lat1) * Math.sin(lat2) -
+        Math.sin(lat1) * Math.cos(lat2) * Math.cos(dLng);
+      const brng = (Math.atan2(y, x) * 180) / Math.PI;
+      return (brng + 360) % 360;
+    }
+    prev = point;
+  }
+  return null;
+}
+
+// 8-point compass arrow glyph for a bearing in degrees.
+export function compassArrow(deg) {
+  if (deg == null) return "→"; // →
+  const arrows = ["↑", "↗", "→", "↘", "↓", "↙", "←", "↖"];
+  return arrows[Math.round(deg / 45) % 8];
+}
+
+// Cumulative distance travelled into the day up to the photo's capture time, and
+// the day's total distance, in km. Ported from the React `progress` useMemo.
+export function cumulativeKm(dayPoints, photoTime) {
+  if (!dayPoints?.length || photoTime == null) return null;
+  let traveled = 0;
+  let total = 0;
+  let prev = null;
+  let found = false;
+  for (const point of dayPoints) {
+    if (prev) {
+      const seg = haversineKm(prev, point);
+      total += seg;
+      const pt = takenMs(point);
+      if (!found && pt != null && pt >= photoTime) found = true;
+      if (!found) traveled += seg;
+    }
+    prev = point;
+  }
+  return {
+    km: Math.round(traveled),
+    total: Math.round(total),
+    percent: total > 0 ? Math.round((traveled / total) * 100) : 0,
+  };
+}
+
+// Exposure-value mood label, from the EXIF light value (EV). Original thresholds.
+export function evLabel(ev) {
+  if (ev == null) return "";
+  if (ev >= 13) return "BRIGHT";
+  if (ev >= 10) return "SUNNY";
+  if (ev >= 7) return "OVERCAST";
+  if (ev >= 4) return "DIM";
+  return "DARK";
+}
+
+// Sun-altitude mood label (degrees). Original thresholds.
+export function solarLabel(altDeg) {
+  if (altDeg == null) return "--";
+  if (altDeg < -6) return "NIGHT";
+  if (altDeg < 0) return "TWILIGHT";
+  if (altDeg < 10) return "LOW";
+  return "DAY";
+}
+
+// "Xh YYm" until sunset, or null when sunset is unknown / already past. Ported
+// from the React getLightRemaining.
+export function lightRemaining(photoTime, sunsetMs) {
+  if (photoTime == null || sunsetMs == null || Number.isNaN(sunsetMs)) {
+    return null;
+  }
+  if (photoTime > sunsetMs) return null;
+  const diff = sunsetMs - photoTime;
+  const hours = Math.floor(diff / (1000 * 60 * 60));
+  const mins = Math.floor((diff % (1000 * 60 * 60)) / (1000 * 60));
+  return `${hours}h ${mins.toString().padStart(2, "0")}m`;
+}
+
+// Format a latitude/longitude as e.g. "12.3456° N" / "12.3456° W".
+export function formatCoord(val, isLat) {
+  if (val == null) return "--";
+  const dir = isLat ? (val >= 0 ? "N" : "S") : val >= 0 ? "E" : "W";
+  return `${Math.abs(val).toFixed(4)}° ${dir}`;
+}
+
+// Wall-clock HH:MM + AM/PM in the trip's IANA zone, for the big TIME readout.
+export function formatClock(iso, tz) {
+  if (!iso) return { time: "--:--", period: "" };
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return { time: "--:--", period: "" };
+  try {
+    const s = d.toLocaleTimeString("en-US", {
+      timeZone: tz || "UTC",
+      hour: "numeric",
+      minute: "2-digit",
+      hour12: true,
+    });
+    const parts = s.match(/(\d+:\d+)\s*(AM|PM)/i);
+    if (parts) return { time: parts[1], period: parts[2].toUpperCase() };
+    return { time: s, period: "" };
+  } catch {
+    return { time: "--:--", period: "" };
+  }
+}
+
+// Bundle every per-photo readout for the telemetry panel. `dayPoints` is the
+// day's full GPS track (image-less gap points included), `tz` the trip zone.
+// Position / elevation are interpolated from the track when the photo lacks a
+// fix; solar fields use that interpolated location.
+export function photoTelemetry(photo, dayPoints, tz) {
+  if (!photo) return null;
+  const pos = interpolatePosition(photo, dayPoints);
+  const photoTime = takenMs(photo);
+  const { time, period } = formatClock(photo.taken_at, tz);
+
+  let solarAltDeg = null;
+  let light = null;
+  if (photoTime != null && pos.lat != null && pos.lng != null) {
+    const date = new Date(photoTime);
+    solarAltDeg = (sunAltitude(date, pos.lat, pos.lng) * 180) / Math.PI;
+    const sunset = sunsetTime(date, pos.lat, pos.lng);
+    light = lightRemaining(photoTime, sunset ? sunset.getTime() : null);
+  }
+
+  const bearing = bearingAt(dayPoints, photoTime);
+  const dist = cumulativeKm(dayPoints, photoTime);
+
+  return {
+    lat: pos.lat,
+    lng: pos.lng,
+    elevation: pos.elevation,
+    time,
+    period,
+    solarAltDeg,
+    solarLabel: solarLabel(solarAltDeg),
+    light,
+    ev: photo.light_value ?? null,
+    evLabel: evLabel(photo.light_value),
+    bearing,
+    bearingArrow: compassArrow(bearing),
+    km: dist?.km ?? null,
+    totalKm: dist?.total ?? null,
+    // Optics passed straight through for the panel to format.
+    focalLength35mm: photo.focal_length_35mm ?? null,
+    aperture: photo.aperture ?? null,
+    iso: photo.iso ?? null,
+    shutterSpeed: photo.shutter_speed ?? null,
+  };
+}

--- a/projects/monolith/frontend/src/lib/trips/telemetry.test.js
+++ b/projects/monolith/frontend/src/lib/trips/telemetry.test.js
@@ -1,0 +1,160 @@
+import { describe, it, expect } from "vitest";
+import {
+  interpolatePosition,
+  bearingAt,
+  compassArrow,
+  cumulativeKm,
+  evLabel,
+  solarLabel,
+  lightRemaining,
+  formatCoord,
+  photoTelemetry,
+} from "./telemetry.js";
+
+// A simple two-leg track: A->B heads due north, B->C heads due east, with a
+// 10-minute gap between each fix.
+const TRACK = [
+  { lat: 49.0, lng: -123.0, elevation: 100, taken_at: "2025-06-21T19:00:00Z" },
+  { lat: 49.1, lng: -123.0, elevation: 200, taken_at: "2025-06-21T19:10:00Z" },
+  { lat: 49.1, lng: -122.8, elevation: 200, taken_at: "2025-06-21T19:20:00Z" },
+];
+
+describe("interpolatePosition", () => {
+  it("returns the photo's own fix when it has one", () => {
+    const photo = { lat: 1, lng: 2, elevation: 3, taken_at: TRACK[0].taken_at };
+    expect(interpolatePosition(photo, TRACK)).toEqual({
+      lat: 1,
+      lng: 2,
+      elevation: 3,
+    });
+  });
+
+  it("interpolates lat/lng/elevation midway between bracketing track points", () => {
+    // 19:05Z is halfway between A (19:00) and B (19:10).
+    const photo = { taken_at: "2025-06-21T19:05:00Z" };
+    const pos = interpolatePosition(photo, TRACK);
+    expect(pos.lat).toBeCloseTo(49.05, 6);
+    expect(pos.lng).toBeCloseTo(-123.0, 6);
+    expect(pos.elevation).toBeCloseTo(150, 6);
+  });
+
+  it("clamps to the first point before the track and the last point after it", () => {
+    const before = interpolatePosition(
+      { taken_at: "2025-06-21T18:00:00Z" },
+      TRACK,
+    );
+    expect(before.lat).toBe(49.0);
+    const after = interpolatePosition(
+      { taken_at: "2025-06-21T20:00:00Z" },
+      TRACK,
+    );
+    expect(after.lat).toBe(49.1);
+    expect(after.lng).toBe(-122.8);
+  });
+});
+
+describe("bearingAt", () => {
+  it("reads ~north for a due-north segment", () => {
+    // Photo at 19:05 falls in the A->B (northbound) segment; bearing ~0deg.
+    const b = bearingAt(TRACK, Date.parse("2025-06-21T19:05:00Z"));
+    expect(b).toBeGreaterThanOrEqual(0);
+    expect(Math.min(b, 360 - b)).toBeLessThan(1);
+  });
+
+  it("reads ~east for a due-east segment", () => {
+    // Photo at 19:15 falls in the B->C (eastbound) segment; bearing ~90deg.
+    const b = bearingAt(TRACK, Date.parse("2025-06-21T19:15:00Z"));
+    expect(b).toBeGreaterThan(89);
+    expect(b).toBeLessThan(91);
+  });
+});
+
+describe("compassArrow", () => {
+  it("maps cardinal bearings to arrow glyphs", () => {
+    expect(compassArrow(0)).toBe("↑");
+    expect(compassArrow(90)).toBe("→");
+    expect(compassArrow(180)).toBe("↓");
+    expect(compassArrow(270)).toBe("←");
+    expect(compassArrow(null)).toBe("→");
+  });
+});
+
+describe("cumulativeKm", () => {
+  it("accumulates distance up to the photo and reports the day total", () => {
+    // At 19:15 the A->B leg is complete (~11km) but B->C is not yet counted.
+    const d = cumulativeKm(TRACK, Date.parse("2025-06-21T19:15:00Z"));
+    expect(d.total).toBeGreaterThan(d.km);
+    expect(d.km).toBeGreaterThan(9);
+    expect(d.km).toBeLessThan(13);
+    expect(d.percent).toBeGreaterThan(0);
+    expect(d.percent).toBeLessThan(100);
+  });
+
+  it("returns zero travelled for a photo at the day's start", () => {
+    const d = cumulativeKm(TRACK, Date.parse("2025-06-21T19:00:00Z"));
+    expect(d.km).toBe(0);
+  });
+});
+
+describe("evLabel", () => {
+  it("buckets EV into mood labels at the original thresholds", () => {
+    expect(evLabel(14)).toBe("BRIGHT");
+    expect(evLabel(11)).toBe("SUNNY");
+    expect(evLabel(8)).toBe("OVERCAST");
+    expect(evLabel(5)).toBe("DIM");
+    expect(evLabel(2)).toBe("DARK");
+    expect(evLabel(null)).toBe("");
+  });
+});
+
+describe("solarLabel", () => {
+  it("labels sun altitude bands", () => {
+    expect(solarLabel(40)).toBe("DAY");
+    expect(solarLabel(5)).toBe("LOW");
+    expect(solarLabel(-3)).toBe("TWILIGHT");
+    expect(solarLabel(-20)).toBe("NIGHT");
+    expect(solarLabel(null)).toBe("--");
+  });
+});
+
+describe("lightRemaining", () => {
+  it("formats time until sunset and returns null once past", () => {
+    const now = Date.parse("2025-06-21T19:00:00Z");
+    const sunset = now + (2 * 60 + 5) * 60 * 1000; // 2h05m later
+    expect(lightRemaining(now, sunset)).toBe("2h 05m");
+    expect(lightRemaining(now, now - 1000)).toBeNull();
+    expect(lightRemaining(now, null)).toBeNull();
+  });
+});
+
+describe("formatCoord", () => {
+  it("formats lat/lng with hemisphere suffixes", () => {
+    expect(formatCoord(49.1234, true)).toBe("49.1234° N");
+    expect(formatCoord(-12.5, true)).toBe("12.5000° S");
+    expect(formatCoord(-123.9876, false)).toBe("123.9876° W");
+    expect(formatCoord(8.5, false)).toBe("8.5000° E");
+    expect(formatCoord(null, true)).toBe("--");
+  });
+});
+
+describe("photoTelemetry", () => {
+  it("bundles interpolated position plus bearing, km and solar context", () => {
+    const photo = {
+      taken_at: "2025-06-21T19:05:00Z",
+      light_value: 11,
+      iso: 100,
+    };
+    const t = photoTelemetry(photo, TRACK, "America/Vancouver");
+    expect(t.lat).toBeCloseTo(49.05, 4);
+    expect(t.evLabel).toBe("SUNNY");
+    expect(t.bearingArrow).toBe("↑"); // northbound leg
+    expect(t.km).toBeGreaterThanOrEqual(0);
+    // Midday summer sun in BC is well above the horizon.
+    expect(t.solarAltDeg).toBeGreaterThan(0);
+    expect(t.solarLabel).toBe("DAY");
+  });
+
+  it("returns null for no photo", () => {
+    expect(photoTelemetry(null, TRACK, "UTC")).toBeNull();
+  });
+});

--- a/projects/monolith/frontend/src/routes/public/app/trips/[slug]/day/[day]/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/trips/[slug]/day/[day]/+page.svelte
@@ -2,6 +2,7 @@
   import DayNav from "$lib/public/components/trips/DayNav.svelte";
   import DayMap from "$lib/public/components/trips/DayMap.svelte";
   import DayStats from "$lib/public/components/trips/DayStats.svelte";
+  import DayTelemetry from "$lib/public/components/trips/DayTelemetry.svelte";
   import ElevationChart from "$lib/public/components/trips/ElevationChart.svelte";
   import {
     groupByDay,
@@ -11,6 +12,7 @@
     elevationSeries,
     clampIndex,
   } from "$lib/trips/trip.js";
+  import { photoTelemetry } from "$lib/trips/telemetry.js";
 
   let { data } = $props();
 
@@ -25,9 +27,9 @@
   const dayStats = $derived(day ? { ...day, photoCount: photos.length } : null);
   const series = $derived(day ? elevationSeries(day.points, 120) : []);
 
-  // Scrubber state: the index of the "current" photo. The map highlights and
-  // centers this photo, the elevation cursor tracks its route position, and the
-  // right-hand panel shows it at display size. Clamped to the photo count.
+  // Scrubber state: the index of the "current" photo. The photo is the dominant
+  // element; the map highlights and centers it, the elevation cursor tracks its
+  // route position, and the telemetry panel shows its per-photo readouts.
   let current = $state(0);
 
   // Reset to the first photo whenever the day changes (SvelteKit reuses this
@@ -42,6 +44,20 @@
   });
 
   const photo = $derived(photos[current] ?? null);
+
+  // Per-photo telemetry (position/elev interpolated from the GPS track when the
+  // photo lacks a fix, plus bearing, cumulative km, EV and solar context).
+  const telemetry = $derived(
+    photo ? photoTelemetry(photo, day?.points ?? [], trip?.tz) : null,
+  );
+
+  // Interpolated coordinates for the map's current-photo marker, so it still
+  // tracks photos that lack their own GPS fix.
+  const currentCoords = $derived(
+    telemetry && telemetry.lat != null && telemetry.lng != null
+      ? [telemetry.lng, telemetry.lat]
+      : null,
+  );
 
   function step(delta) {
     if (!photos.length) return;
@@ -59,20 +75,28 @@
     return idx / (day.points.length - 1);
   });
 
-  function fmtTime(iso) {
-    if (!iso) return "";
-    try {
-      return new Date(iso).toLocaleString("en-CA", {
-        timeZone: trip?.tz || "UTC",
-        month: "short",
-        day: "numeric",
-        hour: "2-digit",
-        minute: "2-digit",
-      });
-    } catch {
-      return "";
+  // Warm the browser/CDN cache for the neighbouring photos so arrow-stepping
+  // shows the next image instantly. Pre-signed `imgDisplay` URLs are already in
+  // the SSR payload, so this just kicks off background GETs via new Image(); it
+  // never blocks render. Browser-only (Image is undefined during SSR).
+  $effect(() => {
+    const i = current;
+    if (typeof Image === "undefined" || !photos.length) return;
+    const preloaders = [];
+    for (const delta of [1, -1, 2, -2]) {
+      const neighbor = photos[i + delta];
+      if (neighbor?.imgDisplay) {
+        const img = new Image();
+        img.src = neighbor.imgDisplay;
+        preloaders.push(img);
+      }
     }
-  }
+    // Drop references on change/teardown so the GC can reclaim them once the
+    // browser cache is warm (no listeners are attached, so nothing leaks).
+    return () => {
+      preloaders.length = 0;
+    };
+  });
 
   // Arrow keys step through photos. No scroll-jacking: keyboard + buttons only.
   $effect(() => {
@@ -102,25 +126,7 @@
     <DayNav slug={trip.slug} {dayNumber} {totalDays} {label} dayColor={color} />
 
     <div class="scrubber">
-      <section class="map-box" aria-label="Day route map">
-        <DayMap
-          points={day.points}
-          {photos}
-          dayColor={color}
-          {current}
-          onPhotoClick={(i) => (current = i)}
-        />
-      </section>
-
-      <section class="stats-box">
-        <p class="eyebrow">Day stats</p>
-        <DayStats stats={dayStats} dayColor={color} />
-      </section>
-
       <section class="photo-box" style={`--day:${color}`}>
-        <p class="eyebrow">
-          Photo {photos.length ? current + 1 : 0} / {photos.length}
-        </p>
         {#if photo}
           <figure class="frame">
             <img
@@ -128,14 +134,6 @@
               alt={`Photo ${current + 1} of ${photos.length}`}
               decoding="async"
             />
-            <figcaption>
-              {#if photo.taken_at}<span>{fmtTime(photo.taken_at)}</span>{/if}
-              {#if photo.focal_length_35mm}<span>{photo.focal_length_35mm}mm</span>{/if}
-              {#if photo.aperture}<span>&fnof;/{photo.aperture}</span>{/if}
-              {#if photo.iso}<span>ISO {photo.iso}</span>{/if}
-              {#if photo.shutter_speed}<span>{photo.shutter_speed}</span>{/if}
-              {#if photo.elevation != null}<span>{Math.round(photo.elevation)}m</span>{/if}
-            </figcaption>
           </figure>
           <div class="controls">
             <button
@@ -146,6 +144,7 @@
             >
               &larr; Prev
             </button>
+            <span class="counter">{photos.length ? current + 1 : 0} / {photos.length}</span>
             <button
               class="step"
               onclick={() => step(1)}
@@ -159,7 +158,30 @@
           <p class="empty">No photos for this day.</p>
         {/if}
       </section>
+
+      <section class="map-box" aria-label="Day route map">
+        <DayMap
+          points={day.points}
+          {photos}
+          dayColor={color}
+          {current}
+          {currentCoords}
+          onPhotoClick={(i) => (current = i)}
+        />
+      </section>
+
+      <section class="stats-box">
+        <p class="eyebrow">Day stats</p>
+        <DayStats stats={dayStats} dayColor={color} />
+      </section>
     </div>
+
+    {#if telemetry}
+      <section class="telem-box">
+        <p class="eyebrow">Telemetry</p>
+        <DayTelemetry t={telemetry} index={current} total={photos.length} dayColor={color} />
+      </section>
+    {/if}
 
     {#if dayStats.hasElevation}
       <section class="profile">
@@ -171,6 +193,7 @@
             {color}
             cursor={cursorFraction}
             cursorColor={color}
+            showMinMax={true}
           />
         </div>
       </section>
@@ -187,53 +210,62 @@
     color: var(--ink);
     min-height: 100vh;
   }
+  /* Photo dominates: a wide left column (2fr) holds the large image; the map and
+     day stats stack in the narrower right rail (1fr). */
   .scrubber {
     display: grid;
-    grid-template-columns: 1.1fr 0.9fr 1.3fr;
-    grid-template-areas: "map stats photo";
+    grid-template-columns: 2fr 1fr;
+    grid-template-areas:
+      "photo map"
+      "photo stats";
     gap: 20px;
     align-items: start;
+  }
+  .photo-box {
+    grid-area: photo;
   }
   .map-box {
     grid-area: map;
     border: 2px solid var(--ink);
-    height: 420px;
+    height: 320px;
   }
   .stats-box {
     grid-area: stats;
-  }
-  .photo-box {
-    grid-area: photo;
   }
   .frame {
     margin: 0;
     border: 2px solid var(--ink);
     background: var(--ink);
-    display: flex;
-    flex-direction: column;
+    display: block;
   }
   .frame img {
     width: 100%;
-    max-height: 460px;
+    aspect-ratio: 16 / 9;
+    max-height: 620px;
     object-fit: contain;
     display: block;
     background: var(--ink);
   }
-  figcaption {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 6px 16px;
-    padding: 10px 12px;
-    font-family: var(--mono);
-    font-size: 11px;
-    letter-spacing: 0.04em;
-    color: var(--paper);
-    border-top: 2px solid var(--day);
-  }
   .controls {
     display: flex;
-    gap: 0;
+    align-items: stretch;
     margin-top: 12px;
+  }
+  .counter {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex: 0 0 auto;
+    padding: 0 18px;
+    font-family: var(--mono);
+    font-size: 12px;
+    font-weight: 700;
+    letter-spacing: 0.06em;
+    color: var(--ink);
+    border: 2px solid var(--ink);
+    border-left: none;
+    border-right: none;
+    background: var(--paper);
   }
   .step {
     flex: 1;
@@ -248,9 +280,6 @@
     padding: 10px 14px;
     cursor: pointer;
   }
-  .step + .step {
-    border-left: none;
-  }
   .step:hover:not(:disabled) {
     background: var(--ink);
     color: var(--paper);
@@ -258,6 +287,9 @@
   .step:disabled {
     opacity: 0.35;
     cursor: default;
+  }
+  .telem-box {
+    margin-top: 28px;
   }
   .profile {
     margin-top: 28px;
@@ -288,17 +320,21 @@
   .missing a {
     color: var(--ink);
   }
-  /* Narrow screens: stack map, photo, stats (in that order), then elevation. */
+  /* Narrow screens: stack photo, map, stats (in that order), then telemetry and
+     elevation below (both already full width). */
   @media (max-width: 900px) {
     .scrubber {
       grid-template-columns: 1fr;
       grid-template-areas:
-        "map"
         "photo"
+        "map"
         "stats";
     }
     .map-box {
-      height: 300px;
+      height: 280px;
+    }
+    .frame img {
+      max-height: 70vh;
     }
   }
 </style>


### PR DESCRIPTION
Restores the original day-view richness the scrubber was missing, plus the owner's two asks (bigger photo, smooth scrubbing).

## Changes
- **Dominant photo**: layout reworked so the current photo anchors a wide column (16:9, contain, up to 620px), with map + stats in a side rail and elevation full-width below. Responsive stack on narrow screens. Still uses the pre-signed `imgDisplay` (no new preset, no client signing).
- **Per-photo telemetry panel** (ported from the original `DataPanel`): TIME (big clock, tz), POSITION (lat/lng, GPS-interpolated from the track when a photo lacks a fix), ELEV, KM into day, BEARING (compass + arrow), OPTICS, EV (+label), SOLAR (sun altitude + label), LIGHT (time to sunset). Sun math inlined in `lib/trips/sun.js` (no new npm dep).
- **Neighbor preloading**: current +-2 `imgDisplay` warmed on selection so arrow-scrubbing is instant.
- **Stats/chart**: High Point / Low Point added to DayStats; min/max labels on the elevation chart; cursor still tracks the current photo; map marker tracks interpolated coords.
- Pure-function unit tests for the telemetry + sun helpers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)