### PR TITLE
feat(monolith): leader-elect in-process singletons via Postgres heartbeat

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.42.0
+version: 0.43.0
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.42.0
+      targetRevision: 0.43.0
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -906,6 +906,17 @@ py_test(
 )
 
 py_test(
+    name = "leadership_test",
+    srcs = ["app/leadership_test.py"],
+    imports = ["."],
+    deps = [
+        ":monolith_backend",
+        "@pip//pytest",
+        "@pip//pytest_asyncio",
+    ],
+)
+
+py_test(
     name = "chat_agent_extra_test",
     srcs = ["chat/agent_extra_test.py"],
     imports = ["."],

--- a/projects/monolith/app/leadership.py
+++ b/projects/monolith/app/leadership.py
@@ -1,0 +1,122 @@
+"""Postgres heartbeat leader election for the monolith's in-process singletons.
+
+Only one replica should run the background singletons (Discord bot, AIS ingest,
+scheduler loop) at a time, so the web tier can scale horizontally without N
+duplicate bots/streams. A single lease row in ``scheduler.leader_lease`` is
+renewed by the leader every ``RENEW_INTERVAL`` seconds; any replica may steal it
+once ``heartbeat_at`` is older than ``LEASE_TTL`` (i.e. ~LEASE_TTL of missed
+heartbeats). It is one atomic upsert per replica per interval, so the load on
+Postgres is negligible.
+
+Fail-safe: any error resolving leadership is treated as "not leader", so a
+partitioned or DB-starved replica relinquishes its singletons rather than risk
+two leaders running two Discord bots.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import platform
+from collections.abc import Awaitable, Callable
+
+from sqlmodel import Session, text
+
+from app.db import get_engine
+
+logger = logging.getLogger("monolith.leadership")
+
+LEASE_KEY = "singletons"
+RENEW_INTERVAL = 2.0  # seconds between heartbeats
+LEASE_TTL = 5.0  # seconds of missed heartbeats before the lease can be stolen
+
+# platform.node() is the pod name under Kubernetes (matches scheduler._HOSTNAME).
+HOLDER_ID = platform.node()
+
+# Acquire, renew, or steal-if-stale in one atomic statement. The ON CONFLICT
+# UPDATE only fires when we already hold the lease (renew) or the current holder
+# has gone stale (steal); otherwise zero rows change and RETURNING is empty, so
+# we are a follower. The row lock on the conflicting key serialises racing
+# replicas, so exactly one wins a contested steal.
+_ACQUIRE_SQL = """
+    INSERT INTO scheduler.leader_lease (lease_key, holder, heartbeat_at)
+    VALUES (:key, :holder, now())
+    ON CONFLICT (lease_key) DO UPDATE
+        SET holder = excluded.holder, heartbeat_at = now()
+    WHERE scheduler.leader_lease.holder = :holder
+       OR scheduler.leader_lease.heartbeat_at < now() - make_interval(secs => :ttl)
+    RETURNING holder
+"""
+
+_RELEASE_SQL = (
+    "DELETE FROM scheduler.leader_lease WHERE lease_key = :key AND holder = :holder"
+)
+
+
+def _acquire_or_renew() -> bool:
+    """Atomically acquire/renew/steal the lease. True if this replica holds it."""
+    with Session(get_engine()) as session:
+        row = session.execute(
+            text(_ACQUIRE_SQL),
+            {"key": LEASE_KEY, "holder": HOLDER_ID, "ttl": LEASE_TTL},
+        ).fetchone()
+        session.commit()
+    return row is not None and row[0] == HOLDER_ID
+
+
+def _release() -> None:
+    """Drop our lease on graceful shutdown so failover is immediate, not TTL-bound."""
+    with Session(get_engine()) as session:
+        session.execute(text(_RELEASE_SQL), {"key": LEASE_KEY, "holder": HOLDER_ID})
+        session.commit()
+
+
+class LeaderElector:
+    """Drives leadership transitions, invoking callbacks on acquire/resign."""
+
+    def __init__(self) -> None:
+        self._is_leader = False
+
+    @property
+    def is_leader(self) -> bool:
+        return self._is_leader
+
+    async def run(
+        self,
+        on_acquire: Callable[[], Awaitable[None]],
+        on_resign: Callable[[], Awaitable[None]],
+    ) -> None:
+        """Loop forever, firing on_acquire/on_resign as leadership changes.
+
+        Runs on every replica; only the one holding the lease invokes on_acquire.
+        Cancel the task to stop (the lease is released if held).
+        """
+        logger.info("leader election started as %s", HOLDER_ID)
+        try:
+            while True:
+                try:
+                    leader = await asyncio.to_thread(_acquire_or_renew)
+                except Exception:
+                    logger.exception("leader lease check failed; treating as follower")
+                    leader = False
+
+                if leader and not self._is_leader:
+                    self._is_leader = True
+                    logger.info("became leader (%s)", HOLDER_ID)
+                    await on_acquire()
+                elif not leader and self._is_leader:
+                    self._is_leader = False
+                    logger.warning(
+                        "lost leadership (%s); stopping singletons", HOLDER_ID
+                    )
+                    await on_resign()
+
+                await asyncio.sleep(RENEW_INTERVAL)
+        except asyncio.CancelledError:
+            if self._is_leader:
+                try:
+                    await asyncio.to_thread(_release)
+                    logger.info("released leader lease on shutdown")
+                except Exception:
+                    logger.exception("leader lease release failed")
+            raise

--- a/projects/monolith/app/leadership_test.py
+++ b/projects/monolith/app/leadership_test.py
@@ -1,0 +1,89 @@
+"""Unit tests for the leader-election state machine (app.leadership).
+
+The lease query is Postgres-specific (ON CONFLICT ... WHERE, make_interval), so
+it is mocked here; these tests exercise the transition logic - acquire/resign
+callbacks, no double-firing, fail-safe to follower, and lease release on
+shutdown - not the SQL itself.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest import mock
+
+import pytest
+
+import app.leadership as leadership
+
+
+def _seq(values):
+    """A fake _acquire_or_renew that yields `values` then stays a follower."""
+    it = iter(values)
+
+    def f():
+        try:
+            return next(it)
+        except StopIteration:
+            return False
+
+    return f
+
+
+@pytest.mark.asyncio
+async def test_acquire_then_resign_fire_once(monkeypatch):
+    # leader, leader (stay), follower -> acquire once, resign once.
+    monkeypatch.setattr(leadership, "_acquire_or_renew", _seq([True, True, False]))
+    monkeypatch.setattr(leadership, "RENEW_INTERVAL", 0)
+    on_acquire = mock.AsyncMock()
+    on_resign = mock.AsyncMock()
+    elector = leadership.LeaderElector()
+
+    task = asyncio.create_task(elector.run(on_acquire, on_resign))
+    await asyncio.sleep(0.05)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    on_acquire.assert_awaited_once()
+    on_resign.assert_awaited_once()
+    assert elector.is_leader is False
+
+
+@pytest.mark.asyncio
+async def test_db_error_is_follower(monkeypatch):
+    def boom():
+        raise RuntimeError("db down")
+
+    monkeypatch.setattr(leadership, "_acquire_or_renew", boom)
+    monkeypatch.setattr(leadership, "RENEW_INTERVAL", 0)
+    on_acquire = mock.AsyncMock()
+    on_resign = mock.AsyncMock()
+    elector = leadership.LeaderElector()
+
+    task = asyncio.create_task(elector.run(on_acquire, on_resign))
+    await asyncio.sleep(0.03)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    # Fail-safe: never became leader, so singletons never started.
+    on_acquire.assert_not_awaited()
+    assert elector.is_leader is False
+
+
+@pytest.mark.asyncio
+async def test_releases_lease_on_cancel_when_leader(monkeypatch):
+    monkeypatch.setattr(leadership, "_acquire_or_renew", lambda: True)
+    monkeypatch.setattr(leadership, "RENEW_INTERVAL", 0)
+    released = mock.Mock()
+    monkeypatch.setattr(leadership, "_release", released)
+    elector = leadership.LeaderElector()
+
+    task = asyncio.create_task(elector.run(mock.AsyncMock(), mock.AsyncMock()))
+    await asyncio.sleep(0.03)  # let it become leader
+    assert elector.is_leader is True
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    released.assert_called_once()

--- a/projects/monolith/app/main.py
+++ b/projects/monolith/app/main.py
@@ -54,35 +54,21 @@ def _log_task_exception(task: "asyncio.Task[object]") -> None:
         )
 
 
