### PR TITLE
fix(fc-agentd): bounded retry for transient microVM launch failures

### DIFF
--- a/projects/agent_platform/fc-agentd/chart/Chart.yaml
+++ b/projects/agent_platform/fc-agentd/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: fc-agentd
 description: Firecracker snapshot/restore controller (ADR 022) - the node-4 Postgres-reconcile daemon that manages agent-thread microVMs
 type: application
-version: 0.16.3
+version: 0.16.4

--- a/projects/agent_platform/fc-agentd/chart/templates/deployment.yaml
+++ b/projects/agent_platform/fc-agentd/chart/templates/deployment.yaml
@@ -113,6 +113,11 @@ spec:
             # maxConcurrent * guestMemMib must fit under resources.limits.memory.
             - name: FC_AGENTD_MAX_CONCURRENT
               value: {{ .Values.agent.maxConcurrent | quote }}
+            # Bounded retry for transient launch failures (e.g. a thread submitted
+            # during this daemon's own rollout). Below the cap the thread stays
+            # PENDING and the next reconcile poll re-attempts; at the cap it FAILs.
+            - name: FC_AGENTD_MAX_CLAIM_ATTEMPTS
+              value: {{ .Values.agent.maxClaimAttempts | quote }}
             - name: FC_AGENTD_GUEST_MEM_MIB
               value: {{ .Values.agent.guestMemMib | quote }}
             - name: FC_AGENTD_GUEST_OOM_SCORE_ADJ

--- a/projects/agent_platform/fc-agentd/chart/values.yaml
+++ b/projects/agent_platform/fc-agentd/chart/values.yaml
@@ -215,6 +215,12 @@ agent:
   maxConcurrent: 8
   guestMemMib: 1024
   guestOomScoreAdj: 1000
+  # How many times a thread's microVM launch may fail before it is marked FAILED.
+  # A launch failure is usually transient (this daemon was just (re)started by a
+  # rollout and KVM/devmapper is not warm yet), so a thread submitted during a
+  # deploy retries, paced by reconcileInterval, instead of being burned terminal
+  # on the first error. 5 * 5s reconcileInterval ~ 25s of weathering.
+  maxClaimAttempts: 5
 
 # The limit must hold maxConcurrent guests plus the daemon: 8 * 1Gi + ~1Gi
 # overhead = 9Gi. Burstable: request a small warm floor (~2 guests), let the

