### PR TITLE
chore(monolith-public): align memory requests to limits per convention

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.59.0
+version: 0.60.0
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/chart/values.yaml
+++ b/projects/monolith-public/chart/values.yaml
@@ -282,14 +282,15 @@ web:
           name: monolith-public-turnstile
           key: IP_HASH_SALT
   # CPU request is sized so the HPA's per-container CPU utilization is a
-  # meaningful signal (idle is ~1m). Memory request covers the FastAPI baseline
-  # (~110Mi idle: SQLModel + psycopg + pgvector + the knowledge internals); the
-  # old 64Mi request was below actual. No CPU limit: let it burst (the HPA scales
+  # meaningful signal (idle is ~1m). No CPU limit: let it burst (the HPA scales
   # out on sustained CPU rather than throttling).
+  # Memory request == limit (was 160/384) per the sizing convention: req<limit
+  # risks an overcommit OOM-kill below the limit under node memory pressure. 384
+  # is ~1.6x the 7-day working-set peak of 238Mi (SigNoz k8s.pod.memory.working_set).
   resources:
     requests:
       cpu: 100m
-      memory: 160Mi
+      memory: 384Mi
     limits:
       memory: 384Mi
   service:
@@ -386,15 +387,16 @@ frontend:
         secretKeyRef:
           name: monolith-public-imgproxy-signing
           key: IMGPROXY_SALT
-  # SSR Node needs more headroom than the read-only backend. CPU request sized
-  # for a meaningful HPA signal (Node SSR is CPU-bound under concurrent renders).
-  # Memory request keeps headroom above the ~37Mi idle baseline for load spikes.
+  # SSR Node: CPU request sized for a meaningful HPA signal (Node SSR is
+  # CPU-bound under concurrent renders); no CPU limit.
+  # Memory request == limit (was 128/512) per the sizing convention. 384 is ~1.6x
+  # the 7-day working-set peak of 234Mi (SigNoz); the old 512 limit was overspec.
   resources:
     requests:
       cpu: 100m
-      memory: 128Mi
+      memory: 384Mi
     limits:
-      memory: 512Mi
+      memory: 384Mi
   service:
     type: ClusterIP
     port: 3000
@@ -536,11 +538,13 @@ imgproxy:
       value: "50"
   # CPU request only (no limit): image decode is bursty CPU-bound work and a
   # limit would only throttle it. Memory request == limit per the sizing
-  # convention.
+  # convention (was 128/512, which violated it). 512 is ~1.4x the 7-day
+  # working-set peak of 360Mi (SigNoz); transcodes are spiky (p99 only 132Mi),
+  # so keep the higher ceiling here rather than trim to the peak.
   resources:
     requests:
       cpu: 100m
-      memory: 128Mi
+      memory: 512Mi
     limits:
       memory: 512Mi
   service:

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.59.0
+      targetRevision: 0.60.0
       helm:
         releaseName: monolith-public
         valueFiles:


### PR DESCRIPTION
## Why
The public tier violated the repo memory sizing convention (`requests == limits`): web 160/384, frontend 128/512, imgproxy 128/512. A request **below** the limit means the scheduler reserves less than the pod can use, so under node memory pressure (node-2 ~92%) the pod can be OOM-killed **below its own limit** — the exact failure the convention prevents. PR 4 of the rightsize/HA series, and the follow-up I'd deferred from #2825 pending data.

## What
Set `req == limit` at values backed by **7-day SigNoz working-set peaks** (`k8s.pod.memory.working_set`), not guesses:

| Container | 7d peak | p99 | old req→limit | new req=limit |
|---|---|---|---|---|
| web | 238Mi | 162 | 160 → 384 | **384** (~1.6x peak) |
| frontend | 234Mi | 182 | 128 → 512 | **384** (was overspec) |
| imgproxy | 360Mi | 132 | 128 → 512 | **512** (spiky transcodes, keep ceiling) |

## Cluster impact
Net reservation change **~+1.25Gi**, **fully covered by the ~3Gi freed** when the monolith backend dropped 4Gi→1Gi (#2823, validated against post-offload SigNoz: 12h peak 367Mi). So the cluster still nets ~1.7Gi better off than before this series, with the overcommit-OOM risk removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)