### PR TITLE
feat(goosecracker): git mirror hydration (WS2) + scratch-ref recording (WS3)

### DIFF
--- a/projects/firecracker/goosecracker/guest-init/cmd/main.go
+++ b/projects/firecracker/goosecracker/guest-init/cmd/main.go
@@ -198,9 +198,16 @@ func (r *execRunner) Run(ctx context.Context, argv []string, env map[string]stri
 	return sb.String(), waitErr
 }
 
-// Clone clones mirror into dest and checks out ref via the shared ExecGit.
+// Clone clones mirror into dest (shallow partial clone) and checks out ref via
+// the shared ExecGit.
 func (r *execRunner) Clone(ctx context.Context, mirror, ref, dest string) error {
 	return (&capabilities.ExecGit{}).Clone(ctx, mirror, ref, dest)
+}
+
+// RecordScratch commits workspace changes and pushes them to
+// refs/agents/<session> on the mirror (WS3 scratch-ref recording).
+func (r *execRunner) RecordScratch(ctx context.Context, workspace, mirrorURL, session string) (string, error) {
+	return (&capabilities.ExecGit{}).RecordScratch(ctx, workspace, mirrorURL, session)
 }
 
 // execSessionStore is the production handler.SessionStore. It persists goose's

--- a/projects/firecracker/goosecracker/guest-init/internal/handler/handler.go
+++ b/projects/firecracker/goosecracker/guest-init/internal/handler/handler.go
@@ -53,29 +53,39 @@ type AgentRequest struct {
 }
 
 // AgentResult is the JSON body of a successful /invoke response. Status is "ok"
-// when goose ran to completion and "error" when the clone or goose run failed;
-// both are returned at HTTP 200, because a run that ran but failed is data, not
-// a transport error. Only an undecodable request body yields a handler error
+// when goose ran to completion and "error" when the goose run failed; both are
+// returned at HTTP 200, because a run that ran but failed is data, not a
+// transport error. Only an undecodable request body yields a handler error
 // (which the shim maps to 502). SessionDb carries the updated goose session back
-// (base64) so the orchestrator can persist it for the next resume.
+// (base64) so the orchestrator can persist it for the next resume. RecordedRef
+// is the git ref pushed to the mirror on a successful scratch-ref recording
+// (WS3); empty when no changes were committed or no mirror is configured.
 type AgentResult struct {
 	Status       string `json:"status"`                 // "ok" | "error"
 	Result       string `json:"result,omitempty"`       // goose output captured from the run
 	Error        string `json:"error,omitempty"`        // failure detail when Status == "error"
 	SessionDb    string `json:"sessionDb,omitempty"`    // base64 updated sessions.db to persist
 	ArtifactHTML string `json:"artifactHtml,omitempty"` // the built artifact HTML for the orchestrator to publish (ADR 024)
+	RecordedRef  string `json:"recordedRef,omitempty"`  // git ref pushed to the mirror (WS3); empty when no changes
 }
 
-// Runner is the seam the handler uses to run goose and (optionally) clone a git
-// mirror. The production implementation shells goose and git via os/exec; tests
-// inject a fake so the handler is exercised with no goose/git binary present.
+// Runner is the seam the handler uses to run goose and (optionally) clone a
+// git mirror or record workspace changes after a run. The production
+// implementation shells goose and git via os/exec; tests inject a fake so the
+// handler is exercised with no goose/git binary present.
 type Runner interface {
 	// Run executes argv with env overlaid on the process environment, invoking
 	// onLine for each output line as it is produced, and returns the full
 	// captured output. A non-nil error means goose ran but exited non-zero.
 	Run(ctx context.Context, argv []string, env map[string]string, onLine func(string)) (string, error)
-	// Clone replicates the repository at mirror into dest and checks out ref.
+	// Clone replicates the repository at mirror into dest (shallow partial
+	// clone) and checks out ref.
 	Clone(ctx context.Context, mirror, ref, dest string) error
+	// RecordScratch commits any workspace changes and pushes them to
+	// refs/agents/<session> on mirrorURL (WS3 scratch-ref recording). Returns
+	// the pushed ref name, or an empty string when nothing was committed. The
+	// caller treats a non-nil error as best-effort: log and continue.
+	RecordScratch(ctx context.Context, workspace, mirrorURL, session string) (string, error)
 }
 
 // SessionStore hydrates and exports goose's SQLite session db for stateful resume
@@ -122,12 +132,15 @@ func New(runner Runner, opts ...Option) shim.Handler {
 			return nil, fmt.Errorf("handler: decode agent request: %w", err)
 		}
 
-		// Seed the workspace from the git mirror before goose starts, so the recipe
-		// operates on a checked-out tree. A clone failure is a run failure, not a
-		// transport error, so it is reported as an error result at 200.
+		// Seed the workspace from the git mirror before goose starts so the recipe
+		// operates on a checked-out tree. Clone failures are soft (best-effort per
+		// ADR 026 risk row): log and continue with an empty workspace rather than
+		// aborting the run. An agent can still complete useful work even without the
+		// checked-out source.
 		if req.GitMirror != "" {
 			if err := runner.Clone(ctx, req.GitMirror, req.GitRef, Workspace); err != nil {
-				return jsonResult(AgentResult{Status: "error", Error: fmt.Sprintf("clone %s: %v", req.GitMirror, err)})
+				slog.Warn("handler: mirror clone failed; continuing with empty workspace",
+					"mirror", req.GitMirror, "ref", req.GitRef, "err", err)
 			}
 		}
 
@@ -187,6 +200,21 @@ func New(runner Runner, opts ...Option) shim.Handler {
 		if html := readArtifact(); len(html) > 0 {
 			result.ArtifactHTML = string(html)
 		}
+
+		// WS3 - Scratch-ref recording: commit workspace changes and push them to
+		// refs/agents/<session> on the mirror. Best-effort: a commit/push failure
+		// must not fail a run that already succeeded. The mirror is the same one we
+		// hydrated from (WS2), so it already has the base commit and the push is
+		// thin.
+		if req.GitMirror != "" {
+			if ref, err := runner.RecordScratch(ctx, Workspace, req.GitMirror, req.Session); err != nil {
+				slog.Warn("handler: scratch ref recording failed; run still succeeded",
+					"mirror", req.GitMirror, "session", req.Session, "err", err)
+			} else if ref != "" {
+				result.RecordedRef = ref
+			}
+		}
+
 		return jsonResult(result)
 	}
 }

