### PR TITLE
fix(fc-agentd): unlink stale vsock UDS before (re)launch

### DIFF
--- a/projects/agent_platform/fc-agentd/chart/Chart.yaml
+++ b/projects/agent_platform/fc-agentd/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: fc-agentd
 description: Firecracker snapshot/restore controller (ADR 022) - the node-4 Postgres-reconcile daemon that manages agent-thread microVMs
 type: application
-version: 0.18.0
+version: 0.18.1

--- a/projects/agent_platform/fc-agentd/deploy/application.yaml
+++ b/projects/agent_platform/fc-agentd/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: fc-agentd
-      targetRevision: 0.18.0
+      targetRevision: 0.18.1
       helm:
         valueFiles:
           - $values/projects/agent_platform/fc-agentd/deploy/values.yaml

--- a/projects/agent_platform/fc-agentd/internal/driver/driver.go
+++ b/projects/agent_platform/fc-agentd/internal/driver/driver.go
@@ -186,6 +186,26 @@ func (d *Driver) VsockUDSPath(threadID string) string {
 	return filepath.Join(d.threadDir(threadID), "vsock.sock")
 }
 
+// removeStaleVsockUDS unlinks any leftover vsock unix-domain socket before a
+// (re)launch. Firecracker *binds* the vsock UDS on PUT /vsock, and bind() fails
+// with EADDRINUSE when the path already exists. A thread's bundle dir lives on
+// the persistent snapshot disk, so a vsock.sock from a previous incarnation
+// survives a daemon/pod restart and makes orphan recovery loop on a 400 until it
+// exhausts retries and marks the thread FAILED. The launcher already clears the
+// API socket; the vsock UDS and its per-port children (<uds>_<port>, created once
+// the guest connects) are not, so clear them here.
+func (d *Driver) removeStaleVsockUDS(threadID string) {
+	vsock := d.VsockUDSPath(threadID)
+	_ = os.Remove(vsock)
+	matches, err := filepath.Glob(vsock + "_*")
+	if err != nil {
+		return
+	}
+	for _, m := range matches {
+		_ = os.Remove(m)
+	}
+}
+
 // bootArgs is the kernel command line. When HarnessInit is set it appends
 // init=<path> so the guest boots straight into fc-agent-init (raw FC boot does
 // not honour the OCI image entrypoint).
@@ -217,6 +237,9 @@ func (d *Driver) loadInto(ctx context.Context, threadID, snapPath, memPath, sock
 	}
 	sock := filepath.Join(dir, sockName)
 	_ = os.Remove(sock)
+	// A restored snapshot re-binds the vsock UDS from its embedded config; clear
+	// any stale socket first so the resume does not fail on EADDRINUSE.
+	d.removeStaleVsockUDS(threadID)
 	vmID := newID("vm")
 
 	proc, err := d.launcher.Launch(ctx, vmID, sock)
@@ -265,6 +288,9 @@ func (d *Driver) Claim(ctx context.Context, spec substrate.ClaimSpec) (substrate
 	if err := os.MkdirAll(dir, 0o750); err != nil {
 		return substrate.Handle{}, fmt.Errorf("driver: mkdir bundle: %w", err)
 	}
+	// Clear a stale vsock UDS left by a prior incarnation so PUT /vsock can bind
+	// (see removeStaleVsockUDS): the bundle dir persists across daemon restarts.
+	d.removeStaleVsockUDS(threadID)
 	sock := filepath.Join(dir, "api.sock")
 	vmID := newID("vm")
 

--- a/projects/agent_platform/fc-agentd/internal/driver/driver_test.go
+++ b/projects/agent_platform/fc-agentd/internal/driver/driver_test.go
@@ -101,6 +101,38 @@ func TestDriverClaimBootsMicroVM(t *testing.T) {
 	}
 }
 
