### PR TITLE
fix(signoz): drop dangling hikes-httpcheck-alert kustomization entry

### DIFF
--- a/projects/platform/signoz/kustomization.yaml
+++ b/projects/platform/signoz/kustomization.yaml
@@ -7,5 +7,4 @@ resources:
   - incidentio-channel.yaml
   - signoz-httpcheck-alert.yaml
   - jomcgi-dev-httpcheck-alert.yaml
-  - hikes-httpcheck-alert.yaml
   - trips-pages-httpcheck-alert.yaml


### PR DESCRIPTION
## Impact: fleet-wide ArgoCD freeze

The hikes-frontend removal (`164be837f` / `77680ca77`) deleted `projects/platform/signoz/hikes-httpcheck-alert.yaml` but left its entry in `projects/platform/signoz/kustomization.yaml:10`. `kustomize build projects/home-cluster` then failed with `must resolve to a file ... hikes-httpcheck-alert.yaml: no such file or directory`, putting the **canada** root app-of-apps into `ComparisonError`.

Because canada syncs `projects/home-cluster` and every Application hangs off it, this froze **all** ArgoCD syncs: canada last synced `03:28Z` and was still stale ~80 min later, so no service (including the pending campsites chart bumps in #3047) rolled.

## Fix

Remove the one dangling resource entry. `trips-pages-httpcheck-alert.yaml` still exists and stays. Verified the other six referenced files are present.

Once merged and canada re-syncs, the fleet unfreezes and the queued chart bumps roll out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)