### PR TITLE
fix(fc-agentd): reap guests that die without completing

### DIFF
--- a/projects/agent_platform/fc-agentd/chart/Chart.yaml
+++ b/projects/agent_platform/fc-agentd/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: fc-agentd
 description: Firecracker snapshot/restore controller (ADR 022) - the node-4 Postgres-reconcile daemon that manages agent-thread microVMs
 type: application
-version: 0.18.1
+version: 0.18.2

--- a/projects/agent_platform/fc-agentd/deploy/application.yaml
+++ b/projects/agent_platform/fc-agentd/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: fc-agentd
-      targetRevision: 0.18.1
+      targetRevision: 0.18.2
       helm:
         valueFiles:
           - $values/projects/agent_platform/fc-agentd/deploy/values.yaml

--- a/projects/agent_platform/fc-agentd/internal/driver/launcher.go
+++ b/projects/agent_platform/fc-agentd/internal/driver/launcher.go
@@ -36,11 +36,12 @@ func (p *execProcess) Kill() error {
 	if p.cmd.Process == nil {
 		return nil
 	}
-	if err := p.cmd.Process.Kill(); err != nil {
-		return err
-	}
+	killErr := p.cmd.Process.Kill()
+	// Always reap the child, even when Kill reports it already exited (a crashed
+	// or panicked VM): without a Wait the dead process lingers as a zombie. Wait
+	// is the sole reaper, so it is safe to call once here.
 	_ = p.cmd.Wait()
-	return nil
+	return killErr
 }
 
 func (p *execProcess) Wait() error { return p.cmd.Wait() }

--- a/projects/agent_platform/fc-agentd/internal/reconcile/reconcile.go
+++ b/projects/agent_platform/fc-agentd/internal/reconcile/reconcile.go
@@ -12,6 +12,7 @@ import (
 	"encoding/json"
 	"log/slog"
 	"net/http"
+	"sync/atomic"
 	"time"
 
 	"go.opentelemetry.io/otel"
@@ -114,6 +115,7 @@ type Loop struct {
 	live    map[string]substrate.Handle   // threadID -> live microVM handle
 	control map[string]context.CancelFunc // threadID -> cancel its control server
 	idle    chan idleEvent                // guest idle boundaries, handled on the loop goroutine
+	died    chan diedEvent                // guests whose control channel dropped without completing
 }
 
 // idleEvent is a guest's quiescent idle-boundary signal, delivered from a
@@ -122,6 +124,18 @@ type Loop struct {
 type idleEvent struct {
 	threadID string
 	wake     vsockproto.WakeCondition
+}
+
+// diedEvent signals that a guest's control channel closed before the run
+// completed: a panic, OOM, or any ungraceful guest exit drops the vsock
+// connection, which ends control.Serve. It is delivered from the control-server
+// goroutine to the loop goroutine so the thread is reaped without racing the
+// loop's live/control maps. A clean Done or an intentional teardown (idle
+// snapshot, reclaim, shutdown) never produces one.
+type diedEvent struct {
+	threadID      string
+	discordThread string
+	progressURL   string
 }
 
 // Run ticks until ctx is cancelled. It returns nil on graceful shutdown.
@@ -138,6 +152,9 @@ func (l *Loop) Run(ctx context.Context) error {
 	}
 	if l.idle == nil {
 		l.idle = make(chan idleEvent, 32)
+	}
+	if l.died == nil {
+		l.died = make(chan diedEvent, 32)
 	}
 	interval := l.Interval
 	if interval <= 0 {
@@ -165,6 +182,8 @@ func (l *Loop) Run(ctx context.Context) error {
 			l.reconcileOnce(ctx, log)
 		case ev := <-l.idle:
 			l.snapshotIdle(ctx, log, ev)
+		case ev := <-l.died:
+			l.reapDied(ctx, log, ev)
 		}
 	}
 }
@@ -201,6 +220,45 @@ func (l *Loop) snapshotIdle(ctx context.Context, log *slog.Logger, ev idleEvent)
 		delete(l.control, ev.threadID)
 	}
 	log.Info("reconcile: thread idled and snapshotted", "thread", ev.threadID, "snapshot", ref.ID, "size", ref.SizeBytes)
