### PR TITLE
chore(monolith): remove test-agent Qwen substrate probe now that it is proven

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.46.1
+version: 0.46.2
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.46.1
+      targetRevision: 0.46.2
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/app/jobs_main.py
+++ b/projects/monolith/app/jobs_main.py
@@ -21,7 +21,6 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import os
 
 import typer
 
@@ -66,72 +65,6 @@ def worldcup_sim() -> None:
     with Session(get_engine()) as session:
         asyncio.run(refresh_handler(session))
     logger.info("worldcup-sim: done")
-
-
-@app.command("test-agent")
-def test_agent() -> None:
-    """Substrate probe: query recent scheduler activity, ask Qwen to summarize it,
-    and log the result. Zero side effects - this exists only to prove the
-    Argo-CronWorkflow + on-cluster-Qwen path end to end (pod -> DB read -> Qwen
-    inference -> output) before porting real agents off the bespoke orchestrator.
-    """
-    import httpx
-    from sqlmodel import Session, text
-
-    from app.db import get_engine
-
-    configure_logging()
-    logger.info("test-agent: starting")
-
-    # 1. "Query logs": recent scheduler job activity (read-only, DATABASE_URL
-    #    is already wired into the CronWorkflow).
-    with Session(get_engine()) as session:
-        rows = session.execute(
-            text(
-                "SELECT name, last_status, last_run_at FROM scheduler.scheduled_jobs "
-                "ORDER BY last_run_at DESC NULLS LAST LIMIT 15"
-            )
-        ).fetchall()
-    activity = "\n".join(f"- {r[0]}: {r[1]} @ {r[2]}" for r in rows) or "(no jobs)"
-    logger.info("test-agent: read %d scheduler rows", len(rows))
-
-    # 2. Ask the on-cluster Qwen (vLLM, OpenAI-compatible) to summarize.
-    url = os.environ["LLAMA_CPP_URL"].rstrip("/")
-    resp = httpx.post(
-        f"{url}/v1/chat/completions",
-        json={
-            "model": "qwen3.6-27b",
-            "messages": [
-                {"role": "system", "content": "You are a terse SRE assistant."},
-                {
-                    "role": "user",
-                    "content": "In one sentence, summarize this scheduler "
-                    f"activity and flag anything failing:\n{activity}",
-                },
-            ],
-            "max_tokens": int(os.environ.get("MAX_TOKENS", "200")),
-            "temperature": 0,
-            # qwen3.6 is a thinking model: left on, it spends the whole
-            # max_tokens budget on <think> reasoning and returns content=null
-            # (the reasoning lands in reasoning_content). Disable it so the
-            # tokens produce the summary, matching chat/vision.py.
-            "chat_template_kwargs": {"enable_thinking": False},
-        },
-        timeout=120,
-    )
-    resp.raise_for_status()
-    try:
-        content = resp.json()["choices"][0]["message"]["content"]
-    except (KeyError, IndexError) as exc:
-        logger.error("test-agent: unexpected Qwen response shape: %s", exc)
-        raise
-    if not content:
-        raise ValueError("test-agent: Qwen returned empty content")
-    summary = content.strip()
-
-    # 3. Log the result (the whole point of the probe).
-    logger.info("test-agent: Qwen says: %s", summary)
-    logger.info("test-agent: done")
 
 
 if __name__ == "__main__":

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.203.1
+version: 0.203.2
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/values.yaml
+++ b/projects/monolith/chart/values.yaml
@@ -46,29 +46,6 @@ jobs:
           memory: 512Mi
         limits:
           memory: 1Gi
-    # Substrate probe: reads recent scheduler activity, asks on-cluster Qwen to
-    # summarize it, logs the result. No `replaces` (net-new, not a cutover) and
-    # suspend=false so it actually runs - this proves the Argo CronWorkflow +
-    # on-cluster-Qwen path end to end before porting real agents onto it.
-    - name: test-agent
-      args: ["test-agent"]
-      # @every <duration> (robfig/cron interval form) is how Argo expresses a
-      # sub-minute cadence; standard 5-field cron floors at 1/min. This is a
-      # throwaway substrate probe, so run it hot for fast feedback. Forbid keeps
-      # runs from overlapping if one Qwen call runs long. Dial down or suspend
-      # once the path is proven.
-      schedule: "@every 30s"
-      concurrencyPolicy: Forbid
-      activeDeadlineSeconds: 300
-      suspend: false
-      env:
-        LLAMA_CPP_URL: "http://inference.inference.svc.cluster.local:8080"
-      resources:
-        requests:
-          cpu: 100m
-          memory: 256Mi
-        limits:
-          memory: 512Mi
 
 frontend:
   otelCollectorUrl: ""

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.203.1
+      targetRevision: 0.203.2
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
## What

Removes the throwaway `test-agent` CronWorkflow probe. It validated the full off-pod path end to end (Argo `@every 30s` -> ephemeral pod -> Kyverno-cloned-secret DB read -> in-cluster Qwen inference -> logged summary, `Succeeded`), so it has served its purpose and no longer needs to run every 30s.

Drops:
- the `test-agent` `jobs_main.py` subcommand (and its now-unused `os` import)
- the `test-agent` entry in `chart/values.yaml` `jobs.cronWorkflows`

## Kept on purpose

The two generic chart improvements the probe introduced stay, since the upcoming `agent_platform` cluster-agent cutover needs exactly them:
- per-entry literal `env` map support in `cronworkflows.yaml` (for `LLAMA_CPP_URL` and friends)
- the `ARGO_JOBS` net-new guard `and (not .suspend) .replaces` (net-new agents have no in-process `replaces`)

## Effect on merge

`helm template` confirms only `worldcup-sim` (still `suspend: true`) renders, and `ARGO_JOBS` stays `""`. After sync, ArgoCD prunes the `test-agent` CronWorkflow from `monolith-workflows`. Jobs-image source change, so `chart-version-bot` auto-bumps the chart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)