### PR TITLE
fix(fc-invoke): warm-restore latency (WaitReady per-attempt timeout)

### DIFF
--- a/projects/firecracker/substrate/invoke/internal/invoker/invoker.go
+++ b/projects/firecracker/substrate/invoke/internal/invoker/invoker.go
@@ -87,8 +87,17 @@ type Config struct {
 	// Arch pins the guest CPU architecture; FC snapshots are arch-affine and
 	// a mismatched restore fails closed.
 	Arch string
-	// BootReadyTimeout bounds the readiness poll after a cold boot or restore.
+	// BootReadyTimeout bounds the readiness poll after a COLD boot (a real boot
+	// plus in-guest warm-up can take seconds).
 	BootReadyTimeout time.Duration
+	// RestoreReadyTimeout bounds the readiness poll after a WARM restore. A
+	// restored guest is already warm, so it answers /shim/ready almost
+	// immediately; this short budget only needs to cover WaitReady retrying
+	// past the Firecracker post-restore vsock RX-queue race (the first
+	// connection can wedge; WaitReady abandons it per-attempt and reconnects).
+	// If a restore is not ready within this budget it is treated as unavailable
+	// and Invoke falls back to a cold boot. Defaults to 2s.
+	RestoreReadyTimeout time.Duration
 }
 
 // Invoker orchestrates invocations for one workload. The daemon creates one
@@ -115,6 +124,9 @@ func New(d vmDriver, t transport, cfg Config, logger *slog.Logger) *Invoker {
 	var sem *semaphore.Weighted
 	if cfg.Workload.Concurrency > 0 {
 		sem = semaphore.NewWeighted(int64(cfg.Workload.Concurrency))
+	}
+	if cfg.RestoreReadyTimeout <= 0 {
+		cfg.RestoreReadyTimeout = 2 * time.Second
 	}
 	return &Invoker{driver: d, transport: t, sem: sem, cfg: cfg, logger: logger}
 }
@@ -215,7 +227,7 @@ func (inv *Invoker) Invoke(ctx context.Context, session string, body io.Reader) 
 			ThreadID:        session,
 			BaseSnapshotRef: base,
 		}
-		resp, cleanup, err := inv.claimInvoke(ctx, warmSpec, session, body)
+		resp, cleanup, err := inv.claimInvoke(ctx, warmSpec, session, body, true)
 		if err == nil {
 			return ownResponse(resp, cleanup, releaseSlot), nil
 		}
@@ -238,7 +250,7 @@ func (inv *Invoker) Invoke(ctx context.Context, session string, body io.Reader) 
 		Arch:     inv.cfg.Arch,
 		ThreadID: session,
 	}
