### PR TITLE
fix(git-mirror): point loom mirror at weave-hand org

### DIFF
--- a/projects/firecracker/git-mirror/deploy/values.yaml
+++ b/projects/firecracker/git-mirror/deploy/values.yaml
@@ -11,8 +11,12 @@
 repos:
   - name: homelab
     url: https://github.com/jomcgi/homelab.git
+  # loom is PRIVATE, under the weave-hand org (not jomcgi). The mirror clones it
+  # via the mirror-side githubToken + insteadOf rewrite; the token has weave-hand
+  # read access. A jomcgi/loom URL 404s and the clone non-fatally skips, so /loom
+  # is "not exported" to guests. Keep this in sync with chart/values.yaml.
   - name: loom
-    url: https://github.com/jomcgi/loom.git
+    url: https://github.com/weave-hand/loom.git
 
 refreshIntervalSeconds: 60
 


### PR DESCRIPTION
## Problem

\`/agent repo:loom\` hydrates an **empty workspace**. Guest log:

\`\`\`
fatal: remote error: access denied or repository not exported: /loom
\`\`\`

Root cause: the mirror never created \`/mirrors/loom.git\`. At pod init:

\`\`\`
[init] cloning https://github.com/jomcgi/loom.git -> /mirrors/loom.git
fatal: repository 'https://github.com/jomcgi/loom.git/' not found
[init] WARNING: clone failed for loom; skipping
\`\`\`

loom lives under the **weave-hand** org, not \`jomcgi\`. \`chart/values.yaml\` already had the correct URL (#3024), but the \`deploy/values.yaml\` cluster override still pointed at \`jomcgi/loom.git\` and shadows the chart default in ArgoCD. \`ensure_repo\` non-fatally skips the 404 clone, so git-daemon later refuses guest clones of \`/loom\`.

## Fix

One-line: correct the deploy override URL to \`https://github.com/weave-hand/loom.git\`, matching the chart default.

## Verification

- Mirror token (\`monolith-chat-secrets\` \`GITHUB_TOKEN\`) already has weave-hand read access — proven via \`git ls-remote --heads https://github.com/weave-hand/loom.git\` from inside the mirror pod (returns \`refs/heads/main\` + branches).
- The \`repos\` list is templated into the supervisor \`ConfigMap\`; the deployment carries \`checksum/config\` over it, so this rolls the git-mirror pod → \`ensure_repo\` re-runs → clones weave-hand/loom → git-daemon serves \`/loom\`.
- \`homelab\` mirror is unaffected (healthy, 9217 commits, scratch \`refs/agents/*\` present).

No chart version bump: \`deploy/values.yaml\` is sourced from \`\$values\` at git HEAD, not the OCI chart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)