### PR TITLE
feat(chat): ADR 036 Phase 1 - OpenRouter client + secret plumbing

### DIFF
--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -1384,6 +1384,18 @@ py_test(
 )
 
 py_test(
+    name = "chat_orchestrator_client_test",
+    srcs = ["chat/orchestrator_client_test.py"],
+    imports = ["."],
+    deps = [
+        ":monolith_backend",
+        "@pip//httpx",
+        "@pip//pytest",
+        "@pip//pytest_asyncio",
+    ],
+)
+
+py_test(
     name = "chat_summarizer_llm_caller_test",
     srcs = ["chat/summarizer_llm_caller_test.py"],
     imports = ["."],

--- a/projects/monolith/chart/templates/deployment.yaml
+++ b/projects/monolith/chart/templates/deployment.yaml
@@ -251,6 +251,28 @@ spec:
               value: {{ .Values.grimoire.extractLimit | quote }}
             {{- end }}
             {{- end }}
+            {{- if .Values.orchestrator.enabled }}
+            # ADR 036 orchestrator brief compiler (host-side only; the guest
+            # egress boundary in ADR 023 never carries this key). OPENROUTER_API_KEY
+            # is synced from the "openrouter" 1Password item into the
+            # {{ include "monolith.fullname" . }}-orchestrator Secret, matching
+            # the field name convention grimoire's OPENROUTER_API_KEY uses.
+            - name: OPENROUTER_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "monolith.fullname" . }}-orchestrator
+                  key: OPENROUTER_API_KEY
+                  # Optional: the Secret only exists once the 1Password item
+                  # is created; the client fails open (OrchestratorUnavailable)
+                  # when the key is absent.
+                  optional: true
+            - name: ORCHESTRATOR_MODEL
+              value: {{ .Values.orchestrator.model | quote }}
+            - name: ORCHESTRATOR_BASE_URL
+              value: {{ .Values.orchestrator.baseUrl | quote }}
+            - name: ORCHESTRATOR_TIMEOUT_S
+              value: {{ .Values.orchestrator.timeoutSeconds | quote }}
+            {{- end }}
           livenessProbe:
             httpGet:
               path: /healthz

--- a/projects/monolith/chart/templates/onepassworditem-orchestrator.yaml
+++ b/projects/monolith/chart/templates/onepassworditem-orchestrator.yaml
@@ -1,0 +1,18 @@
+{{- if and .Values.orchestrator.enabled .Values.orchestrator.onepassword.itemPath }}
+# OpenRouter API key for the ADR 036 orchestrator brief compiler. Synced from
+# the 1Password item named by orchestrator.onepassword.itemPath (the same
+# "openrouter" item in vault k8s-homelab that grimoire uses) into the
+# {{ include "monolith.fullname" . }}-orchestrator Secret. The deployment reads
+# it as OPENROUTER_API_KEY via secretKeyRef, matching the field name the
+# 1Password item exposes (see onepassworditem-openrouter.yaml for the
+# grimoire equivalent).
+apiVersion: onepassword.com/v1
+kind: OnePasswordItem
+metadata:
+  name: {{ include "monolith.fullname" . }}-orchestrator
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "monolith.labels" . | nindent 4 }}
+spec:
+  itemPath: {{ .Values.orchestrator.onepassword.itemPath | quote }}
+{{- end }}

--- a/projects/monolith/chart/values.yaml
+++ b/projects/monolith/chart/values.yaml
@@ -629,6 +629,22 @@ grimoire:
   # change.
   extractLimit: ""
 
+# ADR 036 orchestrator brief compiler: a host-side OpenRouter call that routes
+# chat vs goose and compiles a grounded task brief for escalations. Disabled
+# by default (Phase 1: plumbing only, no chart bump until Phase 3 flips this
+# on). OPENROUTER_API_KEY is synced from the 1Password item named by
+# onepassword.itemPath (item "openrouter", field "OPENROUTER_API_KEY", the
+# same item grimoire uses) into the {fullname}-orchestrator Secret. model is
+# pinned (never ":auto") so briefs stay attributable; timeoutSeconds bounds
+# the fail-open budget before the flow falls back to direct submit.
+orchestrator:
+  enabled: false
+  onepassword:
+    itemPath: ""
+  model: "deepseek/deepseek-chat-v4-flash"
+  baseUrl: "https://openrouter.ai/api/v1"
+  timeoutSeconds: 10
+
 # Marine / AIS ship tracking: streams vessel positions from AISStream.io.
 # Reuses the existing 1Password "marine" vault item (shared with the legacy
 # standalone ships app) so the secret keeps materializing after that app is

