### PR TITLE
fix(trips): smooth the day-view elevation marker

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.19.0
+version: 0.19.1
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.19.0
+      targetRevision: 0.19.1
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.175.0
+version: 0.175.1
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.175.0
+      targetRevision: 0.175.1
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/lib/public/components/trips/DayElevationProfile.svelte
+++ b/projects/monolith/frontend/src/lib/public/components/trips/DayElevationProfile.svelte
@@ -6,34 +6,48 @@
   // route. The marker is an absolutely positioned div (a true circle) rather than
   // an SVG node, since the viewBox is x-stretched (preserveAspectRatio="none").
   //
-  // `data` is the sampled elevation array; `currentIndex` is the marker's index
-  // into it; `accentColor` tints the marker (the day colour).
-  let { data = [], currentIndex = 0, accentColor = "#dc2626" } = $props();
+  // `data` is the sampled elevation array (decimated to ~60 points for a cheap
+  // polyline). `progress` is the marker's position as a continuous 0..1 fraction
+  // of the route, NOT an index into `data`: placing the marker by a sample index
+  // would snap it to one of ~60 fixed x-positions and make it jump in chunky
+  // steps. We map the fraction onto the profile and linearly interpolate the
+  // height between the two bracketing samples, then let CSS glide it between
+  // photos. `accentColor` tints the marker (the day colour).
+  let { data = [], progress = 0, accentColor = "#dc2626" } = $props();
 
   const min = $derived(data.length ? Math.min(...data) : 0);
   const max = $derived(data.length ? Math.max(...data) : 1);
   const range = $derived(max - min || 1);
 
+  const clamped = $derived(Math.max(0, Math.min(1, progress)));
+
   // Normalised 0..100 viewBox (height 100), matching the original formula:
   // y = 100 - ((val - min) / range) * (100 - 4) - 2.
+  const yFor = (val) => 100 - ((val - min) / range) * 96 - 2;
+
   const points = $derived(
     data
       .map((val, i) => {
         const x = data.length > 1 ? (i / (data.length - 1)) * 100 : 0;
-        const y = 100 - ((val - min) / range) * 96 - 2;
-        return `${x},${y}`;
+        return `${x},${yFor(val)}`;
       })
       .join(" "),
   );
 
-  const markerLeftPercent = $derived(
-    data.length > 1 ? (currentIndex / (data.length - 1)) * 100 : 50,
-  );
-  const markerTopPercent = $derived(
-    data[currentIndex] != null
-      ? 100 - ((data[currentIndex] - min) / range) * 96 - 2
-      : 50,
-  );
+  const markerLeftPercent = $derived(data.length > 1 ? clamped * 100 : 50);
+
+  // Interpolated elevation at the continuous route fraction: walk to the
+  // fractional sample position and blend the two neighbouring samples, so the
+  // dot sits on the line at its true position rather than snapping to a sample.
+  const markerTopPercent = $derived.by(() => {
+    if (data.length === 0) return 50;
+    if (data.length === 1) return yFor(data[0]);
+    const pos = clamped * (data.length - 1);
+    const i0 = Math.floor(pos);
+    const i1 = Math.min(i0 + 1, data.length - 1);
+    const t = pos - i0;
+    return yFor(data[i0] + (data[i1] - data[i0]) * t);
+  });
 </script>
 
 {#if data.length}
@@ -107,5 +121,15 @@
     border-radius: 50%;
     border: 2px solid white;
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
+    /* Scrubbing is photo-to-photo (discrete), so glide the marker between
+       positions instead of teleporting. Position-only transition keeps it cheap. */
+    transition:
+      left 180ms ease,
+      top 180ms ease;
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .marker {
+      transition: none;
+    }
   }
 </style>

--- a/projects/monolith/frontend/src/lib/trips/telemetry.js
+++ b/projects/monolith/frontend/src/lib/trips/telemetry.js
@@ -134,6 +134,10 @@ export function cumulativeKm(dayPoints, photoTime) {
     km: Math.round(traveled),
     total: Math.round(total),
     percent: total > 0 ? Math.round((traveled / total) * 100) : 0,
+    // Un-rounded 0..1 ratio. `percent` is for the integer readout; the
+    // elevation-profile marker needs the raw fraction so it can sit at the
+    // photo's true route position instead of snapping to a whole percent.
+    fraction: total > 0 ? traveled / total : 0,
   };
 }
 
