### PR TITLE
revert(inference): back out MTP speculative decoding

### DIFF
--- a/projects/inference/deploy/values.yaml
+++ b/projects/inference/deploy/values.yaml
@@ -187,17 +187,13 @@ server:
     {%- endif %}
 
 vllm:
-  # 32768 (was 49152): with MTP spec decode the model loads at 20.08 GiB (19.66 +
-  # ~0.42 for the extra MTP layer; embeddings + lm_head are shared, not duplicated).
-  # Hybrid KV is tiny (only full-attn layers carry KV): 32K context needs just 0.49
-  # GiB. Those MTP weights dropped available KV to 0.24 GiB at util 0.95 (below the
-  # 0.49 floor => boot fails), so KV is restored via gpuMemoryUtilization 0.97
-  # (~0.73 GiB KV, ~0.24 margin, ~0.74 GiB card still free). NOTE: --enforce-eager is
-  # NOT the lever for this squeeze (spec decode forces PIECEWISE graphs, only ~0.13
-  # GiB); gpu-mem-util is. Raise ctx toward 49152 only after confirming KV headroom
-  # in the vLLM startup logs.
+  # 32768 (was 49152): 35B-A3B int4-mixed weights are ~21-22GB resident (MoE keeps
+  # all experts loaded; mixed precision adds ~2GB over plain INT4), leaving thin KV
+  # headroom on a 24GB card. If load OOMs, add --enforce-eager (frees ~1-2GB of
+  # CUDA-graph capture) before lowering ctx further; raise back toward 49152 only
+  # after confirming KV headroom in the vLLM startup logs.
   maxModelLen: 32768
-  gpuMemoryUtilization: 0.97
+  gpuMemoryUtilization: 0.95
   dtype: "auto"
   quantization: ""
   tokenizer: ""
@@ -215,18 +211,6 @@ vllm:
     - "3"
     - "--kv-cache-dtype"
     - "fp8"
-    # MTP speculative decoding: the checkpoint ships a 1-layer Multi-Token
-    # Prediction head (config.json mtp_num_hidden_layers=1, weights mtp.layers.0.*),
-    # and vLLM 0.19.1 registers Qwen3_5MoeMTP for model_type qwen3_5_moe. At our
-    # batch=1 workload decode is bandwidth-bound, so verifying the 1 drafted token
-    # is nearly free => expect ~1.4-1.8x decode tok/s when acceptance is healthy.
-    # num_speculative_tokens MUST stay 1 (the head has a single layer; >1 reuses it
-    # autoregressively and acceptance collapses). Lossless: the main model verifies
-    # every token, so output is unchanged; only speed varies with acceptance rate.
-    # If load OOMs on the extra MTP weights (~1GB) + spec-decode CUDA graphs, add
-    # --enforce-eager (same lever the maxModelLen note above calls out).
-    - "--speculative-config"
-    - '{"method": "mtp", "num_speculative_tokens": 1}'
 
 runtimeClassName: nvidia
 


### PR DESCRIPTION
Backs out the MTP experiment (#2844, #2846). Data-backed A/B: production is non-concurrent 99.9% of the time, so the real regime is batch=1, where no-MTP = 172 tok/s (two prod pods agree) vs ~180 with MTP (~+4.6%). The batch=2/3 aggregate is ordinary batching in a regime the workload never reaches. Not worth the util 0.97 boot-OOM footgun. Restores util 0.95 + clean margin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)