### PR TITLE
fix(fc-agentd): mark build progress done from the reconciler

### DIFF
--- a/projects/agent_platform/fc-agentd/chart/Chart.yaml
+++ b/projects/agent_platform/fc-agentd/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: fc-agentd
 description: Firecracker snapshot/restore controller (ADR 022) - the node-4 Postgres-reconcile daemon that manages agent-thread microVMs
 type: application
-version: 0.17.2
+version: 0.17.3

--- a/projects/agent_platform/fc-agentd/deploy/application.yaml
+++ b/projects/agent_platform/fc-agentd/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: fc-agentd
-      targetRevision: 0.17.2
+      targetRevision: 0.17.3
       helm:
         valueFiles:
           - $values/projects/agent_platform/fc-agentd/deploy/values.yaml

--- a/projects/agent_platform/fc-agentd/internal/reconcile/reconcile.go
+++ b/projects/agent_platform/fc-agentd/internal/reconcile/reconcile.go
@@ -7,8 +7,11 @@
 package reconcile
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"log/slog"
+	"net/http"
 	"time"
 
 	"go.opentelemetry.io/otel"
@@ -290,7 +293,12 @@ func (l *Loop) startControl(ctx context.Context, log *slog.Logger, t store.Threa
 	cctx, cancel := context.WithCancel(ctx)
 	l.control[t.ThreadID] = cancel
 	uds := l.ControlUDS(t.ThreadID)
-	assign := control.Assignment{ThreadID: t.ThreadID, Recipe: t.Recipe, Task: t.Task, Env: l.envForThread(log, t)}
+	threadEnv := l.envForThread(log, t)
+	assign := control.Assignment{ThreadID: t.ThreadID, Recipe: t.Recipe, Task: t.Task, Env: threadEnv}
+	// The endpoint that flips the Discord build message to its terminal state
+	// (same one the guest streams to); captured here so OnDone can close the
+	// message even when the guest could not (see postProgressDone).
+	progressURL := threadEnv["PROGRESS_PUBLISH_URL"]
 	// Forward the guest's vsock egress to the secret-free sidecar (ADR 023).
 	if l.EgressSidecar != "" {
 		go func() {
@@ -314,6 +322,13 @@ func (l *Loop) startControl(ctx context.Context, log *slog.Logger, t store.Threa
 			if err := l.Registry.SetState(ctx, threadID, substrate.StateCompleted); err != nil {
 				log.Error("reconcile: mark completed on done", "thread", threadID, "err", err)
 			}
+			// Close the live build message (ADR 024 Option A). fc-agent-init also
+			// sends this on a clean guest exit, but cannot when the VM is torn down
+			// before goose returns (supersede / failure); OnDone always fires, so
+			// emitting it here stops the bot live-editing instead of spinning to its
+			// safety timeout. Keyed by the Discord thread id (== the progress id);
+			// a no-op for non-Discord threads.
+			postProgressDone(ctx, log, progressURL, t.DiscordThread)
 			// Surface the result back to the Discord thread that triggered the run
 			// (ADR 024 Task 5). Only when there is an artifact URL to share, so a
 			// non-artifact thread that happens to carry a discord_thread is not spammed
@@ -331,6 +346,41 @@ func (l *Loop) startControl(ctx context.Context, log *slog.Logger, t store.Threa
 			log.Warn("reconcile: control server exited", "thread", t.ThreadID, "err", err)
 		}
 	}()
+}
+
+// progressDoneClient posts the build-done marker. Short timeout: the call is
+// best-effort and must never hold up the reconcile loop.
+var progressDoneClient = &http.Client{Timeout: 10 * time.Second}
+
+// postProgressDone marks a goosecracker run complete on the monolith's progress
+// endpoint (POST {id, done:true}), so the Discord bot stops live-editing the
+// "Building your artifact" message and flips it to its terminal state. This is
+// the same marker fc-agent-init sends on a clean guest exit; the reconciler
+// sends it too because it observes every terminal transition, including the ones
+// where the guest never gets to (the VM is reclaimed before goose returns). Both
+// senders are idempotent (done is a sticky flag), so a double-send is harmless.
+// Best-effort: on any error the message just falls back to the bot's safety
+// timeout, so failures are logged at debug and never propagated.
+func postProgressDone(ctx context.Context, log *slog.Logger, url, artifactID string) {
+	if url == "" || artifactID == "" {
+		return
+	}
+	body, err := json.Marshal(map[string]any{"id": artifactID, "done": true})
+	if err != nil {
+		return
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		log.Debug("reconcile: build progress-done request", "id", artifactID, "err", err)
+		return
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := progressDoneClient.Do(req)
+	if err != nil {
+		log.Debug("reconcile: post progress-done failed", "id", artifactID, "err", err)
+		return
+	}
+	_ = resp.Body.Close()
 }
 
 // envForThread is the per-thread guest env: the tier env (envForTier) plus a

--- a/projects/agent_platform/fc-agentd/internal/reconcile/reconcile_test.go
+++ b/projects/agent_platform/fc-agentd/internal/reconcile/reconcile_test.go
@@ -2,9 +2,12 @@ package reconcile
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"io"
 	"log/slog"
+	"net/http"
+	"net/http/httptest"
 	"sync"
 	"testing"
 	"time"
@@ -579,5 +582,57 @@ func TestEnvForThread(t *testing.T) {
 	}
 	if _, ok := def["ARTIFACT_ID"]; ok {
 		t.Fatalf("non-Discord thread must not carry ARTIFACT_ID: %v", def)
+	}
+}
+
+func TestPostProgressDoneSendsDoneMarker(t *testing.T) {
+	var got struct {
+		body []byte
+		ct   string
+		hits int
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got.hits++
+		got.ct = r.Header.Get("Content-Type")
+		got.body, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	postProgressDone(context.Background(), slog.New(slog.NewTextHandler(io.Discard, nil)), srv.URL, "12345")
+
+	if got.hits != 1 {
+		t.Fatalf("want 1 request, got %d", got.hits)
+	}
+	if got.ct != "application/json" {
+		t.Fatalf("content-type = %q", got.ct)
+	}
+	var payload struct {
+		ID   string `json:"id"`
+		Done bool   `json:"done"`
+	}
+	if err := json.Unmarshal(got.body, &payload); err != nil {
+		t.Fatalf("unmarshal body %q: %v", got.body, err)
+	}
+	if payload.ID != "12345" || !payload.Done {
+		t.Fatalf("payload = %+v, want id=12345 done=true", payload)
+	}
+}
+
+func TestPostProgressDoneNoopWhenUnconfigured(t *testing.T) {
+	var hits int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits++
+	}))
+	defer srv.Close()
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	// No artifact id (non-Discord thread): must not post.
+	postProgressDone(context.Background(), log, srv.URL, "")
+	// No url (tier without PROGRESS_PUBLISH_URL): must not post.
+	postProgressDone(context.Background(), log, "", "12345")
+
+	if hits != 0 {
+		t.Fatalf("want 0 requests when unconfigured, got %d", hits)
 	}
 }


