### PR TITLE
chore(monolith): mark Agent Platform deprecated + trim dead refs

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.60.7
+version: 0.60.8
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.60.8
+version: 0.60.9
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.60.7
+      targetRevision: 0.60.8
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.60.8
+      targetRevision: 0.60.9
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/agent/checks.py
+++ b/projects/monolith/agent/checks.py
@@ -146,12 +146,10 @@ async def check_firing_alerts(
 ) -> list[dict]:
     """Return SigNoz alert rules whose ``state`` is ``firing``.
 
-    Mirrors the Go ``AlertCollector`` in
-    ``projects/agent_platform/cluster_agents/collector_alerts.go`` —
-    same endpoint (``/api/v1/rules``), same auth header
-    (``SIGNOZ-API-KEY``), same ``state == "firing"`` filter. Reads
-    ``SIGNOZ_URL`` and (optional) ``SIGNOZ_API_KEY`` from the
-    environment.
+    Queries the SigNoz ``/api/v1/rules`` endpoint, authenticating with the
+    ``SIGNOZ-API-KEY`` header, and filters the returned rules down to those
+    with ``state == "firing"``. Reads ``SIGNOZ_URL`` and (optional)
+    ``SIGNOZ_API_KEY`` from the environment.
 
     The optional ``transport`` arg exists only for tests; production
     callers always omit it.

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.215.8
+version: 0.215.9
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.215.7
+version: 0.215.8
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.215.8
+      targetRevision: 0.215.9
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.215.7
+      targetRevision: 0.215.8
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/routes/public/HomepageTopology.svelte
+++ b/projects/monolith/frontend/src/routes/public/HomepageTopology.svelte
@@ -44,7 +44,7 @@
   }
 
   // ── Filter for homepage: remove nodes, mark same-rank edges ──
-  const excludeIds = new Set(["agent-platform", "nats", "external"]);
+  const excludeIds = new Set(["external"]);
   const sameRankEdges = new Set(["cloudflare->context-forge"]);
   const fullFiltered = $derived.by(() => {
     const groups = (topology.groups || []).filter((g) => !excludeIds.has(g.id));

--- a/projects/monolith/frontend/src/routes/public/engineering/engineering-data.js
+++ b/projects/monolith/frontend/src/routes/public/engineering/engineering-data.js
@@ -20,7 +20,6 @@ export const marqueeItems = [
   "Rust",
   "Python",
   "Kubernetes Operators",
-  "NATS JetStream",
   "vLLM on a 4090",
   "Postgres + pgvector",
   "Bazel + BuildBuddy",
@@ -42,11 +41,12 @@ export const projects = [
   {
     id: "agent-platform",
     category: "agents",
+    status: "Deprecated",
     title: "Agent Platform",
     oneLiner:
-      "Autonomous Claude and Goose agents in sandboxed Kubernetes pods, dispatched over NATS. Every tool call governed by an MCP gateway.",
+      "Retired. Autonomous Claude and Goose agents in sandboxed Kubernetes pods, dispatched over NATS, with every tool call governed by an MCP gateway. Wound down after Claude terms-of-service changes made running unattended Claude agents this way untenable.",
     motivation:
-      "I wanted agents that do real platform work: triage alerts, fix failing PRs, keep docs fresh. That means handing an LLM tools with blast radius, so the platform is built around containment. Every agent runs in its own sandbox pod, and every tool call passes through a gateway that knows who is asking.",
+      "The bet was agents that do real platform work: triage alerts, fix failing PRs, keep docs fresh, each in its own sandbox pod with every tool call passing through a gateway that knows who is asking. When Claude's terms of service changed around unattended agent use, the dispatch model no longer held, and a local model alone was not capable enough to take its place. So the platform was retired rather than quietly degraded. The durable pieces outlived it: local inference became its own service, the knowledge-graph MCP surface moved into the monolith, and scheduled maintenance now runs as Claude routines and Argo Workflows.",
     facts: [
       {
         k: "Orchestrator",
@@ -71,8 +71,8 @@ export const projects = [
     ],
     links: [
       {
-        label: "projects/agent_platform",
-        href: "https://github.com/jomcgi/homelab/tree/main/projects/agent_platform",
+        label: "projects/inference",
+        href: "https://github.com/jomcgi/homelab/tree/main/projects/inference",
       },
     ],
   },

--- a/projects/monolith/home/observability/config_test.py
+++ b/projects/monolith/home/observability/config_test.py
@@ -24,7 +24,7 @@ class TestTopologyConfig:
                 )
 
     def test_has_nodes(self):
-        assert len(TOPOLOGY.nodes) == 20
+        assert len(TOPOLOGY.nodes) == 18
 
     def test_external_nodes_have_no_slo(self):
         ext = next(n for n in TOPOLOGY.nodes if n.id == "external")
@@ -39,7 +39,7 @@ class TestTopologyConfig:
                 assert n.slo.window_days == 30
 
     def test_edges(self):
-        assert len(TOPOLOGY.edges) == 14
+        assert len(TOPOLOGY.edges) == 11
 
     def test_edge_references_valid_nodes_or_groups(self):
         node_ids = {n.id for n in TOPOLOGY.nodes}

--- a/projects/monolith/home/observability/topology_config.py
+++ b/projects/monolith/home/observability/topology_config.py
@@ -228,28 +228,6 @@ WHERE metric_name = 'llamacpp:tokens_predicted_total'
 ) AND unix_milli >= toUnixTimestamp(now() - INTERVAL 5 MINUTE) * 1000"""
 
 
