### PR TITLE
fix(fc-invoke): bump chart to 0.2.0 to deploy the agent workload

### DIFF
--- a/projects/firecracker/substrate/chart/Chart.yaml
+++ b/projects/firecracker/substrate/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: fc-invoke
 description: Node-affine Firecracker invoke daemon that dispatches HTTP invocations to a pool of warm-base microVMs across named workloads (POST /invoke/{workload}, GET /healthz)
 type: application
-version: 0.1.1
+version: 0.2.0

--- a/projects/firecracker/substrate/deploy/application.yaml
+++ b/projects/firecracker/substrate/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tags pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: fc-invoke
-      targetRevision: 0.1.1
+      targetRevision: 0.2.0
       helm:
         valueFiles:
           - $values/projects/firecracker/substrate/deploy/values.yaml


### PR DESCRIPTION
PR B added the `agent` workload + egress to the fc-invoke chart but did not bump its version (the chart-version-bot bump rides the non-required Push-images step and was raced by merge). `chart-version.sh` confirms a pending `0.1.1 -> 0.2.0` (minor, PR A+B feats). The live app is still on 0.1.1 (no agent workload). This bumps Chart.yaml + application.yaml targetRevision in sync so ArgoCD pulls 0.2.0 with the agent workload, egress sidecar, and pinned agent guest image.

Version-only; no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)