### PR TITLE
fix(monolith): skip in-process registration of Argo-owned jobs centrally

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.54.0
+version: 0.54.1
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.54.0
+      targetRevision: 0.54.1
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.210.0
+version: 0.210.1
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.210.0
+      targetRevision: 0.210.1
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/scheduler/api.py
+++ b/projects/monolith/scheduler/api.py
@@ -89,7 +89,19 @@ def register_job(
 
     Set ``heavy=True`` for memory-intensive jobs (e.g. the graph layout pass) so
     the dispatcher never co-schedules two of them.
+
+    Jobs an active Argo CronWorkflow owns (listed in ARGO_JOBS) are skipped here
+    so they never run both in-process and as a CronWorkflow. This is centralized
+    so every module's on_startup_jobs gets the skip for free - callers do not
+    each need to gate on argo_handled. A previously-registered row is left for
+    purge_unregistered_jobs to drop on the next sweep.
     """
+    if argo_handled(name):
+        logger.info(
+            "%s: owned by Argo CronWorkflow, skipping in-process register", name
+        )
+        return
+
     _registry[name] = handler
     if heavy:
         _heavy.add(name)

--- a/projects/monolith/scheduler/argo_handled_test.py
+++ b/projects/monolith/scheduler/argo_handled_test.py
@@ -18,3 +18,38 @@ def test_argo_handled_parses_env(monkeypatch):
 
     monkeypatch.setenv("ARGO_JOBS", "")
     assert api.argo_handled("worldcup.refresh") is False
+
+
+def test_register_job_skips_argo_handled(monkeypatch):
+    """register_job must skip jobs an Argo CronWorkflow owns, so modules whose
+    on_startup_jobs does not gate on argo_handled still avoid double-running."""
+
+    async def _noop(_session):
+        return None
+
+    # Not handled -> registered.
+    monkeypatch.setenv("ARGO_JOBS", "")
+    api._registry.pop("test.job", None)
+    api.register_job(_FakeSession(), name="test.job", interval_secs=60, handler=_noop)
+    assert api.is_registered("test.job")
+
+    # Handled -> skipped (and a stale registration is not re-added).
+    api._registry.pop("test.job", None)
+    monkeypatch.setenv("ARGO_JOBS", "test.job,")
+    api.register_job(_FakeSession(), name="test.job", interval_secs=60, handler=_noop)
+    assert not api.is_registered("test.job")
+
+
+class _FakeSession:
+    """Minimal stand-in: register_job only touches the session after the
+    argo-handled skip, so the skip path never calls these, and the
+    not-handled path exercises get/add/commit."""
+
+    def get(self, *_a, **_k):
+        return None
+
+    def add(self, *_a, **_k):
+        return None
+
+    def commit(self):
+        return None


### PR DESCRIPTION
## Live bug: cut-over jobs are double-running

Found while deep-diving the scheduler for the migrate-all work. The `ARGO_JOBS` one-flag cutover only disables the in-process job if a module's `on_startup_jobs` calls `argo_handled()` and returns early - **but only `worldcup` does that.** Every other cut-over job was still registered and dispatched in-process **AND** run by its Argo CronWorkflow.

Confirmed against prod (`scheduler.scheduled_jobs.last_run_at`, which only the in-process dispatcher updates):
```
knowledge.ingest               last_run 08:14  (3 min before check)
observability.topology_rollup  last_run 08:16  (1 min before check)
ships.heat_rollup, dr_jobs.scrape_nhs, stars.refresh  all recent
worldcup.refresh               (row purged - correctly Argo-only)
```

So ~16 jobs were executing twice. Mostly wasteful (idempotent rollups/prunes), but `dr_jobs.scrape_nhs` posts a Discord digest on new vacancies and could double-notify.

## Fix
Centralize the skip in `register_job`: any job listed in `ARGO_JOBS` is skipped at registration, so every module gets it for free without each gating on `argo_handled`. The stale `scheduled_jobs` row is dropped by the existing `purge_stale_jobs` sweep (the same way `worldcup.refresh`'s row already disappears). `worldcup` keeps its explicit gate (it also avoids importing the sim graph) - now a harmless double-gate.

Adds a `register_job` skip test. This also de-risks Phase E (deleting the in-process scheduler): the skip is now in one place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)