### PR TITLE
ci(semgrep): add no-bare-nosemgrep rule

### DIFF
--- a/bazel/semgrep/rules/BUILD
+++ b/bazel/semgrep/rules/BUILD
@@ -334,6 +334,22 @@ semgrep_test(
     tags = ["semgrep"],
 )
 
+# no-bare-nosemgrep uses languages: [python] and is tested by python_rules_test via the
+# colocated python/no-bare-nosemgrep.py fixture. This target also wires the rule to the
+# tests/fixtures version for an independent dedicated test.
+filegroup(
+    name = "no_bare_nosemgrep_rule",
+    srcs = ["python/no-bare-nosemgrep.yaml"],
+)
+
+semgrep_test(
+    name = "no_bare_nosemgrep_test",
+    srcs = ["//bazel/semgrep/tests:no_bare_nosemgrep_fixtures"],
+    env = {"SEMGREP_TEST_MODE": "1"},
+    rules = [":no_bare_nosemgrep_rule"],
+    tags = ["semgrep"],
+)
+
 # no-pytest-mark-asyncio-without-plugin is excluded from python_rules because
 # semgrep-core ignores paths: filters (pysemgrep-only feature) and the rule would
 # produce false positives for project files that legitimately use @pip//pytest_asyncio.

--- a/bazel/semgrep/rules/python/no-bare-nosemgrep.py
+++ b/bazel/semgrep/rules/python/no-bare-nosemgrep.py
@@ -1,0 +1,23 @@
+# Tests for the no-bare-nosemgrep semgrep rule.
+#
+# Bare `# nosemgrep` (no colon + rule ID) suppresses ALL rules on the line and
+# cannot be audited. The rule catches these so each suppression is scoped to a
+# specific rule ID.
+#
+# Note: semgrep-core does NOT honour inline `# nosemgrep` annotations, so the
+# positive case below IS detected when scanned with semgrep-core (used in Bazel
+# CI). In pysemgrep (pre-commit hooks), bare `# nosemgrep` self-suppresses the
+# no-bare-nosemgrep rule; enforcement there is via the check-bare-nosemgrep.sh
+# hook.
+
+# ruleid: no-bare-nosemgrep
+x = 1  # nosemgrep
+
+# ruleid: no-bare-nosemgrep
+y = some_call()  # nosemgrep
+
+# ok: no-bare-nosemgrep
+z = boto3_call()  # nosemgrep: boto3-endpoint-url-missing-scheme
+
+# ok: no-bare-nosemgrep
+w = other_call()  # nosemgrep: no-bare-nosemgrep

--- a/bazel/semgrep/rules/python/no-bare-nosemgrep.yaml
+++ b/bazel/semgrep/rules/python/no-bare-nosemgrep.yaml
@@ -1,0 +1,24 @@
+rules:
+  - id: no-bare-nosemgrep
+    pattern-regex: '#\s*nosemgrep\s*$'
+    message: >-
+      Bare `# nosemgrep` suppresses ALL semgrep rules on this line, making the
+      suppression impossible to audit and scope. Always specify the rule ID:
+      `# nosemgrep: <rule-id>`. To find the rule ID, run semgrep locally or
+      check the CI log for the check_id on the failing line. Example:
+      `# nosemgrep: boto3-endpoint-url-missing-scheme`
+    languages: [python]
+    severity: WARNING
+    metadata:
+      category: best-practices
+      subcategory: semgrep
+      confidence: HIGH
+      likelihood: HIGH
+      impact: LOW
+      technology: [python, semgrep]
+      description: >-
+        Bare # nosemgrep (without a colon + rule ID) suppresses all rules on the
+        line. Use # nosemgrep: rule-id to scope the suppression to one rule.
+    paths:
+      include:
+        - "**/*.py"

--- a/bazel/semgrep/tests/BUILD
+++ b/bazel/semgrep/tests/BUILD
@@ -154,6 +154,13 @@ filegroup(
     srcs = ["fixtures/cfingress-rewrite-needs-slash-redirect.yaml"],
 )
 
