### PR TITLE
fix(bazel): widen oci_image_info closure so charts bump on bundled-content changes

### DIFF
--- a/bazel/tools/oci/apko_image.bzl
+++ b/bazel/tools/oci/apko_image.bzl
@@ -215,11 +215,15 @@ def apko_image(
             visibility = visibility,
         )
 
-    # Expose OciImageInfo provider for use by helm_chart(images = {...})
+    # Expose OciImageInfo provider for use by helm_chart(images = {...}). The
+    # image is referenced so the chart-version bot's dependency closure reaches
+    # content layered into the image (e.g. fc-agent-init bundled into the harness
+    # image), not just this package; see oci_image_info in providers.bzl.
     oci_image_info(
         name = name + ".info",
         repository = _repository,
         image_tags = name + "_stamped_ci.tags.txt",
+        image = ":" + name,
         visibility = ["//visibility:public"],
     )
 

--- a/bazel/tools/oci/providers.bzl
+++ b/bazel/tools/oci/providers.bzl
@@ -12,6 +12,7 @@ def _oci_image_info_impl(ctx):
     """Write the repository URL to a file and expose OciImageInfo."""
     repo_file = ctx.actions.declare_file(ctx.label.name + ".repository")
     ctx.actions.write(repo_file, ctx.attr.repository)
+
     # ctx.attr.image is intentionally not read here: it exists only so the image
     # (and its bundled tars) sits in this target's dependency graph. That widens
     # the dependency-query closure the chart-version bot walks

--- a/bazel/tools/oci/providers.bzl
+++ b/bazel/tools/oci/providers.bzl
@@ -12,6 +12,13 @@ def _oci_image_info_impl(ctx):
     """Write the repository URL to a file and expose OciImageInfo."""
     repo_file = ctx.actions.declare_file(ctx.label.name + ".repository")
     ctx.actions.write(repo_file, ctx.attr.repository)
+    # ctx.attr.image is intentionally not read here: it exists only so the image
+    # (and its bundled tars) sits in this target's dependency graph. That widens
+    # the dependency-query closure the chart-version bot walks
+    # (`deps(chart.package)`), so a change to content layered into the image, e.g.
+    # fc-agent-init bundled into the harness image, correctly bumps the dependent
+    # chart. It is deliberately NOT added to DefaultInfo, so the image is never
+    # packaged into the chart itself.
     return [
         DefaultInfo(files = depset([repo_file])),
         OciImageInfo(
@@ -31,6 +38,10 @@ oci_image_info = rule(
             mandatory = True,
             allow_single_file = True,
             doc = "Tags file produced by the CI stamp step (first line is the primary tag)",
+        ),
+        "image": attr.label(
+            doc = "The image target this info describes. Only widens the dependency " +
+                  "closure for the chart-version bot; not built into outputs.",
         ),
     },
     doc = "Exposes OCI image repository + tag information via OciImageInfo provider.",


### PR DESCRIPTION
## The bug

The chart-version bot bumps a chart from conventional commits touching `deps(chart.package)`. But `oci_image_info` only depended on the repository string + the stamped tags file (an `expand_template` over git-stamp vars) — **not the image build**. So the closure reached the image's *own* package and stopped.

Content bundled into an image from a **different** package (e.g. `fc-agent-init` layered into the harness image via `fc_agent_init_tar`) was invisible to the bot. That's why the PATH fix (#2871) rebuilt the harness but **did not** bump the fc-agentd chart that pins it — requiring the manual bump in #2872.

## The fix

`oci_image_info` gains an optional `image` label; `apko_image` passes its image target. The attr is **not** read in the action and **not** added to `DefaultInfo` — it exists purely to put the image (and its bundled tars) in the dependency graph, widening the query closure the bot walks. The image is never packaged into the chart. `--output=package` already drops external repos (`@goose`, wolfi), so the closure stays internal.

After this, `deps(fc-agentd/chart:chart.package)` reaches `harness:image → fc_agent_init_tar → fc-agent-init`, so future fc-agent-init changes bump fc-agentd automatically (no more manual bumps).

## Verification

CI builds the rules + all charts (Buck2 rules / Test). Behavioral proof is a future fc-agent-init change auto-bumping fc-agentd.

🤖 Generated with [Claude Code](https://claude.com/claude-code)