--- a/projects/agent_platform/fc-agentd/cmd/main.go
+++ b/projects/agent_platform/fc-agentd/cmd/main.go
@@ -73,16 +73,17 @@ func run(logger *slog.Logger) error {
 	}, &driver.ExecLauncher{Bin: cfg.FirecrackerBin, OOMScoreAdj: cfg.GuestOOMScoreAdj}, nil)
 
 	loop := &reconcile.Loop{
-		Executor:      fcDriver,
-		Reclaimer:     fcDriver,
-		Node:          cfg.Node,
-		Interval:      cfg.ReconcileInterval,
-		Logger:        logger,
-		ControlUDS:    fcDriver.VsockUDSPath,
-		GooseEnv:      cfg.InjectedEnv,
-		TierEnv:       cfg.TierEnv,
-		EgressSidecar: cfg.EgressSidecar,
-		MaxConcurrent: cfg.MaxConcurrent,
+		Executor:         fcDriver,
+		Reclaimer:        fcDriver,
+		Node:             cfg.Node,
+		Interval:         cfg.ReconcileInterval,
+		Logger:           logger,
+		ControlUDS:       fcDriver.VsockUDSPath,
+		GooseEnv:         cfg.InjectedEnv,
+		TierEnv:          cfg.TierEnv,
+		EgressSidecar:    cfg.EgressSidecar,
+		MaxConcurrent:    cfg.MaxConcurrent,
+		MaxClaimAttempts: cfg.MaxClaimAttempts,
 	}
 
 	if cfg.DatabaseURL != "" {

--- a/projects/agent_platform/fc-agentd/deploy/application.yaml
+++ b/projects/agent_platform/fc-agentd/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: fc-agentd
-      targetRevision: 0.16.3
+      targetRevision: 0.16.4
       helm:
         valueFiles:
           - $values/projects/agent_platform/fc-agentd/deploy/values.yaml

--- a/projects/agent_platform/fc-agentd/internal/config/config.go
+++ b/projects/agent_platform/fc-agentd/internal/config/config.go
@@ -61,6 +61,14 @@ type Config struct {
 	// disables the cap (unbounded; tests/dry-run).
 	MaxConcurrent int
 
+	// MaxClaimAttempts bounds how many failed launch attempts a PENDING thread
+	// gets before the reconcile loop marks it FAILED. A launch failure is usually
+	// transient (the daemon was just (re)started during a rollout and KVM/devmapper
+	// is not warm yet), so retrying a few times, paced by the reconcile poll, lets a
+	// thread submitted during a deploy survive instead of being burned terminal on
+	// the first error.
+	MaxClaimAttempts int
+
 	// GuestOOMScoreAdj is written to each Firecracker child's
 	// /proc/<pid>/oom_score_adj so the guest, never the daemon, is the kernel's
 	// first OOM victim under cgroup or node memory pressure (ADR platform/010's
@@ -117,6 +125,7 @@ func Load() (Config, error) {
 		GuestVCPUs:        atoiDefault("FC_AGENTD_GUEST_VCPUS", 1),
 		GuestMemMib:       atoiDefault("FC_AGENTD_GUEST_MEM_MIB", 1024),
 		MaxConcurrent:     atoiDefault("FC_AGENTD_MAX_CONCURRENT", 8),
+		MaxClaimAttempts:  atoiDefault("FC_AGENTD_MAX_CLAIM_ATTEMPTS", 5),
 		GuestOOMScoreAdj:  atoiDefault("FC_AGENTD_GUEST_OOM_SCORE_ADJ", 1000),
 		EgressSidecar:     os.Getenv("FC_AGENTD_EGRESS_SIDECAR"),
 		InjectedEnv:       injectedEnv(),

--- a/projects/agent_platform/fc-agentd/internal/reconcile/reconcile.go
+++ b/projects/agent_platform/fc-agentd/internal/reconcile/reconcile.go
@@ -30,6 +30,8 @@ type Registry interface {
 	ListWakeRequestedForNode(ctx context.Context, node string) ([]store.Thread, error)
 	ListIdleExpiredForNode(ctx context.Context, node string) ([]store.Thread, error)
 	SetState(ctx context.Context, threadID string, state substrate.State) error
+	RecordClaimFailure(ctx context.Context, threadID string, maxAttempts int) (bool, error)
+	MarkRunningAfterClaim(ctx context.Context, threadID string) error
 	SetThreadSnapshot(ctx context.Context, threadID, ref string, sizeBytes int64) error
 	ClearWake(ctx context.Context, threadID string) error
 	Delete(ctx context.Context, threadID string) error
@@ -65,6 +67,16 @@ type Loop struct {
 	// daemon's cgroup, so a burst of submissions can never OOM the controller. 0
 	// disables the cap.
 	MaxConcurrent int
+
+	// MaxClaimAttempts bounds how many times a PENDING thread's launch may fail
+	// before the loop marks it FAILED. A launch failure is usually transient (the
+	// daemon was just (re)started during a rollout and its KVM/devmapper substrate
+	// is not warm yet), so failing on the first error burned threads submitted in
+	// that window. Below the cap the thread stays PENDING and the next poll
+	// re-attempts (the poll is the backoff); at the cap it goes FAILED. A value <= 1
+	// fails on the first attempt (the pre-retry behaviour); 0 (unset) is treated the
+	// same by the store's >= comparison.
+	MaxClaimAttempts int
 
 	// ControlUDS resolves a thread's vsock control UDS path so the loop can serve
 	// the per-thread control channel (task delivery + idle/done). nil disables
@@ -239,13 +251,25 @@ func (l *Loop) createPending(ctx context.Context, log *slog.Logger) {
 			span.RecordError(err)
 			span.SetStatus(codes.Error, "claim failed")
 			span.End()
-			log.Error("reconcile: claim pending thread", "thread", t.ThreadID, "err", err)
-			_ = l.Registry.SetState(ctx, t.ThreadID, substrate.StateFailed)
+			// A launch failure is usually transient (daemon just (re)started during a
+			// rollout, substrate not warm). Bound the retries: stay PENDING below the
+			// cap so the next poll re-attempts, mark FAILED only once exhausted.
+			failed, rerr := l.Registry.RecordClaimFailure(ctx, t.ThreadID, l.MaxClaimAttempts)
+			switch {
+			case rerr != nil:
+				log.Error("reconcile: record claim failure", "thread", t.ThreadID, "err", rerr)
+			case failed:
+				log.Error("reconcile: claim pending thread exhausted retries; marking FAILED",
+					"thread", t.ThreadID, "max_attempts", l.MaxClaimAttempts, "err", err)
+			default:
+				log.Warn("reconcile: claim pending thread failed; will retry next poll",
+					"thread", t.ThreadID, "err", err)
+			}
 			continue
 		}
 		span.End()
 		l.live[t.ThreadID] = h
-		if err := l.Registry.SetState(ctx, t.ThreadID, substrate.StateRunning); err != nil {
+		if err := l.Registry.MarkRunningAfterClaim(ctx, t.ThreadID); err != nil {
 			log.Error("reconcile: mark running", "thread", t.ThreadID, "err", err)
 		}
 		l.startControl(ctx, log, t)

--- a/projects/agent_platform/fc-agentd/internal/reconcile/reconcile_test.go
+++ b/projects/agent_platform/fc-agentd/internal/reconcile/reconcile_test.go
@@ -15,11 +15,12 @@ import (
 
 // fakeRegistry is an in-memory store keyed by thread ID.
 type fakeRegistry struct {
-	mu      sync.Mutex
-	threads map[string]*store.Thread
-	removed []string
-	listErr error
-	outbox  []outboxRow
+	mu            sync.Mutex
+	threads       map[string]*store.Thread
+	removed       []string
+	listErr       error
+	outbox        []outboxRow
+	claimAttempts map[string]int
 }
 
 // outboxRow records an EnqueueDiscordOutbox call for assertions.
@@ -34,7 +35,7 @@ func newFakeRegistry(ts ...store.Thread) *fakeRegistry {
 		t := ts[i]
 		m[t.ThreadID] = &t
 	}
-	return &fakeRegistry{threads: m}
+	return &fakeRegistry{threads: m, claimAttempts: map[string]int{}}
 }
 
 func (f *fakeRegistry) ListThreadsForNode(_ context.Context, node string) ([]store.Thread, error) {
@@ -78,6 +79,31 @@ func (f *fakeRegistry) SetState(_ context.Context, id string, st substrate.State
 	defer f.mu.Unlock()
 	if t, ok := f.threads[id]; ok {
 		t.State = st
+		t.LastActiveAt = time.Now()
+	}
+	return nil
+}
+
+func (f *fakeRegistry) RecordClaimFailure(_ context.Context, id string, maxAttempts int) (bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.claimAttempts[id]++
+	if f.claimAttempts[id] < maxAttempts {
+		return false, nil // stays PENDING; mirrors the store leaving state untouched
+	}
+	if t, ok := f.threads[id]; ok {
+		t.State = substrate.StateFailed
+		t.LastActiveAt = time.Now()
+	}
+	return true, nil
+}
+
+func (f *fakeRegistry) MarkRunningAfterClaim(_ context.Context, id string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.claimAttempts[id] = 0
+	if t, ok := f.threads[id]; ok {
+		t.State = substrate.StateRunning
 		t.LastActiveAt = time.Now()
 	}
 	return nil
@@ -129,20 +155,30 @@ func (f *fakeRegistry) state(id string) substrate.State {
 	return "GONE"
 }
 
+func (f *fakeRegistry) attempts(id string) int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.claimAttempts[id]
+}
+
 // fakeExec is an in-memory executor + reclaimer.
 type fakeExec struct {
-	mu        sync.Mutex
-	claims    int
-	restores  int
-	releases  int
-	snapshots int
-	removed   []string
-	failNext  error
+	mu         sync.Mutex
+	claims     int
+	restores   int
+	releases   int
+	snapshots  int
+	removed    []string
+	failNext   error
+	failAlways error
 }
 
 func (e *fakeExec) Claim(_ context.Context, spec substrate.ClaimSpec) (substrate.Handle, error) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
+	if e.failAlways != nil {
+		return substrate.Handle{}, e.failAlways
+	}
 	if e.failNext != nil {
 		err := e.failNext
 		e.failNext = nil
@@ -290,13 +326,71 @@ func TestReconcileSnapshotsOnIdle(t *testing.T) {
 	}
 }
 
+// With MaxClaimAttempts=1 a single launch failure exhausts the budget on the
+// first attempt, so the thread is marked FAILED immediately (the pre-retry
+// behaviour, preserved for genuinely fail-fast configs).
 func TestReconcilePendingClaimFailureMarksFailed(t *testing.T) {
 	reg := newFakeRegistry(store.Thread{ThreadID: "t1", State: substrate.StatePending, Node: "node-4"})
 	ex := &fakeExec{failNext: errors.New("no kvm")}
 	l := newLoop(reg, ex)
+	l.MaxClaimAttempts = 1
 	l.reconcileOnce(context.Background(), testLogger())
 	if reg.state("t1") != substrate.StateFailed {
 		t.Fatalf("state = %q, want FAILED", reg.state("t1"))
+	}
+}
+
+// A transient launch failure (the daemon warming up during a rollout) must not be
+// terminal: below the retry cap the thread stays PENDING, and a later poll once
+// the substrate is ready claims it successfully and resets the attempt counter.
+func TestReconcileClaimRetriesThenSucceeds(t *testing.T) {
+	reg := newFakeRegistry(store.Thread{ThreadID: "t1", State: substrate.StatePending, Node: "node-4"})
+	ex := &fakeExec{failNext: errors.New("kvm not warm yet")} // fails once, then succeeds
+	l := newLoop(reg, ex)
+	l.MaxClaimAttempts = 3
+
+	// First pass: claim fails, thread stays PENDING for a retry (not FAILED).
+	l.reconcileOnce(context.Background(), testLogger())
+	if reg.state("t1") != substrate.StatePending {
+		t.Fatalf("after transient failure state = %q, want PENDING (retry pending)", reg.state("t1"))
+	}
+	if reg.attempts("t1") != 1 {
+		t.Fatalf("attempts = %d, want 1 after one failure", reg.attempts("t1"))
+	}
+
+	// Second pass: substrate is ready, claim succeeds, thread goes RUNNING and the
+	// attempt counter resets so a later re-init starts fresh.
+	l.reconcileOnce(context.Background(), testLogger())
+	if reg.state("t1") != substrate.StateRunning {
+		t.Fatalf("after recovery state = %q, want RUNNING", reg.state("t1"))
+	}
+	if reg.attempts("t1") != 0 {
+		t.Fatalf("attempts = %d, want 0 after successful claim", reg.attempts("t1"))
+	}
+	if ex.claims != 1 {
+		t.Fatalf("claims = %d, want 1 successful claim", ex.claims)
+	}
+}
+
+// A genuinely unrecoverable launch (the substrate never comes back) must still
+// terminate: the thread stays PENDING up to the cap, then is marked FAILED.
+func TestReconcileClaimExhaustsRetriesMarksFailed(t *testing.T) {
+	reg := newFakeRegistry(store.Thread{ThreadID: "t1", State: substrate.StatePending, Node: "node-4"})
+	ex := &fakeExec{failAlways: errors.New("no kvm")}
+	l := newLoop(reg, ex)
+	l.MaxClaimAttempts = 3
+
+	// Passes below the cap leave the thread PENDING.
+	for i := 1; i < 3; i++ {
+		l.reconcileOnce(context.Background(), testLogger())
+		if reg.state("t1") != substrate.StatePending {
+			t.Fatalf("attempt %d: state = %q, want PENDING (still retrying)", i, reg.state("t1"))
+		}
+	}
+	// The pass that reaches the cap fails the thread terminally.
+	l.reconcileOnce(context.Background(), testLogger())
+	if reg.state("t1") != substrate.StateFailed {
+		t.Fatalf("after exhausting retries state = %q, want FAILED", reg.state("t1"))
 	}
 }
 

--- a/projects/agent_platform/fc-agentd/internal/store/store.go
+++ b/projects/agent_platform/fc-agentd/internal/store/store.go
@@ -152,6 +152,53 @@ func (s *Store) SetState(ctx context.Context, threadID string, state substrate.S
 	return nil
 }
 
+// RecordClaimFailure accounts for one failed microVM launch on a PENDING thread
+// and decides whether the thread has exhausted its retry budget. It increments
+// claim_attempts; once that reaches maxAttempts it marks the thread FAILED
+// (terminal) and returns true. Below the cap it leaves the thread PENDING and
+// returns false.
+//
+// Crucially, the below-cap path updates ONLY claim_attempts and never the state
+// column, so it does not trip the agent_threads_pending_notify trigger (UPDATE OF
+// state). That keeps the retry from waking the loop off its own write: the thread
+// stays PENDING and the next reconcile poll re-attempts, so the poll interval is
+// the backoff. A maxAttempts <= 1 reproduces the old fail-on-first behaviour
+// (attempt 1 reaches the cap immediately).
+func (s *Store) RecordClaimFailure(ctx context.Context, threadID string, maxAttempts int) (bool, error) {
+	var attempts int
+	err := s.pool.QueryRow(ctx,
+		`UPDATE claude_agent.agent_threads
+		    SET claim_attempts = claim_attempts + 1
+		  WHERE thread_id = $1
+		  RETURNING claim_attempts`, threadID).Scan(&attempts)
+	if err != nil {
+		return false, fmt.Errorf("store: record claim failure: %w", err)
+	}
+	if attempts < maxAttempts {
+		return false, nil
+	}
+	if err := s.SetState(ctx, threadID, substrate.StateFailed); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// MarkRunningAfterClaim moves a freshly-launched thread to RUNNING and resets its
+// claim_attempts. The reset matters because a RUNNING thread can later be pushed
+// back to PENDING (an orphaned snapshotless RUNNING re-inits after a daemon
+// restart); without it, retry budget consumed before the successful claim would
+// carry over and could fail the re-init prematurely.
+func (s *Store) MarkRunningAfterClaim(ctx context.Context, threadID string) error {
+	_, err := s.pool.Exec(ctx,
+		`UPDATE claude_agent.agent_threads
+		    SET state = 'RUNNING', claim_attempts = 0, last_active_at = now()
+		  WHERE thread_id = $1`, threadID)
+	if err != nil {
+		return fmt.Errorf("store: mark running after claim: %w", err)
+	}
+	return nil
+}
+
 // SetThreadSnapshot records a thread's idle snapshot ref + size and moves it to
 // IDLE, clearing any pending wake.
 func (s *Store) SetThreadSnapshot(ctx context.Context, threadID, ref string, sizeBytes int64) error {

--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.76.1
+version: 0.76.2
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.76.1
+      targetRevision: 0.76.2
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.229.2
+version: 0.229.3
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/migrations/20260629140000_agent_threads_claim_attempts.sql
+++ b/projects/monolith/chart/migrations/20260629140000_agent_threads_claim_attempts.sql
@@ -1,0 +1,17 @@
+-- Bounded retry for transient microVM launch failures (fc-agentd, Option B).
+--
+-- Before this, fc-agentd's reconcile loop marked a PENDING thread FAILED on the
+-- FIRST Claim() error, and FAILED is terminal. That is correct for a permanent
+-- failure (bad arch, missing base snapshot) but wrong for a TRANSIENT one: during
+-- an fc-agentd rollout the freshly-started daemon can briefly fail to launch a
+-- guest (KVM / devmapper / firmware not warm yet), so any thread submitted in
+-- that window was burned terminal with no retry. claim_attempts counts launch
+-- failures so the loop can retry a bounded number of times (paced by the reconcile
+-- poll, which is the backoff) before giving up and marking FAILED.
+--
+-- The retry path increments ONLY this column and leaves state = 'PENDING'
+-- untouched, so it does not trip the agent_threads_pending_notify trigger (which
+-- fires on UPDATE OF state) and therefore does not hot-loop off its own write; the
+-- next poll tick re-attempts. A successful claim resets the counter to 0.
+ALTER TABLE claude_agent.agent_threads
+    ADD COLUMN claim_attempts INTEGER NOT NULL DEFAULT 0;

--- a/projects/monolith/chart/migrations/atlas.sum
+++ b/projects/monolith/chart/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:PNjX/ZAvJ1MfwTkDijGWfH0kVDQDyWqqpZoDOuaVKHo=
+h1:w8MiOxixZOIuj9aqPlOOalq4Sj9DX/anSoiPppiDa1g=
 20260330000000_initial_schema.sql h1:J2futpSW0nJAIRR7nR7ssT7LwXIYrvRI+PkHb5Y4tLI=
 20260403000000_chat_schema.sql h1:pERUFC0vzM95etRuzp43XzkCV7lBCzrrtY5Mk7aF3CA=
 20260404000000_chat_attachments.sql h1:tv+Fdbr1rQC5nzUxfaBC0O6fu2OMGgLWf+YNg1WQXi4=
@@ -71,3 +71,4 @@ h1:PNjX/ZAvJ1MfwTkDijGWfH0kVDQDyWqqpZoDOuaVKHo=
 20260627160000_agent_threads_tier.sql h1:byg8x19pnQxW2k7SzNvwiip61vUTSHUlfCh0hjWq64o=
 20260629120000_goosecracker_sessions.sql h1:idaMKKLa9tmNZRIzplWC8oRDIutaI5qJ13YftLTOAV0=
 20260629130000_agent_threads_notify.sql h1:XYqkFTVRwOtMJrxK3aLYAl0tIns5U45lrOC/bTImq3I=
+20260629140000_agent_threads_claim_attempts.sql h1:12hpsYSD0J/ngSHGJDbECm7BfWYAfkzz5/DIx2+CW7U=

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.229.2
+      targetRevision: 0.229.3
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
## Problem

A PENDING agent thread whose microVM launch (`Claim()`) failed was marked **FAILED** on the first error, and FAILED is terminal (nothing re-queues it). That is correct for a *permanent* failure (bad arch, missing base snapshot) but wrong for a *transient* one.

During an fc-agentd rollout the daemon is a single-replica `Recreate` Deployment, so the freshly-started pod can briefly fail to launch a guest (KVM / devmapper / firmware not warm yet). Any thread submitted in that window was burned terminal with no retry.

Real incident (2026-06-29): Discord thread `1521229682580652181` -> agent thread `t-2625de8de871` was created and FAILED in the same ~25ms during the 0.16.3 rollout, with no snapshot and no work persisted.

## Fix (Option B: bounded persisted retry)

- New `claim_attempts` column on `claude_agent.agent_threads` counts launch failures.
- `RecordClaimFailure(threadID, maxAttempts)`: below the cap the thread stays PENDING (next poll re-attempts); at the cap it goes FAILED.
- `MarkRunningAfterClaim`: a successful claim moves the thread to RUNNING and resets the counter, so a later re-init (orphaned snapshotless RUNNING -> PENDING) starts fresh.
- `FC_AGENTD_MAX_CLAIM_ATTEMPTS` (default 5) wired through config -> Loop -> chart values.

### Key subtlety: no hot-loop

The `agent_threads_pending_notify` trigger fires on `AFTER INSERT OR UPDATE OF state`, and Postgres column-scoped triggers fire whenever the column appears in the `SET` list regardless of value. So the retry path updates **only** `claim_attempts` and never touches `state`. That means a failed claim does **not** emit a NOTIFY, does not wake the loop off its own write, and is paced by the 5s reconcile poll. The poll interval *is* the backoff (5 attempts ~ 25s of weathering, which comfortably covers a rollout warm-up).

## Why submission side was already fine

`monolith_agent_submit_agent_task` -> `dispatch.submit()` is a pure Postgres INSERT that returns immediately; it never calls fc-agentd. The substrate is already a queue (fc-agentd drains PENDING rows via a reconcile loop). So the gap was purely on the consumer side, which this PR fixes; no change to the submission path.

## Tests

- `TestReconcileClaimRetriesThenSucceeds`: transient failure stays PENDING, recovers to RUNNING on the next pass, counter resets.
- `TestReconcileClaimExhaustsRetriesMarksFailed`: stays PENDING below the cap, FAILED once exhausted.
- `TestReconcilePendingClaimFailureMarksFailed`: `MaxClaimAttempts=1` preserves fail-fast.
- `go vet ./projects/agent_platform/fc-agentd/...` clean; `atlas migrate hash` regenerated.

## Notes

- Chart versions intentionally left untouched; the chart-version-bot bumps both the fc-agentd chart (Go closure) and the monolith chart (new migration under its dir) on push and keeps `targetRevision` in sync.
- Migration is additive (`ADD COLUMN ... NOT NULL DEFAULT 0`), no table rewrite on PG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)