### PR TITLE
refactor(monolith): rename Discord bot to Bosun, command to /artifact

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.77.1
+version: 0.77.2
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.77.1
+      targetRevision: 0.77.2
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.230.1
+version: 0.230.2
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chat/agent.py
+++ b/projects/monolith/chat/agent.py
@@ -61,11 +61,11 @@ def build_system_prompt() -> str:
         "You are a friend hanging out in a Discord server. "
         "You talk like a real person — casual, direct, and natural.\n\n"
         "WHO YOU ARE:\n"
-        "- Your name in this server is Qwen3.6 — a large language model "
+        "- Your name in this server is Bosun, a large language model "
         "running locally on hardware in this community, often someone's own "
         "GPU, not a hosted API service.\n"
-        '- When people @-mention you, reply to you, talk about "Qwen" or '
-        '"the bot", or comment on how you\'re running ("my 4090 is running '
+        '- When people @-mention you, reply to you, talk about "Bosun", '
+        '"Qwen", or "the bot", or comment on how you\'re running ("my 4090 is running '
         'you", "you\'re kinda dumb"), they mean YOU. Own it.\n'
         '- A "<@" followed by a long number is a Discord user mention. When '
         "the number is your own user ID, that's someone addressing YOU — "

--- a/projects/monolith/chat/agent_test.py
+++ b/projects/monolith/chat/agent_test.py
@@ -18,9 +18,9 @@ class TestBuildSystemPrompt:
         assert "Search before you respond" in prompt
 
     def test_states_own_name(self):
-        """System prompt tells the model its name is Qwen3.6."""
+        """System prompt tells the model its name is Bosun."""
         prompt = build_system_prompt()
-        assert "Qwen3.6" in prompt
+        assert "Bosun" in prompt
 
     def test_explains_self_mention_recognition(self):
         """System prompt explains that its own <@id> mention means itself."""

--- a/projects/monolith/chat/bot.py
+++ b/projects/monolith/chat/bot.py
@@ -46,7 +46,7 @@ def _truncate_thinking(thinking: str) -> str:
     return thinking[:THINKING_TRUNCATE_AT] + "... (truncated)"
 
 
-# Live /goosecracker progress streaming (ADR 024). The guest streams goose's
+# Live /artifact progress streaming (ADR 024). The guest streams goose's
 # stdout to the in-process progress buffer; the bot edits the thread message on
 # this cadence so the owner sees activity instead of a multi-minute silent wait.
 GOOSECRACKER_STREAM_INTERVAL = 1.5  # seconds between Discord edits (rate-limit safe)
@@ -253,7 +253,7 @@ class ChatBot(discord.Client):
         self.embed_client = EmbeddingClient()
         self.vision_client = VisionClient()
         self.agent = create_agent()
-        # Slash commands (e.g. /goosecracker, ADR 024 Task 4) live on a
+        # Slash commands (e.g. /artifact, ADR 024 Task 4) live on a
         # CommandTree; on_message handles plain chat. Registered at construction,
         # synced to the guild in on_ready.
         self.tree = discord.app_commands.CommandTree(self)
@@ -263,7 +263,7 @@ class ChatBot(discord.Client):
         """Register application (slash) commands on the tree."""
 
         @self.tree.command(
-            name="goosecracker",
+            name="artifact",
             description="Build a self-contained web artifact (owner only)",
         )
         @discord.app_commands.describe(prompt="What to build")
@@ -274,7 +274,7 @@ class ChatBot(discord.Client):
 
     async def on_ready(self):
         logger.info("Discord bot connected as %s", self.user)
-        # Sync slash commands globally so /goosecracker is available in every
+        # Sync slash commands globally so /artifact is available in every
         # server the bot is in (still owner-gated at execution by is_owner, so
         # non-owners just get roasted). A global sync can take up to an hour to
         # propagate on first registration; that is acceptable for a command that
@@ -335,7 +335,7 @@ class ChatBot(discord.Client):
     async def _handle_goosecracker_command(
         self, interaction: discord.Interaction, prompt: str
     ) -> None:
-        """Owner-gated /goosecracker: open a thread and dispatch the first run."""
+        """Owner-gated /artifact: open a thread and dispatch the first run."""
         if not goosecracker.is_owner(interaction.user.id):
             # Defer first: the roast hits the qwen model (with retries), which
             # routinely exceeds Discord's 3s initial-response deadline. Without
