### PR TITLE
perf(semgrep-scand): revert to 4 vCPUs (8-vCPU gave no speedup)

### DIFF
--- a/projects/agent_platform/semgrep-scand/chart/Chart.yaml
+++ b/projects/agent_platform/semgrep-scand/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: semgrep-scand
 description: Node-affine semgrep scanner daemon that boots a fresh semgrep-guest microVM per scan and serves HTTP POST /scan + GET /healthz
 type: application
-version: 0.4.3
+version: 0.4.4

--- a/projects/agent_platform/semgrep-scand/deploy/application.yaml
+++ b/projects/agent_platform/semgrep-scand/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tags pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: semgrep-scand
-      targetRevision: 0.4.3
+      targetRevision: 0.4.4
       helm:
         valueFiles:
           - $values/projects/agent_platform/semgrep-scand/deploy/values.yaml

--- a/projects/agent_platform/semgrep-scand/deploy/values.yaml
+++ b/projects/agent_platform/semgrep-scand/deploy/values.yaml
@@ -12,14 +12,11 @@
 node: node-4
 arch: amd64
 
-# Give each guest 8 vCPUs (node-4 is a 16-core node sitting near-idle, and the pod
-# has no CPU limit, so the guest's vCPU threads burst onto the idle cores). semgrep
-# runs jobs=NumCPU, so more vCPUs = more rule parallelism per scan. maxConcurrent is
-# halved to 2 so the worst case (8 * 2 = 16 vCPU-threads) does not oversubscribe the
-# node's 16 cores under concurrent scans.
-agent:
-  maxConcurrent: 2
-  guestVcpus: 8
+# Guest sizing uses the chart defaults (4 vCPUs, maxConcurrent 4). An 8-vCPU
+# experiment (PR #2955) showed NO speedup for a single small-file scan: the ~1.5s
+# scan leg is fixed per-scan cost (parse + applying ~1609 rules to one small AST),
+# not parallelisable work, so the extra cores sat idle. More vCPUs would only help
+# large files or parallel multi-file batches, which is not the common case here.
 
 firecracker:
   enabled: true


### PR DESCRIPTION
The 8-vCPU experiment (#2955) showed no improvement for single small-file scans (8 vCPU ~1611ms vs 4 vCPU ~1540ms). The scan is fixed per-scan cost, not parallelism-bound. Revert to 4 vCPUs / maxConcurrent 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)