### PR TITLE
fix(semgrep): GHCR creds for private semgrep pulls + argocd OCI repo-cred

### DIFF
--- a/projects/agent_platform/semgrep-scand/chart/Chart.yaml
+++ b/projects/agent_platform/semgrep-scand/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: semgrep-scand
 description: Node-affine semgrep scanner daemon that boots a fresh semgrep-guest microVM per scan and serves HTTP POST /scan + GET /healthz
 type: application
-version: 0.2.0
+version: 0.3.0

--- a/projects/agent_platform/semgrep-scand/chart/templates/deployment.yaml
+++ b/projects/agent_platform/semgrep-scand/chart/templates/deployment.yaml
@@ -27,6 +27,10 @@ spec:
       {{- end }}
     spec:
       serviceAccountName: {{ include "semgrep-scand.serviceAccountName" . }}
+      {{- if .Values.imagePullSecret.enabled }}
+      imagePullSecrets:
+        - name: {{ .Values.imagePullSecret.name }}
+      {{- end }}
       priorityClassName: {{ .Values.priorityClassName }}
       nodeSelector:
         {{- toYaml .Values.nodeSelector | nindent 8 }}
@@ -63,6 +67,12 @@ spec:
               value: {{ .Values.firecracker.baseRootfsPath | quote }}
             - name: ROOTFS_SIZE
               value: {{ .Values.rootfsBuilder.rootfsSize | quote }}
+            {{- if .Values.imagePullSecret.enabled }}
+            # crane reads $DOCKER_CONFIG/config.json to pull the private
+            # semgrep-guest image (proprietary engine + Pro rules).
+            - name: DOCKER_CONFIG
+              value: /ghcr
+            {{- end }}
           volumeMounts:
             - name: nvme
               mountPath: {{ .Values.firecracker.nvmeRoot }}
@@ -71,6 +81,11 @@ spec:
               readOnly: true
             - name: rootfs-builder-work
               mountPath: /work
+            {{- if .Values.imagePullSecret.enabled }}
+            - name: ghcr-creds
+              mountPath: /ghcr
+              readOnly: true
+            {{- end }}
           resources:
             requests:
               cpu: 500m
@@ -196,5 +211,13 @@ spec:
             name: {{ include "semgrep-scand.fullname" . }}-rootfs-builder
         - name: rootfs-builder-work
           emptyDir: {}
+        {{- if .Values.imagePullSecret.enabled }}
+        - name: ghcr-creds
+          secret:
+            secretName: {{ .Values.imagePullSecret.name }}
+            items:
+              - key: .dockerconfigjson
+                path: config.json
+        {{- end }}
         {{- end }}
       {{- end }}

--- a/projects/agent_platform/semgrep-scand/chart/templates/image-pull-secret.yaml
+++ b/projects/agent_platform/semgrep-scand/chart/templates/image-pull-secret.yaml
@@ -1,0 +1,20 @@
+{{- /*
+GHCR pull credentials (dockerconfigjson) synced from 1Password. Used two ways:
+  - the pod imagePullSecrets, so the kubelet can pull the private semgrep-scand
+    daemon image;
+  - mounted into the rootfs-builder initContainer as $DOCKER_CONFIG/config.json,
+    so crane can export the private semgrep-guest image (it embeds the
+    proprietary semgrep engine + Pro rules and must stay private).
+*/}}
+{{- if and .Values.imagePullSecret.enabled .Values.imagePullSecret.create }}
+apiVersion: onepassword.com/v1
+kind: OnePasswordItem
+type: kubernetes.io/dockerconfigjson
+metadata:
+  name: {{ .Values.imagePullSecret.name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "semgrep-scand.labels" . | nindent 4 }}
+spec:
+  itemPath: {{ .Values.imagePullSecret.onepassword.itemPath | quote }}
+{{- end }}

--- a/projects/agent_platform/semgrep-scand/chart/values.yaml
+++ b/projects/agent_platform/semgrep-scand/chart/values.yaml
@@ -26,6 +26,17 @@ rootfsBuilder:
   # ~3G guest with headroom.
   rootfsSize: 4G
 
