### PR TITLE
feat(fc-invoke): drain in-flight tasks before pod termination

### DIFF
--- a/projects/firecracker/substrate/chart/Chart.yaml
+++ b/projects/firecracker/substrate/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: fc-invoke
 description: Node-affine Firecracker invoke daemon that dispatches HTTP invocations to a pool of warm-base microVMs across named workloads (POST /invoke/{workload}, GET /healthz)
 type: application
-version: 0.4.21
+version: 0.4.22

--- a/projects/firecracker/substrate/chart/templates/deployment.yaml
+++ b/projects/firecracker/substrate/chart/templates/deployment.yaml
@@ -26,6 +26,11 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
+      # Safe-rollout drain: give the daemon time to finish in-flight invokes on
+      # SIGTERM before Kubernetes SIGKILLs it. Set above drain.timeoutSeconds (the
+      # daemon's own drain budget, FC_INVOKE_DRAIN_TIMEOUT below) so the grace
+      # window always outlasts the drain. See values.yaml `drain`.
+      terminationGracePeriodSeconds: {{ add .Values.drain.timeoutSeconds 30 }}
       serviceAccountName: {{ include "fc-invoke.serviceAccountName" . }}
       {{- if .Values.imagePullSecret.enabled }}
       imagePullSecrets:
@@ -124,6 +129,11 @@ spec:
               value: ":{{ .Values.service.port }}"
             - name: FC_INVOKE_NODE
               value: {{ .Values.node | quote }}
+            # Graceful-drain budget (safe rollout): how long the daemon waits for
+            # in-flight invokes before exiting on SIGTERM. Pinned from
+            # drain.timeoutSeconds; terminationGracePeriodSeconds is set above it.
+            - name: FC_INVOKE_DRAIN_TIMEOUT
+              value: "{{ .Values.drain.timeoutSeconds }}s"
             - name: FC_INVOKE_ARCH
               value: {{ .Values.arch | quote }}
             # The named workload table, rendered as JSON. The daemon builds one

--- a/projects/firecracker/substrate/chart/values.yaml
+++ b/projects/firecracker/substrate/chart/values.yaml
@@ -54,6 +54,18 @@ replicas: 1
 
 podAnnotations: {}
 
+# Safe-rollout drain budget. On SIGTERM the daemon stops accepting new invokes
+# and waits up to drain.timeoutSeconds for in-flight guests to finish before
+# exiting, so a rollout (or any pod delete) never drops a running task. This
+# MUST cover the longest workload requestTimeout (agent: 600s below) or a
+# mid-flight goose run is cut short. terminationGracePeriodSeconds is set to
+# drain.timeoutSeconds + 30s of margin so Kubernetes does not SIGKILL the pod
+# mid-drain (the guest response still needs to flush and the microVM be
+# discarded after the request context ends). Raise this in lockstep if any
+# workload's requestTimeout grows past it.
+drain:
+  timeoutSeconds: 600
+
 # node + arch the daemon runs on. Firecracker guests are node/arch-affine, so
 # the daemon is pinned to its node.
 node: node-4

