### PR TITLE
perf(worldcup): only re-run the sim when results change

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.31.0
+version: 0.31.1
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.31.0
+      targetRevision: 0.31.1
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.188.0
+version: 0.188.1
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.188.0
+      targetRevision: 0.188.1
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/worldcup/jobs.py
+++ b/projects/monolith/worldcup/jobs.py
@@ -26,25 +26,81 @@ logger = logging.getLogger("monolith.worldcup")
 FOCUS_CODE = "SCO"
 
 
-def _upsert(standings_rows: list[dict], fixture_rows: list[dict]) -> None:
+def _upsert(standings_rows: list[dict], fixture_rows: list[dict]) -> bool:
     """Upsert standings (by team_id) and fixtures (by match_id) idempotently.
 
+    Only writes rows whose values actually changed (so updated_at reflects a real
+    data change, not just the poll cadence). Returns True if any SIM-RELEVANT
+    field moved, so the caller can skip the expensive Monte Carlo when nothing
+    that affects the odds changed. Sim-relevant inputs are exactly: a team's
+    (group, points, GF, GA) and a fixture's (group, team codes, finished flag,
+    and, once finished, its score, which feeds the Elo posterior). Live
+    in-progress scores on an unfinished fixture update the row for display but do
+    NOT trigger a re-simulation.
+
     Opens its own Session from get_engine() (this runs in a worker thread, off
-    the scheduler event loop). session.merge() inserts a new row or replaces an
-    existing one keyed on the primary key, so re-running over the same payload
-    converges to the same state.
+    the scheduler event loop).
     """
     from sqlmodel import Session
 
     from app.db import get_engine
 
     now = datetime.now(timezone.utc)
+    sim_changed = False
     with Session(get_engine()) as session:
         for row in standings_rows:
-            session.merge(Standing(**row, updated_at=now))
+            existing = session.get(Standing, row["team_id"])
+            any_diff = existing is None or any(
+                getattr(existing, k) != v for k, v in row.items()
+            )
+            sim_diff = existing is None or (
+                existing.pts,
+                existing.gf,
+                existing.ga,
+                existing.group_name,
+            ) != (row["pts"], row["gf"], row["ga"], row["group_name"])
+            if any_diff:
+                session.merge(Standing(**row, updated_at=now))
+            if sim_diff:
+                sim_changed = True
+
         for row in fixture_rows:
-            session.merge(Fixture(**row, updated_at=now))
+            existing = session.get(Fixture, row["match_id"])
+            any_diff = existing is None or any(
+                getattr(existing, k) != v for k, v in row.items()
+            )
+            # The finished flag, the team codes, the group, and (once finished)
+            # the score all feed the simulation; a score only matters once the
+            # match is final, so an in-progress score on an unfinished fixture is
+            # not sim-relevant.
+            new_finished = bool(row["finished"])
+            new_score = (row["home_score"], row["away_score"]) if new_finished else None
+            old_finished = bool(existing.finished) if existing is not None else None
+            old_score = (
+                (existing.home_score, existing.away_score)
+                if existing is not None and old_finished
+                else None
+            )
+            sim_diff = existing is None or (
+                old_finished,
+                existing.home_code,
+                existing.away_code,
+                existing.group_name,
+                old_score,
+            ) != (
+                new_finished,
+                row["home_code"],
+                row["away_code"],
+                row["group_name"],
+                new_score,
+            )
+            if any_diff:
+                session.merge(Fixture(**row, updated_at=now))
+            if sim_diff:
+                sim_changed = True
+
         session.commit()
+    return sim_changed
 
 
 def _build_sim_inputs(session) -> tuple[list[sim.TeamState], list[sim.Fixture]]:
@@ -187,8 +243,14 @@ def _persist_sim(session, result: sim.SimResult, n: int) -> None:
     session.commit()
 
 
