### PR TITLE
ci(semgrep): fetch and pin the Pro rust rules pack

### DIFF
--- a/.github/workflows/update-semgrep-pro.yaml
+++ b/.github/workflows/update-semgrep-pro.yaml
@@ -177,7 +177,7 @@ jobs:
           # --- Pro rule packs ---
           download_rules() {
             local pids=()
-            for lang in golang python javascript kubernetes; do
+            for lang in golang python javascript kubernetes rust; do
               (
                 dir="artifacts/rules-${lang}"
                 mkdir -p "${dir}"
@@ -335,7 +335,7 @@ jobs:
 
           # Pro artifacts
           GHCR_PRO="ghcr.io/jomcgi/homelab/tools/semgrep-pro"
-          for artifact in engine-amd64 engine-arm64 engine-osx-arm64 engine-osx-x86_64 rules-golang rules-python rules-javascript rules-kubernetes rules-sca-golang rules-sca-python rules-sca-javascript; do
+          for artifact in engine-amd64 engine-arm64 engine-osx-arm64 engine-osx-x86_64 rules-golang rules-python rules-javascript rules-kubernetes rules-rust rules-sca-golang rules-sca-python rules-sca-javascript; do
             key="pro_${artifact//-/_}"
             push_artifact "artifacts/${artifact}" "${GHCR_PRO}/${artifact}:${DATE_TAG}" "${key}" &
             pids+=($!)
@@ -377,6 +377,7 @@ jobs:
           DIGEST_PRO_RULES_PYTHON: ${{ steps.digests.outputs.pro_rules_python }}
           DIGEST_PRO_RULES_JAVASCRIPT: ${{ steps.digests.outputs.pro_rules_javascript }}
           DIGEST_PRO_RULES_KUBERNETES: ${{ steps.digests.outputs.pro_rules_kubernetes }}
+          DIGEST_PRO_RULES_RUST: ${{ steps.digests.outputs.pro_rules_rust }}
           DIGEST_PRO_RULES_SCA_GOLANG: ${{ steps.digests.outputs.pro_rules_sca_golang }}
           DIGEST_PRO_RULES_SCA_PYTHON: ${{ steps.digests.outputs.pro_rules_sca_python }}
           DIGEST_PRO_RULES_SCA_JAVASCRIPT: ${{ steps.digests.outputs.pro_rules_sca_javascript }}
@@ -406,6 +407,7 @@ jobs:
               "rules_python": "${DIGEST_PRO_RULES_PYTHON}",
               "rules_javascript": "${DIGEST_PRO_RULES_JAVASCRIPT}",
               "rules_kubernetes": "${DIGEST_PRO_RULES_KUBERNETES}",
+              "rules_rust": "${DIGEST_PRO_RULES_RUST}",
               "rules_sca_golang": "${DIGEST_PRO_RULES_SCA_GOLANG}",
               "rules_sca_python": "${DIGEST_PRO_RULES_SCA_PYTHON}",
               "rules_sca_javascript": "${DIGEST_PRO_RULES_SCA_JAVASCRIPT}",
@@ -471,7 +473,7 @@ jobs:
 
           - Updates Semgrep OCI artifact digests (semgrep v${SEMGREP_VERSION})
           - Pro engine binaries: amd64, arm64, osx-arm64, osx-x86_64
-          - Pro rule packs: golang, python, javascript, kubernetes
+          - Pro rule packs: golang, python, javascript, kubernetes, rust
           - SCA advisory rules: golang, python, javascript (split by ecosystem)
           - OSS engine binaries: amd64, arm64, osx-arm64, osx-x86_64 (extracted from PyPI wheels)
           - Date tag: ${DATE_TAG}


### PR DESCRIPTION
## Summary

Adds the Semgrep **Pro Rust code-analysis pack** (`p/rust`) to the daily artifact-update pipeline. This is **PR A of 2** (producer/consumer split, see below).

Touches four enumeration sites in `update-semgrep-pro.yaml`:
- `download_rules` loop: fetches `https://semgrep.dev/c/p/rust`
- push-artifact list: pushes `rules-rust` to `ghcr.io/jomcgi/homelab/tools/semgrep-pro/rules-rust`
- `DIGEST_PRO_RULES_RUST` env mapping
- `digests.bzl` heredoc: writes the `rules_rust` pin

## Why two PRs

The Bazel extension builds `@semgrep_pro_rules_<lang>` as an `oci_archive` keyed on a content-addressed digest from `SEMGREP_PRO_DIGESTS`. That digest only exists once this workflow runs with `SEMGREP_APP_TOKEN` and pushes the pack. Referencing `@semgrep_pro_rules_rust` before its digest is pinned would build an `oci_archive` with an empty digest and fail. So:

- **PR A (this one)** — producer. Adds `rust` to the workflow only. No Bazel wiring touched, so it cannot break the build. Merging + running the workflow populates `rules_rust` in `digests.bzl` (and verifies `p/rust` resolves through the authenticated `c/p/` endpoint).
- **PR B (follow-up)** — consumer. Once the digest lands: `extensions.bzl` lang loop, `MODULE.bazel` `use_repo`, `rust_rules` + `all_rules` filegroups, and the `semgrep-guest` image tar (`/etc/semgrep/rules/pro-rust/`) so the semgrep-scand MCP scanner picks up Rust.

## Verification

After merge, dispatch the workflow (`workflow_dispatch`); the run downloads/pushes `rules-rust` and auto-opens a digest-bump PR. If `p/rust` 404s, this PR is trivially revertible with zero build impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)