### PR TITLE
refactor(monolith): delete in-process scheduler dispatch loop (Phase E)

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.58.0
+version: 0.58.1
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.58.0
+      targetRevision: 0.58.1
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/app/main.py
+++ b/projects/monolith/app/main.py
@@ -57,12 +57,11 @@ def _log_task_exception(task: "asyncio.Task[object]") -> None:
 async def _start_singletons(app: FastAPI) -> None:
     """Start the background singletons. Invoked only on the elected leader replica.
 
-    These (Discord bot, scheduler dispatch loop, AIS ingest, bot-coupled lock
+    These (Discord bot, Discord outbox drain, AIS ingest, bot-coupled lock
     sweep) must run on exactly one replica, so they live behind leader election
     rather than starting unconditionally in the lifespan.
     """
     from app.db import get_engine
-    from scheduler.api import purge_stale_jobs, run_scheduler_loop
     from sqlmodel import Session
 
     tasks: list[asyncio.Task] = []
@@ -97,15 +96,6 @@ async def _start_singletons(app: FastAPI) -> None:
         drain_task.add_done_callback(_log_task_exception)
         tasks.append(drain_task)
         logger.info("Discord outbox drain starting")
-
-    # Purge stale jobs (registry housekeeping the leader owns).
-    with Session(get_engine()) as session:
-        purge_stale_jobs(session)
-
-    # Scheduler dispatch loop.
-    scheduler_task = asyncio.create_task(run_scheduler_loop())
-    scheduler_task.add_done_callback(_log_task_exception)
-    tasks.append(scheduler_task)
 
     # Supervised AISStream ingest (reconnects forever; CancelledError on stop).
     from ships.ingest import ais_stream_loop
@@ -176,28 +166,14 @@ async def _stop_singletons(app: FastAPI) -> None:
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    from app.db import get_engine
-    from sqlmodel import Session
-
     app.state.bot = None
     app.state.backfill_task = None
 
-    # Register all scheduled jobs
-    with Session(get_engine()) as session:
-        from knowledge.service import on_startup as knowledge_startup
-
-        knowledge_startup(session)
-        home.on_startup_jobs(session)
-        ships.on_startup_jobs(session)
-        hikes.on_startup_jobs(session)
-        stars.on_startup_jobs(session)
-        dr_jobs.on_startup_jobs(session)
-        worldcup.on_startup_jobs(session)
-        knowledge.on_startup_jobs(session)
-
-        from home.observability import rollup as observability_rollup
-
-        observability_rollup.register(session)
+    # All formerly in-process scheduled jobs now run as Argo CronWorkflows in the
+    # monolith-workflows namespace (one-flag cutover via jobs.cronWorkflows). The
+    # in-process scheduler dispatch loop and its register_job startup hooks were
+    # removed, so the monolith is purely orchestration + APIs - no batch work on
+    # the request-serving pods.
 
     # Prime the observability snapshots (topology + stats) once at startup so the
     # first request has data; the scheduled rollup jobs refresh them thereafter.

--- a/projects/monolith/app/main_extra_test.py
+++ b/projects/monolith/app/main_extra_test.py
@@ -1,6 +1,5 @@
 """Extra coverage for app/main.py lifespan -- exception paths in background tasks and bot.close()."""
 
-import asyncio
 import os
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -104,9 +103,10 @@ class TestSingletonBotClose:
         mock_bot.close.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_start_singletons_creates_five_tasks(self):
-        """The leader starts bot + outbox drain + scheduler + ships ingest + sweep
-        = 5 tasks."""
+    async def test_start_singletons_creates_four_tasks(self):
+        """The leader starts bot + outbox drain + ships ingest + sweep = 4 tasks
+        (the scheduler dispatch loop was removed - jobs run as Argo
+        CronWorkflows)."""
         tasks, capture = _make_task_capturer()
 
         mock_bot = MagicMock()
