### PR TITLE
chore(deprecation): add resources-finalizer to apps slated for deletion (PR0)

### DIFF
--- a/projects/agent_platform/api_gateway/deploy/application.yaml
+++ b/projects/agent_platform/api_gateway/deploy/application.yaml
@@ -3,6 +3,8 @@ kind: Application
 metadata:
   name: api-gateway
   namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
 spec:
   project: default
   source:

--- a/projects/agent_platform/cluster_agents/deploy/Chart.yaml
+++ b/projects/agent_platform/cluster_agents/deploy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cluster-agents
 description: Autonomous cluster monitoring agents
 type: application
-version: 0.7.0
+version: 0.7.1
 appVersion: "0.2.0"
 annotations:
   org.opencontainers.image.source: "https://github.com/jomcgi/homelab"

--- a/projects/agent_platform/cluster_agents/deploy/application.yaml
+++ b/projects/agent_platform/cluster_agents/deploy/application.yaml
@@ -10,7 +10,7 @@ spec:
   source:
     repoURL: ghcr.io/jomcgi/homelab/charts
     chart: cluster-agents
-    targetRevision: 0.7.0
+    targetRevision: 0.7.1
     helm:
       releaseName: cluster-agents
       # IMPORTANT: Do NOT add podAnnotations here. The chart-version-bot regenerates

--- a/projects/agent_platform/cluster_agents/deploy/application.yaml
+++ b/projects/agent_platform/cluster_agents/deploy/application.yaml
@@ -3,6 +3,8 @@ kind: Application
 metadata:
   name: cluster-agents
   namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
 spec:
   project: default
   source:

--- a/projects/agent_platform/deploy/application.yaml
+++ b/projects/agent_platform/deploy/application.yaml
@@ -3,6 +3,8 @@ kind: Application
 metadata:
   name: agent-platform
   namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
 spec:
   project: default
   sources:

--- a/projects/platform/nack/application.yaml
+++ b/projects/platform/nack/application.yaml
@@ -3,6 +3,8 @@ kind: Application
 metadata:
   name: nack
   namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
   labels:
     app.kubernetes.io/part-of: shared-infrastructure
   annotations:

--- a/projects/platform/nats-streams/application.yaml
+++ b/projects/platform/nats-streams/application.yaml
@@ -3,6 +3,8 @@ kind: Application
 metadata:
   name: nats-streams
   namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
   labels:
     app.kubernetes.io/part-of: shared-infrastructure
   annotations:

--- a/projects/platform/nats/application.yaml
+++ b/projects/platform/nats/application.yaml
@@ -3,6 +3,8 @@ kind: Application
 metadata:
   name: nats
   namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
   labels:
     app.kubernetes.io/part-of: shared-infrastructure
   annotations:

--- a/projects/trips/deploy/application.yaml
+++ b/projects/trips/deploy/application.yaml
@@ -3,6 +3,8 @@ kind: Application
 metadata:
   name: trips
   namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
   labels:
     app.kubernetes.io/part-of: yukon-tracker
 spec:


### PR DESCRIPTION
## PR0 of the agent-stack deprecation: finalizers first

Adds `resources-finalizer.argocd.argoproj.io` to the 7 ArgoCD Applications being deleted in the follow-up PRs: `agent-platform`, `api-gateway`, `cluster-agents`, `nats`, `nats-streams`, `nack`, `trips`.

**Why first:** none of them currently carry the finalizer. Without it, removing an app from the app-of-apps deletes the Application object **non-cascading**, orphaning its workloads (StatefulSets, the 50Gi NATS PVC, the agent-sandbox controller + CRDs, namespaces). With the finalizer synced onto the live CRs first, each later deletion cascade-prunes cleanly.

**This PR deletes nothing**; it only changes how the later deletions behave. It must merge + sync before any teardown PR.

Sequence after this: trips → drain sandbox CRs + delete agent_platform (+ api.jomcgi.dev CF route) → platform NATS (streams → nack → nats).

🤖 Generated with [Claude Code](https://claude.com/claude-code)