### PR TITLE
feat(monolith): cut over home.calendar_poll via Postgres snapshot (phase C)

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.54.1
+version: 0.55.0
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.55.0
+version: 0.55.1
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.55.0
+      targetRevision: 0.55.1
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.54.1
+      targetRevision: 0.55.0
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/app/jobs_main.py
+++ b/projects/monolith/app/jobs_main.py
@@ -262,5 +262,21 @@ def knowledge_discover_gaps() -> None:
     _run_job("knowledge-discover-gaps", "knowledge.service", "discover_gaps_handler")
 
 
+@app.command("home-calendar-poll")
+def home_calendar_poll() -> None:
+    """Fetch the iCal feed and snapshot today's events to Postgres.
+
+    One-shot of home.calendar_poll. The handler takes no session (poll_calendar
+    opens its own to write the home.calendar_snapshot row). Needs ICAL_FEED_URL
+    from the cloned monolith-secrets secret; without it the poll logs a warning
+    and no-ops."""
+    from home.schedule import calendar_poll_handler
+
+    configure_logging()
+    logger.info("home-calendar-poll: starting")
+    asyncio.run(calendar_poll_handler())
+    logger.info("home-calendar-poll: done")
+
+
 if __name__ == "__main__":
     app()

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.210.1
+version: 0.211.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.211.0
+version: 0.211.1
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/migrations/20260622120000_home_calendar_snapshot.sql
+++ b/projects/monolith/chart/migrations/20260622120000_home_calendar_snapshot.sql
@@ -1,0 +1,24 @@
+-- home.calendar_snapshot: single-row snapshot of the day's parsed calendar
+-- events. Mirrors the observability snapshot pattern (20260617010000).
+--
+-- Previously home.calendar_poll warmed a process-local in-memory cache
+-- (_cached_events) that only the polling replica saw. Persisting the parsed
+-- events here makes the poll a stateless batch job (so it can run as an Argo
+-- CronWorkflow off the API pod) and lets every API replica serve the same
+-- events from one shared row instead of each warming its own cache - important
+-- for horizontal scaling.
+--
+-- event_date is stored so the read path can return events only when the
+-- snapshot is for the current day (a stale snapshot from a missed run shows
+-- nothing rather than yesterday's events). Single row (id = 1), whole-day
+-- events as JSONB (the read path returns them verbatim).
+
+CREATE SCHEMA IF NOT EXISTS home;
+
+CREATE TABLE home.calendar_snapshot (
+    id          SMALLINT PRIMARY KEY DEFAULT 1,
+    event_date  DATE NOT NULL,
+    events      JSONB NOT NULL,
+    snapshot_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CONSTRAINT calendar_snapshot_singleton CHECK (id = 1)
+);

--- a/projects/monolith/chart/migrations/atlas.sum
+++ b/projects/monolith/chart/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:z07tOEvvBv4WKoKGcBUa1sJj4IbQj/Two0U5Sjfo5hQ=
+h1:Pa1f752P7oC8DL5V4WA1+7XRUUUARKnZ9U5+Mp7/JIU=
 20260330000000_initial_schema.sql h1:J2futpSW0nJAIRR7nR7ssT7LwXIYrvRI+PkHb5Y4tLI=
 20260403000000_chat_schema.sql h1:pERUFC0vzM95etRuzp43XzkCV7lBCzrrtY5Mk7aF3CA=
 20260404000000_chat_attachments.sql h1:tv+Fdbr1rQC5nzUxfaBC0O6fu2OMGgLWf+YNg1WQXi4=
@@ -62,3 +62,4 @@ h1:z07tOEvvBv4WKoKGcBUa1sJj4IbQj/Two0U5Sjfo5hQ=
 20260621120000_worldcup_swing_per_country.sql h1:PF2X+SOSRkR4sMD1fgd+fu0eoJ0BgiiItGI9IZn7ugw=
 20260621130000_chat_public_reader_schema_usage.sql h1:UuKhDAWNrOK/vOEcI7UA89nvKxSRiSAVQTgRwZexRn8=
 20260621140000_leader_lease.sql h1:5IFOe64jbZr4zA1LpMBFBaInGOKZGFUZJfO84qr1vcw=
+20260622120000_home_calendar_snapshot.sql h1:thRmlSLVQzonjgIBOBKpA7/Of4fyFC3r8l22sFNZkw8=

--- a/projects/monolith/chart/values.yaml
+++ b/projects/monolith/chart/values.yaml
@@ -312,6 +312,27 @@ jobs:
           memory: 512Mi
         limits:
           memory: 512Mi
+    # calendar_poll fetches the iCal feed and snapshots today's events to
+    # home.calendar_snapshot (so all API replicas read one shared row instead of
+    # each warming an in-memory cache). Needs ICAL_FEED_URL from the cloned
+    # monolith-secrets secret. 15min cadence (was 900s).
+    - name: home-calendar-poll
+      replaces: home.calendar_poll
+      args: ["home-calendar-poll"]
+      schedule: "*/15 * * * *"
+      concurrencyPolicy: Forbid
+      activeDeadlineSeconds: 120
+      suspend: false
+      secretEnv:
+        ICAL_FEED_URL:
+          secretName: monolith-secrets
+          key: ICAL_FEED_URL
+      resources:
+        requests:
+          cpu: 100m
+          memory: 256Mi
+        limits:
+          memory: 256Mi
 
 frontend:
   otelCollectorUrl: ""

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.210.1
+      targetRevision: 0.211.0
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.211.0
+      targetRevision: 0.211.1
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/home/__init__.py
+++ b/projects/monolith/home/__init__.py
@@ -29,3 +29,10 @@ def on_startup_jobs(session) -> None:
         handler=lambda _: calendar_poll_handler(),
         ttl_secs=120,
     )
