### PR TITLE
fix(fc-agentd): symlink dmsetup onto PATH for the CoW provisioner

### DIFF
--- a/projects/agent_platform/fc-agentd/BUILD
+++ b/projects/agent_platform/fc-agentd/BUILD
@@ -1,7 +1,16 @@
 # gazelle:ignore
 load("@aspect_bazel_lib//lib:tar.bzl", "tar")
 load("@aspect_bazel_lib//lib:transitions.bzl", "platform_transition_filegroup")
+load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 load("//bazel/tools/oci:apko_image.bzl", "apko_image")
+
+# Wolfi's lvm2 ships only the statically-linked `dmsetup.static` (no plain
+# `dmsetup`), so symlink the conventional name onto PATH; the provisioner execs
+# "dmsetup". Arch-independent (a symlink), so a plain tar layer for both arches.
+pkg_tar(
+    name = "dmsetup_symlink_tar",
+    symlinks = {"/usr/local/bin/dmsetup": "/sbin/dmsetup.static"},
+)
 
 # Firecracker snapshot/restore controller (ADR 022) container image. Built as an
 # apko image (Wolfi base with dmsetup/lvm2 + util-linux) rather than the default
@@ -43,4 +52,5 @@ apko_image(
     contents = "@fc_agentd_lock//:contents",
     multiarch_tars = [":fc_agentd_tar"],
     repository = "ghcr.io/jomcgi/homelab/projects/agent_platform/fc-agentd",
+    tars = [":dmsetup_symlink_tar"],
 )

--- a/projects/agent_platform/fc-agentd/chart/Chart.yaml
+++ b/projects/agent_platform/fc-agentd/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: fc-agentd
 description: Firecracker snapshot/restore controller (ADR 022) - the node-4 Postgres-reconcile daemon that manages agent-thread microVMs
 type: application
-version: 0.16.1
+version: 0.16.2

--- a/projects/agent_platform/fc-agentd/deploy/application.yaml
+++ b/projects/agent_platform/fc-agentd/deploy/application.yaml
@@ -9,4 +9,4 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: fc-agentd
-      targetRevision: 0.16.1
+      targetRevision: 0.16.2


### PR DESCRIPTION
Wolfi's lvm2 ships only `dmsetup.static` (no plain `dmsetup`), so the ADR 026 `DevmapperProvisioner` failed at runtime with `exec: "dmsetup": executable file not found`. Adds a symlink layer `/usr/local/bin/dmsetup -> /sbin/dmsetup.static`.

Verified in-cluster on the merged Phase 1 image: `/sbin/dmsetup.static --version` runs (lib 1.02.215) and `dmsetup.static info devpool` shows the pool ACTIVE from inside the privileged fc-agentd container. This symlink was the only gap between merged Phase 1 and a working CoW provision; event-driven dispatch (NOTIFY) already validated live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)