### PR TITLE
fix(goosecracker): router must delegate research, not just declare it

### DIFF
--- a/projects/firecracker/goosecracker/guest/recipes/agent.yaml
+++ b/projects/firecracker/goosecracker/guest/recipes/agent.yaml
@@ -1,4 +1,4 @@
-version: "1.7.1"
+version: "1.7.2"
 title: "Agent"
 description: "Routing agent for a snapshot-managed microVM thread (ADR 022): classifies the task and dispatches the matching sub-recipe."
 instructions: |
@@ -18,14 +18,25 @@ instructions: |
     that is query, not research.
 
     You do NOT research yourself in the router, even when the question looks
-    easy. Only the research sub-recipe has the working web-search wiring
-    (the SEARXNG_URL endpoint and its exact query incantation); the router
-    does not, so inline research wastes many turns failing against public
-    search endpoints that block you. HARD GATE: for a research task your
-    ONLY action after context-gathering is dispatching the research
-    sub-recipe and WAITING for its result, then reporting `mode: research`.
-    If your last action was a thought rather than the actual sub-recipe tool
-    call, you have not dispatched yet.
+    easy. Only the research sub-recipe has the working web-search wiring (the
+    SEARXNG_URL endpoint and its exact query incantation); the router does
+    not, so inline research wastes many turns failing against public search
+    endpoints that block you. You run it as a delegated subagent, using the
+    `delegate` tool, exactly like an artifact:
+      1. `delegate(source: "research")` and WAIT. That subagent reads the
+         question from /tmp/goose/task.md, searches, reads sources, and
+         returns a short cited answer as its result.
+      2. `recipe__final_output` with `mode: research`, putting the subagent's
+         returned answer into `summary` (and `details` if it is long). You are
+         RELAYING the subagent's answer, not describing that you routed: the
+         summary must contain the actual finding and its sources, never a
+         sentence like "routed to research" or "dispatched the sub-recipe".
+
+    HARD GATE: do NOT emit `mode: research` until the `delegate(source:
+    "research")` call has RETURNED a result in THIS turn. Deciding to delegate
+    is not delegating: if your most recent action was a thought rather than an
+    actual `delegate` tool call, nothing has happened yet and you have no
+    answer to relay. Never answer the research question yourself.
   - plan: the task wants a design or implementation plan written, or is a
     large/ambiguous change where planning must precede code. The deliverable
     is a plan document, not the change itself.

--- a/projects/firecracker/substrate/chart/Chart.yaml
+++ b/projects/firecracker/substrate/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: fc-invoke
 description: Node-affine Firecracker invoke daemon that dispatches HTTP invocations to a pool of warm-base microVMs across named workloads (POST /invoke/{workload}, GET /healthz)
 type: application
-version: 0.4.26
+version: 0.4.27

--- a/projects/firecracker/substrate/deploy/application.yaml
+++ b/projects/firecracker/substrate/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tags pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: fc-invoke
-      targetRevision: 0.4.26
+      targetRevision: 0.4.27
       helm:
         valueFiles:
           - $values/projects/firecracker/substrate/deploy/values.yaml


### PR DESCRIPTION
Follow-up to #3092 from the router-level smoke test.

## Symptom

After #3092's HARD GATE, the router stopped researching inline (good) but over-corrected: on thread `t-178a432dec74` it emitted `mode: research` claiming it dispatched, **without ever calling `delegate`** — completed in 5 seconds, no sub-recipe banner in the transcript, no answer returned to the user.

## Root cause

Scanned the agent-thread ledger: **only `artifact` tasks actually call `delegate` today.** Every `query`/`plan`/`implement`/`research` thread runs inline in the router (the "call the matching sub-recipe tool" language never reliably fires; the router just does the work itself with the developer extension).

That is fine for query/plan/implement (the router can read code and open PRs directly) but **broken for research specifically**: the SearXNG search wiring exists only inside `research.yaml`, so when the router works inline it has no idea how to search. The #3092 gate said "dispatch the research sub-recipe" without naming the exact `delegate(source: "research")` call or requiring it to have returned, so qwen declared the routing and stopped.

## Fix

Rewrote the research route to mirror the **proven artifact pattern** exactly:
- Explicit `delegate(source: "research")` and WAIT.
- Return-verified HARD GATE: do not emit `mode: research` until the delegate has RETURNED a result this turn ("deciding to delegate is not delegating").
- Relay the subagent's answer into `summary`/`details`; the summary must carry the actual finding and sources, never "routed to research".

The sub-recipe itself already works end to end when invoked directly (thread `t-c2454650cc97`: SEARXNG POST search, bounded source reads, cited answer). This only fixes the router's dispatch of it.

Manual fc-invoke chart bump to 0.4.22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)