### PR TITLE
feat(discord): add 'Get your facts STR8!' fact-check button

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.82.1
+version: 0.82.2
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.82.0
+version: 0.82.1
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.81.0
+version: 0.82.0
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.80.1
+version: 0.81.0
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.82.0
+      targetRevision: 0.82.1
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.82.1
+      targetRevision: 0.82.2
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.80.1
+      targetRevision: 0.81.0
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.81.0
+      targetRevision: 0.82.0
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.235.0
+version: 0.235.1
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.233.2
+version: 0.234.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.235.1
+version: 0.235.2
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.234.0
+version: 0.235.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chat/agent.py
+++ b/projects/monolith/chat/agent.py
@@ -255,3 +255,46 @@ def create_agent(base_url: str | None = None) -> Agent[ChatDeps]:
         )
 
     return agent
+
+
+def create_fact_check_agent(base_url: str | None = None) -> "Agent[None]":
+    """Create a lightweight agent for fact-checking a bot response via web search.
+
+    Uses the same Qwen model and Bosun persona but no chat deps -- just a
+    web_search tool so it can verify claims against SearXNG.
+    """
+    url = base_url or LLAMA_CPP_URL
+
+    model = OpenAIChatModel(
+        "qwen3.6-27b",
+        provider=OpenAIProvider(
+            base_url=f"{url}/v1",
+            api_key="not-needed",
+        ),
+    )
+
+    fact_agent: "Agent[None]" = Agent(
+        model,
+        system_prompt=(
+            "You're Bosun, and someone just hit the fact-check button on your last response. "
+            "Search the web to verify the key factual claims you made. Be direct and honest: "
+            "call out anything wrong, anything you oversimplified, and confirm what you got right. "
+            "Keep the same confident, no-BS tone -- no hedging, no filler. "
+            "Lead with the verdict, then bullet the specifics."
+        ),
+        model_settings=ModelSettings(
+            temperature=1.0,
+            top_p=0.95,
+            extra_body={
+                "top_k": 20,
+                "presence_penalty": 1.5,
+            },
+        ),
+    )
+
+    @fact_agent.tool_plain
+    async def web_search(query: str) -> str:
+        """Search the web to verify a factual claim."""
+        return await search_web(query)
+
+    return fact_agent

--- a/projects/monolith/chat/bot.py
+++ b/projects/monolith/chat/bot.py
@@ -18,7 +18,7 @@ from pydantic_ai import (
     ThinkingPartDelta,
 )
 
-from chat.agent import create_agent, format_context_messages
+from chat.agent import create_agent, create_fact_check_agent, format_context_messages
 from shared.embedding import EmbeddingClient
 from chat.store import MessageStore
 from chat.vision import VisionClient
@@ -95,12 +95,29 @@ def _render_goosecracker_progress(snap, elapsed: int) -> str:
     return "\n".join(lines)[:DISCORD_MESSAGE_LIMIT]
 
 
-class ThinkingView(discord.ui.View):
-    """Discord View with a 'Show thinking' button that reveals model reasoning."""
+_fact_check_agent = None
 
-    def __init__(self, thinking_text: str):
+
+def _get_fact_check_agent():
+    global _fact_check_agent
+    if _fact_check_agent is None:
+        _fact_check_agent = create_fact_check_agent()
+    return _fact_check_agent
+
+
+class BotMessageView(discord.ui.View):
+    """Discord View with action buttons on bot responses.
+
+    Always shows 'Get your facts STR8!' (fact-check via SearXNG).
+    Shows 'Show thinking' only when the model produced reasoning text.
+    """
+
+    def __init__(self, response_text: str, thinking_text: str | None = None):
         super().__init__(timeout=None)
+        self.response_text = response_text
         self.thinking_text = thinking_text
+        if thinking_text is None:
+            self.remove_item(self.show_thinking)
 
     @discord.ui.button(
         label="Show thinking",
@@ -111,6 +128,29 @@ class ThinkingView(discord.ui.View):
         self, interaction: discord.Interaction, button: discord.ui.Button
     ):
         await interaction.response.send_message(self.thinking_text, ephemeral=True)
+
+    @discord.ui.button(
+        label="Get your facts STR8!",
+        style=discord.ButtonStyle.danger,
+        custom_id="fact_check",
+    )
+    async def fact_check(
+        self, interaction: discord.Interaction, button: discord.ui.Button
+    ):
+        await interaction.response.defer()
+        try:
+            result = await _get_fact_check_agent().run(
+                f"Fact-check this response:\n\n{self.response_text}"
+            )
+            fact_text = result.output
+            if len(fact_text) > DISCORD_MESSAGE_LIMIT:
+                fact_text = fact_text[:THINKING_TRUNCATE_AT] + "... (truncated)"
+            await interaction.followup.send(f"**Fact check:**\n{fact_text}")
+        except Exception:
+            logger.exception("Fact-check failed")
+            await interaction.followup.send(
+                "Couldn't run the fact-check right now.", ephemeral=True
+            )
 
 
 def should_respond(message: discord.Message, bot_user: discord.User) -> bool:
