### PR TITLE
fix(monolith): ship orchestrator_bundle.md in serving runfiles

### DIFF
--- a/projects/monolith/BUILD
+++ b/projects/monolith/BUILD
@@ -111,6 +111,11 @@ py_venv_binary(
         # via Path(__file__).parent / "directive_seed.md" (ADR 035 phase 5); the
         # "chat/**/*.py" glob does not capture the .md, so ship it explicitly.
         "chat/directive_seed.md",
+        # orchestrator.load_bundle reads this committed baked context bundle at
+        # runtime via Path(__file__).with_name("orchestrator_bundle.md") (ADR
+        # 036); the "chat/**/*.py" glob does not capture the .md, so ship it
+        # explicitly or every escalation fails open with FileNotFoundError.
+        "chat/orchestrator_bundle.md",
         "knowledge/repo_docs_manifest.ndjson",
         ":frontend_dist",
     ],

--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.267.1
+version: 0.268.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.267.1
+      targetRevision: 0.268.0
       helm:
         releaseName: monolith
         valueFiles:


### PR DESCRIPTION
## The bug (found via a live escalation)

The orchestrator has been **failing open on every escalation since it went live**. `orchestrator.load_bundle()` reads `chat/orchestrator_bundle.md` at runtime, but that file was only added as `data` on the orchestrator *test* target, never on `:main`. The `chat/**/*.py` srcs glob does not capture a `.md`, so the bundle was absent from the backend runfiles and `compile()` raised `FileNotFoundError`, caught as fail-open.

Symptom: a real `/agent` "deep research vancouver shipping containers" escalation submitted with `recipe=agent` (guest-side routing) and wrote **no** `chat.orchestrator_brief` row. Backend log:
```
ERROR chat.bot: orchestrator: verdict failed; failing open
  ... orchestrator.py line 146, in load_bundle
FileNotFoundError: .../chat/orchestrator_bundle.md
```

## Fix

Add `chat/orchestrator_bundle.md` to `:main`'s `data`, mirroring the adjacent `chat/directive_seed.md` entry (same "glob does not capture the .md" rationale). Chart bump `0.267.1 -> 0.268.0`.

Why config verification missed it: env, migration, grant, and key all confirmed the feature *configured*; only a real escalation exercised the code path, and the unit tests pass because the *test* target has the bundle as data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)