### PR TITLE
fix(monolith): disable Qwen thinking in test-agent so content is non-null

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.46.0
+version: 0.46.1
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.46.0
+      targetRevision: 0.46.1
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/app/jobs_main.py
+++ b/projects/monolith/app/jobs_main.py
@@ -111,15 +111,23 @@ def test_agent() -> None:
             ],
             "max_tokens": int(os.environ.get("MAX_TOKENS", "200")),
             "temperature": 0,
+            # qwen3.6 is a thinking model: left on, it spends the whole
+            # max_tokens budget on <think> reasoning and returns content=null
+            # (the reasoning lands in reasoning_content). Disable it so the
+            # tokens produce the summary, matching chat/vision.py.
+            "chat_template_kwargs": {"enable_thinking": False},
         },
         timeout=120,
     )
     resp.raise_for_status()
     try:
-        summary = resp.json()["choices"][0]["message"]["content"].strip()
-    except (KeyError, IndexError, ValueError) as exc:
+        content = resp.json()["choices"][0]["message"]["content"]
+    except (KeyError, IndexError) as exc:
         logger.error("test-agent: unexpected Qwen response shape: %s", exc)
         raise
+    if not content:
+        raise ValueError("test-agent: Qwen returned empty content")
+    summary = content.strip()
 
     # 3. Log the result (the whole point of the probe).
     logger.info("test-agent: Qwen says: %s", summary)

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.203.0
+version: 0.203.1
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.203.0
+      targetRevision: 0.203.1
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
## What happened

With the `schedules` list fix deployed, the `test-agent` CronWorkflow fired on schedule, the pod read 15 scheduler rows, and reached Qwen with a 200 OK. But the run failed:

```
AttributeError: 'NoneType' object has no attribute 'strip'
  summary = resp.json()["choices"][0]["message"]["content"].strip()
```

`message.content` was `null`.

## Root cause

`qwen3.6-27b` is a thinking model. Left on, it spends the entire `max_tokens=200` budget on `<think>` reasoning tokens (which vLLM returns in `reasoning_content`) and emits `content: null`.

## Fix

- Add `"chat_template_kwargs": {"enable_thinking": False}` so the token budget produces the summary, not reasoning. This is the same fix `chat/vision.py` already uses.
- Guard the empty-content case: extract `content` first and raise a clear `ValueError` if falsy, instead of an `AttributeError` on `None.strip()`.

Jobs-image source change, so `chart-version-bot` auto-bumps the chart (no manual version edit).

## Verification

After sync, the 30s test-agent run should reach `Succeeded` and log `test-agent: Qwen says: <one-line summary>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)