### PR TITLE
fix(goosecracker): retry transient fc-invoke failures with backoff

### DIFF
--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -4080,6 +4080,7 @@ py_test(
     imports = ["."],
     deps = [
         ":monolith_backend",
+        "@pip//httpx",
         "@pip//pytest",
         "@pip//pytest_asyncio",
     ],

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.242.0
+version: 0.242.1
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chat/api.py
+++ b/projects/monolith/chat/api.py
@@ -12,6 +12,7 @@ from chat.goosecracker import artifact_id_for_thread  # re-exported
 from chat.goosecracker import drain_agent_queue  # re-exported
 from chat.goosecracker_progress import (  # re-exported
     mark_done as mark_goosecracker_progress_done,
+    set_notice as set_goosecracker_progress_notice,
 )
 from chat.outbox import enqueue_message  # re-exported
 from chat.summarizer import run_summary_generation  # re-exported
@@ -21,6 +22,7 @@ __all__ = [
     "drain_agent_queue",
     "enqueue_message",
     "mark_goosecracker_progress_done",
+    "set_goosecracker_progress_notice",
     "run_changelog_for_config",
     "run_summary_generation",
     "send_message",

--- a/projects/monolith/chat/bot.py
+++ b/projects/monolith/chat/bot.py
@@ -114,6 +114,13 @@ def _render_goosecracker_progress(snap, elapsed: int, kind: str = "artifact") ->
     else:
         lines.append(f"🧠 Thinking... ({el})")
 
+    # A transient retry notice (set by the runner while it rides out a flaky
+    # fc-invoke) is shown before real output flows, so the owner sees the run
+    # is waiting to start rather than a bare "Thinking".
+    notice = snap.notice if snap else ""
+    if notice and not done:
+        lines.append(notice)
+
     wrote = _GOOSECRACKER_WROTE_RE.search(text)
     if wrote:
         lines.append(f"📝 Wrote {wrote.group(1)} lines")

--- a/projects/monolith/chat/bot_test.py
+++ b/projects/monolith/chat/bot_test.py
@@ -3,7 +3,12 @@
 import pytest
 from unittest.mock import AsyncMock, MagicMock
 
-from chat.bot import download_image_attachments, should_respond
+from chat.bot import (
+    _render_goosecracker_progress,
+    download_image_attachments,
+    should_respond,
+)
+from chat.goosecracker_progress import Progress
 
 
 class TestShouldRespond:
@@ -159,3 +164,26 @@ class TestDownloadImageAttachments:
         assert len(result) == 1
         assert result[0]["description"] == "A sunset"
         vision_client.describe.assert_called_once()
+
+
+class TestRenderGoosecrackerProgress:
+    def test_notice_shown_before_output_flows(self):
+        """A retry notice surfaces while the run waits, alongside Thinking."""
+        snap = Progress(text="", notice="⏳ fc-invoke busy; retrying")
+        body = _render_goosecracker_progress(snap, elapsed=3, kind="agent")
+        assert "🤖 **Running agent**" in body
+        assert "🧠 Thinking" in body
+        assert "⏳ fc-invoke busy; retrying" in body
+
+    def test_notice_suppressed_once_done(self):
+        """A done run shows its result line, not a stale retry notice."""
+        snap = Progress(text="", done=True, notice="⏳ fc-invoke busy; retrying")
+        body = _render_goosecracker_progress(snap, elapsed=5, kind="agent")
+        assert "✅ Done in 0:05" in body
+        assert "retrying" not in body
+
+    def test_no_notice_renders_plain_thinking(self):
+        """Without a notice the render is unchanged (bare Thinking)."""
+        body = _render_goosecracker_progress(Progress(), elapsed=2, kind="agent")
+        assert "🧠 Thinking" in body
+        assert "⏳" not in body

--- a/projects/monolith/chat/goosecracker_progress.py
+++ b/projects/monolith/chat/goosecracker_progress.py
@@ -24,10 +24,17 @@ _MAX_BUFFER = 16384
 
 @dataclass
 class Progress:
-    """A single run's accumulated stdout tail and completion flag."""
+    """A single run's accumulated stdout tail and completion flag.
+
+    ``notice`` is a transient out-of-band status line (e.g. "retrying a
+    transient fc-invoke failure") that the runner sets before the guest starts
+    streaming, so the bot can show the owner what is happening during a retry
+    instead of a bare "Thinking". It is cleared as soon as real stdout flows.
+    """
 
     text: str = ""
     done: bool = False
+    notice: str = ""
     updated_at: float = field(default_factory=time.monotonic)
 
 
@@ -42,6 +49,21 @@ def append(artifact_id: str, chunk: str) -> None:
     with _lock:
         p = _store.setdefault(artifact_id, Progress())
         p.text = (p.text + chunk)[-_MAX_BUFFER:]
+        # Real output supersedes any pre-run retry notice: once the guest is
+        # streaming, the retry is over, so drop the stale line automatically.
+        p.notice = ""
+        p.updated_at = time.monotonic()
+
+
+def set_notice(artifact_id: str, notice: str) -> None:
+    """Set a transient out-of-band status line for a run (see Progress.notice).
+
+    Used by the runner to tell the owner that a transient fc-invoke failure is
+    being retried, before the guest starts streaming its own stdout.
+    """
+    with _lock:
+        p = _store.setdefault(artifact_id, Progress())
+        p.notice = notice
         p.updated_at = time.monotonic()
 
 
@@ -59,7 +81,9 @@ def get(artifact_id: str) -> Progress | None:
         p = _store.get(artifact_id)
         if p is None:
             return None
-        return Progress(text=p.text, done=p.done, updated_at=p.updated_at)
+        return Progress(
+            text=p.text, done=p.done, notice=p.notice, updated_at=p.updated_at
+        )
 
 
 def clear(artifact_id: str) -> None:

--- a/projects/monolith/chat/goosecracker_progress_test.py
+++ b/projects/monolith/chat/goosecracker_progress_test.py
@@ -69,3 +69,25 @@ def test_clear_removes_entry():
     gp.append("t7", "data")
     gp.clear("t7")
     assert gp.get("t7") is None
+
+
+def test_set_notice_is_returned_in_snapshot():
+    _fresh("t8")
+    gp.set_notice("t8", "retrying...")
+    snap = gp.get("t8")
+    assert snap is not None
+    assert snap.notice == "retrying..."
+    assert snap.text == ""
+    _fresh("t8")
+
+
+def test_append_clears_a_pending_notice():
+    # Real stdout supersedes a pre-run retry notice, so it drops automatically
+    # once the guest starts streaming.
+    _fresh("t9")
+    gp.set_notice("t9", "retrying...")
+    gp.append("t9", "first real output")
+    snap = gp.get("t9")
+    assert snap.notice == ""
+    assert snap.text == "first real output"
+    _fresh("t9")

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.242.0
+      targetRevision: 0.242.1
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/goosecracker/runner.py
+++ b/projects/monolith/goosecracker/runner.py
@@ -27,6 +27,7 @@ import json
 import logging
 import os
 import re
+import time
 
 import httpx
 from sqlmodel import Session
@@ -55,6 +56,19 @@ GOOSECRACKER_GIT_MIRROR = os.environ.get("GOOSECRACKER_GIT_MIRROR", "")
 # multi-turn goose run finish (cold Qwen runs take minutes).
 _CONNECT_TIMEOUT = 5.0
 _READ_TIMEOUT = 600.0
+
+# fc-invoke is a single replica with a ~90s cold start (it builds base rootfs
+# and warms a snapshot before its HTTP shim listens). A chart bump rolls it, and
+# any run landing in that gap gets a gateway 502/503/504 or a refused
+# connection: the run never started, so re-POSTing the same session is safe.
+# Ride that out with a small exponential backoff bounded by _RETRY_DEADLINE of
+# wall time; a genuine outage still surfaces within ~2 minutes. A read timeout
+# (the run was accepted and goose ran long) or any other status is terminal:
+# retrying there would spawn a duplicate run.
+_RETRY_STATUSES = frozenset({502, 503, 504})
+_RETRY_DEADLINE = 120.0  # total wall time across all attempts, seconds
+_RETRY_BASE = 2.0  # first backoff sleep, doubled each attempt
+_RETRY_MAX_SLEEP = 20.0  # cap on any single backoff sleep
 
 # Discord's hard message limit is 2000 chars; leave room for the prefix.
 _MAX_DISCORD = 1800
@@ -351,6 +365,56 @@ async def _persist_session_db(session: str, session_db_b64: str | None) -> None:
         logger.exception("goosecracker: failed to persist session db for %s", session)
 
 
+async def _post_agent_run(url: str, payload: dict, on_retry) -> dict:
+    """POST a goose run to fc-invoke, retrying transient failures with backoff.
+
+    Returns the parsed JSON body on the first success. Retries only failures
+    where the run never started (a gateway 502/503/504 from a rollout gap, or a
+    connect/transport error from a mid-restart daemon), sleeping with a small
+    exponential backoff bounded by _RETRY_DEADLINE of wall time and calling
+    ``on_retry(attempt, wait, reason)`` before each sleep so the caller can tell
+    the user. A read timeout (the run was accepted and goose ran long) or a
+    non-transient status re-raises a RuntimeError with the same message shape as
+    before, so the caller's existing failure path is unchanged.
+    """
+    timeout = httpx.Timeout(_READ_TIMEOUT, connect=_CONNECT_TIMEOUT)
+    deadline = time.monotonic() + _RETRY_DEADLINE
+    attempt = 0
+    while True:
+        attempt += 1
+        transient = False
+        try:
+            async with httpx.AsyncClient(timeout=timeout) as client:
+                resp = await client.post(url, json=payload)
+                resp.raise_for_status()
+                return resp.json()
+        except httpx.HTTPStatusError as exc:
+            status = exc.response.status_code
+            transient = status in _RETRY_STATUSES
+            reason = f"HTTP {status}"
+            err = RuntimeError(
+                f"fc-invoke returned HTTP {status}: {exc.response.text[:500]}"
+            )
+            cause = exc
+        except httpx.ReadTimeout as exc:
+            # The run was accepted and goose ran past the read budget; retrying
+            # would spawn a duplicate. Terminal.
+            raise RuntimeError(f"could not reach fc-invoke: {exc}") from exc
+        except httpx.HTTPError as exc:
+            # Connect/transport error: the daemon is mid-restart and nothing
+            # started, so a re-POST of the same session is safe.
+            transient = True
+            reason = "connection failed"
+            err = RuntimeError(f"could not reach fc-invoke: {exc}")
+            cause = exc
+
+        wait = min(_RETRY_BASE * 2 ** (attempt - 1), _RETRY_MAX_SLEEP)
+        if not transient or time.monotonic() + wait >= deadline:
+            raise err from cause
+        on_retry(attempt, wait, reason)
+        await asyncio.sleep(wait)
+
+
 async def run_and_deliver(
     session: str,
     *,
@@ -397,21 +461,29 @@ async def run_and_deliver(
             "resume": session_db is not None,
             "sessionDb": base64.b64encode(session_db).decode() if session_db else "",
         }
-        timeout = httpx.Timeout(_READ_TIMEOUT, connect=_CONNECT_TIMEOUT)
         url = f"{FC_INVOKE_URL}/invoke/agent/{session}"
 
-        try:
-            async with httpx.AsyncClient(timeout=timeout) as client:
-                resp = await client.post(url, json=payload)
-                resp.raise_for_status()
-                data = resp.json()
-        except httpx.HTTPStatusError as exc:
-            raise RuntimeError(
-                f"fc-invoke returned HTTP {exc.response.status_code}: "
-                f"{exc.response.text[:500]}"
-            ) from exc
-        except httpx.HTTPError as exc:
-            raise RuntimeError(f"could not reach fc-invoke: {exc}") from exc
+        def _notify_retry(attempt: int, wait: float, reason: str) -> None:
+            # Surface the retry on the live-progress message the bot is already
+            # editing (a fast in-memory buffer write, no DB), so the owner sees
+            # the run is waiting on fc-invoke rather than a bare "Thinking".
+            from chat.api import set_goosecracker_progress_notice
+
+            logger.info(
+                "goosecracker: transient fc-invoke failure for %s (%s); "
+                "retry %d in %.0fs",
+                session,
+                reason,
+                attempt,
+                wait,
+            )
+            set_goosecracker_progress_notice(
+                session,
+                f"⏳ fc-invoke busy ({reason}); retrying "
+                f"(attempt {attempt}, waiting {wait:.0f}s)…",
+            )
+
+        data = await _post_agent_run(url, payload, _notify_retry)
 
         status = data.get("status")
         if status == "ok":

--- a/projects/monolith/goosecracker/tests/runner_test.py
+++ b/projects/monolith/goosecracker/tests/runner_test.py
@@ -8,6 +8,8 @@ the conversational-queue drain added for /agent thread continuations.
 
 from __future__ import annotations
 
+import httpx
+import pytest
 
 from goosecracker import runner
 
@@ -300,3 +302,126 @@ def test_split_message_hard_splits_an_overlong_line():
     pages = runner._split_message("y" * 4000)
     assert len(pages) >= 2
     assert all(len(p) <= runner._MAX_DISCORD for p in pages)
+
+
+# ---------------------------------------------------------------------------
+# _post_agent_run: transient-failure retry (fc-invoke single-replica rollout gap)
+# ---------------------------------------------------------------------------
+
+
+class _FakeClient:
+    """Stand-in for httpx.AsyncClient that replays a scripted POST sequence.
+
+    Each POST pops the next scripted item: an httpx.Response is returned (the
+    caller runs raise_for_status/json on it), an Exception is raised.
+    """
+
+    def __init__(self, script):
+        self._script = list(script)
+        self.calls = 0
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def post(self, url, json=None):
+        self.calls += 1
+        item = self._script.pop(0)
+        if isinstance(item, Exception):
+            raise item
+        return item
+
+
+def _resp(status, *, json_body=None, text=""):
+    req = httpx.Request("POST", "http://fc-invoke/invoke/agent/s")
+    if json_body is not None:
+        return httpx.Response(status, request=req, json=json_body)
+    return httpx.Response(status, request=req, text=text)
+
+
+def _patch(monkeypatch, script):
+    """Point runner.httpx.AsyncClient at one shared fake and no-op the backoff.
+
+    Returns (fake_client, sleeps) so a test can assert call and backoff counts.
+    """
+    fake = _FakeClient(script)
+    monkeypatch.setattr(runner.httpx, "AsyncClient", lambda **kw: fake)
+    sleeps: list[float] = []
+
+    async def _fake_sleep(delay):
+        sleeps.append(delay)
+
+    monkeypatch.setattr(runner.asyncio, "sleep", _fake_sleep)
+    return fake, sleeps
+
+
+async def test_post_agent_run_retries_504_then_succeeds(monkeypatch):
+    fake, sleeps = _patch(
+        monkeypatch,
+        [
+            _resp(504, text="gateway timeout"),
+            _resp(200, json_body={"status": "ok", "result": "done"}),
+        ],
+    )
+    retries = []
+    data = await runner._post_agent_run(
+        "http://fc-invoke/invoke/agent/s",
+        {"task": "x"},
+        lambda attempt, wait, reason: retries.append((attempt, wait, reason)),
+    )
+    assert data == {"status": "ok", "result": "done"}
+    assert fake.calls == 2
+    assert retries == [(1, runner._RETRY_BASE, "HTTP 504")]
+    assert sleeps == [runner._RETRY_BASE]  # one backoff of the base delay
+
+
+async def test_post_agent_run_retries_connect_error(monkeypatch):
+    fake, _ = _patch(
+        monkeypatch,
+        [
+            httpx.ConnectError("connection refused"),
+            _resp(200, json_body={"status": "ok"}),
+        ],
+    )
+    reasons = []
+    data = await runner._post_agent_run(
+        "http://fc/s", {}, lambda attempt, wait, reason: reasons.append(reason)
+    )
+    assert data == {"status": "ok"}
+    assert fake.calls == 2
+    assert reasons == ["connection failed"]
+
+
+async def test_post_agent_run_no_retry_on_read_timeout(monkeypatch):
+    # A read timeout means goose was accepted and ran long; a retry would spawn
+    # a duplicate, so it must surface immediately.
+    fake, _ = _patch(monkeypatch, [httpx.ReadTimeout("read timed out")])
+    retries = []
+    with pytest.raises(RuntimeError, match="could not reach fc-invoke"):
+        await runner._post_agent_run("http://fc/s", {}, lambda *a: retries.append(a))
+    assert fake.calls == 1
+    assert retries == []
+
+
+async def test_post_agent_run_no_retry_on_non_transient_status(monkeypatch):
+    fake, _ = _patch(monkeypatch, [_resp(400, text="bad request")])
+    retries = []
+    with pytest.raises(RuntimeError, match="fc-invoke returned HTTP 400"):
+        await runner._post_agent_run("http://fc/s", {}, lambda *a: retries.append(a))
+    assert fake.calls == 1
+    assert retries == []
+
+
+async def test_post_agent_run_gives_up_after_deadline(monkeypatch):
+    # With a zero deadline the first transient failure exhausts the budget, so
+    # the loop raises instead of sleeping or calling back.
+    monkeypatch.setattr(runner, "_RETRY_DEADLINE", 0.0)
+    fake, sleeps = _patch(monkeypatch, [_resp(504, text="gateway timeout")])
+    retries = []
+    with pytest.raises(RuntimeError, match="fc-invoke returned HTTP 504"):
+        await runner._post_agent_run("http://fc/s", {}, lambda *a: retries.append(a))
+    assert fake.calls == 1
+    assert sleeps == []
+    assert retries == []


### PR DESCRIPTION
## What

When Quinoa69 asked Bosun to open a PR, the run came back in 3s with `Run failed: fc-invoke returned HTTP 504` (twice). Root cause was timing, not a real breakage: **fc-invoke was mid-rollout**. The `4817459e3` substrate chart bump rolled the deployment, and fc-invoke is a **single replica with a ~90s cold start** (it builds base rootfs for each guest and warms a Firecracker snapshot before its HTTP shim listens). The two requests landed in the ~90s window where the old pod was gone and the new one wasn't serving yet, so the gateway returned 504.

This will recur on *every* fc-invoke chart bump. A rollout blip should be invisible to a Discord user, not a hard failure.

## Change (option B: retry on the caller side, signal to the user)

- **`runner._post_agent_run`** wraps the fc-invoke POST with a small exponential backoff (2, 4, 8, 16, 20, 20…s, capped 20s/sleep) bounded by **120s wall time**.
- **Retries only failures where the run never started** and a re-POST of the same session is safe: gateway **502/503/504** and connect/transport errors (daemon mid-restart).
- **Terminal (no retry):** a **read timeout** (fc-invoke accepted the POST and goose ran long, so a retry would spawn a *duplicate* run) and any other status. This idempotency argument is the reason it's safe to retry a `POST`.
- **User-visible signal:** a new `Progress.notice` field, set via `set_goosecracker_progress_notice`, surfaces `⏳ fc-invoke busy; retrying (attempt N, waiting Ms)…` on the **same live-progress message** the bot already edits every 1.5s. It clears automatically once real goose output flows (`append()` drops it).

## Tests

- `runner_test`: retries 504 then succeeds; retries connect error; no retry on read timeout; no retry on non-transient 4xx; gives up after the deadline.
- `goosecracker_progress_test`: `set_notice` round-trips in the snapshot; `append` clears a pending notice.
- `bot_test`: notice renders alongside "Thinking"; suppressed once done; absent render unchanged.

Bumps the monolith chart 0.242.0 -> 0.242.1 to deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)