### PR TITLE
fix(grimoire): batch embeddings by content size, self-heal missing vectors

### DIFF
--- a/projects/monolith/chart/Chart.yaml
+++ b/projects/monolith/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: monolith
 description: Consolidated homelab web services
-version: 0.268.2
+version: 0.269.0
 type: application
 dependencies:
   - name: cf-ingress

--- a/projects/monolith/chart/templates/cronworkflows.yaml
+++ b/projects/monolith/chart/templates/cronworkflows.yaml
@@ -124,6 +124,15 @@ spec:
               value: {{ $.Values.stars.s3SecretAccessKey | quote }}
             - name: EMBEDDING_URL
               value: {{ $.Values.chat.embeddingUrl | quote }}
+            # Bulk sourcebook loads embed thousands of chunks; the embedding
+            # server is token-throughput-bound, so a batch of large stat-block
+            # chunks can take well over the interactive 60s default. Give the
+            # loader generous per-request and total retry headroom (batches are
+            # still size-bounded in code, so this is margin, not unbounded waits).
+            - name: EMBED_BATCH_READ_TIMEOUT
+              value: "300"
+            - name: EMBED_RETRY_TIMEOUT
+              value: "900"
             - name: OPENROUTER_API_KEY
               valueFrom:
                 secretKeyRef:

--- a/projects/monolith/deploy/application.yaml
+++ b/projects/monolith/deploy/application.yaml
@@ -9,7 +9,7 @@ spec:
     # Chart from OCI registry (pushed by CI via Bazel helm_push)
     - repoURL: ghcr.io/jomcgi/homelab/charts
       chart: monolith
-      targetRevision: 0.268.2
+      targetRevision: 0.269.0
       helm:
         releaseName: monolith
         valueFiles:

--- a/projects/monolith/grimoire/ingest.py
+++ b/projects/monolith/grimoire/ingest.py
@@ -44,11 +44,17 @@ _MANIFEST_SUFFIX = ".ndjson"
 # chunk manifests from other book files and delimits the book id in the key.
 _CHUNKS_SEGMENT = "/chunks/"
 
-# Embeddings are sent in fixed-size batches rather than one call per book, so
-# a large manifest does not force one oversized HTTP request (mirrors the
-# spirit of knowledge.indexing, which batches per note; here the natural
-# batch is per-run rather than per-book).
-EMBED_BATCH_SIZE = 64
+# Embeddings are grouped by a content-size budget, not a fixed item count. The
+# embedding server's latency is token-bound: 64 small front-matter chunks embed
+# in ~4s, but 64 stat-block chunks (~32k tokens) took ~78s and blew the client's
+# 60s read timeout, so the loader retried forever and left the book unembedded.
+# Capping each batch by summed content chars (~4 chars/token) keeps every request
+# well under the timeout regardless of chunk sizes; the item cap stops a flood of
+# tiny chunks from building an oversized request array.
+EMBED_CHAR_BUDGET = (
+    60000  # ~15k tokens, ~36s server-side, safe even under the default 60s read timeout
+)
+EMBED_MAX_BATCH = 64
 
 
 class _Embedder(Protocol):
@@ -154,6 +160,55 @@ def parse_manifest_lines(book_id: str, lines: Iterable[str]) -> tuple[list[dict]
             }
         )
     return valid, errors
