### PR TITLE
fix(campsites): commit availability before weather; weather fast-fail

### DIFF
--- a/projects/monolith/campsites/jobs.py
+++ b/projects/monolith/campsites/jobs.py
@@ -190,7 +190,21 @@ async def refresh_handler(session) -> datetime.datetime | None:
     except Exception:
         logger.error("campsites refresh: availability phase failed", exc_info=True)
 
-    # 3. Weather (Open-Meteo is not WAF-protected; plain httpx).
+    # Commit availability NOW, before touching weather. Availability (BC Parks)
+    # and weather (Open-Meteo) are independent sources joined per-date by the
+    # snapshot API from separate tables, so there is no reason to couple their
+    # commits. Committing here means a later weather-phase failure, or the pod
+    # being killed at activeDeadlineSeconds while weather grinds through a slow
+    # Open-Meteo, can no longer discard a good availability fetch. This is its
+    # own committed transaction (to_thread + fresh session), so a SIGKILL after
+    # it does not roll it back. _upsert_availability prunes elapsed rows even on
+    # an empty dict, and merge never deletes in-window rows, so an empty avail
+    # (WAF block) keeps existing data (stale beats blank).
+    avail_written = await asyncio.to_thread(_upsert_availability, avail, prune_floor)
+
+    # 3. Weather (Open-Meteo is not WAF-protected; plain httpx). fetch_all_weather
+    # bails early after a run of consecutive failures (e.g. an Open-Meteo outage)
+    # rather than timing out park-by-park to the deadline.
     wx: dict[int, list[weather.WxDay]] = {}
     try:
         coords = [
@@ -201,18 +215,8 @@ async def refresh_handler(session) -> datetime.datetime | None:
     except Exception:
         logger.error("campsites refresh: weather phase failed", exc_info=True)
 
-    # 4. Never wipe tables on a total failure: if both sources came back empty,
-    # keep the existing rows (stale data beats a blank page) and return.
-    if not avail and not wx:
-        logger.error(
-            "campsites refresh: availability AND weather both empty; "
-            "keeping existing rows, writing nothing"
-        )
-        return None
-
-    # Commit whatever succeeded. Each helper still prunes elapsed rows even when
-    # its own source was empty, so the rolling window stays clean.
-    avail_written = await asyncio.to_thread(_upsert_availability, avail, prune_floor)
+    # Commit weather independently. Its own prune runs even on an empty dict, so
+    # an Open-Meteo outage keeps the existing (stale) forecast rather than a gap.
     wx_written = await asyncio.to_thread(_upsert_weather, wx, prune_floor)
     logger.info(
         "campsites refresh: wrote %d availability rows (%d parks), "

--- a/projects/monolith/campsites/weather.py
+++ b/projects/monolith/campsites/weather.py
@@ -28,6 +28,13 @@ logger = logging.getLogger("monolith.campsites")
 OPEN_METEO_URL = "https://api.open-meteo.com/v1/forecast"
 FORECAST_DAYS = 14
 
+# Bail out of a refresh's weather phase after this many consecutive fetch
+# failures. During an Open-Meteo outage every request connect-times-out at the
+# client timeout (25s), so without an early break the phase grinds park-by-park
+# all the way to the job's activeDeadlineSeconds. Mirrors
+# client.MAX_CONSECUTIVE_FAILURES for the availability phase.
+MAX_CONSECUTIVE_FAILURES = 5
+
 # Weight applied to the clear-sky component (100 - cloud_cover%).
 CLEAR_WEIGHT = 1.0
 
@@ -212,17 +219,32 @@ async def fetch_all_weather(
     ``coords`` is a list of (resource_location_id, lat, lon, iana_tz). Parks
     whose fetch returns None are skipped (logged inside fetch_forecast). A
     small deterministic per-index sleep paces the requests without hammering
-    the free API.
+    the free API. After MAX_CONSECUTIVE_FAILURES fetches fail in a row (an
+    Open-Meteo outage), the phase stops early and returns what it has rather
+    than timing out against every remaining park to the job deadline; a parse
+    failure does not count (the network was fine, that one park is just skipped).
 
     Caller is expected to pass httpx.AsyncClient(timeout=25).
     """
     results: dict[int, list[WxDay]] = {}
+    consecutive_failures = 0
 
     for i, (rid, lat, lon, tz) in enumerate(coords):
         await asyncio.sleep(random.Random(i).uniform(0.1, 0.2))
         data = await fetch_forecast(client, lat, lon, tz)
         if data is None:
+            consecutive_failures += 1
+            if consecutive_failures >= MAX_CONSECUTIVE_FAILURES:
+                logger.error(
+                    "campsites weather: %d consecutive fetch failures "
+                    "(Open-Meteo likely down); stopping the weather phase early "
+                    "with %d parks collected",
+                    consecutive_failures,
+                    len(results),
+                )
+                break
             continue
+        consecutive_failures = 0
         try:
             rows = parse_forecast(data.get("daily", {}))
         except Exception:

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.255.0
+version: 0.256.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.255.0
+      targetRevision: 0.256.0
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
## Context

Discovered live while shipping the availability enum fix (#3110): **Open-Meteo went down**, and it exposed a fragility in `refresh_handler`.

The handler fetched availability (BC Parks) **and** weather (Open-Meteo), then committed **both only at the very end**. So when weather timed out park-by-park and the pod hit `activeDeadlineSeconds`, the already-successful, freshly-corrected availability fetch was **discarded**. The enum fix couldn't land because Open-Meteo was down.

## Fix

The two sources are independent (different APIs, joined per-date by the snapshot endpoint from separate tables), so decouple their commits:

1. **Commit availability immediately after its fetch, before weather.** It's its own committed transaction, so a later weather failure or a deadline SIGKILL can't roll it back. Availability now lands **even while Open-Meteo is down**.
2. **`fetch_all_weather` bails after 5 consecutive failures** instead of connect-timing-out against all ~145 parks to the deadline (mirrors `client.fetch_all_availability`). A parse failure doesn't count.

Both upsert helpers already prune elapsed rows on an empty dict and `merge` never deletes in-window rows, so an empty result keeps existing data (stale beats blank). Removed the now-moot combined "both empty" guard.

Tests: `jobs_test.py` covers only the sync upsert helpers (unchanged), and the codebase deliberately doesn't unit-test these async network loops (the parallel availability breaker is untested too), so no test churn.

Chart `0.255.0` → `0.256.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)