### PR TITLE
feat(discord): rate-limit fact-check, stream it into a thread

### DIFF
--- a/projects/monolith/chat/agent.py
+++ b/projects/monolith/chat/agent.py
@@ -280,7 +280,9 @@ def create_fact_check_agent(base_url: str | None = None) -> "Agent[None]":
             "Search the web to verify the key factual claims you made. Be direct and honest: "
             "call out anything wrong, anything you oversimplified, and confirm what you got right. "
             "Keep the same confident, no-BS tone -- no hedging, no filler. "
-            "Lead with the verdict, then bullet the specifics."
+            "Be brief: one short verdict line, then at most three terse bullets on the "
+            "specifics that actually matter. Hard ceiling of about 120 words -- skip the "
+            "throat-clearing, the recap of your own response, and the section headers."
         ),
         model_settings=ModelSettings(
             temperature=1.0,

--- a/projects/monolith/chat/bot.py
+++ b/projects/monolith/chat/bot.py
@@ -38,6 +38,12 @@ LLM_MAX_RETRIES = 3
 LLM_RETRY_BASE_DELAY = 1.0  # seconds
 STREAM_EDIT_INTERVAL = 1.0
 
+# Fact-check (the "Get your facts STR8!" button). The result streams into a
+# thread anchored to the response so it stays out of the main channel.
+FACT_CHECK_PREFIX = "**Fact check:**\n"
+FACT_CHECK_THREAD_NAME = "Fact check"
+FACT_CHECK_PLACEHOLDER = "\U0001f50d Fact-checking..."
+
 
 def _truncate_thinking(thinking: str) -> str:
     """Truncate thinking text if it exceeds Discord's message limit."""
@@ -119,6 +125,45 @@ def _get_recent_context(channel_id: str) -> str:
         return format_context_messages(recent, {})
 
 
+def _clip_fact_check(text: str) -> str:
+    """Clip a fact-check body to Discord's single-message limit."""
+    if len(text) <= DISCORD_MESSAGE_LIMIT:
+        return text
+    return text[:THINKING_TRUNCATE_AT] + "... (truncated)"
+
+
+async def _stream_fact_check(message: discord.Message, agent, prompt: str) -> str:
+    """Stream the fact-check agent's output into an already-posted ``message``.
+
+    Edits ``message`` on the ``STREAM_EDIT_INTERVAL`` cadence as text deltas
+    arrive (so Discord rate limits are respected, mirroring ``_stream_response``
+    and the goosecracker progress stream), then a final edit with the
+    authoritative output. Returns the final fact-check text.
+    """
+    streamed = ""
+    final = ""
+    last_edit = 0.0
+    async for event in agent.run_stream_events(prompt):
+        if isinstance(event, AgentRunResultEvent):
+            out = event.result.output
+            if out and isinstance(out, str):
+                final = out
+        elif isinstance(event, PartDeltaEvent) and isinstance(
+            event.delta, TextPartDelta
+        ):
+            streamed += event.delta.content_delta
+            now = asyncio.get_event_loop().time()
+            if (now - last_edit) >= STREAM_EDIT_INTERVAL:
+                await message.edit(
+                    content=_clip_fact_check(FACT_CHECK_PREFIX + streamed)
+                )
+                last_edit = now
+
+    body = final or streamed
+    await message.edit(content=_clip_fact_check(FACT_CHECK_PREFIX + body))
+    return body
+
+
 class BotMessageView(discord.ui.View):
     """Discord View with action buttons on bot responses.
 
@@ -151,7 +196,27 @@ class BotMessageView(discord.ui.View):
     async def fact_check(
         self, interaction: discord.Interaction, button: discord.ui.Button
     ):
+        # Durable one-per-message limit. A fact-check opens a thread anchored to
+        # this message; Discord keeps ``message.thread`` populated across bot
+        # restarts, so its presence means the message was already checked.
+        existing = getattr(interaction.message, "thread", None)
+        if existing is not None:
+            await interaction.response.send_message(
+                f"Already fact-checked in {existing.mention}.", ephemeral=True
+            )
+            return
+
         await interaction.response.defer()
+
+        # Disable the button so it can't be spammed. The edited (disabled)
+        # component is stored on the message itself, so it survives a bot
+        # restart even though the re-registered persistent view starts enabled.
+        button.disabled = True
+        try:
+            await interaction.message.edit(view=self)
+        except discord.HTTPException:
+            logger.exception("Fact-check: failed to disable button")
+
         try:
             channel_id = str(interaction.channel.id)
             context = await asyncio.to_thread(_get_recent_context, channel_id)
@@ -162,11 +227,22 @@ class BotMessageView(discord.ui.View):
                 )
             else:
                 prompt = f"Fact-check this response:\n\n{self.response_text}"
-            result = await _get_fact_check_agent().run(prompt)
-            out = f"**Fact check:**\n{result.output}"
-            if len(out) > DISCORD_MESSAGE_LIMIT:
-                out = out[:THINKING_TRUNCATE_AT] + "... (truncated)"
-            await interaction.followup.send(out)
+
+            # Keep the fact-check out of the main channel: stream it inside a
+            # thread anchored to the response. Discord forbids nested threads,
+            # so if we're already inside one, fall back to an inline followup.
+            try:
+                thread = await interaction.message.create_thread(
+                    name=FACT_CHECK_THREAD_NAME
+                )
+                await interaction.followup.send(
+                    f"Fact-checking in {thread.mention}", ephemeral=True
+                )
+                placeholder = await thread.send(FACT_CHECK_PLACEHOLDER)
+            except discord.HTTPException:
+                placeholder = await interaction.followup.send(FACT_CHECK_PLACEHOLDER)
+
+            await _stream_fact_check(placeholder, _get_fact_check_agent(), prompt)
         except Exception:
             logger.exception("Fact-check failed")
             await interaction.followup.send(

--- a/projects/monolith/chat/bot_thinking_view_callback_test.py
+++ b/projects/monolith/chat/bot_thinking_view_callback_test.py
@@ -2,27 +2,54 @@
 
 Covers the show_thinking and fact_check button handlers:
 - show_thinking sends the AI reasoning text as an ephemeral private message.
-- fact_check defers the interaction, calls the fact-check agent, and sends a
-  public followup with the result.
+- fact_check defers, disables its button (one-per-message limit), opens a
+  thread anchored to the response, and streams the fact-check into it, falling
+  back to an inline followup when a thread can't be created.
 """
 
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import discord
+from pydantic_ai import PartDeltaEvent, TextPartDelta
 
 from chat.bot import BotMessageView
 
 
+def _text_delta(content: str) -> PartDeltaEvent:
+    return PartDeltaEvent(index=0, delta=TextPartDelta(content_delta=content))
+
+
+async def _async_iter(events):
+    for e in events:
+        yield e
+
+
 def _make_interaction() -> AsyncMock:
-    """Return a fully mocked Discord Interaction."""
+    """Return a fully mocked Discord Interaction.
+
+    The ``message`` is wired for the fact-check path: no existing thread,
+    an editable view, and a ``create_thread`` that yields a sendable thread
+    whose ``send`` returns an editable placeholder message.
+    """
     interaction = AsyncMock()
     interaction.response = AsyncMock()
     interaction.response.send_message = AsyncMock()
     interaction.response.defer = AsyncMock()
     interaction.response.edit_message = AsyncMock()
     interaction.followup = AsyncMock()
-    interaction.followup.send = AsyncMock()
+    interaction.followup.send = AsyncMock(return_value=AsyncMock())
+
+    placeholder = AsyncMock()
+    placeholder.edit = AsyncMock()
+    thread = AsyncMock()
+    thread.mention = "<#555>"
+    thread.send = AsyncMock(return_value=placeholder)
+
+    interaction.message = AsyncMock()
+    interaction.message.thread = None
+    interaction.message.edit = AsyncMock()
+    interaction.message.create_thread = AsyncMock(return_value=thread)
     return interaction
 
 
@@ -104,11 +131,15 @@ class TestShowThinkingCallback:
 
 
 def _patch_fact_check(mock_output: str, context: str = ""):
-    """Patch both the fact-check agent and context lookup for button callback tests."""
-    mock_result = MagicMock()
-    mock_result.output = mock_output
-    mock_agent = AsyncMock()
-    mock_agent.run = AsyncMock(return_value=mock_result)
+    """Patch the streaming fact-check agent and the context lookup.
+
+    The agent yields ``mock_output`` as a single ``run_stream_events`` text
+    delta; the streamed body is the accumulated delta text.
+    """
+    mock_agent = MagicMock()
+    mock_agent.run_stream_events = MagicMock(
+        return_value=_async_iter([_text_delta(mock_output)])
+    )
     return (
         patch("chat.bot._get_fact_check_agent", return_value=mock_agent),
         patch("chat.bot._get_recent_context", return_value=context),
@@ -116,12 +147,17 @@ def _patch_fact_check(mock_output: str, context: str = ""):
     )
 
 
+def _streamed_message(interaction) -> AsyncMock:
+    """The placeholder message the fact-check streamed into (thread path)."""
+    return interaction.message.create_thread.return_value.send.return_value
+
+
 class TestFactCheckCallback:
     """Unit tests for BotMessageView.fact_check() button callback."""
 
     @pytest.mark.asyncio
-    async def test_defers_then_sends_followup(self):
-        """fact_check defers the interaction and sends a public followup."""
+    async def test_opens_thread_and_streams_result(self):
+        """fact_check defers, opens a thread, and streams the result into it."""
         view = BotMessageView("The R-27ER has active radar homing.")
         interaction = _make_interaction()
 
@@ -134,10 +170,65 @@ class TestFactCheckCallback:
             )
 
         interaction.response.defer.assert_called_once()
