### PR TITLE
feat(worldcup): drop sub-1% swing matches from prediction cards

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.62.0
+version: 0.62.1
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.61.0
+version: 0.62.0
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.61.0
+      targetRevision: 0.62.0
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.62.0
+      targetRevision: 0.62.1
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.216.0
+version: 0.217.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.217.0
+version: 0.217.1
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.217.0
+      targetRevision: 0.217.1
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.216.0
+      targetRevision: 0.217.0
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/routes/public/app/wc2026/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/wc2026/+page.svelte
@@ -105,7 +105,9 @@
   );
 
   // The swing section's empty-state copy depends on WHY there are no matches to
-  // model: a settled or near-settled team has nothing left that can move it.
+  // model: a settled or near-settled team has nothing left that can move it, and
+  // a contending team can still have no cards when every remaining match leaves
+  // its chances within a percentage point (all sub-threshold swings are dropped).
   const emptyMsg = $derived(
     q.status === "near_certain"
       ? `No realistic combination of remaining results can stop ${countryName} now.`
@@ -115,7 +117,9 @@
           ? `${countryName} has already qualified.`
           : q.status === "eliminated"
             ? `${countryName} can no longer qualify.`
-            : "No remaining matches to model right now.",
+            : q.status === "contention"
+              ? `No remaining match meaningfully changes whether ${countryName} qualifies.`
+              : "No remaining matches to model right now.",
   );
 
   const MONTHS = [

--- a/projects/monolith/worldcup/jobs.py
+++ b/projects/monolith/worldcup/jobs.py
@@ -28,6 +28,14 @@ FOCUS_CODE = "SCO"
 # How many of each contending team's remaining matches to store, ranked by swing.
 _TOP_SWING_PER_COUNTRY = 8
 
+# Smallest swing worth showing as a card. Swing is the spread between a team's
+# best- and worst-case conditional qualify probability for a match, so below this
+# every outcome leaves the team's chances within one percentage point: the card
+# would read "if X win / draw / if Y win" at three near-identical figures with a
+# +-0 magnitude, telling the viewer nothing. We drop those rather than pad each
+# country's top-8 with dead matches.
+_MIN_SWING_TO_STORE = 0.01
+
 
 def _upsert(standings_rows: list[dict], fixture_rows: list[dict]) -> bool:
     """Upsert standings (by team_id) and fixtures (by match_id) idempotently.
@@ -225,7 +233,10 @@ def _persist_sim(session, result: sim.SimResult, n: int) -> None:
     for code, prob in result.per_team.items():
         if prob.status != "contention":
             continue  # settled (qualified/eliminated/near_*): ~0 swing, no rows
-        for swing in swings_by_country.get(code, [])[:_TOP_SWING_PER_COUNTRY]:
+        ranked = [
+            s for s in swings_by_country.get(code, []) if s.swing >= _MIN_SWING_TO_STORE
+        ]
+        for swing in ranked[:_TOP_SWING_PER_COUNTRY]:
             rows.append(
                 SwingMatch(
                     match_id=swing.match_id,

--- a/projects/monolith/worldcup/jobs_test.py
+++ b/projects/monolith/worldcup/jobs_test.py
@@ -232,6 +232,9 @@ class TestPersistSim:
         with Session(engine) as session:
             swings = session.exec(select(SwingMatch)).all()
             assert len(swings) == 1  # no duplicates; prior SCO/GER/HAI rows gone
+            assert swings[0].match_id == "F-SCO-GER"
+            assert swings[0].country_code == "SCO"
+            assert session.get(Qualification, "id-SCO").n_sims == 6000
 
     def test_sub_threshold_swings_are_dropped(self, engine):
         """A contending team's matches whose swing is below the minimum (every
@@ -260,9 +263,6 @@ class TestPersistSim:
             assert len(swings) == 1
             assert swings[0].match_id == "F-SCO-GER"
             assert session.get(SwingMatch, ("F-FRA-AND", "SCO")) is None
-            assert swings[0].match_id == "F-SCO-GER"
-            assert swings[0].country_code == "SCO"
-            assert session.get(Qualification, "id-SCO").n_sims == 6000
 
 
 def _standing_row(code, *, group="A", pts=3, gf=3, ga=2):

--- a/projects/monolith/worldcup/jobs_test.py
+++ b/projects/monolith/worldcup/jobs_test.py
@@ -232,6 +232,34 @@ class TestPersistSim:
         with Session(engine) as session:
             swings = session.exec(select(SwingMatch)).all()
             assert len(swings) == 1  # no duplicates; prior SCO/GER/HAI rows gone
+
+    def test_sub_threshold_swings_are_dropped(self, engine):
+        """A contending team's matches whose swing is below the minimum (every
+        outcome within a percentage point) must not be stored as dead cards."""
+        with Session(engine) as session:
+            session.add_all([_standing("SCO"), _standing("GER")])
+            session.add(_fixture("F-SCO-GER", "SCO", "GER", finished=False))
+            session.add(_fixture("F-FRA-AND", "FRA", "AND", finished=False))
+            session.commit()
+
+            real = Swing("F-SCO-GER", "A", "SCO", "GER", 0.5, 0.9, 0.6, 0.4, True)
+            # 0.005 spread: all three outcomes within a percentage point.
+            flat = Swing(
+                "F-FRA-AND", "A", "FRA", "AND", 0.005, 0.62, 0.62, 0.615, False
+            )
+            result = SimResult(
+                per_team={"SCO": TeamProb("SCO", 0.62, 0.40, 0.22, "contention")},
+                swings=[real, flat],
+                n=5000,
+                swings_by_country={"SCO": [real, flat]},
+            )
+            jobs._persist_sim(session, result, 5000)
+
+        with Session(engine) as session:
+            swings = session.exec(select(SwingMatch)).all()
+            assert len(swings) == 1
+            assert swings[0].match_id == "F-SCO-GER"
+            assert session.get(SwingMatch, ("F-FRA-AND", "SCO")) is None
             assert swings[0].match_id == "F-SCO-GER"
             assert swings[0].country_code == "SCO"
             assert session.get(Qualification, "id-SCO").n_sims == 6000


### PR DESCRIPTION
## Problem

The WC2026 qualification page pads each contending team's swing section out to its top 8 remaining matches by swing magnitude, with no minimum. When a team has fewer than 8 genuinely decisive matches left, the tail gets filled with dead cards: matches like **CPV v KSA** rendering `9% / 9% / 9%` with a **±0** indicator.

A swing card exists to say "this match matters to you." Showing one where all three outcomes leave your qualification chance unchanged is pure noise.

## Cause

`swing = max(conditional qualify probs) - min(...)` (`sim.py:368`). The persistence step in `jobs.py` took `swings_by_country[code][:8]` directly, regardless of whether the 8th match had any swing at all.

## Fix

- Add `_MIN_SWING_TO_STORE = 0.01` and filter swings below a 1 percentage point spread before taking each country's top 8. This matches the intuition that if every outcome leaves you within 1%, the match is not worth a card.
- When the filter leaves a *contending* team with zero cards, the frontend empty state now says **"No remaining match meaningfully changes whether {country} qualifies."** rather than reusing the generic "nothing to model right now" copy, which only fit settled teams.
- Add `test_sub_threshold_swings_are_dropped` covering the new behaviour. Existing `_persist_sim` tests are unaffected (their fixture swings are all ≥0.1).

## Notes

The threshold (1%) follows the reviewer's framing of "near identical outcomes". Easy to tune via the single constant if we want it stricter (2%) or looser (0.5%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rkpyib9yxiqiut6GwY1UvU)_