### PR TITLE
chore(monolith): bump chart version to 0.235.3

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.235.2
+version: 0.235.3
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.235.2
+      targetRevision: 0.235.3
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
Manual chart bump to deploy the fact-check changes that are merged but not live.

`59a91080a` (thread + streaming + one-per-message rate limit) and `db0ba18b1` (live-search grounding + current-date/cutoff injection) both merged and their backend images built and pushed to GHCR, but chart-version-bot's batched rebase hadn't run for these two rapid merges, so the chart stayed at `0.235.2` and ArgoCD kept serving the pre-change build (the live pod even regressed to a pre-#2964 image).

Bumps `chart/Chart.yaml` version and `deploy/application.yaml` OCI-source `targetRevision` together (0.235.2 → 0.235.3) so they stay in sync, per the repo's manual-bump rule. The chart build pins the latest backend image (db0ba18b1), so this carries both changes live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)