### PR TITLE
ci(migrations): enforce linear, non-duplicated migration versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,6 +40,13 @@ repos:
         files: 'migrations/.*\.sql$'
         pass_filenames: false
 
+      - id: check-migration-ordering
+        name: Check migration version ordering
+        entry: bazel/tools/format/check-migration-ordering.sh
+        language: script
+        files: 'migrations/.*\.sql$'
+        pass_filenames: false
+
       # Run format after rebase to catch formatting drift
       # Install with: pre-commit install --hook-type post-rewrite
       - id: post-rewrite-format

--- a/bazel/tools/format/BUILD
+++ b/bazel/tools/format/BUILD
@@ -9,9 +9,18 @@ load("@aspect_rules_lint//format:defs.bzl", "format_multirun")
 load("@npm//:prettier/package_json.bzl", prettier = "bin")
 load("@rules_multirun//:defs.bzl", "multirun")
 load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
 
 # gazelle:exclude
 package(default_visibility = ["//:__subpackages__"])
+
+# Hermetic tests for the migration-ordering guard (no git; base versions are
+# overridden via MIGRATION_BASE_VERSIONS inside the test).
+sh_test(
+    name = "check_migration_ordering_test",
+    srcs = ["check-migration-ordering_test.sh"],
+    data = ["check-migration-ordering.sh"],
+)
 
 js_library(
     name = "prettierrc",

--- a/bazel/tools/format/check-migration-ordering.sh
+++ b/bazel/tools/format/check-migration-ordering.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Enforce linear, non-duplicated Atlas migration history.
+#
+# Atlas versions a migration on the leading timestamp of its filename and
+# refuses to apply a directory whose history is not strictly linear. Two files
+# sharing a version ("multiple files with the same version"), or a migration
+# whose version is below one already applied ("added out of order"), wedge the
+# ENTIRE migration pipeline at apply time, not just the offending file, and
+# `atlas migrate validate` does not catch either before merge. This guard does.
+#
+# Per migrations/ directory it enforces:
+#   1. every version prefix is unique, and
+#   2. any version not already on the base ref is strictly greater than the
+#      base ref's current maximum version (never inserted below an existing,
+#      possibly-already-applied migration).
+#
+# Runs in the CI "Format check" (where origin/main is fetched) and as a local
+# pre-commit hook. Base versions come from `git ls-tree $MIGRATION_BASE_REF`
+# (default origin/main); tests override them hermetically via
+# MIGRATION_BASE_VERSIONS="<version> <version> ...".
+set -euo pipefail
+
+BASE_REF="${MIGRATION_BASE_REF:-origin/main}"
+
+# Extract the leading 14-digit timestamp version of each migration filename.
+# Files that do not match the convention are ignored (not this check's concern).
+_versions() { sed -n 's#.*/\([0-9]\{14\}\)_[^/]*\.sql$#\1#p'; }
+
+# Directories to check: the parents of any migration args (pre-commit passes the
+# changed files), or every migrations/ dir in the tree when run with no args.
+declare -A DIRS=()
+if [ "$#" -gt 0 ]; then
+	for f in "$@"; do
+		case "$f" in */migrations/*.sql) DIRS["${f%/*}"]=1 ;; esac
+	done
+else
+	while IFS= read -r f; do DIRS["${f%/*}"]=1; done < <(git ls-files '*migrations/*.sql')
+fi
+if [ "${#DIRS[@]}" -eq 0 ]; then
+	echo "no migration directories to check"
+	exit 0
+fi
+
+rc=0
+for dir in "${!DIRS[@]}"; do
+	wt="$(find "$dir" -maxdepth 1 -name '*.sql' | _versions | sort || true)"
+	[ -z "$wt" ] && continue
+
+	# Rule 1: unique versions within the directory.
+	dupes="$(printf '%s\n' "$wt" | uniq -d)"
+	if [ -n "$dupes" ]; then
+		rc=1
+		while IFS= read -r v; do
+			[ -z "$v" ] && continue
+			echo "ERROR [$dir]: duplicate migration version $v:" >&2
+			find "$dir" -maxdepth 1 -name "${v}_*.sql" | sort | sed 's/^/    /' >&2
+		done <<<"$dupes"
+	fi
+
+	# Resolve the base versions this directory must build on top of.
+	if [ -n "${MIGRATION_BASE_VERSIONS+x}" ]; then
+		# shellcheck disable=SC2086 # intentional word-split of the space-separated override
+		base="$(printf '%s\n' $MIGRATION_BASE_VERSIONS | sort)"
+	elif git rev-parse --verify --quiet "$BASE_REF" >/dev/null 2>&1; then
+		base="$(git ls-tree -r --name-only "$BASE_REF" -- "$dir" | _versions | sort || true)"
+	else
+		echo "WARN [$dir]: $BASE_REF not found; enforcing uniqueness only (ordering needs the base ref)" >&2
+		base=""
+	fi
+
+	# Rule 2: every version new vs the base must be strictly after the base max.
+	if [ -n "$base" ]; then
+		max_base="$(printf '%s\n' "$base" | tail -n1)"
+		while IFS= read -r v; do
+			[ -z "$v" ] && continue
+			printf '%s\n' "$base" | grep -qxF "$v" && continue # already on base
+			if [ ! "$v" \> "$max_base" ]; then
+				rc=1
+				echo "ERROR [$dir]: new migration $v is not after ${BASE_REF}'s latest ($max_base)." >&2
+				echo "    Rename it to a timestamp greater than $max_base; Atlas needs linear," >&2
+				echo "    non-duplicated history or the whole pipeline wedges at apply time." >&2
+			fi
+		done <<<"$wt"
+	fi
+done
+
+if [ "$rc" -eq 0 ]; then
+	echo "PASS: migration versions are unique and ordered after $BASE_REF."
+fi
+exit "$rc"

--- a/bazel/tools/format/check-migration-ordering_test.sh
+++ b/bazel/tools/format/check-migration-ordering_test.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Hermetic tests for check-migration-ordering.sh. Drives the script against
+# fixture directories with the base versions overridden (MIGRATION_BASE_VERSIONS),
+# so it needs no git and runs in the Bazel sandbox.
+set -uo pipefail
+
+SCRIPT="${SCRIPT:-$(dirname "$0")/check-migration-ordering.sh}"
+
+fail=0
+_case() { # name expected_rc base_versions files...
+	local name="$1" want="$2" bases="$3"
+	shift 3
+	local dir
+	dir="$(mktemp -d)/migrations"
+	mkdir -p "$dir"
+	for f in "$@"; do : >"$dir/$f"; done
+	MIGRATION_BASE_VERSIONS="$bases" bash "$SCRIPT" "$dir/x.sql" >/dev/null 2>&1
+	local got=$?
+	rm -rf "$dir"
+	if [ "$got" -ne "$want" ]; then
+		echo "FAIL: $name — expected exit $want, got $got" >&2
+		fail=1
+	else
+		echo "ok: $name"
+	fi
+}
+
+# Clean: a new migration strictly after the base max.
+_case "clean-after-max" 0 "20260703210000" \
+	20260703210000_orchestrator.sql 20260703230000_new.sql
+
+# Duplicate version prefix within the directory (the #3139 collision).
+_case "duplicate-version" 1 "20260703210000" \
+	20260703130000_a.sql 20260703130000_b.sql
+
+# New migration below the base max (the #3141 / #3142 out-of-order).
+_case "out-of-order-below-max" 1 "20260703210000" \
+	20260703210000_orchestrator.sql 20260703140000_new.sql
+
+# A rebased branch carries the base files too, so a new migration colliding with
+# an existing base version shows up as a duplicate in the tree (Rule 1 catches it).
+_case "cross-base-duplicate-after-rebase" 1 "20260703210000" \
+	20260703210000_orchestrator.sql 20260703210000_dupe.sql
+
+# No base (brand-new dir): uniqueness still enforced, ordering skipped.
+_case "no-base-unique-ok" 0 "" \
+	20260703120000_a.sql 20260703130000_b.sql
+_case "no-base-duplicate-fails" 1 "" \
+	20260703120000_a.sql 20260703120000_b.sql
+
+if [ "$fail" -eq 0 ]; then
+	echo "ALL PASS"
+fi
+exit "$fail"

--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -34,6 +34,12 @@ actions:
           # Validate grep-based generate scripts against bazel query
           ./bazel/images/validate-generate-scripts.sh
 
+          # Enforce linear, non-duplicated Atlas migration versions. A duplicate
+          # version or a migration added below the current head wedges the WHOLE
+          # migration pipeline at apply time; atlas migrate validate does not
+          # catch either, so guard it here (origin/main is fetched in CI).
+          ./bazel/tools/format/check-migration-ordering.sh
+
           # Reject non-ASCII characters in commit messages.
           # Wrangler Pages (Cloudflare) fails with error 8000111 when commits
           # in the deployed branch contain non-ASCII characters (smart quotes,


### PR DESCRIPTION
Follow-up to today's migration incident (the `progress_message_id` rollout wedged the whole monolith pipeline three times).

## Why
Atlas versions a migration on its filename timestamp and refuses a non-linear history **at apply time**, blocking every pending migration — not just the offending file. This session hit it three ways, none caught by `atlas migrate validate`, so all slipped through CI:
- duplicate version prefix `20260703130000` (#3139)
- a migration added below the applied head (#3141, #3142)

## What
`bazel/tools/format/check-migration-ordering.sh` enforces, per `migrations/` dir:
1. **unique** version prefixes, and
2. any version not already on `origin/main` is **strictly greater** than main's current max.

Wired two ways (single source of truth):
- **local pre-commit hook** (`files: migrations/.*\.sql$`) for fast feedback, and
- a **hard-fail step in the CI Format check**, where `origin/main` is fetched (the validator pre-commit hooks don't otherwise run in CI).

A hermetic `sh_test` (`check_migration_ordering_test`) drives the script against fixtures with the base overridden via `MIGRATION_BASE_VERSIONS`, covering the duplicate, both out-of-order shapes, and clean/no-base cases. Verified it passes on the current (fixed) tree and fails on each historical shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)