### PR TITLE
feat(platform): kata-fc PVC-persistence derisk

### DIFF
--- a/projects/platform/kata-fc/templates/pvc-derisk.yaml
+++ b/projects/platform/kata-fc/templates/pvc-derisk.yaml
@@ -1,0 +1,82 @@
+{{- if .Values.pvcDerisk.enabled }}
+# PVC-persistence derisk (ADR 021 filesystem-state model): a kata-fc pod writes
+# to a Longhorn (block-backed) PVC; when the pod is replaced the data survives,
+# proving "tear down the microVM, keep the volume, resume on a fresh microVM".
+# Validates kata-fc + persistent volumes on k8s (Firecracker has no virtio-fs,
+# so the PV is attached as a virtio block device).
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: kata-fc-pvc-derisk
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.pvcDerisk.size }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kata-fc-pvc-derisk
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kata-fc-pvc-derisk
+      app.kubernetes.io/component: pvc-derisk
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: kata-fc-pvc-derisk
+        app.kubernetes.io/component: pvc-derisk
+    spec:
+      runtimeClassName: kata-fc
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        fsGroup: 65532
+      containers:
+        - name: worker
+          image: {{ .Values.pvcDerisk.image | quote }}
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              if [ -f /work/state ]; then
+                echo "RESUMED from volume; prior state:"; cat /work/state
+              else
+                echo "FRESH volume (no prior state)"
+              fi
+              echo "run $(date -u +%FT%TZ) host=$(hostname) kernel=$(uname -r)" >> /work/state
+              echo "=== /work/state now ==="; cat /work/state
+              echo "READY (delete this pod to test resume on a fresh microVM)"
+              sleep 3600
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              memory: 128Mi
+          readinessProbe:
+            exec:
+              command: ["/bin/sh", "-c", "test -f /work/state"]
+            initialDelaySeconds: 2
+            periodSeconds: 5
+          volumeMounts:
+            - name: work
+              mountPath: /work
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: work
+          persistentVolumeClaim:
+            claimName: kata-fc-pvc-derisk
+        - name: tmp
+          emptyDir: {}
+{{- end }}

--- a/projects/platform/kata-fc/values.yaml
+++ b/projects/platform/kata-fc/values.yaml
@@ -4,3 +4,12 @@
 smokeTest:
   enabled: false
   image: docker.io/library/busybox:1.37
+
+# PVC-persistence derisk: a kata-fc pod writes to a Longhorn (block-backed) PVC;
+# the data survives the pod being replaced (the ADR 021 filesystem-state model -
+# tear down the microVM, keep the volume, resume on a fresh one). Real per-thread
+# volumes size to the repo working tree (Longhorn allowVolumeExpansion=true).
+pvcDerisk:
+  enabled: true
+  image: docker.io/library/busybox:1.37
+  size: 1Gi


### PR DESCRIPTION
Derisks the ADR 021 filesystem-state model (per your insight that agentic state is the git working tree + Postgres, not in-memory): a kata-fc pod writes to a Longhorn block-backed PVC; the data survives the pod being replaced, proving "tear down the microVM, keep the volume, resume on a fresh one." Also derisks kata-fc + persistent volumes generally (Firecracker has no virtio-fs, so the PV attaches as a virtio block device).

After merge: ArgoCD deploys the PVC + Deployment; I delete the pod and the fresh one logs `RESUMED from volume`. Gated by `pvcDerisk.enabled`; disabled after validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)