### PR TITLE
chore(release): bump monolith 0.265.0 to ship search-status changes

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.264.0
+version: 0.265.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.264.0
+      targetRevision: 0.265.0
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
Rolls out the merged `chat/bot.py` changes that landed without a chart bump:

- #3124 — dedupe search bullets so model retries don't repeat
- #3126 — live per-search checklist status (`⏳` → `✅`)
- 24d3d9cf9 — ground agent-thread capabilities in recipes

ArgoCD pulls the monolith chart by version from OCI, so these code changes stay un-deployed until `Chart.yaml` `version` and `deploy/application.yaml` `targetRevision` are bumped in lockstep (0.264.0 → 0.265.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PpvtXSA9vTVd9Bm4qrApsu