### PR TITLE
fix(inference): raise gpu-mem-util to 0.97 so MTP KV fits 32k context

### DIFF
--- a/projects/inference/deploy/values.yaml
+++ b/projects/inference/deploy/values.yaml
@@ -187,13 +187,17 @@ server:
     {%- endif %}
 
 vllm:
-  # 32768 (was 49152): 35B-A3B int4-mixed weights are ~21-22GB resident (MoE keeps
-  # all experts loaded; mixed precision adds ~2GB over plain INT4), leaving thin KV
-  # headroom on a 24GB card. If load OOMs, add --enforce-eager (frees ~1-2GB of
-  # CUDA-graph capture) before lowering ctx further; raise back toward 49152 only
-  # after confirming KV headroom in the vLLM startup logs.
+  # 32768 (was 49152): with MTP spec decode the model loads at 20.08 GiB (19.66 +
+  # ~0.42 for the extra MTP layer; embeddings + lm_head are shared, not duplicated).
+  # Hybrid KV is tiny (only full-attn layers carry KV): 32K context needs just 0.49
+  # GiB. Those MTP weights dropped available KV to 0.24 GiB at util 0.95 (below the
+  # 0.49 floor => boot fails), so KV is restored via gpuMemoryUtilization 0.97
+  # (~0.73 GiB KV, ~0.24 margin, ~0.74 GiB card still free). NOTE: --enforce-eager is
+  # NOT the lever for this squeeze (spec decode forces PIECEWISE graphs, only ~0.13
+  # GiB); gpu-mem-util is. Raise ctx toward 49152 only after confirming KV headroom
+  # in the vLLM startup logs.
   maxModelLen: 32768
-  gpuMemoryUtilization: 0.95
+  gpuMemoryUtilization: 0.97
   dtype: "auto"
   quantization: ""
   tokenizer: ""


### PR DESCRIPTION
## What

Fixes the MTP boot crash-loop from #2844 by raising `gpuMemoryUtilization` 0.95 -> 0.97. Inference is currently CrashLoopBackOff, this restores it with MTP intact.

## Root cause (from the failing pod's vLLM logs)

- `Model loading took 20.08 GiB` (MTP added ~0.42 GiB over the prior 19.66; embeddings + lm_head are shared with the draft, only the 1 MTP layer is extra)
- `Available KV cache memory: 0.24 GiB` vs `0.49 GiB needed` for a single 32768-token request -> `_check_enough_kv_cache_memory` ValueError
- **Deficit: exactly 0.25 GiB**

## Why util, not the other levers

- **Not `--enforce-eager`**: spec decode forces `cudagraph_mode` to PIECEWISE (FlashInfer + spec-decode supports only single-token-decode graphs), so graph memory is only 0.13 GiB. Eager would free too little and slow decode.
- **Not lowering `max_model_len`**: vLLM's own estimate says fitting at 0.95 needs ctx <= 8448, a big regression for summarize jobs. (20k wouldn't even fit: needs 0.30, have 0.24.)
- **`gpu_memory_utilization` 0.97**: the card had ~1.23 GiB unused as the 5% margin; 0.97 converts ~0.49 GiB of it to KV -> ~0.73 GiB available (0.24 margin over the 0.49 floor), ~0.74 GiB card still free. Keeps full 32K context.

## Verify after rollout

- Pod boots Ready, `Available KV cache memory` >= ~0.73 GiB, no OOM
- Decode tok/s (`vllm:inter_token_latency_seconds` count/sum) vs ~174 baseline
- Acceptance rate (`vllm:spec_decode_*`); keep if > ~65% and tok/s up, else revert

🤖 Generated with [Claude Code](https://claude.com/claude-code)
