### PR TITLE
feat(agent): publish artifact from the harness, not the goose recipe

### DIFF
--- a/projects/agent_platform/fc-agent-init/cmd/main.go
+++ b/projects/agent_platform/fc-agent-init/cmd/main.go
@@ -10,10 +10,13 @@
 package main
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"io"
 	"log/slog"
 	"net"
+	"net/http"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -126,12 +129,19 @@ func run(logger *slog.Logger) error {
 	if harnessProc != nil {
 		err := harnessProc.Wait()
 		logger.Info("harness exited", "err", err)
+		// Publish the artifact the harness produced (ADR 024). The monolith
+		// mediates the S3 write, so the guest just POSTs the file it built; doing
+		// it here (not in the goose recipe) makes publishing deterministic and
+		// observable (this log is captured host-side by fc-agentd, unlike the
+		// guest console which the PID-1-exit kernel panic truncates) and yields the
+		// URL for the Done result. No-op when ARTIFACT_PUBLISH_URL is unset.
+		artifactURL := publishArtifact(logger)
 		if conn != nil {
 			status := "ok"
 			if err != nil {
 				status = err.Error()
 			}
-			if serr := conn.Send(vsockproto.Message{Kind: vsockproto.KindDone, ThreadID: threadID, Status: status}); serr != nil {
+			if serr := conn.Send(vsockproto.Message{Kind: vsockproto.KindDone, ThreadID: threadID, Status: status, Result: artifactURL}); serr != nil {
 				logger.Warn("failed to send done signal", "err", serr)
 			}
 		}
@@ -455,6 +465,56 @@ func funnelToHost(logger *slog.Logger, local net.Conn, port int) {
 	go func() { _, _ = io.Copy(up, local); done <- struct{}{} }()
 	go func() { _, _ = io.Copy(local, up); done <- struct{}{} }()
 	<-done
+}
+
+// artifactFile is where the artifact recipe writes the page to publish.
+const artifactFile = "/tmp/artifact.html"
+
+// publishArtifact POSTs the artifact the harness built to the monolith (ADR 024),
+// which performs the S3 write (the guest holds no S3 credential), and returns the
+// public URL. It is a no-op (returns "") when ARTIFACT_PUBLISH_URL is unset (any
+// non-artifact tier) or no artifact file was produced. The request egresses
+// through the transparent funnel like all guest traffic; doing the publish here
+// rather than in the goose recipe makes it deterministic and logs the exact
+// result host-side (the guest console is truncated by the PID-1-exit panic). An
+// ARTIFACT_ID re-publishes the same artifact id (hot reload across iterations).
+func publishArtifact(logger *slog.Logger) string {
+	url := os.Getenv("ARTIFACT_PUBLISH_URL")
+	if url == "" {
+		return ""
+	}
+	html, err := os.ReadFile(artifactFile)
+	if err != nil {
+		logger.Info("artifact: nothing to publish", "path", artifactFile, "err", err)
+		return ""
+	}
+	body := map[string]string{"html": string(html)}
+	if id := os.Getenv("ARTIFACT_ID"); id != "" {
+		body["id"] = id
+	}
+	payload, err := json.Marshal(body)
+	if err != nil {
+		logger.Error("artifact: marshal failed", "err", err)
+		return ""
+	}
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Post(url, "application/json", bytes.NewReader(payload))
+	if err != nil {
+		logger.Error("artifact: publish request failed", "url", url, "err", err)
+		return ""
+	}
+	defer resp.Body.Close()
+	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 8192))
+	if resp.StatusCode != http.StatusOK {
+		logger.Error("artifact: publish non-OK", "status", resp.StatusCode, "body", string(respBody))
+		return ""
+	}
+	var out struct {
+		ID, URL, Version string
+	}
+	_ = json.Unmarshal(respBody, &out)
+	logger.Info("artifact: published", "url", out.URL, "version", out.Version, "html_bytes", len(html))
+	return out.URL
 }
 
 // ensureEnv sets key to def only when it is unset, so an injected value (e.g. a

--- a/projects/agent_platform/fc-agentd/chart/Chart.yaml
+++ b/projects/agent_platform/fc-agentd/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: fc-agentd
 description: Firecracker snapshot/restore controller (ADR 022) - the node-4 Postgres-reconcile daemon that manages agent-thread microVMs
 type: application
-version: 0.13.3
+version: 0.14.0
 appVersion: "latest"
 keywords:
   - firecracker

--- a/projects/agent_platform/fc-agentd/deploy/application.yaml
+++ b/projects/agent_platform/fc-agentd/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: fc-agentd
-      targetRevision: 0.13.3
+      targetRevision: 0.14.0
       helm:
         valueFiles:
           - $values/projects/agent_platform/fc-agentd/deploy/values.yaml

--- a/projects/agent_platform/harness/recipes/artifact.yaml
+++ b/projects/agent_platform/harness/recipes/artifact.yaml
@@ -1,52 +1,41 @@
 version: "1.0.0"
 title: "Artifact"
-description: "Build a single self-contained web artifact and publish it to a live URL (ADR 024)."
+description: "Build a single self-contained web artifact; the harness publishes it to a live URL (ADR 024)."
 instructions: |
   You build small, self-contained web artifacts (visualizations, interactive
-  demos, little pages, reports) and publish them to a live URL. You run inside an
-  isolated, sandboxed Firecracker microVM with a shell and a text editor. You
-  have no repo and no credentials: just build the thing and publish it.
+  demos, little pages, reports). You run inside an isolated, sandboxed
+  Firecracker microVM with a shell and a text editor.
 
