### PR TITLE
fix(worldcup): swing number-line dots span the axis

### DIFF
--- a/projects/monolith/frontend/src/routes/public/app/wc2026/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/wc2026/+page.svelte
@@ -821,6 +821,7 @@
   }
 
   .line-track {
+    display: block;
     position: relative;
     height: 4px;
     background: var(--rule);


### PR DESCRIPTION
Follow-up to #2740. The swing-card number line collapsed all its dots and the "Now" marker to the left edge: `.line-track` is a `<span>` (inline, zero layout width), so the dots' `left: X%` resolved against ~0 width. Adds `display: block` so the track fills its container and the outcome dots spread across the qualify axis.

Re-adds the `visual/.reseed-baselines` sentinel to refresh the wc2026 baselines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)