-def _simulate_and_store() -> None:
+def _simulate_and_store(inputs_changed: bool) -> None:
     """Read sim inputs from the DB, run the Monte Carlo, persist the result.
+
+    Short-circuits the expensive simulation when nothing that affects the result
+    has moved: it runs only if a sim-relevant input changed this poll, if the
+    configured iteration count changed (a deploy bumping WORLDCUP_SIM_N should
+    recompute once), or if no results exist yet. Otherwise the cached
+    qualification/swing rows are left in place.
 
     Opens its own Session (runs in a worker thread). If any unfinished fixture
     references a FIFA code missing from the frozen Elo snapshot we log a warning
@@ -196,11 +258,23 @@ def _simulate_and_store() -> None:
     rating is a data problem to surface loudly, not silently paper over, and it
     must not crash the scheduler.
     """
-    from sqlmodel import Session
+    from sqlmodel import Session, select
 
     from app.db import get_engine
 
+    current_n = int(os.environ.get("WORLDCUP_SIM_N", "500000"))
     with Session(get_engine()) as session:
+        existing = session.exec(
+            select(Qualification).where(Qualification.fifa_code == FOCUS_CODE)
+        ).first()
+        n_changed = existing is None or existing.n_sims != current_n
+        if not inputs_changed and not n_changed:
+            logger.info(
+                "worldcup: no sim-relevant change (N=%d unchanged); skipping simulation",
+                current_n,
+            )
+            return
+
         states, fixtures = _build_sim_inputs(session)
         finished = _build_finished_games(session)
         elo = ratings.load_elo()
@@ -227,7 +301,7 @@ def _simulate_and_store() -> None:
             fixtures,
             posterior_elo,
             focus=FOCUS_CODE,
-            n=int(os.environ.get("WORLDCUP_SIM_N", "500000")),
+            n=current_n,
             seed=None,
             sigma=posterior_sigma,
         )
@@ -255,6 +329,6 @@ async def refresh_handler(session) -> datetime | None:
         stats.get("errors", []),
     )
 
-    await asyncio.to_thread(_upsert, standings_rows, fixture_rows)
-    await asyncio.to_thread(_simulate_and_store)
+    sim_changed = await asyncio.to_thread(_upsert, standings_rows, fixture_rows)
+    await asyncio.to_thread(_simulate_and_store, sim_changed)
     return None

--- a/projects/monolith/worldcup/jobs_test.py
+++ b/projects/monolith/worldcup/jobs_test.py
@@ -13,6 +13,7 @@ never touch the network: refresh_handler's httpx call is not exercised here.
 
 from __future__ import annotations
 
+import os
 from datetime import datetime, timezone
 
 import pytest
@@ -246,3 +247,134 @@ class TestPersistSim:
             assert len(swings) == 1  # no duplicates, F-FRA-AND was removed
             assert swings[0].match_id == "F-SCO-GER"
             assert session.get(Qualification, "id-SCO").n_sims == 6000
