### PR TITLE
fix(campsites): give map pins a finger-friendly minimum size

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.257.0
+version: 0.258.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.257.0
+      targetRevision: 0.258.0
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/frontend/src/lib/public/components/campsites/CampsitesMap.svelte
+++ b/projects/monolith/frontend/src/lib/public/components/campsites/CampsitesMap.svelte
@@ -297,46 +297,48 @@
           paint: {
             "circle-color": SCORE_COLOR,
             // Radius grows with good_days (more clear days = bigger pin), with
-            // the selected pin larger still. The outer interpolation is on
-            // ["zoom"], so pins also grow as you zoom in (they used to stay a
-            // fixed pixel size at every zoom, which read as "tiny" on a phone).
-            // Zoom-and-property form: the ["zoom"] interpolate is outermost and
-            // its stop outputs are per-feature expressions (allowed by the GL
-            // spec precisely because the inner expressions never read zoom).
-            // Bumped baselines too so the smallest pin is a realistic touch
-            // target rather than a 5px dot.
+            // the selected pin larger still, and the outer ["zoom"] interpolate
+            // makes pins also grow as you zoom in. Zoom-and-property form: the
+            // ["zoom"] interpolate is outermost and its stop outputs are
+            // per-feature expressions (valid because the inner expressions never
+            // read zoom).
+            //
+            // MINIMUM SIZE FLOOR: the smallest a pin ever renders is the zoomed
+            // -out, zero-clear-days, unselected case = radius 12 (24px diameter).
+            // interpolate clamps to the first stop below zoom 5, so this floor
+            // also holds at the initial full-BC view (~z4.4). 24px visual + the
+            // 14px queryRenderedFeatures tap box on each side gives a ~52px
+            // effective touch target, comfortably finger-pressable on a phone
+            // without the ~145 province-wide pins merging into blobs.
             "circle-radius": [
               "interpolate",
               ["linear"],
               ["zoom"],
-              // Zoomed out: bigger than before so pins stay tappable in the
-              // full-BC view.
+              // Zoomed out (province view): finger-friendly floor.
               5,
               [
                 "case",
                 ["==", ["get", "sel"], 1],
-                ["interpolate", ["linear"], ["get", "good_days"], 0, 11, 7, 17],
-                ["interpolate", ["linear"], ["get", "good_days"], 0, 7, 7, 12],
+                ["interpolate", ["linear"], ["get", "good_days"], 0, 15, 7, 20],
+                ["interpolate", ["linear"], ["get", "good_days"], 0, 12, 7, 16],
               ],
-              // Zoomed in: pins swell so a selected park is unmistakable and
-              // easy to hit with a fingertip.
+              // Zoomed in: pins swell so a selected park is unmistakable.
               11,
               [
                 "case",
                 ["==", ["get", "sel"], 1],
-                ["interpolate", ["linear"], ["get", "good_days"], 0, 20, 7, 28],
-                ["interpolate", ["linear"], ["get", "good_days"], 0, 13, 7, 21],
+                ["interpolate", ["linear"], ["get", "good_days"], 0, 22, 7, 30],
+                ["interpolate", ["linear"], ["get", "good_days"], 0, 18, 7, 24],
               ],
               // Deep zoom (single park fills the screen, e.g. tracing a trail):
               // keep growing so the pin never reads as a tiny dot against a
-              // massive path. Without this stop the radius held at its zoom-11
-              // value and looked like it "stopped scaling" past ~z11.
+              // massive path.
               16,
               [
                 "case",
                 ["==", ["get", "sel"], 1],
                 ["interpolate", ["linear"], ["get", "good_days"], 0, 34, 7, 44],
-                ["interpolate", ["linear"], ["get", "good_days"], 0, 24, 7, 34],
+                ["interpolate", ["linear"], ["get", "good_days"], 0, 28, 7, 38],
               ],
             ],
             "circle-stroke-width": [


### PR DESCRIPTION
Anna (iPhone): pins still too small to press. The radius floor (unselected, zero clear days, zoomed out) was only 7px (14px diameter).

Raise the minimum to **radius 12 (24px diameter)**. `interpolate` clamps to the first stop below zoom 5, so the floor also holds at the initial full-BC view (~z4.4). Combined with the existing 14px `queryRenderedFeatures` tap box (from #3108), the effective touch target is **~52px** — comfortably finger-pressable — while staying small enough that the ~145 province-wide pins don't merge into blobs. Selected and zoomed-in stops scale up from the new floor too.

| zoom | selected (gd 0→7) | unselected (gd 0→7) |
|---|---|---|
| 5 (out) | 15→20 | **12**→16 |
| 11 | 22→30 | 18→24 |
| 16 (deep) | 34→44 | 28→38 |

Chart `0.257.0` → `0.258.0`. This deploy also carries the availability weather-decouple fix (its `0.256.0` chart lost a version-collision race, fixed by `0.257.0`; this supersedes it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)