+// TestDriverClaimClearsStaleVsockUDS reproduces the orphan-recovery failure
+// after a pod roll: a thread's bundle dir persists on the snapshot disk, so a
+// vsock.sock left by the dead incarnation makes Firecracker's PUT /vsock bind
+// fail with EADDRINUSE, looping the reconcile claim until it marks the thread
+// FAILED. Claim must unlink the stale UDS (and its per-port children) first. The
+// fake launcher does not bind the vsock UDS, so we assert the unlink directly:
+// without it, Claim never touches vsock.sock and the seeded file survives.
+func TestDriverClaimClearsStaleVsockUDS(t *testing.T) {
+	d := testDriver(t)
+	dir := d.threadDir("t-orphan")
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		t.Fatalf("mkdir thread dir: %v", err)
+	}
+	stale := d.VsockUDSPath("t-orphan")
+	staleChild := stale + "_1024"
+	for _, p := range []string{stale, staleChild} {
+		if err := os.WriteFile(p, nil, 0o600); err != nil {
+			t.Fatalf("seed stale socket %s: %v", p, err)
+		}
+	}
+
+	if _, err := d.Claim(context.Background(), substrate.ClaimSpec{ThreadID: "t-orphan"}); err != nil {
+		t.Fatalf("Claim over a stale vsock UDS: %v", err)
+	}
+	if _, err := os.Stat(stale); !os.IsNotExist(err) {
+		t.Fatalf("stale vsock.sock should have been removed before bind, stat err=%v", err)
+	}
+	if _, err := os.Stat(staleChild); !os.IsNotExist(err) {
+		t.Fatalf("stale vsock.sock_1024 should have been removed, stat err=%v", err)
+	}
+}
+
 // TestDriverSnapshotRestoreContinuity is the Phase 1 done-criterion in unit
 // form: boot -> snapshot -> release the original microVM -> restore a fresh
 // microVM that keeps the stable ThreadID (continues, not a new identity).


### PR DESCRIPTION
## Problem

A goosecracker Discord thread went silent (counter stopped, no artifact). Investigation traced two in-flight agent threads getting marked `FAILED` after a deploy rolled the `fc-agentd` pod ~70s after submission.

The reconcile loop's orphan recovery (`adoptOrphanedRunning` -> re-init to `PENDING` -> claim) looped on:

```
reconcile: claim pending thread failed; will retry next poll
  err: PUT /vsock: status 400: Vsock config error: Cannot create backend for vsock device:
       Error binding to the host-side Unix socket: Address in use (os error 98)
...(5 retries)...
reconcile: claim pending thread exhausted retries; marking FAILED
```

### Root cause

A thread's bundle dir lives on the persistent snapshot disk (`/disks/nvme-02/agent-threads/<id>/`), so the `vsock.sock` from the dead incarnation survives the pod restart. Firecracker *binds* the vsock UDS on `PUT /vsock`, and `bind()` returns `EADDRINUSE` when the path already exists. The launcher unlinks the API socket before launch, but nothing unlinked the vsock UDS, so every re-init boot was guaranteed to fail. Verified on disk: failed thread dirs had a stale `vsock.sock` (pre-roll mtime) alongside a fresh `api.sock`.

## Fix

Unlink the stale vsock UDS (and its per-port `<uds>_<port>` children) in both launch paths before configuring the device:
- `Claim` (cold-boot)
- `loadInto` (snapshot restore)

Regression test seeds a stale `vsock.sock` + child and asserts `Claim` removes them.

## Recovery semantics (unchanged)

For a thread with no snapshot, recovery re-inits to `PENDING` and the task re-runs from scratch (restart, not resume) - `snapshots are never load-bearing`. This fix just makes that restart actually succeed instead of looping to `FAILED`. Resume-across-deploys (periodic thread snapshotting) is a separate, larger follow-up.

## Test plan

- [x] `go build ./projects/agent_platform/fc-agentd/...`
- [x] `go vet` clean
- [ ] CI: `bazel test //projects/agent_platform/fc-agentd/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)