### PR TITLE
fix(discord): ground fact-check in live search + current date

### DIFF
--- a/projects/monolith/chat/agent.py
+++ b/projects/monolith/chat/agent.py
@@ -3,6 +3,7 @@
 import logging
 import os
 from dataclasses import dataclass, replace
+from datetime import datetime, timezone
 from typing import Any
 
 from pydantic_ai import Agent, ModelSettings, RunContext, ToolDefinition
@@ -16,7 +17,49 @@ from chat.web_search import search_web
 
 LLAMA_CPP_URL = os.environ.get("LLAMA_CPP_URL", "")
 
+# The served inference model's knowledge cutoff. Qwen did not publish a cutoff
+# for Qwen3.6-35B-A3B (released 2026-04-16), so we anchor to the release month
+# as a conservative bound: the true cutoff is at or before it, so telling the
+# model its knowledge ends here never overstates what it knows, and correctly
+# frames anything more recent as beyond its training. Update when the served
+# model changes.
+MODEL_KNOWLEDGE_CUTOFF = "April 2026"
+
 logger = logging.getLogger(__name__)
+
+
+def today_str() -> str:
+    """Today's date at day granularity (e.g. "30 June 2026").
+
+    Day granularity is deliberate: this string goes into a dynamic system
+    prompt, which is part of the KV-cache prefix. A finer (per-request)
+    timestamp would evict the shared prefix on every call; at day granularity
+    the prefix is byte-stable within a day, so vLLM keeps the cache hot and
+    pays at most one eviction per day.
+    """
+    now = datetime.now(timezone.utc)
+    return f"{now.day} {now:%B %Y}"
+
+
+def temporal_grounding_prompt() -> str:
+    """Dynamic system-prompt fragment anchoring the model in real time.
+
+    Registered as a per-run system prompt on both agents so the model knows
+    today's date and that its training is stale past the cutoff -- the gap
+    where it would otherwise confidently assert outdated "facts" about recent
+    releases and events. Re-evaluated each run (the agents are process-lifetime
+    singletons, so a value baked in at creation would freeze at pod-start day).
+    """
+    return (
+        f"Today's date is {today_str()}. Your training knowledge cutoff is "
+        f"{MODEL_KNOWLEDGE_CUTOFF}; you cannot know anything after it. New model "
+        "releases, product launches, announcements, and current events after "
+        "your cutoff are exactly where your memory is blind and wrong. For any "
+        "claim about recent or current facts, do not answer from memory -- "
+        "search the web. Treat search results as more authoritative than your "
+        "training data when they conflict, and never call something false, fake, "
+        "or fabricated just because you do not recognise it; search first."
+    )
 
 
 def signposted(text: str):
@@ -160,6 +203,10 @@ def create_agent(base_url: str | None = None) -> Agent[ChatDeps]:
         prepare_tools=inject_signposts,
     )
 
+    @agent.system_prompt
+    def _temporal_grounding() -> str:
+        return temporal_grounding_prompt()
+
     @agent.tool_plain
     @signposted(
         "Default to searching. The only time you should skip search is for "
@@ -277,8 +324,12 @@ def create_fact_check_agent(base_url: str | None = None) -> "Agent[None]":
         model,
         system_prompt=(
             "You're Bosun, and someone just hit the fact-check button on your last response. "
-            "Search the web to verify the key factual claims you made. Be direct and honest: "
-            "call out anything wrong, anything you oversimplified, and confirm what you got right. "
+            "Live web search results for the claims are provided in the prompt, and you can "
+            "search again with the web_search tool. Base your verdict on those results, not "
+            "on your training memory -- you have a knowledge cutoff and are blind to anything "
+            "after it, so a claim about a recent release or event is NOT false just because "
+            "you don't recognise it; check the results first. Be direct and honest: call out "
+            "what's actually wrong, flag what you oversimplified, and confirm what's right. "
             "Keep the same confident, no-BS tone -- no hedging, no filler. "
             "Be brief: one short verdict line, then at most three terse bullets on the "
             "specifics that actually matter. Hard ceiling of about 120 words -- skip the "
@@ -293,6 +344,10 @@ def create_fact_check_agent(base_url: str | None = None) -> "Agent[None]":
             },
         ),
     )
