### PR TITLE
fix(semgrep): match OSS wheels by manylinux family, not pinned tag

### DIFF
--- a/.github/workflows/update-semgrep-pro.yaml
+++ b/.github/workflows/update-semgrep-pro.yaml
@@ -83,11 +83,16 @@ jobs:
 
           # --- OSS engines (from PyPI wheels) ---
           download_oss_engines() {
+            # Match wheels by a "<os-or-libc-family>.*<arch>" regex rather than a
+            # pinned platform tag. Semgrep raises its manylinux glibc floor over time
+            # (e.g. manylinux2014_x86_64 -> manylinux_2_34_x86_64), which silently
+            # broke the old exact-string match. Matching on family + arch is stable
+            # across those bumps while still excluding musllinux and Windows wheels.
             declare -A PLATFORMS=(
-              ["amd64"]="manylinux2014_x86_64"
-              ["arm64"]="manylinux2014_aarch64"
-              ["osx-arm64"]="macosx_11_0_arm64"
-              ["osx-x86_64"]="macosx_10_14_x86_64"
+              ["amd64"]="manylinux.*x86_64"
+              ["arm64"]="manylinux.*aarch64"
+              ["osx-arm64"]="macosx.*arm64"
+              ["osx-x86_64"]="macosx.*x86_64"
             )
 
             local pids=()
@@ -97,12 +102,12 @@ jobs:
                 dir="artifacts/oss-engine-${arch}"
                 mkdir -p "${dir}"
 
-                echo "[oss-engine-${arch}] Fetching PyPI wheel URL..."
+                echo "[oss-engine-${arch}] Fetching PyPI wheel URL (matching /${platform}/)..."
                 WHEEL_URL=$(curl --compressed -sSf "https://pypi.org/pypi/semgrep/${SEMGREP_VERSION}/json" | python3 -c "
-          import json, sys
+          import json, re, sys
           data = json.load(sys.stdin)
           for f in data['urls']:
-              if '${platform}' in f['filename'] and f['packagetype'] == 'bdist_wheel':
+              if f['packagetype'] == 'bdist_wheel' and re.search(r'${platform}', f['filename']):
                   print(f['url'])
                   break
           else:


### PR DESCRIPTION
## Summary

The daily **Update Semgrep Artifacts** GitHub Actions workflow has been failing at the "Download all artifacts" step with:

```
ERROR: no wheel found for manylinux2014_x86_64
ERROR: no wheel found for manylinux2014_aarch64
```

Root cause: the workflow matched Semgrep's PyPI wheels by hardcoded platform tags (`manylinux2014_x86_64` / `manylinux2014_aarch64`). Semgrep raised its manylinux glibc floor, and the current wheels are now tagged `manylinux_2_34_x86_64` / `manylinux_2_34_aarch64`, so the exact-string match found nothing. The two macOS wheels were unaffected; only the OSS Linux engines broke, but the parallel `wait_all` correctly propagated the failure and exited the step.

## Fix

Match wheels with a `<os-or-libc-family>.*<arch>` regex (`re.search`) instead of an exact substring. This is stable across future glibc-floor bumps while still excluding `musllinux` and Windows wheels.

Verified against live PyPI (semgrep 1.168.0) that each arch resolves to exactly one correct wheel:

| arch | pattern | resolved wheel |
| --- | --- | --- |
| amd64 | `manylinux.*x86_64` | `...manylinux_2_34_x86_64.whl` |
| arm64 | `manylinux.*aarch64` | `...manylinux_2_34_aarch64.whl` |
| osx-arm64 | `macosx.*arm64` | `...macosx_11_0_arm64.whl` |
| osx-x86_64 | `macosx.*x86_64` | `...macosx_10_14_x86_64.whl` |

Note: this is the one workflow in the repo that runs on GitHub Actions rather than BuildBuddy (it needs `SEMGREP_APP_TOKEN` + egress to mint OCI artifacts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)