### PR TITLE
fix(hikes): repair scraper selectors for WalkHighlands' new page layout

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.44.0
+version: 0.44.1
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.44.0
+      targetRevision: 0.44.1
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.201.0
+version: 0.201.1
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.201.0
+      targetRevision: 0.201.1
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/hikes/walkhighlands.py
+++ b/projects/monolith/hikes/walkhighlands.py
@@ -155,7 +155,11 @@ def parse_walk(html: str) -> Walk | None:
     soup = BeautifulSoup(html, "html.parser")
     data: dict = {}
 
-    name_tag = soup.select_one("#content h1")
+    # The route title is an <h1 class="wtitle"> that now sits ABOVE #content
+    # (WalkHighlands moved it out of the content div, and the page also carries
+    # unrelated "app expired" <h1>s, so target the class). Fall back to the old
+    # "#content h1" so a partial revert does not re-break parsing.
+    name_tag = soup.select_one("h1.wtitle") or soup.select_one("#content h1")
     if name_tag:
         data["name"] = name_tag.get_text(strip=True)
 
@@ -163,9 +167,12 @@ def parse_walk(html: str) -> Walk | None:
     if canonical and canonical.get("href"):
         data["url"] = canonical["href"]
 
-    # The H2 titled "Summary" is followed by the summary paragraph.
-    summary_h2 = soup.find("h2", string=lambda t: t and "Summary" in t)
-    summary_p = summary_h2.find_next_sibling("p") if summary_h2 else None
+    # The heading titled "Summary" is followed by the summary paragraph. The page
+    # now uses <h3> (was <h2>) and wraps the paragraph in a div rather than making
+    # it a direct sibling, so match either heading level and take the next <p> in
+    # document order (find_next), which works for both the old and new layouts.
+    summary_heading = soup.find(["h2", "h3"], string=lambda t: t and "Summary" in t)
+    summary_p = summary_heading.find_next("p") if summary_heading else None
     if summary_p:
         data["summary"] = summary_p.get_text(strip=True)
 

--- a/projects/monolith/hikes/walkhighlands_test.py
+++ b/projects/monolith/hikes/walkhighlands_test.py
@@ -73,16 +73,23 @@ SUB_AREA_HTML_NO_TBODY = """
 </body></html>
 """
 
+# Mirrors WalkHighlands' current layout: the title is an <h1 class="wtitle">
+# ABOVE #content (alongside unrelated "app expired" <h1>s), and the Summary is
+# an <h3> whose paragraph is wrapped in a div rather than a direct sibling.
 WALK_PAGE_HTML = """
 <html>
 <head>
   <link rel="canonical" href="https://www.walkhighlands.co.uk/sutherland/sandwood-bay.shtml">
 </head>
 <body>
+<h1 class="wtitle">Sandwood Bay</h1>
+<div id="wrapper">
 <div id="content">
-  <h1>Sandwood Bay</h1>
-  <h2>Summary</h2>
-  <p>A magnificent walk to one of the wildest and most beautiful bays.</p>
+  <h1>This version of the Walkhighlands App has expired</h1>
+  <h3>Summary</h3>
+  <div class="box1 pad2 bg1"><p style="font-weight:bold">A magnificent walk to one of the wildest and most beautiful bays.</p></div>
+  <p class="noprint">Hear pronunciation</p>
+</div>
 </div>
 <div id="col">
   <dl>
@@ -102,10 +109,12 @@ WALK_PAGE_NO_COORDS_HTML = """
   <link rel="canonical" href="https://www.walkhighlands.co.uk/sutherland/sandwood-bay.shtml">
 </head>
 <body>
+<h1 class="wtitle">Sandwood Bay</h1>
+<div id="wrapper">
 <div id="content">
-  <h1>Sandwood Bay</h1>
-  <h2>Summary</h2>
-  <p>A magnificent walk.</p>
+  <h3>Summary</h3>
+  <div class="box1 pad2 bg1"><p>A magnificent walk.</p></div>
+</div>
 </div>
 <div id="col">
   <dl>


### PR DESCRIPTION
## The scraper has been silently broken site-wide

While verifying the duration fix (#2785), the re-scrape returned `walk_parse_failures: 1987, walks_parsed: 0` — **every** page failed. Fetching live pages from inside the cluster showed WalkHighlands restructured the walk page:

- The route title moved to a top-level `<h1 class="wtitle">` **above** `#content` (and the page now also carries unrelated "app expired" `<h1>`s).
- The Summary went from `<h2>Summary</h2><p>…` to `<h3>Summary</h3><div class="box1"><p>…`.

`parse_walk`'s `#content h1` and `h2 + next-sibling p` selectors both miss, so every page fails `Walk` validation (`name` + `summary` missing), and the "zero walks scraped, keep existing corpus" guard silently preserves a **stale, frozen corpus**. That's why every walk's stats are frozen — including the 60–66h dual-format durations #2785 fixed in code but couldn't apply.

## Fix

- Name: `soup.select_one("h1.wtitle") or soup.select_one("#content h1")` (new selector, old as fallback).
- Summary: `soup.find(["h2","h3"], "Summary").find_next("p")` — matches either heading level and takes the next `<p>` in document order, working whether the paragraph is a sibling (old) or nested in a div (new).

Verified in-pod against the live pages and the updated fixtures: name + summary now extract correctly, skipping the stray app-expired `h1`.

## Tests

Fixtures updated to the current layout (including a stray `app expired` `<h1>` so the happy-path test guards that we pick the `wtitle` heading). Existing distance/time/ascent/coords assertions unchanged.

## Rollout

After deploy I'll re-trigger `hikes.scrape_walks`; this unblocks the whole corpus refresh and lets #2785's duration fix finally apply, then I'll confirm the four multi-day routes drop to realistic hours.

(Unchanged pre-existing `getLogger("hikes")` semgrep finding not touched; CI semgrep is diff-aware.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)