@@ -286,23 +326,23 @@ class ChatBot(discord.Client):
             logger.info("Synced application commands (global)")
         except Exception:
             logger.exception("Failed to sync application commands")
-        # Re-register ThinkingView for recent bot messages so the "Show thinking"
-        # button keeps working after a pod restart.
+        # Re-register BotMessageView for recent bot messages so buttons keep
+        # working after a pod restart.
         try:
             with Session(get_engine()) as session:
                 store = MessageStore(session=session, embed_client=self.embed_client)
-                messages_with_thinking = store.get_messages_with_thinking()
-            for msg in messages_with_thinking:
+                recent_bot_messages = store.get_recent_bot_messages()
+            for msg in recent_bot_messages:
                 self.add_view(
-                    ThinkingView(msg.thinking),
+                    BotMessageView(msg.content, msg.thinking),
                     message_id=int(msg.discord_message_id),
                 )
             logger.info(
-                "Re-registered ThinkingView for %d bot messages",
-                len(messages_with_thinking),
+                "Re-registered BotMessageView for %d bot messages",
+                len(recent_bot_messages),
             )
         except Exception:
-            logger.exception("Failed to re-register ThinkingViews on ready")
+            logger.exception("Failed to re-register BotMessageViews on ready")
 
     async def on_message(self, message: discord.Message):
         # Skip own messages — bot responses are stored explicitly after sending
@@ -757,10 +797,9 @@ class ChatBot(discord.Client):
                 if raw:
                     thinking_text = _truncate_thinking(raw)
 
-            if thinking_text:
-                await sent.edit(content=response_text, view=ThinkingView(thinking_text))
-            else:
-                await _edit_if_due(response_text, force=True)
+            await sent.edit(
+                content=response_text, view=BotMessageView(response_text, thinking_text)
+            )
 
             return sent, response_text, thinking_text
 

--- a/projects/monolith/chat/bot.py
+++ b/projects/monolith/chat/bot.py
@@ -163,10 +163,10 @@ class BotMessageView(discord.ui.View):
             else:
                 prompt = f"Fact-check this response:\n\n{self.response_text}"
             result = await _get_fact_check_agent().run(prompt)
