### PR TITLE
feat(agent_platform): egress secret placeholder-swap (ADR 023 6b)

### DIFF
--- a/projects/agent_platform/egress-proxy/cmd/BUILD
+++ b/projects/agent_platform/egress-proxy/cmd/BUILD
@@ -2,7 +2,10 @@ load("@rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 
 go_library(
     name = "cmd_lib",
-    srcs = ["main.go"],
+    srcs = [
+        "main.go",
+        "swap.go",
+    ],
     importpath = "github.com/jomcgi/homelab/projects/agent_platform/egress-proxy/cmd",
     visibility = ["//visibility:private"],
 )
@@ -15,6 +18,9 @@ go_binary(
 
 go_test(
     name = "cmd_test",
-    srcs = ["main_test.go"],
+    srcs = [
+        "main_test.go",
+        "swap_test.go",
+    ],
     embed = [":cmd_lib"],
 )

--- a/projects/agent_platform/egress-proxy/cmd/main.go
+++ b/projects/agent_platform/egress-proxy/cmd/main.go
@@ -68,7 +68,22 @@ func main() {
 		logger.Warn("policy=allowlist with empty EGRESS_ALLOWLIST; all egress will be denied (fail closed)")
 	}
 
-	p := &proxy{policy: policy, allowlist: allowlist, logger: logger}
+	// Secret placeholder-swap (ADR 023 6b): load the catalog and the CA the sidecar
+	// uses to TLS-terminate secret-bearing destinations. Absent CA paths or an empty
+	// catalog leave the proxy a plain transparent router (6a).
+	secrets := loadSecrets(logger)
+	var minter *caMinter
+	if caCert, caKey := os.Getenv("EGRESS_CA_CERT_FILE"), os.Getenv("EGRESS_CA_KEY_FILE"); caCert != "" && caKey != "" && len(secrets) > 0 {
+		m, err := newCAMinter(caCert, caKey)
+		if err != nil {
+			logger.Error("egress CA load failed; secret swap disabled", "err", err)
+		} else {
+			minter = m
+			logger.Info("secret swap enabled", "secrets", len(secrets))
+		}
+	}
+
+	p := &proxy{policy: policy, allowlist: allowlist, secrets: secrets, minter: minter, logger: logger}
 
 	ln, err := net.Listen("tcp", listen)
 	if err != nil {
@@ -85,14 +100,19 @@ func main() {
 	}
 }
 
-// proxy holds the egress posture and logger.
+// proxy holds the egress posture, the secret catalog, and the CA minter.
 type proxy struct {
 	// policy is the egress posture: policyAllow (default) permits every
 	// destination, policyAllowlist permits only allowlist entries.
 	policy string
 	// allowlist is consulted only under policyAllowlist.
 	allowlist []string
-	logger    *slog.Logger
+	// secrets is the placeholder-swap catalog (ADR 023 6b); empty disables swap.
+	secrets []secretEntry
+	// minter mints leaf certs from the egress CA for TLS termination; nil disables
+	// the swap path (the proxy stays a plain transparent router).
+	minter *caMinter
+	logger *slog.Logger
 }
 
 // permits reports whether dest may be reached under the current policy.
@@ -120,7 +140,7 @@ func (p *proxy) handle(client net.Conn) {
 		return
 	}
 
-	host, err := hostFromStream(br)
+	host, isTLS, err := hostFromStream(br)
 	if err != nil {
 		p.logger.Warn("egress host detection failed", "port", port, "err", err)
 		return
@@ -130,6 +150,17 @@ func (p *proxy) handle(client net.Conn) {
 	if !p.permits(dest) {
 		p.logger.Warn("egress denied", "dest", dest)
 		return
+	}
+
+	// Secret-bearing TLS destination: terminate, swap the placeholder, re-originate
+	// (ADR 023 6b). Everything else is blind-tunnelled (6a). The swap fires only for
+	// a host in the secret's egressTo, so the real value is unreachable elsewhere.
+	if p.minter != nil && isTLS {
+		if sec := p.secretFor(host); sec != nil {
+			p.logger.Info("egress allowed (swap)", "dest", dest)
+			p.terminateAndSwap(br, client, dest, host, sec)
+			return
+		}
 	}
 	p.logger.Info("egress allowed", "dest", dest)
 
@@ -149,17 +180,20 @@ func (p *proxy) handle(client net.Conn) {
 }
 
 // hostFromStream peeks the buffered client stream and returns the destination
-// host: the TLS SNI for a handshake record, otherwise the HTTP Host header. It
-// never consumes bytes, so the stream forwards to the upstream verbatim.
-func hostFromStream(br *bufio.Reader) (string, error) {
+// host and whether the stream is TLS: the TLS SNI for a handshake record,
+// otherwise the HTTP Host header. It never consumes bytes, so the stream forwards
+// to the upstream verbatim.
+func hostFromStream(br *bufio.Reader) (host string, isTLS bool, err error) {
 	first, err := br.Peek(1)
 	if err != nil {
-		return "", err
+		return "", false, err
 	}
 	if first[0] == 0x16 { // TLS handshake record
-		return sniFromClientHello(br)
+		host, err = sniFromClientHello(br)
+		return host, true, err
 	}
-	return hostFromHTTP(br)
+	host, err = hostFromHTTP(br)
+	return host, false, err
 }
 
 // maxHeadPeek bounds how far we peek looking for the SNI or Host header.

--- a/projects/agent_platform/egress-proxy/cmd/main_test.go
+++ b/projects/agent_platform/egress-proxy/cmd/main_test.go
@@ -195,9 +195,12 @@ func TestHostFromHTTP(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			br := bufio.NewReader(strings.NewReader(tt.req))
-			got, err := hostFromStream(br)
+			got, isTLS, err := hostFromStream(br)
 			if err != nil {
 				t.Fatalf("hostFromStream: %v", err)
+			}
+			if isTLS {
+				t.Errorf("plain HTTP misdetected as TLS")
 			}
 			if got != tt.want {
 				t.Errorf("host = %q, want %q", got, tt.want)
@@ -213,7 +216,7 @@ func TestHostFromHTTP(t *testing.T) {
 
 func TestHostFromHTTPNoHost(t *testing.T) {
 	br := bufio.NewReader(strings.NewReader("GET / HTTP/1.1\r\nAccept: */*\r\n\r\n"))
-	if _, err := hostFromStream(br); err == nil {
+	if _, _, err := hostFromStream(br); err == nil {
 		t.Fatal("expected error for missing Host header")
 	}
 }
@@ -236,9 +239,12 @@ func TestSNIFromClientHello(t *testing.T) {
 
 	// Via the peeking dispatcher, which must not consume the ClientHello.
 	br := bufio.NewReader(bytes.NewReader(hello))
-	got, err = hostFromStream(br)
+	got, isTLS, err := hostFromStream(br)
 	if err != nil {
 		t.Fatalf("hostFromStream(TLS): %v", err)
+	}
+	if !isTLS {
+		t.Errorf("TLS ClientHello not detected as TLS")
 	}
 	if got != name {
 		t.Errorf("hostFromStream = %q, want %q", got, name)

--- a/projects/agent_platform/egress-proxy/cmd/swap.go
+++ b/projects/agent_platform/egress-proxy/cmd/swap.go
@@ -1,0 +1,249 @@
+package main
+
+// Secret placeholder-swap on egress (ADR 023 6b). For a destination that carries
+// a credential, the sidecar TLS-terminates the guest's connection with a leaf
+// minted from the egress CA (the guest trusts that CA), reads the plaintext
+// request, replaces the high-entropy placeholder the guest holds with the real
+// secret value (mounted only here, never in the guest), and re-originates a fresh
+// TLS connection to the real destination. The swap fires only when the request's
+// destination is in that secret's egressTo, so the real value is unreachable for
+// any other host; everywhere else the inert placeholder passes through untouched.
+
+import (
+	"bufio"
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"log/slog"
+	"math/big"
+	"net"
+	"net/http"
+	"os"
+	"strings"
+	"sync"
+	"time"
+)
+
+// secretEntry is one catalog entry. The guest holds Placeholder as env Env; the
+// sidecar swaps it for value (resolved from its own env at startup, injected from
+// a mounted Secret) on a connection whose host is in EgressTo.
+type secretEntry struct {
+	Placeholder string   `json:"placeholder"`
+	Env         string   `json:"env"`
+	EgressTo    []string `json:"egressTo"`
+	value       string   // resolved real value; never serialized
+}
+
+// loadSecrets parses EGRESS_SECRETS (a JSON catalog) and resolves each real value
+// from the sidecar env. Entries missing a placeholder, egressTo, or a resolved
+// value are dropped with a warning (the placeholder then just passes through).
+func loadSecrets(logger *slog.Logger) []secretEntry {
+	raw := os.Getenv("EGRESS_SECRETS")
+	if strings.TrimSpace(raw) == "" {
+		return nil
+	}
+	var entries []secretEntry
+	if err := json.Unmarshal([]byte(raw), &entries); err != nil {
+		logger.Error("EGRESS_SECRETS is not valid JSON; secret swap disabled", "err", err)
+		return nil
+	}
+	out := make([]secretEntry, 0, len(entries))
+	for _, e := range entries {
+		if e.Placeholder == "" || e.Env == "" || len(e.EgressTo) == 0 {
+			logger.Warn("dropping incomplete secret catalog entry", "env", e.Env)
+			continue
+		}
+		e.value = os.Getenv(e.Env)
+		if e.value == "" {
+			logger.Warn("secret env empty; entry inert (placeholder passes through)", "env", e.Env)
+			continue
+		}
+		out = append(out, e)
+	}
+	return out
+}
+
+// secretFor returns the catalog entry whose egressTo includes host (exact,
+// case-insensitive), or nil. host is the bare hostname (no port).
+func (p *proxy) secretFor(host string) *secretEntry {
+	for i := range p.secrets {
+		for _, allowed := range p.secrets[i].EgressTo {
+			if strings.EqualFold(host, allowed) {
+				return &p.secrets[i]
+			}
+		}
+	}
+	return nil
+}
+
+// caMinter terminates guest TLS by minting leaf certs signed by the egress CA.
+// The CA private key lives only here; one leaf key is generated at startup and
+// reused for every minted cert (the slow key-gen happens once, signing is cheap).
+type caMinter struct {
+	caCert  *x509.Certificate
+	caKey   crypto.Signer
+	leafKey *rsa.PrivateKey
+	mu      sync.Mutex
+	cache   map[string]*tls.Certificate
+}
+
+// newCAMinter loads the CA cert + key (cert-manager Secret, PEM) and pre-generates
+// the shared leaf key.
+func newCAMinter(certFile, keyFile string) (*caMinter, error) {
+	certPEM, err := os.ReadFile(certFile)
+	if err != nil {
+		return nil, fmt.Errorf("read CA cert: %w", err)
+	}
+	keyPEM, err := os.ReadFile(keyFile)
+	if err != nil {
+		return nil, fmt.Errorf("read CA key: %w", err)
+	}
+	caTLS, err := tls.X509KeyPair(certPEM, keyPEM)
+	if err != nil {
+		return nil, fmt.Errorf("parse CA keypair: %w", err)
+	}
+	caCert, err := x509.ParseCertificate(caTLS.Certificate[0])
+	if err != nil {
+		return nil, fmt.Errorf("parse CA cert: %w", err)
+	}
+	caKey, ok := caTLS.PrivateKey.(crypto.Signer)
+	if !ok {
+		return nil, fmt.Errorf("CA key is not a crypto.Signer")
+	}
+	leafKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, fmt.Errorf("generate leaf key: %w", err)
+	}
+	return &caMinter{caCert: caCert, caKey: caKey, leafKey: leafKey, cache: map[string]*tls.Certificate{}}, nil
+}
+
+// getCertificate is the tls.Config.GetCertificate callback: it returns a leaf for
+// the requested SNI host, minting and caching it on first use.
+func (m *caMinter) getCertificate(hello *tls.ClientHelloInfo) (*tls.Certificate, error) {
+	host := hello.ServerName
+	if host == "" {
+		return nil, fmt.Errorf("no SNI in ClientHello")
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if c, ok := m.cache[host]; ok {
+		return c, nil
+	}
+	serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		return nil, err
+	}
+	now := time.Now()
+	tmpl := &x509.Certificate{
+		SerialNumber: serial,
+		Subject:      pkix.Name{CommonName: host},
+		DNSNames:     []string{host},
+		NotBefore:    now.Add(-5 * time.Minute),
+		NotAfter:     now.Add(24 * time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, m.caCert, &m.leafKey.PublicKey, m.caKey)
+	if err != nil {
+		return nil, fmt.Errorf("mint leaf for %s: %w", host, err)
+	}
+	cert := &tls.Certificate{Certificate: [][]byte{der, m.caCert.Raw}, PrivateKey: m.leafKey}
+	m.cache[host] = cert
+	return cert, nil
+}
+
+// caCertPEM returns the CA certificate in PEM form (public, for injecting into
+// the guest trust store).
+func (m *caMinter) caCertPEM() []byte {
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: m.caCert.Raw})
+}
+
+// prefixConn presents a net.Conn whose reads come from a bufio.Reader (which holds
+// the peeked-but-unconsumed ClientHello) while writes/close/deadlines go to the
+// underlying conn, so tls.Server sees the exact original handshake bytes.
+type prefixConn struct {
+	r io.Reader
+	net.Conn
+}
+
+func (c prefixConn) Read(p []byte) (int, error) { return c.r.Read(p) }
+
+// terminateAndSwap MITMs a TLS connection to a secret-bearing destination: it
+// terminates the guest's TLS with a minted leaf, then for each request swaps the
+// placeholder for the real value (header values + URL query only, never the body,
+// so there is no Content-Length to recompute) and re-originates over a freshly
+// validated TLS connection to dest. It returns when either side closes.
+func (p *proxy) terminateAndSwap(br *bufio.Reader, client net.Conn, dest, host string, sec *secretEntry) {
+	serverCfg := &tls.Config{GetCertificate: p.minter.getCertificate, MinVersion: tls.VersionTLS12}
+	guest := tls.Server(prefixConn{r: br, Conn: client}, serverCfg)
+	defer guest.Close()
+	if err := guest.Handshake(); err != nil {
+		p.logger.Warn("egress swap: guest TLS handshake failed", "dest", dest, "err", err)
+		return
+	}
+
+	up, err := tls.DialWithDialer(&net.Dialer{Timeout: dialTimeout}, "tcp", dest, &tls.Config{ServerName: host, MinVersion: tls.VersionTLS12})
+	if err != nil {
+		p.logger.Error("egress swap: upstream TLS dial failed", "dest", dest, "err", err)
+		return
+	}
+	defer up.Close()
+
+	guestR := bufio.NewReader(guest)
+	upR := bufio.NewReader(up)
+	for {
+		req, err := http.ReadRequest(guestR)
+		if err != nil {
+			if err != io.EOF {
+				p.logger.Debug("egress swap: read request", "dest", dest, "err", err)
+			}
+			return
+		}
+		swapRequest(req, sec)
+		// Re-emit as a client request: clear the server-side RequestURI and the
+		// absolute URL parts so req.Write sends origin-form with the Host header.
+		req.RequestURI = ""
+		req.URL.Scheme, req.URL.Host = "", ""
+		if err := req.Write(up); err != nil {
+			p.logger.Warn("egress swap: forward request", "dest", dest, "err", err)
+			return
+		}
+		resp, err := http.ReadResponse(upR, req)
+		if err != nil {
+			p.logger.Warn("egress swap: read response", "dest", dest, "err", err)
+			return
+		}
+		err = resp.Write(guest)
+		_ = resp.Body.Close()
+		if err != nil {
+			p.logger.Warn("egress swap: return response", "dest", dest, "err", err)
+			return
+		}
+		p.logger.Info("egress swapped", "dest", dest, "env", sec.Env, "path", req.URL.Path)
+	}
+}
+
+// swapRequest replaces the placeholder with the real value in every header value
+// and in the URL query/path. The body is deliberately left untouched.
+func swapRequest(req *http.Request, sec *secretEntry) {
+	for k, vs := range req.Header {
+		for i, v := range vs {
+			if strings.Contains(v, sec.Placeholder) {
+				req.Header[k][i] = strings.ReplaceAll(v, sec.Placeholder, sec.value)
+			}
+		}
+	}
+	if strings.Contains(req.URL.RawQuery, sec.Placeholder) {
+		req.URL.RawQuery = strings.ReplaceAll(req.URL.RawQuery, sec.Placeholder, sec.value)
+	}
+	if strings.Contains(req.URL.Path, sec.Placeholder) {
+		req.URL.Path = strings.ReplaceAll(req.URL.Path, sec.Placeholder, sec.value)
+	}
+}

--- a/projects/agent_platform/egress-proxy/cmd/swap_test.go
+++ b/projects/agent_platform/egress-proxy/cmd/swap_test.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"io"
+	"math/big"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestSwapRequest(t *testing.T) {
+	sec := &secretEntry{Placeholder: "kloak:demo:abc123", value: "ghp_REALTOKEN"}
+	req, err := http.NewRequest(http.MethodGet, "https://api.github.com/user?t=kloak:demo:abc123", strings.NewReader("body holds kloak:demo:abc123 and must stay"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Authorization", "Bearer kloak:demo:abc123")
+
+	swapRequest(req, sec)
+
+	if got := req.Header.Get("Authorization"); got != "Bearer ghp_REALTOKEN" {
+		t.Errorf("Authorization = %q, want swapped", got)
+	}
+	if !strings.Contains(req.URL.RawQuery, "ghp_REALTOKEN") || strings.Contains(req.URL.RawQuery, "kloak:") {
+		t.Errorf("query not swapped: %q", req.URL.RawQuery)
+	}
+	// Body must be untouched (no Content-Length recompute risk).
+	body, _ := io.ReadAll(req.Body)
+	if !strings.Contains(string(body), "kloak:demo:abc123") {
+		t.Errorf("body should be untouched, got %q", body)
+	}
+}
+
+func TestSecretFor(t *testing.T) {
+	p := &proxy{secrets: []secretEntry{{
+		Env: "GITHUB_TOKEN", Placeholder: "kloak:gh:x", value: "real", EgressTo: []string{"api.github.com", "github.com"},
+	}}}
+	if p.secretFor("API.GITHUB.COM") == nil {
+		t.Error("expected case-insensitive egressTo match")
+	}
+	if p.secretFor("evil.com") != nil {
+		t.Error("expected no match for unlisted host")
+	}
+}
+
+func TestMinterMintsSignedLeaf(t *testing.T) {
+	certFile, keyFile := writeTestCA(t)
+	m, err := newCAMinter(certFile, keyFile)
+	if err != nil {
+		t.Fatalf("newCAMinter: %v", err)
+	}
+
+	cert, err := m.getCertificate(&tls.ClientHelloInfo{ServerName: "api.github.com"})
+	if err != nil {
+		t.Fatalf("getCertificate: %v", err)
+	}
+	leaf, err := x509.ParseCertificate(cert.Certificate[0])
+	if err != nil {
+		t.Fatalf("parse leaf: %v", err)
+	}
+	if len(leaf.DNSNames) != 1 || leaf.DNSNames[0] != "api.github.com" {
+		t.Errorf("leaf DNSNames = %v, want [api.github.com]", leaf.DNSNames)
+	}
+	if err := leaf.CheckSignatureFrom(m.caCert); err != nil {
+		t.Errorf("leaf not signed by CA: %v", err)
+	}
+	// Second call for the same SNI returns the cached cert.
+	cert2, _ := m.getCertificate(&tls.ClientHelloInfo{ServerName: "api.github.com"})
+	if cert2 != cert {
+		t.Error("expected cached certificate on repeat SNI")
+	}
+	// No SNI is an error (we cannot mint a leaf for an unknown name).
+	if _, err := m.getCertificate(&tls.ClientHelloInfo{}); err == nil {
+		t.Error("expected error for empty SNI")
+	}
+}
+
+// writeTestCA generates a throwaway CA and writes its cert + key to temp PEM files.
+func writeTestCA(t *testing.T) (certFile, keyFile string) {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "test egress CA"},
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir := t.TempDir()
+	certFile = dir + "/ca.crt"
+	keyFile = dir + "/ca.key"
+	if err := os.WriteFile(certFile, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(keyFile, pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)}), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return certFile, keyFile
+}

--- a/projects/agent_platform/fc-agent-init/cmd/main.go
+++ b/projects/agent_platform/fc-agent-init/cmd/main.go
@@ -96,6 +96,7 @@ func run(logger *slog.Logger) error {
 	// is applied and before the harness starts resolving. Only with a controller
 	// (the vsock egress hop needs the host).
 	if conn != nil {
+		installGuestCA(logger)
 		setupTransparentEgress(ctx, logger, os.Getenv("EGRESS_PORTS"))
 	}
 
@@ -249,6 +250,41 @@ func dialController(ctx context.Context, logger *slog.Logger) *vsockproto.Conn {
 // loopback with no listener and fails closed rather than escaping. Generic
 // any-port capture (iptables REDIRECT) is future work (ADR 023).
 var defaultEgressPorts = []int{80, 443, 8080}
+
+// guestCABundle is the system trust bundle most TLS clients (incl. Go's gh) read.
+const guestCABundle = "/etc/ssl/certs/ca-certificates.crt"
+
+// installGuestCA installs the egress CA into the guest trust store (ADR 023 6b).
+// The CA cert (public PEM) arrives in EGRESS_CA_CERT over the trusted vsock Assign
+// channel; the harness must trust it so it accepts the leaf certs the egress-proxy
+// mints when it TLS-terminates a secret-bearing destination. No-op when unset
+// (6a, or a thread with no secrets). Runs before the harness so clients pick it up
+// at startup.
+func installGuestCA(logger *slog.Logger) {
+	caPEM := os.Getenv("EGRESS_CA_CERT")
+	if strings.TrimSpace(caPEM) == "" {
+		return
+	}
+	if f, err := os.OpenFile(guestCABundle, os.O_APPEND|os.O_WRONLY, 0o644); err != nil {
+		logger.Warn("guest CA: open trust bundle failed", "err", err)
+	} else {
+		_, werr := f.WriteString("\n" + caPEM + "\n")
+		_ = f.Close()
+		if werr != nil {
+			logger.Warn("guest CA: append to trust bundle failed", "err", werr)
+		}
+	}
+	// A standalone file + explicit env vars cover tools that do not read the bundle
+	// (node adds NODE_EXTRA_CA_CERTS to its defaults rather than replacing them).
+	const caFile = "/etc/ssl/certs/egress-ca.pem"
+	if err := os.WriteFile(caFile, []byte(caPEM), 0o644); err != nil {
+		logger.Warn("guest CA: write standalone cert failed", "err", err)
+	}
+	ensureEnv("SSL_CERT_FILE", guestCABundle)
+	ensureEnv("GIT_SSL_CAINFO", guestCABundle)
+	ensureEnv("NODE_EXTRA_CA_CERTS", caFile)
+	logger.Info("guest egress CA installed in trust store")
+}
 
 // setupTransparentEgress makes the guest a dumb egress funnel (ADR 023). It
 // points the resolver at a wildcard responder that answers every name with

--- a/projects/agent_platform/fc-agentd/chart/Chart.yaml
+++ b/projects/agent_platform/fc-agentd/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: fc-agentd
 description: Firecracker snapshot/restore controller (ADR 022) - the node-4 Postgres-reconcile daemon that manages agent-thread microVMs
 type: application
-version: 0.9.1
+version: 0.10.0
 appVersion: "latest"
 keywords:
   - firecracker

--- a/projects/agent_platform/fc-agentd/chart/templates/deployment.yaml
+++ b/projects/agent_platform/fc-agentd/chart/templates/deployment.yaml
@@ -126,6 +126,20 @@ spec:
             - name: FC_AGENTD_INJECT_{{ $k }}
               value: {{ $v | quote }}
             {{- end }}
+            {{- if .Values.egress.secrets }}
+            # Secret swap (ADR 023 6b): the guest holds only PLACEHOLDERS as the
+            # secret env vars, plus the CA cert (public, never the key) so it trusts
+            # the leaves the sidecar mints. The real values live only in the sidecar.
+            {{- range $s := .Values.egress.secrets }}
+            - name: FC_AGENTD_INJECT_{{ $s.env }}
+              value: {{ $s.placeholder | quote }}
+            {{- end }}
+            - name: FC_AGENTD_INJECT_EGRESS_CA_CERT
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "fc-agentd.fullname" . }}-egress-ca
+                  key: tls.crt
+            {{- end }}
             {{- end }}
             {{- with .Values.tracing.endpoint }}
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
@@ -180,11 +194,50 @@ spec:
             - name: EGRESS_ALLOWLIST
               value: {{ .Values.egress.allowlist | quote }}
             {{- end }}
+            {{- if .Values.egress.secrets }}
+            # Secret swap (ADR 023 6b). EGRESS_SECRETS is the non-secret catalog
+            # (placeholder -> env -> egressTo); the real value of each is supplied
+            # below from its Secret (or a literal for tests). The CA (cert + key)
+            # is mounted so the sidecar can mint leaves; the key never leaves here.
+            {{- $catalog := list }}
+            {{- range $s := .Values.egress.secrets }}
+            {{- $catalog = append $catalog (dict "placeholder" $s.placeholder "env" $s.env "egressTo" $s.egressTo) }}
+            {{- end }}
+            - name: EGRESS_SECRETS
+              value: {{ $catalog | toJson | quote }}
+            - name: EGRESS_CA_CERT_FILE
+              value: /etc/egress-ca/tls.crt
+            - name: EGRESS_CA_KEY_FILE
+              value: /etc/egress-ca/tls.key
+            {{- range $s := .Values.egress.secrets }}
+            - name: {{ $s.env }}
+              {{- if $s.secretRef }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $s.secretRef.name }}
+                  key: {{ $s.secretRef.key }}
+              {{- else }}
+              value: {{ $s.value | quote }}
+              {{- end }}
+            {{- end }}
+            {{- end }}
+          {{- if .Values.egress.secrets }}
+          volumeMounts:
+            - name: egress-ca
+              mountPath: /etc/egress-ca
+              readOnly: true
+          {{- end }}
           resources:
             {{- toYaml .Values.egress.resources | nindent 12 }}
         {{- end }}
       {{- if .Values.firecracker.enabled }}
       volumes:
+        {{- if and .Values.egress.enabled .Values.egress.secrets }}
+        # cert-manager-issued egress CA (cert + key), mounted into the sidecar only.
+        - name: egress-ca
+          secret:
+            secretName: {{ include "fc-agentd.fullname" . }}-egress-ca
+        {{- end }}
         - name: dev-kvm
           hostPath:
             path: /dev/kvm

--- a/projects/agent_platform/fc-agentd/chart/templates/egress-ca.yaml
+++ b/projects/agent_platform/fc-agentd/chart/templates/egress-ca.yaml
@@ -1,0 +1,40 @@
+{{- if and .Values.firecracker.enabled .Values.egress.enabled .Values.egress.secrets }}
+# Egress secret-swap CA (ADR 023 6b). cert-manager generates and rotates a
+# self-signed CA. The egress-proxy sidecar mounts it (cert + key) to mint leaf
+# certs per connection when it TLS-terminates a secret-bearing destination; the
+# CA private key lives only in that sidecar. fc-agentd injects the CA cert (only,
+# never the key) into each guest's trust store at Assign, so the guest trusts the
+# minted leaves without an image rebuild (rotation-safe). Scoped to the guest:
+# never added to any cluster-wide or host trust store.
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ include "fc-agentd.fullname" . }}-egress-selfsigned
+  labels:
+    {{- include "fc-agentd.labels" . | nindent 4 }}
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "fc-agentd.fullname" . }}-egress-ca
+  labels:
+    {{- include "fc-agentd.labels" . | nindent 4 }}
+spec:
+  isCA: true
+  commonName: fc-agentd egress CA
+  # cert-manager writes tls.crt (CA cert), tls.key (CA key), ca.crt to this Secret.
+  secretName: {{ include "fc-agentd.fullname" . }}-egress-ca
+  # Long-lived: a rotation reissues the CA and (via the guest injection) the guest
+  # picks up the new cert on the next thread, but in-flight snapshots trust the old
+  # one until they cycle, so we keep churn rare.
+  duration: {{ .Values.egress.ca.duration | quote }}
+  renewBefore: {{ .Values.egress.ca.renewBefore | quote }}
+  privateKey:
+    algorithm: RSA
+    size: 2048
+  issuerRef:
+    name: {{ include "fc-agentd.fullname" . }}-egress-selfsigned
+    kind: Issuer
+{{- end }}

--- a/projects/agent_platform/fc-agentd/chart/values.yaml
+++ b/projects/agent_platform/fc-agentd/chart/values.yaml
@@ -56,13 +56,28 @@ egress:
     OPENAI_API_KEY: sk-noauth
     GOOSE_PROVIDER: openai
     GOOSE_MODEL: qwen3.6-27b
+  # 6b CA: cert-manager generates + rotates the self-signed CA the sidecar uses to
+  # mint leaf certs when it TLS-terminates a secret-bearing destination. Only
+  # created when `secrets` below is non-empty.
+  ca:
+    duration: 87600h # 10y; rotation churns guest trust, keep it rare
+    renewBefore: 2160h # 90d
   # 6b: the ADR-023 secret catalog (shaped like the future SecretProxy CRD
-  # spec.secrets). egressTo is the control: the destinations a swapped-in
-  # credential may reach. The guest only ever holds the placeholder.
-  # secrets:
-  #   - env: GITHUB_TOKEN
-  #     secretRef: { name: agent-github-bot, key: token }
-  #     egressTo: [api.github.com]
+  # spec.secrets). Each entry: a high-entropy `placeholder` the guest holds as
+  # `env`; the sidecar swaps it for the real value (literal `value` for tests, or
+  # `secretRef` {name,key} for production) only on a connection whose host is in
+  # `egressTo`. egressTo is the exfiltration control: everywhere else the inert
+  # placeholder leaves. Literal swap only (a base64'd git-Basic token is ADR-
+  # deferred). A non-empty list enables the CA + TLS-terminate path.
+  secrets:
+    # The agent's gh/API calls carry this placeholder; the sidecar swaps it for the
+    # real token (already in-namespace, synced by the monolith from 1Password) only
+    # on api.github.com. Literal swap: gh API works; raw git-over-HTTPS Basic (a
+    # base64'd token) is ADR-deferred.
+    - env: GITHUB_TOKEN
+      placeholder: "kloak:gh:01JZX8K3N7Q2M5R9W4T6Y0F1B8"
+      egressTo: [api.github.com]
+      secretRef: { name: monolith-chat-secrets, key: GITHUB_TOKEN }
   resources:
     requests:
       cpu: 50m

--- a/projects/agent_platform/fc-agentd/deploy/application.yaml
+++ b/projects/agent_platform/fc-agentd/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: fc-agentd
-      targetRevision: 0.9.1
+      targetRevision: 0.10.0
       helm:
         valueFiles:
           - $values/projects/agent_platform/fc-agentd/deploy/values.yaml


### PR DESCRIPTION
## What

Completes ADR 023: the agent's `gh`/API calls carry a high-entropy **placeholder**; the egress sidecar swaps it for the real token **only on the secret's `egressTo`**, so the guest never holds a real credential. Builds on 6a transparent egress (#2881).

## How

- **egress-proxy**: for a TLS destination in a secret's `egressTo`, TLS-terminate with a leaf minted from the egress CA (one pre-generated leaf key; per-SNI cert cached), literal-swap the placeholder in **header values + URL query** (never the body, so no `Content-Length` recompute), and re-originate over a **freshly validated** TLS connection to the real host. `EGRESS_SECRETS` is the non-secret catalog; real values come from the sidecar env (mounted Secret).
- **CA via cert-manager** (self-signed `Issuer` + CA `Certificate`), mounted into the sidecar only. fc-agentd injects the CA cert (cert-only, **never the key**) into the guest at Assign; fc-agent-init installs it in the trust store so the harness trusts the minted leaves. Rotation-safe, no image rebuild.
- **chart**: `egress.secrets` catalog + `egress.ca`. The real `GITHUB_TOKEN` reuses the in-namespace `monolith-chat-secrets`, **no new 1Password item**.
- Tests: `swapRequest` (header/query swapped, body untouched), `secretFor` egressTo match, CA leaf minting + signature.

## Security (ADR 023)

- The guest holds only the placeholder; the real value lives only in the sidecar (off the guest, on the host side of the Firecracker boundary), never in a snapshot.
- The swap fires only for a host in `egressTo`; a prompt-injected agent POSTing its "token" anywhere else leaks the inert placeholder.
- The guest-scoped CA is never added to any cluster-wide/host trust store; the CA key never reaches fc-agentd or the guest.

## Scope

Literal swap covers `gh`/API (`Authorization: Bearer`). Raw `git push` over HTTPS (Basic auth = base64'd token) is **ADR-deferred** to a per-scheme handler.

## Validation

Tests green locally. After merge: submit a thread asking goose to run a read-only `gh api user` and confirm it returns the authenticated login (proves the swap with the real credential, the placeholder would 401).

🤖 Generated with [Claude Code](https://claude.com/claude-code)