### PR TITLE
ci(semgrep): add cronworkflow-values-missing-activedeadline rule

### DIFF
--- a/bazel/semgrep/rules/yaml/cronworkflow-values-missing-activedeadline.yaml
+++ b/bazel/semgrep/rules/yaml/cronworkflow-values-missing-activedeadline.yaml
@@ -1,0 +1,26 @@
+rules:
+  - id: cronworkflow-values-missing-activedeadline
+    languages: [yaml]
+    severity: WARNING
+    message: >-
+      CronWorkflow entry has `schedule:` but no `activeDeadlineSeconds`. Without
+      this limit a stuck workflow pod runs indefinitely, consuming cluster
+      resources until manually killed. Add `activeDeadlineSeconds` to cap the
+      maximum pod lifetime for each CronWorkflow entry.
+    metadata:
+      category: correctness
+    paths:
+      include:
+        - "**/values.yaml"
+    patterns:
+      - pattern: |
+          - schedule: ...
+            ...
+      - pattern-not: |
+          - schedule: ...
+            ...
+            activeDeadlineSeconds: ...
+      - pattern-not: |
+          - activeDeadlineSeconds: ...
+            ...
+            schedule: ...

--- a/bazel/semgrep/tests/fixtures/cronworkflow-values-missing-activedeadline.yaml
+++ b/bazel/semgrep/tests/fixtures/cronworkflow-values-missing-activedeadline.yaml
@@ -1,0 +1,39 @@
+# Tests for cronworkflow-values-missing-activedeadline rule.
+# CronWorkflow entries in values.yaml must include activeDeadlineSeconds to
+# prevent stuck pods from running indefinitely on the cluster.
+---
+# ruleid: cronworkflow-values-missing-activedeadline
+cronWorkflows:
+  - name: my-job
+    schedule: "*/5 * * * *"
+    concurrencyPolicy: Forbid
+    suspend: false
+
+---
+# ruleid: cronworkflow-values-missing-activedeadline
+cronWorkflows:
+  - name: another-job
+    schedule: "0 0 * * *"
+    suspend: true
+
+---
+# ruleid: cronworkflow-values-missing-activedeadline
+cronWorkflows:
+  - name: bare-schedule-job
+    schedule: "0 4 * * 0"
+
+---
+# ok: cronworkflow-values-missing-activedeadline — activeDeadlineSeconds present after schedule
+cronWorkflows:
+  - name: my-job
+    schedule: "*/5 * * * *"
+    activeDeadlineSeconds: 600
+    concurrencyPolicy: Forbid
+
+---
+# ok: cronworkflow-values-missing-activedeadline — activeDeadlineSeconds present before schedule
+cronWorkflows:
+  - name: my-job
+    activeDeadlineSeconds: 300
+    schedule: "0 * * * *"
+    concurrencyPolicy: Forbid


### PR DESCRIPTION
## Summary

- Adds semgrep rule `cronworkflow-values-missing-activedeadline` in `bazel/semgrep/rules/yaml/` to catch CronWorkflow list entries in `values.yaml` that declare a `schedule:` field but omit `activeDeadlineSeconds`
- Without `activeDeadlineSeconds`, a stuck workflow pod runs indefinitely consuming cluster resources until manually killed
- Rule uses `languages: [yaml]` with `paths.include: ['**/values.yaml']` and pattern-not to handle both field orderings
- Fixture covers three `ruleid` cases (bare schedule, schedule with other fields, various orderings) and two `ok` cases (activeDeadlineSeconds present after and before schedule)
- Both rule and fixture are auto-discovered by existing BUILD globs (`yaml_rules` and `yaml_fixtures`) so no BUILD changes are needed

## Test plan

- [ ] CI `yaml_rules_test` passes with the new rule and fixture
- [ ] No false positives on existing `projects/monolith/chart/values.yaml` (all existing CronWorkflow entries already have `activeDeadlineSeconds`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)