@@ -128,73 +128,7 @@ class TestSingletonBotClose:
         ):
             await _start_singletons(app)
 
-        assert len(tasks) == 5
-
-
-# ---------------------------------------------------------------------------
-# run_scheduler_loop raises (background task failure)
-# ---------------------------------------------------------------------------
-
-
-class TestLifespanRunSchedulerLoopException:
-    @pytest.mark.asyncio
-    async def test_lifespan_still_starts_when_run_scheduler_loop_raises(self):
-        """Lifespan yields normally even if run_scheduler_loop() raises immediately."""
-        started = False
-
-        async def failing_run_scheduler_loop():
-            raise RuntimeError("scheduler db error")
-
-        mock_session = MagicMock()
-        mock_session.__enter__ = MagicMock(return_value=mock_session)
-        mock_session.__exit__ = MagicMock(return_value=False)
-
-        with (
-            patch.dict(os.environ, {"DISCORD_BOT_TOKEN": ""}),
-            patch("app.db.get_engine", return_value=MagicMock()),
-            patch("sqlmodel.Session", return_value=mock_session),
-            patch("home.on_startup_jobs"),
-            patch("ships.on_startup_jobs"),
-            patch("hikes.on_startup_jobs"),
-            patch(
-                "scheduler.api.run_scheduler_loop",
-                new=failing_run_scheduler_loop,
-            ),
-        ):
-            async with lifespan(app):
-                await asyncio.sleep(0)
-                started = True
-
-        assert started, (
-            "lifespan should have yielded despite run_scheduler_loop failure"
-        )
-
-    @pytest.mark.asyncio
-    async def test_lifespan_shuts_down_cleanly_after_run_scheduler_loop_failure(self):
-        """Lifespan completes shutdown even when run_scheduler_loop already raised."""
-
-        async def failing_run_scheduler_loop():
-            raise RuntimeError("scheduler db error")
-
-        mock_session = MagicMock()
-        mock_session.__enter__ = MagicMock(return_value=mock_session)
-        mock_session.__exit__ = MagicMock(return_value=False)
-
-        with (
-            patch.dict(os.environ, {"DISCORD_BOT_TOKEN": ""}),
-            patch("app.db.get_engine", return_value=MagicMock()),
-            patch("sqlmodel.Session", return_value=mock_session),
-            patch("home.on_startup_jobs"),
-            patch("ships.on_startup_jobs"),
-            patch("hikes.on_startup_jobs"),
-            patch(
-                "scheduler.api.run_scheduler_loop",
-                new=failing_run_scheduler_loop,
-            ),
-        ):
-            # Should not raise — background task exceptions are not re-raised
-            async with lifespan(app):
-                await asyncio.sleep(0)
+        assert len(tasks) == 4
 
 
 # ---------------------------------------------------------------------------

--- a/projects/monolith/app/main_lifespan_discord_test.py
+++ b/projects/monolith/app/main_lifespan_discord_test.py
@@ -62,9 +62,9 @@ def _capture():
 
 class TestSingletons:
     @pytest.mark.asyncio
-    async def test_start_singletons_starts_five_tasks_with_token(self):
-        """With a token, the leader starts bot + outbox drain + scheduler + ships +
-        sweep = 5 tasks."""
+    async def test_start_singletons_starts_four_tasks_with_token(self):
+        """With a token, the leader starts bot + outbox drain + ships + sweep = 4
+        tasks (the scheduler dispatch loop was removed)."""
         created, cap = _capture()
         mock_bot = MagicMock()
         mock_bot.close = AsyncMock()
@@ -84,11 +84,12 @@ class TestSingletons:
         ):
             await _start_singletons(app)
 
-        assert len(created) == 5
+        assert len(created) == 4
 
     @pytest.mark.asyncio
