### PR TITLE
chore(monolith): run knowledge-layout weekly, drop cpu request to 1

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.48.0
+version: 0.48.1
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.48.0
+      targetRevision: 0.48.1
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.204.0
+version: 0.204.1
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/values.yaml
+++ b/projects/monolith/chart/values.yaml
@@ -46,21 +46,26 @@ jobs:
           memory: 512Mi
         limits:
           memory: 1Gi
-    # knowledge.layout: FA2 graph layout, the heaviest in-process job (3.12GiB
-    # peak). Cutting it off the API pod is what unblocks shrinking monolith
-    # 4Gi -> ~1Gi. Schedule matches the in-process 5-min cadence; Forbid so a
-    # slow layout never overlaps. memory request==limit at 4Gi (repo convention)
-    # to cover the peak; CPU-bound so a generous CPU request, no CPU limit.
+    # knowledge.layout: FA2 graph layout, ~2.7GiB peak / 1 core / ~3 min,
+    # measured live. It recomputes the WHOLE graph every run with no
+    # change-detection, but the graph (notes + links) is static for days at a
+    # time (e.g. 0 note changes in 24h, 36 in 7d), so a 5-min cadence meant
+    # ~860 identical recomputes over 3 days. Run it WEEKLY instead: a
+    # change-gate would still have to reserve the memory and spin a pod every
+    # tick, so cutting the cadence is the cleaner win. Trigger a one-off
+    # Workflow by hand after a bulk note import if an immediate relayout is
+    # needed. Forbid so a slow layout never overlaps; 4Gi request==limit covers
+    # the 2.7GiB peak with growth headroom; cpu:1 (single-threaded FA2).
     - name: knowledge-layout
       replaces: knowledge.layout
       args: ["knowledge-layout"]
-      schedule: "*/5 * * * *"
+      schedule: "0 4 * * 0" # weekly, Sunday 04:00 UTC
       concurrencyPolicy: Forbid
       activeDeadlineSeconds: 600
       suspend: false
       resources:
         requests:
-          cpu: "2"
+          cpu: "1"
           memory: 4Gi
         limits:
           memory: 4Gi

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.204.0
+      targetRevision: 0.204.1
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
## Why

Live measurement of the freshly-cut-over `knowledge.layout` Argo job surfaced that it was doing almost pure waste:

```
peak memory:   ~2.7GiB    (1 sample; pod requested 4Gi)
cpu:           ~1.00 core (pegged the whole run, single-threaded FA2)
runtime:       ~3 min
graph changes: 0 notes in 24h, 36 in 7d, max(updated_at) = 3 days ago
```

`_run_layout_pass` recomputes the **entire** FA2 layout every run with no change-detection (it only warm-starts from prior positions). With the graph static for days, the `*/5` cadence meant ~860 identical recomputations over 3 days, each reserving a 4Gi/1-core pod for ~3 min.

## Decision: cut the cadence, not add a gate

A change-detection gate would still have to **reserve the memory** (the pod request is sized for the real run) and **spin a pod every tick** - so it saves CPU compute but not the resource reservation or pod churn. Running it **weekly** (Sunday 04:00 UTC) sidesteps both. The graph is static for days, so weekly freshness is ample; trigger a one-off Workflow by hand after a bulk note import if an immediate relayout is needed.

Also drops the CPU request `2 -> 1` (the 2nd core was never used).

Values-only change, so Chart.yaml + application.yaml bumped manually to 0.204.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)