### PR TITLE
feat(fc-invoke): egress secret-swap for the artifact/OpenRouter tier (ADR 023 6b)

### DIFF
--- a/projects/firecracker/goosecracker/guest-init/cmd/main.go
+++ b/projects/firecracker/goosecracker/guest-init/cmd/main.go
@@ -9,9 +9,10 @@
 //
 // This is the disposable-VM (cold-run) model: there is no snapshot/idle detector,
 // no host control channel, and no session/artifact persistence. The task arrives
-// in the HTTP request body, not over a vsock control handshake. Session resume,
-// artifact publish, and secret-swap (guest CA install) are deferred; the handler
-// and AgentRequest leave hooks for them.
+// in the HTTP request body, not over a vsock control handshake. The egress
+// secret-swap CA is installed per invoke from the request env (ADR 023 6b, see
+// installGuestCA). Session resume and artifact publish are still deferred; the
+// handler and AgentRequest leave hooks for them.
 package main
 
 import (
@@ -140,6 +141,11 @@ type execRunner struct {
 // non-zero), which the handler surfaces as an error result rather than a
 // transport failure.
 func (r *execRunner) Run(ctx context.Context, argv []string, env map[string]string, onLine func(string)) (string, error) {
+	// Install the egress secret-swap CA (ADR 023 6b) before goose starts, so its
+	// TLS to a swapped host trusts the sidecar's minted leaf. The CA cert rides in
+	// the per-invoke env (EGRESS_CA_CERT), so this happens here, not at boot.
+	installGuestCA(slog.Default(), env)
+
 	cmd := exec.CommandContext(ctx, argv[0], argv[1:]...)
 	cmd.Dir = r.workspace
 	cmd.Env = mergeEnv(env)
@@ -390,5 +396,67 @@ func funnelToHost(logger *slog.Logger, local net.Conn, port int) {
 func ensureEnv(key, def string) {
 	if os.Getenv(key) == "" {
 		_ = os.Setenv(key, def)
+	}
+}
+
+// guestCABundle is the baked system trust bundle most TLS clients read. It is on
+// the read-only shared rootfs, so it is readable but not writable.
+const guestCABundle = "/etc/ssl/certs/ca-certificates.crt"
+
+// tmpfs paths for the guest's writable trust material (the rootfs is read-only,
+// so unlike the old writable-rootfs guest we cannot append to the baked bundle;
+// we copy it to /tmp and append there). /tmp is a tmpfs mounted in run().
+const (
+	guestCABundleRW   = "/tmp/ca-bundle.crt"
+	guestCAStandalone = "/tmp/egress-ca.pem"
+)
+
+// installGuestCA installs the egress secret-swap CA (ADR 023 6b) into the guest
+// trust store for a single goose run, using the CA cert carried in the invoke env
+// (EGRESS_CA_CERT). It is a no-op when that env is empty (no swap configured),
+// which keeps the plain-egress and test paths untouched.
+//
+// The shared rootfs is read-only, so it writes writable trust material to the
+// /tmp tmpfs instead of appending to the baked bundle: a full bundle (the baked
+// public roots plus our CA) at guestCABundleRW, and the CA alone at
+// guestCAStandalone. It then points goose's TLS clients at those via SSL_CERT_FILE
+// / GIT_SSL_CAINFO (full bundle, so real HTTPS to non-swapped hosts still
+// validates against the public roots) and NODE_EXTRA_CA_CERTS (node appends the
+// standalone cert to its defaults). Keys are only set when unset, so an explicit
+// override still wins. The real destination cert is still validated by the
+// sidecar when it re-originates; this only makes the guest trust the sidecar.
+func installGuestCA(logger *slog.Logger, env map[string]string) {
+	caPEM := strings.TrimSpace(env["EGRESS_CA_CERT"])
+	if caPEM == "" {
+		return
+	}
+
+	// The baked bundle is readable on the ro rootfs; tolerate its absence (tests,
+	// a stripped image) by falling back to just our CA.
+	baked, err := os.ReadFile(guestCABundle)
+	if err != nil {
+		logger.Warn("guest CA: read baked bundle failed; using CA only", "err", err)
+		baked = nil
+	}
+	full := append(append([]byte{}, baked...), []byte("\n"+caPEM+"\n")...)
+	if err := os.WriteFile(guestCABundleRW, full, 0o644); err != nil {
+		logger.Warn("guest CA: write bundle failed; egress swap TLS may fail", "err", err)
+		return
+	}
+	if err := os.WriteFile(guestCAStandalone, []byte(caPEM), 0o644); err != nil {
+		logger.Warn("guest CA: write standalone cert failed", "err", err)
+	}
+
+	setIfUnset(env, "SSL_CERT_FILE", guestCABundleRW)
+	setIfUnset(env, "GIT_SSL_CAINFO", guestCABundleRW)
+	setIfUnset(env, "NODE_EXTRA_CA_CERTS", guestCAStandalone)
+	logger.Info("guest egress CA installed", "bundle", guestCABundleRW)
+}
+
+// setIfUnset sets m[key]=val only when key is absent or empty, so an explicit
+// value in the invoke env still wins.
+func setIfUnset(m map[string]string, key, val string) {
+	if m[key] == "" {
+		m[key] = val
 	}
 }

--- a/projects/firecracker/substrate/chart/Chart.yaml
+++ b/projects/firecracker/substrate/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: fc-invoke
 description: Node-affine Firecracker invoke daemon that dispatches HTTP invocations to a pool of warm-base microVMs across named workloads (POST /invoke/{workload}, GET /healthz)
 type: application
-version: 0.2.2
+version: 0.3.0

--- a/projects/firecracker/substrate/chart/templates/deployment.yaml
+++ b/projects/firecracker/substrate/chart/templates/deployment.yaml
@@ -215,15 +215,56 @@ spec:
               value: {{ .Values.egress.policy | default "allowlist" | quote }}
             {{- if eq (.Values.egress.policy | default "allowlist") "allowlist" }}
             # Under policy=allowlist the sidecar denies any destination not in this
-            # list (fail closed). Empty until the agent PR populates it.
+            # list (fail closed). It must include each secrets[].egressTo host so
+            # the swap path is reachable. Values carry a YAML list for readability;
+            # join it into the comma-separated form the sidecar parses.
             - name: EGRESS_ALLOWLIST
-              value: {{ .Values.egress.allowlist | quote }}
+              value: {{ join "," .Values.egress.allowlist | quote }}
             {{- end }}
+            {{- if .Values.egress.secrets }}
+            # Secret swap (ADR 023 6b). EGRESS_SECRETS is the non-secret catalog
+            # (placeholder -> env -> egressTo); the real value of each is supplied
+            # below from its Secret (or a literal for tests). The CA (cert + key)
+            # is mounted so the sidecar can mint leaves; the key never leaves here.
+            {{- $catalog := list }}
+            {{- range $s := .Values.egress.secrets }}
+            {{- $catalog = append $catalog (dict "placeholder" $s.placeholder "env" $s.env "egressTo" $s.egressTo) }}
+            {{- end }}
+            - name: EGRESS_SECRETS
+              value: {{ $catalog | toJson | quote }}
+            - name: EGRESS_CA_CERT_FILE
+              value: /etc/egress-ca/tls.crt
+            - name: EGRESS_CA_KEY_FILE
+              value: /etc/egress-ca/tls.key
+            {{- range $s := .Values.egress.secrets }}
+            - name: {{ $s.env }}
+              {{- if $s.secretRef }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $s.secretRef.name }}
+                  key: {{ $s.secretRef.key }}
+              {{- else }}
+              value: {{ $s.value | quote }}
+              {{- end }}
+            {{- end }}
+            {{- end }}
+          {{- if .Values.egress.secrets }}
+          volumeMounts:
+            - name: egress-ca
+              mountPath: /etc/egress-ca
+              readOnly: true
+          {{- end }}
           resources:
             {{- toYaml .Values.egress.resources | nindent 12 }}
         {{- end }}
       {{- if .Values.firecracker.enabled }}
       volumes:
+        {{- if and .Values.egress.enabled .Values.egress.secrets }}
+        # cert-manager-issued egress CA (cert + key), mounted into the sidecar only.
+        - name: egress-ca
+          secret:
+            secretName: {{ include "fc-invoke.fullname" . }}-egress-ca
+        {{- end }}
         - name: dev-kvm
           hostPath:
             path: /dev/kvm

--- a/projects/firecracker/substrate/chart/templates/egress-ca.yaml
+++ b/projects/firecracker/substrate/chart/templates/egress-ca.yaml
@@ -1,0 +1,39 @@
+{{- if and .Values.egress.enabled .Values.egress.secrets }}
+# Egress secret-swap CA (ADR 023 6b). cert-manager generates and rotates a
+# self-signed CA. The egress-proxy sidecar mounts it (cert + key) to mint leaf
+# certs per connection when it TLS-terminates a secret-bearing destination; the
+# CA private key lives only in that sidecar. The orchestrator injects the CA cert
+# (only, never the key) into each guest's trust store via the tier env, so the
+# guest trusts the minted leaves without an image rebuild (rotation-safe). Scoped
+# to the guest: never added to any cluster-wide or host trust store.
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ include "fc-invoke.fullname" . }}-egress-selfsigned
+  labels:
+    {{- include "fc-invoke.labels" . | nindent 4 }}
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "fc-invoke.fullname" . }}-egress-ca
+  labels:
+    {{- include "fc-invoke.labels" . | nindent 4 }}
+spec:
+  isCA: true
+  commonName: fc-invoke egress CA
+  # cert-manager writes tls.crt (CA cert), tls.key (CA key), ca.crt to this Secret.
+  secretName: {{ include "fc-invoke.fullname" . }}-egress-ca
+  # Long-lived: a rotation reissues the CA and (via the guest injection) the guest
+  # picks up the new cert on the next run, so we keep churn rare.
+  duration: {{ .Values.egress.ca.duration | quote }}
+  renewBefore: {{ .Values.egress.ca.renewBefore | quote }}
+  privateKey:
+    algorithm: RSA
+    size: 2048
+  issuerRef:
+    name: {{ include "fc-invoke.fullname" . }}-egress-selfsigned
+    kind: Issuer
+{{- end }}