+# Fixture for the no-bare-nosemgrep rule (languages: python).
+# Referenced by //bazel/semgrep/rules:no_bare_nosemgrep_test.
+filegroup(
+    name = "no_bare_nosemgrep_fixtures",
+    srcs = ["fixtures/no-bare-nosemgrep.py"],
+)
+
 # New rule fixtures should be added here as they are created.
 filegroup(
     name = "kubernetes_yaml_fixtures",

--- a/bazel/semgrep/tests/fixtures/no-bare-nosemgrep.py
+++ b/bazel/semgrep/tests/fixtures/no-bare-nosemgrep.py
@@ -1,0 +1,17 @@
+# Tests for the no-bare-nosemgrep semgrep rule.
+#
+# Bare `# nosemgrep` (no colon + rule ID) suppresses ALL rules on the line and
+# cannot be audited. The rule catches these so each suppression is scoped to a
+# specific rule ID.
+
+# ruleid: no-bare-nosemgrep
+x = 1  # nosemgrep
+
+# ruleid: no-bare-nosemgrep
+y = some_call()  # nosemgrep
+
+# ok: no-bare-nosemgrep
+z = boto3_call()  # nosemgrep: boto3-endpoint-url-missing-scheme
+
+# ok: no-bare-nosemgrep
+w = other_call()  # nosemgrep: no-bare-nosemgrep

--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.33.3
+version: 0.33.4
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.33.3
+      targetRevision: 0.33.4
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.190.3
+version: 0.190.4
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chat/store.py
+++ b/projects/monolith/chat/store.py
@@ -49,7 +49,7 @@ def _blob_s3_put(sha256: str, data: bytes, content_type: str) -> bool:
     # Scheme guaranteed by the guard above; inline nosemgrep clears the pre-commit
     # boto3-endpoint-url-missing-scheme hook (the Bazel main_semgrep_test, which
     # ignores nosemgrep, is covered by exclude_rules in projects/monolith/BUILD).
-    client = boto3.client(  # nosemgrep
+    client = boto3.client(  # nosemgrep: boto3-endpoint-url-missing-scheme
         "s3",
         endpoint_url=endpoint,
         aws_access_key_id=os.environ.get("S3_ACCESS_KEY_ID", "duckdb"),

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.190.3
+      targetRevision: 0.190.4
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/knowledge/mcp_test.py
+++ b/projects/monolith/knowledge/mcp_test.py
@@ -127,7 +127,9 @@ def _get_note_row(engine, note_id: str) -> Note:
     """Fetch the raw Note ORM row (carries columns get_note_by_id omits)."""
     with Session(engine) as session:
         # test helper: intentionally reads any row (including soft-deleted).
-        stmt = select(Note).where(Note.note_id == note_id)  # nosemgrep: sqlmodel-select-missing-deleted-at-filter
+        stmt = select(Note).where(
+            Note.note_id == note_id
+        )  # nosemgrep: sqlmodel-select-missing-deleted-at-filter
         return session.exec(stmt).one()
 
 

--- a/projects/monolith/knowledge/mcp_test.py
+++ b/projects/monolith/knowledge/mcp_test.py
@@ -127,7 +127,7 @@ def _get_note_row(engine, note_id: str) -> Note:
     """Fetch the raw Note ORM row (carries columns get_note_by_id omits)."""
     with Session(engine) as session:
         # test helper: intentionally reads any row (including soft-deleted).
-        stmt = select(Note).where(Note.note_id == note_id)  # nosemgrep
+        stmt = select(Note).where(Note.note_id == note_id)  # nosemgrep: sqlmodel-select-missing-deleted-at-filter
         return session.exec(stmt).one()
 
 

--- a/projects/monolith/knowledge/notes_crud_test.py
+++ b/projects/monolith/knowledge/notes_crud_test.py
@@ -200,7 +200,7 @@ def _reload_note(session: Session, note_id: str) -> Note | None:
     """
     session.expire_all()
     # test helper: intentionally reads any row (including soft-deleted).
-    stmt = select(Note).where(Note.note_id == note_id)  # nosemgrep
+    stmt = select(Note).where(Note.note_id == note_id)  # nosemgrep: sqlmodel-select-missing-deleted-at-filter
     return session.exec(stmt).one_or_none()
 
 

--- a/projects/monolith/knowledge/notes_crud_test.py
+++ b/projects/monolith/knowledge/notes_crud_test.py
@@ -200,7 +200,9 @@ def _reload_note(session: Session, note_id: str) -> Note | None:
     """
     session.expire_all()
     # test helper: intentionally reads any row (including soft-deleted).
-    stmt = select(Note).where(Note.note_id == note_id)  # nosemgrep: sqlmodel-select-missing-deleted-at-filter
+    stmt = select(Note).where(
+        Note.note_id == note_id
+    )  # nosemgrep: sqlmodel-select-missing-deleted-at-filter
     return session.exec(stmt).one_or_none()
 
 

--- a/projects/monolith/knowledge/raw_store.py
+++ b/projects/monolith/knowledge/raw_store.py
@@ -50,7 +50,7 @@ def _s3_client():
     # pre-commit boto3-endpoint-url-missing-scheme hook (the Bazel
     # main_semgrep_test, which ignores nosemgrep, is covered by exclude_rules
     # in projects/monolith/BUILD).
-    return boto3.client(  # nosemgrep
+    return boto3.client(  # nosemgrep: boto3-endpoint-url-missing-scheme
         "s3",
         endpoint_url=endpoint,
         aws_access_key_id=os.environ.get("S3_ACCESS_KEY_ID", "duckdb"),

--- a/projects/monolith/stars/grid.py
+++ b/projects/monolith/stars/grid.py
@@ -49,7 +49,7 @@ def _s3_client():
     # Scheme is guaranteed by the guard above; the inline nosemgrep clears the
     # pre-commit hook (boto3-endpoint-url-missing-scheme). Bare nosemgrep: this
     # line has no other rule matches.
-    return boto3.client(  # nosemgrep
+    return boto3.client(  # nosemgrep: boto3-endpoint-url-missing-scheme
         "s3",
         endpoint_url=endpoint,
         aws_access_key_id=os.environ.get("S3_ACCESS_KEY_ID", "duckdb"),

--- a/projects/monolith/trips/s3.py
+++ b/projects/monolith/trips/s3.py
@@ -41,7 +41,7 @@ def put_image(image_key: str, data: bytes, content_type: str) -> None:
     # pre-commit boto3-endpoint-url-missing-scheme hook (the Bazel
     # main_semgrep_test, which ignores nosemgrep, is covered by exclude_rules in
     # projects/monolith/BUILD).
-    client = boto3.client(  # nosemgrep
+    client = boto3.client(  # nosemgrep: boto3-endpoint-url-missing-scheme
         "s3",
         endpoint_url=endpoint,
         aws_access_key_id=os.environ.get("S3_ACCESS_KEY_ID", "duckdb"),

--- a/projects/monolith/trips/s3_test.py
+++ b/projects/monolith/trips/s3_test.py
@@ -79,7 +79,7 @@ class TestSchemeGuard:
         monkeypatch.setenv("SEAWEEDFS_S3_ENDPOINT", "seaweed:8333")
         s3 = _make_s3(head_return_value={"ETag": "abc"})
 
-        with patch("boto3.client", return_value=s3) as mock_factory:  # nosemgrep
+        with patch("boto3.client", return_value=s3) as mock_factory:  # nosemgrep: boto3-endpoint-url-missing-scheme
             put_image("img_k.jpg", b"data", "image/jpeg")
 
         _, kwargs = mock_factory.call_args
@@ -89,7 +89,7 @@ class TestSchemeGuard:
         monkeypatch.setenv("SEAWEEDFS_S3_ENDPOINT", "http://seaweed:8333")
         s3 = _make_s3(head_return_value={"ETag": "abc"})
 
-        with patch("boto3.client", return_value=s3) as mock_factory:  # nosemgrep
+        with patch("boto3.client", return_value=s3) as mock_factory:  # nosemgrep: boto3-endpoint-url-missing-scheme
             put_image("img_k.jpg", b"data", "image/jpeg")
 
         _, kwargs = mock_factory.call_args
@@ -99,7 +99,7 @@ class TestSchemeGuard:
         monkeypatch.setenv("SEAWEEDFS_S3_ENDPOINT", "https://seaweed:8333")
         s3 = _make_s3(head_return_value={"ETag": "abc"})
 
-        with patch("boto3.client", return_value=s3) as mock_factory:  # nosemgrep
+        with patch("boto3.client", return_value=s3) as mock_factory:  # nosemgrep: boto3-endpoint-url-missing-scheme
             put_image("img_k.jpg", b"data", "image/jpeg")
 
         _, kwargs = mock_factory.call_args
@@ -117,7 +117,7 @@ class TestHeadObjectHit:
         monkeypatch.setenv("SEAWEEDFS_S3_ENDPOINT", "http://seaweed:8333")
         s3 = _make_s3(head_return_value={"ETag": "existing"})
 
-        with patch("boto3.client", return_value=s3):  # nosemgrep
+        with patch("boto3.client", return_value=s3):  # nosemgrep: boto3-endpoint-url-missing-scheme
             put_image("img_existing.jpg", b"bytes", "image/jpeg")
 
         s3.put_object.assert_not_called()
@@ -133,7 +133,7 @@ class TestHeadObjectMiss:
         monkeypatch.setenv("SEAWEEDFS_S3_ENDPOINT", "http://seaweed:8333")
         s3 = _make_s3(head_side_effect=_client_error("NoSuchKey"))
 
-        with patch("boto3.client", return_value=s3):  # nosemgrep
+        with patch("boto3.client", return_value=s3):  # nosemgrep: boto3-endpoint-url-missing-scheme
             put_image("img_new.jpg", b"newbytes", "image/jpeg")
 
         s3.put_object.assert_called_once()
@@ -146,7 +146,7 @@ class TestHeadObjectMiss:
         monkeypatch.setenv("SEAWEEDFS_S3_ENDPOINT", "http://seaweed:8333")
         s3 = _make_s3(head_side_effect=_client_error("404"))
 
-        with patch("boto3.client", return_value=s3):  # nosemgrep
+        with patch("boto3.client", return_value=s3):  # nosemgrep: boto3-endpoint-url-missing-scheme
             put_image("img_new.jpg", b"data", "image/jpeg")
 
         s3.put_object.assert_called_once()
@@ -155,7 +155,7 @@ class TestHeadObjectMiss:
         monkeypatch.setenv("SEAWEEDFS_S3_ENDPOINT", "http://seaweed:8333")
         s3 = _make_s3(head_side_effect=_client_error("NoSuchBucket"))
 
-        with patch("boto3.client", return_value=s3):  # nosemgrep
+        with patch("boto3.client", return_value=s3):  # nosemgrep: boto3-endpoint-url-missing-scheme
             put_image("img_new.jpg", b"data", "image/jpeg")
 
         s3.put_object.assert_called_once()
@@ -173,7 +173,7 @@ class TestAutoCreateBucket:
         s3.head_object.side_effect = _client_error("NoSuchKey")
         s3.put_object.side_effect = [_client_error("NoSuchBucket"), None]
 
-        with patch("boto3.client", return_value=s3):  # nosemgrep
+        with patch("boto3.client", return_value=s3):  # nosemgrep: boto3-endpoint-url-missing-scheme
             put_image("img_nob.jpg", b"data", "image/jpeg")
 
         s3.create_bucket.assert_called_once()
@@ -185,7 +185,7 @@ class TestAutoCreateBucket:
         s3.head_object.side_effect = _client_error("NoSuchKey")
         s3.put_object.side_effect = [_client_error("404"), None]
 
-        with patch("boto3.client", return_value=s3):  # nosemgrep
+        with patch("boto3.client", return_value=s3):  # nosemgrep: boto3-endpoint-url-missing-scheme
             put_image("img_404b.jpg", b"data", "image/jpeg")
 
         s3.create_bucket.assert_called_once()
@@ -201,7 +201,7 @@ class TestErrorPropagation:
         monkeypatch.setenv("SEAWEEDFS_S3_ENDPOINT", "http://seaweed:8333")
         s3 = _make_s3(head_side_effect=_client_error("AccessDenied"))
 
-        with patch("boto3.client", return_value=s3):  # nosemgrep
+        with patch("boto3.client", return_value=s3):  # nosemgrep: boto3-endpoint-url-missing-scheme
             with pytest.raises(ClientError):
                 put_image("img_denied.jpg", b"data", "image/jpeg")
 
@@ -211,7 +211,7 @@ class TestErrorPropagation:
         s3.head_object.side_effect = _client_error("NoSuchKey")
         s3.put_object.side_effect = _client_error("InternalError")
 
-        with patch("boto3.client", return_value=s3):  # nosemgrep
+        with patch("boto3.client", return_value=s3):  # nosemgrep: boto3-endpoint-url-missing-scheme
             with pytest.raises(ClientError):
                 put_image("img_ierr.jpg", b"data", "image/jpeg")
 
@@ -227,7 +227,7 @@ class TestBucketNameEnvVar:
         monkeypatch.setenv("TRIPS_S3_BUCKET", "custom-bucket")
         s3 = _make_s3(head_return_value={})
 
-        with patch("boto3.client", return_value=s3):  # nosemgrep
+        with patch("boto3.client", return_value=s3):  # nosemgrep: boto3-endpoint-url-missing-scheme
             put_image("img_k.jpg", b"data", "image/jpeg")
 
         kw = s3.head_object.call_args.kwargs
@@ -238,7 +238,7 @@ class TestBucketNameEnvVar:
         monkeypatch.delenv("TRIPS_S3_BUCKET", raising=False)
         s3 = _make_s3(head_return_value={})
 
-        with patch("boto3.client", return_value=s3):  # nosemgrep
+        with patch("boto3.client", return_value=s3):  # nosemgrep: boto3-endpoint-url-missing-scheme
             put_image("img_k.jpg", b"data", "image/jpeg")
 
         kw = s3.head_object.call_args.kwargs

--- a/projects/monolith/trips/s3_test.py
+++ b/projects/monolith/trips/s3_test.py
@@ -79,7 +79,9 @@ class TestSchemeGuard:
         monkeypatch.setenv("SEAWEEDFS_S3_ENDPOINT", "seaweed:8333")
         s3 = _make_s3(head_return_value={"ETag": "abc"})
 
-        with patch("boto3.client", return_value=s3) as mock_factory:  # nosemgrep: boto3-endpoint-url-missing-scheme
+        with patch(
+            "boto3.client", return_value=s3
+        ) as mock_factory:  # nosemgrep: boto3-endpoint-url-missing-scheme
             put_image("img_k.jpg", b"data", "image/jpeg")
 
         _, kwargs = mock_factory.call_args
@@ -89,7 +91,9 @@ class TestSchemeGuard:
         monkeypatch.setenv("SEAWEEDFS_S3_ENDPOINT", "http://seaweed:8333")
         s3 = _make_s3(head_return_value={"ETag": "abc"})
 
-        with patch("boto3.client", return_value=s3) as mock_factory:  # nosemgrep: boto3-endpoint-url-missing-scheme
+        with patch(
+            "boto3.client", return_value=s3
+        ) as mock_factory:  # nosemgrep: boto3-endpoint-url-missing-scheme
             put_image("img_k.jpg", b"data", "image/jpeg")
 
         _, kwargs = mock_factory.call_args
@@ -99,7 +103,9 @@ class TestSchemeGuard:
         monkeypatch.setenv("SEAWEEDFS_S3_ENDPOINT", "https://seaweed:8333")
         s3 = _make_s3(head_return_value={"ETag": "abc"})
 
-        with patch("boto3.client", return_value=s3) as mock_factory:  # nosemgrep: boto3-endpoint-url-missing-scheme
+        with patch(
+            "boto3.client", return_value=s3
+        ) as mock_factory:  # nosemgrep: boto3-endpoint-url-missing-scheme
             put_image("img_k.jpg", b"data", "image/jpeg")
 
         _, kwargs = mock_factory.call_args
@@ -117,7 +123,9 @@ class TestHeadObjectHit:
         monkeypatch.setenv("SEAWEEDFS_S3_ENDPOINT", "http://seaweed:8333")
         s3 = _make_s3(head_return_value={"ETag": "existing"})
 
-        with patch("boto3.client", return_value=s3):  # nosemgrep: boto3-endpoint-url-missing-scheme
+        with patch(
+            "boto3.client", return_value=s3
+        ):  # nosemgrep: boto3-endpoint-url-missing-scheme
             put_image("img_existing.jpg", b"bytes", "image/jpeg")
 
         s3.put_object.assert_not_called()
@@ -133,7 +141,9 @@ class TestHeadObjectMiss:
         monkeypatch.setenv("SEAWEEDFS_S3_ENDPOINT", "http://seaweed:8333")
         s3 = _make_s3(head_side_effect=_client_error("NoSuchKey"))
 
-        with patch("boto3.client", return_value=s3):  # nosemgrep: boto3-endpoint-url-missing-scheme
+        with patch(
+            "boto3.client", return_value=s3
+        ):  # nosemgrep: boto3-endpoint-url-missing-scheme
             put_image("img_new.jpg", b"newbytes", "image/jpeg")
 
         s3.put_object.assert_called_once()
@@ -146,7 +156,9 @@ class TestHeadObjectMiss:
         monkeypatch.setenv("SEAWEEDFS_S3_ENDPOINT", "http://seaweed:8333")
         s3 = _make_s3(head_side_effect=_client_error("404"))
 
-        with patch("boto3.client", return_value=s3):  # nosemgrep: boto3-endpoint-url-missing-scheme
+        with patch(
+            "boto3.client", return_value=s3
+        ):  # nosemgrep: boto3-endpoint-url-missing-scheme
             put_image("img_new.jpg", b"data", "image/jpeg")
 
         s3.put_object.assert_called_once()
@@ -155,7 +167,9 @@ class TestHeadObjectMiss:
         monkeypatch.setenv("SEAWEEDFS_S3_ENDPOINT", "http://seaweed:8333")
         s3 = _make_s3(head_side_effect=_client_error("NoSuchBucket"))
 
-        with patch("boto3.client", return_value=s3):  # nosemgrep: boto3-endpoint-url-missing-scheme
+        with patch(
+            "boto3.client", return_value=s3
+        ):  # nosemgrep: boto3-endpoint-url-missing-scheme
             put_image("img_new.jpg", b"data", "image/jpeg")
 
         s3.put_object.assert_called_once()
@@ -173,7 +187,9 @@ class TestAutoCreateBucket:
         s3.head_object.side_effect = _client_error("NoSuchKey")
         s3.put_object.side_effect = [_client_error("NoSuchBucket"), None]
 
-        with patch("boto3.client", return_value=s3):  # nosemgrep: boto3-endpoint-url-missing-scheme
+        with patch(
+            "boto3.client", return_value=s3
+        ):  # nosemgrep: boto3-endpoint-url-missing-scheme
             put_image("img_nob.jpg", b"data", "image/jpeg")
 
         s3.create_bucket.assert_called_once()
@@ -185,7 +201,9 @@ class TestAutoCreateBucket:
         s3.head_object.side_effect = _client_error("NoSuchKey")
         s3.put_object.side_effect = [_client_error("404"), None]
 
-        with patch("boto3.client", return_value=s3):  # nosemgrep: boto3-endpoint-url-missing-scheme
+        with patch(
+            "boto3.client", return_value=s3
+        ):  # nosemgrep: boto3-endpoint-url-missing-scheme
             put_image("img_404b.jpg", b"data", "image/jpeg")
 
         s3.create_bucket.assert_called_once()
@@ -201,7 +219,9 @@ class TestErrorPropagation:
         monkeypatch.setenv("SEAWEEDFS_S3_ENDPOINT", "http://seaweed:8333")
         s3 = _make_s3(head_side_effect=_client_error("AccessDenied"))
 
-        with patch("boto3.client", return_value=s3):  # nosemgrep: boto3-endpoint-url-missing-scheme
+        with patch(
+            "boto3.client", return_value=s3
+        ):  # nosemgrep: boto3-endpoint-url-missing-scheme
             with pytest.raises(ClientError):
                 put_image("img_denied.jpg", b"data", "image/jpeg")
 
@@ -211,7 +231,9 @@ class TestErrorPropagation:
         s3.head_object.side_effect = _client_error("NoSuchKey")
         s3.put_object.side_effect = _client_error("InternalError")
 
-        with patch("boto3.client", return_value=s3):  # nosemgrep: boto3-endpoint-url-missing-scheme
+        with patch(
+            "boto3.client", return_value=s3
+        ):  # nosemgrep: boto3-endpoint-url-missing-scheme
             with pytest.raises(ClientError):
                 put_image("img_ierr.jpg", b"data", "image/jpeg")
 
@@ -227,7 +249,9 @@ class TestBucketNameEnvVar:
         monkeypatch.setenv("TRIPS_S3_BUCKET", "custom-bucket")
         s3 = _make_s3(head_return_value={})
 
-        with patch("boto3.client", return_value=s3):  # nosemgrep: boto3-endpoint-url-missing-scheme
+        with patch(
+            "boto3.client", return_value=s3
+        ):  # nosemgrep: boto3-endpoint-url-missing-scheme
             put_image("img_k.jpg", b"data", "image/jpeg")
 
         kw = s3.head_object.call_args.kwargs
@@ -238,7 +262,9 @@ class TestBucketNameEnvVar:
         monkeypatch.delenv("TRIPS_S3_BUCKET", raising=False)
         s3 = _make_s3(head_return_value={})
 
-        with patch("boto3.client", return_value=s3):  # nosemgrep: boto3-endpoint-url-missing-scheme
+        with patch(
+            "boto3.client", return_value=s3
+        ):  # nosemgrep: boto3-endpoint-url-missing-scheme
             put_image("img_k.jpg", b"data", "image/jpeg")
 
         kw = s3.head_object.call_args.kwargs

--- a/projects/monolith/worldcup/models.py
+++ b/projects/monolith/worldcup/models.py
@@ -50,7 +50,9 @@ class Fixture(SQLModel, table=True):  # nosemgrep: sqlmodel-datetime-without-fac
     updated_at: datetime | None = None
 
 
-class Qualification(SQLModel, table=True):  # nosemgrep: sqlmodel-datetime-without-factory
+class Qualification(
+    SQLModel, table=True
+):  # nosemgrep: sqlmodel-datetime-without-factory
     __tablename__ = "qualification"
     __table_args__ = _SCHEMA
     team_id: str = Field(primary_key=True)

--- a/projects/monolith/worldcup/models.py
+++ b/projects/monolith/worldcup/models.py
@@ -50,7 +50,7 @@ class Fixture(SQLModel, table=True):  # nosemgrep: sqlmodel-datetime-without-fac
     updated_at: datetime | None = None
 
 
-class Qualification(SQLModel, table=True):  # nosemgrep
+class Qualification(SQLModel, table=True):  # nosemgrep: sqlmodel-datetime-without-factory
     __tablename__ = "qualification"
     __table_args__ = _SCHEMA
     team_id: str = Field(primary_key=True)


### PR DESCRIPTION
## Summary

- Adds `no-bare-nosemgrep` semgrep rule that catches bare `# nosemgrep` (without colon + rule ID) in Python files
- Uses `pattern-regex: '#\s*nosemgrep\s*$'` in `languages: [python]`
- CI enforcement backstop for the advisory `check-bare-nosemgrep.sh` Claude hook
- Fixes 21 existing violations across `projects/monolith/` by adding specific rule IDs:
  - `worldcup/models.py`: `# nosemgrep: sqlmodel-datetime-without-factory`
  - `stars/grid.py`, `chat/store.py`, `knowledge/raw_store.py`, `trips/s3.py`: `# nosemgrep: boto3-endpoint-url-missing-scheme`
  - `knowledge/notes_crud_test.py`, `knowledge/mcp_test.py`: `# nosemgrep: sqlmodel-select-missing-deleted-at-filter`
  - `trips/s3_test.py` (13 lines): `# nosemgrep: boto3-endpoint-url-missing-scheme`
- Adds colocated `rules/python/no-bare-nosemgrep.py` fixture (tested by `python_rules_test`) and `tests/fixtures/no-bare-nosemgrep.py` (dedicated test target)

## Test plan

- [ ] CI passes (`bazel test //...`)
- [ ] `python_rules_test` correctly validates the new rule against the colocated fixture
- [ ] `no_bare_nosemgrep_test` dedicated target appears in CI output
- [ ] No bare `# nosemgrep` remain in `projects/monolith/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)