### PR TITLE
fix(substrate): bump chart to roll goosecracker guest with recipe fixes

### DIFF
--- a/projects/firecracker/substrate/chart/Chart.yaml
+++ b/projects/firecracker/substrate/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: fc-invoke
 description: Node-affine Firecracker invoke daemon that dispatches HTTP invocations to a pool of warm-base microVMs across named workloads (POST /invoke/{workload}, GET /healthz)
 type: application
-version: 0.4.7
+version: 0.4.8

--- a/projects/firecracker/substrate/deploy/application.yaml
+++ b/projects/firecracker/substrate/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tags pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: fc-invoke
-      targetRevision: 0.4.7
+      targetRevision: 0.4.8
       helm:
         valueFiles:
           - $values/projects/firecracker/substrate/deploy/values.yaml


### PR DESCRIPTION
Follow-up to #3038. Recipe edits are baked into the goosecracker guest apko image, and the `fc-invoke` substrate chart pins that guest image at chart-build. Without a chart version bump ArgoCD keeps pulling 0.4.7 and the rebuilt guest never rolls (same pattern as #3034 -> `1afd4411d`).

Bumps `fc-invoke` 0.4.7 -> 0.4.8 (Chart.yaml + deploy/application.yaml targetRevision in sync). CI re-pins the guest tag at chart-build; ArgoCD syncs and the rootfs-builder rebakes the base rootfs from the new guest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)