### PR TITLE
perf(semgrep-guest): warm base snapshot with per-language primer (~3-4x faster first scan)

### DIFF
--- a/projects/agent_platform/semgrep-guest-init/cmd/BUILD
+++ b/projects/agent_platform/semgrep-guest-init/cmd/BUILD
@@ -10,6 +10,7 @@ go_library(
         "main.go",
         "mount_linux.go",
         "mount_other.go",
+        "primers.go",
     ],
     importpath = "github.com/jomcgi/homelab/projects/agent_platform/semgrep-guest-init/cmd",
     visibility = ["//visibility:private"],

--- a/projects/agent_platform/semgrep-guest-init/cmd/main.go
+++ b/projects/agent_platform/semgrep-guest-init/cmd/main.go
@@ -107,6 +107,13 @@ func run(logger *slog.Logger) error {
 	}
 	logger.Info("semgrep lsp warm; rules compiled")
 
+	// Warm the LSP with one realistic scan per supported language BEFORE announcing
+	// readiness, so the base snapshot (taken once the host sees our Hello) captures
+	// the per-process warmup the first real scan otherwise pays. Restored guests then
+	// scan their first file already warmed (~3-4x faster first scan). Best-effort: a
+	// prime failure is logged, not fatal (the guest still serves, just cold-first).
+	warmupPrime(ctx, driver, logger)
+
 	ln, err := scanserver.Listen(vsockproto.ScanPort)
 	if err != nil {
 		return err
@@ -154,6 +161,21 @@ func setupOfflineEnv(logger *slog.Logger) error {
 	}
 	logger.Info("offline semgrep env set", "home", guestHome)
 	return nil
+}
+
+// warmupPrime scans the per-language primer set (primers.go) once so the one-time
+// per-process warm-up is captured in the base snapshot. Bounded by
+// SEMGREP_PRIME_TIMEOUT; best-effort, a failure is logged not fatal.
+func warmupPrime(ctx context.Context, driver *lspdriver.Driver, logger *slog.Logger) {
+	start := time.Now()
+	pctx, cancel := context.WithTimeout(ctx, durationEnv("SEMGREP_PRIME_TIMEOUT", 45*time.Second))
+	defer cancel()
+	findings, err := driver.Scan(pctx, primerFiles)
+	if err != nil {
+		logger.Warn("warmup prime failed", "err", err, "took", time.Since(start))
+		return
+	}
+	logger.Info("warmup prime done", "languages", len(primerFiles), "primer_findings", len(findings), "took", time.Since(start))
 }
 
 // announceReady dials the host ControlPort and sends a Hello so the controller

--- a/projects/agent_platform/semgrep-guest-init/cmd/primers.go
+++ b/projects/agent_platform/semgrep-guest-init/cmd/primers.go
@@ -1,0 +1,99 @@
+package main
+
+import "github.com/jomcgi/homelab/projects/agent_platform/vsockproto"
+
+// primerFiles is one small but realistic source file per supported extension. They
+// are scanned once at base-build time (warmupPrime) BEFORE the snapshot is taken, so
+// the one-time, per-process warmup the first real scan otherwise pays (lazy parser
+// init per language, rule-matcher binding, OCaml runtime warmup) is captured in the
+// snapshot memfile. A restored guest then scans its first real file already warmed.
+//
+// The content only needs to exercise each language's parser and the common rule
+// paths (imports, a function/struct, a call, some control flow); it does not need to
+// trigger findings. The __primer__ name prefix avoids colliding with a real scan
+// path. Covers all extensions semgrep-guest-init recognises: .py .go .js .jsx .ts
+// .tsx .rs (the language parsers behind them: python, go, javascript, typescript,
+// rust).
+var primerFiles = []vsockproto.ScanFile{
+	{Path: "__primer__.py", Content: `import os
+import subprocess
+
+
+def run(cmd: str) -> int:
+    proc = subprocess.run(["echo", cmd], capture_output=True)
+    return proc.returncode
+
+
+class Worker:
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+    def path(self) -> str:
+        return os.path.join("/tmp", self.name)
+`},
+	{Path: "__primer__.go", Content: `package main
+
+import (
+	"fmt"
+	"strings"
+)
+
+type greeter struct{ prefix string }
+
+func (g greeter) greet(name string) string {
+	return fmt.Sprintf("%s %s", g.prefix, strings.TrimSpace(name))
+}
+
+func main() {
+	g := greeter{prefix: "hello"}
+	fmt.Println(g.greet("world"))
+}
+`},
+	{Path: "__primer__.js", Content: `const fs = require("fs");
+
+function load(path) {
+  const data = fs.readFileSync(path, "utf8");
+  return JSON.parse(data);
+}
+
+module.exports = { load };
+`},
+	{Path: "__primer__.jsx", Content: `import React from "react";
+
+export function Hello({ name }) {
+  const label = name || "world";
+  return <div className="hello">Hello {label}</div>;
+}
+`},
+	{Path: "__primer__.ts", Content: `interface User {
+  id: number;
+  name: string;
+}
+
+export function format(u: User): string {
+  return ` + "`${u.id}:${u.name}`" + `;
+}
+`},
+	{Path: "__primer__.tsx", Content: `import React from "react";
+
+type Props = { label: string; onClick: () => void };
+
+export const Button = ({ label, onClick }: Props) => (
+  <button onClick={onClick}>{label}</button>
+);
+`},
+	{Path: "__primer__.rs", Content: `use std::collections::HashMap;
+
+fn count(items: &[&str]) -> HashMap<String, u32> {
+    let mut m = HashMap::new();
+    for it in items {
+        *m.entry(it.to_string()).or_insert(0) += 1;
+    }
+    m
+}
+
+fn main() {
+    let _ = count(&["a", "b", "a"]);
+}
+`},
+}