-@asynccontextmanager
-async def lifespan(app: FastAPI):
+async def _start_singletons(app: FastAPI) -> None:
+    """Start the background singletons. Invoked only on the elected leader replica.
+
+    These (Discord bot, scheduler dispatch loop, AIS ingest, bot-coupled lock
+    sweep) must run on exactly one replica, so they live behind leader election
+    rather than starting unconditionally in the lifespan.
+    """
     from app.db import get_engine
     from scheduler.api import purge_stale_jobs, run_scheduler_loop
     from sqlmodel import Session
 
-    app.state.bot = None
-    app.state.backfill_task = None
+    tasks: list[asyncio.Task] = []
 
-    # Register all scheduled jobs
-    with Session(get_engine()) as session:
-        from knowledge.service import on_startup as knowledge_startup
-
-        knowledge_startup(session)
-        home.on_startup_jobs(session)
-        ships.on_startup_jobs(session)
-        hikes.on_startup_jobs(session)
-        stars.on_startup_jobs(session)
-        dr_jobs.on_startup_jobs(session)
-        worldcup.on_startup_jobs(session)
-        knowledge.on_startup_jobs(session)
-
-        from home.observability import rollup as observability_rollup
-
-        observability_rollup.register(session)
-
-    # Start Discord bot + chat jobs if configured
+    # Discord bot + chat jobs if configured.
     bot = None
-    bot_task = None
     discord_token = os.environ.get("DISCORD_BOT_TOKEN", "")
     if discord_token:
         from chat.bot import create_bot
@@ -91,7 +77,6 @@ async def lifespan(app: FastAPI):
 
         bot = create_bot()
         app.state.bot = bot
-
         with Session(get_engine()) as session:
             chat_startup(session, bot=bot, llm_call=build_llm_caller())
 
@@ -101,28 +86,28 @@ async def lifespan(app: FastAPI):
 
         bot_task = asyncio.create_task(_start_bot_when_ready())
         bot_task.add_done_callback(_log_task_exception)
+        tasks.append(bot_task)
         logger.info("Discord bot starting")
 
-    # Purge stale jobs from DB (e.g. removed changelog channels)
+    # Purge stale jobs (registry housekeeping the leader owns).
     with Session(get_engine()) as session:
         purge_stale_jobs(session)
 
-    # Start the shared scheduler loop (replaces 4 separate asyncio tasks)
+    # Scheduler dispatch loop.
     scheduler_task = asyncio.create_task(run_scheduler_loop())
     scheduler_task.add_done_callback(_log_task_exception)
+    tasks.append(scheduler_task)
 
-    # Start the supervised AISStream ingest listener. It reconnects forever and
-    # never raises out (only CancelledError on shutdown), so it can never crash
-    # the app. Disabled automatically when AISSTREAM_API_KEY is unset.
+    # Supervised AISStream ingest (reconnects forever; CancelledError on stop).
     from ships.ingest import ais_stream_loop
 
     app.state.ships_stop = asyncio.Event()
-    app.state.ships_task = asyncio.create_task(ais_stream_loop(app.state.ships_stop))
-    app.state.ships_task.add_done_callback(_log_task_exception)
+    ships_task = asyncio.create_task(ais_stream_loop(app.state.ships_stop))
+    ships_task.add_done_callback(_log_task_exception)
+    tasks.append(ships_task)
     logger.info("Ships AISStream ingest started")
 
