### PR TITLE
fix(campsites): heatmap glow + list/controls/detail polish

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.82.4
+version: 0.82.5
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.82.4
+      targetRevision: 0.82.5
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/frontend/src/lib/public/components/campsites/CampsitesMap.svelte
+++ b/projects/monolith/frontend/src/lib/public/components/campsites/CampsitesMap.svelte
@@ -26,8 +26,6 @@
   let resizeObs = null;
   let layerReady = $state(false); // $state so effects re-evaluate after load
 
-  let heatOn = $state(true); // weather heatmap visible by default
-
   // Data-viz ramp colors: outside the design-token system (intentionally, same
   // pattern as ShipsMap VESSEL_COLORS / HEAT_COLORS). They live in plain JS
   // constants so the hexes never appear as a `:` + `#hex` pair inside a style
@@ -61,12 +59,15 @@
   // through pale yellow and amber into lime and green as more open-and-clear parks
   // cluster together. Kept as named constants (not inline literals) for the same
   // semgrep-safety reason as the pin colors.
+  // Warm "sunshine" field: transparent at low density (so a single park does
+  // not glow), warming through gold to a hot orange for clusters of open+clear
+  // parks. Warm contrasts with the green terrain and makes the green pins pop.
   const HEAT_C0 = "rgba(0, 0, 0, 0)";
