### PR TITLE
fix(goosecracker): writable HOME/workspace tmpfs so goose can run

### DIFF
--- a/projects/firecracker/goosecracker/guest-init/cmd/main.go
+++ b/projects/firecracker/goosecracker/guest-init/cmd/main.go
@@ -53,19 +53,42 @@ func run(logger *slog.Logger) error {
 	// (goose reaching the model) fails with "could not connect".
 	bringUpLoopback(logger)
 
-	// tmpfs over /tmp keeps the guest's mutable scratch in RAM so the rootfs can
-	// stay read-only and shareable across disposable microVMs.
-	mountTmpfsTmp(logger)
+	// tmpfs over /tmp AND /workspace keeps every guest path goose WRITES to in RAM,
+	// so the rootfs stays read-only and shareable across disposable microVMs. The
+	// baked rootfs mounts /workspace read-only; goose (via the developer extension)
+	// edits files there, and git clones a mirror into it, so it must be writable.
+	// /tmp additionally backs the writable HOME set below.
+	mountTmpfs(logger, "/tmp", "256m")
+	mountTmpfs(logger, handler.Workspace, "256m")
 
 	// A raw Firecracker boot hands PID 1 no environment (the kernel ignores the OCI
-	// image config), so establish the baseline goose needs to find its tools. goose
-	// lives in /usr/local/bin; gh/git/node in /usr/bin. HOME anchors goose's config
-	// under /home/goose-agent (matching the image); GOOSE_RECIPE_PATH points goose
-	// at the baked recipe library. ensureEnv only sets an unset key, so an injected
-	// value still wins.
+	// image config), so establish the baseline goose needs. goose lives in
+	// /usr/local/bin; gh/git/node in /usr/bin. HOME must be WRITABLE: goose creates
+	// its session database and logs under HOME (~/.local/state/goose), so anchoring
+	// HOME on the read-only rootfs (/home/goose-agent) panics goose with a
+	// ReadOnlyFilesystem error. Point HOME at the /tmp tmpfs instead. The XDG_*
+	// dirs are set EXPLICITLY (not left to derive from HOME) because goose resolves
+	// its state/data/config/cache via the XDG base dirs, and an unset XDG var can
+	// resolve to a bare "/.local/..." path (off HOME) that is also unwritable.
+	// GOOSE_RECIPE_PATH still points at the baked recipe library on the read-only
+	// rootfs, which is fine: recipes are only read. ensureEnv only sets an unset
+	// key, so an injected value still wins; HOME/XDG are force-set (a read-only
+	// value must never win).
 	ensureEnv("PATH", "/usr/local/bin:/usr/bin:/bin:/sbin:/usr/local/sbin")
-	ensureEnv("HOME", "/home/goose-agent")
 	ensureEnv("GOOSE_RECIPE_PATH", "/home/goose-agent/recipes")
+	const gooseHome = "/tmp/goose-home"
+	for k, v := range map[string]string{
+		"HOME":            gooseHome,
+		"XDG_STATE_HOME":  gooseHome + "/.local/state",
+		"XDG_DATA_HOME":   gooseHome + "/.local/share",
+		"XDG_CONFIG_HOME": gooseHome + "/.config",
+		"XDG_CACHE_HOME":  gooseHome + "/.cache",
+	} {
+		_ = os.Setenv(k, v)
+		if err := os.MkdirAll(v, 0o755); err != nil {
+			return err // nosemgrep: no-bare-error-return
+		}
+	}
 
 	if err := os.MkdirAll(handler.Workspace, 0o755); err != nil {
 		return err // nosemgrep: no-bare-error-return

--- a/projects/firecracker/goosecracker/guest-init/cmd/mount_linux.go
+++ b/projects/firecracker/goosecracker/guest-init/cmd/mount_linux.go
@@ -8,16 +8,17 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-// mountTmpfsTmp mounts a tmpfs over /tmp so the guest's mutable scratch state
-// lives in RAM rather than on the rootfs drive. This keeps the rootfs read-only
-// and shareable across microVMs (the disposable-VM model), and gives goose a
-// fast, writable /tmp regardless of how the rootfs is provisioned. Best-effort:
-// a failure is logged rather than fatal, since tmpfs mounts effectively never
-// fail in practice and a missing tmpfs only degrades to writing the rootfs.
-func mountTmpfsTmp(logger *slog.Logger) {
-	if err := unix.Mount("tmpfs", "/tmp", "tmpfs", 0, "size=256m,mode=1777"); err != nil {
-		logger.Warn("tmpfs mount on /tmp failed", "err", err)
+// mountTmpfs mounts a tmpfs of the given size over target so guest state written
+// there lives in RAM rather than on the read-only rootfs drive. This keeps the
+// rootfs read-only and shareable across disposable microVMs while giving goose
+// writable scratch (/tmp, HOME) and a writable workspace. Best-effort: a failure
+// is logged rather than fatal, since tmpfs mounts effectively never fail in
+// practice and a missing tmpfs only degrades to a failed write on the read-only
+// rootfs.
+func mountTmpfs(logger *slog.Logger, target, size string) {
+	if err := unix.Mount("tmpfs", target, "tmpfs", 0, "size="+size+",mode=1777"); err != nil {
+		logger.Warn("tmpfs mount failed", "target", target, "err", err)
 		return
 	}
-	logger.Info("mounted tmpfs on /tmp")
+	logger.Info("mounted tmpfs", "target", target, "size", size)
 }

--- a/projects/firecracker/goosecracker/guest-init/cmd/mount_other.go
+++ b/projects/firecracker/goosecracker/guest-init/cmd/mount_other.go
@@ -4,6 +4,6 @@ package main
 
 import "log/slog"
 
-// mountTmpfsTmp is a no-op off Linux; the guest is always Linux, this stub only
+// mountTmpfs is a no-op off Linux; the guest is always Linux, this stub only
 // keeps the package building for host (e.g. darwin) builds.
-func mountTmpfsTmp(*slog.Logger) {}
+func mountTmpfs(*slog.Logger, string, string) {}

--- a/projects/firecracker/substrate/chart/Chart.yaml
+++ b/projects/firecracker/substrate/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: fc-invoke
 description: Node-affine Firecracker invoke daemon that dispatches HTTP invocations to a pool of warm-base microVMs across named workloads (POST /invoke/{workload}, GET /healthz)
 type: application
-version: 0.2.1
+version: 0.2.2

--- a/projects/firecracker/substrate/deploy/application.yaml
+++ b/projects/firecracker/substrate/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tags pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: fc-invoke
-      targetRevision: 0.2.1
+      targetRevision: 0.2.2
       helm:
         valueFiles:
           - $values/projects/firecracker/substrate/deploy/values.yaml


### PR DESCRIPTION
## Problem

The fc-invoke agent guest booted and loaded the goose recipe, but goose panicked at `session_manager.rs:491`:

> Failed to create session database directory: `Os { code: 30, kind: ReadOnlyFilesystem }` at `~/.local/state/goose`

HOME was anchored at `/home/goose-agent`, which lives on the **read-only shared rootfs** (booted `root=/dev/vda ro` so one rootfs backs every disposable microVM). Every goose write (session db, logs) failed.

## Fix

Point every path goose writes to at a tmpfs (mirrors the semgrep guest's `HOME=/tmp/sghome` pattern):

- `HOME` -> `/tmp/goose-home` (on the existing `/tmp` tmpfs), with `XDG_STATE_HOME`/`DATA`/`CONFIG`/`CACHE` set explicitly and created. Explicit XDG is load-bearing: the panic also showed a bare `/.local/state/goose/logs` path, i.e. an unset XDG var resolving off an empty base rather than HOME.
- `/workspace` mounted as its own tmpfs (the baked rootfs mounts it read-only, but the developer extension edits files there and git clones the mirror into it).
- `GOOSE_RECIPE_PATH` still points at the read-only baked recipe library (reads only, fine).

Generalize `mountTmpfsTmp` -> `mountTmpfs(target, size)` and mount both `/tmp` and `/workspace`.

Chart bumped 0.2.1 -> 0.2.2 (+ `application.yaml` targetRevision) so ArgoCD pulls the rebuilt guest image.

Verified: host + `GOOS=linux` builds pass, gofmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)