### PR TITLE
fix(goosecracker): sync slash command globally so it works in all servers

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.77.0
+version: 0.77.1
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.77.0
+      targetRevision: 0.77.1
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.230.0
+version: 0.230.1
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chat/bot.py
+++ b/projects/monolith/chat/bot.py
@@ -274,18 +274,16 @@ class ChatBot(discord.Client):
 
     async def on_ready(self):
         logger.info("Discord bot connected as %s", self.user)
-        # Sync slash commands. Guild-scoped sync (when the agent's default server
-        # is configured) propagates instantly; a global sync can take up to an
-        # hour to appear, so prefer the guild when we have it.
+        # Sync slash commands globally so /goosecracker is available in every
+        # server the bot is in (still owner-gated at execution by is_owner, so
+        # non-owners just get roasted). A global sync can take up to an hour to
+        # propagate on first registration; that is acceptable for a command that
+        # changes rarely. We intentionally do not scope to the default server:
+        # MONOLITH_AGENT_DISCORD_DEFAULT_SERVER_ID still names the home server
+        # for notify, but it no longer limits where commands appear.
         try:
-            guild_id = os.environ.get("MONOLITH_AGENT_DISCORD_DEFAULT_SERVER_ID", "")
-            if guild_id:
-                guild = discord.Object(id=int(guild_id))
-                self.tree.copy_global_to(guild=guild)
-                await self.tree.sync(guild=guild)
-            else:
-                await self.tree.sync()
-            logger.info("Synced application commands (guild=%s)", guild_id or "global")
+            await self.tree.sync()
+            logger.info("Synced application commands (global)")
         except Exception:
             logger.exception("Failed to sync application commands")
         # Re-register ThinkingView for recent bot messages so the "Show thinking"

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.230.0
+      targetRevision: 0.230.1
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
## What

`/goosecracker` was synced only to the home guild (`MONOLITH_AGENT_DISCORD_DEFAULT_SERVER_ID`) in `on_ready`, so it never appeared in any other server the bot is in. This switches to a global `tree.sync()` so the command shows up everywhere the bot is a member.

## Why this is safe

Execution is still gated by `goosecracker.is_owner(interaction.user.id)` against `OWNER_DISCORD_USER_ID`, which is server-agnostic and fails closed. Non-owners get the roast path regardless of which server they call from, so widening visibility does not widen who can actually run it.

`MONOLITH_AGENT_DISCORD_DEFAULT_SERVER_ID` keeps its other roles (notify target via `agent/notify.py`, required field in `agent/config.py`); it just no longer scopes where slash commands appear.

## Caveat

Global sync can take up to ~1h to propagate on first registration. Acceptable for a command that changes rarely. The bot must already be a member of the target server (with the `applications.commands` scope) for the command to land there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)