### PR TITLE
fix(fc-agentd): size container memory to hold its microVMs (OOM)

### DIFF
--- a/projects/agent_platform/fc-agentd/chart/Chart.yaml
+++ b/projects/agent_platform/fc-agentd/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: fc-agentd
 description: Firecracker snapshot/restore controller (ADR 022) - the node-4 Postgres-reconcile daemon that manages agent-thread microVMs
 type: application
-version: 0.8.0
+version: 0.8.1
 appVersion: "latest"
 keywords:
   - firecracker

--- a/projects/agent_platform/fc-agentd/chart/values.yaml
+++ b/projects/agent_platform/fc-agentd/chart/values.yaml
@@ -66,12 +66,17 @@ priorityClassName: homelab-critical
 tolerations: []
 affinity: {}
 
+# fc-agentd launches Firecracker microVMs as child processes, so each guest's
+# memory (firecracker.guestMemMib, default 1024Mi) counts against this container's
+# cgroup. The limit must hold the daemon plus the live microVMs, or the guest's
+# pages OOM-kill the whole container (137) the moment a thread does real work.
+# Burstable: a small steady-state request, a limit that fits ~1 active microVM.
 resources:
   requests:
     cpu: 50m
-    memory: 64Mi
+    memory: 512Mi
   limits:
-    memory: 256Mi
+    memory: 2Gi
 
 # The monolith Postgres DSN (claude_agent.agent_threads registry). Defaults to
 # the CNPG-generated app credential. When deployed outside the monolith

--- a/projects/agent_platform/fc-agentd/deploy/application.yaml
+++ b/projects/agent_platform/fc-agentd/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: fc-agentd
-      targetRevision: 0.8.0
+      targetRevision: 0.8.1
       helm:
         valueFiles:
           - $values/projects/agent_platform/fc-agentd/deploy/values.yaml


### PR DESCRIPTION
The in-cluster 6a validation proved goose works (loads the recipe, uses the injected openai/qwen3.6-27b provider, reaches 'goose is ready') but fc-agentd was OOMKilled (exit 137): the Firecracker microVM (1Gi guest) is a child process in fc-agentd's cgroup, and the 256Mi limit can't hold it once the guest touches pages. Raise to 2Gi limit / 512Mi request (burstable). 🤖 Generated with [Claude Code](https://claude.com/claude-code)