### PR TITLE
feat(monolith): add backend HPA + PDB for rollout/disruption availability

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.58.7
+version: 0.59.0
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.58.7
+      targetRevision: 0.59.0
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.214.5
+version: 0.215.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/templates/deployment.yaml
+++ b/projects/monolith/chart/templates/deployment.yaml
@@ -5,7 +5,9 @@ metadata:
   labels:
     {{- include "monolith.labels" . | nindent 4 }}
 spec:
+  {{- if not (and .Values.backend.autoscaling .Values.backend.autoscaling.enabled) }}
   replicas: {{ .Values.backend.replicas }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "monolith.selectorLabels" . | nindent 6 }}

--- a/projects/monolith/chart/templates/hpa.yaml
+++ b/projects/monolith/chart/templates/hpa.yaml
@@ -1,0 +1,35 @@
+{{- if and .Values.backend.autoscaling .Values.backend.autoscaling.enabled }}
+# HPA for the monolith backend deployment. Scales on the backend container's CPU
+# (ContainerResource, GA in k8s 1.27+) so the linkerd-proxy sidecar's CPU does
+# not dilute the signal. CPU, not memory: Python/Node hold memory after a spike,
+# so a memory-based HPA would never scale back down. Steady state stays at
+# minReplicas; scaling out is safe because the in-process singletons (Discord
+# bot, outbox drain, AIS ingest, lock sweep) are leader-gated via the Postgres
+# lease in app/leadership.py, so only the lease holder runs them while every
+# replica serves HTTP/MCP. Mirrors monolith-public's hpa.yaml.
+#
+# Requires the deployment to omit spec.replicas when autoscaling is enabled (see
+# deployment.yaml) AND the ArgoCD Application to ignore /spec/replicas (see
+# deploy/application.yaml), otherwise ArgoCD reverts every scale-up to replicas.
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "monolith.fullname" . }}
+  labels:
+    {{- include "monolith.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "monolith.fullname" . }}
+  minReplicas: {{ .Values.backend.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.backend.autoscaling.maxReplicas }}
+  metrics:
+    - type: ContainerResource
+      containerResource:
+        name: cpu
+        container: backend
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.backend.autoscaling.targetCPUUtilizationPercentage }}
+{{- end }}

--- a/projects/monolith/chart/templates/pdb.yaml
+++ b/projects/monolith/chart/templates/pdb.yaml
@@ -1,0 +1,20 @@
+{{- if and .Values.backend.pdb .Values.backend.pdb.enabled }}
+# PodDisruptionBudget for the monolith backend. maxUnavailable (NOT minAvailable)
+# is deliberate: at the 1-replica steady state a minAvailable:1 budget would
+# block node drains entirely (the only pod can never be evicted), wedging node
+# maintenance. maxUnavailable:1 lets a drain evict-and-reschedule the single pod
+# (a brief gap, accepted) and, once the HPA has scaled out, caps voluntary
+# disruption to one pod at a time.
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "monolith.fullname" . }}
+  labels:
+    {{- include "monolith.labels" . | nindent 4 }}
+spec:
+  maxUnavailable: {{ .Values.backend.pdb.maxUnavailable }}
+  selector:
+    matchLabels:
+      {{- include "monolith.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: app
+{{- end }}

--- a/projects/monolith/chart/values.yaml
+++ b/projects/monolith/chart/values.yaml
@@ -10,6 +10,22 @@ backend:
       cpu: "200m"
     limits:
       memory: "256Mi"
+  # Autoscaling: steady state stays at minReplicas (1); scale out under CPU load.
+  # Safe to run >1 replica because the in-process singletons are leader-gated
+  # (app/leadership.py) so only the lease holder runs them, while every replica
+  # serves HTTP/MCP. When enabled the deployment omits spec.replicas and the
+  # ArgoCD Application ignores /spec/replicas (deploy/application.yaml), so the
+  # HPA owns the count instead of ArgoCD reverting it.
+  autoscaling:
+    enabled: true
+    minReplicas: 1
+    maxReplicas: 3
+    targetCPUUtilizationPercentage: 60
+  # Disruption budget: maxUnavailable (not minAvailable) so a node drain can
+  # still evict-and-reschedule the single pod at the 1-replica floor.
+  pdb:
+    enabled: true
+    maxUnavailable: 1
 
 # Off-pod batch-job execution via Argo CronWorkflows.
 #

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -42,6 +42,11 @@ spec:
       jsonPointers:
         - /spec/template/metadata/annotations/otel.injected-by
         - /spec/template/metadata/annotations/kubectl.kubernetes.io~1restartedAt
+        # The backend HPA owns the replica count (chart/templates/hpa.yaml). The
+        # deployment omits spec.replicas when autoscaling is enabled, but with
+        # selfHeal on ArgoCD would still revert any HPA scale-up to the default;
+        # ignore /spec/replicas so the HPA holds. Mirrors the monolith-public app.
+        - /spec/replicas
   syncPolicy:
     automated:
       prune: true

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.214.5
+      targetRevision: 0.215.0
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
## Why
The private `monolith` runs as a single replica with no PDB and no HPA. Now that batch jobs run off-pod (Argo CronWorkflows) and every in-process singleton (Discord bot, outbox drain, AIS ingest, lock sweep) is **leader-gated** via the Postgres lease in `app/leadership.py`, the backend can safely run >1 replica: followers just serve HTTP/MCP, only the lease holder runs singletons. PR 2 of the phased rightsize/HA series (PR1 #2823 freed the memory this builds on).

## What
Per the agreed model: **1 replica at rest, scale under load, survive drains** (not forced node-failure HA).

- **HPA** (`chart/templates/hpa.yaml`): min 1 / max 3, `ContainerResource` CPU on the `backend` container at 60%. Mirrors `monolith-public`: targets the app container (not the linkerd-proxy sidecar, which would dilute the signal) and uses CPU not memory (Python/Node hold memory after a spike, so a memory HPA never scales back down).
- **PDB** (`chart/templates/pdb.yaml`): `maxUnavailable: 1` — deliberately **not** `minAvailable: 1`, which would block node drains entirely at the 1-replica floor. This lets a drain evict-and-reschedule the single pod, and caps disruption to one-at-a-time once scaled out.
- **ArgoCD ownership of replicas**: the deployment omits `spec.replicas` when autoscaling is enabled, and the app's `ignoreDifferences` now covers `/spec/replicas`. Without this, `selfHeal: true` would revert every HPA scale-up. Same pattern `monolith-public` already uses.

Rollout strategy is already `maxSurge:1 / maxUnavailable:0`, so 1-replica rollouts stay zero-downtime.

## Trade-off (named, not hidden)
1 replica + PDB gives zero-downtime **rollouts** and graceful **drains**, plus burst capacity — but a sudden **node failure** still drops the single pod until it reschedules. True node-failure HA = flip `minReplicas: 2` (zero code change, leader election already handles it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)