### PR TITLE
feat(monolith-public): top-left back link on docs instead of site nav

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.22.0
+version: 0.23.0
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.20.4
+version: 0.21.0
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.21.0
+version: 0.22.0
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.21.0
+      targetRevision: 0.22.0
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.20.4
+      targetRevision: 0.21.0
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.22.0
+      targetRevision: 0.23.0
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.176.4
+version: 0.177.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.177.0
+version: 0.178.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.178.0
+version: 0.179.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.177.0
+      targetRevision: 0.178.0
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.176.4
+      targetRevision: 0.177.0
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.178.0
+      targetRevision: 0.179.0
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/routes/public/docs/DocsSearch.svelte
+++ b/projects/monolith/frontend/src/routes/public/docs/DocsSearch.svelte
@@ -1,0 +1,274 @@
+<script>
+  import { goto } from "$app/navigation";
+
+  /**
+   * Client-side navigational search over the doc titles already shipped in the
+   * sidebar (no bodies cross to the browser). Filters titles + section group;
+   * full-text content search is the site's knowledge search, per docs/002.
+   * @type {{ docs: {slug:string,title:string,group:string}[] }}
+   */
+  let { docs } = $props();
+
+  let query = $state("");
+  let open = $state(false);
+  let activeIndex = $state(0);
+  /** @type {HTMLInputElement | undefined} */
+  let inputEl = $state();
+  /** @type {HTMLElement | undefined} */
+  let rootEl = $state();
+
+  const results = $derived.by(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return [];
+    const out = [];
+    for (const d of docs) {
+      if (`${d.title} ${d.group}`.toLowerCase().includes(q)) out.push(d);
+      if (out.length >= 12) break;
+    }
+    return out;
+  });
+
+  // Reset the keyboard highlight whenever the result set changes.
+  $effect(() => {
+    void results;
+    activeIndex = 0;
+  });
+
+  function close() {
+    open = false;
+    query = "";
+  }
+
+  /** @param {{slug:string}} d */
+  function pick(d) {
+    close();
+    inputEl?.blur();
+    goto(`/docs/${d.slug}`);
+  }
+
+  /** @param {KeyboardEvent} e */
+  function onKeydown(e) {
+    if (e.key === "Escape") {
+      close();
+      inputEl?.blur();
+      return;
+    }
+    if (!results.length) return;
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      activeIndex = (activeIndex + 1) % results.length;
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      activeIndex = (activeIndex - 1 + results.length) % results.length;
+    } else if (e.key === "Enter") {
+      e.preventDefault();
+      if (results[activeIndex]) pick(results[activeIndex]);
+    }
+  }
+
+  // Cmd/Ctrl+K focuses the box, matching the old VitePress search shortcut.
+  /** @param {KeyboardEvent} e */
+  function onWindowKeydown(e) {
+    if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "k") {
+      e.preventDefault();
+      inputEl?.focus();
+    }
+  }
+
+  /** @param {MouseEvent} e */
+  function onWindowClick(e) {
+    if (open && rootEl && !rootEl.contains(/** @type {Node} */ (e.target)))
+      close();
+  }
+</script>
+
+<svelte:window onkeydown={onWindowKeydown} onclick={onWindowClick} />
+
+<div class="docs-search" bind:this={rootEl}>
+  <span class="docs-search-icon" aria-hidden="true">
+    <svg width="14" height="14" viewBox="0 0 24 24">
+      <circle
+        cx="11"
+        cy="11"
+        r="7"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+      />
+      <path
+        d="M21 21 L16 16"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+      />
+    </svg>
+  </span>
+  <input
+    bind:this={inputEl}
+    bind:value={query}
+    type="search"
+    class="docs-search-input"
+    placeholder="Search docs"
+    aria-label="Search documentation"
+    autocomplete="off"
+    onfocus={() => (open = true)}
+    onkeydown={onKeydown}
+  />
+  <kbd class="docs-search-kbd" aria-hidden="true">⌘K</kbd>
+
+  {#if open && results.length}
+    <ul class="docs-search-results" role="listbox">
+      {#each results as d, i}
+        <li role="option" aria-selected={i === activeIndex}>
+          <a
+            href={`/docs/${d.slug}`}
+            class="docs-search-item"
+            class:active={i === activeIndex}
+            onmouseenter={() => (activeIndex = i)}
+            onclick={(e) => {
+              e.preventDefault();
+              pick(d);
+            }}
+          >
+            <span class="docs-search-title">{d.title}</span>
+            <span class="docs-search-group">{d.group}</span>
+          </a>
+        </li>
+      {/each}
+    </ul>
+  {:else if open && query.trim()}
+    <div class="docs-search-empty">No matches</div>
+  {/if}
+</div>
+
+<style>
+  .docs-search {
+    position: relative;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 6px 10px;
+    background: var(--paper);
+    border: 2px solid var(--ink);
+    box-shadow: var(--shadow-hard-sm);
+  }
+
+  .docs-search-icon {
+    display: grid;
+    place-items: center;
+    color: var(--ink-3);
+    flex: 0 0 auto;
+  }
+
+  .docs-search-input {
+    border: none;
+    outline: none;
+    background: transparent;
+    font-family: var(--mono);
+    font-size: 12px;
+    letter-spacing: 0.04em;
+    color: var(--ink);
+    width: 150px;
+    padding: 0;
+  }
+
+  .docs-search-input::placeholder {
+    color: var(--ink-3);
+  }
+
+  /* Strip the native search clear affordance for a consistent brutalist look. */
+  .docs-search-input::-webkit-search-decoration,
+  .docs-search-input::-webkit-search-cancel-button {
+    appearance: none;
+  }
+
+  .docs-search-kbd {
+    font-family: var(--mono);
+    font-size: 10px;
+    font-weight: 600;
+    color: var(--ink-3);
+    border: 1px solid var(--rule-2);
+    border-radius: 3px;
+    padding: 1px 5px;
+    flex: 0 0 auto;
+  }
+
+  /* ── Dropdown ── */
+  .docs-search-results {
+    position: absolute;
+    top: calc(100% + 6px);
+    right: 0;
+    left: 0;
+    z-index: 60;
+    list-style: none;
+    margin: 0;
+    padding: 6px;
+    max-height: min(60vh, 420px);
+    overflow-y: auto;
+    background: var(--paper);
+    border: 2px solid var(--ink);
+    box-shadow: var(--shadow-hard);
+  }
+
+  .docs-search-item {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 8px 10px;
+    text-decoration: none;
+    border: 2px solid transparent;
+    transition:
+      background 120ms ease,
+      border-color 120ms ease;
+  }
+
+  .docs-search-item.active {
+    border-color: var(--ink);
+    background: var(--accent);
+  }
+
+  .docs-search-title {
+    font-family: var(--sans);
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--ink);
+    line-height: 1.25;
+  }
+
+  .docs-search-group {
+    flex: 0 0 auto;
+    font-family: var(--mono);
+    font-size: 10px;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--ink-3);
+  }
+
+  .docs-search-empty {
+    position: absolute;
+    top: calc(100% + 6px);
+    right: 0;
+    left: 0;
+    z-index: 60;
+    padding: 12px;
+    text-align: center;
+    font-family: var(--mono);
+    font-size: 11px;
+    color: var(--ink-3);
+    background: var(--paper);
+    border: 2px solid var(--ink);
+    box-shadow: var(--shadow-hard);
+  }
+
+  @media (max-width: 720px) {
+    .docs-search-kbd {
+      display: none;
+    }
+    .docs-search-input {
+      width: 96px;
+    }
+  }
+</style>

