### PR TITLE
feat(chat): engagement-policy attention with recent-tag weighting

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.259.0
+version: 0.260.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chat/attention.py
+++ b/projects/monolith/chat/attention.py
@@ -1,8 +1,10 @@
 """Attention gate (ADR 035 phase 3): should the bot engage with a message?
 
 Mentions and replies to the bot always engage (no model call). In channels with
-an ambient grant, a classify-only fast-model call scores the message against the
-channel directive and engages only above ATTENTION_THRESHOLD. Everywhere else,
+an ambient grant, a classify-only fast-model call scores the message against a
+base engagement policy (refined, not gated, by the channel directive) and
+engages only above ATTENTION_THRESHOLD. Recently-tagged threads/channels get a
+lower threshold so the bot leans into relevant follow-ups. Everywhere else,
 ignore. The classifier holds no tools and fails closed (ignore) on any error.
 """
 
@@ -13,6 +15,7 @@ from dataclasses import dataclass
 
 logger = logging.getLogger(__name__)
 ATTENTION_THRESHOLD = float(os.environ.get("ATTENTION_THRESHOLD", "0.8"))
+_RECENT_TAG_THRESHOLD = float(os.environ.get("ATTENTION_RECENT_TAG_THRESHOLD", "0.5"))
 
 
 @dataclass
@@ -22,13 +25,21 @@ class AttentionResult:
 
 
 async def evaluate(
-    message, directive: str, bot_user, is_ambient: bool, *, _caller=None
+    message,
+    directive: str,
+    bot_user,
+    is_ambient: bool,
+    *,
+    recently_tagged: bool = False,
+    _caller=None,
 ) -> AttentionResult:
     """Decide whether to engage. See module docstring.
 
-    ``directive`` is the channel directive text (empty until Phase 5 wires it).
-    ``_caller`` is an injectable llm-caller for tests; defaults to
-    ``build_llm_caller()``.
+    ``directive`` is the channel directive text; it refines the base
+    engagement policy rather than gating it. ``recently_tagged`` means the bot
+    was @mentioned in this channel/thread within a short recent window, which
+    lowers the effective engage threshold. ``_caller`` is an injectable
+    llm-caller for tests; defaults to ``build_llm_caller()``.
     """
     from chat.bot import should_respond  # mention/reply detection (lazy to avoid cycle)
 
