### PR TITLE
feat(goosecracker): ADR 035 phase 1 - structured stage progress + live checklist

### DIFF
--- a/projects/firecracker/goosecracker/guest/recipes/agent.yaml
+++ b/projects/firecracker/goosecracker/guest/recipes/agent.yaml
@@ -41,7 +41,9 @@ instructions: |
     run BOTH steps as delegated subagents, using the `delegate` tool, so that the
     design bar, the JavaScript parse gate and the fresh-eyes review actually run.
     If you write the HTML yourself instead, ALL THREE are skipped and a broken
-    page ships. The steps, in order, each waiting for the result:
+    page ships. Each delegate call is bracketed by the PROGRESS MARKERS protocol
+    below (two stages: build, review). The steps, in order, each waiting for the
+    result:
       1. `delegate(source: "artifact-build")` and WAIT. That subagent reads the
          task from /tmp/goose/task.md and writes the page to /tmp/artifact.html.
       2. `delegate(source: "artifact-review")` and WAIT. That subagent reads
@@ -89,6 +91,35 @@ instructions: |
   it short; if you have nothing useful to add, leave the file untouched. Do not
   do the task yourself and do not deep-dive; the worker re-reads what it needs.
 
+  PROGRESS MARKERS (required, not optional). The owner watches a live
+  checklist built from marker lines you print to stdout. Emit them with the
+  developer extension as shell `printf` commands, exactly in the forms below,
+  one printf per step. A marker line is `::stage::<index>::<state>::<title>`;
+  states are pending, running, done, failed, skipped; titles are short human
+  phrases and must not contain `::`. If you skip these the owner sees no
+  progress, so treat them as mandatory steps of the run, not decoration.
+  Never write markers as prose in your reply; only ever via printf.
+
+  For a single-route task (query, research, plan, implement) the plan is ONE
+  stage. Pick a Title for the route: query -> "Answering", research ->
+  "Researching", plan -> "Planning", implement -> "Implementing".
+    1. Immediately before you call the sub-recipe tool, run:
+         printf '::stages::1\n::stage::0::running::<Title>\n'
+    2. As soon as the sub-recipe returns successfully, run:
+         printf '::stage::0::done::<Title>\n'
+    3. If it fails or you must abort, run instead:
+         printf '::stage::0::failed::<short reason, one line, no ::>\n'
+
+  For an artifact task the plan is TWO stages (build, then review):
+    1. Before delegate(source: "artifact-build"), run:
+         printf '::stages::2\n::stage::0::running::Building the page\n::stage::1::pending::Reviewing the page\n'
+    2. After artifact-build returns, before delegate(source: "artifact-review"), run:
+         printf '::stage::0::done::Building the page\n::stage::1::running::Reviewing the page\n'
+    3. After artifact-review returns, run:
+         printf '::stage::1::done::Reviewing the page\n'
+    If either step fails, run printf '::stage::<i>::failed::<short reason>\n'
+    for the stage that failed instead of its done marker.
+
   Dispatch the actual work; never run it in the router. Your context is
   shared across the whole thread, so a large tool output here (a full
   `git log`, a wide `grep`, a big file) can overflow it and trigger a
@@ -98,10 +129,11 @@ instructions: |
   you do read (pipe through `head`, count with `wc -l` first, sample) and
   never pull hundreds of log lines into your context.
 
-  Then call the matching sub-recipe tool and wait for its result. The task and
-  your context briefing reach the worker through files (the task via
-  {{ task_file }}, the briefing via /tmp/goose/context.md), pre-wired on each
-  sub-recipe, so you do not pass them as tool arguments.
+  Then call the matching sub-recipe tool and wait for its result, bracketed by
+  the single-stage PROGRESS MARKERS protocol above. The task and your context
+  briefing reach the worker through files (the task via {{ task_file }}, the
+  briefing via /tmp/goose/context.md), pre-wired on each sub-recipe, so you do
+  not pass them as tool arguments.
 
   When it returns, produce the structured result enforced by the response
   schema below, from the sub-recipe's output: a short `summary` of the

--- a/projects/firecracker/substrate/chart/Chart.yaml
+++ b/projects/firecracker/substrate/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: fc-invoke
 description: Node-affine Firecracker invoke daemon that dispatches HTTP invocations to a pool of warm-base microVMs across named workloads (POST /invoke/{workload}, GET /healthz)
 type: application
-version: 0.4.24
+version: 0.4.25

--- a/projects/firecracker/substrate/deploy/application.yaml
+++ b/projects/firecracker/substrate/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tags pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: fc-invoke
-      targetRevision: 0.4.24
+      targetRevision: 0.4.25
       helm:
         valueFiles:
           - $values/projects/firecracker/substrate/deploy/values.yaml

--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -1356,6 +1356,7 @@ py_test(
         ":monolith_backend",
         "@pip//discord_py",
         "@pip//pytest",
+        "@pip//pytest_asyncio",
     ],
 )
 

