### PR TITLE
fix(argo-workflows): grant monolith-stats SA the executor permission

### DIFF
--- a/projects/platform/argo-workflows/templates/monolith-stats-rbac.yaml
+++ b/projects/platform/argo-workflows/templates/monolith-stats-rbac.yaml
@@ -53,3 +53,34 @@ subjects:
   - kind: ServiceAccount
     name: monolith-stats
     namespace: {{ .Release.Namespace }}
+---
+# Every Argo workflow pod's `wait` sidecar reports step results by creating a
+# workflowtaskresults object as the pod's own SA. The shared argo-workflow SA
+# gets this from the chart's argo-workflows-workflow Role, but a custom SA does
+# not - without it the work runs fine (main exits 0) yet the Workflow is marked
+# Error on the wait sidecar's RBAC denial. Grant monolith-stats the same minimal
+# executor permission via a self-contained Role (not bound to the chart's Role
+# name, to avoid coupling to an upstream rename).
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: monolith-stats-executor
+  namespace: {{ .Release.Namespace }}
+rules:
+  - apiGroups: ["argoproj.io"]
+    resources: ["workflowtaskresults"]
+    verbs: ["create", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: monolith-stats-executor
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: monolith-stats-executor
+subjects:
+  - kind: ServiceAccount
+    name: monolith-stats
+    namespace: {{ .Release.Namespace }}


### PR DESCRIPTION
## Follow-up to #2808

The stats_rollup job ran correctly under the dedicated `monolith-stats` SA - snapshot written with real data (`nodes: 4, pods: 158, deployments: 68, argocd_apps: 30`), main container exit 0. But the Workflow was marked **Error**:

```
wait: Error (exit code 64): workflowtaskresults.argoproj.io is forbidden:
User "system:serviceaccount:monolith-workflows:monolith-stats" cannot create
resource "workflowtaskresults" in API group "argoproj.io"
```

Every Argo workflow pod's `wait` sidecar creates a `workflowtaskresults` object **as the pod's own SA** to report step results. The shared `argo-workflow` SA gets this from the chart's `argo-workflows-workflow` Role; a custom SA does not. So the work succeeds but the Workflow fails on the sidecar's RBAC denial (and would accumulate in failed-history).

## Fix
Self-contained Role + RoleBinding granting `monolith-stats` exactly `workflowtaskresults: create, patch` (the minimal executor permission). Not bound to the chart's Role name, to avoid coupling to an upstream rename. Platform chart (git-HEAD), no monolith chart bump.

## Lesson
Any custom-SA Argo job needs the executor permission in addition to its job-specific grants - `helm template`/CI can't see this; only a live run's `wait` sidecar surfaces it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)