### PR TITLE
feat(campsites): full-bleed map with clear-sky weather heatmap

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.82.3
+version: 0.82.4
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.82.3
+      targetRevision: 0.82.4
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/frontend/src/lib/public/components/campsites/CampsitesMap.svelte
+++ b/projects/monolith/frontend/src/lib/public/components/campsites/CampsitesMap.svelte
@@ -3,41 +3,46 @@
   // CSS is a static asset processed by Vite at build time; safe at top level
   // even when this component is SSR-rendered (Vite skips it on the server).
   // The map itself is lazy-imported inside onMount to avoid window/WebGL refs
-  // during SSR. Same pattern as ShipsMap / HikesMap.
+  // during SSR. Same pattern as ShipsMap / StarsMap.
   import "maplibre-gl/dist/maplibre-gl.css";
 
-  // `parks` is the full snapshot array (Points for each park).
+  // `parks` is the full snapshot array (one Point per park).
   // `selectedId` is bindable so both the map (click) and the parent list can
-  // drive selection; clicking a circle sets it here and propagates up, and a
-  // list click changes it in the parent and the effect below pans the map.
+  // drive selection: clicking a pin sets it here and propagates up, and a list
+  // click changes it in the parent and the effect below flies the map to it.
   let { parks = [], selectedId = $bindable(null) } = $props();
 
-  // OpenFreeMap needs no API key (same hosted liberty style as ships/hikes so
+  // OpenFreeMap needs no API key (same hosted liberty style as ships/stars so
   // the pages read as siblings).
   const BASEMAP_STYLE = "https://tiles.openfreemap.org/styles/liberty";
   const SOURCE_ID = "parks";
-  const LAYER_ID = "parks-layer";
+  const PIN_LAYER = "parks";
+  const HEAT_LAYER = "weather-heat";
 
   let maplibregl; // loaded lazily in onMount (browser-only)
   let mapContainer; // bound <div>
   let map = null;
   let popup = null;
+  let resizeObs = null;
   let layerReady = $state(false); // $state so effects re-evaluate after load
 
-  // Data-viz ramp colors: outside the design-token system (intentionally, same
-  // pattern as ShipsMap VESSEL_COLORS / HEAT_COLORS). nosemgrep suppressed on
-  // template usages where the hex appears inside a JS expression, not a literal
-  // CSS property value.
-  //   COL_NONE  = grey (nothing open or no forecast)
-  //   COL_LOW   = yellow (a few ok days)
-  //   COL_MED   = amber (decent)
-  //   COL_GOOD  = green (open AND clear-sky)
-  const COL_NONE = "#6b7280";
-  const COL_LOW  = "#eab308";
-  const COL_MED  = "#f59e0b";
-  const COL_GOOD = "#22c55e";
+  let heatOn = $state(true); // weather heatmap visible by default
 
-  // Score-to-color ramp for the MapLibre circle fill expression.
+  // Data-viz ramp colors: outside the design-token system (intentionally, same
+  // pattern as ShipsMap VESSEL_COLORS / HEAT_COLORS). They live in plain JS
+  // constants so the hexes never appear as a `:` + `#hex` pair inside a style
+  // attribute, which is what the hardcoded-color semgrep rule matches.
+  //   COL_NONE = grey (nothing open or no forecast)
+  //   COL_LOW  = yellow (a few clear days)
+  //   COL_MED  = amber (decent)
+  //   COL_GOOD = green (open AND clear-sky)
+  const COL_NONE = "#6b7280";
+  const COL_LOW = "#eab308";
+  const COL_MED = "#f59e0b";
+  const COL_GOOD = "#22c55e";
+  const STROKE = "#111827";
+
+  // Score-to-color ramp for the pin circle fill (grey -> yellow -> amber -> green).
   const SCORE_COLOR = [
     "interpolate",
     ["linear"],
@@ -52,18 +57,49 @@
     COL_GOOD,
   ];
 
-  // Legend items: color is a JS variable reference, so the template can write
-  // `style="background: {item.color}"` without embedding a literal hex in the
-  // style attribute (matching the ShipsMap LEGEND pattern).
+  // "Sunshine" ramp for the weather heatmap: transparent at zero density, warming
+  // through pale yellow and amber into lime and green as more open-and-clear parks
+  // cluster together. Kept as named constants (not inline literals) for the same
+  // semgrep-safety reason as the pin colors.
+  const HEAT_C0 = "rgba(0, 0, 0, 0)";
+  const HEAT_C1 = "#fde68a"; // pale yellow
+  const HEAT_C2 = "#fbbf24"; // yellow
+  const HEAT_C3 = "#f59e0b"; // amber
+  const HEAT_C4 = "#84cc16"; // lime
+  const HEAT_C5 = "#22c55e"; // green
+
+  const HEAT_COLOR = [
+    "interpolate",
+    ["linear"],
+    ["heatmap-density"],
+    0,
+    HEAT_C0,
+    0.2,
+    HEAT_C1,
+    0.4,
+    HEAT_C2,
+    0.6,
+    HEAT_C3,
+    0.8,
+    HEAT_C4,
+    1,
+    HEAT_C5,
+  ];
+
+  // Legend rows: color is a JS variable reference, so the template writes
+  // `style="background: {item.color}"` with no literal hex in the style attribute
+  // (matching the ShipsMap LEGEND pattern).
   const LEGEND_ITEMS = [
     { label: "Open + clear", color: COL_GOOD },
     { label: "Some clear days", color: COL_LOW },
     { label: "Nothing open", color: COL_NONE },
   ];
+  // Swatches for the heat gradient chip in the legend.
+  const HEAT_SWATCHES = [HEAT_C1, HEAT_C3, HEAT_C5];
 
