### PR TITLE
chore(fc-invoke): bump substrate chart to 0.4.20 to deploy the research sub-recipe

### DIFF
--- a/projects/firecracker/substrate/chart/Chart.yaml
+++ b/projects/firecracker/substrate/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: fc-invoke
 description: Node-affine Firecracker invoke daemon that dispatches HTTP invocations to a pool of warm-base microVMs across named workloads (POST /invoke/{workload}, GET /healthz)
 type: application
-version: 0.4.19
+version: 0.4.20

--- a/projects/firecracker/substrate/deploy/application.yaml
+++ b/projects/firecracker/substrate/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tags pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: fc-invoke
-      targetRevision: 0.4.19
+      targetRevision: 0.4.20
       helm:
         valueFiles:
           - $values/projects/firecracker/substrate/deploy/values.yaml


### PR DESCRIPTION
Deploys the research sub-recipe guest image from #3087.

The chart-version bot on that PR logged "No conventional commits found since 0.4.18, no bump needed" despite seven feat(goosecracker) commits touching the guest package, and no degraded-scoping WARNING appeared, so the #3042 --keep_going fix did not actually widen the dep scope to the guest package on its first end-to-end test (that PR noted it was CI-only-verifiable). Manual Chart.yaml + targetRevision bump per the established recipe; the #3042 regression is worth a separate look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)