### PR TITLE
feat(chat): ADR 035 phase 3 - attention gate + ambient grants (contained to opted-in channels)

### DIFF
--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -869,6 +869,21 @@ py_test(
 )
 
 py_test(
+    name = "chat_attention_test",
+    srcs = ["chat/attention_test.py"],
+    imports = ["."],
+    deps = [
+        ":monolith_backend",
+        "@pip//discord_py",
+        "@pip//pgvector",
+        "@pip//pydantic_ai_slim",
+        "@pip//pytest",
+        "@pip//pytest_asyncio",
+        "@pip//sqlmodel",
+    ],
+)
+
+py_test(
     name = "chat_goosecracker_progress_test",
     srcs = ["chat/goosecracker_progress_test.py"],
     imports = ["."],

--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -857,6 +857,18 @@ py_test(
 )
 
 py_test(
+    name = "chat_attention_log_test",
+    srcs = ["chat/attention_log_test.py"],
+    imports = ["."],
+    deps = [
+        ":monolith_backend",
+        "@pip//pgvector",
+        "@pip//pytest",
+        "@pip//sqlmodel",
+    ],
+)
+
+py_test(
     name = "chat_goosecracker_progress_test",
     srcs = ["chat/goosecracker_progress_test.py"],
     imports = ["."],

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.253.0
+version: 0.254.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/migrations/20260703050000_attention_decision.sql
+++ b/projects/monolith/chart/migrations/20260703050000_attention_decision.sql
@@ -1,0 +1,16 @@
+-- Attention-gate decision log (ADR 035 phase 3). One row per attention-gate
+-- decision on a message in an ambient-mode channel: every "engage" is logged,
+-- "ignore" rows are sampled at the app layer to bound volume. Used to tune the
+-- classifier and to audit what the bot chose to engage with. Safe to create
+-- empty; directive_version stays 0 until phase 5 wires channel directives.
+CREATE TABLE IF NOT EXISTS chat.attention_decision (
+    id BIGSERIAL PRIMARY KEY,
+    channel_id TEXT NOT NULL DEFAULT '',
+    message_id TEXT NOT NULL DEFAULT '',
+    decision TEXT NOT NULL DEFAULT 'ignore',
+    confidence DOUBLE PRECISION NOT NULL DEFAULT 0,
+    directive_version INTEGER NOT NULL DEFAULT 0,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT attention_decision_decision_valid CHECK (decision IN ('engage', 'ignore'))
+);
+CREATE INDEX IF NOT EXISTS attention_decision_channel_created ON chat.attention_decision (channel_id, created_at DESC);

--- a/projects/monolith/chart/migrations/atlas.sum
+++ b/projects/monolith/chart/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:ZZBjl/3LPC8tcQLAAFY9ggoCLE/VZH4w1HADWHMloWM=
+h1:CTnBy4TG8yayFwC3lK0eGti/iAvknl7edWVocFQuX5M=
 20260330000000_initial_schema.sql h1:J2futpSW0nJAIRR7nR7ssT7LwXIYrvRI+PkHb5Y4tLI=
 20260403000000_chat_schema.sql h1:pERUFC0vzM95etRuzp43XzkCV7lBCzrrtY5Mk7aF3CA=
 20260404000000_chat_attachments.sql h1:tv+Fdbr1rQC5nzUxfaBC0O6fu2OMGgLWf+YNg1WQXi4=
@@ -86,3 +86,4 @@ h1:ZZBjl/3LPC8tcQLAAFY9ggoCLE/VZH4w1HADWHMloWM=
 20260702170000_goosecracker_parent_channel.sql h1:l1wOFXQ7VgfIeM66A/a2SdMfpKmVfUaf48MytRZOlBA=
 20260703030000_chat_goosecracker_steering.sql h1:/OyfMPzb0nL+sDO+h/7uUIaifHAN00juMXpYY90BtSY=
 20260703040000_goosecracker_steering_capability.sql h1:kCBMOSzulwquD1TP8jDVMgK4uRpBiEsKUGbWhqnMQyk=
+20260703050000_attention_decision.sql h1:POa3AXQPnqQwuZLjddmODislIfGyQ5PkHuz0Vn6bx6Y=

--- a/projects/monolith/chat/acl.py
+++ b/projects/monolith/chat/acl.py
@@ -85,6 +85,21 @@ def allowed_scopes(guild_id: object, subject_id: object, feature: str) -> set[st
     }
 
 
+def ambient_channels(guild_id: object) -> set[str]:
+    """Channel ids with ambient mode enabled in this guild (ADR 035).
+
+    Ambient mode is a DiscordFeatureGrant with feature="ambient", subject_id=""
+    (server-wide), scope=<channel_id>. Returns the set of channel ids so the
+    attention gate can cheaply check whether a channel is opted in.
+    """
+    gid = _norm(guild_id)
+    return {
+        row.scope
+        for row in _grants_for_feature("ambient")
+        if row.guild_id in ("", gid) and row.subject_id == "" and row.scope
+    }
+
+
 def bootstrap_defaults() -> None:
     """Idempotently seed the baked-in default grants (ADR 029).
 

--- a/projects/monolith/chat/acl.py
+++ b/projects/monolith/chat/acl.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import logging
 import os
+import time
 
 from sqlmodel import Session, select
 
@@ -33,15 +34,35 @@ def _norm(value: object) -> str:
     return "" if value is None else str(value)
 
 
+# Phase 3: the attention gate calls ambient_channels on every message, which
+# otherwise means a live SELECT per message. Grants change rarely, so a short
+# TTL cache trades a small staleness window (a newly added/revoked grant
+# applies within the TTL) for keeping the hot path off the DB.
+_GRANTS_CACHE: dict[str, tuple[float, list[DiscordFeatureGrant]]] = {}
+_GRANTS_TTL_SECONDS = 30.0
+
+
+def _clear_grants_cache() -> None:
+    """Drop the cached grants (tests that mutate grants call this to force a
+    refresh; production code has no need to)."""
+    _GRANTS_CACHE.clear()
+
+
 def _grants_for_feature(feature: str) -> list[DiscordFeatureGrant]:
+    now = time.monotonic()
+    cached = _GRANTS_CACHE.get(feature)
+    if cached is not None and now - cached[0] < _GRANTS_TTL_SECONDS:
+        return cached[1]
     with Session(get_engine()) as session:
-        return list(
+        rows = list(
             session.exec(
                 select(DiscordFeatureGrant).where(
                     DiscordFeatureGrant.feature == feature
                 )
             ).all()
         )
+    _GRANTS_CACHE[feature] = (now, rows)
+    return rows
 
 
 def is_granted(

--- a/projects/monolith/chat/acl_test.py
+++ b/projects/monolith/chat/acl_test.py
@@ -28,6 +28,7 @@ def engine_fixture():
             original_schemas[table.name] = table.schema
             table.schema = None
     SQLModel.metadata.create_all(engine)
+    acl._clear_grants_cache()
     yield engine
     for table in SQLModel.metadata.tables.values():
         if table.name in original_schemas:

--- a/projects/monolith/chat/acl_test.py
+++ b/projects/monolith/chat/acl_test.py
@@ -102,6 +102,39 @@ class TestFeatureEnabledAndScopes:
             assert acl.allowed_scopes("g2", "u1", "agent") == set()
 
 
+class TestAmbientChannels:
+    def test_returns_channel_scopes(self, engine):
+        _seed(
+            engine,
+            [("g1", "", "ambient", "c1"), ("g1", "", "ambient", "c2")],
+        )
+        with patch("chat.acl.get_engine", return_value=engine):
+            assert acl.ambient_channels("g1") == {"c1", "c2"}
+
+    def test_ignores_other_features_and_guilds(self, engine):
+        _seed(
+            engine,
+            [
+                ("g1", "", "ambient", "c1"),
+                ("g1", "", "agent", "homelab"),
+                ("g2", "", "ambient", "c9"),
+            ],
+        )
+        with patch("chat.acl.get_engine", return_value=engine):
+            assert acl.ambient_channels("g1") == {"c1"}
+
+    def test_ignores_subject_specific_grant(self, engine):
+        # ambient is server-wide (subject_id ""); a per-user grant should not
+        # count, even though it happens to share the feature name.
+        _seed(engine, [("g1", "u1", "ambient", "c1")])
+        with patch("chat.acl.get_engine", return_value=engine):
+            assert acl.ambient_channels("g1") == set()
+
+    def test_empty_when_no_grants(self, engine):
+        with patch("chat.acl.get_engine", return_value=engine):
+            assert acl.ambient_channels("g1") == set()
+
+
 class TestBootstrapDefaults:
     def test_seeds_home_owner_and_loom(self, engine, monkeypatch):
         monkeypatch.setenv("MONOLITH_AGENT_DISCORD_DEFAULT_SERVER_ID", "home1")

--- a/projects/monolith/chat/attention.py
+++ b/projects/monolith/chat/attention.py
@@ -1,0 +1,71 @@
+"""Attention gate (ADR 035 phase 3): should the bot engage with a message?
+
+Mentions and replies to the bot always engage (no model call). In channels with
+an ambient grant, a classify-only fast-model call scores the message against the
+channel directive and engages only above ATTENTION_THRESHOLD. Everywhere else,
+ignore. The classifier holds no tools and fails closed (ignore) on any error.
+"""
+
+import json
+import logging
+import os
+from dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
+ATTENTION_THRESHOLD = float(os.environ.get("ATTENTION_THRESHOLD", "0.8"))
+
+
+@dataclass
+class AttentionResult:
+    engage: bool
+    confidence: float
+
+
+async def evaluate(
+    message, directive: str, bot_user, is_ambient: bool, *, _caller=None
+) -> AttentionResult:
+    """Decide whether to engage. See module docstring.
+
+    ``directive`` is the channel directive text (empty until Phase 5 wires it).
+    ``_caller`` is an injectable llm-caller for tests; defaults to
+    ``build_llm_caller()``.
+    """
+    from chat.bot import should_respond  # mention/reply detection (lazy to avoid cycle)
+
+    if should_respond(message, bot_user):
+        return AttentionResult(True, 1.0)
+    if not is_ambient:
+        return AttentionResult(False, 0.0)
+    # Ambient channel: classify.
+    try:
+        caller = _caller
+        if caller is None:
+            from chat.summarizer import build_llm_caller
+
+            caller = build_llm_caller()
+        text = (message.content or "")[:500]
+        prompt = (
+            "You decide whether an assistant should jump into a chat message. "
+            "Channel directive (how the assistant should behave here): "
+            + (directive or "(none)")
+            + "\nMessage: "
+            + text
+            + '\nReply with ONLY a JSON object: {"engage": true|false, '
+            '"confidence": 0.0-1.0}. Engage only if the message clearly wants '
+            "the assistant per the directive. No prose, no markdown."
+        )
+        raw = await caller(prompt)
+        data = json.loads(_extract_json(raw))
+        engage = bool(data.get("engage", False))
+        conf = float(data.get("confidence", 0.0))
+        return AttentionResult(engage and conf >= ATTENTION_THRESHOLD, conf)
+    except Exception:
+        logger.exception("attention: classify failed; failing closed (ignore)")
+        return AttentionResult(False, 0.0)
+
+
+def _extract_json(raw: str) -> str:
+    """Pull the first {...} object out of a model reply (tolerates stray text)."""
+    s = raw.find("{")
+    e = raw.rfind("}")
+    return raw[s : e + 1] if s != -1 and e != -1 and e > s else raw

--- a/projects/monolith/chat/attention_log.py
+++ b/projects/monolith/chat/attention_log.py
@@ -1,0 +1,58 @@
+"""Attention-decision logging (ADR 035 phase 3).
+
+Engages are always logged; ignores are sampled by
+``ATTENTION_IGNORE_SAMPLE_RATE`` (default 0.1) to bound volume, since most
+ambient-channel traffic is an ignore.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import random
+
+from sqlmodel import Session
+
+from app.db import get_engine
+from chat.models import AttentionDecision
+
+logger = logging.getLogger(__name__)
+
+ATTENTION_IGNORE_SAMPLE_RATE = float(
+    os.environ.get("ATTENTION_IGNORE_SAMPLE_RATE", "0.1")
+)
+
+
+def log_decision(
+    channel_id: object,
+    message_id: object,
+    decision: str,
+    confidence: float,
+    directive_version: int = 0,
+    *,
+    _rng=random.random,
+) -> None:
+    """Persist an attention decision.
+
+    Engages are always logged; ignores are logged only when ``_rng()`` falls
+    within ``ATTENTION_IGNORE_SAMPLE_RATE``. ``_rng`` is injectable so tests can
+    force sampling deterministically. Synchronous (opens its own session); call
+    via ``asyncio.to_thread`` from the bot's async handlers. Best-effort: never
+    raises into the caller, since a logging failure should not block a reply.
+    """
+    if decision == "ignore" and _rng() > ATTENTION_IGNORE_SAMPLE_RATE:
+        return
+    try:
+        with Session(get_engine()) as session:
+            session.add(
+                AttentionDecision(
+                    channel_id=str(channel_id),
+                    message_id=str(message_id),
+                    decision=decision,
+                    confidence=float(confidence),
+                    directive_version=int(directive_version),
+                )
+            )
+            session.commit()
+    except Exception:
+        logger.exception("attention: failed to log decision")

--- a/projects/monolith/chat/attention_log_test.py
+++ b/projects/monolith/chat/attention_log_test.py
@@ -1,0 +1,95 @@
+"""Tests for chat.attention_log: the attention-gate decision log (ADR 035).
+
+DB-backed tests run against in-memory SQLite with the chat schema stripped,
+mirroring chat.acl_test.
+"""
+
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+from sqlmodel import Session, SQLModel, create_engine, select
+from sqlmodel.pool import StaticPool
+
+from chat import attention_log
+from chat.models import AttentionDecision
+
+
+@pytest.fixture(name="engine")
+def engine_fixture():
+    """In-memory SQLite engine with the chat schema stripped for SQLite compat."""
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    original_schemas = {}
+    for table in SQLModel.metadata.tables.values():
+        if table.schema is not None:
+            original_schemas[table.name] = table.schema
+            table.schema = None
+    SQLModel.metadata.create_all(engine)
+    yield engine
+    for table in SQLModel.metadata.tables.values():
+        if table.name in original_schemas:
+            table.schema = original_schemas[table.name]
+
+
+class TestLogDecision:
+    def test_engage_is_always_logged(self, engine):
+        with patch("chat.attention_log.get_engine", return_value=engine):
+            attention_log.log_decision(
+                "c1", "m1", "engage", 0.9, directive_version=2, _rng=lambda: 0.99
+            )
+        with Session(engine) as session:
+            rows = session.exec(select(AttentionDecision)).all()
+        assert len(rows) == 1
+        row = rows[0]
+        assert row.channel_id == "c1"
+        assert row.message_id == "m1"
+        assert row.decision == "engage"
+        assert row.confidence == 0.9
+        assert row.directive_version == 2
+
+    def test_ignore_logged_when_sampled_in(self, engine):
+        with patch("chat.attention_log.get_engine", return_value=engine):
+            attention_log.log_decision("c1", "m1", "ignore", 0.1, _rng=lambda: 0.0)
+        with Session(engine) as session:
+            rows = session.exec(select(AttentionDecision)).all()
+        assert len(rows) == 1
+        assert rows[0].decision == "ignore"
+
+    def test_ignore_skipped_when_sampled_out(self, engine):
+        with patch("chat.attention_log.get_engine", return_value=engine):
+            attention_log.log_decision("c1", "m1", "ignore", 0.1, _rng=lambda: 0.9)
+        with Session(engine) as session:
+            rows = session.exec(select(AttentionDecision)).all()
+        assert rows == []
+
+    def test_ids_are_stringified(self, engine):
+        with patch("chat.attention_log.get_engine", return_value=engine):
+            attention_log.log_decision(111, 222, "engage", 0.5, _rng=lambda: 0.0)
+        with Session(engine) as session:
+            row = session.exec(select(AttentionDecision)).one()
+        assert row.channel_id == "111"
+        assert row.message_id == "222"
+
+
+class TestDecisionCheckConstraint:
+    def test_rejects_invalid_decision(self, engine):
+        with Session(engine) as session:
+            session.add(
+                AttentionDecision(channel_id="c1", message_id="m1", decision="bogus")
+            )
+            with pytest.raises(IntegrityError):
+                session.commit()
+
+    def test_accepts_engage_and_ignore(self, engine):
+        with Session(engine) as session:
+            session.add(
+                AttentionDecision(channel_id="c1", message_id="m1", decision="engage")
+            )
+            session.add(
+                AttentionDecision(channel_id="c1", message_id="m2", decision="ignore")
+            )
+            session.commit()  # must not raise

--- a/projects/monolith/chat/attention_test.py
+++ b/projects/monolith/chat/attention_test.py
@@ -1,0 +1,90 @@
+"""Tests for chat.attention: the attention gate (ADR 035 phase 3).
+
+Mentions/replies engage without touching the classifier; ambient channels
+classify via an injected fast-model caller; the classifier fails closed on
+any error and tolerates stray text around its JSON reply.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from chat.attention import ATTENTION_THRESHOLD, evaluate
+
+
+def _make_message(content: str = "hey", mentions=None, reference=None):
+    return SimpleNamespace(
+        content=content,
+        mentions=mentions if mentions is not None else [],
+        reference=reference,
+        author=SimpleNamespace(bot=False, id=1),
+    )
+
+
+_BOT_USER = SimpleNamespace(id=999)
+
+
+class TestExplicitTrigger:
+    @pytest.mark.asyncio
+    async def test_mention_engages_without_calling_the_classifier(self):
+        message = _make_message(mentions=[_BOT_USER])
+        caller = AsyncMock()
+        result = await evaluate(
+            message, "", _BOT_USER, is_ambient=False, _caller=caller
+        )
+        assert result.engage is True
+        assert result.confidence == 1.0
+        caller.assert_not_called()
+
+
+class TestNonAmbientNonMention:
+    @pytest.mark.asyncio
+    async def test_ignored_without_calling_the_classifier(self):
+        message = _make_message()
+        caller = AsyncMock()
+        result = await evaluate(
+            message, "", _BOT_USER, is_ambient=False, _caller=caller
+        )
+        assert result.engage is False
+        assert result.confidence == 0.0
+        caller.assert_not_called()
+
+
+class TestAmbientClassification:
+    @pytest.mark.asyncio
+    async def test_engages_above_threshold(self):
+        message = _make_message(content="hey can you help with this")
+        caller = AsyncMock(return_value='{"engage": true, "confidence": 0.9}')
+        result = await evaluate(
+            message, "help with code", _BOT_USER, is_ambient=True, _caller=caller
+        )
+        assert result.engage is True
+        assert result.confidence == 0.9
+        caller.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_ignores_below_threshold(self):
+        message = _make_message(content="maybe you could help")
+        caller = AsyncMock(return_value='{"engage": true, "confidence": 0.5}')
+        result = await evaluate(
+            message, "help with code", _BOT_USER, is_ambient=True, _caller=caller
+        )
+        assert result.confidence < ATTENTION_THRESHOLD
+        assert result.engage is False
+
+    @pytest.mark.asyncio
+    async def test_fails_closed_on_caller_error(self):
+        message = _make_message(content="anything")
+        caller = AsyncMock(side_effect=RuntimeError("model unreachable"))
+        result = await evaluate(message, "", _BOT_USER, is_ambient=True, _caller=caller)
+        assert result.engage is False
+        assert result.confidence == 0.0
+
+    @pytest.mark.asyncio
+    async def test_extracts_json_from_surrounding_prose(self):
+        message = _make_message(content="anything")
+        caller = AsyncMock(return_value='sure! {"engage": true, "confidence": 0.95} ok')
+        result = await evaluate(message, "", _BOT_USER, is_ambient=True, _caller=caller)
+        assert result.engage is True
+        assert result.confidence == 0.95

--- a/projects/monolith/chat/bot.py
+++ b/projects/monolith/chat/bot.py
@@ -29,6 +29,8 @@ from chat.store import MessageStore
 from chat.vision import VisionClient
 from chat.web_search import search_web
 from chat import acl
+from chat import attention
+from chat import attention_log
 from chat import goosecracker
 from chat import goosecracker_progress
 from app.db import get_engine
@@ -678,6 +680,29 @@ class ChatBot(discord.Client):
             if await self._maybe_handle_goosecracker_reply(message):
                 return
 
+        # ADR 035 attention gate: decide whether to engage. Mentions/replies
+        # always engage; ambient channels classify; everything else ignores and
+        # falls through to normal message storage unchanged.
+        guild_id = message.guild.id if message.guild else None
+        is_ambient = channel_id in await asyncio.to_thread(
+            acl.ambient_channels, guild_id
+        )
+        explicit = should_respond(message, self.user)
+        if is_ambient or explicit:
+            directive = ""  # Phase 5 wires directives.get_active(channel)
+            result = await attention.evaluate(message, directive, self.user, is_ambient)
+            await asyncio.to_thread(
+                attention_log.log_decision,
+                channel_id,
+                msg_id,
+                "engage" if result.engage else "ignore",
+                result.confidence,
+                0,
+            )
+            if result.engage:
+                await self._engage_agent(message)
+                return
+
         await self._process_message(message)
 
     async def _handle_goosecracker_command(
@@ -768,11 +793,37 @@ class ChatBot(discord.Client):
             return
 
         await interaction.response.defer(thinking=True)
-        try:
-            name = f"agent: {prompt}"[:90]
-            thread = await channel.create_thread(
-                name=name, type=discord.ChannelType.public_thread
+        thread = await self.start_agent_flow(channel, interaction.user, prompt, repo)
+        if thread is None:
+            await interaction.followup.send(
+                "Couldn't start that one. Check the logs.", ephemeral=True
             )
+            return
+        await interaction.followup.send(f"Running agent in {thread.mention}")
+
+    async def start_agent_flow(
+        self,
+        channel: discord.TextChannel,
+        user: discord.abc.User,
+        prompt: str,
+        repo: str,
+        trigger_message: discord.Message | None = None,
+    ) -> discord.Thread | None:
+        """Shared agent dispatch for the /agent slash command AND mention/ambient
+        triggers (ADR 035). Opens a thread (from ``trigger_message`` if given, so
+        a mention thread hangs off the mention; else from ``channel``), starts
+        the agent session, posts the immutable prompt echo, and starts the live
+        checklist stream. Does NOT do ACL checks or send origin-channel acks (the
+        caller owns those). Returns the thread, or None on failure.
+        """
+        name = f"agent: {prompt}"[:90]
+        try:
+            if trigger_message is not None:
+                thread = await trigger_message.create_thread(name=name)
+            else:
+                thread = await channel.create_thread(
+                    name=name, type=discord.ChannelType.public_thread
+                )
             await asyncio.to_thread(
                 goosecracker.start_agent_session,
                 str(thread.id),
@@ -782,17 +833,13 @@ class ChatBot(discord.Client):
             )
         except Exception:
             logger.exception("goosecracker: failed to start agent session")
-            await interaction.followup.send(
-                "Couldn't start that one. Check the logs.", ephemeral=True
-            )
-            return
+            return None
 
-        await interaction.followup.send(f"Running agent in {thread.mention}")
         try:
             # Echo the full prompt into the thread: the thread title truncates it
             # to ~90 chars, so a long prompt is otherwise lost. Its own message,
             # not the intro (which the progress stream live-edits and would clobber).
-            await thread.send(_format_agent_prompt_echo(interaction.user, prompt))
+            await thread.send(_format_agent_prompt_echo(user, prompt))
         except Exception:
             logger.exception("goosecracker: failed to post agent prompt echo")
         try:
@@ -804,6 +851,7 @@ class ChatBot(discord.Client):
             self._start_goosecracker_stream(str(thread.id), intro, kind="agent")
         except Exception:
             logger.exception("goosecracker: failed to post agent thread intro")
+        return thread
 
     def _start_goosecracker_stream(
         self, artifact_id: str, message: discord.Message, kind: str = "artifact"
@@ -1021,6 +1069,45 @@ class ChatBot(discord.Client):
         self._start_goosecracker_stream(thread_id, progress_msg)
         await asyncio.to_thread(self._complete_lock, msg_id)
         return True
+
+    async def _engage_agent(self, message: discord.Message) -> None:
+        """A mention/reply/ambient engage: run the /agent flow (repo-less) off
+        this message, applying the same agent ACL check as ``/agent``. On a
+        missing grant, an EXPLICIT trigger (mention/reply) gets a short
+        refusal; an ambient engage stays silent (no spam in a channel nobody
+        asked the bot into). Marks the message lock completed either way.
+        """
+        guild_id = message.guild.id if message.guild else None
+        user = message.author
+        granted = await asyncio.to_thread(
+            acl.feature_enabled, guild_id, "agent"
+        ) and await asyncio.to_thread(acl.is_granted, guild_id, user.id, "agent", "")
+        explicit = should_respond(message, self.user)
+        if not granted:
+            if explicit:
+                scopes = await asyncio.to_thread(
+                    acl.allowed_scopes, guild_id, user.id, "agent"
+                )
+                allowed = ", ".join(sorted(scopes)) or "none"
+                try:
+                    await message.reply(
+                        f"I can't run the agent for you here. Allowed: {allowed}."
+                    )
+                except discord.HTTPException:
+                    logger.exception("agent: failed to send refusal")
+            await asyncio.to_thread(self._complete_lock, str(message.id))
+            return
+
+        channel = message.channel
+        if not isinstance(channel, discord.TextChannel):
+            # Ambient/mention only makes sense in a text channel we can thread from.
+            await asyncio.to_thread(self._complete_lock, str(message.id))
+            return
+
+        await self.start_agent_flow(
+            channel, user, message.content, "", trigger_message=message
+        )
+        await asyncio.to_thread(self._complete_lock, str(message.id))
 
     def _complete_lock(self, msg_id: str) -> None:
         """Mark a message lock completed (sync; call via asyncio.to_thread)."""

--- a/projects/monolith/chat/bot.py
+++ b/projects/monolith/chat/bot.py
@@ -680,17 +680,18 @@ class ChatBot(discord.Client):
             if await self._maybe_handle_goosecracker_reply(message):
                 return
 
-        # ADR 035 attention gate: decide whether to engage. Mentions/replies
-        # always engage; ambient channels classify; everything else ignores and
-        # falls through to normal message storage unchanged.
+        # ADR 035 attention gate (Phase 3 rollout: contained to opted-in
+        # channels). Agent-triggering fires ONLY in ambient channels; mentions
+        # and replies in non-ambient channels keep today's inline chat reply via
+        # _process_message. Once Phase 4's chat branch makes an agent-flow reply
+        # lightweight, the spec's "mentions always engage" can extend server-wide.
         guild_id = message.guild.id if message.guild else None
         is_ambient = channel_id in await asyncio.to_thread(
             acl.ambient_channels, guild_id
         )
-        explicit = should_respond(message, self.user)
-        if is_ambient or explicit:
+        if is_ambient:
             directive = ""  # Phase 5 wires directives.get_active(channel)
-            result = await attention.evaluate(message, directive, self.user, is_ambient)
+            result = await attention.evaluate(message, directive, self.user, True)
             await asyncio.to_thread(
                 attention_log.log_decision,
                 channel_id,
@@ -1104,9 +1105,14 @@ class ChatBot(discord.Client):
             await asyncio.to_thread(self._complete_lock, str(message.id))
             return
 
-        await self.start_agent_flow(
+        thread = await self.start_agent_flow(
             channel, user, message.content, "", trigger_message=message
         )
+        if thread is None and explicit:
+            try:
+                await message.reply("Couldn't start that one. Check the logs.")
+            except discord.HTTPException:
+                logger.exception("agent: failed to send start-failure reply")
         await asyncio.to_thread(self._complete_lock, str(message.id))
 
     def _complete_lock(self, msg_id: str) -> None:

--- a/projects/monolith/chat/bot.py
+++ b/projects/monolith/chat/bot.py
@@ -686,9 +686,18 @@ class ChatBot(discord.Client):
         # _process_message. Once Phase 4's chat branch makes an agent-flow reply
         # lightweight, the spec's "mentions always engage" can extend server-wide.
         guild_id = message.guild.id if message.guild else None
-        is_ambient = channel_id in await asyncio.to_thread(
-            acl.ambient_channels, guild_id
-        )
+        try:
+            is_ambient = channel_id in await asyncio.to_thread(
+                acl.ambient_channels, guild_id
+            )
+        except Exception:
+            # Best-effort: if the grants read fails (DB blip), treat the channel
+            # as non-ambient and fall through to normal handling rather than
+            # dropping the message. Fail closed (no ambient engage on error).
+            logger.exception(
+                "attention: ambient lookup failed; treating as non-ambient"
+            )
+            is_ambient = False
         if is_ambient:
             directive = ""  # Phase 5 wires directives.get_active(channel)
             result = await attention.evaluate(message, directive, self.user, True)

--- a/projects/monolith/chat/bot_on_message_test.py
+++ b/projects/monolith/chat/bot_on_message_test.py
@@ -567,6 +567,39 @@ class TestAttentionGate:
         mock_evaluate.assert_not_called()
         bot._process_message.assert_called_once_with(message)
 
+    @pytest.mark.asyncio
+    async def test_ambient_lookup_failure_falls_through_to_chat(self):
+        """If the ambient grants read raises (e.g. a DB blip), on_message treats
+        the channel as non-ambient and falls through to _process_message rather
+        than dropping the message or raising."""
+        bot = _make_bot()
+
+        message = _make_message(content="hello", mentions=[])
+        message.reference = None
+        message.guild = None
+
+        mock_store = _make_store()
+
+        with (
+            patch("chat.bot.get_engine"),
+            patch("chat.bot.Session") as mock_session_cls,
+            patch("chat.bot.MessageStore", return_value=mock_store),
+            patch(
+                "chat.bot.acl.ambient_channels",
+                side_effect=RuntimeError("db down"),
+            ),
+            patch("chat.bot.attention.evaluate", AsyncMock()) as mock_evaluate,
+            patch.object(bot, "_process_message", AsyncMock()),
+        ):
+            mock_session_cls.return_value.__enter__ = MagicMock(
+                return_value=MagicMock()
+            )
+            mock_session_cls.return_value.__exit__ = MagicMock(return_value=False)
+            await bot.on_message(message)
+
+        mock_evaluate.assert_not_called()
+        bot._process_message.assert_called_once_with(message)
+
 
 # ---------------------------------------------------------------------------
 # create_bot

--- a/projects/monolith/chat/bot_on_message_test.py
+++ b/projects/monolith/chat/bot_on_message_test.py
@@ -448,8 +448,10 @@ class TestAttentionGate:
             patch("chat.bot.acl.feature_enabled", return_value=True),
             patch("chat.bot.acl.is_granted", return_value=True),
             patch("chat.bot.attention_log.log_decision", MagicMock()),
-            patch.object(bot, "start_agent_flow", AsyncMock(return_value=MagicMock())),
-            patch.object(bot, "_complete_lock", MagicMock()),
+            patch.object(
+                bot, "start_agent_flow", AsyncMock(return_value=MagicMock())
+            ) as mock_start_flow,
+            patch.object(bot, "_complete_lock", MagicMock()) as mock_complete_lock,
         ):
             mock_session_cls.return_value.__enter__ = MagicMock(
                 return_value=MagicMock()
@@ -457,10 +459,10 @@ class TestAttentionGate:
             mock_session_cls.return_value.__exit__ = MagicMock(return_value=False)
             await bot.on_message(message)
 
-        bot.start_agent_flow.assert_called_once()
-        args, kwargs = bot.start_agent_flow.call_args
-        assert kwargs.get("trigger_message") is message
-        bot._complete_lock.assert_called_once_with(str(message.id))
+            mock_start_flow.assert_called_once()
+            args, kwargs = mock_start_flow.call_args
+            assert kwargs.get("trigger_message") is message
+            mock_complete_lock.assert_called_once_with(str(message.id))
 
     @pytest.mark.asyncio
     async def test_mention_in_ambient_channel_without_grant_gets_refusal(self):
@@ -487,8 +489,8 @@ class TestAttentionGate:
             patch("chat.bot.acl.is_granted", return_value=False),
             patch("chat.bot.acl.allowed_scopes", return_value={"homelab"}),
             patch("chat.bot.attention_log.log_decision", MagicMock()),
-            patch.object(bot, "start_agent_flow", AsyncMock()),
-            patch.object(bot, "_complete_lock", MagicMock()),
+            patch.object(bot, "start_agent_flow", AsyncMock()) as mock_start_flow,
+            patch.object(bot, "_complete_lock", MagicMock()) as mock_complete_lock,
         ):
             mock_session_cls.return_value.__enter__ = MagicMock(
                 return_value=MagicMock()
@@ -496,11 +498,11 @@ class TestAttentionGate:
             mock_session_cls.return_value.__exit__ = MagicMock(return_value=False)
             await bot.on_message(message)
 
-        bot.start_agent_flow.assert_not_called()
-        message.reply.assert_called_once()
-        refusal = message.reply.call_args[0][0]
-        assert "homelab" in refusal
-        bot._complete_lock.assert_called_once_with(str(message.id))
+            mock_start_flow.assert_not_called()
+            message.reply.assert_called_once()
+            refusal = message.reply.call_args[0][0]
+            assert "homelab" in refusal
+            mock_complete_lock.assert_called_once_with(str(message.id))
 
     @pytest.mark.asyncio
     async def test_mention_in_non_ambient_channel_falls_through_to_chat(self):
@@ -524,8 +526,8 @@ class TestAttentionGate:
             patch("chat.bot.MessageStore", return_value=mock_store),
             patch("chat.bot.acl.ambient_channels", return_value=set()),
             patch("chat.bot.attention.evaluate", AsyncMock()) as mock_evaluate,
-            patch.object(bot, "start_agent_flow", AsyncMock()),
-            patch.object(bot, "_process_message", AsyncMock()),
+            patch.object(bot, "start_agent_flow", AsyncMock()) as mock_start_flow,
+            patch.object(bot, "_process_message", AsyncMock()) as mock_proc,
         ):
             mock_session_cls.return_value.__enter__ = MagicMock(
                 return_value=MagicMock()
@@ -533,9 +535,9 @@ class TestAttentionGate:
             mock_session_cls.return_value.__exit__ = MagicMock(return_value=False)
             await bot.on_message(message)
 
-        mock_evaluate.assert_not_called()
-        bot.start_agent_flow.assert_not_called()
-        bot._process_message.assert_called_once_with(message)
+            mock_evaluate.assert_not_called()
+            mock_start_flow.assert_not_called()
+            mock_proc.assert_called_once_with(message)
 
     @pytest.mark.asyncio
     async def test_plain_message_skips_the_gate_entirely(self):
@@ -556,7 +558,7 @@ class TestAttentionGate:
             patch("chat.bot.MessageStore", return_value=mock_store),
             patch("chat.bot.acl.ambient_channels", return_value=set()),
             patch("chat.bot.attention.evaluate", AsyncMock()) as mock_evaluate,
-            patch.object(bot, "_process_message", AsyncMock()),
+            patch.object(bot, "_process_message", AsyncMock()) as mock_proc,
         ):
             mock_session_cls.return_value.__enter__ = MagicMock(
                 return_value=MagicMock()
@@ -564,8 +566,8 @@ class TestAttentionGate:
             mock_session_cls.return_value.__exit__ = MagicMock(return_value=False)
             await bot.on_message(message)
 
-        mock_evaluate.assert_not_called()
-        bot._process_message.assert_called_once_with(message)
+            mock_evaluate.assert_not_called()
+            mock_proc.assert_called_once_with(message)
 
     @pytest.mark.asyncio
     async def test_ambient_lookup_failure_falls_through_to_chat(self):
@@ -589,7 +591,7 @@ class TestAttentionGate:
                 side_effect=RuntimeError("db down"),
             ),
             patch("chat.bot.attention.evaluate", AsyncMock()) as mock_evaluate,
-            patch.object(bot, "_process_message", AsyncMock()),
+            patch.object(bot, "_process_message", AsyncMock()) as mock_proc,
         ):
             mock_session_cls.return_value.__enter__ = MagicMock(
                 return_value=MagicMock()
@@ -597,8 +599,8 @@ class TestAttentionGate:
             mock_session_cls.return_value.__exit__ = MagicMock(return_value=False)
             await bot.on_message(message)
 
-        mock_evaluate.assert_not_called()
-        bot._process_message.assert_called_once_with(message)
+            mock_evaluate.assert_not_called()
+            mock_proc.assert_called_once_with(message)
 
 
 # ---------------------------------------------------------------------------

--- a/projects/monolith/chat/bot_on_message_test.py
+++ b/projects/monolith/chat/bot_on_message_test.py
@@ -4,6 +4,7 @@ import asyncio
 from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import discord
 import pytest
 from pydantic_ai import (
     PartDeltaEvent,
@@ -414,6 +415,117 @@ class TestGoosecrackerReplySteering:
         assert "homelab" in refusal
         assert "otherrepo" in refusal
         message.add_reaction.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# ChatBot.on_message -- attention gate (ADR 035 phase 3)
+# ---------------------------------------------------------------------------
+
+
+class TestAttentionGate:
+    @pytest.mark.asyncio
+    async def test_mention_with_grant_starts_agent_flow(self):
+        """A mention in a channel where the author holds the agent grant runs
+        the shared agent flow off the trigger message, and completes the lock."""
+        bot = _make_bot()
+        bot_user = bot.user
+
+        message = _make_message(content="hey bot help", mentions=[bot_user])
+        message.reference = None
+        message.guild = None
+        message.channel = MagicMock(spec=discord.TextChannel)
+        message.channel.id = 99
+
+        mock_store = _make_store()
+
+        with (
+            patch("chat.bot.get_engine"),
+            patch("chat.bot.Session") as mock_session_cls,
+            patch("chat.bot.MessageStore", return_value=mock_store),
+            patch("chat.bot.acl.ambient_channels", return_value=set()),
+            patch("chat.bot.acl.feature_enabled", return_value=True),
+            patch("chat.bot.acl.is_granted", return_value=True),
+            patch("chat.bot.attention_log.log_decision", MagicMock()),
+            patch.object(bot, "start_agent_flow", AsyncMock(return_value=MagicMock())),
+            patch.object(bot, "_complete_lock", MagicMock()),
+        ):
+            mock_session_cls.return_value.__enter__ = MagicMock(
+                return_value=MagicMock()
+            )
+            mock_session_cls.return_value.__exit__ = MagicMock(return_value=False)
+            await bot.on_message(message)
+
+        bot.start_agent_flow.assert_called_once()
+        args, kwargs = bot.start_agent_flow.call_args
+        assert kwargs.get("trigger_message") is message
+        bot._complete_lock.assert_called_once_with(str(message.id))
+
+    @pytest.mark.asyncio
+    async def test_mention_without_grant_gets_refusal(self):
+        """A mention from a user lacking the agent grant gets a refusal reply
+        naming the allowed scopes; start_agent_flow is never called."""
+        bot = _make_bot()
+        bot_user = bot.user
+
+        message = _make_message(content="hey bot help", mentions=[bot_user])
+        message.reference = None
+        message.guild = None
+
+        mock_store = _make_store()
+
+        with (
+            patch("chat.bot.get_engine"),
+            patch("chat.bot.Session") as mock_session_cls,
+            patch("chat.bot.MessageStore", return_value=mock_store),
+            patch("chat.bot.acl.ambient_channels", return_value=set()),
+            patch("chat.bot.acl.feature_enabled", return_value=True),
+            patch("chat.bot.acl.is_granted", return_value=False),
+            patch("chat.bot.acl.allowed_scopes", return_value={"homelab"}),
+            patch("chat.bot.attention_log.log_decision", MagicMock()),
+            patch.object(bot, "start_agent_flow", AsyncMock()),
+            patch.object(bot, "_complete_lock", MagicMock()),
+        ):
+            mock_session_cls.return_value.__enter__ = MagicMock(
+                return_value=MagicMock()
+            )
+            mock_session_cls.return_value.__exit__ = MagicMock(return_value=False)
+            await bot.on_message(message)
+
+        bot.start_agent_flow.assert_not_called()
+        message.reply.assert_called_once()
+        refusal = message.reply.call_args[0][0]
+        assert "homelab" in refusal
+        bot._complete_lock.assert_called_once_with(str(message.id))
+
+    @pytest.mark.asyncio
+    async def test_plain_message_skips_the_gate_entirely(self):
+        """A plain, non-ambient, non-mention message never touches the
+        attention classifier and falls straight through to _process_message,
+        unchanged from pre-ADR-035 behavior."""
+        bot = _make_bot()
+
+        message = _make_message(content="just chatting", mentions=[])
+        message.reference = None
+        message.guild = None
+
+        mock_store = _make_store()
+
+        with (
+            patch("chat.bot.get_engine"),
+            patch("chat.bot.Session") as mock_session_cls,
+            patch("chat.bot.MessageStore", return_value=mock_store),
+            patch("chat.bot.acl.ambient_channels", return_value=set()),
+            patch("chat.bot.attention.evaluate", AsyncMock()) as mock_evaluate,
+            patch.object(bot, "_process_message", AsyncMock()),
+        ):
+            mock_session_cls.return_value.__enter__ = MagicMock(
+                return_value=MagicMock()
+            )
+            mock_session_cls.return_value.__exit__ = MagicMock(return_value=False)
+            await bot.on_message(message)
+
+        mock_evaluate.assert_not_called()
+        bot._process_message.assert_called_once_with(message)
 
 
 # ---------------------------------------------------------------------------

--- a/projects/monolith/chat/bot_on_message_test.py
+++ b/projects/monolith/chat/bot_on_message_test.py
@@ -424,9 +424,11 @@ class TestGoosecrackerReplySteering:
 
 class TestAttentionGate:
     @pytest.mark.asyncio
-    async def test_mention_with_grant_starts_agent_flow(self):
-        """A mention in a channel where the author holds the agent grant runs
-        the shared agent flow off the trigger message, and completes the lock."""
+    async def test_mention_in_ambient_channel_with_grant_starts_agent_flow(self):
+        """A mention in an AMBIENT channel where the author holds the agent
+        grant runs the shared agent flow off the trigger message, and
+        completes the lock (Phase 3 containment: agent-triggering only fires
+        in opted-in channels)."""
         bot = _make_bot()
         bot_user = bot.user
 
@@ -442,7 +444,7 @@ class TestAttentionGate:
             patch("chat.bot.get_engine"),
             patch("chat.bot.Session") as mock_session_cls,
             patch("chat.bot.MessageStore", return_value=mock_store),
-            patch("chat.bot.acl.ambient_channels", return_value=set()),
+            patch("chat.bot.acl.ambient_channels", return_value={"99"}),
             patch("chat.bot.acl.feature_enabled", return_value=True),
             patch("chat.bot.acl.is_granted", return_value=True),
             patch("chat.bot.attention_log.log_decision", MagicMock()),
@@ -461,15 +463,18 @@ class TestAttentionGate:
         bot._complete_lock.assert_called_once_with(str(message.id))
 
     @pytest.mark.asyncio
-    async def test_mention_without_grant_gets_refusal(self):
-        """A mention from a user lacking the agent grant gets a refusal reply
-        naming the allowed scopes; start_agent_flow is never called."""
+    async def test_mention_in_ambient_channel_without_grant_gets_refusal(self):
+        """A mention in an ambient channel from a user lacking the agent grant
+        gets a refusal reply naming the allowed scopes; start_agent_flow is
+        never called."""
         bot = _make_bot()
         bot_user = bot.user
 
         message = _make_message(content="hey bot help", mentions=[bot_user])
         message.reference = None
         message.guild = None
+        message.channel = MagicMock(spec=discord.TextChannel)
+        message.channel.id = 99
 
         mock_store = _make_store()
 
@@ -477,7 +482,7 @@ class TestAttentionGate:
             patch("chat.bot.get_engine"),
             patch("chat.bot.Session") as mock_session_cls,
             patch("chat.bot.MessageStore", return_value=mock_store),
-            patch("chat.bot.acl.ambient_channels", return_value=set()),
+            patch("chat.bot.acl.ambient_channels", return_value={"99"}),
             patch("chat.bot.acl.feature_enabled", return_value=True),
             patch("chat.bot.acl.is_granted", return_value=False),
             patch("chat.bot.acl.allowed_scopes", return_value={"homelab"}),
@@ -496,6 +501,41 @@ class TestAttentionGate:
         refusal = message.reply.call_args[0][0]
         assert "homelab" in refusal
         bot._complete_lock.assert_called_once_with(str(message.id))
+
+    @pytest.mark.asyncio
+    async def test_mention_in_non_ambient_channel_falls_through_to_chat(self):
+        """A mention in a NON-ambient channel is contained to today's inline
+        chat reply: the attention gate/agent flow never fires, and the message
+        goes straight to _process_message (which already replies to mentions
+        inline). Proves the Phase 3 containment fix and the DM regression fix
+        (DMs are never ambient)."""
+        bot = _make_bot()
+        bot_user = bot.user
+
+        message = _make_message(content="hey bot help", mentions=[bot_user])
+        message.reference = None
+        message.guild = None
+
+        mock_store = _make_store()
+
+        with (
+            patch("chat.bot.get_engine"),
+            patch("chat.bot.Session") as mock_session_cls,
+            patch("chat.bot.MessageStore", return_value=mock_store),
+            patch("chat.bot.acl.ambient_channels", return_value=set()),
+            patch("chat.bot.attention.evaluate", AsyncMock()) as mock_evaluate,
+            patch.object(bot, "start_agent_flow", AsyncMock()),
+            patch.object(bot, "_process_message", AsyncMock()),
+        ):
+            mock_session_cls.return_value.__enter__ = MagicMock(
+                return_value=MagicMock()
+            )
+            mock_session_cls.return_value.__exit__ = MagicMock(return_value=False)
+            await bot.on_message(message)
+
+        mock_evaluate.assert_not_called()
+        bot.start_agent_flow.assert_not_called()
+        bot._process_message.assert_called_once_with(message)
 
     @pytest.mark.asyncio
     async def test_plain_message_skips_the_gate_entirely(self):

--- a/projects/monolith/chat/models.py
+++ b/projects/monolith/chat/models.py
@@ -233,3 +233,30 @@ class DiscordFeatureGrant(SQLModel, table=True):
     subject_id: str = Field(default="", primary_key=True)
     feature: str = Field(primary_key=True)
     scope: str = Field(default="", primary_key=True)
+
+
+class AttentionDecision(SQLModel, table=True):
+    """Log of attention-gate decisions on ambient-channel messages (ADR 035).
+
+    Every engage is logged; ignores are sampled (ATTENTION_IGNORE_SAMPLE_RATE,
+    default 0.1) to bound volume. Used later to tune the classifier and to audit
+    what the bot chose to engage with. directive_version records which channel
+    directive version the decision ran under (0 until Phase 5 wires directives).
+    """
+
+    __tablename__ = "attention_decision"
+    __table_args__ = (
+        CheckConstraint(
+            "decision IN ('engage', 'ignore')",
+            name="attention_decision_decision_valid",
+        ),
+        {"schema": "chat", "extend_existing": True},
+    )
+
+    id: int | None = Field(default=None, primary_key=True)
+    channel_id: str = Field(default="")
+    message_id: str = Field(default="")
+    decision: str = Field(default="ignore")
+    confidence: float = Field(default=0.0)
+    directive_version: int = Field(default=0)
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.253.0
+      targetRevision: 0.254.0
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
## Summary

Phase 3 of the [ADR 035 plan](https://github.com/jomcgi/homelab/blob/main/docs/plans/2026-07-02-discord-multiplayer-agent-ux.md): a two-stage attention gate decides whether the bot engages with a message, and mention/ambient triggers route into the same agent flow as `/agent`.

- **3.1**: `acl.ambient_channels(guild_id)` (DiscordFeatureGrant feature="ambient", subject_id="", scope=channel_id); `chat.attention_decision` log table (CHECK decision IN engage|ignore); `attention_log.log_decision` (engages always, ignores sampled at ATTENTION_IGNORE_SAMPLE_RATE default 0.1).
- **3.2**: `chat/attention.py` `evaluate(message, directive, bot_user, is_ambient)`: mention/reply short-circuits engage (no model); ambient classifies via the in-cluster Qwen (JSON `{engage, confidence}`, threshold ATTENTION_THRESHOLD default 0.8); fails closed (ignore) on any error; holds no tools. directive is a placeholder ("") until Phase 5 wires `directives.get_active`.
- **3.3**: `start_agent_flow(channel, user, prompt, repo, trigger_message=None)` extracted from `_handle_agent_command` (threads off the trigger message for mention/ambient, off the channel for the slash command); `_engage_agent` applies the same repo-less agent ACL check.

## Rollout decision: contained to opted-in channels

Per an explicit owner decision, the agent-triggering gate fires **only in ambient (opted-in) channels**. Mentions/replies in non-ambient channels keep today's inline chat reply (via `_process_message`), and this is unchanged for DMs too. This matches the plan's "live check in one opted-in channel" and avoids converting mention->chat into mention->agent server-wide before Phase 4's "chat" branch makes an agent-flow reply lightweight. The spec's "mentions always engage everywhere" arrives once Phase 4 lands.

## Review

One comprehensive Opus review, then fixes applied: verified the plain-message path is byte-for-byte unchanged, lock discipline (every `_engage_agent` branch completes the lock), the extraction fidelity (slash path identical), and that an ambient engage from an unauthorized user does NOT run an agent. Fixes: contained the gate to ambient (above), a 30s TTL cache on the grants read (kills a per-message DB SELECT on the hot path), and a failure-fallback reply on explicit triggers.

## Deploy

monolith chart `0.253.0 -> 0.254.0` (+ application.yaml targetRevision). No recipe/fc-invoke change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)