### PR TITLE
chore(release): bump monolith to 0.266.1

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.266.0
+version: 0.266.1
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.266.0
+      targetRevision: 0.266.1
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
Ships #3135 (single-live-message agent UX + injected-context trigger persistence + `progress_message_id` migration). The `0.266.0` chart was cut at the orchestrator commit, before that merge, so a new chart version is needed for ArgoCD to pull the new image and the Atlas operator to apply the additive `ADD COLUMN progress_message_id TEXT NOT NULL DEFAULT ''` migration.

Chart.yaml `version` and `deploy/application.yaml` `targetRevision` bumped in lockstep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)