-  // Build the GeoJSON FeatureCollection from the current parks + selectedId.
-  // A `sel` property (0/1) drives the circle-radius and stroke expressions so
-  // the selected marker stands out without a separate layer.
+  // Build the GeoJSON FeatureCollection from the current parks + selectedId. A
+  // `sel` property (0/1) drives the pin radius and stroke expressions so the
+  // selected marker stands out without a separate layer.
   function buildFC() {
     return {
       type: "FeatureCollection",
@@ -74,6 +110,7 @@
         properties: {
           id: p.id,
           name: p.name,
+          region: p.region,
           best_score: p.best_score,
           good_days: p.good_days,
           sel: p.id === selectedId ? 1 : 0,
@@ -92,32 +129,46 @@
         [Math.min(...lons), Math.min(...lats)],
         [Math.max(...lons), Math.max(...lats)],
       ],
-      { padding: 40, maxZoom: 9, duration: 0 },
+      { padding: 56, maxZoom: 9, duration: 0 },
     );
+  }
+
+  function daysText(n) {
+    return n === 1 ? "1 clear day" : `${n} clear days`;
+  }
+
+  function toggleHeat() {
+    heatOn = !heatOn;
+    if (map && layerReady) {
+      map.setLayoutProperty(
+        HEAT_LAYER,
+        "visibility",
+        heatOn ? "visible" : "none",
+      );
+    }
   }
 
   // Re-sync the source whenever parks or selection changes. Runs once map and
   // layer are ready (layerReady is $state, so the effect re-evaluates then).
   $effect(() => {
-    // Explicit reads so Svelte tracks both as dependencies.
     void parks;
     void selectedId;
     if (!map || !layerReady) return;
     map.getSource(SOURCE_ID)?.setData(buildFC());
   });
 
-  // Pan to the newly selected park when selection changes (list or URL drive).
-  // The `layerReady` guard also means this runs once after initial load if
-  // selectedId is already set (e.g. restored from URL state in the parent).
+  // Fly to the newly selected park when selection changes (list row or map
+  // click both funnel through selectedId). The layerReady guard also means this
+  // runs once after initial load if selectedId is already set.
   $effect(() => {
     const id = selectedId;
     if (!id || !map || !layerReady) return;
     const park = parks.find((p) => p.id === id);
     if (park) {
-      map.easeTo({
+      map.flyTo({
         center: [park.lon, park.lat],
         zoom: Math.max(map.getZoom(), 7),
-        duration: 400,
+        duration: 500,
       });
     }
   });
@@ -134,8 +185,8 @@
         container: mapContainer,
         style: BASEMAP_STYLE,
         // Default view centered on BC; fitParks() overrides this on load.
-        center: [-125, 54],
-        zoom: 4.6,
+        center: [-125, 54.5],
+        zoom: 4.4,
         attributionControl: { compact: true },
       });
 
@@ -144,15 +195,15 @@
         "bottom-right",
       );
 
-      // Compact popup for hover; positioned at cursor, no default tip arrow.
+      // Compact popup for click; positioned at the pin, no default tip arrow.
       popup = new maplibregl.Popup({
         closeButton: false,
         closeOnClick: false,
-        offset: 10,
+        offset: 12,
       });
 