--- a/projects/firecracker/substrate/cluster/catalog/config.go
+++ b/projects/firecracker/substrate/cluster/catalog/config.go
@@ -57,6 +57,15 @@ type Config struct {
 	// BootReadyTimeout bounds how long an invoker waits for a freshly booted or
 	// restored guest to announce readiness over its shim.
 	BootReadyTimeout time.Duration
+	// DrainTimeout bounds graceful shutdown: on SIGTERM the daemon stops
+	// accepting new invocations and waits up to this long for in-flight guests
+	// to finish before exiting, so a rollout never drops a running task. It must
+	// cover the longest workload RequestTimeout, and the pod's
+	// terminationGracePeriodSeconds must exceed it so Kubernetes does not SIGKILL
+	// mid-drain. Overridable via FC_INVOKE_DRAIN_TIMEOUT; defaults to the longest
+	// workload RequestTimeout plus a flush/discard margin (or BootReadyTimeout
+	// when no workloads are configured).
+	DrainTimeout time.Duration
 
 	// EgressSidecarAddr is the pod-local egress-proxy sidecar TCP address
 	// (ADR 023 phase 6a). Egress-enabled workloads tunnel each guest's vsock
@@ -106,7 +115,31 @@ func Load() (Config, error) {
 	}
 	c.Workloads = workloads
 
+	// Derive the drain budget from the workload table so it can never silently
+	// fall behind a requestTimeout bump, then let FC_INVOKE_DRAIN_TIMEOUT pin it.
+	c.DrainTimeout = defaultDrainTimeout(c.Workloads, c.BootReadyTimeout)
+	if err := parseDuration("FC_INVOKE_DRAIN_TIMEOUT", &c.DrainTimeout); err != nil {
+		return Config{}, err
+	}
+
 	return c, nil
+}
+
+// defaultDrainTimeout is the graceful-shutdown budget when FC_INVOKE_DRAIN_TIMEOUT
+// is unset: the longest workload RequestTimeout plus a margin for the guest
+// response to flush and the microVM to be discarded, so an in-flight invocation
+// is never cut short. Falls back to bootReady when no workloads are configured.
+func defaultDrainTimeout(workloads map[string]substrate.Workload, bootReady time.Duration) time.Duration {
+	var longest time.Duration
+	for _, w := range workloads {
+		if w.RequestTimeout > longest {
+			longest = w.RequestTimeout
+		}
+	}
+	if longest <= 0 {
+		return bootReady
+	}
+	return longest + 30*time.Second
 }
 
 // loadWorkloads parses the workload table from FC_INVOKE_WORKLOADS_FILE (if

--- a/projects/firecracker/substrate/cluster/catalog/config_test.go
+++ b/projects/firecracker/substrate/cluster/catalog/config_test.go
@@ -19,7 +19,7 @@ func TestLoadDefaultsNoWorkloads(t *testing.T) {
 		"FC_INVOKE_FIRECRACKER_BIN", "FC_INVOKE_KERNEL_IMAGE",
 		"FC_INVOKE_KERNEL_BOOT_ARGS", "FC_INVOKE_HARNESS_INIT",
 		"FC_INVOKE_CANONICAL_VSOCK_DIR", "FC_INVOKE_GUEST_OOM_SCORE_ADJ",
-		"FC_INVOKE_BOOT_READY_TIMEOUT", "NODE_NAME",
+		"FC_INVOKE_BOOT_READY_TIMEOUT", "FC_INVOKE_DRAIN_TIMEOUT", "NODE_NAME",
 	} {
 		t.Setenv(k, "")
 	}
@@ -54,6 +54,41 @@ func TestLoadDefaultsNoWorkloads(t *testing.T) {
 	}
 	if c.BootReadyTimeout != 60*time.Second {
 		t.Errorf("BootReadyTimeout = %s, want 60s", c.BootReadyTimeout)
+	}
+	// With no workloads, the drain budget falls back to BootReadyTimeout.
+	if c.DrainTimeout != 60*time.Second {
+		t.Errorf("DrainTimeout = %s, want 60s (BootReadyTimeout fallback)", c.DrainTimeout)
+	}
+}
+
+// TestDrainTimeoutDerivesFromLongestWorkload verifies the graceful-shutdown
+// budget defaults to the longest workload RequestTimeout plus the flush/discard
+// margin, and that FC_INVOKE_DRAIN_TIMEOUT overrides it outright.
+func TestDrainTimeoutDerivesFromLongestWorkload(t *testing.T) {
+	t.Setenv("FC_INVOKE_WORKLOADS_FILE", "")
+	t.Setenv("FC_INVOKE_DRAIN_TIMEOUT", "")
+	t.Setenv("FC_INVOKE_WORKLOADS", `{
+		"semgrep": {"image": "semgrep-guest", "requestTimeout": "90s"},
+		"agent":   {"image": "agent-guest",   "requestTimeout": "600s"}
+	}`)
+
+	c, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	// Longest workload (agent, 600s) + 30s margin.
+	if want := 630 * time.Second; c.DrainTimeout != want {
+		t.Errorf("DrainTimeout = %s, want %s (longest requestTimeout + margin)", c.DrainTimeout, want)
+	}
+
+	// An explicit env value pins the budget regardless of the workload table.
+	t.Setenv("FC_INVOKE_DRAIN_TIMEOUT", "120s")
+	c, err = Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if want := 120 * time.Second; c.DrainTimeout != want {
+		t.Errorf("DrainTimeout = %s, want %s (env override)", c.DrainTimeout, want)
 	}
 }
 

