### PR TITLE
fix(goosecracker): concise build status instead of raw goose stdout

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.74.0
+version: 0.74.1
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.74.0
+      targetRevision: 0.74.1
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.228.3
+version: 0.228.4
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chat/bot.py
+++ b/projects/monolith/chat/bot.py
@@ -5,6 +5,7 @@ import hashlib
 import json
 import logging
 import os
+import re
 import time
 
 import discord
@@ -51,32 +52,46 @@ def _truncate_thinking(thinking: str) -> str:
 GOOSECRACKER_STREAM_INTERVAL = 1.5  # seconds between Discord edits (rate-limit safe)
 GOOSECRACKER_STREAM_TIMEOUT = 900  # stop streaming after 15 min (run is wedged)
 GOOSECRACKER_THINKING_AFTER = 4.0  # no new output for this long -> show "Thinking"
-GOOSECRACKER_PROGRESS_TAIL = 1700  # chars of build log shown (room for header/footer)
+
+# Pull the human-meaningful beats out of goose's raw stdout (which otherwise
+# echoes the entire file it writes). "Created <path> (N lines)" and the
+# goose-result "summary:" line are the only bits worth showing the owner.
+_GOOSECRACKER_WROTE_RE = re.compile(r"Created\s+\S+\s+\((\d+)\s+lines?\)")
+_GOOSECRACKER_SUMMARY_RE = re.compile(r"^\s*summary:\s*(.+?)\s*`*\s*$", re.MULTILINE)
 
 
 def _render_goosecracker_progress(snap, elapsed: int) -> str:
-    """Render a live build-progress message body from a progress snapshot.
+    """Render a concise live build-progress message from a progress snapshot.
 
     ``snap`` is a chat.goosecracker_progress.Progress or None (nothing yet).
-    Shows a rolling tail of goose's stdout plus a status line: Thinking when the
-    output has been quiet (the model is reasoning, no bytes flow), Working when
-    output is fresh, Built when the run signalled done.
+    Goose's raw stdout includes the whole file it writes, which is noise, so this
+    shows only a phase line (Thinking while the model reasons quietly, Writing
+    while output flows, Built on done) plus the meaningful beats extracted from
+    the stream: lines written and the goose-result summary.
     """
     minutes, seconds = divmod(max(elapsed, 0), 60)
     el = f"{minutes}:{seconds:02d}"
     text = snap.text if snap else ""
+    done = snap is not None and snap.done
+    flowing = bool(text) and (time.monotonic() - snap.updated_at) < (
+        GOOSECRACKER_THINKING_AFTER
+    )
+
     lines = ["🛠 **Building your artifact**"]
-    tail = text[-GOOSECRACKER_PROGRESS_TAIL:].strip()
-    if tail:
-        lines.append(f"```\n{tail}\n```")
-    if snap is not None and snap.done:
-        lines.append(
-            f"✅ Built in {el}. Publishing the link... (reply here to iterate)"
-        )
-    elif text and (time.monotonic() - snap.updated_at) < GOOSECRACKER_THINKING_AFTER:
-        lines.append(f"⚙️ Working... ({el})")
+    if done:
+        lines.append(f"✅ Built in {el} (reply here to iterate)")
+    elif flowing:
+        lines.append(f"⚙️ Writing the artifact... ({el})")
     else:
         lines.append(f"🧠 Thinking... ({el})")
+
+    wrote = _GOOSECRACKER_WROTE_RE.search(text)
+    if wrote:
+        lines.append(f"📝 Wrote {wrote.group(1)} lines")
+    summary = _GOOSECRACKER_SUMMARY_RE.search(text)
+    if summary:
+        lines.append(f"📦 {summary.group(1).strip()}")
+
     return "\n".join(lines)[:DISCORD_MESSAGE_LIMIT]
 
 

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.228.3
+      targetRevision: 0.228.4
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
The live `/goosecracker` progress message streamed goose's **raw stdout**, which echoes the entire HTML file as the write tool-call argument, so the thread filled with the artifact source instead of a short status.

Render a concise view instead (bot-side only; the guest keeps streaming):
- a phase line: 🧠 Thinking (model reasoning, output quiet) / ⚙️ Writing (output flowing) / ✅ Built + elapsed
- 📝 Wrote N lines (parsed from `Created <path> (N lines)`)
- 📦 the goose-result `summary:` line

Verified the two regexes against the real output from a run: extract `1607` lines and the full summary. `ruff` clean, `py_compile` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)