### PR TITLE
feat(agent_platform): Goose harness image + per-thread rootfs provisioning (Plan B B1+B3)

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -455,7 +455,11 @@ apko.translate_lock(
     name = "visual_chromium_lock",
     lock = "//projects/monolith/frontend/visual:apko.lock.json",
 )
-use_repo(apko, "grimoire_frontend_lock", "monolith_frontend_lock", "visual_chromium_lock")
+apko.translate_lock(
+    name = "harness_lock",
+    lock = "//projects/agent_platform/harness:apko.lock.json",
+)
+use_repo(apko, "grimoire_frontend_lock", "harness_lock", "monolith_frontend_lock", "visual_chromium_lock")
 
 # Download multiarch archives (binaries from zip files)
 multiarch_http_archive = use_repo_rule("//bazel/tools/http:multiarch_http_archive.bzl", "multiarch_http_archive")

--- a/bazel/images/BUILD
+++ b/bazel/images/BUILD
@@ -44,6 +44,7 @@ multirun(
         "//projects/agent_platform/fc-agent-init:image.push",
         "//projects/agent_platform/fc-agentd/chart:chart.push",
         "//projects/agent_platform/fc-agentd:image.push",
+        "//projects/agent_platform/harness:image.push",
         "//projects/grimoire/api:image.push",
         "//projects/grimoire/frontend:image.push",
         "//projects/grimoire/ws-gateway:image.push",

--- a/projects/agent_platform/fc-agent-init/cmd/BUILD
+++ b/projects/agent_platform/fc-agent-init/cmd/BUILD
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/jomcgi/homelab/projects/agent_platform/fc-agent-init/cmd",
     visibility = ["//visibility:private"],
     deps = [
+        "//projects/agent_platform/fc-agent-init/internal/harness",
         "//projects/agent_platform/fc-agent-init/internal/idle",
         "//projects/agent_platform/fc-agent-init/internal/reconnect",
         "//projects/agent_platform/vsockproto",

--- a/projects/agent_platform/fc-agent-init/cmd/main.go
+++ b/projects/agent_platform/fc-agent-init/cmd/main.go
@@ -18,6 +18,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/jomcgi/homelab/projects/agent_platform/fc-agent-init/internal/harness"
 	"github.com/jomcgi/homelab/projects/agent_platform/fc-agent-init/internal/idle"
 	"github.com/jomcgi/homelab/projects/agent_platform/fc-agent-init/internal/reconnect"
 	"github.com/jomcgi/homelab/projects/agent_platform/vsockproto"
@@ -123,6 +124,15 @@ func harnessCommand() []string {
 		if a == "--" {
 			return os.Args[i+1:]
 		}
+	}
+	// Goose mode (Plan B): a turn-capped recipe run is the agent harness. The
+	// recipe's own max_turns bounds it and the between-turns boundary is what the
+	// idle detector snapshots on.
+	if g := harness.GooseCommand(harness.Config{
+		Recipe: os.Getenv("FC_GOOSE_RECIPE"),
+		Task:   os.Getenv("FC_TASK"),
+	}); g != nil {
+		return g
 	}
 	if cmd := os.Getenv("FC_HARNESS_CMD"); cmd != "" {
 		return []string{"/bin/sh", "-c", cmd}

--- a/projects/agent_platform/fc-agent-init/internal/harness/BUILD
+++ b/projects/agent_platform/fc-agent-init/internal/harness/BUILD
@@ -1,0 +1,14 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "harness",
+    srcs = ["harness.go"],
+    importpath = "github.com/jomcgi/homelab/projects/agent_platform/fc-agent-init/internal/harness",
+    visibility = ["//projects/agent_platform/fc-agent-init:__subpackages__"],
+)
+
+go_test(
+    name = "harness_test",
+    srcs = ["harness_test.go"],
+    embed = [":harness"],
+)

--- a/projects/agent_platform/fc-agent-init/internal/harness/harness.go
+++ b/projects/agent_platform/fc-agent-init/internal/harness/harness.go
@@ -1,0 +1,40 @@
+// Package harness builds the agent-harness command fc-agent-init launches as the
+// microVM's workload (ADR 022 Phase 5 / Plan B). The harness is Goose: a
+// turn-capped recipe run whose between-turns boundary is the quiescent point the
+// idle detector snapshots on. The command is a pure function of the environment
+// so it is unit-testable with no Goose binary present.
+package harness
+
+import "fmt"
+
+// Config is the harness invocation resolved from the environment.
+type Config struct {
+	// Recipe is the path to a Goose recipe YAML (FC_GOOSE_RECIPE). Recipes carry
+	// their own settings.max_turns / max_tool_repetitions, which is what bounds
+	// the run and gives the idle detector a quiescent boundary.
+	Recipe string
+	// Task is the task description fed to the recipe (FC_TASK).
+	Task string
+}
+
+// GooseCommand returns the argv to run, mirroring the established invocation:
+//
+//	with a recipe:  goose run --recipe <recipe> --no-profile --params task_description=<task>
+//	bare task only: goose run --text <task>
+//
+// It returns nil when there is nothing to run (a warm-base boot with no task),
+// in which case fc-agent-init idles without a harness until a task arrives.
+func GooseCommand(c Config) []string {
+	if c.Recipe != "" {
+		return []string{
+			"goose", "run",
+			"--recipe", c.Recipe,
+			"--no-profile",
+			"--params", fmt.Sprintf("task_description=%s", c.Task),
+		}
+	}
+	if c.Task != "" {
+		return []string{"goose", "run", "--text", c.Task}
+	}
+	return nil
+}

--- a/projects/agent_platform/fc-agent-init/internal/harness/harness_test.go
+++ b/projects/agent_platform/fc-agent-init/internal/harness/harness_test.go
@@ -1,0 +1,36 @@
+package harness
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGooseCommandWithRecipe(t *testing.T) {
+	got := GooseCommand(Config{Recipe: "/etc/goose/recipes/agent.yaml", Task: "fix the flaky test"})
+	want := "goose run --recipe /etc/goose/recipes/agent.yaml --no-profile --params task_description=fix the flaky test"
+	if strings.Join(got, " ") != want {
+		t.Fatalf("got %q, want %q", strings.Join(got, " "), want)
+	}
+}
+
+func TestGooseCommandBareTask(t *testing.T) {
+	got := GooseCommand(Config{Task: "do the thing"})
+	if len(got) != 4 || got[0] != "goose" || got[1] != "run" || got[2] != "--text" || got[3] != "do the thing" {
+		t.Fatalf("unexpected bare-task command: %v", got)
+	}
+}
+
+func TestGooseCommandNoTaskIsNil(t *testing.T) {
+	if got := GooseCommand(Config{}); got != nil {
+		t.Fatalf("expected nil command for a warm-base boot with no task, got %v", got)
+	}
+}
+
+func TestTaskWithSpacesStaysSingleArg(t *testing.T) {
+	// The task is one argv element even with spaces; no shell splitting.
+	got := GooseCommand(Config{Recipe: "r.yaml", Task: "a b c"})
+	last := got[len(got)-1]
+	if last != "task_description=a b c" {
+		t.Fatalf("task param should be a single arg, got %q", last)
+	}
+}

--- a/projects/agent_platform/fc-agentd/chart/Chart.yaml
+++ b/projects/agent_platform/fc-agentd/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: fc-agentd
 description: Firecracker snapshot/restore controller (ADR 022) - the node-4 Postgres-reconcile daemon that manages agent-thread microVMs
 type: application
-version: 0.1.2
+version: 0.2.0
 appVersion: "latest"
 keywords:
   - firecracker

--- a/projects/agent_platform/fc-agentd/cmd/main.go
+++ b/projects/agent_platform/fc-agentd/cmd/main.go
@@ -61,6 +61,8 @@ func run(logger *slog.Logger) error {
 	fcDriver := driver.New(driver.Config{
 		KernelImagePath: cfg.KernelImagePath,
 		RootfsPath:      cfg.RootfsPath,
+		BaseRootfsPath:  cfg.BaseRootfsPath,
+		HarnessInit:     cfg.HarnessInit,
 		VCPUs:           cfg.GuestVCPUs,
 		MemMib:          cfg.GuestMemMib,
 		SnapshotRoot:    cfg.SnapshotRoot,

--- a/projects/agent_platform/fc-agentd/deploy/application.yaml
+++ b/projects/agent_platform/fc-agentd/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: fc-agentd
-      targetRevision: 0.1.2
+      targetRevision: 0.2.0
       helm:
         valueFiles:
           - $values/projects/agent_platform/fc-agentd/deploy/values.yaml

--- a/projects/agent_platform/fc-agentd/internal/config/config.go
+++ b/projects/agent_platform/fc-agentd/internal/config/config.go
@@ -33,8 +33,13 @@ type Config struct {
 	FirecrackerBin string
 	// KernelImagePath is the guest kernel (kata vmlinux.container on node-4).
 	KernelImagePath string
-	// RootfsPath is the host path to the thread rootfs block device.
+	// RootfsPath is a shared/static rootfs, used only when BaseRootfsPath is empty.
 	RootfsPath string
+	// BaseRootfsPath is the read-only base rootfs image (the flattened harness
+	// image). When set, each thread gets its own writable copy.
+	BaseRootfsPath string
+	// HarnessInit is the in-guest init the kernel boots into (fc-agent-init).
+	HarnessInit string
 	// GuestVCPUs and GuestMemMib size each microVM.
 	GuestVCPUs  int
 	GuestMemMib int
@@ -52,6 +57,8 @@ func Load() (Config, error) {
 		FirecrackerBin:    getenvDefault("FC_AGENTD_FIRECRACKER_BIN", "/opt/kata/bin/firecracker"),
 		KernelImagePath:   getenvDefault("FC_AGENTD_KERNEL_IMAGE", "/opt/kata/share/kata-containers/vmlinux.container"),
 		RootfsPath:        os.Getenv("FC_AGENTD_ROOTFS_PATH"),
+		BaseRootfsPath:    os.Getenv("FC_AGENTD_BASE_ROOTFS"),
+		HarnessInit:       getenvDefault("FC_AGENTD_HARNESS_INIT", "/usr/local/bin/fc-agent-init"),
 		GuestVCPUs:        atoiDefault("FC_AGENTD_GUEST_VCPUS", 1),
 		GuestMemMib:       atoiDefault("FC_AGENTD_GUEST_MEM_MIB", 1024),
 	}

--- a/projects/agent_platform/fc-agentd/internal/driver/BUILD
+++ b/projects/agent_platform/fc-agentd/internal/driver/BUILD
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "driver.go",
         "launcher.go",
+        "provisioner.go",
     ],
     importpath = "github.com/jomcgi/homelab/projects/agent_platform/fc-agentd/internal/driver",
     visibility = ["//projects/agent_platform/fc-agentd:__subpackages__"],
@@ -16,7 +17,10 @@ go_library(
 
 go_test(
     name = "driver_test",
-    srcs = ["driver_test.go"],
+    srcs = [
+        "driver_test.go",
+        "provisioner_test.go",
+    ],
     embed = [":driver"],
     deps = ["//projects/agent_platform/substrate"],
 )

--- a/projects/agent_platform/fc-agentd/internal/driver/driver.go
+++ b/projects/agent_platform/fc-agentd/internal/driver/driver.go
@@ -29,8 +29,16 @@ type Config struct {
 	KernelImagePath string
 	// KernelBootArgs are appended to the kernel command line on cold boot.
 	KernelBootArgs string
-	// RootfsPath is the host path to the thread rootfs block device.
+	// RootfsPath is the host path to a shared/static rootfs, used only when no
+	// BaseRootfsPath is set (e.g. the kata rootfs for a heartbeat smoke test).
 	RootfsPath string
+	// BaseRootfsPath is the read-only base rootfs image (the flattened harness
+	// image). When set, each thread gets its own writable copy (CopyProvisioner).
+	BaseRootfsPath string
+	// HarnessInit, when set, is appended to the kernel command line as
+	// init=<path> so the guest boots straight into fc-agent-init (raw FC boot
+	// ignores the OCI entrypoint).
+	HarnessInit string
 	// VCPUs and MemMib size the guest.
 	VCPUs  int
 	MemMib int
@@ -81,9 +89,10 @@ type fcAPI interface {
 
 // Driver implements substrate.Substrate and substrate.Snapshotable for FC-direct.
 type Driver struct {
-	cfg       Config
-	launcher  Launcher
-	newClient func(socketPath string) fcAPI
+	cfg         Config
+	launcher    Launcher
+	newClient   func(socketPath string) fcAPI
+	provisioner RootfsProvisioner // nil => use cfg.RootfsPath (shared/static)
 
 	mu   sync.Mutex
 	live map[string]*instance // handle ID -> instance
@@ -108,13 +117,20 @@ func New(cfg Config, launcher Launcher, newClient func(socketPath string) fcAPI)
 	if newClient == nil {
 		newClient = func(sock string) fcAPI { return fcclient.New(sock) }
 	}
-	return &Driver{
+	d := &Driver{
 		cfg:       cfg.withDefaults(),
 		launcher:  launcher,
 		newClient: newClient,
 		live:      make(map[string]*instance),
 	}
+	if cfg.BaseRootfsPath != "" {
+		d.provisioner = &CopyProvisioner{Base: cfg.BaseRootfsPath}
+	}
+	return d
 }
+
+// SetProvisioner overrides the rootfs provisioner (tests inject a fake).
+func (d *Driver) SetProvisioner(p RootfsProvisioner) { d.provisioner = p }
 
 func newID(prefix string) string {
 	var b [8]byte
@@ -133,6 +149,17 @@ func (d *Driver) snapfilePath(threadID string) string {
 
 func (d *Driver) memfilePath(threadID string) string {
 	return filepath.Join(d.threadDir(threadID), "memfile")
+}
+
+// bootArgs is the kernel command line. When HarnessInit is set it appends
+// init=<path> so the guest boots straight into fc-agent-init (raw FC boot does
+// not honour the OCI image entrypoint).
+func (d *Driver) bootArgs() string {
+	args := d.cfg.KernelBootArgs
+	if d.cfg.HarnessInit != "" {
+		args += " init=" + d.cfg.HarnessInit
+	}
+	return args
 }
 
 // baseDir is the bundle directory for a warm base, keyed by an opaque base key
@@ -212,13 +239,24 @@ func (d *Driver) Claim(ctx context.Context, spec substrate.ClaimSpec) (substrate
 	}
 	client := d.newClient(sock)
 
+	// Each thread gets its own writable rootfs (from the base image) so threads
+	// never share or corrupt one disk. With no provisioner, fall back to the
+	// shared/static rootfs (e.g. a kata rootfs smoke test).
+	rootfsPath := d.cfg.RootfsPath
+	if d.provisioner != nil {
+		rootfsPath, err = d.provisioner.Provision(ctx, threadID, dir)
+		if err != nil {
+			return d.abort(proc, err)
+		}
+	}
+
 	if err := client.PutMachineConfig(ctx, fcclient.MachineConfig{VCPUCount: d.cfg.VCPUs, MemSizeMib: d.cfg.MemMib}); err != nil {
 		return d.abort(proc, err)
 	}
-	if err := client.PutBootSource(ctx, fcclient.BootSource{KernelImagePath: d.cfg.KernelImagePath, BootArgs: d.cfg.KernelBootArgs}); err != nil {
+	if err := client.PutBootSource(ctx, fcclient.BootSource{KernelImagePath: d.cfg.KernelImagePath, BootArgs: d.bootArgs()}); err != nil {
 		return d.abort(proc, err)
 	}
-	if err := client.PutDrive(ctx, fcclient.Drive{DriveID: "rootfs", PathOnHost: d.cfg.RootfsPath, IsRootDevice: true}); err != nil {
+	if err := client.PutDrive(ctx, fcclient.Drive{DriveID: "rootfs", PathOnHost: rootfsPath, IsRootDevice: true}); err != nil {
 		return d.abort(proc, err)
 	}
 	if err := client.Start(ctx); err != nil {

--- a/projects/agent_platform/fc-agentd/internal/driver/driver_test.go
+++ b/projects/agent_platform/fc-agentd/internal/driver/driver_test.go
@@ -61,12 +61,27 @@ func (l *fakeLauncher) Launch(_ context.Context, _ string, socketPath string) (P
 	return &fakeProcess{srv: srv}, nil
 }
 
+// shortTempDir returns a temp dir under /tmp with a short path. The fake
+// launcher binds a unix socket inside it, and macOS caps sun_path at 104 bytes,
+// which t.TempDir()'s long /var/folders/... paths exceed (bind: invalid
+// argument). On node-4 the snapshot root is the short /disks/nvme-02, so this is
+// a test-only portability shim.
+func shortTempDir(t *testing.T) string {
+	t.Helper()
+	d, err := os.MkdirTemp("/tmp", "fc")
+	if err != nil {
+		t.Fatalf("mkdir temp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(d) })
+	return d
+}
+
 func testDriver(t *testing.T) *Driver {
 	t.Helper()
 	return New(Config{
 		KernelImagePath: "/opt/kata/vmlinux",
 		RootfsPath:      "/dev/mapper/thread",
-		SnapshotRoot:    t.TempDir(),
+		SnapshotRoot:    shortTempDir(t),
 		Node:            "node-4",
 		Arch:            "amd64",
 	}, &fakeLauncher{}, nil)

--- a/projects/agent_platform/fc-agentd/internal/driver/provisioner.go
+++ b/projects/agent_platform/fc-agentd/internal/driver/provisioner.go
@@ -1,0 +1,56 @@
+package driver
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+// RootfsProvisioner gives each thread its own writable rootfs derived from a
+// read-only base image, so threads never share or corrupt one disk. The default
+// impl is a file copy ("full snapshots first"); a devmapper thin-COW impl is a
+// future efficiency follow-up behind the same interface.
+type RootfsProvisioner interface {
+	// Provision creates the thread's rootfs under dir and returns its host path.
+	Provision(ctx context.Context, threadID, dir string) (string, error)
+}
+
+// CopyProvisioner copies a base rootfs image to a per-thread file. Simple and
+// correct; the cost is a full copy + full disk per thread, which devmapper
+// thin-COW will later replace.
+type CopyProvisioner struct {
+	// Base is the read-only base rootfs image (a flattened harness image).
+	Base string
+}
+
+// Provision copies Base to dir/rootfs.ext4.
+func (p *CopyProvisioner) Provision(_ context.Context, _, dir string) (string, error) {
+	if p.Base == "" {
+		return "", fmt.Errorf("driver: CopyProvisioner.Base is empty")
+	}
+	dst := filepath.Join(dir, "rootfs.ext4")
+	if err := copyFile(p.Base, dst); err != nil {
+		return "", fmt.Errorf("driver: provision rootfs: %w", err)
+	}
+	return dst, nil
+}
+
+func copyFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(out, in); err != nil {
+		out.Close()
+		return err
+	}
+	return out.Close()
+}

--- a/projects/agent_platform/fc-agentd/internal/driver/provisioner_test.go
+++ b/projects/agent_platform/fc-agentd/internal/driver/provisioner_test.go
@@ -1,0 +1,103 @@
+package driver
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+
+	"github.com/jomcgi/homelab/projects/agent_platform/substrate"
+)
+
+func TestCopyProvisionerCopiesBase(t *testing.T) {
+	base := filepath.Join(shortTempDir(t), "base.ext4")
+	if err := os.WriteFile(base, []byte("ROOTFS-BYTES"), 0o600); err != nil {
+		t.Fatalf("write base: %v", err)
+	}
+	dir := shortTempDir(t)
+
+	p := &CopyProvisioner{Base: base}
+	got, err := p.Provision(context.Background(), "t1", dir)
+	if err != nil {
+		t.Fatalf("Provision: %v", err)
+	}
+	if got != filepath.Join(dir, "rootfs.ext4") {
+		t.Fatalf("rootfs path = %q", got)
+	}
+	b, err := os.ReadFile(got)
+	if err != nil {
+		t.Fatalf("read provisioned: %v", err)
+	}
+	if string(b) != "ROOTFS-BYTES" {
+		t.Fatalf("provisioned content = %q, want the base bytes", b)
+	}
+}
+
+func TestCopyProvisionerEmptyBaseErrors(t *testing.T) {
+	if _, err := (&CopyProvisioner{}).Provision(context.Background(), "t1", t.TempDir()); err == nil {
+		t.Fatal("empty Base should error")
+	}
+}
+
+// fakeProvisioner records calls and creates a stub rootfs file.
+type fakeProvisioner struct {
+	calls    atomic.Int32
+	threadID string
+	fail     error
+}
+
+func (f *fakeProvisioner) Provision(_ context.Context, threadID, dir string) (string, error) {
+	f.calls.Add(1)
+	f.threadID = threadID
+	if f.fail != nil {
+		return "", f.fail
+	}
+	path := filepath.Join(dir, "rootfs.ext4")
+	_ = os.WriteFile(path, []byte("stub"), 0o600)
+	return path, nil
+}
+
+func TestDriverClaimProvisionsPerThreadRootfs(t *testing.T) {
+	d := testDriver(t)
+	fp := &fakeProvisioner{}
+	d.SetProvisioner(fp)
+
+	h, err := d.Claim(context.Background(), substrate.ClaimSpec{ThreadID: "t-prov"})
+	if err != nil {
+		t.Fatalf("Claim: %v", err)
+	}
+	if fp.calls.Load() != 1 {
+		t.Fatalf("provisioner called %d times, want 1", fp.calls.Load())
+	}
+	if fp.threadID != "t-prov" {
+		t.Fatalf("provisioned for %q, want t-prov", fp.threadID)
+	}
+	if h.ThreadID != "t-prov" {
+		t.Fatalf("handle thread = %q", h.ThreadID)
+	}
+}
+
+func TestDriverClaimProvisionFailureAborts(t *testing.T) {
+	d := testDriver(t)
+	d.SetProvisioner(&fakeProvisioner{fail: errors.New("no space")})
+	if _, err := d.Claim(context.Background(), substrate.ClaimSpec{ThreadID: "t1"}); err == nil {
+		t.Fatal("Claim should fail when rootfs provisioning fails")
+	}
+	if d.LiveCount() != 0 {
+		t.Fatalf("a failed provision should not leave a live VM; LiveCount=%d", d.LiveCount())
+	}
+}
+
+func TestBootArgsAppendsInit(t *testing.T) {
+	d := New(Config{
+		KernelBootArgs: "console=ttyS0",
+		HarnessInit:    "/usr/local/bin/fc-agent-init",
+		SnapshotRoot:   shortTempDir(t),
+		Node:           "node-4", Arch: "amd64",
+	}, &fakeLauncher{}, nil)
+	if got := d.bootArgs(); got != "console=ttyS0 init=/usr/local/bin/fc-agent-init" {
+		t.Fatalf("bootArgs = %q", got)
+	}
+}

--- a/projects/agent_platform/harness/BUILD
+++ b/projects/agent_platform/harness/BUILD
@@ -1,0 +1,72 @@
+# gazelle:ignore
+load("@aspect_bazel_lib//lib:tar.bzl", "tar")
+load("@aspect_bazel_lib//lib:transitions.bzl", "platform_transition_filegroup")
+load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
+load("//bazel/tools/oci:apko_image.bzl", "apko_image")
+
+# The microVM agent-harness image (ADR 022 Plan B): apko base (git/gh/go/node/
+# pnpm from Wolfi) + the Goose binary + fc-agent-init as PID 1. fc-agent-init
+# launches a turn-capped `goose run` whose between-turns boundary is the
+# quiescent point the snapshot controller pauses on.
+
+# Bake the Goose config at ~/.config/goose/config.yaml.
+pkg_tar(
+    name = "config_tar",
+    srcs = ["config.yaml"],
+    mode = "0644",
+    owner = "65532.65532",
+    package_dir = "/home/goose-agent/.config/goose",
+)
+
+# Bake the recipe library at ~/recipes (FC_GOOSE_RECIPE points here).
+pkg_tar(
+    name = "recipes_tar",
+    srcs = glob(["recipes/*.yaml"]),
+    mode = "0644",
+    owner = "65532.65532",
+    package_dir = "/home/goose-agent/recipes",
+)
+
+# fc-agent-init binary, cross-compiled per arch and layered at /usr/local/bin.
+platform_transition_filegroup(
+    name = "fc_agent_init_amd64_bin",
+    srcs = ["//projects/agent_platform/fc-agent-init/cmd"],
+    target_platform = "@rules_go//go/toolchain:linux_amd64",
+)
+
+tar(
+    name = "fc_agent_init_tar_amd64",
+    srcs = [":fc_agent_init_amd64_bin"],
+    mtree = [
+        "./usr/local/bin/fc-agent-init type=file content=$(execpath :fc_agent_init_amd64_bin) mode=0755 uid=0 gid=0",
+    ],
+)
+
+platform_transition_filegroup(
+    name = "fc_agent_init_arm64_bin",
+    srcs = ["//projects/agent_platform/fc-agent-init/cmd"],
+    target_platform = "@rules_go//go/toolchain:linux_arm64",
+)
+
+tar(
+    name = "fc_agent_init_tar_arm64",
+    srcs = [":fc_agent_init_arm64_bin"],
+    mtree = [
+        "./usr/local/bin/fc-agent-init type=file content=$(execpath :fc_agent_init_arm64_bin) mode=0755 uid=0 gid=0",
+    ],
+)
+
+apko_image(
+    name = "image",
+    config = "apko.yaml",
+    contents = "@harness_lock//:contents",
+    multiarch_tars = [
+        "@goose//:tar",
+        ":fc_agent_init_tar",
+    ],
+    repository = "ghcr.io/jomcgi/homelab/projects/agent_platform/harness",
+    tars = [
+        ":config_tar",
+        ":recipes_tar",
+    ],
+)

--- a/projects/agent_platform/harness/apko.lock.json
+++ b/projects/agent_platform/harness/apko.lock.json
@@ -1,0 +1,2159 @@
+{
+  "version": "v1",
+  "config": {
+    "name": "projects/agent_platform/harness/apko.yaml",
+    "checksum": "sha256-49zfH5dUL4bgznNldW1jM4TRRVkbEh25ckrSw2FvdTY="
+  },
+  "contents": {
+    "keyring": [
+      {
+        "name": "packages.wolfi.dev/os/wolfi-signing.rsa.pub",
+        "url": "https://packages.wolfi.dev/os/wolfi-signing.rsa.pub"
+      }
+    ],
+    "build_repositories": [],
+    "runtime_repositories": [],
+    "repositories": [
+      {
+        "name": "packages.wolfi.dev/os/x86_64",
+        "url": "https://packages.wolfi.dev/os/x86_64/APKINDEX.tar.gz",
+        "architecture": "x86_64"
+      },
+      {
+        "name": "packages.wolfi.dev/os/aarch64",
+        "url": "https://packages.wolfi.dev/os/aarch64/APKINDEX.tar.gz",
+        "architecture": "aarch64"
+      }
+    ],
+    "packages": [
+      {
+        "name": "wolfi-baselayout",
+        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r29.apk",
+        "version": "20230201-r29",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-1932",
+          "checksum": "sha1-mxVgkD4+r1cSUSeWo6ClkgNR1IA="
+        },
+        "data": {
+          "range": "bytes=1933-13952",
+          "checksum": "sha256-5jOBVeXTWJEbL+Cnxj5Nu4klEL4SEB7IDMzT96rbkkA="
+        },
+        "checksum": "Q1mxVgkD4+r1cSUSeWo6ClkgNR1IA="
+      },
+      {
+        "name": "ca-certificates-bundle",
+        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20260413-r0.apk",
+        "version": "20260413-r0",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-7872",
+          "checksum": "sha1-KyCdEL20IKE+B7DKW97GLXu2QLM="
+        },
+        "data": {
+          "range": "bytes=7873-137518",
+          "checksum": "sha256-foyxNKCWc3UQM3Kq5on+Gt/2d+HlzCUl+1lqiaviWE8="
+        },
+        "checksum": "Q1KyCdEL20IKE+B7DKW97GLXu2QLM="
+      },
+      {
+        "name": "libgcc",
+        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-16.1.0-r4.apk",
+        "version": "16.1.0-r4",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-9951",
+          "checksum": "sha1-v4FvRKA29cOT2WtAXaWZBCzRXaU="
+        },
+        "data": {
+          "range": "bytes=9952-105490",
+          "checksum": "sha256-ExYZSr5G/sH+fzFe+TjVUTTj/GQ1Qbjx8MMEh+6ZxE0="
+        },
+        "checksum": "Q1v4FvRKA29cOT2WtAXaWZBCzRXaU="
+      },
+      {
+        "name": "glibc-locale-posix",
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.43-r9.apk",
+        "version": "2.43-r9",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-12840",
+          "checksum": "sha1-H64y8mukP523u0pCZf8hfFWbbRo="
+        },
+        "data": {
+          "range": "bytes=12841-89581",
+          "checksum": "sha256-Uss+kZ8QQvAIOljUCQsmOCzkr9mDf86+RmdJcmZkHBc="
+        },
+        "checksum": "Q1H64y8mukP523u0pCZf8hfFWbbRo="
+      },
+      {
+        "name": "glibc",
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.43-r9.apk",
+        "version": "2.43-r9",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-13094",
+          "checksum": "sha1-55FrWEeQ3Y3FogkXEzPPmk+3DTM="
+        },
+        "data": {
+          "range": "bytes=13095-3069364",
+          "checksum": "sha256-UODeJ9r02RcR6ys5AtpxdTOz86nLL5T70lcPmbaMdLI="
+        },
+        "checksum": "Q155FrWEeQ3Y3FogkXEzPPmk+3DTM="
+      },
+      {
+        "name": "ld-linux",
+        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.43-r9.apk",
+        "version": "2.43-r9",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-12891",
+          "checksum": "sha1-QXR2tE2zmZfHSFVq6FdarWn4TSI="
+        },
+        "data": {
+          "range": "bytes=12892-147121",
+          "checksum": "sha256-2MetOLJhj/fCCOaw4gPiNRO/dQZSA960MbfYuBUJS9Y="
+        },
+        "checksum": "Q1QXR2tE2zmZfHSFVq6FdarWn4TSI="
+      },
+      {
+        "name": "ncurses-terminfo-base",
+        "url": "https://packages.wolfi.dev/os/x86_64/ncurses-terminfo-base-6.6.20260620-r0.apk",
+        "version": "6.6.20260620-r0",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-9863",
+          "checksum": "sha1-nU2IJBZ81vZ5oRDlHbLale7bkQw="
+        },
+        "data": {
+          "range": "bytes=9864-116078",
+          "checksum": "sha256-rjHVP2hGmWzT4Mfss6FKg4jtZs15bjgVpvA2+ohAxmE="
+        },
+        "checksum": "Q1nU2IJBZ81vZ5oRDlHbLale7bkQw="
+      },
+      {
+        "name": "ncurses",
+        "url": "https://packages.wolfi.dev/os/x86_64/ncurses-6.6.20260620-r0.apk",
+        "version": "6.6.20260620-r0",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-10007",
+          "checksum": "sha1-FqF2vf0lDhnCD+zAMQ5UH1XlOvs="
+        },
+        "data": {
+          "range": "bytes=10008-619739",
+          "checksum": "sha256-sDPKISLkyMMr+Ux8j9h0d5iNgTbgAqQA/b4XUKsZiMw="
+        },
+        "checksum": "Q1FqF2vf0lDhnCD+zAMQ5UH1XlOvs="
+      },
+      {
+        "name": "bash",
+        "url": "https://packages.wolfi.dev/os/x86_64/bash-5.3-r12.apk",
+        "version": "5.3-r12",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-7927",
+          "checksum": "sha1-MiP/OfvIiKKAeeYZwZ9TEZUMUes="
+        },
+        "data": {
+          "range": "bytes=7928-761775",
+          "checksum": "sha256-6a67wARX0cxLzVwnkqQBX1Pn8IgVa9uq95jAGW5nEeM="
+        },
+        "checksum": "Q1MiP/OfvIiKKAeeYZwZ9TEZUMUes="
+      },
+      {
+        "name": "libxcrypt",
+        "url": "https://packages.wolfi.dev/os/x86_64/libxcrypt-4.5.2-r3.apk",
+        "version": "4.5.2-r3",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-8536",
+          "checksum": "sha1-I0YlF5JXljMqn3nnsq4AWUw6X/8="
+        },
+        "data": {
+          "range": "bytes=8537-106099",
+          "checksum": "sha256-mzRytDzhPafMZpD3kpn03C6x2XCNuG0nZ1F3Bjo+Jx4="
+        },
+        "checksum": "Q1I0YlF5JXljMqn3nnsq4AWUw6X/8="
+      },
+      {
+        "name": "libcrypt1",
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.43-r9.apk",
+        "version": "2.43-r9",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-12905",
+          "checksum": "sha1-9oOBflcOvOA9KafVrBVMSnqsOgo="
+        },
+        "data": {
+          "range": "bytes=12906-14518",
+          "checksum": "sha256-U1phbbPmyglswLkLmhDmtnHlO2pHRtoVtEdZSoC6AqA="
+        },
+        "checksum": "Q19oOBflcOvOA9KafVrBVMSnqsOgo="
+      },
+      {
+        "name": "busybox",
+        "url": "https://packages.wolfi.dev/os/x86_64/busybox-1.37.0-r61.apk",
+        "version": "1.37.0-r61",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-10913",
+          "checksum": "sha1-Dc1coU0swhMsnFh4BnVin4Y/z6U="
+        },
+        "data": {
+          "range": "bytes=10914-430452",
+          "checksum": "sha256-Lp5skr4+yaxDhdl+G39Z7VC8YLLcwNh+fGvRe0T6bj0="
+        },
+        "checksum": "Q1Dc1coU0swhMsnFh4BnVin4Y/z6U="
+      },
+      {
+        "name": "libpcre2-8-0",
+        "url": "https://packages.wolfi.dev/os/x86_64/libpcre2-8-0-10.47-r0.apk",
+        "version": "10.47-r0",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-6848",
+          "checksum": "sha1-5bkXL31L9lMVsxJdyleMiTb2Esg="
+        },
+        "data": {
+          "range": "bytes=6849-307246",
+          "checksum": "sha256-LBagnNrkJtEnWnNJIYKGEllGZqRH6y5+9I9lQ05+NIs="
+        },
+        "checksum": "Q15bkXL31L9lMVsxJdyleMiTb2Esg="
+      },
+      {
+        "name": "libsepol",
+        "url": "https://packages.wolfi.dev/os/x86_64/libsepol-3.10-r2.apk",
+        "version": "3.10-r2",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-6353",
+          "checksum": "sha1-Le/AljgZs/GS/EBqoBAw6eH1hyk="
+        },
+        "data": {
+          "range": "bytes=6354-438643",
+          "checksum": "sha256-GV/afF7btcauQYDuq3YdYQ/lIrB5UuBNIm2AiuIh2Og="
+        },
+        "checksum": "Q1Le/AljgZs/GS/EBqoBAw6eH1hyk="
+      },
+      {
+        "name": "libselinux",
+        "url": "https://packages.wolfi.dev/os/x86_64/libselinux-3.10-r0.apk",
+        "version": "3.10-r0",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-7251",
+          "checksum": "sha1-CM7/ih5kzO/43c2A1NI9lWvFHQQ="
+        },
+        "data": {
+          "range": "bytes=7252-318547",
+          "checksum": "sha256-JyOZS2AgOp7yzXMvmXgG+G71DBctZeyuEY15XddGXUU="
+        },
+        "checksum": "Q1CM7/ih5kzO/43c2A1NI9lWvFHQQ="
+      },
+      {
+        "name": "libacl1",
+        "url": "https://packages.wolfi.dev/os/x86_64/libacl1-2.3.2-r55.apk",
+        "version": "2.3.2-r55",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-7702",
+          "checksum": "sha1-yPga0Q7H2gxy18ZuQTovdIHWQvY="
+        },
+        "data": {
+          "range": "bytes=7703-28751",
+          "checksum": "sha256-0/eSvAC2Htvs+FehVF8Wx4+mwO3cLJM3nJly2lJgEPg="
+        },
+        "checksum": "Q1yPga0Q7H2gxy18ZuQTovdIHWQvY="
+      },
+      {
+        "name": "libattr1",
+        "url": "https://packages.wolfi.dev/os/x86_64/libattr1-2.5.2-r56.apk",
+        "version": "2.5.2-r56",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-7764",
+          "checksum": "sha1-0j1iTA8fMboleZUDYCD9qIAvuTE="
+        },
+        "data": {
+          "range": "bytes=7765-19146",
+          "checksum": "sha256-imFwWN+2sySvuV7zIc0t3uOzeW+KNK17XsKolm5X1d8="
+        },
+        "checksum": "Q10j1iTA8fMboleZUDYCD9qIAvuTE="
+      },
+      {
+        "name": "libcrypto3",
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.6.3-r3.apk",
+        "version": "3.6.3-r3",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-10990",
+          "checksum": "sha1-8czJwPp28PlmrUy6evlca3lfXlk="
+        },
+        "data": {
+          "range": "bytes=10991-2439998",
+          "checksum": "sha256-Gtu+CyjMO2oH9qFjvJKo2t0zE0aDLG2dwtmDVnll8/4="
+        },
+        "checksum": "Q18czJwPp28PlmrUy6evlca3lfXlk="
+      },
+      {
+        "name": "coreutils",
+        "url": "https://packages.wolfi.dev/os/x86_64/coreutils-9.11-r3.apk",
+        "version": "9.11-r3",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-8698",
+          "checksum": "sha1-Y+PvSypu3hsUvmwdQ68Tc7uPsdI="
+        },
+        "data": {
+          "range": "bytes=8699-859850",
+          "checksum": "sha256-z7vM1hHBjwnR5wK9Qtx4/PwXBXK2cZTtLP2D/HE9tt8="
+        },
+        "checksum": "Q1Y+PvSypu3hsUvmwdQ68Tc7uPsdI="
+      },
+      {
+        "name": "gh",
+        "url": "https://packages.wolfi.dev/os/x86_64/gh-2.95.0-r0.apk",
+        "version": "2.95.0-r0",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-5917",
+          "checksum": "sha1-4I3xfRkhV+NOiYwpXbhXarngosw="
+        },
+        "data": {
+          "range": "bytes=5918-15870837",
+          "checksum": "sha256-OGrhEJ2ioISbdfJQAZ9lOO5BTNzgNXK7Rs8b04Vbo7o="
+        },
+        "checksum": "Q14I3xfRkhV+NOiYwpXbhXarngosw="
+      },
+      {
+        "name": "zlib",
+        "url": "https://packages.wolfi.dev/os/x86_64/zlib-1.3.2-r3.apk",
+        "version": "1.3.2-r3",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-8782",
+          "checksum": "sha1-d+xgnhv2qmmnyUpkIEMLv/Ccfts="
+        },
+        "data": {
+          "range": "bytes=8783-70985",
+          "checksum": "sha256-GtMaz7tc+6/gw51/jRq2trQH8bshZpL66etBeg87OHE="
+        },
+        "checksum": "Q1d+xgnhv2qmmnyUpkIEMLv/Ccfts="
+      },
+      {
+        "name": "libexpat1",
+        "url": "https://packages.wolfi.dev/os/x86_64/libexpat1-2.8.2-r0.apk",
+        "version": "2.8.2-r0",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-8242",
+          "checksum": "sha1-3bwMuWY+5iQYGH+/1+ug95kLRu0="
+        },
+        "data": {
+          "range": "bytes=8243-110531",
+          "checksum": "sha256-i9mBBrmO//lw8AtYHtm1Tj7N7CDwKVPhGnOaHqpQFKM="
+        },
+        "checksum": "Q13bwMuWY+5iQYGH+/1+ug95kLRu0="
+      },
+      {
+        "name": "libunistring",
+        "url": "https://packages.wolfi.dev/os/x86_64/libunistring-1.4.2-r2.apk",
+        "version": "1.4.2-r2",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-7520",
+          "checksum": "sha1-yQVDwlBj+eVaAbOLQdnJEtSg9X8="
+        },
+        "data": {
+          "range": "bytes=7521-904686",
+          "checksum": "sha256-GI6eG0zWe5m0XvD9gtqeVflLEmYFymJ721kuHiTCrjQ="
+        },
+        "checksum": "Q1yQVDwlBj+eVaAbOLQdnJEtSg9X8="
+      },
+      {
+        "name": "libidn2",
+        "url": "https://packages.wolfi.dev/os/x86_64/libidn2-2.3.8-r7.apk",
+        "version": "2.3.8-r7",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-7265",
+          "checksum": "sha1-+8VxIeYQUa3/Z757IHzsOgDCgso="
+        },
+        "data": {
+          "range": "bytes=7266-125457",
+          "checksum": "sha256-ILpoZL5xVJ5smMN61tGlPXBCD2gsk+q8OsVN/UKo6PY="
+        },
+        "checksum": "Q1+8VxIeYQUa3/Z757IHzsOgDCgso="
+      },
+      {
+        "name": "libpsl",
+        "url": "https://packages.wolfi.dev/os/x86_64/libpsl-0.22.0-r1.apk",
+        "version": "0.22.0-r1",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-7719",
+          "checksum": "sha1-lRx4LxQvDyx0I8518WaiI+aRFEE="
+        },
+        "data": {
+          "range": "bytes=7720-73492",
+          "checksum": "sha256-gytOdYzTtGNYuWDhqNzawhwm6bECytrlXw0nczWihE4="
+        },
+        "checksum": "Q1lRx4LxQvDyx0I8518WaiI+aRFEE="
+      },
+      {
+        "name": "libbrotlicommon1",
+        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlicommon1-1.2.0-r3.apk",
+        "version": "1.2.0-r3",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-6793",
+          "checksum": "sha1-jiywS9aIP3q1TI5UwC1zp/dsVr8="
+        },
+        "data": {
+          "range": "bytes=6794-76948",
+          "checksum": "sha256-OarefY1K7DoAVQnI+gKBLCpdMFeyGlj9gEIfBGp3Fvg="
+        },
+        "checksum": "Q1jiywS9aIP3q1TI5UwC1zp/dsVr8="
+      },
+      {
+        "name": "libbrotlidec1",
+        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlidec1-1.2.0-r3.apk",
+        "version": "1.2.0-r3",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-6806",
+          "checksum": "sha1-G/f4liNwY7eefOjRe3Dd3U9FM7o="
+        },
+        "data": {
+          "range": "bytes=6807-38364",
+          "checksum": "sha256-U7AnPRqeMceKaariNoQB/dP2etJh98p2RzIrSMayits="
+        },
+        "checksum": "Q1G/f4liNwY7eefOjRe3Dd3U9FM7o="
+      },
+      {
+        "name": "libssl3",
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.6.3-r3.apk",
+        "version": "3.6.3-r3",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-11000",
+          "checksum": "sha1-cfdB5BXNoGxB998AA6UNEUQzmG4="
+        },
+        "data": {
+          "range": "bytes=11001-524305",
+          "checksum": "sha256-VtGnoMNcs4UcJxBfFv47/vmpWT2kz+LXfzmLFrDzndQ="
+        },
+        "checksum": "Q1cfdB5BXNoGxB998AA6UNEUQzmG4="
+      },
+      {
+        "name": "ngtcp2",
+        "url": "https://packages.wolfi.dev/os/x86_64/ngtcp2-1.23.0-r0.apk",
+        "version": "1.23.0-r0",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-6388",
+          "checksum": "sha1-hWrors2Ozv2Naa0WxwRvnue7EWo="
+        },
+        "data": {
+          "range": "bytes=6389-231705",
+          "checksum": "sha256-xSid/2L8eT+awz1NX5JM9Qvu+U2TsiklA3D6cW2uyPw="
+        },
+        "checksum": "Q1hWrors2Ozv2Naa0WxwRvnue7EWo="
+      },
+      {
+        "name": "nghttp3",
+        "url": "https://packages.wolfi.dev/os/x86_64/nghttp3-1.17.0-r0.apk",
+        "version": "1.17.0-r0",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-6856",
+          "checksum": "sha1-5w7ZWIIMAvrDoPAfEw4k3gntS44="
+        },
+        "data": {
+          "range": "bytes=6857-108169",
+          "checksum": "sha256-S7NsyT53AL6SRt7kzjA0Bv4WyY6EXZ0HFwVnvJYBn5s="
+        },
+        "checksum": "Q15w7ZWIIMAvrDoPAfEw4k3gntS44="
+      },
+      {
+        "name": "libnghttp2-14",
+        "url": "https://packages.wolfi.dev/os/x86_64/libnghttp2-14-1.69.0-r0.apk",
+        "version": "1.69.0-r0",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-7102",
+          "checksum": "sha1-g6bzH9P+JXiqOWC3Ofkeg+Ae4mk="
+        },
+        "data": {
+          "range": "bytes=7103-108752",
+          "checksum": "sha256-5i2EksNuAPwDuvelewjfjmuqaZAczZZgtce3L4MaPZY="
+        },
+        "checksum": "Q1g6bzH9P+JXiqOWC3Ofkeg+Ae4mk="
+      },
+      {
+        "name": "libverto",
+        "url": "https://packages.wolfi.dev/os/x86_64/libverto-0.3.2-r7.apk",
+        "version": "0.3.2-r7",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-7019",
+          "checksum": "sha1-sDJ1BUkf//wbO4iWftq36lU0TKw="
+        },
+        "data": {
+          "range": "bytes=7020-20251",
+          "checksum": "sha256-Z1Lrte4GAbGfrMW6bu3AKImDbo/cCeXPAl63zVvzDLU="
+        },
+        "checksum": "Q1sDJ1BUkf//wbO4iWftq36lU0TKw="
+      },
+      {
+        "name": "krb5-conf",
+        "url": "https://packages.wolfi.dev/os/x86_64/krb5-conf-1.0-r9.apk",
+        "version": "1.0-r9",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-1146",
+          "checksum": "sha1-Ra+vl5lLBEyOhG8QYdPfwg9wdgg="
+        },
+        "data": {
+          "range": "bytes=1147-2879",
+          "checksum": "sha256-sdgWS1AsGdT2maS7nI53u3Yj9gq6XjsFhKRTO6Ty4jk="
+        },
+        "checksum": "Q1Ra+vl5lLBEyOhG8QYdPfwg9wdgg="
+      },
+      {
+        "name": "keyutils-libs",
+        "url": "https://packages.wolfi.dev/os/x86_64/keyutils-libs-1.6.3-r38.apk",
+        "version": "1.6.3-r38",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-7279",
+          "checksum": "sha1-n6vDDtjepPx8dX6+DNE1ZryKl+A="
+        },
+        "data": {
+          "range": "bytes=7280-17714",
+          "checksum": "sha256-LObgKe6wZKNDXK5PALdGfj3iSGZlvsQvBjy0z7fOaIA="
+        },
+        "checksum": "Q1n6vDDtjepPx8dX6+DNE1ZryKl+A="
+      },
+      {
+        "name": "libcom_err",
+        "url": "https://packages.wolfi.dev/os/x86_64/libcom_err-1.47.4-r1.apk",
+        "version": "1.47.4-r1",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-8252",
+          "checksum": "sha1-CMcRrPrpbLziSeZwJAsj1IggRAg="
+        },
+        "data": {
+          "range": "bytes=8253-16737",
+          "checksum": "sha256-u0G4PIicoyfgySbZKrzDrrgzWhBNmqRVcMg6zQFSSS4="
+        },
+        "checksum": "Q1CMcRrPrpbLziSeZwJAsj1IggRAg="
+      },
+      {
+        "name": "krb5-libs",
+        "url": "https://packages.wolfi.dev/os/x86_64/krb5-libs-1.22.2-r2.apk",
+        "version": "1.22.2-r2",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-8895",
+          "checksum": "sha1-xseCtT4lsF66PC2c5G0LLMk+aq4="
+        },
+        "data": {
+          "range": "bytes=8896-1047954",
+          "checksum": "sha256-By1IkTuSdK0eqziOaHpvntsQA25M3dL+pReOZ1lKbPo="
+        },
+        "checksum": "Q1xseCtT4lsF66PC2c5G0LLMk+aq4="
+      },
+      {
+        "name": "gdbm",
+        "url": "https://packages.wolfi.dev/os/x86_64/gdbm-1.26-r5.apk",
+        "version": "1.26-r5",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-7464",
+          "checksum": "sha1-m4CRD8lCkRLk/whYIwa2UQuA8uk="
+        },
+        "data": {
+          "range": "bytes=7465-274283",
+          "checksum": "sha256-0u2QmNUl9YQxfpb+TygxHhYAOi/40XsqJOfpEEkuGmE="
+        },
+        "checksum": "Q1m4CRD8lCkRLk/whYIwa2UQuA8uk="
+      },
+      {
+        "name": "readline",
+        "url": "https://packages.wolfi.dev/os/x86_64/readline-8.3-r2.apk",
+        "version": "8.3-r2",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-6720",
+          "checksum": "sha1-1WRlY3do45L9jnu5YAoRTSTcimY="
+        },
+        "data": {
+          "range": "bytes=6721-342785",
+          "checksum": "sha256-b8Pq+h8UH9KT10SqvwjnKyZNJ1p5qhjdXy2Yn63jtNw="
+        },
+        "checksum": "Q11WRlY3do45L9jnu5YAoRTSTcimY="
+      },
+      {
+        "name": "sqlite-libs",
+        "url": "https://packages.wolfi.dev/os/x86_64/sqlite-libs-3.53.3-r0.apk",
+        "version": "3.53.3-r0",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-5168",
+          "checksum": "sha1-tJ7DnnhwMzt8gBk/bAznlK0aWe4="
+        },
+        "data": {
+          "range": "bytes=5169-978384",
+          "checksum": "sha256-HI6LwiorM4UnmYXJ0nRzyjf/h8/zgekNc0jrSj0EqH4="
+        },
+        "checksum": "Q1tJ7DnnhwMzt8gBk/bAznlK0aWe4="
+      },
+      {
+        "name": "heimdal-libs",
+        "url": "https://packages.wolfi.dev/os/x86_64/heimdal-libs-7.8.0-r49.apk",
+        "version": "7.8.0-r49",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-9165",
+          "checksum": "sha1-v9y65iYmXEZuawffvZaHk9UhjCo="
+        },
+        "data": {
+          "range": "bytes=9166-1474106",
+          "checksum": "sha256-00ynYZAiSLDSv620LvdwkPgAMI20ifho8a864nJuKYA="
+        },
+        "checksum": "Q1v9y65iYmXEZuawffvZaHk9UhjCo="
+      },
+      {
+        "name": "cyrus-sasl-heimdal-libs",
+        "url": "https://packages.wolfi.dev/os/x86_64/cyrus-sasl-heimdal-libs-2.1.28-r52.apk",
+        "version": "2.1.28-r52",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-9755",
+          "checksum": "sha1-dU1RuQ9xgBNzfbpA1HFnm1vYBWo="
+        },
+        "data": {
+          "range": "bytes=9756-216677",
+          "checksum": "sha256-nhlqN2keSi7L9T0h8EwsMte7aGREj3u6Yhfw0b5+OsM="
+        },
+        "checksum": "Q1dU1RuQ9xgBNzfbpA1HFnm1vYBWo="
+      },
+      {
+        "name": "libldap-2.6",
+        "url": "https://packages.wolfi.dev/os/x86_64/libldap-2.6-2.6.13-r4.apk",
+        "version": "2.6.13-r4",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-14245",
+          "checksum": "sha1-kEG+z4XD6lluFSah75b/8G5seDk="
+        },
+        "data": {
+          "range": "bytes=14246-255477",
+          "checksum": "sha256-+ogmUJc4fCh0yGwxuKr+TEAFMGDbygCDZ4jNRDI+5nM="
+        },
+        "checksum": "Q1kEG+z4XD6lluFSah75b/8G5seDk="
+      },
+      {
+        "name": "libcurl-openssl4",
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.21.0-r0.apk",
+        "version": "8.21.0-r0",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-12857",
+          "checksum": "sha1-hfrUBFTygzhU7bt8RsImH9eO1VM="
+        },
+        "data": {
+          "range": "bytes=12858-572433",
+          "checksum": "sha256-sMZ5zM8q4aVthzMbCDmxNpaMus+NfHrrU6GZ0Vif05M="
+        },
+        "checksum": "Q1hfrUBFTygzhU7bt8RsImH9eO1VM="
+      },
+      {
+        "name": "git",
+        "url": "https://packages.wolfi.dev/os/x86_64/git-2.54.0-r1.apk",
+        "version": "2.54.0-r1",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-12366",
+          "checksum": "sha1-vmyozz0aKv6M1M7gEDzsqMmGv1U="
+        },
+        "data": {
+          "range": "bytes=12367-9614892",
+          "checksum": "sha256-povG6tTVJH6ZA9XlNXUUwuMBl1LuKJBPxTFQ65gF7R0="
+        },
+        "checksum": "Q1vmyozz0aKv6M1M7gEDzsqMmGv1U="
+      },
+      {
+        "name": "go-1.26",
+        "url": "https://packages.wolfi.dev/os/x86_64/go-1.26-1.26.4-r1.apk",
+        "version": "1.26.4-r1",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-7892",
+          "checksum": "sha1-fkVDC/bDA3hU118vMt6gB8GJhQ0="
+        },
+        "data": {
+          "range": "bytes=7893-57347005",
+          "checksum": "sha256-fw1Jpw1aIMcyHpzvVmert559YcilDjfGQANlmRnNhng="
+        },
+        "checksum": "Q1fkVDC/bDA3hU118vMt6gB8GJhQ0="
+      },
+      {
+        "name": "c-ares",
+        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.34.6-r1.apk",
+        "version": "1.34.6-r1",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-7609",
+          "checksum": "sha1-F82ZEADATd22BWq1dXnoVqybexk="
+        },
+        "data": {
+          "range": "bytes=7610-151619",
+          "checksum": "sha256-S59jcuTJHgrZwEZ2B3pWkeYiHjNLFUcw1FRXMziQPws="
+        },
+        "checksum": "Q1F82ZEADATd22BWq1dXnoVqybexk="
+      },
+      {
+        "name": "icu78-data-full",
+        "url": "https://packages.wolfi.dev/os/x86_64/icu78-data-full-78.3-r1.apk",
+        "version": "78.3-r1",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-7666",
+          "checksum": "sha1-oI1UH/9+yaXly/8uY+aUUoI+vWE="
+        },
+        "data": {
+          "range": "bytes=7667-14026886",
+          "checksum": "sha256-j096fD6K9n0KSD6/VNWVNnGGiGvvkv2sOjNHLQVkP+g="
+        },
+        "checksum": "Q1oI1UH/9+yaXly/8uY+aUUoI+vWE="
+      },
+      {
+        "name": "libstdc++",
+        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-16.1.0-r4.apk",
+        "version": "16.1.0-r4",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-9949",
+          "checksum": "sha1-0G/kziut8KEYt22cLifRa9QA+HQ="
+        },
+        "data": {
+          "range": "bytes=9950-1261924",
+          "checksum": "sha256-+PxUlxtKRnSh9H8NjtevLTb3x4S8Bl3jFaJMzHYEGlg="
+        },
+        "checksum": "Q10G/kziut8KEYt22cLifRa9QA+HQ="
+      },
+      {
+        "name": "libicu78",
+        "url": "https://packages.wolfi.dev/os/x86_64/libicu78-78.3-r1.apk",
+        "version": "78.3-r1",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-7766",
+          "checksum": "sha1-doBEfs/wsoGGCsGjvXHeIs36eVA="
+        },
+        "data": {
+          "range": "bytes=7767-3046673",
+          "checksum": "sha256-sFsXb0Kf4YqFRgHUcP5tQfpjl/CC9G4ASIzPeUdJ/Jw="
+        },
+        "checksum": "Q1doBEfs/wsoGGCsGjvXHeIs36eVA="
+      },
+      {
+        "name": "libbrotlienc1",
+        "url": "https://packages.wolfi.dev/os/x86_64/libbrotlienc1-1.2.0-r3.apk",
+        "version": "1.2.0-r3",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-6811",
+          "checksum": "sha1-rulXUw2hoSbJX76oQVOtcU4ddP4="
+        },
+        "data": {
+          "range": "bytes=6812-446988",
+          "checksum": "sha256-MjVS+eTf1Y9Pjx9vF+tjQT+Yrisgdjr0M2p8BE9v6p4="
+        },
+        "checksum": "Q1rulXUw2hoSbJX76oQVOtcU4ddP4="
+      },
+      {
+        "name": "libuv",
+        "url": "https://packages.wolfi.dev/os/x86_64/libuv-1.52.1-r1.apk",
+        "version": "1.52.1-r1",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-6293",
+          "checksum": "sha1-ZlEHBy7u7Se1JgwURofQ2cuppn0="
+        },
+        "data": {
+          "range": "bytes=6294-128835",
+          "checksum": "sha256-/1FtLApl6ohZxfoVIa/zmqOolDw109aZjeBUL9FXwBw="
+        },
+        "checksum": "Q1ZlEHBy7u7Se1JgwURofQ2cuppn0="
+      },
+      {
+        "name": "nodejs-26",
+        "url": "https://packages.wolfi.dev/os/x86_64/nodejs-26-26.4.0-r0.apk",
+        "version": "26.4.0-r0",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-8584",
+          "checksum": "sha1-cm+0mVN7S6lhhLV73V9NlPE4qo8="
+        },
+        "data": {
+          "range": "bytes=8585-33686037",
+          "checksum": "sha256-vzrCtntcO9b5RZ2F6qfyKSDGqBCAoylme6A6aMJAjgo="
+        },
+        "checksum": "Q1cm+0mVN7S6lhhLV73V9NlPE4qo8="
+      },
+      {
+        "name": "libedit",
+        "url": "https://packages.wolfi.dev/os/x86_64/libedit-3.1-r17.apk",
+        "version": "3.1-r17",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-5303",
+          "checksum": "sha1-oW50tq89p1M8UMWWI4BtukWKXzU="
+        },
+        "data": {
+          "range": "bytes=5304-116491",
+          "checksum": "sha256-AAk8yOeI7ThYRNCmZx/Ppdmq0xfc3j62qzirOGji79k="
+        },
+        "checksum": "Q1oW50tq89p1M8UMWWI4BtukWKXzU="
+      },
+      {
+        "name": "openssh-client",
+        "url": "https://packages.wolfi.dev/os/x86_64/openssh-client-10.3_p1-r0.apk",
+        "version": "10.3_p1-r0",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-8817",
+          "checksum": "sha1-uFhgrpkHIE8GbLhM3JnvQdpXohk="
+        },
+        "data": {
+          "range": "bytes=8818-1049923",
+          "checksum": "sha256-NLDC9277z8sBR1MLdbE0VzoDItKRSu2Cm+mjtZJlHzg="
+        },
+        "checksum": "Q1uFhgrpkHIE8GbLhM3JnvQdpXohk="
+      },
+      {
+        "name": "pnpm-11.8",
+        "url": "https://packages.wolfi.dev/os/x86_64/pnpm-11.8-11.8.0-r2.apk",
+        "version": "11.8.0-r2",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-5678",
+          "checksum": "sha1-/uarb96pXhxrz42e9P1IN4aNeOA="
+        },
+        "data": {
+          "range": "bytes=5679-8764250",
+          "checksum": "sha256-Jjbg7WVWfqnFcMgYIIMzEhWeM0ms5BWLfjm3MpcgNrM="
+        },
+        "checksum": "Q1/uarb96pXhxrz42e9P1IN4aNeOA="
+      },
+      {
+        "name": "tzdata",
+        "url": "https://packages.wolfi.dev/os/x86_64/tzdata-2026b-r0.apk",
+        "version": "2026b-r0",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-4953",
+          "checksum": "sha1-XJdlhV9j7CMl4cuG6j8NS28g6RM="
+        },
+        "data": {
+          "range": "bytes=4954-569003",
+          "checksum": "sha256-B0rW1/hKVPjsWwXpOUaTPo7IEgw4QCt2qezRImwj5O0="
+        },
+        "checksum": "Q1XJdlhV9j7CMl4cuG6j8NS28g6RM="
+      },
+      {
+        "name": "wolfi-baselayout",
+        "url": "https://packages.wolfi.dev/os/aarch64/wolfi-baselayout-20230201-r29.apk",
+        "version": "20230201-r29",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-1962",
+          "checksum": "sha1-FcjlR8BAUcyRjMQxsc/f5gWSv8I="
+        },
+        "data": {
+          "range": "bytes=1963-13980",
+          "checksum": "sha256-jYse4NUqE3SQbsor532PGqEhuLikUOl38/yf1PJA1nY="
+        },
+        "checksum": "Q1FcjlR8BAUcyRjMQxsc/f5gWSv8I="
+      },
+      {
+        "name": "ca-certificates-bundle",
+        "url": "https://packages.wolfi.dev/os/aarch64/ca-certificates-bundle-20260413-r0.apk",
+        "version": "20260413-r0",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-7907",
+          "checksum": "sha1-YLGEH8o/PNCjR8sxoxh//AGpOgQ="
+        },
+        "data": {
+          "range": "bytes=7908-137552",
+          "checksum": "sha256-1NKuKrCJxco8aTxdlzNkEjM/4HyDXmO6sGOfSTiu8aE="
+        },
+        "checksum": "Q1YLGEH8o/PNCjR8sxoxh//AGpOgQ="
+      },
+      {
+        "name": "libgcc",
+        "url": "https://packages.wolfi.dev/os/aarch64/libgcc-16.1.0-r4.apk",
+        "version": "16.1.0-r4",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-9968",
+          "checksum": "sha1-0/N/tQIIDrAIbJ8QA8/iMB2bmfU="
+        },
+        "data": {
+          "range": "bytes=9969-86427",
+          "checksum": "sha256-ECrE4xEgBQV3df1UklKqzMzpglmWfjLg9FsjCGK05lc="
+        },
+        "checksum": "Q10/N/tQIIDrAIbJ8QA8/iMB2bmfU="
+      },
+      {
+        "name": "glibc-locale-posix",
+        "url": "https://packages.wolfi.dev/os/aarch64/glibc-locale-posix-2.43-r9.apk",
+        "version": "2.43-r9",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-12867",
+          "checksum": "sha1-+zjJijsP9to6HALuiBMhr0NVlUY="
+        },
+        "data": {
+          "range": "bytes=12868-89612",
+          "checksum": "sha256-xmHsrky7nLUHAGla3KoQ0OR5CjKgq07cQRAnbGhEz10="
+        },
+        "checksum": "Q1+zjJijsP9to6HALuiBMhr0NVlUY="
+      },
+      {
+        "name": "glibc",
+        "url": "https://packages.wolfi.dev/os/aarch64/glibc-2.43-r9.apk",
+        "version": "2.43-r9",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-13108",
+          "checksum": "sha1-SgCmCC0NEfW0pCwgjK28rKoFIQw="
+        },
+        "data": {
+          "range": "bytes=13109-2235391",
+          "checksum": "sha256-Wmld1mffQcj5MAfKrqQw4/lGh/NOIXxAOTwZjmQ5aRc="
+        },
+        "checksum": "Q1SgCmCC0NEfW0pCwgjK28rKoFIQw="
+      },
+      {
+        "name": "ld-linux",
+        "url": "https://packages.wolfi.dev/os/aarch64/ld-linux-2.43-r9.apk",
+        "version": "2.43-r9",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-12898",
+          "checksum": "sha1-NtAS/2IbsF9a+nRo6nqwRo0Fr1Y="
+        },
+        "data": {
+          "range": "bytes=12899-125560",
+          "checksum": "sha256-cOdCKHteGoQ95MXmpgQfR6nZaRca+RLK++IAQbp8PdE="
+        },
+        "checksum": "Q1NtAS/2IbsF9a+nRo6nqwRo0Fr1Y="
+      },
+      {
+        "name": "ncurses-terminfo-base",
+        "url": "https://packages.wolfi.dev/os/aarch64/ncurses-terminfo-base-6.6.20260620-r0.apk",
+        "version": "6.6.20260620-r0",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-9897",
+          "checksum": "sha1-zNAAHFAWUcH0rVBOVprBcC2LeeM="
+        },
+        "data": {
+          "range": "bytes=9898-116104",
+          "checksum": "sha256-1MYmHDhSB/XoDgRwOy99Tqg1Wu5UWbtFyFjLsD8TpwQ="
+        },
+        "checksum": "Q1zNAAHFAWUcH0rVBOVprBcC2LeeM="
+      },
+      {
+        "name": "ncurses",
+        "url": "https://packages.wolfi.dev/os/aarch64/ncurses-6.6.20260620-r0.apk",
+        "version": "6.6.20260620-r0",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-10038",
+          "checksum": "sha1-fK9hMrqbpJk+xE/wnTIFo/Z2jHU="
+        },
+        "data": {
+          "range": "bytes=10039-611348",
+          "checksum": "sha256-Ictbj4wh4IEM3OjRPdHOfZGWgH59KsiFDcfHHzrVkO0="
+        },
+        "checksum": "Q1fK9hMrqbpJk+xE/wnTIFo/Z2jHU="
+      },
+      {
+        "name": "bash",
+        "url": "https://packages.wolfi.dev/os/aarch64/bash-5.3-r12.apk",
+        "version": "5.3-r12",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-7959",
+          "checksum": "sha1-2dQcmgQpMxdFXBxE1gM2ittt310="
+        },
+        "data": {
+          "range": "bytes=7960-751569",
+          "checksum": "sha256-J8ZRuHXuFbZkZgkqoyaVV+y4hToTsQMuUV2qDsYkYks="
+        },
+        "checksum": "Q12dQcmgQpMxdFXBxE1gM2ittt310="
+      },
+      {
+        "name": "libxcrypt",
+        "url": "https://packages.wolfi.dev/os/aarch64/libxcrypt-4.5.2-r3.apk",
+        "version": "4.5.2-r3",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-8572",
+          "checksum": "sha1-ghgqrJg4iSn9gnlkDzpWMPFaymg="
+        },
+        "data": {
+          "range": "bytes=8573-104313",
+          "checksum": "sha256-XizRWLvfUizHwKzjGLYIFKzfDDehNmTY9yPgDFlLPS4="
+        },
+        "checksum": "Q1ghgqrJg4iSn9gnlkDzpWMPFaymg="
+      },
+      {
+        "name": "libcrypt1",
+        "url": "https://packages.wolfi.dev/os/aarch64/libcrypt1-2.43-r9.apk",
+        "version": "2.43-r9",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-12916",
+          "checksum": "sha1-sPFlEfoInhdAXY8N56FiJ8DXvGo="
+        },
+        "data": {
+          "range": "bytes=12917-14527",
+          "checksum": "sha256-V/62hyRVitwFTrfsICnclN543//ZdEgtYLZYkIfNpq4="
+        },
+        "checksum": "Q1sPFlEfoInhdAXY8N56FiJ8DXvGo="
+      },
+      {
+        "name": "busybox",
+        "url": "https://packages.wolfi.dev/os/aarch64/busybox-1.37.0-r61.apk",
+        "version": "1.37.0-r61",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-10947",
+          "checksum": "sha1-EeHjQ8oI9CX5Am00/gUwayfeglc="
+        },
+        "data": {
+          "range": "bytes=10948-429972",
+          "checksum": "sha256-TdoIXtUKXr9KtXVi4OBLcI3jzrea4+YQha1GxArzayI="
+        },
+        "checksum": "Q1EeHjQ8oI9CX5Am00/gUwayfeglc="
+      },
+      {
+        "name": "libpcre2-8-0",
+        "url": "https://packages.wolfi.dev/os/aarch64/libpcre2-8-0-10.47-r0.apk",
+        "version": "10.47-r0",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-6891",
+          "checksum": "sha1-lNf7ODNAkpMSoBvdKCbPrNH+78w="
+        },
+        "data": {
+          "range": "bytes=6892-284052",
+          "checksum": "sha256-c1gHKQBjlH7hmsX+z8z4f6UT3dWMoMQg5aqWNhDOzfs="
+        },
+        "checksum": "Q1lNf7ODNAkpMSoBvdKCbPrNH+78w="
+      },
+      {
+        "name": "libsepol",
+        "url": "https://packages.wolfi.dev/os/aarch64/libsepol-3.10-r2.apk",
+        "version": "3.10-r2",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-6388",
+          "checksum": "sha1-3X3b6mSgBdREmYQf+S5bYf8aGWo="
+        },
+        "data": {
+          "range": "bytes=6389-439116",
+          "checksum": "sha256-ENE9dzVg3nWDMDxfbeCbKnMfYS7M9+3OiabXRg8LtHo="
+        },
+        "checksum": "Q13X3b6mSgBdREmYQf+S5bYf8aGWo="
+      },
+      {
+        "name": "libselinux",
+        "url": "https://packages.wolfi.dev/os/aarch64/libselinux-3.10-r0.apk",
+        "version": "3.10-r0",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-7281",
+          "checksum": "sha1-QskYFn49nq7LobnjH7MC5SrXJ9c="
+        },
+        "data": {
+          "range": "bytes=7282-430625",
+          "checksum": "sha256-H3xcq7N/69/PG3qdcp5sNPbegnICwVAIOK9XTZhjqhw="
+        },
+        "checksum": "Q1QskYFn49nq7LobnjH7MC5SrXJ9c="
+      },
+      {
+        "name": "libacl1",
+        "url": "https://packages.wolfi.dev/os/aarch64/libacl1-2.3.2-r55.apk",
+        "version": "2.3.2-r55",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-7755",
+          "checksum": "sha1-QuETN12TZyAYavvqfsBmZl9q4Bc="
+        },
+        "data": {
+          "range": "bytes=7756-29382",
+          "checksum": "sha256-M4NWjimRiTyV0ZRBtBu7mgAQ6US97kwJjfeRVCFo27A="
+        },
+        "checksum": "Q1QuETN12TZyAYavvqfsBmZl9q4Bc="
+      },
+      {
+        "name": "libattr1",
+        "url": "https://packages.wolfi.dev/os/aarch64/libattr1-2.5.2-r56.apk",
+        "version": "2.5.2-r56",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-7815",
+          "checksum": "sha1-hPhBZnUfnSYZJaT2mL99BYPMRpY="
+        },
+        "data": {
+          "range": "bytes=7816-19489",
+          "checksum": "sha256-UGGyaST8Nl8PYbYyRfaVH/BdznHsOGqwObRCgaBzf18="
+        },
+        "checksum": "Q1hPhBZnUfnSYZJaT2mL99BYPMRpY="
+      },
+      {
+        "name": "libcrypto3",
+        "url": "https://packages.wolfi.dev/os/aarch64/libcrypto3-3.6.3-r3.apk",
+        "version": "3.6.3-r3",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-11026",
+          "checksum": "sha1-IhlZQ3XyVyqnes8zsNjtdfcdEO0="
+        },
+        "data": {
+          "range": "bytes=11027-2210037",
+          "checksum": "sha256-Z8qrYFVxk9L0+ZpEpIV/yFNFZwBgRHR+W4OPv/UJY1k="
+        },
+        "checksum": "Q1IhlZQ3XyVyqnes8zsNjtdfcdEO0="
+      },
+      {
+        "name": "coreutils",
+        "url": "https://packages.wolfi.dev/os/aarch64/coreutils-9.11-r3.apk",
+        "version": "9.11-r3",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-8727",
+          "checksum": "sha1-2Yb/JW2G7uYe+A9HO070lpzVzhw="
+        },
+        "data": {
+          "range": "bytes=8728-823973",
+          "checksum": "sha256-fEcLmh6XG5joa2S12OsF1em8bUkrERAVgQio5rScIys="
+        },
+        "checksum": "Q12Yb/JW2G7uYe+A9HO070lpzVzhw="
+      },
+      {
+        "name": "gh",
+        "url": "https://packages.wolfi.dev/os/aarch64/gh-2.95.0-r0.apk",
+        "version": "2.95.0-r0",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-5950",
+          "checksum": "sha1-vYU25qoLSPDnoqh5z7LRtwRxkxI="
+        },
+        "data": {
+          "range": "bytes=5951-14382836",
+          "checksum": "sha256-L/CwOJMKjBlAMPLR91LDBSpQKVe4m6cVjCE7vX31LCk="
+        },
+        "checksum": "Q1vYU25qoLSPDnoqh5z7LRtwRxkxI="
+      },
+      {
+        "name": "zlib",
+        "url": "https://packages.wolfi.dev/os/aarch64/zlib-1.3.2-r3.apk",
+        "version": "1.3.2-r3",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-8828",
+          "checksum": "sha1-YxX5T6R79BRPOcEnMqh9dQy7E3c="
+        },
+        "data": {
+          "range": "bytes=8829-60677",
+          "checksum": "sha256-ij7mAZJowteCp2WSpbbgRHBrOgQgSAOzkQJnpjb2xoQ="
+        },
+        "checksum": "Q1YxX5T6R79BRPOcEnMqh9dQy7E3c="
+      },
+      {
+        "name": "libexpat1",
+        "url": "https://packages.wolfi.dev/os/aarch64/libexpat1-2.8.2-r0.apk",
+        "version": "2.8.2-r0",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-8293",
+          "checksum": "sha1-Oa3OXYpm20MaYT7Hwwb+6EHklz0="
+        },
+        "data": {
+          "range": "bytes=8294-104085",
+          "checksum": "sha256-ItQWak1TtodK0+W+L3BxcYc6CysiBG6tUX6DxU7E5UQ="
+        },
+        "checksum": "Q1Oa3OXYpm20MaYT7Hwwb+6EHklz0="
+      },
+      {
+        "name": "libunistring",
+        "url": "https://packages.wolfi.dev/os/aarch64/libunistring-1.4.2-r2.apk",
+        "version": "1.4.2-r2",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-7571",
+          "checksum": "sha1-li8Uu5qbyF+ET0JXyOFf3o4pMVY="
+        },
+        "data": {
+          "range": "bytes=7572-891330",
+          "checksum": "sha256-dEmLS1PTRcIFaHF0UbyENBXkoArFt1ypwQyYxV0/TzM="
+        },
+        "checksum": "Q1li8Uu5qbyF+ET0JXyOFf3o4pMVY="
+      },
+      {
+        "name": "libidn2",
+        "url": "https://packages.wolfi.dev/os/aarch64/libidn2-2.3.8-r7.apk",
+        "version": "2.3.8-r7",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-7320",
+          "checksum": "sha1-oyp4vLkXGyi2iVxSI3I0Tq0RpGQ="
+        },
+        "data": {
+          "range": "bytes=7321-125453",
+          "checksum": "sha256-hhOPi0Ait40USn1tN3CP6+TI+dpY+DxLsykNywkeP8w="
+        },
+        "checksum": "Q1oyp4vLkXGyi2iVxSI3I0Tq0RpGQ="
+      },
+      {
+        "name": "libpsl",
+        "url": "https://packages.wolfi.dev/os/aarch64/libpsl-0.22.0-r1.apk",
+        "version": "0.22.0-r1",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-7772",
+          "checksum": "sha1-C9iAF67G2qqI39bSlooSigUBk4I="
+        },
+        "data": {
+          "range": "bytes=7773-73134",
+          "checksum": "sha256-RVW+8pu7gpCjNYNWWBhnn17+hhBJDzyFXJZbNrm4nOk="
+        },
+        "checksum": "Q1C9iAF67G2qqI39bSlooSigUBk4I="
+      },
+      {
+        "name": "libbrotlicommon1",
+        "url": "https://packages.wolfi.dev/os/aarch64/libbrotlicommon1-1.2.0-r3.apk",
+        "version": "1.2.0-r3",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-6821",
+          "checksum": "sha1-/SApRvAZSgrsxktgkdV399xr/mM="
+        },
+        "data": {
+          "range": "bytes=6822-77416",
+          "checksum": "sha256-8TGcNOOkIpkODy+lq3MmfUHfePeny/l8Q0WEd0hc1Q0="
+        },
+        "checksum": "Q1/SApRvAZSgrsxktgkdV399xr/mM="
+      },
+      {
+        "name": "libbrotlidec1",
+        "url": "https://packages.wolfi.dev/os/aarch64/libbrotlidec1-1.2.0-r3.apk",
+        "version": "1.2.0-r3",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-6841",
+          "checksum": "sha1-4R9F7Otbx35skvKpwi9lg2hlpUY="
+        },
+        "data": {
+          "range": "bytes=6842-37918",
+          "checksum": "sha256-97XHhw//ZwGo+uFQSXVpBh/rGrvwajBRVboEyU7vYK8="
+        },
+        "checksum": "Q14R9F7Otbx35skvKpwi9lg2hlpUY="
+      },
+      {
+        "name": "libssl3",
+        "url": "https://packages.wolfi.dev/os/aarch64/libssl3-3.6.3-r3.apk",
+        "version": "3.6.3-r3",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-11031",
+          "checksum": "sha1-b1pa5Bgcwm18pYPDH0t+0fM/OXw="
+        },
+        "data": {
+          "range": "bytes=11032-489215",
+          "checksum": "sha256-Ba2zY8Skdb0ILJ0vTo3C4nxRvw/Y5SOoYAvILmBcOhE="
+        },
+        "checksum": "Q1b1pa5Bgcwm18pYPDH0t+0fM/OXw="
+      },
+      {
+        "name": "ngtcp2",
+        "url": "https://packages.wolfi.dev/os/aarch64/ngtcp2-1.23.0-r0.apk",
+        "version": "1.23.0-r0",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-6429",
+          "checksum": "sha1-Mky9/PGPYht+SaKOeMMEd1LIVVg="
+        },
+        "data": {
+          "range": "bytes=6430-212313",
+          "checksum": "sha256-pSytxa4BVc7dYmCuytU4BtVq+zKjlVyyN3LmpC8IqwU="
+        },
+        "checksum": "Q1Mky9/PGPYht+SaKOeMMEd1LIVVg="
+      },
+      {
+        "name": "nghttp3",
+        "url": "https://packages.wolfi.dev/os/aarch64/nghttp3-1.17.0-r0.apk",
+        "version": "1.17.0-r0",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-6896",
+          "checksum": "sha1-7/a0w7dwRgAcLsFLEpT7Bu79y7Y="
+        },
+        "data": {
+          "range": "bytes=6897-101839",
+          "checksum": "sha256-B6ovA42qYrkJxvBvuRxqSgsKJu+B1FRLQV61vE0cqxE="
+        },
+        "checksum": "Q17/a0w7dwRgAcLsFLEpT7Bu79y7Y="
+      },
+      {
+        "name": "libnghttp2-14",
+        "url": "https://packages.wolfi.dev/os/aarch64/libnghttp2-14-1.69.0-r0.apk",
+        "version": "1.69.0-r0",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-7147",
+          "checksum": "sha1-mP91txpr44vM1/eCYJLijo/QsSA="
+        },
+        "data": {
+          "range": "bytes=7148-105255",
+          "checksum": "sha256-Lfze80E7KAtq7gMx2SJFT3AYMG0q759nd4aegte3sx0="
+        },
+        "checksum": "Q1mP91txpr44vM1/eCYJLijo/QsSA="
+      },
+      {
+        "name": "libverto",
+        "url": "https://packages.wolfi.dev/os/aarch64/libverto-0.3.2-r7.apk",
+        "version": "0.3.2-r7",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-7066",
+          "checksum": "sha1-CNQtYwNZIk4yFFx92FskJ0JCN0Q="
+        },
+        "data": {
+          "range": "bytes=7067-20599",
+          "checksum": "sha256-nUl717o9o+13BGuE5xfELpUi31c84lxCG1yIGezfwHo="
+        },
+        "checksum": "Q1CNQtYwNZIk4yFFx92FskJ0JCN0Q="
+      },
+      {
+        "name": "krb5-conf",
+        "url": "https://packages.wolfi.dev/os/aarch64/krb5-conf-1.0-r9.apk",
+        "version": "1.0-r9",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-1174",
+          "checksum": "sha1-cRVp/4tI0buRLoYjuCDJ0WoM69w="
+        },
+        "data": {
+          "range": "bytes=1175-2906",
+          "checksum": "sha256-UtQw0jJ3ZqB6dHs6oSndHBI+3sCdE0NCmy69XPYmZm8="
+        },
+        "checksum": "Q1cRVp/4tI0buRLoYjuCDJ0WoM69w="
+      },
+      {
+        "name": "keyutils-libs",
+        "url": "https://packages.wolfi.dev/os/aarch64/keyutils-libs-1.6.3-r38.apk",
+        "version": "1.6.3-r38",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-7321",
+          "checksum": "sha1-LIaKjRS0ih4BVQNOfkjd8QrL9gM="
+        },
+        "data": {
+          "range": "bytes=7322-18674",
+          "checksum": "sha256-gD7Qb5AloO3XuzBgXQsGt4UdpyU+ywOxM8ccsshKPic="
+        },
+        "checksum": "Q1LIaKjRS0ih4BVQNOfkjd8QrL9gM="
+      },
+      {
+        "name": "libcom_err",
+        "url": "https://packages.wolfi.dev/os/aarch64/libcom_err-1.47.4-r1.apk",
+        "version": "1.47.4-r1",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-8287",
+          "checksum": "sha1-DVN0DsSOJjY6/QW9goaGicFfuG8="
+        },
+        "data": {
+          "range": "bytes=8288-17345",
+          "checksum": "sha256-JJIiVXjHs200JtxLrKU77nvWzIiVAZ9CW+EMkXmQVcU="
+        },
+        "checksum": "Q1DVN0DsSOJjY6/QW9goaGicFfuG8="
+      },
+      {
+        "name": "krb5-libs",
+        "url": "https://packages.wolfi.dev/os/aarch64/krb5-libs-1.22.2-r2.apk",
+        "version": "1.22.2-r2",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-8946",
+          "checksum": "sha1-jfiCF6kV1ik1+AmecC8VktCjRzQ="
+        },
+        "data": {
+          "range": "bytes=8947-1057177",
+          "checksum": "sha256-WtiRBFfpjzmZKG6YgrD3ffnCBiYY+r068sPz4cRlVxM="
+        },
+        "checksum": "Q1jfiCF6kV1ik1+AmecC8VktCjRzQ="
+      },
+      {
+        "name": "gdbm",
+        "url": "https://packages.wolfi.dev/os/aarch64/gdbm-1.26-r5.apk",
+        "version": "1.26-r5",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-7498",
+          "checksum": "sha1-eTjamri3iEKViuf7vgYABxgQZlQ="
+        },
+        "data": {
+          "range": "bytes=7499-279492",
+          "checksum": "sha256-e1EJqZzjTNojZ1thVO1VWfmiXSKARBEuzhHdGG9fmYA="
+        },
+        "checksum": "Q1eTjamri3iEKViuf7vgYABxgQZlQ="
+      },
+      {
+        "name": "readline",
+        "url": "https://packages.wolfi.dev/os/aarch64/readline-8.3-r2.apk",
+        "version": "8.3-r2",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-6765",
+          "checksum": "sha1-2ElnZowSoKaA2mqerRlzwYmdEXc="
+        },
+        "data": {
+          "range": "bytes=6766-338510",
+          "checksum": "sha256-Pd3fAHN5e0AoYd6JXSxqwO+GjdDeuhkunLpUAR4uCS0="
+        },
+        "checksum": "Q12ElnZowSoKaA2mqerRlzwYmdEXc="
+      },
+      {
+        "name": "sqlite-libs",
+        "url": "https://packages.wolfi.dev/os/aarch64/sqlite-libs-3.53.3-r0.apk",
+        "version": "3.53.3-r0",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-5209",
+          "checksum": "sha1-9yYi+4oaKBgmd/SkzYkuTZNlOSU="
+        },
+        "data": {
+          "range": "bytes=5210-934627",
+          "checksum": "sha256-KRikZ1tqGHvlj52nrZOQoj9TAcawZlbS5Vx6terNUIM="
+        },
+        "checksum": "Q19yYi+4oaKBgmd/SkzYkuTZNlOSU="
+      },
+      {
+        "name": "heimdal-libs",
+        "url": "https://packages.wolfi.dev/os/aarch64/heimdal-libs-7.8.0-r49.apk",
+        "version": "7.8.0-r49",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-9209",
+          "checksum": "sha1-U/tgaW7o0Z1sLZ7cJL1kczD+iWw="
+        },
+        "data": {
+          "range": "bytes=9210-1409453",
+          "checksum": "sha256-CtoYnwpFLtghHqhnVJb8J8BpKtJBkNcKB3xibKWNmvo="
+        },
+        "checksum": "Q1U/tgaW7o0Z1sLZ7cJL1kczD+iWw="
+      },
+      {
+        "name": "cyrus-sasl-heimdal-libs",
+        "url": "https://packages.wolfi.dev/os/aarch64/cyrus-sasl-heimdal-libs-2.1.28-r52.apk",
+        "version": "2.1.28-r52",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-9802",
+          "checksum": "sha1-Dawzz5REmzpgehFltC2vMGTNnTg="
+        },
+        "data": {
+          "range": "bytes=9803-240118",
+          "checksum": "sha256-/berZd4fRJ6y/TdIa4Juy4XrDx2Y55/bkUTgIUN5mww="
+        },
+        "checksum": "Q1Dawzz5REmzpgehFltC2vMGTNnTg="
+      },
+      {
+        "name": "libldap-2.6",
+        "url": "https://packages.wolfi.dev/os/aarch64/libldap-2.6-2.6.13-r4.apk",
+        "version": "2.6.13-r4",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-14281",
+          "checksum": "sha1-2af1B1RzuXO6JpxXz766vyx10tA="
+        },
+        "data": {
+          "range": "bytes=14282-246313",
+          "checksum": "sha256-g+K9wOnM4BTKEIl1v8qGqmBL6lS18ahsduoZ3rQyWq0="
+        },
+        "checksum": "Q12af1B1RzuXO6JpxXz766vyx10tA="
+      },
+      {
+        "name": "libcurl-openssl4",
+        "url": "https://packages.wolfi.dev/os/aarch64/libcurl-openssl4-8.21.0-r0.apk",
+        "version": "8.21.0-r0",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-12904",
+          "checksum": "sha1-mQ//4RbGngY83J/ZXCHhbwQWaFU="
+        },
+        "data": {
+          "range": "bytes=12905-543100",
+          "checksum": "sha256-WUH5p5+MGliAQBg8hevUTxY3CshUJvaGdtXmhjAA5Kk="
+        },
+        "checksum": "Q1mQ//4RbGngY83J/ZXCHhbwQWaFU="
+      },
+      {
+        "name": "git",
+        "url": "https://packages.wolfi.dev/os/aarch64/git-2.54.0-r1.apk",
+        "version": "2.54.0-r1",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-12417",
+          "checksum": "sha1-k8IJo/V6dEok4TJvBY8eyPLKHRc="
+        },
+        "data": {
+          "range": "bytes=12418-9122020",
+          "checksum": "sha256-BfQv6P/vRmjz/VzGfkZ/l0Zk9v8683P8XJ+64er1Hh0="
+        },
+        "checksum": "Q1k8IJo/V6dEok4TJvBY8eyPLKHRc="
+      },
+      {
+        "name": "go-1.26",
+        "url": "https://packages.wolfi.dev/os/aarch64/go-1.26-1.26.4-r1.apk",
+        "version": "1.26.4-r1",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-7923",
+          "checksum": "sha1-jKH+oZ2TweiVbH2CFgpYlH0+DnQ="
+        },
+        "data": {
+          "range": "bytes=7924-53954351",
+          "checksum": "sha256-nmwNXQD83fI24szEDwV0eL+NHTbgBm59VbGwYtvsL7o="
+        },
+        "checksum": "Q1jKH+oZ2TweiVbH2CFgpYlH0+DnQ="
+      },
+      {
+        "name": "c-ares",
+        "url": "https://packages.wolfi.dev/os/aarch64/c-ares-1.34.6-r1.apk",
+        "version": "1.34.6-r1",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-7642",
+          "checksum": "sha1-oGgIcRsfsEm1GV6BqEoN3CXxAdc="
+        },
+        "data": {
+          "range": "bytes=7643-151486",
+          "checksum": "sha256-UUa8BJUaEPwK08JLDLh+DQJY4zpbMx3Dv2E8LyFpFG4="
+        },
+        "checksum": "Q1oGgIcRsfsEm1GV6BqEoN3CXxAdc="
+      },
+      {
+        "name": "icu78-data-full",
+        "url": "https://packages.wolfi.dev/os/aarch64/icu78-data-full-78.3-r1.apk",
+        "version": "78.3-r1",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-7698",
+          "checksum": "sha1-/vCM27CcICaymtO0luSBaJg22d4="
+        },
+        "data": {
+          "range": "bytes=7699-14026916",
+          "checksum": "sha256-F8CQub8+rDi67BIfhgrXx61uvKVTyp4nS9ayuhjBXvI="
+        },
+        "checksum": "Q1/vCM27CcICaymtO0luSBaJg22d4="
+      },
+      {
+        "name": "libstdc++",
+        "url": "https://packages.wolfi.dev/os/aarch64/libstdc++-16.1.0-r4.apk",
+        "version": "16.1.0-r4",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-9975",
+          "checksum": "sha1-UknHYoUowwYP/yjIaxIFq8CaEUg="
+        },
+        "data": {
+          "range": "bytes=9976-1178043",
+          "checksum": "sha256-LFku50w/HG35xaMJmM1fWes2JiJR31JYex1BzQNfwrk="
+        },
+        "checksum": "Q1UknHYoUowwYP/yjIaxIFq8CaEUg="
+      },
+      {
+        "name": "libicu78",
+        "url": "https://packages.wolfi.dev/os/aarch64/libicu78-78.3-r1.apk",
+        "version": "78.3-r1",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-7796",
+          "checksum": "sha1-vEMLGuaA4aiTC9W/0ulD8iiDcH0="
+        },
+        "data": {
+          "range": "bytes=7797-2930435",
+          "checksum": "sha256-B2sq31ZTqTO+jl71BmB7vuAQkJekKpJkdBKwcYWaRPE="
+        },
+        "checksum": "Q1vEMLGuaA4aiTC9W/0ulD8iiDcH0="
+      },
+      {
+        "name": "libbrotlienc1",
+        "url": "https://packages.wolfi.dev/os/aarch64/libbrotlienc1-1.2.0-r3.apk",
+        "version": "1.2.0-r3",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-6844",
+          "checksum": "sha1-CuMepwtD0fww/kU1KGk+amHPekE="
+        },
+        "data": {
+          "range": "bytes=6845-422787",
+          "checksum": "sha256-w9KQ2jduBh2Srk2ETebG9JmEhkMQgLwh06izrYKLYmw="
+        },
+        "checksum": "Q1CuMepwtD0fww/kU1KGk+amHPekE="
+      },
+      {
+        "name": "libuv",
+        "url": "https://packages.wolfi.dev/os/aarch64/libuv-1.52.1-r1.apk",
+        "version": "1.52.1-r1",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-6344",
+          "checksum": "sha1-YPCMJK+s9uMtpWcDe2RcT/fl/qg="
+        },
+        "data": {
+          "range": "bytes=6345-123976",
+          "checksum": "sha256-MGHTT7qigAXD1l+QHLpgtf1V82+xB237mbu4Qb09A0c="
+        },
+        "checksum": "Q1YPCMJK+s9uMtpWcDe2RcT/fl/qg="
+      },
+      {
+        "name": "nodejs-26",
+        "url": "https://packages.wolfi.dev/os/aarch64/nodejs-26-26.4.0-r0.apk",
+        "version": "26.4.0-r0",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-8609",
+          "checksum": "sha1-UcNX0Ew3pxPZLVNEr29Fj5AHTnU="
+        },
+        "data": {
+          "range": "bytes=8610-32551102",
+          "checksum": "sha256-QW+Qiikaoc5gU9mE+I/vByIgKf6u6HnikH0ufNtFe8c="
+        },
+        "checksum": "Q1UcNX0Ew3pxPZLVNEr29Fj5AHTnU="
+      },
+      {
+        "name": "libedit",
+        "url": "https://packages.wolfi.dev/os/aarch64/libedit-3.1-r17.apk",
+        "version": "3.1-r17",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-5344",
+          "checksum": "sha1-fonnZIP5/0v7uIbPBWaxwIvyitg="
+        },
+        "data": {
+          "range": "bytes=5345-117560",
+          "checksum": "sha256-AyOjEbrFjlqLk19So80uGzXBuq5QkCyKzNQllCJwW58="
+        },
+        "checksum": "Q1fonnZIP5/0v7uIbPBWaxwIvyitg="
+      },
+      {
+        "name": "openssh-client",
+        "url": "https://packages.wolfi.dev/os/aarch64/openssh-client-10.3_p1-r0.apk",
+        "version": "10.3_p1-r0",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-8847",
+          "checksum": "sha1-+CHRUZYARzel52mEbtNYDPtFxJM="
+        },
+        "data": {
+          "range": "bytes=8848-1039641",
+          "checksum": "sha256-q9FdIrK+guiGQvuBZz1mJVMgsSsLT3w0gil1fDZpCSU="
+        },
+        "checksum": "Q1+CHRUZYARzel52mEbtNYDPtFxJM="
+      },
+      {
+        "name": "pnpm-11.8",
+        "url": "https://packages.wolfi.dev/os/aarch64/pnpm-11.8-11.8.0-r2.apk",
+        "version": "11.8.0-r2",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-5709",
+          "checksum": "sha1-nEwUqz2QV0XPl+fO2ggNhvkqybs="
+        },
+        "data": {
+          "range": "bytes=5710-8764270",
+          "checksum": "sha256-psaWo4oWUOyoxsW3AsuycD/AWY8QRBE+TIrvt+P0p/I="
+        },
+        "checksum": "Q1nEwUqz2QV0XPl+fO2ggNhvkqybs="
+      },
+      {
+        "name": "tzdata",
+        "url": "https://packages.wolfi.dev/os/aarch64/tzdata-2026b-r0.apk",
+        "version": "2026b-r0",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-4981",
+          "checksum": "sha1-yyT/D58O4t2lena7GdWWe3wxvgU="
+        },
+        "data": {
+          "range": "bytes=4982-569029",
+          "checksum": "sha256-hm5zEK9X026bZXMhXLzowUw9Xnq+9hvgwpw7R47GIXg="
+        },
+        "checksum": "Q1yyT/D58O4t2lena7GdWWe3wxvgU="
+      }
+    ]
+  }
+}

