### PR TITLE
feat(agent_platform): fc-agentd B5 snapshot-on-idle (Task 5)

### DIFF
--- a/projects/agent_platform/fc-agentd/chart/Chart.yaml
+++ b/projects/agent_platform/fc-agentd/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: fc-agentd
 description: Firecracker snapshot/restore controller (ADR 022) - the node-4 Postgres-reconcile daemon that manages agent-thread microVMs
 type: application
-version: 0.4.0
+version: 0.5.0
 appVersion: "latest"
 keywords:
   - firecracker

--- a/projects/agent_platform/fc-agentd/deploy/application.yaml
+++ b/projects/agent_platform/fc-agentd/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: fc-agentd
-      targetRevision: 0.4.0
+      targetRevision: 0.5.0
       helm:
         valueFiles:
           - $values/projects/agent_platform/fc-agentd/deploy/values.yaml

--- a/projects/agent_platform/fc-agentd/internal/reconcile/reconcile.go
+++ b/projects/agent_platform/fc-agentd/internal/reconcile/reconcile.go
@@ -28,6 +28,7 @@ type Registry interface {
 	ListWakeRequestedForNode(ctx context.Context, node string) ([]store.Thread, error)
 	ListIdleExpiredForNode(ctx context.Context, node string) ([]store.Thread, error)
 	SetState(ctx context.Context, threadID string, state substrate.State) error
+	SetThreadSnapshot(ctx context.Context, threadID, ref string, sizeBytes int64) error
 	ClearWake(ctx context.Context, threadID string) error
 	Delete(ctx context.Context, threadID string) error
 }
@@ -61,6 +62,15 @@ type Loop struct {
 
 	live    map[string]substrate.Handle   // threadID -> live microVM handle
 	control map[string]context.CancelFunc // threadID -> cancel its control server
+	idle    chan idleEvent                // guest idle boundaries, handled on the loop goroutine
+}
+
+// idleEvent is a guest's quiescent idle-boundary signal, delivered from a
+// control-server goroutine to the loop goroutine so the snapshot runs without
+// racing the loop's live/control maps.
+type idleEvent struct {
+	threadID string
+	wake     vsockproto.WakeCondition
 }
 
 // Run ticks until ctx is cancelled. It returns nil on graceful shutdown.
@@ -74,6 +84,9 @@ func (l *Loop) Run(ctx context.Context) error {
 	}
 	if l.control == nil {
 		l.control = make(map[string]context.CancelFunc)
+	}
+	if l.idle == nil {
+		l.idle = make(chan idleEvent, 32)
 	}
 	interval := l.Interval
 	if interval <= 0 {
@@ -92,8 +105,44 @@ func (l *Loop) Run(ctx context.Context) error {
 			return nil
 		case <-ticker.C:
 			l.reconcileOnce(ctx, log)
+		case ev := <-l.idle:
+			l.snapshotIdle(ctx, log, ev)
 		}
 	}