--- a/projects/firecracker/goosecracker/guest-init/internal/handler/handler_test.go
+++ b/projects/firecracker/goosecracker/guest-init/internal/handler/handler_test.go
@@ -17,8 +17,8 @@ import (
 )
 
 // fakeRunner is a Runner test double: it records the argv/env it was invoked
-// with, replays a canned set of output lines through onLine, and reports whether
-// Clone was called and with which args. It runs no real goose or git.
+// with, replays a canned set of output lines through onLine, and records Clone
+// and RecordScratch calls. It runs no real goose or git.
 type fakeRunner struct {
 	lines    []string
 	out      string
@@ -30,6 +30,14 @@ type fakeRunner struct {
 	cloneCall struct {
 		called            bool
 		mirror, ref, dest string
+	}
+
+	// RecordScratch seam: configure the returned ref and error.
+	recordScratchRef  string
+	recordScratchErr  error
+	recordScratchCall struct {
+		called                        bool
+		workspace, mirrorURL, session string
 	}
 }
 
@@ -46,6 +54,14 @@ func (f *fakeRunner) Clone(_ context.Context, mirror, ref, dest string) error {
 	f.cloneCall.called = true
 	f.cloneCall.mirror, f.cloneCall.ref, f.cloneCall.dest = mirror, ref, dest
 	return f.cloneErr // nosemgrep: no-bare-error-return
+}
+
+func (f *fakeRunner) RecordScratch(_ context.Context, workspace, mirrorURL, session string) (string, error) {
+	f.recordScratchCall.called = true
+	f.recordScratchCall.workspace = workspace
+	f.recordScratchCall.mirrorURL = mirrorURL
+	f.recordScratchCall.session = session
+	return f.recordScratchRef, f.recordScratchErr // nosemgrep: no-bare-error-return
 }
 
 // progressSink is an httptest server that records the "chunk" of every progress
@@ -182,11 +198,14 @@ func TestGitMirrorTriggersCloneIntoWorkspace(t *testing.T) {
 	}
 }
 
