### PR TITLE
feat(monolith): artifact service for goosecracker (ADR 024 Task 2)

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.72.0
+version: 0.72.1
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.71.0
+version: 0.72.0
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/chart/values.yaml
+++ b/projects/monolith-public/chart/values.yaml
@@ -281,6 +281,21 @@ web:
         secretKeyRef:
           name: monolith-public-turnstile
           key: IP_HASH_SALT
+    # goosecracker artifact read path (ADR 024). The public backend reads the
+    # agent-built HTML from the shared SeaweedFS S3 gateway (in-cluster, so the
+    # public off-cluster EgressNetwork deny does not block it) and the SSR
+    # frontend proxies /artifact/<id>/raw + /version to it. Read-only: the write
+    # router is not mounted on the public binary. Creds are the cluster's dummy
+    # S3 identity (auth disabled); literals, not secrets. ARTIFACTS_S3_BUCKET must
+    # match the full monolith's artifact.bucket (where the write lands).
+    - name: SEAWEEDFS_S3_ENDPOINT
+      value: "http://seaweedfs-s3.seaweedfs.svc.cluster.local:8333"
+    - name: S3_ACCESS_KEY_ID
+      value: "duckdb"
+    - name: S3_SECRET_ACCESS_KEY
+      value: "duckdb"
+    - name: ARTIFACTS_S3_BUCKET
+      value: "artifacts"
   # CPU request is sized so the HPA's per-container CPU utilization is a
   # meaningful signal (idle is ~1m). No CPU limit: let it burst (the HPA scales
   # out on sustained CPU rather than throttling).

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.72.0
+      targetRevision: 0.72.1
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.71.0
+      targetRevision: 0.72.0
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -1,4 +1,5 @@
 # gazelle:exclude agent
+# gazelle:exclude artifact
 # gazelle:exclude chat
 # gazelle:exclude chat_public
 # gazelle:exclude cluster

