### PR TITLE
fix(goosecracker): router delegates artifact build+review + re-reads task on resume

### DIFF
--- a/projects/firecracker/goosecracker/guest/recipes/agent.yaml
+++ b/projects/firecracker/goosecracker/guest/recipes/agent.yaml
@@ -1,4 +1,4 @@
-version: "1.5.0"
+version: "1.6.0"
 title: "Agent"
 description: "Routing agent for a snapshot-managed microVM thread (ADR 022): classifies the task and dispatches the matching sub-recipe."
 instructions: |
@@ -20,38 +20,44 @@ instructions: |
     interactive page, a chart, a small demo, a dashboard, or a report rendered
     as a web page ("make me / build me / show me a ..."). The deliverable is a
     live web page published to a URL, not a repo change. The artifact runs in a
-    sandboxed iframe and cannot touch a repo. Dispatch this to the `artifact-build`
-    sub-recipe. If you build it inline instead, you MUST write the complete,
-    self-contained HTML document to exactly `/tmp/artifact.html` (the harness
-    publishes that path and only that path). Never write the page into the repo
-    workspace: a file left in /workspace is not published and is lost.
+    sandboxed iframe and cannot touch a repo.
 
-    HARD GATE for artifact mode: do NOT call `recipe__final_output` with
-    `mode: artifact` until you have actually produced the page in THIS run, by
-    one of two observable actions:
-      1. the `artifact-build` sub-recipe tool has been called and RETURNED a result, or
-      2. you have written a non-empty `/tmp/artifact.html` yourself.
-    Deciding to dispatch is not dispatching. If your most recent action was a
-    thought about routing (or a plan to build it) rather than an actual `artifact-build`
-    tool call or a file write, the page does not exist yet and finishing now
-    publishes an empty artifact. Take the action, wait for its result or confirm
-    the file is written, and only then emit the final output.
+    You do NOT build the page yourself. Artifacts are BUILD then REVIEW, and you
+    run BOTH steps as delegated subagents, using the `delegate` tool, so that the
+    design bar, the JavaScript parse gate and the fresh-eyes review actually run.
+    If you write the HTML yourself instead, ALL THREE are skipped and a broken
+    page ships. The steps, in order, each waiting for the result:
+      1. `delegate(source: "artifact-build")` and WAIT. That subagent reads the
+         task from /tmp/goose/task.md and writes the page to /tmp/artifact.html.
+      2. `delegate(source: "artifact-review")` and WAIT. That subagent reads
+         /tmp/artifact.html in a fresh context, fixes real correctness and design
+         issues in place, and re-checks that the inline script parses.
+      3. `recipe__final_output` with `mode: artifact` and an empty `url` (the
+         harness publishes /tmp/artifact.html and appends the live URL). Just
+         summarize what was built or changed.
 
-    Artifact tasks are BUILD then REVIEW. Once the page exists (the `artifact-build`
-    sub-recipe returned, or you wrote `/tmp/artifact.html`), call the `artifact-review`
-    sub-recipe exactly once (it receives the same task file automatically). It reads
-    the page in isolated context, fixes real correctness and design issues in place
-    (dead buttons, an unparseable script, weak polish), re-checks the JS still
-    parses, and returns a short note. Only after `artifact-review` returns do you
-    emit the final output. Do this for every artifact, including a resumed one you
-    just changed. The one exception: if `artifact-review` has already run in this
-    turn, do not call it again.
+    HARD GATE: do NOT emit `mode: artifact` until BOTH `delegate` calls have
+    RETURNED a result in THIS turn. Deciding to delegate is not delegating: if
+    your most recent action was a thought rather than an actual `delegate` tool
+    call, nothing has happened yet. Never write /tmp/artifact.html yourself and
+    never skip the review.
 
   When a task mixes modes, pick the deliverable the user actually asked
   for. "Fix X" is implement. "How should we fix X" is plan. "Is X broken"
   is query. On a resumed thread, classify the NEW message: a follow-up
   question after an implement run routes to query, and "now do it" after a
   plan run routes to implement.
+
+  ALWAYS re-read /tmp/goose/task.md as your FIRST action on EVERY turn,
+  including a resumed thread. The file is overwritten with the CURRENT message
+  each turn, so it is almost always a NEW request, not a repeat of what you did
+  before. NEVER answer "already completed", "already built", or "repeated
+  prompt" without cat-ing the file first: assuming the task is unchanged is the
+  single most common way this router fails the owner. A follow-up on an artifact
+  thread ("add X", "change the Y", "make it Z", "that is broken") is a NEW
+  artifact task: re-run BOTH delegates (artifact-build then artifact-review).
+  The previous /tmp/artifact.html is still on disk, so artifact-build modifies
+  it in place rather than starting over.
 
   Before dispatching, spend at most a few tool calls gathering context the
   worker will need: skim the repo's root CLAUDE.md, locate the relevant
@@ -90,10 +96,10 @@ instructions: |
   the worker reported a real PR or issue URL. For an artifact the harness
   publishes the page and adds its live URL to the reply, so leave `url` empty
   and just summarize what you built. Before emitting `mode: artifact`, re-check
-  the HARD GATE above: the `artifact-build` sub-recipe must have returned, or
-  `/tmp/artifact.html` must already be written. Do not summarize a page you only
-  intended to build. The summary describes the ACTION and RESULT, not your
-  reasoning.
+  the HARD GATE above: BOTH `delegate(source: "artifact-build")` and
+  `delegate(source: "artifact-review")` must have returned in this turn. Do not
+  summarize a page you only intended to build. The summary describes the ACTION
+  and RESULT, not your reasoning.
 
   Be brief and finish fast. Length is the main thing that makes a reply feel
   slow: this runs on a local model, so every extra sentence is real wall-time,

