### PR TITLE
chore(campsites): bump monolith + monolith-public charts to deploy campsites changes

### DIFF
--- a/projects/monolith-public/chart/Chart.yaml
+++ b/projects/monolith-public/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monolith-public
 description: Read-only public tier of the monolith (ADR 004 Phase 5), Linkerd-meshed and pruned
 type: application
-version: 0.82.13
+version: 0.82.14
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/projects/monolith-public/deploy/application.yaml
+++ b/projects/monolith-public/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith-public
-      targetRevision: 0.82.13
+      targetRevision: 0.82.14
       helm:
         releaseName: monolith-public
         valueFiles:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.240.7
+version: 0.240.8
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.240.7
+      targetRevision: 0.240.8
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
chart-version-bot did not bump either chart for the recent campsites image-content changes (#3041 Strathcona coords, #3043 60s CDN cache, #3045 night selector), verified by DAG order (both charts still pointed at a pre-campsites revision ~15 min after merge). Bumping both manually so the changes actually roll.

- **monolith** 0.240.7 → 0.240.8: private tier, ships `catalog.json` (for the hourly `refresh_handler` to upsert the corrected Strathcona coords) and the snapshot router cache header.
- **monolith-public** 0.82.13 → 0.82.14: jomcgi.dev tier, ships the SSR page night selector and the 60s `Cache-Control` header.

`Chart.yaml` version and `deploy/application.yaml` `targetRevision` kept in sync for both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)