--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -54,6 +54,7 @@ _BACKEND_SRCS = glob(
     [
         "agent/**/*.py",
         "app/**/*.py",
+        "artifact/**/*.py",
         "chat/**/*.py",
         "chat_public/**/*.py",
         "cluster/**/*.py",
@@ -184,6 +185,7 @@ py_library(
         [
             "agent/**/*.py",
             "app/**/*.py",
+            "artifact/**/*.py",
             "chat/**/*.py",
             "chat_public/**/*.py",
             "cluster/**/*.py",
@@ -381,6 +383,7 @@ py_library(
     srcs = glob(
         [
             "app/**/*.py",
+            "artifact/**/*.py",
             "knowledge/**/*.py",
             "home/**/*.py",
             "shared/**/*.py",
@@ -436,6 +439,7 @@ py_venv_binary(
     srcs = glob(
         [
             "app/**/*.py",
+            "artifact/**/*.py",
             "knowledge/**/*.py",
             "home/**/*.py",
             "shared/**/*.py",
@@ -492,6 +496,7 @@ py_test(
         include = [
             "ships/**/*.py",
             "stars/**/*.py",
+            "artifact/**/*.py",
             "chat/**/*.py",
             "chat_public/**/*.py",
             "knowledge/**/*.py",
@@ -2541,6 +2546,31 @@ py_test(
         "@pip//httpx",
         "@pip//pytest",
         "@pip//sqlmodel",
+    ],
+)
+
+# goosecracker artifact service (ADR 024): TestClient unit tests for the publish
+# + read endpoints (S3 faked) and the S3 helper (boto3 mocked).
+py_test(
+    name = "artifact_router_test",
+    srcs = ["artifact/router_test.py"],
+    imports = ["."],
+    deps = [
+        ":monolith_backend",
+        "@pip//fastapi",
+        "@pip//httpx",
+        "@pip//pytest",
+    ],
+)
+
+py_test(
+    name = "artifact_s3_test",
+    srcs = ["artifact/s3_test.py"],
+    imports = ["."],
+    deps = [
+        ":monolith_backend",
+        "@pip//boto3",
+        "@pip//pytest",
     ],
 )
 

--- a/projects/monolith/app/main.py
+++ b/projects/monolith/app/main.py
@@ -10,6 +10,7 @@ from fastapi import FastAPI
 from fastapi.staticfiles import StaticFiles
 
 from app.log import configure_logging
+import artifact
 import chat
 import dr_jobs
 import hikes
@@ -239,6 +240,7 @@ stars.register(app)
 trips.register(app)
 dr_jobs.register(app)
 worldcup.register(app)
+artifact.register(app)
 app.mount("/mcp", _mcp_app)
 
 

--- a/projects/monolith/app/main_public.py
+++ b/projects/monolith/app/main_public.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import logging
 
+import artifact
 import chat_public
 import dr_jobs
 import hikes
@@ -33,7 +34,7 @@ from sqlmodel import Session, text
 
 configure_logging()
 
-logger = logging.getLogger("monolith_public")
+logger = logging.getLogger("monolith.public")
 
 app = FastAPI(title="Monolith Public")
 
@@ -46,6 +47,7 @@ worldcup.register_public(app)
 knowledge.register_public(app)
 home.register_public(app)
 chat_public.register_public(app)
+artifact.register_public(app)
 
 
 @app.get("/healthz")

--- a/projects/monolith/app/main_public_routes_test.py
+++ b/projects/monolith/app/main_public_routes_test.py
@@ -86,6 +86,11 @@ ALLOWED_PREFIXES = (
     # only in-cluster from the SSR front door over Linkerd mTLS, never directly
     # from the internet.
     "/internal/chat",
+    # Internal-only artifact read API (ADR 024): mounted on the public binary so
+    # the SSR frontend can proxy /artifact/<id>/raw + /version in-cluster, but
+    # kept off the public HTTPRoute (the frontend is the sole public origin). The
+    # write router is NOT mounted here (the public tier stays read-only).
+    "/internal/artifact",
     "/healthz",
     # Deep health probe (DB reachable + public_reader can query). Reached via the
     # frontend /health same-origin proxy; not a private surface.

--- a/projects/monolith/artifact/__init__.py
+++ b/projects/monolith/artifact/__init__.py
@@ -1,0 +1,41 @@
+"""artifact: goosecracker live artifacts (ADR 024).
+
+Agent-built, self-contained HTML pages published to ``s3://artifacts/<id>`` and
+served at ``jomcgi.dev/artifact/<id>``. The monolith mediates every write (the
+agent guest holds no S3 credential), and the page is framed in a sandboxed
+iframe (opaque origin) so untrusted agent markup cannot touch the site origin.
+
+Two surfaces:
+- the full monolith gets the write + read routers (``register``): the agent
+  publishes here in-cluster.
+- the public binary gets the read router only (``register_public``): the SSR
+  frontend proxies ``/raw`` + ``/version`` to it. The public tier stays
+  read-only (ADR 004), so it never mounts the write router.
+
+Both prefixes are ``/internal/artifact`` and are kept off the public HTTPRoute;
+the SSR frontend is the sole public origin.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from fastapi import FastAPI
+
+__all__ = ["register", "register_public"]
+
+
+def register(app: FastAPI) -> None:
+    """Register the write + read artifact routers (full monolith)."""
+    from artifact.router import read_router, write_router
+
+    app.include_router(write_router)
+    app.include_router(read_router)
+
+
+def register_public(app: FastAPI) -> None:
+    """Register only the read artifact router (public, read-only tier)."""
+    from artifact.router import read_router
+
+    app.include_router(read_router)

--- a/projects/monolith/artifact/router.py
+++ b/projects/monolith/artifact/router.py
@@ -1,0 +1,147 @@
+"""Artifact HTTP surface (ADR 024 decisions 3 + 4).
+
+Two routers, both under the ``/internal/artifact`` prefix so neither is on the
+public HTTPRoute (in-cluster only, like chat_public): the gateway never routes
+``/internal`` and the SSR frontend is the sole public origin.
+
+- ``write_router`` (``POST /internal/artifact``): the agent's publish path. The
+  monolith performs the S3 write, so the guest holds no S3 credential. Mounted on
+  the FULL monolith only (the public tier stays read-only, ADR 004).
+- ``read_router`` (``GET /internal/artifact/{id}/raw`` + ``/version``): the read
+  path the public SSR frontend proxies. ``/raw`` serves the agent HTML with a
+  strict CSP; ``/version`` is the ETag the hot-reload poller watches. Mounted on
+  both binaries.
+
+Agent HTML is untrusted (ADR 024 decision 4): ``/raw`` carries a ``sandbox``
+CSP + locked-down ``default-src`` so even a directly-fetched artifact runs with
+no ambient authority, and the SSR wrapper frames it with ``sandbox=allow-scripts``
+(no ``allow-same-origin``) for an opaque origin.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import secrets
+
+from fastapi import APIRouter, HTTPException, Response
+from pydantic import BaseModel, Field
+
+# Artifact ids are capability URLs (unguessable id == access), so generated ids
+# are random url-safe tokens. A caller-supplied id must match this charset to
+# keep it safe as both an S3 key segment and a URL path segment (no traversal,
+# no separators).
+_ID_RE = re.compile(r"\A[A-Za-z0-9_-]{1,64}\Z")
+
+# Max stored artifact size. Self-contained HTML pages are small; this bounds a
+# runaway/abusive publish and the S3 object size.
+_MAX_HTML_BYTES = 2 * 1024 * 1024
+
+# The strict CSP on the raw artifact response. `sandbox allow-scripts` gives the
+# document an opaque origin with scripting but no same-origin/forms/popups/
+# top-navigation; `default-src 'none'` denies everything not explicitly allowed;
+# `connect-src 'none'` blocks beaconing/exfiltration (ADR 024 risk table). Inline
+# script/style are allowed so a self-contained artifact runs; data:/blob: images
+# cover inline assets.
+_ARTIFACT_CSP = (
+    "sandbox allow-scripts; default-src 'none'; script-src 'unsafe-inline'; "
+    "style-src 'unsafe-inline'; img-src data: blob:; font-src data:; "
+    "connect-src 'none'; form-action 'none'; base-uri 'none'"
+)
+
+
+def _public_base() -> str:
+    return os.environ.get("ARTIFACT_PUBLIC_BASE", "https://jomcgi.dev").rstrip("/")
+
+
+class PublishRequest(BaseModel):
+    html: str = Field(..., description="The self-contained artifact HTML document.")
+    id: str | None = Field(
+        default=None,
+        description="Optional artifact id to (re)publish; server-assigned when absent.",
+    )
+
+
+class PublishResponse(BaseModel):
+    id: str
+    url: str
+    version: str
+
+
+write_router = APIRouter(prefix="/internal/artifact", tags=["artifact"])
+read_router = APIRouter(prefix="/internal/artifact", tags=["artifact"])
+
+
+@write_router.post("", response_model=PublishResponse)
+def publish_artifact(req: PublishRequest) -> PublishResponse:
+    """Publish (or re-publish) an artifact to object storage, return its URL."""
+    from artifact import s3
+
+    html_bytes = req.html.encode("utf-8")
+    if not html_bytes:
+        raise HTTPException(status_code=422, detail="empty artifact html")
+    if len(html_bytes) > _MAX_HTML_BYTES:
+        raise HTTPException(
+            status_code=413,
+            detail=f"artifact exceeds {_MAX_HTML_BYTES} bytes",
+        )
+
+    if req.id is None:
+        artifact_id = secrets.token_urlsafe(9)
+    else:
+        if not _ID_RE.match(req.id):
+            raise HTTPException(status_code=422, detail="invalid artifact id")
+        artifact_id = req.id
+
+    version = s3.put_artifact(artifact_id, html_bytes)
+    return PublishResponse(
+        id=artifact_id,
+        url=f"{_public_base()}/artifact/{artifact_id}",
+        version=version,
+    )
+
+
+def _require_valid_id(artifact_id: str) -> str:
+    if not _ID_RE.match(artifact_id):
+        raise HTTPException(status_code=404, detail="not found")
+    return artifact_id
+
+
+@read_router.get("/{artifact_id}/raw")
+def get_artifact_raw(artifact_id: str) -> Response:
+    """Serve the raw artifact HTML with a strict CSP (untrusted; ADR 024)."""
+    from artifact import s3
+
+    _require_valid_id(artifact_id)
+    got = s3.get_artifact(artifact_id)
+    if got is None:
+        raise HTTPException(status_code=404, detail="not found")
+    html, _etag = got
+    return Response(
+        content=html,
+        media_type="text/html; charset=utf-8",
+        headers={
+            "Content-Security-Policy": _ARTIFACT_CSP,
+            # The wrapper hot-reloads via the version endpoint, so the framed doc
+            # must never be cached stale.
+            "Cache-Control": "no-store",
+            "X-Content-Type-Options": "nosniff",
+        },
+    )
+
+
+@read_router.get("/{artifact_id}/version")
+def get_artifact_version(artifact_id: str) -> Response:
+    """Return the artifact's current version (ETag) for the hot-reload poller."""
+    from artifact import s3
+
+    _require_valid_id(artifact_id)
+    version = s3.head_artifact(artifact_id)
+    if version is None:
+        raise HTTPException(status_code=404, detail="not found")
+    return Response(
+        content=json.dumps({"version": version}),
+        media_type="application/json",
+        headers={"Cache-Control": "no-store"},
+    )

--- a/projects/monolith/artifact/router_test.py
+++ b/projects/monolith/artifact/router_test.py
@@ -1,0 +1,112 @@
+"""Tests for the artifact HTTP surface (ADR 024)."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from artifact import s3
+from artifact.router import read_router, write_router
+
+
+@pytest.fixture
+def client(monkeypatch) -> TestClient:
+    # In-memory artifact store keyed by id, so the handlers exercise their real
+    # logic while S3 is faked (the router lazy-imports `artifact.s3`).
+    store: dict[str, bytes] = {}
+
+    def fake_put(artifact_id: str, html: bytes) -> str:
+        store[artifact_id] = html
+        return f"etag-{len(html)}"
+
+    def fake_get(artifact_id: str):
+        if artifact_id not in store:
+            return None
+        return store[artifact_id], f"etag-{len(store[artifact_id])}"
+
+    def fake_head(artifact_id: str):
+        if artifact_id not in store:
+            return None
+        return f"etag-{len(store[artifact_id])}"
+
+    monkeypatch.setattr(s3, "put_artifact", fake_put)
+    monkeypatch.setattr(s3, "get_artifact", fake_get)
+    monkeypatch.setattr(s3, "head_artifact", fake_head)
+    monkeypatch.setenv("ARTIFACT_PUBLIC_BASE", "https://jomcgi.dev")
+
+    app = FastAPI()
+    app.include_router(write_router)
+    app.include_router(read_router)
+    return TestClient(app)
+
+
+def test_publish_assigns_id_and_returns_url(client: TestClient):
+    resp = client.post("/internal/artifact", json={"html": "<h1>hi</h1>"})
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body.get("id")
+    assert body.get("url") == f"https://jomcgi.dev/artifact/{body.get('id')}"
+    assert body.get("version")
+
+
+def test_publish_honours_supplied_id(client: TestClient):
+    resp = client.post(
+        "/internal/artifact", json={"id": "my-demo_1", "html": "<p>x</p>"}
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json().get("id") == "my-demo_1"
+
+
+def test_publish_rejects_invalid_id(client: TestClient):
+    resp = client.post(
+        "/internal/artifact", json={"id": "../etc/passwd", "html": "<p>x</p>"}
+    )
+    assert resp.status_code == 422
+
+
+def test_publish_rejects_empty_html(client: TestClient):
+    resp = client.post("/internal/artifact", json={"html": ""})
+    assert resp.status_code == 422
+
+
+def test_publish_rejects_oversized_html(client: TestClient):
+    big = "x" * (2 * 1024 * 1024 + 1)
+    resp = client.post("/internal/artifact", json={"html": big})
+    assert resp.status_code == 413
+
+
+def test_raw_serves_html_with_strict_csp(client: TestClient):
+    client.post("/internal/artifact", json={"id": "demo", "html": "<h1>hello</h1>"})
+    resp = client.get("/internal/artifact/demo/raw")
+    assert resp.status_code == 200
+    assert resp.text == "<h1>hello</h1>"
+    assert resp.headers["content-type"].startswith("text/html")
+    csp = resp.headers["content-security-policy"]
+    # The artifact tier security invariant (ADR 024 decision 4): sandboxed, no
+    # ambient authority, no beaconing. A regression here re-exposes the origin.
+    assert "sandbox allow-scripts" in csp
+    assert "allow-same-origin" not in csp
+    assert "default-src 'none'" in csp
+    assert "connect-src 'none'" in csp
+    assert resp.headers["cache-control"] == "no-store"
+
+
+def test_raw_missing_is_404(client: TestClient):
+    assert client.get("/internal/artifact/nope/raw").status_code == 404
+
+
+def test_raw_invalid_id_is_404(client: TestClient):
+    assert client.get("/internal/artifact/..%2f..%2fx/raw").status_code == 404
+
+
+def test_version_returns_etag(client: TestClient):
+    client.post("/internal/artifact", json={"id": "demo", "html": "<h1>hello</h1>"})
+    resp = client.get("/internal/artifact/demo/version")
+    assert resp.status_code == 200
+    assert resp.json() == {"version": "etag-14"}
+    assert resp.headers["cache-control"] == "no-store"
+
+
+def test_version_missing_is_404(client: TestClient):
+    assert client.get("/internal/artifact/nope/version").status_code == 404

--- a/projects/monolith/artifact/s3.py
+++ b/projects/monolith/artifact/s3.py
@@ -1,0 +1,127 @@
+"""Artifact storage on the SeaweedFS S3 gateway (ADR 024).
+
+goosecracker artifacts are agent-built, self-contained HTML pages published to
+the ``artifacts`` bucket at ``<id>/index.html``. The monolith mediates every
+write (the agent guest holds no S3 credential, ADR 024 decision 3), so this
+module is the single S3 seam: ``put_artifact`` on the write path (full monolith)
+and ``get_artifact`` / ``head_artifact`` on the public read path (the public
+backend, proxied by the SSR frontend).
+
+The client construction mirrors ``trips.s3`` / ``stars.grid._s3_client`` (dummy
+creds, path-style addressing, scheme guard on the endpoint) and the put +
+auto-create-bucket fallback mirrors ``chat.store._blob_s3_put``. boto3 is
+imported lazily inside each function so importing this module never pulls boto3
+into the public app's import closure (app/main_public_imports_test.py).
+"""
+
+import logging
+import os
+
+logger = logging.getLogger("monolith.artifact.s3")
+
+# Public-image-safe: a single object key per artifact id. Index naming keeps the
+# door open for multi-file artifacts later without changing the id space.
+_OBJECT_SUFFIX = "index.html"
+
+
+def _bucket() -> str:
+    return os.environ.get("ARTIFACTS_S3_BUCKET", "artifacts")
+
+
+def _object_key(artifact_id: str) -> str:
+    return f"{artifact_id}/{_OBJECT_SUFFIX}"
+
+
+def _client():
+    """Build a SeaweedFS S3 client (mirrors trips.s3 / stars.grid)."""
+    import boto3
+    from botocore.config import Config
+
+    endpoint = os.environ.get("SEAWEEDFS_S3_ENDPOINT", "")
+    if not endpoint:
+        raise RuntimeError("SEAWEEDFS_S3_ENDPOINT unset; cannot store artifact")
+    # The chart injects a scheme-less host:port (shared with DuckDB's httpfs);
+    # boto3 requires a scheme and SeaweedFS S3 is plaintext HTTP.
+    if not endpoint.startswith(("http://", "https://")):
+        endpoint = "http://" + endpoint
+    # Scheme guaranteed above; the inline nosemgrep clears the pre-commit
+    # boto3-endpoint-url-missing-scheme hook (the Bazel semgrep test ignores
+    # nosemgrep and is covered by exclude_rules in projects/monolith/BUILD).
+    return boto3.client(  # nosemgrep: boto3-endpoint-url-missing-scheme
+        "s3",
+        endpoint_url=endpoint,
+        aws_access_key_id=os.environ.get("S3_ACCESS_KEY_ID", "duckdb"),
+        aws_secret_access_key=os.environ.get("S3_SECRET_ACCESS_KEY", "duckdb"),
+        region_name=os.environ.get("AWS_REGION", "us-east-1"),
+        config=Config(s3={"addressing_style": "path"}),
+    )
+
+
+def put_artifact(artifact_id: str, html: bytes) -> str:
+    """Write the artifact HTML to ``s3://<bucket>/<id>/index.html``.
+
+    Overwrites any existing object under the id (re-publishing the same id is how
+    an iterated artifact hot-reloads, ADR 024). Returns the stored object's ETag,
+    which is the version the read path serves to the hot-reload poller. Creates
+    the bucket once and retries on a missing bucket (mirrors chat.store).
+    """
+    from botocore.exceptions import ClientError
+
+    client = _client()
+    bucket = _bucket()
+    key = _object_key(artifact_id)
+
+    def _put():
+        return client.put_object(
+            Bucket=bucket,
+            Key=key,
+            Body=html,
+            ContentType="text/html; charset=utf-8",
+        )
+
+    try:
+        resp = _put()
+    except ClientError as exc:
+        code = exc.response.get("Error", {}).get("Code", "")
+        if code in ("NoSuchBucket", "404"):
+            client.create_bucket(Bucket=bucket)
+            resp = _put()
+        else:
+            raise
+    return _clean_etag(resp.get("ETag", ""))
+
+
+def get_artifact(artifact_id: str) -> tuple[bytes, str] | None:
+    """Return ``(html_bytes, etag)`` for the artifact, or None if it is absent."""
+    from botocore.exceptions import ClientError
+
+    client = _client()
+    try:
+        resp = client.get_object(Bucket=_bucket(), Key=_object_key(artifact_id))
+    except ClientError as exc:
+        code = exc.response.get("Error", {}).get("Code", "")
+        if code in ("NoSuchKey", "NoSuchBucket", "404"):
+            return None
+        raise
+    body = resp["Body"].read()
+    return body, _clean_etag(resp.get("ETag", ""))
+
+
+def head_artifact(artifact_id: str) -> str | None:
+    """Return the artifact's current ETag (version), or None if it is absent."""
+    from botocore.exceptions import ClientError
+
+    client = _client()
+    try:
+        resp = client.head_object(Bucket=_bucket(), Key=_object_key(artifact_id))
+    except ClientError as exc:
+        code = exc.response.get("Error", {}).get("Code", "")
+        if code in ("NoSuchKey", "NoSuchBucket", "404"):
+            return None
+        raise
+    return _clean_etag(resp.get("ETag", ""))
+
+
+def _clean_etag(etag: str) -> str:
+    """S3 ETags are quoted; strip the quotes for a clean version token."""
+    return etag.strip('"')

--- a/projects/monolith/artifact/s3_test.py
+++ b/projects/monolith/artifact/s3_test.py
@@ -1,0 +1,91 @@
+"""Tests for artifact S3 storage (boto3 mocked; mirrors trips/s3_test.py)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from artifact import s3
+
+
+@pytest.fixture(autouse=True)
+def _s3_env(monkeypatch):
+    monkeypatch.setenv("SEAWEEDFS_S3_ENDPOINT", "seaweedfs-s3.seaweedfs.svc:8333")
+    monkeypatch.setenv("ARTIFACTS_S3_BUCKET", "artifacts")
+
+
+def _patch_client(monkeypatch, client: MagicMock):
+    fake_boto3 = MagicMock()
+    fake_boto3.client.return_value = client
+    monkeypatch.setattr(s3, "_client", lambda: client)
+    return client
+
+
+def test_put_artifact_writes_index_html_and_returns_clean_etag(monkeypatch):
+    client = MagicMock()
+    client.put_object.return_value = {"ETag": '"abc123"'}
+    _patch_client(monkeypatch, client)
+
+    etag = s3.put_artifact("demo", b"<h1>hi</h1>")
+
+    assert etag == "abc123"  # quotes stripped
+    args = client.put_object.call_args.kwargs
+    assert args["Bucket"] == "artifacts"
+    assert args["Key"] == "demo/index.html"
+    assert args["Body"] == b"<h1>hi</h1>"
+    assert args["ContentType"].startswith("text/html")
+
+
+def test_put_artifact_creates_bucket_then_retries(monkeypatch):
+    from botocore.exceptions import ClientError
+
+    client = MagicMock()
+    err = ClientError({"Error": {"Code": "NoSuchBucket"}}, "PutObject")
+    client.put_object.side_effect = [err, {"ETag": '"e"'}]
+    _patch_client(monkeypatch, client)
+
+    etag = s3.put_artifact("demo", b"x")
+
+    assert etag == "e"
+    client.create_bucket.assert_called_once_with(Bucket="artifacts")
+    assert client.put_object.call_count == 2
+
+
+def test_get_artifact_returns_body_and_etag(monkeypatch):
+    client = MagicMock()
+    body = MagicMock()
+    body.read.return_value = b"<p>hello</p>"
+    client.get_object.return_value = {"Body": body, "ETag": '"v1"'}
+    _patch_client(monkeypatch, client)
+
+    got = s3.get_artifact("demo")
+
+    assert got == (b"<p>hello</p>", "v1")
+    assert client.get_object.call_args.kwargs["Key"] == "demo/index.html"
+
+
+def test_get_artifact_missing_returns_none(monkeypatch):
+    from botocore.exceptions import ClientError
+
+    client = MagicMock()
+    client.get_object.side_effect = ClientError(
+        {"Error": {"Code": "NoSuchKey"}}, "GetObject"
+    )
+    _patch_client(monkeypatch, client)
+
+    assert s3.get_artifact("missing") is None
+
+
+def test_head_artifact_returns_etag_or_none(monkeypatch):
+    from botocore.exceptions import ClientError
+
+    client = MagicMock()
+    client.head_object.return_value = {"ETag": '"v2"'}
+    _patch_client(monkeypatch, client)
+    assert s3.head_artifact("demo") == "v2"
+
+    client.head_object.side_effect = ClientError(
+        {"Error": {"Code": "404"}}, "HeadObject"
+    )
+    assert s3.head_artifact("gone") is None

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.227.0
+version: 0.227.1
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.226.0
+version: 0.227.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/templates/deployment.yaml
+++ b/projects/monolith/chart/templates/deployment.yaml
@@ -162,6 +162,16 @@ spec:
             - name: CHAT_BLOB_S3_BUCKET
               value: {{ .Values.chat.blobBucket | quote }}
             {{- end }}
+            {{- if .Values.artifact }}
+            # goosecracker artifact store (ADR 024) reuses the shared SeaweedFS S3
+            # endpoint/creds above. The full monolith mediates artifact writes
+            # (the agent guest holds no S3 credential); ARTIFACT_PUBLIC_BASE is the
+            # origin the publish response returns the artifact URL on.
+            - name: ARTIFACTS_S3_BUCKET
+              value: {{ .Values.artifact.bucket | quote }}
+            - name: ARTIFACT_PUBLIC_BASE
+              value: {{ .Values.artifact.publicBase | quote }}
+            {{- end }}
             {{- end }}
           livenessProbe:
             httpGet:

--- a/projects/monolith/chart/values.yaml
+++ b/projects/monolith/chart/values.yaml
@@ -538,6 +538,14 @@ stars:
 chat:
   blobBucket: "chat"
 
+# goosecracker artifact store (ADR 024). The full monolith writes agent-built
+# HTML to s3://<bucket>/<id>/index.html (reusing the shared SeaweedFS S3
+# endpoint/creds from the stars block) and returns the artifact URL on
+# publicBase. The bucket auto-creates on first write.
+artifact:
+  bucket: "artifacts"
+  publicBase: "https://jomcgi.dev"
+
 cfIngress:
   private:
     enabled: true

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.226.0
+      targetRevision: 0.227.0
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.227.0
+      targetRevision: 0.227.1
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/routes/public/artifact/[id]/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/artifact/[id]/+page.svelte
@@ -1,0 +1,58 @@
+<script>
+  import { onMount, onDestroy } from "svelte";
+  import { page } from "$app/stores";
+
+  $: id = $page.params.id;
+  $: rawUrl = `/artifact/${id}/raw`;
+
+  let lastVersion = null;
+  let pollInterval = null;
+
+  onMount(() => {
+    pollInterval = setInterval(async () => {
+      try {
+        const res = await fetch(`/artifact/${id}/version`);
+        if (!res.ok) return;
+        const data = await res.json();
+        const v = data?.version;
+        if (!v) return;
+        if (lastVersion !== null && v !== lastVersion) {
+          // Artifact has been updated: force the iframe to reload by bumping
+          // the cache-bust param on rawUrl.
+          rawUrl = `/artifact/${id}/raw?v=${encodeURIComponent(v)}`;
+        }
+        lastVersion = v;
+      } catch {
+        // Network error or JSON parse failure: ignore silently, try again next tick.
+      }
+    }, 3000);
+  });
+
+  onDestroy(() => {
+    clearInterval(pollInterval);
+  });
+</script>
+
+<svelte:head>
+  <title>Artifact</title>
+  <style>
+    body {
+      margin: 0;
+      padding: 0;
+      overflow: hidden;
+    }
+  </style>
+</svelte:head>
+
+<!--
+  SECURITY INVARIANT (ADR 024): sandbox MUST be exactly "allow-scripts".
+  Do NOT add allow-same-origin — that would re-grant the jomcgi.dev origin
+  to artifact code, defeating the entire sandbox. Do NOT add allow-forms,
+  allow-popups, or allow-top-navigation either.
+-->
+<iframe
+  title="artifact"
+  sandbox="allow-scripts"
+  src={rawUrl}
+  style="width:100%;height:100vh;border:0;display:block;"
+></iframe>

--- a/projects/monolith/frontend/src/routes/public/artifact/[id]/page-sandbox.test.js
+++ b/projects/monolith/frontend/src/routes/public/artifact/[id]/page-sandbox.test.js
@@ -1,0 +1,60 @@
+/**
+ * Security invariant tests for the artifact wrapper page (ADR 024).
+ *
+ * We read the +page.svelte source directly and assert on the text because:
+ *  - The sandboxed iframe is the primary security boundary.
+ *  - allow-same-origin would re-grant the jomcgi.dev origin to artifact code,
+ *    defeating the sandbox entirely.
+ *  - A regex over the source is deterministic and does not require a JSDOM
+ *    render of SvelteKit-specific syntax ($app/stores, reactive $: labels).
+ *
+ * These tests MUST NOT be deleted or weakened without an explicit ADR revision.
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { join, dirname } from "node:path";
+
+const pageSource = readFileSync(
+  join(dirname(fileURLToPath(import.meta.url)), "+page.svelte"),
+  "utf8",
+);
+
+describe("+page.svelte iframe sandbox invariant (ADR 024)", () => {
+  it('sandbox attribute is exactly "allow-scripts"', () => {
+    // Must match sandbox="allow-scripts" with no additional tokens.
+    // The attribute value must be the complete string "allow-scripts".
+    expect(pageSource).toMatch(/sandbox="allow-scripts"/);
+  });
+
+  it('sandbox attribute value does not include "allow-same-origin"', () => {
+    // This would re-grant the jomcgi.dev origin to the sandboxed artifact.
+    // We extract the attribute VALUE to avoid false-positives from warning
+    // comments in the source that mention the forbidden token by name.
+    const match = pageSource.match(/sandbox="([^"]*)"/);
+    expect(match).toBeTruthy();
+    expect(match[1]).not.toContain("allow-same-origin");
+  });
+
+  it('sandbox attribute value does not include "allow-forms"', () => {
+    const match = pageSource.match(/sandbox="([^"]*)"/);
+    expect(match).toBeTruthy();
+    expect(match[1]).not.toContain("allow-forms");
+  });
+
+  it('sandbox attribute value does not include "allow-popups"', () => {
+    const match = pageSource.match(/sandbox="([^"]*)"/);
+    expect(match).toBeTruthy();
+    expect(match[1]).not.toContain("allow-popups");
+  });
+
+  it('sandbox attribute value does not include "allow-top-navigation"', () => {
+    const match = pageSource.match(/sandbox="([^"]*)"/);
+    expect(match).toBeTruthy();
+    expect(match[1]).not.toContain("allow-top-navigation");
+  });
+
+  it("renders an <iframe> element", () => {
+    expect(pageSource).toMatch(/<iframe\b/);
+  });
+});

--- a/projects/monolith/frontend/src/routes/public/artifact/[id]/raw/+server.js
+++ b/projects/monolith/frontend/src/routes/public/artifact/[id]/raw/+server.js
@@ -1,0 +1,32 @@
+import { error } from "@sveltejs/kit";
+
+const API_BASE = process.env.API_BASE || "http://localhost:8000";
+
+// Same-origin proxy for an artifact's raw HTML. The browser fetches
+// /artifact/<id>/raw (rerouted from jomcgi.dev/artifact/<id>/raw via the
+// apex->public prefix rule in hooks.js); this handler fetches the HTML
+// server-side from the backend's /internal/artifact/<id>/raw endpoint and
+// forwards it with a strict Content-Security-Policy. The artifact is always
+// rendered inside a sandboxed <iframe sandbox="allow-scripts"> in +page.svelte
+// so the CSP is a defense-in-depth layer, not the primary sandbox boundary.
+// The browser never calls the backend directly.
+const CSP_FALLBACK =
+  "sandbox allow-scripts; default-src 'none'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; img-src data: blob:; font-src data:; connect-src 'none'; form-action 'none'; base-uri 'none'";
+
+export async function GET({ params, fetch }) {
+  const res = await fetch(
+    `${API_BASE}/internal/artifact/${encodeURIComponent(params.id)}/raw`,
+    { signal: AbortSignal.timeout(10_000) },
+  );
+  if (!res.ok) {
+    throw error(res.status === 404 ? 404 : 503, "artifact unavailable");
+  }
+  const csp = res.headers.get("content-security-policy") ?? CSP_FALLBACK;
+  return new Response(await res.text(), {
+    headers: {
+      "content-type": "text/html; charset=utf-8",
+      "cache-control": "no-store",
+      "content-security-policy": csp,
+    },
+  });
+}

--- a/projects/monolith/frontend/src/routes/public/artifact/[id]/raw/server.test.js
+++ b/projects/monolith/frontend/src/routes/public/artifact/[id]/raw/server.test.js
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { GET } from "./+server.js";
+
+const CSP_FALLBACK =
+  "sandbox allow-scripts; default-src 'none'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; img-src data: blob:; font-src data:; connect-src 'none'; form-action 'none'; base-uri 'none'";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("/public/artifact/[id]/raw GET", () => {
+  it("proxies to the correct backend URL", async () => {
+    const fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      headers: { get: () => null },
+      text: async () => "<h1>hello</h1>",
+    });
+    vi.stubGlobal("fetch", fetch);
+
+    await GET({ params: { id: "abc123" }, fetch });
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    const url = fetch.mock.calls[0][0];
+    expect(url).toMatch(/\/internal\/artifact\/abc123\/raw$/);
+  });
+
+  it("URL-encodes the artifact id in the backend request", async () => {
+    const fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      headers: { get: () => null },
+      text: async () => "<p>ok</p>",
+    });
+    vi.stubGlobal("fetch", fetch);
+
+    await GET({ params: { id: "hello world/slash" }, fetch });
+
+    const url = fetch.mock.calls[0][0];
+    expect(url).toContain(encodeURIComponent("hello world/slash"));
+    expect(url).not.toContain(" ");
+  });
+
+  it("returns the HTML body from the backend", async () => {
+    const html = "<html><body>artifact content</body></html>";
+    const fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      headers: { get: () => null },
+      text: async () => html,
+    });
+    vi.stubGlobal("fetch", fetch);
+
+    const res = await GET({ params: { id: "abc123" }, fetch });
+
+    expect(await res.text()).toBe(html);
+    expect(res.headers.get("content-type")).toBe("text/html; charset=utf-8");
+  });
+
+  it("sets cache-control: no-store", async () => {
+    const fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      headers: { get: () => null },
+      text: async () => "<p>ok</p>",
+    });
+    vi.stubGlobal("fetch", fetch);
+
+    const res = await GET({ params: { id: "x" }, fetch });
+
+    expect(res.headers.get("cache-control")).toBe("no-store");
+  });
+
+  it("forwards the CSP header from the backend when present", async () => {
+    const backendCsp = "default-src 'none'; script-src 'unsafe-inline'";
+    const fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      headers: {
+        get: (h) => (h === "content-security-policy" ? backendCsp : null),
+      },
+      text: async () => "<p>ok</p>",
+    });
+    vi.stubGlobal("fetch", fetch);
+
+    const res = await GET({ params: { id: "x" }, fetch });
+
+    expect(res.headers.get("content-security-policy")).toBe(backendCsp);
+  });
+
+  it("uses the fallback CSP when the backend does not set one", async () => {
+    const fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      headers: { get: () => null },
+      text: async () => "<p>ok</p>",
+    });
+    vi.stubGlobal("fetch", fetch);
+
+    const res = await GET({ params: { id: "x" }, fetch });
+
+    expect(res.headers.get("content-security-policy")).toBe(CSP_FALLBACK);
+  });
+
+  it("throws a 404 error when the backend returns 404", async () => {
+    const fetch = vi.fn().mockResolvedValue({ ok: false, status: 404 });
+    vi.stubGlobal("fetch", fetch);
+
+    await expect(
+      GET({ params: { id: "missing" }, fetch }),
+    ).rejects.toMatchObject({ status: 404 });
+  });
+
+  it("throws a 503 error when the backend returns a non-404 error", async () => {
+    const fetch = vi.fn().mockResolvedValue({ ok: false, status: 502 });
+    vi.stubGlobal("fetch", fetch);
+
+    await expect(GET({ params: { id: "x" }, fetch })).rejects.toMatchObject({
+      status: 503,
+    });
+  });
+});

--- a/projects/monolith/frontend/src/routes/public/artifact/[id]/version/+server.js
+++ b/projects/monolith/frontend/src/routes/public/artifact/[id]/version/+server.js
@@ -1,0 +1,22 @@
+import { error, json } from "@sveltejs/kit";
+
+const API_BASE = process.env.API_BASE || "http://localhost:8000";
+
+// Same-origin proxy for the artifact version (ETag string). The hot-reload
+// poller in +page.svelte polls this endpoint every 3s to detect when an
+// artifact has been updated; when the version changes, the iframe is reloaded
+// by bumping a cache-bust query param on the raw URL. Returning no-store
+// ensures the poller always reaches the backend and never serves a stale
+// version from the edge cache.
+export async function GET({ params, fetch }) {
+  const res = await fetch(
+    `${API_BASE}/internal/artifact/${encodeURIComponent(params.id)}/version`,
+    { signal: AbortSignal.timeout(10_000) },
+  );
+  if (!res.ok) {
+    throw error(res.status === 404 ? 404 : 503, "artifact unavailable");
+  }
+  return json(await res.json(), {
+    headers: { "cache-control": "no-store" },
+  });
+}

--- a/projects/monolith/frontend/src/routes/public/artifact/[id]/version/server.test.js
+++ b/projects/monolith/frontend/src/routes/public/artifact/[id]/version/server.test.js
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { GET } from "./+server.js";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("/public/artifact/[id]/version GET", () => {
+  it("proxies to the correct backend URL", async () => {
+    const fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ version: "etag-abc" }),
+    });
+    vi.stubGlobal("fetch", fetch);
+
+    await GET({ params: { id: "abc123" }, fetch });
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    const url = fetch.mock.calls[0][0];
+    expect(url).toMatch(/\/internal\/artifact\/abc123\/version$/);
+  });
+
+  it("URL-encodes the artifact id in the backend request", async () => {
+    const fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ version: "v1" }),
+    });
+    vi.stubGlobal("fetch", fetch);
+
+    await GET({ params: { id: "hello world" }, fetch });
+
+    const url = fetch.mock.calls[0][0];
+    expect(url).toContain(encodeURIComponent("hello world"));
+    expect(url).not.toContain(" ");
+  });
+
+  it("passes the JSON payload through from the backend", async () => {
+    const payload = { version: "etag-deadbeef" };
+    const fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => payload,
+    });
+    vi.stubGlobal("fetch", fetch);
+
+    const res = await GET({ params: { id: "x" }, fetch });
+
+    expect(await res.json()).toEqual(payload);
+  });
+
+  it("sets cache-control: no-store on the response", async () => {
+    const fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ version: "v1" }),
+    });
+    vi.stubGlobal("fetch", fetch);
+
+    const res = await GET({ params: { id: "x" }, fetch });
+
+    expect(res.headers.get("cache-control")).toBe("no-store");
+  });
+
+  it("throws a 404 error when the backend returns 404", async () => {
+    const fetch = vi.fn().mockResolvedValue({ ok: false, status: 404 });
+    vi.stubGlobal("fetch", fetch);
+
+    await expect(
+      GET({ params: { id: "missing" }, fetch }),
+    ).rejects.toMatchObject({ status: 404 });
+  });
+
+  it("throws a 503 error when the backend returns a non-404 error", async () => {
+    const fetch = vi.fn().mockResolvedValue({ ok: false, status: 500 });
+    vi.stubGlobal("fetch", fetch);
+
+    await expect(GET({ params: { id: "x" }, fetch })).rejects.toMatchObject({
+      status: 503,
+    });
+  });
+});


### PR DESCRIPTION
Task 2 of the goosecracker build plan: publish + serve isolated, hot-reloading agent artifacts (ADR 024 decisions 3+4). Builds on Task 1 (#2890, merged).

## Backend `artifact/` domain
- `POST /internal/artifact` `{id?, html}` -> writes `s3://artifacts/<id>/index.html` (monolith-mediated, so the agent guest holds no S3 credential), returns `{id, url, version=ETag}`. Server-assigns an unguessable id; 2 MiB cap; safe id charset (no path traversal). Mounted on the **full monolith only**.
- `GET /internal/artifact/<id>/raw` -> S3 HTML with a strict CSP (`sandbox allow-scripts; default-src 'none'; connect-src 'none'`), `no-store`.
- `GET /internal/artifact/<id>/version` -> the ETag for the hot-reload poller.
- Read routers on **both** binaries; `register_public` is read-only (the public tier never mounts the write router). `s3.py` lazy-imports boto3 so the public import closure stays clean.

## Public serving (design confirmed with Joe: Option A)
jomcgi.dev is the isolated `monolith-public` tier whose backend is never internet-reachable, so the SSR **frontend** serves the public surface:
- `/public/artifact/[id]/+page.svelte`: trusted wrapper framing the artifact in `<iframe sandbox="allow-scripts">` (**no `allow-same-origin`** -> opaque origin per ADR 024 decision 4) + a 3s ETag poller that reloads the iframe on change.
- `raw/+server.js` + `version/+server.js`: in-cluster proxies to the public backend (the `notes/body` pattern). The public backend gains **read-only** artifacts-bucket S3 access (in-cluster SeaweedFS, allowed by the EgressNetwork).

## Security
- Untrusted agent HTML is origin-isolated two ways: the wrapper's sandboxed iframe (opaque origin) **and** a `sandbox` CSP on the raw response, so even a direct fetch runs with no ambient authority. `connect-src 'none'` blocks beaconing. A test asserts the iframe sandbox attr is exactly `allow-scripts` and `allow-same-origin` is absent (ADR-mandated).
- Public tier stays read-only (write router not mounted there). `/internal/artifact` is off the public HTTPRoute (frontend is the sole public origin).

## Validation
Local: both charts render the new env; `helm template` confirmed. Backend unit tests (S3 faked / boto3 mocked) cover publish/read/version, the 2 MiB cap, id validation, the CSP header, and 404s. Frontend tests cover the proxies + the sandbox-attr invariant. Full in-cluster validation (curl POST, open jomcgi.dev/artifact/<id>, re-POST -> hot reload, confirm the iframe cannot read jomcgi.dev localStorage) runs after CI + rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)