### PR TITLE
feat(monolith): cut worldcup.refresh over to Argo CronWorkflow

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.46.2
+version: 0.47.0
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.46.2
+      targetRevision: 0.47.0
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.203.2
+version: 0.203.3
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/values.yaml
+++ b/projects/monolith/chart/values.yaml
@@ -39,7 +39,7 @@ jobs:
       schedule: "*/30 * * * *"
       concurrencyPolicy: Forbid
       activeDeadlineSeconds: 600
-      suspend: true # flip to false to cut worldcup.refresh over to Argo
+      suspend: false # worldcup.refresh cut over to Argo 2026-06-22
       resources:
         requests:
           cpu: 250m

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.203.2
+      targetRevision: 0.203.3
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
## First real job cutover

Flips `worldcup-sim` `suspend: true -> false`. Via the one-flag mechanism this:
- unsuspends the CronWorkflow (Argo schedules it `*/30 * * * *` in `monolith-workflows`)
- adds `worldcup.refresh` to the deployment `ARGO_JOBS` env, so `scheduler.argo_handled()` makes `on_startup_jobs` skip the in-process registration

Net: the Monte Carlo refresh moves off the API pod into an ephemeral job pod.

`helm template` confirms both sides: CronWorkflow `suspend: false` and `ARGO_JOBS="worldcup.refresh,"`.

## Validation loop (post-merge)

1. Sync, wait for CronWorkflow `suspend=false` + monolith pod rollout carrying `ARGO_JOBS=worldcup.refresh`
2. Confirm the in-process `worldcup.refresh` job is no longer registered
3. Manually trigger one Workflow from the CronWorkflow
4. Monitor: Workflow `Succeeded` AND `worldcup.qualification.computed_at` advances past the pre-cutover baseline `2026-06-22 03:07:36`

Values+template change (no image digest), so Chart.yaml + application.yaml bumped manually to 0.203.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)