### PR TITLE
feat(hikes): deep-link the open route card via a ?walk= param

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.45.1
+version: 0.46.0
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.45.1
+      targetRevision: 0.46.0
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.202.1
+version: 0.203.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.202.1
+      targetRevision: 0.203.0
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/lib/public/components/hikes/HikesMap.svelte
+++ b/projects/monolith/frontend/src/lib/public/components/hikes/HikesMap.svelte
@@ -9,10 +9,15 @@
   // `maxima` holds the corpus p95 of duration/ascent/distance, the ceilings the
   // effort score normalizes against (passed in so the colour is stable as the
   // filtered set changes).
+  // `initialUuid` is a deep-linked walk to open on load (from ?walk=); we open
+  // it once the layer is ready and fly to it. `onSelectWalk(uuid|null)` lifts the
+  // open/closed card up to the page so it can mirror the selection to the URL.
   let {
     walks = [],
     selectedDay = null,
     maxima = { duration: 1, ascent: 1, distance: 1 },
+    initialUuid = null,
+    onSelectWalk = () => {},
   } = $props();
 
   // Effort ramp: the universal trail-difficulty convention, green (easy) ->
@@ -80,6 +85,7 @@
 
   async function selectWalk(walk) {
     selected = walk;
+    onSelectWalk(walk.uuid); // lift to the page so it mirrors ?walk=
     selectedDetail = null;
     detailError = false;
     detailLoading = true;
@@ -172,6 +178,7 @@
 
   function closeCard() {
     selected = null;
+    onSelectWalk(null); // clear ?walk= on the page
     selectedDetail = null;
     detailError = false;
     detailLoading = false;
@@ -327,6 +334,23 @@
         });
 
         syncWalks();
