### PR TITLE
perf(monolith): speed up graph notes view (compress payloads, rAF repaints, graph cache)

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.58.2
+version: 0.58.3
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.58.2
+      targetRevision: 0.58.3
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.214.2
+version: 0.214.3
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.214.2
+      targetRevision: 0.214.3
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/hooks.server.js
+++ b/projects/monolith/frontend/src/hooks.server.js
@@ -1,0 +1,113 @@
+// SvelteKit server hook: negotiated response compression.
+//
+// adapter-node does not compress dynamic responses, and Cloudflare in front of
+// us was serving them as identity (the public knowledge-graph JSON alone is
+// ~3.4 MB; ships/stars/trips payloads and every SSR page went out raw too). The
+// browser never reaches the FastAPI backend directly: every API response is
+// fetched server-side inside this Node process and re-emitted through a
+// +server.js proxy or inlined by a +page.server.js load(). That makes this
+// server the single chokepoint every browser-facing byte passes through, so we
+// compress here, once, and it covers all of them.
+//
+// Static assets (/_app/*.js, CSS) do NOT flow through this hook -- adapter-node
+// serves them via sirv before the SvelteKit handler runs -- so they are handled
+// separately by `precompress: true` in svelte.config.js (build-time gzip/brotli).
+//
+// A note on `reroute`: it lives in the universal hooks.js (runs on both server
+// and client). `handle` is server-only and must live here.
+
+import { promisify } from "node:util";
+import zlib from "node:zlib";
+
+const gzip = promisify(zlib.gzip);
+const brotli = promisify(zlib.brotliCompress);
+
+// Below ~one MTU the framing + header overhead of compression outweighs the
+// savings, so small bodies (most API JSON, redirects, 304s) pass through.
+const MIN_BYTES = 1400;
+
+// Only text-shaped payloads. Images/fonts/video are already compressed;
+// re-compressing wastes CPU and can grow the body. text/event-stream is
+// deliberately excluded below (it is a live stream we must never buffer).
+const COMPRESSIBLE =
+  /^(?:text\/|application\/(?:json|javascript|xml|manifest\+json)|application\/[\w.+-]+\+(?:json|xml)|image\/svg\+xml)\b/i;
+
+function pickEncoding(accept) {
+  if (!accept) return null;
+  const a = accept.toLowerCase();
+  // Prefer brotli (better ratio on JSON, and the browser-preferred token) then
+  // gzip. Anything else (identity only) means leave the body alone.
+  if (a.includes("br")) return "br";
+  if (a.includes("gzip")) return "gzip";
+  return null;
+}
+
+/** @type {import('@sveltejs/kit').Handle} */
+export async function handle({ event, resolve }) {
+  const response = await resolve(event);
+
+  // HEAD must not have its body materialised; pass through untouched.
+  if (event.request.method === "HEAD") return response;
+  // Respect anything upstream already encoded.
+  if (response.headers.has("content-encoding")) return response;
+
+  const type = response.headers.get("content-type") || "";
+  // Server-sent events are an open stream: buffering it (below) would stall the
+  // chat transcript forever. Never touch it.
+  if (type.startsWith("text/event-stream")) return response;
+  if (!COMPRESSIBLE.test(type)) return response;
+
+  const encoding = pickEncoding(event.request.headers.get("accept-encoding"));
+  if (!encoding) return response;
+
+  // Fast path: a known-small body never needs buffering at all.
+  const declaredLen = Number(response.headers.get("content-length"));
+  if (declaredLen && declaredLen < MIN_BYTES) return response;
+
+  // Buffer the body. Every browser-facing payload that reaches here is already
+  // buffered upstream (json(await res.json()) for proxies, an SSR string for
+  // pages), so this defeats no streaming we rely on -- and event-stream, the
+  // one thing we DO stream, was excluded above.
+  const original = new Uint8Array(await response.arrayBuffer());
+  if (original.byteLength < MIN_BYTES) {
+    // arrayBuffer() consumed the body; re-emit the small payload verbatim.
+    return new Response(original, {
+      status: response.status,
+      statusText: response.statusText,
+      headers: response.headers,
+    });
+  }
+
+  const compressed =
+    encoding === "br"
+      ? await brotli(original, {
+          params: {
+            // Quality 5 lands near gzip-9's ratio at a fraction of brotli-11's
+            // CPU. The async API runs on the libuv threadpool, so a big body
+            // never blocks the Node event loop / other in-flight requests.
+            [zlib.constants.BROTLI_PARAM_QUALITY]: 5,
+            [zlib.constants.BROTLI_PARAM_SIZE_HINT]: original.byteLength,
+          },
+        })
+      : await gzip(original, { level: 6 });
+
+  const headers = new Headers(response.headers);
+  headers.set("content-encoding", encoding);
+  headers.set("content-length", String(compressed.byteLength));
+
+  // Caches (Cloudflare) must key on accept-encoding so a brotli body is never
+  // handed to a gzip-only client. Add the token without clobbering an existing
+  // Vary or duplicating ourselves.
+  const vary = headers.get("vary");
+  if (!vary) {
+    headers.set("vary", "Accept-Encoding");
+  } else if (!/\baccept-encoding\b/i.test(vary)) {
+    headers.set("vary", `${vary}, Accept-Encoding`);
+  }
+
+  return new Response(compressed, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}

--- a/projects/monolith/frontend/src/lib/components/notes/KnowledgeGraph.svelte
+++ b/projects/monolith/frontend/src/lib/components/notes/KnowledgeGraph.svelte
@@ -80,6 +80,9 @@
   let quadtree;
   let transform = zoomIdentity;
   let zoomBehavior;
+  // Pending requestAnimationFrame id for coalesced repaints (see
+  // scheduleRender). 0 means no frame is queued.
+  let rafId = 0;
 
   let simNodes = [];
   let simEdges = [];
@@ -234,6 +237,20 @@
 
   // ───────────────────────── render ─────────────────────────
 
+  // Coalesce repaints to one per animation frame. d3-zoom fires many "zoom"
+  // events per wheel/drag gesture, and mousemove fires a hover repaint per
+  // pixel; calling render() synchronously on each made a 4.6k-node / 24.5k-edge
+  // graph janky (every frame re-walks all edges twice + the O(n^2) label
+  // collision pass). Requesting a single frame collapses a burst of input
+  // events into one paint that reads the latest `transform`/`hovered`.
+  function scheduleRender() {
+    if (rafId) return;
+    rafId = requestAnimationFrame(() => {
+      rafId = 0;
+      render();
+    });
+  }
+
   function render() {
     if (!ctx || !stage) return;
     const w = stage.clientWidth;
@@ -353,8 +370,6 @@
     ctx.restore();
 
     drawLabels(w, h, filtering, matchSet, selectedNode);
-
-    rebuildQuadtree();
   }
 
   function drawLabels(w, h, filtering, matchSet, selectedNode) {
@@ -666,7 +681,7 @@
         onNodeHover(
           n ? { id: n.id, title: n.title } : { id: null, title: null },
         );
-        render();
+        scheduleRender();
       }
     }
   }
