### PR TITLE
fix(goosecracker): reset live-progress buffer at each turn start

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.246.0
+version: 0.247.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chat/api.py
+++ b/projects/monolith/chat/api.py
@@ -15,6 +15,7 @@ from chat.goosecracker import force_idle_thread  # re-exported
 from chat.goosecracker import mark_inflight_running  # re-exported
 from chat.goosecracker import reclaim_orphaned_agent_sessions  # re-exported
 from chat.goosecracker_progress import (  # re-exported
+    clear as reset_goosecracker_progress,
     mark_done as mark_goosecracker_progress_done,
     set_notice as set_goosecracker_progress_notice,
 )
@@ -30,6 +31,7 @@ __all__ = [
     "reclaim_orphaned_agent_sessions",
     "enqueue_message",
     "mark_goosecracker_progress_done",
+    "reset_goosecracker_progress",
     "set_goosecracker_progress_notice",
     "run_changelog_for_config",
     "run_summary_generation",

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.246.0
+      targetRevision: 0.247.0
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/goosecracker/runner.py
+++ b/projects/monolith/goosecracker/runner.py
@@ -440,6 +440,16 @@ async def _run_one_turn(
     drain/next-turn loop lives in ``run_and_deliver``, which calls this per turn.
     """
     ok = False
+    # Reset the live-progress buffer for this session before the turn starts, so a
+    # stale done=True left by a prior turn cannot poison this one. A runner-driven
+    # turn (a reclaimed or drained await-loop turn) marks the buffer done with no
+    # bot stream to consume+clear it, and the next bot-streamed turn would then
+    # read that stale done and render "Done in 0:01" instead of live progress. The
+    # bot's stream sleeps before its first poll, so clearing at dispatch wins the
+    # race. Reached through chat.api so goosecracker never imports chat internals.
+    from chat.api import reset_goosecracker_progress
+
+    reset_goosecracker_progress(session)
     try:
         if not FC_INVOKE_URL:
             raise RuntimeError("FC_INVOKE_URL is not configured")

--- a/projects/monolith/goosecracker/tests/runner_test.py
+++ b/projects/monolith/goosecracker/tests/runner_test.py
@@ -9,7 +9,7 @@ the conversational-queue drain added for /agent thread continuations.
 from __future__ import annotations
 
 import sys
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
@@ -530,3 +530,33 @@ async def test_run_and_deliver_idles_thread_on_bookkeeping_error(monkeypatch):
     assert turns == ["first turn"]  # ran the turn, then stopped cleanly
     fake_api.force_idle_thread.assert_called_once_with("T")
     fake_api.drain_agent_queue.assert_not_called()
+
+
+async def test_run_one_turn_resets_progress_buffer_at_start(monkeypatch):
+    """Every turn clears the live-progress buffer before running, so a stale
+    done=True left by a prior (streamless) turn cannot render "Done in 0:01" on
+    the next turn's message. Verified by spying the reset seam; the turn is forced
+    to fail fast (no FC_INVOKE_URL) so no real fc-invoke/DB work runs."""
+
+    reset_spy = MagicMock()
+    fake_api = MagicMock()
+    fake_api.reset_goosecracker_progress = reset_spy
+
+    monkeypatch.setattr(runner, "FC_INVOKE_URL", "")  # fail fast in the try body
+    monkeypatch.setattr(runner.threads, "mark_failed", MagicMock())
+    monkeypatch.setattr(runner, "_deliver", AsyncMock())
+    monkeypatch.setattr(runner, "_mark_progress_done", MagicMock())
+
+    with patch.dict(sys.modules, {"chat.api": fake_api}):
+        ok = await runner._run_one_turn(
+            "sess-x",
+            task="do it",
+            recipe="agent",
+            tier="",
+            git_mirror="",
+            git_ref="",
+            discord_thread="T",
+        )
+
+    assert ok is False  # fail-fast path (no FC_INVOKE_URL)
+    reset_spy.assert_called_once_with("sess-x")  # buffer reset before the turn ran


### PR DESCRIPTION
## Problem

Users saw "🤖 Running agent / ✅ Done in 0:01" while the turn was actually still running (confirmed: the thread row was `running=t` for 1m25s+). The result still delivered, but the status message lied.

## Root cause

`goosecracker_progress` is an in-memory buffer keyed by thread id, **shared across turns and never reset between them**. Only the *first* idle turn gets a progress stream from the bot; every runner-dispatched turn (a reclaimed turn from the self-heal sweep, or a drained await-loop turn) calls `mark_done` with **no stream to consume+clear the buffer**. That leaves a `done=True` landmine, so the next bot-streamed turn polls, sees the stale `done`, and renders "Done in 0:01" before the real turn warms up.

This surfaced now because #3085 made turns survive restarts (reclaim) and added runner-driven drained turns — both are streamless, so both leave the landmine.

## Fix

Reset the buffer at the start of `_run_one_turn` (via `chat.api.reset_goosecracker_progress`, keeping the goosecracker→chat import boundary). Every turn now starts fresh, so no turn inherits a prior turn's `done`. The bot's stream sleeps one interval before its first poll, so the dispatch-time clear wins the race.

Chart bump `0.246.0 -> 0.247.0`.

## Note

This is cosmetic-only (turns always ran and delivered correctly). The deeper point: the progress buffer is the one piece of goosecracker state that's neither Postgres (durable queue/ownership) nor Discord (rendered view) — it's ephemeral in-memory, and its assumptions broke once the queue became restart-durable. Reactions remain the durable source of truth for per-message status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)