### PR TITLE
feat(hikes): hide never-doable walks from the map in Any mode

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.41.0
+version: 0.42.0
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.41.0
+      targetRevision: 0.42.0
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.198.0
+version: 0.199.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.198.0
+      targetRevision: 0.199.0
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/routes/public/app/hikes/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/hikes/+page.svelte
@@ -205,6 +205,11 @@
       // (not merely one good hour). Membership is a cheap O(1) check, no hourly
       // windows to re-parse.
       result = result.filter((w) => w.viable_days?.includes(selectedDay));
+    } else {
+      // "Any day": still drop walks doable on NO forecast day, so the map means
+      // "doable somewhere in the 7-day window" rather than plotting walks whose
+      // whole forecast is too short/washed-out to ever complete.
+      result = result.filter((w) => w.viable_days?.length);
     }
     return result;
   });


### PR DESCRIPTION
## Follow-up to the hikes doability work

Picking a day chip already filters the map to walks doable that day, but **"Any day"** mode plotted every walk passing the distance/ascent/duration/region filters, including the ~4 whose entire 7-day forecast is too short or washed-out to ever complete. So the map showed markers for walks you can't do anytime.

## Change

One branch in the `filtered` derivation (`+page.svelte`): when no day is selected, also drop walks with an empty `viable_days`. The map now consistently means "doable somewhere in the forecast window" in both Any mode and a specific-day view.

```js
if (selectedDay != null) {
  result = result.filter((w) => w.viable_days?.includes(selectedDay));
} else {
  result = result.filter((w) => w.viable_days?.length);   // new
}
```

## Scope / visual regression

Frontend-only, no backend/schema/wire change. The hikes visual fixture's 5 walks all have non-empty `viable_days`, so none are hidden in the harness render: **no baseline change** (verified locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)