### PR TITLE
style(campsites): overlay alignment + mobile rework

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.82.5
+version: 0.82.6
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.82.5
+      targetRevision: 0.82.6
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/frontend/src/lib/public/components/campsites/CampsitesMap.svelte
+++ b/projects/monolith/frontend/src/lib/public/components/campsites/CampsitesMap.svelte
@@ -26,6 +26,27 @@
   let resizeObs = null;
   let layerReady = $state(false); // $state so effects re-evaluate after load
 
+  // Legend pop-out state: only relevant on mobile; on desktop the legend is
+  // always visible and the toggle button is hidden via CSS.
+  let legendOpen = $state(false);
+  let legendEl; // DOM ref for click-outside detection
+  let toggleEl; // DOM ref for click-outside detection
+
+  // Close the legend when the user taps anywhere outside it on mobile.
+  $effect(() => {
+    if (!legendOpen) return;
+    function onDocPointerdown(e) {
+      if (
+        legendEl && !legendEl.contains(e.target) &&
+        toggleEl && !toggleEl.contains(e.target)
+      ) {
+        legendOpen = false;
+      }
+    }
+    document.addEventListener("pointerdown", onDocPointerdown, { capture: true });
+    return () => document.removeEventListener("pointerdown", onDocPointerdown, { capture: true });
+  });
+
   // Data-viz ramp colors: outside the design-token system (intentionally, same
   // pattern as ShipsMap VESSEL_COLORS / HEAT_COLORS). They live in plain JS
   // constants so the hexes never appear as a `:` + `#hex` pair inside a style
@@ -355,7 +376,13 @@
 <div class="map-wrap">
   <div class="map" bind:this={mapContainer}></div>
 
-  <div class="legend">
+  <!-- Legend: always visible on desktop; a pop-out toggled by the chip on mobile. -->
+  <div
+    class="legend"
+    id="campsites-legend"
+    class:legend-open={legendOpen}
+    bind:this={legendEl}
+  >
     <p class="legend-title">Open sites + clear sky</p>
     <ul class="legend-list">
       {#each LEGEND_ITEMS as item (item.label)}
@@ -375,6 +402,17 @@
     </div>
     <p class="legend-note">Pin size = clear-sky days</p>
   </div>
+
+  <!-- Mobile-only chip to open/close the legend pop-out.
+       Hidden on desktop via CSS; always a real focusable button. -->
+  <button
+    type="button"
+    class="legend-toggle"
+    aria-expanded={legendOpen}
+    aria-controls="campsites-legend"
+    onclick={() => (legendOpen = !legendOpen)}
+    bind:this={toggleEl}
+  >{legendOpen ? "Close" : "Legend"}</button>
 </div>
 
 <style>
@@ -559,19 +597,68 @@
     letter-spacing: 0.02em;
   }
 
