### PR TITLE
style(trips): un-invert the map + neo-brutalist day view

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.18.0
+version: 0.18.1
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.18.0
+      targetRevision: 0.18.1
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.174.0
+version: 0.174.1
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.174.0
+      targetRevision: 0.174.1
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/lib/public/components/trips/DayMap.svelte
+++ b/projects/monolith/frontend/src/lib/public/components/trips/DayMap.svelte
@@ -3,14 +3,13 @@
   import "maplibre-gl/dist/maplibre-gl.css";
 
   // Single-day route map, a faithful port of the original React DayMap. The
-  // whole container is CSS `invert(1)`ed so the light Carto Positron basemap
-  // reads as a dark map: every colour drawn into it is pre-inverted so it shows
-  // correctly after the filter (a black line draws as white, the day colour is
-  // inverted, etc). Layers, in z-order: a thick `route-line` (black -> white),
-  // a thin `route-color-accent` (inverted day colour) down its centre, and a
-  // wide transparent `route-hit-area` for click-to-select. DOM markers mark the
-  // start, end and the current photo (a square). A sun-lit terrain hillshade
-  // sits under the basemap, relit from the photo-time sun azimuth/altitude.
+  // basemap is the light Carto Positron style, drawn in its normal light form
+  // (no CSS inversion), with a neo-brutalist high-contrast route on top. Layers,
+  // in z-order: a thick ink `route-line` casing, a thin `route-color-accent`
+  // (the real day colour) down its centre, and a wide transparent
+  // `route-hit-area` for click-to-select. DOM markers mark the start, end and
+  // the current photo (a day-colour square). A subtle terrain hillshade sits
+  // under the basemap, its illumination direction relit from the photo-time sun.
   //
   // `currentCoords` ([lng, lat] or null) is the current photo's location with the
   // page's GPS interpolation already applied, so the square marker tracks photos
@@ -51,15 +50,6 @@
     ];
   }
 
-  // Invert a #rrggbb so it displays as the intended colour after the container's
-  // CSS invert(1). Returns an rgb() string.
-  function invertColor(hex) {
-    const r = 255 - parseInt(hex.slice(1, 3), 16);
-    const g = 255 - parseInt(hex.slice(3, 5), 16);
-    const b = 255 - parseInt(hex.slice(5, 7), 16);
-    return `rgb(${r}, ${g}, ${b})`;
-  }
-
   // Drop points within ~20m of the previous one (multiple GPS sources stack
   // duplicates that thicken the rendered line).
   function dedupePoints(pts) {
@@ -84,29 +74,18 @@
     return ((azimuthDeg % 360) + 360) % 360;
   }
 
+  // Subtle, standard (non-inverted) hillshade: shadows dark, highlights light.
+  // The sun still sets the illumination direction (azimuth) and the relief
+  // exaggeration (terrain reads stronger at low sun); the colours are fixed
+  // normals so the shading sits quietly under the light Positron basemap.
   function sunIntensity(sun) {
+    const shadowColor = "#5a5a5a";
+    const highlightColor = "#ffffff";
     if (!sun) {
-      return {
-        exaggeration: 0.8,
-        shadowColor: "#cccccc",
-        highlightColor: "#000000",
-      };
+      return { exaggeration: 0.8, shadowColor, highlightColor };
     }
     const altitudeDeg = (sun.altitude * 180) / Math.PI;
     const lerp = (a, b, t) => a + (b - a) * Math.max(0, Math.min(1, t));
-    const lerpColor = (c1, c2, t) => {
-      const r1 = parseInt(c1.slice(1, 3), 16),
-        g1 = parseInt(c1.slice(3, 5), 16),
-        b1 = parseInt(c1.slice(5, 7), 16);
-      const r2 = parseInt(c2.slice(1, 3), 16),
-        g2 = parseInt(c2.slice(3, 5), 16),
-        b2 = parseInt(c2.slice(5, 7), 16);
-      const r = Math.round(lerp(r1, r2, t)),
-        g = Math.round(lerp(g1, g2, t)),
-        b = Math.round(lerp(b1, b2, t));
-      return `#${r.toString(16).padStart(2, "0")}${g.toString(16).padStart(2, "0")}${b.toString(16).padStart(2, "0")}`;
-    };
-    const t = (altitudeDeg + 12) / 27;
     let exaggeration;
     if (altitudeDeg < -6) {
       exaggeration = lerp(0.2, 0.5, (altitudeDeg + 12) / 6);
@@ -115,8 +94,6 @@
     } else {
       exaggeration = 1.0;
     }
-    const shadowColor = lerpColor("#222222", "#ffffff", t);
-    const highlightColor = lerpColor("#111111", "#000000", t);
     return { exaggeration, shadowColor, highlightColor };
   }
 
