### PR TITLE
fix(model-bench): path-agnostic extraction, rbac graded failures, full results table

### DIFF
--- a/projects/model-bench/bench/cache.py
+++ b/projects/model-bench/bench/cache.py
@@ -1,7 +1,7 @@
 import hashlib
 from pathlib import Path
 
-HARNESS_VERSION = "0.1.1"
+HARNESS_VERSION = "0.1.2"
 
 
 def cell_key(

--- a/projects/model-bench/bench/report.py
+++ b/projects/model-bench/bench/report.py
@@ -54,6 +54,38 @@ def render_leaderboard(
         lines.append("No qualifying budget candidates yet.")
     lines.append("")
 
+    # All results: every candidate x class, including non-qualifiers, so rejects
+    # (models that fail the bar or cost more than it) stay visible instead of
+    # vanishing from the only candidate table. This tool is used to reject models,
+    # so the rejects have to be shown.
+    lines.append("## All results")
+    lines.append("")
+    all_rows: list[dict] = []
+    for model_id, class_data in per_class.items():
+        for cls, scores in class_data.items():
+            all_rows.append(
+                {
+                    "model": model_id,
+                    "class": cls,
+                    "pass1": scores.get("pass1", 0.0),
+                    "cost": scores.get("cost", 0.0),
+                    "tier": scores.get("tier", ""),
+                    "qualifies": "yes" if scores.get("qualifies") else "no",
+                }
+            )
+    all_rows.sort(key=lambda r: (r["class"], r["cost"]))
+    if all_rows:
+        lines.append("| Model | Class | pass@1 | cost ($) | tier | qualifies |")
+        lines.append("| --- | --- | --- | --- | --- | --- |")
+        for row in all_rows:
+            lines.append(
+                f"| {row['model']} | {row['class']} | {row['pass1']:.2f} "
+                f"| {row['cost']:.4f} | {row['tier']} | {row['qualifies']} |"
+            )
+    else:
+        lines.append("No results yet.")
+    lines.append("")
+
     # Anchors: baseline pass1/cost per class
     lines.append("## Anchors")
     lines.append("")

--- a/projects/model-bench/bench/report_test.py
+++ b/projects/model-bench/bench/report_test.py
@@ -34,3 +34,28 @@ def test_report_has_per_class_qualification_and_tombstone():
     assert "## Budget tier" in md
     assert "cheap/x" in md and "config-plumbing" in md
     assert "## Retired" in md and "old/y" in md and "flunked config" in md
+
+
+def test_all_results_shows_non_qualifiers():
+    # A model that does not qualify (too pricey / below bar) is absent from the
+    # Budget tier table but must still appear under All results.
+    md = render_leaderboard(
+        per_class={
+            "pricey/z": {
+                "config-plumbing": {
+                    "pass1": 0.5,
+                    "cost": 9.0,
+                    "tier": "needs-repair",
+                    "qualifies": False,
+                }
+            }
+        },
+        anchors={},
+        frontier={},
+        retired=[],
+    )
+    assert "## All results" in md
+    assert "pricey/z" in md
+    assert (
+        "No qualifying budget candidates yet." in md
+    )  # correctly excluded from budget tier

--- a/projects/model-bench/bench/runner.py
+++ b/projects/model-bench/bench/runner.py
@@ -41,59 +41,58 @@ def _strip_code_fence(content: str) -> str:
     return content.strip("\n")
 
 
+def _is_file_header(line: str) -> bool:
+    """True if a line is a standalone ``FILE <path>`` header.
+
+    Two whitespace-separated tokens where the first is exactly ``FILE``. A real
+    source line like ``FILE: x`` (a YAML key) has ``FILE:`` as token 0 and is not
+    matched, so we never strip genuine content.
+    """
+    parts = line.strip().split()
+    return len(parts) == 2 and parts[0] == "FILE"
+
+
 def extract_files(text: str, target_files: list[str]) -> dict[str, str]:
     """Parse model output into {path: content}.
 
-    Rules (in order):
-    1. Recognize FILE <path> header lines. A line that is exactly ``FILE <path>``
-       starts a block; everything until the next FILE header or EOF is that
-       file's content. Strip one leading newline after the header and one
-       trailing newline.
-    2. If NO FILE headers are found and there is exactly ONE target file, treat
-       the whole response as that file's content, first stripping a surrounding
-       fenced code block if the whole response is fenced.
-    3. Return only keys present in target_files.
-    """
-    lines = text.split("\n")
+    Single-target tasks (all current ones): the whole response is the file. Drop any
+    standalone ``FILE <path>`` header lines and a surrounding code fence, and map the
+    result to the one target regardless of the header path -- a model that writes
+    ``FILE values.yaml`` instead of the full ``FILE chart/values.yaml`` still lands in
+    the right place. This measures capability, not exact envelope format; requiring an
+    exact path match silently drops the answer and grades the untouched fixture.
 
+    Multi-target tasks: parse ``FILE <path>`` headers and match each block against
+    target_files by exact path, else by basename.
+    """
+    if len(target_files) == 1:
+        body = "\n".join(ln for ln in text.split("\n") if not _is_file_header(ln))
+        return {target_files[0]: _strip_code_fence(body)}
+
+    # Multi-target: split on FILE headers.
     file_blocks: dict[str, list[str]] = {}
     current_file: str | None = None
     current_lines: list[str] = []
-    found_headers = False
-
-    for line in lines:
-        if line.startswith("FILE ") and len(line) > 5:
-            found_headers = True
+    for line in text.split("\n"):
+        if _is_file_header(line):
             if current_file is not None:
                 file_blocks[current_file] = current_lines
-            current_file = line[len("FILE ") :].strip()
+            current_file = line.strip().split()[1]
             current_lines = []
-        else:
-            if current_file is not None:
-                current_lines.append(line)
-
+        elif current_file is not None:
+            current_lines.append(line)
     if current_file is not None:
         file_blocks[current_file] = current_lines
 
-    if found_headers:
-        result: dict[str, str] = {}
-        for path, block_lines in file_blocks.items():
-            if path not in target_files:
-                continue
-            # Strip one leading newline: with line-based parsing, an empty
-            # first element represents the newline immediately after the header.
-            if block_lines and block_lines[0] == "":
-                block_lines = block_lines[1:]
-            content = "\n".join(block_lines)
-            # Models often wrap the block in a code fence after the FILE header.
-            result[path] = _strip_code_fence(content)
-        return result
-
-    # No FILE headers found.
-    if len(target_files) == 1:
-        return {target_files[0]: _strip_code_fence(text)}
-
-    return {}
+    result: dict[str, str] = {}
+    basenames = {t.split("/")[-1]: t for t in target_files}
+    for path, block_lines in file_blocks.items():
+        content = _strip_code_fence("\n".join(block_lines))
+        if path in target_files:
+            result[path] = content
+        elif path.split("/")[-1] in basenames:
+            result[basenames[path.split("/")[-1]]] = content
+    return result
 
 
 def _make_workdir(fixture_dir: Path) -> Path:

--- a/projects/model-bench/bench/runner_test.py
+++ b/projects/model-bench/bench/runner_test.py
@@ -31,6 +31,16 @@ def test_extract_unfenced_passthrough():
     }
 
 
+def test_extract_single_target_ignores_mismatched_file_path():
+    # Model wrote `FILE values.yaml` but the target is `chart/values.yaml`. The
+    # content must still map to the target, not be dropped (which would grade the
+    # untouched fixture). This is the helm shot-1 failure regression.
+    text = "FILE values.yaml\nimage:\n  repository: myrepo/demo\n  tag: 1.4.2"
+    assert extract_files(text, ["chart/values.yaml"]) == {
+        "chart/values.yaml": "image:\n  repository: myrepo/demo\n  tag: 1.4.2"
+    }
+
+
 def make_model(script):  # script: list of outputs per attempt
     calls = {"i": 0}
 

--- a/projects/model-bench/bench/verifiers/effect_verifiers_test.py
+++ b/projects/model-bench/bench/verifiers/effect_verifiers_test.py
@@ -10,6 +10,20 @@ rules:
 """
 
 
+def test_rbac_bad_yaml_is_graded_failure_not_crash(tmp_path):
+    # Malformed YAML must return a graded failure (so the model can repair on shot 2),
+    # not raise an exception that the harness records as a dead [harness error] cell.
+    (tmp_path / "role.yaml").write_text("rules: [oops: bad: flow")
+    r = get_verifier("rbac-cover")(
+        tmp_path,
+        {
+            "clusterrole": "role.yaml",
+            "required": [{"group": "g", "resource": "r", "verb": "list"}],
+        },
+    )
+    assert r.passed is False and "not valid YAML" in r.feedback
+
+
 def test_rbac_cover_passes_when_all_calls_covered(tmp_path):
     (tmp_path / "role.yaml").write_text(RBAC_YAML)
     v = get_verifier("rbac-cover")

--- a/projects/model-bench/bench/verifiers/rbac.py
+++ b/projects/model-bench/bench/verifiers/rbac.py
@@ -32,10 +32,24 @@ def verify(workdir: Path, args: dict) -> VerifyResult:
         required: list of {group, resource, verb} dicts that must all be covered
     """
     role_path = workdir / args["clusterrole"]
-    with open(role_path) as f:
-        doc = yaml.safe_load(f)
+    try:
+        with open(role_path) as f:
+            doc = yaml.safe_load(f)
+    except yaml.YAMLError as exc:
+        # A malformed ClusterRole is a graded failure, not a harness crash, so the
+        # model gets the parse error as feedback and can fix it on the retry.
+        return VerifyResult(False, f"clusterrole.yaml is not valid YAML: {exc}")
+
+    if not isinstance(doc, dict):
+        return VerifyResult(
+            False,
+            "clusterrole.yaml must be a YAML mapping with a 'rules' list, "
+            f"got {type(doc).__name__}",
+        )
 
     rules = doc.get("rules", [])
+    if not isinstance(rules, list):
+        return VerifyResult(False, "clusterrole.yaml 'rules' must be a list")
 
     missing = []
     for req in args["required"]:


### PR DESCRIPTION
Smoke-run diagnosis of why the anchors appeared to fail trivial config-plumbing tasks. Three fixes:

1. extract_files dropped model content on a FILE-header path mismatch (FILE values.yaml vs the target chart/values.yaml), grading the untouched fixture -> helm rendered an empty tag and shot 1 failed. Single-target tasks now treat the whole response as the file, stripping FILE-header lines and fences regardless of path.
2. rbac-cover let yaml.safe_load raise on a malformed ClusterRole, recorded as a dead harness-error cell with no retry. Now catches YAMLError and returns a graded failure so the model can repair on shot 2, like helm.
3. Report only showed qualifiers, hiding rejects and pricier-than-bar models. Added an All results table.

HARNESS_VERSION bumped 0.1.1 -> 0.1.2, so a re-run re-executes all cells under the fixed extraction.

After merge: git pull, then bench prune-stale && bench run && bench report.

Generated with Claude Code
