### PR TITLE
feat(trips): reproduce the original day-view layout + map 1:1

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.17.2
+version: 0.18.0
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.17.2
+      targetRevision: 0.18.0
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.173.2
+version: 0.174.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.173.2
+      targetRevision: 0.174.0
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/lib/public/components/trips/DayElevationProfile.svelte
+++ b/projects/monolith/frontend/src/lib/public/components/trips/DayElevationProfile.svelte
@@ -1,0 +1,111 @@
+<script>
+  // Day-view elevation sparkline, a faithful port of the original React
+  // ElevationSparkline (fillHeight mode): a thin polyline profile that
+  // x-stretches to fill its cell, with ↓min / ↑max labels, a baseline, and a
+  // round position marker dot pinned to the current photo's progress along the
+  // route. The marker is an absolutely positioned div (a true circle) rather than
+  // an SVG node, since the viewBox is x-stretched (preserveAspectRatio="none").
+  //
+  // `data` is the sampled elevation array; `currentIndex` is the marker's index
+  // into it; `accentColor` tints the marker (the day colour).
+  let { data = [], currentIndex = 0, accentColor = "#dc2626" } = $props();
+
+  const min = $derived(data.length ? Math.min(...data) : 0);
+  const max = $derived(data.length ? Math.max(...data) : 1);
+  const range = $derived(max - min || 1);
+
+  // Normalised 0..100 viewBox (height 100), matching the original formula:
+  // y = 100 - ((val - min) / range) * (100 - 4) - 2.
+  const points = $derived(
+    data
+      .map((val, i) => {
+        const x = data.length > 1 ? (i / (data.length - 1)) * 100 : 0;
+        const y = 100 - ((val - min) / range) * 96 - 2;
+        return `${x},${y}`;
+      })
+      .join(" "),
+  );
+
+  const markerLeftPercent = $derived(
+    data.length > 1 ? (currentIndex / (data.length - 1)) * 100 : 50,
+  );
+  const markerTopPercent = $derived(
+    data[currentIndex] != null
+      ? 100 - ((data[currentIndex] - min) / range) * 96 - 2
+      : 50,
+  );
+</script>
+
+{#if data.length}
+  <div class="wrap">
+    <div class="minmax">
+      <span>&darr; {Math.round(min)}m</span>
+      <span>&uarr; {Math.round(max)}m</span>
+    </div>
+    <div class="svgbox">
+      <svg
+        width="100%"
+        height="100%"
+        viewBox="0 0 100 100"
+        preserveAspectRatio="none"
+        style="display:block;position:absolute;inset:0"
+        aria-hidden="true"
+      >
+        <line
+          x1="0"
+          y1="99"
+          x2="100"
+          y2="99"
+          stroke="#e5e7eb"
+          stroke-width="1"
+          vector-effect="non-scaling-stroke"
+        />
+        <polyline
+          {points}
+          fill="none"
+          stroke="#1a1a1a"
+          stroke-width="2.5"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          vector-effect="non-scaling-stroke"
+        />
+      </svg>
+      <div
+        class="marker"
+        style={`left:${markerLeftPercent}%;top:${markerTopPercent}%;background:${accentColor}`}
+      ></div>
+    </div>
+  </div>
+{/if}
+
+<style>
+  .wrap {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    flex-direction: column;
+  }
+  .minmax {
+    display: flex;
+    justify-content: space-between;
+    margin-bottom: 4px;
+    font-family: monospace;
+    font-size: 9px;
+    font-weight: 600;
+    color: #9ca3af; /* nosemgrep: svelte-hardcoded-color-in-style */
+  }
+  .svgbox {
+    flex-grow: 1;
+    position: relative;
+    min-height: 0;
+  }
+  .marker {
+    position: absolute;
+    transform: translate(-50%, -50%);
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    border: 2px solid white;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
+  }
+</style>

--- a/projects/monolith/frontend/src/lib/public/components/trips/DayMap.svelte
+++ b/projects/monolith/frontend/src/lib/public/components/trips/DayMap.svelte
@@ -2,36 +2,38 @@
   import { onMount } from "svelte";
   import "maplibre-gl/dist/maplibre-gl.css";
 
-  // Single-day route map: the day's GPS line plus a circle layer marking each
-  // photo location. Interactive (pan/zoom). Follows the ShipsMap pattern
-  // (lazy maplibre import, GeoJSON sources + layers).
+  // Single-day route map, a faithful port of the original React DayMap. The
+  // whole container is CSS `invert(1)`ed so the light Carto Positron basemap
+  // reads as a dark map: every colour drawn into it is pre-inverted so it shows
+  // correctly after the filter (a black line draws as white, the day colour is
+  // inverted, etc). Layers, in z-order: a thick `route-line` (black -> white),
+  // a thin `route-color-accent` (inverted day colour) down its centre, and a
+  // wide transparent `route-hit-area` for click-to-select. DOM markers mark the
+  // start, end and the current photo (a square). A sun-lit terrain hillshade
+  // sits under the basemap, relit from the photo-time sun azimuth/altitude.
   //
-  // `current` is the scrubber's selected photo index: the matching marker is
-  // highlighted (a larger ring on the `day-photo-current` layer) and the map
-  // eases to its coordinates. Clicking any marker calls onPhotoClick(i) so the
-  // page can set `current`.
-  //
-  // `currentCoords` (optional) is the [lng, lat] for the current photo with the
-  // page's GPS interpolation already applied, so the highlight marker tracks
-  // photos that lack their own fix. Falls back to the photo's raw coordinates.
-  //
-  // Note: the old React DayMap also drove a terrain hillshade lit from the sun
-  // position at the photo's timestamp; that relighting needs a raster-DEM
-  // terrain source and is out of scope here. The solar/bearing readouts live in
-  // the telemetry panel instead.
+  // `currentCoords` ([lng, lat] or null) is the current photo's location with the
+  // page's GPS interpolation already applied, so the square marker tracks photos
+  // that lack their own fix. `sunPosition` ({ altitude, azimuth } in radians)
+  // drives the hillshade relighting. `onLocationClick(takenAtIso)` fires with the
+  // nearest route point's capture time when the route is clicked; the page maps
+  // that to the closest photo.
   let {
     points = [],
-    photos = [],
     dayColor = "#2563eb",
-    current = 0,
+    height = "280px",
     currentCoords = null,
-    onPhotoClick,
+    sunPosition = null,
+    onLocationClick,
   } = $props();
 
-  const BASEMAP_STYLE = "https://tiles.openfreemap.org/styles/liberty";
+  const BASEMAP_STYLE =
+    "https://basemaps.cartocdn.com/gl/positron-gl-style/style.json";
 
   let mapContainer;
   let map = null;
+  let maplibre = null;
+  let photoMarker = null;
   let mapReady = $state(false);
 
   function geoPoints() {
@@ -49,37 +51,139 @@
     ];
   }
 
