### PR TITLE
fix(goosecracker): reaction lifecycle + orphan-free queue for agent threads

### DIFF
--- a/projects/monolith/app/main.py
+++ b/projects/monolith/app/main.py
@@ -110,6 +110,20 @@ async def _start_singletons(app: FastAPI) -> None:
         tasks.append(drain_task)
         logger.info("Discord outbox drain starting")
 
+        # Reclaim goosecracker agent turns orphaned by the prior owner's death
+        # (this replica just became leader, so any turn still marked running was
+        # owned by a process that is gone). Re-dispatches them so queued replies
+        # do not wedge forever on ⏳. One-shot; non-fatal so a sweep failure never
+        # blocks startup. Runs off the loop (sync DB work) via to_thread.
+        try:
+            from chat.api import reclaim_orphaned_agent_sessions
+
+            reclaimed = await asyncio.to_thread(reclaim_orphaned_agent_sessions)
+            if reclaimed:
+                logger.info("Reclaimed %d orphaned goosecracker turn(s)", reclaimed)
+        except Exception:
+            logger.exception("goosecracker: orphaned-turn reclaim sweep failed")
+
     # Supervised AISStream ingest (reconnects forever; CancelledError on stop).
     from ships.ingest import ais_stream_loop
 

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.244.0
+version: 0.245.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/migrations/20260702150000_goosecracker_queue_reactions.sql
+++ b/projects/monolith/chart/migrations/20260702150000_goosecracker_queue_reactions.sql
@@ -1,0 +1,29 @@
+-- Reaction lifecycle + self-heal for goosecracker agent threads.
+--
+-- goosecracker_sessions gains per-message queue tracking and in-flight turn
+-- bookkeeping so the runner can drive a ⏳→👀→✅/❌ reaction lifecycle on the
+-- user's own message (replacing the noisy "Queued" text replies) and so an
+-- orphaned turn (leader restart / stale wedge) can be reclaimed losslessly:
+--   pending_message_ids - newline-joined Discord message ids, parallel to pending
+--   inflight_task        - the running turn's task text, kept for lossless reclaim
+--   inflight_ack_ids     - message ids the running turn will resolve with reactions
+--   running_since        - when the turn went running (stale-timeout backstop)
+--   runner_instance      - boot token of the owning process (reset detector)
+--
+-- discord_outbox gains a reaction verb (target_message_id/reaction/reaction_remove)
+-- so the off-loop runner drives reactions through the same leader-safe drain.
+--
+-- All columns have defaults matching pre-migration behaviour, so existing rows
+-- are unaffected (idle artifact/agent sessions with no in-flight turn).
+
+ALTER TABLE chat.goosecracker_sessions
+    ADD COLUMN IF NOT EXISTS pending_message_ids TEXT        NOT NULL DEFAULT '',
+    ADD COLUMN IF NOT EXISTS inflight_task        TEXT        NOT NULL DEFAULT '',
+    ADD COLUMN IF NOT EXISTS inflight_ack_ids     TEXT        NOT NULL DEFAULT '',
+    ADD COLUMN IF NOT EXISTS running_since        TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS runner_instance      TEXT        NOT NULL DEFAULT '';
+
+ALTER TABLE chat.discord_outbox
+    ADD COLUMN IF NOT EXISTS target_message_id TEXT,
+    ADD COLUMN IF NOT EXISTS reaction          TEXT,
+    ADD COLUMN IF NOT EXISTS reaction_remove   BOOLEAN NOT NULL DEFAULT false;

--- a/projects/monolith/chart/migrations/atlas.sum
+++ b/projects/monolith/chart/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:iSJZPnbyom8At6/lziLaBZYIsx66mva70UeMemhokjk=
+h1:0KmTxcbfxfhL9gX6pqxtD3NcZ8Lghqj2QIa2fcKzHAU=
 20260330000000_initial_schema.sql h1:J2futpSW0nJAIRR7nR7ssT7LwXIYrvRI+PkHb5Y4tLI=
 20260403000000_chat_schema.sql h1:pERUFC0vzM95etRuzp43XzkCV7lBCzrrtY5Mk7aF3CA=
 20260404000000_chat_attachments.sql h1:tv+Fdbr1rQC5nzUxfaBC0O6fu2OMGgLWf+YNg1WQXi4=
@@ -81,3 +81,4 @@ h1:iSJZPnbyom8At6/lziLaBZYIsx66mva70UeMemhokjk=
 20260701180000_goosecracker_agent_conversational.sql h1:6fsVJhi04dK+81t0XEgRGtX7AUBsf18oOuxLMo0PkO0=
 20260702060000_discord_feature_grant.sql h1:Ky3Cr59rKGZu8GA/wrhNHPx9TF4vl7lLFNsooxQNFaI=
 20260702090000_goosecracker_artifact_id.sql h1:1Mt3pRLAdCXg+rCndDwEyb8UHS1dfxEgIxKErmqfk6Q=
+20260702150000_goosecracker_queue_reactions.sql h1:NddlTQmd8f6sPFQWuQnIOx7B8i3kWCvts6Rno7t+M5c=

--- a/projects/monolith/chat/api.py
+++ b/projects/monolith/chat/api.py
@@ -8,8 +8,11 @@ from __future__ import annotations
 
 from chat.bot import send_message  # re-exported
 from chat.changelog import run_changelog_for_config  # re-exported
+from chat.goosecracker import ack_inflight  # re-exported
 from chat.goosecracker import artifact_id_for_thread  # re-exported
 from chat.goosecracker import drain_agent_queue  # re-exported
