### PR TITLE
feat(goosecracker): goose OTEL->SigNoz, cut aux LLM round-trips, recipe retry

### DIFF
--- a/projects/agent_platform/fc-agentd/chart/Chart.yaml
+++ b/projects/agent_platform/fc-agentd/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: fc-agentd
 description: Firecracker snapshot/restore controller (ADR 022) - the node-4 Postgres-reconcile daemon that manages agent-thread microVMs
 type: application
-version: 0.15.8
+version: 0.15.9
 appVersion: "latest"
 keywords:
   - firecracker

--- a/projects/agent_platform/fc-agentd/chart/values.yaml
+++ b/projects/agent_platform/fc-agentd/chart/values.yaml
@@ -43,8 +43,9 @@ egress:
   # EGRESS_PORTS). Must list every upstream port a guest dials, since wildcard DNS
   # points all names at loopback and only these ports have a funnel listener:
   # 443 (OpenRouter + open web), 8080 (in-cluster model), 8000 (monolith artifact
-  # publish, ADR 024). 80 kept for plain-HTTP destinations.
-  funnelPorts: "80,443,8080,8000"
+  # publish, ADR 024), 4318 (SigNoz OTLP/HTTP for goose traces). 80 kept for
+  # plain-HTTP destinations.
+  funnelPorts: "80,443,8080,8000,4318"
   # Egress posture. "allow" (default) routes anywhere in or out of cluster, so the
   # agent can read random docs; secrets still only materialise at their egressTo
   # (6b), so the open path cannot leak a credential. Flip to "allowlist" to
@@ -76,6 +77,18 @@ egress:
       # The proven 6b gh flow: a default-tier guest holds the gh placeholder, which
       # the sidecar swaps for the real token only on api.github.com.
       GITHUB_TOKEN: "kloak:gh:01JZX8K3N7Q2M5R9W4T6Y0F1B8"
+      # Auto-approve tool calls: the guest is a sandboxed, turn-capped, credential-
+      # isolated microVM, so the default smart_approve PermissionJudge (an extra LLM
+      # round-trip per mutating call, and a hang risk) buys nothing here.
+      GOOSE_MODE: auto
+      # Skip the LLM call goose makes just to name the session; pointless for
+      # ephemeral runs (and it was an observed extra OpenRouter call on the artifact
+      # tier). Sessions stay on (ADR 026 Phase 2 needs them); only the naming is off.
+      GOOSE_DISABLE_SESSION_NAMING: "true"
+      # Per-turn traces to SigNoz (OTLP/HTTP via the egress funnel) so prefill / tool
+      # / model latency sits next to vLLM metrics. goose defaults to OTLP/HTTP.
+      OTEL_EXPORTER_OTLP_ENDPOINT: http://signoz-k8s-infra-otel-agent.signoz.svc.cluster.local:4318
+      OTEL_SERVICE_NAME: goose-coding
     artifact:
       # goose's NATIVE openrouter provider, not the generic openai-compatible one:
       # reasoning support is provider-specific in goose, and Gemini 3.5 Flash is a
@@ -115,6 +128,15 @@ egress:
       # = the Discord thread). Same in-cluster monolith reached via the egress
       # funnel; artifact tier only, so only artifact runs stream.
       PROGRESS_PUBLISH_URL: http://monolith.monolith.svc.cluster.local:8000/internal/goosecracker/progress
+      # Auto-approve tool calls (sandboxed guest: no PermissionJudge round-trip),
+      # and skip the session-naming LLM call (an observed extra OpenRouter call;
+      # sessions stay on for ADR 026 Phase 2, only the naming is off).
+      GOOSE_MODE: auto
+      GOOSE_DISABLE_SESSION_NAMING: "true"
+      # Per-turn traces to SigNoz (OTLP/HTTP via the egress funnel) so we can see
+      # artifact-build TTFT / thinking / tool latency. goose defaults to OTLP/HTTP.
+      OTEL_EXPORTER_OTLP_ENDPOINT: http://signoz-k8s-infra-otel-agent.signoz.svc.cluster.local:4318
+      OTEL_SERVICE_NAME: goosecracker-artifact
   # 6b CA: cert-manager generates + rotates the self-signed CA the sidecar uses to
   # mint leaf certs when it TLS-terminates a secret-bearing destination. Only
   # created when `secrets` below is non-empty.

--- a/projects/agent_platform/fc-agentd/deploy/application.yaml
+++ b/projects/agent_platform/fc-agentd/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: fc-agentd
-      targetRevision: 0.15.8
+      targetRevision: 0.15.9
       helm:
         valueFiles:
           - $values/projects/agent_platform/fc-agentd/deploy/values.yaml

--- a/projects/agent_platform/harness/recipes/artifact.yaml
+++ b/projects/agent_platform/harness/recipes/artifact.yaml
@@ -49,3 +49,18 @@ extensions:
 settings:
   max_turns: 50
   max_tool_repetitions: 5
+# Belt-and-suspenders: if the run ends without a non-empty /tmp/artifact.html (the
+# occasional model whiff where it chats instead of writing), goose re-runs the turn
+# with failure_prompt injected rather than the harness publishing nothing. The
+# token-budget fix (GOOSE_MAX_TOKENS) already makes the empty-output case rare; this
+# makes a stray miss self-heal instead of producing a dead thread.
+retry:
+  max_retries: 2
+  checks:
+    - type: shell
+      command: "test -s /tmp/artifact.html"
+  failure_prompt: |
+    You have not written /tmp/artifact.html yet (it is missing or empty). Your
+    FIRST action right now must be a tool call that writes the complete,
+    self-contained HTML document to /tmp/artifact.html using the editor or shell.
+    Do not reply with prose, a plan, or the HTML in text. Write the file now.


### PR DESCRIPTION
Three cheap goose wins (chart + recipe only), targeting latency measurement + the live artifact tier. From the research triage we did; the `content:null` blocker is already fixed (GOOSE_MAX_TOKENS), so this is measurement + round-trip cuts + hardening, not a blocker fix.

**1. OTEL -> SigNoz (measurement).** goose emits per-turn traces (prefill / tool / model latency) over OTLP/HTTP. Wired through the egress funnel: new funnel port `4318`, endpoint `signoz-k8s-infra-otel-agent.signoz:4318` (the same agent the monolith uses; confirmed **unmeshed**, so the egress-proxy->agent hop behaves like inference:8080 and needs no `skip-outbound-ports`). Per-tier `OTEL_SERVICE_NAME` (`goosecracker-artifact` / `goose-coding`). This is the measurement substrate for ADR 026.

**2. Cut aux LLM round-trips.** `GOOSE_MODE=auto` (no PermissionJudge round-trip; safe in a sandboxed microVM) and `GOOSE_DISABLE_SESSION_NAMING=true` (kills the session-naming LLM call — the mystery `gemini-2.5-flash` call we saw in the egress capture). Sessions stay **on** (ADR 026 Phase 2 needs them); only naming is off.

**3. Recipe retry (hardening).** `retry` with a `test -s /tmp/artifact.html` shell check + `failure_prompt`, so a stray empty run re-runs the turn instead of the harness publishing nothing.

Verified: `helm template` renders the env on both tiers; recipe YAML parses with the `retry` block; SigNoz agent confirmed unmeshed.

Validation plan post-deploy: a real artifact run should (a) complete promptly with no OTEL exit-flush delay, (b) make only ONE OpenRouter model call (the 2.5-flash naming call gone), (c) show a goose trace in SigNoz. Will confirm on rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)