+
+        // Deep link (?walk=): open that route's card on load and fly to it so a
+        // shared link lands on the marker. Only if it survived the active
+        // filters (it is in the plotted set / index); otherwise there is no
+        // marker to show. fitToWalks already ran in syncWalks, so override the
+        // frame with a closer view centred on the selected walk.
+        if (initialUuid) {
+          const walk = index.get(initialUuid);
+          if (walk && validLatLon(walk.latitude, walk.longitude)) {
+            selectWalk(walk);
+            map.flyTo({
+              center: [walk.longitude, walk.latitude],
+              zoom: Math.max(map.getZoom(), 9),
+              duration: 0,
+            });
+          }
+        }
       });
 
       cleanup = () => {

--- a/projects/monolith/frontend/src/lib/public/hikes/urlParams.js
+++ b/projects/monolith/frontend/src/lib/public/hikes/urlParams.js
@@ -3,10 +3,11 @@
 // $app imports) so the round-trip is unit-testable in the bare node env.
 //
 // State shape:
-//   { selectedDay: string|null, nearKey: string,
+//   { selectedDay: string|null, selectedWalk: string|null, nearKey: string,
 //     minDuration, maxDuration, minDistance, maxDistance, maxAscent: string }
 // The numeric fields are kept as the same strings the <input> binds to ("" =
-// no constraint), so init and write stay loss-free.
+// no constraint), so init and write stay loss-free. selectedWalk is the open
+// route card's uuid (deep-linkable), or null when no card is open.
 
 // Param names: short and stable. Numeric filters are stored verbatim.
 const NUM_PARAMS = {
@@ -21,6 +22,12 @@ const NUM_PARAMS = {
 // day strip rejects keys that match no walk anyway, so this just guards junk).
 const DAY_RE = /^\d{4}-\d{2}-\d{2}$/;
 
+// A walk uuid (uuid5 of the coordinates). Validated to the canonical 8-4-4-4-12
+// hex shape so a junk `walk` param is ignored; an unknown-but-well-formed uuid
+// just opens no card (the map has no such marker).
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 // A finite, non-negative number (matches the <input type=number min=0> domain).
 function parseNum(raw) {
   if (raw == null || raw === "") return "";
@@ -33,9 +40,11 @@ function parseNum(raw) {
 // (plus the geo sentinel) so a stale/garbage `near` is ignored.
 export function readHikeParams(searchParams, validNearKeys) {
   const rawDay = searchParams.get("day");
+  const rawWalk = searchParams.get("walk");
   const rawNear = searchParams.get("near");
   return {
     selectedDay: rawDay && DAY_RE.test(rawDay) ? rawDay : null,
+    selectedWalk: rawWalk && UUID_RE.test(rawWalk) ? rawWalk : null,
     nearKey: rawNear && validNearKeys.has(rawNear) ? rawNear : "",
     minDuration: parseNum(searchParams.get(NUM_PARAMS.minDuration)),
     maxDuration: parseNum(searchParams.get(NUM_PARAMS.maxDuration)),
@@ -54,6 +63,7 @@ export function writeHikeParams(searchParams, state) {
     else searchParams.delete(key);
   };
   set("day", state.selectedDay);
+  set("walk", state.selectedWalk);
   set("near", state.nearKey);
   for (const [field, key] of Object.entries(NUM_PARAMS)) {
     set(key, state[field]);

--- a/projects/monolith/frontend/src/lib/public/hikes/urlParams.test.js
+++ b/projects/monolith/frontend/src/lib/public/hikes/urlParams.test.js
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import { readHikeParams, writeHikeParams } from "./urlParams.js";
 
 const VALID_NEAR = new Set(["__me__", "fort-william", "cairngorms"]);
+const WALK_UUID = "e4040ab6-3bff-585c-b7cc-37bee42d4999";
 
 function params(query) {
   return new URLSearchParams(query);
@@ -11,6 +12,7 @@ describe("readHikeParams", () => {
   it("defaults everything when no params are present", () => {
     expect(readHikeParams(params(""), VALID_NEAR)).toEqual({
       selectedDay: null,
+      selectedWalk: null,
       nearKey: "",
       minDuration: "",
       maxDuration: "",
@@ -23,12 +25,13 @@ describe("readHikeParams", () => {
   it("reads a full set of valid params", () => {
     const got = readHikeParams(
       params(
-        "day=2026-06-21&near=cairngorms&dmin=2&dmax=6&kmin=5&kmax=20&ascent=800",
+        `day=2026-06-21&walk=${WALK_UUID}&near=cairngorms&dmin=2&dmax=6&kmin=5&kmax=20&ascent=800`,
       ),
       VALID_NEAR,
     );
     expect(got).toEqual({
       selectedDay: "2026-06-21",
+      selectedWalk: WALK_UUID,
       nearKey: "cairngorms",
       minDuration: "2",
       maxDuration: "6",
@@ -51,6 +54,15 @@ describe("readHikeParams", () => {
     expect(got.minDuration).toBe("");
     expect(got.maxDistance).toBe("");
   });
+
+  it("reads a well-formed walk uuid and ignores a malformed one", () => {
+    expect(
+      readHikeParams(params(`walk=${WALK_UUID}`), VALID_NEAR).selectedWalk,
+    ).toBe(WALK_UUID);
+    expect(
+      readHikeParams(params("walk=not-a-uuid"), VALID_NEAR).selectedWalk,
+    ).toBeNull();
+  });
 });
 
 describe("writeHikeParams", () => {
@@ -58,6 +70,7 @@ describe("writeHikeParams", () => {
     const sp = params("");
     writeHikeParams(sp, {
       selectedDay: null,
+      selectedWalk: null,
       nearKey: "",
       minDuration: "",
       maxDuration: "",
@@ -72,6 +85,7 @@ describe("writeHikeParams", () => {
     const sp = params("");
     writeHikeParams(sp, {
       selectedDay: "2026-06-21",
+      selectedWalk: WALK_UUID,
       nearKey: "skye",
       minDuration: "",
       maxDuration: "4",
@@ -80,6 +94,7 @@ describe("writeHikeParams", () => {
       maxAscent: "",
     });
     expect(sp.get("day")).toBe("2026-06-21");
+    expect(sp.get("walk")).toBe(WALK_UUID);
     expect(sp.get("near")).toBe("skye");
     expect(sp.get("dmax")).toBe("4");
     expect(sp.has("dmin")).toBe(false);
@@ -89,6 +104,7 @@ describe("writeHikeParams", () => {
   it("round-trips through read", () => {
     const state = {
       selectedDay: "2026-07-01",
+      selectedWalk: WALK_UUID,
       nearKey: "fort-william",
       minDuration: "1.5",
       maxDuration: "",
@@ -101,10 +117,11 @@ describe("writeHikeParams", () => {
     expect(readHikeParams(sp, VALID_NEAR)).toEqual(state);
   });
 
-  it("clears a param that returns to default", () => {
-    const sp = params("day=2026-06-21&near=cairngorms");
+  it("clears the walk param when the card closes", () => {
+    const sp = params(`walk=${WALK_UUID}&near=cairngorms`);
     writeHikeParams(sp, {
       selectedDay: null,
+      selectedWalk: null,
       nearKey: "cairngorms",
       minDuration: "",
       maxDuration: "",
@@ -112,7 +129,7 @@ describe("writeHikeParams", () => {
       maxDistance: "",
       maxAscent: "",
     });
-    expect(sp.has("day")).toBe(false);
+    expect(sp.has("walk")).toBe(false);
     expect(sp.get("near")).toBe("cairngorms");
   });
 });

--- a/projects/monolith/frontend/src/routes/public/app/hikes/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/hikes/+page.svelte
@@ -77,6 +77,14 @@
   const DATE_HORIZON = 7;
   let selectedDay = $state(initial.selectedDay);
 
+  // The open route card's walk uuid, mirrored to ?walk= so a specific hike is
+  // deep-linkable. HikesMap owns the live card; it calls onSelectWalk on
+  // open/close to keep this in sync, and opens initial.selectedWalk on load.
+  let selectedWalkUuid = $state(initial.selectedWalk);
+  function handleSelectWalk(uuid) {
+    selectedWalkUuid = uuid;
+  }
+
   // "Near" filter: a preset hub key, GEO_SENTINEL for the device location, or
   // "" for off. userCoords resolves async once the browser grants permission.
   let nearKey = $state(initial.nearKey);
@@ -246,6 +254,7 @@
     const url = new URL($page.url);
     writeHikeParams(url.searchParams, {
       selectedDay,
+      selectedWalk: selectedWalkUuid,
       nearKey,
       minDuration,
       maxDuration,
@@ -290,7 +299,13 @@
 <div class="hikes-page">
   <h1 class="sr-only">Hike planner, Scotland walks by weather window</h1>
 
-  <HikesMap walks={filtered} {selectedDay} {maxima} />
+  <HikesMap
+    walks={filtered}
+    {selectedDay}
+    {maxima}
+    initialUuid={initial.selectedWalk}
+    onSelectWalk={handleSelectWalk}
+  />
 
   <!-- Floating controls: day chips always visible, the rest expands on demand. -->
   <div class="controls">


### PR DESCRIPTION
## Ask

The day/region/numeric filters round-trip through the URL, but the open route card lived only as internal `HikesMap` state, so a specific hike wasn't shareable or restorable on reload. Add a `?walk=<uuid>` param alongside `?day=`.

## Approach

Mirrors how `selectedDay` works (page-owned, replaceState-synced), using a callback + initial-value flow rather than full two-way control to avoid an `$effect`/URL feedback loop:

- The page owns `selectedWalkUuid` (init from `?walk=`, written back via the existing URL `$effect`).
- `HikesMap` stays the owner of the live card: it calls `onSelectWalk(uuid|null)` on open/close so the page mirrors the URL, and accepts `initialUuid` which it opens **once** on map load, flying to the marker so a shared link lands on it.
- A walk filtered out of the current set doesn't open (consistent: its marker isn't on the map either). The uuid is validated to the canonical 8-4-4-4-12 shape so a junk param is ignored.

Like the day chip, selection uses replaceState (no history spam; back-button won't reopen) for consistency.

## Tests

`urlParams.test.js`: read valid/malformed walk uuid, write + round-trip, clear-on-close, plus the existing assertions updated for the new `selectedWalk` field.

## Scope / visual regression

`urlParams.js` + the page + `HikesMap`. No backend change. The visual harness loads `/app/hikes` with no `?walk=`, so no card opens on load and the baseline is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)