-    async def test_start_singletons_two_tasks_without_token(self):
-        """Without a token: scheduler + ships ingest = 2 tasks (no bot, no sweep)."""
+    async def test_start_singletons_one_task_without_token(self):
+        """Without a token: ships ingest = 1 task (no bot, no drain, no sweep; the
+        scheduler dispatch loop was removed - jobs run as Argo CronWorkflows)."""
         created, cap = _capture()
         env = {k: v for k, v in os.environ.items() if k != "DISCORD_BOT_TOKEN"}
         env["DISCORD_BOT_TOKEN"] = ""
@@ -104,7 +105,7 @@ class TestSingletons:
         ):
             await _start_singletons(app)
 
-        assert len(created) == 2
+        assert len(created) == 1
 
     @pytest.mark.asyncio
     async def test_stop_singletons_closes_and_cancels(self):

--- a/projects/monolith/app/main_lock_sweep_test.py
+++ b/projects/monolith/app/main_lock_sweep_test.py
@@ -81,7 +81,7 @@ def _capture_sweep_coro():
     """Capture the _lock_sweep_loop coroutine (task 4) without closing it.
 
     Task order when DISCORD_BOT_TOKEN is set:
-      1=bot, 2=scheduler, 3=ships ingest, 4=sweep
+      1=bot, 2=outbox drain, 3=ships ingest, 4=sweep
     """
     mock_bot = MagicMock()
     mock_bot.close = AsyncMock()
@@ -93,8 +93,8 @@ def _capture_sweep_coro():
     def capture_create_task(coro, **kwargs):
         task_counter[0] += 1
         t = MagicMock()
-        # 5th task is the lock sweep (bot, outbox drain, scheduler, ships, sweep).
-        if task_counter[0] == 5:
+        # 4th task is the lock sweep (bot, outbox drain, ships, sweep).
+        if task_counter[0] == 4:
             coros.append(coro)  # preserve — do NOT close
         else:
             if hasattr(coro, "close"):
@@ -130,7 +130,7 @@ class TestSweepTaskRegistration:
     async def test_sweep_task_registers_done_callback_with_log_task_exception(self):
         """When DISCORD_BOT_TOKEN is set, sweep_task.add_done_callback(_log_task_exception) is called.
 
-        Task order: 1=bot, 2=scheduler, 3=ships ingest, 4=sweep.
+        Task order: 1=bot, 2=outbox drain, 3=ships ingest, 4=sweep.
         """
         mock_bot = MagicMock()
         mock_bot.close = AsyncMock()
@@ -142,8 +142,8 @@ class TestSweepTaskRegistration:
             if hasattr(coro, "close"):
                 coro.close()
             task_counter[0] += 1
-            # 5th task is the lock sweep (bot, outbox drain, scheduler, ships, sweep).
-            if task_counter[0] == 5:
+            # 4th task is the lock sweep (bot, outbox drain, ships, sweep).
+            if task_counter[0] == 4:
                 return sweep_task_mock
             return MagicMock()
 
@@ -226,8 +226,8 @@ class TestSweepTaskRegistration:
         ):
             await _start_singletons(app)
 
-        # 2 tasks should be created (scheduler + ships ingest)
-        assert len(tasks_created) == 2
+        # 1 task should be created (ships ingest only; scheduler loop removed)
+        assert len(tasks_created) == 1
         messages = [str(c) for c in mock_logger.info.call_args_list]
         assert not any("Message lock sweep started" in m for m in messages)
 

--- a/projects/monolith/app/main_sidecar_test.py
+++ b/projects/monolith/app/main_sidecar_test.py
@@ -477,7 +477,8 @@ async def test_start_bot_when_ready_not_scheduled_when_no_token():
     ):
         await _start_singletons(app)
 
