### PR TITLE
feat(agent): artifact goose recipe for goosecracker (ADR 024 Task 3)

### DIFF
--- a/projects/agent_platform/fc-agentd/chart/Chart.yaml
+++ b/projects/agent_platform/fc-agentd/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: fc-agentd
 description: Firecracker snapshot/restore controller (ADR 022) - the node-4 Postgres-reconcile daemon that manages agent-thread microVMs
 type: application
-version: 0.12.0
+version: 0.13.0
 appVersion: "latest"
 keywords:
   - firecracker

--- a/projects/agent_platform/fc-agentd/chart/values.yaml
+++ b/projects/agent_platform/fc-agentd/chart/values.yaml
@@ -75,6 +75,11 @@ egress:
       OPENAI_API_KEY: "kloak:or:B5BKP27T2KSDN6QW70N34H8DP6"
       GOOSE_PROVIDER: openai
       GOOSE_MODEL: google/gemini-3.5-flash
+      # Where the artifact recipe publishes (ADR 024 Task 3). In-cluster monolith
+      # backend; the guest reaches it through the transparent egress funnel (the
+      # sidecar routes by Host, no secret swap for this host). Injected only into
+      # artifact-tier guests, so only they can publish.
+      ARTIFACT_PUBLISH_URL: http://monolith.monolith.svc.cluster.local:8000/internal/artifact
   # 6b CA: cert-manager generates + rotates the self-signed CA the sidecar uses to
   # mint leaf certs when it TLS-terminates a secret-bearing destination. Only
   # created when `secrets` below is non-empty.

--- a/projects/agent_platform/fc-agentd/deploy/application.yaml
+++ b/projects/agent_platform/fc-agentd/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: fc-agentd
-      targetRevision: 0.12.0
+      targetRevision: 0.13.0
       helm:
         valueFiles:
           - $values/projects/agent_platform/fc-agentd/deploy/values.yaml

--- a/projects/agent_platform/harness/recipes/artifact.yaml
+++ b/projects/agent_platform/harness/recipes/artifact.yaml
@@ -1,0 +1,54 @@
+version: "1.0.0"
+title: "Artifact"
+description: "Build a single self-contained web artifact and publish it to a live URL (ADR 024)."
+instructions: |
+  You build small, self-contained web artifacts (visualizations, interactive
+  demos, little pages, reports) and publish them to a live URL. You run inside an
+  isolated, sandboxed Firecracker microVM with a shell and editor. You have no
+  repo and no credentials: just build the thing and publish it.
+
+  ## Build
+  Write ONE self-contained HTML document to /tmp/artifact.html. It MUST be fully
+  self-contained:
+  - All CSS inside a <style> tag and all JavaScript inside <script> tags, inline.
+  - No external resources: no <script src=...>, no <link href=...>, no web fonts,
+    no images fetched over the network, no API/`fetch` calls. The artifact is
+    served under a strict Content-Security-Policy (default-src 'none';
+    connect-src 'none') inside a sandboxed iframe, so anything that reaches out
+    to the network will simply be blocked. Inline data: URIs for images are fine.
+  - Make it good: clean, working, and visually polished. Test your logic by
+    reading the file back; you cannot open a browser here.
+
+  ## Publish
+  Publish the file by running EXACTLY this command (do not modify it):
+
+      node -e 'const fs=require("fs");const u=process.env.ARTIFACT_PUBLISH_URL;const id=process.env.ARTIFACT_ID;const html=fs.readFileSync("/tmp/artifact.html","utf8");const body={html};if(id)body.id=id;fetch(u,{method:"POST",headers:{"content-type":"application/json"},body:JSON.stringify(body)}).then(async r=>{if(!r.ok)throw new Error("publish failed: "+r.status+" "+await r.text());return r.json()}).then(j=>console.log("ARTIFACT_URL="+j.url)).catch(e=>{console.error(String(e));process.exit(1)})'
+
+  It prints a line `ARTIFACT_URL=<url>`. If it fails, fix the artifact (e.g. if
+  it is too large) and re-run the same command. Re-running publishes a new
+  version of the same artifact (the open page hot-reloads), so iterate freely.
+
+  ## Output Format (REQUIRED)
+  When you are COMPLETELY finished, emit your result as the LAST thing you write,
+  using EXACTLY this format. Nothing after the closing marker.
+
+  ```goose-result
+  type: note
+  url: <the ARTIFACT_URL value from the publish step>
+  summary: <1-2 sentences: what you built>
+  ```
+
+  The summary describes WHAT you built, not your reasoning.
+prompt: |
+  {{ task_description | indent(2) }}
+parameters:
+  - key: task_description
+    description: "What to build"
+    input_type: string
+    requirement: required
+extensions:
+  - type: builtin
+    name: developer
+settings:
+  max_turns: 50
+  max_tool_repetitions: 5


### PR DESCRIPTION
Task 3 of goosecracker: the goose recipe that builds + publishes artifacts. Builds on Task 1 (#2890) + Task 2 (#2891), both merged + validated in-cluster.

## Changes
- `projects/agent_platform/harness/recipes/artifact.yaml`: a `developer`-extension recipe. Instructs goose to write a fully self-contained `/tmp/artifact.html` (no external resources, matching the strict CSP the artifact is served under) and publish it.
- The guest image has **no curl and no python** (and adding curl needs an apko lock regen that can't run on macOS), so publishing is a `node -e` one-liner — node ships in the harness image, and reading the HTML from a file avoids shell-escaping the markup. It POSTs to `$ARTIFACT_PUBLISH_URL`, reports the returned URL in the `goose-result` block, and honours an optional `$ARTIFACT_ID` for same-id re-publish (hot reload on iteration; the per-thread id is wired in Task 4), else server-assigns.
- fc-agentd chart: `ARTIFACT_PUBLISH_URL` injected into **artifact-tier guests only** (the in-cluster monolith backend reached via the egress funnel), so only the artifact tier can publish.

## Validation (after CI + rollout)
`dispatch.submit("make a bouncing-ball canvas demo", recipe="artifact", tier="artifact")` -> goose builds the HTML, publishes via node, the artifact URL renders at jomcgi.dev/artifact/<id>. The recipe change rebuilds the harness image -> fc-agentd base rootfs rebuild, so validation waits for that rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)