### PR TITLE
chore(fc-invoke): bump substrate chart to deploy the harness resume-recipe fix

### DIFF
--- a/projects/firecracker/substrate/chart/Chart.yaml
+++ b/projects/firecracker/substrate/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: fc-invoke
 description: Node-affine Firecracker invoke daemon that dispatches HTTP invocations to a pool of warm-base microVMs across named workloads (POST /invoke/{workload}, GET /healthz)
 type: application
-version: 0.4.11
+version: 0.4.12

--- a/projects/firecracker/substrate/deploy/application.yaml
+++ b/projects/firecracker/substrate/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tags pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: fc-invoke
-      targetRevision: 0.4.11
+      targetRevision: 0.4.12
       helm:
         valueFiles:
           - $values/projects/firecracker/substrate/deploy/values.yaml


### PR DESCRIPTION
Repins the fc-invoke guest image so the guest-init `harness.go` change from #3061 (re-pass `--recipe` on resume) ships. The monolith half of #3061 already deployed via Joe's 0.241.0 bump (556475287); this covers the firecracker guest half.

- substrate/fc-invoke chart `0.4.11 → 0.4.12` + `deploy/application.yaml` targetRevision in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)