### PR TITLE
feat(fc-invoke): egress transport (PR A, goose cutover platform prep)

### DIFF
--- a/projects/firecracker/substrate/chart/BUILD
+++ b/projects/firecracker/substrate/chart/BUILD
@@ -11,6 +11,7 @@ helm_chart(
         "image": "//projects/firecracker/substrate/invoke:image.info",
         "semgrep.guestImage": "//projects/firecracker/semgrep/guest:image.info",
         "rootfsBuilder.image": "//projects/agent_platform/fc-agentd/rootfs-builder:image.info",
+        "egress.image": "//projects/firecracker/substrate/egress-proxy:image.info",
     },
     publish = True,
     visibility = ["//overlays:__subpackages__"],

--- a/projects/firecracker/substrate/chart/templates/deployment.yaml
+++ b/projects/firecracker/substrate/chart/templates/deployment.yaml
@@ -179,6 +179,41 @@ spec:
             - name: nvme
               mountPath: {{ .Values.firecracker.nvmeRoot }}
           {{- end }}
+        {{- if .Values.egress.enabled }}
+        # Egress-proxy sidecar (ADR 023 phase 6a, plain allowlist-forward): the
+        # only process that reaches the network on a guest's behalf. The daemon
+        # forwards each egress-enabled guest's vsock egress here over localhost;
+        # the sidecar never sees the guest's control frames. Pod-level: one sidecar
+        # serves every egress-enabled workload on the node. Runs non-root (uid
+        # 65532). Plain mode: NO secret catalog / CA / secret-swap (a later PR).
+        - name: egress-proxy
+          image: "{{ .Values.egress.image.repository }}:{{ .Values.egress.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65532
+            runAsGroup: 65532
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          env:
+            # The daemon tunnels to 127.0.0.1:8888 by default
+            # (FC_INVOKE_EGRESS_SIDECAR_ADDR); the sidecar listens on the same port.
+            - name: EGRESS_LISTEN
+              value: ":8888"
+            - name: EGRESS_POLICY
+              value: {{ .Values.egress.policy | default "allowlist" | quote }}
+            {{- if eq (.Values.egress.policy | default "allowlist") "allowlist" }}
+            # Under policy=allowlist the sidecar denies any destination not in this
+            # list (fail closed). Empty until the agent PR populates it.
+            - name: EGRESS_ALLOWLIST
+              value: {{ .Values.egress.allowlist | quote }}
+            {{- end }}
+          resources:
+            {{- toYaml .Values.egress.resources | nindent 12 }}
+        {{- end }}
       {{- if .Values.firecracker.enabled }}
       volumes:
         - name: dev-kvm

--- a/projects/firecracker/substrate/chart/values.yaml
+++ b/projects/firecracker/substrate/chart/values.yaml
@@ -137,6 +137,31 @@ firecracker:
   # announce readiness over its shim.
   bootReadyTimeout: 60s
 
+# Egress-proxy sidecar (ADR 023 phase 6a, plain allowlist-forward). When enabled
+# a pod-local egress-proxy sidecar is added; the daemon forwards each egress-
+# enabled workload's guest vsock egress to it over localhost (the sidecar is the
+# only process that reaches the network on a guest's behalf). Plain mode only:
+# NO secret catalog / CA / secret-swap (a later PR). Default off; there is no
+# egress-enabled workload yet (the agent PR flips this on and populates the
+# allowlist). The image repository + tag are Bazel-pinned from the egress-proxy
+# image's .info provider at chart-build (see chart/BUILD `images`).
+egress:
+  enabled: false
+  # Egress posture. "allowlist" denies any destination not in `allowlist` (fail
+  # closed). "allow" routes anywhere. Plain-mode default is allowlist.
+  policy: allowlist
+  # Destinations permitted under policy=allowlist (host[:port], comma-separated).
+  # Empty until the agent PR populates it. Ignored under policy=allow.
+  allowlist: ""
+  # Bazel-pinned at chart-build from the egress-proxy image .info provider.
+  image: {}
+  resources:
+    requests:
+      cpu: 10m
+      memory: 32Mi
+    limits:
+      memory: 64Mi
+
 tracing:
   endpoint: ""
   serviceName: fc-invoke

