### PR TITLE
fix(monolith): render CronWorkflow schedules as v4 list; test-agent @every 30s

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.45.0
+version: 0.45.1
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.45.0
+      targetRevision: 0.45.1
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.202.0
+version: 0.202.1
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/templates/cronworkflows.yaml
+++ b/projects/monolith/chart/templates/cronworkflows.yaml
@@ -23,7 +23,11 @@ metadata:
     {{- include "monolith.labels" $ | nindent 4 }}
     app.kubernetes.io/component: cron-job
 spec:
-  schedule: {{ .schedule | quote }}
+  # Argo Workflows v4 replaced the singular `schedule` string with a `schedules`
+  # list; the v4 controller rejects a bare `schedule` as "must have at least one
+  # schedule" and never fires. Render the single cron expression as a one-item list.
+  schedules:
+    - {{ .schedule | quote }}
   concurrencyPolicy: {{ .concurrencyPolicy | default "Forbid" }}
   suspend: {{ .suspend | default false }}
   startingDeadlineSeconds: {{ .startingDeadlineSeconds | default 30 }}

--- a/projects/monolith/chart/values.yaml
+++ b/projects/monolith/chart/values.yaml
@@ -52,7 +52,12 @@ jobs:
     # on-cluster-Qwen path end to end before porting real agents onto it.
     - name: test-agent
       args: ["test-agent"]
-      schedule: "*/30 * * * *"
+      # @every <duration> (robfig/cron interval form) is how Argo expresses a
+      # sub-minute cadence; standard 5-field cron floors at 1/min. This is a
+      # throwaway substrate probe, so run it hot for fast feedback. Forbid keeps
+      # runs from overlapping if one Qwen call runs long. Dial down or suspend
+      # once the path is proven.
+      schedule: "@every 30s"
       concurrencyPolicy: Forbid
       activeDeadlineSeconds: 300
       suspend: false

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.202.0
+      targetRevision: 0.202.1
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
## Problem

The `test-agent` CronWorkflow's `03:00 UTC` tick never fired despite a healthy `argo-workflows-workflow-controller` (8h uptime), correct RBAC (`cronworkflows` watch + `workflows` create), and a valid-looking manifest. The controller logged, every `cronSyncPeriod` (10s):

```
ERROR "cron workflow must have at least one schedule" conditionType=SpecError cronWorkflow=monolith-workflows/test-agent
```

## Root cause

**Argo Workflows v4 breaking change.** v4 replaced the singular `spec.schedule` string with a `spec.schedules` **list**. The v4.0.6 controller treats a bare `schedule` as "no schedule" and never schedules a run. Our `cronworkflows.yaml` template rendered the old singular form.

Both CronWorkflows the chart produces were affected. `worldcup-sim` masked it behind `suspend: true` (a suspended cron logs the SpecError but nobody waits on it). The non-suspended `test-agent` was the first to expose that no CronWorkflow this chart emits has ever been schedulable. CI/`helm template` couldn't catch it: the manifest is valid YAML and the CRD still accepts `schedule` for back-compat. Only a live v4 controller rejects it.

## Fix

Render the single cron expression as a one-item `schedules` list. Template-only change, so `Chart.yaml` + `application.yaml` are bumped manually to 0.202.1 (no image digest change for chart-version-bot).

## Verification plan

After sync: confirm `test-agent` gets a non-empty `status.lastScheduledTime` and a `test-agent-*` Workflow pod runs, logging a Qwen-generated summary. (Also unblocks the eventual `worldcup-sim` Argo cutover.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)