@@ -237,6 +241,9 @@ export function photoTelemetry(photo, dayPoints, tz) {
     // time. The elevation-profile cursor maps this onto the sampled profile so
     // the position marker tracks where the photo sits along the route.
     progressPercent: dist?.percent ?? 0,
+    // Same quantity un-rounded (0..1), used to place the elevation marker at the
+    // photo's exact route position rather than the nearest whole percent.
+    progressFraction: dist?.fraction ?? 0,
     // Optics passed straight through for the panel to format.
     focalLength35mm: photo.focal_length_35mm ?? null,
     aperture: photo.aperture ?? null,

--- a/projects/monolith/frontend/src/lib/trips/telemetry.test.js
+++ b/projects/monolith/frontend/src/lib/trips/telemetry.test.js
@@ -88,6 +88,11 @@ describe("cumulativeKm", () => {
     expect(d.km).toBeLessThan(13);
     expect(d.percent).toBeGreaterThan(0);
     expect(d.percent).toBeLessThan(100);
+    // The un-rounded fraction backs the elevation marker; percent is just it
+    // rounded to a whole number.
+    expect(d.fraction).toBeGreaterThan(0);
+    expect(d.fraction).toBeLessThan(1);
+    expect(Math.round(d.fraction * 100)).toBe(d.percent);
   });
 
   it("returns zero travelled for a photo at the day's start", () => {

--- a/projects/monolith/frontend/src/routes/public/app/trips/[slug]/day/[day]/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/trips/[slug]/day/[day]/+page.svelte
@@ -121,14 +121,12 @@
     };
   });
 
-  // Elevation sparkline: ~60 samples, with the position marker mapped onto it by
-  // the photo's progress fraction along the route (matches the original).
+  // Elevation sparkline: ~60 samples for the polyline, with the position marker
+  // placed by the photo's continuous progress fraction along the route. Passing
+  // the raw fraction (not a rounded sample index) lets the marker sit at its true
+  // position and glide between photos instead of snapping to one of ~60 buckets.
   const profile = $derived(day ? elevationSeries(day.points, 60) : []);
-  const profileIndex = $derived(
-    profile.length
-      ? Math.round(((telemetry?.progressPercent ?? 0) / 100) * (profile.length - 1))
-      : 0,
-  );
+  const profileProgress = $derived(telemetry?.progressFraction ?? 0);
 
   function step(delta) {
     if (!photos.length) return;
@@ -326,7 +324,7 @@
               <div class="elev-profile">
                 <div class="label">ELEVATION PROFILE</div>
                 <div class="elev-inner">
-                  <DayElevationProfile data={profile} currentIndex={profileIndex} accentColor={color} />
+                  <DayElevationProfile data={profile} progress={profileProgress} accentColor={color} />
                 </div>
               </div>
 


### PR DESCRIPTION
## Problem
The elevation-profile position marker jumped in chunky, uneven steps while scrubbing through a day's photos. The dot's placement was quantized **three times**:

1. `cumulativeKm` rounded progress to a whole percent.
2. `profileIndex` snapped that percent to one of ~60 decimated sample buckets.
3. The marker x was derived from that integer index, so it could only sit at ~60 fixed positions (~1.69% apart).

Adjacent photos in the same bucket → the marker didn't move at all; far-apart photos → it leapt a bucket or more. There was also no CSS transition, so each move was an instant teleport.

(Scrubbing is inherently photo-to-photo/discrete, so "smooth" here means: the marker reflects each photo's *true* route position, and *glides* between positions.)

## Fix
Thread the un-rounded route fraction end to end:

- **`telemetry.js`**: `cumulativeKm` now also returns `fraction` (raw `traveled/total`); `photoTelemetry` exposes it as `progressFraction`. `percent` is unchanged for the integer readouts.
- **`DayElevationProfile.svelte`**: takes a continuous `progress` (0..1) instead of `currentIndex`; places the marker x at `progress * 100`; linearly interpolates the marker height between the two bracketing samples so the dot sits on the line at its true position. The polyline stays cheaply decimated to ~60 points.
- **CSS**: position-only transition (180ms) so the marker glides, with a `prefers-reduced-motion` opt-out.
- **`+page.svelte`**: passes `progress={profileProgress}` (the raw fraction) instead of the rounded `profileIndex`.

## Tests
- Added assertions in the `cumulativeKm` block that `fraction` is the un-rounded `0..1` ratio and `round(fraction * 100) === percent`.
- The marker interpolation lives in the Svelte component (no render-harness test); it's pure derived state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)