-            fact_text = result.output
-            if len(fact_text) > DISCORD_MESSAGE_LIMIT:
-                fact_text = fact_text[:THINKING_TRUNCATE_AT] + "... (truncated)"
-            await interaction.followup.send(f"**Fact check:**\n{fact_text}")
+            out = f"**Fact check:**\n{result.output}"
+            if len(out) > DISCORD_MESSAGE_LIMIT:
+                out = out[:THINKING_TRUNCATE_AT] + "... (truncated)"
+            await interaction.followup.send(out)
         except Exception:
             logger.exception("Fact-check failed")
             await interaction.followup.send(

--- a/projects/monolith/chat/bot.py
+++ b/projects/monolith/chat/bot.py
@@ -105,6 +105,20 @@ def _get_fact_check_agent():
     return _fact_check_agent
 
 
+def _get_recent_context(channel_id: str) -> str:
+    """Fetch recent channel messages as a formatted context string (sync).
+
+    Called via asyncio.to_thread from the fact_check button callback.
+    Returns empty string if the bot is not initialised or the lookup fails.
+    """
+    if bot is None:
+        return ""
+    with Session(get_engine()) as session:
+        store = MessageStore(session=session, embed_client=bot.embed_client)
+        recent = store.get_recent(channel_id, limit=10)
+        return format_context_messages(recent, {})
+
+
 class BotMessageView(discord.ui.View):
     """Discord View with action buttons on bot responses.
 
@@ -139,9 +153,16 @@ class BotMessageView(discord.ui.View):
     ):
         await interaction.response.defer()
         try:
-            result = await _get_fact_check_agent().run(
-                f"Fact-check this response:\n\n{self.response_text}"
-            )
+            channel_id = str(interaction.channel.id)
+            context = await asyncio.to_thread(_get_recent_context, channel_id)
+            if context:
+                prompt = (
+                    f"Recent conversation:\n{context}\n\n"
+                    f"Fact-check your last response:\n\n{self.response_text}"
+                )
+            else:
+                prompt = f"Fact-check this response:\n\n{self.response_text}"
+            result = await _get_fact_check_agent().run(prompt)
             fact_text = result.output
             if len(fact_text) > DISCORD_MESSAGE_LIMIT:
                 fact_text = fact_text[:THINKING_TRUNCATE_AT] + "... (truncated)"

--- a/projects/monolith/chat/bot_streaming_test.py
+++ b/projects/monolith/chat/bot_streaming_test.py
@@ -12,7 +12,7 @@ from pydantic_ai import (
 )
 from pydantic_ai.messages import ToolCallPart
 
-from chat.bot import ChatBot, ThinkingView, STREAM_EDIT_INTERVAL
+from chat.bot import ChatBot, BotMessageView, STREAM_EDIT_INTERVAL
 
 
 # ---------------------------------------------------------------------------
@@ -224,7 +224,7 @@ class TestThinkingCollected:
         sent = message.reply.return_value
         final_edit = sent.edit.call_args_list[-1]
         view = final_edit.kwargs.get("view")
-        assert isinstance(view, ThinkingView)
+        assert isinstance(view, BotMessageView)
         assert view.thinking_text == "Let me think about this."
 
 

--- a/projects/monolith/chat/bot_thinking_test.py
+++ b/projects/monolith/chat/bot_thinking_test.py
@@ -10,7 +10,7 @@ from pydantic_ai import (
     ThinkingPartDelta,
 )
 
-from chat.bot import _truncate_thinking, ThinkingView, ChatBot
+from chat.bot import _truncate_thinking, BotMessageView, ChatBot
 
 
 class TestTruncateThinking:
@@ -31,31 +31,75 @@ class TestTruncateThinking:
         assert _truncate_thinking(text) == text
 
 
-class TestThinkingView:
-    def test_view_has_button(self):
-        """ThinkingView contains a 'Show thinking' button."""
-        view = ThinkingView("some thinking")
+class TestBotMessageView:
+    def test_view_with_thinking_has_two_buttons(self):
+        """BotMessageView with thinking_text shows both buttons."""
+        view = BotMessageView("response text", thinking_text="some thinking")
+        buttons = [c for c in view.children if isinstance(c, discord.ui.Button)]
+        labels = {b.label for b in buttons}
+        assert labels == {"Show thinking", "Get your facts STR8!"}
+
+    def test_view_without_thinking_has_one_button(self):
+        """BotMessageView without thinking_text shows only the fact-check button."""
+        view = BotMessageView("response text")
         buttons = [c for c in view.children if isinstance(c, discord.ui.Button)]
         assert len(buttons) == 1
-        assert buttons[0].label == "Show thinking"
-        assert buttons[0].style == discord.ButtonStyle.secondary
+        assert buttons[0].label == "Get your facts STR8!"
+
+    def test_show_thinking_button_is_secondary(self):
+        """Show thinking button uses secondary (gray) style."""
+        view = BotMessageView("response", thinking_text="reasoning")
+        button = next(
+            b
+            for b in view.children
+            if isinstance(b, discord.ui.Button) and b.label == "Show thinking"
+        )
+        assert button.style == discord.ButtonStyle.secondary
+
+    def test_fact_check_button_is_danger(self):
+        """Fact-check button uses danger (red) style."""
+        view = BotMessageView("response", thinking_text="reasoning")
+        button = next(
+            b
+            for b in view.children
+            if isinstance(b, discord.ui.Button) and b.label == "Get your facts STR8!"
+        )
+        assert button.style == discord.ButtonStyle.danger
 
     def test_view_no_timeout(self):
-        """ThinkingView has no timeout."""
-        view = ThinkingView("some thinking")
+        """BotMessageView has no timeout."""
+        view = BotMessageView("response", thinking_text="some thinking")
         assert view.timeout is None
 
-    def test_button_has_custom_id_for_persistence(self):
-        """ThinkingView button has a fixed custom_id so add_view() works after restarts."""
-        view = ThinkingView("some thinking")
-        buttons = [c for c in view.children if isinstance(c, discord.ui.Button)]
-        assert buttons[0].custom_id == "show_thinking"
+    def test_show_thinking_button_has_custom_id(self):
+        """show_thinking button has fixed custom_id for add_view() persistence."""
+        view = BotMessageView("response", thinking_text="some thinking")
+        button = next(
+            b
+            for b in view.children
+            if isinstance(b, discord.ui.Button) and b.label == "Show thinking"
+        )
+        assert button.custom_id == "show_thinking"
+
+    def test_fact_check_button_has_custom_id(self):
+        """fact_check button has fixed custom_id for add_view() persistence."""
+        view = BotMessageView("response", thinking_text="some thinking")
+        button = next(
+            b
+            for b in view.children
+            if isinstance(b, discord.ui.Button) and b.label == "Get your facts STR8!"
+        )
+        assert button.custom_id == "fact_check"
 
     @pytest.mark.asyncio
-    async def test_button_sends_ephemeral(self):
-        """Clicking the button sends thinking as an ephemeral message."""
-        view = ThinkingView("my reasoning")
-        button = [c for c in view.children if isinstance(c, discord.ui.Button)][0]
+    async def test_show_thinking_sends_ephemeral(self):
+        """Clicking Show thinking sends thinking text as an ephemeral message."""
+        view = BotMessageView("response text", thinking_text="my reasoning")
+        button = next(
+            b
+            for b in view.children
+            if isinstance(b, discord.ui.Button) and b.label == "Show thinking"
+        )
 
         interaction = AsyncMock()
         interaction.response = AsyncMock()
@@ -145,8 +189,8 @@ async def _async_iter(events):
 
 class TestThinkingIntegration:
     @pytest.mark.asyncio
-    async def test_response_with_thinking_adds_view(self):
-        """When model returns thinking, final edit includes ThinkingView."""
+    async def test_response_with_thinking_adds_view_with_thinking(self):
+        """When model returns thinking, final edit includes BotMessageView with thinking."""
         bot = _make_bot()
         bot_user = bot.user
 
@@ -172,14 +216,15 @@ class TestThinkingIntegration:
         sent = message.reply.return_value
         final_edit = sent.edit.call_args_list[-1]
         view = final_edit.kwargs.get("view")
-        assert isinstance(view, ThinkingView)
+        assert isinstance(view, BotMessageView)
+        assert view.thinking_text == "reasoning here"
         # Verify thinking was passed to save_message for the bot response
         bot_save_call = mock_store.save_message.call_args_list[-1]
         assert bot_save_call.kwargs.get("thinking") == "reasoning here"
 
     @pytest.mark.asyncio
-    async def test_response_without_thinking_no_view(self):
-        """When model returns plain text, final edit has no ThinkingView."""
+    async def test_response_without_thinking_still_has_view(self):
+        """When model returns plain text, final edit still has a BotMessageView (fact-check button)."""
         bot = _make_bot()
         bot_user = bot.user
 
@@ -200,9 +245,10 @@ class TestThinkingIntegration:
             await bot.on_message(message)
 
         sent = message.reply.return_value
-        # No edit should have a ThinkingView
-        for call in sent.edit.call_args_list:
-            assert call.kwargs.get("view") is None
+        final_edit = sent.edit.call_args_list[-1]
+        view = final_edit.kwargs.get("view")
+        assert isinstance(view, BotMessageView)
+        assert view.thinking_text is None
 
     @pytest.mark.asyncio
     async def test_empty_stream_sends_fallback(self):
@@ -288,21 +334,23 @@ class TestThinkingIntegration:
         assert last_edit.kwargs.get("content") == literal_output
 
 
-class TestOnReadyThinkingRegistration:
+class TestOnReadyViewRegistration:
     @pytest.mark.asyncio
-    async def test_on_ready_registers_views_for_messages_with_thinking(self):
-        """on_ready calls add_view for each stored bot message that has thinking."""
+    async def test_on_ready_registers_views_for_recent_bot_messages(self):
+        """on_ready calls add_view for each recent bot message."""
         bot = _make_bot()
 
         msg1 = MagicMock()
         msg1.discord_message_id = "111"
+        msg1.content = "response A"
         msg1.thinking = "thought A"
         msg2 = MagicMock()
         msg2.discord_message_id = "222"
-        msg2.thinking = "thought B"
+        msg2.content = "response B"
+        msg2.thinking = None
 
         mock_store = MagicMock()
-        mock_store.get_messages_with_thinking.return_value = [msg1, msg2]
+        mock_store.get_recent_bot_messages.return_value = [msg1, msg2]
 
         bot.add_view = MagicMock()
 
@@ -320,16 +368,18 @@ class TestOnReadyThinkingRegistration:
         calls = bot.add_view.call_args_list
         assert calls[0].kwargs["message_id"] == 111
         assert calls[1].kwargs["message_id"] == 222
-        assert isinstance(calls[0].args[0], ThinkingView)
-        assert isinstance(calls[1].args[0], ThinkingView)
+        assert isinstance(calls[0].args[0], BotMessageView)
+        assert isinstance(calls[1].args[0], BotMessageView)
+        assert calls[0].args[0].thinking_text == "thought A"
+        assert calls[1].args[0].thinking_text is None
 
     @pytest.mark.asyncio
-    async def test_on_ready_no_views_when_no_thinking_messages(self):
-        """on_ready does not call add_view when there are no stored thinking messages."""
+    async def test_on_ready_no_views_when_no_bot_messages(self):
+        """on_ready does not call add_view when there are no stored bot messages."""
         bot = _make_bot()
 
         mock_store = MagicMock()
-        mock_store.get_messages_with_thinking.return_value = []
+        mock_store.get_recent_bot_messages.return_value = []
 
         bot.add_view = MagicMock()
 

--- a/projects/monolith/chat/bot_thinking_view_callback_test.py
+++ b/projects/monolith/chat/bot_thinking_view_callback_test.py
@@ -103,6 +103,19 @@ class TestShowThinkingCallback:
         interaction.response.send_message.assert_called_once()
 
 
+def _patch_fact_check(mock_output: str, context: str = ""):
+    """Patch both the fact-check agent and context lookup for button callback tests."""
+    mock_result = MagicMock()
+    mock_result.output = mock_output
+    mock_agent = AsyncMock()
+    mock_agent.run = AsyncMock(return_value=mock_result)
+    return (
+        patch("chat.bot._get_fact_check_agent", return_value=mock_agent),
+        patch("chat.bot._get_recent_context", return_value=context),
+        mock_agent,
+    )
+
+
 class TestFactCheckCallback:
     """Unit tests for BotMessageView.fact_check() button callback."""
 
@@ -112,12 +125,10 @@ class TestFactCheckCallback:
         view = BotMessageView("The R-27ER has active radar homing.")
         interaction = _make_interaction()
 
-        mock_result = MagicMock()
-        mock_result.output = "Verdict: accurate. The R-27ER does use ARH at endgame."
-        mock_agent = AsyncMock()
-        mock_agent.run = AsyncMock(return_value=mock_result)
-
-        with patch("chat.bot._get_fact_check_agent", return_value=mock_agent):
+        p1, p2, _ = _patch_fact_check(
+            "Verdict: accurate. The R-27ER does use ARH at endgame."
+        )
+        with p1, p2:
             await _get_button_by_label(view, "Get your facts STR8!").callback(
                 interaction
             )
@@ -129,24 +140,53 @@ class TestFactCheckCallback:
         assert "accurate" in call_args[0][0]
 
     @pytest.mark.asyncio
-    async def test_fact_check_passes_response_text_to_agent(self):
-        """The agent receives the bot's response text as the prompt."""
+    async def test_response_text_included_in_prompt(self):
+        """The agent receives the bot's response text in the prompt."""
         response = "The AIM-7P is a 1970s semi-active round."
         view = BotMessageView(response)
         interaction = _make_interaction()
 
-        mock_result = MagicMock()
-        mock_result.output = "Actually the AIM-7P is a modernized variant."
-        mock_agent = AsyncMock()
-        mock_agent.run = AsyncMock(return_value=mock_result)
-
-        with patch("chat.bot._get_fact_check_agent", return_value=mock_agent):
+        p1, p2, mock_agent = _patch_fact_check(
+            "Actually the AIM-7P is a modernized variant."
+        )
+        with p1, p2:
             await _get_button_by_label(view, "Get your facts STR8!").callback(
                 interaction
             )
 
-        call_args = mock_agent.run.call_args
-        assert response in call_args[0][0]
+        assert response in mock_agent.run.call_args[0][0]
+
+    @pytest.mark.asyncio
+    async def test_conversation_context_prepended_when_available(self):
+        """When recent channel context exists it is prepended to the prompt."""
+        view = BotMessageView("The Sparrow needs continuous radar lock.")
+        interaction = _make_interaction()
+        context = "User: are sparrows good in BVR?\nBot: They have limitations."
+
+        p1, p2, mock_agent = _patch_fact_check("Mixed verdict.", context=context)
+        with p1, p2:
+            await _get_button_by_label(view, "Get your facts STR8!").callback(
+                interaction
+            )
+
+        prompt = mock_agent.run.call_args[0][0]
+        assert "Recent conversation:" in prompt
+        assert context in prompt
+        assert "The Sparrow needs continuous radar lock." in prompt
+
+    @pytest.mark.asyncio
+    async def test_no_context_header_when_context_empty(self):
+        """When context lookup returns empty string, no 'Recent conversation:' header is added."""
+        view = BotMessageView("Some claim.")
+        interaction = _make_interaction()
+
+        p1, p2, mock_agent = _patch_fact_check("Looks right.", context="")
+        with p1, p2:
+            await _get_button_by_label(view, "Get your facts STR8!").callback(
+                interaction
+            )
+
+        assert "Recent conversation:" not in mock_agent.run.call_args[0][0]
 
     @pytest.mark.asyncio
     async def test_agent_failure_sends_ephemeral_error(self):
@@ -156,15 +196,16 @@ class TestFactCheckCallback:
 
         mock_agent = AsyncMock()
         mock_agent.run = AsyncMock(side_effect=Exception("LLM timeout"))
-
-        with patch("chat.bot._get_fact_check_agent", return_value=mock_agent):
+        with (
+            patch("chat.bot._get_fact_check_agent", return_value=mock_agent),
+            patch("chat.bot._get_recent_context", return_value=""),
+        ):
             await _get_button_by_label(view, "Get your facts STR8!").callback(
                 interaction
             )
 
         interaction.response.defer.assert_called_once()
-        call_args = interaction.followup.send.call_args
-        assert call_args.kwargs.get("ephemeral") is True
+        assert interaction.followup.send.call_args.kwargs.get("ephemeral") is True
 
     @pytest.mark.asyncio
     async def test_long_fact_check_result_is_truncated(self):
@@ -172,12 +213,8 @@ class TestFactCheckCallback:
         view = BotMessageView("some response")
         interaction = _make_interaction()
 
-        mock_result = MagicMock()
-        mock_result.output = "x" * 3000
-        mock_agent = AsyncMock()
-        mock_agent.run = AsyncMock(return_value=mock_result)
-
-        with patch("chat.bot._get_fact_check_agent", return_value=mock_agent):
+        p1, p2, _ = _patch_fact_check("x" * 3000)
+        with p1, p2:
             await _get_button_by_label(view, "Get your facts STR8!").callback(
                 interaction
             )

--- a/projects/monolith/chat/bot_thinking_view_callback_test.py
+++ b/projects/monolith/chat/bot_thinking_view_callback_test.py
@@ -1,54 +1,54 @@
-"""Focused tests for ThinkingView.show_thinking() Discord button callback.
+"""Tests for BotMessageView button callbacks.
 
-Covers the button callback handler that sends the AI reasoning text as an
-ephemeral (private) message to the user who clicks the button.
-
-These tests complement the basic ephemeral-send test in bot_thinking_test.py
-by exercising the method's contract more thoroughly:
-
-- Invocation via the real button descriptor extracted from ``view.children``
-  (the correct way to call ``@discord.ui.button``-decorated callbacks).
-- Varied thinking content: empty, multiline, Unicode, Discord markdown.
-- Side-effect isolation: only ``response.send_message`` is called; no other
-  Discord response primitives (``defer``, ``edit_message``, etc.) are
-  invoked.
+Covers the show_thinking and fact_check button handlers:
+- show_thinking sends the AI reasoning text as an ephemeral private message.
+- fact_check defers the interaction, calls the fact-check agent, and sends a
+  public followup with the result.
 """
 
 import pytest
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import discord
 
-from chat.bot import ThinkingView
+from chat.bot import BotMessageView
 
 
 def _make_interaction() -> AsyncMock:
-    """Return a fully mocked Discord Interaction whose response supports send_message."""
+    """Return a fully mocked Discord Interaction."""
     interaction = AsyncMock()
     interaction.response = AsyncMock()
     interaction.response.send_message = AsyncMock()
     interaction.response.defer = AsyncMock()
     interaction.response.edit_message = AsyncMock()
+    interaction.followup = AsyncMock()
+    interaction.followup.send = AsyncMock()
     return interaction
 
 
-def _get_button(view: ThinkingView) -> discord.ui.Button:
-    """Extract the real Button descriptor from a ThinkingView."""
-    buttons = [c for c in view.children if isinstance(c, discord.ui.Button)]
-    assert len(buttons) == 1, "ThinkingView should have exactly one button"
+def _get_button_by_label(view: BotMessageView, label: str) -> discord.ui.Button:
+    """Extract a Button from a BotMessageView by label."""
+    buttons = [
+        c
+        for c in view.children
+        if isinstance(c, discord.ui.Button) and c.label == label
+    ]
+    assert len(buttons) == 1, (
+        f"Expected exactly one '{label}' button, got {len(buttons)}"
+    )
     return buttons[0]
 
 
 class TestShowThinkingCallback:
-    """Unit tests for ThinkingView.show_thinking() — the button callback."""
+    """Unit tests for BotMessageView.show_thinking() button callback."""
 
     @pytest.mark.asyncio
     async def test_sends_ephemeral_with_thinking_content(self):
         """Clicking the button sends the stored thinking text as an ephemeral reply."""
-        view = ThinkingView("AI reasoning text")
+        view = BotMessageView("response text", thinking_text="AI reasoning text")
         interaction = _make_interaction()
 
-        await _get_button(view).callback(interaction)
+        await _get_button_by_label(view, "Show thinking").callback(interaction)
 
         interaction.response.send_message.assert_called_once_with(
             "AI reasoning text", ephemeral=True
@@ -57,10 +57,10 @@ class TestShowThinkingCallback:
     @pytest.mark.asyncio
     async def test_ephemeral_flag_is_always_true(self):
         """The ephemeral=True keyword argument must always be present."""
-        view = ThinkingView("some reasoning")
+        view = BotMessageView("response", thinking_text="some reasoning")
         interaction = _make_interaction()
 
-        await _get_button(view).callback(interaction)
+        await _get_button_by_label(view, "Show thinking").callback(interaction)
 
         _, kwargs = interaction.response.send_message.call_args
         assert kwargs.get("ephemeral") is True
@@ -69,115 +69,119 @@ class TestShowThinkingCallback:
     async def test_exact_thinking_text_is_sent(self):
         """The positional argument to send_message is exactly the stored thinking text."""
         thinking = "Step 1: consider X\nStep 2: conclude Y"
-        view = ThinkingView(thinking)
+        view = BotMessageView("response", thinking_text=thinking)
         interaction = _make_interaction()
 
-        await _get_button(view).callback(interaction)
+        await _get_button_by_label(view, "Show thinking").callback(interaction)
 
         args, _ = interaction.response.send_message.call_args
         assert args[0] == thinking
 
     @pytest.mark.asyncio
-    async def test_empty_thinking_text(self):
-        """An empty thinking string is forwarded unchanged (no special-casing)."""
-        view = ThinkingView("")
-        interaction = _make_interaction()
-
-        await _get_button(view).callback(interaction)
-
-        interaction.response.send_message.assert_called_once_with("", ephemeral=True)
-
-    @pytest.mark.asyncio
     async def test_multiline_thinking_text(self):
         """Multiline reasoning is forwarded verbatim."""
         multiline = "First thought.\n\nSecond thought.\n\nConclusion."
-        view = ThinkingView(multiline)
+        view = BotMessageView("response", thinking_text=multiline)
         interaction = _make_interaction()
 
-        await _get_button(view).callback(interaction)
+        await _get_button_by_label(view, "Show thinking").callback(interaction)
 
         interaction.response.send_message.assert_called_once_with(
             multiline, ephemeral=True
         )
 
     @pytest.mark.asyncio
-    async def test_unicode_and_emoji_thinking(self):
-        """Unicode characters and emojis in thinking text pass through unmodified."""
-        unicode_thinking = "思考: 🤔 résumé — naïve approach → 42"
-        view = ThinkingView(unicode_thinking)
-        interaction = _make_interaction()
-
-        await _get_button(view).callback(interaction)
-
-        interaction.response.send_message.assert_called_once_with(
-            unicode_thinking, ephemeral=True
-        )
-
-    @pytest.mark.asyncio
-    async def test_discord_markdown_preserved(self):
-        """Discord markdown formatting characters in thinking are not escaped."""
-        markdown_thinking = "**bold** _italic_ `code` ~~strike~~ > blockquote"
-        view = ThinkingView(markdown_thinking)
-        interaction = _make_interaction()
-
-        await _get_button(view).callback(interaction)
-
-        interaction.response.send_message.assert_called_once_with(
-            markdown_thinking, ephemeral=True
-        )
-
-    @pytest.mark.asyncio
     async def test_only_send_message_is_called(self):
         """No other response methods (defer, edit_message) are invoked."""
-        view = ThinkingView("reasoning")
+        view = BotMessageView("response", thinking_text="reasoning")
         interaction = _make_interaction()
 
-        await _get_button(view).callback(interaction)
+        await _get_button_by_label(view, "Show thinking").callback(interaction)
 
         interaction.response.defer.assert_not_called()
         interaction.response.edit_message.assert_not_called()
         interaction.response.send_message.assert_called_once()
 
+
+class TestFactCheckCallback:
+    """Unit tests for BotMessageView.fact_check() button callback."""
+
     @pytest.mark.asyncio
-    async def test_send_message_called_exactly_once(self):
-        """send_message is called exactly once — no duplicate responses."""
-        view = ThinkingView("reasoning")
+    async def test_defers_then_sends_followup(self):
+        """fact_check defers the interaction and sends a public followup."""
+        view = BotMessageView("The R-27ER has active radar homing.")
         interaction = _make_interaction()
 
-        await _get_button(view).callback(interaction)
+        mock_result = MagicMock()
+        mock_result.output = "Verdict: accurate. The R-27ER does use ARH at endgame."
+        mock_agent = AsyncMock()
+        mock_agent.run = AsyncMock(return_value=mock_result)
 
-        assert interaction.response.send_message.call_count == 1
+        with patch("chat.bot._get_fact_check_agent", return_value=mock_agent):
+            await _get_button_by_label(view, "Get your facts STR8!").callback(
+                interaction
+            )
 
-    @pytest.mark.asyncio
-    async def test_different_thinking_texts_produce_different_messages(self):
-        """Two separate views with different thinking texts send different content."""
-        view_a = ThinkingView("reasoning A")
-        view_b = ThinkingView("reasoning B")
-        interaction_a = _make_interaction()
-        interaction_b = _make_interaction()
-
-        await _get_button(view_a).callback(interaction_a)
-        await _get_button(view_b).callback(interaction_b)
-
-        args_a, _ = interaction_a.response.send_message.call_args
-        args_b, _ = interaction_b.response.send_message.call_args
-        assert args_a[0] == "reasoning A"
-        assert args_b[0] == "reasoning B"
+        interaction.response.defer.assert_called_once()
+        interaction.followup.send.assert_called_once()
+        call_args = interaction.followup.send.call_args
+        assert "Fact check:" in call_args[0][0]
+        assert "accurate" in call_args[0][0]
 
     @pytest.mark.asyncio
-    async def test_button_callback_is_independent_of_button_label(self):
-        """The stored thinking text is what's sent — button label has no effect."""
-        view = ThinkingView("consistent thinking")
-        interaction_1 = _make_interaction()
-        interaction_2 = _make_interaction()
+    async def test_fact_check_passes_response_text_to_agent(self):
+        """The agent receives the bot's response text as the prompt."""
+        response = "The AIM-7P is a 1970s semi-active round."
+        view = BotMessageView(response)
+        interaction = _make_interaction()
 
-        # Call the same button callback twice with separate interactions
-        button = _get_button(view)
-        await button.callback(interaction_1)
-        await button.callback(interaction_2)
+        mock_result = MagicMock()
+        mock_result.output = "Actually the AIM-7P is a modernized variant."
+        mock_agent = AsyncMock()
+        mock_agent.run = AsyncMock(return_value=mock_result)
 
-        args_1, kwargs_1 = interaction_1.response.send_message.call_args
-        args_2, kwargs_2 = interaction_2.response.send_message.call_args
-        assert args_1[0] == args_2[0] == "consistent thinking"
-        assert kwargs_1.get("ephemeral") is True
-        assert kwargs_2.get("ephemeral") is True
+        with patch("chat.bot._get_fact_check_agent", return_value=mock_agent):
+            await _get_button_by_label(view, "Get your facts STR8!").callback(
+                interaction
+            )
+
+        call_args = mock_agent.run.call_args
+        assert response in call_args[0][0]
+
+    @pytest.mark.asyncio
+    async def test_agent_failure_sends_ephemeral_error(self):
+        """If the fact-check agent fails, an ephemeral error is sent."""
+        view = BotMessageView("some bot response")
+        interaction = _make_interaction()
+
+        mock_agent = AsyncMock()
+        mock_agent.run = AsyncMock(side_effect=Exception("LLM timeout"))
+
+        with patch("chat.bot._get_fact_check_agent", return_value=mock_agent):
+            await _get_button_by_label(view, "Get your facts STR8!").callback(
+                interaction
+            )
+
+        interaction.response.defer.assert_called_once()
+        call_args = interaction.followup.send.call_args
+        assert call_args.kwargs.get("ephemeral") is True
+
+    @pytest.mark.asyncio
+    async def test_long_fact_check_result_is_truncated(self):
+        """Results over the Discord message limit are truncated."""
+        view = BotMessageView("some response")
+        interaction = _make_interaction()
+
+        mock_result = MagicMock()
+        mock_result.output = "x" * 3000
+        mock_agent = AsyncMock()
+        mock_agent.run = AsyncMock(return_value=mock_result)
+
+        with patch("chat.bot._get_fact_check_agent", return_value=mock_agent):
+            await _get_button_by_label(view, "Get your facts STR8!").callback(
+                interaction
+            )
+
+        sent_content = interaction.followup.send.call_args[0][0]
+        assert len(sent_content) <= 2000
+        assert "truncated" in sent_content

--- a/projects/monolith/chat/store.py
+++ b/projects/monolith/chat/store.py
@@ -402,6 +402,16 @@ class MessageStore:
         )
         return list(self.session.exec(stmt).all())
 