--- a/projects/firecracker/substrate/deploy/application.yaml
+++ b/projects/firecracker/substrate/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tags pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: fc-invoke
-      targetRevision: 0.4.21
+      targetRevision: 0.4.22
       helm:
         valueFiles:
           - $values/projects/firecracker/substrate/deploy/values.yaml

--- a/projects/firecracker/substrate/invoke/cmd/main.go
+++ b/projects/firecracker/substrate/invoke/cmd/main.go
@@ -158,8 +158,13 @@ func run(logger *slog.Logger) error {
 		}
 		return err
 	case <-ctx.Done():
-		logger.Info("shutdown signal received; draining")
-		shutdownCtx, cancel := context.WithTimeout(context.Background(), cfg.BootReadyTimeout)
+		// Stop accepting new invocations and wait for in-flight ones to finish.
+		// Each /invoke is a synchronous request that holds its guest until the
+		// response is proxied back, so Shutdown draining handlers == draining
+		// running tasks. The budget covers the longest workload so a rollout
+		// never drops a task; the pod's grace period is set above it.
+		logger.Info("shutdown signal received; draining in-flight invocations", "budget", cfg.DrainTimeout)
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), cfg.DrainTimeout)
 		defer cancel()
 		return srv.Shutdown(shutdownCtx)
 	}


### PR DESCRIPTION
## Problem

Rolling the fc-invoke daemon (the node-affine Firecracker invoke daemon on node-4) killed running goose/semgrep tasks. Two timeout budgets were both shorter than a task:

- On SIGTERM the daemon called `srv.Shutdown` with a **60s** budget (`BootReadyTimeout`), but the agent workload's `requestTimeout` is **600s**.
- The pod had no `terminationGracePeriodSeconds`, so Kubernetes SIGKILLed it at the **30s** default regardless of the daemon's own drain.

Net effect: any in-flight goose/agent run past 30s was dropped on every rollout (and on any pod delete / node drain).

## Fix

The graceful-drain primitive already existed: every `POST /invoke/{workload}` is a synchronous request that holds its microVM until the response is proxied back, so `srv.Shutdown` draining in-flight handlers **is** draining running tasks. This PR only aligns the budgets so that drain actually gets to run:

- New `DrainTimeout` config (`FC_INVOKE_DRAIN_TIMEOUT`), used by `srv.Shutdown` instead of `BootReadyTimeout`. When unset it auto-derives from the longest workload `requestTimeout` + 30s, so it can never silently fall behind a `requestTimeout` bump.
- Chart `drain.timeoutSeconds` (600s) drives **both** the env and the pod's `terminationGracePeriodSeconds` (+30s), keeping `grace > drain > longest task` by construction from a single knob.

A rollout now waits for a running task to finish (up to 600s) before the pod exits. `Recreate` strategy is unchanged, so there is still a brief no-daemon gap while the new pod boots and rebuilds its warm base (that is the zero-downtime concern, deliberately out of scope; it would need giving up the one-daemon-per-node / owns-the-scratch-disk invariant).

## Decisions (confirmed with owner)

- Approach: align budgets, keep `Recreate` (not drain+surge).
- Drain ceiling: full **600s** (never drop a running task; worst-case rollout stall is ~10 min).
- **No PodDisruptionBudget** this pass, so `kubectl drain` / involuntary evictions are not yet covered. Follow-up if wanted.

## Verification

- `helm template` renders `terminationGracePeriodSeconds: 630` and `FC_INVOKE_DRAIN_TIMEOUT: "600s"`.
- `go build` of the changed packages passes; `gofmt` clean.
- Added `TestDrainTimeoutDerivesFromLongestWorkload` (derive + env override) and extended the defaults test. Full test run defers to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)