### PR TITLE
fix(campsites): make map pins tappable and zoom-scaled on mobile

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.252.0
+version: 0.253.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.252.0
+      targetRevision: 0.253.0
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/lib/public/components/campsites/CampsitesMap.svelte
+++ b/projects/monolith/frontend/src/lib/public/components/campsites/CampsitesMap.svelte
@@ -296,12 +296,37 @@
           source: SOURCE_ID,
           paint: {
             "circle-color": SCORE_COLOR,
-            // Radius grows with good_days; selected pin is larger.
+            // Radius grows with good_days (more clear days = bigger pin), with
+            // the selected pin larger still. The outer interpolation is on
+            // ["zoom"], so pins also grow as you zoom in (they used to stay a
+            // fixed pixel size at every zoom, which read as "tiny" on a phone).
+            // Zoom-and-property form: the ["zoom"] interpolate is outermost and
+            // its stop outputs are per-feature expressions (allowed by the GL
+            // spec precisely because the inner expressions never read zoom).
+            // Bumped baselines too so the smallest pin is a realistic touch
+            // target rather than a 5px dot.
             "circle-radius": [
-              "case",
-              ["==", ["get", "sel"], 1],
-              ["interpolate", ["linear"], ["get", "good_days"], 0, 9, 7, 16],
-              ["interpolate", ["linear"], ["get", "good_days"], 0, 5, 7, 11],
+              "interpolate",
+              ["linear"],
+              ["zoom"],
+              // Zoomed out: bigger than before so pins stay tappable in the
+              // full-BC view.
+              5,
+              [
+                "case",
+                ["==", ["get", "sel"], 1],
+                ["interpolate", ["linear"], ["get", "good_days"], 0, 11, 7, 17],
+                ["interpolate", ["linear"], ["get", "good_days"], 0, 7, 7, 12],
+              ],
+              // Zoomed in: pins swell so a selected park is unmistakable and
+              // easy to hit with a fingertip.
+              11,
+              [
+                "case",
+                ["==", ["get", "sel"], 1],
+                ["interpolate", ["linear"], ["get", "good_days"], 0, 20, 7, 28],
+                ["interpolate", ["linear"], ["get", "good_days"], 0, 13, 7, 21],
+              ],
             ],
             "circle-stroke-width": [
               "case",
@@ -322,12 +347,32 @@
 
         // Click a pin to select it (drives the bindable + the parent detail
         // panel); click the background to deselect.
+        //
+        // Hit-test a padded BOX around the tap, not the exact pixel: pins are
+        // only a handful of pixels wide, and on a touch screen a fingertip
+        // never lands dead-center, so an exact-point query almost always missed
+        // and silently deselected (Anna's "buttons don't bring up info"). The
+        // box gives a forgiving ~TAP_PAD-px tolerance in every direction; when
+        // several pins fall inside it we pick the one nearest the tap.
+        const TAP_PAD = 14; // px of slop around the tap point
         map.on("click", (e) => {
-          const feats = map.queryRenderedFeatures(e.point, {
+          const box = [
+            [e.point.x - TAP_PAD, e.point.y - TAP_PAD],
+            [e.point.x + TAP_PAD, e.point.y + TAP_PAD],
+          ];
+          const feats = map.queryRenderedFeatures(box, {
             layers: [PIN_LAYER],
           });
           if (feats.length) {
-            const f = feats[0];
+            // Nearest pin to the actual tap wins, so a box that catches two
+            // neighbours still selects the one the finger was closest to.
+            const f = feats.reduce((best, cand) => {
+              const bp = map.project(best.geometry.coordinates);
+              const cp = map.project(cand.geometry.coordinates);
+              const bd = (bp.x - e.point.x) ** 2 + (bp.y - e.point.y) ** 2;
+              const cd = (cp.x - e.point.x) ** 2 + (cp.y - e.point.y) ** 2;
+              return cd < bd ? cand : best;
+            });
             selectedId = f.properties.id;
             const { name, best_score, good_days } = f.properties;
             popup


### PR DESCRIPTION
## What Anna reported (iPhone)

- Campsite pins are very hard to press, and tapping brings up no additional info.
- Zooming in does not make a pin bigger — it stays small on screen.

## Root causes (both in `CampsitesMap.svelte`)

Pins are a MapLibre `circle` layer (5-11px radius), not DOM markers, so behaviour is driven by hit-testing and paint expressions.

1. **Fat-finger misses.** The click handler hit-tested the exact tap pixel via `queryRenderedFeatures(e.point, …)`. A fingertip never lands dead-center on a 5px circle, so the query returned empty and ran the deselect branch — no popup, no detail panel.
2. **No zoom scaling.** `circle-radius` had no `["zoom"]` term, so pins were a fixed pixel size at every zoom and read as tiny.

## Fix

- **Padded-box hit-test.** Query a 14px box around the tap and select the pin nearest the tap point. Forgiving touch target; near-misses now open the popup + drive the parent detail panel.
- **Zoom-and-property radius.** Wrapped `circle-radius` in an outer `["interpolate", ["linear"], ["zoom"], …]` whose stop outputs stay per-feature (still encodes `good_days` and selection). Pins now grow when zooming in, and baselines are bumped so the smallest pin is a realistic touch target.
- Bumped monolith chart `0.252.0` → `0.253.0` (Chart.yaml + application.yaml `targetRevision`) so it rolls out.

## Verification

Read-only + local: pre-push format/semgrep/conventional-commit hooks passed. No local test loop in this repo — relying on BuildBuddy CI (incl. the public-page visual regression, though campsites is not yet in `targets.json`). Will confirm the rollout is live after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)