-  // Coordinates of the photo at index `i`, or null if it has no GPS fix.
-  function photoCoords(i) {
-    const p = photos[i];
-    if (!p || p.lat == null || p.lng == null) return null;
-    return [p.lng, p.lat];
+  // Invert a #rrggbb so it displays as the intended colour after the container's
+  // CSS invert(1). Returns an rgb() string.
+  function invertColor(hex) {
+    const r = 255 - parseInt(hex.slice(1, 3), 16);
+    const g = 255 - parseInt(hex.slice(3, 5), 16);
+    const b = 255 - parseInt(hex.slice(5, 7), 16);
+    return `rgb(${r}, ${g}, ${b})`;
   }
 
-  // Keep the highlight layer + camera in sync with the scrubber's `current`.
-  // Guarded on mapReady so it no-ops until the sources/layers exist. Prefers the
-  // page's interpolated `currentCoords` so the marker tracks fix-less photos.
-  $effect(() => {
-    const i = current;
-    const interp = currentCoords;
-    if (!mapReady || !map) return;
-    const coords = interp ?? photoCoords(i);
-    const src = map.getSource("day-photo-current");
-    if (src) {
-      src.setData({
-        type: "FeatureCollection",
-        features: coords
-          ? [
-              {
-                type: "Feature",
-                properties: { photoIndex: i },
-                geometry: { type: "Point", coordinates: coords },
-              },
-            ]
-          : [],
-      });
+  // Drop points within ~20m of the previous one (multiple GPS sources stack
+  // duplicates that thicken the rendered line).
+  function dedupePoints(pts) {
+    if (!pts.length) return [];
+    const result = [pts[0]];
+    for (let i = 1; i < pts.length; i++) {
+      const prev = result[result.length - 1];
+      const curr = pts[i];
+      const dlat = Math.abs(curr.lat - prev.lat);
+      const dlng = Math.abs(curr.lng - prev.lng);
+      if (dlat > 0.0002 || dlng > 0.0002) result.push(curr);
     }
-    if (coords) map.easeTo({ center: coords, duration: 500 });
+    return result;
+  }
+
+  // --- hillshade relighting from the sun ---
+  // SunCalc azimuth is radians from south, positive west; MapLibre's
+  // illumination-direction is degrees from north.
+  function illuminationDirection(sun) {
+    if (!sun) return 315;
+    const azimuthDeg = (sun.azimuth * 180) / Math.PI + 180;
+    return ((azimuthDeg % 360) + 360) % 360;
+  }
+
+  function sunIntensity(sun) {
+    if (!sun) {
+      return {
+        exaggeration: 0.8,
+        shadowColor: "#cccccc",
+        highlightColor: "#000000",
+      };
+    }
+    const altitudeDeg = (sun.altitude * 180) / Math.PI;
+    const lerp = (a, b, t) => a + (b - a) * Math.max(0, Math.min(1, t));
+    const lerpColor = (c1, c2, t) => {
+      const r1 = parseInt(c1.slice(1, 3), 16),
+        g1 = parseInt(c1.slice(3, 5), 16),
+        b1 = parseInt(c1.slice(5, 7), 16);
+      const r2 = parseInt(c2.slice(1, 3), 16),
+        g2 = parseInt(c2.slice(3, 5), 16),
+        b2 = parseInt(c2.slice(5, 7), 16);
+      const r = Math.round(lerp(r1, r2, t)),
+        g = Math.round(lerp(g1, g2, t)),
+        b = Math.round(lerp(b1, b2, t));
+      return `#${r.toString(16).padStart(2, "0")}${g.toString(16).padStart(2, "0")}${b.toString(16).padStart(2, "0")}`;
+    };
+    const t = (altitudeDeg + 12) / 27;
+    let exaggeration;
+    if (altitudeDeg < -6) {
+      exaggeration = lerp(0.2, 0.5, (altitudeDeg + 12) / 6);
+    } else if (altitudeDeg < 5) {
+      exaggeration = lerp(0.5, 1.0, (altitudeDeg + 6) / 11);
+    } else {
+      exaggeration = 1.0;
+    }
+    const shadowColor = lerpColor("#222222", "#ffffff", t);
+    const highlightColor = lerpColor("#111111", "#000000", t);
+    return { exaggeration, shadowColor, highlightColor };
+  }
+
+  // Reposition + recentre on the current photo. The square marker eases over
+  // 300ms (ease-out-cubic), and the camera eases to zoom 10, matching the
+  // original. Guarded on mapReady so it no-ops until the marker can be created.
+  $effect(() => {
+    const coords = currentCoords;
+    if (!mapReady || !map || !maplibre) return;
+    if (coords) {
+      if (photoMarker) {
+        const start = photoMarker.getLngLat();
+        const startTime = performance.now();
+        const duration = 300;
+        const animate = (now) => {
+          const t = Math.min((now - startTime) / duration, 1);
+          const eased = 1 - Math.pow(1 - t, 3);
+          const lng = start.lng + (coords[0] - start.lng) * eased;
+          const lat = start.lat + (coords[1] - start.lat) * eased;
+          photoMarker.setLngLat([lng, lat]);
+          if (t < 1) requestAnimationFrame(animate);
+        };
+        requestAnimationFrame(animate);
+      } else {
+        const el = document.createElement("div");
+        el.style.cssText = `width:24px;height:24px;background:${invertColor(dayColor)};border:3px solid black;cursor:pointer;`;
+        photoMarker = new maplibre.Marker({ element: el })
+          .setLngLat(coords)
+          .addTo(map);
+      }
+      map.easeTo({
+        center: coords,
+        zoom: 10,
+        duration: 300,
+        easing: (t) => 1 - Math.pow(1 - t, 3),
+      });
+    } else if (photoMarker) {
+      photoMarker.remove();
+      photoMarker = null;
+    }
+  });
+
+  // Relight the hillshade when the sun position changes.
+  $effect(() => {
+    const sun = sunPosition;
+    if (!mapReady || !map || !map.getLayer("hillshade")) return;
+    const intensity = sunIntensity(sun);
+    map.setPaintProperty(
+      "hillshade",
+      "hillshade-illumination-direction",
+      illuminationDirection(sun),
+    );
+    map.setPaintProperty(
+      "hillshade",
+      "hillshade-exaggeration",
+      intensity.exaggeration,
+    );
+    map.setPaintProperty(
+      "hillshade",
+      "hillshade-shadow-color",
+      intensity.shadowColor,
+    );
+    map.setPaintProperty(
+      "hillshade",
+      "hillshade-highlight-color",
+      intensity.highlightColor,
+    );
   });
 
   onMount(() => {
@@ -87,104 +191,154 @@
     let cleanup = () => {};
 
     (async () => {
-      const maplibregl = (await import("maplibre-gl")).default;
+      maplibre = (await import("maplibre-gl")).default;
       if (destroyed) return;
 
       const b = bounds();
-      map = new maplibregl.Map({
+      map = new maplibre.Map({
         container: mapContainer,
         style: BASEMAP_STYLE,
-        ...(b ? { bounds: b, fitBoundsOptions: { padding: 50 } } : { center: [0, 30], zoom: 1.4 }),
-        attributionControl: { compact: true },
+        ...(b
+          ? { bounds: b, fitBoundsOptions: { padding: 50 } }
+          : { center: [0, 30], zoom: 1.4 }),
         dragRotate: false,
-        touchZoomRotate: false,
+        attributionControl: false,
       });
-      map.addControl(new maplibregl.NavigationControl({ showCompass: false }), "top-right");
+      map.addControl(
+        new maplibre.NavigationControl({ showCompass: false }),
+        "top-right",
+      );
 
       map.on("load", () => {
-        const coords = geoPoints().map((p) => [p.lng, p.lat]);
-        if (coords.length >= 2) {
-          map.addSource("day-route", {
+        // Terrain hillshade, lit from the photo-time sun, under the basemap.
+        map.addSource("terrain-dem", {
+          type: "raster-dem",
+          tiles: [
+            "https://s3.amazonaws.com/elevation-tiles-prod/terrarium/{z}/{x}/{y}.png",
+          ],
+          encoding: "terrarium",
+          tileSize: 256,
+          maxzoom: 15,
+        });
+        const firstSymbol = map
+          .getStyle()
+          .layers.find((l) => l.type === "symbol");
+        const intensity = sunIntensity(sunPosition);
+        map.addLayer(
+          {
+            id: "hillshade",
+            type: "hillshade",
+            source: "terrain-dem",
+            minzoom: 0,
+            maxzoom: 22,
+            paint: {
+              "hillshade-exaggeration": intensity.exaggeration,
+              "hillshade-shadow-color": intensity.shadowColor,
+              "hillshade-highlight-color": intensity.highlightColor,
+              "hillshade-accent-color": "#000000",
+              "hillshade-illumination-direction":
+                illuminationDirection(sunPosition),
+            },
+          },
+          firstSymbol?.id,
+        );
+
+        const routePoints = dedupePoints(geoPoints());
+        const coordinates = routePoints.map((p) => [p.lng, p.lat]);
+        if (coordinates.length >= 2) {
+          map.addSource("route", {
             type: "geojson",
             data: {
               type: "Feature",
-              properties: {},
-              geometry: { type: "LineString", coordinates: coords },
+              geometry: { type: "LineString", coordinates },
             },
           });
+          // Thick black line: inverts to a clean white route.
           map.addLayer({
-            id: "day-route",
+            id: "route-line",
             type: "line",
-            source: "day-route",
+            source: "route",
             layout: { "line-join": "round", "line-cap": "round" },
-            paint: { "line-color": dayColor, "line-width": 4, "line-opacity": 1 },
+            paint: { "line-color": "#000000", "line-width": 7, "line-opacity": 1 },
           });
-        }
-
-        // Carry each photo's index in the `photos` array so a marker click can
-        // set that exact photo as the scrubber's current index. `photos` is the
-        // same array the scrubber/elevation use, so the indices line up.
-        const photoFeatures = photos
-          .map((p, i) => ({ p, i }))
-          .filter(({ p }) => p.lat != null && p.lng != null)
-          .map(({ p, i }) => ({
-            type: "Feature",
-            properties: { photoIndex: i },
-            geometry: { type: "Point", coordinates: [p.lng, p.lat] },
-          }));
-        if (photoFeatures.length) {
-          map.addSource("day-photos", {
-            type: "geojson",
-            data: { type: "FeatureCollection", features: photoFeatures },
-          });
+          // Thin inverted-day-colour accent down the centre.
           map.addLayer({
-            id: "day-photos",
-            type: "circle",
-            source: "day-photos",
+            id: "route-color-accent",
+            type: "line",
+            source: "route",
+            layout: { "line-join": "round", "line-cap": "round" },
             paint: {
-              "circle-radius": 5,
-              "circle-color": dayColor,
-              "circle-stroke-color": "#ffffff",
-              "circle-stroke-width": 2,
+              "line-color": invertColor(dayColor),
+              "line-width": 1.5,
+              "line-opacity": 1,
             },
           });
-
-          // Highlight layer for the current photo: a larger ring drawn on top of
-          // the base markers. Driven by the $effect above via its own source.
-          map.addSource("day-photo-current", {
-            type: "geojson",
-            data: { type: "FeatureCollection", features: [] },
-          });
+          // Wide transparent hit area for easier clicking.
           map.addLayer({
-            id: "day-photo-current",
-            type: "circle",
-            source: "day-photo-current",
-            paint: {
-              "circle-radius": 9,
-              "circle-color": dayColor,
-              "circle-stroke-color": "#ffffff",
-              "circle-stroke-width": 3,
-            },
+            id: "route-hit-area",
+            type: "line",
+            source: "route",
+            layout: { "line-join": "round", "line-cap": "round" },
+            paint: { "line-color": "transparent", "line-width": 20, "line-opacity": 0 },
           });
 
-          map.on("click", "day-photos", (e) => {
-            const i = e.features?.[0]?.properties?.photoIndex;
-            if (i != null) onPhotoClick?.(i);
-          });
-          map.on("mouseenter", "day-photos", () => {
-            map.getCanvas().style.cursor = "pointer";
-          });
-          map.on("mouseleave", "day-photos", () => {
-            map.getCanvas().style.cursor = "";
-          });
+          if (onLocationClick) {
+            map.on("mouseenter", "route-hit-area", () => {
+              map.getCanvas().style.cursor = "pointer";
+            });
+            map.on("mouseleave", "route-hit-area", () => {
+              map.getCanvas().style.cursor = "";
+            });
+            map.on("click", "route-hit-area", (e) => {
+              const { lng: clickLng, lat: clickLat } = e.lngLat;
+              let minDist = Infinity;
+              let closest = null;
+              for (const p of points) {
+                if (p.lat == null || p.lng == null || !p.taken_at) continue;
+                const dist =
+                  Math.pow(p.lng - clickLng, 2) + Math.pow(p.lat - clickLat, 2);
+                if (dist < minDist) {
+                  minDist = dist;
+                  closest = p;
+                }
+              }
+              if (closest?.taken_at) onLocationClick(closest.taken_at);
+            });
+          }
         }
 
-        // Signal the $effect that sources/layers exist; it then renders the
-        // initial highlight + centers on the current photo.
+        // Start / end DOM markers (inverted: black draws white, white draws
+        // black). The square current-photo marker is created by the $effect.
+        const pts = geoPoints();
+        if (pts.length > 0) {
+          const startEl = document.createElement("div");
+          startEl.style.cssText =
+            "width:16px;height:16px;background:#000000;border:3px solid #ffffff;border-radius:50%;"; /* nosemgrep: svelte-hardcoded-color-in-style */
+          new maplibre.Marker({ element: startEl })
+            .setLngLat([pts[0].lng, pts[0].lat])
+            .addTo(map);
+
+          const last = pts[pts.length - 1];
+          const distance = Math.sqrt(
+            Math.pow(last.lng - pts[0].lng, 2) +
+              Math.pow(last.lat - pts[0].lat, 2),
+          );
+          if (distance > 0.01) {
+            const endEl = document.createElement("div");
+            endEl.style.cssText =
+              "width:14px;height:14px;background:#ffffff;border:3px solid #000000;border-radius:50%;"; /* nosemgrep: svelte-hardcoded-color-in-style */
+            new maplibre.Marker({ element: endEl })
+              .setLngLat([last.lng, last.lat])
+              .addTo(map);
+          }
+        }
+
         mapReady = true;
       });
 
       cleanup = () => {
+        photoMarker?.remove();
+        photoMarker = null;
         map?.remove();
         map = null;
         mapReady = false;
@@ -198,16 +352,14 @@
   });
 </script>
 
-<div class="map" bind:this={mapContainer}></div>
+<div class="map" style={`height:${height}`} bind:this={mapContainer}></div>
 
 <style>
+  /* The whole map is inverted so the light Carto basemap reads dark; every
+     colour drawn into it is pre-inverted to compensate. */
   .map {
     width: 100%;
-    height: 100%;
-    min-height: 200px;
-  }
-  .map :global(.maplibregl-ctrl-attrib-inner) {
-    font-family: var(--mono);
-    font-size: 10px;
+    overflow: hidden;
+    filter: invert(1);
   }
 </style>

--- a/projects/monolith/frontend/src/lib/public/components/trips/DayNav.svelte
+++ b/projects/monolith/frontend/src/lib/public/components/trips/DayNav.svelte
@@ -1,31 +1,96 @@
 <script>
-  // Per-day navigation header: back to the trip summary, prev/next day, and the
-  // day label + colour swatch.
-  let { slug, dayNumber, totalDays, label, dayColor = "var(--ink)" } = $props();
+  // Per-day navigation header, a faithful port of the original React
+  // DayNavigation: Summary link on the left, the day eyebrow + colour-underlined
+  // title centred, prev/next day buttons on the right. Buttons invert on hover;
+  // unavailable prev/next render as dimmed, non-interactive spans. `date` is the
+  // already-formatted day date (e.g. "Sep 15, 2024").
+  let {
+    slug,
+    dayNumber,
+    totalDays,
+    label,
+    dayColor = "#1a1a1a",
+    date = "",
+  } = $props();
 
   const hasPrev = $derived(dayNumber > 1);
   const hasNext = $derived(dayNumber < totalDays);
 </script>
 
-<nav class="daynav" style={`--day:${dayColor}`} aria-label="Day navigation">
-  <a class="back" href={`/app/trips/${slug}`}>&larr; Summary</a>
+<nav class="daynav" aria-label="Day navigation">
+  <a class="navbtn" href={`/app/trips/${slug}`}>
+    <svg
+      class="chev"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      aria-hidden="true"><polyline points="15 18 9 12 15 6" /></svg>
+    <span>Summary</span>
+  </a>
 
   <div class="title">
-    <span class="swatch" aria-hidden="true"></span>
-    <span class="label">{label}</span>
-    <span class="count">Day {dayNumber} / {totalDays}</span>
+    <div class="eyebrow">
+      Day {dayNumber} of {totalDays}{#if date}<span class="date">{date}</span>{/if}
+    </div>
+    <div class="label" style={`border-bottom:3px solid ${dayColor}`}>{label}</div>
   </div>
 
   <div class="arrows">
     {#if hasPrev}
-      <a class="arrow" href={`/app/trips/${slug}/day/${dayNumber - 1}`} aria-label="Previous day">&larr;</a>
+      <a class="navbtn" href={`/app/trips/${slug}/day/${dayNumber - 1}`}>
+        <svg
+          class="chev"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          aria-hidden="true"><polyline points="15 18 9 12 15 6" /></svg>
+        <span>Prev</span>
+      </a>
     {:else}
-      <span class="arrow disabled" aria-hidden="true">&larr;</span>
+      <span class="navbtn disabled" aria-hidden="true">
+        <svg
+          class="chev"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"><polyline points="15 18 9 12 15 6" /></svg>
+        <span>Prev</span>
+      </span>
     {/if}
+
     {#if hasNext}
-      <a class="arrow" href={`/app/trips/${slug}/day/${dayNumber + 1}`} aria-label="Next day">&rarr;</a>
+      <a class="navbtn" href={`/app/trips/${slug}/day/${dayNumber + 1}`}>
+        <span>Next</span>
+        <svg
+          class="chev"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          aria-hidden="true"><polyline points="9 18 15 12 9 6" /></svg>
+      </a>
     {:else}
-      <span class="arrow disabled" aria-hidden="true">&rarr;</span>
+      <span class="navbtn disabled" aria-hidden="true">
+        <span>Next</span>
+        <svg
+          class="chev"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"><polyline points="9 18 15 12 9 6" /></svg>
+      </span>
     {/if}
   </div>
 </nav>
@@ -33,83 +98,91 @@
 <style>
   .daynav {
     display: flex;
-    align-items: center;
     justify-content: space-between;
-    gap: 12px 20px;
-    flex-wrap: wrap;
-    padding-bottom: 14px;
-    margin-bottom: 20px;
-    border-bottom: 2px solid var(--ink);
+    align-items: center;
+    gap: 20px;
+    padding: 20px 0;
+    border-bottom: 2px solid #1a1a1a;
+    margin-bottom: 24px;
   }
-  .back {
-    font-family: var(--mono);
-    font-size: 11px;
-    font-weight: 700;
-    letter-spacing: 0.06em;
-    text-transform: uppercase;
-    color: var(--ink);
-    text-decoration: none;
-    border: 2px solid var(--ink);
-    background: var(--paper);
-    padding: 8px 12px;
-    transition:
-      transform 110ms ease,
-      box-shadow 110ms ease;
-  }
-  .back:hover {
-    transform: translate(-2px, -2px);
-    box-shadow: 2px 2px 0 var(--ink);
-  }
-  .title {
+
+  .navbtn {
     display: flex;
     align-items: center;
-    gap: 10px;
-    min-width: 0;
+    gap: 4px;
+    padding: 8px 14px;
+    font-family: system-ui, -apple-system, sans-serif;
+    font-size: 13px;
+    font-weight: 600;
+    color: #1a1a1a; /* nosemgrep: svelte-hardcoded-color-in-style */
+    background: white;
+    border: 2px solid #1a1a1a;
+    text-decoration: none;
+    cursor: pointer;
+    transition:
+      background 0.15s,
+      color 0.15s;
   }
-  .swatch {
-    width: 14px;
-    height: 14px;
-    background: var(--day);
-    border: 2px solid var(--ink);
+  a.navbtn:hover {
+    background: #1a1a1a; /* nosemgrep: svelte-hardcoded-color-in-style */
+    color: white;
+  }
+  .navbtn.disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+    pointer-events: none;
+  }
+  .chev {
+    width: 16px;
+    height: 16px;
     flex: none;
   }
+
+  .title {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 4px;
+    flex: 1;
+    text-align: center;
+    min-width: 0;
+  }
+  .eyebrow {
+    font-family: monospace;
+    font-size: 11px;
+    font-weight: 500;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    color: #9ca3af; /* nosemgrep: svelte-hardcoded-color-in-style */
+  }
+  .date {
+    margin-left: 8px;
+  }
   .label {
-    font-family: var(--mono);
-    font-size: 14px;
+    font-family: system-ui, -apple-system, sans-serif;
+    font-size: 18px;
     font-weight: 700;
-    letter-spacing: 0.04em;
-    text-transform: uppercase;
-    color: var(--ink);
+    color: #1a1a1a; /* nosemgrep: svelte-hardcoded-color-in-style */
+    padding-bottom: 4px;
+    letter-spacing: 0.02em;
   }
-  .count {
-    font-family: var(--mono);
-    font-size: 10px;
-    font-weight: 700;
-    letter-spacing: 0.08em;
-    color: var(--ink-3);
-    text-transform: uppercase;
-  }
+
   .arrows {
-    display: inline-flex;
+    display: flex;
+    gap: 8px;
+    justify-content: flex-end;
   }
-  .arrow {
-    font-family: var(--mono);
-    font-size: 16px;
-    font-weight: 700;
-    color: var(--ink);
-    text-decoration: none;
-    border: 2px solid var(--ink);
-    background: var(--paper);
-    padding: 6px 14px;
-  }
-  .arrow + .arrow {
-    border-left: none;
-  }
-  .arrow.disabled {
-    opacity: 0.3;
-  }
-  a.arrow:hover {
-    background: var(--ink);
-    color: var(--paper);
+
+  @media (max-width: 768px) {
+    .daynav {
+      flex-direction: column;
+      align-items: stretch;
+      gap: 16px;
+      padding: 16px 0;
+      margin-bottom: 16px;
+    }
+    .arrows {
+      justify-content: center;
+    }
   }
 </style>

--- a/projects/monolith/frontend/src/lib/telemetry.js
+++ b/projects/monolith/frontend/src/lib/telemetry.js
@@ -35,13 +35,16 @@ export function initTelemetry() {
         new DocumentLoadInstrumentation(),
         new FetchInstrumentation({
           // Skip instrumenting third-party hosts that reject the CORS
-          // preflight: fonts, plus the OpenFreeMap tiles behind the
-          // /app/ships basemap (its OPTIONS returns 405).
+          // preflight: fonts, the OpenFreeMap tiles behind the /app/ships
+          // basemap (its OPTIONS returns 405), plus the Carto Positron basemap
+          // and elevation-tiles DEM behind the /app/trips day map.
           ignoreUrls: [
             /\/otel\//,
             /fonts\.googleapis/,
             /fonts\.gstatic/,
             /tiles\.openfreemap\.org/,
+            /basemaps\.cartocdn\.com/,
+            /elevation-tiles-prod/,
           ],
           // Only continue traces into same-origin requests (the safe
           // default). Propagating to every cross-origin host injects a

--- a/projects/monolith/frontend/src/lib/trips/sun.js
+++ b/projects/monolith/frontend/src/lib/trips/sun.js
@@ -38,6 +38,13 @@ function altitudeRad(H, phi, dec) {
   );
 }
 
+function azimuthRad(H, phi, dec) {
+  return Math.atan2(
+    Math.sin(H),
+    Math.cos(H) * Math.sin(phi) - Math.tan(dec) * Math.cos(phi),
+  );
+}
+
 function siderealTime(d, lw) {
   return rad * (280.16 + 360.9856235 * d) - lw;
 }
@@ -69,6 +76,19 @@ export function sunAltitude(date, lat, lng) {
   const c = sunCoords(d);
   const H = siderealTime(d, lw) - c.ra;
   return altitudeRad(H, phi, c.dec);
+}
+
+// Sun azimuth (radians, measured from south to west: 0 = south, +PI/2 = west) at
+// `date` for the given latitude / longitude in degrees. Matches
+// SunCalc.getPosition().azimuth, which the day-map hillshade uses to relight the
+// terrain from the sun's bearing at the photo's capture time.
+export function sunAzimuth(date, lat, lng) {
+  const lw = rad * -lng;
+  const phi = rad * lat;
+  const d = toDays(date);
+  const c = sunCoords(d);
+  const H = siderealTime(d, lw) - c.ra;
+  return azimuthRad(H, phi, c.dec);
 }
 
 // --- sunset time ---

--- a/projects/monolith/frontend/src/lib/trips/telemetry.js
+++ b/projects/monolith/frontend/src/lib/trips/telemetry.js
@@ -233,6 +233,10 @@ export function photoTelemetry(photo, dayPoints, tz) {
     bearingArrow: compassArrow(bearing),
     km: dist?.km ?? null,
     totalKm: dist?.total ?? null,
+    // Fraction (0..100) of the day's distance travelled by the photo's capture
+    // time. The elevation-profile cursor maps this onto the sampled profile so
+    // the position marker tracks where the photo sits along the route.
+    progressPercent: dist?.percent ?? 0,
     // Optics passed straight through for the panel to format.
     focalLength35mm: photo.focal_length_35mm ?? null,
     aperture: photo.aperture ?? null,

--- a/projects/monolith/frontend/src/routes/public/app/trips/[slug]/day/[day]/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/trips/[slug]/day/[day]/+page.svelte
@@ -1,7 +1,7 @@
 <script>
   import DayNav from "$lib/public/components/trips/DayNav.svelte";
   import DayMap from "$lib/public/components/trips/DayMap.svelte";
-  import ElevationChart from "$lib/public/components/trips/ElevationChart.svelte";
+  import DayElevationProfile from "$lib/public/components/trips/DayElevationProfile.svelte";
   import {
     groupByDay,
     dayColor,
@@ -11,6 +11,7 @@
     clampIndex,
   } from "$lib/trips/trip.js";
   import { photoTelemetry, formatCoord } from "$lib/trips/telemetry.js";
+  import { sunAltitude, sunAzimuth } from "$lib/trips/sun.js";
 
   let { data } = $props();
 
@@ -23,19 +24,40 @@
   const photos = $derived(day ? photosOf(day.points) : []);
   const label = $derived(dayLabel(trip?.days, dayNumber));
   const dayStats = $derived(day ? { ...day, photoCount: photos.length } : null);
-  const series = $derived(day ? elevationSeries(day.points, 120) : []);
 
-  // Scrubber state: the index of the "current" photo. The photo is the dominant
-  // element; the map highlights and centers it, the elevation cursor tracks its
-  // route position, and the telemetry panel shows its per-photo readouts.
+  // Day date for the nav eyebrow, formatted in the trip's zone (e.g. "Sep 15,
+  // 2024"). Taken from the day's first point so it never disagrees with the
+  // day-grouping key.
+  const formattedDate = $derived.by(() => {
+    const iso = day?.points?.[0]?.taken_at;
+    if (!iso) return "";
+    const d = new Date(iso);
+    if (Number.isNaN(d.getTime())) return "";
+    try {
+      return d.toLocaleDateString("en-US", {
+        timeZone: trip?.tz || "UTC",
+        month: "short",
+        day: "numeric",
+        year: "numeric",
+      });
+    } catch {
+      return "";
+    }
+  });
+
+  // Scrubber state: index of the "current" photo. The photo is the dominant
+  // element; the map highlights/centres it, the elevation cursor tracks its
+  // route position, and the data panel shows its per-photo readouts.
   let current = $state(0);
+  let showFullscreen = $state(false);
 
   // Reset to the first photo whenever the day changes (SvelteKit reuses this
-  // component across [day] navigations, so $state(0) alone would persist a stale
-  // index). Also keeps `current` in range if the photo list shrinks.
+  // component across [day] navigations). Also keeps `current` in range if the
+  // photo list shrinks.
   $effect(() => {
     const _ = dayNumber;
     current = 0;
+    showFullscreen = false;
   });
   $effect(() => {
     if (current > photos.length - 1) current = clampIndex(current, photos.length);
@@ -44,9 +66,8 @@
   const photo = $derived(photos[current] ?? null);
 
   // Smooth scrubbing: keep the CURRENT frame on screen until the next image has
-  // actually decoded (instant when it was preloaded), so the photo never flashes
-  // its black cell background between shots while an arrow is held down. Only the
-  // latest target wins, so rapid stepping settles on the right frame.
+  // actually decoded (instant when preloaded), so the photo never flashes its
+  // black cell between shots while an arrow is held. Only the latest target wins.
   let displayedSrc = $state(photos[current]?.imgDisplay ?? null);
   $effect(() => {
     const target = photo?.imgDisplay ?? null;
@@ -78,12 +99,35 @@
     photo ? photoTelemetry(photo, day?.points ?? [], trip?.tz) : null,
   );
 
-  // Interpolated coordinates for the map's current-photo marker, so it still
-  // tracks photos that lack their own GPS fix.
+  // Interpolated [lng, lat] for the map's current-photo marker, so it tracks
+  // photos that lack their own GPS fix.
   const currentCoords = $derived(
     telemetry && telemetry.lat != null && telemetry.lng != null
       ? [telemetry.lng, telemetry.lat]
       : null,
+  );
+
+  // Sun altitude + azimuth (radians) at the photo's capture time and location,
+  // for the map's terrain hillshade relighting (mirrors the original's
+  // SunCalc.getPosition()).
+  const sunPosition = $derived.by(() => {
+    if (!telemetry || telemetry.lat == null || telemetry.lng == null) return null;
+    if (!photo?.taken_at) return null;
+    const d = new Date(photo.taken_at);
+    if (Number.isNaN(d.getTime())) return null;
+    return {
+      altitude: sunAltitude(d, telemetry.lat, telemetry.lng),
+      azimuth: sunAzimuth(d, telemetry.lat, telemetry.lng),
+    };
+  });
+
+  // Elevation sparkline: ~60 samples, with the position marker mapped onto it by
+  // the photo's progress fraction along the route (matches the original).
+  const profile = $derived(day ? elevationSeries(day.points, 60) : []);
+  const profileIndex = $derived(
+    profile.length
+      ? Math.round(((telemetry?.progressPercent ?? 0) / 100) * (profile.length - 1))
+      : 0,
   );
 
   function step(delta) {
@@ -91,24 +135,28 @@
     current = clampIndex(current + delta, photos.length);
   }
 
-  // Cursor fraction (0..1) along the elevation x-axis. The elevation chart is
-  // sampled over every point in the day; map the current photo to its position
-  // in that point sequence so the cursor tracks where the photo sits along the
-  // route. Approximate (photo points are a subset of all points) but tracking.
-  const cursorFraction = $derived.by(() => {
-    if (!photo || !day || day.points.length < 2) return null;
-    const idx = day.points.indexOf(photo);
-    if (idx < 0) return null;
-    return idx / (day.points.length - 1);
-  });
+  // Map route click -> nearest route point's capture time -> nearest photo.
+  function handleMapLocationClick(takenAtIso) {
+    if (!photos.length || !takenAtIso) return;
+    const clickTime = new Date(takenAtIso).getTime();
+    if (Number.isNaN(clickTime)) return;
+    let closest = 0;
+    let minDiff = Infinity;
+    photos.forEach((p, i) => {
+      if (!p.taken_at) return;
+      const diff = Math.abs(new Date(p.taken_at).getTime() - clickTime);
+      if (diff < minDiff) {
+        minDiff = diff;
+        closest = i;
+      }
+    });
+    current = closest;
+  }
 
-  // Warm the browser/CDN cache so scrubbing is always instant. First the close
-  // neighbours (+-5, nearest first), then keep streaming the REST of the day
-  // forward in the background (then backward as filler), paced so we never fire
-  // a burst of hundreds of requests. Pre-signed `imgDisplay` URLs are already in
-  // the SSR payload; new Image() just kicks off background GETs and never blocks
-  // render. Browser-only (Image is undefined during SSR). `warmed` persists
-  // across scrubs so an image is only ever fetched once.
+  // Warm the browser/CDN cache so scrubbing is always instant: first the close
+  // neighbours (+-5, nearest first), then stream the rest of the day forward in
+  // the background (then backward as filler), paced so we never fire hundreds of
+  // requests at once. Browser-only. `warmed` persists across scrubs.
   const warmed = new Set();
   function warm(idx) {
     const p = photos[idx];
@@ -120,12 +168,10 @@
   $effect(() => {
     const i = current;
     if (typeof Image === "undefined" || !photos.length) return;
-    // Priority window around the current photo, nearest first.
     for (let d = 1; d <= 5; d++) {
       warm(i + d);
       warm(i - d);
     }
-    // Then progressively warm everything else, biased forward from i+6, paced.
     let fwd = i + 6;
     let back = i - 6;
     const timer = setInterval(() => {
@@ -139,468 +185,510 @@
     return () => clearInterval(timer);
   });
 
-  // Arrow keys step through photos. No scroll-jacking: keyboard + buttons only.
+  // Arrow keys step through photos; Escape closes the fullscreen overlay.
   $effect(() => {
     const onKey = (e) => {
-      if (!photos.length) return;
-      if (e.key === "ArrowLeft") {
-        step(-1);
-      } else if (e.key === "ArrowRight") {
-        step(1);
+      if (e.key === "Escape") {
+        showFullscreen = false;
+        return;
       }
+      if (!photos.length) return;
+      if (e.key === "ArrowLeft") step(-1);
+      else if (e.key === "ArrowRight") step(1);
     };
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
   });
+
+  const hasPrev = $derived(current > 0);
+  const hasNext = $derived(current < photos.length - 1);
 </script>
 
 <svelte:head>
   <title>{trip ? `${trip.short_title ?? trip.title} - Day ${dayNumber}` : "Day"}</title>
 </svelte:head>
 
-<div class="page">
-  {#if !day}
-    <p class="missing">
-      Day {dayNumber} not found. <a href={`/app/trips/${trip?.slug}`}>Back to summary</a>.
-    </p>
-  {:else}
-    <DayNav slug={trip.slug} {dayNumber} {totalDays} {label} dayColor={color} />
+<div class="root">
+  <div class="inner">
+    {#if !day}
+      <p class="missing">
+        Day {dayNumber} not found. <a href={`/app/trips/${trip?.slug}`}>Back to summary</a>.
+      </p>
+    {:else}
+      <DayNav
+        slug={trip.slug}
+        {dayNumber}
+        {totalDays}
+        {label}
+        dayColor={color}
+        date={formattedDate}
+      />
 
-    <!-- One bordered instrument panel: photo (dominant), map + telemetry rail,
-         controls, elevation strip and day totals all share contiguous 2px ink
-         gaps so the dashboard reads as a single connected unit that fits one
-         viewport. The ink background + 2px grid gap renders every divider; each
-         cell paints its own paper/cream fill on top. -->
-    <div class="panel" style={`--day:${color}`}>
-      <!-- PHOTO: the dominant cell, letterboxed (contain) so it never forces the
-           page taller than the viewport. -->
-      <figure class="photo">
-        {#if photo}
-          <img
-            src={displayedSrc}
-            alt={`Photo ${current + 1} of ${photos.length}`}
-            decoding="async"
-          />
-        {:else}
-          <span class="empty">No photos for this day.</span>
-        {/if}
-      </figure>
-
-      <!-- CONTROLS: prev / counter / next, locked under the photo. -->
-      <div class="ctrls">
-        <button
-          class="step"
-          onclick={() => step(-1)}
-          disabled={current === 0}
-          aria-label="Previous photo"
-        >
-          &larr; Prev
-        </button>
-        <span class="counter">{photos.length ? current + 1 : 0} / {photos.length}</span>
-        <button
-          class="step"
-          onclick={() => step(1)}
-          disabled={current >= photos.length - 1}
-          aria-label="Next photo"
-        >
-          Next &rarr;
-        </button>
-      </div>
-
-      <!-- MAP: top of the right rail. -->
-      <div class="map" aria-label="Day route map">
+      <div class="stack">
+        <!-- MAP: full width, 280px, inverted basemap with the layered route line
+             + start/end/square-current markers. -->
         <DayMap
           points={day.points}
-          {photos}
           dayColor={color}
-          {current}
+          height="280px"
           {currentCoords}
-          onPhotoClick={(i) => (current = i)}
+          {sunPosition}
+          onLocationClick={handleMapLocationClick}
         />
-      </div>
 
-      <!-- TELEMETRY: the per-photo machine readout, beside the photo (mirrors the
-           original DataPanel). All fields preserved. -->
-      <div class="telem">
-        {#if telemetry}
-          {@const t = telemetry}
-          <div class="cell time">
-            <span class="label">Time</span>
-            <span class="clock">{t.time}<span class="period">{t.period}</span></span>
-          </div>
-          <div class="cell">
-            <span class="label">Solar</span>
-            <span class="value">{t.solarAltDeg != null ? `${Math.round(t.solarAltDeg)}°` : "--"}</span>
-            <span class="sub">{t.solarLabel}</span>
-          </div>
-          <div class="cell">
-            <span class="label">Light</span>
-            <span class="value sm">{t.light || "DARK"}</span>
-          </div>
-          <div class="cell">
-            <span class="label">EV</span>
-            <span class="value">{t.ev ?? "--"}</span>
-            <span class="sub">{t.evLabel}</span>
-          </div>
-          <div class="cell">
-            <span class="label">Elev</span>
-            <span class="value">{t.elevation != null ? Math.round(t.elevation) : "--"}<span class="unit">m</span></span>
-          </div>
-          <div class="cell">
-            <span class="label">Km</span>
-            <span class="value">{t.km ?? 0}<span class="unit">/{t.totalKm ?? 0}</span></span>
-          </div>
-          <div class="cell bearing">
-            <span class="label">Bearing</span>
-            <span class="arrow">{t.bearingArrow}</span>
-            <span class="sub">{t.bearing != null ? `${Math.round(t.bearing)}°` : "--"}</span>
-          </div>
-          <div class="cell">
-            <span class="label">Photo</span>
-            <span class="value">{photos.length ? current + 1 : 0}<span class="unit">/{photos.length}</span></span>
-          </div>
-          <div class="cell optics">
-            <span class="label">Optics</span>
-            <span class="value sm">
-              {t.focalLength35mm != null ? `${t.focalLength35mm}mm` : "--"} &fnof;/{t.aperture ?? "--"}
-            </span>
-            <span class="sub">ISO {t.iso ?? "--"} · {t.shutterSpeed ?? "--"}</span>
-          </div>
-          <div class="cell position">
-            <span class="label">Position</span>
-            <span class="coord">{formatCoord(t.lat, true)}</span>
-            <span class="coord">{formatCoord(t.lng, false)}</span>
-          </div>
-        {:else}
-          <div class="cell"><span class="label">Telemetry</span><span class="value sm">--</span></div>
-        {/if}
-      </div>
-
-      <!-- ELEVATION: connected strip across the foot of the panel. -->
-      <div class="elev">
-        <span class="label">Elevation profile</span>
-        {#if dayStats.hasElevation}
-          <div class="chart">
-            <ElevationChart
-              {series}
-              height={88}
-              {color}
-              cursor={cursorFraction}
-              cursorColor={color}
-              showMinMax={true}
-            />
-          </div>
-        {:else}
-          <span class="value sm none">No elevation data</span>
-        {/if}
-      </div>
-
-      <!-- DAY TOTALS: subsumed into the panel, no separate floating card. -->
-      <div class="stats">
-        <div class="cell">
-          <span class="label">Distance</span>
-          <span class="value">{dayStats.distance}<span class="unit">km</span></span>
-        </div>
-        {#if dayStats.hasElevation}
-          <div class="cell">
-            <span class="label">Ascent</span>
-            <span class="value up">+{dayStats.ascent.toLocaleString()}<span class="unit">m</span></span>
-          </div>
-          <div class="cell">
-            <span class="label">Descent</span>
-            <span class="value down">-{dayStats.descent.toLocaleString()}<span class="unit">m</span></span>
-          </div>
-          {#if dayStats.maxElevation != null}
-            <div class="cell">
-              <span class="label">High</span>
-              <span class="value">{dayStats.maxElevation.toLocaleString()}<span class="unit">m</span></span>
-            </div>
+        <!-- TRIPTYCH: 520px photo + the 5-column data panel. -->
+        <div class="triptych">
+          {#if photo}
+            <button
+              class="photo"
+              onclick={() => (showFullscreen = true)}
+              aria-label={`View photo ${current + 1} fullscreen`}
+            >
+              <img
+                src={displayedSrc}
+                alt={`Photo ${current + 1} of ${photos.length}`}
+                decoding="async"
+              />
+            </button>
+          {:else}
+            <div class="photo empty">No photos for this day.</div>
           {/if}
-          {#if dayStats.minElevation != null}
-            <div class="cell">
-              <span class="label">Low</span>
-              <span class="value">{dayStats.minElevation.toLocaleString()}<span class="unit">m</span></span>
-            </div>
-          {/if}
-        {/if}
-        <div class="cell">
-          <span class="label">Photos</span>
-          <span class="value">{dayStats.photoCount ?? 0}</span>
+
+          <div class="panel">
+            {#if telemetry}
+              {@const t = telemetry}
+              <!-- ROW 1: TIME | SOLAR | LIGHT | EV | ELEV -->
+              <div class="cell r1 c-time">
+                <div class="label">TIME</div>
+                <div class="time-big">
+                  {t.time}<span class="period">{t.period}</span>
+                </div>
+              </div>
+              <div class="cell r1 div-thin">
+                <div class="label">SOLAR</div>
+                <div class="val">{t.solarAltDeg != null ? `${t.solarAltDeg.toFixed(0)}°` : "--"}</div>
+                <div class="sub">{t.solarLabel}</div>
+              </div>
+              <div class="cell r1 div-thin">
+                <div class="label">LIGHT</div>
+                <div class="val sm">{t.light || "DARK"}</div>
+              </div>
+              <div class="cell r1 div-thin">
+                <div class="label">EV</div>
+                <div class="val">{t.ev ?? "--"}</div>
+                <div class="sub">{t.evLabel}</div>
+              </div>
+              <div class="cell r1">
+                <div class="label">ELEV</div>
+                <div class="val">{t.elevation != null ? Math.round(t.elevation) : "--"}<span class="unit">m</span></div>
+              </div>
+
+              <!-- ROW 2: OPTICS+NAV+BEARING | ELEVATION PROFILE -->
+              <div class="col1">
+                <div class="optics">
+                  <div class="label">OPTICS</div>
+                  <div class="optics-line">
+                    {t.focalLength35mm != null ? `${t.focalLength35mm}mm` : "--"} &fnof;/{t.aperture ?? "--"}
+                  </div>
+                  <div class="optics-sub">ISO {t.iso ?? "--"} · {t.shutterSpeed ?? "--"}</div>
+                </div>
+
+                <div class="nav">
+                  <div class="navrow">
+                    <button
+                      class="navstep border-r"
+                      onclick={() => step(-1)}
+                      disabled={!hasPrev}
+                      aria-label="Previous photo"
+                    >
+                      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6" /></svg>
+                    </button>
+                    <button
+                      class="navstep"
+                      onclick={() => step(1)}
+                      disabled={!hasNext}
+                      aria-label="Next photo"
+                    >
+                      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6" /></svg>
+                    </button>
+                  </div>
+                  <div class="counter">{photos.length ? current + 1 : 0} / {photos.length}</div>
+                </div>
+
+                <div class="bearing">
+                  <div class="label">BEARING</div>
+                  <div class="arrow">{t.bearingArrow}</div>
+                  <div class="bearing-deg">{t.bearing != null ? `${Math.round(t.bearing)}°` : "--"}</div>
+                </div>
+              </div>
+
+              <div class="elev-profile">
+                <div class="label">ELEVATION PROFILE</div>
+                <div class="elev-inner">
+                  <DayElevationProfile data={profile} currentIndex={profileIndex} accentColor={color} />
+                </div>
+              </div>
+
+              <!-- ROW 3: POSITION | KM | ASCENT | DESCENT | PHOTOS -->
+              <div class="cell-position">
+                <div class="label">POSITION</div>
+                <div class="coords">
+                  <div>{formatCoord(t.lat, true)}</div>
+                  <div>{formatCoord(t.lng, false)}</div>
+                </div>
+              </div>
+              <div class="cell-stat div-thin">
+                <div class="label">KM</div>
+                <div class="km-val">{t.km ?? 0}<span class="small">/{t.totalKm ?? 0}</span></div>
+              </div>
+              <div class="cell-stat div-thin">
+                <div class="label">ASCENT</div>
+                <div class="stat-val up">+{(dayStats?.ascent ?? 0).toLocaleString()}m</div>
+              </div>
+              <div class="cell-stat div-thin">
+                <div class="label">DESCENT</div>
+                <div class="stat-val down">-{(dayStats?.descent ?? 0).toLocaleString()}m</div>
+              </div>
+              <div class="cell-stat">
+                <div class="label">PHOTOS</div>
+                <div class="stat-val">{dayStats?.photoCount ?? 0}</div>
+              </div>
+            {:else}
+              <div class="cell r1"><div class="label">TELEMETRY</div><div class="val sm">--</div></div>
+            {/if}
+          </div>
         </div>
+
+        {#if Array.isArray(trip.highlights) && trip.highlights.length > 0}
+          <!-- (Trip-level highlights; the original showed per-day highlights here.) -->
+        {/if}
       </div>
-    </div>
-  {/if}
+    {/if}
+  </div>
 </div>
 
+{#if showFullscreen && photo}
+  <button
+    class="fs"
+    aria-label="Close fullscreen photo"
+    onclick={() => (showFullscreen = false)}
+  >
+    <img src={photo.imgGallery ?? displayedSrc} alt={`Photo ${current + 1} of ${photos.length}`} />
+  </button>
+{/if}
+
 <style>
-  .page {
-    max-width: 1280px;
-    margin: 0 auto;
-    padding: 16px 24px 24px;
-    background: var(--cream);
-    color: var(--ink);
+  .root {
     min-height: 100vh;
+    background: white;
+    font-family: system-ui, -apple-system, sans-serif;
+    color: #1a1a1a; /* nosemgrep: svelte-hardcoded-color-in-style */
   }
-
-  /* The instrument panel. One grid, contiguous 2px ink dividers (ink background
-     showing through the 2px gap), framed by a 2px border. Sized to fill the
-     viewport below the day-nav so the whole day reads without scrolling on a
-     normal desktop. Rows: a flexing top band (photo + map) then auto-height
-     telemetry, controls, elevation and totals. */
-  .panel {
-    display: grid;
-    grid-template-columns: minmax(0, 1.55fr) minmax(0, 1fr);
-    grid-template-rows: minmax(150px, 1fr) auto auto auto;
-    grid-template-areas:
-      "photo map"
-      "photo telem"
-      "ctrls telem"
-      "elev stats";
-    gap: 2px;
-    background: var(--ink);
-    border: 2px solid var(--ink);
-    /* Fill the viewport minus the page padding + day-nav header. */
-    height: calc(100vh - 132px);
-    min-height: 520px;
+  .inner {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 24px 32px;
   }
-
-  .photo {
-    grid-area: photo;
-    margin: 0;
-    background: var(--ink);
-    min-height: 0;
-    min-width: 0;
-    overflow: hidden;
+  .missing {
+    font-family: monospace;
+    font-size: 13px;
+  }
+  .stack {
     display: flex;
+    flex-direction: column;
+    gap: 24px;
+  }
+
+  /* TRIPTYCH: photo + data panel, sharing a 2px top rule. */
+  .triptych {
+    display: flex;
+    align-items: stretch;
+    border-top: 2px solid #1a1a1a;
+  }
+  .photo {
+    flex: 0 0 auto;
+    width: 520px;
+    height: 520px;
+    cursor: pointer;
+    display: block;
+    padding: 0;
+    border: none;
+    background: #1a1a1a; /* nosemgrep: svelte-hardcoded-color-in-style */
   }
   .photo img {
     width: 100%;
     height: 100%;
-    object-fit: contain;
+    object-fit: cover;
     display: block;
-    background: var(--ink);
   }
-  .photo .empty {
-    margin: auto;
-    font-family: var(--mono);
-    font-size: 12px;
-    color: var(--paper);
-  }
-
-  .ctrls {
-    grid-area: ctrls;
-    display: flex;
-    align-items: stretch;
-    background: var(--paper);
-    min-width: 0;
-  }
-  .counter {
+  .photo.empty {
     display: flex;
     align-items: center;
     justify-content: center;
-    flex: 0 0 auto;
-    padding: 0 18px;
-    font-family: var(--mono);
+    color: white;
+    font-family: monospace;
     font-size: 12px;
-    font-weight: 700;
-    letter-spacing: 0.06em;
-    color: var(--ink);
-    background: var(--paper);
-  }
-  .step {
-    flex: 1;
-    font-family: var(--mono);
-    font-size: 12px;
-    font-weight: 700;
-    letter-spacing: 0.06em;
-    text-transform: uppercase;
-    color: var(--ink);
-    border: none;
-    background: var(--paper);
-    padding: 12px 14px;
-    cursor: pointer;
-  }
-  .step:first-child {
-    border-right: 2px solid var(--ink);
-  }
-  .step:last-child {
-    border-left: 2px solid var(--ink);
-  }
-  .step:hover:not(:disabled) {
-    background: var(--ink);
-    color: var(--paper);
-  }
-  .step:disabled {
-    opacity: 0.35;
     cursor: default;
   }
 
-  .map {
-    grid-area: map;
-    background: var(--paper);
-    min-height: 0;
+  /* DATA PANEL: the aligned 5-column grid. */
+  .panel {
+    flex: 1;
+    display: grid;
+    grid-template-columns: 150px 1fr 1fr 1fr 1fr;
+    grid-template-rows: auto 1fr auto;
+    border-left: 2px solid #1a1a1a;
+    font-family: monospace;
     min-width: 0;
-    overflow: hidden;
   }
 
-  /* Telemetry: a nested grid that inherits the same ink-gap treatment, so its
-     internal dividers line up visually with the rest of the panel. */
-  .telem {
-    grid-area: telem;
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(96px, 1fr));
-    grid-auto-rows: minmax(0, 1fr);
-    gap: 2px;
-    background: var(--ink);
-    font-family: var(--mono);
-    min-width: 0;
-    min-height: 0;
-  }
-  .cell {
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    padding: 10px 12px;
-    background: var(--paper);
-    min-width: 0;
-    overflow: hidden;
-  }
   .label {
-    font-family: var(--mono);
     font-size: 9px;
     font-weight: 700;
+    color: #6b7280; /* nosemgrep: svelte-hardcoded-color-in-style */
     letter-spacing: 0.08em;
-    text-transform: uppercase;
-    color: var(--ink-3);
-    margin-bottom: 5px;
+    margin-bottom: 4px;
   }
-  .value {
-    font-family: var(--mono);
+  .val {
     font-size: 18px;
-    font-weight: 900;
-    line-height: 1;
-    color: var(--ink);
-  }
-  .value.sm {
-    font-size: 12px;
     font-weight: 700;
+    color: #1a1a1a; /* nosemgrep: svelte-hardcoded-color-in-style */
+  }
+  .val.sm {
+    font-size: 14px;
   }
   .unit {
-    font-size: 11px;
-    font-weight: 700;
-    color: var(--ink-3);
-    margin-left: 2px;
+    font-size: 10px;
+    color: #9ca3af; /* nosemgrep: svelte-hardcoded-color-in-style */
   }
   .sub {
     font-size: 9px;
-    font-weight: 700;
-    letter-spacing: 0.06em;
-    color: var(--ink-3);
-    margin-top: 4px;
+    color: #9ca3af; /* nosemgrep: svelte-hardcoded-color-in-style */
+    font-weight: 600;
   }
-  .coord {
-    font-size: 11px;
-    font-weight: 700;
-    line-height: 1.5;
-    color: var(--ink);
+
+  /* Row 1 cells. */
+  .r1 {
+    padding: 12px;
+    border-bottom: 2px solid #1a1a1a;
+    background: white;
   }
-  .up {
-    color: var(--teal);
+  .div-thin {
+    border-right: 1px solid #e5e7eb;
   }
-  .down {
-    color: var(--coral);
+  .c-time {
+    border-right: 2px solid #1a1a1a;
   }
-  /* TIME: the primary readout, accent-topped, spanning the rail width. */
-  .time {
-    grid-column: 1 / -1;
-    border-top: 3px solid var(--day);
-  }
-  .clock {
-    font-size: 26px;
+  .time-big {
+    font-size: 24px;
     font-weight: 900;
+    color: #1a1a1a; /* nosemgrep: svelte-hardcoded-color-in-style */
     line-height: 1;
-    color: var(--ink);
   }
   .period {
-    font-size: 12px;
+    font-size: 11px;
     font-weight: 700;
-    color: var(--ink-3);
+    color: #6b7280; /* nosemgrep: svelte-hardcoded-color-in-style */
     margin-left: 4px;
   }
-  .bearing .arrow {
-    font-size: 26px;
-    line-height: 1;
-    color: var(--ink);
-  }
-  .optics {
-    grid-column: span 2;
-  }
-  .position {
-    grid-column: span 2;
-  }
 
-  /* Elevation strip, foot of the panel under the photo. */
-  .elev {
-    grid-area: elev;
+  /* Row 2, column 1: optics / nav / bearing stack. */
+  .col1 {
     display: flex;
     flex-direction: column;
-    padding: 10px 14px;
-    background: var(--paper);
-    min-width: 0;
-    min-height: 0;
-    overflow: hidden;
+    border-right: 2px solid #1a1a1a;
+    border-bottom: 2px solid #1a1a1a;
+    background: #fafafa; /* nosemgrep: svelte-hardcoded-color-in-style */
   }
-  .elev .chart {
-    flex: 1;
-    min-height: 0;
+  .optics {
+    padding: 12px;
+    border-bottom: 2px solid #1a1a1a;
+    background: #f5f5f5; /* nosemgrep: svelte-hardcoded-color-in-style */
+  }
+  .optics-line {
+    font-size: 14px;
+    font-weight: 700;
+    color: #1a1a1a; /* nosemgrep: svelte-hardcoded-color-in-style */
+  }
+  .optics-sub {
+    font-size: 11px;
+    font-weight: 600;
+    color: #6b7280; /* nosemgrep: svelte-hardcoded-color-in-style */
+    margin-top: 2px;
+  }
+  .nav {
+    border-bottom: 2px solid #1a1a1a;
+    background: white;
+  }
+  .navrow {
     display: flex;
-    align-items: stretch;
+    height: 56px;
   }
-  .elev .chart :global(.elev) {
-    width: 100%;
-    align-self: center;
+  .navstep {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: white;
+    border: none;
+    color: #1a1a1a; /* nosemgrep: svelte-hardcoded-color-in-style */
+    cursor: pointer;
+    transition:
+      background 0.15s,
+      color 0.15s;
   }
-  .elev .none {
-    margin-top: 8px;
-    color: var(--ink-3);
+  .navstep.border-r {
+    border-right: 2px solid #1a1a1a;
+  }
+  .navstep svg {
+    width: 24px;
+    height: 24px;
+  }
+  .navstep:hover:not(:disabled) {
+    background: #1a1a1a; /* nosemgrep: svelte-hardcoded-color-in-style */
+    color: white;
+  }
+  .navstep:disabled {
+    opacity: 0.3;
+    cursor: not-allowed;
+  }
+  .counter {
+    font-size: 11px;
+    font-weight: 700;
+    color: #1a1a1a; /* nosemgrep: svelte-hardcoded-color-in-style */
+    text-align: center;
+    padding: 8px;
+    border-top: 2px solid #1a1a1a;
+  }
+  .bearing {
+    flex-grow: 1;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    padding: 12px;
+    background: white;
+  }
+  .bearing .arrow {
+    font-size: 36px;
+    line-height: 1;
+    color: #1a1a1a; /* nosemgrep: svelte-hardcoded-color-in-style */
+  }
+  .bearing-deg {
+    font-size: 11px;
+    font-weight: 700;
+    color: #6b7280; /* nosemgrep: svelte-hardcoded-color-in-style */
+    margin-top: 4px;
   }
 
-  /* Day totals: nested ink-gap grid, contiguous with the panel. */
-  .stats {
-    grid-area: stats;
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(72px, 1fr));
-    gap: 2px;
-    background: var(--ink);
-    min-width: 0;
+  /* Row 2 elevation profile, spanning columns 2-5. */
+  .elev-profile {
+    grid-column: span 4;
+    padding: 12px 16px;
+    border-bottom: 2px solid #1a1a1a;
+    display: flex;
+    flex-direction: column;
+    background: white;
+  }
+  .elev-profile .label {
+    margin-bottom: 8px;
+  }
+  .elev-inner {
+    flex-grow: 1;
+    position: relative;
+    min-height: 120px;
   }
 
-  /* Narrow screens: drop the fit-to-viewport constraint and stack the panel into
-     a single scrollable column (photo, controls, map, telemetry, elevation,
-     totals). */
-  @media (max-width: 900px) {
-    .panel {
-      grid-template-columns: 1fr;
-      grid-template-rows: auto auto auto auto auto auto;
-      grid-template-areas:
-        "photo"
-        "ctrls"
-        "map"
-        "telem"
-        "elev"
-        "stats";
-      height: auto;
-      min-height: 0;
+  /* Row 3 cells. */
+  .cell-position {
+    padding: 10px 12px;
+    border-right: 2px solid #1a1a1a;
+    background: white;
+  }
+  .coords {
+    font-size: 10px;
+    font-weight: 600;
+    color: #1a1a1a; /* nosemgrep: svelte-hardcoded-color-in-style */
+    line-height: 1.6;
+  }
+  .cell-stat {
+    padding: 10px;
+    background: #fafafa; /* nosemgrep: svelte-hardcoded-color-in-style */
+  }
+  .km-val {
+    font-size: 16px;
+    font-weight: 900;
+    color: #1a1a1a; /* nosemgrep: svelte-hardcoded-color-in-style */
+  }
+  .small {
+    font-size: 10px;
+    color: #9ca3af; /* nosemgrep: svelte-hardcoded-color-in-style */
+  }
+  .stat-val {
+    font-size: 14px;
+    font-weight: 900;
+    color: #1a1a1a; /* nosemgrep: svelte-hardcoded-color-in-style */
+  }
+  .stat-val.up {
+    color: #059669; /* nosemgrep: svelte-hardcoded-color-in-style */
+  }
+  .stat-val.down {
+    color: #dc2626; /* nosemgrep: svelte-hardcoded-color-in-style */
+  }
+
+  /* Fullscreen photo overlay. */
+  .fs {
+    position: fixed;
+    inset: 0;
+    z-index: 1000;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: rgba(0, 0, 0, 0.92);
+    border: none;
+    padding: 24px;
+    cursor: zoom-out;
+  }
+  .fs img {
+    max-width: 100%;
+    max-height: 100%;
+    object-fit: contain;
+  }
+
+  /* Responsive: stack the triptych and reflow the panel to two columns. */
+  @media (max-width: 768px) {
+    .inner {
+      padding: 16px;
+    }
+    .triptych {
+      flex-direction: column;
+      border-top: none;
     }
     .photo {
-      aspect-ratio: 4 / 3;
-      max-height: 70vh;
+      width: 100%;
+      height: auto;
+      max-height: 60vh;
     }
-    .map {
-      height: 280px;
+    .photo img {
+      max-height: 60vh;
+      object-fit: contain;
     }
-    .elev .chart {
-      min-height: 96px;
+    .panel {
+      border-left: none;
+      border-top: 2px solid #1a1a1a;
+      grid-template-columns: 1fr 1fr;
+      grid-template-rows: none;
+    }
+    .c-time,
+    .col1,
+    .elev-profile,
+    .cell-position {
+      grid-column: 1 / -1;
+    }
+    .c-time,
+    .col1,
+    .cell-position {
+      border-right: none;
     }
   }
 </style>


### PR DESCRIPTION
Faithful 1:1 port of the original React day-detail page (the rebuilt version had drifted, loose layout, broken white-blob map line).

- **Layout**: verbatim original, max-1200 container, DayNav, full-width 280px map, then the 520px photo + the exact 5-column DataPanel (TIME/SOLAR/LIGHT/EV/ELEV; OPTICS/NAV/BEARING + ELEVATION PROFILE; POSITION/KM/ASCENT/DESCENT/PHOTOS) in their original cells/fonts/colors.
- **Map fix**: inverted basemap (Carto Positron + `filter: invert(1)`), layered route line (7px black casing + pre-inverted-color 1.5px accent + 20px click hit-area) instead of the white blob, start/end pins, 24px square current-photo marker animated to the photo + `easeTo(zoom 10)`, and the sun-relit terrain hillshade (added `sunAzimuth` to sun.js).
- Reuses signed `imgDisplay` URLs, telemetry/sun computations, ±5 preloader, decode-before-swap. Carto + elevation tiles added to the OTEL fetch ignore list (no CSP on the app).

🤖 Generated with [Claude Code](https://claude.com/claude-code)