### PR TITLE
perf(semgrep-scand): fan out multi-file scans across guests + per-file wait timeout

### DIFF
--- a/projects/agent_platform/semgrep-guest-init/internal/lspdriver/lspdriver.go
+++ b/projects/agent_platform/semgrep-guest-init/internal/lspdriver/lspdriver.go
@@ -485,15 +485,27 @@ func (d *Driver) Scan(ctx context.Context, files []vsockproto.ScanFile) ([]vsock
 
 	// Collect each target's findings once its publishes settle. The findings publish
 	// lands after any work-done-progress "end", and single-file scans emit no
-	// progress, so a publish quiet-window is the reliable completion signal.
+	// progress, so a publish quiet-window is the reliable completion signal. Each
+	// target gets its own first-publish deadline so ONE file that never publishes (a
+	// semgrep target-discovery race, or a future rule crash that drops the publish)
+	// degrades to zero findings instead of stalling the whole batch until ctx.
 	var findings []vsockproto.Finding
 	for _, tgt := range targets {
-		for _, diag := range d.waitDiag(ctx, tgt.uri) {
+		tctx, cancel := context.WithTimeout(ctx, perFileScanTimeout)
+		diags := d.waitDiag(tctx, tgt.uri)
+		cancel()
+		for _, diag := range diags {
 			findings = append(findings, translate(tgt.path, diag))
 		}
 	}
 	return findings, nil
 }
+
+// perFileScanTimeout bounds how long a single file waits for its first
+// publishDiagnostics. Generous enough for a large file's warm scan (a few seconds),
+// short enough that a file which never publishes does not pin the request. Applied
+// per target so one bad file cannot consume the whole batch budget.
+const perFileScanTimeout = 12 * time.Second
 
 // openOrChange opens a document the first time it is seen, and sends a didChange
 // with a bumped version on subsequent scans (forcing a re-scan).

--- a/projects/agent_platform/semgrep-scand/chart/Chart.yaml
+++ b/projects/agent_platform/semgrep-scand/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: semgrep-scand
 description: Node-affine semgrep scanner daemon that boots a fresh semgrep-guest microVM per scan and serves HTTP POST /scan + GET /healthz
 type: application
-version: 0.4.5
+version: 0.4.6

--- a/projects/agent_platform/semgrep-scand/deploy/application.yaml
+++ b/projects/agent_platform/semgrep-scand/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tags pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: semgrep-scand
-      targetRevision: 0.4.5
+      targetRevision: 0.4.6
       helm:
         valueFiles:
           - $values/projects/agent_platform/semgrep-scand/deploy/values.yaml

--- a/projects/agent_platform/semgrep-scand/internal/scanner/scanner.go
+++ b/projects/agent_platform/semgrep-scand/internal/scanner/scanner.go
@@ -224,11 +224,60 @@ func (s *Scanner) invalidateBase(gen uint64) {
 	}()
 }
 
