### PR TITLE
fix(substrate): bump chart to roll the goosecracker guest with sub-recipes

### DIFF
--- a/projects/firecracker/substrate/chart/Chart.yaml
+++ b/projects/firecracker/substrate/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: fc-invoke
 description: Node-affine Firecracker invoke daemon that dispatches HTTP invocations to a pool of warm-base microVMs across named workloads (POST /invoke/{workload}, GET /healthz)
 type: application
-version: 0.4.6
+version: 0.4.7

--- a/projects/firecracker/substrate/deploy/application.yaml
+++ b/projects/firecracker/substrate/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tags pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: fc-invoke
-      targetRevision: 0.4.6
+      targetRevision: 0.4.7
       helm:
         valueFiles:
           - $values/projects/firecracker/substrate/deploy/values.yaml


### PR DESCRIPTION
PR #3034 baked the new query/plan/implement sub-recipes into the goosecracker guest image, but chart-version-bot did not bump the substrate chart (the recipes live under goosecracker/guest/, outside the chart path), so fc-invoke is still running the dc4655e-tagged guest and the new router is not live. This bump re-pins the guest tag at chart-build so ArgoCD rolls it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)