### PR TITLE
fix(campsites): correct availability enum, deep-zoom pins, mobile rain

### DIFF
--- a/projects/monolith/campsites/client.py
+++ b/projects/monolith/campsites/client.py
@@ -154,14 +154,26 @@ def merge_availability(
     start_date: datetime.date,
     ndays: int = WINDOW_DAYS,
 ) -> list[DayAvail]:
-    """Aggregate per-loop availability flags into one DayAvail per date.
+    """Aggregate per-loop availability codes into one DayAvail per date.
 
     ``payload["mapLinkAvailabilities"]`` maps loop map IDs (str keys) to lists
-    of truthy/falsy flags, one per date starting at ``start_date``. A date has
-    availability if any loop has a truthy value at that index. loops_open is
-    the count of loops that have a truthy value at that index. Ragged arrays
-    are safe: a missing index is treated as 0 (closed). An empty or missing
-    payload produces ``ndays`` closed DayAvail rows.
+    of GoingToCamp availability status codes, one per date starting at
+    ``start_date``. The code is an enum, NOT a boolean:
+
+        0 = available (has bookable sites)
+        1 = unavailable / fully booked
+        2 = closed / not operating
+
+    So a loop is open on a date only when its code is exactly ``0``. (An earlier
+    version treated any truthy value as open, which inverted the meaning and
+    reported booked (1) and closed (2) loops as available: full parks showed as
+    "open". Confirmed against the live API, where Gordon Bay returned loops of
+    all-1 and all-2 that were being counted as bookable.)
+
+    A date has availability if any loop is ``0`` at that index. loops_open is
+    the count of loops that are ``0`` at that index. Ragged arrays are safe: a
+    missing index contributes nothing (treated as not available). An empty or
+    missing payload produces ``ndays`` closed DayAvail rows.
     """
     arrays = list((payload.get("mapLinkAvailabilities") or {}).values())
     result: list[DayAvail] = []
@@ -171,7 +183,7 @@ def merge_availability(
         for arr in arrays:
             if not arr or i >= len(arr):
                 continue
-            if arr[i]:
+            if arr[i] == 0:
                 has_avail = True
                 loops_open += 1
         result.append(

--- a/projects/monolith/campsites/client_test.py
+++ b/projects/monolith/campsites/client_test.py
@@ -116,45 +116,61 @@ def test_read_catalog_json_shape():
 # ---------------------------------------------------------------------------
 
 
-def test_merge_availability_or():
-    """OR logic: day open if any loop has 1; loops_open counts active loops."""
+def test_merge_availability_enum():
+    """GoingToCamp enum: only code 0 is available; 1 (booked) and 2 (closed)
+    are NOT. A day is open if any loop is 0; loops_open counts the 0-loops."""
     payload = {
         "mapLinkAvailabilities": {
-            "-1": [0, 1, 0],
-            "-2": [1, 1, 0],
+            "-1": [0, 1, 2],  # available, booked, closed
+            "-2": [1, 0, 2],  # booked, available, closed
         }
     }
     result = merge_availability(payload, _START, ndays=3)
     assert len(result) == 3
 
-    # Day 0: loop -2 is open (1), loop -1 is closed (0): has_availability=True, loops_open=1
+    # Day 0: loop -1 is available (0), loop -2 is booked (1): open, 1 loop.
     assert result[0].date == _START
     assert result[0].has_availability is True
     assert result[0].loops_open == 1
 
-    # Day 1: both loops open: has_availability=True, loops_open=2
+    # Day 1: loop -2 is available (0), loop -1 is booked (1): open, 1 loop.
     assert result[1].date == _START + datetime.timedelta(days=1)
     assert result[1].has_availability is True
-    assert result[1].loops_open == 2
+    assert result[1].loops_open == 1
 
-    # Day 2: both loops closed: has_availability=False, loops_open=0
+    # Day 2: both loops closed (2): NOT open, 0 loops. This is the regression
+    # the old truthy test got wrong (it counted 2 as available).
     assert result[2].date == _START + datetime.timedelta(days=2)
     assert result[2].has_availability is False
     assert result[2].loops_open == 0
+
+
+def test_merge_availability_nonzero_codes_are_not_open():
+    """A loop that is all-booked (1) or all-closed (2) never reads as available,
+    even though those values are truthy in Python."""
+    payload = {
+        "mapLinkAvailabilities": {
+            "-1": [1, 1, 1],  # fully booked every day
+            "-2": [2, 2, 2],  # closed every day
+        }
+    }
+    result = merge_availability(payload, _START, ndays=3)
+    assert all(not d.has_availability for d in result)
+    assert all(d.loops_open == 0 for d in result)
 
 
 def test_merge_availability_ragged():
     """Ragged arrays (shorter than ndays) and empty arrays do not crash."""
     payload = {
         "mapLinkAvailabilities": {
-            "-10": [1],  # only one entry; index 1+ treated as 0
-            "-11": [],  # empty; all indices treated as 0
+            "-10": [0],  # only one entry (available); index 1+ is missing
+            "-11": [],  # empty; every index missing
         }
     }
     result = merge_availability(payload, _START, ndays=3)
     assert len(result) == 3
 
-    # Day 0: array -10 has 1 at index 0.
+    # Day 0: array -10 is 0 (available) at index 0.
     assert result[0].has_availability is True
     assert result[0].loops_open == 1
 

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.253.0
+version: 0.254.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.253.0
+      targetRevision: 0.254.0
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/lib/public/components/campsites/CampsitesMap.svelte
+++ b/projects/monolith/frontend/src/lib/public/components/campsites/CampsitesMap.svelte
@@ -327,6 +327,17 @@
                 ["interpolate", ["linear"], ["get", "good_days"], 0, 20, 7, 28],
                 ["interpolate", ["linear"], ["get", "good_days"], 0, 13, 7, 21],
               ],
+              // Deep zoom (single park fills the screen, e.g. tracing a trail):
+              // keep growing so the pin never reads as a tiny dot against a
+              // massive path. Without this stop the radius held at its zoom-11
+              // value and looked like it "stopped scaling" past ~z11.
+              16,
+              [
+                "case",
+                ["==", ["get", "sel"], 1],
+                ["interpolate", ["linear"], ["get", "good_days"], 0, 34, 7, 44],
+                ["interpolate", ["linear"], ["get", "good_days"], 0, 24, 7, 34],
+              ],
             ],
             "circle-stroke-width": [
               "case",

--- a/projects/monolith/frontend/src/routes/public/app/campsites/+page.svelte
+++ b/projects/monolith/frontend/src/routes/public/app/campsites/+page.svelte
@@ -155,6 +155,10 @@
   const VIZ_YELLOW = "#fbbf24";
   const VIZ_AMBER = "#f59e0b";
   const VIZ_GREY = "#9ca3af";
+  // Rain accent for the always-visible per-day precip figure (a wet day reads
+  // blue). Kept as a JS constant like the others so no literal hex lands in a
+  // style attribute (the hardcoded-color semgrep rule).
+  const VIZ_RAIN = "#2563eb";
 
   function dayCellBg(day) {
     if (!day.available) return "var(--rule)";
@@ -488,6 +492,19 @@
               {#if day.temp_max != null}
                 <span class="day-temp">{Math.round(day.temp_max)}&deg;</span>
               {/if}
+              {#if day.precip != null}
+                <!-- Rain promoted out of the hover title so touch users (no
+                     hover) can see it. Blue + mm on a wet day; a faint dot when
+                     dry keeps the row rhythm without shouting "0.0". -->
+                <span
+                  class="day-rain"
+                  class:day-rain-wet={day.precip > 0}
+                  style={day.precip > 0 ? `color: ${VIZ_RAIN}` : undefined}
+                  >{day.precip > 0
+                    ? `${day.precip.toFixed(1)}mm`
+                    : "·"}</span
+                >
+              {/if}
             </li>
           {/each}
         </ul>
@@ -495,7 +512,8 @@
 
       <p class="detail-legend">
         Check = sites bookable. Color: green (clear) to grey (cloudy or closed).
-        Hover a cell for cloud, rain and temp.
+        Each cell shows max temp (&deg;) and rain (mm, blue when wet). Hover for
+        cloud cover.
       </p>
     </section>
   {/if}
@@ -1167,6 +1185,19 @@
     font-weight: 600;
     color: var(--ink);
     letter-spacing: 0.01em;
+  }
+
+  /* Always-visible rain figure (mm). Dry days show a faint dot; wet days get
+     the blue accent via an inline color so they stand out when scanning on a
+     phone, where the old hover-only title was invisible. */
+  .day-rain {
+    font-family: var(--mono);
+    font-size: 8px;
+    font-weight: 700;
+    line-height: 1;
+    letter-spacing: 0;
+    color: var(--ink-3);
+    white-space: nowrap;
   }
 
   .day-cell:not(.day-open) .day-date,


### PR DESCRIPTION
Follow-up to #3108, from Anna's iPhone testing session. Three fixes.

## 1. Availability was inverted (data-correctness bug)

Anna: *"says sites open for Gordon Bay but nothing is available for Friday night."*

`merge_availability` treated GoingToCamp's `mapLinkAvailabilities` values as booleans (`if arr[i]:`). They are actually a **status enum**: `0 = available, 1 = booked, 2 = closed`. So booked (1) and closed (2) loops were counted as **open**, and full parks glowed green.

Verified against the live API from a WAF-passing client:
```
Gordon Bay loops:
  -2147483565: [0, 1, 0, 0, 0, 0, 0]
  -2147483564: [1, 1, 1, 1, 1, 1, 1]   # always booked -> was counted open
  -2147483563: [2, 2, 2, 2, 2, 2, 2]   # always closed -> was counted open
```
Friday (index 1) = `{1, 1, 2}`, no `0` → genuinely nothing bookable, exactly what Anna found. Fixed the predicate to `== 0` and rewrote the test fixtures, which had encoded the wrong assumption (that's why the bug passed CI).

`router.py` consumes `has_availability` (a bool) directly, so this single chokepoint corrects `available`, `best_score`, and `good_days` downstream.

## 2. Pins stopped scaling past zoom 11

Anna: *"even if I zoom so a tiny path is massive the markers are still shrinking."* #3108 capped the radius interpolation at zoom 11; added a **zoom-16 stop** so pins keep growing at deep zoom.

## 3. Rain invisible on mobile

Rain was only in the day cell's `title=` (hover-only, dead on touch). Promoted precip **(mm)** into the always-visible cell, blue on wet days, and fixed the stale "hover for rain" legend.

Bumps the monolith chart `0.253.0` → `0.254.0`.

## Rollout note

The availability fix corrects newly-scraped data; the hourly `campsites-refresh` job must run to overwrite the currently-wrong rows. I'll trigger it after this deploys so Anna sees correct data immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)