+
+
+def get_today_events(session) -> list[dict]:
+    """Home domain public API: today's calendar events from the snapshot row."""
+    from home.schedule import get_today_events as _get
+
+    return _get(session)

--- a/projects/monolith/home/__init__.py
+++ b/projects/monolith/home/__init__.py
@@ -29,9 +29,3 @@ def on_startup_jobs(session) -> None:
         handler=lambda _: calendar_poll_handler(),
         ttl_secs=120,
     )
-
-
-def get_today_events() -> list[dict]:
-    from home.schedule import get_today_events as _get
-
-    return _get()

--- a/projects/monolith/home/schedule.py
+++ b/projects/monolith/home/schedule.py
@@ -1,17 +1,16 @@
+import asyncio
+import json
 import logging
 import os
-from datetime import date, datetime, time
+from datetime import date, datetime
 from zoneinfo import ZoneInfo
 
 import httpx
 from icalendar import Calendar
-from sqlmodel import Session
+from sqlmodel import Session, text
 
 logger = logging.getLogger(__name__)
 TZ = ZoneInfo("America/Vancouver")
-
-# In-memory cache, populated by poll_calendar()
-_cached_events: list[dict] = []
 
 ICAL_FEED_URL = os.environ.get("ICAL_FEED_URL", "")
 
@@ -73,12 +72,52 @@ def parse_events_for_date(ics_text: str, target_date: date, tz: ZoneInfo) -> lis
     return all_day + timed
 
 
-def get_today_events() -> list[dict]:
-    return list(_cached_events)
+def get_today_events(session: Session) -> list[dict]:
+    """Return the snapshotted events for today.
+
+    Reads the single home.calendar_snapshot row written by poll_calendar. If the
+    snapshot is for an earlier day (the poll has not run yet today) or is absent,
+    returns an empty list rather than stale events.
+    """
+    row = session.execute(
+        text("SELECT event_date, events FROM home.calendar_snapshot WHERE id = 1")
+    ).first()
+    if row is None:
+        return []
+    event_date, events = row
+    today = datetime.now(TZ).date()
+    # SQLite test fixtures hand back event_date as an ISO string; Postgres as a
+    # date. Normalise before comparing.
+    if isinstance(event_date, str):
+        event_date = date.fromisoformat(event_date)
+    if event_date != today:
+        return []
+    return list(events)
+
+
+def _write_calendar_snapshot(event_date: date, events: list[dict]) -> None:
+    """Upsert today's parsed events into the single snapshot row. Opens its own
+    session so it can run in a worker thread off the event loop."""
+    from app.db import get_engine
+
+    with Session(get_engine()) as session:
+        session.execute(
+            text(
+                """
+                INSERT INTO home.calendar_snapshot (id, event_date, events, snapshot_at)
+                VALUES (1, :event_date, :events, now())
+                ON CONFLICT (id) DO UPDATE
+                    SET event_date = EXCLUDED.event_date,
+                        events = EXCLUDED.events,
+                        snapshot_at = EXCLUDED.snapshot_at
+                """
+            ),
+            {"event_date": event_date, "events": json.dumps(events)},
+        )
+        session.commit()
 
 
 async def poll_calendar() -> None:
