### PR TITLE
perf(semgrep-scand): warm-scan phase timing + 200ms prime

### DIFF
--- a/projects/agent_platform/semgrep-scand/chart/Chart.yaml
+++ b/projects/agent_platform/semgrep-scand/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: semgrep-scand
 description: Node-affine semgrep scanner daemon that boots a fresh semgrep-guest microVM per scan and serves HTTP POST /scan + GET /healthz
 type: application
-version: 0.4.0
+version: 0.4.1

--- a/projects/agent_platform/semgrep-scand/deploy/application.yaml
+++ b/projects/agent_platform/semgrep-scand/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tags pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: semgrep-scand
-      targetRevision: 0.4.0
+      targetRevision: 0.4.1
       helm:
         valueFiles:
           - $values/projects/agent_platform/semgrep-scand/deploy/values.yaml

--- a/projects/agent_platform/semgrep-scand/internal/config/config.go
+++ b/projects/agent_platform/semgrep-scand/internal/config/config.go
@@ -97,7 +97,7 @@ func Load() (Config, error) {
 		Arch:              os.Getenv("SEMGREP_SCAND_ARCH"),
 		WarmBase:          boolDefault("SEMGREP_SCAND_WARM_BASE", true),
 		BaseKey:           getenvDefault("SEMGREP_SCAND_BASE_KEY", "semgrep-guest"),
-		RestorePrime:      300 * time.Millisecond,
+		RestorePrime:      200 * time.Millisecond,
 		CanonicalVsockDir: getenvDefault("SEMGREP_SCAND_CANONICAL_VSOCK_DIR", "/disks/nvme-02/semgrep-scand-vsock"),
 		ScanTimeout:       60 * time.Second,
 		BootReadyTimeout:  30 * time.Second,

--- a/projects/agent_platform/semgrep-scand/internal/config/config_test.go
+++ b/projects/agent_platform/semgrep-scand/internal/config/config_test.go
@@ -48,8 +48,8 @@ func TestLoadDefaults(t *testing.T) {
 	if c.CanonicalVsockDir != "/disks/nvme-02/semgrep-scand-vsock" {
 		t.Errorf("CanonicalVsockDir = %q, want /disks/nvme-02/semgrep-scand-vsock", c.CanonicalVsockDir)
 	}
-	if c.RestorePrime != 300*time.Millisecond {
-		t.Errorf("RestorePrime = %s, want 300ms", c.RestorePrime)
+	if c.RestorePrime != 200*time.Millisecond {
+		t.Errorf("RestorePrime = %s, want 200ms", c.RestorePrime)
 	}
 	if c.ScanTimeout != 60*time.Second {
 		t.Errorf("ScanTimeout = %s, want 60s", c.ScanTimeout)

--- a/projects/agent_platform/semgrep-scand/internal/scanner/scanner.go
+++ b/projects/agent_platform/semgrep-scand/internal/scanner/scanner.go
@@ -113,7 +113,7 @@ func New(driver vmDriver, transport guestTransport, cfg Config, logger *slog.Log
 		logger = slog.Default()
 	}
 	if cfg.RestorePrime <= 0 {
-		cfg.RestorePrime = 300 * time.Millisecond
+		cfg.RestorePrime = 200 * time.Millisecond
 	}
 	var sem *semaphore.Weighted
 	if cfg.MaxConcurrent > 0 {
@@ -257,23 +257,28 @@ func (s *Scanner) Scan(ctx context.Context, files []vsockproto.ScanFile) (vsockp
 // RX-queue race, and runs the scan WITHOUT a readiness wait (a restored guest
 // resumes past its readiness announce, so it never re-sends a Hello).
 func (s *Scanner) scanWarm(ctx context.Context, base substrate.SnapshotRef, files []vsockproto.ScanFile) (vsockproto.ScanResult, error) {
+	tRestore := time.Now()
 	h, err := s.driver.Claim(ctx, substrate.ClaimSpec{Arch: s.cfg.Arch, BaseSnapshotRef: base})
 	if err != nil {
 		return vsockproto.ScanResult{}, &GuestUnavailableError{Err: fmt.Errorf("restore guest: %w", err)}
 	}
-	defer s.discard(h)
+	restoreMs := time.Since(tRestore).Milliseconds()
+	defer func() { s.discard(h) }()
 
 	uds := s.driver.VsockUDSPath(h.ThreadID)
 
 	// Prime: the first post-restore vsock connection hits Firecracker's RX-queue
 	// race and is reset or hung. Send a throwaway empty scan with a short deadline to
 	// absorb it; whether it EOFs fast or times out, the next connection is clean.
+	tPrime := time.Now()
 	primeCtx, primeCancel := context.WithTimeout(ctx, s.cfg.RestorePrime)
 	_, _ = s.transport.Scan(primeCtx, uds, vsockproto.ScanRequest{})
 	primeCancel()
+	primeMs := time.Since(tPrime).Milliseconds()
 
 	scanCtx, cancelScan := context.WithTimeout(ctx, s.cfg.ScanTimeout)
 	defer cancelScan()
+	tScan := time.Now()
 	res, err := s.transport.Scan(scanCtx, uds, vsockproto.ScanRequest{Files: files})
 	if err != nil {
 		// Unlike the cold path, a restored guest never proved it warmed (there is no
@@ -282,6 +287,8 @@ func (s *Scanner) scanWarm(ctx context.Context, base substrate.SnapshotRef, file
 		// invalidates the base and retries on a cold boot rather than wedging.
 		return vsockproto.ScanResult{}, &GuestUnavailableError{Err: fmt.Errorf("warm scan: %w", err)}
 	}
+	s.logger.Info("warm scan timing", "restore_ms", restoreMs, "prime_ms", primeMs,
+		"scan_ms", time.Since(tScan).Milliseconds(), "files", len(files), "findings", len(res.Findings))
 	return res, nil
 }
 


### PR DESCRIPTION
Adds per-phase timing logs to the warm restore path (restore/prime/scan ms) to make the latency budget observable, and trims the post-restore vsock prime 300ms->200ms (validated). Daemon-only, no behavior change beyond the prime tuning; cold-boot fallback unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)