### PR TITLE
chore(fc-agentd): temporary goose debug logging (artifact tier diagnostic)

### DIFF
--- a/projects/agent_platform/fc-agentd/chart/Chart.yaml
+++ b/projects/agent_platform/fc-agentd/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: fc-agentd
 description: Firecracker snapshot/restore controller (ADR 022) - the node-4 Postgres-reconcile daemon that manages agent-thread microVMs
 type: application
-version: 0.15.1
+version: 0.15.2
 appVersion: "latest"
 keywords:
   - firecracker

--- a/projects/agent_platform/fc-agentd/chart/values.yaml
+++ b/projects/agent_platform/fc-agentd/chart/values.yaml
@@ -88,6 +88,11 @@ egress:
       GOOSE_PROVIDER: openrouter
       OPENROUTER_API_KEY: "kloak:or:B5BKP27T2KSDN6QW70N34H8DP6"
       GOOSE_MODEL: google/gemini-3.5-flash
+      # TEMPORARY DIAGNOSTIC (revert): goose debug logging to capture the outgoing
+      # OpenRouter request (does it carry `reasoning` + `tools`?) and the model's
+      # response, host-side via fc-agentd, to confirm whether the reasoning budget
+      # is actually applied. HTTP-stack crates quieted to keep the log readable.
+      RUST_LOG: "goose=debug,goose_llm=debug,goose_cli=debug,info,h2=warn,hyper=warn,hyper_util=warn,rustls=warn,reqwest=warn,tower=warn,tower_http=warn"
       # Gemini 3.5 Flash is a thinking model: without an explicit reasoning
       # budget goose's openrouter provider lets the model spend the turn on
       # reasoning and return content:null, so for a generative task it never

--- a/projects/agent_platform/fc-agentd/deploy/application.yaml
+++ b/projects/agent_platform/fc-agentd/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: fc-agentd
-      targetRevision: 0.15.1
+      targetRevision: 0.15.2
       helm:
         valueFiles:
           - $values/projects/agent_platform/fc-agentd/deploy/values.yaml


### PR DESCRIPTION
Diagnostic only (revert after): RUST_LOG on the artifact tier so goose logs the outgoing OpenRouter request (does it carry `reasoning`+`tools`?) + the model response, host-side via fc-agentd. Confirms whether the reasoning budget is applied (current behavior: single ~2k-token no-tool-call turn, no file written).

🤖 Generated with [Claude Code](https://claude.com/claude-code)