+from chat.goosecracker import mark_inflight_running  # re-exported
+from chat.goosecracker import reclaim_orphaned_agent_sessions  # re-exported
 from chat.goosecracker_progress import (  # re-exported
     mark_done as mark_goosecracker_progress_done,
     set_notice as set_goosecracker_progress_notice,
@@ -18,8 +21,11 @@ from chat.outbox import enqueue_message  # re-exported
 from chat.summarizer import run_summary_generation  # re-exported
 
 __all__ = [
+    "ack_inflight",
     "artifact_id_for_thread",
     "drain_agent_queue",
+    "mark_inflight_running",
+    "reclaim_orphaned_agent_sessions",
     "enqueue_message",
     "mark_goosecracker_progress_done",
     "set_goosecracker_progress_notice",

--- a/projects/monolith/chat/api.py
+++ b/projects/monolith/chat/api.py
@@ -11,6 +11,7 @@ from chat.changelog import run_changelog_for_config  # re-exported
 from chat.goosecracker import ack_inflight  # re-exported
 from chat.goosecracker import artifact_id_for_thread  # re-exported
 from chat.goosecracker import drain_agent_queue  # re-exported
+from chat.goosecracker import force_idle_thread  # re-exported
 from chat.goosecracker import mark_inflight_running  # re-exported
 from chat.goosecracker import reclaim_orphaned_agent_sessions  # re-exported
 from chat.goosecracker_progress import (  # re-exported
@@ -24,6 +25,7 @@ __all__ = [
     "ack_inflight",
     "artifact_id_for_thread",
     "drain_agent_queue",
+    "force_idle_thread",
     "mark_inflight_running",
     "reclaim_orphaned_agent_sessions",
     "enqueue_message",

--- a/projects/monolith/chat/bot.py
+++ b/projects/monolith/chat/bot.py
@@ -764,7 +764,7 @@ class ChatBot(discord.Client):
 
         try:
             result = await asyncio.to_thread(
-                goosecracker.continue_session, thread_id, message.content
+                goosecracker.continue_session, thread_id, message.content, msg_id
             )
         except Exception:
             logger.exception("goosecracker: failed to continue session")
@@ -780,7 +780,13 @@ class ChatBot(discord.Client):
 
         if action == "queued":
             # A turn is already running; the reply was queued for the next turn.
-            await message.reply("Queued - I'll pick this up after the current turn.")
+            # Acknowledge with a ⏳ reaction on the user's own message instead of a
+            # text reply, so a burst of replies does not spam the thread. The
+            # runner flips it ⏳ → 👀 → ✅/❌ as the queued turn runs and finishes.
+            try:
+                await message.add_reaction(goosecracker.REACTION_QUEUED)
+            except discord.HTTPException:
+                logger.exception("goosecracker: failed to react queued on %s", msg_id)
             await asyncio.to_thread(self._complete_lock, msg_id)
             return True
 

--- a/projects/monolith/chat/goosecracker.py
+++ b/projects/monolith/chat/goosecracker.py
@@ -18,14 +18,36 @@ from __future__ import annotations
 import logging
 import os
 import secrets
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
-from sqlmodel import Session
+from sqlmodel import Session, select
 
 from app.db import get_engine
 from chat.models import GoosecrackerSession
 
 logger = logging.getLogger(__name__)
+
+# Reaction lifecycle emojis for queued agent replies. A reply queued behind a
+# running turn is acknowledged with QUEUED (no noisy text message); when its turn
+# starts it flips to RUNNING, and on completion to DONE (or FAILED). Driven by the
+# runner via the Discord outbox reaction verb (chat.outbox.enqueue_reaction).
+REACTION_QUEUED = "⏳"  # ⏳
+REACTION_RUNNING = "\U0001f440"  # 👀
+REACTION_DONE = "✅"  # ✅
+REACTION_FAILED = "❌"  # ❌
+
+# Per-process boot token. Every turn stamps the session's runner_instance with
+# this; a running session whose runner_instance differs from the live process's
+# token was owned by a process that has since died (in-process daemon threads do
+# not survive a restart), so it is safe to reclaim. Precise "it reset" signal
+# with no external pod-health probe: the owner identity is the liveness proof.
+INSTANCE_TOKEN = secrets.token_hex(8)
+
+# A running turn older than this is presumed dead (the owning process wedged or
+# died without the startup sweep catching it). Generous: well above the fc-invoke
+# run cap (~600s) plus retries, so a genuinely slow turn is never reclaimed out
+# from under itself. The startup sweep is the fast path; this is the backstop.
+STALE_AFTER = timedelta(minutes=30)
 
 # The artifact recipe + model tier (ADR 024). The tier selects Gemini via
 # OpenRouter (key swapped at egress) and bounds the secret placeholders the guest
@@ -79,6 +101,48 @@ def _append_pending(existing: str, msg: str) -> str:
     return f"{existing}\n{msg}"
 
 
+def _append_id(existing: str, msg_id: str) -> str:
+    """Append a Discord message id to a newline-joined id list."""
+    if not existing:
+        return msg_id
+    return f"{existing}\n{msg_id}"
+
+
+def _merge_ids(*id_lists: str) -> str:
+    """Merge newline-joined id lists, dropping blanks, preserving order."""
+    ids: list[str] = []
+    for chunk in id_lists:
+        ids.extend(i for i in chunk.split("\n") if i)
+    return "\n".join(ids)
+
+
+def _split_ids(joined: str) -> list[str]:
+    """Split a newline-joined id list into non-empty ids."""
+    return [i for i in joined.split("\n") if i]
+
+
+def _is_stale(row: GoosecrackerSession, now: datetime) -> bool:
+    """True when ``row`` is a running turn presumed dead (stale or foreign owner).
+
+    A row is reclaimable when it is running AND either owned by a different
+    process (the owner died: its in-process turn cannot exist here) or older than
+    STALE_AFTER (wedged without a restart). ``running_since`` naive from SQLite is
+    coerced to UTC so the comparison is offset-consistent in tests and prod.
+    """
+    if not row.running:
+        return False
+    if row.runner_instance and row.runner_instance != INSTANCE_TOKEN:
+        return True
+    since = row.running_since
+    if since is None:
+        # Running with no timestamp (legacy row / pre-migration): treat as stale
+        # so it can never wedge the thread forever.
+        return True
+    if since.tzinfo is None:
+        since = since.replace(tzinfo=timezone.utc)
+    return (now - since) > STALE_AFTER
+
+
 def start_session(thread_id: str, prompt: str) -> dict:
     """Record a new thread's transcript and dispatch the first artifact run.
 
@@ -108,7 +172,7 @@ def start_session(thread_id: str, prompt: str) -> dict:
     return result
 
 
-def continue_session(thread_id: str, message: str) -> dict | None:
+def continue_session(thread_id: str, message: str, message_id: str = "") -> dict | None:
     """Append an owner follow-up and re-dispatch or queue depending on recipe.
 
     Artifact sessions (recipe="artifact"): re-dispatch the full transcript (Model
@@ -116,10 +180,12 @@ def continue_session(thread_id: str, message: str) -> dict | None:
     submit result dict.
 
     Agent sessions (recipe="agent"): conversational queuing. If a turn is already
-    running, append the message to ``pending`` and return ``{"action": "queued"}``
-    so the bot can acknowledge without starting a new run. When idle, build the
-    next task from any backlog + this message, set running=True, dispatch, and
-    return ``{"action": "dispatched", ...submit result}``.
+    running (and not stale), append the message to ``pending`` + its id to
+    ``pending_message_ids`` and return ``{"action": "queued"}`` so the bot can
+    acknowledge with a ⏳ reaction instead of a text reply. When idle (or the prior
+    turn is stale and reclaimed), build the next task from any backlog + this
+    message, set running=True, dispatch, and return
+    ``{"action": "dispatched", ...submit result}``.
 
     Returns None when ``thread_id`` is not a goosecracker thread so the caller
     can fall through to normal chat handling. Synchronous; call via
@@ -135,30 +201,61 @@ def continue_session(thread_id: str, message: str) -> dict | None:
     _transcript = ""
 
     with Session(get_engine()) as session:
-        row = session.get(GoosecrackerSession, thread_id)
+        # Lock the row for the whole read-modify-write so a concurrent
+        # drain_agent_queue (runner thread) cannot clobber pending/running with a
+        # stale read. No-op on SQLite (tests), real SELECT FOR UPDATE on Postgres.
+        row = session.get(GoosecrackerSession, thread_id, with_for_update=True)
         if row is None:
             return None
 
         # Accumulate the turn in the curated transcript for all recipe types.
         transcript = _join_transcript(row.transcript, message)
         row.transcript = transcript
-        row.updated_at = datetime.now(timezone.utc)
+        now = datetime.now(timezone.utc)
+        row.updated_at = now
 
         if row.recipe == AGENT_RECIPE:
             _is_agent = True
-            if row.running:
-                # A turn is already in flight: queue this reply for the next turn.
+            if row.running and not _is_stale(row, now):
+                # A live turn is in flight: queue this reply for the next turn and
+                # record its id so the runner can react ⏳→👀→✅ on this message.
                 row.pending = _append_pending(row.pending, message)
+                row.pending_message_ids = _append_id(
+                    row.pending_message_ids, message_id
+                )
                 session.add(row)
                 session.commit()
                 return {"action": "queued"}
-            # Idle: consume any backlog plus the new message as a single task.
-            _task = _append_pending(row.pending, message)
+            if row.running:
+                # Stale/foreign-owned turn: the owner died or wedged. Reclaim its
+                # in-flight work by folding it back into this dispatch so nothing
+                # is lost (the startup sweep is the fast path; this is the inline
+                # backstop when the process lived but the turn died silently).
+                logger.warning(
+                    "goosecracker: reclaiming stale turn for thread %s "
+                    "(owner=%s, since=%s)",
+                    thread_id,
+                    row.runner_instance or "?",
+                    row.running_since,
+                )
+            # Idle (or reclaimed): consume the dead turn's task (if any), the
+            # backlog, and this message as a single task. Backlog + reclaimed
+            # message ids become this turn's ack set (they show the reaction
+            # lifecycle); the triggering message rides the live progress reply.
+            _task = _append_pending(
+                _append_pending(row.inflight_task, row.pending), message
+            )
+            ack_ids = _merge_ids(row.inflight_ack_ids, row.pending_message_ids)
             _stored_recipe = row.recipe
             _stored_tier = row.tier
             _stored_repo = row.repo
             row.pending = ""
+            row.pending_message_ids = ""
+            row.inflight_task = _task
+            row.inflight_ack_ids = ack_ids
             row.running = True
+            row.running_since = now
+            row.runner_instance = INSTANCE_TOKEN
             session.add(row)
             session.commit()
         else:
@@ -207,32 +304,189 @@ def continue_session(thread_id: str, message: str) -> dict | None:
     )
 
 
-def drain_agent_queue(thread_id: str) -> str | None:
+def drain_agent_queue(thread_id: str) -> tuple[str, list[str]] | None:
     """Drain a conversational agent thread's queue after a turn finishes.
 
     Called by the goosecracker runner (via ``chat.api``) when an agent turn
     completes. If replies were queued while the turn was running (``pending``
-    non-empty), return them as the next task, clear ``pending``, and keep
-    ``running=True`` so the caller dispatches the next turn. Otherwise set
-    ``running=False`` so the thread accepts new replies again. Sync; the caller
-    invokes it via ``asyncio.to_thread``. Lives here (not in the goosecracker
-    package) so the runner reaches it through ``chat.api`` and never imports
-    ``chat`` internals directly (import_boundaries_test).
+    non-empty), return ``(task, message_ids)`` as the next turn, promote them to
+    the in-flight slot (``inflight_task``/``inflight_ack_ids``), re-own the turn
+    under this process, and keep ``running=True`` so the caller dispatches the
+    next turn. Otherwise fully idle the row (``running=False``, in-flight cleared)
+    so the thread accepts new replies again, and return None.
+
+    The row is locked FOR UPDATE for the whole read-modify-write so a message
+    arriving concurrently in ``continue_session`` cannot clobber the drain (or be
+    clobbered by it). Sync; the caller invokes it via ``asyncio.to_thread``. Lives
+    here (not in the goosecracker package) so the runner reaches it through
+    ``chat.api`` and never imports ``chat`` internals directly
+    (import_boundaries_test).
     """
     with Session(get_engine()) as session:
-        row = session.get(GoosecrackerSession, thread_id)
+        row = session.get(GoosecrackerSession, thread_id, with_for_update=True)
         if row is None:
             return None
         if row.pending:
             task = row.pending
+            ack_ids = _split_ids(row.pending_message_ids)
+            # Promote the drained batch into the in-flight slot so a reclaim can
+            # rebuild it and the runner's mark/ack reaction calls resolve it.
+            row.inflight_task = task
+            row.inflight_ack_ids = "\n".join(ack_ids)
             row.pending = ""
+            row.pending_message_ids = ""
+            row.running_since = datetime.now(timezone.utc)
+            row.runner_instance = INSTANCE_TOKEN
             session.add(row)
             session.commit()
-            return task
+            return task, ack_ids
         row.running = False
+        row.running_since = None
+        row.inflight_task = ""
+        row.inflight_ack_ids = ""
         session.add(row)
         session.commit()
         return None
+
+
+def _inflight_ack_ids(thread_id: str) -> list[str]:
+    """Read the currently-running turn's ack message ids for ``thread_id``."""
+    with Session(get_engine()) as session:
+        row = session.get(GoosecrackerSession, thread_id)
+        if row is None:
+            return []
+        return _split_ids(row.inflight_ack_ids)
+
+
+def mark_inflight_running(thread_id: str) -> None:
+    """Flip the running turn's queued messages ⏳ → 👀 (turn has started).
+
+    Called by the runner at the start of each agent turn. Enqueues outbox reaction
+    ops (leader-safe) rather than touching Discord directly, so it works from the
+    runner's off-loop thread. A no-op when the turn has no queued acks (e.g. the
+    first turn of a session, whose triggering message rides the live progress
+    reply instead of a reaction). Sync; call via ``asyncio.to_thread``.
+    """
+    ids = _inflight_ack_ids(thread_id)
+    if not ids:
+        return
+    from chat.outbox import enqueue_reaction
+
+    with Session(get_engine()) as session:
+        for msg_id in ids:
+            enqueue_reaction(session, thread_id, msg_id, REACTION_QUEUED, remove=True)
+            enqueue_reaction(session, thread_id, msg_id, REACTION_RUNNING)
+        session.commit()
+
+
+def ack_inflight(thread_id: str, success: bool) -> None:
+    """Resolve the running turn's queued messages 👀 → ✅ (or ❌), and clear the
+    in-flight slot.
+
+    Called by the runner when an agent turn finishes (before it drains the next
+    batch). Removes the transient ⏳/👀 markers and adds the terminal reaction on
+    each acked message, then clears ``inflight_task``/``inflight_ack_ids`` (that
+    batch is done; the next drain repopulates them). Sync; call via
+    ``asyncio.to_thread``.
+    """
+    from chat.outbox import enqueue_reaction
+
+    terminal = REACTION_DONE if success else REACTION_FAILED
+    with Session(get_engine()) as session:
+        row = session.get(GoosecrackerSession, thread_id, with_for_update=True)
+        if row is None:
+            return
+        for msg_id in _split_ids(row.inflight_ack_ids):
+            enqueue_reaction(session, thread_id, msg_id, REACTION_QUEUED, remove=True)
+            enqueue_reaction(session, thread_id, msg_id, REACTION_RUNNING, remove=True)
+            enqueue_reaction(session, thread_id, msg_id, terminal)
+        row.inflight_task = ""
+        row.inflight_ack_ids = ""
+        session.add(row)
+        session.commit()
+
+
+def reclaim_orphaned_agent_sessions() -> int:
+    """Re-dispatch agent turns orphaned by a dead owner (leader restart / crash).
+
+    Every running turn stamps its session with this process's ``INSTANCE_TOKEN``.
+    A running agent session whose token differs was owned by a process that no
+    longer exists (in-process daemon threads do not survive a restart), so its
+    turn is dead and must be reclaimed or the thread wedges forever with queued
+    replies stuck on ⏳. Rebuilds the next task losslessly from ``inflight_task``
+    + ``pending``, re-owns it under this process, and re-dispatches (durably, on
+    the leader's long-lived loop). Returns the number reclaimed.
+
+    Invoked once from ``_start_singletons`` on leader acquisition. Sync; call via
+    ``asyncio.to_thread``.
+    """
+    now = datetime.now(timezone.utc)
+    with Session(get_engine()) as session:
+        candidates = session.exec(
+            select(GoosecrackerSession.discord_thread)
+            .where(GoosecrackerSession.running == True)  # noqa: E712 - SQL boolean
+            .where(GoosecrackerSession.recipe == AGENT_RECIPE)
+            .where(GoosecrackerSession.runner_instance != INSTANCE_TOKEN)
+        ).all()
+
+    reclaimed = 0
+    for thread_id in candidates:
+        dispatch = _reclaim_one(thread_id, now)
+        if dispatch is None:
+            continue
+        task, recipe, tier, repo = dispatch
+        from goosecracker.api import submit
+
+        submit(
+            task,
+            session=thread_id,
+            recipe=recipe,
+            tier=tier,
+            repo=repo,
+            discord_thread=thread_id,
+        )
+        reclaimed += 1
+    if reclaimed:
+        logger.warning(
+            "goosecracker: reclaimed %d orphaned agent turn(s) on startup", reclaimed
+        )
+    return reclaimed
+
+
+def _reclaim_one(thread_id: str, now: datetime) -> tuple[str, str, str, str] | None:
+    """Re-own one orphaned session and return its dispatch params, or None.
+
+    Locks the row, re-checks it is still a foreign-owned running turn (another
+    replica may have raced), rebuilds the task from inflight + pending, and stamps
+    it under this process. Returns None (and idles the row) when there is nothing
+    to run, so the sweep never dispatches an empty turn."""
+    with Session(get_engine()) as session:
+        row = session.get(GoosecrackerSession, thread_id, with_for_update=True)
+        if row is None or not row.running or row.recipe != AGENT_RECIPE:
+            return None
+        if row.runner_instance == INSTANCE_TOKEN:
+            return None  # this process already owns it; still alive
+        task = _append_pending(row.inflight_task, row.pending)
+        ack_ids = _merge_ids(row.inflight_ack_ids, row.pending_message_ids)
+        recipe, tier, repo = row.recipe, row.tier, row.repo
+        row.pending = ""
+        row.pending_message_ids = ""
+        if not task:
+            # Nothing recoverable to run: idle the thread so new replies flow.
+            row.running = False
+            row.running_since = None
+            row.inflight_task = ""
+            row.inflight_ack_ids = ""
+            session.add(row)
+            session.commit()
+            return None
+        row.inflight_task = task
+        row.inflight_ack_ids = ack_ids
+        row.running_since = now
+        row.runner_instance = INSTANCE_TOKEN
+        session.add(row)
+        session.commit()
+        return task, recipe, tier, repo
 
 
 def start_agent_session(thread_id: str, repo: str, prompt: str) -> dict:
@@ -269,6 +523,11 @@ def start_agent_session(thread_id: str, repo: str, prompt: str) -> dict:
                 repo=repo,
                 transcript=prompt,
                 running=True,
+                # Stamp the in-flight turn so a reply arriving during it queues
+                # (not "stale"), and a reclaim can rebuild it losslessly.
+                inflight_task=prompt,
+                running_since=datetime.now(timezone.utc),
+                runner_instance=INSTANCE_TOKEN,
             )
         )
         session.commit()

--- a/projects/monolith/chat/goosecracker.py
+++ b/projects/monolith/chat/goosecracker.py
@@ -242,9 +242,9 @@ def continue_session(thread_id: str, message: str, message_id: str = "") -> dict
             # backlog, and this message as a single task. Backlog + reclaimed
             # message ids become this turn's ack set (they show the reaction
             # lifecycle); the triggering message rides the live progress reply.
-            _task = _append_pending(
-                _append_pending(row.inflight_task, row.pending), message
-            )
+            # Join non-empty parts only: an empty pending/inflight must not inject
+            # a blank line into the task.
+            _task = "\n".join(p for p in (row.inflight_task, row.pending, message) if p)
             ack_ids = _merge_ids(row.inflight_ack_ids, row.pending_message_ids)
             _stored_recipe = row.recipe
             _stored_tier = row.tier
@@ -507,7 +507,7 @@ def _reclaim_one(thread_id: str, now: datetime) -> tuple[str, str, str, str] | N
             return None
         if row.runner_instance == INSTANCE_TOKEN:
             return None  # this process already owns it; still alive
-        task = _append_pending(row.inflight_task, row.pending)
+        task = "\n".join(p for p in (row.inflight_task, row.pending) if p)
         ack_ids = _merge_ids(row.inflight_ack_ids, row.pending_message_ids)
         recipe, tier, repo = row.recipe, row.tier, row.repo
         row.pending = ""

--- a/projects/monolith/chat/goosecracker.py
+++ b/projects/monolith/chat/goosecracker.py
@@ -326,6 +326,18 @@ def drain_agent_queue(thread_id: str) -> tuple[str, list[str]] | None:
         row = session.get(GoosecrackerSession, thread_id, with_for_update=True)
         if row is None:
             return None
+        if row.runner_instance != INSTANCE_TOKEN:
+            # Another process re-owned this turn (a reclaim after this replica lost
+            # leadership without exiting): stop this now-demoted chain and let the
+            # new owner drive the queue. Do NOT idle the row - the new owner is
+            # running it. Returning None ends the caller's loop.
+            logger.info(
+                "goosecracker: drain aborted for %s; turn re-owned by another "
+                "process (%s)",
+                thread_id,
+                row.runner_instance or "?",
+            )
+            return None
         if row.pending:
             task = row.pending
             ack_ids = _split_ids(row.pending_message_ids)
@@ -349,12 +361,17 @@ def drain_agent_queue(thread_id: str) -> tuple[str, list[str]] | None:
         return None
 
 
-def _inflight_ack_ids(thread_id: str) -> list[str]:
-    """Read the currently-running turn's ack message ids for ``thread_id``."""
+def _owned_inflight_ack_ids(thread_id: str) -> list[str] | None:
+    """This process's in-flight ack ids for ``thread_id``, or None if not owner.
+
+    Returns None when the row is missing or has been re-owned by another process
+    (leadership handed over), so callers can skip acting on a turn they no longer
+    own. Returns [] when owned but nothing is queued.
+    """
     with Session(get_engine()) as session:
         row = session.get(GoosecrackerSession, thread_id)
-        if row is None:
-            return []
+        if row is None or row.runner_instance != INSTANCE_TOKEN:
+            return None
         return _split_ids(row.inflight_ack_ids)
 
 
@@ -365,9 +382,10 @@ def mark_inflight_running(thread_id: str) -> None:
     ops (leader-safe) rather than touching Discord directly, so it works from the
     runner's off-loop thread. A no-op when the turn has no queued acks (e.g. the
     first turn of a session, whose triggering message rides the live progress
-    reply instead of a reaction). Sync; call via ``asyncio.to_thread``.
+    reply instead of a reaction) or when this process no longer owns the turn.
+    Sync; call via ``asyncio.to_thread``.
     """
-    ids = _inflight_ack_ids(thread_id)
+    ids = _owned_inflight_ack_ids(thread_id)
     if not ids:
         return
     from chat.outbox import enqueue_reaction
@@ -376,6 +394,27 @@ def mark_inflight_running(thread_id: str) -> None:
         for msg_id in ids:
             enqueue_reaction(session, thread_id, msg_id, REACTION_QUEUED, remove=True)
             enqueue_reaction(session, thread_id, msg_id, REACTION_RUNNING)
+        session.commit()
+
+
+def force_idle_thread(thread_id: str) -> None:
+    """Best-effort reset a thread to idle after a bookkeeping failure (self-heal).
+
+    Called by the runner when the post-turn queue bookkeeping raised, so the
+    thread does not wedge on ``running=True`` for the full stale timeout. CAS on
+    ownership: only idles the row if this process still owns it, so it never
+    clobbers a turn another process has already re-owned. Sync; call via
+    ``asyncio.to_thread``.
+    """
+    with Session(get_engine()) as session:
+        row = session.get(GoosecrackerSession, thread_id, with_for_update=True)
+        if row is None or row.runner_instance != INSTANCE_TOKEN:
+            return
+        row.running = False
+        row.running_since = None
+        row.inflight_task = ""
+        row.inflight_ack_ids = ""
+        session.add(row)
         session.commit()
 
 
@@ -394,7 +433,9 @@ def ack_inflight(thread_id: str, success: bool) -> None:
     terminal = REACTION_DONE if success else REACTION_FAILED
     with Session(get_engine()) as session:
         row = session.get(GoosecrackerSession, thread_id, with_for_update=True)
-        if row is None:
+        if row is None or row.runner_instance != INSTANCE_TOKEN:
+            # Not our turn anymore (re-owned after a leadership handover): the new
+            # owner will resolve these reactions. Skip rather than double-post.
             return
         for msg_id in _split_ids(row.inflight_ack_ids):
             enqueue_reaction(session, thread_id, msg_id, REACTION_QUEUED, remove=True)

--- a/projects/monolith/chat/goosecracker_test.py
+++ b/projects/monolith/chat/goosecracker_test.py
@@ -4,6 +4,7 @@ with the chat schema stripped. goosecracker.api is injected as a fake module so
 the test does not pull the real executor (and so no run is dispatched)."""
 
 import sys