--- a/projects/agent_platform/harness/apko.yaml
+++ b/projects/agent_platform/harness/apko.yaml
@@ -1,0 +1,66 @@
+contents:
+  repositories:
+    - https://packages.wolfi.dev/os
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+  packages:
+    - bash
+    - busybox
+    - ca-certificates-bundle
+    - coreutils
+    - git
+    - gh
+    - go
+    - nodejs
+    - openssh-client
+    - pnpm
+    - tzdata
+
+archs:
+  - x86_64
+  - aarch64
+
+accounts:
+  groups:
+    - groupname: goose-agent
+      gid: 65532
+  users:
+    - username: goose-agent
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+environment:
+  TZ: Europe/Dublin
+  HOME: /home/goose-agent
+  GIT_SSH_COMMAND: ssh -o StrictHostKeyChecking=no
+
+paths:
+  - path: /home/goose-agent
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+  - path: /home/goose-agent/.ssh
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o700
+  - path: /home/goose-agent/.config/goose
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+  - path: /home/goose-agent/.claude
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+  - path: /workspace
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+
+entrypoint:
+  command: /usr/local/bin/fc-agent-init

--- a/projects/agent_platform/harness/config.yaml
+++ b/projects/agent_platform/harness/config.yaml
@@ -1,0 +1,22 @@
+# Goose configuration baked into the goose-agent container image.
+# Provider and model are set via environment variables (GOOSE_PROVIDER, GOOSE_MODEL)
+# injected by the SandboxTemplate, not hardcoded here.
+#
+# Extensions configured:
+#   - developer (builtin): filesystem, shell, editor scoped to /workspace
+#   - context-forge (remote): SigNoz observability, ArgoCD, Kubernetes via MCP gateway
+#     In-cluster access via ClusterIP — no auth required (see ADR 006).
+#   - github: gh CLI is available in PATH (with GITHUB_TOKEN) for PR/issue operations
+extensions:
+  developer:
+    bundled: true
+    enabled: true
+    name: developer
+    timeout: 300
+    type: builtin
+  context-forge:
+    enabled: true
+    name: context-forge
+    timeout: 300
+    type: streamable_http
+    uri: http://context-forge-gateway-mcp-stack-mcpgateway.mcp.svc.cluster.local:80/mcp/

