### PR TITLE
refactor(inference): decoupled lean inference chart (relocation PR1, inert)

### DIFF
--- a/projects/inference/deploy/BUILD
+++ b/projects/inference/deploy/BUILD
@@ -1,0 +1,6 @@
+load("//bazel/helm:defs.bzl", "helm_chart")
+
+helm_chart(
+    name = "chart",
+    visibility = ["//overlays:__subpackages__"],
+)

--- a/projects/inference/deploy/Chart.yaml
+++ b/projects/inference/deploy/Chart.yaml
@@ -1,0 +1,16 @@
+apiVersion: v2
+name: inference
+description: A Helm chart for LLM inference (vLLM LLM serving + llama.cpp CPU embeddings)
+type: application
+version: 2.5.3
+appVersion: "b5270"
+keywords:
+  - llm
+  - inference
+  - vllm
+  - embeddings
+  - gpu
+annotations:
+  org.opencontainers.image.source: "https://github.com/jomcgi/homelab"
+  org.opencontainers.image.url: "https://github.com/jomcgi/homelab"
+  org.opencontainers.image.licenses: "MPL-2.0"

--- a/projects/inference/deploy/application.yaml
+++ b/projects/inference/deploy/application.yaml
@@ -1,0 +1,33 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: inference
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/jomcgi/homelab.git
+    path: projects/inference/deploy
+    targetRevision: HEAD
+    helm:
+      releaseName: inference
+      valueFiles:
+        - values.yaml
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: inference
+  syncPolicy:
+    managedNamespaceMetadata:
+      labels:
+        oci-model-cache.jomcgi.dev/enabled: "true"
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m

--- a/projects/inference/deploy/templates/_helpers.tpl
+++ b/projects/inference/deploy/templates/_helpers.tpl
@@ -1,0 +1,92 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "inference.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "inference.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "inference.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "inference.labels" -}}
+helm.sh/chart: {{ include "inference.chart" . }}
+{{ include "inference.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "inference.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "inference.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Embedding llama-server CLI arguments.
+*/}}
+{{- define "inference.embeddingArgs" -}}
+--n-gpu-layers {{ .Values.embeddings.llamaCpp.nGpuLayers | quote }} \
+--ctx-size {{ .Values.embeddings.llamaCpp.ctxSize | quote }} \
+{{- if .Values.embeddings.llamaCpp.flashAttn }}
+--flash-attn {{ .Values.embeddings.llamaCpp.flashAttn | quote }} \
+{{- end }}
+--cache-type-k {{ .Values.embeddings.llamaCpp.cacheTypeK | quote }} \
+--cache-type-v {{ .Values.embeddings.llamaCpp.cacheTypeV | quote }} \
+--threads {{ .Values.embeddings.llamaCpp.threads | quote }} \
+{{- if .Values.embeddings.llamaCpp.jinja }}
+--jinja \
+{{- end }}
+--host {{ .Values.server.host | quote }} \
+--port {{ .Values.server.port | quote }}{{ range .Values.embeddings.llamaCpp.extraArgs }} \
+{{ . | quote }}{{ end }}
+{{- end }}
+
+{{/*
+vLLM CLI arguments.
+*/}}
+{{- define "inference.vllmArgs" -}}
+--host {{ .Values.server.host }} \
+--port {{ .Values.server.port }} \
+--max-model-len {{ .Values.vllm.maxModelLen }} \
+--gpu-memory-utilization {{ .Values.vllm.gpuMemoryUtilization }} \
+{{- if .Values.vllm.quantization }}
+--quantization {{ .Values.vllm.quantization }} \
+{{- end }}
+{{- if .Values.vllm.tokenizer }}
+--tokenizer {{ .Values.vllm.tokenizer }} \
+{{- end }}
+{{- if .Values.server.chatTemplate }}
+--chat-template /etc/chat-template/chat-template.jinja \
+{{- end }}
+{{- range .Values.vllm.extraArgs }}
+{{ . | quote }} \
+{{- end }}
+--dtype {{ .Values.vllm.dtype }}
+{{- end }}

