### PR TITLE
fix(chat_public): grant public_reader schema usage so shared chat links load

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.40.2
+version: 0.40.3
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.40.2
+      targetRevision: 0.40.3
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.197.2
+version: 0.197.3
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/migrations/20260621130000_chat_public_reader_schema_usage.sql
+++ b/projects/monolith/chart/migrations/20260621130000_chat_public_reader_schema_usage.sql
@@ -1,0 +1,19 @@
+-- Grant public_reader USAGE on the chat_public schema so the public read route
+-- can serve shared chat snapshots (ADR 005 "share this chat").
+--
+-- chat_public.shared_snapshots already grants SELECT to public_reader
+-- (20260620000000_chat_public_shared_snapshots.sql), but that grant was dead on
+-- its own: public_reader was never granted USAGE on the chat_public schema, and
+-- Postgres requires schema USAGE to reach ANY object inside a schema even when a
+-- table-level SELECT exists. So GET /shared/{id} (which runs as public_reader on
+-- the read replica) failed with "permission denied for schema chat_public", and
+-- the SvelteKit SSR loader collapsed that 5xx into a 404. Every freshly minted
+-- share link 404'd as a result, regardless of the URL path.
+--
+-- USAGE on the schema does NOT expose sessions or messages: public_reader still
+-- holds table SELECT only on shared_snapshots (the chat_public default-privilege
+-- grant is scoped to public_writer), so transcripts, IP/UA hashes, and the
+-- response cache stay unreadable. This restores the single read the share route
+-- needs and nothing more. See 20260617000000_public_reader_role.sql for the
+-- role's other schema grants.
+GRANT USAGE ON SCHEMA chat_public TO public_reader;

--- a/projects/monolith/chart/migrations/atlas.sum
+++ b/projects/monolith/chart/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:yZqDgT4EvlrdfiwmA32hN4MPJ5BykDIWGzEwFotG9nk=
+h1:8SphNeTL9tHoWkS/Mj+xE0/kDKqin6Na7dnAO9iyMzI=
 20260330000000_initial_schema.sql h1:J2futpSW0nJAIRR7nR7ssT7LwXIYrvRI+PkHb5Y4tLI=
 20260403000000_chat_schema.sql h1:pERUFC0vzM95etRuzp43XzkCV7lBCzrrtY5Mk7aF3CA=
 20260404000000_chat_attachments.sql h1:tv+Fdbr1rQC5nzUxfaBC0O6fu2OMGgLWf+YNg1WQXi4=
@@ -60,3 +60,4 @@ h1:yZqDgT4EvlrdfiwmA32hN4MPJ5BykDIWGzEwFotG9nk=
 20260620120000_worldcup_schema.sql h1:mgYJYPeeJfkAYuR27Zzvpe/Ldji1yPLLR1iiypGng/k=
 20260620120100_worldcup_public_reader_grant.sql h1:gAXxMO9FNfGw1xAjmbb0GciI59awvH9WFzjtVuw9muQ=
 20260621120000_worldcup_swing_per_country.sql h1:PF2X+SOSRkR4sMD1fgd+fu0eoJ0BgiiItGI9IZn7ugw=
+20260621130000_chat_public_reader_schema_usage.sql h1:UuKhDAWNrOK/vOEcI7UA89nvKxSRiSAVQTgRwZexRn8=

--- a/projects/monolith/chat_public_grants_test.py
+++ b/projects/monolith/chat_public_grants_test.py
@@ -125,3 +125,61 @@ def test_public_reader_cannot_write_chat_public(pg):
             assert "permission denied" in str(exc.value).lower()
     finally:
         engine.dispose()
