### PR TITLE
feat(monolith): cut observability.topology_rollup over to Argo CronWorkflow

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.48.1
+version: 0.49.0
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.48.1
+      targetRevision: 0.49.0
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/app/jobs_main.py
+++ b/projects/monolith/app/jobs_main.py
@@ -89,5 +89,24 @@ def knowledge_layout() -> None:
     logger.info("knowledge-layout: done")
 
 
+@app.command("observability-topology-rollup")
+def observability_topology_rollup() -> None:
+    """Build the service-topology payload from ClickHouse and snapshot it to
+    Postgres as a one-shot.
+
+    One-shot form of the ``observability.topology_rollup`` scheduled job. Unlike
+    the other handlers it takes no session (it opens its own inside the
+    snapshot writer), so there is no Session wrapper here. Needs CLICKHOUSE_URL
+    plus the CLICKHOUSE_USER / CLICKHOUSE_PASSWORD secret env (cloned into
+    monolith-workflows); without them build_topology returns an empty payload.
+    """
+    from home.observability.rollup import topology_rollup
+
+    configure_logging()
+    logger.info("observability-topology-rollup: starting")
+    asyncio.run(topology_rollup())
+    logger.info("observability-topology-rollup: done")
+
+
 if __name__ == "__main__":
     app()

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.204.1
+version: 0.205.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/templates/cronworkflows.yaml
+++ b/projects/monolith/chart/templates/cronworkflows.yaml
@@ -59,6 +59,13 @@ spec:
             - name: {{ $k }}
               value: {{ $v | quote }}
             {{- end }}
+            {{- range $name, $ref := .secretEnv }}
+            - name: {{ $name }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $ref.secretName }}
+                  key: {{ $ref.key }}
+            {{- end }}
           {{- with .resources }}
           resources:
             {{- toYaml . | nindent 12 }}

--- a/projects/monolith/chart/values.yaml
+++ b/projects/monolith/chart/values.yaml
@@ -69,6 +69,34 @@ jobs:
           memory: 4Gi
         limits:
           memory: 4Gi
+    # observability.topology_rollup: queries ClickHouse for the service-topology
+    # graph and snapshots it to Postgres (observability.topology_snapshot, single
+    # upsert row). Light footprint (heavy=True is for serialization, not memory).
+    # First job needing ClickHouse: CLICKHOUSE_URL is a plain in-cluster svc URL
+    # (literal env), USER/PASSWORD come from the monolith-clickhouse Secret cloned
+    # into monolith-workflows by Kyverno. */15 matches the 900s in-process cadence.
+    - name: observability-topology-rollup
+      replaces: observability.topology_rollup
+      args: ["observability-topology-rollup"]
+      schedule: "*/15 * * * *"
+      concurrencyPolicy: Forbid
+      activeDeadlineSeconds: 300
+      suspend: false
+      env:
+        CLICKHOUSE_URL: "http://chi-signoz-clickhouse-cluster-0-0.signoz.svc.cluster.local:8123"
+      secretEnv:
+        CLICKHOUSE_USER:
+          secretName: monolith-clickhouse
+          key: USER
+        CLICKHOUSE_PASSWORD:
+          secretName: monolith-clickhouse
+          key: PASSWORD
+      resources:
+        requests:
+          cpu: 250m
+          memory: 512Mi
+        limits:
+          memory: 512Mi
 
 frontend:
   otelCollectorUrl: ""

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.204.1
+      targetRevision: 0.205.0
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/platform/kyverno/templates/clone-monolith-pg-secret-policy.yaml
+++ b/projects/platform/kyverno/templates/clone-monolith-pg-secret-policy.yaml
@@ -44,6 +44,27 @@ spec:
         clone:
           namespace: monolith
           name: monolith-pg-app
+    # The observability.topology_rollup CronWorkflow queries ClickHouse; clone
+    # the 1Password-backed monolith-clickhouse Secret (USER/PASSWORD) into
+    # monolith-workflows the same way so the job pod can authenticate.
+    - name: clone-clickhouse-to-monolith-workflows
+      match:
+        any:
+          - resources:
+              kinds:
+                - Namespace
+              names:
+                - monolith-workflows
+      generate:
+        apiVersion: v1
+        kind: Secret
+        name: monolith-clickhouse
+        namespace: monolith-workflows
+        synchronize: true
+        generateExisting: true
+        clone:
+          namespace: monolith
+          name: monolith-clickhouse
 ---
 # Kyverno 3.x restricts both controllers' Secret access by default. The
 # BACKGROUND controller does the actual clone (needs get/list/watch on the


### PR DESCRIPTION
## Cutover #3: the last heavy=True job

Moves the `observability.topology_rollup` (ClickHouse -> Postgres topology snapshot) off the API pod. `heavy=True` here is for serialization, not footprint (fixed node/edge query + one snapshot upsert), so this is cleanup, not a pod-shrink blocker (knowledge.layout already unblocked the shrink).

## Reusable plumbing (first job needing creds beyond DATABASE_URL)

- **`cronworkflows.yaml`**: per-entry `secretEnv` map -> `secretKeyRef` env, alongside the existing literal `env` map. Future credentialed jobs (e.g. `stats_rollup`) reuse this.
- **kyverno**: clone the 1Password-backed `monolith-clickhouse` Secret (USER/PASSWORD) into `monolith-workflows`, same pattern as `monolith-pg-app`. Added a **second generate rule** rather than renaming the policy, to avoid pruning the live `monolith-pg-app` clone (which would gap DATABASE_URL). Existing ClusterRoles already cover all Secrets, so no RBAC change.
- **`jobs_main.py`**: `observability-topology-rollup` subcommand (the handler takes no session, opens its own).
- **`values.yaml`**: entry with `CLICKHOUSE_URL` literal env + USER/PASSWORD `secretEnv`, `*/15` (matches the 900s in-process cadence), 512Mi.

## Pre-flight verified

ClickHouse (signoz ns) is **unmeshed** with no Linkerd `Server`/authz, so the unmeshed job reaches it over plain HTTP + basic auth (same as monolith-pg / inference). `helm template` confirms the three ClickHouse env vars render and `ARGO_JOBS="worldcup.refresh,knowledge.layout,observability.topology_rollup,"`.

## Validation loop (post-merge)

1. Sync, wait for the CronWorkflow + monolith pod rollout + the cloned `monolith-clickhouse` secret in `monolith-workflows`
2. Manually trigger one Workflow
3. Monitor: `Succeeded`, `Topology snapshot refreshed (N nodes)` log with N>0, and `observability.topology_snapshot.snapshot_at` advances

🤖 Generated with [Claude Code](https://claude.com/claude-code)