-  ACT, DO NOT CHAT. Your text replies are discarded; only the file you write and
-  the artifact you publish count. Do NOT reply with a plan, a feature list,
-  questions, or a description of what you intend to build. Do NOT print the HTML
-  in your reply. Your FIRST action is a tool call that writes the file. If you
-  answer in prose instead of using the tools, you have FAILED.
+  ACT, DO NOT CHAT. Your text replies are discarded; only the file you write
+  counts. Do NOT reply with a plan, a feature list, questions, or a description
+  of what you intend to build. Do NOT print the HTML in your reply. Your FIRST
+  action is a tool call that writes the file. If you answer in prose instead of
+  using the tools, you have FAILED.
 
-  Do exactly this, in order:
+  Your ONLY job: write ONE complete, self-contained HTML document to
+  /tmp/artifact.html using the shell or editor, in a single step. It MUST be
+  fully self-contained:
+  - All CSS in a <style> tag and all JavaScript in <script> tags, inline.
+  - No external resources: no <script src=...>, no <link href=...>, no web fonts,
+    no network/`fetch` calls. The artifact is served under a strict CSP
+    (default-src 'none'; connect-src 'none') inside a sandboxed iframe, so
+    anything reaching the network is BLOCKED. Inline data: URIs for images are
+    fine. Make it complete, correct, and visually polished on the first write.
 
-  1. WRITE THE FILE. Use the shell or editor to write ONE complete, self-contained
-     HTML document to /tmp/artifact.html in a single step. It MUST be fully
-     self-contained:
-     - All CSS in a <style> tag and all JavaScript in <script> tags, inline.
-     - No external resources: no <script src=...>, no <link href=...>, no web
-       fonts, no network/`fetch` calls. The artifact is served under a strict CSP
-       (default-src 'none'; connect-src 'none') inside a sandboxed iframe, so
-       anything reaching the network is BLOCKED. Inline data: URIs for images are
-       fine. Make it complete and good on the first write.
+  Do NOT try to deploy, serve, or publish the file yourself: the harness publishes
+  /tmp/artifact.html automatically after you finish and returns the live URL. You
+  have no network publish path. Just write the best /tmp/artifact.html you can.
 
-  2. PUBLISH. Run EXACTLY this command (do not modify it):
+  When the file is written, emit your result as the LAST thing you write, using
+  EXACTLY this format, nothing after the closing marker:
 
-         node -e 'const fs=require("fs");const u=process.env.ARTIFACT_PUBLISH_URL;const id=process.env.ARTIFACT_ID;const html=fs.readFileSync("/tmp/artifact.html","utf8");const body={html};if(id)body.id=id;fetch(u,{method:"POST",headers:{"content-type":"application/json"},body:JSON.stringify(body)}).then(async r=>{if(!r.ok)throw new Error("publish failed: "+r.status+" "+await r.text());return r.json()}).then(j=>console.log("ARTIFACT_URL="+j.url)).catch(e=>{console.error(String(e));process.exit(1)})'
-
-     It prints `ARTIFACT_URL=<url>`. If it errors (e.g. the artifact is too
-     large), fix /tmp/artifact.html and run it again. Re-running publishes a new
-     version of the same artifact, which hot-reloads any open page, so iterate
-     freely.
-
-  3. REPORT. Only after the publish step has printed an ARTIFACT_URL, emit your
-     result as the LAST thing you write, using EXACTLY this format, nothing after
-     the closing marker:
-
-     ```goose-result
-     type: note
-     url: <the ARTIFACT_URL value from the publish step>
-     summary: <1-2 sentences: what you built>
-     ```
+  ```goose-result
+  type: note
+  summary: <1-2 sentences: what you built>
+  ```
 prompt: |
-  Build and publish this artifact now. Start immediately by writing
-  /tmp/artifact.html with the shell or editor; do not reply with a plan or a
-  description first:
+  Build this artifact now. Start immediately by writing /tmp/artifact.html with
+  the shell or editor; do not reply with a plan or a description first:
 
   {{ task_description | indent(2) }}
 parameters:

--- a/projects/agent_platform/vsockproto/proto.go
+++ b/projects/agent_platform/vsockproto/proto.go
@@ -85,6 +85,10 @@ type Message struct {
 	Env map[string]string `json:"env,omitempty"`
 	// Status is the harness exit status on KindDone.
 	Status string `json:"status,omitempty"`
+	// Result is an optional result artifact from the run on KindDone: for the
+	// artifact tier (ADR 024) it is the published artifact URL, which the
+	// controller surfaces (e.g. to the Discord thread via discord_outbox).
+	Result string `json:"result,omitempty"`
 	// Reason is a human-readable note for logs/observability.
 	Reason string `json:"reason,omitempty"`
 }


### PR DESCRIPTION
In-cluster validation surfaced two problems with recipe-publishes: goose (Gemini Flash) was unreliable at running the publish step, and the guest console is truncated by the PID-1-exit kernel panic so a failed publish was unobservable.

Move the publish into `fc-agent-init`: after the harness exits it POSTs `/tmp/artifact.html` to `ARTIFACT_PUBLISH_URL` (monolith mediates the S3 write), **logs the exact HTTP status/body/error host-side** (fc-agentd captures it, panic-immune), and carries the URL on the vsockproto Done `Result` field (for Task 5 → discord_outbox). goose's only job is now to write a good self-contained `/tmp/artifact.html`; the recipe is simplified and told not to publish. `ARTIFACT_ID` still re-publishes the same id for hot reload.

This makes publishing deterministic + observable and sets up Task 5. Validation after the harness image + base-rootfs rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)