### PR TITLE
fix(worldcup): drop swing rows for matches between two settled teams

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.35.1
+version: 0.35.2
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.35.1
+      targetRevision: 0.35.2
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.192.1
+version: 0.192.2
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.192.1
+      targetRevision: 0.192.2
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/worldcup/sim.py
+++ b/projects/monolith/worldcup/sim.py
@@ -316,12 +316,24 @@ def simulate(
     # Build each country's ranked swing list from the tally. When an outcome was
     # never sampled (totals 0, e.g. swing_n == 0 or an impossible result) fall
     # back to the team's unconditional qualify probability so its swing is 0.
+    #
+    # A match between two teams whose fates are already sealed (each one qualified
+    # or eliminated) is skipped entirely: it cannot move ANY team's qualification.
+    # Neither participant's own standing matters anymore, and a settled team is
+    # never a best-third contender whose goal difference could shift the cutoff, so
+    # the match's true swing is exactly 0 for everyone. We drop it rather than
+    # surface its noisy Monte Carlo estimate: a rare upset between two settled teams
+    # is sampled in very few trials, so its conditional qualify-probability is high
+    # variance and reads as a phantom swing (the Tunisia-Netherlands case).
+    settled = {code for code, tp in per_team.items() if tp.status != "contention"}
     swings_by_country: dict[str, list[Swing]] = {}
     for c in by_code:
         ci = code_to_idx[c]
         cprob = per_team[c].prob_qualify
         rows = []
         for f in fixtures:
+            if f.home_code in settled and f.away_code in settled:
+                continue
             m = match_to_idx[f.match_id]
             conds = {}
             for oc, o in _OC_IDX.items():

--- a/projects/monolith/worldcup/sim_test.py
+++ b/projects/monolith/worldcup/sim_test.py
@@ -282,6 +282,47 @@ def test_swing_n_zero_yields_no_swing():
     assert 0.0 <= res.per_team["FAV"].prob_qualify <= 1.0
 
 
+def _scenario_settled_match():
+    """A group of four after two matchdays: AAA and BBB have both won twice
+    (6 pts) while CCC and DDD have lost twice (0 pts). The matchday-three
+    fixtures are AAA vs BBB and CCC vs DDD.
+
+    AAA and BBB each finish on >= 6 points whatever happens between them, while
+    the 0-point teams can reach at most 3, so both are guaranteed top-two and
+    are "qualified". Their head-to-head is therefore a settled-vs-settled match
+    that can move no team and must be dropped from every swing list. CCC and DDD
+    are still contesting the single third-place slot, so their match is the one
+    decisive fixture and is kept.
+    """
+    states = [
+        _team("AAA", "A", pts=6, gf=6, ga=0),
+        _team("BBB", "A", pts=6, gf=6, ga=0),
+        _team("CCC", "A", pts=0, gf=0, ga=3),
+        _team("DDD", "A", pts=0, gf=0, ga=3),
+    ]
+    fixtures = [
+        Fixture("A-AAA-BBB", "A", "AAA", "BBB"),
+        Fixture("A-CCC-DDD", "A", "CCC", "DDD"),
+    ]
+    elo = {c: _BASE for c in ("AAA", "BBB", "CCC", "DDD")}
+    return states, fixtures, elo
+
+
+def test_settled_vs_settled_match_excluded_from_swings():
+    # A match between two already-qualified teams has a true swing of 0 for every
+    # team, so it is dropped from all swing lists rather than surfaced with a noisy
+    # estimate; the still-live third-place match survives.
+    states, fixtures, elo = _scenario_settled_match()
+    res = simulate(states, fixtures, elo, focus="AAA", n=4000, seed=3, swing_n=4000)
+    assert res.per_team["AAA"].status == "qualified"
+    assert res.per_team["BBB"].status == "qualified"
+    # The settled-vs-settled fixture is absent from every team's swing list.
+    for code, rows in res.swings_by_country.items():
+        assert all(s.match_id != "A-AAA-BBB" for s in rows), code
+    # The genuinely decisive third-place match is still present.
+    assert "A-CCC-DDD" in {s.match_id for s in res.swings_by_country["CCC"]}
+
+
 def _scenario_head_to_head_tie():
     """A finished group of four where SCO and BRA are level on points for 2nd.
 


### PR DESCRIPTION
## Problem
Scotland's swing list surfaced **Tunisia vs Netherlands** with a 3.1% swing, even though Netherlands has qualified and Tunisia is eliminated, so the match provably cannot affect Scotland (or anyone).

## Cause
Swing is a Monte Carlo conditional: `P(team qualifies | match outcome)`, the spread across the three outcomes. For a match with no causal bearing the three conditionals should be equal, but they're sampled estimates. "Tunisia beats the already-qualified Netherlands" is a rare upset, so that conditional is computed from very few trials, has high variance, and landed on a spurious `1.00000`, producing a phantom 3.1% swing that even outranked Scotland's own decisive SCO vs BRA match.

## Fix (Option A)
A match between two settled teams (each qualified or eliminated) has a true swing of exactly 0 for every team: neither participant's standing matters, and a settled team is never a best-third contender whose goal difference could shift the cutoff. Skip these fixtures when building each country's swing list. Qualification probabilities are untouched.

## Test
`test_settled_vs_settled_match_excluded_from_swings`: a group where two teams clinch top-two (so their head-to-head is settled-vs-settled) while the other two contest the third-place slot. Asserts the settled match is absent from every swing list and the live third-place match survives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)