### PR TITLE
fix(goosecracker): research search must POST, router must dispatch research

### DIFF
--- a/projects/firecracker/goosecracker/guest/recipes/agent.yaml
+++ b/projects/firecracker/goosecracker/guest/recipes/agent.yaml
@@ -1,4 +1,4 @@
-version: "1.7.0"
+version: "1.7.1"
 title: "Agent"
 description: "Routing agent for a snapshot-managed microVM thread (ADR 022): classifies the task and dispatches the matching sub-recipe."
 instructions: |
@@ -16,6 +16,16 @@ instructions: |
     comparisons, news. ("what's the latest X", "how do I use library Y",
     "compare A vs B"). If the answer lives in this repo or this cluster,
     that is query, not research.
+
+    You do NOT research yourself in the router, even when the question looks
+    easy. Only the research sub-recipe has the working web-search wiring
+    (the SEARXNG_URL endpoint and its exact query incantation); the router
+    does not, so inline research wastes many turns failing against public
+    search endpoints that block you. HARD GATE: for a research task your
+    ONLY action after context-gathering is dispatching the research
+    sub-recipe and WAITING for its result, then reporting `mode: research`.
+    If your last action was a thought rather than the actual sub-recipe tool
+    call, you have not dispatched yet.
   - plan: the task wants a design or implementation plan written, or is a
     large/ambiguous change where planning must precede code. The deliverable
     is a plan document, not the change itself.

--- a/projects/firecracker/goosecracker/guest/recipes/research.yaml
+++ b/projects/firecracker/goosecracker/guest/recipes/research.yaml
@@ -1,4 +1,4 @@
-version: "1.0.0"
+version: "1.0.1"
 title: "Research"
 description: "Web research sub-recipe: search and read public sources to answer a question, confirm an assumption, or gather current external facts. Read-only."
 instructions: |
@@ -13,8 +13,9 @@ instructions: |
     GitHub repos (`gh api`, raw.githubusercontent.com), package registries.
   - `curl` for fetching, `jq` for JSON, `gh` for GitHub.
 
-  To search, run EXACTLY this pipeline (do not invent flags):
-    curl -s "${SEARXNG_URL}/search?q=YOUR+QUERY&format=json" | jq -r '.results[:5][] | "\(.title)\n\(.url)\n\(.content)\n"'
+  To search, run EXACTLY this pipeline (do not invent flags; the GET form
+  of this endpoint returns HTML, only POST form data returns JSON):
+    curl -s -X POST "${SEARXNG_URL}/search" -d "q=YOUR+QUERY&format=json" | jq -r '.results[:5][] | "\(.title)\n\(.url)\n\(.content)\n"'
   Replace spaces in the query with +. Run ONE search, then read sources.
   Search again only if the results were clearly off-target, three searches
   maximum.

--- a/projects/firecracker/substrate/chart/Chart.yaml
+++ b/projects/firecracker/substrate/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: fc-invoke
 description: Node-affine Firecracker invoke daemon that dispatches HTTP invocations to a pool of warm-base microVMs across named workloads (POST /invoke/{workload}, GET /healthz)
 type: application
-version: 0.4.20
+version: 0.4.21

--- a/projects/firecracker/substrate/deploy/application.yaml
+++ b/projects/firecracker/substrate/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tags pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: fc-invoke
-      targetRevision: 0.4.20
+      targetRevision: 0.4.21
       helm:
         valueFiles:
           - $values/projects/firecracker/substrate/deploy/values.yaml


### PR DESCRIPTION
Two fixes from live smoke tests of the research sub-recipe shipped in #3087 + #3090:

1. **SearXNG JSON needs POST.** On our deployment (searxng 2026.4.4) `GET /search?...&format=json` returns HTML; only POST form data returns JSON. The direct research-recipe run recovered by discovering this itself, but the prescribed incantation should work first try on a 32k-context model. The pipeline in `research.yaml` now uses `curl -s -X POST ... -d "q=...&format=json"`.

2. **Router HARD GATE for research dispatch.** In both router-level smoke tests the qwen router answered the research task inline instead of dispatching the sub-recipe: it has no SEARXNG_URL guidance (that lives in research.yaml), so it flailed through public SearXNG instances (403s), DuckDuckGo, and Wikipedia scraping for ~30 turns, then reported `mode: query`. Added dispatch-mandate language to the research route mirroring the artifact route's HARD GATE, which fixed the identical failure mode for artifacts.

Verification: the direct-invocation run (thread t-c2454650cc97) proves the full path works once the sub-recipe executes: SEARXNG_URL resolved, egress sidecar allowed the in-cluster SearXNG call, primary sources fetched with bounded reads, and the answer correctly separated confirmed facts from unconfirmed ones. Post-merge I'll rerun the router-level smoke test.

Includes the manual fc-invoke chart bump to 0.4.21 (`Chart.yaml` + `targetRevision`); the chart-version bot still does not scope guest content (see #3090 notes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)