### PR TITLE
ci: harden future-feature BDD query against bb CLI log pollution

### DIFF
--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -157,7 +157,13 @@ actions:
             echo "Skipping automated commit from $AUTHOR"
             exit 0
           fi
-          TARGETS="$(bazel query 'attr(tags, "\bfuture\b", tests(//...))' 2>/dev/null || true)"
+          # grep '^//' keeps only real target labels. The bb CLI interleaves its
+          # own operational log lines (connection warnings, a capabilities JSON
+          # blob) into stdout, which transient proxy resets make frequent; without
+          # this filter that noise lands in $TARGETS and `bazel test` then chokes
+          # on log text as target names ("invalid target name"), failing the step
+          # for a network blip rather than a real spec result.
+          TARGETS="$(bazel query 'attr(tags, "\bfuture\b", tests(//...))' 2>/dev/null | grep '^//' || true)"
           if [ -z "$TARGETS" ]; then
             echo "No future-feature BDD specs (nothing tagged 'future'). Nothing to run."
             exit 0


### PR DESCRIPTION
## Why

The "BDD future features" check flaps red on unlucky runs. Root cause from the logs: the step captures `bazel query` stdout into `$TARGETS`, but `bazel` is the BuildBuddy CLI, which interleaves its own operational logs (connection warnings, a `Remote capabilities {...}` JSON blob) into **stdout**. On transient proxy resets (`connection reset by peer`) that noise lands in `$TARGETS`, and `bazel test $TARGETS` then chokes on log text as target labels:

```
ERROR: Skipping '2026/06/23': invalid target name ...
ERROR: Build did NOT complete successfully
```

So the step fails for a network blip, not a real spec result. (It's non-blocking, but the red is misleading noise on every PR that hits it.)

## Fix

Filter the capture through `grep '^//'` so only real target labels survive; bb's log lines (which never start with `//`) are dropped. A genuinely empty result still yields an empty `$TARGETS` and the existing `exit 0` "nothing to run" path.

One-line change to `buildbuddy.yaml`, plus an explanatory comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)