### PR TITLE
feat(fc-agentd): per-thread model tier for goosecracker artifact agent (ADR 024 Task 1)

### DIFF
--- a/projects/agent_platform/fc-agentd/chart/Chart.yaml
+++ b/projects/agent_platform/fc-agentd/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: fc-agentd
 description: Firecracker snapshot/restore controller (ADR 022) - the node-4 Postgres-reconcile daemon that manages agent-thread microVMs
 type: application
-version: 0.11.0
+version: 0.12.0
 appVersion: "latest"
 keywords:
   - firecracker

--- a/projects/agent_platform/fc-agentd/chart/templates/deployment.yaml
+++ b/projects/agent_platform/fc-agentd/chart/templates/deployment.yaml
@@ -123,25 +123,28 @@ spec:
             {{- end }}
             {{- end }}
             {{- if and .Values.firecracker.enabled .Values.egress.enabled }}
-            # Egress (ADR 023): forward guest vsock egress to the sidecar, and
-            # project the harness env into the guest via the Assign message. Each
-            # harnessEnv key becomes FC_AGENTD_INJECT_<KEY> (the controller strips
-            # the prefix and injects <KEY> into the guest). Routing needs no config:
-            # the guest funnels all egress to the sidecar, which routes by SNI/Host.
+            # Egress (ADR 023 + 024): forward guest vsock egress to the sidecar,
+            # and project the PER-TIER harness env into the guest via the Assign
+            # message. Each tiers.<TIER>.<KEY> becomes FC_AGENTD_TIER_<TIER>__<KEY>;
+            # the controller selects the thread's tier, merges it over the common
+            # injected env, and injects <KEY> into the guest. "__" separates the
+            # tier name from the env name (which may itself contain underscores,
+            # e.g. OPENAI_API_KEY). Routing needs no config: the guest funnels all
+            # egress to the sidecar, which routes by SNI/Host.
             - name: FC_AGENTD_EGRESS_SIDECAR
               value: {{ .Values.egress.sidecarAddr | quote }}
-            {{- range $k, $v := .Values.egress.harnessEnv }}
-            - name: FC_AGENTD_INJECT_{{ $k }}
+            {{- range $tier, $env := .Values.egress.tiers }}
+            {{- range $k, $v := $env }}
+            - name: FC_AGENTD_TIER_{{ $tier }}__{{ $k }}
               value: {{ $v | quote }}
             {{- end }}
-            {{- if .Values.egress.secrets }}
-            # Secret swap (ADR 023 6b): the guest holds only PLACEHOLDERS as the
-            # secret env vars, plus the CA cert (public, never the key) so it trusts
-            # the leaves the sidecar mints. The real values live only in the sidecar.
-            {{- range $s := .Values.egress.secrets }}
-            - name: FC_AGENTD_INJECT_{{ $s.env }}
-              value: {{ $s.placeholder | quote }}
             {{- end }}
+            {{- if .Values.egress.secrets }}
+            # Secret swap (ADR 023 6b): the guest holds PLACEHOLDERS as its secret
+            # env vars, but scoped PER TIER (egress.tiers above, ADR 024) rather
+            # than injected globally, so the tier bounds which credentials a guest
+            # can cause the sidecar to swap. The CA cert (public, never the key) is
+            # common to every tier so any guest trusts the leaves the sidecar mints.
             - name: FC_AGENTD_INJECT_EGRESS_CA_CERT
               valueFrom:
                 secretKeyRef:

--- a/projects/agent_platform/fc-agentd/chart/values.yaml
+++ b/projects/agent_platform/fc-agentd/chart/values.yaml
@@ -47,15 +47,34 @@ egress:
   # Destinations permitted under policy=allowlist (host[:port], comma-separated).
   # Ignored under policy=allow. secrets[*].egressTo are always permitted.
   allowlist: ""
