### PR TITLE
fix(agent_platform): bring up loopback in fc-agent-init guest PID 1

### DIFF
--- a/projects/agent_platform/fc-agent-init/cmd/BUILD
+++ b/projects/agent_platform/fc-agent-init/cmd/BUILD
@@ -2,7 +2,11 @@ load("@rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 
 go_library(
     name = "cmd_lib",
-    srcs = ["main.go"],
+    srcs = [
+        "loopback_linux.go",
+        "loopback_other.go",
+        "main.go",
+    ],
     importpath = "github.com/jomcgi/homelab/projects/agent_platform/fc-agent-init/cmd",
     visibility = ["//visibility:private"],
     deps = [
@@ -11,7 +15,15 @@ go_library(
         "//projects/agent_platform/fc-agent-init/internal/reconnect",
         "//projects/agent_platform/fc-agent-init/internal/vsockdial",
         "//projects/agent_platform/vsockproto",
-    ],
+    ] + select({
+        "@rules_go//go/platform:android": [
+            "@org_golang_x_sys//unix",
+        ],
+        "@rules_go//go/platform:linux": [
+            "@org_golang_x_sys//unix",
+        ],
+        "//conditions:default": [],
+    }),
 )
 
 go_binary(

--- a/projects/agent_platform/fc-agent-init/cmd/loopback_linux.go
+++ b/projects/agent_platform/fc-agent-init/cmd/loopback_linux.go
@@ -1,0 +1,46 @@
+//go:build linux
+
+package main
+
+import (
+	"log/slog"
+
+	"golang.org/x/sys/unix"
+)
+
+// bringUpLoopback sets the loopback interface UP. fc-agent-init is the guest's
+// PID 1 and there is no init system, so nothing else brings lo up. Until it is
+// up, no traffic flows over 127.0.0.1, which makes the transparent egress funnel
+// and the wildcard DNS responder (both loopback-only) unreachable and breaks all
+// guest egress. The kernel already assigns 127.0.0.1/8 to lo, so only the IFF_UP
+// flag is missing; we flip it via SIOCSIFFLAGS. Best-effort: a failure is logged,
+// not fatal (off-cluster runs have no egress to set up anyway).
+func bringUpLoopback(logger *slog.Logger) {
+	fd, err := unix.Socket(unix.AF_INET, unix.SOCK_DGRAM|unix.SOCK_CLOEXEC, 0)
+	if err != nil {
+		logger.Warn("loopback: open socket failed", "err", err)
+		return
+	}
+	defer unix.Close(fd)
+
+	ifr, err := unix.NewIfreq("lo")
+	if err != nil {
+		logger.Warn("loopback: new ifreq failed", "err", err)
+		return
+	}
+	if err := unix.IoctlIfreq(fd, unix.SIOCGIFFLAGS, ifr); err != nil {
+		logger.Warn("loopback: get flags failed", "err", err)
+		return
+	}
+	flags := ifr.Uint16()
+	if flags&unix.IFF_UP != 0 {
+		logger.Info("loopback already up")
+		return
+	}
+	ifr.SetUint16(flags | uint16(unix.IFF_UP) | uint16(unix.IFF_RUNNING))
+	if err := unix.IoctlIfreq(fd, unix.SIOCSIFFLAGS, ifr); err != nil {
+		logger.Warn("loopback: set up failed", "err", err)
+		return
+	}
+	logger.Info("loopback interface up")
+}

--- a/projects/agent_platform/fc-agent-init/cmd/loopback_other.go
+++ b/projects/agent_platform/fc-agent-init/cmd/loopback_other.go
@@ -1,0 +1,9 @@
+//go:build !linux
+
+package main
+
+import "log/slog"
+
+// bringUpLoopback is a no-op off Linux; the guest is always Linux, this stub
+// only keeps the package building for host tests.
+func bringUpLoopback(*slog.Logger) {}

--- a/projects/agent_platform/fc-agent-init/cmd/main.go
+++ b/projects/agent_platform/fc-agent-init/cmd/main.go
@@ -52,6 +52,12 @@ func run(logger *slog.Logger) error {
 	// include it, so point goose at it explicitly.
 	ensureEnv("GOOSE_RECIPE_PATH", "/home/goose-agent/recipes")
 
+	// Raw FC boot with no init system leaves the loopback interface DOWN. Bring it
+	// up before anything uses 127.0.0.1: the transparent egress funnel and the
+	// wildcard DNS responder are loopback-only, so without this all guest egress
+	// (the harness reaching the model) fails with "could not connect".
+	bringUpLoopback(logger)
+
 	threadID := os.Getenv("FC_THREAD_ID")
 	idleAfter := durationEnv("FC_IDLE_AFTER", 60*time.Second)
 

--- a/projects/agent_platform/fc-agentd/chart/Chart.yaml
+++ b/projects/agent_platform/fc-agentd/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: fc-agentd
 description: Firecracker snapshot/restore controller (ADR 022) - the node-4 Postgres-reconcile daemon that manages agent-thread microVMs
 type: application
-version: 0.9.0
+version: 0.9.1
 appVersion: "latest"
 keywords:
   - firecracker

--- a/projects/agent_platform/fc-agentd/deploy/application.yaml
+++ b/projects/agent_platform/fc-agentd/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: fc-agentd
-      targetRevision: 0.9.0
+      targetRevision: 0.9.1
       helm:
         valueFiles:
           - $values/projects/agent_platform/fc-agentd/deploy/values.yaml

--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.70.6
+version: 0.70.7
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.70.6
+      targetRevision: 0.70.7
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.225.6
+version: 0.225.7
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.225.6
+      targetRevision: 0.225.7
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
## Problem

In-cluster validation of the transparent egress proxy (#2881) surfaced this: a submitted thread booted, the guest funnel bound `127.0.0.1:80/443/8080`, goose started (`new session · openai qwen3.6-27b`), but the first model call failed with:

```
Network error: Could not connect to inference.inference.svc.cluster.local:8080
```

and the egress-proxy sidecar logged **zero** routing lines, the traffic never left the guest.

## Root cause

The guest is a raw Firecracker boot with `init=fc-agent-init` and **no init system**. Nothing brings the loopback interface up. `lo` has `127.0.0.1/8` assigned by the kernel (so `bind()` succeeds, which is why the funnel logged "listening"), but it is administratively **DOWN**, so no traffic flows over `127.0.0.1`. The wildcard DNS responder on `127.0.0.1:53` is unreachable, so goose can't resolve the model host. This breaks the entire transparent-funnel design, which is loopback-only.

## Fix

`fc-agent-init` flips `IFF_UP` on `lo` via `SIOCSIFFLAGS` at startup, before any loopback use (linux-only file + a no-op stub for host tests; uses the existing `golang.org/x/sys/unix` dep, same pattern as `vsockdial`).

## Validation

Vetted on linux + darwin. Re-validated in-cluster after merge by submitting a thread and confirming the egress-proxy logs `egress allowed dest=inference.inference.svc.cluster.local:8080`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)