### PR TITLE
fix(helm): keep_going on chart-version dep query so image-content changes auto-bump

### DIFF
--- a/bazel/helm/chart-version.sh
+++ b/bazel/helm/chart-version.sh
@@ -37,16 +37,27 @@ fi
 # --- Determine dependency directories ---
 DEP_DIRS=""
 if [[ -n "$BAZEL_PACKAGE" ]]; then
-	# Query Bazel for transitive source deps
-	DEP_DIRS=$(bazel query "deps(${BAZEL_PACKAGE})" --output=package 2>/dev/null |
+	# Query Bazel for transitive source deps. --keep_going is load-bearing: a
+	# dependency whose external closure fails to preload (e.g. an apko image
+	# layer pulling wolfi packages) otherwise fails the WHOLE query, and we
+	# silently under-scope to the chart dir below, missing image-content changes
+	# that must bump the chart. With --keep_going the query still emits the
+	# main-repo packages it could load, including the guest package where content
+	# like recipes lives. See oci_image_info(image=...), which widens this closure
+	# on purpose so a change layered into a pinned image bumps the dependent chart.
+	DEP_DIRS=$(bazel query "deps(${BAZEL_PACKAGE})" --output=package --keep_going 2>/dev/null |
 		grep -v '^@' |
 		sed 's|^//||' ||
 		true)
 fi
 
 if [[ -z "$DEP_DIRS" ]]; then
-	# Fallback: use chart directory only
-	echo >&2 "INFO: Bazel query unavailable or returned no results, using chart dir only"
+	# Fallback: chart directory only. This is a DEGRADED mode: a change to a
+	# dependency outside the chart dir (application code, a pinned image's
+	# content) will NOT bump the chart. Logged as a warning so a regression to
+	# dir-only scoping is visible in CI instead of surfacing later as a missing
+	# bump that needs a manual chart version fix.
+	echo >&2 "WARNING: Bazel dependency query returned nothing for ${BAZEL_PACKAGE}; falling back to chart-dir-only scoping (${CHART_DIR}). Dependency-scoped version bumping is DISABLED for this run."
 	DEP_DIRS="$CHART_DIR"
 fi
 


### PR DESCRIPTION
## Problem

Guest recipe changes never auto-bump the `fc-invoke` substrate chart, they need a manual `Chart.yaml` bump every time (see #3039, and `1afd4411d` before it). Root cause traced this session:

- The auto-bump dependency already exists by design. `oci_image_info` has an `image` attr wired by `apko_image` (`image = ":" + name`) specifically to widen the chart-version bot's `deps(<chart>.package)` closure so content layered into a pinned image bumps the dependent chart.
- The bot works for other charts (51 `chart-version-bot` bumps in the last 300 commits: monolith, monolith-public, semgrep-scand, ...), but never `fc-invoke`.
- The difference: `fc-invoke` pins two heavy apko guest images. Preloading `deps(//projects/firecracker/substrate/chart:chart.package)` fails on the guests' external wolfi/apko package repos (reproduced: `preloading transitive closure failed: no such package '@@rules_apko++...'`). `chart-version.sh` swallowed the error (`2>/dev/null || true`) and **silently fell back to chart-dir-only scoping**, so image-content changes were invisible to the bump logic.

## Fix

- Add `--keep_going` to the `deps()` query so a failed external-closure preload still emits the main-repo packages the query could load, including `projects/firecracker/goosecracker/guest` (and `.../semgrep/guest`) where recipes live.
- Change the chart-dir-only fallback log from INFO to WARNING and state that dependency-scoped bumping is disabled, so a future regression to degraded scoping is visible in CI rather than surfacing later as a missing bump.

Generalizes to every image-pinning chart, not just fc-invoke.

## Verification

CI-only-verifiable end to end: after this merges, the next change to a pinned image's content (e.g. a goosecracker guest recipe edit) should draw an automatic `chart-version-bot` bump on `fc-invoke` with no manual `Chart.yaml` step. `bash -n` and `shfmt` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)