-  # Env injected into the guest harness (provider/model/keys), carried on the
-  # Assign message. Real URLs: the guest's wildcard DNS + transparent funnel route
-  # them and the sidecar resolves the real name. OPENAI_HOST is scheme+host with no
-  # path (goose appends OPENAI_BASE_PATH). apiKey must be set though vLLM is keyless.
-  harnessEnv:
-    OPENAI_HOST: http://inference.inference.svc.cluster.local:8080
-    OPENAI_API_KEY: sk-noauth
-    GOOSE_PROVIDER: openai
-    GOOSE_MODEL: qwen3.6-27b
+  # Per-tier env injected into the guest harness (ADR 024), carried on the Assign
+  # message. The thread's `tier` column selects one map; fc-agentd merges it over
+  # the common injected env (the CA cert) and injects the result into the guest.
+  # A tier is exactly the model endpoint plus the secret PLACEHOLDERS the guest is
+  # allowed to hold, so the tier is the credential trust boundary: the artifact
+  # tier holds the OpenRouter placeholder and NO gh token, so the sidecar's gh
+  # swap can never fire for an artifact-tier guest.
+  #
+  # Real URLs: the guest's wildcard DNS + transparent funnel route them and the
+  # sidecar resolves the real name. OPENAI_HOST is scheme+host with no path (goose
+  # appends OPENAI_BASE_PATH). OPENAI_API_KEY must be set though vLLM is keyless;
+  # for the artifact tier it is the high-entropy placeholder the sidecar swaps for
+  # the real OpenRouter key on openrouter.ai (must match secrets[].placeholder).
+  # An empty/legacy tier falls back to "default" (in-cluster Qwen).
+  tiers:
+    default:
+      OPENAI_HOST: http://inference.inference.svc.cluster.local:8080
+      OPENAI_API_KEY: sk-noauth
+      GOOSE_PROVIDER: openai
+      GOOSE_MODEL: qwen3.6-27b
+      # The proven 6b gh flow: a default-tier guest holds the gh placeholder, which
+      # the sidecar swaps for the real token only on api.github.com.
+      GITHUB_TOKEN: "kloak:gh:01JZX8K3N7Q2M5R9W4T6Y0F1B8"
+    artifact:
+      OPENAI_HOST: https://openrouter.ai/api
+      OPENAI_API_KEY: "kloak:or:B5BKP27T2KSDN6QW70N34H8DP6"
+      GOOSE_PROVIDER: openai
+      GOOSE_MODEL: google/gemini-3.5-flash
   # 6b CA: cert-manager generates + rotates the self-signed CA the sidecar uses to
   # mint leaf certs when it TLS-terminates a secret-bearing destination. Only
   # created when `secrets` below is non-empty.
@@ -78,6 +97,15 @@ egress:
       placeholder: "kloak:gh:01JZX8K3N7Q2M5R9W4T6Y0F1B8"
       egressTo: [api.github.com]
       secretRef: { name: monolith-chat-secrets, key: GITHUB_TOKEN }
+    # The artifact tier's OpenRouter key (ADR 024): the guest holds this
+    # placeholder as OPENAI_API_KEY (egress.tiers.artifact); the sidecar swaps it
+    # for the real key only on openrouter.ai. The real value is synced from
+    # 1Password into the `goosecracker` Secret by the monolith chart's
+    # OnePasswordItem. placeholder MUST match egress.tiers.artifact.OPENAI_API_KEY.
+    - env: OPENROUTER_KEY
+      placeholder: "kloak:or:B5BKP27T2KSDN6QW70N34H8DP6"
+      egressTo: [openrouter.ai]
+      secretRef: { name: goosecracker, key: OPENROUTER_API_KEY }
   resources:
     requests:
       cpu: 50m

--- a/projects/agent_platform/fc-agentd/cmd/main.go
+++ b/projects/agent_platform/fc-agentd/cmd/main.go
@@ -78,6 +78,7 @@ func run(logger *slog.Logger) error {
 		Logger:        logger,
 		ControlUDS:    fcDriver.VsockUDSPath,
 		GooseEnv:      cfg.InjectedEnv,
+		TierEnv:       cfg.TierEnv,
 		EgressSidecar: cfg.EgressSidecar,
 		MaxConcurrent: cfg.MaxConcurrent,
 	}

--- a/projects/agent_platform/fc-agentd/deploy/application.yaml
+++ b/projects/agent_platform/fc-agentd/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: fc-agentd
-      targetRevision: 0.11.0
+      targetRevision: 0.12.0
       helm:
         valueFiles:
           - $values/projects/agent_platform/fc-agentd/deploy/values.yaml

