### PR TITLE
feat(goosecracker): /agent [repo] [prompt] Discord command (Qwen tier)

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.240.2
+version: 0.240.3
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chat/bot.py
+++ b/projects/monolith/chat/bot.py
@@ -443,6 +443,27 @@ class ChatBot(discord.Client):
         ) -> None:
             await self._handle_goosecracker_command(interaction, prompt)
 
+        @self.tree.command(
+            name="agent",
+            description="Run the coding agent on a repo (owner only)",
+        )
+        @discord.app_commands.describe(
+            prompt="The task for the agent",
+            repo="Repo to hydrate from",
+        )
+        @discord.app_commands.choices(
+            repo=[
+                discord.app_commands.Choice(name="homelab", value="homelab"),
+                discord.app_commands.Choice(name="loom", value="loom"),
+            ]
+        )
+        async def agent_command(
+            interaction: discord.Interaction,
+            prompt: str,
+            repo: discord.app_commands.Choice[str],
+        ) -> None:
+            await self._handle_agent_command(interaction, prompt, repo.value)
+
     async def on_ready(self):
         logger.info("Discord bot connected as %s", self.user)
         # Sync slash commands globally so /artifact is available in every
@@ -546,6 +567,47 @@ class ChatBot(discord.Client):
             self._start_goosecracker_stream(str(thread.id), intro)
         except Exception:
             logger.exception("goosecracker: failed to post thread intro")
+
+    async def _handle_agent_command(
+        self, interaction: discord.Interaction, prompt: str, repo: str
+    ) -> None:
+        """Owner-gated /agent: open a thread and dispatch a one-shot agent run."""
+        if not goosecracker.is_owner(interaction.user.id):
+            await interaction.response.defer(ephemeral=True)
+            roast = await goosecracker.build_roast(prompt)
+            await interaction.followup.send(roast, ephemeral=True)
+            return
+
+        channel = interaction.channel
+        if not isinstance(channel, discord.TextChannel):
+            await interaction.response.send_message(
+                "Run /agent from a normal text channel so I can open a thread.",
+                ephemeral=True,
+            )
+            return
+
+        await interaction.response.defer(thinking=True)
+        try:
+            name = f"agent: {prompt}"[:90]
+            thread = await channel.create_thread(
+                name=name, type=discord.ChannelType.public_thread
+            )
+            await asyncio.to_thread(
+                goosecracker.start_agent_session, str(thread.id), repo, prompt
+            )
+        except Exception:
+            logger.exception("goosecracker: failed to start agent session")
+            await interaction.followup.send(
+                "Couldn't start that one. Check the logs.", ephemeral=True
+            )
+            return
+
+        await interaction.followup.send(f"Running agent in {thread.mention}")
+        try:
+            intro = await thread.send("🛠 On it. Running the agent now...")
+            self._start_goosecracker_stream(str(thread.id), intro)
+        except Exception:
+            logger.exception("goosecracker: failed to post agent thread intro")
 
     def _start_goosecracker_stream(
         self, artifact_id: str, message: discord.Message

--- a/projects/monolith/chat/goosecracker.py
+++ b/projects/monolith/chat/goosecracker.py
@@ -32,6 +32,11 @@ logger = logging.getLogger(__name__)
 ARTIFACT_RECIPE = "artifact"
 ARTIFACT_TIER = "artifact"
 
+# The agent recipe + tier: default (empty) tier runs on the in-cluster Qwen model.
+# The agent recipe is the general coding agent (goosecracker general mode).
+AGENT_RECIPE = "agent"
+AGENT_TIER = ""
+
 # Shown when the owner gate rejects someone and the qwen roast path is
 # unavailable (model down), so a non-owner always gets a clear refusal.
 _FALLBACK_ROAST = "Nice try. /artifact is owner-only."
@@ -130,6 +135,29 @@ def continue_session(thread_id: str, message: str) -> dict | None:
         session=thread_id,
         recipe=ARTIFACT_RECIPE,
         tier=ARTIFACT_TIER,
+        discord_thread=thread_id,
+    )
+
+
+def start_agent_session(thread_id: str, repo: str, prompt: str) -> dict:
+    """Dispatch a one-shot agent run for the given Discord thread.
+
+    Unlike ``start_session`` (artifact), this does not write a
+    GoosecrackerSession DB row, so thread replies fall through to normal chat
+    handling. Iterative /agent threads (continuation) are a future follow-up.
+    Synchronous; call via ``asyncio.to_thread``.
+    """
+    prompt = prompt.strip()
+    # Imported lazily for the same reason as start_session (circular import
+    # guard: chat.bot -> chat.goosecracker -> goosecracker.runner -> chat.api).
+    from goosecracker.api import submit
+
+    return submit(
+        prompt,
+        session=thread_id,
+        recipe=AGENT_RECIPE,
+        tier=AGENT_TIER,
+        repo=repo,
         discord_thread=thread_id,
     )
 

