### PR TITLE
fix(goosecracker): publish the built artifact + post its URL (ADR 024)

### DIFF
--- a/projects/firecracker/goosecracker/guest-init/internal/handler/handler.go
+++ b/projects/firecracker/goosecracker/guest-init/internal/handler/handler.go
@@ -5,12 +5,12 @@
 // caller-supplied model env while streaming each output line to a progress URL,
 // and return the captured output as an AgentResult.
 //
-// Scope covers the cold path (recipe + task -> goose -> result) and stateful
-// resume (ADR 026 Phase 2): when the caller ships a prior goose sessions.db the
-// handler hydrates it, runs `goose run --resume`, and exports the updated db back
-// so the next reply can resume again. Artifact publish is still deferred; the
-// Runner and SessionStore seams leave room to slot it in without reshaping the
-// contract.
+// Scope covers the cold path (recipe + task -> goose -> result), stateful resume
+// (ADR 026 Phase 2): when the caller ships a prior goose sessions.db the handler
+// hydrates it, runs `goose run --resume`, and exports the updated db back so the
+// next reply can resume again; and artifact publish (ADR 024): when the recipe
+// writes /tmp/artifact.html the handler returns its bytes in the result so the
+// orchestrator can publish it to a live URL (the guest holds no S3 credential).
 package handler
 
 import (
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"os"
 	"time"
 
 	"github.com/jomcgi/homelab/projects/firecracker/goosecracker/guest-init/internal/harness"
@@ -58,10 +59,11 @@ type AgentRequest struct {
 // (which the shim maps to 502). SessionDb carries the updated goose session back
 // (base64) so the orchestrator can persist it for the next resume.
 type AgentResult struct {
-	Status    string `json:"status"`              // "ok" | "error"
-	Result    string `json:"result,omitempty"`    // goose output captured from the run
-	Error     string `json:"error,omitempty"`     // failure detail when Status == "error"
-	SessionDb string `json:"sessionDb,omitempty"` // base64 updated sessions.db to persist
+	Status       string `json:"status"`                 // "ok" | "error"
+	Result       string `json:"result,omitempty"`       // goose output captured from the run
+	Error        string `json:"error,omitempty"`        // failure detail when Status == "error"
+	SessionDb    string `json:"sessionDb,omitempty"`    // base64 updated sessions.db to persist
+	ArtifactHTML string `json:"artifactHtml,omitempty"` // the built artifact HTML for the orchestrator to publish (ADR 024)
 }
 
 // Runner is the seam the handler uses to run goose and (optionally) clone a git
@@ -176,8 +178,33 @@ func New(runner Runner, opts ...Option) shim.Handler {
 				result.SessionDb = base64.StdEncoding.EncodeToString(db)
 			}
 		}
+
+		// Return the built artifact (if the recipe wrote one) so the orchestrator
+		// can publish it to a live URL (ADR 024). The guest has no S3 credential,
+		// so it ships the bytes back rather than publishing directly; a run that
+		// wrote no artifact (a non-artifact recipe, or a whiffed build) just leaves
+		// this empty.
+		if html := readArtifact(); len(html) > 0 {
+			result.ArtifactHTML = string(html)
+		}
 		return jsonResult(result)
 	}
+}
+
+// artifactPath is where the artifact recipe writes its single self-contained
+// HTML document (ADR 024); the harness ships it back for the orchestrator to
+// publish. A package var so tests can point it at a temp file.
+var artifactPath = "/tmp/artifact.html"
+
+// readArtifact returns the built artifact HTML, or nil when the run produced
+// none (a non-artifact recipe, or a build that failed to write the file). It
+// never errors: a missing or empty file just means "nothing to publish".
+func readArtifact() []byte {
+	data, err := os.ReadFile(artifactPath)
+	if err != nil || len(data) == 0 {
+		return nil
+	}
+	return data
 }
 
 // jsonResult marshals res into a 200 shim.Response. A marshal failure (which

