### PR TITLE
fix(monolith): k8s MCP tool docstrings + gap-proof the compliance test

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.25.1
+version: 0.25.2
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.25.1
+      targetRevision: 0.25.2
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -3671,6 +3671,9 @@ py_test(
 py_test(
     name = "agent_mcp_description_compliance_test",
     srcs = ["agent/mcp_description_compliance_test.py"],
+    # The test parses app/main.py at runtime to derive the tool-registration
+    # module list, so it must be in the test runfiles.
+    data = ["app/main.py"],
     imports = ["."],
     deps = [
         ":monolith_backend",

--- a/projects/monolith/agent/mcp_description_compliance_test.py
+++ b/projects/monolith/agent/mcp_description_compliance_test.py
@@ -21,7 +21,9 @@ If Context Forge is upgraded and the rules change, update the
 
 from __future__ import annotations
 
+import ast
 import importlib
+import pathlib
 
 import pytest
 
@@ -36,11 +38,37 @@ FORBIDDEN_PATTERNS = ["&&", ";", "||", "$(", "|", "> ", "< "]
 MAX_DESCRIPTION_LENGTH = 8192
 
 
+def _tool_registration_modules() -> list[str]:
+    """The ``<domain>.mcp`` modules ``app/main.py`` imports to register tools.
+
+    Derived from ``app/main.py`` (the single source of truth for tool
+    registration) instead of hand-listed here, so a newly added tool module is
+    covered automatically. A hand-maintained list previously omitted
+    ``cluster.mcp`` and shipped the k8s-* tools unvalidated (the gateway then
+    silently dropped four of them); reading the real registration site closes
+    that gap for good.
+    """
+    main_py = pathlib.Path(__file__).resolve().parent.parent / "app" / "main.py"
+    tree = ast.parse(main_py.read_text())
+    return [
+        alias.name
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Import)
+        for alias in node.names
+        if alias.name.endswith(".mcp")
+    ]
+
+
 @pytest.mark.asyncio
 async def test_all_mcp_tool_descriptions_pass_context_forge_validation():
     """Every registered tool's description must be Context Forge-safe."""
-    importlib.import_module("agent.mcp")
-    importlib.import_module("knowledge.mcp")
+    modules = _tool_registration_modules()
+    assert modules, (
+        "no <domain>.mcp registration imports found in app/main.py; the test "
+        "cannot see the tool set (check the app/main.py data dependency)"
+    )
+    for module in modules:
+        importlib.import_module(module)
     from app.mcp_app import mcp
 
     tools = await mcp.list_tools()

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.182.2
+version: 0.182.3
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/cluster/mcp.py
+++ b/projects/monolith/cluster/mcp.py
@@ -6,7 +6,7 @@ logs, deduped events, and ArgoCD sync. Output is shaped by ``cluster.summarize``
 for token efficiency — never a raw manifest dump unless explicitly requested.
 
 Tool names follow the codebase convention: the FastMCP name is the function
-name (``k8s_*``); the gateway converts underscores to dashes and (today) adds
+name (``k8s_*``). The gateway converts underscores to dashes and (today) adds
 the ``monolith-`` federation prefix, so these surface as ``k8s-*`` once that
 prefix is dropped.
 """
@@ -60,7 +60,7 @@ async def k8s_list_resources(
     Args:
         kind: One of the allowed kinds (see error message for the full set,
             e.g. pods, deployments, services, events, applications).
-        namespace: Restrict to a namespace; omit for all namespaces
+        namespace: Restrict to a namespace, or omit for all namespaces
             (ignored for cluster-scoped kinds like nodes/namespaces).
         label_selector: Standard label selector, e.g. "app=foo".
         limit: Max rows returned (default 100).
@@ -88,7 +88,7 @@ async def k8s_get_resource(
     Args:
         kind: One of the allowed kinds.
         name: Resource name.
-        namespace: Namespace (defaults to "default" for namespaced kinds;
+        namespace: Namespace (defaults to "default" for namespaced kinds,
             "argocd" for applications).
         full: Return the entire manifest instead of the trimmed view.
     """
@@ -120,7 +120,7 @@ async def k8s_get_pod_logs(
         pod: Pod name.
         container: Container name (required only for multi-container pods).
         tail_lines: Lines to fetch from the end (default 200).
-        grep: Optional regex; only matching lines are returned.
+        grep: Optional regex, only matching lines are returned.
         previous: Read the previous (crashed) container instance instead.
     """
     k8s = KubernetesClient()
@@ -147,7 +147,7 @@ async def k8s_get_events(
     """List cluster events, deduplicated by (object, type, reason, message).
 
     Args:
-        namespace: Restrict to a namespace; omit for all namespaces.
+        namespace: Restrict to a namespace, or omit for all namespaces.
         involved_object: Restrict to events about a specific object name.
     """
     k8s = KubernetesClient()

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.182.2
+      targetRevision: 0.182.3
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
## Problem

The `k8s-*` cluster debug tools shipped in #2429, but Context Forge silently dropped **4 of 6** on rollout. The gateway rejects any tool description containing forbidden shell-like patterns (here, `;`) and only logs the rejection, so the tools registered in the monolith pod but never surfaced in the federated `homelab` connector. Confirmed in the gateway logs:

```
Validation failed for tool 'k8s_list_resources': Description contains unsafe characters: ';'
... k8s_get_resource / k8s_get_pod_logs / k8s_get_events
Tool validation completed with 4 error(s).
```

## Why the existing guard missed it

`agent/mcp_description_compliance_test.py` (PR #2301) imports the tool-registration modules by hand (`agent.mcp`, `knowledge.mcp`) before listing tools. #2429 added a third module, `cluster.mcp`, that was never added to that list, so the k8s-* descriptions were never validated. Same hand-maintained-enumeration trap.

## Fix

1. Remove the semicolons from the four affected docstrings (rephrase with commas).
2. **Make the test gap-proof**: derive the tool-registration module list by parsing `app/main.py` (the single source of truth that imports every `<domain>.mcp`), instead of hand-listing. A newly added tool module is now covered automatically. Verified the discovery finds `knowledge.mcp`, `agent.mcp`, `cluster.mcp`.

After this lands and rolls out, a Context Forge tools-refresh will expose all six k8s-* tools (2 are already live; this restores the other 4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)