### PR TITLE
ci(semgrep): add logger-name-missing-monolith-prefix rule

### DIFF
--- a/bazel/semgrep/rules/python/logger-name-missing-monolith-prefix.py
+++ b/bazel/semgrep/rules/python/logger-name-missing-monolith-prefix.py
@@ -1,0 +1,39 @@
+# Tests for logger-name-missing-monolith-prefix rule.
+import logging
+
+# --- bad: string literal without monolith. prefix ---
+
+# ruleid: logger-name-missing-monolith-prefix
+logger = logging.getLogger("ships")
+
+# ruleid: logger-name-missing-monolith-prefix
+logger = logging.getLogger("hikes")
+
+# ruleid: logger-name-missing-monolith-prefix
+logger = logging.getLogger("dr_jobs")
+
+# ruleid: logger-name-missing-monolith-prefix
+logger = logging.getLogger("trips.backfill")
+
+# --- ok: correct monolith. prefix ---
+
+# ok: starts with monolith.
+logger = logging.getLogger("monolith.ships.router")
+
+# ok: starts with monolith.
+logger = logging.getLogger("monolith.hikes.jobs")
+
+# ok: starts with monolith.
+logger = logging.getLogger("monolith.dr_jobs.scraper")
+
+# ok: __name__ resolves at runtime and is outside the string-literal pattern
+logger = logging.getLogger(__name__)
+
+# ok: excluded third-party library logger names
+logging.getLogger("discord.gateway")
+logging.getLogger("discord.client")
+logging.getLogger("httpx")
+logging.getLogger("httpcore")
+logging.getLogger("uvicorn")
+logging.getLogger("uvicorn.access")
+logging.getLogger("uvicorn.error")

--- a/bazel/semgrep/rules/python/logger-name-missing-monolith-prefix.yaml
+++ b/bazel/semgrep/rules/python/logger-name-missing-monolith-prefix.yaml
@@ -1,0 +1,28 @@
+rules:
+  - id: logger-name-missing-monolith-prefix
+    patterns:
+      - pattern: logging.getLogger("$NAME")
+      - metavariable-regex:
+          metavariable: $NAME
+          regex: "^(?!monolith\\.)(?!discord)(?!httpx)(?!httpcore)(?!uvicorn)"
+    paths:
+      include:
+        - "projects/monolith/**"
+      exclude:
+        - "**/*_test.py"
+        - "**/test_*.py"
+    message: >-
+      Logger name "$NAME" does not start with "monolith.". Logger names under
+      projects/monolith/ must be prefixed with "monolith." so they inherit the
+      monolith logging configuration and appear correctly in observability tooling.
+      Use logging.getLogger("monolith.<module>") or logging.getLogger(__name__).
+    languages: [python]
+    severity: WARNING
+    metadata:
+      category: correctness
+      subcategory: logging
+      confidence: HIGH
+      likelihood: LOW
+      impact: LOW
+      technology: [python]
+      description: Logger name missing "monolith." prefix — will not inherit monolith log configuration

--- a/bazel/semgrep/tests/fixtures/logger-name-missing-monolith-prefix.py
+++ b/bazel/semgrep/tests/fixtures/logger-name-missing-monolith-prefix.py
@@ -1,0 +1,39 @@
+# Tests for logger-name-missing-monolith-prefix rule.
+import logging
+
+# --- bad: string literal without monolith. prefix ---
+
+# ruleid: logger-name-missing-monolith-prefix
+logger = logging.getLogger("ships")
+
+# ruleid: logger-name-missing-monolith-prefix
+logger = logging.getLogger("hikes")
+
+# ruleid: logger-name-missing-monolith-prefix
+logger = logging.getLogger("dr_jobs")
+
+# ruleid: logger-name-missing-monolith-prefix
+logger = logging.getLogger("trips.backfill")
+
+# --- ok: correct monolith. prefix ---
+
+# ok: starts with monolith.
+logger = logging.getLogger("monolith.ships.router")
+
+# ok: starts with monolith.
+logger = logging.getLogger("monolith.hikes.jobs")
+
+# ok: starts with monolith.
+logger = logging.getLogger("monolith.dr_jobs.scraper")
+
+# ok: __name__ resolves at runtime and is outside the string-literal pattern
+logger = logging.getLogger(__name__)
+
+# ok: excluded third-party library logger names
+logging.getLogger("discord.gateway")
+logging.getLogger("discord.client")
+logging.getLogger("httpx")
+logging.getLogger("httpcore")
+logging.getLogger("uvicorn")
+logging.getLogger("uvicorn.access")
+logging.getLogger("uvicorn.error")