@@ -142,7 +119,8 @@
         requestAnimationFrame(animate);
       } else {
         const el = document.createElement("div");
-        el.style.cssText = `width:24px;height:24px;background:${invertColor(dayColor)};border:3px solid black;cursor:pointer;`;
+        // Day-colour square with a chunky ink border (neo-brutalist).
+        el.style.cssText = `width:24px;height:24px;background:${dayColor};border:3px solid #1a1a1a;cursor:pointer;`;
         photoMarker = new maplibre.Marker({ element: el })
           .setLngLat(coords)
           .addTo(map);
@@ -235,7 +213,7 @@
               "hillshade-exaggeration": intensity.exaggeration,
               "hillshade-shadow-color": intensity.shadowColor,
               "hillshade-highlight-color": intensity.highlightColor,
-              "hillshade-accent-color": "#000000",
+              "hillshade-accent-color": "transparent",
               "hillshade-illumination-direction":
                 illuminationDirection(sunPosition),
             },
@@ -253,23 +231,23 @@
               geometry: { type: "LineString", coordinates },
             },
           });
-          // Thick black line: inverts to a clean white route.
+          // Thick ink casing: reads boldly on the light Positron basemap.
           map.addLayer({
             id: "route-line",
             type: "line",
             source: "route",
             layout: { "line-join": "round", "line-cap": "round" },
-            paint: { "line-color": "#000000", "line-width": 7, "line-opacity": 1 },
+            paint: { "line-color": "#1a1a1a", "line-width": 6, "line-opacity": 1 },
           });
-          // Thin inverted-day-colour accent down the centre.
+          // Thin real-day-colour core down the centre of the ink casing.
           map.addLayer({
             id: "route-color-accent",
             type: "line",
             source: "route",
             layout: { "line-join": "round", "line-cap": "round" },
             paint: {
-              "line-color": invertColor(dayColor),
-              "line-width": 1.5,
+              "line-color": dayColor,
+              "line-width": 2.5,
               "line-opacity": 1,
             },
           });
@@ -307,13 +285,14 @@
           }
         }
 
