### PR TITLE
feat(agent): read repo CLAUDE.md for conventions + stop inventing URLs

### DIFF
--- a/projects/firecracker/goosecracker/guest/recipes/agent.yaml
+++ b/projects/firecracker/goosecracker/guest/recipes/agent.yaml
@@ -9,6 +9,12 @@ instructions: |
   and test. Commit with Conventional Commits and push a claude/-prefixed branch
   if the task calls for code changes.
 
+  Before you make changes, read ./CLAUDE.md at the repo root and the CLAUDE.md in
+  any project directory you touch (e.g. projects/<service>/CLAUDE.md). They hold
+  the repo's conventions, patterns, and anti-patterns (container images, GitOps,
+  chart bumps, writing style, and more). Follow them: matching the repo's existing
+  rules and style matters more than your own defaults.
+
   When you finish, return a structured result (enforced by the response schema
   below): a short `summary` of the action and outcome, or the answer itself if
   the task was a question; optional `details` for the fuller answer or notable
@@ -43,6 +49,6 @@ response:
         description: "The kind of result."
       url:
         type: string
-        description: "A PR or issue URL if one was opened; otherwise an empty string."
+        description: "A PR or issue URL ONLY if you actually opened one in this run (you have its real URL); otherwise an empty string. Never invent, guess, or reconstruct a URL."
     required:
       - summary

--- a/projects/firecracker/substrate/chart/Chart.yaml
+++ b/projects/firecracker/substrate/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: fc-invoke
 description: Node-affine Firecracker invoke daemon that dispatches HTTP invocations to a pool of warm-base microVMs across named workloads (POST /invoke/{workload}, GET /healthz)
 type: application
-version: 0.4.5
+version: 0.4.6

--- a/projects/firecracker/substrate/deploy/application.yaml
+++ b/projects/firecracker/substrate/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tags pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: fc-invoke
-      targetRevision: 0.4.5
+      targetRevision: 0.4.6
       helm:
         valueFiles:
           - $values/projects/firecracker/substrate/deploy/values.yaml


### PR DESCRIPTION
Option A: the agent already hydrates the repo, so ./CLAUDE.md + projects/*/CLAUDE.md are in /workspace. Instruct the agent to read them and follow the repo conventions before working (dynamic, always current, no recipe bloat). Also tighten the url response field so the model stops inventing links (it linked a homelab commit to block/goose). fc-invoke 0.4.5 -> 0.4.6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)