### PR TITLE
chore(goosecracker): revert temporary diagnostics after Task 3 validation

### DIFF
--- a/projects/agent_platform/egress-proxy/cmd/swap.go
+++ b/projects/agent_platform/egress-proxy/cmd/swap.go
@@ -11,7 +11,6 @@ package main
 
 import (
 	"bufio"
-	"bytes"
 	"crypto"
 	"crypto/rand"
 	"crypto/rsa"
@@ -208,10 +207,6 @@ func (p *proxy) terminateAndSwap(br *bufio.Reader, client net.Conn, dest, host s
 			return
 		}
 		swapRequest(req, sec)
-		// TEMPORARY DIAGNOSTIC (revert): for openrouter, log the request body
-		// summary (does goose send `reasoning` + `tools` + tool_choice?). Body
-		// carries no secret (the key is in the Authorization header, not logged).
-		debugLogOpenRouterRequest(p.logger, host, req)
 		// Re-emit as a client request: clear the server-side RequestURI and the
 		// absolute URL parts so req.Write sends origin-form with the Host header.
 		req.RequestURI = ""
@@ -225,9 +220,6 @@ func (p *proxy) terminateAndSwap(br *bufio.Reader, client net.Conn, dest, host s
 			p.logger.Warn("egress swap: read response", "dest", dest, "err", err)
 			return
 		}
-		// TEMPORARY DIAGNOSTIC (revert): capture the openrouter response body
-		// (tool_calls? content? finish_reason?) then restore it for the guest.
-		debugCaptureOpenRouterResponse(p.logger, host, resp)
 		err = resp.Write(guest)
 		_ = resp.Body.Close()
 		if err != nil {
@@ -236,71 +228,6 @@ func (p *proxy) terminateAndSwap(br *bufio.Reader, client net.Conn, dest, host s
 		}
 		p.logger.Info("egress swapped", "dest", dest, "env", sec.Env, "path", req.URL.Path)
 	}
-}
-
-// debugLogOpenRouterRequest logs a summary of an OpenRouter chat/completions
-// request body (TEMPORARY DIAGNOSTIC, revert): whether goose sends `reasoning`,
-// `tools`, and `tool_choice`, plus the model. The body carries no secret. It
-// reads and restores the body so forwarding is unaffected.
-func debugLogOpenRouterRequest(logger *slog.Logger, host string, req *http.Request) {
-	if !strings.Contains(strings.ToLower(host), "openrouter") || req.Body == nil {
-		return
-	}
-	b, err := io.ReadAll(req.Body)
-	_ = req.Body.Close()
-	req.Body = io.NopCloser(bytes.NewReader(b))
-	if err != nil {
-		return
-	}
-	var m map[string]json.RawMessage
-	if jerr := json.Unmarshal(b, &m); jerr != nil {
-		logger.Info("diag-req: openrouter (non-JSON body)", "bytes", len(b))
-		return
-	}
-	keys := make([]string, 0, len(m))
-	for k := range m {
-		keys = append(keys, k)
-	}
-	toolCount := -1
-	if t, ok := m["tools"]; ok {
-		var arr []json.RawMessage
-		if json.Unmarshal(t, &arr) == nil {
-			toolCount = len(arr)
-		}
-	}
-	logger.Info("diag-req: openrouter request",
-		"bytes", len(b),
-		"keys", strings.Join(keys, ","),
-		"model", string(m["model"]),
-		"reasoning", string(m["reasoning"]),
-		"tool_choice", string(m["tool_choice"]),
-		"tools_count", toolCount,
-		"stream", string(m["stream"]),
-	)
-}
-
-// debugCaptureOpenRouterResponse logs a bounded snippet of an OpenRouter response
-// body (TEMPORARY DIAGNOSTIC, revert) to reveal tool_calls / content /
-// finish_reason / reasoning, then restores the body for the guest.
-func debugCaptureOpenRouterResponse(logger *slog.Logger, host string, resp *http.Response) {
-	if !strings.Contains(strings.ToLower(host), "openrouter") || resp.Body == nil {
-		return
-	}
-	b, err := io.ReadAll(resp.Body)
-	_ = resp.Body.Close()
-	resp.Body = io.NopCloser(bytes.NewReader(b))
-	// We buffered the whole (possibly chunked/streamed) body, so re-frame it with
-	// a fixed Content-Length to keep resp.Write well-formed for the guest.
-	resp.TransferEncoding = nil
-	resp.ContentLength = int64(len(b))
-	if err != nil {
-		return
-	}
-	snippet := string(b)
-	if len(snippet) > 6000 {
-		snippet = snippet[:3000] + "\n...[trunc]...\n" + snippet[len(snippet)-3000:]
-	}
-	logger.Info("diag-resp: openrouter response", "status", resp.StatusCode, "bytes", len(b), "body", snippet)
 }
 
 // swapRequest replaces the placeholder with the real value in every header value

