### PR TITLE
feat(agent): conversational /agent threads with message queuing

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.240.6
+version: 0.240.7
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/migrations/20260701180000_goosecracker_agent_conversational.sql
+++ b/projects/monolith/chart/migrations/20260701180000_goosecracker_agent_conversational.sql
@@ -1,0 +1,18 @@
+-- Make goosecracker Discord thread sessions conversational.
+--
+-- Adds five columns to chat.goosecracker_sessions:
+--   recipe  - "artifact" or "agent", so the reply handler knows which code path to use
+--   tier    - model/guest tier (empty = in-cluster Qwen, "artifact" = OpenRouter)
+--   repo    - repository name for agent sessions (homelab, loom, etc.)
+--   running - true while a turn is in flight, prevents concurrent dispatches
+--   pending - newline-joined replies queued while running=true; drained on turn completion
+--
+-- Safe to run with data: all columns have defaults that match the pre-migration
+-- behaviour (existing rows are artifact sessions with no in-flight turn).
+
+ALTER TABLE chat.goosecracker_sessions
+    ADD COLUMN IF NOT EXISTS recipe  TEXT NOT NULL DEFAULT 'artifact',
+    ADD COLUMN IF NOT EXISTS tier    TEXT NOT NULL DEFAULT '',
+    ADD COLUMN IF NOT EXISTS repo    TEXT NOT NULL DEFAULT '',
+    ADD COLUMN IF NOT EXISTS running BOOLEAN NOT NULL DEFAULT false,
+    ADD COLUMN IF NOT EXISTS pending TEXT NOT NULL DEFAULT '';

--- a/projects/monolith/chart/migrations/atlas.sum
+++ b/projects/monolith/chart/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:3rBeaiC0PEFUF1sY0B2CnrSPZQDbO/LrjqcXubGFN2k=
+h1:zsFpCGgH0RqpUW/d+D4rGOsV+pREQFhprbpgBmpn0VQ=
 20260330000000_initial_schema.sql h1:J2futpSW0nJAIRR7nR7ssT7LwXIYrvRI+PkHb5Y4tLI=
 20260403000000_chat_schema.sql h1:pERUFC0vzM95etRuzp43XzkCV7lBCzrrtY5Mk7aF3CA=
 20260404000000_chat_attachments.sql h1:tv+Fdbr1rQC5nzUxfaBC0O6fu2OMGgLWf+YNg1WQXi4=
@@ -78,3 +78,4 @@ h1:3rBeaiC0PEFUF1sY0B2CnrSPZQDbO/LrjqcXubGFN2k=
 20260630160000_agent_threads_run_ledger.sql h1:CefVRWBVKiOubsPri1QExT9efKAcYvnPhFSLI9Nu0Ew=
 20260701120000_agent_threads_session_db.sql h1:4/JGaQPLywa9h/aIn4arv10pfBdwVQMX9ZhzvqEdgi8=
 20260701170000_drop_agent_threads_session_db.sql h1:9aN4D3ulssztT1xUAFyH0KsXQYlODy66sAbfvw4lCLg=
+20260701180000_goosecracker_agent_conversational.sql h1:6fsVJhi04dK+81t0XEgRGtX7AUBsf18oOuxLMo0PkO0=

--- a/projects/monolith/chat/api.py
+++ b/projects/monolith/chat/api.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 from chat.bot import send_message  # re-exported
 from chat.changelog import run_changelog_for_config  # re-exported
+from chat.goosecracker import drain_agent_queue  # re-exported
 from chat.goosecracker_progress import (  # re-exported
     mark_done as mark_goosecracker_progress_done,
 )
