### PR TITLE
fix(agent_platform): fc-agent-init sets baseline PATH/HOME for the harness

### DIFF
--- a/projects/agent_platform/fc-agent-init/cmd/main.go
+++ b/projects/agent_platform/fc-agent-init/cmd/main.go
@@ -38,6 +38,13 @@ func run(logger *slog.Logger) error {
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
 
+	// A raw Firecracker boot hands PID 1 no environment (the kernel ignores the
+	// OCI image config), so establish the baseline the harness needs to find its
+	// tools. goose lives in /usr/local/bin; gh/git/node in /usr/bin. HOME anchors
+	// goose's config under /home/goose-agent (matching the harness image).
+	ensureEnv("PATH", "/usr/local/bin:/usr/bin:/bin:/sbin:/usr/local/sbin")
+	ensureEnv("HOME", "/home/goose-agent")
+
 	threadID := os.Getenv("FC_THREAD_ID")
 	idleAfter := durationEnv("FC_IDLE_AFTER", 60*time.Second)
 
@@ -204,6 +211,14 @@ func dialController(ctx context.Context, logger *slog.Logger) *vsockproto.Conn {
 			return nil
 		case <-time.After(200 * time.Millisecond):
 		}
+	}
+}
+
+// ensureEnv sets key to def only when it is unset, so an injected value (e.g. a
+// future SandboxTemplate) still wins over the boot-time baseline.
+func ensureEnv(key, def string) {
+	if os.Getenv(key) == "" {
+		_ = os.Setenv(key, def)
 	}
 }
 


### PR DESCRIPTION
The in-cluster vsock task-delivery validation worked end to end (guest dialed the control channel over AF_VSOCK and received its `Assign`), but the harness then failed with `exec: "goose": executable file not found in $PATH`.

A raw FC boot gives PID 1 **no environment** (the kernel ignores the OCI image config), so `$PATH` was empty. `fc-agent-init` now seeds `PATH` (goose is in `/usr/local/bin`) and `HOME` (`/home/goose-agent`) when unset, so the harness launches. Once merged, the harness image rebuilds and the fc-agentd base-rootfs initContainer (PR #2870) rebuilds the base automatically, so this validates without any node access.

🤖 Generated with [Claude Code](https://claude.com/claude-code)