### PR TITLE
feat(semgrep): add memory-request-ne-limit rule

### DIFF
--- a/bazel/semgrep/rules/BUILD
+++ b/bazel/semgrep/rules/BUILD
@@ -28,6 +28,11 @@ filegroup(
     srcs = glob(
         ["yaml/*.yaml"],
         allow_empty = True,
+        # memory-request-ne-limit is path-scoped to **/deploy/values.yaml and
+        # **/chart/values.yaml. Excluded here to prevent yaml_rules_test from
+        # running it against yaml_fixtures (which include require-resource-limits.yaml
+        # with intentional request!=limit mismatches). Tested via its own target below.
+        exclude = ["yaml/memory-request-ne-limit.yaml"],
     ),
 )
 
@@ -481,5 +486,22 @@ semgrep_test(
     srcs = ["//bazel/semgrep/tests:svelte_hardcoded_color_in_style_fixtures"],
     env = {"SEMGREP_TEST_MODE": "1"},
     rules = [":svelte_hardcoded_color_in_style_rule"],
+    tags = ["semgrep"],
+)
+
+# memory-request-ne-limit enforces requests==limits for memory in deploy and chart
+# values files. Excluded from yaml_rules_test (which would run it against fixtures
+# containing intentional request!=limit mismatches from other rules). Tested here
+# against dedicated ok/bad fixture files in bazel/semgrep/tests/yaml/.
+filegroup(
+    name = "memory_request_ne_limit_rule",
+    srcs = ["yaml/memory-request-ne-limit.yaml"],
+)
+
+semgrep_test(
+    name = "memory_request_ne_limit_test",
+    srcs = ["//bazel/semgrep/tests:memory_request_ne_limit_fixtures"],
+    env = {"SEMGREP_TEST_MODE": "1"},
+    rules = [":memory_request_ne_limit_rule"],
     tags = ["semgrep"],
 )

--- a/bazel/semgrep/rules/yaml/memory-request-ne-limit.yaml
+++ b/bazel/semgrep/rules/yaml/memory-request-ne-limit.yaml
@@ -1,0 +1,32 @@
+rules:
+  - id: memory-request-ne-limit
+    languages: [yaml]
+    severity: WARNING
+    message: >-
+      resources.requests.memory ($REQ) differs from resources.limits.memory
+      ($LIM). The repo convention is requests==limits for memory to prevent
+      overcommit OOM-kills: a request below the limit allows the kernel to
+      overcommit, which can kill the pod below its own ceiling under node
+      memory pressure. Set both to the same value, sized to the observed
+      working-set peak with headroom.
+    metadata:
+      category: correctness
+    paths:
+      include:
+        - "**/deploy/values.yaml"
+        - "**/chart/values.yaml"
+      exclude:
+        - "projects/inference/**"
+    patterns:
+      - pattern: |
+          resources:
+            requests:
+              memory: $REQ
+            limits:
+              memory: $LIM
+      - pattern-not: |
+          resources:
+            requests:
+              memory: $MEM
+            limits:
+              memory: $MEM

--- a/bazel/semgrep/tests/BUILD
+++ b/bazel/semgrep/tests/BUILD
@@ -184,3 +184,10 @@ filegroup(
         "fixtures/require-tmp-emptydir.yaml",
     ]),
 )
+
+# Fixtures for the memory-request-ne-limit rule (ok and bad cases in separate files).
+# Referenced by //bazel/semgrep/rules:memory_request_ne_limit_test.
+filegroup(
+    name = "memory_request_ne_limit_fixtures",
+    srcs = glob(["yaml/memory-request-ne-limit/*.yaml"]),
+)

--- a/bazel/semgrep/tests/yaml/memory-request-ne-limit/bad.yaml
+++ b/bazel/semgrep/tests/yaml/memory-request-ne-limit/bad.yaml
@@ -1,0 +1,27 @@
+# Bad cases for memory-request-ne-limit rule.
+# Each resources block below has requests.memory != limits.memory and must fire.
+---
+# ruleid: memory-request-ne-limit
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    memory: 256Mi
+
+---
+# ruleid: memory-request-ne-limit
+resources:
+  requests:
+    memory: 64Mi
+  limits:
+    memory: 512Mi
+
+---
+# ruleid: memory-request-ne-limit
+resources:
+  requests:
+    cpu: 250m
+    memory: 160Mi
+  limits:
+    memory: 384Mi

--- a/bazel/semgrep/tests/yaml/memory-request-ne-limit/ok.yaml
+++ b/bazel/semgrep/tests/yaml/memory-request-ne-limit/ok.yaml
@@ -1,0 +1,27 @@
+# Ok cases for memory-request-ne-limit rule.
+# Each resources block below has requests.memory == limits.memory and must not fire.
+---
+# ok: memory-request-ne-limit
+resources:
+  requests:
+    cpu: 100m
+    memory: 256Mi
+  limits:
+    memory: 256Mi
+
+---
+# ok: memory-request-ne-limit
+resources:
+  requests:
+    memory: 512Mi
+  limits:
+    memory: 512Mi
+
+---
+# ok: memory-request-ne-limit
+resources:
+  requests:
+    cpu: 250m
+    memory: 384Mi
+  limits:
+    memory: 384Mi

--- a/bazel/tools/hooks/check-semgrep-rule-has-fixture.sh
+++ b/bazel/tools/hooks/check-semgrep-rule-has-fixture.sh
@@ -2,10 +2,11 @@
 # PreToolUse hook: warn when writing/editing a semgrep rule YAML file that has
 # no corresponding test fixture.
 #
