### PR TITLE
fix(git-mirror): checksum/config annotation to roll pod on ConfigMap change

### DIFF
--- a/projects/firecracker/git-mirror/chart/Chart.yaml
+++ b/projects/firecracker/git-mirror/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: git-mirror
 description: Hot git mirror for Firecracker agent workspaces on node-4. Keeps bare clones warm via a supervisor loop; serves git:// (port 9418) with a pre-receive hook restricting writes to refs/agents/**.
 type: application
-version: 0.1.5
+version: 0.1.6
 appVersion: "0.1.0"
 maintainers:
   - name: jomcgi

--- a/projects/firecracker/git-mirror/chart/templates/deployment.yaml
+++ b/projects/firecracker/git-mirror/chart/templates/deployment.yaml
@@ -19,10 +19,16 @@ spec:
     metadata:
       labels:
         {{- include "git-mirror.labels" . | nindent 8 }}
-      {{- with .Values.podAnnotations }}
       annotations:
+        # Roll the pod whenever the supervisor ConfigMap changes (repos list, auth
+        # setup, refresh loop). The supervisor reads the ConfigMap once at startup,
+        # so without this a ConfigMap-only change (no image change) updates the
+        # ConfigMap object but never restarts the pod, and the old script keeps
+        # running (this is why the loom URL fix did not take effect).
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
     spec:
       serviceAccountName: {{ include "git-mirror.serviceAccountName" . }}
       {{- if .Values.imagePullSecret.enabled }}

--- a/projects/firecracker/git-mirror/deploy/application.yaml
+++ b/projects/firecracker/git-mirror/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tag pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: git-mirror
-      targetRevision: 0.1.5
+      targetRevision: 0.1.6
       helm:
         releaseName: git-mirror
         valueFiles:


### PR DESCRIPTION
The supervisor reads its ConfigMap once at startup; without a checksum annotation, ConfigMap-only changes never restart the pod (why the loom URL fix did not take effect). Hash the rendered ConfigMap into a pod-template annotation so any change rolls the pod. Deploying also rolls the current pod to pick up weave-hand/loom. Chart 0.1.5 -> 0.1.6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)