--- a/projects/inference/deploy/templates/configmap-chat-template.yaml
+++ b/projects/inference/deploy/templates/configmap-chat-template.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.server.chatTemplate }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "inference.fullname" . }}-chat-template
+  labels:
+    {{- include "inference.labels" . | nindent 4 }}
+data:
+  chat-template.jinja: |
+    {{- .Values.server.chatTemplate | nindent 4 }}
+{{- end }}

--- a/projects/inference/deploy/templates/deployment-embeddings.yaml
+++ b/projects/inference/deploy/templates/deployment-embeddings.yaml
@@ -1,0 +1,102 @@
+{{- if .Values.embeddings.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "inference.fullname" . }}-embeddings
+  labels:
+    {{- include "inference.labels" . | nindent 4 }}
+    app.kubernetes.io/component: embeddings
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      {{- include "inference.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: embeddings
+  template:
+    metadata:
+      {{- with .Values.embeddings.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "inference.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: embeddings
+    spec:
+      {{- if .Values.embeddings.runtimeClassName }}
+      runtimeClassName: {{ .Values.embeddings.runtimeClassName }}
+      {{- end }}
+      {{- if .Values.imagePullSecret.enabled }}
+      imagePullSecrets:
+        - name: ghcr-imagepull-secret
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: llama-server
+          image: "{{ .Values.embeddings.image.repository }}:{{ .Values.embeddings.image.tag }}"
+          imagePullPolicy: {{ .Values.embeddings.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              MODEL=$(find {{ .Values.embeddings.modelVolume.mountPath }} -maxdepth 2 -name '*.gguf' ! -name 'mmproj*' -type f | sort | head -1)
+              if [ -z "$MODEL" ]; then
+                echo "ERROR: no .gguf file found under {{ .Values.embeddings.modelVolume.mountPath }}" >&2
+                exit 1
+              fi
+              echo "Auto-discovered embedding model: $MODEL"
+              exec /app/llama-server \
+                --model "$MODEL" \
+                {{ include "inference.embeddingArgs" . | indent 16 | trim }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.server.port }}
+              protocol: TCP
+          startupProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 5
+            failureThreshold: 60
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            periodSeconds: 10
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            periodSeconds: 10
+            failureThreshold: 3
+          resources:
+            {{- toYaml .Values.embeddings.resources | nindent 12 }}
+          volumeMounts:
+            {{- if .Values.embeddings.modelVolume.enabled }}
+            - name: model
+              mountPath: {{ .Values.embeddings.modelVolume.mountPath }}
+              readOnly: true
+            {{- end }}
+            - name: dshm
+              mountPath: /dev/shm
+      volumes:
+        {{- if .Values.embeddings.modelVolume.enabled }}
+        - name: model
+          image:
+            reference: {{ .Values.embeddings.modelVolume.reference }}
+            pullPolicy: IfNotPresent
+        {{- end }}
+        - name: dshm
+          emptyDir:
+            medium: Memory
+            sizeLimit: "256Mi"
+      {{- with .Values.embeddings.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/projects/inference/deploy/templates/deployment.yaml
+++ b/projects/inference/deploy/templates/deployment.yaml
@@ -1,0 +1,112 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "inference.fullname" . }}
+  labels:
+    {{- include "inference.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  {{- with .Values.strategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "inference.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: inference
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "inference.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: inference
+    spec:
+      {{- with .Values.runtimeClassName }}
+      runtimeClassName: {{ . }}
+      {{- end }}
+      {{- if .Values.imagePullSecret.enabled }}
+      imagePullSecrets:
+        - name: ghcr-imagepull-secret
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: llama-server
+          image: "{{ .Values.image.vllm.repository }}:{{ .Values.image.vllm.tag }}"
+          imagePullPolicy: {{ .Values.image.vllm.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              # Auto-discover model: HuggingFace format (config.json) or GGUF.
+              MODEL=$(find {{ .Values.modelVolume.mountPath }} -maxdepth 2 -name 'config.json' -type f -exec dirname {} \; | head -1)
+              if [ -z "$MODEL" ]; then
+                MODEL=$(find {{ .Values.modelVolume.mountPath }} -maxdepth 2 -name '*.gguf' ! -name 'mmproj*' -type f | sort | head -1)
+              fi
+              if [ -z "$MODEL" ]; then
+                echo "ERROR: no model found under {{ .Values.modelVolume.mountPath }}" >&2
+                exit 1
+              fi
+              echo "Auto-discovered model: $MODEL"
+              exec vllm serve "$MODEL" \
+                {{ include "inference.vllmArgs" . | indent 16 | trim }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.server.port }}
+              protocol: TCP
+          {{- with .Values.startupProbe }}
+          startupProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            {{- if .Values.modelVolume.enabled }}
+            - name: model
+              mountPath: {{ .Values.modelVolume.mountPath }}
+              readOnly: true
+            {{- end }}
+            {{- if .Values.server.chatTemplate }}
+            - name: chat-template
+              mountPath: /etc/chat-template
+              readOnly: true
+            {{- end }}
+            - name: vllm-cache
+              mountPath: /root/.cache
+            - name: dshm
+              mountPath: /dev/shm
+      volumes:
+        {{- if .Values.modelVolume.enabled }}
+        - name: model
+          image:
+            reference: {{ .Values.modelVolume.reference }}
+            pullPolicy: IfNotPresent
+        {{- end }}
+        {{- if .Values.server.chatTemplate }}
+        - name: chat-template
+          configMap:
+            name: {{ include "inference.fullname" . }}-chat-template
+        {{- end }}
+        - name: vllm-cache
+          persistentVolumeClaim:
+            claimName: {{ include "inference.fullname" . }}-vllm-cache
+        - name: dshm
+          emptyDir:
+            medium: Memory
+            sizeLimit: "1Gi"
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/projects/inference/deploy/templates/image-pull-secret.yaml
+++ b/projects/inference/deploy/templates/image-pull-secret.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.imagePullSecret.enabled }}
+---
+apiVersion: onepassword.com/v1
+kind: OnePasswordItem
+type: kubernetes.io/dockerconfigjson
+metadata:
+  name: ghcr-imagepull-secret
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "inference.labels" . | nindent 4 }}
+spec:
+  itemPath: {{ .Values.imagePullSecret.onepassword.itemPath | quote }}
+{{- end }}

--- a/projects/inference/deploy/templates/pvc-vllm-cache.yaml
+++ b/projects/inference/deploy/templates/pvc-vllm-cache.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "inference.fullname" . }}-vllm-cache
+  labels:
+    {{- include "inference.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 2Gi

--- a/projects/inference/deploy/templates/service-embeddings.yaml
+++ b/projects/inference/deploy/templates/service-embeddings.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.embeddings.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "inference.fullname" . }}-embeddings
+  labels:
+    {{- include "inference.labels" . | nindent 4 }}
+    app.kubernetes.io/component: embeddings
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.server.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "inference.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: embeddings
+{{- end }}

--- a/projects/inference/deploy/templates/service.yaml
+++ b/projects/inference/deploy/templates/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "inference.fullname" . }}
+  labels:
+    {{- include "inference.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.server.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "inference.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: inference

--- a/projects/inference/deploy/values.yaml
+++ b/projects/inference/deploy/values.yaml
@@ -1,0 +1,322 @@
+fullnameOverride: "inference"
+
+# LLM is served by vLLM (single backend — no swappable hosting tech).
+image:
+  vllm:
+    repository: vllm/vllm-openai
+    tag: "v0.19.1"
+    pullPolicy: IfNotPresent
+
+imagePullSecret:
+  enabled: true
+  onepassword:
+    itemPath: "vaults/k8s-homelab/items/ghcr-read-permissions"
+
+modelVolume:
+  enabled: true
+  # Qwen3.6-35B-A3B MoE (~3B active) replacing the 27B hybrid (~27B active): at our
+  # batch=1 workload (Discord/summarize) decode is bandwidth-bound on active params,
+  # so this is a large per-call latency win. int4-mixed AutoRound keeps the router/
+  # gate + embeddings at higher precision (better MoE quality) with experts at INT4.
+  # Pushed to ghcr out-of-band via `hf2oci copy Intel/Qwen3.6-35B-A3B-int4-mixed-AutoRound
+  # -r ghcr.io/jomcgi/models`, so this references the resolved ghcr ref directly
+  # (matching the prior 27B convention).
+  reference: "ghcr.io/jomcgi/models/qwen/qwen3.6-35b-a3b:intel-qwen3.6-35b-a3b-int4-mixed-autoround"
+  mountPath: "/model-image"
+
+server:
+  host: "0.0.0.0"
+  port: 8080
+  # Official Qwen3.6 chat template (qwen3_coder <function=...> tool-call format),
+  # shared across the Qwen3.6 family — verified identical for Qwen3.6-35B-A3B.
+  # Required because the AutoRound INT4 quant strips the template from the repo.
+  chatTemplate: |
+    {%- set image_count = namespace(value=0) %}
+    {%- set video_count = namespace(value=0) %}
+    {%- macro render_content(content, do_vision_count, is_system_content=false) %}
+        {%- if content is string %}
+            {{- content }}
+        {%- elif content is iterable and content is not mapping %}
+            {%- for item in content %}
+                {%- if 'image' in item or 'image_url' in item or item.type == 'image' %}
+                    {%- if is_system_content %}
+                        {{- raise_exception('System message cannot contain images.') }}
+                    {%- endif %}
+                    {%- if do_vision_count %}
+                        {%- set image_count.value = image_count.value + 1 %}
+                    {%- endif %}
+                    {%- if add_vision_id %}
+                        {{- 'Picture ' ~ image_count.value ~ ': ' }}
+                    {%- endif %}
+                    {{- '<|vision_start|><|image_pad|><|vision_end|>' }}
+                {%- elif 'video' in item or item.type == 'video' %}
+                    {%- if is_system_content %}
+                        {{- raise_exception('System message cannot contain videos.') }}
+                    {%- endif %}
+                    {%- if do_vision_count %}
+                        {%- set video_count.value = video_count.value + 1 %}
+                    {%- endif %}
+                    {%- if add_vision_id %}
+                        {{- 'Video ' ~ video_count.value ~ ': ' }}
+                    {%- endif %}
+                    {{- '<|vision_start|><|video_pad|><|vision_end|>' }}
+                {%- elif 'text' in item %}
+                    {{- item.text }}
+                {%- else %}
+                    {{- raise_exception('Unexpected item type in content.') }}
+                {%- endif %}
+            {%- endfor %}
+        {%- elif content is none or content is undefined %}
+            {{- '' }}
+        {%- else %}
+            {{- raise_exception('Unexpected content type.') }}
+        {%- endif %}
+    {%- endmacro %}
+    {%- if not messages %}
+        {{- raise_exception('No messages provided.') }}
+    {%- endif %}
+    {%- if tools and tools is iterable and tools is not mapping %}
+        {{- '<|im_start|>system\n' }}
+        {{- "# Tools\n\nYou have access to the following functions:\n\n<tools>" }}
+        {%- for tool in tools %}
+            {{- "\n" }}
+            {{- tool | tojson }}
+        {%- endfor %}
+        {{- "\n</tools>" }}
+        {{- '\n\nIf you choose to call a function ONLY reply in the following format with NO suffix:\n\n<tool_call>\n<function=example_function_name>\n<parameter=example_parameter_1>\nvalue_1\n</parameter>\n<parameter=example_parameter_2>\nThis is the value for the second parameter\nthat can span\nmultiple lines\n</parameter>\n</function>\n</tool_call>\n\n<IMPORTANT>\nReminder:\n- Function calls MUST follow the specified format: an inner <function=...></function> block must be nested within <tool_call></tool_call> XML tags\n- Required parameters MUST be specified\n- You may provide optional reasoning for your function call in natural language BEFORE the function call, but NOT after\n- If there is no function call available, answer the question like normal with your current knowledge and do not tell the user about function calls\n</IMPORTANT>' }}
+        {%- if messages[0].role == 'system' %}
+            {%- set content = render_content(messages[0].content, false, true)|trim %}
+            {%- if content %}
+                {{- '\n\n' + content }}
+            {%- endif %}
+        {%- endif %}
+        {{- '<|im_end|>\n' }}
+    {%- else %}
+        {%- if messages[0].role == 'system' %}
+            {%- set content = render_content(messages[0].content, false, true)|trim %}
+            {{- '<|im_start|>system\n' + content + '<|im_end|>\n' }}
+        {%- endif %}
+    {%- endif %}
+    {%- set ns = namespace(multi_step_tool=true, last_query_index=messages|length - 1) %}
+    {%- for message in messages[::-1] %}
+        {%- set index = (messages|length - 1) - loop.index0 %}
+        {%- if ns.multi_step_tool and message.role == "user" %}
+            {%- set content = render_content(message.content, false)|trim %}
+            {%- if not(content.startswith('<tool_response>') and content.endswith('</tool_response>')) %}
+                {%- set ns.multi_step_tool = false %}
+                {%- set ns.last_query_index = index %}
+            {%- endif %}
+        {%- endif %}
+    {%- endfor %}
+    {%- if ns.multi_step_tool %}
+        {{- raise_exception('No user query found in messages.') }}
+    {%- endif %}
+    {%- for message in messages %}
+        {%- set content = render_content(message.content, true)|trim %}
+        {%- if message.role == "system" %}
+            {%- if not loop.first %}
+                {{- '<|im_start|>system\n' + content + '<|im_end|>\n' }}
+            {%- endif %}
+        {%- elif message.role == "user" %}
+            {{- '<|im_start|>' + message.role + '\n' + content + '<|im_end|>' + '\n' }}
+        {%- elif message.role == "assistant" %}
+            {%- set reasoning_content = '' %}
+            {%- if message.reasoning_content is string %}
+                {%- set reasoning_content = message.reasoning_content %}
+            {%- else %}
+                {%- if '</think>' in content %}
+                    {%- set reasoning_content = content.split('</think>')[0].rstrip('\n').split('<think>')[-1].lstrip('\n') %}
+                    {%- set content = content.split('</think>')[-1].lstrip('\n') %}
+                {%- endif %}
+            {%- endif %}
+            {%- set reasoning_content = reasoning_content|trim %}
+            {%- if (preserve_thinking is defined and preserve_thinking is true) or (loop.index0 > ns.last_query_index) %}
+                {{- '<|im_start|>' + message.role + '\n<think>\n' + reasoning_content + '\n</think>\n\n' + content }}
+            {%- else %}
+                {{- '<|im_start|>' + message.role + '\n' + content }}
+            {%- endif %}
+            {%- if message.tool_calls and message.tool_calls is iterable and message.tool_calls is not mapping %}
+                {%- for tool_call in message.tool_calls %}
+                    {%- if tool_call.function is defined %}
+                        {%- set tool_call = tool_call.function %}
+                    {%- endif %}
+                    {%- if loop.first %}
+                        {%- if content|trim %}
+                            {{- '\n\n<tool_call>\n<function=' + tool_call.name + '>\n' }}
+                        {%- else %}
+                            {{- '<tool_call>\n<function=' + tool_call.name + '>\n' }}
+                        {%- endif %}
+                    {%- else %}
+                        {{- '\n<tool_call>\n<function=' + tool_call.name + '>\n' }}
+                    {%- endif %}
+                    {%- if tool_call.arguments is defined %}
+                        {%- for args_name, args_value in tool_call.arguments|items %}
+                            {{- '<parameter=' + args_name + '>\n' }}
+                            {%- set args_value = args_value | string if args_value is string else args_value | tojson | safe %}
+                            {{- args_value }}
+                            {{- '\n</parameter>\n' }}
+                        {%- endfor %}
+                    {%- endif %}
+                    {{- '</function>\n</tool_call>' }}
+                {%- endfor %}
+            {%- endif %}
+            {{- '<|im_end|>\n' }}
+        {%- elif message.role == "tool" %}
+            {%- if loop.previtem and loop.previtem.role != "tool" %}
+                {{- '<|im_start|>user' }}
+            {%- endif %}
+            {{- '\n<tool_response>\n' }}
+            {{- content }}
+            {{- '\n</tool_response>' }}
+            {%- if not loop.last and loop.nextitem.role != "tool" %}
+                {{- '<|im_end|>\n' }}
+            {%- elif loop.last %}
+                {{- '<|im_end|>\n' }}
+            {%- endif %}
+        {%- else %}
+            {{- raise_exception('Unexpected message role.') }}
+        {%- endif %}
+    {%- endfor %}
+    {%- if add_generation_prompt %}
+        {{- '<|im_start|>assistant\n' }}
+        {%- if enable_thinking is defined and enable_thinking is false %}
+            {{- '<think>\n\n</think>\n\n' }}
+        {%- else %}
+            {{- '<think>\n' }}
+        {%- endif %}
+    {%- endif %}
+
+vllm:
+  # 32768 (was 49152): 35B-A3B int4-mixed weights are ~21-22GB resident (MoE keeps
+  # all experts loaded; mixed precision adds ~2GB over plain INT4), leaving thin KV
+  # headroom on a 24GB card. If load OOMs, add --enforce-eager (frees ~1-2GB of
+  # CUDA-graph capture) before lowering ctx further; raise back toward 49152 only
+  # after confirming KV headroom in the vLLM startup logs.
+  maxModelLen: 32768
+  gpuMemoryUtilization: 0.95
+  dtype: "auto"
+  quantization: ""
+  tokenizer: ""
+  extraArgs:
+    - "--served-model-name"
+    - "qwen3.6-27b"
+    - "--enable-auto-tool-choice"
+    - "--tool-call-parser"
+    - "qwen3_coder"
+    - "--reasoning-parser"
+    - "qwen3"
+    - "--reasoning-config"
+    - '{"reasoning_start_str": "<think>", "reasoning_end_str": "</think>"}'
+    - "--max-num-seqs"
+    - "3"
+    - "--kv-cache-dtype"
+    - "fp8"
+
+runtimeClassName: nvidia
+
+nodeSelector:
+  kubernetes.io/hostname: node-4
+
+strategy:
+  type: Recreate
+
+podAnnotations:
+  linkerd.io/inject: disabled
+  prometheus.io/scrape: "true"
+  prometheus.io/port: "8080"
+
+# vLLM runs as root and needs writable fs for compiled kernels
+podSecurityContext:
+  runAsUser: 0
+  runAsGroup: 0
+  fsGroup: 0
+  seccompProfile:
+    type: RuntimeDefault
+
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: false
+  capabilities:
+    drop:
+      - ALL
+
+startupProbe:
+  httpGet:
+    path: /health
+    port: http
+  initialDelaySeconds: 30
+  periodSeconds: 10
+  failureThreshold: 180
+
+livenessProbe:
+  httpGet:
+    path: /health
+    port: http
+  initialDelaySeconds: 15
+  periodSeconds: 10
+  failureThreshold: 3
+
+readinessProbe:
+  httpGet:
+    path: /health
+    port: http
+  initialDelaySeconds: 5
+  periodSeconds: 10
+  failureThreshold: 3
+
+# CPU request trimmed 4 -> 2: vLLM decode is GPU-bound, 7-day SigNoz peak CPU is
+# ~1715m (avg ~7m), so 2 cores covers peak with headroom and frees node-4 reservation.
+resources:
+  requests:
+    cpu: 2
+    memory: "24Gi"
+    nvidia.com/gpu: 1
+  limits:
+    memory: "32Gi"
+    nvidia.com/gpu: 1
+
+# Embeddings are served by llama.cpp on CPU (no GPU layers).
+embeddings:
+  enabled: true
+  image:
+    repository: ghcr.io/ggml-org/llama.cpp
+    tag: "server-cuda-b8643"
+    pullPolicy: IfNotPresent
+  modelVolume:
+    enabled: true
+    reference: "ghcr.io/jomcgi/models/voyageai/voyage-4-nano:jsonmartin-gguf-q8-0"
+    mountPath: "/model-image"
+  llamaCpp:
+    nGpuLayers: 0
+    ctxSize: 8192
+    flashAttn: "off"
+    cacheTypeK: "f16"
+    cacheTypeV: "f16"
+    threads: 4
+    jinja: false
+    # Raise ubatch/batch from llama.cpp's 512-token default: in --embedding
+    # mode the whole input must fit in one physical batch, and the monolith
+    # chunker's `words * 1.3` estimator undercounts dense markdown (tables,
+    # code) — a "512-est" chunk can decode to ~700 real tokens and 500 out.
+    extraArgs:
+      - "--embedding"
+      - "--alias"
+      - "voyage-4-nano"
+      - "--metrics"
+      - "--ubatch-size"
+      - "8192"
+      - "--batch-size"
+      - "8192"
+  runtimeClassName: null
+  nodeSelector:
+    kubernetes.io/hostname: node-4
+  podAnnotations:
+    linkerd.io/inject: disabled
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "8080"
+  resources:
+    requests:
+      cpu: 2
+      memory: "4Gi"
+    limits:
+      memory: "8Gi"


### PR DESCRIPTION
## PR1 of 3: relocate inference out of `agent_platform`

Adds a new top-level `projects/inference/` chart, a leaned, decoupled copy of `agent_platform/inference/deploy`. **Inert and safe to merge on its own** (deploys nothing).

**What it serves (the live hybrid, unchanged):**
- LLM on **vLLM** (`vllm/vllm-openai:v0.19.1`): Qwen3.6-35B-A3B int4, served as `qwen3.6-27b`.
- Embeddings on **llama.cpp CPU**: `voyage-4-nano` GGUF.

**Leaning:** stripped the unused multi-backend branches (llama.cpp-LLM, vLLM-embeddings) and collapsed `values.yaml` + `values-prod.yaml` into one. Render is **byte-identical** to the current deploy (verified via `helm template` diff, twice), so the cutover changes nothing about the running pods.

**Why it's inert:** no `kustomization.yaml`, so `generate-home-cluster` can't discover it and ArgoCD never syncs it. Confirmed a home-cluster regen produces zero change. The kustomization + root wiring (and removing the `agent_platform` one) is **PR2's atomic cutover**, so only one vLLM ever holds the GPU.

**Consumers unaffected:** same namespace (`inference`) and service names (`inference`, `inference-embeddings`); `monolith`/`monolith-public` need no changes. Sources from the git path (not OCI), so no new GHCR package / visibility flip.

Sequence: **PR1 (this, inert)** → PR2 (atomic cutover: enable here, disable in agent_platform) → PR3 (delete the rest of agent_platform).

🤖 Generated with [Claude Code](https://claude.com/claude-code)