@@ -688,7 +703,7 @@
       hovered = null;
       overNode = false;
       onNodeHover({ id: null, title: null });
-      render();
+      scheduleRender();
     }
   }
 
@@ -731,7 +746,7 @@
         if (e.sourceEvent && e.sourceEvent.type === "mousemove") {
           panning = true;
         }
-        render();
+        scheduleRender();
       })
       .on("end", () => {
         panning = false;
@@ -746,7 +761,7 @@
 
     resizeObserver = new ResizeObserver(() => {
       resize();
-      render();
+      scheduleRender();
     });
     resizeObserver.observe(stage);
 
@@ -758,6 +773,7 @@
     // to the SSR export and crashes on client (svelte/package.json
     // exports map's `default` is the server bundle).
     return () => {
+      if (rafId) cancelAnimationFrame(rafId);
       if (resizeObserver) resizeObserver.disconnect();
       if (canvas) {
         canvas.removeEventListener("mousedown", handleMouseDown);

--- a/projects/monolith/frontend/src/lib/public/chat/GraphView.svelte
+++ b/projects/monolith/frontend/src/lib/public/chat/GraphView.svelte
@@ -23,6 +23,10 @@
     initialGraphSelection,
     selectionForFocus,
   } from "$lib/public/chat/chat-state.js";
+  import {
+    getCachedGraph,
+    setCachedGraph,
+  } from "$lib/public/chat/graph-cache.js";
 
   /** @type {{
    *   touched?: { id: any, title: string }[],
@@ -64,6 +68,17 @@
   });
 
   async function loadGraph() {
+    // Toggling Chat <-> Graph remounts this component. Reuse the parsed graph
+    // from a prior open in this page session instead of re-fetching and
+    // re-parsing ~3.4 MB every time (the HTTP layer's s-maxage/ETag still
+    // governs freshness across full page loads, when the module cache resets).
+    const cached = getCachedGraph();
+    if (cached) {
+      nodes = cached.nodes;
+      edges = cached.edges;
+      status = "ready";
+      return;
+    }
     status = "loading";
     try {
       const res = await fetch("/app/notes/graph", {
@@ -76,6 +91,7 @@
       const graph = await res.json();
       nodes = graph.nodes ?? [];
       edges = graph.edges ?? [];
+      setCachedGraph({ nodes, edges });
       status = "ready";
     } catch {
       status = "error";

--- a/projects/monolith/frontend/src/lib/public/chat/graph-cache.js
+++ b/projects/monolith/frontend/src/lib/public/chat/graph-cache.js
@@ -1,0 +1,18 @@
+// Module-level cache of the parsed public knowledge graph.
+//
+// GraphView remounts every time the visitor toggles Chat <-> Graph, and its
+// onMount re-fetched and re-parsed the full ~3.4 MB graph on each toggle. A
+// module-level singleton persists across those remounts within one page
+// session, so the second and later opens are instant: no fetch, no JSON parse,
+// no rebuild. A full page reload starts a fresh module and clears it, which is
+// the correct TTL -- cross-load freshness is already governed by the HTTP layer
+// (s-maxage / ETag on /app/notes/graph).
+let cache = null;
+
+export function getCachedGraph() {
+  return cache;
+}
+
+export function setCachedGraph(graph) {
+  cache = graph;
+}

--- a/projects/monolith/frontend/svelte.config.js
+++ b/projects/monolith/frontend/svelte.config.js
@@ -10,6 +10,12 @@ const config = {
     // the same Bazel package. Defaults to "build" for the normal build.
     adapter: adapter({
       out: process.env.SVELTE_OUT_DIR || "build",
+      // Build-time gzip + brotli of static assets (/_app/*.js, CSS). These are
+      // served by adapter-node's sirv layer BEFORE the SvelteKit handler, so the
+      // hooks.server.js compression hook never sees them; precompress is how the
+      // JS bundle stops shipping uncompressed. sirv serves the .br/.gz variant
+      // when the client accepts it, at zero runtime cost.
+      precompress: true,
     }),
     // No Content-Security-Policy is set by the app. The markdown renderer
     // (components/notes/markdown.js) HTML-escapes untrusted public-chat output


### PR DESCRIPTION
## Why

The `/app/notes` knowledge-graph view was slow to load and to navigate. Measured from prod: the public graph endpoint returns **4,653 nodes / 24,470 edges = 3.41 MB**, served **uncompressed** end to end (no `content-encoding`, even on the Cloudflare-cached path). The graph is legitimately large, and two inefficiencies amplified it.

Three independent causes, three fixes (A, B, C as discussed):

### A. Large payloads shipped uncompressed (load time)
The browser never reaches the FastAPI backend directly: every API response is fetched server-side inside the SvelteKit **adapter-node** server (`+server.js` proxies / `+page.server.js` loads) and re-emitted. adapter-node does no dynamic compression and Cloudflare was serving identity bytes, so `GZipMiddleware` on FastAPI would have fixed nothing the user sees.

- New `frontend/src/hooks.server.js` `handle` hook negotiates `accept-encoding` and gzip/brotli-compresses compressible responses above a 1400-byte floor. Guards: skips `text/event-stream` (the chat SSE stream), `HEAD`, already-encoded, and small bodies; sets `Vary: Accept-Encoding`; brotli runs at quality 5 on the libuv threadpool (never blocks the event loop). **One chokepoint compresses every browser-facing payload**: public graph, private graph, ships snapshot/heat, stars grid/history, trip points, and all SSR HTML. JSON of this shape gzips ~90% (3.4 MB to roughly 350 KB).
- `precompress: true` on the adapter so the static JS/CSS bundle (served by sirv, which bypasses the hook) ships compressed too.

### B. Synchronous repaint on every input event (navigation jank)
`KnowledgeGraph.svelte` called `render()` directly on every d3-zoom and hover event. Each pass re-walks all 24.5k edges twice plus an O(n²) label-collision scan with `measureText`. d3-zoom fires many events per gesture, so a single swipe queued dozens of full redraws.

- Coalesce repaints behind `requestAnimationFrame` (`scheduleRender`) so an input burst collapses to one paint reading the latest transform.
- Drop the per-frame `rebuildQuadtree()`: node world positions are static under pan/zoom (zoom only changes the draw `transform`), so the tree was identical every frame. Still rebuilt on mount and on data change. Zero pixel change.

Benefits all three graph views (they share the component).

### C. Re-fetch + re-parse on every Chat↔Graph toggle
Toggling remounts `GraphView`, whose `onMount` re-fetched and re-parsed the full 3.4 MB each time. Added a module-level parsed-graph cache (`graph-cache.js`); later opens are instant. A full page reload clears it (HTTP `s-maxage`/ETag governs cross-load freshness).

## Risk / verification notes
- No rendered-pixel changes (A = transport, B = timing, C = fetch caching), so **no visual-regression baseline reseed** is expected.
- New `.js` files are picked up by the existing `src/**/*` glob in `frontend/BUILD`; no BUILD edit.
- No `chart/deploy/values` changes; `chart-version-bot` handles the version bump on image rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)