### PR TITLE
fix(fc-agentd): funnel guest egress port 8000 for artifact publish

### DIFF
--- a/projects/agent_platform/fc-agentd/chart/Chart.yaml
+++ b/projects/agent_platform/fc-agentd/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: fc-agentd
 description: Firecracker snapshot/restore controller (ADR 022) - the node-4 Postgres-reconcile daemon that manages agent-thread microVMs
 type: application
-version: 0.13.1
+version: 0.13.2
 appVersion: "latest"
 keywords:
   - firecracker

--- a/projects/agent_platform/fc-agentd/chart/templates/deployment.yaml
+++ b/projects/agent_platform/fc-agentd/chart/templates/deployment.yaml
@@ -133,6 +133,15 @@ spec:
             # egress to the sidecar, which routes by SNI/Host.
             - name: FC_AGENTD_EGRESS_SIDECAR
               value: {{ .Values.egress.sidecarAddr | quote }}
+            {{- with .Values.egress.funnelPorts }}
+            # Loopback ports the guest's transparent egress funnel listens on
+            # (ADR 023). Injected as EGRESS_PORTS into every guest; fc-agent-init
+            # tunnels each to the sidecar, which routes by SNI/Host. Must include
+            # every upstream port a guest dials: 443 (OpenRouter/web), 8080 (the
+            # in-cluster model), and 8000 (the monolith artifact publish, ADR 024).
+            - name: FC_AGENTD_INJECT_EGRESS_PORTS
+              value: {{ . | quote }}
+            {{- end }}
             {{- range $tier, $env := .Values.egress.tiers }}
             {{- range $k, $v := $env }}
             - name: FC_AGENTD_TIER_{{ $tier }}__{{ $k }}

--- a/projects/agent_platform/fc-agentd/chart/values.yaml
+++ b/projects/agent_platform/fc-agentd/chart/values.yaml
@@ -39,6 +39,12 @@ egress:
     tag: latest
   # Where fc-agentd forwards guest egress (the sidecar's listen address, pod-local).
   sidecarAddr: 127.0.0.1:8888
+  # Loopback ports the guest's transparent egress funnel listens on (injected as
+  # EGRESS_PORTS). Must list every upstream port a guest dials, since wildcard DNS
+  # points all names at loopback and only these ports have a funnel listener:
+  # 443 (OpenRouter + open web), 8080 (in-cluster model), 8000 (monolith artifact
+  # publish, ADR 024). 80 kept for plain-HTTP destinations.
+  funnelPorts: "80,443,8080,8000"
   # Egress posture. "allow" (default) routes anywhere in or out of cluster, so the
   # agent can read random docs; secrets still only materialise at their egressTo
   # (6b), so the open path cannot leak a credential. Flip to "allowlist" to

--- a/projects/agent_platform/fc-agentd/deploy/application.yaml
+++ b/projects/agent_platform/fc-agentd/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: fc-agentd
-      targetRevision: 0.13.1
+      targetRevision: 0.13.2
       helm:
         valueFiles:
           - $values/projects/agent_platform/fc-agentd/deploy/values.yaml


### PR DESCRIPTION
The artifact recipe publishes to the in-cluster monolith backend on **port 8000**, but the guest egress funnel only listened on `[80,443,8080]` (`fc-agent-init` defaultEgressPorts). So goose's node publish to `monolith.monolith.svc:8000` resolved to loopback (wildcard DNS) with no funnel listener and never reached the sidecar — the egress-proxy logged OpenRouter calls but zero connection to `:8000`, which is why artifacts never published.

Inject `EGRESS_PORTS=80,443,8080,8000` into every guest via a new `egress.funnelPorts` value. `fc-agent-init` reads `EGRESS_PORTS` from the Assign env before building the funnel, so this is a chart-only fix (fc-agentd rolls; no harness/base-rootfs rebuild).

Found while validating Task 3 (#2892/#2893) in-cluster. Re-validation after fc-agentd rolls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)