### PR TITLE
fix(monolith): repair two silent no-ops in the batch job cutover

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.52.0
+version: 0.52.1
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.52.0
+      targetRevision: 0.52.1
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -106,11 +106,17 @@ py_venv_binary(
 # own image (:jobs_image) so an ephemeral pod (e.g. an Argo Workflow) can run a
 # single job to completion off the API pod. Only the worldcup Elo snapshot is
 # shipped as data; the jobs entrypoint never serves the frontend, so the static
-# bundle and the repo-docs manifest are deliberately omitted.
+# bundle is omitted. The repo-docs manifest IS needed: the
+# knowledge.repo_docs_reconcile job (knowledge-repo-docs-reconcile subcommand)
+# reads it from runfiles, so ship it here too (it is data on :main, which does
+# not propagate to this separate binary).
 py_venv_binary(
     name = "jobs",
     srcs = _BACKEND_SRCS,  # keep
-    data = ["worldcup/ratings/elo_2026.json"],
+    data = [
+        "knowledge/repo_docs_manifest.ndjson",
+        "worldcup/ratings/elo_2026.json",
+    ],
     imports = ["."],  # keep
     main = "app/jobs_main.py",
     visibility = ["//:__subpackages__"],

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.208.0
+version: 0.208.1
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/templates/cronworkflows.yaml
+++ b/projects/monolith/chart/templates/cronworkflows.yaml
@@ -67,15 +67,23 @@ spec:
                   key: {{ $ref.key }}
             {{- end }}
             {{- if .s3 }}
-            # Shared SeaweedFS S3 endpoint + creds (sourced from the stars block,
-            # which always sets them; creds are the cluster's dummy duckdb pair).
-            # Bucket/key env stay per-entry since they differ by job.
+            # Full SeaweedFS + stars S3 env, mirroring the monolith deployment
+            # exactly. Endpoint/creds AND the bucket/key names must all be set:
+            # the handlers' in-code defaults (e.g. STARS_GRID_S3_KEY defaulting
+            # to "stars/grid.json") do NOT match the configured keys, so omitting
+            # them makes the job fetch a wrong path and silently load 0 rows.
             - name: SEAWEEDFS_S3_ENDPOINT
               value: {{ $.Values.stars.seaweedfsS3Endpoint | quote }}
             - name: S3_ACCESS_KEY_ID
               value: {{ $.Values.stars.s3AccessKeyId | quote }}
             - name: S3_SECRET_ACCESS_KEY
               value: {{ $.Values.stars.s3SecretAccessKey | quote }}
+            - name: STARS_GRID_S3_BUCKET
+              value: {{ $.Values.stars.gridBucket | quote }}
+            - name: STARS_GRID_S3_KEY
+              value: {{ $.Values.stars.gridKey | quote }}
+            - name: STARS_CLIMATOLOGY_S3_KEY
+              value: {{ $.Values.stars.climatologyKey | quote }}
             {{- end }}
           {{- with .resources }}
           resources:

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.208.0
+      targetRevision: 0.208.1
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
## Two silent no-ops caught by per-job validation

Hand-triggering all 6 jobs from PR #2804 (the batch cutover) found two that reached `Succeeded` but did no work - the same failure mode as the earlier climatology near-miss. Invisible to Workflow phase and to CI; only the side-effect check catches them.

### 1. `stars.load_grid` -> NoSuchKey, 0 sites
```
WARNING stars.load_grid: failed to fetch stars/stars/grid.json: NoSuchKey
stars.load_grid: 0 sites
```
The `s3` template flag injected only the endpoint + creds, so the handler fell back to its in-code `STARS_GRID_S3_KEY` default `"stars/grid.json"` instead of the configured `"grid.json"` -> wrong path. Expand the `s3` flag to also set `STARS_GRID_S3_BUCKET` / `STARS_GRID_S3_KEY` / `STARS_CLIMATOLOGY_S3_KEY`, mirroring the monolith deployment exactly. (`load_climatology` survived only because its default already matched the configured key.)

### 2. `knowledge.repo_docs_reconcile` -> manifest not found
```
WARNING repo_docs: manifest not found at .../repo_docs_manifest.ndjson; nothing to index
```
`repo_docs_manifest.ndjson` is `data` on the `:main` binary, which doesn't propagate to the separate `:jobs` binary. Ship it in `:jobs` data too - same class of bug as the original `typer` miss (binary deps don't cross binaries).

Neither corrupts data (both no-op rather than write garbage). BUILD change bumps the jobs image digest, so chart-version-bot auto-bumps.

## Validation (post-merge)
Re-trigger both jobs: `stars-load-grid` should load N>0 sites, `knowledge-repo-docs-reconcile` should index the manifest. The other 4 (dr_jobs, ships x2, stars-refresh) already verified working in #2804.

🤖 Generated with [Claude Code](https://claude.com/claude-code)