### PR TITLE
fix(goosecracker): suppress site nav on artifact pages

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.74.1
+version: 0.74.2
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.74.1
+      targetRevision: 0.74.2
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.228.4
+version: 0.228.5
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.228.4
+      targetRevision: 0.228.5
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/routes/+layout.svelte
+++ b/projects/monolith/frontend/src/routes/+layout.svelte
@@ -20,9 +20,15 @@
   // Error pages (notably the brutalist 404 in src/routes/+error.svelte) also
   // suppress the nav: a not-found page renders its own "back home" affordance
   // and the cross-tier nav would only clutter the dead-end.
+  //
+  // Artifacts under /artifact/* (ADR 024 goosecracker) are full-bleed sandboxed
+  // pages: the page is a 100vh iframe with body overflow hidden, meant to fill
+  // the viewport. The site nav both looks wrong on a standalone artifact and
+  // pushes the iframe down, so suppress it like the /app/* experiences.
   let hideNav = $derived(
     /^\/(public\/|private\/)?app\//.test($page.url.pathname) ||
       /^\/(public\/|private\/)?docs(\/|$)/.test($page.url.pathname) ||
+      /^\/(public\/|private\/)?artifact(\/|$)/.test($page.url.pathname) ||
       $page.error != null,
   );
 


### PR DESCRIPTION
Artifacts at `jomcgi.dev/artifact/<id>` are full-bleed sandboxed pages (a 100vh iframe with `body { overflow: hidden }`), but they inherited the global site nav, which looks wrong on a standalone artifact and pushed the iframe down.

Add `/artifact/*` to the root layout's existing `hideNav` rule, mirroring the `/app/*` and `/docs` suppression (same `(public/|private/)?` prefix guard for direct hits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)