### PR TITLE
fix(goosecracker): correct CLAUDE.md path and cut answer verbosity in recipes

### DIFF
--- a/projects/firecracker/goosecracker/guest/recipes/agent.yaml
+++ b/projects/firecracker/goosecracker/guest/recipes/agent.yaml
@@ -1,4 +1,4 @@
-version: "1.1.0"
+version: "1.2.0"
 title: "Agent"
 description: "Routing agent for a snapshot-managed microVM thread (ADR 022): classifies the task and dispatches the matching sub-recipe."
 instructions: |
@@ -24,9 +24,13 @@ instructions: |
   plan run routes to implement.
 
   Before dispatching, spend at most a few tool calls gathering context the
-  worker will need: skim ./CLAUDE.md at the repo root, locate the relevant
+  worker will need: skim the repo's root CLAUDE.md, locate the relevant
   project directory, and note prior thread state (an earlier plan or PR in
-  this conversation). Pass what you found in the sub-recipe's context
+  this conversation). The root conventions file is not always ./CLAUDE.md:
+  in this repo it lives at .claude/CLAUDE.md. Locate it before reading, for
+  example `find . -maxdepth 2 -name CLAUDE.md`, rather than assuming the
+  path (a wrong guess wastes tool calls on a "No such file" error). Pass
+  what you found in the sub-recipe's context
   parameter as a short briefing: relevant paths, constraints, and any
   earlier results the worker cannot see (sub-recipes do not share your
   conversation history). Do not do the task yourself and do not deep-dive;
@@ -42,6 +46,13 @@ instructions: |
   you routed to; a `type` (pr/issue/note/answer); and a `url` only if the
   worker reported a real PR or issue URL. The summary describes the ACTION
   and RESULT, not your reasoning.
+
+  Keep it tight. For a casual or conversational question the summary is one
+  or two sentences and is the whole answer; leave `details` empty. Put length
+  in `details` only when the task explicitly asks for depth (a full
+  explanation, a breakdown, a report). Do not expand a simple question into a
+  wall of text: an over-long answer costs the owner a follow-up turn asking
+  you to be concise, which is the outcome this recipe exists to avoid.
 prompt: |
   {{ task_description | indent(2) }}
 parameters:

--- a/projects/firecracker/goosecracker/guest/recipes/agent.yaml
+++ b/projects/firecracker/goosecracker/guest/recipes/agent.yaml
@@ -47,12 +47,20 @@ instructions: |
   worker reported a real PR or issue URL. The summary describes the ACTION
   and RESULT, not your reasoning.
 
-  Keep it tight. For a casual or conversational question the summary is one
-  or two sentences and is the whole answer; leave `details` empty. Put length
-  in `details` only when the task explicitly asks for depth (a full
-  explanation, a breakdown, a report). Do not expand a simple question into a
-  wall of text: an over-long answer costs the owner a follow-up turn asking
-  you to be concise, which is the outcome this recipe exists to avoid.
+  Be brief and finish fast. Length is the main thing that makes a reply feel
+  slow: this runs on a local model, so every extra sentence is real wall-time,
+  and the owner reads the result in a chat window. Default to answering the
+  question in one or two sentences in `summary`, and leave `details` empty.
+  Fill `details` only when the task explicitly asks for depth (a full
+  explanation, a breakdown, a report), and keep it to a few short paragraphs
+  even then. Match the owner's register: a casual one-line question gets a
+  one-line answer, not an essay.
+
+  As soon as you have the answer, emit the final result and stop. Do not keep
+  exploring, re-explaining, or re-drafting a longer version once the answer is
+  known: extra turns are wasted wall-time. Over-answering costs the owner a
+  follow-up turn asking you to be concise, which is exactly the outcome this
+  recipe exists to avoid.
 prompt: |
   {{ task_description | indent(2) }}
 parameters:

--- a/projects/firecracker/goosecracker/guest/recipes/implement.yaml
+++ b/projects/firecracker/goosecracker/guest/recipes/implement.yaml
@@ -1,4 +1,4 @@
-version: "1.0.0"
+version: "1.1.0"
 title: "Implement"
 description: "Implementation sub-recipe: make a code or config change, commit it, and open a PR."
 instructions: |
@@ -9,9 +9,11 @@ instructions: |
   build. Commit with Conventional Commits and push a claude/-prefixed
   branch, opening a PR when the change is ready.
 
-  Before you make changes, read ./CLAUDE.md at the repo root and the
+  Before you make changes, read the repo's root CLAUDE.md and the
   CLAUDE.md in any project directory you touch
-  (e.g. projects/<service>/CLAUDE.md). They hold the repo's conventions,
+  (e.g. projects/<service>/CLAUDE.md). The root file is not always
+  ./CLAUDE.md: in this repo it lives at .claude/CLAUDE.md, so locate it
+  first, for example `find . -maxdepth 2 -name CLAUDE.md`. They hold the repo's conventions,
   patterns, and anti-patterns (container images are apko not Dockerfiles,
   GitOps via ArgoCD, chart version bumps must update both Chart.yaml and
   deploy/application.yaml, secrets via the 1Password operator, writing

--- a/projects/firecracker/goosecracker/guest/recipes/plan.yaml
+++ b/projects/firecracker/goosecracker/guest/recipes/plan.yaml
@@ -1,4 +1,4 @@
-version: "1.0.0"
+version: "1.1.0"
 title: "Plan"
 description: "Planning sub-recipe: turn a feature or change request into a written implementation plan, without implementing it."
 instructions: |
@@ -10,9 +10,11 @@ instructions: |
   your only deliverable.
 
   Ground yourself before planning:
-  - Read ./CLAUDE.md at the repo root: it holds the repo's conventions,
+  - Read the repo's root CLAUDE.md: it holds the repo's conventions,
     key patterns (GitOps, apko images, chart version bumps, secrets), and
-    anti-patterns. A plan that violates them is a bad plan.
+    anti-patterns. A plan that violates them is a bad plan. It is not always
+    ./CLAUDE.md: in this repo it lives at .claude/CLAUDE.md, so locate it
+    first, for example `find . -maxdepth 2 -name CLAUDE.md`.
   - Read the CLAUDE.md of any project directory the plan touches
     (e.g. projects/<service>/CLAUDE.md).
   - Check docs/decisions/ for ADRs that constrain the design, and

--- a/projects/firecracker/goosecracker/guest/recipes/query.yaml
+++ b/projects/firecracker/goosecracker/guest/recipes/query.yaml
@@ -1,4 +1,4 @@
-version: "1.0.0"
+version: "1.1.0"
 title: "Query"
 description: "Read-only investigation sub-recipe: answer a question about the repo or cluster without changing anything."
 instructions: |
@@ -6,8 +6,10 @@ instructions: |
   microVM, on a checkout of the repo at /workspace.
 
   Answer the question below by reading the repo. Ground yourself first: read
-  ./CLAUDE.md at the repo root for the repository layout, conventions, and
-  where things live (projects/, docs/, bazel/). If the question touches a
+  the repo's root CLAUDE.md for the repository layout, conventions, and where
+  things live (projects/, docs/, bazel/). It is not always ./CLAUDE.md: in
+  this repo it lives at .claude/CLAUDE.md, so locate it before reading, for
+  example `find . -maxdepth 2 -name CLAUDE.md`. If the question touches a
   specific service, also read that service's CLAUDE.md if one exists
   (e.g. projects/<service>/CLAUDE.md) and its deploy/ directory.
 


### PR DESCRIPTION
First `/improve-recipes` feedback-loop generation, run over the sessions since the recipe router landed (commit `9bc11aaac`, query/plan/implement sub-recipes). Classified against taxonomy v1; eval.json written for the 5 worst sessions.

## Before / after aggregates

There is **no previous generation to compare against**: the window before this one (22:57Z to 23:17Z, between the prior two recipe commits) contains zero sessions. This run establishes the baseline. Next `/improve-recipes` run compares against it.

This generation (9 sessions: 1 running, 1 env-failure, 7 completed):

| Metric | Value |
|---|---|
| Median wall time (completed) | 28.5s |
| Mean owner turns (completed) | 2.5 |
| Worst single-response latency | **233s** (one reply) |
| Failure-mode histogram | structured-output-miss x4, under-delivery x3, missing-context x1, tool-flail x1, wrong-route x1, env-failure x1 |

A key measurement finding: thread-level `wall_seconds` is misleading. On the 1026s "17-minute" session, ~894s were idle gaps waiting for the owner's next Discord message, not agent compute. Per-response latency (owner message to delivered answer) is the metric that reflects felt slowness, and it is dominated by output length.

## Per-edit evidence

### Edit 1: correct the CLAUDE.md path (all four recipes)

Every recipe instructed the agent to read `./CLAUDE.md` at the repo root, but the repo's conventions live at `.claude/CLAUDE.md`.

- **`s-016789282cd0`** (em-dash rule, 12s response, 8 tool calls): `grep /workspace/CLAUDE.md` returned `No such file or directory`, then `find` located `/workspace/.claude/CLAUDE.md`, then a third grep. Three tool calls wasted recovering from a path the recipe supplied.

Fix: recipes now say to locate the file (`find . -maxdepth 2 -name CLAUDE.md`) rather than assume `./CLAUDE.md`. Proven wrong in `agent.yaml`'s router run; the identical wrong path in `query.yaml`/`plan.yaml`/`implement.yaml` is corrected in the same pass (same checkout, same defect).

### Edit 2: brevity + finish-fast (agent.yaml result synthesis)

The router synthesized long answers, which is the primary per-response latency driver on the local model, and each `final_output` retry regenerates the whole payload, so length amplifies the retry cost.

- **`1522036551553515644`** ("explain this repo"): first reply **233s**, generated **~125,585 chars** (a ~10k-char answer regenerated across 11 retries). Owner's next message: "That's too much text, eli5 in 4 sentences or less."
- **`1522050377019822100`** ("wtf has Joe been up to"): ~9,451 chars, then 4 owner pushbacks including "You're yapping too much. Concise TLDR eli5 in 2 sentences." Highest owner-turn count (5) in the generation.
- **`s-016789282cd0`**: owner asked for "one sentence"; agent produced ~5,473 chars.

Fix: added a brevity rule to `agent.yaml` (answer in 1-2 sentences by default, `details` only on explicit depth requests, match the owner's register) plus a finish-fast rule (emit the result and stop once the answer is known; do not keep exploring or re-drafting).

Recipe `version` fields bumped (agent 1.1.0 to 1.2.0; query/plan/implement 1.0.0 to 1.1.0). All four validated with `yaml.safe_load`.

## Out of scope, observed

- **`final_output` vs `recipe__final_output` tool-name mismatch (goose harness bug, highest impact).** In 4 of 4 deep-read sessions the agent called `final_output` and got `-32002: Tool 'final_output' not found`; the registered tool is `recipe__final_output`. The harness then nags "You MUST call the `final_output` tool NOW" using the wrong bare name, and the model loops. Retries: `1522036551553515644` **11** (never recovered in window), `s-016789282cd0` 3, `1522044341294465117` 2, `1522050377019822100` 1. This is the generation's most-retried failure and it multiplies the verbosity cost, but the tool name and nag text come from goose, not the recipe YAML, so it is not fixed here. Recommend fixing the final-output enforcement to use the actual registered tool name (or registering the alias `final_output`).
- **fc-invoke HTTP 504** (`s-a366beed9b44`): infrastructure fault, env-failure, not diffed.
- **Router does the work instead of dispatching** (`1522050377019822100`, `1522036551553515644`): the router ran git log/tree and answered via `recipe__final_output` itself rather than dispatching the `query` sub-recipe. May be acceptable (fewer VM hops for trivial queries); recorded at low confidence, not diffed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)