### PR TITLE
fix(goosecracker): build artifacts incrementally to survive large writes

### DIFF
--- a/projects/firecracker/goosecracker/guest/recipes/artifact-build.yaml
+++ b/projects/firecracker/goosecracker/guest/recipes/artifact-build.yaml
@@ -12,9 +12,27 @@ instructions: |
   action is a tool call that writes the file. If you answer in prose instead of
   using the tools, you have FAILED.
 
-  Your ONLY job: write ONE complete HTML document to /tmp/artifact.html using
-  the shell or editor, in a single step. Make it complete, correct, and visually
-  polished on the first write.
+  Your ONLY job: produce ONE complete, self-contained HTML document at
+  /tmp/artifact.html. BUILD IT INCREMENTALLY with the text editor, never as one
+  giant write. Emitting tens of KB of HTML in a single tool call is the top cause
+  of a corrupted or half-written file: the argument truncates or mis-escapes and
+  the write silently fails. Instead:
+    1. FIRST, write a small SKELETON with the editor: a valid HTML document with
+       <head> (fonts, CDN <script>/<link> tags, your :root CSS variables and base
+       styles) and a <body> whose major sections are empty placeholders marked
+       with UNIQUE HTML comments, e.g. <!--SECTION:HEADER-->, <!--SECTION:CHART-->,
+       <!--SECTION:TABLE-->, plus a <!--SCRIPT:LOGIC--> marker inside the closing
+       <script>. Keep the skeleton small.
+    2. THEN fill each section ONE AT A TIME with a separate str_replace edit that
+       swaps a single marker comment for that section's real markup. Each edit is
+       small and self-contained, so a garbled one costs a cheap retry instead of
+       corrupting the whole file.
+    3. Finally replace <!--SCRIPT:LOGIC--> with your inline JS the same way.
+  Prefer the editor's targeted str_replace over shell heredocs for anything large:
+  a heredoc buries the entire document inside one shell `command` argument, which
+  IS the fragile giant write to avoid. Use the shell for small things (reading the
+  task file, quick checks), not for writing the page. Make the finished page
+  complete, correct, and visually polished.
 
   The artifact renders inside a sandboxed iframe and behaves like a normal web
   page, so use the open web freely (over https only):
@@ -97,9 +115,10 @@ instructions: |
   summary: <1-2 sentences: what you built>
   ```
 prompt: |
-  Build or update this artifact now. Start immediately by writing
-  /tmp/artifact.html with the shell or editor; do not reply with a plan or a
-  description first.
+  Build or update this artifact now. Start immediately with the editor: for a new
+  page write the small skeleton first, then fill each marked section with a
+  separate str_replace edit. Do not reply with a plan or a description first, and
+  do not dump the whole document in one giant write.
 
   What to build is in the file {{ task_file }}: read it first, for example
   `cat {{ task_file }}`.
@@ -185,6 +204,8 @@ retry:
     invalid Tailwind color class like slate-705 (renders as nothing), or an
     interactivity directive (Alpine/Vue x-data/@click/:class, Franken uk-*,
     data-lucide) whose runtime script is never loaded. If /tmp/artifact_error.txt
-    exists, read it first: it lists the exact problems. Fix them (or write the
-    file) and re-write the COMPLETE, self-contained HTML document to
-    /tmp/artifact.html now. Do not reply with prose, a plan, or the HTML in text.
+    exists, read it first: it lists the exact problems. Fix them with targeted
+    str_replace edits to /tmp/artifact.html (or, if the file is missing/empty,
+    write the small skeleton and fill it section by section as before). Do not
+    re-dump the whole document in one giant write, and do not reply with prose, a
+    plan, or the HTML in text.

--- a/projects/firecracker/substrate/chart/Chart.yaml
+++ b/projects/firecracker/substrate/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: fc-invoke
 description: Node-affine Firecracker invoke daemon that dispatches HTTP invocations to a pool of warm-base microVMs across named workloads (POST /invoke/{workload}, GET /healthz)
 type: application
-version: 0.4.21
+version: 0.4.22

--- a/projects/firecracker/substrate/deploy/application.yaml
+++ b/projects/firecracker/substrate/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tags pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: fc-invoke
-      targetRevision: 0.4.21
+      targetRevision: 0.4.22
       helm:
         valueFiles:
           - $values/projects/firecracker/substrate/deploy/values.yaml


### PR DESCRIPTION
## Problem

The `artifact-build` recipe told the model to *"write ONE complete HTML document to `/tmp/artifact.html` ... in a single step"*. On the now-100%-Qwen guest, that forces the entire (~90KB) document into a single tool-call argument. Qwen frequently truncates or mis-escapes an argument that large, so the write fails.

Observed live in session `1522346240120193197` (the "Space Eggx dank charts" build): the guest logged repeated `Error: Failed to parse arguments: missing field \`command\`` from the `shell` tool, each burning a full model turn (~40-50s) before recovering. The build limped forward at roughly half efficiency.

## Fix (Option A: prompt-only, no new tools)

The guest already exposes `text_editor` (part of the `developer` builtin). Rewrite the recipe to build **incrementally** with it:

1. Write a small **skeleton** first: valid HTML doc with `<head>` + CDN links + `:root` CSS vars, and a `<body>` of empty placeholders marked with unique HTML comments (`<!--SECTION:CHART-->`, `<!--SCRIPT:LOGIC-->`, ...).
2. Fill each section **one at a time** with a separate `str_replace` edit.

Each call now carries a small, well-formed payload, so a garbled one costs a cheap retry instead of corrupting the whole file. Also steers explicitly away from shell heredocs (which bury the whole document in one `command` arg) and makes the retry `failure_prompt` apply targeted edits rather than re-dumping the full document.

No new tools, no guest binary changes: just the recipe YAML.

## Deploy

The recipe globs into the apko guest image (`recipes_tar` in `guest/BUILD`), which the **substrate chart** pins. Guest-content changes are **not** auto-bumped, so this bumps the `fc-invoke` substrate chart `0.4.21 -> 0.4.22` (Chart.yaml + `application.yaml` targetRevision in sync) to rebuild the image and roll it out, same as the research sub-recipe deploy (`5874caeb6`).

## Verification

- `helm template` of the substrate chart renders clean.
- Recipe YAML parses (literal block scalars intact).
- No em-dashes.
- Behavioral proof is post-merge: watch a fresh artifact build for the disappearance of the `missing field \`command\`` errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)