### PR TITLE
feat(monolith): manual-only Argo jobs for scrape_walks + load_climatology

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.49.0
+version: 0.50.0
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.49.0
+      targetRevision: 0.50.0
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/app/jobs_main.py
+++ b/projects/monolith/app/jobs_main.py
@@ -108,5 +108,46 @@ def observability_topology_rollup() -> None:
     logger.info("observability-topology-rollup: done")
 
 
+@app.command("hikes-scrape-walks")
+def hikes_scrape_walks() -> None:
+    """Run the full WalkHighlands corpus scrape as a one-shot.
+
+    One-shot form of the ``hikes.scrape_walks`` job. The corpus barely changes
+    and a full scrape can take a couple of hours, so the CronWorkflow ships
+    suspended (manual-only): trigger this by hand when the corpus needs a
+    refresh.
+    """
+    from sqlmodel import Session
+
+    from app.db import get_engine
+    from hikes.jobs import scrape_walks_handler
+
+    configure_logging()
+    logger.info("hikes-scrape-walks: starting")
+    with Session(get_engine()) as session:
+        asyncio.run(scrape_walks_handler(session))
+    logger.info("hikes-scrape-walks: done")
+
+
+@app.command("stars-load-climatology")
+def stars_load_climatology() -> None:
+    """Wholesale-reload the stars climatology table from the S3 backfill.
+
+    One-shot form of the ``stars.load_climatology`` job. The source is a static
+    annual CERRA/ERA5 backfill, so the CronWorkflow ships suspended
+    (manual-only): trigger this by hand after the backfill is regenerated.
+    """
+    from sqlmodel import Session
+
+    from app.db import get_engine
+    from stars.grid import load_climatology_handler
+
+    configure_logging()
+    logger.info("stars-load-climatology: starting")
+    with Session(get_engine()) as session:
+        asyncio.run(load_climatology_handler(session))
+    logger.info("stars-load-climatology: done")
+
+
 if __name__ == "__main__":
     app()

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.205.0
+version: 0.206.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/templates/cronworkflows.yaml
+++ b/projects/monolith/chart/templates/cronworkflows.yaml
@@ -66,6 +66,17 @@ spec:
                   name: {{ $ref.secretName }}
                   key: {{ $ref.key }}
             {{- end }}
+            {{- if .s3 }}
+            # Shared SeaweedFS S3 endpoint + creds (sourced from the stars block,
+            # which always sets them; creds are the cluster's dummy duckdb pair).
+            # Bucket/key env stay per-entry since they differ by job.
+            - name: SEAWEEDFS_S3_ENDPOINT
+              value: {{ $.Values.stars.seaweedfsS3Endpoint | quote }}
+            - name: S3_ACCESS_KEY_ID
+              value: {{ $.Values.stars.s3AccessKeyId | quote }}
+            - name: S3_SECRET_ACCESS_KEY
+              value: {{ $.Values.stars.s3SecretAccessKey | quote }}
+            {{- end }}
           {{- with .resources }}
           resources:
             {{- toYaml . | nindent 12 }}

--- a/projects/monolith/chart/templates/deployment.yaml
+++ b/projects/monolith/chart/templates/deployment.yaml
@@ -39,13 +39,15 @@ spec:
                 secretKeyRef:
                   name: {{ include "monolith.fullname" . }}-pg-app
                   key: uri
-            # Jobs that an ACTIVE (non-suspended) Argo CronWorkflow now owns;
-            # on_startup_jobs skips registering these in-process so they don't
-            # run in both places. Derived from the cronWorkflows list, so flipping
-            # an entry's suspend:false both activates the CronWorkflow and removes
-            # the in-process job - one git change, both sides.
+            # Jobs an Argo CronWorkflow now owns; on_startup_jobs skips
+            # registering these in-process so they never run in both places.
+            # Membership is driven by `replaces` alone, NOT suspend: `replaces`
+            # means "Argo owns this job", while `suspend` only controls whether
+            # the CronWorkflow auto-runs on its schedule. That lets an entry be
+            # manual-only (replaces + suspend:true): in-process off, no auto-run,
+            # still submittable by hand.
             - name: ARGO_JOBS