--- a/projects/firecracker/substrate/chart/values.yaml
+++ b/projects/firecracker/substrate/chart/values.yaml
@@ -168,24 +168,45 @@ firecracker:
   # announce readiness over its shim.
   bootReadyTimeout: 60s
 
-# Egress-proxy sidecar (ADR 023 phase 6a, plain allowlist-forward). When enabled
-# a pod-local egress-proxy sidecar is added; the daemon forwards each egress-
-# enabled workload's guest vsock egress to it over localhost (the sidecar is the
-# only process that reaches the network on a guest's behalf). Plain mode only:
-# NO secret catalog / CA / secret-swap (a later PR). Default off; there is no
-# egress-enabled workload yet (the agent PR flips this on and populates the
-# allowlist). The image repository + tag are Bazel-pinned from the egress-proxy
-# image's .info provider at chart-build (see chart/BUILD `images`).
+# Egress-proxy sidecar (ADR 023). When enabled a pod-local egress-proxy sidecar
+# is added; the daemon forwards each egress-enabled workload's guest vsock egress
+# to it over localhost (the sidecar is the only process that reaches the network
+# on a guest's behalf). Phase 6a is plain allowlist-forward; phase 6b adds the
+# TLS-terminate + placeholder-swap path, enabled by a non-empty `secrets` catalog
+# (see deploy/values.yaml). Default off. The image repository + tag are
+# Bazel-pinned from the egress-proxy image's .info provider at chart-build (see
+# chart/BUILD `images`).
 egress:
   enabled: false
   # Egress posture. "allowlist" denies any destination not in `allowlist` (fail
   # closed). "allow" routes anywhere. Plain-mode default is allowlist.
   policy: allowlist