-	resp, cleanup, err := inv.claimInvoke(ctx, coldSpec, session, body)
+	resp, cleanup, err := inv.claimInvoke(ctx, coldSpec, session, body, false)
 	if err != nil {
 		releaseSlot()
 		return nil, err
@@ -258,7 +270,7 @@ func (inv *Invoker) Invoke(ctx context.Context, session string, body io.Reader) 
 //
 // A Claim or WaitReady failure returns *GuestUnavailableError. A RoundTrip
 // failure is returned as-is (the caller decides the 502/503 mapping).
-func (inv *Invoker) claimInvoke(ctx context.Context, spec substrate.ClaimSpec, session string, body io.Reader) (*http.Response, func(), error) {
+func (inv *Invoker) claimInvoke(ctx context.Context, spec substrate.ClaimSpec, session string, body io.Reader, warm bool) (*http.Response, func(), error) {
 	h, err := inv.driver.Claim(ctx, spec)
 	if err != nil {
 		return nil, nil, &GuestUnavailableError{Err: fmt.Errorf("claim guest: %w", err)}
@@ -266,9 +278,19 @@ func (inv *Invoker) claimInvoke(ctx context.Context, spec substrate.ClaimSpec, s
 
 	uds := inv.driver.VsockUDSPath(h.ThreadID)
 
-	// The readiness wait uses its own short-lived context, always cancelled here
-	// (it never bounds the response body, only the boot handshake).
-	readyCtx, cancelReady := context.WithTimeout(ctx, inv.cfg.BootReadyTimeout)
+	// A warm restore is already warmed in the snapshot, so it answers /shim/ready
+	// almost immediately; use the short RestoreReadyTimeout so a wedged or dead
+	// restore fails fast and falls back to a cold boot. A cold boot needs the
+	// full BootReadyTimeout to cover the real boot plus in-guest warm-up.
+	// WaitReady itself retries past the post-restore vsock RX-queue race
+	// (per-attempt deadline), so no separate "prime" is needed. The readiness
+	// wait uses its own short-lived context, always cancelled here (it never
+	// bounds the response body).
+	readyTimeout := inv.cfg.BootReadyTimeout
+	if warm {
+		readyTimeout = inv.cfg.RestoreReadyTimeout
+	}
+	readyCtx, cancelReady := context.WithTimeout(ctx, readyTimeout)
 	readyErr := inv.transport.WaitReady(readyCtx, uds, inv.cfg.Workload.ReadyPath)
 	cancelReady()
 	if readyErr != nil {
@@ -291,11 +313,19 @@ func (inv *Invoker) claimInvoke(ctx context.Context, spec substrate.ClaimSpec, s
 	}
 	resp, err := inv.transport.RoundTrip(rtCtx, uds, req)
 	if err != nil {
-		// RoundTrip errors are NOT wrapped as GuestUnavailableError: the guest
-		// ran and the round-trip itself failed (HTTP 502 territory). No body to
-		// own, so clean up eagerly.
 		cancelRT()
 		inv.discard(h)
+		if warm {
+			// On the warm path a transport-level round-trip failure (the
+			// connection broke mid-request) after readiness passed suggests the
+			// restored guest is flaky. Surface it as unavailable so Invoke
+			// invalidates the base and retries on a cold boot rather than
+			// returning a hard 502.
+			return nil, nil, &GuestUnavailableError{Err: fmt.Errorf("warm round-trip: %w", err)}
+		}
+		// Cold path: the guest booted and proved ready, so a round-trip failure
+		// is an HTTP-leg error (502 territory), not a guest-unavailable case.
+		// No body to own, so clean up eagerly.
 		return nil, nil, err
 	}
 	// Success: the response body is a lazy stream over the still-live guest.

--- a/projects/firecracker/substrate/invoke/internal/invoker/invoker_test.go
+++ b/projects/firecracker/substrate/invoke/internal/invoker/invoker_test.go
@@ -391,6 +391,54 @@ func TestInvokeColdFallbackWhenNoBase(t *testing.T) {
 	}
 }
 
+// TestInvokeWarmRoundTripFailureFallsBackToCold verifies that a transport-level
+// round-trip failure on the WARM path (a flaky restore whose connection breaks
+// after readiness passed) is treated as guest-unavailable: the base is
+// invalidated and Invoke retries on a cold boot rather than returning a hard
+// 502. The cold retry succeeds, so the caller gets a 200.
+func TestInvokeWarmRoundTripFailureFallsBackToCold(t *testing.T) {
+	drv := &fakeDriver{}
+	// The first round-trip (warm attempt) fails at the transport level; the
+	// second (cold fallback) succeeds. WaitReady succeeds throughout (default).
+	rtCalls := 0
+	tr := &funcTransport{
+		roundTripFn: func(_ context.Context, _ string, _ *http.Request) (*http.Response, error) {
+			rtCalls++
+			if rtCalls == 1 {
+				return nil, errors.New("warm vsock connection broke")
+			}
+			return okResponse("ok"), nil
+		},
+	}
+	inv := New(drv, tr, defaultConfig(), nil) // WarmBase enabled
+	if err := inv.BuildBase(context.Background()); err != nil {
+		t.Fatalf("BuildBase: %v", err)
+	}
+
+	resp, err := inv.Invoke(context.Background(), "sess-warm-flaky", strings.NewReader("body"))
+	if err != nil {
+		t.Fatalf("Invoke should have fallen back to cold and succeeded, got: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want 200", resp.StatusCode)
+	}
+
+	// BuildBase claimed one VM; the warm attempt claimed another (failed); the
+	// cold fallback claimed a third (succeeded). The failed warm attempt's VM
+	// must have been released eagerly.
+	if c := drv.claimCount(); c != 3 {
+		t.Errorf("Claim called %d time(s), want 3 (BuildBase + warm + cold)", c)
+	}
+	if rtCalls != 2 {
+		t.Errorf("RoundTrip called %d time(s), want 2 (warm fail + cold success)", rtCalls)
+	}
+	// The last claim (cold fallback) must carry an empty base ref.
+	if spec := drv.lastClaimSpec(); spec.BaseSnapshotRef.ID != "" {
+		t.Errorf("cold-fallback BaseSnapshotRef.ID = %q, want empty", spec.BaseSnapshotRef.ID)
+	}
+}
+
 // TestBuildBaseStoresRef verifies that BuildBase boots a VM, snapshots it, and
 // stores the resulting ref so that a subsequent Invoke restores from it
 // (BaseSnapshotRef on the Claim spec is the stored base ID).

--- a/projects/firecracker/substrate/invoke/internal/vsockhttp/transport.go
+++ b/projects/firecracker/substrate/invoke/internal/vsockhttp/transport.go
@@ -101,31 +101,58 @@ func (t *Transport) RoundTrip(ctx context.Context, udsPath string, req *http.Req
 // empty. On timeout it returns a descriptive error wrapping ctx.Err().
 //
 // Any error from RoundTrip (such as a connection-refused while the guest is
-// still starting) is treated as "not ready yet" and causes a retry. The poll
-// interval is 50 ms.
+// still starting) is treated as "not ready yet" and causes a retry.
+//
+// Each attempt is bounded by its own short deadline (waitReadyAttempt), NOT the
+// outer ctx. This is load-bearing for warm restores: the first post-restore
+// vsock connection can wedge on Firecracker's RX-queue race, and its
+// CONNECT-reply read would otherwise block for the full outer deadline before
+// the retry loop ever runs. Capping per attempt abandons a wedged connection
+// quickly and reconnects, so WaitReady returns the instant the guest answers
+// (usually the first or second attempt) instead of hanging.
 func (t *Transport) WaitReady(ctx context.Context, udsPath, readyPath string) error {
 	if readyPath == "" {
 		readyPath = "/shim/ready"
 	}
 	for {
-		req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://vsock"+readyPath, nil)
-		if err != nil {
-			return fmt.Errorf("vsockhttp: build ready request: %w", err)
+		if err := t.readyAttempt(ctx, udsPath, readyPath); err == nil {
+			return nil
 		}
-		resp, err := t.RoundTrip(ctx, udsPath, req)
-		if err == nil {
-			_ = resp.Body.Close()
-			if resp.StatusCode == http.StatusOK {
-				return nil
-			}
-		}
-		// Any error or non-200 response is retriable; stop only when ctx fires.
+		// Retriable: back off briefly, stop only when the outer ctx fires.
 		select {
 		case <-ctx.Done():
 			return fmt.Errorf("vsockhttp: timed out waiting for guest ready at %s: %w", readyPath, ctx.Err())
-		case <-time.After(50 * time.Millisecond):
+		case <-time.After(waitReadyBackoff):
 		}
 	}
+}
+
+// waitReadyAttempt bounds a single readiness probe; a wedged post-restore
+// connection is abandoned after this and retried. waitReadyBackoff is the pause
+// between attempts once one has returned (fast failures should not spin).
+const (
+	waitReadyAttempt = 150 * time.Millisecond
+	waitReadyBackoff = 20 * time.Millisecond
+)
+
+// readyAttempt performs one readiness probe bounded by waitReadyAttempt (capped
+// by the outer ctx). It returns nil only on a 200 response.
+func (t *Transport) readyAttempt(ctx context.Context, udsPath, readyPath string) error {
+	attemptCtx, cancel := context.WithTimeout(ctx, waitReadyAttempt)
+	defer cancel()
+	req, err := http.NewRequestWithContext(attemptCtx, http.MethodGet, "http://vsock"+readyPath, nil)
+	if err != nil {
+		return fmt.Errorf("vsockhttp: build ready request: %w", err)
+	}
+	resp, err := t.RoundTrip(attemptCtx, udsPath, req)
+	if err != nil {
+		return err // nosemgrep: no-bare-error-return
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("vsockhttp: guest not ready, status %d", resp.StatusCode)
+	}
+	return nil
 }
 
 // dialConn opens a raw connection to the guest shim at udsPath. In production

--- a/projects/firecracker/substrate/invoke/internal/vsockhttp/transport_test.go
+++ b/projects/firecracker/substrate/invoke/internal/vsockhttp/transport_test.go
@@ -102,6 +102,71 @@ func TestWaitReadyTimeout(t *testing.T) {
 	}
 }
 
+// hangFirstListener makes the FIRST accepted connection wedge (never serviced),
+// simulating the Firecracker post-restore vsock RX-queue race; every subsequent
+// connection is passed through to the real server.
+type hangFirstListener struct {
+	net.Listener
+	tripped atomic.Bool
+	stop    chan struct{}
+}
+
+func (l *hangFirstListener) Accept() (net.Conn, error) {
+	c, err := l.Listener.Accept()
+	if err != nil {
+		return nil, err // nosemgrep: no-bare-error-return
+	}
+	if l.tripped.CompareAndSwap(false, true) {
+		return &hangConn{Conn: c, stop: l.stop}, nil
+	}
+	return c, nil
+}
+
+// hangConn blocks on Read until stop is closed, so the server never reads the
+// request on the wedged first connection and the client's per-attempt deadline
+// must fire for it to make progress.
+type hangConn struct {
+	net.Conn
+	stop chan struct{}
+}
+
+func (c *hangConn) Read(_ []byte) (int, error) {
+	<-c.stop
+	return 0, io.EOF
+}
+
+// TestWaitReadyRetriesPastWedgedFirstConnection is the regression test for the
+// warm-restore latency bug: the first post-restore connection wedges, and
+// WaitReady must abandon it at the per-attempt deadline and reconnect, returning
+// well under the (generous) outer context rather than blocking on it.
+func TestWaitReadyRetriesPastWedgedFirstConnection(t *testing.T) {
+	udsPath := t.TempDir() + "/shim.sock"
+	base, err := net.Listen("unix", udsPath)
+	if err != nil {
+		t.Fatalf("listen unix: %v", err)
+	}
+	stop := make(chan struct{})
+	defer close(stop)
+	ln := &hangFirstListener{Listener: base, stop: stop}
+	srv := shim.NewServer(echoHandler, shim.WithReady(func() bool { return true }))
+	go srv.Serve(ln) //nolint:errcheck
+	t.Cleanup(func() { _ = srv.Close() })
+
+	tr := NewTransport(WithDirectDial())
+	// Outer budget is deliberately generous: without the per-attempt cap the
+	// wedged first connection would block WaitReady for the full 5s.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	start := time.Now()
+	if err := tr.WaitReady(ctx, udsPath, "/shim/ready"); err != nil {
+		t.Fatalf("WaitReady: %v", err)
+	}
+	if elapsed := time.Since(start); elapsed > 2*time.Second {
+		t.Errorf("WaitReady took %v; the per-attempt cap should abandon the wedged connection and retry well under the 5s outer ctx", elapsed)
+	}
+}
+
 // TestRoundTripContextCancel verifies that a context cancelled before the call
 // causes RoundTrip to return promptly with an error.
 func TestRoundTripContextCancel(t *testing.T) {


### PR DESCRIPTION
## Problem

After PR #2970 (semgrep on fc-invoke), live scan latency was bimodal: ~0.9s warm (good, beats the old ~1.4s), but roughly 1 in 4-5 scans hit **~67s** plus a ~7s follow-on. The old `semgrep-scand` did not have this.

## Root cause

`vsockhttp.Transport.WaitReady` built its request and set the connection deadline from the **outer** ctx (the 60s `BootReadyTimeout`). When the first post-restore vsock connection wedges on Firecracker's RX-queue race, the CONNECT-reply read blocks for the *full 60s* before the retry loop runs. It then times out (`GuestUnavailable`), the base is invalidated, and the scan falls back to a cold boot (~7s): `60 + 7 ≈ 67s`. The next scan cold-boots too (base was invalidated), then restores are fast again until the next race.

`semgrep-scand` avoided this with a throwaway "prime" + skip-WaitReady, but only because its readiness was a one-shot `KindHello` that never re-fires on restore. fc-invoke's readiness is a **pollable** HTTP `/shim/ready`, so the clean fix is to make the poll robust.

## Fix

- **`WaitReady` bounds each attempt by its own short deadline** (`waitReadyAttempt` 150ms), not the outer ctx. A wedged connection is abandoned in ~150ms and the retry reconnects, returning the instant the guest answers (usually first try, single-digit ms). This is the "eagerly reconnect and unblock" behavior; no fixed prime delay.
- **The warm path uses a short readiness budget** (`RestoreReadyTimeout`, default 2s) instead of `BootReadyTimeout` (60s): a warm guest answers almost immediately, so a restore that is not ready fast is treated as unavailable and falls back to a cold boot in ~2s, not ~67s.
- **A warm-path round-trip failure is classified `GuestUnavailable`** so a flaky restore falls back to cold rather than returning a hard 502.

No separate "prime" and no skip-WaitReady needed, the pollable HTTP readiness (PR1's design) makes the retry approach both simpler and faster than the original.

## Tests

- `TestWaitReadyRetriesPastWedgedFirstConnection`: a listener wedges the first connection; WaitReady must return well under the generous outer ctx via per-attempt retry (fails before the fix).
- `TestInvokeWarmRoundTripFailureFallsBackToCold`: a warm round-trip failure invalidates the base and cold-retries to a 200.

Verified live before the fix: `0.9, 0.9, 67.5, 7.3, 0.9`s. Post-merge I will re-measure on node-4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)