### PR TITLE
fix(semgrep): set PATH+locale in guest init (raw FC boot has no env)

### DIFF
--- a/projects/agent_platform/semgrep-guest-init/cmd/main.go
+++ b/projects/agent_platform/semgrep-guest-init/cmd/main.go
@@ -50,6 +50,18 @@ func run(logger *slog.Logger) error {
 	// Raw FC boot leaves loopback DOWN; bring it up before anything binds 127.0.0.1.
 	bringUpLoopback(logger)
 
+	// A raw Firecracker boot gives PID 1 no environment, so PATH is empty and every
+	// execvp fails with ENOENT. semgrep-core shells out to `uname` to build its TLS
+	// authenticator at startup, so an unset PATH crashes it even though uname is
+	// installed. Set a standard PATH plus a UTF-8 locale for pysemgrep.
+	for k, v := range map[string]string{
+		"PATH":   "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+		"LANG":   "C.UTF-8",
+		"LC_ALL": "C.UTF-8",
+	} {
+		_ = os.Setenv(k, v)
+	}
+
 	if err := setupOfflineEnv(logger); err != nil {
 		return err
 	}

--- a/projects/agent_platform/semgrep-scand/chart/Chart.yaml
+++ b/projects/agent_platform/semgrep-scand/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: semgrep-scand
 description: Node-affine semgrep scanner daemon that boots a fresh semgrep-guest microVM per scan and serves HTTP POST /scan + GET /healthz
 type: application
-version: 0.3.2
+version: 0.3.3

--- a/projects/agent_platform/semgrep-scand/deploy/application.yaml
+++ b/projects/agent_platform/semgrep-scand/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tags pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: semgrep-scand
-      targetRevision: 0.3.2
+      targetRevision: 0.3.3
       helm:
         valueFiles:
           - $values/projects/agent_platform/semgrep-scand/deploy/values.yaml


### PR DESCRIPTION
Third first-boot fix. The guest still crashed on `uname` after #2945 added coreutils, because a raw Firecracker boot gives PID 1 no environment: PATH was empty, so semgrep-core's `execvp('uname')` (building its TLS authenticator at startup) returned ENOENT even though /usr/bin/uname is installed. Verified via crane that uname is present, so the fix is to set PATH (and a UTF-8 locale for pysemgrep) in semgrep-guest-init before it spawns semgrep lsp.

Validated on the new on-node guest-boot smoke harness (no full rollout needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)