### PR TITLE
feat(goosecracker): ADR 035 phase 2 - stage-boundary steering + multiplayer threads

### DIFF
--- a/projects/firecracker/goosecracker/guest/recipes/agent.yaml
+++ b/projects/firecracker/goosecracker/guest/recipes/agent.yaml
@@ -46,7 +46,8 @@ instructions: |
     result:
       1. `delegate(source: "artifact-build")` and WAIT. That subagent reads the
          task from /tmp/goose/task.md and writes the page to /tmp/artifact.html.
-      2. `delegate(source: "artifact-review")` and WAIT. That subagent reads
+      2. Before dispatching, check for steering per the STEERING section above.
+         `delegate(source: "artifact-review")` and WAIT. That subagent reads
          /tmp/artifact.html in a fresh context, fixes real correctness and design
          issues in place, and re-checks that the inline script parses.
       3. `recipe__final_output` with `mode: artifact` and an empty `url` (the
@@ -120,6 +121,29 @@ instructions: |
     If either step fails, run printf '::stage::<i>::failed::<short reason>\n'
     for the stage that failed instead of its done marker.
 
+  STEERING (mid-run adjustments from the thread). While your run is in flight,
+  people in the thread can post steering messages. Check for them at each stage
+  boundary: right before you dispatch a sub-recipe, and (for artifacts) between
+  the build and review delegations, run:
+      curl -s "${GOOSECRACKER_STEERING_URL}"
+  If GOOSECRACKER_STEERING_URL is empty or the call fails, just proceed (steering
+  is best-effort, never block the run on it). The response is JSON:
+    {"messages": [{"author_id": "...", "tier": "...", "text": "..."}, ...]}
+  Handle it as follows:
+    - No messages: proceed normally.
+    - A message whose text is exactly "stop" or "cancel" (case-insensitive,
+      trimmed): abort the run. Emit a skipped marker for every stage not yet done
+      (printf '::stage::<i>::skipped::<title>\n' for each remaining stage), then a
+      final done marker for the plan, then call recipe__final_output summarizing
+      that the run was cancelled by a participant, and STOP. Do not dispatch
+      further sub-recipes.
+    - Otherwise (real steering content): fold it into the work. Append each
+      message to /tmp/goose/context.md as a line "Steering from <author_id>:
+      <text>" (so the sub-recipe sees it), and if it changes the plan (adds or
+      reorders work) re-announce the plan with a fresh ::stages:: block and
+      per-stage markers (the checklist reflects the change). Then continue.
+  Keep the steering check to a single curl per boundary (do not poll in a loop).
+
   Dispatch the actual work; never run it in the router. Your context is
   shared across the whole thread, so a large tool output here (a full
   `git log`, a wide `grep`, a big file) can overflow it and trigger a
@@ -129,7 +153,8 @@ instructions: |
   you do read (pipe through `head`, count with `wc -l` first, sample) and
   never pull hundreds of log lines into your context.
 
-  Then call the matching sub-recipe tool and wait for its result, bracketed by
+  Before dispatching, check for steering per the STEERING section above. Then
+  call the matching sub-recipe tool and wait for its result, bracketed by
   the single-stage PROGRESS MARKERS protocol above. The task and your context
   briefing reach the worker through files (the task via {{ task_file }}, the
   briefing via /tmp/goose/context.md), pre-wired on each sub-recipe, so you do

--- a/projects/firecracker/substrate/chart/Chart.yaml
+++ b/projects/firecracker/substrate/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: fc-invoke
 description: Node-affine Firecracker invoke daemon that dispatches HTTP invocations to a pool of warm-base microVMs across named workloads (POST /invoke/{workload}, GET /healthz)
 type: application
-version: 0.4.25
+version: 0.4.26

--- a/projects/firecracker/substrate/deploy/application.yaml
+++ b/projects/firecracker/substrate/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI (pushed by CI via Bazel helm_push); image tags pinned at build.
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: fc-invoke
-      targetRevision: 0.4.25
+      targetRevision: 0.4.26
       helm:
         valueFiles:
           - $values/projects/firecracker/substrate/deploy/values.yaml