-# Fixtures can live in two places:
+# Fixtures can live in three places:
 #   1. bazel/semgrep/tests/fixtures/<rule-stem>.<ext>  (central fixtures dir)
 #   2. bazel/semgrep/rules/<subdir>/<rule-stem>.<ext>  (colocated, any non-yaml ext)
 #      Python fixtures use underscore naming: <rule_stem>.py
+#   3. bazel/semgrep/tests/yaml/<rule-stem>/  (directory with ok.yaml + bad.yaml)
 #
 # Input: JSON on stdin from Claude Code hook system
 # Exit 0: allow (warnings emitted on stderr — advisory only)
@@ -53,6 +54,12 @@ if compgen -G "${FIXTURES_DIR}/${STEM}."'*' >/dev/null 2>&1; then
 	exit 0
 fi
 
+# Check 1b: tests/yaml/<stem>/ directory (ok.yaml + bad.yaml convention)
+YAML_TEST_DIR="${PROJECT_DIR}/bazel/semgrep/tests/yaml/${STEM}"
+if [[ -d "$YAML_TEST_DIR" ]]; then
+	exit 0
+fi
+
 # Check 2: colocated fixture with dash-named stem (non-yaml)
 if has_non_yaml_fixture "${RULE_DIR}/${STEM}"; then
 	exit 0
@@ -68,6 +75,7 @@ WARNING: No test fixture found for semgrep rule '${STEM}'.
 
 Expected a fixture in one of:
   ${FIXTURES_DIR}/${STEM}.<ext>
+  ${YAML_TEST_DIR}/  (directory with ok.yaml + bad.yaml)
   ${RULE_DIR}/${STEM}.<ext>  (colocated)
   ${RULE_DIR}/${STEM_UNDERSCORED}.<ext>  (colocated, Python naming)
 

--- a/bazel/tools/hooks/check-semgrep-rule-has-fixture_test.sh
+++ b/bazel/tools/hooks/check-semgrep-rule-has-fixture_test.sh
@@ -85,6 +85,7 @@ export PATH="${TEST_TMPDIR}/bin:${PATH}"
 FAKE_ROOT="${TEST_TMPDIR}/project"
 FAKE_RULES="${FAKE_ROOT}/bazel/semgrep/rules"
 FAKE_FIXTURES="${FAKE_ROOT}/bazel/semgrep/tests/fixtures"
+FAKE_YAML_TESTS="${FAKE_ROOT}/bazel/semgrep/tests/yaml"
 mkdir -p "${FAKE_RULES}/kubernetes" "${FAKE_RULES}/python" "${FAKE_RULES}/yaml" "${FAKE_FIXTURES}"
 
 # ---------------------------------------------------------------------------
@@ -218,6 +219,24 @@ touch "$RULE_G"
 run_test "rule_no_dashes_in_stem_no_fixture_warns" \
 	"$(make_json "$RULE_G")" \
 	0 "WARNING.*noprivileged"
+
+# 11. Rule has a tests/yaml/<stem>/ directory (ok.yaml + bad.yaml convention) → silent
+RULE_H="${FAKE_RULES}/yaml/memory-request-ne-limit.yaml"
+touch "$RULE_H"
+mkdir -p "${FAKE_YAML_TESTS}/memory-request-ne-limit"
+touch "${FAKE_YAML_TESTS}/memory-request-ne-limit/ok.yaml"
+touch "${FAKE_YAML_TESTS}/memory-request-ne-limit/bad.yaml"
+run_test "rule_with_yaml_test_dir_silent" \
+	"$(make_json "$RULE_H")" \
+	0 ""
+
+# 12. Rule with tests/yaml/<stem>/ directory that is empty still counts → silent
+RULE_I="${FAKE_RULES}/yaml/another-rule.yaml"
+touch "$RULE_I"
+mkdir -p "${FAKE_YAML_TESTS}/another-rule"
+run_test "rule_with_empty_yaml_test_dir_silent" \
+	"$(make_json "$RULE_I")" \
+	0 ""
 
 # ---------------------------------------------------------------------------
 # Summary


### PR DESCRIPTION
## Summary

- Adds a new semgrep rule `memory-request-ne-limit` that flags `values.yaml` files where `resources.requests.memory` differs from `resources.limits.memory`
- The repo convention is `requests==limits` for memory to prevent overcommit OOM-kills (see commit 65063f8 which fixed 3 violations)
- Scoped to `**/deploy/values.yaml` and `**/chart/values.yaml`; excludes `projects/inference/**` (GPU workloads intentionally use a headroom gap)
- Introduces the `bazel/semgrep/tests/yaml/<rule>/` directory convention (ok.yaml + bad.yaml) as an alternative to the single-file central fixture pattern; updates `check-semgrep-rule-has-fixture.sh` to recognise it

## Files changed

- `bazel/semgrep/rules/yaml/memory-request-ne-limit.yaml` -- the rule
- `bazel/semgrep/tests/yaml/memory-request-ne-limit/{ok,bad}.yaml` -- test fixtures
- `bazel/semgrep/rules/BUILD` -- exclude from yaml_rules_test; add dedicated test target
- `bazel/semgrep/tests/BUILD` -- add `memory_request_ne_limit_fixtures` filegroup
- `bazel/tools/hooks/check-semgrep-rule-has-fixture.sh` -- add check 1b for tests/yaml/ directory
- `bazel/tools/hooks/check-semgrep-rule-has-fixture_test.sh` -- two new test cases

## Test plan

- [ ] `//bazel/semgrep/rules:memory_request_ne_limit_test` passes
- [ ] `//bazel/semgrep/rules:yaml_rules_test` still passes
- [ ] `//bazel/tools/hooks:check_semgrep_rule_has_fixture_test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)