### PR TITLE
fix(grimoire): make openrouter secret optional so rollout is not blocked

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.261.0
+version: 0.262.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/templates/cronworkflows.yaml
+++ b/projects/monolith/chart/templates/cronworkflows.yaml
@@ -129,6 +129,10 @@ spec:
                 secretKeyRef:
                   name: {{ include "monolith.fullname" $ }}-openrouter
                   key: OPENROUTER_API_KEY
+                  # Optional: the Secret only exists once the "openrouter"
+                  # 1Password item is created; the pod must not be blocked on it
+                  # (the extract job already skips cleanly when the key is unset).
+                  optional: true
             - name: GRIMOIRE_S3_BUCKET
               value: {{ $.Values.grimoire.s3Bucket | quote }}
             - name: GRIMOIRE_EXTRACT_MODEL

--- a/projects/monolith/chart/templates/deployment.yaml
+++ b/projects/monolith/chart/templates/deployment.yaml
@@ -234,6 +234,10 @@ spec:
                 secretKeyRef:
                   name: {{ include "monolith.fullname" . }}-openrouter
                   key: OPENROUTER_API_KEY
+                  # Optional: the Secret only exists once the "openrouter"
+                  # 1Password item is created; the pod must not be blocked on it
+                  # (the extract job already skips cleanly when the key is unset).
+                  optional: true
             - name: GRIMOIRE_S3_BUCKET
               value: {{ .Values.grimoire.s3Bucket | quote }}
             - name: GRIMOIRE_EXTRACT_MODEL

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.261.0
+      targetRevision: 0.262.0
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
The monolith-openrouter Secret only exists once the openrouter 1Password
item is created; the hard secretKeyRef left the new pod in
CreateContainerConfigError and wedged the 0.261.0 rollout. The extract
job already skips cleanly when the key is unset, so mark the env
optional on both the deployment and the grimoire cronworkflows.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