-  # Destinations permitted under policy=allowlist (host[:port], comma-separated).
-  # Empty until the agent PR populates it. Ignored under policy=allow.
-  allowlist: ""
+  # Destinations permitted under policy=allowlist, as a YAML list of host[:port]
+  # (the chart joins it into the comma-separated EGRESS_ALLOWLIST the sidecar
+  # parses). Empty until the agent PR populates it. Ignored under policy=allow.
+  # Under allowlist you must also list each secrets[].egressTo host so the swap
+  # path is reachable (permits() consults only this list, not the catalog).
+  allowlist: []
   # Bazel-pinned at chart-build from the egress-proxy image .info provider.
   image: {}
+  # 6b CA (ADR 023): cert-manager generates + rotates a self-signed CA the sidecar
+  # uses to mint leaf certs when it TLS-terminates a secret-bearing destination.
+  # The CA private key lives only in the sidecar; the public cert is injected into
+  # each guest's trust store (by the orchestrator, via the tier env) so the guest
+  # trusts the minted leaves without an image rebuild. Only created when `secrets`
+  # below is non-empty.
+  ca:
+    duration: 87600h # 10y; rotation churns guest trust, keep it rare
+    renewBefore: 2160h # 90d
+  # 6b secret catalog (ADR 023, shaped like the future SecretProxy CRD
+  # spec.secrets). Each entry: a high-entropy `placeholder` the guest holds as env
+  # `env`; the sidecar swaps it for the real value (`secretRef` {name,key}, or a
+  # literal `value` for tests) only on a connection whose host is in `egressTo`.
+  # egressTo is the exfiltration control: everywhere else the inert placeholder
+  # leaves. Literal swap only (a base64'd git-Basic token is ADR-deferred). Empty
+  # here; the real catalog lives in deploy/values.yaml. A non-empty list enables
+  # the CA + TLS-terminate path.
+  secrets: []
   # Repo convention: memory requests == limits (no memory bursting); CPU is a
   # request only (no CPU limit, to avoid throttling).
   resources:

