### PR TITLE
feat(monolith): cut 6 scheduled batch jobs over to Argo CronWorkflows

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.50.0
+version: 0.51.0
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.50.0
+      targetRevision: 0.51.0
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/app/jobs_main.py
+++ b/projects/monolith/app/jobs_main.py
@@ -20,6 +20,7 @@ import stays cheap and side-effect free, then dispatch to it.
 from __future__ import annotations
 
 import asyncio
+import importlib
 import logging
 
 import typer
@@ -147,6 +148,71 @@ def stars_load_climatology() -> None:
     with Session(get_engine()) as session:
         asyncio.run(load_climatology_handler(session))
     logger.info("stars-load-climatology: done")
+
+
+def _run_job(name: str, import_path: str, handler_name: str) -> None:
+    """Run a session-taking async scheduler handler as a one-shot.
+
+    Shared body for the simple cutovers: import the handler lazily (keeps CLI
+    startup cheap), open a fresh session mirroring the scheduler's contract, and
+    run it to completion. Each command below is a thin wrapper so Typer still
+    sees a distinct, documented subcommand per job.
+    """
+    from sqlmodel import Session
+
+    from app.db import get_engine
+
+    handler = getattr(importlib.import_module(import_path), handler_name)
+    configure_logging()
+    logger.info("%s: starting", name)
+    with Session(get_engine()) as session:
+        asyncio.run(handler(session))
+    logger.info("%s: done", name)
+
+
+@app.command("ships-heat-rollup")
+def ships_heat_rollup() -> None:
+    """Rebuild the ships traffic-heat rollup (one-shot of ships.heat_rollup)."""
+    _run_job("ships-heat-rollup", "ships.heat", "heat_rollup_handler")
+
+
+@app.command("ships-partition-maintenance")
+def ships_partition_maintenance() -> None:
+    """Roll ships position partitions (one-shot of ships.partition_maintenance)."""
+    _run_job(
+        "ships-partition-maintenance",
+        "ships.retention",
+        "partition_maintenance_handler",
+    )
+
+
+@app.command("dr-jobs-scrape-nhs")
+def dr_jobs_scrape_nhs() -> None:
+    """Scrape NHS Scotland vacancies (one-shot of dr_jobs.scrape_nhs)."""
+    _run_job("dr-jobs-scrape-nhs", "dr_jobs.jobs", "scrape_nhs_handler")
+
+
+@app.command("stars-load-grid")
+def stars_load_grid() -> None:
+    """Reload the stars site grid from S3 (one-shot of stars.load_grid)."""
+    _run_job("stars-load-grid", "stars.grid", "load_grid_handler")
+
+
+@app.command("stars-refresh")
+def stars_refresh() -> None:
+    """Refresh stars site clear-dark-hours scoring (one-shot of stars.refresh)."""
+    _run_job("stars-refresh", "stars.jobs", "refresh_handler")
+
+
+@app.command("knowledge-repo-docs-reconcile")
+def knowledge_repo_docs_reconcile() -> None:
+    """Reconcile baked repo-docs manifest into the KG (one-shot of
+    knowledge.repo_docs_reconcile)."""
+    _run_job(
+        "knowledge-repo-docs-reconcile",
+        "knowledge.repo_docs",
+        "repo_docs_reconcile_handler",
+    )
 
 
 if __name__ == "__main__":

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.206.0
+version: 0.207.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/values.yaml
+++ b/projects/monolith/chart/values.yaml
@@ -135,6 +135,87 @@ jobs:
           memory: 1Gi
         limits:
           memory: 1Gi
