### PR TITLE
chore(semgrep-scand): add resources-finalizer ahead of decommission (step 1/2)

### DIFF
--- a/projects/agent_platform/semgrep-scand/deploy/application.yaml
+++ b/projects/agent_platform/semgrep-scand/deploy/application.yaml
@@ -3,6 +3,11 @@ kind: Application
 metadata:
   name: semgrep-scand
   namespace: argocd
+  # Decommission step 1 (semgrep now runs on fc-invoke): add the resources
+  # finalizer so that when this Application is removed from git (step 2), the
+  # root app-of-apps prune cascades to its workloads instead of orphaning them.
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
 spec:
   project: default
   sources:


### PR DESCRIPTION
Step 1 of retiring the `semgrep-scand` daemon now that semgrep runs on fc-invoke (verified live, ~0.85-1.0s/scan).

Adds the ArgoCD `resources-finalizer.argocd.argoproj.io` to the semgrep-scand Application so that when it is removed from git in step 2, the root app-of-apps prune **cascades to its workloads** (Deployment, Service, ConfigMap, etc.) instead of orphaning them. This matches the established decommission pattern (add-finalizer PR, then delete PR).

Must merge and sync (ArgoCD writes the finalizer onto the live Application) BEFORE step 2. No behavior change.

Step 2 (separate PR): delete `projects/agent_platform/semgrep-scand/`, remove it from the agent_platform kustomization + bazel/images push-all + MODULE.bazel apko lock, and drop the now-unused `ScanPort` constant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)