### PR TITLE
fix(fc-agentd): raise artifact-tier output token budget for Gemini thinking

### DIFF
--- a/projects/agent_platform/fc-agentd/chart/Chart.yaml
+++ b/projects/agent_platform/fc-agentd/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: fc-agentd
 description: Firecracker snapshot/restore controller (ADR 022) - the node-4 Postgres-reconcile daemon that manages agent-thread microVMs
 type: application
-version: 0.15.3
+version: 0.15.4
 appVersion: "latest"
 keywords:
   - firecracker

--- a/projects/agent_platform/fc-agentd/chart/values.yaml
+++ b/projects/agent_platform/fc-agentd/chart/values.yaml
@@ -93,16 +93,17 @@ egress:
       # response, host-side via fc-agentd, to confirm whether the reasoning budget
       # is actually applied. HTTP-stack crates quieted to keep the log readable.
       RUST_LOG: "goose=debug,goose_llm=debug,goose_cli=debug,info,h2=warn,hyper=warn,hyper_util=warn,rustls=warn,reqwest=warn,tower=warn,tower_http=warn"
-      # Gemini 3.5 Flash is a thinking model: without an explicit reasoning
-      # budget goose's openrouter provider lets the model spend the turn on
-      # reasoning and return content:null, so for a generative task it never
-      # emits the tool call that writes /tmp/artifact.html (ADR 024 Task 3
-      # blocker). GOOSE_PREDEFINED_MODELS re-declares the model with an
-      # OpenRouter `reasoning` budget so thinking produces an actionable turn
-      # (the owner's steer: keep thinking on, do not disable it). The name must
-      # match GOOSE_MODEL so goose applies these request_params to the selected
-      # model. Renders to FC_AGENTD_TIER_artifact__GOOSE_PREDEFINED_MODELS.
-      GOOSE_PREDEFINED_MODELS: '[{"name":"google/gemini-3.5-flash","provider":"openrouter","request_params":{"reasoning":{"effort":"high"}}}]'
+      # Gemini 3.5 Flash is a thinking model and thinks BY DEFAULT (egress capture
+      # confirmed: the response streams delta.reasoning). The real Task 3 blocker:
+      # goose did not know this model's limits (not in its registry) and capped
+      # the output at ~1024 tokens, so the model spent the whole completion budget
+      # on reasoning (reasoning_tokens==completion_tokens==1013) and hit MAX_TOKENS
+      # (finish_reason:length) with content:"" and NO tool_call -> nothing
+      # actionable -> no file written. GOOSE_PREDEFINED_MODELS declares the real
+      # 1M context window AND a large output budget so thinking has headroom and
+      # the model can still emit the write tool_call. The name matches GOOSE_MODEL
+      # so goose applies it. Renders to FC_AGENTD_TIER_artifact__GOOSE_PREDEFINED_MODELS.
+      GOOSE_PREDEFINED_MODELS: '[{"name":"google/gemini-3.5-flash","provider":"openrouter","context_limit":1048576,"request_params":{"max_tokens":32000}}]'
       # Where the artifact recipe publishes (ADR 024 Task 3). In-cluster monolith
       # backend; the guest reaches it through the transparent egress funnel (the
       # sidecar routes by Host, no secret swap for this host). Injected only into

--- a/projects/agent_platform/fc-agentd/deploy/application.yaml
+++ b/projects/agent_platform/fc-agentd/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: fc-agentd
-      targetRevision: 0.15.3
+      targetRevision: 0.15.4
       helm:
         valueFiles:
           - $values/projects/agent_platform/fc-agentd/deploy/values.yaml


### PR DESCRIPTION
Root cause (from the #2906 egress capture): goose capped output at ~1024 tokens for google/gemini-3.5-flash (unknown model), so the thinking model spent it all on reasoning (reasoning_tokens==completion_tokens==1013) and hit finish_reason:length/MAX_TOKENS with empty content + no tool_call -> no file. Thinking is on by default; it just had no room to act.

Declares the model's 1M window + a large output budget via GOOSE_PREDEFINED_MODELS. Caveat (goose #7839): predefined-models may be unreliably applied; the deployed egress capture verifies whether the budget rose. Fallback if not: native google provider + GEMINI3_THINKING_LEVEL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)