+
+
+def test_public_reader_can_read_shared_snapshots(pg):
+    """The share read route (GET /shared/{id}, ADR 005) runs as public_reader on
+    the replica, so public_reader MUST be able to SELECT a snapshot that
+    public_writer minted. Regression for the missing GRANT USAGE ON SCHEMA
+    chat_public TO public_reader: without schema USAGE the table SELECT was dead
+    and every share link 404'd (the SSR loader collapsed the permission error)."""
+    engine = create_engine(pg.url)
+    try:
+        with Session(engine) as session:
+            # Mint a snapshot as the writer role. source_session_id is nullable,
+            # so no session row is needed to exercise the read grant.
+            session.execute(text("SET ROLE public_writer"))
+            session.execute(
+                text(
+                    "INSERT INTO chat_public.shared_snapshots "
+                    "(id, transcript, message_count) "
+                    "VALUES ('grant-test-snap', '[]'::jsonb, 0)"
+                )
+            )
+            session.execute(text("RESET ROLE"))
+
+            # Read it back as the read-only public_reader role.
+            session.execute(text("SET ROLE public_reader"))
+            count = session.execute(
+                text(
+                    "SELECT count(*) FROM chat_public.shared_snapshots "
+                    "WHERE id = 'grant-test-snap'"
+                )
+            ).scalar_one()
+            assert count == 1
+            # Never commit: the row and the role changes are rolled back.
+            session.rollback()
+    finally:
+        engine.dispose()
+
+
+def test_public_reader_cannot_read_chat_transcripts(pg):
+    """Schema USAGE on chat_public does not leak conversations: public_reader has
+    table SELECT only on shared_snapshots, so reading sessions or messages still
+    raises permission denied. Keeps the share-read grant least-privilege (no
+    transcripts, IP/UA hashes, or response cache exposed to the public reader)."""
+    engine = create_engine(pg.url)
+    try:
+        with Session(engine) as session:
+            for tbl in ("sessions", "messages", "response_cache"):
+                # Re-set the role each iteration: the prior aborted statement is
+                # rolled back, which also unwinds the SET ROLE.
+                session.execute(text("SET ROLE public_reader"))
+                with pytest.raises(Exception) as exc:
+                    session.execute(
+                        text(f"SELECT count(*) FROM chat_public.{tbl}")
+                    ).all()
+                assert "permission denied" in str(exc.value).lower()
+                session.rollback()
+    finally:
+        engine.dispose()

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.197.2
+      targetRevision: 0.197.3
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/routes/public/app/notes/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/notes/+page.svelte
@@ -373,7 +373,7 @@
         return;
       }
       const { snapshot_id: snapshotId } = await resp.json();
-      const shareUrl = `${location.origin}/public/app/notes/s/${snapshotId}`;
+      const shareUrl = `${location.origin}/app/notes/s/${snapshotId}`;
       try {
         await navigator.clipboard.writeText(shareUrl);
         flashShare("LINK COPIED");


### PR DESCRIPTION
## What

Shared chat links (`/app/notes/s/<token>`, the ADR 005 "share this chat" feature) returned a 404 for every freshly minted snapshot. This fixes the real cause and cleans up the copied URL.

## Why it 404'd (it was not URL routing)

The share URL had a redundant `/public/` in the middle, but that was a red herring. Both `jomcgi.dev/app/notes/s/<token>` (rewritten to `/public/...` by the `reroute` hook in `hooks.js`) and the explicit `/public/app/notes/s/<token>` form resolve to the **same** SvelteKit route. That route's SSR `load()` calls `GET /internal/chat/shared/{id}`, which runs as the `public_reader` role on the read replica.

`chat_public.shared_snapshots` already granted `SELECT` to `public_reader` (migration `20260620000000`), but the grant was **dead**: `public_reader` was never granted `USAGE ON SCHEMA chat_public`. Postgres requires schema `USAGE` to reach any object in a schema even when a table-level `SELECT` exists, so the read failed with `permission denied for schema chat_public`. The SSR loader treats any non-OK upstream response as not-found, collapsing that 5xx into a 404 for the visitor.

This matches the silent-grant failure pattern in `CLAUDE.md` (RBAC/grants that "fail silently in prod ... that look like generic 5xx").

## Changes

- **`20260621130000_chat_public_reader_schema_usage.sql`** — `GRANT USAGE ON SCHEMA chat_public TO public_reader`. This does **not** expose sessions or messages: `public_reader` still holds table `SELECT` only on `shared_snapshots` (the `chat_public` default-privilege grant is scoped to `public_writer`), so transcripts, IP/UA hashes, and the response cache stay unreadable.
- **`atlas.sum`** — regenerated for the new migration (only the total line changed plus the appended entry; existing per-file hashes untouched).
- **`chat_public_grants_test.py`** — two regression tests: `public_reader` can read a snapshot minted by `public_writer`, and `public_reader` still cannot read `sessions` / `messages` / `response_cache`.
- **`+page.svelte`** — drop the baked-in `/public/` from the copied share link; the user-facing URL is now `/app/notes/s/<token>`, which reroutes internally on every public host.

## Testing

Defer to CI (`atlas migrate validate` for the checksum, the `chat_public_grants_test` bdd test against a real Postgres). No local test loop per repo convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TVJvuwak3Wg7vNPicKYiU3)_