### PR TITLE
fix(chat): cap summarizer max_tokens and disable thinking

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.58.1
+version: 0.58.2
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.58.1
+      targetRevision: 0.58.2
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.214.1
+version: 0.214.2
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chat/summarizer.py
+++ b/projects/monolith/chat/summarizer.py
@@ -13,7 +13,11 @@ from chat.models import ChannelSummary, Message, UserChannelSummary
 
 logger = logging.getLogger(__name__)
 
-_LLM_MAX_TOKENS = int(os.environ.get("LLM_MAX_TOKENS", "32768"))
+# Output token budget. Must leave room for the prompt: the qwen3.6-27b alias has
+# a 32768-token context, so reserving the whole window for output leaves 0 tokens
+# for input and vLLM rejects every non-empty prompt with a 400. 8192 (matching the
+# vision path) is far more than a summary/changelog needs and leaves ~24k for input.
+_LLM_MAX_TOKENS = int(os.environ.get("LLM_MAX_TOKENS", "8192"))
 
 
 async def generate_summaries(
@@ -310,13 +314,24 @@ def build_llm_caller(base_url: str | None = None) -> Callable[[str], Awaitable[s
                         "model": "qwen3.6-27b",
                         "messages": [{"role": "user", "content": prompt}],
                         "max_tokens": _LLM_MAX_TOKENS,
+                        # Disable thinking so the budget is spent on the summary,
+                        # not <think> reasoning -- a thinking response puts the
+                        # reasoning in reasoning_content and returns content:null
+                        # behind a 200, which would slip past raise_for_status.
+                        "chat_template_kwargs": {"enable_thinking": False},
                     },
                 )
                 resp.raise_for_status()
                 try:
-                    return resp.json()["choices"][0]["message"]["content"]
+                    content = resp.json()["choices"][0]["message"]["content"]
                 except (KeyError, IndexError, ValueError) as e:
                     raise RuntimeError(f"unexpected LLM response shape: {e}") from e
+                if not content:
+                    raise RuntimeError(
+                        "LLM returned empty content (thinking may have consumed "
+                        "the token budget)"
+                    )
+                return content
             except httpx.HTTPStatusError as exc:
                 if exc.response.status_code not in _RETRYABLE_STATUS_CODES:
                     raise

--- a/projects/monolith/chat/summarizer_llm_caller_test.py
+++ b/projects/monolith/chat/summarizer_llm_caller_test.py
@@ -85,7 +85,12 @@ class TestBuildLlmCaller:
         assert payload["model"] == "qwen3.6-27b"
         assert payload["messages"][0]["role"] == "user"
         assert payload["messages"][0]["content"] == "Summarize this conversation."
-        assert payload["max_tokens"] == 32768
+        # max_tokens must leave room for the prompt within the 32768 context;
+        # reserving the whole window 400s on any non-empty prompt.
+        assert payload["max_tokens"] == 8192
+        # Thinking disabled so the model returns the summary in content, not a
+        # content:null thinking response.
+        assert payload["chat_template_kwargs"] == {"enable_thinking": False}
 
     @pytest.mark.asyncio
     async def test_raises_runtime_error_on_missing_choices(self):

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.214.1
+      targetRevision: 0.214.2
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
## The changelog/summary jobs always 400'd against inference

After the jobs-to-Argo migration surfaced them, `chat-changelog-homelab`
and `chat-changelog-loom` were Failing every run in `monolith-workflows`.
The root cause (verified from the vLLM logs, not inferred):

> This model's maximum context length is 32768 tokens. However, you
> requested 32768 output tokens and your prompt contains 880 characters
> (more than 0 characters, which is the upper bound for 0 input tokens).

`call_llm` in `chat/summarizer.py` sent `max_tokens=32768`, which equals
the `qwen3.6-27b` alias's **entire** 32768-token context window, leaving
zero room for the prompt. Any non-empty prompt overflowed. The
`colin-homelab` variant only "succeeded" because it had no new commits
and short-circuited before ever calling the LLM, so the changelog has
never actually summarized via Qwen under this config. This predates the
migration; the cutover faithfully moved an already-broken job.

`summarizer.call_llm` is shared by both the changelog
(`run_changelog_for_config` -> `build_llm_caller`) and the rolling
summary-generation job, so one fix repairs both. It does **not** touch
interactive Discord chat, which uses a separate path.

## Fix (mirrors the proven `vision.py` pattern)
- default `LLM_MAX_TOKENS` 32768 -> **8192** (matches vision; leaves ~24k
  for the prompt, and a summary/changelog needs far less output)
- send `chat_template_kwargs={"enable_thinking": False}` so the budget is
  spent on the summary, not `<think>` reasoning that returns
  `content:null` behind a 200 (the latent bug that would bite the moment
  the 400 was fixed)
- guard empty/None content with a clear `RuntimeError` instead of
  returning `None` to callers

## Tests
Updated the llm-caller payload test to assert `max_tokens == 8192` and
that the `enable_thinking: False` flag is sent. No fixture mocks empty
content, so the new guard is safe.

After deploy I'll manually trigger `chat-changelog-homelab` to confirm a
green run end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)