--- a/projects/agent_platform/harness/recipes/agent.yaml
+++ b/projects/agent_platform/harness/recipes/agent.yaml
@@ -1,0 +1,35 @@
+version: "1.0.0"
+title: "Agent"
+description: "General coding agent for a snapshot-managed microVM thread (ADR 022)."
+instructions: |
+  You are an autonomous coding agent working inside an isolated Firecracker
+  microVM, on a checkout of the repo at /workspace.
+
+  Do the task described below. Use the shell and editor to read, edit, build,
+  and test. Commit with Conventional Commits and push a claude/-prefixed branch
+  if the task calls for code changes.
+
+  ## Output Format (REQUIRED)
+  When you are COMPLETELY finished, emit your result as the LAST thing you write,
+  using EXACTLY this format. Nothing after the closing marker.
+
+  ```goose-result
+  type: pr | issue | note
+  url: <artifact URL, if any>
+  summary: <1-2 sentences: the action you took and the outcome>
+  ```
+
+  The summary describes the ACTION and RESULT, not your reasoning.
+prompt: |
+  {{ task_description | indent(2) }}
+parameters:
+  - key: task_description
+    description: "The task to perform"
+    input_type: string
+    requirement: required
+extensions:
+  - type: builtin
+    name: developer
+settings:
+  max_turns: 50
+  max_tool_repetitions: 5