-    # Scheduler + ships ingest task (no bot task)
-    assert len(created_tasks) == 2, (
-        f"Expected 2 tasks without a bot token, got {len(created_tasks)}"
+    # Ships ingest task only (no bot task; the scheduler dispatch loop was
+    # removed - batch jobs run as Argo CronWorkflows).
+    assert len(created_tasks) == 1, (
+        f"Expected 1 task without a bot token, got {len(created_tasks)}"
     )

--- a/projects/monolith/app/main_summary_test.py
+++ b/projects/monolith/app/main_summary_test.py
@@ -110,8 +110,8 @@ class TestChatStartupHook:
         mock_chat_startup.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_bot_task_and_scheduler_task_both_get_done_callback(self):
-        """Both the bot task and scheduler task register done callbacks."""
+    async def test_singleton_tasks_all_get_done_callback(self):
+        """Every singleton task registers a done callback."""
         mock_bot = MagicMock()
         mock_bot.close = AsyncMock()
 
@@ -141,17 +141,16 @@ class TestChatStartupHook:
         ):
             await _start_singletons(app)
 
-        assert len(task_mocks) == 5
-        # Tasks: 0=bot, 1=outbox drain, 2=scheduler, 3=ships ingest, 4=sweep, all
-        # have done callbacks.
+        assert len(task_mocks) == 4
+        # Tasks: 0=bot, 1=outbox drain, 2=ships ingest, 3=sweep, all have done
+        # callbacks. (The scheduler dispatch loop was removed - all batch jobs
+        # run as Argo CronWorkflows now.)
         bot_task = task_mocks[0]
         drain_task = task_mocks[1]
-        scheduler_task = task_mocks[2]
-        ships_task = task_mocks[3]
-        sweep_task = task_mocks[4]
+        ships_task = task_mocks[2]
+        sweep_task = task_mocks[3]
         bot_task.add_done_callback.assert_called_once_with(_log_task_exception)
         drain_task.add_done_callback.assert_called_once_with(_log_task_exception)
-        scheduler_task.add_done_callback.assert_called_once_with(_log_task_exception)
         ships_task.add_done_callback.assert_called_once_with(_log_task_exception)
         sweep_task.add_done_callback.assert_called_once_with(_log_task_exception)
 

--- a/projects/monolith/app/main_test.py
+++ b/projects/monolith/app/main_test.py
@@ -162,7 +162,8 @@ def _lifespan_patches_no_discord():
 
 @pytest.mark.asyncio
 async def test_lifespan_creates_one_background_task_on_startup():
-    """Lifespan creates two asyncio tasks (scheduler_loop + ships ingest) on startup without discord."""
+    """Without discord, the leader creates a single task (ships ingest); the
+    scheduler dispatch loop was removed - batch jobs run as Argo CronWorkflows."""
     from app.main import lifespan
 
     created_tasks = []
@@ -179,7 +180,7 @@ async def test_lifespan_creates_one_background_task_on_startup():
         with patches[0], patches[1], patches[2], patches[3], patches[4]:
             await _start_singletons(app)
 
-    assert len(created_tasks) == 2
+    assert len(created_tasks) == 1
 
 
 @pytest.mark.asyncio
@@ -202,7 +203,7 @@ async def test_lifespan_cancels_all_tasks_on_shutdown():
             await _start_singletons(app)
             await _stop_singletons(app)
 
-    assert len(mock_tasks) == 2
+    assert len(mock_tasks) == 1
     for task in mock_tasks:
         task.cancel.assert_called_once()
 
@@ -225,7 +226,7 @@ async def test_lifespan_no_tasks_cancelled_before_shutdown():
     with patch("asyncio.create_task", side_effect=capture_create_task):
         with patches[0], patches[1], patches[2], patches[3], patches[4]:
             await _start_singletons(app)
-            assert len(mock_tasks) == 2
+            assert len(mock_tasks) == 1
             for task in mock_tasks:
                 task.cancel.assert_not_called()
             await _stop_singletons(app)
@@ -233,39 +234,6 @@ async def test_lifespan_no_tasks_cancelled_before_shutdown():
     # After _stop_singletons, every task must have been cancelled
     for task in mock_tasks:
         task.cancel.assert_called_once()
