### PR TITLE
fix(agent_platform): load goose developer extension (--with-builtin)

### DIFF
--- a/projects/agent_platform/fc-agent-init/internal/harness/harness.go
+++ b/projects/agent_platform/fc-agent-init/internal/harness/harness.go
@@ -19,8 +19,14 @@ type Config struct {
 
 // GooseCommand returns the argv to run, mirroring the established invocation:
 //
-//	with a recipe:  goose run --recipe <recipe> --no-profile --params task_description=<task>
+//	with a recipe:  goose run --recipe <recipe> --no-profile --with-builtin developer --params task_description=<task>
 //	bare task only: goose run --text <task>
+//
+// --no-profile keeps the run deterministic (it ignores the baked config.yaml), but
+// it also suppresses extension loading, and a recipe's own `extensions:` field does
+// not reliably load builtins, so the agent would start with NO tools (it could talk
+// to the model but not run a shell). --with-builtin developer explicitly loads the
+// shell/editor extension so the agent can actually do work.
 //
 // It returns nil when there is nothing to run (a warm-base boot with no task),
 // in which case fc-agent-init idles without a harness until a task arrives.
@@ -30,6 +36,7 @@ func GooseCommand(c Config) []string {
 			"goose", "run",
 			"--recipe", c.Recipe,
 			"--no-profile",
+			"--with-builtin", "developer",
 			"--params", fmt.Sprintf("task_description=%s", c.Task),
 		}
 	}

--- a/projects/agent_platform/fc-agent-init/internal/harness/harness_test.go
+++ b/projects/agent_platform/fc-agent-init/internal/harness/harness_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestGooseCommandWithRecipe(t *testing.T) {
 	got := GooseCommand(Config{Recipe: "/etc/goose/recipes/agent.yaml", Task: "fix the flaky test"})
-	want := "goose run --recipe /etc/goose/recipes/agent.yaml --no-profile --params task_description=fix the flaky test"
+	want := "goose run --recipe /etc/goose/recipes/agent.yaml --no-profile --with-builtin developer --params task_description=fix the flaky test"
 	if strings.Join(got, " ") != want {
 		t.Fatalf("got %q, want %q", strings.Join(got, " "), want)
 	}

--- a/projects/agent_platform/fc-agentd/chart/Chart.yaml
+++ b/projects/agent_platform/fc-agentd/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: fc-agentd
 description: Firecracker snapshot/restore controller (ADR 022) - the node-4 Postgres-reconcile daemon that manages agent-thread microVMs
 type: application
-version: 0.10.0
+version: 0.10.1
 appVersion: "latest"
 keywords:
   - firecracker

--- a/projects/agent_platform/fc-agentd/deploy/application.yaml
+++ b/projects/agent_platform/fc-agentd/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: fc-agentd
-      targetRevision: 0.10.0
+      targetRevision: 0.10.1
       helm:
         valueFiles:
           - $values/projects/agent_platform/fc-agentd/deploy/values.yaml


### PR DESCRIPTION
## Problem

Validating ADR 023 6b in-cluster, goose started with **0 extensions** and just *printed* `gh api user` in a code block instead of executing it, so the secret-swap path was never exercised.

## Root cause

`goose run --recipe ... --no-profile` suppresses extension loading, and a recipe's own `extensions:` field does not reliably load builtins ([goose#6678](https://github.com/block/goose/issues/6678)). With `--no-profile`, builtins must be added explicitly via `--with-builtin`. So the agent had no shell, it could talk to the model but couldn't run anything.

## Fix

Add `--with-builtin developer` to the recipe invocation. Keeps `--no-profile` (determinism; ignores the baked `config.yaml`) while loading the shell/editor extension the agent needs to do real work.

## Validation

Harness unit test updated. After deploy: re-run the `gh api user` thread and confirm goose executes it and the egress-proxy logs `egress swapped` on `api.github.com`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)