### PR TITLE
feat(model-bench): git-snapshot fixtures + write_files verifier + first real-monolith task

### DIFF
--- a/projects/model-bench/bench/cli.py
+++ b/projects/model-bench/bench/cli.py
@@ -145,6 +145,21 @@ def build_parser() -> argparse.ArgumentParser:
     p_list = sub.add_parser("list", help="List models and their status")
     p_list.add_argument("--models", default="models.yaml")
 
+    # snapshot
+    p_snap = sub.add_parser(
+        "snapshot",
+        help="Materialize task fixtures from a pinned git commit (real repo state)",
+    )
+    p_snap.add_argument("--tasks", default="tasks", help="Path to tasks directory")
+    p_snap.add_argument(
+        "--repo",
+        default=str(Path.home() / "repos" / "homelab"),
+        help="Path to the source git repo",
+    )
+    p_snap.add_argument(
+        "task", nargs="?", help="Only snapshot this task id (default: all)"
+    )
+
     return parser
 
 
@@ -491,6 +506,54 @@ def _prune_stale(args) -> None:
     )
 
 
+def _snapshot(args) -> None:
+    """Materialize task fixtures from a pinned git commit.
+
+    A task.yaml may carry a `snapshot: {commit, paths}` block. This extracts those
+    paths from the source repo at that commit into the task's fixture/ directory, so
+    fixtures are real repo state and can be regenerated or bumped to a newer commit
+    later by editing the commit and re-running snapshot.
+    """
+    import subprocess
+
+    repo = Path(args.repo)
+    tasks_dir = Path(args.tasks)
+    for subdir in sorted(tasks_dir.iterdir()):
+        task_file = subdir / "task.yaml"
+        if not task_file.exists():
+            continue
+        mapping = _load_yaml_mapping(task_file)
+        if args.task and mapping.get("id") != args.task:
+            continue
+        snap = mapping.get("snapshot")
+        if not isinstance(snap, dict):
+            continue
+        commit, paths = snap.get("commit"), snap.get("paths", [])
+        if not commit or not paths:
+            print(f"{mapping.get('id')}: snapshot needs commit + paths; skipping")
+            continue
+        fixture = subdir / "fixture"
+        if fixture.exists():
+            shutil.rmtree(fixture)
+        fixture.mkdir(parents=True)
+        # git archive <commit> -- <paths> | tar -x -C fixture
+        archive = subprocess.run(
+            ["git", "-C", str(repo), "archive", commit, "--", *paths],
+            capture_output=True,
+            check=True,
+            timeout=120,
+        )
+        tar_cmd = ["tar", "-x", "-C", str(fixture)]
+        strip = snap.get("strip_components")
+        if strip:
+            tar_cmd.append(f"--strip-components={strip}")
+        subprocess.run(tar_cmd, input=archive.stdout, check=True, timeout=120)
+        n = sum(1 for _ in fixture.rglob("*") if _.is_file())
+        print(
+            f"{mapping.get('id')}: snapshotted {n} file(s) from {commit[:12]} into {fixture}"
+        )
+
+
 def _list(args) -> None:
     """Print each model: id, status, role."""
     reg = load_registry(Path(args.models))
@@ -514,5 +577,7 @@ def main(argv=None) -> None:
         _prune_stale(args)
     elif args.command == "list":
         _list(args)
+    elif args.command == "snapshot":
+        _snapshot(args)
     else:
         parser.print_help()

--- a/projects/model-bench/bench/cli_test.py
+++ b/projects/model-bench/bench/cli_test.py
@@ -9,7 +9,7 @@ from bench.cli import _prune_stale, build_parser, load_tasks
 def test_parser_has_subcommands():
     p = build_parser()
     choices = p._subparsers._group_actions[0].choices
-    for sub in ("run", "report", "drop", "prune", "prune-stale", "list"):
+    for sub in ("run", "report", "drop", "prune", "prune-stale", "list", "snapshot"):
         assert sub in choices
 
 

--- a/projects/model-bench/bench/verifiers/command.py
+++ b/projects/model-bench/bench/verifiers/command.py
@@ -6,6 +6,13 @@ from bench.verifiers import register, VerifyResult
 
 @register("command")
 def verify(workdir: Path, args: dict) -> VerifyResult:
+    # Optionally drop hidden grading files (e.g. a Go/Python test the model never
+    # sees) into the workdir before running the command, so behavioral tasks can
+    # assert on real execution without leaking the test into the fixture.
+    for name, content in args.get("write_files", {}).items():
+        dest = workdir / name
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_text(content)
     res = run_sandboxed(args["cmd"], cwd=workdir, timeout_s=args.get("timeout_s", 120))
     if res.rc == 0:
         return VerifyResult(True, "")

--- a/projects/model-bench/bench/verifiers/verifiers_test.py
+++ b/projects/model-bench/bench/verifiers/verifiers_test.py
@@ -25,3 +25,16 @@ def test_compile_python_detects_syntax_error(tmp_path):
     v = get_verifier("py-compile")
     r = v(tmp_path, {"file": "m.py"})
     assert not r.passed and "SyntaxError" in r.feedback
+
+
+def test_command_write_files_drops_hidden_test(tmp_path):
+    # write_files drops a hidden grading file into the workdir before the command runs.
+    v = get_verifier("command")
+    r = v(
+        tmp_path,
+        {
+            "write_files": {"check.py": "open('marker','w').write('x')\n"},
+            "cmd": ["python3", "check.py"],
+        },
+    )
+    assert r.passed and (tmp_path / "marker").exists()

--- a/projects/model-bench/tasks/slo-budget-breach-01/fixture/slo.py
+++ b/projects/model-bench/tasks/slo-budget-breach-01/fixture/slo.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import re
+
+
+def compute_status(current: float | None, target: float | None) -> str:
+    if current is None or target is None:
+        return "healthy"
+    if current >= target:
+        return "healthy"
+    if current >= target - 0.5:
+        return "warning"
+    return "degraded"
+
+
+def compute_budget(
+    current: float, target: float, window_days: int, elapsed_days: int | None = None
+) -> dict:
+    if elapsed_days is None:
+        elapsed_days = window_days
+
+    window_minutes = window_days * 24 * 60
+    budget_minutes = window_minutes * (1 - target / 100)
+    error_fraction = 1 - current / 100
+    consumed_minutes = error_fraction * elapsed_days * 24 * 60
+    remaining = max(0.0, budget_minutes - consumed_minutes)
+    consumed_pct = (
+        min(100, round(consumed_minutes / budget_minutes * 100))
+        if budget_minutes > 0
+        else 0
+    )
+
+    return {
+        "consumed": consumed_pct,
+        "elapsed": round(elapsed_days / window_days * 100) if window_days > 0 else 0,
+        "remaining": f"{remaining:.1f} min" if remaining > 0 else "0 min",
+        "window": f"{window_days}d",
+    }
+
+
+def compute_brief(availability: float | None, metrics: dict[str, str]) -> str:
+    parts = []
+    if availability is not None:
+        parts.append(f"{availability:.2f}%" if availability < 100 else "100%")
+    if "rps" in metrics:
+        parts.append(f"{metrics['rps']} rps")
+    elif not parts and metrics:
+        first_val = next(iter(metrics.values()))
+        parts.append(str(first_val))
+    return " · ".join(parts) if parts else "healthy"
+
+
+_STATUS_ORDER = {"healthy": 0, "warning": 1, "degraded": 2}
+
+
+def aggregate_group(children: list[dict], target: float, window_days: int) -> dict:
+    availabilities = [
+        c["slo"]["current"]
+        for c in children
+        if c.get("slo") and c["slo"].get("current") is not None
+    ]
+    current = min(availabilities) if availabilities else None
+
+    statuses = [c.get("status", "healthy") for c in children]
+    worst_status = max(statuses, key=lambda s: _STATUS_ORDER.get(s, 0))
+
+    all_metrics = []
+    for c in children:
+        for m in c.get("metrics", []):
+            all_metrics.append(m)
+
+    aggregated_metrics = []
+    rps_total = 0.0
+    has_rps = False
+    p99_max = 0.0
+    p99_label = ""
+    has_p99 = False
+
+    for m in all_metrics:
+        k, v = m["k"], m["v"]
+        if k == "rps":
+            has_rps = True
+            try:
+                rps_total += float(v)
+            except (ValueError, TypeError):
+                pass
+        elif k in ("p99", "latency"):
+            has_p99 = True
+            num = re.sub(r"[^\d.]", "", str(v))
+            try:
+                val = float(num)
+                if val > p99_max:
+                    p99_max = val
+                    p99_label = str(v)
+            except (ValueError, TypeError):
+                pass
+
+    if has_rps:
+        aggregated_metrics.append({"k": "rps", "v": f"{rps_total:.1f}"})
+    if has_p99:
+        aggregated_metrics.append({"k": "latency", "v": p99_label})
+
+    result: dict = {"status": worst_status, "metrics": aggregated_metrics}
+
+    if current is not None:
+        result["slo"] = {"target": target, "current": current}
+        result["budget"] = compute_budget(current, target, window_days)
+        metrics_dict = {m["k"]: m["v"] for m in aggregated_metrics}
+        result["brief"] = compute_brief(current, metrics_dict)
+    else:
+        result["brief"] = "healthy"
+
+    return result

