### PR TITLE
fix(goosecracker): restore response schema on resume + never ship raw transcript

### DIFF
--- a/projects/firecracker/goosecracker/guest-init/internal/handler/handler_test.go
+++ b/projects/firecracker/goosecracker/guest-init/internal/handler/handler_test.go
@@ -400,13 +400,18 @@ func TestResumeHydratesSessionAndExportsUpdatedDb(t *testing.T) {
 	if string(store.hydrated) != "prior-db" {
 		t.Errorf("hydrated = %q, want %q", store.hydrated, "prior-db")
 	}
-	// argv resumes the named session (no --recipe).
+	// argv resumes the named session AND re-passes --recipe so goose re-applies
+	// the recipe's response schema + settings to the follow-up turn; the task goes
+	// via --params (-t conflicts with --recipe in goose's CLI).
 	argv := strings.Join(runner.gotArgv, " ")
 	if !strings.Contains(argv, "--name sess-9 --resume") {
 		t.Errorf("argv %q missing resume", argv)
 	}
-	if strings.Contains(argv, "--recipe") {
-		t.Errorf("argv %q should not re-pass --recipe on resume", argv)
+	if !strings.Contains(argv, "--recipe agent") {
+		t.Errorf("argv %q should re-pass --recipe on resume", argv)
+	}
+	if !strings.Contains(argv, "task_description=make it bigger") {
+		t.Errorf("argv %q should pass the task via --params on resume", argv)
 	}
 	// updated db exported back.
 	wantDb := base64.StdEncoding.EncodeToString([]byte("updated-db"))

--- a/projects/firecracker/goosecracker/guest-init/internal/harness/harness.go
+++ b/projects/firecracker/goosecracker/guest-init/internal/harness/harness.go
@@ -19,16 +19,16 @@ type Config struct {
 	// so the session is persisted under a stable name; on a resume it selects which
 	// session to replay (ADR 026 Phase 2). Empty means goose auto-manages.
 	SessionName string
-	// Resume runs the named session with --resume instead of the recipe: goose
-	// replays the full prior conversation (which already contains the recipe's
-	// system prompt from turn 1) and continues with Task as the new instruction
-	// (ADR 026 Phase 2, Model A). Requires SessionName; ignored without it.
+	// Resume replays the named session (--resume) and continues with Task as the
+	// new instruction (ADR 026 Phase 2, Model A). The recipe is re-passed so goose
+	// re-applies its response schema and settings to the follow-up turn (see
+	// GooseCommand). Requires SessionName; ignored without it.
 	Resume bool
 }
 
 // GooseCommand returns the argv to run, mirroring the established invocation:
 //
-//	resume:         goose run --name <session> --resume --no-profile --with-builtin developer -t <task>
+//	resume:         goose run --recipe <recipe> --name <session> --resume --no-profile --with-builtin developer --params task_description=<task>
 //	with a recipe:  goose run --recipe <recipe> [--name <session>] --no-profile --with-builtin developer --params task_description=<task>
 //	bare task only: goose run --text <task>
 //
@@ -38,15 +38,33 @@ type Config struct {
 // to the model but not run a shell). --with-builtin developer explicitly loads the
 // shell/editor extension so the agent can actually do work.
 //
-// On resume the recipe is NOT re-passed: turn 1 wrote the recipe's system prompt
-// into the session, and --resume replays the whole conversation, so re-passing it
-// would duplicate the instructions. The task is the latest instruction, given via
-// -t (the recipe's task_description param does not apply without --recipe).
+// On resume the recipe IS re-passed. goose applies a recipe's system prompt and
+// response schema (settings.response.json_schema, which forces the structured
+// final output the delivery path depends on) at RUNTIME on every invocation, not
+// as replayed messages, so re-passing does not duplicate the instructions:
+// --resume replays the prior conversation, and the recipe re-applies the schema
+// and settings on top of it. Dropping --recipe on resume silently loses the
+// schema, so a follow-up turn emits no structured output and delivery falls back
+// to scraping the raw transcript. The new instruction goes via --params (goose's
+// CLI makes -t/-i conflict with --recipe, so the task cannot be passed with -t
+// alongside a recipe). When there is no recipe to re-pass (an edge case), fall
+// back to a plain --resume with the reply as -t.
 //
 // It returns nil when there is nothing to run (a warm-base boot with no task),
 // in which case fc-agent-init idles without a harness until a task arrives.
 func GooseCommand(c Config) []string {
 	if c.Resume && c.SessionName != "" {
+		if c.Recipe != "" {
+			return []string{
+				"goose", "run",
+				"--recipe", c.Recipe,
+				"--name", c.SessionName,
+				"--resume",
+				"--no-profile",
+				"--with-builtin", "developer",
+				"--params", fmt.Sprintf("task_description=%s", c.Task),
+			}
+		}
 		return []string{
 			"goose", "run",
 			"--name", c.SessionName,

--- a/projects/firecracker/goosecracker/guest-init/internal/harness/harness_test.go
+++ b/projects/firecracker/goosecracker/guest-init/internal/harness/harness_test.go
@@ -37,9 +37,21 @@ func TestGooseCommandColdBuildNamesSession(t *testing.T) {
 }
 
 func TestGooseCommandResume(t *testing.T) {
-	// Resume replays the named session (--resume, no --recipe) with the reply as -t.
-	got := GooseCommand(Config{Recipe: "artifact.yaml", Task: "make it bigger", SessionName: "thread-1", Resume: true})
-	want := "goose run --name thread-1 --resume --no-profile --with-builtin developer -t make it bigger"
+	// Resume replays the named session AND re-passes the recipe so goose re-applies
+	// the recipe's response schema + settings to the follow-up turn. The task goes
+	// via --params (-t conflicts with --recipe in goose's CLI).
+	got := GooseCommand(Config{Recipe: "agent.yaml", Task: "how does it work?", SessionName: "thread-1", Resume: true})
+	want := "goose run --recipe agent.yaml --name thread-1 --resume --no-profile --with-builtin developer --params task_description=how does it work?"
+	if strings.Join(got, " ") != want {
+		t.Fatalf("got %q, want %q", strings.Join(got, " "), want)
+	}
+}
+
+func TestGooseCommandResumeWithoutRecipeUsesText(t *testing.T) {
+	// Edge case: a resume with a session but no recipe to re-pass falls back to a
+	// plain --resume with the reply as -t (no schema to restore).
+	got := GooseCommand(Config{Task: "keep going", SessionName: "thread-1", Resume: true})
+	want := "goose run --name thread-1 --resume --no-profile --with-builtin developer -t keep going"
 	if strings.Join(got, " ") != want {
 		t.Fatalf("got %q, want %q", strings.Join(got, " "), want)
 	}

--- a/projects/monolith/goosecracker/runner.py
+++ b/projects/monolith/goosecracker/runner.py
@@ -225,16 +225,39 @@ def _parse_structured_result(result: str) -> dict | None:
     return None
 
 
+# A clean answer never contains goose's terminal chrome: the startup banner text,
+# the tool-call bullet (``▸``), or the box-drawing separators between tool blocks.
+# If a message we are about to deliver still carries any of these, extraction
+# failed and we are about to ship the raw transcript, which is noise and can leak
+# the contents of files goose read (including this module's own source). Suppress
+# it in favor of a clear miss instead.
+_TRANSCRIPT_CHROME = ("goose is ready", "▸", "─")
+
+_NO_CLEAN_ANSWER = (
+    "I couldn't produce a clean answer for that one. Try rephrasing or narrowing "
+    "the question."
+)
+
+
+def _looks_like_transcript(text: str) -> bool:
+    """True when text still carries goose terminal chrome (see _TRANSCRIPT_CHROME)."""
+    return any(marker in text for marker in _TRANSCRIPT_CHROME)
+
+
 def _agent_narrative(result: str) -> str:
     """Extract goose's final narrative answer from a transcript that has no
     ``goose-result`` block (e.g. a question rather than a coding action).
 
-    Goose's answer is what it writes at the END, after the recipe banner and any
-    tool calls, so strip the ``...goose is ready`` preamble and return the full
-    body; _deliver pages it into multiple messages rather than truncating.
+    Goose's answer is what it writes after the startup banner, so strip the
+    ``...goose is ready`` preamble and return the body. Anchor on the FIRST
+    occurrence of the marker (the real startup banner prints it once): the string
+    recurs wherever goose read a file that mentions it, including this module's own
+    source, so ``rfind`` would slice the body mid-file. The caller guards the
+    result with _looks_like_transcript, so a body that is still raw transcript
+    (goose ran tools but never wrote a clean answer) is dropped rather than shipped.
     """
     marker = "goose is ready"
-    idx = result.rfind(marker)
+    idx = result.find(marker)
     body = (result[idx + len(marker) :] if idx != -1 else result).strip()
     return body or "(no output)"
 
@@ -289,8 +312,19 @@ async def _delivery_message(session: str, recipe: str, data: dict) -> str:
                     msg += f"\n{url}"
             else:
                 # goose's answer is its trailing narrative (post that, not the head
-                # of the transcript, which is the recipe banner + tool calls).
-                msg = _agent_narrative(result)
+                # of the transcript, which is the recipe banner + tool calls). If
+                # what's left still looks like a raw transcript, extraction failed
+                # (goose ran tools but never emitted structured output or a clean
+                # answer, e.g. a truncated run): ship a miss, never the transcript.
+                narrative = _agent_narrative(result)
+                if _looks_like_transcript(narrative):
+                    logger.warning(
+                        "goosecracker: no clean answer for %s; suppressing raw transcript",
+                        session,
+                    )
+                    msg = _NO_CLEAN_ANSWER
+                else:
+                    msg = narrative
 
     recorded_ref = data.get("recordedRef")
     if recorded_ref:

--- a/projects/monolith/goosecracker/tests/runner_test.py
+++ b/projects/monolith/goosecracker/tests/runner_test.py
@@ -77,18 +77,43 @@ async def test_delivery_message_agent_falls_back_to_transcript_without_block():
 
 
 async def test_delivery_message_agent_posts_trailing_narrative():
-    # A question (no goose-result block): the answer is goose's trailing
-    # narrative, so post that (banner stripped), not the head of the transcript.
+    # A question answered with a clean narrative (no goose-result block, no tool
+    # chrome): the answer is goose's trailing narrative, so post that (banner
+    # stripped), not the head of the transcript.
     result = (
         "Loading recipe: Agent\n"
         "  __( O)>  goose is ready\n"
-        "  ▸ shell git log --oneline\n"
-        "abc123 some commit\n"
         "Joe has been working on the git mirror and the /agent command this week."
     )
     msg = await runner._delivery_message("s-9", "agent", {"result": result})
     assert "Joe has been working on the git mirror" in msg
     assert "Loading recipe" not in msg  # recipe banner stripped
+    assert "goose is ready" not in msg  # no terminal chrome leaks
+
+
+async def test_delivery_message_agent_suppresses_raw_transcript():
+    # The incident: a resume turn ran without the response schema, so no structured
+    # JSON and no goose-result block. goose spent the run cat-ing files (including
+    # runner.py, whose source literally contains the "goose is ready" marker) and
+    # never wrote a clean answer. Delivery must NOT ship the raw transcript, and the
+    # old rfind bug must not slice into the cat-ed source (it anchored on the marker
+    # inside runner.py's own source).
+    result = (
+        "  __( O)>  goose is ready\n"
+        "  ────────────────────────────────\n"
+        "  ▸ shell\n"
+        "    command: cat runner.py\n"
+        '    marker = "goose is ready"\n'
+        "    idx = result.rfind(marker)\n"
+        "    body = result[idx + len(marker) :]\n"
+        "  ────────────────────────────────\n"
+        "Now I have a thorough picture. Let me compile the answer."
+    )
+    msg = await runner._delivery_message("s-12", "agent", {"result": result})
+    assert "rfind(marker)" not in msg  # did not ship (or slice into) the cat-ed source
+    assert "▸" not in msg
+    assert "goose is ready" not in msg
+    assert "couldn't produce a clean answer" in msg
 
 
 async def test_delivery_message_agent_prefers_typed_response():


### PR DESCRIPTION
## Problem

A `/agent` Discord follow-up ("how does it work under the hood?") delivered ~27KB of raw Python source (runner.py's own `_agent_narrative`/`_delivery_message`) instead of an answer. Traced to a three-part compound failure:

1. **The follow-up ran without the response schema.** Follow-up turns resume the goose session, and the harness dropped `--recipe` on resume, so goose was not re-applying `settings.response.json_schema`. No structured JSON was emitted, and delivery fell through to the transcript-scraping fallback.
2. **The fallback marker was not unique.** `_agent_narrative` used `rfind("goose is ready")` to strip the banner. That string recurs wherever goose reads a file mentioning it, including runner.py's own source. Because goose `cat`-ed runner.py, `rfind` anchored on the marker *inside the cat-ed source* and delivered everything after it.
3. **Even absent the collision, the fallback shipped raw transcript** (tool calls, `cat`-ed source) when goose investigated instead of answering.

## Fix (root cause + backstop, one PR)

**1. Harness (`harness.go`): re-pass `--recipe` on resume.** goose applies a recipe's system prompt and response schema at runtime on every invocation (not as replayed messages), so re-passing does not duplicate instructions. Verified against `block/goose` `crates/goose-cli`: `build_session` calls `apply_recipe_components(recipe.response, ...)` unconditionally, and `--recipe` does not conflict with `--resume`. The task moves from `-t` to `--params task_description` because goose's CLI makes `-t/-i` conflict with `--recipe`. The old comment asserted the opposite (wrong) goose semantics; corrected.

**2. Delivery (`runner.py`): never ship raw transcript.** Anchor on the *first* marker occurrence (the real banner), and guard the result: if it still carries goose terminal chrome (banner text, `▸` bullet, box-drawing separators), extraction failed, so post a clear miss instead of the transcript. Backstop for when the schema contract is still not honored.

## Tests

- `harness_test.go`: resume now expects `--recipe ... --params task_description=...`; added a no-recipe-resume fallback case.
- `runner_test.py`: narrative test rewritten around a clean transcript (asserts no chrome leaks); added an adversarial fixture reproducing the incident (cat-ed source containing the marker) that asserts a clean miss, not source.

Harness unit tests and the delivery helper logic verified locally.

## Deploy

Code-only; the post-merge chart-version-bot (ADR 009) bumps monolith, and guest content auto-bumps fc-invoke (#3042). No manual chart edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)