### PR TITLE
fix(fc-agentd): skip linkerd outbound for port 8000 (artifact publish)

### DIFF
--- a/projects/agent_platform/fc-agentd/chart/Chart.yaml
+++ b/projects/agent_platform/fc-agentd/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: fc-agentd
 description: Firecracker snapshot/restore controller (ADR 022) - the node-4 Postgres-reconcile daemon that manages agent-thread microVMs
 type: application
-version: 0.13.2
+version: 0.13.3
 appVersion: "latest"
 keywords:
   - firecracker

--- a/projects/agent_platform/fc-agentd/chart/templates/deployment.yaml
+++ b/projects/agent_platform/fc-agentd/chart/templates/deployment.yaml
@@ -22,6 +22,10 @@ spec:
     metadata:
       labels:
         {{- include "fc-agentd.labels" . | nindent 8 }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       serviceAccountName: {{ include "fc-agentd.serviceAccountName" . }}
       priorityClassName: {{ .Values.priorityClassName }}

--- a/projects/agent_platform/fc-agentd/chart/values.yaml
+++ b/projects/agent_platform/fc-agentd/chart/values.yaml
@@ -126,6 +126,17 @@ egress:
 
 replicas: 1
 
+# Pod annotations. The egress-proxy sidecar tunnels guest egress to upstreams;
+# its connection to the Linkerd-meshed monolith backend (port 8000, the artifact
+# publish target, ADR 024) stalls in the pod's Linkerd outbound when blind-
+# tunnelled, while unmeshed upstreams (the in-cluster model on 8080) work. Skip
+# Linkerd outbound for port 8000 so the egress-proxy reaches the monolith as a
+# plain in-cluster client (the monolith's permissive Linkerd inbound accepts it,
+# the same path unmeshed callers use). Scoped to 8000, so only the artifact
+# publish is affected; everything else stays meshed.
+podAnnotations:
+  config.linkerd.io/skip-outbound-ports: "8000"
+
 # node + arch the controller manages. Firecracker snapshots are node/arch-bound,
 # so the daemon is pinned to its node and only reconciles that node's threads.
 node: node-4

--- a/projects/agent_platform/fc-agentd/deploy/application.yaml
+++ b/projects/agent_platform/fc-agentd/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: fc-agentd
-      targetRevision: 0.13.2
+      targetRevision: 0.13.3
       helm:
         valueFiles:
           - $values/projects/agent_platform/fc-agentd/deploy/values.yaml


### PR DESCRIPTION
The egress-proxy's blind-tunnelled connection to the Linkerd-meshed monolith backend (port 8000, the ADR 024 artifact publish target) stalls in the pod's Linkerd outbound: the request never reaches the monolith inbound (no inbound logs), node's fetch hangs, and the guest idles mid-publish. Unmeshed upstreams (Qwen on inference:8080) work through the same funnel, and a direct in-pod POST to the monolith service works — so it's specific to the egress-proxy tunnel → Linkerd outbound → meshed dest.

`config.linkerd.io/skip-outbound-ports: "8000"` makes the egress-proxy reach the monolith as a plain in-cluster client (the monolith's permissive inbound accepts it, like any unmeshed caller). Scoped to 8000, so only the artifact publish path changes; reversible. Found while validating Task 3 in-cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)