### PR TITLE
feat(monolith): cut over chat.summary_generation to Argo (phase D, part 1)

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.55.1
+version: 0.56.0
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.55.1
+      targetRevision: 0.56.0
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/app/jobs_main.py
+++ b/projects/monolith/app/jobs_main.py
@@ -278,5 +278,12 @@ def home_calendar_poll() -> None:
     logger.info("home-calendar-poll: done")
 
 
+@app.command("chat-summary-generation")
+def chat_summary_generation() -> None:
+    """Generate per-user and per-channel chat summaries (one-shot of
+    chat.summary_generation). Needs LLAMA_CPP_URL (Qwen); no bot required."""
+    _run_job("chat-summary-generation", "chat.api", "run_summary_generation")
+
+
 if __name__ == "__main__":
     app()

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.211.1
+version: 0.212.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/values.yaml
+++ b/projects/monolith/chart/values.yaml
@@ -333,6 +333,25 @@ jobs:
           memory: 256Mi
         limits:
           memory: 256Mi
+    # chat.summary_generation: per-user + per-channel LLM summaries. LLM-only
+    # (Qwen via LLAMA_CPP_URL), no Discord bot needed, so it is a clean cutover.
+    # Daily (was 86400s); generous deadline since it loops users/channels with
+    # an LLM call each.
+    - name: chat-summary-generation
+      replaces: chat.summary_generation
+      args: ["chat-summary-generation"]
+      schedule: "30 5 * * *" # daily 05:30 UTC
+      concurrencyPolicy: Forbid
+      activeDeadlineSeconds: 1800
+      suspend: false
+      env:
+        LLAMA_CPP_URL: "http://inference.inference.svc.cluster.local:8080"
+      resources:
+        requests:
+          cpu: 250m
+          memory: 512Mi
+        limits:
+          memory: 512Mi
 
 frontend:
   otelCollectorUrl: ""

--- a/projects/monolith/chat/api.py
+++ b/projects/monolith/chat/api.py
@@ -7,5 +7,6 @@ Other domains must import from ``chat.api`` (enforced by
 from __future__ import annotations
 
 from chat.bot import send_message  # re-exported
+from chat.summarizer import run_summary_generation  # re-exported
 
-__all__ = ["send_message"]
+__all__ = ["run_summary_generation", "send_message"]

--- a/projects/monolith/chat/summarizer.py
+++ b/projects/monolith/chat/summarizer.py
@@ -194,6 +194,21 @@ async def generate_channel_summaries(
     logger.info("Channel summary generation complete for %d channels", len(channels))
 
 
+async def run_summary_generation(
+    session: "Session",
+    llm_call: Callable[[str], Awaitable[str]] | None = None,
+) -> None:
+    """Generate per-user and per-channel chat summaries.
+
+    Module-level entrypoint so the one-shot jobs image (jobs_main
+    chat-summary-generation) can run it without the scheduler closure. Builds
+    its own LLM caller (Qwen via LLAMA_CPP_URL) when one is not injected."""
+    if llm_call is None:
+        llm_call = build_llm_caller()
+    await generate_summaries(session, llm_call)
+    await generate_channel_summaries(session, llm_call)
+
+
 def on_startup(
     session: "Session",
     *,
@@ -207,8 +222,7 @@ def on_startup(
         llm_call = build_llm_caller()
 
     async def _summary_handler(session: "Session") -> None:
-        await generate_summaries(session, llm_call)
-        await generate_channel_summaries(session, llm_call)
+        await run_summary_generation(session, llm_call)
         return None
 
     register_job(

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.211.1
+      targetRevision: 0.212.0
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
## Phase D, part 1: the clean half of chat

`chat.summary_generation` (daily per-user + per-channel chat summaries) is **LLM-only** - it calls Qwen via `LLAMA_CPP_URL`, no Discord bot. So it's a clean cutover like the others.

- Exposed a module-level `run_summary_generation` (the handler was a nested closure inside `chat.on_startup`); the in-process closure now delegates to it.
- Re-exported via `chat.api` (the enforced domain boundary; `jobs_main` imports through it).
- `chat-summary-generation` subcommand + cronWorkflows entry (`LLAMA_CPP_URL` env, daily 05:30 UTC). `ARGO_JOBS` skips the in-process registration once deployed.

## chat.changelog.* deferred (needs your call)
The 3 changelog jobs post via the **live Discord bot**, which is a leader-only singleton - so they can't run in an ephemeral Argo pod, and posting via the private API hits the round-robin/bot-less-follower problem. Tracked separately pending the architecture decision (Postgres outbox vs bot-internal scheduling). This also surfaced that the `notify` path is latently broken under multi-replica scaling.

## Validation
Hand-trigger; confirm `Succeeded` and that summaries are written (chat summary tables updated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)