### PR TITLE
fix(scheduler): serialize memory-heavy jobs + bump monolith memory

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.34.0
+version: 0.34.1
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.34.0
+      targetRevision: 0.34.1
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.191.0
+version: 0.191.1
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.191.0
+      targetRevision: 0.191.1
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/deploy/values.yaml
+++ b/projects/monolith/deploy/values.yaml
@@ -4,10 +4,14 @@ backend:
   otelEndpoint: "http://signoz-k8s-infra-otel-agent.signoz.svc.cluster.local:4318/v1/traces"
   resources:
     requests:
-      memory: "3Gi"
+      # 3Gi -> 4Gi: headroom above baseline RSS + one heavy scheduled job (the
+      # FA2 graph layout), which OOMKilled the pod when several jobs piled up.
+      # The scheduler now also serializes heavy jobs (heavy=True); this is the
+      # belt-and-suspenders. requests==limits per the repo memory convention.
+      memory: "4Gi"
       cpu: "10m"
     limits:
-      memory: "3Gi"
+      memory: "4Gi"
 
 frontend:
   otelCollectorUrl: "http://signoz-k8s-infra-otel-agent.signoz.svc.cluster.local:4318"

--- a/projects/monolith/home/observability/rollup.py
+++ b/projects/monolith/home/observability/rollup.py
@@ -84,6 +84,9 @@ def register(session: Session) -> None:
         name="observability.topology_rollup",
         interval_secs=TOPOLOGY_ROLLUP_INTERVAL_SECS,
         handler=lambda _: topology_rollup(),
+        # Builds the full topology payload from ClickHouse; co-resident with the
+        # graph layout in the OOM that motivated heavy-job serialization.
+        heavy=True,
     )
     register_job(
         session,

--- a/projects/monolith/knowledge/service.py
+++ b/projects/monolith/knowledge/service.py
@@ -279,6 +279,9 @@ def on_startup(session: Session) -> None:
         interval_secs=_INTERVAL_SECS,
         handler=layout_handler,
         ttl_secs=_TTL_SECS,
+        # FA2 layout loads the whole graph and is memory-heavy: serialize it
+        # against other heavy jobs so the shared pod is not OOMKilled.
+        heavy=True,
     )
 
     from knowledge.ingest_queue import ingest_handler

--- a/projects/monolith/scheduler/api.py
+++ b/projects/monolith/scheduler/api.py
@@ -38,10 +38,22 @@ Handler = Callable[[Session], Awaitable[datetime | None]]
 # In-memory handler registry (populated at startup)
 _registry: dict[str, Handler] = {}
 
+# Names of jobs flagged memory-heavy at registration. The dispatcher runs at most
+# ``max_heavy`` of these at once (default 1) so two big jobs (e.g. the FA2 graph
+# layout) never pile up and OOMKill the shared pod. Light jobs stay fully
+# parallel. Bounding concurrency by COUNT alone (the old semaphore) does not stop
+# this: several heavy jobs can be admitted in one tick before any has spiked.
+_heavy: set[str] = set()
+
 
 def is_registered(name: str) -> bool:
     """True if a handler is registered for name (public view of the registry)."""
     return name in _registry
+
+
+def is_heavy(name: str) -> bool:
+    """True if the job is flagged memory-heavy (serialized against other heavies)."""
+    return name in _heavy
 
 
 def registered_names() -> list[str]:
@@ -56,9 +68,18 @@ def register_job(
     interval_secs: int,
     handler: Handler,
     ttl_secs: int = 1200,
+    heavy: bool = False,
 ) -> None:
-    """Register a job handler and upsert its row in the database."""
+    """Register a job handler and upsert its row in the database.
+
+    Set ``heavy=True`` for memory-intensive jobs (e.g. the graph layout pass) so
+    the dispatcher never co-schedules two of them.
+    """
     _registry[name] = handler
+    if heavy:
+        _heavy.add(name)
+    else:
+        _heavy.discard(name)
 
     now = datetime.now(timezone.utc)
     # Upsert: insert if new, update interval/ttl if changed, preserve timing
@@ -96,30 +117,42 @@ def purge_stale_jobs(session: Session) -> None:
     session.commit()
 
 
-async def run_scheduler_loop(poll_interval: int = 30, max_concurrent: int = 5) -> None:
+async def run_scheduler_loop(
+    poll_interval: int = 30, max_concurrent: int = 5, max_heavy: int = 1
+) -> None:
     """Poll for due jobs and run them with bounded concurrency. Runs forever."""
     logger.info(
-        "Scheduler loop started (poll=%ds, max_concurrent=%d)",
+        "Scheduler loop started (poll=%ds, max_concurrent=%d, max_heavy=%d)",
         poll_interval,
         max_concurrent,
+        max_heavy,
     )
     while True:
         try:
-            await dispatch_due_jobs(max_concurrent=max_concurrent)
+            await dispatch_due_jobs(max_concurrent=max_concurrent, max_heavy=max_heavy)
         except Exception:
             logger.exception("Scheduler tick failed")
         await asyncio.sleep(poll_interval)
 
 
-async def dispatch_due_jobs(max_concurrent: int = 5) -> int:
+async def dispatch_due_jobs(max_concurrent: int = 5, max_heavy: int = 1) -> int:
     """Claim every currently-due job and run it, up to ``max_concurrent`` in
     parallel. Awaits all spawned handlers before returning.
+
+    Concurrency is bounded two ways. ``max_concurrent`` caps total simultaneous
+    handlers; ``max_heavy`` additionally caps how many memory-heavy jobs (those
+    registered ``heavy=True``) run at once. A heavy job holds BOTH a heavy slot
+    and a regular slot, so it still counts toward the total while guaranteeing no
+    two big jobs (e.g. graph layout + a large rollup) overlap and OOMKill the
+    shared pod. Light jobs are unaffected and stay fully parallel.
 
     Each handler runs on its own ``Session`` because SQLAlchemy sessions are
     not safe to share across concurrently awaiting coroutines.
     """
     if max_concurrent < 1:
         raise ValueError(f"max_concurrent must be >= 1, got {max_concurrent}")
