### PR TITLE
feat(goosecracker): stateful artifact iteration via goose session resume (ADR 026 Phase 2)

### DIFF
--- a/projects/agent_platform/fc-agent-init/cmd/main.go
+++ b/projects/agent_platform/fc-agent-init/cmd/main.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
+	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
@@ -96,7 +97,7 @@ func run(logger *slog.Logger) error {
 	// Determine the work. A raw FC boot gives PID 1 no env, so the task arrives
 	// over vsock (Hello -> Assign). Fall back to env/argv when there is no
 	// controller (tests, a warm-base probe with no task yet).
-	harnessArgv := assignedHarness(logger, conn, threadID)
+	recipe, task, harnessArgv := assignedHarness(logger, conn, threadID)
 	if harnessArgv == nil {
 		harnessArgv = harnessCommand()
 	}
@@ -111,6 +112,25 @@ func run(logger *slog.Logger) error {
 	if conn != nil {
 		installGuestCA(logger)
 		setupTransparentEgress(ctx, logger, os.Getenv("EGRESS_PORTS"), det)
+	}
+
+	// Stateful artifact iteration (ADR 026 Phase 2). The egress funnel is now up,
+	// so the guest can reach the monolith. When the controller marks this run a
+	// resume (GOOSE_RESUME=1 for a Discord-thread reply), fetch the thread's prior
+	// goose session + artifact and re-run goose with --resume so it edits the
+	// existing file off the full conversation instead of rebuilding from scratch.
+	// If the session is missing/unfetchable, fall back to the cold recipe command
+	// assignedHarness already built (Model B safety net).
+	if conn != nil && os.Getenv("GOOSE_RESUME") == "1" {
+		if sessionName := os.Getenv("ARTIFACT_ID"); sessionName != "" {
+			if restoreSession(logger) {
+				restoreArtifact(logger)
+				harnessArgv = harness.GooseCommand(harness.Config{SessionName: sessionName, Resume: true, Task: task})
+				logger.Info("resuming goose session", "session", sessionName)
+			} else {
+				logger.Warn("resume requested but no stored session; cold fallback", "session", sessionName, "recipe", recipe)
+			}
+		}
 	}
 
 	// Live progress stream (ADR 024): tee goose's stdout/stderr to the monolith so
@@ -157,6 +177,10 @@ func run(logger *slog.Logger) error {
 		// guest console which the PID-1-exit kernel panic truncates) and yields the
 		// URL for the Done result. No-op when ARTIFACT_PUBLISH_URL is unset.
 		artifactURL := publishArtifact(logger)
+		// Persist goose's session DB so the next reply on this thread can resume it
+		// (ADR 026 Phase 2). goose has exited, so the SQLite file is checkpointed and
+		// consistent. No-op when the session/ARTIFACT_ID env is unset.
+		publishSession(logger)
 		// Flush any tail output and tell the bot the build is done so it stops the
 		// live edit (the link itself arrives via the Done -> outbox path below).
 		if pw != nil {
@@ -178,27 +202,29 @@ func run(logger *slog.Logger) error {
 }
 
 // assignedHarness performs the control-channel handshake: announce Hello, wait
-// for the controller's Assign, and build the harness command from it. Returns
-// nil if there is no controller or no usable assignment, so the caller falls
-// back to env/argv.
-func assignedHarness(logger *slog.Logger, conn *vsockproto.Conn, threadID string) []string {
+// for the controller's Assign, apply its env, and build the (cold) harness
+// command, also returning the recipe and task so run() can rebuild the command
+// as a session resume once the egress funnel is up (ADR 026 Phase 2 needs the
+// network to fetch the prior session). A nil argv means no controller / no
+// usable assignment, so the caller falls back to env/argv.
+func assignedHarness(logger *slog.Logger, conn *vsockproto.Conn, threadID string) (recipe, task string, argv []string) {
 	if conn == nil {
-		return nil
+		return "", "", nil
 	}
 	if err := conn.Send(vsockproto.Message{Kind: vsockproto.KindHello, ThreadID: threadID}); err != nil {
 		logger.Warn("failed to announce hello", "err", err)
-		return nil
+		return "", "", nil
 	}
 	// Blocking read: the controller replies with Assign immediately after Hello.
 	// This is the only reader until serveControl starts, so there is no race.
 	msg, err := conn.Recv()
 	if err != nil {
 		logger.Warn("failed to receive task assignment", "err", err)
-		return nil
+		return "", "", nil
 	}
 	if msg.Kind != vsockproto.KindAssign {
 		logger.Warn("expected task assignment, got other message", "kind", string(msg.Kind))
-		return nil
+		return "", "", nil
 	}
 	// Apply the controller-injected harness env (goose provider/model + the
 	// in-cluster model base URL): cluster config the guest cannot hardcode.
@@ -206,7 +232,11 @@ func assignedHarness(logger *slog.Logger, conn *vsockproto.Conn, threadID string
 		_ = os.Setenv(k, v)
 	}
 	logger.Info("task assignment received", "recipe", msg.Recipe, "env_keys", len(msg.Env))
-	return harness.GooseCommand(harness.Config{Recipe: msg.Recipe, Task: msg.Task})
+	// Name the session for the Discord thread (= ARTIFACT_ID) on the cold build so
+	// a later reply can --resume it (ADR 026 Phase 2). Resume itself is wired in
+	// run() after the funnel is up.
+	argv = harness.GooseCommand(harness.Config{Recipe: msg.Recipe, Task: msg.Task, SessionName: os.Getenv("ARTIFACT_ID")})
+	return msg.Recipe, msg.Task, argv
 }
 
 // serveControl handles host->guest messages: on a wake, reconnect then ack.
@@ -549,6 +579,135 @@ func publishArtifact(logger *slog.Logger) string {
 	_ = json.Unmarshal(respBody, &out)
 	logger.Info("artifact: published", "url", out.URL, "version", out.Version, "html_bytes", len(html))
 	return out.URL
+}
+
+// sessionDBPath is goose's SQLite session store (ADR 026 Phase 2). goose names it
+// under HOME, which fc-agent-init anchors at /home/goose-agent (the harness image
+// user). Persisting + restoring this single file is what makes a thread's
+// conversation portable across fresh microVMs (validated in the 2.1 spike).
+func sessionDBPath() string {
+	home := os.Getenv("HOME")
+	if home == "" {
+		home = "/home/goose-agent"
+	}
+	return filepath.Join(home, ".local", "share", "goose", "sessions", "sessions.db")
+}
+
+// artifactBaseURL is the per-thread artifact path on the monolith, derived from
+// the publish URL (.../internal/artifact) plus ARTIFACT_ID, so the guest needs no
+// extra env to reach the session (/session) and prior page (/raw) endpoints.
+// Returns "" when either is unset.
+func artifactBaseURL() string {
+	base := strings.TrimRight(os.Getenv("ARTIFACT_PUBLISH_URL"), "/")
+	id := os.Getenv("ARTIFACT_ID")
+	if base == "" || id == "" {
+		return ""
+	}
+	return base + "/" + id
+}
+
+// restoreSession fetches the thread's persisted goose session DB from the monolith
+// and writes it into goose's sessions dir, so the upcoming `goose run --resume`
+// replays the full prior conversation (ADR 026 Phase 2). Returns false when there
+// is no stored session (first reply after a session TTL eviction, or a cold
+// thread), so the caller falls back to a cold build.
+func restoreSession(logger *slog.Logger) bool {
+	base := artifactBaseURL()
+	if base == "" {
+		return false
+	}
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Get(base + "/session")
+	if err != nil {
+		logger.Warn("session: fetch failed; cold fallback", "err", err)
+		return false
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotFound {
+		logger.Info("session: none stored for thread; cold fallback")
+		return false
+	}
+	if resp.StatusCode != http.StatusOK {
+		logger.Warn("session: fetch non-OK; cold fallback", "status", resp.StatusCode)
+		return false
+	}
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		logger.Warn("session: read body failed; cold fallback", "err", err)
+		return false
+	}
+	dst := sessionDBPath()
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		logger.Warn("session: mkdir failed; cold fallback", "err", err)
+		return false
+	}
+	if err := os.WriteFile(dst, data, 0o644); err != nil {
+		logger.Warn("session: write failed; cold fallback", "err", err)
+		return false
+	}
+	logger.Info("session: restored", "path", dst, "bytes", len(data))
+	return true
+}
+
+// restoreArtifact fetches the thread's prior published HTML into /tmp/artifact.html
+// so the resumed goose run edits the existing page in place rather than starting
+// from a blank file. Best-effort: a missing prior artifact is not fatal (goose can
+// rewrite it from the conversation), so failures are logged, not propagated.
+func restoreArtifact(logger *slog.Logger) {
+	base := artifactBaseURL()
+	if base == "" {
+		return
+	}
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Get(base + "/raw")
+	if err != nil {
+		logger.Warn("session: prior artifact fetch failed", "err", err)
+		return
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		logger.Info("session: no prior artifact to restore", "status", resp.StatusCode)
+		return
+	}
+	html, err := io.ReadAll(io.LimitReader(resp.Body, 4*1024*1024))
+	if err != nil {
+		logger.Warn("session: prior artifact read failed", "err", err)
+		return
+	}
+	if err := os.WriteFile(artifactFile, html, 0o644); err != nil {
+		logger.Warn("session: prior artifact write failed", "err", err)
+		return
+	}
+	logger.Info("session: prior artifact restored", "path", artifactFile, "bytes", len(html))
+}
+
+// publishSession ships goose's session DB to the monolith after the run so the
+// next reply on this thread can resume it (ADR 026 Phase 2). goose has exited by
+// now, so the SQLite file is checkpointed and consistent. No-op when the artifact
+// env is unset (non-artifact tier) or goose wrote no session.
+func publishSession(logger *slog.Logger) {
+	base := artifactBaseURL()
+	if base == "" {
+		return
+	}
+	data, err := os.ReadFile(sessionDBPath())
+	if err != nil {
+		logger.Info("session: nothing to publish", "path", sessionDBPath(), "err", err)
+		return
+	}
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Post(base+"/session", "application/octet-stream", bytes.NewReader(data))
+	if err != nil {
+		logger.Error("session: publish request failed", "err", err)
+		return
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	if resp.StatusCode != http.StatusOK {
+		logger.Error("session: publish non-OK", "status", resp.StatusCode, "body", string(body))
+		return
+	}
+	logger.Info("session: published", "bytes", len(data))
 }
 
 // ansiRE matches the ANSI escape sequences goose writes for colour/formatting, so

--- a/projects/agent_platform/fc-agent-init/cmd/main.go
+++ b/projects/agent_platform/fc-agent-init/cmd/main.go
@@ -128,7 +128,16 @@ func run(logger *slog.Logger) error {
 				harnessArgv = harness.GooseCommand(harness.Config{SessionName: sessionName, Resume: true, Task: task})
 				logger.Info("resuming goose session", "session", sessionName)
 			} else {
-				logger.Warn("resume requested but no stored session; cold fallback", "session", sessionName, "recipe", recipe)
+				// The session could not be fetched even though the monolith's gate
+				// said one exists (evicted in the seconds-wide window after that
+				// check, or a transient S3 error). Keep the cold recipe command
+				// assignedHarness built; note that its task is the reply only (not the
+				// full transcript), so this rare path produces a context-light
+				// rebuild rather than a true Model-B rebuild. Accepted: the window is
+				// tiny against a 30-day session TTL and the next reply self-heals
+				// once a session is re-shipped. The full-transcript Model-B path is
+				// the monolith-layer fallback (no session -> submit(transcript)).
+				logger.Warn("resume requested but session unfetchable; reply-only cold fallback", "session", sessionName, "recipe", recipe)
 			}
 		}
 	}

--- a/projects/agent_platform/fc-agent-init/internal/harness/harness.go
+++ b/projects/agent_platform/fc-agent-init/internal/harness/harness.go
@@ -15,11 +15,21 @@ type Config struct {
 	Recipe string
 	// Task is the task description fed to the recipe (FC_TASK).
 	Task string
+	// SessionName names goose's SQLite session (--name). On a cold build it is set
+	// so the session is persisted under a stable name; on a resume it selects which
+	// session to replay (ADR 026 Phase 2). Empty means goose auto-manages.
+	SessionName string
+	// Resume runs the named session with --resume instead of the recipe: goose
+	// replays the full prior conversation (which already contains the recipe's
+	// system prompt from turn 1) and continues with Task as the new instruction
+	// (ADR 026 Phase 2, Model A). Requires SessionName; ignored without it.
+	Resume bool
 }
 
 // GooseCommand returns the argv to run, mirroring the established invocation:
 //
-//	with a recipe:  goose run --recipe <recipe> --no-profile --with-builtin developer --params task_description=<task>
+//	resume:         goose run --name <session> --resume --no-profile --with-builtin developer -t <task>
+//	with a recipe:  goose run --recipe <recipe> [--name <session>] --no-profile --with-builtin developer --params task_description=<task>
 //	bare task only: goose run --text <task>
 //
 // --no-profile keeps the run deterministic (it ignores the baked config.yaml), but
@@ -28,17 +38,35 @@ type Config struct {
 // to the model but not run a shell). --with-builtin developer explicitly loads the
 // shell/editor extension so the agent can actually do work.
 //
+// On resume the recipe is NOT re-passed: turn 1 wrote the recipe's system prompt
+// into the session, and --resume replays the whole conversation, so re-passing it
+// would duplicate the instructions. The task is the latest instruction, given via
+// -t (the recipe's task_description param does not apply without --recipe).
+//
 // It returns nil when there is nothing to run (a warm-base boot with no task),
 // in which case fc-agent-init idles without a harness until a task arrives.
 func GooseCommand(c Config) []string {
-	if c.Recipe != "" {
+	if c.Resume && c.SessionName != "" {
 		return []string{
 			"goose", "run",
-			"--recipe", c.Recipe,
+			"--name", c.SessionName,
+			"--resume",
+			"--no-profile",
+			"--with-builtin", "developer",
+			"-t", c.Task,
+		}
+	}
+	if c.Recipe != "" {
+		argv := []string{"goose", "run", "--recipe", c.Recipe}
+		if c.SessionName != "" {
+			// Name the session on the cold build so a later reply can --resume it.
+			argv = append(argv, "--name", c.SessionName)
+		}
+		return append(argv,
 			"--no-profile",
 			"--with-builtin", "developer",
 			"--params", fmt.Sprintf("task_description=%s", c.Task),
-		}
+		)
 	}
 	if c.Task != "" {
 		return []string{"goose", "run", "--text", c.Task}

--- a/projects/agent_platform/fc-agent-init/internal/harness/harness_test.go
+++ b/projects/agent_platform/fc-agent-init/internal/harness/harness_test.go
@@ -26,6 +26,34 @@ func TestGooseCommandNoTaskIsNil(t *testing.T) {
 	}
 }
 
+func TestGooseCommandColdBuildNamesSession(t *testing.T) {
+	// A cold build with a session name still uses the recipe, but adds --name so
+	// the session is persisted under that name for a later resume (ADR 026 Phase 2).
+	got := GooseCommand(Config{Recipe: "artifact.yaml", Task: "make a ball", SessionName: "thread-1"})
+	want := "goose run --recipe artifact.yaml --name thread-1 --no-profile --with-builtin developer --params task_description=make a ball"
+	if strings.Join(got, " ") != want {
+		t.Fatalf("got %q, want %q", strings.Join(got, " "), want)
+	}
+}
+
+func TestGooseCommandResume(t *testing.T) {
+	// Resume replays the named session (--resume, no --recipe) with the reply as -t.
+	got := GooseCommand(Config{Recipe: "artifact.yaml", Task: "make it bigger", SessionName: "thread-1", Resume: true})
+	want := "goose run --name thread-1 --resume --no-profile --with-builtin developer -t make it bigger"
+	if strings.Join(got, " ") != want {
+		t.Fatalf("got %q, want %q", strings.Join(got, " "), want)
+	}
+}
+
+func TestGooseCommandResumeWithoutSessionFallsBackToRecipe(t *testing.T) {
+	// Resume needs a session name; without one it cannot --resume, so it falls back
+	// to the recipe path (the cold build).
+	got := GooseCommand(Config{Recipe: "artifact.yaml", Task: "x", Resume: true})
+	if len(got) < 3 || got[2] != "--recipe" {
+		t.Fatalf("resume without session should use the recipe, got %v", got)
+	}
+}
+
 func TestTaskWithSpacesStaysSingleArg(t *testing.T) {
 	// The task is one argv element even with spaces; no shell splitting.
 	got := GooseCommand(Config{Recipe: "r.yaml", Task: "a b c"})

--- a/projects/agent_platform/fc-agentd/chart/Chart.yaml
+++ b/projects/agent_platform/fc-agentd/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: fc-agentd
 description: Firecracker snapshot/restore controller (ADR 022) - the node-4 Postgres-reconcile daemon that manages agent-thread microVMs
 type: application
-version: 0.16.4
+version: 0.17.0

--- a/projects/agent_platform/fc-agentd/deploy/application.yaml
+++ b/projects/agent_platform/fc-agentd/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: fc-agentd
-      targetRevision: 0.16.4
+      targetRevision: 0.17.0
       helm:
         valueFiles:
           - $values/projects/agent_platform/fc-agentd/deploy/values.yaml

--- a/projects/agent_platform/fc-agentd/internal/reconcile/reconcile.go
+++ b/projects/agent_platform/fc-agentd/internal/reconcile/reconcile.go
@@ -344,7 +344,7 @@ func (l *Loop) envForThread(log *slog.Logger, t store.Thread) map[string]string 
 	env := l.envForTier(log, t.Tier)
 	// Copy first: envForTier may return the shared GooseEnv map, which must not be
 	// mutated (it is reused across threads).
-	out := make(map[string]string, len(env)+2)
+	out := make(map[string]string, len(env)+3)
 	for k, v := range env {
 		out[k] = v
 	}
@@ -363,6 +363,12 @@ func (l *Loop) envForThread(log *slog.Logger, t store.Thread) map[string]string 
 		out["ARTIFACT_ID"] = t.DiscordThread
 	}
 	out["OTEL_RESOURCE_ATTRIBUTES"] = attrs
+	// Resume mode (ADR 026 Phase 2): the guest restores the thread's persisted
+	// goose session + prior artifact and runs `goose run --resume` instead of a
+	// cold recipe build. Set per-thread (not per-tier) since only a reply resumes.
+	if t.Resume {
+		out["GOOSE_RESUME"] = "1"
+	}
 	return out
 }
 

--- a/projects/agent_platform/fc-agentd/internal/store/store.go
+++ b/projects/agent_platform/fc-agentd/internal/store/store.go
@@ -40,6 +40,11 @@ type Thread struct {
 	// the default/empty tier reaches in-cluster Qwen. The tier also bounds which
 	// secret placeholders the guest holds, so it is the credential trust boundary.
 	Tier string
+	// Resume marks a goosecracker reply that should resume the thread's persisted
+	// goose session (ADR 026 Phase 2, Model A) instead of cold-rebuilding from the
+	// full transcript. The controller injects GOOSE_RESUME=1 into the guest, which
+	// restores the session + prior artifact and runs `goose run --resume`.
+	Resume bool
 	// WakeRequestedAt is non-zero when a caller has asked an IDLE thread to be
 	// restored (the one piece of desired state callers set). Zero means no
 	// pending wake.
@@ -112,6 +117,7 @@ const threadColumns = `thread_id, state, repo, branch, node, arch,
 		COALESCE(size_bytes, 0), COALESCE(discord_thread, ''),
 		created_at, last_active_at, COALESCE(ttl_secs, 0),
 		COALESCE(recipe, ''), COALESCE(task, ''), COALESCE(tier, ''),
+		COALESCE(resume, false),
 		COALESCE(wake_requested_at, 'epoch'::timestamptz)`
 
 func (s *Store) queryThreads(ctx context.Context, where string, args ...any) ([]Thread, error) {
@@ -128,7 +134,7 @@ func (s *Store) queryThreads(ctx context.Context, where string, args ...any) ([]
 			&t.ThreadID, &t.State, &t.Repo, &t.Branch, &t.Node, &t.Arch,
 			&t.BaseSnapshotRef, &t.ThreadSnapshotRef, &t.SizeBytes, &t.DiscordThread,
 			&t.CreatedAt, &t.LastActiveAt, &t.TTLSeconds,
-			&t.Recipe, &t.Task, &t.Tier, &t.WakeRequestedAt,
+			&t.Recipe, &t.Task, &t.Tier, &t.Resume, &t.WakeRequestedAt,
 		); err != nil {
 			return nil, fmt.Errorf("store: scan thread: %w", err)
 		}

--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.76.3
+version: 0.77.0
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.76.3
+      targetRevision: 0.77.0
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -2597,6 +2597,44 @@ py_test(
     ],
 )
 
+# ADR 026 Phase 2: session DB storage + HTTP endpoints (goose resume on Discord
+# thread reply). session_router_test covers the three write_router endpoints and
+# verifies they are absent from read_router (full-monolith-only invariant).
+py_test(
+    name = "artifact_session_router_test",
+    srcs = ["artifact/session_router_test.py"],
+    imports = ["."],
+    deps = [
+        ":monolith_backend",
+        "@pip//fastapi",
+        "@pip//httpx",
+        "@pip//pytest",
+    ],
+)
+
+py_test(
+    name = "artifact_session_s3_test",
+    srcs = ["artifact/session_s3_test.py"],
+    imports = ["."],
+    deps = [
+        ":monolith_backend",
+        "@pip//boto3",
+        "@pip//pytest",
+    ],
+)
+
+# ADR 026 Phase 2 Task 2.5: session eviction batch job handler.
+py_test(
+    name = "artifact_jobs_test",
+    srcs = ["artifact/jobs_test.py"],
+    imports = ["."],
+    deps = [
+        ":monolith_backend",
+        "@pip//boto3",
+        "@pip//pytest",
+    ],
+)
+
 # Hand-registered (chat_public is gazelle-excluded): opt-in read-only transcript
 # snapshots ("share this chat"): server-side mint from the stored transcript,
 # round-trip via the read route, empty-transcript -> 400, missing -> 404.

--- a/projects/monolith/agent/dispatch.py
+++ b/projects/monolith/agent/dispatch.py
@@ -59,6 +59,7 @@ def submit(
     branch: str = "main",
     discord_thread: str = "",
     tier: str = "",
+    resume: bool = False,
     arch: str = DEFAULT_ARCH,
     node: str = DEFAULT_NODE,
     ttl_secs: int = 86400,
@@ -75,6 +76,12 @@ def submit(
     (ADR 024): "artifact" reaches Gemini via OpenRouter (key swapped at egress),
     the default/empty tier reaches in-cluster Qwen. The tier also bounds which
     secret placeholders the guest holds, so it is the credential trust boundary.
+
+    ``resume`` (ADR 026 Phase 2) marks a goosecracker reply that should resume the
+    thread's persisted goose SESSION (restore the prior conversation + artifact and
+    run `goose run --resume`, Model A) instead of cold-rebuilding from the full
+    transcript (Model B). This is distinct from the ``thread_id`` argument above,
+    which wakes an IDLE snapshotted VM (ADR 022); resume runs on a fresh cold VM.
     """
     if thread_id:
         result = threads.request_resume(thread_id)
@@ -89,10 +96,10 @@ def submit(
                 INSERT INTO claude_agent.agent_threads
                     (thread_id, state, repo, branch, node, arch,
                      base_snapshot_ref, discord_thread, ttl_secs,
-                     recipe, task, tier)
+                     recipe, task, tier, resume)
                 VALUES (:id, 'PENDING', :repo, :branch, :node, :arch,
                         :base_ref, :discord_thread, :ttl,
-                        :recipe, :task, :tier)
+                        :recipe, :task, :tier, :resume)
                 """
             ),
             {
@@ -107,6 +114,7 @@ def submit(
                 "recipe": recipe,
                 "task": task,
                 "tier": tier,
+                "resume": resume,
             },
         )
         session.commit()

--- a/projects/monolith/agent/tests/bdd_agent_dispatch_test.py
+++ b/projects/monolith/agent/tests/bdd_agent_dispatch_test.py
@@ -84,3 +84,35 @@ def test_wake_for_unknown_discord_thread(agent_db):
 
 def test_status_missing_thread(agent_db):
     assert dispatch.status("ghost") is None
+
+
+# ---------------------------------------------------------------------------
+# ADR 026 Phase 2: resume flag stored on the thread row
+# ---------------------------------------------------------------------------
+
+
+def test_submit_resume_true_stores_flag(agent_db):
+    """submit(..., resume=True) inserts a thread row with resume=True."""
+    result = dispatch.submit("make it red", repo="homelab", resume=True)
+    tid = result["thread_id"]
+    assert result["action"] == "create"
+
+    row = agent_db.execute(
+        text("SELECT resume FROM claude_agent.agent_threads WHERE thread_id = :id"),
+        {"id": tid},
+    ).fetchone()
+    assert row is not None
+    assert row.resume is True
+
+
+def test_submit_resume_defaults_to_false(agent_db):
+    """submit() without resume= inserts a thread row with resume=False."""
+    result = dispatch.submit("build a clock", repo="homelab")
+    tid = result["thread_id"]
+
+    row = agent_db.execute(
+        text("SELECT resume FROM claude_agent.agent_threads WHERE thread_id = :id"),
+        {"id": tid},
+    ).fetchone()
+    assert row is not None
+    assert row.resume is False

--- a/projects/monolith/app/jobs_main.py
+++ b/projects/monolith/app/jobs_main.py
@@ -298,5 +298,20 @@ def chat_changelog(name: str) -> None:
     logger.info("chat-changelog[%s]: done", name)
 
 
+@app.command("evict-artifact-sessions")
+def evict_artifact_sessions() -> None:
+    """Evict goose session DBs older than the TTL (ADR 026 Phase 2 Task 2.5).
+
+    Sweeps ``s3://artifacts/<id>/sessions.db`` and deletes entries past the TTL so
+    abandoned threads' sessions do not accumulate. Artifacts are left intact.
+    S3-only, so no DB session is opened. Needs the SeaweedFS S3 env."""
+    from artifact.jobs import evict_stale_sessions_handler
+
+    configure_logging()
+    logger.info("evict-artifact-sessions: starting")
+    evict_stale_sessions_handler()
+    logger.info("evict-artifact-sessions: done")
+
+
 if __name__ == "__main__":
     app()

--- a/projects/monolith/artifact/jobs.py
+++ b/projects/monolith/artifact/jobs.py
@@ -1,0 +1,41 @@
+"""artifact batch jobs (ADR 026 Phase 2).
+
+Off-pod jobs for the artifact domain, run as Argo CronWorkflows via
+``app/jobs_main.py`` (the in-process scheduler was retired). Today this is just
+the goose-session TTL sweep (Task 2.5): abandoned threads' persisted session DBs
+are evicted so storage does not grow unbounded.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from sqlmodel import Session
+
+logger = logging.getLogger("monolith.artifact.jobs")
+
+# Evict persisted goose sessions whose threads have been idle this long. Sessions
+# are kilobytes each, so this is generous; an evicted session just makes the next
+# reply cold-rebuild (Model B). Artifacts are never evicted (they are the served
+# output). Override via ARTIFACT_SESSION_TTL_DAYS.
+SESSION_TTL_DAYS = int(os.environ.get("ARTIFACT_SESSION_TTL_DAYS", "30"))
+
+
+def evict_stale_sessions_handler(_session: Session | None = None) -> int:
+    """Delete goose session DBs older than the TTL. Returns the count deleted.
+
+    The ``_session`` arg matches the batch-job handler contract (the CLI opens a
+    DB session for it); this job only touches S3, so it is unused.
+    """
+    from artifact import s3
+
+    deleted = s3.prune_sessions(SESSION_TTL_DAYS)
+    logger.info(
+        "artifact: evicted %d stale goose session(s) (ttl=%dd)",
+        deleted,
+        SESSION_TTL_DAYS,
+    )
+    return deleted

--- a/projects/monolith/artifact/jobs_test.py
+++ b/projects/monolith/artifact/jobs_test.py
@@ -1,0 +1,60 @@
+"""Tests for artifact.jobs (ADR 026 Phase 2 Task 2.5: session eviction handler).
+
+Monkeypatches artifact.s3.prune_sessions so no S3 connection is needed.
+"""
+
+from __future__ import annotations
+
+from artifact import jobs
+from artifact import s3
+
+
+def test_evict_stale_sessions_handler_returns_count_from_prune(monkeypatch):
+    """Handler delegates to prune_sessions and returns the deleted count."""
+    calls = []
+
+    def fake_prune(max_age_days):
+        calls.append(max_age_days)
+        return 3
+
+    monkeypatch.setattr(s3, "prune_sessions", fake_prune)
+
+    result = jobs.evict_stale_sessions_handler()
+
+    assert result == 3
+    assert calls == [jobs.SESSION_TTL_DAYS]
+
+
+def test_evict_stale_sessions_handler_passes_ttl_days(monkeypatch):
+    """The TTL passed to prune_sessions equals SESSION_TTL_DAYS (default 30)."""
+    captured = {}
+
+    def fake_prune(max_age_days):
+        captured["max_age_days"] = max_age_days
+        return 0
+
+    monkeypatch.setattr(s3, "prune_sessions", fake_prune)
+    jobs.evict_stale_sessions_handler()
+
+    assert captured["max_age_days"] == jobs.SESSION_TTL_DAYS
+    assert jobs.SESSION_TTL_DAYS == 30  # default when env var absent
+
+
+def test_evict_stale_sessions_handler_respects_env_override(monkeypatch):
+    """ARTIFACT_SESSION_TTL_DAYS env var sets SESSION_TTL_DAYS at import time;
+    the handler uses whatever the module constant resolves to."""
+    captured = {}
+
+    def fake_prune(max_age_days):
+        captured["max_age_days"] = max_age_days
+        return 7
+
+    monkeypatch.setattr(s3, "prune_sessions", fake_prune)
+    # Directly override the module constant for this test (env override happens
+    # at module import time, so we patch the already-resolved attribute).
+    monkeypatch.setattr(jobs, "SESSION_TTL_DAYS", 7)
+
+    result = jobs.evict_stale_sessions_handler()
+
+    assert result == 7
+    assert captured["max_age_days"] == 7

--- a/projects/monolith/artifact/router.py
+++ b/projects/monolith/artifact/router.py
@@ -25,7 +25,7 @@ import os
 import re
 import secrets
 
-from fastapi import APIRouter, HTTPException, Response
+from fastapi import APIRouter, HTTPException, Request, Response
 from pydantic import BaseModel, Field
 
 # Artifact ids are capability URLs (unguessable id == access), so generated ids
@@ -37,6 +37,10 @@ _ID_RE = re.compile(r"\A[A-Za-z0-9_-]{1,64}\Z")
 # Max stored artifact size. Self-contained HTML pages are small; this bounds a
 # runaway/abusive publish and the S3 object size.
 _MAX_HTML_BYTES = 2 * 1024 * 1024
+
+# Max stored session DB size. goose SQLite DBs are modest; 32 MiB is generous
+# for a single-run session while bounding runaway storage (ADR 026 Phase 2).
+_MAX_SESSION_BYTES = 32 * 1024 * 1024
 
 # The strict CSP on the raw artifact response. `sandbox allow-scripts` gives the
 # document an opaque origin with scripting but no same-origin/forms/popups/
@@ -106,6 +110,67 @@ def _require_valid_id(artifact_id: str) -> str:
     if not _ID_RE.match(artifact_id):
         raise HTTPException(status_code=404, detail="not found")
     return artifact_id
+
+
+# Session storage endpoints (ADR 026 Phase 2). The guest POSTs its SQLite DB
+# after a run and GETs it before resuming so Discord-thread iterations are
+# incremental. All three routes live on write_router (full monolith only); they
+# are never exposed on read_router or the public binary.
+
+
+@write_router.post("/{artifact_id}/session")
+async def put_session(artifact_id: str, request: Request) -> Response:
+    """Store the goose session DB for an artifact id.
+
+    Accepts raw ``application/octet-stream`` bytes. Returns
+    ``{"id": ..., "version": <etag>}``.
+    """
+    from artifact import s3
+
+    _require_valid_id(artifact_id)
+    body = await request.body()
+    if not body:
+        raise HTTPException(status_code=422, detail="empty session db")
+    if len(body) > _MAX_SESSION_BYTES:
+        raise HTTPException(
+            status_code=413,
+            detail=f"session db exceeds {_MAX_SESSION_BYTES} bytes",
+        )
+    version = s3.put_session(artifact_id, body)
+    return Response(
+        content=json.dumps({"id": artifact_id, "version": version}),
+        media_type="application/json",
+    )
+
+
+@write_router.get("/{artifact_id}/session/exists")
+def session_exists(artifact_id: str) -> Response:
+    """Return ``{"exists": bool}`` using a HEAD request, no DB download."""
+    from artifact import s3
+
+    _require_valid_id(artifact_id)
+    etag = s3.head_session(artifact_id)
+    return Response(
+        content=json.dumps({"exists": etag is not None}),
+        media_type="application/json",
+        headers={"Cache-Control": "no-store"},
+    )
+
+
+@write_router.get("/{artifact_id}/session")
+def get_session(artifact_id: str) -> Response:
+    """Return the raw goose session DB bytes, or 404 if no session exists."""
+    from artifact import s3
+
+    _require_valid_id(artifact_id)
+    db = s3.get_session(artifact_id)
+    if db is None:
+        raise HTTPException(status_code=404, detail="not found")
+    return Response(
+        content=db,
+        media_type="application/octet-stream",
+        headers={"Cache-Control": "no-store"},
+    )
 
 
 @read_router.get("/{artifact_id}/raw")

--- a/projects/monolith/artifact/s3.py
+++ b/projects/monolith/artifact/s3.py
@@ -1,4 +1,4 @@
-"""Artifact storage on the SeaweedFS S3 gateway (ADR 024).
+"""Artifact storage on the SeaweedFS S3 gateway (ADR 024 + ADR 026).
 
 goosecracker artifacts are agent-built, self-contained HTML pages published to
 the ``artifacts`` bucket at ``<id>/index.html``. The monolith mediates every
@@ -6,6 +6,12 @@ write (the agent guest holds no S3 credential, ADR 024 decision 3), so this
 module is the single S3 seam: ``put_artifact`` on the write path (full monolith)
 and ``get_artifact`` / ``head_artifact`` on the public read path (the public
 backend, proxied by the SSR frontend).
+
+ADR 026 Phase 2 adds session DB storage at ``<id>/sessions.db`` so goose can
+resume an existing run on a Discord thread reply: ``put_session`` stores the
+SQLite bytes, ``get_session`` retrieves them, and ``head_session`` probes
+existence cheaply.  All three are write-path (full monolith only); the session
+DB is never served publicly.
 
 The client construction mirrors ``trips.s3`` / ``stars.grid._s3_client`` (dummy
 creds, path-style addressing, scheme guard on the endpoint) and the put +
@@ -16,12 +22,18 @@ into the public app's import closure (app/main_public_imports_test.py).
 
 import logging
 import os
+from datetime import datetime, timedelta, timezone
 
 logger = logging.getLogger("monolith.artifact.s3")
 
 # Public-image-safe: a single object key per artifact id. Index naming keeps the
 # door open for multi-file artifacts later without changing the id space.
 _OBJECT_SUFFIX = "index.html"
+
+# Session DB object key per artifact id (ADR 026 Phase 2). Stored alongside the
+# artifact HTML in the same bucket so both objects share the same id namespace
+# and bucket lifecycle.
+_SESSION_OBJECT = "sessions.db"
 
 
 def _bucket() -> str:
@@ -30,6 +42,10 @@ def _bucket() -> str:
 
 def _object_key(artifact_id: str) -> str:
     return f"{artifact_id}/{_OBJECT_SUFFIX}"
+
+
+def _session_key(artifact_id: str) -> str:
+    return f"{artifact_id}/{_SESSION_OBJECT}"
 
 
 def _client():
@@ -125,3 +141,106 @@ def head_artifact(artifact_id: str) -> str | None:
 def _clean_etag(etag: str) -> str:
     """S3 ETags are quoted; strip the quotes for a clean version token."""
     return etag.strip('"')
+
+
+def put_session(artifact_id: str, db: bytes) -> str:
+    """Write the goose session DB to ``s3://<bucket>/<id>/sessions.db``.
+
+    Overwrites any existing session for the id (re-storing after each run keeps
+    the DB current so the next reply resumes from the latest state, ADR 026
+    Phase 2). Returns the stored object's ETag. Creates the bucket once and
+    retries on a missing bucket, mirroring ``put_artifact``.
+    """
+    from botocore.exceptions import ClientError
+
+    client = _client()
+    bucket = _bucket()
+    key = _session_key(artifact_id)
+
+    def _put():
+        return client.put_object(
+            Bucket=bucket,
+            Key=key,
+            Body=db,
+            ContentType="application/octet-stream",
+        )
+
+    try:
+        resp = _put()
+    except ClientError as exc:
+        code = exc.response.get("Error", {}).get("Code", "")
+        if code in ("NoSuchBucket", "404"):
+            client.create_bucket(Bucket=bucket)
+            resp = _put()
+        else:
+            raise
+    return _clean_etag(resp.get("ETag", ""))
+
+
+def get_session(artifact_id: str) -> bytes | None:
+    """Return the raw session DB bytes, or None if no session exists yet."""
+    from botocore.exceptions import ClientError
+
+    client = _client()
+    try:
+        resp = client.get_object(Bucket=_bucket(), Key=_session_key(artifact_id))
+    except ClientError as exc:
+        code = exc.response.get("Error", {}).get("Code", "")
+        if code in ("NoSuchKey", "NoSuchBucket", "404"):
+            return None
+        raise
+    return resp["Body"].read()
+
+
+def head_session(artifact_id: str) -> str | None:
+    """Return the session DB's current ETag, or None if no session exists yet.
+
+    Lets the orchestrator cheaply decide resume vs cold-start without downloading
+    the full DB (ADR 026 Phase 2).
+    """
+    from botocore.exceptions import ClientError
+
+    client = _client()
+    try:
+        resp = client.head_object(Bucket=_bucket(), Key=_session_key(artifact_id))
+    except ClientError as exc:
+        code = exc.response.get("Error", {}).get("Code", "")
+        if code in ("NoSuchKey", "NoSuchBucket", "404"):
+            return None
+        raise
+    return _clean_etag(resp.get("ETag", ""))
+
+
+def prune_sessions(max_age_days: int = 30) -> int:
+    """Delete persisted goose session DBs older than ``max_age_days`` (ADR 026
+    Phase 2 Task 2.5: session TTL / eviction).
+
+    Only session objects (``<id>/sessions.db``) are evicted, never the published
+    artifacts (``<id>/index.html``): the artifact is the served output and must
+    persist, while a session just makes the next reply resumable. Evicting a stale
+    session is therefore safe: the next reply on that thread cleanly falls back to
+    a cold Model-B rebuild (which re-seeds the session). Returns the count deleted.
+    """
+    from botocore.exceptions import ClientError
+
+    client = _client()
+    bucket = _bucket()
+    cutoff = datetime.now(timezone.utc) - timedelta(days=max_age_days)
+    suffix = "/" + _SESSION_OBJECT
+    deleted = 0
+    try:
+        paginator = client.get_paginator("list_objects_v2")
+        for page in paginator.paginate(Bucket=bucket):
+            for obj in page.get("Contents", []):
+                key = obj.get("Key", "")
+                if not key.endswith(suffix):
+                    continue
+                if obj.get("LastModified") and obj["LastModified"] < cutoff:
+                    client.delete_object(Bucket=bucket, Key=key)
+                    deleted += 1
+    except ClientError as exc:
+        code = exc.response.get("Error", {}).get("Code", "")
+        if code in ("NoSuchBucket", "404"):
+            return deleted
+        raise
+    return deleted

--- a/projects/monolith/artifact/session_router_test.py
+++ b/projects/monolith/artifact/session_router_test.py
@@ -1,0 +1,199 @@
+"""Tests for the artifact session HTTP endpoints (ADR 026 Phase 2).
+
+Mirrors artifact/router_test.py: S3 is faked via monkeypatch so the tests
+exercise the real handler logic without a live SeaweedFS endpoint.
+
+All session endpoints live on write_router (full monolith only). The fixture
+mounts only write_router so these tests also confirm the endpoints are reachable
+on write_router. A separate test verifies read_router does NOT expose them.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from artifact import s3
+from artifact.router import read_router, write_router
+
+
+@pytest.fixture
+def client(monkeypatch) -> TestClient:
+    """TestClient with a faked in-memory session store."""
+    store: dict[str, bytes] = {}
+
+    def fake_put(artifact_id: str, db: bytes) -> str:
+        store[artifact_id] = db
+        return f"etag-{len(db)}"
+
+    def fake_get(artifact_id: str) -> bytes | None:
+        return store.get(artifact_id)
+
+    def fake_head(artifact_id: str) -> str | None:
+        if artifact_id not in store:
+            return None
+        return f"etag-{len(store[artifact_id])}"
+
+    monkeypatch.setattr(s3, "put_session", fake_put)
+    monkeypatch.setattr(s3, "get_session", fake_get)
+    monkeypatch.setattr(s3, "head_session", fake_head)
+
+    app = FastAPI()
+    app.include_router(write_router)
+    return TestClient(app)
+
+
+@pytest.fixture
+def read_only_client(monkeypatch) -> TestClient:
+    """TestClient with ONLY read_router mounted (mirrors the public binary)."""
+    app = FastAPI()
+    app.include_router(read_router)
+    return TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# POST /internal/artifact/{id}/session
+# ---------------------------------------------------------------------------
+
+
+def test_put_session_stores_db_and_returns_version(client: TestClient):
+    db = b"SQLite format 3\x00" + b"\x00" * 100
+    resp = client.post(
+        "/internal/artifact/demo/session",
+        content=db,
+        headers={"Content-Type": "application/octet-stream"},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["id"] == "demo"
+    assert body["version"]
+
+
+def test_put_session_returns_updated_version_on_overwrite(client: TestClient):
+    db1 = b"v1" * 10
+    db2 = b"v2" * 20
+    r1 = client.post(
+        "/internal/artifact/demo/session",
+        content=db1,
+        headers={"Content-Type": "application/octet-stream"},
+    )
+    r2 = client.post(
+        "/internal/artifact/demo/session",
+        content=db2,
+        headers={"Content-Type": "application/octet-stream"},
+    )
+    assert r1.status_code == 200
+    assert r2.status_code == 200
+    # etag encodes len in our fake, so they should differ
+    assert r1.json().get("version") != r2.json().get("version")
+
+
+def test_put_session_rejects_empty_body(client: TestClient):
+    resp = client.post(
+        "/internal/artifact/demo/session",
+        content=b"",
+        headers={"Content-Type": "application/octet-stream"},
+    )
+    assert resp.status_code == 422
+
+
+def test_put_session_rejects_oversized_body(client: TestClient):
+    big = b"x" * (32 * 1024 * 1024 + 1)
+    resp = client.post(
+        "/internal/artifact/demo/session",
+        content=big,
+        headers={"Content-Type": "application/octet-stream"},
+    )
+    assert resp.status_code == 413
+
+
+def test_put_session_rejects_invalid_id(client: TestClient):
+    resp = client.post(
+        "/internal/artifact/../etc/session",
+        content=b"x",
+        headers={"Content-Type": "application/octet-stream"},
+    )
+    assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# GET /internal/artifact/{id}/session
+# ---------------------------------------------------------------------------
+
+
+def test_get_session_returns_raw_bytes(client: TestClient):
+    db = b"SQLite format 3\x00raw"
+    client.post(
+        "/internal/artifact/demo/session",
+        content=db,
+        headers={"Content-Type": "application/octet-stream"},
+    )
+    resp = client.get("/internal/artifact/demo/session")
+    assert resp.status_code == 200
+    assert resp.content == db
+    assert resp.headers["content-type"] == "application/octet-stream"
+    assert resp.headers["cache-control"] == "no-store"
+
+
+def test_get_session_missing_is_404(client: TestClient):
+    assert client.get("/internal/artifact/nope/session").status_code == 404
+
+
+def test_get_session_invalid_id_is_404(client: TestClient):
+    assert client.get("/internal/artifact/..%2f..%2fx/session").status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# GET /internal/artifact/{id}/session/exists
+# ---------------------------------------------------------------------------
+
+
+def test_session_exists_false_when_absent(client: TestClient):
+    resp = client.get("/internal/artifact/nope/session/exists")
+    assert resp.status_code == 200
+    assert resp.json() == {"exists": False}
+    assert resp.headers["cache-control"] == "no-store"
+
+
+def test_session_exists_true_after_put(client: TestClient):
+    db = b"SQLite format 3\x00"
+    client.post(
+        "/internal/artifact/demo/session",
+        content=db,
+        headers={"Content-Type": "application/octet-stream"},
+    )
+    resp = client.get("/internal/artifact/demo/session/exists")
+    assert resp.status_code == 200
+    assert resp.json() == {"exists": True}
+
+
+def test_session_exists_invalid_id_is_404(client: TestClient):
+    assert (
+        client.get("/internal/artifact/..%2f..%2fx/session/exists").status_code == 404
+    )
+
+
+# ---------------------------------------------------------------------------
+# Security: session endpoints must NOT be on the public read_router
+# ---------------------------------------------------------------------------
+
+
+def test_session_endpoints_absent_from_read_router(read_only_client: TestClient):
+    """Session routes are write_router-only; the public read_router has none."""
+    # POST
+    resp = read_only_client.post(
+        "/internal/artifact/demo/session",
+        content=b"x",
+        headers={"Content-Type": "application/octet-stream"},
+    )
+    assert resp.status_code == 405, "POST /session must not be present on read_router"
+    # GET
+    assert read_only_client.get("/internal/artifact/demo/session").status_code == 405, (
+        "GET /session must not be present on read_router"
+    )
+    # exists
+    assert (
+        read_only_client.get("/internal/artifact/demo/session/exists").status_code
+        == 405
+    ), "GET /session/exists must not be present on read_router"

--- a/projects/monolith/artifact/session_router_test.py
+++ b/projects/monolith/artifact/session_router_test.py
@@ -180,20 +180,21 @@ def test_session_exists_invalid_id_is_404(client: TestClient):
 
 
 def test_session_endpoints_absent_from_read_router(read_only_client: TestClient):
-    """Session routes are write_router-only; the public read_router has none."""
+    """Session routes are write_router-only; the public read_router has none, so
+    the paths are entirely absent (404), not merely method-not-allowed (405)."""
     # POST
     resp = read_only_client.post(
         "/internal/artifact/demo/session",
         content=b"x",
         headers={"Content-Type": "application/octet-stream"},
     )
-    assert resp.status_code == 405, "POST /session must not be present on read_router"
+    assert resp.status_code == 404, "POST /session must not be present on read_router"
     # GET
-    assert read_only_client.get("/internal/artifact/demo/session").status_code == 405, (
+    assert read_only_client.get("/internal/artifact/demo/session").status_code == 404, (
         "GET /session must not be present on read_router"
     )
     # exists
     assert (
         read_only_client.get("/internal/artifact/demo/session/exists").status_code
-        == 405
+        == 404
     ), "GET /session/exists must not be present on read_router"

--- a/projects/monolith/artifact/session_s3_test.py
+++ b/projects/monolith/artifact/session_s3_test.py
@@ -1,0 +1,170 @@
+"""Tests for artifact session DB S3 storage (ADR 026 Phase 2).
+
+Mirrors artifact/s3_test.py: boto3 is mocked via monkeypatch so the unit tests
+run without a real SeaweedFS endpoint.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock, call
+
+import pytest
+
+from artifact import s3
+
+
+@pytest.fixture(autouse=True)
+def _s3_env(monkeypatch):
+    monkeypatch.setenv("SEAWEEDFS_S3_ENDPOINT", "seaweedfs-s3.seaweedfs.svc:8333")
+    monkeypatch.setenv("ARTIFACTS_S3_BUCKET", "artifacts")
+
+
+def _patch_client(monkeypatch, client: MagicMock):
+    monkeypatch.setattr(s3, "_client", lambda: client)
+    return client
+
+
+def test_put_session_writes_sessions_db_and_returns_clean_etag(monkeypatch):
+    client = MagicMock()
+    client.put_object.return_value = {"ETag": '"abc123"'}
+    _patch_client(monkeypatch, client)
+
+    etag = s3.put_session("demo", b"SQLite format 3")
+
+    assert etag == "abc123"  # quotes stripped
+    args = client.put_object.call_args.kwargs
+    assert args["Bucket"] == "artifacts"
+    assert args["Key"] == "demo/sessions.db"
+    assert args["Body"] == b"SQLite format 3"
+    assert args["ContentType"] == "application/octet-stream"
+
+
+def test_put_session_creates_bucket_then_retries(monkeypatch):
+    from botocore.exceptions import ClientError
+
+    client = MagicMock()
+    err = ClientError({"Error": {"Code": "NoSuchBucket"}}, "PutObject")
+    client.put_object.side_effect = [err, {"ETag": '"e"'}]
+    _patch_client(monkeypatch, client)
+
+    etag = s3.put_session("demo", b"x")
+
+    assert etag == "e"
+    client.create_bucket.assert_called_once_with(Bucket="artifacts")
+    assert client.put_object.call_count == 2
+
+
+def test_get_session_returns_bytes(monkeypatch):
+    client = MagicMock()
+    body = MagicMock()
+    body.read.return_value = b"SQLite format 3\x00"
+    client.get_object.return_value = {"Body": body, "ETag": '"v1"'}
+    _patch_client(monkeypatch, client)
+
+    got = s3.get_session("demo")
+
+    assert got == b"SQLite format 3\x00"
+    assert client.get_object.call_args.kwargs["Key"] == "demo/sessions.db"
+
+
+def test_get_session_absent_returns_none(monkeypatch):
+    from botocore.exceptions import ClientError
+
+    client = MagicMock()
+    client.get_object.side_effect = ClientError(
+        {"Error": {"Code": "NoSuchKey"}}, "GetObject"
+    )
+    _patch_client(monkeypatch, client)
+
+    assert s3.get_session("missing") is None
+
+
+def test_get_session_absent_bucket_returns_none(monkeypatch):
+    from botocore.exceptions import ClientError
+
+    client = MagicMock()
+    client.get_object.side_effect = ClientError(
+        {"Error": {"Code": "NoSuchBucket"}}, "GetObject"
+    )
+    _patch_client(monkeypatch, client)
+
+    assert s3.get_session("missing") is None
+
+
+def test_head_session_returns_etag(monkeypatch):
+    client = MagicMock()
+    client.head_object.return_value = {"ETag": '"v2"'}
+    _patch_client(monkeypatch, client)
+
+    assert s3.head_session("demo") == "v2"
+    assert client.head_object.call_args.kwargs["Key"] == "demo/sessions.db"
+
+
+def test_head_session_absent_returns_none(monkeypatch):
+    from botocore.exceptions import ClientError
+
+    client = MagicMock()
+    client.head_object.side_effect = ClientError(
+        {"Error": {"Code": "404"}}, "HeadObject"
+    )
+    _patch_client(monkeypatch, client)
+
+    assert s3.head_session("gone") is None
+
+
+def test_session_key_uses_session_object_constant(monkeypatch):
+    """_session_key must use _SESSION_OBJECT so a rename stays consistent."""
+    assert s3._session_key("abc") == f"abc/{s3._SESSION_OBJECT}"
+    assert s3._SESSION_OBJECT == "sessions.db"
+
+
+# ---------------------------------------------------------------------------
+# prune_sessions (ADR 026 Phase 2 Task 2.5: session TTL eviction)
+# ---------------------------------------------------------------------------
+
+
+def test_prune_sessions_deletes_old_session_objects_only(monkeypatch):
+    """Only old sessions.db objects are deleted; new ones and non-session keys are left."""
+    from botocore.exceptions import ClientError
+
+    client = MagicMock()
+    now = datetime.now(timezone.utc)
+    old_ts = now - timedelta(days=31)
+    new_ts = now - timedelta(days=1)
+
+    # Three objects: one stale session, one fresh session, one artifact html.
+    pages = [
+        {
+            "Contents": [
+                {"Key": "abc/sessions.db", "LastModified": old_ts},
+                {"Key": "xyz/sessions.db", "LastModified": new_ts},
+                {"Key": "abc/index.html", "LastModified": old_ts},
+            ]
+        }
+    ]
+    paginator = MagicMock()
+    paginator.paginate.return_value = iter(pages)
+    client.get_paginator.return_value = paginator
+    _patch_client(monkeypatch, client)
+
+    deleted = s3.prune_sessions(max_age_days=30)
+
+    assert deleted == 1
+    client.delete_object.assert_called_once_with(
+        Bucket="artifacts", Key="abc/sessions.db"
+    )
+
+
+def test_prune_sessions_no_such_bucket_returns_zero(monkeypatch):
+    """A NoSuchBucket error means the bucket is empty; return 0 without re-raising."""
+    from botocore.exceptions import ClientError
+
+    client = MagicMock()
+    err = ClientError({"Error": {"Code": "NoSuchBucket"}}, "ListObjectsV2")
+    paginator = MagicMock()
+    paginator.paginate.side_effect = err
+    client.get_paginator.return_value = paginator
+    _patch_client(monkeypatch, client)
+
+    assert s3.prune_sessions(max_age_days=30) == 0

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.229.4
+version: 0.230.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/migrations/20260629150000_agent_threads_resume.sql
+++ b/projects/monolith/chart/migrations/20260629150000_agent_threads_resume.sql
@@ -1,0 +1,10 @@
+-- ADR 026 Phase 2: stateful artifact iteration. A goosecracker reply can resume
+-- the thread's persisted goose session (Model A: restore the SQLite session +
+-- prior artifact into a fresh fast-cold VM and `goose run --resume`) instead of
+-- cold-rebuilding the whole artifact from the full transcript (Model B). The
+-- `resume` flag on the thread row is how dispatch.submit signals that mode to
+-- fc-agentd, which injects GOOSE_RESUME=1 into the guest. Defaults false so every
+-- existing/cold path is unchanged.
+
+ALTER TABLE claude_agent.agent_threads
+    ADD COLUMN resume BOOLEAN NOT NULL DEFAULT false;

--- a/projects/monolith/chart/migrations/atlas.sum
+++ b/projects/monolith/chart/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:w8MiOxixZOIuj9aqPlOOalq4Sj9DX/anSoiPppiDa1g=
+h1:S5m3OyBYe8ue9Qi0jz/xtC6pgnLUzE53pUNtCskbxXQ=
 20260330000000_initial_schema.sql h1:J2futpSW0nJAIRR7nR7ssT7LwXIYrvRI+PkHb5Y4tLI=
 20260403000000_chat_schema.sql h1:pERUFC0vzM95etRuzp43XzkCV7lBCzrrtY5Mk7aF3CA=
 20260404000000_chat_attachments.sql h1:tv+Fdbr1rQC5nzUxfaBC0O6fu2OMGgLWf+YNg1WQXi4=
@@ -72,3 +72,4 @@ h1:w8MiOxixZOIuj9aqPlOOalq4Sj9DX/anSoiPppiDa1g=
 20260629120000_goosecracker_sessions.sql h1:idaMKKLa9tmNZRIzplWC8oRDIutaI5qJ13YftLTOAV0=
 20260629130000_agent_threads_notify.sql h1:XYqkFTVRwOtMJrxK3aLYAl0tIns5U45lrOC/bTImq3I=
 20260629140000_agent_threads_claim_attempts.sql h1:12hpsYSD0J/ngSHGJDbECm7BfWYAfkzz5/DIx2+CW7U=
+20260629150000_agent_threads_resume.sql h1:FxbwWxfgDTroHiXNg7MvsQQOYH+FHizJpSLvKYIRnVo=

--- a/projects/monolith/chart/values.yaml
+++ b/projects/monolith/chart/values.yaml
@@ -62,6 +62,21 @@ jobs:
           memory: 512Mi
         limits:
           memory: 1Gi
+    # ADR 026 Phase 2 Task 2.5: evict goose session DBs (s3://artifacts/<id>/
+    # sessions.db) past their TTL so abandoned threads do not accumulate storage.
+    # Artifacts are left intact. S3-only, light; daily is ample.
+    - name: evict-artifact-sessions
+      args: ["evict-artifact-sessions"]
+      schedule: "0 4 * * *" # daily 04:00 UTC
+      concurrencyPolicy: Forbid
+      activeDeadlineSeconds: 300
+      suspend: false
+      resources:
+        requests:
+          cpu: 100m
+          memory: 256Mi
+        limits:
+          memory: 512Mi
     # knowledge.layout: FA2 graph layout, ~2.7GiB peak / 1 core / ~3 min,
     # measured live. It recomputes the WHOLE graph every run with no
     # change-detection, but the graph (notes + links) is static for days at a

--- a/projects/monolith/chat/goosecracker.py
+++ b/projects/monolith/chat/goosecracker.py
@@ -96,7 +96,9 @@ def continue_session(thread_id: str, message: str) -> dict | None:
     via ``asyncio.to_thread``.
     """
     from agent.api import submit
+    from artifact import s3
 
+    message = message.strip()
     with Session(get_engine()) as session:
         row = session.get(GoosecrackerSession, thread_id)
         if row is None:
@@ -106,6 +108,26 @@ def continue_session(thread_id: str, message: str) -> dict | None:
         row.updated_at = datetime.now(timezone.utc)
         session.add(row)
         session.commit()
+
+    # ADR 026 Phase 2: if a persisted goose session exists for this thread, resume
+    # it (Model A) - send only the new reply; the guest restores the session + the
+    # prior artifact and `goose run --resume` edits the page in place, hitting the
+    # inference prefix cache. Otherwise cold-rebuild from the FULL transcript
+    # (Model B), which also seeds the session for next time. The S3 check is the
+    # primary fallback gate (Task 2.4): no stored session -> cold, never a failure.
+    has_session = False
+    try:
+        has_session = s3.head_session(thread_id) is not None
+    except Exception:
+        logger.exception("goosecracker: session existence check failed; cold rebuild")
+    if has_session:
+        return submit(
+            message,
+            recipe=ARTIFACT_RECIPE,
+            tier=ARTIFACT_TIER,
+            discord_thread=thread_id,
+            resume=True,
+        )
     return submit(
         transcript,
         recipe=ARTIFACT_RECIPE,

--- a/projects/monolith/chat/goosecracker_test.py
+++ b/projects/monolith/chat/goosecracker_test.py
@@ -129,3 +129,76 @@ def test_is_goosecracker_thread(engine, fake_api):
         goosecracker.start_session("thread-1", "build a clock")
         assert goosecracker.is_goosecracker_thread("thread-1") is True
         assert goosecracker.is_goosecracker_thread("other") is False
+
+
+# ---------------------------------------------------------------------------
+# ADR 026 Phase 2: continue_session resume gate
+# ---------------------------------------------------------------------------
+
+
+def test_continue_session_resume_path_when_session_exists(
+    engine, fake_api, monkeypatch
+):
+    """When head_session returns a truthy etag, submit is called with resume=True
+    and the task is the latest stripped message (not the full transcript)."""
+    from artifact import s3
+
+    monkeypatch.setattr(s3, "head_session", lambda _: "abc123")
+
+    with patch("chat.goosecracker.get_engine", return_value=engine):
+        goosecracker.start_session("thread-1", "build a clock")
+        fake_api.submit.reset_mock()
+        goosecracker.continue_session("thread-1", "  make it red  ")
+
+    fake_api.submit.assert_called_once_with(
+        "make it red",
+        recipe="artifact",
+        tier="artifact",
+        discord_thread="thread-1",
+        resume=True,
+    )
+
+
+def test_continue_session_cold_path_when_no_session(engine, fake_api, monkeypatch):
+    """When head_session returns None, submit is called without resume and the
+    task is the full accumulated transcript."""
+    from artifact import s3
+
+    monkeypatch.setattr(s3, "head_session", lambda _: None)
+
+    with patch("chat.goosecracker.get_engine", return_value=engine):
+        goosecracker.start_session("thread-1", "build a clock")
+        fake_api.submit.reset_mock()
+        goosecracker.continue_session("thread-1", "make it red")
+
+    fake_api.submit.assert_called_once_with(
+        "build a clock\n\nmake it red",
+        recipe="artifact",
+        tier="artifact",
+        discord_thread="thread-1",
+    )
+
+
+def test_continue_session_falls_back_to_cold_on_head_session_error(
+    engine, fake_api, monkeypatch
+):
+    """When head_session raises any exception, the handler logs and falls back
+    to the cold (Model B) rebuild path using the full transcript."""
+    from artifact import s3
+
+    def _raise(_):
+        raise RuntimeError("S3 unavailable")
+
+    monkeypatch.setattr(s3, "head_session", _raise)
+
+    with patch("chat.goosecracker.get_engine", return_value=engine):
+        goosecracker.start_session("thread-1", "build a clock")
+        fake_api.submit.reset_mock()
+        goosecracker.continue_session("thread-1", "make it red")
+
+    fake_api.submit.assert_called_once_with(
+        "build a clock\n\nmake it red",
+        recipe="artifact",
+        tier="artifact",
+        discord_thread="thread-1",
+    )

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.229.4
+      targetRevision: 0.230.0
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
Phase 2 of [ADR 026](docs/decisions/agents/026-fast-microvm-starts-and-stateful-artifact-iteration.md), on top of the merged Phase 1 (CoW + event-driven dispatch). Makes Discord-thread iterations **incremental** instead of re-running the full ~80-110s build each reply.

## Mechanism
A thread's goose **session** (the SQLite conversation) is persisted per thread. On a reply, the guest restores it + the prior artifact into a fresh fast-cold VM and runs `goose run --resume`, so the model edits the existing file off the full conversation (**Model A**) and hits the inference prefix cache (`cached_tokens > 0`), instead of regenerating from the whole transcript (**Model B**).

- **monolith artifact domain**: `put/get/head_session` (`s3://artifacts/<id>/sessions.db`) + POST/GET/exists session endpoints, derived from the existing artifact path. **Full-monolith-only** (absent from the public binary, verified by test). `prune_sessions` TTL sweep.
- **`harness.GooseCommand`**: `--name` on cold builds (so a reply can resume), and a `--resume` mode (no `--recipe`; the session already carries the system prompt).
- **fc-agent-init**: after the egress funnel is up, on `GOOSE_RESUME=1` restore the session + prior `index.html` and run `--resume`; always ship `sessions.db` after the run. Falls back to the cold recipe build when no session is fetchable.
- **control plane**: `agent_threads.resume` column; `dispatch.submit(resume=)`; reconcile injects `GOOSE_RESUME=1` per-thread; `goosecracker.continue_session` gates resume on whether a session exists in S3, else cold Model-B rebuild with the **full transcript** (the automatic fallback, Task 2.4).
- **Task 2.5**: daily `evict-artifact-sessions` CronWorkflow prunes sessions past a TTL (artifacts left intact).

## Validation plan (post-merge, in-cluster)
Two-step thread: cold build seeds the session; a reply resumes it. Confirm `cached_tokens > 0` in the egress capture on the reply, a markedly shorter build, and the artifact **edited** (not regenerated). Then delete the stored session and confirm clean cold fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)