### PR TITLE
ci: converge doc/config generators into one shared list

### DIFF
--- a/bazel/tools/format/BUILD
+++ b/bazel/tools/format/BUILD
@@ -45,13 +45,17 @@ format_multirun(
     starlark = "@buildifier_prebuilt//:buildifier",
 )
 
+# All committed-artifact generators live in ONE list (run-generators.sh), shared
+# with fast-format.sh, so the local and CI format paths cannot drift.
+sh_binary(
+    name = "run_generators",
+    srcs = ["run-generators.sh"],
+)
+
 multirun(
     name = "format",
     commands = [
-        "//bazel/images:generate-home-cluster",
-        "//bazel/images:generate-push-all",
-        "//bazel/images:generate-push-all-pages",
-        "//projects/monolith:generate-routes",
+        ":run_generators",
         ":format_code",
         "//:gazelle",
     ],

--- a/bazel/tools/format/fast-format.sh
+++ b/bazel/tools/format/fast-format.sh
@@ -101,13 +101,11 @@ if $STAGED; then
 		PIDS+=($!)
 	fi
 
-	# Script generators only if BUILD files changed
-	if [ ${#BUILD_FILES[@]} -gt 0 ]; then
-		./bazel/images/generate-push-all.sh 2>/dev/null &
-		PIDS+=($!)
-		./bazel/images/generate-push-all-pages.sh 2>/dev/null &
-		PIDS+=($!)
-	fi
+	# Doc/config generators — ONE shared list (also run by the CI format multirun
+	# via :run_generators), so local and CI cannot drift. Runs unconditionally;
+	# each generator is idempotent and fast. || true: never block a commit.
+	(./bazel/tools/format/run-generators.sh 2>/dev/null || true) &
+	PIDS+=($!)
 
 	# Atlas migration checksums — only if migration SQL files are staged
 	for f in "${STAGED_FILES[@]}"; do
@@ -122,15 +120,8 @@ if $STAGED; then
 		esac
 	done
 
-	# Home-cluster generator (always run — it scans kustomization.yaml files, not BUILD)
-	./bazel/images/generate-home-cluster.sh 2>/dev/null &
-	PIDS+=($!)
-
-	# Docs sidebar generator (always run — it scans ADR markdown files, not BUILD)
-	./bazel/images/generate-docs-sidebar.sh 2>/dev/null &
-	PIDS+=($!)
-
-	# Sync homelab-library dependency versions (always run — fast no-op when versions match)
+	# Sync homelab-library dependency versions (local-only: needs the helm CLI,
+	# which is not in the CI format runner; charts have their own version gates)
 	./bazel/tools/format/sync-helm-deps.sh 2>/dev/null &
 	PIDS+=($!)
 
@@ -181,17 +172,14 @@ PIDS+=($!)
 prettier --write . 2>/dev/null &
 PIDS+=($!)
 
-# Script generators (run in parallel with formatters)
-./bazel/images/generate-push-all.sh 2>/dev/null &
-PIDS+=($!)
-./bazel/images/generate-push-all-pages.sh 2>/dev/null &
-PIDS+=($!)
-./bazel/images/generate-home-cluster.sh 2>/dev/null &
-PIDS+=($!)
-./bazel/images/generate-docs-sidebar.sh 2>/dev/null &
+# Doc/config generators — ONE shared list (also run by the CI format multirun via
+# :run_generators), so local and CI cannot drift. || true: a local generator
+# hiccup must never block a commit; CI is authoritative.
+(./bazel/tools/format/run-generators.sh 2>/dev/null || true) &
 PIDS+=($!)
 
-# Sync homelab-library dependency versions
+# Sync homelab-library dependency versions (local-only: needs the helm CLI, which
+# is not in the CI format runner; charts have their own version gates)
 ./bazel/tools/format/sync-helm-deps.sh 2>/dev/null &
 PIDS+=($!)
 

--- a/bazel/tools/format/run-generators.sh
+++ b/bazel/tools/format/run-generators.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Single source of truth for the repo's doc/config generators.
+#
+# Every generator that produces a COMMITTED artifact is listed here ONCE and run
+# by BOTH format paths, so the two can never drift (a generator in one list but
+# not the other is the classic "green locally, red in CI" trap):
+#   - CI + `bazel run //bazel/tools/format:format` run it via the :run_generators
+#     target in the format multirun; the Format check action auto-commits any
+#     drift like a formatting fix.
+#   - local pre-commit runs it via bazel/tools/format/fast-format.sh.
+#
+# Generators covered (each self-locates via BUILD_WORKSPACE_DIRECTORY, so this
+# wrapper only cd's to the workspace and invokes them):
+#   - home-cluster kustomization, push-all / push-all-pages BUILD lists,
+#     monolith routes, the ADR sidebar, and the two doc-index manifests
+#     (repo_docs_manifest.ndjson + the public docs-manifest.json).
+#
+# Deliberately NOT here: sync-helm-deps and atlas-checksum generation. They need
+# helm/atlas CLIs that are not in the CI format runner and have their own gates;
+# fast-format.sh runs them locally. Keep this list to pure python/grep generators
+# that are safe in CI.
+#
+# Failure handling: generators run in parallel (they write disjoint files); a
+# non-zero exit from any one fails this script so CI catches a broken generator.
+# fast-format.sh wraps the call so a local generator hiccup never blocks a commit.
+set -uo pipefail
+
+cd "${BUILD_WORKSPACE_DIRECTORY:-$(git rev-parse --show-toplevel)}"
+
+pids=()
+run() {
+	"$@" &
+	pids+=($!)
+}
+
+run ./bazel/images/generate-home-cluster.sh
+run ./bazel/images/generate-push-all.sh
+run ./bazel/images/generate-push-all-pages.sh
+run ./bazel/images/generate-docs-sidebar.sh
+run ./projects/monolith/generate-routes.sh
+run python3 ./projects/monolith/knowledge/tools/gen_repo_docs_manifest.py
+run python3 ./projects/monolith/knowledge/tools/gen_docs_manifest.py
+
+fails=0
+for p in "${pids[@]}"; do
+	wait "$p" || fails=1
+done
+exit "$fails"

--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -25,19 +25,11 @@ actions:
           fi
 
           # Run all formatters, generators, and gazelle in a single Bazel invocation.
-          # This replaces the previous 3-call approach (bazel build + fast-format.sh + bazel run gazelle)
-          # with one gRPC session, reducing transient connection failures.
+          # The :run_generators command runs every doc/config generator (incl. the
+          # KG-ingest + public-docs manifests), so any drift is picked up by the
+          # auto-commit below instead of hard-failing. Same list local pre-commit
+          # runs via fast-format.sh (single source of truth: run-generators.sh).
           bazel run //bazel/tools/format:format --config=ci
-
-          # Regenerate the doc-index manifests (KG ingest + public docs site).
-          # Both embed each doc's content + hash, so ANY doc edit makes them
-          # stale. Run them HERE, before the auto-commit below, so drift is
-          # committed like any other formatting fix instead of hard-failing and
-          # forcing a manual regen (the old validate-generate-scripts.sh path).
-          # python3-direct (pure stdlib + git ls-files): the py_venv_binary
-          # launcher does not resolve its main module in the CI runner.
-          python3 projects/monolith/knowledge/tools/gen_repo_docs_manifest.py
-          python3 projects/monolith/knowledge/tools/gen_docs_manifest.py
 
           # Validate grep-based generate scripts against bazel query
           ./bazel/images/validate-generate-scripts.sh


### PR DESCRIPTION
## What

Implements the two recommendations from the automation review: add the ADR sidebar to CI's generator set, and converge the divergent format paths into a single source of truth so this "green locally, red in CI" class can't recur.

## The problem

Three hand-maintained generator lists that disagreed:

| Generator | `format` multirun (CI) | `fast-format.sh` (local) | `buildbuddy.yaml` |
|---|---|---|---|
| home-cluster / push-all / push-all-pages | ✅ | ✅ | |
| monolith routes | ✅ | ❌ | |
| ADR sidebar | ❌ | ✅ | |
| repo-docs + docs-site manifests | ❌ | ❌ | ✅ (added last PR) |
| sync-helm-deps / atlas | ❌ | ✅ | |

Any generator in one list but not another is a latent trap (the ADR sidebar and manifests bit us repeatedly this week).

## The change

- **New `bazel/tools/format/run-generators.sh`**: the single list of every committed-artifact generator (home-cluster, push-all, push-all-pages, routes, ADR sidebar, both doc-index manifests). Generators self-locate via `BUILD_WORKSPACE_DIRECTORY` and write disjoint files, so it runs them in parallel and fails if any fails.
- **`format` multirun**: the four individual generator commands collapse to one `:run_generators` (new `sh_binary`). CI now regenerates the sidebar + manifests and **auto-commits** any drift, eliminating the last manual ADR step and the manifest red-chase.
- **`fast-format.sh`** (full + staged): calls `run-generators.sh`, gaining routes + the manifests it was missing.
- **`buildbuddy.yaml`**: drop the now-redundant manifest `python3` calls (they're in the multirun via `:run_generators`).
- `sync-helm-deps` + `atlas` stay fast-format-only on purpose (need helm/atlas CLIs absent from the CI format runner; they have their own gates).

## Verification

Locally, `run-generators.sh` runs all 7 generators, exits 0, and produces **zero drift** on a fresh tree (idempotent). The only layer not locally testable (the `sh_binary` under `bazel run`) mirrors the existing `generate-home-cluster` target and python3 (both proven in CI), and is exercised by this PR's own Format check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)