--- a/projects/agent_platform/harness/recipes/code-fix.yaml
+++ b/projects/agent_platform/harness/recipes/code-fix.yaml
@@ -1,0 +1,41 @@
+version: "1.0.0"
+title: "Code Fix"
+description: "Fix code issues without cluster access"
+instructions: |
+  Fix the described issue in the homelab repo.
+  Run bazel test //... to verify your changes.
+  Commit using conventional commits format and create a PR.
+
+  ## Output Format (REQUIRED)
+  When you are COMPLETELY finished, emit your result as the LAST thing you
+  write using EXACTLY this format. Nothing after the closing marker.
+
+  ```goose-result
+  type: pr | issue
+  url: <artifact URL>
+  summary: <1-2 sentences: what you did and the outcome>
+  ```
+
+  The summary must describe the ACTION you took and the RESULT, not your reasoning.
+  Good: "Fixed missing healthcheck port in signoz values.yaml. PR passes CI."
+  Bad: "I investigated the issue and found that the healthcheck port was misconfigured..."
+
+  If you created a PR, use type: pr. If you found a problem you cannot fix, create a
+  GitHub issue and use type: issue.
+prompt: |
+  {{ task_description | indent(2) }}
+parameters:
+  - key: task_description
+    description: "The task to perform"
+    input_type: string
+    requirement: required
+extensions:
+  - type: builtin
+    name: developer
+  - type: streamable_http
+    name: context-forge
+    uri: http://context-forge-gateway-mcp-stack-mcpgateway.mcp.svc.cluster.local:80/mcp/
+    timeout: 300
+settings:
+  max_turns: 50
+  max_tool_repetitions: 5