+
+    @fact_agent.system_prompt
+    def _temporal_grounding() -> str:
+        return temporal_grounding_prompt()
 
     @fact_agent.tool_plain
     async def web_search(query: str) -> str:

--- a/projects/monolith/chat/agent_temporal_grounding_test.py
+++ b/projects/monolith/chat/agent_temporal_grounding_test.py
@@ -1,0 +1,58 @@
+"""Tests for temporal grounding (today's date + knowledge cutoff) injection.
+
+The model was confidently calling true, post-cutoff facts "fabrication" because
+it answered from stale training memory. These helpers feed it today's date and
+its cutoff so it knows where its knowledge ends and must search instead.
+"""
+
+import re
+from unittest.mock import patch
+
+from chat.agent import (
+    MODEL_KNOWLEDGE_CUTOFF,
+    create_fact_check_agent,
+    temporal_grounding_prompt,
+    today_str,
+)
+
+
+class TestTodayStr:
+    def test_is_day_granular(self):
+        """The date is day-level (e.g. "30 June 2026"), not a finer timestamp.
+
+        Day granularity keeps the dynamic-system-prompt prefix stable within a
+        day so vLLM's KV cache is only evicted once per day, not per request.
+        """
+        assert re.fullmatch(r"\d{1,2} [A-Z][a-z]+ \d{4}", today_str())
+
+    def test_no_clock_time(self):
+        """No hours/minutes/seconds leak in (those would thrash the KV cache)."""
+        assert ":" not in today_str()
+
+
+class TestTemporalGroundingPrompt:
+    def test_includes_today_and_cutoff(self):
+        prompt = temporal_grounding_prompt()
+        assert today_str() in prompt
+        assert MODEL_KNOWLEDGE_CUTOFF in prompt
+
+    def test_instructs_to_search_not_trust_memory(self):
+        """The fragment must push the model off stale memory toward searching."""
+        prompt = temporal_grounding_prompt().lower()
+        assert "cutoff" in prompt
+        assert "search" in prompt
+        # The exact failure we are fixing: do not call something fake on sight.
+        assert "fabricated" in prompt or "false" in prompt
+
+
+class TestAgentConstruction:
+    def test_fact_check_agent_constructs_with_dynamic_grounding(self):
+        """create_fact_check_agent registers the dynamic system prompt cleanly.
+
+        The bot tests patch the fact-check agent, so this is the only coverage
+        that the ``@fact_agent.system_prompt`` decorator API is actually valid;
+        without it a pydantic-ai API mismatch would only surface at pod start.
+        """
+        with patch("chat.agent.LLAMA_CPP_URL", "http://fake:8080"):
+            agent = create_fact_check_agent(base_url="http://fake:8080")
+        assert agent is not None

--- a/projects/monolith/chat/bot.py
+++ b/projects/monolith/chat/bot.py
@@ -18,7 +18,12 @@ from pydantic_ai import (
     ThinkingPartDelta,
 )
 
-from chat.agent import create_agent, create_fact_check_agent, format_context_messages
+from chat.agent import (
+    create_agent,
+    create_fact_check_agent,
+    format_context_messages,
+    today_str,
+)
 from shared.embedding import EmbeddingClient
 from chat.store import MessageStore
 from chat.vision import VisionClient
@@ -43,6 +48,9 @@ STREAM_EDIT_INTERVAL = 1.0
 FACT_CHECK_PREFIX = "**Fact check:**\n"
 FACT_CHECK_THREAD_NAME = "Fact check"
 FACT_CHECK_PLACEHOLDER = "\U0001f50d Fact-checking..."
