### PR TITLE
fix(fc-agentd): reclaim FAILED threads so they don't strand CoW devices

### DIFF
--- a/projects/agent_platform/fc-agentd/chart/Chart.yaml
+++ b/projects/agent_platform/fc-agentd/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: fc-agentd
 description: Firecracker snapshot/restore controller (ADR 022) - the node-4 Postgres-reconcile daemon that manages agent-thread microVMs
 type: application
-version: 0.17.3
+version: 0.17.4

--- a/projects/agent_platform/fc-agentd/deploy/application.yaml
+++ b/projects/agent_platform/fc-agentd/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: fc-agentd
-      targetRevision: 0.17.3
+      targetRevision: 0.17.4
       helm:
         valueFiles:
           - $values/projects/agent_platform/fc-agentd/deploy/values.yaml

--- a/projects/agent_platform/fc-agentd/internal/reconcile/reconcile.go
+++ b/projects/agent_platform/fc-agentd/internal/reconcile/reconcile.go
@@ -215,6 +215,7 @@ func (l *Loop) reconcileOnce(ctx context.Context, log *slog.Logger) {
 	l.restoreWakeRequested(ctx, log)
 	l.adoptOrphanedRunning(ctx, log)
 	l.reclaimCompleted(ctx, log)
+	l.reclaimFailed(ctx, log)
 	l.gcIdleExpired(ctx, log)
 }
 
@@ -525,6 +526,41 @@ func (l *Loop) reclaimCompleted(ctx context.Context, log *slog.Logger) {
 			}
 			delete(l.live, t.ThreadID)
 		}
+		l.reclaimBundleAndRow(ctx, log, t.ThreadID)
+	}
+}
+
+// failedRetention is how long a FAILED thread is kept before reclaim: a brief
+// window to inspect why it failed (the reason is also in the daemon logs) before
+// its bundle + copy-on-write rootfs device are released. Deliberately far shorter
+// than the IDLE ttl_secs, which preserves a resumable snapshot for up to a day: a
+// FAILED thread is terminal with nothing to resume, so the only thing the wait
+// buys is observability, while the device it may have provisioned keeps stranding.
+const failedRetention = 5 * time.Minute
+
+// reclaimFailed releases the microVM and deletes the bundle + row for FAILED
+// threads past failedRetention. FAILED is otherwise never reclaimed (the loop only
+// handles COMPLETED and idle-expired IDLE), so a thread that fails AFTER
+// provisioning leaks its CoW rootfs device on the node forever, since only
+// RemoveBundle (reclaimBundleAndRow) tears that device down. This closes that leak
+// without touching the long IDLE TTL.
+func (l *Loop) reclaimFailed(ctx context.Context, log *slog.Logger) {
+	threads, err := l.Registry.ListByStateForNode(ctx, l.Node, substrate.StateFailed)
+	if err != nil {
+		log.Error("reconcile: list failed", "err", err)
+		return
+	}
+	for _, t := range threads {
+		if time.Since(t.LastActiveAt) < failedRetention {
+			continue // keep briefly for inspection
+		}
+		if h, ok := l.live[t.ThreadID]; ok {
+			if err := l.Executor.Release(ctx, h); err != nil {
+				log.Error("reconcile: release failed", "thread", t.ThreadID, "err", err)
+			}
+			delete(l.live, t.ThreadID)
+		}
+		log.Info("reconcile: reclaim FAILED thread", "thread", t.ThreadID, "age", time.Since(t.LastActiveAt).String())
 		l.reclaimBundleAndRow(ctx, log, t.ThreadID)
 	}
 }

--- a/projects/agent_platform/fc-agentd/internal/reconcile/reconcile_test.go
+++ b/projects/agent_platform/fc-agentd/internal/reconcile/reconcile_test.go
@@ -432,6 +432,44 @@ func TestReconcileReclaimsCompleted(t *testing.T) {
 	}
 }
 
+func TestReconcileReclaimsFailedPastRetention(t *testing.T) {
+	// A thread that failed after provisioning has a CoW device; once past the
+	// short retention window the loop must release the bundle + delete the row.
+	reg := newFakeRegistry(store.Thread{
+		ThreadID: "t1", State: substrate.StateFailed, Node: "node-4",
+		LastActiveAt: time.Now().Add(-failedRetention - time.Minute),
+	})
+	ex := &fakeExec{}
+	l := newLoop(reg, ex)
+	l.reconcileOnce(context.Background(), testLogger())
+
+	if len(ex.removed) != 1 || ex.removed[0] != "t1" {
+		t.Fatalf("removed = %v, want [t1] (FAILED past retention should be reclaimed)", ex.removed)
+	}
+	if reg.state("t1") != "GONE" {
+		t.Fatalf("reclaimed FAILED thread row should be deleted, got %q", reg.state("t1"))
+	}
+}
+
+func TestReconcileKeepsRecentlyFailed(t *testing.T) {
+	// A just-failed thread is kept for the retention window so the failure stays
+	// inspectable; it must not be reclaimed yet.
+	reg := newFakeRegistry(store.Thread{
+		ThreadID: "t1", State: substrate.StateFailed, Node: "node-4",
+		LastActiveAt: time.Now(),
+	})
+	ex := &fakeExec{}
+	l := newLoop(reg, ex)
+	l.reconcileOnce(context.Background(), testLogger())
+
+	if len(ex.removed) != 0 {
+		t.Fatalf("removed = %v, want [] (recently FAILED should be kept within retention)", ex.removed)
+	}
+	if reg.state("t1") != substrate.StateFailed {
+		t.Fatalf("recently FAILED thread should remain FAILED, got %q", reg.state("t1"))
+	}
+}
+
 func TestReconcileGCsIdleExpired(t *testing.T) {
 	reg := newFakeRegistry(store.Thread{
 		ThreadID: "t1", State: substrate.StateIdle, Node: "node-4",


### PR DESCRIPTION
The reconcile loop reclaims COMPLETED threads and GCs idle-expired IDLE threads, but **FAILED threads were never reclaimed** - they lingered as rows forever. Worse than clutter: a thread that fails *after* provisioning has a copy-on-write rootfs device (ADR 026) that only `RemoveBundle` releases, so a terminal failure **strands that dm device on node-4 indefinitely** (observed live - a FAILED artifact thread held `fcthr-<id>` until reclaimed by hand).

Adds a `reclaimFailed` pass mirroring `reclaimCompleted`, gated by a short **5-minute retention** so the failure stays briefly inspectable (reason is also logged) before bundle + device release. Decoupled from the long IDLE `ttl_secs` (which preserves a resumable snapshot for ~24h): a FAILED thread is terminal with nothing to resume. Tests cover reclaim-past-retention and keep-within-retention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)