--- a/projects/agent_platform/harness/recipes/docs.yaml
+++ b/projects/agent_platform/harness/recipes/docs.yaml
@@ -1,0 +1,57 @@
+version: "1.0.0"
+title: "Documentation"
+description: "Create or update documentation, READMEs, and the VitePress docs site"
+instructions: |
+  You are writing or updating documentation in the homelab repo.
+  Common tasks include:
+  - Updating the VitePress docs site (docs/) after infrastructure changes
+  - Writing or updating READMEs for services and tools
+  - Documenting a service, chart, or tool for the first time
+  - Updating existing docs to reflect current state
+
+  When updating docs after a change:
+  - Use cluster tools to verify the CURRENT state of the system
+  - Read the existing docs to understand the current structure and tone
+  - Be accurate — documentation that contradicts reality is worse than none
+
+  For the VitePress site:
+  - Follow existing sidebar/nav structure
+  - Use consistent markdown formatting with existing pages
+  - Add new pages to the sidebar config if needed
+
+  Commit using conventional commits format (docs: prefix) and create a PR.
+  DO NOT use kubectl or argocd CLI commands — use MCP tools only.
+
+  ## Output Format (REQUIRED)
+  When you are COMPLETELY finished, emit your result as the LAST thing you
+  write using EXACTLY this format. Nothing after the closing marker.
+
+  ```goose-result
+  type: pr | issue
+  url: <artifact URL>
+  summary: <1-2 sentences: what you did and the outcome>
+  ```
+
+  The summary must describe the ACTION you took and the RESULT, not your reasoning.
+  Good: "Added agent-platform architecture docs with job lifecycle diagram. PR passes CI."
+  Bad: "I read through the existing documentation and added a new section..."
+
+  If you created a PR, use type: pr. If you found a problem you cannot fix, create a
+  GitHub issue and use type: issue.
+prompt: |
+  {{ task_description | indent(2) }}
+parameters:
+  - key: task_description
+    description: "What to document or update"
+    input_type: string
+    requirement: required
+extensions:
+  - type: builtin
+    name: developer
+  - type: streamable_http
+    name: context-forge
+    uri: http://context-forge-gateway-mcp-stack-mcpgateway.mcp.svc.cluster.local:80/mcp/
+    timeout: 300
+settings:
+  max_turns: 40
+  max_tool_repetitions: 5

