### PR TITLE
feat(goosecracker): conversational /agent replies with channel context + prompt echo

### DIFF
--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -1312,6 +1312,30 @@ py_test(
 )
 
 py_test(
+    name = "chat_summarizer_agent_reply_test",
+    srcs = ["chat/summarizer_agent_reply_test.py"],
+    imports = ["."],
+    deps = [
+        ":monolith_backend",
+        "@pip//pgvector",
+        "@pip//pytest",
+        "@pip//pytest_asyncio",
+        "@pip//sqlmodel",
+    ],
+)
+
+py_test(
+    name = "chat_bot_agent_prompt_echo_test",
+    srcs = ["chat/bot_agent_prompt_echo_test.py"],
+    imports = ["."],
+    deps = [
+        ":monolith_backend",
+        "@pip//discord_py",
+        "@pip//pytest",
+    ],
+)
+
+py_test(
     name = "chat_summarizer_channel_test",
     srcs = ["chat/summarizer_channel_test.py"],
     imports = ["."],

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.247.0
+version: 0.248.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/migrations/20260702170000_goosecracker_parent_channel.sql
+++ b/projects/monolith/chart/migrations/20260702170000_goosecracker_parent_channel.sql
@@ -1,0 +1,14 @@
+-- Discord parent channel id for agent (goosecracker) threads.
+--
+-- The /agent command opens a NEW thread and dispatches goose against it, but the
+-- thread has no history: the conversational context (recent messages, per-user
+-- and per-channel rolling summaries) lives on the PARENT channel the command was
+-- run from. Store that parent channel id on the session row so the runner can
+-- fetch channel-scoped context for a conversational reply, and so a cross-process
+-- reclaim (leader restart) reloads it from the row rather than losing it with the
+-- original dispatch params.
+--
+-- Safe to run with data: existing rows default to '' (an empty parent means the
+-- runner falls back to the deterministic summary, no channel context).
+ALTER TABLE chat.goosecracker_sessions
+    ADD COLUMN IF NOT EXISTS parent_channel_id TEXT NOT NULL DEFAULT '';

--- a/projects/monolith/chart/migrations/atlas.sum
+++ b/projects/monolith/chart/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:k8ABgUEt8+SofuLfhtmJgsXqVEfyYpbAXfRIwJeBbFw=
+h1:q47JpV9ZAdqpCFU2HASA2PRp/22WoAs6BBr+IaMj2tc=
 20260330000000_initial_schema.sql h1:J2futpSW0nJAIRR7nR7ssT7LwXIYrvRI+PkHb5Y4tLI=
 20260403000000_chat_schema.sql h1:pERUFC0vzM95etRuzp43XzkCV7lBCzrrtY5Mk7aF3CA=
 20260404000000_chat_attachments.sql h1:tv+Fdbr1rQC5nzUxfaBC0O6fu2OMGgLWf+YNg1WQXi4=
@@ -83,3 +83,4 @@ h1:k8ABgUEt8+SofuLfhtmJgsXqVEfyYpbAXfRIwJeBbFw=
 20260702090000_goosecracker_artifact_id.sql h1:1Mt3pRLAdCXg+rCndDwEyb8UHS1dfxEgIxKErmqfk6Q=
 20260702150000_goosecracker_queue_reactions.sql h1:NddlTQmd8f6sPFQWuQnIOx7B8i3kWCvts6Rno7t+M5c=
 20260702160000_discord_outbox_reaction_check.sql h1:z4OGiXHssnbdv8D7l2J3ZoOIr8zxl4LkyQNkeU6XYEw=
+20260702170000_goosecracker_parent_channel.sql h1:l1wOFXQ7VgfIeM66A/a2SdMfpKmVfUaf48MytRZOlBA=

--- a/projects/monolith/chat/api.py
+++ b/projects/monolith/chat/api.py
@@ -13,6 +13,7 @@ from chat.goosecracker import artifact_id_for_thread  # re-exported
 from chat.goosecracker import drain_agent_queue  # re-exported
 from chat.goosecracker import force_idle_thread  # re-exported
 from chat.goosecracker import mark_inflight_running  # re-exported
+from chat.goosecracker import parent_channel_for_thread  # re-exported
 from chat.goosecracker import reclaim_orphaned_agent_sessions  # re-exported
 from chat.goosecracker_progress import (  # re-exported
     clear as reset_goosecracker_progress,
@@ -20,14 +21,17 @@ from chat.goosecracker_progress import (  # re-exported
     set_notice as set_goosecracker_progress_notice,
 )
 from chat.outbox import enqueue_message  # re-exported
+from chat.summarizer import conversational_agent_reply  # re-exported
 from chat.summarizer import run_summary_generation  # re-exported
 
 __all__ = [
     "ack_inflight",
     "artifact_id_for_thread",
+    "conversational_agent_reply",
     "drain_agent_queue",
     "force_idle_thread",
     "mark_inflight_running",
+    "parent_channel_for_thread",
     "reclaim_orphaned_agent_sessions",
     "enqueue_message",
     "mark_goosecracker_progress_done",

--- a/projects/monolith/chat/bot.py
+++ b/projects/monolith/chat/bot.py
@@ -438,6 +438,29 @@ def _extract_embed_text(message: discord.Message) -> str:
     return "\n".join(parts)
 
 
+# Overhead of the code fence and header formatting in _format_agent_prompt_echo,
+# reserved out of Discord's 2000-char message cap so the echo never overflows.
+_PROMPT_ECHO_MAX = 2000
+
+
+def _format_agent_prompt_echo(user: discord.abc.User, prompt: str) -> str:
+    """Render the ``/agent`` prompt as a fenced, attributed echo message.
+
+    The prompt otherwise survives only in the thread title, which Discord
+    truncates to ~90 chars, so a long prompt is lost. Any code fence in the
+    user-controlled prompt is neutralized (a zero-width space is woven through
+    the backticks) so it cannot break out of the block, and the whole message is
+    capped to fit one Discord message (2000 chars).
+    """
+    zwsp = chr(0x200B)  # zero-width space woven through backticks to defuse fences
+    safe = prompt.replace("```", f"`{zwsp}`{zwsp}`")
+    header = f"Prompt from {user.mention}:\n"
+    budget = _PROMPT_ECHO_MAX - len(header) - len("```\n\n```")
+    if len(safe) > budget:
+        safe = safe[: budget - 1].rstrip() + "…"
+    return f"{header}```\n{safe}\n```"
+
+
 class ChatBot(discord.Client):
     def __init__(self):
         intents = discord.Intents.default()
@@ -657,7 +680,11 @@ class ChatBot(discord.Client):
                 name=name, type=discord.ChannelType.public_thread
             )
             await asyncio.to_thread(
-                goosecracker.start_agent_session, str(thread.id), repo, prompt
+                goosecracker.start_agent_session,
+                str(thread.id),
+                repo,
+                prompt,
+                str(channel.id),
             )
         except Exception:
             logger.exception("goosecracker: failed to start agent session")
@@ -667,6 +694,13 @@ class ChatBot(discord.Client):
             return
 
         await interaction.followup.send(f"Running agent in {thread.mention}")
+        try:
+            # Echo the full prompt into the thread: the thread title truncates it
+            # to ~90 chars, so a long prompt is otherwise lost. Its own message,
+            # not the intro (which the progress stream live-edits and would clobber).
+            await thread.send(_format_agent_prompt_echo(interaction.user, prompt))
+        except Exception:
+            logger.exception("goosecracker: failed to post agent prompt echo")
         try:
             intro = await thread.send("🤖 On it. Running the agent now...")
             self._start_goosecracker_stream(str(thread.id), intro, kind="agent")

--- a/projects/monolith/chat/bot_agent_prompt_echo_test.py
+++ b/projects/monolith/chat/bot_agent_prompt_echo_test.py
@@ -1,0 +1,40 @@
+"""Tests for the /agent prompt echo (_format_agent_prompt_echo in chat.bot).
+
+The prompt otherwise survives only in the ~90-char thread title, so the echo
+posts it in full. Covers attribution, code-fence escaping (the prompt is
+user-controlled and must not break out of the block), and the 2000-char cap.
+"""
+
+from types import SimpleNamespace
+
+from chat.bot import _PROMPT_ECHO_MAX, _format_agent_prompt_echo
+
+_USER = SimpleNamespace(mention="<@123>")
+
+
+def test_attributes_and_fences_the_prompt():
+    out = _format_agent_prompt_echo(_USER, "add a health check endpoint")
+    assert out.startswith("Prompt from <@123>:\n")
+    assert "```\nadd a health check endpoint\n```" in out
+
+
+def test_neutralizes_inner_code_fence():
+    # A triple-backtick in the prompt must not close the echo's own fence. After
+    # escaping, the only raw ``` left are the echo's own opening and closing pair.
+    out = _format_agent_prompt_echo(_USER, "```rm -rf /```")
+    assert out.count("```") == 2
+    zwsp = chr(0x200B)
+    assert f"`{zwsp}`{zwsp}`" in out  # backticks woven with a zero-width space
+
+
+def test_caps_to_one_discord_message():
+    out = _format_agent_prompt_echo(_USER, "x" * 5000)
+    assert len(out) <= _PROMPT_ECHO_MAX
+    assert out.endswith("```")
+    assert "…" in out  # truncation marker
+
+
+def test_short_prompt_not_truncated():
+    out = _format_agent_prompt_echo(_USER, "tiny")
+    assert "…" not in out
+    assert out.count("tiny") == 1

--- a/projects/monolith/chat/goosecracker.py
+++ b/projects/monolith/chat/goosecracker.py
@@ -530,13 +530,19 @@ def _reclaim_one(thread_id: str, now: datetime) -> tuple[str, str, str, str] | N
         return task, recipe, tier, repo
 
 
-def start_agent_session(thread_id: str, repo: str, prompt: str) -> dict:
+def start_agent_session(
+    thread_id: str, repo: str, prompt: str, parent_channel_id: str = ""
+) -> dict:
     """Open a conversational agent session for a Discord thread.
 
     Dispatches the first turn and writes a GoosecrackerSession row so that
     follow-up replies in the thread are routed through ``continue_session``
     (agent path) with queuing support. The row is written AFTER dispatch so
     that a failed submit leaves no row (mirroring ``start_session``).
+
+    ``parent_channel_id`` is the channel the /agent command was run from (the
+    thread's parent); stored on the row so the runner can fetch channel-scoped
+    context for a conversational reply, since the new thread has no history.
 
     Synchronous; call via asyncio.to_thread.
     """
@@ -559,6 +565,7 @@ def start_agent_session(thread_id: str, repo: str, prompt: str) -> dict:
         session.add(
             GoosecrackerSession(
                 discord_thread=thread_id,
+                parent_channel_id=parent_channel_id,
                 recipe=AGENT_RECIPE,
                 tier=AGENT_TIER,
                 repo=repo,
@@ -610,6 +617,20 @@ def artifact_id_for_thread(thread_id: str) -> str:
             session.add(row)
             session.commit()
         return row.artifact_id
+
+
+def parent_channel_for_thread(thread_id: str) -> str:
+    """Return the Discord parent channel id stored for an agent thread, or "".
+
+    The runner reads this at delivery time to fetch channel-scoped context for a
+    conversational reply. Empty when the thread has no session row (an
+    MCP-dispatched run with no Discord front) or none was recorded (an older
+    thread predating this column, or an artifact thread). Sync; call via
+    ``asyncio.to_thread``.
+    """
+    with Session(get_engine()) as session:
+        row = session.get(GoosecrackerSession, thread_id)
+        return row.parent_channel_id if row else ""
 
 
 async def build_roast(attempt_text: str) -> str:

--- a/projects/monolith/chat/goosecracker_test.py
+++ b/projects/monolith/chat/goosecracker_test.py
@@ -220,6 +220,26 @@ def test_start_agent_session_writes_session_row(engine, fake_api):
     assert row.transcript == "fix the bug"
     assert row.running
     assert row.pending == ""
+    # No parent channel supplied -> empty (runner then skips the concierge).
+    assert row.parent_channel_id == ""
+
+
+def test_start_agent_session_round_trips_parent_channel(engine, fake_api):
+    """The parent channel id round-trips: start_agent_session stores it on the
+    row and parent_channel_for_thread reads it back. This is the runner's only
+    path to the channel-scoped context for a conversational reply, so a break
+    here would silently drop every reply to the deterministic fallback."""
+    with patch("chat.goosecracker.get_engine", return_value=engine):
+        goosecracker.start_agent_session(
+            "thread-pc", "homelab", "fix the bug", "parent-chan-9"
+        )
+        with Session(engine) as session:
+            row = session.get(GoosecrackerSession, "thread-pc")
+        assert row.parent_channel_id == "parent-chan-9"
+        # Read back through the getter the runner actually calls.
+        assert goosecracker.parent_channel_for_thread("thread-pc") == "parent-chan-9"
+        # Unknown thread -> "" so the runner falls back to the deterministic summary.
+        assert goosecracker.parent_channel_for_thread("nope") == ""
     # The first turn is stamped live (owned by this process, timestamped) so a
     # reply arriving during it queues rather than being reclaimed as "stale".
     assert row.runner_instance == goosecracker.INSTANCE_TOKEN

--- a/projects/monolith/chat/models.py
+++ b/projects/monolith/chat/models.py
@@ -156,6 +156,11 @@ class GoosecrackerSession(SQLModel, table=True):
     recipe: str = Field(default="artifact")
     tier: str = Field(default="")
     repo: str = Field(default="")
+    # Discord parent channel the /agent thread was opened from. The thread itself
+    # has no history, so the runner reads this to fetch channel-scoped context
+    # (recent messages, rolling summaries) for a conversational reply. Empty for a
+    # non-Discord (MCP) session or an artifact thread; empty means no context.
+    parent_channel_id: str = Field(default="")
     # Conversational queue state (agent sessions only).
     # running: a turn is currently in flight.
     # pending: newline-joined replies queued while running=True; consumed on drain.

--- a/projects/monolith/chat/summarizer.py
+++ b/projects/monolith/chat/summarizer.py
@@ -296,6 +296,116 @@ def on_startup(
             )
 
 
+def _agent_reply_context(
+    session: Session,
+    channel_id: str,
+    *,
+    recent_limit: int = 15,
+    max_users: int = 8,
+) -> str:
+    """Assemble a compact, channel-scoped context blurb for the agent concierge
+    reply.
+
+    Pulls the channel's rolling summary, the rolling per-user summaries of the
+    people around, and the last few messages. Every query filters on
+    ``channel_id``, so nothing authored outside this channel can enter the
+    context: the scope is provenance (where content was written), matching what
+    the requesting user can already read here. Returns "" when the channel has no
+    stored context yet (the caller then falls back to the deterministic summary).
+    """
+    parts: list[str] = []
+
+    channel_summary = session.exec(
+        select(ChannelSummary).where(ChannelSummary.channel_id == channel_id)
+    ).first()
+    if channel_summary and channel_summary.summary.strip():
+        parts.append(f"About this channel: {channel_summary.summary.strip()}")
+
+    user_summaries = session.exec(
+        select(UserChannelSummary)
+        .where(UserChannelSummary.channel_id == channel_id)
+        .order_by(UserChannelSummary.updated_at.desc())
+        .limit(max_users)
+    ).all()
+    people = "\n".join(
+        f"- {u.username}: {u.summary.strip()}"
+        for u in user_summaries
+        if u.summary.strip()
+    )
+    if people:
+        parts.append("People here:\n" + people)
+
+    recent = list(
+        session.exec(
+            select(Message)
+            .where(Message.channel_id == channel_id)
+            .order_by(Message.created_at.desc())
+            .limit(recent_limit)
+        ).all()
+    )
+    recent.reverse()  # oldest-first, chronological
+    convo = "\n".join(
+        f"{m.username}: {m.content.strip()}"
+        for m in recent
+        if m.content and m.content.strip()
+    )
+    if convo:
+        parts.append("Recent conversation:\n" + convo)
+
+    return "\n\n".join(parts)
+
+
+def _fetch_agent_reply_context(channel_id: str) -> str:
+    """Open a fresh session and build the concierge context (sync; via to_thread)."""
+    from app.db import get_engine
+
+    with Session(get_engine()) as session:
+        return _agent_reply_context(session, channel_id)
+
+
+def _build_agent_reply_prompt(summary: str, details: str, context: str) -> str:
+    """Prompt the concierge model to rephrase an agent run's typed result as a
+    natural channel reply. The URL is NOT part of this prompt: it is appended
+    deterministically by the caller so the model can never invent or mangle it."""
+    reported = f"Summary: {summary}"
+    if details:
+        reported += f"\nDetails: {details}"
+    ctx = context.strip() or "(no channel context available)"
+    return (
+        "You are the friendly assistant bot for this Discord channel. The coding "
+        "agent a member asked to run has just finished. Relay what it did to the "
+        "channel in your own voice: natural, warm, and specific, the way you would "
+        "in chat. Keep it to 2 to 4 sentences. Do not invent links, PR numbers, "
+        "file names, or any detail that is not in the agent's report below (any "
+        "link is posted separately). No markdown headers or bullet lists, no "
+        "preamble.\n\n"
+        f"What the agent reported:\n{reported}\n\n"
+        "Channel context, for tone and who is around (do not quote it back):\n"
+        f"{ctx}"
+    )
+
+
+async def conversational_agent_reply(
+    channel_id: str,
+    summary: str,
+    details: str = "",
+    *,
+    llm_call: Callable[[str], Awaitable[str]] | None = None,
+) -> str:
+    """Rephrase an agent run's typed summary as a conversational channel reply,
+    grounded in channel-scoped context.
+
+    Reuses the shared inference seam (``build_llm_caller`` -> Qwen). Raises on a
+    model failure so the caller can fall back to the deterministic summary; the
+    caller (the goose runner's ``_delivery_message``) is fail-open around this.
+    """
+    context = await asyncio.to_thread(_fetch_agent_reply_context, channel_id)
+    if llm_call is None:
+        llm_call = build_llm_caller()
+    prompt = _build_agent_reply_prompt(summary, details, context)
+    return await llm_call(prompt)
+
+
 _RETRYABLE_STATUS_CODES = {502, 503, 504}
 
 

--- a/projects/monolith/chat/summarizer_agent_reply_test.py
+++ b/projects/monolith/chat/summarizer_agent_reply_test.py
@@ -1,0 +1,169 @@
+"""Tests for the /agent conversational reply (concierge) in chat.summarizer.
+
+Covers the channel-scoped context assembly (the provenance guarantee: nothing
+authored outside the channel can enter the reply's context), the prompt shaping
+(no-invent instruction, URL kept out), and the async wiring around the injected
+LLM caller.
+"""
+
+from unittest.mock import AsyncMock
+
+import pytest
+from sqlmodel import Session, SQLModel, create_engine
+from sqlmodel.pool import StaticPool
+
+from chat.models import ChannelSummary, Message, UserChannelSummary
+from chat.summarizer import (
+    _agent_reply_context,
+    _build_agent_reply_prompt,
+    conversational_agent_reply,
+)
+
+
+@pytest.fixture(name="session")
+def session_fixture():
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    original_schemas = {}
+    for table in SQLModel.metadata.tables.values():
+        if table.schema is not None:
+            original_schemas[table.name] = table.schema
+            table.schema = None
+    SQLModel.metadata.create_all(engine)
+    with Session(engine) as session:
+        yield session
+    for table in SQLModel.metadata.tables.values():
+        if table.name in original_schemas:
+            table.schema = original_schemas[table.name]
+
+
+def _msg(session, channel_id, user_id, username, content, msg_id, is_bot=False):
+    m = Message(
+        id=msg_id,
+        discord_message_id=str(msg_id),
+        channel_id=channel_id,
+        user_id=user_id,
+        username=username,
+        content=content,
+        is_bot=is_bot,
+        embedding=[0.0] * 1024,
+    )
+    session.add(m)
+    session.commit()
+    return m
+
+
+class TestAgentReplyContext:
+    def test_includes_channel_and_user_summaries_and_recent(self, session):
+        _msg(session, "ch1", "u1", "Alice", "how's the deploy going?", 1)
+        _msg(session, "ch1", "u2", "Bob", "green across the board", 2)
+        session.add(
+            ChannelSummary(
+                channel_id="ch1",
+                summary="A homelab ops channel.",
+                message_count=2,
+                last_message_id=2,
+            )
+        )
+        session.add(
+            UserChannelSummary(
+                channel_id="ch1",
+                user_id="u1",
+                username="Alice",
+                summary="Alice runs the deploys.",
+                last_message_id=1,
+            )
+        )
+        session.commit()
+
+        ctx = _agent_reply_context(session, "ch1")
+
+        assert "A homelab ops channel." in ctx
+        assert "Alice: Alice runs the deploys." in ctx
+        assert "how's the deploy going?" in ctx
+        assert "Bob: green across the board" in ctx
+
+    def test_is_channel_scoped_by_provenance(self, session):
+        # Content authored in another channel must never leak into ch1's context,
+        # even the same user's summary in ch2.
+        _msg(session, "ch1", "u1", "Alice", "ch1 only message", 1)
+        _msg(session, "ch2", "u1", "Alice", "SECRET ch2 message", 2)
+        session.add(
+            ChannelSummary(
+                channel_id="ch2",
+                summary="SECRET ch2 channel summary.",
+                message_count=1,
+                last_message_id=2,
+            )
+        )
+        session.add(
+            UserChannelSummary(
+                channel_id="ch2",
+                user_id="u1",
+                username="Alice",
+                summary="SECRET ch2 user summary.",
+                last_message_id=2,
+            )
+        )
+        session.commit()
+
+        ctx = _agent_reply_context(session, "ch1")
+
+        assert "ch1 only message" in ctx
+        assert "SECRET" not in ctx
+
+    def test_empty_when_no_channel_data(self, session):
+        assert _agent_reply_context(session, "nope") == ""
+
+    def test_recent_is_chronological_and_limited(self, session):
+        for i in range(1, 21):
+            _msg(session, "ch1", "u1", "Alice", f"msg{i}", i)
+        ctx = _agent_reply_context(session, "ch1", recent_limit=5)
+        # Only the last 5, oldest-first.
+        assert "msg16" in ctx and "msg20" in ctx
+        assert "msg15" not in ctx
+        assert ctx.index("msg16") < ctx.index("msg20")
+
+
+class TestBuildAgentReplyPrompt:
+    def test_carries_summary_details_and_context(self):
+        prompt = _build_agent_reply_prompt(
+            "Opened a PR.", "Added a guard and a test.", "About this channel: ops."
+        )
+        assert "Opened a PR." in prompt
+        assert "Added a guard and a test." in prompt
+        assert "About this channel: ops." in prompt
+
+    def test_instructs_no_invention_and_omits_url(self):
+        prompt = _build_agent_reply_prompt("Done.", "", "ctx")
+        assert "Do not invent" in prompt
+        # The URL is appended by the caller, so the model prompt must not carry it.
+        assert "http" not in prompt
+
+    def test_tolerates_empty_context(self):
+        prompt = _build_agent_reply_prompt("Done.", "", "")
+        assert "no channel context available" in prompt
+
+
+class TestConversationalAgentReply:
+    async def test_calls_llm_with_built_prompt(self, monkeypatch):
+        import chat.summarizer as summarizer
+
+        monkeypatch.setattr(
+            summarizer,
+            "_fetch_agent_reply_context",
+            lambda channel_id: "About this channel: ops.",
+        )
+        mock_llm = AsyncMock(return_value="  All wrapped up.  ")
+
+        out = await conversational_agent_reply(
+            "ch1", "Opened a PR.", "guard + test", llm_call=mock_llm
+        )
+
+        assert out == "  All wrapped up.  "  # caller trims; this returns raw
+        (prompt,), _ = mock_llm.call_args
+        assert "Opened a PR." in prompt
+        assert "About this channel: ops." in prompt

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.247.0
+      targetRevision: 0.248.0
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/goosecracker/runner.py
+++ b/projects/monolith/goosecracker/runner.py
@@ -276,6 +276,37 @@ def _agent_narrative(result: str) -> str:
     return body or "(no output)"
 
 
+async def _agent_reply_message(session: str, summary: str, details: str) -> str:
+    """Compose the conversational reply for a coding-agent run.
+
+    Rephrases goose's typed ``summary`` (+ optional ``details``) in the bot's own
+    voice, grounded in the parent channel's context (recent messages + rolling
+    summaries), so the reply reads like the bot talking to the channel rather than
+    a raw tool dump. The result URL is appended by the caller, never by the model.
+
+    Fail-open: the reply must always go out, so any missing channel id, model
+    outage, or error yields the deterministic ``summary``/``details`` composition
+    (exactly what this path posted before the concierge existed). Reaches the chat
+    domain only through ``chat.api`` (import_boundaries_test).
+    """
+    deterministic = summary + (f"\n\n{details}" if details else "")
+    try:
+        from chat.api import conversational_agent_reply, parent_channel_for_thread
+
+        # nosemgrep: no-session-in-to-thread  # `session` is the fc-invoke session-id string, not a SQLAlchemy Session
+        parent = await asyncio.to_thread(parent_channel_for_thread, session)
+        if not parent:
+            return deterministic
+        reply = (await conversational_agent_reply(parent, summary, details)).strip()
+        return reply or deterministic
+    except Exception:
+        logger.exception(
+            "goosecracker: conversational reply failed for %s; using raw summary",
+            session,
+        )
+        return deterministic
+
+
 async def _delivery_message(session: str, recipe: str, data: dict) -> str:
     """Build the Discord message for a successful run.
 
@@ -318,10 +349,11 @@ async def _delivery_message(session: str, recipe: str, data: dict) -> str:
         result = data.get("result", "") or ""
         structured = _parse_structured_result(result)
         if structured and str(structured.get("summary", "")).strip():
-            msg = str(structured["summary"]).strip()
+            summary = str(structured["summary"]).strip()
             details = str(structured.get("details", "") or "").strip()
-            if details:
-                msg += f"\n\n{details}"
+            # Rephrase the typed summary conversationally (channel-scoped context),
+            # then append the URL deterministically so it can never be mangled.
+            msg = await _agent_reply_message(session, summary, details)
             url = str(structured.get("url", "") or "").strip()
             if url.startswith("http"):
                 msg += f"\n{url}"

--- a/projects/monolith/goosecracker/tests/runner_test.py
+++ b/projects/monolith/goosecracker/tests/runner_test.py
@@ -560,3 +560,82 @@ async def test_run_one_turn_resets_progress_buffer_at_start(monkeypatch):
 
     assert ok is False  # fail-fast path (no FC_INVOKE_URL)
     reset_spy.assert_called_once_with("sess-x")  # buffer reset before the turn ran
+
+
+# ---------------------------------------------------------------------------
+# Conversational reply (_agent_reply_message): rephrase the typed summary in the
+# bot's voice using channel context, fail-open to the deterministic summary.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _default_no_parent_channel(monkeypatch):
+    """Keep the coding-agent delivery tests hermetic.
+
+    _agent_reply_message calls chat.api.parent_channel_for_thread; with no parent
+    it returns the deterministic summary and never touches the DB or the model.
+    Default it to "" so every existing agent-delivery test exercises that path
+    without a stray Postgres connect; the concierge tests below override it.
+    """
+    import chat.api
+
+    monkeypatch.setattr(chat.api, "parent_channel_for_thread", lambda _t: "")
+
+
+async def test_agent_reply_message_uses_conversational_when_parent(monkeypatch):
+    import chat.api
+
+    monkeypatch.setattr(chat.api, "parent_channel_for_thread", lambda _t: "chan-1")
+
+    async def fake_reply(channel_id, summary, details="", **_kw):
+        assert channel_id == "chan-1"
+        assert summary == "Added a null check in parse()."
+        return "Hey, I slipped in that null check you asked for."
+
+    monkeypatch.setattr(chat.api, "conversational_agent_reply", fake_reply)
+
+    msg = await runner._agent_reply_message("s-1", "Added a null check in parse().", "")
+    assert msg == "Hey, I slipped in that null check you asked for."
+
+
+async def test_agent_reply_message_falls_back_without_parent():
+    # autouse fixture forces parent="" -> deterministic summary + details.
+    msg = await runner._agent_reply_message("s-1", "Fixed it.", "Added a guard.")
+    assert msg == "Fixed it.\n\nAdded a guard."
+
+
+async def test_agent_reply_message_fails_open_on_model_error(monkeypatch):
+    import chat.api
+
+    monkeypatch.setattr(chat.api, "parent_channel_for_thread", lambda _t: "chan-1")
+
+    async def boom(*_a, **_kw):
+        raise RuntimeError("model down")
+
+    monkeypatch.setattr(chat.api, "conversational_agent_reply", boom)
+
+    msg = await runner._agent_reply_message("s-1", "Fixed it.", "Added a guard.")
+    assert msg == "Fixed it.\n\nAdded a guard."
+
+
+async def test_delivery_message_agent_appends_url_after_conversational(monkeypatch):
+    # The conversational reply replaces the raw summary/details, but the URL is
+    # still appended deterministically (never routed through the model).
+    import chat.api
+
+    monkeypatch.setattr(chat.api, "parent_channel_for_thread", lambda _t: "chan-1")
+
+    async def fake_reply(channel_id, summary, details="", **_kw):
+        return "All done, opened a PR for you."
+
+    monkeypatch.setattr(chat.api, "conversational_agent_reply", fake_reply)
+
+    result = (
+        '{"type": "pr", "summary": "Fixed the parser.", '
+        '"details": "guard + test", '
+        '"url": "https://github.com/jomcgi/homelab/pull/99"}'
+    )
+    msg = await runner._delivery_message("s-10", "agent", {"result": result})
+    assert msg.startswith("All done, opened a PR for you.")
+    assert "https://github.com/jomcgi/homelab/pull/99" in msg
+    assert "guard + test" not in msg  # raw details replaced by the conversational reply


### PR DESCRIPTION
## What

Two additions to the Discord `/agent` (goosecracker) flow, using the existing chat bot's channel knowledge.

### 1. Conversational concierge reply
After a coding-agent run finishes, the bot rephrases goose's typed `summary`/`details` in its own voice, grounded in **channel-scoped context** (recent messages + rolling per-user and per-channel summaries), instead of posting raw tool output.

- **URL stays deterministic:** the result link is read from goose's structured JSON and appended *after* the model call, never routed through the LLM, so a link can't be hallucinated.
- **Fail-open:** a missing parent channel, a model outage, or any exception falls back to the previous deterministic summary. A reply always ships.
- **Provenance-scoped:** every context query filters on the parent channel id, so nothing authored outside that channel enters the reply. Reuses the guarantee the chat bot already relies on; crosses no credential tier.

### 2. Prompt echo
The full `/agent` prompt is echoed into the thread (fenced, attributed with a mention), since the thread title truncates it to ~90 chars. User input is fence-escaped (zero-width space woven through backticks) and capped to one Discord message.

## How it's wired
- New `parent_channel_id` column on `chat.goosecracker_sessions` (the `/agent` thread has no history of its own). Stored by `start_agent_session`, read at delivery via `chat.api.parent_channel_for_thread`, so it survives a cross-process reclaim.
- The concierge summary lives in `chat/summarizer.py` and reuses the existing `build_llm_caller` (Qwen) inference seam.
- The runner reaches chat only through the `chat.api` facade via lazy imports (keeps `import_boundaries` intact).

## Tests
- Channel scoping incl. a negative "same user, other channel does not leak" assertion.
- `parent_channel_id` write to read round-trip through the real getter.
- Fail-open across no-parent / model-error / happy paths; URL still appended after the conversational reply.
- Fence escaping + 2000-char cap on the prompt echo.

## Deploy
Chart bumped `0.247.0 -> 0.248.0` (`Chart.yaml` + `application.yaml` targetRevision), migration `20260702170000` + `atlas.sum`.

> Note: the two new test files need gazelle `py_test` targets; leaving them for the CI format-bot to generate (its auto-commit re-triggers the run that executes them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)