### PR TITLE
perf(semgrep-scand): 8 vCPUs per guest (burst experiment)

### DIFF
--- a/projects/agent_platform/semgrep-scand/chart/Chart.yaml
+++ b/projects/agent_platform/semgrep-scand/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: semgrep-scand
 description: Node-affine semgrep scanner daemon that boots a fresh semgrep-guest microVM per scan and serves HTTP POST /scan + GET /healthz
 type: application
-version: 0.4.2
+version: 0.4.3

--- a/projects/agent_platform/semgrep-scand/deploy/application.yaml
+++ b/projects/agent_platform/semgrep-scand/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tags pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: semgrep-scand
-      targetRevision: 0.4.2
+      targetRevision: 0.4.3
       helm:
         valueFiles:
           - $values/projects/agent_platform/semgrep-scand/deploy/values.yaml

--- a/projects/agent_platform/semgrep-scand/deploy/values.yaml
+++ b/projects/agent_platform/semgrep-scand/deploy/values.yaml
@@ -12,6 +12,15 @@
 node: node-4
 arch: amd64
 
+# Give each guest 8 vCPUs (node-4 is a 16-core node sitting near-idle, and the pod
+# has no CPU limit, so the guest's vCPU threads burst onto the idle cores). semgrep
+# runs jobs=NumCPU, so more vCPUs = more rule parallelism per scan. maxConcurrent is
+# halved to 2 so the worst case (8 * 2 = 16 vCPU-threads) does not oversubscribe the
+# node's 16 cores under concurrent scans.
+agent:
+  maxConcurrent: 2
+  guestVcpus: 8
+
 firecracker:
   enabled: true
   baseRootfsPath: /disks/nvme-02/semgrep-base/rootfs.ext4


### PR DESCRIPTION
node-4 is 16-core, ~2% used, pod has no CPU limit -> guest vCPU threads burst onto idle cores. Binding cap is the microVM vcpu_count (4), not throttling. Bump GuestVCPUs 4->8 so semgrep (jobs=NumCPU) uses more cores per scan; halve maxConcurrent to 2 to avoid oversubscribing 16 cores. Measurement experiment via the warm-scan timing logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)