-    # Lock sweep stays in-memory (30s, bot-coupled, already multi-pod safe via SKIP LOCKED)
-    sweep_task = None
+    # Bot-coupled lock sweep (reclaims expired message locks via SKIP LOCKED).
     if discord_token and bot:
 
         async def _lock_sweep_loop():
@@ -154,34 +139,87 @@ async def lifespan(app: FastAPI):
 
         sweep_task = asyncio.create_task(_lock_sweep_loop())
         sweep_task.add_done_callback(_log_task_exception)
+        tasks.append(sweep_task)
         logger.info("Message lock sweep started (30s interval)")
+
+    app.state.singleton_tasks = tasks
+
+
+async def _stop_singletons(app: FastAPI) -> None:
+    """Stop the background singletons. Idempotent; runs on resign or shutdown."""
+    bot = getattr(app.state, "bot", None)
+    if bot is not None:
+        try:
+            await bot.close()
+        except Exception:
+            logger.exception("Discord bot close failed")
+        app.state.bot = None
+
+    ships_stop = getattr(app.state, "ships_stop", None)
+    if ships_stop is not None:
+        ships_stop.set()
+        app.state.ships_stop = None
+
+    for task in getattr(app.state, "singleton_tasks", []):
+        task.cancel()  # cancelling an already-done task is a safe no-op
+    app.state.singleton_tasks = []
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    from app.db import get_engine
+    from sqlmodel import Session
+
+    app.state.bot = None
+    app.state.backfill_task = None
+
+    # Register all scheduled jobs
+    with Session(get_engine()) as session:
+        from knowledge.service import on_startup as knowledge_startup
+
+        knowledge_startup(session)
+        home.on_startup_jobs(session)
+        ships.on_startup_jobs(session)
+        hikes.on_startup_jobs(session)
+        stars.on_startup_jobs(session)
+        dr_jobs.on_startup_jobs(session)
+        worldcup.on_startup_jobs(session)
+        knowledge.on_startup_jobs(session)
+
+        from home.observability import rollup as observability_rollup
+
+        observability_rollup.register(session)
 
     # Prime the observability snapshots (topology + stats) once at startup so the
     # first request has data; the scheduled rollup jobs refresh them thereafter.
-    # Best-effort: failures are logged and the scheduler retries (ADR 004 Layer 4).
+    # Runs on every replica (best-effort; the scheduler rollup refreshes later).
     await prime_snapshots()
 
-    logger.info("Monolith started")
+    # Background singletons (Discord bot, scheduler loop, AIS ingest, lock sweep)
+    # run on ONLY ONE replica at a time, elected via a Postgres heartbeat lease,
+    # so the web tier can scale horizontally without N duplicate bots/streams.
+    # Followers just serve HTTP. See app/leadership.py.
+    from app.leadership import LeaderElector
+
+    elector = LeaderElector()
+    app.state.elector = elector
+    app.state.singleton_tasks = []
+    elector_task = asyncio.create_task(
+        elector.run(
+            on_acquire=lambda: _start_singletons(app),
+            on_resign=lambda: _stop_singletons(app),
+        )
+    )
+    elector_task.add_done_callback(_log_task_exception)
+
+    logger.info("Monolith started (leader election active)")
     yield
 
+    elector_task.cancel()
+    await _stop_singletons(app)
     backfill_task = getattr(app.state, "backfill_task", None)
     if backfill_task and not backfill_task.done():
         backfill_task.cancel()
-    if sweep_task:
-        sweep_task.cancel()
-    if bot:
-        await bot.close()
-    if bot_task:
-        bot_task.cancel()
-    scheduler_task.cancel()
-
-    # Stop the ships ingest loop: signal it and cancel (cancel-only, matching the
-    # bot/scheduler/sweep teardown above). The supervised loop re-raises
-    # CancelledError on shutdown; its done callback (_log_task_exception) handles
-    # it. We do not await here so the path stays robust when tests patch
-    # asyncio.create_task into a non-awaitable mock.
-    app.state.ships_stop.set()
-    app.state.ships_task.cancel()
 
     if _tracer_provider is not None:
         _tracer_provider.shutdown()

--- a/projects/monolith/app/main_app_state_test.py
+++ b/projects/monolith/app/main_app_state_test.py
@@ -14,7 +14,6 @@ assignments or the timeout kwarg.
 from __future__ import annotations
 
 import os
-import sys
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -22,7 +21,7 @@ import pytest
 # Ensure no valid static directory is set before importing main
 os.environ.pop("STATIC_DIR", None)
 
-from app.main import app, lifespan, _wait_for_sidecar  # noqa: E402
+from app.main import _start_singletons, _wait_for_sidecar, app, lifespan  # noqa: E402
 
 
 # ---------------------------------------------------------------------------
@@ -130,9 +129,11 @@ class TestWaitForSidecarTimeoutKwarg:
 class TestLifespanAppStateBotAssignment:
     @pytest.mark.asyncio
     async def test_app_state_bot_is_set_to_bot_when_token_present(self):
-        """app.state.bot is set to the create_bot() return value during lifespan."""
+        """app.state.bot is set to the create_bot() return value when the leader
+        starts the singletons (the bot now runs only on the elected leader)."""
         mock_bot = MagicMock()
         mock_bot.close = AsyncMock()
+        mock_bot.start = AsyncMock()
 
         def capture_create_task(coro, **kwargs):
             if hasattr(coro, "close"):
@@ -152,11 +153,10 @@ class TestLifespanAppStateBotAssignment:
             patches[6],
             patches[7],
         ):
-            async with lifespan(app):
-                # During the lifespan body, app.state.bot must be the created bot
-                assert app.state.bot is mock_bot, (
-                    "app.state.bot was not set to the bot created by create_bot()"
-                )
+            await _start_singletons(app)
+            assert app.state.bot is mock_bot, (
+                "app.state.bot was not set to the bot created by create_bot()"
+            )
 
     @pytest.mark.asyncio
     async def test_app_state_bot_is_none_when_no_token(self):

