### PR TITLE
feat(worldcup): describe the Bayesian strength model in the wc2026 explainer

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.31.1
+version: 0.32.0
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.31.1
+      targetRevision: 0.32.0
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.188.1
+version: 0.189.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.188.1
+      targetRevision: 0.189.0
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/routes/public/app/wc2026/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/wc2026/+page.svelte
@@ -211,11 +211,19 @@
         </p>
         <ol class="explainer-steps">
           <li>
-            <strong>Score each match from Elo.</strong> Every team has an Elo
-            rating. For an unplayed match, the rating gap sets two Poisson
-            scoring rates, one per side, and a scoreline is drawn from them, so
-            the stronger team scores more and evenly matched sides draw about a
-            quarter of the time.
+            <strong>Rate each team, with uncertainty.</strong> Every team starts
+            from a pre-tournament Elo rating, then moves up or down with the
+            group results already played, so a side that has over-performed
+            carries that into its remaining games. Because a rating is an
+            estimate and not a fact, each run draws the team's strength from a
+            range around that value (wider for teams who have played fewer
+            games), so a heavy favourite is never treated as a sure thing.
+          </li>
+          <li>
+            <strong>Score each match.</strong> For an unplayed match, the two
+            teams' drawn strengths set two Poisson scoring rates, one per side,
+            and a scoreline is sampled from them, so the stronger team scores
+            more and evenly matched sides draw about a quarter of the time.
           </li>
           <li>
             <strong>Rank by the real rules.</strong> Each simulated tournament
@@ -230,9 +238,9 @@
           </li>
         </ol>
         <p class="explainer-fine">
-          Elo ratings are frozen at kickoff, matches are independent, and the
-          two lowest FIFA tiebreakers (disciplinary record and world ranking)
-          aren't modelled, they're sampled as coin-flips.
+          Matches are simulated independently, and the two lowest FIFA
+          tiebreakers (disciplinary record and world ranking) aren't modelled,
+          they're sampled as coin-flips.
         </p>
       </div>
     </details>
@@ -397,7 +405,7 @@
     <footer class="foot">
       <p>
         Data from <a href="https://worldcup26.ir" rel="external noopener">worldcup26.ir</a>.
-        Odds from an Elo-weighted Monte Carlo, {q.n_sims ?? 0} simulations.
+        Odds from an Elo-weighted Monte Carlo, {nSims} simulations.
       </p>
       <p class="caveat">
         The final two FIFA tiebreakers (disciplinary record and FIFA ranking)


### PR DESCRIPTION
## What

PR #2744 changed the WC2026 sim from a frozen point-estimate Elo to a per-team Bayesian posterior (ratings rolled forward over results already played, strength drawn with epistemic uncertainty per run). The page explainer still described the old model, so it's now updated to match.

## Changes

- **"How does this work?" steps**: new **"Rate each team, with uncertainty"** step explains that ratings update with played results, and that each run draws a team's strength from a range around its rating (wider for teams with fewer games), so a heavy favourite is never treated as a sure thing. The scoring step now reads from those drawn strengths.
- **Fine print**: dropped the now-false "Elo ratings are frozen at kickoff" line; kept the match-independence and tiebreaker-coin-flip caveats.
- **Footer**: renders the formatted sim count (`{nSims}`, e.g. `500,000`) instead of the raw integer, matching the explainer. (The 500k count itself was already live from an earlier commit; it renders dynamically from `n_sims`.)

## Visual regression

The explainer body lives in a collapsed `<details>`, so it is not in the snapshots. The footer count **is** visible and changes `500000` -> `500,000`, so this reseeds the wc2026 baseline via the one-shot `.reseed-baselines` sentinel (`visual-baseline-bot` regenerates the PNG and removes the sentinel on the next CI run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)