### PR TITLE
fix(goosecracker): artifact route must write /tmp/artifact.html

### DIFF
--- a/projects/firecracker/goosecracker/guest/recipes/agent.yaml
+++ b/projects/firecracker/goosecracker/guest/recipes/agent.yaml
@@ -1,4 +1,4 @@
-version: "1.4.0"
+version: "1.4.1"
 title: "Agent"
 description: "Routing agent for a snapshot-managed microVM thread (ADR 022): classifies the task and dispatches the matching sub-recipe."
 instructions: |
@@ -20,7 +20,11 @@ instructions: |
     interactive page, a chart, a small demo, a dashboard, or a report rendered
     as a web page ("make me / build me / show me a ..."). The deliverable is a
     live web page published to a URL, not a repo change. The artifact runs in a
-    sandboxed iframe and cannot touch a repo.
+    sandboxed iframe and cannot touch a repo. Dispatch this to the `artifact`
+    sub-recipe. If you build it inline instead, you MUST write the complete,
+    self-contained HTML document to exactly `/tmp/artifact.html` (the harness
+    publishes that path and only that path). Never write the page into the repo
+    workspace: a file left in /workspace is not published and is lost.
 
   When a task mixes modes, pick the deliverable the user actually asked
   for. "Fix X" is implement. "How should we fix X" is plan. "Is X broken"

--- a/projects/firecracker/substrate/chart/Chart.yaml
+++ b/projects/firecracker/substrate/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: fc-invoke
 description: Node-affine Firecracker invoke daemon that dispatches HTTP invocations to a pool of warm-base microVMs across named workloads (POST /invoke/{workload}, GET /healthz)
 type: application
-version: 0.4.13
+version: 0.4.14

--- a/projects/firecracker/substrate/deploy/application.yaml
+++ b/projects/firecracker/substrate/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tags pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: fc-invoke
-      targetRevision: 0.4.13
+      targetRevision: 0.4.14
       helm:
         valueFiles:
           - $values/projects/firecracker/substrate/deploy/values.yaml


### PR DESCRIPTION
Live smoke test of the artifact fold (#3069): the router classified the task as artifact correctly but built it inline and wrote to /workspace/bouncing-ball.html instead of dispatching to the artifact sub-recipe. The publish path is content-keyed on /tmp/artifact.html, so that artifact would never be published. Make the router's artifact criterion explicit: dispatch to the sub-recipe, or if inline write exactly /tmp/artifact.html, never into the workspace. Recipe-only; substrate 0.4.13 -> 0.4.14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)