### PR TITLE
perf(monolith-public): enable AVIF + lower imgproxy quality for trip images

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.58.4
+version: 0.58.5
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/chart/values.yaml
+++ b/projects/monolith-public/chart/values.yaml
@@ -494,10 +494,26 @@ imgproxy:
     - name: IMGPROXY_TTL
       value: "31536000"
     - name: IMGPROXY_QUALITY
-      value: "90"
+      value: "82"
+    # Output quality per delivered format. This takes priority over the per-preset
+    # quality:NN above for webp/avif/jpeg, so it is what actually governs the bytes
+    # on the wire (the preset quality:NN only applies to formats not listed here).
+    # Lowered from 92/90/90: for photo galleries WebP ~82 / AVIF ~78 is visually
+    # near-indistinguishable from the low-90s while cutting ~25-40% of the bytes.
+    # AVIF is set a few points lower than WebP because its encoder holds perceived
+    # quality better at the same numeric value.
     - name: IMGPROXY_FORMAT_QUALITY
-      value: "webp=92,avif=90,jpeg=90"
+      value: "webp=82,avif=78,jpeg=82"
     - name: IMGPROXY_ENABLE_WEBP_DETECTION
+      value: "true"
+    # Serve AVIF to browsers that advertise it (Accept: image/avif), falling
+    # back to WebP then JPEG. AVIF is ~20-30% smaller than WebP at equal quality;
+    # avif=... in IMGPROXY_FORMAT_QUALITY was already defined but unreachable
+    # without this. Safe to enable because imgproxy sets Vary: Accept, so the CDN
+    # caches each format variant separately. Trade-off: AVIF encode is more
+    # CPU-heavy than WebP, but every result is cached (IMGPROXY_TTL=1y + the
+    # Cloudflare immutable edge cache), so the encode cost is paid once per image.
+    - name: IMGPROXY_ENABLE_AVIF_DETECTION
       value: "true"
     - name: IMGPROXY_STRIP_METADATA
       value: "true"

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.58.4
+      targetRevision: 0.58.5
       helm:
         releaseName: monolith-public
         valueFiles:


### PR DESCRIPTION
## Why

Follow-up to the compression work (#2817). Trips is image-heavy, and while gzip/brotli can't shrink already-encoded images, **format + quality** can. Two config-only changes to the imgproxy fronting the `monolith-trips` bucket.

Measured baseline (live): a 600×600 `gallery` image is served as **WebP, 28,470 bytes**, even when the client sends `Accept: image/avif` first. `Vary: Accept` is already set, so per-format CDN caching is safe.

## Changes (both in `monolith-public/chart/values.yaml`)

1. **Enable `IMGPROXY_ENABLE_AVIF_DETECTION`.** `avif=...` was already defined in `IMGPROXY_FORMAT_QUALITY` but unreachable with only WebP detection on. AVIF is ~20-30% smaller than WebP at equal quality. Zero frontend change.
2. **Lower output quality.** `IMGPROXY_FORMAT_QUALITY` takes priority over the per-preset `quality:NN` for delivered formats, so it's what governs wire bytes: `webp 92→82, avif 90→78, jpeg 90→82`, and base `IMGPROXY_QUALITY 90→82`. For photo galleries this is visually near-indistinguishable while cutting ~25-40% of the bytes.

Combined, a typical gallery image should drop from ~28 KB toward the mid-to-high teens KB on AVIF-capable browsers.

## Notes / risk
- **CPU:** AVIF encode is heavier than WebP, but every result is cached (`IMGPROXY_TTL=1y` + Cloudflare immutable edge cache), so the encode cost is paid once per image. imgproxy pod already has a CPU request and no limit.
- **Quality:** this is a photography app, so I kept WebP/AVIF in the low-80s/high-70s rather than going aggressive; easy to nudge if any photo looks soft.
- Chart `0.58.4 → 0.58.5`, `targetRevision` kept in sync.
- Did NOT touch the bigger frontend items (day-scrubber eager preload at full `display` res; `thumb`+`srcset` for small grid tiles) — those are a separate frontend pass if needed.

## Verify after rollout
`curl -H "Accept: image/avif,image/webp" <img-url>` should return `content-type: image/avif` at a smaller `content-length` than the current 28,470-byte WebP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)