### PR TITLE
fix(fc-invoke): per-workload harnessInit (agent guest e2e boot fix)

### DIFF
--- a/projects/firecracker/substrate/chart/Chart.yaml
+++ b/projects/firecracker/substrate/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: fc-invoke
 description: Node-affine Firecracker invoke daemon that dispatches HTTP invocations to a pool of warm-base microVMs across named workloads (POST /invoke/{workload}, GET /healthz)
 type: application
-version: 0.2.0
+version: 0.2.1

--- a/projects/firecracker/substrate/chart/values.yaml
+++ b/projects/firecracker/substrate/chart/values.yaml
@@ -91,6 +91,7 @@ workloads:
   semgrep:
     image: semgrep-guest
     rootfsPath: /disks/nvme-02/fc-invoke/semgrep/rootfs.ext4
+    harnessInit: /usr/local/bin/semgrep-guest-init
     vcpus: 4
     memMib: 2048
     concurrency: 4
@@ -109,6 +110,7 @@ workloads:
   agent:
     image: agent-guest
     rootfsPath: /disks/nvme-02/fc-invoke/agent/rootfs.ext4
+    harnessInit: /usr/local/bin/fc-agent-init
     vcpus: 4
     memMib: 4096
     concurrency: 2

--- a/projects/firecracker/substrate/deploy/application.yaml
+++ b/projects/firecracker/substrate/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tags pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: fc-invoke
-      targetRevision: 0.2.0
+      targetRevision: 0.2.1
       helm:
         valueFiles:
           - $values/projects/firecracker/substrate/deploy/values.yaml

--- a/projects/firecracker/substrate/invoke/cmd/main.go
+++ b/projects/firecracker/substrate/invoke/cmd/main.go
@@ -76,6 +76,13 @@ func run(logger *slog.Logger) error {
 	// isolation directory.
 	invokers := make(map[string]server.Invoker, len(cfg.Workloads))
 	for name, wl := range cfg.Workloads {
+		// Per-workload PID-1 path: guest images install their init at different
+		// paths (e.g. semgrep-guest-init vs the agent's fc-agent-init), so the
+		// kernel init= boot arg must be per-workload; fall back to the global.
+		harnessInit := wl.HarnessInit
+		if harnessInit == "" {
+			harnessInit = cfg.HarnessInit
+		}
 		// The driver boots the workload's base rootfs READ-ONLY: every mutable
 		// guest path is a tmpfs (RAM, captured in the snapshot memfile), so one
 		// read-only rootfs file backs every microVM with no per-request copy.
@@ -89,7 +96,7 @@ func run(logger *slog.Logger) error {
 			RootfsPath:        wl.RootfsPath,
 			RootfsReadOnly:    true,
 			CanonicalVsockDir: cfg.CanonicalVsockDir,
-			HarnessInit:       cfg.HarnessInit,
+			HarnessInit:       harnessInit,
 			VCPUs:             wl.VCPUs,
 			MemMib:            wl.MemMib,
 			SnapshotRoot:      cfg.SnapshotRoot,

--- a/projects/firecracker/substrate/invoke/internal/config/config.go
+++ b/projects/firecracker/substrate/invoke/internal/config/config.go
@@ -26,6 +26,11 @@ type Workload struct {
 	// (all mutable guest state is tmpfs), so one file backs every microVM for
 	// the workload with no per-request copy.
 	RootfsPath string `json:"rootfsPath"`
+	// HarnessInit is the in-guest PID-1 path the kernel boots into (the guest
+	// shim server) for this workload. Different guest images install their init
+	// at different paths (semgrep-guest-init vs the agent's), so this is
+	// per-workload; empty falls back to the daemon-global HarnessInit.
+	HarnessInit string `json:"harnessInit"`
 	// VCPUs is the number of virtual CPUs to allocate per microVM. Default 2.
 	VCPUs int `json:"vcpus"`
 	// MemMib is the guest memory in MiB. Default 2048.


### PR DESCRIPTION
Live-verified blocker: the agent guest kernel-panicked on boot. Root cause: fc-invoke used one GLOBAL `harnessInit` (`/usr/local/bin/semgrep-guest-init`) as the kernel `init=` boot arg for ALL workloads, but the agent guest installs its PID-1 at `/usr/local/bin/fc-agent-init`. So the agent VM booted `init=<semgrep path>`, which does not exist in the agent rootfs -> panic (semgrep worked only because the global matched it).

Fix: `harnessInit` is now a per-workload field (guests install their init at different paths), falling back to the global. Values: semgrep -> semgrep-guest-init, agent -> fc-agent-init. Chart 0.2.0 -> 0.2.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)