### PR TITLE
feat(skills): add unsafe-feedback lens + worktree-safe landing to stpa

### DIFF
--- a/.claude/skills/stpa/SKILL.md
+++ b/.claude/skills/stpa/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: stpa
-description: Generate or refresh the STPA (System-Theoretic Process Analysis, STPA-Sec) safety model for one system in this repo, written colocated as <system>/STPA.md, landing any change as a PR against main that merges (rebase) on green CI. Use when asked to update/regenerate a system's STPA safety analysis, run the STPA routine, audit unsafe control actions, or when invoked on a schedule. Takes a `system` argument (the directory to analyze, e.g. projects/monolith). The analysis is deterministic, findings are extracted as JSON (judgment) and the markdown is rendered by an embedded jq renderer (mechanism), so scheduled runs produce small reviewable diffs.
+description: Generate or refresh the STPA (System-Theoretic Process Analysis, STPA-Sec) safety model for one system in this repo, written colocated as <system>/STPA.md, landing any change as a PR against main that merges (rebase) on green CI. Use when asked to update/regenerate a system's STPA safety analysis, run the STPA routine, audit unsafe control actions or unsafe feedback (data staleness, corruption, provenance drift), or when invoked on a schedule. Takes a `system` argument (the directory to analyze, e.g. projects/monolith). The analysis is deterministic, findings are extracted as JSON (judgment) and the markdown is rendered by an embedded jq renderer (mechanism), so scheduled runs produce small reviewable diffs.
 ---
 
 Generate/update the STPA safety model for ONE system in this repository, written
@@ -37,6 +37,7 @@ physical/CI-execution view and a thin logical one). Omit the view you cannot
 ground; do not invent one.
 
 ────────────────────────────────────────────────────────
+
 ## Target invariants per system
 
 Derive the mission and reason-to-exist from the system itself: read its
@@ -53,6 +54,7 @@ Unsafe states violate those.
 ────────────────────────────────────────────────────────
 
 ## Steps
+
 1. **Read the prior, if any.** If `<system>/STPA.md` exists, read it: it is your
    prior analysis. Its tables carry the stable semantic keys (first column),
    conditions, and evidence. Reuse them to minimize drift.
@@ -71,16 +73,32 @@ Unsafe states violate those.
    genuinely-unsafe ones: `providing`, `not-providing`, `wrong-timing`,
    `wrong-duration`. A bounded nuisance recovered by a fallback is NOT a UCA, put
    it in `non_ucas`.
+   Then analyze the FEEDBACK and data channels the same way. A controller acting
+   on a wrong process model is an STPA cause, not a component failure: for each
+   feedback signal, and for each data flow a controller's decisions depend on
+   (caches, mirrors, replicas, fetched policy, queue state, lineage), test four
+   guidewords and keep only genuinely-unsafe ones as `unsafe_feedback`:
+   `missing` (never arrives; the controller acts on absence), `stale` (reflects
+   an old state by the time it is acted on), `corrupted` (wrong content that
+   passes silently), `unauthorized-source` (spoofable or unauthenticated
+   origin). This is where data-integrity failures live: staleness windows, lost
+   updates, cache or mirror drift, provenance divergence. Do NOT restate a data
+   failure as a strained control-action UCA (e.g. a check-then-act staleness
+   window is `<channel>.stale`, not `<action>.wrong-timing`). The same
+   rejection bar applies: a bounded nuisance with a recovery path goes in
+   `non_ucas`.
 4. **Write your findings** as a single JSON object (schema below) to
    `/tmp/stpa.json`. Set `system_dir` to the system directory.
-5. **Render** by running BLOCK A VERBATIM. It writes `<system>/STPA.md` from your
-   JSON deterministically and prints either `STPA_RESULT=nochange` or
-   `STPA_RESULT=changed`.
+5. **Render** by running BLOCK A VERBATIM. It renders `/tmp/STPA.candidate.md`
+   from your JSON deterministically, compares it against what `origin/main`
+   actually has (this checkout may be stale), and prints either
+   `STPA_RESULT=nochange` or `STPA_RESULT=changed`. It does NOT touch the
+   working tree; BLOCK B lands the file from a disposable worktree.
 6. **If `nochange`:** report "no change, STPA.md already current" and STOP. Do not
    open a PR.
 7. **If `changed`:** prepare the PR text. Run
