### PR TITLE
fix(model-bench): report ignores stale-harness-version cells

### DIFF
--- a/projects/model-bench/bench/cli.py
+++ b/projects/model-bench/bench/cli.py
@@ -132,6 +132,15 @@ def build_parser() -> argparse.ArgumentParser:
         "--results", default="results", help="Directory to read result JSON files from"
     )
 
+    # prune-stale
+    p_prune_stale = sub.add_parser(
+        "prune-stale",
+        help="Delete result cells left over from a different harness version",
+    )
+    p_prune_stale.add_argument(
+        "--results", default="results", help="Directory to read result JSON files from"
+    )
+
     # list
     p_list = sub.add_parser("list", help="List models and their status")
     p_list.add_argument("--models", default="models.yaml")
@@ -340,12 +349,30 @@ def _report(args) -> None:
 
     results_root = Path(args.results)
     cells: list[ResultCell] = []
+    stale = 0
     if results_root.exists():
         for json_path in results_root.rglob("*.json"):
             try:
-                cells.append(ResultCell.model_validate_json(json_path.read_text()))
+                cell = ResultCell.model_validate_json(json_path.read_text())
             except Exception as exc:
                 logger.warning("skipping %s: %s", json_path, exc)
+                continue
+            # Only aggregate cells from the current harness version. Results from a
+            # prior version (e.g. before a bug fix bumped HARNESS_VERSION, or under an
+            # old model slug) linger on disk next to fresh cells; counting both would
+            # double-count and mix corrupt data into the leaderboard.
+            if cell.harness_version != HARNESS_VERSION:
+                stale += 1
+                continue
+            cells.append(cell)
+
+    if stale:
+        logger.warning(
+            "ignored %d result cell(s) from a different harness version (current %s); "
+            "run `python -m bench prune-stale` to delete them",
+            stale,
+            HARNESS_VERSION,
+        )
 
     agg = aggregate_by_class(cells, task_class_of)
 
@@ -445,6 +472,25 @@ def _prune(args) -> None:
     print(pruned)
 
 
+def _prune_stale(args) -> None:
+    """Delete result cells whose harness_version differs from the current one."""
+    results_root = Path(args.results)
+    removed = 0
+    if results_root.exists():
+        for json_path in results_root.rglob("*.json"):
+            try:
+                cell = ResultCell.model_validate_json(json_path.read_text())
+            except Exception as exc:
+                logger.warning("skipping unreadable cell %s: %s", json_path, exc)
+                continue
+            if cell.harness_version != HARNESS_VERSION:
+                json_path.unlink()
+                removed += 1
+    print(
+        f"Removed {removed} stale result cell(s) (kept harness version {HARNESS_VERSION})."
+    )
+
+
 def _list(args) -> None:
     """Print each model: id, status, role."""
     reg = load_registry(Path(args.models))
@@ -464,6 +510,8 @@ def main(argv=None) -> None:
         _drop(args)
     elif args.command == "prune":
         _prune(args)
+    elif args.command == "prune-stale":
+        _prune_stale(args)
     elif args.command == "list":
         _list(args)
     else:

--- a/projects/model-bench/bench/cli_test.py
+++ b/projects/model-bench/bench/cli_test.py
@@ -1,13 +1,34 @@
+import argparse
+
 import pytest  # noqa: F401
 
-from bench.cli import build_parser, load_tasks
+from bench.cache import HARNESS_VERSION
+from bench.cli import _prune_stale, build_parser, load_tasks
 
 
 def test_parser_has_subcommands():
     p = build_parser()
     choices = p._subparsers._group_actions[0].choices
-    for sub in ("run", "report", "drop", "prune", "list"):
+    for sub in ("run", "report", "drop", "prune", "prune-stale", "list"):
         assert sub in choices
+
+
+def test_prune_stale_removes_only_other_versions(tmp_path, capsys):
+    root = tmp_path / "results" / "m" / "t1"
+    root.mkdir(parents=True)
+    cur = (
+        '{"task_id":"t1","task_version":"v1","model_id":"m","content_hash":"aaa",'
+        '"outcome":"pass@1","attempts":[],"cost_usd":0.0,'
+        f'"harness_version":"{HARNESS_VERSION}","prompt_template_hash":"x"}}'
+    )
+    old = cur.replace(
+        f'"harness_version":"{HARNESS_VERSION}"', '"harness_version":"0.0.0"'
+    )
+    (root / "cur.json").write_text(cur)
+    (root / "old.json").write_text(old)
+    _prune_stale(argparse.Namespace(results=str(tmp_path / "results")))
+    assert (root / "cur.json").exists()
+    assert not (root / "old.json").exists()
 
 
 def test_load_tasks_reads_pack(tmp_path):


### PR DESCRIPTION
The smoke re-run's leaderboard double-counted results. When HARNESS_VERSION bumped (or a model slug was fixed), the new run wrote new cell files alongside the old buggy ones in the same results dir, and the report globbed all of them. Symptoms: Opus showed config-plumbing pass@1 = 0.25 (impossible with 2 tasks), and the old mis-typed qwen2.5-coder slug appeared as a phantom row next to the fixed one.

Fix: aggregate only cells whose harness_version matches the current one, log how many stale cells were skipped, and add a prune-stale subcommand to delete them from disk. After merge, re-running is not needed: bench report re-reads clean.

Generated with Claude Code