--- a/projects/agent_platform/fc-agent-init/cmd/main.go
+++ b/projects/agent_platform/fc-agent-init/cmd/main.go
@@ -14,14 +14,12 @@ import (
 	"context"
 	"encoding/json"
 	"io"
-	"io/fs"
 	"log/slog"
 	"net"
 	"net/http"
 	"os"
 	"os/exec"
 	"os/signal"
-	"path/filepath"
 	"strconv"
 	"strings"
 	"syscall"
@@ -137,7 +135,6 @@ func run(logger *slog.Logger) error {
 		// observable (this log is captured host-side by fc-agentd, unlike the
 		// guest console which the PID-1-exit kernel panic truncates) and yields the
 		// URL for the Done result. No-op when ARTIFACT_PUBLISH_URL is unset.
-		dumpGuestDiag(logger)
 		artifactURL := publishArtifact(logger)
 		if conn != nil {
 			status := "ok"
@@ -472,61 +469,6 @@ func funnelToHost(logger *slog.Logger, local net.Conn, port int) {
 
 // artifactFile is where the artifact recipe writes the page to publish.
 const artifactFile = "/tmp/artifact.html"
-
-// dumpGuestDiag logs what the harness actually did, host-side via the controller
-// (fc-agentd captures this, unlike the guest console which the PID-1-exit panic
-// truncates): a listing of likely write targets (did goose write a file at all,
-// and where?) and the tail of goose's newest session/log file (did it emit a
-// tool call, and what did the model return?). Diagnostic only; bounded output.
-func dumpGuestDiag(logger *slog.Logger) {
-	home := os.Getenv("HOME")
-	for _, dir := range []string{"/tmp", home, "/", "/workspace"} {
-		entries, err := os.ReadDir(dir)
-		if err != nil {
-			continue
-		}
-		var names []string
-		for _, e := range entries {
-			info, _ := e.Info()
-			sz := int64(-1)
-			if info != nil {
-				sz = info.Size()
-			}
-			names = append(names, e.Name()+"("+strconv.FormatInt(sz, 10)+")")
-		}
-		logger.Info("diag: dir", "path", dir, "entries", strings.Join(names, " "))
-	}
-	// Newest goose session/log file under HOME (goose stores transcripts + logs
-	// there); its tail shows the model turns + whether a tool call was emitted.
-	var newest string
-	var newestT time.Time
-	if home != "" {
-		_ = filepath.WalkDir(home, func(p string, d fs.DirEntry, err error) error {
-			if err != nil || d.IsDir() {
-				return nil
-			}
-			if strings.HasSuffix(p, ".jsonl") || strings.HasSuffix(p, ".log") {
-				if info, e := d.Info(); e == nil && info.ModTime().After(newestT) {
-					newestT, newest = info.ModTime(), p
-				}
-			}
-			return nil
-		})
-	}
-	if newest == "" {
-		logger.Info("diag: no goose session/log file found under HOME")
-		return
-	}
-	b, err := os.ReadFile(newest)
-	if err != nil {
-		logger.Info("diag: read goose log failed", "path", newest, "err", err)
-		return
-	}
-	if len(b) > 16384 {
-		b = b[len(b)-16384:]
-	}
-	logger.Info("diag: goose log tail", "path", newest, "tail", string(b))
-}
 
 // publishArtifact POSTs the artifact the harness built to the monolith (ADR 024),
 // which performs the S3 write (the guest holds no S3 credential), and returns the

--- a/projects/agent_platform/fc-agentd/chart/Chart.yaml
+++ b/projects/agent_platform/fc-agentd/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: fc-agentd
 description: Firecracker snapshot/restore controller (ADR 022) - the node-4 Postgres-reconcile daemon that manages agent-thread microVMs
 type: application
-version: 0.15.5
+version: 0.15.6
 appVersion: "latest"
 keywords:
   - firecracker

--- a/projects/agent_platform/fc-agentd/chart/values.yaml
+++ b/projects/agent_platform/fc-agentd/chart/values.yaml
@@ -88,11 +88,6 @@ egress:
       GOOSE_PROVIDER: openrouter
       OPENROUTER_API_KEY: "kloak:or:B5BKP27T2KSDN6QW70N34H8DP6"
       GOOSE_MODEL: google/gemini-3.5-flash
-      # TEMPORARY DIAGNOSTIC (revert): goose debug logging to capture the outgoing
-      # OpenRouter request (does it carry `reasoning` + `tools`?) and the model's
-      # response, host-side via fc-agentd, to confirm whether the reasoning budget
-      # is actually applied. HTTP-stack crates quieted to keep the log readable.
-      RUST_LOG: "goose=debug,goose_llm=debug,goose_cli=debug,info,h2=warn,hyper=warn,hyper_util=warn,rustls=warn,reqwest=warn,tower=warn,tower_http=warn"
       # Gemini 3.5 Flash is a thinking model and thinks BY DEFAULT (egress capture
       # confirmed: the response streams delta.reasoning). The real Task 3 blocker:
       # goose did not know this model's limits (not in its registry), so its output

--- a/projects/agent_platform/fc-agentd/deploy/application.yaml
+++ b/projects/agent_platform/fc-agentd/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: fc-agentd
-      targetRevision: 0.15.5
+      targetRevision: 0.15.6
       helm:
         valueFiles:
           - $values/projects/agent_platform/fc-agentd/deploy/values.yaml


### PR DESCRIPTION
Now that the goosecracker artifact tier is validated end-to-end (the `GOOSE_MAX_TOKENS=32000` fix in #2908: Gemini 3.5 Flash writes the artifact, publishes to `s3://artifacts`, and serves at `jomcgi.dev/artifact/<id>/raw` under the strict sandbox CSP with a working hot-reload version endpoint), this reverts the three temporary diagnostics added during debugging:

- **RUST_LOG** debug logging on the artifact tier (fc-agentd values, #2905)
- **egress-proxy** OpenRouter request/response body capture (`swap.go`, #2906) — `debugLogOpenRouterRequest` + `debugCaptureOpenRouterResponse` and their call sites; dropped the now-orphaned `bytes` import
- **guest `dumpGuestDiag`** dump on harness exit (`fc-agent-init/cmd/main.go`); dropped the now-orphaned `io/fs` and `path/filepath` imports

`skip-outbound-ports: "8000"` is **kept** — it is load-bearing for the artifact publish path to the meshed monolith (from #2895), not a diagnostic.

Verified locally: `go build ./projects/agent_platform/egress-proxy/... ./projects/agent_platform/fc-agent-init/...` is clean, gofumpt-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)