+from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -11,7 +12,11 @@ from sqlmodel import Session, SQLModel, create_engine
 from sqlmodel.pool import StaticPool
 
 from chat import goosecracker
-from chat.models import GoosecrackerSession
+from chat.models import DiscordOutbox, GoosecrackerSession
+
+# Sentinel so _make_agent_session can distinguish "caller passed None" from
+# "caller passed nothing" for the running_since / runner_instance overrides.
+_UNSET = object()
 
 
 # ---------------------------------------------------------------------------
@@ -215,6 +220,12 @@ def test_start_agent_session_writes_session_row(engine, fake_api):
     assert row.transcript == "fix the bug"
     assert row.running
     assert row.pending == ""
+    # The first turn is stamped live (owned by this process, timestamped) so a
+    # reply arriving during it queues rather than being reclaimed as "stale".
+    assert row.runner_instance == goosecracker.INSTANCE_TOKEN
+    assert row.running_since is not None
+    assert row.inflight_task == "fix the bug"
+    assert not goosecracker._is_stale(row, datetime.now(timezone.utc))
 
 
 # ---------------------------------------------------------------------------
@@ -228,8 +239,24 @@ def _make_agent_session(
     repo: str = "homelab",
     running: bool = False,
     pending: str = "",
+    pending_message_ids: str = "",
+    inflight_task: str = "",
+    inflight_ack_ids: str = "",
+    running_since: object = _UNSET,
+    runner_instance: object = _UNSET,
 ) -> None:
-    """Insert a GoosecrackerSession row for an agent thread directly."""
+    """Insert a GoosecrackerSession row for an agent thread directly.
+
+    A running session defaults to a *live* turn (running_since=now, owned by this
+    process) so the queue tests exercise the queue path rather than the stale
+    reclaim path. Pass ``running_since=None`` / a foreign ``runner_instance`` to
+    simulate an orphaned/stale turn.
+    """
+    now = datetime.now(timezone.utc)
+    if running_since is _UNSET:
+        running_since = now if running else None
+    if runner_instance is _UNSET:
+        runner_instance = goosecracker.INSTANCE_TOKEN if running else ""
     with Session(engine) as session:
         session.add(
             GoosecrackerSession(
@@ -240,6 +267,11 @@ def _make_agent_session(
                 transcript="initial task",
                 running=running,
                 pending=pending,
+                pending_message_ids=pending_message_ids,
+                inflight_task=inflight_task,
+                inflight_ack_ids=inflight_ack_ids,
+                running_since=running_since,
+                runner_instance=runner_instance,
             )
         )
         session.commit()
@@ -273,7 +305,9 @@ def test_continue_agent_session_queues_when_running(engine, fake_api):
     returns action='queued' without dispatching."""
     with patch("chat.goosecracker.get_engine", return_value=engine):
         _make_agent_session(engine, "agent-t2", running=True)
-        result = goosecracker.continue_session("agent-t2", "extra instruction")
+        result = goosecracker.continue_session(
+            "agent-t2", "extra instruction", "msg-99"
+        )
 
     assert result == {"action": "queued"}
     fake_api.submit.assert_not_called()
@@ -282,6 +316,8 @@ def test_continue_agent_session_queues_when_running(engine, fake_api):
         row = session.get(GoosecrackerSession, "agent-t2")
     assert row.running
     assert row.pending == "extra instruction"
+    # The queued message's id is recorded so the runner can react on it.
+    assert row.pending_message_ids == "msg-99"
 
 
 def test_continue_agent_session_queues_multiple_appends_to_pending(engine, fake_api):
@@ -341,21 +377,32 @@ def test_continue_session_falls_back_to_cold_on_head_session_error(
 
 
 def test_drain_agent_queue_returns_task_and_clears_pending(engine):
-    """When pending is non-empty, drain returns the queued task, clears pending,
-    and keeps running=True so the runner dispatches the next turn."""
-    _make_agent_session(engine, "d-t1", running=True, pending="do something extra")
+    """When pending is non-empty, drain returns (task, ack_ids), clears pending,
+    promotes the batch into the in-flight slot, and keeps running=True so the
+    runner dispatches the next turn."""
+    _make_agent_session(
+        engine,
+        "d-t1",
+        running=True,
+        pending="do something extra",
+        pending_message_ids="m1\nm2",
+    )
     with patch("chat.goosecracker.get_engine", return_value=engine):
-        task = goosecracker.drain_agent_queue("d-t1")
+        drained = goosecracker.drain_agent_queue("d-t1")
 
-    assert task == "do something extra"
+    assert drained == ("do something extra", ["m1", "m2"])
     with Session(engine) as session:
         row = session.get(GoosecrackerSession, "d-t1")
     assert row.pending == ""
+    assert row.pending_message_ids == ""
+    assert row.inflight_task == "do something extra"
+    assert row.inflight_ack_ids == "m1\nm2"
+    assert row.runner_instance == goosecracker.INSTANCE_TOKEN
     assert row.running  # runner handles dispatching the next turn
 
 
 def test_drain_agent_queue_clears_running_when_empty(engine):
-    """When pending is empty, drain returns None and sets running=False so the
+    """When pending is empty, drain returns None and fully idles the row so the
     thread accepts new replies again."""
     _make_agent_session(engine, "d-t2", running=True, pending="")
     with patch("chat.goosecracker.get_engine", return_value=engine):
@@ -365,12 +412,170 @@ def test_drain_agent_queue_clears_running_when_empty(engine):
     with Session(engine) as session:
         row = session.get(GoosecrackerSession, "d-t2")
     assert not row.running
+    assert row.running_since is None
+    assert row.inflight_task == ""
 
 
 def test_drain_agent_queue_returns_none_for_unknown_thread(engine):
     """No session row for the thread: drain returns None gracefully."""
     with patch("chat.goosecracker.get_engine", return_value=engine):
         assert goosecracker.drain_agent_queue("no-such-thread") is None
+
+
+# ---------------------------------------------------------------------------
+# Self-heal: stale / orphaned running turns
+# ---------------------------------------------------------------------------
+
+
+def test_continue_agent_session_reclaims_stale_running_turn(engine, fake_api):
+    """A running turn owned by a dead process (foreign runner_instance) is not
+    treated as live: the new reply reclaims it, folding the dead turn's inflight
+    task + this message into a fresh dispatch so nothing is lost."""
+    _make_agent_session(
+        engine,
+        "stale-t1",
+        running=True,
+        runner_instance="dead-process",
+        inflight_task="prev work",
+        inflight_ack_ids="m1",
+    )
+    with patch("chat.goosecracker.get_engine", return_value=engine):
+        result = goosecracker.continue_session("stale-t1", "resume please", "m2")
+
+    assert result.get("action") == "dispatched"
+    call = fake_api.submit.call_args
+    assert call.args[0] == "prev work\nresume please"  # dead task folded in
+    with Session(engine) as session:
+        row = session.get(GoosecrackerSession, "stale-t1")
+    assert row.runner_instance == goosecracker.INSTANCE_TOKEN  # re-owned
+    assert row.inflight_ack_ids == "m1"  # prior queued msg still tracked
+    assert row.running
+
+
+def test_continue_agent_session_stale_by_timeout_is_reclaimed(engine, fake_api):
+    """A running turn older than STALE_AFTER with no live owner is reclaimed even
+    when the runner_instance matches (process lived but the turn died silently)."""
+    old = datetime.now(timezone.utc) - goosecracker.STALE_AFTER - timedelta(minutes=1)
+    _make_agent_session(
+        engine,
+        "stale-t2",
+        running=True,
+        runner_instance=goosecracker.INSTANCE_TOKEN,
+        running_since=old,
+    )
+    with patch("chat.goosecracker.get_engine", return_value=engine):
+        result = goosecracker.continue_session("stale-t2", "still there?", "m3")
+
+    assert result.get("action") == "dispatched"
+    fake_api.submit.assert_called_once()
+
+
+def test_mark_inflight_running_enqueues_running_reactions(engine):
+    """mark_inflight_running flips each in-flight message ⏳→👀 via outbox rows."""
+    _make_agent_session(engine, "r-t1", running=True, inflight_ack_ids="m1\nm2")
+    with patch("chat.goosecracker.get_engine", return_value=engine):
+        goosecracker.mark_inflight_running("r-t1")
+
+    with Session(engine) as session:
+        rows = session.query(DiscordOutbox).order_by(DiscordOutbox.id).all()
+    # Two messages x (remove ⏳, add 👀) = 4 reaction rows, all on the thread.
+    assert len(rows) == 4
+    assert {r.target_message_id for r in rows} == {"m1", "m2"}
+    assert all(r.channel_id == "r-t1" for r in rows)
+    removes = [r for r in rows if r.reaction_remove]
+    adds = [r for r in rows if not r.reaction_remove]
+    assert all(r.reaction == goosecracker.REACTION_QUEUED for r in removes)
+    assert all(r.reaction == goosecracker.REACTION_RUNNING for r in adds)
+
+
+def test_mark_inflight_running_noop_without_acks(engine):
+    """No queued messages -> no reaction rows (first turn rides progress reply)."""
+    _make_agent_session(engine, "r-t2", running=True, inflight_ack_ids="")
+    with patch("chat.goosecracker.get_engine", return_value=engine):
+        goosecracker.mark_inflight_running("r-t2")
+    with Session(engine) as session:
+        assert session.query(DiscordOutbox).count() == 0
+
+
+def test_ack_inflight_success_adds_done_and_clears(engine):
+    """On success, ack_inflight adds ✅ (and removes transient markers) per acked
+    message, then clears the in-flight slot."""
+    _make_agent_session(
+        engine, "a-t1", running=True, inflight_task="work", inflight_ack_ids="m1"
+    )
+    with patch("chat.goosecracker.get_engine", return_value=engine):
+        goosecracker.ack_inflight("a-t1", True)
+
+    with Session(engine) as session:
+        rows = session.query(DiscordOutbox).all()
+        row = session.get(GoosecrackerSession, "a-t1")
+    added = [r for r in rows if not r.reaction_remove]
+    assert [r.reaction for r in added] == [goosecracker.REACTION_DONE]
+    assert row.inflight_task == ""
+    assert row.inflight_ack_ids == ""
+
+
+def test_ack_inflight_failure_adds_cross(engine):
+    """On failure, the terminal reaction is ❌."""
+    _make_agent_session(engine, "a-t2", running=True, inflight_ack_ids="m1")
+    with patch("chat.goosecracker.get_engine", return_value=engine):
+        goosecracker.ack_inflight("a-t2", False)
+    with Session(engine) as session:
+        added = [r for r in session.query(DiscordOutbox).all() if not r.reaction_remove]
+    assert [r.reaction for r in added] == [goosecracker.REACTION_FAILED]
+
+
+def test_reclaim_orphaned_agent_sessions_redispatches(engine, fake_api):
+    """A running agent session owned by a dead process is re-dispatched and
+    re-owned; a live one (this process's token) is left alone."""
+    _make_agent_session(
+        engine,
+        "orphan",
+        running=True,
+        runner_instance="dead-process",
+        inflight_task="half-done work",
+        inflight_ack_ids="m1",
+        pending="a queued follow-up",
+        pending_message_ids="m2",
+    )
+    _make_agent_session(
+        engine,
+        "live",
+        running=True,
+        runner_instance=goosecracker.INSTANCE_TOKEN,
+        inflight_task="in progress",
+    )
+    with patch("chat.goosecracker.get_engine", return_value=engine):
+        reclaimed = goosecracker.reclaim_orphaned_agent_sessions()
+
+    assert reclaimed == 1
+    call = fake_api.submit.call_args
+    # Dead turn's inflight + pending folded losslessly into the re-dispatch.
+    assert call.args[0] == "half-done work\na queued follow-up"
+    assert call.kwargs["discord_thread"] == "orphan"
+    with Session(engine) as session:
+        orphan = session.get(GoosecrackerSession, "orphan")
+        live = session.get(GoosecrackerSession, "live")
+    assert orphan.runner_instance == goosecracker.INSTANCE_TOKEN  # re-owned
+    assert orphan.inflight_ack_ids == "m1\nm2"
+    assert orphan.pending == ""
+    assert live.inflight_task == "in progress"  # untouched
+
+
+def test_reclaim_orphaned_idles_when_nothing_to_run(engine, fake_api):
+    """A foreign-owned running session with no recoverable task is idled, not
+    re-dispatched (never dispatches an empty turn)."""
+    _make_agent_session(
+        engine, "empty-orphan", running=True, runner_instance="dead-process"
+    )
+    with patch("chat.goosecracker.get_engine", return_value=engine):
+        reclaimed = goosecracker.reclaim_orphaned_agent_sessions()
+
+    assert reclaimed == 0
+    fake_api.submit.assert_not_called()
+    with Session(engine) as session:
+        row = session.get(GoosecrackerSession, "empty-orphan")
+    assert not row.running
 
 
 def test_artifact_id_is_random_stable_and_not_the_thread_id(engine):

--- a/projects/monolith/chat/goosecracker_test.py
+++ b/projects/monolith/chat/goosecracker_test.py
@@ -562,6 +562,60 @@ def test_reclaim_orphaned_agent_sessions_redispatches(engine, fake_api):
     assert live.inflight_task == "in progress"  # untouched
 
 
+def test_drain_agent_queue_aborts_when_reowned(engine):
+    """If the turn was re-owned by another process (leadership handover), drain
+    returns None WITHOUT touching pending/running - the new owner drives it."""
+    _make_agent_session(
+        engine,
+        "reowned",
+        running=True,
+        runner_instance="other-process",
+        pending="queued work",
+        pending_message_ids="m1",
+    )
+    with patch("chat.goosecracker.get_engine", return_value=engine):
+        assert goosecracker.drain_agent_queue("reowned") is None
+    with Session(engine) as session:
+        row = session.get(GoosecrackerSession, "reowned")
+    # Untouched: the new owner still has the queued work to run.
+    assert row.pending == "queued work"
+    assert row.running
+
+
+def test_ack_inflight_skips_when_reowned(engine):
+    """ack_inflight is a no-op when another process owns the turn (no double-post,
+    no clobber of the new owner's in-flight slot)."""
+    _make_agent_session(
+        engine,
+        "reowned-ack",
+        running=True,
+        runner_instance="other-process",
+        inflight_task="work",
+        inflight_ack_ids="m1",
+    )
+    with patch("chat.goosecracker.get_engine", return_value=engine):
+        goosecracker.ack_inflight("reowned-ack", True)
+    with Session(engine) as session:
+        assert session.query(DiscordOutbox).count() == 0
+        row = session.get(GoosecrackerSession, "reowned-ack")
+    assert row.inflight_ack_ids == "m1"  # left for the new owner
+
+
+def test_force_idle_thread_cas(engine):
+    """force_idle_thread idles a row this process owns, but leaves a re-owned row
+    alone (never clobbers a turn another process now runs)."""
+    _make_agent_session(
+        engine, "mine", running=True, runner_instance=goosecracker.INSTANCE_TOKEN
+    )
+    _make_agent_session(engine, "theirs", running=True, runner_instance="other-process")
+    with patch("chat.goosecracker.get_engine", return_value=engine):
+        goosecracker.force_idle_thread("mine")
+        goosecracker.force_idle_thread("theirs")
+    with Session(engine) as session:
+        assert not session.get(GoosecrackerSession, "mine").running
+        assert session.get(GoosecrackerSession, "theirs").running  # untouched
+
+
 def test_reclaim_orphaned_idles_when_nothing_to_run(engine, fake_api):
     """A foreign-owned running session with no recoverable task is idled, not
     re-dispatched (never dispatches an empty turn)."""

--- a/projects/monolith/chat/models.py
+++ b/projects/monolith/chat/models.py
@@ -112,12 +112,20 @@ class DiscordOutbox(SQLModel, table=True):
     content: str | None = Field(default=None)
     embed_json: str | None = Field(default=None)
     level: str = Field(default="info")
+    # Reaction verb: when reaction is set, this row is not a post but an add/remove
+    # of a unicode reaction on target_message_id in channel_id (reaction_remove
+    # picks which). Lets an off-loop producer (the goose runner) drive the ⏳/👀/✅
+    # lifecycle on a user's message through the same leader-safe drain.
+    target_message_id: str | None = Field(default=None)
+    reaction: str | None = Field(default=None)
+    reaction_remove: bool = Field(default=False)
     created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     posted_at: datetime | None = Field(default=None)
     attempts: int = Field(default=0)
     last_error: str | None = Field(default=None)
 
 
+# nosemgrep: sqlmodel-datetime-without-factory (running_since is intentionally NULL until a turn goes running)
 class GoosecrackerSession(SQLModel, table=True):
     """Per-Discord-thread curated transcript for the goosecracker agent (ADR 024).
 
@@ -142,8 +150,22 @@ class GoosecrackerSession(SQLModel, table=True):
     # Conversational queue state (agent sessions only).
     # running: a turn is currently in flight.
     # pending: newline-joined replies queued while running=True; consumed on drain.
+    # pending_message_ids: newline-joined Discord message ids, one per queued reply
+    #   (parallel to pending), so the runner can react ⏳/👀/✅ on the exact messages.
     running: bool = Field(default=False)
     pending: str = Field(default="")
+    pending_message_ids: str = Field(default="")
+    # In-flight turn bookkeeping, for the reaction lifecycle and self-heal.
+    # inflight_task: the task text the currently-running turn is executing; kept so
+    #   a reclaim (startup sweep or stale-timeout) can rebuild the turn losslessly.
+    # inflight_ack_ids: Discord message ids the running turn will resolve (⏳→👀→✅).
+    # running_since: when the current turn went running (stale-timeout backstop).
+    # runner_instance: boot token of the process that owns the running turn; a
+    #   mismatch on startup means the owner died, so the turn is reclaimable.
+    inflight_task: str = Field(default="")
+    inflight_ack_ids: str = Field(default="")
+    running_since: datetime | None = Field(default=None)
+    runner_instance: str = Field(default="")
     # Unguessable capability id the artifact is published under (ADR 024 amend).
     # Random per thread, assigned on first publish and reused on re-publish so the
     # live page hot-reloads at a stable but non-discoverable URL (never the

--- a/projects/monolith/chat/outbox.py
+++ b/projects/monolith/chat/outbox.py
@@ -55,6 +55,30 @@ def enqueue_message(
     )
 
 
+def enqueue_reaction(
+    session: Session,
+    channel_id: str,
+    message_id: str,
+    emoji: str,
+    *,
+    remove: bool = False,
+) -> None:
+    """Enqueue an add/remove of ``emoji`` on ``message_id`` in ``channel_id``.
+
+    A reaction row carries no content/embed; the drain resolves the message and
+    adds (or removes) the bot's reaction. Used off-loop by the goose runner to
+    drive the ⏳→👀→✅/❌ lifecycle on a queued reply. Caller commits the session.
+    """
+    session.add(
+        DiscordOutbox(
+            channel_id=channel_id,
+            target_message_id=message_id,
+            reaction=emoji,
+            reaction_remove=remove,
+        )
+    )
+
+
 def _claim_pending(engine) -> list[dict]:
     """Read the oldest unposted, not-exhausted rows. Returns plain dicts so the
     async drain never holds an ORM row across an await."""
@@ -63,7 +87,10 @@ def _claim_pending(engine) -> list[dict]:
             select(DiscordOutbox)
             .where(DiscordOutbox.posted_at.is_(None))
             .where(DiscordOutbox.attempts < _MAX_ATTEMPTS)
-            .order_by(DiscordOutbox.created_at)
+            # Order by (created_at, id) so a remove-then-add reaction pair enqueued
+            # together drains in insertion order (id breaks created_at ties), never
+            # leaving the stale emoji on top of the new one.
+            .order_by(DiscordOutbox.created_at, DiscordOutbox.id)
             .limit(_BATCH)
         ).all()
         return [
@@ -73,6 +100,9 @@ def _claim_pending(engine) -> list[dict]:
                 "content": r.content,
                 "embed_json": r.embed_json,
                 "level": r.level,
+                "target_message_id": r.target_message_id,
+                "reaction": r.reaction,
+                "reaction_remove": r.reaction_remove,
             }
             for r in rows
         ]
@@ -108,12 +138,34 @@ async def _post_row(bot, row: dict) -> None:
     channel = bot.get_channel(int(row["channel_id"]))
     if channel is None:
         channel = await bot.fetch_channel(int(row["channel_id"]))
-    if row["embed_json"] is not None:
+    if row.get("reaction") is not None:
+        await _apply_reaction(bot, channel, row)
+    elif row["embed_json"] is not None:
         embed = discord.Embed.from_dict(json.loads(row["embed_json"]))
         await channel.send(embed=embed)
     else:
         prefix = _LEVEL_PREFIX.get(row["level"], "")
         await channel.send(f"{prefix}{row['content']}")
+
+
+async def _apply_reaction(bot, channel, row: dict) -> None:
+    """Add or remove the bot's reaction on a target message.
+
+    A removal of an absent reaction (or a message that lost it) is not an error:
+    the lifecycle is idempotent, so a missing prior emoji is swallowed rather than
+    burning the row's retry budget. A missing *message* likewise resolves the row
+    (nothing to react to). An add failure propagates so the drain retries it."""
+    import discord
+
+    message = await channel.fetch_message(int(row["target_message_id"]))
+    emoji = row["reaction"]
+    if row["reaction_remove"]:
+        try:
+            await message.remove_reaction(emoji, bot.user)
+        except (discord.NotFound, discord.HTTPException) as exc:
+            logger.debug("outbox: reaction remove no-op (%s): %s", emoji, exc)
+    else:
+        await message.add_reaction(emoji)
 
 
 async def drain_once(bot, engine) -> int:

--- a/projects/monolith/chat/outbox.py
+++ b/projects/monolith/chat/outbox.py
@@ -157,7 +157,15 @@ async def _apply_reaction(bot, channel, row: dict) -> None:
     (nothing to react to). An add failure propagates so the drain retries it."""
     import discord
 
-    message = await channel.fetch_message(int(row["target_message_id"]))
+    try:
+        message = await channel.fetch_message(int(row["target_message_id"]))
+    except discord.NotFound:
+        # The target message was deleted: nothing to react to. Resolve the row
+        # rather than burn its retry budget re-fetching a message that is gone.
+        logger.debug(
+            "outbox: reaction target %s gone; skipping", row["target_message_id"]
+        )
+        return
     emoji = row["reaction"]
     if row["reaction_remove"]:
         try:

--- a/projects/monolith/chat/outbox_test.py
+++ b/projects/monolith/chat/outbox_test.py
@@ -2,10 +2,11 @@
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import discord
 import pytest
 
 import chat.outbox as outbox
-from chat.outbox import drain_once, enqueue_message
+from chat.outbox import drain_once, enqueue_message, enqueue_reaction
 
 
 def test_enqueue_text_adds_row():
@@ -85,6 +86,85 @@ async def test_drain_posts_embed():
 
     # Posted as an embed, not text.
     assert channel.send.await_args.kwargs.get("embed") is not None
+
+
+def test_enqueue_reaction_adds_row():
+    session = MagicMock()
+    enqueue_reaction(session, "C1", "M9", "⏳", remove=True)
+    row = session.add.call_args.args[0]
+    assert row.channel_id == "C1"
+    assert row.target_message_id == "M9"
+    assert row.reaction == "⏳"
+    assert row.reaction_remove is True
+    assert row.content is None and row.embed_json is None
+
+
+@pytest.mark.asyncio
+async def test_drain_adds_reaction():
+    row = {
+        "id": 4,
+        "channel_id": "100",
+        "content": None,
+        "embed_json": None,
+        "level": "info",
+        "target_message_id": "555",
+        "reaction": "\U0001f440",
+        "reaction_remove": False,
+    }
+    message = MagicMock()
+    message.add_reaction = AsyncMock()
+    message.remove_reaction = AsyncMock()
+    channel = MagicMock()
+    channel.fetch_message = AsyncMock(return_value=message)
+    bot = MagicMock()
+    bot.get_channel = MagicMock(return_value=channel)
+
+    with (
+        patch.object(outbox, "_claim_pending", return_value=[row]),
+        patch.object(outbox, "_mark_posted") as mark_posted,
+        patch.object(outbox, "_mark_failed") as mark_failed,
+    ):
+        await drain_once(bot, engine=object())
+
+    channel.fetch_message.assert_awaited_once_with(555)
+    message.add_reaction.assert_awaited_once_with("\U0001f440")
+    message.remove_reaction.assert_not_awaited()
+    mark_posted.assert_called_once()
+    mark_failed.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_drain_reaction_remove_swallows_missing():
+    """Removing an absent reaction resolves the row (idempotent), not a failure."""
+    row = {
+        "id": 5,
+        "channel_id": "100",
+        "content": None,
+        "embed_json": None,
+        "level": "info",
+        "target_message_id": "555",
+        "reaction": "⏳",
+        "reaction_remove": True,
+    }
+    message = MagicMock()
+    message.remove_reaction = AsyncMock(
+        side_effect=discord.HTTPException(MagicMock(), "no reaction")
+    )
+    channel = MagicMock()
+    channel.fetch_message = AsyncMock(return_value=message)
+    bot = MagicMock()
+    bot.get_channel = MagicMock(return_value=channel)
+
+    with (
+        patch.object(outbox, "_claim_pending", return_value=[row]),
+        patch.object(outbox, "_mark_posted") as mark_posted,
+        patch.object(outbox, "_mark_failed") as mark_failed,
+    ):
+        await drain_once(bot, engine=object())
+
+    # A missing prior reaction is swallowed: the row counts as posted.
+    mark_posted.assert_called_once()
+    mark_failed.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.244.0
+      targetRevision: 0.245.0
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/goosecracker/runner.py
+++ b/projects/monolith/goosecracker/runner.py
@@ -421,7 +421,7 @@ async def _post_agent_run(url: str, payload: dict, on_retry) -> dict:
         await asyncio.sleep(wait)
 
 
-async def run_and_deliver(
+async def _run_one_turn(
     session: str,
     *,
     task: str,
@@ -431,12 +431,15 @@ async def run_and_deliver(
     git_mirror: str,
     git_ref: str,
     discord_thread: str,
-) -> None:
-    """POST the goose run to fc-invoke, then mark + deliver the result.
+) -> bool:
+    """POST one goose turn to fc-invoke, then mark + deliver the result.
 
-    Always marks the progress stream done (in a ``finally``) so the bot's stream
-    loop ends whether the run succeeded, failed, or the daemon was unreachable.
+    Returns True when the run succeeded, False on any failure. Always marks the
+    progress stream done (in a ``finally``) so the bot's stream loop ends whether
+    the run succeeded, failed, or the daemon was unreachable. The conversational
+    drain/next-turn loop lives in ``run_and_deliver``, which calls this per turn.
     """
+    ok = False
     try:
         if not FC_INVOKE_URL:
             raise RuntimeError("FC_INVOKE_URL is not configured")
@@ -503,6 +506,7 @@ async def run_and_deliver(
             await _deliver(
                 discord_thread, await _delivery_message(session, recipe, data)
             )
+            ok = True
         else:
             err = data.get("error", "") or "goose run failed with no detail"
             # nosemgrep: no-session-in-to-thread  # `session` is the fc-invoke session-id string, not a SQLAlchemy Session
@@ -518,43 +522,80 @@ async def run_and_deliver(
         await _deliver(discord_thread, f"Run failed: {exc}")
     finally:
         _mark_progress_done(session)
+    return ok
 
-    # For agent runs fronting a Discord thread: drain any replies that arrived
-    # while this turn was running, then dispatch them as the next turn.
-    # This also clears running=False on the failed path so a crashed turn does
-    # not wedge the thread. Runs after finally: so the progress stream is already
-    # marked done before the next turn potentially starts.
-    if recipe == "agent" and discord_thread:
-        # The drain (DB work on chat.goosecracker_sessions) lives in the chat
-        # domain; reach it through chat.api so goosecracker never imports chat
-        # internals (import_boundaries_test).
-        from chat.api import drain_agent_queue
 
+async def run_and_deliver(
+    session: str,
+    *,
+    task: str,
+    recipe: str,
+    tier: str,
+    repo: str = "",
+    git_mirror: str,
+    git_ref: str,
+    discord_thread: str,
+) -> None:
+    """Run a conversational agent thread to completion, one turn at a time.
+
+    Runs the given turn, then for agent threads drains any replies that arrived
+    while it ran and runs them as the next turn, looping until the queue is empty.
+    Each turn is ``await``-ed in place (never ``create_task``-ed): ``submit``
+    dispatches the first turn on a throwaway daemon thread via ``asyncio.run``,
+    which tears its loop down the instant the coroutine returns, so a
+    ``create_task``-ed next turn would be cancelled before it ran (the "queued
+    reply never comes back" bug). Awaiting keeps the whole chain inside that one
+    live loop. Serial-by-design: one turn per thread at a time.
+
+    Reaction lifecycle: each turn flips its queued messages ⏳→👀 at the start
+    (``mark_inflight_running``) and 👀→✅/❌ at the end (``ack_inflight``), so a
+    queued reply shows honest state on the user's own message with no text spam.
+    """
+    is_agent_thread = recipe == "agent" and bool(discord_thread)
+    current_task = task
+    while True:
+        if is_agent_thread:
+            # The queue/reaction bookkeeping lives in the chat domain; reach it
+            # through chat.api so goosecracker never imports chat internals
+            # (import_boundaries_test).
+            from chat.api import mark_inflight_running
+
+            # nosemgrep: no-session-in-to-thread  # discord_thread is a str id, not a SQLAlchemy Session
+            await asyncio.to_thread(mark_inflight_running, discord_thread)
+
+        ok = await _run_one_turn(
+            session,
+            task=current_task,
+            recipe=recipe,
+            tier=tier,
+            repo=repo,
+            git_mirror=git_mirror,
+            git_ref=git_ref,
+            discord_thread=discord_thread,
+        )
+
+        if not is_agent_thread:
+            return
+
+        from chat.api import ack_inflight, drain_agent_queue
+
+        # Resolve this turn's queued messages (👀 → ✅/❌) before draining the next
+        # batch, so their reactions reflect this turn's outcome.
         # nosemgrep: no-session-in-to-thread  # discord_thread is a str id, not a SQLAlchemy Session
-        next_task = await asyncio.to_thread(drain_agent_queue, discord_thread)
-        if next_task is not None:
-            # Update the run ledger for the next task (mirrors dispatch.submit).
-            # nosemgrep: no-session-in-to-thread  # threads.upsert_run opens its own Session
-            await asyncio.to_thread(
-                threads.upsert_run,
-                session,
-                recipe=recipe,
-                tier=tier,
-                task=next_task,
-                discord_thread=discord_thread,
-            )
-            # Schedule the next turn as a detached task on the current event loop.
-            # No import of dispatch (circular: dispatch imports runner); use
-            # create_task directly since we are already inside an async context.
-            asyncio.create_task(
-                run_and_deliver(
-                    session,
-                    task=next_task,
-                    recipe=recipe,
-                    tier=tier,
-                    repo=repo,
-                    git_mirror=git_mirror,
-                    git_ref=git_ref,
-                    discord_thread=discord_thread,
-                )
-            )
+        await asyncio.to_thread(ack_inflight, discord_thread, ok)
+        # nosemgrep: no-session-in-to-thread  # discord_thread is a str id, not a SQLAlchemy Session
+        drained = await asyncio.to_thread(drain_agent_queue, discord_thread)
+        if drained is None:
+            return  # queue empty: drain_agent_queue set running=False, thread idle
+        next_task, _ack_ids = drained
+        # Update the run ledger for the next task (mirrors dispatch.submit).
+        # nosemgrep: no-session-in-to-thread  # threads.upsert_run opens its own Session
+        await asyncio.to_thread(
+            threads.upsert_run,
+            session,
+            recipe=recipe,
+            tier=tier,
+            task=next_task,
+            discord_thread=discord_thread,
+        )
+        current_task = next_task

--- a/projects/monolith/goosecracker/runner.py
+++ b/projects/monolith/goosecracker/runner.py
@@ -577,16 +577,31 @@ async def run_and_deliver(
         if not is_agent_thread:
             return
 
-        from chat.api import ack_inflight, drain_agent_queue
+        from chat.api import ack_inflight, drain_agent_queue, force_idle_thread
 
-        # Resolve this turn's queued messages (👀 → ✅/❌) before draining the next
-        # batch, so their reactions reflect this turn's outcome.
-        # nosemgrep: no-session-in-to-thread  # discord_thread is a str id, not a SQLAlchemy Session
-        await asyncio.to_thread(ack_inflight, discord_thread, ok)
-        # nosemgrep: no-session-in-to-thread  # discord_thread is a str id, not a SQLAlchemy Session
-        drained = await asyncio.to_thread(drain_agent_queue, discord_thread)
+        # Post-turn bookkeeping. Guard it: if a transient DB error escaped here the
+        # loop would die with running=True and the thread would wedge for the full
+        # stale timeout. On failure, best-effort idle the row (CAS on ownership) so
+        # the next reply can start a fresh turn, then stop this chain.
+        try:
+            # Resolve this turn's queued messages (👀 → ✅/❌) before draining the
+            # next batch, so their reactions reflect this turn's outcome.
+            # nosemgrep: no-session-in-to-thread  # discord_thread is a str id, not a SQLAlchemy Session
+            await asyncio.to_thread(ack_inflight, discord_thread, ok)
+            # nosemgrep: no-session-in-to-thread  # discord_thread is a str id, not a SQLAlchemy Session
+            drained = await asyncio.to_thread(drain_agent_queue, discord_thread)
+        except Exception:
+            logger.exception(
+                "goosecracker: post-turn bookkeeping failed for %s; idling thread",
+                discord_thread,
+            )
+            # nosemgrep: no-session-in-to-thread  # discord_thread is a str id, not a SQLAlchemy Session
+            await asyncio.to_thread(force_idle_thread, discord_thread)
+            return
         if drained is None:
-            return  # queue empty: drain_agent_queue set running=False, thread idle
+            # Queue empty (running=False set by drain) or this turn was re-owned by
+            # another process after a leadership handover: either way, stop.
+            return
         next_task, _ack_ids = drained
         # Update the run ledger for the next task (mirrors dispatch.submit).
         # nosemgrep: no-session-in-to-thread  # threads.upsert_run opens its own Session

--- a/projects/monolith/goosecracker/tests/runner_test.py
+++ b/projects/monolith/goosecracker/tests/runner_test.py
@@ -499,3 +499,34 @@ async def test_run_and_deliver_non_agent_runs_once(monkeypatch):
 
     assert turns == ["build it"]
     fake_api.drain_agent_queue.assert_not_called()
+
+
+async def test_run_and_deliver_idles_thread_on_bookkeeping_error(monkeypatch):
+    """If post-turn bookkeeping raises (a DB blip), the loop force-idles the
+    thread and stops instead of dying with running=True (which would wedge the
+    thread for the full stale timeout)."""
+    turns = []
+
+    async def fake_turn(session, **kwargs):
+        turns.append(kwargs["task"])
+        return True
+
+    monkeypatch.setattr(runner, "_run_one_turn", fake_turn)
+
+    fake_api = MagicMock()
+    fake_api.ack_inflight = MagicMock(side_effect=RuntimeError("db blip"))
+
+    with patch.dict(sys.modules, {"chat.api": fake_api}):
+        await runner.run_and_deliver(
+            "sess",
+            task="first turn",
+            recipe="agent",
+            tier="",
+            git_mirror="",
+            git_ref="",
+            discord_thread="T",
+        )
+
+    assert turns == ["first turn"]  # ran the turn, then stopped cleanly
+    fake_api.force_idle_thread.assert_called_once_with("T")
+    fake_api.drain_agent_queue.assert_not_called()

--- a/projects/monolith/goosecracker/tests/runner_test.py
+++ b/projects/monolith/goosecracker/tests/runner_test.py
@@ -8,6 +8,9 @@ the conversational-queue drain added for /agent thread continuations.
 
 from __future__ import annotations
 
+import sys
+from unittest.mock import MagicMock, patch
+
 import httpx
 import pytest
 
@@ -430,3 +433,69 @@ async def test_post_agent_run_gives_up_after_deadline(monkeypatch):
     assert fake.calls == 1
     assert sleeps == []
     assert retries == []
+
+
+# ---------------------------------------------------------------------------
+# run_and_deliver conversational loop (the orphan-free next-turn dispatch)
+# ---------------------------------------------------------------------------
+
+
+async def test_run_and_deliver_runs_drained_turn_in_loop(monkeypatch):
+    """The drained next turn runs inside the same run_and_deliver call (awaited),
+    not via a create_task that asyncio.run would cancel on teardown. Also drives
+    the reaction lifecycle: mark_inflight_running each turn, ack_inflight at each
+    turn's end."""
+    turns = []
+
+    async def fake_turn(session, **kwargs):
+        turns.append(kwargs["task"])
+        return True
+
+    monkeypatch.setattr(runner, "_run_one_turn", fake_turn)
+    monkeypatch.setattr(runner.threads, "upsert_run", MagicMock())
+
+    fake_api = MagicMock()
+    # One queued batch, then the queue is empty.
+    fake_api.drain_agent_queue = MagicMock(side_effect=[("second turn", ["m1"]), None])
+
+    with patch.dict(sys.modules, {"chat.api": fake_api}):
+        await runner.run_and_deliver(
+            "sess",
+            task="first turn",
+            recipe="agent",
+            tier="",
+            git_mirror="",
+            git_ref="",
+            discord_thread="T",
+        )
+
+    assert turns == ["first turn", "second turn"]  # both ran in one call
+    assert fake_api.mark_inflight_running.call_count == 2
+    fake_api.ack_inflight.assert_any_call("T", True)
+    assert fake_api.ack_inflight.call_count == 2
+
+
+async def test_run_and_deliver_non_agent_runs_once(monkeypatch):
+    """A non-agent (artifact) run does one turn and never touches the queue."""
+    turns = []
+
+    async def fake_turn(session, **kwargs):
+        turns.append(kwargs["task"])
+        return True
+
+    monkeypatch.setattr(runner, "_run_one_turn", fake_turn)
+    fake_api = MagicMock()
+
+    with patch.dict(sys.modules, {"chat.api": fake_api}):
+        await runner.run_and_deliver(
+            "sess",
+            task="build it",
+            recipe="artifact",
+            tier="artifact",
+            git_mirror="",
+            git_ref="",
+            discord_thread="T",
+        )
+
+    assert turns == ["build it"]
+    fake_api.drain_agent_queue.assert_not_called()


### PR DESCRIPTION
## Problem

In `/agent` Discord threads (Brosun / goosecracker, ADR 024), replies sent while a turn is running produced two bad behaviours (see Joe's screenshot):

1. **Noise** - every mid-turn reply got its own text reply `Queued - I'll pick this up after the current turn.`, spamming the thread.
2. **"Nothing came back"** - queued work silently vanished; the thread wedged and every later reply queued forever.

## Root cause of the drop

The drained next turn was scheduled with a bare `asyncio.create_task` inside `run_and_deliver`. The first turn runs on a throwaway daemon thread via `asyncio.run` (that's how `dispatch.submit` fires when there's no running loop). `asyncio.run` tears its loop down the instant the first coroutine returns, so the `create_task`'d next turn was cancelled before it ran. `running` was left `True`, so the thread wedged and later replies queued into the void.

## Fix

- **Await-loop (the real fix):** `run_and_deliver` now drains and `await`s the next turn in place, keeping the whole conversation chain inside one live loop. Nothing is orphaned. Serial by design (one turn per thread).
- **Reaction lifecycle replaces the text spam:** a queued reply is acknowledged with ⏳ on the user's own message, flipped to 👀 when its turn starts and ✅/❌ when it finishes. Driven off-loop by the runner through a new leader-safe Discord outbox reaction verb.
- **Self-heal:** every turn stamps the session with a per-process boot token + `running_since`. On leader acquisition a reclaim sweep re-dispatches turns owned by a now-dead process (precise "it reset" signal, no pod-health probe needed - the owner identity is the liveness proof), and a stale-timeout backstop reclaims a turn wedged without a restart. Reclaim rebuilds the next task losslessly from `inflight_task + pending`.
- **Race hardening:** `continue_session` and `drain_agent_queue` lock the session row `FOR UPDATE` so a message arriving mid-drain cannot clobber the queue.

## Deploy

- New migration `20260702150000_goosecracker_queue_reactions.sql` (5 columns on `goosecracker_sessions`, 3 on `discord_outbox`, all defaulted).
- Chart bump `0.244.0 -> 0.245.0` (Chart.yaml + application.yaml).

## Tests

- `run_and_deliver` runs the drained turn in-loop (regression for the orphan bug) + reaction mark/ack ordering.
- Stale/foreign-owner reclaim (inline + startup sweep), lossless task rebuild, idle-when-nothing-to-run.
- Outbox reaction verb add + missing-reaction-removal swallow.
- Queue records message ids; drain returns `(task, ack_ids)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)