### PR TITLE
fix(grimoire): route /api/grimoire to the backend on the private ingress

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.262.0
+version: 0.263.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/templates/httproute-private.yaml
+++ b/projects/monolith/chart/templates/httproute-private.yaml
@@ -39,6 +39,17 @@ spec:
       backendRefs:
         - name: {{ include "monolith.fullname" . }}
           port: {{ .Values.service.apiPort | int }}
+    # Grimoire API — pass through to backend without rewriting. Without this
+    # rule /api/grimoire/* falls through to the catch-all below and lands on
+    # the SvelteKit port, which 404s it (the private-tier equivalent of the
+    # public ALLOWED_PREFIXES gap).
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /api/grimoire
+      backendRefs:
+        - name: {{ include "monolith.fullname" . }}
+          port: {{ .Values.service.apiPort | int }}
     # Chat interface — SvelteKit SSR calls LLM backend, needs long timeout
     - matches:
         - path:

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.262.0
+      targetRevision: 0.263.0
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
## Problem

The `/app/grimoire` page loads its shell but every `/api/grimoire/*` fetch returns **404** (`request failed (404)` banner in the UI).

## Root cause

The private `HTTPRoute` (`projects/monolith/chart/templates/httproute-private.yaml`) routes traffic by path prefix across two ports:

- `/api/knowledge`, `/api/scheduler` -> `service.apiPort` (backend FastAPI, :8000)
- `/_app/`, `/private/chat`, catch-all `/` -> `cfIngress.private.servicePort` (SvelteKit SSR, :3000)

`/api/grimoire` was never added, so it fell through to the catch-all `/` rule and was sent to the **SvelteKit** container, which has no such route and 404s it. The backend serves `/api/grimoire` correctly on :8000 (verified in-cluster: `GET /api/grimoire/campaigns` returns 200 with the seeded "Demo Campaign"). The edge just never routed there.

PR #3119 added the SvelteKit page and the FastAPI router but missed the ingress rule. This is the private-tier analogue of the public `ALLOWED_PREFIXES` gap.

## Fix

Add an `/api/grimoire` `PathPrefix` rule pointing at `service.apiPort`, mirroring the existing `/api/scheduler` rule. Chart bumped `0.262.0 -> 0.263.0` with `targetRevision` kept in sync.

## Verification

- `helm template` renders the new rule -> port 8000, ordered before the `/` catch-all.
- In-cluster the backend already answers 200 on all page-load endpoints (`/campaigns`, `/campaigns/{id}/characters`, `/campaigns/{id}/entities?as=dm`, `/grants`); only the edge route was missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)