-    global _cached_events
     if not ICAL_FEED_URL:
         logger.warning("ICAL_FEED_URL not set, skipping calendar poll")
         return
@@ -87,8 +126,9 @@ async def poll_calendar() -> None:
             resp = await client.get(ICAL_FEED_URL, timeout=30)
             resp.raise_for_status()
         today = datetime.now(TZ).date()
-        _cached_events = parse_events_for_date(resp.text, today, TZ)
-        logger.info("Calendar refreshed: %d events for %s", len(_cached_events), today)
+        events = parse_events_for_date(resp.text, today, TZ)
+        await asyncio.to_thread(_write_calendar_snapshot, today, events)
+        logger.info("Calendar refreshed: %d events for %s", len(events), today)
     except Exception:
         logger.exception("Failed to fetch calendar feed")
 

--- a/projects/monolith/home/schedule.py
+++ b/projects/monolith/home/schedule.py
@@ -7,6 +7,7 @@ from zoneinfo import ZoneInfo
 
 import httpx
 from icalendar import Calendar
+from sqlalchemy.exc import OperationalError, ProgrammingError
 from sqlmodel import Session, text
 
 logger = logging.getLogger(__name__)
@@ -77,11 +78,18 @@ def get_today_events(session: Session) -> list[dict]:
 
     Reads the single home.calendar_snapshot row written by poll_calendar. If the
     snapshot is for an earlier day (the poll has not run yet today) or is absent,
