### PR TITLE
feat(worldcup): shareable country URLs + upstream retry + swing self-heal

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.33.6
+version: 0.34.0
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.33.6
+      targetRevision: 0.34.0
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.190.6
+version: 0.191.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.190.6
+      targetRevision: 0.191.0
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/routes/public/app/wc2026/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/wc2026/+page.svelte
@@ -1,4 +1,7 @@
 <script>
+  import { page } from "$app/stores";
+  import { goto } from "$app/navigation";
+
   let { data } = $props();
 
   // The whole tournament arrives in one payload; the visitor picks a country and
@@ -16,11 +19,16 @@
     Object.fromEntries(allTeams.map((t) => [t.fifa_code, t.name])),
   );
 
-  // Selected country: the page opens on the default (Scotland). Guarded so a
-  // code missing from the data falls back to the default rather than blanking.
-  let picked = $state(data.default_country ?? "SCO");
+  // Selected country lives in the URL (?country=CODE) so a chosen team is
+  // shareable and bookmarkable. It derives from $page.url (works in SSR and on
+  // the client), falling back to the default (Scotland) when absent or unknown.
+  // load() does not read url, so updating the query never re-runs it: switching
+  // stays an instant client-side re-derive with no refetch.
+  const requested = $derived($page.url.searchParams.get("country"));
   const selectedCode = $derived(
-    codeToGroup[picked] ? picked : (data.default_country ?? "SCO"),
+    requested && codeToGroup[requested]
+      ? requested
+      : (data.default_country ?? "SCO"),
   );
   const countryName = $derived(codeToName[selectedCode] ?? selectedCode);
 
@@ -41,7 +49,12 @@
       : allTeams,
   );
   function choose(code) {
-    picked = code;
+    // Mirror the pick into the URL (shareable). replaceState keeps every dropdown
+    // flip out of browser history; keepFocus/noScroll avoid a jump. load() does
+    // not depend on url, so this does not refetch.
+    const url = new URL($page.url);
+    url.searchParams.set("country", code);
+    goto(url, { keepFocus: true, noScroll: true, replaceState: true });
     pickerOpen = false;
     pickerQuery = "";
   }

--- a/projects/monolith/worldcup/client.py
+++ b/projects/monolith/worldcup/client.py
@@ -21,6 +21,7 @@ corpus). This module does NO database writes; persistence is a separate concern.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from datetime import datetime, timezone
 from zoneinfo import ZoneInfo
@@ -39,6 +40,14 @@ _LOCAL_DATE_FMT = "%m/%d/%Y %H:%M"
 
 # Per-request timeout; the client-level timeout in the handler is the ceiling.
 _TIMEOUT_SECS = 20.0
+
+# Retry transient upstream failures (5xx, timeouts, connection resets) with
+# exponential backoff. worldcup26.ir intermittently 500s on a single endpoint,
+# and /get/teams is the join table the whole poll depends on, so one blip must
+# not collapse the fetch. 4xx responses are NOT retried (a client error will not
+# fix itself). Backoff is 0.5s, then 1.0s between the three attempts.
+_FETCH_ATTEMPTS = 3
+_FETCH_BACKOFF_SECS = 0.5
 
 
 def _to_int(value) -> int:
@@ -186,20 +195,49 @@ def parse_fixtures(games_payload: dict, team_index: dict) -> list[dict]:
     return fixtures
 
 
+def _is_retryable(exc: Exception) -> bool:
+    """Retry transient failures only. A 4xx is a client error that will not fix
+    itself on retry; 5xx, timeouts, and connection errors are transient."""
+    response = getattr(exc, "response", None)
+    status = getattr(response, "status_code", None)
+    if status is not None:
+        return status >= 500
+    # No response (timeout, connect error, read error) -> transient.
+    return isinstance(exc, httpx.HTTPError)
+
+
 async def _get_json(client: httpx.AsyncClient, path: str, stats: dict) -> dict:
     """GET a path off the client's base_url and decode JSON. Never raises.
 
-    Records any HTTP or decode failure into stats["errors"] and returns {} so a
-    single bad endpoint degrades gracefully instead of aborting the whole fetch.
+    Retries transient upstream failures (5xx, timeouts, connection errors) with
+    exponential backoff so a single intermittent blip on one endpoint does not
+    abort the whole fetch. After the final attempt (or on a non-retryable 4xx)
+    it records the failure into stats["errors"] and returns {} so the caller
+    degrades gracefully.
     """