-              value: "{{- range .Values.jobs.cronWorkflows }}{{- if and (not .suspend) .replaces }}{{ .replaces }},{{- end }}{{- end }}"
+              value: "{{- range .Values.jobs.cronWorkflows }}{{- if .replaces }}{{ .replaces }},{{- end }}{{- end }}"
             {{- if .Values.onepassword.enabled }}
             - name: ICAL_FEED_URL
               valueFrom:

--- a/projects/monolith/chart/values.yaml
+++ b/projects/monolith/chart/values.yaml
@@ -97,6 +97,44 @@ jobs:
           memory: 512Mi
         limits:
           memory: 512Mi
+    # MANUAL-ONLY jobs: replaces disables the in-process job, suspend:true keeps
+    # the CronWorkflow from ever auto-firing, but it stays submittable by hand
+    # (argo submit --from cronworkflow/<name>, or kubectl create from its
+    # workflowSpec). The yearly schedule is inert belt-and-suspenders: even an
+    # accidental un-suspend can only fire it once a year, not constantly.
+    #
+    # hikes.scrape_walks: full WalkHighlands corpus scrape, ~hours. The corpus
+    # barely changes; trigger by hand when a refresh is wanted.
+    - name: hikes-scrape-walks
+      replaces: hikes.scrape_walks
+      args: ["hikes-scrape-walks"]
+      schedule: "0 0 1 1 *" # inert; suspended, manual-only
+      concurrencyPolicy: Forbid
+      activeDeadlineSeconds: 14400 # 4h headroom for the full scrape
+      suspend: true
+      resources:
+        requests:
+          cpu: 250m
+          memory: 1Gi
+        limits:
+          memory: 1Gi
+    # stars.load_climatology: wholesale-replaces stars.site_month_climatology
+    # from a STATIC annual CERRA/ERA5 S3 backfill, so daily runs just re-loaded
+    # identical data. Trigger by hand after regenerating the backfill.
+    - name: stars-load-climatology
+      replaces: stars.load_climatology
+      args: ["stars-load-climatology"]
+      schedule: "0 0 1 1 *" # inert; suspended, manual-only
+      concurrencyPolicy: Forbid
+      activeDeadlineSeconds: 1800
+      suspend: true
+      s3: true # _fetch_climatology reads the S3 backfill; needs the endpoint set
+      resources:
+        requests:
+          cpu: 250m
+          memory: 1Gi
+        limits:
+          memory: 1Gi
 
 frontend:
   otelCollectorUrl: ""

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.205.0
+      targetRevision: 0.206.0
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
## Manual-only jobs

Two jobs operate on near-static data, so scheduling them just re-does identical work:
- **`hikes.scrape_walks`**: full WalkHighlands corpus scrape (~hours); the corpus barely changes
- **`stars.load_climatology`**: wholesale-replaces `stars.site_month_climatology` from a **static annual CERRA/ERA5 S3 backfill** — daily runs re-downloaded the same file and rewrote identical rows

Both become **manual-only**: the CronWorkflow ships `suspend: true` (never auto-fires) but stays submittable by hand (`argo submit --from cronworkflow/<name>`, or `kubectl create` from its `workflowSpec`). Trigger them when the corpus / backfill actually changes.

## Mechanism change: decouple ARGO_JOBS from suspend

`ARGO_JOBS` membership now keys off `replaces` alone, not `(not suspend) and replaces`:
- `replaces` = "Argo owns this job" -> disable the in-process registration
- `suspend` = independently controls whether the CronWorkflow auto-runs

That yields three clean states: scheduled cutover (`replaces` + `suspend:false`), **manual-only (`replaces` + `suspend:true`)**, and untouched (no `replaces`). No regression: the three live scheduled cutovers all have `replaces` + `suspend:false` and stay in `ARGO_JOBS`. `helm template` confirms `ARGO_JOBS="worldcup.refresh,knowledge.layout,observability.topology_rollup,hikes.scrape_walks,stars.load_climatology,"`.

The manual-only entries also get an inert yearly schedule (`0 0 1 1 *`) so an accidental un-suspend can only fire once a year, not constantly.

## Validation (post-merge)

In-process off for both (ARGO_JOBS), CronWorkflows present + suspended. Manually trigger `stars-load-climatology` and confirm `Succeeded` + the `N rows` log (fast). Manually trigger `hikes-scrape-walks` and confirm it starts cleanly in-image (the full scrape takes hours; let it run async).

🤖 Generated with [Claude Code](https://claude.com/claude-code)