-        interaction.followup.send.assert_called_once()
-        call_args = interaction.followup.send.call_args
-        assert "Fact check:" in call_args[0][0]
-        assert "accurate" in call_args[0][0]
+        interaction.message.create_thread.assert_called_once()
+        final = _streamed_message(interaction).edit.call_args.kwargs["content"]
+        assert "Fact check:" in final
+        assert "accurate" in final
+
+    @pytest.mark.asyncio
+    async def test_button_disabled_after_use(self):
+        """The fact-check button is disabled and the view re-edited onto the message."""
+        view = BotMessageView("some claim")
+        interaction = _make_interaction()
+        button = _get_button_by_label(view, "Get your facts STR8!")
+
+        p1, p2, _ = _patch_fact_check("Looks right.")
+        with p1, p2:
+            await button.callback(interaction)
+
+        assert button.disabled is True
+        interaction.message.edit.assert_called_once()
+        assert interaction.message.edit.call_args.kwargs.get("view") is view
+
+    @pytest.mark.asyncio
+    async def test_existing_thread_blocks_repeat(self):
+        """A message that already has a thread is not fact-checked again."""
+        view = BotMessageView("some claim")
+        interaction = _make_interaction()
+        interaction.message.thread = MagicMock(mention="<#999>")
+
+        p1, p2, mock_agent = _patch_fact_check("should not run")
+        with p1, p2:
+            await _get_button_by_label(view, "Get your facts STR8!").callback(
+                interaction
+            )
+
+        interaction.response.defer.assert_not_called()
+        mock_agent.run_stream_events.assert_not_called()
+        assert (
+            interaction.response.send_message.call_args.kwargs.get("ephemeral") is True
+        )
+
+    @pytest.mark.asyncio
+    async def test_inline_fallback_when_thread_creation_fails(self):
+        """If a thread can't be opened, the fact-check streams inline instead."""
+        view = BotMessageView("some claim")
+        interaction = _make_interaction()
+        interaction.message.create_thread = AsyncMock(
+            side_effect=discord.HTTPException(MagicMock(), "no nested threads")
+        )
+
+        p1, p2, _ = _patch_fact_check("Inline verdict.")
+        with p1, p2:
+            await _get_button_by_label(view, "Get your facts STR8!").callback(
+                interaction
+            )
+
+        # The placeholder posted inline is the followup.send return value; it is
+        # the message the stream edits with the final body.
+        interaction.followup.send.assert_any_call("\U0001f50d Fact-checking...")
+        final = interaction.followup.send.return_value.edit.call_args.kwargs["content"]
+        assert "Inline verdict." in final
 
     @pytest.mark.asyncio
     async def test_response_text_included_in_prompt(self):
