### PR TITLE
chore(monolith-public): deploy campsites public route (chart 0.82.3)

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.82.2
+version: 0.82.3
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.82.2
+      targetRevision: 0.82.3
       helm:
         releaseName: monolith-public
         valueFiles:


### PR DESCRIPTION
The campsites feature (PR #2972) bumped the `monolith` chart (0.236.0), which correctly deployed the schema, `public_reader` grant, and hourly CronWorkflow. But `jomcgi.dev/app/campsites` and `/api/campsites/snapshot` are served by the separate **`monolith-public`** tier, whose chart was not bumped by the chart-version-bot, so the public pods kept running the pre-campsites image and returned 404.

This bumps `monolith-public` to 0.82.3 so CI rebuilds the public image (now containing `main_public.py`'s campsites `register_public` and the `routes/public/app/campsites` SvelteKit route) and ArgoCD rolls it out.

No code change, deploy plumbing only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)