### PR TITLE
feat(mcp): periodic Context Forge tool-catalog refresh CronJob

### DIFF
--- a/projects/mcp/context-forge-gateway/chart/Chart.yaml
+++ b/projects/mcp/context-forge-gateway/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: context-forge
 description: MCP gateway aggregating observability and infrastructure tools
 type: application
-version: 3.0.0
+version: 3.1.0
 appVersion: "1.0.0-RC1"
 annotations:
   org.opencontainers.image.source: "https://github.com/jomcgi/homelab"

--- a/projects/mcp/context-forge-gateway/chart/templates/tool-refresh-cronjob.yaml
+++ b/projects/mcp/context-forge-gateway/chart/templates/tool-refresh-cronjob.yaml
@@ -1,0 +1,105 @@
+{{- if .Values.toolRefresh.enabled }}
+# Periodic Context Forge tool-catalog refresh.
+#
+# CF caches each gateway's tool catalog in its own Postgres and does NOT
+# re-discover on its own: its auto-refresh runs inside the health-check loop and
+# only fires after a healthy tick, but that loop speaks streamablehttp while the
+# monolith gateway serves SSE, so the monolith gateway's last_seen never advances
+# and CF's built-in auto-refresh never fires for it. Without this, every new or
+# changed monolith MCP tool stays invisible to the homelab connector until
+# someone POSTs the refresh endpoint by hand.
+#
+# This CronJob mints a short-lived admin JWT (JWT_SECRET_KEY + PLATFORM_ADMIN_EMAIL
+# come from the context-forge secret, the same envFrom the gateway uses), looks
+# up the target gateway id by name, and POSTs /gateways/{id}/tools/refresh. It
+# reuses the gateway image, which already bundles mcpgateway + httpx.
+#
+# The pod opts out of the Linkerd mesh (linkerd.io/inject: disabled) so the
+# proxy sidecar does not keep the Job alive forever; it reaches the meshed
+# gateway over plaintext on the in-cluster Service.
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ .Release.Name }}-tool-refresh
+  labels:
+    {{- include "context-forge.labels" . | nindent 4 }}
+spec:
+  schedule: {{ .Values.toolRefresh.schedule | quote }}
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  startingDeadlineSeconds: 120
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      activeDeadlineSeconds: {{ .Values.toolRefresh.activeDeadlineSeconds }}
+      ttlSecondsAfterFinished: 600
+      template:
+        metadata:
+          labels:
+            {{- include "context-forge.selectorLabels" . | nindent 12 }}
+          annotations:
+            linkerd.io/inject: disabled
+        spec:
+          restartPolicy: Never
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1001
+            runAsGroup: 0
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+            - name: tool-refresh
+              image: "{{ .Values.toolRefresh.image.repository }}:{{ .Values.toolRefresh.image.tag }}"
+              imagePullPolicy: {{ .Values.toolRefresh.image.pullPolicy }}
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                capabilities:
+                  drop:
+                    - ALL
+              envFrom:
+                - secretRef:
+                    name: {{ .Values.secret.name }}
+              env:
+                - name: CF_GATEWAY_URL
+                  value: "http://{{ .Release.Name }}-mcp-stack-mcpgateway:80"
+                - name: CF_GATEWAY_NAME
+                  value: {{ .Values.toolRefresh.gatewayName | quote }}
+                - name: HOME
+                  value: /tmp
+                - name: TMPDIR
+                  value: /tmp
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -e
+                  TOKEN=$(python3 -m mcpgateway.utils.create_jwt_token -u "$PLATFORM_ADMIN_EMAIL" --admin -e 600 | tail -1)
+                  export TOKEN
+                  python3 - <<'PY'
+                  import os, httpx
+                  base = os.environ["CF_GATEWAY_URL"]
+                  name = os.environ["CF_GATEWAY_NAME"]
+                  headers = {"Authorization": "Bearer " + os.environ["TOKEN"]}
+                  resp = httpx.get(f"{base}/gateways", headers=headers, timeout=30)
+                  resp.raise_for_status()
+                  body = resp.json()
+                  # The API may return a bare list or wrap it; handle both.
+                  items = body if isinstance(body, list) else body.get("data", body.get("gateways", []))
+                  gid = next((g["id"] for g in items if g.get("name") == name), None)
+                  if not gid:
+                      raise SystemExit(f"gateway {name!r} not found among {len(items)} gateways")
+                  r = httpx.post(f"{base}/gateways/{gid}/tools/refresh", headers=headers, timeout=90)
+                  print(name, r.status_code, r.text[:400])
+                  r.raise_for_status()
+                  PY
+              resources:
+                {{- toYaml .Values.toolRefresh.resources | nindent 16 }}
+              volumeMounts:
+                - name: tmp
+                  mountPath: /tmp
+          volumes:
+            - name: tmp
+              emptyDir: {}
+{{- end }}