-   `git --no-pager diff -- <system>/STPA.md` to see exactly what moved (or note
-   this is the first version). Then:
+   `diff -u /tmp/STPA.prior.md /tmp/STPA.candidate.md` to see exactly what moved
+   (no prior file means this is the first version). Then:
    - Write a Conventional-Commits title to `/tmp/stpa-title.txt`, ONE line, <=72
      chars, form `docs(stpa): <what changed>` (e.g.
      `docs(stpa): add queue.dequeue wrong-timing UCA for monolith`; first run:
@@ -95,7 +113,9 @@ Unsafe states violate those.
    PR URL and whether it merged or was left open for review.
 
 ## Drift minimization (this is an UPDATE, not a rewrite)
+
 The rendered doc is committed and reviewed as a diff, keep churn minimal:
+
 - REUSE each prior finding's semantic key VERBATIM when the code it cites still
   exists and still means the same thing.
 - KEEP prior `condition`/`statement`/`label`/`scope` wording UNCHANGED unless the
@@ -104,11 +124,13 @@ The rendered doc is committed and reviewed as a diff, keep churn minimal:
 - But RE-VERIFY, never parrot: open each prior finding's cited code and confirm it
   still holds. Logic changed -> update it. Cited code deleted -> drop it. New
   unsafe control action -> add it with a new key.
-Net: unchanged code => identical finding; changed code => localized change;
-added/removed code => added/removed finding. Nothing else moves.
+  Net: unchanged code => identical finding; changed code => localized change;
+  added/removed code => added/removed finding. Nothing else moves.
 
 ## Semantic keys (what makes diffs stable, the renderer sorts by them)
+
 Derive each `key` from WHAT IT IS, never its position. Lowercase, no spaces.
+
 - nodes: short component slug, NO dots (mermaid id): `acl`, `public-api`,
   `scheduler`, `postgres`, `public-binary`.
 - losses: `L.unauthorized-access`, `L.integrity-loss`, `L.silent-incorrectness`,
@@ -118,9 +140,13 @@ Derive each `key` from WHAT IT IS, never its position. Lowercase, no spaces.
 - hazards: condition slug: `stale-policy`, `partial-atomic-unit`,
   `secret-in-public-binary`, `cross-schema-grant`.
 - ucas: `<control_action-key>.<guideword>`: `scheduler.dispatch.wrong-timing`.
-`from`/`to`/`control_action`/`hazards`/`losses` reference other objects BY KEY.
+- unsafe_feedback: `<channel-slug>.<guideword>` where the channel slug names the
+  signal or data flow itself, never its position: `policy-fetch.stale`,
+  `queue-notify.missing`, `mirror-sync.corrupted`.
+  `from`/`to`/`control_action`/`hazards`/`losses` reference other objects BY KEY.
 
 ## Grounding rules (hard)
+
 - Every node, control_action, uca has `evidence`: `path:line` (or `path`); for a
   doc/comment, also a <=8-word verbatim quote. No evidence -> omit it.
 - NEVER mark a designed-only element `built`.
@@ -129,6 +155,7 @@ Derive each `key` from WHAT IT IS, never its position. Lowercase, no spaces.
   newlines.
 
 ## JSON schema (write to /tmp/stpa.json; arrays in ANY order, the renderer sorts)
+
 ```
 {
   "system": "string (human label, e.g. 'monolith')",
@@ -141,20 +168,26 @@ Derive each `key` from WHAT IT IS, never its position. Lowercase, no spaces.
   "feedback": [ {"view":"logical","from":"postgres","to":"scheduler","signal":"NOTIFY wakeup hint"}, ... ],
   "hazards": [ {"key":"stale-policy","view":"logical","statement":"...","losses":["L.unauthorized-access"],"maturity":"built"}, ... ],
   "ucas": [ {"key":"scheduler.dispatch.wrong-timing","view":"logical","control_action":"scheduler.dispatch","guideword":"wrong-timing","condition":"...","severity":"high","hazards":["premature-reclaim"],"evidence":"projects/monolith/.../scheduler.py:153"}, ... ],
+  "unsafe_feedback": [ {"key":"policy-fetch.stale","view":"logical","from":"acl","to":"public-api","signal":"policy rows for subject+target","guideword":"stale","condition":"...","severity":"high","hazards":["stale-policy"],"evidence":"projects/monolith/.../acl.py:126"}, ... ],
   "non_ucas": [ {"item":"await missed NOTIFY","reason":"bounded by 5s poll fallback (path:line)"}, ... ],
   "open_questions": [ "string", ... ]
 }
 ```
+
 `view` is `logical` or `physical`. `layer` is a free-form subgraph group WITHIN a
 view (e.g. `enforcement`, `control-plane`, `store` for logical; `ingress`,
 `compute`, `data`, `secrets` for physical). `severity` is `high|medium|low`.
+UCA guidewords: `providing|not-providing|wrong-timing|wrong-duration`.
+unsafe_feedback guidewords: `missing|stale|corrupted|unauthorized-source`.
+`unsafe_feedback` is optional: omit the array entirely when no feedback channel
+survives the rejection bar.
 
 ## BLOCK A — render + detect change (run verbatim; never hand-write the .md)
-```bash
+
+````bash
 set -euo pipefail
 SYSTEM_DIR="$(jq -r '.system_dir' /tmp/stpa.json)"
 test -n "$SYSTEM_DIR" -a "$SYSTEM_DIR" != "null"
-mkdir -p "$SYSTEM_DIR"
 cat > /tmp/stpa-render.jq <<'JQ'
 # Deterministic STPA.md renderer.
 #   input : stpa.json  (semantic-keyed findings, ANY array order)
@@ -189,13 +222,13 @@ def diagram($v):
       + "\n```\n"
     end;
 
-"# STPA Control Analysis — \(.system) @ \(.commit)\n\n"
+"# STPA Control Analysis: \(.system) @ \(.commit)\n\n"
 
 + "_Auto-generated STPA safety model: the unsafe states this system can reach and the control actions that get it there. Two views: logical (functional control flow) and physical (deployment)._\n\n"
 
-+ "<details>\n<summary><b>How to read this</b> — STPA primer and diagram legend</summary>\n\n"
++ "<details>\n<summary><b>How to read this</b>: STPA primer and diagram legend</summary>\n\n"
 + "**STPA** (System-Theoretic Process Analysis) treats the system as *controllers* issuing *control actions* to *controlled processes*, with *feedback* flowing back up. Instead of \"what component can fail,\" it asks \"what control action, given or withheld at the wrong time, drives the system into an unsafe state?\" \"Unsafe\" means a violation of this system's reason to exist, not merely a crash.\n\n"
-+ "Read top-down: **Losses** are outcomes we must never cause; **Hazards** are system states that lead to a loss; the **control-structure diagrams** (one per view) show who commands whom (solid arrows = control actions, dashed = feedback, a node tagged `(designed)` is in the architecture but **not yet built**); the **Unsafe Control Actions** table is the core. Every claim cites `path:line`; unbuilt elements are marked. Semantic, stable IDs mean regenerating changes only the findings that changed.\n</details>\n\n"
++ "Read top-down: **Losses** are outcomes we must never cause; **Hazards** are system states that lead to a loss; the **control-structure diagrams** (one per view) show who commands whom (solid arrows = control actions, dashed = feedback, a node tagged `(designed)` is in the architecture but **not yet built**); the **Unsafe Control Actions** table is the core, and **Unsafe Feedback** covers the dashed arrows: data channels whose absence, staleness, corruption, or spoofing drives a controller into a hazard. Every claim cites `path:line`; unbuilt elements are marked. Semantic, stable IDs mean regenerating changes only the findings that changed.\n</details>\n\n"
 
 + "**Scope.** \(.scope.summary|esc)\n\n"
 + "<details>\n<summary>Maturity detail</summary>\n\n"
@@ -221,9 +254,15 @@ def diagram($v):
 + "| ID | View | Control action | Guideword | Unsafe condition | Severity | → Hazards | Evidence |\n|----|----|----|----|----|----|----|----|\n"
 + ( .ucas | sort_by(.key) | map("| `\(.key)` | \(.view|esc) | `\(.control_action)` | \(.guideword|esc) | \(.condition|esc) | \(.severity|esc) | \((.hazards // [])|join(", ")) | \(.evidence|esc) |") | join("\n") ) + "\n\n"
 
++ ( if (.unsafe_feedback // []) | length > 0
+    then "## Unsafe feedback\n\n*Feedback and data channels whose absence, staleness, corruption, or spoofed origin drives a controller into a hazard. This is where data-integrity failures live.*\n\n"
+       + "| ID | View | Channel | Guideword | Unsafe condition | Severity | → Hazards | Evidence |\n|----|----|----|----|----|----|----|----|\n"
+       + ( .unsafe_feedback | sort_by(.key) | map("| `\(.key)` | \(.view|esc) | `\(.from)` → `\(.to)`: \(.signal|esc) | \(.guideword|esc) | \(.condition|esc) | \(.severity|esc) | \((.hazards // [])|join(", ")) | \(.evidence|esc) |") | join("\n") ) + "\n\n"
+    else "" end )
+
 + ( if (.non_ucas // []) | length > 0
-    then "<details>\n<summary><b>Not UCAs</b> — \(.non_ucas|length) examined and rejected</summary>\n\n"
-       + ( .non_ucas | sort_by("\(.item)|\(.reason)") | map("- **\(.item|esc)** — \(.reason|esc)") | join("\n") )
+    then "<details>\n<summary><b>Not UCAs</b>: \(.non_ucas|length) examined and rejected</summary>\n\n"
+       + ( .non_ucas | sort_by("\(.item)|\(.reason)") | map("- **\(.item|esc)**: \(.reason|esc)") | join("\n") )
        + "\n</details>\n\n"
     else "" end )
 
@@ -231,28 +270,46 @@ def diagram($v):
 + ( (.open_questions // []) | sort | map("- \(esc)") | join("\n") ) + "\n"
 JQ
 LC_ALL=C jq -rf /tmp/stpa-render.jq /tmp/stpa.json > /tmp/STPA.candidate.md
-if [ -f "$SYSTEM_DIR/STPA.md" ] && diff -q "$SYSTEM_DIR/STPA.md" /tmp/STPA.candidate.md >/dev/null; then
-  echo "STPA_RESULT=nochange"
+# Compare against what origin/main actually has: this checkout's working tree
+# may be stale (or mid-task on another branch), and BLOCK B lands from a fresh
+# worktree based on origin/main anyway.
+git fetch -q origin main 2>/dev/null || true
+if git show "origin/main:$SYSTEM_DIR/STPA.md" > /tmp/STPA.prior.md 2>/dev/null; then
+  if diff -q /tmp/STPA.prior.md /tmp/STPA.candidate.md >/dev/null; then
+    echo "STPA_RESULT=nochange"
+  else
+    echo "STPA_RESULT=changed"
+  fi
 else
-  mv /tmp/STPA.candidate.md "$SYSTEM_DIR/STPA.md"
+  rm -f /tmp/STPA.prior.md   # first version: no prior on origin/main
   echo "STPA_RESULT=changed"
 fi
-```
+````
 
 ## BLOCK B — commit, PR, watch CI, merge on green (run verbatim; ONLY when STPA_RESULT=changed)
+
 ```bash
 set -euo pipefail
 SYSTEM_DIR="$(jq -r '.system_dir' /tmp/stpa.json)"
 SLUG="$(printf '%s' "$SYSTEM_DIR" | tr '/' '-' | tr -cd 'a-zA-Z0-9-')"
 BRANCH="bot/stpa-$SLUG"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+WT="/tmp/claude-worktrees/stpa-$SLUG"
 git config --get user.email >/dev/null 2>&1 || git config user.email "stpa-bot@users.noreply.github.com"
 git config --get user.name  >/dev/null 2>&1 || git config user.name  "stpa-bot"
-git switch -C "$BRANCH"
-git add "$SYSTEM_DIR/STPA.md"
+# Never build the branch in this checkout: it may sit on main (which this repo
+# forbids committing to) and auto-fetches every 60s. Land the rendered file
+# from a disposable worktree based on origin/main instead.
+git -C "$REPO_ROOT" worktree remove -f "$WT" 2>/dev/null || true
+git -C "$REPO_ROOT" worktree prune
+git -C "$REPO_ROOT" worktree add -B "$BRANCH" "$WT" origin/main
+mkdir -p "$WT/$SYSTEM_DIR"
+cp /tmp/STPA.candidate.md "$WT/$SYSTEM_DIR/STPA.md"
+git -C "$WT" add "$SYSTEM_DIR/STPA.md"
 # The conventional `docs(stpa): ...` title satisfies the commit-msg hook, so we
 # do NOT use --no-verify (the hook is cheap and is the gate we want).
-git commit -m "$(cat /tmp/stpa-title.txt)" -m "$(cat /tmp/stpa-body.md)"
-git push -f -u origin "$BRANCH"
+git -C "$WT" commit -m "$(cat /tmp/stpa-title.txt)" -m "$(cat /tmp/stpa-body.md)"
+git -C "$WT" push -f -u origin "$BRANCH"
 # Create a PR only when there isn't already an OPEN one for this branch. A
 # closed/merged PR on the branch must NOT count as "exists", else the create is
 # skipped and the later `gh pr merge` targets a dead PR and wedges.
@@ -263,10 +320,16 @@ fi
 URL="$(gh pr view "$BRANCH" --json url -q .url)"
 echo "PR: $URL"
 # This repo is rebase-merge only (squash is disabled). Poll CI ourselves, then
-# rebase-merge on green.
+# rebase-merge on green. Merge WITHOUT --delete-branch first (the branch is
+# checked out in the worktree, which would make local deletion fail), then
+# clean up the worktree and both branch refs ourselves.
 if gh pr checks "$BRANCH" --watch --fail-fast; then
-  gh pr merge "$BRANCH" --rebase --delete-branch && echo "merged (CI green): $URL"
+  gh pr merge "$BRANCH" --rebase
+  git -C "$REPO_ROOT" worktree remove -f "$WT" 2>/dev/null || true
+  git -C "$REPO_ROOT" branch -D "$BRANCH" 2>/dev/null || true
+  git -C "$REPO_ROOT" push -q origin --delete "$BRANCH" 2>/dev/null || true
+  echo "merged (CI green): $URL"
 else
-  echo "NOTE: CI not green, PR left open for review: $URL"
+  echo "NOTE: CI not green, PR left open for review: $URL (worktree kept: $WT)"
 fi
 ```


### PR DESCRIPTION
## Summary
- Adds an `unsafe_feedback` finding type to the STPA skill: feedback/data channels analyzed with their own guidewords (`missing`/`stale`/`corrupted`/`unauthorized-source`), rendered as a new **Unsafe feedback** section. This is where data-integrity failures (staleness windows, lost updates, cache/mirror drift, provenance divergence) now live, instead of being strained through control-action UCAs (loom's `acl.set-policy.wrong-timing`) or parked in `open_questions`. One skill, one doc, one renderer: no split.
- BLOCK B now lands the file from a disposable worktree based on `origin/main`. The old `git switch -C` flow switched whatever checkout it ran in onto the bot branch and never switched back.
- BLOCK A renders to `/tmp/STPA.candidate.md` and diffs against `origin/main` (not the possibly-stale working tree); it no longer writes into the checkout at all.
- Renderer no longer emits em-dashes (repo writing style).

Backwards compatible: JSON without `unsafe_feedback` renders with the section omitted. Renderer verified deterministic against a sample with and without the new field; both bash blocks pass `bash -n`.

Note for the loom routine: porting this renderer produces a one-time cosmetic diff (title/summary punctuation) on the next scheduled run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)