@@ -348,7 +348,7 @@ class ChatBot(discord.Client):
         channel = interaction.channel
         if not isinstance(channel, discord.TextChannel):
             await interaction.response.send_message(
-                "Run /goosecracker from a normal text channel so I can open a thread.",
+                "Run /artifact from a normal text channel so I can open a thread.",
                 ephemeral=True,
             )
             return

--- a/projects/monolith/chat/bot_summary_injection_test.py
+++ b/projects/monolith/chat/bot_summary_injection_test.py
@@ -224,7 +224,7 @@ class TestIdentityInjection:
 
         mock_store = _make_store()
 
-        events = [_text_delta("I'm Qwen3.6.")]
+        events = [_text_delta("I'm Bosun.")]
         bot.agent.run_stream_events = MagicMock(return_value=_async_iter(events))
 
         with (

--- a/projects/monolith/chat/goosecracker.py
+++ b/projects/monolith/chat/goosecracker.py
@@ -1,6 +1,6 @@
 """goosecracker: the owner-gated Discord artifact agent (ADR 024 Task 4).
 
-``/goosecracker <prompt>`` opens a Discord thread and runs goose in a
+``/artifact <prompt>`` opens a Discord thread and runs goose in a
 Firecracker microVM (the ``artifact`` recipe + tier), which builds a
 self-contained HTML artifact and publishes it; fc-agentd posts the artifact URL
 back into the thread (Task 5). Each owner follow-up in the thread re-runs goose
@@ -34,7 +34,7 @@ ARTIFACT_TIER = "artifact"
 
 # Shown when the owner gate rejects someone and the qwen roast path is
 # unavailable (model down), so a non-owner always gets a clear refusal.
-_FALLBACK_ROAST = "Nice try. /goosecracker is owner-only."
+_FALLBACK_ROAST = "Nice try. /artifact is owner-only."
 
 
 def owner_id() -> str:
@@ -152,7 +152,7 @@ async def build_roast(attempt_text: str) -> str:
     attempt_text = (attempt_text or "").strip()[:300]
     prompt = (
         "You are a cynical senior engineer. Someone who is NOT the owner just "
-        "tried to run the owner-only /goosecracker artifact bot"
+        "tried to run the owner-only /artifact command"
         + (f' with: "{attempt_text}"' if attempt_text else "")
         + ". Roast them in one or two dry sentences for reaching for a tool that "
         "isn't theirs. Past tense or present, declarative. No preamble, no "

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.230.1
+      targetRevision: 0.230.2
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
## Why

The single Discord app exposed two things under the model-specific name **Qwen3.6**:
- a **Qwen-backed chat persona** (`agent.py`, runs `qwen3.6-27b` on local vLLM) — name correct
- the **gemini-backed artifact builder** (`/goosecracker` → fc-agentd → goose → `gemini-3.5-flash`) — name wrong

No single model name fits both halves, and naming a bot after its model ages badly the moment the model changes. Adopt a neutral, seafaring name (**Bosun** — the crew member who actually does the work) so identity stays true regardless of which model backs which half.

## Changes

- **Persona → "Bosun"**: `agent.py` system prompt + `agent_test.py`. Still recognises "Qwen" and "the bot" so existing references and the local-model personality keep resolving.
- **Command `/goosecracker` → `/artifact`**: names the outcome, not the internal system. `tree.sync()` re-registers on startup; the old global command prunes on the next sync (global propagation up to ~1h).
- **User-facing strings updated**: wrong-channel hint, owner-gate fallback roast, roast-generation prompt.

## Deliberately unchanged

- Internal system name: the `goosecracker` module, `is_goosecracker_thread`, and the `/internal/goosecracker/progress` endpoint (a wire contract with `fc-agent-init`'s `PROGRESS_PUBLISH_URL` — renaming it would break live progress streaming).
- The `qwen3.6-27b` model id (`vision.py`/`explorer.py`/`summarizer.py`/`agent.py`) — the real local vLLM alias, not the persona name.
- The pre-existing unused `create_agent` import in `agent_test.py` (out of scope; identical on main).

## Out of band

The Discord app **username** is changed by the owner in the Developer Portal (not in this repo). The numeric bot user ID is stable, so existing `@`-mentions keep resolving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)