### PR TITLE
fix(fc-agentd): use goose native openrouter provider for artifact tier

### DIFF
--- a/projects/agent_platform/fc-agentd/chart/Chart.yaml
+++ b/projects/agent_platform/fc-agentd/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: fc-agentd
 description: Firecracker snapshot/restore controller (ADR 022) - the node-4 Postgres-reconcile daemon that manages agent-thread microVMs
 type: application
-version: 0.14.0
+version: 0.14.1
 appVersion: "latest"
 keywords:
   - firecracker

--- a/projects/agent_platform/fc-agentd/chart/values.yaml
+++ b/projects/agent_platform/fc-agentd/chart/values.yaml
@@ -77,9 +77,16 @@ egress:
       # the sidecar swaps for the real token only on api.github.com.
       GITHUB_TOKEN: "kloak:gh:01JZX8K3N7Q2M5R9W4T6Y0F1B8"
     artifact:
-      OPENAI_HOST: https://openrouter.ai/api
-      OPENAI_API_KEY: "kloak:or:B5BKP27T2KSDN6QW70N34H8DP6"
-      GOOSE_PROVIDER: openai
+      # goose's NATIVE openrouter provider, not the generic openai-compatible one:
+      # reasoning support is provider-specific in goose, and Gemini 3.5 Flash is a
+      # thinking model, so under the generic openai provider goose returns turns it
+      # cannot act on for generative tasks (it never emits the tool call / writes
+      # the file). The native openrouter provider handles Gemini's thinking + tool
+      # calls. The guest holds the placeholder as OPENROUTER_API_KEY (the var this
+      # provider reads); the sidecar swaps it for the real key on openrouter.ai.
+      # Host defaults to openrouter.ai, reached via the transparent egress funnel.
+      GOOSE_PROVIDER: openrouter
+      OPENROUTER_API_KEY: "kloak:or:B5BKP27T2KSDN6QW70N34H8DP6"
       GOOSE_MODEL: google/gemini-3.5-flash
       # Where the artifact recipe publishes (ADR 024 Task 3). In-cluster monolith
       # backend; the guest reaches it through the transparent egress funnel (the

--- a/projects/agent_platform/fc-agentd/deploy/application.yaml
+++ b/projects/agent_platform/fc-agentd/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: fc-agentd
-      targetRevision: 0.14.0
+      targetRevision: 0.14.1
       helm:
         valueFiles:
           - $values/projects/agent_platform/fc-agentd/deploy/values.yaml


### PR DESCRIPTION
Root cause (per Joe's hint: Gemini Flash is meant to be used with thinking): the artifact tier used goose's generic `openai`-compatible provider pointed at OpenRouter. Reasoning support is **provider-specific** in goose, and Gemini 3.5 Flash is a thinking model — so under the generic openai provider goose returns turns it can't act on for content-generation tasks (loads, sits ~20s, emits no tool call, exits without writing the file). Mechanical tool calls (echo) worked; generative ones didn't.

Switch the artifact tier to goose's **native openrouter provider**, which handles Gemini's thinking + tool calls. The guest holds the placeholder as `OPENROUTER_API_KEY` (the var that provider reads); the egress swap still fires on openrouter.ai (placeholder string match). Keeps Gemini 3.5 Flash (ADR 024). Chart-only, fast roll. Validation: re-run the bouncing-ball artifact end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)