### PR TITLE
feat(goosecracker): upgrade goose to v1.39.0 and set qwen context budget

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -483,10 +483,10 @@ multiarch_http_archive = use_repo_rule("//bazel/tools/http:multiarch_http_archiv
 
 multiarch_http_archive(
     name = "goose",
-    amd64_sha256 = "cfd81f9e17a02d3b87917de7411e43daa7bb72fb3b79fc26c3329010a0471f1e",
-    amd64_url = "https://github.com/block/goose/releases/download/v1.27.1/goose-x86_64-unknown-linux-gnu.tar.bz2",
-    arm64_sha256 = "fae890273700778a73891c51afe992aee254657fb0882702596eb7a6aeb1b894",
-    arm64_url = "https://github.com/block/goose/releases/download/v1.27.1/goose-aarch64-unknown-linux-gnu.tar.bz2",
+    amd64_sha256 = "cf0100d2f4e085e4ec537e8399950d4695661bff83d12dc45a9a6d357cd33c41",
+    amd64_url = "https://github.com/block/goose/releases/download/v1.39.0/goose-x86_64-unknown-linux-gnu.tar.bz2",
+    arm64_sha256 = "a0a03859f0b3810863ce212b0c11a6cf3126a074db708bf39cf46af513bdd273",
+    arm64_url = "https://github.com/block/goose/releases/download/v1.39.0/goose-aarch64-unknown-linux-gnu.tar.bz2",
     binary_name = "goose",
     package_dir = "/usr/local/bin",
 )

--- a/projects/firecracker/substrate/chart/Chart.yaml
+++ b/projects/firecracker/substrate/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: fc-invoke
 description: Node-affine Firecracker invoke daemon that dispatches HTTP invocations to a pool of warm-base microVMs across named workloads (POST /invoke/{workload}, GET /healthz)
 type: application
-version: 0.4.8
+version: 0.4.9

--- a/projects/firecracker/substrate/deploy/application.yaml
+++ b/projects/firecracker/substrate/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tags pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: fc-invoke
-      targetRevision: 0.4.8
+      targetRevision: 0.4.9
       helm:
         valueFiles:
           - $values/projects/firecracker/substrate/deploy/values.yaml

--- a/projects/monolith/deploy/values.yaml
+++ b/projects/monolith/deploy/values.yaml
@@ -174,6 +174,22 @@ goosecracker:
       OPENAI_API_KEY: sk-noauth
       GOOSE_PROVIDER: openai
       GOOSE_MODEL: qwen3.6-27b
+      # Context budget for the qwen endpoint (vLLM maxModelLen 32768). Without
+      # GOOSE_CONTEXT_LIMIT goose assumes 128k and never compacts before the real
+      # 32k wall, so a large tool output (e.g. a full git log) overruns the model,
+      # errors, and goose reactively summarizes in a loop that can drop the answer.
+      # Telling goose the true window makes it compact proactively at ~80%.
+      GOOSE_CONTEXT_LIMIT: "32768"
+      # Cap a single tool response so one big output cannot fill a 32k window
+      # (goose >= 1.38 truncates above this many characters). Catches git-log /
+      # wide-grep dumps while leaving normal file reads intact.
+      GOOSE_MAX_TOOL_RESPONSE_SIZE: "10000"
+      # Cap per-response generation (output tokens), leaving input room in 32k.
+      # Bounds a text answer; a PR is built across many turns so it is unaffected.
+      GOOSE_MAX_TOKENS: "8000"
+      # Summarize older tool outputs after this many calls (default 10) to keep
+      # long resumed threads lean on a small window.
+      GOOSE_TOOL_CALL_CUTOFF: "5"
       # A default-tier guest holds the gh placeholder; the fc-invoke egress proxy
       # swaps it for the real token only on api.github.com.
       GITHUB_TOKEN: "kloak:gh:01JZX8K3N7Q2M5R9W4T6Y0F1B8"


### PR DESCRIPTION
## What

- Upgrades the guest goose binary **v1.27.1 -> v1.39.0** (`MODULE.bazel`).
- Sets the qwen (`default`) tier's context budget in `projects/monolith/deploy/values.yaml` (artifact/Gemini tier untouched).
- Bumps the `fc-invoke` substrate chart **0.4.8 -> 0.4.9** to rebuild and roll the guest. This also finally deploys the recipe fixes from #3046 (chart-version-bot did not auto-bump; see note).

## Why

A production session ran a ~48k-char `git log` into a 32k-token model and looped in reactive compaction, dropping the answer. Root cause was a context-budget mismatch: goose defaulted `GOOSE_CONTEXT_LIMIT` to 128k while vLLM `maxModelLen` is 32768, so it never compacted before the real wall. The deterministic per-tool-output cap (`GOOSE_MAX_TOOL_RESPONSE_SIZE`) needed goose >= v1.38.0, hence the upgrade.

## Upgrade safety (static, no local test loop)

- **CLI flags survive**: `--recipe`, `--no-profile` (confirmed in `cli.rs:191`, present but undocumented), `--with-builtin`, `--params`, `--resume`, `--name`, `--text`.
- **Recipe schema compatible**: `Recipe`/`Settings` have no `deny_unknown_fields`, so our `settings.max_tool_repetitions` becomes a silent no-op instead of a parse error; `version`/`instructions`/`prompt`/`extensions`/`parameters`/`response.json_schema`/`sub_recipes`/`retry` all still supported.
- New sha256 for both arches verified by downloading the v1.39.0 gnu tarballs.

## Context budget (qwen `default` tier only)

| Env | Value | Why |
|---|---|---|
| `GOOSE_CONTEXT_LIMIT` | `32768` | Match vLLM maxModelLen; compact proactively before the wall (primary fix) |
| `GOOSE_MAX_TOOL_RESPONSE_SIZE` | `10000` | One big tool output can't fill a 32k window (v1.39 truncates above this) |
| `GOOSE_MAX_TOKENS` | `8000` | Leave input room; bounds text answers, not multi-turn PRs |
| `GOOSE_TOOL_CALL_CUTOFF` | `5` | Summarize old tool outputs sooner on a small window |

## Verification

Static checks above pass. Runtime behavior (recipe load, sub-recipe dispatch, structured output, compaction) is verifiable only live: after deploy I'll run an `/agent` smoke test and confirm a run completes and delivers an answer, plus a repeat of the "fix commits" query that previously overflowed.

## Note (separate follow-up)

`chart-version-bot` still did not auto-bump `fc-invoke` after #3046 despite #3042's `--keep_going` fix, so this PR bumps the substrate chart manually. The auto-bump path needs more investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)