### PR TITLE
chore(fc-agentd): add ArgoCD resources-finalizer (decommission step 1)

### DIFF
--- a/projects/agent_platform/fc-agentd/deploy/application.yaml
+++ b/projects/agent_platform/fc-agentd/deploy/application.yaml
@@ -3,6 +3,13 @@ kind: Application
 metadata:
   name: fc-agentd
   namespace: argocd
+  # Decommission step 1 (2-step ArgoCD finalizer pattern): superseded by the
+  # goosecracker agent fc-invoke workload (ADR 030). This finalizer makes the
+  # app-of-apps prune CASCADE to fc-agentd's live workloads when the app manifest
+  # is deleted in the follow-up PR; without it the deleted manifest would orphan
+  # the running pod (kubectl delete is forbidden under GitOps).
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
 spec:
   project: default
   sources:


### PR DESCRIPTION
Step 1 of the 2-step ArgoCD decommission of fc-agentd, now superseded by the goosecracker agent fc-invoke workload (ADR 030, verified e2e — goose runs to completion via both the direct `/invoke/agent` path and the monolith `submit_agent_task` MCP path).

Adds the `resources-finalizer.argocd.argoproj.io` finalizer so ArgoCD writes it onto the **live** Application. The follow-up PR deletes the manifest + code; the app-of-apps prune then cascades to fc-agentd's running pod. Deleting the manifest without the finalizer first would orphan the workload (kubectl delete is forbidden under GitOps).

No workload change — this only adds a metadata finalizer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)