### PR TITLE
fix(worldcup): square the country search input

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.35.0
+version: 0.35.1
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.35.0
+      targetRevision: 0.35.1
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.192.0
+version: 0.192.1
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.192.0
+      targetRevision: 0.192.1
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/routes/public/app/wc2026/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/wc2026/+page.svelte
@@ -698,6 +698,11 @@
     background: var(--cream);
     border: none;
     border-bottom: 2px solid var(--ink);
+    /* Strip the native input chrome: WebKit gives text inputs rounded corners
+       and an inner bevel by default, which breaks the hard-edge brutalist box. */
+    border-radius: 0;
+    -webkit-appearance: none;
+    appearance: none;
     outline: none;
   }
   .picker-search::placeholder {


### PR DESCRIPTION
The dropdown search box ("Type a country...") was rendering with rounded corners, breaking the hard-edge brutalist language of the rest of the picker.

Cause: `.picker-search` set a border but no `border-radius` / `appearance`, so WebKit's default user-agent styling for text inputs (rounded corners + inner bevel) leaked through.

Fix: `border-radius: 0` + `appearance: none` (with `-webkit-` prefix) on `.picker-search` so it's square cross-browser. CSS-only, one rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)