### PR TITLE
feat(fc-agentd): bound microVM concurrency to protect the controller

### DIFF
--- a/projects/agent_platform/fc-agentd/chart/Chart.yaml
+++ b/projects/agent_platform/fc-agentd/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: fc-agentd
 description: Firecracker snapshot/restore controller (ADR 022) - the node-4 Postgres-reconcile daemon that manages agent-thread microVMs
 type: application
-version: 0.10.1
+version: 0.11.0
 appVersion: "latest"
 keywords:
   - firecracker

--- a/projects/agent_platform/fc-agentd/chart/templates/deployment.yaml
+++ b/projects/agent_platform/fc-agentd/chart/templates/deployment.yaml
@@ -105,6 +105,14 @@ spec:
               value: {{ .Values.firecracker.binPath | quote }}
             - name: FC_AGENTD_KERNEL_IMAGE
               value: {{ .Values.firecracker.kernelImagePath | quote }}
+            # Concurrency cap + per-guest RAM + OOM bias (see values.yaml `agent`).
+            # maxConcurrent * guestMemMib must fit under resources.limits.memory.
+            - name: FC_AGENTD_MAX_CONCURRENT
+              value: {{ .Values.agent.maxConcurrent | quote }}
+            - name: FC_AGENTD_GUEST_MEM_MIB
+              value: {{ .Values.agent.guestMemMib | quote }}
+            - name: FC_AGENTD_GUEST_OOM_SCORE_ADJ
+              value: {{ .Values.agent.guestOomScoreAdj | quote }}
             {{- with .Values.firecracker.rootfsPath }}
             - name: FC_AGENTD_ROOTFS_PATH
               value: {{ . | quote }}

--- a/projects/agent_platform/fc-agentd/chart/values.yaml
+++ b/projects/agent_platform/fc-agentd/chart/values.yaml
@@ -101,17 +101,30 @@ priorityClassName: homelab-critical
 tolerations: []
 affinity: {}
 
-# fc-agentd launches Firecracker microVMs as child processes, so each guest's
-# memory (firecracker.guestMemMib, default 1024Mi) counts against this container's
-# cgroup. The limit must hold the daemon plus the live microVMs, or the guest's
-# pages OOM-kill the whole container (137) the moment a thread does real work.
-# Burstable: a small steady-state request, a limit that fits ~1 active microVM.
+# Concurrency + OOM safety for the microVM tier. fc-agentd runs each Firecracker
+# guest as a child process, so guest RAM counts against THIS container's cgroup.
+# Two mechanisms keep that from taking the controller down:
+#   1. maxConcurrent caps live microVMs; the reconcile loop queues the rest as
+#      PENDING. Since Firecracker hard-caps each guest's RAM, maxConcurrent *
+#      guestMemMib is a true upper bound on microVM memory in the cgroup.
+#   2. guestOomScoreAdj biases the kernel to kill a guest, never the daemon, if
+#      memory pressure does hit (the disposable-victim intent of ADR platform/010,
+#      applied to processes because the guests are not pods).
+agent:
+  maxConcurrent: 8
+  guestMemMib: 1024
+  guestOomScoreAdj: 1000
+
+# The limit must hold maxConcurrent guests plus the daemon: 8 * 1Gi + ~1Gi
+# overhead = 9Gi. Burstable: request a small warm floor (~2 guests), let the
+# limit cover the capped peak. The admission cap guarantees the cgroup never
+# exceeds it, and oom_score_adj guarantees a guest dies first if it ever nears.
 resources:
   requests:
     cpu: 50m
-    memory: 512Mi
-  limits:
     memory: 2Gi
+  limits:
+    memory: 9Gi
 
 # The monolith Postgres DSN (claude_agent.agent_threads registry). Defaults to
 # the CNPG-generated app credential. When deployed outside the monolith

