### PR TITLE
fix(goosecracker): enforce router dispatch and bound tool output in recipes

### DIFF
--- a/projects/firecracker/goosecracker/guest/recipes/agent.yaml
+++ b/projects/firecracker/goosecracker/guest/recipes/agent.yaml
@@ -1,4 +1,4 @@
-version: "1.2.0"
+version: "1.3.0"
 title: "Agent"
 description: "Routing agent for a snapshot-managed microVM thread (ADR 022): classifies the task and dispatches the matching sub-recipe."
 instructions: |
@@ -35,6 +35,15 @@ instructions: |
   earlier results the worker cannot see (sub-recipes do not share your
   conversation history). Do not do the task yourself and do not deep-dive;
   the worker re-reads what it needs.
+
+  Dispatch the actual work; never run it in the router. Your context is
+  shared across the whole thread, so a large tool output here (a full
+  `git log`, a wide `grep`, a big file) can overflow it and trigger a
+  compaction that drops the answer mid-run. Context-gathering is a couple of
+  SMALL reads only. If answering needs the git history, many files, or large
+  output, that is the sub-recipe's job, not yours: route it. Bound anything
+  you do read (pipe through `head`, count with `wc -l` first, sample) and
+  never pull hundreds of log lines into your context.
 
   Then call the matching sub-recipe tool with the task (verbatim or lightly
   clarified) and your context briefing, and wait for its result.

--- a/projects/firecracker/goosecracker/guest/recipes/implement.yaml
+++ b/projects/firecracker/goosecracker/guest/recipes/implement.yaml
@@ -1,4 +1,4 @@
-version: "1.1.0"
+version: "1.2.0"
 title: "Implement"
 description: "Implementation sub-recipe: make a code or config change, commit it, and open a PR."
 instructions: |
@@ -23,6 +23,11 @@ instructions: |
   Keep the change minimal and focused on the task. Tests run in CI on push,
   not locally; make the change correct by reading the surrounding code and
   existing tests, and update any tests that assert on values you changed.
+
+  Keep tool output small: you run in a limited context window, so bound reads
+  (`head`, `wc -l` first, sample) rather than dumping a full `git log` or
+  large files, which can overflow context and trigger a compaction that loses
+  progress.
 
   Your final message is returned verbatim to the routing agent: state the
   action taken and the outcome in one or two sentences, the branch name,

--- a/projects/firecracker/goosecracker/guest/recipes/plan.yaml
+++ b/projects/firecracker/goosecracker/guest/recipes/plan.yaml
@@ -1,4 +1,4 @@
-version: "1.1.0"
+version: "1.2.0"
 title: "Plan"
 description: "Planning sub-recipe: turn a feature or change request into a written implementation plan, without implementing it."
 instructions: |
@@ -21,6 +21,10 @@ instructions: |
     docs/plans/ for prior plans that overlap.
   - Read the actual code and deploy configs the plan would change; a plan
     grounded in real file paths beats one written from memory.
+  - Keep tool output small: you run in a limited context window, so bound
+    reads (`head`, `wc -l` first, sample, narrow the query) rather than
+    dumping a full `git log` or large files, which can overflow context and
+    trigger a compaction that loses progress.
 
   The plan itself:
   - Start with the goal in one or two sentences, then list 2-3 candidate

--- a/projects/firecracker/goosecracker/guest/recipes/query.yaml
+++ b/projects/firecracker/goosecracker/guest/recipes/query.yaml
@@ -1,4 +1,4 @@
-version: "1.1.0"
+version: "1.2.0"
 title: "Query"
 description: "Read-only investigation sub-recipe: answer a question about the repo or cluster without changing anything."
 instructions: |
@@ -17,6 +17,12 @@ instructions: |
   - READ ONLY. Do not edit files, do not commit, do not push, do not open
     PRs or issues. Shell commands must be non-mutating (cat, ls, grep, find,
     git log, git show).
+  - Keep tool output small. You run in a limited context window; a large dump
+    (a full `git log`, a wide `grep`, a big file) can overflow it and trigger
+    a compaction that loses your progress and can drop the final answer. Bound
+    every read: pipe through `head`, count with `wc -l` first, sample, or
+    narrow the query, and analyze incrementally rather than pulling everything
+    in at once.
   - Cite evidence: name the files and paths your answer rests on.
   - If the answer is genuinely not in the repo, say so plainly instead of
     guessing.


### PR DESCRIPTION
## Problem (from a live test session)

Session `1522083285574877215` ("looking at fix commits are there dev tooling improvements...") showed "Done" in Discord with **no answer delivered**. Transcript root cause:

1. The router ran `git log --grep="^fix" -n 300` **itself** instead of dispatching to the `query` sub-recipe, pulling **~48,000 chars** of commit log into its shared thread context (on an already-long resumed thread).
2. That overflowed the context window and triggered goose compaction (`"Your context was compacted..."` appears verbatim in the transcript).
3. Compaction **replayed the user turn**, and the agent looped re-running git log and re-analyzing, never calling `final_output`. The run ended with no summary posted.

This is distinct from the earlier `final_output` naming bug (turn 1 of the same thread delivered fine).

## Fix (Option 3: both levers)

- **Router dispatch enforcement (`agent.yaml`):** a hard rule that the router dispatches the actual work and never runs it inline. Context-gathering is a couple of small reads only; heavy reads (git history, many files, large output) are the sub-recipe's job, which runs in an isolated context so a big output can't overflow the router's shared thread context.
- **Output-size discipline (all four recipes):** keep tool output small, `head` / `wc -l` first / sample / narrow the query, so a large dump can't overflow the limited context window and trigger a compaction that drops progress.

Recipe versions bumped (agent 1.2.0 -> 1.3.0; query/plan/implement 1.1.0 -> 1.2.0). All four validated with `yaml.safe_load`.

## Out of scope (harness)

goose compaction replays the turn without guaranteeing a `final_output`. These recipe mitigations shrink the trigger (less chance of overflow), but a mid-task compaction can still drop the answer. A durable fix belongs in the harness: emit/preserve the structured final output across compaction, or raise the router's context budget.

## Note: also verifies #3042

This is a guest-content change with no manual substrate bump. If #3042's `--keep_going` fix works, `chart-version-bot` should auto-bump `fc-invoke` on merge. I'll confirm post-merge and bump manually only if the bot doesn't fire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)