-// Scan runs one scan. It restores from the warm base when available (fast path) and
-// otherwise cold-boots a guest (fallback). A boot/restore/readiness failure returns
-// a *GuestUnavailableError (the HTTP layer's 503); a scan-leg failure is folded into
-// ScanResult.Errors with a nil error (the HTTP layer's 200).
+// Scan scans a batch of files. Each file is scanned on its OWN microVM,
+// concurrently — a freshly restored guest scans one target, so semgrep's per-file
+// cost is paid in parallel across the batch instead of sequentially within one
+// guest (which the warm LSP serializes). Concurrency is bounded by the per-file
+// semaphore (MaxConcurrent guests), so K*GuestMemMib still bounds microVM memory.
+// Findings and per-file errors are merged. A whole-batch *GuestUnavailableError
+// (the HTTP layer's 503) is returned only if EVERY file failed to get a guest;
+// otherwise partial results return 200 with the failures folded into Errors.
 func (s *Scanner) Scan(ctx context.Context, files []vsockproto.ScanFile) (vsockproto.ScanResult, error) {
+	if len(files) == 1 {
+		return s.scanOne(ctx, files[0])
+	}
+
+	type fileResult struct {
+		res     vsockproto.ScanResult
+		unavail error
+	}
+	results := make([]fileResult, len(files))
+	var wg sync.WaitGroup
+	for i := range files {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			res, err := s.scanOne(ctx, files[i])
+			results[i] = fileResult{res: res, unavail: err}
+		}(i)
+	}
+	wg.Wait()
+
+	var merged vsockproto.ScanResult
+	unavailable := 0
+	var lastUnavail error
+	for _, r := range results {
+		if r.unavail != nil {
+			unavailable++
+			lastUnavail = r.unavail
+			merged.Errors = append(merged.Errors, r.unavail.Error())
+			continue
+		}
+		merged.Findings = append(merged.Findings, r.res.Findings...)
+		merged.Errors = append(merged.Errors, r.res.Errors...)
+	}
+	// Only a total failure to get any guest is a 503; partial success is 200.
+	if unavailable == len(files) {
+		return vsockproto.ScanResult{}, lastUnavail
+	}
+	return merged, nil
+}
+
+// scanOne scans a single file on one guest: it restores from the warm base when
+// available (fast path) and otherwise cold-boots (fallback). A boot/restore/readiness
+// failure returns a *GuestUnavailableError; a scan-leg failure is folded into
+// ScanResult.Errors with a nil error.
+func (s *Scanner) scanOne(ctx context.Context, file vsockproto.ScanFile) (vsockproto.ScanResult, error) {
 	// Cap concurrency before spending a boot/restore, so at most K guests are ever
 	// live and K*GuestMemMib bounds the microVM memory in our cgroup.
 	if s.sem != nil {
@@ -238,6 +287,7 @@ func (s *Scanner) Scan(ctx context.Context, files []vsockproto.ScanFile) (vsockp
 		defer s.sem.Release(1)
 	}
 
+	files := []vsockproto.ScanFile{file}
 	if base, gen, ok := s.currentBase(); ok {
 		res, err := s.scanWarm(ctx, base, files)
 		if err == nil {

--- a/projects/agent_platform/semgrep-scand/internal/scanner/scanner_test.go
+++ b/projects/agent_platform/semgrep-scand/internal/scanner/scanner_test.go
@@ -229,6 +229,52 @@ func TestWarmBaseRestoreScans(t *testing.T) {
 	}
 }
 
+func TestScanFansOutAcrossFiles(t *testing.T) {
+	d := &fakeDriver{}
+	tr := &fakeTransport{res: vsockproto.ScanResult{
+		Findings: []vsockproto.Finding{{Path: "f", RuleID: "r1"}},
+	}}
+	cfg := testCfg()
+	cfg.WarmBase = true
+	cfg.BaseKey = "k"
+	cfg.RestorePrime = time.Millisecond
+	s := New(d, tr, cfg, nil)
+	if err := s.BuildBase(context.Background()); err != nil {
+		t.Fatalf("BuildBase() error = %v", err)
+	}
+
+	files := []vsockproto.ScanFile{{Path: "a.py"}, {Path: "b.py"}, {Path: "c.py"}}
+	res, err := s.Scan(context.Background(), files)
+	if err != nil {
+		t.Fatalf("Scan() error = %v", err)
+	}
+	// Each of the 3 files scans on its own restored guest; their findings merge.
+	if len(res.Findings) != 3 {
+		t.Errorf("findings = %d, want 3 (one per file, merged across guests)", len(res.Findings))
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.baseClaims != 3 {
+		t.Errorf("baseClaims = %d, want 3 (each file restored its own guest)", d.baseClaims)
+	}
+	if d.removed != 4 {
+		t.Errorf("removed = %d, want 4 (base-build guest + 3 per-file guests cleaned up)", d.removed)
+	}
+}
+
+func TestScanFanOutAllUnavailableIs503(t *testing.T) {
+	// Every Claim fails: every per-file scan is guest-unavailable, so the whole
+	// batch must surface a *GuestUnavailableError (the HTTP 503), not a 200.
+	d := &fakeDriver{claimErr: errors.New("no kvm")}
+	s := New(d, &fakeTransport{}, testCfg(), nil)
+
+	_, err := s.Scan(context.Background(), []vsockproto.ScanFile{{Path: "a.py"}, {Path: "b.py"}})
+	var gu *GuestUnavailableError
+	if !errors.As(err, &gu) {
+		t.Fatalf("error = %v, want *GuestUnavailableError when every file fails to get a guest", err)
+	}
+}
+
 func TestWarmBaseRestoreFailsOverToColdBoot(t *testing.T) {
 	d := &fakeDriver{}
 	tr := &fakeTransport{res: vsockproto.ScanResult{


### PR DESCRIPTION
**Fan-out:** an N-file batch was scanned sequentially inside one guest (the warm LSP serializes per-file scans). Now each file scans on its own restored guest, concurrently (bounded by the existing semaphore), so semgrep's per-file cost is paid in parallel — a 5-file diff goes from ~5x sequential to ~1x wall (within the concurrency cap). Findings/errors merge; 503 only if every file fails to get a guest.

**Per-file wait timeout:** `waitDiag` was bounded only by the batch ctx, so one file that never publishes (a semgrep target-discovery race, seen on the warm-up primer) stalled the batch 45-55s. Each target now gets a 12s first-publish deadline and degrades to 0 findings — also fixes the base-build occasionally blocking on a primer file.

Unit-tested (fan-out merge, all-unavailable 503, plus existing warm/cold/fallback/semaphore), -race clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)