-    returns an empty list rather than stale events.
+    returns an empty list rather than stale events. A missing table (the SQLite
+    test fixtures build tables from SQLModel metadata, not migrations, and this
+    snapshot is raw-SQL; likewise a not-yet-migrated environment) degrades to an
+    empty list so the home page renders rather than 500ing.
     """
-    row = session.execute(
-        text("SELECT event_date, events FROM home.calendar_snapshot WHERE id = 1")
-    ).first()
+    try:
+        row = session.execute(
+            text("SELECT event_date, events FROM home.calendar_snapshot WHERE id = 1")
+        ).first()
+    except (OperationalError, ProgrammingError):
+        session.rollback()
+        return []
     if row is None:
         return []
     event_date, events = row

--- a/projects/monolith/home/schedule_extra_test.py
+++ b/projects/monolith/home/schedule_extra_test.py
@@ -1,9 +1,11 @@
 """Extra coverage tests for home/schedule.py — timezone-aware events,
 date-type DTEND, get_today_events(), and DTSTART with no value."""
 
-from datetime import date
-from unittest.mock import patch
+from datetime import date, datetime
+from unittest.mock import MagicMock
 from zoneinfo import ZoneInfo
+
+from sqlalchemy.exc import OperationalError
 
 import home.schedule as svc
 from home.schedule import get_today_events, parse_events_for_date
@@ -12,45 +14,56 @@ TZ = ZoneInfo("America/Vancouver")
 
 
 # ---------------------------------------------------------------------------
-# get_today_events
+# get_today_events — reads the home.calendar_snapshot row
 # ---------------------------------------------------------------------------
 
 
+def _session(row=None, *, raises=None):
+    """Fake session whose execute().first() returns `row`, or whose execute()
+    raises `raises` (to exercise the missing-table degradation)."""
+    session = MagicMock()
+    if raises is not None:
+        session.execute = MagicMock(side_effect=raises)
+    else:
+        result = MagicMock()
+        result.first = MagicMock(return_value=row)
+        session.execute = MagicMock(return_value=result)
+    return session
+
+
+def _today():
+    return datetime.now(svc.TZ).date()
+
+
 class TestGetTodayEvents:
-    def test_returns_empty_list_when_cache_empty(self):
-        """get_today_events returns [] when the in-memory cache is unpopulated."""
-        # Patch the module-level cache to be empty
-        with patch.object(svc, "_cached_events", []):
-            result = get_today_events()
-        assert result == []
+    def test_returns_empty_when_no_snapshot(self):
+        """No snapshot row -> []."""
+        assert get_today_events(_session(None)) == []
 
-    def test_returns_copy_of_cached_events(self):
-        """get_today_events returns a shallow copy, not the original list."""
-        fake_events = [{"time": "09:00", "title": "Standup", "allDay": False}]
-        with patch.object(svc, "_cached_events", fake_events):
-            result = get_today_events()
-        assert result == fake_events
-        assert result is not fake_events  # must be a copy
+    def test_returns_events_for_today(self):
+        """A snapshot dated today returns its events."""
+        events = [{"time": "09:00", "title": "Standup", "allDay": False}]
+        assert get_today_events(_session((_today(), events))) == events
 
-    def test_mutation_of_result_does_not_affect_cache(self):
-        """Mutating the returned list does not change the internal cache."""
-        original = [{"title": "Meeting"}]
-        with patch.object(svc, "_cached_events", list(original)):
-            result = get_today_events()
-            result.append({"title": "Extra"})
-            # Re-read the cache
-            assert len(get_today_events()) == 1
+    def test_returns_empty_when_stale(self):
+        """A snapshot from an earlier day returns [] (not stale events)."""
+        events = [{"time": None, "title": "Yesterday", "allDay": True}]
+        assert get_today_events(_session((date(2000, 1, 1), events))) == []
 
-    def test_returns_all_cached_events(self):
-        """get_today_events returns every item in the cache."""
-        fake_events = [
+    def test_returns_empty_when_table_missing(self):
+        """A missing table degrades to [] rather than raising (SQLite fixtures /
+        not-yet-migrated environments)."""
+        err = OperationalError("no such table", None, Exception())
+        assert get_today_events(_session(raises=err)) == []
+
+    def test_returns_all_events(self):
+        """Every event in the snapshot is returned."""
+        events = [
             {"time": None, "title": "Holiday", "allDay": True},
             {"time": "10:00", "title": "Sync", "allDay": False},
             {"time": "14:00", "title": "Demo", "allDay": False},
         ]
-        with patch.object(svc, "_cached_events", fake_events):
-            result = get_today_events()
-        assert len(result) == 3
+        assert len(get_today_events(_session((_today(), events)))) == 3
 
 
 # ---------------------------------------------------------------------------

--- a/projects/monolith/home/schedule_router.py
+++ b/projects/monolith/home/schedule_router.py
@@ -1,10 +1,12 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
+from sqlmodel import Session
 
+from app.db import get_session
 from home.schedule import get_today_events
 
 router = APIRouter(prefix="/api/home/schedule", tags=["schedule"])
 
 
 @router.get("/today")
-def schedule_today() -> list[dict]:
-    return get_today_events()
+def schedule_today(session: Session = Depends(get_session)) -> list[dict]:
+    return get_today_events(session)

--- a/projects/monolith/home/schedule_test.py
+++ b/projects/monolith/home/schedule_test.py
@@ -6,7 +6,39 @@ import httpx
 import pytest
 
 import home.schedule as svc
-from home.schedule import parse_events_for_date, poll_calendar
+from home.schedule import get_today_events, parse_events_for_date, poll_calendar
+
+
+class _RowSession:
+    """Fake session whose execute().first() returns a fixed (event_date, events)
+    tuple, or None for the no-snapshot case."""
+
+    def __init__(self, row):
+        self._row = row
+
+    def execute(self, *_a, **_k):
+        result = MagicMock()
+        result.first = MagicMock(return_value=self._row)
+        return result
+
+
+def _today():
+    return datetime.now(svc.TZ).date()
+
+
+def test_get_today_events_returns_events_for_today():
+    events = [{"title": "Standup", "time": "09:00", "allDay": False}]
+    assert get_today_events(_RowSession((_today(), events))) == events
+
+
+def test_get_today_events_empty_when_no_snapshot():
+    assert get_today_events(_RowSession(None)) == []
+
+
+def test_get_today_events_empty_when_snapshot_is_stale():
+    events = [{"title": "Yesterday", "time": None, "allDay": True}]
+    assert get_today_events(_RowSession((date(2000, 1, 1), events))) == []
+
 
 TZ = ZoneInfo("America/Vancouver")
 
@@ -125,140 +157,93 @@ def test_missing_dtend_returns_none():
 # ---------------------------------------------------------------------------
 
 
+def _mock_client(*, get=None, response=None):
+    """Build an httpx.AsyncClient-shaped async-context mock."""
+    client = AsyncMock()
+    client.get = AsyncMock(side_effect=get) if get else AsyncMock(return_value=response)
+    client.__aenter__ = AsyncMock(return_value=client)
+    client.__aexit__ = AsyncMock(return_value=False)
+    return client
+
+
 @pytest.mark.asyncio
 async def test_poll_calendar_skips_when_url_not_set():
-    """poll_calendar returns immediately without touching the cache when ICAL_FEED_URL is empty."""
-    original = svc._cached_events
-    try:
-        svc._cached_events = [{"sentinel": True}]
-        with patch.object(svc, "ICAL_FEED_URL", ""):
-            await poll_calendar()
-        # Cache must be untouched
-        assert svc._cached_events == [{"sentinel": True}]
-    finally:
-        svc._cached_events = original
+    """poll_calendar returns without writing a snapshot when ICAL_FEED_URL is empty."""
+    with (
+        patch.object(svc, "ICAL_FEED_URL", ""),
+        patch.object(svc, "_write_calendar_snapshot") as write,
+    ):
+        await poll_calendar()
+    write.assert_not_called()
 
 
 @pytest.mark.asyncio
 async def test_poll_calendar_handles_network_failure():
-    """Network error during calendar fetch is caught; _cached_events is not cleared."""
-    original = svc._cached_events
-    try:
-        sentinel_events = [{"title": "Keep me", "time": None, "allDay": True}]
-        svc._cached_events = sentinel_events.copy()
-
-        mock_client = AsyncMock()
-        mock_client.get = AsyncMock(
-            side_effect=httpx.ConnectError("connection refused")
-        )
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=False)
-
-        with (
-            patch.object(svc, "ICAL_FEED_URL", "http://example.com/calendar.ics"),
-            patch("home.schedule.httpx.AsyncClient", return_value=mock_client),
-        ):
-            await poll_calendar()
-
-        # Cache must be preserved after a network failure
-        assert svc._cached_events == sentinel_events
-    finally:
-        svc._cached_events = original
+    """Network error during fetch is caught; no snapshot is written."""
+    client = _mock_client(get=httpx.ConnectError("connection refused"))
+    with (
+        patch.object(svc, "ICAL_FEED_URL", "http://example.com/calendar.ics"),
+        patch("home.schedule.httpx.AsyncClient", return_value=client),
+        patch.object(svc, "_write_calendar_snapshot") as write,
+    ):
+        await poll_calendar()
+    write.assert_not_called()
 
 
 @pytest.mark.asyncio
 async def test_poll_calendar_handles_http_error_response():
-    """HTTP error status (e.g. 500) is caught via raise_for_status; cache is preserved."""
-    original = svc._cached_events
-    try:
-        sentinel_events = [{"title": "Keep me", "time": None, "allDay": True}]
-        svc._cached_events = sentinel_events.copy()
-
-        mock_response = MagicMock()
-        mock_response.raise_for_status = MagicMock(
-            side_effect=httpx.HTTPStatusError(
-                "500 Internal Server Error",
-                request=MagicMock(),
-                response=MagicMock(),
-            )
+    """HTTP error status (e.g. 500) is caught via raise_for_status; no write."""
+    response = MagicMock()
+    response.raise_for_status = MagicMock(
+        side_effect=httpx.HTTPStatusError(
+            "500 Internal Server Error", request=MagicMock(), response=MagicMock()
         )
-
-        mock_client = AsyncMock()
-        mock_client.get = AsyncMock(return_value=mock_response)
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=False)
-
-        with (
-            patch.object(svc, "ICAL_FEED_URL", "http://example.com/calendar.ics"),
-            patch("home.schedule.httpx.AsyncClient", return_value=mock_client),
-        ):
-            await poll_calendar()
-
-        # Cache must be preserved after an HTTP error
-        assert svc._cached_events == sentinel_events
-    finally:
-        svc._cached_events = original
+    )
+    client = _mock_client(response=response)
+    with (
+        patch.object(svc, "ICAL_FEED_URL", "http://example.com/calendar.ics"),
+        patch("home.schedule.httpx.AsyncClient", return_value=client),
+        patch.object(svc, "_write_calendar_snapshot") as write,
+    ):
+        await poll_calendar()
+    write.assert_not_called()
 
 
 @pytest.mark.asyncio
 async def test_poll_calendar_handles_malformed_ical():
-    """A parse error from malformed iCal bytes is caught; _cached_events is not cleared.
+    """A parse error from malformed iCal bytes is caught; no snapshot is written.
 
-    This test exercises the real parse path: Calendar.from_ical() raises when given
-    garbage data, and poll_calendar()'s broad except clause must absorb that error and
-    leave the existing cache intact.
+    Exercises the real parse path: Calendar.from_ical() raises on garbage data,
+    and poll_calendar()'s broad except clause must absorb it without writing.
     """