--- a/projects/firecracker/goosecracker/guest-init/internal/handler/handler_test.go
+++ b/projects/firecracker/goosecracker/guest-init/internal/handler/handler_test.go
@@ -7,6 +7,8 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
@@ -341,6 +343,51 @@ func TestFailedRunDoesNotExportSession(t *testing.T) {
 	}
 	if res.SessionDb != "" {
 		t.Errorf("a failed run should not export a session, got %q", res.SessionDb)
+	}
+}
+
+func TestArtifactHTMLReturnedWhenRecipeWroteIt(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "artifact.html")
+	if err := os.WriteFile(path, []byte("<html>built</html>"), 0o644); err != nil {
+		t.Fatalf("write artifact: %v", err)
+	}
+	old := artifactPath
+	artifactPath = path
+	defer func() { artifactPath = old }()
+
+	runner := &fakeRunner{out: "done"}
+	h := New(runner)
+	body, _ := json.Marshal(AgentRequest{Recipe: "artifact", Task: "build", Session: "sess-a"})
+
+	resp, err := invoke(t, h, string(body))
+	if err != nil {
+		t.Fatalf("handler returned error: %v", err)
+	}
+	res := decodeResult(t, resp)
+	if res.Status != "ok" {
+		t.Fatalf("status = %q, want ok", res.Status)
+	}
+	if res.ArtifactHTML != "<html>built</html>" {
+		t.Errorf("ArtifactHTML = %q, want the built HTML", res.ArtifactHTML)
+	}
+}
+
+func TestNoArtifactHTMLWhenAbsent(t *testing.T) {
+	old := artifactPath
+	artifactPath = filepath.Join(t.TempDir(), "missing.html")
+	defer func() { artifactPath = old }()
+
+	runner := &fakeRunner{out: "done"}
+	h := New(runner)
+	body, _ := json.Marshal(AgentRequest{Recipe: "agent", Task: "t"})
+
+	resp, err := invoke(t, h, string(body))
+	if err != nil {
+		t.Fatalf("handler returned error: %v", err)
+	}
+	if res := decodeResult(t, resp); res.ArtifactHTML != "" {
+		t.Errorf("ArtifactHTML = %q, want empty (no artifact written)", res.ArtifactHTML)
 	}
 }
 

--- a/projects/firecracker/substrate/chart/Chart.yaml
+++ b/projects/firecracker/substrate/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: fc-invoke
 description: Node-affine Firecracker invoke daemon that dispatches HTTP invocations to a pool of warm-base microVMs across named workloads (POST /invoke/{workload}, GET /healthz)
 type: application
-version: 0.4.0
+version: 0.4.1

--- a/projects/firecracker/substrate/deploy/application.yaml
+++ b/projects/firecracker/substrate/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tags pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: fc-invoke
-      targetRevision: 0.4.0
+      targetRevision: 0.4.1
       helm:
         valueFiles:
           - $values/projects/firecracker/substrate/deploy/values.yaml

