### PR TITLE
fix(platform): run Argo Workflows unmeshed in monolith-workflows ns

### DIFF
--- a/projects/platform/argo-workflows/BUILD
+++ b/projects/platform/argo-workflows/BUILD
@@ -10,7 +10,7 @@ argocd_app(
     name = "argo-workflows",
     chart = "projects/platform/argo-workflows",
     chart_files = ":chart",
-    namespace = "argo",
+    namespace = "monolith-workflows",
     release_name = "argo-workflows",
     # The bundled Argo CRDs (workflows, workflowtemplates, ...) embed full
     # pod/container OpenAPI schemas inside their `description:` text. Two Semgrep

--- a/projects/platform/argo-workflows/application.yaml
+++ b/projects/platform/argo-workflows/application.yaml
@@ -19,8 +19,19 @@ spec:
         - values.yaml
   destination:
     server: https://kubernetes.default.svc
-    namespace: argo
+    namespace: monolith-workflows
   syncPolicy:
+    # Stamp the mesh opt-out onto the namespace at creation. This cluster meshes
+    # every namespace by default (Kyverno inject-linkerd-namespace-annotation),
+    # but that policy excludes namespaces carrying a linkerd.io/inject label. A
+    # meshed Workflow pod would never terminate (its linkerd-proxy never exits),
+    # so the whole namespace (controller, server, and Workflow pods) runs
+    # unmeshed via this opt-out.
+    managedNamespaceMetadata:
+      labels:
+        linkerd.io/inject: disabled
+      annotations:
+        linkerd.io/inject: disabled
     automated:
       prune: true
       selfHeal: true

--- a/projects/platform/argo-workflows/values.yaml
+++ b/projects/platform/argo-workflows/values.yaml
@@ -8,22 +8,28 @@
 #
 # Scope: NAMESPACE-SCOPED. singleNamespace=true makes the controller and server
 # run with --namespaced and creates Roles (not ClusterRoles) bound only in the
-# release namespace 'argo'. Workflow pods also run in 'argo'.
+# release namespace 'monolith-workflows'. Workflow pods also run there.
 #
-# Why a dedicated 'argo' namespace and NOT the monolith namespace: the monolith
-# namespace is Linkerd-meshed (linkerd.io/inject: enabled). A meshed pod's
-# linkerd-proxy never exits when the main container completes, so a Workflow pod
-# would never reach Completed and the controller would think it is stuck forever
-# (the classic mesh + Job problem). The 'argo' namespace is intentionally NOT
-# injected, so Workflow pods terminate cleanly with zero sidecar-kill hacks.
-# monolith-pg has no AuthorizationPolicy/Server in the monolith namespace, so
-# unmeshed jobs reach it over plaintext in-cluster without being denied.
+# Linkerd + workflow-pod termination: a meshed pod's linkerd-proxy never exits
+# when the main container completes, so a meshed Workflow pod would never reach
+# Completed and the controller would think it is stuck forever (the classic
+# mesh + Job problem). This cluster meshes every namespace by default via the
+# Kyverno `inject-linkerd-namespace-annotation` policy, and the existing
+# `disable-linkerd-on-jobs` policy only matches kind=Job, NOT Argo's bare
+# Workflow pods. Rather than opt out per workflow pod, the whole
+# 'monolith-workflows' namespace opts out: the ArgoCD Application stamps
+# `linkerd.io/inject: disabled` (label + annotation) onto the namespace via
+# managedNamespaceMetadata, which is exactly the exclusion the Kyverno policy
+# honours. So controller, server, and every Workflow pod run UNMESHED and
+# Workflow pods terminate cleanly with zero sidecar-kill hacks. monolith-pg has
+# no AuthorizationPolicy/Server in the monolith namespace, so unmeshed Workflow
+# pods reach it over plaintext in-cluster without being denied.
 #
 # Values are wrapped under the `argo-workflows:` key because the upstream
 # argoproj/argo-workflows chart is pulled in as a subchart dependency (Chart.yaml).
 argo-workflows:
   # Namespace-scoped install: Roles instead of ClusterRoles, controller+server
-  # restricted to the 'argo' namespace.
+  # restricted to the 'monolith-workflows' namespace.
   singleNamespace: true
 
   # Do NOT create the cluster-wide aggregate view/edit/admin ClusterRoles: this

--- a/projects/platform/kustomization.yaml
+++ b/projects/platform/kustomization.yaml
@@ -4,7 +4,7 @@ kind: Kustomization
 resources:
   - ./argocd
   - ./argocd-image-updater
-  - ./argo-workflows # Namespace-scoped (argo ns) batch-job executor for the monolith
+  - ./argo-workflows # Namespace-scoped (monolith-workflows ns) batch-job executor for the monolith
   - ./atlas-operator/deploy
   - ./cert-manager # Must be before linkerd
   - ./cloudnative-pg/deploy


### PR DESCRIPTION
## Problem (caught at rollout)

After #2766 deployed, the `argo` namespace pods came up **2/2** — a `linkerd-proxy` sidecar. This cluster meshes every namespace by default (Kyverno `inject-linkerd-namespace-annotation`), and ArgoCD's `CreateNamespace=true` made a bare namespace with no opt-out label, so it got meshed. **A meshed Workflow pod never terminates** (its proxy never exits on container completion), so the controller would think every job is stuck forever — defeating the whole reason we chose an unmeshed namespace. The existing `disable-linkerd-on-jobs` policy only matches `kind=Job`, not Argo's bare Workflow pods.

## Fix

Opt the whole namespace out of the mesh via ArgoCD `managedNamespaceMetadata` (`linkerd.io/inject: disabled` label + annotation) — exactly the exclusion the Kyverno policy honours (it skips namespaces carrying that label). Controller, server, and every Workflow pod now run **unmeshed**, so jobs terminate cleanly with zero sidecar-kill hacks. This is cleaner than per-pod `workflowDefaults` because one namespace-level declaration covers everything uniformly.

Also rename `argo` → **`monolith-workflows`** to say what the namespace is for.

## Notes

- `monolith-pg` has no `AuthorizationPolicy` in the monolith ns, so unmeshed Workflow pods still reach it over plaintext in-cluster.
- After merge, ArgoCD moves resources to `monolith-workflows` and prunes the `argo`-ns ones; the now-empty `argo` namespace (ArgoCD-created, untracked) will be deleted manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)