### PR TITLE
chore(fc-invoke): bump substrate chart to 0.4.19 to deploy artifact recipe changes

### DIFF
--- a/projects/firecracker/substrate/chart/Chart.yaml
+++ b/projects/firecracker/substrate/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: fc-invoke
 description: Node-affine Firecracker invoke daemon that dispatches HTTP invocations to a pool of warm-base microVMs across named workloads (POST /invoke/{workload}, GET /healthz)
 type: application
-version: 0.4.18
+version: 0.4.19

--- a/projects/firecracker/substrate/deploy/application.yaml
+++ b/projects/firecracker/substrate/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tags pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: fc-invoke
-      targetRevision: 0.4.18
+      targetRevision: 0.4.19
       helm:
         valueFiles:
           - $values/projects/firecracker/substrate/deploy/values.yaml


### PR DESCRIPTION
Deploys the artifact design-token + component-gate recipe changes merged in #3084 (`bbab90138`).

## Why a bump is needed

The goosecracker guest image tag is `latest` in source; Bazel pins the real digest into the fc-invoke chart **at chart-build time**. ArgoCD pulls the chart from OCI by `targetRevision`, so the already-published `0.4.18` chart still embeds the *old* guest digest. Bumping to `0.4.19` makes CI rebuild + republish the chart against the current goosecracker guest (which now carries the new `artifact-build.yaml` / `artifact-review.yaml`), and ArgoCD syncs it.

Both files bumped in sync per the repo convention:
- `chart/Chart.yaml`: `0.4.18` -> `0.4.19`
- `deploy/application.yaml` `targetRevision`: `0.4.18` -> `0.4.19`

🤖 Generated with [Claude Code](https://claude.com/claude-code)