### PR TITLE
feat(goosecracker): store goose sessions on S3, not Postgres (ADR 026 Phase 2)

### DIFF
--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -4042,12 +4042,13 @@ bdd_test(
     ],
 )
 
-bdd_test(
+py_test(
     name = "goosecracker_sessions_test",
-    srcs = [
-        "goosecracker/tests/__init__.py",
-        "goosecracker/tests/conftest.py",
-        "goosecracker/tests/sessions_test.py",
+    srcs = ["goosecracker/tests/sessions_test.py"],
+    imports = ["."],
+    deps = [
+        ":monolith_backend",
+        "@pip//pytest",
     ],
 )
 

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.239.0
+version: 0.240.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/migrations/20260701170000_drop_agent_threads_session_db.sql
+++ b/projects/monolith/chart/migrations/20260701170000_drop_agent_threads_session_db.sql
@@ -1,0 +1,10 @@
+-- ADR 026 Phase 2: move the goose session store from Postgres to S3. The
+-- session_db BYTEA column (added 20260701120000) was an interim store taken while
+-- SeaweedFS S3 was assumed unavailable; S3 is in fact the intended store (the
+-- session sits at s3://artifacts/<id>/sessions.db alongside the artifact HTML,
+-- ADR 024 + ADR 026), and goosecracker.sessions now reads/writes it via
+-- artifact.s3. Drop the now-unused column. Safe: the blob is a resumability
+-- optimization, so any in-flight session simply cold-rebuilds on its next reply.
+
+ALTER TABLE claude_agent.agent_threads
+    DROP COLUMN IF EXISTS session_db;

--- a/projects/monolith/chart/migrations/atlas.sum
+++ b/projects/monolith/chart/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:qFioJN4yd/QxVzlIXWuPRZkv2E+TJzOdRA3GwKzinOc=
+h1:3rBeaiC0PEFUF1sY0B2CnrSPZQDbO/LrjqcXubGFN2k=
 20260330000000_initial_schema.sql h1:J2futpSW0nJAIRR7nR7ssT7LwXIYrvRI+PkHb5Y4tLI=
 20260403000000_chat_schema.sql h1:pERUFC0vzM95etRuzp43XzkCV7lBCzrrtY5Mk7aF3CA=
 20260404000000_chat_attachments.sql h1:tv+Fdbr1rQC5nzUxfaBC0O6fu2OMGgLWf+YNg1WQXi4=
@@ -77,3 +77,4 @@ h1:qFioJN4yd/QxVzlIXWuPRZkv2E+TJzOdRA3GwKzinOc=
 20260630150100_campsites_public_reader_grant.sql h1:vXU+Rc+U8htY+yjBb5whSk5dYKLp3mzXa172GxkAah8=
 20260630160000_agent_threads_run_ledger.sql h1:CefVRWBVKiOubsPri1QExT9efKAcYvnPhFSLI9Nu0Ew=
 20260701120000_agent_threads_session_db.sql h1:4/JGaQPLywa9h/aIn4arv10pfBdwVQMX9ZhzvqEdgi8=
+20260701170000_drop_agent_threads_session_db.sql h1:9aN4D3ulssztT1xUAFyH0KsXQYlODy66sAbfvw4lCLg=

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.239.0
+      targetRevision: 0.240.0
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/goosecracker/sessions.py
+++ b/projects/monolith/goosecracker/sessions.py
@@ -3,25 +3,26 @@
 The durable store for a thread's goose SQLite session, so a reply can resume the
 prior conversation (Model A) instead of cold-rebuilding from the full transcript
 (Model B). This is the single seam between the goosecracker runner and durable
-storage: today it is a BYTEA column on the run ledger
-(``claude_agent.agent_threads.session_db``); the ADR's S3 object store is deferred
-(SeaweedFS S3 auth is currently disabled) and, when enabled, drops in here using
-presigned URLs so the guest still holds no credential.
+storage.
+
+Backed by the SeaweedFS S3 object store via ``artifact.s3`` (the same seam the
+artifact HTML uses): the session lands at
+``s3://artifacts/<session_id>/sessions.db``, sharing the id namespace and bucket
+lifecycle with the published artifact (so the artifact session-prune job also
+evicts stale sessions). The monolith mediates every S3 access (the agent guest
+holds no credential): the runner ships the bytes to the guest inline in the
+AgentRequest and stores the returned bytes here, so the guest never touches S3.
 
 The blob is kilobytes (goose exits between turns, so sessions.db is consistent at
-export). One row per session (``upsert_run`` created it before the run), keyed by
-``session_id``. Every function opens its own Session, so an async caller must hand
-these to ``asyncio.to_thread`` (a sync Session must not run on the event loop).
+export). boto3 does blocking network I/O, so an async caller must hand these to
+``asyncio.to_thread``.
 """
 
 from __future__ import annotations
 
 import logging
 
-from sqlalchemy import text
-from sqlmodel import Session
-
-from app.db import get_engine
+from artifact import s3
 
 logger = logging.getLogger(__name__)
 
@@ -29,36 +30,16 @@ logger = logging.getLogger(__name__)
 def load(session_id: str) -> bytes | None:
     """Return the stored sessions.db blob for ``session_id``, or None.
 
-    None means "no prior session" (a first/cold run, a legacy row, or a run that
-    never persisted one), which the runner reads as "cold run, do not resume".
+    None means "no prior session" (a first/cold run, or a run that never persisted
+    one), which the runner reads as "cold run, do not resume".
     """
-    with Session(get_engine()) as session:
-        row = session.execute(
-            text(
-                "SELECT session_db FROM claude_agent.agent_threads "
-                "WHERE session_id = :s"
-            ),
-            {"s": session_id},
-        ).fetchone()
-    if row is None or row[0] is None:
-        return None
-    return bytes(row[0])
+    return s3.get_session(session_id)
 
 
 def save(session_id: str, data: bytes) -> None:
-    """Persist the sessions.db blob for ``session_id`` onto its ledger row.
+    """Persist the sessions.db blob for ``session_id`` to S3.
 
-    A no-op-safe UPDATE: if the row does not exist yet (it should, upsert_run runs
-    first) nothing is written. Stamps last_active_at so the row's recency reflects
-    the resume.
+    Overwrites any prior session for the id so the next reply resumes from the
+    latest state (``artifact.s3.put_session`` creates the bucket on first use).
     """
-    with Session(get_engine()) as session:
-        session.execute(
-            text(
-                "UPDATE claude_agent.agent_threads "
-                "SET session_db = :d, last_active_at = now() "
-                "WHERE session_id = :s"
-            ),
-            {"d": data, "s": session_id},
-        )
-        session.commit()
+    s3.put_session(session_id, data)

--- a/projects/monolith/goosecracker/tests/sessions_test.py
+++ b/projects/monolith/goosecracker/tests/sessions_test.py
@@ -1,35 +1,48 @@
-"""BDD tests for the goosecracker sessions.db blob store (ADR 026 Phase 2)."""
+"""Unit tests for the goosecracker sessions.db store seam (ADR 026 Phase 2).
+
+The store is a thin passthrough to ``artifact.s3`` (S3-backed), so the tests
+assert the wiring: load/save delegate to get_session/put_session keyed by the
+session id. artifact.s3 is stubbed with an in-memory dict so no S3 is needed.
+"""
 
 from __future__ import annotations
 
-from goosecracker import sessions, threads
+from goosecracker import sessions
 
 
-def _make_row(session_id: str) -> None:
-    threads.upsert_run(session_id, recipe="agent", tier="", task="t", discord_thread="")
+def test_save_then_load_round_trips_via_s3(monkeypatch):
+    store: dict[str, bytes] = {}
+    monkeypatch.setattr(
+        "artifact.s3.put_session", lambda sid, db: store.__setitem__(sid, db)
+    )
+    monkeypatch.setattr("artifact.s3.get_session", lambda sid: store.get(sid))
 
-
-def test_save_then_load_round_trips_bytes(ledger_db):
-    _make_row("sess-db-1")
     blob = b"\x00sqlite-bytes\xff\x01"
+    sessions.save("sess-1", blob)
 
-    sessions.save("sess-db-1", blob)
-
-    assert sessions.load("sess-db-1") == blob
-
-
-def test_load_returns_none_when_never_saved(ledger_db):
-    _make_row("sess-db-2")
-    assert sessions.load("sess-db-2") is None
+    assert sessions.load("sess-1") == blob
 
 
-def test_load_returns_none_for_unknown_session(ledger_db):
+def test_load_returns_none_when_absent(monkeypatch):
+    monkeypatch.setattr("artifact.s3.get_session", lambda sid: None)
     assert sessions.load("no-such-session") is None
 
 
-def test_save_overwrites_previous_blob(ledger_db):
-    _make_row("sess-db-3")
-    sessions.save("sess-db-3", b"first")
-    sessions.save("sess-db-3", b"second")
+def test_save_overwrites_previous_blob(monkeypatch):
+    store: dict[str, bytes] = {}
+    monkeypatch.setattr(
+        "artifact.s3.put_session", lambda sid, db: store.__setitem__(sid, db)
+    )
+    monkeypatch.setattr("artifact.s3.get_session", lambda sid: store.get(sid))
 
-    assert sessions.load("sess-db-3") == b"second"
+    sessions.save("sess-3", b"first")
+    sessions.save("sess-3", b"second")
+
+    assert sessions.load("sess-3") == b"second"
+
+
+def test_load_delegates_with_session_id(monkeypatch):
+    seen: list[str] = []
+    monkeypatch.setattr("artifact.s3.get_session", lambda sid: seen.append(sid) or b"x")
+    sessions.load("the-session-id")
+    assert seen == ["the-session-id"]


### PR DESCRIPTION
The SeaweedFS S3 gateway runs auth-disabled (dummy `duckdb` creds), so it's a working object store today, chat blobs, trips, knowledge raws, and stars grid all use it, and the `artifacts` bucket already exists. `artifact.s3` already ships `put_session`/`get_session` (`s3://artifacts/<id>/sessions.db`). PR #2998 had parked the goose session in a Postgres `BYTEA` column only because S3 was (wrongly) assumed unavailable.

## Change
- **`goosecracker.sessions`** now delegates to `artifact.s3.get_session`/`put_session`, so the goose session lives next to the published artifact under the same id namespace + prune lifecycle.
- **Drop** the now-unused `claude_agent.agent_threads.session_db` column.
- The **runner is unchanged**: still loads before dispatch + persists after success via `sessions.load/save` (now S3-backed, monolith-mediated, guest holds no credential).
- Sessions test reworked to stub `artifact.s3` (no Postgres harness needed).

## Verified
S3 reachability + auth confirmed live from the monolith backend (read-only probe): endpoint `seaweedfs-s3.seaweedfs:8333`, buckets include `artifacts`. The resume mechanism itself was already proven live (cold→persist→`--resume`→recall); this only swaps the store backend behind the same seam.

Artifacts already publish to S3 unchanged (`artifact.s3.put_artifact` via `/internal/artifact`); this PR only moves the session store onto the same seam.

Bump: monolith chart 0.239.0 -> 0.240.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)