--- a/projects/monolith/app/main_extra_test.py
+++ b/projects/monolith/app/main_extra_test.py
@@ -9,7 +9,12 @@ import pytest
 # Ensure no valid STATIC_DIR is set (mirrors main_coverage_test.py approach)
 os.environ.pop("STATIC_DIR", None)
 
-from app.main import app, lifespan  # noqa: E402
+from app.main import (  # noqa: E402
+    _start_singletons,
+    _stop_singletons,
+    app,
+    lifespan,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -69,14 +74,16 @@ def _lifespan_patches_with_discord(mock_bot):
 # ---------------------------------------------------------------------------
 
 
-class TestLifespanBotCloseException:
+class TestSingletonBotClose:
     @pytest.mark.asyncio
-    async def test_bot_close_exception_propagates(self):
-        """When bot.close() raises during shutdown the exception propagates out of lifespan."""
+    async def test_bot_close_exception_is_swallowed_on_stop(self):
+        """_stop_singletons logs and swallows bot.close() errors so a resign or
+        shutdown never crashes (the leader must be able to step down cleanly)."""
         tasks, capture = _make_task_capturer()
 
         mock_bot = MagicMock()
         mock_bot.close = AsyncMock(side_effect=RuntimeError("Discord connection lost"))
+        mock_bot.start = AsyncMock()
 
         patches = _lifespan_patches_with_discord(mock_bot)
         with (
@@ -91,17 +98,19 @@ class TestLifespanBotCloseException:
             patches[6],
             patches[7],
         ):
-            with pytest.raises(RuntimeError, match="Discord connection lost"):
-                async with lifespan(app):
-                    pass
+            await _start_singletons(app)
+            await _stop_singletons(app)  # must NOT raise
+
+        mock_bot.close.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_bot_close_exception_does_not_prevent_task_creation(self):
-        """Even when bot.close() will later raise, all 4 tasks are still created at startup."""
+    async def test_start_singletons_creates_four_tasks(self):
+        """The leader starts bot + scheduler + ships ingest + sweep = 4 tasks."""
         tasks, capture = _make_task_capturer()
 
         mock_bot = MagicMock()
-        mock_bot.close = AsyncMock(side_effect=RuntimeError("close error"))
+        mock_bot.close = AsyncMock()
+        mock_bot.start = AsyncMock()
 
         patches = _lifespan_patches_with_discord(mock_bot)
         with (
@@ -116,13 +125,8 @@ class TestLifespanBotCloseException:
             patches[6],
             patches[7],
         ):
-            try:
-                async with lifespan(app):
-                    pass
-            except RuntimeError:
-                pass  # expected
+            await _start_singletons(app)
 
-        # bot + scheduler + ships ingest + sweep = 4 tasks must have been created
         assert len(tasks) == 4
 
 

--- a/projects/monolith/app/main_lifespan_discord_test.py
+++ b/projects/monolith/app/main_lifespan_discord_test.py
@@ -1,6 +1,12 @@
-"""Additional coverage for app.main -- lifespan with Discord bot token set."""
+"""Coverage for the background singletons (Discord bot, scheduler, ships, sweep).
 
-import asyncio
+These used to start unconditionally in the lifespan; they now live in
+app.main._start_singletons / _stop_singletons, invoked only on the elected
+leader replica (see app/leadership.py). The lifespan itself just starts the
+leader-election task, so the task-count assertions target _start_singletons
+directly. A separate test covers the lifespan wiring + tracer shutdown.
+"""
+
 import os
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -9,201 +15,155 @@ import pytest
 # Ensure no valid STATIC_DIR is set (matches main_test.py approach)
 os.environ.pop("STATIC_DIR", None)
 
-from app.main import app, lifespan  # noqa: E402
+from app.main import _start_singletons, _stop_singletons, app, lifespan  # noqa: E402
 
 
-def _lifespan_patches_no_discord():
-    """Return patches needed for lifespan without discord token."""
+def _singleton_patches_no_discord():
+    """Patches for _start_singletons without a discord token."""
     mock_session = MagicMock()
     mock_session.__enter__ = MagicMock(return_value=mock_session)
     mock_session.__exit__ = MagicMock(return_value=False)
     return [
         patch("app.db.get_engine", return_value=MagicMock()),
         patch("sqlmodel.Session", return_value=mock_session),
-        patch("home.on_startup_jobs"),
         patch("scheduler.api.run_scheduler_loop", new_callable=AsyncMock),
-        patch("ships.on_startup_jobs"),
-        patch("hikes.on_startup_jobs"),
+        patch("scheduler.api.purge_stale_jobs"),
     ]
 
 
-def _lifespan_patches_with_discord(mock_bot):
-    """Return patches needed for lifespan with discord token."""
+def _singleton_patches_with_discord(mock_bot):
+    """Patches for _start_singletons with a discord token."""
     mock_session = MagicMock()
     mock_session.__enter__ = MagicMock(return_value=mock_session)
     mock_session.__exit__ = MagicMock(return_value=False)
     return [
         patch("app.db.get_engine", return_value=MagicMock()),
         patch("sqlmodel.Session", return_value=mock_session),
-        patch("home.on_startup_jobs"),
         patch("scheduler.api.run_scheduler_loop", new_callable=AsyncMock),
+        patch("scheduler.api.purge_stale_jobs"),
         patch("chat.summarizer.on_startup"),
         patch("chat.summarizer.build_llm_caller", return_value=MagicMock()),
         patch("chat.bot.create_bot", return_value=mock_bot),
-        patch("ships.on_startup_jobs"),
-        patch("hikes.on_startup_jobs"),
     ]
 
 
-class TestLifespanWithDiscordToken:
-    @pytest.mark.asyncio
-    async def test_lifespan_starts_bot_when_token_set(self):
-        """When DISCORD_BOT_TOKEN is set lifespan creates four tasks (bot, scheduler, ships ingest, sweep)."""
-        created_tasks = []
-
-        def capture_create_task(coro, **kwargs):
-            if hasattr(coro, "close"):
-                coro.close()
-            mock_task = MagicMock()
-            created_tasks.append(mock_task)
-            return mock_task
-
-        mock_bot = MagicMock()
-        mock_bot.close = AsyncMock()
-        mock_bot.start = AsyncMock(return_value=None)
-
-        patches = _lifespan_patches_with_discord(mock_bot)
-        with (
-            patch.dict(os.environ, {"DISCORD_BOT_TOKEN": "fake-token-xyz"}),
-            patch("asyncio.create_task", side_effect=capture_create_task),
-            patches[0],
-            patches[1],
-            patches[2],
-            patches[3],
-            patches[4],
-            patches[5],
-            patches[6],
-            patches[7],
-        ):
-            async with lifespan(app):
-                pass
-
-        # bot + scheduler + ships ingest + sweep = 4 tasks
-        assert len(created_tasks) == 4
-
-    @pytest.mark.asyncio
-    async def test_lifespan_closes_bot_on_shutdown(self):
-        """When Discord bot is started lifespan calls bot.close() on shutdown."""
-        created_tasks = []
-
-        def capture_create_task(coro, **kwargs):
-            if hasattr(coro, "close"):
-                coro.close()
-            mock_task = MagicMock()
-            created_tasks.append(mock_task)
-            return mock_task
-
-        mock_bot = MagicMock()
-        mock_bot.close = AsyncMock()
-
-        patches = _lifespan_patches_with_discord(mock_bot)
-        with (
-            patch.dict(os.environ, {"DISCORD_BOT_TOKEN": "fake-token-xyz"}),
-            patch("asyncio.create_task", side_effect=capture_create_task),
-            patches[0],
-            patches[1],
-            patches[2],
-            patches[3],
-            patches[4],
-            patches[5],
-            patches[6],
-            patches[7],
-        ):
-            async with lifespan(app):
-                pass
-
-        mock_bot.close.assert_called_once()
-
-    @pytest.mark.asyncio
-    async def test_lifespan_cancels_bot_task_on_shutdown(self):
-        """Bot task is cancelled when the lifespan context exits."""
-        created_tasks = []
-
-        def capture_create_task(coro, **kwargs):
-            if hasattr(coro, "close"):
-                coro.close()
-            mock_task = MagicMock()
-            created_tasks.append(mock_task)
-            return mock_task
-
-        mock_bot = MagicMock()
-        mock_bot.close = AsyncMock()
-
-        patches = _lifespan_patches_with_discord(mock_bot)
-        with (
-            patch.dict(os.environ, {"DISCORD_BOT_TOKEN": "fake-token-xyz"}),
-            patch("asyncio.create_task", side_effect=capture_create_task),
-            patches[0],
-            patches[1],
-            patches[2],
-            patches[3],
-            patches[4],
-            patches[5],
-            patches[6],
-            patches[7],
-        ):
-            async with lifespan(app):
-                pass
-
-        # All four tasks (bot, scheduler, ships ingest, sweep) should be cancelled
-        for task in created_tasks:
-            task.cancel.assert_called_once()
-
-    @pytest.mark.asyncio
-    async def test_lifespan_no_bot_task_when_token_empty(self):
-        """When DISCORD_BOT_TOKEN is absent lifespan creates exactly 2 tasks (scheduler, ships ingest)."""
-        created_tasks = []
-
-        def capture_create_task(coro, **kwargs):
-            if hasattr(coro, "close"):
-                coro.close()
-            mock_task = MagicMock()
-            created_tasks.append(mock_task)
-            return mock_task
-
-        env_without_token = {
-            k: v for k, v in os.environ.items() if k != "DISCORD_BOT_TOKEN"
-        }
-        env_without_token["DISCORD_BOT_TOKEN"] = ""
-
-        patches = _lifespan_patches_no_discord()
-        with (
-            patch.dict(os.environ, env_without_token, clear=True),
-            patch("asyncio.create_task", side_effect=capture_create_task),
-            patches[0],
-            patches[1],
-            patches[2],
-            patches[3],
-            patches[4],
-        ):
-            async with lifespan(app):
-                pass
-
-        assert len(created_tasks) == 2
-
-
-@pytest.mark.asyncio
-async def test_lifespan_calls_tracer_provider_shutdown_on_exit():
-    """_tracer_provider.shutdown() is called exactly once when the lifespan context exits."""
+def _capture():
+    created = []
 
     def capture_create_task(coro, **kwargs):
         if hasattr(coro, "close"):
             coro.close()
-        return MagicMock()
+        task = MagicMock()
+        created.append(task)
+        return task
 
+    return created, capture_create_task
+
+
+class TestSingletons:
+    @pytest.mark.asyncio
+    async def test_start_singletons_starts_four_tasks_with_token(self):
+        """With a token, the leader starts bot + scheduler + ships + sweep = 4 tasks."""
+        created, cap = _capture()
+        mock_bot = MagicMock()
+        mock_bot.close = AsyncMock()
+        mock_bot.start = AsyncMock(return_value=None)
+
+        patches = _singleton_patches_with_discord(mock_bot)
+        with (
+            patch.dict(os.environ, {"DISCORD_BOT_TOKEN": "fake-token-xyz"}),
+            patch("asyncio.create_task", side_effect=cap),
+            patches[0],
+            patches[1],
+            patches[2],
+            patches[3],
+            patches[4],
+            patches[5],
+            patches[6],
+        ):
+            await _start_singletons(app)
+
+        assert len(created) == 4
+
+    @pytest.mark.asyncio
+    async def test_start_singletons_two_tasks_without_token(self):
+        """Without a token: scheduler + ships ingest = 2 tasks (no bot, no sweep)."""
+        created, cap = _capture()
+        env = {k: v for k, v in os.environ.items() if k != "DISCORD_BOT_TOKEN"}
+        env["DISCORD_BOT_TOKEN"] = ""
+
+        patches = _singleton_patches_no_discord()
+        with (
+            patch.dict(os.environ, env, clear=True),
+            patch("asyncio.create_task", side_effect=cap),
+            patches[0],
+            patches[1],
+            patches[2],
+            patches[3],
+        ):
+            await _start_singletons(app)
+
+        assert len(created) == 2
+
+    @pytest.mark.asyncio
+    async def test_stop_singletons_closes_and_cancels(self):
+        """_stop_singletons closes the bot and cancels every started task."""
+        created, cap = _capture()
+        mock_bot = MagicMock()
+        mock_bot.close = AsyncMock()
+        mock_bot.start = AsyncMock(return_value=None)
+
+        patches = _singleton_patches_with_discord(mock_bot)
+        with (
+            patch.dict(os.environ, {"DISCORD_BOT_TOKEN": "fake-token-xyz"}),
+            patch("asyncio.create_task", side_effect=cap),
+            patches[0],
+            patches[1],
+            patches[2],
+            patches[3],
+            patches[4],
+            patches[5],
+            patches[6],
+        ):
+            await _start_singletons(app)
+            await _stop_singletons(app)
+
+        mock_bot.close.assert_called_once()
+        for task in created:
+            task.cancel.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_lifespan_starts_elector_and_shuts_down_tracer():
+    """The lifespan starts exactly one task (the leader elector) and shuts down
+    the tracer on exit; the singletons themselves are leader-gated."""
+    created, cap = _capture()
     mock_tracer_provider = MagicMock()
 
-    patches = _lifespan_patches_no_discord()
+    mock_session = MagicMock()
+    mock_session.__enter__ = MagicMock(return_value=mock_session)
+    mock_session.__exit__ = MagicMock(return_value=False)
+
     with (
-        patch("asyncio.create_task", side_effect=capture_create_task),
+        patch("asyncio.create_task", side_effect=cap),
         patch("app.main._tracer_provider", mock_tracer_provider),
-        patches[0],
-        patches[1],
-        patches[2],
-        patches[3],
-        patches[4],
+        patch("app.main.prime_snapshots", new_callable=AsyncMock),
+        patch("app.db.get_engine", return_value=MagicMock()),
+        patch("sqlmodel.Session", return_value=mock_session),
+        patch("knowledge.service.on_startup"),
+        patch("home.on_startup_jobs"),
+        patch("ships.on_startup_jobs"),
+        patch("hikes.on_startup_jobs"),
+        patch("stars.on_startup_jobs"),
+        patch("dr_jobs.on_startup_jobs"),
+        patch("worldcup.on_startup_jobs"),
+        patch("knowledge.on_startup_jobs"),
+        patch("home.observability.rollup.register"),
     ):
         async with lifespan(app):
             mock_tracer_provider.shutdown.assert_not_called()
 
+    # Exactly one task created by the lifespan body: the leader elector.
+    assert len(created) == 1
+    created[0].cancel.assert_called_once()
     mock_tracer_provider.shutdown.assert_called_once()

--- a/projects/monolith/app/main_lock_sweep_test.py
+++ b/projects/monolith/app/main_lock_sweep_test.py
@@ -36,7 +36,7 @@ import pytest
 # Ensure no valid STATIC_DIR is set before importing main
 os.environ.pop("STATIC_DIR", None)
 
-from app.main import app, lifespan, _log_task_exception  # noqa: E402
+from app.main import _log_task_exception, _start_singletons, app  # noqa: E402
 
 
 # ---------------------------------------------------------------------------
@@ -158,8 +158,7 @@ class TestSweepTaskRegistration:
             patches[6],
             patches[7],
         ):
