### PR TITLE
fix(agent): make artifact recipe force immediate tool use

### DIFF
--- a/projects/agent_platform/fc-agentd/chart/Chart.yaml
+++ b/projects/agent_platform/fc-agentd/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: fc-agentd
 description: Firecracker snapshot/restore controller (ADR 022) - the node-4 Postgres-reconcile daemon that manages agent-thread microVMs
 type: application
-version: 0.13.0
+version: 0.13.1
 appVersion: "latest"
 keywords:
   - firecracker

--- a/projects/agent_platform/fc-agentd/deploy/application.yaml
+++ b/projects/agent_platform/fc-agentd/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: fc-agentd
-      targetRevision: 0.13.0
+      targetRevision: 0.13.1
       helm:
         valueFiles:
           - $values/projects/agent_platform/fc-agentd/deploy/values.yaml

--- a/projects/agent_platform/harness/recipes/artifact.yaml
+++ b/projects/agent_platform/harness/recipes/artifact.yaml
@@ -4,42 +4,50 @@ description: "Build a single self-contained web artifact and publish it to a liv
 instructions: |
   You build small, self-contained web artifacts (visualizations, interactive
   demos, little pages, reports) and publish them to a live URL. You run inside an
-  isolated, sandboxed Firecracker microVM with a shell and editor. You have no
-  repo and no credentials: just build the thing and publish it.
+  isolated, sandboxed Firecracker microVM with a shell and a text editor. You
+  have no repo and no credentials: just build the thing and publish it.
 
-  ## Build
-  Write ONE self-contained HTML document to /tmp/artifact.html. It MUST be fully
-  self-contained:
-  - All CSS inside a <style> tag and all JavaScript inside <script> tags, inline.
-  - No external resources: no <script src=...>, no <link href=...>, no web fonts,
-    no images fetched over the network, no API/`fetch` calls. The artifact is
-    served under a strict Content-Security-Policy (default-src 'none';
-    connect-src 'none') inside a sandboxed iframe, so anything that reaches out
-    to the network will simply be blocked. Inline data: URIs for images are fine.
-  - Make it good: clean, working, and visually polished. Test your logic by
-    reading the file back; you cannot open a browser here.
+  ACT, DO NOT CHAT. Your text replies are discarded; only the file you write and
+  the artifact you publish count. Do NOT reply with a plan, a feature list,
+  questions, or a description of what you intend to build. Do NOT print the HTML
+  in your reply. Your FIRST action is a tool call that writes the file. If you
+  answer in prose instead of using the tools, you have FAILED.
 
-  ## Publish
-  Publish the file by running EXACTLY this command (do not modify it):
+  Do exactly this, in order:
 
-      node -e 'const fs=require("fs");const u=process.env.ARTIFACT_PUBLISH_URL;const id=process.env.ARTIFACT_ID;const html=fs.readFileSync("/tmp/artifact.html","utf8");const body={html};if(id)body.id=id;fetch(u,{method:"POST",headers:{"content-type":"application/json"},body:JSON.stringify(body)}).then(async r=>{if(!r.ok)throw new Error("publish failed: "+r.status+" "+await r.text());return r.json()}).then(j=>console.log("ARTIFACT_URL="+j.url)).catch(e=>{console.error(String(e));process.exit(1)})'
+  1. WRITE THE FILE. Use the shell or editor to write ONE complete, self-contained
+     HTML document to /tmp/artifact.html in a single step. It MUST be fully
+     self-contained:
+     - All CSS in a <style> tag and all JavaScript in <script> tags, inline.
+     - No external resources: no <script src=...>, no <link href=...>, no web
+       fonts, no network/`fetch` calls. The artifact is served under a strict CSP
+       (default-src 'none'; connect-src 'none') inside a sandboxed iframe, so
+       anything reaching the network is BLOCKED. Inline data: URIs for images are
+       fine. Make it complete and good on the first write.
 
-  It prints a line `ARTIFACT_URL=<url>`. If it fails, fix the artifact (e.g. if
-  it is too large) and re-run the same command. Re-running publishes a new
-  version of the same artifact (the open page hot-reloads), so iterate freely.
+  2. PUBLISH. Run EXACTLY this command (do not modify it):
 
-  ## Output Format (REQUIRED)
-  When you are COMPLETELY finished, emit your result as the LAST thing you write,
-  using EXACTLY this format. Nothing after the closing marker.
+         node -e 'const fs=require("fs");const u=process.env.ARTIFACT_PUBLISH_URL;const id=process.env.ARTIFACT_ID;const html=fs.readFileSync("/tmp/artifact.html","utf8");const body={html};if(id)body.id=id;fetch(u,{method:"POST",headers:{"content-type":"application/json"},body:JSON.stringify(body)}).then(async r=>{if(!r.ok)throw new Error("publish failed: "+r.status+" "+await r.text());return r.json()}).then(j=>console.log("ARTIFACT_URL="+j.url)).catch(e=>{console.error(String(e));process.exit(1)})'
 
-  ```goose-result
-  type: note
-  url: <the ARTIFACT_URL value from the publish step>
-  summary: <1-2 sentences: what you built>
-  ```
+     It prints `ARTIFACT_URL=<url>`. If it errors (e.g. the artifact is too
+     large), fix /tmp/artifact.html and run it again. Re-running publishes a new
+     version of the same artifact, which hot-reloads any open page, so iterate
+     freely.
 
-  The summary describes WHAT you built, not your reasoning.
+  3. REPORT. Only after the publish step has printed an ARTIFACT_URL, emit your
+     result as the LAST thing you write, using EXACTLY this format, nothing after
+     the closing marker:
+
+     ```goose-result
+     type: note
+     url: <the ARTIFACT_URL value from the publish step>
+     summary: <1-2 sentences: what you built>
+     ```
 prompt: |
+  Build and publish this artifact now. Start immediately by writing
+  /tmp/artifact.html with the shell or editor; do not reply with a plan or a
+  description first:
+
   {{ task_description | indent(2) }}
 parameters:
   - key: task_description


### PR DESCRIPTION
In-cluster validation of Task 3 (#2892) showed Gemini 3.5 Flash answering the artifact task with a prose feature-list and no tool call, so goose's headless `run` exited without writing/publishing. A diagnostic confirmed Gemini-via-OpenRouter tool calling works with goose (it ran a shell `echo` + returned a clean goose-result); the recipe was just too open-ended for a chatty Flash model.

This rewrites the recipe to be imperative (ACT, DO NOT CHAT; first action must write the file; prose instead of tools is a failure). Validation re-runs after the harness image + fc-agentd base-rootfs rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)