### PR TITLE
fix(monolith): add typer to the :jobs binary so the jobs image starts

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.40.0
+version: 0.40.1
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.40.0
+      targetRevision: 0.40.1
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -114,7 +114,13 @@ py_venv_binary(
     imports = ["."],  # keep
     main = "app/jobs_main.py",
     visibility = ["//:__subpackages__"],
-    deps = [":monolith_backend"],  # keep
+    # typer is the jobs entrypoint's CLI framework but is NOT a serving dep, so
+    # it is absent from :monolith_backend; the binary must depend on it directly
+    # or the jobs image fails at startup with `ModuleNotFoundError: typer`.
+    deps = [
+        ":monolith_backend",
+        "@pip//typer",
+    ],  # keep
 )
 
 # Phase-1 vault-mutation script: walk a vault and inject `visibility:` lines

--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -4251,6 +4251,8 @@ semgrep_target_test(
         "tainted-path-traversal-stdlib-fastapi",
         "test-hardcoded-past-timestamp",  # keep
     ],
+    lockfiles = ["//bazel/requirements:all.txt"],
     rules = ["//bazel/semgrep/rules:python_rules"],
+    sca_rules = ["//bazel/semgrep/rules:sca_python_rules"],
     target = ":jobs",
 )

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.197.0
+version: 0.197.1
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.197.0
+      targetRevision: 0.197.1
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
## Problem (caught by a live workflow run)

A verification workflow running the jobs image's `worldcup-sim` failed:

```
File ".../app/jobs_main.py", line 25, in <module>
    import typer
ModuleNotFoundError: No module named 'typer'
```

The `:jobs` binary deps on `:monolith_backend`, which does **not** include `typer` (it's not a serving dependency — only the jobs entrypoint and `trips/backfill` use it). The `jobs_main_test` target listed `@pip//typer` *explicitly*, which masked the gap: the **test target** had typer, the **binary target** didn't. Unit tests + `helm template` couldn't see it; only the first pod to actually `import typer` from the image did.

## Fix

Add `@pip//typer` to the `:jobs` binary deps. After this rebuilds the jobs image, the workflow starts.

Found while verifying the gated Argo path (#2773) end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)