+}
+
+// snapshotIdle captures a thread's microVM at a quiescent boundary, records the
+// snapshot as the thread's durable IDLE form, and releases the live VM so an
+// idle thread costs nothing but disk. It runs on the loop goroutine, so live and
+// control are safe to touch. Restore-on-wake rebuilds the VM from the snapshot.
+func (l *Loop) snapshotIdle(ctx context.Context, log *slog.Logger, ev idleEvent) {
+	h, ok := l.live[ev.threadID]
+	if !ok {
+		return // already gone (reclaimed, or a duplicate idle signal)
+	}
+	snapshotter, ok := l.Executor.(substrate.Snapshotable)
+	if !ok {
+		log.Warn("reconcile: executor cannot snapshot; leaving thread running", "thread", ev.threadID)
+		return
+	}
+	ref, err := snapshotter.Snapshot(ctx, h)
+	if err != nil {
+		log.Error("reconcile: snapshot on idle", "thread", ev.threadID, "err", err)
+		return
+	}
+	if err := l.Registry.SetThreadSnapshot(ctx, ev.threadID, ref.ID, ref.SizeBytes); err != nil {
+		log.Error("reconcile: record idle snapshot", "thread", ev.threadID, "err", err)
+		return
+	}
+	if err := l.Executor.Release(ctx, h); err != nil {
+		log.Error("reconcile: release after snapshot", "thread", ev.threadID, "err", err)
+	}
+	delete(l.live, ev.threadID)
+	if cancel, ok := l.control[ev.threadID]; ok {
+		cancel()
+		delete(l.control, ev.threadID)
+	}
+	log.Info("reconcile: thread idled and snapshotted", "thread", ev.threadID, "snapshot", ref.ID, "size", ref.SizeBytes)
 }
 
 func (l *Loop) reconcileOnce(ctx context.Context, log *slog.Logger) {
@@ -157,8 +206,12 @@ func (l *Loop) startControl(ctx context.Context, log *slog.Logger, t store.Threa
 	assign := control.Assignment{ThreadID: t.ThreadID, Recipe: t.Recipe, Task: t.Task}
 	handlers := control.Handlers{
 		OnIdle: func(threadID string, wake vsockproto.WakeCondition) {
-			// Snapshot-on-idle is wired in a later task; for now record the boundary.
 			log.Info("reconcile: thread reached idle boundary", "thread", threadID, "wake", string(wake))
+			// Hand off to the loop goroutine so the snapshot does not race live/control.
+			select {
+			case l.idle <- idleEvent{threadID: threadID, wake: wake}:
+			case <-cctx.Done():
+			}
 		},
 		OnDone: func(threadID, status string) {
 			log.Info("reconcile: thread harness done", "thread", threadID, "status", status)

--- a/projects/agent_platform/fc-agentd/internal/reconcile/reconcile_test.go
+++ b/projects/agent_platform/fc-agentd/internal/reconcile/reconcile_test.go
@@ -76,6 +76,19 @@ func (f *fakeRegistry) SetState(_ context.Context, id string, st substrate.State
 	return nil
 }
 
+func (f *fakeRegistry) SetThreadSnapshot(_ context.Context, id, ref string, sizeBytes int64) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if t, ok := f.threads[id]; ok {
+		t.State = substrate.StateIdle
+		t.ThreadSnapshotRef = ref
+		t.SizeBytes = sizeBytes
+		t.WakeRequestedAt = time.Time{}
+		t.LastActiveAt = time.Now()
+	}
+	return nil
+}
+
 func (f *fakeRegistry) ClearWake(_ context.Context, id string) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -104,12 +117,13 @@ func (f *fakeRegistry) state(id string) substrate.State {
 
 // fakeExec is an in-memory executor + reclaimer.
 type fakeExec struct {
-	mu       sync.Mutex
-	claims   int
-	restores int
-	releases int
-	removed  []string
-	failNext error
+	mu        sync.Mutex
+	claims    int
+	restores  int
+	releases  int
+	snapshots int
+	removed   []string
+	failNext  error
 }
 
 func (e *fakeExec) Claim(_ context.Context, spec substrate.ClaimSpec) (substrate.Handle, error) {
@@ -138,6 +152,15 @@ func (e *fakeExec) Release(_ context.Context, _ substrate.Handle) error {
 	return nil
 }
 
+// Snapshot makes fakeExec satisfy substrate.Snapshotable so snapshot-on-idle is
+// exercised.
+func (e *fakeExec) Snapshot(_ context.Context, h substrate.Handle) (substrate.SnapshotRef, error) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.snapshots++
+	return substrate.SnapshotRef{ID: "snap-" + h.ThreadID, ThreadID: h.ThreadID, Node: h.Node, SizeBytes: 1024}, nil
+}
+
 func (e *fakeExec) RemoveBundle(threadID string) error {
 	e.mu.Lock()
 	defer e.mu.Unlock()
@@ -163,6 +186,32 @@ func TestReconcileCreatesPending(t *testing.T) {
 	}
 	if l.LiveThreads() != 1 {
 		t.Fatalf("live = %d, want 1", l.LiveThreads())
+	}
+}
+
+func TestReconcileSnapshotsOnIdle(t *testing.T) {
+	reg := newFakeRegistry(store.Thread{ThreadID: "t1", State: substrate.StatePending, Node: "node-4"})
+	ex := &fakeExec{}
+	l := newLoop(reg, ex)
+	ctx := context.Background()
+	// Claim it so it is live + RUNNING.
+	l.reconcileOnce(ctx, testLogger())
+	if l.LiveThreads() != 1 {
+		t.Fatalf("live = %d, want 1 before idle", l.LiveThreads())
+	}
+	// An idle boundary snapshots the VM, records it as the IDLE form, and releases.
+	l.snapshotIdle(ctx, testLogger(), idleEvent{threadID: "t1"})
+	if ex.snapshots != 1 {
+		t.Fatalf("snapshots = %d, want 1", ex.snapshots)
+	}
+	if ex.releases != 1 {
+		t.Fatalf("releases = %d, want 1", ex.releases)
+	}
+	if reg.state("t1") != substrate.StateIdle {
+		t.Fatalf("state = %q, want IDLE", reg.state("t1"))
+	}
+	if l.LiveThreads() != 0 {
+		t.Fatalf("live = %d, want 0 after snapshot", l.LiveThreads())
 	}
 }
 


### PR DESCRIPTION
**Draft** (part of B5; safe to merge but validates best alongside egress). Continues ADR 022 Plan B after the task-delivery increment (#2867).

## Task 5: snapshot-on-idle

When a guest signals a quiescent idle boundary (`KindIdle`), the controller now captures the microVM, records the snapshot as the thread's durable `IDLE` form (`SetThreadSnapshot`), and releases the live VM, so an idle agent thread costs nothing but disk (the core ADR 022 payoff). The existing `restoreWakeRequested` path already rebuilds the VM from the snapshot on a wake request.

### Concurrency
The idle signal arrives on a control-server goroutine, but the snapshot touches the loop's `live`/`control` maps. Rather than locking, the handler hands the event to the loop goroutine over a buffered channel, keeping those maps single-owner.

### Seam reuse
The snapshot goes through the existing `substrate.Snapshotable` seam via a type assertion (the driver satisfies it; a non-snapshotting executor leaves the thread running). Unit test added.

## Remaining B5 (not in this PR)
- **Task 6 (egress)** needs a design decision: goose must reach multiple in-cluster upstreams (Qwen + context-forge MCP + GitHub), so egress should be a vsock-tunneled forward proxy (allowlisted HTTP+CONNECT), not a fixed tunnel. Flagged for review before implementing.
- **Task 7 (restore guest-reconnect)**: the guest must re-establish its control channel after a restore; intricate, best validated interactively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)