### PR TITLE
chore(monolith-public): deploy llm-leaderboard route (chart 0.82.7)

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.82.6
+version: 0.82.7
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.82.6
+      targetRevision: 0.82.7
       helm:
         releaseName: monolith-public
         valueFiles:


### PR DESCRIPTION
The `/app/llm-leaderboard` page merged in #3005 is built into the shared `//projects/monolith/frontend:image_public`, but the public tier (`monolith-public`, which serves jomcgi.dev) pulls its chart by version and was still on 0.82.6 with the pre-route frontend digest, so the route 404s. Bump the chart + targetRevision in lockstep so CI re-pins the current `image_public` digest and ArgoCD rolls it out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)