### PR TITLE
fix(fc-invoke): bump chart to 0.1.1 to deploy the warm-restore latency fix

### DIFF
--- a/projects/firecracker/substrate/chart/Chart.yaml
+++ b/projects/firecracker/substrate/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: fc-invoke
 description: Node-affine Firecracker invoke daemon that dispatches HTTP invocations to a pool of warm-base microVMs across named workloads (POST /invoke/{workload}, GET /healthz)
 type: application
-version: 0.1.0
+version: 0.1.1

--- a/projects/firecracker/substrate/deploy/application.yaml
+++ b/projects/firecracker/substrate/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tags pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: fc-invoke
-      targetRevision: 0.1.0
+      targetRevision: 0.1.1
       helm:
         valueFiles:
           - $values/projects/firecracker/substrate/deploy/values.yaml


### PR DESCRIPTION
The warm-restore latency fix (PR #2971) merged, but the fc-invoke chart version was not bumped (the chart-version-bot commit lands via the non-required "Push images" step, and #2971 was merged on green Format+Test before it landed). So the fix is on main but the chart is still 0.1.0 and ArgoCD has not rolled it.

`chart-version.sh` confirms a bump is pending: `0.1.0 -> 0.1.1 (patch)` (my fix commit is in the fc-invoke chart's Bazel dependency closure). This PR lands that bump (Chart.yaml + application.yaml targetRevision in sync) so ArgoCD pulls the 0.1.1 chart, which carries the rebuilt image digest with the fix.

No code change; version bump only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)