--- a/projects/agent_platform/harness/recipes/feature.yaml
+++ b/projects/agent_platform/harness/recipes/feature.yaml
@@ -1,0 +1,44 @@
+version: "1.0.0"
+title: "Feature"
+description: "Implement a new feature with tests"
+instructions: |
+  Implement the described feature in the homelab repo.
+  Follow existing patterns and conventions in the codebase.
+  Write tests for your implementation.
+  Run bazel test //... to verify your changes.
+  Commit using conventional commits format (feat: prefix) and create a PR.
+  DO NOT use kubectl or argocd CLI commands.
+
+  ## Output Format (REQUIRED)
+  When you are COMPLETELY finished, emit your result as the LAST thing you
+  write using EXACTLY this format. Nothing after the closing marker.
+
+  ```goose-result
+  type: pr | issue
+  url: <artifact URL>
+  summary: <1-2 sentences: what you did and the outcome>
+  ```
+
+  The summary must describe the ACTION you took and the RESULT, not your reasoning.
+  Good: "Added webhook retry logic with exponential backoff. Tests pass, PR ready."
+  Bad: "I looked at the codebase and decided to add retry logic..."
+
+  If you created a PR, use type: pr. If you found a problem you cannot fix, create a
+  GitHub issue and use type: issue.
+prompt: |
+  {{ task_description | indent(2) }}
+parameters:
+  - key: task_description
+    description: "The feature to implement"
+    input_type: string
+    requirement: required
+extensions:
+  - type: builtin
+    name: developer
+  - type: streamable_http
+    name: context-forge
+    uri: http://context-forge-gateway-mcp-stack-mcpgateway.mcp.svc.cluster.local:80/mcp/
+    timeout: 300
+settings:
+  max_turns: 50
+  max_tool_repetitions: 5

