### PR TITLE
feat(model-bench): per-task deep-dive on the LLM leaderboard rows

### DIFF
--- a/projects/model-bench/bench/cli.py
+++ b/projects/model-bench/bench/cli.py
@@ -576,9 +576,16 @@ def _report(args) -> None:
     # Agentic leaderboard: aggregate tool-calling cells (turns is not None) per model.
     from statistics import median
 
+    # Only count cells for tasks that are still in the current task set. Cells for a
+    # task that was later removed or renamed linger in the durable results cache; the
+    # harness-version filter above does not catch them (same version, dropped task),
+    # so without this scope a stale task would silently inflate every model's n and
+    # skew the medians away from the published task set. This mirrors the per-task and
+    # per-model breakdowns below, which are already scoped to current tasks.
+    current_agentic_ids = {t.id for t in tasks if t.mode == "agentic"}
     agentic_groups: dict[str, list[ResultCell]] = {}
     for cell in cells:
-        if cell.turns is not None:
+        if cell.turns is not None and cell.task_id in current_agentic_ids:
             agentic_groups.setdefault(cell.model_id, []).append(cell)
     agentic: dict[str, dict] = {}
     for model_id, group in agentic_groups.items():
@@ -648,12 +655,26 @@ def _write_leaderboard_json(
 
     # Per-task pass counts over agentic cells.
     per_task: dict[str, dict] = {}
+    # Per-(model, task) breakdown so the page can render a deep-dive on each model
+    # row: which of the tasks it passed, and the tokens/turns/wall-time it spent on
+    # each. This is the same agentic cells, just kept disaggregated instead of only
+    # rolled up into the model's medians.
+    per_model_tasks: dict[str, dict[str, dict]] = {}
     for cell in cells:
         if cell.turns is None or cell.task_id not in agentic_ids:
             continue
         d = per_task.setdefault(cell.task_id, {"passed": 0, "n": 0})
         d["n"] += 1
         d["passed"] += int(cell.first_attempt_passed)
+        # Last cell wins if a (model, task) somehow has duplicates on disk; within one
+        # harness version there is exactly one cached cell per pair.
+        per_model_tasks.setdefault(cell.model_id, {})[cell.task_id] = {
+            "id": cell.task_id,
+            "passed": cell.first_attempt_passed,
+            "tokens": cell.total_tokens,
+            "turns": cell.turns,
+            "latency_ms": cell.total_latency_ms,
+        }
 
     def _blurb(tid: str) -> str:
         if tid not in task_meta:
@@ -701,6 +722,11 @@ def _write_leaderboard_json(
                 else None
             ),
             "tool_use_ok": round(s["tool_ok_rate"], 4),
+            # Per-task breakdown, ordered by task id so it lines up with tasks_json.
+            "tasks": [
+                per_model_tasks[mid][tid]
+                for tid in sorted(per_model_tasks.get(mid, {}))
+            ],
         }
         for mid, s in agentic.items()
     ]

--- a/projects/model-bench/bench/cli_test.py
+++ b/projects/model-bench/bench/cli_test.py
@@ -121,6 +121,11 @@ def test_write_leaderboard_json_shape_and_ranking(tmp_path):
     # Value fields surfaced: wall-time and cost-per-solve.
     assert data["models"][0]["median_latency_ms"] == 8000
     assert data["models"][0]["cost_per_solve_usd"] == 0.001
+    # Per-task breakdown is embedded for the deep-dive: one entry per graded task,
+    # carrying pass/fail plus the per-task tokens and turns.
+    (mt,) = data["models"][0]["tasks"]
+    assert mt["id"] == "worldcup-fixtures-guard-01"
+    assert mt["passed"] is True and mt["tokens"] == 1000 and mt["turns"] == 4
     # The one agentic task appears with its real-test flag, blurb, and pass count.
     (t,) = data["tasks"]
     assert t["id"] == "worldcup-fixtures-guard-01"

--- a/projects/monolith/frontend/src/lib/public/llm-leaderboard/leaderboard.json
+++ b/projects/monolith/frontend/src/lib/public/llm-leaderboard/leaderboard.json
@@ -84,7 +84,58 @@
       "median_latency_ms": 33822,
       "cost_usd": 0.002148,
       "cost_per_solve_usd": 0.002148,