--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -4063,6 +4063,17 @@ py_test(
 )
 
 py_test(
+    name = "goosecracker_runner_test",
+    srcs = ["goosecracker/tests/runner_test.py"],
+    imports = ["."],
+    deps = [
+        ":monolith_backend",
+        "@pip//pytest",
+        "@pip//pytest_asyncio",
+    ],
+)
+
+py_test(
     name = "agent_checks_firing_alerts_test",
     srcs = ["agent/checks_firing_alerts_test.py"],
     imports = ["."],

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.240.0
+version: 0.240.1
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.240.0
+      targetRevision: 0.240.1
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/goosecracker/runner.py
+++ b/projects/monolith/goosecracker/runner.py
@@ -25,6 +25,7 @@ import asyncio
 import base64
 import logging
 import os
+import re
 
 import httpx
 from sqlmodel import Session
@@ -92,6 +93,53 @@ def _mark_progress_done(session: str) -> None:
     from chat.api import mark_goosecracker_progress_done
 
     mark_goosecracker_progress_done(session)
+
+
+def _publish_artifact(session: str, html: str) -> str:
+    """Publish the built artifact HTML to S3 and return its live URL (ADR 024).
+
+    Reuses the /internal/artifact publish path so the S3 write + URL/version logic
+    lives in one place. The artifact id is the session (== the Discord thread for
+    /artifact), so a reply on the same thread re-publishes the same id and the live
+    page hot-reloads instead of spawning a new artifact.
+    """
+    from artifact.router import PublishRequest, publish_artifact
+
+    return publish_artifact(PublishRequest(html=html, id=session)).url
+
+
+def _extract_summary(result: str) -> str:
+    """Pull the recipe's ``goose-result`` summary line out of goose's output.
+
+    The artifact recipe ends with a ```goose-result``` block carrying
+    ``summary: <what it built>``; surface that one line rather than the raw
+    transcript. Empty when absent.
+    """
+    m = re.search(r"^\s*summary:\s*(.+)$", result, re.MULTILINE)
+    return m.group(1).strip() if m else ""
+
+
+async def _delivery_message(session: str, recipe: str, data: dict) -> str:
+    """Build the Discord message for a successful run.
+
+    Artifact runs publish the built HTML and post a clean ``Artifact ready: <url>``
+    (plus the recipe's one-line summary) instead of the raw goose transcript. A run
+    that was meant to build an artifact but produced none gets a clear miss message.
+    Any other run posts its (truncated) result text.
+    """
+    html = data.get("artifactHtml")
+    if html:
+        try:
+            # nosemgrep: no-session-in-to-thread  # `session` is the fc-invoke session-id string, not a SQLAlchemy Session
+            url = await asyncio.to_thread(_publish_artifact, session, html)
+        except Exception:
+            logger.exception("goosecracker: artifact publish failed for %s", session)
+            return "Build finished, but publishing the artifact failed. Check the logs."
+        summary = _extract_summary(data.get("result", "") or "")
+        return f"Artifact ready: {url}" + (f"\n\n{summary}" if summary else "")
+    if recipe == "artifact":
+        return "Build finished but produced no artifact. Try rephrasing the request."
+    return _truncate(data.get("result", "") or "(no output)")
 
 
 async def _persist_session_db(session: str, session_db_b64: str | None) -> None:
@@ -174,7 +222,9 @@ async def run_and_deliver(
             await _persist_session_db(session, data.get("sessionDb"))
             # nosemgrep: no-session-in-to-thread  # `session` is the fc-invoke session-id string, not a SQLAlchemy Session
             await asyncio.to_thread(threads.mark_completed, session, result)
-            await _deliver(discord_thread, _truncate(f"Artifact ready.\n\n{result}"))
+            await _deliver(
+                discord_thread, await _delivery_message(session, recipe, data)
+            )
         else:
             err = data.get("error", "") or "goose run failed with no detail"
             # nosemgrep: no-session-in-to-thread  # `session` is the fc-invoke session-id string, not a SQLAlchemy Session

--- a/projects/monolith/goosecracker/tests/runner_test.py
+++ b/projects/monolith/goosecracker/tests/runner_test.py
@@ -1,0 +1,66 @@
+"""Unit tests for the goosecracker delivery/publish path (ADR 024).
+
+Covers the artifact publish + Discord message shaping: an artifact run publishes
+the built HTML and posts a clean "Artifact ready: <url>" (with the recipe summary)
+rather than the raw goose transcript; a whiffed artifact build and a publish
+failure both get clear messages.
+"""
+
+from __future__ import annotations
+
+from goosecracker import runner
+
+_GOOSE_RESULT = (
+    "  ▸ write path /tmp/artifact.html\n"
+    "```goose-result\n"
+    "type: note\n"
+    "summary: A bouncing ball demo with gravity.\n"
+    "```\n"
+)
+
+
+def test_extract_summary_pulls_summary_line():
+    assert (
+        runner._extract_summary(_GOOSE_RESULT) == "A bouncing ball demo with gravity."
+    )
+
+
+def test_extract_summary_empty_when_absent():
+    assert runner._extract_summary("no result block here") == ""
+
+
+async def test_delivery_message_publishes_and_links(monkeypatch):
+    monkeypatch.setattr(
+        runner, "_publish_artifact", lambda s, h: "https://jomcgi.dev/artifact/abc123"
+    )
+    data = {"artifactHtml": "<html>x</html>", "result": _GOOSE_RESULT}
+
+    msg = await runner._delivery_message("sess", "artifact", data)
+
+    assert "https://jomcgi.dev/artifact/abc123" in msg
+    assert "A bouncing ball demo with gravity." in msg
+    # the raw transcript (the write tool line) must NOT be dumped
+    assert "▸ write path" not in msg
+
+
+async def test_delivery_message_artifact_run_with_no_artifact():
+    msg = await runner._delivery_message(
+        "sess", "artifact", {"result": "chatted instead"}
+    )
+    assert "no artifact" in msg.lower()
+
+
+async def test_delivery_message_publish_failure_is_reported(monkeypatch):
+    def boom(_s, _h):
+        raise RuntimeError("s3 down")
+
+    monkeypatch.setattr(runner, "_publish_artifact", boom)
+    msg = await runner._delivery_message(
+        "sess", "artifact", {"artifactHtml": "<html>x</html>"}
+    )
+    assert "failed" in msg.lower()
+
+
+async def test_delivery_message_non_artifact_posts_result():
+    msg = await runner._delivery_message("sess", "agent", {"result": "hello from qwen"})
+    assert msg == "hello from qwen"


### PR DESCRIPTION
**Bug** (from a live `/artifact` run): the goosecracker cutover left artifact publish deferred. The `artifact` recipe writes `/tmp/artifact.html` expecting "the harness publishes it and returns the live URL", but the guest handler only ran goose and returned stdout, so Discord posted **"Artifact ready."** followed by the **raw goose transcript** (recipe banner + `▸ write` tool call + raw HTML) and never actually published anything, no S3 write, no URL.

## Fix (monolith-mediated; guest holds no S3 credential)
- **Guest handler** returns the built `/tmp/artifact.html` bytes in `AgentResult.artifactHtml` after a successful run (empty for non-artifact runs).
- **Runner** publishes it via the existing `/internal/artifact` path (`artifact.router.publish_artifact`) with `id = session`, so a reply on the same Discord thread re-publishes the same id and the live page **hot-reloads**. It then posts a clean **`Artifact ready: <url>`** plus the recipe's one-line summary, instead of the transcript. A whiffed build and a publish failure each get a clear message.

This reuses the S3 layer just confirmed working (auth-disabled gateway, `artifacts` bucket exists).

## Tests
Guest returns `ArtifactHTML` iff the recipe wrote it; runner publishes + links + summarizes, handles no-artifact + publish-failure, and passes non-artifact results through.

## Bumps
fc-invoke chart 0.4.0 -> 0.4.1 (guest image), monolith 0.240.0 -> 0.240.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)