### PR TITLE
fix(goosecracker): resolve lingering checklist stages on run completion

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.249.0
+version: 0.250.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chat/bot.py
+++ b/projects/monolith/chat/bot.py
@@ -172,14 +172,31 @@ def render_checklist(progress) -> str | None:
     if progress.notice and not progress.done:
         lines.append(progress.notice)
 
+    def _effective(state: str) -> str:
+        # Once the run is over no stage can still be pending or running. The
+        # recipe's terminal marker is best-effort (the local router model
+        # sometimes skips the trailing done printf), so resolve lingering
+        # stages deterministically at render time: running -> done (it was in
+        # flight when the run ended), pending -> skipped (it never started).
+        # A failed stage keeps its failed marker. This is what lets the final
+        # edit always show all stages resolved, per the ADR 035 spec.
+        if not progress.done:
+            return state
+        if state == "running":
+            return "done"
+        if state == "pending":
+            return "skipped"
+        return state
+
     stage_lines = [
-        f"{_STAGE_EMOJI.get(s.state, '⬜')} {s.title}" for s in progress.stages
+        f"{_STAGE_EMOJI.get(_effective(s.state), '⬜')} {s.title}"
+        for s in progress.stages
     ]
     body = "\n".join(lines + stage_lines)
 
     collapsed = 0
     while len(body) > _CHECKLIST_COLLAPSE_AT and collapsed < len(progress.stages):
-        if progress.stages[collapsed].state not in ("done", "skipped"):
+        if _effective(progress.stages[collapsed].state) not in ("done", "skipped"):
             break
         collapsed += 1
         summary = [f"✅ {collapsed} earlier stages"]

--- a/projects/monolith/chat/bot_checklist_render_test.py
+++ b/projects/monolith/chat/bot_checklist_render_test.py
@@ -82,6 +82,31 @@ class TestRenderChecklistStates:
         )
         assert "stale retry notice" not in body
 
+    def test_done_run_resolves_lingering_stages(self):
+        # The local router model sometimes skips the trailing done marker, so a
+        # completed run can still carry running/pending stages. On done the
+        # renderer resolves them (running -> done, pending -> skipped, failed
+        # kept) so the final edit shows every stage resolved, per the spec.
+        stages = [
+            _stage(0, "Fetch", "running"),
+            _stage(1, "Write", "pending"),
+            _stage(2, "Deploy (connection refused)", "failed"),
+        ]
+        body = render_checklist(_progress(stages, done=True))
+
+        assert "✅ Fetch" in body
+        assert "⏭️ Write" in body
+        assert "❌ Deploy (connection refused)" in body
+        assert "🔄" not in body  # nothing still spinning after the run ended
+
+    def test_live_run_keeps_running_and_pending(self):
+        # The coercion applies only once done: a live run shows real states.
+        body = render_checklist(
+            _progress([_stage(0, "Fetch", "running"), _stage(1, "Write", "pending")])
+        )
+        assert "🔄 Fetch" in body
+        assert "⬜ Write" in body
+
 
 class TestRenderChecklistIsTimeFree:
     def test_identical_progress_renders_identically(self):

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.249.0
+      targetRevision: 0.250.0
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
## Summary

Phase 1 live-check follow-up for [ADR 035](https://github.com/jomcgi/homelab/blob/main/docs/plans/2026-07-02-discord-multiplayer-agent-ux.md).

The live check (a headless `recipe=agent` run against the in-cluster Qwen router) confirmed the big unknown: stage markers reach goose stdout **verbatim** (`line: "::stages::1"`, `line: "::stage::0::running::Answering"`), so the parser sees them cleanly. It also surfaced a real gap: the local router model reliably emits the *running* marker (batched with the plan announcement, one printf) but sometimes skips the standalone *done* printf after the sub-recipe returns. A completed run then rendered `✅ Done` (header) over `🔄 Answering` (stage stuck running), violating the spec's "on session completion the final edit shows all stages resolved."

## Fix

Make the consumer robust to a best-effort producer rather than chasing local-model reliability: in `render_checklist`, once `progress.done` is true, coerce lingering states at render time (display only, no stored mutation):
- `running -> done`
- `pending -> skipped`
- `failed` kept as-is

So the final checklist always shows every stage resolved, regardless of whether the recipe emitted the trailing marker. Tests cover the coercion and confirm a live (not-done) run still shows real running/pending states.

## Deploy

monolith chart `0.249.0 -> 0.250.0` (+ application.yaml targetRevision). No recipe/fc-invoke change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)