-            async with lifespan(app):
-                pass
+            await _start_singletons(app)
 
         sweep_task_mock.add_done_callback.assert_called_once_with(_log_task_exception)
 
@@ -188,8 +187,7 @@ class TestSweepTaskRegistration:
             patches[7],
             patch("app.main.logger") as mock_logger,
         ):
-            async with lifespan(app):
-                pass
+            await _start_singletons(app)
 
         messages = [str(c) for c in mock_logger.info.call_args_list]
         assert any("Message lock sweep started" in m for m in messages), (
@@ -224,8 +222,7 @@ class TestSweepTaskRegistration:
             patches[4],
             patch("app.main.logger") as mock_logger,
         ):
-            async with lifespan(app):
-                pass
+            await _start_singletons(app)
 
         # 2 tasks should be created (scheduler + ships ingest)
         assert len(tasks_created) == 2
@@ -265,8 +262,7 @@ class TestLockSweepLoopNoExpiredLocks:
             patches[6],
             patches[7],
         ):
-            async with lifespan(app):
-                pass
+            await _start_singletons(app)
 
         assert len(coros) == 1
 
@@ -320,8 +316,7 @@ class TestLockSweepLoopNoExpiredLocks:
             patches[6],
             patches[7],
         ):
-            async with lifespan(app):
-                pass
+            await _start_singletons(app)
 
         assert len(coros) == 1
 
