### PR TITLE
chore(monolith): bump chart to 0.241.0 to deploy the ACL migration

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.240.8
+version: 0.241.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.240.8
+      targetRevision: 0.241.0
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
Deploys #3060 (ADR 029 per-server Discord feature ACL: new chat.discord_feature_grant table + migration + code) and the goosecracker fixes merged behind it. No chart bump landed with #3060 and chart-version-bot is not currently bumping monolith, so ArgoCD stayed on 0.240.8 and the migration/code never deployed. Bumps Chart.yaml + deploy/application.yaml targetRevision in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)