### PR TITLE
chore(visual): reseed docs baselines after layout fix

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.36.2
+version: 0.36.3
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.36.2
+      targetRevision: 0.36.3
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.193.2
+version: 0.193.3
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.193.2
+      targetRevision: 0.193.3
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/visual/.reseed-baselines
+++ b/projects/monolith/frontend/visual/.reseed-baselines
@@ -1,0 +1,1 @@
+docs layout reseed (PR #2760): regenerate docs + docs-slug baselines


### PR DESCRIPTION
The `.reseed-baselines` sentinel committed in PR #2760 was dropped during its rebase merge (an empty file already existed on the new base, so the diff vanished), leaving the `docs` / `docs-slug` visual baselines showing the old pre-fix layout. Re-add the sentinel so CI regenerates them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)