+# How much of the response seeds the mandatory pre-search query (claims usually
+# lead, and SearXNG handles a long query fine; this just bounds it).
+FACT_CHECK_SEARCH_SEED_CHARS = 500
 
 
 def _truncate_thinking(thinking: str) -> str:
@@ -130,6 +138,33 @@ def _clip_fact_check(text: str) -> str:
     if len(text) <= DISCORD_MESSAGE_LIMIT:
         return text
     return text[:THINKING_TRUNCATE_AT] + "... (truncated)"
+
+
+async def _build_fact_check_prompt(response_text: str, context: str) -> str:
+    """Build the fact-check prompt with fresh, searched grounding.
+
+    Prepends today's date and a mandatory live web search seeded from the
+    response, so the model judges against current reality instead of its stale
+    training memory (it was confidently calling true, post-cutoff facts
+    "fabrication"). The search is best-effort: on failure the agent still has
+    its own ``web_search`` tool, so we degrade to a no-results prompt rather
+    than aborting the fact-check.
+    """
+    parts = [f"Today is {today_str()}."]
+    try:
+        live = await search_web(response_text[:FACT_CHECK_SEARCH_SEED_CHARS])
+    except Exception:
+        logger.exception("Fact-check pre-search failed")
+        live = ""
+    if live:
+        parts.append(
+            "Live web search results for the claims (current ground truth, "
+            f"trust these over your memory):\n{live}"
+        )
+    if context:
+        parts.append(f"Recent conversation:\n{context}")
+    parts.append(f"Fact-check this response:\n\n{response_text}")
+    return "\n\n".join(parts)
 
 
 async def _stream_fact_check(message: discord.Message, agent, prompt: str) -> str:
@@ -220,13 +255,7 @@ class BotMessageView(discord.ui.View):
         try:
             channel_id = str(interaction.channel.id)
             context = await asyncio.to_thread(_get_recent_context, channel_id)
-            if context:
-                prompt = (
-                    f"Recent conversation:\n{context}\n\n"
-                    f"Fact-check your last response:\n\n{self.response_text}"
-                )
-            else:
-                prompt = f"Fact-check this response:\n\n{self.response_text}"
+            prompt = await _build_fact_check_prompt(self.response_text, context)
 
             # Keep the fact-check out of the main channel: stream it inside a
             # thread anchored to the response. Discord forbids nested threads,

--- a/projects/monolith/chat/bot_thinking_view_callback_test.py
+++ b/projects/monolith/chat/bot_thinking_view_callback_test.py
@@ -155,6 +155,16 @@ def _streamed_message(interaction) -> AsyncMock:
 class TestFactCheckCallback:
     """Unit tests for BotMessageView.fact_check() button callback."""
 
+    @pytest.fixture(autouse=True)
+    def _patch_search(self):
+        """Stub the mandatory pre-search so tests never hit SearXNG."""
+        with patch(
+            "chat.bot.search_web",
+            new=AsyncMock(return_value="LIVE_SEARCH_RESULTS"),
+        ) as m:
+            self.search = m
+            yield
+
     @pytest.mark.asyncio
     async def test_opens_thread_and_streams_result(self):
         """fact_check defers, opens a thread, and streams the result into it."""
@@ -315,3 +325,43 @@ class TestFactCheckCallback:
         final = _streamed_message(interaction).edit.call_args.kwargs["content"]
         assert len(final) <= 2000
         assert "truncated" in final