--- a/projects/agent_platform/semgrep-scand/chart/Chart.yaml
+++ b/projects/agent_platform/semgrep-scand/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: semgrep-scand
 description: Node-affine semgrep scanner daemon that boots a fresh semgrep-guest microVM per scan and serves HTTP POST /scan + GET /healthz
 type: application
-version: 0.4.4
+version: 0.4.5

--- a/projects/agent_platform/semgrep-scand/deploy/application.yaml
+++ b/projects/agent_platform/semgrep-scand/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tags pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: semgrep-scand
-      targetRevision: 0.4.4
+      targetRevision: 0.4.5
       helm:
         valueFiles:
           - $values/projects/agent_platform/semgrep-scand/deploy/values.yaml

--- a/projects/agent_platform/semgrep-scand/internal/config/config.go
+++ b/projects/agent_platform/semgrep-scand/internal/config/config.go
@@ -100,7 +100,7 @@ func Load() (Config, error) {
 		RestorePrime:      200 * time.Millisecond,
 		CanonicalVsockDir: getenvDefault("SEMGREP_SCAND_CANONICAL_VSOCK_DIR", "/disks/nvme-02/semgrep-scand-vsock"),
 		ScanTimeout:       60 * time.Second,
-		BootReadyTimeout:  30 * time.Second,
+		BootReadyTimeout:  60 * time.Second,
 	}
 
 	if c.Node == "" {

--- a/projects/agent_platform/semgrep-scand/internal/config/config_test.go
+++ b/projects/agent_platform/semgrep-scand/internal/config/config_test.go
@@ -54,8 +54,8 @@ func TestLoadDefaults(t *testing.T) {
 	if c.ScanTimeout != 60*time.Second {
 		t.Errorf("ScanTimeout = %s, want 60s", c.ScanTimeout)
 	}
-	if c.BootReadyTimeout != 30*time.Second {
-		t.Errorf("BootReadyTimeout = %s, want 30s", c.BootReadyTimeout)
+	if c.BootReadyTimeout != 60*time.Second {
+		t.Errorf("BootReadyTimeout = %s, want 60s", c.BootReadyTimeout)
 	}
 	if c.Arch == "" {
 		t.Error("Arch should fall back to runtime.GOARCH, got empty")


### PR DESCRIPTION
The base snapshot was only warmed by a trivial `x = 1` probe, so every restored guest paid a ~1.3s per-process warmup on its first real scan. Measured: fresh restore scans runner.py in ~1660ms, but a 2nd identical scan in the same process is ~334ms — the gap is one-time warmup, not rule-matching. Prime the LSP with one realistic file per extension (.py .go .js .jsx .ts .tsx .rs) before snapshotting so restored guests start warmed. No rule cut, no coverage loss. Expect single-file e2e to drop from ~1.6s toward ~0.5-0.7s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)