### PR TITLE
fix(frontend): bundle marked into the SSR build for /docs

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.20.0
+version: 0.20.1
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.20.0
+      targetRevision: 0.20.1
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.176.0
+version: 0.176.1
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.176.0
+      targetRevision: 0.176.1
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/vite.config.js
+++ b/projects/monolith/frontend/vite.config.js
@@ -18,7 +18,13 @@ export default defineConfig({
     // The runtime image ships only the SvelteKit `build/` output — there is
     // no node_modules. Any package imported by SSR-rendered code must be
     // bundled into the server chunks, not externalized.
-    noExternal: ["@dagrejs/dagre", "d3-quadtree", "d3-selection", "d3-zoom"],
+    noExternal: [
+      "@dagrejs/dagre",
+      "d3-quadtree",
+      "d3-selection",
+      "d3-zoom",
+      "marked",
+    ],
   },
   server: {
     proxy: {


### PR DESCRIPTION
`/docs` deployed but 500'd in prod:

```
[500] GET /docs
Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'marked' imported from /app/build/server/chunks/4-*.js
```

The docs route renders markdown server-side (`$lib/server/docs.js`), the first SSR use of `marked`. `adapter-node` externalizes node_modules deps by default, but the runtime image ships only `build/` with no `node_modules` (as the existing `ssr.noExternal` comment in `vite.config.js` already documents for d3/dagre). Adding `marked` to `ssr.noExternal` bundles it into the server chunks.

Local node smoke test passed because `marked` was resolvable locally; the gap only appears in the hermetic image. One-line fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)