### PR TITLE
chore(linkerd): right-size proxy CPU request, drop CPU limit

### DIFF
--- a/projects/platform/linkerd/values.yaml
+++ b/projects/platform/linkerd/values.yaml
@@ -30,11 +30,15 @@ linkerd-control-plane:
     tracing:
       enabled: false
 
-    # Resource limits for proxy sidecars
+    # Resource requests for proxy sidecars.
+    # CPU: request only, no limit. Measured usage across 49 meshed pods is
+    # ~0.5m each (27m total cluster-wide), so the previous 100m request
+    # reserved ~4.9 cores of phantom capacity. 20m leaves headroom while
+    # cutting the reservation. No CPU limit, per the repo convention that
+    # CPU limits cause throttling (memory is requests=limits, not CPU).
     resources:
       cpu:
-        request: 100m
-        limit: 1000m
+        request: 20m
       memory:
         request: 20Mi
         limit: 250Mi


### PR DESCRIPTION
## What

Tunes the `linkerd-proxy` data-plane sidecar resources in `projects/platform/linkerd/values.yaml`:

- CPU request: `100m` -> `20m`
- CPU limit: `1000m` -> removed
- Memory request/limit: unchanged (`20Mi` / `250Mi`)

## Why

The proxy is injected into **all 49 meshed pods**. Measured live usage (metrics API) is ~0.5m CPU each, **27m total cluster-wide**. The previous `100m` request therefore reserved ~4.9 cores of capacity that is never used. Dropping to `20m` frees ~3.9 cores of phantom reservation across the mesh.

This directly targets the reserved-vs-used CPU gap flagged in the 2026-06-18 right-sizing review (~9% used / 57% reserved). Removing the CPU limit follows the repo convention: CPU gets requests but no limits (limits cause throttling); memory stays requests/limits.

Actual proxy consumption is trivial, so no throughput or latency risk; bumps can still burst freely with no CPU ceiling.

## Rollout

Linkerd is a git-HEAD-sourced platform app (no chart bump). ArgoCD syncs on merge; the new requests take effect as proxies are re-injected on pod restart (no forced restart in this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)