+}
+
+// reapDied fails and tears down a thread whose guest dropped its control channel
+// without completing (panic / OOM / ungraceful exit). It runs on the loop
+// goroutine, so live and control are safe to touch. SetState(FAILED) hands the
+// thread to reclaimFailed, which deletes the bundle + row (and releases the CoW
+// device) after the retention window. It is gated on a live handle: a thread
+// that already idled, completed, or was reclaimed has none, so a stale death
+// signal is a no-op. The Discord notifications turn a silent stuck thread (the
+// build counter frozen forever) into a visible failure the user can retry.
+func (l *Loop) reapDied(ctx context.Context, log *slog.Logger, ev diedEvent) {
+	h, ok := l.live[ev.threadID]
+	if !ok {
+		return
+	}
+	log.Warn("reconcile: guest control channel closed before completion; marking FAILED", "thread", ev.threadID)
+	if err := l.Registry.SetState(ctx, ev.threadID, substrate.StateFailed); err != nil {
+		log.Error("reconcile: mark failed on guest death", "thread", ev.threadID, "err", err)
+	}
+	// Flip the live build message out of its spinning state and tell the thread it
+	// failed, so the user is not left watching a frozen counter. postProgressDone
+	// is a best-effort HTTP call with its own timeout; run it off the loop
+	// goroutine so a slow monolith never stalls reconciliation.
+	go postProgressDone(context.WithoutCancel(ctx), log, ev.progressURL, ev.discordThread)
+	if ev.discordThread != "" {
+		if err := l.Registry.EnqueueDiscordOutbox(ctx, ev.discordThread, "Build failed: the agent stopped before producing an artifact."); err != nil {
+			log.Error("reconcile: enqueue discord outbox on guest death", "thread", ev.threadID, "err", err)
+		}
+	}
+	// Release the dead VM handle (reaps the Firecracker child) and stop its control
+	// server; reclaimFailed handles the on-disk teardown after the retention window.
+	if err := l.Executor.Release(ctx, h); err != nil {
+		log.Debug("reconcile: release dead vm", "thread", ev.threadID, "err", err)
+	}
+	delete(l.live, ev.threadID)
+	if cancel, ok := l.control[ev.threadID]; ok {
+		cancel()
+		delete(l.control, ev.threadID)
+	}
 }
 
 func (l *Loop) reconcileOnce(ctx context.Context, log *slog.Logger) {
@@ -300,6 +358,9 @@ func (l *Loop) startControl(ctx context.Context, log *slog.Logger, t store.Threa
 	// (same one the guest streams to); captured here so OnDone can close the
 	// message even when the guest could not (see postProgressDone).
 	progressURL := threadEnv["PROGRESS_PUBLISH_URL"]
+	// doneFired distinguishes a clean completion from an ungraceful guest death:
+	// both end control.Serve, but only a death should reap the thread as FAILED.
+	var doneFired atomic.Bool
 	// Forward the guest's vsock egress to the secret-free sidecar (ADR 023).
 	if l.EgressSidecar != "" {
 		go func() {
@@ -318,6 +379,7 @@ func (l *Loop) startControl(ctx context.Context, log *slog.Logger, t store.Threa
 			}
 		},
 		OnDone: func(threadID, status, result string) {
+			doneFired.Store(true)
 			log.Info("reconcile: thread harness done", "thread", threadID, "status", status, "result", result)
 			ctx := context.WithoutCancel(cctx)
 			if err := l.Registry.SetState(ctx, threadID, substrate.StateCompleted); err != nil {
@@ -345,6 +407,21 @@ func (l *Loop) startControl(ctx context.Context, log *slog.Logger, t store.Threa
 	go func() {
 		if err := control.Serve(cctx, log, uds, assign, handlers); err != nil && cctx.Err() == nil {
 			log.Warn("reconcile: control server exited", "thread", t.ThreadID, "err", err)
+		}
+		// control.Serve returned. If the thread was neither intentionally torn down
+		// (cctx cancelled by idle-snapshot / reclaim / shutdown) nor cleanly done,
+		// the guest died mid-run: a panic / OOM / ungraceful exit dropped the vsock
+		// connection. Nothing else reaps a RUNNING thread whose VM is gone (gc only
+		// touches IDLE; reclaim only touches terminal states), so it would strand
+		// until the next daemon restart. Hand off to the loop goroutine to fail and
+		// reclaim it. A late signal after an intentional teardown is filtered by
+		// reapDied's live-handle check.
+		if cctx.Err() != nil || doneFired.Load() {
+			return
+		}
+		select {
+		case l.died <- diedEvent{threadID: t.ThreadID, discordThread: t.DiscordThread, progressURL: progressURL}:
+		case <-ctx.Done():
 		}
 	}()
 }

--- a/projects/agent_platform/fc-agentd/internal/reconcile/reconcile_test.go
+++ b/projects/agent_platform/fc-agentd/internal/reconcile/reconcile_test.go
@@ -329,6 +329,52 @@ func TestReconcileSnapshotsOnIdle(t *testing.T) {
 	}
 }
 
+// TestReconcileReapsDiedGuest covers the host-side death reaper: when a guest's
+// control channel drops without a clean Done (a panic / OOM / ungraceful exit),
+// the loop marks the thread FAILED, releases the dead VM, and posts a failure to
+// the Discord thread instead of leaving the build counter frozen forever.
+func TestReconcileReapsDiedGuest(t *testing.T) {
+	reg := newFakeRegistry(store.Thread{ThreadID: "t1", State: substrate.StatePending, Node: "node-4", DiscordThread: "d-123"})
+	ex := &fakeExec{}
+	l := newLoop(reg, ex)
+	ctx := context.Background()
+	// Claim it so it is live + RUNNING.
+	l.reconcileOnce(ctx, testLogger())
+	if l.LiveThreads() != 1 || reg.state("t1") != substrate.StateRunning {
+		t.Fatalf("precondition: want 1 live RUNNING thread, got live=%d state=%q", l.LiveThreads(), reg.state("t1"))
+	}
+
+	// Its guest drops the control channel without completing.
+	l.reapDied(ctx, testLogger(), diedEvent{threadID: "t1", discordThread: "d-123"})
+
+	if reg.state("t1") != substrate.StateFailed {
+		t.Fatalf("state = %q, want FAILED", reg.state("t1"))
+	}
+	if l.LiveThreads() != 0 {
+		t.Fatalf("live = %d, want 0 (dead VM released)", l.LiveThreads())
+	}
+	if ex.releases != 1 {
+		t.Fatalf("releases = %d, want 1", ex.releases)
+	}
+	if len(reg.outbox) != 1 || reg.outbox[0].channelID != "d-123" {
+		t.Fatalf("outbox = %+v, want one failure message to d-123", reg.outbox)
+	}
+}
+
+// TestReconcileReapDiedIgnoresStaleSignal proves the live-handle gate: a death
+// signal for a thread with no live handle (already idled, completed, or
+// reclaimed) is a no-op, so a late signal never double-fails a thread or spams
+// Discord.
+func TestReconcileReapDiedIgnoresStaleSignal(t *testing.T) {
+	reg := newFakeRegistry()
+	ex := &fakeExec{}
+	l := newLoop(reg, ex)
+	l.reapDied(context.Background(), testLogger(), diedEvent{threadID: "ghost", discordThread: "d-x"})
+	if ex.releases != 0 || len(reg.outbox) != 0 {
+		t.Fatalf("reap of unknown thread should be a no-op: releases=%d outbox=%d", ex.releases, len(reg.outbox))
+	}
+}
+
 // With MaxClaimAttempts=1 a single launch failure exhausts the budget on the
 // first attempt, so the thread is marked FAILED immediately (the pre-retry
 // behaviour, preserved for genuinely fail-fast configs).


### PR DESCRIPTION
## Problem

Follow-up to #2933. While diagnosing a goosecracker thread that went silent (build counter frozen, no artifact), we found a class of stuck threads the daemon never recovers: a `RUNNING` thread whose microVM dies **ungracefully** (guest kernel panic, OOM, or any exit that drops the vsock control channel without a clean `Done`).

Nothing transitions such a thread:
- `gcIdleExpired` only reaps `IDLE` threads.
- `reclaimCompleted` / `reclaimFailed` only touch terminal states.
- `adoptOrphanedRunning` only runs after a daemon restart.

So a dead-VM `RUNNING` row sits until the next daemon restart, and the Discord thread is left spinning forever with no failure message.

## Fix

`control.Serve` already returns when the guest disconnects, so use that as the death signal. When it returns while the thread was **neither** cleanly done (`doneFired`) **nor** intentionally torn down (`cctx` cancelled by idle-snapshot / reclaim / shutdown), the guest died mid-run. The serve goroutine hands the thread to the loop goroutine via a new `died` channel (mirroring the existing `idle` channel), and `reapDied`:

1. marks the thread `FAILED` (feeds the existing `reclaimFailed` CoW-device teardown),
2. posts a progress-done marker + `"Build failed"` message to the Discord thread, so the user sees a terminal state instead of a frozen counter,
3. releases the dead VM and stops its control server.

`reapDied` is gated on a live handle, so a late signal after an intentional teardown (idle / completion / reclaim) is a no-op. Any idle-then-die race resolves to a single outcome via that gate.

Also: `execProcess.Kill` now always reaps the child (`cmd.Wait` even when `Kill` reports it already exited), so a crashed VM's process does not linger as a zombie.

## Scope

This is the Mode B (host-side VM-death) reaper. It does **not** cover the goose-wedged-but-VM-alive hang (Mode A) — the only true signal there is goose's progress stream, which never reaches the daemon; that needs a harness heartbeat (the protocol already has `KindHeartbeat`) and is a deliberate follow-up.

## Test plan

- [x] `go build ./projects/agent_platform/fc-agentd/...`
- [x] `go vet` clean
- [x] New unit tests: `TestReconcileReapsDiedGuest` (death -> FAILED + release + Discord failure message), `TestReconcileReapDiedIgnoresStaleSignal` (no live handle -> no-op)
- [ ] CI: `bazel test //projects/agent_platform/fc-agentd/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)