### PR TITLE
fix(git-mirror): add imagePullSecrets for the private GHCR image

### DIFF
--- a/projects/firecracker/git-mirror/chart/Chart.yaml
+++ b/projects/firecracker/git-mirror/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: git-mirror
 description: Hot git mirror for Firecracker agent workspaces on node-4. Keeps bare clones warm via a supervisor loop; serves git:// (port 9418) with a pre-receive hook restricting writes to refs/agents/**.
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: "0.1.0"
 maintainers:
   - name: jomcgi

--- a/projects/firecracker/git-mirror/chart/templates/deployment.yaml
+++ b/projects/firecracker/git-mirror/chart/templates/deployment.yaml
@@ -25,6 +25,13 @@ spec:
       {{- end }}
     spec:
       serviceAccountName: {{ include "git-mirror.serviceAccountName" . }}
+      {{- if .Values.imagePullSecret.enabled }}
+      # The git-mirror image is private (GHCR); reference the shared pull secret
+      # (a dockerconfigjson OnePasswordItem created by the fc-invoke chart in this
+      # namespace). Without it the kubelet gets a 401 and ImagePullBackOff.
+      imagePullSecrets:
+        - name: {{ .Values.imagePullSecret.name }}
+      {{- end }}
       nodeSelector:
         {{- toYaml .Values.nodeSelector | nindent 8 }}
       {{- with .Values.tolerations }}

--- a/projects/firecracker/git-mirror/chart/values.yaml
+++ b/projects/firecracker/git-mirror/chart/values.yaml
@@ -82,3 +82,11 @@ resources:
 serviceAccount:
   create: false
   name: ""
+
+# Reference the shared GHCR pull secret so the kubelet can pull the private
+# git-mirror image. The secret (a dockerconfigjson OnePasswordItem) is created by
+# the fc-invoke chart in this namespace; git-mirror only references it, it does
+# not create it.
+imagePullSecret:
+  enabled: true
+  name: ghcr-imagepull-secret

--- a/projects/firecracker/git-mirror/deploy/application.yaml
+++ b/projects/firecracker/git-mirror/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: git-mirror
-      targetRevision: 0.1.0
+      targetRevision: 0.1.1
       helm:
         releaseName: git-mirror
         valueFiles:


### PR DESCRIPTION
The git-mirror pod is in ImagePullBackOff (401 pulling the private image) because WS1's deployment omitted imagePullSecrets. Reference the shared `ghcr-imagepull-secret` (created by the fc-invoke chart in this namespace). Chart 0.1.0 -> 0.1.1 + application targetRevision bumped in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)