### PR TITLE
feat(chat_public): fork a shared chat snapshot to continue it

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.40.4
+version: 0.41.0
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.40.4
+      targetRevision: 0.41.0
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.197.4
+version: 0.198.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chat_public/router.py
+++ b/projects/monolith/chat_public/router.py
@@ -170,6 +170,15 @@ class ShareRequest(BaseModel):
     session_id: str | None = None
 
 
+class ForkRequest(BaseModel):
+    # "Fork this chat" from a read-only snapshot: the only client input honored
+    # is the snapshot id and a Turnstile token (admission, same as a fresh
+    # session). The seeded history comes server-side from the immutable snapshot,
+    # never from the client body.
+    snapshot_id: str | None = None
+    turnstile_token: str | None = None
+
+
 def _iso(dt: datetime | None) -> str | None:
     """Serialize a possibly-naive timestamp as an offset-consistent ISO string.
 
@@ -561,4 +570,88 @@ def get_shared_chat(
         "id": snapshot.id,
         "created_at": _iso(snapshot.created_at),
         "messages": list(snapshot.transcript or []),
+    }
+
+
+@router.post("/fork", response_model=SessionCreateResponse)
+async def fork_chat(
+    payload: ForkRequest = Body(default_factory=ForkRequest),
+    db: Session = Depends(get_chat_session),
+    read_db: Session = Depends(get_session),
+    cf_ipcountry: str | None = Header(default=None, alias="CF-IPCountry"),
+    cf_connecting_ip: str | None = Header(default=None, alias="CF-Connecting-IP"),
+    user_agent: str | None = Header(default=None, alias="User-Agent"),
+) -> SessionCreateResponse:
+    """Fork a read-only snapshot into a new, continuable session.
+
+    Admission is identical to creating a fresh session (siteverify the forwarded
+    Turnstile token: no valid token, no session), because a fork mints a new
+    server-side session backed by real inference. Only then is the snapshot read
+    (public_reader replica) and its frozen transcript seeded into a new session
+    (public_writer primary). The seeded turns/tokens are charged to the new
+    session so the fork inherits the conversation's budget. Returns the opaque
+    session id; SSR stores it in the httpOnly cookie, then lands the visitor on
+    the live app, which rehydrates the seeded transcript.
+
+    404 (identical to a missing snapshot) when the snapshot id is unknown.
+    """
+    result = await turnstile.siteverify(payload.turnstile_token, cf_connecting_ip)
+    if not result.success:
+        raise HTTPException(
+            status_code=_limit_status("turnstile_failed"),
+            detail={
+                "code": "turnstile_failed",
+                "message": "Challenge verification failed. Please try again.",
+            },
+        )
+
+    snapshot = snapshots.load_snapshot(read_db, payload.snapshot_id)
+    if snapshot is None:
+        raise HTTPException(status_code=404, detail="Snapshot not found")
+
+    session = snapshots.fork_snapshot(
+        db,
+        snapshot,
+        turnstile_outcome=result.outcome,
+        ip=cf_connecting_ip,
+        country=cf_ipcountry,
+        user_agent=user_agent,
+    )
+    logger.info(
+        "chat_public.snapshot.forked snapshot=%s session=%s turns=%d",
+        snapshot.id,
+        session.id,
+        session.turn_count,
+    )
+    return SessionCreateResponse(session_id=session.id)
+
+
+@router.get("/transcript")
+def get_chat_transcript(
+    db: Session = Depends(get_chat_session),
+    header_session_id: str | None = Header(default=None, alias="X-Chat-Session-Id"),
+) -> dict:
+    """Return the current session's stored transcript so the live app can resume.
+
+    The session id is resolved from the X-Chat-Session-Id header (SSR forwards it
+    from the httpOnly cookie), same posture as /message and /share. Returns the
+    user/assistant turns (each assistant turn with its grounding) plus the
+    running counters, so a reload, or a freshly-forked session, rehydrates the
+    same view the server already holds. 404 (identical to /message) for a
+    missing/expired/invalid session; the browser never sends history, so this is
+    the only way to read it back.
+    """
+    session = sessions.load_active_session(db, header_session_id)
+    if session is None:
+        raise HTTPException(status_code=404, detail="Session not found")
+
+    messages = [
+        {"role": m.role, "content": m.content, "touched": list(m.touched or [])}
+        for m in sessions.get_transcript(db, session)
+        if m.role in ("user", "assistant")
+    ]
+    return {
+        "messages": messages,
+        "turn_count": session.turn_count,
+        "total_tokens": session.total_tokens,
     }

--- a/projects/monolith/chat_public/sessions.py
+++ b/projects/monolith/chat_public/sessions.py
@@ -152,6 +152,54 @@ def append_message(
     return message
 
 
+def append_messages(
+    db: Session,
+    session: ChatSession,
+    entries: list[dict],
+) -> list[ChatMessage]:
+    """Persist several transcript messages under the session in one write.
+
+    Each entry is a ``{role, content, tokens?, touched?}`` dict. Built and
+    inserted with a single ``add_all`` (never ``session.add`` in a loop, per the
+    monolith semgrep rule); the autoincrement id preserves insertion order, which
+    is the transcript order ``get_transcript`` reads back. Used to seed a forked
+    session from an immutable snapshot's frozen transcript.
+    """
+    messages = [
+        ChatMessage(
+            session_id=session.id,
+            role=entry["role"],
+            content=entry["content"],
+            tokens=entry.get("tokens", 0),
+            touched=entry.get("touched") or [],
+        )
+        for entry in entries
+    ]
+    db.add_all(messages)
+    db.commit()
+    return messages
+
+
+def set_counters(
+    db: Session,
+    session: ChatSession,
+    *,
+    turn_count: int,
+    total_tokens: int,
+) -> None:
+    """Set the per-session budget counters directly (not an increment).
+
+    Used to seed a forked session so the carried-over history counts against the
+    per-session turn/token ceilings from the first new turn (a fork inherits the
+    conversation's spend; it cannot reset the budget by re-forking).
+    """
+    session.turn_count = turn_count
+    session.total_tokens = total_tokens
+    session.last_seen_at = _utcnow()
+    db.add(session)
+    db.commit()
+
+
 def record_turn(
     db: Session,
     session: ChatSession,

--- a/projects/monolith/chat_public/snapshots.py
+++ b/projects/monolith/chat_public/snapshots.py
@@ -111,9 +111,7 @@ def fork_snapshot(
 
     if entries:
         sessions.append_messages(db, session, entries)
-    sessions.set_counters(
-        db, session, turn_count=turns, total_tokens=seeded_tokens
-    )
+    sessions.set_counters(db, session, turn_count=turns, total_tokens=seeded_tokens)
     db.refresh(session)
     return session
 

--- a/projects/monolith/chat_public/snapshots.py
+++ b/projects/monolith/chat_public/snapshots.py
@@ -55,6 +55,69 @@ def create_snapshot(db: Session, session: ChatSession) -> ChatSnapshot:
     return snapshot
 
 
+def fork_snapshot(
+    db: Session,
+    snapshot: ChatSnapshot,
+    *,
+    turnstile_outcome: str = "passed",
+    ip: str | None = None,
+    country: str | None = None,
+    user_agent: str | None = None,
+) -> ChatSession:
+    """Open a new live session seeded with a snapshot's frozen transcript.
+
+    "Fork this chat": a snapshot is read-only, so to continue it we mint a fresh
+    server-side session and copy the immutable snapshot's transcript into it as
+    the new session's server-authoritative history. The browser supplies nothing
+    but the snapshot id and a solved Turnstile token (verified in the router,
+    same admission as a fresh session); the seeded content comes only from the
+    stored snapshot, so a forged body cannot inject history.
+
+    The carried-over turns/tokens are charged to the new session's counters, so
+    the fork inherits the conversation's spend against the per-session ceilings
+    rather than resetting the budget (re-forking cannot mint unlimited turns).
+    """
+    from chat_public import limits, sessions  # local import: avoid an import cycle
+
+    session = sessions.create_session(
+        db,
+        turnstile_outcome=turnstile_outcome,
+        ip=ip,
+        country=country,
+        user_agent=user_agent,
+    )
+
+    entries: list[dict] = []
+    seeded_tokens = 0
+    turns = 0
+    for row in snapshot.transcript or []:
+        role = row.get("role")
+        if role not in _SHARABLE_ROLES:
+            continue
+        content = row.get("content") or ""
+        tokens = limits.estimate_tokens(content)
+        seeded_tokens += tokens
+        # One turn = one user message answered, so count user rows.
+        if role == "user":
+            turns += 1
+        entries.append(
+            {
+                "role": role,
+                "content": content,
+                "tokens": tokens,
+                "touched": list(row.get("touched") or []),
+            }
+        )
+
+    if entries:
+        sessions.append_messages(db, session, entries)
+    sessions.set_counters(
+        db, session, turn_count=turns, total_tokens=seeded_tokens
+    )
+    db.refresh(session)
+    return session
+
+
 def has_sharable_transcript(db: Session, session: ChatSession) -> bool:
     """True iff the session has at least one user/assistant turn to share.
 

--- a/projects/monolith/chat_public/snapshots_test.py
+++ b/projects/monolith/chat_public/snapshots_test.py
@@ -25,7 +25,7 @@ from sqlmodel.pool import StaticPool
 from app.db import get_session
 from chat_public import sessions
 from chat_public.db import get_chat_session
-from chat_public.models import ChatSession, ChatSnapshot
+from chat_public.models import ChatMessage, ChatSession, ChatSnapshot
 
 
 @pytest.fixture(name="session")
@@ -177,3 +177,163 @@ def test_get_missing_snapshot_is_404(client):
     got = client.get("/internal/chat/shared/nope-not-a-real-id")
     assert got.status_code == 404
     assert got.json()["detail"] == "Snapshot not found"
+
+
+# ── fork this chat ─────────────────────────────────────────────────────────
+# Forking a read-only snapshot mints a NEW session seeded with the snapshot's
+# frozen transcript (server-side), so the viewer can continue the conversation.
+# Turnstile stub-accepts in tests (TURNSTILE_SECRET_KEY unset), exercising the
+# admission path without a live challenge.
+
+
+def test_fork_seeds_a_new_session_from_the_snapshot(client, session):
+    row = sessions.create_session(session)
+    sessions.append_message(session, row, role="user", content="What is STPA?")
+    sessions.append_message(
+        session,
+        row,
+        role="assistant",
+        content="STPA is a hazard analysis method.",
+        touched=[{"id": "stpa", "title": "STPA"}],
+    )
+    snapshot_id = client.post(
+        "/internal/chat/share", json={"session_id": row.id}
+    ).json()["snapshot_id"]
+
+    forked = client.post("/internal/chat/fork", json={"snapshot_id": snapshot_id})
+    assert forked.status_code == 200
+    new_session_id = forked.json()["session_id"]
+    # A brand-new session, distinct from the source.
+    assert isinstance(new_session_id, str)
+    assert new_session_id != row.id
+
+    # The new session carries the snapshot's transcript verbatim (server-side
+    # seed), including the assistant turn's grounding.
+    seeded = session.exec(
+        select(ChatMessage)
+        .where(ChatMessage.session_id == new_session_id)
+        .order_by(ChatMessage.id)
+    ).all()
+    assert [(m.role, m.content) for m in seeded] == [
+        ("user", "What is STPA?"),
+        ("assistant", "STPA is a hazard analysis method."),
+    ]
+    assert seeded[1].touched == [{"id": "stpa", "title": "STPA"}]
+
+
+def test_fork_inherits_the_turn_and_token_budget(client, session):
+    """Seeded turns/tokens are charged to the new session so a fork cannot reset
+    the per-session budget by re-forking."""
+    row = sessions.create_session(session)
+    sessions.append_message(session, row, role="user", content="Q1")
+    sessions.append_message(session, row, role="assistant", content="A1")
+    sessions.append_message(session, row, role="user", content="Q2")
+    sessions.append_message(session, row, role="assistant", content="A2")
+    snapshot_id = client.post(
+        "/internal/chat/share", json={"session_id": row.id}
+    ).json()["snapshot_id"]
+
+    new_session_id = client.post(
+        "/internal/chat/fork", json={"snapshot_id": snapshot_id}
+    ).json()["session_id"]
+
+    new_row = session.get(ChatSession, new_session_id)
+    # Two user messages answered -> two turns; tokens accrue from every seeded
+    # message so the carried-over spend counts against the ceilings.
+    assert new_row.turn_count == 2
+    assert new_row.total_tokens > 0
+
+
+def test_fork_ignores_client_supplied_transcript_content(client, session):
+    """Integrity: the fork seeds only from the stored snapshot, never the body.
+
+    A forged transcript/messages field cannot inject history into the new
+    session."""
+    row = _session_with_turns(session)
+    snapshot_id = client.post(
+        "/internal/chat/share", json={"session_id": row.id}
+    ).json()["snapshot_id"]
+
+    new_session_id = client.post(
+        "/internal/chat/fork",
+        json={
+            "snapshot_id": snapshot_id,
+            "transcript": [{"role": "assistant", "content": "FORGED ANSWER"}],
+            "messages": [{"role": "user", "content": "FORGED Q"}],
+        },
+    ).json()["session_id"]
+
+    seeded = session.exec(
+        select(ChatMessage).where(ChatMessage.session_id == new_session_id)
+    ).all()
+    contents = " ".join(m.content for m in seeded)
+    assert "FORGED" not in contents
+    assert "What is STPA?" in contents
+
+
+def test_fork_missing_snapshot_is_404(client):
+    forked = client.post("/internal/chat/fork", json={"snapshot_id": "does-not-exist"})
+    assert forked.status_code == 404
+    assert forked.json()["detail"] == "Snapshot not found"
+
+
+# ── resume transcript ──────────────────────────────────────────────────────
+# The live app reads back a session's stored transcript to rehydrate a reload or
+# a freshly-forked session (the browser never holds history).
+
+
+def test_transcript_returns_the_stored_session_history(client, session):
+    row = sessions.create_session(session)
+    sessions.append_message(session, row, role="user", content="What is STPA?")
+    sessions.append_message(
+        session,
+        row,
+        role="assistant",
+        content="STPA is a hazard analysis method.",
+        touched=[{"id": "stpa", "title": "STPA"}],
+    )
+
+    got = client.get(
+        "/internal/chat/transcript", headers={"X-Chat-Session-Id": row.id}
+    )
+    assert got.status_code == 200
+    body = got.json()
+    assert body["messages"] == [
+        {"role": "user", "content": "What is STPA?", "touched": []},
+        {
+            "role": "assistant",
+            "content": "STPA is a hazard analysis method.",
+            "touched": [{"id": "stpa", "title": "STPA"}],
+        },
+    ]
+    assert body["turn_count"] == 0  # counters move on record_turn, not append
+    assert "total_tokens" in body
+
+
+def test_transcript_missing_session_is_404(client):
+    got = client.get(
+        "/internal/chat/transcript", headers={"X-Chat-Session-Id": "does-not-exist"}
+    )
+    assert got.status_code == 404
+    assert got.json()["detail"] == "Session not found"
+
+
+def test_fork_then_transcript_round_trips_the_seeded_history(client, session):
+    """End to end: share -> fork -> the new session's transcript reads back the
+    same turns, which is exactly what the live app rehydrates."""
+    row = _session_with_turns(session)
+    snapshot_id = client.post(
+        "/internal/chat/share", json={"session_id": row.id}
+    ).json()["snapshot_id"]
+    new_session_id = client.post(
+        "/internal/chat/fork", json={"snapshot_id": snapshot_id}
+    ).json()["session_id"]
+
+    body = client.get(
+        "/internal/chat/transcript",
+        headers={"X-Chat-Session-Id": new_session_id},
+    ).json()
+    assert [(m["role"], m["content"]) for m in body["messages"]] == [
+        ("user", "What is STPA?"),
+        ("assistant", "STPA is a hazard analysis method."),
+    ]

--- a/projects/monolith/chat_public/snapshots_test.py
+++ b/projects/monolith/chat_public/snapshots_test.py
@@ -293,9 +293,7 @@ def test_transcript_returns_the_stored_session_history(client, session):
         touched=[{"id": "stpa", "title": "STPA"}],
     )
 