+
+
+def _embed_batches(rows: list, char_budget: int, max_count: int):
+    """Yield sub-lists of ``rows`` bounded by both summed content length and item
+    count, so each embedding request finishes within the client read timeout
+    regardless of how large individual chunks are. A single row whose content
+    already exceeds ``char_budget`` is yielded alone rather than dropped.
+    """
+    batch: list = []
+    size = 0
+    for row in rows:
+        clen = len(row.content or "")
+        if batch and (size + clen > char_budget or len(batch) >= max_count):
+            yield batch
+            batch, size = [], 0
+        batch.append(row)
+        size += clen
+    if batch:
+        yield batch
+
+
+def _chunks_missing_embedding(session: Session, book_ids, model: str) -> list:
+    """Chunks in ``book_ids`` with no embedding row for ``model`` yet.
+
+    Self-heal for a prior partial embed failure: such chunks are unchanged on a
+    re-run so ``_upsert_book_chunks`` never re-queues them, yet they still have no
+    vector. Selecting them here lets a plain re-run finish an interrupted embed.
+    """
+    if not book_ids:
+        return []
+    embedding_exists = (
+        select(Embedding.embeddable_id)
+        .where(
+            Embedding.embeddable_kind == "chunk",
+            Embedding.embeddable_id == KnowledgeChunk.id,
+            Embedding.model == model,
+        )
+        .exists()
+    )
+    return list(
+        session.execute(
+            select(KnowledgeChunk).where(
+                KnowledgeChunk.book_id.in_(list(book_ids)),
+                ~embedding_exists,
+            )
+        )
+        .scalars()
+        .all()
+    )
 
 
 def _list_manifest_keys(s3_client, bucket: str, prefix: str) -> list[str]:
@@ -311,6 +366,7 @@ async def load_chunks(
     chunks_embedded = 0
     errors = 0
     pending_embed: list[KnowledgeChunk] = []
+    book_ids: set[str] = set()
 
     for key in keys:
         book_id = _book_id_from_key(key, prefix)
@@ -320,13 +376,25 @@ async def load_chunks(
         parsed, err_count = parse_manifest_lines(book_id, body.splitlines())
         errors += err_count
         books += 1
+        book_ids.add(book_id)
 
         book_pending, book_upserted = _upsert_book_chunks(session, book_id, parsed)
         chunks_upserted += book_upserted
         pending_embed.extend(book_pending)
 
-    for start in range(0, len(pending_embed), EMBED_BATCH_SIZE):
-        batch = pending_embed[start : start + EMBED_BATCH_SIZE]
+    # Also (re-)embed chunks that exist but have no vector for this model, e.g.
+    # left behind when a prior run's embed step failed partway. Dedupe against
+    # the rows already queued from this run's upserts.
+    queued = {row.id for row in pending_embed}
+    for row in _chunks_missing_embedding(session, book_ids, embed_client.model):
+        if row.id not in queued:
+            pending_embed.append(row)
+            queued.add(row.id)
+
+    # Each batch commits its own embeddings (see upsert_embedding_batch), so an
+    # interrupted run leaves durable partial progress and the next run's
+    # self-heal finishes the rest.
+    for batch in _embed_batches(pending_embed, EMBED_CHAR_BUDGET, EMBED_MAX_BATCH):
         vectors = await embed_client.embed_batch([row.content for row in batch])
         chunks_embedded += upsert_embedding_batch(
             session, embed_client.model, "chunk", batch, vectors

--- a/projects/monolith/grimoire/ingest_test.py
+++ b/projects/monolith/grimoire/ingest_test.py
@@ -286,3 +286,37 @@ def test_load_chunks_two_books_in_one_run(session: Session):
         ("phb", "c1"),
         ("dmg", "c1"),
     }
+
+
+# --- embed batching + self-heal ------------------------------------------
+
+
+def test_embed_batches_bounds_by_size_and_count():
+    from types import SimpleNamespace as NS
+
+    rows = [NS(content="a" * 10) for _ in range(5)]
+    # char_budget 25 -> at most 2 rows/batch (a 3rd would be 30 > 25).
+    assert [len(b) for b in ingest._embed_batches(rows, 25, 64)] == [2, 2, 1]
+    # max_count caps a batch even when the size budget is huge.
+    assert [len(b) for b in ingest._embed_batches(rows, 10_000, 2)] == [2, 2, 1]
+    # a single over-budget row is yielded alone, never dropped.
+    big = [NS(content="x" * 100), NS(content="y" * 5)]
+    assert [len(b) for b in ingest._embed_batches(big, 25, 64)] == [1, 1]
+
+
+def test_load_chunks_reembeds_chunks_missing_embedding(session: Session):
+    # A prior run loaded the chunk but its embed step failed, leaving a chunk
+    # with no vector. A plain re-run over unchanged data must self-heal it.
+    s3 = FakeS3Client({"books/phb/chunks/chunks.ndjson": _line("c1", "content one")})
+    embedder = FakeEmbedClient()
+    _run(ingest.load_chunks(session, s3, embedder, bucket="grimoire"))
+    assert len(session.execute(select(Embedding)).scalars().all()) == 1
+
+    for e in session.execute(select(Embedding)).scalars().all():
+        session.delete(e)
+    session.commit()
+
+    # Content is unchanged, so the upsert queues nothing; self-heal must re-embed.
+    summary = _run(ingest.load_chunks(session, s3, embedder, bucket="grimoire"))
+    assert summary["chunks_embedded"] == 1
+    assert len(session.execute(select(Embedding)).scalars().all()) == 1

--- a/projects/monolith/shared/embedding.py
+++ b/projects/monolith/shared/embedding.py
@@ -14,11 +14,16 @@ EMBEDDING_URL = os.environ.get("EMBEDDING_URL", "")
 EMBED_MAX_RETRIES = 12
 EMBED_RETRY_BASE_DELAY = 2.0  # seconds
 EMBED_RETRY_MAX_DELAY = 30.0  # cap per-retry wait
-EMBED_RETRY_TIMEOUT = 300.0  # 5 min total deadline
+# Total deadline; env-overridable so a bulk backfill (e.g. grimoire loading a
+# whole sourcebook) can allow more retry headroom than the interactive default.
+EMBED_RETRY_TIMEOUT = float(os.environ.get("EMBED_RETRY_TIMEOUT", "300"))
 
 EMBED_CONNECT_TIMEOUT = 5.0
 EMBED_READ_TIMEOUT = 30.0
-EMBED_BATCH_READ_TIMEOUT = 60.0
+# Per-request read timeout for a batch. Env-overridable: throughput is token-
+# bound, so a caller that deliberately sends large batches (bulk ingest) can
+# raise this without affecting the interactive default.
+EMBED_BATCH_READ_TIMEOUT = float(os.environ.get("EMBED_BATCH_READ_TIMEOUT", "60"))
 
 
 def _is_retryable(exc: Exception) -> bool:


### PR DESCRIPTION
## What

Fixes the grimoire chunk-embedding failure found while loading the Monster Manual: the load embedded only 64/1,224 chunks, then failed.

## Root cause

The loader embedded in **fixed batches of 64**. The embedding server (`voyage-4-nano` via llama.cpp) is **token-throughput-bound**: reproduced directly, 64 small front-matter chunks embed in ~4s, but 64 stat-block chunks (~32,365 tokens) take **77.9s**, over the client's **60s `EMBED_BATCH_READ_TIMEOUT`**. The batch times out, retries forever, and the load fails. Worse, the loader only re-embeds *changed* content, so the stuck chunks would never retry on a re-run.

It's not a size-limit or rejection, the endpoint returns all 64 vectors; the client just gives up first.

## Fix

- **Size-budget batching** (`EMBED_CHAR_BUDGET`, ~60k chars ≈ 36s) + an item cap, so every request finishes well under the timeout regardless of chunk size. Total embed time is throughput-bound (~13 min for the book) either way, so this is about reliability, not speed.
- **Self-heal**: also (re-)embed chunks that exist but have no vector for the model, so a plain re-run finishes an interrupted embed (recovers the 1,160 stuck chunks). Each batch commits, so partial progress is durable and convergent across runs.
- **Env-overridable timeouts** (`EMBED_BATCH_READ_TIMEOUT`, `EMBED_RETRY_TIMEOUT`) in the shared client (defaults unchanged); grimoire jobs set 300s/900s as margin.
- chart 0.268.2 → 0.269.0.

## Verification

Reproduced the 78s/60s timeout against the live endpoint with the real batch-2 content. Unit tests for the batcher (size + count bounds, oversized-row-alone) and self-heal (delete vector → re-run re-embeds). ruff clean; `helm template` renders both grimoire CronWorkflows with the new env.

After deploy, a re-run of `grimoire-load-chunks` will embed all 1,224 chunks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