@@ -154,7 +245,7 @@ class TestFactCheckCallback:
                 interaction
             )
 
-        assert response in mock_agent.run.call_args[0][0]
+        assert response in mock_agent.run_stream_events.call_args[0][0]
 
     @pytest.mark.asyncio
     async def test_conversation_context_prepended_when_available(self):
@@ -169,7 +260,7 @@ class TestFactCheckCallback:
                 interaction
             )
 
-        prompt = mock_agent.run.call_args[0][0]
+        prompt = mock_agent.run_stream_events.call_args[0][0]
         assert "Recent conversation:" in prompt
         assert context in prompt
         assert "The Sparrow needs continuous radar lock." in prompt
@@ -186,7 +277,9 @@ class TestFactCheckCallback:
                 interaction
             )
 
-        assert "Recent conversation:" not in mock_agent.run.call_args[0][0]
+        assert (
+            "Recent conversation:" not in mock_agent.run_stream_events.call_args[0][0]
+        )
 
     @pytest.mark.asyncio
     async def test_agent_failure_sends_ephemeral_error(self):
@@ -194,8 +287,8 @@ class TestFactCheckCallback:
         view = BotMessageView("some bot response")
         interaction = _make_interaction()
 
-        mock_agent = AsyncMock()
-        mock_agent.run = AsyncMock(side_effect=Exception("LLM timeout"))
+        mock_agent = MagicMock()
+        mock_agent.run_stream_events = MagicMock(side_effect=Exception("LLM timeout"))
         with (
             patch("chat.bot._get_fact_check_agent", return_value=mock_agent),
             patch("chat.bot._get_recent_context", return_value=""),
@@ -219,6 +312,6 @@ class TestFactCheckCallback:
                 interaction
             )
 
