### PR TITLE
feat(monolith): goosecracker Overview SigNoz dashboard

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.75.0
+version: 0.76.0
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.75.0
+      targetRevision: 0.76.0
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.229.0
+version: 0.229.1
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/dashboards/goosecracker-overview.json
+++ b/projects/monolith/chart/dashboards/goosecracker-overview.json
@@ -1,0 +1,803 @@
+{
+  "title": "goosecracker Overview",
+  "description": "Cold-start phases (fc-agentd launch/provision/boot) and goose model-turn latency for the Discord artifact agent (ADR 024 / 026). Correlate a single run in Traces by thread.id.",
+  "tags": ["goosecracker", "agent", "fc-agentd", "traces", "red"],
+  "variables": {},
+  "version": "v5",
+  "layout": [
+    {
+      "h": 3,
+      "w": 6,
+      "x": 0,
+      "y": 0,
+      "i": "gc-run-rate",
+      "moved": false,
+      "static": false
+    },
+    {
+      "h": 3,
+      "w": 6,
+      "x": 6,
+      "y": 0,
+      "i": "gc-coldstart-phases",
+      "moved": false,
+      "static": false
+    },
+    {
+      "h": 3,
+      "w": 6,
+      "x": 0,
+      "y": 3,
+      "i": "gc-launch-latency",
+      "moved": false,
+      "static": false
+    },
+    {
+      "h": 3,
+      "w": 6,
+      "x": 6,
+      "y": 3,
+      "i": "gc-model-turn",
+      "moved": false,
+      "static": false
+    },
+    {
+      "h": 3,
+      "w": 6,
+      "x": 0,
+      "y": 6,
+      "i": "gc-model-rate",
+      "moved": false,
+      "static": false
+    },
+    {
+      "h": 3,
+      "w": 6,
+      "x": 6,
+      "y": 6,
+      "i": "gc-launch-errors",
+      "moved": false,
+      "static": false
+    }
+  ],
+  "widgets": [
+    {
+      "id": "gc-run-rate",
+      "panelTypes": "graph",
+      "title": "Run Rate (runs/s)",
+      "description": "goosecracker runs started, by tier (fc-agentd agent.thread.launch).",
+      "fillSpans": false,
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "softMax": null,
+      "softMin": null,
+      "selectedLogFields": [],
+      "selectedTracesFields": [],
+      "thresholds": [],
+      "contextLinks": {
+        "linksData": []
+      },
+      "query": {
+        "queryType": "builder",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "builder": {
+          "queryData": [
+            {
+              "queryName": "A",
+              "stepInterval": 60,
+              "dataSource": "traces",
+              "aggregateOperator": "rate",
+              "aggregateAttribute": {},
+              "groupBy": [
+                {
+                  "key": "tier",
+                  "dataType": "string",
+                  "type": "tag",
+                  "isColumn": false,
+                  "isJSON": false
+                }
+              ],
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "key": {
+                      "key": "serviceName",
+                      "dataType": "string",
+                      "type": "tag",
+                      "isColumn": true,
+                      "isJSON": false
+                    },
+                    "op": "=",
+                    "value": "fc-agentd"
+                  },
+                  {
+                    "key": {
+                      "key": "name",
+                      "dataType": "string",
+                      "type": "tag",
+                      "isColumn": true,
+                      "isJSON": false
+                    },
+                    "op": "=",
+                    "value": "agent.thread.launch"
+                  }
+                ],
+                "op": "AND"
+              },
+              "having": {
+                "expression": ""
+              },
+              "legend": "{{tier}}",
+              "limit": null,
+              "orderBy": [],
+              "selectColumns": [],
+              "functions": [],
+              "aggregations": [],
+              "disabled": false,
+              "reduceTo": "avg"
+            }
+          ],
+          "queryFormulas": []
+        }
+      }
+    },
+    {
+      "id": "gc-coldstart-phases",
+      "panelTypes": "graph",
+      "title": "Cold-Start Phase Duration (p95)",
+      "description": "p95 of the launch phases. provision_rootfs is the CoW scoreboard (ADR 026).",
+      "fillSpans": false,
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "softMax": null,
+      "softMin": null,
+      "selectedLogFields": [],
+      "selectedTracesFields": [],
+      "thresholds": [],
+      "contextLinks": {
+        "linksData": []
+      },
+      "query": {
+        "queryType": "builder",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "builder": {
+          "queryData": [
+            {
+              "queryName": "A",
+              "stepInterval": 60,
+              "dataSource": "traces",
+              "aggregateOperator": "p95",
+              "aggregateAttribute": {
+                "key": "durationNano",
+                "dataType": "float64",
+                "type": "tag",
+                "isColumn": true,
+                "isJSON": false
+              },
+              "groupBy": [
+                {
+                  "key": "name",
+                  "dataType": "string",
+                  "type": "tag",
+                  "isColumn": true,
+                  "isJSON": false
+                }
+              ],
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "key": {
+                      "key": "serviceName",
+                      "dataType": "string",
+                      "type": "tag",
+                      "isColumn": true,
+                      "isJSON": false
+                    },
+                    "op": "=",
+                    "value": "fc-agentd"
+                  },
+                  {
+                    "key": {
+                      "key": "name",
+                      "dataType": "string",
+                      "type": "tag",
+                      "isColumn": true,
+                      "isJSON": false
+                    },
+                    "op": "!=",
+                    "value": "reconcileOnce"
+                  }
+                ],
+                "op": "AND"
+              },
+              "having": {
+                "expression": ""
+              },
+              "legend": "{{name}}",
+              "limit": null,
+              "orderBy": [],
+              "selectColumns": [],
+              "functions": [],
+              "aggregations": [],
+              "disabled": false,
+              "reduceTo": "avg"
+            }
+          ],
+          "queryFormulas": []
+        }
+      }
+    },
+    {
+      "id": "gc-launch-latency",
+      "panelTypes": "graph",
+      "title": "Cold Start Duration (p50 / p95)",
+      "description": "agent.thread.launch total: rootfs provision + firecracker boot.",
+      "fillSpans": false,
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "softMax": null,
+      "softMin": null,
+      "selectedLogFields": [],
+      "selectedTracesFields": [],
+      "thresholds": [],
+      "contextLinks": {
+        "linksData": []
+      },
+      "query": {
+        "queryType": "builder",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "builder": {
+          "queryData": [
+            {
+              "queryName": "A",
+              "stepInterval": 60,
+              "dataSource": "traces",
+              "aggregateOperator": "p50",
+              "aggregateAttribute": {
+                "key": "durationNano",
+                "dataType": "float64",
+                "type": "tag",
+                "isColumn": true,
+                "isJSON": false
+              },
+              "groupBy": [],
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "key": {
+                      "key": "serviceName",
+                      "dataType": "string",
+                      "type": "tag",
+                      "isColumn": true,
+                      "isJSON": false
+                    },
+                    "op": "=",
+                    "value": "fc-agentd"
+                  },
+                  {
+                    "key": {
+                      "key": "name",
+                      "dataType": "string",
+                      "type": "tag",
+                      "isColumn": true,
+                      "isJSON": false
+                    },
+                    "op": "=",
+                    "value": "agent.thread.launch"
+                  }
+                ],
+                "op": "AND"
+              },
+              "having": {
+                "expression": ""
+              },
+              "legend": "p50",
+              "limit": null,
+              "orderBy": [],
+              "selectColumns": [],
+              "functions": [],
+              "aggregations": [],
+              "disabled": false,
+              "reduceTo": "avg"
+            },
+            {
+              "queryName": "B",
+              "stepInterval": 60,
+              "dataSource": "traces",
+              "aggregateOperator": "p95",
+              "aggregateAttribute": {
+                "key": "durationNano",
+                "dataType": "float64",
+                "type": "tag",
+                "isColumn": true,
+                "isJSON": false
+              },
+              "groupBy": [],
+              "expression": "B",
+              "filters": {
+                "items": [
+                  {
+                    "key": {
+                      "key": "serviceName",
+                      "dataType": "string",
+                      "type": "tag",
+                      "isColumn": true,
+                      "isJSON": false
+                    },
+                    "op": "=",
+                    "value": "fc-agentd"
+                  },
+                  {
+                    "key": {
+                      "key": "name",
+                      "dataType": "string",
+                      "type": "tag",
+                      "isColumn": true,
+                      "isJSON": false
+                    },
+                    "op": "=",
+                    "value": "agent.thread.launch"
+                  }
+                ],
+                "op": "AND"
+              },
+              "having": {
+                "expression": ""
+              },
+              "legend": "p95",
+              "limit": null,
+              "orderBy": [],
+              "selectColumns": [],
+              "functions": [],
+              "aggregations": [],
+              "disabled": false,
+              "reduceTo": "avg"
+            }
+          ],
+          "queryFormulas": []
+        }
+      }
+    },
+    {
+      "id": "gc-model-turn",
+      "panelTypes": "graph",
+      "title": "Model Turn Duration (p50 / p95 / p99)",
+      "description": "goose reply_stream on the artifact tier: the dominant build latency.",
+      "fillSpans": false,
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "softMax": null,
+      "softMin": null,
+      "selectedLogFields": [],
+      "selectedTracesFields": [],
+      "thresholds": [],
+      "contextLinks": {
+        "linksData": []
+      },
+      "query": {
+        "queryType": "builder",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "builder": {
+          "queryData": [
+            {
+              "queryName": "A",
+              "stepInterval": 60,
+              "dataSource": "traces",
+              "aggregateOperator": "p50",
+              "aggregateAttribute": {
+                "key": "durationNano",
+                "dataType": "float64",
+                "type": "tag",
+                "isColumn": true,
+                "isJSON": false
+              },
+              "groupBy": [],
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "key": {
+                      "key": "serviceName",
+                      "dataType": "string",
+                      "type": "tag",
+                      "isColumn": true,
+                      "isJSON": false
+                    },
+                    "op": "=",
+                    "value": "goosecracker-artifact"
+                  },
+                  {
+                    "key": {
+                      "key": "name",
+                      "dataType": "string",
+                      "type": "tag",
+                      "isColumn": true,
+                      "isJSON": false
+                    },
+                    "op": "=",
+                    "value": "reply_stream"
+                  }
+                ],
+                "op": "AND"
+              },
+              "having": {
+                "expression": ""
+              },
+              "legend": "p50",
+              "limit": null,
+              "orderBy": [],
+              "selectColumns": [],
+              "functions": [],
+              "aggregations": [],
+              "disabled": false,
+              "reduceTo": "avg"
+            },
+            {
+              "queryName": "B",
+              "stepInterval": 60,
+              "dataSource": "traces",
+              "aggregateOperator": "p95",
+              "aggregateAttribute": {
+                "key": "durationNano",
+                "dataType": "float64",
+                "type": "tag",
+                "isColumn": true,
+                "isJSON": false
+              },
+              "groupBy": [],
+              "expression": "B",
+              "filters": {
+                "items": [
+                  {
+                    "key": {
+                      "key": "serviceName",
+                      "dataType": "string",
+                      "type": "tag",
+                      "isColumn": true,
+                      "isJSON": false
+                    },
+                    "op": "=",
+                    "value": "goosecracker-artifact"
+                  },
+                  {
+                    "key": {
+                      "key": "name",
+                      "dataType": "string",
+                      "type": "tag",
+                      "isColumn": true,
+                      "isJSON": false
+                    },
+                    "op": "=",
+                    "value": "reply_stream"
+                  }
+                ],
+                "op": "AND"
+              },
+              "having": {
+                "expression": ""
+              },
+              "legend": "p95",
+              "limit": null,
+              "orderBy": [],
+              "selectColumns": [],
+              "functions": [],
+              "aggregations": [],
+              "disabled": false,
+              "reduceTo": "avg"
+            },
+            {
+              "queryName": "C",
+              "stepInterval": 60,
+              "dataSource": "traces",
+              "aggregateOperator": "p99",
+              "aggregateAttribute": {
+                "key": "durationNano",
+                "dataType": "float64",
+                "type": "tag",
+                "isColumn": true,
+                "isJSON": false
+              },
+              "groupBy": [],
+              "expression": "C",
+              "filters": {
+                "items": [
+                  {
+                    "key": {
+                      "key": "serviceName",
+                      "dataType": "string",
+                      "type": "tag",
+                      "isColumn": true,
+                      "isJSON": false
+                    },
+                    "op": "=",
+                    "value": "goosecracker-artifact"
+                  },
+                  {
+                    "key": {
+                      "key": "name",
+                      "dataType": "string",
+                      "type": "tag",
+                      "isColumn": true,
+                      "isJSON": false
+                    },
+                    "op": "=",
+                    "value": "reply_stream"
+                  }
+                ],
+                "op": "AND"
+              },
+              "having": {
+                "expression": ""
+              },
+              "legend": "p99",
+              "limit": null,
+              "orderBy": [],
+              "selectColumns": [],
+              "functions": [],
+              "aggregations": [],
+              "disabled": false,
+              "reduceTo": "avg"
+            }
+          ],
+          "queryFormulas": []
+        }
+      }
+    },
+    {
+      "id": "gc-model-rate",
+      "panelTypes": "graph",
+      "title": "Model Turn Rate (turns/s)",
+      "description": "goose model turns per second (build throughput).",
+      "fillSpans": false,
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "softMax": null,
+      "softMin": null,
+      "selectedLogFields": [],
+      "selectedTracesFields": [],
+      "thresholds": [],
+      "contextLinks": {
+        "linksData": []
+      },
+      "query": {
+        "queryType": "builder",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "builder": {
+          "queryData": [
+            {
+              "queryName": "A",
+              "stepInterval": 60,
+              "dataSource": "traces",
+              "aggregateOperator": "rate",
+              "aggregateAttribute": {},
+              "groupBy": [],
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "key": {
+                      "key": "serviceName",
+                      "dataType": "string",
+                      "type": "tag",
+                      "isColumn": true,
+                      "isJSON": false
+                    },
+                    "op": "=",
+                    "value": "goosecracker-artifact"
+                  },
+                  {
+                    "key": {
+                      "key": "name",
+                      "dataType": "string",
+                      "type": "tag",
+                      "isColumn": true,
+                      "isJSON": false
+                    },
+                    "op": "=",
+                    "value": "reply_stream"
+                  }
+                ],
+                "op": "AND"
+              },
+              "having": {
+                "expression": ""
+              },
+              "legend": "reply_stream",
+              "limit": null,
+              "orderBy": [],
+              "selectColumns": [],
+              "functions": [],
+              "aggregations": [],
+              "disabled": false,
+              "reduceTo": "avg"
+            }
+          ],
+          "queryFormulas": []
+        }
+      }
+    },
+    {
+      "id": "gc-launch-errors",
+      "panelTypes": "graph",
+      "title": "Launch Errors",
+      "description": "Failed cold-starts (agent.thread.launch spans with an error).",
+      "fillSpans": false,
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "softMax": null,
+      "softMin": null,
+      "selectedLogFields": [],
+      "selectedTracesFields": [],
+      "thresholds": [],
+      "contextLinks": {
+        "linksData": []
+      },
+      "query": {
+        "queryType": "builder",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "builder": {
+          "queryData": [
+            {
+              "queryName": "A",
+              "stepInterval": 60,
+              "dataSource": "traces",
+              "aggregateOperator": "count",
+              "aggregateAttribute": {},
+              "groupBy": [],
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "key": {
+                      "key": "serviceName",
+                      "dataType": "string",
+                      "type": "tag",
+                      "isColumn": true,
+                      "isJSON": false
+                    },
+                    "op": "=",
+                    "value": "fc-agentd"
+                  },
+                  {
+                    "key": {
+                      "key": "name",
+                      "dataType": "string",
+                      "type": "tag",
+                      "isColumn": true,
+                      "isJSON": false
+                    },
+                    "op": "=",
+                    "value": "agent.thread.launch"
+                  },
+                  {
+                    "key": {
+                      "key": "hasError",
+                      "dataType": "string",
+                      "type": "tag",
+                      "isColumn": true,
+                      "isJSON": false
+                    },
+                    "op": "=",
+                    "value": "true"
+                  }
+                ],
+                "op": "AND"
+              },
+              "having": {
+                "expression": ""
+              },
+              "legend": "errors",
+              "limit": null,
+              "orderBy": [],
+              "selectColumns": [],
+              "functions": [],
+              "aggregations": [],
+              "disabled": false,
+              "reduceTo": "avg"
+            }
+          ],
+          "queryFormulas": []
+        }
+      }
+    }
+  ]
+}

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.229.0
+      targetRevision: 0.229.1
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/deploy/values.yaml
+++ b/projects/monolith/deploy/values.yaml
@@ -101,6 +101,10 @@ dashboards:
     enabled: true
     name: "Monolith RED Dashboard"
     tags: "monolith,red,performance,traces"
