### PR TITLE
feat(goosecracker): fold artifact into the router as a sub-recipe (ADR 024 amend)

### DIFF
--- a/projects/firecracker/goosecracker/guest/recipes/agent.yaml
+++ b/projects/firecracker/goosecracker/guest/recipes/agent.yaml
@@ -1,4 +1,4 @@
-version: "1.3.2"
+version: "1.4.0"
 title: "Agent"
 description: "Routing agent for a snapshot-managed microVM thread (ADR 022): classifies the task and dispatches the matching sub-recipe."
 instructions: |
@@ -16,6 +16,11 @@ instructions: |
     is a plan document, not the change itself.
   - implement: the task is a concrete, actionable change to code, config,
     or docs. The deliverable is a commit and a PR.
+  - artifact: the task asks for a thing to look at, a visualization, an
+    interactive page, a chart, a small demo, a dashboard, or a report rendered
+    as a web page ("make me / build me / show me a ..."). The deliverable is a
+    live web page published to a URL, not a repo change. The artifact runs in a
+    sandboxed iframe and cannot touch a repo.
 
   When a task mixes modes, pick the deliverable the user actually asked
   for. "Fix X" is implement. "How should we fix X" is plan. "Is X broken"
@@ -52,9 +57,11 @@ instructions: |
   schema below, from the sub-recipe's output: a short `summary` of the
   action and outcome, or the answer itself if the task was a question;
   optional `details` for the fuller answer or notable findings; the `mode`
-  you routed to; a `type` (pr/issue/note/answer); and a `url` only if the
-  worker reported a real PR or issue URL. The summary describes the ACTION
-  and RESULT, not your reasoning.
+  you routed to; a `type` (pr/issue/note/answer/artifact); and a `url` only if
+  the worker reported a real PR or issue URL. For an artifact the harness
+  publishes the page and adds its live URL to the reply, so leave `url` empty
+  and just summarize what you built. The summary describes the ACTION and
+  RESULT, not your reasoning.
 
   Be brief and finish fast. Length is the main thing that makes a reply feel
   slow: this runs on a local model, so every extra sentence is real wall-time,
@@ -92,6 +99,8 @@ sub_recipes:
   - name: implement
     path: /home/goose-agent/recipes/implement.yaml
     sequential_when_repeated: true
+  - name: artifact
+    path: /home/goose-agent/recipes/artifact.yaml
 extensions:
   - type: builtin
     name: developer
@@ -110,12 +119,12 @@ response:
         description: "Optional longer detail: the full answer, notable findings, or next steps. May be empty."
       mode:
         type: string
-        enum: ["query", "plan", "implement"]
+        enum: ["query", "plan", "implement", "artifact"]
         description: "Which sub-recipe the task was routed to."
       type:
         type: string
-        enum: ["pr", "issue", "note", "answer"]
-        description: "The kind of result."
+        enum: ["pr", "issue", "note", "answer", "artifact"]
+        description: "The kind of result. Use 'artifact' for a published web page; the harness adds its live URL, so leave `url` empty."
       url:
         type: string
         description: "A PR or issue URL ONLY if the worker actually opened one in this run (it reported the real URL); otherwise an empty string. Never invent, guess, or reconstruct a URL."

--- a/projects/firecracker/goosecracker/guest/recipes/artifact.yaml
+++ b/projects/firecracker/goosecracker/guest/recipes/artifact.yaml
@@ -1,4 +1,4 @@
-version: "1.0.1"
+version: "1.1.0"
 title: "Artifact"
 description: "Build a single web artifact (may use CDN libs + live https APIs); the harness publishes it to a live URL (ADR 024)."
 instructions: |
@@ -44,11 +44,19 @@ prompt: |
   the shell or editor; do not reply with a plan or a description first:
 
   {{ task_description }}
+
+  Context from the router (may be empty):
+  {{ context }}
 parameters:
   - key: task_description
     description: "What to build"
     input_type: string
     requirement: required
+  - key: context
+    description: "Context the router gathered: constraints, prior thread state"
+    input_type: string
+    requirement: optional
+    default: ""
 extensions:
   - type: builtin
     name: developer

--- a/projects/firecracker/substrate/chart/Chart.yaml
+++ b/projects/firecracker/substrate/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: fc-invoke
 description: Node-affine Firecracker invoke daemon that dispatches HTTP invocations to a pool of warm-base microVMs across named workloads (POST /invoke/{workload}, GET /healthz)
 type: application
-version: 0.4.12
+version: 0.4.13

--- a/projects/firecracker/substrate/deploy/application.yaml
+++ b/projects/firecracker/substrate/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tags pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: fc-invoke
-      targetRevision: 0.4.12
+      targetRevision: 0.4.13
       helm:
         valueFiles:
           - $values/projects/firecracker/substrate/deploy/values.yaml

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.242.1
+version: 0.243.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.242.1
+      targetRevision: 0.243.0
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/goosecracker/runner.py
+++ b/projects/monolith/goosecracker/runner.py
@@ -299,7 +299,15 @@ async def _delivery_message(session: str, recipe: str, data: dict) -> str:
         except Exception:
             logger.exception("goosecracker: artifact publish failed for %s", session)
             return "Build finished, but publishing the artifact failed. Check the logs."
-        summary = _extract_summary(data.get("result", "") or "")
+        # Summary can come from the artifact recipe's markdown goose-result
+        # (/artifact command) or the router's typed JSON (a /agent run routed to
+        # the artifact sub-recipe). Prefer the structured summary, fall back to
+        # the markdown one.
+        result_text = data.get("result", "") or ""
+        structured = _parse_structured_result(result_text)
+        summary = (
+            str(structured.get("summary", "")).strip() if structured else ""
+        ) or _extract_summary(result_text)
         msg = f"Artifact ready: {url}" + (f"\n\n{summary}" if summary else "")
     elif recipe == "artifact":
         msg = "Build finished but produced no artifact. Try rephrasing the request."


### PR DESCRIPTION
Final artifact item: one `/agent` entry point that also builds artifacts.

## Why it's a recipe-only fold
The publish path is already content-keyed, not recipe-keyed: the guest reads `/tmp/artifact.html` after *any* run (`handler.go:200`) and the runner publishes on `artifactHtml` presence (`runner.py:294`), independent of the recipe. So routing `/agent` to an artifact sub-recipe that writes the file gets published to a capability URL automatically, no plumbing rework (this was the piece I'd flagged as risky; it isn't).

## Changes
- `agent.yaml`: `artifact` added to the routing criteria, `sub_recipes`, and the `mode`/`type` enums. The router leaves `url` empty for artifacts (the harness appends the live URL).
- `artifact.yaml`: gains the optional `context` param, matching the other sub-recipes, so the router can pass a briefing.
- `runner.py`: the artifact-publish branch now reads the summary from the router's typed JSON as well as the legacy `/artifact` markdown, so a `/agent`-routed artifact still posts a summary alongside the URL.
- `/artifact` stays as a shortcut; no command removed.

Optional outputs: goose already supports them (only `summary` is `required`); added `artifact` to the enums rather than new fields, since the artifact outcome is already known from `artifactHtml` presence and `type`/`url` already distinguish PR vs issue.

Substrate 0.4.13 (guest recipes) + monolith 0.243.0 (runner).

🤖 Generated with [Claude Code](https://claude.com/claude-code)