### PR TITLE
chore(monolith-public): bump chart to 0.82.10 to deploy the leaderboard deep-dive

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.82.9
+version: 0.82.10
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.82.9
+      targetRevision: 0.82.10
       helm:
         releaseName: monolith-public
         valueFiles:


### PR DESCRIPTION
Follow-up to #3011. That PR merged without a chart-version-bot bump (the bot lands its bump on the PR branch during CI, and the rebased fast-merge slipped through without one), so the monolith-public chart stayed at 0.82.9 and the new leaderboard frontend build was never pulled by ArgoCD.

This bumps `Chart.yaml` version and `deploy/application.yaml` `targetRevision` together (manual-bump convention) to 0.82.10, rolling monolith-public onto the rebuilt image with the per-task deep-dive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)