--- a/projects/model-bench/tasks/slo-budget-breach-01/task.yaml
+++ b/projects/model-bench/tasks/slo-budget-breach-01/task.yaml
@@ -1,0 +1,52 @@
+id: slo-budget-breach-01
+version: v1
+class: code-fix
+snapshot:
+  commit: ba5b4d39afcb67e2581d87836a6c9d98221499d6
+  paths:
+    - projects/monolith/home/observability/slo.py
+  strip_components: 4
+prompt: |
+  slo.py computes SLO status and error-budget figures for the observability
+  dashboard. aggregate_group() rolls a group's children up into a single status,
+  currently taking the worst child status. But it ignores the group's own error
+  budget: a group can show "healthy" even when its aggregated availability has
+  fully consumed the error budget for the window. Fix aggregate_group so that when
+  the group has an SLO (current is not None) and its error budget is fully consumed
+  (the "consumed" value from compute_budget is >= 100), the group's status is at
+  least "degraded" (never "healthy" or "warning"), while still respecting a worse
+  child status if one exists. Do not change the other functions' behavior or any
+  signature. Return the complete updated slo.py.
+target_files:
+  - slo.py
+verifier:
+  kind: command
+  args:
+    cmd: ["python3", "_check.py"]
+    write_files:
+      _check.py: |
+        import sys
+        sys.path.insert(0, ".")
+        import slo
+
+        # A single child, healthy child-status, but availability far below target
+        # over a full window -> budget fully consumed -> group must be >= degraded.
+        children = [{"status": "healthy", "slo": {"current": 90.0}, "metrics": []}]
+        g = slo.aggregate_group(children, target=99.9, window_days=30)
+        assert g["budget"]["consumed"] >= 100, f"test setup: expected full budget burn, got {g['budget']}"
+        if g["status"] != "degraded":
+            sys.stderr.write(f"group with a fully-consumed error budget must be 'degraded', got {g['status']!r}\n")
+            sys.exit(1)
+
+        # Healthy group (current meets target) stays healthy.
+        ok = slo.aggregate_group([{"status": "healthy", "slo": {"current": 99.95}, "metrics": []}], 99.9, 30)
+        if ok["status"] != "healthy":
+            sys.stderr.write(f"a group meeting its target must stay 'healthy', got {ok['status']!r}\n")
+            sys.exit(1)
+
+        # A worse child status must still win over a non-breached budget.
+        worse = slo.aggregate_group([{"status": "degraded", "slo": {"current": 99.95}, "metrics": []}], 99.9, 30)
+        if worse["status"] != "degraded":
+            sys.stderr.write(f"a worse child status must be respected, got {worse['status']!r}\n")
+            sys.exit(1)
+        print("ok")


### PR DESCRIPTION
Foundations for real-repo-sourced tasks, validated live against 14 models.

- **`bench snapshot`** materializes a task fixture from a pinned git commit (`git archive` + optional `strip_components`), so fixtures are real repo state and can be bumped to a newer commit later. Stored as a `snapshot: {commit, paths}` block in task.yaml.
- **`write_files`** on the command verifier drops hidden grading files (a test the model never sees) into the workdir before running, for behavioral grading.
- **slo-budget-breach-01**: first real-monolith task, snapshotting the actual `home/observability/slo.py`. Proven that real monolith modules + their real tests run standalone against a vendored venv with SQLite (no bazel/Postgres): `slo_test.py` is 15/15.

Next: the agentic harness (native tool-calling, multi-turn) - which also eliminates the hand-written-JSON format noise that dominated single-shot results.

Generated with Claude Code
