### PR TITLE
fix(model-bench): inject file contents into prompt, reliable reasoning judge

### DIFF
--- a/projects/model-bench/bench/cache.py
+++ b/projects/model-bench/bench/cache.py
@@ -1,7 +1,7 @@
 import hashlib
 from pathlib import Path
 
-HARNESS_VERSION = "0.1.2"
+HARNESS_VERSION = "0.1.3"
 
 
 def cell_key(

--- a/projects/model-bench/bench/cli.py
+++ b/projects/model-bench/bench/cli.py
@@ -43,7 +43,7 @@ from bench.registry import (
     prune_retired,
 )
 from bench.report import render_leaderboard
-from bench.runner import run_cell
+from bench.runner import _strip_code_fence, run_cell
 from bench.schema import Attempt, ResultCell, TaskSpec
 from bench.verifiers import get_verifier, verifier_source_hash
 
@@ -234,7 +234,7 @@ async def _run(args) -> None:
         try:
             result = await asyncio.to_thread(
                 judge_free_text,
-                candidate=c1.text,
+                candidate=_strip_code_fence(c1.text),
                 task_prompt=task.prompt,
                 cfg=cfg,
                 caller=sync_caller,

--- a/projects/model-bench/bench/judge.py
+++ b/projects/model-bench/bench/judge.py
@@ -70,13 +70,31 @@ def judge_free_text(
             f"Task prompt: {task_prompt}\n\n"
             f"Criteria (evaluate in this order):\n{criteria_block}\n\n"
             f"Candidate output:\n{candidate}\n\n"
-            f"Reply with exactly PASS if the candidate satisfies all criteria, "
-            f"or FAIL if it does not."
+            "For each criterion, state on one line whether it is met and why. Then end "
+            "with a final line exactly of the form 'VERDICT: PASS' if every criterion is "
+            "met, or 'VERDICT: FAIL' if one or more is not met."
         )
 
-        verdict = caller(prompt)
-        vote = "PASS" if verdict.strip().upper().startswith("PASS") else "FAIL"
-        votes.append(vote)
+        votes.append(_parse_verdict(caller(prompt)))
 
     passed = votes.count("PASS") > len(votes) / 2
     return JudgeResult(passed=passed, votes=votes)
+
+
+def _parse_verdict(text: str) -> str:
+    """Extract PASS/FAIL from a reasoned judge reply.
+
+    The judge reasons per-criterion and ends with a ``VERDICT: PASS``/``FAIL`` line,
+    so a naive startswith() on the whole reply misreads it. Look from the last
+    ``VERDICT`` marker (falling back to the whole text) and take whichever of
+    PASS/FAIL appears first there. Defaults to FAIL when neither is present.
+    """
+    up = text.upper()
+    marker = up.rfind("VERDICT")
+    tail = up[marker:] if marker != -1 else up
+    p, f = tail.find("PASS"), tail.find("FAIL")
+    if p == -1:
+        return "FAIL"
+    if f == -1:
+        return "PASS"
+    return "PASS" if p < f else "FAIL"

--- a/projects/model-bench/bench/judge_test.py
+++ b/projects/model-bench/bench/judge_test.py
@@ -1,9 +1,26 @@
-from bench.judge import judge_free_text, JudgeConfig
+from bench.judge import _parse_verdict, judge_free_text, JudgeConfig
 
 
 def fake_caller(prompt: str) -> str:
     # deterministic stub: returns PASS iff the candidate contains "feat("
     return "PASS" if "feat(" in prompt else "FAIL"
+
+
+def test_parse_verdict_reads_reasoned_reply():
+    # A reasoned reply starts with per-criterion lines and ends with VERDICT.
+    reasoned_pass = (
+        "1. Met - subject ok\n2. Met - body ok\n3. Met - no em-dash\n\nVERDICT: PASS"
+    )
+    reasoned_fail = "1. Met\n2. Not met - body missing\n\nVERDICT: FAIL"
+    assert _parse_verdict(reasoned_pass) == "PASS"
+    assert _parse_verdict(reasoned_fail) == "FAIL"
+    # Bare verdicts still parse.
+    assert _parse_verdict("PASS") == "PASS"
+    assert _parse_verdict("FAIL") == "FAIL"
+    # Reasoning that mentions FAIL earlier but ends VERDICT: PASS reads the verdict line.
+    assert (
+        _parse_verdict("could FAIL if empty, but it is fine.\nVERDICT: PASS") == "PASS"
+    )
 
 
 def test_judge_passes_conventional_commit():

--- a/projects/model-bench/bench/runner.py
+++ b/projects/model-bench/bench/runner.py
@@ -33,8 +33,10 @@ def _strip_code_fence(content: str) -> str:
     lines = content.split("\n")
     fence_idxs = [i for i, ln in enumerate(lines) if ln.lstrip().startswith("```")]
     if len(fence_idxs) >= 2:
-        # Body between the first opening fence and the last closing fence.
-        return "\n".join(lines[fence_idxs[0] + 1 : fence_idxs[-1]])
+        # Body of the FIRST fenced block (first opening fence to the next fence).
+        # Using the first pair, not first-to-last, keeps a trailing example block
+        # (e.g. a ```bash one-liner after the file) from leaking into the content.
+        return "\n".join(lines[fence_idxs[0] + 1 : fence_idxs[1]])
     if len(fence_idxs) == 1:
         # Only an opening fence survived (e.g. truncated); take everything after.
         return "\n".join(lines[fence_idxs[0] + 1 :]).strip("\n")
@@ -102,6 +104,32 @@ def _make_workdir(fixture_dir: Path) -> Path:
     return dst
 
 
+def _augment_prompt_with_files(
+    prompt: str, fixture_dir: Path, target_files: list[str]
+) -> str:
+    """Append the current contents of the editable files to the prompt.
+
+    A full-file-replacement task asks the model to return the complete updated file,
+    but without the current contents the model has nothing to update: a careful model
+    refuses (Opus: "returning a fabricated file could drop your existing config") and a
+    careless one guesses. Injecting the fixture's current file contents makes the task
+    well-posed. Free-text tasks (no target_files) are returned unchanged.
+    """
+    blocks = []
+    for tf in target_files:
+        p = fixture_dir / tf
+        if p.exists():
+            blocks.append(f"FILE {tf}\n{p.read_text()}")
+    if not blocks:
+        return prompt
+    return (
+        prompt
+        + "\n\nHere are the current contents of the file(s) you may edit. Return the "
+        "complete updated file(s), each prefixed with its FILE line:\n\n"
+        + "\n\n".join(blocks)
+    )
+
+
 async def run_cell(
     *,
     task_id: str,
@@ -129,6 +157,9 @@ async def run_cell(
     workdirs: list[Path] = []
     outcome: str
     attempts: list[Attempt]
+
+    # Give the model the current file contents so it can return a complete update.
+    prompt = _augment_prompt_with_files(prompt, fixture_dir, target_files)
 
     try:
         # Shot 1

--- a/projects/model-bench/bench/runner_test.py
+++ b/projects/model-bench/bench/runner_test.py
@@ -3,8 +3,27 @@ from pathlib import Path
 
 import pytest  # noqa: F401
 
-from bench.runner import extract_files, run_cell
+from bench.runner import _augment_prompt_with_files, extract_files, run_cell
 from bench.verifiers import VerifyResult
+
+
+def test_extract_takes_first_fenced_block_not_last():
+    # A file block followed by a trailing example block: only the file is taken.
+    text = "FILE values.yaml\n```yaml\nfoo: 1\n```\nExample:\n```bash\nyq -i x\n```"
+    assert extract_files(text, ["values.yaml"]) == {"values.yaml": "foo: 1"}
+
+
+def test_augment_prompt_injects_file_contents(tmp_path):
+    (tmp_path / "values.yaml").write_text('image:\n  tag: ""\n')
+    out = _augment_prompt_with_files("set the tag", tmp_path, ["values.yaml"])
+    assert "set the tag" in out
+    assert "FILE values.yaml" in out and "image:" in out
+
+
+def test_augment_prompt_noop_for_free_text(tmp_path):
+    assert (
+        _augment_prompt_with_files("write a commit", tmp_path, []) == "write a commit"
+    )
 
 
 def test_extract_strips_fence_after_file_header():


### PR DESCRIPTION
Ran the pack directly against OpenRouter (with a live key) and found both graded columns were measuring harness bugs, not models:

1. **config-plumbing was ill-posed** - the prompt told the model to "return the complete updated file" but never included the current file. Opus refused to fabricate; others guessed. Now the runner injects the fixture's current file contents into the prompt. Validated: Opus returns a clean parseable file.
2. **free-text was judge noise** - a terse PASS/FAIL prompt + startswith parsing failed a flawless Sonnet commit message on a 1-1 order split. Now the judge reasons per-criterion and ends with a VERDICT: line that is parsed directly. Validated live: good -> PASS, em-dash -> FAIL, non-conventional -> FAIL. Free-text candidate is also fence-stripped.
3. **extraction** takes the first fenced block, not first-to-last, so a trailing example block cannot corrupt the file.

HARNESS_VERSION -> 0.1.3. With these fixes every model one-shots all 3 seed tasks, confirming the harness is correct and the task pack now needs to get harder/bigger to discriminate models (next work).

Generated with Claude Code