+  goosecracker-overview:
+    enabled: true
+    name: "goosecracker Overview"
+    tags: "goosecracker,agent,fc-agentd,traces"
 
 chat:
   enabled: true


### PR DESCRIPTION
A GitOps SigNoz dashboard for the Discord artifact agent, built on the spans added in #2915/#2917 (ADR 024/026).

**Panels (6, 2-wide grid):**
| Panel | Source |
|-------|--------|
| Run Rate (runs/s) by tier | `fc-agentd` `agent.thread.launch` rate, grouped by `tier` |
| Cold-Start Phase Duration (p95) | `fc-agentd` durations grouped by span name (`provision_rootfs` = the CoW scoreboard, `firecracker_boot`, `agent.thread.launch`) |
| Cold Start Duration (p50/p95) | `agent.thread.launch` total |
| Model Turn Duration (p50/p95/p99) | `goosecracker-artifact` `reply_stream` (the dominant build latency) |
| Model Turn Rate (turns/s) | `reply_stream` rate (build throughput) |
| Launch Errors | `agent.thread.launch` spans with an error |

**Wiring:** `chart/dashboards/goosecracker-overview.json` + a `dashboards:` values entry → the existing signoz-dashboards configmap helper renders a `signoz.io/dashboard: "true"` ConfigMap → the dashboard-sidecar loads it into SigNoz. Same pattern as `monolith-red` / `cnpg-overview`.

Verified: JSON valid; `helm template` renders the ConfigMap with the discovery label + embedded JSON. To correlate a single run across prep + model turn, filter Traces by `thread.id`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)