### PR TITLE
fix(goosecracker): restore newline on guest progress chunks so stage markers parse

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.251.0
+version: 0.252.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chat/router.py
+++ b/projects/monolith/chat/router.py
@@ -128,7 +128,7 @@ async def post_progress(body: ProgressIn) -> Response:
     if not _ID_RE.match(body.id):
         raise HTTPException(400, "invalid id")
     if body.chunk:
-        gp.append(body.id, body.chunk)
+        gp.append(body.id, body.chunk + "\n")
     if body.done:
         gp.mark_done(body.id)
     return Response(status_code=204)
@@ -148,13 +148,21 @@ async def post_progress_by_id(run_id: str, body: ProgressChunkIn) -> Response:
     the run id rides in the path here rather than the body. Same in-memory buffer,
     keyed by ``run_id`` (== the Discord thread the bot polls), so the live stream
     just works.
+
+    The guest streams goose stdout one line per POST, and its scanner strips the
+    trailing newline, so each chunk is a complete line with no newline. Restore
+    it before appending: the buffer's marker parser treats a marker-prefixed
+    fragment with no trailing newline as an incomplete line and holds it (waiting
+    for a newline that never arrives on the next, different line), so without this
+    every ``::stage::`` marker would accumulate unparsed and the checklist would
+    never render (ADR 035).
     """
     from chat import goosecracker_progress as gp
 
     if not _ID_RE.match(run_id):
         raise HTTPException(400, "invalid id")
     if body.chunk:
-        gp.append(run_id, body.chunk)
+        gp.append(run_id, body.chunk + "\n")
     if body.done:
         gp.mark_done(run_id)
     return Response(status_code=204)

--- a/projects/monolith/chat/router_test.py
+++ b/projects/monolith/chat/router_test.py
@@ -1,4 +1,4 @@
-"""Tests for chat router -- backfill endpoint."""
+"""Tests for chat router -- backfill and internal progress endpoints."""
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -6,7 +6,8 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-from chat.router import router
+from chat import goosecracker_progress as gp
+from chat.router import internal_router, router
 
 
 @pytest.fixture
@@ -57,3 +58,52 @@ class TestBackfillEndpoint:
         with patch("chat.router.run_backfill", new_callable=AsyncMock):
             resp = client.post("/api/chat/backfill")
         assert resp.status_code == 202
+
+
+@pytest.fixture
+def internal_client():
+    app = FastAPI()
+    app.include_router(internal_router)
+    return TestClient(app)
+
+
+class TestProgressEndpointRestoresNewlines:
+    """Regression: the guest streams goose stdout one line per POST with the
+    trailing newline stripped, so each chunk is a complete line with no newline.
+    The endpoint must restore the newline or marker lines are never parsed into
+    stages (they get held as an incomplete fragment forever) and the live
+    checklist never renders. This replays the real guest format."""
+
+    def test_line_per_post_markers_parse_into_stages(self, internal_client):
+        rid = "test-progress-newline"
+        gp.clear(rid)
+        for line in ["::stages::1", "::stage::0::running::Answering"]:
+            resp = internal_client.post(
+                f"/internal/goosecracker/progress/{rid}", json={"chunk": line}
+            )
+            assert resp.status_code == 204
+        snap = gp.get(rid)
+        assert snap is not None
+        assert len(snap.stages) == 1
+        assert snap.stages[0].index == 0
+        assert snap.stages[0].state == "running"
+        assert snap.stages[0].title == "Answering"
+        # A following done marker (also its own newline-less POST) resolves it.
+        internal_client.post(
+            f"/internal/goosecracker/progress/{rid}",
+            json={"chunk": "::stage::0::done::Answering"},
+        )
+        snap = gp.get(rid)
+        assert snap.stages[0].state == "done"
+        gp.clear(rid)
+
+    def test_non_marker_line_still_reaches_text(self, internal_client):
+        rid = "test-progress-text"
+        gp.clear(rid)
+        internal_client.post(
+            f"/internal/goosecracker/progress/{rid}", json={"chunk": "wrote 12 lines"}
+        )
+        snap = gp.get(rid)
+        assert snap is not None
+        assert "wrote 12 lines" in snap.text
+        gp.clear(rid)

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.251.0
+      targetRevision: 0.252.0
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
## Summary

**Hotfix for the ADR 035 live checklist**, found during Phase 3 Discord testing: the checklist never rendered (it always fell back to the old tail renderer showing `🧠 Thinking… / ✅ Done in 0:06`), even though the guest emitted clean `::stage::` markers on stdout.

## Root cause

The guest streams goose stdout **one line per POST**, and its `bufio.Scanner` **strips the trailing newline** (`poster.post(line)` with no `\n`). But the buffer's marker parser (`goosecracker_progress.append`) treats a marker-prefixed fragment *without* a trailing newline as an incomplete line and holds it in `_partial`, waiting for a newline that never arrives (the next POST is a *different* line, which concatenates and is held again). So every `::stages::`/`::stage::` marker accumulated unparsed and no stages ever reached the buffer, so `render_checklist` always returned `None`. Non-marker text escaped this (a non-marker fragment flushes immediately), which is exactly why the tail renderer always worked but the checklist never did. The Phase 1 unit tests fed chunks *with* `\n`, so they passed; the real guest sends them *without* — a test-vs-reality gap at the boundary.

Verified live: a clean `/agent` query emitted `::stages::1` / `::stage::0::running::Answering` / `::stage::0::done::Answering` verbatim on stdout, but the Discord message stayed on the tail renderer.

## Fix

Restore the newline the guest's scanner stripped, at both progress endpoints (`gp.append(id, body.chunk + "\n")`). Each POST is exactly one complete line, so this is always correct. Monolith-only (no guest rebuild). A regression test replays the real line-per-POST, no-newline guest format through the endpoint and asserts stages populate.

## Deploy

monolith chart `0.251.0 -> 0.252.0` (+ application.yaml targetRevision).

🤖 Generated with [Claude Code](https://claude.com/claude-code)