### PR TITLE
feat(agent): typed goose response schema (always a structured result)

### DIFF
--- a/projects/firecracker/goosecracker/guest/recipes/agent.yaml
+++ b/projects/firecracker/goosecracker/guest/recipes/agent.yaml
@@ -9,17 +9,11 @@ instructions: |
   and test. Commit with Conventional Commits and push a claude/-prefixed branch
   if the task calls for code changes.
 
-  ## Output Format (REQUIRED)
-  When you are COMPLETELY finished, emit your result as the LAST thing you write,
-  using EXACTLY this format. Nothing after the closing marker.
-
-  ```goose-result
-  type: pr | issue | note
-  url: <artifact URL, if any>
-  summary: <1-2 sentences: the action you took and the outcome>
-  ```
-
-  The summary describes the ACTION and RESULT, not your reasoning.
+  When you finish, return a structured result (enforced by the response schema
+  below): a short `summary` of the action and outcome, or the answer itself if
+  the task was a question; optional `details` for the fuller answer or notable
+  findings; a `type` (pr/issue/note/answer); and a `url` if you opened a PR or
+  issue. The summary describes the ACTION and RESULT, not your reasoning.
 prompt: |
   {{ task_description | indent(2) }}
 parameters:
@@ -33,3 +27,22 @@ extensions:
 settings:
   max_turns: 50
   max_tool_repetitions: 5
+response:
+  json_schema:
+    type: object
+    properties:
+      summary:
+        type: string
+        description: "One or two sentences: the action taken and the outcome, or the answer itself if the task was a question."
+      details:
+        type: string
+        description: "Optional longer detail: the full answer, notable findings, or next steps. May be empty."
+      type:
+        type: string
+        enum: ["pr", "issue", "note", "answer"]
+        description: "The kind of result."
+      url:
+        type: string
+        description: "A PR or issue URL if one was opened; otherwise an empty string."
+    required:
+      - summary

--- a/projects/firecracker/substrate/chart/Chart.yaml
+++ b/projects/firecracker/substrate/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: fc-invoke
 description: Node-affine Firecracker invoke daemon that dispatches HTTP invocations to a pool of warm-base microVMs across named workloads (POST /invoke/{workload}, GET /healthz)
 type: application
-version: 0.4.4
+version: 0.4.5

--- a/projects/firecracker/substrate/deploy/application.yaml
+++ b/projects/firecracker/substrate/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tags pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: fc-invoke
-      targetRevision: 0.4.4
+      targetRevision: 0.4.5
       helm:
         valueFiles:
           - $values/projects/firecracker/substrate/deploy/values.yaml

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.240.4
+version: 0.240.5
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.240.4
+      targetRevision: 0.240.5
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/goosecracker/runner.py
+++ b/projects/monolith/goosecracker/runner.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import json
 import logging
 import os
 import re
@@ -163,6 +164,29 @@ def _extract_result_field(result: str, key: str) -> str:
     return m.group(1).strip() if m else ""
 
 
+def _parse_structured_result(result: str) -> dict | None:
+    """Parse the response-schema JSON goose emits as its final output.
+
+    A recipe with a ``response.json_schema`` (the agent recipe) makes goose print
+    a JSON object as the LAST line of stdout. Scan from the end for that trailing
+    brace-delimited line and parse it. Returns the dict, or None when there is no
+    valid trailing JSON object (e.g. a model that did not honor the schema), so
+    the caller can fall back to the markdown summary or the narrative.
+    """
+    for line in reversed(result.strip().splitlines()):
+        line = line.strip()
+        if not line:
+            continue
+        if line.startswith("{") and line.endswith("}"):
+            try:
+                obj = json.loads(line)
+            except ValueError:
+                return None
+            return obj if isinstance(obj, dict) else None
+        return None  # the last non-empty line is not a JSON object
+    return None
+
+
 def _agent_narrative(result: str) -> str:
     """Extract goose's final narrative answer from a transcript that has no
     ``goose-result`` block (e.g. a question rather than a coding action).
@@ -188,9 +212,10 @@ async def _delivery_message(session: str, recipe: str, data: dict) -> str:
     Artifact runs publish the built HTML and post a clean ``Artifact ready: <url>``
     (plus the recipe's one-line summary) instead of the raw goose transcript. A run
     that was meant to build an artifact but produced none gets a clear miss message.
-    Any other run (e.g. the coding ``agent``) posts the recipe's ``goose-result``
-    summary (plus a PR/issue url if it opened one), falling back to the truncated
-    transcript only when goose emitted no structured result block. When the guest
+    Any other run (e.g. the coding ``agent``) prefers the recipe's typed response
+    (a JSON object from response.json_schema): summary, optional details, and a
+    PR/issue url. It falls back to the legacy markdown summary, then goose's
+    trailing narrative, so there is always a meaningful response. When the guest
     recorded a scratch ref (WS3), a ``recorded: refs/agents/<session>`` line is
     appended for all run types.
     """
