### PR TITLE
perf(semgrep-guest): return findings immediately, skip the 350ms settle

### DIFF
--- a/projects/agent_platform/semgrep-guest-init/internal/lspdriver/lspdriver.go
+++ b/projects/agent_platform/semgrep-guest-init/internal/lspdriver/lspdriver.go
@@ -347,52 +347,50 @@ func (d *Driver) handleProgress(raw json.RawMessage) {
 	_ = json.Unmarshal(raw, &p)
 }
 
-// scanSettleQuiet is how long waitDiag waits with no further publishDiagnostics for
-// a URI before treating its diagnostics as final. semgrep lsp may publish an empty
-// set (clearing) and then the real findings a few tens of ms later, so the quiet
-// window lets the real publish overwrite the empty one. Tunable: the observed
-// empty->real gap is ~50ms warm; this keeps a comfortable margin under load.
+// scanSettleQuiet is how long waitDiag waits for a findings publish after seeing an
+// empty one before concluding a scan genuinely found nothing. It only gates the
+// zero-finding case (see waitDiag); a findings publish returns immediately. The
+// observed empty->real gap is ~50ms warm; this keeps a comfortable margin under load.
 const scanSettleQuiet = 350 * time.Millisecond
 
-// waitDiag waits for uri's scan to publish and settle, then returns its latest
-// diagnostics. It first blocks until at least one publishDiagnostics for uri has
-// arrived (the scan computed; warm scans take ~1s), then settles until no further
-// publish lands for scanSettleQuiet so a real-findings publish overwrites an
-// earlier empty clear. Bounded by ctx (the per-scan timeout); on cancellation it
+// waitDiag waits for uri's scan result. A semgrep LSP publishes an empty set on
+// didOpen (clearing) and then, once compute finishes, the real findings, in that
+// order and exactly once per scan. So a NON-EMPTY publish is always the final
+// result: waitDiag returns on it immediately, which is the common
+// security-relevant case and removes the settle window from the hot path. Only when
+// the latest publish is EMPTY does it settle a quiet window, since an empty clear
+// and a genuine zero-finding result are indistinguishable by content and only time
+// tells them apart. Bounded by ctx (the per-scan timeout); on cancellation it
 // returns whatever was collected so a slow file degrades rather than errors.
 func (d *Driver) waitDiag(ctx context.Context, uri string) []lspDiagnostic {
-	// Phase 1: block until the first publish for uri arrives.
 	for {
 		d.diagMu.Lock()
-		_, seen := d.latestDiag[uri]
+		diags, seen := d.latestDiag[uri]
 		ch := d.diagSignalLocked(uri)
 		d.diagMu.Unlock()
-		if seen {
-			break
+
+		if seen && len(diags) > 0 {
+			return diags // findings published; final, return at once
 		}
-		select {
-		case <-ctx.Done():
-			return d.snapshotDiag(uri)
-		case <-ch:
-		}
-	}
-	// Phase 2: settle until no new publish for scanSettleQuiet.
-	timer := time.NewTimer(scanSettleQuiet)
-	defer timer.Stop()
-	for {
-		d.diagMu.Lock()
-		ch := d.diagSignalLocked(uri)
-		d.diagMu.Unlock()
-		select {
-		case <-ctx.Done():
-			return d.snapshotDiag(uri)
-		case <-ch:
-			if !timer.Stop() {
-				<-timer.C
+		if !seen {
+			// No publish yet: wait for the first one, then re-evaluate.
+			select {
+			case <-ctx.Done():
+				return d.snapshotDiag(uri)
+			case <-ch:
 			}
-			timer.Reset(scanSettleQuiet)
-		case <-timer.C:
+			continue
+		}
+		// Seen, but empty: settle for a findings publish that may still be coming.
+		timer := time.NewTimer(scanSettleQuiet)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
 			return d.snapshotDiag(uri)
+		case <-ch:
+			timer.Stop() // a new publish arrived; loop to check if it has findings
+		case <-timer.C:
+			return d.snapshotDiag(uri) // quiet window elapsed: a genuine empty result
 		}
 	}
 }

--- a/projects/agent_platform/semgrep-guest-init/internal/lspdriver/lspdriver_test.go
+++ b/projects/agent_platform/semgrep-guest-init/internal/lspdriver/lspdriver_test.go
@@ -81,6 +81,43 @@ func fakeLSP(t *testing.T, clientToServer io.Reader, serverToClient io.Writer, d
 	}()
 }
 
+// TestScanReturnsFindingsWithoutFullSettle verifies the hot-path optimisation: when
+// a scan publishes findings, waitDiag returns on that publish instead of waiting out
+// the settle window. The fake emits the empty clear then the findings back to back,
+// so a correct implementation returns in well under scanSettleQuiet.
+func TestScanReturnsFindingsWithoutFullSettle(t *testing.T) {
+	var ws string
+	diagFor := func(uri string) []lspDiagnostic {
+		if uri != pathToURI(filepath.Join(ws, "a.py")) {
+			return nil
+		}
+		return []lspDiagnostic{{Severity: 1, Code: json.RawMessage(`"r1"`), Message: "bad"}}
+	}
+	var d *Driver
+	d, ws = newTestDriver(t, diagFor)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := d.Initialize(ctx, "/etc/semgrep/rules", 1); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	if err := d.WaitReady(ctx); err != nil {
+		t.Fatalf("WaitReady: %v", err)
+	}
+
+	start := time.Now()
+	findings, err := d.Scan(ctx, []vsockproto.ScanFile{{Path: "a.py", Content: "bad()\n"}})
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(findings))
+	}
+	if elapsed >= scanSettleQuiet {
+		t.Errorf("scan took %s; findings should return without the %s settle", elapsed, scanSettleQuiet)
+	}
+}
+
 func newTestDriver(t *testing.T, diagFor func(uri string) []lspDiagnostic) (*Driver, string) {
 	t.Helper()
 	c2sR, c2sW := io.Pipe()

--- a/projects/agent_platform/semgrep-scand/chart/Chart.yaml
+++ b/projects/agent_platform/semgrep-scand/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: semgrep-scand
 description: Node-affine semgrep scanner daemon that boots a fresh semgrep-guest microVM per scan and serves HTTP POST /scan + GET /healthz
 type: application
-version: 0.4.1
+version: 0.4.2

--- a/projects/agent_platform/semgrep-scand/deploy/application.yaml
+++ b/projects/agent_platform/semgrep-scand/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tags pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: semgrep-scand
-      targetRevision: 0.4.1
+      targetRevision: 0.4.2
       helm:
         valueFiles:
           - $values/projects/agent_platform/semgrep-scand/deploy/values.yaml


### PR DESCRIPTION
The warm-scan leg is ~1.93s (measured via the new phase-timing logs); ~350ms of that is waitDiag's quiet-settle window, paid even when findings are already published. Since a semgrep LSP publishes findings exactly once per scan (after the empty clear), a non-empty publish is final and returns immediately. Only zero-finding scans still settle. Removes ~350ms from every findings-present scan. Unit-tested (new timing assertion + existing empty->real test) and -race clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)