### PR TITLE
feat(goosecracker): stream live build progress to the Discord thread

### DIFF
--- a/projects/agent_platform/fc-agent-init/cmd/main.go
+++ b/projects/agent_platform/fc-agent-init/cmd/main.go
@@ -20,8 +20,10 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
+	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -111,11 +113,22 @@ func run(logger *slog.Logger) error {
 		setupTransparentEgress(ctx, logger, os.Getenv("EGRESS_PORTS"), det)
 	}
 
+	// Live progress stream (ADR 024): tee goose's stdout/stderr to the monolith so
+	// the Discord bot can show the build as it happens. No-op unless the tier sets
+	// PROGRESS_PUBLISH_URL (artifact tier only). The host log still gets the full
+	// output via os.Stdout.
+	pw := newProgressStreamer(logger)
+
 	var harnessProc *exec.Cmd
 	if len(harnessArgv) > 0 {
 		harnessProc = exec.CommandContext(ctx, harnessArgv[0], harnessArgv[1:]...)
-		harnessProc.Stdout = os.Stdout
-		harnessProc.Stderr = os.Stderr
+		var out io.Writer = os.Stdout
+		if pw != nil {
+			out = io.MultiWriter(os.Stdout, pw)
+			go pw.flushLoop(ctx, logger)
+		}
+		harnessProc.Stdout = out
+		harnessProc.Stderr = out
 		harnessProc.Env = os.Environ()
 		if err := harnessProc.Start(); err != nil {
 			return err
@@ -144,6 +157,11 @@ func run(logger *slog.Logger) error {
 		// guest console which the PID-1-exit kernel panic truncates) and yields the
 		// URL for the Done result. No-op when ARTIFACT_PUBLISH_URL is unset.
 		artifactURL := publishArtifact(logger)
+		// Flush any tail output and tell the bot the build is done so it stops the
+		// live edit (the link itself arrives via the Done -> outbox path below).
+		if pw != nil {
+			pw.finish(logger)
+		}
 		if conn != nil {
 			status := "ok"
 			if err != nil {
@@ -531,6 +549,92 @@ func publishArtifact(logger *slog.Logger) string {
 	_ = json.Unmarshal(respBody, &out)
 	logger.Info("artifact: published", "url", out.URL, "version", out.Version, "html_bytes", len(html))
 	return out.URL
+}
+
+// ansiRE matches the ANSI escape sequences goose writes for colour/formatting, so
+// the streamed build log reads cleanly in Discord (which renders them literally).
+var ansiRE = regexp.MustCompile("\x1b\\[[0-9;?]*[ -/]*[@-~]")
+
+func stripANSI(s string) string {
+	return ansiRE.ReplaceAllString(s, "")
+}
+
+// progressStreamer tees the harness's stdout/stderr to the monolith's
+// goosecracker progress endpoint so the Discord bot can show the build live (ADR
+// 024). Writes are buffered and POSTed coarsely on a ticker, so the harness
+// never blocks on the network. nil (all methods no-op) unless both
+// PROGRESS_PUBLISH_URL and ARTIFACT_ID are set, i.e. the artifact tier only.
+type progressStreamer struct {
+	url    string
+	id     string
+	client *http.Client
+	mu     sync.Mutex
+	buf    []byte
+}
+
+func newProgressStreamer(logger *slog.Logger) *progressStreamer {
+	url := os.Getenv("PROGRESS_PUBLISH_URL")
+	id := os.Getenv("ARTIFACT_ID")
+	if url == "" || id == "" {
+		return nil
+	}
+	logger.Info("progress streaming enabled", "url", url, "id", id)
+	return &progressStreamer{url: url, id: id, client: &http.Client{Timeout: 10 * time.Second}}
+}
+
+// Write buffers harness output. It never errors or blocks, so a slow/broken
+// progress endpoint can never stall or fail the build itself.
+func (p *progressStreamer) Write(b []byte) (int, error) {
+	if p == nil {
+		return len(b), nil
+	}
+	p.mu.Lock()
+	p.buf = append(p.buf, b...)
+	p.mu.Unlock()
+	return len(b), nil
+}
+
+// flushLoop POSTs buffered output on a ticker until ctx is cancelled.
+func (p *progressStreamer) flushLoop(ctx context.Context, logger *slog.Logger) {
+	t := time.NewTicker(750 * time.Millisecond)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			p.flush(logger, false)
+		}
+	}
+}
+
+// finish flushes the tail and marks the run done so the bot stops live-editing.
+func (p *progressStreamer) finish(logger *slog.Logger) {
+	p.flush(logger, true)
+}
+
+func (p *progressStreamer) flush(logger *slog.Logger, done bool) {
+	if p == nil {
+		return
+	}
+	p.mu.Lock()
+	b := p.buf
+	p.buf = nil
+	p.mu.Unlock()
+	chunk := stripANSI(string(b))
+	if chunk == "" && !done {
+		return
+	}
+	payload, err := json.Marshal(map[string]any{"id": p.id, "chunk": chunk, "done": done})
+	if err != nil {
+		return
+	}
+	resp, err := p.client.Post(p.url, "application/json", bytes.NewReader(payload))
+	if err != nil {
+		logger.Debug("progress: post failed", "err", err)
+		return
+	}
+	_ = resp.Body.Close()
 }
 
 // ensureEnv sets key to def only when it is unset, so an injected value (e.g. a

--- a/projects/agent_platform/fc-agentd/chart/Chart.yaml
+++ b/projects/agent_platform/fc-agentd/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: fc-agentd
 description: Firecracker snapshot/restore controller (ADR 022) - the node-4 Postgres-reconcile daemon that manages agent-thread microVMs
 type: application
-version: 0.15.7
+version: 0.15.8
 appVersion: "latest"
 keywords:
   - firecracker

--- a/projects/agent_platform/fc-agentd/chart/values.yaml
+++ b/projects/agent_platform/fc-agentd/chart/values.yaml
@@ -110,6 +110,11 @@ egress:
       # sidecar routes by Host, no secret swap for this host). Injected only into
       # artifact-tier guests, so only they can publish.
       ARTIFACT_PUBLISH_URL: http://monolith.monolith.svc.cluster.local:8000/internal/artifact
+      # Live build-progress sink (ADR 024): fc-agent-init tees goose's stdout here
+      # as the build runs so the Discord bot can show it live (keyed by ARTIFACT_ID
+      # = the Discord thread). Same in-cluster monolith reached via the egress
+      # funnel; artifact tier only, so only artifact runs stream.
+      PROGRESS_PUBLISH_URL: http://monolith.monolith.svc.cluster.local:8000/internal/goosecracker/progress
   # 6b CA: cert-manager generates + rotates the self-signed CA the sidecar uses to
   # mint leaf certs when it TLS-terminates a secret-bearing destination. Only
   # created when `secrets` below is non-empty.

--- a/projects/agent_platform/fc-agentd/deploy/application.yaml
+++ b/projects/agent_platform/fc-agentd/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: fc-agentd
-      targetRevision: 0.15.7
+      targetRevision: 0.15.8
       helm:
         valueFiles:
           - $values/projects/agent_platform/fc-agentd/deploy/values.yaml

--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.73.2
+version: 0.74.0
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.73.2
+      targetRevision: 0.74.0
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -788,6 +788,16 @@ py_test(
 )
 
 py_test(
+    name = "chat_goosecracker_progress_test",
+    srcs = ["chat/goosecracker_progress_test.py"],
+    imports = ["."],
+    deps = [
+        ":monolith_backend",
+        "@pip//pytest",
+    ],
+)
+
+py_test(
     name = "chat_web_search_test",
     srcs = ["chat/web_search_test.py"],
     imports = ["."],

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.228.2
+version: 0.228.3
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chat/__init__.py
+++ b/projects/monolith/chat/__init__.py
@@ -5,6 +5,10 @@ from fastapi import FastAPI
 
 def register(app: FastAPI) -> None:
     """Register chat domain routers with the app."""
-    from chat.router import router
+    from chat.router import internal_router, router
 
     app.include_router(router)
+    # /internal/goosecracker/progress: the build-progress sink for live Discord
+    # streaming (ADR 024). Full monolith only (the public tier never runs the bot
+    # and must not expose it).
+    app.include_router(internal_router)

--- a/projects/monolith/chat/bot.py
+++ b/projects/monolith/chat/bot.py
@@ -5,6 +5,7 @@ import hashlib
 import json
 import logging
 import os
+import time
 
 import discord
 from pydantic_ai import (
@@ -22,6 +23,7 @@ from chat.store import MessageStore
 from chat.vision import VisionClient
 from chat.web_search import search_web
 from chat import goosecracker
+from chat import goosecracker_progress
 from app.db import get_engine
 
 from sqlmodel import Session
@@ -41,6 +43,41 @@ def _truncate_thinking(thinking: str) -> str:
     if len(thinking) <= DISCORD_MESSAGE_LIMIT:
         return thinking
     return thinking[:THINKING_TRUNCATE_AT] + "... (truncated)"
+
+
+# Live /goosecracker progress streaming (ADR 024). The guest streams goose's
+# stdout to the in-process progress buffer; the bot edits the thread message on
+# this cadence so the owner sees activity instead of a multi-minute silent wait.
+GOOSECRACKER_STREAM_INTERVAL = 1.5  # seconds between Discord edits (rate-limit safe)
+GOOSECRACKER_STREAM_TIMEOUT = 900  # stop streaming after 15 min (run is wedged)
+GOOSECRACKER_THINKING_AFTER = 4.0  # no new output for this long -> show "Thinking"
+GOOSECRACKER_PROGRESS_TAIL = 1700  # chars of build log shown (room for header/footer)
+
+
+def _render_goosecracker_progress(snap, elapsed: int) -> str:
+    """Render a live build-progress message body from a progress snapshot.
+
+    ``snap`` is a chat.goosecracker_progress.Progress or None (nothing yet).
+    Shows a rolling tail of goose's stdout plus a status line: Thinking when the
+    output has been quiet (the model is reasoning, no bytes flow), Working when
+    output is fresh, Built when the run signalled done.
+    """
+    minutes, seconds = divmod(max(elapsed, 0), 60)
+    el = f"{minutes}:{seconds:02d}"
+    text = snap.text if snap else ""
+    lines = ["🛠 **Building your artifact**"]
+    tail = text[-GOOSECRACKER_PROGRESS_TAIL:].strip()
+    if tail:
+        lines.append(f"```\n{tail}\n```")
+    if snap is not None and snap.done:
+        lines.append(
+            f"✅ Built in {el}. Publishing the link... (reply here to iterate)"
+        )
+    elif text and (time.monotonic() - snap.updated_at) < GOOSECRACKER_THINKING_AFTER:
+        lines.append(f"⚙️ Working... ({el})")
+    else:
+        lines.append(f"🧠 Thinking... ({el})")
+    return "\n".join(lines)[:DISCORD_MESSAGE_LIMIT]
 
 
 class ThinkingView(discord.ui.View):
@@ -321,12 +358,65 @@ class ChatBot(discord.Client):
 
         await interaction.followup.send(f"Building your artifact in {thread.mention}")
         try:
-            await thread.send(
-                "On it. Building your artifact now; I'll drop the link here when "
-                "it's ready. Reply in this thread to iterate on it."
-            )
+            intro = await thread.send("🛠 On it. Building your artifact now...")
+            self._start_goosecracker_stream(str(thread.id), intro)
         except Exception:
             logger.exception("goosecracker: failed to post thread intro")
+
+    def _start_goosecracker_stream(
+        self, artifact_id: str, message: discord.Message
+    ) -> None:
+        """Spawn the background task that live-edits ``message`` with build output.
+
+        Fire-and-forget: the task ends itself on the run's done marker or a
+        safety timeout. Kept on the instance so it is not garbage-collected
+        mid-run, and logs any unhandled error.
+        """
+        task = asyncio.create_task(
+            self._stream_goosecracker_progress(artifact_id, message)
+        )
+        streams = getattr(self, "_goosecracker_streams", None)
+        if streams is None:
+            streams = set()
+            self._goosecracker_streams = streams
+        streams.add(task)
+        task.add_done_callback(streams.discard)
+
+    async def _stream_goosecracker_progress(
+        self, artifact_id: str, message: discord.Message
+    ) -> None:
+        """Edit ``message`` with goose's live build output until done or timeout.
+
+        Polls the in-process progress buffer (fed by the guest's stdout stream)
+        and re-renders on a fixed cadence, so Discord edits stay within rate
+        limits. The final ``Artifact ready: <url>`` link is posted separately by
+        the controller's Done -> outbox path (ADR 024 Task 5).
+        """
+        gp = goosecracker_progress
+        start = time.monotonic()
+        last_body = message.content
+        while True:
+            await asyncio.sleep(GOOSECRACKER_STREAM_INTERVAL)
+            snap = gp.get(artifact_id)
+            elapsed = int(time.monotonic() - start)
+            body = _render_goosecracker_progress(snap, elapsed)
+            if body != last_body:
+                try:
+                    await message.edit(content=body)
+                    last_body = body
+                except discord.HTTPException:
+                    logger.exception(
+                        "goosecracker: progress edit failed for %s", artifact_id
+                    )
+            if snap is not None and snap.done:
+                gp.clear(artifact_id)
+                return
+            if elapsed >= GOOSECRACKER_STREAM_TIMEOUT:
+                logger.warning(
+                    "goosecracker: progress stream timed out for %s", artifact_id
+                )
+                gp.clear(artifact_id)
+                return
 
     async def _maybe_handle_goosecracker_reply(self, message: discord.Message) -> bool:
         """Handle a reply inside a goosecracker thread (Model B re-run).
@@ -364,9 +454,10 @@ class ChatBot(discord.Client):
             # Lost a race with session teardown; let normal handling take it.
             return False
 
-        await message.reply(
-            "On it. Rebuilding your artifact; the link above will hot-reload."
+        progress_msg = await message.reply(
+            "🛠 On it. Rebuilding your artifact; the link above will hot-reload..."
         )
+        self._start_goosecracker_stream(thread_id, progress_msg)
         await asyncio.to_thread(self._complete_lock, msg_id)
         return True
 

--- a/projects/monolith/chat/goosecracker_progress.py
+++ b/projects/monolith/chat/goosecracker_progress.py
@@ -1,0 +1,68 @@
+"""In-process live-progress buffer for /goosecracker (ADR 024).
+
+While a goosecracker run builds, the guest streams goose's stdout to
+``POST /internal/goosecracker/progress`` and the Discord bot (same monolith
+process) reads the per-thread buffer to edit the thread message live, so the
+owner sees activity within seconds instead of a multi-minute silent wait.
+
+In-memory and single-replica by design: this is transient build output keyed by
+the Discord thread id (== the artifact id). If the pod restarts mid-build the
+run is lost anyway, so the buffer needs no durability. The buffer keeps only the
+tail (Discord shows ~2000 chars), so memory is bounded per thread.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from threading import Lock
+
+# Keep only the tail of the output: Discord renders ~2000 chars and the bot
+# shows a rolling window, so retaining more wastes memory.
+_MAX_BUFFER = 16384
+
+
+@dataclass
+class Progress:
+    """A single run's accumulated stdout tail and completion flag."""
+
+    text: str = ""
+    done: bool = False
+    updated_at: float = field(default_factory=time.monotonic)
+
+
+_store: dict[str, Progress] = {}
+_lock = Lock()
+
+
+def append(artifact_id: str, chunk: str) -> None:
+    """Append a stdout chunk to a run's buffer, keeping only the tail."""
+    if not chunk:
+        return
+    with _lock:
+        p = _store.setdefault(artifact_id, Progress())
+        p.text = (p.text + chunk)[-_MAX_BUFFER:]
+        p.updated_at = time.monotonic()
+
+
+def mark_done(artifact_id: str) -> None:
+    """Mark a run complete so the bot's streamer stops editing and finishes."""
+    with _lock:
+        p = _store.setdefault(artifact_id, Progress())
+        p.done = True
+        p.updated_at = time.monotonic()
+
+
+def get(artifact_id: str) -> Progress | None:
+    """Return a snapshot copy of a run's progress, or None if unknown."""
+    with _lock:
+        p = _store.get(artifact_id)
+        if p is None:
+            return None
+        return Progress(text=p.text, done=p.done, updated_at=p.updated_at)
+
+
+def clear(artifact_id: str) -> None:
+    """Drop a run's buffer once the bot has finished streaming it."""
+    with _lock:
+        _store.pop(artifact_id, None)

--- a/projects/monolith/chat/goosecracker_progress_test.py
+++ b/projects/monolith/chat/goosecracker_progress_test.py
@@ -1,0 +1,71 @@
+"""Tests for the in-process goosecracker live-progress buffer."""
+
+from chat import goosecracker_progress as gp
+
+
+def _fresh(artifact_id: str) -> None:
+    gp.clear(artifact_id)
+
+
+def test_append_accumulates_and_get_returns_snapshot():
+    _fresh("t1")
+    assert gp.get("t1") is None
+    gp.append("t1", "hello ")
+    gp.append("t1", "world")
+    snap = gp.get("t1")
+    assert snap is not None
+    assert snap.text == "hello world"
+    assert snap.done is False
+    _fresh("t1")
+
+
+def test_get_returns_copy_not_live_reference():
+    _fresh("t2")
+    gp.append("t2", "abc")
+    snap = gp.get("t2")
+    gp.append("t2", "def")
+    # The earlier snapshot must not mutate when the buffer grows.
+    assert snap.text == "abc"
+    assert gp.get("t2").text == "abcdef"
+    _fresh("t2")
+
+
+def test_append_keeps_only_the_tail():
+    _fresh("t3")
+    gp.append("t3", "x" * (gp._MAX_BUFFER + 500))
+    snap = gp.get("t3")
+    assert len(snap.text) == gp._MAX_BUFFER
+    _fresh("t3")
+
+
+def test_empty_chunk_is_ignored():
+    _fresh("t4")
+    gp.append("t4", "")
+    assert gp.get("t4") is None
+    _fresh("t4")
+
+
+def test_mark_done_sets_flag():
+    _fresh("t5")
+    gp.append("t5", "building")
+    gp.mark_done("t5")
+    snap = gp.get("t5")
+    assert snap.done is True
+    assert snap.text == "building"
+    _fresh("t5")
+
+
+def test_mark_done_without_prior_append_creates_entry():
+    _fresh("t6")
+    gp.mark_done("t6")
+    snap = gp.get("t6")
+    assert snap is not None
+    assert snap.done is True
+    _fresh("t6")
+
+
+def test_clear_removes_entry():
+    _fresh("t7")
+    gp.append("t7", "data")
+    gp.clear("t7")
+    assert gp.get("t7") is None

--- a/projects/monolith/chat/router.py
+++ b/projects/monolith/chat/router.py
@@ -2,8 +2,9 @@
 
 import asyncio
 import logging
+import re
 
-from fastapi import APIRouter, HTTPException, Request
+from fastapi import APIRouter, HTTPException, Request, Response
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, Field
 
@@ -99,3 +100,35 @@ async def explore(body: ExploreRequest, request: Request):
             yield event
 
     return StreamingResponse(generate(), media_type="text/event-stream")
+
+
+# Internal router (ADR 024): the goosecracker guest streams goose's stdout here
+# as the build runs, and the in-process Discord bot reads the buffer to edit the
+# thread message live. Prefixed /internal so it is kept off the public HTTPRoute
+# (in-cluster only, reached by the guest through the egress funnel), like
+# artifact's /internal/artifact.
+internal_router = APIRouter(prefix="/internal/goosecracker", tags=["goosecracker"])
+
+# Artifact ids are the Discord thread id (numeric), but accept the same charset
+# as the artifact router so the two validations never disagree.
+_ID_RE = re.compile(r"^[A-Za-z0-9_-]{1,64}$")
+
+
+class ProgressIn(BaseModel):
+    id: str = Field(min_length=1, max_length=64)
+    chunk: str = ""
+    done: bool = False
+
+
+@internal_router.post("/progress", status_code=204)
+async def post_progress(body: ProgressIn) -> Response:
+    """Append a guest stdout chunk (and/or a done marker) to a run's buffer."""
+    from chat import goosecracker_progress as gp
+
+    if not _ID_RE.match(body.id):
+        raise HTTPException(400, "invalid id")
+    if body.chunk:
+        gp.append(body.id, body.chunk)
+    if body.done:
+        gp.mark_done(body.id)
+    return Response(status_code=204)

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.228.2
+      targetRevision: 0.228.3
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
## Why

A `/goosecracker` run is silent for minutes (the model's reasoning), so the owner sees nothing until the artifact link appears. This streams goose's stdout into the thread so the build is visible as it happens, killing the dead-wait feeling.

Chosen approach (per discussion): **goose stdout + thinking indicator** — no changes to the generic egress-proxy security component.

## How

- **Guest (`fc-agent-init`):** tee the harness stdout/stderr to a `progressStreamer` that POSTs coarse, ANSI-stripped chunks to `PROGRESS_PUBLISH_URL` (artifact tier only), keyed by `ARTIFACT_ID` (= the Discord thread). Buffered + ticker-flushed (750ms) so the network never blocks or fails the build; a `done` marker is sent after publish.
- **Monolith (`chat`):** an in-process per-thread progress buffer (`chat/goosecracker_progress.py`, single-replica, transient) fed by `POST /internal/goosecracker/progress` (full monolith only, off the public route), read by the bot.
- **Bot:** a background task live-edits the thread message on a rate-limit-safe 1.5s cadence — a rolling tail of the build log plus a status line: 🧠 Thinking when output is quiet (the silent reasoning wait), ⚙️ Working when fresh, ✅ Built on done. The final `Artifact ready: <url>` link still comes from the Done → outbox path (Task 5). Wired into both the initial command and the reply (iterate) path.

Builds on #2910 (the idle fix) — the open progress-POST connections also count as in-flight RPCs, reinforcing "never snapshot mid-build."

## Verification

- `go build ./projects/agent_platform/fc-agent-init/...` clean; `gofumpt` clean.
- `ruff check` clean on all edited Python; progress-store logic unit-tested (`chat/goosecracker_progress_test.py`) and exercised locally.
- `helm template` renders `FC_AGENTD_TIER_artifact__PROGRESS_PUBLISH_URL`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)