+
+    @pytest.mark.asyncio
+    async def test_pre_search_runs_and_results_injected(self):
+        """A live web search runs and its results plus today's date ground the prompt."""
+        from chat.agent import today_str
+
+        response = "Anthropic just dropped Sonnet 5, beats Opus on coding."
+        view = BotMessageView(response)
+        interaction = _make_interaction()
+
+        p1, p2, mock_agent = _patch_fact_check("Verdict: real, it shipped today.")
+        with p1, p2:
+            await _get_button_by_label(view, "Get your facts STR8!").callback(
+                interaction
+            )
+
+        # The search is seeded from the response and its results land in the prompt.
+        assert self.search.call_count == 1
+        assert response[:50] in self.search.call_args[0][0]
+        prompt = mock_agent.run_stream_events.call_args[0][0]
+        assert "LIVE_SEARCH_RESULTS" in prompt
+        assert today_str() in prompt
+
+    @pytest.mark.asyncio
+    async def test_pre_search_failure_degrades_gracefully(self):
+        """If the pre-search raises, the fact-check still runs without injected results."""
+        view = BotMessageView("some claim")
+        interaction = _make_interaction()
+        self.search.side_effect = Exception("SearXNG down")
+
+        p1, p2, mock_agent = _patch_fact_check("Verdict from the model's own tool.")
+        with p1, p2:
+            await _get_button_by_label(view, "Get your facts STR8!").callback(
+                interaction
+            )
+
+        mock_agent.run_stream_events.assert_called_once()
+        prompt = mock_agent.run_stream_events.call_args[0][0]
+        assert "LIVE_SEARCH_RESULTS" not in prompt
+        assert "some claim" in prompt


### PR DESCRIPTION
## Why

Follow-up to #2964. The fact-check button looked good but wasn't actually fact-checking, it answered from the model's **stale training memory** instead of searching. In testing it confidently called a true, post-cutoff fact ("Anthropic dropped Sonnet 5 today") a **"Total fabrication"**, because:

1. The `web_search` tool was optional and Qwen just skipped it.
2. The model had no idea what today's date was, or that its own training has a cutoff, so it couldn't reason about "could this have changed since I was trained?"

## What changed

**`bot.py` — mandatory pre-search (the fact-check):**
- Before the model judges, `_build_fact_check_prompt` runs one `search_web` seeded from the response and injects the results into the prompt as "current ground truth." The model can no longer answer purely from priors; it always has fresh data in front of it (and keeps its own `web_search` tool for follow-ups).
- Best-effort: if SearXNG is down the search is caught and we degrade to a no-results prompt rather than aborting the fact-check.

**`agent.py` — temporal grounding on BOTH agents (chat + fact-check):**
- A `temporal_grounding_prompt()` fragment injects **today's date** and the **knowledge cutoff** (`April 2026`, anchored to the [Qwen3.6-35B-A3B release](https://huggingface.co/Qwen/Qwen3.6-35B-A3B) of 2026-04-16 as a conservative bound, the vendor didn't publish an exact cutoff), and tells the model to search recent claims, trust results over memory, and never call something fake just because it doesn't recognise it.
- Registered as a **dynamic** system prompt (`@agent.system_prompt`), not baked in at construction, because the agents are process-lifetime singletons; a static value would read "today is [pod-start day]" forever until the next deploy.

**KV-cache aware (per review feedback):**
- The date is **day-granular** (`today_str()` → e.g. "30 June 2026", no clock time). The dynamic grounding sits at the tail of the system prompt, so the large static persona prefix stays cached and only the small dated tail recomputes, at most **once per day** instead of per request. A finer timestamp would thrash the vLLM prefix cache on every call.

## Tests

- `agent_temporal_grounding_test.py` (new): `today_str()` is day-granular with no clock time; `temporal_grounding_prompt()` includes today + cutoff + search framing; `create_fact_check_agent()` constructs cleanly (the only coverage that the `@fact_agent.system_prompt` decorator API is valid, since the bot tests patch the agent).
- `bot_thinking_view_callback_test.py`: autouse fixture stubs the pre-search; new tests assert the search runs + its results and today's date land in the prompt, and that a search failure degrades gracefully (fact-check still runs, no injected-results header). Existing thread/stream/rate-limit tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)