-      // Collapse the attribution on every styledata/sourcedata event so it
-      // never renders as a full-width credit bar. Same pattern as ShipsMap.
+      // Collapse the attribution on every styledata/sourcedata event so it never
+      // renders as a full-width credit bar. Same pattern as ShipsMap.
       let userOpenedAttrib = false;
       const collapseAttrib = () => {
         if (userOpenedAttrib) return;
@@ -172,14 +223,65 @@
       map.on("load", () => {
         map.addSource(SOURCE_ID, { type: "geojson", data: buildFC() });
 
+        // Layer A: weather heatmap, added FIRST so it sits UNDER the pins. Weight
+        // rides on good_days (open AND clear parks), so regions with more good
+        // camping glow. Fades out at high zoom so the pins dominate up close.
         map.addLayer({
-          id: LAYER_ID,
+          id: HEAT_LAYER,
+          type: "heatmap",
+          source: SOURCE_ID,
+          layout: { visibility: heatOn ? "visible" : "none" },
+          paint: {
+            "heatmap-weight": [
+              "interpolate",
+              ["linear"],
+              ["get", "good_days"],
+              0,
+              0,
+              1,
+              0.35,
+              7,
+              1,
+            ],
+            "heatmap-intensity": [
+              "interpolate",
+              ["linear"],
+              ["zoom"],
+              4,
+              1,
+              8,
+              2,
+            ],
+            "heatmap-radius": [
+              "interpolate",
+              ["linear"],
+              ["zoom"],
+              4,
+              28,
+              8,
+              48,
+            ],
+            "heatmap-opacity": [
+              "interpolate",
+              ["linear"],
+              ["zoom"],
+              7,
+              0.55,
+              9,
+              0,
+            ],
+            "heatmap-color": HEAT_COLOR,
+          },
+        });
+
+        // Layer B: park pins, added AFTER the heatmap so they sit ON TOP.
+        map.addLayer({
+          id: PIN_LAYER,
           type: "circle",
           source: SOURCE_ID,
           paint: {
-            // Fill: interpolated by best_score (grey -> yellow -> green).
             "circle-color": SCORE_COLOR,
-            // Radius grows with good_days; selected marker is larger.
+            // Radius grows with good_days; selected pin is larger.
             "circle-radius": [
               "case",
               ["==", ["get", "sel"], 1],
@@ -192,52 +294,56 @@
               3,
               1.5,
             ],
-            "circle-stroke-color": "#111827",
-            "circle-opacity": [
-              "case",
-              ["==", ["get", "sel"], 1],
-              1,
-              0.85,
-            ],
+            "circle-stroke-color": STROKE,
+            "circle-opacity": ["case", ["==", ["get", "sel"], 1], 1, 0.85],
           },
         });
 
         layerReady = true;
         fitParks();
+        // Belt-and-suspenders against a container that was still zero-sized when
+        // the map initialised (the split-layout race that rendered blank before).
+        map.resize();
 
-        // Click handler: set selection or deselect on background click.
+        // Click a pin to select it (drives the bindable + the parent detail
+        // panel); click the background to deselect.
         map.on("click", (e) => {
           const feats = map.queryRenderedFeatures(e.point, {
-            layers: [LAYER_ID],
+            layers: [PIN_LAYER],
           });
           if (feats.length) {
-            selectedId = feats[0].properties.id;
+            const f = feats[0];
+            selectedId = f.properties.id;
+            const { name, best_score, good_days } = f.properties;
+            popup
+              .setLngLat(f.geometry.coordinates.slice())
+              .setHTML(
+                `<strong>${name}</strong><br>Score ${best_score} &middot; ${daysText(good_days)}`,
+              )
+              .addTo(map);
           } else {
             selectedId = null;
+            popup.remove();
           }
         });
 
-        // Hover popup: park name + good_days count.
-        map.on("mouseenter", LAYER_ID, (e) => {
+        map.on("mouseenter", PIN_LAYER, () => {
           map.getCanvas().style.cursor = "pointer";
-          const f = e.features?.[0];
-          if (!f) return;
-          const { name, good_days } = f.properties;
-          const daysText =
-            good_days === 1 ? "1 clear day" : `${good_days} clear days`;
-          popup
-            .setLngLat(e.lngLat)
-            .setHTML(`<strong>${name}</strong><br>${daysText}`)
-            .addTo(map);
         });
-
-        map.on("mouseleave", LAYER_ID, () => {
+        map.on("mouseleave", PIN_LAYER, () => {
           map.getCanvas().style.cursor = "";
-          popup.remove();
         });
       });
 
+      // A late-sized container (grid/flex settling after mount) can leave the
+      // GL canvas at 0x0 and paint blank. Observe the container and resize the
+      // map whenever its box changes, so it always fills the viewport.
+      resizeObs = new ResizeObserver(() => map?.resize());
+      resizeObs.observe(mapContainer);
+
       cleanup = () => {
+        resizeObs?.disconnect();
+        resizeObs = null;
         popup?.remove();
         map?.remove();
         map = null;
@@ -255,24 +361,46 @@
 <div class="map-wrap">
   <div class="map" bind:this={mapContainer}></div>
 
+  <div class="heat-toggle" role="group" aria-label="Weather heatmap">
+    <button
+      type="button"
+      class:active={heatOn}
+      aria-pressed={heatOn}
+      onclick={toggleHeat}
+    >
+      Heat {heatOn ? "on" : "off"}
+    </button>
+  </div>
+
   <div class="legend">
     <p class="legend-title">Open sites + clear sky</p>
     <ul class="legend-list">
       {#each LEGEND_ITEMS as item (item.label)}
         <li>
-          <span class="sw" style="background: {item.color}" aria-hidden="true"></span>{item.label}
+          <span class="sw" style="background: {item.color}" aria-hidden="true"
+          ></span>{item.label}
         </li>
       {/each}
     </ul>
-    <p class="legend-note">Circle size = clear-sky days</p>
+    <div class="legend-heat">
+      <span class="legend-heat-label">Heatmap = density of good camping</span>
+      <span class="legend-heat-bar" aria-hidden="true">
+        {#each HEAT_SWATCHES as c (c)}
+          <span class="legend-heat-cell" style="background: {c}"></span>
+        {/each}
+      </span>
+    </div>
+    <p class="legend-note">Pin size = clear-sky days</p>
   </div>
 </div>
 
 <style>
+  /* Full-bleed: the map fills the whole page (its .campsites-page ancestor is
+     the positioned containing block). Matches ShipsMap. */
   .map-wrap {
-    position: relative;
-    width: 100%;
-    height: 100%;
+    position: absolute;
+    inset: 0;
+    overflow: hidden;
     background: var(--cream);
   }
 
@@ -299,7 +427,9 @@
   .map :global(.maplibregl-ctrl-group button) {
     border: 2px solid var(--ink);
     background: var(--paper);
-    transition: transform 110ms ease, box-shadow 110ms ease;
+    transition:
+      transform 110ms ease,
+      box-shadow 110ms ease;
   }
 
   .map :global(.maplibregl-ctrl-group button + button) {
@@ -358,11 +488,45 @@
     display: none;
   }
 
-  /* Legend: bottom-left, same hard-edge style as ShipsMap legend. */
+  /* Heat on/off switch, top-right (same idiom as the ShipsMap mode toggle). */
+  .heat-toggle {
+    position: absolute;
+    top: 16px;
+    right: 16px;
+    display: inline-flex;
+    border: 2px solid var(--ink);
+    background: var(--paper);
+    font-family: var(--mono);
+    font-size: 12px;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+
+  .heat-toggle button {
+    padding: 8px 14px;
+    background: var(--paper);
+    border: none;
+    color: var(--ink);
+    cursor: pointer;
+    transition: background 120ms ease;
+  }
+
+  .heat-toggle button:hover {
+    background: var(--cream);
+  }
+
+  .heat-toggle button.active {
+    background: var(--ink);
+    color: var(--paper);
+  }
+
+  /* Legend: bottom-left, same hard-edge style as the ShipsMap legend. */
   .legend {
     position: absolute;
     bottom: 16px;
     left: 16px;
+    max-width: 240px;
     padding: 10px 12px;
     background: var(--paper);
     border: 2px solid var(--ink);
@@ -397,7 +561,7 @@
     letter-spacing: 0.02em;
   }
 
-  /* Circular swatch to echo the circle markers on the map. */
+  /* Circular swatch to echo the circle pins on the map. */
   .sw {
     width: 12px;
     height: 12px;
@@ -406,11 +570,65 @@
     flex: none;
   }
 
+  .legend-heat {
+    margin-top: 9px;
+    padding-top: 8px;
+    border-top: 1.5px dashed var(--rule-2);
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+  }
+
+  .legend-heat-label {
+    font-family: var(--mono);
+    font-size: 10px;
+    font-weight: 600;
+    letter-spacing: 0.02em;
+    color: var(--ink-3);
+  }
+
+  .legend-heat-bar {
+    display: inline-flex;
+    height: 10px;
+    border: 1.5px solid var(--ink);
+  }
+
+  .legend-heat-cell {
+    flex: 1;
+    min-width: 22px;
+  }
+
   .legend-note {
-    margin: 7px 0 0;
+    margin: 8px 0 0;
     font-family: var(--mono);
     font-size: 10px;
     color: var(--ink-3);
     letter-spacing: 0.02em;
+  }
+
+  @media (max-width: 640px) {
+    .heat-toggle {
+      top: 12px;
+      right: 12px;
+      font-size: 13px;
+    }
+
+    .heat-toggle button {
+      padding: 11px 18px;
+    }
+
+    .legend {
+      bottom: 12px;
+      left: 12px;
+      max-width: 200px;
+      padding: 9px 11px;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .map :global(.maplibregl-ctrl-group button),
+    .heat-toggle button {
+      transition: none;
+    }
   }
 </style>

--- a/projects/monolith/frontend/src/routes/public/app/campsites/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/campsites/+page.svelte
@@ -8,13 +8,16 @@
   let parks = $derived(data.snapshot?.parks ?? []);
   let generatedAt = $derived(data.snapshot?.generated_at);
 
-  // Two-way binding between the map and the ranked list: clicking a circle on
-  // the map sets selectedId here, and clicking a list row sets it from the
-  // parent. CampsitesMap uses $bindable(null) so both directions work.
+  // Two-way binding between the map and the ranked list: clicking a pin sets
+  // selectedId here, and clicking a list row sets it from the parent.
+  // CampsitesMap uses $bindable(null) so both directions work.
   let selectedId = $state(null);
   let selectedPark = $derived(parks.find((p) => p.id === selectedId) ?? null);
 
-  // Sort and filter state
+  // List panel collapse (map-first: the whole map stays visible when collapsed).
+  let listOpen = $state(true);
+
+  // Sort and filter state.
   let sortKey = $state("best_score"); // "best_score" | "good_days" | "name" | "region"
   let filterRegion = $state("");
   let clearOnly = $state(false);
@@ -33,28 +36,34 @@
     if (clearOnly) list = list.filter((p) => p.good_days > 0);
     const out = [...list];
     if (sortKey === "best_score") {
-      out.sort((a, b) => b.best_score - a.best_score || a.name.localeCompare(b.name));
+      out.sort(
+        (a, b) => b.best_score - a.best_score || a.name.localeCompare(b.name),
+      );
     } else if (sortKey === "good_days") {
-      out.sort((a, b) => b.good_days - a.good_days || a.name.localeCompare(b.name));
+      out.sort(
+        (a, b) => b.good_days - a.good_days || a.name.localeCompare(b.name),
+      );
     } else if (sortKey === "name") {
       out.sort((a, b) => a.name.localeCompare(b.name));
     } else if (sortKey === "region") {
       out.sort(
-        (a, b) => a.region.localeCompare(b.region) || a.name.localeCompare(b.name),
+        (a, b) =>
+          (a.region ?? "").localeCompare(b.region ?? "") ||
+          a.name.localeCompare(b.name),
       );
     }
     return out;
   });
 
-  // ── Date formatting ────────────────────────────────────────────────────────
+  // Date formatting.
 
   const MONTHS = [
-    "Jan","Feb","Mar","Apr","May","Jun",
-    "Jul","Aug","Sep","Oct","Nov","Dec",
+    "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+    "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
   ];
-  const SHORT_DAYS = ["Su","Mo","Tu","We","Th","Fr","Sa"];
+  const SHORT_DAYS = ["Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"];
 
-  // "Tu 30" from "2026-06-30"; uses local date constructor (no UTC offset).
+  // "Tu 30" from "2026-06-30"; local date constructor (no UTC offset).
   function fmtDayCell(iso) {
     if (!iso) return "";
     const [y, m, d] = iso.split("-").map(Number);
@@ -72,20 +81,16 @@
     return `${d.getUTCDate()} ${MONTHS[d.getUTCMonth()]} ${d.getUTCFullYear()}, ${hh}:${mm} UTC`;
   }
 
-  // ── Color helpers ──────────────────────────────────────────────────────────
-  // Data-viz ramp: outside the design-token system (intentionally; same class
-  // of values as ShipsMap VESSEL_COLORS / HEAT_COLORS). The hex literals are
-  // stored in plain JS constants so they never appear as `:` + `#hex` in the
-  // source, which is the pattern the svelte-hardcoded-color-in-style rule
-  // matches. Template usage is `style="background: {colVar}"`.
-  const VIZ_GREEN  = "#22c55e";
-  const VIZ_LIME   = "#84cc16";
+  // Color helpers. Data-viz ramp hexes live in plain JS constants so they never
+  // appear as `:` + `#hex` inside a style attribute (the pattern the
+  // svelte-hardcoded-color-in-style rule matches). Template usage is
+  // `style="background: {colVar}"`.
+  const VIZ_GREEN = "#22c55e";
+  const VIZ_LIME = "#84cc16";
   const VIZ_YELLOW = "#fbbf24";
-  const VIZ_AMBER  = "#f59e0b";
-  const VIZ_GREY   = "#9ca3af";
+  const VIZ_AMBER = "#f59e0b";
+  const VIZ_GREY = "#9ca3af";
 
-  // Returns a plain color string (not a full CSS property), composed in the
-  // template as `style="background: {dayCellBg(day)}"`.
   function dayCellBg(day) {
     if (!day.available) return "var(--rule)";
     const s = day.sunny_score ?? 0;
@@ -96,17 +101,15 @@
     return VIZ_GREY; // open but overcast
   }
 
-  // Returns a plain color string for the badge `style="background: {badgeColor(score)}"`.
-  // When score is 0 the badge uses CSS tokens (no hex needed).
   function badgeColor(score) {
     if (score >= 80) return VIZ_GREEN;
     if (score >= 60) return VIZ_LIME;
     if (score >= 40) return VIZ_YELLOW;
-    if (score > 0)  return VIZ_AMBER;
+    if (score > 0) return VIZ_AMBER;
     return null; // zero score: badge styled via CSS class, not inline
   }
 
-  // title= text for day cell hover: cloud/precip/temp summary.
+  // title= text for a day cell: cloud/precip/temp summary.
   function dayTitle(day) {
     const parts = [day.available ? "Open" : "Closed"];
     if (day.cloud != null) parts.push(`${Math.round(day.cloud)}% cloud`);
@@ -115,7 +118,12 @@
     return parts.join(", ");
   }
 
-  // Toggle selection: clicking the same row again deselects.
+  function daysLabel(n) {
+    return n === 1 ? "1 clear day" : `${n} clear days`;
+  }
+
+  // Clicking a row selects (and pans the map via the bindable); clicking the
+  // selected row again deselects.
   function selectPark(id) {
     selectedId = selectedId === id ? null : id;
   }
@@ -131,47 +139,50 @@
   <title>BC Parks campsites, open sites and clear-sky weather</title>
   <meta
     name="description"
-    content="BC Parks campsite availability overlaid with clear-sky weather forecasts for the next 14 days. Find parks that are open and forecast to have good weather."
+    content="A full-screen map of BC Parks campsites overlaid with clear-sky weather forecasts for the next 14 days. Find parks that are open and forecast to have good weather."
   />
 </svelte:head>
 
-<div class="page">
+<div class="campsites-page" class:has-selection={!!selectedPark}>
+  <!-- The visible heading is the breadcrumb chip; keep a real (hidden) h1 for
+       SEO + a11y. -->
   <h1 class="sr-only">BC Parks campsites, open sites and clear-sky weather</h1>
 
-  <div class="board">
-    <header class="board-head">
-      <div class="crumb-row">
-        <nav class="crumb" aria-label="Breadcrumb">
-          <a class="crumb-home" href="https://jomcgi.dev/"
-            >jomcgi.dev<span class="crumb-arrow" aria-hidden="true">&nearr;</span
-            ></a
-          >
-          <span class="crumb-sep">/</span>
-          <span class="crumb-name">campsites</span>
-        </nav>
-        <p class="stats">
-          <strong>{parks.length}</strong> parks
-        </p>
-      </div>
-      <p class="source">
-        BC Parks availability + 14-day weather. Green = sites open AND clear
-        skies. Circle size = number of good days.
-        {#if generatedAt}
-          As of {fmtGeneratedAt(generatedAt)}.
-        {/if}
-      </p>
-    </header>
+  <CampsitesMap {parks} bind:selectedId />
 
-    <div class="split">
-      <!-- Map column: map fills the column height via CSS. -->
-      <div class="map-col">
-        <CampsitesMap {parks} bind:selectedId />
+  <!-- Top-left crumb / title card. -->
+  <div class="crumb-card">
+    <nav class="crumb" aria-label="Breadcrumb">
+      <a class="crumb-home" href="https://jomcgi.dev/"
+        >jomcgi.dev<span class="crumb-arrow" aria-hidden="true">&nearr;</span></a
+      >
+      <span class="crumb-sep">/</span>
+      <span class="crumb-name">campsites</span>
+      <span class="crumb-count"><strong>{parks.length}</strong> parks</span>
+    </nav>
+    <p class="crumb-note">
+      {#if generatedAt}As of {fmtGeneratedAt(generatedAt)}. {/if}Green = open AND
+      clear skies.
+    </p>
+  </div>
+
+  <!-- Right-side list panel (collapsible). -->
+  <aside class="list-panel" class:collapsed={!listOpen}>
+    <header class="list-head">
+      <div class="list-head-top">
+        <p class="list-title">Ranked parks</p>
+        <button
+          type="button"
+          class="collapse-btn"
+          aria-expanded={listOpen}
+          onclick={() => (listOpen = !listOpen)}
+        >
+          {listOpen ? "Hide" : "List"}
+        </button>
       </div>
 
-      <!-- Panel column: controls + ranked list + detail strip. -->
-      <div class="panel-col">
+      {#if listOpen}
         <div class="controls">
-          <!-- Sort toggle -->
           <div class="sort-row">
             <span class="control-label">Sort</span>
             <div class="toggle" role="group" aria-label="Sort parks by">
@@ -181,13 +192,12 @@
                   class="seg"
                   class:active={sortKey === key}
                   aria-pressed={sortKey === key}
-                  onclick={() => (sortKey = key)}
-                >{label}</button>
+                  onclick={() => (sortKey = key)}>{label}</button
+                >
               {/each}
             </div>
           </div>
 
-          <!-- Region filter + clear-nights toggle -->
           <div class="filter-row">
             <label class="field-wrap">
               <span class="sr-only">Filter by region</span>
@@ -210,100 +220,115 @@
             </label>
           </div>
         </div>
+      {/if}
+    </header>
 
-        {#if visibleParks.length === 0}
-          <p class="empty">No parks match the current filters.</p>
-        {:else}
-          <ul class="rows" aria-label="Ranked park list">
-            {#each visibleParks as park (park.id)}
-              <li>
-                <button
-                  type="button"
-                  class="row"
-                  class:selected={selectedId === park.id}
-                  aria-pressed={selectedId === park.id}
-                  onclick={() => selectPark(park.id)}
-                >
-                  <span class="r-body">
-                    <span class="r-name">{park.name}</span>
-                    <span class="r-region">{park.region}</span>
-                  </span>
-                  <span class="r-right">
-                    <span
-                      class="score-badge"
-                      class:score-zero={park.best_score === 0}
-                      style={badgeColor(park.best_score)
-                        ? `background: ${badgeColor(park.best_score)}`
-                        : undefined}
-                    >{park.best_score}</span>
-                    <span class="r-days">
-                      {park.good_days === 1
-                        ? "1 clear day"
-                        : `${park.good_days} clear days`}
-                    </span>
-                  </span>
-                </button>
-              </li>
-            {/each}
-          </ul>
-        {/if}
-
-        <!-- 14-day detail strip for the selected park. -->
-        {#if selectedPark}
-          <section class="detail" aria-label="{selectedPark.name} 14-day forecast">
-            <div class="detail-head">
-              <div class="detail-names">
-                <h2 class="detail-park">{selectedPark.name}</h2>
-                <p class="detail-region">{selectedPark.region}</p>
-              </div>
-              <a
-                href={selectedPark.booking_url}
-                target="_blank"
-                rel="noopener noreferrer"
-                class="book-link"
-              >Book on BC Parks &nearr;</a>
-            </div>
-
-            <div class="days-scroll">
-              <ul class="days-strip" aria-label="14-day forecast strip">
-                {#each selectedPark.days as day (day.date)}
-                  <li
-                    class="day-cell"
-                    class:day-open={day.available}
-                    class:day-good={day.is_good}
-                    style="background: {dayCellBg(day)}"
-                    title={dayTitle(day)}
+    {#if listOpen}
+      {#if visibleParks.length === 0}
+        <p class="empty">No parks match the current filters.</p>
+      {:else}
+        <ul class="rows" aria-label="Ranked park list">
+          {#each visibleParks as park (park.id)}
+            <li>
+              <button
+                type="button"
+                class="row"
+                class:selected={selectedId === park.id}
+                aria-pressed={selectedId === park.id}
+                onclick={() => selectPark(park.id)}
+              >
+                <span class="r-body">
+                  <span class="r-name">{park.name}</span>
+                  <span class="r-region">{park.region}</span>
+                </span>
+                <span class="r-right">
+                  <span
+                    class="score-badge"
+                    class:score-zero={park.best_score === 0}
+                    style={badgeColor(park.best_score)
+                      ? `background: ${badgeColor(park.best_score)}`
+                      : undefined}>{park.best_score}</span
                   >
-                    <span class="day-date">{fmtDayCell(day.date)}</span>
-                    <span class="day-icon" aria-hidden="true"
-                      >{day.available ? "✓" : "×"}</span
-                    >
-                    {#if day.temp_max != null}
-                      <span class="day-temp">{Math.round(day.temp_max)}°</span>
-                    {/if}
-                  </li>
-                {/each}
-              </ul>
-            </div>
+                  <span class="r-days">{daysLabel(park.good_days)}</span>
+                </span>
+              </button>
+            </li>
+          {/each}
+        </ul>
+      {/if}
+    {/if}
+  </aside>
 
-            <p class="detail-legend">
-              Check = sites bookable. Color: green (clear) to grey (cloudy or
-              closed). Hover a cell for cloud/rain/temp.
-            </p>
-          </section>
+  <!-- Detail panel: bottom sheet for the selected park's 14-day forecast. -->
+  {#if selectedPark}
+    <section
+      class="detail"
+      aria-label="{selectedPark.name} 14-day forecast"
+    >
+      <button
+        type="button"
+        class="detail-close"
+        onclick={() => (selectedId = null)}
+        aria-label="Close park detail">&times;</button
+      >
+      <div class="detail-head">
+        <div class="detail-names">
+          <h2 class="detail-park">{selectedPark.name}</h2>
+          <p class="detail-region">
+            {selectedPark.region} &middot; {daysLabel(selectedPark.good_days)}
+          </p>
+        </div>
+        {#if selectedPark.booking_url}
+          <a
+            href={selectedPark.booking_url}
+            target="_blank"
+            rel="noopener noreferrer"
+            class="book-link">Book on BC Parks &nearr;</a
+          >
         {/if}
       </div>
-    </div>
-  </div>
+
+      <div class="days-scroll">
+        <ul class="days-strip" aria-label="14-day forecast strip">
+          {#each selectedPark.days as day (day.date)}
+            <li
+              class="day-cell"
+              class:day-open={day.available}
+              class:day-good={day.is_good}
+              style="background: {dayCellBg(day)}"
+              title={dayTitle(day)}
+            >
+              <span class="day-date">{fmtDayCell(day.date)}</span>
+              <span class="day-icon" aria-hidden="true"
+                >{day.available ? "✓" : "×"}</span
+              >
+              {#if day.temp_max != null}
+                <span class="day-temp">{Math.round(day.temp_max)}&deg;</span>
+              {/if}
+            </li>
+          {/each}
+        </ul>
+      </div>
+
+      <p class="detail-legend">
+        Check = sites bookable. Color: green (clear) to grey (cloudy or closed).
+        Hover a cell for cloud, rain and temp.
+      </p>
+    </section>
+  {/if}
 </div>
 
 <style>
-  .page {
-    min-height: 100vh;
-    min-height: 100dvh;
+  /* Full-bleed shell: the map fills the whole viewport under the global nav
+     (no site nav on /app/* routes), and every panel is an absolutely-positioned
+     overlay on top of it. Mirrors the ships/stars page shells. */
+  .campsites-page {
+    position: relative;
+    height: 100vh;
+    height: 100dvh;
+    overflow: hidden;
     background: var(--cream);
     color: var(--ink);
-    padding: 12px;
   }
 
   .sr-only {
@@ -318,35 +343,21 @@
     border: 0;
   }
 
-  /* One hard-edged sheet; wide enough to hold the map + list side by side. */
-  .board {
-    max-width: 1200px;
-    margin: 0 auto;
+  /* Top-left crumb / title card. */
+  .crumb-card {
+    position: absolute;
+    top: 16px;
+    left: 16px;
+    max-width: calc(100% - 32px);
+    padding: 8px 12px;
     background: var(--paper);
     border: 2px solid var(--ink);
   }
 
-  /* ── Header ────────────────────────────────────────────────────────────── */
-
-  .board-head {
-    display: flex;
-    flex-direction: column;
-    gap: 7px;
-    padding: 12px 14px;
-    border-bottom: 2px solid var(--ink);
-  }
-
-  .crumb-row {
+  .crumb {
     display: flex;
     align-items: baseline;
-    justify-content: space-between;
-    gap: 8px 14px;
     flex-wrap: wrap;
-  }
-
-  .crumb {
-    display: inline-flex;
-    align-items: center;
     gap: 8px;
     font-family: var(--mono);
     font-size: 12px;
@@ -360,6 +371,7 @@
     text-decoration: underline;
     text-decoration-color: var(--blue);
     text-decoration-thickness: 2px;
+    text-decoration-skip-ink: none;
     text-underline-offset: 2px;
     padding: 0 2px;
     transition: background 140ms ease;
@@ -372,6 +384,8 @@
   }
 
   .crumb-arrow {
+    display: inline-block;
+    margin-left: 2px;
     font-size: 0.85em;
   }
 
@@ -379,75 +393,99 @@
     color: var(--ink-3);
   }
 
-  .stats {
-    margin: 0;
-    font-family: var(--mono);
-    font-size: 12px;
-    font-weight: 600;
+  .crumb-count {
+    font-size: 11px;
+    color: var(--ink-3);
     letter-spacing: 0.04em;
-    color: var(--ink-3);
-    white-space: nowrap;
   }
 
-  .stats strong {
+  .crumb-count strong {
     color: var(--ink);
-    font-weight: 700;
   }
 
-  .source {
-    margin: 0;
-    font-size: 12px;
+  .crumb-note {
+    margin: 6px 0 0;
+    font-family: var(--mono);
+    font-size: 10px;
     line-height: 1.4;
+    letter-spacing: 0.02em;
     color: var(--ink-3);
   }
 
-  /* ── Main split layout ─────────────────────────────────────────────────── */
-
-  .split {
-    display: grid;
-    grid-template-columns: 1fr;
-  }
-
-  /* Map: defined height on mobile, sticky column on desktop. */
-  .map-col {
-    height: 45vh;
-    min-height: 280px;
-    border-bottom: 2px solid var(--ink);
-  }
-
-  .panel-col {
+  /* Right-side ranked-list panel. Narrow by default so the page reads map-first;
+     collapse button shrinks it to just the header handle. */
+  .list-panel {
+    position: absolute;
+    top: 64px;
+    right: 16px;
+    bottom: 16px;
+    width: 340px;
+    max-width: calc(100% - 32px);
     display: flex;
     flex-direction: column;
+    background: var(--paper);
+    border: 2px solid var(--ink);
     overflow: hidden;
   }
 
-  @media (min-width: 768px) {
-    .split {
-      /* 60% map, 40% panel */
-      grid-template-columns: 3fr 2fr;
-      align-items: start;
-      min-height: 600px;
-    }
-
-    .map-col {
-      height: auto;
-      min-height: 600px;
-      position: sticky;
-      top: 0;
-      /* Panel is to the right; show a vertical rule between them. */
-      border-bottom: none;
-      border-right: 2px solid var(--ink);
-    }
+  .list-panel.collapsed {
+    bottom: auto;
   }
 
-  /* ── Controls ──────────────────────────────────────────────────────────── */
+  .list-head {
+    border-bottom: 2px solid var(--ink);
+  }
+
+  .list-panel.collapsed .list-head {
+    border-bottom: none;
+  }
+
+  .list-head-top {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    padding: 8px 12px;
+  }
+
+  .list-title {
+    margin: 0;
+    font-family: var(--mono);
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--ink-3);
+  }
+
+  .collapse-btn {
+    font-family: var(--mono);
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    padding: 4px 10px;
+    background: var(--paper);
+    color: var(--ink);
+    border: 2px solid var(--ink);
+    cursor: pointer;
+    transition:
+      transform 110ms ease,
+      box-shadow 110ms ease;
+  }
+
+  .collapse-btn:hover,
+  .collapse-btn:focus-visible {
+    transform: translate(-2px, -2px);
+    box-shadow: 2px 2px 0 var(--ink);
+    outline: none;
+  }
 
   .controls {
     display: flex;
     flex-direction: column;
     gap: 8px;
-    padding: 10px 12px;
-    border-bottom: 2px solid var(--ink);
+    padding: 0 12px 10px;
   }
 
   .sort-row {
@@ -467,7 +505,6 @@
     white-space: nowrap;
   }
 
-  /* Segmented sort control (same idiom as dr-jobs LIVE/HISTORY toggle). */
   .toggle {
     display: inline-flex;
   }
@@ -478,12 +515,15 @@
     font-weight: 700;
     letter-spacing: 0.06em;
     text-transform: uppercase;
-    padding: 5px 10px;
+    padding: 5px 9px;
     background: var(--paper);
     color: var(--ink);
     border: 2px solid var(--ink);
     cursor: pointer;
-    transition: transform 120ms ease, box-shadow 120ms ease, background 120ms ease;
+    transition:
+      transform 120ms ease,
+      box-shadow 120ms ease,
+      background 120ms ease;
   }
 
   .seg + .seg {
@@ -512,7 +552,6 @@
     display: contents;
   }
 
-  /* Region select: hard-edge, no browser chrome. */
   .region-select {
     font-family: var(--mono);
     font-size: 11px;
@@ -528,7 +567,6 @@
     cursor: pointer;
   }
 
-  /* Clear-nights toggle label. */
   .check-label {
     display: inline-flex;
     align-items: center;
@@ -548,8 +586,6 @@
     cursor: pointer;
   }
 
-  /* ── Ranked list ───────────────────────────────────────────────────────── */
-
   .rows {
     list-style: none;
     margin: 0;
@@ -562,8 +598,6 @@
     border-top: 2px solid var(--ink);
   }
 
-  /* Each row is a button so it is keyboard-accessible and clearly interactive.
-     Flat wash on hover (no lift: it does not open a new page, so no nav affordance). */
   .row {
     display: flex;
     align-items: center;
@@ -632,7 +666,6 @@
     flex-shrink: 0;
   }
 
-  /* Score badge: colored square, font-mono, tabular. */
   .score-badge {
     display: inline-block;
     font-family: var(--mono);
@@ -645,7 +678,6 @@
     text-align: center;
   }
 
-  /* Zero-score badge: no inline color, use token-based neutral styling. */
   .score-badge.score-zero {
     background: var(--rule);
     color: var(--ink-3);
@@ -671,11 +703,32 @@
     color: var(--ink-3);
   }
 
-  /* ── 14-day detail strip ───────────────────────────────────────────────── */
-
+  /* Detail panel: bottom card anchored center-bottom, clear of the legend
+     (bottom-left, inside the map) and the list panel (bottom-right) on desktop. */
   .detail {
-    border-top: 2px solid var(--ink);
-    padding: 12px;
+    position: absolute;
+    bottom: 16px;
+    left: 280px;
+    right: 372px;
+    max-height: 44vh;
+    overflow-y: auto;
+    padding: 12px 14px;
+    background: var(--paper);
+    border: 2px solid var(--ink);
+    box-shadow: 4px 4px 0 var(--ink);
+  }
+
+  .detail-close {
+    position: absolute;
+    top: 6px;
+    right: 10px;
+    background: none;
+    border: none;
+    font-family: var(--mono);
+    font-size: 22px;
+    line-height: 1;
+    cursor: pointer;
+    color: var(--ink);
   }
 
   .detail-head {
@@ -683,7 +736,7 @@
     align-items: flex-start;
     justify-content: space-between;
     gap: 10px;
-    margin-bottom: 8px;
+    margin: 0 24px 8px 0;
     flex-wrap: wrap;
   }
 
@@ -707,8 +760,6 @@
     letter-spacing: 0.02em;
   }
 
-  /* "Book on BC Parks" link: same lifted-box treatment as the sort/toggle
-     buttons so it reads as the primary action in this section. */
   .book-link {
     display: inline-flex;
     align-items: center;
@@ -723,7 +774,9 @@
     color: var(--paper);
     border: 2px solid var(--ink);
     white-space: nowrap;
-    transition: transform 110ms ease, box-shadow 110ms ease;
+    transition:
+      transform 110ms ease,
+      box-shadow 110ms ease;
   }
 
   .book-link:hover,
@@ -733,8 +786,6 @@
     outline: none;
   }
 
-  /* Horizontally scrollable container for the 14-day strip so it never
-     wraps and looks broken on narrow screens. */
   .days-scroll {
     overflow-x: auto;
     margin-bottom: 8px;
@@ -745,11 +796,10 @@
     gap: 4px;
     list-style: none;
     margin: 0;
-    padding: 2px 0 6px; /* bottom clearance for the scrollbar */
+    padding: 2px 0 6px;
     width: max-content;
   }
 
-  /* Each day cell: small card colored by available + sunny_score. */
   .day-cell {
     display: flex;
     flex-direction: column;
@@ -759,7 +809,6 @@
     padding: 5px 3px;
     border: 1.5px solid var(--ink);
     cursor: default;
-    /* Transition the background when data refreshes. */
     transition: background 300ms ease;
   }
 
@@ -786,7 +835,6 @@
     letter-spacing: 0.01em;
   }
 
-  /* Closed cells: dim the text so closed days read as muted. */
   .day-cell:not(.day-open) .day-date,
   .day-cell:not(.day-open) .day-icon,
   .day-cell:not(.day-open) .day-temp {
@@ -802,61 +850,49 @@
     line-height: 1.4;
   }
 
-  /* ── Desktop scale-up ──────────────────────────────────────────────────── */
-
-  @media (min-width: 768px) {
-    .page {
-      padding: 24px;
+  /* Mobile: list + detail become bottom sheets; the map still owns the top of
+     the screen (map-first). A selected park's detail takes over the sheet space,
+     so the list hides while it is open to avoid stacking two bottom sheets. */
+  @media (max-width: 768px) {
+    .crumb-card {
+      top: 12px;
+      left: 12px;
     }
 
-    .board-head {
-      gap: 9px;
-      padding: 14px 18px;
+    .list-panel {
+      top: auto;
+      bottom: 0;
+      left: 0;
+      right: 0;
+      width: auto;
+      max-width: none;
+      max-height: 46vh;
+      border-width: 2px 0 0;
     }
 
-    .crumb,
-    .stats,
-    .source {
-      font-size: 13px;
+    .list-panel.collapsed {
+      bottom: 0;
     }
 
-    .controls {
-      padding: 12px 14px;
-    }
-
-    .seg {
-      font-size: 12px;
-      padding: 6px 12px;
-    }
-
-    .row {
-      padding: 10px 14px;
-    }
-
-    .r-name {
-      font-size: 15px;
+    .has-selection .list-panel {
+      display: none;
     }
 
     .detail {
-      padding: 14px;
-    }
-
-    .detail-park {
-      font-size: 24px;
-    }
-  }
-
-  /* On very narrow screens keep the filter row readable. */
-  @media (max-width: 400px) {
-    .filter-row {
-      flex-direction: column;
-      align-items: flex-start;
+      bottom: 0;
+      left: 0;
+      right: 0;
+      max-height: 60vh;
+      border-width: 2px 0 0;
+      box-shadow: none;
+      padding-bottom: calc(12px + env(safe-area-inset-bottom));
     }
   }
 
   @media (prefers-reduced-motion: reduce) {
     .seg,
     .book-link,
+    .collapse-btn,
     .row {
       transition: none;
     }


### PR DESCRIPTION
The initial /app/campsites shipped as a split map+list where the map rendered blank (a MapLibre container-sizing race in the CSS-grid column: the canvas initialized at 0x0 and never resized). This makes it map-first like /app/stars and /app/ships.

## Changes
- **Full-bleed map** (100dvh, `position:absolute; inset:0`), which also fixes the blank render, plus a belt-and-suspenders `map.resize()` on load + a `ResizeObserver`.
- **Clear-sky weather heatmap** (`type: "heatmap"`) under the pins, weighted by `good_days` (open AND clear), with a sunshine ramp (transparent to warm to green) that fades out when zoomed in so the pins take over. Toggle-able.
- **Pins** on top, colored by `best_score`, clickable with fly-to + popup.
- **Overlay list** (collapsible right panel) with sort/filter, and a **14-day detail panel** on selection with a Book-on-BC-Parks link.
- Deploy: bumps `monolith-public` to 0.82.4 (the public tier that serves jomcgi.dev).

🤖 Generated with [Claude Code](https://claude.com/claude-code)