@@ -373,8 +368,7 @@ class TestLockSweepLoopNoExpiredLocks:
             patches[6],
             patches[7],
         ):
-            async with lifespan(app):
-                pass
+            await _start_singletons(app)
 
         assert len(coros) == 1
 
@@ -430,8 +424,7 @@ class TestLockSweepLoopNoExpiredLocks:
             patches[6],
             patches[7],
         ):
-            async with lifespan(app):
-                pass
+            await _start_singletons(app)
 
         assert len(coros) == 1
 
@@ -495,8 +488,7 @@ class TestLockSweepLoopWithExpiredLocks:
             patches[6],
             patches[7],
         ):
-            async with lifespan(app):
-                pass
+            await _start_singletons(app)
 
         assert len(coros) == 1
 
@@ -554,8 +546,7 @@ class TestLockSweepLoopWithExpiredLocks:
             patches[6],
             patches[7],
         ):
-            async with lifespan(app):
-                pass
+            await _start_singletons(app)
 
         assert len(coros) == 1
 
@@ -613,8 +604,7 @@ class TestLockSweepLoopWithExpiredLocks:
             patches[6],
             patches[7],
         ):
-            async with lifespan(app):
-                pass
+            await _start_singletons(app)
 
         assert len(coros) == 1
 
@@ -675,8 +665,7 @@ class TestLockSweepLoopExceptionHandling:
             patches[6],
             patches[7],
         ):