--- a/projects/firecracker/substrate/deploy/application.yaml
+++ b/projects/firecracker/substrate/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tags pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: fc-invoke
-      targetRevision: 0.2.2
+      targetRevision: 0.3.0
       helm:
         valueFiles:
           - $values/projects/firecracker/substrate/deploy/values.yaml

--- a/projects/firecracker/substrate/deploy/values.yaml
+++ b/projects/firecracker/substrate/deploy/values.yaml
@@ -34,10 +34,45 @@ imagePullSecret:
 #   - monolith.monolith.svc.cluster.local:8000    monolith progress / artifact sink
 #   - context-forge-...mcpgateway.mcp.svc.cluster.local:80  MCP tools (baked guest ext)
 #   - signoz-k8s-infra-otel-agent.signoz.svc.cluster.local:4318  goose OTLP traces
-# There is no in-cluster git mirror, so none is listed. GitHub (api.github.com)
-# needs the credential swap (kloak) from ADR 023 phase 6b, which this plain-mode
-# sidecar does not do yet, so it is deliberately omitted (gh egress is a 6b follow-up).
+# There is no in-cluster git mirror, so none is listed. The two external hosts
+# (api.github.com, openrouter.ai) carry a credential, so they ride the ADR 023
+# phase 6b swap path (secrets below) and must ALSO be listed here on :443, since
+# the sidecar's permits() consults only this allowlist, not the catalog.
 egress:
   enabled: true
   policy: allowlist
