### PR TITLE
perf(inference): enable MTP speculative decoding for qwen3.6-35b-a3b

### DIFF
--- a/projects/inference/deploy/values.yaml
+++ b/projects/inference/deploy/values.yaml
@@ -211,6 +211,18 @@ vllm:
     - "3"
     - "--kv-cache-dtype"
     - "fp8"
+    # MTP speculative decoding: the checkpoint ships a 1-layer Multi-Token
+    # Prediction head (config.json mtp_num_hidden_layers=1, weights mtp.layers.0.*),
+    # and vLLM 0.19.1 registers Qwen3_5MoeMTP for model_type qwen3_5_moe. At our
+    # batch=1 workload decode is bandwidth-bound, so verifying the 1 drafted token
+    # is nearly free => expect ~1.4-1.8x decode tok/s when acceptance is healthy.
+    # num_speculative_tokens MUST stay 1 (the head has a single layer; >1 reuses it
+    # autoregressively and acceptance collapses). Lossless: the main model verifies
+    # every token, so output is unchanged; only speed varies with acceptance rate.
+    # If load OOMs on the extra MTP weights (~1GB) + spec-decode CUDA graphs, add
+    # --enforce-eager (same lever the maxModelLen note above calls out).
+    - "--speculative-config"
+    - '{"method": "mtp", "num_speculative_tokens": 1}'
 
 runtimeClassName: nvidia
 


### PR DESCRIPTION
## What

Enable vLLM MTP (Multi-Token Prediction) speculative decoding for the inference LLM (Qwen3.6-35B-A3B), adding one arg to `projects/inference/deploy/values.yaml`:

```
--speculative-config '{"method": "mtp", "num_speculative_tokens": 1}'
```

## Why it is supported (both gates verified against the live pod)

1. **The checkpoint has an MTP head.** `config.json` has `mtp_num_hidden_layers: 1`; the weight index carries `mtp.fc.weight` + `mtp.layers.0.*` (int4-quantized, survived AutoRound).
2. **vLLM 0.19.1 supports it for this arch.** `vllm/model_executor/models/qwen3_5_mtp.py` is in the installed package, and `config/speculative.py` maps `model_type: qwen3_5_moe -> qwen3_5_mtp` (registered in `MTPModelTypes`), so `method` auto-resolves to `mtp`.

`num_speculative_tokens` is pinned to `1` because the head is a single layer (vLLM warns and acceptance collapses if you ask for more).

## Expected effect

At our batch=1 workload decode is bandwidth-bound, so verifying the one drafted token is nearly free. Live single-stream peak is ~174 tok/s; expect **~1.4-1.8x** when acceptance is healthy. **Lossless**: the main model verifies every token, so output is unchanged, only speed varies with acceptance rate.

## Risk / rollback

- **VRAM**: hybrid KV pool runs at 13-19% utilization, leaving slack to absorb the ~1GB MTP weights by shrinking the pool. If boot OOMs on spec-decode CUDA graphs, add `--enforce-eager`.
- **Concurrency**: benefit is for low-concurrency (current `max-num-seqs: 3`); re-measure if sustained concurrent load grows.
- **Rollback**: drop the two args. Git-HEAD-sourced app, so no Chart.yaml bump; ArgoCD re-renders from main on next sync.

## Verification plan after rollout

- Read vLLM startup logs to confirm MTP loaded, no force-eager, KV still fits 32K context.
- Compare `vllm:inter_token_latency_seconds` (count/sum = mean decode tok/s) before vs after.
- Check acceptance via `vllm:spec_decode_*` counters (accepted / draft). Keep if acceptance > ~65% and tok/s is up; otherwise revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
