### PR TITLE
chore(goosecracker): bump monolith + fc-invoke charts to deploy the resume fix

### DIFF
--- a/projects/firecracker/substrate/chart/Chart.yaml
+++ b/projects/firecracker/substrate/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: fc-invoke
 description: Node-affine Firecracker invoke daemon that dispatches HTTP invocations to a pool of warm-base microVMs across named workloads (POST /invoke/{workload}, GET /healthz)
 type: application
-version: 0.4.11
+version: 0.4.12

--- a/projects/firecracker/substrate/deploy/application.yaml
+++ b/projects/firecracker/substrate/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tags pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: fc-invoke
-      targetRevision: 0.4.11
+      targetRevision: 0.4.12
       helm:
         valueFiles:
           - $values/projects/firecracker/substrate/deploy/values.yaml

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.240.8
+version: 0.240.9
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.240.8
+      targetRevision: 0.240.9
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
Deploys the code merged in #3061 (which landed code-only). Chart version bumps are manual in this repo today (ADR 009 post-merge automation is Draft), so bumping here:

- `monolith` chart `0.240.8 → 0.240.9` (+ `deploy/application.yaml` targetRevision) — ships the `runner.py` delivery backstop.
- `fc-invoke`/substrate chart `0.4.11 → 0.4.12` (+ `deploy/application.yaml` targetRevision) — repins the guest image so the `harness.go` resume-recipe change ships.

Each Chart.yaml version stays in sync with its application.yaml targetRevision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)