--- a/projects/mcp/context-forge-gateway/chart/values.yaml
+++ b/projects/mcp/context-forge-gateway/chart/values.yaml
@@ -101,3 +101,28 @@ httpRoute:
   gatewayRef:
     name: cloudflare-ingress
     namespace: envoy-gateway-system
+
+# Periodic tool-catalog refresh. CF does not auto-discover new monolith MCP
+# tools (its health-gated auto-refresh never fires for the SSE monolith gateway,
+# whose last_seen never advances under the streamablehttp health tick), so a
+# CronJob POSTs the gateways/<id>/tools/refresh admin endpoint on a schedule.
+# Reuses the gateway image (bundles mcpgateway + httpx) and the context-forge
+# secret (JWT_SECRET_KEY + PLATFORM_ADMIN_EMAIL) to mint a short-lived admin JWT.
+toolRefresh:
+  enabled: true
+  # Every 10 minutes: tool changes follow a monolith rollout, not a tight loop.
+  schedule: "*/10 * * * *"
+  # Cap each run's lifetime so a hung refresh pod cannot linger.
+  activeDeadlineSeconds: 120
+  # Gateway whose catalog to refresh, matched by name via the gateways API.
+  gatewayName: monolith
+  image:
+    repository: ghcr.io/ibm/mcp-context-forge
+    tag: "v1.0.0-RC1"
+    pullPolicy: IfNotPresent
+  resources:
+    requests:
+      cpu: 10m
+      memory: 128Mi
+    limits:
+      memory: 128Mi


### PR DESCRIPTION
## What

Adds a CronJob (ns `mcp`) that refreshes Context Forge's tool catalog every 10 minutes, so new/changed monolith MCP tools appear through the homelab connector without a manual refresh.

## Why

CF caches each gateway's tool catalog in its own Postgres and does **not** re-discover automatically. Its built-in auto-refresh runs inside the health-check loop and only fires after a healthy tick, but that loop speaks `streamablehttp` while the monolith gateway serves `SSE` (`http_app(transport="sse")` mounted at `/mcp`). So the monolith gateway's `last_seen` never advances (it's frozen at 2026-06-09) and CF's own auto-refresh never fires for it. The symptom this fixes: the ADR 022 agent-thread dispatch tools (`submit_agent_task`, `list/get/resume_agent_thread`, `wake_agent_thread_for_discord`) were invisible to the connector until POSTing the refresh endpoint by hand.

Flipping `AUTO_REFRESH_SERVERS=true` alone would be a no-op for exactly the gateway we care about, hence the out-of-band CronJob.

## How

Each run:
1. Mints a short-lived admin JWT via `python3 -m mcpgateway.utils.create_jwt_token` (reads `JWT_SECRET_KEY` + `PLATFORM_ADMIN_EMAIL` from the `context-forge` secret via `envFrom`, same as the gateway).
2. `GET /gateways`, resolves the target gateway id by name (`monolith`).
3. `POST /gateways/{id}/tools/refresh`.

Details:
- Reuses the gateway image (`ghcr.io/ibm/mcp-context-forge:v1.0.0-RC1`) which already bundles `mcpgateway` + `httpx`.
- Runs non-root (`uid 1001`, matching the image's `app` user), read-only rootfs (+ emptyDir `/tmp`), all caps dropped.
- Opts out of the Linkerd mesh (`linkerd.io/inject: disabled`) so the proxy sidecar doesn't keep the Job alive forever; reaches the meshed gateway over plaintext on the in-cluster Service.
- Gated behind `toolRefresh.enabled` (default `true`); `gatewayName`, `schedule`, and `activeDeadlineSeconds` are configurable.

## Validation

The refresh script logic (mint JWT → resolve gateway id by name → POST refresh) was run inside the live CF pod against `localhost:4444`: resolved `monolith` → `4a0481da...`, `POST .../tools/refresh` returned `200 success:true`. `helm template` confirms the rendered CronJob (mesh opt-out, non-root, mounts, service URL `context-forge-gateway-mcp-stack-mcpgateway:80`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)