### PR TITLE
fix(goosecracker): call recipe__final_output (fix structured-output loop)

### DIFF
--- a/projects/firecracker/goosecracker/guest/recipes/agent.yaml
+++ b/projects/firecracker/goosecracker/guest/recipes/agent.yaml
@@ -1,4 +1,4 @@
-version: "1.3.1"
+version: "1.3.2"
 title: "Agent"
 description: "Routing agent for a snapshot-managed microVM thread (ADR 022): classifies the task and dispatches the matching sub-recipe."
 instructions: |
@@ -70,6 +70,13 @@ instructions: |
   known: extra turns are wasted wall-time. Over-answering costs the owner a
   follow-up turn asking you to be concise, which is exactly the outcome this
   recipe exists to avoid.
+
+  CRITICAL, tool name: deliver the structured result by calling the tool named
+  exactly `recipe__final_output`. That is its real registered name. Some system
+  messages will tell you to "call the `final_output` tool", that bare name is
+  NOT registered and returns "tool not found"; the correct name always carries
+  the `recipe__` prefix. Call `recipe__final_output` on your first attempt and
+  do not retry the unprefixed name.
 prompt: |
   {{ task_description }}
 parameters:

--- a/projects/firecracker/substrate/chart/Chart.yaml
+++ b/projects/firecracker/substrate/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: fc-invoke
 description: Node-affine Firecracker invoke daemon that dispatches HTTP invocations to a pool of warm-base microVMs across named workloads (POST /invoke/{workload}, GET /healthz)
 type: application
-version: 0.4.10
+version: 0.4.11

--- a/projects/firecracker/substrate/deploy/application.yaml
+++ b/projects/firecracker/substrate/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tags pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: fc-invoke
-      targetRevision: 0.4.10
+      targetRevision: 0.4.11
       helm:
         valueFiles:
           - $values/projects/firecracker/substrate/deploy/values.yaml


### PR DESCRIPTION
## Problem

Every `/agent` run loops to max-turns without delivering an answer. Root cause (confirmed by running goose v1.39.0 locally and inspecting the binary): goose builds the structured-output tool from a recipe's `response.json_schema` and **registers it as `recipe__final_output`** (recipe-extension namespace prefix, captured in the actual API request), but every enforcement nag string says to "call the `final_output` tool". qwen follows the nag, gets `Tool 'final_output' not found. Available tools: [write, edit, shell, tree, read_image]`, and loops.

This is a goose-internal naming inconsistency present in **both v1.27.1 and v1.39.0** (it was the dominant failure in the first `/improve-recipes` run), so it is not caused by the upgrade and reverting would not fix it. The v1.39.0 upgrade only made it unbounded, `settings.max_tool_repetitions` is a silent no-op there.

## Fix

`agent.yaml` (the only recipe with a response schema) now instructs the model that the tool's real name is `recipe__final_output` and to ignore any prompt calling it `final_output`.

## Verified locally against real qwen (before deploy)

goose v1.39.0 darwin build, in-cluster inference port-forwarded, same recipe shape and flags as prod (`--with-builtin developer --no-profile`):

| | nags | structured output collected |
|---|---|---|
| baseline (no instruction) | 61 | 0 (looped to max-turns) |
| with the fix | 1 | yes (`{"summary": ...}`) |

Rolls via substrate chart 0.4.10 -> 0.4.11. After deploy I'll re-run the in-cluster smoke test.

## Follow-ups (not in this PR)

- The clean decoupling (option B): drop `response.json_schema`, have the model emit JSON as its final message, and parse it in the monolith runner, removes the dependence on goose's tool naming entirely.
- `settings.max_tool_repetitions` is now a no-op on v1.39.0; consider passing `--max-tool-repetitions` via the harness as a loop backstop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)