### PR TITLE
chore(platform): disable kata-fc pvcDerisk (rejected, superseded by snapshot/restore)

### DIFF
--- a/projects/platform/kata-fc/values.yaml
+++ b/projects/platform/kata-fc/values.yaml
@@ -5,11 +5,11 @@ smokeTest:
   enabled: false
   image: docker.io/library/busybox:1.37
 
-# PVC-persistence derisk: a kata-fc pod writes to a Longhorn (block-backed) PVC;
-# the data survives the pod being replaced (the ADR 021 filesystem-state model -
-# tear down the microVM, keep the volume, resume on a fresh one). Real per-thread
-# volumes size to the repo working tree (Longhorn allowVolumeExpansion=true).
+# PVC-persistence derisk: REJECTED 2026-06-27. A Longhorn filesystem PVC mounts
+# as tmpfs INSIDE a kata-fc microVM (Firecracker has no virtio-fs), so data did
+# not survive pod replacement. Superseded by FC snapshot/restore (captures
+# memory + disk = resume exactly). Disabled; kept for reference / block-mode retry.
 pvcDerisk:
-  enabled: true
+  enabled: false
   image: docker.io/library/busybox:1.37
   size: 1Gi


### PR DESCRIPTION
The PVC-persistence model was rejected: a Longhorn filesystem PVC mounts as tmpfs inside a kata-fc microVM (Firecracker has no virtio-fs), so data didn't survive pod replacement. FC snapshot/restore (28ms cold restore, captures memory + disk) supersedes it. Disables the derisk so the idle sleep pod + PVC are pruned; kept gated for a possible block-mode retry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)