### PR TITLE
fix(chat): dedupe search bullets so model retries don't repeat

### DIFF
--- a/projects/monolith/chat/bot.py
+++ b/projects/monolith/chat/bot.py
@@ -1483,11 +1483,15 @@ class ChatBot(discord.Client):
                         query = args.get("query", str(args))
                     else:
                         query = str(args)
-                    tool_queries.append(query)
-                    bullets = "\n".join(f"\u2022 {q}" for q in tool_queries)
-                    content = f"\U0001f50d Searching...\n{bullets}"
-                    await _ensure_sent(content)
-                    await _edit_if_due(content, force=True)
+                    # Dedupe: a model-unavailable retry replays the turn and
+                    # re-emits the same tool call. Showing it once keeps the
+                    # progress list honest instead of spamming repeat bullets.
+                    if query not in tool_queries:
+                        tool_queries.append(query)
+                        bullets = "\n".join(f"\u2022 {q}" for q in tool_queries)
+                        content = f"\U0001f50d Searching...\n{bullets}"
+                        await _ensure_sent(content)
+                        await _edit_if_due(content, force=True)
 
             # Fallback if no events arrived or no text was produced
             if not had_events or not response_text:

--- a/projects/monolith/chat/bot_streaming_test.py
+++ b/projects/monolith/chat/bot_streaming_test.py
@@ -265,6 +265,47 @@ class TestMultipleToolCalls:
         assert "first query" in combined
         assert "second query" in combined
 
+    @pytest.mark.asyncio
+    async def test_retried_tool_call_shows_single_bullet(self):
+        """A model-unavailable retry re-emits the same tool call; the
+        progress message must show that query once, not once per retry."""
+        bot = _make_bot()
+        bot_user = bot.user
+        message = _make_message(content="Hi", mentions=[bot_user])
+        mock_store = _make_store()
+
+        # Same query emitted repeatedly, as PydanticAI does when it replays
+        # the turn after a transient model-unavailable error.
+        events = [
+            _tool_call_event("web_search", {"query": "cafes New Westminster"}),
+            _tool_call_event("web_search", {"query": "cafes New Westminster"}),
+            _tool_call_event("web_search", {"query": "cafes New Westminster"}),
+            _text_delta("Here are some cafes."),
+        ]
+
+        bot.agent.run_stream_events = MagicMock(return_value=_async_iter(events))
+
+        with (
+            patch("chat.bot.get_engine"),
+            patch("chat.bot.Session") as mock_session_cls,
+            patch("chat.bot.MessageStore", return_value=mock_store),
+        ):
+            ctx = MagicMock()
+            mock_session_cls.return_value.__enter__ = MagicMock(return_value=ctx)
+            mock_session_cls.return_value.__exit__ = MagicMock(return_value=False)
+            await bot.on_message(message)
+
+        sent = message.reply.return_value
+        all_contents = [
+            call.kwargs.get("content", "") for call in sent.edit.call_args_list
+        ]
+        all_contents.extend(
+            call.args[0] for call in message.reply.call_args_list if call.args
+        )
+        # No rendered progress message may repeat the query bullet.
+        for content in all_contents:
+            assert content.count("• cafes New Westminster") <= 1
+
 
 class TestNoEventsFallback:
     @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

When the LLM was temporarily unavailable, Bosun's `🔍 Searching...` progress message on Discord showed the same search query repeated a dozen-plus times (see the reported screenshot with `best cafes restaurants along Trans Canada Trail New Westminster Port Mann 2025 2026` stacked repeatedly).

## Cause

`_stream_response` in `chat/bot.py` appends every `FunctionToolCallEvent` to `tool_queries` unconditionally. On a model-unavailable error PydanticAI replays the turn and re-emits the same tool call, so each retry added another identical bullet (and forced another Discord edit).

## Fix

Skip the append and the redundant edit when the query string is already present. Keyed on the query string, not `tool_call_id`, because a genuine retry regenerates the call with a fresh id, which id-based dedup would miss.

## Test

Adds `test_retried_tool_call_shows_single_bullet`, which feeds three identical `web_search` events (the retry shape) and asserts no rendered progress message contains the query bullet more than once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PpvtXSA9vTVd9Bm4qrApsu