### PR TITLE
chore(monolith): right-size backend 4Gi -> 1Gi after jobs offload

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.58.6
+version: 0.58.7
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.58.6
+      targetRevision: 0.58.7
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.214.4
+version: 0.214.5
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.214.4
+      targetRevision: 0.214.5
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/deploy/values.yaml
+++ b/projects/monolith/deploy/values.yaml
@@ -4,14 +4,19 @@ backend:
   otelEndpoint: "http://signoz-k8s-infra-otel-agent.signoz.svc.cluster.local:4318/v1/traces"
   resources:
     requests:
-      # 3Gi -> 4Gi: headroom above baseline RSS + one heavy scheduled job (the
-      # FA2 graph layout), which OOMKilled the pod when several jobs piled up.
-      # The scheduler now also serializes heavy jobs (heavy=True); this is the
-      # belt-and-suspenders. requests==limits per the repo memory convention.
-      memory: "4Gi"
-      cpu: "10m"
+      # 4Gi -> 1Gi: the old 4Gi was headroom for the in-process FA2 graph-layout
+      # job that OOMKilled the API pod when heavy jobs piled up. All batch jobs
+      # now run off-pod as Argo CronWorkflows (knowledge.layout carries its own
+      # 4Gi request), so the API pod only serves HTTP/MCP: live baseline RSS is
+      # ~250Mi, and 1Gi is ~4x headroom for request-path spikes. requests==limits
+      # per the repo memory convention.
+      memory: "1Gi"
+      # cpu 10m -> 250m: 10m was too low for fair scheduling and made a CPU-based
+      # HPA meaningless (any load reads as a huge % of 10m). No CPU limit per the
+      # repo convention (avoid throttling).
+      cpu: "250m"
     limits:
-      memory: "4Gi"
+      memory: "1Gi"
 
 frontend:
   otelCollectorUrl: "http://signoz-k8s-infra-otel-agent.signoz.svc.cluster.local:4318"


### PR DESCRIPTION
## Why
The private `monolith` backend is pinned at **4Gi** (req=limit) in `deploy/values.yaml`. That headroom was sized for the **in-process FA2 graph-layout job** (`knowledge.layout`, ~2.7GiB peak) which OOMKilled the pod when heavy jobs piled up. With the jobs offload complete, **all batch jobs now run off-pod as Argo CronWorkflows** (`knowledge-layout` carries its own 4Gi request), so the API pod only serves HTTP/MCP.

Live baseline RSS is **~250Mi**. The 4Gi is now stale headroom for a job that no longer runs here.

## What
- `backend` memory **4Gi → 1Gi** (req=limit) — ~4x the ~250Mi baseline, comfortable for request-path spikes. Frees **~3Gi** of reservation on the binding cluster resource (node memory; node-2 has been ~92%).
- `backend` cpu request **10m → 250m** — 10m was too low for fair scheduling and would make a CPU-based HPA meaningless (a follow-up PR adds the HPA). No cpu limit, per the repo convention.

## Safety
- Memory-only working set: the in-process scheduler loop is deleted and singletons are leader-gated (`app/leadership.py`), so this pod's footprint is request-serving only.
- This is PR 1 of a small phased series (rightsize → monolith HPA+PDB → public-tier PDB/req=limit). Independently revertible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)