--- a/projects/agent_platform/fc-agentd/internal/config/BUILD
+++ b/projects/agent_platform/fc-agentd/internal/config/BUILD
@@ -1,8 +1,14 @@
-load("@rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "config",
     srcs = ["config.go"],
     importpath = "github.com/jomcgi/homelab/projects/agent_platform/fc-agentd/internal/config",
     visibility = ["//projects/agent_platform/fc-agentd:__subpackages__"],
+)
+
+go_test(
+    name = "config_test",
+    srcs = ["config_test.go"],
+    embed = [":config"],
 )

--- a/projects/agent_platform/fc-agentd/internal/config/config.go
+++ b/projects/agent_platform/fc-agentd/internal/config/config.go
@@ -65,15 +65,31 @@ type Config struct {
 	// EgressSidecar is the localhost address of the egress-proxy sidecar (ADR
 	// 023) the loop forwards guest egress to. Empty disables egress forwarding.
 	EgressSidecar string
-	// InjectedEnv is harness environment injected into each guest via the Assign
-	// message, gathered from FC_AGENTD_INJECT_<NAME> env vars (the prefix is
-	// stripped). Lets chart values supply the goose provider/model + the model
-	// base URL without hardcoding cluster config in the guest binary.
+	// InjectedEnv is the common harness environment injected into every guest
+	// regardless of tier, gathered from FC_AGENTD_INJECT_<NAME> env vars (the
+	// prefix is stripped). This is tier-independent infrastructure (e.g. the
+	// egress CA cert), never a credential or model selector.
 	InjectedEnv map[string]string
+	// TierEnv is the per-tier harness environment (ADR 024), gathered from
+	// FC_AGENTD_TIER_<TIER>__<NAME> env vars: {<TIER>: {<NAME>: value}}. The
+	// thread's tier selects one map, which the controller merges over InjectedEnv
+	// and injects into the guest. A tier is exactly the model endpoint plus the
+	// secret PLACEHOLDERS the guest may hold, so it is the credential trust
+	// boundary: an artifact-tier guest holds the OpenRouter placeholder and no gh
+	// token, a default-tier guest holds the in-cluster Qwen config.
+	TierEnv map[string]map[string]string
 }
 
-// injectEnvPrefix marks env vars fc-agentd forwards into the guest (stripped).
+// injectEnvPrefix marks env vars fc-agentd forwards into every guest (stripped).
 const injectEnvPrefix = "FC_AGENTD_INJECT_"
+
+// tierEnvPrefix marks per-tier env vars (ADR 024). The remainder is
+// "<TIER>__<NAME>": the "__" separates the tier name (no underscores) from the
+// env name (which may contain underscores, e.g. OPENAI_API_KEY).
+const tierEnvPrefix = "FC_AGENTD_TIER_"
+
+// tierEnvSep separates the tier name from the env name in a tierEnvPrefix var.
+const tierEnvSep = "__"
 
 // Load resolves configuration from the environment, applying defaults. It
 // returns an error only for values that are present but malformed.
