### PR TITLE
fix(chat): allow reaction rows in discord_outbox CHECK constraint

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.245.0
+version: 0.246.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/migrations/20260702160000_discord_outbox_reaction_check.sql
+++ b/projects/monolith/chart/migrations/20260702160000_discord_outbox_reaction_check.sql
@@ -1,0 +1,19 @@
+-- Allow reaction rows in the Discord outbox.
+--
+-- 20260702150000 added a reaction verb (target_message_id/reaction/reaction_remove)
+-- so the goose runner can drive ⏳/👀/✅ on a message off-loop. A reaction row
+-- carries neither content nor embed_json, which violates the original
+-- discord_outbox_content_or_embed CHECK (content OR embed). That rejected every
+-- mark_inflight_running / ack_inflight insert in prod, wedging any thread with
+-- queued replies (the SQLite test fixtures build the table from the model, which
+-- did not carry this CHECK, so the tests never saw it).
+--
+-- Relax the constraint to accept a reaction row as a valid third kind of outbox
+-- entry, while still rejecting a fully-empty row.
+
+ALTER TABLE chat.discord_outbox
+    DROP CONSTRAINT IF EXISTS discord_outbox_content_or_embed;
+
+ALTER TABLE chat.discord_outbox
+    ADD CONSTRAINT discord_outbox_content_or_embed
+        CHECK (content IS NOT NULL OR embed_json IS NOT NULL OR reaction IS NOT NULL);

--- a/projects/monolith/chart/migrations/atlas.sum
+++ b/projects/monolith/chart/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:0KmTxcbfxfhL9gX6pqxtD3NcZ8Lghqj2QIa2fcKzHAU=
+h1:k8ABgUEt8+SofuLfhtmJgsXqVEfyYpbAXfRIwJeBbFw=
 20260330000000_initial_schema.sql h1:J2futpSW0nJAIRR7nR7ssT7LwXIYrvRI+PkHb5Y4tLI=
 20260403000000_chat_schema.sql h1:pERUFC0vzM95etRuzp43XzkCV7lBCzrrtY5Mk7aF3CA=
 20260404000000_chat_attachments.sql h1:tv+Fdbr1rQC5nzUxfaBC0O6fu2OMGgLWf+YNg1WQXi4=
@@ -82,3 +82,4 @@ h1:0KmTxcbfxfhL9gX6pqxtD3NcZ8Lghqj2QIa2fcKzHAU=
 20260702060000_discord_feature_grant.sql h1:Ky3Cr59rKGZu8GA/wrhNHPx9TF4vl7lLFNsooxQNFaI=
 20260702090000_goosecracker_artifact_id.sql h1:1Mt3pRLAdCXg+rCndDwEyb8UHS1dfxEgIxKErmqfk6Q=
 20260702150000_goosecracker_queue_reactions.sql h1:NddlTQmd8f6sPFQWuQnIOx7B8i3kWCvts6Rno7t+M5c=
+20260702160000_discord_outbox_reaction_check.sql h1:z4OGiXHssnbdv8D7l2J3ZoOIr8zxl4LkyQNkeU6XYEw=

--- a/projects/monolith/chat/models.py
+++ b/projects/monolith/chat/models.py
@@ -5,7 +5,7 @@ from datetime import datetime, timezone
 
 from pgvector.sqlalchemy import Vector
 from pydantic import field_validator
-from sqlalchemy import Column, UniqueConstraint
+from sqlalchemy import CheckConstraint, Column, UniqueConstraint
 from sqlmodel import Field, SQLModel
 
 