--- a/projects/firecracker/substrate/deploy/values.yaml
+++ b/projects/firecracker/substrate/deploy/values.yaml
@@ -20,3 +20,10 @@ firecracker:
 # the ArgoCD repo-cred added in projects/platform/argocd.
 imagePullSecret:
   enabled: true
+
+# Egress-proxy sidecar (ADR 023 phase 6a). Off for now: the only live workload
+# is semgrep, which runs with egress disabled. The agent workload PR flips this
+# on and populates egress.allowlist (in-cluster Qwen, the git mirror, the
+# monolith progress endpoint).
+egress:
+  enabled: false

--- a/projects/firecracker/substrate/invoke/cmd/main.go
+++ b/projects/firecracker/substrate/invoke/cmd/main.go
@@ -107,6 +107,7 @@ func run(logger *slog.Logger) error {
 			BaseKey:          name,
 			Arch:             cfg.Arch,
 			BootReadyTimeout: cfg.BootReadyTimeout,
+			SidecarAddr:      cfg.EgressSidecarAddr,
 		}, logger)
 		invokers[name] = inv
 

--- a/projects/firecracker/substrate/invoke/internal/config/config.go
+++ b/projects/firecracker/substrate/invoke/internal/config/config.go
@@ -99,6 +99,13 @@ type Config struct {
 	// restored guest to announce readiness over its shim.
 	BootReadyTimeout time.Duration
 
+	// EgressSidecarAddr is the pod-local egress-proxy sidecar TCP address
+	// (ADR 023 phase 6a). Egress-enabled workloads tunnel each guest's vsock
+	// egress connections here; the daemon holds no secrets and never parses the
+	// bytes. Daemon-global (one sidecar per pod serves every egress-enabled
+	// workload). Default "127.0.0.1:8888".
+	EgressSidecarAddr string
+
 	// Workloads is the set of named workloads the daemon can dispatch, keyed
 	// by workload name. Empty when no workload table is configured.
 	Workloads map[string]Workload
@@ -120,6 +127,7 @@ func Load() (Config, error) {
 		CanonicalVsockDir: getenvDefault("FC_INVOKE_CANONICAL_VSOCK_DIR", "/disks/nvme-02/fc-invoke-vsock"),
 		GuestOomScoreAdj:  atoiDefault("FC_INVOKE_GUEST_OOM_SCORE_ADJ", 1000),
 		BootReadyTimeout:  60 * time.Second,
+		EgressSidecarAddr: getenvDefault("FC_INVOKE_EGRESS_SIDECAR_ADDR", "127.0.0.1:8888"),
 	}
 
 	if c.Node == "" {

--- a/projects/firecracker/substrate/invoke/internal/egress/BUILD
+++ b/projects/firecracker/substrate/invoke/internal/egress/BUILD
@@ -1,0 +1,16 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "egress",
+    srcs = ["forwarder.go"],
+    importpath = "github.com/jomcgi/homelab/projects/firecracker/substrate/invoke/internal/egress",
+    visibility = ["//projects/firecracker/substrate/invoke:__subpackages__"],
+    deps = ["//projects/firecracker/substrate/vsockproto"],
+)
+
+go_test(
+    name = "egress_test",
+    srcs = ["forwarder_test.go"],
+    embed = [":egress"],
+    deps = ["//projects/firecracker/substrate/vsockproto"],
+)

--- a/projects/firecracker/substrate/invoke/internal/egress/forwarder.go
+++ b/projects/firecracker/substrate/invoke/internal/egress/forwarder.go
@@ -1,0 +1,77 @@
+// Package egress forwards a guest's vsock egress connections to a pod-local
+// egress-proxy sidecar (ADR 023 phase 6a). The daemon holds no secrets and
+// never parses the bytes (a raw tunnel): the secret-holding proxy is a separate
+// process reached only over localhost, preserving the blast-radius split even
+// though the daemon parses guest control frames. This is plain
+// allowlist-forward only; the secret-swap catalog and CA are a later phase.
+package egress
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"os"
+
+	"github.com/jomcgi/homelab/projects/firecracker/substrate/vsockproto"
+)
+
+// egressListenPath is the host unix socket Firecracker bridges the guest's
+// egress-port connections to.
+func egressListenPath(udsPath string) string {
+	return fmt.Sprintf("%s_%d", udsPath, vsockproto.EgressPort)
+}
+
+// ServeEgress forwards a guest's vsock egress connections to the co-located
+// egress-proxy sidecar (ADR 023). The daemon holds no secrets and never parses
+// the bytes (a raw tunnel): the secret-holding proxy is a separate process
+// reached only over localhost, preserving the blast-radius split even though the
+// daemon parses guest control frames. Each guest connection (one per outbound
+// request the guest's HTTP client opens) gets its own tunnel to sidecarAddr.
+// Returns nil on ctx cancellation.
+func ServeEgress(ctx context.Context, logger *slog.Logger, udsPath, sidecarAddr string) error {
+	path := egressListenPath(udsPath)
+	_ = os.Remove(path)
+	ln, err := net.Listen("unix", path)
+	if err != nil {
+		return fmt.Errorf("egress: listen %s: %w", path, err)
+	}
+	defer func() {
+		_ = ln.Close()
+		_ = os.Remove(path)
+	}()
+
+	go func() {
+		<-ctx.Done()
+		_ = ln.Close()
+	}()
+
+	for {
+		guestConn, err := ln.Accept()
+		if err != nil {
+			if ctx.Err() != nil {
+				return nil
+			}
+			return fmt.Errorf("egress: accept: %w", err)
+		}
+		go tunnelToSidecar(logger, guestConn, sidecarAddr)
+	}
+}
+
+// tunnelToSidecar dials the sidecar and copies bytes both ways until either side
+// closes; closing both conns then unblocks the other copy.
+func tunnelToSidecar(logger *slog.Logger, guestConn net.Conn, sidecarAddr string) {
+	defer guestConn.Close()
+	up, err := net.Dial("tcp", sidecarAddr)
+	if err != nil {
+		logger.Warn("egress: dial sidecar", "addr", sidecarAddr, "err", err)
+		return
+	}
+	defer up.Close()
+
+	done := make(chan struct{}, 2)
+	go func() { _, _ = io.Copy(up, guestConn); done <- struct{}{} }()
+	go func() { _, _ = io.Copy(guestConn, up); done <- struct{}{} }()
+	<-done
+}

