### PR TITLE
feat(monolith): add Qwen test-agent CronWorkflow to validate Argo substrate

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.44.2
+version: 0.45.0
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.44.2
+      targetRevision: 0.45.0
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/app/jobs_main.py
+++ b/projects/monolith/app/jobs_main.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 
 import typer
 
@@ -65,6 +66,64 @@ def worldcup_sim() -> None:
     with Session(get_engine()) as session:
         asyncio.run(refresh_handler(session))
     logger.info("worldcup-sim: done")
+
+
+@app.command("test-agent")
+def test_agent() -> None:
+    """Substrate probe: query recent scheduler activity, ask Qwen to summarize it,
+    and log the result. Zero side effects - this exists only to prove the
+    Argo-CronWorkflow + on-cluster-Qwen path end to end (pod -> DB read -> Qwen
+    inference -> output) before porting real agents off the bespoke orchestrator.
+    """
+    import httpx
+    from sqlmodel import Session, text
+
+    from app.db import get_engine
+
+    configure_logging()
+    logger.info("test-agent: starting")
+
+    # 1. "Query logs": recent scheduler job activity (read-only, DATABASE_URL
+    #    is already wired into the CronWorkflow).
+    with Session(get_engine()) as session:
+        rows = session.execute(
+            text(
+                "SELECT name, last_status, last_run_at FROM scheduler.scheduled_jobs "
+                "ORDER BY last_run_at DESC NULLS LAST LIMIT 15"
+            )
+        ).fetchall()
+    activity = "\n".join(f"- {r[0]}: {r[1]} @ {r[2]}" for r in rows) or "(no jobs)"
+    logger.info("test-agent: read %d scheduler rows", len(rows))
+
+    # 2. Ask the on-cluster Qwen (vLLM, OpenAI-compatible) to summarize.
+    url = os.environ["LLAMA_CPP_URL"].rstrip("/")
+    resp = httpx.post(
+        f"{url}/v1/chat/completions",
+        json={
+            "model": "qwen3.6-27b",
+            "messages": [
+                {"role": "system", "content": "You are a terse SRE assistant."},
+                {
+                    "role": "user",
+                    "content": "In one sentence, summarize this scheduler "
+                    f"activity and flag anything failing:\n{activity}",
+                },
+            ],
+            "max_tokens": int(os.environ.get("MAX_TOKENS", "200")),
+            "temperature": 0,
+        },
+        timeout=120,
+    )
+    resp.raise_for_status()
+    try:
+        summary = resp.json()["choices"][0]["message"]["content"].strip()
+    except (KeyError, IndexError, ValueError) as exc:
+        logger.error("test-agent: unexpected Qwen response shape: %s", exc)
+        raise
+
+    # 3. Log the result (the whole point of the probe).
+    logger.info("test-agent: Qwen says: %s", summary)
+    logger.info("test-agent: done")
 
 
 if __name__ == "__main__":

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.201.2
+version: 0.202.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/templates/cronworkflows.yaml
+++ b/projects/monolith/chart/templates/cronworkflows.yaml
@@ -51,6 +51,10 @@ spec:
                 secretKeyRef:
                   name: {{ $.Values.jobs.dbSecretName }}
                   key: {{ $.Values.jobs.dbSecretKey }}
+            {{- range $k, $v := .env }}
+            - name: {{ $k }}
+              value: {{ $v | quote }}
+            {{- end }}
           {{- with .resources }}
           resources:
             {{- toYaml . | nindent 12 }}

--- a/projects/monolith/chart/templates/deployment.yaml
+++ b/projects/monolith/chart/templates/deployment.yaml
@@ -45,7 +45,7 @@ spec:
             # an entry's suspend:false both activates the CronWorkflow and removes
             # the in-process job - one git change, both sides.
             - name: ARGO_JOBS
-              value: "{{- range .Values.jobs.cronWorkflows }}{{- if not .suspend }}{{ .replaces }},{{- end }}{{- end }}"
+              value: "{{- range .Values.jobs.cronWorkflows }}{{- if and (not .suspend) .replaces }}{{ .replaces }},{{- end }}{{- end }}"
             {{- if .Values.onepassword.enabled }}
             - name: ICAL_FEED_URL
               valueFrom:

--- a/projects/monolith/chart/values.yaml
+++ b/projects/monolith/chart/values.yaml
@@ -46,6 +46,24 @@ jobs:
           memory: 512Mi
         limits:
           memory: 1Gi
+    # Substrate probe: reads recent scheduler activity, asks on-cluster Qwen to
+    # summarize it, logs the result. No `replaces` (net-new, not a cutover) and
+    # suspend=false so it actually runs - this proves the Argo CronWorkflow +
+    # on-cluster-Qwen path end to end before porting real agents onto it.
+    - name: test-agent
+      args: ["test-agent"]
+      schedule: "*/30 * * * *"
+      concurrencyPolicy: Forbid
+      activeDeadlineSeconds: 300
+      suspend: false
+      env:
+        LLAMA_CPP_URL: "http://inference.inference.svc.cluster.local:8080"
+      resources:
+        requests:
+          cpu: 100m
+          memory: 256Mi
+        limits:
+          memory: 512Mi
 
 frontend:
   otelCollectorUrl: ""

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.201.2
+      targetRevision: 0.202.0
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
## What

Adds a `test-agent` jobs subcommand and a non-suspended CronWorkflow that proves the off-pod **Argo CronWorkflow + on-cluster-Qwen** path end to end, before porting the real agent-platform cluster agents onto it.

The agent:
1. Reads recent `scheduler.scheduled_jobs` rows (read-only, via the already-wired `DATABASE_URL`).
2. Asks the on-cluster Qwen (vLLM, OpenAI-compatible `/v1/chat/completions`, model `qwen3.6-27b`) to summarize them and flag failures.
3. Logs the result.

Zero side effects, zero new RBAC, zero blast radius. It is the substrate smoke test.

## Supporting changes

- **`cronworkflows.yaml`**: per-entry literal `env` map support, so a CronWorkflow can inject `LLAMA_CPP_URL` (and future config) alongside the `DATABASE_URL` secretKeyRef.
- **`deployment.yaml`**: `ARGO_JOBS` now skips entries with no `replaces`, so a net-new agent (no in-process counterpart) does not emit a stray trailing comma.

## Safety / no behavior change on merge

- `test-agent` has no `replaces` and `suspend: false` -> it runs net-new; nothing in the in-process scheduler changes.
- `worldcup-sim` stays `suspend: true`; `ARGO_JOBS` renders `""` (verified via `helm template`), so `on_startup_jobs` still registers the in-process worldcup job.
- Both `monolith-workflows` and `inference` are unmeshed (`linkerd.io/inject: disabled`), so the plain-HTTP call to inference needs no mTLS authorization policy.

## Verification plan

After merge + sync: watch a `test-agent-*` Workflow pod in `monolith-workflows` log a Qwen-generated one-line summary of recent scheduler activity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)