-        // Start / end DOM markers (inverted: black draws white, white draws
-        // black). The square current-photo marker is created by the $effect.
+        // Start / end DOM markers: start = solid ink dot with a white ring,
+        // end = white dot with an ink ring. The square current-photo marker is
+        // created by the $effect.
         const pts = geoPoints();
         if (pts.length > 0) {
           const startEl = document.createElement("div");
           startEl.style.cssText =
-            "width:16px;height:16px;background:#000000;border:3px solid #ffffff;border-radius:50%;"; /* nosemgrep: svelte-hardcoded-color-in-style */
+            "width:16px;height:16px;background:#1a1a1a;border:3px solid #ffffff;border-radius:50%;"; /* nosemgrep: svelte-hardcoded-color-in-style */
           new maplibre.Marker({ element: startEl })
             .setLngLat([pts[0].lng, pts[0].lat])
             .addTo(map);
@@ -326,7 +305,7 @@
           if (distance > 0.01) {
             const endEl = document.createElement("div");
             endEl.style.cssText =
-              "width:14px;height:14px;background:#ffffff;border:3px solid #000000;border-radius:50%;"; /* nosemgrep: svelte-hardcoded-color-in-style */
+              "width:14px;height:14px;background:#ffffff;border:3px solid #1a1a1a;border-radius:50%;"; /* nosemgrep: svelte-hardcoded-color-in-style */
             new maplibre.Marker({ element: endEl })
               .setLngLat([last.lng, last.lat])
               .addTo(map);
@@ -355,11 +334,14 @@
 <div class="map" style={`height:${height}`} bind:this={mapContainer}></div>
 
 <style>
-  /* The whole map is inverted so the light Carto basemap reads dark; every
-     colour drawn into it is pre-inverted to compensate. */
+  /* Light Positron basemap framed as a neo-brutalist card: chunky ink border
+     and a hard offset drop-shadow (no blur). box-sizing keeps the framed box at
+     its given height so the border does not change the outer dimensions. */
   .map {
     width: 100%;
+    box-sizing: border-box;
     overflow: hidden;
-    filter: invert(1);
+    border: 3px solid #1a1a1a;
+    box-shadow: 5px 5px 0 0 #1a1a1a;
   }
 </style>

--- a/projects/monolith/frontend/src/lib/public/components/trips/DayNav.svelte
+++ b/projects/monolith/frontend/src/lib/public/components/trips/DayNav.svelte
@@ -102,10 +102,11 @@
     align-items: center;
     gap: 20px;
     padding: 20px 0;
-    border-bottom: 2px solid #1a1a1a;
+    border-bottom: 3px solid #1a1a1a;
     margin-bottom: 24px;
   }
 
+  /* Neo-brutalist nav buttons: chunky ink border + hard offset drop-shadow. */
   .navbtn {
     display: flex;
     align-items: center;
@@ -116,21 +117,30 @@
     font-weight: 600;
     color: #1a1a1a; /* nosemgrep: svelte-hardcoded-color-in-style */
     background: white;
-    border: 2px solid #1a1a1a;
+    border: 3px solid #1a1a1a;
+    box-shadow: 3px 3px 0 0 #1a1a1a;
     text-decoration: none;
     cursor: pointer;
     transition:
       background 0.15s,
-      color 0.15s;
+      color 0.15s,
+      box-shadow 0.1s,
+      transform 0.1s;
   }
   a.navbtn:hover {
     background: #1a1a1a; /* nosemgrep: svelte-hardcoded-color-in-style */
     color: white;
   }
+  /* Tactile "press": the button shifts onto its shadow. */
+  a.navbtn:active {
+    transform: translate(2px, 2px);
+    box-shadow: 1px 1px 0 0 #1a1a1a;
+  }
   .navbtn.disabled {
     opacity: 0.4;
     cursor: not-allowed;
     pointer-events: none;
+    box-shadow: none;
   }
   .chev {
     width: 16px;

--- a/projects/monolith/frontend/src/routes/public/app/trips/[slug]/day/[day]/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/trips/[slug]/day/[day]/+page.svelte
@@ -225,8 +225,8 @@
       />
 
       <div class="stack">
-        <!-- MAP: full width, 280px, inverted basemap with the layered route line
-             + start/end/square-current markers. -->
+        <!-- MAP: full width, 280px, light Positron basemap with the layered
+             route line + start/end/square-current markers. -->
         <DayMap
           points={day.points}
           dayColor={color}
@@ -258,7 +258,8 @@
             {#if telemetry}
               {@const t = telemetry}
               <!-- ROW 1: TIME | SOLAR | LIGHT | EV | ELEV -->
-              <div class="cell r1 c-time">
+              <!-- TIME is the hero readout: a solid day-colour block. -->
+              <div class="cell r1 c-time" style={`background:${color}`}>
                 <div class="label">TIME</div>
                 <div class="time-big">
                   {t.time}<span class="period">{t.period}</span>
@@ -312,7 +313,7 @@
                       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6" /></svg>
                     </button>
                   </div>
-                  <div class="counter">{photos.length ? current + 1 : 0} / {photos.length}</div>
+                  <div class="counter" style={`background:${color}`}>{photos.length ? current + 1 : 0} / {photos.length}</div>
                 </div>
 
                 <div class="bearing">
@@ -399,11 +400,14 @@
     gap: 24px;
   }
 
-  /* TRIPTYCH: photo + data panel, sharing a 2px top rule. */
+  /* TRIPTYCH: photo + data panel framed as one neo-brutalist card: a chunky
+     ink border all around plus a hard offset drop-shadow (no blur). */
   .triptych {
     display: flex;
     align-items: stretch;
-    border-top: 2px solid #1a1a1a;
+    border: 3px solid #1a1a1a;
+    box-shadow: 5px 5px 0 0 #1a1a1a;
+    background: white;
   }
   .photo {
     flex: 0 0 auto;
@@ -437,7 +441,7 @@
     display: grid;
     grid-template-columns: 150px 1fr 1fr 1fr 1fr;
     grid-template-rows: auto 1fr auto;
-    border-left: 2px solid #1a1a1a;
+    border-left: 3px solid #1a1a1a;
     font-family: monospace;
     min-width: 0;
   }
@@ -491,6 +495,14 @@
     color: #6b7280; /* nosemgrep: svelte-hardcoded-color-in-style */
     margin-left: 4px;
   }
+  /* TIME hero: white readout on the solid day-colour block (set inline). */
+  .c-time .label,
+  .c-time .period {
+    color: rgba(255, 255, 255, 0.82);
+  }
+  .c-time .time-big {
+    color: white;
+  }
 
   /* Row 2, column 1: optics / nav / bearing stack. */
   .col1 {
@@ -535,7 +547,8 @@
     cursor: pointer;
     transition:
       background 0.15s,
-      color 0.15s;
+      color 0.15s,
+      transform 0.1s;
   }
   .navstep.border-r {
     border-right: 2px solid #1a1a1a;
@@ -548,14 +561,19 @@
     background: #1a1a1a; /* nosemgrep: svelte-hardcoded-color-in-style */
     color: white;
   }
+  /* Tactile press to match the day-nav buttons. */
+  .navstep:active:not(:disabled) {
+    transform: translate(1px, 1px);
+  }
   .navstep:disabled {
     opacity: 0.3;
     cursor: not-allowed;
   }
+  /* Photo counter: a solid day-colour accent block (set inline) with white text. */
   .counter {
     font-size: 11px;
     font-weight: 700;
-    color: #1a1a1a; /* nosemgrep: svelte-hardcoded-color-in-style */
+    color: white;
     text-align: center;
     padding: 8px;
     border-top: 2px solid #1a1a1a;
@@ -662,7 +680,6 @@
     }
     .triptych {
       flex-direction: column;
-      border-top: none;
     }
     .photo {
       width: 100%;


### PR DESCRIPTION
Aesthetic pass on the (now structurally-locked) day view.

- **Map un-inverted**: removed `filter: invert(1)`; route re-colored to real values, a 6px ink casing with a vivid `dayColor` 2.5px core (reads boldly on the light Carto Positron basemap instead of the inverted black/white blob). Markers use real colors (ink start dot, white end dot, `dayColor` square current marker w/ ink border). Hillshade relighting simplified to normal (non-inverted) tones.
- **Neo-brutalist panels** (same grid/positions/sizes): hard offset drop-shadows (`5px 5px 0` ink on the photo+panel card and map, `3px 3px 0` on nav buttons), chunkier 3px ink frames, the TIME readout + photo counter as solid `dayColor` blocks, tactile press on buttons.

No layout/data/sizing changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)