@@ -100,12 +100,21 @@ class DiscordOutbox(SQLModel, table=True):
     so posting works regardless of which replica a request lands on.
 
     embed_json holds a JSON-serialised Discord embed dict (TEXT, not JSONB, so
-    the SQLite test fixtures build it cleanly); content is plain text. Exactly
-    one of the two is set.
+    the SQLite test fixtures build it cleanly); content is plain text. A post row
+    sets exactly one of the two; a reaction row (target_message_id + reaction)
+    sets neither. The CHECK mirrors the DB constraint so the SQLite test fixtures
+    enforce it too (create_all does not see migration-only constraints, which is
+    how a reaction row's NULL/NULL content once slipped past tests into prod).
     """
 
     __tablename__ = "discord_outbox"
-    __table_args__ = {"schema": "chat", "extend_existing": True}
+    __table_args__ = (
+        CheckConstraint(
+            "content IS NOT NULL OR embed_json IS NOT NULL OR reaction IS NOT NULL",
+            name="discord_outbox_content_or_embed",
+        ),
+        {"schema": "chat", "extend_existing": True},
+    )
 
     id: int | None = Field(default=None, primary_key=True)
     channel_id: str

--- a/projects/monolith/chat/outbox_test.py
+++ b/projects/monolith/chat/outbox_test.py
@@ -4,9 +4,53 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import discord
 import pytest
+from sqlalchemy.exc import IntegrityError
+from sqlmodel import Session, SQLModel, create_engine
+from sqlmodel.pool import StaticPool
 
 import chat.outbox as outbox
+from chat.models import DiscordOutbox
 from chat.outbox import drain_once, enqueue_message, enqueue_reaction
+
+
+@pytest.fixture(name="engine")
+def engine_fixture():
+    """In-memory SQLite engine with the chat schema stripped, so the DB-level
+    CHECK constraint (mirrored into the model) is actually exercised."""
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    original = {}
+    for table in SQLModel.metadata.tables.values():
+        if table.schema is not None:
+            original[table.name] = table.schema
+            table.schema = None
+    SQLModel.metadata.create_all(engine)
+    yield engine
+    for table in SQLModel.metadata.tables.values():
+        if table.name in original:
+            table.schema = original[table.name]
+
+
+def test_reaction_row_satisfies_content_or_embed_check(engine):
+    """A reaction row (no content, no embed) must be accepted by the DB CHECK -
+    the regression that wedged prod: the constraint required content OR embed."""
+    with Session(engine) as session:
+        enqueue_reaction(session, "chan", "msg", "⏳", remove=True)
+        session.commit()
+    with Session(engine) as session:
+        row = session.query(DiscordOutbox).one()
+    assert row.reaction == "⏳" and row.content is None and row.embed_json is None
+
+
+def test_fully_empty_outbox_row_is_rejected(engine):
+    """The relaxed CHECK still rejects a row with no content, embed, or reaction."""
+    with Session(engine) as session:
+        session.add(DiscordOutbox(channel_id="chan"))
+        with pytest.raises(IntegrityError):
+            session.commit()
 
 
 def test_enqueue_text_adds_row():

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.245.0
+      targetRevision: 0.246.0
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
## Hotfix for #3085

The reaction verb added in #3085 (0.245.0) writes `discord_outbox` rows with **neither `content` nor `embed_json`** (just `target_message_id` + `reaction`). Prod's table has:

```
CHECK (content IS NOT NULL OR embed_json IS NOT NULL)
```

so every `mark_inflight_running` / `ack_inflight` insert was rejected. Result: the bot adds ⏳ directly (works), but the 👀/✅ transitions go through the outbox and fail, so any thread with **queued replies wedges with its messages stuck on ⏳**. Confirmed live in the `EggFutures` thread.

### Why tests missed it (and how they won't again)
The constraint was added by a raw-SQL migration, not the SQLModel model. The SQLite test fixtures build the table via `create_all`, which never carried it, so reaction-row tests inserted NULL/NULL happily. This is the documented "mirror migration CHECKs into `__table_args__`" gotcha.

### Fix
- **Migration** relaxes the constraint to `content OR embed OR reaction` (reaction rows are a valid third kind of outbox entry; a fully-empty row is still rejected).
- **Mirror the CHECK into `DiscordOutbox.__table_args__`** — SQLite does honour model-level CheckConstraints (verified), so the existing reaction tests now enforce it as a regression guard.
- **DB-backed tests**: a reaction row is accepted; a fully-empty row raises `IntegrityError`.
- Chart bump `0.245.0 -> 0.246.0`.

Once this deploys, the wedged thread self-heals: the reclaim sweep re-dispatches the stuck turn and the now-valid reaction inserts let it progress ⏳ → 👀 → ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)