### PR TITLE
chore(fc-agentd): bump chart to 0.7.0 to re-pin PATH-fixed harness

### DIFF
--- a/projects/agent_platform/fc-agentd/chart/Chart.yaml
+++ b/projects/agent_platform/fc-agentd/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: fc-agentd
 description: Firecracker snapshot/restore controller (ADR 022) - the node-4 Postgres-reconcile daemon that manages agent-thread microVMs
 type: application
-version: 0.6.0
+version: 0.7.0
 appVersion: "latest"
 keywords:
   - firecracker

--- a/projects/agent_platform/fc-agentd/deploy/application.yaml
+++ b/projects/agent_platform/fc-agentd/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: fc-agentd
-      targetRevision: 0.6.0
+      targetRevision: 0.7.0
       helm:
         valueFiles:
           - $values/projects/agent_platform/fc-agentd/deploy/values.yaml


### PR DESCRIPTION
Forces a chart rebuild so the fc-agentd base-rootfs initContainer pins the PATH-fixed harness image (#2871). The chart-version-bot does not bump fc-agentd on harness-only changes (follow-up: teach it that dependency). 🤖 Generated with [Claude Code](https://claude.com/claude-code)