### PR TITLE
feat(frontend): add Trips to nav + refresh ships/stars/trips engineering arch

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.18.1
+version: 0.19.0
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.18.1
+      targetRevision: 0.19.0
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.174.1
+version: 0.175.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.174.1
+      targetRevision: 0.175.0
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/lib/public/components/Nav.svelte
+++ b/projects/monolith/frontend/src/lib/public/components/Nav.svelte
@@ -31,6 +31,12 @@
   // when an app page passes its own slug as `route`.
   const apps = [
     {
+      slug: "trips",
+      label: "Trips",
+      desc: "Geotagged photo journeys",
+      href: "/app/trips",
+    },
+    {
       slug: "hikes",
       label: "Hikes",
       desc: "Scottish hill-walk planner",
@@ -145,7 +151,27 @@
                     onclick={() => (open = false)}
                   >
                     <span class="md-apps-icon" aria-hidden="true">
-                      {#if app.slug === "hikes"}
+                      {#if app.slug === "trips"}
+                        <svg width="22" height="22" viewBox="0 0 24 24">
+                          <path
+                            d="M5 20 C 7 14 12 14 17 12"
+                            fill="none"
+                            stroke="currentColor"
+                            stroke-width="1.8"
+                            stroke-linecap="round"
+                            stroke-dasharray="0.2 3.4"
+                          />
+                          <circle cx="5" cy="20" r="1.9" fill="currentColor" stroke="none" />
+                          <path
+                            d="M17 3 C 14.5 3 13 4.8 13 6.8 C 13 9.6 17 12.5 17 12.5 C 17 12.5 21 9.6 21 6.8 C 21 4.8 19.5 3 17 3 Z"
+                            fill="none"
+                            stroke="currentColor"
+                            stroke-width="1.8"
+                            stroke-linejoin="round"
+                          />
+                          <circle cx="17" cy="6.8" r="1.4" fill="currentColor" stroke="none" />
+                        </svg>
+                      {:else if app.slug === "hikes"}
                         <svg width="22" height="22" viewBox="0 0 24 24">
                           <path
                             d="M2 20 L9 6 L13 13 L16 8 L22 20 Z"
@@ -406,6 +432,15 @@
   .md-apps-item[data-app="notes"]:hover .md-apps-icon,
   .md-apps-item[data-app="notes"]:focus-visible .md-apps-icon {
     background: #ffd84d; /* nosemgrep: svelte-hardcoded-color-in-style */
+  }
+
+  .md-apps-item[data-app="trips"]:hover,
+  .md-apps-item[data-app="trips"]:focus-visible {
+    background: #ffece9; /* nosemgrep: svelte-hardcoded-color-in-style */
+  }
+  .md-apps-item[data-app="trips"]:hover .md-apps-icon,
+  .md-apps-item[data-app="trips"]:focus-visible .md-apps-icon {
+    background: #ff8d7a; /* nosemgrep: svelte-hardcoded-color-in-style */
   }
 
   .md-apps-icon {

--- a/projects/monolith/frontend/src/routes/public/engineering/diagrams/Ships.svelte
+++ b/projects/monolith/frontend/src/routes/public/engineering/diagrams/Ships.svelte
@@ -7,11 +7,13 @@
 <Diagram label="AIS pipeline">
   <DBox role="external">AISStream.io</DBox>
   <DArrow label="WebSocket" />
-  <DBox role="process">ais-ingest</DBox>
+  <DBox role="process" sub="in monolith">AIS ingest</DBox>
+  <DArrow label="batched write" />
+  <DBox role="store" sub="daily partitions">Postgres</DBox>
+  <DArrow label="snapshot" />
+  <DBox role="process" sub="SSR">ships-api</DBox>
   <DArrow />
-  <DBox role="store">NATS JetStream</DBox>
-  <DArrow label="replay + subscribe" />
-  <DBox role="process">ships-api</DBox>
+  <DBox role="external">Cloudflare CDN</DBox>
   <DArrow />
   <DBox role="output" sub="MapLibre">jomcgi.dev/app/ships</DBox>
 </Diagram>

--- a/projects/monolith/frontend/src/routes/public/engineering/diagrams/Stargazer.svelte
+++ b/projects/monolith/frontend/src/routes/public/engineering/diagrams/Stargazer.svelte
@@ -5,19 +5,15 @@
   import DArrow from "$lib/public/components/diagrams/DArrow.svelte";
 </script>
 
-<Diagram label="Scoring pipeline">
-  <DGroup label="Acquire" stack>
-    <DBox role="source">Light pollution</DBox>
-    <DBox role="source">OSM roads</DBox>
-    <DBox role="source">SRTM elevation</DBox>
-    <DBox role="source">MET Norway</DBox>
+<Diagram label="Forecast scoring">
+  <DGroup label="Sources" stack>
+    <DBox role="store" sub="from SeaweedFS">LP site grid</DBox>
+    <DBox role="external">MET Norway</DBox>
   </DGroup>
+  <DArrow label="hourly" />
+  <DBox role="process" sub="dark + clear">Score hours</DBox>
   <DArrow />
-  <DGroup label="Process" stack>
-    <DBox role="process">Dark regions</DBox>
-    <DBox role="process">Road buffers</DBox>
-    <DBox role="process">Zones</DBox>
-  </DGroup>
+  <DBox role="store" sub="qualifying hours">stars.site_hours</DBox>
   <DArrow />
-  <DBox role="output" sub="0 to 100">Composite score</DBox>
+  <DBox role="output" sub="SSR, edge-cached">jomcgi.dev/app/stars</DBox>
 </Diagram>

--- a/projects/monolith/frontend/src/routes/public/engineering/diagrams/Trips.svelte
+++ b/projects/monolith/frontend/src/routes/public/engineering/diagrams/Trips.svelte
@@ -6,20 +6,20 @@
 </script>
 
 <Diagram label="Camera to browser">
-  <DBox role="source" sub="27MP interval">GoPro</DBox>
+  <DBox role="source" sub="GPS interval">GoPro</DBox>
   <DArrow />
   <DBox role="store">SQLite queue</DBox>
-  <DArrow />
-  <DBox role="process">EXIF + GPS</DBox>
+  <DArrow label="Cloudflare Access" />
+  <DBox role="process" sub="server-side">EXIF ingest</DBox>
   <DArrow />
   <DGroup label="Storage" stack>
+    <DBox role="store">Postgres</DBox>
     <DBox role="store">SeaweedFS</DBox>
-    <DBox role="store">NATS JetStream</DBox>
   </DGroup>
   <DArrow />
   <DBox role="process" sub="resize on the fly">imgproxy</DBox>
   <DArrow />
   <DBox role="external">Cloudflare CDN</DBox>
   <DArrow />
-  <DBox role="output" sub="SvelteKit SSR">/app/trips</DBox>
+  <DBox role="output" sub="SSR, read-only">/app/trips</DBox>
 </Diagram>

--- a/projects/monolith/frontend/src/routes/public/engineering/engineering-data.js
+++ b/projects/monolith/frontend/src/routes/public/engineering/engineering-data.js
@@ -262,25 +262,29 @@ export const projects = [
     category: "apps",
     title: "Trips: Camera to Browser",
     oneLiner:
-      "A dash-mounted GoPro becomes a live trip feed: EXIF extraction, event sourcing on NATS, on-the-fly image resizing, edge caching.",
+      "A dash-mounted GoPro becomes a browseable journey: server-side EXIF extraction, Postgres-backed trip points, on-the-fly image resizing, edge caching.",
     motivation:
-      "I wanted an easy way to share trips with friends and family. A GoPro on the dash captures photos automatically, and my homelab turns them into a live feed they can follow along with, or replay later. Works for anything with GPS-tagged photos.",
+      "I wanted an easy way to share trips with friends and family. A GoPro on the dash captures photos automatically, and my homelab turns them into a map they can follow day by day, or replay later. Works for anything with GPS-tagged photos.",
     facts: [
       {
         k: "Capture",
         v: "A Python asyncio controller drives the camera over WiFi: GPS-triggered interval capture, a persistent SQLite download queue, and exponential backoff on connection drops.",
       },
       {
-        k: "Event store",
-        v: "Trip points are events in NATS JetStream. The API replays the stream on startup to rebuild state (about 200ms for 10k events) and deletions are tombstone events. No database.",
+        k: "Ingest",
+        v: "Each geotagged frame is POSTed to a private endpoint gated by Cloudflare Access at the gateway (no app-level key). The server extracts EXIF, derives a trip point, and upserts it. The write path ships only in the private image, so it is unreachable from the internet.",
+      },
+      {
+        k: "Store",
+        v: "Postgres is the source of truth for trip points; folding trips into the monolith retired the old NATS event store. Image bytes live content-addressed in SeaweedFS, so a re-POST of the same frame is idempotent.",
       },
       {
         k: "Delivery",
-        v: "27MB originals live in SeaweedFS; imgproxy resizes on the fly and Cloudflare CDN caches at the edge. Content-addressed keys mean cache invalidation is never needed.",
+        v: "imgproxy resizes originals on the fly and Cloudflare caches at the edge. Content-addressed keys mean cache invalidation is never needed.",
       },
       {
         k: "Display",
-        v: "MapLibre vector tiles with terrain hillshade, day-by-day galleries, elevation profiles, and WebSocket live updates during active trips.",
+        v: "A read-only, SSR tier renders the public pages from localhost in-pod and is CDN-cached: MapLibre vector tiles with terrain hillshade, day-by-day galleries, and an elevation-profile scrubber. No live socket, the public reads never touch the write path.",
       },
     ],
     links: [{ label: "Live trips", href: "/app/trips" }],
@@ -290,25 +294,25 @@ export const projects = [
     category: "apps",
     title: "Ships: AIS Vessel Tracking",
     oneLiner:
-      "Live maritime traffic on a map: AIS position reports streamed through the cluster to a MapLibre frontend over WebSockets.",
+      "Live maritime traffic on a map: AIS position reports streamed into the cluster, persisted to Postgres, and served as a CDN-cached MapLibre snapshot.",
     motivation:
-      "Living near the coast, I wanted to see what ships are passing by in real time. AIS data is publicly broadcast by vessels, but there is no simple way to visualize it locally. This pipeline streams AIS data through my cluster to a live map.",
+      "Living near the coast, I wanted to see what ships are passing by in real time. AIS data is publicly broadcast by vessels, but there is no simple way to visualize it locally. This pipeline streams AIS data through my cluster onto a map.",
     facts: [
       {
         k: "AIS ingest",
-        v: "A Python service holds a WebSocket to AISStream.io, filters to a Pacific Northwest bounding box, and publishes position reports to NATS JetStream.",
+        v: "A supervised background task inside the monolith holds a websocket to AISStream.io, filters to a Pacific Northwest bounding box, and batches position reports. NATS is gone: it writes straight to Postgres, and an AISStream hiccup can never crash the app.",
       },
       {
-        k: "Event sourcing",
-        v: "Same pattern as Trips: JetStream is the source of truth and the API replays the stream on startup to rebuild vessel state.",
+        k: "Storage",
+        v: "Postgres is the single source of truth. ships.positions is range-partitioned by day, so retention drops whole partitions with zero vacuum churn; a stateless persister reads affected vessels back, dedups, and upserts a latest-positions serving table.",
       },
       {
         k: "Ships API",
-        v: "REST plus WebSocket streaming, with position deduplication to cut noise from stationary vessels.",
+        v: "SSR-only REST reached from localhost in-pod: a snapshot endpoint for the initial render and a per-vessel track on click. Both are CDN-cached with ETag 304s, so they run a few times a minute regardless of how many browsers are watching.",
       },
       {
         k: "MapLibre UI",
-        v: "Vessels render as directional arrows by heading. Click for ship type, speed, course, and destination.",
+        v: "Vessels render as a GPU GeoJSON symbol layer, directional icons by heading, so panning stays smooth at scale. A separate WebGL layer maps distinct-vessel traffic density per ~500m cell.",
       },
     ],
     links: [
@@ -321,27 +325,27 @@ export const projects = [
   {
     id: "stargazer",
     category: "apps",
-    title: "Stargazer",
+    title: "Stars: Dark-Sky Windows",
     oneLiner:
-      "Scores stargazing locations by combining light pollution, road access, elevation, and rolling weather forecasts into one number.",
+      "Finds the best dark-sky viewing windows across Scotland: scores each site's upcoming hours for darkness and clear sky, then serves the ones that qualify.",
     motivation:
-      "Finding good stargazing spots means combining light pollution maps, road access, elevation for horizon clearance, and the weather forecast. Stargazer scores locations across Scotland on all of these and updates continuously.",
+      "Finding a good stargazing night means combining how dark a site is with whether the sky will actually be clear once it gets dark. Stars pairs a light-pollution grid of road-accessible dark sites with rolling weather forecasts and surfaces the upcoming hours that are both dark and clear.",
     facts: [
       {
-        k: "16-task DAG",
-        v: "Parallel acquisition of the light pollution atlas, OSM road network, SRTM elevation, and MET Norway forecasts, scheduled by dependency.",
+        k: "Site grid",
+        v: "A light-pollution grid of ~14k road-accessible dark sites is built offline and uploaded to SeaweedFS; a scheduled job wholesale-replaces the stars.sites table from it, so the scorer always works off a current site list.",
       },
       {
-        k: "Spatial analysis",
-        v: "Dark-region extraction from the light pollution raster, road buffering for accessibility, zone classification by sky quality.",
+        k: "Forecast scoring",
+        v: "An hourly job fetches MET Norway forecasts for every site and scores each future hour for darkness (sun below the threshold, astronomy via astral) and clear sky (cloud below the threshold).",
       },
       {
-        k: "Weather scoring",
-        v: "Cloud cover, humidity, fog probability, wind, and dew point with configurable weights, refreshed hourly.",
+        k: "Metric",
+        v: "The unit is clear-dark hours, not a single composite score. Qualifying hours land in Postgres (stars.site_hours); an hourly prune drops hours once their clock hour has elapsed.",
       },
       {
-        k: "Composite score",
-        v: "0 to 100: darkness 40%, weather 25%, accessibility 20%, horizon 15%. Filterable by threshold.",
+        k: "Delivery",
+        v: "A wholly public, read-only domain folded into the monolith: a slim SSR payload lists sites with their upcoming windows, the per-site history graph loads lazily, and the page is edge-cached.",
       },
     ],
     links: [


### PR DESCRIPTION
## What

Two things, both driven by trips having folded into the monolith:

### 1. Nav: add Trips to the APPS dropdown
- New `trips` entry in the shared `Nav.svelte` apps list, featured first.
- Custom icon (a dotted route line from a start dot to a map pin) and a coral hover accent (`#ffece9` / `#ff8d7a`), consistent with the per-app accent pattern.
- The trips app pages don't render the shared Nav and no `/app/*` page wires `route=`, so this is a pure dropdown addition (no active-highlight plumbing needed).

### 2. Engineering page: refresh all three colocated apps to the monolith architecture
The Trips/Ships/Stars entries still described the **retired standalone designs** (NATS JetStream event sourcing, "No database", WebSocket live, a 0-100 composite scoring service). Rewrote the copy + facts + diagrams to the real current architecture:

- **Trips**: Postgres is the source of truth; private `POST /api/trips/ingest` gated by Cloudflare Access at the gateway (no app key); server-side EXIF; content-addressed bytes in the `monolith-trips` SeaweedFS bucket; SSR-only read tier, no live socket.
- **Ships**: a supervised in-monolith AISStream websocket task writing batched straight to **day-partitioned Postgres** (NATS gone); SSR snapshot + per-vessel track API, CDN-cached with ETag 304s; GPU GeoJSON symbol layer + WebGL traffic heatmap.
- **Stars**: dark-sky **viewing windows** scored hourly from MET Norway forecasts over a SeaweedFS-sourced site grid; metric is **clear-dark hours** (not a composite 0-100 score), stored in `stars.site_hours`; public read-only SSR. (Retitled "Stargazer" -> "Stars: Dark-Sky Windows"; kept the `stargazer` id to avoid a cross-file diagram-registry rename.)

Diagrams `Trips.svelte` / `Ships.svelte` / `Stargazer.svelte` redrawn to the new data flows.

## Notes
- No manual chart bump: the `chart-version-bot` computes the bump from this `feat:` commit over each chart's Bazel dep closure (the shared frontend is in both `monolith` and `monolith-public`) and keeps `application.yaml` in sync. Leaving versions untouched keeps the targetRevision sync-check green.
- All copy is em-dash free (the `engineering-data.test.js` no-em-dash assertion covers the data objects).

## Out of scope (flagged earlier)
- The elevation-profile marker smoothing fix from the prior discussion is intentionally not bundled here; happy to do it as a follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)