### PR TITLE
chore(monolith): bump to 0.229.4 to release clickhouse_sql dashboard

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.76.2
+version: 0.76.3
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.76.2
+      targetRevision: 0.76.3
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.229.3
+version: 0.229.4
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.229.3
+      targetRevision: 0.229.4
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
Releases the clickhouse_sql goosecracker dashboard JSON (already on main from #2924) under a fresh chart version. The previous bump collided with a chart-version-bot 0.229.3 bump, so the OCI 0.229.3 chart still has the old builder JSON. Bumping to 0.229.4 forces the rebuild. No code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)