### PR TITLE
build(semgrep): wire the Pro rust rules pack into the scanner

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -420,6 +420,7 @@ use_repo(
     "semgrep_pro_rules_javascript",
     "semgrep_pro_rules_kubernetes",
     "semgrep_pro_rules_python",
+    "semgrep_pro_rules_rust",
     "semgrep_sca_rules_golang",
     "semgrep_sca_rules_javascript",
     "semgrep_sca_rules_python",

--- a/bazel/semgrep/guest/BUILD
+++ b/bazel/semgrep/guest/BUILD
@@ -3,7 +3,7 @@
 # Tar layers for the semgrep-guest microVM image (Task 1.1):
 #   - engine_tar:  the per-arch Semgrep Pro engine at
 #                  /opt/semgrep/semgrep-core-proprietary (SEMGREP_CORE_BIN).
-#   - rules_tar:   the merged rule set (local rules + the 4 Pro packs) flattened
+#   - rules_tar:   the merged rule set (local rules + the 5 Pro packs) flattened
 #                  under /etc/semgrep/rules/, structure-preserved to avoid the
 #                  basename collisions that exist across the local rule subdirs.
 #
@@ -89,6 +89,14 @@ pkg_files(
     strip_prefix = strip_prefix.from_pkg(""),
 )
 
+pkg_files(
+    name = "pro_rust_files",
+    srcs = ["@semgrep_pro_rules_rust//:rules"],
+    attributes = pkg_attributes(mode = "0644"),
+    prefix = "etc/semgrep/rules/pro-rust",
+    strip_prefix = strip_prefix.from_pkg(""),
+)
+
 pkg_tar(
     name = "rules_tar",
     srcs = [
@@ -97,5 +105,6 @@ pkg_tar(
         ":pro_javascript_files",
         ":pro_kubernetes_files",
         ":pro_python_files",
+        ":pro_rust_files",
     ],
 )

--- a/bazel/semgrep/rules/BUILD
+++ b/bazel/semgrep/rules/BUILD
@@ -66,6 +66,17 @@ filegroup(
     ) + ["@semgrep_pro_rules_golang//:rules"],
 )
 
+# No local Rust rules yet — the repo has no Rust sources. This filegroup exists
+# for parity with the other languages and carries only the Pro p/rust pack, which
+# the semgrep-scand MCP scanner uses against agent-generated Rust code.
+filegroup(
+    name = "rust_rules",
+    srcs = glob(
+        ["rust/*.yaml"],
+        allow_empty = True,
+    ) + ["@semgrep_pro_rules_rust//:rules"],
+)
+
 filegroup(
     name = "typescript_rules",
     srcs = glob(
@@ -129,6 +140,7 @@ filegroup(
         "@semgrep_pro_rules_javascript//:rules",
         "@semgrep_pro_rules_kubernetes//:rules",
         "@semgrep_pro_rules_python//:rules",
+        "@semgrep_pro_rules_rust//:rules",
     ],
 )
 

--- a/bazel/semgrep/third_party/semgrep_pro/extensions.bzl
+++ b/bazel/semgrep/third_party/semgrep_pro/extensions.bzl
@@ -45,7 +45,7 @@ def _semgrep_pro_impl(module_ctx):
         )
 
     # Rule packs — one repo per language
-    for lang in ["golang", "python", "javascript", "kubernetes"]:
+    for lang in ["golang", "python", "javascript", "kubernetes", "rust"]:
         oci_archive(
             name = "semgrep_pro_rules_" + lang,
             image = _GHCR_PREFIX + "/rules-" + lang,

--- a/projects/agent_platform/semgrep-scand/chart/Chart.yaml
+++ b/projects/agent_platform/semgrep-scand/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: semgrep-scand
 description: Node-affine semgrep scanner daemon that boots a fresh semgrep-guest microVM per scan and serves HTTP POST /scan + GET /healthz
 type: application
-version: 0.4.5
+version: 0.4.6

--- a/projects/agent_platform/semgrep-scand/deploy/application.yaml
+++ b/projects/agent_platform/semgrep-scand/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tags pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: semgrep-scand
-      targetRevision: 0.4.5
+      targetRevision: 0.4.6
       helm:
         valueFiles:
           - $values/projects/agent_platform/semgrep-scand/deploy/values.yaml


### PR DESCRIPTION
## Summary

**PR B of 2** (consumer half). PR #2958 added `rust` to the artifact-update workflow, and the auto digest-bump #2959 pinned `rules_rust` (`sha256:14f66ffe…`) in `semgrep_pro/digests.bzl`. This PR consumes that pin so the Pro Rust pack (`p/rust`) is actually used:

- **`extensions.bzl`** — add `rust` to the per-language rule-pack loop, creating `@semgrep_pro_rules_rust` as an `oci_archive` from `ghcr.io/jomcgi/homelab/tools/semgrep-pro/rules-rust`.
- **`MODULE.bazel`** — register `semgrep_pro_rules_rust` in `use_repo`.
- **`rules/BUILD`** — add a `rust_rules` filegroup (parity with the other languages) and fold the pack into `all_rules`.
- **`guest/BUILD`** — add `pro_rust_files` and layer it into `rules_tar`, placing the pack at `/etc/semgrep/rules/pro-rust/` inside the `semgrep-guest` microVM image.

The last item is what reaches the **semgrep-scand MCP** (`monolith-semgrep-scan`): the guest scanner runs offline (`SEMGREP_APP_TOKEN=""`) against `SEMGREP_RULES_DIR=/etc/semgrep/rules`, so layering the pack into the image is how Rust rules get applied to agent-generated code.

## Notes

- No local `rust/` rules and no Rust fixtures exist, so no `semgrep_test` target is added — the Pro pack rides along in `all_rules` and the guest tar. (Code-rules only; cargo SCA was explicitly out of scope.)
- **Post-merge:** CI rebuilds the `semgrep-guest` image on `main`. The semgrep-scand FC snapshot is warmed from that image, so it picks up the new pack on its next base rebuild (snapshot-warm path). No chart value change is needed in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)