### PR TITLE
fix(goosecracker): gate artifact final_output on the page actually existing

### DIFF
--- a/projects/firecracker/goosecracker/guest/recipes/agent.yaml
+++ b/projects/firecracker/goosecracker/guest/recipes/agent.yaml
@@ -1,4 +1,4 @@
-version: "1.4.1"
+version: "1.4.2"
 title: "Agent"
 description: "Routing agent for a snapshot-managed microVM thread (ADR 022): classifies the task and dispatches the matching sub-recipe."
 instructions: |
@@ -25,6 +25,17 @@ instructions: |
     self-contained HTML document to exactly `/tmp/artifact.html` (the harness
     publishes that path and only that path). Never write the page into the repo
     workspace: a file left in /workspace is not published and is lost.
+
+    HARD GATE for artifact mode: do NOT call `recipe__final_output` with
+    `mode: artifact` until you have actually produced the page in THIS run, by
+    one of two observable actions:
+      1. the `artifact` sub-recipe tool has been called and RETURNED a result, or
+      2. you have written a non-empty `/tmp/artifact.html` yourself.
+    Deciding to dispatch is not dispatching. If your most recent action was a
+    thought about routing (or a plan to build it) rather than an actual `artifact`
+    tool call or a file write, the page does not exist yet and finishing now
+    publishes an empty artifact. Take the action, wait for its result or confirm
+    the file is written, and only then emit the final output.
 
   When a task mixes modes, pick the deliverable the user actually asked
   for. "Fix X" is implement. "How should we fix X" is plan. "Is X broken"
@@ -64,8 +75,11 @@ instructions: |
   you routed to; a `type` (pr/issue/note/answer/artifact); and a `url` only if
   the worker reported a real PR or issue URL. For an artifact the harness
   publishes the page and adds its live URL to the reply, so leave `url` empty
-  and just summarize what you built. The summary describes the ACTION and
-  RESULT, not your reasoning.
+  and just summarize what you built. Before emitting `mode: artifact`, re-check
+  the HARD GATE above: the `artifact` sub-recipe must have returned, or
+  `/tmp/artifact.html` must already be written. Do not summarize a page you only
+  intended to build. The summary describes the ACTION and RESULT, not your
+  reasoning.
 
   Be brief and finish fast. Length is the main thing that makes a reply feel
   slow: this runs on a local model, so every extra sentence is real wall-time,

--- a/projects/firecracker/substrate/chart/Chart.yaml
+++ b/projects/firecracker/substrate/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: fc-invoke
 description: Node-affine Firecracker invoke daemon that dispatches HTTP invocations to a pool of warm-base microVMs across named workloads (POST /invoke/{workload}, GET /healthz)
 type: application
-version: 0.4.14
+version: 0.4.15

--- a/projects/firecracker/substrate/deploy/application.yaml
+++ b/projects/firecracker/substrate/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tags pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: fc-invoke
-      targetRevision: 0.4.14
+      targetRevision: 0.4.15
       helm:
         valueFiles:
           - $values/projects/firecracker/substrate/deploy/values.yaml


### PR DESCRIPTION
## What

Adds a hard ordering gate to the goosecracker router recipe (`agent.yaml`): the model must not call `recipe__final_output` with `mode: artifact` until it has actually produced the page this run, by one of two observable actions:

1. the `artifact` sub-recipe tool has been called and **returned**, or
2. a non-empty `/tmp/artifact.html` has been written.

## Why

Live eval of the post-fold router (the 2 sessions since `2eb786230`) caught a remaining hole. In Discord session `1522279067234074666` (task: "bouncing ball page"), qwen's turn-1 thinking said *"I should dispatch this to the artifact sub-recipe"* and then its very next action was `recipe__final_output` with summary *"Built a bouncing ball animation..."*. It neither called the sub-recipe nor wrote the file: it **hallucinated the dispatch**. The harness published an empty artifact and Joe had to ask "where is it", at which point the model admitted it and wrote the file on turn 2.

The identical task on the harness path (`s-d2162e14ef8b`) succeeded inline, so `2eb786230` works when the model takes the inline path, but nothing stopped `final_output` from firing before *either* path ran. This is the classic small-model intent-action gap: the internal "I decided to dispatch" narrative satisfied the model enough to skip the actual tool call. Recipes for local models need ordering constraints on tool calls, not just descriptions of the desired workflow.

## Changes

- `agent.yaml`: HARD GATE added to the artifact routing criterion + a re-check reminder at the final-output paragraph. Recipe `1.4.1 -> 1.4.2`.
- `substrate/chart/Chart.yaml` + `deploy/application.yaml`: fc-invoke `0.4.14 -> 0.4.15` so the guest re-ships with the new recipe text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)