### PR TITLE
feat(monolith): cut over 5 more scheduled jobs to Argo (phase A of migrate-all)

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.52.1
+version: 0.53.0
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.52.1
+      targetRevision: 0.53.0
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/app/jobs_main.py
+++ b/projects/monolith/app/jobs_main.py
@@ -215,5 +215,35 @@ def knowledge_repo_docs_reconcile() -> None:
     )
 
 
+@app.command("hikes-refresh-forecasts")
+def hikes_refresh_forecasts() -> None:
+    """Refresh hike weather forecasts (one-shot of hikes.refresh_forecasts)."""
+    _run_job("hikes-refresh-forecasts", "hikes.jobs", "refresh_forecasts_handler")
+
+
+@app.command("hikes-prune-windows")
+def hikes_prune_windows() -> None:
+    """Prune stale hike forecast windows (one-shot of hikes.prune_windows)."""
+    _run_job("hikes-prune-windows", "hikes.jobs", "prune_windows_handler")
+
+
+@app.command("stars-prune-hours")
+def stars_prune_hours() -> None:
+    """Prune stale stars live-hours rows (one-shot of stars.prune_hours)."""
+    _run_job("stars-prune-hours", "stars.jobs", "prune_hours_handler")
+
+
+@app.command("knowledge-ingest")
+def knowledge_ingest() -> None:
+    """Drain the knowledge ingest queue (one-shot of knowledge.ingest)."""
+    _run_job("knowledge-ingest", "knowledge.ingest_queue", "ingest_handler")
+
+
+@app.command("knowledge-discover-gaps")
+def knowledge_discover_gaps() -> None:
+    """Discover knowledge-graph gaps (one-shot of knowledge.discover-gaps)."""
+    _run_job("knowledge-discover-gaps", "knowledge.service", "discover_gaps_handler")
+
+
 if __name__ == "__main__":
     app()

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.208.1
+version: 0.209.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/values.yaml
+++ b/projects/monolith/chart/values.yaml
@@ -216,6 +216,74 @@ jobs:
           memory: 512Mi
         limits:
           memory: 512Mi
+    # Phase A: remaining Postgres / HTTP jobs. All small; cadences match the
+    # in-process intervals. Per-run pod overhead is ~10s (measured), trivial
+    # even at the 5-min cadences.
+    - name: hikes-refresh-forecasts
+      replaces: hikes.refresh_forecasts
+      args: ["hikes-refresh-forecasts"]
+      schedule: "20 */2 * * *" # every 2h (was 7200s)
+      concurrencyPolicy: Forbid
+      activeDeadlineSeconds: 1800
+      suspend: false
+      resources:
+        requests:
+          cpu: 250m
+          memory: 512Mi
+        limits:
+          memory: 512Mi
+    - name: hikes-prune-windows
+      replaces: hikes.prune_windows
+      args: ["hikes-prune-windows"]
+      schedule: "40 * * * *" # hourly (was 3600s)
+      concurrencyPolicy: Forbid
+      activeDeadlineSeconds: 300
+      suspend: false
+      resources:
+        requests:
+          cpu: 100m
+          memory: 256Mi
+        limits:
+          memory: 256Mi
+    - name: stars-prune-hours
+      replaces: stars.prune_hours
+      args: ["stars-prune-hours"]
+      schedule: "50 * * * *" # hourly (was 3600s)
+      concurrencyPolicy: Forbid
+      activeDeadlineSeconds: 300
+      suspend: false
+      resources:
+        requests:
+          cpu: 100m
+          memory: 256Mi
+        limits:
+          memory: 256Mi
+    - name: knowledge-ingest
+      replaces: knowledge.ingest
+      args: ["knowledge-ingest"]
+      schedule: "*/5 * * * *" # every 5 min (was 300s)
+      concurrencyPolicy: Forbid
+      activeDeadlineSeconds: 600
+      suspend: false
+      resources:
+        requests:
+          cpu: 250m
+          memory: 512Mi
+        limits:
+          memory: 512Mi
+    - name: knowledge-discover-gaps
+      replaces: knowledge.discover-gaps
+      args: ["knowledge-discover-gaps"]
+      schedule: "2-59/5 * * * *" # every 5 min, offset from ingest
+      concurrencyPolicy: Forbid
+      activeDeadlineSeconds: 600
+      suspend: false
+      resources:
+        requests:
+          cpu: 250m
+          memory: 512Mi
+        limits:
+          memory: 512Mi
 
 frontend:
   otelCollectorUrl: ""

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.208.1
+      targetRevision: 0.209.0
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
## Phase A of migrate-all: the easy remaining 5

Goal is now to migrate every schedulable job off the API pod so the in-process scheduler loop can be deleted (monolith = orchestration + APIs only). This is the easy batch - Postgres/HTTP jobs with importable handlers, no new creds:

| Job | Cadence | Work |
|-----|---------|------|
| `hikes.refresh_forecasts` | 2h | weather HTTP fetch |
| `hikes.prune_windows` | hourly | DB delete |
| `stars.prune_hours` | hourly | DB delete |
| `knowledge.ingest` | 5min | drain ingest queue (Postgres) |
| `knowledge.discover-gaps` | 5min | KG gap discovery (Postgres) |

Each is a thin `_run_job` wrapper + a cronWorkflows entry. `discover-gaps` is offset (`2-59/5`) from `ingest` so the two 5-min KG jobs don't fire together. Measured per-run pod overhead is ~10s, trivial even at 5-min cadence. `helm template` confirms 16 CronWorkflows and all 16 in `ARGO_JOBS`.

## Remaining for full migrate-all (tracked separately)
- **Phase B** `observability.stats_rollup`: needs K8s RBAC for the job SA (build_stats counts nodes/pods/deployments/argocd-apps)
- **Phase C** `home.calendar_poll`: Google Calendar creds
- **Phase D** `chat.summary_generation` / `chat.changelog.*`: nested-closure refactor + LLM creds
- **Phase E** delete the in-process scheduler loop

## Validation (post-merge, per-job)
Hand-trigger each; confirm side effects (forecasts refreshed, windows/hours pruned, ingest queue drained, gaps discovered).

🤖 Generated with [Claude Code](https://claude.com/claude-code)