### PR TITLE
feat(monolith): cut over chat.changelog.* to Argo via the outbox (phase D, part 2b)

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.57.1
+version: 0.58.0
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.57.1
+      targetRevision: 0.58.0
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/app/jobs_main.py
+++ b/projects/monolith/app/jobs_main.py
@@ -285,5 +285,18 @@ def chat_summary_generation() -> None:
     _run_job("chat-summary-generation", "chat.api", "run_summary_generation")
 
 
+@app.command("chat-changelog")
+def chat_changelog(name: str) -> None:
+    """Compute the changelog for one config and enqueue it to the Discord outbox
+    (one-shot of chat.changelog.<name>; the leader's drain posts it). Needs
+    GITHUB_TOKEN, CHANGELOG_CONFIGS, LLAMA_CPP_URL; no bot required."""
+    from chat.api import run_changelog_for_config
+
+    configure_logging()
+    logger.info("chat-changelog[%s]: starting", name)
+    asyncio.run(run_changelog_for_config(name))
+    logger.info("chat-changelog[%s]: done", name)
+
+
 if __name__ == "__main__":
     app()

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.213.1
+version: 0.214.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/templates/cronworkflows.yaml
+++ b/projects/monolith/chart/templates/cronworkflows.yaml
@@ -87,6 +87,20 @@ spec:
             - name: STARS_CLIMATOLOGY_S3_KEY
               value: {{ $.Values.stars.climatologyKey | quote }}
             {{- end }}
+            {{- if .changelog }}
+            # chat.changelog needs the full config list (to look up the named
+            # config) + a GitHub token. CHANGELOG_CONFIGS mirrors the deployment;
+            # GITHUB_TOKEN comes from the monolith-chat-secrets Secret cloned into
+            # monolith-workflows. No bot token is referenced - the job only
+            # enqueues; the leader's drain posts.
+            - name: CHANGELOG_CONFIGS
+              value: {{ $.Values.chat.changelogs | toJson | quote }}
+            - name: GITHUB_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: monolith-chat-secrets
+                  key: GITHUB_TOKEN
+            {{- end }}
           {{- with .resources }}
           resources:
             {{- toYaml . | nindent 12 }}

--- a/projects/monolith/chart/values.yaml
+++ b/projects/monolith/chart/values.yaml
@@ -352,6 +352,58 @@ jobs:
           memory: 512Mi
         limits:
           memory: 512Mi
+    # chat.changelog.* (one per config): fetch new commits, summarize via Qwen,
+    # ENQUEUE the embed to the Discord outbox (the leader's bot drains + posts).
+    # No bot in the job. `changelog: true` injects CHANGELOG_CONFIGS + GITHUB_TOKEN.
+    # Hourly (was intervalHours=1), offset so the three do not fire together.
+    - name: chat-changelog-homelab
+      replaces: chat.changelog.homelab
+      args: ["chat-changelog", "homelab"]
+      schedule: "5 * * * *"
+      concurrencyPolicy: Forbid
+      activeDeadlineSeconds: 600
+      suspend: false
+      changelog: true
+      env:
+        LLAMA_CPP_URL: "http://inference.inference.svc.cluster.local:8080"
+      resources:
+        requests:
+          cpu: 250m
+          memory: 512Mi
+        limits:
+          memory: 512Mi
+    - name: chat-changelog-colin-homelab
+      replaces: chat.changelog.colin-homelab
+      args: ["chat-changelog", "colin-homelab"]
+      schedule: "10 * * * *"
+      concurrencyPolicy: Forbid
+      activeDeadlineSeconds: 600
+      suspend: false
+      changelog: true
+      env:
+        LLAMA_CPP_URL: "http://inference.inference.svc.cluster.local:8080"
+      resources:
+        requests:
+          cpu: 250m
+          memory: 512Mi
+        limits:
+          memory: 512Mi
+    - name: chat-changelog-loom
+      replaces: chat.changelog.loom
+      args: ["chat-changelog", "loom"]
+      schedule: "15 * * * *"
+      concurrencyPolicy: Forbid
+      activeDeadlineSeconds: 600
+      suspend: false
+      changelog: true
+      env:
+        LLAMA_CPP_URL: "http://inference.inference.svc.cluster.local:8080"
+      resources:
+        requests:
+          cpu: 250m
+          memory: 512Mi
+        limits:
+          memory: 512Mi
 
 frontend:
   otelCollectorUrl: ""

