### PR TITLE
chore(campsites): raise refresh job deadline to 25m

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.254.0
+version: 0.255.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/values.yaml
+++ b/projects/monolith/chart/values.yaml
@@ -444,7 +444,13 @@ jobs:
       args: ["campsites-refresh"]
       schedule: "0 * * * *"
       concurrencyPolicy: Forbid
-      activeDeadlineSeconds: 900
+      # 25m. A normal scrape of ~145 parks finishes in ~2-3 min, but an
+      # occasional WAF-throttled run pushes scattered parks onto the 2s-retry
+      # path and can exceed 15m (the old 900s), timing out and writing nothing
+      # (jobs.py commits only after the full fetch). 1500s gives a degraded run
+      # room to finish; a fully-blocked run still bails early via
+      # MAX_CONSECUTIVE_FAILURES. Safe under the hourly schedule + Forbid.
+      activeDeadlineSeconds: 1500
       suspend: false
       resources:
         requests:

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.254.0
+      targetRevision: 0.255.0
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
The hourly `campsites-refresh` CronWorkflow had `activeDeadlineSeconds: 900` (15m).

A normal scrape of ~145 parks finishes in **~2-3 min** (observed `generated_at` ~2.5 min after the :00 trigger). But an occasional WAF-throttled run pushes scattered parks onto the 2s-retry path and can exceed 15m. When it hits the deadline the pod is killed, and because `jobs.py` commits only **after** the full fetch, that run writes nothing: the hour's refresh is silently lost.

Observed: the 04:00 UTC run died at 15:09 ("Pod was active on the node longer than the specified deadline"), leaving availability data stale at the 03:00 snapshot.

Raise to **1500s (25m)** so a degraded run still completes; a fully WAF-blocked run still bails early via `MAX_CONSECUTIVE_FAILURES`. Safe under the hourly schedule with `concurrencyPolicy: Forbid` (25m << 60m window).

Chart `0.254.0` → `0.255.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)