-    original = svc._cached_events
-    try:
-        sentinel_events = [{"title": "Keep me", "time": None, "allDay": True}]
-        svc._cached_events = sentinel_events.copy()
-
-        mock_response = MagicMock()
-        mock_response.raise_for_status = MagicMock(return_value=None)
-        # Provide genuinely malformed iCal bytes so Calendar.from_ical() raises
-        mock_response.text = "NOT-ICAL\x00\xff garbage data that no parser can handle"
-
-        mock_client = AsyncMock()
-        mock_client.get = AsyncMock(return_value=mock_response)
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=False)
-
-        with (
-            patch.object(svc, "ICAL_FEED_URL", "http://example.com/calendar.ics"),
-            patch("home.schedule.httpx.AsyncClient", return_value=mock_client),
-        ):
-            await poll_calendar()
-
-        # Cache must be preserved after a parse error
-        assert svc._cached_events == sentinel_events
-    finally:
-        svc._cached_events = original
+    response = MagicMock()
+    response.raise_for_status = MagicMock(return_value=None)
+    response.text = "NOT-ICAL\x00\xff garbage data that no parser can handle"
+    client = _mock_client(response=response)
+    with (
+        patch.object(svc, "ICAL_FEED_URL", "http://example.com/calendar.ics"),
+        patch("home.schedule.httpx.AsyncClient", return_value=client),
+        patch.object(svc, "_write_calendar_snapshot") as write,
+    ):
+        await poll_calendar()
+    write.assert_not_called()
 
 
 @pytest.mark.asyncio
