### PR TITLE
feat(monolith): cut knowledge.layout over to Argo CronWorkflow

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.47.0
+version: 0.48.0
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.47.0
+      targetRevision: 0.48.0
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/app/jobs_main.py
+++ b/projects/monolith/app/jobs_main.py
@@ -67,5 +67,27 @@ def worldcup_sim() -> None:
     logger.info("worldcup-sim: done")
 
 
+@app.command("knowledge-layout")
+def knowledge_layout() -> None:
+    """Recompute knowledge-graph node positions as a one-shot.
+
+    Runs the full-graph + public FA2 layout passes (CPU-bound, dispatched to a
+    worker thread inside the handler). One-shot form of the ``knowledge.layout``
+    scheduled job; opens its own session to mirror the scheduler's handler
+    contract. The handler swallows per-pass exceptions and logs them, so a
+    silent layout failure still exits 0 - check the ``pass succeeded`` log line.
+    """
+    from sqlmodel import Session
+
+    from app.db import get_engine
+    from knowledge.service import layout_handler
+
+    configure_logging()
+    logger.info("knowledge-layout: starting")
+    with Session(get_engine()) as session:
+        asyncio.run(layout_handler(session))
+    logger.info("knowledge-layout: done")
+
+
 if __name__ == "__main__":
     app()

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.203.3
+version: 0.204.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/values.yaml
+++ b/projects/monolith/chart/values.yaml
@@ -46,6 +46,24 @@ jobs:
           memory: 512Mi
         limits:
           memory: 1Gi
+    # knowledge.layout: FA2 graph layout, the heaviest in-process job (3.12GiB
+    # peak). Cutting it off the API pod is what unblocks shrinking monolith
+    # 4Gi -> ~1Gi. Schedule matches the in-process 5-min cadence; Forbid so a
+    # slow layout never overlaps. memory request==limit at 4Gi (repo convention)
+    # to cover the peak; CPU-bound so a generous CPU request, no CPU limit.
+    - name: knowledge-layout
+      replaces: knowledge.layout
+      args: ["knowledge-layout"]
+      schedule: "*/5 * * * *"
+      concurrencyPolicy: Forbid
+      activeDeadlineSeconds: 600
+      suspend: false
+      resources:
+        requests:
+          cpu: "2"
+          memory: 4Gi
+        limits:
+          memory: 4Gi
 
 frontend:
   otelCollectorUrl: ""

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.203.3
+      targetRevision: 0.204.0
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
## Cutover #2: the heavy one

`knowledge.layout` is the heaviest in-process scheduler job: FA2 graph layout, **3.12GiB peak, `heavy=True`**. Keeping it on the API pod is what forces the 4Gi pod sizing. Moving it to an ephemeral `monolith-workflows` pod is the prerequisite for shrinking the monolith pods (4Gi -> ~1Gi x3 + PodDisruptionBudget).

Adds:
- `knowledge-layout` `jobs_main` subcommand (one-shot of `layout_handler`)
- a `cronWorkflows` entry: `replaces: knowledge.layout`, `*/5` (matches in-process cadence), `Forbid`, **4Gi request==limit** (covers the peak), **cpu:2 request, no cpu limit** (CPU-bound FA2)

Via the one-flag mechanism `ARGO_JOBS` gains `knowledge.layout`, so `on_startup_jobs` skips the in-process registration. `helm template` confirms both CronWorkflows `suspend: false` and `ARGO_JOBS="worldcup.refresh,knowledge.layout,"`. Source change, so chart-version-bot auto-bumps.

## Validation note

`layout_handler` swallows per-pass exceptions internally and always returns, so a **silent layout failure still exits 0**. Validation checks the `knowledge.layout: pass succeeded ... positioned=N` log line, not just Workflow phase.

## Validation loop (post-merge)

1. Sync, wait for the `knowledge-layout` CronWorkflow + monolith pod rollout with the new `ARGO_JOBS`
2. Confirm in-process `knowledge.layout` deregistered
3. Manually trigger one Workflow
4. Monitor: `Succeeded` AND both `pass succeeded` log lines with `positioned > 0`

Follow-up worth considering: now that it is isolated, relax the `*/5` cadence (graph-layout freshness is not latency-critical) to cut pod churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)