--- a/projects/agent_platform/fc-agentd/cmd/main.go
+++ b/projects/agent_platform/fc-agentd/cmd/main.go
@@ -68,7 +68,7 @@ func run(logger *slog.Logger) error {
 		SnapshotRoot:    cfg.SnapshotRoot,
 		Node:            cfg.Node,
 		Arch:            cfg.Arch,
-	}, &driver.ExecLauncher{Bin: cfg.FirecrackerBin}, nil)
+	}, &driver.ExecLauncher{Bin: cfg.FirecrackerBin, OOMScoreAdj: cfg.GuestOOMScoreAdj}, nil)
 
 	loop := &reconcile.Loop{
 		Executor:      fcDriver,
@@ -79,6 +79,7 @@ func run(logger *slog.Logger) error {
 		ControlUDS:    fcDriver.VsockUDSPath,
 		GooseEnv:      cfg.InjectedEnv,
 		EgressSidecar: cfg.EgressSidecar,
+		MaxConcurrent: cfg.MaxConcurrent,
 	}
 
 	if cfg.DatabaseURL != "" {

--- a/projects/agent_platform/fc-agentd/deploy/application.yaml
+++ b/projects/agent_platform/fc-agentd/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: fc-agentd
-      targetRevision: 0.10.1
+      targetRevision: 0.11.0
       helm:
         valueFiles:
           - $values/projects/agent_platform/fc-agentd/deploy/values.yaml

--- a/projects/agent_platform/fc-agentd/internal/config/config.go
+++ b/projects/agent_platform/fc-agentd/internal/config/config.go
@@ -45,6 +45,23 @@ type Config struct {
 	GuestVCPUs  int
 	GuestMemMib int
 
+	// MaxConcurrent caps how many microVMs may be live (RUNNING or restored) at
+	// once on this node. The reconcile loop refuses to claim past it, leaving
+	// excess threads PENDING (a queue drained as live VMs idle or complete).
+	// Because Firecracker hard-caps each guest's RAM, MaxConcurrent * GuestMemMib
+	// is a true upper bound on the microVM memory in this daemon's cgroup, which
+	// is what keeps a burst of submissions from OOM-killing the controller. 0
+	// disables the cap (unbounded; tests/dry-run).
+	MaxConcurrent int
+
+	// GuestOOMScoreAdj is written to each Firecracker child's
+	// /proc/<pid>/oom_score_adj so the guest, never the daemon, is the kernel's
+	// first OOM victim under cgroup or node memory pressure (ADR platform/010's
+	// disposable-victim intent, applied to processes because the guests are child
+	// processes, not pods). 0 leaves the inherited score; a high value (e.g.
+	// 1000) makes guests strictly preferred for the kill.
+	GuestOOMScoreAdj int
+
 	// EgressSidecar is the localhost address of the egress-proxy sidecar (ADR
 	// 023) the loop forwards guest egress to. Empty disables egress forwarding.
 	EgressSidecar string
@@ -74,6 +91,8 @@ func Load() (Config, error) {
 		HarnessInit:       getenvDefault("FC_AGENTD_HARNESS_INIT", "/usr/local/bin/fc-agent-init"),
 		GuestVCPUs:        atoiDefault("FC_AGENTD_GUEST_VCPUS", 1),
 		GuestMemMib:       atoiDefault("FC_AGENTD_GUEST_MEM_MIB", 1024),
+		MaxConcurrent:     atoiDefault("FC_AGENTD_MAX_CONCURRENT", 8),
+		GuestOOMScoreAdj:  atoiDefault("FC_AGENTD_GUEST_OOM_SCORE_ADJ", 1000),
 		EgressSidecar:     os.Getenv("FC_AGENTD_EGRESS_SIDECAR"),
 		InjectedEnv:       injectedEnv(),
 	}

--- a/projects/agent_platform/fc-agentd/internal/driver/launcher.go
+++ b/projects/agent_platform/fc-agentd/internal/driver/launcher.go
@@ -3,9 +3,11 @@ package driver
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"net"
 	"os"
 	"os/exec"
+	"strconv"
 	"time"
 )
 
@@ -18,6 +20,12 @@ type ExecLauncher struct {
 	// ReadyTimeout bounds how long Launch waits for the API socket to accept
 	// connections before giving up.
 	ReadyTimeout time.Duration
+	// OOMScoreAdj, when > 0, is written to the launched Firecracker process's
+	// /proc/<pid>/oom_score_adj so the guest is the kernel's first OOM victim
+	// under memory pressure, never the daemon (the guests share the daemon's
+	// cgroup because they are child processes, not pods). Best-effort: a write
+	// failure is logged, not fatal.
+	OOMScoreAdj int
 }
 
 type execProcess struct {
@@ -53,6 +61,14 @@ func (l *ExecLauncher) Launch(ctx context.Context, vmID, socketPath string) (Pro
 	}
 	proc := &execProcess{cmd: cmd}
 
+	if l.OOMScoreAdj > 0 {
+		if err := setOOMScoreAdj(cmd.Process.Pid, l.OOMScoreAdj); err != nil {
+			// Best-effort hardening; the cap still bounds memory if this fails.
+			slog.Warn("driver: set firecracker oom_score_adj",
+				"vm", vmID, "pid", cmd.Process.Pid, "score", l.OOMScoreAdj, "err", err)
+		}
+	}
+
 	timeout := l.ReadyTimeout
 	if timeout <= 0 {
 		timeout = 10 * time.Second
@@ -62,6 +78,14 @@ func (l *ExecLauncher) Launch(ctx context.Context, vmID, socketPath string) (Pro
 		return nil, err
 	}
 	return proc, nil
+}
+
+// setOOMScoreAdj writes score to /proc/<pid>/oom_score_adj, biasing the kernel
+// OOM killer to pick this process first. Valid range is -1000..1000; the daemon
+// must have permission (fc-agentd runs privileged on node-4).
+func setOOMScoreAdj(pid, score int) error {
+	path := fmt.Sprintf("/proc/%d/oom_score_adj", pid)
+	return os.WriteFile(path, []byte(strconv.Itoa(score)), 0o644)
 }
 
 func waitForSocket(ctx context.Context, socketPath string, timeout time.Duration) error {

--- a/projects/agent_platform/fc-agentd/internal/reconcile/reconcile.go
+++ b/projects/agent_platform/fc-agentd/internal/reconcile/reconcile.go
@@ -55,6 +55,14 @@ type Loop struct {
 	Interval  time.Duration
 	Logger    *slog.Logger
 
+	// MaxConcurrent caps the number of live microVMs (RUNNING or restored) on this
+	// node. createPending and restoreWakeRequested stop claiming once the live set
+	// reaches it, leaving the rest PENDING / wake-requested for a later tick. With
+	// Firecracker's per-guest RAM cap this bounds the microVM memory in the
+	// daemon's cgroup, so a burst of submissions can never OOM the controller. 0
+	// disables the cap.
+	MaxConcurrent int
+
 	// ControlUDS resolves a thread's vsock control UDS path so the loop can serve
 	// the per-thread control channel (task delivery + idle/done). nil disables
 	// control serving (dry-run / tests with no vsock).
@@ -181,6 +189,12 @@ func (l *Loop) createPending(ctx context.Context, log *slog.Logger) {
 		if _, ok := l.live[t.ThreadID]; ok {
 			continue
 		}
+		if l.atCapacity() {
+			// Leave the rest PENDING; a later tick claims them as slots free.
+			log.Info("reconcile: at concurrency cap, deferring pending threads",
+				"max", l.MaxConcurrent, "live", len(l.live))
+			return
+		}
 		spec := substrate.ClaimSpec{ThreadID: t.ThreadID, Repo: t.Repo, Branch: t.Branch, Arch: t.Arch}
 		if t.BaseSnapshotRef != "" {
 			spec.BaseSnapshotRef = substrate.SnapshotRef{ID: t.BaseSnapshotRef, Node: t.Node, Arch: t.Arch, Base: true}
@@ -256,6 +270,12 @@ func (l *Loop) restoreWakeRequested(ctx context.Context, log *slog.Logger) {
 		if _, ok := l.live[t.ThreadID]; ok {
 			_ = l.Registry.ClearWake(ctx, t.ThreadID)
 			continue
+		}
+		if l.atCapacity() {
+			// Keep the wake request set; a later tick restores it once a slot frees.
+			log.Info("reconcile: at concurrency cap, deferring wake restores",
+				"max", l.MaxConcurrent, "live", len(l.live))
+			return
 		}
 		h, err := l.Executor.Restore(ctx, refFor(t))
 		if err != nil {
@@ -352,6 +372,12 @@ func refFor(t store.Thread) substrate.SnapshotRef {
 		Arch:      t.Arch,
 		SizeBytes: t.SizeBytes,
 	}
+}
+
+// atCapacity reports whether the live microVM set has reached MaxConcurrent. A
+// zero MaxConcurrent disables the cap (unbounded).
+func (l *Loop) atCapacity() bool {
+	return l.MaxConcurrent > 0 && len(l.live) >= l.MaxConcurrent
 }
 
 // LiveThreads reports the thread IDs the loop currently tracks (test/observability).

--- a/projects/agent_platform/fc-agentd/internal/reconcile/reconcile_test.go
+++ b/projects/agent_platform/fc-agentd/internal/reconcile/reconcile_test.go
@@ -189,6 +189,67 @@ func TestReconcileCreatesPending(t *testing.T) {
 	}
 }
 
+func TestReconcileAdmissionCapDefersExcess(t *testing.T) {
+	reg := newFakeRegistry(
+		store.Thread{ThreadID: "t1", State: substrate.StatePending, Node: "node-4"},
+		store.Thread{ThreadID: "t2", State: substrate.StatePending, Node: "node-4"},
+		store.Thread{ThreadID: "t3", State: substrate.StatePending, Node: "node-4"},
+	)
+	ex := &fakeExec{}
+	l := newLoop(reg, ex)
+	l.MaxConcurrent = 2
+	l.reconcileOnce(context.Background(), testLogger())
+
+	if ex.claims != 2 {
+		t.Fatalf("claims = %d, want 2 (capped at MaxConcurrent)", ex.claims)
+	}
+	if l.LiveThreads() != 2 {
+		t.Fatalf("live = %d, want 2", l.LiveThreads())
+	}
+	// Exactly one of the three stays PENDING (map order is non-deterministic, so
+	// assert the count, not which one).
+	pending := 0
+	for _, id := range []string{"t1", "t2", "t3"} {
+		if reg.state(id) == substrate.StatePending {
+			pending++
+		}
+	}
+	if pending != 1 {
+		t.Fatalf("pending = %d, want 1 deferred past the cap", pending)
+	}
+}
+
+func TestReconcileAdmissionCapDrainsAsSlotsFree(t *testing.T) {
+	reg := newFakeRegistry(
+		store.Thread{ThreadID: "t1", State: substrate.StatePending, Node: "node-4"},
+		store.Thread{ThreadID: "t2", State: substrate.StatePending, Node: "node-4"},
+	)
+	ex := &fakeExec{}
+	l := newLoop(reg, ex)
+	l.MaxConcurrent = 1
+	l.reconcileOnce(context.Background(), testLogger())
+	if l.LiveThreads() != 1 {
+		t.Fatalf("live after first pass = %d, want 1", l.LiveThreads())
+	}
+
+	// Complete whichever thread was admitted; the loop reclaims it and frees the
+	// slot, and a later pass admits the queued one (so the queue drains).
+	for _, id := range []string{"t1", "t2"} {
+		if reg.state(id) == substrate.StateRunning {
+			_ = reg.SetState(context.Background(), id, substrate.StateCompleted)
+		}
+	}
+	l.reconcileOnce(context.Background(), testLogger()) // reclaims completed, frees the slot
+	l.reconcileOnce(context.Background(), testLogger()) // admits the queued thread
+
+	if ex.claims != 2 {
+		t.Fatalf("claims = %d, want 2 (both admitted over time)", ex.claims)
+	}
+	if l.LiveThreads() != 1 {
+		t.Fatalf("live = %d, want 1 (still capped)", l.LiveThreads())
+	}
+}
+
 func TestReconcileSnapshotsOnIdle(t *testing.T) {
 	reg := newFakeRegistry(store.Thread{ThreadID: "t1", State: substrate.StatePending, Node: "node-4"})
 	ex := &fakeExec{}


### PR DESCRIPTION
## Problem

fc-agentd runs each Firecracker guest as a **child process**, so guest RAM counts against the controller container's own cgroup. Two latent failure modes:

1. **No admission control.** `createPending` booted a microVM for *every* PENDING thread unconditionally. Submit N threads → N microVMs, unbounded.
2. **The cgroup limit was the only bound, and it was also the kill trigger.** With a 2Gi limit and 1Gi guests, the *second* active guest breaches the limit and the cgroup OOM-killer can take down the daemon (137). The ADR platform/010 disposable-victim PriorityClass didn't help, because the guests inherit the daemon pod's `homelab-critical` priority (they aren't pods).

## Fix

**1. Admission cap** (`FC_AGENTD_MAX_CONCURRENT`, default 8). `createPending` and `restoreWakeRequested` stop claiming once the live set hits the cap, leaving the rest PENDING / wake-requested — a queue drained as VMs idle or complete. Since Firecracker hard-caps each guest's RAM, `maxConcurrent × guestMemMib` is a **true** upper bound on microVM memory in the cgroup.

**2. Guest `oom_score_adj`** (`FC_AGENTD_GUEST_OOM_SCORE_ADJ`, default 1000). Each Firecracker child's `/proc/<pid>/oom_score_adj` is set high so the kernel kills a **guest, never the daemon**, under cgroup or node memory pressure. This is ADR platform/010's disposable-victim intent applied at the process level (best-effort: a write failure logs, the cap still bounds memory).

## Sizing

| | before | after |
|---|---|---|
| max concurrent | unbounded | **8** |
| guest RAM | 1Gi | 1Gi (kept) |
| cgroup request / limit | 512Mi / 2Gi | **2Gi / 9Gi** (8×1Gi + ~1Gi daemon) |

node-4 has ~43Gi real headroom after the round-3 right-size (#2887), so 1Gi guests are kept for per-guest reliability. A 512Mi / 16-concurrent variant is **deferred** pending a heavy-task (50-turn) validation — it only matters if node-4 ever gets memory-tight, which it isn't.

Guest RAM was confirmed safe at 1Gi by an **e2e thread run this session** (goose → Qwen → `harness done, status: ok`). The guest working set proved too small and short-lived to sample via metrics-server (the fc-agentd container never exceeded 11Mi during a full run), which is *why* the cgroup is sized to the hard `N × guestMemMib` ceiling rather than a measured typical.

## Tests / verification

- New `TestReconcileAdmissionCapDefersExcess` (cap defers the surplus) and `TestReconcileAdmissionCapDrainsAsSlotsFree` (queue drains as slots free).
- `go test ./internal/{reconcile,driver}` pass; `go vet` clean; `go build` ok.
- `helm template` renders the three env vars + the 9Gi/2Gi resources with `firecracker.enabled=true`.
- Chart bumped 0.10.1 → 0.11.0 (Chart.yaml + application.yaml targetRevision in sync).

## Follow-ups

- 512Mi-guest validation under a 50-turn task (would double concurrency per Gi).
- Longer-term: revisit fc-agentd vs pod-shaped kata-fc for this tier (ADR 022 decision 6) — pod-shaped would make admission/accounting/OOM-victim native k8s primitives instead of hand-rolled. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)