-
-
-@pytest.mark.asyncio
-async def test_lifespan_scheduler_task_is_run_scheduler_loop():
-    """The scheduler task wraps run_scheduler_loop (the single scheduler loop)."""
-    from app.main import lifespan
-
-    mock_scheduler = AsyncMock()
-
-    def capture_create_task(coro, **kwargs):
-        if hasattr(coro, "close"):
-            coro.close()
-        return MagicMock()
-
-    patches = [
-        patch("app.db.get_engine", return_value=MagicMock()),
-        patch(
-            "sqlmodel.Session",
-            return_value=MagicMock(
-                __enter__=MagicMock(return_value=MagicMock()),
-                __exit__=MagicMock(return_value=False),
-            ),
-        ),
-        patch("home.on_startup_jobs"),
-        patch("scheduler.api.run_scheduler_loop", mock_scheduler),
-        patch("ships.on_startup_jobs"),
-        patch("hikes.on_startup_jobs"),
-    ]
-    with patch("asyncio.create_task", side_effect=capture_create_task):
-        with patches[0], patches[1], patches[2], patches[3], patches[4]:
-            await _start_singletons(app)
-
-    mock_scheduler.assert_called_once()
 
 
 # ---------------------------------------------------------------------------
@@ -485,9 +453,9 @@ async def test_lifespan_logs_discord_bot_starting_when_token_set():
 
 
 @pytest.mark.asyncio
-async def test_lifespan_creates_five_tasks_when_discord_token_set():
-    """When DISCORD_BOT_TOKEN is set, the leader creates five tasks (bot, outbox
-    drain, scheduler, ships ingest, sweep)."""
+async def test_lifespan_creates_four_tasks_when_discord_token_set():
+    """When DISCORD_BOT_TOKEN is set, the leader creates four tasks (bot, outbox
+    drain, ships ingest, sweep). The scheduler dispatch loop was removed."""
     from app.main import lifespan
 
     mock_bot = MagicMock()
@@ -517,7 +485,7 @@ async def test_lifespan_creates_five_tasks_when_discord_token_set():
             ):
                 await _start_singletons(app)
 
-    assert len(created_tasks) == 5
+    assert len(created_tasks) == 4
 
 
 @pytest.mark.asyncio

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.214.0
+version: 0.214.1
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.214.0
+      targetRevision: 0.214.1
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
## Phase E: the payoff of the jobs-to-Argo migration

This is the final phase of moving every batch/scheduled job off the
request-serving monolith pods and onto Argo CronWorkflows. Phases A-D cut
the jobs over one by one (each behind the `replaces`/`suspend` one-flag
cutover); with no in-process job left to dispatch, the scheduler dispatch
loop itself can go.

### What changes (production)
`app/main.py`:
- `_start_singletons`: remove the `run_scheduler_loop()` task and the
  `purge_stale_jobs()` registry housekeeping. The leader no longer owns a
  dispatch loop.
- `lifespan`: remove the register-jobs block (`knowledge`/`home`/`ships`/
  `hikes`/`stars`/`dr_jobs`/`worldcup` `on_startup_jobs` + observability
  rollup `register`).
- `prime_snapshots()` stays: it is a one-time observability warm-up, not a
  scheduled job.

After this, the leader's background singletons are:
- **with a Discord token:** bot, outbox drain, ships ingest, lock sweep (4)
- **without a token:** ships ingest only (1)

### Scope / what is intentionally left
The scheduler router and `scheduler.api` functions remain for now;
dead-code removal (router, MCP tools, dropping the empty `scheduled_jobs`
table) is a separate follow-up. This PR is purely about stopping batch
work on the API pods.

### Tests
Updated the lifespan task-count assertions across the `main_*` test files
(5->4 with token, 2->1 without) and dropped the obsolete scheduler-loop
coverage. No new ruff errors; `scheduled_jobs` is already empty in prod
(verified after the Phase D changelog cutover purged the last rows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)