### PR TITLE
chore(campsites): bump monolith to 0.257.0 to ship decouple fix

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.256.0
+version: 0.257.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.256.0
+      targetRevision: 0.257.0
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
The weather-decouple fix (#3113) merged as chart `0.256.0`, but the ADR-035 PR (`39d043c`) had already pushed `0.256.0` to OCI with its own pinned jobs image. OCI chart versions are immutable (push-if-absent), so #3113's jobs image was never pinned into a published chart: the **source is on main** but the deployed `0.256.0` chart still runs the pre-decouple jobs image (confirmed: the `campsites-refresh` CronWorkflow references image `...39d043c`, which lacks the fix).

Fresh bump to `0.257.0` forces a clean chart build pinning the current HEAD jobs image (includes decouple + weather fast-fail). No code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)