### PR TITLE
feat(monolith-public): add PodDisruptionBudgets for web/frontend/imgproxy

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.58.7
+version: 0.59.0
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/chart/templates/pdb.yaml
+++ b/projects/monolith-public/chart/templates/pdb.yaml
@@ -1,0 +1,23 @@
+{{- range $component := list "web" "frontend" "imgproxy" }}
+{{- $vals := index $.Values $component }}
+{{- if and $vals.enabled $vals.pdb $vals.pdb.enabled }}
+# PodDisruptionBudget for the {{ $component }} component. maxUnavailable (NOT
+# minAvailable) is deliberate: web and frontend sit at a 1-replica floor (HPA
+# minReplicas: 1), and a minAvailable:1 budget would block node drains entirely
+# there (the only pod could never be evicted). maxUnavailable:1 lets a drain
+# evict-and-reschedule the single pod, and caps voluntary disruption to one pod
+# at a time once the HPA has scaled out (or, for imgproxy, across its 2 replicas).
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "monolith-public.fullname" $ }}-{{ $component }}
+  labels:
+    {{- include "homelab.componentLabels" (dict "context" $ "component" $component) | nindent 4 }}
+spec:
+  maxUnavailable: {{ $vals.pdb.maxUnavailable }}
+  selector:
+    matchLabels:
+      {{- include "homelab.componentSelectorLabels" (dict "context" $ "component" $component) | nindent 6 }}
+---
+{{- end }}
+{{- end }}

--- a/projects/monolith-public/chart/values.yaml
+++ b/projects/monolith-public/chart/values.yaml
@@ -174,6 +174,12 @@ imgproxySigning:
 web:
   enabled: true
   replicas: 1
+  # Disruption budget: maxUnavailable (not minAvailable) so a node drain can
+  # evict-and-reschedule at the 1-replica floor; caps disruption to 1 at a time
+  # once the HPA has scaled out.
+  pdb:
+    enabled: true
+    maxUnavailable: 1
   image:
     repository: ghcr.io/jomcgi/homelab/projects/monolith/public-backend
     tag: latest
@@ -316,6 +322,10 @@ web:
 frontend:
   enabled: true
   replicas: 1
+  # Disruption budget (see web.pdb): maxUnavailable so drains work at 1 replica.
+  pdb:
+    enabled: true
+    maxUnavailable: 1
   image:
     repository: ghcr.io/jomcgi/homelab/projects/monolith/public-frontend
     tag: latest
@@ -410,6 +420,11 @@ frontend:
 imgproxy:
   enabled: true
   replicas: 2
+  # Disruption budget (see web.pdb). imgproxy runs 2 replicas, so maxUnavailable:1
+  # keeps one serving through a drain.
+  pdb:
+    enabled: true
+    maxUnavailable: 1
   image:
     repository: darthsim/imgproxy
     tag: v3.25.0

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.58.7
+      targetRevision: 0.59.0
       helm:
         releaseName: monolith-public
         valueFiles:


### PR DESCRIPTION
## Why
The public tier already autoscales (HPAs, min1/max3) but has **no PodDisruptionBudget**, so a node drain can evict its only pod with nothing holding the line. PR 3 of the phased rightsize/HA series.

## What
A per-component PDB (`chart/templates/pdb.yaml`, ranging web/frontend/imgproxy like the chart's `hpa.yaml`), `maxUnavailable: 1` each.

- **`maxUnavailable` not `minAvailable`** — deliberate: web/frontend sit at a 1-replica floor, where a `minAvailable: 1` budget would block node drains entirely (the only pod could never be evicted, wedging maintenance). `maxUnavailable: 1` lets a drain evict-and-reschedule, and caps disruption to one-at-a-time once the HPA scales out (or across imgproxy's 2 replicas).
- Matches the repo's existing `projects/trips/chart/templates/api-pdb.yaml` pattern.

Steady state, autoscaling, and rollout behaviour are unchanged — this only adds the budget.

## Deferred (deliberately, not dropped)
The public tier violates the `requests == limits` memory convention (web 160/384, frontend 128/512, imgproxy 128/512). I'm **not** folding that in here: naively raising requests to the limits would add ~1Gi+ of reservation under existing node-memory pressure (node-2 ~92%), and doing it *right* means right-sizing the limits down to real peaks first — which wants SigNoz peak data. Tracked as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)