### PR TITLE
feat(agent_platform): build fc-agentd base rootfs in-cluster (no node-4 sudo)

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -459,7 +459,11 @@ apko.translate_lock(
     name = "harness_lock",
     lock = "//projects/agent_platform/harness:apko.lock.json",
 )
-use_repo(apko, "grimoire_frontend_lock", "harness_lock", "monolith_frontend_lock", "visual_chromium_lock")
+apko.translate_lock(
+    name = "rootfs_builder_lock",
+    lock = "//projects/agent_platform/fc-agentd/rootfs-builder:apko.lock.json",
+)
+use_repo(apko, "grimoire_frontend_lock", "harness_lock", "monolith_frontend_lock", "rootfs_builder_lock", "visual_chromium_lock")
 
 # Download multiarch archives (binaries from zip files)
 multiarch_http_archive = use_repo_rule("//bazel/tools/http:multiarch_http_archive.bzl", "multiarch_http_archive")

--- a/bazel/images/BUILD
+++ b/bazel/images/BUILD
@@ -43,6 +43,7 @@ multirun(
         "//bazel/tools/image:image.push",
         "//projects/agent_platform/fc-agent-init:image.push",
         "//projects/agent_platform/fc-agentd/chart:chart.push",
+        "//projects/agent_platform/fc-agentd/rootfs-builder:image.push",
         "//projects/agent_platform/fc-agentd:image.push",
         "//projects/agent_platform/harness:image.push",
         "//projects/grimoire/api:image.push",

--- a/projects/agent_platform/fc-agentd/chart/BUILD
+++ b/projects/agent_platform/fc-agentd/chart/BUILD
@@ -1,11 +1,15 @@
 load("//bazel/helm:defs.bzl", "helm_chart")
 
-# Firecracker snapshot/restore controller chart (ADR 022). The image tag is
-# pinned into values.image at build time from the go_image .info provider.
+# Firecracker snapshot/restore controller chart (ADR 022). Image tags are pinned
+# into values at build time from each image's .info provider: the controller
+# itself, the harness image the base rootfs is built from, and the rootfs-builder
+# tools image its initContainer runs.
 helm_chart(
     name = "chart",
     images = {
         "image": "//projects/agent_platform/fc-agentd:image.info",
+        "harnessImage": "//projects/agent_platform/harness:image.info",
+        "rootfsBuilder.image": "//projects/agent_platform/fc-agentd/rootfs-builder:image.info",
     },
     publish = True,
     visibility = ["//overlays:__subpackages__"],

--- a/projects/agent_platform/fc-agentd/chart/Chart.yaml
+++ b/projects/agent_platform/fc-agentd/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: fc-agentd
 description: Firecracker snapshot/restore controller (ADR 022) - the node-4 Postgres-reconcile daemon that manages agent-thread microVMs
 type: application
-version: 0.5.0
+version: 0.6.0
 appVersion: "latest"
 keywords:
   - firecracker

--- a/projects/agent_platform/fc-agentd/chart/templates/deployment.yaml
+++ b/projects/agent_platform/fc-agentd/chart/templates/deployment.yaml
@@ -45,6 +45,36 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       {{- end }}
+      {{- if and .Values.firecracker.enabled .Values.firecracker.baseRootfsPath }}
+      # Build the base rootfs in-cluster from the pinned harness image, so the
+      # node never needs a manual sudo rootfs placement. Idempotent: rebuilds
+      # only when the harness image ref changes.
+      initContainers:
+        - name: build-base-rootfs
+          image: "{{ .Values.rootfsBuilder.image.repository }}:{{ .Values.rootfsBuilder.image.tag }}"
+          command: ["/bin/bash", "/scripts/build-base-rootfs.sh"]
+          env:
+            - name: HARNESS_IMAGE
+              value: "{{ .Values.harnessImage.repository }}:{{ .Values.harnessImage.tag }}"
+            - name: BASE_ROOTFS_PATH
+              value: {{ .Values.firecracker.baseRootfsPath | quote }}
+            - name: ROOTFS_SIZE
+              value: {{ .Values.rootfsBuilder.rootfsSize | quote }}
+          volumeMounts:
+            - name: nvme
+              mountPath: {{ .Values.firecracker.nvmeRoot }}
+            - name: rootfs-builder-script
+              mountPath: /scripts
+              readOnly: true
+            - name: rootfs-builder-work
+              mountPath: /work
+          resources:
+            requests:
+              cpu: 500m
+              memory: 512Mi
+            limits:
+              memory: 512Mi
+      {{- end }}
       containers:
         - name: fc-agentd
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -126,4 +156,11 @@ spec:
           hostPath:
             path: {{ .Values.firecracker.nvmeRoot }}
             type: Directory
+        {{- if .Values.firecracker.baseRootfsPath }}
+        - name: rootfs-builder-script
+          configMap:
+            name: {{ include "fc-agentd.fullname" . }}-rootfs-builder
+        - name: rootfs-builder-work
+          emptyDir: {}
+        {{- end }}
       {{- end }}

--- a/projects/agent_platform/fc-agentd/chart/templates/rootfs-builder-configmap.yaml
+++ b/projects/agent_platform/fc-agentd/chart/templates/rootfs-builder-configmap.yaml
@@ -1,0 +1,37 @@
+{{- if .Values.firecracker.enabled }}
+# Build script for the base-rootfs initContainer (ADR 022). Kept in a ConfigMap
+# so it can be tuned without rebuilding the tools image.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "fc-agentd.fullname" . }}-rootfs-builder
+  labels:
+    {{- include "fc-agentd.labels" . | nindent 4 }}
+data:
+  build-base-rootfs.sh: |
+    #!/bin/bash
+    # Build the agent base rootfs in-cluster from the pinned harness image, so no
+    # human on node-4 with sudo is needed. crane exports the harness filesystem
+    # and mkfs.ext4 bakes it into an ext4 image on the mounted nvme disk.
+    set -euo pipefail
+    : "${HARNESS_IMAGE:?HARNESS_IMAGE required}"
+    : "${BASE_ROOTFS_PATH:?BASE_ROOTFS_PATH required}"
+    size="${ROOTFS_SIZE:-3G}"
+    base_dir="$(dirname "$BASE_ROOTFS_PATH")"
+    marker="$base_dir/.harness-ref"
+    mkdir -p "$base_dir"
+    # Idempotent: skip the multi-GB rebuild when the base already matches the
+    # deployed harness image (pod restarts with an unchanged harness are common).
+    if [ -f "$BASE_ROOTFS_PATH" ] && [ -f "$marker" ] && [ "$(cat "$marker")" = "$HARNESS_IMAGE" ]; then
+      echo "base rootfs already current for $HARNESS_IMAGE"
+      exit 0
+    fi
+    echo "building base rootfs from $HARNESS_IMAGE"
+    rm -rf /work/root "$BASE_ROOTFS_PATH.tmp"
+    mkdir -p /work/root
+    crane export --platform linux/amd64 "$HARNESS_IMAGE" - | tar -x -C /work/root
+    mkfs.ext4 -q -F -L agentbase -d /work/root "$BASE_ROOTFS_PATH.tmp" "$size"
+    mv -f "$BASE_ROOTFS_PATH.tmp" "$BASE_ROOTFS_PATH"
+    echo "$HARNESS_IMAGE" > "$marker"
+    echo "base rootfs built at $BASE_ROOTFS_PATH ($size)"
+{{- end }}

--- a/projects/agent_platform/fc-agentd/chart/values.yaml
+++ b/projects/agent_platform/fc-agentd/chart/values.yaml
@@ -6,6 +6,23 @@ image:
   tag: latest
   pullPolicy: Always
 
+# The harness image (projects/agent_platform/harness) the base rootfs is built
+# from. The base-rootfs initContainer exports this image and bakes it into
+# firecracker.baseRootfsPath, so the base always matches the deployed harness
+# (the vsock-dialing fc-agent-init). Bazel pins repository + tag at build time.
+harnessImage:
+  repository: ghcr.io/jomcgi/homelab/projects/agent_platform/harness
+  tag: latest
+
+# Tools image (crane + e2fsprogs) the base-rootfs initContainer runs to build the
+# ext4 base rootfs in-cluster, removing the manual node-4 sudo step. Bazel-pinned.
+rootfsBuilder:
+  image:
+    repository: ghcr.io/jomcgi/homelab/projects/agent_platform/fc-agentd/rootfs-builder
+    tag: latest
+  # Size of the ext4 base rootfs image built from the harness filesystem.
+  rootfsSize: 3G
+
 replicas: 1
 
 # node + arch the controller manages. Firecracker snapshots are node/arch-bound,

--- a/projects/agent_platform/fc-agentd/deploy/application.yaml
+++ b/projects/agent_platform/fc-agentd/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: fc-agentd
-      targetRevision: 0.5.0
+      targetRevision: 0.6.0
       helm:
         valueFiles:
           - $values/projects/agent_platform/fc-agentd/deploy/values.yaml

--- a/projects/agent_platform/fc-agentd/rootfs-builder/BUILD
+++ b/projects/agent_platform/fc-agentd/rootfs-builder/BUILD
@@ -1,0 +1,11 @@
+load("//bazel/tools/oci:apko_image.bzl", "apko_image")
+
+# Tools image for the base-rootfs initContainer (ADR 022): crane + e2fsprogs to
+# build the agent base rootfs in-cluster from the pinned harness image, removing
+# the manual node-4 sudo step. Pinned into the fc-agentd chart values.
+apko_image(
+    name = "image",
+    config = "apko.yaml",
+    contents = "@rootfs_builder_lock//:contents",
+    repository = "ghcr.io/jomcgi/homelab/projects/agent_platform/fc-agentd/rootfs-builder",
+)

--- a/projects/agent_platform/fc-agentd/rootfs-builder/apko.lock.json
+++ b/projects/agent_platform/fc-agentd/rootfs-builder/apko.lock.json
@@ -1,0 +1,981 @@
+{
+  "version": "v1",
+  "config": {
+    "name": "apko.yaml",
+    "checksum": "sha256-oI1meHO9zqTyCrx8r/IImpGFhC9oawgVr3xyli0hGiU="
+  },
+  "contents": {
+    "keyring": [
+      {
+        "name": "packages.wolfi.dev/os/wolfi-signing.rsa.pub",
+        "url": "https://packages.wolfi.dev/os/wolfi-signing.rsa.pub"
+      }
+    ],
+    "build_repositories": [],
+    "runtime_repositories": [],
+    "repositories": [
+      {
+        "name": "packages.wolfi.dev/os/x86_64",
+        "url": "https://packages.wolfi.dev/os/x86_64/APKINDEX.tar.gz",
+        "architecture": "x86_64"
+      },
+      {
+        "name": "packages.wolfi.dev/os/aarch64",
+        "url": "https://packages.wolfi.dev/os/aarch64/APKINDEX.tar.gz",
+        "architecture": "aarch64"
+      }
+    ],
+    "packages": [
+      {
+        "name": "wolfi-baselayout",
+        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r29.apk",
+        "version": "20230201-r29",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-1932",
+          "checksum": "sha1-mxVgkD4+r1cSUSeWo6ClkgNR1IA="
+        },
+        "data": {
+          "range": "bytes=1933-13952",
+          "checksum": "sha256-5jOBVeXTWJEbL+Cnxj5Nu4klEL4SEB7IDMzT96rbkkA="
+        },
+        "checksum": "Q1mxVgkD4+r1cSUSeWo6ClkgNR1IA="
+      },
+      {
+        "name": "ca-certificates-bundle",
+        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20260413-r0.apk",
+        "version": "20260413-r0",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-7872",
+          "checksum": "sha1-KyCdEL20IKE+B7DKW97GLXu2QLM="
+        },
+        "data": {
+          "range": "bytes=7873-137518",
+          "checksum": "sha256-foyxNKCWc3UQM3Kq5on+Gt/2d+HlzCUl+1lqiaviWE8="
+        },
+        "checksum": "Q1KyCdEL20IKE+B7DKW97GLXu2QLM="
+      },
+      {
+        "name": "libgcc",
+        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-16.1.0-r4.apk",
+        "version": "16.1.0-r4",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-9951",
+          "checksum": "sha1-v4FvRKA29cOT2WtAXaWZBCzRXaU="
+        },
+        "data": {
+          "range": "bytes=9952-105490",
+          "checksum": "sha256-ExYZSr5G/sH+fzFe+TjVUTTj/GQ1Qbjx8MMEh+6ZxE0="
+        },
+        "checksum": "Q1v4FvRKA29cOT2WtAXaWZBCzRXaU="
+      },
+      {
+        "name": "glibc-locale-posix",
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.43-r9.apk",
+        "version": "2.43-r9",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-12840",
+          "checksum": "sha1-H64y8mukP523u0pCZf8hfFWbbRo="
+        },
+        "data": {
+          "range": "bytes=12841-89581",
+          "checksum": "sha256-Uss+kZ8QQvAIOljUCQsmOCzkr9mDf86+RmdJcmZkHBc="
+        },
+        "checksum": "Q1H64y8mukP523u0pCZf8hfFWbbRo="
+      },
+      {
+        "name": "glibc",
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.43-r9.apk",
+        "version": "2.43-r9",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-13094",
+          "checksum": "sha1-55FrWEeQ3Y3FogkXEzPPmk+3DTM="
+        },
+        "data": {
+          "range": "bytes=13095-3069364",
+          "checksum": "sha256-UODeJ9r02RcR6ys5AtpxdTOz86nLL5T70lcPmbaMdLI="
+        },
+        "checksum": "Q155FrWEeQ3Y3FogkXEzPPmk+3DTM="
+      },
+      {
+        "name": "ld-linux",
+        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.43-r9.apk",
+        "version": "2.43-r9",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-12891",
+          "checksum": "sha1-QXR2tE2zmZfHSFVq6FdarWn4TSI="
+        },
+        "data": {
+          "range": "bytes=12892-147121",
+          "checksum": "sha256-2MetOLJhj/fCCOaw4gPiNRO/dQZSA960MbfYuBUJS9Y="
+        },
+        "checksum": "Q1QXR2tE2zmZfHSFVq6FdarWn4TSI="
+      },
+      {
+        "name": "ncurses-terminfo-base",
+        "url": "https://packages.wolfi.dev/os/x86_64/ncurses-terminfo-base-6.6.20260620-r0.apk",
+        "version": "6.6.20260620-r0",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-9863",
+          "checksum": "sha1-nU2IJBZ81vZ5oRDlHbLale7bkQw="
+        },
+        "data": {
+          "range": "bytes=9864-116078",
+          "checksum": "sha256-rjHVP2hGmWzT4Mfss6FKg4jtZs15bjgVpvA2+ohAxmE="
+        },
+        "checksum": "Q1nU2IJBZ81vZ5oRDlHbLale7bkQw="
+      },
+      {
+        "name": "ncurses",
+        "url": "https://packages.wolfi.dev/os/x86_64/ncurses-6.6.20260620-r0.apk",
+        "version": "6.6.20260620-r0",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-10007",
+          "checksum": "sha1-FqF2vf0lDhnCD+zAMQ5UH1XlOvs="
+        },
+        "data": {
+          "range": "bytes=10008-619739",
+          "checksum": "sha256-sDPKISLkyMMr+Ux8j9h0d5iNgTbgAqQA/b4XUKsZiMw="
+        },
+        "checksum": "Q1FqF2vf0lDhnCD+zAMQ5UH1XlOvs="
+      },
+      {
+        "name": "bash",
+        "url": "https://packages.wolfi.dev/os/x86_64/bash-5.3-r12.apk",
+        "version": "5.3-r12",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-7927",
+          "checksum": "sha1-MiP/OfvIiKKAeeYZwZ9TEZUMUes="
+        },
+        "data": {
+          "range": "bytes=7928-761775",
+          "checksum": "sha256-6a67wARX0cxLzVwnkqQBX1Pn8IgVa9uq95jAGW5nEeM="
+        },
+        "checksum": "Q1MiP/OfvIiKKAeeYZwZ9TEZUMUes="
+      },
+      {
+        "name": "libxcrypt",
+        "url": "https://packages.wolfi.dev/os/x86_64/libxcrypt-4.5.2-r3.apk",
+        "version": "4.5.2-r3",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-8536",
+          "checksum": "sha1-I0YlF5JXljMqn3nnsq4AWUw6X/8="
+        },
+        "data": {
+          "range": "bytes=8537-106099",
+          "checksum": "sha256-mzRytDzhPafMZpD3kpn03C6x2XCNuG0nZ1F3Bjo+Jx4="
+        },
+        "checksum": "Q1I0YlF5JXljMqn3nnsq4AWUw6X/8="
+      },
+      {
+        "name": "libcrypt1",
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.43-r9.apk",
+        "version": "2.43-r9",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-12905",
+          "checksum": "sha1-9oOBflcOvOA9KafVrBVMSnqsOgo="
+        },
+        "data": {
+          "range": "bytes=12906-14518",
+          "checksum": "sha256-U1phbbPmyglswLkLmhDmtnHlO2pHRtoVtEdZSoC6AqA="
+        },
+        "checksum": "Q19oOBflcOvOA9KafVrBVMSnqsOgo="
+      },
+      {
+        "name": "busybox",
+        "url": "https://packages.wolfi.dev/os/x86_64/busybox-1.37.0-r61.apk",
+        "version": "1.37.0-r61",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-10913",
+          "checksum": "sha1-Dc1coU0swhMsnFh4BnVin4Y/z6U="
+        },
+        "data": {
+          "range": "bytes=10914-430452",
+          "checksum": "sha256-Lp5skr4+yaxDhdl+G39Z7VC8YLLcwNh+fGvRe0T6bj0="
+        },
+        "checksum": "Q1Dc1coU0swhMsnFh4BnVin4Y/z6U="
+      },
+      {
+        "name": "libpcre2-8-0",
+        "url": "https://packages.wolfi.dev/os/x86_64/libpcre2-8-0-10.47-r0.apk",
+        "version": "10.47-r0",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-6848",
+          "checksum": "sha1-5bkXL31L9lMVsxJdyleMiTb2Esg="
+        },
+        "data": {
+          "range": "bytes=6849-307246",
+          "checksum": "sha256-LBagnNrkJtEnWnNJIYKGEllGZqRH6y5+9I9lQ05+NIs="
+        },
+        "checksum": "Q15bkXL31L9lMVsxJdyleMiTb2Esg="
+      },
+      {
+        "name": "libsepol",
+        "url": "https://packages.wolfi.dev/os/x86_64/libsepol-3.10-r2.apk",
+        "version": "3.10-r2",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-6353",
+          "checksum": "sha1-Le/AljgZs/GS/EBqoBAw6eH1hyk="
+        },
+        "data": {
+          "range": "bytes=6354-438643",
+          "checksum": "sha256-GV/afF7btcauQYDuq3YdYQ/lIrB5UuBNIm2AiuIh2Og="
+        },
+        "checksum": "Q1Le/AljgZs/GS/EBqoBAw6eH1hyk="
+      },
+      {
+        "name": "libselinux",
+        "url": "https://packages.wolfi.dev/os/x86_64/libselinux-3.10-r0.apk",
+        "version": "3.10-r0",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-7251",
+          "checksum": "sha1-CM7/ih5kzO/43c2A1NI9lWvFHQQ="
+        },
+        "data": {
+          "range": "bytes=7252-318547",
+          "checksum": "sha256-JyOZS2AgOp7yzXMvmXgG+G71DBctZeyuEY15XddGXUU="
+        },
+        "checksum": "Q1CM7/ih5kzO/43c2A1NI9lWvFHQQ="
+      },
+      {
+        "name": "libacl1",
+        "url": "https://packages.wolfi.dev/os/x86_64/libacl1-2.3.2-r55.apk",
+        "version": "2.3.2-r55",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-7702",
+          "checksum": "sha1-yPga0Q7H2gxy18ZuQTovdIHWQvY="
+        },
+        "data": {
+          "range": "bytes=7703-28751",
+          "checksum": "sha256-0/eSvAC2Htvs+FehVF8Wx4+mwO3cLJM3nJly2lJgEPg="
+        },
+        "checksum": "Q1yPga0Q7H2gxy18ZuQTovdIHWQvY="
+      },
+      {
+        "name": "libattr1",
+        "url": "https://packages.wolfi.dev/os/x86_64/libattr1-2.5.2-r56.apk",
+        "version": "2.5.2-r56",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-7764",
+          "checksum": "sha1-0j1iTA8fMboleZUDYCD9qIAvuTE="
+        },
+        "data": {
+          "range": "bytes=7765-19146",
+          "checksum": "sha256-imFwWN+2sySvuV7zIc0t3uOzeW+KNK17XsKolm5X1d8="
+        },
+        "checksum": "Q10j1iTA8fMboleZUDYCD9qIAvuTE="
+      },
+      {
+        "name": "libcrypto3",
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.6.3-r3.apk",
+        "version": "3.6.3-r3",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-10990",
+          "checksum": "sha1-8czJwPp28PlmrUy6evlca3lfXlk="
+        },
+        "data": {
+          "range": "bytes=10991-2439998",
+          "checksum": "sha256-Gtu+CyjMO2oH9qFjvJKo2t0zE0aDLG2dwtmDVnll8/4="
+        },
+        "checksum": "Q18czJwPp28PlmrUy6evlca3lfXlk="
+      },
+      {
+        "name": "coreutils",
+        "url": "https://packages.wolfi.dev/os/x86_64/coreutils-9.11-r3.apk",
+        "version": "9.11-r3",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-8698",
+          "checksum": "sha1-Y+PvSypu3hsUvmwdQ68Tc7uPsdI="
+        },
+        "data": {
+          "range": "bytes=8699-859850",
+          "checksum": "sha256-z7vM1hHBjwnR5wK9Qtx4/PwXBXK2cZTtLP2D/HE9tt8="
+        },
+        "checksum": "Q1Y+PvSypu3hsUvmwdQ68Tc7uPsdI="
+      },
+      {
+        "name": "crane",
+        "url": "https://packages.wolfi.dev/os/x86_64/crane-0.21.7-r0.apk",
+        "version": "0.21.7-r0",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-6913",
+          "checksum": "sha1-AnCLgqu6oVKGgUM4saeACYJdTgk="
+        },
+        "data": {
+          "range": "bytes=6914-5205108",
+          "checksum": "sha256-sTreXsvvqCnmg+ZBacCGKbPLgKQv6K16/cgoiGbzuDw="
+        },
+        "checksum": "Q1AnCLgqu6oVKGgUM4saeACYJdTgk="
+      },
+      {
+        "name": "libcom_err",
+        "url": "https://packages.wolfi.dev/os/x86_64/libcom_err-1.47.4-r1.apk",
+        "version": "1.47.4-r1",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-8252",
+          "checksum": "sha1-CMcRrPrpbLziSeZwJAsj1IggRAg="
+        },
+        "data": {
+          "range": "bytes=8253-16737",
+          "checksum": "sha256-u0G4PIicoyfgySbZKrzDrrgzWhBNmqRVcMg6zQFSSS4="
+        },
+        "checksum": "Q1CMcRrPrpbLziSeZwJAsj1IggRAg="
+      },
+      {
+        "name": "e2fsprogs-libs",
+        "url": "https://packages.wolfi.dev/os/x86_64/e2fsprogs-libs-1.47.4-r1.apk",
+        "version": "1.47.4-r1",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-8258",
+          "checksum": "sha1-1hxIEw4QVSeajx+FDtDuspATbx0="
+        },
+        "data": {
+          "range": "bytes=8259-287358",
+          "checksum": "sha256-myR9OUT2SCo+fg3sHHdzEJ3ZS06462aQke0zAS9WZao="
+        },
+        "checksum": "Q11hxIEw4QVSeajx+FDtDuspATbx0="
+      },
+      {
+        "name": "libblkid",
+        "url": "https://packages.wolfi.dev/os/x86_64/libblkid-2.42.2-r0.apk",
+        "version": "2.42.2-r0",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-8824",
+          "checksum": "sha1-pbMNc7Ew1CUyk7LcZmNFWp2KoYA="
+        },
+        "data": {
+          "range": "bytes=8825-869406",
+          "checksum": "sha256-th0Ey1wCWxtA9qAvUR4LRGUZypymk/pmMLUb4FJPdNM="
+        },
+        "checksum": "Q1pbMNc7Ew1CUyk7LcZmNFWp2KoYA="
+      },
+      {
+        "name": "libuuid",
+        "url": "https://packages.wolfi.dev/os/x86_64/libuuid-2.42.2-r0.apk",
+        "version": "2.42.2-r0",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-8832",
+          "checksum": "sha1-ls7rIbdJFe9ng7bSo/rg3Ld6UNI="
+        },
+        "data": {
+          "range": "bytes=8833-63370",
+          "checksum": "sha256-0DrrnQM+Vo9D93jmK/MqxIuLa136WA6EGMiAuh0LRIA="
+        },
+        "checksum": "Q1ls7rIbdJFe9ng7bSo/rg3Ld6UNI="
+      },
+      {
+        "name": "e2fsprogs",
+        "url": "https://packages.wolfi.dev/os/x86_64/e2fsprogs-1.47.4-r1.apk",
+        "version": "1.47.4-r1",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-8264",
+          "checksum": "sha1-Q0787H1hQS0+/OeGVERX9ExonLg="
+        },
+        "data": {
+          "range": "bytes=8265-267133",
+          "checksum": "sha256-NQ3sNSl8cHuKOipD0agI4gYfZmqtS82x1h+Xhp27nnc="
+        },
+        "checksum": "Q1Q0787H1hQS0+/OeGVERX9ExonLg="
+      },
+      {
+        "name": "wolfi-baselayout",
+        "url": "https://packages.wolfi.dev/os/aarch64/wolfi-baselayout-20230201-r29.apk",
+        "version": "20230201-r29",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-1962",
+          "checksum": "sha1-FcjlR8BAUcyRjMQxsc/f5gWSv8I="
+        },
+        "data": {
+          "range": "bytes=1963-13980",
+          "checksum": "sha256-jYse4NUqE3SQbsor532PGqEhuLikUOl38/yf1PJA1nY="
+        },
+        "checksum": "Q1FcjlR8BAUcyRjMQxsc/f5gWSv8I="
+      },
+      {
+        "name": "ca-certificates-bundle",
+        "url": "https://packages.wolfi.dev/os/aarch64/ca-certificates-bundle-20260413-r0.apk",
+        "version": "20260413-r0",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-7907",
+          "checksum": "sha1-YLGEH8o/PNCjR8sxoxh//AGpOgQ="
+        },
+        "data": {
+          "range": "bytes=7908-137552",
+          "checksum": "sha256-1NKuKrCJxco8aTxdlzNkEjM/4HyDXmO6sGOfSTiu8aE="
+        },
+        "checksum": "Q1YLGEH8o/PNCjR8sxoxh//AGpOgQ="
+      },
+      {
+        "name": "libgcc",
+        "url": "https://packages.wolfi.dev/os/aarch64/libgcc-16.1.0-r4.apk",
+        "version": "16.1.0-r4",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-9968",
+          "checksum": "sha1-0/N/tQIIDrAIbJ8QA8/iMB2bmfU="
+        },
+        "data": {
+          "range": "bytes=9969-86427",
+          "checksum": "sha256-ECrE4xEgBQV3df1UklKqzMzpglmWfjLg9FsjCGK05lc="
+        },
+        "checksum": "Q10/N/tQIIDrAIbJ8QA8/iMB2bmfU="
+      },
+      {
+        "name": "glibc-locale-posix",
+        "url": "https://packages.wolfi.dev/os/aarch64/glibc-locale-posix-2.43-r9.apk",
+        "version": "2.43-r9",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-12867",
+          "checksum": "sha1-+zjJijsP9to6HALuiBMhr0NVlUY="
+        },
+        "data": {
+          "range": "bytes=12868-89612",
+          "checksum": "sha256-xmHsrky7nLUHAGla3KoQ0OR5CjKgq07cQRAnbGhEz10="
+        },
+        "checksum": "Q1+zjJijsP9to6HALuiBMhr0NVlUY="
+      },
+      {
+        "name": "glibc",
+        "url": "https://packages.wolfi.dev/os/aarch64/glibc-2.43-r9.apk",
+        "version": "2.43-r9",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-13108",
+          "checksum": "sha1-SgCmCC0NEfW0pCwgjK28rKoFIQw="
+        },
+        "data": {
+          "range": "bytes=13109-2235391",
+          "checksum": "sha256-Wmld1mffQcj5MAfKrqQw4/lGh/NOIXxAOTwZjmQ5aRc="
+        },
+        "checksum": "Q1SgCmCC0NEfW0pCwgjK28rKoFIQw="
+      },
+      {
+        "name": "ld-linux",
+        "url": "https://packages.wolfi.dev/os/aarch64/ld-linux-2.43-r9.apk",
+        "version": "2.43-r9",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-12898",
+          "checksum": "sha1-NtAS/2IbsF9a+nRo6nqwRo0Fr1Y="
+        },
+        "data": {
+          "range": "bytes=12899-125560",
+          "checksum": "sha256-cOdCKHteGoQ95MXmpgQfR6nZaRca+RLK++IAQbp8PdE="
+        },
+        "checksum": "Q1NtAS/2IbsF9a+nRo6nqwRo0Fr1Y="
+      },
+      {
+        "name": "ncurses-terminfo-base",
+        "url": "https://packages.wolfi.dev/os/aarch64/ncurses-terminfo-base-6.6.20260620-r0.apk",
+        "version": "6.6.20260620-r0",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-9897",
+          "checksum": "sha1-zNAAHFAWUcH0rVBOVprBcC2LeeM="
+        },
+        "data": {
+          "range": "bytes=9898-116104",
+          "checksum": "sha256-1MYmHDhSB/XoDgRwOy99Tqg1Wu5UWbtFyFjLsD8TpwQ="
+        },
+        "checksum": "Q1zNAAHFAWUcH0rVBOVprBcC2LeeM="
+      },
+      {
+        "name": "ncurses",
+        "url": "https://packages.wolfi.dev/os/aarch64/ncurses-6.6.20260620-r0.apk",
+        "version": "6.6.20260620-r0",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-10038",
+          "checksum": "sha1-fK9hMrqbpJk+xE/wnTIFo/Z2jHU="
+        },
+        "data": {
+          "range": "bytes=10039-611348",
+          "checksum": "sha256-Ictbj4wh4IEM3OjRPdHOfZGWgH59KsiFDcfHHzrVkO0="
+        },
+        "checksum": "Q1fK9hMrqbpJk+xE/wnTIFo/Z2jHU="
+      },
+      {
+        "name": "bash",
+        "url": "https://packages.wolfi.dev/os/aarch64/bash-5.3-r12.apk",
+        "version": "5.3-r12",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-7959",
+          "checksum": "sha1-2dQcmgQpMxdFXBxE1gM2ittt310="
+        },
+        "data": {
+          "range": "bytes=7960-751569",
+          "checksum": "sha256-J8ZRuHXuFbZkZgkqoyaVV+y4hToTsQMuUV2qDsYkYks="
+        },
+        "checksum": "Q12dQcmgQpMxdFXBxE1gM2ittt310="
+      },
+      {
+        "name": "libxcrypt",
+        "url": "https://packages.wolfi.dev/os/aarch64/libxcrypt-4.5.2-r3.apk",
+        "version": "4.5.2-r3",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-8572",
+          "checksum": "sha1-ghgqrJg4iSn9gnlkDzpWMPFaymg="
+        },
+        "data": {
+          "range": "bytes=8573-104313",
+          "checksum": "sha256-XizRWLvfUizHwKzjGLYIFKzfDDehNmTY9yPgDFlLPS4="
+        },
+        "checksum": "Q1ghgqrJg4iSn9gnlkDzpWMPFaymg="
+      },
+      {
+        "name": "libcrypt1",
+        "url": "https://packages.wolfi.dev/os/aarch64/libcrypt1-2.43-r9.apk",
+        "version": "2.43-r9",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-12916",
+          "checksum": "sha1-sPFlEfoInhdAXY8N56FiJ8DXvGo="
+        },
+        "data": {
+          "range": "bytes=12917-14527",
+          "checksum": "sha256-V/62hyRVitwFTrfsICnclN543//ZdEgtYLZYkIfNpq4="
+        },
+        "checksum": "Q1sPFlEfoInhdAXY8N56FiJ8DXvGo="
+      },
+      {
+        "name": "busybox",
+        "url": "https://packages.wolfi.dev/os/aarch64/busybox-1.37.0-r61.apk",
+        "version": "1.37.0-r61",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-10947",
+          "checksum": "sha1-EeHjQ8oI9CX5Am00/gUwayfeglc="
+        },
+        "data": {
+          "range": "bytes=10948-429972",
+          "checksum": "sha256-TdoIXtUKXr9KtXVi4OBLcI3jzrea4+YQha1GxArzayI="
+        },
+        "checksum": "Q1EeHjQ8oI9CX5Am00/gUwayfeglc="
+      },
+      {
+        "name": "libpcre2-8-0",
+        "url": "https://packages.wolfi.dev/os/aarch64/libpcre2-8-0-10.47-r0.apk",
+        "version": "10.47-r0",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-6891",
+          "checksum": "sha1-lNf7ODNAkpMSoBvdKCbPrNH+78w="
+        },
+        "data": {
+          "range": "bytes=6892-284052",
+          "checksum": "sha256-c1gHKQBjlH7hmsX+z8z4f6UT3dWMoMQg5aqWNhDOzfs="
+        },
+        "checksum": "Q1lNf7ODNAkpMSoBvdKCbPrNH+78w="
+      },
+      {
+        "name": "libsepol",
+        "url": "https://packages.wolfi.dev/os/aarch64/libsepol-3.10-r2.apk",
+        "version": "3.10-r2",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-6388",
+          "checksum": "sha1-3X3b6mSgBdREmYQf+S5bYf8aGWo="
+        },
+        "data": {
+          "range": "bytes=6389-439116",
+          "checksum": "sha256-ENE9dzVg3nWDMDxfbeCbKnMfYS7M9+3OiabXRg8LtHo="
+        },
+        "checksum": "Q13X3b6mSgBdREmYQf+S5bYf8aGWo="
+      },
+      {
+        "name": "libselinux",
+        "url": "https://packages.wolfi.dev/os/aarch64/libselinux-3.10-r0.apk",
+        "version": "3.10-r0",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-7281",
+          "checksum": "sha1-QskYFn49nq7LobnjH7MC5SrXJ9c="
+        },
+        "data": {
+          "range": "bytes=7282-430625",
+          "checksum": "sha256-H3xcq7N/69/PG3qdcp5sNPbegnICwVAIOK9XTZhjqhw="
+        },
+        "checksum": "Q1QskYFn49nq7LobnjH7MC5SrXJ9c="
+      },
+      {
+        "name": "libacl1",
+        "url": "https://packages.wolfi.dev/os/aarch64/libacl1-2.3.2-r55.apk",
+        "version": "2.3.2-r55",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-7755",
+          "checksum": "sha1-QuETN12TZyAYavvqfsBmZl9q4Bc="
+        },
+        "data": {
+          "range": "bytes=7756-29382",
+          "checksum": "sha256-M4NWjimRiTyV0ZRBtBu7mgAQ6US97kwJjfeRVCFo27A="
+        },
+        "checksum": "Q1QuETN12TZyAYavvqfsBmZl9q4Bc="
+      },
+      {
+        "name": "libattr1",
+        "url": "https://packages.wolfi.dev/os/aarch64/libattr1-2.5.2-r56.apk",
+        "version": "2.5.2-r56",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-7815",
+          "checksum": "sha1-hPhBZnUfnSYZJaT2mL99BYPMRpY="
+        },
+        "data": {
+          "range": "bytes=7816-19489",
+          "checksum": "sha256-UGGyaST8Nl8PYbYyRfaVH/BdznHsOGqwObRCgaBzf18="
+        },
+        "checksum": "Q1hPhBZnUfnSYZJaT2mL99BYPMRpY="
+      },
+      {
+        "name": "libcrypto3",
+        "url": "https://packages.wolfi.dev/os/aarch64/libcrypto3-3.6.3-r3.apk",
+        "version": "3.6.3-r3",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-11026",
+          "checksum": "sha1-IhlZQ3XyVyqnes8zsNjtdfcdEO0="
+        },
+        "data": {
+          "range": "bytes=11027-2210037",
+          "checksum": "sha256-Z8qrYFVxk9L0+ZpEpIV/yFNFZwBgRHR+W4OPv/UJY1k="
+        },
+        "checksum": "Q1IhlZQ3XyVyqnes8zsNjtdfcdEO0="
+      },
+      {
+        "name": "coreutils",
+        "url": "https://packages.wolfi.dev/os/aarch64/coreutils-9.11-r3.apk",
+        "version": "9.11-r3",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-8727",
+          "checksum": "sha1-2Yb/JW2G7uYe+A9HO070lpzVzhw="
+        },
+        "data": {
+          "range": "bytes=8728-823973",
+          "checksum": "sha256-fEcLmh6XG5joa2S12OsF1em8bUkrERAVgQio5rScIys="
+        },
+        "checksum": "Q12Yb/JW2G7uYe+A9HO070lpzVzhw="
+      },
+      {
+        "name": "crane",
+        "url": "https://packages.wolfi.dev/os/aarch64/crane-0.21.7-r0.apk",
+        "version": "0.21.7-r0",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-6939",
+          "checksum": "sha1-8yYpAH2lewFaZ1tDssW9AMEKk2w="
+        },
+        "data": {
+          "range": "bytes=6940-4699654",
+          "checksum": "sha256-7QXWgKAqs3YaRpg7JrvdsohOdwBhbIdiq/mE6NM2rEE="
+        },
+        "checksum": "Q18yYpAH2lewFaZ1tDssW9AMEKk2w="
+      },
+      {
+        "name": "libcom_err",
+        "url": "https://packages.wolfi.dev/os/aarch64/libcom_err-1.47.4-r1.apk",
+        "version": "1.47.4-r1",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-8287",
+          "checksum": "sha1-DVN0DsSOJjY6/QW9goaGicFfuG8="
+        },
+        "data": {
+          "range": "bytes=8288-17345",
+          "checksum": "sha256-JJIiVXjHs200JtxLrKU77nvWzIiVAZ9CW+EMkXmQVcU="
+        },
+        "checksum": "Q1DVN0DsSOJjY6/QW9goaGicFfuG8="
+      },
+      {
+        "name": "e2fsprogs-libs",
+        "url": "https://packages.wolfi.dev/os/aarch64/e2fsprogs-libs-1.47.4-r1.apk",
+        "version": "1.47.4-r1",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-8305",
+          "checksum": "sha1-RPohLtRuz+j00s45d/ZEGo84Zp0="
+        },
+        "data": {
+          "range": "bytes=8306-292536",
+          "checksum": "sha256-3Kd9CvEGlZdUnFtsd5lX7evI81I6WiegKvRin/ecfCk="
+        },
+        "checksum": "Q1RPohLtRuz+j00s45d/ZEGo84Zp0="
+      },
+      {
+        "name": "libblkid",
+        "url": "https://packages.wolfi.dev/os/aarch64/libblkid-2.42.2-r0.apk",
+        "version": "2.42.2-r0",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-8868",
+          "checksum": "sha1-pkJjz48IE4Vtve4m7uV4JcVFURQ="
+        },
+        "data": {
+          "range": "bytes=8869-849899",
+          "checksum": "sha256-mYbNtygDeUHC6YYTzW91KBeSwpRYzAsEIh009hmUQQE="
+        },
+        "checksum": "Q1pkJjz48IE4Vtve4m7uV4JcVFURQ="
+      },
+      {
+        "name": "libuuid",
+        "url": "https://packages.wolfi.dev/os/aarch64/libuuid-2.42.2-r0.apk",
+        "version": "2.42.2-r0",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-8875",
+          "checksum": "sha1-CZKMqgSIovXl6DHThmTNqbDBN5s="
+        },
+        "data": {
+          "range": "bytes=8876-61795",
+          "checksum": "sha256-Wcxi+3xB23hBWACBcImAv5bvUnFosC5cbyOyxkaM4YY="
+        },
+        "checksum": "Q1CZKMqgSIovXl6DHThmTNqbDBN5s="
+      },
+      {
+        "name": "e2fsprogs",
+        "url": "https://packages.wolfi.dev/os/aarch64/e2fsprogs-1.47.4-r1.apk",
+        "version": "1.47.4-r1",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-8297",
+          "checksum": "sha1-6JS0nQM58/kpjdjpXq/F8AMOCD0="
+        },
+        "data": {
+          "range": "bytes=8298-259825",
+          "checksum": "sha256-4aIPu3vaH4fgqXtsptBvBXbSJEhobHyTaJXLLJ5KedA="
+        },
+        "checksum": "Q16JS0nQM58/kpjdjpXq/F8AMOCD0="
+      }
+    ]
+  }
+}