--- a/projects/firecracker/goosecracker/guest/recipes/artifact-build.yaml
+++ b/projects/firecracker/goosecracker/guest/recipes/artifact-build.yaml
@@ -1,4 +1,4 @@
-version: "1.2.0"
+version: "1.3.0"
 title: "Artifact"
 description: "Build a single web artifact (may use CDN libs + live https APIs); the harness publishes it to a live URL (ADR 024)."
 instructions: |
@@ -74,24 +74,32 @@ instructions: |
   summary: <1-2 sentences: what you built>
   ```
 prompt: |
-  Build this artifact now. Start immediately by writing /tmp/artifact.html with
-  the shell or editor; do not reply with a plan or a description first.
+  Build or update this artifact now. Start immediately by writing
+  /tmp/artifact.html with the shell or editor; do not reply with a plan or a
+  description first.
 
   What to build is in the file {{ task_file }}: read it first, for example
   `cat {{ task_file }}`.
 
-  Router context may be in the file {{ context_file }} (the path may be empty,
-  meaning none): if it is a non-empty path, read it too.
+  If /tmp/artifact.html ALREADY EXISTS, this is very likely a follow-up change to
+  that page (for example "add real product pics" or "make it darker"): read the
+  existing file first and MODIFY it in place to satisfy the new request,
+  preserving everything that is not being changed. Only build a fresh page from
+  scratch when none exists yet.
+
+  Router context may be in the file {{ context_file }} (it may be empty or
+  missing): read it if it is a non-empty file.
 parameters:
   - key: task_file
     description: "Path to a file describing what to build"
     input_type: string
-    requirement: required
+    requirement: optional
+    default: "/tmp/goose/task.md"
   - key: context_file
     description: "Path to an optional file with router-gathered context (constraints, prior thread state); may be empty"
     input_type: string
     requirement: optional
-    default: ""
+    default: "/tmp/goose/context.md"
 extensions:
   - type: builtin
     name: developer

--- a/projects/firecracker/goosecracker/guest/recipes/artifact-review.yaml
+++ b/projects/firecracker/goosecracker/guest/recipes/artifact-review.yaml
@@ -1,4 +1,4 @@
-version: "1.0.0"
+version: "1.1.0"
 title: "Review"
 description: "Review and polish an already-built web artifact in isolated context (ADR 024): read /tmp/artifact.html, fix real correctness and design issues IN PLACE, and re-gate that the JS still parses."
 instructions: |
@@ -63,12 +63,13 @@ parameters:
   - key: task_file
     description: "Path to a file with the original artifact request, so the review stays true to intent"
     input_type: string
-    requirement: required
+    requirement: optional
+    default: "/tmp/goose/task.md"
   - key: context_file
     description: "Path to an optional file with router-gathered context (constraints, prior thread state); may be empty"
     input_type: string
     requirement: optional
-    default: ""
+    default: "/tmp/goose/context.md"
 extensions:
   - type: builtin
     name: developer


### PR DESCRIPTION
## Why

Reading the GT0-Beta prod thread (session `1522321497161601214`) after the last deploy exposed two router bugs. Neither is the JS gate; the gate/design-bar/review shipped but were **never reachable**.

### Bug 1: sub-recipe dispatch never worked
The router tried `recipe__artifact-review` and got "tool isn't available", then built the artifact **inline in its own context**. I traced goose v1.39.0 source: sub-recipes are invoked through the **`delegate(source: "<name>")`** platform tool (Summon extension, `default_enabled: true`), there is no `recipe__<name>` tool. Because the router built inline, `artifact-build.yaml` was never invoked, so **the design bar and the JS-parse gate never ran**, and `artifact-review` was skipped. A query session confirmed the same: the router inlines everything and dispatches nothing.

### Bug 2: resume returned "Already completed"
On the follow-up "Can you add real product pics?", the router's own reasoning was *"this is a repeated prompt"* and it **never `cat`-ed `/tmp/goose/task.md`** (which held the new request). It returned "Already completed" and did nothing, the "didn't work after feedback" symptom.

## Fix

- **Artifact route now delegates explicitly**: `delegate(source: "artifact-build")` → `delegate(source: "artifact-review")` → `recipe__final_output`, and building inline is forbidden. This is the only path where the gate, design bar and isolated review actually execute. `query`/`plan`/`implement` are unchanged (inline works for them; converting is unnecessary risk).
- **Resume re-read**: force a fresh read of `/tmp/goose/task.md` as the first action every turn; an artifact follow-up ("add X", "change Y") is a NEW task that re-delegates build+review.
- **Robust dispatch**: `artifact-build`/`artifact-review` read fixed paths (`/tmp/goose/task.md`, `/tmp/artifact.html`), params optional and defaulted to them, so a bare `delegate(source:)` works without relying on parameter threading I can't test.
- **Follow-up = modify**: `artifact-build` reads and edits an existing `/tmp/artifact.html` in place rather than rebuilding from scratch.

## Validation

No local guest loop exists, so this is verified by: recipes parse; goose-source trace of the `delegate` mechanism (`crates/goose/src/agents/platform_extensions/summon.rs`, tools `load`/`delegate`, `default_enabled: true`, `unprefixed_tools: true`); and a **live Discord run after deploy** (fire an artifact + a follow-up, read the session DB to confirm both delegates fired, the gate ran, and resume re-reads). Chosen deliberately over a blind merge.