+# Private GHCR pull credentials. The semgrep-scand daemon image and (via the
+# rootfs-builder's crane export) the proprietary semgrep-guest image are private
+# GHCR packages, so both the kubelet and crane authenticate with a dockerconfigjson
+# synced from the cluster's ghcr-read-permissions 1Password item.
+imagePullSecret:
+  enabled: false
+  create: true
+  name: ghcr-imagepull-secret
+  onepassword:
+    itemPath: "vaults/k8s-homelab/items/ghcr-read-permissions"
+
 replicas: 1
 
 podAnnotations: {}

--- a/projects/agent_platform/semgrep-scand/deploy/application.yaml
+++ b/projects/agent_platform/semgrep-scand/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tags pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: semgrep-scand
-      targetRevision: 0.2.0
+      targetRevision: 0.3.0
       helm:
         valueFiles:
           - $values/projects/agent_platform/semgrep-scand/deploy/values.yaml

--- a/projects/agent_platform/semgrep-scand/deploy/values.yaml
+++ b/projects/agent_platform/semgrep-scand/deploy/values.yaml
@@ -16,3 +16,9 @@ firecracker:
   scanRoot: /disks/nvme-02/semgrep-scand
   rootfsProvisioner: devmapper
   thinPool: devpool
+
+# The daemon image (private) and the proprietary semgrep-guest image (crane-pulled
+# by the rootfs-builder) need GHCR creds in-cluster; charts stay private too via
+# the ArgoCD repo-cred added in projects/platform/argocd.
+imagePullSecret:
+  enabled: true

--- a/projects/platform/argocd/templates/ghcr-repo-creds.yaml
+++ b/projects/platform/argocd/templates/ghcr-repo-creds.yaml
@@ -1,0 +1,21 @@
+{{- /*
+Authenticate ArgoCD's repo-server to pull private OCI Helm charts under
+ghcr.io/jomcgi/homelab. Without this, ArgoCD pulls charts anonymously, so every
+new (private-by-default) chart package needs a manual public-visibility flip
+(the recurring toil that blocked monolith-public and semgrep-scand).
+
+The 1Password item argocd-ghcr-repo-creds carries url/type/enableOCI/username/
+password as fields. The 1Password operator syncs them into a Secret and
+propagates this OnePasswordItem's labels onto it, so the synced Secret carries
+the argocd.argoproj.io/secret-type=repo-creds label that ArgoCD auto-discovers
+as a credential template matching the url prefix. Charts can now stay private.
+*/}}
+apiVersion: onepassword.com/v1
+kind: OnePasswordItem
+metadata:
+  name: argocd-ghcr-repo-creds
+  namespace: {{ .Release.Namespace }}
+  labels:
+    argocd.argoproj.io/secret-type: repo-creds
+spec:
+  itemPath: "vaults/k8s-homelab/items/argocd-ghcr-repo-creds"


### PR DESCRIPTION
Follow-up to #2942. The semgrep-scand rollout 401'd because its packages are private-by-default and **cannot be made public**, the guest image embeds the proprietary semgrep engine + Pro rules. Three private pulls, all now authenticated in-cluster:

1. **ArgoCD repo-server pulling the chart** (`oci://.../charts/semgrep-scand`), the actual 401 that stalled the sync. Fixed **cluster-wide**: a `repo-creds` OnePasswordItem for `ghcr.io/jomcgi/homelab` in the argocd namespace (label-propagated by the 1Password operator, ArgoCD auto-discovers it). New private chart packages no longer need a manual public-visibility flip.
2. **kubelet pulling the daemon image**: pod `imagePullSecrets`.
3. **crane exporting the proprietary guest image** in the rootfs-builder: a `DOCKER_CONFIG` mount of the dockerconfigjson.

Image creds source the existing `ghcr-read-permissions` 1Password item; the ArgoCD repo-cred sources a new `argocd-ghcr-repo-creds` item (url/type/enableOCI/username/password).

semgrep-scand chart `0.2.0 -> 0.3.0`; argocd app is git-HEAD sourced (no bump). Both charts `helm template`-verified (creds render when enabled, absent when disabled).

**Requires:** the `argocd-ghcr-repo-creds` 1Password item must exist for ArgoCD to authenticate the chart pull.

🤖 Generated with [Claude Code](https://claude.com/claude-code)