--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -855,6 +855,16 @@ py_test(
 )
 
 py_test(
+    name = "chat_goosecracker_progress_stages_test",
+    srcs = ["chat/goosecracker_progress_stages_test.py"],
+    imports = ["."],
+    deps = [
+        ":monolith_backend",
+        "@pip//pytest",
+    ],
+)
+
+py_test(
     name = "chat_web_search_test",
     srcs = ["chat/web_search_test.py"],
     imports = ["."],

--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -952,6 +952,20 @@ py_test(
 )
 
 py_test(
+    name = "chat_bot_checklist_render_test",
+    srcs = ["chat/bot_checklist_render_test.py"],
+    imports = ["."],
+    deps = [
+        ":monolith_backend",
+        "@pip//discord_py",
+        "@pip//pydantic_ai_slim",
+        "@pip//pytest",
+        "@pip//pytest_asyncio",
+        "@pip//sqlmodel",
+    ],
+)
+
+py_test(
     name = "chat_web_search_coverage_test",
     srcs = ["chat/web_search_coverage_test.py"],
     imports = ["."],

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.248.0
+version: 0.249.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chat/bot.py
+++ b/projects/monolith/chat/bot.py
@@ -704,7 +704,8 @@ class ChatBot(discord.Client):
 
         await interaction.followup.send(f"Building your artifact in {thread.mention}")
         try:
-            intro = await thread.send("🛠 On it. Building your artifact now...")
+            # ADR 035: see the matching comment in _handle_agent_command.
+            intro = await thread.send("🛠 Planning...")
             self._start_goosecracker_stream(str(thread.id), intro)
         except Exception:
             logger.exception("goosecracker: failed to post thread intro")
@@ -778,7 +779,11 @@ class ChatBot(discord.Client):
         except Exception:
             logger.exception("goosecracker: failed to post agent prompt echo")
         try:
-            intro = await thread.send("🤖 On it. Running the agent now...")
+            # ADR 035: a bare "Planning..." placeholder, not a progress claim.
+            # render_checklist takes over once the run announces its stage
+            # plan; until then the tail renderer shows "Thinking", so this is
+            # only the very first beat.
+            intro = await thread.send("🤖 Planning...")
             self._start_goosecracker_stream(str(thread.id), intro, kind="agent")
         except Exception:
             logger.exception("goosecracker: failed to post agent thread intro")
@@ -945,16 +950,16 @@ class ChatBot(discord.Client):
 
         if action == "dispatched":
             # Agent thread: a new turn was dispatched (session was idle).
-            progress_msg = await message.reply("🤖 On it. Running the agent now...")
+            # ADR 035: see the matching comment in _handle_agent_command.
+            progress_msg = await message.reply("🤖 Planning...")
             self._start_goosecracker_stream(thread_id, progress_msg, kind="agent")
             await asyncio.to_thread(self._complete_lock, msg_id)
             return True
 
         # Artifact path: continue_session returned the raw submit result dict
         # (action is "create" or "resume" from threads.upsert_run).
-        progress_msg = await message.reply(
-            "🛠 On it. Rebuilding your artifact; the link above will hot-reload..."
-        )
+        # ADR 035: see the matching comment in _handle_agent_command.
+        progress_msg = await message.reply("🛠 Planning...")
         self._start_goosecracker_stream(thread_id, progress_msg)
         await asyncio.to_thread(self._complete_lock, msg_id)
         return True

--- a/projects/monolith/chat/bot.py
+++ b/projects/monolith/chat/bot.py
@@ -131,6 +131,82 @@ def _render_goosecracker_progress(snap, elapsed: int, kind: str = "artifact") ->
     return "\n".join(lines)[:DISCORD_MESSAGE_LIMIT]
 
 
+# ADR 035: stage-marker checklist renderer, an alternative to the raw-tail
+# renderer above for recipes that announce a structured plan. Edits gated on
+# this path use stages_version/done rather than body diffing (see
+# _should_edit_checklist), so render_checklist must stay pure and time-free:
+# identical stage state has to produce byte-identical output.
+_STAGE_EMOJI = {
+    "pending": "⬜",
+    "running": "🔄",
+    "done": "✅",
+    "failed": "❌",
+    "skipped": "⏭️",
+}
+# Leave headroom under DISCORD_MESSAGE_LIMIT before collapsing, so the
+# collapse summary line itself never pushes the render over the hard cap.
+_CHECKLIST_COLLAPSE_AT = 1900
+GOOSECRACKER_CHECKLIST_MIN_EDIT_INTERVAL = 2.0  # coalesce checklist edits
+
+
+def render_checklist(progress) -> str | None:
+    """Render a stage checklist from a progress snapshot, or None to fall back.
+
+    ``progress`` is a chat.goosecracker_progress.Progress or None. Returns
+    None when there is no stage plan to show (no snapshot yet, or a recipe
+    that never emits stage markers), which tells the caller to use the
+    original tail renderer (_render_goosecracker_progress) instead.
+
+    One line per stage, emoji by state. A failed stage's title already carries
+    its one-line reason (the marker producer puts it there), so it is rendered
+    as-is. When the full render would exceed _CHECKLIST_COLLAPSE_AT chars, the
+    oldest contiguous run of already-completed stages (done/skipped) is folded
+    into a single "N earlier stages" line; running/pending/failed stages are
+    never collapsed, since those are what the owner needs to see.
+    """
+    if progress is None or not progress.stages:
+        return None
+
+    header = "✅ **Done**" if progress.done else "🤖 **Working**"
+    lines = [header]
+    if progress.notice and not progress.done:
+        lines.append(progress.notice)
+
+    stage_lines = [
+        f"{_STAGE_EMOJI.get(s.state, '⬜')} {s.title}" for s in progress.stages
+    ]
+    body = "\n".join(lines + stage_lines)
+
+    collapsed = 0
+    while len(body) > _CHECKLIST_COLLAPSE_AT and collapsed < len(progress.stages):
+        if progress.stages[collapsed].state not in ("done", "skipped"):
+            break
+        collapsed += 1
+        summary = [f"✅ {collapsed} earlier stages"]
+        body = "\n".join(lines + summary + stage_lines[collapsed:])
+
+    return body[:DISCORD_MESSAGE_LIMIT]
+
+
+def _should_edit_checklist(
+    stages_version: int,
+    last_stages_version: int,
+    done: bool,
+    last_done: bool,
+    now: float,
+    last_edit_at: float,
+) -> bool:
+    """True when the checklist stream loop should edit the Discord message now.
+
+    Gates on stages_version/done changing (render_checklist is time-free by
+    design, so body diffing would defeat the point) and coalesces to at most
+    once per GOOSECRACKER_CHECKLIST_MIN_EDIT_INTERVAL seconds, so a burst of
+    marker updates collapses into one edit instead of one per poll.
+    """
+    changed = stages_version != last_stages_version or done != last_done
+    return changed and (now - last_edit_at) >= GOOSECRACKER_CHECKLIST_MIN_EDIT_INTERVAL
+
+
 _fact_check_agent = None
 
 
@@ -736,24 +812,67 @@ class ChatBot(discord.Client):
         and re-renders on a fixed cadence, so Discord edits stay within rate
         limits. The final ``Artifact ready: <url>`` link is posted separately by
         the controller's Done -> outbox path (ADR 024 Task 5).
+
+        ADR 035: once a run announces a stage plan, render_checklist takes over
+        from the raw tail renderer and edits switch from "whenever the rendered
+        body changes" to stages_version/done gating (_should_edit_checklist), so
+        a burst of marker updates coalesces into one Discord edit. Runs that
+        never emit markers keep the original tail-renderer behaviour untouched.
         """
         gp = goosecracker_progress
         start = time.monotonic()
         last_body = message.content
+        last_stages_version = -1
+        last_done = False
+        last_edit_at = 0.0
         while True:
             await asyncio.sleep(GOOSECRACKER_STREAM_INTERVAL)
+            now = time.monotonic()
             snap = gp.get(artifact_id)
-            elapsed = int(time.monotonic() - start)
-            body = _render_goosecracker_progress(snap, elapsed, kind)
-            if body != last_body:
+            elapsed = int(now - start)
+            checklist = render_checklist(snap)
+
+            if checklist is None:
+                body = _render_goosecracker_progress(snap, elapsed, kind)
+                if body != last_body:
+                    try:
+                        await message.edit(content=body)
+                        last_body = body
+                    except discord.HTTPException:
+                        logger.exception(
+                            "goosecracker: progress edit failed for %s", artifact_id
+                        )
+            elif _should_edit_checklist(
+                snap.stages_version,
+                last_stages_version,
+                snap.done,
+                last_done,
+                now,
+                last_edit_at,
+            ):
                 try:
-                    await message.edit(content=body)
-                    last_body = body
+                    await message.edit(content=checklist)
+                    last_body = checklist
+                    last_edit_at = now
                 except discord.HTTPException:
                     logger.exception(
                         "goosecracker: progress edit failed for %s", artifact_id
                     )
+                last_stages_version = snap.stages_version
+                last_done = snap.done
+
             if snap is not None and snap.done:
+                if checklist is not None:
+                    # The coalescing gate above may have just swallowed the
+                    # done transition; force it through so the terminal
+                    # checklist is never dropped.
+                    try:
+                        await message.edit(content=checklist)
+                    except discord.HTTPException:
+                        logger.exception(
+                            "goosecracker: final progress edit failed for %s",
+                            artifact_id,
+                        )
                 gp.clear(artifact_id)
                 return
             if elapsed >= GOOSECRACKER_STREAM_TIMEOUT:

--- a/projects/monolith/chat/bot.py
+++ b/projects/monolith/chat/bot.py
@@ -836,6 +836,7 @@ class ChatBot(discord.Client):
             snap = gp.get(artifact_id)
             elapsed = int(now - start)
             checklist = render_checklist(snap)
+            edited_now = False
 
             if checklist is None:
                 body = _render_goosecracker_progress(snap, elapsed, kind)
@@ -857,20 +858,25 @@ class ChatBot(discord.Client):
             ):
                 try:
                     await message.edit(content=checklist)
+                    # Advance the delivered markers only after a successful
+                    # edit, so a transient HTTPException retries on the next
+                    # poll instead of marking this version delivered unseen.
                     last_body = checklist
                     last_edit_at = now
+                    last_stages_version = snap.stages_version
+                    last_done = snap.done
+                    edited_now = True
                 except discord.HTTPException:
                     logger.exception(
                         "goosecracker: progress edit failed for %s", artifact_id
                     )
-                last_stages_version = snap.stages_version
-                last_done = snap.done
 
             if snap is not None and snap.done:
-                if checklist is not None:
-                    # The coalescing gate above may have just swallowed the
-                    # done transition; force it through so the terminal
-                    # checklist is never dropped.
+                if checklist is not None and not edited_now:
+                    # The coalescing gate above may have swallowed the done
+                    # transition (or its edit failed); force it through so the
+                    # terminal checklist is never dropped. Skip when this poll
+                    # already edited the done checklist, to avoid a duplicate.
                     try:
                         await message.edit(content=checklist)
                     except discord.HTTPException:

--- a/projects/monolith/chat/bot_agent_prompt_echo_test.py
+++ b/projects/monolith/chat/bot_agent_prompt_echo_test.py
@@ -3,11 +3,20 @@
 The prompt otherwise survives only in the ~90-char thread title, so the echo
 posts it in full. Covers attribution, code-fence escaping (the prompt is
 user-controlled and must not break out of the block), and the 2000-char cap.
+
+Also covers the ADR 035 ack/checklist split in _handle_agent_command: the
+prompt echo (message A) must never be the message handed to the streaming
+progress editor (message B), so the echo stays put while the checklist
+above it gets live-edited.
 """
 
 from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
 
-from chat.bot import _PROMPT_ECHO_MAX, _format_agent_prompt_echo
+import discord
+import pytest
+
+from chat.bot import ChatBot, _PROMPT_ECHO_MAX, _format_agent_prompt_echo
 
 _USER = SimpleNamespace(mention="<@123>")
 
@@ -38,3 +47,59 @@ def test_short_prompt_not_truncated():
     out = _format_agent_prompt_echo(_USER, "tiny")
     assert "…" not in out
     assert out.count("tiny") == 1
+
+
+def _make_bot() -> ChatBot:
+    """Build a ChatBot with mocked internals, same pattern as bot_streaming_test.py."""
+    with (
+        patch("chat.bot.EmbeddingClient") as mock_ec,
+        patch("chat.bot.create_agent") as mock_ca,
+    ):
+        mock_ec.return_value = AsyncMock()
+        mock_ca.return_value = MagicMock()
+        return ChatBot()
+
+
+@pytest.mark.asyncio
+async def test_handle_agent_command_never_streams_the_prompt_echo():
+    """The prompt echo (message A) and the streamed checklist placeholder
+    (message B) are two distinct thread.send() calls, and only B is handed to
+    _start_goosecracker_stream. This locks in the split an earlier PR (#3096)
+    already made, so a future edit can't collapse them back into one message."""
+    bot = _make_bot()
+    bot._start_goosecracker_stream = MagicMock()
+
+    interaction = MagicMock()
+    interaction.guild_id = 555
+    interaction.user.id = 42
+    interaction.user.mention = "<@42>"
+    interaction.response.defer = AsyncMock()
+    interaction.followup.send = AsyncMock()
+
+    channel = MagicMock(spec=discord.TextChannel)
+    interaction.channel = channel
+
+    thread = MagicMock()
+    thread.id = 777
+    thread.mention = "<#777>"
+    echo_msg = MagicMock(name="echo_msg")
+    intro_msg = MagicMock(name="intro_msg")
+    thread.send = AsyncMock(side_effect=[echo_msg, intro_msg])
+    channel.create_thread = AsyncMock(return_value=thread)
+
+    with (
+        patch("chat.bot.acl.feature_enabled", return_value=True),
+        patch("chat.bot.acl.is_granted", return_value=True),
+        patch("chat.bot.goosecracker.start_agent_session"),
+    ):
+        await bot._handle_agent_command(interaction, "add a health check", "some/repo")
+
+    assert thread.send.call_count == 2
+    echo_call_content = thread.send.call_args_list[0][0][0]
+    assert echo_call_content.startswith("Prompt from <@42>:")
+
+    # Only the second thread.send() result (the placeholder) is streamed; the
+    # ack is never touched by the editor.
+    bot._start_goosecracker_stream.assert_called_once_with(
+        str(thread.id), intro_msg, kind="agent"
+    )

--- a/projects/monolith/chat/bot_checklist_render_test.py
+++ b/projects/monolith/chat/bot_checklist_render_test.py
@@ -191,7 +191,7 @@ class TestShouldEditChecklistGating:
 
     def test_rapid_version_bumps_within_window_coalesce_to_one_edit(self):
         """Two version bumps arriving within 2s of each other, and of the last
-        edit, must not each trigger an edit — only the first (or a later poll
+        edit, must not each trigger an edit, only the first (or a later poll
         once the window has passed) does."""
         last_stages_version = -1
         last_done = False

--- a/projects/monolith/chat/bot_checklist_render_test.py
+++ b/projects/monolith/chat/bot_checklist_render_test.py
@@ -1,0 +1,326 @@
+"""Tests for the ADR 035 stage checklist renderer and edit-coalescing gate."""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import discord
+
+from chat import goosecracker_progress as gp
+from chat.bot import (
+    DISCORD_MESSAGE_LIMIT,
+    ChatBot,
+    _should_edit_checklist,
+    render_checklist,
+)
+
+
+def _stage(index, title, state):
+    return gp.Stage(index=index, title=title, state=state)
+
+
+def _progress(stages, done=False, notice=""):
+    return gp.Progress(stages=stages, done=done, notice=notice)
+
+
+# ---------------------------------------------------------------------------
+# render_checklist
+# ---------------------------------------------------------------------------
+
+
+class TestRenderChecklistFallback:
+    def test_none_progress_returns_none(self):
+        """No snapshot yet: fall back to the tail renderer."""
+        assert render_checklist(None) is None
+
+    def test_no_stages_returns_none(self):
+        """A run that never emits stage markers falls back to the tail renderer."""
+        assert render_checklist(_progress(stages=[])) is None
+
+
+class TestRenderChecklistStates:
+    def test_each_state_gets_its_emoji(self):
+        # A failed stage's one-line reason is carried in the title by the
+        # marker producer, so the renderer just shows the title as-is.
+        stages = [
+            _stage(0, "Plan", "pending"),
+            _stage(1, "Fetch data", "running"),
+            _stage(2, "Write file", "done"),
+            _stage(3, "Deploy (connection refused)", "failed"),
+            _stage(4, "Notify", "skipped"),
+        ]
+        body = render_checklist(_progress(stages))
+
+        assert "⬜ Plan" in body
+        assert "🔄 Fetch data" in body
+        assert "✅ Write file" in body
+        assert "❌ Deploy (connection refused)" in body
+        assert "⏭️ Notify" in body
+
+    def test_header_working_when_not_done(self):
+        body = render_checklist(_progress([_stage(0, "Plan", "running")]))
+        assert "Working" in body
+
+    def test_header_done_when_progress_done(self):
+        body = render_checklist(_progress([_stage(0, "Plan", "done")], done=True))
+        assert "Done" in body
+
+    def test_notice_shown_while_not_done(self):
+        body = render_checklist(
+            _progress(
+                [_stage(0, "Plan", "pending")], notice="retrying a transient failure"
+            )
+        )
+        assert "retrying a transient failure" in body
+
+    def test_notice_hidden_once_done(self):
+        body = render_checklist(
+            _progress(
+                [_stage(0, "Plan", "done")], done=True, notice="stale retry notice"
+            )
+        )
+        assert "stale retry notice" not in body
+
+
+class TestRenderChecklistIsTimeFree:
+    def test_identical_progress_renders_identically(self):
+        """No wall-clock component: same stage state -> byte-identical output.
+
+        This is what lets the stream loop gate edits on stages_version alone.
+        """
+        stages = [_stage(0, "Plan", "running")]
+        first = render_checklist(_progress(stages))
+        second = render_checklist(_progress(stages))
+        assert first == second
+
+
+class TestRenderChecklistCollapse:
+    def test_long_completed_run_collapses_to_earlier_stages_line(self):
+        # Enough long-titled done stages to blow past 1900 chars, plus an
+        # active window that must survive collapsing.
+        done_stages = [
+            _stage(i, f"Completed step number {i} with a fairly long title", "done")
+            for i in range(60)
+        ]
+        active_stages = [
+            _stage(60, "Currently running step", "running"),
+            _stage(61, "Not started yet", "pending"),
+        ]
+        body = render_checklist(_progress(done_stages + active_stages))
+
+        assert "earlier stages" in body
+        assert "Currently running step" in body
+        assert "Not started yet" in body
+        assert len(body) <= DISCORD_MESSAGE_LIMIT
+
+    def test_never_exceeds_discord_message_limit(self):
+        # Even with an enormous active window that alone can't be collapsed,
+        # the hard cap must still apply.
+        active_stages = [
+            _stage(i, f"Running step {i} " * 20, "running") for i in range(20)
+        ]
+        body = render_checklist(_progress(active_stages))
+        assert len(body) <= DISCORD_MESSAGE_LIMIT
+
+    def test_never_collapses_running_pending_or_failed(self):
+        stages = [_stage(i, f"Done step {i} " * 10, "done") for i in range(50)]
+        stages.append(_stage(50, "Active step", "running"))
+        stages.append(_stage(51, "Failed step (boom)", "failed"))
+        stages.append(_stage(52, "Pending step", "pending"))
+        body = render_checklist(_progress(stages))
+
+        assert "Active step" in body
+        assert "Failed step (boom)" in body
+        assert "Pending step" in body
+
+
+# ---------------------------------------------------------------------------
+# _should_edit_checklist gating
+# ---------------------------------------------------------------------------
+
+
+class TestShouldEditChecklistGating:
+    def test_first_change_after_min_interval_edits(self):
+        assert _should_edit_checklist(
+            stages_version=1,
+            last_stages_version=-1,
+            done=False,
+            last_done=False,
+            now=100.0,
+            last_edit_at=0.0,
+        )
+
+    def test_no_change_does_not_edit(self):
+        assert not _should_edit_checklist(
+            stages_version=1,
+            last_stages_version=1,
+            done=False,
+            last_done=False,
+            now=200.0,
+            last_edit_at=0.0,
+        )
+
+    def test_change_within_min_interval_is_coalesced(self):
+        assert not _should_edit_checklist(
+            stages_version=2,
+            last_stages_version=1,
+            done=False,
+            last_done=False,
+            now=100.5,
+            last_edit_at=100.0,
+        )
+
+    def test_change_after_min_interval_edits(self):
+        assert _should_edit_checklist(
+            stages_version=2,
+            last_stages_version=1,
+            done=False,
+            last_done=False,
+            now=102.0,
+            last_edit_at=100.0,
+        )
+
+    def test_done_flip_alone_triggers_edit(self):
+        assert _should_edit_checklist(
+            stages_version=1,
+            last_stages_version=1,
+            done=True,
+            last_done=False,
+            now=102.0,
+            last_edit_at=100.0,
+        )
+
+    def test_rapid_version_bumps_within_window_coalesce_to_one_edit(self):
+        """Two version bumps arriving within 2s of each other, and of the last
+        edit, must not each trigger an edit — only the first (or a later poll
+        once the window has passed) does."""
+        last_stages_version = -1
+        last_done = False
+        last_edit_at = 0.0
+        edits = 0
+
+        # poll 1: version 0 -> 1, far past the window -> edits
+        if _should_edit_checklist(
+            1, last_stages_version, False, last_done, 100.0, last_edit_at
+        ):
+            edits += 1
+            last_stages_version, last_done, last_edit_at = 1, False, 100.0
+
+        # poll 2: version 1 -> 2, only 0.5s later -> coalesced, no edit
+        if _should_edit_checklist(
+            2, last_stages_version, False, last_done, 100.5, last_edit_at
+        ):
+            edits += 1
+            last_stages_version, last_done, last_edit_at = 2, False, 100.5
+
+        # poll 3: still version 2 (no new bump), only 0.9s after the last edit -> no edit
+        if _should_edit_checklist(
+            2, last_stages_version, False, last_done, 100.9, last_edit_at
+        ):
+            edits += 1
+            last_stages_version, last_done, last_edit_at = 2, False, 100.9
+
+        assert edits == 1
+        # The coalesced version bump (2) was never recorded as edited, proving
+        # it was swallowed rather than double-counted.
+        assert last_stages_version == 1
+
+
+# ---------------------------------------------------------------------------
+# Full loop integration: the terminal checklist must never be dropped by the
+# 2s coalescing gate.
+# ---------------------------------------------------------------------------
+
+
+def _make_bot() -> ChatBot:
+    with (
+        patch("chat.bot.EmbeddingClient") as mock_ec,
+        patch("chat.bot.create_agent") as mock_ca,
+    ):
+        mock_ec.return_value = AsyncMock()
+        mock_ca.return_value = MagicMock()
+        bot = ChatBot()
+    return bot
+
+
+class TestStreamLoopFinalEditNeverDropped:
+    @pytest.mark.asyncio
+    async def test_done_transition_within_gate_window_still_lands(self):
+        """A poll that flips done within the 2s gate is coalesced on the normal
+        edit path, but the unconditional final edit must still deliver it."""
+        bot = _make_bot()
+        message = MagicMock()
+        message.content = ""
+        message.edit = AsyncMock()
+
+        snap1 = _progress([_stage(0, "Plan", "running")])
+        snap1.stages_version = 1
+        snap2 = _progress([_stage(0, "Plan", "done")], done=True)
+        snap2.stages_version = 1
+
+        with (
+            patch("chat.bot.asyncio.sleep", new=AsyncMock()),
+            patch("chat.bot.time.monotonic", side_effect=[0.0, 100.0, 100.5]),
+            patch("chat.bot.goosecracker_progress.get", side_effect=[snap1, snap2]),
+            patch("chat.bot.goosecracker_progress.clear") as mock_clear,
+        ):
+            await bot._stream_goosecracker_progress(
+                "artifact-1", message, kind="artifact"
+            )
+
+        # poll 1: version -1 -> 1, far past the window -> edit
+        # poll 2: done flips False -> True only 0.5s later -> gate coalesces the
+        # normal edit, but the unconditional final edit still fires.
+        assert message.edit.call_count == 2
+        final_content = message.edit.call_args_list[-1].kwargs["content"]
+        assert "Done" in final_content
+        mock_clear.assert_called_once_with("artifact-1")
+
+    @pytest.mark.asyncio
+    async def test_edit_http_exception_does_not_crash_the_loop(self):
+        bot = _make_bot()
+        message = MagicMock()
+        message.content = ""
+        message.edit = AsyncMock(side_effect=discord.HTTPException(MagicMock(), "boom"))
+
+        snap = _progress([_stage(0, "Plan", "done")], done=True)
+        snap.stages_version = 1
+
+        with (
+            patch("chat.bot.asyncio.sleep", new=AsyncMock()),
+            patch("chat.bot.time.monotonic", side_effect=[0.0, 100.0]),
+            patch("chat.bot.goosecracker_progress.get", side_effect=[snap]),
+            patch("chat.bot.goosecracker_progress.clear") as mock_clear,
+        ):
+            await bot._stream_goosecracker_progress(
+                "artifact-2", message, kind="artifact"
+            )
+
+        mock_clear.assert_called_once_with("artifact-2")
+
+    @pytest.mark.asyncio
+    async def test_no_stages_path_unchanged_edits_on_every_body_change(self):
+        """Artifact recipes that never emit markers keep the original
+        edit-whenever-content-changes behaviour, byte-for-byte."""
+        bot = _make_bot()
+        message = MagicMock()
+        message.content = ""
+        message.edit = AsyncMock()
+
+        snap_thinking = gp.Progress(text="", done=False)
+        snap_done = gp.Progress(text="built it", done=True)
+
+        with (
+            patch("chat.bot.asyncio.sleep", new=AsyncMock()),
+            patch("chat.bot.time.monotonic", side_effect=[0.0, 1.0, 2.0]),
+            patch(
+                "chat.bot.goosecracker_progress.get",
+                side_effect=[snap_thinking, snap_done],
+            ),
+            patch("chat.bot.goosecracker_progress.clear") as mock_clear,
+        ):
+            await bot._stream_goosecracker_progress(
+                "artifact-3", message, kind="artifact"
+            )
+
+        assert message.edit.call_count == 2
+        mock_clear.assert_called_once_with("artifact-3")

--- a/projects/monolith/chat/bot_checklist_render_test.py
+++ b/projects/monolith/chat/bot_checklist_render_test.py
@@ -1,5 +1,7 @@
 """Tests for the ADR 035 stage checklist renderer and edit-coalescing gate."""
 
+import itertools
+
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -309,9 +311,13 @@ class TestStreamLoopFinalEditNeverDropped:
         snap_thinking = gp.Progress(text="", done=False)
         snap_done = gp.Progress(text="built it", done=True)
 
+        # The no-stages path renders via _render_goosecracker_progress, which
+        # itself calls time.monotonic() (for the "flowing" window), so the count
+        # of clock reads per iteration is an implementation detail. Use an
+        # unbounded increasing clock and assert edit behaviour, not call counts.
         with (
             patch("chat.bot.asyncio.sleep", new=AsyncMock()),
-            patch("chat.bot.time.monotonic", side_effect=[0.0, 1.0, 2.0]),
+            patch("chat.bot.time.monotonic", side_effect=itertools.count()),
             patch(
                 "chat.bot.goosecracker_progress.get",
                 side_effect=[snap_thinking, snap_done],

--- a/projects/monolith/chat/goosecracker_progress.py
+++ b/projects/monolith/chat/goosecracker_progress.py
@@ -9,6 +9,13 @@ In-memory and single-replica by design: this is transient build output keyed by
 the Discord thread id (== the artifact id). If the pod restarts mid-build the
 run is lost anyway, so the buffer needs no durability. The buffer keeps only the
 tail (Discord shows ~2000 chars), so memory is bounded per thread.
+
+ADR 035 adds a structured stage-marker channel alongside the raw text tail.
+Recipes can emit marker lines on stdout to announce a plan and progress
+through it: ``::stages::<n>`` declares a fresh plan of (advisory) length
+``n``, and ``::stage::<index>::<state>::<title>`` reports one stage's current
+state. Marker lines are parsed out of the stream and never rendered as raw
+text; everything else behaves exactly as before.
 """
 
 from __future__ import annotations
@@ -21,6 +28,19 @@ from threading import Lock
 # shows a rolling window, so retaining more wastes memory.
 _MAX_BUFFER = 16384
 
+_STAGE_MARKER_PREFIX = "::stage::"
+_STAGES_MARKER_PREFIX = "::stages::"
+_STAGE_STATES = frozenset({"pending", "running", "done", "failed", "skipped"})
+
+
+@dataclass
+class Stage:
+    """One step of a recipe's announced plan, as reported by a stage marker."""
+
+    index: int
+    title: str
+    state: str
+
 
 @dataclass
 class Progress:
@@ -30,25 +50,130 @@ class Progress:
     transient fc-invoke failure") that the runner sets before the guest starts
     streaming, so the bot can show the owner what is happening during a retry
     instead of a bare "Thinking". It is cleared as soon as real stdout flows.
+
+    ``stages`` is the structured plan reported via stage markers (see module
+    docstring), ordered by arrival. ``stages_version`` bumps on any change to
+    ``stages`` so the renderer can cheaply detect "needs edit" without diffing
+    the list itself.
     """
 
     text: str = ""
     done: bool = False
     notice: str = ""
+    stages: list[Stage] = field(default_factory=list)
+    stages_version: int = 0
     updated_at: float = field(default_factory=time.monotonic)
 
 
 _store: dict[str, Progress] = {}
 _lock = Lock()
 
+# Per-artifact unterminated trailing line fragment, carried forward until the
+# next chunk completes it. Chunks are not guaranteed to be line-aligned, so a
+# marker (or the plain text before one) can be split across two append()
+# calls; this is what lets us reassemble it before deciding what it is.
+_partial: dict[str, str] = {}
+
+
+def _looks_like_marker_prefix(fragment: str) -> bool:
+    """True if an unterminated line could still grow into a marker line.
+
+    Used to decide whether to hold an incomplete trailing fragment back from
+    ``text`` (it might be a marker) or flush it immediately (it can't be).
+    """
+    if not fragment:
+        return False
+    for prefix in (_STAGE_MARKER_PREFIX, _STAGES_MARKER_PREFIX):
+        if prefix.startswith(fragment) or fragment.startswith(prefix):
+            return True
+    return False
+
+
+def _apply_marker(p: Progress, line: str) -> None:
+    """Parse one complete marker line and mutate ``p.stages`` in place.
+
+    Malformed markers (unknown state, non-integer index, wrong shape) are
+    dropped silently: no stage is added or updated, and the line is not
+    rendered as text either, since it was already routed away from ``text``
+    by prefix.
+    """
+    if line.startswith(_STAGES_MARKER_PREFIX):
+        # "::stages::<n>": a fresh plan announcement (e.g. after steering
+        # triggers re-planning). <n> is advisory only, the stage markers that
+        # follow populate the list, so we don't validate or pre-size on it.
+        p.stages = []
+        p.stages_version += 1
+        return
+
+    # "::stage::<index>::<state>::<title>". Split with maxsplit=4 so a title
+    # containing "::" is not mangled: parts are ("", "stage", index, state,
+    # title).
+    parts = line.split("::", 4)
+    if len(parts) != 5:
+        return
+    _, _tag, index_str, state, title = parts
+    if state not in _STAGE_STATES:
+        return
+    try:
+        index = int(index_str)
+    except ValueError:
+        return
+
+    for stage in p.stages:
+        if stage.index == index:
+            if stage.title == title and stage.state == state:
+                return
+            stage.title = title
+            stage.state = state
+            p.stages_version += 1
+            return
+    p.stages.append(Stage(index=index, title=title, state=state))
+    p.stages_version += 1
+
 
 def append(artifact_id: str, chunk: str) -> None:
-    """Append a stdout chunk to a run's buffer, keeping only the tail."""
+    """Append a stdout chunk to a run's buffer, keeping only the tail.
+
+    Marker lines (see module docstring) are parsed into ``Progress.stages``
+    and never appear in ``Progress.text``. Everything else is appended
+    exactly as before, including chunks with no trailing newline.
+    """
     if not chunk:
         return
     with _lock:
         p = _store.setdefault(artifact_id, Progress())
-        p.text = (p.text + chunk)[-_MAX_BUFFER:]
+        pending = _partial.pop(artifact_id, "")
+        combined = pending + chunk
+        segments = combined.split("\n")
+        incomplete = segments[-1]
+        complete_lines = segments[:-1]
+
+        # Segments we keep for text, in order. Complete lines that are
+        # markers are dropped (parsed instead); everything else is kept.
+        # Rejoining the kept segments with "\n" reproduces the original
+        # chunk minus exactly the marker lines and their newlines.
+        text_segments: list[str] = []
+        for line in complete_lines:
+            stripped = line.strip()
+            if stripped.startswith(_STAGE_MARKER_PREFIX) or stripped.startswith(
+                _STAGES_MARKER_PREFIX
+            ):
+                _apply_marker(p, stripped)
+            else:
+                text_segments.append(line)
+
+        if _looks_like_marker_prefix(incomplete):
+            # Might still grow into a marker: hold it back until the next
+            # chunk completes the line (or proves it isn't one).
+            _partial[artifact_id] = incomplete
+        else:
+            # Not a marker in progress, so flush it immediately: plain
+            # chunks with no newline must append exactly as before.
+            text_segments.append(incomplete)
+
+        if text_segments:
+            p.text = (p.text + "\n".join(text_segments))[-_MAX_BUFFER:]
+
         # Real output supersedes any pre-run retry notice: once the guest is
         # streaming, the retry is over, so drop the stale line automatically.
         p.notice = ""
@@ -82,7 +207,14 @@ def get(artifact_id: str) -> Progress | None:
         if p is None:
             return None
         return Progress(
-            text=p.text, done=p.done, notice=p.notice, updated_at=p.updated_at
+            text=p.text,
+            done=p.done,
+            notice=p.notice,
+            stages=[
+                Stage(index=s.index, title=s.title, state=s.state) for s in p.stages
+            ],
+            stages_version=p.stages_version,
+            updated_at=p.updated_at,
         )
 
 
@@ -90,3 +222,4 @@ def clear(artifact_id: str) -> None:
     """Drop a run's buffer once the bot has finished streaming it."""
     with _lock:
         _store.pop(artifact_id, None)
+        _partial.pop(artifact_id, None)

--- a/projects/monolith/chat/goosecracker_progress_stages_test.py
+++ b/projects/monolith/chat/goosecracker_progress_stages_test.py
@@ -1,0 +1,123 @@
+"""Tests for stage-marker parsing in the goosecracker live-progress buffer.
+
+Recipes emit marker lines on stdout (``::stage::<index>::<state>::<title>``
+and ``::stages::<n>``) to announce structured plan progress alongside the
+free-text tail. See ``goosecracker_progress.py`` for the grammar.
+"""
+
+from chat import goosecracker_progress as gp
+
+
+def _fresh(artifact_id: str) -> None:
+    gp.clear(artifact_id)
+
+
+def test_single_stage_marker_adds_a_stage():
+    _fresh("s1")
+    gp.append("s1", "::stage::0::running::Fetch data\n")
+    snap = gp.get("s1")
+    assert len(snap.stages) == 1
+    assert snap.stages[0].index == 0
+    assert snap.stages[0].title == "Fetch data"
+    assert snap.stages[0].state == "running"
+    _fresh("s1")
+
+
+def test_stage_marker_updates_state_in_place():
+    _fresh("s2")
+    gp.append("s2", "::stage::0::pending::Fetch data\n")
+    gp.append("s2", "::stage::0::done::Fetch data\n")
+    snap = gp.get("s2")
+    assert len(snap.stages) == 1
+    assert snap.stages[0].state == "done"
+    _fresh("s2")
+
+
+def test_stages_reset_discards_old_stages():
+    _fresh("s3")
+    gp.append("s3", "::stage::0::done::Old step\n")
+    gp.append("s3", "::stages::2\n")
+    gp.append("s3", "::stage::0::pending::New step A\n")
+    gp.append("s3", "::stage::1::pending::New step B\n")
+    snap = gp.get("s3")
+    assert [s.title for s in snap.stages] == ["New step A", "New step B"]
+    _fresh("s3")
+
+
+def test_title_containing_double_colon_is_preserved():
+    _fresh("s4")
+    gp.append("s4", "::stage::0::running::Build a::b::c\n")
+    snap = gp.get("s4")
+    assert snap.stages[0].title == "Build a::b::c"
+    _fresh("s4")
+
+
+def test_malformed_marker_is_dropped_not_added_as_stage_or_text():
+    _fresh("s5")
+    gp.append("s5", "::stage::notanindex::running::Fetch data\n")
+    gp.append("s5", "::stage::0::not-a-real-state::Fetch data\n")
+    snap = gp.get("s5")
+    assert snap.stages == []
+    assert snap.text == ""
+    _fresh("s5")
+
+
+def test_marker_line_never_appears_in_text():
+    _fresh("s6")
+    gp.append("s6", "before\n::stage::0::running::Step 1\nafter\n")
+    snap = gp.get("s6")
+    assert snap.text == "before\nafter\n"
+    _fresh("s6")
+
+
+def test_plain_chunk_with_no_newline_appends_exactly_as_before():
+    # Compatibility guard: chunks with no marker and no newline must still
+    # append immediately, matching the pre-stage-marker behaviour, because
+    # the artifact recipes render the raw tail unchanged.
+    _fresh("s7")
+    gp.append("s7", "hello ")
+    gp.append("s7", "world")
+    snap = gp.get("s7")
+    assert snap.text == "hello world"
+    assert snap.stages == []
+    _fresh("s7")
+
+
+def test_marker_split_across_two_append_calls_is_parsed_once():
+    _fresh("s8")
+    gp.append("s8", "::stage::0::run")
+    # Not yet complete: nothing should be parsed or rendered yet.
+    mid = gp.get("s8")
+    assert mid.stages == []
+    assert mid.text == ""
+    gp.append("s8", "ning::Step 1\n")
+    snap = gp.get("s8")
+    assert len(snap.stages) == 1
+    assert snap.stages[0].state == "running"
+    assert snap.stages[0].title == "Step 1"
+    assert snap.text == ""
+    _fresh("s8")
+
+
+def test_stages_version_bumps_on_change_and_not_on_no_op_repeat():
+    _fresh("s9")
+    gp.append("s9", "::stage::0::pending::Step 1\n")
+    v1 = gp.get("s9").stages_version
+    gp.append("s9", "::stage::0::running::Step 1\n")
+    v2 = gp.get("s9").stages_version
+    assert v2 > v1
+    gp.append("s9", "::stage::0::running::Step 1\n")
+    v3 = gp.get("s9").stages_version
+    assert v3 == v2
+    _fresh("s9")
+
+
+def test_get_returns_isolated_copy_of_stages():
+    _fresh("s10")
+    gp.append("s10", "::stage::0::pending::Step 1\n")
+    snap = gp.get("s10")
+    gp.append("s10", "::stage::0::done::Step 1\n")
+    # The earlier snapshot's stage list must not mutate underneath it.
+    assert snap.stages[0].state == "pending"
+    assert gp.get("s10").stages[0].state == "done"
+    _fresh("s10")

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.248.0
+      targetRevision: 0.249.0
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
## Summary

Phase 1 of the [ADR 035 Discord Multiplayer Agent UX plan](https://github.com/jomcgi/homelab/blob/main/docs/plans/2026-07-02-discord-multiplayer-agent-ux.md): turn the opaque goose-stdout tail into a structured live checklist in Discord.

Four tasks, plus review fixes and chart bumps:

- **1.1 Stage marker parser** (`chat/goosecracker_progress.py`): parse `::stages::<n>` (plan announcement) and `::stage::<index>::<state>::<title>` lines out of the guest stdout stream into `Progress.stages` + a `stages_version` counter. Marker lines never appear in `Progress.text`; malformed markers drop silently; partial markers split across chunks reassemble; the no-marker path is byte-for-byte unchanged so artifact recipes are unaffected.
- **1.2 Checklist renderer + edit coalescing** (`chat/bot.py`): pure `render_checklist(progress)` (⬜/🔄/✅/❌/⏭️, collapses old completed stages past 1900 chars, hard-capped at 2000, no wall-clock component). Stream loop edits only on `stages_version`/`done` change and at most once per 2s, with a forced terminal edit so the final `done` checklist always lands. No-stages runs keep the original tail renderer.
- **1.3 Recipe marker emission** (`recipes/agent.yaml`): the router emits batched `printf` markers (1 stage per single route, 2 for artifact build+review). Existing HARD GATEs and `recipe__final_output` guidance preserved.
- **1.4 Immutable ack split** (`chat/bot.py`): the prompt-echo ack is never handed to the stream editor; the checklist is its own message starting as a `Planning...` placeholder (formalizes the #3096 split, locked with a handler test).

## Review

One comprehensive Opus review (safety net for the Sonnet-implemented diff): verdict **APPROVE**, minors only. Fixes applied in-branch: dropped a new em-dash, advance delivered stage markers only after a successful edit (transient failures retry), and skip the redundant duplicate terminal edit.

## Deploy

- monolith chart `0.248.0 -> 0.249.0` (+ application.yaml targetRevision) for the parser/bot changes.
- fc-invoke (substrate) chart `0.4.24 -> 0.4.25` (+ application.yaml targetRevision) so the guest image carrying the new `agent.yaml` recipe actually rolls out.

## Verification note

Marker emission is guest content (a local model running `printf`), verifiable only by a live `/agent` check after rollout. The parser fails open (empty checklist, no crash) if markers do not survive goose's stdout rendering, in which case the fallback is a file-tailed marker channel. Live check is the phase gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)