--- a/projects/monolith/chat/api.py
+++ b/projects/monolith/chat/api.py
@@ -7,7 +7,13 @@ Other domains must import from ``chat.api`` (enforced by
 from __future__ import annotations
 
 from chat.bot import send_message  # re-exported
+from chat.changelog import run_changelog_for_config  # re-exported
 from chat.outbox import enqueue_message  # re-exported
 from chat.summarizer import run_summary_generation  # re-exported
 
-__all__ = ["enqueue_message", "run_summary_generation", "send_message"]
+__all__ = [
+    "enqueue_message",
+    "run_changelog_for_config",
+    "run_summary_generation",
+    "send_message",
+]

--- a/projects/monolith/chat/changelog.py
+++ b/projects/monolith/chat/changelog.py
@@ -1,5 +1,6 @@
 """Hourly changelog notifier — polls GitHub for new feat commits, summarizes via Qwen, posts to Discord."""
 
+import asyncio
 import dataclasses
 import json
 import logging
@@ -231,3 +232,81 @@ async def run_changelog_iteration(
         logger.warning(
             "Changelog[%s]: channel %s not found", config.name, config.channel_id
         )
+
+
+def _enqueue_changelog(channel_id: str, embed_dict: dict) -> None:
+    """Enqueue a changelog embed to the Discord outbox. Sync so the async job
+    can hand it to a worker thread (no sync Session on the event loop)."""
+    from app.db import get_engine
+    from chat.outbox import enqueue_message
+    from sqlmodel import Session
+
+    with Session(get_engine()) as session:
+        enqueue_message(session, channel_id, embed=embed_dict)
+        session.commit()
+
+
+async def run_changelog_for_config(
+    name: str,
+    llm_call: Callable[[str], Awaitable[str]] | None = None,
+) -> None:
+    """One-shot changelog for a named config, ENQUEUED to the Discord outbox.
+
+    Module-level entrypoint for the off-pod Argo job (jobs_main chat-changelog
+    <name>). It computes the embed exactly like run_changelog_iteration (GitHub
+    fetch + Qwen summary), but instead of posting via the bot it enqueues the
+    embed - the leader's outbox drain posts it. No bot is required, so this runs
+    in an ephemeral pod. Reads the config from CHANGELOG_CONFIGS by name.
+
+    The in-process path's best-effort store-after-send (which made the changelog
+    searchable in the bot's memory, keyed on the real sent message id) is not
+    reproduced here: the job has no sent id until the drain posts. Users still
+    see the post; only the bot-memory searchability is dropped. It can be added
+    back later by having the drain store after posting.
+    """
+    if llm_call is None:
+        from chat.summarizer import build_llm_caller
+
+        llm_call = build_llm_caller()
+
+    configs = load_changelog_configs(os.environ.get("CHANGELOG_CONFIGS", ""))
+    config = next((c for c in configs if c.name == name), None)
+    if config is None:
+        logger.warning("Changelog[%s]: no matching config in CHANGELOG_CONFIGS", name)
+        return
+
+    github_token = os.environ.get("GITHUB_TOKEN", "")
+    if not github_token:
+        logger.warning("Changelog[%s] disabled: missing GITHUB_TOKEN", config.name)
+        return
+
+    since = datetime.now(timezone.utc) - timedelta(hours=config.interval_hours)
+    async with httpx.AsyncClient(timeout=httpx.Timeout(600.0)) as client:
+        commits = await _fetch_commits_since(
+            client, config.github_repo, github_token, since
+        )
+        if not commits:
+            logger.info("Changelog[%s]: no new commits", config.name)
+            return
+        if config.commit_filter is not None:
+            commits = _filter_changelog_commits(commits, config.commit_filter)
+    if not commits:
+        logger.info("Changelog[%s]: commits found but none match filter", config.name)
+        return
+
+    prompt_key = config.prompt
+    if config.roast_chance > 0 and random.random() < config.roast_chance:
+        prompt_key = "roast"
+        logger.info("Changelog[%s]: roast mode activated", config.name)
+    summary = await _summarize_with_qwen(commits, llm_call, PROMPTS[prompt_key])
+    embed = _build_embed(
+        summary, len(commits), title=config.embed_title, color=config.embed_color
+    )
+
+    await asyncio.to_thread(_enqueue_changelog, config.channel_id, embed.to_dict())
+    logger.info(
+        "Changelog[%s]: enqueued %d changes to channel %s",
+        config.name,
+        len(commits),
+        config.channel_id,
+    )

--- a/projects/monolith/chat/changelog_test.py
+++ b/projects/monolith/chat/changelog_test.py
@@ -1,6 +1,7 @@
 """Tests for the hourly changelog notifier module."""
 
 import json
+import os
 import re
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -16,6 +17,7 @@ from chat.changelog import (
     _filter_changelog_commits,
     _summarize_with_qwen,
     load_changelog_configs,
+    run_changelog_for_config,
     run_changelog_iteration,
 )
 
@@ -400,8 +402,6 @@ class TestRunChangelogIteration:
         config = _make_config()
 
         with patch.dict("os.environ", {}, clear=True):
-            import os
-
             os.environ.pop("GITHUB_TOKEN", None)
             await run_changelog_iteration(bot, mock_llm, config)
 
@@ -670,3 +670,92 @@ class TestRunChangelogIteration:
         prompt_used = mock_llm.call_args[0][0]
         assert "roasting" not in prompt_used
         assert "changelog writer" in prompt_used
+
+
+def _configs_json(name="homelab", channel="999"):
+    return json.dumps(
+        [
+            {
+                "name": name,
+                "githubRepo": "owner/repo",
+                "channelId": channel,
+                "prompt": "professional",
+                "embedTitle": "Homelab Changelog",
+                "embedColor": "2ECC71",
+                "intervalHours": 1,
+            }
+        ]
+    )
+
+
+def _http_client(commits):
+    response = MagicMock()
+    response.json.return_value = commits
+    response.raise_for_status = MagicMock()
+    client = AsyncMock()
+    client.get = AsyncMock(return_value=response)
+    client.__aenter__ = AsyncMock(return_value=client)
+    client.__aexit__ = AsyncMock(return_value=False)
+    return client
+
+
+class TestRunChangelogForConfig:
+    """The off-pod Argo entrypoint: compute the embed and enqueue it (no bot)."""
+
+    @pytest.mark.asyncio
+    async def test_enqueues_embed_for_matching_config(self):
+        mock_llm = AsyncMock(return_value="Added a great new feature.")
+        client = _http_client([_make_commit("feat: amazing thing", "Alice")])
+        with (
+            patch.dict(
+                "os.environ",
+                {"GITHUB_TOKEN": "ghp_tok", "CHANGELOG_CONFIGS": _configs_json()},
+            ),
+            patch("chat.changelog.httpx.AsyncClient", return_value=client),
+            patch("chat.changelog._enqueue_changelog") as enqueue,
+        ):
+            await run_changelog_for_config("homelab", mock_llm)
+
+        mock_llm.assert_called_once()
+        enqueue.assert_called_once()
+        assert enqueue.call_args.args[0] == "999"  # channel_id
+        assert isinstance(enqueue.call_args.args[1], dict)  # serialised embed
+
+    @pytest.mark.asyncio
+    async def test_no_matching_config_does_not_enqueue(self):
+        with (
+            patch.dict(
+                "os.environ",
+                {"GITHUB_TOKEN": "ghp_tok", "CHANGELOG_CONFIGS": "[]"},
+            ),
+            patch("chat.changelog._enqueue_changelog") as enqueue,
+        ):
+            await run_changelog_for_config("nope", AsyncMock())
+        enqueue.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_no_commits_does_not_enqueue(self):
+        client = _http_client([])
+        with (
+            patch.dict(
+                "os.environ",
+                {"GITHUB_TOKEN": "ghp_tok", "CHANGELOG_CONFIGS": _configs_json()},
+            ),
+            patch("chat.changelog.httpx.AsyncClient", return_value=client),
+            patch("chat.changelog._enqueue_changelog") as enqueue,
+        ):
+            await run_changelog_for_config("homelab", AsyncMock())
+        enqueue.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_missing_github_token_does_not_enqueue(self):
+        with (
+            patch.dict(
+                "os.environ",
+                {"CHANGELOG_CONFIGS": _configs_json()},
+                clear=True,
+            ),
+            patch("chat.changelog._enqueue_changelog") as enqueue,
+        ):
+            await run_changelog_for_config("homelab", AsyncMock())
+        enqueue.assert_not_called()

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.213.1
+      targetRevision: 0.214.0
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/platform/kyverno/templates/clone-monolith-pg-secret-policy.yaml
+++ b/projects/platform/kyverno/templates/clone-monolith-pg-secret-policy.yaml
@@ -86,6 +86,32 @@ spec:
         clone:
           namespace: monolith
           name: monolith-secrets
+    # The chat.changelog CronWorkflows need GITHUB_TOKEN. It lives in
+    # monolith-chat-secrets, which ALSO holds the Discord bot token. The
+    # changelog jobs only wire GITHUB_TOKEN (they enqueue, never post), but
+    # cloning the whole secret puts the bot token in monolith-workflows too -
+    # an acceptable widening within the monolith trust domain (the namespace
+    # already holds the monolith-pg password), but tighten it later to a
+    # single-key generate (data-from-apiCall) if least-privilege on the bot
+    # token is wanted.
+    - name: clone-chat-secrets-to-monolith-workflows
+      match:
+        any:
+          - resources:
+              kinds:
+                - Namespace
+              names:
+                - monolith-workflows
+      generate:
+        apiVersion: v1
+        kind: Secret
+        name: monolith-chat-secrets
+        namespace: monolith-workflows
+        synchronize: true
+        generateExisting: true
+        clone:
+          namespace: monolith
+          name: monolith-chat-secrets
 ---
 # Kyverno 3.x restricts both controllers' Secret access by default. The
 # BACKGROUND controller does the actual clone (needs get/list/watch on the


### PR DESCRIPTION
## Phase D, part 2b: changelog → Argo via the outbox (the last migrate-all job)

The 3 `chat.changelog.*` jobs posted via the leader-only Discord bot, so they couldn't run off-pod. Now they do, using the outbox shipped in part 2a: a `chat-changelog <name>` Argo job fetches commits + summarises via Qwen + builds the embed (**no bot**), then **enqueues** the embed to `chat.discord_outbox`; the leader's drain posts it.

- `chat/changelog.py`: `run_changelog_for_config(name)` — computes the embed (reusing the existing helpers) and enqueues. The in-process `run_changelog_iteration` and its 6+ tests are left **untouched** (too risky to refactor without a local test loop).
- `chat.api` re-exports it; `jobs_main chat-changelog <name>` subcommand.
- `cronworkflows.yaml`: `changelog: true` flag injects `CHANGELOG_CONFIGS` + `GITHUB_TOKEN`. 3 hourly values entries (offset 5/10/15). `ARGO_JOBS` gains all three → `on_startup_jobs` skips them.
- kyverno: clone `monolith-chat-secrets` into `monolith-workflows` for `GITHUB_TOKEN`.

## ⚠️ Two things flagged for your review

1. **Security — secret scope.** `monolith-chat-secrets` also holds the **Discord bot token**. The changelog jobs only wire `GITHUB_TOKEN` (they enqueue, never post), but cloning the whole secret puts the bot token in `monolith-workflows`. Acceptable within the monolith trust domain (the namespace already holds the pg password), but worth tightening to a single-key generate (`data`-from-`apiCall`) later. **Want me to do that now or follow up?**
2. **Behavior — store-after-send dropped.** The in-process path stored the posted changelog as a chat message (searchable in the bot's memory, keyed on the real sent id). The job has no sent id until the drain posts, so that's dropped here. Users still see the post; only bot-memory searchability is lost. Can be restored by having the drain store after posting.

## Validation (post-merge)
Hand-trigger `chat-changelog homelab`; confirm it enqueues a row in `chat.discord_outbox` (embed_json set) and the leader's drain posts the changelog embed to Discord. This is the **last job** — after it, `scheduler.scheduled_jobs` is empty and Phase E (delete the scheduler) can land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)