### PR TITLE
chore(model-bench): curate model registry from live research

### DIFF
--- a/projects/model-bench/models.yaml
+++ b/projects/model-bench/models.yaml
@@ -1,23 +1,63 @@
 # Model ids must match OpenRouter /models slugs; verify before a real run.
 # Anchors define the qualification bar: a budget candidate must reach anchor
 # pass@1 on a class at materially lower cost to qualify for that class.
+#
+# Prices are 2026-07 snapshots ($/M tokens, input -> output) for reference only;
+# the harness pulls live pricing from OpenRouter /models at run time. Candidate
+# selection is grounded in a cited research pass (mid-2026 coding + 4090 landscape).
 models:
-  - id: anthropic/claude-opus-4.8
+  # --- Anchors: bar = Sonnet, ceiling = Opus ---
+  - id: anthropic/claude-opus-4.8 # 5 -> 25  quality ceiling
     role: anchor
     status: active
 
-  - id: anthropic/claude-sonnet-4.6
+  - id: anthropic/claude-sonnet-4.6 # 3 -> 15  qualification bar
     role: anchor
     status: active
 
-  - id: qwen/qwen-2.5-coder-32b-instruct
+  # --- Tier A: open coders self-hostable on a single 24GB 4090 at int4 (the prize:
+  # test on OpenRouter, self-host the winner on node-4 for free) ---
+  - id: qwen/qwen3.6-27b # 0.29 -> 2.4  dense 27B, ~17GB Q4, #1 4090 coder (77.2 SWE-bench).
+    status: active #              NOTE: the REAL dense 27B, distinct from node-4's 35B-A3B alias.
+
+  - id: qwen/qwen3.6-35b-a3b # 0.14 -> 1.0  MoE 35B/3B, node-4's current model (73.4 SWE-bench).
     status: active
 
-  - id: deepseek/deepseek-chat
+  - id: qwen/qwen3-coder-30b-a3b-instruct # 0.07 -> 0.27  Apache coder MoE, best tool-use ergonomics.
     status: active
 
-  - id: google/gemini-flash-1.5
+  - id: mistralai/devstral-2512 # 0.40 -> 2.0  24B Apache coding model, best 32k+ context headroom.
     status: active
 
-  - id: mistralai/mistral-small
+  - id: qwen/qwen2.5-coder-32b-instruct # 0.66 -> 1.0  proven dense-32B coder baseline (older).
     status: active
+
+  - id: google/gemma-4-31b-it # 0.12 -> 0.35  dense 31B, 4090-fit (coding aptitude unverified).
+    status: active
+
+  - id: google/gemma-4-26b-a4b-it # 0.06 -> 0.33  MoE 26B/4B, 4090-fit (coding aptitude unverified).
+    status: active
+
+  # --- Tier B: cheap cloud coders (too big to self-host on a 4090) ---
+  - id: deepseek/deepseek-v4-flash # 0.10 -> 0.20  best coding-per-dollar (79.0 SWE-bench, 284B/13B).
+    status: active
+
+  - id: deepseek/deepseek-v4-pro # 0.44 -> 0.87  cheapest high-quality API coder (80.6 SWE-bench).
+    status: active
+
+  - id: qwen/qwen3-coder-next # 0.11 -> 0.80  strong open coder (71.3 SWE-bench), 80B so cloud-only.
+    status: active
+
+  - id: z-ai/glm-4.7 # 0.40 -> 1.75  GLM mid-tier coder.
+    status: active
+
+  - id: z-ai/glm-5.2 # 0.93 -> 3.0  #1 open-weight on the Artificial Analysis Intelligence Index.
+    status: active
+
+  # --- Closed-model sanity check (pricey for a "flash"; coding lead was unverified) ---
+  - id: google/gemini-3.5-flash # 1.5 -> 9.0
+    status: active
+
+  # --- Free lane (zero cost, rate-limited) ---
+  - id: qwen/qwen3-coder:free # 0 -> 0
+    status: experimental


### PR DESCRIPTION
Replaces the placeholder `models.yaml` candidate IDs with a researched, current (2026-07) set of 16 models.

**Anchors (bar/ceiling):** claude-opus-4.8, claude-sonnet-4.6.

**Tier A - 4090-self-hostable open coders** (test on OpenRouter, self-host the winner on node-4): qwen3.6-27b (real dense 27B, #1 4090 coder), qwen3.6-35b-a3b (node-4's current MoE), qwen3-coder-30b-a3b-instruct, devstral-2512, qwen2.5-coder-32b-instruct, gemma-4-31b-it, gemma-4-26b-a4b-it.

**Tier B - cheap cloud coders:** deepseek-v4-flash (best coding-per-dollar), deepseek-v4-pro, qwen3-coder-next, glm-4.7, glm-5.2.

**Closed sanity check:** gemini-3.5-flash. **Free lane:** qwen3-coder:free (experimental).

Slugs verified against the live OpenRouter `/models` catalog; tier assignments and 4090-fit grounded in a cited mid-2026 research pass (Qwen3.6-27B is the real dense 27B, distinct from the 35B-A3B MoE node-4 serves under that alias). Gemini/Gemma coding aptitude is unverified by the research and flagged as such in comments; the benchmark is how we find out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)