+    def get_recent_bot_messages(self, limit: int = 200) -> list[Message]:
+        """Return recent bot messages for button view re-registration on startup."""
+        stmt = (
+            select(Message)
+            .where(Message.is_bot == True)  # noqa: E712
+            .order_by(Message.created_at.desc())
+            .limit(limit)
+        )
+        return list(self.session.exec(stmt).all())
+
     # -- Message lock operations ------------------------------------------------
 
     def acquire_lock(self, discord_message_id: str, channel_id: str) -> bool:

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.234.0
+      targetRevision: 0.235.0
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.235.0
+      targetRevision: 0.235.1
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.235.1
+      targetRevision: 0.235.2
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.233.2
+      targetRevision: 0.234.0
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
## Summary

- Adds a red **Get your facts STR8!** button to every bot response alongside the existing Show thinking button
- When clicked, Bosun defers the interaction, runs the response through a lightweight Qwen agent armed with SearXNG web search, and posts the verdict publicly in-channel in the same voice
- `BotMessageView` replaces `ThinkingView`: Show thinking appears only when reasoning text exists, fact-check button is always present
- On pod restart, `on_ready` now re-registers views for ALL recent bot messages (not just those with thinking text), so the fact-check button survives restarts

## Changes

- `chat/bot.py`: `ThinkingView` -> `BotMessageView` with new `fact_check` button; `_stream_response` always attaches view; `on_ready` uses `get_recent_bot_messages()`
- `chat/agent.py`: `create_fact_check_agent()` -- Qwen + `web_search` tool + Bosun fact-check system prompt, no chat deps needed
- `chat/store.py`: `get_recent_bot_messages()` for restart re-registration
- Tests updated for two-button layout and new `TestFactCheckCallback` class

## Test plan

- [ ] CI passes (unit tests cover show_thinking and fact_check callbacks, button visibility logic, view re-registration)
- [ ] After merge: click the button in Discord and confirm Bosun searches + posts a public fact-check reply in-channel
- [ ] Verify button survives a pod restart (on_ready re-registration)

Generated with [Claude Code](https://claude.com/claude-code)