### PR TITLE
fix(model-bench): strip code fences + fix qwen2.5 slug (smoke-run bugs)

### DIFF
--- a/projects/model-bench/bench/cache.py
+++ b/projects/model-bench/bench/cache.py
@@ -1,7 +1,7 @@
 import hashlib
 from pathlib import Path
 
-HARNESS_VERSION = "0.1.0"
+HARNESS_VERSION = "0.1.1"
 
 
 def cell_key(

--- a/projects/model-bench/bench/runner.py
+++ b/projects/model-bench/bench/runner.py
@@ -13,13 +13,32 @@ Safety invariants:
 from __future__ import annotations
 
 import hashlib
-import re
 import shutil
 import tempfile
 from pathlib import Path
 
 from bench.cache import HARNESS_VERSION
 from bench.schema import Attempt, ResultCell
+
+
+def _strip_code_fence(content: str) -> str:
+    """Remove a surrounding markdown code fence if present, tolerating prose
+    before or after the fence.
+
+    Models routinely wrap file output in ```lang ... ``` even when asked for raw
+    content; leaving the backticks in corrupts the file (yaml.safe_load chokes on
+    a leading backtick, compilers reject it). Returns the fenced body, or the
+    content trimmed of surrounding blank lines when no fence is present.
+    """
+    lines = content.split("\n")
+    fence_idxs = [i for i, ln in enumerate(lines) if ln.lstrip().startswith("```")]
+    if len(fence_idxs) >= 2:
+        # Body between the first opening fence and the last closing fence.
+        return "\n".join(lines[fence_idxs[0] + 1 : fence_idxs[-1]])
+    if len(fence_idxs) == 1:
+        # Only an opening fence survived (e.g. truncated); take everything after.
+        return "\n".join(lines[fence_idxs[0] + 1 :]).strip("\n")
+    return content.strip("\n")
 
 
 def extract_files(text: str, target_files: list[str]) -> dict[str, str]:
@@ -66,21 +85,13 @@ def extract_files(text: str, target_files: list[str]) -> dict[str, str]:
             if block_lines and block_lines[0] == "":
                 block_lines = block_lines[1:]
             content = "\n".join(block_lines)
-            # Strip one trailing newline.
-            if content.endswith("\n"):
-                content = content[:-1]
-            result[path] = content
+            # Models often wrap the block in a code fence after the FILE header.
+            result[path] = _strip_code_fence(content)
         return result
 
     # No FILE headers found.
     if len(target_files) == 1:
-        content = text
-        # Strip surrounding fenced code block if the whole response is fenced.
-        stripped = content.strip()
-        fence_match = re.match(r"^```[^\n]*\n(.*)\n```$", stripped, re.DOTALL)
-        if fence_match:
-            content = fence_match.group(1)
-        return {target_files[0]: content}
+        return {target_files[0]: _strip_code_fence(text)}
 
     return {}
 

--- a/projects/model-bench/bench/runner_test.py
+++ b/projects/model-bench/bench/runner_test.py
@@ -3,8 +3,32 @@ from pathlib import Path
 
 import pytest  # noqa: F401
 
-from bench.runner import run_cell
+from bench.runner import extract_files, run_cell
 from bench.verifiers import VerifyResult
+
+
+def test_extract_strips_fence_after_file_header():
+    text = "FILE clusterrole.yaml\n```yaml\nrules:\n- verbs: [get, list]\n```"
+    assert extract_files(text, ["clusterrole.yaml"]) == {
+        "clusterrole.yaml": "rules:\n- verbs: [get, list]"
+    }
+
+
+def test_extract_strips_bare_fence_single_target():
+    assert extract_files("```yaml\nfoo: 1\n```", ["values.yaml"]) == {
+        "values.yaml": "foo: 1"
+    }
+
+
+def test_extract_strips_fence_with_surrounding_prose():
+    text = "Here is the fixed file:\n```yaml\nfoo: 1\n```\nThat adds the key."
+    assert extract_files(text, ["values.yaml"]) == {"values.yaml": "foo: 1"}
+
+
+def test_extract_unfenced_passthrough():
+    assert extract_files("foo: 1\nbar: 2", ["values.yaml"]) == {
+        "values.yaml": "foo: 1\nbar: 2"
+    }
 
 
 def make_model(script):  # script: list of outputs per attempt

--- a/projects/model-bench/models.yaml
+++ b/projects/model-bench/models.yaml
@@ -29,7 +29,7 @@ models:
   - id: mistralai/devstral-2512 # 0.40 -> 2.0  24B Apache coding model, best 32k+ context headroom.
     status: active
 
-  - id: qwen/qwen2.5-coder-32b-instruct # 0.66 -> 1.0  proven dense-32B coder baseline (older).
+  - id: qwen/qwen-2.5-coder-32b-instruct # 0.66 -> 1.0  proven dense-32B coder baseline (older).
     status: active
 
   - id: google/gemma-4-31b-it # 0.12 -> 0.35  dense 31B, 4090-fit (coding aptitude unverified).

--- a/projects/model-bench/tasks/commit-message-01/task.yaml
+++ b/projects/model-bench/tasks/commit-message-01/task.yaml
@@ -10,7 +10,7 @@ target_files: []
 verifier:
   kind: judge
   args:
-    judge_model: anthropic/claude-sonnet-4.6
+    judge_model: anthropic/claude-opus-4.8
     criteria:
       - "valid Conventional Commits subject (type(scope): description)"
       - "body explains the motivation, not just the what"


### PR DESCRIPTION
First live smoke run surfaced two harness bugs that made the config-plumbing results (including the anchors) meaningless:

1. **Code fences not stripped** - models wrap file output in ```lang ... ```, and `extract_files` left the backticks in, so the RBAC verifier's `yaml.safe_load` threw on a leading backtick. Opus and Sonnet themselves 'errored' on RBAC. Fixed with a robust `_strip_code_fence` applied to every extracted file (handles FILE-header blocks and prose around the fence) + regression tests.
2. **Bad slug** - `qwen/qwen2.5-coder-32b-instruct` 400'd; correct OpenRouter slug is `qwen/qwen-2.5-coder-32b-instruct`.

Plus: bump `HARNESS_VERSION` 0.1.0 -> 0.1.1 so buggy cached cells auto-invalidate on re-run, and move the free-text judge to Opus so the Sonnet bar model gets scored instead of self-skipping.

After merge, re-run `python -m bench run` (all cells re-execute at the new harness version).

🤖 Generated with [Claude Code](https://claude.com/claude-code)