@@ -15,6 +16,7 @@ from chat.outbox import enqueue_message  # re-exported
 from chat.summarizer import run_summary_generation  # re-exported
 
 __all__ = [
+    "drain_agent_queue",
     "enqueue_message",
     "mark_goosecracker_progress_done",
     "run_changelog_for_config",

--- a/projects/monolith/chat/bot.py
+++ b/projects/monolith/chat/bot.py
@@ -715,6 +715,23 @@ class ChatBot(discord.Client):
             # Lost a race with session teardown; let normal handling take it.
             return False
 
+        action = result.get("action") if isinstance(result, dict) else None
+
+        if action == "queued":
+            # A turn is already running; the reply was queued for the next turn.
+            await message.reply("Queued - I'll pick this up after the current turn.")
+            await asyncio.to_thread(self._complete_lock, msg_id)
+            return True
+
+        if action == "dispatched":
+            # Agent thread: a new turn was dispatched (session was idle).
+            progress_msg = await message.reply("🤖 On it. Running the agent now...")
+            self._start_goosecracker_stream(thread_id, progress_msg, kind="agent")
+            await asyncio.to_thread(self._complete_lock, msg_id)
+            return True
+
+        # Artifact path: continue_session returned the raw submit result dict
+        # (action is "create" or "resume" from threads.upsert_run).
         progress_msg = await message.reply(
             "🛠 On it. Rebuilding your artifact; the link above will hot-reload..."
         )

--- a/projects/monolith/chat/goosecracker.py
+++ b/projects/monolith/chat/goosecracker.py
@@ -66,6 +66,18 @@ def _join_transcript(existing: str, message: str) -> str:
     return f"{existing}\n\n{message}"
 
 
+def _append_pending(existing: str, msg: str) -> str:
+    """Join a new reply onto the pending queue (newline-separated).
+
+    Used by the agent conversational path to accumulate replies that arrive
+    while a turn is running; the queue is drained as a single next-turn task
+    when the current turn finishes.
+    """
+    if not existing:
+        return msg
+    return f"{existing}\n{msg}"
+
+
 def start_session(thread_id: str, prompt: str) -> dict:
     """Record a new thread's transcript and dispatch the first artifact run.
 
@@ -96,40 +108,92 @@ def start_session(thread_id: str, prompt: str) -> dict:
 
 
 def continue_session(thread_id: str, message: str) -> dict | None:
-    """Append an owner follow-up and re-dispatch the FULL transcript (Model B).
+    """Append an owner follow-up and re-dispatch or queue depending on recipe.
 
-    Returns the dispatch result, or None when ``thread_id`` is not a goosecracker
-    thread (so the caller can fall through to normal handling). Synchronous; call
-    via ``asyncio.to_thread``.
+    Artifact sessions (recipe="artifact"): re-dispatch the full transcript (Model
+    B), preserving the original ADR 026 Phase 2 resume gate. Returns the raw
+    submit result dict.
+
+    Agent sessions (recipe="agent"): conversational queuing. If a turn is already
+    running, append the message to ``pending`` and return ``{"action": "queued"}``
+    so the bot can acknowledge without starting a new run. When idle, build the
+    next task from any backlog + this message, set running=True, dispatch, and
+    return ``{"action": "dispatched", ...submit result}``.
+
+    Returns None when ``thread_id`` is not a goosecracker thread so the caller
+    can fall through to normal chat handling. Synchronous; call via
+    asyncio.to_thread.
     """
-    from artifact import s3
-    from goosecracker.api import submit
-
     message = message.strip()
+    # Captured inside the session for use after the with-block.
+    _is_agent = False
+    _task = ""
+    _stored_recipe = ""
+    _stored_tier = ""
+    _stored_repo = ""
+    _transcript = ""
+
     with Session(get_engine()) as session:
         row = session.get(GoosecrackerSession, thread_id)
         if row is None:
             return None
+
+        # Accumulate the turn in the curated transcript for all recipe types.
         transcript = _join_transcript(row.transcript, message)
         row.transcript = transcript
         row.updated_at = datetime.now(timezone.utc)
-        session.add(row)
-        session.commit()
 
-    # ADR 026 Phase 2 (Model A vs B): if a persisted goose session exists for this
-    # thread, send only the new reply (Model A) so the guest can restore the
-    # session + prior artifact and edit in place; otherwise cold-rebuild from the
-    # FULL transcript (Model B). Guest-side session resume is still deferred (the
-    # fc-invoke agent handler names the session but does not restore it yet), so
-    # today both paths run cold and the choice only sets how much context is sent.
-    # The S3 check is the fallback gate (Task 2.4): no stored session -> full
-    # transcript, never a failure. Both paths run under the same session id.
+        if row.recipe == AGENT_RECIPE:
+            _is_agent = True
+            if row.running:
+                # A turn is already in flight: queue this reply for the next turn.
+                row.pending = _append_pending(row.pending, message)
+                session.add(row)
+                session.commit()
+                return {"action": "queued"}
+            # Idle: consume any backlog plus the new message as a single task.
+            _task = _append_pending(row.pending, message)
+            _stored_recipe = row.recipe
+            _stored_tier = row.tier
+            _stored_repo = row.repo
+            row.pending = ""
+            row.running = True
+            session.add(row)
+            session.commit()
+        else:
+            # Artifact path: commit the transcript update, then do the S3 check.
+            _transcript = transcript
+            session.add(row)
+            session.commit()
+
+    # Imports are lazy (circular import guard: chat.bot -> chat.goosecracker ->
+    # goosecracker.runner -> chat.api).
+    from goosecracker.api import submit
+
+    if _is_agent:
+        result = submit(
+            _task,
+            session=thread_id,
+            recipe=_stored_recipe,
+            tier=_stored_tier,
+            repo=_stored_repo,
+            discord_thread=thread_id,
+        )
+        return {"action": "dispatched", **result}
+
+    # Artifact path: ADR 026 Phase 2 (Model A vs B). If a persisted goose session
+    # exists for this thread, send only the new reply (Model A) so the guest can
+    # restore the session and edit in place; otherwise cold-rebuild from the full
+    # transcript (Model B). The S3 check is best-effort: a failure falls back to
+    # Model B, never a hard error.
+    from artifact import s3
+
     has_session = False
     try:
         has_session = s3.head_session(thread_id) is not None
     except Exception:
         logger.exception("goosecracker: session existence check failed; cold rebuild")
-    task = message if has_session else transcript
+    task = message if has_session else _transcript
     return submit(
         task,
         session=thread_id,
@@ -140,19 +204,23 @@ def continue_session(thread_id: str, message: str) -> dict | None:
 
 
 def start_agent_session(thread_id: str, repo: str, prompt: str) -> dict:
-    """Dispatch a one-shot agent run for the given Discord thread.
+    """Open a conversational agent session for a Discord thread.
 
-    Unlike ``start_session`` (artifact), this does not write a
-    GoosecrackerSession DB row, so thread replies fall through to normal chat
-    handling. Iterative /agent threads (continuation) are a future follow-up.
-    Synchronous; call via ``asyncio.to_thread``.
+    Dispatches the first turn and writes a GoosecrackerSession row so that
+    follow-up replies in the thread are routed through ``continue_session``
+    (agent path) with queuing support. The row is written AFTER dispatch so
+    that a failed submit leaves no row (mirroring ``start_session``).
+
+    Synchronous; call via asyncio.to_thread.
     """
     prompt = prompt.strip()
     # Imported lazily for the same reason as start_session (circular import
     # guard: chat.bot -> chat.goosecracker -> goosecracker.runner -> chat.api).
     from goosecracker.api import submit
 
-    return submit(
+    # Dispatch first: a failed submit leaves no session row, avoiding a stuck
+    # thread where future replies queue forever with no runner to drain them.
+    result = submit(
         prompt,
         session=thread_id,
         recipe=AGENT_RECIPE,
@@ -160,6 +228,19 @@ def start_agent_session(thread_id: str, repo: str, prompt: str) -> dict:
         repo=repo,
         discord_thread=thread_id,
     )
+    with Session(get_engine()) as session:
+        session.add(
+            GoosecrackerSession(
+                discord_thread=thread_id,
+                recipe=AGENT_RECIPE,
+                tier=AGENT_TIER,
+                repo=repo,
+                transcript=prompt,
+                running=True,
+            )
+        )
+        session.commit()
+    return result
 
 
 def is_goosecracker_thread(thread_id: str) -> bool:

--- a/projects/monolith/chat/goosecracker.py
+++ b/projects/monolith/chat/goosecracker.py
@@ -203,6 +203,34 @@ def continue_session(thread_id: str, message: str) -> dict | None:
     )
 
 
+def drain_agent_queue(thread_id: str) -> str | None:
+    """Drain a conversational agent thread's queue after a turn finishes.
+
+    Called by the goosecracker runner (via ``chat.api``) when an agent turn
+    completes. If replies were queued while the turn was running (``pending``
+    non-empty), return them as the next task, clear ``pending``, and keep
+    ``running=True`` so the caller dispatches the next turn. Otherwise set
+    ``running=False`` so the thread accepts new replies again. Sync; the caller
+    invokes it via ``asyncio.to_thread``. Lives here (not in the goosecracker
+    package) so the runner reaches it through ``chat.api`` and never imports
+    ``chat`` internals directly (import_boundaries_test).
+    """
+    with Session(get_engine()) as session:
+        row = session.get(GoosecrackerSession, thread_id)
+        if row is None:
+            return None
+        if row.pending:
+            task = row.pending
+            row.pending = ""
+            session.add(row)
+            session.commit()
+            return task
+        row.running = False
+        session.add(row)
+        session.commit()
+        return None
+
+
 def start_agent_session(thread_id: str, repo: str, prompt: str) -> dict:
     """Open a conversational agent session for a Discord thread.
 

--- a/projects/monolith/chat/goosecracker.py
+++ b/projects/monolith/chat/goosecracker.py
@@ -179,7 +179,10 @@ def continue_session(thread_id: str, message: str) -> dict | None:
             repo=_stored_repo,
             discord_thread=thread_id,
         )
-        return {"action": "dispatched", **result}
+        # Spread the submit result first, then set action: submit returns its own
+        # "action" (create/resume) and a later key wins in a dict merge, so
+        # "dispatched" must come last to override it (the bot routes on this).
+        return {**result, "action": "dispatched"}
 
     # Artifact path: ADR 026 Phase 2 (Model A vs B). If a persisted goose session
     # exists for this thread, send only the new reply (Model A) so the guest can

--- a/projects/monolith/chat/goosecracker_test.py
+++ b/projects/monolith/chat/goosecracker_test.py
@@ -213,7 +213,7 @@ def test_start_agent_session_writes_session_row(engine, fake_api):
     assert row.tier == ""
     assert row.repo == "homelab"
     assert row.transcript == "fix the bug"
-    assert row.running is True
+    assert row.running
     assert row.pending == ""
 
 
@@ -264,7 +264,7 @@ def test_continue_agent_session_dispatches_when_idle(engine, fake_api):
     # running should be True (set before dispatch)
     with Session(engine) as session:
         row = session.get(GoosecrackerSession, "agent-t1")
-    assert row.running is True
+    assert row.running
     assert row.pending == ""
 
 
@@ -280,7 +280,7 @@ def test_continue_agent_session_queues_when_running(engine, fake_api):
 
     with Session(engine) as session:
         row = session.get(GoosecrackerSession, "agent-t2")
-    assert row.running is True
+    assert row.running
     assert row.pending == "extra instruction"
 
 
@@ -311,7 +311,7 @@ def test_continue_agent_session_consumes_pending_on_dispatch(engine, fake_api):
     with Session(engine) as session:
         row = session.get(GoosecrackerSession, "agent-t4")
     assert row.pending == ""
-    assert row.running is True
+    assert row.running
 
 
 def test_continue_session_falls_back_to_cold_on_head_session_error(
@@ -338,3 +338,36 @@ def test_continue_session_falls_back_to_cold_on_head_session_error(
         tier="artifact",
         discord_thread="thread-1",
     )
+
+
+def test_drain_agent_queue_returns_task_and_clears_pending(engine):
+    """When pending is non-empty, drain returns the queued task, clears pending,
+    and keeps running=True so the runner dispatches the next turn."""
+    _make_agent_session(engine, "d-t1", running=True, pending="do something extra")
+    with patch("chat.goosecracker.get_engine", return_value=engine):
+        task = goosecracker.drain_agent_queue("d-t1")
+
+    assert task == "do something extra"
+    with Session(engine) as session:
+        row = session.get(GoosecrackerSession, "d-t1")
+    assert row.pending == ""
+    assert row.running  # runner handles dispatching the next turn
+
+
+def test_drain_agent_queue_clears_running_when_empty(engine):
+    """When pending is empty, drain returns None and sets running=False so the
+    thread accepts new replies again."""
+    _make_agent_session(engine, "d-t2", running=True, pending="")
+    with patch("chat.goosecracker.get_engine", return_value=engine):
+        task = goosecracker.drain_agent_queue("d-t2")
+
+    assert task is None
+    with Session(engine) as session:
+        row = session.get(GoosecrackerSession, "d-t2")
+    assert not row.running
+
+
+def test_drain_agent_queue_returns_none_for_unknown_thread(engine):
+    """No session row for the thread: drain returns None gracefully."""
+    with patch("chat.goosecracker.get_engine", return_value=engine):
+        assert goosecracker.drain_agent_queue("no-such-thread") is None

--- a/projects/monolith/chat/goosecracker_test.py
+++ b/projects/monolith/chat/goosecracker_test.py
@@ -185,9 +185,10 @@ def test_continue_session_cold_path_when_no_session(engine, fake_api, monkeypatc
     )
 
 
-def test_start_agent_session_dispatches_with_agent_recipe(fake_api):
+def test_start_agent_session_dispatches_with_agent_recipe(engine, fake_api):
     """start_agent_session submits with recipe='agent', tier='', and passes repo."""
-    goosecracker.start_agent_session("thread-2", "loom", "  add a login page  ")
+    with patch("chat.goosecracker.get_engine", return_value=engine):
+        goosecracker.start_agent_session("thread-2", "loom", "  add a login page  ")
 
     fake_api.submit.assert_called_once_with(
         "add a login page",
@@ -197,6 +198,120 @@ def test_start_agent_session_dispatches_with_agent_recipe(fake_api):
         repo="loom",
         discord_thread="thread-2",
     )
+
+
+def test_start_agent_session_writes_session_row(engine, fake_api):
+    """start_agent_session writes a GoosecrackerSession row with recipe='agent'
+    and running=True so that follow-up replies route through the agent path."""
+    with patch("chat.goosecracker.get_engine", return_value=engine):
+        goosecracker.start_agent_session("thread-3", "homelab", "  fix the bug  ")
+
+    with Session(engine) as session:
+        row = session.get(GoosecrackerSession, "thread-3")
+    assert row is not None
+    assert row.recipe == "agent"
+    assert row.tier == ""
+    assert row.repo == "homelab"
+    assert row.transcript == "fix the bug"
+    assert row.running is True
+    assert row.pending == ""
+
+
+# ---------------------------------------------------------------------------
+# Agent conversational path: continue_session queuing + dispatching
+# ---------------------------------------------------------------------------
+
+
+def _make_agent_session(
+    engine,
+    thread_id: str,
+    repo: str = "homelab",
+    running: bool = False,
+    pending: str = "",
+) -> None:
+    """Insert a GoosecrackerSession row for an agent thread directly."""
+    with Session(engine) as session:
+        session.add(
+            GoosecrackerSession(
+                discord_thread=thread_id,
+                recipe="agent",
+                tier="",
+                repo=repo,
+                transcript="initial task",
+                running=running,
+                pending=pending,
+            )
+        )
+        session.commit()
+
+
+def test_continue_agent_session_dispatches_when_idle(engine, fake_api):
+    """When recipe=agent and running=False, continue_session dispatches and returns
+    action='dispatched'."""
+    with patch("chat.goosecracker.get_engine", return_value=engine):
+        _make_agent_session(engine, "agent-t1", running=False)
+        result = goosecracker.continue_session("agent-t1", "now do this")
+
+    assert result is not None
+    assert result.get("action") == "dispatched"
+    fake_api.submit.assert_called_once()
+    call = fake_api.submit.call_args
+    assert call.args[0] == "now do this"  # task = message (no pending backlog)
+    assert call.kwargs["recipe"] == "agent"
+    assert call.kwargs["repo"] == "homelab"
+    assert call.kwargs["discord_thread"] == "agent-t1"
+
+    # running should be True (set before dispatch)
+    with Session(engine) as session:
+        row = session.get(GoosecrackerSession, "agent-t1")
+    assert row.running is True
+    assert row.pending == ""
+
+
+def test_continue_agent_session_queues_when_running(engine, fake_api):
+    """When recipe=agent and running=True, continue_session appends to pending and
+    returns action='queued' without dispatching."""
+    with patch("chat.goosecracker.get_engine", return_value=engine):
+        _make_agent_session(engine, "agent-t2", running=True)
+        result = goosecracker.continue_session("agent-t2", "extra instruction")
+
+    assert result == {"action": "queued"}
+    fake_api.submit.assert_not_called()
+
+    with Session(engine) as session:
+        row = session.get(GoosecrackerSession, "agent-t2")
+    assert row.running is True
+    assert row.pending == "extra instruction"
+
+
+def test_continue_agent_session_queues_multiple_appends_to_pending(engine, fake_api):
+    """Multiple queued replies are newline-joined in pending."""
+    with patch("chat.goosecracker.get_engine", return_value=engine):
+        _make_agent_session(engine, "agent-t3", running=True, pending="first reply")
+        result = goosecracker.continue_session("agent-t3", "second reply")
+
+    assert result == {"action": "queued"}
+    with Session(engine) as session:
+        row = session.get(GoosecrackerSession, "agent-t3")
+    assert row.pending == "first reply\nsecond reply"
+
+
+def test_continue_agent_session_consumes_pending_on_dispatch(engine, fake_api):
+    """When idle with a non-empty pending backlog, the full backlog + new message
+    becomes the task, and pending is cleared after dispatch."""
+    with patch("chat.goosecracker.get_engine", return_value=engine):
+        _make_agent_session(engine, "agent-t4", running=False, pending="queued msg")
+        result = goosecracker.continue_session("agent-t4", "new msg")
+
+    assert result is not None
+    assert result.get("action") == "dispatched"
+    call = fake_api.submit.call_args
+    assert call.args[0] == "queued msg\nnew msg"  # backlog + new joined by \n
+
+    with Session(engine) as session:
+        row = session.get(GoosecrackerSession, "agent-t4")
+    assert row.pending == ""
+    assert row.running is True
 
 
 def test_continue_session_falls_back_to_cold_on_head_session_error(

--- a/projects/monolith/chat/models.py
+++ b/projects/monolith/chat/models.py
@@ -119,12 +119,14 @@ class DiscordOutbox(SQLModel, table=True):
 
 
 class GoosecrackerSession(SQLModel, table=True):
-    """Per-Discord-thread curated transcript for the goosecracker artifact agent
-    (ADR 024 Task 4). One row per thread; transcript accumulates the owner's
-    instructions (never ambient chatter or the bot's replies). Each owner
-    follow-up re-runs goose from scratch with the full transcript (Model B), and
-    the thread id doubles as the stable ARTIFACT_ID so re-runs hot-reload the
-    same artifact.
+    """Per-Discord-thread curated transcript for the goosecracker agent (ADR 024).
+
+    One row per thread; transcript accumulates the owner's instructions (never
+    ambient chatter or the bot's replies). ``recipe`` distinguishes artifact
+    sessions (iterative HTML builder) from agent sessions (conversational coding
+    agent). Agent sessions are conversational: ``running`` is True while a turn is
+    in flight; replies that arrive during a run are appended to ``pending`` and
+    dispatched as the next turn when the current one finishes.
     """
 
     __tablename__ = "goosecracker_sessions"
@@ -132,5 +134,15 @@ class GoosecrackerSession(SQLModel, table=True):
 
     discord_thread: str = Field(primary_key=True)
     transcript: str = Field(default="")
+    # recipe/tier/repo mirror the dispatch.submit params so continue_session can
+    # re-dispatch without the caller re-supplying them.
+    recipe: str = Field(default="artifact")
+    tier: str = Field(default="")
+    repo: str = Field(default="")
+    # Conversational queue state (agent sessions only).
+    # running: a turn is currently in flight.
+    # pending: newline-joined replies queued while running=True; consumed on drain.
+    running: bool = Field(default=False)
+    pending: str = Field(default="")
     created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     updated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.240.6
+      targetRevision: 0.240.7
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/goosecracker/runner.py
+++ b/projects/monolith/goosecracker/runner.py
@@ -132,6 +132,41 @@ def _split_message(content: str) -> list[str]:
     return chunks
 
 
+def _drain_agent_queue(discord_thread: str) -> str | None:
+    """Drain the pending queue for an agent Discord thread after a turn finishes.
+
+    If replies were queued while the previous turn was running (``pending``
+    non-empty), take them as the next task, clear ``pending``, and keep
+    ``running=True`` so the caller can dispatch the next turn immediately.
+    If the queue is empty, set ``running=False`` so the thread accepts new
+    replies again.
+
+    Returns the next task string, or None when the queue was empty.
+
+    Opens its own Session; always call via asyncio.to_thread. Imports
+    ``chat.models.GoosecrackerSession`` lazily to avoid a module-level import
+    of the chat package from within the goosecracker package.
+    """
+    from chat.models import GoosecrackerSession
+
+    with Session(get_engine()) as session:
+        row = session.get(GoosecrackerSession, discord_thread)
+        if row is None:
+            return None
+        if row.pending:
+            task = row.pending
+            row.pending = ""
+            # Keep running=True; the caller dispatches the next run.
+            session.add(row)
+            session.commit()
+            return task
+        # Queue empty: allow new replies.
+        row.running = False
+        session.add(row)
+        session.commit()
+        return None
+
+
 def _enqueue_sync(channel_id: str, content: str) -> None:
     """Open a session, enqueue a Discord outbox row, commit. Sync so the async
     runner hands it to a worker thread (a sync Session must not run on the event
@@ -404,3 +439,38 @@ async def run_and_deliver(
         await _deliver(discord_thread, f"Run failed: {exc}")
     finally:
         _mark_progress_done(session)
+
+    # For agent runs fronting a Discord thread: drain any replies that arrived
+    # while this turn was running, then dispatch them as the next turn.
+    # This also clears running=False on the failed path so a crashed turn does
+    # not wedge the thread. Runs after finally: so the progress stream is already
+    # marked done before the next turn potentially starts.
+    if recipe == "agent" and discord_thread:
+        # nosemgrep: no-session-in-to-thread  # discord_thread is a str id, not a SQLAlchemy Session
+        next_task = await asyncio.to_thread(_drain_agent_queue, discord_thread)
+        if next_task is not None:
+            # Update the run ledger for the next task (mirrors dispatch.submit).
+            # nosemgrep: no-session-in-to-thread  # threads.upsert_run opens its own Session
+            await asyncio.to_thread(
+                threads.upsert_run,
+                session,
+                recipe=recipe,
+                tier=tier,
+                task=next_task,
+                discord_thread=discord_thread,
+            )
+            # Schedule the next turn as a detached task on the current event loop.
+            # No import of dispatch (circular: dispatch imports runner); use
+            # create_task directly since we are already inside an async context.
+            asyncio.create_task(
+                run_and_deliver(
+                    session,
+                    task=next_task,
+                    recipe=recipe,
+                    tier=tier,
+                    repo=repo,
+                    git_mirror=git_mirror,
+                    git_ref=git_ref,
+                    discord_thread=discord_thread,
+                )
+            )

--- a/projects/monolith/goosecracker/runner.py
+++ b/projects/monolith/goosecracker/runner.py
@@ -132,41 +132,6 @@ def _split_message(content: str) -> list[str]:
     return chunks
 
 
-def _drain_agent_queue(discord_thread: str) -> str | None:
-    """Drain the pending queue for an agent Discord thread after a turn finishes.
-
-    If replies were queued while the previous turn was running (``pending``
-    non-empty), take them as the next task, clear ``pending``, and keep
-    ``running=True`` so the caller can dispatch the next turn immediately.
-    If the queue is empty, set ``running=False`` so the thread accepts new
-    replies again.
-
-    Returns the next task string, or None when the queue was empty.
-
-    Opens its own Session; always call via asyncio.to_thread. Imports
-    ``chat.models.GoosecrackerSession`` lazily to avoid a module-level import
-    of the chat package from within the goosecracker package.
-    """
-    from chat.models import GoosecrackerSession
-
-    with Session(get_engine()) as session:
-        row = session.get(GoosecrackerSession, discord_thread)
-        if row is None:
-            return None
-        if row.pending:
-            task = row.pending
-            row.pending = ""
-            # Keep running=True; the caller dispatches the next run.
-            session.add(row)
-            session.commit()
-            return task
-        # Queue empty: allow new replies.
-        row.running = False
-        session.add(row)
-        session.commit()
-        return None
-
-
 def _enqueue_sync(channel_id: str, content: str) -> None:
     """Open a session, enqueue a Discord outbox row, commit. Sync so the async
     runner hands it to a worker thread (a sync Session must not run on the event
@@ -446,8 +411,13 @@ async def run_and_deliver(
     # not wedge the thread. Runs after finally: so the progress stream is already
     # marked done before the next turn potentially starts.
     if recipe == "agent" and discord_thread:
+        # The drain (DB work on chat.goosecracker_sessions) lives in the chat
+        # domain; reach it through chat.api so goosecracker never imports chat
+        # internals (import_boundaries_test).
+        from chat.api import drain_agent_queue
+
         # nosemgrep: no-session-in-to-thread  # discord_thread is a str id, not a SQLAlchemy Session
-        next_task = await asyncio.to_thread(_drain_agent_queue, discord_thread)
+        next_task = await asyncio.to_thread(drain_agent_queue, discord_thread)
         if next_task is not None:
             # Update the run ledger for the next task (mirrors dispatch.submit).
             # nosemgrep: no-session-in-to-thread  # threads.upsert_run opens its own Session

--- a/projects/monolith/goosecracker/tests/runner_test.py
+++ b/projects/monolith/goosecracker/tests/runner_test.py
@@ -2,10 +2,17 @@
 
 Covers the artifact publish + Discord message shaping, the default mirror wiring
 (WS2: GOOSECRACKER_GIT_MIRROR defaults gitMirror when caller omits it), and the
-recorded-ref line in delivery messages (WS3).
+recorded-ref line in delivery messages (WS3). Also covers _drain_agent_queue,
+the conversational-queue drain added for /agent thread continuations.
 """
 
 from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from sqlmodel import Session, SQLModel, create_engine
+from sqlmodel.pool import StaticPool
 
 from goosecracker import runner
 
@@ -273,3 +280,86 @@ def test_split_message_hard_splits_an_overlong_line():
     pages = runner._split_message("y" * 4000)
     assert len(pages) >= 2
     assert all(len(p) <= runner._MAX_DISCORD for p in pages)
+
+
+# ---------------------------------------------------------------------------
+# _drain_agent_queue: conversational-queue drain
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(name="engine")
+def engine_fixture():
+    """In-memory SQLite engine with schemas stripped for SQLite compatibility."""
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    original_schemas: dict[str, str] = {}
+    for table in SQLModel.metadata.tables.values():
+        if table.schema is not None:
+            original_schemas[table.name] = table.schema
+            table.schema = None
+    SQLModel.metadata.create_all(engine)
+    yield engine
+    for table in SQLModel.metadata.tables.values():
+        if table.name in original_schemas:
+            table.schema = original_schemas[table.name]
+
+
+def _insert_session(engine, thread_id: str, *, running: bool, pending: str) -> None:
+    from chat.models import GoosecrackerSession
+
+    with Session(engine) as session:
+        session.add(
+            GoosecrackerSession(
+                discord_thread=thread_id,
+                recipe="agent",
+                tier="",
+                repo="homelab",
+                transcript="do the thing",
+                running=running,
+                pending=pending,
+            )
+        )
+        session.commit()
+
+
+def test_drain_agent_queue_returns_task_and_clears_pending(engine):
+    """When pending is non-empty, _drain_agent_queue returns the task, clears
+    pending, and leaves running=True so the caller can dispatch the next turn."""
+    _insert_session(engine, "d-t1", running=True, pending="do something extra")
+
+    with patch("goosecracker.runner.get_engine", return_value=engine):
+        task = runner._drain_agent_queue("d-t1")
+
+    assert task == "do something extra"
+    from chat.models import GoosecrackerSession
+
+    with Session(engine) as session:
+        row = session.get(GoosecrackerSession, "d-t1")
+    assert row.pending == ""
+    assert row.running is True  # caller handles dispatching next turn
+
+
+def test_drain_agent_queue_clears_running_when_empty(engine):
+    """When pending is empty, _drain_agent_queue returns None and sets
+    running=False so the thread accepts new replies."""
+    _insert_session(engine, "d-t2", running=True, pending="")
+
+    with patch("goosecracker.runner.get_engine", return_value=engine):
+        task = runner._drain_agent_queue("d-t2")
+
+    assert task is None
+    from chat.models import GoosecrackerSession
+
+    with Session(engine) as session:
+        row = session.get(GoosecrackerSession, "d-t2")
+    assert row.running is False
+
+
+def test_drain_agent_queue_returns_none_for_unknown_thread(engine):
+    """When no GoosecrackerSession exists for the thread, return None gracefully."""
+    with patch("goosecracker.runner.get_engine", return_value=engine):
+        task = runner._drain_agent_queue("no-such-thread")
+    assert task is None

--- a/projects/monolith/goosecracker/tests/runner_test.py
+++ b/projects/monolith/goosecracker/tests/runner_test.py
@@ -8,11 +8,6 @@ the conversational-queue drain added for /agent thread continuations.
 
 from __future__ import annotations
 
-from unittest.mock import patch
-
-import pytest
-from sqlmodel import Session, SQLModel, create_engine
-from sqlmodel.pool import StaticPool
 
 from goosecracker import runner
 
@@ -280,86 +275,3 @@ def test_split_message_hard_splits_an_overlong_line():
     pages = runner._split_message("y" * 4000)
     assert len(pages) >= 2
     assert all(len(p) <= runner._MAX_DISCORD for p in pages)
-
-
-# ---------------------------------------------------------------------------
-# _drain_agent_queue: conversational-queue drain
-# ---------------------------------------------------------------------------
-
-
-@pytest.fixture(name="engine")
-def engine_fixture():
-    """In-memory SQLite engine with schemas stripped for SQLite compatibility."""
-    engine = create_engine(
-        "sqlite://",
-        connect_args={"check_same_thread": False},
-        poolclass=StaticPool,
-    )
-    original_schemas: dict[str, str] = {}
-    for table in SQLModel.metadata.tables.values():
-        if table.schema is not None:
-            original_schemas[table.name] = table.schema
-            table.schema = None
-    SQLModel.metadata.create_all(engine)
-    yield engine
-    for table in SQLModel.metadata.tables.values():
-        if table.name in original_schemas:
-            table.schema = original_schemas[table.name]
-
-
-def _insert_session(engine, thread_id: str, *, running: bool, pending: str) -> None:
-    from chat.models import GoosecrackerSession
-
-    with Session(engine) as session:
-        session.add(
-            GoosecrackerSession(
-                discord_thread=thread_id,
-                recipe="agent",
-                tier="",
-                repo="homelab",
-                transcript="do the thing",
-                running=running,
-                pending=pending,
-            )
-        )
-        session.commit()
-
-
-def test_drain_agent_queue_returns_task_and_clears_pending(engine):
-    """When pending is non-empty, _drain_agent_queue returns the task, clears
-    pending, and leaves running=True so the caller can dispatch the next turn."""
-    _insert_session(engine, "d-t1", running=True, pending="do something extra")
-
-    with patch("goosecracker.runner.get_engine", return_value=engine):
-        task = runner._drain_agent_queue("d-t1")
-
-    assert task == "do something extra"
-    from chat.models import GoosecrackerSession
-
-    with Session(engine) as session:
-        row = session.get(GoosecrackerSession, "d-t1")
-    assert row.pending == ""
-    assert row.running is True  # caller handles dispatching next turn
-
-
-def test_drain_agent_queue_clears_running_when_empty(engine):
-    """When pending is empty, _drain_agent_queue returns None and sets
-    running=False so the thread accepts new replies."""
-    _insert_session(engine, "d-t2", running=True, pending="")
-
-    with patch("goosecracker.runner.get_engine", return_value=engine):
-        task = runner._drain_agent_queue("d-t2")
-
-    assert task is None
-    from chat.models import GoosecrackerSession
-
-    with Session(engine) as session:
-        row = session.get(GoosecrackerSession, "d-t2")
-    assert row.running is False
-
-
-def test_drain_agent_queue_returns_none_for_unknown_thread(engine):
-    """When no GoosecrackerSession exists for the thread, return None gracefully."""
-    with patch("goosecracker.runner.get_engine", return_value=engine):
-        task = runner._drain_agent_queue("no-such-thread")
-    assert task is None


### PR DESCRIPTION
Makes `/agent` Discord threads conversational (owner's request): a reply in an `/agent` thread re-runs the coding agent in the same repo (conversation context resumes via the persisted sessions.db) instead of falling through to the chat agent. While a turn is running, incoming replies are **queued and batched into the next turn**, so it flows agent → response → queued feedback → next turn → response.

- **Migration** `20260701180000`: `chat.goosecracker_sessions` gains `recipe`/`tier`/`repo`/`running`/`pending` (safe defaults; existing artifact rows unaffected).
- `start_agent_session` writes a session row; `continue_session` branches on recipe (agent threads queue when running, dispatch when idle; artifact path unchanged).
- `run_and_deliver` **drains the queue on completion** (success + failure): dispatch the next turn carrying repo/mirror if pending, else clear `running` so a crashed turn can't wedge the thread. Re-dispatch via `asyncio.create_task` to avoid the dispatch↔runner circular import.
- Bot acks a queued reply without a second stream; a dispatched reply starts the agent stream.

Mentions stay chat (owner decision). Extracted clean 9-file set (+ migration) from the implementer branch; ruff/semgrep/atlas-checksum pass. Bump monolith 0.240.6 → 0.240.7.

Known limitation (later enhancement): each turn re-clones a fresh workspace but resumes the conversation, so multi-turn edits building on prior uncommitted work would need scratch-ref hydration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)