--- a/projects/agent_platform/fc-agentd/rootfs-builder/apko.yaml
+++ b/projects/agent_platform/fc-agentd/rootfs-builder/apko.yaml
@@ -1,0 +1,27 @@
+# Tools image for the fc-agentd base-rootfs initContainer (ADR 022). It builds
+# the agent base rootfs in-cluster from the pinned harness image, so no human on
+# node-4 with sudo is needed: crane exports the harness image filesystem and
+# mkfs.ext4 (e2fsprogs) bakes it into an ext4 image on the mounted nvme disk.
+# Runs as root (apko default) because it writes to the root-owned snapshot dir.
+contents:
+  repositories:
+    - https://packages.wolfi.dev/os
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+  packages:
+    - bash
+    - busybox
+    - ca-certificates-bundle
+    - coreutils
+    - crane
+    - e2fsprogs
+
+archs:
+  - x86_64
+  - aarch64
+
+environment:
+  HOME: /root
+
+entrypoint:
+  command: /bin/bash


### PR DESCRIPTION
## What

Removes the manual `sudo` step on node-4 for placing the agent base rootfs. fc-agentd already runs privileged with `/disks/nvme-02` mounted, so an **initContainer** now builds the base rootfs **in-cluster** from the pinned harness image.

## How

- New `rootfs-builder` apko tools image (`crane` + `e2fsprogs`), registered as an apko `translate_lock` in MODULE.bazel and pushed by CI.
- The chart pins `harnessImage` + `rootfsBuilder.image` via Bazel `.info` providers (same mechanism as the controller image), so the initContainer always builds from the harness that matches this deploy (the vsock-dialing `fc-agent-init`).
- initContainer: `crane export --platform linux/amd64 <harness>` → `mkfs.ext4 -d` → `firecracker.baseRootfsPath`. Idempotent via a `.harness-ref` marker (skips the multi-GB rebuild when the harness ref is unchanged). Gated on `firecracker.enabled` + a set `baseRootfsPath`.

## Why this matters now

It eliminates the node-4 SSH/sudo dependency for the base rootfs, which means the **whole Firecracker feature becomes validatable via kubectl alone**: once this deploys, the base rootfs auto-appears (with the current harness), and a submitted thread boots the vsock-dialing init without any human on the node.

## Render-validated

`helm template` confirms the initContainer (image, `HARNESS_IMAGE`/`BASE_ROOTFS_PATH`/`ROOTFS_SIZE` env, nvme + script + work mounts, mem req==limit) and the build-script ConfigMap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)