-            async with lifespan(app):
-                pass
+            await _start_singletons(app)
 
         assert len(coros) == 1
 
@@ -734,8 +723,7 @@ class TestLockSweepLoopExceptionHandling:
             patches[6],
             patches[7],
         ):
-            async with lifespan(app):
-                pass
+            await _start_singletons(app)
 
         assert len(coros) == 1
 
@@ -790,8 +778,7 @@ class TestLockSweepLoopExceptionHandling:
             patches[6],
             patches[7],
         ):
-            async with lifespan(app):
-                pass
+            await _start_singletons(app)
 
         assert len(coros) == 1
 

--- a/projects/monolith/app/main_sidecar_test.py
+++ b/projects/monolith/app/main_sidecar_test.py
@@ -386,7 +386,7 @@ async def test_wait_for_sidecar_logs_ready_message():
 @pytest.mark.asyncio
 async def test_start_bot_when_ready_calls_wait_for_sidecar_before_bot_start():
     """_start_bot_when_ready awaits _wait_for_sidecar before calling bot.start."""
-    from app.main import app, lifespan
+    from app.main import _start_singletons, app
 
     call_order = []
 
@@ -434,8 +434,7 @@ async def test_start_bot_when_ready_calls_wait_for_sidecar_before_bot_start():
         patches[6],
         patches[7],
     ):
-        async with lifespan(app):
-            pass
+        await _start_singletons(app)
 
         assert len(captured_bot_coro) == 1, (
             "Expected exactly one bot coroutine captured from create_task"
@@ -451,7 +450,7 @@ async def test_start_bot_when_ready_calls_wait_for_sidecar_before_bot_start():
 @pytest.mark.asyncio
 async def test_start_bot_when_ready_not_scheduled_when_no_token():
     """When DISCORD_BOT_TOKEN is absent, no bot task (and thus no sidecar wait) is created."""
-    from app.main import app, lifespan
+    from app.main import _start_singletons, app
 
     created_tasks: list = []
 
@@ -476,8 +475,7 @@ async def test_start_bot_when_ready_not_scheduled_when_no_token():
         patches[3],
         patches[4],
     ):
-        async with lifespan(app):
-            pass
+        await _start_singletons(app)
 
     # Scheduler + ships ingest task (no bot task)
     assert len(created_tasks) == 2, (

--- a/projects/monolith/app/main_summary_test.py
+++ b/projects/monolith/app/main_summary_test.py
@@ -18,7 +18,7 @@ import pytest
 # Ensure no valid static directory before importing main
 os.environ.pop("STATIC_DIR", None)
 
-from app.main import app, lifespan, _log_task_exception  # noqa: E402
+from app.main import _log_task_exception, _start_singletons, app  # noqa: E402
 
 
 # ---------------------------------------------------------------------------
@@ -105,8 +105,7 @@ class TestChatStartupHook:
             patch("chat.summarizer.build_llm_caller", return_value=MagicMock()),
             patch("chat.bot.create_bot", return_value=mock_bot),
         ):
-            async with lifespan(app):
-                pass
+            await _start_singletons(app)
 
         mock_chat_startup.assert_called_once()
 
@@ -140,8 +139,7 @@ class TestChatStartupHook:
             patches[6],
             patches[7],
         ):
-            async with lifespan(app):
-                pass
+            await _start_singletons(app)
 
         assert len(task_mocks) == 4
         # Tasks: 0=bot, 1=scheduler, 2=ships ingest, 3=sweep, all have done callbacks
@@ -187,8 +185,7 @@ class TestSummaryLoopLogging:
             patch("hikes.on_startup_jobs"),
             patch("scheduler.api.run_scheduler_loop", new_callable=AsyncMock),
         ):
-            async with lifespan(app):
-                pass
+            await _start_singletons(app)
 
         # chat_startup should never have been imported/called since the discord
         # branch was not entered

--- a/projects/monolith/app/main_test.py
+++ b/projects/monolith/app/main_test.py
@@ -20,7 +20,7 @@ from sqlmodel.pool import StaticPool
 os.environ.pop("STATIC_DIR", None)
 
 from app.db import get_session  # noqa: E402
-from app.main import app  # noqa: E402
+from app.main import _start_singletons, _stop_singletons, app  # noqa: E402
 
 
 # ---------------------------------------------------------------------------
@@ -177,8 +177,7 @@ async def test_lifespan_creates_one_background_task_on_startup():
     patches = _lifespan_patches_no_discord()
     with patch("asyncio.create_task", side_effect=capture_create_task):
         with patches[0], patches[1], patches[2], patches[3], patches[4]:
-            async with lifespan(app):
-                pass
+            await _start_singletons(app)
 
     assert len(created_tasks) == 2
 
@@ -200,8 +199,8 @@ async def test_lifespan_cancels_all_tasks_on_shutdown():
     patches = _lifespan_patches_no_discord()
     with patch("asyncio.create_task", side_effect=capture_create_task):
         with patches[0], patches[1], patches[2], patches[3], patches[4]:
-            async with lifespan(app):
-                pass
+            await _start_singletons(app)
+            await _stop_singletons(app)
 
     assert len(mock_tasks) == 2
     for task in mock_tasks:
