### PR TITLE
feat(git-mirror): mirror loom from weave-hand/loom

### DIFF
--- a/projects/firecracker/git-mirror/chart/Chart.yaml
+++ b/projects/firecracker/git-mirror/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: git-mirror
 description: Hot git mirror for Firecracker agent workspaces on node-4. Keeps bare clones warm via a supervisor loop; serves git:// (port 9418) with a pre-receive hook restricting writes to refs/agents/**.
 type: application
-version: 0.1.4
+version: 0.1.5
 appVersion: "0.1.0"
 maintainers:
   - name: jomcgi

--- a/projects/firecracker/git-mirror/chart/values.yaml
+++ b/projects/firecracker/git-mirror/chart/values.yaml
@@ -16,10 +16,11 @@ image:
 repos:
   - name: homelab
     url: https://github.com/jomcgi/homelab.git
-  # loom is a PRIVATE repo but `jomcgi/loom` does not exist (it is a 50:50 project
-  # with Rowan, so it lives under a different owner/org). Re-add it here with the
-  # CORRECT owner/repo once known: the mirror-side githubToken + insteadOf auth
-  # below is in place, so it is a one-line add. A clone failure stays non-fatal.
+  # loom is a PRIVATE repo under the weave-hand org (50:50 with Rowan). The mirror
+  # clones it via the mirror-side githubToken + insteadOf auth below; the token
+  # must have weave-hand read access or the clone non-fatally skips.
+  - name: loom
+    url: https://github.com/weave-hand/loom.git
 
 # Seconds between git fetch --prune passes. Keep short enough that guests
 # hydrate from a near-head branch, long enough not to hammer GitHub rate limits.

--- a/projects/firecracker/git-mirror/deploy/application.yaml
+++ b/projects/firecracker/git-mirror/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: git-mirror
-      targetRevision: 0.1.4
+      targetRevision: 0.1.5
       helm:
         releaseName: git-mirror
         valueFiles:


### PR DESCRIPTION
loom is under the weave-hand org (50:50 with Rowan), not jomcgi/loom. Re-add with the correct URL; clones via the insteadOf token auth. Non-fatal if the token lacks weave-hand read. Chart 0.1.4 -> 0.1.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)