--- a/projects/monolith/frontend/src/routes/public/docs/DocsShell.svelte
+++ b/projects/monolith/frontend/src/routes/public/docs/DocsShell.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { Nav, Footer } from "$lib/public/components";
+  import { Footer } from "$lib/public/components";
 
   /**
    * @type {{
@@ -14,7 +14,12 @@
   const hasToc = $derived(Array.isArray(toc) && toc.length > 0);
 </script>
 
-<Nav route="docs" />
+<header class="docs-topbar">
+  <a class="docs-back" href="https://jomcgi.dev/">
+    <span class="docs-back-arrow" aria-hidden="true">&larr;</span>
+    <span class="docs-back-label">jomcgi.dev</span>
+  </a>
+</header>
 
 <div class="docs-layout" class:has-toc={hasToc}>
   <aside class="docs-side">
@@ -86,6 +91,62 @@
 <Footer />
 
 <style>
+  /* ── Top bar: a single back link to the apex, in place of the shared
+     site nav. Sticky height (~48px) matches the old nav so the sidebar /
+     TOC `top: 76px` offsets and heading scroll-margins stay valid. ── */
+  .docs-topbar {
+    position: sticky;
+    top: 0;
+    z-index: 50;
+    background: var(--paper);
+    border-bottom: 2px solid var(--ink);
+  }
+
+  .docs-back {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    max-width: 1280px;
+    margin: 0 auto;
+    padding: 14px 32px;
+    font-family: var(--mono);
+    font-size: 12px;
+    font-weight: 600;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--ink-2);
+    text-decoration: none;
+    transition: color 160ms ease;
+  }
+
+  .docs-back-arrow {
+    font-size: 14px;
+    transition: transform 160ms ease;
+  }
+
+  .docs-back:hover {
+    color: var(--ink);
+  }
+
+  .docs-back:hover .docs-back-arrow {
+    transform: translateX(-3px);
+  }
+
+  .docs-back-label {
+    border-bottom: 2px solid transparent;
+    transition: border-color 160ms ease;
+  }
+
+  .docs-back:hover .docs-back-label {
+    border-bottom-color: var(--coral);
+  }
+
+  @media (max-width: 1080px) {
+    .docs-back {
+      padding: 12px 20px;
+    }
+  }
+
   .docs-layout {
     display: grid;
     grid-template-columns: 248px minmax(0, 1fr);

--- a/projects/monolith/frontend/src/routes/public/docs/DocsShell.svelte
+++ b/projects/monolith/frontend/src/routes/public/docs/DocsShell.svelte
@@ -1,5 +1,6 @@
 <script>
   import { Footer } from "$lib/public/components";
+  import DocsSearch from "./DocsSearch.svelte";
 
   /**
    * @type {{
@@ -18,6 +19,42 @@
   // (empty slug) leaves both inactive.
   const onDecisions = $derived(activeSlug.startsWith("decisions"));
   const onReference = $derived(activeSlug !== "" && !onDecisions);
+
+  // Flat doc list for search: titles/slugs only (already client-safe), tagged
+  // with their sidebar group so results can show where each doc lives.
+  const allDocs = $derived([
+    ...sidebar.reference.map((d) => ({
+      slug: d.slug,
+      title: d.title,
+      group: "Reference",
+    })),
+    ...(sidebar.decisions.index
+      ? [
+          {
+            slug: sidebar.decisions.index.slug,
+            title: sidebar.decisions.index.title,
+            group: "Decisions",
+          },
+        ]
+      : []),
+    ...sidebar.decisions.categories.flatMap((c) =>
+      c.items.map((d) => ({ slug: d.slug, title: d.title, group: c.name })),
+    ),
+  ]);
+
+  // Collapsible ADR categories (accordion), matching VitePress's `collapsed`
+  // groups. Start collapsed except the category holding the active doc, which
+  // opens so the current page is visible on load.
+  const DECISIONS_PREFIX = "decisions/";
+  const activeCat = activeSlug.startsWith(DECISIONS_PREFIX)
+    ? activeSlug.slice(DECISIONS_PREFIX.length).split("/")[0]
+    : null;
+  let openCats = $state(activeCat ? { [activeCat]: true } : {});
+
+  /** @param {string} name */
+  function toggleCat(name) {
+    openCats = { ...openCats, [name]: !openCats[name] };
+  }
 </script>
 
 <header class="docs-topbar">
@@ -27,20 +64,28 @@
       <span class="docs-back-label">jomcgi.dev</span>
     </a>
 
-    <nav class="docs-topnav" aria-label="Documentation sections">
-      <a class="docs-topnav-link" class:active={onReference} href="/docs/services"
-        >Architecture</a
-      >
-      <a class="docs-topnav-link" class:active={onDecisions} href="/docs/decisions"
-        >ADRs</a
-      >
-      <a
-        class="docs-topnav-link"
-        href="https://github.com/jomcgi/homelab"
-        target="_blank"
-        rel="noopener noreferrer">GitHub</a
-      >
-    </nav>
+    <div class="docs-topbar-right">
+      <DocsSearch docs={allDocs} />
+
+      <nav class="docs-topnav" aria-label="Documentation sections">
+        <a
+          class="docs-topnav-link"
+          class:active={onReference}
+          href="/docs/services">Architecture</a
+        >
+        <a
+          class="docs-topnav-link"
+          class:active={onDecisions}
+          href="/docs/decisions">ADRs</a
+        >
+        <a
+          class="docs-topnav-link"
+          href="https://github.com/jomcgi/homelab"
+          target="_blank"
+          rel="noopener noreferrer">GitHub</a
+        >
+      </nav>
+    </div>
   </div>
 </header>
 
@@ -74,19 +119,45 @@
       </ul>
 
       {#each sidebar.decisions.categories as cat}
-        <p class="side-subhead">{cat.name}</p>
-        <ul class="side-list">
-          {#each cat.items as item}
-            <li>
-              <a
-                class="side-link"
-                class:active={activeSlug === item.slug}
-                href={`/docs/${item.slug}`}
-                title={item.title}>{item.title}</a
-              >
-            </li>
-          {/each}
-        </ul>
+        <button
+          type="button"
+          class="side-cat"
+          aria-expanded={!!openCats[cat.name]}
+          onclick={() => toggleCat(cat.name)}
+        >
+          <svg
+            class="side-cat-chevron"
+            class:open={openCats[cat.name]}
+            width="9"
+            height="9"
+            viewBox="0 0 10 10"
+            aria-hidden="true"
+          >
+            <path
+              d="M3 1 L7 5 L3 9"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.6"
+              stroke-linecap="square"
+            />
+          </svg>
+          <span class="side-cat-name">{cat.name}</span>
+          <span class="side-cat-count">{cat.items.length}</span>
+        </button>
+        {#if openCats[cat.name]}
+          <ul class="side-list">
+            {#each cat.items as item}
+              <li>
+                <a
+                  class="side-link"
+                  class:active={activeSlug === item.slug}
+                  href={`/docs/${item.slug}`}
+                  title={item.title}>{item.title}</a
+                >
+              </li>
+            {/each}
+          </ul>
+        {/if}
       {/each}
     </nav>
   </aside>
@@ -172,7 +243,14 @@
     border-bottom-color: var(--coral);
   }
 
-  /* ── Right-hand section nav ── */
+  /* ── Right-hand cluster: search + section nav ── */
+  .docs-topbar-right {
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    min-width: 0;
+  }
+
   .docs-topnav {
     display: flex;
     align-items: center;
@@ -285,14 +363,47 @@
     margin-top: 0;
   }
 
-  .side-subhead {
+  /* ── Collapsible ADR category (accordion disclosure) ── */
+  .side-cat {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    width: 100%;
+    margin: 12px 0 6px;
+    padding: 4px 0;
+    background: none;
+    border: none;
+    cursor: pointer;
     font-family: var(--mono);
     font-size: 10px;
     font-weight: 600;
     letter-spacing: 0.12em;
     text-transform: uppercase;
     color: var(--ink-3);
-    margin: 12px 0 6px;
+    text-align: left;
+    transition: color 120ms ease;
+  }
+
+  .side-cat:hover {
+    color: var(--ink);
+  }
+
+  .side-cat-chevron {
+    flex: 0 0 auto;
+    transition: transform 140ms ease;
+  }
+
+  .side-cat-chevron.open {
+    transform: rotate(90deg);
+  }
+
+  .side-cat-name {
+    flex: 1 1 auto;
+  }
+
+  .side-cat-count {
+    flex: 0 0 auto;
+    color: var(--ink-3);
   }
 
   .side-list {

--- a/projects/monolith/frontend/src/routes/public/docs/DocsShell.svelte
+++ b/projects/monolith/frontend/src/routes/public/docs/DocsShell.svelte
@@ -12,13 +12,36 @@
   let { sidebar, toc = [], activeSlug = "", children } = $props();
 
   const hasToc = $derived(Array.isArray(toc) && toc.length > 0);
+
+  // Top-nav active state, mirroring the old VitePress nav: ADRs lights up on any
+  // decisions page, Architecture on any other (reference) doc. The /docs index
+  // (empty slug) leaves both inactive.
+  const onDecisions = $derived(activeSlug.startsWith("decisions"));
+  const onReference = $derived(activeSlug !== "" && !onDecisions);
 </script>
 
 <header class="docs-topbar">
-  <a class="docs-back" href="https://jomcgi.dev/">
-    <span class="docs-back-arrow" aria-hidden="true">&larr;</span>
-    <span class="docs-back-label">jomcgi.dev</span>
-  </a>
+  <div class="docs-topbar-inner">
+    <a class="docs-back" href="https://jomcgi.dev/">
+      <span class="docs-back-arrow" aria-hidden="true">&larr;</span>
+      <span class="docs-back-label">jomcgi.dev</span>
+    </a>
+
+    <nav class="docs-topnav" aria-label="Documentation sections">
+      <a class="docs-topnav-link" class:active={onReference} href="/docs/services"
+        >Architecture</a
+      >
+      <a class="docs-topnav-link" class:active={onDecisions} href="/docs/decisions"
+        >ADRs</a
+      >
+      <a
+        class="docs-topnav-link"
+        href="https://github.com/jomcgi/homelab"
+        target="_blank"
+        rel="noopener noreferrer">GitHub</a
+      >
+    </nav>
+  </div>
 </header>
 
 <div class="docs-layout" class:has-toc={hasToc}>
@@ -91,9 +114,10 @@
 <Footer />
 
 <style>
-  /* ── Top bar: a single back link to the apex, in place of the shared
-     site nav. Sticky height (~48px) matches the old nav so the sidebar /
-     TOC `top: 76px` offsets and heading scroll-margins stay valid. ── */
+  /* ── Top bar: apex back link on the left, docs section nav on the right
+     (mirrors the old VitePress nav). Sticky height (~48px) matches the old
+     site nav so the sidebar / TOC `top: 76px` offsets and heading
+     scroll-margins stay valid. ── */
   .docs-topbar {
     position: sticky;
     top: 0;
@@ -102,13 +126,20 @@
     border-bottom: 2px solid var(--ink);
   }
 
+  .docs-topbar-inner {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+    max-width: 1280px;
+    margin: 0 auto;
+    padding: 14px 32px;
+  }
+
   .docs-back {
     display: inline-flex;
     align-items: center;
     gap: 8px;
-    max-width: 1280px;
-    margin: 0 auto;
-    padding: 14px 32px;
     font-family: var(--mono);
     font-size: 12px;
     font-weight: 600;
@@ -141,9 +172,72 @@
     border-bottom-color: var(--coral);
   }
 
+  /* ── Right-hand section nav ── */
+  .docs-topnav {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+  }
+
+  .docs-topnav-link {
+    position: relative;
+    padding: 6px 10px;
+    font-family: var(--mono);
+    font-size: 12px;
+    font-weight: 600;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--ink-2);
+    text-decoration: none;
+    transition: color 160ms ease;
+  }
+
+  .docs-topnav-link::after {
+    content: "";
+    position: absolute;
+    left: 10px;
+    right: 10px;
+    bottom: 0;
+    height: 2px;
+    background: var(--coral);
+    transform: scaleX(0);
+    transition: transform 160ms ease;
+  }
+
+  .docs-topnav-link:hover {
+    color: var(--ink);
+  }
+
+  .docs-topnav-link:hover::after {
+    transform: scaleX(1);
+  }
+
+  .docs-topnav-link.active {
+    color: var(--ink);
+  }
+
+  .docs-topnav-link.active::after {
+    background: var(--ink);
+    transform: scaleX(1);
+  }
+
   @media (max-width: 1080px) {
-    .docs-back {
+    .docs-topbar-inner {
       padding: 12px 20px;
+    }
+  }
+
+  @media (max-width: 560px) {
+    .docs-topbar-inner {
+      gap: 10px;
+    }
+    .docs-topnav {
+      gap: 0;
+    }
+    .docs-topnav-link {
+      padding: 6px 7px;
+      font-size: 11px;
+      letter-spacing: 0.06em;
     }
   }
 


### PR DESCRIPTION
## What

The migrated docs route (`jomcgi.dev/docs/*`, served by the `monolith-public` SvelteKit tier per [docs/002](https://github.com/jomcgi/homelab/blob/main/docs/decisions/docs/002-websites-decommission-docs-into-monolith.md)) inherited the full shared site nav bar (HOME / ENGINEERING / APPS / DOCS / CV). This gives the docs their own slim chrome instead: a single top-left back link to `jomcgi.dev`, mirroring the original `docs.jomcgi.dev` site's top-left home link but pointing at the apex.

## Changes

- `DocsShell.svelte`: drop `<Nav route="docs" />`; add a sticky `.docs-topbar` with a single `← jomcgi.dev` back link.
- Styled with the existing public design tokens (`--paper`, `--ink`, `--ink-2`, `--mono`, `--coral`). Sticky height (~48px) and padding match the old nav so the sidebar/TOC `top: 76px` offsets and heading scroll-margins stay valid.

The Reference + Decisions sidebar, ADR tree, and hero already mirror the old VitePress structure in the house style; only the top chrome changes here.

## Notes

- Tradeoff: docs pages no longer surface the other top-level links (ENGINEERING / APPS / CV) in their header. That's intentional per the request (back link "instead of a nav bar").

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MiFv7c9gxgKKxFBuYd7DKx)_