### PR DESCRIPTION
## Problem

When a `/goosecracker` artifact build finishes, the Discord "🛠 Building your artifact / 🧠 Thinking… (m:ss)" status message can stay stuck forever, its timer climbing, even though the build is done and the `Artifact ready: <url>` link has already been posted.

Root cause: two decoupled writers. fc-agentd's reconciler posts the `Artifact ready` link, but the live status message is owned by the monolith bot's progress loop (`chat/bot.py`), which only flips to "✅ Built" when the progress buffer's `done` flag is set. That flag is set **only** by the guest (`fc-agent-init`'s `finish()`), POSTing `{id, done:true}` to `/internal/goosecracker/progress`. When the microVM is torn down before goose returns (supersede or failure), the guest never sends it, so the bot keeps editing the message until its 15-minute safety timeout (`GOOSECRACKER_STREAM_TIMEOUT = 900`), then freezes it on "Thinking 15:00" (the timeout path clears state without a terminal edit).

The climbing timer is the bot's own local clock, not a signal from the agent, so it is not evidence the work is ongoing.

## Fix (Option A)

Give the reconciler the same one-line capability. It observes **every** terminal transition (`OnDone`), so it emits the same done marker the guest does: a best-effort `POST {id, done:true}` to the same endpoint, keyed by the Discord thread id (== the progress id). `done` is a sticky flag, so the guest and reconciler both sending it is idempotent. A failed POST just falls back to the bot's existing timeout, so it never blocks reclaim.

Sends on any completion, not only artifact-bearing runs, so a failed/empty run also closes its live message.

## Scope / non-goals

The concurrent-runs-on-one-thread race (a re-run opening a second live message that shares the single thread-keyed progress buffer, so one `done`/`clear` can orphan the other) is **unchanged** and remains the domain of a future per-run progress key (Option C, deferred).

## Testing

Added `TestPostProgressDoneSendsDoneMarker` (httptest server asserts the `{id, done:true}` JSON + content-type) and `TestPostProgressDoneNoopWhenUnconfigured` (no URL / no artifact id → no request). `gofumpt` clean. Full build/test runs in BuildBuddy CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)