-      "tool_use_ok": 1.0
+      "tool_use_ok": 1.0,
+      "tasks": [
+        {
+          "id": "flights-module-01",
+          "passed": true,
+          "tokens": 39071,
+          "turns": 15,
+          "latency_ms": 29289
+        },
+        {
+          "id": "hikes-walkhighlands-dom-01",
+          "passed": true,
+          "tokens": 15803,
+          "turns": 3,
+          "latency_ms": 33822
+        },
+        {
+          "id": "hikes-walkhighlands-duration-01",
+          "passed": true,
+          "tokens": 17844,
+          "turns": 5,
+          "latency_ms": 37828
+        },
+        {
+          "id": "slo-budget-breach-01",
+          "passed": true,
+          "tokens": 7779,
+          "turns": 4,
+          "latency_ms": 17705
+        },
+        {
+          "id": "stars-climatology-months-01",
+          "passed": true,
+          "tokens": 29530,
+          "turns": 7,
+          "latency_ms": 48707
+        },
+        {
+          "id": "worldcup-fixtures-guard-01",
+          "passed": true,
+          "tokens": 14436,
+          "turns": 5,
+          "latency_ms": 29278
+        },
+        {
+          "id": "worldcup-swing-settled-01",
+          "passed": true,
+          "tokens": 26786,
+          "turns": 6,
+          "latency_ms": 42765
+        }
+      ]
     },
     {
       "id": "google/gemma-4-26b-a4b-it",
@@ -96,7 +147,58 @@
       "median_latency_ms": 52615,
       "cost_usd": 0.002154,
       "cost_per_solve_usd": 0.002154,
-      "tool_use_ok": 1.0
+      "tool_use_ok": 1.0,
+      "tasks": [
+        {
+          "id": "flights-module-01",
+          "passed": true,
+          "tokens": 17500,
+          "turns": 11,
+          "latency_ms": 14290
+        },
+        {
+          "id": "hikes-walkhighlands-dom-01",
+          "passed": true,
+          "tokens": 32524,
+          "turns": 7,
+          "latency_ms": 252840
+        },
+        {
+          "id": "hikes-walkhighlands-duration-01",
+          "passed": true,
+          "tokens": 27755,
+          "turns": 7,
+          "latency_ms": 75376
+        },
+        {
+          "id": "slo-budget-breach-01",
+          "passed": true,
+          "tokens": 6560,
+          "turns": 4,
+          "latency_ms": 30872
+        },
+        {
+          "id": "stars-climatology-months-01",
+          "passed": true,
+          "tokens": 29403,
+          "turns": 6,
+          "latency_ms": 52615
+        },
+        {
+          "id": "worldcup-fixtures-guard-01",
+          "passed": true,
+          "tokens": 14339,
+          "turns": 5,
+          "latency_ms": 47880
+        },
+        {
+          "id": "worldcup-swing-settled-01",
+          "passed": true,
+          "tokens": 19802,
+          "turns": 5,
+          "latency_ms": 54135
+        }
+      ]
     },
     {
       "id": "deepseek/deepseek-v4-flash",
@@ -108,7 +210,58 @@
       "median_latency_ms": 40046,
       "cost_usd": 0.002971,
       "cost_per_solve_usd": 0.002971,
-      "tool_use_ok": 1.0
+      "tool_use_ok": 1.0,
+      "tasks": [
+        {
+          "id": "flights-module-01",
+          "passed": true,
+          "tokens": 23567,
+          "turns": 8,
+          "latency_ms": 40046
+        },
+        {
+          "id": "hikes-walkhighlands-dom-01",
+          "passed": true,
+          "tokens": 17573,
+          "turns": 3,
+          "latency_ms": 32452
+        },
+        {
+          "id": "hikes-walkhighlands-duration-01",
+          "passed": true,
+          "tokens": 33377,
+          "turns": 5,
+          "latency_ms": 53163
+        },
+        {
+          "id": "slo-budget-breach-01",
+          "passed": true,
+          "tokens": 14694,
+          "turns": 4,
+          "latency_ms": 44671
+        },
+        {
+          "id": "stars-climatology-months-01",
+          "passed": true,
+          "tokens": 73419,
+          "turns": 6,
+          "latency_ms": 101850
+        },
+        {
+          "id": "worldcup-fixtures-guard-01",
+          "passed": true,
+          "tokens": 14002,
+          "turns": 3,
+          "latency_ms": 30226
+        },
+        {
+          "id": "worldcup-swing-settled-01",
+          "passed": true,
+          "tokens": 18903,
+          "turns": 3,
+          "latency_ms": 35170
+        }
+      ]
     },
     {
       "id": "qwen/qwen3-coder-next",
@@ -120,7 +273,58 @@
       "median_latency_ms": 15977,
       "cost_usd": 0.005987,
       "cost_per_solve_usd": 0.005987,
-      "tool_use_ok": 1.0
+      "tool_use_ok": 1.0,
+      "tasks": [
+        {
+          "id": "flights-module-01",
+          "passed": true,
+          "tokens": 149571,
+          "turns": 40,
+          "latency_ms": 44699
+        },
+        {
+          "id": "hikes-walkhighlands-dom-01",
+          "passed": true,
+          "tokens": 15574,
+          "turns": 3,
+          "latency_ms": 15059
+        },
+        {
+          "id": "hikes-walkhighlands-duration-01",
+          "passed": true,
+          "tokens": 15030,
+          "turns": 3,
+          "latency_ms": 14663
+        },
+        {
+          "id": "slo-budget-breach-01",
+          "passed": true,
+          "tokens": 6300,
+          "turns": 3,
+          "latency_ms": 6090
+        },
+        {
+          "id": "stars-climatology-months-01",
+          "passed": true,
+          "tokens": 26582,
+          "turns": 4,
+          "latency_ms": 21486
+        },
+        {
+          "id": "worldcup-fixtures-guard-01",
+          "passed": true,
+          "tokens": 12456,
+          "turns": 3,
+          "latency_ms": 15977
+        },
+        {
+          "id": "worldcup-swing-settled-01",
+          "passed": true,
+          "tokens": 17110,
+          "turns": 3,
+          "latency_ms": 17437
+        }
+      ]
     },
     {
       "id": "qwen/qwen3.6-35b-a3b",
@@ -132,7 +336,58 @@
       "median_latency_ms": 43131,
       "cost_usd": 0.010698,
       "cost_per_solve_usd": 0.010698,
-      "tool_use_ok": 1.0
+      "tool_use_ok": 1.0,
+      "tasks": [
+        {
+          "id": "flights-module-01",
+          "passed": true,
+          "tokens": 39603,
+          "turns": 10,
+          "latency_ms": 29745
+        },
+        {
+          "id": "hikes-walkhighlands-dom-01",
+          "passed": true,
+          "tokens": 60698,
+          "turns": 7,
+          "latency_ms": 73170
+        },
+        {
+          "id": "hikes-walkhighlands-duration-01",
+          "passed": true,
+          "tokens": 71327,
+          "turns": 6,
+          "latency_ms": 98877
+        },
+        {
+          "id": "slo-budget-breach-01",
+          "passed": true,
+          "tokens": 16762,
+          "turns": 5,
+          "latency_ms": 26690
+        },
+        {
+          "id": "stars-climatology-months-01",
+          "passed": true,
+          "tokens": 46289,
+          "turns": 7,
+          "latency_ms": 53698
+        },
+        {
+          "id": "worldcup-fixtures-guard-01",
+          "passed": true,
+          "tokens": 24710,
+          "turns": 6,
+          "latency_ms": 27991
+        },
+        {
+          "id": "worldcup-swing-settled-01",
+          "passed": true,
+          "tokens": 45127,
+          "turns": 7,
+          "latency_ms": 43131
+        }
+      ]
     },
     {
       "id": "z-ai/glm-4.7",
@@ -144,7 +399,58 @@
       "median_latency_ms": 96613,
       "cost_usd": 0.015035,
       "cost_per_solve_usd": 0.015035,
-      "tool_use_ok": 1.0
+      "tool_use_ok": 1.0,
+      "tasks": [
+        {
+          "id": "flights-module-01",
+          "passed": true,
+          "tokens": 41975,
+          "turns": 17,
+          "latency_ms": 45147
+        },
+        {
+          "id": "hikes-walkhighlands-dom-01",
+          "passed": true,
+          "tokens": 19132,
+          "turns": 5,
+          "latency_ms": 114119
+        },
+        {
+          "id": "hikes-walkhighlands-duration-01",
+          "passed": true,
+          "tokens": 30722,
+          "turns": 6,
+          "latency_ms": 112209
+        },
+        {
+          "id": "slo-budget-breach-01",
+          "passed": true,
+          "tokens": 7842,
+          "turns": 3,
+          "latency_ms": 39981
+        },
+        {
+          "id": "stars-climatology-months-01",
+          "passed": true,
+          "tokens": 27388,
+          "turns": 6,
+          "latency_ms": 96613
+        },
+        {
+          "id": "worldcup-fixtures-guard-01",
+          "passed": true,
+          "tokens": 24840,
+          "turns": 6,
+          "latency_ms": 168936
+        },
+        {
+          "id": "worldcup-swing-settled-01",
+          "passed": true,
+          "tokens": 18644,
+          "turns": 5,
+          "latency_ms": 69472
+        }
+      ]
     },
     {
       "id": "deepseek/deepseek-v4-pro",
@@ -156,7 +462,58 @@
       "median_latency_ms": 55998,
       "cost_usd": 0.015769,
       "cost_per_solve_usd": 0.015769,
-      "tool_use_ok": 1.0
+      "tool_use_ok": 1.0,
+      "tasks": [
+        {
+          "id": "flights-module-01",
+          "passed": true,
+          "tokens": 20335,
+          "turns": 7,
+          "latency_ms": 55998
+        },
+        {
+          "id": "hikes-walkhighlands-dom-01",
+          "passed": true,
+          "tokens": 17137,
+          "turns": 3,
+          "latency_ms": 43898
+        },
+        {
+          "id": "hikes-walkhighlands-duration-01",
+          "passed": true,
+          "tokens": 39883,
+          "turns": 6,
+          "latency_ms": 110596
+        },
+        {
+          "id": "slo-budget-breach-01",
+          "passed": true,
+          "tokens": 9506,
+          "turns": 4,
+          "latency_ms": 33509
+        },
+        {
+          "id": "stars-climatology-months-01",
+          "passed": true,
+          "tokens": 93884,
+          "turns": 9,
+          "latency_ms": 125005
+        },
+        {
+          "id": "worldcup-fixtures-guard-01",
+          "passed": true,
+          "tokens": 13053,
+          "turns": 3,
+          "latency_ms": 30428
+        },
+        {
+          "id": "worldcup-swing-settled-01",
+          "passed": true,
+          "tokens": 23507,
+          "turns": 4,
+          "latency_ms": 72842
+        }
+      ]
     },
     {
       "id": "qwen/qwen3.6-27b",
@@ -168,7 +525,58 @@
       "median_latency_ms": 66471,
       "cost_usd": 0.029225,
       "cost_per_solve_usd": 0.029225,
-      "tool_use_ok": 1.0
+      "tool_use_ok": 1.0,
+      "tasks": [
+        {
+          "id": "flights-module-01",
+          "passed": true,
+          "tokens": 112283,
+          "turns": 19,
+          "latency_ms": 74141
+        },
+        {
+          "id": "hikes-walkhighlands-dom-01",
+          "passed": true,
+          "tokens": 31738,
+          "turns": 6,
+          "latency_ms": 66471
+        },
+        {
+          "id": "hikes-walkhighlands-duration-01",
+          "passed": true,
+          "tokens": 175349,
+          "turns": 10,
+          "latency_ms": 158619
+        },
+        {
+          "id": "slo-budget-breach-01",
+          "passed": true,
+          "tokens": 13904,
+          "turns": 5,
+          "latency_ms": 32990
+        },
+        {
+          "id": "stars-climatology-months-01",
+          "passed": true,
+          "tokens": 45059,
+          "turns": 7,
+          "latency_ms": 66394
+        },
+        {
+          "id": "worldcup-fixtures-guard-01",
+          "passed": true,
+          "tokens": 15102,
+          "turns": 5,
+          "latency_ms": 51616
+        },
+        {
+          "id": "worldcup-swing-settled-01",
+          "passed": true,
+          "tokens": 42886,
+          "turns": 7,
+          "latency_ms": 83108
+        }
+      ]
     },
     {
       "id": "z-ai/glm-5.2",
@@ -180,7 +588,58 @@
       "median_latency_ms": 129345,
       "cost_usd": 0.030749,
       "cost_per_solve_usd": 0.030749,
-      "tool_use_ok": 0.7143
+      "tool_use_ok": 0.7143,
+      "tasks": [
+        {
+          "id": "flights-module-01",
+          "passed": true,
+          "tokens": 12813,
+          "turns": 6,
+          "latency_ms": 80120
+        },
+        {
+          "id": "hikes-walkhighlands-dom-01",
+          "passed": true,
+          "tokens": 18815,
+          "turns": 4,
+          "latency_ms": 169824
+        },
+        {
+          "id": "hikes-walkhighlands-duration-01",
+          "passed": true,
+          "tokens": 18291,
+          "turns": 3,
+          "latency_ms": 132012
+        },
+        {
+          "id": "slo-budget-breach-01",
+          "passed": true,
+          "tokens": 5950,
+          "turns": 3,
+          "latency_ms": 77460
+        },
+        {
+          "id": "stars-climatology-months-01",
+          "passed": true,
+          "tokens": 81408,
+          "turns": 9,
+          "latency_ms": 129345
+        },
+        {
+          "id": "worldcup-fixtures-guard-01",
+          "passed": true,
+          "tokens": 19545,
+          "turns": 4,
+          "latency_ms": 63512
+        },
+        {
+          "id": "worldcup-swing-settled-01",
+          "passed": true,
+          "tokens": 20746,
+          "turns": 4,
+          "latency_ms": 181376
+        }
+      ]
     },
     {
       "id": "anthropic/claude-sonnet-4.6",
@@ -192,7 +651,58 @@
       "median_latency_ms": 77305,
       "cost_usd": 0.140811,
       "cost_per_solve_usd": 0.140811,
-      "tool_use_ok": 1.0
+      "tool_use_ok": 1.0,
+      "tasks": [
+        {
+          "id": "flights-module-01",
+          "passed": true,
+          "tokens": 28849,
+          "turns": 8,
+          "latency_ms": 42842
+        },
+        {
+          "id": "hikes-walkhighlands-dom-01",
+          "passed": true,
+          "tokens": 22214,
+          "turns": 4,
+          "latency_ms": 77305
+        },
+        {
+          "id": "hikes-walkhighlands-duration-01",
+          "passed": true,
+          "tokens": 49666,
+          "turns": 7,
+          "latency_ms": 99806
+        },
+        {
+          "id": "slo-budget-breach-01",
+          "passed": true,
+          "tokens": 8950,
+          "turns": 3,
+          "latency_ms": 31316
+        },
+        {
+          "id": "stars-climatology-months-01",
+          "passed": true,
+          "tokens": 44844,
+          "turns": 5,
+          "latency_ms": 96757
+        },
+        {
+          "id": "worldcup-fixtures-guard-01",
+          "passed": true,
+          "tokens": 15898,
+          "turns": 3,
+          "latency_ms": 52099
+        },
+        {
+          "id": "worldcup-swing-settled-01",
+          "passed": true,
+          "tokens": 42757,
+          "turns": 5,
+          "latency_ms": 88674
+        }
+      ]
     },
     {
       "id": "anthropic/claude-opus-4.8",
@@ -204,7 +714,58 @@
       "median_latency_ms": 52773,
       "cost_usd": 0.195475,
       "cost_per_solve_usd": 0.195475,
-      "tool_use_ok": 1.0
+      "tool_use_ok": 1.0,
+      "tasks": [
+        {
+          "id": "flights-module-01",
+          "passed": true,
+          "tokens": 10242,
+          "turns": 3,
+          "latency_ms": 19536
+        },
+        {
+          "id": "hikes-walkhighlands-dom-01",
+          "passed": true,
+          "tokens": 23921,
+          "turns": 3,
+          "latency_ms": 52773
+        },
+        {
+          "id": "hikes-walkhighlands-duration-01",
+          "passed": true,
+          "tokens": 23501,
+          "turns": 3,
+          "latency_ms": 56019
+        },
+        {
+          "id": "slo-budget-breach-01",
+          "passed": true,
+          "tokens": 8934,
+          "turns": 3,
+          "latency_ms": 19405
+        },
+        {
+          "id": "stars-climatology-months-01",
+          "passed": true,
+          "tokens": 39973,
+          "turns": 4,
+          "latency_ms": 68372
+        },
+        {
+          "id": "worldcup-fixtures-guard-01",
+          "passed": true,
+          "tokens": 18587,
+          "turns": 3,
+          "latency_ms": 40354
+        },
+        {
+          "id": "worldcup-swing-settled-01",
+          "passed": true,
+          "tokens": 25103,
+          "turns": 3,
+          "latency_ms": 57894
+        }
+      ]
     },
     {
       "id": "google/gemma-4-31b-it",
@@ -216,7 +777,58 @@
       "median_latency_ms": 83288,
       "cost_usd": 0.00287,
       "cost_per_solve_usd": 0.003348,
-      "tool_use_ok": 1.0
+      "tool_use_ok": 1.0,
+      "tasks": [
+        {
+          "id": "flights-module-01",
+          "passed": true,
+          "tokens": 18925,
+          "turns": 12,
+          "latency_ms": 36581
+        },
+        {
+          "id": "hikes-walkhighlands-dom-01",
+          "passed": true,
+          "tokens": 17171,
+          "turns": 4,
+          "latency_ms": 432302
+        },
+        {
+          "id": "hikes-walkhighlands-duration-01",
+          "passed": true,
+          "tokens": 28139,
+          "turns": 7,
+          "latency_ms": 295152
+        },
+        {
+          "id": "slo-budget-breach-01",
+          "passed": true,
+          "tokens": 6604,
+          "turns": 4,
+          "latency_ms": 32620
+        },
+        {
+          "id": "stars-climatology-months-01",
+          "passed": true,
+          "tokens": 29381,
+          "turns": 6,
+          "latency_ms": 95474
+        },
+        {
+          "id": "worldcup-fixtures-guard-01",
+          "passed": true,
+          "tokens": 14382,
+          "turns": 5,
+          "latency_ms": 67094
+        },
+        {
+          "id": "worldcup-swing-settled-01",
+          "passed": false,
+          "tokens": 10803,
+          "turns": 4,
+          "latency_ms": 83288
+        }
+      ]
     },
     {
       "id": "mistralai/devstral-2512",
@@ -228,7 +840,58 @@
       "median_latency_ms": 77963,
       "cost_usd": 0.0076,
       "cost_per_solve_usd": 0.017732,
-      "tool_use_ok": 0.8571
+      "tool_use_ok": 0.8571,
+      "tasks": [
+        {
+          "id": "flights-module-01",
+          "passed": true,
+          "tokens": 19916,
+          "turns": 12,
+          "latency_ms": 77963
+        },
+        {
+          "id": "hikes-walkhighlands-dom-01",
+          "passed": false,
+          "tokens": 8825,
+          "turns": 1,
+          "latency_ms": 67882
+        },
+        {
+          "id": "hikes-walkhighlands-duration-01",
+          "passed": true,
+          "tokens": 27866,
+          "turns": 5,
+          "latency_ms": 56929
+        },
+        {
+          "id": "slo-budget-breach-01",
+          "passed": true,
+          "tokens": 6798,
+          "turns": 4,
+          "latency_ms": 51457
+        },
+        {
+          "id": "stars-climatology-months-01",
+          "passed": false,
+          "tokens": 6879,
+          "turns": 5,
+          "latency_ms": 146616
+        },
+        {
+          "id": "worldcup-fixtures-guard-01",
+          "passed": false,
+          "tokens": 1746,
+          "turns": 4,
+          "latency_ms": 148096
+        },
+        {
+          "id": "worldcup-swing-settled-01",
+          "passed": false,
+          "tokens": 1243,
+          "turns": 3,
+          "latency_ms": 140740
+        }
+      ]
     },
     {
       "id": "google/gemini-3.5-flash",
@@ -240,7 +903,58 @@
       "median_latency_ms": 53668,
       "cost_usd": 0.227067,
       "cost_per_solve_usd": 0.529822,
-      "tool_use_ok": 1.0
+      "tool_use_ok": 1.0,
+      "tasks": [
+        {
+          "id": "flights-module-01",
+          "passed": true,
+          "tokens": 39944,
+          "turns": 13,
+          "latency_ms": 41989
+        },
+        {
+          "id": "hikes-walkhighlands-dom-01",
+          "passed": false,
+          "tokens": 23043,
+          "turns": 6,
+          "latency_ms": 37640
+        },
+        {
+          "id": "hikes-walkhighlands-duration-01",
+          "passed": false,
+          "tokens": 65447,
+          "turns": 9,
+          "latency_ms": 60901
+        },
+        {
+          "id": "slo-budget-breach-01",
+          "passed": true,
+          "tokens": 17174,
+          "turns": 5,
+          "latency_ms": 25760
+        },
+        {
+          "id": "stars-climatology-months-01",
+          "passed": false,
+          "tokens": 173447,
+          "turns": 14,
+          "latency_ms": 105992
+        },
+        {
+          "id": "worldcup-fixtures-guard-01",
+          "passed": false,
+          "tokens": 192040,
+          "turns": 16,
+          "latency_ms": 107773
+        },
+        {
+          "id": "worldcup-swing-settled-01",
+          "passed": true,
+          "tokens": 68004,
+          "turns": 9,
+          "latency_ms": 53668
+        }
+      ]
     },
     {
       "id": "qwen/qwen-2.5-coder-32b-instruct",
@@ -252,7 +966,58 @@
       "median_latency_ms": 0,
       "cost_usd": 0.0,
       "cost_per_solve_usd": null,
-      "tool_use_ok": 0.0
+      "tool_use_ok": 0.0,
+      "tasks": [
+        {
+          "id": "flights-module-01",
+          "passed": false,
+          "tokens": 0,
+          "turns": 1,
+          "latency_ms": 0
+        },
+        {
+          "id": "hikes-walkhighlands-dom-01",
+          "passed": false,
+          "tokens": 0,
+          "turns": 1,
+          "latency_ms": 0
+        },
+        {
+          "id": "hikes-walkhighlands-duration-01",
+          "passed": false,
+          "tokens": 0,
+          "turns": 1,
+          "latency_ms": 0
+        },
+        {
+          "id": "slo-budget-breach-01",
+          "passed": false,
+          "tokens": 0,
+          "turns": 1,
+          "latency_ms": 0
+        },
+        {
+          "id": "stars-climatology-months-01",
+          "passed": false,
+          "tokens": 0,
+          "turns": 1,
+          "latency_ms": 0
+        },
+        {
+          "id": "worldcup-fixtures-guard-01",
+          "passed": false,
+          "tokens": 0,
+          "turns": 1,
+          "latency_ms": 0
+        },
+        {
+          "id": "worldcup-swing-settled-01",
+          "passed": false,
+          "tokens": 0,
+          "turns": 1,
+          "latency_ms": 0
+        }
+      ]
     }
   ]
 }

