### PR TITLE
chore(platform): right-size node-4 memory from 7-day SigNoz peaks

### DIFF
--- a/projects/inference/deploy/values.yaml
+++ b/projects/inference/deploy/values.yaml
@@ -268,12 +268,16 @@ readinessProbe:
 # memory pressure now that its memory request is set to steady-state, not peak.
 priorityClassName: homelab-critical
 
-# Burstable memory (ADR platform/010): request = steady-state, limit = peak.
-# 7-day SigNoz peak memory is ~20Gi (vLLM KV cache), but steady-state is ~5Gi and
-# sub-peaks ~6.6Gi, and the 20Gi spike is rare and uncorrelated with other node-4
-# workloads. Requesting 8Gi (steady + margin) instead of 24Gi frees ~16Gi of
-# node-4 reservation for the agent-microVM tier; the 32Gi limit still covers the
-# burst.
+# Burstable memory (ADR platform/010): request = steady-state, limit holds the
+# real anonymous peak. The model and its KV cache live in GPU VRAM, which is a
+# separate resource from the host RAM this limit governs. 7-day SigNoz shows host
+# RSS (the non-reclaimable part that can actually OOM) never exceeds ~5Gi.
+# working_set spikes to ~20Gi only during model load, when the ~18-20GB of int4
+# weight files transit host page cache on the way to VRAM; that cache is clean and
+# reclaimable, so the cgroup evicts it before any OOM. A 16Gi limit sits ~3x above
+# the real RSS and only forces page-cache reclaim during the rare load, which is
+# harmless (the weights are already in VRAM by then). Trimmed 32 -> 16 to keep the
+# node-4 paper overcommit honest for the agent-microVM tier.
 # CPU request trimmed 4 -> 2: vLLM decode is GPU-bound, 7-day SigNoz peak CPU is
 # ~1715m (avg ~7m), so 2 cores covers peak with headroom.
 resources:
@@ -282,7 +286,7 @@ resources:
     memory: "8Gi"
     nvidia.com/gpu: 1
   limits:
-    memory: "32Gi"
+    memory: "16Gi"
     nvidia.com/gpu: 1
 
 # Embeddings are served by llama.cpp on CPU (no GPU layers).
@@ -324,9 +328,13 @@ embeddings:
     linkerd.io/inject: disabled
     prometheus.io/scrape: "true"
     prometheus.io/port: "8080"
+  # 7-day SigNoz RSS is ~5.5Gi and almost entirely anonymous (working_set == RSS:
+  # llama.cpp holds the GGUF weights in host RAM, n-gpu-layers 0), so the 4Gi
+  # request under-reserved what it actually needs. Raised 4 -> 6 to reserve the
+  # real footprint; the 8Gi limit keeps headroom for ubatch spikes.
   resources:
     requests:
       cpu: 2
-      memory: "4Gi"
+      memory: "6Gi"
     limits:
       memory: "8Gi"

--- a/projects/mcp/context-forge-gateway/deploy/values.yaml
+++ b/projects/mcp/context-forge-gateway/deploy/values.yaml
@@ -20,13 +20,16 @@ mcp-stack:
         periodSeconds: 15
         timeoutSeconds: 5
         failureThreshold: 5
+    # 7-day SigNoz peak RSS 490Mi / working_set 533Mi. Trimmed 1Gi -> 768Mi
+    # (req==limit, Guaranteed) to reclaim reservation on node-2 (a 12.3Gi
+    # control-plane node) while keeping ~1.4x headroom over the real peak.
     resources:
       requests:
         cpu: 50m
-        memory: 1Gi
+        memory: 768Mi
       limits:
         cpu: 200m
-        memory: 1Gi
+        memory: 768Mi
   migration:
     enabled: false
   postgres:

--- a/projects/platform/signoz/values-prod.yaml
+++ b/projects/platform/signoz/values-prod.yaml
@@ -213,13 +213,16 @@ signoz:
       # Health probes are exempt and stay on /api/v1/health at the root.
       signoz_global_external__url: https://private.jomcgi.dev/app/signoz
   clickhouse:
+    # 7-day SigNoz working_set ~6.4Gi, growing, against the old 8Gi limit (~80%).
+    # Raised request 5 -> 6.5 to reserve real usage and limit 8 -> 10 for headroom
+    # (node-4 has ample room). The telemetry store is the binding signoz tenant.
     resources:
       requests:
         cpu: 2
