### PR TITLE
fix(goosecracker): read task/context from files, not templated recipe YAML

### DIFF
--- a/projects/firecracker/goosecracker/guest-init/internal/handler/handler.go
+++ b/projects/firecracker/goosecracker/guest-init/internal/handler/handler.go
@@ -22,6 +22,7 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/jomcgi/homelab/projects/firecracker/goosecracker/guest-init/internal/harness"
@@ -158,9 +159,18 @@ func New(runner Runner, opts ...Option) shim.Handler {
 			}
 		}
 
+		// Write the task to a file the recipe reads, rather than templating it into
+		// the recipe YAML (see taskFilePath). Only the recipe paths use it; the
+		// bare-task/resume-without-recipe paths pass req.Task raw via --text.
+		if err := writeTaskFile(req.Task); err != nil {
+			slog.Error("handler: task file write failed", "err", err)
+			return jsonResult(AgentResult{Status: "error", Error: err.Error()})
+		}
+
 		argv := harness.GooseCommand(harness.Config{
 			Recipe:      req.Recipe,
 			Task:        req.Task,
+			TaskFile:    taskFilePath,
 			SessionName: req.Session,
 			Resume:      resume,
 		})
@@ -178,6 +188,11 @@ func New(runner Runner, opts ...Option) shim.Handler {
 		result := AgentResult{Status: "ok", Result: out}
 		if runErr != nil {
 			result.Status = "error"
+			// Keep goose's captured output on the failure path: for a run that
+			// started but exited non-zero (e.g. a recipe that failed to load) the
+			// only diagnostic is what goose printed. Dropping it leaves a bare
+			// "exit status 1" in the ledger and the reply, forcing a log dig.
+			result.Result = out
 			result.Error = runErr.Error()
 			return jsonResult(result)
 		}
@@ -223,6 +238,40 @@ func New(runner Runner, opts ...Option) shim.Handler {
 // HTML document (ADR 024); the harness ships it back for the orchestrator to
 // publish. A package var so tests can point it at a temp file.
 var artifactPath = "/tmp/artifact.html"
+
+// taskFilePath / contextFilePath are the files recipes read the task and the
+// router's context briefing from, instead of having that (untrusted, possibly
+// multi-line) text templated into the recipe YAML. goose renders a recipe as a
+// template and re-parses it as YAML before running, so a newline in a value
+// substituted into a `prompt: |` block scalar breaks the parse; a fixed
+// single-line path never can. The handler writes the task here; the router
+// writes its briefing to contextFilePath (sub-recipes read both via pre-bound
+// values). Package vars so tests can point them at a temp dir. These paths must
+// match the ones wired into the recipes (agent.yaml sub_recipes values).
+var (
+	taskFilePath    = "/tmp/goose/task.md"
+	contextFilePath = "/tmp/goose/context.md"
+)
+
+// writeTaskFile writes the task to taskFilePath and truncates contextFilePath to
+// empty, creating the parent dir. Truncating context clears any briefing left by
+// a prior turn in the same (snapshot-restored) microVM, so a sub-recipe never
+// reads a stale one; the router overwrites it when it has something to say. A
+// failure to write the task file is fatal to the run (the recipe would read an
+// empty task); a context-truncate failure is soft.
+func writeTaskFile(task string) error {
+	if err := os.MkdirAll(filepath.Dir(taskFilePath), 0o755); err != nil {
+		return fmt.Errorf("handler: create task dir: %w", err)
+	}
+	if err := os.WriteFile(taskFilePath, []byte(task), 0o644); err != nil {
+		return fmt.Errorf("handler: write task file: %w", err)
+	}
+	if err := os.WriteFile(contextFilePath, nil, 0o644); err != nil {
+		slog.Warn("handler: could not truncate context file; a stale briefing may leak",
+			"path", contextFilePath, "err", err)
+	}
+	return nil
+}
 
 // readArtifact returns the built artifact HTML, or nil when the run produced
 // none (a non-artifact recipe, or a build that failed to write the file). It

--- a/projects/firecracker/goosecracker/guest-init/internal/handler/handler_test.go
+++ b/projects/firecracker/goosecracker/guest-init/internal/handler/handler_test.go
@@ -112,6 +112,20 @@ func (f *fakeSessionStore) Export(_ context.Context) ([]byte, error) {
 	return f.exportData, f.exportErr
 }
 
+// TestMain points the task/context file paths at a temp dir so the handler's
+// per-run file write does not touch the real /tmp during tests.
+func TestMain(m *testing.M) {
+	dir, err := os.MkdirTemp("", "goose-handler-test")
+	if err != nil {
+		panic(err)
+	}
+	taskFilePath = filepath.Join(dir, "task.md")
+	contextFilePath = filepath.Join(dir, "context.md")
+	code := m.Run()
+	_ = os.RemoveAll(dir)
+	os.Exit(code)
+}
+
 func invoke(t *testing.T, h shim.Handler, body string) (*shim.Response, error) {
 	t.Helper()
 	return h(context.Background(), &shim.Request{Path: "/invoke", Body: strings.NewReader(body)})
@@ -158,12 +172,17 @@ func TestColdRunBuildsArgvStreamsAndReturnsResult(t *testing.T) {
 		t.Errorf("result = %q, want %q", res.Result, "final answer")
 	}
 
-	// argv reflects recipe + task + session.
+	// argv reflects recipe + session + the task-file param (the task itself is
+	// written to that file, not templated into the recipe).
 	argv := strings.Join(runner.gotArgv, " ")
-	for _, want := range []string{"--recipe agent", "--name sess-1", "task_description=do the thing"} {
+	for _, want := range []string{"--recipe agent", "--name sess-1", "task_file=" + taskFilePath} {
 		if !strings.Contains(argv, want) {
 			t.Errorf("argv %q missing %q", argv, want)
 		}
+	}
+	// the task text landed in the task file
+	if b, err := os.ReadFile(taskFilePath); err != nil || string(b) != "do the thing" {
+		t.Errorf("task file = %q (err %v), want %q", b, err, "do the thing")
 	}
 
 	// env forwarded verbatim.
@@ -360,6 +379,11 @@ func TestGooseRunErrorIsErrorResultAt200(t *testing.T) {
 	if res.Status != "error" || res.Error == "" {
 		t.Errorf("want error result, got %+v", res)
 	}
+	// goose's captured output is preserved on the error path so the failure is
+	// self-diagnosing (a bare exit code is useless).
+	if res.Result != "partial" {
+		t.Errorf("error result should keep goose output for diagnosis, got Result %q", res.Result)
+	}
 }
 
 func TestUndecodableBodyReturnsHandlerError(t *testing.T) {
@@ -410,8 +434,11 @@ func TestResumeHydratesSessionAndExportsUpdatedDb(t *testing.T) {
 	if !strings.Contains(argv, "--recipe agent") {
 		t.Errorf("argv %q should re-pass --recipe on resume", argv)
 	}
-	if !strings.Contains(argv, "task_description=make it bigger") {
-		t.Errorf("argv %q should pass the task via --params on resume", argv)
+	if !strings.Contains(argv, "task_file="+taskFilePath) {
+		t.Errorf("argv %q should pass the task file via --params on resume", argv)
+	}
+	if b, err := os.ReadFile(taskFilePath); err != nil || string(b) != "make it bigger" {
+		t.Errorf("resume task file = %q (err %v), want %q", b, err, "make it bigger")
 	}
 	// updated db exported back.
 	wantDb := base64.StdEncoding.EncodeToString([]byte("updated-db"))

--- a/projects/firecracker/goosecracker/guest-init/internal/harness/harness.go
+++ b/projects/firecracker/goosecracker/guest-init/internal/harness/harness.go
@@ -13,8 +13,18 @@ type Config struct {
 	// their own settings.max_turns / max_tool_repetitions, which is what bounds
 	// the run and gives the idle detector a quiescent boundary.
 	Recipe string
-	// Task is the task description fed to the recipe (FC_TASK).
+	// Task is the raw task text. It is passed directly to goose as --text/-t on
+	// the recipe-less paths (bare task, resume-without-recipe), where goose uses
+	// it verbatim as the prompt and multi-line content is safe.
 	Task string
+	// TaskFile is the path to a file holding the task, used on the recipe paths
+	// (--params task_file=<TaskFile>). Recipes read the task from this file rather
+	// than having it templated into their YAML: goose renders a recipe as a
+	// template and re-parses it as YAML before running, so a multi-line task
+	// substituted into a `prompt: |` block scalar breaks the parse ("could not
+	// find expected ':'"), and goose dropped the `indent` filter that used to
+	// re-indent it in v1.39.0. A single-line file path is always safe.
+	TaskFile string
 	// SessionName names goose's SQLite session (--name). On a cold build it is set
 	// so the session is persisted under a stable name; on a resume it selects which
 	// session to replay (ADR 026 Phase 2). Empty means goose auto-manages.
@@ -28,8 +38,8 @@ type Config struct {
 
 // GooseCommand returns the argv to run, mirroring the established invocation:
 //
-//	resume:         goose run --recipe <recipe> --name <session> --resume --no-profile --with-builtin developer --params task_description=<task>
-//	with a recipe:  goose run --recipe <recipe> [--name <session>] --no-profile --with-builtin developer --params task_description=<task>
+//	resume:         goose run --recipe <recipe> --name <session> --resume --no-profile --with-builtin developer --params task_file=<taskfile>
+//	with a recipe:  goose run --recipe <recipe> [--name <session>] --no-profile --with-builtin developer --params task_file=<taskfile>
 //	bare task only: goose run --text <task>
 //
 // --no-profile keeps the run deterministic (it ignores the baked config.yaml), but
@@ -62,7 +72,7 @@ func GooseCommand(c Config) []string {
 				"--resume",
 				"--no-profile",
 				"--with-builtin", "developer",
-				"--params", fmt.Sprintf("task_description=%s", c.Task),
+				"--params", fmt.Sprintf("task_file=%s", c.TaskFile),
 			}
 		}
 		return []string{
@@ -83,7 +93,7 @@ func GooseCommand(c Config) []string {
 		return append(argv,
 			"--no-profile",
 			"--with-builtin", "developer",
-			"--params", fmt.Sprintf("task_description=%s", c.Task),
+			"--params", fmt.Sprintf("task_file=%s", c.TaskFile),
 		)
 	}
 	if c.Task != "" {

--- a/projects/firecracker/goosecracker/guest-init/internal/harness/harness_test.go
+++ b/projects/firecracker/goosecracker/guest-init/internal/harness/harness_test.go
@@ -6,8 +6,8 @@ import (
 )
 
 func TestGooseCommandWithRecipe(t *testing.T) {
-	got := GooseCommand(Config{Recipe: "/etc/goose/recipes/agent.yaml", Task: "fix the flaky test"})
-	want := "goose run --recipe /etc/goose/recipes/agent.yaml --no-profile --with-builtin developer --params task_description=fix the flaky test"
+	got := GooseCommand(Config{Recipe: "/etc/goose/recipes/agent.yaml", Task: "fix the flaky test", TaskFile: "/tmp/goose/task.md"})
+	want := "goose run --recipe /etc/goose/recipes/agent.yaml --no-profile --with-builtin developer --params task_file=/tmp/goose/task.md"
 	if strings.Join(got, " ") != want {
 		t.Fatalf("got %q, want %q", strings.Join(got, " "), want)
 	}
@@ -29,8 +29,8 @@ func TestGooseCommandNoTaskIsNil(t *testing.T) {
 func TestGooseCommandColdBuildNamesSession(t *testing.T) {
 	// A cold build with a session name still uses the recipe, but adds --name so
 	// the session is persisted under that name for a later resume (ADR 026 Phase 2).
-	got := GooseCommand(Config{Recipe: "artifact.yaml", Task: "make a ball", SessionName: "thread-1"})
-	want := "goose run --recipe artifact.yaml --name thread-1 --no-profile --with-builtin developer --params task_description=make a ball"
+	got := GooseCommand(Config{Recipe: "artifact.yaml", Task: "make a ball", TaskFile: "/tmp/goose/task.md", SessionName: "thread-1"})
+	want := "goose run --recipe artifact.yaml --name thread-1 --no-profile --with-builtin developer --params task_file=/tmp/goose/task.md"
 	if strings.Join(got, " ") != want {
 		t.Fatalf("got %q, want %q", strings.Join(got, " "), want)
 	}
@@ -39,9 +39,9 @@ func TestGooseCommandColdBuildNamesSession(t *testing.T) {
 func TestGooseCommandResume(t *testing.T) {
 	// Resume replays the named session AND re-passes the recipe so goose re-applies
 	// the recipe's response schema + settings to the follow-up turn. The task goes
-	// via --params (-t conflicts with --recipe in goose's CLI).
-	got := GooseCommand(Config{Recipe: "agent.yaml", Task: "how does it work?", SessionName: "thread-1", Resume: true})
-	want := "goose run --recipe agent.yaml --name thread-1 --resume --no-profile --with-builtin developer --params task_description=how does it work?"
+	// via --params task_file (-t conflicts with --recipe in goose's CLI).
+	got := GooseCommand(Config{Recipe: "agent.yaml", Task: "how does it work?", TaskFile: "/tmp/goose/task.md", SessionName: "thread-1", Resume: true})
+	want := "goose run --recipe agent.yaml --name thread-1 --resume --no-profile --with-builtin developer --params task_file=/tmp/goose/task.md"
 	if strings.Join(got, " ") != want {
 		t.Fatalf("got %q, want %q", strings.Join(got, " "), want)
 	}
@@ -66,11 +66,21 @@ func TestGooseCommandResumeWithoutSessionFallsBackToRecipe(t *testing.T) {
 	}
 }
 
-func TestTaskWithSpacesStaysSingleArg(t *testing.T) {
-	// The task is one argv element even with spaces; no shell splitting.
-	got := GooseCommand(Config{Recipe: "r.yaml", Task: "a b c"})
+func TestTaskFileParamStaysSingleArg(t *testing.T) {
+	// The task_file param is one argv element even if the path contains a space;
+	// no shell splitting.
+	got := GooseCommand(Config{Recipe: "r.yaml", Task: "a b c", TaskFile: "/tmp/goose dir/task.md"})
 	last := got[len(got)-1]
-	if last != "task_description=a b c" {
-		t.Fatalf("task param should be a single arg, got %q", last)
+	if last != "task_file=/tmp/goose dir/task.md" {
+		t.Fatalf("task_file param should be a single arg, got %q", last)
+	}
+}
+
+func TestBareTaskPassesRawTextNotFile(t *testing.T) {
+	// The recipe-less path passes the raw task via --text, where goose uses it
+	// verbatim as the prompt: multi-line content is safe here (no YAML templating).
+	got := GooseCommand(Config{Task: "line one\nline two"})
+	if len(got) != 4 || got[2] != "--text" || got[3] != "line one\nline two" {
+		t.Fatalf("bare task should pass raw multi-line text via --text, got %v", got)
 	}
 }

--- a/projects/firecracker/goosecracker/guest/recipes/agent.yaml
+++ b/projects/firecracker/goosecracker/guest/recipes/agent.yaml
@@ -1,4 +1,4 @@
-version: "1.4.2"
+version: "1.5.0"
 title: "Agent"
 description: "Routing agent for a snapshot-managed microVM thread (ADR 022): classifies the task and dispatches the matching sub-recipe."
 instructions: |
@@ -49,12 +49,14 @@ instructions: |
   this conversation). The root conventions file is not always ./CLAUDE.md:
   in this repo it lives at .claude/CLAUDE.md. Locate it before reading, for
   example `find . -maxdepth 2 -name CLAUDE.md`, rather than assuming the
-  path (a wrong guess wastes tool calls on a "No such file" error). Pass
-  what you found in the sub-recipe's context
-  parameter as a short briefing: relevant paths, constraints, and any
-  earlier results the worker cannot see (sub-recipes do not share your
-  conversation history). Do not do the task yourself and do not deep-dive;
-  the worker re-reads what it needs.
+  path (a wrong guess wastes tool calls on a "No such file" error). Write
+  what you found as a short briefing to the file /tmp/goose/context.md (for
+  example with the editor, or `printf '%s' '...' > /tmp/goose/context.md`):
+  relevant paths, constraints, and any earlier results the worker cannot see
+  (sub-recipes do not share your conversation history). Every sub-recipe reads
+  that file automatically, so this is how the briefing reaches the worker. Keep
+  it short; if you have nothing useful to add, leave the file untouched. Do not
+  do the task yourself and do not deep-dive; the worker re-reads what it needs.
 
   Dispatch the actual work; never run it in the router. Your context is
   shared across the whole thread, so a large tool output here (a full
@@ -65,8 +67,10 @@ instructions: |
   you do read (pipe through `head`, count with `wc -l` first, sample) and
   never pull hundreds of log lines into your context.
 
-  Then call the matching sub-recipe tool with the task (verbatim or lightly
-  clarified) and your context briefing, and wait for its result.
+  Then call the matching sub-recipe tool and wait for its result. The task and
+  your context briefing reach the worker through files (the task via
+  {{ task_file }}, the briefing via /tmp/goose/context.md), pre-wired on each
+  sub-recipe, so you do not pass them as tool arguments.
 
   When it returns, produce the structured result enforced by the response
   schema below, from the sub-recipe's output: a short `summary` of the
@@ -103,22 +107,43 @@ instructions: |
   the `recipe__` prefix. Call `recipe__final_output` on your first attempt and
   do not retry the unprefixed name.
 prompt: |
-  {{ task_description }}
+  Your task is in the file {{ task_file }}. Read it in full first, for example
+  `cat {{ task_file }}`, then classify and route it.
 parameters:
-  - key: task_description
-    description: "The task to perform"
+  - key: task_file
+    description: "Path to a file containing the task to perform"
     input_type: string
     requirement: required
+# Sub-recipes receive the task and the router briefing through files, not
+# templated params: task_file is threaded through from this recipe's param,
+# context_file is the fixed path the router writes its briefing to. Passing the
+# untrusted, possibly multi-line task text as a recipe parameter would be
+# substituted into the sub-recipe YAML and re-parsed, which breaks the block
+# scalar on any newline (goose renders the recipe as a template before parsing,
+# and dropped the `indent` filter in v1.39.0). File paths are single-line and
+# safe.
 sub_recipes:
   - name: query
     path: /home/goose-agent/recipes/query.yaml
+    values:
+      task_file: "{{ task_file }}"
+      context_file: /tmp/goose/context.md
   - name: plan
     path: /home/goose-agent/recipes/plan.yaml
+    values:
+      task_file: "{{ task_file }}"
+      context_file: /tmp/goose/context.md
   - name: implement
     path: /home/goose-agent/recipes/implement.yaml
     sequential_when_repeated: true
+    values:
+      task_file: "{{ task_file }}"
+      context_file: /tmp/goose/context.md
   - name: artifact
     path: /home/goose-agent/recipes/artifact.yaml
+    values:
+      task_file: "{{ task_file }}"
+      context_file: /tmp/goose/context.md
 extensions:
   - type: builtin
     name: developer

--- a/projects/firecracker/goosecracker/guest/recipes/artifact.yaml
+++ b/projects/firecracker/goosecracker/guest/recipes/artifact.yaml
@@ -1,4 +1,4 @@
-version: "1.1.0"
+version: "1.2.0"
 title: "Artifact"
 description: "Build a single web artifact (may use CDN libs + live https APIs); the harness publishes it to a live URL (ADR 024)."
 instructions: |
@@ -41,19 +41,20 @@ instructions: |
   ```
 prompt: |
   Build this artifact now. Start immediately by writing /tmp/artifact.html with
-  the shell or editor; do not reply with a plan or a description first:
+  the shell or editor; do not reply with a plan or a description first.
 
-  {{ task_description }}
+  What to build is in the file {{ task_file }}: read it first, for example
+  `cat {{ task_file }}`.
 
-  Context from the router (may be empty):
-  {{ context }}
+  Router context may be in the file {{ context_file }} (the path may be empty,
+  meaning none): if it is a non-empty path, read it too.
 parameters:
-  - key: task_description
-    description: "What to build"
+  - key: task_file
+    description: "Path to a file describing what to build"
     input_type: string
     requirement: required
-  - key: context
-    description: "Context the router gathered: constraints, prior thread state"
+  - key: context_file
+    description: "Path to an optional file with router-gathered context (constraints, prior thread state); may be empty"
     input_type: string
     requirement: optional
     default: ""

--- a/projects/firecracker/goosecracker/guest/recipes/implement.yaml
+++ b/projects/firecracker/goosecracker/guest/recipes/implement.yaml
@@ -1,4 +1,4 @@
-version: "1.2.1"
+version: "1.3.0"
 title: "Implement"
 description: "Implementation sub-recipe: make a code or config change, commit it, and open a PR."
 instructions: |
@@ -34,20 +34,22 @@ instructions: |
   and the PR URL if you opened one (only a URL you actually received, never
   an invented one).
 parameters:
-  - key: task_description
-    description: "The change to implement"
+  - key: task_file
+    description: "Path to a file containing the change to implement"
     input_type: string
     requirement: required
-  - key: context
-    description: "Context the router gathered: relevant paths, prior thread state, constraints, or a plan to follow"
+  - key: context_file
+    description: "Path to an optional file with router-gathered context (relevant paths, prior thread state, constraints, or a plan to follow); may be empty"
     input_type: string
     requirement: optional
     default: ""
 prompt: |
-  {{ task_description }}
+  The change to implement is in the file {{ task_file }}. Read it in full first,
+  for example `cat {{ task_file }}`.
 
-  Router context (may be empty):
-  {{ context }}
+  Router context may be in the file {{ context_file }} (the path may be empty,
+  meaning none): if it is a non-empty path, read it too, for example
+  `cat {{ context_file }}`.
 extensions:
   - type: builtin
     name: developer

--- a/projects/firecracker/goosecracker/guest/recipes/plan.yaml
+++ b/projects/firecracker/goosecracker/guest/recipes/plan.yaml
@@ -1,4 +1,4 @@
-version: "1.2.1"
+version: "1.3.0"
 title: "Plan"
 description: "Planning sub-recipe: turn a feature or change request into a written implementation plan, without implementing it."
 instructions: |
@@ -43,20 +43,22 @@ instructions: |
   you planned, the recommended approach in one sentence, the plan file path,
   and the PR URL if you opened one.
 parameters:
-  - key: task_description
-    description: "The feature or change request to plan"
+  - key: task_file
+    description: "Path to a file containing the feature or change request to plan"
     input_type: string
     requirement: required
-  - key: context
-    description: "Context the router gathered: relevant paths, prior thread state, constraints"
+  - key: context_file
+    description: "Path to an optional file with router-gathered context (relevant paths, prior thread state, constraints); may be empty"
     input_type: string
     requirement: optional
     default: ""
 prompt: |
-  {{ task_description }}
+  The feature or change request to plan is in the file {{ task_file }}. Read it
+  in full first, for example `cat {{ task_file }}`.
 
-  Router context (may be empty):
-  {{ context }}
+  Router context may be in the file {{ context_file }} (the path may be empty,
+  meaning none): if it is a non-empty path, read it too, for example
+  `cat {{ context_file }}`.
 extensions:
   - type: builtin
     name: developer

--- a/projects/firecracker/goosecracker/guest/recipes/query.yaml
+++ b/projects/firecracker/goosecracker/guest/recipes/query.yaml
@@ -1,4 +1,4 @@
-version: "1.2.1"
+version: "1.3.0"
 title: "Query"
 description: "Read-only investigation sub-recipe: answer a question about the repo or cluster without changing anything."
 instructions: |
@@ -31,20 +31,22 @@ instructions: |
   message is returned verbatim to the routing agent, so lead with the answer,
   then the supporting evidence.
 parameters:
-  - key: task_description
-    description: "The question to answer"
+  - key: task_file
+    description: "Path to a file containing the question to answer"
     input_type: string
     requirement: required
-  - key: context
-    description: "Context the router gathered: relevant paths, prior thread state, constraints"
+  - key: context_file
+    description: "Path to an optional file with router-gathered context (relevant paths, prior thread state, constraints); may be empty"
     input_type: string
     requirement: optional
     default: ""
 prompt: |
-  {{ task_description }}
+  The question to answer is in the file {{ task_file }}. Read it in full first,
+  for example `cat {{ task_file }}`.
 
-  Router context (may be empty):
-  {{ context }}
+  Router context may be in the file {{ context_file }} (the path may be empty,
+  meaning none): if it is a non-empty path, read it too, for example
+  `cat {{ context_file }}`.
 extensions:
   - type: builtin
     name: developer

--- a/projects/firecracker/substrate/chart/Chart.yaml
+++ b/projects/firecracker/substrate/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: fc-invoke
 description: Node-affine Firecracker invoke daemon that dispatches HTTP invocations to a pool of warm-base microVMs across named workloads (POST /invoke/{workload}, GET /healthz)
 type: application
-version: 0.4.15
+version: 0.4.16

--- a/projects/firecracker/substrate/deploy/application.yaml
+++ b/projects/firecracker/substrate/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tags pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: fc-invoke
-      targetRevision: 0.4.15
+      targetRevision: 0.4.16
       helm:
         valueFiles:
           - $values/projects/firecracker/substrate/deploy/values.yaml


### PR DESCRIPTION
## Problem

A multi-line Discord message broke every `/agent` run at recipe load: `Error: Invalid recipe: could not find expected ':'` (exit status 1, ~1s), confirmed in the fc-invoke guest logs via SigNoz.

goose renders a recipe as a template and **re-parses it as YAML before running**, so the task substituted into the `prompt: |` block scalar breaks the parse whenever it spans more than one line (the continuation line un-indents out of the block scalar). Yesterday's `4d083a661` removed the `| indent(2)` filter (goose v1.39.0 dropped it), which fixed a different "unknown filter" error but silently reopened this one. The `context` param has the same flaw and can additionally cause *silent* recipe corruption when a continuation line happens to contain a colon.

## Fix

Stop templating untrusted, possibly multi-line text into recipe YAML at all:

- The guest handler writes the task to `/tmp/goose/task.md`; recipes read it via a single-line `task_file` **path** param.
- The router writes its briefing to `/tmp/goose/context.md`; every sub-recipe reads it via a **pre-bound** `context_file` value (goose `sub_recipes.values`), so the router never passes multi-line args.
- File paths are single-line, so they can never break the block scalar. This also closes a latent **template-injection** surface (a task containing goose template markers was being evaluated by goose's engine).
- Independently: the guest handler no longer discards goose's captured output on the run-failed path, so a future recipe-load failure surfaces its real reason in the ledger and the Discord reply instead of a bare `exit status 1`.

## Verification

Reproduced and fixed **locally against the real goose v1.39.0** (same version baked into the guest):

- Before: the exact multi-line prod input (`wtf is this - nobody is fighting.\nDeep fry this shit`) → `Invalid recipe: could not find expected ':'`.
- After: all five recipes (`agent`, `query`, `plan`, `implement`, `artifact`) load cleanly with pathological content (colons, dashes, newlines, `{{ }}`/`{% %}`, quotes, backslash) in the file; `goose recipe validate agent.yaml` → `✓ recipe file is valid`.
- `go vet` + `go test` pass for the `harness` and `handler` packages.

Rolls via substrate chart 0.4.15 -> 0.4.16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)