-  allowlist: "inference.inference.svc.cluster.local:8080,monolith.monolith.svc.cluster.local:8000,context-forge-gateway-mcp-stack-mcpgateway.mcp.svc.cluster.local:80,signoz-k8s-infra-otel-agent.signoz.svc.cluster.local:4318"
+  # A real list for readability; the chart joins it into the comma-separated
+  # EGRESS_ALLOWLIST the sidecar parses. A bare host allows any port; host:port
+  # pins the port.
+  allowlist:
+    - inference.inference.svc.cluster.local:8080 # in-cluster model (Qwen; OPENAI_HOST)
+    - monolith.monolith.svc.cluster.local:8000 # monolith progress / artifact sink
+    - context-forge-gateway-mcp-stack-mcpgateway.mcp.svc.cluster.local:80 # MCP tools
+    - signoz-k8s-infra-otel-agent.signoz.svc.cluster.local:4318 # goose OTLP traces
+    - api.github.com:443 # gh/API (6b swap host)
+    - openrouter.ai:443 # artifact tier model (6b swap host)
+  # ADR 023 phase 6b secret catalog. Each guest holds only the high-entropy
+  # placeholder as env; the sidecar TLS-terminates the egressTo host with a leaf
+  # minted from the cert-manager egress CA and swaps the placeholder for the real
+  # value (from the referenced in-namespace Secret) only on that host. Everywhere
+  # else the inert placeholder passes through, so a prompt-injected agent cannot
+  # exfiltrate a real credential. A non-empty catalog enables the CA + swap path.
+  secrets:
+    # The agent's gh/API calls carry this placeholder (default tier GITHUB_TOKEN);
+    # the sidecar swaps it for the real token (already in-namespace, synced by the
+    # monolith from 1Password) only on api.github.com. Literal swap: gh API works;
+    # raw git-over-HTTPS Basic (a base64'd token) is ADR-deferred. placeholder MUST
+    # match goosecracker.tiers.default.GITHUB_TOKEN in the monolith deploy values.
+    - env: GITHUB_TOKEN
+      placeholder: "kloak:gh:01JZX8K3N7Q2M5R9W4T6Y0F1B8"
+      egressTo: [api.github.com]
+      secretRef: { name: monolith-chat-secrets, key: GITHUB_TOKEN }
+    # The artifact tier's OpenRouter key (ADR 024): the guest holds this
+    # placeholder as OPENROUTER_API_KEY (goosecracker.tiers.artifact); the sidecar
+    # swaps it for the real key only on openrouter.ai. The real value is synced
+    # from 1Password into the `goosecracker` Secret by the monolith chart's
+    # OnePasswordItem. placeholder MUST match tiers.artifact.OPENROUTER_API_KEY.
+    - env: OPENROUTER_KEY
+      placeholder: "kloak:or:B5BKP27T2KSDN6QW70N34H8DP6"
+      egressTo: [openrouter.ai]
+      secretRef: { name: goosecracker, key: OPENROUTER_API_KEY }