--- a/projects/agent_platform/harness/recipes/pr-review.yaml
+++ b/projects/agent_platform/harness/recipes/pr-review.yaml
@@ -1,0 +1,48 @@
+version: "1.0.0"
+title: "PR Review"
+description: "Review a pull request and post feedback"
+instructions: |
+  Review the specified pull request on the homelab repo.
+  Use the GitHub extension to read the PR diff, comments, and description.
+  Evaluate the changes for:
+  - Correctness: logic errors, edge cases, off-by-one mistakes
+  - Style: consistency with existing codebase patterns
+  - Security: injection, secrets, OWASP top 10
+  - Tests: adequate coverage of new/changed behavior
+
+  Post your review as a GitHub PR review using the GitHub extension.
+  Use APPROVE if the PR looks good, REQUEST_CHANGES if there are blocking issues,
+  or COMMENT for non-blocking suggestions.
+
+  DO NOT modify any files or create commits. This is a read-only review.
+
+  ## Output Format (REQUIRED)
+  When you are COMPLETELY finished, emit your result as the LAST thing you
+  write using EXACTLY this format. Nothing after the closing marker.
+
+  ```goose-result
+  type: pr
+  url: <PR URL>
+  summary: <1-2 sentences: review verdict and key findings>
+  ```
+
+  The summary must describe your VERDICT and KEY FINDINGS, not your process.
+  Good: "Approved PR #42. Clean implementation, one minor suggestion on error handling."
+  Bad: "I read through the diff and checked for issues..."
+prompt: |
+  {{ task_description | indent(2) }}
+parameters:
+  - key: task_description
+    description: "The PR number or URL to review"
+    input_type: string
+    requirement: required
+extensions:
+  - type: builtin
+    name: developer
+  - type: streamable_http
+    name: context-forge
+    uri: http://context-forge-gateway-mcp-stack-mcpgateway.mcp.svc.cluster.local:80/mcp/
+    timeout: 300
+settings:
+  max_turns: 30
+  max_tool_repetitions: 5

