### PR TITLE
ci: auto-commit doc-index manifests instead of hard-failing on drift

### DIFF
--- a/bazel/images/validate-generate-scripts.sh
+++ b/bazel/images/validate-generate-scripts.sh
@@ -145,79 +145,14 @@ else
 	fi
 fi
 
-# --- Validation 4: repo-docs knowledge-graph manifest ---
-#
-# projects/monolith/knowledge/repo_docs_manifest.ndjson is a committed snapshot of
-# the repo's markdown (docs/, project READMEs, CLAUDE.md files), baked into the
-# monolith image and ingested into the knowledge graph for public-chat grounding.
-# It is produced by a py_venv_binary (hermetic python, no system python3 needed),
-# not the format multirun, so regenerate it here and fail if it drifts from what is
-# committed. This stops a doc change from silently going unindexed.
-
-echo "Validating repo-docs manifest ..."
-
-REPO_DOCS_MANIFEST=projects/monolith/knowledge/repo_docs_manifest.ndjson
-# Run the generator directly with python3 (it is pure stdlib + git ls-files), not
-# `bazel run`: the py_venv_binary launcher does not resolve its main module in the
-# CI runner. git-driven discovery keeps the output identical to a local run.
-if python3 projects/monolith/knowledge/tools/gen_repo_docs_manifest.py >/dev/null 2>"$TMPDIR_VALIDATE/gen_repo_docs.err"; then
-	if git diff --quiet -- "$REPO_DOCS_MANIFEST"; then
-		echo "  repo-docs-manifest: PASS"
-	else
-		echo "  repo-docs-manifest: FAIL"
-		echo "    $REPO_DOCS_MANIFEST is out of date with the repo's markdown."
-		# Diagnostic: which doc PATHS the regen added/removed vs what is committed.
-		# Each manifest line is one sort_keys JSON object: {"content":..,"path":..,..}
-		_extract_paths() { sed 's/.*, "path": "\([^"]*\)", "sha256":.*/\1/'; }
-		git show "HEAD:$REPO_DOCS_MANIFEST" | _extract_paths | LC_ALL=C sort >"$TMPDIR_VALIDATE/rd_committed.txt"
-		_extract_paths <"$REPO_DOCS_MANIFEST" | LC_ALL=C sort >"$TMPDIR_VALIDATE/rd_regen.txt"
-		echo "    committed_lines=$(wc -l <"$TMPDIR_VALIDATE/rd_committed.txt") regen_lines=$(wc -l <"$TMPDIR_VALIDATE/rd_regen.txt")"
-		echo "    paths only in regen (+) / only in committed (-):"
-		comm -3 "$TMPDIR_VALIDATE/rd_committed.txt" "$TMPDIR_VALIDATE/rd_regen.txt" | sed 's/^\t/      +/; s/^\([^ +]\)/      -\1/' | head -40
-		echo "    Regenerate it and commit the result:"
-		echo "      bazel run //projects/monolith:gen_repo_docs_manifest"
-		echo "      git add $REPO_DOCS_MANIFEST && git commit"
-		FAILED=1
-		# Restore the committed version so later format steps see a clean tree.
-		git checkout -- "$REPO_DOCS_MANIFEST" 2>/dev/null || true
-	fi
-else
-	echo "  repo-docs-manifest: FAIL (generator did not run)"
-	sed 's/^/    /' "$TMPDIR_VALIDATE/gen_repo_docs.err"
-	FAILED=1
-fi
-
-# --- Validation 5: public docs-site manifest ---
-#
-# projects/monolith/frontend/src/lib/public/docs/docs-manifest.json is a committed
-# snapshot of the public-allowlisted repo docs (top-level docs/*.md + the
-# docs/decisions/** ADR tree), baked into the monolith-public frontend image and
-# rendered server-side by the SvelteKit /docs route. Regenerate it here and fail
-# if it drifts from what is committed, so a doc change does not silently go
-# unpublished. Same git-driven, stdlib-only generator pattern as the repo-docs
-# manifest above.
-
-echo "Validating docs-site manifest ..."
-
-DOCS_MANIFEST=projects/monolith/frontend/src/lib/public/docs/docs-manifest.json
-if python3 projects/monolith/knowledge/tools/gen_docs_manifest.py >/dev/null 2>"$TMPDIR_VALIDATE/gen_docs.err"; then
-	if git diff --quiet -- "$DOCS_MANIFEST"; then
-		echo "  docs-site-manifest: PASS"
-	else
-		echo "  docs-site-manifest: FAIL"
-		echo "    $DOCS_MANIFEST is out of date with the public docs allowlist."
-		echo "    Regenerate it and commit the result:"
-		echo "      bazel run //projects/monolith:gen_docs_manifest"
-		echo "      git add $DOCS_MANIFEST && git commit"
-		FAILED=1
-		# Restore the committed version so later format steps see a clean tree.
-		git checkout -- "$DOCS_MANIFEST" 2>/dev/null || true
-	fi
-else
-	echo "  docs-site-manifest: FAIL (generator did not run)"
-	sed 's/^/    /' "$TMPDIR_VALIDATE/gen_docs.err"
-	FAILED=1
-fi
+# NOTE: the two doc-index manifests (repo_docs_manifest.ndjson and the public
+# docs-site docs-manifest.json) used to be validated here and hard-fail on drift.
+# They now regenerate in the "Format check" action (buildbuddy.yaml) BEFORE its
+# auto-commit, so a doc edit auto-commits the refreshed manifest like any other
+# formatting fix instead of failing CI and forcing a manual regen. Keeping them
+# out of this validator avoids a redundant second check. This validator stays for
+# the BUILD-graph generate scripts above, whose drift needs human attention (a
+# changed build graph), not a mechanical regen.
 
 # --- Summary ---
 