-  const HEAT_C1 = "#fde68a"; // pale yellow
-  const HEAT_C2 = "#fbbf24"; // yellow
-  const HEAT_C3 = "#f59e0b"; // amber
-  const HEAT_C4 = "#84cc16"; // lime
-  const HEAT_C5 = "#22c55e"; // green
+  const HEAT_C1 = "rgba(254, 243, 199, 0.35)"; // amber-100, very soft
+  const HEAT_C2 = "rgba(253, 224, 71, 0.6)"; // yellow-300
+  const HEAT_C3 = "rgba(251, 146, 60, 0.8)"; // orange-400
+  const HEAT_C4 = "#f97316"; // orange-500
+  const HEAT_C5 = "#ea580c"; // orange-600, hot
 
   const HEAT_COLOR = [
     "interpolate",
@@ -74,13 +75,13 @@
     ["heatmap-density"],
     0,
     HEAT_C0,
-    0.2,
+    0.3,
     HEAT_C1,
-    0.4,
+    0.55,
     HEAT_C2,
-    0.6,
+    0.75,
     HEAT_C3,
-    0.8,
+    0.9,
     HEAT_C4,
     1,
     HEAT_C5,
@@ -135,17 +136,6 @@
 
   function daysText(n) {
     return n === 1 ? "1 clear day" : `${n} clear days`;
-  }
-
-  function toggleHeat() {
-    heatOn = !heatOn;
-    if (map && layerReady) {
-      map.setLayoutProperty(
-        HEAT_LAYER,
-        "visibility",
-        heatOn ? "visible" : "none",
-      );
-    }
   }
 
   // Re-sync the source whenever parks or selection changes. Runs once map and
@@ -230,7 +220,7 @@
           id: HEAT_LAYER,
           type: "heatmap",
           source: SOURCE_ID,
-          layout: { visibility: heatOn ? "visible" : "none" },
+          layout: { visibility: "visible" },
           paint: {
             "heatmap-weight": [
               "interpolate",
@@ -238,8 +228,10 @@
               ["get", "good_days"],
               0,
               0,
-              1,
-              0.35,
+              2,
+              0.12,
+              4,
+              0.45,
               7,
               1,
             ],
@@ -248,26 +240,30 @@
               ["linear"],
               ["zoom"],
               4,
-              1,
+              0.85,
               8,
-              2,
+              1.5,
             ],
             "heatmap-radius": [
               "interpolate",
               ["linear"],
               ["zoom"],
               4,
-              28,
-              8,
-              48,
+              45,
+              6,
+              62,
+              9,
+              34,
             ],
             "heatmap-opacity": [
               "interpolate",
               ["linear"],
               ["zoom"],
-              7,
-              0.55,
-              9,
+              4,
+              0.5,
+              8,
+              0.45,
+              10,
               0,
             ],
             "heatmap-color": HEAT_COLOR,
@@ -361,17 +357,6 @@
 <div class="map-wrap">
   <div class="map" bind:this={mapContainer}></div>
 
-  <div class="heat-toggle" role="group" aria-label="Weather heatmap">
-    <button
-      type="button"
-      class:active={heatOn}
-      aria-pressed={heatOn}
-      onclick={toggleHeat}
-    >
-      Heat {heatOn ? "on" : "off"}
-    </button>
-  </div>
-
   <div class="legend">
     <p class="legend-title">Open sites + clear sky</p>
     <ul class="legend-list">
@@ -439,7 +424,6 @@
   .map :global(.maplibregl-ctrl-group button:hover),
   .map :global(.maplibregl-ctrl-group button:focus-visible) {
     transform: translate(-2px, -2px);
-    box-shadow: 2px 2px 0 var(--ink);
     background: var(--paper);
     position: relative;
     z-index: 1;
@@ -477,7 +461,6 @@
     background: var(--paper);
     border: 2px solid var(--ink);
     border-radius: 0;
-    box-shadow: 3px 3px 0 var(--ink);
     padding: 8px 10px;
     font-family: var(--mono);
     font-size: 12px;
@@ -486,39 +469,6 @@
 
   .map :global(.maplibregl-popup-tip) {
     display: none;
-  }
-
-  /* Heat on/off switch, top-right (same idiom as the ShipsMap mode toggle). */
-  .heat-toggle {
-    position: absolute;
-    top: 16px;
-    right: 16px;
-    display: inline-flex;
-    border: 2px solid var(--ink);
-    background: var(--paper);
-    font-family: var(--mono);
-    font-size: 12px;
-    font-weight: 700;
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
-  }
-
-  .heat-toggle button {
-    padding: 8px 14px;
-    background: var(--paper);
-    border: none;
-    color: var(--ink);
-    cursor: pointer;
-    transition: background 120ms ease;
-  }
-
-  .heat-toggle button:hover {
-    background: var(--cream);
-  }
-
-  .heat-toggle button.active {
-    background: var(--ink);
-    color: var(--paper);
   }
 
   /* Legend: bottom-left, same hard-edge style as the ShipsMap legend. */
@@ -607,16 +557,6 @@
   }
 
   @media (max-width: 640px) {
-    .heat-toggle {
-      top: 12px;
-      right: 12px;
-      font-size: 13px;
-    }
-
-    .heat-toggle button {
-      padding: 11px 18px;
-    }
-
     .legend {
       bottom: 12px;
       left: 12px;
@@ -626,8 +566,7 @@
   }
 
   @media (prefers-reduced-motion: reduce) {
-    .map :global(.maplibregl-ctrl-group button),
-    .heat-toggle button {
+    .map :global(.maplibregl-ctrl-group button) {
       transition: none;
     }
   }

--- a/projects/monolith/frontend/src/lib/public/components/campsites/CampsitesMap.svelte
+++ b/projects/monolith/frontend/src/lib/public/components/campsites/CampsitesMap.svelte
@@ -55,13 +55,11 @@
     COL_GOOD,
   ];
 
-  // "Sunshine" ramp for the weather heatmap: transparent at zero density, warming
-  // through pale yellow and amber into lime and green as more open-and-clear parks
-  // cluster together. Kept as named constants (not inline literals) for the same
-  // semgrep-safety reason as the pin colors.
-  // Warm "sunshine" field: transparent at low density (so a single park does
-  // not glow), warming through gold to a hot orange for clusters of open+clear
-  // parks. Warm contrasts with the green terrain and makes the green pins pop.
+  // Warm "sunshine" field for the weather heatmap: transparent at low density
+  // (so a single park does not glow), warming through gold to a hot orange for
+  // clusters of open-and-clear parks. Warm contrasts with the green terrain and
+  // makes the green pins pop. Kept as named constants (not inline literals) for
+  // the same semgrep-safety reason as the pin colors.
   const HEAT_C0 = "rgba(0, 0, 0, 0)";
   const HEAT_C1 = "rgba(254, 243, 199, 0.35)"; // amber-100, very soft
   const HEAT_C2 = "rgba(253, 224, 71, 0.6)"; // yellow-300

--- a/projects/monolith/frontend/src/routes/public/app/campsites/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/campsites/+page.svelte
@@ -15,24 +15,16 @@
   let selectedPark = $derived(parks.find((p) => p.id === selectedId) ?? null);
 
   // List panel collapse (map-first: the whole map stays visible when collapsed).
-  let listOpen = $state(true);
+  // Starts closed so the map is unobstructed on load.
+  let listOpen = $state(false);
 
   // Sort and filter state.
-  let sortKey = $state("best_score"); // "best_score" | "good_days" | "name" | "region"
-  let filterRegion = $state("");
+  let sortKey = $state("best_score"); // "best_score" | "good_days" | "name"
   let clearOnly = $state(false);
-
-  // Unique region options, alphabetised.
-  let regions = $derived(
-    [...new Set(parks.map((p) => p.region).filter(Boolean))].sort((a, b) =>
-      a.localeCompare(b),
-    ),
-  );
 
   // Filter then sort. $derived.by for the multi-step computation.
   let visibleParks = $derived.by(() => {
     let list = parks;
-    if (filterRegion) list = list.filter((p) => p.region === filterRegion);
     if (clearOnly) list = list.filter((p) => p.good_days > 0);
     const out = [...list];
     if (sortKey === "best_score") {
@@ -45,12 +37,6 @@
       );
     } else if (sortKey === "name") {
       out.sort((a, b) => a.name.localeCompare(b.name));
-    } else if (sortKey === "region") {
-      out.sort(
-        (a, b) =>
-          (a.region ?? "").localeCompare(b.region ?? "") ||
-          a.name.localeCompare(b.name),
-      );
     }
     return out;
   });
@@ -186,7 +172,7 @@
           <div class="sort-row">
             <span class="control-label">Sort</span>
             <div class="toggle" role="group" aria-label="Sort parks by">
-              {#each [["best_score", "Score"], ["good_days", "Days"], ["name", "Name"], ["region", "Region"]] as [key, label] (key)}
+              {#each [["best_score", "Score"], ["good_days", "Days"], ["name", "Name"]] as [key, label] (key)}
                 <button
                   type="button"
                   class="seg"
@@ -199,16 +185,6 @@
           </div>
 
           <div class="filter-row">
-            <label class="field-wrap">
-              <span class="sr-only">Filter by region</span>
-              <select class="region-select" bind:value={filterRegion}>
-                <option value="">All regions</option>
-                {#each regions as r (r)}
-                  <option value={r}>{r}</option>
-                {/each}
-              </select>
-            </label>
-
             <label class="check-label">
               <input
                 type="checkbox"
@@ -413,7 +389,9 @@
   }
 
   /* Right-side ranked-list panel. Narrow by default so the page reads map-first;
-     collapse button shrinks it to just the header handle. */
+     collapse button shrinks it to just the header handle. z-index 20 ensures the
+     panel and its toggle sit above the MapLibre control group (z-index ~2) so the
+     open panel covers the zoom/attribution buttons cleanly. */
   .list-panel {
     position: absolute;
     top: 64px;
@@ -426,6 +404,7 @@
     background: var(--paper);
     border: 2px solid var(--ink);
     overflow: hidden;
+    z-index: 20;
   }
 
   .list-panel.collapsed {
@@ -469,15 +448,12 @@
     color: var(--ink);
     border: 2px solid var(--ink);
     cursor: pointer;
-    transition:
-      transform 110ms ease,
-      box-shadow 110ms ease;
+    transition: transform 110ms ease;
   }
 
   .collapse-btn:hover,
   .collapse-btn:focus-visible {
     transform: translate(-2px, -2px);
-    box-shadow: 2px 2px 0 var(--ink);
     outline: none;
   }
 
@@ -522,7 +498,6 @@
     cursor: pointer;
     transition:
       transform 120ms ease,
-      box-shadow 120ms ease,
       background 120ms ease;
   }
 
@@ -537,7 +512,6 @@
 
   .seg:hover {
     transform: translate(-2px, -2px);
-    box-shadow: var(--shadow-hard);
     z-index: 2;
   }
 
@@ -546,25 +520,6 @@
     align-items: center;
     gap: 10px;
     flex-wrap: wrap;
-  }
-
-  .field-wrap {
-    display: contents;
-  }
-
-  .region-select {
-    font-family: var(--mono);
-    font-size: 11px;
-    font-weight: 600;
-    letter-spacing: 0.04em;
-    padding: 5px 8px;
-    background: var(--paper);
-    color: var(--ink);
-    border: 2px solid var(--ink);
-    border-radius: 0;
-    -webkit-appearance: none;
-    appearance: none;
-    cursor: pointer;
   }
 
   .check-label {
@@ -715,7 +670,6 @@
     padding: 12px 14px;
     background: var(--paper);
     border: 2px solid var(--ink);
-    box-shadow: 4px 4px 0 var(--ink);
   }
 
   .detail-close {
@@ -774,15 +728,12 @@
     color: var(--paper);
     border: 2px solid var(--ink);
     white-space: nowrap;
-    transition:
-      transform 110ms ease,
-      box-shadow 110ms ease;
+    transition: transform 110ms ease;
   }
 
   .book-link:hover,
   .book-link:focus-visible {
     transform: translate(-2px, -2px);
-    box-shadow: 2px 2px 0 var(--ink-3);
     outline: none;
   }
 
@@ -805,7 +756,9 @@
     flex-direction: column;
     align-items: center;
     gap: 3px;
+    flex: 0 0 40px;
     width: 40px;
+    height: 64px;
     padding: 5px 3px;
     border: 1.5px solid var(--ink);
     cursor: default;


### PR DESCRIPTION
Feedback pass on the live /app/campsites map.

- **Heatmap glow**: bigger radius so it reads as a regional field (not per-pin halos), fainter low-end weight (a single park no longer glows, only clusters), and a cleaner warm sunshine ramp (transparent to gold to hot orange) that contrasts with the green terrain and makes the green pins pop.
- **Ranked list**: closed by default; when opened it now sits ON TOP of the map zoom/info controls (z-index) instead of overlapping them.
- **14-day detail**: uniform day-cell size.
- **Removed**: the Heat on/off toggle (not needed), the region filter dropdown + Region sort (0 of 145 parks have a region), and all drop-shadows (black-line brutalist framing only).

Deploy: bumps monolith-public to 0.82.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)