### PR TITLE
feat(worldcup): add near-certain/near-eliminated qualification tiers

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.60.11
+version: 0.61.0
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.60.11
+      targetRevision: 0.61.0
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.215.11
+version: 0.216.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.215.11
+      targetRevision: 0.216.0
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/routes/public/app/wc2026/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/wc2026/+page.svelte
@@ -81,14 +81,41 @@
   const pct = (x) => `${Math.round((x ?? 0) * 100)}%`;
   const points = (x) => Math.round((x ?? 0) * 100);
 
-  // The headline reads the status first: a settled group shows the verdict,
-  // otherwise the live qualify probability.
+  // A contending team's headline must never round to a bare 100%/0%: those read
+  // as certainty, but certainty is its own status (qualified / near_certain and
+  // their mirrors). Clamp the live figure to 1..99% so the only routes to
+  // "effectively certain" language are the dedicated tiers below.
+  const pctClamped = (x) =>
+    `${Math.min(99, Math.max(1, Math.round((x ?? 0) * 100)))}%`;
+
+  // The headline reads the status first. Exact certainties show a verdict word;
+  // the near_* tiers show a bounded ">99.9%"/"<0.1%" figure (no swing cards,
+  // because no realistic combination of results changes the outcome); a live
+  // contender shows its clamped qualify probability.
   const headline = $derived(
     q.status === "qualified"
       ? "Qualified"
       : q.status === "eliminated"
         ? "Eliminated"
-        : pct(q.prob_qualify),
+        : q.status === "near_certain"
+          ? ">99.9%"
+          : q.status === "near_eliminated"
+            ? "<0.1%"
+            : pctClamped(q.prob_qualify),
+  );
+
+  // The swing section's empty-state copy depends on WHY there are no matches to
+  // model: a settled or near-settled team has nothing left that can move it.
+  const emptyMsg = $derived(
+    q.status === "near_certain"
+      ? `No realistic combination of remaining results can stop ${countryName} now.`
+      : q.status === "near_eliminated"
+        ? `No realistic combination of remaining results can save ${countryName} now.`
+        : q.status === "qualified"
+          ? `${countryName} has already qualified.`
+          : q.status === "eliminated"
+            ? `${countryName} can no longer qualify.`
+            : "No remaining matches to model right now.",
   );
 
   const MONTHS = [
@@ -441,7 +468,7 @@
                     <span class="verdict out">Out</span>
                   {:else}
                     <span class="chance">
-                      <span class="chance-num">{pct(ql.prob_qualify)}</span>
+                      <span class="chance-num">{pctClamped(ql.prob_qualify)}</span>
                       <span class="chance-bar">
                         <span
                           class="chance-fill"
@@ -473,7 +500,7 @@
       </p>
 
       {#if swings.length === 0}
-        <p class="empty">No remaining matches to model right now.</p>
+        <p class="empty">{emptyMsg}</p>
       {:else}
         <ul class="swings">
           {#each swings as m, i (m.match_id)}

--- a/projects/monolith/worldcup/jobs.py
+++ b/projects/monolith/worldcup/jobs.py
@@ -224,7 +224,7 @@ def _persist_sim(session, result: sim.SimResult, n: int) -> None:
     rows: list[SwingMatch] = []
     for code, prob in result.per_team.items():
         if prob.status != "contention":
-            continue  # clinched/eliminated: ~0 swing, no rows
+            continue  # settled (qualified/eliminated/near_*): ~0 swing, no rows
         for swing in swings_by_country.get(code, [])[:_TOP_SWING_PER_COUNTRY]:
             rows.append(
                 SwingMatch(

--- a/projects/monolith/worldcup/sim.py
+++ b/projects/monolith/worldcup/sim.py
@@ -74,6 +74,35 @@ class SimResult:
 # Fixed outcome ordering, mapped to integer indices for the hot swing tally.
 _OC_IDX = {"home_win": 0, "draw": 1, "away_win": 2}
 
+# A team is "qualified"/"eliminated" only when it advances/fails in EVERY trial
+# (an exact combinatorial certainty the Monte Carlo reproduces as pq == 1.0/0.0).
+# Between those extremes and the certainties sit two "effectively settled" tiers:
+# at or beyond these thresholds no realistic combination of remaining results
+# changes the outcome, so we label them distinctly and drop their swing cards
+# (which would otherwise all read a rounded 100%/0%). The thresholds also bound
+# what "contention" can be, so a contending team's headline never rounds to a
+# misleading 100%/0% (the page clamps the contention figure to 1..99%).
+NEAR_CERTAIN_THRESHOLD = 0.999
+NEAR_ELIMINATED_THRESHOLD = 0.001
+
+
+def _status(pq: float) -> str:
+    """Map a qualify probability to a display status tier.
+
+    Exact 1.0/0.0 are combinatorial certainties ("qualified"/"eliminated"). The
+    near_* tiers are "all but settled": overwhelmingly likely but not provably
+    certain. Everything else is live "contention".
+    """
+    if pq >= 1.0:
+        return "qualified"
+    if pq <= 0.0:
+        return "eliminated"
+    if pq >= NEAR_CERTAIN_THRESHOLD:
+        return "near_certain"
+    if pq <= NEAR_ELIMINATED_THRESHOLD:
+        return "near_eliminated"
+    return "contention"
+
 
 def attack_defence(
     states, shrink: float = ATT_DEF_SHRINK
@@ -306,19 +335,16 @@ def simulate(
             prob_qualify=pq,
             prob_top2=top2_count[c] / n,
             prob_third=third_count[c] / n,
-            status="qualified"
-            if pq == 1.0
-            else "eliminated"
-            if pq == 0.0
-            else "contention",
+            status=_status(pq),
         )
 
     # Build each country's ranked swing list from the tally. When an outcome was
     # never sampled (totals 0, e.g. swing_n == 0 or an impossible result) fall
     # back to the team's unconditional qualify probability so its swing is 0.
     #
-    # A match between two teams whose fates are already sealed (each one qualified
-    # or eliminated) is skipped entirely: it cannot move ANY team's qualification.
+    # A match between two teams whose fates are already settled (each one
+    # qualified, eliminated, or in a near_* tier, i.e. status != "contention") is
+    # skipped entirely: it cannot move ANY team's qualification.
     # Neither participant's own standing matters anymore, and a settled team is
     # never a best-third contender whose goal difference could shift the cutoff, so
     # the match's true swing is exactly 0 for everyone. We drop it rather than

--- a/projects/monolith/worldcup/sim_test.py
+++ b/projects/monolith/worldcup/sim_test.py
@@ -6,7 +6,16 @@ analytically from the construction (independent of the rng seed where the
 docstring says "guaranteed").
 """
 
-from worldcup.sim import Fixture, TeamState, simulate
+import pytest
+
+from worldcup.sim import (
+    NEAR_CERTAIN_THRESHOLD,
+    NEAR_ELIMINATED_THRESHOLD,
+    Fixture,
+    TeamState,
+    _status,
+    simulate,
+)
 
 # A neutral baseline Elo used wherever the exact strength does not change the
 # logical outcome of a scenario.
@@ -157,6 +166,33 @@ def _scenario_swing():
     fixtures = [Fixture("A-SCO-GER", "A", "SCO", "GER", is_own=True)]
     elo = {"SCO": 1750.0, "GER": 1750.0, "FRA": 1900.0, "AND": 1300.0}
     return states, fixtures, elo
+
+
+@pytest.mark.parametrize(
+    "pq,expected",
+    [
+        # Exact combinatorial certainties.
+        (1.0, "qualified"),
+        (0.0, "eliminated"),
+        # Near_* tiers: overwhelmingly likely but not provably certain. The
+        # boundary itself belongs to the near_* tier (>= / <=).
+        (NEAR_CERTAIN_THRESHOLD, "near_certain"),
+        (0.9995, "near_certain"),
+        (0.99999, "near_certain"),
+        (NEAR_ELIMINATED_THRESHOLD, "near_eliminated"),
+        (0.0005, "near_eliminated"),
+        (0.00001, "near_eliminated"),
+        # Live contention sits strictly between the thresholds. The values just
+        # inside each boundary must NOT be swallowed by a near_* tier.
+        (0.99, "contention"),
+        (0.9989, "contention"),
+        (0.5, "contention"),
+        (0.0011, "contention"),
+        (0.01, "contention"),
+    ],
+)
+def test_status_tiers(pq, expected):
+    assert _status(pq) == expected
 
 
 def test_clinched_team_is_certain():


### PR DESCRIPTION
## Why

You spotted that the wc2026 page showed England a **100%** chance of reaching the Round of 32 while *not* calling it "Qualified", and still listed "matches that could change it" where every outcome also read 100%.

Root cause: the verdict word required `prob_qualify == 1.0` exactly (qualified in all ~500k Monte Carlo trials), but the headline rounded at `0.995`. So across the whole `0.995..1.0` band the figure rounded up to "100%" while the status stayed `contention`, keeping the (meaningless, all-100%) swing cards.

## What

Adds two "effectively settled" status tiers between `contention` and the exact certainties:

- **`sim.py`**: extracts the status decision into a pure `_status(pq)` helper and adds `near_certain` (`pq >= 0.999`) and `near_eliminated` (`pq <= 0.001`). Because both the swing-persistence skip (`jobs.py`) and the settled-match drop key on `status != "contention"`, the new tiers automatically produce **no swing cards** — no backend persistence change needed.
- **`+page.svelte`**: renders `>99.9%` / `<0.1%` figures for the new tiers, with a tailored *"No realistic combination of remaining results can stop/save X now."* message replacing the swing cards. Also clamps the `contention` headline and standings figures to `1..99%`, so a live contender can never round to a misleading 100%/0% (closes the same bug one band lower).

## Tests

- New parametrized `test_status_tiers` covering every boundary of `_status` (extracted as a pure function precisely so the thresholds are testable without forcing a 99.95% Monte Carlo outcome). Existing `qualified`/`eliminated` integration tests still hold.

## Visual regression

The committed wc2026 fixtures all sit in the 3..97% band (all `contention`), so the rendered page is unchanged — **no baseline reseed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)