-        sent_content = interaction.followup.send.call_args[0][0]
-        assert len(sent_content) <= 2000
-        assert "truncated" in sent_content
+        final = _streamed_message(interaction).edit.call_args.kwargs["content"]
+        assert len(final) <= 2000
+        assert "truncated" in final


### PR DESCRIPTION
## Why

The "Get your facts STR8!" button (see screenshot in the linked discussion) dumped a full, non-streaming wall of text straight into the main channel with no limit. That was noisy, slow (a silent multi-second wait, then a giant message), and trivially spammable, one click per message with no guard.

## What changed

All in `projects/monolith/chat/`:

1. **Shorter output** (`agent.py`): the fact-check system prompt now asks for a one-line verdict plus at most three terse bullets, with a ~120-word ceiling, instead of the open-ended "lead with the verdict, then bullet the specifics" that produced the wall of text.

2. **Streams like the others** (`bot.py`): swapped `agent.run()` for `agent.run_stream_events()`, editing the message on the existing `STREAM_EDIT_INTERVAL` (1.0s) cadence, the same idiom as `_stream_response` and the goosecracker progress stream. Latency is now visible instead of a silent wait.

3. **Lands in a thread** (`bot.py`): the fact-check opens a public thread anchored to the response and streams there, keeping the main channel clean. A short ephemeral pointer ("Fact-checking in #thread") goes to the clicker. If a thread can't be created (Discord forbids nested threads, i.e. the button was clicked from inside a thread), it falls back to streaming an inline followup.

4. **One fact-check per message** (`bot.py`), durable across restarts via two layers:
   - The button is disabled on use and the view re-edited onto the message. The disabled component is stored on the message itself, and startup `add_view(...)` only re-wires interaction routing (it does not re-edit the message), so the disabled state survives a pod restart.
   - An existing `message.thread` short-circuits a repeat click with an ephemeral pointer to the existing thread.

## Tests

Rewrote the fact-check unit tests in `bot_thinking_view_callback_test.py` for the new streaming + thread surface: thread-open + stream, button-disable, existing-thread short-circuit, inline fallback when thread creation fails, prompt-context plumbing, ephemeral error on agent failure, and long-result truncation. The `show_thinking` tests and the button style/custom_id tests in `bot_thinking_test.py` are unaffected (the button definition is unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)