### PR TITLE
fix(monolith): build JOBS_IMAGE ref from pinned object

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.40.0
+version: 0.40.1
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.40.0
+      targetRevision: 0.40.1
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.197.0
+version: 0.197.1
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/templates/deployment.yaml
+++ b/projects/monolith/chart/templates/deployment.yaml
@@ -47,10 +47,12 @@ spec:
             - name: WORKFLOW_NAMESPACE
               value: {{ .Values.jobs.workflowNamespace | default "monolith-workflows" | quote }}
             {{- if .Values.jobs.image }}
-            # Digest-pinned at build time by helm_images_values (chart/BUILD
-            # images "jobs.image"); the Workflow runs this exact image.
+            # Pinned at build time by helm_images_values (chart/BUILD images
+            # "jobs.image") as a {repository, tag} object - same shape as
+            # backend.image - so build the ref the same way; the Workflow runs
+            # this exact image.
             - name: JOBS_IMAGE
-              value: {{ .Values.jobs.image | quote }}
+              value: "{{ .Values.jobs.image.repository }}:{{ .Values.jobs.image.tag }}"
             {{- end }}
             {{- if .Values.onepassword.enabled }}
             - name: ICAL_FEED_URL

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.197.0
+      targetRevision: 0.197.1
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
## Problem

`helm_images_values` pins `jobs.image` as a `{repository, tag}` object (same shape as `backend.image`), but the deployment template did `{{ .Values.jobs.image | quote }}`, stringifying the whole map. The live pod had `JOBS_IMAGE=map[repository:... tag:...]` — a Workflow using it would `ImagePullBackOff`.

## Fix

Build the ref as `repository:tag`, exactly like `backend.image`. Verified render: `JOBS_IMAGE: "ghcr.io/.../jobs:2026.06.21.19.06.28-e2b175f"`.

Found while verifying the gated Argo path (#2773) end-to-end before declaring it functional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)