### PR TITLE
feat(monolith): cut over observability.stats_rollup with least-privilege SA

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.53.0
+version: 0.54.0
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.53.0
+      targetRevision: 0.54.0
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/app/jobs_main.py
+++ b/projects/monolith/app/jobs_main.py
@@ -109,6 +109,23 @@ def observability_topology_rollup() -> None:
     logger.info("observability-topology-rollup: done")
 
 
+@app.command("observability-stats-rollup")
+def observability_stats_rollup() -> None:
+    """Build the cluster-stats payload and snapshot it to Postgres as a one-shot.
+
+    One-shot form of ``observability.stats_rollup``. build_stats counts cluster
+    resources via the in-cluster K8s API, so this job runs under a dedicated
+    least-privilege SA (monolith-stats) rather than the shared executor SA. Also
+    needs CLICKHOUSE_URL + USER/PASSWORD for the GPU metrics queries. No session
+    (the snapshot writer opens its own)."""
+    from home.observability.rollup import stats_rollup
+
+    configure_logging()
+    logger.info("observability-stats-rollup: starting")
+    asyncio.run(stats_rollup())
+    logger.info("observability-stats-rollup: done")
+
+
 @app.command("hikes-scrape-walks")
 def hikes_scrape_walks() -> None:
     """Run the full WalkHighlands corpus scrape as a one-shot.

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.209.0
+version: 0.210.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/templates/cronworkflows.yaml
+++ b/projects/monolith/chart/templates/cronworkflows.yaml
@@ -35,7 +35,9 @@ spec:
   failedJobsHistoryLimit: {{ .failedJobsHistoryLimit | default 5 }}
   workflowSpec:
     entrypoint: run
-    serviceAccountName: argo-workflow
+    # Most jobs use the shared executor SA; a job needing extra cluster access
+    # (e.g. stats_rollup reading node/pod counts) sets its own least-privilege SA.
+    serviceAccountName: {{ .serviceAccountName | default "argo-workflow" }}
     {{- if .activeDeadlineSeconds }}
     activeDeadlineSeconds: {{ .activeDeadlineSeconds }}
     {{- end }}

--- a/projects/monolith/chart/values.yaml
+++ b/projects/monolith/chart/values.yaml
@@ -97,6 +97,34 @@ jobs:
           memory: 512Mi
         limits:
           memory: 512Mi
+    # stats_rollup counts cluster resources via the in-cluster K8s API, so it
+    # runs under the dedicated least-privilege monolith-stats SA (defined in the
+    # argo-workflows platform chart) instead of the shared executor SA. Also
+    # needs ClickHouse for GPU metrics. 2-min cadence (was 120s); per-run pod
+    # overhead ~10s is fine.
+    - name: observability-stats-rollup
+      replaces: observability.stats_rollup
+      args: ["observability-stats-rollup"]
+      schedule: "*/2 * * * *"
+      concurrencyPolicy: Forbid
+      activeDeadlineSeconds: 120
+      suspend: false
+      serviceAccountName: monolith-stats
+      env:
+        CLICKHOUSE_URL: "http://chi-signoz-clickhouse-cluster-0-0.signoz.svc.cluster.local:8123"
+      secretEnv:
+        CLICKHOUSE_USER:
+          secretName: monolith-clickhouse
+          key: USER
+        CLICKHOUSE_PASSWORD:
+          secretName: monolith-clickhouse
+          key: PASSWORD
+      resources:
+        requests:
+          cpu: 250m
+          memory: 512Mi
+        limits:
+          memory: 512Mi
     # MANUAL-ONLY jobs: replaces disables the in-process job, suspend:true keeps
     # the CronWorkflow from ever auto-firing, but it stays submittable by hand
     # (argo submit --from cronworkflow/<name>, or kubectl create from its

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.209.0
+      targetRevision: 0.210.0
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/platform/argo-workflows/templates/monolith-stats-rbac.yaml
+++ b/projects/platform/argo-workflows/templates/monolith-stats-rbac.yaml
@@ -1,0 +1,55 @@
+# Dedicated least-privilege ServiceAccount for the observability.stats_rollup
+# CronWorkflow. stats_rollup's build_stats() counts cluster resources (nodes,
+# pods, deployments, ArgoCD applications) and aggregates node capacity/metrics,
+# so its job pod needs cluster-read that the shared argo-workflow executor SA
+# (deliberately) lacks. Rather than broaden every batch pod's permissions
+# (overprivileged-SA anti-pattern, docs/security.md), give just this one job a
+# dedicated SA bound to a read-only ClusterRole scoped to exactly what
+# build_stats reads: no secrets, no pods/log, no write verbs (the in-process
+# job only ever reads; the patch verb the monolith API SA has for triggering
+# ArgoCD syncs is intentionally omitted here).
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: monolith-stats
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: monolith-stats-read
+rules:
+  # count_nodes / count_pods + aggregate_node_resources (list_node).
+  - apiGroups: [""]
+    resources: ["nodes", "pods"]
+    verbs: ["get", "list"]
+  # aggregate_node_resources reads the kubelet Summary API for honest RSS.
+  - apiGroups: [""]
+    resources: ["nodes/proxy"]
+    verbs: ["get"]
+  # count_deployments.
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get", "list"]
+  # count_argocd_applications + get_argocd_app_status. Read-only: no patch
+  # (stats never triggers a sync).
+  - apiGroups: ["argoproj.io"]
+    resources: ["applications"]
+    verbs: ["get", "list"]
+  # aggregate_node_resources reads metrics.k8s.io for per-node CPU usage.
+  - apiGroups: ["metrics.k8s.io"]
+    resources: ["nodes"]
+    verbs: ["list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: monolith-stats-read
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: monolith-stats-read
+subjects:
+  - kind: ServiceAccount
+    name: monolith-stats
+    namespace: {{ .Release.Namespace }}


### PR DESCRIPTION
## Phase B of migrate-all: the one needing cluster RBAC

`stats_rollup`'s `build_stats()` counts cluster resources (nodes, pods, deployments, ArgoCD applications) and aggregates node capacity/metrics via the in-cluster K8s API. The shared `argo-workflow` executor SA deliberately has no cluster-read, so this job needs more.

### Least-privilege, not broaden-the-shared-SA
Granting the shared executor SA cluster-read would over-privilege **every** batch pod (scrapers, prunes) - the overprivileged-SA anti-pattern called out in `docs/security.md`. Instead: a dedicated `monolith-stats` ServiceAccount bound to a read-only ClusterRole scoped to exactly what `build_stats` reads:

| Resource | Verbs | Used by |
|----------|-------|---------|
| `nodes`, `pods` | get, list | count_nodes, count_pods, aggregate_node_resources |
| `nodes/proxy` | get | kubelet Summary API (honest RSS) |
| `apps/deployments` | get, list | count_deployments |
| `argoproj.io/applications` | get, list | count_applications, get_app_status |
| `metrics.k8s.io/nodes` | list | per-node CPU usage |

No secrets, no pods/log, no write verbs (omits even the `applications` **patch** the monolith API SA holds for triggering syncs - stats only reads). RBAC lives in the argo-workflows platform chart, which owns the `monolith-workflows` namespace.

### Plumbing
- `cronworkflows.yaml`: per-entry `serviceAccountName` (default `argo-workflow`); stats sets `monolith-stats`.
- Reuses the ClickHouse `secretEnv` (GPU metrics queries).
- `helm template` confirms stats uses `monolith-stats`, topology still uses `argo-workflow`, RBAC renders.

## Deploy note
Two apps sync: argo-workflows (git-HEAD, gets the SA/RBAC) and monolith (chart bump, gets the CronWorkflow). The SA must exist before the job runs.

## Validation
Hand-trigger; confirm `Succeeded` + the stats snapshot row's `snapshot_at` advances AND node/pod counts are non-zero (proving the K8s RBAC works, not a silent empty payload).

🤖 Generated with [Claude Code](https://claude.com/claude-code)