@@ -45,20 +56,36 @@ async def evaluate(
             caller = build_llm_caller()
         text = (message.content or "")[:500]
         prompt = (
-            "You decide whether an assistant should jump into a chat message. "
-            "Channel directive (how the assistant should behave here): "
-            + (directive or "(none)")
-            + "\nMessage: "
+            "You decide whether the assistant (a Discord bot named Bosun) should "
+            "jump into this message unprompted. Engage (true) when the message is "
+            "an open question or request that EITHER addresses the bot or the group "
+            "and wants a response, OR is about a code repository or codebase, OR "
+            "would benefit from a web search or fact-check (a factual claim, a "
+            "current event, anything checkable). Lean ignore (false) for idle "
+            "chatter, statements not seeking help, or messages clearly between "
+            "other people.\n"
+            + (
+                "The bot was recently mentioned in this channel, so lean toward "
+                "engaging on a relevant follow-up.\n"
+                if recently_tagged
+                else ""
+            )
+            + (
+                "Channel guidance (adjust the above if it applies): " + directive + "\n"
+                if directive
+                else ""
+            )
+            + "Message: "
             + text
             + '\nReply with ONLY a JSON object: {"engage": true|false, '
-            '"confidence": 0.0-1.0}. Engage only if the message clearly wants '
-            "the assistant per the directive. No prose, no markdown."
+            '"confidence": 0.0-1.0}. No prose, no markdown.'
         )
         raw = await caller(prompt)
         data = json.loads(_extract_json(raw))
         engage = bool(data.get("engage", False))
         conf = float(data.get("confidence", 0.0))
-        return AttentionResult(engage and conf >= ATTENTION_THRESHOLD, conf)
+        threshold = _RECENT_TAG_THRESHOLD if recently_tagged else ATTENTION_THRESHOLD
+        return AttentionResult(engage and conf >= threshold, conf)
     except Exception:
         logger.exception("attention: classify failed; failing closed (ignore)")
         return AttentionResult(False, 0.0)

--- a/projects/monolith/chat/attention_test.py
+++ b/projects/monolith/chat/attention_test.py
@@ -90,6 +90,57 @@ class TestAmbientClassification:
         assert result.confidence == 0.95
 
 
+class TestRecentTagWeighting:
+    """ADR 035 engagement policy: recently_tagged lowers the engage threshold."""
+
+    @pytest.mark.asyncio
+    async def test_recently_tagged_engages_below_default_threshold(self):
+        message = _make_message(content="is that actually true though?")
+        caller = AsyncMock(return_value='{"engage": true, "confidence": 0.6}')
+        result = await evaluate(
+            message,
+            "",
+            _BOT_USER,
+            is_ambient=True,
+            recently_tagged=True,
+            _caller=caller,
+        )
+        assert result.confidence == 0.6
+        assert result.confidence < ATTENTION_THRESHOLD
+        assert result.engage is True
+
+    @pytest.mark.asyncio
+    async def test_same_confidence_ignored_without_recent_tag(self):
+        message = _make_message(content="is that actually true though?")
+        caller = AsyncMock(return_value='{"engage": true, "confidence": 0.6}')
+        result = await evaluate(
+            message,
+            "",
+            _BOT_USER,
+            is_ambient=True,
+            recently_tagged=False,
+            _caller=caller,
+        )
+        assert result.confidence == 0.6
+        assert result.engage is False
+
+    @pytest.mark.asyncio
+    async def test_mention_still_short_circuits_without_a_caller(self):
+        message = _make_message(mentions=[_BOT_USER])
+        caller = AsyncMock()
+        result = await evaluate(
+            message,
+            "",
+            _BOT_USER,
+            is_ambient=False,
+            recently_tagged=True,
+            _caller=caller,
+        )
+        assert result.engage is True
+        assert result.confidence == 1.0
+        caller.assert_not_called()
+
+
 class TestNeedsAgent:
     """ADR 035 Phase 4: the in-monolith depth classify (chat vs goose guest)."""
 

--- a/projects/monolith/chat/bot.py
+++ b/projects/monolith/chat/bot.py
@@ -7,6 +7,7 @@ import logging
 import os
 import re
 import time
+from datetime import datetime, timedelta, timezone
 
 import discord
 from pydantic_ai import (
@@ -655,6 +656,43 @@ class ChatBot(discord.Client):
         except Exception:
             logger.exception("Failed to re-register BotMessageViews on ready")
 
+    # How far back to look for a recent bot tag when deciding to lean into an
+    # ambient reply (ADR 035 engagement policy). A thread the bot was tagged
+    # in, or a channel tagged within this window, gets a lower engage
+    # threshold.
+    _RECENT_TAG_MESSAGES = 10
+    _RECENT_TAG_WINDOW = timedelta(minutes=10)
+
+    def _recently_tagged(self, channel_id: str, exclude_message_id: str) -> bool:
+        """True if the bot was @mentioned in this channel/thread within the
+        last ``_RECENT_TAG_MESSAGES`` messages and ``_RECENT_TAG_WINDOW``.
+        Threads are channels in Discord, so this one query covers both "a
+        thread I've tagged in" and "a window around a channel tag". Sync;
+        call via asyncio.to_thread. Fails closed to False.
+        """
+        try:
+            with Session(get_engine()) as session:
+                store = MessageStore(session=session, embed_client=self.embed_client)
+                recent = store.get_recent(channel_id, limit=self._RECENT_TAG_MESSAGES)
+        except Exception:
+            logger.exception("attention: recent-tag lookup failed")
+            return False
+        needles = (f"<@{self.user.id}>", f"<@!{self.user.id}>")
+        now = datetime.now(timezone.utc)
+        for m in recent:
+            if m.discord_message_id == exclude_message_id:
+                continue
+            created = (
+                m.created_at
+                if m.created_at.tzinfo
+                else m.created_at.replace(tzinfo=timezone.utc)
+            )
+            if now - created > self._RECENT_TAG_WINDOW:
+                continue
+            if m.content and any(n in m.content for n in needles):
+                return True
+        return False
+
     async def on_message(self, message: discord.Message):
         # Skip own messages — bot responses are stored explicitly after sending
         if message.author.id == self.user.id:
@@ -703,7 +741,12 @@ class ChatBot(discord.Client):
             is_ambient = False
         if is_ambient:
             directive = await asyncio.to_thread(directives.get_active, channel_id)
-            result = await attention.evaluate(message, directive, self.user, True)
+            recently_tagged = await asyncio.to_thread(
+                self._recently_tagged, channel_id, msg_id
+            )
+            result = await attention.evaluate(
+                message, directive, self.user, True, recently_tagged=recently_tagged
+            )
             directive_version = await asyncio.to_thread(
                 directives.get_active_version, channel_id
             )

--- a/projects/monolith/chat/bot_on_message_test.py
+++ b/projects/monolith/chat/bot_on_message_test.py
@@ -1,7 +1,7 @@
 """Additional coverage for ChatBot -- on_message(), on_ready(), streaming response."""
 
 import asyncio
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -501,16 +501,23 @@ class TestAttentionGate:
             patch(
                 "chat.bot.attention.needs_agent", AsyncMock(return_value=False)
             ) as mock_needs_agent,
+            patch.object(
+                bot, "_recently_tagged", MagicMock(return_value=True)
+            ) as mock_recently_tagged,
+            patch("chat.bot.attention.evaluate") as mock_evaluate,
             patch.object(bot, "_engage_agent", AsyncMock()) as mock_engage_agent,
             patch.object(bot, "start_agent_flow", AsyncMock()) as mock_start_flow,
             patch.object(bot, "_process_message", AsyncMock()) as mock_proc,
         ):
+            mock_evaluate.return_value = SimpleNamespace(engage=True, confidence=0.9)
             mock_session_cls.return_value.__enter__ = MagicMock(
                 return_value=MagicMock()
             )
             mock_session_cls.return_value.__exit__ = MagicMock(return_value=False)
             await bot.on_message(message)
 
+            mock_recently_tagged.assert_called_once_with("99", str(message.id))
+            assert mock_evaluate.call_args.kwargs.get("recently_tagged") is True
             mock_needs_agent.assert_called_once()
             mock_proc.assert_called_once_with(message, force_respond=True)
             mock_engage_agent.assert_not_called()
@@ -656,6 +663,80 @@ class TestAttentionGate:
 
             mock_evaluate.assert_not_called()
             mock_proc.assert_called_once_with(message)
+
+
+class TestRecentlyTagged:
+    """ChatBot._recently_tagged: recent-tag weighting for the attention gate."""
+
+    def _recent_message(self, content: str, minutes_ago: float, msg_id: str = "1"):
+        # SQLite created_at comes back tz-naive; mirror that here.
+        created = datetime.now(timezone.utc) - timedelta(minutes=minutes_ago)
+        return SimpleNamespace(
+            discord_message_id=msg_id, content=content, created_at=created
+        )
+
+    def test_true_when_tag_within_window(self):
+        bot = _make_bot()
+        recent = [self._recent_message("<@999> can you check this", 2, msg_id="1")]
+        mock_store = MagicMock()
+        mock_store.get_recent = MagicMock(return_value=recent)
+
+        with (
+            patch("chat.bot.get_engine"),
+            patch("chat.bot.Session"),
+            patch("chat.bot.MessageStore", return_value=mock_store),
+        ):
+            assert bot._recently_tagged("99", "2") is True
+
+    def test_false_when_tag_older_than_window(self):
+        bot = _make_bot()
+        recent = [self._recent_message("<@999> old ping", 30, msg_id="1")]
+        mock_store = MagicMock()
+        mock_store.get_recent = MagicMock(return_value=recent)
+
+        with (
+            patch("chat.bot.get_engine"),
+            patch("chat.bot.Session"),
+            patch("chat.bot.MessageStore", return_value=mock_store),
+        ):
+            assert bot._recently_tagged("99", "2") is False
+
+    def test_false_when_no_tag_present(self):
+        bot = _make_bot()
+        recent = [self._recent_message("just chatting", 1, msg_id="1")]
+        mock_store = MagicMock()
+        mock_store.get_recent = MagicMock(return_value=recent)
+
+        with (
+            patch("chat.bot.get_engine"),
+            patch("chat.bot.Session"),
+            patch("chat.bot.MessageStore", return_value=mock_store),
+        ):
+            assert bot._recently_tagged("99", "2") is False
+
+    def test_excludes_the_current_message(self):
+        bot = _make_bot()
+        # The only tag present is the message being evaluated itself.
+        recent = [self._recent_message("<@999> hey", 1, msg_id="2")]
+        mock_store = MagicMock()
+        mock_store.get_recent = MagicMock(return_value=recent)
+
+        with (
+            patch("chat.bot.get_engine"),
+            patch("chat.bot.Session"),
+            patch("chat.bot.MessageStore", return_value=mock_store),
+        ):
+            assert bot._recently_tagged("99", "2") is False
+
+    def test_fails_closed_on_store_error(self):
+        bot = _make_bot()
+
+        with (
+            patch("chat.bot.get_engine"),
+            patch("chat.bot.Session"),
+            patch("chat.bot.MessageStore", side_effect=RuntimeError("db down")),
+        ):
+            assert bot._recently_tagged("99", "2") is False
 
 
 # ---------------------------------------------------------------------------

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.259.0
+      targetRevision: 0.260.0
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
## Summary

Makes ambient channels actually participate. Follow-on to ADR 035 Phase 3/5.

Before: the attention classifier engaged "only if the message clearly wants the assistant per the directive" - with the tone-only default directive it engaged on almost nothing except @mentions. Now:

- **Base engagement policy** lives in the classifier prompt (not the directive, which stays tone-only for the reply): engage on an open question/request that addresses the bot or the group and wants a response, OR is about a repo/codebase, OR would benefit from a web search / fact-check. Lean ignore for idle chatter, statements, or other people's conversation. The channel directive is injected as a *refinement*, not the sole gate.
- **Recent-tag weighting**: `_recently_tagged` scans `get_recent` for `<@bot>` within the last ~10 messages / ~10 min (a thread is a channel, so this covers both "a thread I've tagged in" and "a window around a channel tag"). When hit, the engage threshold drops 0.8 -> 0.5 (`ATTENTION_RECENT_TAG_THRESHOLD`), so the bot leans into follow-ups right after being tagged.

Mention/reply short-circuit (engage 1.0), non-ambient ignore, and fail-closed-on-error are unchanged. Every decision still logs to `chat.attention_decision`, so the policy is observable and tunable.

## Deploy

monolith chart `0.259.0 -> 0.260.0`.

## Watch after rollout

The base criteria are a denser instruction for the local Qwen classifier; worth watching `attention_decision` for whether "fact-checkable" over-triggers on factual-sounding statements. Thresholds are env-tunable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)