### PR TITLE
fix(goosecracker): drop unsupported indent filter from recipe prompts (v1.39.0 hotfix)

### DIFF
--- a/projects/firecracker/goosecracker/guest/recipes/agent.yaml
+++ b/projects/firecracker/goosecracker/guest/recipes/agent.yaml
@@ -1,4 +1,4 @@
-version: "1.3.0"
+version: "1.3.1"
 title: "Agent"
 description: "Routing agent for a snapshot-managed microVM thread (ADR 022): classifies the task and dispatches the matching sub-recipe."
 instructions: |
@@ -71,7 +71,7 @@ instructions: |
   follow-up turn asking you to be concise, which is exactly the outcome this
   recipe exists to avoid.
 prompt: |
-  {{ task_description | indent(2) }}
+  {{ task_description }}
 parameters:
   - key: task_description
     description: "The task to perform"

--- a/projects/firecracker/goosecracker/guest/recipes/artifact.yaml
+++ b/projects/firecracker/goosecracker/guest/recipes/artifact.yaml
@@ -1,4 +1,4 @@
-version: "1.0.0"
+version: "1.0.1"
 title: "Artifact"
 description: "Build a single web artifact (may use CDN libs + live https APIs); the harness publishes it to a live URL (ADR 024)."
 instructions: |
@@ -43,7 +43,7 @@ prompt: |
   Build this artifact now. Start immediately by writing /tmp/artifact.html with
   the shell or editor; do not reply with a plan or a description first:
 
-  {{ task_description | indent(2) }}
+  {{ task_description }}
 parameters:
   - key: task_description
     description: "What to build"

--- a/projects/firecracker/goosecracker/guest/recipes/implement.yaml
+++ b/projects/firecracker/goosecracker/guest/recipes/implement.yaml
@@ -1,4 +1,4 @@
-version: "1.2.0"
+version: "1.2.1"
 title: "Implement"
 description: "Implementation sub-recipe: make a code or config change, commit it, and open a PR."
 instructions: |
@@ -44,10 +44,10 @@ parameters:
     requirement: optional
     default: ""
 prompt: |
-  {{ task_description | indent(2) }}
+  {{ task_description }}
 
   Router context (may be empty):
-  {{ context | indent(2) }}
+  {{ context }}
 extensions:
   - type: builtin
     name: developer

--- a/projects/firecracker/goosecracker/guest/recipes/plan.yaml
+++ b/projects/firecracker/goosecracker/guest/recipes/plan.yaml
@@ -1,4 +1,4 @@
-version: "1.2.0"
+version: "1.2.1"
 title: "Plan"
 description: "Planning sub-recipe: turn a feature or change request into a written implementation plan, without implementing it."
 instructions: |
@@ -53,10 +53,10 @@ parameters:
     requirement: optional
     default: ""
 prompt: |
-  {{ task_description | indent(2) }}
+  {{ task_description }}
 
   Router context (may be empty):
-  {{ context | indent(2) }}
+  {{ context }}
 extensions:
   - type: builtin
     name: developer

--- a/projects/firecracker/goosecracker/guest/recipes/query.yaml
+++ b/projects/firecracker/goosecracker/guest/recipes/query.yaml
@@ -1,4 +1,4 @@
-version: "1.2.0"
+version: "1.2.1"
 title: "Query"
 description: "Read-only investigation sub-recipe: answer a question about the repo or cluster without changing anything."
 instructions: |
@@ -41,10 +41,10 @@ parameters:
     requirement: optional
     default: ""
 prompt: |
-  {{ task_description | indent(2) }}
+  {{ task_description }}
 
   Router context (may be empty):
-  {{ context | indent(2) }}
+  {{ context }}
 extensions:
   - type: builtin
     name: developer

--- a/projects/firecracker/substrate/chart/Chart.yaml
+++ b/projects/firecracker/substrate/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: fc-invoke
 description: Node-affine Firecracker invoke daemon that dispatches HTTP invocations to a pool of warm-base microVMs across named workloads (POST /invoke/{workload}, GET /healthz)
 type: application
-version: 0.4.9
+version: 0.4.10

--- a/projects/firecracker/substrate/deploy/application.yaml
+++ b/projects/firecracker/substrate/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tags pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: fc-invoke
-      targetRevision: 0.4.9
+      targetRevision: 0.4.10
       helm:
         valueFiles:
           - $values/projects/firecracker/substrate/deploy/values.yaml


### PR DESCRIPTION
## Hotfix: agent runs broken by the goose v1.39.0 upgrade

After #3051 (goose v1.27.1 -> v1.39.0), every `/agent` run failed at recipe load:

```
Error: Invalid recipe: unknown filter: filter indent is unknown (in recipe:74)
```

(exit status 1, ~1s; confirmed in the fc-invoke guest logs). goose v1.39.0's recipe template engine no longer registers the `indent` filter, and all five recipes used `{{ task_description | indent(2) }}` (and `{{ context | indent(2) }}`) in their `prompt:` blocks.

## Fix

Remove ` | indent(2)` from every recipe prompt. The filter was purely cosmetic (indenting multi-line continuation under the YAML block scalar); plain `{{ task_description }}` / `{{ context }}` substitution is unaffected and is the only template construct left. Patch-bumped the five recipes; substrate chart 0.4.9 -> 0.4.10 to roll.

This is the one runtime incompatibility the static pre-upgrade checks (CLI flags, recipe struct fields) couldn't catch, template-filter registration isn't in the recipe schema.

## Verify

After deploy I'll re-run the `/agent` smoke test (the fix-commits query) and confirm a run completes and delivers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)