-    try:
-        resp = await client.get(path, timeout=_TIMEOUT_SECS)
-        resp.raise_for_status()
-        return resp.json()
-    except (httpx.HTTPError, ValueError) as exc:
-        logger.error("worldcup fetch failed for %s: %s", path, exc)
-        stats["errors"].append(f"{path}: {exc}")
-        return {}
+    last_exc: Exception | None = None
+    for attempt in range(_FETCH_ATTEMPTS):
+        try:
+            resp = await client.get(path, timeout=_TIMEOUT_SECS)
+            resp.raise_for_status()
+            return resp.json()
+        except (httpx.HTTPError, ValueError) as exc:
+            last_exc = exc
+            if not _is_retryable(exc) or attempt == _FETCH_ATTEMPTS - 1:
+                break
+            backoff = _FETCH_BACKOFF_SECS * (2**attempt)
+            logger.warning(
+                "worldcup fetch %s attempt %d/%d failed (%s); retrying in %.1fs",
+                path,
+                attempt + 1,
+                _FETCH_ATTEMPTS,
+                exc,
+                backoff,
+            )
+            await asyncio.sleep(backoff)
+    logger.error("worldcup fetch failed for %s: %s", path, last_exc)
+    stats["errors"].append(f"{path}: {last_exc}")
+    return {}
 
 
 async def fetch_all(

--- a/projects/monolith/worldcup/client_test.py
+++ b/projects/monolith/worldcup/client_test.py
@@ -1,6 +1,72 @@
+import asyncio
 from datetime import datetime, timezone
 
-from worldcup.client import build_team_index, parse_fixtures, parse_standings
+import httpx
+
+from worldcup import client as wc_client
+from worldcup.client import _get_json, build_team_index, parse_fixtures, parse_standings
+
+
+def _async_client(handler):
+    # MockTransport never hits the network, but set a timeout to satisfy the
+    # httpx-client-no-timeout rule and mirror production usage.
+    return httpx.AsyncClient(
+        transport=httpx.MockTransport(handler), base_url="https://test", timeout=5.0
+    )
+
+
+def _fetch(handler, monkeypatch):
+    """Run _get_json against a MockTransport handler with backoff zeroed."""
+    monkeypatch.setattr(wc_client, "_FETCH_BACKOFF_SECS", 0)
+    stats = {"errors": []}
+
+    async def go():
+        async with _async_client(handler) as c:
+            return await _get_json(c, "/get/teams", stats)
+
+    return asyncio.run(go()), stats
+
+
+def test_get_json_retries_5xx_then_succeeds(monkeypatch):
+    calls = {"n": 0}
+
+    def handler(request):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return httpx.Response(500, text="boom")
+        return httpx.Response(200, json={"ok": True})
+
+    result, stats = _fetch(handler, monkeypatch)
+    assert result == {"ok": True}
+    assert calls["n"] == 2  # retried once, then succeeded
+    assert stats["errors"] == []
+
+
+def test_get_json_does_not_retry_4xx(monkeypatch):
+    calls = {"n": 0}
+
+    def handler(request):
+        calls["n"] += 1
+        return httpx.Response(404, text="nope")
+
+    result, stats = _fetch(handler, monkeypatch)
+    assert result == {}  # degrades gracefully
+    assert calls["n"] == 1  # a client error is not retried
+    assert len(stats["errors"]) == 1
+
+
+def test_get_json_exhausts_retries_then_degrades(monkeypatch):
+    calls = {"n": 0}
+
+    def handler(request):
+        calls["n"] += 1
+        return httpx.Response(503, text="down")
+
+    result, stats = _fetch(handler, monkeypatch)
+    assert result == {}
+    assert calls["n"] == wc_client._FETCH_ATTEMPTS  # all attempts used
+    assert len(stats["errors"]) == 1
+
 
 TEAMS = {
     "teams": [

--- a/projects/monolith/worldcup/jobs.py
+++ b/projects/monolith/worldcup/jobs.py
@@ -280,14 +280,25 @@ def _simulate_and_store(inputs_changed: bool) -> None:
             select(Qualification).where(Qualification.fifa_code == FOCUS_CODE)
         ).first()
         n_changed = existing is None or existing.n_sims != current_n
-        if not inputs_changed and not n_changed:
+
+        states, fixtures = _build_sim_inputs(session)
+
+        # Self-heal: if there are remaining fixtures but no swing rows at all, the
+        # swing table is unpopulated (e.g. just recreated by a migration) and must
+        # be recomputed even when nothing else changed. Without this the table can
+        # stay empty until the tournament data happens to move. (No remaining
+        # fixtures => no swing to compute, so an empty table is correct then.)
+        swing_missing = bool(fixtures) and (
+            session.exec(select(SwingMatch).limit(1)).first() is None
+        )
+
+        if not inputs_changed and not n_changed and not swing_missing:
             logger.info(
                 "worldcup: no sim-relevant change (N=%d unchanged); skipping simulation",
                 current_n,
             )
             return
 
-        states, fixtures = _build_sim_inputs(session)
         finished = _build_finished_games(session)
         elo = ratings.load_elo()
 

--- a/projects/monolith/worldcup/jobs_test.py
+++ b/projects/monolith/worldcup/jobs_test.py
@@ -319,9 +319,25 @@ def _fake_result():
 
 
 class TestSimulateGate:
-    def _seed(self, session, *, qual_n):
+    def _seed(self, session, *, qual_n, with_swing=True):
         session.add_all([_standing("SCO"), _standing("GER", pts=4)])
         session.add(_fixture("F-SCO-GER", "SCO", "GER", finished=False))
+        if with_swing:
+            # A populated swing table; without one the self-heal gate would fire.
+            session.add(
+                SwingMatch(
+                    match_id="F-SCO-GER",
+                    country_code="SCO",
+                    group_name="A",
+                    home_code="SCO",
+                    away_code="GER",
+                    swing=0.3,
+                    p_qualify_home_win=0.9,
+                    p_qualify_draw=0.6,
+                    p_qualify_away_win=0.4,
+                    is_own_match=True,
+                )
+            )
         session.add(
             Qualification(
                 team_id="id-SCO",
@@ -360,6 +376,20 @@ class TestSimulateGate:
         # recompute once even though no match result moved.
         with Session(engine) as session:
             self._seed(session, qual_n=123)
+        calls = []
+        monkeypatch.setattr(
+            jobs.sim, "simulate", lambda *a, **k: (calls.append(1), _fake_result())[1]
+        )
+        jobs._simulate_and_store(inputs_changed=False)
+        assert len(calls) == 1
+
+    def test_runs_when_swing_missing_even_if_inputs_same(self, engine, monkeypatch):
+        # Remaining fixtures exist but the swing table is empty (e.g. just
+        # recreated by a migration): self-heal by recomputing, even when inputs
+        # and N are unchanged.
+        current_n = int(os.environ.get("WORLDCUP_SIM_N", "500000"))
+        with Session(engine) as session:
+            self._seed(session, qual_n=current_n, with_swing=False)
         calls = []
         monkeypatch.setattr(
             jobs.sim, "simulate", lambda *a, **k: (calls.append(1), _fake_result())[1]


### PR DESCRIPTION
Three robustness/UX fixes surfaced by the per-country tracker incident (where an upstream `worldcup26.ir` 500 + an empty post-migration swing table left the page blank).

## 1. Shareable country URLs (your ask)
The selected country now lives in the URL (`?country=CODE`), so a chosen team is **shareable and bookmarkable**. It derives from `$page.url` (works in SSR and client), falls back to Scotland when absent/unknown, and choosing a team mirrors it back via `goto(replaceState)`. `load()` doesn't read `url`, so switching stays an instant client-side re-derive with **no refetch**, and the default no-param render is unchanged (no visual reseed needed). Matches the `$page` + `goto` convention used by stars/notes/dr-jobs.

## 2. Upstream retry with backoff
`client._get_json` now retries transient failures (5xx, timeouts, connection errors) with exponential backoff (3 attempts, 0.5s → 1.0s). `worldcup26.ir` intermittently 500s on a single endpoint, and `/get/teams` is the join table the whole poll depends on, so one blip used to collapse the entire fetch. **4xx is not retried** (it won't self-fix).

## 3. Swing self-heal
`_simulate_and_store` now also re-sims when there are remaining fixtures but `swing_matches` is empty (e.g. just recreated by a migration), instead of skipping on unchanged inputs. Closes the window where swings could stay empty until the tournament data happened to move — which is exactly what required a manual nudge during the last rollout.

## Tests
- `client_test`: retry-then-succeed (2 calls), no-retry-on-4xx (1 call), exhaust-all-attempts (3 calls), backoff zeroed for speed.
- `jobs_test`: `test_runs_when_swing_missing_even_if_inputs_same`; `_seed` now seeds a swing row so the existing skip test still skips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)