--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -4043,6 +4043,16 @@ bdd_test(
 )
 
 py_test(
+    name = "goosecracker_tiers_test",
+    srcs = ["goosecracker/tests/tiers_test.py"],
+    imports = ["."],
+    deps = [
+        ":monolith_backend",
+        "@pip//pytest",
+    ],
+)
+
+py_test(
     name = "agent_checks_firing_alerts_test",
     srcs = ["agent/checks_firing_alerts_test.py"],
     imports = ["."],

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.237.0
+version: 0.238.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/templates/deployment.yaml
+++ b/projects/monolith/chart/templates/deployment.yaml
@@ -98,6 +98,22 @@ spec:
             - name: GOOSECRACKER_PROGRESS_URL
               value: {{ .Values.goosecracker.progressUrl | quote }}
             {{- end }}
+            {{- if .Values.goosecracker.tiers }}
+            # Egress secret-swap CA public cert (ADR 023 6b). The fc-invoke egress
+            # proxy TLS-terminates swapped hosts with a leaf minted from this CA;
+            # the guest must trust it. Only the fc-invoke daemon can inject env at
+            # boot, but the guest env is orchestrator-owned (carried in the
+            # AgentRequest), so the monolith reads the public cert here and the
+            # goosecracker runner injects it into every tier's guest env. Same
+            # namespace as the substrate release; optional so the monolith still
+            # starts before the CA Secret exists (the swap is inert until then).
+            - name: EGRESS_CA_CERT
+              valueFrom:
+                secretKeyRef:
+                  name: fc-invoke-egress-ca
+                  key: tls.crt
+                  optional: true
+            {{- end }}
             {{- if .Values.chat.enabled }}
             - name: DISCORD_BOT_TOKEN
               valueFrom:

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.237.0
+      targetRevision: 0.238.0
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/deploy/values.yaml
+++ b/projects/monolith/deploy/values.yaml
@@ -182,10 +182,11 @@ goosecracker:
       # defaults to OTLP/HTTP.
       OTEL_EXPORTER_OTLP_ENDPOINT: http://signoz-k8s-infra-otel-agent.signoz.svc.cluster.local:4318
       OTEL_SERVICE_NAME: goose-coding
-    # The artifact tier reaches Gemini via OpenRouter. NOTE: the OpenRouter key is
-    # a placeholder the fc-invoke egress proxy must swap on openrouter.ai; until
-    # that egress secret-swap lands this tier will not reach the model. Kept here
-    # so the code path is complete; correctness is focused on the default tier.
+    # The artifact tier reaches Gemini via OpenRouter. The OPENROUTER_API_KEY is a
+    # placeholder the fc-invoke egress proxy swaps for the real key on
+    # openrouter.ai (ADR 023 6b, catalog in the substrate deploy values); the guest
+    # never holds the real key. Requires the egress CA (fc-invoke-egress-ca),
+    # injected into the guest env by the goosecracker runner.
     artifact:
       GOOSE_PROVIDER: openrouter
       OPENROUTER_API_KEY: "kloak:or:B5BKP27T2KSDN6QW70N34H8DP6"

--- a/projects/monolith/goosecracker/tests/tiers_test.py
+++ b/projects/monolith/goosecracker/tests/tiers_test.py
@@ -1,0 +1,60 @@
+"""Unit tests for the goosecracker tier -> guest env map (tiers.env_for_tier).
+
+Focus: the ADR 023 6b egress CA is merged into every tier's guest env from the
+process env, so goose in the guest trusts the swap sidecar's minted leaf.
+"""
+
+from __future__ import annotations
+
+import json
+
+from goosecracker import tiers
+
+_TIERS = {
+    "default": {"OPENAI_HOST": "http://model:8080", "GITHUB_TOKEN": "kloak:gh:X"},
+    "artifact": {"GOOSE_PROVIDER": "openrouter", "OPENROUTER_API_KEY": "kloak:or:Y"},
+}
+
+
+def _set_tiers(monkeypatch) -> None:
+    monkeypatch.setenv("GOOSECRACKER_TIERS", json.dumps(_TIERS))
+
+
+def test_ca_cert_merged_into_tier_env(monkeypatch):
+    _set_tiers(monkeypatch)
+    monkeypatch.setenv(
+        "EGRESS_CA_CERT", "-----BEGIN CERTIFICATE-----\nAAA\n-----END CERTIFICATE-----"
+    )
+
+    env = tiers.env_for_tier("artifact")
+    assert env["GOOSE_PROVIDER"] == "openrouter"
+    assert env["OPENROUTER_API_KEY"] == "kloak:or:Y"
+    assert "BEGIN CERTIFICATE" in env["EGRESS_CA_CERT"]
+
+
+def test_ca_cert_absent_when_env_unset(monkeypatch):
+    _set_tiers(monkeypatch)
+    monkeypatch.delenv("EGRESS_CA_CERT", raising=False)
+
+    env = tiers.env_for_tier("default")
+    assert "EGRESS_CA_CERT" not in env
+
+
+def test_unknown_tier_falls_back_to_default_and_gets_ca(monkeypatch):
+    _set_tiers(monkeypatch)
+    monkeypatch.setenv("EGRESS_CA_CERT", "PEM")
+
+    env = tiers.env_for_tier("nope")
+    assert env["OPENAI_HOST"] == "http://model:8080"
+    assert env["EGRESS_CA_CERT"] == "PEM"
+
+
+def test_explicit_tier_ca_wins_over_process_env(monkeypatch):
+    monkeypatch.setenv(
+        "GOOSECRACKER_TIERS",
+        json.dumps({"default": {"EGRESS_CA_CERT": "tier-pem"}}),
+    )
+    monkeypatch.setenv("EGRESS_CA_CERT", "process-pem")
+
+    env = tiers.env_for_tier("default")
+    assert env["EGRESS_CA_CERT"] == "tier-pem"

--- a/projects/monolith/goosecracker/tiers.py
+++ b/projects/monolith/goosecracker/tiers.py
@@ -58,11 +58,28 @@ def _load_tiers() -> dict[str, dict[str, str]]:
     return out
 
 
+# The egress secret-swap CA (ADR 023 6b) public cert, injected into every tier's
+# guest env so goose trusts the sidecar's minted leaf when a placeholder is
+# swapped on a TLS host (api.github.com, openrouter.ai). Sourced from the
+# fc-invoke-egress-ca Secret via the deployment env (never hardcoded); empty when
+# the CA is not deployed, which leaves the swap inert (the guest just holds the
+# placeholder).
+_CA_ENV_VAR = "EGRESS_CA_CERT"
+
+
 def env_for_tier(tier: str) -> dict[str, str]:
-    """The guest env dict for ``tier`` (empty/unknown falls back to default)."""
+    """The guest env dict for ``tier`` (empty/unknown falls back to default).
+
+    The egress CA cert is merged in from the process env so the guest can trust
+    the swap sidecar's leaf; a tier that sets it explicitly still wins.
+    """
     tiers = _load_tiers()
     key = tier or _DEFAULT_TIER
     env = tiers.get(key)
     if env is None and key != _DEFAULT_TIER:
         env = tiers.get(_DEFAULT_TIER)
-    return dict(env or {})
+    out = dict(env or {})
+    ca_cert = os.environ.get(_CA_ENV_VAR, "").strip()
+    if ca_cert and not out.get(_CA_ENV_VAR):
+        out[_CA_ENV_VAR] = ca_cert
+    return out


### PR DESCRIPTION
Ports the proven ADR 023 phase 6b placeholder-swap wiring from the deleted fc-agentd chart into fc-invoke, so the artifact tier's OpenRouter key (and the default tier's GitHub token) reach their upstreams without the guest ever holding the real value. This unblocks the artifact/OpenRouter tier.