+
+
+def _standing_row(code, *, group="A", pts=3, gf=3, ga=2):
+    return {
+        "team_id": f"id-{code}",
+        "name": code,
+        "fifa_code": code,
+        "flag_url": None,
+        "group_name": group,
+        "mp": 2,
+        "w": 1,
+        "d": 0,
+        "l": 1,
+        "pts": pts,
+        "gf": gf,
+        "ga": ga,
+        "gd": gf - ga,
+    }
+
+
+def _fixture_row(
+    match_id, home, away, *, finished, group="A", home_score=None, away_score=None
+):
+    return {
+        "match_id": match_id,
+        "group_name": group,
+        "matchday": 3,
+        "home_id": f"id-{home}",
+        "home_name": home,
+        "home_code": home,
+        "away_id": f"id-{away}",
+        "away_name": away,
+        "away_code": away,
+        "home_score": home_score,
+        "away_score": away_score,
+        "finished": finished,
+        "kickoff": None,
+    }
+
+
+class TestUpsertChangeDetection:
+    def test_first_insert_is_sim_changed(self, engine):
+        changed = jobs._upsert(
+            [_standing_row("SCO")], [_fixture_row("F1", "SCO", "GER", finished=False)]
+        )
+        assert changed is True
+
+    def test_identical_rerun_not_changed(self, engine):
+        s = [_standing_row("SCO")]
+        f = [_fixture_row("F1", "SCO", "GER", finished=False)]
+        jobs._upsert(s, f)
+        assert jobs._upsert(s, f) is False
+
+    def test_points_change_is_sim_changed(self, engine):
+        jobs._upsert([_standing_row("SCO", pts=3)], [])
+        assert jobs._upsert([_standing_row("SCO", pts=6, gf=4)], []) is True
+
+    def test_fixture_finished_flip_is_sim_changed(self, engine):
+        jobs._upsert([], [_fixture_row("F1", "SCO", "GER", finished=False)])
+        flipped = _fixture_row(
+            "F1", "SCO", "GER", finished=True, home_score=1, away_score=0
+        )
+        assert jobs._upsert([], [flipped]) is True
+
+    def test_live_score_on_unfinished_is_not_sim_changed(self, engine):
+        # A score ticking up on an in-progress (unfinished) match updates the row
+        # for display but must NOT re-trigger the expensive simulation: an
+        # unfinished score does not feed the Elo posterior.
+        jobs._upsert([], [_fixture_row("F1", "SCO", "GER", finished=False)])
+        live = _fixture_row(
+            "F1", "SCO", "GER", finished=False, home_score=1, away_score=0
+        )
+        assert jobs._upsert([], [live]) is False
+
+
+def _fake_result():
+    return SimResult(
+        per_team={"SCO": TeamProb("SCO", 0.8, 0.1, 0.7, "contention")},
+        swings=[],
+        n=0,
+    )
+
+
+class TestSimulateGate:
+    def _seed(self, session, *, qual_n):
+        session.add_all([_standing("SCO"), _standing("GER", pts=4)])
+        session.add(_fixture("F-SCO-GER", "SCO", "GER", finished=False))
+        session.add(
+            Qualification(
+                team_id="id-SCO",
+                fifa_code="SCO",
+                prob_qualify=0.8,
+                prob_top2=0.1,
+                prob_third=0.7,
+                status="contention",
+                n_sims=qual_n,
+            )
+        )
+        session.commit()
+
+    def test_skips_when_unchanged_and_n_matches(self, engine, monkeypatch):
+        current_n = int(os.environ.get("WORLDCUP_SIM_N", "500000"))
+        with Session(engine) as session:
+            self._seed(session, qual_n=current_n)
+        calls = []
+        monkeypatch.setattr(jobs.sim, "simulate", lambda *a, **k: calls.append(1))
+        jobs._simulate_and_store(inputs_changed=False)
+        assert calls == []  # simulation skipped
+
+    def test_runs_when_inputs_changed(self, engine, monkeypatch):
+        current_n = int(os.environ.get("WORLDCUP_SIM_N", "500000"))
+        with Session(engine) as session:
+            self._seed(session, qual_n=current_n)
+        calls = []
+        monkeypatch.setattr(
+            jobs.sim, "simulate", lambda *a, **k: (calls.append(1), _fake_result())[1]
+        )
+        jobs._simulate_and_store(inputs_changed=True)
+        assert len(calls) == 1
+
+    def test_runs_when_n_changed_even_if_inputs_same(self, engine, monkeypatch):
+        # Stored qualification used a different N (a deploy bumped WORLDCUP_SIM_N):
+        # recompute once even though no match result moved.
+        with Session(engine) as session:
+            self._seed(session, qual_n=123)
+        calls = []
+        monkeypatch.setattr(
+            jobs.sim, "simulate", lambda *a, **k: (calls.append(1), _fake_result())[1]
+        )
+        jobs._simulate_and_store(inputs_changed=False)
+        assert len(calls) == 1


### PR DESCRIPTION
Follow-up requested: the refresh job ran the full Monte Carlo unconditionally every 30 minutes, even when no match had finished. With 500k iterations that's ~33s of wasted compute on most ticks.

Now `_upsert` reports whether any **sim-relevant** field changed (a team's group/points/GF/GA, or an unfinished fixture's group/team-codes/finished flag) and only writes rows that actually changed, so `updated_at` reflects real data movement. `_simulate_and_store` then skips the Monte Carlo unless a sim-relevant input changed, the configured `WORLDCUP_SIM_N` changed (so a deploy recomputes once), or no results exist yet. Live in-progress scores on unfinished matches update the row for display but do not re-trigger the sim.

Tests cover: first-insert/identical-rerun/points-change/finished-flip/live-score-only detection, and the gate skipping vs running across the three cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)