-  @media (max-width: 640px) {
+  /* Legend toggle chip: hidden on desktop, revealed on mobile only. */
+  .legend-toggle {
+    display: none;
+    position: absolute;
+    bottom: 56px;
+    left: 12px;
+    z-index: 10;
+    font-family: var(--mono);
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    padding: 6px 10px;
+    background: var(--paper);
+    color: var(--ink);
+    border: 2px solid var(--ink);
+    cursor: pointer;
+    transition: transform 110ms ease;
+  }
+
+  .legend-toggle:hover,
+  .legend-toggle:focus-visible {
+    transform: translate(-2px, -2px);
+    outline: none;
+  }
+
+  /* Mobile (<=768px): legend becomes a pop-out, toggle chip is visible.
+     The list bar is 48px tall at bottom:0. The toggle chip sits at
+     bottom:56px (8px clear). The legend pops above the chip at bottom:96px
+     (56px base + ~36px chip + 4px gap). */
+  @media (max-width: 768px) {
+    /* Hidden by default; display:block added via .legend-open when toggled. */
     .legend {
-      bottom: 12px;
+      display: none;
+      bottom: 96px;
       left: 12px;
       width: auto;
       height: auto;
       max-width: 200px;
       padding: 9px 11px;
+      z-index: 10;
+    }
+
+    .legend.legend-open {
+      display: block;
+    }
+
+    /* Show the toggle chip above the list bar. */
+    .legend-toggle {
+      display: flex;
+      align-items: center;
+    }
+
+    /* Zoom controls: nudge above the 48px list bar so they never overlap it. */
+    .map :global(.maplibregl-ctrl-bottom-right) {
+      bottom: calc(56px + env(safe-area-inset-bottom, 0));
     }
   }
 
   @media (prefers-reduced-motion: reduce) {
-    .map :global(.maplibregl-ctrl-group button) {
+    .map :global(.maplibregl-ctrl-group button),
+    .legend-toggle {
       transition: none;
     }
   }

--- a/projects/monolith/frontend/src/lib/public/components/campsites/CampsitesMap.svelte
+++ b/projects/monolith/frontend/src/lib/public/components/campsites/CampsitesMap.svelte
@@ -469,12 +469,17 @@
     display: none;
   }
 
-  /* Legend: bottom-left, same hard-edge style as the ShipsMap legend. */
+  /* Legend: bottom-left, same hard-edge style as the ShipsMap legend. Fixed
+     width + height so the bottom row (legend left, detail right) share the
+     same bottom edge AND top edge. */
   .legend {
     position: absolute;
     bottom: 16px;
     left: 16px;
-    max-width: 240px;
+    width: 200px;
+    height: 168px;
+    box-sizing: border-box;
+    overflow-y: auto;
     padding: 10px 12px;
     background: var(--paper);
     border: 2px solid var(--ink);
@@ -558,6 +563,8 @@
     .legend {
       bottom: 12px;
       left: 12px;
+      width: auto;
+      height: auto;
       max-width: 200px;
       padding: 9px 11px;
     }

--- a/projects/monolith/frontend/src/routes/public/app/campsites/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/campsites/+page.svelte
@@ -821,15 +821,34 @@
     line-height: 1.4;
   }
 
-  /* Mobile: list + detail become bottom sheets; the map still owns the top of
-     the screen (map-first). A selected park's detail takes over the sheet space,
-     so the list hides while it is open to avoid stacking two bottom sheets. */
+  /* Mobile: slim top bar, full-width bottom list bar that is always visible,
+     legend behind a pop-out chip, detail sheet clearing the bar from above. */
   @media (max-width: 768px) {
+    /* Slim single-line top bar: drop the verbose crumb-note, compact padding,
+       switch to row layout so only one line of breadcrumb is shown. */
     .crumb-card {
       top: 12px;
       left: 12px;
+      min-height: auto;
+      padding: 6px 10px;
+      flex-direction: row;
+      align-items: center;
     }
 
+    .crumb {
+      flex-wrap: nowrap;
+      font-size: 11px;
+      overflow: hidden;
+    }
+
+    /* Hide the "As of HH:MM UTC. Green = open AND clear skies." note on mobile.
+       The same context is available in the legend pop-out and on desktop. */
+    .crumb-note {
+      display: none;
+    }
+
+    /* Full-width bottom sheet. z-index 30 means the bar always wins over the
+       legend pop-out (z-index 10 inside map-wrap) and the detail (z-index 20). */
     .list-panel {
       top: auto;
       bottom: 0;
@@ -839,18 +858,33 @@
       max-width: none;
       max-height: 46vh;
       border-width: 2px 0 0;
+      z-index: 30;
     }
 
+    /* Collapsed bar: exactly 48px so legend chip, legend panel, and detail sheet
+       can use a known offset to clear it (bottom: 56px for chip, bottom: 96px
+       for legend, bottom: 48px for detail). */
     .list-panel.collapsed {
       bottom: 0;
+      height: 48px;
+      min-height: 48px;
+      max-height: 48px;
+      box-sizing: border-box;
+      overflow: hidden;
     }
 
+    /* When a park is selected: keep the 48px collapsed bar visible at the bottom
+       rather than hiding the whole panel. The detail sheet clears it from above
+       (bottom: 48px) so both are simultaneously visible. */
     .has-selection .list-panel {
-      display: none;
+      display: flex;
+      max-height: 48px;
+      overflow: hidden;
     }
 
+    /* Detail sheet: bottom = 48px so the RANKED PARKS bar is never obscured. */
     .detail {
-      bottom: 0;
+      bottom: 48px;
       left: 0;
       right: 0;
       height: auto;
@@ -858,6 +892,7 @@
       border-width: 2px 0 0;
       box-shadow: none;
       padding-bottom: calc(12px + env(safe-area-inset-bottom));
+      z-index: 20;
     }
 
     .campsites-page.list-open .detail {

--- a/projects/monolith/frontend/src/routes/public/app/campsites/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/campsites/+page.svelte
@@ -129,7 +129,7 @@
   />
 </svelte:head>
 
-<div class="campsites-page" class:has-selection={!!selectedPark}>
+<div class="campsites-page" class:has-selection={!!selectedPark} class:list-open={listOpen}>
   <!-- The visible heading is the breadcrumb chip; keep a real (hidden) h1 for
        SEO + a11y. -->
   <h1 class="sr-only">BC Parks campsites, open sites and clear-sky weather</h1>
@@ -325,6 +325,11 @@
     top: 16px;
     left: 16px;
     max-width: calc(100% - 32px);
+    min-height: 52px;
+    box-sizing: border-box;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
     padding: 8px 12px;
     background: var(--paper);
     border: 2px solid var(--ink);
@@ -394,7 +399,7 @@
      open panel covers the zoom/attribution buttons cleanly. */
   .list-panel {
     position: absolute;
-    top: 64px;
+    top: 16px;
     right: 16px;
     bottom: 16px;
     width: 340px;
@@ -409,6 +414,8 @@
 
   .list-panel.collapsed {
     bottom: auto;
+    min-height: 52px;
+    box-sizing: border-box;
   }
 
   .list-head {
@@ -417,6 +424,10 @@
 
   .list-panel.collapsed .list-head {
     border-bottom: none;
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
   }
 
   .list-head-top {
@@ -658,18 +669,25 @@
     color: var(--ink-3);
   }
 
-  /* Detail panel: bottom card anchored center-bottom, clear of the legend
-     (bottom-left, inside the map) and the list panel (bottom-right) on desktop. */
+  /* Detail panel: bottom strip anchored bottom, between the legend (left) and
+     the zoom controls (right, collapsed) or the list panel (right, expanded). */
   .detail {
     position: absolute;
     bottom: 16px;
-    left: 280px;
-    right: 372px;
-    max-height: 44vh;
+    left: 232px;
+    right: 64px;
+    height: 168px;
+    box-sizing: border-box;
     overflow-y: auto;
     padding: 12px 14px;
     background: var(--paper);
     border: 2px solid var(--ink);
+  }
+
+  /* When the list panel is open it occupies right:16px width:340px, so the
+     detail must clear it (340 + 16 + 16 gap = 372px). */
+  .campsites-page.list-open .detail {
+    right: 372px;
   }
 
   .detail-close {
@@ -835,10 +853,15 @@
       bottom: 0;
       left: 0;
       right: 0;
+      height: auto;
       max-height: 60vh;
       border-width: 2px 0 0;
       box-shadow: none;
       padding-bottom: calc(12px + env(safe-area-inset-bottom));
+    }
+
+    .campsites-page.list-open .detail {
+      right: 0;
     }
   }
 


### PR DESCRIPTION
Two polish passes on the /app/campsites map.

**Desktop alignment**: the four overlay cards now form a tidy frame. Top row (crumb card + RANKED PARKS) share a top edge and a 52px height; bottom row (legend + detail) share a bottom edge and a 168px height; consistent 16px insets; the detail panel's right inset is dynamic so it clears the zoom controls when the list is collapsed and the list panel when it is open.

**Mobile rework** (<=768px only, desktop unchanged): slim one-line top bar (the verbose "As of" note is hidden on mobile), the legend becomes a pop-out behind a toggle chip instead of a big permanent card, and the bottom RANKED PARKS bar is a fixed 48px bar that nothing overlaps (legend popout, detail sheet, and zoom controls all sit above it).

Deploy: bumps monolith-public to 0.82.6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)