### PR TITLE
fix(fc-agentd): inject OPENAI_HOST for goose (reach Qwen)

### DIFF
--- a/projects/agent_platform/fc-agentd/chart/Chart.yaml
+++ b/projects/agent_platform/fc-agentd/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: fc-agentd
 description: Firecracker snapshot/restore controller (ADR 022) - the node-4 Postgres-reconcile daemon that manages agent-thread microVMs
 type: application
-version: 0.8.1
+version: 0.8.2
 appVersion: "latest"
 keywords:
   - firecracker

--- a/projects/agent_platform/fc-agentd/chart/templates/deployment.yaml
+++ b/projects/agent_platform/fc-agentd/chart/templates/deployment.yaml
@@ -123,8 +123,10 @@ spec:
               value: {{ .Values.egress.goose.provider | quote }}
             - name: FC_AGENTD_INJECT_GOOSE_MODEL
               value: {{ .Values.egress.goose.model | quote }}
-            - name: FC_AGENTD_INJECT_OPENAI_BASE_URL
-              value: {{ .Values.egress.goose.baseURL | quote }}
+            - name: FC_AGENTD_INJECT_OPENAI_HOST
+              value: {{ .Values.egress.goose.host | quote }}
+            - name: FC_AGENTD_INJECT_OPENAI_API_KEY
+              value: {{ .Values.egress.goose.apiKey | quote }}
             {{- end }}
             {{- with .Values.tracing.endpoint }}
             - name: OTEL_EXPORTER_OTLP_ENDPOINT

--- a/projects/agent_platform/fc-agentd/chart/values.yaml
+++ b/projects/agent_platform/fc-agentd/chart/values.yaml
@@ -42,7 +42,11 @@ egress:
   goose:
     provider: openai
     model: qwen3.6-27b
-    baseURL: http://inference.inference.svc.cluster.local:8080/v1
+    # goose's OpenAI provider reads OPENAI_HOST (scheme + host, no path; it appends
+    # OPENAI_BASE_PATH=v1/chat/completions), not OPENAI_BASE_URL. apiKey must be set
+    # even though in-cluster vLLM is keyless.
+    host: http://inference.inference.svc.cluster.local:8080
+    apiKey: sk-noauth
   resources:
     requests:
       cpu: 50m

--- a/projects/agent_platform/fc-agentd/deploy/application.yaml
+++ b/projects/agent_platform/fc-agentd/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: fc-agentd
-      targetRevision: 0.8.1
+      targetRevision: 0.8.2
       helm:
         valueFiles:
           - $values/projects/agent_platform/fc-agentd/deploy/values.yaml


### PR DESCRIPTION
goose ran cleanly but hit 'Could not connect to api.openai.com' - it reads OPENAI_HOST, not OPENAI_BASE_URL. Inject OPENAI_HOST=http://inference...:8080 + a dummy OPENAI_API_KEY so the request routes through the egress proxy to in-cluster Qwen. 🤖 Generated with [Claude Code](https://claude.com/claude-code)