### PR TITLE
feat(model-bench): structured-output I/O contract

### DIFF
--- a/projects/model-bench/bench/cache.py
+++ b/projects/model-bench/bench/cache.py
@@ -1,7 +1,7 @@
 import hashlib
 from pathlib import Path
 
-HARNESS_VERSION = "0.1.3"
+HARNESS_VERSION = "0.1.4"
 
 
 def cell_key(

--- a/projects/model-bench/bench/runner.py
+++ b/projects/model-bench/bench/runner.py
@@ -13,12 +13,45 @@ Safety invariants:
 from __future__ import annotations
 
 import hashlib
+import json
 import shutil
 import tempfile
 from pathlib import Path
 
 from bench.cache import HARNESS_VERSION
 from bench.schema import Attempt, ResultCell
+
+
+def _parse_structured_or_extract(text: str, target_files: list[str]) -> dict[str, str]:
+    """Prefer a structured {"files": [{path, content}]} JSON response; fall back to
+    lenient text extraction.
+
+    A JSON ``content`` field is a discrete string, so prose, markdown fences, and
+    stray unicode cannot leak into the file the way they do when the model emits the
+    file as free text. Most models return clean JSON when asked; the rest fall back to
+    the text extractor so no model is lost.
+    """
+    try:
+        obj = json.loads(_strip_code_fence(text))
+    except (json.JSONDecodeError, TypeError):
+        obj = None
+    files = obj.get("files") if isinstance(obj, dict) else None
+    if isinstance(files, list) and files:
+        result: dict[str, str] = {}
+        basenames = {t.split("/")[-1]: t for t in target_files}
+        for f in files:
+            if not isinstance(f, dict) or not isinstance(f.get("content"), str):
+                continue
+            path, content = f.get("path", ""), f["content"]
+            if path in target_files:
+                result[path] = content
+            elif path.split("/")[-1] in basenames:
+                result[basenames[path.split("/")[-1]]] = content
+            elif len(target_files) == 1:
+                result[target_files[0]] = content
+        if result:
+            return result
+    return extract_files(text, target_files)
 
 
 def _strip_code_fence(content: str) -> str:
@@ -124,9 +157,11 @@ def _augment_prompt_with_files(
         return prompt
     return (
         prompt
-        + "\n\nHere are the current contents of the file(s) you may edit. Return the "
-        "complete updated file(s), each prefixed with its FILE line:\n\n"
+        + "\n\nHere are the current contents of the file(s) you may edit:\n\n"
         + "\n\n".join(blocks)
+        + '\n\nRespond with ONLY a JSON object of the form {"files": [{"path": '
+        '"<path>", "content": "<full updated file contents>"}]} and nothing else. '
+        "Include every file you changed, with its complete updated contents."
     )
 
 
@@ -171,7 +206,9 @@ async def run_cell(
         )
         workdir1 = _make_workdir(fixture_dir)
         workdirs.append(workdir1)
-        for rel_path, content in extract_files(c1.text, target_files).items():
+        for rel_path, content in _parse_structured_or_extract(
+            c1.text, target_files
+        ).items():
             dest = workdir1 / rel_path
             dest.parent.mkdir(parents=True, exist_ok=True)
             dest.write_text(content)
@@ -211,7 +248,9 @@ async def run_cell(
             # Fresh clean copy: shot-1 writes must not leak into shot 2.
             workdir2 = _make_workdir(fixture_dir)
             workdirs.append(workdir2)
-            for rel_path, content in extract_files(c2.text, target_files).items():
+            for rel_path, content in _parse_structured_or_extract(
+                c2.text, target_files
+            ).items():
                 dest = workdir2 / rel_path
                 dest.parent.mkdir(parents=True, exist_ok=True)
                 dest.write_text(content)

--- a/projects/model-bench/bench/runner_test.py
+++ b/projects/model-bench/bench/runner_test.py
@@ -129,3 +129,23 @@ def test_pass_at_2_feeds_stderr_not_golden(tmp_path):
         )
     )
     assert cell.outcome == "pass@2" and len(cell.attempts) == 2
+
+
+def test_parse_structured_json_beats_text(tmp_path):
+    from bench.runner import _parse_structured_or_extract
+
+    # Clean JSON content maps path-agnostically to the single target.
+    got = _parse_structured_or_extract(
+        '{"files": [{"path": "x.py", "content": "def f():\\n    return 1"}]}',
+        ["extract_text.py"],
+    )
+    assert got == {"extract_text.py": "def f():\n    return 1"}
+    # Fenced JSON still parses.
+    got2 = _parse_structured_or_extract(
+        '```json\n{"files": [{"path": "a", "content": "ok"}]}\n```', ["a"]
+    )
+    assert got2 == {"a": "ok"}
+    # Non-JSON falls back to lenient text extraction.
+    assert _parse_structured_or_extract("def f(): pass", ["a.py"]) == {
+        "a.py": "def f(): pass"
+    }

--- a/projects/model-bench/tasks/null-content-fix-01/fixture/extract_text.py
+++ b/projects/model-bench/tasks/null-content-fix-01/fixture/extract_text.py
@@ -1,0 +1,3 @@
+def extract_text(data: dict) -> str:
+    """Return the assistant message text from a chat-completions API response."""
+    return data["choices"][0]["message"].get("content", "")

--- a/projects/model-bench/tasks/null-content-fix-01/task.yaml
+++ b/projects/model-bench/tasks/null-content-fix-01/task.yaml
@@ -1,0 +1,38 @@
+id: null-content-fix-01
+version: v1
+class: code-fix
+source_commit: bc6f81dfb
+prompt: |
+  extract_text() pulls the assistant text out of a chat-completions API response.
+  In production it intermittently crashes a downstream caller with
+  "AttributeError: 'NoneType' object has no attribute ...": some models (reasoning
+  or "thinking" models) return a response whose message "content" field is present
+  but JSON null while they are still reasoning. Fix extract_text so it always
+  returns a string for every response shape, without changing its name or
+  signature. Return the complete updated contents of extract_text.py.
+target_files:
+  - extract_text.py
+verifier:
+  kind: command
+  args:
+    cmd:
+      - python3
+      - -c
+      - |
+        import sys
+        sys.path.insert(0, ".")
+        try:
+            from extract_text import extract_text
+        except Exception as e:
+            sys.stderr.write(f"could not import extract_text: {e}\n"); sys.exit(1)
+        cases = {
+            "normal content": ({"choices": [{"message": {"content": "hello"}}]}, "hello"),
+            "null content (thinking model)": ({"choices": [{"message": {"content": None}}]}, ""),
+            "missing content": ({"choices": [{"message": {}}]}, ""),
+        }
+        for name, (data, want) in cases.items():
+            got = extract_text(data)
+            if not isinstance(got, str):
+                sys.stderr.write(f"{name}: expected a str, got {type(got).__name__} ({got!r})\n"); sys.exit(1)
+            if got != want:
+                sys.stderr.write(f"{name}: expected {want!r}, got {got!r}\n"); sys.exit(1)


### PR DESCRIPTION
Ran hard tasks directly against OpenRouter and found the emit-file-as-text I/O contract conflates output *format* with capability. Opus wrote an excellent null-content fix, but its response leaked a prose line with a unicode arrow into the extracted file (invalid character), and qwen3-coder renamed the function - both format failures, not capability, and temp-0 nondeterministic.

Fix: file-emitting tasks now use a structured contract. The prompt asks for a JSON object `{"files":[{"path","content"}]}` and the runner parses it, falling back to lenient text extraction when a model does not return JSON. A JSON content field is a discrete string, so prose/markdown/unicode cannot leak into the file.

Validated live across 14 models: Opus and the rest pass cleanly now (only qwen3-coder-30b needs one repair round). `response_format` is deliberately NOT forced - it returns null for glm/deepseek and would regress passing models.

Also adds `null-content-fix-01` (a representative code-fix task from the real content:null crash) and bumps HARNESS_VERSION 0.1.3 -> 0.1.4.

Generated with Claude Code
