### PR TITLE
build(fc-invoke): bump chart to 0.4.2 to deploy the egress guardrail

### DIFF
--- a/projects/firecracker/substrate/chart/Chart.yaml
+++ b/projects/firecracker/substrate/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: fc-invoke
 description: Node-affine Firecracker invoke daemon that dispatches HTTP invocations to a pool of warm-base microVMs across named workloads (POST /invoke/{workload}, GET /healthz)
 type: application
-version: 0.4.1
+version: 0.4.2

--- a/projects/firecracker/substrate/deploy/application.yaml
+++ b/projects/firecracker/substrate/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tags pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: fc-invoke
-      targetRevision: 0.4.1
+      targetRevision: 0.4.2
       helm:
         valueFiles:
           - $values/projects/firecracker/substrate/deploy/values.yaml


### PR DESCRIPTION
Deploys WS4 (#3010). The chart-version-bot bump raced behind auto-merge, leaving fc-invoke at 0.4.1 with the egress guardrail undeployed. Manual bump of Chart.yaml + application targetRevision in sync (CLAUDE.md-sanctioned). On merge, main CI republishes fc-invoke 0.4.2 with the new egress-proxy + guest images pinned, and ArgoCD rolls it out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)