### PR TITLE
fix(agent): /agent Discord output, branding, and clone history

### DIFF
--- a/projects/firecracker/substrate/chart/Chart.yaml
+++ b/projects/firecracker/substrate/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: fc-invoke
 description: Node-affine Firecracker invoke daemon that dispatches HTTP invocations to a pool of warm-base microVMs across named workloads (POST /invoke/{workload}, GET /healthz)
 type: application
-version: 0.4.3
+version: 0.4.4

--- a/projects/firecracker/substrate/deploy/application.yaml
+++ b/projects/firecracker/substrate/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tags pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: fc-invoke
-      targetRevision: 0.4.3
+      targetRevision: 0.4.4
       helm:
         valueFiles:
           - $values/projects/firecracker/substrate/deploy/values.yaml

--- a/projects/firecracker/substrate/shim/capabilities/git.go
+++ b/projects/firecracker/substrate/shim/capabilities/git.go
@@ -86,13 +86,16 @@ func (g *ExecGit) runOutput(ctx context.Context, args ...string) ([]byte, error)
 	return out, nil
 }
 
-// Clone clones the repository at mirror into dest using a shallow partial
-// clone (--single-branch --depth=1 --filter=blob:none), then checks out ref.
-// The shallow flags keep the clone sub-second against the in-cluster mirror
-// (ADR 026). Both branch names and full SHAs work: clone fetches only the tip
-// commit for the default branch, then checkout selects the requested ref.
+// Clone clones the repository at mirror into dest using a single-branch partial
+// clone (--single-branch --filter=blob:none), then checks out ref. It keeps the
+// FULL commit history of the branch (so `git log`, blame, and "recent commits"
+// tasks work) while deferring file contents: --filter=blob:none fetches commits
+// and trees up front and lazily pulls a blob only when a file is opened, which
+// keeps the clone fast against the in-cluster mirror without the --depth=1
+// shallow cut that left the workspace with only the tip commit (ADR 026). Both
+// branch names and full SHAs work.
 func (g *ExecGit) Clone(ctx context.Context, mirror, ref, dest string) error {
-	if err := g.run(ctx, "clone", "--single-branch", "--depth=1", "--filter=blob:none", mirror, dest); err != nil {
+	if err := g.run(ctx, "clone", "--single-branch", "--filter=blob:none", mirror, dest); err != nil {
 		return fmt.Errorf("git Clone (clone): %w", err)
 	}
 	if err := g.run(ctx, "-C", dest, "checkout", ref); err != nil {

--- a/projects/firecracker/substrate/shim/capabilities/git_test.go
+++ b/projects/firecracker/substrate/shim/capabilities/git_test.go
@@ -73,10 +73,11 @@ func (f *fakeRunnerSpy) run(ctx context.Context, name string, args ...string) ([
 	return f.output, f.err
 }
 
-// TestExecGitClonePassesShallowFlags verifies that Clone issues a shallow
-// partial clone (--single-branch --depth=1 --filter=blob:none) followed by
-// "git -C <dest> checkout <ref>", without spawning a real process.
-func TestExecGitClonePassesShallowFlags(t *testing.T) {
+// TestExecGitClonePassesPartialFlags verifies that Clone issues a single-branch
+// partial clone (--single-branch --filter=blob:none, NOT --depth=1 so full commit
+// history is present) followed by "git -C <dest> checkout <ref>", without
+// spawning a real process.
+func TestExecGitClonePassesPartialFlags(t *testing.T) {
 	spy := &fakeRunnerSpy{}
 	g := &ExecGit{runner: spy.run}
 
@@ -89,17 +90,21 @@ func TestExecGitClonePassesShallowFlags(t *testing.T) {
 		t.Fatalf("expected 2 git invocations, got %d: %v", len(spy.calls), spy.calls)
 	}
 
-	// First call: git clone --single-branch --depth=1 --filter=blob:none <mirror> <dest>
+	// First call: git clone --single-branch --filter=blob:none <mirror> <dest>
 	cloneArgs := spy.calls[0]
-	// Verify key positions: command is "clone", shallow flags are present, mirror and dest are last.
+	// Verify key positions: command is "clone", partial flags are present, mirror and dest are last.
 	if len(cloneArgs) < 2 || cloneArgs[1] != "clone" {
 		t.Fatalf("first call must be git clone, got %v", cloneArgs)
 	}
 	joined := strings.Join(cloneArgs, " ")
-	for _, want := range []string{"--single-branch", "--depth=1", "--filter=blob:none", "git://mirror:9418/homelab", "/tmp/dst"} {
+	for _, want := range []string{"--single-branch", "--filter=blob:none", "git://mirror:9418/homelab", "/tmp/dst"} {
 		if !strings.Contains(joined, want) {
 			t.Errorf("clone call %q missing %q", joined, want)
 		}
+	}
+	// --depth=1 must NOT be present (it would drop commit history).
+	if strings.Contains(joined, "--depth") {
+		t.Errorf("clone call %q must not be shallow (--depth), it drops commit history", joined)
 	}
 
 	// Second call: git -C <dest> checkout <ref>

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.240.3
+version: 0.240.4
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chat/bot.py
+++ b/projects/monolith/chat/bot.py
@@ -74,14 +74,15 @@ _GOOSECRACKER_WROTE_RE = re.compile(r"Created\s+\S+\s+\((\d+)\s+lines?\)")
 _GOOSECRACKER_SUMMARY_RE = re.compile(r"^\s*summary:\s*(.+?)\s*`*\s*$", re.MULTILINE)
 
 
-def _render_goosecracker_progress(snap, elapsed: int) -> str:
-    """Render a concise live build-progress message from a progress snapshot.
+def _render_goosecracker_progress(snap, elapsed: int, kind: str = "artifact") -> str:
+    """Render a concise live progress message from a progress snapshot.
 
     ``snap`` is a chat.goosecracker_progress.Progress or None (nothing yet).
     Goose's raw stdout includes the whole file it writes, which is noise, so this
-    shows only a phase line (Thinking while the model reasons quietly, Writing
-    while output flows, Built on done) plus the meaningful beats extracted from
-    the stream: lines written and the goose-result summary.
+    shows only a phase line (Thinking while the model reasons quietly, Working
+    while output flows, Done on done) plus the meaningful beats extracted from the
+    stream: lines written and the goose-result summary. ``kind`` selects the copy:
+    "artifact" (the iterable HTML builder) or "agent" (the one-shot coding agent).
     """
     minutes, seconds = divmod(max(elapsed, 0), 60)
     el = f"{minutes}:{seconds:02d}"
@@ -91,11 +92,24 @@ def _render_goosecracker_progress(snap, elapsed: int) -> str:
         GOOSECRACKER_THINKING_AFTER
     )
 
-    lines = ["🛠 **Building your artifact**"]
+    if kind == "agent":
+        header, done_line, flowing_line = (
+            "🤖 **Running agent**",
+            f"✅ Done in {el}",
+            f"⚙️ Working... ({el})",
+        )
+    else:
+        header, done_line, flowing_line = (
+            "🛠 **Building your artifact**",
+            f"✅ Built in {el} (reply here to iterate)",
+            f"⚙️ Writing the artifact... ({el})",
+        )
+
+    lines = [header]
     if done:
-        lines.append(f"✅ Built in {el} (reply here to iterate)")
+        lines.append(done_line)
     elif flowing:
-        lines.append(f"⚙️ Writing the artifact... ({el})")
+        lines.append(flowing_line)
     else:
         lines.append(f"🧠 Thinking... ({el})")
 
@@ -604,22 +618,23 @@ class ChatBot(discord.Client):
 
         await interaction.followup.send(f"Running agent in {thread.mention}")
         try:
-            intro = await thread.send("🛠 On it. Running the agent now...")
-            self._start_goosecracker_stream(str(thread.id), intro)
+            intro = await thread.send("🤖 On it. Running the agent now...")
+            self._start_goosecracker_stream(str(thread.id), intro, kind="agent")
         except Exception:
             logger.exception("goosecracker: failed to post agent thread intro")
 
     def _start_goosecracker_stream(
-        self, artifact_id: str, message: discord.Message
+        self, artifact_id: str, message: discord.Message, kind: str = "artifact"
     ) -> None:
-        """Spawn the background task that live-edits ``message`` with build output.
+        """Spawn the background task that live-edits ``message`` with run output.
 
         Fire-and-forget: the task ends itself on the run's done marker or a
         safety timeout. Kept on the instance so it is not garbage-collected
-        mid-run, and logs any unhandled error.
+        mid-run, and logs any unhandled error. ``kind`` selects the progress copy
+        ("artifact" or "agent").
         """
         task = asyncio.create_task(
-            self._stream_goosecracker_progress(artifact_id, message)
+            self._stream_goosecracker_progress(artifact_id, message, kind)
         )
         streams = getattr(self, "_goosecracker_streams", None)
         if streams is None:
@@ -629,7 +644,7 @@ class ChatBot(discord.Client):
         task.add_done_callback(streams.discard)
 
     async def _stream_goosecracker_progress(
-        self, artifact_id: str, message: discord.Message
+        self, artifact_id: str, message: discord.Message, kind: str = "artifact"
     ) -> None:
         """Edit ``message`` with goose's live build output until done or timeout.
 
@@ -645,7 +660,7 @@ class ChatBot(discord.Client):
             await asyncio.sleep(GOOSECRACKER_STREAM_INTERVAL)
             snap = gp.get(artifact_id)
             elapsed = int(time.monotonic() - start)
-            body = _render_goosecracker_progress(snap, elapsed)
+            body = _render_goosecracker_progress(snap, elapsed, kind)
             if body != last_body:
                 try:
                     await message.edit(content=body)

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.240.3
+      targetRevision: 0.240.4
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/goosecracker/runner.py
+++ b/projects/monolith/goosecracker/runner.py
@@ -163,6 +163,25 @@ def _extract_result_field(result: str, key: str) -> str:
     return m.group(1).strip() if m else ""
 
 
+def _agent_narrative(result: str) -> str:
+    """Extract goose's final narrative answer from a transcript that has no
+    ``goose-result`` block (e.g. a question rather than a coding action).
+
+    Goose's answer is what it writes at the END, after the recipe banner and any
+    tool calls, so strip the ``...goose is ready`` preamble and keep the TAIL when
+    it overflows Discord's limit, rather than the head (which is banner + tools and
+    would cut off the answer).
+    """
+    marker = "goose is ready"
+    idx = result.rfind(marker)
+    body = (result[idx + len(marker) :] if idx != -1 else result).strip()
+    if not body:
+        return "(no output)"
+    if len(body) <= _MAX_DISCORD:
+        return body
+    return "…" + body[-(_MAX_DISCORD - 1) :]
+
+
 async def _delivery_message(session: str, recipe: str, data: dict) -> str:
     """Build the Discord message for a successful run.
 
@@ -199,9 +218,11 @@ async def _delivery_message(session: str, recipe: str, data: dict) -> str:
             if url.startswith("http"):
                 msg += f"\n{url}"
         else:
-            # No structured block: fall back to the truncated transcript so the
-            # thread never gets an empty message.
-            msg = _truncate(result or "(no output)")
+            # No structured block (e.g. a question rather than a coding action):
+            # goose's answer is its trailing narrative, so post that, not the head
+            # of the transcript (which is the recipe banner + tool calls, and would
+            # truncate away the actual answer at the end).
+            msg = _agent_narrative(result)
 
     recorded_ref = data.get("recordedRef")
     if recorded_ref:

--- a/projects/monolith/goosecracker/tests/runner_test.py
+++ b/projects/monolith/goosecracker/tests/runner_test.py
@@ -74,6 +74,21 @@ async def test_delivery_message_agent_falls_back_to_transcript_without_block():
     assert "just some raw output" in msg
 
 
+async def test_delivery_message_agent_posts_trailing_narrative():
+    # A question (no goose-result block): the answer is goose's trailing
+    # narrative, so post that (banner stripped), not the head of the transcript.
+    result = (
+        "Loading recipe: Agent\n"
+        "  __( O)>  goose is ready\n"
+        "  ▸ shell git log --oneline\n"
+        "abc123 some commit\n"
+        "Joe has been working on the git mirror and the /agent command this week."
+    )
+    msg = await runner._delivery_message("s-9", "agent", {"result": result})
+    assert "Joe has been working on the git mirror" in msg
+    assert "Loading recipe" not in msg  # recipe banner stripped
+
+
 async def test_delivery_message_publishes_and_links(monkeypatch):
     monkeypatch.setattr(
         runner, "_publish_artifact", lambda s, h: "https://jomcgi.dev/artifact/abc123"


### PR DESCRIPTION
Three fixes from live `/agent` testing:

1. **Delivery** — a non-artifact run with no `goose-result` block (e.g. a question) now posts goose's **trailing narrative answer** (recipe banner stripped, tail kept) instead of the head-truncated raw transcript, which dumped the banner + tool calls and cut off the actual answer at the end. Every run now yields a meaningful response.
2. **Branding** — the live progress render is parametrized by command kind, so `/agent` shows "🤖 Running agent" / "✅ Done in Xs" instead of `/artifact`'s "🛠 Building your artifact" / "Built in Xs (reply here to iterate)".
3. **History** — dropped `--depth=1` from the workspace clone (kept `--filter=blob:none`). The shallow cut left the workspace with only the tip commit, so `git log` / "recent commits" saw 1 commit. Full commit history is now present, blobs still fetched lazily.

Charts: monolith `0.240.3 -> 0.240.4` (bot/runner), fc-invoke `0.4.3 -> 0.4.4` (guest git clone), targetRevisions in sync.

Verified: `go build`/`vet` + `ruff` clean; new tests for the trailing-narrative delivery and the no-`--depth` clone.

Follow-up (separate): a typed goose response schema so the agent always returns a structured result (addressing "always want some response").

🤖 Generated with [Claude Code](https://claude.com/claude-code)