--- a/projects/firecracker/substrate/invoke/internal/egress/forwarder_test.go
+++ b/projects/firecracker/substrate/invoke/internal/egress/forwarder_test.go
@@ -1,0 +1,132 @@
+package egress
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"net"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/jomcgi/homelab/projects/firecracker/substrate/vsockproto"
+)
+
+// startEchoSidecar starts a fake egress-proxy sidecar: a TCP listener that
+// echoes every byte back on each accepted connection. It returns the listen
+// address and a cleanup func. This stands in for the real sidecar so the tunnel
+// can be exercised over plain in-process sockets (no Firecracker, no vsock).
+func startEchoSidecar(t *testing.T) (addr string, stop func()) {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("echo sidecar listen: %v", err)
+	}
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func(c net.Conn) {
+				defer c.Close()
+				_, _ = io.Copy(c, c)
+			}(conn)
+		}
+	}()
+	return ln.Addr().String(), func() { _ = ln.Close() }
+}
+
+// TestServeEgressTunnelsBidirectionally asserts that a guest connection to
+// <uds>_<EgressPort> is tunnelled bidirectionally to the sidecar: bytes written
+// by the guest reach the (echo) sidecar and its reply is copied back to the
+// guest. The udsPath is a plain unix socket path standing in for the FC vsock
+// UDS; ServeEgress listens on the derived egress path exactly as it would in
+// production.
+func TestServeEgressTunnelsBidirectionally(t *testing.T) {
+	sidecarAddr, stopSidecar := startEchoSidecar(t)
+	defer stopSidecar()
+
+	// The base UDS path the driver would return for a thread; ServeEgress
+	// listens on "<uds>_<EgressPort>".
+	udsPath := filepath.Join(t.TempDir(), "vsock.sock")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	serveErr := make(chan error, 1)
+	go func() {
+		serveErr <- ServeEgress(ctx, slog.Default(), udsPath, sidecarAddr)
+	}()
+
+	listenPath := egressListenPath(udsPath)
+	guest := dialWithRetry(t, listenPath)
+	defer guest.Close()
+
+	want := []byte("hello sidecar")
+	if _, err := guest.Write(want); err != nil {
+		t.Fatalf("guest write: %v", err)
+	}
+	if err := guest.SetReadDeadline(time.Now().Add(2 * time.Second)); err != nil {
+		t.Fatalf("set read deadline: %v", err)
+	}
+	got := make([]byte, len(want))
+	if _, err := io.ReadFull(guest, got); err != nil {
+		t.Fatalf("guest read echo: %v", err)
+	}
+	if string(got) != string(want) {
+		t.Fatalf("echo mismatch: got %q want %q", got, want)
+	}
+
+	// Cancelling the context stops the accept loop and returns nil.
+	cancel()
+	select {
+	case err := <-serveErr:
+		if err != nil {
+			t.Fatalf("ServeEgress returned error on ctx cancel: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("ServeEgress did not return after ctx cancel")
+	}
+}
+
+// TestEgressListenPath pins the derived listen path so the guest-side funnel and
+// the host forwarder agree on the same socket name.
+func TestEgressListenPath(t *testing.T) {
+	got := egressListenPath("/run/vsock.sock")
+	want := "/run/vsock.sock_" + itoa(int(vsockproto.EgressPort))
+	if got != want {
+		t.Fatalf("egressListenPath = %q, want %q", got, want)
+	}
+}
+
+// dialWithRetry dials the unix socket, retrying briefly so the test does not
+// race ServeEgress's Listen call.
+func dialWithRetry(t *testing.T, path string) net.Conn {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		conn, err := net.Dial("unix", path)
+		if err == nil {
+			return conn
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("dial %s: %v", path, err)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+// itoa is a tiny local int-to-string to avoid importing strconv just for the
+// path assertion.
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var b [20]byte
+	i := len(b)
+	for n > 0 {
+		i--
+		b[i] = byte('0' + n%10)
+		n /= 10
+	}
+	return string(b[i:])
+}

--- a/projects/firecracker/substrate/invoke/internal/invoker/BUILD
+++ b/projects/firecracker/substrate/invoke/internal/invoker/BUILD
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//projects/firecracker/substrate/invoke:__subpackages__"],
     deps = [
         "//projects/firecracker/substrate/invoke/internal/config",
+        "//projects/firecracker/substrate/invoke/internal/egress",
         "//projects/firecracker/substrate/substrate",
         "@org_golang_x_sync//semaphore",
     ],

--- a/projects/firecracker/substrate/invoke/internal/invoker/invoker.go
+++ b/projects/firecracker/substrate/invoke/internal/invoker/invoker.go
@@ -22,6 +22,7 @@ import (
 	"golang.org/x/sync/semaphore"
 
 	"github.com/jomcgi/homelab/projects/firecracker/substrate/invoke/internal/config"
+	"github.com/jomcgi/homelab/projects/firecracker/substrate/invoke/internal/egress"
 	"github.com/jomcgi/homelab/projects/firecracker/substrate/substrate"
 )
 
@@ -98,6 +99,11 @@ type Config struct {
 	// If a restore is not ready within this budget it is treated as unavailable
 	// and Invoke falls back to a cold boot. Defaults to 2s.
 	RestoreReadyTimeout time.Duration
+	// SidecarAddr is the pod-local egress-proxy sidecar TCP address (ADR 023
+	// phase 6a). When Workload.EgressEnabled is true, each guest's vsock egress
+	// connections are tunnelled here; the daemon holds no secrets and never
+	// parses the bytes. Ignored when egress is disabled (e.g. semgrep).
+	SidecarAddr string
 }
 
 // Invoker orchestrates invocations for one workload. The daemon creates one
@@ -278,6 +284,32 @@ func (inv *Invoker) claimInvoke(ctx context.Context, spec substrate.ClaimSpec, s
 
 	uds := inv.driver.VsockUDSPath(h.ThreadID)
 
+	// Egress (ADR 023 phase 6a): when this workload has egress enabled, forward
+	// the guest's vsock egress connections to the pod-local egress-proxy sidecar.
+	// The forwarder runs for the life of the guest, bound to its own background
+	// context (independent of the request context, so it survives while the
+	// response body streams). egressCancel stops it and is folded into every path
+	// that discards the guest below, so the forwarder goroutine never outlives the
+	// VM. It is a no-op when egress is disabled (e.g. semgrep), leaving that path
+	// completely unaffected.
+	egressCancel := func() {}
+	if inv.cfg.Workload.EgressEnabled {
+		ectx, cancel := context.WithCancel(context.Background())
+		egressCancel = cancel
+		go func() {
+			if err := egress.ServeEgress(ectx, inv.logger, uds, inv.cfg.SidecarAddr); err != nil {
+				inv.logger.Warn("invoker: egress forwarder stopped", "thread", h.ThreadID, "err", err)
+			}
+		}()
+	}
+	// discardGuest tears the VM down and stops its egress forwarder together, so
+	// the forwarder's context is cancelled exactly when the guest is discarded on
+	// every path (each eager error return below, and the success body Close).
+	discardGuest := func() {
+		egressCancel()
+		inv.discard(h)
+	}
+
 	// A warm restore is already warmed in the snapshot, so it answers /shim/ready
 	// almost immediately; use the short RestoreReadyTimeout so a wedged or dead
 	// restore fails fast and falls back to a cold boot. A cold boot needs the
@@ -294,7 +326,7 @@ func (inv *Invoker) claimInvoke(ctx context.Context, spec substrate.ClaimSpec, s
 	readyErr := inv.transport.WaitReady(readyCtx, uds, inv.cfg.Workload.ReadyPath)
 	cancelReady()
 	if readyErr != nil {
-		inv.discard(h)
+		discardGuest()
 		return nil, nil, &GuestUnavailableError{Err: fmt.Errorf("guest readiness: %w", readyErr)}
 	}
 
@@ -308,13 +340,13 @@ func (inv *Invoker) claimInvoke(ctx context.Context, spec substrate.ClaimSpec, s
 		// This only fails for malformed method strings; treat as infrastructure
 		// error, not a VM issue. No body to own, so clean up eagerly.
 		cancelRT()
-		inv.discard(h)
+		discardGuest()
 		return nil, nil, fmt.Errorf("invoker: build request: %w", err)
 	}
 	resp, err := inv.transport.RoundTrip(rtCtx, uds, req)
 	if err != nil {
 		cancelRT()
-		inv.discard(h)
+		discardGuest()
 		if warm {
 			// On the warm path a transport-level round-trip failure (the
 			// connection broke mid-request) after readiness passed suggests the
@@ -333,7 +365,7 @@ func (inv *Invoker) claimInvoke(ctx context.Context, spec substrate.ClaimSpec, s
 	// the VM; it will run only when the body is closed, after streaming. Cancel
 	// the context AFTER discarding so an in-flight read is never aborted early.
 	cleanup := func() {
-		inv.discard(h)
+		discardGuest()
 		cancelRT()
 	}
 	return resp, cleanup, nil


### PR DESCRIPTION
PR A of the goose cutover (ADR 030): give the fc-invoke daemon the egress transport an agent workload needs, so its guest can reach in-cluster Qwen, a git mirror, and the monolith progress endpoint.

- Ports fc-agentd's `ServeEgress` vsock->sidecar forwarder into `invoke/internal/egress`; the invoker runs it per guest **only when the workload has `egressEnabled`**, with the forwarder ctx cancelled exactly when the guest is discarded (all success + error paths, no goroutine leak).
- Adds the `egress-proxy` sidecar to the fc-invoke chart, gated by `egress.enabled` (pod-level), non-root, **plain mode** (allowlist-forward; NO secret-swap catalog/CA yet, that comes with the artifact/OpenRouter tier). Image digest pinned via `helm_images_values`.

Ships nothing into the request path: no workload sets `egressEnabled` yet (semgrep stays `egress.enabled: false` and renders **no sidecar**, verified via `helm template`). The agent workload (PR B) is the first consumer.

Deferred (post-e2e): egress secret-swap (6b) + ObjectStore S3 + sessions.db resume.

🤖 Generated with [Claude Code](https://claude.com/claude-code)