### PR TITLE
fix(monolith): tidy docs page layout and sizing

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.36.1
+version: 0.36.2
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.36.1
+      targetRevision: 0.36.2
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.193.1
+version: 0.193.2
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.193.1
+      targetRevision: 0.193.2
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/routes/+layout.svelte
+++ b/projects/monolith/frontend/src/routes/+layout.svelte
@@ -12,11 +12,17 @@
   // hooks.js reroute keeps the browser path un-prefixed, but match the
   // /public|/private prefixes too in case a route is hit directly.
   //
+  // Docs under /docs are likewise suppressed: DocsShell renders its own
+  // purpose-built topbar (back-to-apex link, docs search, section nav), so the
+  // global site nav would just stack a second sticky bar on top of it. Matches
+  // /docs and /docs/* but not unrelated prefixes like /docstore.
+  //
   // Error pages (notably the brutalist 404 in src/routes/+error.svelte) also
   // suppress the nav: a not-found page renders its own "back home" affordance
   // and the cross-tier nav would only clutter the dead-end.
   let hideNav = $derived(
     /^\/(public\/|private\/)?app\//.test($page.url.pathname) ||
+      /^\/(public\/|private\/)?docs(\/|$)/.test($page.url.pathname) ||
       $page.error != null,
   );
 

--- a/projects/monolith/frontend/src/routes/public/docs/DocsShell.svelte
+++ b/projects/monolith/frontend/src/routes/public/docs/DocsShell.svelte
@@ -185,10 +185,11 @@
 <Footer />
 
 <style>
-  /* ── Top bar: apex back link on the left, docs section nav on the right
-     (mirrors the old VitePress nav). Sticky height (~48px) matches the old
-     site nav so the sidebar / TOC `top: 76px` offsets and heading
-     scroll-margins stay valid. ── */
+  /* ── Top bar: apex back link on the left, docs section nav on the right.
+     This is the *only* header on docs pages: the global site nav is
+     suppressed on /docs (see routes/+layout.svelte), so this bar owns
+     `top: 0` alone. Its height (~64px with the search box) sets the
+     sidebar / TOC `top: 76px` offsets and heading scroll-margins. ── */
   .docs-topbar {
     position: sticky;
     top: 0;
@@ -202,7 +203,7 @@
     align-items: center;
     justify-content: space-between;
     gap: 16px;
-    max-width: 1280px;
+    max-width: 1320px;
     margin: 0 auto;
     padding: 14px 32px;
   }
@@ -321,16 +322,16 @@
 
   .docs-layout {
     display: grid;
-    grid-template-columns: 248px minmax(0, 1fr);
-    gap: 28px;
-    max-width: 1280px;
+    grid-template-columns: 240px minmax(0, 1fr);
+    gap: 32px;
+    max-width: 1320px;
     margin: 0 auto;
     padding: 32px;
     align-items: start;
   }
 
   .docs-layout.has-toc {
-    grid-template-columns: 248px minmax(0, 1fr) 220px;
+    grid-template-columns: 240px minmax(0, 1fr) 200px;
   }
 
   /* ── Left sidebar ────────────────────────────────────────── */
@@ -493,8 +494,23 @@
     border-left-color: var(--coral);
   }
 
-  /* ── Responsive: collapse the rails on narrow viewports ──── */
-  @media (max-width: 1080px) {
+  /* ── Responsive: shed the rails in two stages ─────────────────
+     The right TOC is the first to go (≤1200px): below that width the
+     nav + content + TOC triple squeezes the prose into a cramped
+     column and makes the serif headings look oversized. Dropping the
+     TOC first hands that space back to the content. The left nav only
+     unsticks and stacks on top once the viewport can no longer hold a
+     two-column layout (≤920px). */
+  @media (max-width: 1200px) {
+    .docs-layout.has-toc {
+      grid-template-columns: 240px minmax(0, 1fr);
+    }
+    .docs-toc {
+      display: none;
+    }
+  }
+
+  @media (max-width: 920px) {
     .docs-layout,
     .docs-layout.has-toc {
       grid-template-columns: minmax(0, 1fr);
@@ -504,9 +520,6 @@
     .docs-side {
       position: static;
       max-height: none;
-    }
-    .docs-toc {
-      display: none;
     }
     .docs-card {
       padding: 28px 22px;
@@ -528,21 +541,21 @@
   }
 
   .docs-card :global(h1) {
-    font-size: 2.6rem;
-    letter-spacing: -0.02em;
-    margin: 0 0 24px;
+    font-size: 2.2rem;
+    letter-spacing: -0.01em;
+    margin: 0 0 20px;
   }
 
   .docs-card :global(h2) {
-    font-size: 1.7rem;
-    margin: 38px 0 14px;
+    font-size: 1.5rem;
+    margin: 34px 0 14px;
     padding-bottom: 8px;
     border-bottom: 2px solid var(--ink);
   }
 
   .docs-card :global(h3) {
-    font-size: 1.3rem;
-    margin: 28px 0 10px;
+    font-size: 1.2rem;
+    margin: 26px 0 10px;
   }
 
   .docs-card :global(h4) {
@@ -681,6 +694,12 @@
     padding: 8px 10px;
     text-align: left;
     vertical-align: top;
+    /* Long unbroken mono tokens (file paths like
+       projects/platform/agent-sandbox, URLs) would otherwise force the
+       auto-laid-out table wider than the card and bleed past its right
+       border. Let them wrap inside the cell instead. */
+    overflow-wrap: anywhere;
+    word-break: break-word;
   }
 
   .docs-card :global(thead th) {


### PR DESCRIPTION
## What

The `/docs` pages looked cramped and rendered **two stacked sticky headers** that collided on scroll: the global site nav (`HOME / ENGINEERING / APPS / DOCS / CV`) and DocsShell's own purpose-built topbar (back-to-apex link, search, Architecture/ADRs/GitHub). Both pinned to `top: 0` with the same `z-index`.

## Changes

- **Single header.** Suppress the global site nav on `/docs` (root `+layout.svelte` `hideNav`) so DocsShell's topbar is the sole header. The topbar already carries a `← jomcgi.dev` link back to the site. Standard docs-site UX.
- **Shed the TOC rail earlier.** The right "On this page" rail now drops at `<=1200px` (before the full single-column collapse, moved to `<=920px`). Previously the three-column grid squeezed the prose into a cramped ~600px column across the whole 1080-1280px band, which includes the 1280px CI screenshot viewport.
- **More room for content.** Trim the side rails (248->240, 220->200) and widen the cap to 1320px.
- **Soften display headings.** h1 2.6->2.2rem, h2 1.7->1.5rem so they no longer overwhelm the column.
- **Stop table overflow.** Long mono tokens (file paths, URLs) now wrap in table cells (`overflow-wrap: anywhere`) instead of pushing the table past the card's right border.

## Visual regression

Committed the `.reseed-baselines` sentinel: the `docs` and `docs-slug` renders change (and lose the global nav), so CI regenerates the baselines as the new truth and removes the sentinel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)