+    if max_heavy < 1:
+        raise ValueError(f"max_heavy must be >= 1, got {max_heavy}")
 
     job_names: list[str] = []
     with Session(get_engine()) as session:
@@ -132,11 +165,18 @@ async def dispatch_due_jobs(max_concurrent: int = 5) -> int:
     if not job_names:
         return 0
 
-    semaphore = asyncio.Semaphore(max_concurrent)
+    slots = asyncio.Semaphore(max_concurrent)
+    heavy_slots = asyncio.Semaphore(max_heavy)
 
     async def _run(name: str) -> None:
-        async with semaphore:
-            await _run_claimed_job(name)
+        if name in _heavy:
+            # A heavy job takes a heavy slot first, then a regular slot, so it is
+            # serialized against other heavies AND counts toward the total cap.
+            async with heavy_slots, slots:
+                await _run_claimed_job(name)
+        else:
+            async with slots:
+                await _run_claimed_job(name)
 
     await asyncio.gather(*(_run(name) for name in job_names))
     return len(job_names)

--- a/projects/monolith/scheduler/scheduler_loop_test.py
+++ b/projects/monolith/scheduler/scheduler_loop_test.py
@@ -11,9 +11,11 @@ from scheduler.api import (
     ScheduledJob,
     _complete_job,
     _fail_job,
+    _heavy,
     _registry,
     _release_lock,
     _run_claimed_job,
+    dispatch_due_jobs,
     run_scheduler_loop,
 )
 
@@ -50,8 +52,10 @@ def session_fixture():
 def _clear_registry():
     """Ensure a clean handler registry for each test."""
     _registry.clear()
+    _heavy.clear()
     yield
     _registry.clear()
+    _heavy.clear()
 
 
 def _make_job(
@@ -330,3 +334,43 @@ class TestRunSchedulerLoop:
         assert call_count >= 3
         # sleep was called between dispatch calls
         assert mock_sleep.call_count >= 2
+
+
+class TestDispatchHeavyJobs:
+    @pytest.mark.asyncio
+    async def test_heavy_jobs_serialized_light_jobs_parallel(self):
+        """With several heavy jobs claimed in one tick, at most max_heavy run at
+        once, while light jobs still run in parallel."""
+        import asyncio
+
+        claimed = ["h1", "h2", "h3", "l1", "l2"]
+        _heavy.update({"h1", "h2", "h3"})
+        state = {"heavy_now": 0, "heavy_max": 0, "light_now": 0, "light_max": 0}
+
+        async def fake_run(name):
+            kind = "heavy" if name in _heavy else "light"
+            state[f"{kind}_now"] += 1
+            state[f"{kind}_max"] = max(state[f"{kind}_max"], state[f"{kind}_now"])
+            await asyncio.sleep(0.02)  # hold the slot so overlaps are observable
+            state[f"{kind}_now"] -= 1
+
+        seq = iter(claimed + [None])
+
+        with (
+            patch("scheduler.api.get_engine"),
+            patch("scheduler.api.Session"),
+            patch("scheduler.api._claim_next_job", side_effect=lambda *_: next(seq)),
+            patch("scheduler.api._run_claimed_job", side_effect=fake_run),
+        ):
+            ran = await dispatch_due_jobs(max_concurrent=5, max_heavy=1)
+
+        assert ran == 5
+        assert state["heavy_max"] == 1  # heavy jobs never overlap
+        assert state["light_max"] >= 2  # light jobs run concurrently
+
+    @pytest.mark.asyncio
+    async def test_rejects_bad_bounds(self):
+        with pytest.raises(ValueError):
+            await dispatch_due_jobs(max_concurrent=0)
+        with pytest.raises(ValueError):
+            await dispatch_due_jobs(max_heavy=0)


### PR DESCRIPTION
## Why
At 06:09 a batch of concurrently-dispatched jobs (`knowledge.layout` + `observability.topology_rollup` + worldcup + dr_jobs) collectively exceeded the monolith pod's **3Gi limit and OOMKilled it** (exit 137), 502-ing every service in the pod. The scheduler bounded concurrency by **count** (a 5-wide semaphore) but not by **memory** — and a runtime memory check wouldn't help, because all the jobs were admitted in the *same* tick before any had spiked. The only reliable fix is to know a priori which jobs are heavy and not co-schedule them.

## What
- **`register_job(..., heavy=True)`** flag + `dispatch_due_jobs(max_heavy=1)`: at most `max_heavy` (default 1) heavy jobs run at once via a second semaphore. A heavy job holds **both** a heavy slot and a regular slot, so it counts toward the total cap *and* can never overlap another heavy job. Light jobs are untouched and stay fully parallel.
- Tag the two memory-heavy jobs: **`knowledge.layout`** (ForceAtlas2 layout loads the whole graph) and **`observability.topology_rollup`** (full payload build) — both co-resident in the OOM.
- **Bump monolith backend memory 3Gi → 4Gi** (requests==limits per the repo convention) for headroom above baseline RSS + one heavy job. Belt-and-suspenders with the serialization. Verified the small nodes have ~5-6Gi of request headroom, so it schedules.

## Test
`TestDispatchHeavyJobs`: with 3 heavy + 2 light claimed in one tick, heavy concurrency peaks at 1 while light jobs run in parallel; plus bounds validation. The autouse fixture now also resets `_heavy`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)