-    got = client.get(
-        "/internal/chat/transcript", headers={"X-Chat-Session-Id": row.id}
-    )
+    got = client.get("/internal/chat/transcript", headers={"X-Chat-Session-Id": row.id})
     assert got.status_code == 200
     body = got.json()
     assert body["messages"] == [

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.197.4
+      targetRevision: 0.198.0
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/hooks.js
+++ b/projects/monolith/frontend/src/hooks.js
@@ -37,6 +37,7 @@ const CHAT_PREFIX_MAP = {
   "/chat/session": "/public/chat/session",
   "/chat/message": "/public/chat/message",
   "/chat/share": "/public/chat/share",
+  "/chat/fork": "/public/chat/fork",
 };
 
 /** @type {import('@sveltejs/kit').Reroute} */

--- a/projects/monolith/frontend/src/hooks.test.js
+++ b/projects/monolith/frontend/src/hooks.test.js
@@ -63,6 +63,9 @@ describe("reroute", () => {
     expect(reroute({ url: url("jomcgi.dev", "/chat/share") })).toBe(
       "/public/chat/share",
     );
+    expect(reroute({ url: url("jomcgi.dev", "/chat/fork") })).toBe(
+      "/public/chat/fork",
+    );
     // Host-independent: the same browser path resolves under /public on the
     // public subdomain too.
     expect(reroute({ url: url("public.jomcgi.dev", "/chat/share") })).toBe(

--- a/projects/monolith/frontend/src/lib/public/chat/admission.js
+++ b/projects/monolith/frontend/src/lib/public/chat/admission.js
@@ -9,6 +9,9 @@
 
 // Same-origin SSR proxy path (the reroute hook maps it to /public/chat/session).
 const SESSION_PROXY_PATH = "/chat/session";
+// Same-origin SSR proxy path for forking a shared snapshot into a live session
+// (the reroute hook maps it to /public/chat/fork).
+const FORK_PROXY_PATH = "/chat/fork";
 
 /**
  * Exchange a solved Turnstile token for a server-side session.
@@ -25,6 +28,36 @@ export async function createChatSession(turnstileToken, fetchImpl = fetch) {
     method: "POST",
     headers: { "content-type": "application/json" },
     body: JSON.stringify({ turnstile_token: turnstileToken }),
+  });
+  return { ok: resp.ok, status: resp.status };
+}
+
+/**
+ * Fork a read-only shared snapshot into a new, continuable session.
+ *
+ * Same admission as {@link createChatSession} (a solved Turnstile token), plus
+ * the snapshot id to seed the new session's history. On success the SSR proxy
+ * sets the httpOnly `cps` cookie; the caller then navigates to the live app,
+ * which rehydrates the seeded transcript. The snapshot content is seeded
+ * server-side, never from the browser.
+ *
+ * @param {string} snapshotId The shared snapshot to continue.
+ * @param {string} turnstileToken The token the Turnstile widget produced.
+ * @param {typeof fetch} [fetchImpl] Injectable fetch (defaults to global fetch).
+ * @returns {Promise<{ ok: boolean, status: number }>}
+ */
+export async function forkChatSession(
+  snapshotId,
+  turnstileToken,
+  fetchImpl = fetch,
+) {
+  const resp = await fetchImpl(FORK_PROXY_PATH, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      snapshot_id: snapshotId,
+      turnstile_token: turnstileToken,
+    }),
   });
   return { ok: resp.ok, status: resp.status };
 }

--- a/projects/monolith/frontend/src/lib/public/chat/admission.test.js
+++ b/projects/monolith/frontend/src/lib/public/chat/admission.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { createChatSession } from "./admission.js";
+import { createChatSession, forkChatSession } from "./admission.js";
 
 describe("createChatSession", () => {
   it("POSTs the turnstile token to the same-origin session proxy", async () => {
@@ -21,5 +21,31 @@ describe("createChatSession", () => {
     const result = await createChatSession("bad-token", fetchImpl);
 
     expect(result).toEqual({ ok: false, status: 403 });
+  });
+});
+
+describe("forkChatSession", () => {
+  it("POSTs the snapshot id and turnstile token to the same-origin fork proxy", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+
+    const result = await forkChatSession("snap-123", "tok-abc", fetchImpl);
+
+    expect(result).toEqual({ ok: true, status: 200 });
+    const [url, init] = fetchImpl.mock.calls[0];
+    // Same-origin SSR proxy, not the internal chat API directly.
+    expect(url).toBe("/chat/fork");
+    expect(init.method).toBe("POST");
+    expect(JSON.parse(init.body)).toEqual({
+      snapshot_id: "snap-123",
+      turnstile_token: "tok-abc",
+    });
+  });
+
+  it("relays a rejected fork as ok:false with the upstream status", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({ ok: false, status: 404 });
+
+    const result = await forkChatSession("missing", "tok", fetchImpl);
+
+    expect(result).toEqual({ ok: false, status: 404 });
   });
 });

--- a/projects/monolith/frontend/src/lib/public/components/TurnstileGate.svelte
+++ b/projects/monolith/frontend/src/lib/public/components/TurnstileGate.svelte
@@ -13,15 +13,22 @@
    * https://challenges.cloudflare.com. The app sets no Content-Security-Policy
    * (a CSP hardening layer is deferred to a later pass).
    *
+   * `admit` is the token-exchange seam: it takes the solved Turnstile token and
+   * resolves to `{ ok }`. It defaults to `createChatSession` (open a fresh
+   * session); the shared-snapshot "fork this chat" flow passes a variant that
+   * forks the snapshot instead. Keeping it a prop lets one gate serve both
+   * admission paths without duplicating the widget lifecycle.
+   *
    * @type {{
    *   siteKey: string,
    *   onAdmitted?: () => void,
+   *   admit?: (token: string) => Promise<{ ok: boolean }>,
    * }}
    */
-  let { siteKey, onAdmitted } = $props();
-
   import { onMount } from "svelte";
   import { createChatSession } from "$lib/public/chat/admission.js";
+
+  let { siteKey, onAdmitted, admit = createChatSession } = $props();
 
   const SCRIPT_SRC = "https://challenges.cloudflare.com/turnstile/v0/api.js";
 
@@ -40,7 +47,7 @@
   async function onSolve(token) {
     status = "verifying";
     try {
-      const { ok } = await createChatSession(token);
+      const { ok } = await admit(token);
       if (ok) {
         status = "ready";
         onAdmitted?.();

--- a/projects/monolith/frontend/src/routes/public/app/notes/+page.server.js
+++ b/projects/monolith/frontend/src/routes/public/app/notes/+page.server.js
@@ -7,7 +7,38 @@
 // switches to the graph view, so the initial chat load stays light.
 const TURNSTILE_SITE_KEY = process.env.TURNSTILE_SITE_KEY || "";
 
-export async function load({ fetch }) {
+// The internal chat API base (server-side only; the browser never reaches it).
+// Same seam the snapshot loader uses to read a shared transcript.
+const CHAT_API_BASE = process.env.CHAT_API_BASE || "http://localhost:8000";
+// Opaque httpOnly session cookie set by /chat/session and /chat/fork.
+const SESSION_COOKIE = "cps";
+
+// Rehydrate an existing session's transcript so a reload, or a freshly-forked
+// session, lands the visitor straight back in their conversation instead of the
+// admission gate. Returns { admitted, messages, tokens }: admitted only when the
+// backend confirms a live session (a stale/expired cookie 404s and falls back to
+// the gate). Fail-soft: any upstream hiccup leaves the visitor at the gate.
+async function loadSession(fetch, cookies) {
+  const sessionId = cookies?.get?.(SESSION_COOKIE);
+  if (!sessionId) return { admitted: false, messages: [], tokens: 0 };
+  try {
+    const res = await fetch(`${CHAT_API_BASE}/internal/chat/transcript`, {
+      headers: { "X-Chat-Session-Id": sessionId },
+      signal: AbortSignal.timeout(5_000),
+    });
+    if (!res.ok) return { admitted: false, messages: [], tokens: 0 };
+    const body = await res.json();
+    return {
+      admitted: true,
+      messages: Array.isArray(body.messages) ? body.messages : [],
+      tokens: typeof body.total_tokens === "number" ? body.total_tokens : 0,
+    };
+  } catch {
+    return { admitted: false, messages: [], tokens: 0 };
+  }
+}
+
+export async function load({ fetch, cookies }) {
   // Seed the live ticker's GPU readout with the cluster stats snapshot (the
   // same payload the homepage renders), via the same-origin proxy. The page
   // then polls it client-side. Fail-soft: the ticker falls back to its static
@@ -20,5 +51,15 @@ export async function load({ fetch }) {
     // leave stats null; the ticker degrades gracefully
   }
 
-  return { turnstileSiteKey: TURNSTILE_SITE_KEY, stats };
+  // Rehydrate an existing session (a reload, or a just-completed fork) so the
+  // visitor resumes their conversation rather than re-passing the gate.
+  const session = await loadSession(fetch, cookies);
+
+  return {
+    turnstileSiteKey: TURNSTILE_SITE_KEY,
+    stats,
+    admitted: session.admitted,
+    initialMessages: session.messages,
+    initialTokens: session.tokens,
+  };
 }

--- a/projects/monolith/frontend/src/routes/public/app/notes/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/notes/+page.svelte
@@ -101,11 +101,15 @@
   });
 
   // ── admission / session ──────────────────────────────────────────
-  let admitted = $state(false);
+  // Seeded from the server loader: a live session (a reload, or a chat just
+  // forked from a shared snapshot) hydrates as already-admitted with its stored
+  // transcript, so the visitor resumes rather than re-passing the gate. A
+  // cookieless visit hydrates as { admitted: false, [] } and shows the gate.
+  let admitted = $state(data.admitted ?? false);
 
   // ── transcript ───────────────────────────────────────────────────
   // Committed turns. Each: { role: "user" | "assistant", content, touched? }.
-  let messages = $state([]);
+  let messages = $state(data.initialMessages ?? []);
   let input = $state("");
   let sending = $state(false);
   // The in-flight assistant turn (token stream + per-turn touched set).
@@ -119,8 +123,21 @@
 
   // ── grounding ────────────────────────────────────────────────────
   // The cumulative set of public notes the whole conversation has touched,
-  // deduped by id and in first-seen order. Drives the graph highlight.
-  let touchedMap = $state(new Map());
+  // deduped by id and in first-seen order. Drives the graph highlight. Seeded
+  // from a hydrated transcript so a resumed/forked session's graph view lights
+  // up the notes the carried-over turns grounded on.
+  function seedTouched(msgs) {
+    const map = new Map();
+    for (const msg of msgs ?? []) {
+      for (const n of msg.touched ?? []) {
+        const id = n?.id;
+        if (id === undefined || id === null || map.has(id)) continue;
+        map.set(id, { id, title: n.title ?? "" });
+      }
+    }
+    return map;
+  }
+  let touchedMap = $state(seedTouched(data.initialMessages));
   let touched = $derived([...touchedMap.values()]);
 
   // ── live ticker readouts ─────────────────────────────────────────
@@ -146,7 +163,7 @@
   // public graph node count.
   const PUBLIC_NOTE_COUNT = 4636;
 
-  let sessionTokens = $state(0); // running CTX total for this session
+  let sessionTokens = $state(data.initialTokens ?? 0); // running CTX total
   let tokPerSec = $state(0); // last computed decode rate
   let turnStart = 0; // performance.now() at turn start (plain, non-reactive)
 

--- a/projects/monolith/frontend/src/routes/public/app/notes/page.server.test.js
+++ b/projects/monolith/frontend/src/routes/public/app/notes/page.server.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterEach } from "vitest";
+import { describe, it, expect, afterEach, vi } from "vitest";
 import { load } from "./+page.server.js";
 
 describe("/public/app/notes load", () => {
@@ -28,5 +28,64 @@ describe("/public/app/notes load", () => {
     const result = await load({ fetch });
     expect(result).toHaveProperty("turnstileSiteKey");
     expect(result.stats).toBeNull();
+  });
+
+  it("hydrates as not-admitted with no transcript when there is no session cookie", async () => {
+    // A cookieless visitor lands at the admission gate: the transcript endpoint
+    // is never called, so the only fetch is the stats snapshot.
+    const fetch = vi.fn(async (url) => {
+      expect(url).toBe("/app/notes/stats");
+      return { ok: true, json: async () => ({}) };
+    });
+    const cookies = { get: () => undefined };
+    const result = await load({ fetch, cookies });
+    expect(result.admitted).toBe(false);
+    expect(result.initialMessages).toEqual([]);
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("rehydrates the stored transcript when a live session cookie is present", async () => {
+    // A reload or a freshly-forked session resumes: the loader reads the cps
+    // cookie, fetches the stored transcript, and hydrates admitted + messages.
+    const messages = [
+      { role: "user", content: "What is STPA?", touched: [] },
+      {
+        role: "assistant",
+        content: "STPA is a hazard analysis method.",
+        touched: [{ id: "stpa", title: "STPA" }],
+      },
+    ];
+    const fetch = vi.fn(async (url, init) => {
+      if (url === "/app/notes/stats") {
+        return { ok: true, json: async () => ({}) };
+      }
+      // The transcript fetch forwards the session id from the cookie as a header.
+      expect(url).toMatch(/\/internal\/chat\/transcript$/);
+      expect(init.headers["X-Chat-Session-Id"]).toBe("sid-123");
+      return {
+        ok: true,
+        json: async () => ({ messages, total_tokens: 42 }),
+      };
+    });
+    const cookies = { get: () => "sid-123" };
+    const result = await load({ fetch, cookies });
+    expect(result.admitted).toBe(true);
+    expect(result.initialMessages).toEqual(messages);
+    expect(result.initialTokens).toBe(42);
+  });
+
+  it("falls back to the gate when the session cookie is stale (transcript 404)", async () => {
+    // An expired/invalid cookie 404s on the transcript: hydrate as not-admitted
+    // so the visitor re-passes the gate rather than seeing an empty session.
+    const fetch = vi.fn(async (url) => {
+      if (url === "/app/notes/stats") {
+        return { ok: true, json: async () => ({}) };
+      }
+      return { ok: false, status: 404 };
+    });
+    const cookies = { get: () => "stale-sid" };
+    const result = await load({ fetch, cookies });
+    expect(result.admitted).toBe(false);
+    expect(result.initialMessages).toEqual([]);
   });
 });

--- a/projects/monolith/frontend/src/routes/public/app/notes/s/[id]/+page.server.js
+++ b/projects/monolith/frontend/src/routes/public/app/notes/s/[id]/+page.server.js
@@ -6,6 +6,12 @@ import { error } from "@sveltejs/kit";
 // never talks to the internal chat API: SSR fetches the snapshot here.
 const CHAT_API_BASE = process.env.CHAT_API_BASE || "http://localhost:8000";
 
+// The public Turnstile site key gates "fork this chat" (a fork mints a new live
+// session, same admission as starting a fresh chat). Public by design (it
+// identifies the widget, not a credential); the Turnstile secret never enters
+// SSR. Empty when unset, which disables the fork affordance gracefully.
+const TURNSTILE_SITE_KEY = process.env.TURNSTILE_SITE_KEY || "";
+
 export async function load({ params, fetch }) {
   let resp;
   try {
@@ -34,5 +40,6 @@ export async function load({ params, fetch }) {
     messages: Object.freeze(
       Array.isArray(snapshot.messages) ? snapshot.messages : [],
     ),
+    turnstileSiteKey: TURNSTILE_SITE_KEY,
   };
 }

--- a/projects/monolith/frontend/src/routes/public/app/notes/s/[id]/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/notes/s/[id]/+page.svelte
@@ -7,7 +7,10 @@
   // (HTML-escapes &<> on every path, emits no raw HTML, no links, no
   // javascript:/data: URLs), and rendered with the same user-bubble / bot-turn
   // look as the live app.
+  import { goto } from "$app/navigation";
   import { renderMarkdown } from "$lib/components/notes/markdown.js";
+  import TurnstileGate from "$lib/public/components/TurnstileGate.svelte";
+  import { forkChatSession } from "$lib/public/chat/admission.js";
 
   let { data } = $props();
 
@@ -16,6 +19,28 @@
   function renderReply(text) {
     // Empty title map: [[wikilinks]] render as inert text (no graph nav here).
     return renderMarkdown(text ?? "", new Map());
+  }
+
+  // ── fork this chat ───────────────────────────────────────────────
+  // A snapshot is read-only, but a visitor can FORK it: solving a Turnstile
+  // challenge mints a new live session seeded with this snapshot's transcript
+  // (server-side), then we land them on the live app to keep chatting. The
+  // challenge is the same admission gate as starting a fresh chat (a fork is a
+  // new inference-backed session). Only offered when a site key is configured
+  // and there is a transcript to continue.
+  const canFork = $derived(
+    Boolean(data.turnstileSiteKey) && data.messages.length > 0,
+  );
+  let forking = $state(false); // gate revealed?
+
+  function startFork() {
+    forking = true;
+  }
+
+  function onForked() {
+    // The fork set the httpOnly session cookie; the live app's loader reads it
+    // and rehydrates the seeded transcript. Navigate there to continue.
+    goto("/app/notes");
   }
 </script>
 
@@ -48,6 +73,11 @@
       <span class="panel-tag">SHARED CHAT</span>
       <span class="panel-readonly">READ-ONLY</span>
       <span class="panel-spacer"></span>
+      {#if canFork && !forking}
+        <button type="button" class="bar-btn bar-btn-primary" onclick={startFork}>
+          CONTINUE THIS CHAT
+        </button>
+      {/if}
       <a class="bar-btn" href="/public/app/notes">START YOUR OWN CHAT</a>
     </div>
 
@@ -80,6 +110,22 @@
         {/each}
       {/if}
     </div>
+
+    {#if forking}
+      <div class="fork-panel">
+        <p class="fork-eyebrow">CONTINUE THIS CHAT</p>
+        <p class="fork-copy">
+          Solve the challenge to pick up this conversation in a fresh session.
+          The transcript above is carried over and you can keep asking from
+          there. No sign-in, no tracking beyond what keeps the bots out.
+        </p>
+        <TurnstileGate
+          siteKey={data.turnstileSiteKey}
+          admit={(token) => forkChatSession(data.snapshotId, token)}
+          onAdmitted={onForked}
+        />
+      </div>
+    {/if}
 
     <div class="share-foot">
       <p class="share-foot-copy">
@@ -192,6 +238,35 @@
     background: var(--accent);
     transform: translate(-1px, -1px);
     box-shadow: var(--shadow-hard-sm);
+  }
+  /* The primary "continue this chat" action: filled blue so it reads as the
+     main affordance next to the neutral "start your own chat" link. */
+  .bar-btn-primary {
+    background: var(--blue);
+  }
+
+  /* The fork gate panel: revealed under the transcript when a visitor opts to
+     continue. The same neo-brutalist framing as the rest of the share view. */
+  .fork-panel {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    padding: 18px 24px;
+    border-top: 2.5px solid var(--ink);
+    background: var(--paper);
+  }
+  .fork-eyebrow {
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0.16em;
+    margin: 0;
+  }
+  .fork-copy {
+    font-size: 13px;
+    line-height: 1.6;
+    color: var(--ink-2, #6b6b6b);
+    max-width: 60ch;
+    margin: 0;
   }
 
   .chat-transcript {

--- a/projects/monolith/frontend/src/routes/public/chat/fork/+server.js
+++ b/projects/monolith/frontend/src/routes/public/chat/fork/+server.js
@@ -1,0 +1,81 @@
+import { json } from "@sveltejs/kit";
+
+// Server-only BFF for "fork this chat" (ADR 005 follow-up). A shared snapshot is
+// read-only; forking it mints a NEW server-side session seeded with the
+// snapshot's frozen transcript so the visitor can continue it. The browser POSTs
+// here same-origin (jomcgi.dev/chat/fork, rerouted to /public/chat/fork) with a
+// solved Turnstile token + the snapshot id; this handler forwards them to the
+// internal chat API, which verifies the challenge (the Turnstile secret lives in
+// the backend, never SSR) and seeds the new session SERVER-SIDE from the stored
+// snapshot. On success the opaque session id lands in the httpOnly cookie, never
+// the body, exactly like /chat/session. The browser never talks to the internal
+// chat API directly.
+const CHAT_API_BASE = process.env.CHAT_API_BASE || "http://localhost:8000";
+
+// Opaque, httpOnly session cookie (same carrier as /chat/session): the value is
+// the backend's opaque session id; the row, not the cookie, is the budget
+// authority.
+const SESSION_COOKIE = "cps";
+// Mirrors CHAT_PUBLIC_SESSION_TTL_SECONDS (chart values, default 1800s).
+const SESSION_COOKIE_MAX_AGE = 1800;
+
+export async function POST({ request, cookies }) {
+  // The snapshot id to fork and the solved Turnstile token. A missing/invalid
+  // body falls through with nulls: the backend rejects an absent token as a
+  // failed challenge (in production) and an unknown snapshot as a 404.
+  let snapshotId = null;
+  let turnstileToken = null;
+  try {
+    const body = await request.json();
+    if (body && typeof body.snapshot_id === "string") {
+      snapshotId = body.snapshot_id;
+    }
+    if (body && typeof body.turnstile_token === "string") {
+      turnstileToken = body.turnstile_token;
+    }
+  } catch {
+    // Empty/malformed body: forwarded as nulls; the backend fails the challenge.
+  }
+
+  // Forward coarse geo + user-agent for the new session's pseudonymous row, plus
+  // the real client IP from Cloudflare's CF-Connecting-IP header (salted-hashed
+  // by the backend for reactive abuse forensics). The backend trusts
+  // CF-Connecting-IP only on connections bearing SSR's Linkerd identity, so a
+  // direct caller cannot spoof it.
+  const headers = { "content-type": "application/json" };
+  const country = request.headers.get("cf-ipcountry");
+  if (country) headers["CF-IPCountry"] = country;
+  const userAgent = request.headers.get("user-agent");
+  if (userAgent) headers["User-Agent"] = userAgent;
+  const connectingIp = request.headers.get("cf-connecting-ip");
+  if (connectingIp) headers["CF-Connecting-IP"] = connectingIp;
+
+  const resp = await fetch(`${CHAT_API_BASE}/internal/chat/fork`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({
+      snapshot_id: snapshotId,
+      turnstile_token: turnstileToken,
+    }),
+    signal: AbortSignal.timeout(10_000),
+  });
+
+  if (!resp.ok) {
+    // Backend errors: 403 (failed challenge), 404 (unknown snapshot). Relay the
+    // status; no session cookie is set.
+    return json({ ok: false }, { status: resp.status });
+  }
+
+  const { session_id: sessionId } = await resp.json();
+  cookies.set(SESSION_COOKIE, sessionId, {
+    httpOnly: true,
+    secure: true,
+    sameSite: "lax",
+    path: "/",
+    maxAge: SESSION_COOKIE_MAX_AGE,
+  });
+
+  // The session id stays server-side; the cookie is the carrier. The client now
+  // navigates to the live app, which rehydrates the seeded transcript.
+  return json({ ok: true });
+}

--- a/projects/monolith/frontend/src/routes/public/chat/fork/server.test.js
+++ b/projects/monolith/frontend/src/routes/public/chat/fork/server.test.js
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { POST } from "./+server.js";
+
+function makeHeaders(map = {}) {
+  const lower = Object.fromEntries(
+    Object.entries(map).map(([k, v]) => [k.toLowerCase(), v]),
+  );
+  return { get: (name) => lower[name.toLowerCase()] ?? null };
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("/public/chat/fork POST", () => {
+  it("forks a snapshot into a session, setting the opaque cps cookie httpOnly", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ session_id: "forked-session-id-123" }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const cookies = { set: vi.fn() };
+    const request = {
+      json: async () => ({
+        snapshot_id: "snap-abc",
+        turnstile_token: "tok-xyz",
+      }),
+      headers: makeHeaders(),
+    };
+
+    const resp = await POST({ request, cookies });
+
+    // The internal API is forked with the snapshot id + the solved token.
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toMatch(/\/internal\/chat\/fork$/);
+    expect(JSON.parse(init.body)).toEqual({
+      snapshot_id: "snap-abc",
+      turnstile_token: "tok-xyz",
+    });
+
+    // The new session id lands in the httpOnly cookie, not the response body.
+    expect(cookies.set).toHaveBeenCalledTimes(1);
+    const [name, value, opts] = cookies.set.mock.calls[0];
+    expect(name).toBe("cps");
+    expect(value).toBe("forked-session-id-123");
+    expect(opts).toMatchObject({
+      httpOnly: true,
+      secure: true,
+      sameSite: "lax",
+      path: "/",
+    });
+
+    const body = await resp.json();
+    expect(body).toEqual({ ok: true });
+    expect(JSON.stringify(body)).not.toContain("forked-session-id-123");
+  });
+
+  it("forwards coarse geo + client IP for the new session's pseudonymous row", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ session_id: "sid" }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const cookies = { set: vi.fn() };
+    const request = {
+      json: async () => ({ snapshot_id: "snap", turnstile_token: "tok" }),
+      headers: makeHeaders({
+        "cf-ipcountry": "GB",
+        "user-agent": "UA/1",
+        "cf-connecting-ip": "203.0.113.7",
+      }),
+    };
+
+    await POST({ request, cookies });
+
+    const [, init] = fetchMock.mock.calls[0];
+    expect(init.headers["CF-IPCountry"]).toBe("GB");
+    expect(init.headers["User-Agent"]).toBe("UA/1");
+    expect(init.headers["CF-Connecting-IP"]).toBe("203.0.113.7");
+  });
+
+  it("relays the upstream status and sets no cookie when the fork is rejected", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValue({ ok: false, status: 404, json: async () => ({}) }),
+    );
+    const cookies = { set: vi.fn() };
+    const request = {
+      json: async () => ({ snapshot_id: "missing", turnstile_token: "tok" }),
+      headers: makeHeaders(),
+    };
+
+    const resp = await POST({ request, cookies });
+    expect(resp.status).toBe(404);
+    expect(cookies.set).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## What

A shared-chat snapshot (`/app/notes/s/<id>`) is read-only. This adds a **"continue this chat"** affordance so a viewer can **fork** the snapshot into a new live session and keep talking, instead of only being able to start a blank chat.

## How it works

The chat is server-authoritative (the browser never holds history), so forking means **minting a new session seeded with the snapshot's frozen transcript** server-side, then landing the viewer on the live app, which rehydrates that transcript.

### Decisions (per request)
- **Redirect to live chat** — fork seeds a new session and opens `/app/notes` with the history loaded. As a bonus, the live page is now **resumable**: a reload re-hydrates an existing session from its cookie.
- **Turnstile-gated** — a fork mints a new inference-backed session, so it carries the same admission challenge as starting a fresh chat.
- **Inherit seeded turns** — the carried-over turns/tokens are charged to the new session, so a fork inherits the conversation's budget and cannot reset the per-session ceiling by re-forking.

## Changes

**Backend (`chat_public`)**
- `POST /internal/chat/fork` — verifies Turnstile, reads the immutable snapshot (reader replica), seeds its transcript into a new session (writer primary). No client-supplied content is ever seeded (same integrity posture as `/share`).
- `GET /internal/chat/transcript` — reads a session's stored transcript back (resolved from `X-Chat-Session-Id`) so the live app can rehydrate.
- `sessions.append_messages` (bulk `add_all`, not `session.add` in a loop) + `sessions.set_counters` back the seed.

**Frontend**
- `/chat/fork` SSR proxy mirrors `/chat/session`: forwards the solved token + coarse geo / client IP, sets the opaque httpOnly `cps` cookie, never echoes the session id.
- `TurnstileGate` gains an `admit` prop so one gate serves both fresh-session and fork admission; the snapshot page reveals it on **CONTINUE THIS CHAT**.
- The notes loader rehydrates an existing session from the `cps` cookie (fail-soft to the gate on a stale cookie); the live page seeds its transcript, grounding set, and CTX readout from it. After a fork the snapshot page navigates to the live app and resumes.

## Tests
- Backend: fork seeds the transcript + grounding, inherits the turn/token budget, ignores forged body content, 404s an unknown snapshot; transcript round-trips (incl. share → fork → transcript end to end).
- Frontend: `forkChatSession` proxy call, `/chat/fork` SSR proxy (cookie set / geo forwarded / rejection relayed), reroute mapping, and notes-loader hydration (cookieless → gate, live cookie → resume, stale cookie → gate).

## Notes
- No DB migration: forking reuses the existing `sessions`/`messages` tables.
- The snapshot page is not in the visual-regression target set, and the live `/app/notes` cookieless render is unchanged, so no baseline reseed is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0143Sk7qqEzJPjfAwcpNcHV4)_