### PR TITLE
fix(fc-agentd): restore truncated application.yaml (unblocks rollouts)

### DIFF
--- a/projects/agent_platform/fc-agentd/chart/Chart.yaml
+++ b/projects/agent_platform/fc-agentd/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: fc-agentd
 description: Firecracker snapshot/restore controller (ADR 022) - the node-4 Postgres-reconcile daemon that manages agent-thread microVMs
 type: application
-version: 0.16.2
+version: 0.16.3

--- a/projects/agent_platform/fc-agentd/deploy/application.yaml
+++ b/projects/agent_platform/fc-agentd/deploy/application.yaml
@@ -10,3 +10,27 @@ spec:
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: fc-agentd
       targetRevision: 0.16.2
+      helm:
+        valueFiles:
+          - $values/projects/agent_platform/fc-agentd/deploy/values.yaml
+    # Git repo for environment-specific values.
+    - repoURL: https://github.com/jomcgi/homelab.git
+      targetRevision: HEAD
+      ref: values
+  destination:
+    server: https://kubernetes.default.svc
+    # Deploy into the monolith namespace so the CNPG-generated monolith-pg-app
+    # DSN secret is available without cross-namespace cloning.
+    namespace: monolith
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m

--- a/projects/agent_platform/fc-agentd/deploy/application.yaml
+++ b/projects/agent_platform/fc-agentd/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: fc-agentd
-      targetRevision: 0.16.2
+      targetRevision: 0.16.3
       helm:
         valueFiles:
           - $values/projects/agent_platform/fc-agentd/deploy/values.yaml


### PR DESCRIPTION
Commit 67eadcc28 truncated `deploy/application.yaml` to just the chart source + `targetRevision`, dropping `spec.destination`, the `$values` git source, `helm.valueFiles`, and `syncPolicy`. The `canada` root app then failed to apply the fc-agentd Application (`spec.destination: Required value`), **freezing every fc-agentd rollout at 0.16.0** — so the ADR 026 CoW provisioner and the dmsetup fix never deployed.

Restores the full manifest at the current chart version 0.16.2 (recovered from the live app + git history before truncation). Verified against the live fc-agentd Application spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)