@@ -207,22 +232,33 @@ async def _delivery_message(session: str, recipe: str, data: dict) -> str:
     elif recipe == "artifact":
         msg = "Build finished but produced no artifact. Try rephrasing the request."
     else:
-        # Coding agent (and any non-artifact recipe): post the recipe's
-        # goose-result summary, not the raw transcript. Append the url only when
-        # it is a real link (goose leaves a placeholder when it opened nothing).
+        # Coding agent (and any non-artifact recipe). Prefer the typed response
+        # (the agent recipe's response.json_schema makes goose emit a JSON object
+        # as its final line): post its summary, plus optional details and a real
+        # url. Fall back to the legacy markdown goose-result summary, then to
+        # goose's trailing narrative, so there is ALWAYS a meaningful response.
         result = data.get("result", "") or ""
-        summary = _extract_summary(result)
-        if summary:
-            msg = summary
-            url = _extract_result_field(result, "url")
+        structured = _parse_structured_result(result)
+        if structured and str(structured.get("summary", "")).strip():
+            msg = str(structured["summary"]).strip()
+            details = str(structured.get("details", "") or "").strip()
+            if details:
+                msg += f"\n\n{details}"
+            url = str(structured.get("url", "") or "").strip()
             if url.startswith("http"):
                 msg += f"\n{url}"
+            msg = _truncate(msg)
         else:
-            # No structured block (e.g. a question rather than a coding action):
-            # goose's answer is its trailing narrative, so post that, not the head
-            # of the transcript (which is the recipe banner + tool calls, and would
-            # truncate away the actual answer at the end).
-            msg = _agent_narrative(result)
+            summary = _extract_summary(result)
+            if summary:
+                msg = summary
+                url = _extract_result_field(result, "url")
+                if url.startswith("http"):
+                    msg += f"\n{url}"
+            else:
+                # goose's answer is its trailing narrative (post that, not the head
+                # of the transcript, which is the recipe banner + tool calls).
+                msg = _agent_narrative(result)
 
     recorded_ref = data.get("recordedRef")
     if recorded_ref:

--- a/projects/monolith/goosecracker/tests/runner_test.py
+++ b/projects/monolith/goosecracker/tests/runner_test.py
@@ -89,6 +89,36 @@ async def test_delivery_message_agent_posts_trailing_narrative():
     assert "Loading recipe" not in msg  # recipe banner stripped
 
 
+async def test_delivery_message_agent_prefers_typed_response():
+    # The agent recipe's response.json_schema makes goose emit a JSON object as
+    # its last line; delivery posts its summary + details + real url, not the
+    # transcript.
+    result = (
+        "Loading recipe: Agent\n"
+        "  ▸ shell git status\n"
+        '{"type": "pr", "summary": "Fixed the parser null check.", '
+        '"details": "Added a guard in parse() and a regression test.", '
+        '"url": "https://github.com/jomcgi/homelab/pull/99"}'
+    )
+    msg = await runner._delivery_message("s-10", "agent", {"result": result})
+    assert "Fixed the parser null check." in msg
+    assert "Added a guard in parse()" in msg
+    assert "https://github.com/jomcgi/homelab/pull/99" in msg
+    assert "▸ shell" not in msg  # transcript not dumped
+
+
+async def test_delivery_message_agent_typed_response_summary_only():
+    result = '{"type": "answer", "summary": "There were 3 commits today."}'
+    msg = await runner._delivery_message("s-11", "agent", {"result": result})
+    assert "There were 3 commits today." in msg
+
+
+def test_parse_structured_result_none_when_no_trailing_json():
+    assert runner._parse_structured_result("just prose, no json") is None
+    assert runner._parse_structured_result("{ not valid json }") is None
+    assert runner._parse_structured_result('{"summary": "ok"}')["summary"] == "ok"
+
+
 async def test_delivery_message_publishes_and_links(monkeypatch):
     monkeypatch.setattr(
         runner, "_publish_artifact", lambda s, h: "https://jomcgi.dev/artifact/abc123"


### PR DESCRIPTION
Answers 'can we specify a typed goose output'. Adds a `response.json_schema` to the agent recipe (summary required; optional details/type/url) so goose returns a structured JSON result as its final line (via the provider's structured-output; vLLM guided_json). Delivery prefers the typed response, then the legacy markdown summary, then goose's trailing narrative, so a Discord interaction always gets a meaningful, structured response and degrades safely if the model ignores the schema.

Stacked on #3028. Charts: fc-invoke 0.4.4 -> 0.4.5 (recipe), monolith 0.240.4 -> 0.240.5 (delivery). Verified: ruff/compile/yaml clean; new tests for the typed path + parser + fallbacks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)