-async def test_poll_calendar_updates_cache_on_success():
-    """On a successful fetch, _cached_events is replaced with parsed events."""
-    original = svc._cached_events
-    try:
-        svc._cached_events = []
-
-        valid_events = [{"title": "Standup", "time": "09:00", "allDay": False}]
-        mock_response = MagicMock()
-        mock_response.raise_for_status = MagicMock(return_value=None)
-        mock_response.text = "BEGIN:VCALENDAR\nVERSION:2.0\nEND:VCALENDAR\n"
-
-        mock_client = AsyncMock()
-        mock_client.get = AsyncMock(return_value=mock_response)
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=False)
-
-        with (
-            patch.object(svc, "ICAL_FEED_URL", "http://example.com/calendar.ics"),
-            patch("home.schedule.httpx.AsyncClient", return_value=mock_client),
-            patch.object(svc, "parse_events_for_date", return_value=valid_events),
-        ):
-            await poll_calendar()
-
-        assert svc._cached_events == valid_events
-    finally:
-        svc._cached_events = original
+async def test_poll_calendar_writes_snapshot_on_success():
+    """On a successful fetch, the parsed events are written to the snapshot."""
+    valid_events = [{"title": "Standup", "time": "09:00", "allDay": False}]
+    response = MagicMock()
+    response.raise_for_status = MagicMock(return_value=None)
+    response.text = "BEGIN:VCALENDAR\nVERSION:2.0\nEND:VCALENDAR\n"
+    client = _mock_client(response=response)
+    with (
+        patch.object(svc, "ICAL_FEED_URL", "http://example.com/calendar.ics"),
+        patch("home.schedule.httpx.AsyncClient", return_value=client),
+        patch.object(svc, "parse_events_for_date", return_value=valid_events),
+        patch.object(svc, "_write_calendar_snapshot") as write,
+    ):
+        await poll_calendar()
+    write.assert_called_once()
+    # Second positional arg is the parsed events list.
+    assert write.call_args.args[1] == valid_events

