### PR TITLE
feat(chat): live per-search status in the Discord checklist

### DIFF
--- a/projects/monolith/chat/bot.py
+++ b/projects/monolith/chat/bot.py
@@ -14,6 +14,7 @@ from pydantic_ai import (
     AgentRunResultEvent,
     BinaryContent,
     FunctionToolCallEvent,
+    FunctionToolResultEvent,
     PartDeltaEvent,
     TextPartDelta,
     ThinkingPartDelta,
@@ -1437,10 +1438,23 @@ class ChatBot(discord.Client):
             # Streaming state
             sent: discord.Message | None = None
             thinking_parts: list[str] = []
-            tool_queries: list[str] = []
+            # Live search checklist. search_status is keyed by query string so a
+            # model-unavailable retry (which replays the same tool call under a
+            # fresh id) collapses to one row; id_to_query maps every seen
+            # tool_call_id back to its query so a result event can flip the
+            # marker from pending to done.
+            search_status: dict[str, bool] = {}  # query -> done
+            id_to_query: dict[str, str] = {}  # tool_call_id -> query
             response_text = ""
             last_edit_time = 0.0
             had_events = False
+
+            def _search_content() -> str:
+                lines = []
+                for q, done in search_status.items():
+                    marker = "✅" if done else "⏳"
+                    lines.append(f"{marker} {q}")
+                return "\U0001f50d Searching...\n" + "\n".join(lines)
 
             async def _ensure_sent(content: str) -> discord.Message:
                 nonlocal sent
@@ -1483,15 +1497,26 @@ class ChatBot(discord.Client):
                         query = args.get("query", str(args))
                     else:
                         query = str(args)
+                    call_id = event.part.tool_call_id
+                    if call_id:
+                        id_to_query[call_id] = query
                     # Dedupe: a model-unavailable retry replays the turn and
                     # re-emits the same tool call. Showing it once keeps the
-                    # progress list honest instead of spamming repeat bullets.
-                    if query not in tool_queries:
-                        tool_queries.append(query)
-                        bullets = "\n".join(f"\u2022 {q}" for q in tool_queries)
-                        content = f"\U0001f50d Searching...\n{bullets}"
+                    # checklist honest instead of spamming repeat rows; a later
+                    # result event for either id flips the shared row to done.
+                    if query not in search_status:
+                        search_status[query] = False
+                        content = _search_content()
                         await _ensure_sent(content)
                         await _edit_if_due(content, force=True)
+                elif isinstance(event, FunctionToolResultEvent):
+                    # A search returned: flip its row from \u23f3 to \u2705.
+                    done_query = id_to_query.get(event.tool_call_id)
+                    if done_query is not None and not search_status.get(
+                        done_query, True
+                    ):
+                        search_status[done_query] = True
+                        await _edit_if_due(_search_content(), force=True)
 
             # Fallback if no events arrived or no text was produced
             if not had_events or not response_text:

--- a/projects/monolith/chat/bot_streaming_test.py
+++ b/projects/monolith/chat/bot_streaming_test.py
@@ -6,11 +6,12 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from pydantic_ai import (
     AgentRunResultEvent,
     FunctionToolCallEvent,
+    FunctionToolResultEvent,
     PartDeltaEvent,
     TextPartDelta,
     ThinkingPartDelta,
 )
-from pydantic_ai.messages import ToolCallPart
+from pydantic_ai.messages import ToolCallPart, ToolReturnPart
 
 from chat.bot import ChatBot, BotMessageView, STREAM_EDIT_INTERVAL
 
@@ -94,10 +95,21 @@ def _thinking_delta(content: str) -> PartDeltaEvent:
     return PartDeltaEvent(index=0, delta=ThinkingPartDelta(content_delta=content))
 
 
-def _tool_call_event(tool_name: str, args: dict) -> FunctionToolCallEvent:
+def _tool_call_event(
+    tool_name: str, args: dict, tool_call_id: str | None = None
+) -> FunctionToolCallEvent:
     """Create a FunctionToolCallEvent with dict args."""
-    part = ToolCallPart(tool_name=tool_name, args=args)
+    kwargs = {"tool_name": tool_name, "args": args}
+    if tool_call_id is not None:
+        kwargs["tool_call_id"] = tool_call_id
+    part = ToolCallPart(**kwargs)
     return FunctionToolCallEvent(part=part)
+
+
+def _tool_result_event(tool_name: str, tool_call_id: str) -> FunctionToolResultEvent:
+    """Create a FunctionToolResultEvent for a completed tool call."""
+    part = ToolReturnPart(tool_name=tool_name, content="ok", tool_call_id=tool_call_id)
+    return FunctionToolResultEvent(result=part)
 
 
 def _tool_call_event_str_args(tool_name: str, args_str: str) -> FunctionToolCallEvent:
@@ -302,9 +314,47 @@ class TestMultipleToolCalls:
         all_contents.extend(
             call.args[0] for call in message.reply.call_args_list if call.args
         )
-        # No rendered progress message may repeat the query bullet.
+        # No rendered progress message may repeat the query row.
         for content in all_contents:
-            assert content.count("• cafes New Westminster") <= 1
+            assert content.count("cafes New Westminster") <= 1
+
+    @pytest.mark.asyncio
+    async def test_tool_result_flips_search_to_done(self):
+        """A tool result event flips its search row from pending to done."""
+        bot = _make_bot()
+        bot_user = bot.user
+        message = _make_message(content="Hi", mentions=[bot_user])
+        mock_store = _make_store()
+
+        events = [
+            _tool_call_event("web_search", {"query": "trail cafes"}, tool_call_id="c1"),
+            _tool_result_event("web_search", tool_call_id="c1"),
+            _text_delta("Here are some cafes."),
+        ]
+
+        bot.agent.run_stream_events = MagicMock(return_value=_async_iter(events))
+
+        with (
+            patch("chat.bot.get_engine"),
+            patch("chat.bot.Session") as mock_session_cls,
+            patch("chat.bot.MessageStore", return_value=mock_store),
+        ):
+            ctx = MagicMock()
+            mock_session_cls.return_value.__enter__ = MagicMock(return_value=ctx)
+            mock_session_cls.return_value.__exit__ = MagicMock(return_value=False)
+            await bot.on_message(message)
+
+        sent = message.reply.return_value
+        all_contents = [
+            call.kwargs.get("content", "") for call in sent.edit.call_args_list
+        ]
+        all_contents.extend(
+            call.args[0] for call in message.reply.call_args_list if call.args
+        )
+        # The pending marker appears while searching...
+        assert any("⏳ trail cafes" in c for c in all_contents)
+        # ...and the completed marker appears once the result arrives.
+        assert any("✅ trail cafes" in c for c in all_contents)
 
 
 class TestNoEventsFallback:


### PR DESCRIPTION
## What

Builds on #3124. The `🔍 Searching...` progress message now shows each search as a checklist row that flips from pending (`⏳`) to done (`✅`), mirroring the ADR-035 agent-stage markers.

Before (post-#3124): flat `• query` bullets, no completion signal.
After: `⏳ query` while the search runs, `✅ query` once it returns.

## How

- New `elif isinstance(event, FunctionToolResultEvent)` branch in `_stream_response`. PydanticAI emits this when a tool returns, carrying the same `tool_call_id` as the originating call event.
- `search_status: dict[query -> done]` keeps the dedup identity (a model-unavailable retry replays the same query, so it stays one row).
- `id_to_query: dict[tool_call_id -> query]` maps every seen call id (including a retry's fresh id) back to its query, so whichever call completes flips the single visible row.
- `_search_content()` renders the checklist; it reuses the raw-emoji marker style already used by `render_checklist`.

The checklist is transient: the final answer text (or the fallback) overwrites the message, so a search still pending when the reply lands is never the terminal visible state (per the agreed "assume done" behavior).

## Tests

- `test_tool_result_flips_search_to_done` — a call event then a matching result event renders `⏳ trail cafes` and later `✅ trail cafes`.
- Updated `test_retried_tool_call_shows_single_bullet` to be marker-agnostic (asserts the query row never repeats).
- Existing "Searching" / query-decoding tests still hold (the header and query text are unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PpvtXSA9vTVd9Bm4qrApsu