### PR TITLE
feat(git-mirror): mirror-side token to mirror private repos (loom)

### DIFF
--- a/projects/firecracker/git-mirror/chart/Chart.yaml
+++ b/projects/firecracker/git-mirror/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: git-mirror
 description: Hot git mirror for Firecracker agent workspaces on node-4. Keeps bare clones warm via a supervisor loop; serves git:// (port 9418) with a pre-receive hook restricting writes to refs/agents/**.
 type: application
-version: 0.1.2
+version: 0.1.3
 appVersion: "0.1.0"
 maintainers:
   - name: jomcgi

--- a/projects/firecracker/git-mirror/chart/templates/configmap.yaml
+++ b/projects/firecracker/git-mirror/chart/templates/configmap.yaml
@@ -113,6 +113,20 @@ data:
     echo "[supervisor] starting: mirrors=$MIRRORS_DIR port=$GIT_DAEMON_PORT interval=${REFRESH_INTERVAL}s gc_days=$GC_RETENTION_DAYS"
     mkdir -p "$MIRRORS_DIR"
 
+    # Optional mirror-side GitHub read auth so the mirror can clone PRIVATE repos
+    # (e.g. loom). The token lives ONLY in this trusted pod's ephemeral HOME
+    # (/tmp, emptyDir): it is never written to the PVC (remote URLs stay
+    # token-less) and never reaches a guest (guests clone from the mirror over
+    # git:// with no credential). Reuses the in-namespace token synced from
+    # 1Password. A credential.helper store keyed on github.com covers clone +
+    # every periodic fetch without tokenizing any remote URL.
+    if [ -n "${GITHUB_TOKEN:-}" ]; then
+      git config --global credential.helper store
+      printf 'https://x-access-token:%s@github.com\n' "$GITHUB_TOKEN" > "$HOME/.git-credentials"
+      chmod 600 "$HOME/.git-credentials"
+      echo "[init] GitHub read auth configured (private repos enabled)"
+    fi
+
     # Initialize each registered repo.
     {{- range .Values.repos }}
     ensure_repo {{ .name | quote }} {{ .url | quote }}

--- a/projects/firecracker/git-mirror/chart/templates/deployment.yaml
+++ b/projects/firecracker/git-mirror/chart/templates/deployment.yaml
@@ -61,6 +61,16 @@ spec:
               value: /tmp
             - name: GIT_CONFIG_NOSYSTEM
               value: "1"
+            {{- if .Values.githubToken.enabled }}
+            # Mirror-side read token for private repos. Stays in this trusted pod
+            # only (written to the ephemeral HOME as a credential store by the
+            # supervisor); never on the PVC, never in a guest.
+            - name: GITHUB_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.githubToken.secretRef.name }}
+                  key: {{ .Values.githubToken.secretRef.key }}
+            {{- end }}
           ports:
             - name: git
               containerPort: {{ .Values.gitDaemonPort }}

--- a/projects/firecracker/git-mirror/chart/values.yaml
+++ b/projects/firecracker/git-mirror/chart/values.yaml
@@ -16,10 +16,12 @@ image:
 repos:
   - name: homelab
     url: https://github.com/jomcgi/homelab.git
-  # loom is a PRIVATE repo: the mirror clones anonymously (no GitHub creds), so it
-  # cannot be added until mirror-side read auth exists (a follow-up). ADR 026
-  # assumed public repos; a private repo needs a server-side token on the mirror,
-  # never on the guest. Adding it here without that would fail the clone.
+  # loom is a PRIVATE repo; the mirror clones it using githubToken below (a
+  # mirror-side read token that never reaches a guest). A clone failure is still
+  # non-fatal, so a token/scope problem degrades to skipping loom, it does not
+  # crash the mirror.
+  - name: loom
+    url: https://github.com/jomcgi/loom.git
 
 # Seconds between git fetch --prune passes. Keep short enough that guests
 # hydrate from a near-head branch, long enough not to hammer GitHub rate limits.
@@ -90,3 +92,15 @@ serviceAccount:
 imagePullSecret:
   enabled: true
   name: ghcr-imagepull-secret
+
+# Mirror-side GitHub read token so the mirror can clone PRIVATE repos (e.g. loom).
+# The token lives ONLY in this trusted pod (written to the ephemeral HOME as a
+# credential store by the supervisor); it is never on the PVC and never in a
+# guest (guests clone from the mirror over git:// with no credential). Reuses the
+# in-namespace token synced from 1Password. A dedicated fine-grained read-only PAT
+# scoped to just these repos would be tighter; a follow-up.
+githubToken:
+  enabled: true
+  secretRef:
+    name: monolith-chat-secrets
+    key: GITHUB_TOKEN

--- a/projects/firecracker/git-mirror/deploy/application.yaml
+++ b/projects/firecracker/git-mirror/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: git-mirror
-      targetRevision: 0.1.2
+      targetRevision: 0.1.3
       helm:
         releaseName: git-mirror
         valueFiles:


### PR DESCRIPTION
Answers 'don't we have creds for loom': yes. Gives the mirror a read token (reused monolith-chat-secrets/GITHUB_TOKEN) so it can clone the private loom repo, and re-adds loom. The token stays in the trusted mirror pod only, written to a credential store in the ephemeral HOME (/tmp emptyDir): never on the PVC (remote URLs stay token-less), never in a guest (guests clone over git:// with no cred, preserving ADR 023). Clone failure stays non-fatal. Chart 0.1.2 -> 0.1.3.

Follow-up: a fine-grained read-only PAT scoped to just these repos would be tighter than the broad token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)