-func TestCloneFailureIsErrorResultAt200(t *testing.T) {
-	runner := &fakeRunner{cloneErr: io.ErrUnexpectedEOF}
+func TestCloneFailureContinuesWithEmptyWorkspace(t *testing.T) {
+	// Clone failure is soft (best-effort per ADR 026): the run continues with an
+	// empty workspace rather than aborting. The result is "ok" when goose itself
+	// succeeds, even though the mirror clone failed.
+	runner := &fakeRunner{cloneErr: io.ErrUnexpectedEOF, out: "ok despite no workspace"}
 	h := New(runner)
 
-	req := AgentRequest{Recipe: "agent", Task: "t", GitMirror: "https://git/mirror.git"}
+	req := AgentRequest{Recipe: "agent", Task: "t", GitMirror: "git://mirror:9418/repo", GitRef: "main"}
 	body, _ := json.Marshal(req)
 
 	resp, err := invoke(t, h, string(body))
@@ -197,8 +216,132 @@ func TestCloneFailureIsErrorResultAt200(t *testing.T) {
 		t.Fatalf("status = %d, want 200", resp.Status)
 	}
 	res := decodeResult(t, resp)
-	if res.Status != "error" || res.Error == "" {
-		t.Errorf("want error result, got %+v", res)
+	// clone failure is soft: the run must not be reported as an error
+	if res.Status != "ok" {
+		t.Errorf("clone failure should not fail the run (soft-fail); got status %q error %q", res.Status, res.Error)
+	}
+}
+
+// TestHandlerRecordsScratchRefOnSuccess verifies that after a successful goose
+// run the handler calls RecordScratch and populates RecordedRef in the result.
+func TestHandlerRecordsScratchRefOnSuccess(t *testing.T) {
+	r := &fakeRunner{out: "done", recordScratchRef: "refs/agents/sess-5"}
+	h := New(r)
+
+	req := AgentRequest{
+		Recipe:    "agent",
+		Task:      "t",
+		Session:   "sess-5",
+		GitMirror: "git://mirror:9418/repo",
+		GitRef:    "main",
+	}
+	body, _ := json.Marshal(req)
+
+	resp, err := invoke(t, h, string(body))
+	if err != nil {
+		t.Fatalf("handler returned error: %v", err)
+	}
+	res := decodeResult(t, resp)
+	if res.Status != "ok" {
+		t.Fatalf("status = %q, want ok", res.Status)
+	}
+
+	// RecordScratch must have been called with the right args.
+	if !r.recordScratchCall.called {
+		t.Fatal("RecordScratch was not called")
+	}
+	if r.recordScratchCall.workspace != Workspace {
+		t.Errorf("RecordScratch workspace = %q, want %q", r.recordScratchCall.workspace, Workspace)
+	}
+	if r.recordScratchCall.mirrorURL != "git://mirror:9418/repo" {
+		t.Errorf("RecordScratch mirrorURL = %q, want git://mirror:9418/repo", r.recordScratchCall.mirrorURL)
+	}
+	if r.recordScratchCall.session != "sess-5" {
+		t.Errorf("RecordScratch session = %q, want sess-5", r.recordScratchCall.session)
+	}
+
+	// RecordedRef set in the result.
+	if res.RecordedRef != "refs/agents/sess-5" {
+		t.Errorf("RecordedRef = %q, want refs/agents/sess-5", res.RecordedRef)
+	}
+}
+
+// TestHandlerSkipsScratchWhenNoChanges verifies that when RecordScratch returns
+// ("", nil) (workspace clean), RecordedRef is empty in the result.
+func TestHandlerSkipsScratchWhenNoChanges(t *testing.T) {
+	r := &fakeRunner{out: "done", recordScratchRef: ""} // empty ref = no changes
+	h := New(r)
+
+	req := AgentRequest{
+		Recipe:    "agent",
+		Task:      "t",
+		Session:   "sess-6",
+		GitMirror: "git://mirror:9418/repo",
+		GitRef:    "main",
+	}
+	body, _ := json.Marshal(req)
+
+	resp, err := invoke(t, h, string(body))
+	if err != nil {
+		t.Fatalf("handler returned error: %v", err)
+	}
+	res := decodeResult(t, resp)
+	if res.Status != "ok" {
+		t.Fatalf("status = %q, want ok", res.Status)
+	}
+	if res.RecordedRef != "" {
+		t.Errorf("RecordedRef = %q, want empty when no changes", res.RecordedRef)
+	}
+}
+
+// TestHandlerScratchFailureDoesNotFailRun verifies that a RecordScratch error
+// does not fail a run that already succeeded (best-effort, non-fatal).
+func TestHandlerScratchFailureDoesNotFailRun(t *testing.T) {
+	r := &fakeRunner{out: "done", recordScratchErr: io.ErrUnexpectedEOF}
+	h := New(r)
+
+	req := AgentRequest{
+		Recipe:    "agent",
+		Task:      "t",
+		Session:   "sess-7",
+		GitMirror: "git://mirror:9418/repo",
+		GitRef:    "main",
+	}
+	body, _ := json.Marshal(req)
+
+	resp, err := invoke(t, h, string(body))
+	if err != nil {
+		t.Fatalf("handler returned error: %v", err)
+	}
+	res := decodeResult(t, resp)
+	// A RecordScratch failure must not change the run status from "ok".
+	if res.Status != "ok" {
+		t.Errorf("RecordScratch failure should not fail the run; got status %q", res.Status)
+	}
+	if res.RecordedRef != "" {
+		t.Errorf("RecordedRef = %q, want empty on failure", res.RecordedRef)
+	}
+}
+
+// TestHandlerSkipsScratchWhenNoMirrorSet verifies that when no GitMirror is
+// provided, RecordScratch is not called at all.
+func TestHandlerSkipsScratchWhenNoMirrorSet(t *testing.T) {
+	r := &fakeRunner{out: "done"}
+	h := New(r)
+
+	req := AgentRequest{Recipe: "agent", Task: "t", Session: "sess-8"}
+	body, _ := json.Marshal(req)
+
+	resp, err := invoke(t, h, string(body))
+	if err != nil {
+		t.Fatalf("handler returned error: %v", err)
+	}
+	res := decodeResult(t, resp)
+	if res.Status != "ok" {
+		t.Fatalf("status = %q, want ok", res.Status)
+	}
+	if r.recordScratchCall.called {
+		t.Error("RecordScratch must not be called when no GitMirror is set")
 	}
 }
 

--- a/projects/firecracker/substrate/shim/capabilities/git.go
+++ b/projects/firecracker/substrate/shim/capabilities/git.go
@@ -4,18 +4,21 @@ import (
 	"context"
 	"fmt"
 	"os/exec"
+	"strings"
 )
 
 // Git provides the workspace operations a shim hook needs: clone a repository
-// into a guest directory and push local commits back to the origin.
+// into a guest directory and push commits back to a remote with an explicit
+// refspec (WS3 scratch-ref recording).
 type Git interface {
-	// Clone replicates the repository at mirror into dest, then checks out ref.
-	// ref may be a branch name, tag, or commit SHA.
+	// Clone replicates the repository at mirror into dest using a shallow
+	// partial clone (--single-branch --depth=1 --filter=blob:none), then
+	// checks out ref. ref may be a branch name, tag, or commit SHA.
 	Clone(ctx context.Context, mirror, ref, dest string) error
 
-	// Push sends the commits on branch in the repository at dest to its
-	// configured origin remote.
-	Push(ctx context.Context, dest, branch string) error
+	// PushRefspec pushes refspec from the repository at dest to remoteURL.
+	// For the scratch-ref recording path the refspec is "HEAD:refs/agents/<session>".
+	PushRefspec(ctx context.Context, dest, remoteURL, refspec string) error
 }
 
 // runnerFunc is the function signature used to execute a subprocess. The
@@ -54,6 +57,8 @@ func (g *ExecGit) bin() string {
 	return "git"
 }
 
+// run executes a git sub-command and returns only an error. Output bytes are
+// included in the error message when the command fails.
 func (g *ExecGit) run(ctx context.Context, args ...string) error {
 	r := g.runner
 	if r == nil {
@@ -66,10 +71,28 @@ func (g *ExecGit) run(ctx context.Context, args ...string) error {
 	return nil
 }
 
-// Clone clones the repository at mirror into dest, then checks out ref.
-// Using clone-then-checkout means any ref type (branch, tag, full SHA) works.
+// runOutput executes a git sub-command and returns the output bytes. It is
+// used by callers that need to inspect stdout/stderr content (e.g.
+// git status --porcelain for change detection).
+func (g *ExecGit) runOutput(ctx context.Context, args ...string) ([]byte, error) {
+	r := g.runner
+	if r == nil {
+		r = defaultRunner
+	}
+	out, err := r(ctx, g.bin(), args...)
+	if err != nil {
+		return nil, fmt.Errorf("git %v: %w\noutput: %s", args, err, out)
+	}
+	return out, nil
+}
+
+// Clone clones the repository at mirror into dest using a shallow partial
+// clone (--single-branch --depth=1 --filter=blob:none), then checks out ref.
+// The shallow flags keep the clone sub-second against the in-cluster mirror
+// (ADR 026). Both branch names and full SHAs work: clone fetches only the tip
+// commit for the default branch, then checkout selects the requested ref.
 func (g *ExecGit) Clone(ctx context.Context, mirror, ref, dest string) error {
-	if err := g.run(ctx, "clone", mirror, dest); err != nil {
+	if err := g.run(ctx, "clone", "--single-branch", "--depth=1", "--filter=blob:none", mirror, dest); err != nil {
 		return fmt.Errorf("git Clone (clone): %w", err)
 	}
 	if err := g.run(ctx, "-C", dest, "checkout", ref); err != nil {
@@ -78,12 +101,101 @@ func (g *ExecGit) Clone(ctx context.Context, mirror, ref, dest string) error {
 	return nil
 }
 
-// Push pushes the commits on branch in the repository at dest to origin.
-func (g *ExecGit) Push(ctx context.Context, dest, branch string) error {
-	if err := g.run(ctx, "-C", dest, "push", "origin", branch); err != nil {
-		return fmt.Errorf("git Push: %w", err)
+// PushRefspec pushes refspec from the repository at dest to remoteURL.
+// For the WS3 scratch-ref recording path the refspec is
+// "HEAD:refs/agents/<session>" and remoteURL is the in-cluster mirror address.
+func (g *ExecGit) PushRefspec(ctx context.Context, dest, remoteURL, refspec string) error {
+	if err := g.run(ctx, "-C", dest, "push", remoteURL, refspec); err != nil {
+		return fmt.Errorf("git PushRefspec: %w", err)
 	}
 	return nil
+}
+
+// RecordScratch commits any workspace changes and pushes them to
+// refs/agents/<session> on mirrorURL (WS3). It returns the pushed ref name on
+// success, or an empty string when the workspace is clean (nothing to commit).
+// A non-nil error means the commit or push failed; the caller treats this as
+// best-effort and continues without failing the run.
+//
+// Shallow-push validity: the workspace was cloned shallow from the same mirror,
+// so the mirror already has the base commit. If git refuses the push due to a
+// shallow boundary, RecordScratch unshallows the clone and retries once.
+func (g *ExecGit) RecordScratch(ctx context.Context, workspace, mirrorURL, session string) (string, error) {
+	ref := "refs/agents/" + sanitizeRefComponent(session)
+
+	// Set a bot git identity so the commit is attributed correctly.
+	if err := g.run(ctx, "-C", workspace, "config", "user.name", "goosecracker"); err != nil {
+		return "", fmt.Errorf("git RecordScratch (config name): %w", err)
+	}
+	if err := g.run(ctx, "-C", workspace, "config", "user.email", "agent@jomcgi.dev"); err != nil {
+		return "", fmt.Errorf("git RecordScratch (config email): %w", err)
+	}
+
+	// Stage all workspace changes (new files, modifications, deletions).
+	if err := g.run(ctx, "-C", workspace, "add", "-A"); err != nil {
+		return "", fmt.Errorf("git RecordScratch (add): %w", err)
+	}
+
+	// Check for staged changes via git status --porcelain. Empty output means
+	// the workspace is clean; nothing to commit or push.
+	out, err := g.runOutput(ctx, "-C", workspace, "status", "--porcelain")
+	if err != nil {
+		return "", fmt.Errorf("git RecordScratch (status): %w", err)
+	}
+	if len(strings.TrimSpace(string(out))) == 0 {
+		return "", nil // no changes; nothing to push
+	}
+
+	// Commit with a message that identifies the session for later retrieval.
+	msg := "agent " + session + ": workspace changes"
+	if err := g.run(ctx, "-C", workspace, "commit", "-m", msg); err != nil {
+		return "", fmt.Errorf("git RecordScratch (commit): %w", err)
+	}
+
+	// Push to the mirror. The workspace was cloned shallow from the same mirror
+	// (WS2), so the mirror already has the base commit and the push should
+	// succeed. If git refuses due to the shallow boundary, unshallow the clone
+	// and retry once.
+	refspec := "HEAD:" + ref
+	if err := g.PushRefspec(ctx, workspace, mirrorURL, refspec); err != nil {
+		// Attempt to unshallow the clone and retry the push.
+		if fetchErr := g.run(ctx, "-C", workspace, "fetch", "--unshallow"); fetchErr != nil {
+			return "", fmt.Errorf(
+				"git RecordScratch (push failed, unshallow also failed): push=%w unshallow=%v",
+				err, fetchErr,
+			)
+		}
+		if err := g.PushRefspec(ctx, workspace, mirrorURL, refspec); err != nil {
+			return "", fmt.Errorf("git RecordScratch (push after unshallow): %w", err)
+		}
+	}
+	return ref, nil
+}
+
+// sanitizeRefComponent replaces characters that are invalid in a git ref
+// component with a hyphen, and trims leading/trailing hyphens and dots. A
+// Discord snowflake (all digits) and a UUID (hex + hyphens) both pass through
+// unchanged; only adversarial or unusual session ids are rewritten.
+func sanitizeRefComponent(s string) string {
+	var b strings.Builder
+	for _, c := range s {
+		switch {
+		case c >= 'a' && c <= 'z', c >= 'A' && c <= 'Z', c >= '0' && c <= '9',
+			c == '-', c == '_', c == '.':
+			b.WriteRune(c)
+		default:
+			b.WriteByte('-')
+		}
+	}
+	result := strings.Trim(b.String(), "-.")
+	// Remove double-dot sequences, which are invalid in git refs.
+	for strings.Contains(result, "..") {
+		result = strings.ReplaceAll(result, "..", ".")
+	}
+	if result == "" {
+		return "session"
+	}
+	return result
 }
 
 // Compile-time check: ExecGit satisfies Git.

--- a/projects/firecracker/substrate/shim/capabilities/git_test.go
+++ b/projects/firecracker/substrate/shim/capabilities/git_test.go
@@ -2,15 +2,24 @@ package capabilities
 
 import (
 	"context"
+	"errors"
+	"strings"
 	"testing"
 )
 
+// spyResponse holds the (output, error) pair a fakeRunnerSpy returns for one
+// git call. It powers per-call response sequences in RecordScratch tests.
+type spyResponse struct {
+	output []byte
+	err    error
+}
+
 // fakeGit is a test double for the Git interface that records every call made
-// to it. Use it in handler tests to assert on the Clone/Push arguments without
-// touching the filesystem or a real git process.
+// to it. Use it in handler tests to assert on the Clone/PushRefspec arguments
+// without touching the filesystem or a real git process.
 type fakeGit struct {
-	cloneCalls []cloneCall
-	pushCalls  []pushCall
+	cloneCalls       []cloneCall
+	pushRefspecCalls []pushRefspecCall
 }
 
 type cloneCall struct {
@@ -19,9 +28,10 @@ type cloneCall struct {
 	Dest   string
 }
 
-type pushCall struct {
-	Dest   string
-	Branch string
+type pushRefspecCall struct {
+	Dest      string
+	RemoteURL string
+	Refspec   string
 }
 
 func (f *fakeGit) Clone(_ context.Context, mirror, ref, dest string) error {
@@ -29,8 +39,8 @@ func (f *fakeGit) Clone(_ context.Context, mirror, ref, dest string) error {
 	return nil
 }
 
-func (f *fakeGit) Push(_ context.Context, dest, branch string) error {
-	f.pushCalls = append(f.pushCalls, pushCall{Dest: dest, Branch: branch})
+func (f *fakeGit) PushRefspec(_ context.Context, dest, remoteURL, refspec string) error {
+	f.pushRefspecCalls = append(f.pushRefspecCalls, pushRefspecCall{Dest: dest, RemoteURL: remoteURL, Refspec: refspec})
 	return nil
 }
 
@@ -38,30 +48,40 @@ func (f *fakeGit) Push(_ context.Context, dest, branch string) error {
 var _ Git = (*fakeGit)(nil)
 
 // fakeRunnerSpy records every (name, args) invocation of ExecGit's runner seam
-// and returns a configurable output/error pair. Inject it via ExecGit.runner.
+// and returns either per-call responses (responses slice) or a single default
+// output/error pair. Inject it via ExecGit.runner.
 type fakeRunnerSpy struct {
-	calls  [][]string // each element is [name, arg0, arg1, ...]
-	output []byte
-	err    error
+	calls     [][]string    // each element is [name, arg0, arg1, ...]
+	responses []spyResponse // per-call; last entry is reused once exhausted
+	output    []byte        // default output when responses is nil or empty
+	err       error         // default error when responses is nil or empty
 }
 
 func (f *fakeRunnerSpy) run(ctx context.Context, name string, args ...string) ([]byte, error) {
 	call := make([]string, 0, 1+len(args))
 	call = append(call, name)
 	call = append(call, args...)
+	idx := len(f.calls)
 	f.calls = append(f.calls, call)
+	if len(f.responses) > 0 {
+		ri := idx
+		if ri >= len(f.responses) {
+			ri = len(f.responses) - 1
+		}
+		return f.responses[ri].output, f.responses[ri].err
+	}
 	return f.output, f.err
 }
 
-// TestExecGitCloneInvokesGit verifies that Clone issues "git clone <mirror>
-// <dest>" followed by "git -C <dest> checkout <ref>", without spawning a real
-// process.
-func TestExecGitCloneInvokesGit(t *testing.T) {
+// TestExecGitClonePassesShallowFlags verifies that Clone issues a shallow
+// partial clone (--single-branch --depth=1 --filter=blob:none) followed by
+// "git -C <dest> checkout <ref>", without spawning a real process.
+func TestExecGitClonePassesShallowFlags(t *testing.T) {
 	spy := &fakeRunnerSpy{}
 	g := &ExecGit{runner: spy.run}
 
 	ctx := context.Background()
-	if err := g.Clone(ctx, "https://github.com/example/repo", "main", "/tmp/dst"); err != nil {
+	if err := g.Clone(ctx, "git://mirror:9418/homelab", "main", "/tmp/dst"); err != nil {
 		t.Fatalf("Clone: %v", err)
 	}
 
@@ -69,10 +89,17 @@ func TestExecGitCloneInvokesGit(t *testing.T) {
 		t.Fatalf("expected 2 git invocations, got %d: %v", len(spy.calls), spy.calls)
 	}
 
-	// First call: git clone <mirror> <dest>
+	// First call: git clone --single-branch --depth=1 --filter=blob:none <mirror> <dest>
 	cloneArgs := spy.calls[0]
-	if len(cloneArgs) < 4 || cloneArgs[1] != "clone" || cloneArgs[2] != "https://github.com/example/repo" || cloneArgs[3] != "/tmp/dst" {
-		t.Errorf("first call = %v, want [git clone <mirror> <dest>]", cloneArgs)
+	// Verify key positions: command is "clone", shallow flags are present, mirror and dest are last.
+	if len(cloneArgs) < 2 || cloneArgs[1] != "clone" {
+		t.Fatalf("first call must be git clone, got %v", cloneArgs)
+	}
+	joined := strings.Join(cloneArgs, " ")
+	for _, want := range []string{"--single-branch", "--depth=1", "--filter=blob:none", "git://mirror:9418/homelab", "/tmp/dst"} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("clone call %q missing %q", joined, want)
+		}
 	}
 
 	// Second call: git -C <dest> checkout <ref>
@@ -82,29 +109,171 @@ func TestExecGitCloneInvokesGit(t *testing.T) {
 	}
 }
 
-// TestExecGitPushInvokesGit verifies that Push issues
-// "git -C <dest> push origin <branch>".
-func TestExecGitPushInvokesGit(t *testing.T) {
+// TestExecGitPushRefspecInvokesGit verifies that PushRefspec issues
+// "git -C <dest> push <remoteURL> <refspec>".
+func TestExecGitPushRefspecInvokesGit(t *testing.T) {
 	spy := &fakeRunnerSpy{}
 	g := &ExecGit{runner: spy.run}
 
 	ctx := context.Background()
-	if err := g.Push(ctx, "/tmp/dst", "my-branch"); err != nil {
-		t.Fatalf("Push: %v", err)
+	if err := g.PushRefspec(ctx, "/tmp/dst", "git://mirror:9418/homelab", "HEAD:refs/agents/sess-1"); err != nil {
+		t.Fatalf("PushRefspec: %v", err)
 	}
 
 	if len(spy.calls) != 1 {
 		t.Fatalf("expected 1 git invocation, got %d: %v", len(spy.calls), spy.calls)
 	}
-	// Expect: git -C /tmp/dst push origin my-branch
+	// Expect: git -C /tmp/dst push git://mirror:9418/homelab HEAD:refs/agents/sess-1
 	pushArgs := spy.calls[0]
-	if len(pushArgs) < 6 || pushArgs[1] != "-C" || pushArgs[2] != "/tmp/dst" || pushArgs[3] != "push" || pushArgs[4] != "origin" || pushArgs[5] != "my-branch" {
-		t.Errorf("push call = %v, want [git -C <dest> push origin <branch>]", pushArgs)
+	if len(pushArgs) < 6 ||
+		pushArgs[1] != "-C" ||
+		pushArgs[2] != "/tmp/dst" ||
+		pushArgs[3] != "push" ||
+		pushArgs[4] != "git://mirror:9418/homelab" ||
+		pushArgs[5] != "HEAD:refs/agents/sess-1" {
+		t.Errorf("push call = %v, want [git -C <dest> push <remoteURL> <refspec>]", pushArgs)
+	}
+}
+
+// TestExecGitRecordScratchSequencesGitCommands verifies the full command
+// sequence for a workspace with staged changes: config, add, status (returns
+// non-empty), commit, push.
+func TestExecGitRecordScratchSequencesGitCommands(t *testing.T) {
+	spy := &fakeRunnerSpy{
+		responses: []spyResponse{
+			{nil, nil},                    // git config user.name
+			{nil, nil},                    // git config user.email
+			{nil, nil},                    // git add -A
+			{[]byte("M  file.go\n"), nil}, // git status --porcelain: has changes
+			{nil, nil},                    // git commit
+			{nil, nil},                    // git push
+		},
+	}
+	g := &ExecGit{runner: spy.run}
+
+	ref, err := g.RecordScratch(context.Background(), "/ws", "git://mirror:9418/repo", "sess-1")
+	if err != nil {
+		t.Fatalf("RecordScratch: %v", err)
+	}
+	if ref == "" {
+		t.Error("expected non-empty ref when workspace has changes")
+	}
+	if ref != "refs/agents/sess-1" {
+		t.Errorf("ref = %q, want refs/agents/sess-1", ref)
+	}
+
+	// Verify push was called with the right remote URL and refspec.
+	var pushCall []string
+	for _, c := range spy.calls {
+		if len(c) > 3 && c[3] == "push" {
+			pushCall = c
+		}
+	}
+	if pushCall == nil {
+		t.Fatal("no push call found in git invocations")
+	}
+	if len(pushCall) < 6 || pushCall[4] != "git://mirror:9418/repo" || pushCall[5] != "HEAD:refs/agents/sess-1" {
+		t.Errorf("push call = %v, want remote=git://mirror:9418/repo refspec=HEAD:refs/agents/sess-1", pushCall)
+	}
+}
+
+// TestExecGitRecordScratchNoChangesSkipsCommit verifies that RecordScratch
+// returns ("", nil) and calls no commit or push when git status reports a
+// clean workspace.
+func TestExecGitRecordScratchNoChangesSkipsCommit(t *testing.T) {
+	spy := &fakeRunnerSpy{
+		responses: []spyResponse{
+			{nil, nil},        // git config user.name
+			{nil, nil},        // git config user.email
+			{nil, nil},        // git add -A
+			{[]byte(""), nil}, // git status --porcelain: empty = no changes
+		},
+	}
+	g := &ExecGit{runner: spy.run}
+
+	ref, err := g.RecordScratch(context.Background(), "/ws", "git://mirror:9418/repo", "sess-2")
+	if err != nil {
+		t.Fatalf("RecordScratch (no changes): %v", err)
+	}
+	if ref != "" {
+		t.Errorf("expected empty ref when no changes, got %q", ref)
+	}
+
+	// No commit or push should have been issued.
+	for _, c := range spy.calls {
+		joined := strings.Join(c, " ")
+		if strings.Contains(joined, "commit") || strings.Contains(joined, "push") {
+			t.Errorf("unexpected git call when workspace is clean: %v", c)
+		}
+	}
+}
+
+// TestExecGitRecordScratchUnshallowFallback verifies that when the initial
+// push fails, RecordScratch unshallows the clone and retries the push.
+func TestExecGitRecordScratchUnshallowFallback(t *testing.T) {
+	pushErr := errors.New("shallow update not allowed")
+	spy := &fakeRunnerSpy{
+		responses: []spyResponse{
+			{nil, nil},                    // git config user.name
+			{nil, nil},                    // git config user.email
+			{nil, nil},                    // git add -A
+			{[]byte("M  file.go\n"), nil}, // git status --porcelain
+			{nil, nil},                    // git commit
+			{nil, pushErr},                // git push: first attempt fails
+			{nil, nil},                    // git fetch --unshallow
+			{nil, nil},                    // git push: retry after unshallow
+		},
+	}
+	g := &ExecGit{runner: spy.run}
+
+	ref, err := g.RecordScratch(context.Background(), "/ws", "git://mirror:9418/repo", "sess-3")
+	if err != nil {
+		t.Fatalf("RecordScratch (unshallow fallback): %v", err)
+	}
+	if ref == "" {
+		t.Error("expected non-empty ref after successful retry")
+	}
+
+	// Verify fetch --unshallow was called.
+	var sawUnshallow bool
+	for _, c := range spy.calls {
+		if len(c) >= 4 && c[3] == "fetch" && strings.Join(c, " ") != "" {
+			joined := strings.Join(c, " ")
+			if strings.Contains(joined, "--unshallow") {
+				sawUnshallow = true
+			}
+		}
+	}
+	if !sawUnshallow {
+		t.Error("expected git fetch --unshallow to be called after push failure")
+	}
+}
+
+// TestSanitizeRefComponent verifies the sanitize helper for common session id
+// shapes (snowflake, UUID, adversarial input).
+func TestSanitizeRefComponent(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"123456789012345678", "123456789012345678"}, // Discord snowflake (all digits)
+		{"a1b2c3d4-e5f6-7890", "a1b2c3d4-e5f6-7890"}, // UUID-like
+		{"s-abc123def456", "s-abc123def456"},         // generated session id
+		{"feat/thing", "feat-thing"},                 // slash replaced
+		{"has space", "has-space"},                   // space replaced
+		{"", "session"},                              // empty fallback
+		{"a..b", "a.b"},                              // double-dot collapsed
+	}
+	for _, c := range cases {
+		got := sanitizeRefComponent(c.in)
+		if got != c.want {
+			t.Errorf("sanitizeRefComponent(%q) = %q, want %q", c.in, got, c.want)
+		}
 	}
 }
 
 // TestFakeGitRecordsCalls verifies the fakeGit double faithfully records every
-// Clone and Push invocation for use in handler tests.
+// Clone and PushRefspec invocation for use in handler tests.
 func TestFakeGitRecordsCalls(t *testing.T) {
 	ctx := context.Background()
 	g := &fakeGit{}
@@ -112,23 +281,23 @@ func TestFakeGitRecordsCalls(t *testing.T) {
 	if err := g.Clone(ctx, "mirror-url", "sha1abc", "/dst"); err != nil {
 		t.Fatalf("Clone: %v", err)
 	}
-	if err := g.Push(ctx, "/dst", "feat/x"); err != nil {
-		t.Fatalf("Push: %v", err)
+	if err := g.PushRefspec(ctx, "/dst", "git://mirror:9418/repo", "HEAD:refs/agents/s1"); err != nil {
+		t.Fatalf("PushRefspec: %v", err)
 	}
 
 	if len(g.cloneCalls) != 1 {
 		t.Fatalf("cloneCalls = %d, want 1", len(g.cloneCalls))
 	}
-	want := cloneCall{Mirror: "mirror-url", Ref: "sha1abc", Dest: "/dst"}
-	if g.cloneCalls[0] != want {
-		t.Errorf("cloneCall = %+v, want %+v", g.cloneCalls[0], want)
+	wantClone := cloneCall{Mirror: "mirror-url", Ref: "sha1abc", Dest: "/dst"}
+	if g.cloneCalls[0] != wantClone {
+		t.Errorf("cloneCall = %+v, want %+v", g.cloneCalls[0], wantClone)
 	}
 
-	if len(g.pushCalls) != 1 {
-		t.Fatalf("pushCalls = %d, want 1", len(g.pushCalls))
+	if len(g.pushRefspecCalls) != 1 {
+		t.Fatalf("pushRefspecCalls = %d, want 1", len(g.pushRefspecCalls))
 	}
-	wantPush := pushCall{Dest: "/dst", Branch: "feat/x"}
-	if g.pushCalls[0] != wantPush {
-		t.Errorf("pushCall = %+v, want %+v", g.pushCalls[0], wantPush)
+	wantPush := pushRefspecCall{Dest: "/dst", RemoteURL: "git://mirror:9418/repo", Refspec: "HEAD:refs/agents/s1"}
+	if g.pushRefspecCalls[0] != wantPush {
+		t.Errorf("pushRefspecCall = %+v, want %+v", g.pushRefspecCalls[0], wantPush)
 	}
 }

--- a/projects/monolith/chart/templates/deployment.yaml
+++ b/projects/monolith/chart/templates/deployment.yaml
@@ -98,6 +98,10 @@ spec:
             - name: GOOSECRACKER_PROGRESS_URL
               value: {{ .Values.goosecracker.progressUrl | quote }}
             {{- end }}
+            {{- if .Values.goosecracker.gitMirror }}
+            - name: GOOSECRACKER_GIT_MIRROR
+              value: {{ .Values.goosecracker.gitMirror | quote }}
+            {{- end }}
             {{- if .Values.goosecracker.tiers }}
             # Egress secret-swap CA public cert (ADR 023 6b). The fc-invoke egress
             # proxy TLS-terminates swapped hosts with a leaf minted from this CA;

--- a/projects/monolith/deploy/values.yaml
+++ b/projects/monolith/deploy/values.yaml
@@ -156,6 +156,11 @@ goosecracker:
   # there through the fc-invoke egress funnel, and the Discord bot polls the
   # in-memory buffer keyed by the session (== the Discord thread id).
   progressUrl: "http://monolith.monolith.svc.cluster.local:8000/internal/goosecracker/progress"
+  # The in-cluster git mirror base URL (WS2 hydration). The runner defaults
+  # gitMirror to "<gitMirror>/homelab" when the caller does not specify one.
+  # The mirror serves git:// on :9418 (ADR 026 + git-mirror service in
+  # projects/firecracker/git-mirror/). Keep empty if the mirror is not deployed.
+  gitMirror: "git://git-mirror.monolith.svc.cluster.local:9418"
   # Per-tier guest env (relocated from the fc-agentd chart). The runner merges the
   # selected tier into the AgentRequest.env it POSTs to fc-invoke. A tier is the
   # model endpoint plus the secret PLACEHOLDERS the guest may hold: the kloak:

--- a/projects/monolith/goosecracker/runner.py
+++ b/projects/monolith/goosecracker/runner.py
@@ -44,6 +44,12 @@ FC_INVOKE_URL = os.environ.get("FC_INVOKE_URL", "")
 # guest's id-less {"chunk": ...} posts land in the right per-session buffer.
 PROGRESS_URL_BASE = os.environ.get("GOOSECRACKER_PROGRESS_URL", "")
 
+# Base URL of the in-cluster git mirror. Injected from Helm values
+# (GOOSECRACKER_GIT_MIRROR); never hardcoded here (semgrep no-hardcoded-k8s-service-url).
+# When set, the runner defaults every agent run to clone from <mirror>/homelab
+# unless the caller specifies git_mirror explicitly.
+GOOSECRACKER_GIT_MIRROR = os.environ.get("GOOSECRACKER_GIT_MIRROR", "")
+
 # A fast connect surfaces a down daemon quickly; a generous read budget lets a
 # multi-turn goose run finish (cold Qwen runs take minutes).
 _CONNECT_TIMEOUT = 5.0
@@ -57,6 +63,25 @@ def _progress_url(session: str) -> str:
     if not PROGRESS_URL_BASE:
         return ""
     return f"{PROGRESS_URL_BASE.rstrip('/')}/{session}"
+
+
+def _effective_mirror_ref(git_mirror: str, git_ref: str) -> tuple[str, str]:
+    """Return the (mirror URL, ref) pair for a goose run, applying defaults.
+
+    When the caller does not specify a mirror, defaults to
+    ``<GOOSECRACKER_GIT_MIRROR>/homelab`` (the in-cluster mirror). When no ref
+    is specified, defaults to ``main``. Both values are passed through
+    unchanged when explicitly supplied by the caller, so an override always
+    wins.
+
+    Returns ("", "main") when GOOSECRACKER_GIT_MIRROR is also unset, which
+    makes the handler skip the clone step entirely (no mirror configured).
+    """
+    effective_mirror = git_mirror
+    if not effective_mirror and GOOSECRACKER_GIT_MIRROR:
+        effective_mirror = GOOSECRACKER_GIT_MIRROR.rstrip("/") + "/homelab"
+    effective_ref = git_ref or "main"
+    return effective_mirror, effective_ref
 
 
 def _truncate(text_body: str) -> str:
@@ -125,7 +150,9 @@ async def _delivery_message(session: str, recipe: str, data: dict) -> str:
     Artifact runs publish the built HTML and post a clean ``Artifact ready: <url>``
     (plus the recipe's one-line summary) instead of the raw goose transcript. A run
     that was meant to build an artifact but produced none gets a clear miss message.
-    Any other run posts its (truncated) result text.
+    Any other run posts its (truncated) result text. When the guest recorded a
+    scratch ref (WS3), a ``recorded: refs/agents/<session>`` line is appended for
+    all run types.
     """
     html = data.get("artifactHtml")
     if html:
@@ -136,10 +163,16 @@ async def _delivery_message(session: str, recipe: str, data: dict) -> str:
             logger.exception("goosecracker: artifact publish failed for %s", session)
             return "Build finished, but publishing the artifact failed. Check the logs."
         summary = _extract_summary(data.get("result", "") or "")
-        return f"Artifact ready: {url}" + (f"\n\n{summary}" if summary else "")
-    if recipe == "artifact":
-        return "Build finished but produced no artifact. Try rephrasing the request."
-    return _truncate(data.get("result", "") or "(no output)")
+        msg = f"Artifact ready: {url}" + (f"\n\n{summary}" if summary else "")
+    elif recipe == "artifact":
+        msg = "Build finished but produced no artifact. Try rephrasing the request."
+    else:
+        msg = _truncate(data.get("result", "") or "(no output)")
+
+    recorded_ref = data.get("recordedRef")
+    if recorded_ref:
+        msg += f"\nrecorded: {recorded_ref}"
+    return msg
 
 
 async def _persist_session_db(session: str, session_db_b64: str | None) -> None:
@@ -186,14 +219,19 @@ async def run_and_deliver(
         # falls back to cold if the db fails to hydrate/resume.
         # nosemgrep: no-session-in-to-thread  # `session` is the fc-invoke session-id string, not a SQLAlchemy Session
         session_db = await asyncio.to_thread(sessions.load, session)
+        # WS2 - Hydration: default the mirror and ref when the caller did not
+        # specify them. The mirror is read from GOOSECRACKER_GIT_MIRROR, injected
+        # via Helm values. An empty effective_mirror means no clone (no mirror
+        # configured in this environment).
+        effective_mirror, effective_ref = _effective_mirror_ref(git_mirror, git_ref)
         payload = {
             "recipe": recipe,
             "task": task,
             "session": session,
             "env": env,
             "progressUrl": _progress_url(session),
-            "gitMirror": git_mirror,
-            "gitRef": git_ref,
+            "gitMirror": effective_mirror,
+            "gitRef": effective_ref,
             "resume": session_db is not None,
             "sessionDb": base64.b64encode(session_db).decode() if session_db else "",
         }

--- a/projects/monolith/goosecracker/tests/runner_test.py
+++ b/projects/monolith/goosecracker/tests/runner_test.py
@@ -1,9 +1,8 @@
-"""Unit tests for the goosecracker delivery/publish path (ADR 024).
+"""Unit tests for the goosecracker delivery/publish path (ADR 024) and WS2/WS3.
 
-Covers the artifact publish + Discord message shaping: an artifact run publishes
-the built HTML and posts a clean "Artifact ready: <url>" (with the recipe summary)
-rather than the raw goose transcript; a whiffed artifact build and a publish
-failure both get clear messages.
+Covers the artifact publish + Discord message shaping, the default mirror wiring
+(WS2: GOOSECRACKER_GIT_MIRROR defaults gitMirror when caller omits it), and the
+recorded-ref line in delivery messages (WS3).
 """
 
 from __future__ import annotations
@@ -64,3 +63,74 @@ async def test_delivery_message_publish_failure_is_reported(monkeypatch):
 async def test_delivery_message_non_artifact_posts_result():
     msg = await runner._delivery_message("sess", "agent", {"result": "hello from qwen"})
     assert msg == "hello from qwen"
+
+
+# ---------------------------------------------------------------------------
+# WS2: default mirror wiring via _effective_mirror_ref
+# ---------------------------------------------------------------------------
+
+
+def test_effective_mirror_defaults_to_env_when_caller_omits(monkeypatch):
+    """GOOSECRACKER_GIT_MIRROR is injected as the base; /homelab is appended."""
+    monkeypatch.setattr(runner, "GOOSECRACKER_GIT_MIRROR", "git://mirror:9418")
+    m, r = runner._effective_mirror_ref("", "")
+    assert m == "git://mirror:9418/homelab"
+    assert r == "main"
+
+
+def test_effective_mirror_caller_override_wins(monkeypatch):
+    """Explicit git_mirror from the caller takes precedence over the env default."""
+    monkeypatch.setattr(runner, "GOOSECRACKER_GIT_MIRROR", "git://mirror:9418")
+    m, r = runner._effective_mirror_ref("git://other:9418/loom", "feat/x")
+    assert m == "git://other:9418/loom"
+    assert r == "feat/x"
+
+
+def test_effective_mirror_empty_when_env_unset(monkeypatch):
+    """When GOOSECRACKER_GIT_MIRROR is unset, effective mirror is empty (no clone)."""
+    monkeypatch.setattr(runner, "GOOSECRACKER_GIT_MIRROR", "")
+    m, r = runner._effective_mirror_ref("", "")
+    assert m == ""
+    assert r == "main"
+
+
+def test_effective_mirror_ref_defaults_to_main_when_only_mirror_set(monkeypatch):
+    """git_ref defaults to 'main' when caller omits it but mirror is specified."""
+    monkeypatch.setattr(runner, "GOOSECRACKER_GIT_MIRROR", "git://mirror:9418")
+    m, r = runner._effective_mirror_ref("", "")
+    assert r == "main"
+
+
+# ---------------------------------------------------------------------------
+# WS3: _delivery_message appends recorded ref
+# ---------------------------------------------------------------------------
+
+
+async def test_delivery_message_appends_recorded_ref_for_agent():
+    """A recorded scratch ref is appended to the agent result message."""
+    data = {"result": "did the work", "recordedRef": "refs/agents/sess-abc"}
+    msg = await runner._delivery_message("sess-abc", "agent", data)
+    assert "did the work" in msg
+    assert "recorded: refs/agents/sess-abc" in msg
+
+
+async def test_delivery_message_appends_recorded_ref_for_artifact(monkeypatch):
+    """A recorded ref is also appended when the run produced an artifact."""
+    monkeypatch.setattr(
+        runner, "_publish_artifact", lambda s, h: "https://jomcgi.dev/artifact/x"
+    )
+    data = {
+        "artifactHtml": "<html/>",
+        "result": "",
+        "recordedRef": "refs/agents/sess-art",
+    }
+    msg = await runner._delivery_message("sess-art", "artifact", data)
+    assert "https://jomcgi.dev/artifact/x" in msg
+    assert "recorded: refs/agents/sess-art" in msg
+
+
+async def test_delivery_message_no_recorded_ref_unchanged():
+    """When no recordedRef is present, the message is unchanged."""
+    msg = await runner._delivery_message("sess", "agent", {"result": "result text"})
+    assert msg == "result text"
+    assert "recorded:" not in msg


### PR DESCRIPTION
Implements **WS2** (hydration) + **WS3** (recording) from `docs/plans/2026-07-01-git-mirror-recording-generic-egress.md`, completing the agent-workspace lifecycle over the merged git mirror (#3012) and generic egress (#3010).

## WS2 - hydration
- Guest clones its workspace from the in-cluster mirror with a shallow partial clone (`--single-branch --depth=1 --filter=blob:none`) for sub-second provisioning (ADR 026).
- Mirror base injected via `GOOSECRACKER_GIT_MIRROR` (monolith deploy values -> chart env, no hardcoded svc URL in code); the runner defaults `gitMirror` to `<base>/homelab` when the caller omits one.
- Clone failure is a soft-fail (log + continue with an empty workspace), per the ADR 026 degraded-path risk row.

## WS3 - scratch-ref recording
- After a successful run, `ExecGit.RecordScratch` sets a bot identity, `git add -A`, and if dirty commits + pushes `HEAD:refs/agents/<session>` to the mirror. No credential: the mirror's `pre-receive` hook fences that namespace.
- Short-circuits on a clean workspace; retries once with `--unshallow` if the shallow boundary refuses the push.
- Pushed ref surfaced in `AgentResult.RecordedRef` and appended to the Discord delivery (`recorded: refs/agents/<session>`).

## Notes
- The `Git` capability interface gains `PushRefspec` (replacing the unused `Push`); `ExecGit` gains `RecordScratch`. Session ids are sanitized to valid ref components.
- This is a clean 9-file extraction from the implementer's commit, which had picked up repo-wide `format` churn and semgrep-config edits (dropped deliberately; semgrep passes without them).
- **Deploy is a follow-up:** the guest-init change needs an fc-invoke chart bump and the monolith env needs a monolith chart bump, done after this merges so the new guest image is built first.

Verified locally: `go build` (linux) + `go vet` clean; semgrep clean; monolith config diffs are additive only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)