### PR TITLE
chore(monolith-public): bump chart to 0.82.13 for the leaderboard scatter redesign

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.82.12
+version: 0.82.13
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.82.12
+      targetRevision: 0.82.13
       helm:
         releaseName: monolith-public
         valueFiles:


### PR DESCRIPTION
Deploys the pass-rate-vs-efficiency scatter (PR #3026), which merged without a chart-version-bot bump (fast-merge skipped the PR-branch bot). Bumps Chart.yaml + targetRevision to 0.82.13 so ArgoCD pulls the rebuilt monolith-public frontend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)