--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.20.1
+version: 0.20.2
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.20.1
+      targetRevision: 0.20.2
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -3348,6 +3348,10 @@ semgrep_target_test(
         # in-memory upload bytes (NOT a filesystem path), so there is no path
         # traversal; the rule false-positives on any Image.open of request data.
         "tainted-path-traversal-pillow-fastapi",  # keep
+        # TODO: fix dr_jobs, ships, hikes, stars logger names to use "monolith."
+        # prefix. semgrep-core does not honour inline # nosemgrep, so excluded
+        # here until all callers are updated.
+        "logger-name-missing-monolith-prefix",  # keep
     ],
     rules = ["//bazel/semgrep/rules:python_rules"],
     target = ":main",
@@ -3715,6 +3719,9 @@ semgrep_target_test(
         "tainted-path-traversal-stdlib-fastapi",
         # validate_image opens in-memory bytes, not a path; false positive (mirrors :main).
         "tainted-path-traversal-pillow-fastapi",
+        # TODO: fix trips/backfill/main.py logger name to use "monolith." prefix.
+        # semgrep-core does not honour inline # nosemgrep, so excluded here until fixed.
+        "logger-name-missing-monolith-prefix",  # keep
     ],
     rules = ["//bazel/semgrep/rules:python_rules"],
     target = ":trips_backfill",
@@ -3838,6 +3845,10 @@ semgrep_target_test(
         "boto3-endpoint-url-missing-scheme",  # keep
         "test-hardcoded-past-timestamp",  # keep
         "tainted-path-traversal-pillow-fastapi",
+        # TODO: fix dr_jobs, ships, hikes, stars, app/main_public.py logger names
+        # to use "monolith." prefix. semgrep-core does not honour inline
+        # # nosemgrep, so excluded here until all callers are updated.
+        "logger-name-missing-monolith-prefix",  # keep
     ],
     rules = ["//bazel/semgrep/rules:python_rules"],
     target = ":main_public",

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.176.1
+version: 0.176.2
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.176.1
+      targetRevision: 0.176.2
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
## Summary

- Adds `bazel/semgrep/rules/python/logger-name-missing-monolith-prefix.yaml`: flags `logging.getLogger("...")` calls under `projects/monolith/` where the string argument does not start with `monolith.`
- Third-party library names (`discord`, `httpx`, `httpcore`, `uvicorn`) and `__name__` usage are allowed. Test files are excluded via `paths.exclude`
- Adds co-located annotation fixture (`rules/python/logger-name-missing-monolith-prefix.py`) picked up automatically by `python_rules_test`
- Adds reference fixture at `tests/fixtures/logger-name-missing-monolith-prefix.py`
- Suppresses 15 existing violations (dr_jobs x3, ships x5, hikes x4, stars x1, trips/backfill x1, app/main_public x1) via `exclude_rules` in `main_semgrep_test`, `trips_backfill_semgrep_test`, and `main_public_semgrep_test` with TODO comments to fix

## Notes

semgrep-core does not honour inline `# nosemgrep` comments (confirmed by existing comments in the BUILD file), so the `exclude_rules` pattern mirrors the established approach for `sqlmodel-datetime-without-factory` and `boto3-endpoint-url-missing-scheme`. The task says 14 violations; `app/main_public.py` uses `"monolith_public"` (underscore not dot) which is a 15th violation also suppressed here.

## Test plan

- [ ] `//bazel/semgrep/rules:python_rules_test` passes (co-located fixture has correct ruleid/ok annotations)
- [ ] `//projects/monolith:main_semgrep_test` passes (rule excluded via exclude_rules)
- [ ] `//projects/monolith:trips_backfill_semgrep_test` passes (rule excluded via exclude_rules)
- [ ] `//projects/monolith:main_public_semgrep_test` passes (rule excluded via exclude_rules)

🤖 Generated with [Claude Code](https://claude.com/claude-code)