### PR TITLE
fix(hikes): parse single-push hours for dual-format walk durations

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.43.0
+version: 0.43.1
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.43.0
+      targetRevision: 0.43.1
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.200.0
+version: 0.200.1
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.200.0
+      targetRevision: 0.200.1
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/hikes/walkhighlands.py
+++ b/projects/monolith/hikes/walkhighlands.py
@@ -128,13 +128,23 @@ def parse_walk_links(html: str, base_url: str) -> list[str]:
 def _parse_duration_hours(text: str) -> float | None:
     """Parse a walk duration via TimeLength; ranges take the upper bound.
 
-    "5.5 - 6.5 hours" parses the part after the dash (6.5), matching the
-    original scraper exactly.
+    "5.5 - 6.5 hours" parses the part after the dash (6.5), matching the original
+    scraper. WalkHighlands also offers some long routes as both a single-push and
+    a multi-day option, e.g. "18 hours/2 days" or "12 hours+ or 2 days". Passed
+    whole, TimeLength SUMS every token (18h + 2 days = 66h), which is meaningless
+    for the per-day doability model (it wants walking hours, not elapsed days).
+    So when an hours alternative is present, keep only it and drop the "N days"
+    framing. A pure "2 days" with no hours figure falls through to TimeLength
+    unchanged (such routes are inherently multi-day).
     """
+    segments = re.split(r"\s*/\s*|\s+or\s+", text)
+    hour_segments = [seg for seg in segments if "hour" in seg.lower()]
+    # "12 hours+" -> "12 hours": the trailing + would trip TimeLength.
+    candidate = (hour_segments[0] if hour_segments else text).replace("+", " ").strip()
     try:
-        if "-" in text:
-            return TimeLength(text.split("-")[1]).to_hours()
-        return TimeLength(text).to_hours()
+        if "-" in candidate:
+            return TimeLength(candidate.split("-")[1]).to_hours()
+        return TimeLength(candidate).to_hours()
     except Exception:
         logger.warning("hikes scrape: could not parse duration %r", text)
         return None

--- a/projects/monolith/hikes/walkhighlands_test.py
+++ b/projects/monolith/hikes/walkhighlands_test.py
@@ -201,3 +201,20 @@ def test_parse_duration_single_value():
 
 def test_parse_duration_range_takes_upper_bound():
     assert _parse_duration_hours("5.5 - 6.5 hours") == 6.5
+
+
+def test_parse_duration_hours_slash_days_keeps_hours():
+    # WalkHighlands' "18 hours/2 days" must NOT sum to 66h (18 + 2*24); the
+    # single-push hours figure is what the doability model needs.
+    assert _parse_duration_hours("18 hours/2 days") == 18.0
+
+
+def test_parse_duration_hours_or_days_strips_plus_and_days():
+    # "12 hours+ or 2 days" -> 12.0 (drop the trailing + and the multi-day option).
+    assert _parse_duration_hours("12 hours+ or 2 days") == 12.0
+
+
+def test_parse_duration_pure_days_falls_through():
+    # No hours figure: a genuinely multi-day route still yields a real number
+    # (2 days = 48h), so it stays in the corpus as inherently multi-day.
+    assert _parse_duration_hours("2 days") == 48.0


### PR DESCRIPTION
## The bug behind the never-doable multi-day routes

The 4 walks hidden in Any mode (Trotternish Ridge, Cairn Toul-Braeriach, Bidein/Lurg Mhòr, the Dirty 30) had durations of **60-66h**, which made them never doable. Fetching the actual WalkHighlands pages (from inside the cluster, since the site 403s other IPs) showed why: those routes state the Time field as **both** a single-push and a multi-day option:

- Trotternish: `Time => 18 hours/2 days`
- Dirty 30: `Time => 12 hours+ or 2 days`

`_parse_duration_hours` passed the whole string to `TimeLength`, which **sums every token**: `18h + 2 days = 66h`, `12h + 2 days = 60h`. Hence the four bogus values.

(Aside: those pages do have "Stage 1…8" headings, but they're turn-by-turn GPS route segments with no per-stage distance/time/ascent, so there's no scrapeable per-day leg breakdown to use; the duration was the real issue.)

## Fix

Isolate the hours alternative before parsing and drop the "N days" framing, so these read as their real single-push times (~18h, ~12h). The per-day doability model already handles long walks (the >7h dark-shoulder credit), so an 18h route is correctly "rarely doable" and a 12h route is doable on a good long summer day. A pure "N days" with no hours figure still falls through to `TimeLength` unchanged (genuinely multi-day routes keep a real, if large, number).

Effort colour also stops being max-red-because-64h.

## Tests

Added cases for `"18 hours/2 days"` → 18.0, `"12 hours+ or 2 days"` → 12.0, and pure `"2 days"` → 48.0 (fall-through), alongside the existing single-value and range tests.

## Rollout note

Durations are stored at scrape time, so this takes effect on the **next scrape**. I'll trigger the hikes scrape job after merge + deploy so the four routes repopulate with correct hours, then confirm.

(The unchanged pre-existing `getLogger("hikes")` semgrep finding is not touched; CI semgrep is diff-aware.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)