### PR TITLE
feat(discord): attribute fact-check to the clicker, hide button on use

### DIFF
--- a/projects/monolith/chat/bot.py
+++ b/projects/monolith/chat/bot.py
@@ -243,14 +243,15 @@ class BotMessageView(discord.ui.View):
 
         await interaction.response.defer()
 
-        # Disable the button so it can't be spammed. The edited (disabled)
-        # component is stored on the message itself, so it survives a bot
-        # restart even though the re-registered persistent view starts enabled.
-        button.disabled = True
+        # Remove the button so it can't be clicked again. The edited (button-
+        # removed) component is stored on the message itself, so it survives a
+        # bot restart even though the re-registered persistent view starts with
+        # the button present.
+        self.remove_item(button)
         try:
             await interaction.message.edit(view=self)
         except discord.HTTPException:
-            logger.exception("Fact-check: failed to disable button")
+            logger.exception("Fact-check: failed to remove button")
 
         try:
             channel_id = str(interaction.channel.id)
@@ -267,6 +268,10 @@ class BotMessageView(discord.ui.View):
                 await interaction.followup.send(
                     f"Fact-checking in {thread.mention}", ephemeral=True
                 )
+                # Attribute the check publicly so the channel knows who asked.
+                # Its own message, not the placeholder, which the stream
+                # overwrites with the verdict.
+                await thread.send(f"Fact-check requested by {interaction.user.mention}")
                 placeholder = await thread.send(FACT_CHECK_PLACEHOLDER)
             except discord.HTTPException:
                 placeholder = await interaction.followup.send(FACT_CHECK_PLACEHOLDER)

--- a/projects/monolith/chat/bot_thinking_view_callback_test.py
+++ b/projects/monolith/chat/bot_thinking_view_callback_test.py
@@ -46,6 +46,7 @@ def _make_interaction() -> AsyncMock:
     thread.mention = "<#555>"
     thread.send = AsyncMock(return_value=placeholder)
 
+    interaction.user.mention = "<@42>"
     interaction.message = AsyncMock()
     interaction.message.thread = None
     interaction.message.edit = AsyncMock()
@@ -181,13 +182,19 @@ class TestFactCheckCallback:
 
         interaction.response.defer.assert_called_once()
         interaction.message.create_thread.assert_called_once()
+        # The clicker is named publicly in the thread so the channel knows who
+        # to blame, in its own message (the placeholder is overwritten by the
+        # streamed verdict).
+        interaction.message.create_thread.return_value.send.assert_any_call(
+            "Fact-check requested by <@42>"
+        )
         final = _streamed_message(interaction).edit.call_args.kwargs["content"]
         assert "Fact check:" in final
         assert "accurate" in final
 
     @pytest.mark.asyncio
-    async def test_button_disabled_after_use(self):
-        """The fact-check button is disabled and the view re-edited onto the message."""
+    async def test_button_removed_after_use(self):
+        """The fact-check button is removed and the view re-edited onto the message."""
         view = BotMessageView("some claim")
         interaction = _make_interaction()
         button = _get_button_by_label(view, "Get your facts STR8!")
@@ -196,7 +203,7 @@ class TestFactCheckCallback:
         with p1, p2:
             await button.callback(interaction)
 
-        assert button.disabled is True
+        assert button not in view.children
         interaction.message.edit.assert_called_once()
         assert interaction.message.edit.call_args.kwargs.get("view") is view
 


### PR DESCRIPTION
## What

Two small UX changes to the Discord fact-check button (the red "Get your facts STR8!"), in response to a channel where the new feature flooded the channel with anonymous "started a thread: Fact check" lines.

- **Attribution:** the thread now opens with `Fact-check requested by @clicker`, so the channel knows who triggered each check (and the clicker gets pinged). It is its own message rather than the placeholder, because `_stream_fact_check` overwrites the placeholder content with the streamed verdict.
- **Hide on use:** after a check, the button is removed (`self.remove_item`) instead of greyed (`button.disabled = True`). Durability is unchanged: the removed component is stored on the message, so it survives a pod restart, and the existing `interaction.message.thread` guard still blocks repeats.

## Notes

`interaction.user` is the clicker (the button lives on a bot message, so `message.author` is the bot). Uses `display_name`-equivalent mention for an in-channel ping.

Scope is deliberately attribution + button hide only. A per-channel throttle / owner-gate to stop the broader flood is a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)