### PR TITLE
test(monolith): add unit test for KubernetesClient.create_workflow

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.58.3
+version: 0.58.4
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.58.3
+      targetRevision: 0.58.4
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.214.3
+version: 0.214.4
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/cluster/kubernetes_test.py
+++ b/projects/monolith/cluster/kubernetes_test.py
@@ -201,3 +201,37 @@ async def test_close_cleans_up(k8s_client):
 
     mock_api.close.assert_called_once()
     assert k8s_client._api is None
+
+
+@pytest.mark.asyncio
+async def test_create_workflow_passes_correct_args_and_returns_name(k8s_client):
+    mock_api = MagicMock()
+    mock_custom = MagicMock()
+    server_response = {"metadata": {"name": "my-workflow-xyz"}}
+    mock_custom.create_namespaced_custom_object = AsyncMock(return_value=server_response)
+
+    body = {
+        "apiVersion": "argoproj.io/v1alpha1",
+        "kind": "Workflow",
+        "metadata": {"generateName": "my-workflow-"},
+        "spec": {"entrypoint": "main", "templates": []},
+    }
+
+    with (
+        patch("cluster.kubernetes.config.load_incluster_config"),
+        patch("cluster.kubernetes.ApiClient", return_value=mock_api),
+        patch(
+            "cluster.kubernetes.client.CustomObjectsApi",
+            return_value=mock_custom,
+        ),
+    ):
+        name = await k8s_client.create_workflow(namespace="monolith-workflows", body=body)
+
+    mock_custom.create_namespaced_custom_object.assert_called_once_with(
+        group="argoproj.io",
+        version="v1alpha1",
+        namespace="monolith-workflows",
+        plural="workflows",
+        body=body,
+    )
+    assert name == "my-workflow-xyz"

--- a/projects/monolith/cluster/kubernetes_test.py
+++ b/projects/monolith/cluster/kubernetes_test.py
@@ -208,7 +208,9 @@ async def test_create_workflow_passes_correct_args_and_returns_name(k8s_client):
     mock_api = MagicMock()
     mock_custom = MagicMock()
     server_response = {"metadata": {"name": "my-workflow-xyz"}}
-    mock_custom.create_namespaced_custom_object = AsyncMock(return_value=server_response)
+    mock_custom.create_namespaced_custom_object = AsyncMock(
+        return_value=server_response
+    )
 
     body = {
         "apiVersion": "argoproj.io/v1alpha1",
@@ -225,7 +227,9 @@ async def test_create_workflow_passes_correct_args_and_returns_name(k8s_client):
             return_value=mock_custom,
         ),
     ):
-        name = await k8s_client.create_workflow(namespace="monolith-workflows", body=body)
+        name = await k8s_client.create_workflow(
+            namespace="monolith-workflows", body=body
+        )
 
     mock_custom.create_namespaced_custom_object.assert_called_once_with(
         group="argoproj.io",

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.214.3
+      targetRevision: 0.214.4
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
## Summary

- Adds `test_create_workflow_passes_correct_args_and_returns_name` to `cluster/kubernetes_test.py`
- Follows the existing `AsyncMock` / `patch` pattern used by surrounding tests
- Asserts the correct `group`, `version`, `plural`, `namespace`, and `body` are forwarded to `CustomObjectsApi.create_namespaced_custom_object`
- Asserts the server-assigned name is extracted from `created["metadata"]["name"]` and returned

## Test plan
- [x] Happy path: correct args passed, server-assigned name returned
- [x] Follows existing mock pattern (no new test dependencies introduced)

🤖 Generated with [Claude Code](https://claude.com/claude-code)