--- a/projects/monolith/frontend/src/routes/public/app/llm-leaderboard/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/llm-leaderboard/+page.svelte
@@ -5,6 +5,8 @@
   const models = $derived(lb.models ?? []);
   const tasks = $derived(lb.tasks ?? []);
   const realTestCount = $derived(tasks.filter((t) => t.real_test).length);
+  // Join per-model task cells back to task metadata (real-test flag, blurb) by id.
+  const taskById = $derived(Object.fromEntries(tasks.map((t) => [t.id, t])));
 
   const pct = (x) => `${Math.round((x ?? 0) * 100)}%`;
   const num = (x) => (x ?? 0).toLocaleString("en-US");
@@ -13,6 +15,23 @@
   // Drop the provider prefix for the headline name, keep the full slug beneath.
   const shortName = (id) => (id.includes("/") ? id.split("/").slice(1).join("/") : id);
   const isAnchor = (m) => m.role === "anchor";
+
+  // Deep-dive: a row expands into its per-task breakdown. Guard on the data so the
+  // page still renders if a leaderboard.json predates the per-task field (the rows
+  // just stay non-expandable until it is regenerated).
+  const hasBreakdown = (m) => Array.isArray(m.tasks) && m.tasks.length > 0;
+  const solvedCount = (m) => (m.tasks ?? []).filter((t) => t.passed).length;
+  let openId = $state(null); // accordion: at most one model open at a time
+  const toggle = (m) => {
+    if (!hasBreakdown(m)) return;
+    openId = openId === m.id ? null : m.id;
+  };
+  const onRowKey = (e, m) => {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      toggle(m);
+    }
+  };
 
   // Colour a pass-rate cell: full green, partial coral-ish, zero muted.
   const rateClass = (r) => (r >= 0.999 ? "full" : r > 0 ? "partial" : "zero");