@@ -225,12 +224,13 @@ async def test_lifespan_no_tasks_cancelled_before_shutdown():
     patches = _lifespan_patches_no_discord()
     with patch("asyncio.create_task", side_effect=capture_create_task):
         with patches[0], patches[1], patches[2], patches[3], patches[4]:
-            async with lifespan(app):
-                assert len(mock_tasks) == 2
-                for task in mock_tasks:
-                    task.cancel.assert_not_called()
+            await _start_singletons(app)
+            assert len(mock_tasks) == 2
+            for task in mock_tasks:
+                task.cancel.assert_not_called()
+            await _stop_singletons(app)
 
-    # After lifespan exits, task must have been cancelled
+    # After _stop_singletons, every task must have been cancelled
     for task in mock_tasks:
         task.cancel.assert_called_once()
 
@@ -263,8 +263,7 @@ async def test_lifespan_scheduler_task_is_run_scheduler_loop():
     ]
     with patch("asyncio.create_task", side_effect=capture_create_task):
         with patches[0], patches[1], patches[2], patches[3], patches[4]:
-            async with lifespan(app):
-                pass
+            await _start_singletons(app)
 
     mock_scheduler.assert_called_once()
 
@@ -477,8 +476,7 @@ async def test_lifespan_logs_discord_bot_starting_when_token_set():
                 patches[7],
             ):
                 with patch("app.main.logger") as mock_logger:
-                    async with lifespan(app):
-                        pass
+                    await _start_singletons(app)
 
     logged_messages = [str(c) for c in mock_logger.info.call_args_list]
     assert any("Discord bot starting" in m for m in logged_messages), (
@@ -516,8 +514,7 @@ async def test_lifespan_creates_three_tasks_when_discord_token_set():
                 patches[6],
                 patches[7],
             ):
-                async with lifespan(app):
-                    pass
+                await _start_singletons(app)
 
     assert len(created_tasks) == 4
 

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.199.0
+version: 0.200.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/migrations/20260621130000_leader_lease.sql
+++ b/projects/monolith/chart/migrations/20260621130000_leader_lease.sql
@@ -1,0 +1,12 @@
+-- Heartbeat leader election for the monolith's in-process singletons (Discord
+-- bot, AIS ingest, scheduler loop). A single lease row is renewed by the leader
+-- every couple of seconds; any replica may steal it once heartbeat_at is older
+-- than the TTL (missed heartbeats). This lets the web tier scale horizontally
+-- without running N duplicate bots/streams. One upsert per replica per interval,
+-- so the load on Postgres is negligible.
+
+CREATE TABLE scheduler.leader_lease (
+    lease_key    TEXT PRIMARY KEY,
+    holder       TEXT NOT NULL,
+    heartbeat_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);

--- a/projects/monolith/chart/migrations/atlas.sum
+++ b/projects/monolith/chart/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:8SphNeTL9tHoWkS/Mj+xE0/kDKqin6Na7dnAO9iyMzI=
+h1:Q1j/VDdB0jWwNh/bXVJkcqnz/aTTaBk6T7w4NmRiMeE=
 20260330000000_initial_schema.sql h1:J2futpSW0nJAIRR7nR7ssT7LwXIYrvRI+PkHb5Y4tLI=
 20260403000000_chat_schema.sql h1:pERUFC0vzM95etRuzp43XzkCV7lBCzrrtY5Mk7aF3CA=
 20260404000000_chat_attachments.sql h1:tv+Fdbr1rQC5nzUxfaBC0O6fu2OMGgLWf+YNg1WQXi4=
@@ -61,3 +61,4 @@ h1:8SphNeTL9tHoWkS/Mj+xE0/kDKqin6Na7dnAO9iyMzI=
 20260620120100_worldcup_public_reader_grant.sql h1:gAXxMO9FNfGw1xAjmbb0GciI59awvH9WFzjtVuw9muQ=
 20260621120000_worldcup_swing_per_country.sql h1:PF2X+SOSRkR4sMD1fgd+fu0eoJ0BgiiItGI9IZn7ugw=
 20260621130000_chat_public_reader_schema_usage.sql h1:UuKhDAWNrOK/vOEcI7UA89nvKxSRiSAVQTgRwZexRn8=
+20260621130000_leader_lease.sql h1:XtX+yhjGVAOmLyP+9iwVnr/fcIsxklUTqD5Y8OllIuo=

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.199.0
+      targetRevision: 0.200.0
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
## What

Lets the monolith web tier scale horizontally (many small replicas, no single point of failure) without running **N duplicate Discord bots / AIS streams**. Only the elected **leader** replica runs the background singletons (Discord bot, scheduler loop, AIS ingest, lock sweep); followers just serve HTTP.

## Mechanism (`app/leadership.py`)

A single `scheduler.leader_lease` row, renewed by the leader every ~2s; any replica steals it once `heartbeat_at` is >5s stale (your chosen failover window). **One atomic upsert per replica per interval** (`ON CONFLICT ... WHERE holder=me OR stale`), so Postgres load is negligible. **Fail-safe to follower** on any DB error (never two leaders). Graceful lease release on SIGTERM for <2s failover on rolling deploys.

The singletons moved out of the lifespan into `_start_singletons`/`_stop_singletons`, gated by the elector's `on_acquire`/`on_resign`. Lifespan tests that asserted the singletons start unconditionally now target `_start_singletons` directly.

## Not yet (follow-ups)

- **To actually shrink + multiply the pods** (`4Gi → ~1Gi × 3`), the heavy in-process jobs (`knowledge.layout` FA2, 3.12 GiB peak per SigNoz) must also move to Argo — else whichever replica is leader still needs 4Gi. Leader election is the *correctness* half; jobs-to-Argo is the *memory* half.
- Then: `replicas: 1 → 3`, `4Gi → ~1Gi`, add a `PodDisruptionBudget`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)