### PR TITLE
fix(git-mirror): insteadOf token auth + drop non-existent jomcgi/loom

### DIFF
--- a/projects/firecracker/git-mirror/chart/Chart.yaml
+++ b/projects/firecracker/git-mirror/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: git-mirror
 description: Hot git mirror for Firecracker agent workspaces on node-4. Keeps bare clones warm via a supervisor loop; serves git:// (port 9418) with a pre-receive hook restricting writes to refs/agents/**.
 type: application
-version: 0.1.3
+version: 0.1.4
 appVersion: "0.1.0"
 maintainers:
   - name: jomcgi

--- a/projects/firecracker/git-mirror/chart/templates/configmap.yaml
+++ b/projects/firecracker/git-mirror/chart/templates/configmap.yaml
@@ -113,17 +113,18 @@ data:
     echo "[supervisor] starting: mirrors=$MIRRORS_DIR port=$GIT_DAEMON_PORT interval=${REFRESH_INTERVAL}s gc_days=$GC_RETENTION_DAYS"
     mkdir -p "$MIRRORS_DIR"
 
-    # Optional mirror-side GitHub read auth so the mirror can clone PRIVATE repos
-    # (e.g. loom). The token lives ONLY in this trusted pod's ephemeral HOME
-    # (/tmp, emptyDir): it is never written to the PVC (remote URLs stay
-    # token-less) and never reaches a guest (guests clone from the mirror over
-    # git:// with no credential). Reuses the in-namespace token synced from
-    # 1Password. A credential.helper store keyed on github.com covers clone +
-    # every periodic fetch without tokenizing any remote URL.
+    # Optional mirror-side GitHub read auth so the mirror can clone PRIVATE repos.
+    # The token lives ONLY in this trusted pod's ephemeral HOME (/tmp, emptyDir),
+    # never on the PVC and never in a guest (guests clone from the mirror over
+    # git:// with no credential). We use a url.<tokenized>.insteadOf rewrite (pure
+    # git core, applied at transport) rather than credential.helper store, because
+    # the wolfi git package ships no git-credential-store binary ("cannot exec
+    # 'git credential-store get'"). The stored remote URLs stay token-less; the
+    # token only appears in the rewrite in the ephemeral /tmp gitconfig.
     if [ -n "${GITHUB_TOKEN:-}" ]; then
-      git config --global credential.helper store
-      printf 'https://x-access-token:%s@github.com\n' "$GITHUB_TOKEN" > "$HOME/.git-credentials"
-      chmod 600 "$HOME/.git-credentials"
+      git config --global \
+        "url.https://x-access-token:${GITHUB_TOKEN}@github.com/.insteadOf" \
+        "https://github.com/"
       echo "[init] GitHub read auth configured (private repos enabled)"
     fi
 

--- a/projects/firecracker/git-mirror/chart/values.yaml
+++ b/projects/firecracker/git-mirror/chart/values.yaml
@@ -16,12 +16,10 @@ image:
 repos:
   - name: homelab
     url: https://github.com/jomcgi/homelab.git
-  # loom is a PRIVATE repo; the mirror clones it using githubToken below (a
-  # mirror-side read token that never reaches a guest). A clone failure is still
-  # non-fatal, so a token/scope problem degrades to skipping loom, it does not
-  # crash the mirror.
-  - name: loom
-    url: https://github.com/jomcgi/loom.git
+  # loom is a PRIVATE repo but `jomcgi/loom` does not exist (it is a 50:50 project
+  # with Rowan, so it lives under a different owner/org). Re-add it here with the
+  # CORRECT owner/repo once known: the mirror-side githubToken + insteadOf auth
+  # below is in place, so it is a one-line add. A clone failure stays non-fatal.
 
 # Seconds between git fetch --prune passes. Keep short enough that guests
 # hydrate from a near-head branch, long enough not to hammer GitHub rate limits.

--- a/projects/firecracker/git-mirror/deploy/application.yaml
+++ b/projects/firecracker/git-mirror/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: git-mirror
-      targetRevision: 0.1.3
+      targetRevision: 0.1.4
       helm:
         releaseName: git-mirror
         valueFiles:


### PR DESCRIPTION
credential.helper store needs a git-credential-store binary the wolfi git package lacks (runtime 'cannot exec' error); switch to url.<tokenized>.insteadOf (pure git core). Also drop jomcgi/loom: it does not exist (loom is under a different owner/org). Token + insteadOf wiring stays ready so re-adding loom with the correct path is a one-liner. Chart 0.1.3 -> 0.1.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)