-def _nats_storage_query() -> str:
-    """Metric query: JetStream storage used in MB."""
-    return """\
-SELECT round(max(value) / 1048576, 1) AS value
-FROM signoz_metrics.distributed_samples_v4
-WHERE metric_name = 'nats_varz_jetstream_stats_storage'
-  AND unix_milli >= toUnixTimestamp(now() - INTERVAL 5 MINUTE) * 1000"""
-
-
-def _nats_queue_depth_query() -> str:
-    """Metric query: total pending messages across all JetStream consumers."""
-    return """\
-WITH latest AS (
-  SELECT fingerprint, argMax(value, unix_milli) AS v
-  FROM signoz_metrics.distributed_samples_v4
-  WHERE metric_name = 'nats_consumer_num_pending'
-    AND unix_milli >= toUnixTimestamp(now() - INTERVAL 5 MINUTE) * 1000
-  GROUP BY fingerprint
-)
-SELECT round(sum(v)) AS value FROM latest"""
-
-
 def _linkerd_p99_rps_query(src: str, dst_ns: str, dst_svc: str) -> str:
     """Metric query: P99 per-minute request rate over 7 days (Linkerd outbound).
 
@@ -520,36 +498,6 @@ TOPOLOGY = TopologyConfig(
             ],
         ),
         NodeConfig(
-            id="nats",
-            label="NATS",
-            tier="critical",
-            description="jetstream message bus",
-            slo=_slo(_container_ready_query("nats", "nats")),
-            metrics=[
-                MetricConfig(key="storage", query=_nats_storage_query(), unit=" MB"),
-                MetricConfig(key="pending", query=_nats_queue_depth_query()),
-            ],
-        ),
-        NodeConfig(
-            id="agent-platform",
-            label="AGENT PLATFORM",
-            tier="critical",
-            ingress=True,
-            description="orchestrator + mcp clients",
-            slo=_slo(_envoy_success_rate_query("agent-orchestrator")),
-            metrics=[
-                MetricConfig(
-                    key="rps",
-                    query=_envoy_rps_query("agent-orchestrator"),
-                ),
-                MetricConfig(
-                    key="latency",
-                    query=_envoy_avg_latency_query("agent-orchestrator"),
-                    unit="ms",
-                ),
-            ],
-        ),
-        NodeConfig(
             id="llama-cpp",
             label="QWEN 3",
             tier="critical",
@@ -682,7 +630,6 @@ TOPOLOGY = TopologyConfig(
     edges=[
         EdgeConfig(source="external", target="cloudflare"),
         EdgeConfig(source="cloudflare", target="monolith"),
-        EdgeConfig(source="cloudflare", target="agent-platform"),
         EdgeConfig(source="knowledge", target="postgres"),
         EdgeConfig(
             source="knowledge",
@@ -702,16 +649,6 @@ TOPOLOGY = TopologyConfig(
         EdgeConfig(source="chat", target="discord"),
         EdgeConfig(source="chat", target="knowledge"),
         EdgeConfig(source="mcp", target="knowledge"),
-        EdgeConfig(source="nats", target="agent-platform", bidi=True),
-        EdgeConfig(
-            source="agent-platform",
-            target="context-forge",
-            linkerd=_linkerd(
-                "agent-platform-agent-orchestrator",
-                "mcp",
-                "context-forge-gateway-mcp-stack-mcpgateway",
-            ),
-        ),
         EdgeConfig(
             source="context-forge",
             target="mcp",

--- a/projects/monolith/home/observability/topology_config_test.py
+++ b/projects/monolith/home/observability/topology_config_test.py
@@ -29,8 +29,6 @@ from home.observability.topology_config import (
     _linkerd_p99_rps_query,
     _llamacpp_requests_query,
     _llamacpp_tokens_query,
-    _nats_queue_depth_query,
-    _nats_storage_query,
     _seaweedfs_disk_query,
     _slo,
 )
@@ -305,35 +303,6 @@ class TestLlamaCppTokensQuery:
         assert "max(value) - min(value)" in q
 
 
-class TestNatsStorageQuery:
-    def test_returns_string(self):
-        q = _nats_storage_query()
-        assert isinstance(q, str)
-
-    def test_contains_metric_name(self):
-        q = _nats_storage_query()
-        assert "nats_varz_jetstream_stats_storage" in q
-
-    def test_converts_to_mb(self):
-        q = _nats_storage_query()
-        assert "1048576" in q
-
-
-class TestNatsQueueDepthQuery:
-    def test_returns_string(self):
-        q = _nats_queue_depth_query()
-        assert isinstance(q, str)
-
-    def test_contains_metric_name(self):
-        q = _nats_queue_depth_query()
-        assert "nats_consumer_num_pending" in q
-
-    def test_uses_latest_value_per_fingerprint(self):
-        # argMax picks the most recent value per consumer
-        q = _nats_queue_depth_query()
-        assert "argMax" in q
-
-
 class TestLinkerdP99RpsQuery:
     def test_returns_string(self):
         q = _linkerd_p99_rps_query("monolith", "llama-cpp", "llama-cpp")
@@ -505,8 +474,6 @@ class TestQueryParameterIsolation:
             _cnpg_db_size_query,
             _seaweedfs_disk_query,
             _argocd_apps_synced_query,
-            _nats_storage_query,
-            _nats_queue_depth_query,
         ],
     )
     def test_no_arg_queries_return_nonempty_string(self, query_fn):
@@ -522,8 +489,6 @@ class TestQueryParameterIsolation:
             _cnpg_db_size_query,
             _seaweedfs_disk_query,
             _argocd_apps_synced_query,
-            _nats_storage_query,
-            _nats_queue_depth_query,
         ],
     )
     def test_no_arg_queries_contain_select_and_from(self, query_fn):


### PR DESCRIPTION
Follow-up to the agent-stack deprecation: the small cosmetic cleanup that didn't belong in a deletion PR.

**Engineering page (`jomcgi.dev/engineering`):** marks the **Agent Platform** entry `Deprecated`, framed as the Claude ToS change that made unattended Claude agents untenable, with a note on what survived (local inference as its own service, the KG MCP surface in the monolith, scheduled work as Claude routines + Argo Workflows). Also fixes the now-404 `projects/agent_platform` link and drops the deleted **NATS JetStream** from the tech marquee.

**Dead-code trim** (services are gone from the cluster):
- `topology_config.py`: removed the `nats` + `agent-platform` nodes, their 3 edges, and the unused `_nats_*_query` helpers. `context-forge` kept (still reachable).
- `agent/checks.py`: dropped the docstring reference to the deleted `collector_alerts.go` (behavior unchanged).
- `HomepageTopology.svelte`: dropped `agent-platform`/`nats` from `excludeIds` (they were already hidden; the nodes no longer exist, so the homepage render is unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)