-        memory: 5Gi
+        memory: 6.5Gi
       limits:
         cpu: 4
-        memory: 8Gi
+        memory: 10Gi
     persistence:
       size: 150Gi
     # System table TTL settings (days) - prevents unbounded growth
@@ -244,18 +247,23 @@ signoz:
         ttl: 7
     # Zookeeper is a subchart of clickhouse
     zookeeper:
+      # 7-day working_set ~1.13Gi against a 1Gi request: raised 1 -> 1.25 to
+      # reserve real usage. Lives on a small (12.3Gi) control-plane node.
       resources:
         requests:
           cpu: 100m
-          memory: 1Gi
+          memory: 1.25Gi
         limits:
           cpu: 1
           memory: 1.5Gi
   otelCollector:
+    # 7-day SigNoz peak RSS 667Mi / working_set 680Mi: the old 2Gi request / 4Gi
+    # limit reserved ~3x the real peak. Trimmed to 768Mi / 1.5Gi (above the 680Mi
+    # peak with ~2x burst headroom for incident-time telemetry spikes).
     resources:
       requests:
         cpu: 200m
-        memory: 2Gi
+        memory: 768Mi
       limits:
         cpu: 2
-        memory: 4Gi
+        memory: 1.5Gi


### PR DESCRIPTION
## Why

While planning the Firecracker agent-microVM tier's concurrency/memory budget on node-4, an audit of node-4 (which looked "93% committed" but is only **26% real usage**, ~45Gi free) surfaced both over-provisioned ceilings and under-reserved workloads. All numbers below are **7-day SigNoz RSS/working_set peaks**, not instantaneous `kubectl top` (which misses peaks).

The headline finding: the inference pod's documented "~20Gi memory peak" was a **VRAM/host-RAM conflation**. The model and KV cache live in GPU VRAM; the host RAM this limit governs has an RSS that never exceeds **~5Gi**. The 13-20Gi working_set spikes are reclaimable page cache during model load (int4 weights transiting host page cache to VRAM), which the cgroup evicts before any OOM.

## Changes

**Trim over-provisioning:**
| Workload | node | before (req/lim) | after | basis (7-day) |
|---|---|---|---|---|
| inference | node-4 | 8Gi / 32Gi | 8Gi / **16Gi** | RSS ≤4.9Gi; 20Gi working_set is reclaimable load-time cache |
| signoz otelCollector | node-4 | 2Gi / 4Gi | **768Mi / 1.5Gi** | peak RSS 667Mi |
| context-forge gateway | node-2 | 1Gi / 1Gi | **768Mi / 768Mi** | peak RSS 490Mi; reclaims on a 12.3Gi CP node |

**Fix under-reservation (latent eviction/OOM risk):**
| Workload | node | before (req/lim) | after | basis (7-day) |
|---|---|---|---|---|
| embeddings | node-4 | 4Gi / 8Gi | **6Gi** / 8Gi | uses ~5.5Gi anonymous (GGUF weights in host RAM, n-gpu-layers 0) |
| signoz clickhouse | node-4 | 5Gi / 8Gi | **6.5Gi / 10Gi** | at ~80% of old limit, growing |
| signoz zookeeper | node-1 | 1Gi / 1.5Gi | **1.25Gi** / 1.5Gi | uses ~1.13Gi |

## Effect

node-4 committed limits drop **~93% -> ~68%** with real usage unchanged, leaving clean headroom for the agent-microVM tier. The under-reservation fixes prevent the kubelet from mis-ranking these for eviction under node pressure (clickhouse and embeddings both run hot vs their old requests).

## Deferred

- **monolith-pg request 512Mi -> 768Mi** (uses 719Mi): needs a chart-template edit that rolls the primary CNPG instance (switchover). Not worth bundling with values-only changes; will follow up. The 1Gi limit still covers current usage, so it is not an active risk.

## Verification

- `helm template` of the inference chart renders the 16Gi limit / 6Gi embeddings request correctly.
- No tests assert on the changed values.
- All edits are values-only (inference deploy values, signoz values-prod, context-forge deploy values), so no chart version bumps; ArgoCD picks them up on sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)