--- a/projects/agent_platform/harness/recipes/research.yaml
+++ b/projects/agent_platform/harness/recipes/research.yaml
@@ -1,0 +1,48 @@
+version: "1.0.0"
+title: "Research"
+description: "Investigate infrastructure topics and produce a written report"
+instructions: |
+  You are researching a topic related to the homelab infrastructure.
+  Use cluster tools (Kubernetes, ArgoCD, SigNoz, BuildBuddy) to gather data.
+  Write your findings as a clear, structured markdown document.
+  DO NOT modify any files, create commits, or open PRs.
+  DO NOT use kubectl or argocd CLI commands — use MCP tools only.
+
+  When your research is complete, create a GitHub gist with your findings
+  using the GitHub extension (gh gist create).
+
+  ## Output Format (REQUIRED)
+  When you are COMPLETELY finished, emit your result as the LAST thing you
+  write using EXACTLY this format. Nothing after the closing marker.
+
+  ```goose-result
+  type: gist | issue
+  url: <gist or issue URL>
+  summary: <1-2 sentences: what you investigated and the key finding>
+  ```
+
+  The summary must describe what you INVESTIGATED and the KEY FINDING, not your process.
+  Good: "Investigated SigNoz trace sampling config. Current rate is 10%, recommend 25% for full coverage."
+  Bad: "I used the MCP tools to look at the SigNoz configuration and found some settings..."
+
+  If your research reveals a problem that needs fixing, create a GitHub issue
+  and use type: issue instead.
+prompt: |
+  {{ task_description | indent(2) }}
+
+  REMINDER: When finished, create a GitHub gist with your findings and emit the goose-result block as the LAST thing you write.
+parameters:
+  - key: task_description
+    description: "The research question or topic to investigate"
+    input_type: string
+    requirement: required
+extensions:
+  - type: builtin
+    name: developer
+  - type: streamable_http
+    name: context-forge
+    uri: http://context-forge-gateway-mcp-stack-mcpgateway.mcp.svc.cluster.local:80/mcp/
+    timeout: 300
+settings:
+  max_turns: 60
+  max_tool_repetitions: 15


### PR DESCRIPTION
## What

**Plan B, step B1**: the agent harness that runs *inside* a snapshot-managed Firecracker microVM (ADR 022). Revives the deleted `goose_agent` image as `projects/agent_platform/harness`, adapted for the microVM model.

## Design

- **apko base** (Wolfi: git/gh/go/node/pnpm) + the **Goose** binary (`@goose`, block/goose v1.27.1) + **`fc-agent-init` as PID 1** (entrypoint).
- `fc-agent-init` launches a **turn-capped** `goose run --recipe <r> --no-profile --params task_description=<task>`. The recipe's `settings.max_turns` (50) + `max_tool_repetitions` (5) bound the run, and the **between-turns boundary is the quiescent point** the controller snapshots on — so "limit turns with Goose" *is* the idle-detection seam (ADR 022).
- Model: Goose talks to the model directly via `GOOSE_PROVIDER`/`GOOSE_MODEL` env (in-cluster Qwen, OpenAI-compatible, for the first proof). No Claude CLI / agent-runner / BuildBuddy-CLI layers — minimal first image.

## Changes

- `fc-agent-init/internal/harness`: `GooseCommand(recipe, task)` (unit-tested), wired into the PID-1 launch (`FC_GOOSE_RECIPE` + `FC_TASK`).
- `harness/`: `apko.yaml` (entrypoint `fc-agent-init`), re-locked `apko.lock.json`, baked goose config, recovered recipe library + a generic turn-capped `agent.yaml` (developer extension only, isolated first proof).
- `MODULE.bazel`: `harness_lock` apko translate_lock (`@goose` was already present). Registers the image in `push_all`.

## Verification

- `go test ./projects/agent_platform/fc-agent-init/...` green (harness command builder).
- apko re-locked against current Wolfi; pre-commit apko-lock + format + semgrep all pass.
- The apko image build itself validates on BuildBuddy CI.

## Next (this branch / follow-ons)

- **B2**: flatten the image to a bootable ext4 base rootfs on `/disks/nvme-02` (node-4 host op).
- **B3**: `fc-agentd` driver provisions a per-thread rootfs + boots FC with it.
- **B4-B6**: warm base, vsock idle signal, `firecracker.enabled=true` + real boot→snapshot→restore.

Note: the unrelated `TestDriverWarmBaseStartReusesBaseBundle` failure on macOS local is the `sun_path` 104-char limit on long `t.TempDir()` socket paths (green in CI on linux); a small test-portability fix is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)