## What
- **Substrate chart**: cert-manager egress CA (`fc-invoke-egress-ca`), sidecar mounts CA cert+key + renders the `EGRESS_SECRETS` catalog and per-secret real-value env; `egress.ca` + `egress.secrets` seams; allowlist is now a YAML list joined into the env var.
- **fc-invoke deploy values**: GitHub + OpenRouter catalog entries; `api.github.com:443` + `openrouter.ai:443` added to the allowlist.
- **Guest**: `installGuestCA` installs the per-invoke CA into the trust store, read-only-rootfs adapted (copy baked bundle to tmpfs + append; set `SSL_CERT_FILE`/`GIT_SSL_CAINFO`/`NODE_EXTRA_CA_CERTS`). No-op when the CA env is empty.
- **Monolith**: injects the public CA cert (`EGRESS_CA_CERT`, optional) from `fc-invoke-egress-ca`; `tiers.env_for_tier` merges it into every tier's guest env (guest env is orchestrator-owned). New `goosecracker_tiers_test`.

## Security (ADR 023)
The guest holds only the high-entropy `kloak:` placeholder. The sidecar TLS-terminates the egressTo host with a leaf minted from the egress CA and swaps the placeholder for the real value (from the in-namespace Secret) only on that host; everywhere else the inert placeholder passes through, so a prompt-injected agent cannot exfiltrate a real credential. The CA private key never leaves the sidecar.

## Bumps
fc-invoke chart 0.2.2 -> 0.3.0, monolith chart 0.237.0 -> 0.238.0.

## Notes
- S3 ObjectStore + sessions.db resume (ADR 026 Phase 2) is a separate follow-on PR.
- Rendered both charts locally; cross-compiled + vetted the guest-init for linux.

🤖 Generated with [Claude Code](https://claude.com/claude-code)