--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -1,6 +1,6 @@
 actions:
-  # Format check - runs formatters and gazelle, auto-commits fixes on PR branches
-  # Runs in parallel with Test and Push images
+  # Format check - runs formatters, gazelle, and the doc-index manifests,
+  # auto-commits fixes on PR branches. Runs in parallel with Test and Push images
   - name: "Format check"
     container_image: "ubuntu-24.04"
     max_retries: 2
@@ -28,6 +28,16 @@ actions:
           # This replaces the previous 3-call approach (bazel build + fast-format.sh + bazel run gazelle)
           # with one gRPC session, reducing transient connection failures.
           bazel run //bazel/tools/format:format --config=ci
+
+          # Regenerate the doc-index manifests (KG ingest + public docs site).
+          # Both embed each doc's content + hash, so ANY doc edit makes them
+          # stale. Run them HERE, before the auto-commit below, so drift is
+          # committed like any other formatting fix instead of hard-failing and
+          # forcing a manual regen (the old validate-generate-scripts.sh path).
+          # python3-direct (pure stdlib + git ls-files): the py_venv_binary
+          # launcher does not resolve its main module in the CI runner.
+          python3 projects/monolith/knowledge/tools/gen_repo_docs_manifest.py
+          python3 projects/monolith/knowledge/tools/gen_docs_manifest.py
 
           # Validate grep-based generate scripts against bazel query
           ./bazel/images/validate-generate-scripts.sh

--- a/projects/monolith/knowledge/tools/gen_docs_manifest.py
+++ b/projects/monolith/knowledge/tools/gen_docs_manifest.py
@@ -17,11 +17,11 @@ allowlist, never the RAG ingest (which indexes internal docs). Excluded:
 personal / non-homelab docs. Be conservative: if unsure whether a doc is public,
 it stays off the allowlist.
 
-When the published docs change, regenerate and commit the manifest:
-``bazel run //projects/monolith:gen_docs_manifest`` (or run this script with any
-python3). CI enforces freshness: bazel/images/validate-generate-scripts.sh
-(run in the Format check action) regenerates the manifest and fails the build if
-it differs from what is committed, with the regen command in the error.
+Regeneration is automatic: the "Format check" CI action (buildbuddy.yaml) runs
+this generator on every push and auto-commits any change to the manifest on PR
+branches (as ci-format-bot), like any other formatting fix, so a doc edit never
+needs a manual regen. To regenerate locally: run this script with any python3
+(or ``bazel run //projects/monolith:gen_docs_manifest``).
 """
 
 from __future__ import annotations

--- a/projects/monolith/knowledge/tools/gen_repo_docs_manifest.py
+++ b/projects/monolith/knowledge/tools/gen_repo_docs_manifest.py
@@ -6,12 +6,12 @@ projects/monolith/knowledge/repo_docs_manifest.ndjson. Using git (not a filesyst
 walk) makes the output deterministic across platforms and Python versions and
 never picks up untracked files or build artifacts under symlinked bazel-out/ dirs.
 
-When indexed docs change, regenerate and commit the manifest:
-`bazel run //projects/monolith:gen_repo_docs_manifest` (or run this script with
-any python3). CI enforces freshness: bazel/images/validate-generate-scripts.sh
-(run in the Format check action) regenerates the manifest and fails the build if
-it differs from what is committed, with the regen command in the error. The
-private monolith's reconcile job reads the committed manifest from the image.
+Regeneration is automatic: the "Format check" CI action (buildbuddy.yaml) runs
+this generator on every push and auto-commits any change to the manifest on PR
+branches (as ci-format-bot), like any other formatting fix, so a doc edit never
+needs a manual regen. To regenerate locally: run this script with any python3
+(or `bazel run //projects/monolith:gen_repo_docs_manifest`). The private
+monolith's reconcile job reads the committed manifest from the image.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## What

Implements Option 1 from the manifest-friction discussion. The two content-embedding manifests, `repo_docs_manifest.ndjson` (KG ingest) and `docs-manifest.json` (public jomcgi.dev/docs site), embed each doc's full content, so **any** doc edit makes them stale. Today they're validated in `validate-generate-scripts.sh`, which reverts the regen and **hard-fails**, forcing a manual regen and a second CI round for every docs change (this bit us three times across the loom-mapping and ADR PRs).

## Change

Move them into the **Format check** action's existing auto-commit path:

- `buildbuddy.yaml`: run both generators (`python3` direct, same invocation the validator used) right after `bazel run format`, before the `git diff` auto-commit. Drift now lands as a `ci-format-bot` `style: auto-format` commit, exactly like prettier/gazelle fixes.
- `validate-generate-scripts.sh`: drop the two manifest validations. It keeps the BUILD-graph generate-script checks (push-all, push-all-pages, home-cluster), whose drift reflects a changed build graph and genuinely needs human attention, unlike a mechanical doc-content regen.
- Generator docstrings updated to describe the auto-regen behavior.

## Why not "build in bazel, don't commit" (Option 2)

Two hard blockers: the generators discover files via `git ls-files` (non-hermetic; a bazel sandbox has no `.git`), and `docs-manifest.json` is a **SvelteKit source import** (un-committing it means threading a generated artifact into the frontend build + a local-dev fallback). Option 1 removes the friction without either fight.

## Net

A docs-only change never needs a manual manifest regen and never red-chases the manifest check. The check's intent ("a doc must not silently go unindexed") is served *better* by auto-regen than by a failing gate: it can't be forgotten.

No manifest impact from this PR itself (only `.py`/`.sh`/`.yaml` touched; generators run clean on current main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)