--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -833,6 +833,18 @@ py_test(
 )
 
 py_test(
+    name = "chat_goosecracker_steering_test",
+    srcs = ["chat/goosecracker_steering_test.py"],
+    imports = ["."],
+    deps = [
+        ":monolith_backend",
+        "@pip//pgvector",
+        "@pip//pytest",
+        "@pip//sqlmodel",
+    ],
+)
+
+py_test(
     name = "chat_acl_test",
     srcs = ["chat/acl_test.py"],
     imports = ["."],

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.250.0
+version: 0.251.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/migrations/20260703030000_chat_goosecracker_steering.sql
+++ b/projects/monolith/chart/migrations/20260703030000_chat_goosecracker_steering.sql
@@ -1,0 +1,30 @@
+-- Mid-run steering queue for goosecracker agent threads (ADR 035 Phase 2).
+--
+-- While a turn is running, thread participants can post replies that should
+-- steer the in-flight run rather than queue as the next turn (that queuing
+-- already exists via goosecracker_sessions.pending). Steering messages are
+-- enqueued here by the bot (ACL-gated, Task 2.3) and fetched by the running
+-- guest recipe at stage boundaries (Task 2.2), which marks them delivered so
+-- a re-poll never redelivers the same message.
+--
+-- A dedicated table (not reusing pending) because steering is delivered
+-- mid-run to a live process over HTTP, not drained by the runner between
+-- turns: the access pattern (poll-and-mark-delivered by an external guest)
+-- is different enough to warrant its own rows and its own delivered flag.
+--
+-- Small and append-mostly; safe to run with no data (new table).
+CREATE TABLE IF NOT EXISTS chat.goosecracker_steering (
+    id BIGSERIAL PRIMARY KEY,
+    thread_id TEXT NOT NULL,
+    message_id TEXT NOT NULL,
+    author_id TEXT NOT NULL,
+    tier TEXT NOT NULL DEFAULT '',
+    text TEXT NOT NULL,
+    delivered BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- The fetch query selects undelivered rows for a thread ordered by id; this
+-- index covers it directly.
+CREATE INDEX IF NOT EXISTS goosecracker_steering_thread_delivered_id_idx
+    ON chat.goosecracker_steering (thread_id, delivered, id);

--- a/projects/monolith/chart/migrations/20260703040000_goosecracker_steering_capability.sql
+++ b/projects/monolith/chart/migrations/20260703040000_goosecracker_steering_capability.sql
@@ -1,0 +1,16 @@
+-- Bind the guest steering fetch to an unguessable per-session capability token
+-- instead of the Discord thread snowflake (ADR 035 Phase 2 hardening).
+--
+-- The steering endpoint was keyed on thread_id, which is a guessable Discord
+-- snowflake: a compromised guest that learned another thread's id could read,
+-- deny, or pollute that victim thread's steering. The runner now injects a
+-- token-keyed URL instead, so a guest can only ever address its own thread.
+--
+-- Safe with existing data: rows default to '' and get a token lazily on next
+-- dispatch (ensure_steering_token assigns one on first use, same pattern as
+-- artifact_id). The partial unique index excludes the empty default so
+-- multiple un-migrated rows never collide on ''.
+ALTER TABLE chat.goosecracker_sessions ADD COLUMN IF NOT EXISTS steering_token TEXT NOT NULL DEFAULT '';
+
+CREATE UNIQUE INDEX IF NOT EXISTS goosecracker_sessions_steering_token_key
+    ON chat.goosecracker_sessions (steering_token) WHERE steering_token <> '';

--- a/projects/monolith/chart/migrations/atlas.sum
+++ b/projects/monolith/chart/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:5fKz+FKs7eVXXkUBTtfO3tKiMujQnsnrQfe0jTFUDig=
+h1:ZZBjl/3LPC8tcQLAAFY9ggoCLE/VZH4w1HADWHMloWM=
 20260330000000_initial_schema.sql h1:J2futpSW0nJAIRR7nR7ssT7LwXIYrvRI+PkHb5Y4tLI=
 20260403000000_chat_schema.sql h1:pERUFC0vzM95etRuzp43XzkCV7lBCzrrtY5Mk7aF3CA=
 20260404000000_chat_attachments.sql h1:tv+Fdbr1rQC5nzUxfaBC0O6fu2OMGgLWf+YNg1WQXi4=
@@ -85,3 +85,4 @@ h1:5fKz+FKs7eVXXkUBTtfO3tKiMujQnsnrQfe0jTFUDig=
 20260702160000_discord_outbox_reaction_check.sql h1:z4OGiXHssnbdv8D7l2J3ZoOIr8zxl4LkyQNkeU6XYEw=
 20260702170000_goosecracker_parent_channel.sql h1:l1wOFXQ7VgfIeM66A/a2SdMfpKmVfUaf48MytRZOlBA=
 20260703030000_chat_goosecracker_steering.sql h1:/OyfMPzb0nL+sDO+h/7uUIaifHAN00juMXpYY90BtSY=
+20260703040000_goosecracker_steering_capability.sql h1:kCBMOSzulwquD1TP8jDVMgK4uRpBiEsKUGbWhqnMQyk=

--- a/projects/monolith/chart/migrations/atlas.sum
+++ b/projects/monolith/chart/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:q47JpV9ZAdqpCFU2HASA2PRp/22WoAs6BBr+IaMj2tc=
+h1:5fKz+FKs7eVXXkUBTtfO3tKiMujQnsnrQfe0jTFUDig=
 20260330000000_initial_schema.sql h1:J2futpSW0nJAIRR7nR7ssT7LwXIYrvRI+PkHb5Y4tLI=
 20260403000000_chat_schema.sql h1:pERUFC0vzM95etRuzp43XzkCV7lBCzrrtY5Mk7aF3CA=
 20260404000000_chat_attachments.sql h1:tv+Fdbr1rQC5nzUxfaBC0O6fu2OMGgLWf+YNg1WQXi4=
@@ -84,3 +84,4 @@ h1:q47JpV9ZAdqpCFU2HASA2PRp/22WoAs6BBr+IaMj2tc=
 20260702150000_goosecracker_queue_reactions.sql h1:NddlTQmd8f6sPFQWuQnIOx7B8i3kWCvts6Rno7t+M5c=
 20260702160000_discord_outbox_reaction_check.sql h1:z4OGiXHssnbdv8D7l2J3ZoOIr8zxl4LkyQNkeU6XYEw=
 20260702170000_goosecracker_parent_channel.sql h1:l1wOFXQ7VgfIeM66A/a2SdMfpKmVfUaf48MytRZOlBA=
+20260703030000_chat_goosecracker_steering.sql h1:/OyfMPzb0nL+sDO+h/7uUIaifHAN00juMXpYY90BtSY=

--- a/projects/monolith/chart/templates/deployment.yaml
+++ b/projects/monolith/chart/templates/deployment.yaml
@@ -98,6 +98,10 @@ spec:
             - name: GOOSECRACKER_PROGRESS_URL
               value: {{ .Values.goosecracker.progressUrl | quote }}
             {{- end }}
+            {{- if .Values.goosecracker.steeringUrl }}
+            - name: GOOSECRACKER_STEERING_URL
+              value: {{ .Values.goosecracker.steeringUrl | quote }}
+            {{- end }}
             {{- if .Values.goosecracker.gitMirror }}
             - name: GOOSECRACKER_GIT_MIRROR
               value: {{ .Values.goosecracker.gitMirror | quote }}

--- a/projects/monolith/chart/values.yaml
+++ b/projects/monolith/chart/values.yaml
@@ -549,6 +549,9 @@ goosecracker:
     itemPath: ""
   tiers: {}
   progressUrl: ""
+  # The monolith's own in-cluster steering endpoint base the guest polls at
+  # stage boundaries (ADR 035 phase 2); empty disables steering.
+  steeringUrl: ""
 
 # Knowledge gardener: LLM-driven decomposition of raw vault notes into
 # typed knowledge artifacts via the claude Code CLI. Uses CLAUDE_CODE_OAUTH_TOKEN

--- a/projects/monolith/chat/api.py
+++ b/projects/monolith/chat/api.py
@@ -11,6 +11,7 @@ from chat.changelog import run_changelog_for_config  # re-exported
 from chat.goosecracker import ack_inflight  # re-exported
 from chat.goosecracker import artifact_id_for_thread  # re-exported
 from chat.goosecracker import drain_agent_queue  # re-exported
+from chat.goosecracker import ensure_steering_token  # re-exported
 from chat.goosecracker import force_idle_thread  # re-exported
 from chat.goosecracker import mark_inflight_running  # re-exported
 from chat.goosecracker import parent_channel_for_thread  # re-exported
@@ -29,6 +30,7 @@ __all__ = [
     "artifact_id_for_thread",
     "conversational_agent_reply",
     "drain_agent_queue",
+    "ensure_steering_token",
     "force_idle_thread",
     "mark_inflight_running",
     "parent_channel_for_thread",

--- a/projects/monolith/chat/bot.py
+++ b/projects/monolith/chat/bot.py
@@ -926,12 +926,31 @@ class ChatBot(discord.Client):
         if message.author.bot:
             await asyncio.to_thread(self._complete_lock, msg_id)
             return True
-        # Agent threads are open to everyone (ADR 029). Artifact threads are open
-        # to whoever is granted /artifact in this server (ADR 024 amendment), so
-        # the person who built an artifact can iterate on it, not just the owner.
+        # Artifact threads are open to whoever is granted /artifact in this
+        # server (ADR 024 amendment), so the person who built an artifact can
+        # iterate on it, not just the owner. Agent threads are per-server ACL
+        # gated on the session's own repo scope (ADR 035 Phase 2): steering an
+        # in-flight agent turn needs the same grant that opened it.
         is_agent = await asyncio.to_thread(goosecracker.is_agent_thread, thread_id)
-        if not is_agent:
-            guild_id = message.guild.id if message.guild else None
+        guild_id = message.guild.id if message.guild else None
+        if is_agent:
+            repo = await asyncio.to_thread(goosecracker.session_scope, thread_id) or ""
+            if not await asyncio.to_thread(
+                acl.is_granted, guild_id, message.author.id, "agent", repo
+            ):
+                scopes = await asyncio.to_thread(
+                    acl.allowed_scopes, guild_id, message.author.id, "agent"
+                )
+                allowed = ", ".join(sorted(scopes)) or "none"
+                roast = await goosecracker.build_roast(message.content)
+                target = f"`{repo}`" if repo else "this"
+                await message.reply(
+                    f"{roast}\nYou'd need an `agent` grant for {target} in this "
+                    f"server to steer here. Allowed here: {allowed}."
+                )
+                await asyncio.to_thread(self._complete_lock, msg_id)
+                return True
+        else:
             allowed = goosecracker.is_owner(
                 message.author.id
             ) or await asyncio.to_thread(
@@ -945,7 +964,11 @@ class ChatBot(discord.Client):
 
         try:
             result = await asyncio.to_thread(
-                goosecracker.continue_session, thread_id, message.content, msg_id
+                goosecracker.continue_session,
+                thread_id,
+                message.content,
+                msg_id,
+                author_id=str(message.author.id),
             )
         except Exception:
             logger.exception("goosecracker: failed to continue session")
@@ -968,6 +991,18 @@ class ChatBot(discord.Client):
                 await message.add_reaction(goosecracker.REACTION_QUEUED)
             except discord.HTTPException:
                 logger.exception("goosecracker: failed to react queued on %s", msg_id)
+            await asyncio.to_thread(self._complete_lock, msg_id)
+            return True
+
+        if action == "steering":
+            # A turn is already running; the reply was enqueued as steering
+            # (ADR 035 Phase 2) rather than queued behind the turn. Acknowledge
+            # with 👀 directly (no ⏳ stage: it is not waiting for a slot, it will
+            # be picked up by the running guest at its next stage boundary).
+            try:
+                await message.add_reaction(goosecracker.REACTION_RUNNING)
+            except discord.HTTPException:
+                logger.exception("goosecracker: failed to react steering on %s", msg_id)
             await asyncio.to_thread(self._complete_lock, msg_id)
             return True
 

--- a/projects/monolith/chat/bot_on_message_test.py
+++ b/projects/monolith/chat/bot_on_message_test.py
@@ -1,6 +1,7 @@
 """Additional coverage for ChatBot -- on_message(), on_ready(), streaming response."""
 
 import asyncio
+from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -296,8 +297,6 @@ class TestStreamResponseContext:
     @pytest.mark.asyncio
     async def test_includes_recent_messages_in_prompt(self):
         """Streaming response calls agent.run_stream_events with recent conversation context."""
-        from datetime import datetime, timezone
-
         from chat.models import Message
 
         bot = _make_bot()
@@ -339,6 +338,82 @@ class TestStreamResponseContext:
         assert "recent message" in prompt_arg
         # Verify deps were passed
         assert "deps" in bot.agent.run_stream_events.call_args[1]
+
+
+# ---------------------------------------------------------------------------
+# ChatBot._maybe_handle_goosecracker_reply -- agent-thread ACL gate + steering
+# (ADR 035 Phase 2)
+# ---------------------------------------------------------------------------
+
+
+def _make_goosecracker_mock(**overrides) -> MagicMock:
+    """A chat.bot.goosecracker stand-in for an agent thread mid-turn."""
+    mock = MagicMock()
+    mock.is_goosecracker_thread = MagicMock(return_value=True)
+    mock.is_agent_thread = MagicMock(return_value=True)
+    mock.session_scope = MagicMock(return_value="homelab")
+    mock.is_owner = MagicMock(return_value=False)
+    mock.build_roast = AsyncMock(return_value="Nice try.")
+    mock.continue_session = MagicMock(return_value={"action": "steering"})
+    mock.REACTION_RUNNING = "\U0001f440"
+    mock.REACTION_QUEUED = "⏳"
+    for key, value in overrides.items():
+        setattr(mock, key, value)
+    return mock
+
+
+class TestGoosecrackerReplySteering:
+    @pytest.mark.asyncio
+    async def test_permitted_user_steering_gets_running_reaction(self):
+        """A user holding the agent grant for the thread's repo steers a running
+        turn: 👀 reaction, no text reply, continue_session is called."""
+        bot = _make_bot()
+        message = _make_message(content="also add tests", channel_id=555, msg_id=7)
+        message.add_reaction = AsyncMock()
+
+        mock_gc = _make_goosecracker_mock()
+        mock_acl = MagicMock()
+        mock_acl.is_granted = MagicMock(return_value=True)
+
+        with (
+            patch("chat.bot.goosecracker", mock_gc),
+            patch("chat.bot.acl", mock_acl),
+            patch.object(bot, "_complete_lock", MagicMock()),
+        ):
+            handled = await bot._maybe_handle_goosecracker_reply(message)
+
+        assert handled is True
+        mock_gc.continue_session.assert_called_once()
+        message.add_reaction.assert_called_once_with(mock_gc.REACTION_RUNNING)
+        message.reply.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_unpermitted_user_gets_refusal_and_nothing_enqueued(self):
+        """A user without the agent grant for the thread's repo gets a refusal
+        reply naming the missing grant; continue_session is never called."""
+        bot = _make_bot()
+        message = _make_message(content="also add tests", channel_id=555, msg_id=7)
+        message.add_reaction = AsyncMock()
+
+        mock_gc = _make_goosecracker_mock()
+        mock_acl = MagicMock()
+        mock_acl.is_granted = MagicMock(return_value=False)
+        mock_acl.allowed_scopes = MagicMock(return_value={"otherrepo"})
+
+        with (
+            patch("chat.bot.goosecracker", mock_gc),
+            patch("chat.bot.acl", mock_acl),
+            patch.object(bot, "_complete_lock", MagicMock()),
+        ):
+            handled = await bot._maybe_handle_goosecracker_reply(message)
+
+        assert handled is True
+        mock_gc.continue_session.assert_not_called()
+        message.reply.assert_called_once()
+        refusal = message.reply.call_args[0][0]
+        assert "homelab" in refusal
+        assert "otherrepo" in refusal
+        message.add_reaction.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/projects/monolith/chat/goosecracker.py
+++ b/projects/monolith/chat/goosecracker.py
@@ -23,7 +23,7 @@ from datetime import datetime, timedelta, timezone
 from sqlmodel import Session, select
 
 from app.db import get_engine
-from chat.models import GoosecrackerSession
+from chat.models import GoosecrackerSession, GoosecrackerSteering
 
 logger = logging.getLogger(__name__)
 
@@ -302,6 +302,85 @@ def continue_session(thread_id: str, message: str, message_id: str = "") -> dict
         tier=ARTIFACT_TIER,
         discord_thread=thread_id,
     )
+
+
+def enqueue_steering(
+    thread_id: str, message_id: str, author_id: str, tier: str, text: str
+) -> None:
+    """Record a mid-run steering message for a running agent turn (ADR 035
+    Phase 2). Inserted undelivered; the running guest recipe fetches and
+    marks it delivered at its next stage boundary via ``fetch_steering``.
+
+    A no-op on blank text so an empty reply never leaves a dangling row for
+    the guest to chew on. Synchronous; call via ``asyncio.to_thread``.
+    """
+    text = text.strip()
+    if not text:
+        return
+    with Session(get_engine()) as session:
+        session.add(
+            GoosecrackerSteering(
+                thread_id=thread_id,
+                message_id=message_id,
+                author_id=author_id,
+                tier=tier,
+                text=text,
+            )
+        )
+        session.commit()
+
+
+def fetch_steering(thread_id: str, after_id: int = 0) -> list[dict]:
+    """Deliver undelivered steering messages for a running agent turn.
+
+    Locks and marks each undelivered row (``id > after_id``, ordered
+    ascending) as delivered in a single read-modify-write, mirroring the
+    ``with_for_update`` pattern in ``continue_session`` so a concurrent
+    enqueue can never race a fetch into double-delivering (or losing) a row.
+    Also appends each steered message to the session's curated transcript
+    (with attribution) so the steerer's input survives in the record the same
+    way an owner turn does; a missing session row (e.g. steering arrived after
+    the thread was cleaned up) still delivers the rows, it just skips the
+    transcript append rather than raising. Synchronous; call via
+    ``asyncio.to_thread``.
+    """
+    with Session(get_engine()) as session:
+        rows = session.exec(
+            select(GoosecrackerSteering)
+            .where(GoosecrackerSteering.thread_id == thread_id)
+            .where(GoosecrackerSteering.delivered == False)  # noqa: E712 - SQL boolean
+            .where(GoosecrackerSteering.id > after_id)
+            .order_by(GoosecrackerSteering.id)
+            .with_for_update()
+        ).all()
+        if not rows:
+            return []
+
+        session_row = session.get(GoosecrackerSession, thread_id, with_for_update=True)
+        delivered: list[dict] = []
+        for row in rows:
+            # rows come from this session's own query, so they are already
+            # attached; mutating attributes marks them dirty and commit()
+            # flushes the update. No session.add() needed (and adding inside
+            # a loop trips session-add-in-loop, which is for freshly
+            # constructed rows, not already-tracked ones).
+            row.delivered = True
+            if session_row is not None:
+                session_row.transcript = _join_transcript(
+                    session_row.transcript,
+                    f"[steering from {row.author_id}]: {row.text}",
+                )
+            delivered.append(
+                {
+                    "id": row.id,
+                    "message_id": row.message_id,
+                    "author_id": row.author_id,
+                    "tier": row.tier,
+                    "text": row.text,
+                }
+            )
+        session.commit()
+        return delivered
 
 
 def drain_agent_queue(thread_id: str) -> tuple[str, list[str]] | None:

--- a/projects/monolith/chat/goosecracker.py
+++ b/projects/monolith/chat/goosecracker.py
@@ -733,6 +733,46 @@ def artifact_id_for_thread(thread_id: str) -> str:
         return row.artifact_id
 
 
+def ensure_steering_token(thread_id: str) -> str:
+    """Return the thread's unguessable steering capability token, assigning one
+    on first use (ADR 035 Phase 2 hardening). Synchronous; call via
+    ``asyncio.to_thread``.
+
+    Mirrors ``artifact_id_for_thread``: random per thread, stored on the session
+    row so a re-dispatch reuses the same token, and idempotent (a second call
+    returns the existing value rather than rotating it). Returns "" when the
+    thread has no session row (nothing to bind a token to).
+    """
+    with Session(get_engine()) as session:
+        row = session.get(GoosecrackerSession, thread_id, with_for_update=True)
+        if row is None:
+            return ""
+        if not row.steering_token:
+            row.steering_token = secrets.token_urlsafe(24)
+            session.add(row)
+            session.commit()
+        return row.steering_token
+
+
+def thread_for_steering_token(token: str) -> str | None:
+    """Resolve a steering token back to its owning thread id, or None.
+
+    The steering endpoint is keyed on this token (not the guessable Discord
+    thread snowflake), so a compromised guest can only ever resolve its own
+    thread's steering. None on an empty or unknown token. Synchronous; call via
+    ``asyncio.to_thread``.
+    """
+    if not token:
+        return None
+    with Session(get_engine()) as session:
+        row = session.exec(
+            select(GoosecrackerSession).where(
+                GoosecrackerSession.steering_token == token
+            )
+        ).first()
+        return row.discord_thread if row else None
+
+
 def parent_channel_for_thread(thread_id: str) -> str:
     """Return the Discord parent channel id stored for an agent thread, or "".
 

--- a/projects/monolith/chat/goosecracker.py
+++ b/projects/monolith/chat/goosecracker.py
@@ -172,7 +172,13 @@ def start_session(thread_id: str, prompt: str) -> dict:
     return result
 
 
-def continue_session(thread_id: str, message: str, message_id: str = "") -> dict | None:
+def continue_session(
+    thread_id: str,
+    message: str,
+    message_id: str = "",
+    author_id: str = "",
+    tier: str = "",
+) -> dict | None:
     """Append an owner follow-up and re-dispatch or queue depending on recipe.
 
     Artifact sessions (recipe="artifact"): re-dispatch the full transcript (Model
@@ -180,9 +186,12 @@ def continue_session(thread_id: str, message: str, message_id: str = "") -> dict
     submit result dict.
 
     Agent sessions (recipe="agent"): conversational queuing. If a turn is already
-    running (and not stale), append the message to ``pending`` + its id to
-    ``pending_message_ids`` and return ``{"action": "queued"}`` so the bot can
-    acknowledge with a ⏳ reaction instead of a text reply. When idle (or the prior
+    running (and not stale), the reply becomes STEERING (ADR 035 Phase 2): an
+    undelivered ``GoosecrackerSteering`` row is inserted for the running guest to
+    consume mid-run, and ``{"action": "steering"}`` is returned so the bot can
+    acknowledge with a 👀 reaction instead of a text reply. ``author_id``/``tier``
+    are only used on this path (a steering row needs an attributed author; tier
+    falls back to the session's own tier when blank). When idle (or the prior
     turn is stale and reclaimed), build the next task from any backlog + this
     message, set running=True, dispatch, and return
     ``{"action": "dispatched", ...submit result}``.
@@ -208,24 +217,32 @@ def continue_session(thread_id: str, message: str, message_id: str = "") -> dict
         if row is None:
             return None
 
-        # Accumulate the turn in the curated transcript for all recipe types.
-        transcript = _join_transcript(row.transcript, message)
-        row.transcript = transcript
         now = datetime.now(timezone.utc)
         row.updated_at = now
 
         if row.recipe == AGENT_RECIPE:
             _is_agent = True
             if row.running and not _is_stale(row, now):
-                # A live turn is in flight: queue this reply for the next turn and
-                # record its id so the runner can react ⏳→👀→✅ on this message.
-                row.pending = _append_pending(row.pending, message)
-                row.pending_message_ids = _append_id(
-                    row.pending_message_ids, message_id
+                # A live turn is in flight: this reply steers it rather than
+                # queuing behind it (ADR 035 Phase 2). The steering insert and the
+                # running-check above must be atomic under the row lock, so a
+                # turn finishing concurrently can never be missed between the
+                # check and the write. Do NOT append to the transcript here:
+                # fetch_steering owns that write (with attribution) when the
+                # running guest consumes the row, so appending it here too would
+                # double it.
+                session.add(
+                    GoosecrackerSteering(
+                        thread_id=thread_id,
+                        message_id=message_id,
+                        author_id=author_id,
+                        tier=tier or row.tier,
+                        text=message,
+                        delivered=False,
+                    )
                 )
-                session.add(row)
                 session.commit()
-                return {"action": "queued"}
+                return {"action": "steering"}
             if row.running:
                 # Stale/foreign-owned turn: the owner died or wedged. Reclaim its
                 # in-flight work by folding it back into this dispatch so nothing
@@ -238,12 +255,15 @@ def continue_session(thread_id: str, message: str, message_id: str = "") -> dict
                     row.runner_instance or "?",
                     row.running_since,
                 )
-            # Idle (or reclaimed): consume the dead turn's task (if any), the
-            # backlog, and this message as a single task. Backlog + reclaimed
-            # message ids become this turn's ack set (they show the reaction
-            # lifecycle); the triggering message rides the live progress reply.
-            # Join non-empty parts only: an empty pending/inflight must not inject
-            # a blank line into the task.
+            # Idle (or reclaimed): the transcript gets this turn verbatim (the
+            # dispatch path is the record of what was asked, unlike steering).
+            row.transcript = _join_transcript(row.transcript, message)
+            # Consume the dead turn's task (if any), the backlog, and this
+            # message as a single task. Backlog + reclaimed message ids become
+            # this turn's ack set (they show the reaction lifecycle); the
+            # triggering message rides the live progress reply. Join non-empty
+            # parts only: an empty pending/inflight must not inject a blank line
+            # into the task.
             _task = "\n".join(p for p in (row.inflight_task, row.pending, message) if p)
             ack_ids = _merge_ids(row.inflight_ack_ids, row.pending_message_ids)
             _stored_recipe = row.recipe
@@ -259,8 +279,10 @@ def continue_session(thread_id: str, message: str, message_id: str = "") -> dict
             session.add(row)
             session.commit()
         else:
-            # Artifact path: commit the transcript update, then do the S3 check.
-            _transcript = transcript
+            # Artifact path: append this turn to the transcript, commit, then do
+            # the S3 check.
+            row.transcript = _join_transcript(row.transcript, message)
+            _transcript = row.transcript
             session.add(row)
             session.commit()
 
@@ -676,6 +698,19 @@ def is_agent_thread(thread_id: str) -> bool:
     with Session(get_engine()) as session:
         row = session.get(GoosecrackerSession, thread_id)
         return row is not None and row.recipe == AGENT_RECIPE
+
+
+def session_scope(thread_id: str) -> str | None:
+    """Return the repo scope stored for a goosecracker thread, or None.
+
+    Used by the bot's ACL gate on agent-thread replies (ADR 035 Phase 2) to look
+    up which repo an ``is_granted`` check should be scoped to. None when the
+    thread has no session row; "" when it does but is a repo-less run.
+    Synchronous; call via ``asyncio.to_thread``.
+    """
+    with Session(get_engine()) as session:
+        row = session.get(GoosecrackerSession, thread_id)
+        return row.repo if row else None
 
 
 def artifact_id_for_thread(thread_id: str) -> str:

--- a/projects/monolith/chat/goosecracker_steering_test.py
+++ b/projects/monolith/chat/goosecracker_steering_test.py
@@ -1,7 +1,9 @@
-"""Tests for chat.goosecracker mid-run steering (ADR 035 Phase 2 Task 2.1):
+"""Tests for chat.goosecracker mid-run steering (ADR 035 Phase 2):
 enqueue_steering, fetch_steering, and their transcript-attribution and
-delivered-flag semantics. DB-backed tests run against in-memory SQLite with
-the chat schema stripped, mirroring the fixture in goosecracker_test.py."""
+delivered-flag semantics (Task 2.1), plus the unguessable per-session steering
+token that keys the guest fetch endpoint (Phase 2 hardening). DB-backed tests
+run against in-memory SQLite with the chat schema stripped, mirroring the
+fixture in goosecracker_test.py."""
 
 from unittest.mock import patch
 
@@ -144,3 +146,72 @@ class TestFetchSteering:
             delivered = goosecracker.fetch_steering("t1")
 
         assert [d["text"] for d in delivered] == ["for t1"]
+
+
+class TestSteeringToken:
+    """ADR 035 Phase 2 hardening: the steering endpoint is keyed on an
+    unguessable per-session token, not the guessable Discord thread id."""
+
+    def test_assigns_and_persists_a_token(self, engine):
+        _make_session(engine, "t1")
+        with patch("chat.goosecracker.get_engine", return_value=engine):
+            token = goosecracker.ensure_steering_token("t1")
+
+        assert token
+        with Session(engine) as session:
+            row = session.get(GoosecrackerSession, "t1")
+        assert row.steering_token == token
+
+    def test_idempotent(self, engine):
+        _make_session(engine, "t1")
+        with patch("chat.goosecracker.get_engine", return_value=engine):
+            first = goosecracker.ensure_steering_token("t1")
+            second = goosecracker.ensure_steering_token("t1")
+
+        assert first == second
+
+    def test_unknown_thread_returns_empty(self, engine):
+        with patch("chat.goosecracker.get_engine", return_value=engine):
+            token = goosecracker.ensure_steering_token("no-such-thread")
+
+        assert token == ""
+
+    def test_resolves_token_to_its_thread(self, engine):
+        _make_session(engine, "t1")
+        with patch("chat.goosecracker.get_engine", return_value=engine):
+            token = goosecracker.ensure_steering_token("t1")
+
+            resolved = goosecracker.thread_for_steering_token(token)
+
+        assert resolved == "t1"
+
+    def test_unknown_token_returns_none(self, engine):
+        with patch("chat.goosecracker.get_engine", return_value=engine):
+            assert goosecracker.thread_for_steering_token("not-a-real-token") is None
+
+    def test_empty_token_returns_none(self, engine):
+        with patch("chat.goosecracker.get_engine", return_value=engine):
+            assert goosecracker.thread_for_steering_token("") is None
+
+    def test_cross_thread_isolation(self, engine):
+        """Two sessions get distinct tokens, and each token resolves only to
+        its own thread: guest A's token can never fetch guest B's steering."""
+        _make_session(engine, "t1")
+        _make_session(engine, "t2")
+        with patch("chat.goosecracker.get_engine", return_value=engine):
+            token_a = goosecracker.ensure_steering_token("t1")
+            token_b = goosecracker.ensure_steering_token("t2")
+
+            assert token_a != token_b
+            assert goosecracker.thread_for_steering_token(token_a) == "t1"
+            assert goosecracker.thread_for_steering_token(token_b) == "t2"
+
+            goosecracker.enqueue_steering("t1", "m1", "u1", "", "for t1 only")
+            goosecracker.enqueue_steering("t2", "m2", "u2", "", "for t2 only")
+
+            # The endpoint's actual flow: resolve the token to a thread, then
+            # fetch that thread's steering. Token A must never surface t2's rows.
+            thread_for_a = goosecracker.thread_for_steering_token(token_a)
+            delivered_for_a = goosecracker.fetch_steering(thread_for_a)
+
+        assert [d["text"] for d in delivered_for_a] == ["for t1 only"]

--- a/projects/monolith/chat/goosecracker_steering_test.py
+++ b/projects/monolith/chat/goosecracker_steering_test.py
@@ -1,0 +1,146 @@
+"""Tests for chat.goosecracker mid-run steering (ADR 035 Phase 2 Task 2.1):
+enqueue_steering, fetch_steering, and their transcript-attribution and
+delivered-flag semantics. DB-backed tests run against in-memory SQLite with
+the chat schema stripped, mirroring the fixture in goosecracker_test.py."""
+
+from unittest.mock import patch
+
+import pytest
+from sqlmodel import Session, SQLModel, create_engine
+from sqlmodel.pool import StaticPool
+
+from chat import goosecracker
+from chat.models import GoosecrackerSession, GoosecrackerSteering
+
+
+@pytest.fixture(name="engine")
+def engine_fixture():
+    """In-memory SQLite engine with the chat schema stripped for SQLite compat."""
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    original_schemas = {}
+    for table in SQLModel.metadata.tables.values():
+        if table.schema is not None:
+            original_schemas[table.name] = table.schema
+            table.schema = None
+    SQLModel.metadata.create_all(engine)
+    yield engine
+    for table in SQLModel.metadata.tables.values():
+        if table.name in original_schemas:
+            table.schema = original_schemas[table.name]
+
+
+def _make_session(engine, thread_id: str, transcript: str = "initial task") -> None:
+    with Session(engine) as session:
+        session.add(
+            GoosecrackerSession(
+                discord_thread=thread_id,
+                recipe="agent",
+                transcript=transcript,
+            )
+        )
+        session.commit()
+
+
+class TestEnqueueSteering:
+    def test_inserts_undelivered_row(self, engine):
+        with patch("chat.goosecracker.get_engine", return_value=engine):
+            goosecracker.enqueue_steering("t1", "m1", "u1", "beta", "  do this  ")
+
+        with Session(engine) as session:
+            rows = session.query(GoosecrackerSteering).all()
+        assert len(rows) == 1
+        row = rows[0]
+        assert row.thread_id == "t1"
+        assert row.message_id == "m1"
+        assert row.author_id == "u1"
+        assert row.tier == "beta"
+        assert row.text == "do this"  # stripped
+        assert row.delivered is False
+
+    def test_empty_text_is_noop(self, engine):
+        with patch("chat.goosecracker.get_engine", return_value=engine):
+            goosecracker.enqueue_steering("t1", "m1", "u1", "beta", "   ")
+
+        with Session(engine) as session:
+            assert session.query(GoosecrackerSteering).count() == 0
+
+
+class TestFetchSteering:
+    def test_returns_undelivered_in_order_and_marks_delivered(self, engine):
+        _make_session(engine, "t1")
+        with patch("chat.goosecracker.get_engine", return_value=engine):
+            goosecracker.enqueue_steering("t1", "m1", "u1", "beta", "first")
+            goosecracker.enqueue_steering("t1", "m2", "u2", "beta", "second")
+
+            delivered = goosecracker.fetch_steering("t1")
+
+        assert [d["text"] for d in delivered] == ["first", "second"]
+        assert [d["message_id"] for d in delivered] == ["m1", "m2"]
+        assert delivered[0]["author_id"] == "u1"
+        assert delivered[0]["tier"] == "beta"
+        assert all("id" in d for d in delivered)
+
+        with Session(engine) as session:
+            rows = session.query(GoosecrackerSteering).all()
+        assert all(r.delivered for r in rows)
+
+    def test_second_fetch_returns_nothing(self, engine):
+        _make_session(engine, "t1")
+        with patch("chat.goosecracker.get_engine", return_value=engine):
+            goosecracker.enqueue_steering("t1", "m1", "u1", "", "hello")
+            goosecracker.fetch_steering("t1")
+            second = goosecracker.fetch_steering("t1")
+
+        assert second == []
+
+    def test_after_id_filters_older_rows(self, engine):
+        _make_session(engine, "t1")
+        with patch("chat.goosecracker.get_engine", return_value=engine):
+            goosecracker.enqueue_steering("t1", "m1", "u1", "", "first")
+            goosecracker.enqueue_steering("t1", "m2", "u2", "", "second")
+
+            with Session(engine) as session:
+                first_id = (
+                    session.query(GoosecrackerSteering)
+                    .order_by(GoosecrackerSteering.id)
+                    .first()
+                    .id
+                )
+
+            delivered = goosecracker.fetch_steering("t1", after_id=first_id)
+
+        assert [d["text"] for d in delivered] == ["second"]
+
+    def test_appends_to_transcript_with_attribution(self, engine):
+        _make_session(engine, "t1", transcript="build a clock")
+        with patch("chat.goosecracker.get_engine", return_value=engine):
+            goosecracker.enqueue_steering("t1", "m1", "user-42", "", "make it red")
+            goosecracker.fetch_steering("t1")
+
+        with Session(engine) as session:
+            row = session.get(GoosecrackerSession, "t1")
+        assert "build a clock" in row.transcript
+        assert "[steering from user-42]: make it red" in row.transcript
+
+    def test_missing_session_row_still_delivers(self, engine):
+        # No GoosecrackerSession row for "no-session" - fetch must not raise.
+        with patch("chat.goosecracker.get_engine", return_value=engine):
+            goosecracker.enqueue_steering("no-session", "m1", "u1", "", "hi")
+            delivered = goosecracker.fetch_steering("no-session")
+
+        assert [d["text"] for d in delivered] == ["hi"]
+
+    def test_other_threads_not_returned(self, engine):
+        _make_session(engine, "t1")
+        _make_session(engine, "t2")
+        with patch("chat.goosecracker.get_engine", return_value=engine):
+            goosecracker.enqueue_steering("t1", "m1", "u1", "", "for t1")
+            goosecracker.enqueue_steering("t2", "m2", "u2", "", "for t2")
+
+            delivered = goosecracker.fetch_steering("t1")
+
+        assert [d["text"] for d in delivered] == ["for t1"]

--- a/projects/monolith/chat/goosecracker_test.py
+++ b/projects/monolith/chat/goosecracker_test.py
@@ -8,11 +8,11 @@ from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, patch
 
 import pytest
-from sqlmodel import Session, SQLModel, create_engine
+from sqlmodel import Session, SQLModel, create_engine, select
 from sqlmodel.pool import StaticPool
 
 from chat import goosecracker
-from chat.models import DiscordOutbox, GoosecrackerSession
+from chat.models import DiscordOutbox, GoosecrackerSession, GoosecrackerSteering
 
 # Sentinel so _make_agent_session can distinguish "caller passed None" from
 # "caller passed nothing" for the running_since / runner_instance overrides.
@@ -313,43 +313,69 @@ def test_continue_agent_session_dispatches_when_idle(engine, fake_api):
     assert call.kwargs["repo"] == "homelab"
     assert call.kwargs["discord_thread"] == "agent-t1"
 
-    # running should be True (set before dispatch)
+    # running should be True (set before dispatch), and the dispatch path
+    # appends the turn to the transcript (unlike the steering path).
     with Session(engine) as session:
         row = session.get(GoosecrackerSession, "agent-t1")
     assert row.running
     assert row.pending == ""
+    assert row.transcript == "initial task\n\nnow do this"
 
 
-def test_continue_agent_session_queues_when_running(engine, fake_api):
-    """When recipe=agent and running=True, continue_session appends to pending and
-    returns action='queued' without dispatching."""
+def test_continue_agent_session_steers_when_running(engine, fake_api):
+    """When recipe=agent and running=True, continue_session enqueues steering
+    (ADR 035 Phase 2) and returns action='steering' without dispatching or
+    touching pending. The transcript is untouched: fetch_steering owns that
+    write (with attribution) when the running guest consumes the row, so
+    continue_session must not double it."""
     with patch("chat.goosecracker.get_engine", return_value=engine):
         _make_agent_session(engine, "agent-t2", running=True)
         result = goosecracker.continue_session(
-            "agent-t2", "extra instruction", "msg-99"
+            "agent-t2", "extra instruction", "msg-99", author_id="U1"
         )
 
-    assert result == {"action": "queued"}
+    assert result == {"action": "steering"}
     fake_api.submit.assert_not_called()
 
     with Session(engine) as session:
         row = session.get(GoosecrackerSession, "agent-t2")
+        steering = session.exec(select(GoosecrackerSteering)).all()
     assert row.running
-    assert row.pending == "extra instruction"
-    # The queued message's id is recorded so the runner can react on it.
-    assert row.pending_message_ids == "msg-99"
+    assert row.pending == ""
+    assert row.transcript == "initial task"  # unchanged by this call
+    assert len(steering) == 1
+    assert steering[0].thread_id == "agent-t2"
+    assert steering[0].message_id == "msg-99"
+    assert steering[0].author_id == "U1"
+    assert steering[0].text == "extra instruction"
+    assert steering[0].delivered is False
 
 
-def test_continue_agent_session_queues_multiple_appends_to_pending(engine, fake_api):
-    """Multiple queued replies are newline-joined in pending."""
+def test_continue_agent_session_steering_falls_back_to_session_tier(engine, fake_api):
+    """A blank tier argument falls back to the session's own tier."""
     with patch("chat.goosecracker.get_engine", return_value=engine):
-        _make_agent_session(engine, "agent-t3", running=True, pending="first reply")
-        result = goosecracker.continue_session("agent-t3", "second reply")
+        _make_agent_session(engine, "agent-t2b", running=True)
+        goosecracker.continue_session("agent-t2b", "steer this", author_id="U1")
 
-    assert result == {"action": "queued"}
     with Session(engine) as session:
-        row = session.get(GoosecrackerSession, "agent-t3")
-    assert row.pending == "first reply\nsecond reply"
+        steering = session.exec(select(GoosecrackerSteering)).all()
+    assert steering[0].tier == ""  # _make_agent_session defaults tier to ""
+
+
+def test_continue_agent_session_multiple_steers_insert_separate_rows(engine, fake_api):
+    """Multiple steering replies each become their own row, not a joined string
+    (unlike the legacy pending queue)."""
+    with patch("chat.goosecracker.get_engine", return_value=engine):
+        _make_agent_session(engine, "agent-t3", running=True)
+        goosecracker.continue_session("agent-t3", "first reply", author_id="U1")
+        goosecracker.continue_session("agent-t3", "second reply", author_id="U2")
+
+    with Session(engine) as session:
+        steering = session.exec(
+            select(GoosecrackerSteering).order_by(GoosecrackerSteering.id)
+        ).all()
+    assert [s.text for s in steering] == ["first reply", "second reply"]
+    assert [s.author_id for s in steering] == ["U1", "U2"]
 
 
 def test_continue_agent_session_consumes_pending_on_dispatch(engine, fake_api):

--- a/projects/monolith/chat/models.py
+++ b/projects/monolith/chat/models.py
@@ -189,6 +189,29 @@ class GoosecrackerSession(SQLModel, table=True):
     updated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
 
 
+class GoosecrackerSteering(SQLModel, table=True):
+    """Mid-run steering queue for goosecracker agent threads (ADR 035 Phase 2).
+
+    While a turn is running, thread participants' replies are enqueued here
+    (by the bot, ACL-gated) rather than into ``GoosecrackerSession.pending``
+    (which is drained between turns by the runner). The running guest recipe
+    polls the steering endpoint at stage boundaries and marks rows delivered
+    as it consumes them, so a re-poll never redelivers the same message.
+    """
+
+    __tablename__ = "goosecracker_steering"
+    __table_args__ = {"schema": "chat", "extend_existing": True}
+
+    id: int | None = Field(default=None, primary_key=True)
+    thread_id: str = Field(index=True)
+    message_id: str = Field(default="")
+    author_id: str = Field(default="")
+    tier: str = Field(default="")
+    text: str = Field(default="")
+    delivered: bool = Field(default=False)
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+
+
 class DiscordFeatureGrant(SQLModel, table=True):
     """Generic per-server Discord bot feature ACL (ADR 029).
 

--- a/projects/monolith/chat/models.py
+++ b/projects/monolith/chat/models.py
@@ -185,6 +185,11 @@ class GoosecrackerSession(SQLModel, table=True):
     # live page hot-reloads at a stable but non-discoverable URL (never the
     # enumerable Discord thread id).
     artifact_id: str = Field(default="")
+    # Unguessable per-session capability token that keys the guest steering fetch
+    # URL (ADR 035 Phase 2 hardening), so a compromised guest cannot address
+    # another thread's steering by guessing its Discord thread id. Assigned
+    # lazily on first dispatch, same pattern as artifact_id.
+    steering_token: str = Field(default="")
     created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     updated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
 
@@ -203,7 +208,7 @@ class GoosecrackerSteering(SQLModel, table=True):
     __table_args__ = {"schema": "chat", "extend_existing": True}
 
     id: int | None = Field(default=None, primary_key=True)
-    thread_id: str = Field(index=True)
+    thread_id: str = Field(default="")
     message_id: str = Field(default="")
     author_id: str = Field(default="")
     tier: str = Field(default="")

--- a/projects/monolith/chat/router.py
+++ b/projects/monolith/chat/router.py
@@ -158,3 +158,17 @@ async def post_progress_by_id(run_id: str, body: ProgressChunkIn) -> Response:
     if body.done:
         gp.mark_done(run_id)
     return Response(status_code=204)
+
+
+@internal_router.get("/steering/{thread_id}")
+async def get_steering(thread_id: str, after_id: int = 0) -> dict:
+    """Return undelivered steering messages for a running agent session and
+    mark them delivered. The guest recipe polls this at stage boundaries.
+    In-cluster only (reached by the guest via the egress funnel), like the
+    progress sink; the bot ACL-gates what gets enqueued (Task 2.3)."""
+    from chat import goosecracker
+
+    if not _ID_RE.match(thread_id):
+        raise HTTPException(400, "invalid id")
+    messages = await asyncio.to_thread(goosecracker.fetch_steering, thread_id, after_id)
+    return {"messages": messages}

--- a/projects/monolith/chat/router.py
+++ b/projects/monolith/chat/router.py
@@ -160,15 +160,20 @@ async def post_progress_by_id(run_id: str, body: ProgressChunkIn) -> Response:
     return Response(status_code=204)
 
 
-@internal_router.get("/steering/{thread_id}")
-async def get_steering(thread_id: str, after_id: int = 0) -> dict:
-    """Return undelivered steering messages for a running agent session and
-    mark them delivered. The guest recipe polls this at stage boundaries.
-    In-cluster only (reached by the guest via the egress funnel), like the
-    progress sink; the bot ACL-gates what gets enqueued (Task 2.3)."""
+@internal_router.get("/steering/{token}")
+async def get_steering(token: str, after_id: int = 0) -> dict:
+    """Return undelivered steering for the session addressed by an unguessable
+    per-session token (NOT the thread id), and mark it delivered. The runner
+    injects this token-keyed URL into the guest; keying on the token (not the
+    guessable Discord thread snowflake) stops a compromised guest from reading,
+    denying, or polluting another thread's steering. In-cluster only, like the
+    progress sink."""
     from chat import goosecracker
 
-    if not _ID_RE.match(thread_id):
-        raise HTTPException(400, "invalid id")
+    if not _ID_RE.match(token):
+        raise HTTPException(400, "invalid token")
+    thread_id = await asyncio.to_thread(goosecracker.thread_for_steering_token, token)
+    if thread_id is None:
+        return {"messages": []}
     messages = await asyncio.to_thread(goosecracker.fetch_steering, thread_id, after_id)
     return {"messages": messages}

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.250.0
+      targetRevision: 0.251.0
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/deploy/values.yaml
+++ b/projects/monolith/deploy/values.yaml
@@ -158,6 +158,10 @@ goosecracker:
   # there through the fc-invoke egress funnel, and the Discord bot polls the
   # in-memory buffer keyed by the session (== the Discord thread id).
   progressUrl: "http://monolith.monolith.svc.cluster.local:8000/internal/goosecracker/progress"
+  # The monolith's own in-cluster steering endpoint base (ADR 035 phase 2). The
+  # runner hands the guest "<this>/<session>"; the recipe polls it at stage
+  # boundaries for mid-run adjustments posted to the thread.
+  steeringUrl: "http://monolith.monolith.svc.cluster.local:8000/internal/goosecracker/steering"
   # The in-cluster git mirror base URL (WS2 hydration). The runner defaults
   # gitMirror to "<gitMirror>/homelab" when the caller does not specify one.
   # The mirror serves git:// on :9418 (ADR 026 + git-mirror service in

--- a/projects/monolith/goosecracker/runner.py
+++ b/projects/monolith/goosecracker/runner.py
@@ -81,16 +81,18 @@ def _progress_url(session: str) -> str:
 
 
 # The monolith's own in-cluster steering endpoint base (ADR 035 phase 2). The
-# runner injects "<this>/<session>" into the guest env as
+# runner injects "<this>/<token>" into the guest env as
 # GOOSECRACKER_STEERING_URL so the recipe can poll it at stage boundaries for
-# mid-run adjustments posted to the thread.
+# mid-run adjustments posted to the thread. Keyed on the unguessable per-session
+# token (not the session/thread id) so a compromised guest cannot fetch another
+# thread's steering by guessing its Discord thread snowflake.
 STEERING_URL_BASE = os.environ.get("GOOSECRACKER_STEERING_URL", "")
 
 
-def _steering_url(session: str) -> str:
-    if not STEERING_URL_BASE:
+def _steering_url(token: str) -> str:
+    if not STEERING_URL_BASE or not token:
         return ""
-    return f"{STEERING_URL_BASE.rstrip('/')}/{session}"
+    return f"{STEERING_URL_BASE.rstrip('/')}/{token}"
 
 
 def _effective_mirror_ref(
@@ -500,9 +502,18 @@ async def _run_one_turn(
             raise RuntimeError("FC_INVOKE_URL is not configured")
 
         env = tiers.env_for_tier(tier)
-        # ADR 035 phase 2: inject the steering URL into a copy of the tier env so
-        # the recipe can poll it, without mutating the dict env_for_tier returned.
-        steering_url = _steering_url(session)
+        # ADR 035 phase 2 (hardening): inject a steering URL keyed on an
+        # unguessable per-session token, not the thread/session id, into a copy
+        # of the tier env so the recipe can poll it without mutating the dict
+        # env_for_tier returned. A compromised guest that reads this env only
+        # learns its own token, which can never resolve another thread's
+        # steering. Reached through chat.api's boundary the same as the other
+        # chat.* calls in this module (import_boundaries_test).
+        from chat.api import ensure_steering_token
+
+        # nosemgrep: no-session-in-to-thread  # `session` is the fc-invoke session-id string, not a SQLAlchemy Session
+        steering_token = await asyncio.to_thread(ensure_steering_token, session)
+        steering_url = _steering_url(steering_token) if steering_token else ""
         if steering_url:
             env = {**env, "GOOSECRACKER_STEERING_URL": steering_url}
         # ADR 026 Phase 2: restore the thread's persisted goose session so this run

--- a/projects/monolith/goosecracker/runner.py
+++ b/projects/monolith/goosecracker/runner.py
@@ -80,6 +80,19 @@ def _progress_url(session: str) -> str:
     return f"{PROGRESS_URL_BASE.rstrip('/')}/{session}"
 
 
+# The monolith's own in-cluster steering endpoint base (ADR 035 phase 2). The
+# runner injects "<this>/<session>" into the guest env as
+# GOOSECRACKER_STEERING_URL so the recipe can poll it at stage boundaries for
+# mid-run adjustments posted to the thread.
+STEERING_URL_BASE = os.environ.get("GOOSECRACKER_STEERING_URL", "")
+
+
+def _steering_url(session: str) -> str:
+    if not STEERING_URL_BASE:
+        return ""
+    return f"{STEERING_URL_BASE.rstrip('/')}/{session}"
+
+
 def _effective_mirror_ref(
     git_mirror: str, git_ref: str, repo: str = ""
 ) -> tuple[str, str]:
@@ -487,6 +500,11 @@ async def _run_one_turn(
             raise RuntimeError("FC_INVOKE_URL is not configured")
 
         env = tiers.env_for_tier(tier)
+        # ADR 035 phase 2: inject the steering URL into a copy of the tier env so
+        # the recipe can poll it, without mutating the dict env_for_tier returned.
+        steering_url = _steering_url(session)
+        if steering_url:
+            env = {**env, "GOOSECRACKER_STEERING_URL": steering_url}
         # ADR 026 Phase 2: restore the thread's persisted goose session so this run
         # resumes the prior conversation (Model A) instead of cold-rebuilding
         # (Model B). Resume is derived from the blob's presence, not a stored flag:


### PR DESCRIPTION
## Summary

Phase 2 of the [ADR 035 plan](https://github.com/jomcgi/homelab/blob/main/docs/plans/2026-07-02-discord-multiplayer-agent-ux.md): while a goose agent turn runs, ACL-permitted thread participants can steer it mid-run, and the running recipe consumes that steering at stage boundaries.

- **2.1 Steering surface**: new `chat.goosecracker_steering` table + `enqueue_steering` / `fetch_steering(thread_id, after_id)` (marks delivered, appends to the session transcript with attribution) + a guest endpoint.
- **2.2 Recipe consumption**: the monolith runner injects a steering URL into the guest env (mirrors the progress URL, via the existing env-merge seam, no guest-init Go changes); `agent.yaml` curls it at stage boundaries, folds content into the sub-recipe context, or aborts on `stop`/`cancel` (emitting skipped + done markers). curl is best-effort (never blocks the run).
- **2.3 Tier-gated multiplayer**: `_maybe_handle_goosecracker_reply` now gates agent-thread replies with `acl.is_granted(guild, author, "agent", session_repo)` (was open to everyone); permitted participants steer a running turn (👀 reaction), others get a grant-naming refusal. `continue_session`'s running-turn branch enqueues steering atomically under the row lock instead of the old `pending` append, and the transcript append moved to the dispatch/artifact paths only (so steering is never double-recorded, since `fetch_steering` writes it on consumption).
- **Security hardening**: the steering endpoint is keyed on an unguessable per-session token (`secrets.token_urlsafe`, the `artifact_id` capability-URL pattern), not the guessable Discord thread snowflake, so a compromised guest can only ever fetch its own thread's steering. Unknown token fails closed (empty, no leak, no 500).

## Review

One comprehensive Opus review: verified the transcript refactor (appended exactly once in dispatch and once in artifact, never in steering), the atomic steering enqueue, deadlock-freedom (no session↔steering lock cycle), and ACL scope consistency, all correct. The one flagged security gap (cross-thread capability on the snowflake-keyed endpoint) was closed by the token binding above, per an explicit accept/close decision.

## Deploy

monolith `0.250.0 -> 0.251.0`, fc-invoke (substrate) `0.4.25 -> 0.4.26` (+ application.yaml targetRevisions).

## Deferred (documented, not a gap)

Per-action "requires a higher tier" refusal *inside* a run is deferred: it needs reliable action-intent classification the local router model can't provide. The `acl.is_granted` gate is the multiplayer access control for this phase.

## Verification note

Steering consumption is local-model-driven recipe behavior (curl + branch on JSON), verifiable only by a live smoke test (post a real steering comment and a real `stop` mid-run). That is the phase live check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)