--- a/projects/monolith/chat/orchestrator_client.py
+++ b/projects/monolith/chat/orchestrator_client.py
@@ -81,7 +81,7 @@ async def call(system: str, user: str) -> OrchestratorResponse:
     try:
         async with httpx.AsyncClient(timeout=httpx.Timeout(timeout_s)) as client:
             resp = await client.post(
-                f"{base_url}/v1/chat/completions",
+                f"{base_url}/chat/completions",
                 headers={"Authorization": f"Bearer {api_key}"},
                 json={
                     "model": model,

--- a/projects/monolith/chat/orchestrator_client.py
+++ b/projects/monolith/chat/orchestrator_client.py
@@ -1,0 +1,118 @@
+"""ADR 036 orchestrator brief-compiler OpenRouter client.
+
+Unary, short-timeout httpx client shaped like ``summarizer.build_llm_caller``
+(summarizer.py:412), but for the paid OpenRouter escalation tier rather than
+the local Qwen executor. Per the fail-open philosophy (ADR 036 Architecture:
+"Fail open"), this client makes exactly one attempt: any timeout or HTTP error
+raises ``OrchestratorUnavailable`` so the caller can fall back to direct
+submit. There is no retry loop here (contrast with build_llm_caller's 3
+retries), because escalations must degrade quickly, not stall on a paid call.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from dataclasses import dataclass
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_BASE_URL = "https://openrouter.ai/api/v1"
+_DEFAULT_TIMEOUT_S = 10.0
+
+
+class OrchestratorUnavailable(Exception):
+    """Raised when the orchestrator call cannot be completed (timeout, HTTP
+    error, or any other transport failure). Callers should treat this as a
+    fail-open signal and fall back to today's direct-submit path."""
+
+
+@dataclass
+class OrchestratorResponse:
+    """Parsed result of one orchestrator call."""
+
+    content: str
+    prompt_tokens: int | None
+    completion_tokens: int | None
+    cached_tokens: int | None
+    latency_ms: int
+
+
+def _read_config() -> tuple[str, str, str, float]:
+    """Read the model, base URL, API key, and timeout from the environment.
+
+    The model is expected to be pinned (never ``:auto``) so briefs stay
+    attributable to a specific provider model (ADR 036 Risks table).
+    """
+    model = os.environ.get("ORCHESTRATOR_MODEL", "")
+    base_url = os.environ.get("ORCHESTRATOR_BASE_URL", "") or _DEFAULT_BASE_URL
+    api_key = os.environ.get("OPENROUTER_API_KEY", "")
+    timeout_raw = os.environ.get("ORCHESTRATOR_TIMEOUT_S", "")
+    try:
+        timeout_s = float(timeout_raw) if timeout_raw else _DEFAULT_TIMEOUT_S
+    except ValueError:
+        timeout_s = _DEFAULT_TIMEOUT_S
+    return model, base_url, api_key, timeout_s
+
+
+def _extract_usage(payload: dict) -> tuple[int | None, int | None, int | None]:
+    """Pull prompt/completion/cached token counts out of an OpenRouter
+    response body, tolerating any of them being absent."""
+    usage = payload.get("usage") or {}
+    prompt_tokens = usage.get("prompt_tokens")
+    completion_tokens = usage.get("completion_tokens")
+    cached_tokens = None
+    prompt_details = usage.get("prompt_tokens_details") or {}
+    if isinstance(prompt_details, dict):
+        cached_tokens = prompt_details.get("cached_tokens")
+    return prompt_tokens, completion_tokens, cached_tokens
+
+
+async def call(system: str, user: str) -> OrchestratorResponse:
+    """Send one system/user turn to the configured OpenRouter model and
+    parse the response. Raises ``OrchestratorUnavailable`` on any timeout or
+    HTTP error; makes a single attempt (no retries)."""
+    model, base_url, api_key, timeout_s = _read_config()
+
+    started = time.monotonic()
+    try:
+        async with httpx.AsyncClient(timeout=httpx.Timeout(timeout_s)) as client:
+            resp = await client.post(
+                f"{base_url}/v1/chat/completions",
+                headers={"Authorization": f"Bearer {api_key}"},
+                json={
+                    "model": model,
+                    "messages": [
+                        {"role": "system", "content": system},
+                        {"role": "user", "content": user},
+                    ],
+                },
+            )
+            resp.raise_for_status()
+            payload = resp.json()
+    except httpx.TimeoutException as exc:
+        raise OrchestratorUnavailable(f"orchestrator call timed out: {exc}") from exc
+    except httpx.HTTPError as exc:
+        raise OrchestratorUnavailable(f"orchestrator call failed: {exc}") from exc
+
+    latency_ms = int((time.monotonic() - started) * 1000)
+
+    try:
+        content = payload["choices"][0]["message"]["content"]
+    except (KeyError, IndexError, TypeError) as exc:
+        raise OrchestratorUnavailable(
+            f"unexpected orchestrator response shape: {exc}"
+        ) from exc
+
+    prompt_tokens, completion_tokens, cached_tokens = _extract_usage(payload)
+
+    return OrchestratorResponse(
+        content=content,
+        prompt_tokens=prompt_tokens,
+        completion_tokens=completion_tokens,
+        cached_tokens=cached_tokens,
+        latency_ms=latency_ms,
+    )

--- a/projects/monolith/chat/orchestrator_client_test.py
+++ b/projects/monolith/chat/orchestrator_client_test.py
@@ -1,0 +1,164 @@
+"""Tests for chat.orchestrator_client (ADR 036 Phase 1)."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from chat.orchestrator_client import OrchestratorUnavailable, call
+
+
+def _mock_client(mock_response=None, post_side_effect=None):
+    """Build a MagicMock standing in for httpx.AsyncClient used as an async
+    context manager (``async with httpx.AsyncClient(...) as client``)."""
+    instance = MagicMock()
+    if post_side_effect is not None:
+        instance.post = AsyncMock(side_effect=post_side_effect)
+    else:
+        instance.post = AsyncMock(return_value=mock_response)
+    instance.__aenter__ = AsyncMock(return_value=instance)
+    instance.__aexit__ = AsyncMock(return_value=False)
+    return instance
+
+
+def _ok_response(payload):
+    resp = MagicMock()
+    resp.raise_for_status = MagicMock()
+    resp.json.return_value = payload
+    return resp
+
+
+class TestCallHappyPath:
+    @pytest.mark.asyncio
+    async def test_parses_content_and_usage(self):
+        payload = {
+            "choices": [{"message": {"content": "brief text"}}],
+            "usage": {
+                "prompt_tokens": 100,
+                "completion_tokens": 20,
+                "prompt_tokens_details": {"cached_tokens": 80},
+            },
+        }
+        instance = _mock_client(mock_response=_ok_response(payload))
+
+        env = {
+            "ORCHESTRATOR_MODEL": "deepseek/deepseek-chat-v4-flash",
+            "ORCHESTRATOR_BASE_URL": "https://openrouter.ai/api/v1",
+            "OPENROUTER_API_KEY": "test-key",
+            "ORCHESTRATOR_TIMEOUT_S": "10",
+        }
+        with (
+            patch("chat.orchestrator_client.httpx.AsyncClient", return_value=instance),
+            patch.dict("os.environ", env, clear=False),
+        ):
+            result = await call("system prompt", "user prompt")
+
+        assert result.content == "brief text"
+        assert result.prompt_tokens == 100
+        assert result.completion_tokens == 20
+        assert result.cached_tokens == 80
+        assert result.latency_ms >= 0
+
+    @pytest.mark.asyncio
+    async def test_missing_usage_fields_return_none(self):
+        payload = {"choices": [{"message": {"content": "brief text"}}]}
+        instance = _mock_client(mock_response=_ok_response(payload))
+
+        env = {"ORCHESTRATOR_MODEL": "m", "OPENROUTER_API_KEY": "k"}
+        with (
+            patch("chat.orchestrator_client.httpx.AsyncClient", return_value=instance),
+            patch.dict("os.environ", env, clear=False),
+        ):
+            result = await call("system", "user")
+
+        assert result.content == "brief text"
+        assert result.prompt_tokens is None
+        assert result.completion_tokens is None
+        assert result.cached_tokens is None
+
+    @pytest.mark.asyncio
+    async def test_sends_pinned_model_and_auth_header(self):
+        payload = {"choices": [{"message": {"content": "ok"}}]}
+        instance = _mock_client(mock_response=_ok_response(payload))
+
+        env = {
+            "ORCHESTRATOR_MODEL": "deepseek/deepseek-chat-v4-flash",
+            "ORCHESTRATOR_BASE_URL": "https://openrouter.ai/api/v1",
+            "OPENROUTER_API_KEY": "secret-key",
+        }
+        with (
+            patch("chat.orchestrator_client.httpx.AsyncClient", return_value=instance),
+            patch.dict("os.environ", env, clear=False),
+        ):
+            await call("sys text", "usr text")
+
+        instance.post.assert_called_once()
+        args, kwargs = instance.post.call_args
+        assert args[0] == "https://openrouter.ai/api/v1/v1/chat/completions"
+        assert kwargs["headers"]["Authorization"] == "Bearer secret-key"
+        payload_sent = kwargs["json"]
+        assert payload_sent["model"] == "deepseek/deepseek-chat-v4-flash"
+        assert payload_sent["messages"][0] == {
+            "role": "system",
+            "content": "sys text",
+        }
+        assert payload_sent["messages"][1] == {"role": "user", "content": "usr text"}
+
+
+class TestCallFailures:
+    @pytest.mark.asyncio
+    async def test_timeout_raises_orchestrator_unavailable(self):
+        instance = _mock_client(post_side_effect=httpx.TimeoutException("timed out"))
+
+        env = {"ORCHESTRATOR_MODEL": "m", "OPENROUTER_API_KEY": "k"}
+        with (
+            patch("chat.orchestrator_client.httpx.AsyncClient", return_value=instance),
+            patch.dict("os.environ", env, clear=False),
+        ):
+            with pytest.raises(OrchestratorUnavailable):
+                await call("system", "user")
+
+    @pytest.mark.asyncio
+    async def test_http_500_raises_orchestrator_unavailable(self):
+        resp = MagicMock()
+        resp.status_code = 500
+        error = httpx.HTTPStatusError(
+            "500 Internal Server Error", request=MagicMock(), response=resp
+        )
+        resp.raise_for_status.side_effect = error
+        instance = _mock_client(mock_response=resp)
+
+        env = {"ORCHESTRATOR_MODEL": "m", "OPENROUTER_API_KEY": "k"}
+        with (
+            patch("chat.orchestrator_client.httpx.AsyncClient", return_value=instance),
+            patch.dict("os.environ", env, clear=False),
+        ):
+            with pytest.raises(OrchestratorUnavailable):
+                await call("system", "user")
+
+    @pytest.mark.asyncio
+    async def test_no_retry_on_failure(self):
+        """The client makes exactly one attempt; no retry loop."""
+        instance = _mock_client(post_side_effect=httpx.ConnectError("refused"))
+
+        env = {"ORCHESTRATOR_MODEL": "m", "OPENROUTER_API_KEY": "k"}
+        with (
+            patch("chat.orchestrator_client.httpx.AsyncClient", return_value=instance),
+            patch.dict("os.environ", env, clear=False),
+        ):
+            with pytest.raises(OrchestratorUnavailable):
+                await call("system", "user")
+
+        assert instance.post.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_unexpected_response_shape_raises_orchestrator_unavailable(self):
+        instance = _mock_client(mock_response=_ok_response({"unexpected": "shape"}))
+
+        env = {"ORCHESTRATOR_MODEL": "m", "OPENROUTER_API_KEY": "k"}
+        with (
+            patch("chat.orchestrator_client.httpx.AsyncClient", return_value=instance),
+            patch.dict("os.environ", env, clear=False),
+        ):
+            with pytest.raises(OrchestratorUnavailable):
+                await call("system", "user")

--- a/projects/monolith/chat/orchestrator_client_test.py
+++ b/projects/monolith/chat/orchestrator_client_test.py
@@ -94,7 +94,7 @@ class TestCallHappyPath:
 
         instance.post.assert_called_once()
         args, kwargs = instance.post.call_args
-        assert args[0] == "https://openrouter.ai/api/v1/v1/chat/completions"
+        assert args[0] == "https://openrouter.ai/api/v1/chat/completions"
         assert kwargs["headers"]["Authorization"] == "Bearer secret-key"
         payload_sent = kwargs["json"]
         assert payload_sent["model"] == "deepseek/deepseek-chat-v4-flash"

--- a/projects/monolith/deploy/values.yaml
+++ b/projects/monolith/deploy/values.yaml
@@ -269,6 +269,14 @@ grimoire:
   extractModel: "qwen3.6-27b"
   extractBaseUrl: "http://inference.inference.svc.cluster.local:8080/v1/chat/completions"
 
+# ADR 036 orchestrator brief compiler. Phase 1 only wires the secret and
+# config; enabled stays false until Phase 3 flips the rollout on. Reuses the
+# same "openrouter" 1Password item grimoire uses.
+orchestrator:
+  enabled: false
+  onepassword:
+    itemPath: "vaults/k8s-homelab/items/openrouter"
+
 agent:
   discord:
     defaultServerId: "1501965852042330302"


### PR DESCRIPTION
## Summary

Implements Phase 1 of `docs/plans/2026-07-02-orchestrator-brief-compiler.md` (ADR 036: Orchestrator Brief-Compiler Tier via OpenRouter).

- **Task 1.1: values + 1Password secret + env wiring.** Adds `orchestrator.*` block to `projects/monolith/chart/values.yaml` (default `enabled: false`, model pinned to `deepseek/deepseek-chat-v4-flash`, `baseUrl`, `timeoutSeconds: 10`), cluster overrides in `projects/monolith/deploy/values.yaml` (still `enabled: false`, itemPath pointed at the same `openrouter` 1Password item grimoire uses), a new `onepassworditem-orchestrator.yaml` template mirroring the gardener shape, and gated env vars (`OPENROUTER_API_KEY`, `ORCHESTRATOR_MODEL`, `ORCHESTRATOR_BASE_URL`, `ORCHESTRATOR_TIMEOUT_S`) in the monolith deployment template.
- **Task 1.2: OpenRouter client module.** New `projects/monolith/chat/orchestrator_client.py`: an async `call(system, user) -> OrchestratorResponse` shaped like `summarizer.build_llm_caller` but unary and single-attempt (no retries, per the fail-open philosophy). Raises `OrchestratorUnavailable` on timeout or any HTTP error. Parses `usage.prompt_tokens`/`completion_tokens` and OpenRouter's `usage.prompt_tokens_details.cached_tokens`, tolerating absence. New `orchestrator_client_test.py` covers the happy path, missing usage fields, pinned model/auth header, timeout, HTTP 500, and no-retry behavior; registered as `chat_orchestrator_client_test` in `projects/monolith/BUILD`.

`orchestrator.enabled` stays `false` this phase, so **no chart version bump**.

## Notes / deviations

- The 1Password item field name for `OPENROUTER_API_KEY` was matched from grimoire's `onepassworditem-openrouter.yaml`/deployment wiring (item "openrouter" in vault `k8s-homelab`, field labelled `OPENROUTER_API_KEY`). The orchestrator gets its own `OnePasswordItem` CR (`{{ include "monolith.fullname" . }}-orchestrator`) per the plan's explicit instruction, syncing the same underlying 1Password item into a separate Secret, rather than reusing grimoire's `-openrouter` Secret directly.
- Verified both `helm template` render paths locally (enabled:false and enabled:true with a fake itemPath); no errors, OnePasswordItem + env vars appear only when `orchestrator.enabled` is true.
- Verified the client's mocking/logic manually with a standalone script (bypassing the `chat` package's FastAPI import, which isn't available outside the hermetic Bazel Python); full test execution is deferred to CI per repo convention (no local test loop).

## Test plan

- [ ] CI: format check green
- [ ] CI: `chat_orchestrator_client_test` passes
- [ ] Manual: `helm template monolith projects/monolith/chart/ -f projects/monolith/deploy/values.yaml` renders clean (done locally)
- [ ] Manual: same with `--set orchestrator.enabled=true --set orchestrator.onepassword.itemPath=...` renders the secret + env vars (done locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)