@@ -95,6 +111,7 @@ func Load() (Config, error) {
 		GuestOOMScoreAdj:  atoiDefault("FC_AGENTD_GUEST_OOM_SCORE_ADJ", 1000),
 		EgressSidecar:     os.Getenv("FC_AGENTD_EGRESS_SIDECAR"),
 		InjectedEnv:       injectedEnv(),
+		TierEnv:           tierEnv(),
 	}
 
 	if c.Node == "" {
@@ -128,6 +145,32 @@ func injectedEnv() map[string]string {
 		if stripped := strings.TrimPrefix(name, injectEnvPrefix); stripped != "" {
 			out[stripped] = val
 		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// tierEnv collects FC_AGENTD_TIER_<TIER>__<NAME> env vars into a nested
+// {<TIER>: {<NAME>: value}} map (ADR 024). Vars whose remainder lacks the
+// "__" separator, or whose tier/name is empty, are skipped.
+func tierEnv() map[string]map[string]string {
+	out := map[string]map[string]string{}
+	for _, kv := range os.Environ() {
+		name, val, ok := strings.Cut(kv, "=")
+		if !ok || !strings.HasPrefix(name, tierEnvPrefix) {
+			continue
+		}
+		rest := strings.TrimPrefix(name, tierEnvPrefix)
+		tier, key, ok := strings.Cut(rest, tierEnvSep)
+		if !ok || tier == "" || key == "" {
+			continue
+		}
+		if out[tier] == nil {
+			out[tier] = map[string]string{}
+		}
+		out[tier][key] = val
 	}
 	if len(out) == 0 {
 		return nil

--- a/projects/agent_platform/fc-agentd/internal/config/config_test.go
+++ b/projects/agent_platform/fc-agentd/internal/config/config_test.go
@@ -1,0 +1,48 @@
+package config
+
+import "testing"
+
+// TestTierEnvParsesNestedTierMaps verifies FC_AGENTD_TIER_<TIER>__<NAME> vars
+// are grouped by tier, and that env names containing underscores (the reason for
+// the "__" separator) survive intact.
+func TestTierEnvParsesNestedTierMaps(t *testing.T) {
+	t.Setenv("FC_AGENTD_TIER_default__OPENAI_HOST", "http://qwen:8080")
+	t.Setenv("FC_AGENTD_TIER_default__OPENAI_API_KEY", "sk-noauth")
+	t.Setenv("FC_AGENTD_TIER_artifact__OPENAI_HOST", "https://openrouter.ai/api")
+	t.Setenv("FC_AGENTD_TIER_artifact__GOOSE_MODEL", "google/gemini-3.5-flash")
+
+	got := tierEnv()
+	if got == nil {
+		t.Fatal("tierEnv() = nil, want two tiers")
+	}
+	if v := got["default"]["OPENAI_API_KEY"]; v != "sk-noauth" {
+		t.Errorf("default OPENAI_API_KEY = %q, want sk-noauth", v)
+	}
+	if v := got["artifact"]["OPENAI_HOST"]; v != "https://openrouter.ai/api" {
+		t.Errorf("artifact OPENAI_HOST = %q, want the openrouter host", v)
+	}
+	if v := got["artifact"]["GOOSE_MODEL"]; v != "google/gemini-3.5-flash" {
+		t.Errorf("artifact GOOSE_MODEL = %q, want the gemini id", v)
+	}
+}
+
+// TestTierEnvSkipsMalformed verifies vars without the "__" separator (or with an
+// empty tier/name) are ignored rather than mis-parsed.
+func TestTierEnvSkipsMalformed(t *testing.T) {
+	t.Setenv("FC_AGENTD_TIER_noseparator", "x")
+	t.Setenv("FC_AGENTD_TIER___EMPTYTIER", "y")
+	got := tierEnv()
+	if _, ok := got["noseparator"]; ok {
+		t.Error("a var without the __ separator should be skipped")
+	}
+	if _, ok := got[""]; ok {
+		t.Error("an empty tier name should be skipped")
+	}
+}
+
+// TestTierEnvEmptyWhenUnset verifies no tier vars yields nil (the dry-run path).
+func TestTierEnvEmptyWhenUnset(t *testing.T) {
+	if got := tierEnv(); got != nil {
+		t.Errorf("tierEnv() = %v, want nil when no FC_AGENTD_TIER_* set", got)
+	}
+}

--- a/projects/agent_platform/fc-agentd/internal/reconcile/reconcile.go
+++ b/projects/agent_platform/fc-agentd/internal/reconcile/reconcile.go
@@ -68,10 +68,18 @@ type Loop struct {
 	// control serving (dry-run / tests with no vsock).
 	ControlUDS func(threadID string) string
 
-	// GooseEnv is harness environment injected into every guest via the Assign
-	// message (goose provider/model + the in-cluster model base URL). Empty means
-	// no injection.
+	// GooseEnv is the common harness environment injected into every guest via the
+	// Assign message regardless of tier (tier-independent infrastructure such as
+	// the egress CA cert). Empty means no common injection.
 	GooseEnv map[string]string
+
+	// TierEnv is the per-tier harness environment (ADR 024): {<tier>: {<NAME>:
+	// value}}. A thread's tier selects one map, merged over GooseEnv, to give the
+	// model endpoint + the secret placeholders that tier is allowed to hold. The
+	// tier is the credential trust boundary, so the placeholder set is scoped here
+	// rather than injected globally. An empty/unknown tier falls back to
+	// "default", and a missing "default" falls back to GooseEnv alone.
+	TierEnv map[string]map[string]string
 
 	// EgressSidecar, when set, is the localhost address of the egress-proxy
 	// sidecar (ADR 023). The loop forwards each thread's vsock egress connections
@@ -227,7 +235,7 @@ func (l *Loop) startControl(ctx context.Context, log *slog.Logger, t store.Threa
 	cctx, cancel := context.WithCancel(ctx)
 	l.control[t.ThreadID] = cancel
 	uds := l.ControlUDS(t.ThreadID)
-	assign := control.Assignment{ThreadID: t.ThreadID, Recipe: t.Recipe, Task: t.Task, Env: l.GooseEnv}
+	assign := control.Assignment{ThreadID: t.ThreadID, Recipe: t.Recipe, Task: t.Task, Env: l.envForTier(log, t.Tier)}
 	// Forward the guest's vsock egress to the secret-free sidecar (ADR 023).
 	if l.EgressSidecar != "" {
 		go func() {
@@ -257,6 +265,35 @@ func (l *Loop) startControl(ctx context.Context, log *slog.Logger, t store.Threa
 			log.Warn("reconcile: control server exited", "thread", t.ThreadID, "err", err)
 		}
 	}()
+}
+
+// envForTier resolves the harness env injected into a guest for its tier (ADR
+// 024): the per-tier map merged over the common GooseEnv, so a tier only needs
+// to specify what differs (model endpoint, secret placeholders). An empty tier
+// means "default"; an unknown tier falls back to GooseEnv alone (fail safe: the
+// guest gets no model credential rather than another tier's). The returned map
+// is freshly allocated, so the caller may not mutate the shared inputs.
+func (l *Loop) envForTier(log *slog.Logger, tier string) map[string]string {
+	if tier == "" {
+		tier = "default"
+	}
+	te, ok := l.TierEnv[tier]
+	if !ok {
+		// No env configured for this tier. "default" with no TierEnv at all is the
+		// expected dry-run/test path, so only warn for a genuinely unknown tier.
+		if len(l.TierEnv) > 0 {
+			log.Warn("reconcile: no env for thread tier; using common env only", "tier", tier)
+		}
+		return l.GooseEnv
+	}
+	out := make(map[string]string, len(l.GooseEnv)+len(te))
+	for k, v := range l.GooseEnv {
+		out[k] = v
+	}
+	for k, v := range te {
+		out[k] = v
+	}
+	return out
 }
 
 // restoreWakeRequested restores IDLE threads that have a pending wake request.

--- a/projects/agent_platform/fc-agentd/internal/reconcile/reconcile_test.go
+++ b/projects/agent_platform/fc-agentd/internal/reconcile/reconcile_test.go
@@ -392,3 +392,50 @@ func TestDryRunWithoutRegistry(t *testing.T) {
 }
 
 func testLogger() *slog.Logger { return slog.New(slog.NewTextHandler(io.Discard, nil)) }
+
+// TestEnvForTier covers ADR 024 tier selection: a tier's env is merged over the
+// common GooseEnv, an empty tier resolves to "default", and an unknown tier
+// fails safe to the common env alone (no other tier's credentials leak in).
+func TestEnvForTier(t *testing.T) {
+	l := &Loop{
+		GooseEnv: map[string]string{"EGRESS_CA_CERT": "ca"},
+		TierEnv: map[string]map[string]string{
+			"default":  {"OPENAI_HOST": "http://qwen:8080", "GITHUB_TOKEN": "kloak:gh:x"},
+			"artifact": {"OPENAI_HOST": "https://openrouter.ai/api", "OPENAI_API_KEY": "kloak:or:x"},
+		},
+	}
+	log := testLogger()
+
+	// Empty tier -> "default", merged over the common env.
+	def := l.envForTier(log, "")
+	if def["EGRESS_CA_CERT"] != "ca" || def["OPENAI_HOST"] != "http://qwen:8080" {
+		t.Fatalf("empty tier should resolve to default merged over common env: %v", def)
+	}
+
+	// Artifact tier holds the OpenRouter placeholder and, crucially, NOT the gh
+	// token (the credential trust boundary, ADR 024).
+	art := l.envForTier(log, "artifact")
+	if art["OPENAI_API_KEY"] != "kloak:or:x" {
+		t.Fatalf("artifact tier should hold the openrouter placeholder: %v", art)
+	}
+	if _, leaked := art["GITHUB_TOKEN"]; leaked {
+		t.Fatal("artifact tier must NOT hold the gh token placeholder (tier boundary leak)")
+	}
+	if art["EGRESS_CA_CERT"] != "ca" {
+		t.Fatalf("artifact tier should still get the common CA cert: %v", art)
+	}
+
+	// Unknown tier fails safe to the common env alone.
+	unk := l.envForTier(log, "nope")
+	if _, ok := unk["OPENAI_HOST"]; ok {
+		t.Fatalf("unknown tier should not get any model credential: %v", unk)
+	}
+	if unk["EGRESS_CA_CERT"] != "ca" {
+		t.Fatalf("unknown tier should still get the common env: %v", unk)
+	}
+
+	// The merge must not mutate the shared input maps.
+	if _, mutated := l.GooseEnv["OPENAI_HOST"]; mutated {
+		t.Fatal("envForTier mutated the shared GooseEnv map")
+	}
+}

--- a/projects/agent_platform/fc-agentd/internal/store/store.go
+++ b/projects/agent_platform/fc-agentd/internal/store/store.go
@@ -35,6 +35,11 @@ type Thread struct {
 	// Recipe and Task are the work assignment delivered to the guest over vsock.
 	Recipe string
 	Task   string
+	// Tier selects the model substrate the controller injects into the guest
+	// (ADR 024): "artifact" reaches Gemini via OpenRouter (key swapped at egress),
+	// the default/empty tier reaches in-cluster Qwen. The tier also bounds which
+	// secret placeholders the guest holds, so it is the credential trust boundary.
+	Tier string
 	// WakeRequestedAt is non-zero when a caller has asked an IDLE thread to be
 	// restored (the one piece of desired state callers set). Zero means no
 	// pending wake.
@@ -106,7 +111,7 @@ const threadColumns = `thread_id, state, repo, branch, node, arch,
 		COALESCE(base_snapshot_ref, ''), COALESCE(thread_snapshot_ref, ''),
 		COALESCE(size_bytes, 0), COALESCE(discord_thread, ''),
 		created_at, last_active_at, COALESCE(ttl_secs, 0),
-		COALESCE(recipe, ''), COALESCE(task, ''),
+		COALESCE(recipe, ''), COALESCE(task, ''), COALESCE(tier, ''),
 		COALESCE(wake_requested_at, 'epoch'::timestamptz)`
 
 func (s *Store) queryThreads(ctx context.Context, where string, args ...any) ([]Thread, error) {
@@ -123,7 +128,7 @@ func (s *Store) queryThreads(ctx context.Context, where string, args ...any) ([]
 			&t.ThreadID, &t.State, &t.Repo, &t.Branch, &t.Node, &t.Arch,
 			&t.BaseSnapshotRef, &t.ThreadSnapshotRef, &t.SizeBytes, &t.DiscordThread,
 			&t.CreatedAt, &t.LastActiveAt, &t.TTLSeconds,
-			&t.Recipe, &t.Task, &t.WakeRequestedAt,
+			&t.Recipe, &t.Task, &t.Tier, &t.WakeRequestedAt,
 		); err != nil {
 			return nil, fmt.Errorf("store: scan thread: %w", err)
 		}

--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.70.11
+version: 0.71.0
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.70.11
+      targetRevision: 0.71.0
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/agent/dispatch.py
+++ b/projects/monolith/agent/dispatch.py
@@ -58,6 +58,7 @@ def submit(
     repo: str = "",
     branch: str = "main",
     discord_thread: str = "",
+    tier: str = "",
     arch: str = DEFAULT_ARCH,
     node: str = DEFAULT_NODE,
     ttl_secs: int = 86400,
@@ -69,6 +70,11 @@ def submit(
     name to run, defaulting to "agent"; and ``task``, the task description) is
     stored on the new thread's row so the controller can hand it to the guest
     microVM over vsock.
+
+    ``tier`` selects the model substrate the controller injects into the guest
+    (ADR 024): "artifact" reaches Gemini via OpenRouter (key swapped at egress),
+    the default/empty tier reaches in-cluster Qwen. The tier also bounds which
+    secret placeholders the guest holds, so it is the credential trust boundary.
     """
     if thread_id:
         result = threads.request_resume(thread_id)
@@ -83,10 +89,10 @@ def submit(
                 INSERT INTO claude_agent.agent_threads
                     (thread_id, state, repo, branch, node, arch,
                      base_snapshot_ref, discord_thread, ttl_secs,
-                     recipe, task)
+                     recipe, task, tier)
                 VALUES (:id, 'PENDING', :repo, :branch, :node, :arch,
                         :base_ref, :discord_thread, :ttl,
-                        :recipe, :task)
+                        :recipe, :task, :tier)
                 """
             ),
             {
@@ -100,6 +106,7 @@ def submit(
                 "ttl": ttl_secs,
                 "recipe": recipe,
                 "task": task,
+                "tier": tier,
             },
         )
         session.commit()

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.225.11
+version: 0.226.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/migrations/20260627160000_agent_threads_tier.sql
+++ b/projects/monolith/chart/migrations/20260627160000_agent_threads_tier.sql
@@ -1,0 +1,13 @@
+-- Adds the per-thread model tier to claude_agent.agent_threads (ADR 024). The
+-- tier is exactly the set of harness env the controller injects into the guest:
+-- the model endpoint plus the secret PLACEHOLDERS the guest is allowed to hold.
+-- "artifact" reaches Gemini via OpenRouter (the OpenRouter key swapped at the
+-- egress hop, ADR 023 6b) and holds no other credential; the default/empty tier
+-- reaches in-cluster Qwen.
+--
+-- Nullable: legacy rows predate the column, and a resume (wake) does not
+-- re-supply it, so the controller treats an absent tier as the default tier
+-- (in-cluster Qwen) rather than a new assignment.
+
+ALTER TABLE claude_agent.agent_threads
+    ADD COLUMN tier TEXT;

--- a/projects/monolith/chart/migrations/atlas.sum
+++ b/projects/monolith/chart/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:egHu/gloe1yTVNA6D9fXGNCbvbXgtQ9Ld/PFFnRagTA=
+h1:JKgbNmyNf9jhjogiEb8GQRxkkdBGj7Qhxl42s+lh8Zk=
 20260330000000_initial_schema.sql h1:J2futpSW0nJAIRR7nR7ssT7LwXIYrvRI+PkHb5Y4tLI=
 20260403000000_chat_schema.sql h1:pERUFC0vzM95etRuzp43XzkCV7lBCzrrtY5Mk7aF3CA=
 20260404000000_chat_attachments.sql h1:tv+Fdbr1rQC5nzUxfaBC0O6fu2OMGgLWf+YNg1WQXi4=
@@ -68,3 +68,4 @@ h1:egHu/gloe1yTVNA6D9fXGNCbvbXgtQ9Ld/PFFnRagTA=
 20260627130000_agent_threads_wake.sql h1:KDElIZTTwDZPAYxoGsZU+/EFrFtpV1UkPZFcUZzzVSs=
 20260627140000_agent_base_snapshots.sql h1:SZ6Xel4lm7qKjDpfkXTc1TxQ51nP5GyZWjh9bQ8PLik=
 20260627150000_agent_threads_task.sql h1:ayLpSJVAgLsFwTe45d/x7pmdHt5vYo3GaCFuOJls/OU=
+20260627160000_agent_threads_tier.sql h1:byg8x19pnQxW2k7SzNvwiip61vUTSHUlfCh0hjWq64o=

--- a/projects/monolith/chart/templates/onepassworditem-goosecracker.yaml
+++ b/projects/monolith/chart/templates/onepassworditem-goosecracker.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.goosecracker.enabled }}
+# OpenRouter API key for the goosecracker artifact tier (ADR 024). The synced
+# Secret is named "goosecracker" (not fullname-prefixed) because the fc-agentd
+# egress-proxy sidecar references it by that exact name in egress.secrets[].
+# secretRef. The key never enters the guest microVM: the guest holds only the
+# kloak:or: placeholder, which the sidecar swaps for this value on openrouter.ai.
+apiVersion: onepassword.com/v1
+kind: OnePasswordItem
+metadata:
+  name: goosecracker
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "monolith.labels" . | nindent 4 }}
+spec:
+  itemPath: {{ .Values.goosecracker.onepassword.itemPath | quote }}
+{{- end }}

--- a/projects/monolith/chart/values.yaml
+++ b/projects/monolith/chart/values.yaml
@@ -492,6 +492,15 @@ chat:
   onepassword:
     itemPath: ""
 
+# goosecracker artifact agent (ADR 024): syncs the OpenRouter API key from
+# 1Password into the `goosecracker` Secret, consumed by the fc-agentd egress
+# proxy to swap the artifact tier's kloak:or: placeholder on openrouter.ai.
+# Disabled by default for portability.
+goosecracker:
+  enabled: false
+  onepassword:
+    itemPath: ""
+
 # Knowledge gardener: LLM-driven decomposition of raw vault notes into
 # typed knowledge artifacts via the claude Code CLI. Uses CLAUDE_CODE_OAUTH_TOKEN
 # from the litellm-claude-auth 1Password item (same token as goose agents).

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.225.11
+      targetRevision: 0.226.0
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/deploy/values.yaml
+++ b/projects/monolith/deploy/values.yaml
@@ -137,6 +137,13 @@ chat:
   onepassword:
     itemPath: "vaults/k8s-homelab/items/discord-bot"
 
+# goosecracker artifact tier (ADR 024): sync the OpenRouter API key into the
+# `goosecracker` Secret for the fc-agentd egress proxy to swap on openrouter.ai.
+goosecracker:
+  enabled: true
+  onepassword:
+    itemPath: "vaults/k8s-homelab/items/goosecracker"
+
 # Taken offline 2026-06-14 for the ADR 006 Phase 4 transition: with the
 # gardener paused, the raw export / file moves can be done as a controlled
 # one-off, and the gardener stays down until the CLI-based version (Phase 4a-ii)


### PR DESCRIPTION
Task 1 of the goosecracker build plan (`docs/plans/2026-06-27-goosecracker-discord-artifact-agent.md`, ADR 024). The model substrate: a thread carries a `tier` that selects which model + secrets the controller injects into the Firecracker guest.

## What changes

- **Migration** `claude_agent.agent_threads.tier` (nullable; absent == default tier).
- **dispatch.submit(tier=...)** plumbs the tier onto the new PENDING row.
- **store.Thread.Tier** + SELECT/scan.
- **config** parses `FC_AGENTD_TIER_<tier>__<KEY>` env vars into a nested `TierEnv` map (the `__` separates the tier name from keys like `OPENAI_API_KEY`).
- **reconcile** selects the per-tier env (merged over the common CA-cert env) at Assign time.
- **fc-agentd chart**: `egress.tiers.{default,artifact}`; `openrouter.ai` `egress.secrets` entry (real key from the new `goosecracker` Secret).
- **monolith chart**: `goosecracker` OnePasswordItem -> `goosecracker` Secret (`OPENROUTER_API_KEY` from `vaults/k8s-homelab/items/goosecracker`).

## The tier is the credential trust boundary

Secret placeholders are now scoped **per tier** (`egress.tiers`) instead of injected globally. The egress sidecar's swap catalog is host-keyed and global, so the only thing stopping an artifact-tier guest from obtaining the real gh token is **not holding the placeholder**. The artifact tier therefore holds the OpenRouter placeholder and NO gh token, matching ADR 024's "artifact tier holds neither repo nor gh token". Verified in the rendered manifest: no `FC_AGENTD_TIER_artifact__GITHUB_TOKEN`.

- **artifact tier**: `OPENAI_HOST=https://openrouter.ai/api`, `GOOSE_MODEL=google/gemini-3.5-flash`, `OPENAI_API_KEY=kloak:or:...` (swapped on openrouter.ai).
- **default tier**: in-cluster Qwen + the proven gh placeholder (swapped on api.github.com).

## Validation

Local: both charts render correctly; `helm template` confirms per-tier env and the tier boundary. New Go unit tests cover tier parsing and the merge/fallback/no-leak semantics. Full in-cluster validation (submit an artifact-tier thread, confirm `egress swapped dest=openrouter.ai` + goose names Gemini, and a default-tier thread still uses Qwen) runs after CI builds the image and the chart rolls out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)