--- a/projects/monolith/chat/goosecracker_test.py
+++ b/projects/monolith/chat/goosecracker_test.py
@@ -185,6 +185,20 @@ def test_continue_session_cold_path_when_no_session(engine, fake_api, monkeypatc
     )
 
 
+def test_start_agent_session_dispatches_with_agent_recipe(fake_api):
+    """start_agent_session submits with recipe='agent', tier='', and passes repo."""
+    goosecracker.start_agent_session("thread-2", "loom", "  add a login page  ")
+
+    fake_api.submit.assert_called_once_with(
+        "add a login page",
+        session="thread-2",
+        recipe="agent",
+        tier="",
+        repo="loom",
+        discord_thread="thread-2",
+    )
+
+
 def test_continue_session_falls_back_to_cold_on_head_session_error(
     engine, fake_api, monkeypatch
 ):

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.240.2
+      targetRevision: 0.240.3
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/goosecracker/dispatch.py
+++ b/projects/monolith/goosecracker/dispatch.py
@@ -83,6 +83,7 @@ def submit(
             task=task,
             recipe=recipe,
             tier=tier,
+            repo=repo,
             git_mirror=git_mirror,
             git_ref=git_ref,
             discord_thread=discord_thread,

--- a/projects/monolith/goosecracker/runner.py
+++ b/projects/monolith/goosecracker/runner.py
@@ -65,21 +65,29 @@ def _progress_url(session: str) -> str:
     return f"{PROGRESS_URL_BASE.rstrip('/')}/{session}"
 
 
-def _effective_mirror_ref(git_mirror: str, git_ref: str) -> tuple[str, str]:
+def _effective_mirror_ref(
+    git_mirror: str, git_ref: str, repo: str = ""
+) -> tuple[str, str]:
     """Return the (mirror URL, ref) pair for a goose run, applying defaults.
 
     When the caller does not specify a mirror, defaults to
-    ``<GOOSECRACKER_GIT_MIRROR>/homelab`` (the in-cluster mirror). When no ref
-    is specified, defaults to ``main``. Both values are passed through
-    unchanged when explicitly supplied by the caller, so an override always
-    wins.
+    ``<GOOSECRACKER_GIT_MIRROR>/<repo or "homelab">`` (the in-cluster mirror).
+    When no ref is specified, defaults to ``main``. Both values are passed
+    through unchanged when explicitly supplied by the caller, so an override
+    always wins.
+
+    The ``repo`` param selects which repository under the mirror base to clone;
+    it defaults to ``"homelab"`` when empty. Explicit ``git_mirror`` takes
+    precedence and ``repo`` is ignored in that case.
 
     Returns ("", "main") when GOOSECRACKER_GIT_MIRROR is also unset, which
     makes the handler skip the clone step entirely (no mirror configured).
     """
     effective_mirror = git_mirror
     if not effective_mirror and GOOSECRACKER_GIT_MIRROR:
-        effective_mirror = GOOSECRACKER_GIT_MIRROR.rstrip("/") + "/homelab"
+        effective_mirror = (
+            GOOSECRACKER_GIT_MIRROR.rstrip("/") + "/" + (repo or "homelab")
+        )
     effective_ref = git_ref or "main"
     return effective_mirror, effective_ref
 
@@ -144,15 +152,28 @@ def _extract_summary(result: str) -> str:
     return m.group(1).strip() if m else ""
 
 
+def _extract_result_field(result: str, key: str) -> str:
+    """Pull a ``<key>: <value>`` line out of the recipe's ``goose-result`` block.
+
+    Used to surface the ``url`` (a PR/issue the agent opened) alongside the
+    summary. Empty when the key is absent. The recipe's placeholder text (e.g.
+    ``<artifact URL, if any>``) is left for the caller to filter (it is not a URL).
+    """
+    m = re.search(rf"^\s*{re.escape(key)}:\s*(.+)$", result, re.MULTILINE)
+    return m.group(1).strip() if m else ""
+
+
 async def _delivery_message(session: str, recipe: str, data: dict) -> str:
     """Build the Discord message for a successful run.
 
     Artifact runs publish the built HTML and post a clean ``Artifact ready: <url>``
     (plus the recipe's one-line summary) instead of the raw goose transcript. A run
     that was meant to build an artifact but produced none gets a clear miss message.
-    Any other run posts its (truncated) result text. When the guest recorded a
-    scratch ref (WS3), a ``recorded: refs/agents/<session>`` line is appended for
-    all run types.
+    Any other run (e.g. the coding ``agent``) posts the recipe's ``goose-result``
+    summary (plus a PR/issue url if it opened one), falling back to the truncated
+    transcript only when goose emitted no structured result block. When the guest
+    recorded a scratch ref (WS3), a ``recorded: refs/agents/<session>`` line is
+    appended for all run types.
     """
     html = data.get("artifactHtml")
     if html:
@@ -167,7 +188,20 @@ async def _delivery_message(session: str, recipe: str, data: dict) -> str:
     elif recipe == "artifact":
         msg = "Build finished but produced no artifact. Try rephrasing the request."
     else:
-        msg = _truncate(data.get("result", "") or "(no output)")
+        # Coding agent (and any non-artifact recipe): post the recipe's
+        # goose-result summary, not the raw transcript. Append the url only when
+        # it is a real link (goose leaves a placeholder when it opened nothing).
+        result = data.get("result", "") or ""
+        summary = _extract_summary(result)
+        if summary:
+            msg = summary
+            url = _extract_result_field(result, "url")
+            if url.startswith("http"):
+                msg += f"\n{url}"
+        else:
+            # No structured block: fall back to the truncated transcript so the
+            # thread never gets an empty message.
+            msg = _truncate(result or "(no output)")
 
     recorded_ref = data.get("recordedRef")
     if recorded_ref:
@@ -198,6 +232,7 @@ async def run_and_deliver(
     task: str,
     recipe: str,
     tier: str,
+    repo: str = "",
     git_mirror: str,
     git_ref: str,
     discord_thread: str,
@@ -223,7 +258,9 @@ async def run_and_deliver(
         # specify them. The mirror is read from GOOSECRACKER_GIT_MIRROR, injected
         # via Helm values. An empty effective_mirror means no clone (no mirror
         # configured in this environment).
-        effective_mirror, effective_ref = _effective_mirror_ref(git_mirror, git_ref)
+        effective_mirror, effective_ref = _effective_mirror_ref(
+            git_mirror, git_ref, repo
+        )
         payload = {
             "recipe": recipe,
             "task": task,

--- a/projects/monolith/goosecracker/tests/runner_test.py
+++ b/projects/monolith/goosecracker/tests/runner_test.py
@@ -28,6 +28,52 @@ def test_extract_summary_empty_when_absent():
     assert runner._extract_summary("no result block here") == ""
 
 
+_AGENT_RESULT = (
+    "Loading recipe: Agent\n"
+    "  ▸ shell git status\n"
+    "```goose-result\n"
+    "type: note\n"
+    "url: <artifact URL, if any>\n"
+    "summary: Added a null check in parse().\n"
+    "```\n"
+)
+
+_AGENT_RESULT_WITH_PR = (
+    "```goose-result\n"
+    "type: pr\n"
+    "url: https://github.com/jomcgi/homelab/pull/42\n"
+    "summary: Opened a PR fixing the parser.\n"
+    "```\n"
+)
+
+
+async def test_delivery_message_agent_posts_summary_not_transcript():
+    data = {"result": _AGENT_RESULT, "recordedRef": "refs/agents/s-1"}
+    msg = await runner._delivery_message("s-1", "agent", data)
+    assert "Added a null check in parse()." in msg
+    # the raw transcript (recipe banner + tool lines) must NOT be dumped
+    assert "▸ shell" not in msg
+    assert "Loading recipe" not in msg
+    assert "recorded: refs/agents/s-1" in msg
+    # the recipe's placeholder url is not a real link, so it is not appended
+    assert "<artifact URL" not in msg
+
+
+async def test_delivery_message_agent_appends_real_pr_url():
+    msg = await runner._delivery_message(
+        "s-2", "agent", {"result": _AGENT_RESULT_WITH_PR}
+    )
+    assert "Opened a PR fixing the parser." in msg
+    assert "https://github.com/jomcgi/homelab/pull/42" in msg
+
+
+async def test_delivery_message_agent_falls_back_to_transcript_without_block():
+    msg = await runner._delivery_message(
+        "s-3", "agent", {"result": "just some raw output, no result block"}
+    )
+    assert "just some raw output" in msg
+
+
 async def test_delivery_message_publishes_and_links(monkeypatch):
     monkeypatch.setattr(
         runner, "_publish_artifact", lambda s, h: "https://jomcgi.dev/artifact/abc123"
@@ -99,6 +145,34 @@ def test_effective_mirror_ref_defaults_to_main_when_only_mirror_set(monkeypatch)
     monkeypatch.setattr(runner, "GOOSECRACKER_GIT_MIRROR", "git://mirror:9418")
     m, r = runner._effective_mirror_ref("", "")
     assert r == "main"
+
+
+# ---------------------------------------------------------------------------
+# repo param: _effective_mirror_ref selects the right repo under the base
+# ---------------------------------------------------------------------------
+
+
+def test_effective_mirror_custom_repo_appended(monkeypatch):
+    """repo='loom' -> gitMirror <base>/loom, not <base>/homelab."""
+    monkeypatch.setattr(runner, "GOOSECRACKER_GIT_MIRROR", "git://mirror:9418")
+    m, r = runner._effective_mirror_ref("", "", "loom")
+    assert m == "git://mirror:9418/loom"
+    assert r == "main"
+
+
+def test_effective_mirror_empty_repo_falls_back_to_homelab(monkeypatch):
+    """repo='' -> gitMirror <base>/homelab (same as 2-arg default behavior)."""
+    monkeypatch.setattr(runner, "GOOSECRACKER_GIT_MIRROR", "git://mirror:9418")
+    m, r = runner._effective_mirror_ref("", "", "")
+    assert m == "git://mirror:9418/homelab"
+    assert r == "main"
+
+
+def test_effective_mirror_explicit_git_mirror_overrides_repo(monkeypatch):
+    """Explicit git_mirror always wins; repo is ignored when mirror is set."""
+    monkeypatch.setattr(runner, "GOOSECRACKER_GIT_MIRROR", "git://mirror:9418")
+    m, r = runner._effective_mirror_ref("git://other:9418/explicit", "", "loom")
+    assert m == "git://other:9418/explicit"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Adds an owner-gated **`/agent <repo> <prompt>`** Discord slash command that runs the general coding agent on the **default in-cluster Qwen tier**, hydrating from the chosen mirror repo and recording its work to `refs/agents/<thread>`.

## What it does
- `repo` is a dropdown Choice (`homelab` | `loom`); `prompt` is free text. Owner-gated exactly like `/artifact`, opens a thread, streams live progress.
- `dispatch.submit`'s `repo` param (previously dropped) now flows to `run_and_deliver` -> `_effective_mirror_ref`, which builds `<mirror>/<repo>` (default `homelab`). So the choice selects which mirror repo the guest hydrates.
- v1 is one-shot (agent threads write no session row; replies go to normal chat). Iterative `/agent` threads are a noted follow-up.

## Output format (chosen: clean summary + ref)
A non-artifact run now posts the recipe's `goose-result` **summary** (plus a real PR/issue url if it opened one) instead of the raw goose transcript, falling back to the truncated transcript only if goose emitted no structured block. `recorded: refs/agents/<thread>` is appended (mirror-only, per the where-work-lands decision).

## Verified locally
`ruff check` clean, `py_compile` OK, wiring confirmed. New runner tests: repo->mirror mapping (loom/homelab/override) and the agent-summary delivery (summary posted, transcript not dumped, real PR url appended, fallback without a block). Monolith chart bumped `0.240.2 -> 0.240.3` to deploy.

Clean 8-file set extracted from the implementer's branch (no format churn / semgrep-config edits); the delivery-format change is mine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)