--- a/projects/monolith/home/tests/bdd_public_test.py
+++ b/projects/monolith/home/tests/bdd_public_test.py
@@ -9,8 +9,10 @@ import home
 
 class TestPublicFunctions:
     @covers_public("home.get_today_events")
-    def test_get_today_events_returns_list(self):
-        result = home.get_today_events()
+    def test_get_today_events_returns_list(self, session):
+        # The test session is SQLite with no calendar_snapshot table, so the
+        # reader degrades to []; the point here is the public surface shape.
+        result = home.get_today_events(session)
         assert isinstance(result, list)
 
     @covers_public("home.on_startup_jobs")

--- a/projects/platform/kyverno/templates/clone-monolith-pg-secret-policy.yaml
+++ b/projects/platform/kyverno/templates/clone-monolith-pg-secret-policy.yaml
@@ -65,6 +65,27 @@ spec:
         clone:
           namespace: monolith
           name: monolith-clickhouse
+    # The home.calendar_poll CronWorkflow fetches the iCal feed; clone the
+    # 1Password-backed monolith-secrets Secret (single key ICAL_FEED_URL) into
+    # monolith-workflows so the job pod can read the feed URL.
+    - name: clone-secrets-to-monolith-workflows
+      match:
+        any:
+          - resources:
+              kinds:
+                - Namespace
+              names:
+                - monolith-workflows
+      generate:
+        apiVersion: v1
+        kind: Secret
+        name: monolith-secrets
+        namespace: monolith-workflows
+        synchronize: true
+        generateExisting: true
+        clone:
+          namespace: monolith
+          name: monolith-secrets
 ---
 # Kyverno 3.x restricts both controllers' Secret access by default. The
 # BACKGROUND controller does the actual clone (needs get/list/watch on the


### PR DESCRIPTION
## Phase C of migrate-all: a persistence refactor, not a mechanical cutover

`calendar_poll` warmed a **process-local in-memory cache** (`_cached_events`) that only the polling replica saw - so it could not run as an off-pod job (an ephemeral pod updating its own memory and exiting does nothing). Naively cutting it over would have silently emptied the calendar.

Fix: persist to a single `home.calendar_snapshot` row (the same pattern `topology_snapshot`/`stats_snapshot` already use). The poll writes it (now a stateless Argo CronWorkflow); `/api/home/schedule/today` reads it. Every API replica now serves the same events from one shared row instead of each warming its own cache - which also removes a latent multi-replica inconsistency as the web tier scales out (the whole point of the leader-election work).

## Changes
- **Migration** `20260622120000_home_calendar_snapshot.sql`: single-row table, `events` JSONB + `event_date` (a stale snapshot from a missed run returns nothing, not yesterday's events).
- `schedule.py`: `poll_calendar` writes the snapshot (own session via `to_thread`); `get_today_events(session)` reads it. Removed the `_cached_events` global + the dead `home` wrapper.
- `schedule_router.py`: session dependency.
- `jobs_main` `home-calendar-poll` subcommand; values entry (`ICAL_FEED_URL` via `secretEnv`); Kyverno clone of the single-key `monolith-secrets` into `monolith-workflows`.
- Rewrote the 5 poll tests (assert snapshot write/skip instead of the removed global) + added 3 reader tests.

## Validation (post-merge)
Two apps sync (kyverno for the secret clone, monolith chart). Confirm `home.calendar_snapshot` exists, hand-trigger the job, verify it writes a row, and `/api/home/schedule/today` returns today's events.

🤖 Generated with [Claude Code](https://claude.com/claude-code)