### PR TITLE
fix(trips): exempt /img from rate limit + smooth photo transitions

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.17.1
+version: 0.17.2
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/chart/templates/httproute-public.yaml
+++ b/projects/monolith-public/chart/templates/httproute-public.yaml
@@ -27,22 +27,6 @@ spec:
           port: {{ .Values.frontend.service.port | int }}
       timeouts:
         request: 60s
-    # /img/ -> imgproxy. This is a DELIBERATE, narrow exception to the otherwise
-    # frontend-only routing: imgproxy is read-only and tightly locked down
-    # (IMGPROXY_ALLOWED_SOURCES pins it to the monolith-trips bucket,
-    # IMGPROXY_ONLY_PRESETS caps it to the named resize presets), so exposing it
-    # same-origin replaces the old img.jomcgi.dev tunnel without widening the
-    # attack surface. No URLRewrite: imgproxy serves under /img via
-    # IMGPROXY_PATH_PREFIX, so the /img prefix is forwarded as-is.
-    - matches:
-        - path:
-            type: PathPrefix
-            value: /img/
-      backendRefs:
-        - name: {{ include "monolith-public.fullname" . }}-imgproxy
-          port: {{ .Values.imgproxy.service.port | int }}
-      timeouts:
-        request: 60s
     # NO /api rule: the public backend is never internet-reachable. Every
     # backend read is server-side (SSR +page.server.js or a frontend +server.js
     # proxy, e.g. /notes/body/<id>, ships/stars heat/track), so the browser only
@@ -58,6 +42,40 @@ spec:
       backendRefs:
         - name: {{ include "monolith-public.fullname" . }}-frontend
           port: {{ .Values.frontend.service.port | int }}
+      timeouts:
+        request: 60s
+---
+# /img/ -> imgproxy on its OWN HTTPRoute, deliberately SEPARATE from the route
+# above so the rate-limit BackendTrafficPolicy (which targets -public) does NOT
+# apply to image serving. A single trip day legitimately loads hundreds of
+# photos (the scrubber also preloads the whole day), which would trip the
+# page-level 100 req/min limit (local_rate_limited). Images are safe to leave
+# unlimited: imgproxy is read-only, signed (IMGPROXY_KEY), bucket-locked
+# (ALLOWED_SOURCES=monolith-trips) and preset-capped (ONLY_PRESETS), and almost
+# all requests are served from the Cloudflare 1-year immutable cache, never
+# reaching origin. No URLRewrite: imgproxy serves under /img via
+# IMGPROXY_PATH_PREFIX, so the /img prefix is forwarded as-is.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "monolith-public.fullname" . }}-img
+  labels:
+    ingress-tier: {{ .Values.cfIngress.public.tier }}
+    {{- include "monolith-public.labels" . | nindent 4 }}
+spec:
+  parentRefs:
+    - name: {{ .Values.cfIngress.public.gateway.name }}
+      namespace: {{ .Values.cfIngress.public.gateway.namespace }}
+  hostnames:
+    - {{ .Values.cfIngress.public.hostname | quote }}
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /img/
+      backendRefs:
+        - name: {{ include "monolith-public.fullname" . }}-imgproxy
+          port: {{ .Values.imgproxy.service.port | int }}
       timeouts:
         request: 60s
 ---

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.17.1
+      targetRevision: 0.17.2
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.173.1
+version: 0.173.2
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.173.1
+      targetRevision: 0.173.2
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/routes/public/app/trips/[slug]/day/[day]/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/trips/[slug]/day/[day]/+page.svelte
@@ -43,6 +43,35 @@
 
   const photo = $derived(photos[current] ?? null);
 
+  // Smooth scrubbing: keep the CURRENT frame on screen until the next image has
+  // actually decoded (instant when it was preloaded), so the photo never flashes
+  // its black cell background between shots while an arrow is held down. Only the
+  // latest target wins, so rapid stepping settles on the right frame.
+  let displayedSrc = $state(photos[current]?.imgDisplay ?? null);
+  $effect(() => {
+    const target = photo?.imgDisplay ?? null;
+    if (!target) {
+      displayedSrc = null;
+      return;
+    }
+    if (typeof Image === "undefined") {
+      displayedSrc = target; // SSR: render the URL directly
+      return;
+    }
+    let cancelled = false;
+    const swap = () => {
+      if (!cancelled) displayedSrc = target;
+    };
+    const img = new Image();
+    img.src = target;
+    if (img.complete) swap();
+    else if (img.decode) img.decode().then(swap).catch(swap);
+    else img.onload = swap;
+    return () => {
+      cancelled = true;
+    };
+  });
+
   // Per-photo telemetry (position/elev interpolated from the GPS track when the
   // photo lacks a fix, plus bearing, cumulative km, EV and solar context).
   const telemetry = $derived(
@@ -148,7 +177,7 @@
       <figure class="photo">
         {#if photo}
           <img
-            src={photo.imgDisplay}
+            src={displayedSrc}
             alt={`Photo ${current + 1} of ${photos.length}`}
             decoding="async"
           />


### PR DESCRIPTION
Two scrubbing fixes.

- **Rate limit**: the public HTTPRoute is rate-limited to 100 req/min, which the image preloader (and even a normal photo-heavy day) trips with `local_rate_limited`. Moved `/img/` to its own HTTPRoute so the rate-limit BackendTrafficPolicy (targets `-public`) no longer applies. Images stay safe unlimited (signed + bucket-locked + preset-capped + 1yr CDN cache).
- **Black flash**: the photo now keeps the current frame until the next image has decoded (instant when preloaded), so holding an arrow to scrub no longer flashes the black photo cell.

monolith-public 0.17.1 -> 0.17.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)