+    # Scheduled batch cutovers (Postgres / external-HTTP / S3). Cadences match
+    # the in-process intervals; all light enough for a 512Mi-1Gi ephemeral pod.
+    - name: ships-heat-rollup
+      replaces: ships.heat_rollup
+      args: ["ships-heat-rollup"]
+      schedule: "0 * * * *" # hourly (was 3600s)
+      concurrencyPolicy: Forbid
+      activeDeadlineSeconds: 1800
+      suspend: false
+      resources:
+        requests:
+          cpu: 250m
+          memory: 512Mi
+        limits:
+          memory: 512Mi
+    - name: ships-partition-maintenance
+      replaces: ships.partition_maintenance
+      args: ["ships-partition-maintenance"]
+      schedule: "30 3 * * *" # daily 03:30 UTC (was 86400s)
+      concurrencyPolicy: Forbid
+      activeDeadlineSeconds: 1800
+      suspend: false
+      resources:
+        requests:
+          cpu: 100m
+          memory: 256Mi
+        limits:
+          memory: 256Mi
+    - name: dr-jobs-scrape-nhs
+      replaces: dr_jobs.scrape_nhs
+      args: ["dr-jobs-scrape-nhs"]
+      schedule: "15 * * * *" # hourly (was 3600s)
+      concurrencyPolicy: Forbid
+      activeDeadlineSeconds: 600
+      suspend: false
+      resources:
+        requests:
+          cpu: 250m
+          memory: 512Mi
+        limits:
+          memory: 512Mi
+    - name: stars-load-grid
+      replaces: stars.load_grid
+      args: ["stars-load-grid"]
+      schedule: "0 */6 * * *" # every 6h (was 21600s)
+      concurrencyPolicy: Forbid
+      activeDeadlineSeconds: 900
+      suspend: false
+      s3: true # load_grid reads grid.json from S3
+      resources:
+        requests:
+          cpu: 250m
+          memory: 1Gi
+        limits:
+          memory: 1Gi
+    - name: stars-refresh
+      replaces: stars.refresh
+      args: ["stars-refresh"]
+      schedule: "0 */3 * * *" # every 3h (was 10800s)
+      concurrencyPolicy: Forbid
+      activeDeadlineSeconds: 1800
+      suspend: false
+      resources:
+        requests:
+          cpu: 250m
+          memory: 512Mi
+        limits:
+          memory: 512Mi
+    - name: knowledge-repo-docs-reconcile
+      replaces: knowledge.repo_docs_reconcile
+      args: ["knowledge-repo-docs-reconcile"]
+      schedule: "0 */6 * * *" # every 6h (was 21600s)
+      concurrencyPolicy: Forbid
+      activeDeadlineSeconds: 900
+      suspend: false
+      resources:
+        requests:
+          cpu: 250m
+          memory: 512Mi
+        limits:
+          memory: 512Mi
 
 frontend:
   otelCollectorUrl: ""

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.206.0
+      targetRevision: 0.207.0
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
## Cutover batch: 6 scheduled jobs

Moves the next tranche off the API pod. All have importable, session-taking handlers (Postgres / external-HTTP / S3), so each is a thin `jobs_main` subcommand + a `cronWorkflows` entry. Cadences match the in-process intervals:

| Job | Cadence | Notes |
|-----|---------|-------|
| `ships.heat_rollup` | hourly | Postgres rollup |
| `ships.partition_maintenance` | daily 03:30 | DB partition roll |
| `dr_jobs.scrape_nhs` | hourly | external JobTrain scrape (no auth) |
| `stars.load_grid` | every 6h | reads grid.json from S3 (`s3: true`) |
| `stars.refresh` | every 3h | site scoring (Postgres + weather HTTP) |
| `knowledge.repo_docs_reconcile` | every 6h | baked-manifest diff into KG |

Adds a small `_run_job(name, import_path, handler)` helper to DRY the now-mechanical wrappers. `helm template` confirms 11 total CronWorkflows and `ARGO_JOBS` carrying all 11 `replaces` (so all six skip in-process registration). Source change, so chart-version-bot auto-bumps.

## Deferred (need follow-up work)

- `chat.summary_generation` / `chat.changelog.*`: handler is a nested closure inside `summarizer.py`; needs a refactor to expose a module-level entry.
- `home.calendar_poll`: needs Google Calendar creds (new secret to clone).

## Validation (post-merge, per-job)

Sync, confirm in-process off (ARGO_JOBS) + 6 CronWorkflows present. Hand-trigger each and confirm `Succeeded` + its side effect (heat cells rebuilt, partitions present, dr_jobs vacancies upserted, grid rows loaded, site scores refreshed, repo-docs reconciled). The climatology near-miss (silent S3 no-op) is why each gets an explicit per-job trigger, not just a phase check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)