### PR TITLE
fix(hikes): walk card respects duration-aware doability

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.38.1
+version: 0.38.2
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.38.1
+      targetRevision: 0.38.2
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.195.1
+version: 0.195.2
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.195.1
+      targetRevision: 0.195.2
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/lib/public/components/hikes/HikesMap.svelte
+++ b/projects/monolith/frontend/src/lib/public/components/hikes/HikesMap.svelte
@@ -181,15 +181,21 @@
   // Window rows for the selected walk's card, grouped by UK-local day. Windows
   // come from the per-walk detail fetch (selectedDetail), not the light list.
   // We show the day the user filtered to (the parent's selectedDay chip) when
-  // this walk has windows on it, so clicking a marker that survived a
-  // "Saturday" filter shows Saturday's rows. Otherwise we fall back to the
-  // earliest day with a future window.
+  // this walk is doable on it, so clicking a marker that survived a "Saturday"
+  // filter shows Saturday's rows. Otherwise we fall back to the earliest DOABLE
+  // day.
   let cardDays = $derived(selectedDetail ? groupWindowsByDay(selectedDetail) : {});
   let cardDayKeys = $derived(Object.keys(cardDays).sort());
+  // The days the server judged DOABLE for this walk's length (duration-aware: a
+  // long-enough run of good hours, see router._doable_days). The card must honour
+  // it: otherwise an 8 h walk with 3 good evening hours would still read "Next
+  // viable: today". We only ever land on a day that is both doable AND present in
+  // cardDays, so there is always an hourly table to show beneath the label.
+  let doableDays = $derived(new Set(selected?.viable_days ?? []));
   let cardDayKey = $derived(
-    selectedDay && cardDays[selectedDay]?.length
+    selectedDay && cardDays[selectedDay]?.length && doableDays.has(selectedDay)
       ? selectedDay
-      : (cardDayKeys[0] ?? null),
+      : (cardDayKeys.find((d) => doableDays.has(d)) ?? null),
   );
   let cardRows = $derived(
     cardDayKey ? cardDays[cardDayKey].map(windowFields) : [],
@@ -378,6 +384,12 @@
             {/each}
           </tbody>
         </table>
+      {:else if cardDayKeys.length}
+        <p class="card-empty">
+          Not enough good daylight hours for this {fmtDuration(
+            selected.duration_h,
+          )} walk on any day in the forecast.
+        </p>
       {:else}
         <p class="card-empty">No viable weather windows in the forecast.</p>
       {/if}


### PR DESCRIPTION
## Follow-up to #2764

#2764 made the day strip and list filtering duration-aware (via the server's `viable_days`), but the **selected-walk card** was missed: it computed its own "Next viable: <day>" label from the raw hourly windows, length-blind, picking the earliest day with **any** good hour.

Result (spotted live): an 8h Munro (Stob Coire Easain) showed **"NEXT VIABLE: SUNDAY 21 JUN"** with only three good evening hours (20:00, 21:00, 22:00, the last at 100% cloud). Three hours can't fit an 8h walk.

## Fix

Make the card honour the server's already-correct, duration-aware `viable_days` (it's on the selected walk row):

- "Next viable" / hourly table now land on the **earliest day that is both doable and present in the fetched windows**, so the label and table always reflect a day the walk actually fits.
- New distinct empty state when good hours exist but **no day is doable** for the walk's length: *"Not enough good daylight hours for this 8 h walk on any day in the forecast."* (the generic "no viable weather windows" message is kept for the truly-no-windows case).

Single source of truth: doability is computed once on the server (`router._doable_days`); the card now reads it rather than re-deriving it. No algorithm duplication.

## Scope

One component (`HikesMap.svelte`), logic-only in the `cardDayKey` derivation plus one new empty-state branch. No backend, schema, or wire change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)