### PR TITLE
fix(hikes): dedupe scraped walks by uuid before upsert

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.44.1
+version: 0.44.2
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.44.1
+      targetRevision: 0.44.2
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.201.1
+version: 0.201.2
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.201.1
+      targetRevision: 0.201.2
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/hikes/jobs.py
+++ b/projects/monolith/hikes/jobs.py
@@ -29,54 +29,71 @@ SCRAPE_TIMEOUT_SECS = 30.0
 FORECAST_TIMEOUT_SECS = 30.0
 
 
-def _persist_walks(walks: list[ScrapedWalk]) -> tuple[int, int]:
-    """Upsert scraped walks in a fresh session. Returns (new, updated).
+def _upsert_walks(session: Session, walks: list[ScrapedWalk]) -> tuple[int, int]:
+    """Upsert scraped walks into ``session`` (no commit). Returns (new, updated).
 
-    Upserts only the scraped columns plus scraped_at; the typed walk_hours
-    rows belong to the forecast job and are never touched here. Runs off the
-    event loop via asyncio.to_thread.
+    Dedupes the batch by uuid first: two walk pages can share a trailhead
+    coordinate, and the uuid is uuid5 of "lat,lon", so the scraped list may carry
+    duplicate uuids. Without deduping, two not-yet-persisted rows with the same
+    uuid both take the insert path and the batch INSERT trips ``walks_pkey``,
+    rolling back the entire upsert (which is exactly how the corpus stayed frozen
+    once scraping started succeeding again). Last occurrence wins.
+
+    Upserts only the scraped columns plus scraped_at; the typed walk_hours rows
+    belong to the forecast job and are never touched here. Takes an explicit
+    session so the SQLite create_all fixtures can drive it.
+    """
+    now = datetime.now(timezone.utc)
+    deduped = list({walk.uuid: walk for walk in walks}.values())
+    new_rows: list[models.Walk] = []
+    updated = 0
+    for walk in deduped:
+        existing = session.get(models.Walk, walk.uuid)
+        if existing is None:
+            new_rows.append(
+                models.Walk(
+                    uuid=walk.uuid,
+                    name=walk.name,
+                    url=walk.url,
+                    distance_km=walk.distance_km,
+                    ascent_m=walk.ascent_m,
+                    duration_h=walk.duration_h,
+                    summary=walk.summary,
+                    latitude=walk.latitude,
+                    longitude=walk.longitude,
+                    scraped_at=now,
+                )
+            )
+            continue
+        existing.name = walk.name
+        existing.url = walk.url
+        existing.distance_km = walk.distance_km
+        existing.ascent_m = walk.ascent_m
+        existing.duration_h = walk.duration_h
+        existing.summary = walk.summary
+        existing.latitude = walk.latitude
+        existing.longitude = walk.longitude
+        existing.scraped_at = now
+        updated += 1
+        # Rows fetched via session.get are already tracked; attribute mutations
+        # flush on commit without a session.add in the loop.
+
+    if new_rows:
+        session.add_all(new_rows)
+    return len(new_rows), updated
+
+
+def _persist_walks(walks: list[ScrapedWalk]) -> tuple[int, int]:
+    """Open a fresh session and upsert the scraped walks. Runs off the event
+    loop via asyncio.to_thread (so it must own its session, never the
+    scheduler's). Delegates the testable upsert to ``_upsert_walks``.
     """
     from app.db import get_engine
 
-    now = datetime.now(timezone.utc)
-    new_rows: list[models.Walk] = []
-    updated = 0
     with Session(get_engine()) as session:
-        for walk in walks:
-            existing = session.get(models.Walk, walk.uuid)
-            if existing is None:
-                new_rows.append(
-                    models.Walk(
-                        uuid=walk.uuid,
-                        name=walk.name,
-                        url=walk.url,
-                        distance_km=walk.distance_km,
-                        ascent_m=walk.ascent_m,
-                        duration_h=walk.duration_h,
-                        summary=walk.summary,
-                        latitude=walk.latitude,
-                        longitude=walk.longitude,
-                        scraped_at=now,
-                    )
-                )
-                continue
-            existing.name = walk.name
-            existing.url = walk.url
-            existing.distance_km = walk.distance_km
-            existing.ascent_m = walk.ascent_m
-            existing.duration_h = walk.duration_h
-            existing.summary = walk.summary
-            existing.latitude = walk.latitude
-            existing.longitude = walk.longitude
-            existing.scraped_at = now
-            updated += 1
-            # Rows fetched via session.get are already tracked; attribute
-            # mutations flush on commit without a session.add in the loop.
-
-        if new_rows:
-            session.add_all(new_rows)
+        result = _upsert_walks(session, walks)
         session.commit()
-    return len(new_rows), updated
+    return result
 
 
 async def scrape_walks_handler(session: Session) -> datetime | None:

--- a/projects/monolith/hikes/jobs_test.py
+++ b/projects/monolith/hikes/jobs_test.py
@@ -18,8 +18,25 @@ from sqlmodel import Session, SQLModel, create_engine, select
 from sqlmodel.pool import StaticPool
 
 import hikes.jobs as jobs
-from hikes.models import WalkHour
+from hikes.models import Walk, WalkHour
 from shared.forecast_freshness import top_of_hour
+
+
+def _scraped(uuid, **over):
+    """A scraped Walk (hikes.walkhighlands.Walk == hikes.models.Walk)."""
+    fields = dict(
+        uuid=uuid,
+        name="A Walk",
+        url=f"https://example.invalid/{uuid}.shtml",
+        distance_km=10.0,
+        ascent_m=500,
+        duration_h=4.0,
+        summary="A fine walk.",
+        latitude=57.0,
+        longitude=-4.0,
+    )
+    fields.update(over)
+    return Walk(**fields)
 
 
 @pytest.fixture(name="session")
@@ -158,3 +175,35 @@ def test_prune_elapsed_drops_only_elapsed_hours(session):
 
     remaining = {_utc(r.hour_time) for r in session.exec(select(WalkHour)).all()}
     assert remaining == {current, future}
+
+
+def test_upsert_walks_inserts_new(session):
+    new, updated = jobs._upsert_walks(session, [_scraped("u1"), _scraped("u2")])
+    session.commit()
+    assert (new, updated) == (2, 0)
+    assert {w.uuid for w in session.exec(select(Walk)).all()} == {"u1", "u2"}
+
+
+def test_upsert_walks_updates_existing(session):
+    session.add(_scraped("u1", duration_h=66.0, name="Old"))
+    session.commit()
+    new, updated = jobs._upsert_walks(session, [_scraped("u1", duration_h=18.0)])
+    session.commit()
+    assert (new, updated) == (0, 1)
+    row = session.get(Walk, "u1")
+    assert row.duration_h == 18.0 and row.name == "A Walk"
+
+
+def test_upsert_walks_dedupes_batch_by_uuid(session):
+    # Two walk pages at the same trailhead share uuid5(lat,lon). Both would take
+    # the insert path and trip walks_pkey; dedup keeps the last and the commit
+    # must succeed (the bug that froze the corpus once scraping worked again).
+    new, updated = jobs._upsert_walks(
+        session,
+        [_scraped("dup", duration_h=18.0), _scraped("dup", duration_h=12.0)],
+    )
+    session.commit()  # must not raise UniqueViolation
+    assert (new, updated) == (1, 0)
+    rows = session.exec(select(Walk).where(Walk.uuid == "dup")).all()
+    assert len(rows) == 1
+    assert rows[0].duration_h == 12.0  # last occurrence wins


### PR DESCRIPTION
## Third bug in the chain: the upsert rolls back

After the scraper selector fix (#2788) restored parsing (1950/1987 pages), the re-scrape's persist phase threw:

```
psycopg.errors.UniqueViolation: duplicate key value violates unique constraint "walks_pkey"
ERROR monolith.scheduler: Job hikes.scrape_walks failed
```

The whole upsert transaction rolled back, so **no** walk rows updated and the corpus stayed frozen (durations still 60-66h for the four multi-day routes despite the code fixes).

Cause: two walk pages can share a trailhead coordinate, and a walk's `uuid` is `uuid5(NAMESPACE_URL, "lat,lon")`, so the scraped batch can contain duplicate uuids. Both copies miss the not-yet-flushed row in `session.get` and take the insert path, so `session.add_all` + commit collides on the primary key. This never surfaced before because parsing produced zero walks, so the persist code never ran.

## Fix

Extract a testable `_upsert_walks(session, walks)` core (matching the monolith "sync core takes an explicit session" convention) that **dedupes the batch by uuid** (last occurrence wins) before upserting. `_persist_walks` keeps owning the worker thread's own session and committing.

## Tests

`_upsert_walks` insert / update / dedup-regression (the dedup test commits and asserts no `UniqueViolation`, one row, last-duration-wins).

## Rollout

After deploy I'll re-trigger `hikes.scrape_walks` once more; with all three fixes in place the upsert should finally land and the corpus (durations included) refresh. Then I'll confirm the four routes.

(Unchanged pre-existing `getLogger("hikes")` semgrep finding not touched; CI semgrep is diff-aware.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)