@@ -52,7 +71,10 @@
   </header>
 
   <section class="panel">
-    <div class="panel-head">Agentic ranking</div>
+    <div class="panel-head">
+      Agentic ranking
+      <span class="panel-hint">click a row for its per-task breakdown</span>
+    </div>
     <div class="scroll">
       <table>
         <thead>
@@ -70,8 +92,22 @@
         </thead>
         <tbody>
           {#each models as m, i}
-            <tr class:winner={i === 0} class:anchor-row={isAnchor(m)}>
-              <td class="rk">{i + 1}</td>
+            <!-- svelte-ignore a11y_no_static_element_interactions -->
+            <tr
+              class:winner={i === 0}
+              class:anchor-row={isAnchor(m)}
+              class:expandable={hasBreakdown(m)}
+              class:open={openId === m.id}
+              role={hasBreakdown(m) ? "button" : undefined}
+              tabindex={hasBreakdown(m) ? 0 : undefined}
+              aria-expanded={hasBreakdown(m) ? openId === m.id : undefined}
+              aria-controls={hasBreakdown(m) ? `bd-detail-${i}` : undefined}
+              onclick={() => toggle(m)}
+              onkeydown={(e) => onRowKey(e, m)}
+            >
+              <td class="rk">
+                {#if hasBreakdown(m)}<span class="chev" aria-hidden="true">{openId === m.id ? "▾" : "▸"}</span>{/if}{i + 1}
+              </td>
               <td class="mdl">
                 <span class="name">{shortName(m.id)}</span>
                 <span class="slug">{m.id}</span>
@@ -90,6 +126,39 @@
                 <span class="pill {toolLabel(m.tool_use_ok)}">{toolLabel(m.tool_use_ok)}</span>
               </td>
             </tr>
+            {#if openId === m.id && hasBreakdown(m)}
+              <tr class="detail-row" id={`bd-detail-${i}`}>
+                <td colspan="9">
+                  <div class="detail">
+                    <div class="detail-head">
+                      Per-task breakdown
+                      <span class="detail-sub">solved {solvedCount(m)}/{m.tasks.length}</span>
+                    </div>
+                    <ul class="bd">
+                      {#each m.tasks as bt (bt.id)}
+                        {@const meta = taskById[bt.id]}
+                        <li>
+                          <span class="bd-status {bt.passed ? 'pass' : 'fail'}">{bt.passed ? "PASS" : "FAIL"}</span>
+                          <span class="bd-main">
+                            <span class="bd-id">{bt.id}</span>
+                            {#if meta?.real_test}
+                              <span class="tag real">repo test</span>
+                            {:else if meta}
+                              <span class="tag synth">behavioural</span>
+                            {/if}
+                          </span>
+                          <span class="bd-nums mono">
+                            <span>{num(bt.tokens)} tok</span>
+                            <span>{bt.turns} turns</span>
+                            <span>{secs(bt.latency_ms)}</span>
+                          </span>
+                        </li>
+                      {/each}
+                    </ul>
+                  </div>
+                </td>
+              </tr>
+            {/if}
           {/each}
         </tbody>
       </table>
@@ -150,7 +219,6 @@
   .hero {
     border: 2px solid var(--ink);
     background: var(--paper);
-    box-shadow: var(--shadow-hard-lg);
     padding: 24px 22px;
     margin-bottom: 26px;
   }
@@ -196,7 +264,6 @@
   .panel {
     border: 2px solid var(--ink);
     background: var(--paper);
-    box-shadow: var(--shadow-hard);
     margin-bottom: 26px;
   }
   .panel-head {
@@ -208,6 +275,15 @@
     padding: 12px 16px;
     border-bottom: 2px solid var(--ink);
     background: var(--bg-elev);
+  }
+  .panel-hint {
+    float: right;
+    font-family: var(--mono);
+    font-size: 10.5px;
+    font-weight: 400;
+    letter-spacing: 0.04em;
+    text-transform: none;
+    color: var(--ink-3);
   }
 
   /* ── Table ────────────────────────────── */
@@ -255,9 +331,82 @@
 
   tr.winner td { background: var(--accent); }
   tr.winner td.rk { color: var(--ink); }
-  tr:not(.winner):hover td { background: var(--bg-elev); }
   /* Claude anchors: the paid baseline you are deciding whether to replace. */
   tr.anchor-row:not(.winner) td.rk { box-shadow: inset 3px 0 0 var(--blue); }
+
+  /* Expandable rows: the hover/highlight is now a real affordance (click or Enter
+     opens the per-task deep-dive) rather than a dead visual. */
+  tr.expandable { cursor: pointer; }
+  tr.expandable:not(.winner):hover td,
+  tr.expandable.open:not(.winner) td { background: var(--bg-elev); }
+  tr.expandable:focus-visible {
+    outline: 2px solid var(--ink);
+    outline-offset: -2px;
+  }
+  .chev {
+    font-family: var(--mono);
+    font-size: 10px;
+    color: var(--ink-3);
+    margin-right: 4px;
+  }
+  tr.open .chev { color: var(--ink); }
+
+  /* Deep-dive detail row */
+  .detail-row td {
+    padding: 0;
+    text-align: left;
+    background: var(--cream);
+    border-bottom: 1px solid var(--rule);
+  }
+  .detail { padding: 14px 16px 16px; }
+  .detail-head {
+    font-family: var(--mono);
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: var(--ink-3);
+    margin-bottom: 10px;
+  }
+  .detail-sub { margin-left: 8px; color: var(--ink-2); }
+  .bd { display: flex; flex-direction: column; gap: 6px; }
+  .bd li {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 7px 10px;
+    background: var(--paper);
+    border: 1px solid var(--rule-2);
+  }
+  .bd-status {
+    font-family: var(--mono);
+    font-size: 10.5px;
+    font-weight: 700;
+    letter-spacing: 0.06em;
+    border: 1.5px solid var(--ink);
+    padding: 1px 6px;
+    flex-shrink: 0;
+    width: 46px;
+    text-align: center;
+  }
+  .bd-status.pass { background: var(--green); }
+  .bd-status.fail { background: var(--coral); color: var(--paper); }
+  .bd-main { display: flex; align-items: center; gap: 6px; min-width: 0; flex: 1; }
+  .bd-id {
+    font-family: var(--mono);
+    font-size: 12.5px;
+    font-weight: 700;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .bd-nums {
+    display: flex;
+    gap: 12px;
+    margin-left: auto;
+    font-size: 11.5px;
+    color: var(--ink-3);
+    flex-shrink: 0;
+  }
 
   /* pass-rate cell */
   .rate { font-family: var(--mono); font-weight: 700; font-size: 15px; }
@@ -347,5 +496,7 @@
   @media (max-width: 560px) {
     .slug { display: none; }
     .hero { padding: 20px 16px; }
+    .bd li { flex-wrap: wrap; }
+    .bd-nums { margin-left: 0; width: 100%; }
   }
 </style>


### PR DESCRIPTION
## What

The LLM leaderboard rows are now clickable and expand into a **per-task breakdown**: which of the graded tasks each model passed or failed, plus the tokens, turns, and wall-time it spent on each. This replaces a hover highlight that faked a click affordance the page never had.

Also: dropped the neo-brutalist offset shadows from the hero and panels (borders only now), and wired proper disclosure a11y (`role="button"`, keyboard toggle, `aria-expanded`/`aria-controls`).

## How

- **`bench/cli.py`** — `_write_leaderboard_json` embeds a `tasks` array per model from the agentic cells it already aggregates.
- **Defensive scoping** — the agentic aggregation is now scoped to tasks in the current task set (`current_agentic_ids`), matching the per-task and per-model breakdowns that were already scoped. Guards against a future removed task's cells lingering in the durable results cache (same harness version, so the version filter misses them) inflating `n` or skewing medians. With the current 7-task set the regenerated aggregates are **byte-identical** to the published `leaderboard.json`, now with the matrix added.
- **`+page.svelte`** — accordion expand, shadow removal, a11y, graceful degradation if a `leaderboard.json` lacks the new field.

## Verification

- Regenerated over the current 7-task set (rebased onto `ea31bb107`, which added `flights-module-01` and fixed the `real_test` flag). Aggregates match the published leaderboard exactly; only the per-model `tasks[]` arrays are new.
- For all models `len(tasks) == n == 7`, matrix sorted by task id, `real_test` flags follow the `source_commit` definition (slo + flights = behavioural).
- New assertion in `cli_test.py` covers the `tasks[]` field.
- Independent review: no correctness issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)