### PR TITLE
feat(chat): ground orchestrator briefs in contextually similar messages

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.266.0
+version: 0.267.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chat/bot.py
+++ b/projects/monolith/chat/bot.py
@@ -1070,6 +1070,9 @@ class ChatBot(discord.Client):
             channel_context = await asyncio.to_thread(
                 summarizer._fetch_agent_reply_context, channel_id
             )
+            similar_messages = await self._orchestrator_similar_messages(
+                channel_id, prompt
+            )
             ctx = orchestrator.RequestContext(
                 request=prompt,
                 guild_id=guild_id,
@@ -1077,12 +1080,49 @@ class ChatBot(discord.Client):
                 invoker_scope=repo,
                 allowed_scopes=frozenset(allowed),
                 channel_context=channel_context,
+                similar_messages=similar_messages,
                 directive=directive,
             )
             return await orchestrator.compile(ctx)
         except Exception:
             logger.exception("orchestrator: verdict failed; failing open")
             return orchestrator.FailOpen("orchestrator raised")
+
+    async def _orchestrator_similar_messages(
+        self, channel_id: str, prompt: str
+    ) -> list[str]:
+        """Contextually similar past messages from THIS channel, via pgvector
+        similarity, for orchestrator grounding (ADR 036).
+
+        Channel-scoped, preserving the chat provenance guarantee: nothing
+        authored outside the channel enters the context. Returns [] on any
+        failure so a retrieval miss degrades the brief's grounding without
+        failing the whole orchestrator open.
+        """
+        try:
+            query_embedding = await self.embed_client.embed(prompt)
+
+            def _search() -> list[str]:
+                with Session(get_engine()) as session:
+                    store = MessageStore(
+                        session=session, embed_client=self.embed_client
+                    )
+                    results = store.search_similar(
+                        channel_id=channel_id,
+                        query_embedding=query_embedding,
+                        limit=5,
+                    )
+                if not results:
+                    return []
+                block = format_context_messages(results)
+                return [line for line in block.split("\n") if line.strip()]
+
+            return await asyncio.to_thread(_search)
+        except Exception:
+            logger.warning(
+                "orchestrator: similar-message retrieval failed", exc_info=True
+            )
+            return []
 
     async def _orchestrator_chat_reply(
         self, channel_id: str, prompt: str, verdict: "orchestrator.ChatVerdict"

--- a/projects/monolith/chat/orchestrator.py
+++ b/projects/monolith/chat/orchestrator.py
@@ -112,8 +112,9 @@ class RequestContext:
 
     ``allowed_scopes`` are the invoker's ADR 029 repo grants; ``invoker_scope``
     is the repo the command was invoked with (used to replace an out-of-scope
-    brief repo). ``kg_results`` and ``channel_context`` are volatile grounding
-    placed in the ``user`` message only.
+    brief repo). ``similar_messages`` (contextually similar past messages from
+    this channel, retrieved by pgvector similarity) and ``channel_context`` are
+    volatile grounding placed in the ``user`` message only.
     """
 
     request: str
@@ -123,7 +124,7 @@ class RequestContext:
     invoker_scope: str = ""
     allowed_scopes: frozenset[str] = frozenset()
     channel_context: str = ""
-    kg_results: list[str] = field(default_factory=list)
+    similar_messages: list[str] = field(default_factory=list)
     directive: Directive = field(default_factory=Directive)
 
 
@@ -148,7 +149,7 @@ def load_bundle() -> str:
 def assemble_prompt(
     bundle: str,
     directive: Directive,
-    kg_results: list[str],
+    similar_messages: list[str],
     channel_context: str,
     request: str,
 ) -> tuple[str, str]:
@@ -158,9 +159,9 @@ def assemble_prompt(
     ``system`` = baked bundle + the versioned channel directive; it contains no
     timestamps, ids, or unsorted collections, so two consecutive escalations in
     the same channel produce byte-identical ``system`` messages and the
-    provider's prefix cache hits. All volatile content (KG results, channel
-    context, the request) goes in ``user``. Byte-deterministic: identical inputs
-    give identical bytes.
+    provider's prefix cache hits. All volatile content (contextually similar
+    past messages, channel context, the request) goes in ``user``.
+    Byte-deterministic: identical inputs give identical bytes.
     """
     system = (
         bundle.rstrip("\n")
@@ -168,10 +169,12 @@ def assemble_prompt(
         + (directive.text.strip() or "(no channel directive set)")
         + "\n"
     )
-    kg_block = "\n".join(f"- {r}" for r in kg_results) if kg_results else "(none)"
+    similar_block = (
+        "\n".join(f"- {r}" for r in similar_messages) if similar_messages else "(none)"
+    )
     user = (
-        "## Knowledge graph results\n\n"
-        + kg_block
+        "## Contextually similar past messages in this channel\n\n"
+        + similar_block
         + "\n\n## Channel context\n\n"
         + (channel_context.strip() or "(none)")
         + "\n\n## Request\n\n"
@@ -422,7 +425,7 @@ async def compile(ctx: RequestContext) -> Verdict:
     system, user = assemble_prompt(
         load_bundle(),
         ctx.directive,
-        ctx.kg_results,
+        ctx.similar_messages,
         ctx.channel_context,
         ctx.request,
     )

--- a/projects/monolith/chat/orchestrator_test.py
+++ b/projects/monolith/chat/orchestrator_test.py
@@ -131,6 +131,19 @@ class TestAssemblePrompt:
         assert "(no channel directive set)" in system
         assert "(none)" in user
 
+    def test_similar_messages_render_under_labeled_block(self):
+        _system, user = assemble_prompt(
+            "BUNDLE",
+            Directive(),
+            ["[2026-07-03 10:00] alice: is stars broken?"],
+            "chan ctx",
+            "do it",
+        )
+        assert "## Contextually similar past messages in this channel" in user
+        assert "- [2026-07-03 10:00] alice: is stars broken?" in user
+        # The channel context stays a separate, distinct block.
+        assert "## Channel context" in user
+
 
 # ---------------------------------------------------------------------------
 # parse_brief

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.266.0
+      targetRevision: 0.267.0
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
## What

Fills the orchestrator's previously-empty grounding slot with **contextually similar past messages** from the channel, so DeepSeek frames briefs against semantically-relevant history, not just the recent window.

## Why

Per direction: full KG-graph grounding isn't needed right now **as long as** the orchestrator gets channel info + history + contextually similar messages. The first three were already baked in (`_agent_reply_context`: channel summary, people, last 15 messages). The similar-messages piece was the gap, and its primitive already ships (every chat message is pgvector-embedded; `store.search_similar` does channel-scoped semantic search).

## Change

- `bot._orchestrator_similar_messages`: embed the request, `search_similar` (channel-scoped, top-5), format the hits, pass them in. Fails soft to `[]` so a retrieval miss degrades grounding without failing the orchestrator open.
- `orchestrator.py`: rename the misnamed `kg_results` slot to `similar_messages` and relabel the prompt block `## Contextually similar past messages in this channel` (an empty "Knowledge graph results" header would mislead the model).
- Assembler test for the new labeled block; chart bump `0.266.0 -> 0.267.0`.

**Channel-scoped by design**: preserves the chat provenance guarantee (nothing authored outside the channel enters the context), same trust boundary as the recent-history window.

Full KG-graph grounding remains a deliberate non-goal for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)